### PR TITLE
fix(signal): add Signal.from_dict() method (#260)

### DIFF
--- a/services/signal/models.py
+++ b/services/signal/models.py
@@ -30,6 +30,24 @@ class Signal:
         if self.side is None and self.direction:
             self.side = self.direction
 
+    @classmethod
+    def from_dict(cls, data: dict) -> "Signal":
+        """Create a Signal from a transport payload."""
+        return cls(
+            signal_id=data.get("signal_id"),
+            strategy_id=data.get("strategy_id"),
+            bot_id=data.get("bot_id"),
+            symbol=data.get("symbol", ""),
+            direction=data.get("direction", ""),
+            strength=float(data.get("strength", 0.0)),
+            timestamp=data.get("timestamp", 0.0),
+            side=data.get("side"),
+            confidence=data.get("confidence"),
+            reason=data.get("reason"),
+            price=data.get("price"),
+            pct_change=data.get("pct_change"),
+        )
+
     def to_dict(self) -> dict:
         """Convert to a plain dictionary for transport."""
         return {

--- a/tests/unit/signal/test_models.py
+++ b/tests/unit/signal/test_models.py
@@ -1,0 +1,106 @@
+"""
+Unit-Tests für Signal Model.
+
+Issue: #260 - Signal.from_dict() missing
+"""
+
+import pytest
+from services.signal.models import Signal
+
+
+@pytest.mark.unit
+class TestSignalFromDict:
+    """Tests für Signal.from_dict() Methode."""
+
+    def test_from_dict_full_payload(self):
+        """Test: from_dict mit vollständigem Payload."""
+        payload = {
+            "signal_id": "sig-123",
+            "strategy_id": "strat-001",
+            "bot_id": "bot-001",
+            "symbol": "BTC/USDT",
+            "direction": "BUY",
+            "strength": 0.85,
+            "timestamp": 1735000000,
+            "side": "BUY",
+            "confidence": 0.9,
+            "reason": "momentum breakout",
+            "price": 42000.0,
+            "pct_change": 2.5,
+        }
+
+        signal = Signal.from_dict(payload)
+
+        assert signal.signal_id == "sig-123"
+        assert signal.strategy_id == "strat-001"
+        assert signal.bot_id == "bot-001"
+        assert signal.symbol == "BTC/USDT"
+        assert signal.direction == "BUY"
+        assert signal.strength == 0.85
+        assert signal.timestamp == 1735000000
+        assert signal.side == "BUY"
+        assert signal.confidence == 0.9
+        assert signal.reason == "momentum breakout"
+        assert signal.price == 42000.0
+        assert signal.pct_change == 2.5
+
+    def test_from_dict_minimal_payload(self):
+        """Test: from_dict mit minimalem Payload."""
+        payload = {
+            "symbol": "ETH/USDT",
+            "direction": "SELL",
+        }
+
+        signal = Signal.from_dict(payload)
+
+        assert signal.symbol == "ETH/USDT"
+        assert signal.direction == "SELL"
+        assert signal.signal_id is None
+        assert signal.strength == 0.0
+        assert signal.timestamp == 0.0
+
+    def test_from_dict_empty_payload(self):
+        """Test: from_dict mit leerem Payload verwendet Defaults."""
+        payload = {}
+
+        signal = Signal.from_dict(payload)
+
+        assert signal.symbol == ""
+        assert signal.direction == ""
+        assert signal.strength == 0.0
+        assert signal.signal_id is None
+
+    def test_from_dict_to_dict_roundtrip(self):
+        """Test: from_dict → to_dict Roundtrip erhält Daten."""
+        original = {
+            "signal_id": "roundtrip-test",
+            "symbol": "SOL/USDT",
+            "direction": "BUY",
+            "strength": 0.75,
+            "timestamp": 1735000000,
+            "side": "BUY",
+            "confidence": 0.8,
+        }
+
+        signal = Signal.from_dict(original)
+        result = signal.to_dict()
+
+        assert result["signal_id"] == original["signal_id"]
+        assert result["symbol"] == original["symbol"]
+        assert result["direction"] == original["direction"]
+        assert result["strength"] == original["strength"]
+        assert result["timestamp"] == original["timestamp"]
+        assert result["side"] == original["side"]
+        assert result["confidence"] == original["confidence"]
+
+    def test_from_dict_strength_conversion(self):
+        """Test: from_dict konvertiert strength zu float."""
+        payload = {
+            "symbol": "BTC/USDT",
+            "strength": "0.95",  # String statt float
+        }
+
+        signal = Signal.from_dict(payload)
+
+        assert signal.strength == 0.95
+        assert isinstance(signal.strength, float)


### PR DESCRIPTION
- Add from_dict classmethod to services/signal/models.Signal
- Add unit tests for from_dict (full, minimal, empty, roundtrip)
- Matches existing implementation in core/domain/models.Signal

Fixes #260
