### PR TITLE
chore: Replace AGENTS.md with pointer to Docs Hub canonical

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,6 @@ Claire_de_Binare_Docs/
 .cdb_local/
 .claude/
 scripts/
-AGENTS.md
+# AGENTS.md - Now tracked as pointer to Docs Hub canonical (was ignored pre-consolidation)
 .gemini/
 gha-creds-*.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS — Pointer to Canonical Registry
+
+⚠️ **THIS IS A POINTER FILE — NOT THE CANONICAL REGISTRY**
+
+## Canonical Location
+
+The **authoritative AGENTS registry** is located at:
+
+```
+C:\Users\janne\Documents\GitHub\Workspaces\Claire_de_Binare_Docs\agents\AGENTS.md
+```
+
+## Why This Pointer Exists
+
+- **Working Repo** (this repo): Code execution only
+- **Docs Hub**: Single source of truth for governance, knowledge, and agent definitions
+
+**ALL AGENTS MUST LOAD FROM DOCS HUB**, not from this file.
+
+## Agent Role Files
+
+All agent-specific role files are in Docs Hub:
+
+- `Claire_de_Binare_Docs\agents\CLAUDE.md`
+- `Claire_de_Binare_Docs\agents\CODEX.md`
+- `Claire_de_Binare_Docs\agents\COPILOT.md`
+- `Claire_de_Binare_Docs\agents\GEMINI.md`
+
+## Local Workspace State
+
+Machine-local agent state (not committed) is in:
+
+```
+Claire_de_Binare_Docs\.local\workspaces-root\.cdb_local\agents\
+```
+
+## Migration Note
+
+This pointer was created during the **Workspaces Root Consolidation** (Dec 2025) to enforce the canonical separation:
+
+- **Before:** AGENTS.md lived in Working Repo root
+- **After:** AGENTS.md lives in Docs Hub; this file is a pointer
+
+---
+
+**For the full canonical AGENTS registry, refer to:**
+`C:\Users\janne\Documents\GitHub\Workspaces\Claire_de_Binare_Docs\agents\AGENTS.md`


### PR DESCRIPTION
## Summary
Replaces canonical AGENTS.md with a **pointer file** as part of Workspaces Root Consolidation.

This PR is the **Working Repo companion** to jannekbuengener/Claire_de_Binare_Docs#20.

## Changes

### AGENTS.md (Replaced)
**Before:** Canonical agent registry (308 lines, full governance rules)
**After:** Pointer file (47 lines) directing to Docs Hub canonical

```
C:\Users\janne\Documents\GitHub\Workspaces\Claire_de_Binare_Docs\agents\AGENTS.md
```

### .gitignore (Fixed)
- Removed `AGENTS.md` exclusion (was blocking pointer from being tracked)
- Added comment explaining why it's now tracked

## Rationale

**Working Repo** = Code execution only
**Docs Hub** = Single source of truth for governance, knowledge, agent definitions

Keeping the canonical AGENTS.md in Working Repo violated this separation and caused:
- Governance drift between repos
- Unclear source of truth
- Agents loading wrong definitions

## Agent Impact

All agents (Claude, Codex, Copilot, Gemini) will now load from:
- `Claire_de_Binare_Docs\agents\AGENTS.md` (canonical registry)
- `Claire_de_Binare_Docs\agents\CLAUDE.md` (role-specific)
- `Claire_de_Binare_Docs\agents\CODEX.md`
- `Claire_de_Binare_Docs\agents\COPILOT.md`
- `Claire_de_Binare_Docs\agents\GEMINI.md`

## Related

- **Docs Hub PR:** jannekbuengener/Claire_de_Binare_Docs#20 (main consolidation)
- **Specification:** `zusatz.txt` (6-phase Workspaces Root Consolidation)
- **Documentation:** `Claire_de_Binare_Docs\knowledge\operations\WORKSPACE_LAYOUT.md`

## Verification

✅ AGENTS.md is a pointer (not canonical)
✅ Pointer directs to correct Docs Hub path
✅ .gitignore allows AGENTS.md to be tracked
✅ No governance content in Working Repo

## Checklist

- [x] AGENTS.md replaced with pointer
- [x] .gitignore updated
- [x] Pointer references correct canonical path
- [x] No governance rules duplicated

## Merge Order

1. **Merge Docs Hub PR first** (jannekbuengener/Claire_de_Binare_Docs#20)
2. **Then merge this PR** (ensures canonical exists before pointer is active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>