### PR TITLE
fix(monitoring): cdb_ws Metrics Export (Flask Response)

### DIFF
--- a/services/ws/service.py
+++ b/services/ws/service.py
@@ -15,7 +15,7 @@ import logging
 import os
 import sys
 import threading
-from flask import Flask, jsonify
+from flask import Flask, jsonify, Response
 from prometheus_client import Counter, Gauge, generate_latest, CONTENT_TYPE_LATEST
 import redis
 
@@ -93,7 +93,7 @@ def metrics():
         decode_errors_total.set(m.get("decode_errors_total", 0))
         ws_connected.set(m.get("ws_connected", 0))
         last_message_ts_ms.set(m.get("last_message_ts_ms", 0))
-    return generate_latest(), 200, {"Content-Type": CONTENT_TYPE_LATEST}
+    return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
 
 
 def start_flask_server():


### PR DESCRIPTION
Closes #341

## Problem

Prometheus scraping cdb_ws `/metrics` endpoint fehlte. Target "cdb_ws" zeigte `up{job="cdb_ws"} = 0` trotz healthy Container.

**Symptom:**
```promql
up{job="cdb_ws", instance="cdb_ws", service="market_data"} = 0
```

**Container Status:** ✅ HEALTHY (Port 8000 erreichbar, `/health` funktioniert)

## Root Cause

Flask `/metrics` endpoint nutzte inkorrekte 3-tuple Response-Syntax:

```python
# BROKEN (old)
return generate_latest(), 200, {"Content-Type": CONTENT_TYPE_LATEST}
```

**Problem:** `generate_latest()` gibt `bytes` zurück. Flask hat Probleme, `bytes` im 3-tuple-Format korrekt zu senden (Content-Type Header wird nicht korrekt gesetzt).

## Solution

Korrekte Flask Response-Objekt-Syntax:

```python
# FIXED (new)
from flask import Response
return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
```

**Changes:**
1. Import `Response` from `flask` (Line 18)
2. Return `Response(...)` statt 3-tuple (Line 96)

## Testing

**Local:**
```powershell
# Start Stack
.\infrastructure\scripts\stack_up.ps1

# Test metrics endpoint directly
Invoke-WebRequest http://localhost:8000/metrics

# Expected Output:
# - HTTP 200 OK
# - Content-Type: text/plain; version=0.0.4; charset=utf-8
# - Body: Prometheus-formatted metrics
```

**Prometheus Target:**
```powershell
# Open Prometheus UI
Start-Process http://localhost:9090/targets

# Verify: cdb_ws (1/1 up)
```

## Evidence (Post-Fix)

**Expected:**
- ✅ `up{job="cdb_ws"} = 1` (Target UP)
- ✅ Metrics verfügbar: `decoded_messages_total`, `ws_connected`, `redis_publish_total`
- ✅ Grafana Dashboards zeigen cdb_ws Metrics

## Files Changed

- `services/ws/service.py` (M)

## References

- Issue: #341
- Epic: #346 (Phase 0 – Shipability Base)