### PR TITLE
Potential fix for code scanning alert no. 1511: Code injection

### DIFF
--- a/.github/workflows/emoji-bot.yml
+++ b/.github/workflows/emoji-bot.yml
@@ -66,8 +66,6 @@ jobs:
       env:
         COMMENT_BODY: ${{ github.event.comment.body }}
       run: |
-        COMMENT_BODY="$COMMENT_BODY"
-        
         if [[ "$COMMENT_BODY" == *"/emoji-fix"* ]]; then
           echo "command=fix" >> $GITHUB_OUTPUT
           echo "🔧 Auto-Fix Befehl erkannt"

--- a/.github/workflows/emoji-bot.yml
+++ b/.github/workflows/emoji-bot.yml
@@ -63,8 +63,10 @@ jobs:
     
     - name: 🤖 Process Bot Command
       id: bot-command
+      env:
+        COMMENT_BODY: ${{ github.event.comment.body }}
       run: |
-        COMMENT_BODY="${{ github.event.comment.body }}"
+        COMMENT_BODY="$COMMENT_BODY"
         
         if [[ "$COMMENT_BODY" == *"/emoji-fix"* ]]; then
           echo "command=fix" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Potential fix for [https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/1511](https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/1511)

General fix: Do not use `${{ github.event.comment.body }}` directly inside the shell script. Instead, assign it to an environment variable using the workflow `env:` block, and then reference that variable using native shell syntax (`$COMMENT_BODY`), not `${{ env.COMMENT_BODY }}`.

Best concrete fix here:

- For the `🤖 Process Bot Command` step, move `github.event.comment.body` into an environment variable via `env:`:
  ```yaml
  env:
    COMMENT_BODY: ${{ github.event.comment.body }}
  ```
- In the `run:` script, remove the direct expression interpolation and rely only on shell expansion:
  ```bash
  COMMENT_BODY="$COMMENT_BODY"
  ```
  or just use `$COMMENT_BODY` directly; keeping the assignment preserves existing behavior if later someone changes the step.

This change is confined to the single step starting at line 64 in `.github/workflows/emoji-bot.yml`. No additional imports or dependencies are needed; we only modify the YAML for that step.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enhancements:
- Route the GitHub issue comment body through a workflow env variable and reference it via native shell expansion in the emoji-bot workflow step to avoid direct expression interpolation in the shell script.