### PR TITLE
Potential fix for code scanning alert no. 1818: Clear-text logging of sensitive information

### DIFF
--- a/core/secrets.py
+++ b/core/secrets.py
@@ -152,8 +152,7 @@ def validate_secrets(*secret_names: str) -> bool:
             missing.append(name)
 
     if missing:
-        missing_labels = [str(item) for item in missing]
-        logger.error(f"Missing required secrets: {', '.join(missing_labels)}")
+        logger.error("Missing required secrets: %d secret(s) missing", len(missing))
         return False
 
     return True


### PR DESCRIPTION
Potential fix for [https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/1818](https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/1818)

In general, to fix clear-text logging issues you either (a) avoid logging the sensitive data entirely, (b) log only non-sensitive metadata (like counts or generic labels), or (c) sanitize/mask the data before logging. Here, we don’t really need to list which secrets are missing; it is enough to say that some required secrets are missing and maybe how many there are.

The best minimal change that preserves functionality is to change the error log in `validate_secrets` so it does not interpolate `missing_labels` (derived from `secret_names`) into the log message. Instead, we can log the number of missing secrets and a fixed, non-tainted description. For example:

- Replace:
  - `missing_labels = [str(item) for item in missing]`
  - `logger.error(f"Missing required secrets: {', '.join(missing_labels)}")`
- With something like:
  - `logger.error("Missing required secrets: %d secret(s) missing", len(missing))`

This removes the tainted data from the logging call entirely, while still indicating an error condition. No new imports or helper functions are required, and we keep all behavior except for not echoing possibly sensitive identifiers.

Concretely, in `core/secrets.py` inside `validate_secrets`, adjust lines 155–156 as above. There is no need to modify other parts of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent clear-text logging of missing secret names by logging only the count of missing secrets instead.