### PR TITLE
Potential fix for code scanning alert no. 1793: Incomplete URL substring sanitization

### DIFF
--- a/.worktrees_backup/012-batch-database-inserts-in-db-writer-service/tests/integration/test_mexc_testnet.py
+++ b/.worktrees_backup/012-batch-database-inserts-in-db-writer-service/tests/integration/test_mexc_testnet.py
@@ -21,6 +21,7 @@ import pytest
 import requests_mock
 import logging
 from typing import Any, Dict
+from urllib.parse import urlparse
 
 # Add services to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "services", "execution"))
@@ -171,7 +172,9 @@ class TestMexcTestnetExternal:
     def test_testnet_client_initialization(self, external_client):
         """Verify testnet client is properly initialized."""
         assert external_client is not None
-        assert "testnet" in external_client.base_url.lower() or "contract.mexc.com" in external_client.base_url
+        parsed_url = urlparse(external_client.base_url)
+        hostname = (parsed_url.hostname or "").lower()
+        assert "testnet" in hostname or hostname == "contract.mexc.com"
         logger.info("Testnet client initialized")
 
     def test_get_account_balance(self, external_client):


### PR DESCRIPTION
Potential fix for [https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/1793](https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/1793)

In general, to fix incomplete URL substring sanitization, you should parse the URL and inspect its hostname (and possibly scheme/port) instead of searching for substrings in the full URL string. For host-based checks, `urllib.parse.urlparse` (Python stdlib) gives a `hostname` attribute that you can compare against an allowlist or verify with `endswith` on the hostname only.

Here, we want to keep the existing semantics: the external client should point either to a URL whose hostname contains “testnet” (case-insensitive) or to exactly `contract.mexc.com` (or a subdomain thereof, if that’s the intent). The safest approach is:
- Parse `external_client.base_url` with `urllib.parse.urlparse`.
- Extract `hostname = parsed.hostname` (already lowercased by `urlparse`).
- Assert that `hostname` is not `None`, then assert that either `"testnet"` is in `hostname` or `hostname` equals `contract.mexc.com` (or, if desired, `hostname.endswith(".contract.mexc.com")` / equals that string).

Concretely for `.worktrees_backup/012-batch-database-inserts-in-db-writer-service/tests/integration/test_mexc_testnet.py`:
- Add an import: `from urllib.parse import urlparse`.
- Replace line 174’s substring check on `external_client.base_url` with a parsed-host-based check. For example:

```python
parsed = urlparse(external_client.base_url)
hostname = parsed.hostname or ""
assert "testnet" in hostname or hostname == "contract.mexc.com"
```

This keeps the logical intent (ensuring the client points to a testnet-ish host) while eliminating substring checks on the raw URL string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent incomplete URL sanitization in the testnet client initialization test by validating the hostname derived from a parsed URL.