### PR TITLE
ci: exclude worktree backups from Ruff (refs #477)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         run: pip install ruff
 
       - name: Run Ruff
-        run: ruff check . --output-format=github
+        run: ruff check . --output-format=github --exclude .worktrees_backup/**
 
   format-check:
     name: Format Check (Black)

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,7 @@
+[tool.ruff]
+exclude = [
+    "**/.worktrees_backup/**",
+]
+extend-exclude = [
+    "**/.worktrees_backup/**",
+]


### PR DESCRIPTION
Fix:\n- add a root .ruff.toml exclude and pass --exclude .worktrees_backup/** so Ruff completely ignores the backup checkout\nFiles:\n- .ruff.toml\n- .github/workflows/ci.yaml\nWhy:\n- removes the @core-guard and lint noise coming from .worktrees_backup so future runs focus on the real repo\nEvidence:\n- CI/CD Pipeline (https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/20684148244) – failure still shows Trivy, Gitleaks, Format/Black, Ruff, Core Guard and tests failing on the real sources but .worktrees_backup is no longer scanned\nRelated:\n- Issue #477 (Ruff exclusion item)