### PR TITLE
ci: register pytest markers (refs #477)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,8 @@ markers =
     chaos: Chaos/Resilience Tests - DESTRUKTIV! (NUR lokal)
     feature: Feature workflow tests for deployment validation
     mandatory: Tests that must pass for feature deployment
+    performance: Performance benchmarks and load markers
+    resilience: Resilience scenarios (chaos/stress) to validate fallback wiring
 
 testpaths = tests
 python_files = test_*.py


### PR DESCRIPTION
Fix:\n- document the performance and resilience markers so pytest no longer aborts during collection\nFiles:\n- pytest.ini\nWhy:\n- prevents the performance/esilience marker errors that kept pytest from reaching coverage\nEvidence:\n- CI/CD Pipeline (https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/20684156744) – failure continues because Gitleaks, Ruff/Black, Core Guard and the tests coverage run still hit real issues\nRelated:\n- Issue #477 (Pytest marker item)