### PR TITLE
ci: fix docker context (refs #477)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,9 +22,6 @@ jobs:
       fail-fast: true
       matrix:
         service:
-          - name: cdb_core
-            dockerfile: services/core/Dockerfile
-            context: .
           - name: cdb_risk
             dockerfile: services/risk/Dockerfile
             context: .


### PR DESCRIPTION
Fix:\n- drop the cdb_core matrix entry that looked for services/core/Dockerfile so buildx no longer lstat’s a missing path\nFiles:\n- .github/workflows/docker-publish.yml\nWhy:\n- keeps the GHCR workflow healthy by only building the services that actually exist; the remaining failure is now the uppercase repo tag which must be addressed separately\nEvidence:\n- Build & Push Containers (GHCR) (https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/20684167072) – failure is now just the invalid tag ... repository name must be lowercase error for the remaining services\nRelated:\n- Issue #477 (Buildx context item)