### PR TITLE
hardening: enforce threshold contract (#487)

### DIFF
--- a/tests/unit/validation/test_runner_failure_modes.py
+++ b/tests/unit/validation/test_runner_failure_modes.py
@@ -81,3 +81,34 @@ def test_runner_sqlite_locked(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None
     assert report["pass"] is False
     assert "sqlite_locked" in report["reasons"]
     assert (tmp_path / "1" / "report.json").exists()
+
+
+@pytest.mark.unit
+def test_runner_invalid_thresholds(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    def dummy_connect(*args, **kwargs):
+        return DummyConn()
+
+    def fake_window(*args, **kwargs):
+        return {
+            "summary": {
+                "orders_total": 10,
+                "filled_total": 10,
+                "not_filled_total": 0,
+                "symbols": 1,
+                "qty_sum": 20.0,
+                "avg_price": 100.0,
+            }
+        }
+
+    monkeypatch.setattr(runner, "_connect_with_retries", dummy_connect)
+    monkeypatch.setattr(runner, "run_validation_window", fake_window)
+    monkeypatch.setattr(runner, "RealValidationFetcher", DummyFetcher)
+    monkeypatch.setenv("VALIDATION_MIN_FILL_RATE", "not-a-number")
+    monkeypatch.setenv("VALIDATION_EVIDENCE_DIR", str(tmp_path))
+
+    report = runner.run("2026-01-01T00:00:00Z", "2026-01-01T01:00:00Z")
+
+    assert report["pass"] is False
+    assert any(reason.startswith("invalid_thresholds") for reason in report["reasons"])
+    assert report["criteria_used"] == {}
+    assert any(path.name == "report.json" for path in tmp_path.rglob("report.json"))


### PR DESCRIPTION
## Summary
- treat the validation thresholds env vars as a strict contract so invalid values still surface a failure reason and produce a report
- cover the invalid-thresholds scenario so future runners cannot silently miss the contract

## Testing
- python -m pytest tests/unit/validation/test_runner_failure_modes.py -k invalid_thresholds -q --basetemp .\.tmp\pytest (1 passed, 2 deselected, 1 DeprecationWarning from core/utils/clock.py about datetime.utcnow)

## Summary by Sourcery

Tests:
- Add a unit test ensuring the validation runner fails, records an invalid_thresholds reason, and writes a report when threshold env vars are invalid.