### PR TITLE
docs: add MUST-READ pointers

### DIFF
--- a/knowledge/SYSTEM.CONTEXT.md
+++ b/knowledge/SYSTEM.CONTEXT.md
@@ -1,0 +1,6 @@
+MUST-READ: System Context Pointer
+
+Authoritative source liegt im Docs Hub.
+Canonical path: C:\Users\jannek\Documents\GitHub\Workspaces\Claire_de_Binare_Docs\knowledge\SYSTEM.CONTEXT.md
+
+Do not duplicate here, keep this file as a lightweight pointer.

--- a/knowledge/roadmap/EXPANDED_ECOSYSTEM_ROADMAP.md
+++ b/knowledge/roadmap/EXPANDED_ECOSYSTEM_ROADMAP.md
@@ -1,0 +1,6 @@
+MUST-READ: Expanded Ecosystem Roadmap Pointer
+
+Authoritative source liegt im Docs Hub.
+Canonical path: C:\Users\jannek\Documents\GitHub\Workspaces\Claire_de_Binare_Docs\knowledge\roadmap\EXPANDED_ECOSYSTEM_ROADMAP.md
+
+Do not duplicate here, keep this file as a lightweight pointer.


### PR DESCRIPTION
## Feature Overview
Pointer-Stubs für MUST-READ Knowledge Docs.

## Technical Overview
Adds two lightweight pointer markdown files to canonical docs hub paths.

## Test Evidence
N/A (docs-only change).

## Code Quality
No code changes.

## Deployment & Rollback
No deployment. Rollback = revert PR.

## Documentation
Adds pointers; authoritative docs remain in docs hub.

## Agent Approvals
- Codex: prepared PR
- Jannek: pending
