### PR TITLE
chore(governance): migrate canonical docs to docs-hub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,10 @@
-# AGENTS (Working Repo Pointer)
+# AGENTS (Pointer)
 
-Dieses Repository (`Claire_de_Binare`) ist **Execution Only**.
+Diese Datei ist ein Read-Only-Pointer. Die kanonische AGENTS-Registry und alle Agenten-Charter liegen im Docs-Hub.
 
-✅ **Kanonische Agenten-Registry / Rollen / Trust-Score-Regeln** liegen im Docs Hub:
+Kanonischer Pfad:
+D:\Dev\Workspaces\Repos\Claire_de_Binare_Docs\agents\AGENTS.md
 
-`D:\Dev\Workspaces\Repos\Claire_de_Binare_Docs\agents\AGENTS.md`
+Scope dieser Änderung: nur Migration (move + pointer), keine inhaltlichen Änderungen an der kanonischen Datei.
 
-## Pflicht
-Jeder Agent MUSS:
-1) die kanonische `AGENTS.md` im Docs Hub laden
-2) danach seine eigene Rollendatei (`CLAUDE.md`, `CODEX.md`, `GEMINI.md` …) laden
-3) die Governance- & Trust-Entry-Points aus der kanonischen `AGENTS.md` beachten
-
-❗ Keine Kopien, keine Ableitungen, keine „lokalen Regeln“ in diesem Working Repo.
+Bitte Änderungen am Canon nur im Docs-Hub vornehmen.


### PR DESCRIPTION
Move canonical AGENTS.md to Docs-Hub and replace with pointer in Working Repo. Scope: move + pointer only. No content edits to canonical.

## Summary by Sourcery

Documentation:
- Replace AGENTS.md content with a concise pointer directing readers to the canonical AGENTS registry and charters in the Docs-Hub.