### PR TITLE
bugfix(security): bump aiohttp to 3.13.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,7 @@ werkzeug>=3.1.4  # Security: CVE fixes
 psycopg2-binary==2.9.9
 requests==2.32.4
 cryptography==44.0.1
-aiohttp==3.12.14
+aiohttp>=3.13.3
 python-dateutil==2.8.2
 tabulate==0.9.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@
 # Signal Engine - Requirements
 # Utilities
 # Web Framework
-aiohttp==3.12.14
+aiohttp>=3.13.3
 cryptography==44.0.1
 flask==3.1.2
 werkzeug>=3.1.4  # Security: Fix CVEs in Dependabot alerts #339


### PR DESCRIPTION
Fixes Trivy finding CVE-2025-69223 (HIGH).

## Summary by Sourcery

Build:
- Relax aiohttp version pin to require at least 3.13.3 in production requirements to resolve a high-severity CVE.