### PR TITLE
chore(git): ignore .local workspace artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ gha-creds-*.json
 GEMINI_FINAL_REPORT_WORKING_REPO.md
 
 Repository—Überblick.md
+/.local/


### PR DESCRIPTION
Add /.local/ to .gitignore to avoid accidentally tracking local workspace artifacts. Hygiene-only.

## Summary by Sourcery

Chores:
- Add /.local/ directory to .gitignore to prevent committing local workspace artifacts.