### PR TITLE
chore(security): update Redis and Prometheus to fix CVEs

### DIFF
--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -12,7 +12,7 @@ name: ${STACK_NAME:-cdb}
 
 services:
   cdb_redis:
-    image: redis:7-alpine
+    image: redis:7.4-alpine
     container_name: cdb_redis
     restart: unless-stopped
     volumes:
@@ -53,7 +53,7 @@ services:
       - cdb_network
 
   cdb_prometheus:
-    image: prom/prometheus:v2.51.0
+    image: prom/prometheus:v2.55.0
     container_name: cdb_prometheus
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary
Addresses P0 security vulnerabilities in infrastructure images.

## Changes
- `redis:7-alpine` → `redis:7.4-alpine`
- `prom/prometheus:v2.51.0` → `prom/prometheus:v2.55.0`

## Rationale
- GitHub Security Advisory: 9 moderate CVEs on main branch
- redis:7-alpine contains known vulnerabilities (zlib, etc.)
- prometheus:v2.51.0 outdated, v2.55.0 latest stable

## Not Updated
- `grafana:11.4.0` intentionally excluded (deferred to post-monitoring phase per CLAUDE_PROMPT.md)

## Verification
```powershell
# Image versions
docker inspect cdb_redis --format '{{.Config.Image}}'       # redis:7.4-alpine
docker inspect cdb_prometheus --format '{{.Config.Image}}'  # prom/prometheus:v2.55.0

# Health checks
docker ps --filter "name=cdb_redis|cdb_prometheus" --filter "status=running"

# Prometheus targets still UP
curl http://localhost:19090/api/v1/targets

# Redis connectivity
docker exec cdb_redis sh -c 'redis-cli -a $(cat /run/secrets/redis_password) ping'
```

## Files Modified
- `infrastructure/compose/base.yml` (2 lines)

## Related
- Security Scan P0 findings
- See: CLAUDE_REPORT.md Section "Security Scan – Kernergebnisse"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update infrastructure service images to newer Redis and Prometheus releases to address security vulnerabilities.

Bug Fixes:
- Resolve security scan findings by upgrading Redis and Prometheus images to versions without the reported CVEs.

Build:
- Bump Redis container image from redis:7-alpine to redis:7.4-alpine in the base docker-compose configuration.
- Bump Prometheus container image from prom/prometheus:v2.51.0 to prom/prometheus:v2.55.0 in the base docker-compose configuration.