### PR TITLE
chore(risk): add price to order payload

### DIFF
--- a/services/risk/models.py
+++ b/services/risk/models.py
@@ -90,6 +90,7 @@ class Order:
     strategy_id: str
     bot_id: Optional[str] = None
     client_id: Optional[str] = None
+    price: Optional[float] = None  # For observability/debugging
     type: Literal["order"] = "order"  # Type-safe event type
 
     def to_dict(self) -> dict:
@@ -105,6 +106,7 @@ class Order:
             "strategy_id": self.strategy_id,
             "bot_id": self.bot_id,
             "client_id": self.client_id,
+            "price": self.price,
         }
 
 

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -452,6 +452,7 @@ class RiskManager:
             client_id=f"{signal.symbol}-{signal.timestamp}",
             strategy_id=signal.strategy_id,
             bot_id=signal.bot_id,
+            price=signal.price,
         )
 
         logger.info(


### PR DESCRIPTION
Adds signal price to published orders for debugging/forensics. No trading logic change.

## Summary by Sourcery

New Features:
- Add optional price field to Order model and include it in serialized payloads from the risk service.