### PR TITLE
chore(risk): dev-only sanity guardrail for position sizing

### DIFF
--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -491,6 +491,18 @@ class RiskManager:
 
         # Konvertiere USDT-Notional zu Coin-Quantity
         qty = notional_usdt / price
+
+        # Dev/Paper-only sanity check: catch absurdly large quantities
+        if not self.config.use_real_balance:
+            # For BTC pairs, qty > 1.0 is extremely suspicious (likely sizing bug)
+            if "BTC" in signal.symbol and qty > 1.0:
+                logger.error(
+                    f"SANITY CHECK FAILED: qty={qty:.4f} for {signal.symbol} is absurdly large "
+                    f"(notional={notional_usdt:.2f} USDT, price={price:.2f}). "
+                    f"Possible sizing regression detected! Blocking order in dev/paper mode."
+                )
+                return 0.0
+
         return float(max(qty, 0.0))
 
     def send_order(self, order: Order):


### PR DESCRIPTION
## Purpose
Adds a dev/paper-only sanity check to catch absurd quantities that indicate position sizing regressions.

## Implementation
**Location:** `services/risk/service.py:calculate_position_size()`

**Logic:**
```python
if not self.config.use_real_balance:  # Dev/Paper only
    if "BTC" in signal.symbol and qty > 1.0:
        logger.error("SANITY CHECK FAILED: qty=... is absurdly large")
        return 0.0
```

## Behavior
- **Active:** Only when `use_real_balance=false` (dev/paper mode)
- **Trigger:** BTC pairs with qty > 1.0
- **Action:** Logs ERROR + returns 0.0 (blocks order)
- **Prod Impact:** None (never runs in live trading)

## Rationale
1. **Early Detection:** Catches sizing bugs before they reach prod
2. **Zero Prod Risk:** Only active in dev/paper environments
3. **Documented Assumptions:** Codifies implicit knowledge ("1+ BTC per order is absurd")
4. **Complements #538:** Additional safety layer for position sizing

## Example Scenarios

### Scenario 1: Regression (would trigger)
```
notional=20 USDT
price=0.001 (bug: price too low)
→ qty=20000 BTC (absurd)
→ Guardrail blocks + ERROR log
```

### Scenario 2: Normal Operation (passes)
```
notional=20 USDT
price=90000 (correct)
→ qty=0.00022 BTC (normal)
→ Guardrail silent, order proceeds
```

## Testing
Can be tested by:
1. Setting `use_real_balance=false` (dev mode)
2. Injecting a signal with artificially low price
3. Observing ERROR log + qty=0.0 result

---

Related: #538 (Position Sizing Fix)
Complements: #539 (Order Observability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Introduce a development-mode sanity check that logs and blocks BTC orders with abnormally large calculated quantities when not using real balances.