### PR TITLE
fix(market): align Dockerfile copy paths

### DIFF
--- a/services/market/Dockerfile
+++ b/services/market/Dockerfile
@@ -11,12 +11,12 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies
-COPY requirements.txt .
+COPY services/market/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application
-COPY service.py .
-COPY email_alerter.py .
+COPY services/market/service.py .
+COPY services/market/email_alerter.py .
 
 # Create logs directory
 RUN mkdir -p /app/logs /app/logs/events


### PR DESCRIPTION
## Feature Overview
Fix market Dockerfile to copy stub files from repo paths so CI builds/scans succeed.

## Technical Overview
Update COPY paths for requirements.txt, service.py, and email_alerter.py to use services/market/* with repo-root build context.

## Test Evidence
CI checks will validate (market build no longer fails on missing files).

## Code Quality
Minimal change, no refactors.

## Deployment & Rollback
Build-only change. Rollback = revert PR.

## Documentation
None.

## Agent Approvals
CODEX: executed.