### PR TITLE
chore(ci): reduce workflow spend

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,10 @@ env:
   PYTHON_VERSION: '3.12'
   CACHE_VERSION: 1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ============================================
   # CODE QUALITY CHECKS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     name: ci

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,9 +2,13 @@
 name: Build & Push Containers (GHCR)
 
 on:
-  pull_request:
   push:
-    branches: ["main"]
+    branches: ["main", "release/*"]
+    paths:
+      - "Dockerfile"
+      - "services/**/Dockerfile"
+      - "infrastructure/compose/**"
+      - ".github/workflows/docker-publish.yml"
   workflow_dispatch:
 
 permissions:
@@ -14,6 +18,10 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAMESPACE: ${{ github.repository_owner }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,6 +13,10 @@ env:
   # Secrets are REQUIRED - workflow fails if not set (no hardcoded fallbacks)
   SECRETS_PATH: ${{ github.workspace }}/.ci-secrets
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e-paper-trading:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,13 +8,10 @@ on:
       - 'services/**'
       - 'infrastructure/compose/**'
       - '.github/workflows/e2e.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'tests/e2e/**'
-      - 'services/**'
-      - 'infrastructure/compose/**'
-      - '.github/workflows/e2e.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   e2e_smoke:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -5,7 +5,10 @@ name: Security Scan
 on:
   schedule:
     - cron: '0 2 * * 1'  # Monday 02:00 UTC
-  pull_request:
+  push:
+    branches:
+      - main
+      - 'release/*'
     paths:
       - 'services/**/Dockerfile'
       - 'infrastructure/compose/**'
@@ -16,6 +19,10 @@ env:
   TRIVY_VERSION: "0.58.0"
   TRIVY_ALLOWLIST_CVES: "CVE-2025-12818"
   TRIVY_SUMMARY_MAX: "5"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # ============================================================================

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,14 +1,8 @@
 name: trivy
 
 on:
-  pull_request:
-    branches: ["main"]
-    paths:
-      - "Dockerfile"
-      - "infrastructure/**"
-      - "services/**"
   push:
-    branches: ["main"]
+    branches: ["main", "release/*"]
     paths:
       - "Dockerfile"
       - "infrastructure/**"
@@ -22,6 +16,10 @@ permissions:
 env:
   TRIVY_ALLOWLIST_CVES: "CVE-2025-12818"
   TRIVY_SUMMARY_MAX: "5"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   trivy-image:


### PR DESCRIPTION
## Feature Overview
Reduce CI cost by throttling heavy workflows and canceling redundant runs while keeping PR smoke/E2E gating.

## Technical Overview
- Move security scans (trivy/security-scan) to main/release/schedule only.
- Remove PR trigger from GHCR publish and push-only E2E; keep E2E PR gate via e2e-tests.
- Add concurrency/cancel-in-progress to main CI and E2E to avoid duplicate runners.
- Add paths filters for container publishing to avoid no-op builds.

## Test Evidence
Not run (workflow-only changes).

## Code Quality
Scoped to .github/workflows only.

## Deployment & Rollback
CI-only change. Rollback = revert PR.

## Documentation
Workflow triggers updated to reflect new CI policy.

## Agent Approvals
CODEX: executed.

## Summary by Sourcery

Reduce CI workflow cost and duplication by tightening triggers, adding concurrency controls, and limiting heavy scans to main and release branches.

CI:
- Add concurrency and cancel-in-progress settings to main CI, E2E, Trivy, security scan, and container publish workflows to prevent duplicate runs.
- Restrict Trivy and security scan workflows to run on pushes to main and release branches and scheduled runs instead of on every pull request.
- Update container publish workflow to run only on pushes to main and release branches with path filters to avoid no-op builds.
- Remove pull request triggers from heavy E2E and container publish workflows while retaining separate PR-gating E2E tests.