### PR TITLE
fix(security): remove libpq5 runtime CVE (#557)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -17,7 +17,6 @@ on:
 
 env:
   TRIVY_VERSION: "0.58.0"
-  TRIVY_ALLOWLIST_CVES: "CVE-2025-12818"
   TRIVY_SUMMARY_MAX: "5"
 
 concurrency:

--- a/services/execution/Dockerfile
+++ b/services/execution/Dockerfile
@@ -31,7 +31,6 @@ WORKDIR /app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
-        libpq5 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /venv /venv


### PR DESCRIPTION
Replaces allowlist for CVE-2025-12818 by removing the vulnerable libpq5 runtime package from the execution image (psycopg2-binary bundles libpq).

## Feature Overview
Remove the libpq5 runtime dependency from the execution image to eliminate CVE-2025-12818.

## Technical Overview
- Drop libpq5 from the runtime apt install in `services/execution/Dockerfile`.
- Remove `TRIVY_ALLOWLIST_CVES` from `.github/workflows/security-scan.yml`.

## Test Evidence
- `docker build -f services/execution/Dockerfile -t cdb_execution:cvefix .`
- `docker run --rm --entrypoint python cdb_execution:cvefix -c "import psycopg2; print(psycopg2.__version__)"`

## Code Quality
Minimal change; no refactors.

## Deployment & Rollback
No deployment change. Rollback = revert this PR.

## Documentation
No docs changes required.

## Agent Approvals
CODEX: executed.

## Summary by Sourcery

Remove a vulnerable PostgreSQL client runtime dependency and its associated vulnerability allowlist entry to address a security CVE in the execution image.

Bug Fixes:
- Eliminate the libpq5 runtime package from the execution Docker image to resolve CVE-2025-12818.

CI:
- Remove the TRIVY_ALLOWLIST_CVES environment variable from the security scan workflow so the previously allowed CVE is now reported normally.