### PR TITLE
fix: paper smoke exit loop (risk/execution)

### DIFF
--- a/services/risk/config.py
+++ b/services/risk/config.py
@@ -30,6 +30,7 @@ class RiskConfig:
     max_daily_drawdown_pct: float = float(os.getenv("MAX_DAILY_DRAWDOWN_PCT", "0.05"))
     stop_loss_pct: float = float(os.getenv("STOP_LOSS_PCT", "0.02"))
     early_live_max_alloc: float = float(os.getenv("EARLY_LIVE_MAX_ALLOC", "0.02"))
+    paper_auto_unwind: bool = os.getenv("PAPER_AUTO_UNWIND", "false").lower() == "true"
 
     # Topics
     input_topic: str = "signals"


### PR DESCRIPTION
## Summary
- Allow reduce-only SELL signals to bypass max-exposure gate in Risk
- Publish execution results to `stream.order_results` (plus filled_size/avg_fill_price fields)
- Add paper auto-unwind flag to enqueue SELL closes on BUY fills

## Type
- Bug fix

## Testing
- `pytest tests/unit/risk/test_service.py::test_exposure_limit_bypassed_for_reduce_only_sell`
- `docker exec cdb_postgres sh -c 'psql -U claire_user -d claire_de_binare -c "select side, count(*) from trades group by side order by count(*) desc;"'`
  - Output: buy=2766, sell=2
- `docker exec cdb_redis sh -c 'redis-cli -a $(cat /run/secrets/redis_password) XREVRANGE stream.order_results + - COUNT 3'`
  - Output: entries present (BUY + SELL)
- `docker compose -f infrastructure/compose/base.yml -f infrastructure/compose/dev.yml logs --since=20m cdb_risk | Select-String -Pattern "Order freigegeben:.*SELL"`
  - Output: SELL approved line present
- `docker compose -f infrastructure/compose/base.yml -f infrastructure/compose/dev.yml logs --since=20m cdb_risk | Select-String -Pattern "Max Exposure erreicht"`
  - Output: (no matches)

Ref: #427
