### PR TITLE
fix: wire PAPER_AUTO_UNWIND into cdb_risk compose (dev)

### DIFF
--- a/infrastructure/compose/dev.yml
+++ b/infrastructure/compose/dev.yml
@@ -222,6 +222,7 @@ services:
       REDIS_HOST: cdb_redis
       POSTGRES_HOST: cdb_postgres
       POSTGRES_USER: ${POSTGRES_USER:-claire_user}
+      PAPER_AUTO_UNWIND: ${PAPER_AUTO_UNWIND:-0}
     entrypoint: ["sh", "-c", "export REDIS_PASSWORD=$(cat /run/secrets/redis_password) && export POSTGRES_PASSWORD=$(cat /run/secrets/postgres_password) && export MEXC_API_KEY=$(cat /run/secrets/mexc_api_key) && export MEXC_API_SECRET=$(cat /run/secrets/mexc_api_secret) && exec python -m services.risk.service"]
     ports:
       - "127.0.0.1:8002:8002"


### PR DESCRIPTION
## Problem
PAPER_AUTO_UNWIND was set in `.env` but did not reach `cdb_risk` container.  
`docker compose config` showed no `PAPER_AUTO_UNWIND` in `cdb_risk` environment.

## Solution
Added `PAPER_AUTO_UNWIND: ${PAPER_AUTO_UNWIND:-0}` to `cdb_risk` environment section in `infrastructure/compose/dev.yml`.

## Evidence

**Before:**
```bash
docker inspect cdb_risk | grep PAPER_AUTO_UNWIND
# (no output - variable not present)
```

**After:**
```bash
docker inspect cdb_risk | grep PAPER_AUTO_UNWIND
"PAPER_AUTO_UNWIND=1"

docker exec cdb_risk sh -c 'echo "PAPER_AUTO_UNWIND=$PAPER_AUTO_UNWIND"'
PAPER_AUTO_UNWIND=1
```

## Smoke Check
✅ Service healthy: `Up 46s (healthy)`  
✅ Logs: Orders flowing (signals → approvals → fills)  
✅ Metrics: `orders_blocked_total=0`, `circuit_breaker_active` available

## Testing
```bash
# Verify config shows PAPER_AUTO_UNWIND
docker compose --env-file .env -f infrastructure/compose/base.yml -f infrastructure/compose/dev.yml config | grep -A 15 "cdb_risk:" | grep PAPER_AUTO_UNWIND

# Restart and verify in container
docker compose --env-file .env -f infrastructure/compose/base.yml -f infrastructure/compose/dev.yml up -d cdb_risk
docker exec cdb_risk sh -c 'echo "PAPER_AUTO_UNWIND=$PAPER_AUTO_UNWIND"'
# Expected: PAPER_AUTO_UNWIND=1
```

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Expose PAPER_AUTO_UNWIND in the cdb_risk service environment in the dev compose file with a default value of 0.