### PR TITLE
fix: enable PAPER_AUTO_UNWIND (config parsing + compose env)

### DIFF
--- a/infrastructure/compose/dev.yml
+++ b/infrastructure/compose/dev.yml
@@ -222,6 +222,7 @@ services:
       REDIS_HOST: cdb_redis
       POSTGRES_HOST: cdb_postgres
       POSTGRES_USER: ${POSTGRES_USER:-claire_user}
+      PAPER_AUTO_UNWIND: ${PAPER_AUTO_UNWIND:-0}
     entrypoint: ["sh", "-c", "export REDIS_PASSWORD=$(cat /run/secrets/redis_password) && export POSTGRES_PASSWORD=$(cat /run/secrets/postgres_password) && export MEXC_API_KEY=$(cat /run/secrets/mexc_api_key) && export MEXC_API_SECRET=$(cat /run/secrets/mexc_api_secret) && exec python -m services.risk.service"]
     ports:
       - "127.0.0.1:8002:8002"

--- a/services/risk/config.py
+++ b/services/risk/config.py
@@ -30,7 +30,7 @@ class RiskConfig:
     max_daily_drawdown_pct: float = float(os.getenv("MAX_DAILY_DRAWDOWN_PCT", "0.05"))
     stop_loss_pct: float = float(os.getenv("STOP_LOSS_PCT", "0.02"))
     early_live_max_alloc: float = float(os.getenv("EARLY_LIVE_MAX_ALLOC", "0.02"))
-    paper_auto_unwind: bool = os.getenv("PAPER_AUTO_UNWIND", "false").lower() == "true"
+    paper_auto_unwind: bool = os.getenv("PAPER_AUTO_UNWIND", "0") in ("1", "true", "True", "TRUE")
 
     # Topics
     input_topic: str = "signals"


### PR DESCRIPTION
## Problem (Issue #589)
Auto-unwind E2E verification failed:
- `PAPER_AUTO_UNWIND=1` in `.env`
- But `config.paper_auto_unwind` evaluated to `False`
- NO SELL orders generated (only 2 historical SELL trades from 2026-01-14)
- BUY:SELL ratio was **1984:1** (expected ~1:1)

## Root Cause

**Dual bug:**

1. **Config Parsing Bug** (`services/risk/config.py`):
   - Checked for string `"true"` only
   - `.env` had `PAPER_AUTO_UNWIND=1` (not `"true"`)
   - Logic: `.lower() == "true"` → False

2. **Missing ENV Variable** (`infrastructure/compose/dev.yml`):
   - `PAPER_AUTO_UNWIND` not in `cdb_risk` environment section
   - ENV var never reached container

## Solution

### 1. Fixed Config Parsing
```python
# OLD
paper_auto_unwind: bool = os.getenv("PAPER_AUTO_UNWIND", "false").lower() == "true"

# NEW
paper_auto_unwind: bool = os.getenv("PAPER_AUTO_UNWIND", "0") in ("1", "true", "True", "TRUE")
```

### 2. Added Compose ENV
```yaml
cdb_risk:
  environment:
    + PAPER_AUTO_UNWIND: ${PAPER_AUTO_UNWIND:-0}
```

## Evidence

### Before Fix ❌
```bash
docker exec cdb_risk python -c "from services.risk.config import config; print(config.paper_auto_unwind)"
→ False (despite ENV=1)

docker logs cdb_risk --since 48h | grep "PAPER_AUTO_UNWIND"
→ (no results - auto-unwind never triggered)

DB trades: BUY=1984, SELL=1
```

### After Fix ✅
```bash
docker exec cdb_risk python -c "from services.risk.config import config; print(config.paper_auto_unwind)"
→ True ✅

docker logs cdb_risk --since 2m | grep "PAPER_AUTO_UNWIND"
→ 2026-01-15 17:11:21 PAPER_AUTO_UNWIND: queued SELL BTCUSDT qty=0.0002 (order_id=MOCK_21726610)
→ 2026-01-15 17:11:53 PAPER_AUTO_UNWIND: queued SELL BTCUSDT qty=0.0002 (order_id=MOCK_84875932)
```

**stream.order_results (E2E flow):**
```
BUY FILLED:  MOCK_48836023, timestamp 1768497203, client_id BTCUSDT-1768497203
SELL FILLED: MOCK_47177030, timestamp 1768497204, client_id paper-unwind-MOCK_48836023 ✅
```

**DB trades (last 2 minutes):**
```
BUY:  4
SELL: 4  (1:1 ratio) ✅
```

## Acceptance Criteria Met

✅ PAPER_AUTO_UNWIND=1 verified  
✅ stream.order_results shows BUY → SELL sequence  
✅ DB trades shows SELL count increased  
✅ Logs show SELL approval ("PAPER_AUTO_UNWIND: queued SELL")

## Impact

Auto-unwind now functional. Every BUY FILLED triggers automatic SELL order for paper strategy.

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix PAPER_AUTO_UNWIND configuration so the paper trading auto-unwind behavior is correctly controlled via environment variables.

Bug Fixes:
- Make PAPER_AUTO_UNWIND config flag accept common truthy values (e.g. 1/true) instead of only the lowercase string 'true'.
- Expose PAPER_AUTO_UNWIND into the cdb_risk service environment in the dev compose configuration so the flag propagates into the container.