### PR TITLE
fix(ci): restore green pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,6 @@ concurrency:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   ci:
     name: ci


### PR DESCRIPTION
Rote Checks:
- .github/workflows/ci.yml (workflow file issue): https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/21150736256

Repro-Kommandos:
- gh run view 21150736256 -R jannekbuengener/Claire_de_Binare
- gh run view 21150736256 --log-failed

Grüne Checks:
- (pending) Actions derzeit durch billing lock blockiert; nach Owner-Disable erwartet gruen

Actions-Link:
- https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/21150736256

## Summary by Sourcery

CI:
- Clean up the GitHub Actions ci workflow by removing a duplicate concurrency block that interfered with pipeline runs.