### PR TITLE
fix(risk): use price fallback for exposure reservation (PR #617 hotfix)

### DIFF
--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -617,6 +617,15 @@ class RiskManager:
                 else "risk_off_limited"
             )
 
+        # PR #617 Hotfix: Use price fallback for exposure reservation
+        price_used = signal.price or risk_state.last_prices.get(signal.symbol, 0.0)
+        if price_used <= 0.0:
+            logger.warning(
+                f"Signal SKIPPED: {signal.symbol} {signal.side} - No valid price for exposure reservation (signal.price={signal.price}, last_price={risk_state.last_prices.get(signal.symbol, 'N/A')})"
+            )
+            stats["orders_skipped"] += 1
+            return None
+
         order = Order(
             symbol=signal.symbol,
             side=signal.side,
@@ -628,7 +637,7 @@ class RiskManager:
             client_id=f"{signal.symbol}-{signal.timestamp}",
             strategy_id=signal.strategy_id,
             bot_id=signal.bot_id,
-            price=signal.price,
+            price=price_used,
         )
 
         logger.info(
@@ -638,8 +647,8 @@ class RiskManager:
         risk_state.signals_approved += 1
         risk_state.pending_orders += 1
 
-        # PR #XXX: Reserve exposure for pending order to prevent race condition
-        estimated_notional = order.quantity * order.price if order.price else 0.0
+        # PR #617: Reserve exposure for pending order to prevent race condition
+        estimated_notional = order.quantity * price_used
         risk_state.pending_exposure_usdt += estimated_notional
         risk_state.pending_reservations[order.client_id] = estimated_notional
         logger.debug(


### PR DESCRIPTION
## Critical Hotfix for PR #617

PR #617 introduced exposure reservation but **was ineffective** due to  being  in most cases.

### Root Cause
-  is often 
-  → 
-  → **0.0** (no reservation!)
- Redis stream shows  (null)

### Evidence (Post PR #617)
```bash
# No reservation logs despite 132 approvals
docker logs cdb_risk | grep "Reserved" → EMPTY

# Orders have null price
docker exec cdb_redis ... XREVRANGE stream.orders + - COUNT 5
→ price: --  (NULL)
```

---

## Fix (3 Changes)

**1. Price Fallback:**
```python
price_used = signal.price or risk_state.last_prices.get(signal.symbol, 0.0)
```

**2. Skip if No Price:**
```python
if price_used <= 0.0:
    logger.warning("Signal SKIPPED: No valid price for exposure reservation")
    return None
```

**3. Use price_used:**
```python
order.price = price_used  # Non-null in Redis stream
estimated_notional = order.quantity * price_used  # Now > 0
```

---

## Expected After Deploy

**Immediate (within 1 minute):**
- [ ] Orders in Redis stream show  (not null)
- [ ] Debug logs: `"Reserved 19.998 USDT exposure for BTCUSDT-123..."`
- [ ]  endpoint: `pending_exposure_usdt > 0` when orders pending

**24h Observation:**
- [ ] Exposure-blocks = 0 (PR #617 now functional)

---

## Verification Commands

```bash
# 1. Check price in new orders (NOT null)
docker exec cdb_redis sh -c 'redis-cli -a $(cat /run/secrets/redis_password) XREVRANGE stream.orders + - COUNT 3' | grep -A1 "price"

# 2. Check reservation logs (MUST appear)
docker logs cdb_risk --since 5m 2>&1 | grep "Reserved"

# 3. Check pending_exposure > 0
curl -s http://localhost:8002/status | jq '.risk_state.pending_exposure_usdt'
```

---

## Rollback (if needed)

Same as PR #617: Revert commit + restart Risk service.

---

**Urgency:** Critical (PR #617 currently non-functional)  
**Scope:** Risk Service only (12 lines changed)  
**Risk:** Low (fallback to established last_prices mechanism)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

## Summary by Sourcery

Fix exposure reservation in the risk service by ensuring a valid price is used when creating pending orders and computing reserved notional.

Bug Fixes:
- Fallback to the latest known symbol price when the incoming signal has no price to ensure exposure reservation works.
- Skip signal processing when no valid price is available, preventing zero-notional reservations and inconsistent state.

Enhancements:
- Ensure orders store the effective price used for exposure calculations, keeping Redis order data and reservation logic consistent.