### PR TITLE
ci: back to green (post billing) - step 1

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -38,12 +38,14 @@ jobs:
 
       # Optional: Node only if you really have JS tooling
       - name: Setup Node (optional)
+        if: ${{ hashFiles('package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock') != '' }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "npm"
 
       - name: Install Node deps (if present)
+        if: ${{ hashFiles('package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock') != '' }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
Summary:
- CI/CD back to green (post billing); first fix disables Copilot node setup when no lockfile exists.

Context:
- Tracks #624.
- CircleCI is obsolete/removed.

Changes:
- Skip setup-node and npm install when no JS lockfile is present.

Test Plan:
- GitHub Actions PR checks.

## Summary by Sourcery

CI:
- Guard Node setup and npm install steps in the Copilot workflow with a lockfile check to avoid unnecessary Node tooling setup.