### PR TITLE
Verify E2E exception issue on main

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -119,6 +119,35 @@ jobs:
           echo "SMTP_PASSWORD=stub" >> "$GITHUB_ENV"
           echo "ALERT_EMAIL_TO=ci-stub@example.invalid" >> "$GITHUB_ENV"
 
+      - name: Create issue on protected exception
+        if: |
+          env.CDB_E2E_EXCEPTION == 'true' &&
+          (github.ref == 'refs/heads/main' || github.event_name == 'schedule')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          title="[CI][E2E] STUB MODE on protected context (secrets missing)"
+          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          body=$(cat <<EOF
+          Run URL: ${run_url}
+          Run ID: ${GITHUB_RUN_ID}
+          Ref: ${GITHUB_REF}
+          Event: ${GITHUB_EVENT_NAME}
+          Expected secrets: SMTP_FROM, SMTP_HOST, SMTP_USER, SMTP_PASSWORD, ALERT_EMAIL_TO
+
+          Green != Real E2E
+          EOF
+          )
+
+          if gh issue create --title "$title" --body "$body" --label "type:infra,prio:must,scope:ci,pipeline:generated"; then
+            echo "Issue created with labels."
+          else
+            gh issue create --title "$title" --body "$body"
+          fi
+
       # --- 4) Hard fail on protected contexts if secrets are missing ---------------
       - name: ❌ Missing secrets on protected context (HARD FAIL)
         if: |


### PR DESCRIPTION
Temporary workflow-only change to validate protected-context exception issue creation. Will revert after verification.

## Summary by Sourcery

Guard E2E workflow against missing SMTP-related secrets by introducing a REAL vs STUB execution mode with explicit signalling and failure on protected contexts.

CI:
- Add SMTP-related secrets handling to the E2E workflow with defaults for non-secret contexts.
- Introduce REAL vs STUB E2E modes based on presence of SMTP secrets, including environment stubbing when secrets are absent.
- Create GitHub issues automatically when E2E runs in STUB mode on protected branches or scheduled runs, and hard-fail those runs to enforce proper secret configuration.