### PR TITLE
ci: bump jaraco.context + wheel for Trivy fix (#634)

### DIFF
--- a/services/signal/requirements.txt
+++ b/services/signal/requirements.txt
@@ -7,3 +7,7 @@ werkzeug>=3.1.4  # Security: Fix CVEs in Dependabot alerts #339
 
 # Utilities
 python-dotenv==1.0.0
+
+# CI security: Trivy HIGH CVEs
+jaraco.context==6.1.0
+wheel==0.46.3


### PR DESCRIPTION
## Summary
- bump jaraco.context to 6.1.0
- bump wheel to 0.46.3

## Testing
- not run (dependency update only)

Closes #634