### PR TITLE
ci: add guardrails for secrets and format drift (#627)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,11 +31,38 @@ jobs:
       - name: Create CI secrets directory
         run: |
           mkdir -p $SECRETS_PATH
-          for name in REDIS_PASSWORD POSTGRES_PASSWORD GRAFANA_PASSWORD MEXC_API_KEY.txt MEXC_API_SECRET.txt; do
+          for name in REDIS_PASSWORD POSTGRES_PASSWORD GRAFANA_PASSWORD SMTP_USER SMTP_PASSWORD SMTP_FROM ALERT_EMAIL_TO MEXC_API_KEY.txt MEXC_API_SECRET.txt; do
             printf 'ci-%s\n' "$name" > "$SECRETS_PATH/$name"
           done
           POSTGRES_PW=$(cat "$SECRETS_PATH/POSTGRES_PASSWORD")
           echo "postgresql://claire_user:${POSTGRES_PW}@postgres:5432/claire?sslmode=disable" > "$SECRETS_PATH/POSTGRES_PASSWORD_DSN"
+          echo "✅ CI secrets placeholders created"
+
+      - name: Validate CI secrets contract
+        run: |
+          required=(
+            REDIS_PASSWORD
+            POSTGRES_PASSWORD
+            GRAFANA_PASSWORD
+            SMTP_USER
+            SMTP_PASSWORD
+            SMTP_FROM
+            ALERT_EMAIL_TO
+            MEXC_API_KEY.txt
+            MEXC_API_SECRET.txt
+          )
+          missing=0
+          for name in "${required[@]}"; do
+            if [ ! -s "$SECRETS_PATH/$name" ]; then
+              echo "❌ Missing required secret placeholder: $name"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "❌ CI secrets contract not satisfied"
+            exit 1
+          fi
+          echo "✅ CI secrets contract satisfied"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # Makefile für Claire de Binare Test-Suite
 # Unterstützt sowohl CI (schnell, Mocks) als auch lokale E2E-Tests
 
-.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup paper-trading-start paper-trading-logs paper-trading-stop rollback cleanup format format-check
+.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup paper-trading-start paper-trading-logs paper-trading-stop rollback cleanup cleanup-live format format-check
 
 help:
 	@echo "Claire de Binare - Test Commands"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # Makefile für Claire de Binare Test-Suite
 # Unterstützt sowohl CI (schnell, Mocks) als auch lokale E2E-Tests
 
-.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup paper-trading-start paper-trading-logs paper-trading-stop rollback cleanup
+.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup paper-trading-start paper-trading-logs paper-trading-stop rollback cleanup format format-check
 
 help:
 	@echo "Claire de Binare - Test Commands"
@@ -26,6 +26,7 @@ help:
 	@echo "  make test-unit               - Nur Unit-Tests"
 	@echo "  make test-integration        - Nur Integration-Tests (mit Mocks)"
 	@echo "  make test-coverage           - Tests mit Coverage-Report"
+	@echo "  make format-check            - Python-Format prüfen (Black)"
 	@echo ""
 	@echo "Lokale E2E-Tests (mit echten Containern):"
 	@echo "  make test-e2e                - Alle E2E-Tests (18 Tests)"
@@ -56,6 +57,7 @@ help:
 	@echo "  make rollback MR=<number>    - Rollback eines Merge Requests"
 	@echo "  make cleanup                 - Aufräumen merged Branches (DRY-RUN)"
 	@echo "  make cleanup-live            - Aufräumen merged Branches (LIVE)"
+	@echo "  make format                  - Python-Dateien formatieren (Black)"
 
 # ============================================================================
 # CI-Tests (schnell, mit Mocks)
@@ -76,6 +78,14 @@ test-coverage:
 	@echo "📊 Führe Tests mit Coverage-Report aus..."
 	pytest --cov=core --cov=services --cov=infrastructure/scripts --cov-report=html --cov-report=term --cov-fail-under=80 -m "not e2e and not local_only"
 	@echo "📄 Coverage-Report: htmlcov/index.html"
+
+format:
+	@echo "🎨 Formatiere Python-Dateien mit Black..."
+	black .
+
+format-check:
+	@echo "🔎 Prüfe Python-Format mit Black..."
+	black --check .
 
 # ============================================================================
 # Lokale E2E-Tests (mit echten Containern)

--- a/tests/unit/test_import_smoke.py
+++ b/tests/unit/test_import_smoke.py
@@ -1,0 +1,17 @@
+"""Smoke import tests for critical services."""
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.unit
+def test_import_risk_service_module():
+    """Import risk service to catch fragile relative imports early."""
+    importlib.import_module("services.risk.service")
+
+
+@pytest.mark.unit
+def test_import_signal_service_module():
+    """Import signal service to catch fragile relative imports early."""
+    importlib.import_module("services.signal.service")


### PR DESCRIPTION
## Summary
- add Makefile targets for black format/check
- add smoke import test for risk/signal services
- ensure CI E2E workflow stubs SMTP/alert secrets and validates secrets contract

## Testing
- not run (guardrails only)

Closes #627

## Summary by Sourcery

Tighten CI guardrails around secrets and code formatting while adding smoke tests for critical service imports.

New Features:
- Add Makefile targets to format Python code with Black and to check formatting in CI or locally.
- Introduce unit-level smoke tests that verify risk and signal service modules can be imported successfully.

Enhancements:
- Extend the CI E2E workflow to create placeholders for SMTP and alert-related secrets and to validate that all required CI secrets exist before running tests.

CI:
- Update the e2e GitHub Actions workflow to stub additional secrets and enforce a CI secrets contract check step.

Tests:
- Add import-based smoke tests for risk and signal services to catch fragile import issues early.