### PR TITLE
ci: add jules-gated automerge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,163 @@
+name: Auto-merge (Jules + checks + label)
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  workflow_run:
+    workflows:
+      - "CI/CD Pipeline"
+      - "Delivery Gate"
+      - "Gitleaks Secret Scan"
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  AUTOMERGE_LABEL: automerge
+  JULES_LOGIN: ${{ vars.JULES_LOGIN }}
+  REQUIRED_CHECKS: ${{ vars.AUTOMERGE_REQUIRED_CHECKS || 'CI/CD Pipeline,Delivery Gate,Gitleaks Secret Scan' }}
+  MERGE_METHOD: ${{ vars.AUTOMERGE_METHOD || 'merge' }}
+
+jobs:
+  automerge:
+    if: |
+      (github.event_name != 'workflow_run') ||
+      (github.event.workflow_run.head_repository.full_name == github.repository)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate config
+        env:
+          AUTOMERGE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+        run: |
+          if [ -z "${AUTOMERGE_TOKEN}" ]; then
+            echo "AUTOMERGE_TOKEN secret missing"
+            exit 1
+          fi
+          if [ -z "${JULES_LOGIN}" ]; then
+            echo "JULES_LOGIN repo variable missing"
+            exit 1
+          fi
+
+      - name: Evaluate PRs and merge when eligible
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        env:
+          AUTOMERGE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+        with:
+          github-token: ${{ secrets.AUTOMERGE_TOKEN }}
+          script: |
+            const core = require('@actions/core');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const julesLogin = (process.env.JULES_LOGIN || '').toLowerCase();
+            const requiredChecks = (process.env.REQUIRED_CHECKS || '')
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean);
+            const automergeLabel = process.env.AUTOMERGE_LABEL || 'automerge';
+            const mergeMethod = process.env.MERGE_METHOD || 'merge';
+
+            async function listPRsForSha(sha) {
+              const prs = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
+                owner,
+                repo,
+                commit_sha: sha,
+              });
+              return prs;
+            }
+
+            async function getPR(number) {
+              const { data } = await github.rest.pulls.get({ owner, repo, pull_number: number });
+              return data;
+            }
+
+            async function hasJulesApproval(prNumber) {
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner,
+                repo,
+                pull_number: prNumber,
+              });
+              const julesReviews = reviews.filter(r => (r.user?.login || '').toLowerCase() === julesLogin);
+              if (julesReviews.length === 0) return false;
+              const latest = julesReviews.sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at)).pop();
+              return latest && latest.state === 'APPROVED';
+            }
+
+            async function checksGreen(sha) {
+              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+                owner,
+                repo,
+                ref: sha,
+              });
+
+              if (requiredChecks.length === 0) {
+                const { data } = await github.rest.repos.getCombinedStatusForRef({ owner, repo, ref: sha });
+                return data.state === 'success';
+              }
+
+              const byName = new Map();
+              for (const run of checkRuns) {
+                if (run.status !== 'completed') continue;
+                if (!byName.has(run.name)) {
+                  byName.set(run.name, run);
+                  continue;
+                }
+                const existing = byName.get(run.name);
+                if (new Date(run.completed_at) > new Date(existing.completed_at)) {
+                  byName.set(run.name, run);
+                }
+              }
+
+              for (const name of requiredChecks) {
+                const run = byName.get(name);
+                if (!run) return false;
+                if (run.conclusion !== 'success') return false;
+              }
+              return true;
+            }
+
+            function hasLabel(pr, label) {
+              return (pr.labels || []).some(l => (l.name || '').toLowerCase() === label.toLowerCase());
+            }
+
+            let prs = [];
+            if (context.eventName === 'pull_request' || context.eventName === 'pull_request_review') {
+              prs = [context.payload.pull_request];
+            } else if (context.eventName === 'workflow_run') {
+              const sha = context.payload.workflow_run.head_sha;
+              prs = await listPRsForSha(sha);
+            }
+
+            if (!prs || prs.length === 0) {
+              core.info('No PRs to evaluate');
+              return;
+            }
+
+            for (const prRef of prs) {
+              const pr = prRef.number ? await getPR(prRef.number) : prRef;
+              if (pr.state !== 'open' || pr.draft) continue;
+              if (pr.head?.repo?.full_name !== `${owner}/${repo}`) continue;
+              if (!hasLabel(pr, automergeLabel)) continue;
+
+              const julesApproved = await hasJulesApproval(pr.number);
+              if (!julesApproved) continue;
+
+              const checksOk = await checksGreen(pr.head.sha);
+              if (!checksOk) continue;
+
+              core.info(`Merging PR #${pr.number}`);
+              await github.rest.pulls.merge({
+                owner,
+                repo,
+                pull_number: pr.number,
+                merge_method: mergeMethod,
+              });
+            }

--- a/.github/workflows/labels.json
+++ b/.github/workflows/labels.json
@@ -28,6 +28,7 @@
     { "name": "redis", "color": "dc382d", "description": "Redis Pub/Sub, Streams" },
     { "name": "postgres", "color": "336791", "description": "PostgreSQL, Schemas, Queries" },
     { "name": "testing", "color": "fbca04", "description": "Test-Coverage, E2E, Fixtures" },
-    { "name": "dependencies", "color": "0366d6", "description": "Dependency Updates (Dependabot)" }
+    { "name": "dependencies", "color": "0366d6", "description": "Dependency Updates (Dependabot)" },
+    { "name": "automerge", "color": "6f42c1", "description": "PR eligible for auto-merge (Jules + checks)" }
   ]
 }

--- a/docs/ci/AUTOMERGE.md
+++ b/docs/ci/AUTOMERGE.md
@@ -1,0 +1,24 @@
+# Auto-merge (Jules + checks + label)
+
+Rules
+- Auto-merge runs only when ALL are true:
+  - PR has label `automerge`
+  - Jules review is APPROVED
+  - Required checks are green on PR head SHA
+
+How to use
+1) Ensure label `automerge` exists (sync labels from `.github/workflows/labels.json` or create manually).
+2) Set repo variable `JULES_LOGIN` to the GitHub login of the Jules bot.
+3) Add secret `AUTOMERGE_TOKEN` (PAT with `repo` scope) for merge permission.
+4) (Optional) Set repo variable `AUTOMERGE_REQUIRED_CHECKS` as a comma-separated list of check names.
+5) Apply label `automerge` to an eligible PR.
+
+Branch protection settings (manual)
+- Require pull request before merging
+- Require approvals (>= 1)
+- Require status checks to pass
+- Restrict dismissing reviews
+- Require CODEOWNERS review (only if Jules is enforced via CODEOWNERS)
+
+Workflow
+- `.github/workflows/automerge.yml`


### PR DESCRIPTION
## Summary
- add auto-merge workflow gated by Jules approval, required checks, and `automerge` label
- add `automerge` label to labels.json for sync
- document usage in docs/ci/AUTOMERGE.md

## Rules
- PR must have label `automerge`
- Jules review must be APPROVED (via `JULES_LOGIN`)
- Required checks must be green on PR head SHA

## How to use `automerge`
1) Sync labels from `.github/workflows/labels.json` (or create label manually).
2) Set repo variable `JULES_LOGIN` (Jules GitHub login).
3) Add secret `AUTOMERGE_TOKEN` (PAT with repo scope).
4) (Optional) Set `AUTOMERGE_REQUIRED_CHECKS` (comma-separated check names).
5) Apply label `automerge` to an eligible PR.

## Summary by Sourcery

Add a gated auto-merge workflow that merges PRs only when a specific reviewer (Jules), required checks, and an `automerge` label conditions are satisfied.

New Features:
- Introduce a GitHub Actions workflow to automatically merge eligible pull requests based on label, reviewer approval, and check status.

CI:
- Add an `automerge` GitHub Actions workflow triggered by pull request, review, and selected workflow_run events, using configurable required checks and merge method.
- Extend shared CI label configuration to include an `automerge` label for use with the auto-merge workflow.

Documentation:
- Add documentation describing the auto-merge rules, configuration, and usage for the new Jules-gated workflow.