### PR TITLE
feat(grafana): add API CLI helpers

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,25 @@
+# Scripts
+
+## Grafana API helpers
+
+These scripts provide a deterministic Grafana HTTP API path without MCP changes.
+
+Requirements:
+- Grafana reachable at GF_URL (default: http://localhost:3000)
+- API token via GRAFANA_TOKEN or %SECRETS_PATH%\grafana_api_token
+- SECRETS_PATH default: C:\Users\janne\Documents\.secrets\.cdb
+
+Inventory dump:
+```powershell
+pwsh -File scripts/grafana_inventory_dump.ps1
+```
+
+Function usage:
+```powershell
+. scripts/grafana_api.ps1
+Get-GrafanaHealth
+Get-GrafanaDatasources
+Get-GrafanaFolders
+Search-GrafanaDashboards -Query "Claire"
+Export-GrafanaDashboardByUid -Uid "<uid>"
+```

--- a/scripts/grafana_api.ps1
+++ b/scripts/grafana_api.ps1
@@ -1,0 +1,133 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Grafana HTTP API helper functions.
+.DESCRIPTION
+    Uses GF_URL and GRAFANA_TOKEN (or a token file) to call the Grafana API.
+#>
+
+$ErrorActionPreference = "Stop"
+
+function Get-GrafanaBaseUrl {
+    $url = $env:GF_URL
+    if ([string]::IsNullOrWhiteSpace($url)) {
+        return "http://localhost:3000"
+    }
+
+    return $url.Trim()
+}
+
+function Get-GrafanaToken {
+    $token = $env:GRAFANA_TOKEN
+    if (-not [string]::IsNullOrWhiteSpace($token)) {
+        return $token.Trim()
+    }
+
+    $secretsPath = $env:SECRETS_PATH
+    if ([string]::IsNullOrWhiteSpace($secretsPath)) {
+        $secretsPath = "C:\\Users\\janne\\Documents\\.secrets\\.cdb"
+    }
+
+    $tokenPath = Join-Path $secretsPath "grafana_api_token"
+    if (Test-Path $tokenPath) {
+        $fileToken = Get-Content -Path $tokenPath -Raw
+        if (-not [string]::IsNullOrWhiteSpace($fileToken)) {
+            return $fileToken.Trim()
+        }
+    }
+
+    Write-Error "Grafana API token not found. Set GRAFANA_TOKEN or place a token file at $tokenPath."
+    return $null
+}
+
+function Get-GrafanaAuthHeaders {
+    $token = Get-GrafanaToken
+    if (-not $token) {
+        return $null
+    }
+
+    return @{ Authorization = "Bearer $token" }
+}
+
+function Invoke-GrafanaApi {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter()]
+        [ValidateSet("GET", "POST", "PUT", "DELETE")]
+        [string]$Method = "GET",
+
+        [Parameter()]
+        [object]$Body
+    )
+
+    $baseUrl = Get-GrafanaBaseUrl
+    $headers = Get-GrafanaAuthHeaders
+    if (-not $headers) {
+        return $null
+    }
+
+    $uri = $baseUrl.TrimEnd("/") + $Path
+
+    try {
+        if ($null -ne $Body) {
+            $json = $Body | ConvertTo-Json -Depth 10
+            return Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers -ContentType "application/json" -Body $json
+        }
+
+        return Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers
+    } catch {
+        Write-Error "Grafana API request failed ($Method $Path): $($_.Exception.Message)"
+        return $null
+    }
+}
+
+function Get-GrafanaHealth {
+    return Invoke-GrafanaApi -Path "/api/health"
+}
+
+function Get-GrafanaDatasources {
+    return Invoke-GrafanaApi -Path "/api/datasources"
+}
+
+function Get-GrafanaFolders {
+    return Invoke-GrafanaApi -Path "/api/folders"
+}
+
+function Search-GrafanaDashboards {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$Query = "",
+
+        [Parameter()]
+        [string]$Type = "dash-db"
+    )
+
+    $queryParts = @()
+    if (-not [string]::IsNullOrWhiteSpace($Query)) {
+        $queryParts += "query=$([System.Uri]::EscapeDataString($Query))"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($Type)) {
+        $queryParts += "type=$Type"
+    }
+
+    $path = "/api/search"
+    if ($queryParts.Count -gt 0) {
+        $path = $path + "?" + ($queryParts -join "&")
+    }
+
+    return Invoke-GrafanaApi -Path $path
+}
+
+function Export-GrafanaDashboardByUid {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Uid
+    )
+
+    return Invoke-GrafanaApi -Path ("/api/dashboards/uid/{0}" -f $Uid)
+}

--- a/scripts/grafana_inventory_dump.ps1
+++ b/scripts/grafana_inventory_dump.ps1
@@ -1,0 +1,63 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Dump Grafana inventory to JSON files.
+.DESCRIPTION
+    Writes health, datasources, folders, and dashboard search results to
+    .cdb_agent_workspace/grafana_inventory/<timestamp>/
+#>
+
+$ErrorActionPreference = "Stop"
+
+$scriptRoot = $PSScriptRoot
+$repoRoot = Resolve-Path (Join-Path $scriptRoot "..")
+$outputRoot = Join-Path $repoRoot ".cdb_agent_workspace" "grafana_inventory"
+$timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$outputDir = Join-Path $outputRoot $timestamp
+
+. (Join-Path $scriptRoot "grafana_api.ps1")
+
+function Write-JsonFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [object]$Value
+    )
+
+    $json = $Value | ConvertTo-Json -Depth 10
+    $json | Out-File -FilePath $Path -Encoding utf8
+}
+
+New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+
+$health = Get-GrafanaHealth
+if (-not $health) {
+    Write-Error "Grafana health query failed."
+    exit 1
+}
+Write-JsonFile -Path (Join-Path $outputDir "health.json") -Value $health
+
+$datasources = Get-GrafanaDatasources
+if ($null -eq $datasources) {
+    Write-Error "Grafana datasources query failed."
+    exit 1
+}
+Write-JsonFile -Path (Join-Path $outputDir "datasources.json") -Value $datasources
+
+$folders = Get-GrafanaFolders
+if ($null -eq $folders) {
+    Write-Error "Grafana folders query failed."
+    exit 1
+}
+Write-JsonFile -Path (Join-Path $outputDir "folders.json") -Value $folders
+
+$dashboards = Search-GrafanaDashboards
+if ($null -eq $dashboards) {
+    Write-Error "Grafana dashboard search failed."
+    exit 1
+}
+Write-JsonFile -Path (Join-Path $outputDir "dashboards_search.json") -Value $dashboards
+
+Write-Host "Grafana inventory written to: $outputDir"


### PR DESCRIPTION
## Summary
- add Grafana HTTP API helper functions in PowerShell
- add inventory dump script to emit JSON under .cdb_agent_workspace/grafana_inventory/<timestamp>
- add minimal usage docs for Grafana API scripts

## Testing
- not run (requires local Grafana + token)

## Evidence
```
scripts/
  README.md
  grafana_api.ps1
  grafana_inventory_dump.ps1
```

Closes #674

## Summary by Sourcery

Add PowerShell helpers for interacting with the Grafana HTTP API and a script to dump Grafana inventory to JSON files.

New Features:
- Introduce PowerShell module providing Grafana HTTP API helper functions for common operations such as health checks, datasource listing, folder listing, dashboard search, and dashboard export by UID.
- Add a Grafana inventory dump script that writes health, datasources, folders, and dashboard search results to timestamped JSON files under .cdb_agent_workspace/grafana_inventory.
- Document prerequisites and usage examples for the Grafana API helper and inventory dump scripts in scripts/README.md.