### PR TITLE
Harden safety gates and risk limits

### DIFF
--- a/claire-de-binare.mcp.json
+++ b/claire-de-binare.mcp.json
@@ -6,7 +6,7 @@
       "args": ["npx", "-y", "@modelcontextprotocol/redis"],
       "env": {
         "REDIS_PORT": "6379",
-        "REDIS_HOST": "cdb_redis"
+        "REDIS_HOST": "cdb_redis",
         "REDIS_PASSWORD": "${REDIS_PASSWORD}"
       },
       "type": "stdio"

--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -472,16 +472,31 @@ def signal_handler(signum, frame):
 
 
 def _require_live_confirmation() -> None:
-    if config.DRY_RUN and config.MOCK_TRADING:
+    """
+    Sicherheitsprüfung für Live-Trading.
+    Erfordert explizite Bestätigung, wenn echtes Geld (Mainnet + Live Executor) im Spiel ist.
+    """
+    # Sicherer Modus, wenn:
+    # 1. MOCK_TRADING aktiv ist (MockExecutor wird verwendet)
+    # 2. DRY_RUN aktiv ist (LiveExecutor loggt nur, führt nicht aus)
+    # 3. MEXC_TESTNET aktiv ist (Testnet, kein echtes Geld)
+    if config.MOCK_TRADING or config.DRY_RUN or config.MEXC_TESTNET:
         return
 
+    # Nur wenn alle oben genannten Sicherheitsnetze deaktiviert sind,
+    # ist es eine ECHTE Live-Umgebung auf dem Mainnet.
     confirmation = os.getenv("CONFIRM_LIVE_TRADING", "").lower().strip()
     if confirmation != "true":
-        logger.critical("LIVE trading safety gate triggered.")
+        logger.critical("🚨 LIVE TRADING SAFETY GATE TRIGGERED 🚨")
+        logger.critical("Sie versuchen, auf dem MAINNET ohne MOCK/DRY-RUN zu traden!")
         logger.critical(
-            "Set CONFIRM_LIVE_TRADING=true to proceed (DRY_RUN=%s, MOCK_TRADING=%s).",
+            "Setzen Sie CONFIRM_LIVE_TRADING=true, um fortzufahren."
+        )
+        logger.critical(
+            "Aktuelle Konfiguration: DRY_RUN=%s, MOCK_TRADING=%s, TESTNET=%s",
             config.DRY_RUN,
             config.MOCK_TRADING,
+            config.MEXC_TESTNET,
         )
         sys.exit(1)
 

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -26,6 +26,7 @@ from core.auth import validate_all_auth
 try:
     from .config import config
     from .models import Order, Alert, RiskState, OrderResult
+    from .balance_fetcher import RealBalanceFetcher
 except ImportError:
     # Fallback for script/importlib execution: ensure repo root is on sys.path.
     repo_root = Path(__file__).resolve().parents[2]
@@ -91,6 +92,13 @@ class RiskManager:
     def __init__(self):
         self.config = config
         self.redis_client: Optional[redis.Redis] = None
+        self.balance_fetcher: Optional[RealBalanceFetcher] = None
+        if self.config.use_real_balance:
+            try:
+                self.balance_fetcher = RealBalanceFetcher()
+                logger.info("RealBalanceFetcher initialisiert")
+            except Exception as e:
+                logger.error(f"Fehler beim Initialisieren von RealBalanceFetcher: {e}")
         self.pubsub: Optional[redis.client.PubSub] = None
         self.pubsub_results: Optional[redis.client.PubSub] = None
         self._order_result_thread: Optional[Thread] = None
@@ -440,38 +448,51 @@ class RiskManager:
                 time.sleep(1)
 
     def check_position_limit(self, signal: Signal) -> tuple[bool, str]:
-        """Prüft Positions-Limit"""
-        # REAL BALANCE - NO MORE FAKE test_balance
-        from .balance_fetcher import RealBalanceFetcher
-
-        if self.config.use_real_balance:
-            balance_fetcher = RealBalanceFetcher()
-            current_balance = balance_fetcher.get_usdt_balance()
+        """
+        Prüft das Positions-Limit für ein Symbol.
+        Verhindert den Aufbau von Positionen, die das konfigurierte Limit (max_position_pct) überschreiten.
+        """
+        if self.config.use_real_balance and self.balance_fetcher:
+            try:
+                current_balance = self.balance_fetcher.get_usdt_balance()
+            except Exception as e:
+                logger.error(f"Fehler beim Abrufen der Balance: {e}")
+                return False, f"Balance-Fehler: {e}"
         else:
             current_balance = self.config.test_balance
 
-        # Max 10% des REAL Kapitals pro Position
-        max_position_size = current_balance * self.config.max_position_pct
+        # Max. Notional-Wert pro Position (z.B. 10% des Kapitals)
+        max_notional_usdt = current_balance * self.config.max_position_pct
 
-        # Vereinfachte Berechnung (später mit echtem Portfolio)
-        estimated_position = max_position_size * 0.8  # 80% vom Limit nutzen
+        # Aktuelle Position und Preis ermitteln
+        current_qty = risk_state.positions.get(signal.symbol, 0.0)
+        current_price = signal.price or risk_state.last_prices.get(signal.symbol, 0.0)
 
-        if estimated_position > max_position_size:
+        if current_price <= 0:
+            # Ohne Preis können wir keine Notional-Prüfung machen.
+            # Da calculate_position_size dies auch prüft, lassen wir es hier durch.
+            return True, "Position OK (Preis unbekannt)"
+
+        current_notional = abs(current_qty) * current_price
+
+        # Wenn wir bereits am oder über dem Limit sind, blockieren wir weitere Positionsvergrößerungen.
+        # Hinweis: Reduce-only Orders werden in process_signal vorab gefiltert und umgehen Exposure-Checks.
+        if current_notional >= max_notional_usdt:
             return (
                 False,
-                f"Position zu groß: {estimated_position:.2f} > {max_position_size:.2f}",
+                f"Position für {signal.symbol} am Limit: {current_notional:.2f} >= {max_notional_usdt:.2f}",
             )
 
         return True, "Position OK"
 
     def check_exposure_limit(self) -> tuple[bool, str]:
         """Prüft Gesamt-Exposure (filled + pending reserved)"""
-        # REAL BALANCE - NO MORE FAKE
-        from .balance_fetcher import RealBalanceFetcher
-
-        if self.config.use_real_balance:
-            balance_fetcher = RealBalanceFetcher()
-            current_balance = balance_fetcher.get_usdt_balance()
+        if self.config.use_real_balance and self.balance_fetcher:
+            try:
+                current_balance = self.balance_fetcher.get_usdt_balance()
+            except Exception as e:
+                logger.error(f"Fehler beim Abrufen der Balance: {e}")
+                return False, f"Balance-Fehler: {e}"
         else:
             current_balance = self.config.test_balance
 
@@ -491,12 +512,12 @@ class RiskManager:
 
     def check_drawdown_limit(self) -> tuple[bool, str]:
         """Prüft Daily-Drawdown (Circuit Breaker)"""
-        # REAL BALANCE - NO MORE FAKE
-        from .balance_fetcher import RealBalanceFetcher
-
-        if self.config.use_real_balance:
-            balance_fetcher = RealBalanceFetcher()
-            current_balance = balance_fetcher.get_usdt_balance()
+        if self.config.use_real_balance and self.balance_fetcher:
+            try:
+                current_balance = self.balance_fetcher.get_usdt_balance()
+            except Exception as e:
+                logger.error(f"Fehler beim Abrufen der Balance: {e}")
+                return False, f"Balance-Fehler: {e}"
         else:
             current_balance = self.config.test_balance
 
@@ -716,12 +737,12 @@ class RiskManager:
         Returns:
             (quantity, skip_reason): qty=0.0 mit reason wenn skipped
         """
-        # REAL BALANCE - NO MORE FAKE
-        from .balance_fetcher import RealBalanceFetcher
-
-        if self.config.use_real_balance:
-            balance_fetcher = RealBalanceFetcher()
-            current_balance = balance_fetcher.get_usdt_balance()
+        if self.config.use_real_balance and self.balance_fetcher:
+            try:
+                current_balance = self.balance_fetcher.get_usdt_balance()
+            except Exception as e:
+                logger.error(f"Fehler beim Abrufen der Balance: {e}")
+                return 0.0, f"Balance-Fehler: {e}"
         else:
             current_balance = self.config.test_balance
 

--- a/tests/unit/risk/test_service.py
+++ b/tests/unit/risk/test_service.py
@@ -397,3 +397,43 @@ def test_proactive_unwind_no_trigger_when_no_open_positions(mock_redis, mock_pos
             risk_service.risk_state.positions = original_positions
             risk_service.risk_state.total_exposure = original_total_exposure
             risk_service.risk_off_active = original_risk_off
+
+
+@pytest.mark.unit
+def test_check_position_limit_enforcement(mock_redis, mock_postgres):
+    """
+    Test: check_position_limit blockiert wenn Symbol bereits am Limit ist.
+    """
+    test_config = RiskConfig(
+        max_position_pct=0.10,  # 10%
+        test_balance=1000.0,    # Max 100 USD pro Position
+    )
+
+    with patch.object(risk_service, "config", test_config):
+        manager = RiskManager()
+
+        # Setup: Symbol am Limit
+        risk_service.risk_state.positions = {"BTCUSDT": 0.002}  # 0.002 * 50000 = 100 USD
+        risk_service.risk_state.last_prices = {"BTCUSDT": 50000.0}
+
+        signal = Signal(
+            symbol="BTCUSDT",
+            side="BUY",
+            price=50000.0,
+            timestamp=1
+        )
+
+        # Check: Sollte blockieren
+        ok, reason = manager.check_position_limit(signal)
+        assert ok is False
+        assert "am Limit" in reason
+
+        # Setup: Anderes Symbol nicht am Limit
+        signal_2 = Signal(
+            symbol="ETHUSDT",
+            side="BUY",
+            price=3000.0,
+            timestamp=1
+        )
+        ok, reason = manager.check_position_limit(signal_2)
+        assert ok is True


### PR DESCRIPTION
Hardened the trading bot's safety mechanisms and risk management. The execution safety gate is now smarter, allowing Testnet/Dry Run modes without explicit confirmation while still protecting the Mainnet. Risk limits are now correctly enforced based on real-time data, and balance fetching is more efficient.

---
*PR created automatically by Jules for task [8424555337036876510](https://jules.google.com/task/8424555337036876510) started by @jannekbuengener*

## Summary by Sourcery

Harden trading risk management and live-execution safety to rely on real balances and enforce per-symbol limits while keeping test and dry-run modes convenient.

New Features:
- Introduce a reusable RealBalanceFetcher instance in the risk manager to centralize access to real-time account balances.
- Add per-symbol position-limit checks based on actual notional exposure and configured max_position_pct.

Bug Fixes:
- Ensure risk checks and position sizing use a shared real balance fetcher instead of creating new instances on each call, improving reliability and performance.
- Correctly gate true mainnet live trading behind an explicit CONFIRM_LIVE_TRADING confirmation while allowing mock, dry-run, and testnet modes to run without extra confirmation.
- Propagate balance retrieval errors through clear failure reasons in risk and sizing checks instead of silently falling back.

Tests:
- Add a unit test verifying that check_position_limit blocks when a symbol is already at its configured notional exposure limit and allows other symbols.