### PR TITLE
testpack: wire chaos ingestion + metrics assertions

### DIFF
--- a/tools/test_pack/CHANGELOG.md
+++ b/tools/test_pack/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v2.0
+- Reorganized pack into clearer structure (templates/, scenarios/, integrations/)
+- Added Mock Exchange stub server
+- Added metrics smoke helper
+- Upgraded chaos harness with CDB adapter hook
+- Added pack manifest + scenario catalog

--- a/tools/test_pack/PACK_MANIFEST.json
+++ b/tools/test_pack/PACK_MANIFEST.json
@@ -1,0 +1,15 @@
+{
+  "pack_name": "cdb_test_pack_v2_plus_issue_pack",
+  "built_at": "2026-01-26T19:07:09",
+  "inputs": {
+    "cdb_test_pack_v2.zip": {
+      "sha256": "ceb1dc18d936259ad1dbb287a23d9b645ba7338bb36d62644a57eff835231a30"
+    },
+    "PROMPT_CodeX_Import_TestPack_v2.md": {
+      "sha256": "61914ecbd05f3e529dad8435601286731210f820bb8bfb5751b9cd196118c534"
+    },
+    "PROMPT_CodeX_IssuePack_CDB_LiveReadiness.md": {
+      "sha256": "401e84f8f6aa62feda8dc98da43e0efca551574946f6ce51e0dd10f75ddcf88c"
+    }
+  }
+}

--- a/tools/test_pack/README.md
+++ b/tools/test_pack/README.md
@@ -1,0 +1,56 @@
+# CDB Test Pack v2 (Upgradeable)
+
+This pack is the “safety + readiness” layer before anything touches a real market.
+
+It is built around four things you can prove with evidence packs:
+1) Planning consistency (do we all mean the same thing?)
+2) Chaos drills (does the system stay safe under stress?)
+3) Operator drills (can a human stop it fast, every time?)
+4) Mock exchange (realistic order lifecycle without real money)
+
+## What you get
+- Deterministic scenario generator (JSONL)
+- Harness scripts that produce an Evidence Pack folder
+- Templates for assertions and evidence documentation
+- A tiny Mock Exchange server (stdlib-only) as a drop-in test target
+
+## How we run it (recommended order)
+1) Planning lint → baseline “we’re aligned”
+2) Mock Exchange smoke → baseline “order lifecycle works”
+3) Chaos drill → baseline “risk + safeguards hold”
+4) Kill-switch drill → baseline “human can stop it”
+
+## Quickstart (Windows / PowerShell)
+Requirements:
+- Python 3.10+
+- PowerShell 7+
+
+### Generate a scenario
+```powershell
+python tools/chaos/generate_scenario.py --mode highvol_noise --minutes 180 --seed 1337 --out .\scenario_noise.jsonl
+```
+
+### Run a chaos drill (creates an evidence pack)
+```powershell
+.\infrastructure\scripts\run-chaos-drill.ps1 `
+  -ScenarioFile .\scenario_noise.jsonl `
+  -EvidenceDir .\evidence\2026-01-26_S-CHAOS-001 `
+  -RedisHost 127.0.0.1 -RedisPort 6379 `
+  -PromUrl http://127.0.0.1:19090
+```
+
+### Run the operator kill-switch drill (creates an evidence pack)
+```powershell
+.\tools\drills\trigger-operator-drill.ps1 -EvidenceDir .\evidence\2026-01-26_S-OPS-001
+```
+
+### Run the mock exchange (for order lifecycle tests)
+```powershell
+python tools\mock_exchange\mock_exchange.py --port 18080
+# health: http://127.0.0.1:18080/health
+```
+
+## Where to extend next
+- Expand assertions in `tools/assertions/evaluate_assertions.py` for your gates
+- Add additional Prometheus queries in `tools/metrics/metrics_snapshot.py`
+- Add more scenarios in `scenarios/catalog.yaml`

--- a/tools/test_pack/infrastructure/scripts/run-chaos-drill.ps1
+++ b/tools/test_pack/infrastructure/scripts/run-chaos-drill.ps1
@@ -1,0 +1,180 @@
+# infrastructure/scripts/run-chaos-drill.ps1
+<#!
+Chaos Drill Harness (upgradeable)
+
+What it does:
+  - prepares an evidence pack folder
+  - (optional) brings up a stack (generic docker-compose.yml OR via integrations/cdb-stack-adapter.ps1)
+  - records the scenario used
+  - ingests the scenario into CDB (Redis market_data)
+  - captures a metrics snapshot + evaluates assertions
+  - collects logs
+  - (optional) brings the stack down
+
+Rule:
+  Evidence pack is a first-class artifact. If it doesn't exist, the drill didn't happen.
+#>
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory=$true)][string]$ScenarioFile,
+  [Parameter(Mandatory=$true)][string]$EvidenceDir,
+
+  # Generic mode (fallback):
+  [string]$ComposeFile = "docker-compose.yml",
+
+  # CDB mode (preferred when you have the repo locally):
+  [string]$CdbRepoRoot = "",
+
+  # Ingestion config
+  [string]$RedisHost = "localhost",
+  [int]$RedisPort = 6379,
+  [int]$RedisDb = 0,
+  [string]$RedisPassword = "",
+  [string]$Symbol = "BTCUSDT",
+  [string]$TradeQty = "1",
+  [int]$TickDelayMs = 0,
+  [switch]$DryRunIngestion,
+
+  # Metrics
+  [string]$PromUrl = "http://127.0.0.1:19090",
+  [switch]$RunMetricsSmoke
+)
+
+$ErrorActionPreference = "Stop"
+
+function New-EvidenceDir([string]$Path) {
+  New-Item -ItemType Directory -Force -Path $Path | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $Path "service_logs") | Out-Null
+  New-Item -ItemType Directory -Force -Path (Join-Path $Path "reports") | Out-Null
+}
+
+function Write-Stamp([string]$Dir, [string]$Message) {
+  $line = "{0} {1}" -f (Get-Date).ToString("o"), $Message
+  Add-Content -Path (Join-Path $Dir "timeline.log") -Value $line
+}
+
+function Stack-Up([string]$Dir) {
+  if ($CdbRepoRoot -and (Test-Path (Join-Path $PSScriptRoot "..\..\integrations\cdb-stack-adapter.ps1"))) {
+    Write-Stamp $Dir "STACK_UP_CDB"
+    & pwsh -NoProfile -File (Join-Path $PSScriptRoot "..\..\integrations\cdb-stack-adapter.ps1") `
+      -CdbRepoRoot $CdbRepoRoot -EvidenceDir (Join-Path $Dir "stack") 2>&1 | Out-Null
+    return
+  }
+
+  Write-Stamp $Dir "STACK_UP_COMPOSE"
+  docker compose -f $ComposeFile up -d --build 2>&1 | Tee-Object -FilePath (Join-Path $Dir "compose_up.log") | Out-Null
+}
+
+function Stack-Down([string]$Dir) {
+  if ($CdbRepoRoot -and (Test-Path (Join-Path $PSScriptRoot "..\..\integrations\cdb-stack-adapter.ps1"))) {
+    Write-Stamp $Dir "STACK_DOWN_CDB"
+    # adapter does up+down together today; keep placeholder for future split
+    return
+  }
+
+  Write-Stamp $Dir "STACK_DOWN_COMPOSE"
+  docker compose -f $ComposeFile down 2>&1 | Tee-Object -FilePath (Join-Path $Dir "compose_down.log") | Out-Null
+}
+
+$PackRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$IngestScript = Join-Path $PackRoot "tools\ingestion\ingest_scenario.py"
+$SnapshotScript = Join-Path $PackRoot "tools\metrics\metrics_snapshot.py"
+$AssertionsScript = Join-Path $PackRoot "tools\assertions\evaluate_assertions.py"
+$MetricsSmokeScript = Join-Path $PackRoot "tools\metrics\metrics-smoke.ps1"
+$ReadmeTemplate = Join-Path $PackRoot "templates\evidence_pack_README.md"
+
+New-EvidenceDir -Path $EvidenceDir
+Copy-Item -Force $ScenarioFile (Join-Path $EvidenceDir "scenario.jsonl")
+
+if (Test-Path $ReadmeTemplate) {
+  Copy-Item -Force $ReadmeTemplate (Join-Path $EvidenceDir "README.md")
+}
+
+$runConfig = [ordered]@{
+  ts_utc = (Get-Date).ToString("o")
+  scenario_file = $ScenarioFile
+  evidence_dir = $EvidenceDir
+  redis = @{
+    host = $RedisHost
+    port = $RedisPort
+    db = $RedisDb
+    symbol = $Symbol
+    trade_qty = $TradeQty
+    tick_delay_ms = $TickDelayMs
+    dry_run = [bool]$DryRunIngestion
+  }
+  prometheus = @{ url = $PromUrl }
+}
+$runConfig | ConvertTo-Json -Depth 6 | Out-File (Join-Path $EvidenceDir "run_config.json") -Encoding utf8
+
+$sources = @()
+if (Test-Path $ScenarioFile) { $sources += @{ path = $ScenarioFile; sha256 = (Get-FileHash $ScenarioFile).Hash } }
+if (Test-Path $IngestScript) { $sources += @{ path = $IngestScript; sha256 = (Get-FileHash $IngestScript).Hash } }
+if (Test-Path $SnapshotScript) { $sources += @{ path = $SnapshotScript; sha256 = (Get-FileHash $SnapshotScript).Hash } }
+if (Test-Path $AssertionsScript) { $sources += @{ path = $AssertionsScript; sha256 = (Get-FileHash $AssertionsScript).Hash } }
+$sources | ConvertTo-Json -Depth 6 | Out-File (Join-Path $EvidenceDir "sources_manifest.txt") -Encoding utf8
+
+Write-Stamp $EvidenceDir "CHAOS_DRILL_START"
+
+Stack-Up -Dir $EvidenceDir
+
+$failed = $false
+
+# Ingestion
+Write-Stamp $EvidenceDir "INGEST_SCENARIO"
+$ingestReport = Join-Path $EvidenceDir "reports\ingestion_report.json"
+$ingestArgs = @(
+  $IngestScript,
+  "--scenario", $ScenarioFile,
+  "--out", $ingestReport,
+  "--redis-host", $RedisHost,
+  "--redis-port", $RedisPort,
+  "--redis-db", $RedisDb,
+  "--symbol", $Symbol,
+  "--trade-qty", $TradeQty
+)
+if ($RedisPassword) { $ingestArgs += @("--redis-password", $RedisPassword) }
+if ($TickDelayMs -gt 0) { $ingestArgs += @("--tick-delay-ms", $TickDelayMs) }
+if ($DryRunIngestion) { $ingestArgs += "--dry-run" }
+
+& python @ingestArgs
+if ($LASTEXITCODE -ne 0) {
+  Write-Stamp $EvidenceDir "INGESTION_FAIL"
+  $failed = $true
+}
+
+# Optional quick smoke
+if ($RunMetricsSmoke) {
+  Write-Stamp $EvidenceDir "METRICS_SMOKE"
+  try {
+    & pwsh -NoProfile -File $MetricsSmokeScript -PromUrl $PromUrl -OutDir (Join-Path $EvidenceDir "reports\metrics_smoke") | Out-Null
+  } catch {
+    $_.Exception.Message | Out-File -FilePath (Join-Path $EvidenceDir "reports\metrics_smoke_error.txt") -Encoding utf8
+  }
+}
+
+# Metrics snapshot
+Write-Stamp $EvidenceDir "METRICS_SNAPSHOT"
+$metricsSnapshot = Join-Path $EvidenceDir "reports\metrics_snapshot.json"
+& python $SnapshotScript --prom-url $PromUrl --out $metricsSnapshot
+
+# Assertions
+Write-Stamp $EvidenceDir "ASSERTIONS_EVAL"
+$assertionsResult = Join-Path $EvidenceDir "reports\assertions_result.json"
+& python $AssertionsScript --snapshot $metricsSnapshot --out $assertionsResult
+if ($LASTEXITCODE -ne 0) {
+  $failed = $true
+}
+
+Write-Stamp $EvidenceDir "COLLECT_LOGS"
+try {
+  docker compose -f $ComposeFile logs --no-color > (Join-Path $EvidenceDir "service_logs\stack.log")
+} catch {
+  $_.Exception.Message | Out-File -FilePath (Join-Path $EvidenceDir "service_logs\stack_logs_error.txt") -Encoding utf8
+}
+
+Stack-Down -Dir $EvidenceDir
+Write-Stamp $EvidenceDir "CHAOS_DRILL_END"
+
+if ($failed) { exit 1 }

--- a/tools/test_pack/integrations/cdb-stack-adapter.ps1
+++ b/tools/test_pack/integrations/cdb-stack-adapter.ps1
@@ -1,0 +1,30 @@
+# integrations/cdb-stack-adapter.ps1
+<#
+Purpose:
+  Run pack drills against the real CDB stack scripts if they exist.
+
+How:
+  - points to the working repo root
+  - calls scripts/stack_up.ps1 and scripts/stack_down.ps1
+  - returns the compose invocation output into the evidence pack
+
+This keeps the Test Pack generic while still "clicking" into CDB with minimal friction.
+#>
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory=$true)][string]$CdbRepoRoot,
+  [Parameter(Mandatory=$true)][string]$EvidenceDir
+)
+
+$ErrorActionPreference = "Stop"
+New-Item -ItemType Directory -Force -Path $EvidenceDir | Out-Null
+
+$up = Join-Path $CdbRepoRoot "scripts\stack_up.ps1"
+$down = Join-Path $CdbRepoRoot "scripts\stack_down.ps1"
+
+if (!(Test-Path $up)) { throw "Missing: $up" }
+if (!(Test-Path $down)) { throw "Missing: $down" }
+
+& pwsh -NoProfile -File $up 2>&1 | Tee-Object -FilePath (Join-Path $EvidenceDir "stack_up.log") | Out-Null
+& pwsh -NoProfile -File $down 2>&1 | Tee-Object -FilePath (Join-Path $EvidenceDir "stack_down.log") | Out-Null

--- a/tools/test_pack/issue_pack/README.md
+++ b/tools/test_pack/issue_pack/README.md
@@ -1,0 +1,21 @@
+# CDB Issue-Pack (bundled with Testpack v2)
+
+This folder contains the curated GitHub Issue Pack for **Live‑Trading Readiness**.
+
+## How to use
+1) Use the prompt in `prompts/PROMPT_CodeX_IssuePack_CDB_LiveReadiness.md` to create GitHub issues automatically (recommended).
+2) Or manually copy each file from `issues/` into a GitHub Issue (one file = one issue).
+
+## Special note: Branch Protection restore (saved files)
+Source-of-truth folder (local):
+`D:\Dev\Workspaces\Worktrees\branch-protection files`
+
+Expectation:
+- Re-apply via **Playwright through MCP** (UI automation), using those saved files as reference.
+
+## Contents
+- `issues/` — Issue bodies (Titles, Labels, Scope, AC, Dependencies)
+- `prompts/` — Codex prompts (import testpack, create issues)
+- `links/` — Placeholders for future references/screenshots (optional)
+
+Generated: 2026-01-26

--- a/tools/test_pack/issue_pack/issues/001_p0_obs_metrics_overhaul_fix_prometheus_targets_no_data_dashb.md
+++ b/tools/test_pack/issue_pack/issues/001_p0_obs_metrics_overhaul_fix_prometheus_targets_no_data_dashb.md
@@ -1,0 +1,18 @@
+## ISSUE 1 — [P0][OBS] Metrics Overhaul: fix Prometheus targets + “No Data” dashboards + main panel restore
+Labels: prio:p0, type:obs, scope:metrics
+Scope:
+- Prometheus scrape targets
+- Grafana datasource
+- Dashboard queries/variables
+Description:
+- Panels showing “No Data” and the broken main panel must be fixed. This is a prerequisite for chaos assertions and kill-switch verification.
+Acceptance Criteria:
+- Prometheus targets: all core services `UP=1` (stable, no flapping)
+- Main dashboard loads without errors
+- 0 broken panels; “No Data” either fixed or explicitly marked as “expected empty” with explanation
+- Golden Signals section exists: throughput, error rate, latency, backlog/queue, orders/fills, risk blocks, kill-switch state
+- Add a 5-step “No Data” troubleshooting checklist to docs
+Links/Refs:
+- Add links to the dashboards/panels in the issue once identified
+
+---

--- a/tools/test_pack/issue_pack/issues/002_p0_safety_kill_switch_one_button_trigger_live_status_verifia.md
+++ b/tools/test_pack/issue_pack/issues/002_p0_safety_kill_switch_one_button_trigger_live_status_verifia.md
@@ -1,0 +1,16 @@
+## ISSUE 2 — [P0][SAFETY] Kill-Switch “One Button”: trigger + live status + verifiable stop of order flow
+Labels: prio:p0, type:safety, scope:drills
+Scope:
+- Implement/standardize a single action to HALT
+- Surface clear state: SAFE/HALT/FAILSAFE
+Description:
+- Kill-switch must be usable under stress: one action + immediate effect + clear verification.
+Acceptance Criteria:
+- One action (CLI/UI/shortcut) toggles SAFE↔HALT
+- In HALT: no new orders are sent; any open orders canceled/frozen per design
+- Status is visible (endpoint/metric) and auditable (who/when)
+- Verification procedure exists and is automated where possible (metric or state endpoint)
+Dependencies:
+- Depends on Issue 1 for reliable metrics
+
+---

--- a/tools/test_pack/issue_pack/issues/003_p0_gov_enforcement_re_apply_branch_protection_from_saved_fil.md
+++ b/tools/test_pack/issue_pack/issues/003_p0_gov_enforcement_re_apply_branch_protection_from_saved_fil.md
@@ -1,0 +1,21 @@
+## ISSUE 3 — [P0][GOV][ENFORCEMENT] Re-apply Branch Protection from saved files using Playwright (MCP)
+Labels: prio:p0, type:gov, scope:repo, scope:security
+Scope:
+- Restore branch protection rules for `main`
+- Required checks and review requirements
+Description:
+- Branch protection must be restored from the previously saved configuration.
+- Use Playwright via MCP to apply settings through GitHub UI (automation), referencing local saved files.
+Implementation Notes:
+- Source of truth folder: `D:\Dev\Workspaces\Worktrees\branch-protection files`
+- Codex must inspect this folder and translate it into exact GitHub settings
+Acceptance Criteria:
+- Branch protection for `main` active and matches saved config
+- Direct pushes blocked; PR required
+- Required checks set and enforced
+- Admin bypass disabled or explicitly controlled (document choice)
+- A proof artifact is produced: screenshot(s) or exported settings summary in an evidence folder
+Dependencies:
+- None (but coordinate with CI checks from Issue 4)
+
+---

--- a/tools/test_pack/issue_pack/issues/004_p0_ci_required_checks_green_or_stop_ci_gates_stabilized.md
+++ b/tools/test_pack/issue_pack/issues/004_p0_ci_required_checks_green_or_stop_ci_gates_stabilized.md
@@ -1,0 +1,15 @@
+## ISSUE 4 — [P0][CI] Required Checks: “Green or Stop” (CI gates stabilized)
+Labels: prio:p0, type:infra, scope:ci
+Scope:
+- Define the minimal set of required workflows
+- Ensure failures are actionable
+Description:
+- CI must be a real gate. “Green” must mean safe to merge.
+Acceptance Criteria:
+- Required checks list documented (name → purpose)
+- 3 consecutive green runs on `main` without manual reruns
+- Failure logs are readable and point to the root cause
+Dependencies:
+- Works together with Issue 3 (required checks are referenced by branch protection)
+
+---

--- a/tools/test_pack/issue_pack/issues/005_p0_test_wire_test_pack_v2_ingestion_hook_metrics_snapshot_as.md
+++ b/tools/test_pack/issue_pack/issues/005_p0_test_wire_test_pack_v2_ingestion_hook_metrics_snapshot_as.md
@@ -1,0 +1,19 @@
+## ISSUE 5 — [P0][TEST] Wire Test Pack v2: ingestion hook + metrics snapshot + assertions evaluator
+Labels: prio:p0, type:test, scope:drills
+Scope:
+- Take the Test Pack v2 skeleton and make it runnable end-to-end
+Description:
+- The harness currently has TODO hooks for ingestion + metrics/assertions. Implement them so the chaos drill produces PASS/FAIL automatically.
+Acceptance Criteria:
+- One supported ingestion path is implemented end-to-end (choose one; document):
+  - HTTP ingest endpoint OR message bus publish OR file adapter replay
+- Drill produces artifacts:
+  - metrics_snapshot.json
+  - assertions_result.json (overall_pass, per-assertion evidence links)
+- Evidence pack structure produced per template (README + sources manifest + logs + reports)
+Dependencies:
+- Depends on Issue 1 (metrics snapshot source)
+Links/Refs:
+- Reference `cdb_test_pack_v2.zip` integration path in repo (if already imported)
+
+---

--- a/tools/test_pack/issue_pack/issues/006_p0_test_operator_drill_implement_real_alert_trigger_kill_swi.md
+++ b/tools/test_pack/issue_pack/issues/006_p0_test_operator_drill_implement_real_alert_trigger_kill_swi.md
@@ -1,0 +1,15 @@
+## ISSUE 6 — [P0][TEST] Operator Drill: implement real alert trigger + kill-switch verification + timeline evidence
+Labels: prio:p0, type:test, type:safety, scope:drills
+Scope:
+- Turn the operator drill skeleton into a real drill
+Description:
+- Implement a real alert trigger (webhook/email/alertmanager) and a verifiable kill-switch check.
+Acceptance Criteria:
+- Trigger produces a captured payload/message inside evidence pack
+- Verification uses one canonical source (metric/state endpoint/log marker) and is automated
+- timeline.json produced with key stamps
+Dependencies:
+- Depends on Issue 2 (kill-switch state + verification method)
+- Depends on Issue 1 if verification uses metrics
+
+---

--- a/tools/test_pack/issue_pack/issues/007_p1_ci_jules_ai_reviewer_pr_comment_pass_fail_findings_no_mer.md
+++ b/tools/test_pack/issue_pack/issues/007_p1_ci_jules_ai_reviewer_pr_comment_pass_fail_findings_no_mer.md
@@ -1,0 +1,15 @@
+## ISSUE 7 — [P1][CI] Jules AI Reviewer: PR comment PASS/FAIL + findings (no merge rights)
+Labels: prio:p1, type:infra, scope:ci
+Scope:
+- Automated PR review comment
+Description:
+- Jules runs on PR events and posts/updates a structured comment with verdict PASS/FAIL + risk flags.
+Acceptance Criteria:
+- Runs on PR open/sync
+- Posts exactly one updatable “Jules Review” comment (no spam)
+- Contains: verdict, key findings, suggested checks for human signer
+- No write access beyond commenting
+Dependencies:
+- None
+
+---

--- a/tools/test_pack/issue_pack/issues/008_p1_gov_enforce_six_eyes_human_signoff_only_after_jules_pass.md
+++ b/tools/test_pack/issue_pack/issues/008_p1_gov_enforce_six_eyes_human_signoff_only_after_jules_pass.md
@@ -1,0 +1,15 @@
+## ISSUE 8 — [P1][GOV] Enforce “Six-Eyes”: Human Signoff only after Jules PASS
+Labels: prio:p1, type:gov, scope:repo
+Scope:
+- Process + gating rule
+Description:
+- Human signer (second account) merges only when Jules verdict is PASS.
+Acceptance Criteria:
+- PR template fields: Builder, Jules Review link, Human Signer
+- Clear policy documented: Jules FAIL => no merge
+- Dry-run PR proves the flow
+Dependencies:
+- Depends on Issue 7
+- Pairs with Issue 3 (branch protection reviews)
+
+---

--- a/tools/test_pack/issue_pack/issues/009_p2_sim_mock_exchange_execution_simulator_market_like_feedbac.md
+++ b/tools/test_pack/issue_pack/issues/009_p2_sim_mock_exchange_execution_simulator_market_like_feedbac.md
@@ -1,0 +1,14 @@
+## ISSUE 9 — [P2][SIM] Mock Exchange / Execution Simulator (market-like feedback without real market)
+Labels: prio:p2, type:sim
+Scope:
+- Local service or module that mimics exchange API semantics
+Description:
+- Accept orders; simulate fills/rejects/partial fills/latency/rate limits; deterministic seed mode.
+Acceptance Criteria:
+- Scenarios: full fill, partial fill, reject, timeout, rate limit, delayed fill
+- Deterministic mode (seed) + chaos mode
+- Produces order_result events compatible with execution/risk pipeline
+Dependencies:
+- Enables stronger chaos drills later
+
+---

--- a/tools/test_pack/issue_pack/issues/010_p2_gov_planning_lint_in_ci_anti_drift_for_phases_gaps.md
+++ b/tools/test_pack/issue_pack/issues/010_p2_gov_planning_lint_in_ci_anti_drift_for_phases_gaps.md
@@ -1,0 +1,28 @@
+## ISSUE 10 — [P2][GOV] Planning Lint in CI (anti-drift for phases/gaps)
+Labels: prio:p2, type:gov, type:infra, scope:ci
+Scope:
+- Run `planning_lint.py` on chosen planning docs folders
+Description:
+- Keep planning docs consistent and enforce phase/gap conventions (optional strictness).
+Acceptance Criteria:
+- CI job runs on PR
+- Outputs JSON report artifact
+- Fails PR on phase inconsistency (and optionally gap violations)
+Dependencies:
+- None
+
+---
+
+Execution instructions for Codex (how to create issues)
+1) Use GitHub Issues API or CLI (gh) to create issues in `jannekbuengener/Claire_de_Binare`.
+2) Apply labels exactly as listed above.
+3) For each issue, include “Links/Refs” with placeholders if missing and add a checklist for artifacts/evidence.
+4) After creating all issues, post a final summary comment in the last issue:
+   - Issue numbers + titles
+   - Dependency graph (P0 first)
+   - Immediate next action recommendation: start with Issue 1 (metrics) and Issue 3 (branch protection restore)
+
+Output required
+- List of created issue URLs
+- Any labels that had to be created
+- Notes on anything blocked (and the proposed default)

--- a/tools/test_pack/pack/manifest.yaml
+++ b/tools/test_pack/pack/manifest.yaml
@@ -1,0 +1,23 @@
+name: cdb_test_pack
+version: '2.0'
+status: upgradeable-skeleton
+focus:
+- planning_audit
+- chaos_drills
+- operator_drills
+- mock_exchange
+principles:
+- deterministic
+- evidence_pack_first
+- rollback_safe
+- kill_switch_verified
+run_order:
+- planning_lint
+- mock_exchange_smoke
+- chaos_drill
+- operator_drill
+outputs:
+- evidence_pack/README.md
+- evidence_pack/timeline.log or timeline.json
+- reports/*.json
+- service_logs/*

--- a/tools/test_pack/prompts/PROMPT_CodeX_Import_TestPack_v2.md
+++ b/tools/test_pack/prompts/PROMPT_CodeX_Import_TestPack_v2.md
@@ -1,0 +1,70 @@
+# Codex Prompt — Import & Wire CDB Test Pack v2 into Repo (local → PR)
+
+Context:
+- We work **local → remote**.
+- Do **not** edit governance constitution/policies unless explicitly asked.
+- Goal: integrate the already-built test pack ZIP into the repo in a clean, upgradeable way.
+
+Inputs (local Windows):
+- Test pack ZIP: `D:\Dev\Workspaces\Prompts\TEST\cdb_test_pack_v2.zip`
+- Prompt folder: `D:\Dev\Workspaces\Prompts\TEST`
+- Target repo (assume already cloned): `D:\Dev\Workspaces\Repos\Claire_de_Binare`
+  - If the repo path differs, discover it via `git rev-parse --show-toplevel`.
+
+Deliverable:
+- A single PR that adds the Test Pack v2 into the repo under a stable path, plus a minimal wiring layer and docs:
+  - Copy test pack to: `tools/test_pack/` (or `tests/test_pack/` if you prefer—pick ONE and document it)
+  - Add a short README in that folder explaining how to run locally (PowerShell) and how to generate an evidence pack.
+  - Add a “smoke” CI job that runs only the planning lint + scenario generation (NO docker compose up in CI yet).
+
+Hard rules:
+- No “TODO-only” PR. Every script must at least run and produce outputs (even if adapters are stubs).
+- Keep changes surgical: add files + minimal integration. Don’t refactor existing system code.
+- No internet access assumptions.
+
+Steps:
+1) Create a new branch:
+   - `git checkout -b testpack/import-v2`
+2) Unzip the pack into a temp folder:
+   - `Expand-Archive -Path "D:\Dev\Workspaces\Prompts\TEST\cdb_test_pack_v2.zip" -DestinationPath "$env:TEMP\cdb_test_pack_v2" -Force`
+3) Copy contents into repo target folder (choose ONE target root and stick to it):
+   - `Copy-Item -Recurse -Force "$env:TEMP\cdb_test_pack_v2\*" "<REPO>\tools\test_pack\"`
+4) Normalize line endings if needed (no CRLF surprises).
+5) Add a top-level integration doc entry:
+   - In repo README or docs index (whichever is appropriate), add a short “Testing: Chaos/Drills” link pointing to `tools/test_pack/README.md`.
+6) Add a tiny “adapter contract” file that declares where the hooks will connect:
+   - Example: `tools/test_pack/adapters/ADAPTERS.md` describing:
+     - ingestion path (HTTP vs stream vs file) = **NOT selected yet**
+     - metrics snapshot source (Prometheus vs endpoint) = **NOT selected yet**
+     - kill-switch verification source (metric/log/state endpoint) = **NOT selected yet**
+   - This document is the single source of truth so later we can kill TODO drift.
+7) CI smoke job:
+   - Add a workflow (or extend existing) to run:
+     - `python tools/test_pack/tools/planning/planning_lint.py --sources <some docs folder> --out <artifact>`
+       - If actual planning docs paths are unknown, run it on `tools/test_pack/README.md` just to prove the pipeline works, but clearly document how to point it at real docs.
+     - `python tools/test_pack/tools/chaos/generate_scenario.py --mode whipsaw --minutes 30 --seed 1337 --out <artifact>`
+   - Upload artifacts.
+   - Do NOT attempt docker compose in CI.
+8) Validate locally:
+   - `python ...planning_lint.py ...`
+   - `python ...generate_scenario.py ...`
+   - Ensure scripts exit 0.
+9) Commit with message:
+   - `feat(testpack): import CDB test pack v2 + CI smoke`
+10) Push branch and open PR. Include in PR body:
+   - What was added
+   - How to run locally
+   - What remains intentionally un-wired (ingestion/metrics/kill-switch verification) and why
+
+Acceptance criteria (must be true):
+- Repo contains `tools/test_pack/` (or chosen location) with all test pack files.
+- `planning_lint.py` runs and outputs JSON.
+- `generate_scenario.py` runs and outputs JSONL.
+- CI has a green “Test Pack Smoke” job producing the two artifacts.
+- Docs link exists and points to the new README.
+- No changes to core trading services or governance canon.
+
+Output required:
+- PR link
+- List of changed files
+- Local commands to run the pack after merge

--- a/tools/test_pack/prompts/PROMPT_CodeX_IssuePack_CDB_LiveReadiness.md
+++ b/tools/test_pack/prompts/PROMPT_CodeX_IssuePack_CDB_LiveReadiness.md
@@ -1,0 +1,216 @@
+# Codex Prompt — Create GitHub Issue Pack (CDB: Live-Trading Readiness)
+
+Context
+- Work **local → remote**.
+- Repo: `jannekbuengener/Claire_de_Binare`
+- Target: Create a prioritized Issue Pack (P0/P1/P2) based on the agreed readiness plan.
+- IMPORTANT: Use existing local artifacts whenever available. Do not “reinvent” branch protection.
+
+New input (Branch Protection assets)
+- Branch protection saved files are located at:
+  `D:\Dev\Workspaces\Worktrees\branch-protection files`
+- During execution, you MUST:
+  1) Read those files first
+  2) Re-apply branch protection using **Playwright via MCP** (web UI automation) rather than manual clicking
+  3) Reference the folder path in the issue(s) as the source of truth for settings
+
+General rules
+- Do NOT edit canonical governance docs unless explicitly requested.
+- Each issue must include: Title, Labels, Scope, Description, Acceptance Criteria, Dependencies/Links.
+- If an issue is blocked by unknown details, still create it with explicit “Open Questions” and a proposed default.
+- Prefer “enforceable” mechanisms: CI gates, required checks, branch rules, audit-friendly artifacts.
+
+Labels (use consistently)
+- Priority: `prio:p0`, `prio:p1`, `prio:p2`
+- Type: `type:infra`, `type:obs`, `type:gov`, `type:test`, `type:safety`, `type:sim`
+- Scope: `scope:ci`, `scope:repo`, `scope:metrics`, `scope:drills`, `scope:security`
+
+Create the following issues (in this order)
+
+---
+
+## ISSUE 1 — [P0][OBS] Metrics Overhaul: fix Prometheus targets + “No Data” dashboards + main panel restore
+Labels: prio:p0, type:obs, scope:metrics
+Scope:
+- Prometheus scrape targets
+- Grafana datasource
+- Dashboard queries/variables
+Description:
+- Panels showing “No Data” and the broken main panel must be fixed. This is a prerequisite for chaos assertions and kill-switch verification.
+Acceptance Criteria:
+- Prometheus targets: all core services `UP=1` (stable, no flapping)
+- Main dashboard loads without errors
+- 0 broken panels; “No Data” either fixed or explicitly marked as “expected empty” with explanation
+- Golden Signals section exists: throughput, error rate, latency, backlog/queue, orders/fills, risk blocks, kill-switch state
+- Add a 5-step “No Data” troubleshooting checklist to docs
+Links/Refs:
+- Add links to the dashboards/panels in the issue once identified
+
+---
+
+## ISSUE 2 — [P0][SAFETY] Kill-Switch “One Button”: trigger + live status + verifiable stop of order flow
+Labels: prio:p0, type:safety, scope:drills
+Scope:
+- Implement/standardize a single action to HALT
+- Surface clear state: SAFE/HALT/FAILSAFE
+Description:
+- Kill-switch must be usable under stress: one action + immediate effect + clear verification.
+Acceptance Criteria:
+- One action (CLI/UI/shortcut) toggles SAFE↔HALT
+- In HALT: no new orders are sent; any open orders canceled/frozen per design
+- Status is visible (endpoint/metric) and auditable (who/when)
+- Verification procedure exists and is automated where possible (metric or state endpoint)
+Dependencies:
+- Depends on Issue 1 for reliable metrics
+
+---
+
+## ISSUE 3 — [P0][GOV][ENFORCEMENT] Re-apply Branch Protection from saved files using Playwright (MCP)
+Labels: prio:p0, type:gov, scope:repo, scope:security
+Scope:
+- Restore branch protection rules for `main`
+- Required checks and review requirements
+Description:
+- Branch protection must be restored from the previously saved configuration.
+- Use Playwright via MCP to apply settings through GitHub UI (automation), referencing local saved files.
+Implementation Notes:
+- Source of truth folder: `D:\Dev\Workspaces\Worktrees\branch-protection files`
+- Codex must inspect this folder and translate it into exact GitHub settings
+Acceptance Criteria:
+- Branch protection for `main` active and matches saved config
+- Direct pushes blocked; PR required
+- Required checks set and enforced
+- Admin bypass disabled or explicitly controlled (document choice)
+- A proof artifact is produced: screenshot(s) or exported settings summary in an evidence folder
+Dependencies:
+- None (but coordinate with CI checks from Issue 4)
+
+---
+
+## ISSUE 4 — [P0][CI] Required Checks: “Green or Stop” (CI gates stabilized)
+Labels: prio:p0, type:infra, scope:ci
+Scope:
+- Define the minimal set of required workflows
+- Ensure failures are actionable
+Description:
+- CI must be a real gate. “Green” must mean safe to merge.
+Acceptance Criteria:
+- Required checks list documented (name → purpose)
+- 3 consecutive green runs on `main` without manual reruns
+- Failure logs are readable and point to the root cause
+Dependencies:
+- Works together with Issue 3 (required checks are referenced by branch protection)
+
+---
+
+## ISSUE 5 — [P0][TEST] Wire Test Pack v2: ingestion hook + metrics snapshot + assertions evaluator
+Labels: prio:p0, type:test, scope:drills
+Scope:
+- Take the Test Pack v2 skeleton and make it runnable end-to-end
+Description:
+- The harness currently has TODO hooks for ingestion + metrics/assertions. Implement them so the chaos drill produces PASS/FAIL automatically.
+Acceptance Criteria:
+- One supported ingestion path is implemented end-to-end (choose one; document):
+  - HTTP ingest endpoint OR message bus publish OR file adapter replay
+- Drill produces artifacts:
+  - metrics_snapshot.json
+  - assertions_result.json (overall_pass, per-assertion evidence links)
+- Evidence pack structure produced per template (README + sources manifest + logs + reports)
+Dependencies:
+- Depends on Issue 1 (metrics snapshot source)
+Links/Refs:
+- Reference `cdb_test_pack_v2.zip` integration path in repo (if already imported)
+
+---
+
+## ISSUE 6 — [P0][TEST] Operator Drill: implement real alert trigger + kill-switch verification + timeline evidence
+Labels: prio:p0, type:test, type:safety, scope:drills
+Scope:
+- Turn the operator drill skeleton into a real drill
+Description:
+- Implement a real alert trigger (webhook/email/alertmanager) and a verifiable kill-switch check.
+Acceptance Criteria:
+- Trigger produces a captured payload/message inside evidence pack
+- Verification uses one canonical source (metric/state endpoint/log marker) and is automated
+- timeline.json produced with key stamps
+Dependencies:
+- Depends on Issue 2 (kill-switch state + verification method)
+- Depends on Issue 1 if verification uses metrics
+
+---
+
+## ISSUE 7 — [P1][CI] Jules AI Reviewer: PR comment PASS/FAIL + findings (no merge rights)
+Labels: prio:p1, type:infra, scope:ci
+Scope:
+- Automated PR review comment
+Description:
+- Jules runs on PR events and posts/updates a structured comment with verdict PASS/FAIL + risk flags.
+Acceptance Criteria:
+- Runs on PR open/sync
+- Posts exactly one updatable “Jules Review” comment (no spam)
+- Contains: verdict, key findings, suggested checks for human signer
+- No write access beyond commenting
+Dependencies:
+- None
+
+---
+
+## ISSUE 8 — [P1][GOV] Enforce “Six-Eyes”: Human Signoff only after Jules PASS
+Labels: prio:p1, type:gov, scope:repo
+Scope:
+- Process + gating rule
+Description:
+- Human signer (second account) merges only when Jules verdict is PASS.
+Acceptance Criteria:
+- PR template fields: Builder, Jules Review link, Human Signer
+- Clear policy documented: Jules FAIL => no merge
+- Dry-run PR proves the flow
+Dependencies:
+- Depends on Issue 7
+- Pairs with Issue 3 (branch protection reviews)
+
+---
+
+## ISSUE 9 — [P2][SIM] Mock Exchange / Execution Simulator (market-like feedback without real market)
+Labels: prio:p2, type:sim
+Scope:
+- Local service or module that mimics exchange API semantics
+Description:
+- Accept orders; simulate fills/rejects/partial fills/latency/rate limits; deterministic seed mode.
+Acceptance Criteria:
+- Scenarios: full fill, partial fill, reject, timeout, rate limit, delayed fill
+- Deterministic mode (seed) + chaos mode
+- Produces order_result events compatible with execution/risk pipeline
+Dependencies:
+- Enables stronger chaos drills later
+
+---
+
+## ISSUE 10 — [P2][GOV] Planning Lint in CI (anti-drift for phases/gaps)
+Labels: prio:p2, type:gov, type:infra, scope:ci
+Scope:
+- Run `planning_lint.py` on chosen planning docs folders
+Description:
+- Keep planning docs consistent and enforce phase/gap conventions (optional strictness).
+Acceptance Criteria:
+- CI job runs on PR
+- Outputs JSON report artifact
+- Fails PR on phase inconsistency (and optionally gap violations)
+Dependencies:
+- None
+
+---
+
+Execution instructions for Codex (how to create issues)
+1) Use GitHub Issues API or CLI (gh) to create issues in `jannekbuengener/Claire_de_Binare`.
+2) Apply labels exactly as listed above.
+3) For each issue, include “Links/Refs” with placeholders if missing and add a checklist for artifacts/evidence.
+4) After creating all issues, post a final summary comment in the last issue:
+   - Issue numbers + titles
+   - Dependency graph (P0 first)
+   - Immediate next action recommendation: start with Issue 1 (metrics) and Issue 3 (branch protection restore)
+
+Output required
+- List of created issue URLs
+- Any labels that had to be created
+- Notes on anything blocked (and the proposed default)

--- a/tools/test_pack/runbooks/kill_switch_checklist.md
+++ b/tools/test_pack/runbooks/kill_switch_checklist.md
@@ -1,0 +1,31 @@
+# Kill-Switch Checklist (1-page)
+
+Goal: stop order flow safely and verifiably.
+
+Preconditions:
+- You know the correct environment (paper/live).
+- You have credentials/access ready.
+- You have the incident channel open.
+
+Steps (record timestamps):
+1) Acknowledge alert (if your process requires it).
+2) Confirm this is not a false positive (max 5 seconds).
+3) Activate kill switch:
+   - Method: {API|UI|CLI}
+   - Command/Action: {fill in exact command}
+4) Verify "order flow stopped":
+   - No new orders after activation timestamp
+   - Open orders canceled/frozen per design
+   - System state reflects STOP/HALT
+5) Announce status in incident channel:
+   - 'Kill-switch active' + time
+   - Verification result
+6) Preserve evidence:
+   - screenshot(s)
+   - logs snapshot
+   - timeline.json
+
+Post-Drill:
+- What slowed you down?
+- Any ambiguous runbook step?
+- Any missing observability hook?

--- a/tools/test_pack/scenarios/catalog.yaml
+++ b/tools/test_pack/scenarios/catalog.yaml
@@ -1,0 +1,27 @@
+scenarios:
+- id: S-CHAOS-001
+  name: High Volatility Noise
+  generator: tools/chaos/generate_scenario.py
+  mode: highvol_noise
+  minutes: 180
+  seed: 1337
+  intent: Stress risk/kill/circuit-breaker under noisy prices
+  evidence: templates/assertions_chaos.md
+- id: S-CHAOS-002
+  name: Whipsaw Regime Switch
+  generator: tools/chaos/generate_scenario.py
+  mode: whipsaw
+  minutes: 180
+  seed: 1337
+  intent: Stress regime detection + overtrading guards
+  evidence: templates/assertions_chaos.md
+- id: S-OPS-001
+  name: Kill-Switch Drill
+  trigger: tools/drills/trigger-operator-drill.ps1
+  intent: Human can stop order flow quickly and verifiably
+  evidence: runbooks/kill_switch_checklist.md
+- id: S-MOCK-001
+  name: Mock Exchange Smoke
+  server: tools/mock_exchange/mock_exchange.py
+  intent: Exercise order lifecycle without touching real market APIs
+  evidence: templates/evidence_pack_README.md

--- a/tools/test_pack/templates/assertions_chaos.md
+++ b/tools/test_pack/templates/assertions_chaos.md
@@ -1,0 +1,36 @@
+# Chaos Drill Assertions (Template)
+
+Fill in concrete thresholds based on CDB design constraints.
+
+## Inputs
+- Scenario: {flipflop|highvol_noise|whipsaw}
+- Seed: {int}
+- Duration: {minutes}
+- System config: commit hash + config references
+
+## Assertions (Pass/Fail)
+
+1) Exposure reduction in chaos window
+- Metric/source: {prometheus|endpoint|db}
+- Check: exposure <= {threshold} within {seconds} after volatility/regime trigger
+- Fail if: exposure stays above threshold for longer than allowed
+
+2) Overtrading guard
+- Metric/source: orders_sent_total (or equivalent)
+- Check: orders_per_minute <= {threshold}
+- Fail if: threshold exceeded for >= {N} consecutive minutes
+
+3) Drawdown / circuit breaker
+- Metric/source: drawdown_pct, circuit_breaker_active
+- Check: drawdown_pct <= {max} OR circuit_breaker_active becomes true before max is breached
+- Fail if: drawdown exceeds max without breaker/stop
+
+4) Defensive state transitions
+- Source: logs + state endpoint
+- Check: system enters {HOLD|REDUCE} state in response to chaos triggers
+- Fail if: system remains in aggressive state or increases allocation
+
+## Output format
+- assertions_result.json
+  - assertions: list with {id, name, pass, observed, threshold, evidence_links}
+  - overall_pass: bool

--- a/tools/test_pack/templates/evidence_pack_README.md
+++ b/tools/test_pack/templates/evidence_pack_README.md
@@ -1,0 +1,33 @@
+# Evidence Pack (Template)
+
+Path convention:
+docs/ops/evidence/YYYY-MM-DD_PHASEX_<topic>/
+
+Required artifacts:
+- README.md (this file, filled in)
+- sources_manifest.txt (all inputs + hashes)
+- run_config.json (all runtime parameters + versions)
+- logs/ or service_logs/ (raw logs)
+- reports/ (JSON metrics + assertion outputs)
+- screenshots/ (if applicable)
+- hashes.txt (optional: hashes of large artifacts)
+
+## Run Summary
+- Date/Time (UTC):
+- Commit/Ref:
+- Environment (local/CI):
+- Operator (if drill):
+
+## What was executed
+- Command(s):
+- Scenario/Seed (if chaos):
+- Expected outcomes:
+
+## Results
+- PASS/FAIL:
+- Key metrics:
+- Links to raw artifacts:
+
+## Notes / Deviations
+- Any deviations from standard runbook:
+- Known gaps / TODOs:

--- a/tools/test_pack/tools/assertions/evaluate_assertions.py
+++ b/tools/test_pack/tools/assertions/evaluate_assertions.py
@@ -1,0 +1,110 @@
+# tools/test_pack/tools/assertions/evaluate_assertions.py
+# Purpose: evaluate basic assertions from a Prometheus snapshot.
+# Stdlib only.
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _extract_values(result_payload: dict) -> list[float]:
+    data = result_payload.get("data", {}) if isinstance(result_payload, dict) else {}
+    items = data.get("data", {}).get("result", []) if isinstance(data, dict) else []
+    values = []
+    for item in items:
+        value = item.get("value")
+        if isinstance(value, list) and len(value) == 2:
+            try:
+                values.append(float(value[1]))
+            except ValueError:
+                continue
+    return values
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Evaluate chaos drill assertions")
+    ap.add_argument("--snapshot", required=True, help="Path to metrics_snapshot.json")
+    ap.add_argument("--out", required=True, help="Path to assertions_result.json")
+    args = ap.parse_args()
+
+    snapshot_path = Path(args.snapshot)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    assertions: list[dict[str, Any]] = []
+
+    if not snapshot_path.exists():
+        assertions.append({
+            "id": "snapshot_exists",
+            "name": "metrics snapshot exists",
+            "pass": False,
+            "observed": "missing",
+            "threshold": "file present",
+            "evidence_links": [str(snapshot_path)],
+        })
+        result = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "overall_pass": False,
+            "assertions": assertions,
+        }
+        out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        return 2
+
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    queries = snapshot.get("queries", {})
+
+    # Assertion 1: up{job=~"cdb_.*"} all == 1
+    up = queries.get("up_cdb", {})
+    up_vals = _extract_values(up)
+    up_pass = bool(up_vals) and all(v >= 1 for v in up_vals)
+    assertions.append({
+        "id": "up_cdb",
+        "name": "all CDB targets UP",
+        "pass": up_pass,
+        "observed": up_vals,
+        "threshold": ">= 1 for all",
+        "evidence_links": [str(snapshot_path)],
+    })
+
+    # Assertion 2: circuit_breaker_active metric present
+    cb = queries.get("circuit_breaker_active", {})
+    cb_vals = _extract_values(cb)
+    cb_pass = bool(cb_vals)
+    assertions.append({
+        "id": "circuit_breaker_metric",
+        "name": "circuit_breaker_active present",
+        "pass": cb_pass,
+        "observed": cb_vals,
+        "threshold": "metric exists",
+        "evidence_links": [str(snapshot_path)],
+    })
+
+    # Assertion 3: orders metrics present (approved or blocked)
+    approved = _extract_values(queries.get("orders_approved_total", {}))
+    blocked = _extract_values(queries.get("orders_blocked_total", {}))
+    ob_pass = bool(approved) or bool(blocked)
+    assertions.append({
+        "id": "orders_metrics_present",
+        "name": "orders_approved_total or orders_blocked_total present",
+        "pass": ob_pass,
+        "observed": {"approved": approved, "blocked": blocked},
+        "threshold": "at least one metric present",
+        "evidence_links": [str(snapshot_path)],
+    })
+
+    overall_pass = all(a["pass"] for a in assertions)
+
+    result = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "overall_pass": overall_pass,
+        "assertions": assertions,
+    }
+
+    out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    return 0 if overall_pass else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_pack/tools/chaos/generate_scenario.py
+++ b/tools/test_pack/tools/chaos/generate_scenario.py
@@ -1,0 +1,78 @@
+# tools/chaos/generate_scenario.py
+# Purpose: generate deterministic market-ish scenario streams (JSONL), used as input for chaos drills.
+#
+# Output format: one JSON object per line (JSONL)
+# Fields: ts, price, regime_hint, seed, step
+
+import argparse
+import json
+import random
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Tick:
+    ts: str
+    price: float
+    regime_hint: str
+    seed: int
+    step: int
+
+
+def gen_regime(mode: str, step: int) -> str:
+    if mode == "flipflop":
+        return "TREND" if (step % 2 == 0) else "RANGE"
+    if mode == "highvol_noise":
+        return "NOISE"
+    if mode == "whipsaw":
+        return "TREND" if (step % 20 < 10) else "RANGE"
+    raise ValueError(f"Unknown mode: {mode}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Generate deterministic chaos scenario (JSONL)")
+    ap.add_argument("--seed", type=int, default=1337)
+    ap.add_argument("--minutes", type=int, default=180, help="Scenario length in minutes")
+    ap.add_argument("--mode", choices=["flipflop", "highvol_noise", "whipsaw"], required=True)
+    ap.add_argument("--start-utc", default="2026-01-03T12:00:00Z",
+                    help="Start timestamp (UTC), ISO format like 2026-01-03T12:00:00Z")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    rnd = random.Random(args.seed)
+    start = args.start_utc.replace("Z", "+00:00")
+    t = datetime.fromisoformat(start).astimezone(timezone.utc)
+
+    price = 100.0
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with out_path.open("w", encoding="utf-8") as f:
+        for i in range(args.minutes):
+            regime = gen_regime(args.mode, i)
+
+            if regime == "NOISE":
+                shock = rnd.uniform(-2.5, 2.5)
+            elif regime == "TREND":
+                shock = rnd.uniform(-1.2, 1.2)
+            else:  # RANGE
+                shock = rnd.uniform(-0.8, 0.8)
+
+            price = max(1.0, price + shock)
+            tick = Tick(
+                ts=t.isoformat().replace("+00:00", "Z"),
+                price=round(price, 6),
+                regime_hint=regime,
+                seed=args.seed,
+                step=i,
+            )
+            f.write(json.dumps(tick.__dict__) + "\n")
+            t += timedelta(minutes=1)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_pack/tools/drills/trigger-operator-drill.ps1
+++ b/tools/test_pack/tools/drills/trigger-operator-drill.ps1
@@ -1,0 +1,67 @@
+\
+    # tools/drills/trigger-operator-drill.ps1
+    <#
+    Skeleton operator drill trigger:
+      - writes a timeline.json with stamps
+      - TODO: triggers a real alert (email/alertmanager/webhook)
+      - TODO: verifies kill-switch state and "order flow stopped"
+      - captures docker compose logs (if applicable)
+    #>
+
+    [CmdletBinding()]
+    param(
+      [Parameter(Mandatory=$true)][string]$EvidenceDir,
+      [string]$ComposeFile = "docker-compose.yml"
+    )
+
+    $ErrorActionPreference = "Stop"
+
+    function Stamp([System.Collections.ArrayList]$Timeline, [string]$Event) {
+      $null = $Timeline.Add([pscustomobject]@{
+        ts = (Get-Date).ToString("o")
+        event = $Event
+      })
+    }
+
+    New-Item -ItemType Directory -Force -Path $EvidenceDir | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $EvidenceDir "screenshots") | Out-Null
+
+    $timeline = New-Object System.Collections.ArrayList
+    Stamp $timeline "DRILL_START"
+
+    Stamp $timeline "ALERT_TRIGGERED_TODO"
+    @"
+    TODO: Implement a real trigger.
+
+    Pick ONE:
+      A) Alertmanager webhook (recommended)
+      B) Email notifier from a local script
+      C) Synthetic 'DRILL ALERT' to your paging channel
+
+    Output requirement:
+      - record the alert payload or message in evidence pack
+    "@ | Out-File -FilePath (Join-Path $EvidenceDir "trigger.todo.txt") -Encoding utf8
+
+    Stamp $timeline "VERIFY_KILL_SWITCH_TODO"
+    @"
+    TODO: Implement verification that:
+      - kill switch is active
+      - order flow is stopped (no new orders, cancels/freeze per design)
+
+    Verification options:
+      - query an admin endpoint
+      - query DB state
+      - grep logs for a canonical marker
+      - query Prometheus metric (e.g., orders_sent_total not increasing)
+    "@ | Out-File -FilePath (Join-Path $EvidenceDir "verify.todo.txt") -Encoding utf8
+
+    try {
+      Stamp $timeline "CAPTURE_STACK_LOGS"
+      docker compose -f $ComposeFile logs --no-color > (Join-Path $EvidenceDir "stack.log")
+    } catch {
+      Stamp $timeline "CAPTURE_STACK_LOGS_FAILED"
+      $_.Exception.Message | Out-File -FilePath (Join-Path $EvidenceDir "stack_logs_error.txt") -Encoding utf8
+    }
+
+    Stamp $timeline "DRILL_END"
+    $timeline | ConvertTo-Json -Depth 6 | Out-File (Join-Path $EvidenceDir "timeline.json") -Encoding utf8

--- a/tools/test_pack/tools/ingestion/ingest_scenario.py
+++ b/tools/test_pack/tools/ingestion/ingest_scenario.py
@@ -1,0 +1,150 @@
+# tools/test_pack/tools/ingestion/ingest_scenario.py
+# Purpose: publish chaos scenario JSONL into CDB market_data channel (Redis).
+# Stdlib + redis client (matches repo dependency).
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Any
+
+import redis
+
+# Ensure repo root is on sys.path for shared utils
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core.utils.redis_payload import sanitize_market_data
+
+
+def _iso_to_ms(ts: str) -> int:
+    dt = datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def _load_redis_password() -> str | None:
+    env_pw = os.getenv("REDIS_PASSWORD")
+    if env_pw:
+        return env_pw
+
+    secrets_path = os.getenv("SECRETS_PATH", os.path.expanduser("~/.secrets/.cdb"))
+    pw_file = Path(secrets_path) / "REDIS_PASSWORD"
+    if pw_file.exists():
+        return pw_file.read_text().strip()
+
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Ingest chaos scenario JSONL into Redis market_data")
+    ap.add_argument("--scenario", required=True, help="Path to scenario JSONL")
+    ap.add_argument("--out", required=True, help="Output report JSON path")
+    ap.add_argument("--redis-host", default=os.getenv("REDIS_HOST", "localhost"))
+    ap.add_argument("--redis-port", type=int, default=int(os.getenv("REDIS_PORT", "6379")))
+    ap.add_argument("--redis-db", type=int, default=int(os.getenv("REDIS_DB", "0")))
+    ap.add_argument("--redis-password", default=None)
+    ap.add_argument("--symbol", default="BTCUSDT")
+    ap.add_argument("--trade-qty", default="1")
+    ap.add_argument("--source", default="test_pack")
+    ap.add_argument("--tick-delay-ms", type=int, default=0)
+    ap.add_argument("--dry-run", action="store_true", help="Parse only, no Redis publish")
+    ap.add_argument("--channel", default="market_data")
+    ap.add_argument("--run-id", default=None, help="Optional run id for traceability")
+    args = ap.parse_args()
+
+    scenario_path = Path(args.scenario)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    stats: Dict[str, Any] = {
+        "scenario": str(scenario_path),
+        "channel": args.channel,
+        "symbol": args.symbol,
+        "trade_qty": args.trade_qty,
+        "source": args.source,
+        "run_id": args.run_id,
+        "ticks_total": 0,
+        "ticks_published": 0,
+        "errors": 0,
+        "dry_run": bool(args.dry_run),
+    }
+
+    if not scenario_path.exists():
+        stats["error"] = f"Scenario not found: {scenario_path}"
+        out_path.write_text(json.dumps(stats, indent=2), encoding="utf-8")
+        return 1
+
+    redis_password = args.redis_password or _load_redis_password()
+
+    client = None
+    if not args.dry_run:
+        try:
+            client = redis.Redis(
+                host=args.redis_host,
+                port=args.redis_port,
+                password=redis_password,
+                db=args.redis_db,
+                decode_responses=True,
+            )
+            client.ping()
+            stats["redis_connected"] = True
+        except Exception as e:
+            stats["redis_connected"] = False
+            stats["error"] = f"Redis connection failed: {e}"
+            out_path.write_text(json.dumps(stats, indent=2), encoding="utf-8")
+            return 1
+
+    try:
+        with scenario_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                stats["ticks_total"] += 1
+                try:
+                    tick = json.loads(line)
+                    ts = tick.get("ts") or tick.get("timestamp")
+                    if not ts:
+                        raise ValueError("missing ts")
+
+                    payload = {
+                        "schema_version": "v1.0",
+                        "type": "market_data",
+                        "source": args.source,
+                        "symbol": args.symbol,
+                        "ts_ms": _iso_to_ms(ts),
+                        "price": str(tick.get("price", "0")),
+                        "trade_qty": str(args.trade_qty),
+                        "side": "BUY" if (tick.get("step", 0) % 2 == 0) else "SELL",
+                    }
+
+                    if args.run_id:
+                        payload["bot_id"] = args.run_id
+
+                    sanitized = sanitize_market_data(payload)
+
+                    if not args.dry_run and client is not None:
+                        client.publish(args.channel, json.dumps(sanitized))
+                        stats["ticks_published"] += 1
+
+                except Exception:
+                    stats["errors"] += 1
+
+                if args.tick_delay_ms > 0:
+                    import time
+
+                    time.sleep(args.tick_delay_ms / 1000.0)
+
+    finally:
+        if client is not None:
+            client.close()
+
+    out_path.write_text(json.dumps(stats, indent=2), encoding="utf-8")
+    return 0 if stats["errors"] == 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_pack/tools/metrics/metrics-smoke.ps1
+++ b/tools/test_pack/tools/metrics/metrics-smoke.ps1
@@ -1,0 +1,52 @@
+# tools/metrics/metrics-smoke.ps1
+<#
+Purpose:
+  Quick "are we blind?" check before running longer drills.
+  - Prometheus targets reachable?
+  - Grafana health ok?
+  - Optional: detect "No data" by running a minimal query (TODO hook)
+
+This is a lightweight helper, not a full monitoring test suite.
+#>
+
+[CmdletBinding()]
+param(
+  [string]$PromUrl = "http://127.0.0.1:19090",
+  [string]$GrafanaUrl = "http://127.0.0.1:3000",
+  [string]$OutDir = ".\evidence\metrics_smoke"
+)
+
+$ErrorActionPreference = "Stop"
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+function Write-Json($path, $obj) {
+  $obj | ConvertTo-Json -Depth 8 | Out-File -FilePath $path -Encoding utf8
+}
+
+$report = [ordered]@{
+  ts = (Get-Date).ToString("o")
+  prometheus = @{}
+  grafana = @{}
+  notes = @()
+}
+
+try {
+  $targets = Invoke-RestMethod -Uri "$PromUrl/api/v1/targets" -Method GET -TimeoutSec 10
+  $report.prometheus.targets_active = @($targets.data.activeTargets).Count
+  $report.prometheus.targets_dropped = @($targets.data.droppedTargets).Count
+  Write-Json (Join-Path $OutDir "prometheus_targets.json") $targets
+} catch {
+  $report.prometheus.error = $_.Exception.Message
+}
+
+try {
+  $g = Invoke-RestMethod -Uri "$GrafanaUrl/api/health" -Method GET -TimeoutSec 10
+  $report.grafana = $g
+  Write-Json (Join-Path $OutDir "grafana_health.json") $g
+} catch {
+  $report.grafana = @{ error = $_.Exception.Message }
+}
+
+Write-Json (Join-Path $OutDir "report.json") $report
+Write-Host "OK: wrote $OutDir\report.json"

--- a/tools/test_pack/tools/metrics/metrics_snapshot.py
+++ b/tools/test_pack/tools/metrics/metrics_snapshot.py
@@ -1,0 +1,63 @@
+# tools/test_pack/tools/metrics/metrics_snapshot.py
+# Purpose: capture a minimal Prometheus metrics snapshot for chaos drills.
+# Stdlib only.
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlencode
+from urllib.request import urlopen, Request
+
+DEFAULT_QUERIES = {
+    "up_cdb": 'up{job=~"cdb_.*"}',
+    "signals_received_total": "signals_received_total",
+    "orders_approved_total": "orders_approved_total",
+    "orders_blocked_total": "orders_blocked_total",
+    "circuit_breaker_active": "circuit_breaker_active",
+    "risk_total_exposure_value": "risk_total_exposure_value",
+    "risk_pending_orders_total": "risk_pending_orders_total",
+}
+
+
+def _query_prom(base_url: str, query: str) -> dict:
+    params = urlencode({"query": query})
+    url = f"{base_url}/api/v1/query?{params}"
+    req = Request(url, headers={"User-Agent": "cdb-test-pack"})
+    try:
+        with urlopen(req, timeout=10) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+        return {"status": "success", "data": payload}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Prometheus snapshot for chaos drills")
+    ap.add_argument("--prom-url", default="http://127.0.0.1:19090")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    report = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "prom_url": args.prom_url,
+        "queries": {},
+    }
+
+    for name, query in DEFAULT_QUERIES.items():
+        result = _query_prom(args.prom_url, query)
+        report["queries"][name] = {
+            "query": query,
+            **result,
+        }
+
+    out_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_pack/tools/mock_exchange/mock_exchange.py
+++ b/tools/test_pack/tools/mock_exchange/mock_exchange.py
@@ -1,0 +1,123 @@
+"""
+Mock Exchange (stdlib only)
+
+Purpose:
+- Accept orders/cancels like a trading API would
+- Deterministic responses for testing (no real market access)
+- Provides a minimal /health endpoint for harness scripts
+
+This is intentionally small: it's a "shim" you can wire to cdb_execution
+when you want realistic order-lifecycle tests without the real exchange.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from dataclasses import dataclass, asdict
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Dict, Any, Optional
+
+STATE: Dict[str, Any] = {
+    "started_ts": time.time(),
+    "orders": {},  # order_id -> dict
+    "fills": [],   # list of fills
+}
+
+@dataclass
+class Order:
+    order_id: str
+    symbol: str
+    side: str
+    qty: float
+    price: Optional[float]
+    status: str  # NEW | FILLED | CANCELED | REJECTED
+    ts: float
+
+def _json(handler: BaseHTTPRequestHandler, code: int, payload: Dict[str, Any]) -> None:
+    data = json.dumps(payload).encode("utf-8")
+    handler.send_response(code)
+    handler.send_header("Content-Type", "application/json; charset=utf-8")
+    handler.send_header("Content-Length", str(len(data)))
+    handler.end_headers()
+    handler.wfile.write(data)
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt: str, *args) -> None:
+        # keep quiet; evidence scripts can capture stdout if needed
+        return
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/health":
+            return _json(self, 200, {"ok": True, "uptime_s": round(time.time() - STATE["started_ts"], 3)})
+        if self.path == "/state":
+            return _json(self, 200, {"orders": len(STATE["orders"]), "fills": len(STATE["fills"])})
+        return _json(self, 404, {"ok": False, "error": "not_found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        raw = self.rfile.read(length) if length > 0 else b"{}"
+        try:
+            body = json.loads(raw.decode("utf-8") or "{}")
+        except Exception:
+            return _json(self, 400, {"ok": False, "error": "invalid_json"})
+
+        if self.path == "/order":
+            # expected: {symbol, side, qty, price?}
+            try:
+                symbol = str(body["symbol"])
+                side = str(body["side"]).upper()
+                qty = float(body["qty"])
+                price = body.get("price", None)
+                price = float(price) if price is not None else None
+                if side not in {"BUY", "SELL"} or qty <= 0:
+                    raise ValueError("bad_order")
+            except Exception:
+                return _json(self, 400, {"ok": False, "error": "bad_order_payload"})
+
+            oid = str(uuid.uuid4())
+            order = Order(order_id=oid, symbol=symbol, side=side, qty=qty, price=price, status="NEW", ts=time.time())
+            STATE["orders"][oid] = asdict(order)
+
+            # deterministic auto-fill: if price is provided, fill immediately; else keep NEW
+            if price is not None:
+                STATE["orders"][oid]["status"] = "FILLED"
+                STATE["fills"].append({"order_id": oid, "qty": qty, "price": price, "ts": time.time()})
+
+            return _json(self, 200, {"ok": True, "order": STATE["orders"][oid]})
+
+        if self.path == "/cancel":
+            try:
+                oid = str(body["order_id"])
+            except Exception:
+                return _json(self, 400, {"ok": False, "error": "bad_cancel_payload"})
+
+            order = STATE["orders"].get(oid)
+            if not order:
+                return _json(self, 404, {"ok": False, "error": "unknown_order"})
+            if order["status"] in {"FILLED", "CANCELED"}:
+                return _json(self, 200, {"ok": True, "order": order})
+
+            order["status"] = "CANCELED"
+            return _json(self, 200, {"ok": True, "order": order})
+
+        return _json(self, 404, {"ok": False, "error": "not_found"})
+
+def main() -> int:
+    import argparse
+    ap = argparse.ArgumentParser(description="Mock Exchange (HTTP)")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=18080)
+    args = ap.parse_args()
+
+    httpd = HTTPServer((args.host, args.port), Handler)
+    print(f"MockExchange listening on http://{args.host}:{args.port}")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_pack/tools/planning/planning_lint.py
+++ b/tools/test_pack/tools/planning/planning_lint.py
@@ -1,0 +1,124 @@
+# tools/planning/planning_lint.py
+# Purpose: detect planning/document fragmentation regressions (phase/milestone/gap conventions).
+#
+# Stdlib only. Designed to be run locally or in CI.
+
+import argparse
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, List, Dict, Tuple
+
+PHASE_RE = re.compile(r"\b(phase|phasen)\s*[:#-]?\s*(\d+)\b", re.IGNORECASE)
+MILESTONE_RE = re.compile(r"\b(alpha|beta|gamma)\b", re.IGNORECASE)
+GAP_RE = re.compile(r"\bGAP[-_ ]?0*(\d+)\b", re.IGNORECASE)
+
+DEFAULT_TASK_LINE_RE = r"^\s*[-*]\s+.+$"  # bullet-like
+
+
+@dataclass
+class FileScan:
+    path: str
+    sha256: str
+    phase_numbers: List[int]
+    milestones: List[str]
+    gap_refs: List[int]
+    gap_ref_count: int
+    task_lines_total: int
+    task_lines_missing_gap: int
+
+
+def sha256(p: Path) -> str:
+    h = hashlib.sha256()
+    h.update(p.read_bytes())
+    return h.hexdigest()
+
+
+def scan_file(p: Path, require_gap_per_task_line: bool, task_line_pattern: re.Pattern) -> FileScan:
+    text = p.read_text(encoding="utf-8", errors="replace")
+    phases = [int(m.group(2)) for m in PHASE_RE.finditer(text)]
+    milestones = [m.group(1).lower() for m in MILESTONE_RE.finditer(text)]
+    gaps = [int(m.group(1)) for m in GAP_RE.finditer(text)]
+
+    task_total = 0
+    task_missing = 0
+    if require_gap_per_task_line:
+        for line in text.splitlines():
+            if task_line_pattern.search(line):
+                task_total += 1
+                if not GAP_RE.search(line):
+                    task_missing += 1
+
+    return FileScan(
+        path=str(p),
+        sha256=sha256(p),
+        phase_numbers=sorted(set(phases)),
+        milestones=sorted(set(milestones)),
+        gap_refs=sorted(set(gaps)),
+        gap_ref_count=len(gaps),
+        task_lines_total=task_total,
+        task_lines_missing_gap=task_missing,
+    )
+
+
+def normalize_sources(sources: Iterable[str]) -> List[Path]:
+    out: List[Path] = []
+    for s in sources:
+        p = Path(s)
+        if p.is_dir():
+            for ext in ("*.md", "*.txt"):
+                out.extend(sorted(p.rglob(ext)))
+        else:
+            out.append(p)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="CDB Planning Doc Lint (phase/gap/milestone conventions)")
+    ap.add_argument("--sources", nargs="+", required=True,
+                    help="List of markdown/text files OR directories (dirs will be recursively scanned for *.md/*.txt).")
+    ap.add_argument("--out", required=True, help="Output JSON report path.")
+    ap.add_argument("--require-gap-per-task-line", action="store_true",
+                    help="If set, every bullet-like line must contain a GAP-XXX reference.")
+    ap.add_argument("--task-line-regex", default=DEFAULT_TASK_LINE_RE,
+                    help=f"Regex for 'task-like' lines. Default: {DEFAULT_TASK_LINE_RE!r}")
+    args = ap.parse_args()
+
+    files = normalize_sources(args.sources)
+    missing = [str(p) for p in files if not p.exists()]
+    if missing:
+        raise SystemExit(f"Missing source files: {missing}")
+
+    task_line_pattern = re.compile(args.task_line_regex)
+    scans = [scan_file(p, args.require_gap_per_task_line, task_line_pattern) for p in files]
+
+    phase_sets: List[Tuple[int, ...]] = [tuple(s.phase_numbers) for s in scans]
+    non_empty_phase_sets = [ps for ps in phase_sets if len(ps) > 0]
+    phase_consistent = (len(set(non_empty_phase_sets)) <= 1)  # allow empty docs
+
+    gap_rule_violations = sum(s.task_lines_missing_gap for s in scans)
+
+    report: Dict[str, object] = {
+        "phase_consistent": phase_consistent,
+        "phase_sets": phase_sets,
+        "uses_alpha_beta_gamma": any(len(s.milestones) > 0 for s in scans),
+        "require_gap_per_task_line": bool(args.require_gap_per_task_line),
+        "gap_rule_violations": int(gap_rule_violations),
+        "files": [asdict(s) for s in scans],
+    }
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    if not phase_consistent:
+        return 2
+    if args.require_gap_per_task_line and gap_rule_violations > 0:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_pack/tools/planning/sources.example.txt
+++ b/tools/test_pack/tools/planning/sources.example.txt
@@ -1,0 +1,7 @@
+# List one file path per line. Lines starting with # are comments.
+# You can also list directories; planning_lint.py will scan *.md and *.txt recursively.
+
+docs/planning/EngineeringRoadmap.md
+docs/planning/OpsPlan.md
+docs/planning/GovernanceLine.md
+docs/planning/IssuePack.md


### PR DESCRIPTION
## Summary
- add Test Pack v2 under tools/test_pack
- wire chaos ingestion to Redis market_data
- add metrics snapshot + assertions evaluator and evidence pack metadata

## Testing
- not run locally (CI only)

## Notes
- run-chaos-drill.ps1 writes evidence pack README + sources manifest
