### PR TITLE
dashboards: add owner cockpit + archive legacy (#656)

### DIFF
--- a/infrastructure/monitoring/grafana/dashboards/cdb_money_result_owner_v1.json
+++ b/infrastructure/monitoring/grafana/dashboards/cdb_money_result_owner_v1.json
@@ -1,0 +1,299 @@
+{
+  "uid": "cdb_money_result_owner_v1",
+  "title": "CDB - Money / Result",
+  "description": "Owner cockpit. Black-first, blue/teal tone. TODO (missing KPIs): daily_pnl_percent, daily_pnl_abs, profit_factor_rolling, profit_factor_lifetime, avg_win, avg_loss, max_drawdown_pct, win_rate/hitrate, portfolio_total_value_usdt.",
+  "tags": [
+    "cdb",
+    "owner",
+    "money",
+    "result"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m"
+    ]
+  },
+  "refresh": "10s",
+  "style": "dark",
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "STATUS SNAPSHOT",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "HEALTH RELAY (SYSTEM MIRROR)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "min(up{job=~\"cdb_.*\"})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#4fc3f7",
+                "value": null
+              },
+              {
+                "color": "#0b1d2a",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 3,
+      "type": "text",
+      "title": "MISSING KPI SUMMARY",
+      "gridPos": {
+        "h": 4,
+        "w": 18,
+        "x": 6,
+        "y": 1
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "PnL/ProfitFactor/Hitrate/Drawdown not instrumented. See TODO list."
+      }
+    },
+    {
+      "id": 4,
+      "type": "row",
+      "title": "MONEY TODAY",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 5,
+      "type": "text",
+      "title": "PNL TODAY (%)",
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "KPI missing: daily_pnl_percent."
+      }
+    },
+    {
+      "id": 6,
+      "type": "text",
+      "title": "PNL TODAY (ABS)",
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "KPI missing: daily_pnl_abs or portfolio_total_value_usdt delta."
+      }
+    },
+    {
+      "id": 7,
+      "type": "row",
+      "title": "LIFETIME REALITY",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 8,
+      "type": "text",
+      "title": "PROFIT FACTOR (ROLLING/LIFETIME)",
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "KPI missing: profit_factor_rolling, profit_factor_lifetime."
+      }
+    },
+    {
+      "id": 9,
+      "type": "row",
+      "title": "HITRATE",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 10,
+      "type": "text",
+      "title": "HITRATE",
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "KPI missing: win_rate or hit_rate."
+      }
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "TRADE ECONOMICS",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 12,
+      "type": "text",
+      "title": "AVG WIN vs AVG LOSS",
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "KPI missing: avg_win, avg_loss."
+      }
+    },
+    {
+      "id": 13,
+      "type": "row",
+      "title": "EDGE & ROBUSTNESS",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 14,
+      "type": "text",
+      "title": "MAX DRAWDOWN",
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "KPI missing: max_drawdown_pct."
+      }
+    },
+    {
+      "id": 16,
+      "type": "row",
+      "title": "META",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "collapsed": true,
+      "panels": [
+        {
+          "id": 15,
+          "type": "text",
+          "title": "META",
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 31
+          },
+          "options": {
+            "mode": "markdown",
+            "content": "Critical is rare; positive extremes also critical. Aggregates dominate. No blinking."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/infrastructure/monitoring/grafana/dashboards/cdb_system_health_owner_v1.json
+++ b/infrastructure/monitoring/grafana/dashboards/cdb_system_health_owner_v1.json
@@ -1,0 +1,1662 @@
+{
+  "uid": "cdb_system_health_owner_v1",
+  "title": "CDB - System / Health",
+  "description": "Owner cockpit. Black-first, red tone. TODO (missing KPIs): E2E cycle latency, kill_switch_active, risk_on + exposure% limit, queue lag/drops, db locks/slow queries, exchange/API health, build/version/config metrics.",
+  "tags": [
+    "cdb",
+    "owner",
+    "system",
+    "health"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m"
+    ]
+  },
+  "refresh": "10s",
+  "style": "dark",
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "OVERVIEW",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "SYSTEM HEALTH (CORE UP)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "min(up{job=~\"cdb_.*\"})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#ff3b3b",
+                "value": null
+              },
+              {
+                "color": "#3a0d0d",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 3,
+      "type": "text",
+      "title": "TRADING READINESS (E2E)",
+      "gridPos": {
+        "h": 4,
+        "w": 9,
+        "x": 6,
+        "y": 1
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "KPI missing: E2E cycle latency. See TODO list."
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "INPUT FRESHNESS (s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 9,
+        "x": 15,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "(time()*1000 - last_message_ts_ms) / 1000",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 6,
+      "type": "row",
+      "title": "KILL & CONTROL",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "collapsed": true,
+      "panels": [
+        {
+          "id": 5,
+          "type": "text",
+          "title": "KILL SWITCH",
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 6
+          },
+          "options": {
+            "mode": "markdown",
+            "content": "KPI missing: kill_switch_active. Dashboard is read-only (visual only)."
+          }
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "row",
+      "title": "DATA INGEST & FRESHNESS",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "WS CONNECTED",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "ws_connected",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "LAST MESSAGE AGE (s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "(time()*1000 - last_message_ts_ms) / 1000",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "WS DECODE RATE",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "rate(decoded_messages_total[1m])",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#3a0d0d"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "SIGNAL PIPELINE QUALITY",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "SIGNALS GENERATED (rate)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "targets": [
+        {
+          "expr": "rate(signals_generated_total[1m])",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#3a0d0d"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 13,
+      "type": "stat",
+      "title": "SIGNAL LATENCY p95 (ms)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 14
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(signal_processing_latency_ms_bucket[1m]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 14,
+      "type": "stat",
+      "title": "SIGNAL ERRORS (rate)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 14
+      },
+      "targets": [
+        {
+          "expr": "rate(signal_errors_total[1m])",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 15,
+      "type": "row",
+      "title": "RISK ENGINE",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 16,
+      "type": "stat",
+      "title": "CIRCUIT BREAKER",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 21
+      },
+      "targets": [
+        {
+          "expr": "circuit_breaker_active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "ORDERS BLOCKED (rate)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 6,
+        "y": 21
+      },
+      "targets": [
+        {
+          "expr": "rate(orders_blocked_total[1m])",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#3a0d0d"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 18,
+      "type": "stat",
+      "title": "RISK EXPOSURE (notional)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 21
+      },
+      "targets": [
+        {
+          "expr": "risk_total_exposure_value",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 19,
+      "type": "text",
+      "title": "RISK STATE (TODO)",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "Missing KPIs: risk_on state, exposure % of limit."
+      }
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "EXECUTION & ORDERS",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "EXECUTION FLOW (rate)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "targets": [
+        {
+          "expr": "rate(execution_orders_received_total[1m])",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(execution_orders_filled_total[1m])",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(execution_orders_rejected_total[1m])",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#3a0d0d"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 22,
+      "type": "stat",
+      "title": "EXECUTION ERROR RATE (%)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 31
+      },
+      "targets": [
+        {
+          "expr": "(rate(execution_orders_rejected_total[5m]) / clamp_min(rate(execution_orders_received_total[5m]), 1)) * 100",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 23,
+      "type": "stat",
+      "title": "EXECUTION UPTIME (s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 31
+      },
+      "targets": [
+        {
+          "expr": "execution_uptime_seconds",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 24,
+      "type": "row",
+      "title": "END-TO-END FLOW",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 25,
+      "type": "timeseries",
+      "title": "PIPELINE RATE",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "targets": [
+        {
+          "expr": "rate(decoded_messages_total[1m])",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(signals_generated_total[1m])",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(orders_approved_total[1m])",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(orders_blocked_total[1m])",
+          "refId": "D"
+        },
+        {
+          "expr": "rate(execution_orders_filled_total[1m])",
+          "refId": "E"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#3a0d0d"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 26,
+      "type": "row",
+      "title": "QUEUES & BACKPRESSURE",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 27,
+      "type": "timeseries",
+      "title": "REDIS STREAM LENGTH (fills)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 46
+      },
+      "targets": [
+        {
+          "expr": "redis_stream_length{stream=\"stream.fills\"}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#3a0d0d"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 28,
+      "type": "stat",
+      "title": "DB WRITER FAILURES (rate)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 46
+      },
+      "targets": [
+        {
+          "expr": "rate(db_writer_events_failed_total[5m])",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 29,
+      "type": "text",
+      "title": "QUEUE LAG (TODO)",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 46
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "Missing KPI: queue lag / drops."
+      }
+    },
+    {
+      "id": 30,
+      "type": "row",
+      "title": "CORE INFRA",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 31,
+      "type": "stat",
+      "title": "SERVICES UP (count)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "count(up{job=~\"cdb_.*\"} == 1)",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 32,
+      "type": "stat",
+      "title": "PROMETHEUS UP",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "up{job=\"prometheus\"}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 33,
+      "type": "stat",
+      "title": "REDIS UP",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "redis_up",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 34,
+      "type": "stat",
+      "title": "POSTGRES UP",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "pg_up",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 35,
+      "type": "row",
+      "title": "DATA BACKBONE (DB)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 36,
+      "type": "timeseries",
+      "title": "PG CONNECTIONS",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 58
+      },
+      "targets": [
+        {
+          "expr": "pg_stat_activity_count",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#3a0d0d"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 37,
+      "type": "stat",
+      "title": "REDIS MEMORY (MB)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 58
+      },
+      "targets": [
+        {
+          "expr": "redis_memory_used_bytes / 1024 / 1024",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 38,
+      "type": "text",
+      "title": "DB LOCKS / SLOW QUERIES (TODO)",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 58
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "Missing KPI: locks + pg_stat_statements_*."
+      }
+    },
+    {
+      "id": 39,
+      "type": "row",
+      "title": "EXTERNAL DEPENDENCIES",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 40,
+      "type": "stat",
+      "title": "EXCHANGE WS CONNECTED",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 65
+      },
+      "targets": [
+        {
+          "expr": "ws_connected",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 41,
+      "type": "stat",
+      "title": "REDIS PUBLISH ERRORS (rate)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 65
+      },
+      "targets": [
+        {
+          "expr": "rate(redis_publish_errors_total[5m])",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3a0d0d",
+                "value": null
+              },
+              {
+                "color": "#7a1f1f",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 42,
+      "type": "text",
+      "title": "EXTERNAL HEALTH (TODO)",
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 65
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "Missing KPI: exchange/API health."
+      }
+    },
+    {
+      "id": 43,
+      "type": "row",
+      "title": "TIME & CONFIG",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 69
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 44,
+      "type": "text",
+      "title": "TIME & CONFIG",
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 70
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "KPI missing: build/version/config flags. Provide read-only config metrics."
+      }
+    }
+  ]
+}

--- a/infrastructure/monitoring/grafana/dashboards/cdb_system_health_v1.json
+++ b/infrastructure/monitoring/grafana/dashboards/cdb_system_health_v1.json
@@ -1,8 +1,15 @@
 {
   "uid": "cdb_system_health_v1",
   "title": "CDB - System Health & Trade Flow",
-  "description": "Single-screen observability: System health, Trade pipeline, Risk blocks - Live-Trading readiness dashboard",
-  "tags": ["claire", "system", "health", "trade-flow", "live"],
+  "description": "ARCHIVED (legacy dashboard). Single-screen observability: System health, Trade pipeline, Risk blocks - Live-Trading readiness dashboard",
+  "tags": [
+    "claire",
+    "system",
+    "health",
+    "trade-flow",
+    "live",
+    "legacy"
+  ],
   "timezone": "browser",
   "editable": true,
   "graphTooltip": 1,
@@ -11,7 +18,13 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m"]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m"
+    ]
   },
   "refresh": "10s",
   "style": "dark",
@@ -20,7 +33,12 @@
       "id": 0,
       "type": "text",
       "title": "⚠️ Planned Maintenance Events",
-      "gridPos": {"h": 3, "w": 24, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "options": {
         "mode": "markdown",
         "content": "**Last 5 Events** (Source: `knowledge/ops/maintenance_events.log`):\n\n| Timestamp | Type | Reason |\n|-----------|------|--------|\n| 2026-01-12 18:00 UTC | ⚠️ **unplanned** | Stack restart (root cause: TBD) |\n\n**Shadow Mode DoD:** 0 unplanned restarts allowed. Planned restarts require marker BEFORE event."
@@ -30,22 +48,43 @@
       "id": 1,
       "type": "stat",
       "title": "SERVICES UP",
-      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 3},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{
-        "expr": "count(up{job=~\"cdb_.*\"} == 1)",
-        "refId": "A",
-        "legendFormat": "UP"
-      }],
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 3
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "count(up{job=~\"cdb_.*\"} == 1)",
+          "refId": "A",
+          "legendFormat": "UP"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#dc2626", "value": null},
-              {"color": "#ea580c", "value": 5},
-              {"color": "#f59e0b", "value": 8}
+              {
+                "color": "#dc2626",
+                "value": null
+              },
+              {
+                "color": "#ea580c",
+                "value": 5
+              },
+              {
+                "color": "#f59e0b",
+                "value": 8
+              }
             ]
           },
           "unit": "short"
@@ -61,24 +100,52 @@
       "id": 2,
       "type": "stat",
       "title": "POSTGRESQL",
-      "gridPos": {"h": 4, "w": 3, "x": 4, "y": 0},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{
-        "expr": "pg_up",
-        "refId": "A"
-      }],
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 4,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "pg_up",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            {"type": "value", "value": "0", "text": "DOWN", "color": "#dc2626"},
-            {"type": "value", "value": "1", "text": "UP", "color": "#f59e0b"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "DOWN",
+              "color": "#dc2626"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "UP",
+              "color": "#f59e0b"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#dc2626", "value": null},
-              {"color": "#f59e0b", "value": 1}
+              {
+                "color": "#dc2626",
+                "value": null
+              },
+              {
+                "color": "#f59e0b",
+                "value": 1
+              }
             ]
           }
         }
@@ -93,24 +160,52 @@
       "id": 3,
       "type": "stat",
       "title": "REDIS",
-      "gridPos": {"h": 4, "w": 3, "x": 7, "y": 0},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{
-        "expr": "redis_up",
-        "refId": "A"
-      }],
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 7,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "redis_up",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            {"type": "value", "value": "0", "text": "DOWN", "color": "#dc2626"},
-            {"type": "value", "value": "1", "text": "UP", "color": "#f59e0b"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "DOWN",
+              "color": "#dc2626"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "UP",
+              "color": "#f59e0b"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#dc2626", "value": null},
-              {"color": "#f59e0b", "value": 1}
+              {
+                "color": "#dc2626",
+                "value": null
+              },
+              {
+                "color": "#f59e0b",
+                "value": 1
+              }
             ]
           }
         }
@@ -125,24 +220,52 @@
       "id": 4,
       "type": "stat",
       "title": "CIRCUIT BREAKER",
-      "gridPos": {"h": 4, "w": 3, "x": 10, "y": 0},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{
-        "expr": "circuit_breaker_active",
-        "refId": "A"
-      }],
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 10,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "circuit_breaker_active",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            {"type": "value", "value": "0", "text": "OK", "color": "#f59e0b"},
-            {"type": "value", "value": "1", "text": "ACTIVE", "color": "#dc2626"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "OK",
+              "color": "#f59e0b"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "ACTIVE",
+              "color": "#dc2626"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#f59e0b", "value": null},
-              {"color": "#dc2626", "value": 1}
+              {
+                "color": "#f59e0b",
+                "value": null
+              },
+              {
+                "color": "#dc2626",
+                "value": 1
+              }
             ]
           }
         }
@@ -157,21 +280,42 @@
       "id": 5,
       "type": "stat",
       "title": "ERROR RATE",
-      "gridPos": {"h": 4, "w": 4, "x": 13, "y": 0},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{
-        "expr": "sum(rate(execution_orders_rejected_total[5m]))",
-        "refId": "A"
-      }],
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 13,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(execution_orders_rejected_total[5m]))",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#f59e0b", "value": null},
-              {"color": "#ea580c", "value": 0.1},
-              {"color": "#dc2626", "value": 1}
+              {
+                "color": "#f59e0b",
+                "value": null
+              },
+              {
+                "color": "#ea580c",
+                "value": 0.1
+              },
+              {
+                "color": "#dc2626",
+                "value": 1
+              }
             ]
           },
           "unit": "reqps",
@@ -188,21 +332,42 @@
       "id": 6,
       "type": "stat",
       "title": "MIN UPTIME",
-      "gridPos": {"h": 4, "w": 7, "x": 17, "y": 0},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{
-        "expr": "min(time() - process_start_time_seconds{job=~\"cdb_.*\"})",
-        "refId": "A"
-      }],
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 17,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "min(time() - process_start_time_seconds{job=~\"cdb_.*\"})",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#dc2626", "value": null},
-              {"color": "#ea580c", "value": 60},
-              {"color": "#f59e0b", "value": 300}
+              {
+                "color": "#dc2626",
+                "value": null
+              },
+              {
+                "color": "#ea580c",
+                "value": 60
+              },
+              {
+                "color": "#f59e0b",
+                "value": 300
+              }
             ]
           },
           "unit": "s"
@@ -218,21 +383,42 @@
       "id": 11,
       "type": "stat",
       "title": "1. WS MESSAGES",
-      "gridPos": {"h": 5, "w": 5, "x": 0, "y": 4},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{
-        "expr": "rate(decoded_messages_total[1m])",
-        "refId": "A"
-      }],
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 0,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "rate(decoded_messages_total[1m])",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#1a1a1a", "value": null},
-              {"color": "#4d0000", "value": 1},
-              {"color": "#8b0000", "value": 10}
+              {
+                "color": "#1a1a1a",
+                "value": null
+              },
+              {
+                "color": "#4d0000",
+                "value": 1
+              },
+              {
+                "color": "#8b0000",
+                "value": 10
+              }
             ]
           },
           "unit": "ops",
@@ -249,21 +435,42 @@
       "id": 12,
       "type": "stat",
       "title": "2. SIGNALS",
-      "gridPos": {"h": 5, "w": 5, "x": 5, "y": 4},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{
-        "expr": "rate(signals_generated_total[1m])",
-        "refId": "A"
-      }],
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 5,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "rate(signals_generated_total[1m])",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#1a1a1a", "value": null},
-              {"color": "#4d0000", "value": 0.01},
-              {"color": "#8b0000", "value": 1}
+              {
+                "color": "#1a1a1a",
+                "value": null
+              },
+              {
+                "color": "#4d0000",
+                "value": 0.01
+              },
+              {
+                "color": "#8b0000",
+                "value": 1
+              }
             ]
           },
           "unit": "ops",
@@ -280,21 +487,42 @@
       "id": 13,
       "type": "stat",
       "title": "3. APPROVED",
-      "gridPos": {"h": 5, "w": 4, "x": 10, "y": 4},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{
-        "expr": "rate(orders_approved_total[1m])",
-        "refId": "A"
-      }],
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 10,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "rate(orders_approved_total[1m])",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#1a1a1a", "value": null},
-              {"color": "#4d0000", "value": 0.01},
-              {"color": "#8b0000", "value": 0.1}
+              {
+                "color": "#1a1a1a",
+                "value": null
+              },
+              {
+                "color": "#4d0000",
+                "value": 0.01
+              },
+              {
+                "color": "#8b0000",
+                "value": 0.1
+              }
             ]
           },
           "unit": "ops",
@@ -311,20 +539,38 @@
       "id": 14,
       "type": "stat",
       "title": "⚠️ BLOCKED",
-      "gridPos": {"h": 5, "w": 5, "x": 14, "y": 4},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{
-        "expr": "rate(orders_blocked_total[1m])",
-        "refId": "A"
-      }],
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 14,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "rate(orders_blocked_total[1m])",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#f59e0b", "value": null},
-              {"color": "#dc2626", "value": 0.001}
+              {
+                "color": "#f59e0b",
+                "value": null
+              },
+              {
+                "color": "#dc2626",
+                "value": 0.001
+              }
             ]
           },
           "unit": "ops",
@@ -341,21 +587,42 @@
       "id": 15,
       "type": "stat",
       "title": "4. FILLED",
-      "gridPos": {"h": 5, "w": 5, "x": 19, "y": 4},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{
-        "expr": "rate(execution_orders_filled_total[1m])",
-        "refId": "A"
-      }],
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 19,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "rate(execution_orders_filled_total[1m])",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#1a1a1a", "value": null},
-              {"color": "#4d0000", "value": 0.001},
-              {"color": "#8b0000", "value": 0.01}
+              {
+                "color": "#1a1a1a",
+                "value": null
+              },
+              {
+                "color": "#4d0000",
+                "value": 0.001
+              },
+              {
+                "color": "#8b0000",
+                "value": 0.01
+              }
             ]
           },
           "unit": "ops",
@@ -372,8 +639,16 @@
       "id": 21,
       "type": "timeseries",
       "title": "Trade Flow Pipeline (Rate)",
-      "gridPos": {"h": 8, "w": 16, "x": 0, "y": 9},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 9
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "rate(decoded_messages_total[1m])",
@@ -403,7 +678,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "lineWidth": 2,
             "fillOpacity": 10,
@@ -413,38 +690,76 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Orders BLOCKED"},
+            "matcher": {
+              "id": "byName",
+              "options": "Orders BLOCKED"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#dc2626"}},
-              {"id": "custom.lineWidth", "value": 3}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#dc2626"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": {"mode": "multi"},
-        "legend": {"displayMode": "list", "placement": "bottom"}
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
       }
     },
     {
       "id": 22,
       "type": "stat",
       "title": "RISK BLOCKS (Total)",
-      "gridPos": {"h": 4, "w": 8, "x": 16, "y": 9},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "targets": [{
-        "expr": "orders_blocked_total",
-        "refId": "A"
-      }],
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "orders_blocked_total",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#f59e0b", "value": null},
-              {"color": "#ea580c", "value": 1},
-              {"color": "#dc2626", "value": 10}
+              {
+                "color": "#f59e0b",
+                "value": null
+              },
+              {
+                "color": "#ea580c",
+                "value": 1
+              },
+              {
+                "color": "#dc2626",
+                "value": 10
+              }
             ]
           },
           "unit": "short"
@@ -460,8 +775,16 @@
       "id": 23,
       "type": "bargauge",
       "title": "Execution Status",
-      "gridPos": {"h": 4, "w": 8, "x": 16, "y": 13},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 13
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "execution_orders_received_total",
@@ -481,12 +804,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#1a1a1a", "value": null},
-              {"color": "#8b0000", "value": 1}
+              {
+                "color": "#1a1a1a",
+                "value": null
+              },
+              {
+                "color": "#8b0000",
+                "value": 1
+              }
             ]
           },
           "unit": "short"

--- a/infrastructure/monitoring/grafana/dashboards/claire_dark_v1.json
+++ b/infrastructure/monitoring/grafana/dashboards/claire_dark_v1.json
@@ -1,8 +1,13 @@
 {
   "uid": "claire_dark_v1",
   "title": "Claire de Binare - Dark Trading",
-  "description": "Minimalistic dark dashboard with deep red accents for Claire Paper Trading",
-  "tags": ["claire", "trading", "dark"],
+  "description": "ARCHIVED (legacy dashboard). Minimalistic dark dashboard with deep red accents for Claire Paper Trading",
+  "tags": [
+    "claire",
+    "trading",
+    "dark",
+    "legacy"
+  ],
   "timezone": "browser",
   "editable": true,
   "graphTooltip": 1,
@@ -11,7 +16,13 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m"]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m"
+    ]
   },
   "style": "dark",
   "panels": [
@@ -19,7 +30,12 @@
       "id": 1,
       "type": "stat",
       "title": "CIRCUIT BREAKER",
-      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -29,21 +45,37 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
             {
               "type": "value",
               "options": {
-                "0": {"color": "#1a1a1a", "index": 0, "text": "INACTIVE"},
-                "1": {"color": "#8b0000", "index": 1, "text": "⚠ ACTIVE"}
+                "0": {
+                  "color": "#1a1a1a",
+                  "index": 0,
+                  "text": "INACTIVE"
+                },
+                "1": {
+                  "color": "#8b0000",
+                  "index": 1,
+                  "text": "⚠ ACTIVE"
+                }
               }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#1a1a1a", "value": null},
-              {"color": "#8b0000", "value": 1}
+              {
+                "color": "#1a1a1a",
+                "value": null
+              },
+              {
+                "color": "#8b0000",
+                "value": 1
+              }
             ]
           }
         }
@@ -53,7 +85,9 @@
         "graphMode": "none",
         "textMode": "value_and_name",
         "reduceOptions": {
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         }
       }
     },
@@ -61,7 +95,12 @@
       "id": 2,
       "type": "stat",
       "title": "ORDERS FILLED",
-      "gridPos": {"h": 6, "w": 6, "x": 6, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -71,12 +110,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#1a1a1a", "value": null},
-              {"color": "#8b0000", "value": 1}
+              {
+                "color": "#1a1a1a",
+                "value": null
+              },
+              {
+                "color": "#8b0000",
+                "value": 1
+              }
             ]
           }
         }
@@ -91,7 +138,12 @@
       "id": 3,
       "type": "stat",
       "title": "ORDERS REJECTED",
-      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -101,12 +153,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#1a1a1a", "value": null},
-              {"color": "#4d0000", "value": 10}
+              {
+                "color": "#1a1a1a",
+                "value": null
+              },
+              {
+                "color": "#4d0000",
+                "value": 10
+              }
             ]
           }
         }
@@ -121,7 +181,12 @@
       "id": 4,
       "type": "stat",
       "title": "UPTIME",
-      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -131,12 +196,17 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "s",
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#1a1a1a", "value": null}
+              {
+                "color": "#1a1a1a",
+                "value": null
+              }
             ]
           }
         }
@@ -151,7 +221,12 @@
       "id": 5,
       "type": "timeseries",
       "title": "ORDER FLOW",
-      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 6},
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -172,7 +247,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "bars",
             "lineInterpolation": "linear",
@@ -183,43 +260,81 @@
             "spanNulls": false,
             "showPoints": "never",
             "pointSize": 5,
-            "stacking": {"mode": "normal", "group": "A"}
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
           },
           "unit": "short",
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "transparent", "value": null}
+              {
+                "color": "transparent",
+                "value": null
+              }
             ]
           }
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Received"},
+            "matcher": {
+              "id": "byName",
+              "options": "Received"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#ff0000"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#ff0000"
+                }
+              }
             ]
           },
           {
-            "matcher": {"id": "byName", "options": "Filled"},
+            "matcher": {
+              "id": "byName",
+              "options": "Filled"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#8b0000"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#8b0000"
+                }
+              }
             ]
           },
           {
-            "matcher": {"id": "byName", "options": "Rejected"},
+            "matcher": {
+              "id": "byName",
+              "options": "Rejected"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#4d0000"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#4d0000"
+                }
+              }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": {"mode": "multi"},
+        "tooltip": {
+          "mode": "multi"
+        },
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
-          "calcs": ["last", "max"]
+          "calcs": [
+            "last",
+            "max"
+          ]
         }
       }
     },
@@ -227,7 +342,12 @@
       "id": 6,
       "type": "timeseries",
       "title": "RISK METRICS",
-      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 16},
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -243,7 +363,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "smooth",
@@ -257,25 +379,49 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Max Exposure %"},
+            "matcher": {
+              "id": "byName",
+              "options": "Max Exposure %"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#8b0000"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#8b0000"
+                }
+              }
             ]
           },
           {
-            "matcher": {"id": "byName", "options": "Signal Threshold %"},
+            "matcher": {
+              "id": "byName",
+              "options": "Signal Threshold %"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#ff0000"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#ff0000"
+                }
+              }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": {"mode": "multi"},
+        "tooltip": {
+          "mode": "multi"
+        },
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": ["last", "min", "max"]
+          "calcs": [
+            "last",
+            "min",
+            "max"
+          ]
         }
       }
     },
@@ -283,7 +429,12 @@
       "id": 7,
       "type": "timeseries",
       "title": "PERFORMANCE SCORE",
-      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 16},
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -294,7 +445,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "smooth",
@@ -307,19 +460,34 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#8b0000", "value": null},
-              {"color": "#4d0000", "value": 0.5},
-              {"color": "#ff0000", "value": 0.8}
+              {
+                "color": "#8b0000",
+                "value": null
+              },
+              {
+                "color": "#4d0000",
+                "value": 0.5
+              },
+              {
+                "color": "#ff0000",
+                "value": 0.8
+              }
             ]
           }
         }
       },
       "options": {
-        "tooltip": {"mode": "single"},
+        "tooltip": {
+          "mode": "single"
+        },
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": ["last", "mean", "max"]
+          "calcs": [
+            "last",
+            "mean",
+            "max"
+          ]
         }
       }
     }

--- a/infrastructure/monitoring/grafana/dashboards/claire_database_v1.json
+++ b/infrastructure/monitoring/grafana/dashboards/claire_database_v1.json
@@ -1,8 +1,15 @@
 {
   "uid": "claire_database_v1",
   "title": "Claire - Database Metrics",
-  "description": "PostgreSQL & Redis monitoring - Connections, Query Performance, Memory - Yellow/Orange/Black theme",
-  "tags": ["claire", "database", "postgres", "redis", "monitoring"],
+  "description": "ARCHIVED (legacy dashboard). PostgreSQL & Redis monitoring - Connections, Query Performance, Memory - Yellow/Orange/Black theme",
+  "tags": [
+    "claire",
+    "database",
+    "postgres",
+    "redis",
+    "monitoring",
+    "legacy"
+  ],
   "timezone": "browser",
   "editable": true,
   "graphTooltip": 1,
@@ -11,7 +18,12 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m"]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m"
+    ]
   },
   "style": "dark",
   "panels": [
@@ -19,7 +31,12 @@
       "id": 1,
       "type": "stat",
       "title": "POSTGRES STATUS",
-      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -29,16 +46,40 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            {"type": "value", "options": {"0": {"text": "DOWN", "color": "#dc2626"}}},
-            {"type": "value", "options": {"1": {"text": "UP", "color": "#f59e0b"}}}
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "#dc2626"
+                }
+              }
+            },
+            {
+              "type": "value",
+              "options": {
+                "1": {
+                  "text": "UP",
+                  "color": "#f59e0b"
+                }
+              }
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#dc2626", "value": null},
-              {"color": "#f59e0b", "value": 1}
+              {
+                "color": "#dc2626",
+                "value": null
+              },
+              {
+                "color": "#f59e0b",
+                "value": 1
+              }
             ]
           }
         }
@@ -48,7 +89,12 @@
       "id": 2,
       "type": "stat",
       "title": "REDIS STATUS",
-      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -58,16 +104,40 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            {"type": "value", "options": {"0": {"text": "DOWN", "color": "#dc2626"}}},
-            {"type": "value", "options": {"1": {"text": "UP", "color": "#f59e0b"}}}
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "#dc2626"
+                }
+              }
+            },
+            {
+              "type": "value",
+              "options": {
+                "1": {
+                  "text": "UP",
+                  "color": "#f59e0b"
+                }
+              }
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#dc2626", "value": null},
-              {"color": "#f59e0b", "value": 1}
+              {
+                "color": "#dc2626",
+                "value": null
+              },
+              {
+                "color": "#f59e0b",
+                "value": 1
+              }
             ]
           }
         }
@@ -77,7 +147,12 @@
       "id": 3,
       "type": "stat",
       "title": "PG CONNECTIONS",
-      "gridPos": {"h": 4, "w": 4, "x": 8, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -87,13 +162,24 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#f59e0b", "value": null},
-              {"color": "#ea580c", "value": 50},
-              {"color": "#dc2626", "value": 90}
+              {
+                "color": "#f59e0b",
+                "value": null
+              },
+              {
+                "color": "#ea580c",
+                "value": 50
+              },
+              {
+                "color": "#dc2626",
+                "value": 90
+              }
             ]
           }
         }
@@ -103,7 +189,12 @@
       "id": 4,
       "type": "stat",
       "title": "REDIS MEMORY",
-      "gridPos": {"h": 4, "w": 4, "x": 12, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -114,13 +205,24 @@
       "fieldConfig": {
         "defaults": {
           "unit": "MB",
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#f59e0b", "value": null},
-              {"color": "#ea580c", "value": 200},
-              {"color": "#dc2626", "value": 240}
+              {
+                "color": "#f59e0b",
+                "value": null
+              },
+              {
+                "color": "#ea580c",
+                "value": 200
+              },
+              {
+                "color": "#dc2626",
+                "value": 240
+              }
             ]
           }
         }
@@ -130,7 +232,12 @@
       "id": 5,
       "type": "stat",
       "title": "REDIS KEYS",
-      "gridPos": {"h": 4, "w": 4, "x": 16, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -140,11 +247,16 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#f59e0b", "value": null}
+              {
+                "color": "#f59e0b",
+                "value": null
+              }
             ]
           }
         }
@@ -154,7 +266,12 @@
       "id": 6,
       "type": "stat",
       "title": "STREAM FILLS",
-      "gridPos": {"h": 4, "w": 4, "x": 20, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -164,11 +281,16 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#f59e0b", "value": null}
+              {
+                "color": "#f59e0b",
+                "value": null
+              }
             ]
           }
         }
@@ -178,7 +300,12 @@
       "id": 10,
       "type": "timeseries",
       "title": "PostgreSQL Query Performance",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -194,7 +321,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "lineWidth": 2,
             "fillOpacity": 10
@@ -202,8 +331,19 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Query Time Rate"},
-            "properties": [{"id": "color", "value": {"fixedColor": "#f59e0b", "mode": "fixed"}}]
+            "matcher": {
+              "id": "byName",
+              "options": "Query Time Rate"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#f59e0b",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       }
@@ -212,7 +352,12 @@
       "id": 11,
       "type": "timeseries",
       "title": "Redis Operations/sec",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -228,7 +373,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "lineWidth": 2,
             "fillOpacity": 10
@@ -236,8 +383,19 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Commands/sec"},
-            "properties": [{"id": "color", "value": {"fixedColor": "#ea580c", "mode": "fixed"}}]
+            "matcher": {
+              "id": "byName",
+              "options": "Commands/sec"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#ea580c",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       }
@@ -246,7 +404,12 @@
       "id": 20,
       "type": "timeseries",
       "title": "PostgreSQL Connections Over Time",
-      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 12},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -270,7 +433,9 @@
           "custom": {
             "lineWidth": 2,
             "fillOpacity": 20,
-            "stacking": {"mode": "normal"}
+            "stacking": {
+              "mode": "normal"
+            }
           }
         }
       }
@@ -279,7 +444,12 @@
       "id": 21,
       "type": "timeseries",
       "title": "Redis Memory Usage",
-      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 12},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -303,8 +473,18 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Max MB"},
-            "properties": [{"id": "custom.lineStyle", "value": {"fill": "dash"}}]
+            "matcher": {
+              "id": "byName",
+              "options": "Max MB"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash"
+                }
+              }
+            ]
           }
         ]
       }
@@ -313,7 +493,12 @@
       "id": 30,
       "type": "table",
       "title": "Slow Queries (Last Hour)",
-      "gridPos": {"h": 6, "w": 24, "x": 0, "y": 18},
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
       "datasource": "Prometheus",
       "targets": [
         {

--- a/infrastructure/monitoring/grafana/dashboards/claire_execution_v1.json
+++ b/infrastructure/monitoring/grafana/dashboards/claire_execution_v1.json
@@ -1,8 +1,13 @@
 {
   "uid": "claire_execution_v1",
   "title": "Claire - Execution Engine",
-  "description": "Live trade execution monitoring - Toxic Green/Black theme",
-  "tags": ["claire", "execution", "green"],
+  "description": "ARCHIVED (legacy dashboard). Live trade execution monitoring - Toxic Green/Black theme",
+  "tags": [
+    "claire",
+    "execution",
+    "green",
+    "legacy"
+  ],
   "timezone": "browser",
   "editable": true,
   "graphTooltip": 1,
@@ -11,7 +16,11 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s"]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s"
+    ]
   },
   "style": "dark",
   "panels": [
@@ -19,7 +28,12 @@
       "id": 1,
       "type": "stat",
       "title": "ORDERS FILLED",
-      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -29,14 +43,28 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#16a34a", "value": 1},
-              {"color": "#22c55e", "value": 10},
-              {"color": "#84cc16", "value": 50}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#16a34a",
+                "value": 1
+              },
+              {
+                "color": "#22c55e",
+                "value": 10
+              },
+              {
+                "color": "#84cc16",
+                "value": 50
+              }
             ]
           }
         }
@@ -51,7 +79,12 @@
       "id": 2,
       "type": "stat",
       "title": "ORDERS RECEIVED",
-      "gridPos": {"h": 6, "w": 6, "x": 6, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -61,12 +94,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#10b981", "value": 1}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#10b981",
+                "value": 1
+              }
             ]
           }
         }
@@ -81,7 +122,12 @@
       "id": 3,
       "type": "gauge",
       "title": "FILL RATE",
-      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -91,17 +137,31 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "percent",
           "min": 0,
           "max": 100,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#16a34a", "value": 20},
-              {"color": "#22c55e", "value": 50},
-              {"color": "#84cc16", "value": 80}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#16a34a",
+                "value": 20
+              },
+              {
+                "color": "#22c55e",
+                "value": 50
+              },
+              {
+                "color": "#84cc16",
+                "value": 80
+              }
             ]
           }
         }
@@ -115,7 +175,12 @@
       "id": 4,
       "type": "stat",
       "title": "UPTIME",
-      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -125,13 +190,21 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "s",
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#10b981", "value": 60}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#10b981",
+                "value": 60
+              }
             ]
           }
         }
@@ -146,7 +219,12 @@
       "id": 5,
       "type": "timeseries",
       "title": "EXECUTION FLOW (Real-time)",
-      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 6},
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -167,7 +245,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "smooth",
@@ -181,31 +261,63 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Received/s"},
+            "matcher": {
+              "id": "byName",
+              "options": "Received/s"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#84cc16"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#84cc16"
+                }
+              }
             ]
           },
           {
-            "matcher": {"id": "byName", "options": "Filled/s"},
+            "matcher": {
+              "id": "byName",
+              "options": "Filled/s"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#22c55e"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#22c55e"
+                }
+              }
             ]
           },
           {
-            "matcher": {"id": "byName", "options": "Rejected/s"},
+            "matcher": {
+              "id": "byName",
+              "options": "Rejected/s"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#16a34a"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#16a34a"
+                }
+              }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": {"mode": "multi"},
+        "tooltip": {
+          "mode": "multi"
+        },
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": ["last", "max"]
+          "calcs": [
+            "last",
+            "max"
+          ]
         }
       }
     },
@@ -213,7 +325,12 @@
       "id": 6,
       "type": "timeseries",
       "title": "ORDER RESULTS TIMELINE",
-      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 16},
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -224,7 +341,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "bars",
             "lineWidth": 2,
@@ -235,23 +354,41 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Results/min"},
+            "matcher": {
+              "id": "byName",
+              "options": "Results/min"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#22c55e"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#22c55e"
+                }
+              }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": {"mode": "single"},
-        "legend": {"displayMode": "hidden"}
+        "tooltip": {
+          "mode": "single"
+        },
+        "legend": {
+          "displayMode": "hidden"
+        }
       }
     },
     {
       "id": 7,
       "type": "stat",
       "title": "TOTAL RESULTS",
-      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 16},
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -261,14 +398,28 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#16a34a", "value": 1},
-              {"color": "#22c55e", "value": 50},
-              {"color": "#84cc16", "value": 100}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#16a34a",
+                "value": 1
+              },
+              {
+                "color": "#22c55e",
+                "value": 50
+              },
+              {
+                "color": "#84cc16",
+                "value": 100
+              }
             ]
           }
         }
@@ -284,7 +435,12 @@
       "id": 8,
       "type": "table",
       "title": "RECENT TRADES (Live)",
-      "gridPos": {"h": 12, "w": 24, "x": 0, "y": 26},
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
       "datasource": "PostgreSQL",
       "targets": [
         {
@@ -302,7 +458,10 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "side"},
+            "matcher": {
+              "id": "byName",
+              "options": "side"
+            },
             "properties": [
               {
                 "id": "custom.displayMode",
@@ -314,8 +473,14 @@
                   {
                     "type": "value",
                     "options": {
-                      "buy": {"color": "#22c55e", "index": 0},
-                      "sell": {"color": "#84cc16", "index": 1}
+                      "buy": {
+                        "color": "#22c55e",
+                        "index": 0
+                      },
+                      "sell": {
+                        "color": "#84cc16",
+                        "index": 1
+                      }
                     }
                   }
                 ]
@@ -323,7 +488,10 @@
             ]
           },
           {
-            "matcher": {"id": "byName", "options": "status"},
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
             "properties": [
               {
                 "id": "custom.displayMode",
@@ -335,9 +503,18 @@
                   {
                     "type": "value",
                     "options": {
-                      "filled": {"color": "#22c55e", "index": 0},
-                      "rejected": {"color": "#16a34a", "index": 1},
-                      "pending": {"color": "#10b981", "index": 2}
+                      "filled": {
+                        "color": "#22c55e",
+                        "index": 0
+                      },
+                      "rejected": {
+                        "color": "#16a34a",
+                        "index": 1
+                      },
+                      "pending": {
+                        "color": "#10b981",
+                        "index": 2
+                      }
                     }
                   }
                 ]

--- a/infrastructure/monitoring/grafana/dashboards/claire_hitl_control_v1.json
+++ b/infrastructure/monitoring/grafana/dashboards/claire_hitl_control_v1.json
@@ -1,8 +1,14 @@
 {
   "uid": "claire_hitl_v1",
   "title": "Claire - HITL Control Center",
-  "description": "Human-in-the-Loop monitoring and control dashboard for real-money trading operations",
-  "tags": ["claire", "hitl", "control", "safety"],
+  "description": "ARCHIVED (legacy dashboard). Human-in-the-Loop monitoring and control dashboard for real-money trading operations",
+  "tags": [
+    "claire",
+    "hitl",
+    "control",
+    "safety",
+    "legacy"
+  ],
   "timezone": "browser",
   "editable": true,
   "graphTooltip": 1,
@@ -11,7 +17,13 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m"]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m"
+    ]
   },
   "refresh": "10s",
   "style": "dark",
@@ -20,7 +32,12 @@
       "id": 1,
       "type": "stat",
       "title": "🚨 KILL-SWITCH STATUS",
-      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -31,21 +48,37 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
             {
               "type": "value",
               "options": {
-                "0": {"color": "green", "index": 0, "text": "✅ INACTIVE"},
-                "1": {"color": "red", "index": 1, "text": "🚨 ACTIVE - TRADING STOPPED"}
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "✅ INACTIVE"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "🚨 ACTIVE - TRADING STOPPED"
+                }
               }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "red", "value": 1}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           },
           "unit": "none"
@@ -62,7 +95,12 @@
       "id": 2,
       "type": "stat",
       "title": "⚙️ TRADING MODE",
-      "gridPos": {"h": 6, "w": 6, "x": 6, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -73,23 +111,46 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
             {
               "type": "value",
               "options": {
-                "0": {"color": "blue", "index": 0, "text": "📄 PAPER"},
-                "1": {"color": "yellow", "index": 1, "text": "🧪 STAGED"},
-                "2": {"color": "red", "index": 2, "text": "💰 LIVE"}
+                "0": {
+                  "color": "blue",
+                  "index": 0,
+                  "text": "📄 PAPER"
+                },
+                "1": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "🧪 STAGED"
+                },
+                "2": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "💰 LIVE"
+                }
               }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "blue", "value": null},
-              {"color": "yellow", "value": 1},
-              {"color": "red", "value": 2}
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
             ]
           },
           "unit": "none"
@@ -106,7 +167,12 @@
       "id": 3,
       "type": "stat",
       "title": "⚡ CIRCUIT BREAKER",
-      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -117,21 +183,37 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
             {
               "type": "value",
               "options": {
-                "0": {"color": "green", "index": 0, "text": "✅ SAFE"},
-                "1": {"color": "orange", "index": 1, "text": "⚠️ TRIPPED"}
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "✅ SAFE"
+                },
+                "1": {
+                  "color": "orange",
+                  "index": 1,
+                  "text": "⚠️ TRIPPED"
+                }
               }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "orange", "value": 1}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
             ]
           },
           "unit": "none"
@@ -148,7 +230,12 @@
       "id": 4,
       "type": "stat",
       "title": "📊 DAILY P&L (%)",
-      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -159,15 +246,32 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "red", "value": null},
-              {"color": "red", "value": -5},
-              {"color": "yellow", "value": -2},
-              {"color": "green", "value": 0},
-              {"color": "green", "value": 2}
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": -5
+              },
+              {
+                "color": "yellow",
+                "value": -2
+              },
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 2
+              }
             ]
           },
           "unit": "percent",
@@ -185,7 +289,12 @@
       "id": 5,
       "type": "timeseries",
       "title": "💰 Portfolio Value (USDT)",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 6},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -196,7 +305,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisLabel": "USDT",
             "axisPlacement": "auto",
@@ -224,7 +335,12 @@
       "id": 6,
       "type": "timeseries",
       "title": "📈 Daily P&L Trend",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 6},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -240,7 +356,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisLabel": "%",
             "axisPlacement": "auto",
@@ -255,10 +373,28 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Circuit Breaker Limit"},
+            "matcher": {
+              "id": "byName",
+              "options": "Circuit Breaker Limit"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}},
-              {"id": "custom.lineStyle", "value": {"dash": [10, 10], "fill": "dash"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
             ]
           }
         ]
@@ -277,7 +413,12 @@
       "id": 7,
       "type": "table",
       "title": "🔒 Active Risk Limits",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 14},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -326,7 +467,12 @@
       "id": 8,
       "type": "table",
       "title": "📜 Recent Manual Interventions",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 14},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -366,7 +512,12 @@
       "id": 9,
       "type": "stat",
       "title": "🎯 Active Orders",
-      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 22},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 22
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -377,13 +528,24 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 10},
-              {"color": "red", "value": 50}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
             ]
           },
           "unit": "short"
@@ -400,7 +562,12 @@
       "id": 10,
       "type": "stat",
       "title": "💸 Total Exposure (USDT)",
-      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 22},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 22
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -411,13 +578,24 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "percentage",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 50},
-              {"color": "red", "value": 80}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
             ]
           },
           "unit": "currencyUSD",
@@ -435,7 +613,12 @@
       "id": 11,
       "type": "stat",
       "title": "⏱️ Service Uptime",
-      "gridPos": {"h": 4, "w": 4, "x": 8, "y": 22},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 22
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -446,21 +629,37 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
             {
               "type": "value",
               "options": {
-                "0": {"color": "red", "index": 0, "text": "❌ DOWN"},
-                "1": {"color": "green", "index": 1, "text": "✅ UP"}
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "❌ DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "✅ UP"
+                }
               }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "red", "value": null},
-              {"color": "green", "value": 1}
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
             ]
           },
           "unit": "none"
@@ -477,7 +676,12 @@
       "id": 12,
       "type": "text",
       "title": "⚠️ HUMAN-IN-THE-LOOP CONTROLS",
-      "gridPos": {"h": 4, "w": 12, "x": 12, "y": 22},
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
       "options": {
         "content": "**Manual Intervention Required:**\n\n1. **Kill-Switch Activation**: Use `make kill-switch-activate` or Emergency Stop SOP\n2. **Trading Mode Change**: Update .env SIGNAL_STRATEGY_ID and restart services\n3. **Risk Limit Adjustment**: Update risk service config and restart\n4. **Manual Order Cancel**: Use execution service API or database directly\n\n**Emergency Contacts**: See EMERGENCY_STOP_SOP.md for escalation matrix\n\n**Audit Trail**: All interventions logged to Redis and Postgres audit tables",
         "mode": "markdown"

--- a/infrastructure/monitoring/grafana/dashboards/claire_minimal_observability_v1.json
+++ b/infrastructure/monitoring/grafana/dashboards/claire_minimal_observability_v1.json
@@ -1,8 +1,13 @@
 {
   "uid": "claire_minimal_observability_v1",
   "title": "Claire - Minimal Observability",
-  "description": "Minimal service health + throughput for signal, execution, db_writer, candles (dev-only).",
-  "tags": ["claire", "observability", "minimal"],
+  "description": "ARCHIVED (legacy dashboard). Minimal service health + throughput for signal, execution, db_writer, candles (dev-only).",
+  "tags": [
+    "claire",
+    "observability",
+    "minimal",
+    "legacy"
+  ],
   "timezone": "browser",
   "editable": true,
   "graphTooltip": 1,
@@ -11,7 +16,12 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m"]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m"
+    ]
   },
   "refresh": "10s",
   "style": "dark",
@@ -20,22 +30,49 @@
       "id": 1,
       "type": "stat",
       "title": "SIGNAL UP",
-      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        {"expr": "up{job=\"cdb_signal\"}", "refId": "A"}
+        {
+          "expr": "up{job=\"cdb_signal\"}",
+          "refId": "A"
+        }
       ],
       "fieldConfig": {
         "defaults": {
           "mappings": [
-            {"type": "value", "value": "0", "text": "DOWN", "color": "#dc2626"},
-            {"type": "value", "value": "1", "text": "UP", "color": "#16a34a"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "DOWN",
+              "color": "#dc2626"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "UP",
+              "color": "#16a34a"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#dc2626", "value": null},
-              {"color": "#16a34a", "value": 1}
+              {
+                "color": "#dc2626",
+                "value": null
+              },
+              {
+                "color": "#16a34a",
+                "value": 1
+              }
             ]
           }
         }
@@ -50,22 +87,49 @@
       "id": 2,
       "type": "stat",
       "title": "EXECUTION UP",
-      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        {"expr": "up{job=\"cdb_execution\"}", "refId": "A"}
+        {
+          "expr": "up{job=\"cdb_execution\"}",
+          "refId": "A"
+        }
       ],
       "fieldConfig": {
         "defaults": {
           "mappings": [
-            {"type": "value", "value": "0", "text": "DOWN", "color": "#dc2626"},
-            {"type": "value", "value": "1", "text": "UP", "color": "#16a34a"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "DOWN",
+              "color": "#dc2626"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "UP",
+              "color": "#16a34a"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#dc2626", "value": null},
-              {"color": "#16a34a", "value": 1}
+              {
+                "color": "#dc2626",
+                "value": null
+              },
+              {
+                "color": "#16a34a",
+                "value": 1
+              }
             ]
           }
         }
@@ -80,22 +144,49 @@
       "id": 3,
       "type": "stat",
       "title": "DB WRITER UP",
-      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        {"expr": "up{job=\"cdb_db_writer\"}", "refId": "A"}
+        {
+          "expr": "up{job=\"cdb_db_writer\"}",
+          "refId": "A"
+        }
       ],
       "fieldConfig": {
         "defaults": {
           "mappings": [
-            {"type": "value", "value": "0", "text": "DOWN", "color": "#dc2626"},
-            {"type": "value", "value": "1", "text": "UP", "color": "#16a34a"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "DOWN",
+              "color": "#dc2626"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "UP",
+              "color": "#16a34a"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#dc2626", "value": null},
-              {"color": "#16a34a", "value": 1}
+              {
+                "color": "#dc2626",
+                "value": null
+              },
+              {
+                "color": "#16a34a",
+                "value": 1
+              }
             ]
           }
         }
@@ -110,22 +201,49 @@
       "id": 4,
       "type": "stat",
       "title": "CANDLES UP (DEV)",
-      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        {"expr": "up{job=\"cdb_candles\"}", "refId": "A"}
+        {
+          "expr": "up{job=\"cdb_candles\"}",
+          "refId": "A"
+        }
       ],
       "fieldConfig": {
         "defaults": {
           "mappings": [
-            {"type": "value", "value": "0", "text": "DOWN", "color": "#dc2626"},
-            {"type": "value", "value": "1", "text": "UP", "color": "#16a34a"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "DOWN",
+              "color": "#dc2626"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "UP",
+              "color": "#16a34a"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#dc2626", "value": null},
-              {"color": "#16a34a", "value": 1}
+              {
+                "color": "#dc2626",
+                "value": null
+              },
+              {
+                "color": "#16a34a",
+                "value": 1
+              }
             ]
           }
         }
@@ -140,8 +258,16 @@
       "id": 5,
       "type": "timeseries",
       "title": "Throughput (per second)",
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 4},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "rate(signals_generated_total[5m])",
@@ -166,7 +292,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "lineWidth": 2,
             "fillOpacity": 10,
@@ -176,16 +304,29 @@
         }
       },
       "options": {
-        "tooltip": {"mode": "multi"},
-        "legend": {"displayMode": "list", "placement": "bottom"}
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
       }
     },
     {
       "id": 6,
       "type": "timeseries",
       "title": "Failures (per second)",
-      "gridPos": {"h": 6, "w": 24, "x": 0, "y": 12},
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "rate(execution_orders_rejected_total[5m])",
@@ -200,7 +341,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "lineWidth": 2,
             "fillOpacity": 10,
@@ -210,8 +353,13 @@
         }
       },
       "options": {
-        "tooltip": {"mode": "multi"},
-        "legend": {"displayMode": "list", "placement": "bottom"}
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
       }
     }
   ]

--- a/infrastructure/monitoring/grafana/dashboards/claire_paper_trading_v1.json
+++ b/infrastructure/monitoring/grafana/dashboards/claire_paper_trading_v1.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Claire de Binare - Paper Trading Dashboard (Phase N1)",
+  "description": "ARCHIVED (legacy dashboard). Claire de Binare - Paper Trading Dashboard (Phase N1)",
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
@@ -24,7 +24,9 @@
       "description": "Overall system performance and approval rate",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisLabel": "",
             "axisPlacement": "auto",
@@ -44,23 +46,42 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 5},
-              {"color": "red", "value": 20}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
             ]
           },
           "unit": "percent"
         }
       },
-      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "options": {
         "legend": {
-          "calcs": ["mean", "last"],
+          "calcs": [
+            "mean",
+            "last"
+          ],
           "displayMode": "table",
           "placement": "bottom"
         },
-        "tooltip": {"mode": "multi"}
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -77,7 +98,9 @@
       "description": "Signal generation rate over time",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisLabel": "",
             "axisPlacement": "auto",
@@ -94,20 +117,35 @@
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{"color": "green", "value": null}]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 0},
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
       "id": 2,
       "options": {
         "legend": {
-          "calcs": ["mean", "last"],
+          "calcs": [
+            "mean",
+            "last"
+          ],
           "displayMode": "table",
           "placement": "bottom"
         },
-        "tooltip": {"mode": "multi"}
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -122,7 +160,12 @@
     {
       "collapsed": false,
       "datasource": null,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 10},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
       "id": 10,
       "panels": [],
       "title": "Summary - Real-time Status",
@@ -133,21 +176,40 @@
       "description": "Total signals generated since start",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 10},
-              {"color": "orange", "value": 50},
-              {"color": "red", "value": 100}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
             ]
           },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 11},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 11
+      },
       "id": 11,
       "options": {
         "colorMode": "value",
@@ -155,7 +217,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -175,20 +239,36 @@
       "description": "Orders approved by risk manager",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "red", "value": null},
-              {"color": "yellow", "value": 1},
-              {"color": "green", "value": 5}
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "green",
+                "value": 5
+              }
             ]
           },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 11},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 11
+      },
       "id": 12,
       "options": {
         "colorMode": "value",
@@ -196,7 +276,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -216,20 +298,36 @@
       "description": "Orders blocked by risk manager",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 20},
-              {"color": "red", "value": 50}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 20
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
             ]
           },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 4, "w": 4, "x": 8, "y": 11},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 11
+      },
       "id": 13,
       "options": {
         "colorMode": "value",
@@ -237,7 +335,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -257,27 +357,45 @@
       "description": "Approval rate percentage",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "max": 100,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "red", "value": null},
-              {"color": "yellow", "value": 5},
-              {"color": "green", "value": 20}
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "green",
+                "value": 20
+              }
             ]
           },
           "unit": "percent"
         }
       },
-      "gridPos": {"h": 4, "w": 4, "x": 12, "y": 11},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 11
+      },
       "id": 14,
       "options": {
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -300,23 +418,43 @@
       "description": "Signal Engine running status",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
             {
               "options": {
-                "0": {"color": "red", "index": 0, "text": "STOPPED"},
-                "1": {"color": "green", "index": 1, "text": "RUNNING"}
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "STOPPED"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "RUNNING"
+                }
               },
               "type": "value"
             }
           ],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{"color": "green", "value": null}]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           }
         }
       },
-      "gridPos": {"h": 4, "w": 4, "x": 16, "y": 11},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 11
+      },
       "id": 15,
       "options": {
         "colorMode": "background",
@@ -324,7 +462,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -344,12 +484,22 @@
       "description": "Circuit breaker active status",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
             {
               "options": {
-                "0": {"color": "green", "index": 0, "text": "INACTIVE"},
-                "1": {"color": "red", "index": 1, "text": "ACTIVE"}
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "INACTIVE"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "ACTIVE"
+                }
               },
               "type": "value"
             }
@@ -357,13 +507,24 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "red", "value": 1}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           }
         }
       },
-      "gridPos": {"h": 4, "w": 4, "x": 20, "y": 11},
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 11
+      },
       "id": 16,
       "options": {
         "colorMode": "background",
@@ -371,7 +532,9 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -389,7 +552,12 @@
     {
       "collapsed": false,
       "datasource": null,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 15},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
       "id": 20,
       "panels": [],
       "title": "Detailed Metrics - Time Series",
@@ -400,7 +568,9 @@
       "description": "Signal generation and order processing over time",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisLabel": "",
             "axisPlacement": "auto",
@@ -417,20 +587,36 @@
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{"color": "green", "value": null}]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
       "id": 21,
       "options": {
         "legend": {
-          "calcs": ["mean", "last", "max"],
+          "calcs": [
+            "mean",
+            "last",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom"
         },
-        "tooltip": {"mode": "multi"}
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -457,7 +643,9 @@
       "description": "Rate of change for signals and orders",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisLabel": "per second",
             "axisPlacement": "auto",
@@ -474,20 +662,35 @@
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{"color": "green", "value": null}]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "reqps"
         }
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 16},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
       "id": 22,
       "options": {
         "legend": {
-          "calcs": ["mean", "last"],
+          "calcs": [
+            "mean",
+            "last"
+          ],
           "displayMode": "table",
           "placement": "bottom"
         },
-        "tooltip": {"mode": "multi"}
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -514,7 +717,9 @@
       "description": "Order execution results received",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisLabel": "",
             "axisPlacement": "auto",
@@ -531,20 +736,34 @@
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{"color": "green", "value": null}]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 24},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
       "id": 23,
       "options": {
         "legend": {
-          "calcs": ["sum"],
+          "calcs": [
+            "sum"
+          ],
           "displayMode": "table",
           "placement": "bottom"
         },
-        "tooltip": {"mode": "multi"}
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -566,7 +785,9 @@
       "description": "System health and status indicators",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisLabel": "",
             "axisPlacement": "auto",
@@ -586,22 +807,37 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "red", "value": null},
-              {"color": "green", "value": 1}
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
             ]
           },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 24},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
       "id": 24,
       "options": {
         "legend": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "displayMode": "table",
           "placement": "bottom"
         },
-        "tooltip": {"mode": "multi"}
+        "tooltip": {
+          "mode": "multi"
+        }
       },
       "targets": [
         {
@@ -622,14 +858,30 @@
   "refresh": "30s",
   "schemaVersion": 27,
   "style": "dark",
-  "tags": ["claire", "paper-trading", "phase-n1"],
-  "templating": {"list": []},
+  "tags": [
+    "claire",
+    "paper-trading",
+    "phase-n1",
+    "legacy"
+  ],
+  "templating": {
+    "list": []
+  },
   "time": {
     "from": "now-3h",
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h"]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h"
+    ]
   },
   "timezone": "browser",
   "title": "Claire de Binare - Paper Trading (N1)",

--- a/infrastructure/monitoring/grafana/dashboards/claire_risk_manager_v1.json
+++ b/infrastructure/monitoring/grafana/dashboards/claire_risk_manager_v1.json
@@ -1,8 +1,13 @@
 {
   "uid": "claire_risk_v1",
   "title": "Claire - Risk Manager",
-  "description": "Risk analysis and circuit breaker monitoring - Blue/Black theme",
-  "tags": ["claire", "risk", "blue"],
+  "description": "ARCHIVED (legacy dashboard). Risk analysis and circuit breaker monitoring - Blue/Black theme",
+  "tags": [
+    "claire",
+    "risk",
+    "blue",
+    "legacy"
+  ],
   "timezone": "browser",
   "editable": true,
   "graphTooltip": 1,
@@ -11,7 +16,12 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m"]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m"
+    ]
   },
   "style": "dark",
   "panels": [
@@ -19,7 +29,12 @@
       "id": 1,
       "type": "stat",
       "title": "CIRCUIT BREAKER",
-      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -29,21 +44,37 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
             {
               "type": "value",
               "options": {
-                "0": {"color": "#0a0a0a", "index": 0, "text": "SAFE"},
-                "1": {"color": "#1e3a8a", "index": 1, "text": "⚠ TRIPPED"}
+                "0": {
+                  "color": "#0a0a0a",
+                  "index": 0,
+                  "text": "SAFE"
+                },
+                "1": {
+                  "color": "#1e3a8a",
+                  "index": 1,
+                  "text": "⚠ TRIPPED"
+                }
               }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#1e3a8a", "value": 1}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#1e3a8a",
+                "value": 1
+              }
             ]
           }
         }
@@ -53,7 +84,9 @@
         "graphMode": "none",
         "textMode": "value_and_name",
         "reduceOptions": {
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         }
       }
     },
@@ -61,7 +94,12 @@
       "id": 2,
       "type": "gauge",
       "title": "MAX EXPOSURE",
-      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0},
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -71,17 +109,31 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "percent",
           "min": 0,
           "max": 100,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#0ea5e9", "value": 30},
-              {"color": "#3b82f6", "value": 50},
-              {"color": "#1e3a8a", "value": 80}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#0ea5e9",
+                "value": 30
+              },
+              {
+                "color": "#3b82f6",
+                "value": 50
+              },
+              {
+                "color": "#1e3a8a",
+                "value": 80
+              }
             ]
           }
         }
@@ -95,7 +147,12 @@
       "id": 3,
       "type": "stat",
       "title": "ORDERS BLOCKED",
-      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 0},
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -105,14 +162,28 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#0ea5e9", "value": 10},
-              {"color": "#3b82f6", "value": 50},
-              {"color": "#1e3a8a", "value": 100}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#0ea5e9",
+                "value": 10
+              },
+              {
+                "color": "#3b82f6",
+                "value": 50
+              },
+              {
+                "color": "#1e3a8a",
+                "value": 100
+              }
             ]
           }
         }
@@ -127,7 +198,12 @@
       "id": 4,
       "type": "timeseries",
       "title": "EXPOSURE TIMELINE",
-      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 8},
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -138,7 +214,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "smooth",
@@ -152,27 +230,51 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0ea5e9", "value": null},
-              {"color": "#3b82f6", "value": 50},
-              {"color": "#1e3a8a", "value": 80}
+              {
+                "color": "#0ea5e9",
+                "value": null
+              },
+              {
+                "color": "#3b82f6",
+                "value": 50
+              },
+              {
+                "color": "#1e3a8a",
+                "value": 80
+              }
             ]
           }
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Max Exposure %"},
+            "matcher": {
+              "id": "byName",
+              "options": "Max Exposure %"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#3b82f6"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#3b82f6"
+                }
+              }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": {"mode": "multi"},
+        "tooltip": {
+          "mode": "multi"
+        },
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": ["last", "max", "mean"]
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ]
         }
       }
     },
@@ -180,7 +282,12 @@
       "id": 5,
       "type": "timeseries",
       "title": "RISK THRESHOLDS",
-      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 18},
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -196,7 +303,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "smooth",
@@ -208,21 +317,41 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Signal Threshold"},
+            "matcher": {
+              "id": "byName",
+              "options": "Signal Threshold"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#3b82f6"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#3b82f6"
+                }
+              }
             ]
           },
           {
-            "matcher": {"id": "byName", "options": "RSI Threshold"},
+            "matcher": {
+              "id": "byName",
+              "options": "RSI Threshold"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#0ea5e9"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#0ea5e9"
+                }
+              }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": {"mode": "multi"},
+        "tooltip": {
+          "mode": "multi"
+        },
         "legend": {
           "displayMode": "list",
           "placement": "bottom"
@@ -233,7 +362,12 @@
       "id": 6,
       "type": "gauge",
       "title": "PERFORMANCE SCORE",
-      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 18},
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -243,16 +377,30 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "min": 0,
           "max": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#0ea5e9", "value": 0.3},
-              {"color": "#3b82f6", "value": 0.6},
-              {"color": "#1e3a8a", "value": 0.8}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#0ea5e9",
+                "value": 0.3
+              },
+              {
+                "color": "#3b82f6",
+                "value": 0.6
+              },
+              {
+                "color": "#1e3a8a",
+                "value": 0.8
+              }
             ]
           }
         }
@@ -266,7 +414,12 @@
       "id": 7,
       "type": "table",
       "title": "RISK EVENTS LOG",
-      "gridPos": {"h": 12, "w": 24, "x": 0, "y": 28},
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
       "datasource": "PostgreSQL",
       "targets": [
         {
@@ -284,7 +437,10 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "confidence"},
+            "matcher": {
+              "id": "byName",
+              "options": "confidence"
+            },
             "properties": [
               {
                 "id": "custom.displayMode",
@@ -295,9 +451,18 @@
                 "value": {
                   "mode": "absolute",
                   "steps": [
-                    {"color": "#1e3a8a", "value": null},
-                    {"color": "#3b82f6", "value": 0.3},
-                    {"color": "#0ea5e9", "value": 0.5}
+                    {
+                      "color": "#1e3a8a",
+                      "value": null
+                    },
+                    {
+                      "color": "#3b82f6",
+                      "value": 0.3
+                    },
+                    {
+                      "color": "#0ea5e9",
+                      "value": 0.5
+                    }
                   ]
                 }
               }

--- a/infrastructure/monitoring/grafana/dashboards/claire_signal_engine_v1.json
+++ b/infrastructure/monitoring/grafana/dashboards/claire_signal_engine_v1.json
@@ -1,8 +1,14 @@
 {
   "uid": "claire_signal_engine_v1",
   "title": "Claire - Signal Engine",
-  "description": "Real-time signal generation and analysis dashboard",
-  "tags": ["claire", "signals", "engine", "dark"],
+  "description": "ARCHIVED (legacy dashboard). Real-time signal generation and analysis dashboard",
+  "tags": [
+    "claire",
+    "signals",
+    "engine",
+    "dark",
+    "legacy"
+  ],
   "timezone": "browser",
   "editable": true,
   "graphTooltip": 1,
@@ -11,7 +17,12 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m"]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m"
+    ]
   },
   "style": "dark",
   "panels": [
@@ -19,7 +30,12 @@
       "id": 1,
       "type": "stat",
       "title": "SIGNALS GENERATED",
-      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
       "datasource": "PostgreSQL",
       "targets": [
         {
@@ -30,14 +46,28 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#1a1a1a", "value": null},
-              {"color": "#4d0000", "value": 10},
-              {"color": "#8b0000", "value": 50},
-              {"color": "#ff0000", "value": 100}
+              {
+                "color": "#1a1a1a",
+                "value": null
+              },
+              {
+                "color": "#4d0000",
+                "value": 10
+              },
+              {
+                "color": "#8b0000",
+                "value": 50
+              },
+              {
+                "color": "#ff0000",
+                "value": 100
+              }
             ]
           }
         }
@@ -52,7 +82,12 @@
       "id": 2,
       "type": "stat",
       "title": "BUY SIGNALS",
-      "gridPos": {"h": 6, "w": 6, "x": 6, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
       "datasource": "PostgreSQL",
       "targets": [
         {
@@ -63,12 +98,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#1a1a1a", "value": null},
-              {"color": "#8b0000", "value": 1}
+              {
+                "color": "#1a1a1a",
+                "value": null
+              },
+              {
+                "color": "#8b0000",
+                "value": 1
+              }
             ]
           }
         }
@@ -83,7 +126,12 @@
       "id": 3,
       "type": "stat",
       "title": "SELL SIGNALS",
-      "gridPos": {"h": 6, "w": 6, "x": 12, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
       "datasource": "PostgreSQL",
       "targets": [
         {
@@ -94,12 +142,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#1a1a1a", "value": null},
-              {"color": "#4d0000", "value": 1}
+              {
+                "color": "#1a1a1a",
+                "value": null
+              },
+              {
+                "color": "#4d0000",
+                "value": 1
+              }
             ]
           }
         }
@@ -114,7 +170,12 @@
       "id": 4,
       "type": "stat",
       "title": "AVG CONFIDENCE",
-      "gridPos": {"h": 6, "w": 6, "x": 18, "y": 0},
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
       "datasource": "PostgreSQL",
       "targets": [
         {
@@ -125,14 +186,25 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "percentunit",
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#4d0000", "value": null},
-              {"color": "#8b0000", "value": 0.3},
-              {"color": "#ff0000", "value": 0.6}
+              {
+                "color": "#4d0000",
+                "value": null
+              },
+              {
+                "color": "#8b0000",
+                "value": 0.3
+              },
+              {
+                "color": "#ff0000",
+                "value": 0.6
+              }
             ]
           }
         }
@@ -147,7 +219,12 @@
       "id": 5,
       "type": "timeseries",
       "title": "SIGNAL GENERATION RATE",
-      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 6},
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
       "datasource": "PostgreSQL",
       "targets": [
         {
@@ -158,7 +235,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "bars",
             "lineInterpolation": "linear",
@@ -173,21 +252,35 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "transparent", "value": null}
+              {
+                "color": "transparent",
+                "value": null
+              }
             ]
           }
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "value"},
+            "matcher": {
+              "id": "byName",
+              "options": "value"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#8b0000"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#8b0000"
+                }
+              }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": {"mode": "single"},
+        "tooltip": {
+          "mode": "single"
+        },
         "legend": {
           "displayMode": "hidden"
         }
@@ -197,7 +290,12 @@
       "id": 6,
       "type": "bargauge",
       "title": "TOP SYMBOLS (Last Hour)",
-      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 16},
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
       "datasource": "PostgreSQL",
       "targets": [
         {
@@ -208,14 +306,28 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#1a1a1a", "value": null},
-              {"color": "#4d0000", "value": 5},
-              {"color": "#8b0000", "value": 10},
-              {"color": "#ff0000", "value": 20}
+              {
+                "color": "#1a1a1a",
+                "value": null
+              },
+              {
+                "color": "#4d0000",
+                "value": 5
+              },
+              {
+                "color": "#8b0000",
+                "value": 10
+              },
+              {
+                "color": "#ff0000",
+                "value": 20
+              }
             ]
           }
         }
@@ -225,7 +337,9 @@
         "orientation": "horizontal",
         "reduceOptions": {
           "values": false,
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "showUnfilled": true
       }
@@ -234,7 +348,12 @@
       "id": 7,
       "type": "piechart",
       "title": "SIGNAL TYPE DISTRIBUTION",
-      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 16},
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
       "datasource": "PostgreSQL",
       "targets": [
         {
@@ -245,30 +364,55 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"}
+          "color": {
+            "mode": "palette-classic"
+          }
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "buy"},
+            "matcher": {
+              "id": "byName",
+              "options": "buy"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#8b0000"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#8b0000"
+                }
+              }
             ]
           },
           {
-            "matcher": {"id": "byName", "options": "sell"},
+            "matcher": {
+              "id": "byName",
+              "options": "sell"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#ff0000"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#ff0000"
+                }
+              }
             ]
           }
         ]
       },
       "options": {
         "pieType": "donut",
-        "displayLabels": ["name", "percent"],
+        "displayLabels": [
+          "name",
+          "percent"
+        ],
         "legend": {
           "displayMode": "table",
           "placement": "right",
-          "calcs": ["sum"]
+          "calcs": [
+            "sum"
+          ]
         }
       }
     },
@@ -276,7 +420,12 @@
       "id": 8,
       "type": "table",
       "title": "RECENT SIGNALS (Live Feed)",
-      "gridPos": {"h": 12, "w": 24, "x": 0, "y": 26},
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
       "datasource": "PostgreSQL",
       "targets": [
         {
@@ -294,7 +443,10 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "signal_type"},
+            "matcher": {
+              "id": "byName",
+              "options": "signal_type"
+            },
             "properties": [
               {
                 "id": "custom.displayMode",
@@ -306,8 +458,14 @@
                   {
                     "type": "value",
                     "options": {
-                      "buy": {"color": "#8b0000", "index": 0},
-                      "sell": {"color": "#ff0000", "index": 1}
+                      "buy": {
+                        "color": "#8b0000",
+                        "index": 0
+                      },
+                      "sell": {
+                        "color": "#ff0000",
+                        "index": 1
+                      }
                     }
                   }
                 ]
@@ -315,7 +473,10 @@
             ]
           },
           {
-            "matcher": {"id": "byName", "options": "confidence"},
+            "matcher": {
+              "id": "byName",
+              "options": "confidence"
+            },
             "properties": [
               {
                 "id": "custom.displayMode",
@@ -326,19 +487,40 @@
                 "value": {
                   "mode": "absolute",
                   "steps": [
-                    {"color": "#1a1a1a", "value": null},
-                    {"color": "#4d0000", "value": 0.3},
-                    {"color": "#8b0000", "value": 0.5},
-                    {"color": "#ff0000", "value": 0.7}
+                    {
+                      "color": "#1a1a1a",
+                      "value": null
+                    },
+                    {
+                      "color": "#4d0000",
+                      "value": 0.3
+                    },
+                    {
+                      "color": "#8b0000",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "#ff0000",
+                      "value": 0.7
+                    }
                   ]
                 }
               },
-              {"id": "max", "value": 1},
-              {"id": "min", "value": 0}
+              {
+                "id": "max",
+                "value": 1
+              },
+              {
+                "id": "min",
+                "value": 0
+              }
             ]
           },
           {
-            "matcher": {"id": "byName", "options": "pct_change"},
+            "matcher": {
+              "id": "byName",
+              "options": "pct_change"
+            },
             "properties": [
               {
                 "id": "custom.displayMode",
@@ -349,9 +531,18 @@
                 "value": {
                   "mode": "absolute",
                   "steps": [
-                    {"color": "#1a1a1a", "value": null},
-                    {"color": "#8b0000", "value": 3},
-                    {"color": "#ff0000", "value": 5}
+                    {
+                      "color": "#1a1a1a",
+                      "value": null
+                    },
+                    {
+                      "color": "#8b0000",
+                      "value": 3
+                    },
+                    {
+                      "color": "#ff0000",
+                      "value": 5
+                    }
                   ]
                 }
               }

--- a/infrastructure/monitoring/grafana/dashboards/claire_soak_test_v1.json
+++ b/infrastructure/monitoring/grafana/dashboards/claire_soak_test_v1.json
@@ -1,8 +1,14 @@
 {
   "uid": "claire_soak_test_v1",
   "title": "Claire - 72h Soak Test Monitor",
-  "description": "Zero Restart Policy validation - 72-hour continuous operation monitoring (Issue #428)",
-  "tags": ["claire", "soak-test", "stability", "zero-restart"],
+  "description": "ARCHIVED (legacy dashboard). Zero Restart Policy validation - 72-hour continuous operation monitoring (Issue #428)",
+  "tags": [
+    "claire",
+    "soak-test",
+    "stability",
+    "zero-restart",
+    "legacy"
+  ],
   "timezone": "browser",
   "schemaVersion": 38,
   "version": 1,
@@ -16,14 +22,24 @@
       "id": 1,
       "type": "row",
       "title": "ABORT TRIGGERS - Critical Monitoring",
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "collapsed": false
     },
     {
       "id": 2,
       "type": "stat",
       "title": "🚨 CONTAINER RESTARTS (MUST BE 0)",
-      "gridPos": {"h": 6, "w": 8, "x": 0, "y": 1},
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -35,7 +51,9 @@
       "options": {
         "reduceOptions": {
           "values": false,
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "text": {
           "titleSize": 16,
@@ -49,8 +67,14 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "green"},
-              {"value": 1, "color": "red"}
+              {
+                "value": 0,
+                "color": "green"
+              },
+              {
+                "value": 1,
+                "color": "red"
+              }
             ]
           },
           "unit": "none",
@@ -62,7 +86,12 @@
       "id": 3,
       "type": "stat",
       "title": "💾 DISK SPACE REMAINING",
-      "gridPos": {"h": 6, "w": 8, "x": 8, "y": 1},
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -74,7 +103,9 @@
       "options": {
         "reduceOptions": {
           "values": false,
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "colorMode": "background"
       },
@@ -83,9 +114,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "red"},
-              {"value": 10, "color": "orange"},
-              {"value": 30, "color": "green"}
+              {
+                "value": 0,
+                "color": "red"
+              },
+              {
+                "value": 10,
+                "color": "orange"
+              },
+              {
+                "value": 30,
+                "color": "green"
+              }
             ]
           },
           "unit": "percent",
@@ -97,7 +137,12 @@
       "id": 4,
       "type": "stat",
       "title": "⏱️ TEST DURATION",
-      "gridPos": {"h": 6, "w": 8, "x": 16, "y": 1},
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -108,7 +153,9 @@
       "options": {
         "reduceOptions": {
           "values": false,
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "colorMode": "value"
       },
@@ -117,9 +164,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "yellow"},
-              {"value": 86400, "color": "orange"},
-              {"value": 259200, "color": "green"}
+              {
+                "value": 0,
+                "color": "yellow"
+              },
+              {
+                "value": 86400,
+                "color": "orange"
+              },
+              {
+                "value": 259200,
+                "color": "green"
+              }
             ]
           },
           "unit": "s",
@@ -131,14 +187,24 @@
       "id": 10,
       "type": "row",
       "title": "Service Health (8 Critical Services)",
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 7},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
       "collapsed": false
     },
     {
       "id": 11,
       "type": "stat",
       "title": "cdb_redis",
-      "gridPos": {"h": 4, "w": 3, "x": 0, "y": 8},
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 8
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -147,7 +213,12 @@
         }
       ],
       "options": {
-        "reduceOptions": {"values": false, "calcs": ["lastNotNull"]},
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background"
       },
       "fieldConfig": {
@@ -155,13 +226,27 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "red"},
-              {"value": 1, "color": "green"}
+              {
+                "value": 0,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
             ]
           },
           "mappings": [
-            {"type": "value", "value": "0", "text": "DOWN"},
-            {"type": "value", "value": "1", "text": "UP"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "DOWN"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "UP"
+            }
           ]
         }
       }
@@ -170,11 +255,26 @@
       "id": 12,
       "type": "stat",
       "title": "cdb_postgres",
-      "gridPos": {"h": 4, "w": 3, "x": 3, "y": 8},
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 8
+      },
       "datasource": "Prometheus",
-      "targets": [{"expr": "up{job=\"cdb_postgres\"}", "refId": "A"}],
+      "targets": [
+        {
+          "expr": "up{job=\"cdb_postgres\"}",
+          "refId": "A"
+        }
+      ],
       "options": {
-        "reduceOptions": {"values": false, "calcs": ["lastNotNull"]},
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background"
       },
       "fieldConfig": {
@@ -182,13 +282,27 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "red"},
-              {"value": 1, "color": "green"}
+              {
+                "value": 0,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
             ]
           },
           "mappings": [
-            {"type": "value", "value": "0", "text": "DOWN"},
-            {"type": "value", "value": "1", "text": "UP"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "DOWN"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "UP"
+            }
           ]
         }
       }
@@ -197,11 +311,26 @@
       "id": 13,
       "type": "stat",
       "title": "cdb_ws",
-      "gridPos": {"h": 4, "w": 3, "x": 6, "y": 8},
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 8
+      },
       "datasource": "Prometheus",
-      "targets": [{"expr": "up{job=\"cdb_ws\"}", "refId": "A"}],
+      "targets": [
+        {
+          "expr": "up{job=\"cdb_ws\"}",
+          "refId": "A"
+        }
+      ],
       "options": {
-        "reduceOptions": {"values": false, "calcs": ["lastNotNull"]},
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background"
       },
       "fieldConfig": {
@@ -209,13 +338,27 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "red"},
-              {"value": 1, "color": "green"}
+              {
+                "value": 0,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
             ]
           },
           "mappings": [
-            {"type": "value", "value": "0", "text": "DOWN"},
-            {"type": "value", "value": "1", "text": "UP"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "DOWN"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "UP"
+            }
           ]
         }
       }
@@ -224,11 +367,26 @@
       "id": 14,
       "type": "stat",
       "title": "cdb_signal",
-      "gridPos": {"h": 4, "w": 3, "x": 9, "y": 8},
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 8
+      },
       "datasource": "Prometheus",
-      "targets": [{"expr": "up{job=\"cdb_signal\"}", "refId": "A"}],
+      "targets": [
+        {
+          "expr": "up{job=\"cdb_signal\"}",
+          "refId": "A"
+        }
+      ],
       "options": {
-        "reduceOptions": {"values": false, "calcs": ["lastNotNull"]},
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background"
       },
       "fieldConfig": {
@@ -236,13 +394,27 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "red"},
-              {"value": 1, "color": "green"}
+              {
+                "value": 0,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
             ]
           },
           "mappings": [
-            {"type": "value", "value": "0", "text": "DOWN"},
-            {"type": "value", "value": "1", "text": "UP"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "DOWN"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "UP"
+            }
           ]
         }
       }
@@ -251,11 +423,26 @@
       "id": 15,
       "type": "stat",
       "title": "cdb_risk",
-      "gridPos": {"h": 4, "w": 3, "x": 12, "y": 8},
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 8
+      },
       "datasource": "Prometheus",
-      "targets": [{"expr": "up{job=\"cdb_risk\"}", "refId": "A"}],
+      "targets": [
+        {
+          "expr": "up{job=\"cdb_risk\"}",
+          "refId": "A"
+        }
+      ],
       "options": {
-        "reduceOptions": {"values": false, "calcs": ["lastNotNull"]},
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background"
       },
       "fieldConfig": {
@@ -263,13 +450,27 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "red"},
-              {"value": 1, "color": "green"}
+              {
+                "value": 0,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
             ]
           },
           "mappings": [
-            {"type": "value", "value": "0", "text": "DOWN"},
-            {"type": "value", "value": "1", "text": "UP"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "DOWN"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "UP"
+            }
           ]
         }
       }
@@ -278,11 +479,26 @@
       "id": 16,
       "type": "stat",
       "title": "cdb_execution",
-      "gridPos": {"h": 4, "w": 3, "x": 15, "y": 8},
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 8
+      },
       "datasource": "Prometheus",
-      "targets": [{"expr": "up{job=\"cdb_execution\"}", "refId": "A"}],
+      "targets": [
+        {
+          "expr": "up{job=\"cdb_execution\"}",
+          "refId": "A"
+        }
+      ],
       "options": {
-        "reduceOptions": {"values": false, "calcs": ["lastNotNull"]},
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background"
       },
       "fieldConfig": {
@@ -290,13 +506,27 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "red"},
-              {"value": 1, "color": "green"}
+              {
+                "value": 0,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
             ]
           },
           "mappings": [
-            {"type": "value", "value": "0", "text": "DOWN"},
-            {"type": "value", "value": "1", "text": "UP"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "DOWN"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "UP"
+            }
           ]
         }
       }
@@ -305,11 +535,26 @@
       "id": 17,
       "type": "stat",
       "title": "cdb_db_writer",
-      "gridPos": {"h": 4, "w": 3, "x": 18, "y": 8},
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 8
+      },
       "datasource": "Prometheus",
-      "targets": [{"expr": "up{job=\"cdb_db_writer\"}", "refId": "A"}],
+      "targets": [
+        {
+          "expr": "up{job=\"cdb_db_writer\"}",
+          "refId": "A"
+        }
+      ],
       "options": {
-        "reduceOptions": {"values": false, "calcs": ["lastNotNull"]},
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background"
       },
       "fieldConfig": {
@@ -317,13 +562,27 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "red"},
-              {"value": 1, "color": "green"}
+              {
+                "value": 0,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
             ]
           },
           "mappings": [
-            {"type": "value", "value": "0", "text": "DOWN"},
-            {"type": "value", "value": "1", "text": "UP"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "DOWN"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "UP"
+            }
           ]
         }
       }
@@ -332,11 +591,26 @@
       "id": 18,
       "type": "stat",
       "title": "cdb_paper_runner",
-      "gridPos": {"h": 4, "w": 3, "x": 21, "y": 8},
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 8
+      },
       "datasource": "Prometheus",
-      "targets": [{"expr": "up{job=\"cdb_paper_runner\"}", "refId": "A"}],
+      "targets": [
+        {
+          "expr": "up{job=\"cdb_paper_runner\"}",
+          "refId": "A"
+        }
+      ],
       "options": {
-        "reduceOptions": {"values": false, "calcs": ["lastNotNull"]},
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background"
       },
       "fieldConfig": {
@@ -344,13 +618,27 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "red"},
-              {"value": 1, "color": "green"}
+              {
+                "value": 0,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
             ]
           },
           "mappings": [
-            {"type": "value", "value": "0", "text": "DOWN"},
-            {"type": "value", "value": "1", "text": "UP"}
+            {
+              "type": "value",
+              "value": "0",
+              "text": "DOWN"
+            },
+            {
+              "type": "value",
+              "value": "1",
+              "text": "UP"
+            }
           ]
         }
       }
@@ -359,14 +647,24 @@
       "id": 20,
       "type": "row",
       "title": "Container Restart Tracking (72h Timeline)",
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 12},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
       "collapsed": false
     },
     {
       "id": 21,
       "type": "timeseries",
       "title": "CONTAINER RESTARTS OVER TIME (Zero Restart Policy)",
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 13},
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -379,7 +677,10 @@
         "legend": {
           "displayMode": "table",
           "placement": "right",
-          "calcs": ["max", "last"]
+          "calcs": [
+            "max",
+            "last"
+          ]
         }
       },
       "fieldConfig": {
@@ -392,8 +693,14 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "green"},
-              {"value": 1, "color": "red"}
+              {
+                "value": 0,
+                "color": "green"
+              },
+              {
+                "value": 1,
+                "color": "red"
+              }
             ]
           },
           "unit": "none",
@@ -405,14 +712,24 @@
       "id": 30,
       "type": "row",
       "title": "Resource Usage (Memory Leak Detection)",
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 21},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
       "collapsed": false
     },
     {
       "id": 31,
       "type": "timeseries",
       "title": "MEMORY USAGE % (Threshold: 80%)",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 22},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -425,7 +742,11 @@
         "legend": {
           "displayMode": "table",
           "placement": "right",
-          "calcs": ["mean", "max", "last"]
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ]
         }
       },
       "fieldConfig": {
@@ -433,9 +754,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "green"},
-              {"value": 80, "color": "yellow"},
-              {"value": 90, "color": "red"}
+              {
+                "value": 0,
+                "color": "green"
+              },
+              {
+                "value": 80,
+                "color": "yellow"
+              },
+              {
+                "value": 90,
+                "color": "red"
+              }
             ]
           },
           "unit": "percent",
@@ -444,7 +774,10 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byFrameRefID", "options": "A"},
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
             "properties": [
               {
                 "id": "custom.lineWidth",
@@ -459,7 +792,12 @@
       "id": 32,
       "type": "timeseries",
       "title": "CPU USAGE %",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 22},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -472,7 +810,11 @@
         "legend": {
           "displayMode": "table",
           "placement": "right",
-          "calcs": ["mean", "max", "last"]
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ]
         }
       },
       "fieldConfig": {
@@ -480,9 +822,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "green"},
-              {"value": 50, "color": "yellow"},
-              {"value": 80, "color": "red"}
+              {
+                "value": 0,
+                "color": "green"
+              },
+              {
+                "value": 50,
+                "color": "yellow"
+              },
+              {
+                "value": 80,
+                "color": "red"
+              }
             ]
           },
           "unit": "percent",
@@ -494,14 +845,24 @@
       "id": 40,
       "type": "row",
       "title": "Business Metrics (Pipeline Health)",
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 30},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
       "collapsed": false
     },
     {
       "id": 41,
       "type": "timeseries",
       "title": "ORDERS GENERATED (per hour)",
-      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 31},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -515,8 +876,14 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "red"},
-              {"value": 1, "color": "green"}
+              {
+                "value": 0,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
             ]
           },
           "unit": "none",
@@ -528,7 +895,12 @@
       "id": 42,
       "type": "timeseries",
       "title": "SIGNALS GENERATED (per hour)",
-      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 31},
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -542,8 +914,14 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"value": 0, "color": "red"},
-              {"value": 1, "color": "green"}
+              {
+                "value": 0,
+                "color": "red"
+              },
+              {
+                "value": 1,
+                "color": "green"
+              }
             ]
           },
           "unit": "none",

--- a/infrastructure/monitoring/grafana/dashboards/claire_system_performance_v1.json
+++ b/infrastructure/monitoring/grafana/dashboards/claire_system_performance_v1.json
@@ -1,8 +1,14 @@
 {
   "uid": "claire_system_v1",
   "title": "Claire - System Performance",
-  "description": "Complete system monitoring - CPU, Memory, Services, Health - Yellow/Orange/Black theme",
-  "tags": ["claire", "system", "performance", "monitoring"],
+  "description": "ARCHIVED (legacy dashboard). Complete system monitoring - CPU, Memory, Services, Health - Yellow/Orange/Black theme",
+  "tags": [
+    "claire",
+    "system",
+    "performance",
+    "monitoring",
+    "legacy"
+  ],
   "timezone": "browser",
   "editable": true,
   "graphTooltip": 1,
@@ -11,7 +17,12 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m"]
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m"
+    ]
   },
   "style": "dark",
   "panels": [
@@ -19,7 +30,12 @@
       "id": 1,
       "type": "stat",
       "title": "SERVICES UP",
-      "gridPos": {"h": 5, "w": 4, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -29,14 +45,28 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#ea580c", "value": 1},
-              {"color": "#d97706", "value": 3},
-              {"color": "#f59e0b", "value": 4}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#ea580c",
+                "value": 1
+              },
+              {
+                "color": "#d97706",
+                "value": 3
+              },
+              {
+                "color": "#f59e0b",
+                "value": 4
+              }
             ]
           }
         }
@@ -51,7 +81,12 @@
       "id": 2,
       "type": "stat",
       "title": "SIGNAL ENGINE",
-      "gridPos": {"h": 5, "w": 5, "x": 4, "y": 0},
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 4,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -61,21 +96,37 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
             {
               "type": "value",
               "options": {
-                "0": {"color": "#0a0a0a", "index": 0, "text": "DOWN"},
-                "1": {"color": "#d97706", "index": 1, "text": "UP"}
+                "0": {
+                  "color": "#0a0a0a",
+                  "index": 0,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "#d97706",
+                  "index": 1,
+                  "text": "UP"
+                }
               }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#d97706", "value": 1}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#d97706",
+                "value": 1
+              }
             ]
           }
         }
@@ -90,7 +141,12 @@
       "id": 3,
       "type": "stat",
       "title": "RISK MANAGER",
-      "gridPos": {"h": 5, "w": 5, "x": 9, "y": 0},
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 9,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -100,21 +156,37 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
             {
               "type": "value",
               "options": {
-                "0": {"color": "#0a0a0a", "index": 0, "text": "DOWN"},
-                "1": {"color": "#d97706", "index": 1, "text": "UP"}
+                "0": {
+                  "color": "#0a0a0a",
+                  "index": 0,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "#d97706",
+                  "index": 1,
+                  "text": "UP"
+                }
               }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#d97706", "value": 1}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#d97706",
+                "value": 1
+              }
             ]
           }
         }
@@ -129,7 +201,12 @@
       "id": 4,
       "type": "stat",
       "title": "EXECUTION",
-      "gridPos": {"h": 5, "w": 5, "x": 14, "y": 0},
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 14,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -139,21 +216,37 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
             {
               "type": "value",
               "options": {
-                "0": {"color": "#0a0a0a", "index": 0, "text": "DOWN"},
-                "1": {"color": "#d97706", "index": 1, "text": "UP"}
+                "0": {
+                  "color": "#0a0a0a",
+                  "index": 0,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "#d97706",
+                  "index": 1,
+                  "text": "UP"
+                }
               }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#d97706", "value": 1}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#d97706",
+                "value": 1
+              }
             ]
           }
         }
@@ -168,7 +261,12 @@
       "id": 5,
       "type": "stat",
       "title": "PROMETHEUS",
-      "gridPos": {"h": 5, "w": 5, "x": 19, "y": 0},
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 19,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -178,21 +276,37 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
             {
               "type": "value",
               "options": {
-                "0": {"color": "#0a0a0a", "index": 0, "text": "DOWN"},
-                "1": {"color": "#d97706", "index": 1, "text": "UP"}
+                "0": {
+                  "color": "#0a0a0a",
+                  "index": 0,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "#d97706",
+                  "index": 1,
+                  "text": "UP"
+                }
               }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#d97706", "value": 1}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#d97706",
+                "value": 1
+              }
             ]
           }
         }
@@ -207,7 +321,12 @@
       "id": 6,
       "type": "timeseries",
       "title": "CPU USAGE (Go Runtime)",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 5},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -218,7 +337,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "smooth",
@@ -234,15 +355,26 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byRegexp", "options": "/cdb_.*/"},
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/cdb_.*/"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#f59e0b"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#f59e0b"
+                }
+              }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": {"mode": "multi"},
+        "tooltip": {
+          "mode": "multi"
+        },
         "legend": {
           "displayMode": "list",
           "placement": "bottom"
@@ -253,7 +385,12 @@
       "id": 7,
       "type": "timeseries",
       "title": "MEMORY USAGE (RSS)",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 5},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -264,7 +401,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "smooth",
@@ -278,15 +417,26 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byRegexp", "options": "/cdb_.*/"},
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/cdb_.*/"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#fbbf24"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#fbbf24"
+                }
+              }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": {"mode": "multi"},
+        "tooltip": {
+          "mode": "multi"
+        },
         "legend": {
           "displayMode": "list",
           "placement": "bottom"
@@ -297,7 +447,12 @@
       "id": 8,
       "type": "timeseries",
       "title": "GOROUTINES (Concurrency Load)",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 13},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -308,7 +463,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "smooth",
@@ -323,29 +480,58 @@
           {
             "matcher": {"id": "byName", "options": "cdb_signal"},
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#d97706"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#d97706"
+                }
+              }
             ]
           },
           {
-            "matcher": {"id": "byName", "options": "cdb_risk"},
+            "matcher": {
+              "id": "byName",
+              "options": "cdb_risk"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#f59e0b"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#f59e0b"
+                }
+              }
             ]
           },
           {
-            "matcher": {"id": "byName", "options": "cdb_execution"},
+            "matcher": {
+              "id": "byName",
+              "options": "cdb_execution"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#fbbf24"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#fbbf24"
+                }
+              }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": {"mode": "multi"},
+        "tooltip": {
+          "mode": "multi"
+        },
         "legend": {
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": ["last", "max"]
+          "calcs": [
+            "last",
+            "max"
+          ]
         }
       }
     },
@@ -353,7 +539,12 @@
       "id": 9,
       "type": "timeseries",
       "title": "HTTP REQUEST RATE",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 13},
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -364,7 +555,9 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "bars",
             "barAlignment": 0,
@@ -376,15 +569,26 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byRegexp", "options": "/cdb_.*/"},
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/cdb_.*/"
+            },
             "properties": [
-              {"id": "color", "value": {"mode": "fixed", "fixedColor": "#ea580c"}}
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#ea580c"
+                }
+              }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": {"mode": "multi"},
+        "tooltip": {
+          "mode": "multi"
+        },
         "legend": {
           "displayMode": "list",
           "placement": "bottom"
@@ -395,7 +599,12 @@
       "id": 10,
       "type": "bargauge",
       "title": "SERVICE UPTIME",
-      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 21},
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -406,16 +615,33 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "s",
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#ea580c", "value": 60},
-              {"color": "#d97706", "value": 300},
-              {"color": "#f59e0b", "value": 3600},
-              {"color": "#fbbf24", "value": 86400}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#ea580c",
+                "value": 60
+              },
+              {
+                "color": "#d97706",
+                "value": 300
+              },
+              {
+                "color": "#f59e0b",
+                "value": 3600
+              },
+              {
+                "color": "#fbbf24",
+                "value": 86400
+              }
             ]
           }
         }
@@ -430,7 +656,12 @@
       "id": 11,
       "type": "stat",
       "title": "TOTAL METRICS SCRAPED",
-      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 21},
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -440,12 +671,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "#0a0a0a", "value": null},
-              {"color": "#d97706", "value": 1}
+              {
+                "color": "#0a0a0a",
+                "value": null
+              },
+              {
+                "color": "#d97706",
+                "value": 1
+              }
             ]
           }
         }
@@ -461,7 +700,12 @@
       "id": 12,
       "type": "table",
       "title": "SERVICE HEALTH OVERVIEW",
-      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 31},
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -480,7 +724,10 @@
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "Value"},
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
             "properties": [
               {
                 "id": "custom.displayMode",
@@ -492,8 +739,16 @@
                   {
                     "type": "value",
                     "options": {
-                      "0": {"color": "#0a0a0a", "index": 0, "text": "DOWN"},
-                      "1": {"color": "#d97706", "index": 1, "text": "UP"}
+                      "0": {
+                        "color": "#0a0a0a",
+                        "index": 0,
+                        "text": "DOWN"
+                      },
+                      "1": {
+                        "color": "#d97706",
+                        "index": 1,
+                        "text": "UP"
+                      }
                     }
                   }
                 ]

--- a/infrastructure/monitoring/grafana/dashboards/risk_decision_accounting.json
+++ b/infrastructure/monitoring/grafana/dashboards/risk_decision_accounting.json
@@ -2,7 +2,7 @@
   "annotations": {
     "list": []
   },
-  "description": "Risk Manager - Complete decision accounting with signals_received, approved, blocked, skipped metrics",
+  "description": "ARCHIVED (legacy dashboard). Risk Manager - Complete decision accounting with signals_received, approved, blocked, skipped metrics",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -512,7 +512,8 @@
   "tags": [
     "claire",
     "risk",
-    "accounting"
+    "accounting",
+    "legacy"
   ],
   "templating": {
     "list": []

--- a/infrastructure/monitoring/grafana/dashboards/signals_sprint1.json
+++ b/infrastructure/monitoring/grafana/dashboards/signals_sprint1.json
@@ -510,7 +510,8 @@
   "tags": [
     "signals",
     "observability",
-    "sprint1"
+    "sprint1",
+    "legacy"
   ],
   "templating": {
     "list": []
@@ -521,8 +522,9 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Signals - Observability (Sprint 1)",
+  "title": "[LEGACY] [LEGACY] Signals - Observability (Sprint 1)",
   "uid": "signals-sprint1",
   "version": 1,
-  "weekStart": ""
+  "weekStart": "",
+  "description": "ARCHIVED (legacy dashboard)."
 }


### PR DESCRIPTION
Refs #656\n\n- add owner cockpit dashboards (System/Health, Money/Result)\n- mark legacy dashboards as [LEGACY] + legacy tag (no deletions)

## Summary by Sourcery

Introduce owner cockpit Grafana dashboards and mark existing dashboards as legacy for archival while keeping them available.

New Features:
- Add owner cockpit system health Grafana dashboard.
- Add owner cockpit money/result Grafana dashboard.

Enhancements:
- Tag existing Grafana dashboards as legacy to distinguish them from the new owner-focused views.