### PR TITLE
mcp: fix time server deps + ci smoke (#432)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,6 +176,8 @@ jobs:
           else
             pip install mypy
           fi
+      - name: MCP Time smoke
+        run: python -m mcp_server_time --help
 
       - name: Run mypy
         run: mypy services/ --ignore-missing-imports --no-strict-optional

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,15 +1,17 @@
 {
   "mcpServers": {
     "grafana": {
+      "enabled": true,
       "command": "cmd",
       "args": ["/c", "npx", "-y", "@leval/mcp-grafana"],
       "env": {
         "GRAFANA_URL": "http://localhost:3000",
-        "GRAFANA_SERVICE_ACCOUNT_TOKEN": "glsa_kiNdufwm7SCnbGhtAPKma0gltXXUkYd4_d98916f0"
+        "GRAFANA_SERVICE_ACCOUNT_TOKEN": "${GRAFANA_SERVICE_ACCOUNT_TOKEN}"
       },
       "type": "stdio"
     },
     "postgres": {
+      "enabled": true,
       "command": "cmd",
       "args": [
         "/c",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,3 +34,4 @@ tabulate==0.9.0
 
 # Utilities
 python-dotenv==1.2.1
+mcp-server-time==2026.1.26


### PR DESCRIPTION
## Summary
- add mcp-server-time to dev deps so time MCP can start
- smoke-check time MCP in CI (python -m mcp_server_time --help)
- align .mcp.json to env token (no hardcoded Grafana token)

## Test Evidence
- Local: python -m mcp_server_time --help (ok)
- Local: pwsh -File D:\Dev\Config\MCP\mcp-healthcheck.ps1 (PASS 3/3 required)

## Documentation
- n/a

Refs #432