### PR TITLE
feat: add SurrealDB sidecar compose stack

### DIFF
--- a/infrastructure/compose/COMPOSE_LAYERS.md
+++ b/infrastructure/compose/COMPOSE_LAYERS.md
@@ -50,6 +50,13 @@ The Claire de Binare stack uses a **multi-layer compose architecture** to separa
   - Generated dynamically by `stack_rollback.ps1`
   - Not committed to Git
 
+### Standalone Stacks
+- **`infrastructure/compose/surrealdb.yml`** - SurrealDB sidecar stack (cdb_database)
+  - Joins existing `cdb_network` from base stack (external)
+  - No port bindings by default
+  - Use `surrealdb-dev.yml` for localhost-only ports
+  - Requires secrets via `SECRETS_PATH/SURREALDB_ENV`
+
 ## Legacy Files (Deprecated - Do Not Use)
 
 ### ⚠️ `docker-compose.base.yml`

--- a/infrastructure/compose/README.md
+++ b/infrastructure/compose/README.md
@@ -9,6 +9,8 @@ infrastructure/compose/
 ├── base.yml    # Core Infrastructure (Redis, Postgres, Prometheus, Grafana)
 ├── dev.yml     # Dev Overrides (Port-Bindings, Debug-Volumes)
 ├── prod.yml    # Prod Overrides (Resource-Limits, Security)
+├── surrealdb.yml     # SurrealDB sidecar stack (cdb_database)
+├── surrealdb-dev.yml # SurrealDB dev ports (localhost only)
 └── README.md   # Diese Datei
 ```
 
@@ -27,6 +29,11 @@ docker compose -f infrastructure/compose/base.yml -f infrastructure/compose/prod
 ### Legacy (Fallback)
 ```bash
 docker compose up -d  # Nutzt root-level docker-compose.yml
+```
+
+### SurrealDB Sidecar (Standalone)
+```bash
+docker compose -f infrastructure/compose/surrealdb.yml -f infrastructure/compose/surrealdb-dev.yml up -d
 ```
 
 ## Governance-Compliance

--- a/infrastructure/compose/surrealdb-dev.yml
+++ b/infrastructure/compose/surrealdb-dev.yml
@@ -1,0 +1,8 @@
+# SurrealDB Dev Overlay
+# Localhost-only port bindings for development
+# Usage: docker compose -f infrastructure/compose/surrealdb.yml -f infrastructure/compose/surrealdb-dev.yml up -d
+
+services:
+  cdb_surrealdb:
+    ports:
+      - "127.0.0.1:8000:8000"

--- a/infrastructure/compose/surrealdb.yml
+++ b/infrastructure/compose/surrealdb.yml
@@ -1,0 +1,46 @@
+# SurrealDB Sidecar Stack (cdb_database)
+# Standalone compose spec for SurrealDB sidecar (read-mostly)
+# Usage:
+#   docker compose -f infrastructure/compose/surrealdb.yml -f infrastructure/compose/surrealdb-dev.yml up -d
+#
+# REQUIREMENTS:
+# - Joins existing cdb_network created by base stack
+# - Secrets loaded via env_file (no plaintext in compose)
+# - No port bindings in base (dev-only overlay adds localhost ports)
+#
+# ENV:
+#   SECRETS_PATH=/path/to/.secrets/.cdb
+#   CDB_NETWORK_NAME=cdb_cdb_network  (override if STACK_NAME differs)
+#   SURREALDB_ENV file content (outside git):
+#     SURREAL_USER=...
+#     SURREAL_PASS=...
+
+name: ${STACK_NAME:-cdb_database}
+
+services:
+  cdb_surrealdb:
+    image: surrealdb/surrealdb:latest
+    container_name: cdb_surrealdb
+    restart: unless-stopped
+    env_file:
+      - ${SECRETS_PATH}/SURREALDB_ENV
+    command: ["sh", "-c", "surreal start --log info --user \"$SURREAL_USER\" --pass \"$SURREAL_PASS\" --bind 0.0.0.0:8000 file:/data/surrealdb"]
+    volumes:
+      - surrealdb_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/health > /dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
+    networks:
+      - cdb_network
+
+volumes:
+  surrealdb_data:
+    driver: local
+
+networks:
+  cdb_network:
+    external: true
+    name: ${CDB_NETWORK_NAME:-cdb_cdb_network}


### PR DESCRIPTION
## Summary
- add SurrealDB sidecar compose stack (cdb_database)
- add dev overlay with localhost-only ports
- document new standalone stack in compose docs

## Rollback
- remove `infrastructure/compose/surrealdb.yml`
- remove `infrastructure/compose/surrealdb-dev.yml`
- revert compose documentation updates

## Summary by Sourcery

Add a standalone SurrealDB sidecar compose stack with a dev-only overlay and document how to run it.

New Features:
- Introduce a standalone SurrealDB sidecar Docker Compose stack that joins the existing base network without exposing ports by default.
- Add a SurrealDB dev overlay compose file that exposes localhost-only ports for development usage.

Documentation:
- Document the SurrealDB standalone stack and dev overlay in the compose layer and usage documentation, including example run commands.