### PR TITLE
docs: add SurrealDB data ownership matrix

### DIFF
--- a/docs/surrealdb/data-ownership-matrix.md
+++ b/docs/surrealdb/data-ownership-matrix.md
@@ -37,3 +37,4 @@ Postgres remains the single source of truth for all trading state.
 
 - This matrix is tracked in Git; any change requires PR review.
 - SurrealDB mirrors must reference Git commit hashes for traceability.
+- Machine-readable version: `infrastructure/config/surrealdb/ownership.yaml`

--- a/infrastructure/config/surrealdb/ownership.yaml
+++ b/infrastructure/config/surrealdb/ownership.yaml
@@ -1,0 +1,49 @@
+version: 1
+domains:
+  trading_state:
+    canonical: postgres
+    surrealdb: none
+    writers:
+      - trading_services
+    readers:
+      - trading_pipeline
+    notes: "Orders, positions, risk, fills stay in Postgres only."
+  governance_docs:
+    canonical: git_docs_hub
+    surrealdb: mirror_read_only
+    writers:
+      - docs_owners
+    readers:
+      - governance_queries
+    notes: "SurrealDB mirrors Git; no direct edits."
+  decision_events:
+    canonical: git_ledger
+    surrealdb: append_only_mirror
+    writers:
+      - agents_via_ledger
+    readers:
+      - audit_analytics
+    notes: "SurrealDB ingest only; no edits."
+  shared_memory:
+    canonical: surrealdb
+    surrealdb: primary_scoped
+    writers:
+      - agents_scoped
+    readers:
+      - agents
+    notes: "Scoped by namespace + TTL."
+  observability_metrics:
+    canonical: prometheus_grafana
+    surrealdb: none
+    writers:
+      - observability_stack
+    readers:
+      - ops_dashboards
+    notes: "Metrics stay in Prometheus/Grafana."
+drift_rules:
+  - id: doc_hash_missing
+    description: "SurrealDB doc nodes must include Git hash reference."
+  - id: ledger_link_missing
+    description: "SurrealDB decision events must reference ledger source + event id."
+  - id: trading_state_in_surrealdb
+    description: "Any trading-state record in SurrealDB is invalid."


### PR DESCRIPTION
## Summary
- add SurrealDB data ownership matrix (Postgres vs Git vs SurrealDB)
- document write permissions, read patterns, drift checks

## Rollback
- remove docs/surrealdb/data-ownership-matrix.md

## Summary by Sourcery

Define and document the SurrealDB data ownership model across core data domains, including sources of truth, SurrealDB’s role, and auditability rules.

New Features:
- Introduce a machine-readable SurrealDB ownership matrix configuration describing canonical data sources, SurrealDB roles, and drift rules for key domains.
- Add user-facing documentation outlining the SurrealDB data ownership matrix, write permissions, read patterns, and audit requirements.

Enhancements:
- Clarify cross-system data responsibilities between Postgres, Git-based stores, SurrealDB, and observability tooling to prevent misuse of SurrealDB as a trading-state source.