### PR TITLE
docs: add SurrealDB mirror strategy

### DIFF
--- a/docs/surrealdb/dual-write-mirror-strategy.md
+++ b/docs/surrealdb/dual-write-mirror-strategy.md
@@ -1,0 +1,50 @@
+# SurrealDB Dual-Write / Mirror Strategy (P0)
+
+SurrealDB is a **read-only mirror** for governance/doc/ledger data. Postgres remains the
+single source of truth for trading state. The mirror must **never** block trading flows.
+
+## Write Pattern (Postgres-first)
+
+1. **Primary write** to canonical source:
+   - Governance docs/policies: Git (Docs Hub)
+   - Decision events/evidence: Git ledger
+2. **Mirror write** to SurrealDB (async by default):
+   - Append-only ingestion, no updates-in-place unless idempotent
+3. **Failure handling**:
+   - SurrealDB lag or failure must **not** block primary writes
+   - Mirror retries are queued and can be replayed
+
+## Read-Only Boundaries
+
+- Trading pipeline **never** writes to SurrealDB.
+- SurrealDB endpoints are used by **read-only** governance queries.
+- No bidirectional writes; SurrealDB is a **sink**.
+
+## Data Contract (What Mirrors)
+
+**Included (mirror/append-only):**
+- Governance docs snapshots
+- Policy snapshots
+- Ledger decision events
+- Evidence references (hash + path)
+
+**Excluded (never mirrored):**
+- Orders, positions, risk state, fills
+- Live trading state
+
+## Idempotence Rules
+
+- Mirror records must include a **source id**:
+  - Git commit hash + document path
+  - Ledger event id + file path
+- Re-import of the same source id must be a **no-op**.
+
+## Operational Guardrails
+
+- Mirror write failures are logged and retried; they do not block primary writes.
+- SurrealDB is append-only; deletes are prohibited.
+- Drift detection compares SurrealDB hashes vs Git hashes.
+
+## Machine-Readable Spec
+
+- `infrastructure/config/surrealdb/mirror-strategy.yaml`

--- a/infrastructure/config/surrealdb/mirror-strategy.yaml
+++ b/infrastructure/config/surrealdb/mirror-strategy.yaml
@@ -1,0 +1,31 @@
+version: 1
+mode: async_mirror
+primary_sources:
+  governance_docs: git_docs_hub
+  policies: git_docs_hub
+  ledger_events: git_ledger
+mirror_targets:
+  surrealdb:
+    write_policy: append_only
+    trading_state: disabled
+data_contract:
+  include:
+    - governance_docs
+    - policies
+    - ledger_events
+    - evidence_refs
+  exclude:
+    - orders
+    - positions
+    - risk_state
+    - fills
+idempotence:
+  source_id_fields:
+    - git_commit
+    - source_path
+    - ledger_event_id
+failure_handling:
+  block_primary_writes: false
+  retry_policy: queued_replay
+access:
+  write_endpoints: read_only_from_trading


### PR DESCRIPTION
## Summary
- document SurrealDB dual-write/mirror strategy
- add machine-readable mirror strategy config

## Rollback
- remove docs/surrealdb/dual-write-mirror-strategy.md
- remove infrastructure/config/surrealdb/mirror-strategy.yaml

## Summary by Sourcery

Document the SurrealDB dual-write mirror strategy and add a corresponding machine-readable configuration for infrastructure use.

Deployment:
- Introduce a SurrealDB mirror strategy YAML config to define primary sources, mirror targets, data contract, idempotence, and failure handling for infrastructure tooling.

Documentation:
- Add a SurrealDB dual-write/mirror strategy document clarifying read-only usage, data contracts, and operational guardrails.