### PR TITLE
\ feat: add shadow/soak evidence workflow\

### DIFF
--- a/.github/workflows/shadow-soak-evidence.yml
+++ b/.github/workflows/shadow-soak-evidence.yml
@@ -152,7 +152,7 @@ jobs:
             url="$2"
             ext="$3"
             out="evidence/endpoints/${name}.${ext}"
-            if ! curl -fsS "$url" -o "$out"; then
+            if ! curl --connect-timeout 5 --max-time 15 -fsS "$url" -o "$out"; then
               echo "Endpoint check failed: $name ($url)"
               exit 1
             fi


### PR DESCRIPTION
﻿## Summary
- add Shadow + Soak evidence workflow (dispatch + nightly)
- run compose stack in deterministic stub mode and capture artifacts

## Testing
- not run (workflow only)

## Rollback
- remove .github/workflows/shadow-soak-evidence.yml

Refs: #639 #637 #635

## Summary by Sourcery

Add a scheduled and manually-triggerable GitHub Actions workflow to run a deterministic shadow/soak environment and collect diagnostic artifacts.

New Features:
- Introduce a Shadow + Soak Evidence workflow that spins up the compose stack in deterministic stub mode on a schedule or via manual dispatch and performs a timed soak.

Enhancements:
- Capture health checks, container state, logs, and run metadata as short-retention artifacts after each shadow/soak run for observability.