### PR TITLE
\ chore: fix shadow/soak CI secrets access\

### DIFF
--- a/.github/workflows/shadow-soak-evidence.yml
+++ b/.github/workflows/shadow-soak-evidence.yml
@@ -62,19 +62,37 @@ jobs:
           override_file="$RUNNER_TEMP/shadow-soak-override.yml"
           cat > "$override_file" <<'EOF'
           services:
+            cdb_grafana:
+              user: "0"
             cdb_ws:
+              user: "0"
               environment:
                 WS_SOURCE: stub
             cdb_signal:
+              user: "0"
               environment:
                 SIGNAL_STRATEGY_ID: paper
+            cdb_candles:
+              user: "0"
+            cdb_allocation:
+              user: "0"
+            cdb_regime:
+              user: "0"
+            cdb_risk:
+              user: "0"
             cdb_execution:
+              user: "0"
               environment:
                 MOCK_TRADING: "true"
                 USE_REAL_BALANCE: "false"
+            cdb_db_writer:
+              user: "0"
             cdb_paper_runner:
+              user: "0"
               environment:
                 PAPER_TRADING_DURATION_DAYS: "1"
+            cdb_reports:
+              profiles: ["ci-disabled"]
           EOF
           echo "OVERRIDE_FILE=$override_file" >> "$GITHUB_ENV"
 
@@ -102,7 +120,6 @@ jobs:
             cdb_regime
             cdb_db_writer
             cdb_paper_runner
-            cdb_reports
           )
           running_services=(
             cdb_risk


### PR DESCRIPTION
﻿## Summary
- run CI shadow/soak services as root to read Docker secrets
- disable cdb_reports in CI profile to avoid missing core module

## Testing
- not run (workflow only)

## Rollback
- revert .github/workflows/shadow-soak-evidence.yml override changes

## Summary by Sourcery

Adjust shadow/soak CI workflow service configuration for Docker secrets access and to disable an unavailable reports service.

CI:
- Run all relevant shadow/soak Docker services as root in CI to allow reading Docker secrets.
- Disable the cdb_reports service in the shadow/soak CI workflow by applying a CI-disabled profile and removing it from the service startup list.