### PR TITLE
\ chore: relax redis exporter health gate\

### DIFF
--- a/.github/workflows/shadow-soak-evidence.yml
+++ b/.github/workflows/shadow-soak-evidence.yml
@@ -112,7 +112,6 @@ jobs:
             cdb_prometheus
             cdb_grafana
             cdb_postgres_exporter
-            cdb_redis_exporter
             cdb_ws
             cdb_signal
             cdb_candles
@@ -122,6 +121,7 @@ jobs:
             cdb_paper_runner
           )
           running_services=(
+            cdb_redis_exporter
             cdb_risk
             cdb_execution
           )


### PR DESCRIPTION
﻿## Summary
- treat redis exporter as running (healthcheck flaky) while keeping endpoint verification

## Testing
- not run (workflow only)

## Rollback
- revert healthy/running lists in .github/workflows/shadow-soak-evidence.yml

## Summary by Sourcery

Enhancements:
- Treat the Redis exporter as a running service rather than a health-gated service in the shadow soak evidence GitHub Actions workflow.