### PR TITLE
fix: relax shadow-soak gate

### DIFF
--- a/.github/workflows/shadow-soak-evidence.yml
+++ b/.github/workflows/shadow-soak-evidence.yml
@@ -116,16 +116,6 @@ jobs:
             cdb_risk
             cdb_execution
           )
-          optional_services=(
-            cdb_postgres_exporter
-            cdb_redis_exporter
-            cdb_candles
-            cdb_allocation
-            cdb_regime
-            cdb_db_writer
-            cdb_paper_runner
-            cdb_reports
-          )
           deadline=$((SECONDS + 300))
           while true; do
             all_ok=1


### PR DESCRIPTION
## Summary\n- split required healthy vs optional running services\n- reduce health gate timeout to 300s\n- write run_summary.md with gate tables\n- optionalize non-critical endpoint checks\n\n## Why\nUnblock after-soak evidence for #639 #637 #635 by avoiding optional service gating.\n\n## Rollback\n- Revert this PR.

## Summary by Sourcery

CI:
- Introduce a Shadow + Soak Evidence workflow that spins up the docker-compose stack with deterministic overrides, runs a timed soak, performs required/optional endpoint checks, and uploads run artifacts including structured summaries.