### PR TITLE
feat(secrets): add --ExportAfter flag to apply command

### DIFF
--- a/tools/secrets/README.md
+++ b/tools/secrets/README.md
@@ -15,11 +15,8 @@ This tool rotates **machine-readable secrets** (DB passwords, Redis, app keys) w
 # Plan what will be rotated
 .\tools\secrets\Rotate-Secrets.ps1 plan
 
-# Apply rotation (auto secrets only)
-.\tools\secrets\Rotate-Secrets.ps1 apply
-
-# Export to .env.runtime
-.\tools\secrets\Rotate-Secrets.ps1 export
+# Apply rotation and auto-export (auto secrets only)
+.\tools\secrets\Rotate-Secrets.ps1 apply -ExportAfter
 
 # Restart stack (auto-loads .env.runtime)
 .\infrastructure\scripts\stack_up.ps1
@@ -52,9 +49,16 @@ Rotates all auto secrets (rotation_mode=auto, exclude_by_default=false) and writ
 
 **Hard-fail protection:** `--IncludeManual` flag is FORBIDDEN and will cause immediate error.
 
+**Flags:**
+- `--ExportAfter` (Alias: `--Export`): Automatically run export after successful rotation
+
 **Example:**
 ```powershell
+# Apply only (manual export needed)
 .\Rotate-Secrets.ps1 apply
+
+# Apply + auto-export (recommended for incidents)
+.\Rotate-Secrets.ps1 apply -ExportAfter
 ```
 
 ### `export`

--- a/tools/secrets/Rotate-Secrets.ps1
+++ b/tools/secrets/Rotate-Secrets.ps1
@@ -24,10 +24,14 @@
 .PARAMETER Force
     Force rotation even if state indicates recent rotation (use with caution)
 
+.PARAMETER ExportAfter
+    Automatically run export after successful apply (Alias: Export)
+
 .EXAMPLE
     .\Rotate-Secrets.ps1 plan
     .\Rotate-Secrets.ps1 apply
     .\Rotate-Secrets.ps1 apply -Force
+    .\Rotate-Secrets.ps1 apply -ExportAfter
     .\Rotate-Secrets.ps1 export
 
 .NOTES
@@ -44,7 +48,10 @@ param(
     [switch]$All,
     [string]$Secret,
     [switch]$IncludeManual,
-    [switch]$Force
+    [switch]$Force,
+
+    [Alias('Export')]
+    [switch]$ExportAfter
 )
 
 Set-StrictMode -Version Latest
@@ -418,15 +425,32 @@ function Invoke-Apply($manifest) {
     # Persist rotation state
     Write-RotationState $state
 
+    # Auto-export if --ExportAfter flag is set
+    if ($ExportAfter) {
+        Write-Info ""
+        Write-Info "Auto-exporting secrets (--ExportAfter flag set)..."
+        try {
+            Invoke-Export $manifest
+        } catch {
+            Write-Error "Export failed: $_"
+            exit 1
+        }
+    }
+
     Write-Section "Apply Complete"
     Write-Success "Rotated: $rotated secrets"
     if ($skipped -gt 0) {
         Write-Info "Skipped: $skipped secrets (fresh, age < $MAX_AGE_DAYS days)"
     }
     Write-Info ""
-    Write-Info "Next steps:"
-    Write-Info "  1. Run 'Rotate-Secrets.ps1 export' to generate .env.runtime"
-    Write-Info "  2. Run 'infrastructure/scripts/stack_up.ps1' to restart stack"
+    if ($ExportAfter) {
+        Write-Info "Next step:"
+        Write-Info "  1. Run 'infrastructure/scripts/stack_up.ps1' to restart stack"
+    } else {
+        Write-Info "Next steps:"
+        Write-Info "  1. Run 'Rotate-Secrets.ps1 export' to generate .env.runtime"
+        Write-Info "  2. Run 'infrastructure/scripts/stack_up.ps1' to restart stack"
+    }
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Streamlines incident response by combining rotation + export in single step.

**New Flag**: `-ExportAfter` (Alias: `-Export`)

## What changed

- **tools/secrets/Rotate-Secrets.ps1**:
  - Added `-ExportAfter` switch parameter (Alias: `-Export`)
  - After successful apply + state-persist: auto-run export if flag set
  - Exit code: export failure = non-zero (fail-closed)
  - Updated help documentation (.PARAMETER + .EXAMPLE)

- **tools/secrets/README.md**:
  - Updated incident flow: `plan → apply -ExportAfter → stack_up`
  - Added flag documentation to `apply` command section
  - Simplified quickstart (removed separate export step)

## Behavior

| Command | Behavior |
|---------|----------|
| `apply` | Unchanged (manual export needed) |
| `apply -ExportAfter` | Auto-exports after rotation |
| `apply -Export` | Same (alias works) |

**Safe Logging**: Export never logs values (only names/lengths) ✅

## Incident Flow (new)

```powershell
.\Rotate-Secrets.ps1 plan
.\Rotate-Secrets.ps1 apply -ExportAfter  # ← combined step
.\infrastructure\scripts\stack_up.ps1
```

## Acceptance Criteria

- ✅ `apply` without flag behaves identically to v1.1
- ✅ `apply -ExportAfter` creates/updates `.env.runtime`
- ✅ Export logs only names/lengths (no values)
- ✅ Smoke test: `plan → apply -ExportAfter -Force → stack_up` passes

## Smoke Test Evidence

```
[INFO] Auto-exporting secrets (--ExportAfter flag set)...
[INFO] Export REDIS_PASSWORD (length: 32)
[INFO] Export POSTGRES_PASSWORD (length: 32)
[INFO] Export POSTGRES_PASSWORD_DSN (length: 32)
[OK]   Created: .env.runtime
```

**Exit Codes**: ✅ Success (0), Export auto-ran, no values logged

## Testing

From repo root:
```powershell
# Test without flag (unchanged behavior)
.\tools\secrets\Rotate-Secrets.ps1 apply

# Test with flag (auto-export)
.\tools\secrets\Rotate-Secrets.ps1 apply -ExportAfter -Force

# Verify .env.runtime created
Test-Path tools/secrets/.env.runtime  # → True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

## Summary by Sourcery

Add an option for the secrets rotation script to automatically export secrets after applying changes and update documentation to reflect the streamlined incident workflow.

New Features:
- Introduce an ExportAfter switch (with Export alias) to the apply command to automatically run export after a successful rotation.

Enhancements:
- Adjust post-apply messaging to reflect whether export was auto-run or still needs to be run manually.

Documentation:
- Update secrets tool README to recommend apply with ExportAfter for incidents and document the new flag and workflow.