### PR TITLE
Fix CI E2E STUB MODE (secrets missing)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -36,14 +36,16 @@ jobs:
           REDIS_VAL="${{ secrets.REDIS_PASSWORD != '' && secrets.REDIS_PASSWORD || 'ci-redis-password' }}"
           POSTGRES_VAL="${{ secrets.POSTGRES_PASSWORD != '' && secrets.POSTGRES_PASSWORD || 'ci-postgres-password' }}"
           GRAFANA_VAL="${{ secrets.GRAFANA_PASSWORD != '' && secrets.GRAFANA_PASSWORD || 'ci-grafana-password' }}"
+          SMTP_HOST_VAL="${{ secrets.SMTP_HOST != '' && secrets.SMTP_HOST || 'smtp.gmail.com:587' }}"
           SMTP_USER_VAL="${{ secrets.SMTP_USER != '' && secrets.SMTP_USER || 'ci-smtp-user' }}"
           SMTP_PASSWORD_VAL="${{ secrets.SMTP_PASSWORD != '' && secrets.SMTP_PASSWORD || 'ci-smtp-password' }}"
           SMTP_FROM_VAL="${{ secrets.SMTP_FROM != '' && secrets.SMTP_FROM || 'ci-smtp-from@example.com' }}"
           ALERT_EMAIL_TO_VAL="${{ secrets.ALERT_EMAIL_TO != '' && secrets.ALERT_EMAIL_TO || 'ci-alert-to@example.com' }}"
           echo "$REDIS_VAL" > $SECRETS_PATH/REDIS_PASSWORD
           echo "$POSTGRES_VAL" > $SECRETS_PATH/POSTGRES_PASSWORD
-          echo "postgresql://claire_user:${POSTGRES_VAL}@postgres:5432/claire?sslmode=disable" > $SECRETS_PATH/POSTGRES_PASSWORD_DSN
+          echo "postgresql://claire_user:${POSTGRES_VAL}@cdb_postgres:5432/claire_de_binare?sslmode=disable" > $SECRETS_PATH/POSTGRES_PASSWORD_DSN
           echo "$GRAFANA_VAL" > $SECRETS_PATH/GRAFANA_PASSWORD
+          echo "$SMTP_HOST_VAL" > $SECRETS_PATH/SMTP_HOST
           echo "$SMTP_USER_VAL" > $SECRETS_PATH/SMTP_USER
           echo "$SMTP_PASSWORD_VAL" > $SECRETS_PATH/SMTP_PASSWORD
           echo "$SMTP_FROM_VAL" > $SECRETS_PATH/SMTP_FROM
@@ -76,12 +78,14 @@ jobs:
           SMTP_USER: ${{ secrets.SMTP_USER }}
           SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
           ALERT_EMAIL_TO: ${{ secrets.ALERT_EMAIL_TO }}
+          MEXC_API_KEY: ${{ secrets.MEXC_API_KEY }}
+          MEXC_API_SECRET: ${{ secrets.MEXC_API_SECRET }}
         run: |
           set -euo pipefail
 
           # Define "real secrets present" condition (adjust names to your repo)
           missing=0
-          req=(SMTP_FROM SMTP_HOST SMTP_USER SMTP_PASSWORD ALERT_EMAIL_TO)
+          req=(SMTP_FROM SMTP_HOST SMTP_USER SMTP_PASSWORD ALERT_EMAIL_TO MEXC_API_KEY MEXC_API_SECRET)
           for k in "${req[@]}"; do
             if [[ -z "${!k:-}" ]]; then missing=1; fi
           done
@@ -123,11 +127,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "SMTP_FROM=ci-stub@example.invalid" >> "$GITHUB_ENV"
-          echo "SMTP_HOST=stub" >> "$GITHUB_ENV"
-          echo "SMTP_USER=stub" >> "$GITHUB_ENV"
-          echo "SMTP_PASSWORD=stub" >> "$GITHUB_ENV"
-          echo "ALERT_EMAIL_TO=ci-stub@example.invalid" >> "$GITHUB_ENV"
+          echo "SMTP_FROM=ci-smtp-from@example.com" >> "$GITHUB_ENV"
+          echo "SMTP_HOST=smtp.gmail.com:587" >> "$GITHUB_ENV"
+          echo "SMTP_USER=ci-smtp-user" >> "$GITHUB_ENV"
+          echo "SMTP_PASSWORD=ci-smtp-password" >> "$GITHUB_ENV"
+          echo "ALERT_EMAIL_TO=ci-alert-to@example.com" >> "$GITHUB_ENV"
+          echo "MEXC_API_KEY=ci-mexc-key" >> "$GITHUB_ENV"
+          echo "MEXC_API_SECRET=ci-mexc-secret" >> "$GITHUB_ENV"
 
       - name: Create issue on protected exception
         if: |
@@ -146,7 +152,7 @@ jobs:
           Run ID: ${GITHUB_RUN_ID}
           Ref: ${GITHUB_REF}
           Event: ${GITHUB_EVENT_NAME}
-          Expected secrets: SMTP_FROM, SMTP_HOST, SMTP_USER, SMTP_PASSWORD, ALERT_EMAIL_TO
+          Expected secrets: SMTP_FROM, SMTP_HOST, SMTP_USER, SMTP_PASSWORD, ALERT_EMAIL_TO, MEXC_API_KEY, MEXC_API_SECRET
 
           Green != Real E2E
           EOF

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -82,7 +82,7 @@ services:
       GF_USERS_ALLOW_SIGN_UP: "false"
       # SMTP Configuration for Email Alerts
       GF_SMTP_ENABLED: "true"
-      GF_SMTP_HOST: smtp.gmail.com:587
+      GF_SMTP_HOST__FILE: /run/secrets/smtp_host
       GF_SMTP_USER__FILE: /run/secrets/smtp_user
       GF_SMTP_PASSWORD__FILE: /run/secrets/smtp_password
       GF_SMTP_FROM_ADDRESS__FILE: /run/secrets/smtp_from
@@ -90,6 +90,7 @@ services:
       GF_SMTP_STARTTLS_POLICY: MandatoryStartTLS
     secrets:
       - grafana_password
+      - smtp_host
       - smtp_user
       - smtp_password
       - smtp_from
@@ -180,6 +181,8 @@ secrets:
     file: ${SECRETS_PATH}/POSTGRES_PASSWORD_DSN
   grafana_password:
     file: ${SECRETS_PATH}/GRAFANA_PASSWORD
+  smtp_host:
+    file: ${SECRETS_PATH}/SMTP_HOST
   smtp_user:
     file: ${SECRETS_PATH}/SMTP_USER
   smtp_password:

--- a/infrastructure/compose/dev.yml
+++ b/infrastructure/compose/dev.yml
@@ -340,6 +340,7 @@ services:
     secrets:
       - postgres_password_dsn
       - postgres_password
+      - smtp_host
       - smtp_user
       - smtp_password
       - smtp_from

--- a/services/reports/daily_orders_summary.py
+++ b/services/reports/daily_orders_summary.py
@@ -219,15 +219,17 @@ def format_email_body(data, start_time, end_time):
 def send_email(subject, body_html):
     """Send email via SMTP using Docker secrets"""
     try:
-        # Read SMTP config from secrets
-        smtp_host = "smtp.gmail.com:587"
+        # Read SMTP config from secrets or environment
+        smtp_host = read_secret("/run/secrets/smtp_host") or os.getenv(
+            "SMTP_HOST", "smtp.gmail.com:587"
+        )
         smtp_user = read_secret("/run/secrets/smtp_user")
         smtp_password = read_secret("/run/secrets/smtp_password")
         from_address = read_secret("/run/secrets/smtp_from")
         to_address = read_secret("/run/secrets/alert_email_to")
 
         if not all([smtp_user, smtp_password, from_address, to_address]):
-            print("[ERROR] Missing SMTP credentials")
+            print(f"[ERROR] Missing SMTP credentials (host: {smtp_host})")
             return False
 
         # Create message


### PR DESCRIPTION
This PR fixes the CI E2E pipeline failure by resolving issues with missing secrets and incorrect stubs.

Specifically:
- It adds `SMTP_HOST` to the CI secrets setup and ensures it's treated as a secret throughout the infrastructure.
- It corrects the `POSTGRES_PASSWORD_DSN` which used an incorrect database name and host.
- It ensures that `MEXC_API_KEY` and `MEXC_API_SECRET` are checked when deciding whether to run in `REAL` or `STUB` mode, preventing false-positive "REAL" runs.
- It updates the `daily_orders_summary` report service to read its SMTP host dynamically.

These changes prevent the pipeline from incorrectly falling back to `STUB` mode on `main` and ensures that all services have the necessary credentials to function correctly in both real and stubbed environments.

---
*PR created automatically by Jules for task [7233041125478409525](https://jules.google.com/task/7233041125478409525) started by @jannekbuengener*