### PR TITLE
Add task suggestions report from codebase review

### DIFF
--- a/docs/task_suggestions.md
+++ b/docs/task_suggestions.md
@@ -1,0 +1,6 @@
+# Task-Vorschläge (Codebasis-Review)
+
+1. **Tippfehler beheben:** In `cdb_agent_sdk/README.md` steht die Überschrift "Programmatisch mit Options". Korrektur auf "Programmatisch mit Optionen".
+2. **Programmierfehler beheben:** In `core/domain/models.py` und `services/risk/models.py` setzt `Signal.__post_init__` `side = direction`, wodurch bei `direction="LONG"` ein ungültiger `side`-Wert entsteht. Korrigieren durch Normalisierung/Mapping auf `BUY`/`SELL` oder keine Übernahme.
+3. **Kommentar/Dokumentation konsistent machen:** `PROJECT_STATUS.md` beschreibt den Market Service als "PRODUCTION-READY", während `services/market/service.py` als STUB/TEMPLATE markiert ist. Status aktualisieren oder Implementation nachziehen.
+4. **Test verbessern:** `tests/unit/market/test_service.py` enthält ausschließlich `@pytest.mark.skip`-Platzhalter. Task: Implementiere mindestens einen echten Unit-Test (z. B. Health-Endpoint oder Konfig-Validierung).


### PR DESCRIPTION
### Motivation
- Capture concrete, actionable issues found during a deterministic codebase review: a README typo, a potential model bug in `Signal.__post_init__`, a docs/implementation inconsistency for the Market service, and placeholder-only unit tests that need improvement.

### Description
- Add `docs/task_suggestions.md` with four short, merge-ready tasks: fix the README heading typo, correct `Signal.__post_init__` behavior in `core/domain/models.py` and `services/risk/models.py`, reconcile `PROJECT_STATUS.md` with `services/market/service.py`, and replace skipped placeholder tests in `tests/unit/market/test_service.py` with at least one real unit test.

### Testing
- No automated tests were executed as part of this change; the PR only adds a documentation file describing follow-up code and test tasks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ce4945ed88333bcaf46b56e239c8b)

## Summary by Sourcery

Documentation:
- Document four concrete follow-up tasks covering a README typo, a potential Signal model bug, an inconsistency between market service docs and implementation status, and missing unit tests for the market service.