### PR TITLE
feat(governance): add risk_events schema drift guard + CI integration

### DIFF
--- a/.github/workflows/core-guard.yml
+++ b/.github/workflows/core-guard.yml
@@ -27,17 +27,25 @@ jobs:
       - name: Run Core Guard Check
         run: python scripts/check_core_duplicates.py
 
+      - name: Run Schema Contract Check
+        run: python scripts/governance/check_risk_events_schema_contract.py
+
       - name: Summary
         if: always()
         run: |
           if [ $? -eq 0 ]; then
             echo "✅ Core Guard check passed"
+            echo "✅ Schema Contract check passed"
           else
             echo "❌ Core Guard check failed"
             echo ""
             echo "Core Guard detects:"
             echo "1. Duplicate core/ directories in services/*"
             echo "2. Additional secrets.py files (only core/domain/secrets.py is allowed)"
+            echo ""
+            echo "Schema Contract detects drift between:"
+            echo "1. services/risk/service.py INSERT statement"
+            echo "2. knowledge/governance/risk_events.schema.yaml"
             echo ""
             echo "Fix violations before merging."
           fi

--- a/.github/workflows/core-guard.yml
+++ b/.github/workflows/core-guard.yml
@@ -19,6 +19,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Checkout Docs Repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: jannekbuengener/Claire_de_Binare_Docs
+          path: Claire_de_Binare_Docs
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/docs/governance/risk_events.schema.yaml
+++ b/docs/governance/risk_events.schema.yaml
@@ -1,0 +1,86 @@
+version: 1.0
+title: "risk_events Table Schema Contract"
+description: "Canonical schema definition for risk_events audit table. Derived from code contract, not assumed."
+
+source:
+  code_file: "services/risk/service.py"
+  code_lines: "377-388"
+  last_verified: "2026-02-09T15:52:00+01:00"
+
+table: "risk_events"
+
+required:
+  - id
+  - timestamp_ms
+  - symbol
+  - decision
+  - created_at
+
+fields:
+  id:
+    type: "SERIAL"
+    constraints: "PRIMARY KEY"
+    description: "Auto-incrementing unique identifier"
+
+  timestamp_ms:
+    type: "BIGINT"
+    nullable: false
+    description: "Unix timestamp in milliseconds (event time)"
+
+  symbol:
+    type: "VARCHAR"
+    max_length: 20
+    nullable: false
+    description: "Trading pair symbol (e.g., BTCUSDT)"
+
+  decision:
+    type: "VARCHAR"
+    max_length: 10
+    nullable: false
+    description: "Risk decision outcome (BLOCK, APPROVED)"
+
+  reason_code:
+    type: "VARCHAR"
+    max_length: 20
+    nullable: true
+    description: "Decision contract reason code (e.g., RC_002)"
+
+  contract_version:
+    type: "VARCHAR"
+    max_length: 50
+    nullable: true
+    description: "Decision contract version identifier"
+
+  payload:
+    type: "JSONB"
+    nullable: true
+    description: "Full event payload (JSON)"
+
+  created_at:
+    type: "TIMESTAMPTZ"
+    nullable: false
+    default: "NOW()"
+    description: "Record creation timestamp"
+
+indexes:
+  - name: "idx_risk_events_timestamp_ms"
+    columns: ["timestamp_ms"]
+    order: "DESC"
+
+  - name: "idx_risk_events_symbol"
+    columns: ["symbol"]
+
+insert_columns:
+  # Columns used in INSERT statement (order matters)
+  - timestamp_ms
+  - symbol
+  - decision
+  - reason_code
+  - contract_version
+  - payload
+
+notes: |
+  - Spec derived from actual INSERT statement in services/risk/service.py
+  - Column order in insert_columns MUST match code expectations
+  - VARCHAR lengths verified from P0 fix (2026-02-09)
+  - contract_version increased from 10 to 50 chars after initial failure

--- a/scripts/governance/check_risk_events_schema_contract.py
+++ b/scripts/governance/check_risk_events_schema_contract.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Drift Guard: Validates risk_events schema contract.
+
+Ensures INSERT column list in services/risk/service.py matches
+canonical spec in Docs repo governance/risk_events.schema.yaml.
+
+Exit Codes:
+  0 - PASS (no drift detected)
+  1 - FAIL (drift detected or spec missing)
+"""
+
+import sys
+import re
+from pathlib import Path
+
+
+def main():
+    violations = []
+    root_dir = Path.cwd()
+
+    # 1. Find code INSERT statement
+    code_file = root_dir / "services" / "risk" / "service.py"
+    if not code_file.exists():
+        violations.append(f"MISSING: {code_file.relative_to(root_dir)}")
+        print_violations(violations)
+        sys.exit(1)
+
+    code_text = code_file.read_text(encoding="utf-8")
+
+    # Extract INSERT columns from code
+    insert_pattern = r'INSERT INTO risk_events\s*\(\s*([^)]+)\s*\)'
+    match = re.search(insert_pattern, code_text, re.IGNORECASE | re.DOTALL)
+
+    if not match:
+        violations.append("ERROR: Could not find INSERT INTO risk_events in code")
+        print_violations(violations)
+        sys.exit(1)
+
+    code_columns_raw = match.group(1)
+    code_columns = [col.strip() for col in code_columns_raw.split(',')]
+
+    # 2. Find spec file (try both Docs repo and local copy)
+    docs_repo = root_dir.parent / "Claire_de_Binare_Docs"
+    spec_paths = [
+        docs_repo / "knowledge" / "governance" / "risk_events.schema.yaml",
+        root_dir / "docs" / "governance" / "risk_events.schema.yaml",  # local copy
+    ]
+
+    spec_file = None
+    for path in spec_paths:
+        if path.exists():
+            spec_file = path
+            break
+
+    if not spec_file:
+        violations.append("MISSING: risk_events.schema.yaml not found in Docs or local repo")
+        print_violations(violations)
+        sys.exit(1)
+
+    # 3. Parse YAML spec (simple regex, no external deps)
+    spec_text = spec_file.read_text(encoding="utf-8")
+
+    # Extract insert_columns from spec
+    insert_section_pattern = r'insert_columns:\s*\n((?:  (?:#.*|-.+)\n?)+)'
+    spec_match = re.search(insert_section_pattern, spec_text)
+
+    if not spec_match:
+        violations.append("ERROR: Spec missing insert_columns section")
+        print_violations(violations)
+        sys.exit(1)
+
+    spec_columns = [
+        line.strip().lstrip('- ').strip()
+        for line in spec_match.group(1).strip().split('\n')
+        if line.strip() and not line.strip().startswith('#')
+    ]
+
+    # 4. Compare column sets (order-agnostic)
+    code_set = set(code_columns)
+    spec_set = set(spec_columns)
+
+    missing_in_spec = code_set - spec_set
+    missing_in_code = spec_set - code_set
+
+    if missing_in_spec:
+        violations.append(f"DRIFT: Code inserts columns NOT in spec: {sorted(missing_in_spec)}")
+
+    if missing_in_code:
+        violations.append(f"DRIFT: Spec declares columns NOT in code: {sorted(missing_in_code)}")
+
+    # 5. Warn on order mismatch (not FAIL, just warn)
+    if code_columns != spec_columns:
+        print("WARNING: Column order differs (spec vs code)")
+        print(f"  Spec order: {spec_columns}")
+        print(f"  Code order: {code_columns}")
+        print("  (Not a FAIL, but may indicate update needed)")
+        print()
+
+    # 6. Report results
+    if violations:
+        print_violations(violations)
+        sys.exit(1)
+    else:
+        print("[PASS] risk_events Schema Contract: PASS")
+        print(f"   Code columns: {code_columns}")
+        print(f"   Spec columns: {spec_columns}")
+        sys.exit(0)
+
+
+def print_violations(violations):
+    print("[FAIL] risk_events Schema Contract: FAIL")
+    for v in violations:
+        print(f"   {v}")
+    print()
+    print("Fix: Update risk_events.schema.yaml or services/risk/service.py to align")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Prevents Code↔Schema drift for `risk_events` table by creating a canonical schema spec and CI drift detection.

**Motivation:** P0 fix on 2026-02-09 revealed schema mismatch (initial migration didn't match code expectations).

## Changes

**Working Repo:**
- ✅ `scripts/governance/check_risk_events_schema_contract.py` (NEW)
  - Compares code INSERT vs spec `insert_columns`
  - Exit 1 on drift, Exit 0 on match
  - No external dependencies (stdlib only)

- ✅ `.github/workflows/core-guard.yml` (UPDATED)
  - Added schema contract check step
  - Runs on every PR + push to main
  - Blocks merge if drift detected

**Docs Repo (already pushed):**
- ✅ `knowledge/governance/risk_events.schema.yaml` (NEW)
  - Canonical schema definition with INSERT column contract
  - Verified against code: `services/risk/service.py:377-388`

- ✅ `knowledge/logs/sessions/2026-02-09_daily-shadow-check.md` (UPDATED)
  - Follow-up section documenting governance hardening

## Testing

**Local Test:**
```bash
python scripts/governance/check_risk_events_schema_contract.py

[PASS] risk_events Schema Contract: PASS
   Code columns: ['timestamp_ms', 'symbol', 'decision', 'reason_code', 'contract_version', 'payload']
   Spec columns: ['timestamp_ms', 'symbol', 'decision', 'reason_code', 'contract_version', 'payload']
```

**Expected CI Behavior:**
- ✅ PASS: Code INSERT columns match spec `insert_columns`
- ❌ FAIL: Code inserts column not in spec (or vice versa)
- ⚠️ WARN: Column order differs (informational, not blocking)

## Impact

- Prevents repeat of 2026-02-09 P0 schema mismatch
- Establishes pattern for future table contracts (e.g., `orders`, `positions`)
- Low-overhead enforcement (no external dependencies, <100 LOC)

## Related

- Issue #762 ([P0][RISK] Decision Contract 0/1 v1)
- P0 Fix Evidence: `knowledge/logs/sessions/2026-02-09_daily-shadow-check.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

## Summary by Sourcery

Add an automated drift guard for the risk_events schema and integrate it into the core CI guard workflow.

New Features:
- Introduce a governance script to validate the risk_events INSERT column contract against a canonical schema spec without external dependencies.

Enhancements:
- Extend the core guard GitHub Actions workflow to run the risk_events schema contract check and surface drift diagnostics in the job summary.