### PR TITLE
governance: add correlation event coverage guard (Phase 8D)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -355,6 +355,24 @@ jobs:
           echo ""
           echo "See: docs/live-readiness/LR-004-SPEC.md"
 
+  correlation-event-coverage-guard:
+    name: Correlation Event Coverage Guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+
+      - name: Run Correlation Event Coverage Guard
+        env:
+          ALLOW_EVIDENCE_DEBT: "1"  # TEMP: FILL not yet implemented
+        run: |
+          python scripts/governance/check_correlation_event_coverage.py
+
   # ============================================
   # SECURITY CHECKS
   # ============================================

--- a/scripts/governance/check_correlation_event_coverage.py
+++ b/scripts/governance/check_correlation_event_coverage.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Coverage Guard: Validates correlation event type implementation (Phase 8D).
+
+Checks that all required event types have literal persist calls in code.
+This is NOT schema validation (see check_correlation_schema_contract.py).
+This guard ensures event types are actually implemented, not just defined.
+
+Detection method:
+- Searches for persist_correlation_event( or _persist_correlation_event(
+- Only counts string literals: event_type="ORDER"
+- Variables or dynamic values are NOT counted
+
+Exit codes:
+- 0: PASS (all required events implemented, or ALLOW_EVIDENCE_DEBT=1)
+- 1: FAIL (missing event implementations)
+
+Environment:
+- ALLOW_EVIDENCE_DEBT=1: Treat missing events as PASS with INFO (exit 0)
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+# Environment gate
+ALLOW_EVIDENCE_DEBT = os.getenv("ALLOW_EVIDENCE_DEBT", "0") == "1"
+
+# Required event types for full correlation chain
+REQUIRED_EVENT_TYPES = {"SIGNAL", "DECISION", "ORDER", "FILL"}
+
+# Target files to scan (hardcoded, deterministic)
+TARGET_FILES = [
+    "services/signal/service.py",
+    "services/risk/service.py",
+    "services/execution/service.py",
+    "services/execution/database.py",
+]
+
+# Search window: how many characters after persist call to look for event_type
+SEARCH_WINDOW = 500
+
+
+def extract_event_types(code: str) -> set[str]:
+    """Extract event_type string literals from persist_correlation_event calls.
+
+    Strategy:
+    1. Find all persist_correlation_event( or _persist_correlation_event( calls
+    2. For each call, search within a bounded window for event_type="LITERAL"
+    3. Only string literals count (no variables)
+
+    Returns set of found event type literals.
+    """
+    found = set()
+
+    # Find all persist call positions
+    persist_pattern = r"_?persist_correlation_event\s*\("
+    for match in re.finditer(persist_pattern, code):
+        start_pos = match.end()
+        # Search within bounded window for event_type literal
+        window = code[start_pos : start_pos + SEARCH_WINDOW]
+
+        # Look for event_type="LITERAL" or event_type='LITERAL'
+        event_match = re.search(r'event_type\s*=\s*["\']([A-Z_]+)["\']', window)
+        if event_match:
+            found.add(event_match.group(1))
+
+    return found
+
+
+def scan_file(file_path: Path) -> set[str]:
+    """Scan a single file for event type implementations."""
+    if not file_path.exists():
+        return set()
+
+    code = file_path.read_text(encoding="utf-8")
+    return extract_event_types(code)
+
+
+def main() -> int:
+    root_dir = Path(__file__).parent.parent.parent
+
+    # Collect all implemented event types across target files
+    implemented = set()
+
+    for rel_path in TARGET_FILES:
+        file_path = root_dir / rel_path
+        found = scan_file(file_path)
+        implemented.update(found)
+
+    # Determine missing
+    missing = REQUIRED_EVENT_TYPES - implemented
+
+    # Output - strict contract: only PASS or FAIL as status
+    if not missing:
+        print("[PASS] Correlation Event Coverage: PASS")
+        return 0
+
+    if ALLOW_EVIDENCE_DEBT:
+        print("[PASS] Correlation Event Coverage: PASS")
+        print()
+        print("[INFO] Evidence debt allowed (ALLOW_EVIDENCE_DEBT=1)")
+        print(f"  Missing: {', '.join(sorted(missing))}")
+        return 0
+
+    # Fail-closed
+    print("[FAIL] Correlation Event Coverage: FAIL")
+    print(f"Missing: {', '.join(sorted(missing))}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/signal/service.py
+++ b/services/signal/service.py
@@ -114,7 +114,7 @@ class SignalEngine:
             self._pg_conn = None
             return None
 
-    def _persist_correlation_event(self, signal: "Signal") -> bool:
+    def _persist_correlation_event(self, signal: "Signal", *, event_type: str) -> bool:
         """
         Persist SIGNAL event to correlation_ledger (Phase 8C).
 
@@ -128,7 +128,7 @@ class SignalEngine:
 
         try:
             correlation_id = compute_correlation_id(signal.signal_id)
-            event_pk = compute_event_pk(signal.signal_id, "SIGNAL")
+            event_pk = compute_event_pk(signal.signal_id, event_type)
 
             conn = self._get_postgres_conn()
             if conn is None:
@@ -152,7 +152,7 @@ class SignalEngine:
                     None,  # decision_id (not applicable for SIGNAL)
                     None,  # order_id (not applicable for SIGNAL)
                     None,  # fill_id (not applicable for SIGNAL)
-                    "SIGNAL",
+                    event_type,
                     signal.symbol,
                     signal.ts_ms,
                     json.dumps(signal.to_dict()),
@@ -299,7 +299,7 @@ class SignalEngine:
             # Phase 8C: Persist SIGNAL event to correlation_ledger
             # ValueError (missing signal_id) = fail-closed (bubble up)
             # DB errors = warn-only (evidence debt, don't block trading)
-            if not self._persist_correlation_event(signal):
+            if not self._persist_correlation_event(signal, event_type="SIGNAL"):
                 logger.warning(
                     f"⚠️ correlation_ledger write failed for {signal.signal_id} (evidence debt)"
                 )


### PR DESCRIPTION
## Summary
- Adds deterministic Coverage Guard for correlation event type implementation
- Complements existing Drift Guard (schema validation)
- SIGNAL contract compliance fix in signal service

## What
| Component | Change |
|-----------|--------|
| `scripts/governance/check_correlation_event_coverage.py` | New guard - checks literal `event_type="X"` in persist calls |
| `.github/workflows/ci.yaml` | New job: Correlation Event Coverage Guard |
| `services/signal/service.py` | Contract fix: `event_type="SIGNAL"` as keyword literal |

## Coverage Status
| Event Type | Status |
|------------|--------|
| SIGNAL | ✅ implemented |
| DECISION | ✅ implemented |
| ORDER | ✅ implemented |
| FILL | ❌ conscious debt |

## CI Configuration
- `ALLOW_EVIDENCE_DEBT=1` set temporarily (FILL not yet implemented)
- Remove after FILL implementation to enforce full coverage

## Test Plan
- [x] Local: `python scripts/governance/check_correlation_event_coverage.py` → FAIL, Missing: FILL
- [x] Local: `ALLOW_EVIDENCE_DEBT=1 ...` → PASS + INFO
- [ ] CI: New job passes with debt flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a deterministic governance guard to enforce correlation event type coverage and wire it into CI while updating the signal service to use an explicit event_type literal for correlation persistence.

New Features:
- Introduce a coverage guard script that validates required correlation event types have literal persist calls in the codebase.

Enhancements:
- Update the signal service correlation event persistence to accept an explicit event_type keyword and use it when computing and storing correlation events.

CI:
- Add a CI job that runs the correlation event coverage guard with temporary evidence-debt allowance for missing FILL coverage.