### PR TITLE
phase-8e: implement FILL correlation event and close evidence debt

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -368,8 +368,6 @@ jobs:
           python-version: '3.12'
 
       - name: Run Correlation Event Coverage Guard
-        env:
-          ALLOW_EVIDENCE_DEBT: "1"  # TEMP: FILL not yet implemented
         run: |
           python scripts/governance/check_correlation_event_coverage.py
 

--- a/services/execution/live_executor.py
+++ b/services/execution/live_executor.py
@@ -156,8 +156,9 @@ class LiveExecutor:
         filled_qty = float(response.get("executedQty", 0))
 
         order_price = getattr(order, "price", None)
+        order_id_str = str(response.get("orderId"))
         result = ExecutionResult(
-            order_id=str(response.get("orderId")),
+            order_id=order_id_str,
             client_id=order.client_id or response.get("clientOrderId", ""),
             symbol=order.symbol,
             side=order.side,
@@ -166,6 +167,7 @@ class LiveExecutor:
             price=execution_price or order_price,
             status=status.value,
             timestamp=utcnow().isoformat(),
+            fill_id=order_id_str if status == OrderStatus.FILLED else None,
             error_message=None,
         )
 

--- a/services/execution/mexc_executor.py
+++ b/services/execution/mexc_executor.py
@@ -14,6 +14,7 @@ from .config import MEXC_API_KEY, MEXC_API_SECRET, MEXC_BASE_URL, MEXC_TESTNET
 from core.utils.clock import utcnow
 from core.utils.uuid_gen import generate_uuid_hex
 
+
 class MexcExecutor:
     """Real MEXC API Executor - NO MORE MOCK DATA"""
 
@@ -106,13 +107,15 @@ class MexcExecutor:
             result = self._make_request("POST", "/api/v3/order", params)
 
             # Create execution result with REAL data
+            order_id_str = str(result["orderId"])
             execution_result = ExecutionResult(
-                order_id=result["orderId"],
+                order_id=order_id_str,
                 client_id=order.client_id,
                 status=OrderStatus.FILLED.value,  # Assume filled for now
                 filled_price=current_price,
                 filled_quantity=order.quantity,
                 timestamp=utcnow().isoformat(),
+                fill_id=order_id_str,  # Phase 8E: 1:1 mapping, always FILLED here
                 error_message=None,
             )
 

--- a/services/execution/mock_executor.py
+++ b/services/execution/mock_executor.py
@@ -92,6 +92,7 @@ class MockExecutor:
                 client_id=client_id,
                 error_message=None,
                 timestamp=utcnow().isoformat(),
+                fill_id=order_id,  # Phase 8E: 1:1 mapping, always FILLED in success case
             )
 
             # Store order

--- a/services/execution/models.py
+++ b/services/execution/models.py
@@ -137,6 +137,7 @@ class ExecutionResult:
     price: Optional[float] = None
     error_message: Optional[str] = None
     timestamp: Optional[str] = None
+    fill_id: Optional[str] = None  # Phase 8E: 1:1 mapping to order_id for FILL events
     type: Literal["order_result"] = "order_result"
 
     def __post_init__(self) -> None:

--- a/services/execution/paper_trading.py
+++ b/services/execution/paper_trading.py
@@ -15,6 +15,7 @@ import time
 
 from core.utils.clock import utcnow
 
+
 class OrderType(Enum):
     """Order types for paper trading"""
 

--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -280,12 +280,13 @@ def process_order(order_data: dict):
         result.strategy_id = order.strategy_id
         result.bot_id = order.bot_id
 
-        # Phase 8C: Persist ORDER event to correlation_ledger
+        # Phase 8C/8E: Persist ORDER and FILL events to correlation_ledger
         # order_id ist jetzt final (von executor zurückgegeben)
-        # TODO: FILL requires adding fill_id (or trade_id) to ExecutionResult + executor
-        # integration; until then chain is SIGNAL→DECISION→ORDER only.
         if db:
             timestamp_ms = int(time.time() * 1000)
+            schema_status = ExecutionResult._schema_status(result.status)
+
+            # ORDER event (always persisted)
             order_payload = {
                 "signal_id": order.signal_id,
                 "decision_id": order.decision_id,
@@ -308,6 +309,34 @@ def process_order(order_data: dict):
                 logger.warning(
                     "⚠️ correlation_ledger ORDER write failed (evidence debt)"
                 )
+
+            # Phase 8E: FILL event (only for fully filled orders, same timestamp_ms)
+            if schema_status == "FILLED" and result.fill_id:
+                fill_payload = {
+                    "signal_id": order.signal_id,
+                    "decision_id": order.decision_id,
+                    "order_id": result.order_id,
+                    "fill_id": result.fill_id,
+                    "symbol": order.symbol,
+                    "side": order.side,
+                    "filled_quantity": result.filled_quantity,
+                    "price": result.price,
+                    "strategy_id": order.strategy_id,
+                    "trace_id": order.trace_id,
+                }
+                if not db.persist_correlation_event(
+                    signal_id=order.signal_id,
+                    event_type="FILL",
+                    symbol=order.symbol,
+                    timestamp_ms=timestamp_ms,
+                    decision_id=order.decision_id,
+                    order_id=result.order_id,
+                    fill_id=result.fill_id,
+                    payload=fill_payload,
+                ):
+                    logger.warning(
+                        "⚠️ correlation_ledger FILL write failed (evidence debt)"
+                    )
 
         # Update stats (Thread-safe)
         schema_status = ExecutionResult._schema_status(result.status)


### PR DESCRIPTION
## Summary
- Add `fill_id` field to ExecutionResult (= order_id for FILLED orders)
- Set fill_id in all executors (live, mexc, mock) for FILLED orders
- Persist `event_type="FILL"` in correlation_ledger (same timestamp_ms as ORDER)
- Remove ALLOW_EVIDENCE_DEBT from CI → Coverage Guard now fail-closed

## Correlation Chain
```
SIGNAL → DECISION → ORDER → FILL ✅
```

## Changes
| File | Change |
|------|--------|
| `services/execution/models.py` | +1 field: `fill_id` |
| `services/execution/live_executor.py` | set fill_id for FILLED |
| `services/execution/mexc_executor.py` | set fill_id for FILLED |
| `services/execution/mock_executor.py` | set fill_id for FILLED |
| `services/execution/service.py` | persist FILL event |
| `.github/workflows/ci.yaml` | remove ALLOW_EVIDENCE_DEBT |

## Risk
Minimal - deterministic, idempotent, no behavioral change for non-FILLED orders.

## Test Plan
- [x] Coverage Guard PASS locally (no ALLOW_EVIDENCE_DEBT)
- [ ] CI Coverage Guard job PASS
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

## Summary by Sourcery

Track filled executions as FILL correlation events and tighten correlation coverage enforcement.

New Features:
- Add a fill_id field to ExecutionResult and populate it for filled orders across live, MEXC, and mock executors.
- Persist FILL events in the correlation ledger for fully filled orders, linked by fill_id and sharing the ORDER timestamp.

CI:
- Remove the ALLOW_EVIDENCE_DEBT escape hatch so the Correlation Event Coverage Guard now fails on missing evidence.