### PR TITLE
docs(governance): log solo-maintainer branch protection change

### DIFF
--- a/docs/governance/BRANCH_PROTECTION_LOG.md
+++ b/docs/governance/BRANCH_PROTECTION_LOG.md
@@ -35,3 +35,34 @@ This document records governance interventions on branch protection rules for au
 **Decision:** CI is the gatekeeper. Reviews are optional for solo-maintainer workflow.
 
 **Approver:** jannekbuengener (repo owner)
+
+---
+
+## 2026-02-16T10:10:00Z - Solo-Maintainer Mode (PR #846)
+
+**Context:** PR #846 (fix: psycopg2-binary for signal service) blocked by `required_approving_review_count: 1` despite self-approval being impossible on GitHub.
+
+**Problem:**
+- GitHub blocks self-approval: "Cannot approve your own pull request"
+- Solo-maintainer has no one to approve PRs
+- All required status checks: PASS
+
+**Action Taken:**
+```bash
+gh api repos/jannekbuengener/Claire_de_Binare/branches/main/protection/required_pull_request_reviews \
+  --method PATCH --field required_approving_review_count=0
+```
+
+**Final State:**
+| Setting | Before | After |
+|---------|--------|-------|
+| `required_approving_review_count` | 1 | 0 |
+
+**Rationale:**
+- Solo-maintainer mode: approval requirement is unworkable
+- CI status checks (7 required) remain the actual gatekeeper
+- Bot reviews with suggestions still create unresolved threads (caught by `required_conversation_resolution`)
+
+**Decision:** Reviews remain optional. CI + conversation resolution = sufficient governance for solo-maintainer.
+
+**Approver:** jannekbuengener (repo owner)


### PR DESCRIPTION
## Summary
- Document branch protection change for PR #846
- Changed `required_approving_review_count` from 1 to 0 for solo-maintainer mode

## Risk
None - documentation only.

## Summary by Sourcery

Documentation:
- Add a governance log entry describing the change of required approving review count from 1 to 0 for solo-maintainer mode, including context, rationale, and final state.