### PR TITLE
docs(services): clarify market_data uses Pub/Sub not Streams

### DIFF
--- a/services/README.md
+++ b/services/README.md
@@ -11,3 +11,8 @@
 *   [Risk Service (services/risk/)](services/risk/)
 *   [Signal Service (services/signal/)](services/signal/)
 *   [Allocation Service (services/allocation/)](services/allocation/)
+
+## Redis Transport Notes
+
+- **market_data**: Uses Redis **Pub/Sub** (not Redis Streams). `XLEN market_data` returns 0 — this is expected.
+- **signals, orders, allocation_decisions**: Use Redis **Streams** for durable event log.


### PR DESCRIPTION
## Summary
- Add Redis transport notes to services/README.md
- Clarifies that `market_data` uses Pub/Sub (XLEN returns 0 is expected)
- Prevents future confusion during debugging

## Risk
None - documentation only.

## Summary by Sourcery

Clarify Redis transport usage across services in the services documentation.

Documentation:
- Document that the market_data service uses Redis Pub/Sub rather than Redis Streams and that an XLEN of 0 is expected.
- Document that signals, orders, and allocation_decisions use Redis Streams for a durable event log.