### PR TITLE
Phase 9 PR-0: Trace Contract v1 Infrastructure

### DIFF
--- a/core/utils/uuid_gen.py
+++ b/core/utils/uuid_gen.py
@@ -183,3 +183,62 @@ def compute_event_pk(
         f"{signal_id}|{canonical_event_type}|{canonical_order_id}|{canonical_fill_id}"
     )
     return str(uuid.uuid5(CORRELATION_EVENT_NAMESPACE, input_str))
+
+
+# =============================================================================
+# Phase 9: Trace Contract v1 - Policy Governance
+# =============================================================================
+
+POLICY_ID = "risk_policy_v1"
+
+
+def compute_policy_hash(thresholds: dict) -> str:
+    """Compute SHA256 hash of policy/threshold bundle.
+
+    Args:
+        thresholds: The DECISION_THRESHOLDS dict used for risk decision.
+
+    Returns:
+        64-char hex SHA256 hash.
+    """
+    canonical = json.dumps(thresholds, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def compute_output_hash(
+    decision: str,
+    reason_code: str | None,
+    decision_pk: str,
+    decision_id: str,
+    contract_version: str,
+    input_hash: str,
+    policy_hash: str,
+) -> str:
+    """Compute SHA256 hash of deterministic decision output object.
+
+    Fingerprints the complete decision output so changes in any
+    deterministic field will produce a different hash.
+
+    Args:
+        decision: "ALLOW" or "BLOCK"
+        reason_code: RC_XXX or None
+        decision_pk: Deterministic decision primary key
+        decision_id: UUIDv5 decision identifier
+        contract_version: e.g., "decision_contract_v1"
+        input_hash: SHA256 of input snapshot
+        policy_hash: SHA256 of thresholds used
+
+    Returns:
+        64-char hex SHA256 hash.
+    """
+    output = {
+        "decision": decision,
+        "reason_code": reason_code,
+        "decision_pk": decision_pk,
+        "decision_id": decision_id,
+        "contract_version": contract_version,
+        "input_hash": input_hash,
+        "policy_hash": policy_hash,
+    }
+    canonical = json.dumps(output, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/services/execution/models.py
+++ b/services/execution/models.py
@@ -50,6 +50,11 @@ class Order:
     decision_id: Optional[str] = None
     order_id: Optional[str] = None
     trace_id: Optional[str] = None
+    # Phase 9: Trace Contract v1 - Policy governance
+    policy_id: Optional[str] = None
+    policy_hash: Optional[str] = None
+    input_hash: Optional[str] = None
+    output_hash: Optional[str] = None
 
     @classmethod
     def from_event(cls, payload: dict) -> "Order":
@@ -79,6 +84,11 @@ class Order:
             decision_id=payload.get("decision_id"),
             order_id=payload.get("order_id"),  # canonical internal order_id
             trace_id=payload.get("trace_id"),
+            # Phase 9: Trace Contract v1 - Policy governance
+            policy_id=payload.get("policy_id"),
+            policy_hash=payload.get("policy_hash"),
+            input_hash=payload.get("input_hash"),
+            output_hash=payload.get("output_hash"),
         )
 
     def to_dict(self) -> dict:
@@ -118,6 +128,15 @@ class Order:
             payload["order_id"] = self.order_id
         if self.trace_id is not None:
             payload["trace_id"] = self.trace_id
+        # Phase 9: Trace Contract v1 - Policy governance
+        if self.policy_id is not None:
+            payload["policy_id"] = self.policy_id
+        if self.policy_hash is not None:
+            payload["policy_hash"] = self.policy_hash
+        if self.input_hash is not None:
+            payload["input_hash"] = self.input_hash
+        if self.output_hash is not None:
+            payload["output_hash"] = self.output_hash
         return payload
 
 

--- a/services/risk/models.py
+++ b/services/risk/models.py
@@ -125,6 +125,11 @@ class Order:
     order_id: Optional[str] = None
     decision_id: Optional[str] = None
     trace_id: Optional[str] = None
+    # Phase 9: Trace Contract v1 - Policy governance
+    policy_id: Optional[str] = None
+    policy_hash: Optional[str] = None
+    input_hash: Optional[str] = None
+    output_hash: Optional[str] = None
 
     def to_dict(self) -> dict:
         return {
@@ -144,6 +149,11 @@ class Order:
             "order_id": self.order_id,
             "decision_id": self.decision_id,
             "trace_id": self.trace_id,
+            # Phase 9: Trace Contract v1 - Policy governance
+            "policy_id": self.policy_id,
+            "policy_hash": self.policy_hash,
+            "input_hash": self.input_hash,
+            "output_hash": self.output_hash,
         }
 
 

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -3,6 +3,9 @@ Risk Manager - Main Service
 Multi-Layer Risk Management
 """
 
+from __future__ import annotations
+
+import copy
 import json
 import logging
 import logging.config
@@ -27,6 +30,9 @@ from core.utils.uuid_gen import (
     compute_input_snapshot_hash,
     compute_correlation_id,
     compute_event_pk,
+    compute_policy_hash,  # Phase 9
+    compute_output_hash,  # Phase 9
+    POLICY_ID,  # Phase 9
 )
 from core.utils.clock import utcnow
 from core.utils.redis_payload import sanitize_payload
@@ -57,6 +63,9 @@ except ImportError:
 
 # Phase 8C: Evidence debt safety valve (default: fail-closed)
 ALLOW_EVIDENCE_DEBT = os.getenv("ALLOW_EVIDENCE_DEBT", "0") == "1"
+
+# Phase 9: Trace Contract v1 toggle (default: DISABLED for safety)
+TRACE_CONTRACT_V1_ENABLED = os.getenv("TRACE_CONTRACT_V1_ENABLED", "0") == "1"
 
 # Logging konfigurieren via JSON-Config
 logging_config_path = Path(__file__).parent.parent.parent / "logging_config.json"
@@ -314,6 +323,91 @@ def decide_trade(
     return DECISION_ALLOW, None, evidence
 
 
+def _phase9_enrich_evidence(
+    evidence: dict,
+    decision: str,
+    reason_code: str | None,
+    symbol: str,
+    ts_ms: int,
+) -> tuple[dict, str | None, str | None]:
+    """
+    Phase 9: Enrich evidence with policy governance fields for Trace Contract v1.
+
+    MUST be called ONCE before both:
+    - emitting DECISION event
+    - creating Order object
+
+    Args:
+        evidence: The evidence dict from decide_trade() (mutated in place when toggle ON)
+        decision: "ALLOW" or "BLOCK"
+        reason_code: RC_XXX or None
+        symbol: Trading symbol
+        ts_ms: Exact timestamp used for DECISION event (caller passes this)
+
+    Returns:
+        (enriched_evidence, input_hash, decision_pk)
+        - When toggle OFF: returns (evidence, None, None) - ZERO IMPACT
+        - When toggle ON: returns enriched evidence with computed hashes
+    """
+    # ZERO-IMPACT when toggle OFF: no mutations, no validations, no computations
+    if not TRACE_CONTRACT_V1_ENABLED:
+        return evidence, None, None
+
+    # Toggle ON: proceed with enrichment
+
+    # Ensure thresholds are set BEFORE computing hashes
+    # (so input_hash/decision_pk reflect the same immutable context)
+    # Use deepcopy because DECISION_THRESHOLDS contains lists (allowed_regimes, blocked_regimes)
+    if "thresholds" not in evidence or evidence["thresholds"] is None:
+        evidence["thresholds"] = copy.deepcopy(DECISION_THRESHOLDS)
+
+    # Compute hashes ONCE (deterministic, AFTER thresholds are set)
+    input_hash = compute_input_snapshot_hash(evidence)
+    decision_pk = generate_decision_pk(symbol, ts_ms, evidence)
+
+    # Compute policy_hash from evidence["thresholds"] (same as used in input_hash)
+    policy_hash = compute_policy_hash(evidence["thresholds"])
+
+    # Enrich evidence with Phase 9 fields
+    evidence["policy_id"] = POLICY_ID
+    evidence["policy_hash"] = policy_hash
+    evidence[
+        "input_hash"
+    ] = input_hash  # alias, keep input_snapshot_hash for backwards compat
+
+    # output_hash uses the SAME decision_pk that will be written to event
+    evidence["output_hash"] = compute_output_hash(
+        decision=decision,
+        reason_code=reason_code,
+        decision_pk=decision_pk,
+        decision_id=evidence.get("decision_id"),
+        contract_version=evidence.get("contract_version", DECISION_CONTRACT_VERSION),
+        input_hash=input_hash,
+        policy_hash=policy_hash,
+    )
+
+    # Minimal immutable decision_context for replay
+    evidence["decision_context"] = {
+        "thresholds": evidence["thresholds"],
+        "inputs": {
+            "regime_id": evidence.get("regime_id"),
+            "return_1m": evidence.get("return_1m"),
+            "return_5m": evidence.get("return_5m"),
+            "price_change_5m": evidence.get("price_change_5m"),
+            "pct_change_15m": evidence.get("pct_change_15m"),
+            "volume_15m": evidence.get("volume_15m"),
+            "daily_drawdown_pct": evidence.get("daily_drawdown_pct"),
+            "total_exposure_pct": evidence.get("total_exposure_pct"),
+            "slippage_pct": evidence.get("slippage_pct"),
+            "staleness_s": evidence.get("staleness_s"),
+            "data_silence_s": evidence.get("data_silence_s"),
+        },
+        "contract_version": DECISION_CONTRACT_VERSION,
+    }
+
+    return evidence, input_hash, decision_pk
+
+
 class RiskManager:
     """Multi-Layer Risk-Management"""
 
@@ -479,13 +573,30 @@ class RiskManager:
             return None
 
     def _emit_risk_event(
-        self, decision: str, reason_code: str | None, evidence: dict
+        self,
+        decision: str,
+        reason_code: str | None,
+        evidence: dict,
+        decision_pk: str | None = None,
+        input_hash: str | None = None,
     ) -> bool:
-        """Emit risk event with deterministic decision_pk for idempotent persistence."""
+        """Emit risk event with deterministic decision_pk for idempotent persistence.
+
+        Args:
+            decision: "ALLOW" or "BLOCK"
+            reason_code: RC_XXX or None
+            evidence: The evidence dict from decide_trade
+            decision_pk: Pre-computed decision_pk (Phase 9), or None to compute here
+            input_hash: Pre-computed input_hash (Phase 9), or None to compute here
+        """
         symbol = evidence.get("symbol", "")
         ts_ms = evidence.get("timestamp_ms", 0)
-        input_hash = compute_input_snapshot_hash(evidence)
-        decision_pk = generate_decision_pk(symbol, ts_ms, evidence)
+
+        # Use pre-computed values if provided (Phase 9), else compute (backwards compat)
+        if input_hash is None:
+            input_hash = compute_input_snapshot_hash(evidence)
+        if decision_pk is None:
+            decision_pk = generate_decision_pk(symbol, ts_ms, evidence)
 
         event = {
             **evidence,
@@ -1036,7 +1147,27 @@ class RiskManager:
             market_health=market_health,
             now_ms=now_ms,
         )
-        self._emit_risk_event(decision, reason_code, evidence)
+
+        # Phase 9: Enrich evidence ONCE (before DECISION emit AND Order creation)
+        # Pass exact ts_ms used for DECISION event timestamp
+        evidence, input_hash, decision_pk = _phase9_enrich_evidence(
+            evidence=evidence,
+            decision=decision,
+            reason_code=reason_code,
+            symbol=signal.symbol,
+            ts_ms=now_ms,
+        )
+
+        # Emit DECISION event
+        # When toggle OFF: input_hash/decision_pk are None, _emit_risk_event computes them
+        # When toggle ON: pass pre-computed values to avoid recomputation divergence
+        self._emit_risk_event(
+            decision=decision,
+            reason_code=reason_code,
+            evidence=evidence,
+            decision_pk=decision_pk,
+            input_hash=input_hash,
+        )
 
         # Phase 8C: Persist DECISION event to correlation_ledger
         signal_id = evidence.get("signal_id")
@@ -1245,6 +1376,11 @@ class RiskManager:
             order_id=generate_uuid(),
             decision_id=evidence.get("decision_id"),
             trace_id=evidence.get("trace_id"),
+            # Phase 9: Trace Contract v1 - Policy governance (None when toggle OFF)
+            policy_id=evidence.get("policy_id"),
+            policy_hash=evidence.get("policy_hash"),
+            input_hash=evidence.get("input_hash"),
+            output_hash=evidence.get("output_hash"),
         )
 
         # PR #619: HARD EXPOSURE GATE - Block order if projected exposure exceeds limit


### PR DESCRIPTION
## Summary
Add Phase 9 Trace Contract v1 infrastructure (prerequisite for PR-1).

### Changes
- **core/utils/uuid_gen.py**: POLICY_ID, compute_policy_hash(), compute_output_hash()
- **services/risk/service.py**: TRACE_CONTRACT_V1_ENABLED toggle (default OFF), _phase9_enrich_evidence()
- **services/risk/models.py**: Order policy_* fields
- **services/execution/models.py**: Order policy_* fields + serialization

### Guardrails
- Toggle `TRACE_CONTRACT_V1_ENABLED` defaults to OFF (zero behavior change)
- All additions are additive only
- No decision logic/threshold/signal changes

Prerequisite for #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)