### PR TITLE
ci: rename pipeline:generated label to ci:generated in e2e issue creation

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -148,7 +148,7 @@ jobs:
           EOF
           )
 
-          if gh issue create --title "$title" --body "$body" --label "type:infra,prio:must,scope:ci,pipeline:generated"; then
+          if gh issue create --title "$title" --body "$body" --label "type:infra,prio:must,scope:ci,ci:generated"; then
             echo "Issue created with labels."
           else
             gh issue create --title "$title" --body "$body"


### PR DESCRIPTION
## Summary
- Cosmetic-only label rename in `.github/workflows/e2e-tests.yml`.
- Replaced `pipeline:generated` with `ci:generated` in the e2e issue creation label list.
- Kept fallback behavior unchanged: if labeled `gh issue create` fails, workflow still creates the issue without labels.

## Why
- Neutralize legacy pipeline terminology after Discussion Pipeline decommission.
- No functional behavior change intended.

## Maintainer note
- You may create label `ci:generated` in GitHub UI.
- If it does not exist, workflow behavior is still safe because fallback path already creates the issue without labels.

## Evidence
- Diff scope: one line in one file (`.github/workflows/e2e-tests.yml`).
- `rg -n "pipeline:generated" .` returns 0 hits in this repo.

## Rollback
- Revert commit `9f3d467`.