### PR TITLE
fix(ci): unblock e2e real-mode health by fixing secret file readability

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -129,7 +129,9 @@ jobs:
           echo "$ALERT_EMAIL_TO_VAL" > "$SECRETS_PATH/ALERT_EMAIL_TO"
           echo "$MEXC_KEY_VAL" > "$SECRETS_PATH/MEXC_API_KEY.txt"
           echo "$MEXC_SECRET_VAL" > "$SECRETS_PATH/MEXC_API_SECRET.txt"
-          chmod 600 "$SECRETS_PATH"/*
+          # Compose mounts these files into /run/secrets/*; keep read access for non-root service users.
+          chmod 755 "$SECRETS_PATH"
+          chmod 644 "$SECRETS_PATH"/*
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5


### PR DESCRIPTION
## Problem
`E2E Tests` on `workflow_dispatch@main` already passed REAL preflight but still failed in runtime health wait.
Containers reported `/run/secrets/*: Permission denied`, then Redis auth errors and unhealthy/restarting services.

## Fix
- CI-only change in `.github/workflows/e2e.yml`.
- In `Create CI secrets directory`, changed secret file permissions from `600` to:
  - `chmod 755 "$SECRETS_PATH"`
  - `chmod 644 "$SECRETS_PATH"/*`
- This keeps mounted secret files readable for non-root service users inside containers.

## Why safe
- No fail-closed/preflight logic changed.
- No Docker/Compose files changed.
- No trading logic/thresholds changed.

## Test plan
1. Trigger `workflow_dispatch` on `main` for `E2E Tests`.
2. Verify summary still shows `e2e_mode=REAL`.
3. Verify health step progresses past service readiness.
4. Run 3 consecutive dispatches for stability evidence.