### PR TITLE
ci: rename label pipeline:generated to ci:generated

### DIFF
--- a/.github/workflows/labels.json
+++ b/.github/workflows/labels.json
@@ -13,6 +13,7 @@
     { "name": "scope:monitoring", "color": "006b75", "description": "Prometheus, Grafana, Alerts" },
     { "name": "scope:data", "color": "336791", "description": "PostgreSQL, Redis, Migrations" },
     { "name": "scope:docs", "color": "0075ca", "description": "Markdown, ADRs, Guides" },
+    { "name": "ci:generated", "color": "0e8a16", "description": "Auto-created by CI" },
 
     { "name": "prio:must", "color": "d73a4a", "description": "Kritisch – Release Blocker" },
     { "name": "prio:should", "color": "ff9800", "description": "Hoch – für nächstes Milestone" },

--- a/reports/LABEL_RENAME_PIPELINE_TO_CI_GENERATED_2026-02-19.md
+++ b/reports/LABEL_RENAME_PIPELINE_TO_CI_GENERATED_2026-02-19.md
@@ -1,0 +1,30 @@
+# Label Rename Audit: `pipeline:generated` -> `ci:generated`
+
+Date: 2026-02-19
+Branch: `ci/rename-generated-label`
+
+## Scope
+- Label/workflow metadata and audit docs only.
+- No Docker/Compose/Dockerfile changes.
+- No trading logic changes.
+
+## Discovery Result
+- No repository references to `pipeline:generated` were found in:
+  - `.github/workflows/**`
+  - `.github/ISSUE_TEMPLATE/**`
+  - `.github/pull_request_template.md`
+  - `docs/**`
+  - `reports/**`
+
+## Change Applied
+- Added `ci:generated` to `.github/workflows/labels.json` with canonical metadata:
+  - name: `ci:generated`
+  - color: `0e8a16`
+  - description: `Auto-created by CI`
+
+## Compatibility Decision
+- Migration mode: complete in-repo migration (no in-repo `pipeline:generated` usages existed).
+- No alias entry was added because there were no old references to preserve in repository files.
+
+## Audit Note
+- This documents the rename intent from `pipeline:generated` to `ci:generated`.


### PR DESCRIPTION
## Problem
Rename and consolidate label usage from `pipeline:generated` to `ci:generated` without changing CI behavior, trading logic, or Docker setup.

## Before/After
- Before: `pipeline:generated`
- After: `ci:generated`

## Compatibility
- Strategy: complete in-repo migration (no in-repo references to `pipeline:generated` were found).
- No workflow logic depended on `pipeline:generated`, so no dual-label runtime branch was needed.
- Added canonical label definition for `ci:generated` in the sync manifest.

## Diff Map
- `.github/workflows/labels.json`
  - Added label entry: `ci:generated` (`0e8a16`, `Auto-created by CI`)
- `reports/LABEL_RENAME_PIPELINE_TO_CI_GENERATED_2026-02-19.md`
  - Audit note for rename intent and discovery evidence

## Guarantees
- No Docker/Compose/Dockerfile changes.
- No `services/*` or trading decision logic changes.
- No workflow name changes and no required-check context changes.
- No CI decision logic changes (metadata-only label manifest update).

## Test Notes
- YAML parse: `YAML parse OK: 40 workflow files`
- Grep check (operational scope): `NO_OPERATIONAL_PIPELINE_GENERATED_REFERENCES`
- Label check: `gh label list` confirms `ci:generated` present.