### PR TITLE
docs(ci): add runbook for action_required workflow runs (bots/apps)

### DIFF
--- a/docs/ci/ACTION_REQUIRED_RUNBOOK.md
+++ b/docs/ci/ACTION_REQUIRED_RUNBOOK.md
@@ -1,0 +1,80 @@
+# GitHub Actions `action_required` Runbook (Bots/Apps)
+
+## Purpose
+This runbook defines deterministic handling for workflow runs that end in `action_required`, especially on bot/app PRs where checks show no started jobs.
+
+## A) Symptom / Detection
+- Workflow run conclusion is `action_required`.
+- Run details show `jobs=[]` (no jobs started).
+- UI typically shows an approval gate, e.g. `Approval required` / `Approve and run`.
+- Why this is critical:
+  - Required contexts may not be emitted.
+  - PR signal is blocked even when workflow definitions are valid.
+  - This can deadlock bot/app PRs.
+
+Evidence anchors from triage:
+- `22192989773` (PR `#867`, branch `copilot/sub-pr-865`) -> `action_required`, `jobs=[]`  
+  Link: `https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/22192989773`
+- `22192989851` (`E2E Happy Path`) -> `action_required`  
+  Link: `https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/22192989851`
+
+## B) Immediate Unblock (< 60 seconds)
+1. Open the affected run in GitHub Actions (`Actions` -> run).
+2. Check for the approval banner (`Approval required`).
+3. Click `Approve and run` (or equivalent approval button).
+4. Verify jobs are created and start running (no longer `jobs=[]`).
+5. Verify required context emission on the PR, especially `ci (Unit/Integration + Lint gesammelt)`.
+
+Important:
+- Approve only; do not post or expose secret values.
+- Only secret names may be referenced for troubleshooting.
+
+## C) Root Cause (Policy, Not Flake)
+`action_required` is usually deterministic governance behavior, not an intermittent test failure.
+
+Typical causes:
+- Repository policy requires approval for workflows from untrusted contributors.
+- Bot/app-authored PRs are treated as untrusted until maintainer approval.
+- Token/permission constraints for app-triggered runs.
+
+## D) Prevention / Governance Options (Documentation Only)
+No settings are changed by this runbook. This section documents decision options.
+
+Decision tree:
+- Need maximum safety and explicit human gate? -> **MODE 1 (Strict approval)**
+- Need fewer bot/app deadlocks and faster CI signal? -> **MODE 2 (Auto-run for trusted bots)**
+
+### MODE 1: Strict approval (safer default)
+- Keep approval gates enabled.
+- Maintainers must explicitly approve `action_required` runs.
+- This runbook is mandatory operating procedure.
+- Watch required-check workflows first.
+
+### MODE 2: Auto-run for trusted bots
+- Goal: bot/app PR workflows run without manual approval deadlock.
+- This is a repository settings decision and must be consciously approved.
+- UI paths to review:
+  - `Settings -> Actions -> General -> Fork pull request workflows`
+  - `Require approval for all outside collaborators` (on/off)
+  - `Require approval for first-time contributors` (on/off)
+  - `Settings -> Actions -> General -> Workflow permissions` (keep least privilege)
+- Security warning:
+  - Auto-run increases attack surface.
+  - Keep least privilege and review trust boundaries before enabling.
+
+## E) Maintainer Checklist (Daily Ops)
+- If a PR run is `action_required`:
+  - 1) Approve run.
+  - 2) Confirm required context is emitted: `ci (Unit/Integration + Lint gesammelt)`.
+  - 3) If recurring, review governance settings using MODE 1 vs MODE 2.
+
+## F) Do / Don't
+DO:
+- Approve runs only as a maintainer.
+- Reference secret names only (never values).
+- Track repeat incidents as governance debt.
+
+DON'T:
+- Do not switch workflows to `pull_request_target` as a quick fix (scope/threat-model risk).
+- Do not rename workflows/jobs that participate in required-check context stability.
+- Do not treat `action_required` as a flaky test symptom.


### PR DESCRIPTION
## Problem
ction_required runs (often with jobs=[]) block CI signal visibility and can deadlock bot/app PR flows.

## What Changed
- Added docs-only runbook: docs/ci/ACTION_REQUIRED_RUNBOOK.md
- Includes:
  - symptom detection (ction_required, jobs=[])
  - <60s unblock steps (Approve and run path)
  - policy-based root cause explanation (not test flake)
  - governance decision tree (MODE 1 strict approval vs MODE 2 auto-run for trusted bots)
  - maintainer checklist and do/don't guardrails
  - concrete evidence anchors from triage runs:
    - 22192989773 (PR #867, copilot/sub-pr-865)
    - 22192989851 (E2E Happy Path)

## Why Safe
- Docs-only change.
- No CI workflow logic changes.
- No Docker/Compose/Dockerfile changes.
- No trading logic changes.
- No GitHub settings changes (documented only).

## No-Change Statement
This PR does **not** modify .github/workflows/**, services/**, core/**, infrastructure/**, or 	ests/**.

## Rollback
- Revert this PR (single docs file).
