### PR TITLE
ci(trivy): fix Docker API mismatch (Issue #837)

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -46,8 +46,17 @@ jobs:
             trivy-${{ runner.os }}-${{ github.workflow }}-
             trivy-${{ runner.os }}-
 
+      - name: Debug Docker version
+        run: docker version
+
+      - name: Debug Docker info
+        run: docker info
+
+      - name: Debug Trivy action version
+        run: echo "Using aquasecurity/trivy-action@22438a435773de8c97dc0958cc0b823c45b064ac"
+
       - name: Run Trivy (JSON)
-        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe # 7b7aa264d83dc58691451798b4d117d53d21edfe
+        uses: aquasecurity/trivy-action@22438a435773de8c97dc0958cc0b823c45b064ac # v0.68.1 default trivy
         with:
           scan-type: "fs"
           scan-ref: "."
@@ -103,7 +112,7 @@ jobs:
           path: trivy-results.json
 
       - name: Run Trivy (SARIF)
-        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe # 7b7aa264d83dc58691451798b4d117d53d21edfe
+        uses: aquasecurity/trivy-action@22438a435773de8c97dc0958cc0b823c45b064ac # v0.68.1 default trivy
         with:
           scan-type: "fs"
           scan-ref: "."


### PR DESCRIPTION
## Summary

- **Root cause:** Outdated `aquasecurity/trivy-action` pin (`7b7aa…`) caused Docker API mismatch (`client 1.42 too old, min 1.44`) on current GitHub Actions runner.
- **Fix:** Upgrade trivy-action to `22438a435773de8c97dc0958cc0b823c45b064ac` (SHA pinned, v0.68.1) for both JSON + SARIF scan steps. `scan-type: fs` unchanged.
- **Evidence:** Added `docker version`, `docker info`, and action pin echo right before scan for diagnostics.
- **Scope:** CI only (`.github/workflows/trivy.yml`). No changes to trading/risk/signal/order logic.

## Test plan

- [ ] CI trivy workflow runs without Docker API mismatch error
- [ ] Debug steps show `docker version` (Client/Server/API), `docker info`, and action pin in log
- [ ] JSON scan produces `trivy-results.json` artifact
- [ ] SARIF upload to GitHub Security succeeds

Closes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)