### PR TITLE
fix(obs): Grafana Postgres datasource reads password from secret (fixes #730)

### DIFF
--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -89,9 +89,8 @@ services:
       GF_SMTP_FROM_ADDRESS__FILE: /run/secrets/smtp_from
       GF_SMTP_FROM_NAME: "CDB Alerts"
       GF_SMTP_STARTTLS_POLICY: MandatoryStartTLS
-      # Postgres Datasource Auth
+      # Postgres Datasource Auth (read from secret at startup via entrypoint)
       POSTGRES_USER: ${POSTGRES_USER:-claire_user}
-      POSTGRES_PASSWORD__FILE: /run/secrets/postgres_password
     secrets:
       - postgres_password
       - grafana_password
@@ -99,13 +98,18 @@ services:
       - smtp_password
       - smtp_from
       - alert_email_to
+    # Export POSTGRES_PASSWORD from secret file before starting Grafana
+    # so $__env{POSTGRES_PASSWORD} in datasource provisioning resolves correctly
+    entrypoint: ["/bin/sh", "/usr/local/bin/entrypoint-postgres-password.sh"]
     volumes:
       - grafana_data:/var/lib/grafana
+      - ../../infrastructure/monitoring/grafana/entrypoint-postgres-password.sh:/usr/local/bin/entrypoint-postgres-password.sh:ro
       - ../../infrastructure/monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
       - ../../infrastructure/monitoring/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
       - ../../infrastructure/monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
     depends_on:
       - cdb_prometheus
+      - cdb_postgres
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:3000/api/health"]
       interval: 30s

--- a/infrastructure/monitoring/grafana/entrypoint-postgres-password.sh
+++ b/infrastructure/monitoring/grafana/entrypoint-postgres-password.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+export POSTGRES_PASSWORD="$(cat /run/secrets/postgres_password)"
+exec /run.sh "$@"


### PR DESCRIPTION
## Summary
- **Root cause:** Datasource provisioning uses `$__env{POSTGRES_PASSWORD}`, but compose set `POSTGRES_PASSWORD__FILE` — a non-`GF_` key that Grafana ignores. Password env was empty → connection failed.
- **Fix:** Add wrapper entrypoint (`entrypoint-postgres-password.sh`) that exports `POSTGRES_PASSWORD` from `/run/secrets/postgres_password` before executing `/run.sh`. Add missing `depends_on: cdb_postgres`.
- **Scope:** Infra/monitoring only. No trading behavior changes.

Closes #730
Note: #741 (Postgres least-privilege/RLS hardening) remains out of scope.

## Test plan
- [x] `docker ps` — `cdb_grafana` running, no restart loop
- [x] Grafana API datasource health: `{"message":"Database Connection OK","status":"OK"}`
- [x] Provisioned datasources: PostgreSQL, Prometheus, Loki all present

🤖 Generated with [Claude Code](https://claude.com/claude-code)