### PR TITLE
fix(obs): WSL2 node_exporter dev override (drop rslave)

### DIFF
--- a/infrastructure/compose/dev.yml
+++ b/infrastructure/compose/dev.yml
@@ -32,6 +32,11 @@ services:
     ports:
       - "127.0.0.1:9187:9187"
 
+  cdb_node_exporter:
+    # Override: drop rslave mount propagation (unsupported on Docker Desktop/WSL2)
+    volumes:
+      - /:/host:ro
+
   cdb_redis_exporter:
     ports:
       - "127.0.0.1:9121:9121"


### PR DESCRIPTION
## Summary
Refs #656

**Root cause (Windows/WSL2):**
- node_exporter volume in base.yml uses `/:/host:ro,rslave`
- Docker Desktop/WSL2: `/` is not a shared/slave mount → container fails to start with `path / is mounted on / but it is not a shared or slave mount`

**Fix (dev-only):**
- dev.yml override replaces volume with `/:/host:ro` (drops rslave)
- No production impact, no trading behavior change

**Evidence:**
- Prometheus target: `job=cdb_node_exporter health=UP` (lastError empty)
- PromQL proof: `node_uname_info` returns 1 series (WSL2 kernel confirmed)

## Test plan
- [x] `docker compose up -d cdb_node_exporter` starts without error
- [x] Prometheus target UP
- [x] `node_uname_info` query returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)