### PR TITLE
refactor(toggles): centralize ALLOW_EVIDENCE_DEBT (#884)

### DIFF
--- a/core/utils/trace_toggle.py
+++ b/core/utils/trace_toggle.py
@@ -15,3 +15,8 @@ import os
 def trace_contract_v1_enabled() -> bool:
     """True nur wenn TRACE_CONTRACT_V1_ENABLED=1."""
     return os.getenv("TRACE_CONTRACT_V1_ENABLED", "0") == "1"
+
+
+def allow_evidence_debt() -> bool:
+    """True nur wenn ALLOW_EVIDENCE_DEBT=1 (fail-closed default)."""
+    return os.getenv("ALLOW_EVIDENCE_DEBT", "0") == "1"

--- a/services/execution/database.py
+++ b/services/execution/database.py
@@ -14,6 +14,7 @@ import time
 from contextlib import contextmanager
 
 from core.utils.uuid_gen import compute_correlation_id, compute_event_pk
+from core.utils.trace_toggle import allow_evidence_debt
 
 try:
     from . import config
@@ -25,7 +26,7 @@ except ImportError:
 logger = logging.getLogger(config.SERVICE_NAME)
 
 # Phase 8C: Fail-closed with safety valve
-ALLOW_EVIDENCE_DEBT = os.getenv("ALLOW_EVIDENCE_DEBT", "0") == "1"
+# Modul-Level-Konstante entfernt; allow_evidence_debt() aus core.utils.trace_toggle
 
 # Valid event types for correlation_ledger
 # BLOCK ist ein Entscheidungsergebnis (event_type="DECISION"), kein eigener Event-Typ.
@@ -107,7 +108,7 @@ class Database:
         # Canonicalize event_type
         event_type = event_type.strip().upper()
         if event_type not in VALID_EVENT_TYPES:
-            if ALLOW_EVIDENCE_DEBT:
+            if allow_evidence_debt():
                 logger.warning(
                     f"⚠️ correlation_ledger skipped: unknown event_type={event_type} "
                     f"(ALLOW_EVIDENCE_DEBT=1)"
@@ -119,7 +120,7 @@ class Database:
 
         # Fail-closed: validate required IDs
         if not signal_id or not decision_id:
-            if ALLOW_EVIDENCE_DEBT:
+            if allow_evidence_debt():
                 logger.warning(
                     f"⚠️ correlation_ledger {event_type} skipped: "
                     f"signal_id={signal_id}, decision_id={decision_id} (ALLOW_EVIDENCE_DEBT=1)"
@@ -131,7 +132,7 @@ class Database:
             )
 
         if event_type == "ORDER" and not order_id:
-            if ALLOW_EVIDENCE_DEBT:
+            if allow_evidence_debt():
                 logger.warning(
                     f"⚠️ correlation_ledger ORDER skipped: order_id missing (ALLOW_EVIDENCE_DEBT=1)"
                 )
@@ -139,7 +140,7 @@ class Database:
             raise ValueError("order_id required for correlation_ledger ORDER")
 
         if event_type == "FILL" and (not order_id or not fill_id):
-            if ALLOW_EVIDENCE_DEBT:
+            if allow_evidence_debt():
                 logger.warning(
                     f"⚠️ correlation_ledger FILL skipped: "
                     f"order_id={order_id}, fill_id={fill_id} (ALLOW_EVIDENCE_DEBT=1)"

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -43,7 +43,7 @@ from core.utils.uuid_gen import (
 )
 from core.utils.clock import utcnow
 from core.utils.redis_payload import sanitize_payload
-from core.utils.trace_toggle import trace_contract_v1_enabled
+from core.utils.trace_toggle import trace_contract_v1_enabled, allow_evidence_debt
 from core.auth import validate_all_auth
 from core.domain.models import Signal
 
@@ -70,7 +70,7 @@ except ImportError:
     from services.risk.models import Order, Alert, RiskState, OrderResult
 
 # Phase 8C: Evidence debt safety valve (default: fail-closed)
-ALLOW_EVIDENCE_DEBT = os.getenv("ALLOW_EVIDENCE_DEBT", "0") == "1"
+# Modul-Level-Konstante entfernt; allow_evidence_debt() aus core.utils.trace_toggle
 
 # Phase 9: Trace Contract v1 toggle → zentral in core.utils.trace_toggle
 # (Modul-Level-Konstante entfernt; trace_contract_v1_enabled() wird direkt aufgerufen)
@@ -1189,7 +1189,7 @@ class RiskManager:
             # BLOCK-Entscheidungen nutzen event_type="DECISION" (BLOCK ist Entscheidungsergebnis,
             # kein eigener Event-Typ). Details in blocked_decisions-Tabelle.
             if not signal_id or not decision_id:
-                if ALLOW_EVIDENCE_DEBT:
+                if allow_evidence_debt():
                     logger.warning(
                         f"⚠️ correlation_ledger DECISION skipped: "
                         f"signal_id={signal_id}, decision_id={decision_id} (ALLOW_EVIDENCE_DEBT=1)"
@@ -1221,7 +1221,7 @@ class RiskManager:
             if trace_contract_v1_enabled():
                 # Phase 8C: blocked_decisions INSERT (fail-closed)
                 if not signal_id or not decision_id:
-                    if ALLOW_EVIDENCE_DEBT:
+                    if allow_evidence_debt():
                         logger.warning(
                             f"⚠️ blocked_decisions skipped: "
                             f"signal_id={signal_id}, decision_id={decision_id} (ALLOW_EVIDENCE_DEBT=1)"


### PR DESCRIPTION
## Summary
- Adds `allow_evidence_debt()` accessor to `core/utils/trace_toggle.py` (same pattern as `trace_contract_v1_enabled()`)
- Replaces duplicated `ALLOW_EVIDENCE_DEBT = os.getenv(...)` module-level constants in `services/risk/service.py` and `services/execution/database.py` with imports of the central accessor
- **No behavior change**: default remains `"0"` (fail-closed), env var name unchanged

## DoD verification
- `grep -rn "ALLOW_EVIDENCE_DEBT.*os.getenv" services/` → **0 matches** ✅
- `grep -rn "def allow_evidence_debt" core/utils/trace_toggle.py` → **match** ✅
- `pytest tests/unit/test_trace_contract_v1.py tests/unit/risk/ -q` → **55 passed** ✅

## Changed files
- `core/utils/trace_toggle.py` — new `allow_evidence_debt()` function
- `services/risk/service.py` — import accessor, remove constant, update 2 call sites
- `services/execution/database.py` — import accessor, remove constant, update 4 call sites

## Test plan
- [x] DoD greps pass (no remaining os.getenv duplicates)
- [x] Targeted unit tests pass (55/55)
- [ ] CI green

Closes #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)