### PR TITLE
docs(operations): soak monitor + 72h zero restart runbooks (refs #467)

### DIFF
--- a/docs/operations/72H_SOAK_TEST_RUNBOOK.md
+++ b/docs/operations/72H_SOAK_TEST_RUNBOOK.md
@@ -1,0 +1,138 @@
+# 72h Zero Restart Soak Test Runbook
+
+Issue #428.
+
+## Goal
+
+Run the full CDB Compose stack for 72 consecutive hours with zero
+container restarts. This gate must pass before any live deployment.
+
+Gate criteria:
+- Zero container restarts across all `cdb_*` services
+- No OOM kills
+- Disk free > 10%
+- Signal queue length < 1000 (no stalls)
+
+## Start Procedure
+
+```bash
+# 1. Pull latest main
+git pull origin main
+
+# 2. Start stack
+cd infrastructure/compose
+docker compose -f compose.blue.yml up -d
+
+# 3. Verify all services healthy
+docker ps --filter name=cdb_ --format '{{.Names}}: {{.Status}}'
+
+# 4. Verify monitoring
+curl -s http://localhost:9090/-/ready   # Prometheus
+curl -s http://localhost:3000/api/health # Grafana
+
+# 5. Create artifacts dir and install hourly monitor
+mkdir -p artifacts
+chmod +x infrastructure/scripts/soak_monitor.sh
+
+# 6. Dry run
+./infrastructure/scripts/soak_monitor.sh
+
+# 7. Install cron (adjust path)
+(crontab -l 2>/dev/null; echo "0 * * * * cd $(pwd)/../.. && ./infrastructure/scripts/soak_monitor.sh >> artifacts/soak_cron.log 2>&1") | crontab -
+```
+
+## During the Run
+
+**Dashboards:**
+Open the soak test dashboard in Grafana. To find name and file:
+
+```bash
+grep -n "title" infrastructure/monitoring/grafana/dashboards/*soak* | head -3
+```
+
+**What is normal:**
+- Container restart count stays at 0
+- Memory usage fluctuates but stays below 80% of limit
+- Order flow may pause outside market hours (expected)
+- Disk usage grows slowly from logs/DB
+
+**Periodic checks (automated by `soak_monitor.sh`):**
+- Hourly: container restarts, service health, disk space
+- Every 6h: resource snapshots saved to `artifacts/`
+- Every 12h: database row counts
+
+## Abort Triggers
+
+The soak test MUST be aborted if any of these occur:
+
+1. **Container restart** — any `cdb_*` container restarts for any reason
+2. **OOM kill** — kernel kills a container for memory
+3. **Disk full** — free space drops below 10%
+4. **Queue stall** — signal queue > 1000 messages for > 10 min
+
+The script writes `soak_test_FAILED.txt` into the artifacts directory
+on restart detection. Prometheus alerts with `soak_test: abort` fire
+independently.
+
+To see which alerts are abort-triggers:
+
+```bash
+grep -B2 "soak_test: abort" infrastructure/monitoring/alerts.yml
+```
+
+## Stop / Abort Procedure
+
+```bash
+# 1. Remove cron
+crontab -l | grep -v soak_monitor | crontab -
+
+# 2. Capture final state
+./infrastructure/scripts/soak_monitor.sh
+docker ps --filter name=cdb_ > artifacts/final_container_status.txt
+docker stats --no-stream > artifacts/final_resources.txt
+
+# 3. Stop stack (optional — may keep running for investigation)
+cd infrastructure/compose
+docker compose -f compose.blue.yml down
+```
+
+## Post-run
+
+**Artifacts to preserve** (in `artifacts/soak_test_YYYYMMDD_HHMMSS/`):
+- `hourly_checks.log` — full timeline of hourly checks
+- `resources_snapshot_*.txt` — 6h resource snapshots
+- `db_growth_*.txt` — 12h database growth
+- `restart_alerts.log` — empty if test passed
+- `soak_test_FAILED.txt` — absent if test passed
+
+**Go / No-Go decision:**
+- PASS: no `soak_test_FAILED.txt`, no restart entries, 72h elapsed
+- FAIL: any abort trigger hit — document root cause before re-attempting
+
+## Troubleshooting: Common Issues
+
+| Symptom | Investigation |
+|---|---|
+| Service down but no restart | Check `docker logs <service> --tail 200`; may be crash-loop with backoff |
+| High memory usage (>80%) | Check for leak: `docker stats --no-stream`; compare 6h snapshots |
+| Message queue backlog | `docker exec cdb_redis redis-cli XLEN stream.orders`; check signal/risk logs |
+| No orders generated for 1h+ | Verify market data flow: `docker logs cdb_ws --tail 50` |
+| Cron not firing | `grep CRON /var/log/syslog`; verify docker group membership for cron user |
+
+## High Memory Usage
+
+If `SoakTest_HighMemoryUsage` fires (container > 80% of limit for 30 min):
+
+1. Identify container: check alert label `name`
+2. Compare memory across 6h snapshots in artifacts
+3. If monotonically increasing: likely memory leak — abort and file bug
+4. If stable plateau: may be normal working set — continue monitoring
+
+## Message Queue Backlog
+
+If `SoakTest_MessageQueueStalled` fires (queue > 1000 for 10 min):
+
+1. Check consumer health: `docker logs cdb_signal --tail 100`
+2. Check Redis: `docker exec cdb_redis redis-cli XLEN stream.orders`
+3. If consumer is alive but slow: resource contention — check CPU/memory
+4. If consumer is dead: abort, capture logs

--- a/docs/operations/SOAK_MONITOR_RUNBOOK.md
+++ b/docs/operations/SOAK_MONITOR_RUNBOOK.md
@@ -1,0 +1,115 @@
+# Soak Monitor Runbook
+
+Operational guide for `infrastructure/scripts/soak_monitor.sh` (Issue #428).
+
+## Purpose
+
+Hourly monitoring script for the 72h Zero Restart Soak Test.
+Runs 5 checks per invocation: container restarts, service health,
+resource snapshots (6h), database growth (12h), and disk space.
+On restart detection the script writes a `soak_test_FAILED.txt` marker
+and captures failure evidence.
+
+## Preconditions
+
+| Requirement | How to verify |
+|---|---|
+| Docker + Compose running | `docker ps --filter name=cdb_` shows services (script expects `EXPECTED_SERVICES=8`, see `soak_monitor.sh:108`) |
+| Prometheus scraping | `curl -s http://localhost:9090/-/ready` returns 200 |
+| Grafana reachable | `curl -s http://localhost:3000/api/health` returns `ok` |
+| Write permissions | `touch artifacts/.probe && rm artifacts/.probe` succeeds |
+
+## Pre-start Checklist
+
+```bash
+# 1. Create artifacts directory (script auto-creates if missing,
+#    but pre-creating avoids the warning in the first run)
+mkdir -p artifacts
+
+# 2. Make script executable
+chmod +x infrastructure/scripts/soak_monitor.sh
+
+# 3. Verify Compose stack is healthy
+docker ps --filter name=cdb_ --format '{{.Names}}: {{.Status}}'
+```
+
+## Manual / Dry Run
+
+```bash
+# Run once to verify output and artifact creation
+./infrastructure/scripts/soak_monitor.sh
+
+# Expected output:
+#   [CHECK 1/5] Container Restart Detection... No restarts detected
+#   [CHECK 2/5] Service Health Status... All 8/8 services running
+#   [CHECK 3/5] Resource Snapshot (skipped - not 6h interval)
+#   [CHECK 4/5] Database Growth Check (skipped - not 12h interval)
+#   [CHECK 5/5] Disk Space Check... Disk usage: <N>%
+
+# Expected artifacts (in artifacts/soak_test_YYYYMMDD_HHMMSS/):
+#   hourly_checks.log   — one line per successful check
+#   restart_alerts.log   — only if restarts detected
+#   soak_test_FAILED.txt — only if Zero Restart violated
+```
+
+## Cron Installation (Linux)
+
+```bash
+# Open crontab
+crontab -e
+
+# Add (adjust /absolute/path/to/repo):
+SHELL=/bin/bash
+0 * * * * cd /absolute/path/to/repo && ./infrastructure/scripts/soak_monitor.sh >> artifacts/soak_cron.log 2>&1
+```
+
+**Notes:**
+- Use absolute path to the repo root (cron has minimal `$PATH`).
+- `cd` into the repo so relative `artifacts/` paths resolve correctly.
+- Redirect output to `soak_cron.log` for debugging cron issues.
+- The script uses `docker` CLI; ensure the cron user is in the `docker` group.
+
+## Prometheus Alerts
+
+Soak-test alerts live in `infrastructure/monitoring/alerts.yml`,
+group `soak_test_gates`. To list current alert names and thresholds:
+
+```bash
+grep -n "alert: SoakTest_" infrastructure/monitoring/alerts.yml
+grep -n "soak_test_gates" infrastructure/monitoring/alerts.yml
+```
+
+Alerts with `soak_test: abort` are hard-stop criteria (soak test fails).
+Alerts with `soak_test: investigate` require manual triage but do not
+auto-abort.
+
+## Grafana Dashboard
+
+**Dashboard:** `Claire - 72h Soak Test Monitor`
+**File:** `infrastructure/monitoring/grafana/dashboards/claire_soak_test_v1.json`
+
+Key panels: Container Restarts (must be 0), Disk Space Remaining,
+Test Duration, per-service health (redis, postgres, ws, signal,
+risk, execution, db_writer, paper_runner).
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| `No soak test artifacts directory found` | Script auto-creates; for clean start: `mkdir -p artifacts` |
+| Cron not running | `grep CRON /var/log/syslog`; check crontab user, PATH, docker group |
+| Targets DOWN in Prometheus | `docker ps --filter name=cdb_` + check compose health |
+| Disk usage critical (>90%) | `docker system prune -f`; review log volume mounts |
+| DB query fails | Verify cdb_postgres is running; check DB user/name in compose |
+
+## Disable / Rollback
+
+```bash
+# Remove cron entry
+crontab -e   # delete the soak_monitor line
+
+# Or comment out temporarily
+# 0 * * * * cd /path/to/repo && ./infrastructure/scripts/soak_monitor.sh ...
+```
+
+No rollback needed for the script itself; it is read-only against the stack.


### PR DESCRIPTION
## Summary
- `docs/operations/SOAK_MONITOR_RUNBOOK.md` — script usage, pre-start checklist, cron wiring, troubleshooting
- `docs/operations/72H_SOAK_TEST_RUNBOOK.md` — full start/run/stop procedure, abort criteria, post-run Go/No-Go (matches `runbook_url` references in `infrastructure/monitoring/alerts.yml`)

## No code changes
- `soak_monitor.sh` already handles `mkdir -p` internally (lines 28-30)
- Runbooks reference alerts/dashboards via grep commands (not hardcoded names) to avoid drift

## Test plan
- [x] Docs-only, no tests needed
- [ ] CI green

Refs #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)