### PR TITLE
fix(execution): prevent correlation_ledger validation errors from dropping order_results

### DIFF
--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -310,79 +310,87 @@ def process_order(order_data: dict):
 
         # Phase 8C/8E: Persist ORDER and FILL events to correlation_ledger
         # order_id ist jetzt final (von executor zurückgegeben)
+        # Correlation write failures must NOT prevent order_results publish.
         if db:
-            timestamp_ms = int(time.time() * 1000)
-            schema_status = ExecutionResult._schema_status(result.status)
+            try:
+                timestamp_ms = int(time.time() * 1000)
+                schema_status = ExecutionResult._schema_status(result.status)
 
-            # ORDER event (always persisted)
-            order_payload = {
-                "signal_id": order.signal_id,
-                "decision_id": order.decision_id,
-                "order_id": result.order_id,
-                "symbol": order.symbol,
-                "side": order.side,
-                "quantity": order.quantity,
-                "strategy_id": order.strategy_id,
-                "trace_id": order.trace_id,
-            }
-            # Phase 9: Trace Contract v1 - Policy governance (conditional)
-            if getattr(order, "policy_id", None) is not None:
-                order_payload["policy_id"] = order.policy_id
-            if getattr(order, "policy_hash", None) is not None:
-                order_payload["policy_hash"] = order.policy_hash
-            if getattr(order, "input_hash", None) is not None:
-                order_payload["input_hash"] = order.input_hash
-            if getattr(order, "output_hash", None) is not None:
-                order_payload["output_hash"] = order.output_hash
-            if not db.persist_correlation_event(
-                signal_id=order.signal_id,
-                event_type="ORDER",
-                symbol=order.symbol,
-                timestamp_ms=timestamp_ms,
-                decision_id=order.decision_id,
-                order_id=result.order_id,
-                payload=order_payload,
-            ):
-                logger.warning(
-                    "⚠️ correlation_ledger ORDER write failed (evidence debt)"
-                )
-
-            # Phase 8E: FILL event (only for fully filled orders, same timestamp_ms)
-            if schema_status == "FILLED" and result.fill_id:
-                fill_payload = {
+                # ORDER event (always persisted)
+                order_payload = {
                     "signal_id": order.signal_id,
                     "decision_id": order.decision_id,
                     "order_id": result.order_id,
-                    "fill_id": result.fill_id,
                     "symbol": order.symbol,
                     "side": order.side,
-                    "filled_quantity": result.filled_quantity,
-                    "price": result.price,
+                    "quantity": order.quantity,
                     "strategy_id": order.strategy_id,
                     "trace_id": order.trace_id,
                 }
                 # Phase 9: Trace Contract v1 - Policy governance (conditional)
                 if getattr(order, "policy_id", None) is not None:
-                    fill_payload["policy_id"] = order.policy_id
+                    order_payload["policy_id"] = order.policy_id
                 if getattr(order, "policy_hash", None) is not None:
-                    fill_payload["policy_hash"] = order.policy_hash
+                    order_payload["policy_hash"] = order.policy_hash
                 if getattr(order, "input_hash", None) is not None:
-                    fill_payload["input_hash"] = order.input_hash
+                    order_payload["input_hash"] = order.input_hash
                 if getattr(order, "output_hash", None) is not None:
-                    fill_payload["output_hash"] = order.output_hash
+                    order_payload["output_hash"] = order.output_hash
                 if not db.persist_correlation_event(
                     signal_id=order.signal_id,
-                    event_type="FILL",
+                    event_type="ORDER",
                     symbol=order.symbol,
                     timestamp_ms=timestamp_ms,
                     decision_id=order.decision_id,
                     order_id=result.order_id,
-                    fill_id=result.fill_id,
-                    payload=fill_payload,
+                    payload=order_payload,
                 ):
                     logger.warning(
-                        "⚠️ correlation_ledger FILL write failed (evidence debt)"
+                        "⚠️ correlation_ledger ORDER write failed (evidence debt)"
                     )
+
+                # Phase 8E: FILL event (only for fully filled orders, same timestamp_ms)
+                if schema_status == "FILLED" and result.fill_id:
+                    fill_payload = {
+                        "signal_id": order.signal_id,
+                        "decision_id": order.decision_id,
+                        "order_id": result.order_id,
+                        "fill_id": result.fill_id,
+                        "symbol": order.symbol,
+                        "side": order.side,
+                        "filled_quantity": result.filled_quantity,
+                        "price": result.price,
+                        "strategy_id": order.strategy_id,
+                        "trace_id": order.trace_id,
+                    }
+                    # Phase 9: Trace Contract v1 - Policy governance (conditional)
+                    if getattr(order, "policy_id", None) is not None:
+                        fill_payload["policy_id"] = order.policy_id
+                    if getattr(order, "policy_hash", None) is not None:
+                        fill_payload["policy_hash"] = order.policy_hash
+                    if getattr(order, "input_hash", None) is not None:
+                        fill_payload["input_hash"] = order.input_hash
+                    if getattr(order, "output_hash", None) is not None:
+                        fill_payload["output_hash"] = order.output_hash
+                    if not db.persist_correlation_event(
+                        signal_id=order.signal_id,
+                        event_type="FILL",
+                        symbol=order.symbol,
+                        timestamp_ms=timestamp_ms,
+                        decision_id=order.decision_id,
+                        order_id=result.order_id,
+                        fill_id=result.fill_id,
+                        payload=fill_payload,
+                    ):
+                        logger.warning(
+                            "⚠️ correlation_ledger FILL write failed (evidence debt)"
+                        )
+            except ValueError as corr_err:
+                logger.warning(
+                    "correlation_ledger write skipped for order %s: %s",
+                    result.order_id,
+                    corr_err,
+                )
 
         # Update stats (Thread-safe)
         schema_status = ExecutionResult._schema_status(result.status)

--- a/tests/e2e/test_paper_trading_p0.py
+++ b/tests/e2e/test_paper_trading_p0.py
@@ -526,10 +526,12 @@ def test_tc_p0_001_happy_path_market_to_trade(redis_client, unique_order_id):
     - Latency < 1000ms
     """
     start_time = time.time()
+    t_start = time.monotonic()
 
     # Subscribe to order_results
     pubsub = redis_client.pubsub()
     pubsub.subscribe("order_results")
+    t_subscribed = time.monotonic()
     for _ in range(3):
         pubsub.get_message(timeout=0.1)
 
@@ -542,33 +544,70 @@ def test_tc_p0_001_happy_path_market_to_trade(redis_client, unique_order_id):
         "type": "order",  # Fixed: execution service expects "order" not "MARKET"
         "source": "e2e_test_happy_path",
     }
+    t_publish = time.monotonic()
     redis_client.publish("orders", json.dumps(order_payload))
 
     # Wait for result
     result_message = None
-    for _ in range(20):
+    t_first_recv = None
+    attempts_used = 0
+    for i in range(20):
         message = pubsub.get_message(timeout=0.5)
         if message and message["type"] == "message":
+            t_first_recv = time.monotonic()
+            attempts_used = i + 1
             result_message = message
             break
 
     pubsub.unsubscribe("order_results")
     pubsub.close()
+    t_end = time.monotonic()
 
     end_time = time.time()
     latency_ms = (end_time - start_time) * 1000
 
-    # Assertions
-    assert result_message is not None, "TC-P0-001 FAILED: No order_result received"
+    # Instrumentation (log only)
+    publish_to_receive_ms = (
+        (t_first_recv - t_publish) * 1000 if t_first_recv is not None else -1.0
+    )
+    _env_type = ""
+    _recv_oid = ""
+    _recv_st = ""
+    if result_message is not None:
+        _env_type = result_message.get("type", "")
+        try:
+            _rp = json.loads(result_message["data"])
+            _recv_oid = _rp.get("order_id", "")
+            _recv_st = _rp.get("status", "")
+        except Exception:
+            pass
 
-    payload = json.loads(result_message["data"])
-    assert payload["status"] in [
-        "FILLED",
-        "filled",
-    ], f"TC-P0-001 FAILED: Expected FILLED, got {payload['status']}"
-    assert latency_ms < 1000, f"TC-P0-001 FAILED: Latency {latency_ms:.0f}ms > 1000ms"
+    try:
+        # Assertions
+        assert result_message is not None, "TC-P0-001 FAILED: No order_result received"
 
-    print(f"✅ TC-P0-001 PASSED: Happy path completed in {latency_ms:.0f}ms")
+        payload = json.loads(result_message["data"])
+        assert payload["status"] in [
+            "FILLED",
+            "filled",
+        ], f"TC-P0-001 FAILED: Expected FILLED, got {payload['status']}"
+        assert latency_ms < 1000, f"TC-P0-001 FAILED: Latency {latency_ms:.0f}ms > 1000ms"
+
+        print(f"✅ TC-P0-001 PASSED: Happy path completed in {latency_ms:.0f}ms")
+    finally:
+        print(
+            f"TC-P0-001 latency_ms={latency_ms:.1f}"
+            f" publish_to_receive_ms={publish_to_receive_ms:.1f}"
+            f" breakdown: start={t_start:.4f}"
+            f" subscribed={t_subscribed:.4f}"
+            f" publish={t_publish:.4f}"
+            f" first_recv={t_first_recv or 0:.4f}"
+            f" end={t_end:.4f}"
+            f" attempts={attempts_used}"
+            f" envelope_type={_env_type}"
+            f" order_id={_recv_oid}"
+            f" status={_recv_st}"
+        )
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
## Summary
- Wrap correlation_ledger ORDER/FILL persistence in `try/except ValueError` so validation failures (missing signal_id/decision_id) no longer abort `process_order()` before `_publish_result()`
- Previously: silent drop — consumers never received an `order_results` event, causing E2E timeouts (TC-P0-001)
- Add monotonic instrumentation to TC-P0-001 for latency breakdown diagnostics (log-only, no assertion changes)

## Test plan
- [x] TC-P0-001 passes: `publish_to_receive_ms=188.9ms`, status=FILLED, 1 attempt
- [x] Before fix: `publish_to_receive_ms=-1.0` (no receive, silent drop, timeout after 10s)
- [ ] CI green on existing unit/integration tests
- [ ] Verify execution logs show `correlation_ledger write skipped` warning (not stacktrace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)