### PR TITLE
docs(lr): re-attestation addenda for LR-002 LR-006 LR-007

### DIFF
--- a/docs/live-readiness/LR-002-EVIDENCE-ADDENDUM.md
+++ b/docs/live-readiness/LR-002-EVIDENCE-ADDENDUM.md
@@ -1,0 +1,168 @@
+# LR-002 Evidence Addendum: Contract Test Count Growth
+
+**Task ID:** LR-002
+**Task Title:** P0 Contract Tests as First-Class Gate
+**Addendum Date:** 2026-02-22
+**Author:** Claude Code (Repo Analyst)
+**Type:** Append-only addendum. Does not modify `LR-002-STATE.yaml` or `LR-002-EVIDENCE.md`.
+
+---
+
+## 1. Purpose and Scope
+
+This addendum documents the growth in contract test count since the original LR-002 attestation (2026-02-04, baseline `81955684a2ef`). The original `LR-002-EVIDENCE.md` attested 16 contract tests in `tests/contract/test_decision_contract.py`. This addendum records the current state at HEAD `1d08c7c` (2026-02-22).
+
+This document is append-only. It does not rewrite or invalidate the original LR-002 evidence. It records the current test count, the delta, and the test execution result.
+
+No claims are made about thresholds, units, or decision logic. This addendum only records that tests exist and pass.
+
+---
+
+## 2. Current State (2026-02-22)
+
+**Source:** `tests/contract/test_decision_contract.py`
+**Marker:** `@pytest.mark.contract`
+**Python:** 3.14.3, pytest 9.0.2
+**Commit:** `1d08c7c`
+
+### 2.1 Test Collection
+
+```
+$ pytest --co -q tests/contract
+collected 24 items
+
+<Dir Claire_de_Binare>
+  <Package tests>
+    <Dir contract>
+      <Module test_decision_contract.py>
+        <Function test_decision_allow>
+        <Function test_decision_rc_002_panic_return_1m>
+        <Function test_decision_rc_002_panic_return_5m>
+        <Function test_decision_rc_002_panic_price_change>
+        <Function test_decision_rc_003_stale>
+        <Function test_decision_rc_004_data_silence>
+        <Function test_decision_rc_001_regime_block>
+        <Function test_decision_rc_010_signal_thresholds>
+        <Function test_decision_rc_020_daily_drawdown>
+        <Function test_decision_rc_021_exposure>
+        <Function test_decision_rc_022_slippage>
+        <Function test_decision_determinism>
+        <Function test_decision_first_fail_panic_wins>
+        <Function test_decision_first_fail_stale_wins_over_regime>
+        <Function test_decision_first_fail_regime_wins_over_signal>
+        <Function test_decision_first_fail_drawdown_wins_over_exposure>
+        <Function test_decision_rc_003_staleness_computed_without_market_health>
+        <Function test_decision_rc_003_all_timestamps_none>
+        <Function test_decision_rc_022_skipped_when_market_health_none>
+        <Function test_decision_rc_004_when_last_tick_ts_ms_missing>
+        <Function test_decision_rc_004_when_data_silence_exceeds_threshold>
+        <Function test_decision_rc_001_when_regime_id_missing>
+        <Function test_decision_rc_001_blocks_regime_2_volatile>
+        <Function test_decision_rc_001_blocks_regime_3_crisis>
+
+========================= 24 tests collected in 0.24s =========================
+```
+
+### 2.2 Test Execution
+
+```
+$ pytest -v --tb=short tests/contract
+============================= test session starts =============================
+platform win32 -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
+rootdir: D:\Dev\Workspaces\Repos\Claire_de_Binare
+configfile: pytest.ini
+collected 24 items
+
+tests/contract/test_decision_contract.py::test_decision_allow PASSED     [  4%]
+tests/contract/test_decision_contract.py::test_decision_rc_002_panic_return_1m PASSED [  8%]
+tests/contract/test_decision_contract.py::test_decision_rc_002_panic_return_5m PASSED [ 12%]
+tests/contract/test_decision_contract.py::test_decision_rc_002_panic_price_change PASSED [ 16%]
+tests/contract/test_decision_contract.py::test_decision_rc_003_stale PASSED [ 20%]
+tests/contract/test_decision_contract.py::test_decision_rc_004_data_silence PASSED [ 25%]
+tests/contract/test_decision_contract.py::test_decision_rc_001_regime_block PASSED [ 29%]
+tests/contract/test_decision_contract.py::test_decision_rc_010_signal_thresholds PASSED [ 33%]
+tests/contract/test_decision_contract.py::test_decision_rc_020_daily_drawdown PASSED [ 37%]
+tests/contract/test_decision_contract.py::test_decision_rc_021_exposure PASSED [ 41%]
+tests/contract/test_decision_contract.py::test_decision_rc_022_slippage PASSED [ 45%]
+tests/contract/test_decision_contract.py::test_decision_determinism PASSED [ 50%]
+tests/contract/test_decision_contract.py::test_decision_first_fail_panic_wins PASSED [ 54%]
+tests/contract/test_decision_contract.py::test_decision_first_fail_stale_wins_over_regime PASSED [ 58%]
+tests/contract/test_decision_contract.py::test_decision_first_fail_regime_wins_over_signal PASSED [ 62%]
+tests/contract/test_decision_contract.py::test_decision_first_fail_drawdown_wins_over_exposure PASSED [ 66%]
+tests/contract/test_decision_contract.py::test_decision_rc_003_staleness_computed_without_market_health PASSED [ 70%]
+tests/contract/test_decision_contract.py::test_decision_rc_003_all_timestamps_none PASSED [ 75%]
+tests/contract/test_decision_contract.py::test_decision_rc_022_skipped_when_market_health_none PASSED [ 79%]
+tests/contract/test_decision_contract.py::test_decision_rc_004_when_last_tick_ts_ms_missing PASSED [ 83%]
+tests/contract/test_decision_contract.py::test_decision_rc_004_when_data_silence_exceeds_threshold PASSED [ 87%]
+tests/contract/test_decision_contract.py::test_decision_rc_001_when_regime_id_missing PASSED [ 91%]
+tests/contract/test_decision_contract.py::test_decision_rc_001_blocks_regime_2_volatile PASSED [ 95%]
+tests/contract/test_decision_contract.py::test_decision_rc_001_blocks_regime_3_crisis PASSED [100%]
+
+============================= 24 passed in 0.18s ==============================
+```
+
+---
+
+## 3. Delta vs LR-002 Original Attestation
+
+| Attribute | LR-002 Evidence (2026-02-04) | Current (2026-02-22) | Changed? |
+|---|---|---|---|
+| Test file location | `tests/contract/test_decision_contract.py` | same | No |
+| Marker | `@pytest.mark.contract` | same | No |
+| Test count | 16 | 24 | Yes (+8) |
+| All tests pass | Yes | Yes | No |
+
+### 3.1 Original 16 Tests (Unchanged)
+
+| # | Test Function |
+|---|---|
+| 1 | `test_decision_allow` |
+| 2 | `test_decision_rc_002_panic_return_1m` |
+| 3 | `test_decision_rc_002_panic_return_5m` |
+| 4 | `test_decision_rc_002_panic_price_change` |
+| 5 | `test_decision_rc_003_stale` |
+| 6 | `test_decision_rc_004_data_silence` |
+| 7 | `test_decision_rc_001_regime_block` |
+| 8 | `test_decision_rc_010_signal_thresholds` |
+| 9 | `test_decision_rc_020_daily_drawdown` |
+| 10 | `test_decision_rc_021_exposure` |
+| 11 | `test_decision_rc_022_slippage` |
+| 12 | `test_decision_determinism` |
+| 13 | `test_decision_first_fail_panic_wins` |
+| 14 | `test_decision_first_fail_stale_wins_over_regime` |
+| 15 | `test_decision_first_fail_regime_wins_over_signal` |
+| 16 | `test_decision_first_fail_drawdown_wins_over_exposure` |
+
+### 3.2 New Tests Added Since LR-002 (+8)
+
+| # | Test Function | Area |
+|---|---|---|
+| 17 | `test_decision_rc_003_staleness_computed_without_market_health` | RC_003 edge case |
+| 18 | `test_decision_rc_003_all_timestamps_none` | RC_003 edge case |
+| 19 | `test_decision_rc_022_skipped_when_market_health_none` | RC_022 edge case |
+| 20 | `test_decision_rc_004_when_last_tick_ts_ms_missing` | RC_004 edge case |
+| 21 | `test_decision_rc_004_when_data_silence_exceeds_threshold` | RC_004 edge case |
+| 22 | `test_decision_rc_001_when_regime_id_missing` | RC_001 edge case |
+| 23 | `test_decision_rc_001_blocks_regime_2_volatile` | RC_001 regime variant |
+| 24 | `test_decision_rc_001_blocks_regime_3_crisis` | RC_001 regime variant |
+
+All 8 new tests exercise edge cases and additional regime variants of existing reason codes. No new reason codes introduced.
+
+---
+
+## 4. Reproduction Commands
+
+```bash
+# Collect tests (count)
+pytest --co -q tests/contract
+
+# Run contract tests (verbose)
+pytest -v --tb=short tests/contract
+
+# Run by marker, scoped to contract directory
+pytest -m contract -v --tb=short tests/contract
+```
+
+---
+
+**End of addendum. No files modified beyond this document.**

--- a/docs/live-readiness/LR-006-EVIDENCE-ADDENDUM.md
+++ b/docs/live-readiness/LR-006-EVIDENCE-ADDENDUM.md
@@ -1,0 +1,139 @@
+# LR-006 Evidence Addendum: Evidence Dict Key Inventory
+
+**Task ID:** LR-006
+**Task Title:** P0 Deterministic Decision Traceability Contract
+**Addendum Date:** 2026-02-22
+**Author:** Claude Code (Repo Analyst)
+**Type:** Append-only addendum. Does not modify `LR-006-STATE.yaml` or `LR-006-EVIDENCE.md`.
+
+---
+
+## 1. Purpose and Scope
+
+This addendum documents the current structure of the evidence dictionary returned by `decide_trade()` at `services/risk/service.py:193`, observed at HEAD `1d08c7c` (2026-02-22).
+
+The original `LR-006-EVIDENCE.md` (2026-02-07) attested 3 example trace records and acceptance criteria AC8/AC9/AC13/AC14. This addendum records the current evidence dict key inventory as returned by the public `decide_trade()` API, under both toggle states of `TRACE_CONTRACT_V1_ENABLED`.
+
+This document is append-only. It does not rewrite or invalidate the original LR-006 evidence. No claims are made about traceability quality or compliance — only the observable key set is inventoried.
+
+---
+
+## 2. Evidence Dict Keys — Toggle OFF (Default)
+
+**Environment:** `TRACE_CONTRACT_V1_ENABLED` not set (default `"0"`)
+**Command:**
+
+```bash
+python -c "
+from services.risk import service as rs
+now_ms = 1_700_000_000_000
+sig = {'signal_id':'sig-test','symbol':'BTCUSDT','pct_change_15m':3.5,'volume_15m':200000.0,'ts_ms':now_ms-1000}
+ms  = {'regime_id':0,'return_1m':-1.0,'return_5m':-1.0,'price_change_5m':5.0,'last_tick_ts_ms':now_ms-500,'ts_ms':now_ms-900}
+acc = {'daily_drawdown_pct':1.0,'total_exposure_pct':10.0,'ts_ms':now_ms-800}
+mh  = {'slippage_pct':0.5,'ts_ms':now_ms-700}
+d, rc, ev = rs.decide_trade(sig, ms, acc, mh, now_ms)
+print('decision:', d, 'reason_code:', rc)
+print('key_count:', len(ev))
+print('evidence_keys:', sorted(ev.keys()))
+"
+```
+
+**Output:**
+
+```
+decision: ALLOW reason_code: None
+key_count: 20
+evidence_keys: ['contract_version', 'daily_drawdown_pct', 'data_silence_s', 'decision_id', 'pct_change_15m', 'price_change_5m', 'regime_id', 'return_1m', 'return_5m', 'signal_id', 'slippage_pct', 'staleness_s', 'staleness_sources', 'symbol', 'thresholds', 'timestamp_ms', 'timestamps_ms', 'total_exposure_pct', 'trace_id', 'volume_15m']
+```
+
+**Key count:** 20
+
+**Correlation IDs present:** `decision_id`, `trace_id`, `signal_id`
+**Contract marker present:** `contract_version`
+
+---
+
+## 3. Evidence Dict Keys — Toggle ON (`TRACE_CONTRACT_V1_ENABLED=1`)
+
+**Environment:** `TRACE_CONTRACT_V1_ENABLED=1`
+**Command:**
+
+```bash
+TRACE_CONTRACT_V1_ENABLED=1 python -c "
+from services.risk import service as rs
+now_ms = 1_700_000_000_000
+sig = {'signal_id':'sig-test','symbol':'BTCUSDT','pct_change_15m':3.5,'volume_15m':200000.0,'ts_ms':now_ms-1000}
+ms  = {'regime_id':0,'return_1m':-1.0,'return_5m':-1.0,'price_change_5m':5.0,'last_tick_ts_ms':now_ms-500,'ts_ms':now_ms-900}
+acc = {'daily_drawdown_pct':1.0,'total_exposure_pct':10.0,'ts_ms':now_ms-800}
+mh  = {'slippage_pct':0.5,'ts_ms':now_ms-700}
+d, rc, ev = rs.decide_trade(sig, ms, acc, mh, now_ms)
+print('decision:', d, 'reason_code:', rc)
+print('key_count:', len(ev))
+print('evidence_keys:', sorted(ev.keys()))
+"
+```
+
+**Output:**
+
+```
+decision: ALLOW reason_code: None
+key_count: 20
+evidence_keys: ['contract_version', 'daily_drawdown_pct', 'data_silence_s', 'decision_id', 'pct_change_15m', 'price_change_5m', 'regime_id', 'return_1m', 'return_5m', 'signal_id', 'slippage_pct', 'staleness_s', 'staleness_sources', 'symbol', 'thresholds', 'timestamp_ms', 'timestamps_ms', 'total_exposure_pct', 'trace_id', 'volume_15m']
+```
+
+**Key count:** 20
+
+**Observation:** The evidence dict returned by `decide_trade()` is identical under both toggle states (20 keys, same set). The toggle `TRACE_CONTRACT_V1_ENABLED` does not affect the `decide_trade()` return value itself. Phase 9 enrichment (`_phase9_enrich_evidence`) is invoked downstream in the `RiskManager.process_signal` pipeline, not within `decide_trade()`.
+
+---
+
+## 4. Toggle Reference
+
+| Attribute | Value |
+|---|---|
+| Toggle file | `core/utils/trace_toggle.py` |
+| Toggle function | `trace_contract_v1_enabled()` |
+| Environment variable | `TRACE_CONTRACT_V1_ENABLED` |
+| Default | `"0"` (OFF) |
+| Phase 9 enrichment function | `services/risk/service.py:_phase9_enrich_evidence()` |
+| Phase 9 invocation site | Downstream in `RiskManager.process_signal`, not in `decide_trade()` |
+
+Per code path at `services/risk/service.py:337-419`, `_phase9_enrich_evidence()` may add keys (`policy_id`, `policy_hash`, `input_hash`, `output_hash`, `decision_context`) when invoked downstream. These keys are not observable from `decide_trade()` alone.
+
+---
+
+## 5. Reproduction Commands
+
+```bash
+# Toggle OFF (default) — evidence keys from decide_trade()
+python -c "
+from services.risk import service as rs
+now_ms = 1_700_000_000_000
+sig = {'signal_id':'sig-test','symbol':'BTCUSDT','pct_change_15m':3.5,'volume_15m':200000.0,'ts_ms':now_ms-1000}
+ms  = {'regime_id':0,'return_1m':-1.0,'return_5m':-1.0,'price_change_5m':5.0,'last_tick_ts_ms':now_ms-500,'ts_ms':now_ms-900}
+acc = {'daily_drawdown_pct':1.0,'total_exposure_pct':10.0,'ts_ms':now_ms-800}
+mh  = {'slippage_pct':0.5,'ts_ms':now_ms-700}
+d, rc, ev = rs.decide_trade(sig, ms, acc, mh, now_ms)
+print('decision:', d, 'reason_code:', rc)
+print('key_count:', len(ev))
+print('evidence_keys:', sorted(ev.keys()))
+"
+
+# Toggle ON — same observation via decide_trade()
+TRACE_CONTRACT_V1_ENABLED=1 python -c "
+from services.risk import service as rs
+now_ms = 1_700_000_000_000
+sig = {'signal_id':'sig-test','symbol':'BTCUSDT','pct_change_15m':3.5,'volume_15m':200000.0,'ts_ms':now_ms-1000}
+ms  = {'regime_id':0,'return_1m':-1.0,'return_5m':-1.0,'price_change_5m':5.0,'last_tick_ts_ms':now_ms-500,'ts_ms':now_ms-900}
+acc = {'daily_drawdown_pct':1.0,'total_exposure_pct':10.0,'ts_ms':now_ms-800}
+mh  = {'slippage_pct':0.5,'ts_ms':now_ms-700}
+d, rc, ev = rs.decide_trade(sig, ms, acc, mh, now_ms)
+print('decision:', d, 'reason_code:', rc)
+print('key_count:', len(ev))
+print('evidence_keys:', sorted(ev.keys()))
+"
+```
+
+---
+
+**End of addendum. No files modified beyond this document.**

--- a/docs/live-readiness/LR-007-STATUS-ADDENDUM.md
+++ b/docs/live-readiness/LR-007-STATUS-ADDENDUM.md
@@ -1,0 +1,178 @@
+# LR-007 Status Addendum: Invariant Delta Since Baseline
+
+**Task ID:** LR-007
+**Task Title:** Shadow Mode Validation Gate
+**Addendum Date:** 2026-02-22
+**Author:** Claude Code (Repo Analyst)
+**Type:** Append-only addendum. Does not modify `LR-007-STATE.yaml` or `LR-007-STATUS.md`.
+
+---
+
+## 1. Purpose and Scope
+
+This addendum documents changes to code paths relevant to LR-007 invariants since the baseline commit `bef8da1` (2026-02-09) to HEAD `1d08c7c` (2026-02-22).
+
+This document is append-only. It does not rewrite or invalidate the original LR-007 status. It does not restart, reset, or modify the shadow mode timeline or any soak metric collection. It records factual file-path and commit references only.
+
+---
+
+## 2. Baseline Reference
+
+| Attribute | Value |
+|---|---|
+| LR-007 baseline commit | `bef8da1` |
+| LR-007 baseline date | 2026-02-09 |
+| `evidence_commit` in `LR-007-STATE.yaml` | `bef8da1` |
+| Current HEAD | `1d08c7c` |
+| Current HEAD date | 2026-02-22 |
+| Total commits in range | `git rev-list --count bef8da1..HEAD` — Observed output: 128 |
+
+---
+
+## 3. Code Path Changes Since Baseline
+
+### 3.1 Contract Tests (`tests/contract/`)
+
+| Files touched | Lines changed |
+|---|---|
+| `tests/contract/test_decision_contract.py` | +152 |
+
+Collected 24 tests as of HEAD (see LR-002-EVIDENCE-ADDENDUM.md for the full test list and execution output).
+
+**Reproduce:**
+
+    git diff --stat bef8da1..HEAD -- tests/contract/
+    git log --oneline --no-merges bef8da1..HEAD -- tests/contract/
+
+### 3.2 Correlation Tables (`core/utils/uuid_gen.py`)
+
+| Files touched | Lines changed |
+|---|---|
+| `core/utils/uuid_gen.py` | +185 |
+
+| Commit | Subject |
+|---|---|
+| `7cf6c40` | `chore(phase-8c): correlation chain implemented (signal/decision/order/block) (#839)` |
+| `3a742a0` | `audit(db): deterministic risk_events persistence with idempotent PK` |
+| `2570242` | `fix(p0-b2): decision_pk deterministisch (kein wall-clock)` |
+
+**Reproduce:**
+
+    git diff --stat bef8da1..HEAD -- core/utils/uuid_gen.py
+    git log --oneline --no-merges bef8da1..HEAD -- core/utils/uuid_gen.py
+
+### 3.3 Trace Toggles (`core/utils/trace_toggle.py`)
+
+| Files touched | Lines changed |
+|---|---|
+| `core/utils/trace_toggle.py` | +22 (new file) |
+
+| Commit | Subject |
+|---|---|
+| `1850b98` | `Phase 9 PR-0: Trace Contract v1 Infrastructure (#850)` |
+| `800ee45` | `refactor(toggles): centralize ALLOW_EVIDENCE_DEBT (no behavior change)` |
+
+**Reproduce:**
+
+    git diff --stat bef8da1..HEAD -- core/utils/trace_toggle.py
+    git log --oneline --no-merges bef8da1..HEAD -- core/utils/trace_toggle.py
+
+### 3.4 Risk Service (`services/risk/service.py`)
+
+| Files touched | Lines changed |
+|---|---|
+| `services/risk/service.py` | +696/-130 |
+
+| Commit | Subject |
+|---|---|
+| `ddd7469` | `fix(risk): Phase 1 - Open Pipeline + Correlation Backbone (#831)` |
+| `d2924f5` | `feat(risk): Market State V1 + RC_003/RC_022 staleness fix` |
+| `1062c1d` | `Phase 9 PR-1: Trace Contract v1 (ORDER/FILL payload + unit tests) (#849)` |
+| `1850b98` | `Phase 9 PR-0: Trace Contract v1 Infrastructure (#850)` |
+| `08508c4` | `fix(p0-b1): Toggle-OFF erzeugt zero side effects` |
+| `6851347` | `fix(p0-b3): BLOCK-Event strukturell aligned` |
+| `0a3200e` | `fix(risk): Flask optional dependency (Issue #883) (#885)` |
+| `49252d3` | `style: black formatting for risk service` |
+
+**Reproduce:**
+
+    git diff --stat bef8da1..HEAD -- services/risk/service.py
+    git log --oneline --no-merges bef8da1..HEAD -- services/risk/service.py
+
+### 3.5 Execution Service (`services/execution/`)
+
+| Files touched | Lines changed |
+|---|---|
+| `services/execution/database.py` | +118 |
+| `services/execution/live_executor.py` | +4/-1 |
+| `services/execution/mexc_executor.py` | +5/-1 |
+| `services/execution/mock_executor.py` | +1 |
+| `services/execution/models.py` | +40 |
+| `services/execution/paper_trading.py` | +1 |
+| `services/execution/requirements.txt` | +4/-1 |
+| `services/execution/service.py` | +116 |
+
+| Commit | Subject |
+|---|---|
+| `d9cf2d7` | `fix(execution): enforce decision_id gate for TC-P0-002 (refs #467) (#891)` |
+| `a76168b` | `fix(execution): prevent correlation_ledger validation errors from dropping order_results (#893)` |
+| `6e3c0e2` | `phase-8e: implement FILL correlation event and close evidence debt (#843)` |
+
+**Reproduce:**
+
+    git diff --stat bef8da1..HEAD -- services/execution/
+    git log --oneline --no-merges bef8da1..HEAD -- services/execution/
+
+### 3.6 Candles Service (supporting)
+
+| Commit | Subject |
+|---|---|
+| `6b52a5b` | `fix(candles): populate last_tick_ts_ms in market_state to satisfy RC_004` |
+| `db135af` | `feat(candles): deterministic regime lookup via stream.regime_signals` |
+
+**Reproduce:**
+
+    git log --oneline --no-merges bef8da1..HEAD -- services/candles/
+
+---
+
+## 4. Soak Metrics Status
+
+Per `LR-007-STATUS.md` (L64-L73):
+
+> **NOTE:** Metrics collection and daily digest generation pending. Required artifacts:
+> - Container uptime logs (RED/BLACK/BLUE stacks)
+> - Decision rate metrics (Prometheus queries)
+> - Circuit breaker trip counts
+> - Kill switch activation logs
+> - Stream gap monitoring
+>
+> **Next Action:** Set up daily digest script or manual evidence collection process.
+
+**Status as of 2026-02-22:** TBD — Pending Evidence Collection. No soak metrics artifacts have been produced.
+
+---
+
+## 5. Day-0 Definition
+
+Day 0 begins when soak metrics collection starts. This addendum does not start, claim, or imply that soak metrics collection has begun.
+
+---
+
+## 6. Reproduction Commands
+
+    # Commits in range (non-merge, invariant-relevant paths)
+    git log --oneline --no-merges bef8da1..HEAD -- tests/contract/ core/utils/uuid_gen.py core/utils/trace_toggle.py services/risk/service.py services/execution/
+
+    # Diff stats for key paths
+    git diff --stat bef8da1..HEAD -- tests/contract/ core/utils/uuid_gen.py core/utils/trace_toggle.py services/risk/service.py services/execution/
+
+    # Total commit count in range
+    git rev-list --count bef8da1..HEAD
+
+    # Full non-merge commit list
+    git log --oneline --no-merges bef8da1..HEAD
+
+---
+
+**End of addendum. No files modified beyond this document.**


### PR DESCRIPTION
## Summary

- **LR-002 addendum:** contract test count grew from 16 to 24, all 24 pass
- **LR-006 addendum:** evidence dict key inventory from `decide_trade()` (toggle OFF and ON, identical 20-key set)
- **LR-007 addendum:** invariant delta since baseline `bef8da1..HEAD` (128 commits), soak metrics still TBD

## Scope

Append-only evidence/status addenda. No runtime impact.

- 3 new files in `docs/live-readiness/`
- Zero changes to existing files
- Zero changes to runtime code, thresholds, decision logic, signals, schemas, or workflows
- Zero changes to `LR-STATE.yaml` files

## Test plan

- [ ] Verify only 3 new files in diff (no other changes)
- [ ] Verify no `STATE.yaml` modifications
- [ ] Verify CI passes (docs-only, contract tests unaffected)
- [ ] Verify each addendum ends with "End of addendum. No files modified beyond this document."

🤖 Generated with [Claude Code](https://claude.com/claude-code)