### PR TITLE
docs(governance): no-human-review policy + CI gate runbook

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,26 @@
 
 **Moved:** Canon liegt im Docs Hub: `../Claire_de_Binare_Docs/meta/github/pull_request_template.md`
 
+## Merge Policy
+
+> **No Human Review** — CI Gate only.
+> See [no_human_review_policy.md](docs/governance/no_human_review_policy.md)
+
+### Checklist
+
+- [ ] Required CI checks green
+- [ ] Scope: what changed / what was NOT changed
+- [ ] Risk: none / low / medium
+- [ ] Rollback plan (for infra/security/schema PRs)
+- [ ] No secrets in diff
+
+### Self-Review
+
+**Scope**: <!-- what this PR changes -->
+**Not touched**: <!-- what was explicitly left unchanged -->
+**Risk**: <!-- none / low / medium — 1 sentence -->
+**Tests**: <!-- test command + result -->
+**Rollback**: <!-- revert command or feature flag -->
+**Evidence**: <!-- link to CI run or test output -->
+
 ## Agent Approvals

--- a/docs/governance/no_human_review_policy.md
+++ b/docs/governance/no_human_review_policy.md
@@ -1,0 +1,110 @@
+# No Human Review Policy
+
+**Status**: Active
+**Scope**: All PRs to `main` in `Claire_de_Binare`
+**Effective**: 2026-02-23
+**Owner**: jannekbuengener (repo owner)
+
+## Context
+
+This is a solo-maintainer repo with AI-assisted development (Claude, Copilot).
+Human review gates create a bottleneck with zero security benefit:
+GitHub blocks self-approval, and there is no second human reviewer.
+
+The repo already operates this way de facto since 2026-02-15
+(see [BRANCH_PROTECTION_LOG.md](BRANCH_PROTECTION_LOG.md) — PR #839, PR #846).
+This document makes the practice explicit and auditable.
+
+## Decision
+
+**No human reviews required. Merge gate = required CI checks green.**
+
+A PR may merge when:
+1. All required status checks pass (currently: `ci (Unit/Integration + Lint gesammelt)`)
+2. All conversation threads are resolved (`required_conversation_resolution: true`)
+3. A self-review comment is present (see template below)
+
+No approval from any GitHub user or bot is required.
+
+## Scope and Exceptions
+
+This policy applies to **all PRs** with two explicit exception categories:
+
+| Exception | Trigger | Required action |
+|-----------|---------|-----------------|
+| System invariant changes | Edits to `SYSTEM_INVARIANTS.md` or enforcement mechanisms | Documented justification + link to DocsHub change |
+| Live trading enablement | Changes to `soak_mode`, `paper_mode`, or live exchange credentials | Explicit operator sign-off in PR comment |
+
+Exception PRs follow the same CI gate but **must** include a `## Risk Assessment`
+section with rollback steps. No additional human approval is required —
+the documentation itself is the control.
+
+## Definition of Done for PRs
+
+- [ ] Required CI checks green
+- [ ] Self-review comment posted (see template)
+- [ ] Scope statement: what changed, what was NOT changed
+- [ ] For infra/security/schema PRs: rollback plan or revert command documented
+- [ ] For new features: feature flag (default OFF) or evidence of no runtime impact
+- [ ] No secrets in diff (`gitleaks` check passes)
+
+## Self-Review Template
+
+PR authors post this as a comment before merge:
+
+```markdown
+## Self-Review
+
+**Scope**: [1-2 sentences: what this PR changes]
+**Not touched**: [what was explicitly left unchanged]
+**Risk**: [none / low / medium] — [1 sentence justification]
+**Tests**: [test command + result summary]
+**Rollback**: [revert command or "git revert <sha>" or "feature flag OFF"]
+**Evidence**: [link to CI run or paste of test output]
+```
+
+## Risk Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Bad code merges without review | Required CI checks (unit, integration, lint, contract tests, gitleaks) |
+| Schema/infra breakage | Runbooks required for infra PRs; enforcement scripts are opt-in operator steps |
+| Silent behavioral regression | Decision contract tests (`tests/contract/`), deterministic gate in conftest.py |
+| Accidental secret exposure | `gitleaks` workflow as required check |
+| Force-push / branch deletion | `enforce_admins: true`, `allow_force_pushes: false`, `allow_deletions: false` |
+| Flakey/pre-existing test failures | See "Quarantined Tests" below |
+
+## Quarantined Tests
+
+Tests that fail due to missing dependencies or external services (not code bugs)
+are documented here. They do not block merge.
+
+| Test | Reason | Tracked in |
+|------|--------|-----------|
+| `tests/smoke/test_mcp_runtime.py` | Requires `pytest-twisted` (not in CI deps) | Pre-existing |
+| `tests/integration/test_execution_pipeline.py` | Requires `flask` (service dep, not in test env) | Pre-existing |
+| `tests/integration/test_mexc_testnet.py` | Requires `requests_mock` | Pre-existing |
+| `tests/unit/candles/test_regime_lookup.py` | Requires `flask` | Pre-existing |
+| `tests/unit/execution/test_service*.py` | Requires `flask` | Pre-existing |
+| `tests/unit/signal/test_service.py` | Requires `flask` | Pre-existing |
+
+When a quarantined test is fixed, remove it from this table and add it
+to the required CI check suite.
+
+## Branch Protection Settings (current state)
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| `required_status_checks` | `ci (Unit/Integration + Lint gesammelt)` | CI is the gatekeeper |
+| `required_status_checks.strict` | `true` | Branch must be up-to-date |
+| `required_approving_review_count` | `0` | No human approval needed |
+| `enforce_admins` | `true` | Admins also bound by checks |
+| `required_conversation_resolution` | `true` | All threads must be resolved |
+| `allow_force_pushes` | `false` | No force-push to main |
+| `allow_deletions` | `false` | Cannot delete main |
+
+## References
+
+- [BRANCH_PROTECTION_LOG.md](BRANCH_PROTECTION_LOG.md) — historical decisions
+- [GOVERNANCE_AUDIT_RUNBOOK.md](GOVERNANCE_AUDIT_RUNBOOK.md)
+- [docs/ci/ACTION_REQUIRED_RUNBOOK.md](../ci/ACTION_REQUIRED_RUNBOOK.md) — bot PR approval flow

--- a/docs/runbooks/merge_policy_ci_gate.md
+++ b/docs/runbooks/merge_policy_ci_gate.md
@@ -1,0 +1,107 @@
+# Runbook: Merge Policy — CI Gate Configuration
+
+## Overview
+
+This runbook documents the GitHub settings that enforce the
+"No Human Review" policy. CI is the sole merge gate.
+
+See [no_human_review_policy.md](../governance/no_human_review_policy.md)
+for the policy rationale.
+
+## Current State (as of 2026-02-23)
+
+Settings match the policy. No changes needed unless something drifted.
+
+## Required GitHub Settings
+
+### Branch Protection (main)
+
+Apply via GitHub UI (Settings > Branches > main) or CLI:
+
+```bash
+# Set required status checks (strict: branch must be up to date)
+gh api repos/jannekbuengener/Claire_de_Binare/branches/main/protection \
+  --method PUT \
+  --field required_status_checks='{"strict":true,"contexts":["ci (Unit/Integration + Lint gesammelt)"]}' \
+  --field enforce_admins=true \
+  --field required_pull_request_reviews=null \
+  --field restrictions=null \
+  --field required_conversation_resolution=true \
+  --field allow_force_pushes=false \
+  --field allow_deletions=false
+```
+
+### Verify Settings
+
+```bash
+gh api repos/jannekbuengener/Claire_de_Binare/branches/main/protection \
+  | python -m json.tool
+```
+
+Expected output (key fields):
+
+| Field | Expected |
+|-------|----------|
+| `required_status_checks.strict` | `true` |
+| `required_status_checks.contexts` | `["ci (Unit/Integration + Lint gesammelt)"]` |
+| `required_approving_review_count` | `0` |
+| `enforce_admins.enabled` | `true` |
+| `required_conversation_resolution.enabled` | `true` |
+| `allow_force_pushes.enabled` | `false` |
+| `allow_deletions.enabled` | `false` |
+
+### Disable Human Reviews (if re-enabled accidentally)
+
+```bash
+# Remove required_pull_request_reviews entirely:
+gh api repos/jannekbuengener/Claire_de_Binare/branches/main/protection/required_pull_request_reviews \
+  --method DELETE
+
+# Or set to 0 approvals:
+gh api repos/jannekbuengener/Claire_de_Binare/branches/main/protection/required_pull_request_reviews \
+  --method PATCH \
+  --field required_approving_review_count=0
+```
+
+### Enable Auto-merge (optional)
+
+```bash
+# Enable auto-merge at repo level (PRs merge when checks pass):
+gh api repos/jannekbuengener/Claire_de_Binare \
+  --method PATCH \
+  --field allow_auto_merge=true
+```
+
+Then per PR:
+
+```bash
+gh pr merge <number> --auto --squash
+```
+
+### Adding Required Checks
+
+When a quarantined test is fixed and added to CI:
+
+1. Add the job to `.github/workflows/ci.yml`
+2. Update branch protection to include the new check context:
+
+```bash
+gh api repos/jannekbuengener/Claire_de_Binare/branches/main/protection/required_status_checks \
+  --method PATCH \
+  --field strict=true \
+  --field contexts='["ci (Unit/Integration + Lint gesammelt)", "<new-check-name>"]'
+```
+
+3. Remove the test from the quarantine table in `no_human_review_policy.md`
+
+## Rollback: Re-enable Human Reviews
+
+If the policy is reverted:
+
+```bash
+gh api repos/jannekbuengener/Claire_de_Binare/branches/main/protection/required_pull_request_reviews \
+  --method PATCH \
+  --field required_approving_review_count=1
+```
+
+Document the change in [BRANCH_PROTECTION_LOG.md](../governance/BRANCH_PROTECTION_LOG.md).


### PR DESCRIPTION
## Summary

Formalizes the existing solo-maintainer practice (documented in BRANCH_PROTECTION_LOG.md since PR #839) as an explicit, auditable policy.

- **Policy**: `docs/governance/no_human_review_policy.md` — merge gate = required CI checks green, no human approval
- **PR Template**: `.github/pull_request_template.md` — added self-review checklist and CI gate notice
- **Runbook**: `docs/runbooks/merge_policy_ci_gate.md` — exact GitHub CLI commands for verify/apply/rollback

## What this does NOT change

- No CI workflow changes
- No branch protection changes (settings already match policy)
- No trading logic, no runtime code, no schema changes

## Self-Review

**Scope**: Docs-only — 3 files (1 new policy, 1 new runbook, 1 template extension)
**Not touched**: CI workflows, branch protection settings, any code
**Risk**: None — documentation only
**Tests**: N/A (no code changes)
**Rollback**: `git revert <sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)