### PR TITLE
refactor(execution,signal,candles): lazy-load Flask for unit-test isolation (#914)

### DIFF
--- a/services/candles/service.py
+++ b/services/candles/service.py
@@ -13,7 +13,16 @@ from threading import Thread
 from typing import Optional
 
 import redis
-from flask import Flask, jsonify, Response
+import importlib.util
+try:
+    _FLASK_AVAILABLE = importlib.util.find_spec("flask") is not None
+except ModuleNotFoundError as e:
+    if e.name == "flask" or (e.name and e.name.startswith("flask.")):
+        _FLASK_AVAILABLE = False
+    else:
+        raise
+except ValueError:
+    _FLASK_AVAILABLE = False
 
 from core.utils.clock import utcnow
 from core.utils.redis_payload import sanitize_payload
@@ -38,7 +47,6 @@ else:
     )
 
 logger = logging.getLogger("candle_service")
-app = Flask(__name__)
 
 stats = {
     "started_at": None,
@@ -345,28 +353,36 @@ class CandleService:
                 logger.error(f"Error processing trade: {e}")
 
 
-@app.route("/health")
-def health():
-    return jsonify(
-        {
-            "status": "ok" if stats["status"] == "running" else "error",
-            "service": "candle_service",
-            "version": config.source_version,
-        }
-    )
+# ===== FLASK ENDPOINTS =====
 
+if _FLASK_AVAILABLE:
+    from flask import Flask, jsonify, Response
 
-@app.route("/metrics")
-def metrics():
-    body = (
-        "# HELP candle_trades_processed_total Anzahl verarbeiteter Trades\n"
-        "# TYPE candle_trades_processed_total counter\n"
-        f"candle_trades_processed_total {stats['trades_processed']}\n\n"
-        "# HELP candle_candles_emitted_total Anzahl emittierter Candles\n"
-        "# TYPE candle_candles_emitted_total counter\n"
-        f"candle_candles_emitted_total {stats['candles_emitted']}\n"
-    )
-    return Response(body, mimetype="text/plain")
+    app = Flask(__name__)
+
+    @app.route("/health")
+    def health():
+        return jsonify(
+            {
+                "status": "ok" if stats["status"] == "running" else "error",
+                "service": "candle_service",
+                "version": config.source_version,
+            }
+        )
+
+    @app.route("/metrics")
+    def metrics():
+        body = (
+            "# HELP candle_trades_processed_total Anzahl verarbeiteter Trades\n"
+            "# TYPE candle_trades_processed_total counter\n"
+            f"candle_trades_processed_total {stats['trades_processed']}\n\n"
+            "# HELP candle_candles_emitted_total Anzahl emittierter Candles\n"
+            "# TYPE candle_candles_emitted_total counter\n"
+            f"candle_candles_emitted_total {stats['candles_emitted']}\n"
+        )
+        return Response(body, mimetype="text/plain")
+else:
+    app = None
 
 
 if __name__ == "__main__":
@@ -374,6 +390,11 @@ if __name__ == "__main__":
     service.connect_redis()
 
     # Start Flask in background thread
+    if not _FLASK_AVAILABLE or app is None:
+        raise RuntimeError(
+            "Flask ist nicht installiert. HTTP-Endpoints (health/metrics) "
+            "benötigen Flask als optionale Abhängigkeit: pip install flask"
+        )
     flask_thread = Thread(target=lambda: app.run(host="0.0.0.0", port=config.port))
     flask_thread.daemon = True
     flask_thread.start()

--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -12,7 +12,16 @@ import logging.config
 import time
 from datetime import datetime
 from pathlib import Path
-from flask import Flask, jsonify, Response
+import importlib.util
+try:
+    _FLASK_AVAILABLE = importlib.util.find_spec("flask") is not None
+except ModuleNotFoundError as e:
+    if e.name == "flask" or (e.name and e.name.startswith("flask.")):
+        _FLASK_AVAILABLE = False
+    else:
+        raise
+except ValueError:
+    _FLASK_AVAILABLE = False
 import redis
 from threading import Thread, Lock
 
@@ -57,9 +66,6 @@ else:
     )
 
 logger = logging.getLogger(config.SERVICE_NAME)
-
-# Flask app
-app = Flask(__name__)
 
 # Global state
 executor = None
@@ -492,88 +498,93 @@ def listen_bot_shutdown():
             time.sleep(1)
 
 
-# Health Check Endpoint
-@app.route("/health", methods=["GET"])
-def health():
-    """Health check endpoint"""
-    return (
-        jsonify(
-            {
-                "service": config.SERVICE_NAME,
-                "status": "ok",
-                "version": config.SERVICE_VERSION,
-            }
-        ),
-        200,
-    )
+# ===== FLASK ENDPOINTS =====
 
+if _FLASK_AVAILABLE:
+    from flask import Flask, jsonify, Response
 
-@app.route("/status", methods=["GET"])
-def status():
-    """Status endpoint with statistics"""
-    try:
-        redis_connected = redis_client.ping() if redis_client else False
-    except Exception:
-        redis_connected = False
+    app = Flask(__name__)
 
-    return (
-        jsonify(
-            {
-                "service": config.SERVICE_NAME,
-                "version": config.SERVICE_VERSION,
-                "mode": "mock" if config.MOCK_TRADING else "live",
-                "stats": stats,
-                "redis": {"connected": redis_connected},
-                "database": db.get_stats() if db else {"error": "not initialized"},
-            }
-        ),
-        200,
-    )
+    @app.route("/health", methods=["GET"])
+    def health():
+        """Health check endpoint"""
+        return (
+            jsonify(
+                {
+                    "service": config.SERVICE_NAME,
+                    "status": "ok",
+                    "version": config.SERVICE_VERSION,
+                }
+            ),
+            200,
+        )
 
+    @app.route("/status", methods=["GET"])
+    def status():
+        """Status endpoint with statistics"""
+        try:
+            redis_connected = redis_client.ping() if redis_client else False
+        except Exception:
+            redis_connected = False
 
-@app.route("/metrics", methods=["GET"])
-def metrics():
-    """Metrics endpoint for Prometheus"""
-    # Thread-safe stats read (Fix for Issue #306)
-    current_stats = get_stats_copy()
+        return (
+            jsonify(
+                {
+                    "service": config.SERVICE_NAME,
+                    "version": config.SERVICE_VERSION,
+                    "mode": "mock" if config.MOCK_TRADING else "live",
+                    "stats": stats,
+                    "redis": {"connected": redis_connected},
+                    "database": db.get_stats() if db else {"error": "not initialized"},
+                }
+            ),
+            200,
+        )
 
-    uptime_seconds = max(
-        0.0,
-        (
-            utcnow() - datetime.fromisoformat(current_stats["start_time"])
-        ).total_seconds(),
-    )
+    @app.route("/metrics", methods=["GET"])
+    def metrics():
+        """Metrics endpoint for Prometheus"""
+        # Thread-safe stats read (Fix for Issue #306)
+        current_stats = get_stats_copy()
 
-    body = (
-        "# HELP execution_orders_received_total Anzahl eingegangener Orders\n"
-        "# TYPE execution_orders_received_total counter\n"
-        f"execution_orders_received_total {current_stats['orders_received']}\n"
-        "# HELP execution_orders_filled_total Anzahl erfolgreich ausgefuehrter Orders\n"
-        "# TYPE execution_orders_filled_total counter\n"
-        f"execution_orders_filled_total {current_stats['orders_filled']}\n"
-        "# HELP execution_orders_rejected_total Anzahl abgelehnter Orders\n"
-        "# TYPE execution_orders_rejected_total counter\n"
-        f"execution_orders_rejected_total {current_stats['orders_rejected']}\n"
-        "# HELP execution_uptime_seconds Service Laufzeit in Sekunden\n"
-        "# TYPE execution_uptime_seconds gauge\n"
-        f"execution_uptime_seconds {uptime_seconds}\n"
-    )
+        uptime_seconds = max(
+            0.0,
+            (
+                utcnow() - datetime.fromisoformat(current_stats["start_time"])
+            ).total_seconds(),
+        )
 
-    return Response(body, mimetype="text/plain")
+        body = (
+            "# HELP execution_orders_received_total Anzahl eingegangener Orders\n"
+            "# TYPE execution_orders_received_total counter\n"
+            f"execution_orders_received_total {current_stats['orders_received']}\n"
+            "# HELP execution_orders_filled_total Anzahl erfolgreich ausgefuehrter Orders\n"
+            "# TYPE execution_orders_filled_total counter\n"
+            f"execution_orders_filled_total {current_stats['orders_filled']}\n"
+            "# HELP execution_orders_rejected_total Anzahl abgelehnter Orders\n"
+            "# TYPE execution_orders_rejected_total counter\n"
+            f"execution_orders_rejected_total {current_stats['orders_rejected']}\n"
+            "# HELP execution_uptime_seconds Service Laufzeit in Sekunden\n"
+            "# TYPE execution_uptime_seconds gauge\n"
+            f"execution_uptime_seconds {uptime_seconds}\n"
+        )
 
+        return Response(body, mimetype="text/plain")
 
-@app.route("/orders", methods=["GET"])
-def orders():
-    """Get recent orders from database"""
-    if not db:
-        return jsonify({"error": "Database not initialized"}), 503
+    @app.route("/orders", methods=["GET"])
+    def orders():
+        """Get recent orders from database"""
+        if not db:
+            return jsonify({"error": "Database not initialized"}), 503
 
-    try:
-        recent_orders = db.get_recent_orders(limit=20)
-        return jsonify({"count": len(recent_orders), "orders": recent_orders}), 200
-    except Exception as e:
-        logger.error(f"Error retrieving orders: {e}")
-        return jsonify({"error": str(e)}), 500
+        try:
+            recent_orders = db.get_recent_orders(limit=20)
+            return jsonify({"count": len(recent_orders), "orders": recent_orders}), 200
+        except Exception as e:
+            logger.error(f"Error retrieving orders: {e}")
+            return jsonify({"error": str(e)}), 500
+else:
+    app = None
 
 
 def signal_handler(signum, frame):
@@ -657,6 +668,11 @@ def main():
     logger.info("Bot-shutdown listener started")
 
     # Start Flask app
+    if not _FLASK_AVAILABLE or app is None:
+        raise RuntimeError(
+            "Flask ist nicht installiert. HTTP-Endpoints (health/status/metrics) "
+            "benötigen Flask als optionale Abhängigkeit: pip install flask"
+        )
     try:
         app.run(
             host="0.0.0.0", port=config.SERVICE_PORT, debug=False, use_reloader=False

--- a/services/signal/service.py
+++ b/services/signal/service.py
@@ -11,7 +11,16 @@ import signal
 import logging
 import logging.config
 import redis
-from flask import Flask, jsonify, Response
+import importlib.util
+try:
+    _FLASK_AVAILABLE = importlib.util.find_spec("flask") is not None
+except ModuleNotFoundError as e:
+    if e.name == "flask" or (e.name and e.name.startswith("flask.")):
+        _FLASK_AVAILABLE = False
+    else:
+        raise
+except ValueError:
+    _FLASK_AVAILABLE = False
 from typing import Optional
 from pathlib import Path
 
@@ -56,9 +65,6 @@ else:
     )
 
 logger = logging.getLogger("signal_engine")
-
-# Flask App für Health-Check
-app = Flask(__name__)
 
 # Globale Statistiken
 stats = {
@@ -380,82 +386,86 @@ class SignalEngine:
 
 # ===== FLASK ENDPOINTS =====
 
+if _FLASK_AVAILABLE:
+    from flask import Flask, jsonify, Response
 
-@app.route("/health")
-def health():
-    """Health-Check Endpoint"""
-    return jsonify(
-        {
-            "status": "ok" if stats["status"] == "running" else "error",
-            "service": "signal_engine",
-            "version": "0.1.0",
-        }
-    )
+    app = Flask(__name__)
 
-
-@app.route("/status")
-def status():
-    """Status & Statistiken"""
-    return jsonify(stats)
-
-
-@app.route("/metrics")
-def metrics():
-    """Prometheus Metriken (text/plain)"""
-    # Sprint 1 #622: Extended metrics with latency histogram and error counter
-
-    # Calculate histogram buckets for latency
-    buckets = [1, 5, 10, 25, 50, 100, 250, 500, 1000]
-    latency_buckets = {b: 0 for b in buckets}
-    latency_buckets["+Inf"] = 0
-
-    for sample in stats["latency_samples"]:
-        for bucket in buckets:
-            if sample <= bucket:
-                latency_buckets[bucket] += 1
-        latency_buckets["+Inf"] += 1
-
-    # Build histogram output
-    histogram_lines = []
-    cumulative = 0
-    for bucket in buckets + ["+Inf"]:
-        if bucket == "+Inf":
-            cumulative = latency_buckets["+Inf"]
-        else:
-            cumulative += latency_buckets[bucket]
-        histogram_lines.append(
-            f'signal_processing_latency_ms_bucket{{le="{bucket}"}} {cumulative}'
+    @app.route("/health")
+    def health():
+        """Health-Check Endpoint"""
+        return jsonify(
+            {
+                "status": "ok" if stats["status"] == "running" else "error",
+                "service": "signal_engine",
+                "version": "0.1.0",
+            }
         )
 
-    histogram_lines.append(
-        f"signal_processing_latency_ms_sum {stats['latency_sum_ms']}"
-    )
-    histogram_lines.append(
-        f"signal_processing_latency_ms_count {stats['latency_count']}"
-    )
+    @app.route("/status")
+    def status():
+        """Status & Statistiken"""
+        return jsonify(stats)
 
-    # Build error counter with labels
-    error_lines = []
-    for error_type, count in stats["errors_by_type"].items():
-        error_lines.append(f'signal_errors_total{{error_type="{error_type}"}} {count}')
+    @app.route("/metrics")
+    def metrics():
+        """Prometheus Metriken (text/plain)"""
+        # Sprint 1 #622: Extended metrics with latency histogram and error counter
 
-    body = (
-        "# HELP signals_generated_total Anzahl generierter Signale\n"
-        "# TYPE signals_generated_total counter\n"
-        f"signals_generated_total {stats['signals_generated']}\n\n"
-        "# HELP signal_engine_status Service Status (1=running, 0=stopped)\n"
-        "# TYPE signal_engine_status gauge\n"
-        f"signal_engine_status {1 if stats['status'] == 'running' else 0}\n\n"
-        "# HELP signal_processing_latency_ms Signal processing latency in milliseconds\n"
-        "# TYPE signal_processing_latency_ms histogram\n"
-        + "\n".join(histogram_lines)
-        + "\n\n"
-        "# HELP signal_errors_total Total signal processing errors\n"
-        "# TYPE signal_errors_total counter\n"
-        + ("\n".join(error_lines) if error_lines else "signal_errors_total 0")
-        + "\n"
-    )
-    return Response(body, mimetype="text/plain")
+        # Calculate histogram buckets for latency
+        buckets = [1, 5, 10, 25, 50, 100, 250, 500, 1000]
+        latency_buckets = {b: 0 for b in buckets}
+        latency_buckets["+Inf"] = 0
+
+        for sample in stats["latency_samples"]:
+            for bucket in buckets:
+                if sample <= bucket:
+                    latency_buckets[bucket] += 1
+            latency_buckets["+Inf"] += 1
+
+        # Build histogram output
+        histogram_lines = []
+        cumulative = 0
+        for bucket in buckets + ["+Inf"]:
+            if bucket == "+Inf":
+                cumulative = latency_buckets["+Inf"]
+            else:
+                cumulative += latency_buckets[bucket]
+            histogram_lines.append(
+                f'signal_processing_latency_ms_bucket{{le="{bucket}"}} {cumulative}'
+            )
+
+        histogram_lines.append(
+            f"signal_processing_latency_ms_sum {stats['latency_sum_ms']}"
+        )
+        histogram_lines.append(
+            f"signal_processing_latency_ms_count {stats['latency_count']}"
+        )
+
+        # Build error counter with labels
+        error_lines = []
+        for error_type, count in stats["errors_by_type"].items():
+            error_lines.append(f'signal_errors_total{{error_type="{error_type}"}} {count}')
+
+        body = (
+            "# HELP signals_generated_total Anzahl generierter Signale\n"
+            "# TYPE signals_generated_total counter\n"
+            f"signals_generated_total {stats['signals_generated']}\n\n"
+            "# HELP signal_engine_status Service Status (1=running, 0=stopped)\n"
+            "# TYPE signal_engine_status gauge\n"
+            f"signal_engine_status {1 if stats['status'] == 'running' else 0}\n\n"
+            "# HELP signal_processing_latency_ms Signal processing latency in milliseconds\n"
+            "# TYPE signal_processing_latency_ms histogram\n"
+            + "\n".join(histogram_lines)
+            + "\n\n"
+            "# HELP signal_errors_total Total signal processing errors\n"
+            "# TYPE signal_errors_total counter\n"
+            + ("\n".join(error_lines) if error_lines else "signal_errors_total 0")
+            + "\n"
+        )
+        return Response(body, mimetype="text/plain")
+else:
+    app = None
 
 
 # ===== SIGNAL HANDLER =====
@@ -480,6 +490,11 @@ if __name__ == "__main__":
     engine.connect_redis()
 
     # Flask in separatem Thread starten
+    if not _FLASK_AVAILABLE or app is None:
+        raise RuntimeError(
+            "Flask ist nicht installiert. HTTP-Endpoints (health/status/metrics) "
+            "benötigen Flask als optionale Abhängigkeit: pip install flask"
+        )
     from threading import Thread
 
     flask_thread = Thread(target=lambda: app.run(host="0.0.0.0", port=config.port))

--- a/tests/unit/execution/test_service.py
+++ b/tests/unit/execution/test_service.py
@@ -15,6 +15,7 @@ from services.execution import config, service
 
 
 @pytest.mark.unit
+@pytest.mark.skipif(service.app is None, reason="Flask not installed")
 def test_health_endpoint_reports_ok() -> None:
     client = service.app.test_client()
     response = client.get("/health")


### PR DESCRIPTION
## Summary

Applies the same `find_spec` + lazy-import pattern from PR #913 to the three remaining services:

- `services/execution/service.py` — 4 routes (`/health`, `/status`, `/metrics`, `/orders`)
- `services/signal/service.py` — 3 routes (`/health`, `/status`, `/metrics`)
- `services/candles/service.py` — 2 routes (`/health`, `/metrics`)

Each service now:
1. Probes Flask availability via `importlib.util.find_spec("flask")` (zero-import)
2. Imports Flask names + creates `app` only inside the endpoints block
3. Sets `app = None` when Flask is unavailable
4. Raises `RuntimeError` in `__main__` if Flask is missing at startup

Also adds `skipif` guard to `test_health_endpoint_reports_ok` in execution tests (needs Flask test client).

No behaviour change. Only import wiring. Route handler bodies are byte-for-byte identical.

Closes #914

## Evidence

| Test suite | Result |
|---|---|
| `tests/unit/execution/` | 7 passed, 4 skipped |
| `tests/unit/signal/` | 17 passed |
| `tests/unit/candles/` | 21 passed |
| `pytest -m unit` | 0 Flask collection errors (was 5) |

Remaining 1 collection error (`test_mexc_testnet.py`) is unrelated — missing `requests_mock` package.

## Test plan

- [ ] CI green
- [ ] `pytest tests/unit/execution/ -v` — no collection errors
- [ ] `pytest tests/unit/signal/ -v` — no collection errors
- [ ] `pytest tests/unit/candles/ -v` — no collection errors
- [ ] `pytest -m unit -q` — 0 Flask-related collection errors
- [ ] health/status/metrics endpoints respond when Flask installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)