### PR TITLE
test: fix requests-mock collection error with importorskip

### DIFF
--- a/tests/integration/test_mexc_testnet.py
+++ b/tests/integration/test_mexc_testnet.py
@@ -18,7 +18,7 @@ completely different UUIDs. This requires disciplined event design:
 import os
 import sys
 import pytest
-import requests_mock
+requests_mock = pytest.importorskip("requests_mock", reason="test requires requests-mock")
 import logging
 from urllib.parse import urlparse, parse_qsl
 from typing import Any, Dict


### PR DESCRIPTION
## Summary

Replace bare `import requests_mock` with `pytest.importorskip("requests_mock")` in `tests/integration/test_mexc_testnet.py`.

This was the last remaining pytest collection error. The dependency is already in `requirements-dev.txt` and CI installs it — this only affects local envs without dev deps.

**Before:** `ModuleNotFoundError` crashes pytest collection
**After:** Clean skip with reason "test requires requests-mock"

No behavior change. Test-only, 1 line changed.

## Evidence

```
pytest -m unit -q → 168 passed, 16 skipped, 0 errors
pytest tests/integration/test_mexc_testnet.py -q → 1 skipped
```

## Test plan

- [ ] CI green
- [ ] `pytest -m unit -q` → 0 collection errors
- [ ] `pytest tests/integration/test_mexc_testnet.py -q` → clean skip (not error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)