### PR TITLE
fix(replay): guard non-dict JSON input + clarify docstring

### DIFF
--- a/core/replay/canonical_json.py
+++ b/core/replay/canonical_json.py
@@ -8,7 +8,8 @@ Rules:
   - Compact separators (",", ":") -- no whitespace variance
   - None values OMITTED from dict serialization (not serialized as null)
   - None values in lists are preserved as null (removing would change indices)
-  - Floats sanitized: NaN/Inf -> None -> omitted; normal floats rounded to 10 decimals
+  - Floats sanitized: NaN/Inf -> None (omitted from dicts, null in lists);
+    normal floats rounded to 10 decimals; -0.0 normalized to 0.0
   - UTF-8 encoding for hashing
 
 Isolation: This module has its own _sanitize_float(), intentionally decoupled

--- a/docs/live-readiness/LR-021-EVIDENCE-SLICE1.md
+++ b/docs/live-readiness/LR-021-EVIDENCE-SLICE1.md
@@ -15,7 +15,7 @@
 | `tests/fixtures/replay/lr021_expected_hashes.jsonl` | Golden file (frozen expected hashes) |
 | `tests/unit/replay/test_canonical_json.py` | 30 tests: sanitization, None-omission, key-order independence, pinned bytes |
 | `tests/unit/replay/test_envelopes.py` | 7 tests: envelope `to_dict()` contract |
-| `tests/unit/replay/test_lr021_replay.py` | 13 tests: golden-file replay, validation, chain integrity, lenient mode |
+| `tests/unit/replay/test_lr021_replay.py` | 15 tests: golden-file replay, validation, chain integrity, lenient mode |
 
 ## How to Run Replay
 

--- a/scripts/replay/lr021_replay.py
+++ b/scripts/replay/lr021_replay.py
@@ -42,9 +42,15 @@ REQUIRED_FIELDS = {"schema_version", "event_type", "event_id", "ts_ms", "payload
 VALID_EVENT_TYPES = {"DECISION", "ORDER", "FILL"}
 
 
-def validate_envelope(obj: dict, line_number: int) -> list[str]:
+def validate_envelope(obj: object, line_number: int) -> list[str]:
     """Validate envelope schema. Returns list of error messages (empty = valid)."""
     errors = []
+    if not isinstance(obj, dict):
+        errors.append(
+            f"line {line_number}: envelope must be a JSON object, "
+            f"got {type(obj).__name__}"
+        )
+        return errors
     missing = REQUIRED_FIELDS - set(obj.keys())
     if missing:
         errors.append(f"line {line_number}: missing fields: {sorted(missing)}")

--- a/tests/unit/replay/test_lr021_replay.py
+++ b/tests/unit/replay/test_lr021_replay.py
@@ -72,6 +72,20 @@ class TestGoldenFileReplay:
 
 
 class TestValidation:
+    def test_non_dict_json_strict(self):
+        """Valid JSON but not an object -> strict raises."""
+        for bad_value in ["[]", '"foo"', "42", "true"]:
+            with pytest.raises(ValueError, match="must be a JSON object"):
+                replay(io.StringIO(bad_value + "\n"), io.StringIO(), strict=True)
+
+    def test_non_dict_json_lenient(self):
+        """Valid JSON but not an object -> lenient skips."""
+        output = io.StringIO()
+        summary = replay(io.StringIO("[]\n"), output, strict=False, chain=True)
+        assert summary["processed"] == 0
+        assert summary["skipped"] == 1
+        assert "must be a JSON object" in summary["errors"][0]
+
     def test_missing_fields_strict(self):
         bad_input = '{"event_type":"DECISION"}\n'
         with pytest.raises(ValueError, match="missing fields"):


### PR DESCRIPTION
## Summary

Follow-up to #917 (merged). Addresses review feedback from copilot-pull-request-reviewer:

- `validate_envelope()` now rejects non-dict JSON (`[]`, `"foo"`, `42`, `true`) with clear error before accessing `.keys()`
- 2 new tests: strict mode raises `ValueError`, lenient mode skips+errors
- Docstring float rule clarified: "omitted from dicts, null in lists, -0.0 normalized"
- Evidence doc test count updated (13 → 15)

No behavior change for valid envelopes. Hashes unchanged. 52 tests green.

## Test plan

- [x] `pytest tests/unit/replay/ -v` — 52/52 passed
- [x] New tests cover `[]`, `"foo"`, `42`, `true` as input lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)