### PR TITLE
docs(governance): evidence specs for #748/#743/#777/#778

### DIFF
--- a/docs/governance/evidence/ISSUE-743-import-integrity-guard.md
+++ b/docs/governance/evidence/ISSUE-743-import-integrity-guard.md
@@ -1,0 +1,17 @@
+# Evidence Spec for Issue #743 — Ledger Import Integrity Guard (Anti-Replay / Anti-Spoof)
+Purpose:
+- Define the evidence contract for proving anti-replay / anti-spoof protections in ledger import paths without changing implementation code.
+- Provide a stable reference that can be linked in Issue #743 until implementation evidence exists.
+
+Pass criteria:
+- [ ] At least one implementation PR is linked that introduces replay/spoof/integrity checks or guardrails relevant to ledger import.
+- [ ] At least one CI/test run is linked that validates the guard behavior (or related constraints).
+- [ ] At least one doc/spec/runbook reference is linked that explains the integrity guard approach and expected failure behavior.
+
+Evidence plan:
+- Expected PR(s): import integrity / replay guard / spoof protection PR(s) referencing #743 (or explicitly covering the same scope).
+- Expected CI runs: test runs for integrity guard checks, constraint tests, or import validation pipelines.
+- Expected docs/ADRs: ADR/spec/runbook documenting replay prevention, spoof rejection, and auditability of import errors.
+
+Current status:
+- Spec only (no implementation evidence yet). Date: 2026-02-24

--- a/docs/governance/evidence/ISSUE-748-policy-snapshot-binding.md
+++ b/docs/governance/evidence/ISSUE-748-policy-snapshot-binding.md
@@ -1,0 +1,17 @@
+# Evidence Spec for Issue #748 — Policy Snapshot Binding: policy hash/version in ledger events
+Purpose:
+- Define a docs-only evidence contract for how implementation proof for policy snapshot binding should be collected and linked in Issue #748.
+- Ensure future implementation work can add auditable evidence without changing the issue structure again.
+
+Pass criteria:
+- [ ] At least one implementation PR is linked that introduces or updates `policy_id` / hash / version binding for relevant events.
+- [ ] At least one CI run or validation run is linked and attributable to the implementation PR(s).
+- [ ] At least one spec/ADR/docs reference is linked that documents the intended binding behavior and compatibility expectations.
+
+Evidence plan:
+- Expected PR(s): policy snapshot binding implementation PR(s) referencing #748.
+- Expected CI runs: workflow runs validating tests/linting for the implementation PR(s), plus any focused validation job if present.
+- Expected docs/ADRs: spec/ADR/docs that describe policy hash/version binding, anti-drift intent, and event/ledger linkage.
+
+Current status:
+- Spec only (no implementation evidence yet). Date: 2026-02-24

--- a/docs/governance/evidence/ISSUE-777-contract-tests-schemas.md
+++ b/docs/governance/evidence/ISSUE-777-contract-tests-schemas.md
@@ -1,0 +1,17 @@
+# Evidence Spec for Issue #777 — LR-002 Contract Tests for all Redis/Event Schemas
+Purpose:
+- Define a docs-only evidence target for LR-002 so contract-test evidence can be collected consistently once implementation work lands.
+- Capture what counts as proof for schema contract coverage and backward-compatibility checks.
+
+Pass criteria:
+- [ ] At least one implementation PR is linked that adds or updates contract tests for Redis/Event schemas in LR-002 scope.
+- [ ] At least one CI run is linked showing contract tests or equivalent schema validation checks executing.
+- [ ] At least one docs/spec reference is linked that describes schema contracts, payload fixtures, or compatibility expectations.
+
+Evidence plan:
+- Expected PR(s): LR-002 contract-test PR(s) or equivalent schema validation PR(s) referencing #777.
+- Expected CI runs: workflow runs for test/contract/schema validation jobs on the implementation PR(s).
+- Expected docs/ADRs: schema docs, payload contract docs, fixture documentation, or ADRs for contract testing strategy.
+
+Current status:
+- Spec only (no implementation evidence yet). Date: 2026-02-24

--- a/docs/governance/evidence/ISSUE-778-governance-gate-human-recovery-limits.md
+++ b/docs/governance/evidence/ISSUE-778-governance-gate-human-recovery-limits.md
@@ -1,0 +1,17 @@
+# Evidence Spec for Issue #778 — Governance Gate (Human Gate / Recovery / Limits)
+Purpose:
+- Define a docs-only evidence contract for the governance gate in Issue #778 (limits, recovery procedure, human gate workflow).
+- Provide a stable reference for future implementation/drill evidence links without changing non-Evidence issue text.
+
+Pass criteria:
+- [ ] At least one implementation or drill PR is linked that materially contributes to limits/recovery/human-gate enforcement or verification.
+- [ ] At least one CI/drill run is linked that demonstrates or validates gate-relevant behavior.
+- [ ] At least one runbook/checklist/spec document is linked that describes human gate, recovery steps, and limits/exposure expectations.
+
+Evidence plan:
+- Expected PR(s): operator drill / recovery / limit controls / governance-gate PR(s) referencing #778 or child issues (#661 / #658).
+- Expected CI runs: drill or validation runs, plus workflow runs tied to the implementing PR(s).
+- Expected docs/ADRs: runbooks, checklists, governance gate criteria docs, recovery procedures, and operator approval flow docs.
+
+Current status:
+- Spec only (no implementation evidence yet). Date: 2026-02-24


### PR DESCRIPTION
Docs-only PR adding evidence specs. No code changes.