### PR TITLE
fix(gap006): tighten tamper test — assert no error cascade

### DIFF
--- a/tests/unit/audit/test_gap006_audit_export.py
+++ b/tests/unit/audit/test_gap006_audit_export.py
@@ -104,7 +104,10 @@ class TestVerifyChainNegative:
 
         result = verify_chain(str(f))
         assert result["ok"] is False
-        assert any("chain_hash mismatch" in e for e in result["errors"])
+        # Only the tampered line should fail — no error cascade
+        chain_errors = [e for e in result["errors"] if "chain_hash mismatch" in e]
+        assert len(chain_errors) == 1
+        assert "line 3" in chain_errors[0]
 
     def test_mutated_payload_fails(self, tmp_path):
         """Changing a payload field invalidates event_hash."""


### PR DESCRIPTION
## Summary

Follow-up to PR #927. Tightens `test_mutated_chain_hash_fails` to assert exactly 1 chain_hash error (no cascade), matching the `computed_chain_hash` propagation fix.

## Changes

- `tests/unit/audit/test_gap006_audit_export.py`: assert `len(chain_errors) == 1` + error on correct line

## Test plan

- [ ] 20/20 audit tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)