### PR TITLE
#748 Slice 1: optional policy_snapshot field (replay/envelopes + emitter, no drift)

### DIFF
--- a/core/replay/emitter.py
+++ b/core/replay/emitter.py
@@ -66,6 +66,7 @@ def _build_envelope(
     policy_hash: Optional[str] = None,
     input_hash: Optional[str] = None,
     output_hash: Optional[str] = None,
+    policy_snapshot: Optional[Dict[str, Any]] = None,
 ) -> dict:
     """Build envelope dict with optional fields omitted when None."""
     envelope: dict[str, Any] = {
@@ -83,6 +84,8 @@ def _build_envelope(
         envelope["input_hash"] = input_hash
     if output_hash is not None:
         envelope["output_hash"] = output_hash
+    if policy_snapshot is not None:
+        envelope["policy_snapshot"] = policy_snapshot
     return envelope
 
 
@@ -113,6 +116,7 @@ def emit_decision_envelope(
     policy_hash: Optional[str] = None,
     input_hash: Optional[str] = None,
     output_hash: Optional[str] = None,
+    policy_snapshot: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Emit a DECISION envelope. No-op when toggle OFF."""
     if not envelope_emit_enabled():
@@ -137,6 +141,7 @@ def emit_decision_envelope(
         policy_hash=policy_hash,
         input_hash=input_hash,
         output_hash=output_hash,
+        policy_snapshot=policy_snapshot,
     )
     emit_envelope(envelope)
 
@@ -155,6 +160,7 @@ def emit_order_envelope(
     policy_hash: Optional[str] = None,
     input_hash: Optional[str] = None,
     output_hash: Optional[str] = None,
+    policy_snapshot: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Emit an ORDER envelope. No-op when toggle OFF."""
     if not envelope_emit_enabled():
@@ -180,6 +186,7 @@ def emit_order_envelope(
         policy_hash=policy_hash,
         input_hash=input_hash,
         output_hash=output_hash,
+        policy_snapshot=policy_snapshot,
     )
     emit_envelope(envelope)
 
@@ -198,6 +205,7 @@ def emit_fill_envelope(
     policy_hash: Optional[str] = None,
     input_hash: Optional[str] = None,
     output_hash: Optional[str] = None,
+    policy_snapshot: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Emit a FILL envelope. No-op when toggle OFF."""
     if not envelope_emit_enabled():
@@ -222,5 +230,6 @@ def emit_fill_envelope(
         policy_hash=policy_hash,
         input_hash=input_hash,
         output_hash=output_hash,
+        policy_snapshot=policy_snapshot,
     )
     emit_envelope(envelope)

--- a/core/replay/envelopes.py
+++ b/core/replay/envelopes.py
@@ -15,6 +15,7 @@ All envelopes share:
 
 Optional fields (set to None when not applicable):
   - policy_id, policy_hash, input_hash, output_hash
+  - policy_snapshot (dict): nested policy metadata (#748, Slice 1)
 
 relations:
   role: envelope_definition
@@ -45,6 +46,7 @@ class DecisionEnvelopeV1:
     policy_hash: Optional[str] = None
     input_hash: Optional[str] = None
     output_hash: Optional[str] = None
+    policy_snapshot: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> dict:
         """Convert to dict, omitting None-valued optional fields."""
@@ -63,6 +65,8 @@ class DecisionEnvelopeV1:
             result["input_hash"] = self.input_hash
         if self.output_hash is not None:
             result["output_hash"] = self.output_hash
+        if self.policy_snapshot is not None:
+            result["policy_snapshot"] = self.policy_snapshot
         return result
 
 
@@ -79,6 +83,7 @@ class OrderEnvelopeV1:
     policy_hash: Optional[str] = None
     input_hash: Optional[str] = None
     output_hash: Optional[str] = None
+    policy_snapshot: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> dict:
         """Convert to dict, omitting None-valued optional fields."""
@@ -97,6 +102,8 @@ class OrderEnvelopeV1:
             result["input_hash"] = self.input_hash
         if self.output_hash is not None:
             result["output_hash"] = self.output_hash
+        if self.policy_snapshot is not None:
+            result["policy_snapshot"] = self.policy_snapshot
         return result
 
 
@@ -113,6 +120,7 @@ class FillEnvelopeV1:
     policy_hash: Optional[str] = None
     input_hash: Optional[str] = None
     output_hash: Optional[str] = None
+    policy_snapshot: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> dict:
         """Convert to dict, omitting None-valued optional fields."""
@@ -131,4 +139,6 @@ class FillEnvelopeV1:
             result["input_hash"] = self.input_hash
         if self.output_hash is not None:
             result["output_hash"] = self.output_hash
+        if self.policy_snapshot is not None:
+            result["policy_snapshot"] = self.policy_snapshot
         return result

--- a/docs/governance/evidence/ISSUE-748-policy-snapshot-binding.md
+++ b/docs/governance/evidence/ISSUE-748-policy-snapshot-binding.md
@@ -14,4 +14,46 @@ Evidence plan:
 - Expected docs/ADRs: spec/ADR/docs that describe policy hash/version binding, anti-drift intent, and event/ledger linkage.
 
 Current status:
-- Spec only (no implementation evidence yet). Date: 2026-02-24
+- **Slice 1 implemented.** Date: 2026-02-24
+
+---
+
+## Slice 1: Optional `policy_snapshot` Field
+
+**Scope:** Additive, offline/replay-only schema preparation. No runtime/trading impact.
+
+### What Was Changed
+
+| File | Change |
+|------|--------|
+| `core/replay/envelopes.py` | Added `policy_snapshot: Optional[Dict[str, Any]] = None` to all 3 envelope dataclasses + conditional `to_dict()` emission |
+| `core/replay/emitter.py` | Added `policy_snapshot` param to `_build_envelope()` + all 3 `emit_*` functions (default None, conditional emission) |
+| `tests/unit/replay/test_envelopes.py` | +4 tests: omit-when-None assertions, include-when-set, determinism with snapshot |
+
+### Schema
+
+`policy_snapshot` is an optional nested dict with suggested fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `policy_id` | string | Policy identifier |
+| `policy_version` | string | Semantic version |
+| `git_commit` | string | Git commit hash of policy source |
+| `checksum` | string | Deterministic checksum of policy content |
+| `effective_at` | string | ISO 8601 timestamp of when policy became effective |
+
+All fields are free-form strings. The dict is opaque to the replay framework — no validation of inner fields.
+
+### Guardrails
+
+| Guardrail | How |
+|-----------|-----|
+| No golden hash drift | `to_dict()` omits `policy_snapshot` when None; existing fixtures byte-identical |
+| No runtime impact | Default None; emitter toggle gate unchanged; no service hooks modified |
+| Backward compatible | Optional field with default None; no new required fields |
+| Deterministic | `canonical_json_dumps()` handles nested dicts via `sort_keys=True` |
+
+### Test Evidence
+
+- 63/63 replay tests green (7 existing envelope + 4 new snapshot + 22 emitter + 30 replay)
+- Golden file hashes unchanged (`test_replay_matches_golden_hashes`, `test_golden_canonical_bytes_stability`)

--- a/tests/unit/replay/test_envelopes.py
+++ b/tests/unit/replay/test_envelopes.py
@@ -11,6 +11,15 @@ from core.replay.envelopes import (
 )
 
 
+SAMPLE_SNAPSHOT = {
+    "policy_id": "risk_v2",
+    "policy_version": "2.1.0",
+    "git_commit": "abc1234",
+    "checksum": "deadbeef",
+    "effective_at": "2026-01-15T00:00:00Z",
+}
+
+
 class TestDecisionEnvelopeV1:
     def test_to_dict_omits_none(self):
         env = DecisionEnvelopeV1(
@@ -25,6 +34,7 @@ class TestDecisionEnvelopeV1:
         assert "policy_hash" not in d
         assert "input_hash" not in d
         assert "output_hash" not in d
+        assert "policy_snapshot" not in d
         assert d["event_type"] == "DECISION"
         assert d["schema_version"] == "envelope.v1"
 
@@ -44,6 +54,18 @@ class TestDecisionEnvelopeV1:
         assert "input_hash" not in d
         assert "output_hash" not in d
 
+    def test_policy_snapshot_included_when_set(self):
+        env = DecisionEnvelopeV1(
+            schema_version="envelope.v1",
+            event_type="DECISION",
+            event_id="ev-001",
+            ts_ms=1700000000000,
+            payload={"decision": "ALLOW"},
+            policy_snapshot=SAMPLE_SNAPSHOT,
+        )
+        d = env.to_dict()
+        assert d["policy_snapshot"] == SAMPLE_SNAPSHOT
+
     def test_roundtrip_determinism(self):
         kwargs = dict(
             schema_version="envelope.v1",
@@ -52,6 +74,19 @@ class TestDecisionEnvelopeV1:
             ts_ms=1700000000000,
             payload={"decision": "BLOCK", "symbol": "ETHUSDT"},
             policy_id="risk_policy_v1",
+        )
+        env1 = DecisionEnvelopeV1(**kwargs)
+        env2 = DecisionEnvelopeV1(**kwargs)
+        assert canonical_hash(env1.to_dict()) == canonical_hash(env2.to_dict())
+
+    def test_roundtrip_determinism_with_snapshot(self):
+        kwargs = dict(
+            schema_version="envelope.v1",
+            event_type="DECISION",
+            event_id="ev-001",
+            ts_ms=1700000000000,
+            payload={"decision": "ALLOW"},
+            policy_snapshot=SAMPLE_SNAPSHOT,
         )
         env1 = DecisionEnvelopeV1(**kwargs)
         env2 = DecisionEnvelopeV1(**kwargs)
@@ -69,6 +104,7 @@ class TestOrderEnvelopeV1:
         )
         d = env.to_dict()
         assert "policy_id" not in d
+        assert "policy_snapshot" not in d
         assert d["event_type"] == "ORDER"
 
     def test_to_dict_includes_present_optionals(self):
@@ -85,6 +121,18 @@ class TestOrderEnvelopeV1:
         assert d["input_hash"] == "inp-hash"
         assert d["output_hash"] == "out-hash"
 
+    def test_policy_snapshot_included_when_set(self):
+        env = OrderEnvelopeV1(
+            schema_version="envelope.v1",
+            event_type="ORDER",
+            event_id="ord-001",
+            ts_ms=1700000000000,
+            payload={"symbol": "BTCUSDT"},
+            policy_snapshot=SAMPLE_SNAPSHOT,
+        )
+        d = env.to_dict()
+        assert d["policy_snapshot"] == SAMPLE_SNAPSHOT
+
 
 class TestFillEnvelopeV1:
     def test_to_dict_omits_none(self):
@@ -97,6 +145,7 @@ class TestFillEnvelopeV1:
         )
         d = env.to_dict()
         assert "policy_id" not in d
+        assert "policy_snapshot" not in d
         assert d["event_type"] == "FILL"
 
     def test_to_dict_includes_present_optionals(self):
@@ -116,3 +165,15 @@ class TestFillEnvelopeV1:
         assert d["policy_hash"] == "ph"
         assert d["input_hash"] == "ih"
         assert d["output_hash"] == "oh"
+
+    def test_policy_snapshot_included_when_set(self):
+        env = FillEnvelopeV1(
+            schema_version="envelope.v1",
+            event_type="FILL",
+            event_id="fill-001",
+            ts_ms=1700000000000,
+            payload={"order_id": "ord-001"},
+            policy_snapshot=SAMPLE_SNAPSHOT,
+        )
+        d = env.to_dict()
+        assert d["policy_snapshot"] == SAMPLE_SNAPSHOT


### PR DESCRIPTION
## Summary

- **Scope:** Additive, optional, no runtime/trading impact
- **Change:** `policy_snapshot: Optional[Dict[str, Any]]` in all 3 envelope dataclasses + emitter passthrough; emit only if `!= None`
- **Golden hashes unchanged**, 142/142 tests green
- **Evidence:** [`docs/governance/evidence/ISSUE-748-policy-snapshot-binding.md`](docs/governance/evidence/ISSUE-748-policy-snapshot-binding.md)

## Test plan

- [ ] CI green (142/142, golden hash stability confirmed)
- [ ] Verify no existing file behavior changed (`test_replay_matches_golden_hashes`, `test_golden_canonical_bytes_stability`)

Refs #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)