### PR TITLE
chore(project): auto-add issues/prs to CDB Control Board

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -9,7 +9,7 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/users/jannekbuengener/projects/8
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically adds new issues and PRs to the existing Project v2 board (CDB Control Board / #8) using actions/add-to-project and the repo secret ADD_TO_PROJECT_PAT.

No trading/service code changes.