### PR TITLE
chore(project): exempt report issues from triage guard

### DIFF
--- a/.github/workflows/triage_guard.yml
+++ b/.github/workflows/triage_guard.yml
@@ -198,9 +198,18 @@ jobs:
           if jq -e --arg n "$TRIAGE_LABEL_NAME" '.data.node.labels.nodes[]? | select(.name == $n)' >/dev/null 2>&1 <<<"$item_json"; then
             has_triage_label=true
           fi
+          has_report_label=false
+          if jq -e '.data.node.labels.nodes[]? | select(.name == "report:weekly" or .name == "report:weekly-fail")' >/dev/null 2>&1 <<<"$item_json"; then
+            has_report_label=true
+          fi
 
           if [[ -z "$item_url" ]]; then
             item_url="$payload_url"
+          fi
+
+          if [[ "$has_report_label" == true ]]; then
+            echo "Report issue detected; triage label sync skipped for $item_url."
+            exit 0
           fi
 
           if [[ "$item_state" != "OPEN" ]]; then

--- a/docs/runbooks/project_board_automation.md
+++ b/docs/runbooks/project_board_automation.md
@@ -72,6 +72,10 @@ Kurzer Betriebsleitfaden für die Repo-Organisation über Milestones, Labels und
 - Weise jedem Item zuerst einen der 6 Milestones zu; dadurch entfernt `triage_guard` das Label automatisch.
 - Setze danach optional `status:*` Labels (z. B. `status:approved` / `status:in-progress`), damit das Board den Kanban-Status korrekt zieht.
 
+Report-Ausnahme:
+- Issues mit `report:weekly` oder `report:weekly-fail` sind `triage:offen`-exempt.
+- `triage_guard` überspringt diese Report-Issues deterministisch ohne Label-Mutation.
+
 ## Troubleshooting (Klassiker)
 
 ### 1) Actions Minutes / Billing blockiert


### PR DESCRIPTION
Exclude report issues from triage label automation.

### Changes
- 	riage_guard: early skip when issue has eport:weekly or eport:weekly-fail.
- Runbook note: report issues are 	riage:offen-exempt.

### Checklist
- [x] Scope limited to workflow/runbook only
- [x] Deterministic and idempotent behavior
- [x] No trading code touched