### PR TITLE
fix(ci): pin actions/checkout to full SHA for control board workflows

### DIFF
--- a/.github/workflows/control_board_auto_routing.yml
+++ b/.github/workflows/control_board_auto_routing.yml
@@ -37,7 +37,7 @@ jobs:
           echo "enabled=true" >> "$GITHUB_OUTPUT"
 
       - if: ${{ steps.feature-toggle.outputs.enabled == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (pinned)
 
       - if: ${{ steps.feature-toggle.outputs.enabled == 'true' }}
         name: Resolve CDB auth token (APP preferred, PAT fallback)

--- a/.github/workflows/control_board_upsert.yml
+++ b/.github/workflows/control_board_upsert.yml
@@ -38,7 +38,7 @@ jobs:
           echo "enabled=true" >> "$GITHUB_OUTPUT"
 
       - if: ${{ steps.feature-toggle.outputs.enabled == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (pinned)
 
       - if: ${{ steps.feature-toggle.outputs.enabled == 'true' }}
         name: Resolve CDB auth token (APP preferred, PAT fallback)


### PR DESCRIPTION
- Problem: checkout@v4 blocked by policy requiring full SHA\n- Fix: pin to 34e114876b0b11c390a56381ad16ebd13914f8d5\n- Scope: only control board workflows\n- No functional change besides unblocking workflow execution