### PR TITLE
#961: deploy env wiring for policy_snapshot (CDB_GIT_COMMIT, CDB_POLICY_VERSION)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,15 @@ SIGNAL_STRATEGY_ID=paper
 # ALLOCATION_RULES_JSON={"default": {"base_pct": 0.1, "max_pct": 0.5}}
 
 # ------------------------------------------------------------------
+# Policy Snapshot (Issue #748)
+# ------------------------------------------------------------------
+# Used by build_policy_snapshot() when CDB_POLICY_SNAPSHOT_BINDING_ENABLED=1
+# CDB_GIT_COMMIT: Set automatically in CI from github.sha. Local: leave unset (fallback "unknown").
+# CDB_POLICY_VERSION: Set from git tag in CI, or "dev-<shortsha>" for non-tag builds.
+# CDB_GIT_COMMIT=
+# CDB_POLICY_VERSION=
+
+# ------------------------------------------------------------------
 # Docker Image Digests (Security: Pinned versions)
 # ------------------------------------------------------------------
 REDIS_IMAGE=redis@sha256:ee64a64eaab618d88051c3ade8f6352d11531fcf79d9a4818b9b183d8c1d18ba

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -153,6 +153,12 @@ jobs:
           if [[ "${{ steps.preflight.outputs.e2e_mode }}" == "REAL" ]]; then
             ws_source="mexc_pb"
           fi
+          # Issue #748: derive policy version from tag or short SHA
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            policy_version="${{ github.ref_name }}"
+          else
+            policy_version="dev-$(echo '${{ github.sha }}' | cut -c1-7)"
+          fi
           cat > .env << EOF
           # E2E Test Environment
           WS_SOURCE=${ws_source}
@@ -160,6 +166,8 @@ jobs:
           REDIS_PORT=6379
           REDIS_PASSWORD=
           LOG_LEVEL=INFO
+          CDB_GIT_COMMIT=${{ github.sha }}
+          CDB_POLICY_VERSION=${policy_version}
           EOF
 
       - name: Start Docker Compose stack

--- a/infrastructure/compose/dev.yml
+++ b/infrastructure/compose/dev.yml
@@ -229,6 +229,9 @@ services:
       POSTGRES_HOST: cdb_postgres
       POSTGRES_USER: ${POSTGRES_USER:-claire_user}
       PAPER_AUTO_UNWIND: "true"  # Auto-close paper positions to prevent exposure accumulation
+      # Issue #748: Policy snapshot env (fallback "unknown" when unset)
+      CDB_GIT_COMMIT: ${CDB_GIT_COMMIT:-unknown}
+      CDB_POLICY_VERSION: ${CDB_POLICY_VERSION:-unknown}
     entrypoint: ["sh", "-c", "export REDIS_PASSWORD=$(cat /run/secrets/redis_password) && export POSTGRES_PASSWORD=$(cat /run/secrets/postgres_password) && export MEXC_API_KEY=$(cat /run/secrets/mexc_api_key) && export MEXC_API_SECRET=$(cat /run/secrets/mexc_api_secret) && exec python -m services.risk.service"]
     ports:
       - "127.0.0.1:8002:8002"
@@ -260,6 +263,9 @@ services:
       REDIS_HOST: cdb_redis
       POSTGRES_HOST: cdb_postgres
       POSTGRES_USER: ${POSTGRES_USER:-claire_user}
+      # Issue #748: Policy snapshot env (fallback "unknown" when unset)
+      CDB_GIT_COMMIT: ${CDB_GIT_COMMIT:-unknown}
+      CDB_POLICY_VERSION: ${CDB_POLICY_VERSION:-unknown}
     entrypoint: ["sh", "-c", "export REDIS_PASSWORD=$(cat /run/secrets/redis_password) && export POSTGRES_PASSWORD=$(cat /run/secrets/postgres_password) && export MEXC_API_KEY=$(cat /run/secrets/mexc_api_key) && export MEXC_API_SECRET=$(cat /run/secrets/mexc_api_secret) && exec python -u service.py"]
     ports:
       - "127.0.0.1:8003:8003"

--- a/infrastructure/compose/prod.yml
+++ b/infrastructure/compose/prod.yml
@@ -80,6 +80,8 @@ services:
     environment:
       ENV: "production"
       LOG_LEVEL: "WARNING"
+      CDB_GIT_COMMIT: ${CDB_GIT_COMMIT:-unknown}
+      CDB_POLICY_VERSION: ${CDB_POLICY_VERSION:-unknown}
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -98,6 +100,8 @@ services:
     environment:
       ENV: "production"
       LOG_LEVEL: "WARNING"
+      CDB_GIT_COMMIT: ${CDB_GIT_COMMIT:-unknown}
+      CDB_POLICY_VERSION: ${CDB_POLICY_VERSION:-unknown}
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/infrastructure/compose/test.yml
+++ b/infrastructure/compose/test.yml
@@ -62,6 +62,9 @@ services:
       TRADING_MODE: paper
       DRY_RUN: "1"
       LOG_LEVEL: DEBUG
+      # Issue #748: Policy snapshot env (test fallback)
+      CDB_GIT_COMMIT: ${CDB_GIT_COMMIT:-test}
+      CDB_POLICY_VERSION: ${CDB_POLICY_VERSION:-test}
 
       # Python settings
       PYTHONUNBUFFERED: "1"
@@ -111,6 +114,9 @@ services:
       TRADING_MODE: paper
       DRY_RUN: "1"
       LOG_LEVEL: DEBUG
+      # Issue #748: Policy snapshot env (test fallback)
+      CDB_GIT_COMMIT: ${CDB_GIT_COMMIT:-test}
+      CDB_POLICY_VERSION: ${CDB_POLICY_VERSION:-test}
 
       # Python settings
       PYTHONUNBUFFERED: "1"


### PR DESCRIPTION
Refs #961

## Scope
Deploy/workflow env wiring only — no app/trading logic changes.

## What
Sets `CDB_GIT_COMMIT` and `CDB_POLICY_VERSION` for `cdb_risk` and `cdb_execution` services so `build_policy_snapshot()` (from PR #960) produces meaningful values instead of `"unknown"` when toggle ON.

## Version Logic
```
if GITHUB_REF is a tag → CDB_POLICY_VERSION = tag name (e.g. "v1.2.0")
else → CDB_POLICY_VERSION = "dev-<7-char-sha>"
```
No hard-fail: Compose defaults to `"unknown"` when CI doesn't set the var.

## Geänderte Dateien

| Datei | Änderung |
|-------|----------|
| `.env.example` | Dokumentation beider Variablen |
| `infrastructure/compose/dev.yml` | `CDB_GIT_COMMIT` + `CDB_POLICY_VERSION` für cdb_risk, cdb_execution (fallback `unknown`) |
| `infrastructure/compose/prod.yml` | Gleiche Ergänzung im Prod-Overlay |
| `infrastructure/compose/test.yml` | Gleiche Ergänzung für cdb_risk_test, cdb_execution_test (fallback `test`) |
| `.github/workflows/e2e.yml` | Setzt beide Vars in dynamisch erzeugter `.env` aus `github.sha` + Tag/SHA-Logik |

## Nicht geändert
- Keine `services/*` oder `core/*` Python-Dateien
- Keine Dockerfiles
- Keine neuen Secrets/Tokens
- `policy_snapshot` bleibt toggle-gated (default OFF) — hier wird nur die Qualität der Werte verbessert

🤖 Generated with [Claude Code](https://claude.com/claude-code)