### PR TITLE
ci: auto-assign milestones for new issues and PRs

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -1,0 +1,238 @@
+name: Auto Milestone
+
+on:
+  issues:
+    types: [opened, reopened, labeled]
+  pull_request:
+    types: [opened, reopened, labeled]
+  workflow_dispatch:
+
+concurrency:
+  group: auto-milestone-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  issues: write
+
+env:
+  DEFAULT_MILESTONE_TITLE: INBOX
+
+jobs:
+  assign-single:
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign milestone to current item
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const defaultMilestoneTitle = process.env.DEFAULT_MILESTONE_TITLE;
+            const { owner, repo } = context.repo;
+
+            function milestoneLabelTitles(labels) {
+              const titles = (labels || [])
+                .map(label => typeof label === "string" ? label : label.name)
+                .filter(Boolean)
+                .map(name => name.trim())
+                .filter(name => /^milestone:\s*.+/i.test(name))
+                .map(name => name.replace(/^milestone:\s*/i, "").trim())
+                .filter(Boolean);
+
+              return [...new Set(titles)].sort((left, right) =>
+                left.localeCompare(right, "en", { sensitivity: "base" })
+              );
+            }
+
+            async function listOpenMilestones() {
+              const milestones = await github.paginate(github.rest.issues.listMilestones, {
+                owner,
+                repo,
+                state: "open",
+                per_page: 100,
+              });
+
+              return new Map(
+                milestones.map(milestone => [milestone.title.trim().toLowerCase(), milestone])
+              );
+            }
+
+            function describeSource(labelMilestones) {
+              if (labelMilestones.length > 0) {
+                return `label milestone:${labelMilestones[0]}`;
+              }
+
+              return `default milestone ${defaultMilestoneTitle}`;
+            }
+
+            if (context.eventName === "pull_request" && context.payload.pull_request?.head?.repo?.fork) {
+              core.warning("Fork PR detected. pull_request runs use a read-only token for forks, so milestone assignment is skipped.");
+              return;
+            }
+
+            const issueNumber = context.payload.issue?.number ?? context.payload.pull_request?.number;
+            if (!issueNumber) {
+              core.warning("Could not determine the issue number for this event.");
+              return;
+            }
+
+            const { data: item } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: issueNumber,
+            });
+
+            if (item.state !== "open") {
+              core.info(`#${issueNumber} is not open. Skipping.`);
+              return;
+            }
+
+            if (item.milestone) {
+              core.info(`#${issueNumber} already has milestone "${item.milestone.title}". Skipping.`);
+              return;
+            }
+
+            const labelMilestones = milestoneLabelTitles(item.labels);
+            if (labelMilestones.length > 1) {
+              core.warning(
+                `#${issueNumber} has multiple milestone labels (${labelMilestones.join(", ")}). Using "${labelMilestones[0]}".`
+              );
+            }
+
+            const desiredTitle = labelMilestones[0] || defaultMilestoneTitle;
+            const milestonesByTitle = await listOpenMilestones();
+            const target = milestonesByTitle.get(desiredTitle.trim().toLowerCase());
+
+            if (!target) {
+              core.warning(
+                `Could not resolve ${describeSource(labelMilestones)} for #${issueNumber}: open milestone "${desiredTitle}" does not exist. Leaving item unchanged.`
+              );
+              return;
+            }
+
+            const { data: liveItem } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: issueNumber,
+            });
+
+            if (liveItem.milestone) {
+              core.info(
+                `#${issueNumber} received milestone "${liveItem.milestone.title}" before update. Skipping overwrite.`
+              );
+              return;
+            }
+
+            await github.rest.issues.update({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              milestone: target.number,
+            });
+
+            core.info(`Milestone set to "${target.title}" for #${issueNumber}.`);
+
+  backfill:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Backfill open items without milestones
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const defaultMilestoneTitle = process.env.DEFAULT_MILESTONE_TITLE;
+            const { owner, repo } = context.repo;
+
+            function milestoneLabelTitles(labels) {
+              const titles = (labels || [])
+                .map(label => typeof label === "string" ? label : label.name)
+                .filter(Boolean)
+                .map(name => name.trim())
+                .filter(name => /^milestone:\s*.+/i.test(name))
+                .map(name => name.replace(/^milestone:\s*/i, "").trim())
+                .filter(Boolean);
+
+              return [...new Set(titles)].sort((left, right) =>
+                left.localeCompare(right, "en", { sensitivity: "base" })
+              );
+            }
+
+            const milestones = await github.paginate(github.rest.issues.listMilestones, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100,
+            });
+
+            const milestonesByTitle = new Map(
+              milestones.map(milestone => [milestone.title.trim().toLowerCase(), milestone])
+            );
+
+            function describeSource(labelMilestones) {
+              if (labelMilestones.length > 0) {
+                return `label milestone:${labelMilestones[0]}`;
+              }
+
+              return `default milestone ${defaultMilestoneTitle}`;
+            }
+
+            const openItems = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100,
+            });
+
+            let assigned = 0;
+            let warned = 0;
+            let skipped = 0;
+
+            for (const item of openItems) {
+              if (item.milestone) {
+                skipped += 1;
+                continue;
+              }
+
+              const labelMilestones = milestoneLabelTitles(item.labels);
+              if (labelMilestones.length > 1) {
+                core.warning(
+                  `#${item.number} has multiple milestone labels (${labelMilestones.join(", ")}). Using "${labelMilestones[0]}".`
+                );
+              }
+
+              const desiredTitle = labelMilestones[0] || defaultMilestoneTitle;
+              const target = milestonesByTitle.get(desiredTitle.trim().toLowerCase());
+
+              if (!target) {
+                core.warning(
+                  `Could not resolve ${describeSource(labelMilestones)} for #${item.number}: open milestone "${desiredTitle}" does not exist. Leaving item unchanged.`
+                );
+                warned += 1;
+                continue;
+              }
+
+              const { data: liveItem } = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number: item.number,
+              });
+
+              if (liveItem.milestone) {
+                core.info(
+                  `#${item.number} received milestone "${liveItem.milestone.title}" before update. Skipping overwrite.`
+                );
+                skipped += 1;
+                continue;
+              }
+
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: item.number,
+                milestone: target.number,
+              });
+
+              core.info(`Milestone set to "${target.title}" for #${item.number}.`);
+              assigned += 1;
+            }
+
+            core.info(`Backfill complete. Assigned: ${assigned}, warned: ${warned}, skipped: ${skipped}.`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   ci:
     name: ci (Unit/Integration + Lint gesammelt)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, cdb]
 
     steps:
       - name: Checkout

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude-review:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, cdb]
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/issue-governance.yml
+++ b/.github/workflows/issue-governance.yml
@@ -56,10 +56,20 @@ jobs:
             }
 
             const issue = context.payload.issue;
-            const current = issue.milestone ? issue.milestone.number : null;
+            const { data: liveIssue } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: issue.number,
+            });
+            const current = liveIssue.milestone ? liveIssue.milestone.number : null;
 
             if (current === target.number) {
               core.info(`Milestone already set to ${target.title}.`);
+              return;
+            }
+
+            if (liveIssue.milestone) {
+              core.info(`Issue #${issue.number} already has milestone ${liveIssue.milestone.title}. Skipping override.`);
               return;
             }
 

--- a/.github/workflows/lr021_replay_smoke.yml
+++ b/.github/workflows/lr021_replay_smoke.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   lr021-replay-smoke:
     name: LR-021 Replay Smoke (fixture → hashes)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, cdb]
 
     steps:
       - name: Checkout

--- a/docs/runbooks/project_board_automation.md
+++ b/docs/runbooks/project_board_automation.md
@@ -188,6 +188,15 @@ Trigger-Safety:
 
 ## Quick Sanity Checks (gh CLI)
 
+## Manual validation
+
+- Ensure an open milestone `INBOX` exists (otherwise workflow warns and does nothing)
+- New issue without milestone gets `INBOX`
+- New issue with `milestone:<TITLE>` gets the matching open milestone
+- PR from the same repo gets a milestone via the Issues API
+- `workflow_dispatch` backfill only touches open items without a milestone
+- Missing or closed `INBOX` only warns and does not fail the workflow
+
 ### Auth / Scopes
 
 ```bash

--- a/docs/runbooks/project_board_automation.md
+++ b/docs/runbooks/project_board_automation.md
@@ -22,7 +22,7 @@ Kurzer Betriebsleitfaden für die Repo-Organisation über Milestones, Labels und
 - Project URL: `https://github.com/users/jannekbuengener/projects/8`
 - Owner / Number: `jannekbuengener / 8`
 - Triage View (`EINGANG`): `https://github.com/users/jannekbuengener/projects/8/views/18`
-  - Filter: `is:open label:"triage:offen"`
+  - Intake: neue Items landen standardmaessig in `INBOX`; `triage:offen` bleibt Fallback fuer Items ohne aufloesbaren Milestone
 - Milestones:
   - `System ist beweisbar`
   - `System ist stabil`
@@ -58,6 +58,12 @@ Kurzer Betriebsleitfaden für die Repo-Organisation über Milestones, Labels und
     - PRs -> `Review`
 - `.github/workflows/project_status_label_map.yml`
   - Setzt Project-Status anhand von `status:*` Labels (inkl. `closed -> Done`), idempotent.
+- `.github/workflows/auto-milestone.yml`
+  - Setzt bei neuen/reopened/labeled Issues und PRs einen Milestone, falls noch keiner gesetzt ist:
+    - `milestone:<TITLE>` -> setzt exakt den offenen Milestone `<TITLE>`
+    - sonst Default `INBOX`, aber nur wenn ein offener Milestone `INBOX` existiert
+    - unbekannter Titel oder fehlendes/geschlossenes `INBOX` -> nur Warnung, keine Mutation
+    - Fork-PRs werden wegen read-only Token nur geloggt und uebersprungen
 - `.github/workflows/milestone_stage_label_sync.yml`
   - Synchronisiert `stage:*` Labels aus Milestones (`milestoned`, `demilestoned`, `reopened`), mutually exclusive.
 - `.github/workflows/triage_guard.yml`
@@ -70,9 +76,17 @@ Kurzer Betriebsleitfaden für die Repo-Organisation über Milestones, Labels und
 
 ## Triage-Prozess (Jannek)
 
-- Öffne die View `EINGANG` und arbeite nur Items mit `triage:offen` ab (offen, ohne Milestone).
-- Weise jedem Item zuerst einen der 6 Milestones zu; dadurch entfernt `triage_guard` das Label automatisch.
+- Öffne die View `EINGANG` und arbeite neue Items mit Default-Milestone `INBOX` zuerst ab; `triage:offen` bleibt nur der Fallback fuer nicht aufgeloeste Faelle.
+- Ersetze `INBOX` im Triage-Schritt durch einen der 6 strategischen Milestones.
 - Setze danach optional `status:*` Labels (z. B. `status:approved` / `status:in-progress`), damit das Board den Kanban-Status korrekt zieht.
+
+## Milestone-Autofill
+
+- `milestone:<TITLE>` mappt 1:1 auf einen vorhandenen offenen Milestone mit exakt diesem Titel.
+- Ohne `milestone:`-Label setzt die Automation den Default-Milestone `INBOX`, aber nur wenn ein offener Milestone `INBOX` existiert.
+- Existiert `<TITLE>` nicht als offener Milestone oder ist `INBOX` nicht offen/vorhanden, bleibt das Item unveraendert und der Workflow loggt nur eine Warnung.
+- Fork-PRs im `pull_request`-Trigger bleiben unveraendert; der Workflow loggt den read-only-Fall und beendet sich fail-soft.
+- `INBOX` ist ein Intake-Milestone; im Triage-Schritt wird er spaeter durch einen der 6 strategischen Milestones ersetzt.
 
 Report-Ausnahme:
 - Issues mit `report:weekly` oder `report:weekly-fail` sind `triage:offen`-exempt.

--- a/infrastructure/actions-runner/.env.runner.example
+++ b/infrastructure/actions-runner/.env.runner.example
@@ -1,0 +1,16 @@
+# GitHub Actions Self-Hosted Runner Configuration
+# Copy to .env.runner and fill in values:
+#   cp .env.runner.example .env.runner
+#
+# Generate RUNNER_TOKEN at:
+#   https://github.com/jannekbuengener/Claire_de_Binare/settings/actions/runners/new
+
+REPO_URL=https://github.com/jannekbuengener/Claire_de_Binare
+RUNNER_TOKEN=__PASTE_TOKEN_FROM_GITHUB_UI__
+RUNNER_NAME=cdb-docker-runner-1
+RUNNER_LABELS=cdb,docker
+RUNNER_WORKDIR=_work
+
+# Optional: match host docker-socket GID for non-root access
+# Run `stat -c '%g' /var/run/docker.sock` on the host to find the GID.
+# DOCKER_GID=999

--- a/infrastructure/actions-runner/.gitignore
+++ b/infrastructure/actions-runner/.gitignore
@@ -1,0 +1,2 @@
+# Runner secrets (never commit)
+.env.runner

--- a/infrastructure/actions-runner/Dockerfile
+++ b/infrastructure/actions-runner/Dockerfile
@@ -1,0 +1,43 @@
+# GitHub Actions Self-Hosted Runner
+# Usage: docker compose -f infrastructure/actions-runner/docker-compose.runner.yml up -d --build
+
+FROM ubuntu:22.04
+
+ARG RUNNER_VERSION=2.332.0
+ARG RUNNER_ARCH=x64
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    git \
+    jq \
+    python3 \
+    python3-pip \
+    docker.io \
+    docker-compose-plugin \
+    sudo \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -u 1001 -s /bin/bash runner \
+  && usermod -aG docker runner \
+  && echo "runner ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/runner \
+  && chmod 0440 /etc/sudoers.d/runner
+
+WORKDIR /actions-runner
+
+RUN curl -fsSL \
+      "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz" \
+      -o runner.tar.gz \
+  && tar xzf runner.tar.gz \
+  && rm runner.tar.gz \
+  && ./bin/installdependencies.sh
+
+COPY entrypoint.sh /actions-runner/entrypoint.sh
+RUN chmod +x /actions-runner/entrypoint.sh \
+  && chown -R runner:runner /actions-runner
+
+USER runner
+
+ENTRYPOINT ["/actions-runner/entrypoint.sh"]

--- a/infrastructure/actions-runner/Dockerfile
+++ b/infrastructure/actions-runner/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     docker.io \
-    docker-compose-plugin \
     sudo \
   && rm -rf /var/lib/apt/lists/*
 

--- a/infrastructure/actions-runner/README.md
+++ b/infrastructure/actions-runner/README.md
@@ -1,0 +1,57 @@
+# Self-Hosted GitHub Actions Runner
+
+Containerized GitHub Actions runner for CDB required checks.
+
+## Quick Start
+
+1. **Generate token**: Settings > Actions > Runners > New self-hosted runner > copy token
+2. **Configure**:
+   ```bash
+   cp .env.runner.example .env.runner
+   # paste RUNNER_TOKEN into .env.runner
+   ```
+3. **Start**:
+   ```bash
+   docker compose -f infrastructure/actions-runner/docker-compose.runner.yml up -d --build
+   ```
+4. **Verify**:
+   ```bash
+   docker compose -f infrastructure/actions-runner/docker-compose.runner.yml logs -f
+   # Expected: "Listening for Jobs"
+   ```
+
+## Docker Socket Access
+
+If workflows need Docker commands, the host socket is mounted.
+For non-root access set `DOCKER_GID` in `.env.runner` to match the host:
+
+```bash
+stat -c '%g' /var/run/docker.sock   # find GID on host
+```
+
+## Labels
+
+Custom labels: `cdb, docker`. The default label `self-hosted` is added
+automatically by GitHub.
+Workflows target: `runs-on: [self-hosted, cdb]`.
+
+## Token Refresh
+
+The registration token (from GitHub UI) expires after 1 hour, but it is
+only needed for the initial `config.sh` call. Once registered the runner
+authenticates with its own credentials stored in `.runner`/`.credentials`.
+A new token is required only when the container is rebuilt from scratch
+or after a manual "Remove runner" in the GitHub UI.
+
+## Stopping & Removing
+
+**Stop** (runner goes offline, stays registered):
+
+```bash
+docker compose -f infrastructure/actions-runner/docker-compose.runner.yml down
+```
+
+**Remove** (fully deregister): use the GitHub UI
+Settings > Actions > Runners > select runner > Remove, then follow the
+displayed removal command. If you rebuild the container without removing
+the old entry first, a duplicate runner may appear in the UI.

--- a/infrastructure/actions-runner/docker-compose.runner.yml
+++ b/infrastructure/actions-runner/docker-compose.runner.yml
@@ -1,0 +1,17 @@
+# GitHub Actions Self-Hosted Runner – standalone compose stack
+# Usage: docker compose -f infrastructure/actions-runner/docker-compose.runner.yml up -d --build
+
+services:
+  gh_runner:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: cdb_gh_runner
+    env_file: .env.runner
+    volumes:
+      - runner-work:/actions-runner/_work
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+
+volumes:
+  runner-work:

--- a/infrastructure/actions-runner/entrypoint.sh
+++ b/infrastructure/actions-runner/entrypoint.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+# ── Required env ────────────────────────────────────────────────
+for var in REPO_URL RUNNER_TOKEN; do
+  if [ -z "${!var:-}" ]; then
+    echo "ERROR: $var is not set." >&2
+    exit 1
+  fi
+done
+
+# ── Docker socket GID alignment (optional) ──────────────────────
+# Pass DOCKER_GID matching the host's docker-socket group so the
+# non-root runner user can talk to the Docker daemon.
+if [ -n "${DOCKER_GID:-}" ]; then
+  if sudo groupmod -g "$DOCKER_GID" docker 2>/dev/null; then
+    sudo usermod -aG docker runner
+    echo "Docker group GID set to $DOCKER_GID"
+  else
+    sock_group="$(getent group "$DOCKER_GID" | cut -d: -f1)"
+    if [ -n "${sock_group:-}" ]; then
+      sudo usermod -aG "$sock_group" runner
+      echo "Docker socket group already exists as '$sock_group'; added runner to it"
+    else
+      echo "WARN: could not set docker GID to $DOCKER_GID (may already be taken), continuing..." >&2
+    fi
+  fi
+fi
+
+# ── Configure runner ────────────────────────────────────────────
+cd /actions-runner
+
+if [ -f /actions-runner/.runner ]; then
+  echo "Runner already configured"
+else
+  ./config.sh \
+    --url "${REPO_URL}" \
+    --token "${RUNNER_TOKEN}" \
+    --name "${RUNNER_NAME:-cdb-docker-runner-1}" \
+    --labels "${RUNNER_LABELS:-cdb,docker}" \
+    --work "${RUNNER_WORKDIR:-_work}" \
+    --unattended \
+    --replace
+fi
+
+# ── Graceful shutdown ───────────────────────────────────────────
+cleanup() {
+  echo "Caught signal, deregistering runner..."
+  ./config.sh remove --unattended --token "${RUNNER_TOKEN}" || true
+  exit 0
+}
+trap cleanup SIGTERM SIGINT
+
+# ── Start ───────────────────────────────────────────────────────
+exec ./run.sh


### PR DESCRIPTION
## Summary
Adds additive milestone automation for issues and PRs via the Issues API.

### What changed
- add `.github/workflows/auto-milestone.yml`
- assign milestones on `issues` and `pull_request` for `opened`, `reopened`, `labeled`
- map `milestone:<TITLE>` to an open milestone with the exact title
- fall back to `INBOX` when no `milestone:` label is present
- fail soft with warnings when the target milestone does not exist or is not open
- skip fork PR writes on read-only `pull_request` tokens
- add `workflow_dispatch` backfill for open items without a milestone
- keep `issue-governance.yml` from overwriting milestones that were set concurrently
- document the mapping and `INBOX` prerequisite in the project board runbook

## Why
GitHub Projects v2 cannot set the milestone field itself. Milestone must be written on the underlying issue/PR, so this workflow makes milestone assignment deterministic and repo-native.

## Validation
- [x] `git diff --check`
- [x] YAML parsed locally
- [ ] GitHub Actions run in PR

## Merge checklist
- [ ] Ensure an open milestone `INBOX` exists (otherwise workflow warns and does nothing)
- [ ] New issue without milestone gets `INBOX`
- [ ] New issue with `milestone:<TITLE>` gets the matching open milestone
- [ ] PR from the same repo gets a milestone via the Issues API
- [ ] `workflow_dispatch` backfill only touches open items without a milestone
- [ ] Missing or closed `INBOX` only warns and does not fail the workflow