### PR TITLE
ci: add non-blocking MCP runtime workflow

### DIFF
--- a/.github/workflows/mcp_runtime.yml
+++ b/.github/workflows/mcp_runtime.yml
@@ -3,7 +3,7 @@ name: mcp-runtime
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 3 * * *"
+    - cron: "30 3,11,19 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Keeps required `ci` deterministic (test remains excluded there)
- Adds scheduled (03:30 UTC daily) + manual runtime validation for `test_mcp_time_server_runtime`
- Includes robust `libpython` linking step via `ldconfig` (no app/core changes)
- Diagnose block logs Python/lib layout for debugging

## New file

- `.github/workflows/mcp_runtime.yml`

## How to run

```bash
gh workflow run mcp_runtime.yml
```

Or: Actions tab > mcp-runtime > Run workflow

## Test plan

- [ ] Manual trigger via `workflow_dispatch` picks up self-hosted runner
- [ ] `libpython3.12.so` is found and linked via `ldconfig`
- [ ] `test_mcp_time_server_runtime` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)