### PR TITLE
ci: isolate milestone labeled runs from non-milestone label concurrency

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -8,7 +8,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: auto-milestone-${{ github.event.issue.number || github.event.pull_request.number }}
+  group: >-
+    auto-milestone-${{ github.event.issue.number || github.event.pull_request.number }}-${{
+      github.event.action == 'labeled' && startsWith(github.event.label.name || '', 'milestone:') && 'milestone' ||
+      github.event.action == 'labeled' && 'other' ||
+      'base'
+    }}
   cancel-in-progress: true
 
 permissions:
@@ -86,8 +91,12 @@ jobs:
               return;
             }
 
+            const eventLabelName = (context.payload.label?.name || "").trim();
+            core.info(
+              `Auto Milestone event: action=${action || "<none>"} label=${eventLabelName || "<none>"} issueNumber=${issueNumber}`
+            );
+
             if (context.eventName === "issues" && action === "labeled") {
-              const eventLabelName = (context.payload.label?.name || "").trim();
               if (!/^milestone:\s*.+/i.test(eventLabelName)) {
                 core.info("Non-milestone label event; skipping.");
                 return;


### PR DESCRIPTION
## Summary
- isolate `issues.labeled` milestone runs from unrelated label runs in workflow concurrency
- keep opened/reopened/synchronize behavior unchanged
- add a small `core.info` event log at workflow start for faster debugging

## Why
A `milestone:<TITLE>` labeled run could be canceled by a second non-milestone labeled run on the same issue. The second run then skipped with `Non-milestone label event; skipping.`, leaving the milestone unset.

## Validation
- [x] `git diff --check`
- [x] YAML parsed locally
- [ ] Post-merge smoke: add `milestone:VALIDIERUNG` and another label shortly after; milestone run must still win