### PR TITLE
ci: fix auto-milestone workflow validation for PR runs

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -18,7 +18,6 @@ concurrency:
 
 permissions:
   issues: write
-  metadata: read
 
 env:
   DEFAULT_MILESTONE_TITLE: INBOX


### PR DESCRIPTION
## Summary
Fix the auto-milestone workflow file so GitHub can validate and run the `pull_request_target` PR path.

## Root cause
The workflow declared `metadata: read` inside `permissions:`. `metadata` is not a configurable workflow permission key, so GitHub rejected the workflow file before any jobs started.

## Validation
- [x] `git diff --check`
- [x] YAML parsed locally
- [ ] GitHub Actions run in PR