### PR TITLE
[workflows-only] ci: pin workflow actions to commit SHAs (artifact policy)

### DIFF
--- a/.github/workflows/auto-milestone-pr-intent.yml
+++ b/.github/workflows/auto-milestone-pr-intent.yml
@@ -25,7 +25,7 @@ jobs:
           EOF
 
       - name: Upload PR event artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pr_event
           path: pr_event.json


### PR DESCRIPTION
Fixes org policy requiring full-length commit SHAs for all actions/uses, unblocks PR intent/apply pipeline.