### PR TITLE
[workflows-only] ci: fallback to CDB_PR_AUTOMATION_TOKEN when GITHUB_TOKEN is downscoped on PR apply

### DIFF
--- a/.github/workflows/auto-milestone-pr-apply.yml
+++ b/.github/workflows/auto-milestone-pr-apply.yml
@@ -12,6 +12,7 @@ permissions:
 
 env:
   DEFAULT_MILESTONE_TITLE: INBOX
+  FALLBACK_TOKEN: ${{ secrets.CDB_PR_AUTOMATION_TOKEN }}
 
 jobs:
   apply-pr-milestone:
@@ -37,10 +38,12 @@ jobs:
         with:
           script: |
             const defaultMilestoneTitle = process.env.DEFAULT_MILESTONE_TITLE;
+            const fallbackToken = process.env.FALLBACK_TOKEN || "";
             const { owner, repo } = context.repo;
             const workflowRun = context.payload.workflow_run;
             const fs = require("fs");
             const artifactPath = "pr_event_artifact/pr_event.json";
+            const { getOctokit } = require("@actions/github");
 
             function logPermissionWarning(error, action) {
               const status = error?.status ?? error?.response?.status;
@@ -50,6 +53,12 @@ jobs:
               core.warning(
                 `${action} skipped: ${message}${status ? ` (status ${status})` : ""}${accepted ? ` [accepted permissions: ${accepted}]` : ""}`
               );
+            }
+
+            function isDownscopedIntegrationError(error) {
+              const status = error?.status ?? error?.response?.status;
+              const message = (error?.response?.data?.message || error?.message || "").toLowerCase();
+              return status === 403 && message.includes("resource not accessible by integration");
             }
 
             function milestoneLabelTitles(labels) {
@@ -121,7 +130,7 @@ jobs:
               return;
             }
 
-            core.info("PR path active: same-repo guard passed.");
+            core.info("same-repo guard passed.");
             core.info(
               `Auto Milestone PR Apply event: action=${action || "<none>"} label=${eventLabelName || "<none>"} issueNumber=${issueNumber}`
             );
@@ -131,16 +140,44 @@ jobs:
               return;
             }
 
+            let apiClient = github;
             let liveItem;
-            try {
-              ({ data: liveItem } = await github.rest.issues.get({
+            core.info("Using GITHUB_TOKEN");
+
+            async function readIssue(client) {
+              const { data } = await client.rest.issues.get({
                 owner,
                 repo,
                 issue_number: issueNumber,
-              }));
+              });
+
+              return data;
+            }
+
+            try {
+              liveItem = await readIssue(apiClient);
             } catch (error) {
-              logPermissionWarning(error, `Read for #${issueNumber}`);
-              return;
+              if (!isDownscopedIntegrationError(error)) {
+                logPermissionWarning(error, `Read for #${issueNumber}`);
+                return;
+              }
+
+              if (!fallbackToken) {
+                core.warning(
+                  "PR apply blocked (GITHUB_TOKEN downscoped) and no CDB_PR_AUTOMATION_TOKEN configured. Skipping."
+                );
+                return;
+              }
+
+              core.info("Retrying PR apply with CDB_PR_AUTOMATION_TOKEN");
+              apiClient = getOctokit(fallbackToken);
+
+              try {
+                liveItem = await readIssue(apiClient);
+              } catch (fallbackError) {
+                logPermissionWarning(fallbackError, `Fallback read for #${issueNumber}`);
+                return;
+              }
             }
 
             if (liveItem.state !== "open") {
@@ -214,7 +251,7 @@ jobs:
             core.info(`Milestone write attempt: target="${target.title}" issueNumber=${issueNumber}`);
 
             try {
-              await github.rest.issues.update({
+              await apiClient.rest.issues.update({
                 owner,
                 repo,
                 issue_number: issueNumber,

--- a/docs/runbooks/project_board_automation.md
+++ b/docs/runbooks/project_board_automation.md
@@ -72,6 +72,7 @@ Kurzer Betriebsleitfaden für die Repo-Organisation über Milestones, Labels und
 - `.github/workflows/auto-milestone-pr-apply.yml`
   - Reagiert via `workflow_run` auf `Auto Milestone PR Intent`, laeuft im Default-Branch-Kontext und setzt PR-Milestones ueber die Issues API.
   - Metadata-only: kein Checkout, same-repo guard fuer Fork-PRs, fail-soft bei API-/Berechtigungsfehlern.
+  - Wenn GitHub den `GITHUB_TOKEN` im Apply-Pfad serverseitig auf `issues=read` herunterstuft, nutzt der Workflow optional das Repo-Secret `CDB_PR_AUTOMATION_TOKEN` als Fallback.
 - `.github/workflows/milestone_stage_label_sync.yml`
   - Synchronisiert `stage:*` Labels aus Milestones (`milestoned`, `demilestoned`, `reopened`), mutually exclusive.
 - `.github/workflows/triage_guard.yml`
@@ -221,6 +222,8 @@ Trigger-Safety:
   - Der Applier laeuft im trusted Default-Branch-Kontext, macht keinen Checkout und setzt den Milestone ueber die Issues API.
 - Externe Fork-PRs werden absichtlich per same-repo guard geskippt.
 - Hintergrund: PR-Event-Token koennen serverseitig read-only sein; `workflow_run` kann dagegen die benoetigten Write-Tokens fuer Metadata-Mutationen erhalten.
+- Wenn `GITHUB_TOKEN` im Apply-Workflow trotzdem mit `403` und `accepted permissions: issues=read` downscoped wird, benoetigt der Workflow das Repo-Secret `CDB_PR_AUTOMATION_TOKEN` (fine-grained PAT mit minimal `Issues`/`Pull requests` Read+Write), um PR-Milestones zu setzen.
+- Security bleibt unveraendert: metadata-only, kein Checkout, same-repo guard.
 
 ## Manual backfill (monthly)
 


### PR DESCRIPTION
Adds an optional fallback token path for Auto Milestone PR Apply when GitHub server-side downscopes GITHUB_TOKEN to issues=read in workflow_run context. Keeps metadata-only behavior, same-repo guard, and fail-soft warnings when no fallback secret is configured.