### PR TITLE
[workflows-only] ci: remove @actions/github require from PR apply script

### DIFF
--- a/.github/workflows/auto-milestone-pr-apply.yml
+++ b/.github/workflows/auto-milestone-pr-apply.yml
@@ -43,7 +43,6 @@ jobs:
             const workflowRun = context.payload.workflow_run;
             const fs = require("fs");
             const artifactPath = "pr_event_artifact/pr_event.json";
-            const { getOctokit } = require("@actions/github");
 
             function logPermissionWarning(error, action) {
               const status = error?.status ?? error?.response?.status;
@@ -170,7 +169,7 @@ jobs:
               }
 
               core.info("Retrying PR apply with CDB_PR_AUTOMATION_TOKEN");
-              apiClient = getOctokit(fallbackToken);
+              apiClient = github.getOctokit(fallbackToken);
 
               try {
                 liveItem = await readIssue(apiClient);


### PR DESCRIPTION
Removes the unsupported @actions/github require from the inline github-script step and uses the injected github object for fallback Octokit creation instead.