### PR TITLE
[workflows-only] ci: use fetch-based REST fallback for PR apply token

### DIFF
--- a/.github/workflows/auto-milestone-pr-apply.yml
+++ b/.github/workflows/auto-milestone-pr-apply.yml
@@ -60,6 +60,33 @@ jobs:
               return status === 403 && message.includes("resource not accessible by integration");
             }
 
+            async function ghFetch(token, method, path, body) {
+              const url = `https://api.github.com${path}`;
+              const res = await fetch(url, {
+                method,
+                headers: {
+                  "Authorization": `Bearer ${token}`,
+                  "Accept": "application/vnd.github+json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+                  "Content-Type": "application/json",
+                },
+                body: body ? JSON.stringify(body) : undefined,
+              });
+              const text = await res.text();
+              let data;
+              try {
+                data = text ? JSON.parse(text) : null;
+              } catch {
+                data = text;
+              }
+
+              if (!res.ok) {
+                throw new Error(`Fallback API ${method} ${path} failed: ${res.status} ${res.statusText} :: ${text}`);
+              }
+
+              return data;
+            }
+
             function milestoneLabelTitles(labels) {
               const titles = (labels || [])
                 .map(label => typeof label === "string" ? label : label.name)
@@ -139,12 +166,12 @@ jobs:
               return;
             }
 
-            let apiClient = github;
+            let useFallbackApi = false;
             let liveItem;
             core.info("Using GITHUB_TOKEN");
 
-            async function readIssue(client) {
-              const { data } = await client.rest.issues.get({
+            async function readIssue() {
+              const { data } = await github.rest.issues.get({
                 owner,
                 repo,
                 issue_number: issueNumber,
@@ -154,7 +181,7 @@ jobs:
             }
 
             try {
-              liveItem = await readIssue(apiClient);
+              liveItem = await readIssue();
             } catch (error) {
               if (!isDownscopedIntegrationError(error)) {
                 logPermissionWarning(error, `Read for #${issueNumber}`);
@@ -169,10 +196,14 @@ jobs:
               }
 
               core.info("Retrying PR apply with CDB_PR_AUTOMATION_TOKEN");
-              apiClient = github.getOctokit(fallbackToken);
+              useFallbackApi = true;
 
               try {
-                liveItem = await readIssue(apiClient);
+                liveItem = await ghFetch(
+                  fallbackToken,
+                  "GET",
+                  `/repos/${owner}/${repo}/issues/${issueNumber}`
+                );
               } catch (fallbackError) {
                 logPermissionWarning(fallbackError, `Fallback read for #${issueNumber}`);
                 return;
@@ -199,7 +230,15 @@ jobs:
               }
             }
 
-            const milestonesByTitle = await listOpenMilestones();
+            const milestonesByTitle = useFallbackApi
+              ? new Map(
+                  (await ghFetch(
+                    fallbackToken,
+                    "GET",
+                    `/repos/${owner}/${repo}/milestones?state=open&per_page=100`
+                  )).map(milestone => [milestone.title.trim().toLowerCase(), milestone])
+                )
+              : await listOpenMilestones();
             const currentMilestone = liveItem.milestone || null;
             const currentTitle = currentMilestone ? currentMilestone.title.trim() : null;
             const currentTitleLower = currentTitle ? currentTitle.toLowerCase() : null;
@@ -250,12 +289,21 @@ jobs:
             core.info(`Milestone write attempt: target="${target.title}" issueNumber=${issueNumber}`);
 
             try {
-              await apiClient.rest.issues.update({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                milestone: target.number,
-              });
+              if (useFallbackApi) {
+                await ghFetch(
+                  fallbackToken,
+                  "PATCH",
+                  `/repos/${owner}/${repo}/issues/${issueNumber}`,
+                  { milestone: target.number }
+                );
+              } else {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  milestone: target.number,
+                });
+              }
             } catch (error) {
               logPermissionWarning(error, `Milestone update for #${issueNumber}`);
               return;


### PR DESCRIPTION
Replaces the invalid github.getOctokit fallback with direct fetch-based GitHub REST calls using CDB_PR_AUTOMATION_TOKEN, while keeping the existing GITHUB_TOKEN-first path and milestone precedence logic.