### PR TITLE
[workflows-only] ci: remove debug output from PR apply workflow

### DIFF
--- a/.github/workflows/auto-milestone-pr-apply.yml
+++ b/.github/workflows/auto-milestone-pr-apply.yml
@@ -27,12 +27,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: pr_event_artifact
 
-      - name: Inspect PR intent artifact
-        shell: bash
-        run: |
-          ls -la pr_event_artifact
-          cat pr_event_artifact/pr_event.json
-
       - name: Apply milestone to PR
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:


### PR DESCRIPTION
Removes the temporary debug step that listed the artifact directory and printed pr_event.json contents from the PR apply workflow.