### PR TITLE
docs: standardize secret store path + rotator-only policy

### DIFF
--- a/docs/governance/evidence/ISSUE-741-postgres-least-privilege-rls.md
+++ b/docs/governance/evidence/ISSUE-741-postgres-least-privilege-rls.md
@@ -24,18 +24,26 @@ Current status:
 - RLS table flags and policy inventory for the tracked `public` tables
 - Offline desired-vs-observed diff against `scripts/audit/desired_privileges.json`
 
+## Secret Policy
+
+- Canonical Secret Store: `C:\Users\janne\Documents\.secrets\.cdb`
+- Rotation / changes: rotator-only via `infrastructure/scripts/manage_secrets.ps1`; do not hand-edit secret files or stage secret material in the repo.
+- Connection env: export or load `POSTGRES_DSN`, `DATABASE_URL`, and related connection settings via the rotator workflow before running the dump or report commands.
+
 ## How to Generate Live Evidence
 
 - Follow [postgres_least_privilege_rls.md](../../runbooks/postgres_least_privilege_rls.md) to dump live CSV artifacts and run the offline report.
-- Attach the generated dump directory plus `report.json` / `summary.md` to the Issue, PR, or workflow artifact store.
-- Do not commit live dumps, DSNs, passwords, or other environment-specific secrets to the repository.
+- Generate the evidence bundle in a local or external path outside the repo, then upload the ZIP via GitHub UI attachment or an external artifact store and paste the resulting link into the Issue.
+- Do not commit live dumps, ZIP bundles, DSNs, passwords, or other environment-specific secrets to the repository.
 
 ## Evidence Placeholders
 
 - Dump timestamp (UTC): `TBD`
 - Environment: `TBD`
+- Local / external evidence bundle path: `TBD`
 - Dump artifact links: `TBD`
 - Offline report artifact links: `TBD`
+- Issue comment permalink: `TBD`
 - Operator notes: `TBD`
 
 ## Current Gaps

--- a/docs/runbooks/postgres_least_privilege_rls.md
+++ b/docs/runbooks/postgres_least_privilege_rls.md
@@ -54,32 +54,46 @@ All scripts are in `infrastructure/database/`:
 | `rollback_least_privilege.sql` | Restore `claire_user` ALL PRIVILEGES | superuser |
 | `verify_privileges.sql` | Show effective grants, memberships, ownership | superuser |
 
+## Secret Policy
+
+- Canonical Secret Store: `C:\Users\janne\Documents\.secrets\.cdb`
+- Rotation / changes: rotator-only via `infrastructure/scripts/manage_secrets.ps1`; do not hand-edit secret files and do not create alternate secret copies inside the repo.
+- Connection env: export or load `POSTGRES_DSN`, `DATABASE_URL`, and related connection material via the rotator workflow before running these commands. Do not paste credentials directly into shells, docs, or committed config.
+
 ## Live Evidence Workflow
 
 Use exactly these three commands to capture live evidence, run the offline
-diff, and prepare attachable artifacts without committing secrets:
+diff, and prepare attachable artifacts without committing secrets. The
+evidence bundle must live outside the repo and be linked from the Issue after
+upload:
 
 ```bash
-mkdir -p .artifacts/postgres-privileges
+export EVIDENCE_DIR="/tmp/cdb_pg_evidence_<ENV>_<YYYYMMDD_HHMM>"
+mkdir -p "$EVIDENCE_DIR"
 
+# Load POSTGRES_DSN / DATABASE_URL via the rotator first. Do not hand-edit
+# secret files or inline credentials here.
 psql "$POSTGRES_DSN" \
-  -v roles_out="$(pwd)/.artifacts/postgres-privileges/roles.csv" \
-  -v role_memberships_out="$(pwd)/.artifacts/postgres-privileges/role_memberships.csv" \
-  -v table_privileges_out="$(pwd)/.artifacts/postgres-privileges/table_privileges.csv" \
-  -v column_privileges_out="$(pwd)/.artifacts/postgres-privileges/column_privileges.csv" \
-  -v rls_tables_out="$(pwd)/.artifacts/postgres-privileges/rls_tables.csv" \
-  -v policies_out="$(pwd)/.artifacts/postgres-privileges/policies.csv" \
-  -v default_privileges_out="$(pwd)/.artifacts/postgres-privileges/default_privileges.csv" \
+  -v roles_out="$EVIDENCE_DIR/roles.csv" \
+  -v role_memberships_out="$EVIDENCE_DIR/role_memberships.csv" \
+  -v table_privileges_out="$EVIDENCE_DIR/table_privileges.csv" \
+  -v column_privileges_out="$EVIDENCE_DIR/column_privileges.csv" \
+  -v rls_tables_out="$EVIDENCE_DIR/rls_tables.csv" \
+  -v policies_out="$EVIDENCE_DIR/policies.csv" \
+  -v default_privileges_out="$EVIDENCE_DIR/default_privileges.csv" \
   -f scripts/audit/postgres_privilege_dump.sql
 
 python scripts/audit/postgres_least_privilege_report.py \
-  --input-dir .artifacts/postgres-privileges \
-  --out-dir .artifacts/postgres-privilege-report
+  --input-dir "$EVIDENCE_DIR" \
+  --out-dir "$EVIDENCE_DIR/report"
+
+zip -r "${EVIDENCE_DIR}.zip" "$EVIDENCE_DIR"
 ```
 
-Attach `.artifacts/postgres-privileges/` and
-`.artifacts/postgres-privilege-report/` to the Issue/PR/run as external
-artifacts. Do not commit the live dump files or any DSN/secret material.
+Upload `${EVIDENCE_DIR}.zip` via GitHub UI attachment or an external
+artifact-store, then paste the resulting link or issue-comment permalink into
+the Issue. Do not commit the live dump files, the ZIP bundle, or any
+DSN/secret material.
 
 ## Apply Steps
 


### PR DESCRIPTION
- standardize the canonical secret store path in the least-privilege runbook and evidence doc\n- require rotator-only secret creation/rotation and explicit rotator-based env loading\n- move evidence bundle guidance to local/external storage with issue links instead of repo paths\n\nRefs #741\n\nDocs-only. No secrets created or changed. No .github changes.

## Summary by Sourcery

Document standardized secret handling and evidence collection workflow for Postgres least-privilege RLS runbook and related governance evidence.

Documentation:
- Document a canonical secret store path and rotator-only workflow for Postgres connection credentials in the least-privilege runbook and evidence issue.
- Update the live evidence workflow to generate artifacts in a temporary external directory, zip them, and link uploads from GitHub or an external store instead of storing under the repo.
- Clarify evidence placeholders to capture external bundle locations, artifact links, and issue permalinks without committing secret-bearing files.