### PR TITLE
ops: harden claude workflow to avoid red main runs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,13 @@ on:
 
 jobs:
   claude:
+    if: |
+      github.event_name == 'pull_request' || (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -21,32 +28,29 @@ jobs:
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
+    env:
+      HAS_CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
     steps:
       - name: Required check (no-op on PR)
         if: github.event_name == 'pull_request'
-        run: echo "claude required check: noop SUCCESS (prevents SKIPPED blocker)."
+        run: |
+          echo "claude required check: noop SUCCESS (prevents SKIPPED blocker)."
 
       - name: Checkout repository
-        if: |
-          github.event_name != 'pull_request' && (
-            (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-            (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-            (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-            (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-          )
+        if: github.event_name != 'pull_request' && env.HAS_CLAUDE_CODE_OAUTH_TOKEN == 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
+      - name: Skip Claude Code when token is missing
+        if: github.event_name != 'pull_request' && env.HAS_CLAUDE_CODE_OAUTH_TOKEN != 'true'
+        run: |
+          echo "CLAUDE_CODE_OAUTH_TOKEN missing; skipping Claude Code."
+
       - name: Run Claude Code
         id: claude
-        if: |
-          github.event_name != 'pull_request' && (
-            (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-            (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-            (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-            (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-          )
+        if: github.event_name != 'pull_request' && env.HAS_CLAUDE_CODE_OAUTH_TOKEN == 'true'
+        continue-on-error: true
         uses: anthropics/claude-code-action@7145c3e0510bcdbdd29f67cc4a8c1958f1acfa2f # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Root Cause
GitHub did not start any jobs for the workflow and marked the run as a workflow-file failure.

```text
X main .github/workflows/claude.yml jannekbuengener/Claire_de_Binare#3 · 22620644288
Triggered via push about 1 hour ago

X This run likely failed because of a workflow file issue.

For more information, see: https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/22620644288
```

Additional CLI evidence:

```text
failed to get run log: log not found
jobs=[]
workflowName=.github/workflows/claude.yml
```

## What Changed
- added job-level gating so the workflow only runs for PR required-check no-op or explicit `@claude` invocations
- gated Claude execution on token presence and added a graceful skip message when the secret is missing
- made the Claude action step non-blocking with `continue-on-error: true`
- converted the inline no-op `run:` string to a block scalar so the workflow parses cleanly for strict YAML tooling

## Verification
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/claude.yml').read_text(encoding='utf-8')); print('YAML_OK')"`
- `git diff --check -- .github/workflows/claude.yml`

## Summary by Sourcery

Tighten the Claude GitHub Actions workflow to only run when relevant and to fail gracefully instead of producing red runs when misconfigured or missing secrets.

CI:
- Gate the Claude job so it only runs for pull requests or when explicitly invoked with '@claude' on supported GitHub events.
- Introduce an environment-based check for the CLAUDE_CODE_OAUTH_TOKEN secret and skip Claude execution with a clear message when the token is absent.
- Make the Claude action step non-blocking with continue-on-error and adjust the no-op step to be YAML-tooling friendly.