### PR TITLE
docs: add indices

### DIFF
--- a/docs/ci/index.md
+++ b/docs/ci/index.md
@@ -1,0 +1,46 @@
+# CI Index
+
+Kurzer Einstieg fuer Workflows, Trigger, Failure Modes und den merge-relevanten
+CI-Contract.
+
+## Canonical PR Gate
+
+- Workflow: [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
+- Merge-relevante Check-Namen auf PRs:
+  - `ci (Unit/Integration + Lint gesammelt)`
+  - `policy-gate`
+- Canon-Runbook: [docs/runbooks/merge_policy_ci_gate.md](../runbooks/merge_policy_ci_gate.md)
+
+Wichtig: `ci.yml` ist der PR-Gate-Workflow. Die groessere Push-/Dispatch-Pipeline
+[`ci.yaml`](../../.github/workflows/ci.yaml) ist nicht merge-relevant, solange der
+Contract nicht explizit geaendert wird.
+
+## Workflow-Familien
+
+| Bereich | Primaere Dateien | Trigger | Einstieg |
+|-------|-------|-------|-------|
+| PR Gate | [ci.yml](../../.github/workflows/ci.yml), [policy-gate.yml](../../.github/workflows/policy-gate.yml) | `pull_request`, `push` | [merge_policy_ci_gate.md](../runbooks/merge_policy_ci_gate.md) |
+| Main / Dispatch Pipeline | [ci.yaml](../../.github/workflows/ci.yaml) | `push`, `workflow_dispatch` | [merge_policy_ci_gate.md](../runbooks/merge_policy_ci_gate.md) |
+| Board / Milestone Automation | [add_to_project.yml](../../.github/workflows/add_to_project.yml), [project_status_sync.yml](../../.github/workflows/project_status_sync.yml), [auto-milestone.yml](../../.github/workflows/auto-milestone.yml) | `issues`, `pull_request`, `repository_dispatch` | [project_board_automation.md](../runbooks/project_board_automation.md) |
+| Board-as-Code | [control_board_upsert.yml](../../.github/workflows/control_board_upsert.yml), [control_board_auto_routing.yml](../../.github/workflows/control_board_auto_routing.yml) | `workflow_dispatch`, `issues`, `pull_request`, `schedule` | [control_board_board_as_code.md](../runbooks/control_board_board_as_code.md) |
+| Soak / Heavy Evidence | [shadow-soak-evidence.yml](../../.github/workflows/shadow-soak-evidence.yml) | `schedule`, `workflow_dispatch` | [72H_SOAK_TEST_RUNBOOK.md](../operations/72H_SOAK_TEST_RUNBOOK.md) |
+| Audit / Exception Semantics | [required-checks-enforcer.yml](../../.github/workflows/required-checks-enforcer.yml) | `workflow_dispatch` | [README.md](README.md), [ACTION_REQUIRED_RUNBOOK.md](ACTION_REQUIRED_RUNBOOK.md) |
+
+## workflow_run Kanten
+
+- `Auto Milestone PR Intent` -> `Auto Milestone PR Apply`
+- `Weekly Project Digest` -> `Weekly Digest Failure Alert`
+
+Die aktuelle Dependency-Map und die Rename-Regel stehen in
+[docs/ci/README.md](README.md).
+
+## Haeufige Failure Modes
+
+- Required Check rot oder Branch Protection blockiert:
+  - [docs/runbooks/merge_policy_ci_gate.md](../runbooks/merge_policy_ci_gate.md)
+- Project-v2 / Token / Scope Fehler:
+  - [docs/runbooks/project_board_automation.md](../runbooks/project_board_automation.md)
+- `workflow_run`-Rename-Drift:
+  - [docs/ci/README.md](README.md)
+- Gruen mit Ausnahmepfad statt echtem E2E-Pass:
+  - [docs/ci/README.md](README.md)

--- a/docs/db/index.md
+++ b/docs/db/index.md
@@ -1,0 +1,56 @@
+# DB Index
+
+Kurzer Einstieg fuer Schema, Migrations, Privileges, Fixtures und Validierung.
+Postgres ist der Canon fuer Runtime-Daten; SurrealDB ist eine optionale Mirror-Schicht.
+
+## Postgres Canon
+
+- Schema:
+  - [`infrastructure/database/schema.sql`](../../infrastructure/database/schema.sql)
+- Migrations:
+  - [`infrastructure/database/migrations/`](../../infrastructure/database/migrations/)
+- Least-Privilege / Rollen / Verifikation:
+  - [docs/runbooks/postgres_least_privilege_rls.md](../runbooks/postgres_least_privilege_rls.md)
+  - [`infrastructure/database/roles_and_grants.sql`](../../infrastructure/database/roles_and_grants.sql)
+  - [`infrastructure/database/enforce_least_privilege.sql`](../../infrastructure/database/enforce_least_privilege.sql)
+  - [`infrastructure/database/rollback_least_privilege.sql`](../../infrastructure/database/rollback_least_privilege.sql)
+  - [`infrastructure/database/verify_privileges.sql`](../../infrastructure/database/verify_privileges.sql)
+
+## Fixtures und Seed-Daten
+
+- Einstieg:
+  - [`tests/fixtures/README.md`](../../tests/fixtures/README.md)
+- SQL:
+  - [`tests/fixtures/sql/00_reset.sql`](../../tests/fixtures/sql/00_reset.sql)
+  - [`tests/fixtures/sql/01_seed_data.sql`](../../tests/fixtures/sql/01_seed_data.sql)
+- Python-Fixtures:
+  - [`tests/fixtures/db_fixtures.py`](../../tests/fixtures/db_fixtures.py)
+
+## Validierung und Audits
+
+- Pipeline-DB-Validierung:
+  - [`tests/integration/validation/test_pipeline_db.py`](../../tests/integration/validation/test_pipeline_db.py)
+- Schema-/Contract-Validierung:
+  - [`tests/integration/test_lr005_schema_compliance.py`](../../tests/integration/test_lr005_schema_compliance.py)
+  - [`tests/contract/test_event_schemas.py`](../../tests/contract/test_event_schemas.py)
+- Redis/Postgres-Integration:
+  - [`tests/integration/verlosung/test_redis_postgres_integration.py`](../../tests/integration/verlosung/test_redis_postgres_integration.py)
+- Least-Privilege-Audit:
+  - [`scripts/audit/postgres_privilege_dump.sql`](../../scripts/audit/postgres_privilege_dump.sql)
+  - [`scripts/audit/postgres_least_privilege_report.py`](../../scripts/audit/postgres_least_privilege_report.py)
+  - [`tests/unit/audit/test_postgres_least_privilege_report.py`](../../tests/unit/audit/test_postgres_least_privilege_report.py)
+
+## SurrealDB Mirror
+
+- Mirror-Ueberblick:
+  - [`infrastructure/surrealdb/README.md`](../../infrastructure/surrealdb/README.md)
+- Mirror-Config:
+  - [`infrastructure/config/surrealdb/feature-flags.yaml`](../../infrastructure/config/surrealdb/feature-flags.yaml)
+  - [`infrastructure/config/surrealdb/ownership.yaml`](../../infrastructure/config/surrealdb/ownership.yaml)
+  - [`infrastructure/config/surrealdb/mirror-strategy.yaml`](../../infrastructure/config/surrealdb/mirror-strategy.yaml)
+  - [`infrastructure/config/surrealdb/ledger-mapping.yaml`](../../infrastructure/config/surrealdb/ledger-mapping.yaml)
+- Operative Docs:
+  - [docs/runbooks/surrealdb_append_only_enforcement.md](../runbooks/surrealdb_append_only_enforcement.md)
+  - [docs/surrealdb/rollback-cutover-plan.md](../surrealdb/rollback-cutover-plan.md)
+  - [docs/surrealdb/dual-write-mirror-strategy.md](../surrealdb/dual-write-mirror-strategy.md)
+  - [docs/surrealdb/data-ownership-matrix.md](../surrealdb/data-ownership-matrix.md)

--- a/docs/env/index.md
+++ b/docs/env/index.md
@@ -1,0 +1,47 @@
+# Env Index
+
+Kurzer operativer Index fuer Toggles, Secrets, Defaults und ihre primaeren Consumer.
+Nicht exhaustiv; diese Seite zeigt die Canon-Pointer.
+
+## Betriebsrelevante Schalter
+
+| Variable / Config | Default | Primaere Consumer | Canon-Pointer |
+|-------|-------|-------|-------|
+| `TRADING_MODE` | `paper` | Trading-Mode-Auswahl, Execution-Logging | [`core/config/trading_mode.py`](../../core/config/trading_mode.py) |
+| `LIVE_TRADING_CONFIRMED` | unset | Human gate fuer `TRADING_MODE=live` | [`core/config/trading_mode.py`](../../core/config/trading_mode.py) |
+| `CDB_CONTROL_BOARD_AUTOMATION_ENABLED` | `false` | Control-Board-Routing und Upsert | [docs/runbooks/control_board_board_as_code.md](../runbooks/control_board_board_as_code.md) |
+| `POSTGRES_SSLMODE` | `prefer` | Postgres-DSN / SSL-Verbindung | [`core/utils/postgres_client.py`](../../core/utils/postgres_client.py), [`infrastructure/tls/TLS_SETUP.md`](../../infrastructure/tls/TLS_SETUP.md) |
+| `SECRETS_PATH` | lokal: `~/Documents/.secrets/.cdb`, CI: `${{ github.workspace }}/.ci-secrets` | Compose, Bootstrap, E2E/Soak | [`infrastructure/scripts/stack_up.ps1`](../../infrastructure/scripts/stack_up.ps1), [`infrastructure/scripts/bootstrap_local.sh`](../../infrastructure/scripts/bootstrap_local.sh), [tests/fixtures/README.md](../../tests/fixtures/README.md) |
+| `CDB_EXTERNAL_TESTS` | off | Opt-in fuer externe Integrations-Tests | [`tests/integration/test_mexc_testnet.py`](../../tests/integration/test_mexc_testnet.py) |
+| `surrealdb_enabled` / `governance_source` | `false` / `git` | SurrealDB-Mirror und Governance-Read-Quelle | [`infrastructure/config/surrealdb/feature-flags.yaml`](../../infrastructure/config/surrealdb/feature-flags.yaml), [docs/surrealdb/rollback-cutover-plan.md](../surrealdb/rollback-cutover-plan.md) |
+
+## GitHub-Automation Secrets
+
+Diese Secrets steuern vor allem Board-, Milestone- und Weekly-Digest-Automation:
+
+- `ADD_TO_PROJECT_PAT`
+- `CDB_GH_APP_ID`
+- `CDB_GH_APP_PRIVATE_KEY`
+- `CDB_GH_APP_INSTALLATION_ID`
+- `CDB_PR_AUTOMATION_TOKEN`
+
+Canon-Pointer:
+
+- [docs/runbooks/project_board_automation.md](../runbooks/project_board_automation.md)
+- [docs/runbooks/control_board_board_as_code.md](../runbooks/control_board_board_as_code.md)
+
+## Lokale Secret Stores und Runner-Env
+
+- Lokale Secret-Verwaltung:
+  - [`infrastructure/scripts/manage_secrets.ps1`](../../infrastructure/scripts/manage_secrets.ps1)
+  - [`infrastructure/scripts/init-secrets.ps1`](../../infrastructure/scripts/init-secrets.ps1)
+  - [`infrastructure/scripts/check_env.ps1`](../../infrastructure/scripts/check_env.ps1)
+- Self-hosted Runner Env:
+  - [`infrastructure/actions-runner/.env.runner.example`](../../infrastructure/actions-runner/.env.runner.example)
+
+## Wenn du etwas nachschlagen willst
+
+- Defaults und Validierung fuer lokale Laufzeit: [`infrastructure/scripts/check_env.ps1`](../../infrastructure/scripts/check_env.ps1)
+- DB-Verbindungsvariablen und TLS: [`core/utils/postgres_client.py`](../../core/utils/postgres_client.py)
+- Fixture-DB-Zugang fuer Tests: [tests/fixtures/README.md](../../tests/fixtures/README.md)
+- Board-/Project-v2-Auth und Fallbacks: [docs/runbooks/project_board_automation.md](../runbooks/project_board_automation.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,38 @@
+# Start Here
+
+Kurzer Navigationsindex fuer das Working Repo. Diese Seite ist kein Canon fuer Inhalte,
+sondern ein Pointer auf die bestehenden Docs, Runbooks und Source Trees.
+
+## Nach Aufgabe
+
+| Wenn du ... | Geh hierhin | Warum |
+|-------|-------|-------|
+| Merge-Gates, Required Checks oder Actions-Fehler verstehen willst | [CI Index](ci/index.md) | Canon fuer PR-Gate, Trigger, Failure Modes und Workflow-Familien |
+| Toggles, Secrets, Defaults oder operative Env-Variablen suchst | [Env Index](env/index.md) | Einstieg fuer Schalter, Secret Stores und Consumer |
+| Schema, Migrations, Privileges, Fixtures oder DB-Validierung suchst | [DB Index](db/index.md) | Einstieg fuer Postgres-Canon und Surreal-Mirror |
+| den Echtgeld-Go/No-Go-Stand brauchst | [docs/live-readiness/README.md](live-readiness/README.md) | Single Source of Truth fuer Live-Readiness |
+| Board-, Milestone- oder Project-v2-Automation brauchst | [docs/runbooks/project_board_automation.md](runbooks/project_board_automation.md) | Operativer Leitfaden fuer Board-Automation |
+
+## Kern-Pointer
+
+- [docs/runbooks/merge_policy_ci_gate.md](runbooks/merge_policy_ci_gate.md)
+  - Branch protection, merge-relevante Check-Namen, PR-Gate Contract.
+- [docs/runbooks/project_board_automation.md](runbooks/project_board_automation.md)
+  - Milestones, Labels, Project-v2-Flow, Token-Pfade und Troubleshooting.
+- [docs/runbooks/control_board_board_as_code.md](runbooks/control_board_board_as_code.md)
+  - Toggle, Dry-Run/Apply und Guardrails fuer Board-as-Code.
+- [docs/operations/72H_SOAK_TEST_RUNBOOK.md](operations/72H_SOAK_TEST_RUNBOOK.md)
+  - Operativer Einstieg fuer Shadow/Soak Evidence.
+- [docs/governance/README.md](governance/README.md)
+  - Governance-Dokumente und Audit-Artefakte.
+
+## Wichtige Source Trees
+
+- [`.github/workflows/`](../.github/workflows/)
+  - Alle GitHub Actions Workflows.
+- [`infrastructure/compose/README.md`](../infrastructure/compose/README.md)
+  - Compose-Layer, Stack-Aufbau und Infra-Einstieg.
+- [`infrastructure/database/`](../infrastructure/database/)
+  - Postgres-Schema, Migrations und Privilege-Skripte.
+- [`tests/fixtures/README.md`](../tests/fixtures/README.md)
+  - Deterministische DB-Fixtures und Seed-Daten.


### PR DESCRIPTION
## Summary
Nur Docs. Keine Code- oder Workflow-Aenderung.

Diese PR fuegt vier knappe Navigationsseiten hinzu:
- `docs/index.md` als Start-here-Index
- `docs/ci/index.md` fuer Workflows, Trigger, Failure Modes und den canonical PR gate
- `docs/env/index.md` fuer Toggles, Secrets, Defaults und Consumer
- `docs/db/index.md` fuer Schema, Migrations, Privileges, Fixtures und Validation Tests

Die Seiten zeigen bewusst auf bestehende Canon-Docs, Runbooks und Source Trees. Sie fuehren keine neue Wahrheit ein.

## Verification
- `git diff --cached --check`
- Stichproben auf bestehende Pointer nach `.github/workflows/`, `infrastructure/database/`, `tests/fixtures/README.md`, `docs/runbooks/*`

Closes #1050
Closes #1051
Closes #1052
Closes #1053
