### PR TITLE
#1038: clear custom-service Trivy findings on slim trixie

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -22,8 +22,8 @@ permissions:
 env:
   TRIVY_VERSION: "0.58.0"
   TRIVY_SUMMARY_MAX: "5"
-  # CVE-2025-12818: non-OpenSSL, verbleibt bis Upstream-Fix verfügbar
-  TRIVY_ALLOWLIST_CVES: "CVE-2025-12818"
+  # Debian 13/trixie currently has no fixed package published for CVE-2026-0861.
+  TRIVY_ALLOWLIST_CVES: "CVE-2026-0861"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/services/allocation/Dockerfile
+++ b/services/allocation/Dockerfile
@@ -1,6 +1,6 @@
 # Allocation Service - Dockerfile
 
-FROM python:3.11-slim-bookworm@sha256:65a93d69fa75478d554f4ad27c85c1e69fa184956261b4301ebaf6dbb0a3543d
+FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
 WORKDIR /app
 

--- a/services/db_writer/Dockerfile
+++ b/services/db_writer/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile - DB Writer Service
 # Claire de Binare Trading Bot
 
-FROM python:3.11-slim-bookworm@sha256:65a93d69fa75478d554f4ad27c85c1e69fa184956261b4301ebaf6dbb0a3543d
+FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
 WORKDIR /app
 

--- a/services/execution/Dockerfile
+++ b/services/execution/Dockerfile
@@ -1,6 +1,6 @@
 # Execution Service - Gehärtetes Image
 # Claire de Binare Trading Bot
-FROM python:3.11-slim-bookworm@sha256:65a93d69fa75478d554f4ad27c85c1e69fa184956261b4301ebaf6dbb0a3543d AS build
+FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39 AS build
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
@@ -21,7 +21,7 @@ RUN python -m venv /venv \
     && /venv/bin/pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2 \
     && /venv/bin/pip install --no-cache-dir -r requirements.txt
 
-FROM python:3.11-slim-bookworm@sha256:65a93d69fa75478d554f4ad27c85c1e69fa184956261b4301ebaf6dbb0a3543d
+FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
@@ -33,6 +33,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         curl \
     && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 
 COPY --from=build /venv /venv
 ENV PATH="/venv/bin:$PATH"

--- a/services/market/Dockerfile
+++ b/services/market/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm@sha256:65a93d69fa75478d554f4ad27c85c1e69fa184956261b4301ebaf6dbb0a3543d
+FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
 WORKDIR /app
 

--- a/services/regime/Dockerfile
+++ b/services/regime/Dockerfile
@@ -1,6 +1,6 @@
 # Regime Service - Dockerfile
 
-FROM python:3.11-slim-bookworm@sha256:65a93d69fa75478d554f4ad27c85c1e69fa184956261b4301ebaf6dbb0a3543d
+FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
 WORKDIR /app
 

--- a/services/risk/Dockerfile
+++ b/services/risk/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm@sha256:65a93d69fa75478d554f4ad27c85c1e69fa184956261b4301ebaf6dbb0a3543d
+FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
 WORKDIR /app
 

--- a/services/signal/Dockerfile
+++ b/services/signal/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm@sha256:65a93d69fa75478d554f4ad27c85c1e69fa184956261b4301ebaf6dbb0a3543d
+FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
 WORKDIR /app
 

--- a/services/ws/Dockerfile
+++ b/services/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm@sha256:65a93d69fa75478d554f4ad27c85c1e69fa184956261b4301ebaf6dbb0a3543d
+FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary\n- refresh the shared custom-service Python base from slim-bookworm to slim-trixie across allocation/db_writer/execution/market/regime/risk/signal/ws\n- upgrade execution runtime setuptools/wheel so the final image no longer carries the old vendored Python findings\n- replace the stale CVE-2025-12818 phantom allowlist with a single targeted allowlist for CVE-2026-0861, which Trivy still reports on Debian 13/glibc without a published fixed package version\n\n## Why this is the smallest safe fix\n- the previous Bookworm digest was the common source of the eight red Trivy jobs on main\n- switching the shared base to the current slim-trixie digest removes the old zlib/sqlite/glibc/ldap cluster from local Trivy validation\n- the only remaining HIGH/CRITICAL finding in representative images is CVE-2026-0861 on libc6/libc-bin, with no FixedVersion in Trivy output today; that is allowlisted narrowly instead of turning the workflow report-only\n\n## Verification\n- built representative images locally: allocation, execution\n- scanned both with Trivy 0.58.0 from the workflow\n- both images reduced to the same single remaining finding: CVE-2026-0861 on libc6/libc-bin\n- YAML parse check passed for .github/workflows/security-scan.yml\n- manual GitHub Security Scan dispatch on this branch follows to validate all 8 custom-service jobs\n\nCloses #1038