### PR TITLE
#1079: apply recommended Grafana 11.4.7-ubuntu digest candidate

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -42,7 +42,7 @@ jobs:
           - redis:7.4.8-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065
           - postgres:15.17-alpine
           - prom/prometheus:v2.55.0
-          - grafana/grafana:11.4.8
+          - grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
       fail-fast: false
 
     steps:

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -73,7 +73,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:11.4.8
+    image: grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
     container_name: cdb_grafana
     restart: unless-stopped
     environment:

--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -107,7 +107,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:11.4.8
+    image: grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
     container_name: cdb_grafana
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary
- Implements the recommended candidate from #1079.
- Pins Grafana references to `grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800`.
- Contract preserved: runtime + scan matrix aligned.

## Scope
- `infrastructure/compose/base.yml`
- `infrastructure/compose/compose.red.yml`
- `.github/workflows/security-scan.yml`

## Comparison summary (from #1079 decision matrix)
- Previous candidate in repo (`11.4.8`): 49 total (`11C/38H`)
- Implemented candidate (`11.4.7-ubuntu`): 23 total (`3C/20H`)
- Risk trend: fewer app-near and base-layer findings in aggregate.

## Verification
- YAML parse passed for workflow + affected compose files.
- `docker compose -f infrastructure/compose/base.yml config --quiet` passed.
- `docker compose -f infrastructure/compose/compose.red.yml config --quiet` passed.