### PR TITLE
ci: rename required-checks-enforcer to audit-only sentinel

### DIFF
--- a/.github/workflows/required-checks-audit.yml
+++ b/.github/workflows/required-checks-audit.yml
@@ -1,13 +1,7 @@
-# .github/workflows/required-checks-enforcer.yml
-name: required-checks-enforcer (Sentinel)
+# .github/workflows/required-checks-audit.yml
+name: required-checks-audit (Sentinel)
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches: [main]
-  schedule:
-    - cron: "30 4 * * 0"
   workflow_dispatch:
 
 permissions:
@@ -16,56 +10,49 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: required-checks-enforcer-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: required-checks-audit-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  enforce:
-    name: required-checks-enforcer (Sentinel)
+  audit:
+    name: required-checks-audit (Sentinel)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
-      SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      SENTINEL_MODE: ${{ vars.SENTINEL_MODE || 'report' }}
+      SHA: ${{ github.sha }}
     steps:
       - name: Audit required check status
         shell: bash
         run: |
           set -u
 
-          mode="$(printf '%s' "${SENTINEL_MODE:-report}" | tr '[:upper:]' '[:lower:]')"
-          if [[ -z "$mode" ]]; then
-            mode="report"
-          fi
-          if [[ "$mode" != "report" && "$mode" != "enforce" ]]; then
-            echo "::warning::Unknown SENTINEL_MODE='${SENTINEL_MODE:-}'; falling back to report."
-            mode="report"
-          fi
-
           event_name="${GITHUB_EVENT_NAME}"
           deadline=$((SECONDS + 780)) # 13 min
           sleep_seconds=10
           summary_file="${GITHUB_STEP_SUMMARY:-}"
 
-          required_checks=("ci (Unit/Integration + Lint gesammelt)")
-          if [[ "$event_name" == "pull_request" ]]; then
-            required_checks=("policy-gate" "ci (Unit/Integration + Lint gesammelt)")
-          fi
+          required_checks=(
+            "policy-gate"
+            "ci (Unit/Integration + Lint gesammelt)"
+          )
 
-          echo "Sentinel mode: $mode"
+          echo "Sentinel mode: audit-only"
           echo "Event: $event_name"
           echo "SHA: $SHA"
+          echo "Scope: run on the PR head ref/SHA you want to audit."
           echo "Required checks: ${required_checks[*]}"
 
           if [[ -n "$summary_file" ]]; then
             {
               echo "## Sentinel Summary"
               echo
-              echo "- Mode: \`$mode\`"
+              echo "- Mode: \`audit-only\`"
               echo "- Event: \`$event_name\`"
               echo "- SHA: \`$SHA\`"
+              echo "- Scope: run on the PR head ref/SHA you want to audit."
+              echo "- Behavior: warnings + summary only; never blocks."
               echo
               echo "| Check | Final state | Detail |"
               echo "| --- | --- | --- |"
@@ -77,7 +64,6 @@ jobs:
           missing_count=0
           failed_count=0
           timeout_count=0
-          enforce_failure=0
 
           for required_check in "${required_checks[@]}"; do
             final_state=""
@@ -170,23 +156,14 @@ jobs:
               safe_detail="${final_detail//|/\\|}"
               echo "| \`$required_check\` | \`$final_state\` | $safe_detail |" >> "$summary_file"
             fi
-
-            if [[ "$mode" == "enforce" && "$final_state" =~ ^(MISSING|FAILED|TIMEOUT)$ ]]; then
-              enforce_failure=1
-            fi
           done
 
           if [[ -n "$summary_file" ]]; then
             {
               echo
               echo "- Totals: OK=$ok_count, PENDING=$pending_count, MISSING=$missing_count, FAILED=$failed_count, TIMEOUT=$timeout_count"
-              echo "- Mode behavior: \`report\` never blocks; \`enforce\` exits non-zero on MISSING / FAILED / TIMEOUT."
+              echo "- Mode behavior: \`audit-only\` always exits 0."
             } >> "$summary_file"
           fi
 
-          if [[ "$mode" == "enforce" && "$enforce_failure" -ne 0 ]]; then
-            echo "::error::Sentinel enforce-mode detected missing, failed, or timed-out required checks."
-            exit 1
-          fi
-
-          echo "Sentinel completed in $mode mode."
+          echo "Sentinel completed in audit-only mode."

--- a/docs/ci/index.md
+++ b/docs/ci/index.md
@@ -24,7 +24,7 @@ Contract nicht explizit geaendert wird.
 | Board / Milestone Automation | [add_to_project.yml](../../.github/workflows/add_to_project.yml), [project_status_sync.yml](../../.github/workflows/project_status_sync.yml), [auto-milestone.yml](../../.github/workflows/auto-milestone.yml) | `issues`, `pull_request`, `repository_dispatch` | [project_board_automation.md](../runbooks/project_board_automation.md) |
 | Board-as-Code | [control_board_upsert.yml](../../.github/workflows/control_board_upsert.yml), [control_board_auto_routing.yml](../../.github/workflows/control_board_auto_routing.yml) | `workflow_dispatch`, `issues`, `pull_request`, `schedule` | [control_board_board_as_code.md](../runbooks/control_board_board_as_code.md) |
 | Soak / Heavy Evidence | [shadow-soak-evidence.yml](../../.github/workflows/shadow-soak-evidence.yml) | `schedule`, `workflow_dispatch` | [72H_SOAK_TEST_RUNBOOK.md](../operations/72H_SOAK_TEST_RUNBOOK.md) |
-| Audit / Exception Semantics | [required-checks-enforcer.yml](../../.github/workflows/required-checks-enforcer.yml) | `workflow_dispatch` | [README.md](README.md), [ACTION_REQUIRED_RUNBOOK.md](ACTION_REQUIRED_RUNBOOK.md) |
+| Audit / Exception Semantics | [required-checks-audit.yml](../../.github/workflows/required-checks-audit.yml) | `workflow_dispatch` | [README.md](README.md), [ACTION_REQUIRED_RUNBOOK.md](ACTION_REQUIRED_RUNBOOK.md) |
 
 ## workflow_run Kanten
 

--- a/docs/live-readiness/LR-001-EVIDENCE-ADDENDUM.md
+++ b/docs/live-readiness/LR-001-EVIDENCE-ADDENDUM.md
@@ -174,7 +174,7 @@ The following controls still operate but are not merge-blocking:
 | Docs hub guard | `docs-hub-guard.yml` | push to main + weekly schedule | post-merge detection |
 | E2E Happy Path | `e2e-happy-path.yaml` | push to main + weekly schedule | post-merge detection |
 | Governance audit | `governance-audit.yml` | weekly schedule | reporting only |
-| Required checks enforcer | `required-checks-enforcer.yml` | manual | on-demand audit |
+| Required checks audit sentinel | `required-checks-audit.yml` | manual | on-demand audit |
 
 These controls detect issues after merge to main or on schedule. They do not prevent merging of PRs that would fail these checks.
 

--- a/docs/runbooks/merge_policy_ci_gate.md
+++ b/docs/runbooks/merge_policy_ci_gate.md
@@ -14,7 +14,7 @@ for the policy rationale.
 - Canonical PR gate workflow: `.github/workflows/ci.yml` (`name: ci`)
 - Canonical merge-relevant check names on PRs: `ci (Unit/Integration + Lint gesammelt)` and `policy-gate`
 - Main/dispatch CI pipeline: `.github/workflows/ci.yaml` (`name: CI/CD Pipeline`)
-- Sentinel source of truth: `.github/workflows/required-checks-enforcer.yml` checks `policy-gate` + `ci (Unit/Integration + Lint gesammelt)` on PR and `ci (Unit/Integration + Lint gesammelt)` on `push`/`schedule`/`workflow_dispatch`
+- Sentinel source of truth: `.github/workflows/required-checks-audit.yml` is an on-demand `workflow_dispatch` audit that checks `policy-gate` + `ci (Unit/Integration + Lint gesammelt)` for the ref/SHA you run it on (use the relevant PR head ref for merge-contract audits)
 - Governance decision: the PR gate wins, not the larger workflow. `ci.yaml` is not merge-relevant until explicitly consolidated into the PR contract.
 
 ## Canonical PR Gate Contract
@@ -36,7 +36,7 @@ stable identifiers.
 
 Any rename/split of canonical checks must ship in one migration change set that also updates:
 
-1. Sentinel mapping in `.github/workflows/required-checks-enforcer.yml` (#1065)
+1. Sentinel mapping in `.github/workflows/required-checks-audit.yml` (#1065)
 2. Branch protection required contexts on `main`
 3. `workflow_run` dependency map and downstream mappings in `docs/ci/README.md` (#1068 / #1071)
 

--- a/reports/CI_STABILIZATION_ROLLUP.md
+++ b/reports/CI_STABILIZATION_ROLLUP.md
@@ -12,7 +12,7 @@ Scope statement: `Docs/reports only — no workflows/settings/trading/docker cha
 | [#869](https://github.com/jannekbuengener/Claire_de_Binare/pull/869) | OPEN | `ci/action-required-runbook` | Added docs runbook `docs/ci/ACTION_REQUIRED_RUNBOOK.md` for deterministic unblock of `action_required` + `jobs=[]` bot/app runs. | https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/22192989773 ; https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/22192989851 | n/a (open) |
 | [#871](https://github.com/jannekbuengener/Claire_de_Binare/pull/871) | OPEN | `docs/log-actions-approval-mode1` | Added MODE 1 governance log entry with before/after evidence and explicit operational finding for 403 on `/actions/runs/{id}/approve` in non-fork context. | https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/22192989773 ; https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/22192989851 | n/a (open) |
 | [#872](https://github.com/jannekbuengener/Claire_de_Binare/pull/872) | OPEN | `reports/ci-triage-restore-green` | Added read-only triage snapshot report `reports/CI_TRIAGE_RESTORE_GREEN.md` as RedStack evidence baseline for restore-green context. | https://github.com/jannekbuengener/Claire_de_Binare/blob/b12ea984607693ed81faf5b88b11e6f10e6b541a/reports/CI_TRIAGE_RESTORE_GREEN.md | n/a (open) |
-| [#873](https://github.com/jannekbuengener/Claire_de_Binare/pull/873) | OPEN | `ci/sentinel-denoise` | Sentinel de-noise by removing recurring auto-runs and keeping manual dispatch path (`required-checks-enforcer` on-demand). | https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/22195859100 | n/a (open) |
+| [#873](https://github.com/jannekbuengener/Claire_de_Binare/pull/873) | OPEN | `ci/sentinel-denoise` | Sentinel de-noise by removing recurring auto-runs and keeping manual dispatch path (`required-checks-audit` on-demand). | https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/22195859100 | n/a (open) |
 
 ## Executive Summary
 
@@ -60,7 +60,7 @@ MODE 1 (Strict Approval) is intentionally kept; no auto-run loosening was introd
 
 - PR: https://github.com/jannekbuengener/Claire_de_Binare/pull/873
 - Branch: `ci/sentinel-denoise`
-- Change: `required-checks-enforcer` de-noised by decommissioning recurring auto-runs while preserving manual dispatch availability.
+- Change: `required-checks-audit` de-noised by decommissioning recurring auto-runs while preserving manual dispatch availability.
 - Evidence (manual green): https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/22195859100
 - Representative historical failing runs: https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/22075752655 ; https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/22075680307
 - Merge commit: n/a (OPEN at snapshot time)

--- a/reports/CI_TRIAGE_RESTORE_GREEN.md
+++ b/reports/CI_TRIAGE_RESTORE_GREEN.md
@@ -73,7 +73,7 @@ Last 20 conclusions:
 Current outlier matching the same PR symptom:
 - `22192989851` (`pull_request`, branch `copilot/sub-pr-865`) -> `action_required`, no jobs.
 
-### 2.4 Historical sentinel: `required-checks-enforcer (Sentinel)` (`.github/workflows/required-checks-enforcer.yml`)
+### 2.4 Historical sentinel: `required-checks-audit (Sentinel)` (`.github/workflows/required-checks-audit.yml`)
 
 Last 20 conclusions:
 - `failure: 20` (historical window, mostly 2026-02-16)
@@ -89,7 +89,7 @@ Representative failed run:
 | `ci` required workflow | `22192989773` | `conclusion=action_required`, `jobs=[]` | Permission/approval gate | PRs opened by `Copilot` branch can enter manual-approval state before jobs are scheduled; required context is not emitted until approval/run. |
 | `E2E Happy Path` | `22192989851` | `conclusion=action_required`, `jobs=[]` | Permission/approval gate | Same approval gating condition as above on the same PR branch; not a test/runtime flake. |
 | `CI/CD Pipeline / Container Scan (Trivy)` | `22191851100` | Trivy reports `CVE-2026-26007` for `cryptography 44.0.1`, then `Process completed with exit code 1` | Deterministic dependency/vuln gate | `.github/workflows/ci.yaml` sets Trivy `exit-code: "1"` (`trivy-scan`), so known HIGH findings produce repeatable hard failures on `main`. |
-| `required-checks-enforcer (Sentinel)` (historical) | `22075752655` | "run likely failed because of a workflow file issue" | Deterministic historical workflow issue | Older revisions in that period were unstable and fail-closed against broader check sets; current file is now report-only and aligned to the single required context. |
+| `required-checks-audit (Sentinel)` (historical) | `22075752655` | "run likely failed because of a workflow file issue" | Deterministic historical workflow issue | Older revisions in that period were unstable and fail-closed against broader check sets; current file is now report-only and aligned to the single required context. |
 
 Historical but now resolved (kept for completeness):
 - `Sync Repository Labels` had deterministic failures:
@@ -103,7 +103,7 @@ Historical but now resolved (kept for completeness):
 |---|---|---|---|
 | `CI/CD Pipeline` Trivy red-on-main | Convert the `trivy-scan` inside `ci.yaml` to reporting-only in this pipeline (while keeping security signal visible in summary), and keep dedicated `trivy.yml` as the security evidence workflow. | `.github/workflows/ci.yaml` | Removes repeated hard-fail from a known dependency CVE backlog without touching service/runtime deps or Docker. |
 | `action_required` on Copilot PRs | Treat as governance/permissions issue: require maintainer approval of queued runs before expecting required contexts. Optional runbook documentation to make this operationally deterministic. | Optional docs-only: `docs/**` (new runbook) | Root cause is workflow approval policy, not flaky test execution. |
-| Sentinel historical instability | Keep sentinel non-blocking/reporting semantics; optionally harden output messaging for `action_required`/missing context diagnostics. | Optional: `.github/workflows/required-checks-enforcer.yml` | Prevents false-red governance noise while preserving observability. |
+| Sentinel historical instability | Keep sentinel non-blocking/reporting semantics; optionally harden output messaging for `action_required`/missing context diagnostics. | Optional: `.github/workflows/required-checks-audit.yml` | Prevents false-red governance noise while preserving observability. |
 
 ## 5) Draft PR-sized fix plan (no execution yet)
 

--- a/reports/REQUIRED_CHECK_CONTEXTS_DRIFT_REPORT_main.md
+++ b/reports/REQUIRED_CHECK_CONTEXTS_DRIFT_REPORT_main.md
@@ -72,7 +72,7 @@ State: **NO DRIFT**
 - `noop`
 - `opencode`
 - `performance-check`
-- `required-checks-enforcer (Sentinel)`
+- `required-checks-audit (Sentinel)`
 - `review`
 - `shadow-soak-evidence`
 - `smart-insights`


### PR DESCRIPTION
## Summary
- renamed `.github/workflows/required-checks-enforcer.yml` to `.github/workflows/required-checks-audit.yml`
- switched sentinel trigger to `workflow_dispatch` only
- removed enforce semantics (`SENTINEL_MODE` + non-zero exit path), workflow is now audit-only
- updated docs/report references to the new workflow name and semantics

## Contract
- required contexts unchanged: `ci (Unit/Integration + Lint gesammelt)` and `policy-gate`

## Notes
- No changes to `ci.yml`, `policy-gate.yml`, branch protection, or repo settings.
- No `workflow_run` dependencies introduced.