### PR TITLE
board: restrict project_status_label_map to status labels + lifecycle

### DIFF
--- a/.github/workflows/project_status_label_map.yml
+++ b/.github/workflows/project_status_label_map.yml
@@ -5,6 +5,14 @@ on:
 
 jobs:
   sync-project-status-label-map:
+    if: >-
+      github.event.action == 'closed' ||
+      github.event.action == 'reopened' ||
+      (
+        (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+        github.event.label.name != '' &&
+        startsWith(github.event.label.name, 'status:')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -107,6 +115,19 @@ jobs:
           event_path="${GITHUB_EVENT_PATH}"
           repo="${GITHUB_REPOSITORY}"
           action="$(jq -r '.action // empty' "$event_path")"
+          label_name="$(jq -r '.label.name // empty' "$event_path")"
+
+          if [[ "$action" == "labeled" || "$action" == "unlabeled" ]]; then
+            if [[ "$label_name" != status:* ]]; then
+              echo "Ignoring non-status label event '$label_name' (action='$action')."
+              exit 0
+            fi
+          elif [[ "$action" == "closed" || "$action" == "reopened" ]]; then
+            :
+          else
+            echo "Ignoring unsupported issue action '$action'."
+            exit 0
+          fi
 
           graphql_call() {
             local payload="$1"
@@ -128,22 +149,14 @@ jobs:
             jq -e --arg name "$name" '.[] | select(. == $name)' >/dev/null 2>&1 <<<"$labels_json"
           }
 
-          case "$event_name" in
-            issues)
-              content_node_id="$(jq -r '.issue.node_id // empty' "$event_path")"
-              labels_json="$(jq -c '[.issue.labels[]?.name] | map(select(type == "string" and length > 0))' "$event_path")"
-              default_status="Backlog"
-              ;;
-            pull_request)
-              content_node_id="$(jq -r '.pull_request.node_id // empty' "$event_path")"
-              labels_json="$(jq -c '[.pull_request.labels[]?.name] | map(select(type == "string" and length > 0))' "$event_path")"
-              default_status="Review"
-              ;;
-            *)
-              echo "Unsupported event: $event_name"
-              exit 0
-              ;;
-          esac
+          if [[ "$event_name" != "issues" ]]; then
+            echo "Unsupported event: $event_name"
+            exit 0
+          fi
+
+          content_node_id="$(jq -r '.issue.node_id // empty' "$event_path")"
+          labels_json="$(jq -c '[.issue.labels[]?.name] | map(select(type == "string" and length > 0))' "$event_path")"
+          default_status="Backlog"
 
           if [[ -z "$content_node_id" ]]; then
             echo "No content node id in event payload; skipping."

--- a/docs/runbooks/project_board_automation.md
+++ b/docs/runbooks/project_board_automation.md
@@ -58,6 +58,7 @@ Kurzer Betriebsleitfaden für die Repo-Organisation über Milestones, Labels und
     - PRs -> `Review`
 - `.github/workflows/project_status_label_map.yml`
   - Setzt Project-Status anhand von `status:*` Labels (inkl. `closed -> Done`), idempotent.
+  - Reagiert nur auf `closed`/`reopened` sowie auf `labeled`/`unlabeled` mit Label-Prefix `status:`.
 - `.github/workflows/auto-milestone.yml`
   - Setzt bei neuen/reopened/labeled Issues deterministisch nach Precedence:
     - `labeled`-Events reagieren nur auf Labels mit Prefix `milestone:`


### PR DESCRIPTION
## Summary
- restrict job execution to `closed`/`reopened` and `status:*` label events only
- add defense-in-depth early-exit for non-status label events
- remove unused pull_request path from script

## Behavior
- non-status label changes no longer mutate Project status
- status labels + lifecycle remain the only inputs