### PR TITLE
docs: add live readiness audit status snapshot (2026-03-05)

### DIFF
--- a/docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md
+++ b/docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md
@@ -1,0 +1,128 @@
+# Live Readiness Audit Status - 2026-03-05
+
+Status date: 2026-03-05 (Europe/Berlin)  
+Scope: Echtgeld Go/No-Go readiness snapshot from existing live-readiness SSOT sources.
+
+## A) Executive Summary
+
+- Objective: a compact, audit-ready Go/No-Go snapshot for live trading readiness.
+- Scope basis: `ROADMAP.yaml`, `LR-001..LR-007-STATE.yaml`, `ISSUES.md`, and current GitHub LR issues.
+- Governance mode remains `governance-first`.
+- Current verdict: **NO-GO**.
+- Blocking phase in roadmap: `P0` (`blocking: true`).
+- `P0` has state files marked `DONE`, but related LR issues (`LR-001`, `LR-003`) are still open and require tracker reconciliation.
+- `P1` to `P5` still contain open operational tasks; no phase beyond P0 is complete.
+- `P5` canary is additionally gated by explicit human approval (`requires: explicit_human_approval`).
+- Guardrail reminder: **No real trades without human gate**.
+- Decision policy: evidence over assumptions; open blockers keep system in NO-GO.
+
+## B) Phase Status Table
+
+| Phase | Blocking? | LR-Tasks | Status | Evidence / Links |
+|---|---|---|---|---|
+| P0 Preconditions | `true` | `LR-001`, `LR-002`, `LR-003` | `PARTIAL` | State files show DONE: [LR-001-STATE](./LR-001-STATE.yaml), [LR-002-STATE](./LR-002-STATE.yaml), [LR-003-STATE](./LR-003-STATE.yaml); issue tracker still open for [LR-001 #776](https://github.com/jannekbuengener/Claire_de_Binare/issues/776) and [LR-003 #778](https://github.com/jannekbuengener/Claire_de_Binare/issues/778), [LR-002 #777](https://github.com/jannekbuengener/Claire_de_Binare/issues/777) closed |
+| P1 Deterministic Tests | `false` | `LR-010`, `LR-011`, `LR-012` | `OPEN` | [LR-010 #779](https://github.com/jannekbuengener/Claire_de_Binare/issues/779), [LR-011 #780](https://github.com/jannekbuengener/Claire_de_Binare/issues/780), [LR-012 #781](https://github.com/jannekbuengener/Claire_de_Binare/issues/781) |
+| P2 E2E + Replay | `false` | `LR-020`, `LR-021` | `PARTIAL` | [LR-020 #782](https://github.com/jannekbuengener/Claire_de_Binare/issues/782) open; [LR-021 #783](https://github.com/jannekbuengener/Claire_de_Binare/issues/783) closed with evidence slices present |
+| P3 Shadow Mode | `false` | `LR-030`, `LR-031` | `OPEN` | [LR-030 #784](https://github.com/jannekbuengener/Claire_de_Binare/issues/784), [LR-031 #785](https://github.com/jannekbuengener/Claire_de_Binare/issues/785) |
+| P4 Soak + Chaos | `false` | `LR-040`, `LR-041`, `LR-042` | `OPEN` | [LR-040 #786](https://github.com/jannekbuengener/Claire_de_Binare/issues/786), [LR-041 #787](https://github.com/jannekbuengener/Claire_de_Binare/issues/787), [LR-042 #788](https://github.com/jannekbuengener/Claire_de_Binare/issues/788) |
+| P5 Canary Echtgeld | `false` (`gated: true`) | `LR-050` | `OPEN` | [LR-050 #792](https://github.com/jannekbuengener/Claire_de_Binare/issues/792); roadmap requires explicit human approval |
+
+Phase notes (audit interpretation):
+
+- P0 is the only roadmap phase with explicit `blocking: true`; therefore any unresolved inconsistency in P0 keeps verdict at NO-GO.
+- P0 issue-state drift is treated as a governance control gap, not as a technical completion claim.
+- P1 remains foundational for deterministic behavior under invalid input and transition edges.
+- P2 is the first integrated runtime checkpoint and is not satisfied while LR-020 is open.
+- P3 and P4 are operational confidence layers and currently fully open.
+- P5 cannot start while P0-P4 are unresolved and explicit human approval is absent.
+- `LR-021` closure improves P2 readiness posture but does not convert phase status to DONE.
+
+## C) DONE Snapshot (LR-001..LR-007)
+
+| LR Task | Completion timestamp (UTC) | Evidence file | Evidence commit |
+|---|---|---|---|
+| `LR-001` | `2026-01-28T14:32:00Z` | [LR-001-EVIDENCE.md](./LR-001-EVIDENCE.md) | `928d33f` |
+| `LR-002` | `2026-01-30T10:15:00Z` | [LR-002-EVIDENCE.md](./LR-002-EVIDENCE.md) | `1ec79a1` |
+| `LR-003` | `2026-02-04T16:42:00Z` | [LR-003-EVIDENCE.md](./LR-003-EVIDENCE.md) | `928d33f` |
+| `LR-004` | `2026-02-06T11:20:49Z` | [LR-004-EVIDENCE.md](./LR-004-EVIDENCE.md) | `a1efea8` |
+| `LR-005` | `2026-02-06T19:08:37Z` | [LR-005-SPEC.md](./LR-005-SPEC.md) | `e727373` |
+| `LR-006` | `2026-02-07T09:10:00Z` | [LR-006-EVIDENCE.md](./LR-006-EVIDENCE.md) | `c07ffa2` |
+| `LR-007` | `2026-02-09T18:20:00Z` | [LR-007-STATUS.md](./LR-007-STATUS.md) | `bef8da1` |
+
+DONE consistency checks:
+
+- All listed evidence files are present in `docs/live-readiness/`.
+- All seven state files use `status: DONE`.
+- Evidence commits are present as explicit short SHAs in state files.
+- `LR-007` includes a completion reason code and explanatory note.
+- DONE snapshot quality is structurally acceptable for audit reference.
+- Tracker reconciliation is still required for DONE items with open LR issues.
+
+## D) OPEN / Next Tasks (prioritized)
+
+1. `LR-011` ([#780](https://github.com/jannekbuengener/Claire_de_Binare/issues/780)): execution state machine test coverage is required to prove deterministic order lifecycle transitions; DoD: full state transition matrix tested with pass/fail evidence.
+2. `LR-012` ([#781](https://github.com/jannekbuengener/Claire_de_Binare/issues/781)): malformed payload handling must fail closed; DoD: negative schema/payload tests pass and rejection paths are evidenced.
+3. `LR-020` ([#782](https://github.com/jannekbuengener/Claire_de_Binare/issues/782)): end-to-end paper trading is the first integrated runtime proof; DoD: complete pipeline run with reproducible logs and result summary.
+4. `LR-030` ([#784](https://github.com/jannekbuengener/Claire_de_Binare/issues/784)): shadow mode validates live-data behavior with zero execution; DoD: shadow run active with documented no-trade enforcement.
+5. `LR-031` ([#785](https://github.com/jannekbuengener/Claire_de_Binare/issues/785)): shadow metrics comparison is needed to evaluate model/control drift; DoD: baseline vs shadow metrics report with acceptance thresholds.
+6. `LR-040` ([#786](https://github.com/jannekbuengener/Claire_de_Binare/issues/786)): 72h soak validates stability under sustained load; DoD: uninterrupted soak report with incident log and KPI summary.
+7. `LR-041` ([#787](https://github.com/jannekbuengener/Claire_de_Binare/issues/787)): chaos test for Redis/Postgres failures validates recovery behavior; DoD: controlled failure drill with recovery timing evidence.
+8. `LR-042` ([#788](https://github.com/jannekbuengener/Claire_de_Binare/issues/788)): network latency/loss chaos validates resilience of decision/execution path; DoD: induced network fault report with bounded degradation.
+9. `LR-050` ([#792](https://github.com/jannekbuengener/Claire_de_Binare/issues/792)): canary checklist gates live capital exposure; DoD: checklist complete and explicitly approved by human gate.
+10. Tracker alignment task (P0): reconcile `LR-001`/`LR-003` issue state vs state-file DONE status; DoD: issue tracker and SSOT state files reflect one consistent completion state.
+
+Open LR issue map (quick reference):
+
+| LR Task | Issue | Why important | DoD (one sentence) |
+|---|---|---|---|
+| `LR-011` | [#780](https://github.com/jannekbuengener/Claire_de_Binare/issues/780) | Prevents nondeterministic execution transitions | State transition tests cover all allowed and forbidden paths |
+| `LR-012` | [#781](https://github.com/jannekbuengener/Claire_de_Binare/issues/781) | Ensures fail-closed behavior on bad inputs | Negative payload suite rejects malformed events with evidence |
+| `LR-020` | [#782](https://github.com/jannekbuengener/Claire_de_Binare/issues/782) | Validates full pipeline correctness | End-to-end paper trade flow is reproducible and documented |
+| `LR-030` | [#784](https://github.com/jannekbuengener/Claire_de_Binare/issues/784) | Verifies live-data no-trade operating mode | Shadow mode runs with explicit zero-execution proof |
+| `LR-031` | [#785](https://github.com/jannekbuengener/Claire_de_Binare/issues/785) | Quantifies drift between expected and shadow behavior | Metrics comparison report published with thresholds |
+| `LR-040` | [#786](https://github.com/jannekbuengener/Claire_de_Binare/issues/786) | Proves medium-term system stability | 72h soak finishes with KPI and incident summary |
+| `LR-041` | [#787](https://github.com/jannekbuengener/Claire_de_Binare/issues/787) | Tests datastore failure resilience | Redis/Postgres failure drill shows bounded recovery |
+| `LR-042` | [#788](https://github.com/jannekbuengener/Claire_de_Binare/issues/788) | Tests network fault resilience | Latency/loss drill demonstrates controlled degradation |
+| `LR-050` | [#792](https://github.com/jannekbuengener/Claire_de_Binare/issues/792) | Final gate before live capital exposure | Canary checklist approved under explicit human gate |
+
+## E) Risks / Known Gaps
+
+- P0 issue-state mismatch (`DONE` in state files vs open LR issues) weakens audit consistency and release confidence.
+- Deterministic test layer (P1) is incomplete; regressions can pass unnoticed without full state-machine and negative-path coverage.
+- Full-pipeline paper trading evidence (P2) is still open, so integrated runtime behavior is not yet proven end to end.
+- Shadow mode and shadow-metric comparison (P3) are open; there is no live-market dry-run confidence baseline.
+- Soak and chaos evidence (P4) is open; resilience under sustained load and fault conditions is not validated.
+- Canary checklist (P5) remains open; no staged live-capital rollout plan is approved.
+- Explicit human-gate requirement for real trades is active and must remain enforced until all gating conditions are met.
+- Any go-live claim before closing blocking inconsistencies and open runtime validation tasks would violate evidence-first policy.
+
+## F) Next Actions (next 7 days)
+
+1. Resolve P0 tracking drift: close or update [LR-001 #776](https://github.com/jannekbuengener/Claire_de_Binare/issues/776) and [LR-003 #778](https://github.com/jannekbuengener/Claire_de_Binare/issues/778) so issue tracker matches state files.
+2. Complete and evidence `LR-011` and `LR-012` test suites as highest-impact deterministic test blockers.
+3. Execute one full `LR-020` paper-trading E2E run and publish compact evidence (inputs, outputs, failure summary).
+4. Start `LR-030` shadow mode run and define comparison window for `LR-031`.
+5. Prepare and schedule `LR-040`/`LR-041`/`LR-042` soak-chaos execution plan with explicit pass/fail criteria.
+6. Keep canary `LR-050` in NO-GO state until all upstream readiness gates are evidenced and human approval is recorded.
+
+Audit constraints and assumptions:
+
+- This snapshot is documentation-only and does not execute validation pipelines.
+- Source of truth priority used here: roadmap and state files first, then issue tracker as operational signal.
+- Where state files and issue tracker diverge, verdict is conservative (NO-GO).
+- No claim is made about production safety beyond documented evidence coverage.
+- No policy changes are introduced in this document.
+- Human gate requirement remains mandatory and unchanged.
+
+## Sources
+
+- [README.md](./README.md)
+- [ROADMAP.yaml](./ROADMAP.yaml)
+- [ISSUES.md](./ISSUES.md)
+- [LR-001-STATE.yaml](./LR-001-STATE.yaml)
+- [LR-002-STATE.yaml](./LR-002-STATE.yaml)
+- [LR-003-STATE.yaml](./LR-003-STATE.yaml)
+- [LR-004-STATE.yaml](./LR-004-STATE.yaml)
+- [LR-005-STATE.yaml](./LR-005-STATE.yaml)
+- [LR-006-STATE.yaml](./LR-006-STATE.yaml)
+- [LR-007-STATE.yaml](./LR-007-STATE.yaml)

--- a/docs/live-readiness/README.md
+++ b/docs/live-readiness/README.md
@@ -8,3 +8,4 @@ Ziel:
 - Kein Echtgeld ohne Human Gate
 
 Siehe ROADMAP.yaml für die operative Abfolge.
+Latest audit status: [LR-AUDIT-STATUS-2026-03-05.md](./LR-AUDIT-STATUS-2026-03-05.md)


### PR DESCRIPTION
## Summary
- add audit status snapshot for live readiness (Go/No-Go)
- link from live-readiness README
## Sources
- ROADMAP.yaml + LR-STATE files + open LR issues