### PR TITLE
ops: document MCP/worktree hygiene to prevent drift

### DIFF
--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -30,3 +30,15 @@ Operational contract:
   reviewable without scanning all workflow files.
 - If a future audit finds a mismatch, the minimal fix is the exact string update in
   the downstream workflow only. No trigger refactor is required for this issue.
+
+## Quick Verify: Workflow Name Drift
+
+If you change any workflow `name:`, verify `workflow_run` bindings in the same PR.
+
+```bash
+rg -n "^name:" .github/workflows
+rg -n "workflow_run" .github/workflows
+rg -n "workflows:\\s*\\[" .github/workflows
+```
+
+Then confirm the documented map in this file still matches the repository state.

--- a/docs/ci/index.md
+++ b/docs/ci/index.md
@@ -42,5 +42,7 @@ Die aktuelle Dependency-Map und die Rename-Regel stehen in
   - [docs/runbooks/project_board_automation.md](../runbooks/project_board_automation.md)
 - `workflow_run`-Rename-Drift:
   - [docs/ci/README.md](README.md)
+- MCP/Worktree Usability Drift:
+  - [docs/runbooks/mcp_worktree_hygiene.md](../runbooks/mcp_worktree_hygiene.md)
 - Gruen mit Ausnahmepfad statt echtem E2E-Pass:
   - [docs/ci/README.md](README.md)

--- a/docs/runbooks/mcp_worktree_hygiene.md
+++ b/docs/runbooks/mcp_worktree_hygiene.md
@@ -1,0 +1,59 @@
+# Runbook: MCP Worktree Hygiene
+
+## Purpose
+
+Keep operator workflows predictable and reduce local MCP/repo drift before PR work.
+
+## Principle
+
+- Default mode is read-only until intent and target branch are clear.
+- Validate repository state first, then edit.
+- Do not treat local machine state as source of truth; `origin/main` is the baseline.
+
+## Common Drift Pitfalls
+
+- Local branch is behind `main`, but files are inspected as if current.
+- Worktree points to an older commit while another worktree was already merged.
+- Unrelated local edits leak into a task because work happens in a dirty tree.
+- Temporary local artifacts are created in tracked paths.
+
+## Safe Pre-PR Checklist
+
+Run these checks before preparing a PR:
+
+```bash
+git status -sb
+git fetch origin
+git log --oneline --decorate -n 5 origin/main
+```
+
+For content sanity checks, run explicit `rg` commands:
+
+```bash
+rg -n "workflow_run" .github/workflows
+rg -n "workflows:\\s*\\[" .github/workflows
+rg -n "required-checks-enforcer|required-checks-audit" docs .github/workflows
+```
+
+Interpretation:
+
+- If local `HEAD` is behind `origin/main`, rebase/refresh before changing files.
+- If `git status -sb` is not clean and edits are unrelated, switch to a clean worktree.
+- If old workflow names still appear, update references in the same change set.
+
+## Worktree Handling
+
+- Prefer one dedicated worktree per issue/PR branch.
+- Name worktrees by issue id to avoid accidental overlap.
+- Remove stale worktrees after merge.
+- Never rely on a local branch pointer as merge evidence; verify with GitHub PR state.
+
+## Local Artifacts
+
+- Local helper scripts and machine-specific outputs belong in `.local/` or outside repo.
+- For known local-only script policy, see [local_ops_artifacts.md](./local_ops_artifacts.md).
+
+## Scope Guard
+
+- This runbook is read/validate guidance only.
+- It does not introduce write automation, secret handling changes, or workflow behavior changes.


### PR DESCRIPTION
## Summary
- add MCP/worktree hygiene runbook (read-only operator checklist)
- add minimal drift verification guidance in CI docs
## Scope
- docs only