### PR TITLE
lr: harden execution service against invalid payloads (LR-012)

### DIFF
--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -9,6 +9,7 @@ import signal
 import sys
 import logging
 import logging.config
+import math
 import time
 from datetime import datetime
 from pathlib import Path
@@ -81,6 +82,7 @@ stats = {
     "orders_received": 0,
     "orders_filled": 0,
     "orders_rejected": 0,
+    "invalid_payloads": 0,
     "start_time": utcnow().isoformat(),
     "last_result": None,
 }
@@ -109,6 +111,70 @@ def get_stats_copy() -> dict:
     """Thread-safe stats read"""
     with _stats_lock:
         return stats.copy()
+
+
+def _mark_invalid_payload(reason: str, *, exc: Exception | None = None) -> None:
+    """Track malformed input payloads without side effects."""
+    increment_stat("invalid_payloads")
+    if exc is not None:
+        logger.warning("Invalid order payload skipped: %s (%s)", reason, exc)
+        return
+    logger.warning("Invalid order payload skipped: %s", reason)
+
+
+def _validate_optional_json_object_field(payload: dict, field_name: str) -> None:
+    """Validate optional JSON-string/object fields used by order contract."""
+    if field_name not in payload:
+        return
+
+    raw_value = payload.get(field_name)
+    if raw_value is None:
+        return
+
+    if isinstance(raw_value, dict):
+        return
+
+    if isinstance(raw_value, str):
+        parsed = json.loads(raw_value)
+        if not isinstance(parsed, dict):
+            raise ValueError(f"Field '{field_name}' must encode a JSON object")
+        return
+
+    raise ValueError(f"Field '{field_name}' must be dict or JSON object string")
+
+
+def _parse_order_payload(order_data: object) -> Order | None:
+    """Return validated Order or None for invalid payload input."""
+    if not isinstance(order_data, dict):
+        _mark_invalid_payload(f"payload_type={type(order_data).__name__}")
+        return None
+
+    try:
+        sanitized_payload = sanitize_payload(order_data)
+    except (TypeError, ValueError) as exc:
+        _mark_invalid_payload("sanitize_failed", exc=exc)
+        return None
+
+    event_type = sanitized_payload.get("type")
+    if event_type not in (None, "order"):
+        _mark_invalid_payload(f"unexpected_type={event_type}")
+        return None
+
+    try:
+        _validate_optional_json_object_field(sanitized_payload, "policy_snapshot")
+        order = Order.from_event(sanitized_payload)
+    except (ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+        _mark_invalid_payload("order_parse_failed", exc=exc)
+        return None
+
+    if not math.isfinite(order.quantity):
+        _mark_invalid_payload("quantity_not_finite")
+        return None
+    if order.quantity <= 0:
+        _mark_invalid_payload("quantity_non_positive")
+        return None
+
+    return order
 
 
 def _init_with_retry(
@@ -231,17 +297,13 @@ def _publish_result(result: ExecutionResult) -> None:
             db.save_trade(result)
 
 
-def process_order(order_data: dict):
-    """Process incoming order"""
+def process_order(order_data: object):
+    """Process incoming order."""
+    order = _parse_order_payload(order_data)
+    if order is None:
+        return None
+
     try:
-        if order_data.get("type") not in (None, "order"):
-            logger.warning(
-                "Ignoriere Event mit unerwartetem Typ: %s", order_data.get("type")
-            )
-            return None
-
-        order = Order.from_event(order_data)
-
         increment_stat("orders_received")  # Thread-safe
 
         # Safety gate: reject orders without Risk Service approval (refs #467)
@@ -452,12 +514,8 @@ def process_order(order_data: dict):
         _publish_result(result)
 
         return result
-    except (KeyError, ValueError) as err:
-        logger.error("Fehlerhafte Orderdaten: %s", err)
-        increment_stat("orders_rejected")  # Thread-safe
-        return None
-    except Exception as e:
-        logger.error(f"Error processing order: {e}")
+    except Exception as exc:
+        logger.error("Error processing order: %s", exc)
         increment_stat("orders_rejected")  # Thread-safe
         return None
 
@@ -472,17 +530,21 @@ def message_loop():
         try:
             message = pubsub.get_message(timeout=1.0)
 
-            if message and message["type"] == "message":
+            if message and message.get("type") == "message":
                 try:
-                    order_data = json.loads(message["data"])
+                    raw_data = message.get("data")
+                    if raw_data is None:
+                        _mark_invalid_payload("missing_message_data")
+                        continue
+                    order_data = json.loads(raw_data)
                     process_order(order_data)
-                except json.JSONDecodeError as e:
-                    logger.error(f"Invalid JSON in message: {e}")
-                except Exception as e:
-                    logger.error(f"Error handling message: {e}")
+                except json.JSONDecodeError as exc:
+                    _mark_invalid_payload("json_decode_failed", exc=exc)
+                except Exception as exc:
+                    logger.error("Error handling message: %s", exc)
 
-        except Exception as e:
-            logger.error(f"Error in message loop: {e}")
+        except Exception as exc:
+            logger.error("Error in message loop: %s", exc)
             time.sleep(1)
 
     logger.info("Message loop stopped")
@@ -604,6 +666,9 @@ if _FLASK_AVAILABLE:
             "# HELP execution_orders_rejected_total Anzahl abgelehnter Orders\n"
             "# TYPE execution_orders_rejected_total counter\n"
             f"execution_orders_rejected_total {current_stats['orders_rejected']}\n"
+            "# HELP execution_invalid_payloads_total Anzahl invalid/malformed Payloads\n"
+            "# TYPE execution_invalid_payloads_total counter\n"
+            f"execution_invalid_payloads_total {current_stats['invalid_payloads']}\n"
             "# HELP execution_uptime_seconds Service Laufzeit in Sekunden\n"
             "# TYPE execution_uptime_seconds gauge\n"
             f"execution_uptime_seconds {uptime_seconds}\n"

--- a/tests/unit/services/test_execution_negative_payloads.py
+++ b/tests/unit/services/test_execution_negative_payloads.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.execution import service
+
+
+@dataclass
+class _Harness:
+    executor: MagicMock
+    publish_result: MagicMock
+    db: MagicMock
+
+
+@pytest.fixture
+def execution_harness(monkeypatch: pytest.MonkeyPatch) -> _Harness:
+    original_stats = service.stats.copy()
+    service.stats.clear()
+    service.stats.update(
+        {
+            "orders_received": 0,
+            "orders_filled": 0,
+            "orders_rejected": 0,
+            "invalid_payloads": 0,
+            "start_time": original_stats["start_time"],
+            "last_result": None,
+        }
+    )
+
+    executor = MagicMock()
+    publish_result = MagicMock()
+    db = MagicMock()
+
+    monkeypatch.setattr(service, "executor", executor)
+    monkeypatch.setattr(service, "_publish_result", publish_result)
+    monkeypatch.setattr(service, "db", db)
+    monkeypatch.setattr(service, "bot_shutdown_active", False)
+    monkeypatch.setattr(service, "blocked_strategy_ids", set())
+    monkeypatch.setattr(service, "blocked_bot_ids", set())
+    monkeypatch.setenv("TRACE_CONTRACT_V1_ENABLED", "0")
+
+    yield _Harness(executor=executor, publish_result=publish_result, db=db)
+
+    service.stats.clear()
+    service.stats.update(original_stats)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"type": "order", "side": "BUY", "quantity": 1.0},  # missing symbol
+        {"type": "order", "symbol": "BTCUSDT", "quantity": 1.0},  # missing side
+        {"type": "order", "symbol": "BTCUSDT", "side": "BUY"},  # missing quantity
+        {"type": "order", "symbol": "BTCUSDT", "side": "HOLD", "quantity": 1.0},
+        {"type": "order", "symbol": "BTCUSDT", "side": "BUY", "quantity": "abc"},
+        {"type": "order", "symbol": "BTCUSDT", "side": "BUY", "quantity": -1.0},
+        {"type": "order", "symbol": "BTCUSDT", "side": "BUY", "quantity": float("nan")},
+        {"type": "order", "symbol": "BTCUSDT", "side": "BUY", "quantity": float("inf")},
+        {"type": "signal", "symbol": "BTCUSDT", "side": "BUY", "quantity": 1.0},
+        {
+            "type": "order",
+            "symbol": "BTCUSDT",
+            "side": "BUY",
+            "quantity": 1.0,
+            "policy_snapshot": "{not-json",
+        },
+        None,
+        "not-a-dict",
+        ["order", "BTCUSDT", "BUY", 1.0],
+    ],
+)
+def test_invalid_payloads_are_deterministic_noops(
+    payload: object,
+    execution_harness: _Harness,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    before = service.get_stats_copy()
+    caplog.set_level(logging.WARNING)
+
+    result = service.process_order(payload)
+
+    after = service.get_stats_copy()
+    assert result is None
+    assert after["invalid_payloads"] == before["invalid_payloads"] + 1
+    assert after["orders_received"] == before["orders_received"]
+    execution_harness.executor.execute_order.assert_not_called()
+    execution_harness.publish_result.assert_not_called()
+    assert execution_harness.db.mock_calls == []
+    assert "Invalid order payload skipped" in caplog.text
+
+
+def test_message_loop_invalid_json_is_skipped_without_processing(
+    monkeypatch: pytest.MonkeyPatch,
+    execution_harness: _Harness,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class _OneBadMessagePubSub:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def get_message(self, timeout: float = 1.0):  # noqa: ARG002
+            self.calls += 1
+            if self.calls == 1:
+                return {"type": "message", "data": "{bad json"}
+            monkeypatch.setattr(service, "running", False)
+            return None
+
+    before = service.get_stats_copy()
+    process_order_mock = MagicMock()
+    caplog.set_level(logging.WARNING)
+
+    monkeypatch.setattr(service, "pubsub", _OneBadMessagePubSub())
+    monkeypatch.setattr(service, "running", True)
+    monkeypatch.setattr(service, "process_order", process_order_mock)
+
+    service.message_loop()
+
+    after = service.get_stats_copy()
+    assert after["invalid_payloads"] == before["invalid_payloads"] + 1
+    process_order_mock.assert_not_called()
+    execution_harness.executor.execute_order.assert_not_called()
+    execution_harness.publish_result.assert_not_called()
+    assert "json_decode_failed" in caplog.text


### PR DESCRIPTION
## Summary
- guard execution consumer against malformed/invalid order payloads (no crash)
- add unit tests covering negative payload cases
## Safety
- invalid payloads become deterministic no-ops (log + counter), no trading side-effects