### PR TITLE
ci(shadow): extend full soak window to 30 minutes

### DIFF
--- a/.github/workflows/shadow-soak-evidence.yml
+++ b/.github/workflows/shadow-soak-evidence.yml
@@ -18,7 +18,7 @@ on:
 env:
   SECRETS_PATH: ${{ github.workspace }}/.ci-secrets
   STACK_NAME: shadow-soak-${{ github.run_id }}
-  FULL_SOAK_MINUTES: 20
+  FULL_SOAK_MINUTES: 30
   LEAN_SOAK_MINUTES: 5
 
 concurrency:


### PR DESCRIPTION
## Summary

- Increase `FULL_SOAK_MINUTES` from 20 to 30

## Test plan

- [ ] CI passes
- [ ] P5-Shadow-Dry-Run with `mode=full` produces longer effective test window after regime warmup

🤖 Generated with [Claude Code](https://claude.com/claude-code)