### PR TITLE
fix(chaos): align LR-042 shadow-blocked metric name

### DIFF
--- a/scripts/drills/lr042_network_latency_packet_loss_runner.py
+++ b/scripts/drills/lr042_network_latency_packet_loss_runner.py
@@ -338,8 +338,8 @@ def _collect_snapshot() -> dict[str, Any]:
             "execution_orders_rejected_total": _metric_or_zero(
                 execution_metrics, "execution_orders_rejected_total"
             ),
-            "execution_orders_shadow_blocked_total": _metric_or_zero(
-                execution_metrics, "execution_orders_shadow_blocked_total"
+            "execution_shadow_blocked_total": _metric_or_zero(
+                execution_metrics, "execution_shadow_blocked_total"
             ),
             "signals_received_total": _metric_or_zero(
                 risk_metrics, "signals_received_total"


### PR DESCRIPTION
## Summary

- LR-042 network-latency/packet-loss drill runner used the outdated metric name `execution_orders_shadow_blocked_total` in the snapshot collector
- Corrected to `execution_shadow_blocked_total` to align with the current metric schema
- One-file key swap, no functional scope change

## Scope

- **Changed:** `scripts/drills/lr042_network_latency_packet_loss_runner.py` (2 lines)
- **No** LR-041 changes included
- **No** additional tests — intentional, as this is an isolated one-file key rename
- **No** functional scope extension

## Verification

- `rg execution_orders_shadow_blocked_total scripts/drills/lr042_*` returns no matches
- `python -m py_compile scripts/drills/lr042_network_latency_packet_loss_runner.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)