### PR TITLE
fix(soak): preserve LR-040 monitor artifacts across 72h runs

### DIFF
--- a/docs/operations/72H_SOAK_TEST_RUNBOOK.md
+++ b/docs/operations/72H_SOAK_TEST_RUNBOOK.md
@@ -100,14 +100,22 @@ docker compose -f compose.blue.yml down
 
 **Artifacts to preserve** (in `artifacts/soak_test_YYYYMMDD_HHMMSS/`):
 - `hourly_checks.log` — full timeline of hourly checks
-- `resources_snapshot_*.txt` — 6h resource snapshots
-- `db_growth_*.txt` — 12h database growth
+- `resources_snapshot_YYYYMMDD_HH*.txt` — 6h resource snapshots (date-prefixed, no overwrites)
+- `db_growth_YYYYMMDD_HH*.txt` — 12h database growth (date-prefixed, no overwrites)
+- `lr040_soak_gate_eval.json` — machine-readable verdict (generated post-run)
 - `restart_alerts.log` — empty if test passed
 - `soak_test_FAILED.txt` — absent if test passed
 
+**Evaluate (LR-040 gate):**
+
+```bash
+python infrastructure/scripts/lr040_soak_gate_eval.py artifacts/soak_test_YYYYMMDD_HHMMSS/
+cat artifacts/soak_test_YYYYMMDD_HHMMSS/lr040_soak_gate_eval.json
+```
+
 **Go / No-Go decision:**
-- PASS: no `soak_test_FAILED.txt`, no restart entries, 72h elapsed
-- FAIL: any abort trigger hit — document root cause before re-attempting
+- PASS: `lr040_soak_gate_eval.json` verdict is `PASS`
+- FAIL: any check failed — see `failures` array for root cause before re-attempting
 
 ## Troubleshooting: Common Issues
 

--- a/infrastructure/scripts/soak_monitor.sh
+++ b/infrastructure/scripts/soak_monitor.sh
@@ -122,7 +122,7 @@ fi
 if [ "$((HOUR % 6))" -eq 0 ]; then
   echo -e "\n${YELLOW}[CHECK 3/5]${NC} Resource Snapshot (6h interval)..."
 
-  SNAPSHOT_FILE="$ARTIFACT_PATH/resources_snapshot_${HOUR}h.txt"
+  SNAPSHOT_FILE="$ARTIFACT_PATH/resources_snapshot_$(date -u +%Y%m%d_%H)h.txt"
 
   echo "Timestamp: $TIMESTAMP" > "$SNAPSHOT_FILE"
   echo "=========================================" >> "$SNAPSHOT_FILE"
@@ -140,7 +140,7 @@ fi
 if [ "$((HOUR % 12))" -eq 0 ]; then
   echo -e "\n${YELLOW}[CHECK 4/5]${NC} Database Growth Check (12h interval)..."
 
-  DB_FILE="$ARTIFACT_PATH/db_growth_${HOUR}h.txt"
+  DB_FILE="$ARTIFACT_PATH/db_growth_$(date -u +%Y%m%d_%H)h.txt"
 
   # Check if postgres is running
   if docker ps --filter "name=cdb_postgres" --filter "status=running" | grep -q "cdb_postgres"; then


### PR DESCRIPTION
## Summary

- Fix data-loss bug in `soak_monitor.sh`: snapshot and DB-growth filenames used only the hour-of-day (`resources_snapshot_06h.txt`), causing day-2 and day-3 files to silently overwrite day-1 data. Now uses date-prefixed names (`resources_snapshot_20260310_06h.txt`).
- Add missing `lr040_soak_gate_eval.py` post-run evaluation step to the 72h soak runbook.
- Update artifact path documentation to match the new naming scheme.

### What this PR does NOT do

- No PASS claim — no 72h soak run has been performed
- No generated artifacts committed
- No changes to `lr040_soak_gate_eval.py` (it already globs `resources_snapshot_*.txt`)

## Test plan

- [x] `lr040_soak_gate_eval.py` unit tests still pass (12/12) — evaluator uses glob, compatible with both naming formats
- [ ] CI passes (`ci` + `policy-gate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)