### PR TITLE
test: canonicalize local E2E entrypoint and workflow for #149

### DIFF
--- a/infrastructure/scripts/run_e2e.ps1
+++ b/infrastructure/scripts/run_e2e.ps1
@@ -1,23 +1,28 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    E2E Test Runner - Deterministic Test Path (Issue #354)
+    E2E Test Runner - Canonical local E2E entry point (Issue #354, #149)
 
 .DESCRIPTION
     Automated E2E test runner:
-    1. Starts Claire de Binare stack (stack_up.ps1)
-    2. Waits for services to be healthy
-    3. Runs E2E smoke tests
-    4. Tears down stack (optional)
+    1. Resolves repo root and loads secrets (CI/Test-Compose-Pfad)
+    2. Starts Claire de Binare stack via docker compose (base + dev + logging)
+    3. Waits for services to be healthy
+    4. Runs E2E smoke tests
+    5. Tears down stack (optional)
+
+    Secrets are loaded from the single source of truth (~\Documents\.secrets\.cdb\).
+    Optional .env.runtime auto-load from tools\secrets\.env.runtime (disable via CDB_IGNORE_RUNTIME_ENV=1).
+    Runtime-/Operator-Pfad (BLUE+RED) is NOT used here.
 
 .PARAMETER SkipStackStart
-    Skip stack_up.ps1 (assume stack already running)
+    Skip stack start (assume stack already running)
 
 .PARAMETER SkipTeardown
     Keep stack running after tests (for debugging)
 
 .PARAMETER TestPath
-    Path to specific E2E test (default: all E2E tests)
+    Path to specific E2E test (default: tests/e2e/test_smoke_pipeline.py)
 
 .EXAMPLE
     .\infrastructure\scripts\run_e2e.ps1
@@ -26,7 +31,7 @@
     .\infrastructure\scripts\run_e2e.ps1 -SkipStackStart -SkipTeardown
 
 .NOTES
-    Issue: #354
+    Issue: #354, #149
     Author: Team B (Engineering)
 #>
 
@@ -39,15 +44,105 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# --- Repo Root ---
+$scriptDir = $PSScriptRoot
+if (-not $scriptDir) {
+    $definition = $MyInvocation.MyCommand.Definition
+    $scriptDir = if ($definition) { Split-Path -Parent $definition } else { Get-Location }
+}
+$repoRoot = Split-Path -Parent (Split-Path -Parent $scriptDir)
+
+Push-Location -LiteralPath $repoRoot
+try {
+
+# --- STEP 1: SECRETS_PATH setzen (Single Source of Truth) ---
+$SECRETS_PATH = Join-Path $env:USERPROFILE 'Documents\.secrets\.cdb'
+[Environment]::SetEnvironmentVariable('SECRETS_PATH', $SECRETS_PATH, 'Process')
+
+if (-not (Test-Path $SECRETS_PATH)) {
+    Write-Error @"
+
+FATAL: Secrets directory not found!
+Expected: $SECRETS_PATH
+
+Run infrastructure\scripts\init-secrets.ps1 or create manually:
+  mkdir -p ~/.secrets/.cdb
+  openssl rand -base64 24 > ~/.secrets/.cdb/REDIS_PASSWORD
+  openssl rand -base64 24 > ~/.secrets/.cdb/POSTGRES_PASSWORD
+  openssl rand -base64 24 > ~/.secrets/.cdb/GRAFANA_PASSWORD
+
+"@
+    exit 1
+}
+
+# --- STEP 2: Optional .env.runtime auto-load (same order as stack_up.ps1) ---
+if ($env:CDB_IGNORE_RUNTIME_ENV -ne '1') {
+    $runtimeEnvPath = Join-Path $repoRoot 'tools\secrets\.env.runtime'
+    if (Test-Path $runtimeEnvPath) {
+        Write-Host "Loading .env.runtime from $runtimeEnvPath" -ForegroundColor Cyan
+        $loaded = 0
+        Get-Content $runtimeEnvPath | ForEach-Object {
+            $line = $_.Trim()
+            if ([string]::IsNullOrWhiteSpace($line) -or $line.StartsWith('#')) { return }
+            if ($line -match '^([^=]+)=(.*)$') {
+                $key = $matches[1].Trim()
+                $val = $matches[2]
+                [Environment]::SetEnvironmentVariable($key, $val, 'Process')
+                $loaded++
+            }
+        }
+        if ($loaded -gt 0) {
+            Write-Host "  Loaded $loaded runtime env vars" -ForegroundColor Green
+        }
+    }
+}
+
+# --- STEP 3: Required secrets pruefen und laden ---
+$requiredSecrets = @('REDIS_PASSWORD', 'POSTGRES_PASSWORD', 'GRAFANA_PASSWORD')
+$missing = @()
+
+foreach ($secret in $requiredSecrets) {
+    $secretFile = Join-Path $SECRETS_PATH $secret
+    if (-not (Test-Path $secretFile)) {
+        $missing += $secret
+    } else {
+        $value = (Get-Content $secretFile -Raw).Trim()
+        if ([string]::IsNullOrEmpty($value)) {
+            $missing += "$secret (empty)"
+        } else {
+            [Environment]::SetEnvironmentVariable($secret, $value, 'Process')
+        }
+    }
+}
+
+if ($missing.Count -gt 0) {
+    Write-Error "FATAL: Missing required secrets: $($missing -join ', ')"
+    exit 1
+}
+
+# --- STEP 4: Non-secret defaults (same as stack_up.ps1) ---
+[Environment]::SetEnvironmentVariable('POSTGRES_USER', 'claire_user', 'Process')
+[Environment]::SetEnvironmentVariable('STACK_NAME', 'cdb', 'Process')
+
+# --- CI/Test-Compose-Pfad (base + dev + logging) ---
+$ComposeFiles = @(
+    "infrastructure/compose/base.yml",
+    "infrastructure/compose/dev.yml",
+    "infrastructure/compose/logging.yml"
+)
+$ComposeArgs = ($ComposeFiles | ForEach-Object { "-f"; $_ })
+
 Write-Host "==================================" -ForegroundColor Cyan
-Write-Host "E2E Test Runner - Issue #354" -ForegroundColor Cyan
+Write-Host "E2E Test Runner - Issue #354, #149" -ForegroundColor Cyan
 Write-Host "==================================" -ForegroundColor Cyan
+Write-Host "  Secrets: $SECRETS_PATH" -ForegroundColor Gray
+Write-Host "  Compose: CI/Test (base + dev + logging)" -ForegroundColor Gray
 Write-Host ""
 
 # Step 1: Start Stack (unless skipped)
 if (-not $SkipStackStart) {
-    Write-Host "📦 Starting Claire de Binare stack..." -ForegroundColor Yellow
-    & ".\infrastructure\scripts\stack_up.ps1" -Logging
+    Write-Host "📦 Starting Claire de Binare stack (CI/Test-Compose)..." -ForegroundColor Yellow
+    docker compose @ComposeArgs up -d
 
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Stack start failed. Aborting E2E tests."
@@ -94,7 +189,7 @@ if ($elapsed -ge $maxWait) {
     Write-Error "Timeout waiting for services to be healthy. Check: docker ps"
     if (-not $SkipTeardown) {
         Write-Host "🧹 Tearing down stack..." -ForegroundColor Yellow
-        docker compose -f infrastructure/compose/base.yml -f infrastructure/compose/monitoring.yml -f infrastructure/compose/logging.yml down
+        docker compose @ComposeArgs down
     }
     exit 1
 }
@@ -124,7 +219,7 @@ Write-Host ""
 # Step 4: Teardown (unless skipped)
 if (-not $SkipTeardown) {
     Write-Host "🧹 Tearing down stack..." -ForegroundColor Yellow
-    docker compose -f infrastructure/compose/base.yml -f infrastructure/compose/monitoring.yml -f infrastructure/compose/logging.yml down
+    docker compose @ComposeArgs down
 
     if ($LASTEXITCODE -ne 0) {
         Write-Warning "Stack teardown failed (non-fatal)"
@@ -142,3 +237,7 @@ Write-Host "E2E Test Runner - Complete" -ForegroundColor Cyan
 Write-Host "==================================" -ForegroundColor Cyan
 
 exit $testExitCode
+
+} finally {
+    Pop-Location
+}

--- a/knowledge/testing/TEST_HARNESS_V1.md
+++ b/knowledge/testing/TEST_HARNESS_V1.md
@@ -41,16 +41,28 @@
 ```
 
 ### 3. E2E Suite (Requires Docker Stack)
+
+**Offizieller lokaler Einstieg:** `infrastructure/scripts/run_e2e.ps1`
+**Offizielles Smoke-/E2E-Ziel:** `tests/e2e/test_smoke_pipeline.py`
+**Offizieller CI-Workflow:** `.github/workflows/e2e.yml`
+
+> **Runtime-Canon vs CI/Test-Compose:**
+> - `BLUE+RED` (`compose.blue.yml` + `compose.red.yml`) = Runtime-/Operator-Pfad
+> - `base.yml + dev.yml` (+ `logging.yml`) = CI/Test-/Legacy-Kompatibilitätspfad
+
 ```powershell
-# Prerequisites: Docker stack running
-# Check: docker ps --filter "name=cdb_"
+# Kanonischer lokaler E2E-Lauf (Stack-Start + Tests + Teardown)
+.\infrastructure\scripts\run_e2e.ps1
 
-# P0 Happy Path
-.venv/Scripts/python.exe -m pytest -m e2e tests/e2e/test_paper_trading_p0.py -v
+# Nur Tests, Stack bereits manuell gestartet
+.\infrastructure\scripts\run_e2e.ps1 -SkipStackStart -SkipTeardown
 
-# Full E2E (longer)
-.venv/Scripts/python.exe -m pytest tests/e2e/ -v
+# Manueller Debug-/Fallback-Start (CI/Test-Compose-Pfad)
+docker compose -f infrastructure/compose/base.yml -f infrastructure/compose/dev.yml -f infrastructure/compose/logging.yml up -d
+.venv/Scripts/python.exe -m pytest tests/e2e/test_smoke_pipeline.py -v
 ```
+
+> `test_paper_trading_p0.py` ist ein historischer/breiterer E2E-Pfad, aber nicht der kanonische Einstieg.
 
 ### 4. Integration Tests (Partial Docker)
 ```powershell
@@ -114,7 +126,7 @@
 
 ### For E2E Validation:
 - [ ] Docker stack healthy: `docker ps --filter "name=cdb_"`
-- [ ] E2E P0 suite PASSES: `pytest -m e2e tests/e2e/test_paper_trading_p0.py`
+- [ ] E2E Smoke PASSES: `pytest tests/e2e/test_smoke_pipeline.py -v`
 - [ ] Key metrics visible:
   - `signals_generated_total > 0`
   - `risk_pending_orders_total >= 0`
@@ -137,9 +149,9 @@
 ```
 
 ### Problem: E2E tests fail with connection errors
-**Solution:** Ensure Docker stack is running
+**Solution:** Ensure Docker stack is running (CI/Test-Compose-Pfad)
 ```powershell
-docker-compose -f infrastructure/compose/base.yml -f infrastructure/compose/dev.yml up -d
+docker compose -f infrastructure/compose/base.yml -f infrastructure/compose/dev.yml -f infrastructure/compose/logging.yml up -d
 ```
 
 ### Problem: Tests hang or timeout

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,7 +14,7 @@ markers =
     integration: Tests mit Mock-Services (CI + lokal)
     contract: Contract Tests - validate API/service contracts (CI + lokal)
     external: External network tests (opt-in only)
-    e2e: End-to-End Tests mit echten Containern (NUR lokal)
+    e2e: End-to-End Tests mit echten Containern (lokal + CI via e2e.yml)
     local_only: Explizit nur lokal ausführen (nicht in CI)
     slow: Tests mit >10s Laufzeit
     chaos: Chaos/Resilience Tests - DESTRUKTIV! (NUR lokal)

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -82,37 +82,42 @@ Deterministisches market_data Fixture für reproducible Tests.
 
 ## Running Tests
 
-### Local (PowerShell)
+### Local (offizieller Einstieg)
 
 ```powershell
-# 1. Start Stack (mit Logging für Debugging)
-.\infrastructure\scripts\stack_up.ps1 -Logging
-# stack_up exports required secrets (e.g., REDIS_PASSWORD) into the session
+# Kanonischer lokaler E2E-Lauf (Stack-Start + Tests + Teardown)
+.\infrastructure\scripts\run_e2e.ps1
+
+# Nur Tests, Stack bereits manuell gestartet
+.\infrastructure\scripts\run_e2e.ps1 -SkipStackStart -SkipTeardown
+```
+
+### Local (manueller Debug-/Fallback-Pfad)
+
+```powershell
+# 1. Stack starten (CI/Test-Compose-Pfad)
+docker compose -f infrastructure/compose/base.yml -f infrastructure/compose/dev.yml -f infrastructure/compose/logging.yml up -d
 
 # 2. Run E2E Smoke Test
-.\.venv\Scripts\python.exe -m pytest tests\e2e -m e2e -v --tb=short
+.\.venv\Scripts\python.exe -m pytest tests/e2e/test_smoke_pipeline.py -v --tb=short
 
 # 3. Repeat 3x für Determinismus-Check
 for ($i=1; $i -le 3; $i++) {
     Write-Host "Run $i/3..."
-    .\.venv\Scripts\python.exe -m pytest tests\e2e -m e2e -v
+    .\.venv\Scripts\python.exe -m pytest tests/e2e/test_smoke_pipeline.py -v
 }
-```
-
-### Local (via Runner-Script)
-
-```powershell
-# Automatisierter Run (Stack-Start + Tests + Teardown)
-.\infrastructure\scripts\run_e2e.ps1
 ```
 
 ### CI (GitHub Actions)
 
-Automatisch bei:
-- Pull Requests (paths: `tests/e2e/**`, `services/**`, `infrastructure/**`)
-- Manuell via `workflow_dispatch`
+**Offizieller Workflow:** `.github/workflows/e2e.yml`
 
-**Workflow:** `.github/workflows/e2e-tests.yml`
+Automatisch bei:
+- Push auf `main` (paths: `tests/e2e/**`, `services/**`, `infrastructure/compose/**`)
+- Manuell via `workflow_dispatch`
+- Wöchentlich (Sonntag 06:30 UTC)
+
+> `e2e-tests.yml` und `e2e-happy-path.yaml` sind historische Nebenpfade, nicht der offizielle E2E-Source-of-Truth.
 
 ---
 


### PR DESCRIPTION
## Summary

Dieser PR zieht den Test-Harness für #149 auf einen eindeutigen Canon:

- **Offizieller lokaler Einstieg:** `infrastructure/scripts/run_e2e.ps1`
- **Offizielles Smoke-/E2E-Ziel:** `tests/e2e/test_smoke_pipeline.py`
- **Offizieller GitHub-E2E-Workflow:** `.github/workflows/e2e.yml`

## Enthalten

- Doku in `knowledge/testing/TEST_HARNESS_V1.md` bereinigt
- Doku in `tests/e2e/README.md` bereinigt
- `infrastructure/scripts/run_e2e.ps1` funktional auf den realen CI/Test-Compose-Pfad gezogen (stack_up.ps1 ersetzt, monitoring.yml entfernt, Secrets/Path-Vorbereitung übernommen)
- `pytest.ini` Markertext an die Realität angepasst

## Bewusst nicht enthalten

- Keine Änderungen an Compose-Dateien
- Keine Workflow-Änderungen
- Keine Coverage-/Required-Checks-/Governance-Themen
- Kein Scope-Drift in Nachbar-Issues (#145, #147, #169, #170, #151, #94, #189)

## Test plan

- [x] Alle aktualisierten Texte nennen denselben offiziellen lokalen E2E-Einstieg (`run_e2e.ps1`)
- [x] Alle aktualisierten Texte nennen denselben offiziellen CI-Workflow (`e2e.yml`)
- [x] `run_e2e.ps1` referenziert weder `stack_up.ps1` noch `monitoring.yml`
- [x] Keine Doku behauptet, `e2e-tests.yml` oder `e2e-happy-path.yaml` seien der offizielle Source-of-Truth
- [x] Keine Coverage-Gates, Required-Checks oder Compose-Reconciliation aufgemacht

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)