### PR TITLE
fix: ignore non-workflow files in policy gate

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -42,7 +42,9 @@ jobs:
 
             const changedFiles = files.map((file) => file.filename);
             const isDocsFile = (path) => path.startsWith('docs/') || path.toLowerCase().endsWith('.md');
-            const isWorkflowFile = (path) => path.startsWith('.github/workflows/');
+            const isWorkflowFile = (path) =>
+              path.startsWith('.github/workflows/') &&
+              (path.endsWith('.yml') || path.endsWith('.yaml'));
             const isWorkflowScopeCompanionDoc = (path) =>
               path === 'docs/runbooks/project_board_automation.md';
             const isInfraFile = (path) => path.startsWith('infrastructure/');


### PR DESCRIPTION
## Summary

- Policy-gate workflow safety check treated **all** files under `.github/workflows/` as workflow files
- `.github/workflows/labels.json` (a data file) was checked for a YAML `permissions:` section and failed
- This caused a false positive blocking PR #1159

## Fix

`isWorkflowFile()` now requires `.yml` or `.yaml` extension in addition to the `.github/workflows/` prefix.

## Not changed

- `labels.json` itself (no move, no rename)
- #169 content (status/triage taxonomy)
- Other policy-gate rules or workflow logic

## Validation

```
PASS .github/workflows/ci.yml -> true
PASS .github/workflows/policy-gate.yml -> true
PASS .github/workflows/bar.yaml -> true
PASS .github/workflows/labels.json -> false
PASS .github/workflows/readme.md -> false
PASS .github/workflows/template.txt -> false
PASS .github/labels.json -> false
PASS docs/foo.yml -> false
8/8 passed
```

## Test plan

- [x] `.yml`/`.yaml` under `.github/workflows/` still recognized as workflows
- [x] `.json`/`.md`/`.txt` under `.github/workflows/` excluded from workflow checks
- [x] Node.js unit validation of `isWorkflowFile()` logic (8/8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)