### PR TITLE
workflows-only: move lightweight PR workflows to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
   ci:
     # Canonical PR gate: branch protection and Sentinel depend on this exact check-run name.
     name: ci (Unit/Integration + Lint gesammelt)
-    runs-on: [self-hosted, cdb]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude-review:
-    runs-on: [self-hosted, cdb]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/lr021_replay_smoke.yml
+++ b/.github/workflows/lr021_replay_smoke.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   lr021-replay-smoke:
     name: LR-021 Replay Smoke (fixture → hashes)
-    runs-on: [self-hosted, cdb]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
Moves lightweight, stateless PR workflows from the self-hosted runner to GitHub-hosted runners to reduce queue pressure on the CDB self-hosted runner.

## What changed
- `.github/workflows/ci.yml`
- `.github/workflows/lr021_replay_smoke.yml`
- `.github/workflows/claude-code-review.yml`

Each workflow changed by exactly one line:
- `runs-on: [self-hosted, cdb]` -> `runs-on: ubuntu-latest`

## Why this is safe
- no workflow/job/check names changed
- no trigger changes
- no permissions changes
- no step logic changes
- no branch-protection contract changes

## Merge-contract impact
The merge-relevant PR check names remain unchanged:
- `ci (Unit/Integration + Lint gesammelt)`
- `policy-gate`

`LR-021 Replay Smoke (fixture → hashes)` also remains unchanged as a check name.

## Rationale
These workflows are stateless and only perform:
- checkout
- Python setup / pip install
- lint / tests / replay verification
- review action execution

They do not require Docker socket access, runner-local volumes, or other self-hosted-only runtime features.

## Risks
- GitHub-hosted runs may install dependencies from scratch more often, so runtime may be slightly longer
- `mcp_runtime.yml` remains on self-hosted and is intentionally out of scope here

🤖 Generated with [Claude Code](https://claude.com/claude-code)