### PR TITLE
docs: reconcile P0 tracker drift in live-readiness artifacts (#1153)

### DIFF
--- a/docs/live-readiness/GO_NO_GO.md
+++ b/docs/live-readiness/GO_NO_GO.md
@@ -6,9 +6,9 @@
 
 | Phase | Bereich | Status | Blocker | Evidence | Owner |
 |-------|---------|--------|---------|----------|-------|
-| P0 | CI Required Checks | | YES | | |
-| P0 | Contract Tests | | YES | | |
-| P0 | Kill-Switch + Limits | | YES | | |
+| P0 | CI Required Checks | PASS | YES | [LR-001-EVIDENCE](./LR-001-EVIDENCE.md), [LR-001-STATE](./LR-001-STATE.yaml) | jannekbuengener |
+| P0 | Contract Tests | PASS | YES | [LR-002-EVIDENCE](./LR-002-EVIDENCE.md), [LR-002-STATE](./LR-002-STATE.yaml) | jannekbuengener |
+| P0 | Kill-Switch + Limits | PASS | YES | [LR-003-EVIDENCE](./LR-003-EVIDENCE.md), [LR-003-STATE](./LR-003-STATE.yaml) | jannekbuengener |
 | P1 | Risk Engine Tests | | NO | | |
 | P1 | State Machine Tests | | NO | | |
 | P1 | Negative Payload | | NO | | |

--- a/docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md
+++ b/docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md
@@ -1,6 +1,7 @@
 # Live Readiness Audit Status - 2026-03-05
 
-Status date: 2026-03-05 (Europe/Berlin)  
+Status date: 2026-03-05 (Europe/Berlin)
+Last reconciliation: 2026-03-15 (P0 tracker drift resolved)
 Scope: Echtgeld Go/No-Go readiness snapshot from existing live-readiness SSOT sources.
 
 ## A) Executive Summary
@@ -10,7 +11,7 @@ Scope: Echtgeld Go/No-Go readiness snapshot from existing live-readiness SSOT so
 - Governance mode remains `governance-first`.
 - Current verdict: **NO-GO**.
 - Blocking phase in roadmap: `P0` (`blocking: true`).
-- `P0` has state files marked `DONE`, but related LR issues (`LR-001`, `LR-003`) are still open and require tracker reconciliation.
+- `P0` is fully complete: all three state files are `DONE` and all corresponding GitHub issues (`LR-001` [#776](https://github.com/jannekbuengener/Claire_de_Binare/issues/776), `LR-002` [#777](https://github.com/jannekbuengener/Claire_de_Binare/issues/777), `LR-003` [#778](https://github.com/jannekbuengener/Claire_de_Binare/issues/778)) are closed. Tracker drift resolved as of 2026-03-15.
 - `P1` to `P5` still contain open operational tasks; no phase beyond P0 is complete.
 - `P5` canary is additionally gated by explicit human approval (`requires: explicit_human_approval`).
 - Guardrail reminder: **No real trades without human gate**.
@@ -20,7 +21,7 @@ Scope: Echtgeld Go/No-Go readiness snapshot from existing live-readiness SSOT so
 
 | Phase | Blocking? | LR-Tasks | Status | Evidence / Links |
 |---|---|---|---|---|
-| P0 Preconditions | `true` | `LR-001`, `LR-002`, `LR-003` | `PARTIAL` | State files show DONE: [LR-001-STATE](./LR-001-STATE.yaml), [LR-002-STATE](./LR-002-STATE.yaml), [LR-003-STATE](./LR-003-STATE.yaml); issue tracker still open for [LR-001 #776](https://github.com/jannekbuengener/Claire_de_Binare/issues/776) and [LR-003 #778](https://github.com/jannekbuengener/Claire_de_Binare/issues/778), [LR-002 #777](https://github.com/jannekbuengener/Claire_de_Binare/issues/777) closed |
+| P0 Preconditions | `true` | `LR-001`, `LR-002`, `LR-003` | `DONE` | State files DONE + all issues closed: [LR-001 #776](https://github.com/jannekbuengener/Claire_de_Binare/issues/776), [LR-002 #777](https://github.com/jannekbuengener/Claire_de_Binare/issues/777), [LR-003 #778](https://github.com/jannekbuengener/Claire_de_Binare/issues/778). Evidence: [LR-001-EVIDENCE](./LR-001-EVIDENCE.md), [LR-002-EVIDENCE](./LR-002-EVIDENCE.md), [LR-003-EVIDENCE](./LR-003-EVIDENCE.md) |
 | P1 Deterministic Tests | `false` | `LR-010`, `LR-011`, `LR-012` | `OPEN` | [LR-010 #779](https://github.com/jannekbuengener/Claire_de_Binare/issues/779), [LR-011 #780](https://github.com/jannekbuengener/Claire_de_Binare/issues/780), [LR-012 #781](https://github.com/jannekbuengener/Claire_de_Binare/issues/781) |
 | P2 E2E + Replay | `false` | `LR-020`, `LR-021` | `PARTIAL` | [LR-020 #782](https://github.com/jannekbuengener/Claire_de_Binare/issues/782) open; [LR-021 #783](https://github.com/jannekbuengener/Claire_de_Binare/issues/783) closed with evidence slices present |
 | P3 Shadow Mode | `false` | `LR-030`, `LR-031` | `OPEN` | [LR-030 #784](https://github.com/jannekbuengener/Claire_de_Binare/issues/784), [LR-031 #785](https://github.com/jannekbuengener/Claire_de_Binare/issues/785) |
@@ -29,8 +30,8 @@ Scope: Echtgeld Go/No-Go readiness snapshot from existing live-readiness SSOT so
 
 Phase notes (audit interpretation):
 
-- P0 is the only roadmap phase with explicit `blocking: true`; therefore any unresolved inconsistency in P0 keeps verdict at NO-GO.
-- P0 issue-state drift is treated as a governance control gap, not as a technical completion claim.
+- P0 is the only roadmap phase with explicit `blocking: true`. P0 is now fully consistent (state files + tracker aligned).
+- P0 issue-state drift was resolved on 2026-03-15; all three P0 issues are closed.
 - P1 remains foundational for deterministic behavior under invalid input and transition edges.
 - P2 is the first integrated runtime checkpoint and is not satisfied while LR-020 is open.
 - P3 and P4 are operational confidence layers and currently fully open.
@@ -56,7 +57,7 @@ DONE consistency checks:
 - Evidence commits are present as explicit short SHAs in state files.
 - `LR-007` includes a completion reason code and explanatory note.
 - DONE snapshot quality is structurally acceptable for audit reference.
-- Tracker reconciliation is still required for DONE items with open LR issues.
+- Tracker reconciliation complete: all DONE items have closed GitHub issues (verified 2026-03-15).
 
 ## D) OPEN / Next Tasks (prioritized)
 
@@ -69,7 +70,7 @@ DONE consistency checks:
 7. `LR-041` ([#787](https://github.com/jannekbuengener/Claire_de_Binare/issues/787)): chaos test for Redis/Postgres failures validates recovery behavior; DoD: controlled failure drill with recovery timing evidence.
 8. `LR-042` ([#788](https://github.com/jannekbuengener/Claire_de_Binare/issues/788)): network latency/loss chaos validates resilience of decision/execution path; DoD: induced network fault report with bounded degradation.
 9. `LR-050` ([#792](https://github.com/jannekbuengener/Claire_de_Binare/issues/792)): canary checklist gates live capital exposure; DoD: checklist complete and explicitly approved by human gate.
-10. Tracker alignment task (P0): reconcile `LR-001`/`LR-003` issue state vs state-file DONE status; DoD: issue tracker and SSOT state files reflect one consistent completion state.
+10. ~~Tracker alignment task (P0)~~ Resolved 2026-03-15: `LR-001` #776 and `LR-003` #778 closed; state files and tracker consistent.
 
 Open LR issue map (quick reference):
 
@@ -87,7 +88,7 @@ Open LR issue map (quick reference):
 
 ## E) Risks / Known Gaps
 
-- P0 issue-state mismatch (`DONE` in state files vs open LR issues) weakens audit consistency and release confidence.
+- ~~P0 issue-state mismatch~~ Resolved 2026-03-15: state files and issue tracker are now consistent.
 - Deterministic test layer (P1) is incomplete; regressions can pass unnoticed without full state-machine and negative-path coverage.
 - Full-pipeline paper trading evidence (P2) is still open, so integrated runtime behavior is not yet proven end to end.
 - Shadow mode and shadow-metric comparison (P3) are open; there is no live-market dry-run confidence baseline.
@@ -98,7 +99,7 @@ Open LR issue map (quick reference):
 
 ## F) Next Actions (next 7 days)
 
-1. Resolve P0 tracking drift: close or update [LR-001 #776](https://github.com/jannekbuengener/Claire_de_Binare/issues/776) and [LR-003 #778](https://github.com/jannekbuengener/Claire_de_Binare/issues/778) so issue tracker matches state files.
+1. ~~Resolve P0 tracking drift~~ Done (2026-03-15): #776 and #778 closed, state files consistent.
 2. Complete and evidence `LR-011` and `LR-012` test suites as highest-impact deterministic test blockers.
 3. Execute one full `LR-020` paper-trading E2E run and publish compact evidence (inputs, outputs, failure summary).
 4. Start `LR-030` shadow mode run and define comparison window for `LR-031`.


### PR DESCRIPTION
## Summary
- Update `GO_NO_GO.md`: P0 rows set to PASS with evidence links and owner
- Update `LR-AUDIT-STATUS-2026-03-05.md`: P0 status PARTIAL → DONE, tracker drift marked resolved (2026-03-15)
- Overall verdict remains **NO-GO** (P1–P5 still open)

## Changed files
- `docs/live-readiness/GO_NO_GO.md` — 3 P0 rows updated
- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` — 8 sections updated

## Test plan
- [x] P0 status consistent with closed GitHub issues (#776, #777, #778)
- [x] No change to P1–P5 status
- [x] Verdict remains NO-GO
- [x] docs-only change, no code impact

Does not close #1153 (P1–P5 remain open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)