### PR TITLE
feat(infra): consolidated backup/restore for Postgres + Redis (#1151)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #     - pytest.ini
 #     - infrastructure/scripts/systemcheck.py
 #     - infrastructure/scripts/daily_check.py
-#     - infrastructure/scripts/backup_postgres.ps1
+#     - infrastructure/scripts/backup_all.ps1
 #   downstream: []
 #   invariants:
 #     - docker must be installed and in PATH.
@@ -18,7 +18,7 @@
 
 MCP_CONFIG_PATHS ?=
 
-.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup paper-trading-start paper-trading-logs paper-trading-stop rollback cleanup mcp-config-validate security-scan
+.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop rollback cleanup mcp-config-validate security-scan
 
 help:
 	@echo "Claire de Binare - Test Commands"
@@ -52,7 +52,10 @@ help:
 	@echo "  make paper-trading-logs      - Zeige Paper Trading Logs (live)"
 	@echo "  make paper-trading-stop      - Stoppe Paper Trading Runner"
 	@echo "  make daily-check             - Täglicher Gesundheitscheck"
-	@echo "  make backup                  - PostgreSQL Backup (manuell)"
+	@echo "  make backup                  - Konsolidiertes Backup (Postgres + Redis)"
+	@echo "  make backup-postgres-only    - Legacy PostgreSQL-only Backup"
+	@echo "  make restore                 - Restore aus F:\\Claire_Backups"
+	@echo "  make backup-health           - Backup-Aktualitaet pruefen"
 	@echo ""
 	@echo "Repo-Hygiene & Rollback:"
 	@echo "  make rollback MR=<number>    - Rollback eines Merge Requests"
@@ -189,8 +192,20 @@ daily-check:
 	python infrastructure/scripts/daily_check.py
 
 backup:
-	@echo "💾 Führe PostgreSQL Backup aus..."
+	@echo "💾 Führe konsolidiertes Backup aus (Postgres + Redis)..."
+	powershell.exe -ExecutionPolicy Bypass -File infrastructure/scripts/backup_all.ps1
+
+backup-postgres-only:
+	@echo "💾 Führe PostgreSQL-only Backup aus (Legacy)..."
 	powershell.exe -ExecutionPolicy Bypass -File infrastructure/scripts/backup_postgres.ps1
+
+restore:
+	@echo "🔄 Restore aus F:\\Claire_Backups (interaktiv)..."
+	powershell.exe -ExecutionPolicy Bypass -File infrastructure/scripts/restore_all.ps1
+
+backup-health:
+	@echo "🏥 Prüfe Backup-Aktualität..."
+	powershell.exe -ExecutionPolicy Bypass -File infrastructure/scripts/backup_health_check.ps1
 
 paper-trading-start: systemcheck
 	@echo "🚀 Starte Paper Trading Runner..."

--- a/infrastructure/scripts/backup_all.ps1
+++ b/infrastructure/scripts/backup_all.ps1
@@ -1,0 +1,256 @@
+# backup_all.ps1 - Consolidated Backup (Postgres + Redis)
+# Target: F:\Claire_Backups
+# Creates pg_dump + Redis RDB snapshot, manifest, ZIP archive, 14d retention
+#
+# Usage:
+#   powershell.exe -ExecutionPolicy Bypass -File backup_all.ps1
+#   powershell.exe -ExecutionPolicy Bypass -File backup_all.ps1 -BackupDir "D:\Other\Path"
+#   powershell.exe -ExecutionPolicy Bypass -File backup_all.ps1 -AllowRedisFailure
+#
+# Exit codes:
+#   0 = both Postgres and Redis backed up successfully
+#   1 = any component failed (default: both are required)
+#       Use -AllowRedisFailure to tolerate Redis failure (exit 0 if Postgres OK)
+
+[CmdletBinding()]
+param(
+    [string]$BackupDir = "F:\Claire_Backups",
+    [int]$RetentionDays = 14,
+    [int]$MinFreeGB = 10,
+    [switch]$AllowRedisFailure
+)
+
+$ErrorActionPreference = "Stop"
+
+$TIMESTAMP = Get-Date -Format "yyyyMMdd_HHmmss"
+$BACKUP_NAME = "cdb_backup_$TIMESTAMP"
+$WORK_DIR = Join-Path $BackupDir $BACKUP_NAME
+
+function Write-Pass  { param([string]$Msg) Write-Host "PASS  $Msg" -ForegroundColor Green }
+function Write-Fail  { param([string]$Msg) Write-Host "FAIL  $Msg" -ForegroundColor Red }
+function Write-Step  { param([string]$Msg) Write-Host "---   $Msg" -ForegroundColor Cyan }
+
+Write-Host ""
+Write-Host "=== Claire de Binare - Consolidated Backup ===" -ForegroundColor Cyan
+Write-Host "Timestamp:  $TIMESTAMP"
+Write-Host "Target:     $BackupDir"
+Write-Host ""
+
+# ── 1. Pre-flight checks ────────────────────────────────────────────────
+
+Write-Step "Pre-flight: backup directory"
+try {
+    New-Item -ItemType Directory -Force -Path $BackupDir | Out-Null
+} catch {
+    Write-Fail "Cannot create backup directory: $BackupDir"
+    exit 1
+}
+
+Write-Step "Pre-flight: disk space"
+try {
+    $drive = (Get-Item $BackupDir).PSDrive
+    $freeGB = [math]::Round(($drive.Free / 1GB), 2)
+    if ($freeGB -lt $MinFreeGB) {
+        Write-Fail "Insufficient disk space: $freeGB GB free (minimum $MinFreeGB GB)"
+        exit 1
+    }
+    Write-Pass "Disk space OK ($freeGB GB free)"
+} catch {
+    Write-Fail "Disk space check failed: $_"
+    exit 1
+}
+
+Write-Step "Pre-flight: Docker"
+try {
+    $dockerCheck = docker ps --format "{{.Names}}" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Fail "Docker is not running"
+        exit 1
+    }
+    Write-Pass "Docker reachable"
+} catch {
+    Write-Fail "Docker check failed: $_"
+    exit 1
+}
+
+# Create working directory
+New-Item -ItemType Directory -Force -Path $WORK_DIR | Out-Null
+
+$componentStatus = @{
+    Postgres = $false
+    Redis = $false
+}
+
+$startTime = Get-Date
+
+# ── 2. Postgres backup ──────────────────────────────────────────────────
+
+Write-Host ""
+Write-Step "[1/2] Postgres backup via pg_dump..."
+
+$pgRunning = docker ps --filter "name=cdb_postgres" --format "{{.Names}}" 2>&1
+if ($pgRunning -notmatch "cdb_postgres") {
+    Write-Fail "Container cdb_postgres not running - skipping Postgres backup"
+} else {
+    $pgFile = Join-Path $WORK_DIR "postgres_dump.sql"
+    try {
+        docker exec cdb_postgres pg_dump -U claire_user -d claire_de_binare --no-owner --no-acl | Out-File -FilePath $pgFile -Encoding UTF8
+
+        if ($LASTEXITCODE -ne 0) {
+            Write-Fail "pg_dump returned exit code $LASTEXITCODE"
+        } elseif (-not (Test-Path $pgFile) -or (Get-Item $pgFile).Length -eq 0) {
+            Write-Fail "pg_dump produced empty file"
+        } else {
+            $pgSizeMB = [math]::Round((Get-Item $pgFile).Length / 1MB, 2)
+
+            # Basic integrity check: dump must contain CREATE TABLE
+            $headContent = Get-Content $pgFile -TotalCount 200 -ErrorAction SilentlyContinue | Out-String
+            if ($headContent -match "PostgreSQL database dump") {
+                $componentStatus.Postgres = $true
+                Write-Pass "Postgres backup: $pgSizeMB MB"
+            } else {
+                Write-Fail "Postgres dump missing expected header"
+            }
+        }
+    } catch {
+        Write-Fail "Postgres backup failed: $_"
+    }
+}
+
+# ── 3. Redis backup ─────────────────────────────────────────────────────
+
+Write-Step "[2/2] Redis backup via SAVE + cp..."
+
+$redisRunning = docker ps --filter "name=cdb_redis" --format "{{.Names}}" 2>&1
+if ($redisRunning -notmatch "cdb_redis") {
+    Write-Fail "Container cdb_redis not running - skipping Redis backup"
+} else {
+    $redisFile = Join-Path $WORK_DIR "redis_dump.rdb"
+    try {
+        # Trigger synchronous save
+        docker exec cdb_redis redis-cli SAVE 2>&1 | Out-Null
+
+        if ($LASTEXITCODE -ne 0) {
+            Write-Fail "redis-cli SAVE failed"
+        } else {
+            # Copy RDB from container
+            docker cp cdb_redis:/data/dump.rdb $redisFile 2>&1
+
+            if ($LASTEXITCODE -ne 0 -or -not (Test-Path $redisFile)) {
+                Write-Fail "Redis RDB copy failed"
+            } else {
+                $redisSizeKB = [math]::Round((Get-Item $redisFile).Length / 1KB, 2)
+                $componentStatus.Redis = $true
+                Write-Pass "Redis backup: $redisSizeKB KB"
+            }
+        }
+    } catch {
+        Write-Fail "Redis backup failed: $_"
+    }
+}
+
+# ── 4. Manifest ──────────────────────────────────────────────────────────
+
+Write-Step "Writing manifest..."
+
+$gitCommit = "unknown"
+try {
+    $gitCommit = (git rev-parse HEAD 2>&1).Trim()
+    if ($LASTEXITCODE -ne 0) { $gitCommit = "unavailable" }
+} catch {
+    $gitCommit = "unavailable"
+}
+
+$manifest = @{
+    Timestamp = (Get-Date -Format 'o')
+    BackupName = $BACKUP_NAME
+    Components = $componentStatus
+    GitCommit = $gitCommit
+    RetentionDays = $RetentionDays
+    BackupDir = $BackupDir
+} | ConvertTo-Json -Depth 10
+
+$manifestPath = Join-Path $WORK_DIR "manifest.json"
+$manifest | Out-File -FilePath $manifestPath -Encoding UTF8
+Write-Pass "Manifest written"
+
+# ── 5. Compress ──────────────────────────────────────────────────────────
+
+Write-Step "Compressing archive..."
+
+$archivePath = Join-Path $BackupDir "$BACKUP_NAME.zip"
+try {
+    Compress-Archive -Path $WORK_DIR -DestinationPath $archivePath -Force
+
+    if (Test-Path $archivePath) {
+        $archiveSizeMB = [math]::Round((Get-Item $archivePath).Length / 1MB, 2)
+        Write-Pass "Archive: $archiveSizeMB MB -> $archivePath"
+        # Remove uncompressed working directory
+        Remove-Item -Path $WORK_DIR -Recurse -Force
+    } else {
+        Write-Fail "Archive creation failed"
+        exit 1
+    }
+} catch {
+    Write-Fail "Compression failed: $_"
+    exit 1
+}
+
+# ── 6. Retention cleanup ────────────────────────────────────────────────
+
+Write-Step "Retention cleanup ($RetentionDays days)..."
+
+try {
+    $cutoff = (Get-Date).AddDays(-$RetentionDays)
+    $oldArchives = Get-ChildItem "$BackupDir\cdb_backup_*.zip" -ErrorAction SilentlyContinue |
+        Where-Object { $_.LastWriteTime -lt $cutoff }
+
+    if ($oldArchives.Count -gt 0) {
+        $oldArchives | ForEach-Object {
+            Write-Host "      Removing: $($_.Name)" -ForegroundColor Gray
+            Remove-Item $_.FullName -Force
+        }
+        Write-Pass "Removed $($oldArchives.Count) old archive(s)"
+    } else {
+        Write-Host "      No archives older than $RetentionDays days" -ForegroundColor Gray
+    }
+} catch {
+    Write-Host "WARN  Retention cleanup failed: $_ (non-fatal)" -ForegroundColor Yellow
+}
+
+# ── 7. Summary ───────────────────────────────────────────────────────────
+
+$duration = [math]::Round(((Get-Date) - $startTime).TotalSeconds, 1)
+$totalArchives = (Get-ChildItem "$BackupDir\cdb_backup_*.zip" -ErrorAction SilentlyContinue).Count
+
+Write-Host ""
+Write-Host "=== Backup Summary ===" -ForegroundColor Cyan
+Write-Host "  Postgres: $(if ($componentStatus.Postgres) { 'OK' } else { 'FAILED' })"
+Write-Host "  Redis:    $(if ($componentStatus.Redis) { 'OK' } else { 'FAILED' })"
+Write-Host "  Archive:  $archivePath"
+Write-Host "  Duration: $duration s"
+Write-Host "  Total archives in $BackupDir : $totalArchives"
+Write-Host ""
+
+# Exit with failure if any component failed
+if (-not $componentStatus.Postgres) {
+    Write-Fail "Backup incomplete - Postgres failed"
+    exit 1
+}
+
+if (-not $componentStatus.Redis) {
+    if ($AllowRedisFailure) {
+        Write-Host "WARN  Redis backup failed - tolerated via -AllowRedisFailure" -ForegroundColor Yellow
+    } else {
+        Write-Fail "Backup incomplete - Redis failed (use -AllowRedisFailure to override)"
+        exit 1
+    }
+}
+
+Write-Pass "Backup completed successfully"
+Write-Host ""
+Write-Host "Restore with:" -ForegroundColor Yellow
+Write-Host "  powershell.exe -ExecutionPolicy Bypass -File infrastructure\scripts\restore_all.ps1 -BackupName $BACKUP_NAME" -ForegroundColor White
+Write-Host ""
+
+exit 0

--- a/infrastructure/scripts/backup_health_check.ps1
+++ b/infrastructure/scripts/backup_health_check.ps1
@@ -1,14 +1,64 @@
-# Enhanced Backup Status Check
-Write-Host "🔍 COPILOT SMART BACKUP ENHANCEMENT" -ForegroundColor Green
-$backupDir = "F:\Claire_Backups"
-if (Test-Path $backupDir) {
-    $latestBackup = Get-ChildItem $backupDir | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-    $age = (Get-Date) - $latestBackup.LastWriteTime
-    if ($age.TotalHours -lt 2) {
-        Write-Host "✅ Backup system healthy - Latest: $($latestBackup.Name)" -ForegroundColor Green
+# backup_health_check.ps1 - Backup Health Check with exit codes
+# Checks F:\Claire_Backups for recent backup archives
+#
+# Usage:
+#   powershell.exe -ExecutionPolicy Bypass -File backup_health_check.ps1
+#   powershell.exe -ExecutionPolicy Bypass -File backup_health_check.ps1 -MaxAgeHours 4
+#   powershell.exe -ExecutionPolicy Bypass -File backup_health_check.ps1 -BackupDir "D:\Other"
+#
+# Exit codes:
+#   0 = PASS (recent backup found)
+#   1 = FAIL (no backup, stale, or directory missing)
+
+[CmdletBinding()]
+param(
+    [string]$BackupDir = "F:\Claire_Backups",
+    [int]$MaxAgeHours = 2
+)
+
+# Check directory exists
+if (-not (Test-Path $BackupDir)) {
+    Write-Host "FAIL  Backup directory not accessible: $BackupDir" -ForegroundColor Red
+    exit 1
+}
+
+# Find latest cdb_backup archive (from backup_all.ps1)
+$latestConsolidated = Get-ChildItem "$BackupDir\cdb_backup_*.zip" -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+
+# Fallback: also check legacy claire_de_binare_*.zip (from backup_postgres.ps1)
+$latestLegacy = Get-ChildItem "$BackupDir\claire_de_binare_*.sql.zip" -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+
+# Pick the most recent of either
+$latest = $null
+if ($latestConsolidated -and $latestLegacy) {
+    if ($latestConsolidated.LastWriteTime -ge $latestLegacy.LastWriteTime) {
+        $latest = $latestConsolidated
     } else {
-        Write-Host "⚠️ Backup potentially stale - Age: $($age.TotalHours.ToString(\"F1\")) hours" -ForegroundColor Yellow
+        $latest = $latestLegacy
     }
+} elseif ($latestConsolidated) {
+    $latest = $latestConsolidated
+} elseif ($latestLegacy) {
+    $latest = $latestLegacy
+}
+
+if (-not $latest) {
+    Write-Host "FAIL  No backup archives found in $BackupDir" -ForegroundColor Red
+    exit 1
+}
+
+$age = (Get-Date) - $latest.LastWriteTime
+$ageHours = [math]::Round($age.TotalHours, 1)
+$sizeMB = [math]::Round($latest.Length / 1MB, 2)
+
+if ($age.TotalHours -lt $MaxAgeHours) {
+    Write-Host "PASS  Latest backup: $($latest.Name) ($sizeMB MB, ${ageHours}h old)" -ForegroundColor Green
+    exit 0
 } else {
-    Write-Host "❌ Backup directory not accessible" -ForegroundColor Red
+    Write-Host "FAIL  Backup stale: $($latest.Name) is ${ageHours}h old (threshold: ${MaxAgeHours}h)" -ForegroundColor Red
+    exit 1
 }

--- a/infrastructure/scripts/restore_all.ps1
+++ b/infrastructure/scripts/restore_all.ps1
@@ -1,0 +1,249 @@
+# restore_all.ps1 - Consolidated Restore (Postgres + Redis)
+# Source: F:\Claire_Backups
+# Restores from backup_all.ps1 archives
+#
+# Usage:
+#   powershell.exe -ExecutionPolicy Bypass -File restore_all.ps1 -BackupName cdb_backup_20260315_120000
+#   powershell.exe -ExecutionPolicy Bypass -File restore_all.ps1 -BackupName cdb_backup_20260315_120000 -Force
+#   powershell.exe -ExecutionPolicy Bypass -File restore_all.ps1 -ListAvailable
+
+[CmdletBinding()]
+param(
+    [string]$BackupName = "",
+    [string]$BackupDir = "F:\Claire_Backups",
+    [switch]$Force,
+    [switch]$ListAvailable
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Pass { param([string]$Msg) Write-Host "PASS  $Msg" -ForegroundColor Green }
+function Write-Fail { param([string]$Msg) Write-Host "FAIL  $Msg" -ForegroundColor Red }
+function Write-Step { param([string]$Msg) Write-Host "---   $Msg" -ForegroundColor Cyan }
+
+Write-Host ""
+Write-Host "=== Claire de Binare - Consolidated Restore ===" -ForegroundColor Cyan
+Write-Host ""
+
+# ── List available backups ───────────────────────────────────────────────
+
+if ($ListAvailable -or $BackupName -eq "") {
+    Write-Step "Available backups in $BackupDir :"
+
+    if (-not (Test-Path $BackupDir)) {
+        Write-Fail "Backup directory not found: $BackupDir"
+        exit 1
+    }
+
+    $archives = Get-ChildItem "$BackupDir\cdb_backup_*.zip" -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending
+
+    if ($archives.Count -eq 0) {
+        Write-Host "      No backup archives found" -ForegroundColor Yellow
+        exit 1
+    }
+
+    foreach ($a in $archives) {
+        $sizeMB = [math]::Round($a.Length / 1MB, 2)
+        $age = [math]::Round(((Get-Date) - $a.LastWriteTime).TotalHours, 1)
+        Write-Host "      $($a.BaseName)  ($sizeMB MB, ${age}h ago)" -ForegroundColor White
+    }
+
+    Write-Host ""
+    Write-Host "Usage:" -ForegroundColor Yellow
+    Write-Host "  .\restore_all.ps1 -BackupName <name>" -ForegroundColor White
+    Write-Host ""
+
+    if ($BackupName -eq "") { exit 0 }
+}
+
+# ── Pre-flight ───────────────────────────────────────────────────────────
+
+$archivePath = Join-Path $BackupDir "$BackupName.zip"
+
+if (-not (Test-Path $archivePath)) {
+    Write-Fail "Archive not found: $archivePath"
+    Write-Host ""
+    Write-Host "Run with -ListAvailable to see available backups" -ForegroundColor Yellow
+    exit 1
+}
+
+$archiveSizeMB = [math]::Round((Get-Item $archivePath).Length / 1MB, 2)
+Write-Host "Archive:  $archivePath ($archiveSizeMB MB)"
+Write-Host ""
+
+# ── Extract ──────────────────────────────────────────────────────────────
+
+Write-Step "Extracting archive..."
+
+$extractDir = Join-Path $BackupDir "${BackupName}_restore_temp"
+if (Test-Path $extractDir) {
+    Remove-Item -Path $extractDir -Recurse -Force
+}
+
+Expand-Archive -Path $archivePath -DestinationPath $extractDir
+
+# Find manifest (may be nested in subdirectory from Compress-Archive)
+$manifestFile = Get-ChildItem -Path $extractDir -Filter "manifest.json" -Recurse | Select-Object -First 1
+
+if (-not $manifestFile) {
+    Write-Fail "No manifest.json found in archive - is this a backup_all.ps1 archive?"
+    Remove-Item -Path $extractDir -Recurse -Force
+    exit 1
+}
+
+$manifest = Get-Content $manifestFile.FullName | ConvertFrom-Json
+$backupRoot = $manifestFile.DirectoryName
+
+Write-Pass "Manifest loaded"
+Write-Host "      Backup from:  $($manifest.Timestamp)"
+Write-Host "      Git commit:   $($manifest.GitCommit)"
+Write-Host "      Postgres:     $(if ($manifest.Components.Postgres) { 'included' } else { 'not included' })"
+Write-Host "      Redis:        $(if ($manifest.Components.Redis) { 'included' } else { 'not included' })"
+Write-Host ""
+
+# ── Safety confirmation ──────────────────────────────────────────────────
+
+if (-not $Force) {
+    Write-Host "WARNING: This will REPLACE current Postgres and Redis data!" -ForegroundColor Red
+    Write-Host ""
+    $confirmation = Read-Host "Type 'yes' to proceed (anything else cancels)"
+    if ($confirmation -ne 'yes') {
+        Write-Host "Restore cancelled" -ForegroundColor Yellow
+        Remove-Item -Path $extractDir -Recurse -Force
+        exit 0
+    }
+    Write-Host ""
+}
+
+$startTime = Get-Date
+$restoreResults = @{
+    Postgres = $false
+    Redis = $false
+}
+
+# ── Restore Postgres ─────────────────────────────────────────────────────
+
+if ($manifest.Components.Postgres) {
+    Write-Step "[1/2] Restoring Postgres..."
+
+    $pgDump = Get-ChildItem -Path $backupRoot -Filter "postgres_dump.sql" -Recurse | Select-Object -First 1
+
+    if (-not $pgDump) {
+        Write-Fail "postgres_dump.sql not found in archive"
+    } else {
+        # Check container is running
+        $pgRunning = docker ps --filter "name=cdb_postgres" --format "{{.Names}}" 2>&1
+        if ($pgRunning -notmatch "cdb_postgres") {
+            Write-Fail "Container cdb_postgres not running - start the stack first"
+        } else {
+            try {
+                # Drop and recreate database
+                docker exec cdb_postgres psql -U claire_user -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'claire_de_binare' AND pid <> pg_backend_pid();" 2>&1 | Out-Null
+                docker exec cdb_postgres psql -U claire_user -d postgres -c "DROP DATABASE IF EXISTS claire_de_binare;" 2>&1 | Out-Null
+                docker exec cdb_postgres psql -U claire_user -d postgres -c "CREATE DATABASE claire_de_binare;" 2>&1 | Out-Null
+
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Fail "Database drop/create failed"
+                } else {
+                    # Restore dump via stdin pipe
+                    Get-Content $pgDump.FullName | docker exec -i cdb_postgres psql -U claire_user -d claire_de_binare 2>&1 | Out-Null
+
+                    # Verify: check that tables exist
+                    $tableCheck = docker exec cdb_postgres psql -U claire_user -d claire_de_binare -t -c "\dt" 2>&1
+                    if ($tableCheck -match "public") {
+                        $restoreResults.Postgres = $true
+                        Write-Pass "Postgres restored and verified (tables present)"
+                    } else {
+                        Write-Fail "Postgres restore completed but no tables found"
+                    }
+                }
+            } catch {
+                Write-Fail "Postgres restore failed: $_"
+            }
+        }
+    }
+} else {
+    Write-Host "      Postgres not included in this backup - skipping" -ForegroundColor Gray
+}
+
+# ── Restore Redis ────────────────────────────────────────────────────────
+
+if ($manifest.Components.Redis) {
+    Write-Step "[2/2] Restoring Redis..."
+
+    $redisDump = Get-ChildItem -Path $backupRoot -Filter "redis_dump.rdb" -Recurse | Select-Object -First 1
+
+    if (-not $redisDump) {
+        Write-Fail "redis_dump.rdb not found in archive"
+    } else {
+        $redisRunning = docker ps --filter "name=cdb_redis" --format "{{.Names}}" 2>&1
+        if ($redisRunning -notmatch "cdb_redis") {
+            Write-Fail "Container cdb_redis not running - start the stack first"
+        } else {
+            try {
+                # Stop Redis to replace RDB safely
+                docker stop cdb_redis 2>&1 | Out-Null
+
+                # Copy RDB into container volume via alpine helper
+                # The volume name follows Docker Compose convention
+                docker run --rm `
+                    -v claire_de_binare_redis_data:/data `
+                    -v "$($redisDump.DirectoryName):/backup:ro" `
+                    alpine sh -c "cp /backup/redis_dump.rdb /data/dump.rdb && chmod 644 /data/dump.rdb"
+
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Fail "Redis RDB copy into volume failed"
+                } else {
+                    # Restart Redis
+                    docker start cdb_redis 2>&1 | Out-Null
+                    Start-Sleep -Seconds 3
+
+                    # Verify Redis is up
+                    $redisPing = docker exec cdb_redis redis-cli PING 2>&1
+                    if ($redisPing -match "PONG") {
+                        $restoreResults.Redis = $true
+                        Write-Pass "Redis restored and responding"
+                    } else {
+                        Write-Fail "Redis not responding after restore"
+                    }
+                }
+            } catch {
+                Write-Fail "Redis restore failed: $_"
+                # Try to restart Redis even on failure
+                docker start cdb_redis 2>&1 | Out-Null
+            }
+        }
+    }
+} else {
+    Write-Host "      Redis not included in this backup - skipping" -ForegroundColor Gray
+}
+
+# ── Cleanup temp ─────────────────────────────────────────────────────────
+
+Write-Step "Cleaning up temp files..."
+Remove-Item -Path $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+
+# ── Summary ──────────────────────────────────────────────────────────────
+
+$duration = [math]::Round(((Get-Date) - $startTime).TotalSeconds, 1)
+
+Write-Host ""
+Write-Host "=== Restore Summary ===" -ForegroundColor Cyan
+Write-Host "  Postgres: $(if ($restoreResults.Postgres) { 'OK' } else { 'FAILED / skipped' })"
+Write-Host "  Redis:    $(if ($restoreResults.Redis) { 'OK' } else { 'FAILED / skipped' })"
+Write-Host "  Duration: $duration s"
+Write-Host ""
+Write-Host "Verify manually:" -ForegroundColor Yellow
+Write-Host "  docker exec cdb_postgres psql -U claire_user -d claire_de_binare -c '\dt'" -ForegroundColor White
+Write-Host "  docker exec cdb_redis redis-cli DBSIZE" -ForegroundColor White
+Write-Host ""
+
+# Exit code: fail only if Postgres restore was expected and failed
+if ($manifest.Components.Postgres -and -not $restoreResults.Postgres) {
+    Write-Fail "Restore incomplete - Postgres failed"
+    exit 1
+}
+
+Write-Pass "Restore completed"
+exit 0

--- a/infrastructure/scripts/setup_backup_task.ps1
+++ b/infrastructure/scripts/setup_backup_task.ps1
@@ -27,8 +27,11 @@ Write-Host ""
 Write-Host "[INFO] Administrator-Rechte erkannt" -ForegroundColor Green
 
 # Task Configuration
+# NOTE: Points to consolidated backup_all.ps1 (Postgres + Redis).
+#       If a previous task "Claire_Hourly_Backup" exists pointing to
+#       backup_postgres.ps1, re-running this script will replace it.
 $taskName = "Claire_Hourly_Backup"
-$scriptPath = Join-Path $PSScriptRoot "backup_postgres.ps1"
+$scriptPath = Join-Path $PSScriptRoot "backup_all.ps1"
 $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-ExecutionPolicy Bypass -WindowStyle Hidden -File `"$scriptPath`""
 
 # Trigger: Every hour, starting at midnight
@@ -53,7 +56,7 @@ try {
     }
 
     # Register new task
-    Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Settings $settings -Principal $principal -Description "Stundliche PostgreSQL Backups fur Claire de Binare Paper Trading (14 Tage)"
+    Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Settings $settings -Principal $principal -Description "Stundliche Postgres+Redis Backups fur Claire de Binare (14 Tage Retention)"
 
     Write-Host ""
     Write-Host "[OK] Task erfolgreich erstellt!" -ForegroundColor Green


### PR DESCRIPTION
## Summary

- Add `backup_all.ps1` — consolidated Postgres + Redis backup to `F:\Claire_Backups` with JSON manifest, ZIP compression, 14-day retention
- Add `restore_all.ps1` — manifest-validated restore with safety confirmation gate and post-restore verification
- Harden `backup_health_check.ps1` with configurable threshold (`-MaxAgeHours`) and proper exit codes (0/1)
- Update `setup_backup_task.ps1` to point to consolidated `backup_all.ps1`
- Update Makefile with new targets: `backup`, `restore`, `backup-health`, `backup-postgres-only`

### Exit-code behavior

`backup_all.ps1` is **fail-closed by default**: both Postgres and Redis must succeed for exit 0. Explicit override only via `-AllowRedisFailure`.

### Out of scope

- No Grafana/Prometheus backup (dashboards are code, metrics are ephemeral)
- No encryption (deferred per prior decision)
- No CI integration of health check
- No automated restore test in CI
- No changes to DR suite (`dr_backup.ps1`, `dr_restore.ps1`, `dr_drill.ps1`)
- No removal of legacy `backup_postgres.ps1`

### Policy-gate note

This PR touches `Makefile` (repo root), which the policy-gate does not classify as `infra-only`. Label `allow-core-change` is set. No actual core/service code is affected.

### Host verification (post-merge)

Issue #1151 remains **open after merge** until verified on the host:

1. `make backup` → `cdb_backup_*.zip` on `F:\Claire_Backups` with `manifest.json`
2. `make backup-health` → exit 0
3. Scheduled Task re-registered and active (`setup_backup_task.ps1` as Admin)
4. `make restore` → Postgres tables + Redis PING verified

## Test plan

- [ ] `make backup` on host with running stack produces archive with manifest
- [ ] `make backup-health` returns exit 0
- [ ] `make restore` restores Postgres tables and Redis responds to PING
- [ ] Scheduled Task re-registered via `setup_backup_task.ps1`
- [ ] Legacy path `make backup-postgres-only` still functional

> #1151 will be closed only after host verification is documented in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)