### PR TITLE
fix(infra): add Redis auth to backup/restore scripts (#1151)

### DIFF
--- a/infrastructure/scripts/backup_all.ps1
+++ b/infrastructure/scripts/backup_all.ps1
@@ -73,6 +73,18 @@ try {
     exit 1
 }
 
+# Resolve Redis password from Docker secret (same source as compose stack)
+$redisPassword = ""
+try {
+    $redisPassword = (docker exec cdb_redis sh -c 'cat /run/secrets/redis_password 2>/dev/null' 2>&1).Trim()
+    if ($LASTEXITCODE -ne 0 -or $redisPassword -eq "") {
+        $redisPassword = ""
+        Write-Host "      Redis password not found in container secrets - will try without auth" -ForegroundColor Gray
+    }
+} catch {
+    $redisPassword = ""
+}
+
 # Create working directory
 New-Item -ItemType Directory -Force -Path $WORK_DIR | Out-Null
 
@@ -127,8 +139,12 @@ if ($redisRunning -notmatch "cdb_redis") {
 } else {
     $redisFile = Join-Path $WORK_DIR "redis_dump.rdb"
     try {
-        # Trigger synchronous save
-        docker exec cdb_redis redis-cli SAVE 2>&1 | Out-Null
+        # Trigger synchronous save (with auth if available)
+        if ($redisPassword -ne "") {
+            docker exec cdb_redis redis-cli -a $redisPassword --no-auth-warning SAVE 2>&1 | Out-Null
+        } else {
+            docker exec cdb_redis redis-cli SAVE 2>&1 | Out-Null
+        }
 
         if ($LASTEXITCODE -ne 0) {
             Write-Fail "redis-cli SAVE failed"

--- a/infrastructure/scripts/restore_all.ps1
+++ b/infrastructure/scripts/restore_all.ps1
@@ -197,10 +197,21 @@ if ($manifest.Components.Redis) {
                 } else {
                     # Restart Redis
                     docker start cdb_redis 2>&1 | Out-Null
-                    Start-Sleep -Seconds 3
+                    Start-Sleep -Seconds 5
 
-                    # Verify Redis is up
-                    $redisPing = docker exec cdb_redis redis-cli PING 2>&1
+                    # Resolve Redis password from Docker secret
+                    $redisPassword = ""
+                    try {
+                        $redisPassword = (docker exec cdb_redis sh -c 'cat /run/secrets/redis_password 2>/dev/null' 2>&1).Trim()
+                        if ($LASTEXITCODE -ne 0) { $redisPassword = "" }
+                    } catch { $redisPassword = "" }
+
+                    # Verify Redis is up (with auth if available)
+                    if ($redisPassword -ne "") {
+                        $redisPing = docker exec cdb_redis redis-cli -a $redisPassword --no-auth-warning PING 2>&1
+                    } else {
+                        $redisPing = docker exec cdb_redis redis-cli PING 2>&1
+                    }
                     if ($redisPing -match "PONG") {
                         $restoreResults.Redis = $true
                         Write-Pass "Redis restored and responding"


### PR DESCRIPTION
## Summary

Host-verify of #1177 revealed that Redis uses `requirepass` via Docker secrets. The `redis-cli SAVE` in `backup_all.ps1` and `redis-cli PING` in `restore_all.ps1` were called without authentication, causing silent SAVE failure and false-negative PING verification.

**Fix:**
- Read Redis password from `/run/secrets/redis_password` inside the container (same source as the compose stack)
- Pass `-a <password> --no-auth-warning` to all `redis-cli` calls
- Fall back to no-auth if secret is unavailable
- Increase post-restart sleep from 3s to 5s for Redis startup margin

## Evidence

```
# Before fix:
docker exec cdb_redis redis-cli PING
→ NOAUTH Authentication required.

# After fix (manual verify):
docker exec cdb_redis redis-cli -a <secret> PING
→ PONG
```

## Test plan

- [ ] `make backup` → both Postgres and Redis PASS
- [ ] `make restore -Force` → Redis verification shows PONG, not FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)