### PR TITLE
fix(infra): fix scheduled task trigger duration (#1151)

### DIFF
--- a/infrastructure/scripts/setup_backup_task.ps1
+++ b/infrastructure/scripts/setup_backup_task.ps1
@@ -34,8 +34,8 @@ $taskName = "Claire_Hourly_Backup"
 $scriptPath = Join-Path $PSScriptRoot "backup_all.ps1"
 $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-ExecutionPolicy Bypass -WindowStyle Hidden -File `"$scriptPath`""
 
-# Trigger: Every hour, starting at midnight
-$trigger = New-ScheduledTaskTrigger -Once -At "00:00" -RepetitionInterval (New-TimeSpan -Hours 1) -RepetitionDuration ([TimeSpan]::MaxValue)
+# Trigger: Every hour, daily repeat window (MaxValue causes XML schema rejection)
+$trigger = New-ScheduledTaskTrigger -Daily -At "00:00" -RepetitionInterval (New-TimeSpan -Hours 1) -RepetitionDuration (New-TimeSpan -Days 1)
 
 # Settings
 $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RunOnlyIfNetworkAvailable:$false


### PR DESCRIPTION
## Summary

One-line fix in `setup_backup_task.ps1`.

`[TimeSpan]::MaxValue` serializes to `P99999999DT23H59M59S` which Windows Task Scheduler rejects with an XML schema validation error. The task cannot be registered.

**Fix:** Replace `-Once` + `MaxValue` with `-Daily` + `RepetitionDuration (New-TimeSpan -Days 1)`. Standard pattern for "run hourly indefinitely" — scheduler re-arms itself each day.

## Test plan

- [ ] Run `setup_backup_task.ps1` as Admin → no error
- [ ] `Get-ScheduledTask -TaskName "Claire_Hourly_Backup"` → `State: Ready`

🤖 Generated with [Claude Code](https://claude.com/claude-code)