### PR TITLE
fix(governance): sync LR-041 readiness status with merged evidence

### DIFF
--- a/governance/p5_canary_readiness.yaml
+++ b/governance/p5_canary_readiness.yaml
@@ -59,12 +59,14 @@ required_controls:
     allowed_statuses: [IMPLEMENTED, PASS]
     hard_gate: true
   - id: LR-041
-    status: OPEN
-    evidence_path: docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md
+    status: IMPLEMENTED
+    evidence_path: docs/evidence/LR-041.md
     evidence_note: >
-      Tracking reference only. No Redis/Postgres chaos drill evidence exists.
-      Requires dedicated drill execution and evidence before status
-      can move to IMPLEMENTED.
+      Deterministic Redis/Postgres restart recovery drill implemented and
+      documented. Local drill evidence met recovery thresholds, preserved
+      shadow runtime mode, and observed zero execution. PASS requires
+      CI-backed artifact persistence; IMPLEMENTED is justified by the
+      merged runner, chaos test, and successful local drill run.
     allowed_statuses: [IMPLEMENTED, PASS]
     hard_gate: true
   - id: LR-042


### PR DESCRIPTION
## Summary

- Promotes `LR-041` in `governance/p5_canary_readiness.yaml` from `OPEN` to `IMPLEMENTED`
- Updates `evidence_path` to `docs/evidence/LR-041.md` (was pointing to generic audit-status tracker)
- Replaces stale `evidence_note` ("no evidence exists") with accurate note reflecting merged runner, chaos test, and successful local drill run
- `PASS` is explicitly NOT claimed — that remains gated on CI-backed artifact persistence

## Why now

The implementation was merged in PR #1130 (`8c5eb82`). `docs/evidence/LR-041.md` already states `IMPLEMENTED`. The governance YAML was never synchronized after merge — this is a pure tracker-drift fix.

## What was NOT changed

- `LR-031` — remains `IMPLEMENTED` (remote state, preserved through rebase conflict resolution)
- No production code, no new evidence, no scope changes

## Test plan

- [ ] CI passes (`ci` required check)
- [ ] `policy-gate` passes (docs/infra-only change, no `allow-core-change` label needed)
- [ ] `governance/p5_canary_readiness.yaml`: LR-041 = `IMPLEMENTED`, LR-031 = `IMPLEMENTED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)