### PR TITLE
feat(infra): move cdb_market from RED to BLUE stack (#1202)

### DIFF
--- a/infrastructure/compose/compose.blue.yml
+++ b/infrastructure/compose/compose.blue.yml
@@ -59,6 +59,35 @@ services:
     networks:
       - cdb_network
 
+  cdb_market:
+    build:
+      context: ../..
+      dockerfile: services/market/Dockerfile
+    container_name: cdb_market
+    restart: unless-stopped
+    secrets:
+      - redis_password
+    environment:
+      ENV: "development"
+      LOG_LEVEL: "INFO"
+      REDIS_HOST: cdb_redis
+      MARKET_PORT: "8009"
+    entrypoint: ["sh", "-c", "export REDIS_PASSWORD=$(cat /run/secrets/redis_password) && exec python -m services.market.service"]
+    ports:
+      - "127.0.0.1:8009:8009"
+    volumes:
+      - ../../logs:/app/logs
+    depends_on:
+      cdb_redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8009/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - cdb_network
+
   # ==================== CONTROL LAYER ====================
   # Evidence: Risk depends on allocation + regime (services/risk/service.py:588-639)
 


### PR DESCRIPTION
## Summary

- Moves `cdb_market` from `compose.red.yml` to `compose.blue.yml`
- Removes `depends_on: cdb_ws` (RED service, not a hard runtime dependency)
- `cdb_market` depends only on `cdb_redis` (already BLUE)

## Why

`cdb_market` is the future owner of `market_state:{symbol}` (per #1201). While in RED, it would create an undeclared RED→BLUE mandatory dependency: `cdb_risk` (BLUE) consumes that key fail-closed. Stopping RED would silently block all trading after the 120s TTL expiry — no obvious error.

Closes #1202. Fulfills Pre-condition P0 for #1201.

## Scope

- `infrastructure/compose/compose.blue.yml` — add `cdb_market` to DATA LAYER
- `infrastructure/compose/compose.red.yml` — remove `cdb_market` block
- No application code changes
- `prometheus.yml`, `rollback.yml` unchanged (stack-agnostic)

## Test plan

- [ ] `docker compose -f compose.blue.yml up -d` — `cdb_market` starts and becomes healthy
- [ ] `curl http://localhost:8009/health` in BLUE-only mode (RED not started) → 200
- [ ] RED start → `cdb_ws` publishes → `market_price:{symbol}` written to Redis
- [ ] RED stop → `cdb_market` stays healthy in BLUE; `cdb_risk` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)