### PR TITLE
fix(digest): auto-close weekly digest issue after create/update

### DIFF
--- a/.github/workflows/weekly_digest.yml
+++ b/.github/workflows/weekly_digest.yml
@@ -409,3 +409,14 @@ jobs:
           echo "Summary: open_items(issues=${open_issue_count}, prs=${open_pr_count}, total=${open_total_count}); now=${now_count}, blocked=${blocked_count}, eingang=${eingang_count}, pr_review=${pr_review_count}"
           echo "Status summary (open): backlog=${status_backlog_count}, ready=${status_ready_count}, in_progress=${status_in_progress_count}, review=${status_review_count}, blocked=${status_blocked_count}, done=${status_done_count}"
           echo "Stage summary (open): proof=${stage_proof_count}, stability=${stage_stability_count}, trade_capable=${stage_trade_count}, strategy_validated=${stage_validated_count}, monetization=${stage_monetization_count}, scale=${stage_scale_count}"
+
+          current_state="$(gh api "repos/${repo}/issues/${issue_number}" --jq '.state')"
+          if [[ "$current_state" == "open" ]]; then
+            gh issue close "${issue_number}" \
+              --repo "${repo}" \
+              --reason "not planned" \
+              --comment "Generated reporting artifact. Closed intentionally to keep the open issue list focused on actionable work. Weekly digest history remains preserved in the issue body/workflow."
+            echo "Digest issue #${issue_number} closed (reporting artifact)."
+          else
+            echo "Digest issue #${issue_number} already closed (state=${current_state}), skipping."
+          fi


### PR DESCRIPTION
## Summary
- Weekly Digest Issues sind reine Reporting-Artefakte, kein Backlog
- Workflow ließ Issues bisher dauerhaft offen → verseuchten das Open-Issue-Board
- Neuer Close-Step am Ende des `run`-Blocks schließt das Issue nach create/update

## Delta
Einzige geänderte Datei: `.github/workflows/weekly_digest.yml` (+11 Zeilen, 0 Deletions)

## Eigenschaften
- **Idempotent**: `gh api ... --jq '.state'` Guard — bereits geschlossene Issues werden übersprungen
- **Kein Datenverlust**: Body, History und Marker bleiben erhalten
- `reason: not planned` + erklärender Comment beim ersten Close
- PAT-Scope `repo` (bereits vorhanden) reicht aus

## Manuell bereinigt (als Teil dieser Maßnahme)
- #1181 (2026-03-16), #1122 (2026-03-09), #1027 (2026-03-02), #940 (2026-02-24) — alle geschlossen

## Test plan
- [ ] `workflow_dispatch` auf `weekly_digest.yml` triggern → Issue wird erstellt/aktualisiert, danach geschlossen
- [ ] Zweiter Lauf: Log zeigt „already closed", kein zweiter Comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)