### PR TITLE
fix(regime): add heartbeat to prevent stale regime_id → RC_001 block (#1213)

### DIFF
--- a/services/regime/config.py
+++ b/services/regime/config.py
@@ -40,6 +40,10 @@ class RegimeConfig:
     atr_high_vol_threshold: float = _required_float("REGIME_ATR_HIGH_VOL_THRESHOLD")
     confirmation_bars: int = _required_int("REGIME_CONFIRMATION_BARS")
 
+    # Heartbeat: re-emit current regime even without a change, to keep signal fresh.
+    # Must be << CANDLE_REGIME_STALENESS_SECONDS (default 300s in cdb_candles/cdb_market).
+    heartbeat_interval_s: int = int(os.getenv("REGIME_HEARTBEAT_INTERVAL_S", "60"))
+
     source_version: str = os.getenv("REGIME_SOURCE_VERSION", "1")
     schema_version: str = "1"
 

--- a/services/regime/service.py
+++ b/services/regime/service.py
@@ -69,6 +69,7 @@ class RegimeService:
         self.current_regime: dict[str, str] = defaultdict(lambda: "UNKNOWN")
         self.candidate_regime: dict[str, str | None] = defaultdict(lambda: None)
         self.candidate_count: dict[str, int] = defaultdict(int)
+        self.last_emitted_ts: dict[str, float] = defaultdict(float)
 
     def connect_redis(self):
         self.redis_client = redis.Redis(
@@ -100,6 +101,8 @@ class RegimeService:
         self.redis_client.xadd(self.config.output_stream, sanitized, maxlen=10000)
         stats["regime_changes"] += 1
         stats["last_regime"] = sanitized
+        key = f"{candle.symbol}:{candle.timeframe}:{candle.venue or ''}"
+        self.last_emitted_ts[key] = time.time()
         logger.info(
             "Regime-Signal: %s %s %s",
             candle.symbol,
@@ -127,6 +130,15 @@ class RegimeService:
         if raw_regime == self.current_regime[key]:
             self.candidate_regime[key] = None
             self.candidate_count[key] = 0
+            # Heartbeat: re-emit unchanged regime so downstream staleness checks pass.
+            # Without this, a stable regime produces no stream entries → _lookup_regime_id
+            # sees a stale ts → returns None → market_state has no regime_id → RC_001 blocks.
+            if (
+                raw_regime != "UNKNOWN"
+                and time.time() - self.last_emitted_ts[key]
+                > self.config.heartbeat_interval_s
+            ):
+                self._emit_regime(candle, raw_regime, adx, atr)
             return
 
         if self.candidate_regime[key] != raw_regime:


### PR DESCRIPTION
## Summary

- **Root cause**: `RegimeService` emittiert Signale nur bei Regime-*Änderung*. Bei stabilem Markt (z.B. 54 Tage `HIGH_VOL_CHAOTIC`) existiert kein neues Signal → `_lookup_regime_id` sieht `ts` aus Wochen → älter als `CANDLE_REGIME_STALENESS_SECONDS=300s` → returns `None` → `market_state` ohne `regime_id` → `decide_trade(regime_id=None)` → RC_001 BLOCK (100% Block-Rate)
- **Fix**: Heartbeat-Mechanismus in `RegimeService._derive_regime()` — bei unverändertem Regime wird nach `REGIME_HEARTBEAT_INTERVAL_S` (default 60s) ein frisches Signal mit aktuellem Candle-ts re-emittiert
- **Scope**: Minimaler Fix, 2 Dateien, kein Gate-Loosening

## Geänderte Dateien

- `services/regime/config.py`: `heartbeat_interval_s` Config-Parameter (Env: `REGIME_HEARTBEAT_INTERVAL_S`, Default: `60`)
- `services/regime/service.py`: `last_emitted_ts` Dict, Tracking in `_emit_regime`, Heartbeat-Logik in `_derive_regime`

## Validierung

- Heartbeat nach ~90s bestätigt: frisches Signal in `stream.regime_signals` (ts=1773917220)
- `market_state:BTCUSDT` enthält `regime_id: 2` (HIGH_VOL_CHAOTIC)
- `decide_trade` blockt weiterhin korrekt wegen `regime_id=2` (by design), nicht mehr wegen stale Signal
- 833 Unit-Tests pass, ruff + black clean

## Test plan

- [ ] `cdb_regime` rebuild + restart → nach ≤90s erscheint Heartbeat-Eintrag in `stream.regime_signals`
- [ ] `market_state:{symbol}` enthält `regime_id` (kein fehlender Key mehr)
- [ ] Bei Regime-Wechsel feuert Heartbeat sofort (nicht erst nach 60s)
- [ ] `REGIME_HEARTBEAT_INTERVAL_S` ist konfigurierbar (z.B. für Tests auf 5 setzen)

Closes #1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)