### PR TITLE
docs(governance): upgrade LR-010 evidence status to PASS

### DIFF
--- a/docs/live-readiness/LR-010-EVIDENCE.md
+++ b/docs/live-readiness/LR-010-EVIDENCE.md
@@ -1,8 +1,9 @@
 # LR-010 Evidence: Risk Engine Deterministic Unit Test Coverage
 
 **Issue:** #779
-**Status:** IMPLEMENTED
+**Status:** PASS
 **Date:** 2026-03-19
+**PASS confirmed:** 2026-03-19
 
 ## Ziel
 
@@ -63,7 +64,18 @@ pytest --collect-only -q tests/unit/risk tests/unit/verlosung
 
 IMPLEMENTED ist gerechtfertigt, wenn die oben genannten control-spezifischen Testanker vorhanden sind und im CI-Pfad liegen.
 
-PASS würde zusätzlich einen bestätigten grünen CI-Run mit nachvollziehbarer Referenz erfordern, zum Beispiel Run-URL, Run-ID oder Merge-Commit-Nachweis auf main. Dieses Dokument beansprucht PASS ohne diesen Nachweis ausdrücklich nicht.
+PASS erfordert einen bestätigten grünen CI-Run mit nachvollziehbarer Referenz auf main.
+
+**PASS-Referenz (verifiziert 2026-03-19):**
+
+- Run ID: `23295248170`
+- Commit: `e164abe474c64981036ceee86222b7db95e48e32`
+- Branch: `main`
+- Job: `ci (Unit/Integration + Lint gesammelt)` — conclusion: `success`
+- Step: `Tests` (`pytest -q -k "not test_mcp_time_server_runtime"`) — conclusion: `success`
+- URL: https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/23295248170
+
+Alle LR-010-Testanker liegen im `tests/unit/risk/` und `tests/unit/verlosung/` Pfad, der vom obigen CI-Run ohne Directory-Exclusion ausgeführt wurde.
 
 ## Go/No-Go Relevanz
 

--- a/governance/p5_canary_readiness.yaml
+++ b/governance/p5_canary_readiness.yaml
@@ -19,15 +19,14 @@ required_controls:
     allowed_statuses: [IMPLEMENTED, PASS]
     hard_gate: true
   - id: LR-010
-    status: IMPLEMENTED
+    status: PASS
     evidence_path: docs/live-readiness/LR-010-EVIDENCE.md
     evidence_note: >
-      Control-specific evidence created 2026-03-19. Test anchors in
-      tests/unit/risk/ and tests/unit/verlosung/ cover circuit-breaker
-      thresholds, approve/reject paths, position sizing, stop-loss generation,
-      and edge cases. Tests are in CI path (pytest -q, no directory exclusion).
-      IMPLEMENTED: anchors present and in CI path.
-      PASS requires confirmed green CI run with verifiable reference.
+      PASS confirmed 2026-03-19. CI run 23295248170, commit e164abe474c6,
+      branch main, job ci (Unit/Integration + Lint gesammelt): success.
+      Test anchors in tests/unit/risk/ and tests/unit/verlosung/ cover
+      circuit-breaker thresholds, approve/reject paths, position sizing,
+      stop-loss generation, and edge cases.
     allowed_statuses: [IMPLEMENTED, PASS]
     hard_gate: true
   - id: LR-020


### PR DESCRIPTION
## What changed

- `docs/live-readiness/LR-010-EVIDENCE.md`
  - Status upgraded from `IMPLEMENTED` to `PASS`
  - Added verified CI reference for PASS:
    - Run ID: `23295248170`
    - Commit: `e164abe474c64981036ceee86222b7db95e48e32`
    - Branch: `main`
    - Job: `ci (Unit/Integration + Lint gesammelt)` — `success`
    - Step: `Tests` (`pytest -q -k "not test_mcp_time_server_runtime"`) — `success`
    - URL: https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/23295248170

- `governance/p5_canary_readiness.yaml`
  - LR-010 status updated from `IMPLEMENTED` to `PASS`
  - Evidence note aligned to the verified CI reference above

## Why this is a separate PR

This is a minimal governance/evidence status upgrade only.
It is intentionally separated from prior monitoring and governance-sync PRs.

## What this does NOT change

- No service behavior
- No runtime config
- No compose files
- No P5 canary run evidence
- No LR-040 soak PASS claim