### PR TITLE
[GOVERNANCE] Define status SSOT taxonomy for repo/ops status

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -1,6 +1,10 @@
 # Current Status
 
-## Ops Status (2026-02-21)
+**Status Class**: Working Repo / Engineering Status
+**Authority**: Current repo/main/test/dependency snapshot; not the canonical live-readiness or Echtgeld Go/No-Go source.
+**Operational Canon**: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+
+## Repo / Engineering Status (2026-02-21)
 
 - **main**: green, 0 open PRs (backlog cleanup: 30 → 0)
 - **Dependencies**: Dependabot OK, last merged: #897 Flask 3.1.3

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,13 +1,19 @@
 # Claire de Binare - Project Status
 
 **Last Updated**: 2026-01-15
+**Status Class**: Historical / Audit Snapshot
 **Status Type**: Service Implementation Audit (historical snapshot from 2026-01-15)
+**Authority**: Historical service implementation audit only; not the current live-readiness verdict and not the current repo/main/test status.
+**Operational Canon**: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+**Working Repo Canon**: `CURRENT_STATUS.md`
 **Related Issue**: #148
 **Auditor**: Claude Code (autonomous)
 
 ---
 
 ## Executive Summary
+
+This section preserves the 2026-01-15 audit viewpoint. Do not read it as the current project-wide operational or engineering status.
 
 **Overall Project Health**: 🟢 **STRONG**
 
@@ -21,7 +27,7 @@ Claire de Binare demonstrates mature service architecture with **9 containerized
 - Test Coverage: **80%+ requirement** enforced
 - CI/CD Pipeline: ✅ Complete with delivery gate
 
-**Status**: Ready for Shadow Mode validation (all blockers resolved)
+**Historical Audit Verdict**: Ready for Shadow Mode validation (all blockers resolved on 2026-01-15)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@ Welcome to the Claire de Binare repository. This project is a complex system for
 ---
 ## 🚦 Live Readiness (Operational Gate)
 
-**Status:** ✅ **LIVE-READY**  
-**Gate:** PASSED (LR-001 → LR-007 vollständig abgeschlossen)
+**Status:** ❌ **NO-GO**<br>
+**Canonical source:** `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
 
-- **Completion:** ★★★★★ **100 %**
-- **Tasks:** 7 / 7 DONE · 0 BLOCKED
-- **Validator:** `python scripts/lr004_completion_guard.py --check` → **PASS**
-- **Last verified:** 2026-02-10 15:50 CET
-- **Commit:** `27d2f4b9cda518821ae855009db68793cd9656cf`
+- **Scope basis:** `ROADMAP.yaml` + `LR-001..LR-007-STATE.yaml` + aktuelle GitHub-LR-Issues
+- **Last reconciliation:** 2026-03-15
+- **Roadmap status:** `P0` DONE, `P1` bis `P5` nicht abgeschlossen
+- **Human gate:** Keine Echtgeld-Freigabe ohne vollstaendige Evidenz und explizite menschliche Freigabe
 
-**Interpretation (bindend):**  
-Das System ist **betriebsfähig**, **governance-konform**, **fail-closed**, **recovery-fähig** und kann im Shadow / Live-Betrieb laufen.  
-Es gibt **keine offenen Blocker** für den operativen Einsatz.
+**Einordnung:**<br>
+`CURRENT_STATUS.md` beschreibt den aktuellen Repo-/Main-/Testzustand.<br>
+`PROJECT_STATUS.md` ist ein historischer Implementierungs-Snapshot und kein operativer Go/No-Go-Status.<br>
+`knowledge/CURRENT_STATUS.md` ist nur ein historischer Knowledge-Snapshot und keine aktuelle Repo-/Ops-Quelle.
 
 ---
 
@@ -38,9 +38,10 @@ Er ist **kein Maß für Betriebsreife** und **kein Release-Gate**.
 
 ### Kurzfassung (fuer Leser mit wenig Zeit)
 
-- **Live Readiness:** NO-GO (Post-Migration, BLUE+RED canonical runtime)
+- **Live Readiness:** NO-GO (siehe `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`)
 - **Systemstatus:** Runtime migriert auf BLUE+RED; base.yml + dev.yml sind CI/Legacy-only
-- **Offene Issues:** betreffen Ausbau, nicht Betrieb
+- **Repo-/Teststatus:** siehe `CURRENT_STATUS.md`
+- **Historischer Implementierungsstand:** siehe `PROJECT_STATUS.md` (historischer Snapshot)
 
 ---
 
@@ -269,6 +270,6 @@ See **[DEVELOPER_ONBOARDING.md](DEVELOPER_ONBOARDING.md)** for detailed troubles
 
 - **Setup Guide**: [DEVELOPER_ONBOARDING.md](DEVELOPER_ONBOARDING.md) - Comprehensive onboarding
 - **Service Status**: [PROJECT_STATUS.md](PROJECT_STATUS.md) - Service implementation audit
-- **Governance**: [Governance Audit](governance-audit-2026-01-15.md) - Governance compliance
+- **Governance**: [Governance Audit](governance-audit-2026-01-15.md) - Historical governance audit snapshot
 - **Agent Registry**: [agents/AGENTS.md](agents/AGENTS.md) - Local agent entrypoint
 - **Policies**: `knowledge/governance/` - Canonical governance and policy documents

--- a/agents/CLAUDE.md
+++ b/agents/CLAUDE.md
@@ -4,10 +4,13 @@
 Claude **muss** zu Beginn jeder Session folgende Dateien lesen:
 - agents/AGENTS.md
 - knowledge/SYSTEM.CONTEXT.md
-- knowledge/CURRENT_STATUS.md
+- CURRENT_STATUS.md
+- docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md
 - knowledge/ACTIVE_ROADMAP.md
 
-Diese Dateien sind die **autoritative Quelle** für Kontext, Status und Governance.
+Diese Dateien sind die **autoritative Einstiegskette** für Kontext, Governance
+und die getrennten Statusrollen. `knowledge/CURRENT_STATUS.md` bleibt nur
+historischer Kontext.
 
 ---
 
@@ -89,7 +92,8 @@ Wenn das Verständnis falsch ist:
 ### Session-Ende (Pflicht)
 Keine Session gilt als abgeschlossen, bevor nicht:
 - eine Session-Datei gepflegt ist
-- `knowledge/CURRENT_STATUS.md` aktualisiert wurde
+- `CURRENT_STATUS.md` aktualisiert wurde, wenn sich der Repo-/Engineering-Status
+  geaendert hat
 - Blocker benannt oder gelöst sind
 
 ---
@@ -278,12 +282,15 @@ Keine Architektur-/Prozessdokumente außerhalb `/knowledge`.
 
 ## 10. Dateistatus
 Lebendig:
-- knowledge/CURRENT_STATUS.md
+- CURRENT_STATUS.md
 - knowledge/logs/sessions/*.md
 
 Stabil:
 - knowledge/SYSTEM.CONTEXT.md
 - knowledge/ACTIVE_ROADMAP.md
+
+Historischer Kontext:
+- knowledge/CURRENT_STATUS.md
 
 ---
 

--- a/agents/roles/CLAUDE.md
+++ b/agents/roles/CLAUDE.md
@@ -4,10 +4,13 @@
 Claude **muss** zu Beginn jeder Session folgende Dateien lesen:
 - agents/AGENTS.md
 - knowledge/SYSTEM.CONTEXT.md
-- knowledge/CURRENT_STATUS.md
+- CURRENT_STATUS.md
+- docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md
 - knowledge/ACTIVE_ROADMAP.md
 
-Diese Dateien sind die **autoritative Quelle** für Kontext, Status und Governance.
+Diese Dateien sind die **autoritative Einstiegskette** für Kontext, Governance
+und die getrennten Statusrollen. `knowledge/CURRENT_STATUS.md` bleibt nur
+historischer Kontext.
 
 ---
 
@@ -89,7 +92,8 @@ Wenn das Verständnis falsch ist:
 ### Session-Ende (Pflicht)
 Keine Session gilt als abgeschlossen, bevor nicht:
 - eine Session-Datei gepflegt ist
-- `knowledge/CURRENT_STATUS.md` aktualisiert wurde
+- `CURRENT_STATUS.md` aktualisiert wurde, wenn sich der Repo-/Engineering-Status
+  geaendert hat
 - Blocker benannt oder gelöst sind
 
 ---
@@ -278,12 +282,15 @@ Keine Architektur-/Prozessdokumente außerhalb `/knowledge`.
 
 ## 10. Dateistatus
 Lebendig:
-- knowledge/CURRENT_STATUS.md
+- CURRENT_STATUS.md
 - knowledge/logs/sessions/*.md
 
 Stabil:
 - knowledge/SYSTEM.CONTEXT.md
 - knowledge/ACTIVE_ROADMAP.md
+
+Historischer Kontext:
+- knowledge/CURRENT_STATUS.md
 
 ---
 

--- a/docs/meta/WORKING_REPO_CANON.md
+++ b/docs/meta/WORKING_REPO_CANON.md
@@ -22,7 +22,28 @@ Das alte Docs-Hub-Material ist nur noch:
 | Knowledge hub | `knowledge/` |
 | GitHub templates / community docs | `.github/` |
 | Navigation / runbooks / archive | `docs/` |
-| Root entrypoints | `README.md`, `AGENTS.md`, `CDB_CONSTITUTION.md`, `CDB_GOVERNANCE.md` |
+| Root entrypoints | `README.md`, `AGENTS.md`, `CDB_CONSTITUTION.md`, `CDB_GOVERNANCE.md`, `CURRENT_STATUS.md`, `PROJECT_STATUS.md` |
+
+## Status SSOT Rule
+
+Status im Working Repo ist absichtlich rollenspezifisch und nicht in einer
+einzigen generischen "Current Status"-Datei gebuendelt.
+
+| Status class | Canonical source | Rule |
+| --- | --- | --- |
+| Operational / live-readiness status | `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` | Autoritative Quelle fuer aktuellen Go/No-Go-Status und operative Live-Readiness-Blocker |
+| Working repo / engineering status | `CURRENT_STATUS.md` | Autoritative Quelle fuer aktuellen Repo-, Main-, Test- und aktiven Arbeitsstatus |
+| Historical implementation / audit snapshots | `PROJECT_STATUS.md`, `knowledge/CURRENT_STATUS.md` | Nur punktuelle historische Snapshots; keine aktuelle operative oder repo-weite Wahrheit |
+| Evidence / milestone / governance reports | z. B. `governance-audit-2026-01-15.md`, `CODEX_RUN_REPORT.md`, `docs/governance/status/` | Nachweis-, Audit- oder Milestone-Artefakte; nicht-kanonisch fuer aktuellen Gesamtstatus |
+
+## Status Usage Rules
+
+- `README.md` bleibt Front Door und darf Status nur zusammenfassen oder auf die
+  jeweilige kanonische Quelle verweisen.
+- Statusdateien mit historischem oder sekundaerem Charakter muessen ihren
+  Status-Typ explizit kennzeichnen.
+- Neue Reports, Pass-Reports oder Audit-Snapshots duerfen scope-lokale Findings
+  dokumentieren, aber nicht als aktuelle repo-weite Wahrheit auftreten.
 
 ## Internal Redirect Map
 
@@ -40,6 +61,8 @@ Das alte Docs-Hub-Material ist nur noch:
 - Navigation, guards and scripts must prefer local repo paths.
 - References to the retired external docs repo are legacy-only and must not be the default path.
 - Pointer files may exist at root for discoverability, but they must resolve internally.
+- Status-bearing docs must declare whether they are `operational`, `working-repo`, `historical snapshot`, or `scoped evidence` whenever ambiguity is plausible.
+- No secondary file may override or restate the current repo-wide operational verdict independently of the canonical live-readiness source.
 
 ## Legacy Archive
 

--- a/knowledge/ACTIVE_ROADMAP.md
+++ b/knowledge/ACTIVE_ROADMAP.md
@@ -9,9 +9,10 @@ start. It now resolves only to local working-repo sources.
 
 ## Canonical Locations
 
-- Primary status: `knowledge/CURRENT_STATUS.md`
+- Working repo / engineering status: `CURRENT_STATUS.md`
+- Operational live-readiness status: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- Historical knowledge snapshot: `knowledge/CURRENT_STATUS.md` (context only)
 - Detailed plans: `knowledge/roadmap/`
-- Live-readiness tracking: `docs/live-readiness/`
 - Canon and archive policy: `docs/meta/WORKING_REPO_CANON.md`
 
 ## Current Focus

--- a/knowledge/CURRENT_STATUS.md
+++ b/knowledge/CURRENT_STATUS.md
@@ -1,13 +1,17 @@
-# Claire de Binare - Current Status
+# Claire de Binare - Current Status (Historical Knowledge Snapshot)
 
+**Status Class:** Historical / Knowledge Snapshot
+**Snapshot Scope:** Legacy knowledge-hub working snapshot
 **Last Updated:** 2026-01-10 18:30 CET
+**Authority:** Historical context only. This file is not the current live-readiness verdict and not the current repo/main/test status.
+**Current Canonical Sources:** `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` (operational live readiness), `CURRENT_STATUS.md` (working repo / engineering status)
 **Branch:** main
 **Latest Commit:** 94488ca
 **Session:** Risk Position Sizing Fix + Order Observability
 
 ---
 
-## System Status: NO-GO (Post-Migration)
+## Historical Snapshot Status: NO-GO (Post-Migration)
 
 **Runtime:** BLUE+RED canonical (compose.blue.yml + compose.red.yml)
 **Trading Pipeline:** STABLE END-TO-END

--- a/knowledge/GOVERNANCE_QUICKREF.md
+++ b/knowledge/GOVERNANCE_QUICKREF.md
@@ -63,7 +63,9 @@ Must not:
 
 ## 7. Session-End Minimum
 
-- update `knowledge/CURRENT_STATUS.md` when needed
+- update `CURRENT_STATUS.md` when repo/main/test/dependency status materially changes
+- update `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` only when the operational Go/No-Go verdict or its gating evidence changes
+- update `knowledge/CURRENT_STATUS.md` only for historical snapshot maintenance or context backfill
 - leave evidence in local issue, report, or knowledge paths
 - state blockers explicitly
 - do not offload the final state to an external docs repo

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -11,7 +11,9 @@ reviews, and evidence that must stay close to the working codebase.
 ## Key Entry Points
 
 - `knowledge/CDB_KNOWLEDGE_HUB.md`
-- `knowledge/CURRENT_STATUS.md`
+- `CURRENT_STATUS.md` (working repo / engineering status)
+- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` (operational live-readiness status)
+- `knowledge/CURRENT_STATUS.md` (historical knowledge snapshot)
 - `knowledge/SYSTEM.CONTEXT.md`
 - `knowledge/ACTIVE_ROADMAP.md`
 - `knowledge/governance/`

--- a/knowledge/SESSION_HANDOFF.md
+++ b/knowledge/SESSION_HANDOFF.md
@@ -201,7 +201,9 @@ gh run list --branch main --limit 5
 5. **Clean commits**: Conventional Commits Format + Co-Authored-By Footer
 
 **Referenzen**:
-- `knowledge/CURRENT_STATUS.md` - Live System Status
+- `CURRENT_STATUS.md` - Working repo / engineering status
+- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` - Operativer Live-Readiness / Go-No-Go-Status
+- `knowledge/CURRENT_STATUS.md` - Historischer Knowledge-Snapshot
 - `D:\Dev\Workspaces\Repos\Claire_de_Binare\agents\AGENTS.md` - Governance Rules
 - `D:\Dev\Workspaces\Repos\Claire_de_Binare\agents\CLAUDE.md` - Session Lead Role
 - `.orchestrator_issue_355_analysis.md` - CI/CD Analysis

--- a/knowledge/SYSTEM.CONTEXT.md
+++ b/knowledge/SYSTEM.CONTEXT.md
@@ -26,7 +26,9 @@ historical material is needed, use the local archive snapshot under
 
 - `agents/AGENTS.md` local agent registry and read order
 - `knowledge/CDB_KNOWLEDGE_HUB.md` knowledge hub and key operating links
-- `knowledge/CURRENT_STATUS.md` current system state and open priorities
+- `CURRENT_STATUS.md` current working repo / engineering status
+- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` current operational live-readiness verdict
+- `knowledge/CURRENT_STATUS.md` historical knowledge snapshot and older open-priority context
 - `knowledge/ACTIVE_ROADMAP.md` consolidated roadmap entrypoint
 - `docs/meta/WORKING_REPO_CANON.md` canon decision and archive policy
 

--- a/knowledge/content/ONBOARDING_LINKS.md
+++ b/knowledge/content/ONBOARDING_LINKS.md
@@ -13,9 +13,10 @@
 Claire_de_Binare/
 ├── CLAUDE.md                    ← Session Lead governance
 ├── README.md                    ← Project overview (add onboarding section)
+├── CURRENT_STATUS.md            ← Working repo / engineering status
 ├── knowledge/                   ← Knowledge base (canonical docs)
 │   ├── SYSTEM.CONTEXT.md       ← Architecture, data flow
-│   ├── CURRENT_STATUS.md       ← Latest status, active sprint
+│   ├── CURRENT_STATUS.md       ← Historical knowledge snapshot
 │   └── roadmap/
 │       └── EXPANDED_ECOSYSTEM_ROADMAP.md  ← Milestones, timeline
 ├── agents/
@@ -38,7 +39,7 @@ Claire_de_Binare/
 ## 🎯 Quick Navigation
 
 ### New Developer? Start Here:
-1. `README.md` -> [`CURRENT_STATUS.md`](../CURRENT_STATUS.md) -> [`COMPOSE_LAYERS.md`](../../infrastructure/compose/COMPOSE_LAYERS.md) -> [`QUICK_START.md`](../../infrastructure/docs/QUICK_START.md) (current entry chain)
+1. `README.md` -> [`CURRENT_STATUS.md`](../../CURRENT_STATUS.md) -> [`LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md) -> [`COMPOSE_LAYERS.md`](../../infrastructure/compose/COMPOSE_LAYERS.md) -> [`QUICK_START.md`](../../infrastructure/docs/QUICK_START.md) (current entry chain)
 2. [knowledge/SYSTEM.CONTEXT.md](../SYSTEM.CONTEXT.md) (architecture)
 3. [TEST_HARNESS_V1.md](TEST_HARNESS_V1.md) (how to test)
 
@@ -49,8 +50,9 @@ Claire_de_Binare/
 
 ### Fixing Bugs? See:
 1. 📄 [PATCHSET_PLAN_345.md](PATCHSET_PLAN_345.md) (example workflow)
-2. 📄 [knowledge/CURRENT_STATUS.md](../knowledge/CURRENT_STATUS.md) (known issues)
-3. 📄 [TEST_HARNESS_V1.md](TEST_HARNESS_V1.md) (testing strategy)
+2. 📄 [CURRENT_STATUS.md](../../CURRENT_STATUS.md) (current repo / engineering status)
+3. 📄 [knowledge/CURRENT_STATUS.md](../CURRENT_STATUS.md) (historical context and older known issues)
+4. 📄 [TEST_HARNESS_V1.md](TEST_HARNESS_V1.md) (testing strategy)
 
 ---
 
@@ -81,7 +83,8 @@ Claire_de_Binare/
 | Document | Purpose | Location |
 |----------|---------|----------|
 | PATCHSET_PLAN_345.md | Example fix workflow | `/docs/PATCHSET_PLAN_345.md` |
-| CURRENT_STATUS.md | Latest sprint status | `/knowledge/CURRENT_STATUS.md` |
+| CURRENT_STATUS.md | Working repo / engineering status | `/CURRENT_STATUS.md` |
+| knowledge/CURRENT_STATUS.md | Historical knowledge snapshot | `/knowledge/CURRENT_STATUS.md` |
 | requirements-dev.txt | Dev dependencies | `/requirements-dev.txt` |
 
 ### Infrastructure

--- a/knowledge/content/ONBOARDING_QUICK_START.md
+++ b/knowledge/content/ONBOARDING_QUICK_START.md
@@ -10,7 +10,7 @@
 ## 🎯 Essential Reading (30 min)
 
 ### 1. README + Current Entry Chain (5 min)
-📍 **Start:** `README.md` then [`CURRENT_STATUS.md`](../CURRENT_STATUS.md), [`COMPOSE_LAYERS.md`](../../infrastructure/compose/COMPOSE_LAYERS.md), [`QUICK_START.md`](../../infrastructure/docs/QUICK_START.md)
+📍 **Start:** `README.md` then [`CURRENT_STATUS.md`](../../CURRENT_STATUS.md), [`LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md), [`COMPOSE_LAYERS.md`](../../infrastructure/compose/COMPOSE_LAYERS.md), [`QUICK_START.md`](../../infrastructure/docs/QUICK_START.md)
 **What:** Project overview, current runtime model, canonical compose layers, getting started
 
 ### 2. System Context (5 min)
@@ -18,8 +18,9 @@
 **What:** Architecture, components, data flow
 
 ### 3. Current Status (3 min)
-📍 **Location:** `knowledge/CURRENT_STATUS.md`
-**What:** Latest sprint, resolved issues, active work
+📍 **Location:** `CURRENT_STATUS.md` + `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+**What:** Current repo/test/engineering status plus the current operational Go/No-Go verdict
+**Historical context only:** `knowledge/CURRENT_STATUS.md`
 
 ### 4. Roadmap (10 min)
 📍 **Location:** `knowledge/roadmap/EXPANDED_ECOSYSTEM_ROADMAP.md`
@@ -137,7 +138,7 @@ docker ps --filter "name=cdb_"
 ## 🤝 Getting Help
 
 ### Documentation Issues
-- Check `knowledge/CURRENT_STATUS.md` for latest updates
+- Check `CURRENT_STATUS.md` and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for the latest status
 - Review relevant runbook in `docs/services/`
 - Search GitHub issues for keywords
 

--- a/knowledge/roadmap/EXPANDED_ECOSYSTEM_ROADMAP.md
+++ b/knowledge/roadmap/EXPANDED_ECOSYSTEM_ROADMAP.md
@@ -5,7 +5,9 @@ Scope: roadmap entrypoint after Docs-Hub consolidation
 
 ## Canonical Inputs
 
-- `knowledge/CURRENT_STATUS.md` for the live status line
+- `CURRENT_STATUS.md` for the current working repo / engineering status line
+- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for the current operational Go/No-Go line
+- `knowledge/CURRENT_STATUS.md` for historical status context only
 - `knowledge/ACTIVE_ROADMAP.md` for active priorities
 - `knowledge/roadmap/M7_TESTNET_PLAN.md`
 - `knowledge/roadmap/M8_SECURITY_PLAN.md`
@@ -21,10 +23,12 @@ changes, evidence, and planning can be reviewed together.
 ## Reading Order
 
 1. `knowledge/ACTIVE_ROADMAP.md`
-2. `knowledge/CURRENT_STATUS.md`
-3. `knowledge/roadmap/M7_TESTNET_PLAN.md`
-4. `knowledge/roadmap/M8_SECURITY_PLAN.md`
-5. `knowledge/roadmap/M9_RELEASE_PLAN.md`
+2. `CURRENT_STATUS.md`
+3. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+4. `knowledge/CURRENT_STATUS.md` (historical context only)
+5. `knowledge/roadmap/M7_TESTNET_PLAN.md`
+6. `knowledge/roadmap/M8_SECURITY_PLAN.md`
+7. `knowledge/roadmap/M9_RELEASE_PLAN.md`
 
 ## Legacy Note
 


### PR DESCRIPTION
## Summary
- define an explicit status SSOT rule and taxonomy in the working-repo canon
- reclassify current vs historical status documents to remove competing repo-wide truth claims
- update active bootstrap/onboarding pointers so they route to the correct status class

## Scope
- focused on issue #1232 only
- no report migration, archive cleanup, or runbook consolidation

## Verification
- checked README, CURRENT_STATUS.md, PROJECT_STATUS.md, knowledge/CURRENT_STATUS.md, and the LR audit for logical consistency
- ran git diff --check

Refs #1232