### PR TITLE
fix(alerting): add relativeTimeRange to provisioned alert rules (#1227)

### DIFF
--- a/infrastructure/monitoring/grafana/provisioning/alerting/circuit_breaker.yml
+++ b/infrastructure/monitoring/grafana/provisioning/alerting/circuit_breaker.yml
@@ -13,6 +13,9 @@ groups:
         condition: C
         data:
           - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
             datasourceUid: prometheus
             model:
               datasource:

--- a/infrastructure/monitoring/grafana/provisioning/alerting/high_error_rate.yml
+++ b/infrastructure/monitoring/grafana/provisioning/alerting/high_error_rate.yml
@@ -13,6 +13,9 @@ groups:
         condition: C
         data:
           - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
             datasourceUid: prometheus
             model:
               datasource:

--- a/infrastructure/monitoring/grafana/provisioning/alerting/orders_rejected.yml
+++ b/infrastructure/monitoring/grafana/provisioning/alerting/orders_rejected.yml
@@ -13,6 +13,9 @@ groups:
         condition: C
         data:
           - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
             datasourceUid: prometheus
             model:
               datasource:


### PR DESCRIPTION
## Problem

Grafana 10+ requires `relativeTimeRange` on every alert query data item. Without it, Grafana crashes on startup with:

```
Failed to provision alerting: invalid alert rule query A: invalid relative time range [From: 0s, To: 0s]
```

All three CDB alert provisioning files were missing this field. Additionally, the stale UI-managed alert `CDB - High Error Rate (>5%)` in folder `Claire de Binare` used UID `cdb_error_rate_high` — same as the file-provisioned version — causing a provenance conflict that also blocked startup.

## Fix

Added `relativeTimeRange` to all three provisioned alert rule files:

| File | from | to | Reason |
|------|------|----|--------|
| `circuit_breaker.yml` | 300s | 0 | 1m interval, instant metric |
| `orders_rejected.yml` | 600s | 0 | 5m interval, `[5m]` range query |
| `high_error_rate.yml` | 600s | 0 | 5m interval, `[5m]` range query |

Stale UI-managed rules in `Claire de Binare` folder were deleted via Grafana API before re-enabling provisioning.

## Verified live

After fix, all 3 rules active with `provenance=file` in `CDB Alerts`:
- `cdb-circuit-breaker-activated`
- `cdb-orders-rejected`
- `cdb_error_rate_high`

No more `DatasourceError` or startup crashes.

## Changed files

- `infrastructure/monitoring/grafana/provisioning/alerting/circuit_breaker.yml` (+3 lines)
- `infrastructure/monitoring/grafana/provisioning/alerting/high_error_rate.yml` (+3 lines)
- `infrastructure/monitoring/grafana/provisioning/alerting/orders_rejected.yml` (+3 lines)

Closes #1227