### PR TITLE
docs(sessions): update #1266/#1267 log with rollback note and decision matrix

### DIFF
--- a/knowledge/logs/sessions/2026-03-24-alerting-1266-1267.md
+++ b/knowledge/logs/sessions/2026-03-24-alerting-1266-1267.md
@@ -1,7 +1,7 @@
 # Session Log: 2026-03-24 — Grafana DatasourceError Fix #1266 #1267
 
 **Datum:** 2026-03-24
-**Status:** CLOSED
+**Status:** REOPENED — Fix-Rollback (Grafana 11.4.7 Provisioning-Inkompatibilität)
 **Issues:**
 - #1266 — [ALERTING][GRAFANA] Orders-Rejected-Alert scheitert an Prometheus-Zielauflösung über DNS-Host `cdb_prometheus`
 - #1267 — [ALERTING][GRAFANA] High-Error-Rate-Alert scheitert ebenfalls als DatasourceError wegen nicht auflösbarem Prometheus-Host `cdb_prometheus`
@@ -111,3 +111,34 @@ f22ad9f fix(alerting): suppress noisy DatasourceError mails on prometheus restar
   und nicht Teil dieses Fixes.
 - Ein echter, langfristiger Prometheus-Ausfall würde jetzt nicht durch diese Alert-Regeln
   gemeldet. Dafür wäre ein separater Prometheus-Health-Alert nötig (nicht Scope dieses Issues).
+
+---
+
+## Nachtrag 2026-03-24 — Fix-Rollback (PR #1273 operativer Cleanup)
+
+**Problem beim Aktivieren:** `KeepLastState` wird von Grafana 11.4.7-ubuntu im
+Provisioning-YAML-Parser **nicht akzeptiert**:
+```
+failure parsing rules: rule 'CDB - Orders Rejected' failed to parse:
+unknown Error state option KeepLastState
+```
+Grafana startet nicht (Restart-Loop). Der Wert ist in der Grafana HTTP API als gültig
+dokumentiert (`ExecutionErrorState` enum), aber der Provisioning-Pfad dieser Version
+kennt ihn nicht.
+
+**Aktion:** `execErrState: KeepLastState` → `execErrState: Error` zurückgerollt.
+Commit: `77e4a79 revert(alerting): revert KeepLastState — not supported by Grafana 11.4.7-ubuntu`
+
+**Issues:** #1266 und #1267 reopened. Root Cause korrekt diagnostiziert, Implementierung blockiert.
+
+**Offene Lösungsoptionen (Entscheidungsvorlage):**
+
+| Option | Aufwand | Risiko | Empfehlung |
+|---|---|---|---|
+| A) Grafana-Image-Upgrade auf kompatible Version (z.B. latest) | mittel | niedrig (Provisioning-YAML bleibt unverändert) | **Bevorzugt** — löst das Problem sauber |
+| B) Alertmanager-Routing: separate Route für `alertname=DatasourceError` → dedizierter Receiver (z.B. silence/low-prio-mail) | mittel | niedrig | Alternative wenn Grafana-Version nicht angehoben werden soll |
+| C) `execErrState: Alerting` statt `Error` | minimal | mittel (würde als normaler Alert feuern, nicht als DatasourceError — immer noch noisy) | Nicht empfohlen |
+
+**Empfehlung:** Option A (Grafana-Version prüfen/hochstufen). Nach Upgrade kann der Fix aus PR #1273
+(f22ad9f) direkt reaktiviert werden. Option B ist sinnvoll als unabhängige Verbesserung
+(DatasourceError-Routing), ersetzt aber nicht Option A.


### PR DESCRIPTION
## Summary

- Updates session log `knowledge/logs/sessions/2026-03-24-alerting-1266-1267.md`
- Documents Grafana 11.4.7-ubuntu provisioning incompatibility with `KeepLastState`
- Records fix rollback and reopen of #1266/#1267
- Adds three-option decision matrix for the real fix path

Docs-only, no code changes.