### PR TITLE
devops(gitignore): fix test/evidence tracking and remove dead ignore rules (#1234)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 # Allow official test suite in tests/ directory (must come AFTER wildcard)
 !tests/**/*.py
 !tests/**/*.js
+!cdb_agent_sdk/tests/**/*.py
+!cdb_agent_sdk/tests/**/*.js
 debug_*.py
 simple_test.*
 quick_test.*
@@ -62,6 +64,7 @@ logs
 !knowledge/logs/
 !knowledge/logs/**
 *.log
+!docs/runbooks/evidence/**/*.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
@@ -123,6 +126,7 @@ docker-compose.dev.yml
 # Coverage
 coverage/
 *.lcov
+.coverage
 
 # Dependencies  
 node_modules/
@@ -136,13 +140,6 @@ Claire_de_Binare_Docs/
 .claude/
 .gemini/
 gha-creds-*.json
-
-# Historical root scripts guard. Keep semantics stable until a dedicated
-# scripts-policy cleanup removes the need for broad ignore + negation logic.
-/scripts/
-# LR-003 Contract Drift Guard (P0) - must be versioned
-!scripts/
-!scripts/lr003_contract_drift_guard.py
 
 # Auto Claude data directory
 .auto-claude/


### PR DESCRIPTION
## Summary

Follow-up to #1234. The previous branch (`chore/issue-1234-gitignore-artifact-policy`) had the right intent but was not mergeable: it removed the `!knowledge/logs/` negation (regression), added noise rules from Gemini/Codex contamination, and contained spurious comments. The positive parts of that branch were already present on `main`. This PR applies the four remaining concrete fixes cleanly.

- **Δ1** — Add `!cdb_agent_sdk/tests/**/*.py|js` negations. The broad `*test*.py` rule was silently swallowing real test files in `cdb_agent_sdk/tests/`. The existing `!tests/**/*.py` negation only covers the root `tests/` path.
- **Δ2** — Add `!docs/runbooks/evidence/**/*.log` after the `*.log` wildcard. Evidence logs under the canonical `docs/runbooks/evidence/` path were invisible to git, contradicting the Local-Artifact-Policy.
- **Δ3** — Remove the dead `/scripts/` + `!scripts/` + `!scripts/lr003…` block. The directory was ignored and immediately re-included — a no-op. `scripts/cdb_ops.ps1` remains protected via its own direct rule.
- **Δ4** — Add `.coverage` to the Coverage section. Previously only in `.git/info/exclude`.

**Note:** The earlier branch `chore/issue-1234-gitignore-artifact-policy` is intentionally not merged. It contains regressions and Gemini/Codex noise. All positive changes from that branch are already present on `main`.

## Verification

- `git check-ignore cdb_agent_sdk/tests/test_agent.py` → exit 1 (not ignored) ✓
- `git check-ignore docs/runbooks/evidence/.../10_backup_run.log` → exit 1 (not ignored) ✓
- `git check-ignore scripts/cdb_ops.ps1` → exit 0 (still ignored) ✓
- `git check-ignore scripts/lr003_contract_drift_guard.py` → exit 1 (tracked) ✓
- `git check-ignore knowledge/logs/sessions/...` → exit 1 (not ignored, no regression) ✓

## Test plan

- [ ] CI passes (unit + integration + lint)
- [ ] `policy-gate` kategorisiert als `docs-only` oder ähnlich (kein `allow-core-change` nötig)
- [ ] Branch `chore/issue-1234-gitignore-artifact-policy` anschließend schließen ohne Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)