### PR TITLE
chore(root): rm redundanter 360-SYSTEMCHECK-Stub (#1231)

### DIFF
--- a/360-SYSTEMCHECK.md
+++ b/360-SYSTEMCHECK.md
@@ -1,6 +1,0 @@
-# 360-SYSTEMCHECK
-
-Historical entrypoint only.
-
-No local canonical replacement was restored for this document during #1140.
-Use `docs/meta/WORKING_REPO_CANON.md` to find the active local canon.

--- a/docs/archive/LEGACY_FILES.md
+++ b/docs/archive/LEGACY_FILES.md
@@ -7,7 +7,6 @@ This file replaces the broken cross-repo pointer that previously targeted
 
 Use this page as the local landing point for legacy and migration-only artifacts:
 - `DOCS_MOVED_TO_DOCS_HUB.md`
-- `360-SYSTEMCHECK.md`
 - `ORCHESTRATOR_PACK_144.md`
 
 Active canon lives in `docs/meta/WORKING_REPO_CANON.md`.


### PR DESCRIPTION
## Summary

- `git rm 360-SYSTEMCHECK.md`: 7-Zeilen-Pointer auf `WORKING_REPO_CANON.md` ohne operativen Mehrwert
- `docs/archive/LEGACY_FILES.md`: verwaisten Listeneintrag `360-SYSTEMCHECK.md` entfernt

## Referenzprüfung

```
rg -l "360-SYSTEMCHECK" -g "*.md" -g "*.yaml" -g "*.yml" -g "!docs/archive/**" -g "!knowledge/logs/**" .
```
Ergebnis vor Deletion: nur Self-Match (`./360-SYSTEMCHECK.md`).
Alle anderen Referenzen liegen in `docs/archive/` oder `knowledge/logs/` (Legacy/Migration-Material).

## Verifikation

- `git diff --cached --stat`: genau 2 Dateien, 7 Deletions
- `tools/enforce-root-baseline.ps1`: **PASS**

## Nicht angefasst

- `governance-audit-2026-01-15.md` (aktive Refs in README + GOVERNANCE_CORE_STATUS_REPORT_v4)
- `.gitignore` (lokale Artefakte bereits via `.git/info/exclude` abgedeckt)
- Weitere Root-Snapshots (Referenzlage nicht vollständig geprüft)

Closes #1231 (partiell — erster kleiner sicherer Schnitt; Handoff für Folge-Patches dokumentiert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)