### PR TITLE
docs(p5): formalize 2026-03-28 prestart NO-GO after LR-040 inconclusive

### DIFF
--- a/reports/p5_canary/2026-03-28/decision_record.yaml
+++ b/reports/p5_canary/2026-03-28/decision_record.yaml
@@ -1,0 +1,46 @@
+schema_version: "1.0"
+decision_type: p5_canary_prestart
+decision_utc: 2026-03-28T18:15:31Z
+decision_date_utc: 2026-03-28
+operator: jannekbuengener
+source_commit_sha: c315d076c989c6f40f113cccbe9e28fb91323630
+canary_artifact_path: reports/p5_canary/2026-03-28/
+
+# LR-040: Soak-Run soak_test_20260325_121250 (gestartet 2026-03-25T12:12:50Z auf main@ac6ab87)
+# Planmaessiges Ende: 2026-03-28T12:12:50Z
+# Evaluator ausgefuehrt: 2026-03-28T18:15:31Z
+# python infrastructure/scripts/lr040_soak_gate_eval.py artifacts/soak_test_20260325_121250
+# Exit-Code: 1
+lr040_pass_run_id: NOT_AVAILABLE
+lr040_pass_commit: ac6ab87  # Commit an dem der Soak-Run gestartet wurde
+lr040_soak_artifact: artifacts/soak_test_20260325_121250
+lr040_verdict: INCONCLUSIVE
+
+# status: GO nur setzen wenn:
+#   - LR-040 verdict == PASS
+#   - prestart_evidence_lock.yaml vollstaendig ausgefuellt (all_gates_pass: true)
+#   - endpoints/*.json live gecaptured
+#   - worktree_status: clean
+#   - Human Gate explizit erteilt
+status: NO-GO
+rationale: >
+  LR-040 Evaluator liefert deterministisch INCONCLUSIVE (exit 1).
+  Soak-Artefakt soak_test_20260325_121250 lief 77.75h; duration_gte_72h=true,
+  no_failed_marker=true, memory_growth 1.14%, cpu_avg 2.13% — alle Metriken gruen.
+  soak_test_INCONCLUSIVE.txt ist vorhanden, ausgeloest durch einen post-72h
+  Docker/Host-Restart (2026-03-28 15:54 UTC, ca. 3h41m nach 72h-Ende).
+  Der Evaluator kennt keine Zeitfenster-Unterscheidung: Marker vorhanden => INCONCLUSIVE.
+  Option A / fail-closed: INCONCLUSIVE wird als NO-GO gewertet.
+  Naechster Schritt: neuer sauberer 72h-Soak-Run, dann erneute Evaluation.
+  Lean-Run (shadow-soak-evidence.yml) bleibt bis dahin blockiert.
+
+hard_blockers:
+  - lr040_gate_verdict: FAIL  # formales Verdict INCONCLUSIVE — kein Gate-Pass, daher FAIL
+  - prestart_evidence_lock: PENDING
+  - human_gate: NOT_GRANTED
+
+notes:
+  - Option A (fail-closed) wurde explizit vom Operator gewaehlt
+  - status: GO erst nach: LR-040 PASS + all_gates_pass: true + Human Gate erteilt
+  - Diese Datei ist kein GO-Signal; nur der explizit gesetzte status-Wert zaehlt
+  - endpoints/ fehlen — kein BLUE-Stack-Capture erfolgt, da NO-GO bereits feststeht

--- a/reports/p5_canary/2026-03-28/lr040/lr040_soak_gate_eval.json
+++ b/reports/p5_canary/2026-03-28/lr040/lr040_soak_gate_eval.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": "1.1",
+  "control": "LR-040",
+  "issue": "#786",
+  "run_intent": "lr040",
+  "verdict": "INCONCLUSIVE",
+  "checks": {
+    "hourly_log_present": true,
+    "duration_gte_72h": true,
+    "no_failed_marker": true,
+    "not_both_markers": true,
+    "no_restart_alerts": false,
+    "memory_growth_below_10pct": true,
+    "cpu_avg_below_70pct": true,
+    "resource_snapshots_present": true
+  },
+  "failures": [
+    "no_restart_alerts"
+  ],
+  "metrics": {
+    "duration_hours": 77.75,
+    "hourly_entries": 76,
+    "max_memory_growth_pct": 1.14,
+    "overall_cpu_avg_pct": 2.13,
+    "resource_snapshot_count": 14
+  },
+  "artifacts": {
+    "hourly_log": "hourly_checks.log",
+    "failed_marker": null,
+    "inconclusive_marker": "soak_test_INCONCLUSIVE.txt",
+    "restart_cause": "environment_interruption",
+    "restart_alerts": "restart_alerts.log",
+    "resource_snapshots": [
+      "resources_snapshot_20260325_12h.txt",
+      "resources_snapshot_20260325_13h.txt",
+      "resources_snapshot_20260325_19h.txt",
+      "resources_snapshot_20260326_01h.txt",
+      "resources_snapshot_20260326_07h.txt",
+      "resources_snapshot_20260326_13h.txt",
+      "resources_snapshot_20260326_19h.txt",
+      "resources_snapshot_20260327_01h.txt",
+      "resources_snapshot_20260327_07h.txt",
+      "resources_snapshot_20260327_13h.txt",
+      "resources_snapshot_20260327_19h.txt",
+      "resources_snapshot_20260328_01h.txt",
+      "resources_snapshot_20260328_07h.txt",
+      "resources_snapshot_20260328_13h.txt"
+    ]
+  }
+}

--- a/reports/p5_canary/2026-03-28/manifest.json
+++ b/reports/p5_canary/2026-03-28/manifest.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "1.0",
+  "package_type": "p5-canary-artifacts",
+  "package_status": "NO-GO",
+  "artifact_instance_type": "committed_prestart_no_go",
+  "artifact_root": "reports/p5_canary/2026-03-28/",
+  "commit_sha": "c315d076c989c6f40f113cccbe9e28fb91323630",
+  "commit_sha_role": "source_revision_at_prestart_capture",
+  "execution_runtime_mode": {
+    "value": null,
+    "value_basis": "not_captured_no_go_path",
+    "capture_state": "pending_runtime_capture",
+    "live_assertion": false,
+    "canonical_field": "execution_status.mode"
+  },
+  "evidence_lock_path": "prestart_evidence_lock.yaml",
+  "decision_record_path": "decision_record.yaml",
+  "endpoint_snapshots": {
+    "execution_status": null,
+    "risk_status": null,
+    "kill_switch_status": null,
+    "note": "not_captured — NO-GO path; endpoints/ directory absent"
+  },
+  "lr040_verdict_path": "lr040/lr040_soak_gate_eval.json",
+  "lr040_verdict": "INCONCLUSIVE",
+  "optional_shadow_prereq_package": {
+    "state": "not_materialized_in_this_handoff_instance",
+    "path": null,
+    "reason": "shadow_prereq_evidence remains separate from p5 core artifacts"
+  },
+  "source_integrity": {
+    "handoff_state": "committed_no_go",
+    "runtime_capture_state": "not_captured",
+    "lr040_state": "FAIL",
+    "all_required_paths_present": false,
+    "missing_paths": [
+      "endpoints/execution_status.json",
+      "endpoints/risk_status.json",
+      "endpoints/kill_switch_status.json"
+    ]
+  },
+  "checksums": {
+    "algorithm": "sha256",
+    "state": "partial — only committed files; endpoints/ not captured",
+    "omitted_self_hash": "manifest.json",
+    "files": {
+      "prestart_evidence_lock.yaml": "769df2a5bcff91fef46dda1c4717dcccd71eb7293062b73ea3c22af47ef8c940",
+      "decision_record.yaml": "00d0abb63e2fe88dd5f128b234cd861e0e4b47903f4afcfb243f26097aec1d60",
+      "endpoints/execution_status.json": null,
+      "endpoints/risk_status.json": null,
+      "endpoints/kill_switch_status.json": null,
+      "lr040/lr040_soak_gate_eval.json": "b7239be108d912577f73a57a859bb3f9958f00d762f3450b95e8495b28e9e3c1"
+    }
+  },
+  "notes": [
+    "NO-GO path: LR-040 INCONCLUSIVE (exit 1), fail-closed, Option A.",
+    "Endpoint captures not performed — NO-GO already established before BLUE-Stack capture.",
+    "Checksums only for files present at commit time. Endpoint nulls are intentional.",
+    "package_status GO requires: LR-040 PASS + all_required_paths_present: true + decision_record status: GO.",
+    "Next step: start new clean 72h soak run with new artifact directory."
+  ]
+}

--- a/reports/p5_canary/2026-03-28/prestart_evidence_lock.yaml
+++ b/reports/p5_canary/2026-03-28/prestart_evidence_lock.yaml
@@ -1,0 +1,59 @@
+schema_version: "1.0"
+handoff_instance: lr040_soak_complete_2026-03-28
+artifact_root: reports/p5_canary/2026-03-28/
+status: NO-GO
+authorization: not_authorized
+evidence_lock_utc: 2026-03-28T18:15:31Z
+capture_state: no_go_before_runtime_capture
+commit_sha: c315d076c989c6f40f113cccbe9e28fb91323630
+worktree_status: dirty  # untracked files present at evidence-lock time
+operator: jannekbuengener
+purpose: prestart_evidence_lock_after_lr040_soak_completion
+
+# Endpoint-Captures wurden nicht durchgefuehrt.
+# Begruendung: LR-040 Evaluator liefert INCONCLUSIVE (exit 1) — NO-GO steht bereits
+# fest. Endpoint-Captures sind erst bei GO-Entscheidung sinnvoll und erforderlich.
+# Alle Capture-Felder bleiben auf null / pending / fail-closed.
+
+kill_switch_status:
+  active: null
+  source: http://127.0.0.1:8002/kill-switch
+  captured_utc: null
+  capture_state: pending
+  response: null
+  expected_field: active
+  required_value_before_start: false
+  gate_pass: false  # nicht gecaptured => fail-closed
+
+execution_status:
+  mode: null
+  source: http://127.0.0.1:8003/status
+  captured_utc: null
+  capture_state: pending
+  response: null
+  canonical_field: execution_status.mode
+  required_value_before_start: mock
+  gate_pass: false  # nicht gecaptured => fail-closed
+
+risk_status:
+  circuit_breaker: null
+  source: http://127.0.0.1:8002/status
+  captured_utc: null
+  capture_state: pending
+  response: null
+  expected_field: risk_state.circuit_breaker
+  required_value_before_start: false
+  gate_pass: false  # nicht gecaptured => fail-closed
+
+gate_summary:
+  kill_switch_inactive: false
+  execution_mode_mock: false
+  circuit_breaker_inactive: false
+  all_gates_pass: false
+
+notes:
+  - NO-GO vor Endpoint-Capture — LR-040 INCONCLUSIVE blockiert jeden GO-Pfad
+  - Endpoint-Captures bewusst nicht durchgefuehrt, da NO-GO bereits feststeht
+  - gate_pass-Felder auf false gesetzt (nicht gecaptured, fail-closed)
+  - keine Aenderung an bestehenden Evidence-Artefakten
+  - naechster Schritt: neuen sauberen 72h-Soak mit neuem Artefaktverzeichnis starten


### PR DESCRIPTION
## Summary

- LR-040 Evaluator ausgeführt: `INCONCLUSIVE`, exit 1
- Soak-Artefakt `soak_test_20260325_121250` lief 77.75h, alle Metriken grün, kein SUT-Defekt
- INCONCLUSIVE durch post-72h Docker/Host-Restart — Evaluator kennt keine Zeitfenster-Unterscheidung
- Option A / fail-closed: INCONCLUSIVE als NO-GO gewertet
- Neuer sauberer 72h-Soak erforderlich vor nächstem P5-Attempt

## Geänderte Dateien

- `reports/p5_canary/2026-03-28/decision_record.yaml` — `lr040_verdict: INCONCLUSIVE`, `status: NO-GO`, `human_gate: NOT_GRANTED`
- `reports/p5_canary/2026-03-28/prestart_evidence_lock.yaml` — NO-GO vor Endpoint-Capture, alle Gates fail-closed
- `reports/p5_canary/2026-03-28/manifest.json` — Checksums für vorhandene Dateien, endpoints/ als fehlend markiert
- `reports/p5_canary/2026-03-28/lr040/lr040_soak_gate_eval.json` — formaler Evaluator-Output

## Test plan

- [ ] `grep "status" reports/p5_canary/2026-03-28/decision_record.yaml` → `status: NO-GO`
- [ ] `grep "lr040_verdict" reports/p5_canary/2026-03-28/decision_record.yaml` → `INCONCLUSIVE`
- [ ] `grep "human_gate" reports/p5_canary/2026-03-28/decision_record.yaml` → `NOT_GRANTED`
- [ ] `grep "package_status" reports/p5_canary/2026-03-28/manifest.json` → `NO-GO`
- [ ] `grep "verdict" reports/p5_canary/2026-03-28/lr040/lr040_soak_gate_eval.json` → `INCONCLUSIVE`

Closes #1224 (teilweise — neuer Soak-Run und erneuter Prestart-Versuch folgen in separatem Issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)