### PR TITLE
docs(knowledge): CONTEXT_CORE_BUILD_FINAL_REPORT als historisches Artefakt markieren (#1303)

### DIFF
--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -1,100 +1,205 @@
 # ARCHITECTURE_MAP - Claire de Binare
 
-**Version:** 1.0
+**Version:** 2.0
 **Erstellt:** 2025-12-28
+**Letzte Aktualisierung:** 2026-03-28 (Drift-Fix #1304 — auf BLUE/RED-Realität gebracht)
 **Status:** Kanonisch
 **Pruefintervall:** Bei jedem Session-Start
+
+**Primärquellen:**
+- `infrastructure/compose/compose.blue.yml`
+- `infrastructure/compose/compose.red.yml`
+- `infrastructure/compose/logging.yml`
+- `knowledge/governance/SERVICE_CATALOG.md`
 
 ---
 
 ## 1. System Overview
 
 Claire de Binare ist ein **event-getriebenes Krypto-Trading-System** mit:
-- Redis Pub/Sub fuer Inter-Service-Kommunikation
-- PostgreSQL fuer Event-Persistenz
-- Docker Compose fuer Orchestrierung
-- Paper Trading als Default-Modus (Live Trading erfordert explizites Gate)
+- Redis Pub/Sub und Streams für Inter-Service-Kommunikation
+- PostgreSQL für Event-Persistenz
+- Docker Compose für Orchestrierung (BLUE/RED-Split)
+- Paper Trading als Default-Modus (`MOCK_TRADING=true`; Live Trading erfordert explizites Human Gate)
 
-**Operatives Inventar:** `governance/SERVICE_CATALOG.md` (Working Repo)
+**Operatives Service-Inventar:** `knowledge/governance/SERVICE_CATALOG.md`
 
 ---
 
-## 2. Service Map (SOLL)
+## 2. BLUE/RED Stack-Split
 
-### Core Pipeline
-```
-[Market] --> [WS] --> [Signal] --> [Risk] --> [Execution]
-   |           |          |          |            |
-   v           v          v          v            v
-             Redis     Redis      Redis        Redis
-             pub/sub   pub/sub    pub/sub      pub/sub
-                                    |            |
-                                    +-----<------+
-                                    (order_results)
-                                          |
-                                          v
-                                    [DB Writer] --> [PostgreSQL]
-```
+### BLUE — Core Trading (compose.blue.yml)
 
-### Services (AKTIV)
+Always-on. Voraussetzung für Trading-Betrieb.
 
 | Service | Container | Port | Funktion |
 |---------|-----------|------|----------|
-| WebSocket | cdb_ws | 8000 | Market Data Stream |
-| Signal | cdb_signal | 8005 | Signal Generation |
-| Risk | cdb_risk | 8002 | Risk Management, Circuit Breaker |
-| Execution | cdb_execution | 8003 | Order Execution |
-| DB Writer | cdb_db_writer | - | Event Persistenz |
-| Paper Runner | cdb_paper_runner | 8004 | Paper Trading Orchestrator |
-
-### Infrastruktur (AKTIV)
-
-| Service | Container | Port | Funktion |
-|---------|-----------|------|----------|
-| Redis | cdb_redis | 6379 | Cache, Pub/Sub |
 | PostgreSQL | cdb_postgres | 5432 | Persistenz |
-| Prometheus | cdb_prometheus | 19090 | Metrics |
-| Grafana | cdb_grafana | 3000 | Dashboards |
+| Redis | cdb_redis | 6379 | Cache, Pub/Sub, Streams |
+| Market | cdb_market | 8009 | Konsumiert `market_data`; schreibt `market_state:{symbol}` (post-Cutover #1201) |
+| Candles | cdb_candles | 8007 | Konsumiert `market_data`; aggregiert → `stream.candles_1m` |
+| Regime | cdb_regime | 8008 | Konsumiert `stream.candles_1m`; klassifiziert Marktregime → `stream.regime_signals` |
+| Allocation | cdb_allocation | 8006 | Konsumiert `stream.regime_signals`; mappt → `stream.allocation_decisions` |
+| Risk | cdb_risk | 8002 | Zentrales Gate; liest Streams + `market_state`; publiziert `orders`; hält Kill-Switch |
+| Execution | cdb_execution | 8003 | Konsumiert `orders`; publiziert `order_results` (`MOCK_TRADING=true` per Default) |
+| DB Writer | cdb_db_writer | — | Konsumiert `signals`, `orders`, `order_results`, `portfolio_snapshots` → PostgreSQL |
+| Paper Runner | cdb_paper_runner | 8004 | Paper-Trading-Runner; publiziert `portfolio_snapshots` stündlich |
 
-### Optional (Logging Stack)
+### RED — Signal Generation + Monitoring (compose.red.yml)
 
-| Service | Container | Aktivierung |
-|---------|-----------|-------------|
-| Loki | cdb_loki | `-Logging` Flag |
-| Promtail | cdb_promtail | `-Logging` Flag |
+Restartbar ohne BLUE zu beeinflussen.
 
-### Deaktiviert (Code vorhanden)
+| Service | Container | Port | Funktion |
+|---------|-----------|------|----------|
+| WebSocket | cdb_ws | 8000 | MEXC-Marktdaten-Feed → publiziert `market_data` |
+| Signal | cdb_signal | 8005 | Konsumiert `market_data`; publiziert `signals` |
+| Prometheus | cdb_prometheus | 19090 | Metrics-Collection |
+| Grafana | cdb_grafana | 3000 | Dashboards, Alerting |
+| Postgres Exporter | cdb_postgres_exporter | 9187 | PostgreSQL-Metriken für Prometheus |
+| Redis Exporter | cdb_redis_exporter | 9121 | Redis-Metriken für Prometheus |
+| cAdvisor | cdb_cadvisor | — | Container-Ressourcenmetriken |
+| Reports | cdb_reports | — | Tägliche Order-Summary per E-Mail (cron-Prozess) |
 
-| Service | Grund | Action Required |
-|---------|-------|-----------------|
-| cdb_allocation | Fehlende Env-Vars | ALLOCATION_* definieren |
-| cdb_regime | Fehlende Env-Vars | REGIME_* definieren |
-| cdb_market | Nicht implementiert | service.py verifizieren |
+### Optional — Logging-Stack (logging.yml)
+
+Separat startbar.
+
+| Service | Container | Funktion |
+|---------|-----------|----------|
+| Alertmanager | cdb_alertmanager | Alert-Routing |
+| Loki | cdb_loki | Log-Aggregation |
+| Promtail | cdb_promtail | Log-Shipping |
 
 ---
 
-## 3. Runtime Reality (IST)
+## 3. Core Pipeline (Datenfluss)
 
-### Verification Command
+```
+cdb_ws
+  │
+  └─→ market_data (pub/sub)
+         │
+         ├─→ cdb_market
+         │      └─→ market_state:{symbol}  (post-Cutover #1201;
+         │               MARKET_STATE_KEY_PREFIX=market_state in compose.blue.yml;
+         │               cdb_candles schreibt market_state nicht mehr:
+         │               CANDLE_WRITE_MARKET_STATE=false)
+         │
+         ├─→ cdb_candles
+         │      └─→ stream.candles_1m
+         │               └─→ cdb_regime
+         │                      └─→ stream.regime_signals
+         │                               ├─→ cdb_allocation
+         │                               │      └─→ stream.allocation_decisions
+         │                               └─→ cdb_risk (liest Regime + Allocation + market_state)
+         │
+         └─→ cdb_signal
+                └─→ signals (pub/sub)
+                         ├─→ cdb_risk
+                         │      └─→ orders (pub/sub)
+                         │               ├─→ cdb_execution
+                         │               │      └─→ order_results (pub/sub)
+                         │               │               ├─→ cdb_risk
+                         │               │               └─→ cdb_db_writer → PostgreSQL
+                         │               └─→ cdb_db_writer → PostgreSQL
+                         └─→ cdb_db_writer → PostgreSQL
+
+cdb_paper_runner → portfolio_snapshots (pub/sub) → cdb_db_writer → PostgreSQL
+```
+
+---
+
+## 4. Redis Channels / Streams
+
+Nur belegte Einträge. Publisher und Subscriber aus Service-Config und Service-Code verifiziert.
+
+| Channel / Stream | Typ | Publisher | Subscriber(s) |
+|-----------------|-----|-----------|---------------|
+| `market_data` | pub/sub | cdb_ws | cdb_market, cdb_candles, cdb_signal |
+| `market_state:{symbol}` | Redis-Key | cdb_market | cdb_risk |
+| `stream.candles_1m` | stream | cdb_candles | cdb_regime |
+| `stream.regime_signals` | stream | cdb_regime | cdb_allocation, cdb_risk |
+| `stream.allocation_decisions` | stream | cdb_allocation | cdb_risk |
+| `signals` | pub/sub | cdb_signal | cdb_risk, cdb_db_writer |
+| `orders` | pub/sub | cdb_risk | cdb_execution, cdb_db_writer |
+| `order_results` | pub/sub | cdb_execution | cdb_risk, cdb_db_writer |
+| `portfolio_snapshots` | pub/sub | cdb_paper_runner | cdb_db_writer |
+| `alerts` | pub/sub | cdb_risk | — (Monitoring) |
+| `stream.bot_shutdown` | stream | cdb_risk | cdb_execution |
+
+Hinweis: Weitere interne Streams (`stream.signals`, `stream.orders`, `stream.orders_blocked`, `stream.fills`) sind in Service-Configs referenziert, aber nicht vollständig kartiert. Sie sind hier weggelassen, bis ihre Subscriber verifiziert sind.
+
+---
+
+## 5. Compose-Architektur
+
+### Aktive Operator-Runtime (kanonisch)
+
+```
+compose.blue.yml    → BLUE Stack: Core Trading
+compose.red.yml     → RED Stack: Signal + Monitoring
+logging.yml         → Optional: Alertmanager + Loki + Promtail
+```
+
+Startbefehl (kanonischer PowerShell-Einstieg):
 ```powershell
-# Stack starten
-.\infrastructure\scripts\stack_up.ps1 -Profile dev
+.\tools\cdb.ps1 runtime up
+```
 
-# Vollstaendigkeitspruefung
-.\infrastructure\scripts\stack_verify.ps1
+Oder direkt:
+```bash
+docker network create cdb_network
+docker compose -f infrastructure/compose/compose.blue.yml up -d
+docker compose -f infrastructure/compose/compose.red.yml up -d
+```
 
-# Schnellcheck
+### CI-Lab-Baseline (431B)
+
+```
+base.yml + test.yml → kanonische CI-Lab-Baseline für isolierte Test-/E2E-Labs
+```
+
+### Legacy/Sekundärpfad
+
+`base.yml + dev.yml` — sekundärer Dev-/Kompatibilitätspfad; kein kanonischer Operator-Runtime-Stack.
+
+---
+
+## 6. Invariants (nicht verhandelbar)
+
+1. **Paper Trading Default**: `MOCK_TRADING=true`; Live Trading erfordert explizites Human Gate
+2. **Event Sourcing**: Alle State-Änderungen über Events (Replay-fähig)
+3. **Circuit Breaker**: Risk Service gated alle Order-Ausführung
+4. **Determinismus**: Reproduzierbare Ergebnisse via Event Replay
+5. **Localhost Binding**: Alle Ports auf `127.0.0.1` (keine externe Exposition)
+6. **Kill-Switch**: Shared State-Datei zwischen cdb_risk und cdb_execution (Volume `kill_switch_state`)
+
+---
+
+## 7. Verification Commands
+
+```powershell
+# Kanonischer Stack-Start
+.\tools\cdb.ps1 runtime up
+
+# Stack verifizieren
+.\tools\cdb.ps1 stack verify
+
+# Smoke-Test (BLUE core path)
+.\tools\cdb.ps1 runtime smoke
+
+# Schnellcheck Container-Status
 docker ps --filter "name=cdb_" --format "table {{.Names}}\t{{.Status}}"
 ```
 
-### Erwarteter Output (healthy)
+Erwarteter Status (BLUE healthy):
 ```
-cdb_redis         Up X minutes (healthy)
 cdb_postgres      Up X minutes (healthy)
-cdb_prometheus    Up X minutes (healthy)
-cdb_grafana       Up X minutes (healthy)
-cdb_ws            Up X minutes (healthy)
-cdb_signal        Up X minutes (healthy)
+cdb_redis         Up X minutes (healthy)
+cdb_market        Up X minutes (healthy)
+cdb_candles       Up X minutes (healthy)
+cdb_regime        Up X minutes (healthy)
+cdb_allocation    Up X minutes (healthy)
 cdb_risk          Up X minutes
 cdb_execution     Up X minutes
 cdb_db_writer     Up X minutes (healthy)
@@ -103,66 +208,9 @@ cdb_paper_runner  Up X minutes (healthy)
 
 ---
 
-## 4. Key Dataflows
-
-### Redis Channels
-| Channel | Publisher | Subscriber(s) |
-|---------|-----------|---------------|
-| market_data | cdb_ws | cdb_signal |
-| signals | cdb_signal | cdb_risk, cdb_db_writer |
-| orders | cdb_risk | cdb_execution, cdb_db_writer |
-| order_results | cdb_execution | cdb_risk, cdb_db_writer |
-| alerts | cdb_risk | (Monitoring) |
-| portfolio_snapshots | cdb_paper_runner | cdb_db_writer |
-
-### Event Types
-- `SIGNAL_GENERATED` - Handelssignal erzeugt
-- `ORDER_PLACED` - Order an Exchange gesendet
-- `POSITION_OPENED` - Position eroeffnet
-
----
-
-## 5. Invariants (nicht verhandelbar)
-
-1. **Paper Trading Default**: Live Trading erfordert explizites Delivery Gate
-2. **Event Sourcing**: Alle State-Aenderungen ueber Events (Replay-faehig)
-3. **Circuit Breaker**: Risk Service gated alle Order Execution
-4. **Determinismus**: Reproduzierbare Ergebnisse via Event Replay
-5. **TLS Optional**: Aktivierbar via `-TLS` Flag (Redis + PostgreSQL)
-6. **Localhost Binding**: Alle Ports auf 127.0.0.1 (keine externe Exposition)
-
----
-
-## 6. Known Drifts (zu beheben)
-
-| Drift | Beschreibung | Priority |
-|-------|--------------|----------|
-| prod.yml Naming | Referenziert `cdb_core` statt `cdb_signal` | HIGH |
-| tls.yml Naming | Referenziert `cdb_core` statt `cdb_signal` | HIGH |
-| CLAUDE.md Port | Signal als Port 8001 dokumentiert (ist 8005) | MEDIUM |
-
----
-
-## 7. Compose Layer Referenz
-
-```
-base.yml          -> Infrastruktur
-  |
-dev.yml           -> App-Services + Port-Bindings
-  |
-logging.yml       -> Loki + Promtail (optional)
-  |
-tls.yml           -> TLS Encryption (optional)
-  |
-healthchecks-strict.yml -> Strikte Checks (optional)
-  |
-network-prod.yml  -> Network Isolation (optional)
-```
-
----
-
 ## Changelog
 
-| Datum | Aenderung | Durch |
-|-------|-----------|-------|
+| Datum | Änderung | Durch |
+|-------|----------|-------|
 | 2025-12-28 | Initiale Erstellung via Context Build Sprint | Claude (Orchestrator) |
+| 2026-03-28 | Vollständiges Update auf BLUE/RED-Realität (#1304): cdb_candles ergänzt; cdb_market/regime/allocation als AKTIV mit Port korrigiert; Core-Pipeline-Diagramm auf echte Redis-Channel-Namen und candles→regime→allocation→risk-Flow aktualisiert; market_state-Ownership post-Cutover #1201 dokumentiert; Redis-Tabelle auf belegte Einträge beschränkt; RED-Stack komplett (Reports, Exporter, cAdvisor, Logging-Stack); Compose-Layer auf BLUE/RED umgestellt; alte Drifts-Sektion und veraltete Stack-Start-Referenzen entfernt | Claude |

--- a/knowledge/context_build/CONTEXT_CORE_BUILD_FINAL_REPORT.md
+++ b/knowledge/context_build/CONTEXT_CORE_BUILD_FINAL_REPORT.md
@@ -1,5 +1,17 @@
 # CONTEXT CORE BUILD SPRINT - Final Report
 
+> **HISTORICAL ARTIFACT — NOT CANONICAL**
+>
+> Dieses Dokument ist ein Sprint-Abschlussbericht vom **2025-12-28** und beschreibt den damaligen Zustand.
+> Es ist **kein aktives Steuerungsdokument** und **nicht autoritativ** für die aktuelle Session-Start-Read-Order.
+>
+> Die verbindliche Session-Start-Read-Order steht in [`CLAUDE.md`](../../CLAUDE.md) (Root).
+> Kanonische Bootstrap-Dokumente: `agents/roles/CLAUDE.md`, `agents/AGENTS.md`, `knowledge/SYSTEM.CONTEXT.md`, `CURRENT_STATUS.md`.
+>
+> Dieses Artefakt wird als Historizitäts-Nachweis für den Context-Core-Build-Sprint erhalten.
+
+---
+
 **Sprint:** Context Core Build
 **Datum:** 2025-12-28
 **Orchestrator:** Claude (Orchestrator Mode)

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -1,8 +1,14 @@
 # SERVICE_CATALOG.md - Vollständige Service-Inventarisierung
 
 **Erstellt:** 2025-12-28
+**Letzte Aktualisierung:** 2026-03-28 (Drift-Fix #1304 — auf BLUE/RED-Realität gebracht)
 **Verantwortlich:** Claude (Session Lead)
 **Prüfintervall:** Bei jedem Stack-Start, mindestens wöchentlich
+
+**Primärquellen für dieses Dokument:**
+- `infrastructure/compose/compose.blue.yml`
+- `infrastructure/compose/compose.red.yml`
+- `infrastructure/compose/logging.yml`
 
 ---
 
@@ -10,128 +16,125 @@
 
 | Status | Bedeutung |
 |--------|-----------|
-| **AKTIV** | Service läuft in Production/Dev Stack |
-| **BEREIT** | Code vollständig, Dockerfile vorhanden, Compose deaktiviert |
+| **AKTIV** | Service in compose.blue.yml oder compose.red.yml definiert und aktiv deployt |
+| **OPTIONAL** | Service vorhanden, nur bei explizitem Start aktiv (z. B. logging.yml) |
+| **BEREIT** | Code vollständig, Dockerfile vorhanden, aber nicht in aktivem Compose-Stack |
 | **GEPLANT** | Architektur definiert, Implementierung ausstehend |
-| **LEGACY** | Deprecated, wird nicht mehr verwendet |
-| **GAP** | Diskrepanz zwischen Code und Deployment |
+| **LEGACY** | Deprecated, nicht mehr verwendet |
+| **GAP** | Verifizierte Diskrepanz zwischen Code und Deployment |
 
 ---
 
-## Applikations-Services
+## BLUE Stack — Core Trading Infrastructure
 
-| Service | Container | Code | Dockerfile | Compose | Status | Begründung |
-|---------|-----------|------|------------|---------|--------|------------|
-| **Signal** | cdb_signal | services/signal/ (6 files, service.py) | ✅ | ✅ aktiv | **AKTIV** | Signal Engine, Momentum-Strategie |
-| **Risk** | cdb_risk | services/risk/ (11 files, service.py) | ✅ | ✅ aktiv | **AKTIV** | Risk Management, Circuit Breaker |
-| **Execution** | cdb_execution | services/execution/ (11 files, service.py) | ✅ | ✅ aktiv | **AKTIV** | Order Execution, MEXC Integration |
-| **DB Writer** | cdb_db_writer | services/db_writer/ (db_writer.py) | ✅ | ✅ aktiv | **AKTIV** | PostgreSQL Persistenz |
-| **WebSocket** | cdb_ws | services/ws/ (service.py) | ✅ | ✅ aktiv | **AKTIV** | Market Data Stream |
-| **Paper Runner** | cdb_paper_runner | tools/paper_trading/ (service.py, 15k lines) | ✅ | ✅ aktiv | **AKTIV** | Paper Trading Orchestrator |
-| **Allocation** | cdb_allocation | services/allocation/ (3 files, 378 LOC) | ✅ | ❌ auskommentiert | **BEREIT** | Deaktiviert: fehlende Env-Vars (ALLOCATION_*) |
-| **Regime** | cdb_regime | services/regime/ (4 files, 213 LOC) | ✅ | ❌ auskommentiert | **BEREIT** | Deaktiviert: fehlende Env-Vars (REGIME_*) |
-| **Market** | cdb_market | services/market/ (2 files, 82 LOC) | ✅ | ❌ auskommentiert | **BEREIT** | Deaktiviert laut stack_up.ps1: "not implemented" |
+Stets aktiv. Voraussetzung für Trading.
+
+| Service | Container | Port (extern) | Code-Pfad | Funktion |
+|---------|-----------|--------------|-----------|----------|
+| **PostgreSQL** | cdb_postgres | 5432 | `postgres:15.17-alpine` | Persistenz |
+| **Redis** | cdb_redis | 6379 | `redis:7.4.8-alpine` | Cache, Pub/Sub, Streams |
+| **Market** | cdb_market | 8009 | `services/market/` | Besitzt `market_state:{symbol}` in Redis (nach Cutover #1201) |
+| **Candles** | cdb_candles | 8007 | `services/candles/` | Aggregiert Ticks → 1-min-Candles auf `stream.candles_1m` |
+| **Regime** | cdb_regime | 8008 | `services/regime/` | Liest Candles, klassifiziert Marktregime (ADX/ATR) |
+| **Allocation** | cdb_allocation | 8006 | `services/allocation/` | Mappt Regime → Allokationsprozentsatz pro Modus |
+| **Risk** | cdb_risk | 8002 | `services/risk/` | Zentrales Gate: blockiert Orders wenn `allocation_pct <= 0`; hält Kill-Switch |
+| **Execution** | cdb_execution | 8003 | `services/execution/` | Sendet Orders; `MOCK_TRADING=true` per Default |
+| **DB Writer** | cdb_db_writer | — | `services/db_writer/` | Persistiert Redis-Stream-Events nach PostgreSQL |
+| **Paper Runner** | cdb_paper_runner | 8004 | `tools/paper_trading/` | 14-Tage-Paper-Trading-Runner; publiziert Portfolio-Snapshots stündlich |
 
 ---
 
-## Infrastruktur-Services
+## RED Stack — Signal Generation + Monitoring
 
-| Service | Container | Image | Compose | Status | Begründung |
-|---------|-----------|-------|---------|--------|------------|
-| **Redis** | cdb_redis | redis:7-alpine | ✅ aktiv | **AKTIV** | Cache, Pub/Sub |
-| **PostgreSQL** | cdb_postgres | postgres:15-alpine | ✅ aktiv | **AKTIV** | Persistenz |
-| **Prometheus** | cdb_prometheus | prom/prometheus:v2.51.0 | ✅ aktiv | **AKTIV** | Metrics Collection |
-| **Grafana** | cdb_grafana | grafana/grafana:11.4.0 | ✅ aktiv | **AKTIV** | Dashboards |
-| **Loki** | cdb_loki | grafana/loki:2.9.0 | ✅ logging.yml | **AKTIV** | Log Aggregation |
-| **Promtail** | cdb_promtail | grafana/promtail:2.9.0 | ✅ logging.yml | **AKTIV** | Log Shipping |
+Restartbar ohne BLUE zu beeinflussen.
+
+| Service | Container | Port (extern) | Quelle | Funktion |
+|---------|-----------|--------------|--------|----------|
+| **WebSocket** | cdb_ws | 8000 | `services/ws/` | MEXC-Marktdaten-Feed (Protobuf) |
+| **Signal** | cdb_signal | 8005 | `services/signal/` | Konsumiert Candles/Regime, generiert Trade-Signale |
+| **Prometheus** | cdb_prometheus | 19090 | `prom/prometheus:v3.10.0` | Metrics-Collection |
+| **Grafana** | cdb_grafana | 3000 | `grafana/grafana:11.4.7-ubuntu` | Dashboards, Alerting |
+| **Postgres Exporter** | cdb_postgres_exporter | 9187 | `prometheuscommunity/postgres-exporter:latest` | PostgreSQL-Metriken für Prometheus |
+| **Redis Exporter** | cdb_redis_exporter | 9121 | `bitnami/redis-exporter:latest` | Redis-Metriken für Prometheus |
+| **cAdvisor** | cdb_cadvisor | — | `gcr.io/cadvisor/cadvisor:v0.49.2` | Container-Ressourcenmetriken |
+| **Reports** | cdb_reports | — | `services/reports/` | Tägliche Order-Summary per E-Mail (cron-Prozess) |
+
+---
+
+## Optionaler Logging-Stack (logging.yml)
+
+Separat startbar. Nicht in compose.red.yml enthalten.
+
+| Service | Container | Quelle | Funktion |
+|---------|-----------|--------|----------|
+| **Alertmanager** | cdb_alertmanager | `prom/alertmanager:v0.27.0` | Alert-Routing (E-Mail, Webhooks) |
+| **Loki** | cdb_loki | `grafana/loki:2.9.3` | Log-Aggregation |
+| **Promtail** | cdb_promtail | `grafana/promtail:2.9.3` | Log-Shipping zu Loki |
+
+Start: `docker compose -f infrastructure/compose/compose.blue.yml -f infrastructure/compose/compose.red.yml -f infrastructure/compose/logging.yml up -d`
 
 ---
 
 ## Test-Services (test.yml)
 
+Isolierte Instanzen für CI-Läufe.
+
 | Service | Container | Zweck |
 |---------|-----------|-------|
-| cdb_redis_test | Redis für Tests | Isolierte Test-DB |
-| cdb_postgres_test | PostgreSQL für Tests | Isolierte Test-DB |
-| cdb_risk_test | Risk Service Test | Integration Tests |
-| cdb_execution_test | Execution Service Test | Integration Tests |
-| cdb_test_runner | pytest Container | Test Orchestration |
+| cdb_redis_test | Redis (Test) | Isolierte Test-DB |
+| cdb_postgres_test | PostgreSQL (Test) | Isolierte Test-DB |
+| cdb_risk_test | Risk Service (Test) | Integration Tests |
+| cdb_execution_test | Execution Service (Test) | Integration Tests |
+| cdb_test_runner | pytest Container | Test-Orchestration |
 
 ---
 
-## GAP-Analyse
+## Compose-Architektur
 
-### Aktuell keine kritischen GAPs
-
-✅ **Signal Service** wurde am 2025-12-28 aktiviert:
-- Container: `cdb_signal` (Port 8005)
-- Vorher: War als `cdb_core` fehlbenannt
-- Fix: Umbenennung + korrekter Port
-
-### Allocation/Regime/Market - BEREIT aber deaktiviert
-
-Diese Services haben vollständigen Code, sind aber in `dev.yml` auskommentiert.
-
-**Begründung laut Code-Kommentare:**
-- allocation: "missing env vars"
-- regime: "missing env vars"
-- market: "not implemented" (widersprüchlich - service.py existiert!)
-
-**Action Required:**
-- [ ] Env-Vars für allocation/regime definieren
-- [ ] market Status klären (Code existiert!)
-
----
-
-## Compose Layer Architektur
+### Aktive Operator-Runtime (kanonisch)
 
 ```
-base.yml          → Infrastruktur (Redis, Postgres, Prometheus, Grafana)
-  ↓
-dev.yml           → Applikations-Services (Core, Risk, Execution, etc.)
-  ↓
-logging.yml       → Loki + Promtail
-  ↓
-tls.yml           → TLS Certificates (optional)
-  ↓
-healthchecks-strict.yml → Strikte Health Checks
-  ↓
-network-prod.yml  → Production Network Isolation
+compose.blue.yml    → BLUE Stack: Core Trading (Daten + Control + Trading)
+compose.red.yml     → RED Stack: Signal Generation + Monitoring
+logging.yml         → Optional: Alertmanager + Loki + Promtail
 ```
 
----
+Startbefehl (kanonisch):
+```powershell
+.\tools\cdb.ps1 runtime up
+```
 
-## Stack-Start Befehl (vollständig)
+Oder direkt:
+```bash
+docker network create cdb_network
+docker compose -f infrastructure/compose/compose.blue.yml up -d
+docker compose -f infrastructure/compose/compose.red.yml up -d
+```
+
+### CI-Lab-Baseline (431B, isoliert)
+
+```
+base.yml + test.yml → kanonische Docker-CI-Lab-Baseline für isolierte Test-/E2E-Labs
+```
 
 ```bash
-# Development mit Logging
-docker compose \
-  --env-file ".cdb_local/.secrets/.env.compose" \
-  -f infrastructure/compose/base.yml \
-  -f infrastructure/compose/dev.yml \
-  -f infrastructure/compose/logging.yml \
-  up -d
-
-# Production (mit TLS + strict healthchecks)
-docker compose \
-  --env-file ".cdb_local/.secrets/.env.compose" \
-  -f infrastructure/compose/base.yml \
-  -f infrastructure/compose/dev.yml \
-  -f infrastructure/compose/logging.yml \
-  -f infrastructure/compose/tls.yml \
-  -f infrastructure/compose/healthchecks-strict.yml \
-  up -d
+docker compose -f infrastructure/compose/base.yml -f infrastructure/compose/test.yml up --abort-on-container-exit
 ```
+
+### Legacy/Sekundärpfad
+
+`base.yml + dev.yml` — sekundärer Dev-/Kompatibilitätspfad; kein kanonischer Operator-Runtime-Stack.
 
 ---
 
 ## Prüf-Checkliste (bei jedem Stack-Start)
 
-- [ ] Alle AKTIV-Services laufen (`docker ps`)
-- [ ] Alle Services "healthy" (keine "unhealthy" oder "starting")
-- [ ] GAP-Services bewusst nicht gestartet (dokumentiert)
-- [ ] BEREIT-Services bewusst deaktiviert (Begründung aktuell)
-- [ ] Keine unbekannten Container im Stack
+- [ ] Alle BLUE-Services laufen (`docker ps`)
+- [ ] PostgreSQL und Redis healthy
+- [ ] cdb_market, cdb_candles, cdb_regime, cdb_allocation healthy
+- [ ] cdb_risk, cdb_execution gestartet
+- [ ] cdb_paper_runner healthy
+- [ ] RED-Services nach Bedarf gestartet
 
 ---
 
@@ -140,5 +143,4 @@ docker compose \
 | Datum | Änderung | Durch |
 |-------|----------|-------|
 | 2025-12-28 | Initiale Erstellung nach Governance-Review | Claude |
-| 2025-12-28 | GAP identifiziert: Signal Service fehlt in Compose | Claude |
-| 2025-12-28 | Signal Service aktiviert: cdb_core → cdb_signal (Port 8005) | Claude |
+| 2026-03-28 | Vollständiges Update auf BLUE/RED-Realität (#1304): cdb_candles ergänzt, cdb_market/regime/allocation als AKTIV korrigiert, RED-Stack-Services (Reports, Exporter, cAdvisor) ergänzt, logging.yml-Abschnitt ergänzt, Compose-Architektur auf BLUE/RED umgestellt | Claude |

--- a/knowledge/logs/sessions/2026-03-28-issue-1304-service-catalog-arch-map-update.md
+++ b/knowledge/logs/sessions/2026-03-28-issue-1304-service-catalog-arch-map-update.md
@@ -1,0 +1,60 @@
+# Session Log — 2026-03-28 — Issue #1304 SERVICE_CATALOG + ARCHITECTURE_MAP Update
+
+**Topic:** Drift-Fix: SERVICE_CATALOG.md + ARCHITECTURE_MAP.md auf BLUE/RED-Realität
+**Issue:** #1304
+**Status:** ABGESCHLOSSEN
+**Branch:** main
+
+---
+
+## Gelesene Quellen
+
+- `infrastructure/compose/compose.blue.yml`
+- `infrastructure/compose/compose.red.yml`
+- `infrastructure/compose/logging.yml`
+- `services/signal/config.py`, `services/risk/config.py`, `services/execution/config.py`
+- `services/candles/config.py`, `services/candles/service.py`
+- `services/db_writer/db_writer.py`
+- `services/market/service.py`
+- `services/risk/service.py`
+
+---
+
+## Durchgeführte Korrekturen
+
+### SERVICE_CATALOG.md
+- `cdb_candles` (Port 8007) ergänzt — fehlte komplett
+- `cdb_market`, `cdb_regime`, `cdb_allocation` von "BEREIT (deaktiviert)" auf AKTIV korrigiert mit Ports (8009, 8008, 8006)
+- RED-Stack komplett ergänzt: `cdb_reports`, `cdb_postgres_exporter` (9187), `cdb_redis_exporter` (9121), `cdb_cadvisor`
+- Optionaler Logging-Stack (logging.yml) als eigene Sektion ergänzt: `cdb_alertmanager`, `cdb_loki`, `cdb_promtail`
+- Compose-Architektur auf BLUE/RED umgestellt; altes `base.yml + dev.yml`-Primärmodell als legacy markiert
+- Stack-Start-Befehl auf kanonischen `.\tools\cdb.ps1 runtime up` aktualisiert
+
+### ARCHITECTURE_MAP.md
+- `cdb_candles` in Service-Map und Core-Pipeline-Diagramm ergänzt
+- `cdb_market`, `cdb_regime`, `cdb_allocation` mit korrekten Ports und Funktionen eingetragen
+- RED-Stack-Services komplett ergänzt
+- Core-Pipeline-Diagramm auf echte Redis-Channel-Namen aktualisiert (`market_data`, `signals`, `orders`, `order_results`)
+- `candles → regime → allocation → risk`-Flow korrekt dargestellt
+- market_state-Ownership post-Cutover #1201 dokumentiert (mit compose.blue.yml-Evidenz)
+- Redis-Tabelle auf verifizierte Einträge beschränkt — drei Korrekturen nach Nachschärfung:
+  - `stream.regime_signals`: cdb_candles als Subscriber entfernt (nur one-shot XREVRANGE-Lookup, kein persistenter Consumer)
+  - `alerts`: Publisher nur cdb_risk (cdb_execution-Nutzung in service.py nicht belegt)
+  - `stream.bot_shutdown`: Publisher cdb_risk, Subscriber cdb_execution (nicht beidseitig)
+- Interne Streams ohne bekannte Subscriber in Hinweis-Zeile ausgelagert
+- Compose-Layer auf BLUE/RED umgestellt; alte Drifts-Sektion entfernt
+- Stack-Start auf `.\tools\cdb.ps1 runtime up` aktualisiert
+
+---
+
+## Offene Restunsicherheiten
+
+- `stream.signals`, `stream.orders`, `stream.orders_blocked`, `stream.fills`: Publisher belegt, Subscriber nicht vollständig kartiert
+- `cdb_candles` macht einen XREVRANGE-Lookup auf `stream.regime_signals` — ob das als "Consumer" dokumentiert werden sollte, bleibt offen für separate Entscheidung
+- `alerts`-Kanal: cdb_execution hat TOPIC_ALERTS in config.py definiert, aber Nutzung in service.py nicht gefunden — konservativ weggelassen
+
+---
+
+## CURRENT_STATUS-Änderungen
+
+Keine Änderungen an CURRENT_STATUS.md notwendig — dieser Fix ändert keinen Engineering-/LR-Status.


### PR DESCRIPTION
Closes #1303

## Summary

- `knowledge/context_build/CONTEXT_CORE_BUILD_FINAL_REPORT.md`: HISTORICAL ARTIFACT-Banner am Dokumentkopf eingefügt
- Sprint-Abschlussbericht vom 2025-12-28 wird klar als nicht-kanonisch und nicht-autoritativ für die aktuelle Session-Start-Read-Order gekennzeichnet
- Verweis auf verbindliche `CLAUDE.md`-Read-Order als aktive Canon-Quelle
- Historie (Historizitäts-Nachweis) bleibt vollständig erhalten

## Test plan

- [ ] Dokument zeigt HISTORICAL ARTIFACT-Banner als erstes nach dem Titel
- [ ] Keine aktiven Bootstrap-Referenzen auf das Dokument in CLAUDE.md / AGENTS.md (verifiziert: keine)
- [ ] Nur `knowledge/context_build/CONTEXT_CORE_BUILD_FINAL_REPORT.md` geändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)