### PR TITLE
docs(context-core): align SERVICE_CATALOG path and Delivery Gate canon (#1301)

### DIFF
--- a/knowledge/GOVERNANCE_QUICKREF.md
+++ b/knowledge/GOVERNANCE_QUICKREF.md
@@ -20,8 +20,12 @@ Status: canonical
 
 Rule: no live deployment without explicit user gate.
 
-Canonical file:
-- `knowledge/governance/DELIVERY_APPROVED.yaml`
+Canonical file (CI-enforced):
+- `governance/DELIVERY_APPROVED.yaml`
+
+The active CI workflow (`delivery-gate.yml`) reads `governance/DELIVERY_APPROVED.yaml`
+at the repo root. A duplicate exists at `knowledge/governance/DELIVERY_APPROVED.yaml`
+and is not CI-active; see #1311 for cleanup.
 
 ## 3. Agent Behavior
 

--- a/knowledge/context_build/CODEX_CONTEXT_CORE_VERIFICATION.md
+++ b/knowledge/context_build/CODEX_CONTEXT_CORE_VERIFICATION.md
@@ -14,23 +14,21 @@ governance, and operational mistakes.
 
 ## AUTHORITATIVE INPUTS
 
-### Docs Repository (Context Core)
+### Context Core (Working Repo)
 - knowledge/ARCHITECTURE_MAP.md
-- governance/SERVICE_CATALOG.md
+- knowledge/governance/SERVICE_CATALOG.md
 - knowledge/GOVERNANCE_QUICKREF.md
 - knowledge/SYSTEM_INVARIANTS.md
 - knowledge/OPERATIONS_RUNBOOK.md
 - knowledge/CURRENT_STATUS.md
 
 ### Working Repository
-- docker-compose.base.yml
 - infrastructure/compose/base.yml
 - infrastructure/compose/dev.yml
 - infrastructure/compose/prod.yml
 - infrastructure/compose/tls.yml
 
 ### Scripts
-- stack_up.ps1
 - infrastructure/scripts/stack_up.ps1
 - infrastructure/scripts/stack_verify.ps1
 


### PR DESCRIPTION
## Summary

- **GOVERNANCE_QUICKREF.md §2**: korrigiert kanonischen Delivery-Gate-Pfad von `knowledge/governance/DELIVERY_APPROVED.yaml` auf `governance/DELIVERY_APPROVED.yaml` (übereinstimmend mit dem aktiven `delivery-gate.yml`-Workflow); fügt Hinweis auf Duplikat + #1311 hinzu
- **CODEX_CONTEXT_CORE_VERIFICATION.md AUTHORITATIVE INPUTS**:
  - `governance/SERVICE_CATALOG.md` → `knowledge/governance/SERVICE_CATALOG.md` (einziger tatsächlicher Speicherort)
  - `docker-compose.base.yml` entfernt (existiert nicht; `infrastructure/compose/base.yml` war bereits gelistet)
  - Root-`stack_up.ps1` entfernt (existiert nicht im Repo-Root)
  - Header `"Docs Repository"` → `"Context Core (Working Repo)"` (kein separates Docs-Repo mehr)

Schließt #1301. Nicht verwechseln mit #1311 (Dual-DELIVERY_APPROVED.yaml-Cleanup).

## Test plan

- [ ] Kein Workflow geändert — CI sollte grün sein
- [ ] `knowledge/GOVERNANCE_QUICKREF.md` zeigt auf aktiven CI-Gate-Pfad
- [ ] `CODEX_CONTEXT_CORE_VERIFICATION.md` listet ausschließlich existierende Dateipfade

🤖 Generated with [Claude Code](https://claude.com/claude-code)