### PR TITLE
docs: Docs-Hub-Referenzen aus aktiven Working-Repo-Dateien entfernt (#1300)

### DIFF
--- a/knowledge/content/FINAL_HANDOFF.md
+++ b/knowledge/content/FINAL_HANDOFF.md
@@ -1,8 +1,12 @@
-# Final Handoff — CDB_GITHUB_MANAGER
+# Final Handoff — CDB_GITHUB_MANAGER (Historical — 2025-12-16)
 
-**Date:** 2025-12-16  
-**Session:** Feierabend-Session (Home Office)  
-**Agent:** Copilot  
+> **Note:** Historical snapshot from the split-repo era. References to "Docs Hub"
+> and "Docs Hub Guard" reflect the repo topology as of 2025-12-16. The Docs Hub
+> repository was retired in #1140.
+
+**Date:** 2025-12-16
+**Session:** Feierabend-Session (Home Office)
+**Agent:** Copilot
 **Status:** ✅ **COMPLETE & READY FOR HANDOFF**
 
 ---

--- a/knowledge/migrations/LEGACY_FILES.md
+++ b/knowledge/migrations/LEGACY_FILES.md
@@ -1,3 +1,5 @@
 # LEGACY_FILES.md
 
-**Moved:** Canon liegt im Docs Hub: `../Claire_de_Binare_Docs/knowledge/migrations/LEGACY_FILES.md`
+> **Historical redirect stub.** The former Docs Hub repository is retired (#1140).
+> A read-only snapshot exists at `docs/archive/docs_hub_snapshot/knowledge/migrations/LEGACY_FILES.md`.
+> Active legacy-file tracking is no longer maintained at this path.

--- a/tools/secrets/README.md
+++ b/tools/secrets/README.md
@@ -149,14 +149,10 @@ Run commands in order:
 2. `export` (creates .env.runtime)
 3. Start BLUE+RED runtime (`docker compose -f infrastructure/compose/compose.blue.yml up -d` + `compose.red.yml`)
 
-## Documentation (Docs Hub)
-
-This tool is governed by the official Docs Hub policies/runbooks:
-
-- **Secret Rotation Policy**
-  https://github.com/jannekbuengener/Claire_de_Binare_Docs/blob/main/knowledge/governance/SECRET_ROTATION_POLICY.md
+## Related Documentation
 
 - **Grafana Admin Incident Runbook (MANUAL rotation)**
-  https://github.com/jannekbuengener/Claire_de_Binare_Docs/blob/main/knowledge/runbooks/GRAFANA_ADMIN_INCIDENT.md
+  `knowledge/runbooks/GRAFANA_ADMIN_INCIDENT.md`
 
-**Tip:** Keep these links close during incidents — policy defines guardrails, runbook defines break-glass steps.
+**Note:** The former Docs Hub repository is retired. All active governance
+and runbook content lives in this working repo.


### PR DESCRIPTION
## Summary

- Active non-archive files no longer point to `Claire_de_Binare_Docs` as the canonical or default read/edit path
- 6 files corrected: retired Docs Hub links replaced with local repo paths or explicit historical markers
- `.claude/CLAUDE_BOOTLOADER.md` (gitignored) also cleaned locally

## Changed Files

| File | Change |
|------|--------|
| `tools/secrets/README.md` | Docs Hub GitHub links → local repo path |
| `knowledge/reviews/CLAUDE_PROJECT_OVERVIEW.md` | Marked as historical (2025-12-19 snapshot) |
| `knowledge/migrations/LEGACY_FILES.md` | Redirect stub → archive pointer + retired note |
| `knowledge/decisions/ADR-001-documentation-only-repository.md` | Status: Accepted → Superseded |
| `knowledge/logs/sessions/README.md` | Removed "for Docs Hub work" scope qualifier |
| `knowledge/content/FINAL_HANDOFF.md` | Added historical marker for split-repo era |

## Residual Hits (historical-acceptable)

All remaining `Docs Hub` / `Claire_de_Binare_Docs` mentions fall into:
- **`docs/archive/`** — archive content, not active canon
- **`docs/meta/DOCS_HUB_*`** — retirement meta-docs (self-referentially about the retirement)
- **Guard tooling** (`docs-hub-guard.yml`, `enforce-root-baseline.ps1`) — functional guards
- **`governance_*_work/`**, `artifacts/`, `agents/tasklists/`, `copilot_briefing/` — historical work artifacts
- **`knowledge/agent_trust/ledger/`** — historical ledger entries

No active non-archive file points to `Claire_de_Binare_Docs` as a default read/edit path after this PR.

## Test plan

- [x] `grep -r Claire_de_Binare_Docs` re-scan confirms no active fehlpointers remain
- [ ] CI passes (docs-only change, no code impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1300