### PR TITLE
docs(dataflow): reconcile market_data subscribers with code reality (#1323)

### DIFF
--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -108,7 +108,7 @@ cdb_paper_runner  Up X minutes (healthy)
 ### Redis Channels
 | Channel | Publisher | Subscriber(s) |
 |---------|-----------|---------------|
-| market_data | cdb_ws | cdb_signal |
+| market_data | cdb_ws | cdb_market, cdb_candles, cdb_signal, cdb_paper_runner |
 | signals | cdb_signal | cdb_risk, cdb_db_writer |
 | orders | cdb_risk | cdb_execution, cdb_db_writer |
 | order_results | cdb_execution | cdb_risk, cdb_db_writer |
@@ -166,3 +166,4 @@ network-prod.yml  -> Network Isolation (optional)
 | Datum | Aenderung | Durch |
 |-------|-----------|-------|
 | 2025-12-28 | Initiale Erstellung via Context Build Sprint | Claude (Orchestrator) |
+| 2026-03-29 | market_data Subscriber-Liste: cdb_market, cdb_candles, cdb_paper_runner ergaenzt (#1323) | Claude |


### PR DESCRIPTION
## Summary
- market_data Subscriber-Liste in ARCHITECTURE_MAP hatte nur `cdb_signal`
- Tatsächlich subscriben 4 Services: `cdb_market`, `cdb_candles`, `cdb_signal`, `cdb_paper_runner`
- 3 fehlende Subscriber ergänzt, alle per Code-Trace verifiziert

## Evidence
| Subscriber | Code-Stelle | Stack |
|---|---|---|
| cdb_market | `services/market/service.py:52` → `SUBSCRIBE_CHANNEL = "market_data"` | BLUE |
| cdb_candles | `services/candles/config.py:27` → `input_channel = "market_data"` | BLUE |
| cdb_signal | `services/signal/config.py:40` → `input_topic = "market_data"` | RED |
| cdb_paper_runner | `tools/paper_trading/service.py:172` → subscribes `["market_data", ...]` | BLUE |

## Test plan
- [ ] Subscriber-Liste gegen `grep -r "market_data" services/ tools/paper_trading/` verifizieren
- [ ] Keine Subscriber vergessen (alle `.subscribe("market_data")` Callsites geprüft)

Closes #1323

🤖 Generated with [Claude Code](https://claude.com/claude-code)