### PR TITLE
docs(inventory): clarify services/validation as library/CLI, not compose-wired

### DIFF
--- a/docs/live-readiness/LR-002-STACK-SNAPSHOT.md
+++ b/docs/live-readiness/LR-002-STACK-SNAPSHOT.md
@@ -19,10 +19,10 @@
 | **reports** | Generates reports | `services/reports/` |
 | **risk** | **Risk gating + Decision Contract 0/1** | `services/risk/service.py` |
 | **signal** | Signal generation | `services/signal/service.py` |
-| **validation** | Validation logic | `services/validation/` |
+| **validation** | 72h validation gate logic (library/CLI, not compose-wired) | `services/validation/runner.py` |
 | **ws** | WebSocket data ingestion | `services/ws/service.py` |
 
-**Total:** 12 services (11 with Dockerfiles)
+**Total:** 11 compose-wired services + 1 library/CLI component (validation)
 
 ---
 


### PR DESCRIPTION
## Summary
- **Fixes** #1334
- Qualifies `services/validation/` in LR-002 Stack Map as library/CLI component, not a compose-wired service
- Corrects misleading total count ("12 services" → "11 compose-wired + 1 library/CLI")

## Evidence / Classification

| Check | Result |
|---|---|
| Compose service `cdb_validation`? | **No** — not in blue/red/base/dev/prod |
| Dockerfile? | **No** |
| HTTP endpoint / health check? | **No** — CLI runner (`argparse`, `__main__`) |
| Imported by any running service? | **No** — `runner.py` imports *from* `services.risk`, not the other way |
| `validation_data` volume? | Mounted on `cdb_risk:/app/data`, not a validation container |
| Tests? | **Yes** — unit + integration tests exist and pass |
| Governance refs? | SYSTEM_INVARIANTS references `gate_evaluator.py` as LR gate logic |

**Classification:** `inactive-dormant-but-intentionally-retained` — 72h validation gate library for future Live-Readiness gates, tested but not compose-wired.

## Files changed
- `docs/live-readiness/LR-002-STACK-SNAPSHOT.md` (2 lines)

## Test plan
- [ ] Verify no inventory sweep flags `services/validation/` as unclassified
- [ ] Confirm LR-002 table and total are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)