### PR TITLE
docs(governance): reconcile INV-006 gate contract with code reality

### DIFF
--- a/knowledge/governance/SYSTEM_INVARIANTS.md
+++ b/knowledge/governance/SYSTEM_INVARIANTS.md
@@ -139,12 +139,12 @@ This is not a redesign proposal, implementation guide, or "nice to have" require
 **Rationale:** Prevents untested strategies from accessing real capital. Requires proof of operational correctness.
 
 **Enforcement:**
-- Code: Working Repo `services/risk/live_trading_gate.py::authorize_level()` validates test completion
-- Code: Working Repo `services/validation/gate_evaluator.py::evaluate()` checks thresholds (min_orders=10, min_fill_rate=0.45)
-- Spec: Working Repo `docs/live-readiness/LR-007-SPEC.md` defines 72-hour validation requirements
+- Code: Working Repo `services/risk/live_trading_gate.py::check_authorization()` validates test completion
+- Code: Working Repo `services/validation/gate_evaluator.py::evaluate()` checks thresholds (min_orders=1 default via `VALIDATION_MIN_ORDERS`, min_fill_rate=0.45)
+- Spec: Working Repo `docs/live-readiness/LR-007-SPEC.md` defines validation requirements
 
 **References:**
-- Working Repo: `services/risk/live_trading_gate.py::authorize_level()`
+- Working Repo: `services/risk/live_trading_gate.py::check_authorization()`
 - Working Repo: `services/validation/gate_evaluator.py::GateThresholds`
 - Working Repo: `docs/live-readiness/LR-007-SPEC.md`
 


### PR DESCRIPTION
## Summary

Closes #1342.

INV-006 in `SYSTEM_INVARIANTS.md` beschrieb einen Gate-Vertrag der nicht mehr mit dem Code uebereinstimmt:
- `authorize_level()` → `check_authorization()` (Methode umbenannt)
- `min_orders=10` → `min_orders=1` (Default via `VALIDATION_MIN_ORDERS` Env-Variable)
- Hardcoded 72h-Referenz aus Spec-Zeile entfernt (Code = 72h, LR-007-Spec = 30d; Duration gehoert in die Spec, nicht ins Invariant-Doc)

Kein Code-Change. Nur Doku-Korrektur auf Repo-Wahrheit.

## Test plan

- [ ] `grep -n 'authorize_level\|min_orders=10' knowledge/governance/SYSTEM_INVARIANTS.md` → 0 Treffer
- [ ] INV-006 Referenzen matchen `services/risk/live_trading_gate.py::check_authorization()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)