### PR TITLE
docs: remove stale Docs-Hub wording from sessions README

### DIFF
--- a/knowledge/logs/sessions/README.md
+++ b/knowledge/logs/sessions/README.md
@@ -1,6 +1,6 @@
 # Sessions Log Index
 
-This directory stores session log notes and investigation records for Docs Hub work.
+This directory stores session log notes and investigation records.
 
 - [2025-12-28-issue-cleanup.md](2025-12-28-issue-cleanup.md)
 - [2025-12-29-cdb-ws-implementation.md](2025-12-29-cdb-ws-implementation.md)


### PR DESCRIPTION
## Summary

Closes #1352.

Einzeiliger Fix: "for Docs Hub work" aus `knowledge/logs/sessions/README.md` entfernt. Session-Logs sind seit der Konsolidierung lokal im Working Repo.

## Test plan

- [ ] `grep 'Docs Hub' knowledge/logs/sessions/README.md` → 0 Treffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)