### PR TITLE
docs(signal): clarify alerts-topic claim as not implemented

### DIFF
--- a/services/signal/README.md
+++ b/services/signal/README.md
@@ -43,7 +43,7 @@ curl http://localhost:8005/health
 - Top-Mover Analyse (`TOP_N`, `LOOKBACK_MINUTES` aus `.env`)
 - Momentum-Score (prozentuale Veränderung, Volumenfilter)
 - Konfigurierbare Mindestliquidität (`SIGNAL_MIN_VOLUME`, optional)
-- Glitch-Schutz: Idle-Timeout → Warnung auf `alerts` Topic (geplant)
+- Glitch-Schutz: Idle-Timeout (geplant, nicht implementiert — kein Publish auf `alerts` durch Signal-Service)
 
 ## 🧾 Konfiguration
 


### PR DESCRIPTION
## Summary

Closes #1350.

`services/signal/README.md` behauptete geplanten Publish auf `alerts` Topic. Signal-Service publiziert tatsaechlich nicht auf `alerts`. Klargestellt als "geplant, nicht implementiert".

## Test plan

- [ ] Formulierung macht klar: kein aktiver alerts-Publish durch Signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)