### PR TITLE
docs(governance): document VALIDATION_MIN_QTY_SUM in INV-006

### DIFF
--- a/knowledge/governance/SYSTEM_INVARIANTS.md
+++ b/knowledge/governance/SYSTEM_INVARIANTS.md
@@ -140,7 +140,7 @@ This is not a redesign proposal, implementation guide, or "nice to have" require
 
 **Enforcement:**
 - Code: Working Repo `services/risk/live_trading_gate.py::check_authorization()` validates test completion
-- Code: Working Repo `services/validation/gate_evaluator.py::evaluate()` checks thresholds (min_orders=1 default via `VALIDATION_MIN_ORDERS`, min_fill_rate=0.45)
+- Code: Working Repo `services/validation/gate_evaluator.py::evaluate()` checks thresholds (min_orders=1 default via `VALIDATION_MIN_ORDERS`, min_fill_rate=0.45, min_qty_sum=0.0 via `VALIDATION_MIN_QTY_SUM`)
 - Spec: Working Repo `docs/live-readiness/LR-007-SPEC.md` defines validation requirements
 
 **References:**


### PR DESCRIPTION
## Summary

Closes #1348.

`gate_evaluator.py` hat `min_qty_sum` (Default 0.0, env `VALIDATION_MIN_QTY_SUM`) als aktiven Gate-Threshold. INV-006 in SYSTEM_INVARIANTS.md dokumentierte ihn nicht.

Hinweis: Merge-Konflikt mit PR #1355 (#1342) erwartet — beide aendern dieselbe Zeile. Merge-Reihenfolge beachten.

## Test plan

- [ ] `grep min_qty_sum knowledge/governance/SYSTEM_INVARIANTS.md` → 1 Treffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)