### PR TITLE
docs: historize workdir-source refs in tracked governance artifacts

### DIFF
--- a/docs/governance/status/2026-02-24/README.md
+++ b/docs/governance/status/2026-02-24/README.md
@@ -26,3 +26,4 @@ Files:
 
 Notes:
 - Snapshot ist ein Governance-/Audit-Artefakt. Keine Aussagen über Trading-Performance.
+- Historisch: Referenzen auf `Claire_de_Binare_Docs` und `governance_*_work/` Pfade spiegeln den Stand vom 2026-02-24 (pre-consolidation). Nicht als aktuelle Repo-Topologie lesen.

--- a/reports/PASS45_PLACEHOLDER_CLEANUP_REPORT.md
+++ b/reports/PASS45_PLACEHOLDER_CLEANUP_REPORT.md
@@ -1,7 +1,9 @@
 ## PASS 4.5 Placeholder Cleanup Report
 
+> Historical generated report (2026-02-24). The `governance_core_status_report_work` source path refers to a local workspace that is no longer tracked.
+
 - Repo: `jannekbuengener/Claire_de_Binare`
-- CSV source: `governance_core_status_report_work\reports\GOVERNANCE_CORE_STATUS_REPORT_v2.csv`
+- CSV source: `governance_core_status_report_work\reports\GOVERNANCE_CORE_STATUS_REPORT_v2.csv` *(historical local path)*
 - Candidate issues (placeholder=true AND has_hard_evidence=true): `7`
 - Patched issues: `7`
 - evidence-only diff verified (all processed): `true`


### PR DESCRIPTION
## Summary

Closes #1344.

Tracked governance-/report-Artefakte ausserhalb der ignorierten `governance_*_work/` Verzeichnisse enthielten noch Workdir-Pfade und Docs-Hub-Links ohne historische Markierung.

- `docs/governance/status/2026-02-24/README.md`: Pre-consolidation-Note hinzugefuegt
- `reports/PASS45_PLACEHOLDER_CLEANUP_REPORT.md`: Historical-Marker und Pfad-Annotation

Kein Inhalts-Rewrite — nur minimale Markierung zur Disambiguierung.

## Test plan

- [ ] Leser erkennt Docs-Hub/Workdir-Referenzen als historisch

🤖 Generated with [Claude Code](https://claude.com/claude-code)