### PR TITLE
fix(soak): auto-stop guard + ARTIFACT_ROOT override (#1419)

### DIFF
--- a/infrastructure/scripts/soak_monitor.sh
+++ b/infrastructure/scripts/soak_monitor.sh
@@ -186,18 +186,30 @@ fi
 # Validation runs skip this guard (no fixed target duration).
 # Issue #1419.
 # ---------------------------------------------------------------------------
-SOAK_TARGET_HOURS="${SOAK_TARGET_HOURS:-72}"
+SOAK_TARGET_HOURS_RAW="${SOAK_TARGET_HOURS:-72}"
+case "$SOAK_TARGET_HOURS_RAW" in
+  ''|*[!0-9]*)
+    echo "ERROR: SOAK_TARGET_HOURS must be an integer, got '$SOAK_TARGET_HOURS_RAW'. Falling back to 72." >&2
+    SOAK_TARGET_HOURS=72
+    ;;
+  *)
+    SOAK_TARGET_HOURS="$SOAK_TARGET_HOURS_RAW"
+    ;;
+esac
 if [ "$SOAK_RUN_INTENT" = "lr040" ] && [ "$ELAPSED_HOURS" -ge "$SOAK_TARGET_HOURS" ]; then
   (
     flock -x -w 30 200 || exit 0
     _CK=-1
     [ -f "$LAST_CHECKPOINT_FILE" ] && _CK=$(cat "$LAST_CHECKPOINT_FILE")
-    if [ "$ELAPSED_HOURS" -le "$_CK" ]; then
-      : # already written
+    if [ "$_CK" -ge "$SOAK_TARGET_HOURS" ]; then
+      : # monitoring window completion already recorded; do not mutate artifacts
+    elif [ "$ELAPSED_HOURS" -le "$_CK" ]; then
+      : # already written for this or a later hour within the window
     else
       echo "$TIMESTAMP - Hour $ELAPSED_HOURS: Monitoring window complete ($SOAK_TARGET_HOURS h reached)" \
         >> "$ARTIFACT_PATH/hourly_checks.log"
-      echo "$ELAPSED_HOURS" > "$LAST_CHECKPOINT_FILE"
+      # Cap the checkpoint at SOAK_TARGET_HOURS to act as a completion sentinel
+      echo "$SOAK_TARGET_HOURS" > "$LAST_CHECKPOINT_FILE"
     fi
   ) 200>"$ARTIFACT_PATH/checkpoint.lock"
   echo "LR-040 monitoring window complete (${ELAPSED_HOURS}h >= ${SOAK_TARGET_HOURS}h). Skipping checks."

--- a/tests/unit/scripts/test_soak_monitor_timeline.py
+++ b/tests/unit/scripts/test_soak_monitor_timeline.py
@@ -1470,3 +1470,18 @@ class TestAutoStopGuard:
 
     def test_guard_custom_target(self) -> None:
         assert would_skip_guard(5, 5, "lr040") is True
+
+    def test_guard_present_in_soak_monitor_sh(self) -> None:
+        """Verify the bash implementation contains the auto-stop guard."""
+        script = (
+            Path(__file__).resolve().parents[3]
+            / "infrastructure"
+            / "scripts"
+            / "soak_monitor.sh"
+        )
+        content = script.read_text(encoding="utf-8")
+        assert "SOAK_TARGET_HOURS" in content, "SOAK_TARGET_HOURS variable missing"
+        assert (
+            'SOAK_RUN_INTENT" = "lr040"' in content
+        ), "lr040 intent guard condition missing"
+        assert "Monitoring window complete" in content, "Guard exit message missing"


### PR DESCRIPTION
## Summary

- Adds auto-stop guard to `soak_monitor.sh`: after `SOAK_TARGET_HOURS` (default 72) elapsed hours, the monitor exits cleanly without performing restart detection or writing markers. Prevents post-window Docker/host restarts from tainting a valid LR-040 run.
- Makes `ARTIFACT_ROOT` env-overridable (`${ARTIFACT_ROOT:-artifacts}`) for safe verification in disposable test paths without contaminating production artifacts.
- Adds `would_skip_guard()` Python mirror helper + 5 mandatory test cases in `test_soak_monitor_timeline.py`.

## Context (Issue #1419)

The last LR-040 72h soak run (`soak_test_20260325_121250`) got verdict INCONCLUSIVE. Primary taint: environment interruption at 2026-03-26 17:33 UTC (~29h into the 72h window). The monitor continued running post-72h (still active at Hour 158+), accumulating additional restart events that further contaminated the artifact directory.

## Files changed

- `infrastructure/scripts/soak_monitor.sh` — auto-stop guard + ARTIFACT_ROOT override
- `tests/unit/scripts/test_soak_monitor_timeline.py` — 5 new tests for guard logic

## Test plan

- [x] 115/115 existing + new tests pass (`pytest tests/unit/scripts/test_soak_monitor_timeline.py`)
- [x] Black formatting clean
- [ ] CI pipeline (Unit/Integration + Lint + policy-gate)
- [ ] Manual verification with `ARTIFACT_ROOT=$(mktemp -d) SOAK_TARGET_HOURS=0` after merge

Closes #1419

🤖 Generated with [Claude Code](https://claude.com/claude-code)