### PR TITLE
chore(session): close session #24 — #1426 market healthcheck

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -3,8 +3,8 @@
 **Status Class**: Working Repo / Engineering Status
 **Authority**: Current repo/main/test/dependency snapshot; not the canonical live-readiness or Echtgeld Go/No-Go source.
 **Operational Canon**: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-**Last Updated**: 2026-04-01
-**Latest Main Commit**: 9f92651c — chore(session): close session #22 — git-divergenz + PR-batch #1414/#1415 + issues #1410–#1413 (#1416)
+**Last Updated**: 2026-04-04
+**Latest Main Commit**: a0685a26 — Merge branch 'main' (includes #1420/#1425 soak flock fix)
 **Previous**: 04b91d4b — chore(sessions): nachziehen Session 18–21 — #1410 / #1411 / #1413 + Close-Commits
 
 ---
@@ -34,6 +34,7 @@
   - **Merged (Session 21+22, 2026-03-31/04-01)**: #1412 — LR-AUDIT-STATUS / CURRENT_STATUS SSOT-Trennung bereinigt. Operative Phasentabelle aus CURRENT_STATUS.md entfernt; Rueckkopplung in LR-AUDIT-STATUS beseitigt; P-Phasen-Inline-Status aus AGENTS.md entfernt. PR #1414 (bb0c42c0). Issue #1412 geschlossen.
   - **Merged (Session 22, 2026-04-01)**: Git-Divergenz aufgeloest; PR-Batch #1414+#1415 durchgezogen; Issues #1410/#1411/#1412/#1413 geschlossen. PR #1416 (9f92651c).
   - **Merged (Session 23, 2026-04-01)**: #1409 — ARCHITECTURE_MAP + SERVICE_CATALOG gegen BLUE/RED-Runtime reconciled; Logging Overlay als separates Overlay klassifiziert; CDB_DOCKER_STACK_INVENTORY ergaenzt. PR #1416 (9f92651c). Issue #1409 geschlossen.
+  - **Open (Session 24, 2026-04-04)**: #1430 — `start_period: 30s` fuer cdb_market-Healthcheck (compose.blue.yml). Fixes #1426 (unhealthy 503 im LR-040-Preflight). Pending merge.
 
 ---
 

--- a/knowledge/logs/sessions/2026-04-04-issue-1426-market-healthcheck-start-period.md
+++ b/knowledge/logs/sessions/2026-04-04-issue-1426-market-healthcheck-start-period.md
@@ -1,0 +1,37 @@
+# Session: Issue #1426 — cdb_market unhealthy (503) Healthcheck-Fix
+
+**Datum:** 2026-04-04
+**Issue:** #1426 `[MARKET][HEALTH] cdb_market meldet unhealthy (503) ohne Restart im LR-040-Preflight`
+**PR:** #1430
+**Branch:** `fix/1426-market-healthcheck-start-period`
+**Commit:** `f5f60ff4`
+
+---
+
+## Befund
+
+- `cdb_market` Health-Endpoint (`/health`) liefert HTTP 503, wenn `_redis_connected` oder `_subscription_active` noch nicht gesetzt sind
+- Flask startet auf Daemon-Thread bevor `_subscription_active = True` gesetzt wird (Startup-Race-Window)
+- Docker-Healthcheck in `compose.blue.yml` hatte kein `start_period` — Failures zaehlen ab erster Pruefung
+- Beobachtet im LR-040-Preflight: `knowledge/logs/sessions/2026-03-22-lr040-soak-start.md:72`
+
+## Umgesetzter Fix
+
+- `infrastructure/compose/compose.blue.yml`: `start_period: 30s` zum `cdb_market`-Healthcheck hinzugefuegt
+- Einzelne Zeile, kein Service-Code geaendert
+- Validierung: `docker compose config` bestanden
+
+## Scope-Entscheidung
+
+- Nur Fix 1 (Compose-seitig, `start_period`) umgesetzt
+- Fix 2 (Redis-Startup-Retry in `services/market/service.py`) bewusst nicht mitgezogen — im LR-040-Befund nicht als tatsaechliche Ursache belegt
+
+## Side-Issue-Kandidaten
+
+- Permanenter Degraded-Mode ohne Recovery in `services/market/service.py:352-355`: kein Reconnect-Versuch bei Redis-Startup-Failure
+- Andere Services (`cdb_candles`, `cdb_regime`, `cdb_allocation`) haben ebenfalls kein `start_period` — gleiche Klasse, separater Sweep-Kandidat
+
+## Status
+
+- PR #1430 erstellt, Issue #1426 kommentiert
+- Status: `erledigt` (pending PR-Merge)


### PR DESCRIPTION
## Summary
- Session log for Issue #1426 analysis + fix
- CURRENT_STATUS.md updated with PR #1430 reference

## Changes
- `knowledge/logs/sessions/2026-04-04-issue-1426-market-healthcheck-start-period.md` (new)
- `CURRENT_STATUS.md` (updated last-updated date + session 24 entry)

## Test plan
- [ ] Docs-only, no code changes — CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)