### PR TITLE
evidence(p5): lean shadow evidence handoff — closes #1423

### DIFF
--- a/reports/p5_canary/2026-04-04/lean_shadow_evidence_handoff.yaml
+++ b/reports/p5_canary/2026-04-04/lean_shadow_evidence_handoff.yaml
@@ -1,0 +1,39 @@
+schema_version: "1.0"
+handoff_type: lean_shadow_evidence_run
+purpose: post_go_shadow_evidence_anchor
+workflow_name: "Shadow + Soak Evidence"
+run_id: "24001373890"
+run_url: https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/24001373890
+ref: refs/heads/main
+commit_sha: 1a0ebaba88fce8d6050f1a2bdb6093011dfe26bc
+soak_profile: lean
+soak_minutes: 5
+gate_status: PASS
+completed_utc: 2026-04-05T12:26:21Z
+artifact_name: shadow-soak-evidence-24001373890
+parent_proof_pack: reports/p5_canary/2026-04-04/
+operator: jannekbuengener
+
+gate_checks:
+  shadow_blocked_total_gte_1: true
+  execution_orders_filled_total_eq_0: true
+  auditable_reject_present: true
+  reject_filled_quantity_eq_0: true
+  shadow_probe_artifact_present: true
+  has_live_data_true: true
+  orders_approved_eq_0: true
+  risk_blocked_all_true: true
+  runtime_mode_verified: true
+  kill_switch_precheck_inactive: true
+
+probe_result:
+  probe_order_id: ci-shadow-probe-24001373890
+  order_result_status: REJECTED
+  error_message: "Order blocked: shadow mode (zero execution)"
+  filled_quantity: 0.0
+
+notes:
+  - Lean shadow evidence run triggered after formal GO path closure (PR #1434)
+  - All 10 gate checks PASS; shadow probe correctly REJECTED with zero execution
+  - This is the continuity proof following the P5 prestart pack
+  - Runtime mode mock confirmed; kill switch inactive

--- a/reports/p5_canary/2026-04-04/manifest.json
+++ b/reports/p5_canary/2026-04-04/manifest.json
@@ -40,7 +40,8 @@
       "endpoints/execution_status.json": "5ea4b33d8945bff67a806af7cc0fe5fe6959cb6603ed0fd464bf4d753d5f7243",
       "endpoints/risk_status.json": "eb73fef46978f824709a5f20d2ab23889d6640f963e915b3bdc9d3efbf3ff2dc",
       "endpoints/kill_switch_status.json": "62edd97262835310625203806b14fa1bcce70216efd0bebbfcd6319b4fa22d31",
-      "lr040/lr040_soak_gate_eval.json": "0b4a8b9ccce37d3078965d739aaf44e9ce111b0e44b7185c4c346ca7fb3f14ce"
+      "lr040/lr040_soak_gate_eval.json": "0b4a8b9ccce37d3078965d739aaf44e9ce111b0e44b7185c4c346ca7fb3f14ce",
+      "lean_shadow_evidence_handoff.yaml": "c77fcbc3447e07a7aaa9e1e352463af8e3172711a47804a6d9bf6708c2e900db"
     }
   },
   "notes": [


### PR DESCRIPTION
## Summary

- Lean shadow evidence run `24001373890` on main (`1a0ebaba`) completed with `gate_status: PASS`
- Shadow probe correctly REJECTED (`filled_quantity: 0.0`, `"Order blocked: shadow mode (zero execution)"`)
- All 10 gate checks PASS; runtime mode mock, kill switch inactive
- `lean_shadow_evidence_handoff.yaml` anchors the run evidence in the P5 proof pack
- manifest.json checksum updated

Closes #1423

## Test plan

- [x] Lean shadow run completed successfully (run 24001373890)
- [x] Gate status PASS (10/10 checks)
- [ ] CI green (ci + policy-gate)
- [ ] `sha256sum lean_shadow_evidence_handoff.yaml` matches manifest.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)