### PR TITLE
fix(policy-gate): infra-only file-inference for pure infrastructure/** diffs

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -114,6 +114,9 @@ jobs:
             } else if (changedFiles.length > 0 && changedFiles.every(isWorkflowFile)) {
               category = 'workflows-only';
               categorySource = 'file-inference';
+            } else if (changedFiles.length > 0 && changedFiles.every(isInfraFile)) {
+              category = 'infra-only';
+              categorySource = 'file-inference';
             }
 
             const failures = [];

--- a/docs/runbooks/merge_policy_ci_gate.md
+++ b/docs/runbooks/merge_policy_ci_gate.md
@@ -93,6 +93,12 @@ and changed files:
 | `infra-only` | `infra-only` | `[infra-only]` or `infra-only:` | `infrastructure/**` and `.github/workflows/**` |
 | `core/service` | none | none | Any other diff; requires `manual-approval` or `allow-core-change` |
 
+> **Auto-inference:** `infra-only` is inferred automatically only when **all** changed files
+> are pure `infrastructure/**` paths. Mixed diffs (e.g. `infrastructure/**` +
+> `.github/workflows/**`) are **not** auto-inferred and remain fail-closed at `core/service`,
+> even though the `infra-only` category permits both path sets when set via label or title prefix.
+> An explicit label or title prefix is required for mixed diffs.
+
 Hard-fails for workflow changes in `.github/workflows/**`:
 
 - Any workflow containing `pull_request_target`


### PR DESCRIPTION
## Summary

- Adds `infra-only` auto-inference to `policy-gate.yml`: when **all** changed files are pure `infrastructure/**` paths, the category is set to `infra-only` with `categorySource = 'file-inference'`
- Mixed diffs (`infrastructure/**` + `.github/workflows/**`, or infra + docs, etc.) are **not** auto-inferred — they remain fail-closed at `core/service`
- Explicit label/prefix (`infra-only`) continues to work as before for mixed sets
- Adds a clarifying note in `docs/runbooks/merge_policy_ci_gate.md` below the category table

Closes #1461

## Scope boundaries respected

- No new category
- No auto-inference for `scripts/**`, `knowledge/**`, or other maintenance paths
- No Dependabot/bot special logic
- No mixed-file relaxation
- `isInfraFile` already existed; reused as-is

## Expected behavior

| Changed files | Category |
|---|---|
| `infrastructure/compose/foo.yml` only | `infra-only` (file-inference) |
| `infrastructure/scripts/bar.sh` only | `infra-only` (file-inference) |
| `infrastructure/**` + `.github/workflows/**` | `core/service` (fail-closed) |
| `infrastructure/**` + `docs/**` | `core/service` (fail-closed) |
| `.github/workflows/**` only | `workflows-only` (unchanged) |
| `docs/**` only | `docs-only` (unchanged) |

## Test plan

- [ ] policy-gate CI run on this PR (workflows-only category, no infra files changed)
- [ ] After merge: open a test PR with only `infrastructure/**` changes and verify policy-gate reports `infra-only (file-inference)`
- [ ] Verify mixed PR (infra + workflows) still requires explicit label

🤖 Generated with [Claude Code](https://claude.com/claude-code)