### PR TITLE
fix(session-close): pre-close sweep guard for canonical artifact paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 
 MCP_CONFIG_PATHS ?=
 
-.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop rollback cleanup mcp-config-validate security-scan
+.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop rollback cleanup mcp-config-validate security-scan pre-close
 
 help:
 	@echo "Claire de Binare - Test Commands"
@@ -58,6 +58,9 @@ help:
 	@echo "  make backup-postgres-only    - Legacy PostgreSQL-only Backup"
 	@echo "  make restore                 - Restore aus F:\\Claire_Backups"
 	@echo "  make backup-health           - Backup-Aktualitaet pruefen"
+	@echo ""
+	@echo "Session-Close:"
+	@echo "  make pre-close               - Pre-close sweep: prueft untracked Artefakte in kanonischen Pfaden"
 	@echo ""
 	@echo "Repo-Hygiene & Rollback:"
 	@echo "  make rollback MR=<number>    - Rollback eines Merge Requests"
@@ -179,6 +182,9 @@ docker-health:
 # ============================================================================
 # Paper Trading (14-Tage Test)
 # ============================================================================
+
+pre-close:
+	@bash scripts/pre_close_sweep.sh
 
 systemcheck:
 	@echo "🔍 Führe Pre-Flight-Checks aus..."

--- a/agents/roles/CLAUDE.md
+++ b/agents/roles/CLAUDE.md
@@ -92,6 +92,7 @@ Wenn das Verständnis falsch ist:
 
 ### Session-Ende (Pflicht)
 Keine Session gilt als abgeschlossen, bevor nicht:
+- `make pre-close` ausgeführt wurde und kein untracked Artefakt in kanonischen Pfaden gemeldet wird
 - eine Session-Datei gepflegt ist
 - `CURRENT_STATUS.md` aktualisiert wurde, wenn sich der Repo-/Engineering-Status
   geaendert hat

--- a/scripts/pre_close_sweep.sh
+++ b/scripts/pre_close_sweep.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# pre_close_sweep.sh — Pre-close guard for canonical versioned artifact trees.
+#
+# Checks whether untracked, non-ignored files exist in the canonical session
+# artifact paths before a session is closed. If any are found, it prints them
+# and exits non-zero so the operator can commit or explicitly ignore them.
+#
+# Sweep scope is derived from the #1450 batch (commit 39c5d864):
+#   knowledge/logs/sessions/   — session evidence logs (20 of 40 files)
+#   docs/runbooks/evidence/    — runbook drill evidence (3 files)
+#   reports/                   — reports and canary output (2 files)
+#   docs/operations/           — operational verification docs (1 file)
+#
+# This script does NOT introduce any .gitignore entries and does NOT flag
+# files that are already covered by existing ignore rules.
+#
+# Usage:
+#   bash scripts/pre_close_sweep.sh
+#   make pre-close
+
+set -euo pipefail
+
+SWEEP_PATHS=(
+  "knowledge/logs/sessions"
+  "docs/runbooks/evidence"
+  "reports"
+  "docs/operations"
+)
+
+untracked=()
+
+for path in "${SWEEP_PATHS[@]}"; do
+  if [ -d "$path" ]; then
+    while IFS= read -r file; do
+      [[ -n "$file" ]] && untracked+=("$file")
+    done < <(git ls-files --others --exclude-standard -- "$path")
+  fi
+done
+
+if [ ${#untracked[@]} -gt 0 ]; then
+  echo "ERROR: pre-close sweep found untracked files in canonical artifact paths."
+  echo ""
+  echo "Untracked files:"
+  for f in "${untracked[@]}"; do
+    echo "  $f"
+  done
+  echo ""
+  echo "Action required before session close:"
+  echo "  - Commit these files if they belong in the repo, OR"
+  echo "  - Add them to .gitignore if they are local-only artifacts."
+  echo "  Do not leave them silently untracked."
+  exit 1
+fi
+
+echo "pre-close sweep: OK — no untracked files in canonical artifact paths."
+exit 0


### PR DESCRIPTION
## Summary

- Adds `scripts/pre_close_sweep.sh`: checks canonical versioned artifact trees for untracked non-ignored files before session close
- Exits non-zero and prints offending paths — the operator must commit or explicitly ignore them
- Wires into `make pre-close` and one bullet in `agents/roles/CLAUDE.md` Session-Ende checklist
- No `.gitignore` changes, no auto-commits, no broad ignore policy

Closes #1464

## Root Cause (#1450)

The #1450 batch (commit `39c5d864`) was a post-session catch-up commit: 40 files in canonical artifact paths had been created during sessions but were never committed at session close. The guard makes this detectable before closing.

## Sweep scope (evidence-based from #1450)

| Path | Files in #1450 batch |
|---|---|
| `knowledge/logs/sessions/` | 20 |
| `docs/runbooks/evidence/` | 3 |
| `reports/` | 2 |
| `docs/operations/` | 1 |

`cdb_agent_sdk/tests/` and `infrastructure/scripts/` (also in batch) are code/infra paths, not canonical session artifact trees — excluded from sweep scope.

## Guard behavior

Uses `git ls-files --others --exclude-standard` — only untracked non-ignored files are flagged.
Files already covered by `.gitignore` (e.g. `*.tmp`, local-only artifacts) produce no false positives.

## Test plan

- [ ] `bash scripts/pre_close_sweep.sh` on clean repo → exit 0
- [ ] `touch knowledge/logs/sessions/test.md && make pre-close` → exit 1, prints path
- [ ] `touch reports/test.md && make pre-close` → exit 1, prints path
- [ ] `touch reports/test.tmp && make pre-close` → exit 0 (ignored by .gitignore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)