### PR TITLE
fix(dr-docs): anchor backup/restore front door in DR documents (#1460)

### DIFF
--- a/knowledge/operations/disaster_recovery/QUICK_START.md
+++ b/knowledge/operations/disaster_recovery/QUICK_START.md
@@ -15,20 +15,26 @@ docker compose version
 ```
 ✅ Sollte funktionieren nach Neuinstallation
 
-### 2. Restore ausführen (kanonischer Einstieg)
+### 2. Verfügbare Backups anzeigen
 ```powershell
 make restore
-# → infrastructure/scripts/restore_all.ps1 — wählt interaktiv aus F:\Claire_Backups
+# → listet Archive in F:\Claire_Backups
+```
+
+### 3. Restore mit konkretem Backup-Namen ausführen
+```powershell
+powershell.exe -ExecutionPolicy Bypass -File infrastructure/scripts/restore_all.ps1 -BackupName cdb_backup_YYYYMMDD_HHMMSS
+# → Backup-Name aus Schritt 2 einsetzen
 ```
 ⏱️ Dauer: ~2-3 Minuten
 
-### 3. Stack starten
+### 4. Stack starten
 ```powershell
 make docker-up
 ```
 ⏱️ Dauer: ~30-60 Sekunden
 
-### 4. Backup-Health prüfen
+### 5. Backup-Health prüfen
 ```powershell
 make backup-health
 # → infrastructure/scripts/backup_health_check.ps1
@@ -141,5 +147,5 @@ cdb_paper_runner - running/healthy
 ---
 
 **Gesamt-Dauer für komplettes Restore:** ~5 Minuten  
-**Kanonischer Einstieg:** `make restore` → `infrastructure/scripts/restore_all.ps1`  
+**Kanonischer Einstieg:** `make restore` (Backup-Liste), dann `restore_all.ps1 -BackupName <name>`  
 **Hintergrund-Referenz:** `RESTORE_GUIDE.md` (historischer 2025-12-31-Snapshot)

--- a/knowledge/operations/disaster_recovery/README.md
+++ b/knowledge/operations/disaster_recovery/README.md
@@ -67,14 +67,18 @@ Diese Dokumentation beschreibt den **Docker Volume Backup und Restore Prozess** 
 **Nach Docker Neuinstallation:**
 
 ```powershell
-# 1. Restore ausführen — kanonischer Einstieg (2-3 Min)
+# 1. Verfügbare Backups anzeigen
 make restore
-# → infrastructure/scripts/restore_all.ps1 — wählt interaktiv aus F:\Claire_Backups
+# → listet Archive in F:\Claire_Backups
 
-# 2. Stack starten (30-60 Sek)
+# 2. Restore mit konkretem Backup-Namen ausführen (2-3 Min)
+powershell.exe -ExecutionPolicy Bypass -File infrastructure/scripts/restore_all.ps1 -BackupName cdb_backup_YYYYMMDD_HHMMSS
+# → Backup-Name aus Schritt 1 einsetzen
+
+# 3. Stack starten (30-60 Sek)
 make docker-up
 
-# 3. Health prüfen
+# 4. Health prüfen
 make backup-health
 ```
 
@@ -124,8 +128,12 @@ docker network ls > ${BACKUP_DIR}\network_list.txt
 
 ### Kanonischer Einstieg (empfohlen):
 ```powershell
+# Schritt 1: verfügbare Backups anzeigen
 make restore
-# → infrastructure/scripts/restore_all.ps1 — wählt interaktiv aus F:\Claire_Backups
+# → listet Archive in F:\Claire_Backups
+
+# Schritt 2: Restore mit konkretem Namen ausführen
+powershell.exe -ExecutionPolicy Bypass -File infrastructure/scripts/restore_all.ps1 -BackupName cdb_backup_YYYYMMDD_HHMMSS
 ```
 
 ### Hintergrund-Referenz:

--- a/knowledge/operations/disaster_recovery/RESTORE_GUIDE.md
+++ b/knowledge/operations/disaster_recovery/RESTORE_GUIDE.md
@@ -1,7 +1,7 @@
 # Docker Reinstall - Restore Guide
 
 > **Historischer Snapshot — 2025-12-31-Docker-Reinstall.**  
-> Aktuelle Restore-Front-Door: `make restore` (→ `infrastructure/scripts/restore_all.ps1`)  
+> Aktuelle Restore-Front-Door: `make restore` (listet Backups), dann `restore_all.ps1 -BackupName <name>` (führt Restore aus)  
 > Aktuelle Backup-Location: `F:\Claire_Backups` — Setup und Health: `docs/runbooks/BACKUP_AUTOMATION.md`  
 > Die nachfolgenden Befehle sind event-spezifisch und referenzieren den damaligen Backup-Pfad.
 


### PR DESCRIPTION
## Summary

Closes #1460. Enger Docs-Schnitt — nur Operator-Einstiegspunkte für Backup/Restore/Backup-Health in den aktiven DR-Dokumenten korrigiert.

- **README.md**: Quick-Start und Restore-Prozess zeigen jetzt `make restore` / `restore_all.ps1` als kanonischen Einstieg; Backup-Prozess nennt `make backup` / `backup_all.ps1` explizit als Front Door; `Automatisches Backup (TODO)` durch Referenz auf aktiven Windows-Task + `BACKUP_AUTOMATION.md` ersetzt; `restore_volumes.ps1` / `verify_restore.ps1` als historische Artefakte (2025-12-31-Snapshot) markiert
- **QUICK_START.md**: Hardcodierter Event-Pfad `D:\Dev\Backups\docker_reinstall_20251231_075507` + `restore_volumes.ps1` durch `make restore` / `restore_all.ps1` ersetzt; `F:\Claire_Backups` als aktuelle Backup-Location sichtbar gemacht
- **RESTORE_GUIDE.md**: Top-of-document-Notice ergänzt — macht klar dass dies ein historischer 2025-12-31-Snapshot ist und nennt `make restore` / `restore_all.ps1` als aktuelle Front Door

Keine Script-Änderungen, keine Makefile-Änderungen, kein DR-Refactor.

## Validierung

- `make backup` → `infrastructure/scripts/backup_all.ps1` (Makefile Zeile 199) ✅
- `make restore` → `infrastructure/scripts/restore_all.ps1` (Makefile Zeile 207) ✅
- `make backup-health` → `infrastructure/scripts/backup_health_check.ps1` (Makefile Zeile 211) ✅
- Keine host-spezifischen Pfade mehr als aktive Kanonik in den DR-Docs ✅
- `docs/runbooks/BACKUP_AUTOMATION.md` als SSOT für aktive Automation referenziert ✅

## Test plan

- [ ] README.md Quick-Start zeigt `make restore` als Schritt 1
- [ ] README.md Backup-Prozess nennt `make backup` / `backup_all.ps1` als kanonischen Einstieg
- [ ] QUICK_START.md Schritt 2 zeigt `make restore` statt event-spezifischen Pfad
- [ ] RESTORE_GUIDE.md hat top-of-document Notice mit aktueller Front Door
- [ ] Kein Vorkommen von `restore_volumes.ps1` ohne historischen Kontext-Hinweis

🤖 Generated with [Claude Code](https://claude.com/claude-code)