### PR TITLE
fix(backup): replace Compress-Archive with .NET streaming ZIP to fix OOM (#1478)

### DIFF
--- a/infrastructure/scripts/backup_all.ps1
+++ b/infrastructure/scripts/backup_all.ps1
@@ -447,7 +447,10 @@ Write-Step "Compressing archive..."
 
 $archivePath = Join-Path $BackupDir "$BACKUP_NAME.zip"
 try {
-    Compress-Archive -Path $WORK_DIR -DestinationPath $archivePath -Force
+    # Use .NET streaming ZIP to avoid Compress-Archive OutOfMemoryException on large dumps
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    if (Test-Path $archivePath) { Remove-Item $archivePath -Force }
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($WORK_DIR, $archivePath)
 
     if (Test-Path $archivePath) {
         $archiveSizeMB = [math]::Round((Get-Item $archivePath).Length / 1MB, 2)


### PR DESCRIPTION
## Problem
`Compress-Archive` lädt alle Quelldateien vollständig in den Heap und wirft `OutOfMemoryException` bei realistischen Postgres-Dump-Größen (≥ 500 MB). Blockierte den #1473-Drill und jede produktive DR-Validierung.

Siehe: #1478

## Fix
Engster möglicher Eingriff — nur der Compression-Block in `backup_all.ps1` (3 Zeilen):

```diff
-    Compress-Archive -Path $WORK_DIR -DestinationPath $archivePath -Force
+    # Use .NET streaming ZIP to avoid Compress-Archive OutOfMemoryException on large dumps
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    if (Test-Path $archivePath) { Remove-Item $archivePath -Force }
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($WORK_DIR, $archivePath)
```

`ZipFile.CreateFromDirectory` ist reines .NET BCL (keine externe Dependency), streaming-basiert, kein Heap-Load der Quelldateien.

## Validierung (realer Lauf, 2026-04-07)

| Check | Ergebnis |
|---|---|
| `make backup` Exit-Code | **0** |
| Postgres-Dump (628 MB) | PASS |
| Redis-Dump (8.1 MB) | PASS |
| ZIP erzeugt | `cdb_backup_20260407_113446.zip` — 78.4 MB |
| ZIP-Inhalt | `manifest.json`, `postgres_dump.sql`, `redis_dump.rdb` |
| Work-Directory entfernt | True |
| `make backup-health` | **PASS** — 0h old |
| OOM | nicht aufgetreten |
| Laufzeit | 61.7 s |

## Scope
- Nur `infrastructure/scripts/backup_all.ps1`, nur Compression-Block
- Keine Änderung an fachfremden Teilen, kein Refactor, keine neuen Parameter

Closes #1478
Unblocks #1473

🤖 Generated with [Claude Code](https://claude.com/claude-code)