### PR TITLE
docs(status): reconcile stage and lr canon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,17 +20,22 @@ Wichtige kanonische Dateien:
 - [`knowledge/CDB_KNOWLEDGE_HUB.md`](knowledge/CDB_KNOWLEDGE_HUB.md)
 - [`CURRENT_STATUS.md`](CURRENT_STATUS.md)
 - [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)
+- [`docs/runbooks/CONTROL_REGISTER.md`](docs/runbooks/CONTROL_REGISTER.md)
+- [`knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md`](knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md)
 - [`PROJECT_STATUS.md`](PROJECT_STATUS.md)
 
 Aktueller Projektstand:
 - Working Repo ist der produktive Canon fuer Agenten-, Governance-, Knowledge- und Navigationsdoku.
-- Engineering-Status laut [`CURRENT_STATUS.md`](CURRENT_STATUS.md): `main` gruen; offene PRs und Arbeitsstatus aktuell dort einsehen.
+- Repo-/Engineering-Status steht in [`CURRENT_STATUS.md`](CURRENT_STATUS.md); offene PRs, letzte Main-Merges und Arbeitsstatus dort einsehen.
 - Operatives Live-Readiness-Verdikt laut [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md): `NO-GO`; reale Trades bleiben durch Human Gate blockiert.
+- Board-/Stage-Status laut [`docs/runbooks/CONTROL_REGISTER.md`](docs/runbooks/CONTROL_REGISTER.md): `stage:trade-capable` (ratifiziert 2026-04-08 via Issue `#1492`); dieses Stage-System ist orthogonal zum LR-System und autorisiert weder Live-Kapital noch Strategie-Freigabe.
 - [`PROJECT_STATUS.md`](PROJECT_STATUS.md) und `knowledge/CURRENT_STATUS.md` sind historische Snapshots und nicht der aktuelle Gesamtstatus.
 
 Status-Regel:
+- Fuer Board-/Stage-Status und operativen Fokus zuerst [`docs/runbooks/CONTROL_REGISTER.md`](docs/runbooks/CONTROL_REGISTER.md) lesen; Stage-Mapping und Board-Regeln stehen in [`knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md`](knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md).
 - Fuer aktuellen Repo- und Engineering-Stand zuerst [`CURRENT_STATUS.md`](CURRENT_STATUS.md) lesen.
 - Fuer operativen Go/No-Go- und Echtgeld-Stand zuerst [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md) lesen.
+- Stage-Aussagen nie als LR-Go/No-Go lesen und LR-Verdikte nie aus einer Board-Stage ableiten.
 - Historische Statusdateien nur als Rueckgriff verwenden und nicht als SSOT behandeln.
 
 Hinweis:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,11 @@ The authoritative role definition for Claude is at `agents/roles/CLAUDE.md`. Rea
 3. `knowledge/SYSTEM.CONTEXT.md`
 4. `CURRENT_STATUS.md` (current repo/engineering status)
 5. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` (Go/No-Go verdict)
-6. `knowledge/ACTIVE_ROADMAP.md`
+6. `docs/runbooks/CONTROL_REGISTER.md` (board/stage focus)
+7. `knowledge/ACTIVE_ROADMAP.md`
 
 **Live-Readiness: NO-GO** — no real trades without explicit human gate. See `docs/live-readiness/`.
+**Control Board Stage:** `trade-capable` (ratified 2026-04-08) — orthogonal to LR `NO-GO`; no live capital, no Grafana gate, no strategy validation.
 
 **Session-Ende (Pflicht):** Session-Log unter `knowledge/logs/sessions/YYYY-MM-DD-<topic>.md` ablegen. `CURRENT_STATUS.md` aktualisieren wenn sich Repo-/Engineering-Status geändert hat.
 
@@ -91,9 +93,16 @@ This is the canonical 431B baseline for isolated test/E2E labs — distinct from
 ```bash
 make systemcheck         # pre-flight checks before paper trading
 make paper-trading-start # requires running stack
+make paper-trading-logs  # live logs of paper-trading runner
+make paper-trading-stop
 make daily-check
 make backup              # Postgres + Redis to F:\Claire_Backups
 make security-scan       # gitleaks + ruff + bandit
+make pre-close           # pre-close sweep (untracked artefacts)
+make rollback MR=<number>  # rollback a merged MR
+make cleanup             # DRY-RUN: clean up merged branches
+make cleanup-live        # LIVE: clean up merged branches
+make mcp-config-validate # validate MCP configuration
 ```
 
 ---
@@ -184,6 +193,35 @@ Coverage target: 80% on `core/` and `services/` (enforced by `make test-coverage
 - `docs/live-readiness/` — LR-STATE.yaml files + evidence per phase (P0–P5)
 - `knowledge/logs/sessions/` — session evidence logs
 - `mcp_navpack_working_repo/` — MCP navigation presets (ENTRYPOINTS.yaml, CHEATSHEET.md)
+
+### Service Conventions
+
+All services under `services/` follow the same layout: `service.py`, `config.py`, `models.py`, `Dockerfile`, `requirements.txt`. The canonical entry point is:
+
+```bash
+python -m services.<name>.service
+```
+
+Logging is configured via `LOG_LEVEL` env var (or `logging_config.json` if present in the service dir).
+
+### Determinism & Audit Trail
+
+**No-float rule:** All monetary values must use `Decimal` with fixed quantization. `core/contracts/decision_contract_v1.py` defines `_MONEY_Q`, `_RATIO_Q`, `_QTY_Q` and enforces this via `_to_decimal()`. Never use `float` on the order path.
+
+**TRACE_CONTRACT_V1:** Use `build_decision_contract_v1_bundle` / `verify_decision_contract_v1_bundle` from `core/contracts/decision_contract_v1.py` to hash inputs and outputs for audit. Raise `DecisionContractError` on violation.
+
+**Envelope chain:** Shadow/replay produces a linked chain `DecisionEnvelopeV1 → OrderEnvelopeV1 → FillEnvelopeV1` (see `core/replay/envelopes.py`). `core/replay/canonical_json.py` provides sorted-key JSON serialization for deterministic hashes.
+
+### Agent SDK (`cdb_agent_sdk/`)
+
+Standalone Python package with analysis CLI tools (installed separately):
+
+```bash
+cdb-dataflow       # data-flow analysis
+cdb-determinism    # determinism inspection
+cdb-governance     # governance audit
+cdb-impact         # change-impact analysis
+```
 
 ### MINGW64 / Git Bash (Windows)
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ Welcome to the Claire de Binare repository. This project is a complex system for
 **Canonical source:** `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
 
 - **Scope basis:** `ROADMAP.yaml` + `LR-001..LR-007-STATE.yaml` + aktuelle GitHub-LR-Issues
-- **Last reconciliation:** 2026-03-29
-- **Roadmap status:** `P0` + `P2` DONE; `P1` + `P4` PARTIAL; `P3` + `P5` OPEN
+- **Last reconciliation:** 2026-04-07
+- **Roadmap status:** `P0` DONE; `P1` PARTIAL; `P2` DONE; `P3` PARTIAL; `P4` DONE; `P5` NO-GO
 - **Human gate:** Keine Echtgeld-Freigabe ohne vollstaendige Evidenz und explizite menschliche Freigabe
 
 **Einordnung:**<br>
 `CURRENT_STATUS.md` beschreibt den aktuellen Repo-/Main-/Testzustand.<br>
+`docs/runbooks/CONTROL_REGISTER.md` beschreibt den aktuellen Board-/Stage-Fokus; aktuell `trade-capable` (ratifiziert 2026-04-08), weiterhin ohne Live-Kapital und orthogonal zum LR-System.<br>
 `PROJECT_STATUS.md` ist ein historischer Implementierungs-Snapshot und kein operativer Go/No-Go-Status.<br>
 `knowledge/CURRENT_STATUS.md` ist nur ein historischer Knowledge-Snapshot und keine aktuelle Repo-/Ops-Quelle.
 
@@ -39,6 +40,7 @@ Er ist **kein Maß für Betriebsreife** und **kein Release-Gate**.
 ### Kurzfassung (fuer Leser mit wenig Zeit)
 
 - **Live Readiness:** NO-GO (siehe `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`)
+- **Control-Board Stage:** `trade-capable` (siehe `docs/runbooks/CONTROL_REGISTER.md`) bei weiterhin `LR-050 = NO-GO`
 - **Systemstatus:** Runtime migriert auf BLUE+RED; base.yml + dev.yml sind CI/Legacy-only
 - **Repo-/Teststatus:** siehe `CURRENT_STATUS.md`
 - **Historischer Implementierungsstand:** siehe `PROJECT_STATUS.md` (historischer Snapshot)
@@ -101,9 +103,10 @@ Kanonische 431C-Linie:
 >
 > | Quelle | Inhalt |
 > |---|---|
+> | [`docs/runbooks/CONTROL_REGISTER.md`](docs/runbooks/CONTROL_REGISTER.md) | Board-/Stage-Status und operativer Fokus |
 > | [`CURRENT_STATUS.md`](CURRENT_STATUS.md) | Aktueller Repo-/Engineering-/Teststatus |
 > | [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md) | Operativer Go/No-Go (Live Readiness) |
-> | [`PROJECT_STATUS.md`](PROJECT_STATUS.md) | Historischer Implementierungs-Snapshot (Stand 2026-01-07, archiviert) |
+> | [`PROJECT_STATUS.md`](PROJECT_STATUS.md) | Historischer Implementierungs-Snapshot (Stand 2026-01-15, archiviert) |
 
 ---
 

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -14,6 +14,10 @@ in einem separaten externen Doku-Repo gesucht wurde.
 3. `knowledge/governance/CDB_AGENT_POLICY.md`
 4. `knowledge/governance/SYSTEM_INVARIANTS.md`
 5. `knowledge/CDB_KNOWLEDGE_HUB.md`
+6. `docs/meta/WORKING_REPO_CANON.md`
+7. `CURRENT_STATUS.md`
+8. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+9. `docs/runbooks/CONTROL_REGISTER.md`
 
 ## Canonical Domains
 
@@ -28,10 +32,29 @@ in einem separaten externen Doku-Repo gesucht wurde.
 - `docs/`
   - Navigation, Runbooks, Archive und abgeleitete Views.
 
+## Status Surfaces
+
+- `CURRENT_STATUS.md`
+  - Autoritative Quelle fuer aktuellen Repo-, Main-, Test- und Arbeitsstatus.
+- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+  - Autoritative Quelle fuer operativen Go/No-Go-Status und Echtgeld-Blocker.
+- `docs/runbooks/CONTROL_REGISTER.md`
+  - Autoritative Quelle fuer aktuellen Board-/Stage-Status und operativen Fokus im Control Board.
+- `PROJECT_STATUS.md`, `knowledge/CURRENT_STATUS.md`
+  - Historische Snapshots; keine aktuelle repo-weite oder operative Wahrheit.
+
+## Current Project Reality
+
+- Working Repo bleibt der produktive Canon fuer Agenten-, Governance-, Knowledge- und Navigationsdoku.
+- Aktuelle Board-Stage ist `trade-capable` (ratifiziert 2026-04-08 via Issue `#1492`).
+- Diese Board-Stage ist orthogonal zum LR-System; `LR-050` bleibt `NO-GO` und autorisiert kein Live-Kapital.
+
 ## Operating Rules
 
 - `AGENTS.md` im Repo-Root ist nur ein Pointer auf diese Datei.
 - Agenten und Tools sollen standardmaessig lokale Pfade im Working Repo verwenden.
+- Stage-/Board-Aussagen und LR-Go/No-Go-Aussagen muessen strikt getrennt bleiben.
+- Eine Board-Stage darf nie als implizite Live-Freigabe oder Strategie-Validierung interpretiert werden.
 - Das lokale Archiv `docs/archive/docs_hub_snapshot/` ist nur noch ein optionaler historischer Rueckgriff.
 - Externe Docs-Repo-Pfade sind kein produktiver Default mehr.
 

--- a/agents/CLAUDE.md
+++ b/agents/CLAUDE.md
@@ -7,11 +7,13 @@ Claude **muss** zu Beginn jeder Session folgende Dateien lesen:
 - knowledge/SYSTEM.CONTEXT.md
 - CURRENT_STATUS.md
 - docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md
+- docs/runbooks/CONTROL_REGISTER.md
 - knowledge/ACTIVE_ROADMAP.md
 
 Diese Dateien sind die **autoritative Einstiegskette** für Kontext, Governance
 und die getrennten Statusrollen. `knowledge/CURRENT_STATUS.md` bleibt nur
-historischer Kontext.
+historischer Kontext. Board-/Stage-Status und LR-Go/No-Go muessen explizit
+getrennt gelesen werden.
 
 ---
 

--- a/agents/CODEX.md
+++ b/agents/CODEX.md
@@ -7,6 +7,7 @@ MUST READ FIRST:
 - knowledge/CDB_KNOWLEDGE_HUB.md
 - CURRENT_STATUS.md
 - docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md
+- docs/runbooks/CONTROL_REGISTER.md
 - PROJECT_STATUS.md (historical only)
 
 ---
@@ -16,7 +17,9 @@ MUST READ FIRST:
 - Das Working Repo ist der produktive Canon fuer Agenten-, Governance-, Knowledge- und Navigationsdoku.
 - `CURRENT_STATUS.md` ist der aktuelle Repo- und Engineering-Status.
 - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` ist der operative Go/No-Go- und Echtgeld-Status.
+- `docs/runbooks/CONTROL_REGISTER.md` ist der aktuelle Board-/Stage-Status; aktuell `trade-capable`, aber orthogonal zu LR-`NO-GO`.
 - `PROJECT_STATUS.md` und `knowledge/CURRENT_STATUS.md` sind historische Snapshots und duerfen nicht als aktueller SSOT gelesen werden.
+- Eine Board-Stage darf nie als Live-Kapital-Freigabe oder Strategie-Validierung interpretiert werden.
 - Bei Statuskonflikten gilt die SSOT-Regel aus `docs/meta/WORKING_REPO_CANON.md`.
 
 ---

--- a/agents/COPILOT.md
+++ b/agents/COPILOT.md
@@ -5,8 +5,9 @@
 - `agents/AGENTS.md`
 - `knowledge/governance/CDB_AGENT_POLICY.md`
 - `knowledge/CDB_KNOWLEDGE_HUB.md`
+- `docs/runbooks/CONTROL_REGISTER.md`
 
-Aktueller Projektstatus: `CURRENT_STATUS.md` (Repo-/Engineering-Status); `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` (operativer Go/No-Go-Status).
+Aktueller Projektstatus: `CURRENT_STATUS.md` (Repo-/Engineering-Status); `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` (operativer Go/No-Go-Status); `docs/runbooks/CONTROL_REGISTER.md` (Board-/Stage-Status, aktuell `trade-capable` bei weiterhin `LR-050 NO-GO`).
 
 ---
 

--- a/agents/GEMINI.md
+++ b/agents/GEMINI.md
@@ -15,8 +15,9 @@ MUST READ FIRST:
 - knowledge/CDB_KNOWLEDGE_HUB.md
 - CURRENT_STATUS.md
 - docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md
+- docs/runbooks/CONTROL_REGISTER.md
 
-Canon- und Status-Guardrail: `CURRENT_STATUS.md` = aktueller Repo-/Engineering-Status; `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` = operativer Go/No-Go-Status. `PROJECT_STATUS.md` und `knowledge/CURRENT_STATUS.md` sind historische Snapshots und duerfen nicht als aktueller SSOT gelesen werden. Working Repo ist maßgeblicher Canon.
+Canon- und Status-Guardrail: `CURRENT_STATUS.md` = aktueller Repo-/Engineering-Status; `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` = operativer Go/No-Go-Status; `docs/runbooks/CONTROL_REGISTER.md` = aktueller Board-/Stage-Status. `PROJECT_STATUS.md` und `knowledge/CURRENT_STATUS.md` sind historische Snapshots und duerfen nicht als aktueller SSOT gelesen werden. Working Repo ist massgeblicher Canon. `trade-capable` ist kein LR-GO und kein Live-Kapital-Signal.
 
 ---
 

--- a/agents/roles/CLAUDE.md
+++ b/agents/roles/CLAUDE.md
@@ -7,11 +7,13 @@ Claude **muss** zu Beginn jeder Session folgende Dateien lesen:
 - knowledge/SYSTEM.CONTEXT.md
 - CURRENT_STATUS.md
 - docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md
+- docs/runbooks/CONTROL_REGISTER.md
 - knowledge/ACTIVE_ROADMAP.md
 
 Diese Dateien sind die **autoritative Einstiegskette** für Kontext, Governance
 und die getrennten Statusrollen. `knowledge/CURRENT_STATUS.md` bleibt nur
-historischer Kontext.
+historischer Kontext. Board-/Stage-Status und LR-Go/No-Go muessen explizit
+getrennt gelesen werden.
 
 ---
 

--- a/agents/roles/CODEX.md
+++ b/agents/roles/CODEX.md
@@ -17,6 +17,7 @@ MUST READ FIRST:
 - [`../../knowledge/CDB_KNOWLEDGE_HUB.md`](../../knowledge/CDB_KNOWLEDGE_HUB.md)
 - [`../../CURRENT_STATUS.md`](../../CURRENT_STATUS.md)
 - [`../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)
+- [`../../docs/runbooks/CONTROL_REGISTER.md`](../../docs/runbooks/CONTROL_REGISTER.md)
 - [`../../PROJECT_STATUS.md`](../../PROJECT_STATUS.md) (historical only)
 
 ## 0. Canon & Status Guardrails
@@ -24,7 +25,9 @@ MUST READ FIRST:
 - Das Working Repo ist der produktive Canon fuer Agenten-, Governance-, Knowledge- und Navigationsdoku.
 - [`../../CURRENT_STATUS.md`](../../CURRENT_STATUS.md) ist der aktuelle Repo- und Engineering-Status.
 - [`../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md) ist der operative Go/No-Go- und Echtgeld-Status.
+- [`../../docs/runbooks/CONTROL_REGISTER.md`](../../docs/runbooks/CONTROL_REGISTER.md) ist der aktuelle Board-/Stage-Status; aktuell `trade-capable`, aber orthogonal zu LR-`NO-GO`.
 - [`../../PROJECT_STATUS.md`](../../PROJECT_STATUS.md) und `../../knowledge/CURRENT_STATUS.md` sind historische Snapshots und duerfen nicht als aktueller SSOT gelesen werden.
+- Eine Board-Stage darf nie als Live-Kapital-Freigabe oder Strategie-Validierung interpretiert werden.
 - Bei Statuskonflikten gilt die SSOT-Regel aus [`../../docs/meta/WORKING_REPO_CANON.md`](../../docs/meta/WORKING_REPO_CANON.md).
 
 ---

--- a/agents/roles/COPILOT.md
+++ b/agents/roles/COPILOT.md
@@ -5,8 +5,9 @@
 - `agents/AGENTS.md`
 - `knowledge/governance/CDB_AGENT_POLICY.md`
 - `knowledge/CDB_KNOWLEDGE_HUB.md`
+- `docs/runbooks/CONTROL_REGISTER.md`
 
-Aktueller Projektstatus: `CURRENT_STATUS.md` (Repo-/Engineering-Status); `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` (operativer Go/No-Go-Status).
+Aktueller Projektstatus: `CURRENT_STATUS.md` (Repo-/Engineering-Status); `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` (operativer Go/No-Go-Status); `docs/runbooks/CONTROL_REGISTER.md` (Board-/Stage-Status, aktuell `trade-capable` bei weiterhin `LR-050 NO-GO`).
 
 ---
 

--- a/agents/roles/GEMINI.md
+++ b/agents/roles/GEMINI.md
@@ -15,8 +15,9 @@ MUST READ FIRST:
 - knowledge/CDB_KNOWLEDGE_HUB.md
 - CURRENT_STATUS.md
 - docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md
+- docs/runbooks/CONTROL_REGISTER.md
 
-Canon- und Status-Guardrail: `CURRENT_STATUS.md` = aktueller Repo-/Engineering-Status; `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` = operativer Go/No-Go-Status. `PROJECT_STATUS.md` und `knowledge/CURRENT_STATUS.md` sind historische Snapshots und duerfen nicht als aktueller SSOT gelesen werden. Working Repo ist maßgeblicher Canon.
+Canon- und Status-Guardrail: `CURRENT_STATUS.md` = aktueller Repo-/Engineering-Status; `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` = operativer Go/No-Go-Status; `docs/runbooks/CONTROL_REGISTER.md` = aktueller Board-/Stage-Status. `PROJECT_STATUS.md` und `knowledge/CURRENT_STATUS.md` sind historische Snapshots und duerfen nicht als aktueller SSOT gelesen werden. Working Repo ist massgeblicher Canon. `trade-capable` ist kein LR-GO und kein Live-Kapital-Signal.
 
 ---
 

--- a/docs/meta/WORKING_REPO_CANON.md
+++ b/docs/meta/WORKING_REPO_CANON.md
@@ -33,6 +33,7 @@ einzigen generischen "Current Status"-Datei gebuendelt.
 | --- | --- | --- |
 | Operational / live-readiness status | `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` | Autoritative Quelle fuer aktuellen Go/No-Go-Status und operative Live-Readiness-Blocker |
 | Working repo / engineering status | `CURRENT_STATUS.md` | Autoritative Quelle fuer aktuellen Repo-, Main-, Test- und aktiven Arbeitsstatus |
+| Board / stage status | `docs/runbooks/CONTROL_REGISTER.md` plus GitHub Control Board Stage-/Milestone-Zustand | Autoritative Quelle fuer aktuellen Stage-/Operating-Focus; das Stage-System ist orthogonal zum LR-System |
 | Historical implementation / audit snapshots | `PROJECT_STATUS.md`, `knowledge/CURRENT_STATUS.md` | Nur punktuelle historische Snapshots; keine aktuelle operative oder repo-weite Wahrheit |
 | Evidence / milestone / governance reports | z. B. `docs/archive/governance-audit-2026-01-15.md`, `CODEX_RUN_REPORT.md`, `docs/governance/status/` | Nachweis-, Audit- oder Milestone-Artefakte; nicht-kanonisch fuer aktuellen Gesamtstatus |
 
@@ -40,6 +41,8 @@ einzigen generischen "Current Status"-Datei gebuendelt.
 
 - `README.md` bleibt Front Door und darf Status nur zusammenfassen oder auf die
   jeweilige kanonische Quelle verweisen.
+- Board-/Stage-Claims und LR-Go/No-Go-Claims muessen explizit getrennt bleiben.
+- Eine Stage-Transition darf weder Live-Kapital-Freigabe noch Strategie-Validierung implizieren, solange die jeweilige kanonische Quelle das nicht ausdruecklich sagt.
 - Statusdateien mit historischem oder sekundaerem Charakter muessen ihren
   Status-Typ explizit kennzeichnen.
 - Neue Reports, Pass-Reports oder Audit-Snapshots duerfen scope-lokale Findings

--- a/docs/runbooks/CONTROL_REGISTER.md
+++ b/docs/runbooks/CONTROL_REGISTER.md
@@ -1,16 +1,31 @@
 # Control Register
 
-**Letzte Aktualisierung:** 2026-04-06
+**Letzte Aktualisierung:** 2026-04-08
 **SSOT Live-Readiness:** `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
 **Verdict:** NO-GO
+**Control-Board Stage:** `trade-capable` (ratifiziert 2026-04-08 via Issue `#1492`)
 
 ---
 
 ## Cockpit-Einstieg
 
 1. GitHub Issue `[CONTROL] Claire de Binare — Operatives Cockpit (dauerhaft offen)` — **#1445**
-2. `CURRENT_STATUS.md` — Repo/Engineering-Status, Session-Ledger
-3. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` — Live-Readiness-Verdikt
+2. GitHub Issue `#1492` — ratifizierter Stage-Uebergang `stability -> trade-capable`
+3. `CURRENT_STATUS.md` — Repo/Engineering-Status, Session-Ledger
+4. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` — Live-Readiness-Verdikt
+
+---
+
+## Aktueller Stage-Stand
+
+- Board-/Projekt-Stage: `trade-capable`
+- Ratifikation: 2026-04-08 via Issue `#1492`
+- Guardrails bleiben unveraendert:
+  - shadow/mock only
+  - kein Live-Kapital
+  - kein Grafana-Gate
+  - keine Strategie-Validierung
+  - `LR-050` bleibt `NO-GO`
 
 ---
 
@@ -18,11 +33,12 @@
 
 | Quelle | Zuständigkeit |
 |---|---|
+| `docs/runbooks/CONTROL_REGISTER.md` | Control-Board-Cockpit, aktueller Stage-/Operating-Focus |
 | `CURRENT_STATUS.md` | Repo-Stand, Session-Ledger, offene PRs |
 | `LR-AUDIT-STATUS-2026-03-05.md` | Live-Readiness-Phasenstatus, Go/No-Go-Verdikt |
 | `ACTIVE_ROADMAP.md` | Pointer auf beide SSoTs |
 
-Regel: Phasen-Status nie in CURRENT_STATUS eintragen. Verdikt nie aus CURRENT_STATUS ableiten.
+Regel: Phasen-Status nie in CURRENT_STATUS eintragen. LR-Verdikt nie aus einer Board-Stage ableiten. Board-Stage nie als implizites LR-GO lesen.
 
 ---
 

--- a/docs/runbooks/control_board_board_as_code.md
+++ b/docs/runbooks/control_board_board_as_code.md
@@ -4,6 +4,9 @@
 
 Deterministische Automation fuer Project v2 `CDB Control Board` ohne manuelles Klicken.
 
+Guardrail: Das Stage-System des Boards ist orthogonal zum LR-System. `trade-capable`
+ist kein Live-Kapital-GO und keine Strategie-Validierung.
+
 ## Komponenten
 
 - Upsert-Script: `scripts/project/upsert_control_board.py`
@@ -148,6 +151,10 @@ Aktionen:
   - `stability` -> `System ist stabil`
   - `trade-capable` -> `System kann handeln`
   - `strategy-validated` -> `Strategie ist validiert`
+
+Wichtig:
+- Diese Stage-Werte steuern Board-/Milestone-Organisation.
+- Sie aendern keinen LR-Go/No-Go-Status und heben `LR-050 NO-GO` nicht auf.
 
 Konfliktregeln (deterministisch):
 

--- a/docs/runbooks/project_board_automation.md
+++ b/docs/runbooks/project_board_automation.md
@@ -16,6 +16,7 @@ Kurzer Betriebsleitfaden für die Repo-Organisation über Milestones, Labels und
 8. Neue Issues/PRs erhalten automatisch einen Default-Status (Issue=`Backlog`, PR=`Review`).
 9. `status:*` Labels überschreiben/setzen den Project-Status per Label-Mapping.
 10. Milestone-Änderungen synchronisieren automatisch das passende `stage:*` Label.
+11. `stage:*` Labels sind Board-/Fokus-Signale und ersetzen keinen LR-Go/No-Go-Status.
 
 ## Hard Facts
 
@@ -49,6 +50,8 @@ Kurzer Betriebsleitfaden für die Repo-Organisation über Milestones, Labels und
   Diese alten Labels werden weder im Board-Mapping noch in Workflows verwendet.
 - **Abgrenzung:** Project-v2-Statuswerte (`Backlog`, `Ready`, `In Progress`,
   `Review`, `Blocked`, `Done`) sind Board-Feldwerte, keine Labels.
+- **Abgrenzung:** `stage:*` Labels bilden das Board-Stage-System ab und sind
+  orthogonal zum LR-System in `docs/live-readiness/`.
 
 ## Automationen (Workflow-Dateien)
 

--- a/knowledge/logs/sessions/2026-04-08-agents-stage-lr-reconcile.md
+++ b/knowledge/logs/sessions/2026-04-08-agents-stage-lr-reconcile.md
@@ -1,0 +1,55 @@
+# Session Log -- 2026-04-08 -- Agents/Canon: Stage-vs-LR Reconciliation
+
+## Scope
+
+Aktive Agenten-, Canon- und Front-Door-Doku an die aktuelle Projektlage angepasst.
+Kein Code, keine Runtime-Aenderung, keine LR- oder Stage-Entscheidung neu getroffen.
+
+## Warum die Aenderung noetig war
+
+- Mehrere Entrypoints transportierten nur die Zweiteilung `CURRENT_STATUS.md` vs.
+  `LR-AUDIT-STATUS-*`, aber nicht den inzwischen ratifizierten Control-Board-Stage-Stand.
+- `README.md` zeigte veraltete LR-Reconciliation-Daten (`2026-03-29`, `P4 PARTIAL`, `P5 OPEN`).
+- Die neue Klarheit aus Issue `#1492` war lokal noch nicht sauber in die
+  Agenten- und Canon-Einstiege rueckgekoppelt:
+  - Board-Stage `trade-capable`
+  - LR-System weiterhin `NO-GO`
+  - beide Systeme sind orthogonal
+
+## Gepruefte Quellen
+
+- `CURRENT_STATUS.md`
+- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- `docs/runbooks/CONTROL_REGISTER.md`
+- `knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md`
+- `docs/runbooks/control_board_board_as_code.md`
+- `docs/runbooks/project_board_automation.md`
+- `README.md`
+- GitHub Issue `#1445`
+- GitHub Issue `#1492` inkl. Maintainer-Ratifizierung vom 2026-04-08
+
+## Durchgefuehrte Aenderungen
+
+- Root-/Agenten-Entrypoints auf drei getrennte Statusflaechen gezogen:
+  - Repo/Engineering
+  - Live-Readiness Go/No-Go
+  - Board/Stage
+- Canon-Regeln explizit um die Orthogonalitaet von Stage-System und LR-System ergaenzt.
+- `CONTROL_REGISTER.md` um den ratifizierten Stage-Stand `trade-capable` erweitert.
+- Board-Runbooks um Guardrails ergaenzt: `trade-capable` ist kein LR-GO.
+- `README.md` auf aktuellen LR-Reconcile-Stand gebracht und um den Board-Stage-Hinweis ergaenzt.
+
+## Ergebnislage nach Reconcile
+
+- Aktueller Board-/Stage-Stand: `trade-capable`
+- Aktuelles LR-Verdikt: `NO-GO`
+- Guardrails unveraendert:
+  - kein Live-Kapital
+  - kein Grafana-Gate
+  - keine Strategie-Validierung
+  - `LR-050` bleibt `NO-GO`
+
+## CURRENT_STATUS-Auswirkung
+
+Keine Aktualisierung von `CURRENT_STATUS.md`.
+Grund: kein Main-Merge, keine Repo-/Engineering-Statusaenderung, nur Doku-Reconcile.

--- a/knowledge/logs/sessions/2026-04-08-gate-review-1492-trade-capable.md
+++ b/knowledge/logs/sessions/2026-04-08-gate-review-1492-trade-capable.md
@@ -1,0 +1,64 @@
+# Session Log — 2026-04-08: Gate-Review #1492 / stage:trade-capable
+
+## Scope
+
+Review- und Gate-Vorbereitungssession für Issue #1492.
+Kein Code, keine Commits, kein Branch-Wechsel.
+Ausschließlich GitHub-Aktionen (Issue-Body-Update, Kommentare).
+
+## Was erledigt wurde
+
+- #1492 body vollständig geschärft:
+  - `weekly-gap ~1%` explizit als kein Repo-Canon / kein Gate-Kriterium markiert (zero Matches im gesamten Repo)
+  - `Einsatzfähigkeit` als informeller Maintainer-Begriff eingeordnet
+  - `stage:trade-capable` ("System kann handeln") als kanonischer Repo-Begriff verankert — belegt durch `.github/workflows/milestone_stage_label_sync.yml` (Zeile 146), `docs/runbooks/control_board_board_as_code.md` (Zeile 149), `knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md` (Zeile 41)
+  - LR-System (P0–P5) und Stage-System als orthogonal klargestellt
+  - Zentrale Gate-Frage auf `stage:stability → stage:trade-capable`-Transition umformuliert
+  - Offene Maintainer-Policy-Frage (P1/P3 nicht blockierend?) explizit als offen benannt
+
+- Gate-Analyse-Kommentar in #1492 gepostet (Kommentar #4201919712):
+  - 5 minimale Gate-Kriterien abgeleitet und belegt (alle bereits durch committed Artefakte erfüllt)
+  - P1 PARTIAL (LR-012): blockiert nicht — begründet mit repo-backed Execution-Negativpfad + 72h-Soak ohne Failure
+  - P3 PARTIAL (LR-030): blockiert nicht — LR-030-Restunsicherheit bleibt ausdrücklich bestehen; für stage:trade-capable nicht blockierend unter expliziten Grenzen
+  - Explizite Grenzen dokumentiert: shadow/mock only, kein Grafana, kein Live-Kapital, Strategie nicht validiert, LR-050 NO-GO unberührt
+  - Kommentar nach Maintainer-Feedback geschärft: P3-Begründung von "faktisch demonstriert" auf "Restunsicherheit bleibt ausdrücklich bestehen" korrigiert
+
+- Maintainer-Ratifizierung in #1492 gepostet (Kommentar #4202397985):
+  - Stage-Übergang `stage:stability → stage:trade-capable` ratifiziert
+  - P1/P3 als nicht blockierend bestätigt
+  - LR-050 NO-GO, kein Live-Kapital, kein Grafana-Gate, keine Strategie-Validierung ausdrücklich bestätigt
+
+## Gelesene Artefakte
+
+- #1445 (Wochenkommentar KW15 + Stabilitäts-Abschluss 2026-04-07)
+- #1492 (alle Versionen)
+- `docs/live-readiness/ROADMAP.yaml`
+- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- `docs/live-readiness/GO_NO_GO.md`
+- `docs/live-readiness/LR-020-STATE.yaml`
+- `docs/live-readiness/LR-003-STATE.yaml`
+- `docs/evidence/LR-030.md`
+- `docs/evidence/LR-031.md`
+- `reports/p5_canary/2026-04-04/decision_record.yaml`
+- `reports/p5_canary/2026-04-04/prestart_evidence_lock.yaml`
+- `reports/p5_canary/2026-04-04/lean_shadow_evidence_handoff.yaml`
+- `docs/runbooks/CONTROL_REGISTER.md`
+- `CURRENT_STATUS.md`
+- `.github/workflows/milestone_stage_label_sync.yml`
+- `docs/runbooks/control_board_board_as_code.md`
+- `knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md`
+
+## Verbleibende Restunsicherheiten (carry-forward)
+
+- LR-030 "Alerts funktionieren" — bleibt offen für LR Go/No-Go; kein trade-capable-Blocker
+- LR-012 candles/signals full scope — bleibt offen für LR P1-Abschluss; kein trade-capable-Blocker
+
+## Repo-/Engineering-Status-Änderung
+
+Keine. Kein Code, keine neuen PRs, kein main-Merge.
+CURRENT_STATUS.md nicht aktualisiert (kein squash-merge-SHA auf main).
+
+## Branch-Zustand bei Session-Ende
+
+- Branch: `docs/session-41-log` (1 lokaler Commit ungepusht — gehört zu session-41, nicht zu dieser Session)
+- Worktree: Alt-/Parallelzustand aus session-41, keine offenen Änderungen aus dieser Session

--- a/knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md
+++ b/knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md
@@ -7,6 +7,7 @@ Zweck: Steuerung von Issues/PRs entlang der Stages (Beweisbarkeit -> Stabilitaet
 
 - Gilt fuer alle aktiven Issues/PRs, die im CDB Control Board landen.
 - Board ist "operational control": Ownership, Priorisierung, Evidence, Blocker, Routing.
+- Das Stage-System (`proof -> stability -> trade-capable -> strategy-validated`) ist orthogonal zum LR-System (`P0-P5`) und ersetzt kein LR-Go/No-Go-Verdikt.
 - Guardrail: Keine Aenderungen an Trading-Logik/Thresholds/Decision-Logik durch dieses Runbook.
 
 ## Pflichtfelder (Issue-Standard)
@@ -69,6 +70,7 @@ Board-Automation setzt/verifiziert:
 
 ## Guardrails
 
+- Keine Ableitung von Live-Kapital-Freigaben aus `Stage`.
 - Keine Aenderungen unter `knowledge/governance/**`.
 - Keine Code-/Policy-Aenderungen durch diese Doku.
 - Jede "Done"-Aussage braucht Evidence. Ohne Evidence kein Merge-Gate, kein "fertig".


### PR DESCRIPTION
## Summary

Reconciles the repo’s status canon after the 2026-04-08 stage clarification.

This updates the agent/front-door documentation so the three status surfaces are now explicitly separated:

- CURRENT_STATUS.md = repo / engineering status
- docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md = LR go / no-go
- docs/runbooks/CONTROL_REGISTER.md = board / stage status

It also pulls the ratified stage:trade-capable state into the active docs without weakening the existing LR NO-GO guardrails.

## What changed

- updated root and agent entrypoints (AGENTS.md, gents/*, gents/roles/*)
- updated canon/meta docs to formalize board-stage vs LR separation
- updated control-board runbooks to state that 	rade-capable is not live-capital approval
- updated README.md to remove stale LR summary data
- included the Claude/session log carry-forward docs from 2026-04-08

## Current clarified state

- Control Board stage: 	rade-capable
- Live Readiness: NO-GO
- unchanged guardrails:
  - no live capital
  - no Grafana gate
  - no strategy validation
  - LR-050 remains NO-GO

## Why

Issue #1492 ratified the stage:stability -> stage:trade-capable transition, but the local canon and agent entrypoints still reflected only the older two-surface split and stale README wording.

This PR aligns the active docs with the current project reality and makes the boundaries explicit so stage claims cannot be misread as LR go-live claims.

## Notes

- docs-only change
- no code/runtime behavior changed
- no LR status was upgraded by this PR