### PR TITLE
docs(security): correct python dependency canon in SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -91,7 +91,8 @@ Currently supported versions for security updates:
 - **Tresor Zone:** Physically separated (not in Docker stack)
 
 ### Dependencies
-- See `requirements.txt` for all Python dependencies
+- Root `requirements.txt` / `requirements-dev.txt` cover CI, test, and local convenience dependencies.
+- Active runtime Python dependencies are defined per service via service-local `requirements.txt` files or, where applicable, service Dockerfiles.
 - Regular updates via Dependabot
 - Critical CVEs patched within 7 days
 


### PR DESCRIPTION
#### Kontext
`.github/SECURITY.md` enthielt noch die falsche aktive Aussage, dass `requirements.txt` alle Python-Dependencies abbildet. Das widerspricht dem geklärten Repo-Canon aus `#1502`.

#### Was geändert wurde
- Die vereinfachende Aussage zu `requirements.txt` wurde korrigiert.
- Die Datei stellt jetzt knapp klar:
  - root `requirements.txt` / `requirements-dev.txt` decken vor allem CI-, Test- und lokale Convenience-Dependencies ab
  - aktive Runtime-Python-Dependencies sind pro Service in service-lokalen `requirements.txt` oder in Service-Dockerfiles definiert

#### Warum
Root requirements sind im aktuellen Repo **nicht** die Runtime-SSOT aktiver Service-Images. Die alte Formulierung war deshalb Canon-Drift.

#### Scope
Enger Doku-Canon-Fix in `.github/SECURITY.md`.
Keine Dependency-, Runtime-, Dockerfile- oder Workflow-Änderungen.