### PR TITLE
docs(deps): clarify root requirements canon for #1502

### DIFF
--- a/docs/runbooks/merge_policy_ci_gate.md
+++ b/docs/runbooks/merge_policy_ci_gate.md
@@ -125,6 +125,14 @@ setzen. Keine Automatik. Das Gate bleibt fail-closed.
 Dependabot-PRs, die **ausschließlich** `.github/workflows/**` oder `infrastructure/**` berühren,
 werden als `workflows-only` bzw. `infra-only` auto-inferred und benötigen keinen Override.
 
+Root `requirements.txt` und `requirements-dev.txt` sind aktuell ein CI/Test-/Convenience-Layer,
+nicht der Runtime-Truth für aktive Services. Für aktive Runtime-Pfade gilt als Dependency-Canon
+die Kombination aus service-lokalen `requirements.txt` plus den real referenzierten
+Dockerfile-Installationsstellen. Folge: root-only Dependabot-Bumps für runtime-relevante
+Libraries sind nicht als gleichwertige Runtime-Updates mergebar; sie bleiben geparkt oder
+werden nur zusammen mit einer Runtime-Reconciliation bewertet. Root-only Bumps bleiben nur dann
+sauber mergebar, wenn die Dependency für aktive Service-Buildpfade nicht runtime-relevant ist.
+
 The gate reevaluates on `opened`, `synchronize`, `reopened`, `labeled`,
 `unlabeled`, and `edited` so label removals cannot leave a stale PASS behind.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
-# Development and testing dependencies
+# Development and testing dependencies for repo-level CI/test only.
+# Active service runtime dependencies are controlled service-locally, not here.
 # Claire de Binare Trading Bot
 
 # Testing Framework (Issue #21 scaffolding)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-
+# Root dependency layer for repo-level CI/test and convenience flows.
+# Active runtime canon lives in service-local requirements plus real Dockerfile
+# install paths; root-only bumps are not equivalent to runtime reconciliation.
 # Async Support
 # Claire de Binare Trading Bot
 # Core


### PR DESCRIPTION
## Summary
- document that root `requirements.txt` and `requirements-dev.txt` are CI/test/convenience layers, not active runtime truth
- codify the merge-policy rule that runtime-relevant root-only Dependabot bumps are not equivalent to runtime reconciliation
- add self-describing headers to the root requirements files without changing package versions

## Why
Issue #1502 established that active runtime dependency canon comes from service-local `requirements.txt` plus real Dockerfile install paths, while root requirements drive CI/test convenience surfaces. This PR makes that rule explicit in the repo so future root-only Dependabot reviews do not silently blur root vs. runtime truth.

Closes #1502