### PR TITLE
fix(persistence): reduce dual writers for orders and trades (#1498)

### DIFF
--- a/services/db_writer/db_writer.py
+++ b/services/db_writer/db_writer.py
@@ -364,35 +364,74 @@ class DatabaseWriter:
             # Get limit price (NULL for market orders without limit)
             order_price = self.get_order_price(data)
             metadata = self.normalize_metadata(data.get("metadata"))
+            order_id = data.get("order_id")
 
             # Convert timestamp (handles Unix timestamps and ISO strings)
             timestamp = self.convert_timestamp(data.get("timestamp"))
 
             cursor = self.db_conn.cursor()
-            cursor.execute(
-                """
-                INSERT INTO orders
-                (symbol, side, order_type, price, size, approved, rejection_reason, status, metadata, created_at)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                RETURNING id
-            """,
-                (
-                    data.get("symbol"),
-                    self.normalize_side(data.get("side")),
-                    data.get("order_type", "market"),
-                    order_price,  # Can be None for market orders
-                    data.get("quantity", data.get("size", 0)),
-                    data.get("approved", False),
-                    data.get("rejection_reason"),
-                    data.get("status", "pending"),
-                    json.dumps(metadata),
-                    timestamp,
-                ),
-            )
-            order_id = cursor.fetchone()[0]
+            if order_id:
+                cursor.execute(
+                    """
+                    INSERT INTO orders
+                    (order_id, symbol, side, order_type, price, size, approved, rejection_reason, status, metadata, created_at)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (order_id) DO UPDATE
+                    SET symbol = EXCLUDED.symbol,
+                        side = EXCLUDED.side,
+                        order_type = EXCLUDED.order_type,
+                        price = EXCLUDED.price,
+                        size = EXCLUDED.size,
+                        approved = EXCLUDED.approved,
+                        rejection_reason = COALESCE(EXCLUDED.rejection_reason, orders.rejection_reason),
+                        status = CASE
+                            WHEN orders.status IN ('filled', 'partial', 'cancelled', 'rejected')
+                                THEN orders.status
+                            ELSE EXCLUDED.status
+                        END,
+                        metadata = COALESCE(EXCLUDED.metadata, '{}'::jsonb) || COALESCE(orders.metadata, '{}'::jsonb),
+                        created_at = LEAST(orders.created_at, EXCLUDED.created_at)
+                    RETURNING id
+                """,
+                    (
+                        order_id,
+                        data.get("symbol"),
+                        self.normalize_side(data.get("side")),
+                        data.get("order_type", "market"),
+                        order_price,
+                        data.get("quantity", data.get("size", 0)),
+                        data.get("approved", False),
+                        data.get("rejection_reason"),
+                        data.get("status", "pending"),
+                        json.dumps(metadata),
+                        timestamp,
+                    ),
+                )
+            else:
+                cursor.execute(
+                    """
+                    INSERT INTO orders
+                    (symbol, side, order_type, price, size, approved, rejection_reason, status, metadata, created_at)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    RETURNING id
+                """,
+                    (
+                        data.get("symbol"),
+                        self.normalize_side(data.get("side")),
+                        data.get("order_type", "market"),
+                        order_price,
+                        data.get("quantity", data.get("size", 0)),
+                        data.get("approved", False),
+                        data.get("rejection_reason"),
+                        data.get("status", "pending"),
+                        json.dumps(metadata),
+                        timestamp,
+                    ),
+                )
+            persisted_order_id = cursor.fetchone()[0]
             logger.info(
                 "✅ Order persisted: ID=%d, %s %s",
-                order_id,
+                persisted_order_id,
                 data.get("symbol"),
                 data.get("side"),
             )

--- a/services/execution/database.py
+++ b/services/execution/database.py
@@ -205,7 +205,42 @@ class Database:
                     metadata_json = json.dumps(metadata_payload)
 
                     has_order_id = self._orders_has_order_id(cur)
-                    # Insert into orders table
+                    if has_order_id and result.order_id:
+                        cur.execute(
+                            """
+                            UPDATE orders
+                            SET filled_size = %s,
+                                avg_fill_price = %s,
+                                status = %s,
+                                submitted_at = COALESCE(submitted_at, to_timestamp(%s)),
+                                filled_at = CASE
+                                    WHEN %s = %s THEN COALESCE(filled_at, to_timestamp(%s))
+                                    ELSE filled_at
+                                END,
+                                metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb
+                            WHERE order_id = %s
+                            RETURNING id
+                        """,
+                            (
+                                result.filled_quantity,
+                                result.price,
+                                result.status.lower(),
+                                int(time.time()),
+                                result.status.lower(),
+                                OrderStatus.FILLED.value.lower(),
+                                int(time.time()),
+                                metadata_json,
+                                result.order_id,
+                            ),
+                        )
+                        if cur.fetchone():
+                            logger.info(
+                                "Updated order lifecycle in database: %s",
+                                result.order_id,
+                            )
+                            return True
+
+                    # Insert fallback for execution-local outcomes without a prior canonical order row.
                     if has_order_id:
                         cur.execute(
                             """

--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -384,8 +384,6 @@ def _publish_result(result: ExecutionResult) -> None:
 
     if db:
         db.save_order(result)
-        if ExecutionResult._schema_status(result.status) == "FILLED":
-            db.save_trade(result)
 
 
 def process_order(order_data: object):

--- a/tests/integration/test_execution_pipeline.py
+++ b/tests/integration/test_execution_pipeline.py
@@ -29,13 +29,9 @@ class DummyRedisClient:
 class DummyDatabase:
     def __init__(self) -> None:
         self.saved_orders: list[str] = []
-        self.saved_trades: list[str] = []
 
     def save_order(self, result: object) -> None:
         self.saved_orders.append(result.order_id)
-
-    def save_trade(self, result: object) -> None:
-        self.saved_trades.append(result.order_id)
 
     def persist_correlation_event(self, **kwargs) -> bool:
         """No-op stub for Phase 8C (not validated by this test)."""
@@ -85,7 +81,6 @@ def test_process_order_publishes_real_result(monkeypatch: pytest.MonkeyPatch) ->
         data = json.loads(text)
         assert data["symbol"] == payload["symbol"]
         assert db_stub.saved_orders
-        assert db_stub.saved_trades
         stats_after = service.get_stats_copy()
         assert stats_after["orders_received"] == stats_before["orders_received"] + 1
         assert stats_after["orders_filled"] == stats_before["orders_filled"] + 1
@@ -163,7 +158,6 @@ def test_shadow_order_blocks_via_risk_contract_and_exports_metrics(
         assert "shadow mode" in (result.error_message or "").lower()
         executor.execute_order.assert_not_called()
         assert db_stub.saved_orders == ["test-ord-shadow-001"]
-        assert db_stub.saved_trades == []
         assert len(redis_stub.published) == 1
 
         channel, text = redis_stub.published[0]

--- a/tests/integration/test_lr020_e2e_pipeline.py
+++ b/tests/integration/test_lr020_e2e_pipeline.py
@@ -43,13 +43,9 @@ class DummyRedisClient:
 class DummyDatabase:
     def __init__(self) -> None:
         self.saved_orders: list[str] = []
-        self.saved_trades: list[str] = []
 
     def save_order(self, result: object) -> None:
         self.saved_orders.append(result.order_id)
-
-    def save_trade(self, result: object) -> None:
-        self.saved_trades.append(result.order_id)
 
     def persist_correlation_event(self, **kwargs) -> bool:
         return True
@@ -165,7 +161,6 @@ def test_tc_lr020_01_allow_path_fills_order(monkeypatch: pytest.MonkeyPatch) -> 
 
         # Persisted to DB (MockExecutor generates its own MOCK_<n> order_id)
         assert db_stub.saved_orders, "Order must be saved to DB"
-        assert db_stub.saved_trades, "Trade must be saved to DB"
     finally:
         service.stats.clear()
         service.stats.update(stats_before)

--- a/tests/unit/db_writer/test_service.py
+++ b/tests/unit/db_writer/test_service.py
@@ -128,6 +128,33 @@ def test_process_signal_event_persists_metadata_object(mock_postgres):
 
 
 @pytest.mark.unit
+def test_process_order_event_upserts_by_order_id_without_losing_terminal_status():
+    writer = DatabaseWriter()
+    writer.db_conn = MagicMock()
+    cursor = writer.db_conn.cursor.return_value
+    cursor.fetchone.return_value = [7]
+
+    writer.process_order_event(
+        {
+            "order_id": "ord-1498-1",
+            "symbol": "BTCUSDT",
+            "side": "BUY",
+            "quantity": 0.01,
+            "price": 50000.0,
+            "approved": True,
+            "status": "pending",
+            "timestamp": 1700000000,
+            "metadata": {"signal_id": "sig-1498-1"},
+        }
+    )
+
+    query, params = cursor.execute.call_args[0]
+    assert "ON CONFLICT (order_id) DO UPDATE" in query
+    assert params[0] == "ord-1498-1"
+    assert json.loads(params[9]) == {"signal_id": "sig-1498-1"}
+
+
+@pytest.mark.unit
 @pytest.mark.unit
 @pytest.mark.skip(reason="Placeholder - needs implementation (Issue #308)")
 def test_service_initialization(mock_postgres, test_config):

--- a/tests/unit/execution/test_database_security.py
+++ b/tests/unit/execution/test_database_security.py
@@ -88,3 +88,39 @@ def test_save_trade_preserves_fill_context_metadata(mock_connect, mock_db_config
     parsed_metadata = json.loads(metadata_json)
     assert parsed_metadata["order_id"] == "test-order-ctx"
     assert parsed_metadata["fill_context"]["signal_ts_ms"] == 1700000000123
+
+
+@patch("psycopg2.connect")
+def test_save_order_updates_existing_order_row_and_merges_metadata(
+    mock_connect, mock_db_config
+):
+    mock_conn = MagicMock()
+    mock_connect.return_value = mock_conn
+    mock_cur = mock_conn.cursor.return_value.__enter__.return_value
+    mock_cur.fetchone.side_effect = [(1,), (123,)]
+
+    db = Database()
+    result = ExecutionResult(
+        order_id="ord-1498-update",
+        client_id="client-1498",
+        symbol="BTCUSDT",
+        side="BUY",
+        quantity=1.0,
+        filled_quantity=1.0,
+        price=50000.0,
+        status=OrderStatus.FILLED.value,
+        timestamp="2026-01-01T00:00:00Z",
+        metadata={"fill_context": {"signal_ts_ms": 1700000000123}},
+    )
+
+    success = db.save_order(result)
+
+    assert success is True
+    assert mock_cur.execute.call_count == 3
+    update_query, update_params = mock_cur.execute.call_args_list[2][0]
+    assert "UPDATE orders" in update_query
+    assert "metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb" in update_query
+    assert update_params[8] == "ord-1498-update"
+    parsed_metadata = json.loads(update_params[7])
+    assert parsed_metadata["order_id"] == "ord-1498-update"
+    assert parsed_metadata["fill_context"]["signal_ts_ms"] == 1700000000123

--- a/tests/unit/execution/test_service_stats.py
+++ b/tests/unit/execution/test_service_stats.py
@@ -25,13 +25,9 @@ class DummyRedisClient:
 class DummyDatabase:
     def __init__(self) -> None:
         self.saved_orders: list[ExecutionResult] = []
-        self.saved_trades: list[ExecutionResult] = []
 
     def save_order(self, result: ExecutionResult) -> None:
         self.saved_orders.append(result)
-
-    def save_trade(self, result: ExecutionResult) -> None:
-        self.saved_trades.append(result)
 
 
 def test_stats_increment_isolates_copy() -> None:
@@ -80,8 +76,7 @@ def test_publish_result_updates_stats_and_history(
         }
         assert dummy_redis.streams[0][0] == config.STREAM_ORDER_RESULTS
         assert dummy_db.saved_orders
-        assert dummy_db.saved_trades
-        assert dummy_db.saved_trades[0].metadata == {
+        assert dummy_db.saved_orders[0].metadata == {
             "signal_id": "sig-42",
             "expected_price": 41950.0,
         }


### PR DESCRIPTION
## Summary
- make db_writer the canonical 	rades writer by removing execution-side 	rades inserts from _publish_result()
- persist orders.order_id in db_writer and upsert by order_id so canonical risk/order rows can survive execution-first timing
- reduce xecution/database.py from second orders inserter to order lifecycle enrichment (status, fill fields, merged metadata) with insert fallback only for execution-local orphan outcomes
- update targeted unit/integration coverage for the new ownership split

## Why
Issue #1498 tracks the remaining dual-writer seam after #1488. Before this change:
- db_writer inserted orders from the payload path and 	rades from order_results
- xecution/database.py inserted a second orders row from execution results and also inserted a second 	rades row for filled results

That created mixed timing and metadata semantics across the same business tables.

## Checks
- pytest tests/unit/db_writer/test_service.py tests/unit/execution/test_database_security.py tests/unit/execution/test_service_stats.py tests/integration/test_execution_pipeline.py tests/integration/test_lr020_e2e_pipeline.py

## Scope guard
- no schema redesign
- no analytics/ML scope
- no #1500 follow-up pulled in