### PR TITLE
fix(execution): remove order fallback insert after #1498 (#1520)

### DIFF
--- a/services/execution/database.py
+++ b/services/execution/database.py
@@ -191,19 +191,19 @@ class Database:
         try:
             with self.get_connection() as conn:
                 with conn.cursor() as cur:
-                    metadata_payload = (
+                    raw_metadata = (
                         dict(result.metadata)
                         if isinstance(result.metadata, dict)
                         else {}
                     )
+                    canonical_order_id = raw_metadata.get("order_id")
+                    metadata_payload = dict(raw_metadata)
                     metadata_payload.setdefault("source", "execution_service")
                     if result.order_id:
-                        metadata_payload.setdefault("order_id", result.order_id)
                         metadata_payload.setdefault(
                             "exchange_order_id", result.order_id
                         )
                     metadata_json = json.dumps(metadata_payload)
-                    canonical_order_id = metadata_payload.get("order_id")
 
                     has_order_id = self._orders_has_order_id(cur)
                     if not has_order_id:

--- a/tests/unit/execution/test_database_security.py
+++ b/tests/unit/execution/test_database_security.py
@@ -162,3 +162,34 @@ def test_save_order_skips_when_no_canonical_order_row_exists(
     assert "UPDATE orders" in update_query
     assert update_params[8] == "ord-miss-1"
     assert "no existing order row found" in caplog.text
+
+
+@patch("psycopg2.connect")
+def test_save_order_skips_when_canonical_order_id_missing_even_if_exchange_id_exists(
+    mock_connect, mock_db_config, caplog
+):
+    mock_conn = MagicMock()
+    mock_connect.return_value = mock_conn
+    mock_cur = mock_conn.cursor.return_value.__enter__.return_value
+    mock_cur.fetchone.side_effect = [(1,)]
+
+    db = Database()
+    result = ExecutionResult(
+        order_id="exchange-only-1",
+        client_id="client-exchange-only-1",
+        symbol="BTCUSDT",
+        side="BUY",
+        quantity=1.0,
+        filled_quantity=0.0,
+        price=None,
+        status=OrderStatus.REJECTED.value,
+        timestamp="2026-01-01T00:00:00Z",
+        metadata={"exchange": "mock"},
+    )
+
+    with caplog.at_level("WARNING"):
+        success = db.save_order(result)
+
+    assert success is False
+    assert mock_cur.execute.call_count == 2
+    assert "missing canonical order_id" in caplog.text


### PR DESCRIPTION
## Summary
- remove the execution-side orders insert fallback from services/execution/database.py
- update order lifecycle rows strictly by canonical internal order_id from result metadata instead of by exchange/mock esult.order_id
- warn and return False when execution cannot find a canonical order row instead of silently recreating one
- extend unit coverage to prove canonical-id updates and explicit miss behavior

## Why
Issue #1520 asked whether the remaining fallback insert was still a real timing/orphan guard.

Repo-backed evidence showed:
- canonical runtime orders already carry order_id from Risk (services/risk/service.py)
- e2e order publishers also send explicit order_id
- runtime evidence expects db_writer to be the persistence layer for orders/trades
- the fallback was still active mainly because save_order() matched on ExecutionResult.order_id, while executors emit exchange/mock order IDs (MOCK_*, exchange order IDs)

That means the fallback was compensating for an ID-domain mismatch, not a legitimate second ownership path.

## Checks
- pytest tests/unit/execution/test_database_security.py tests/unit/execution/test_service_stats.py tests/unit/db_writer/test_service.py tests/integration/test_execution_pipeline.py tests/integration/test_lr020_e2e_pipeline.py

## Scope guard
- no schema work
- no #1500 scope
- no broad persistence refactor