### PR TITLE
fix(ci): suppress emoji alert issues for lenient advisory scans (#1440)

### DIFF
--- a/.github/workflows/emoji-filter.yml
+++ b/.github/workflows/emoji-filter.yml
@@ -205,7 +205,8 @@ jobs:
     name: 📢 Notifications
     needs: [emoji-detection, security-check]
     runs-on: ubuntu-latest
-    if: always() && needs.emoji-detection.outputs.error-count > 0
+    # Keep lenient scans advisory-only; open issues only when the scan is in blocking mode.
+    if: always() && needs.emoji-detection.outputs.block-pr == 'true'
     permissions:
       issues: write
     


### PR DESCRIPTION
## Summary
- couple emoji alert issue creation to the existing `block-pr` output
- keep lenient scans advisory-only instead of opening recurring GitHub issue noise
- leave scanner behavior, artifacts, and PR block logic unchanged

## Validation
- `git diff --check`
- YAML parse via `python -c "import pathlib,yaml; yaml.safe_load(...)"`

Closes #1440
