### PR TITLE
docs: add repo-backed metrics matrix SSOT (#1527)

### DIFF
--- a/infrastructure/monitoring/KPI_REFERENCE.md
+++ b/infrastructure/monitoring/KPI_REFERENCE.md
@@ -1,121 +1,18 @@
-# KPI Reference — Claire de Binare Operational Metrics
+# KPI Reference
 
-Canonical reference for all Prometheus metrics scraped by the CDB monitoring stack.
-Metrics are exposed via `/metrics` endpoints on each service and collected by Prometheus (15s scrape interval).
+Front-door pointer for monitoring canon.
 
-## Risk Manager (`:8002/metrics`)
+Current SSOT for the actually scraped and repo-backed metric surface:
+- `infrastructure/monitoring/METRICS_MATRIX.md`
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `signals_received_total` | counter | Signals received from Signal Engine via Redis PubSub |
-| `orders_approved_total` | counter | Orders that passed all risk checks and were forwarded to Execution |
-| `orders_blocked_total` | counter | Orders rejected by risk checks (limits, circuit breaker, kill-switch) |
-| `orders_skipped_total` | counter | Orders skipped due to qty=0 or parse errors |
-| `circuit_breaker_active` | gauge | Circuit breaker state (1=tripped, 0=normal) |
-| `order_results_received_total` | counter | Order result events processed (fills, rejects) |
-| `orders_rejected_execution_total` | counter | Orders rejected by Execution Service |
-| `risk_pending_orders_total` | gauge | Open orders awaiting execution confirmation |
-| `risk_total_exposure_value` | gauge | Total notional exposure across all positions |
-| `risk_reduce_only_approved_total` | counter | Reduce-only SELL orders approved while over exposure limit |
-| `risk_proactive_unwind_triggered_total` | counter | Auto-unwind triggers when position exceeds limits |
-| `risk_alerts_generated_total` | counter | Risk alerts published to Redis Pub/Sub channel `alerts` (not Prometheus alerting) |
-| `risk_kill_switch_active` | gauge | Kill-switch state (1=active/trading halted, 0=inactive) |
+Use this file only as a navigation entry point.
 
-## Signal Engine (`:8005/metrics`)
+Scope split:
+- scrape truth: `infrastructure/monitoring/prometheus.yml`
+- metric inventory and drift status: `infrastructure/monitoring/METRICS_MATRIX.md`
+- alert rules: `infrastructure/monitoring/alerts.yml`
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `latency_samples` | gauge | Number of latency observations |
-| `latency_sum_ms` | gauge | Cumulative signal processing latency (ms) |
-| `latency_count` | counter | Total signal processing invocations |
-| `errors_total` | counter | Signal processing errors |
-
-## Execution Service (`:8003/metrics`)
-
-| Metric | Type | Description |
-|--------|------|-------------|
-| `execution_orders_received_total` | counter | Orders received from Risk Manager |
-| `execution_orders_filled_total` | counter | Orders successfully filled on exchange |
-| `execution_orders_rejected_total` | counter | Orders rejected (exchange error, invalid params) |
-| `execution_shadow_blocked_total` | counter | Orders blocked by shadow mode (no real execution) |
-| `execution_invalid_payloads_total` | counter | Malformed order payloads received |
-
-## DB Writer (`:8010/metrics`)
-
-| Metric | Type | Description |
-|--------|------|-------------|
-| `db_writer_events_processed_total` | counter | Events persisted to PostgreSQL (by channel) |
-| `db_writer_events_failed_total` | counter | Events that failed to persist (by channel) |
-| `db_writer_uptime_seconds` | gauge | Service uptime |
-
-## WebSocket Screener (`:8000/metrics`)
-
-| Metric | Type | Description |
-|--------|------|-------------|
-| `decoded_messages_total` | counter | Market data messages decoded from MEXC WebSocket |
-| `decode_errors_total` | counter | Failed message decodes |
-| `ws_connected` | gauge | WebSocket connection state (1=connected) |
-| `last_message_ts_ms` | gauge | Timestamp of last received message (ms since epoch) |
-| `redis_publish_total` | counter | Messages published to Redis |
-| `redis_publish_errors_total` | counter | Failed Redis publishes |
-
-## Candle Aggregator (`:8007/metrics`)
-
-| Metric | Type | Description |
-|--------|------|-------------|
-| `candles_trades_processed_total` | counter | Raw trades aggregated into candles |
-| `candles_emitted_total` | counter | Completed candles emitted |
-| `candles_market_state_updates_total` | counter | Market state updates processed |
-| `candles_market_state_skipped_total` | counter | Market state updates skipped (dedup) |
-
-## Infrastructure Exporters
-
-| Exporter | Port | Metrics |
-|----------|------|---------|
-| `cdb_postgres_exporter` | 9187 | PostgreSQL stats: connections, locks, replication lag, table sizes |
-| `cdb_redis_exporter` | 9121 | Redis stats: memory, connected clients, keyspace, commands/s |
-| `cdb_cadvisor` | 8080 | Container metrics: CPU, memory, network, disk I/O per container |
-| `cdb_node_exporter` | 9100 | Host metrics: CPU, memory, disk, network, load average |
-
-## Prometheus Alert Rules
-
-26 Prometheus alerting rules in 8 groups defined in `infrastructure/monitoring/alerts.yml` (distinct from the Redis Pub/Sub `alerts` channel above):
-
-| Group | Focus | Key Thresholds |
-|-------|-------|----------------|
-| `minimal_observability` | Service up/down | 4 core services monitored |
-| `critical_alerts` | Circuit breaker, DB/Redis loss, drawdown | Drawdown >5% |
-| `high_priority_alerts` | Latency, error rate, order processing | P95 >500ms, error >5% |
-| `warning_alerts` | Resource usage, throughput | CPU >80%, memory >85% |
-| `infrastructure_alerts` | Restarts, disk, targets | Disk <10%, restart loops |
-| `soak_test_gates` | 72h soak validation | Zero-restart policy, OOM, stalls |
-
-## Dashboards
-
-15 Grafana dashboards provisioned from `infrastructure/monitoring/grafana/dashboards/`:
-
-| Dashboard | Coverage |
-|-----------|----------|
-| `claire_minimal_observability_v1` | Entry-level 4-service health |
-| `cdb_system_health_v1` | All services up/down, error rates, latency |
-| `cdb_system_health_owner_v1` | Enhanced system health (owner view) |
-| `claire_risk_manager_v1` | Risk decisions, exposure, circuit breaker |
-| `claire_execution_v1` | Order lifecycle, shadow blocks |
-| `claire_signal_engine_v1` | Signal generation, latency histogram |
-| `claire_database_v1` | PostgreSQL connections, query timing |
-| `claire_system_performance_v1` | CPU, memory, disk, container restarts |
-| `claire_soak_test_v1` | 72h soak test monitoring |
-| `claire_paper_trading_v1` | P&L, win rate, Sharpe ratio |
-| `claire_hitl_control_v1` | Human-in-the-loop approval rates |
-| `cdb_money_result_owner_v1` | Financial results |
-| `risk_decision_accounting` | Risk decision audit trail |
-| `signals_sprint1` | Signal generation tracking |
-| `claire_dark_v1` | Dark-mode variant |
-
-## Datasources
-
-| Source | Type | Endpoint |
-|--------|------|----------|
-| Prometheus | Time series | `cdb_prometheus:9090` |
-| PostgreSQL | SQL | `cdb_postgres:5432` |
-| Loki | Logs | `cdb_loki:3100` |
+Explicit non-scope for this file:
+- no dashboard spec
+- no operator KPI shortlist
+- no duplicate per-metric inventory

--- a/infrastructure/monitoring/METRICS_MATRIX.md
+++ b/infrastructure/monitoring/METRICS_MATRIX.md
@@ -1,0 +1,137 @@
+# Metrics Matrix
+
+Repo-backed SSOT for Prometheus-scraped metrics in the working repo.
+
+Scope of this file:
+- inventory and canon only
+- no dashboard spec
+- no operator KPI shortlist
+- no new telemetry
+
+Collection authority:
+- Prometheus scrape plan: `infrastructure/monitoring/prometheus.yml`
+- Runtime/job evidence: `infrastructure/compose/compose.blue.yml`, `infrastructure/compose/compose.red.yml`, `infrastructure/compose/base.yml`, `infrastructure/compose/dev.yml`
+- Metric producer evidence: service code and exporter wiring in the repo
+- Grafana is downstream only and is not a source-of-truth surface for this file
+
+## Ist-Zustand
+
+- Prometheus currently defines 12 scrape jobs in `infrastructure/monitoring/prometheus.yml`.
+- Repo-backed custom `/metrics` producers exist for `cdb_risk`, `cdb_execution`, `cdb_signal`, `cdb_db_writer`, `cdb_ws`, and `cdb_candles`.
+- Repo-backed exporter jobs exist for `cdb_postgres`, `cdb_redis`, and `cdb_cadvisor`.
+- `cdb_paper_runner` is configured as a scrape target, but the repo-backed service only exposes `/health` and `/status`; no `/metrics` endpoint exists.
+- `cdb_node_exporter` is configured as a scrape target and exists in `base.yml` / `dev.yml`, but no active `compose.blue.yml` / `compose.red.yml` runtime definition exists. This is tracked separately in issue `#1528`.
+- `infrastructure/monitoring/KPI_REFERENCE.md` had become broader than the repo-backed metric surface and is now reduced to a front-door pointer to this file.
+
+## Scrape Jobs
+
+| job_name | source_service / exporter | scrape_target / endpoint | Runtime evidence | status | Notes |
+|---|---|---|---|---|---|
+| `prometheus` | Prometheus self-scrape | `localhost:9090/metrics` | `infrastructure/monitoring/prometheus.yml` | `aktiv` | Self metrics plus Prometheus-generated `up` |
+| `cdb_execution` | Execution Service | `cdb_execution:8003/metrics` | `services/execution/service.py` | `aktiv` | Manual text/plain metrics endpoint |
+| `cdb_signal` | Signal Engine | `cdb_signal:8005/metrics` | `services/signal/service.py` | `aktiv` | Manual text/plain metrics endpoint |
+| `cdb_candles` | Candle Aggregator | `cdb_candles:8007/metrics` | `services/candles/service.py` | `aktiv` | Marked `env=dev` in scrape config |
+| `cdb_db_writer` | DB Writer | `cdb_db_writer:8010/metrics` | `services/db_writer/db_writer.py` | `aktiv` | `prometheus_client.start_http_server()` |
+| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `services/risk/service.py` | `aktiv` | Manual text/plain metrics endpoint |
+| `cdb_ws` | WebSocket service | `cdb_ws:8000/metrics` | `services/ws/service.py` | `aktiv` | `prometheus_client.generate_latest()` |
+| `cdb_postgres` | postgres-exporter | `cdb_postgres_exporter:9187/metrics` | `infrastructure/compose/base.yml`, `infrastructure/compose/compose.red.yml` | `aktiv` | Standard exporter surface; exact collector set not customized in repo |
+| `cdb_redis` | redis-exporter | `cdb_redis_exporter:9121/metrics` | `infrastructure/compose/base.yml`, `infrastructure/compose/compose.red.yml` | `aktiv` | Standard exporter surface; exact collector set not customized in repo |
+| `cdb_cadvisor` | cAdvisor | `cdb_cadvisor:8080/metrics` | `infrastructure/compose/base.yml`, `infrastructure/compose/compose.red.yml` | `aktiv` | Container resource metrics |
+| `cdb_paper_runner` | Paper Trading Runner | `cdb_paper_runner:8004/metrics` | `tools/paper_trading/service.py`, `infrastructure/compose/compose.blue.yml` | `deprecated/drift` | Service exists, but only `/health` and `/status` are repo-backed |
+| `cdb_node_exporter` | node-exporter | `cdb_node_exporter:9100/metrics` | `infrastructure/compose/base.yml`, `infrastructure/compose/dev.yml`, `infrastructure/compose/SERVICE_MAPPING.md` | `unklar` | Scrape configured, base/dev define the service, but BLUE+RED runtime canon omits it; tracked in `#1528` |
+
+Note:
+- Prometheus generates `up{job,instance,...}` for every configured scrape target. To avoid duplicating one row per job, `up` is only called out below where it is the main known signal for a drifted or exporter-backed target.
+
+## Metrics Matrix
+
+### Repo-backed custom service metrics
+
+| job_name | source_service / exporter | scrape_target / endpoint | metric_name | type | kurze Bedeutung | class | status | labels | spaetere dashboard_eignung |
+|---|---|---|---|---|---|---|---|---|---|
+| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `signals_received_total` | `counter` | Count of signals consumed from Redis PubSub | `business` | `aktiv` | none visible | `kandidat` |
+| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `orders_approved_total` | `counter` | Orders approved by risk checks and forwarded | `business` | `aktiv` | none visible | `kandidat` |
+| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `orders_blocked_total` | `counter` | Orders blocked by risk checks | `business` | `aktiv` | none visible | `kandidat` |
+| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `orders_skipped_total` | `counter` | Orders skipped due to qty/parsing edge cases | `mixed/unclear` | `aktiv` | none visible | `unklar` |
+| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `circuit_breaker_active` | `gauge` | Circuit breaker state, `1` when tripped | `business` | `aktiv` | none visible | `kandidat` |
+| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `order_results_received_total` | `counter` | Count of execution result events processed by risk | `mixed/unclear` | `aktiv` | none visible | `unklar` |
+| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `orders_rejected_execution_total` | `counter` | Orders rejected downstream by execution | `mixed/unclear` | `aktiv` | none visible | `kandidat` |
+| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `risk_pending_orders_total` | `gauge` | Current number of pending order confirmations | `business` | `aktiv` | none visible | `kandidat` |
+| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `risk_total_exposure_value` | `gauge` | Current total notional exposure | `business` | `aktiv` | none visible | `kandidat` |
+| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `risk_reduce_only_approved_total` | `counter` | Reduce-only sells approved while over exposure limit | `business` | `aktiv` | none visible | `unklar` |
+| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `risk_proactive_unwind_triggered_total` | `counter` | Auto-unwind triggers raised by risk logic | `business` | `aktiv` | none visible | `unklar` |
+| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `risk_alerts_generated_total` | `counter` | Alerts published to Redis topic `alerts` | `mixed/unclear` | `aktiv` | none visible | `unklar` |
+| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `risk_kill_switch_active` | `gauge` | Kill-switch state, `1` when trading is halted | `business` | `aktiv` | none visible | `kandidat` |
+| `cdb_execution` | Execution Service | `cdb_execution:8003/metrics` | `execution_orders_received_total` | `counter` | Orders received by execution | `business` | `aktiv` | none visible | `kandidat` |
+| `cdb_execution` | Execution Service | `cdb_execution:8003/metrics` | `execution_orders_filled_total` | `counter` | Orders filled successfully | `business` | `aktiv` | none visible | `kandidat` |
+| `cdb_execution` | Execution Service | `cdb_execution:8003/metrics` | `execution_orders_rejected_total` | `counter` | Orders rejected by execution | `business` | `aktiv` | none visible | `kandidat` |
+| `cdb_execution` | Execution Service | `cdb_execution:8003/metrics` | `execution_invalid_payloads_total` | `counter` | Invalid order payloads dropped fail-closed | `mixed/unclear` | `aktiv` | none visible | `unklar` |
+| `cdb_execution` | Execution Service | `cdb_execution:8003/metrics` | `execution_shadow_blocked_total` | `counter` | Orders blocked by shadow-mode gate | `business` | `aktiv` | none visible | `kandidat` |
+| `cdb_execution` | Execution Service | `cdb_execution:8003/metrics` | `execution_uptime_seconds` | `gauge` | Service uptime in seconds | `infra` | `aktiv` | none visible | `eher nicht` |
+| `cdb_signal` | Signal Engine | `cdb_signal:8005/metrics` | `signals_generated_total` | `counter` | Signals emitted by the signal engine | `business` | `aktiv` | none visible | `kandidat` |
+| `cdb_signal` | Signal Engine | `cdb_signal:8005/metrics` | `signal_engine_status` | `gauge` | Service status, `1` when running | `infra` | `aktiv` | none visible | `unklar` |
+| `cdb_signal` | Signal Engine | `cdb_signal:8005/metrics` | `signal_processing_latency_ms` | `histogram` | Signal processing latency histogram | `mixed/unclear` | `aktiv` | `le` | `kandidat` |
+| `cdb_signal` | Signal Engine | `cdb_signal:8005/metrics` | `signal_errors_total` | `counter` | Signal processing errors by error type | `mixed/unclear` | `aktiv` | `error_type` when present | `kandidat` |
+| `cdb_db_writer` | DB Writer | `cdb_db_writer:8010/metrics` | `db_writer_events_processed_total` | `counter` | Persisted Redis events by subscribed channel | `mixed/unclear` | `aktiv` | `channel` | `kandidat` |
+| `cdb_db_writer` | DB Writer | `cdb_db_writer:8010/metrics` | `db_writer_events_failed_total` | `counter` | Failed persistence attempts by subscribed channel | `mixed/unclear` | `aktiv` | `channel` | `kandidat` |
+| `cdb_db_writer` | DB Writer | `cdb_db_writer:8010/metrics` | `db_writer_uptime_seconds` | `gauge` | Service uptime in seconds | `infra` | `aktiv` | none visible | `eher nicht` |
+| `cdb_ws` | WebSocket service | `cdb_ws:8000/metrics` | `decoded_messages_total` | `counter` | Decoded WebSocket market-data messages | `mixed/unclear` | `aktiv` | none visible | `unklar` |
+| `cdb_ws` | WebSocket service | `cdb_ws:8000/metrics` | `decode_errors_total` | `counter` | WebSocket message decode failures | `infra` | `aktiv` | none visible | `kandidat` |
+| `cdb_ws` | WebSocket service | `cdb_ws:8000/metrics` | `ws_connected` | `gauge` | WebSocket connection state, `1` when connected | `infra` | `aktiv` | none visible | `kandidat` |
+| `cdb_ws` | WebSocket service | `cdb_ws:8000/metrics` | `last_message_ts_ms` | `gauge` | Timestamp of last received message in ms | `infra` | `aktiv` | none visible | `kandidat` |
+| `cdb_ws` | WebSocket service | `cdb_ws:8000/metrics` | `redis_publish_total` | `counter` | Market-data publishes to Redis | `mixed/unclear` | `aktiv` | none visible | `unklar` |
+| `cdb_ws` | WebSocket service | `cdb_ws:8000/metrics` | `redis_publish_errors_total` | `counter` | Failed market-data publishes to Redis | `infra` | `aktiv` | none visible | `kandidat` |
+| `cdb_candles` | Candle Aggregator | `cdb_candles:8007/metrics` | `candle_trades_processed_total` | `counter` | Raw trades aggregated into candles | `business` | `aktiv` | none visible | `unklar` |
+| `cdb_candles` | Candle Aggregator | `cdb_candles:8007/metrics` | `candle_candles_emitted_total` | `counter` | Completed candles emitted by the aggregator | `business` | `aktiv` | none visible | `unklar` |
+
+### Exporter-backed and scrape-level families
+
+| job_name | source_service / exporter | scrape_target / endpoint | metric_name | type | kurze Bedeutung | class | status | labels | spaetere dashboard_eignung |
+|---|---|---|---|---|---|---|---|---|---|
+| `prometheus` | Prometheus self-scrape | `localhost:9090/metrics` | `up` | `gauge` | Scrape success for the Prometheus target itself | `infra` | `aktiv` | `job`, `instance`, static target labels | `kandidat` |
+| `prometheus` | Prometheus self-scrape | `localhost:9090/metrics` | `prometheus_*` | `mixed/unclear` | Prometheus server internal metric families; exact subset not enumerated here | `infra` | `unklar` | exporter-defined | `unklar` |
+| `cdb_postgres` | postgres-exporter | `cdb_postgres_exporter:9187/metrics` | `pg_up` | `gauge` | Postgres scrape/connectivity state used by alerts | `infra` | `aktiv` | exporter-defined | `kandidat` |
+| `cdb_postgres` | postgres-exporter | `cdb_postgres_exporter:9187/metrics` | `pg_*` | `mixed/unclear` | Standard postgres-exporter families; exact collector subset not customized in repo | `infra` | `unklar` | exporter-defined | `unklar` |
+| `cdb_redis` | redis-exporter | `cdb_redis_exporter:9121/metrics` | `redis_up` | `gauge` | Redis scrape/connectivity state used by alerts | `infra` | `aktiv` | exporter-defined | `kandidat` |
+| `cdb_redis` | redis-exporter | `cdb_redis_exporter:9121/metrics` | `redis_*` | `mixed/unclear` | Standard redis-exporter families; exact subset not customized in repo | `infra` | `unklar` | exporter-defined | `unklar` |
+| `cdb_cadvisor` | cAdvisor | `cdb_cadvisor:8080/metrics` | `container_cpu_usage_seconds_total` | `counter` | Per-container CPU usage | `infra` | `aktiv` | cAdvisor container labels | `kandidat` |
+| `cdb_cadvisor` | cAdvisor | `cdb_cadvisor:8080/metrics` | `container_memory_usage_bytes` | `gauge` | Per-container memory usage | `infra` | `aktiv` | cAdvisor container labels | `kandidat` |
+| `cdb_cadvisor` | cAdvisor | `cdb_cadvisor:8080/metrics` | `container_memory_limit_bytes` | `gauge` | Per-container memory limit | `infra` | `aktiv` | cAdvisor container labels | `kandidat` |
+| `cdb_cadvisor` | cAdvisor | `cdb_cadvisor:8080/metrics` | `container_restart_count` | `gauge` | Container restart count used by soak/infra alerts | `infra` | `aktiv` | cAdvisor container labels | `kandidat` |
+| `cdb_cadvisor` | cAdvisor | `cdb_cadvisor:8080/metrics` | `container_memory_oom_kill_total` | `counter` | OOM kill count per container | `infra` | `aktiv` | cAdvisor container labels | `kandidat` |
+| `cdb_node_exporter` | node-exporter | `cdb_node_exporter:9100/metrics` | `up` | `gauge` | Scrape success for configured node-exporter target | `infra` | `unklar` | `job`, `instance`, static target labels | `unklar` |
+| `cdb_node_exporter` | node-exporter | `cdb_node_exporter:9100/metrics` | `node_filesystem_avail_bytes` | `gauge` | Host filesystem free bytes referenced by alert rules | `infra` | `unklar` | node-exporter labels | `kandidat` |
+| `cdb_node_exporter` | node-exporter | `cdb_node_exporter:9100/metrics` | `node_filesystem_size_bytes` | `gauge` | Host filesystem size bytes referenced by alert rules | `infra` | `unklar` | node-exporter labels | `kandidat` |
+| `cdb_paper_runner` | Paper Trading Runner | `cdb_paper_runner:8004/metrics` | `up` | `gauge` | Prometheus scrape success for the configured paper-runner target | `infra` | `deprecated/drift` | `job`, `instance`, static target labels | `eher nicht` |
+
+### Documented but not repo-backed as active exports
+
+| job_name | source_service / exporter | scrape_target / endpoint | metric_name | type | kurze Bedeutung | class | status | labels | spaetere dashboard_eignung |
+|---|---|---|---|---|---|---|---|---|---|
+| `cdb_signal` | Signal Engine | `cdb_signal:8005/metrics` | `latency_samples`, `latency_sum_ms`, `latency_count` | `gauge/counter` | Older names still documented in `KPI_REFERENCE.md`, but current code exports `signal_processing_latency_ms_*` | `deprecated/drift` | `deprecated/drift` | none visible | `eher nicht` |
+| `cdb_signal` | Signal Engine | `cdb_signal:8005/metrics` | `errors_total` | `counter` | Older doc name; current code exports `signal_errors_total` | `deprecated/drift` | `deprecated/drift` | none visible | `eher nicht` |
+| `cdb_candles` | Candle Aggregator | `cdb_candles:8007/metrics` | `candles_trades_processed_total`, `candles_emitted_total` | `counter` | Older doc names; current code exports `candle_trades_processed_total` and `candle_candles_emitted_total` | `deprecated/drift` | `deprecated/drift` | none visible | `eher nicht` |
+| `cdb_candles` | Candle Aggregator | `cdb_candles:8007/metrics` | `candles_market_state_updates_total`, `candles_market_state_skipped_total` | `counter` | Stats exist in code, but they are not exported on `/metrics` | `mixed/unclear` | `deprecated/drift` | none visible | `eher nicht` |
+
+## Erkannte Canon- und Dokudrift
+
+1. `infrastructure/monitoring/KPI_REFERENCE.md` documented Signal metrics with outdated names (`latency_samples`, `latency_sum_ms`, `latency_count`, `errors_total`) while the actual service exports `signal_processing_latency_ms_*` and `signal_errors_total`.
+2. `infrastructure/monitoring/KPI_REFERENCE.md` documented Candle metrics with outdated names (`candles_*`) and extra market-state counters that are tracked in memory but not exposed on `/metrics`.
+3. `prometheus.yml` scrapes `cdb_paper_runner:8004/metrics`, but `tools/paper_trading/service.py` only exposes `/health` and `/status`.
+4. `prometheus.yml` scrapes `cdb_node_exporter:9100/metrics`, while `base.yml` / `dev.yml` still define the service, `compose.blue.yml` / `compose.red.yml` omit it, and `SERVICE_MAPPING.md` already lists it under removed services. This contradiction is tracked separately in `#1528`.
+5. `infrastructure/monitoring/alerts.yml` mixes repo-backed metrics with stale names:
+   - repo-backed examples: `circuit_breaker_active`, `pg_up`, `redis_up`, `execution_orders_received_total`, `signals_received_total`, `orders_approved_total`, `orders_blocked_total`, `execution_orders_filled_total`, `container_*`, `node_filesystem_*`
+   - stale/non-repo-backed examples: `cdb_daily_drawdown_pct`, `cdb_latency_seconds_bucket`, `cdb_errors_total`, `cdb_requests_total`, `cdb_order_processing_seconds`, `cdb_position_utilization_pct`, `cdb_orders_processed_total`, `cdb_signal_queue_length`
+6. `alerts.yml` excludes `cadvisor` and `node_exporter` by old job names, but the current Prometheus jobs are `cdb_cadvisor` and `cdb_node_exporter`.
+7. `infrastructure/compose/COMPOSE_LAYERS.md` still says `cdb_paper_runner` is disabled / not implemented, which no longer matches the repo-backed service and compose wiring. That drift is adjacent context, not changed in this session.
+
+## Schnitt fuer spaetere Grafana- und KPI-Auswahl
+
+This matrix is intentionally split so the next session can filter without re-inventorying:
+- `business`: trade-path and operator-control metrics that could become candidate KPIs later
+- `infra`: health, scrape, runtime, and exporter metrics
+- `mixed/unclear`: persistence or pipeline metrics that need operator-context decisions later
+
+Recommended next step after this file:
+- choose a minimal operator-facing subset from the rows already marked `kandidat`
+- do not add new metrics before that selection is justified against this inventory


### PR DESCRIPTION
## Summary
- add `infrastructure/monitoring/METRICS_MATRIX.md` as the repo-backed SSOT for currently scraped Prometheus metrics
- reduce `infrastructure/monitoring/KPI_REFERENCE.md` to a front-door pointer to the matrix
- classify scrape jobs, metric families, business vs infra, active vs drift, and later dashboard suitability without selecting operator KPIs yet
- split the `cdb_node_exporter` contradiction into dedicated follow-up issue #1528 after repo-backed verification

## What was checked
- `infrastructure/monitoring/prometheus.yml`
- `infrastructure/monitoring/KPI_REFERENCE.md`
- real metric producers in `services/risk`, `services/execution`, `services/signal`, `services/db_writer`, `services/ws`, `services/candles`
- `tools/paper_trading/service.py`
- compose/runtime evidence in `compose.blue.yml`, `compose.red.yml`, `base.yml`, `dev.yml`, `SERVICE_MAPPING.md`, `COMPOSE_LAYERS.md`
- downstream references in `alerts.yml` and Grafana dashboards only as secondary usage evidence

## Explicit non-scope
- no dashboard work
- no operator KPI shortlist
- no new metrics
- no Prometheus/Grafana refactor

## Drift handling
- `cdb_paper_runner` remains documented as configured scrape drift because the repo-backed service has no `/metrics`
- `cdb_node_exporter` is not resolved here; the contradiction is tracked separately in #1528

## Checks
- `git diff --check`
