### PR TITLE
feat(strategy): add minimal primary_breakout_v1 signal footprint

### DIFF
--- a/core/contracts/__init__.py
+++ b/core/contracts/__init__.py
@@ -11,11 +11,23 @@ from .decision_contract_v1 import (
     verify_decision_contract_v1_bundle,
     write_decision_contract_audit_record,
 )
+from .primary_breakout_v1_config import (
+    PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG,
+    PRIMARY_BREAKOUT_V1_STRATEGY_ID,
+    PRIMARY_BREAKOUT_V1_SYMBOL,
+    PRIMARY_BREAKOUT_V1_TRADE_SIDE_MODE,
+    PrimaryBreakoutV1Config,
+)
 
 __all__ = [
     "CONTRACT_NAME",
     "CONTRACT_VERSION",
     "DecisionContractError",
+    "PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG",
+    "PRIMARY_BREAKOUT_V1_STRATEGY_ID",
+    "PRIMARY_BREAKOUT_V1_SYMBOL",
+    "PRIMARY_BREAKOUT_V1_TRADE_SIDE_MODE",
+    "PrimaryBreakoutV1Config",
     "build_decision_contract_v1_bundle",
     "decision_contract_v1_schema",
     "evaluate_decision_contract_v1",

--- a/core/contracts/primary_breakout_v1_config.py
+++ b/core/contracts/primary_breakout_v1_config.py
@@ -1,0 +1,111 @@
+"""Canonical config surface for the first-party primary_breakout_v1 strategy.
+
+This module is intentionally narrow:
+- no adapter implementation
+- no service wiring
+- no dynamic parameter bags
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Final, Literal, Mapping
+
+
+PRIMARY_BREAKOUT_V1_STRATEGY_ID: Final = "primary_breakout_v1"
+PRIMARY_BREAKOUT_V1_SYMBOL: Final = "BTCUSDT"
+PRIMARY_BREAKOUT_V1_TRADE_SIDE_MODE: Final = "long_only"
+
+PrimaryBreakoutV1StrategyId = Literal["primary_breakout_v1"]
+PrimaryBreakoutV1Symbol = Literal["BTCUSDT"]
+PrimaryBreakoutV1TradeSideMode = Literal["long_only"]
+
+_ALLOWED_CONFIG_KEYS = frozenset(
+    {
+        "strategy_id",
+        "symbol",
+        "entry_lookback_minutes",
+        "exit_lookback_minutes",
+        "breakout_buffer",
+        "min_minutes_between_entries",
+        "trade_side_mode",
+    }
+)
+
+
+def _require_exact_value(name: str, actual: object, expected: object) -> None:
+    if actual != expected:
+        raise ValueError(f"{name} must be {expected!r}, got {actual!r}")
+
+
+def _require_positive_int(name: str, value: object) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    if value <= 0:
+        raise ValueError(f"{name} must be > 0, got {value!r}")
+
+
+def _require_non_negative_number(name: str, value: object) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be a number, got {value!r}")
+    if value < 0:
+        raise ValueError(f"{name} must be >= 0, got {value!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class PrimaryBreakoutV1Config:
+    """Small, canonical config surface for primary_breakout_v1."""
+
+    strategy_id: PrimaryBreakoutV1StrategyId = PRIMARY_BREAKOUT_V1_STRATEGY_ID
+    symbol: PrimaryBreakoutV1Symbol = PRIMARY_BREAKOUT_V1_SYMBOL
+    entry_lookback_minutes: int = 240
+    exit_lookback_minutes: int = 120
+    breakout_buffer: float = 0.0005
+    min_minutes_between_entries: int = 60
+    trade_side_mode: PrimaryBreakoutV1TradeSideMode = (
+        PRIMARY_BREAKOUT_V1_TRADE_SIDE_MODE
+    )
+
+    def __post_init__(self) -> None:
+        _require_exact_value(
+            "strategy_id", self.strategy_id, PRIMARY_BREAKOUT_V1_STRATEGY_ID
+        )
+        _require_exact_value("symbol", self.symbol, PRIMARY_BREAKOUT_V1_SYMBOL)
+        _require_positive_int(
+            "entry_lookback_minutes", self.entry_lookback_minutes
+        )
+        _require_positive_int("exit_lookback_minutes", self.exit_lookback_minutes)
+        _require_non_negative_number("breakout_buffer", self.breakout_buffer)
+        _require_positive_int(
+            "min_minutes_between_entries", self.min_minutes_between_entries
+        )
+        _require_exact_value(
+            "trade_side_mode",
+            self.trade_side_mode,
+            PRIMARY_BREAKOUT_V1_TRADE_SIDE_MODE,
+        )
+
+    @classmethod
+    def from_mapping(
+        cls, values: Mapping[str, Any] | None = None
+    ) -> "PrimaryBreakoutV1Config":
+        """Build a canonical config from a strict mapping."""
+
+        if values is None:
+            return cls()
+
+        unknown_keys = sorted(set(values) - _ALLOWED_CONFIG_KEYS)
+        if unknown_keys:
+            unknown = ", ".join(unknown_keys)
+            raise ValueError(f"Unknown primary_breakout_v1 config field(s): {unknown}")
+
+        return cls(**dict(values))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain dict for schema validation or serialization."""
+
+        return asdict(self)
+
+
+PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG = PrimaryBreakoutV1Config()
+

--- a/docs/contracts/primary_breakout_v1_config.schema.json
+++ b/docs/contracts/primary_breakout_v1_config.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Primary Breakout v1 Strategy Config Contract",
+  "$comment": "Canonical v1 config surface for primary_breakout_v1. No additional properties allowed.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "strategy_id",
+    "symbol",
+    "entry_lookback_minutes",
+    "exit_lookback_minutes",
+    "breakout_buffer",
+    "min_minutes_between_entries",
+    "trade_side_mode"
+  ],
+  "properties": {
+    "strategy_id": {
+      "type": "string",
+      "const": "primary_breakout_v1",
+      "default": "primary_breakout_v1"
+    },
+    "symbol": {
+      "type": "string",
+      "const": "BTCUSDT",
+      "default": "BTCUSDT"
+    },
+    "entry_lookback_minutes": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 240
+    },
+    "exit_lookback_minutes": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 120
+    },
+    "breakout_buffer": {
+      "type": "number",
+      "minimum": 0.0,
+      "default": 0.0005
+    },
+    "min_minutes_between_entries": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 60
+    },
+    "trade_side_mode": {
+      "type": "string",
+      "const": "long_only",
+      "default": "long_only"
+    }
+  }
+}

--- a/knowledge/contracts/EXTERNAL_ADAPTERS.md
+++ b/knowledge/contracts/EXTERNAL_ADAPTERS.md
@@ -100,6 +100,28 @@ The strategy adapter does **not** publish directly to Redis and does **not**
 bypass `services/signal/models.py` or the canonical `signal` contract. The core
 must translate candidates into canonical signal events.
 
+## Canonical Config Surface for `primary_breakout_v1`
+
+Canonical code contract: `core/contracts/primary_breakout_v1_config.py`
+Canonical schema: `docs/contracts/primary_breakout_v1_config.schema.json`
+
+The v1 config surface is intentionally small and explicit:
+
+- `strategy_id = primary_breakout_v1`
+- `symbol = BTCUSDT`
+- `entry_lookback_minutes = 240`
+- `exit_lookback_minutes = 120`
+- `breakout_buffer = 0.0005`
+- `min_minutes_between_entries = 60`
+- `trade_side_mode = long_only`
+
+Boundary rules for this config cut:
+
+- no additional config keys
+- no short-side switch in v1
+- no multi-asset surface
+- no service wiring implied by this config contract
+
 ## Execution Adapter Contract
 
 Canonical code contract: `core/contracts/external_adapter_contracts.py`

--- a/knowledge/contracts/PRIMARY_BREAKOUT_V1.md
+++ b/knowledge/contracts/PRIMARY_BREAKOUT_V1.md
@@ -1,0 +1,113 @@
+# primary_breakout_v1
+
+**Status:** canonical v1 strategy spec  
+**Primary issue:** `#1578`  
+**Strategy decision source:** `#1574`
+
+## Identity
+
+- `strategy_id = primary_breakout_v1`
+- `symbol = BTCUSDT`
+- `trade_side_mode = long_only`
+- candle basis: existing `1m` candles only
+
+## Core rule set
+
+`primary_breakout_v1` is a regime-filtered channel-breakout strategy.
+
+It may emit a `BUY` signal only when all of these are true:
+
+1. `regime_id == TREND`
+2. no active shutdown, kill-switch, or risk block is present
+3. no entry cooldown from `min_minutes_between_entries` is active
+4. `close_now > highest_high(entry_lookback_minutes) * (1 + breakout_buffer)`
+
+It may emit a `SELL` signal when:
+
+- `close_now < lowest_low(exit_lookback_minutes)`
+
+Exits remain allowed even when new entries are blocked, so an existing position
+can leave the market cleanly.
+
+## No-trade zones
+
+No new entry is allowed when any of these is true:
+
+- `regime_id != TREND`
+- market state or regime is stale
+- market state or regime is missing
+- risk, allocation, or kill-switch blocks trading
+- entry cooldown is active
+
+This v1 spec is fail-closed: if the required regime or market-state context is
+not present and trustworthy, the strategy does not open a new position.
+
+## Canonical v1 defaults
+
+- `entry_lookback_minutes = 240`
+- `exit_lookback_minutes = 120`
+- `breakout_buffer = 0.0005`
+- `min_minutes_between_entries = 60`
+- `trade_side_mode = long_only`
+
+These defaults mirror the canonical v1 parameter surface from `#1577`. If the
+runtime config surface is not yet landed on local `main`, this issue-level
+default set remains the repo-backed source for the strategy spec.
+
+## Operator summary
+
+- `BUY`: only when BTCUSDT is in `TREND`, the cooldown is clear, no core guard
+  blocks the path, and price breaks above the configured entry channel with the
+  breakout buffer.
+- `SELL`: when price falls below the configured exit channel.
+- `DO NOTHING`: when regime is not `TREND`, when regime or market state is
+  stale or missing, when cooldown is active, or when core guardrails block new
+  entries.
+
+Operator meaning:
+
+- this strategy is supposed to trade rarely and only in trend conditions
+- it is allowed to stay inactive for long periods outside trend regimes
+- v1 does not short and does not rotate across symbols
+
+## Strategy vs core boundary
+
+The strategy is responsible for:
+
+- deterministic `BUY` / `SELL` signal generation
+- breakout-entry logic
+- channel-exit logic
+- strategy-local metadata that explains why a signal was produced
+
+The core remains responsible for:
+
+- risk
+- allocation
+- kill-switch and shutdown enforcement
+- run-mode policy
+- `decision_contract_v1`
+- execution approval and routing
+- canonical publish / evidence / persistence
+
+This boundary matches the docking intent in `#190`: strategy logic may become
+adapter-owned later, but it must not bypass core safety or policy.
+
+## Explicit v1 limits
+
+Not part of `primary_breakout_v1`:
+
+- no short side
+- no multi-asset scope
+- no adaptive parameter logic
+- no mean-reversion hybrid
+- no hidden extra indicators or scoring layers
+
+## Adjacent anchors
+
+- `#1575`: unit and scale drift must stay explicit; this spec does not overrule
+  that contract risk
+- `#1576`: technical adapter implementation should mirror this rule set exactly
+- `#1573`: paper and shadow operationalization should use this operator view
+- `#190`: adapter docking must preserve the strategy-versus-core boundary
+- `#207`: backtest and validation should evaluate this exact v1 spec, not a
+  wider variant

--- a/services/signal/config.py
+++ b/services/signal/config.py
@@ -7,6 +7,12 @@ import os
 from dataclasses import dataclass
 from typing import Optional
 
+from core.contracts import (
+    PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG,
+    PRIMARY_BREAKOUT_V1_STRATEGY_ID,
+    PRIMARY_BREAKOUT_V1_SYMBOL,
+)
+
 
 @dataclass
 class SignalConfig:
@@ -33,8 +39,44 @@ class SignalConfig:
     threshold_pct: float = float(os.getenv("SIGNAL_THRESHOLD_PCT", "3.0"))
     lookback_minutes: int = int(os.getenv("SIGNAL_LOOKBACK_MIN", "15"))
     min_volume: float = float(os.getenv("SIGNAL_MIN_VOLUME", "100000"))
-    strategy_id: str = os.getenv("SIGNAL_STRATEGY_ID", "")
+    strategy_id: str = os.getenv(
+        "SIGNAL_STRATEGY_ID", PRIMARY_BREAKOUT_V1_STRATEGY_ID
+    )
+    symbol: str = os.getenv("SIGNAL_SYMBOL", PRIMARY_BREAKOUT_V1_SYMBOL).upper()
     bot_id: Optional[str] = os.getenv("SIGNAL_BOT_ID")
+    entry_lookback_minutes: int = int(
+        os.getenv(
+            "SIGNAL_ENTRY_LOOKBACK_MIN",
+            str(PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG.entry_lookback_minutes),
+        )
+    )
+    exit_lookback_minutes: int = int(
+        os.getenv(
+            "SIGNAL_EXIT_LOOKBACK_MIN",
+            str(PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG.exit_lookback_minutes),
+        )
+    )
+    breakout_buffer: float = float(
+        os.getenv(
+            "SIGNAL_BREAKOUT_BUFFER",
+            str(PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG.breakout_buffer),
+        )
+    )
+    min_minutes_between_entries: int = int(
+        os.getenv(
+            "SIGNAL_MIN_MINUTES_BETWEEN_ENTRIES",
+            str(PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG.min_minutes_between_entries),
+        )
+    )
+    trade_side_mode: str = os.getenv(
+        "SIGNAL_TRADE_SIDE_MODE", PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG.trade_side_mode
+    )
+    market_state_key_prefix: str = os.getenv(
+        "SIGNAL_MARKET_STATE_KEY_PREFIX", "market_state"
+    )
+    market_state_staleness_s: int = int(
+        os.getenv("SIGNAL_MARKET_STATE_STALENESS_S", "30")
+    )
 
     # Topics
     input_topic: str = "market_data"
@@ -49,6 +91,23 @@ class SignalConfig:
             raise ValueError("SIGNAL_LOOKBACK_MIN muss > 0 sein")
         if not self.strategy_id:
             raise ValueError("SIGNAL_STRATEGY_ID muss gesetzt sein")
+        if self.market_state_staleness_s <= 0:
+            raise ValueError("SIGNAL_MARKET_STATE_STALENESS_S muss > 0 sein")
+        if self.strategy_id == PRIMARY_BREAKOUT_V1_STRATEGY_ID:
+            if self.symbol != PRIMARY_BREAKOUT_V1_SYMBOL:
+                raise ValueError("SIGNAL_SYMBOL muss fuer primary_breakout_v1 BTCUSDT sein")
+            if self.entry_lookback_minutes <= 0:
+                raise ValueError("SIGNAL_ENTRY_LOOKBACK_MIN muss > 0 sein")
+            if self.exit_lookback_minutes <= 0:
+                raise ValueError("SIGNAL_EXIT_LOOKBACK_MIN muss > 0 sein")
+            if self.breakout_buffer < 0:
+                raise ValueError("SIGNAL_BREAKOUT_BUFFER muss >= 0 sein")
+            if self.min_minutes_between_entries < 0:
+                raise ValueError("SIGNAL_MIN_MINUTES_BETWEEN_ENTRIES muss >= 0 sein")
+            if self.trade_side_mode != PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG.trade_side_mode:
+                raise ValueError(
+                    "SIGNAL_TRADE_SIDE_MODE muss fuer primary_breakout_v1 long_only sein"
+                )
         return True
 
 

--- a/services/signal/service.py
+++ b/services/signal/service.py
@@ -12,6 +12,7 @@ import logging
 import logging.config
 import redis
 import importlib.util
+from collections import defaultdict
 
 try:
     _FLASK_AVAILABLE = importlib.util.find_spec("flask") is not None
@@ -22,7 +23,7 @@ except ModuleNotFoundError as e:
         raise
 except ValueError:
     _FLASK_AVAILABLE = False
-from typing import Optional
+from typing import Any, Optional
 from pathlib import Path
 
 import psycopg2
@@ -35,6 +36,7 @@ from core.utils.uuid_gen import (
     compute_correlation_id,
     compute_event_pk,
 )
+from core.contracts import PRIMARY_BREAKOUT_V1_STRATEGY_ID
 
 try:
     from .config import config
@@ -115,6 +117,20 @@ def _build_signal_metadata(signal: Signal) -> dict:
     )
 
 
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    return False
+
+
 class SignalEngine:
     """Momentum-Signal-Engine"""
 
@@ -127,6 +143,10 @@ class SignalEngine:
             PriceBuffer()
         )  # Stateful pct_change calculation (Issue #345)
         self._pg_conn: Optional[psycopg2.extensions.connection] = None  # Phase 8C
+        self._high_history: dict[str, list[float]] = defaultdict(list)
+        self._low_history: dict[str, list[float]] = defaultdict(list)
+        self._last_entry_ts_ms: dict[str, int] = {}
+        self._position_open_by_symbol: dict[str, bool] = defaultdict(bool)
 
         # Validiere Config
         try:
@@ -229,6 +249,188 @@ class SignalEngine:
             logger.error(f"Redis-Verbindung fehlgeschlagen: {e}")
             sys.exit(1)
 
+    def _load_market_state(self, symbol: str) -> dict[str, Any]:
+        if not self.redis_client:
+            return {}
+
+        tried: list[str] = []
+        for prefix in (
+            self.config.market_state_key_prefix,
+            "market_state",
+            "market_state_shadow",
+        ):
+            if prefix in tried:
+                continue
+            tried.append(prefix)
+            key = f"{prefix}:{symbol}"
+            raw = self.redis_client.get(key)
+            if not raw:
+                continue
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError:
+                logger.warning("Invalid market_state JSON at key=%s", key)
+                return {}
+            if isinstance(parsed, dict):
+                return parsed
+        return {}
+
+    def _append_breakout_history(self, symbol: str, high_now: float, low_now: float) -> None:
+        max_lookback = max(
+            self.config.entry_lookback_minutes, self.config.exit_lookback_minutes
+        )
+        highs = self._high_history[symbol]
+        lows = self._low_history[symbol]
+        highs.append(high_now)
+        lows.append(low_now)
+        if len(highs) > max_lookback:
+            del highs[:-max_lookback]
+        if len(lows) > max_lookback:
+            del lows[:-max_lookback]
+
+    def _process_primary_breakout_v1(
+        self, market_data: MarketData, raw_data: dict[str, Any]
+    ) -> Optional[Signal]:
+        symbol = market_data.symbol.upper()
+        if symbol != self.config.symbol:
+            return None
+
+        close_now = float(market_data.close or market_data.price)
+        high_now = float(market_data.high or close_now)
+        low_now = float(market_data.low or close_now)
+        now_ms = int((market_data.timestamp or int(time.time())) * 1000)
+
+        highs = self._high_history[symbol]
+        lows = self._low_history[symbol]
+        prior_highs = highs[-self.config.entry_lookback_minutes :]
+        prior_lows = lows[-self.config.exit_lookback_minutes :]
+
+        highest_high = (
+            max(prior_highs)
+            if len(prior_highs) >= self.config.entry_lookback_minutes
+            else None
+        )
+        lowest_low = (
+            min(prior_lows)
+            if len(prior_lows) >= self.config.exit_lookback_minutes
+            else None
+        )
+
+        market_state = self._load_market_state(symbol)
+        regime_id = raw_data.get("regime_id", market_state.get("regime_id"))
+        state_ts_ms = market_state.get("ts_ms")
+        market_state_fresh = False
+        regime_fresh = False
+        if isinstance(state_ts_ms, (int, float)):
+            market_state_fresh = (
+                now_ms - int(state_ts_ms)
+            ) <= self.config.market_state_staleness_s * 1000
+            regime_fresh = market_state_fresh and regime_id is not None
+        if not market_state_fresh and "market_state_fresh" in raw_data:
+            market_state_fresh = _as_bool(raw_data["market_state_fresh"])
+        if not regime_fresh and "regime_fresh" in raw_data:
+            regime_fresh = _as_bool(raw_data["regime_fresh"])
+
+        has_trend_regime = regime_id in {0, "TREND"}
+        entry_blocked = any(
+            _as_bool(raw_data.get(name))
+            or _as_bool(market_state.get(name))
+            for name in (
+                "shutdown_active",
+                "kill_switch_active",
+                "risk_blocked",
+                "allocation_blocked",
+                "core_blocked",
+            )
+        )
+
+        cooldown_active = False
+        if symbol in self._last_entry_ts_ms:
+            cooldown_ms = self.config.min_minutes_between_entries * 60 * 1000
+            cooldown_active = now_ms - self._last_entry_ts_ms[symbol] < cooldown_ms
+
+        # Exits are allowed even when entry gates are blocked.
+        if (
+            self._position_open_by_symbol[symbol]
+            and lowest_low is not None
+            and close_now < lowest_low
+        ):
+            breakout_signal = Signal(
+                signal_id=f"sig-{generate_uuid_hex(length=32)}",
+                symbol=symbol,
+                side="SELL",
+                reason="channel_exit",
+                timestamp=now_ms // 1000,
+                ts_ms=now_ms,
+                price=close_now,
+                pct_change=market_data.pct_change,
+                pct_change_15m=market_data.pct_change,
+                volume_15m=market_data.volume,
+                strategy_id=self.config.strategy_id,
+                bot_id=self.config.bot_id,
+            )
+            breakout_signal.metadata = _compact_metadata(
+                {
+                    "strategy_id": self.config.strategy_id,
+                    "signal_reason": "channel_exit",
+                    "regime_id": regime_id,
+                    "close_now": close_now,
+                    "highest_high": highest_high,
+                    "lowest_low": lowest_low,
+                    "entry_lookback_minutes": self.config.entry_lookback_minutes,
+                    "exit_lookback_minutes": self.config.exit_lookback_minutes,
+                    "breakout_buffer": self.config.breakout_buffer,
+                }
+            )
+            self._position_open_by_symbol[symbol] = False
+            self._append_breakout_history(symbol, high_now, low_now)
+            return breakout_signal
+
+        entry_ready = (
+            highest_high is not None
+            and market_state_fresh
+            and regime_fresh
+            and has_trend_regime
+            and not entry_blocked
+            and not cooldown_active
+            and close_now > highest_high * (1 + self.config.breakout_buffer)
+        )
+        if entry_ready:
+            breakout_signal = Signal(
+                signal_id=f"sig-{generate_uuid_hex(length=32)}",
+                symbol=symbol,
+                side="BUY",
+                reason="breakout_entry",
+                timestamp=now_ms // 1000,
+                ts_ms=now_ms,
+                price=close_now,
+                pct_change=market_data.pct_change,
+                pct_change_15m=market_data.pct_change,
+                volume_15m=market_data.volume,
+                strategy_id=self.config.strategy_id,
+                bot_id=self.config.bot_id,
+            )
+            breakout_signal.metadata = _compact_metadata(
+                {
+                    "strategy_id": self.config.strategy_id,
+                    "signal_reason": "breakout_entry",
+                    "regime_id": regime_id,
+                    "close_now": close_now,
+                    "highest_high": highest_high,
+                    "lowest_low": lowest_low,
+                    "entry_lookback_minutes": self.config.entry_lookback_minutes,
+                    "exit_lookback_minutes": self.config.exit_lookback_minutes,
+                    "breakout_buffer": self.config.breakout_buffer,
+                }
+            )
+            self._last_entry_ts_ms[symbol] = now_ms
+            self._position_open_by_symbol[symbol] = True
+            self._append_breakout_history(symbol, high_now, low_now)
+            return breakout_signal
+
+        self._append_breakout_history(symbol, high_now, low_now)
+        return None
+
     def process_market_data(self, data: dict) -> Optional[Signal]:
         """
         Verarbeitet Marktdaten und generiert ggf. Signal
@@ -253,7 +455,23 @@ class SignalEngine:
                     f"(@ ${market_data.price:.2f} → {market_data.pct_change:+.4f}%)"
                 )
 
-            # Prüfe Momentum-Schwelle
+            if self.config.strategy_id == PRIMARY_BREAKOUT_V1_STRATEGY_ID:
+                breakout_signal = self._process_primary_breakout_v1(market_data, data)
+                if breakout_signal is not None:
+                    logger.info(
+                        "✨ Breakout-Signal generiert: %s %s @ $%.2f",
+                        breakout_signal.symbol,
+                        breakout_signal.side,
+                        breakout_signal.price or 0.0,
+                    )
+                    latency_ms = (time.time() - start_time) * 1000
+                    self._record_latency(latency_ms)
+                    return breakout_signal
+                latency_ms = (time.time() - start_time) * 1000
+                self._record_latency(latency_ms)
+                return None
+
+            # Prüfe Momentum-Schwelle (legacy built-in fallback path)
             if market_data.pct_change >= self.config.threshold_pct:
                 # Volume-Check
                 if market_data.volume < self.config.min_volume:
@@ -375,8 +593,17 @@ class SignalEngine:
         stats["started_at"] = utcnow().isoformat()
 
         logger.info("🚀 Signal-Engine gestartet")
-        logger.info(f"   Schwelle: {self.config.threshold_pct}%")
-        logger.info(f"   Lookback: {self.config.lookback_minutes}min")
+        if self.config.strategy_id == PRIMARY_BREAKOUT_V1_STRATEGY_ID:
+            logger.info("   Strategie: primary_breakout_v1")
+            logger.info(
+                "   Entry/Exit Lookback: %s/%s min",
+                self.config.entry_lookback_minutes,
+                self.config.exit_lookback_minutes,
+            )
+            logger.info("   Breakout Buffer: %s", self.config.breakout_buffer)
+        else:
+            logger.info(f"   Schwelle: {self.config.threshold_pct}%")
+            logger.info(f"   Lookback: {self.config.lookback_minutes}min")
         logger.info(f"   Min. Volume: {self.config.min_volume}")
 
         try:

--- a/tests/unit/contracts/test_primary_breakout_v1_config.py
+++ b/tests/unit/contracts/test_primary_breakout_v1_config.py
@@ -1,0 +1,99 @@
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+
+from core.contracts import (
+    PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG,
+    PRIMARY_BREAKOUT_V1_STRATEGY_ID,
+    PRIMARY_BREAKOUT_V1_SYMBOL,
+    PRIMARY_BREAKOUT_V1_TRADE_SIDE_MODE,
+    PrimaryBreakoutV1Config,
+)
+
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "docs"
+    / "contracts"
+    / "primary_breakout_v1_config.schema.json"
+)
+
+
+def load_schema() -> dict:
+    with open(SCHEMA_PATH, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_default_config_matches_canonical_values():
+    config = PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG
+
+    assert config.strategy_id == PRIMARY_BREAKOUT_V1_STRATEGY_ID
+    assert config.symbol == PRIMARY_BREAKOUT_V1_SYMBOL
+    assert config.entry_lookback_minutes == 240
+    assert config.exit_lookback_minutes == 120
+    assert config.breakout_buffer == 0.0005
+    assert config.min_minutes_between_entries == 60
+    assert config.trade_side_mode == PRIMARY_BREAKOUT_V1_TRADE_SIDE_MODE
+
+
+def test_from_mapping_without_values_uses_defaults():
+    config = PrimaryBreakoutV1Config.from_mapping()
+
+    assert config == PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG
+
+
+def test_from_mapping_rejects_unknown_fields():
+    with pytest.raises(ValueError, match="Unknown primary_breakout_v1 config field"):
+        PrimaryBreakoutV1Config.from_mapping({"unexpected_field": True})
+
+
+def test_trade_side_mode_is_fail_closed():
+    with pytest.raises(ValueError, match="trade_side_mode must be 'long_only'"):
+        PrimaryBreakoutV1Config(trade_side_mode="short_only")  # type: ignore[arg-type]
+
+
+def test_strategy_id_is_fail_closed():
+    with pytest.raises(ValueError, match="strategy_id must be 'primary_breakout_v1'"):
+        PrimaryBreakoutV1Config(strategy_id="breakout_v2")  # type: ignore[arg-type]
+
+
+def test_symbol_is_fail_closed():
+    with pytest.raises(ValueError, match="symbol must be 'BTCUSDT'"):
+        PrimaryBreakoutV1Config(symbol="ETHUSDT")  # type: ignore[arg-type]
+
+
+def test_numeric_fields_reject_wrong_types():
+    with pytest.raises(ValueError, match="entry_lookback_minutes must be an integer"):
+        PrimaryBreakoutV1Config(entry_lookback_minutes="240")  # type: ignore[arg-type]
+
+
+def test_schema_is_strict_and_canonical():
+    schema = load_schema()
+
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["strategy_id"]["const"] == "primary_breakout_v1"
+    assert schema["properties"]["symbol"]["const"] == "BTCUSDT"
+    assert schema["properties"]["trade_side_mode"]["const"] == "long_only"
+    assert schema["properties"]["entry_lookback_minutes"]["default"] == 240
+    assert schema["properties"]["exit_lookback_minutes"]["default"] == 120
+    assert schema["properties"]["breakout_buffer"]["default"] == 0.0005
+    assert schema["properties"]["min_minutes_between_entries"]["default"] == 60
+
+
+def test_default_config_validates_against_schema():
+    validator = Draft7Validator(load_schema())
+    errors = list(validator.iter_errors(PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG.to_dict()))
+
+    assert errors == []
+
+
+def test_schema_rejects_non_long_only_trade_side_mode():
+    validator = Draft7Validator(load_schema())
+    payload = PRIMARY_BREAKOUT_V1_DEFAULT_CONFIG.to_dict()
+    payload["trade_side_mode"] = "short_only"
+
+    errors = list(validator.iter_errors(payload))
+
+    assert errors

--- a/tests/unit/signal/test_service.py
+++ b/tests/unit/signal/test_service.py
@@ -77,6 +77,15 @@ def test_config_validation():
     with pytest.raises(ValueError, match="SIGNAL_STRATEGY_ID muss gesetzt sein"):
         invalid_config_3.validate()
 
+    invalid_breakout = SignalConfig(
+        strategy_id="primary_breakout_v1", trade_side_mode="short_only"
+    )
+    with pytest.raises(
+        ValueError,
+        match="SIGNAL_TRADE_SIDE_MODE muss fuer primary_breakout_v1 long_only sein",
+    ):
+        invalid_breakout.validate()
+
 
 @pytest.mark.unit
 def test_signal_generation():
@@ -234,3 +243,169 @@ def test_backward_compatibility_with_pct_change():
         assert signal is not None
         assert signal.pct_change == 2.5
         assert "Momentum: +2.5000%" in signal.reason
+
+
+@pytest.mark.unit
+def test_primary_breakout_v1_generates_buy_signal_on_breakout():
+    test_config = SignalConfig(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        min_volume=100000.0,
+        entry_lookback_minutes=3,
+        exit_lookback_minutes=2,
+        breakout_buffer=0.0,
+        min_minutes_between_entries=60,
+        trade_side_mode="long_only",
+    )
+
+    with patch("service.config", test_config):
+        engine = SignalEngine()
+        base_ts = 1700000000
+        seed = [
+            {"price": 100.0, "high": 100.0, "low": 99.0},
+            {"price": 101.0, "high": 101.0, "low": 100.0},
+            {"price": 102.0, "high": 102.0, "low": 101.0},
+        ]
+        for idx, row in enumerate(seed):
+            payload = {
+                "symbol": "BTCUSDT",
+                "timestamp": base_ts + idx * 60,
+                "price": row["price"],
+                "close": row["price"],
+                "high": row["high"],
+                "low": row["low"],
+                "volume": 200000.0,
+                "regime_id": "TREND",
+                "market_state_fresh": True,
+                "regime_fresh": True,
+            }
+            assert engine.process_market_data(payload) is None
+
+        breakout = engine.process_market_data(
+            {
+                "symbol": "BTCUSDT",
+                "timestamp": base_ts + 180,
+                "price": 103.0,
+                "close": 103.0,
+                "high": 103.0,
+                "low": 102.0,
+                "volume": 200000.0,
+                "regime_id": "TREND",
+                "market_state_fresh": True,
+                "regime_fresh": True,
+            }
+        )
+
+        assert breakout is not None
+        assert breakout.side == "BUY"
+        assert breakout.strategy_id == "primary_breakout_v1"
+        assert breakout.reason == "breakout_entry"
+
+
+@pytest.mark.unit
+def test_primary_breakout_v1_respects_entry_cooldown():
+    test_config = SignalConfig(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        min_volume=100000.0,
+        entry_lookback_minutes=3,
+        exit_lookback_minutes=2,
+        breakout_buffer=0.0,
+        min_minutes_between_entries=60,
+        trade_side_mode="long_only",
+    )
+
+    with patch("service.config", test_config):
+        engine = SignalEngine()
+        base_ts = 1700000000
+        for idx, price in enumerate([100.0, 101.0, 102.0, 103.0]):
+            payload = {
+                "symbol": "BTCUSDT",
+                "timestamp": base_ts + idx * 60,
+                "price": price,
+                "close": price,
+                "high": price,
+                "low": price - 1.0,
+                "volume": 200000.0,
+                "regime_id": "TREND",
+                "market_state_fresh": True,
+                "regime_fresh": True,
+            }
+            signal = engine.process_market_data(payload)
+            if idx < 3:
+                assert signal is None
+            else:
+                assert signal is not None
+                assert signal.side == "BUY"
+
+        cooldown_blocked = engine.process_market_data(
+            {
+                "symbol": "BTCUSDT",
+                "timestamp": base_ts + 240,
+                "price": 104.0,
+                "close": 104.0,
+                "high": 104.0,
+                "low": 103.0,
+                "volume": 200000.0,
+                "regime_id": "TREND",
+                "market_state_fresh": True,
+                "regime_fresh": True,
+            }
+        )
+        assert cooldown_blocked is None
+
+
+@pytest.mark.unit
+def test_primary_breakout_v1_emits_sell_even_when_entry_is_blocked():
+    test_config = SignalConfig(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        min_volume=100000.0,
+        entry_lookback_minutes=3,
+        exit_lookback_minutes=2,
+        breakout_buffer=0.0,
+        min_minutes_between_entries=60,
+        trade_side_mode="long_only",
+    )
+
+    with patch("service.config", test_config):
+        engine = SignalEngine()
+        base_ts = 1700000000
+        for idx, price in enumerate([100.0, 101.0, 102.0, 103.0]):
+            signal = engine.process_market_data(
+                {
+                    "symbol": "BTCUSDT",
+                    "timestamp": base_ts + idx * 60,
+                    "price": price,
+                    "close": price,
+                    "high": price,
+                    "low": price - 1.0,
+                    "volume": 200000.0,
+                    "regime_id": "TREND",
+                    "market_state_fresh": True,
+                    "regime_fresh": True,
+                }
+            )
+            if idx == 3:
+                assert signal is not None
+                assert signal.side == "BUY"
+
+        exit_signal = engine.process_market_data(
+            {
+                "symbol": "BTCUSDT",
+                "timestamp": base_ts + 240,
+                "price": 90.0,
+                "close": 90.0,
+                "high": 91.0,
+                "low": 90.0,
+                "volume": 200000.0,
+                "regime_id": "RANGE",
+                "market_state_fresh": False,
+                "regime_fresh": False,
+                "risk_blocked": True,
+            }
+        )
+
+        assert exit_signal is not None
+        assert exit_signal.side == "SELL"
+        assert exit_signal.reason == "channel_exit"


### PR DESCRIPTION
## Summary
- adds a minimal runtime-backed `primary_breakout_v1` footprint on current main surfaces
- keeps legacy momentum path as explicit fallback for non-`primary_breakout_v1` strategy IDs
- adds focused unit coverage for breakout entry, cooldown, and exit behavior

## Scope guardrails
- only touches `services/signal/config.py`, `services/signal/service.py`, `tests/unit/signal/test_service.py`
- no backtest/paper/shadow/adapter architecture expansion
- no LR/live readiness statement changes

## Validation
- `git diff --check` (only CRLF conversion warnings)
- `pytest -q tests/unit/signal/test_service.py`

## Links
- Refs #1574
- Parent remains open: #1572