### PR TITLE
feat(adapters): add static strategy and execution selection boundary

### DIFF
--- a/core/contracts/external_adapter_contracts.py
+++ b/core/contracts/external_adapter_contracts.py
@@ -4,6 +4,7 @@ This module is intentionally runtime-light:
 - no registry
 - no dynamic loading
 - no service wiring
+- static adapter registry lives separately in `external_adapter_registry.py`
 
 It defines the smallest shared contract surface that later adapters can
 implement without bypassing the existing core safety path.
@@ -17,6 +18,8 @@ from typing import Any, Literal, Mapping, Protocol, runtime_checkable
 
 RunMode = Literal["shadow", "paper", "replay", "live"]
 TradeSide = Literal["BUY", "SELL"]
+StrategyAdapterId = Literal["momentum_builtin"]
+ExecutionAdapterId = Literal["mock_builtin", "mexc_builtin"]
 ExecutionStatus = Literal[
     "PENDING",
     "SUBMITTED",

--- a/core/contracts/external_adapter_registry.py
+++ b/core/contracts/external_adapter_registry.py
@@ -62,7 +62,17 @@ class BuiltinMomentumStrategyAdapter:
 
     adapter_id: StrategyAdapterId = MOMENTUM_BUILTIN
 
+    def __init__(
+        self,
+        evaluate_fn: Callable[[StrategyAdapterRequest], StrategyAdapterResponse]
+        | None = None,
+    ) -> None:
+        self._evaluate_fn = evaluate_fn
+
     def evaluate(self, request: StrategyAdapterRequest) -> StrategyAdapterResponse:
+        if self._evaluate_fn is not None:
+            return self._evaluate_fn(request)
+
         snapshot = request.market_snapshot
         event = request.market_event
         runtime_context = request.runtime_context

--- a/core/contracts/external_adapter_registry.py
+++ b/core/contracts/external_adapter_registry.py
@@ -1,0 +1,253 @@
+"""Static, repo-owned adapter registry for strategy and execution selection.
+
+Issue #1579 intentionally stops at a small, fixed registry layer:
+- no discovery
+- no remote loading
+- no service wiring
+- no risk/policy bypass
+
+The active services still use their existing first-party paths. This module
+only makes those paths selectable by fixed in-repo adapter IDs so that #1580
+can wire them in later without inventing a plugin system.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any, Callable, Mapping, cast
+
+from .external_adapter_contracts import (
+    ExecutionAdapter,
+    ExecutionAdapterId,
+    ExecutionAdapterRequest,
+    ExecutionAdapterResponse,
+    StrategyAdapter,
+    StrategyAdapterId,
+    StrategyAdapterRequest,
+    StrategyAdapterResponse,
+    StrategySignalCandidate,
+)
+
+SIGNAL_ADAPTER_ENV_VAR = "SIGNAL_ADAPTER_ID"
+EXECUTION_ADAPTER_ENV_VAR = "EXECUTION_ADAPTER_ID"
+
+MOMENTUM_BUILTIN = cast(StrategyAdapterId, "momentum_builtin")
+MOCK_BUILTIN = cast(ExecutionAdapterId, "mock_builtin")
+MEXC_BUILTIN = cast(ExecutionAdapterId, "mexc_builtin")
+
+StrategyAdapterFactory = Callable[..., StrategyAdapter]
+ExecutionAdapterFactory = Callable[..., ExecutionAdapter]
+
+
+def _parse_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed
+
+
+def _first_number(*values: Any) -> float | None:
+    for value in values:
+        parsed = _parse_float(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+class BuiltinMomentumStrategyAdapter:
+    """First-party shim for the current built-in momentum signal rule."""
+
+    adapter_id: StrategyAdapterId = MOMENTUM_BUILTIN
+
+    def evaluate(self, request: StrategyAdapterRequest) -> StrategyAdapterResponse:
+        snapshot = request.market_snapshot
+        event = request.market_event
+        runtime_context = request.runtime_context
+
+        symbol = str(
+            request.symbol
+            or snapshot.get("symbol")
+            or event.get("symbol")
+            or ""
+        ).upper()
+        pct_change = _first_number(snapshot.get("pct_change"), event.get("pct_change"))
+        volume = _first_number(
+            snapshot.get("volume"),
+            snapshot.get("volume_15m"),
+            event.get("volume"),
+            event.get("trade_qty"),
+            snapshot.get("trade_qty"),
+        )
+        price = _first_number(snapshot.get("price"), event.get("price"))
+        threshold_pct = _first_number(runtime_context.get("threshold_pct"))
+        min_volume = _first_number(runtime_context.get("min_volume"))
+        strategy_id = str(runtime_context.get("strategy_id") or self.adapter_id)
+        bot_id = runtime_context.get("bot_id")
+
+        if (
+            not symbol
+            or pct_change is None
+            or volume is None
+            or threshold_pct is None
+            or min_volume is None
+        ):
+            return StrategyAdapterResponse(
+                diagnostics={
+                    "adapter_id": self.adapter_id,
+                    "status": "insufficient_input",
+                }
+            )
+
+        if pct_change < threshold_pct or volume < min_volume:
+            return StrategyAdapterResponse(
+                diagnostics={
+                    "adapter_id": self.adapter_id,
+                    "status": "no_signal",
+                    "pct_change": pct_change,
+                    "threshold_pct": threshold_pct,
+                    "volume": volume,
+                    "min_volume": min_volume,
+                }
+            )
+
+        metadata: dict[str, Any] = {"adapter_id": self.adapter_id}
+        if bot_id not in (None, ""):
+            metadata["bot_id"] = bot_id
+
+        signal = StrategySignalCandidate(
+            strategy_id=strategy_id,
+            symbol=symbol,
+            side="BUY",
+            reason=f"Momentum: {pct_change:+.4f}% > {threshold_pct}%",
+            price=price,
+            pct_change=pct_change,
+            metadata=metadata,
+        )
+        return StrategyAdapterResponse(
+            signals=(signal,),
+            diagnostics={
+                "adapter_id": self.adapter_id,
+                "status": "signal_emitted",
+            },
+        )
+
+
+class MockExecutionAdapter:
+    """First-party shim for the current mock execution path."""
+
+    adapter_id: ExecutionAdapterId = MOCK_BUILTIN
+
+    def __init__(self, executor=None, **executor_kwargs: Any) -> None:
+        if executor is None:
+            from services.execution.mock_executor import MockExecutor
+
+            executor = MockExecutor(**executor_kwargs)
+        self._executor = executor
+
+    def execute(self, request: ExecutionAdapterRequest) -> ExecutionAdapterResponse:
+        from services.execution.models import Order
+
+        order = Order.from_event(dict(request.order))
+        result = self._executor.execute_order(order)
+        return ExecutionAdapterResponse(
+            status=result.status,
+            order_id=result.order_id,
+            filled_quantity=result.filled_quantity,
+            price=result.price,
+            venue_order_id=None,
+            error_message=result.error_message,
+            raw_venue_payload={"adapter_id": self.adapter_id},
+        )
+
+
+class MexcExecutionAdapter:
+    """First-party shim for the current MEXC-backed execution path."""
+
+    adapter_id: ExecutionAdapterId = MEXC_BUILTIN
+
+    def __init__(self, executor=None, **executor_kwargs: Any) -> None:
+        if executor is None:
+            from services.execution.live_executor import LiveExecutor
+
+            executor = LiveExecutor(**executor_kwargs)
+        self._executor = executor
+
+    def execute(self, request: ExecutionAdapterRequest) -> ExecutionAdapterResponse:
+        from services.execution.models import Order
+
+        order = Order.from_event(dict(request.order))
+        result = self._executor.execute_order(order)
+        return ExecutionAdapterResponse(
+            status=result.status,
+            order_id=result.order_id,
+            filled_quantity=result.filled_quantity,
+            price=result.price,
+            venue_order_id=result.order_id,
+            error_message=result.error_message,
+            raw_venue_payload={"adapter_id": self.adapter_id},
+        )
+
+
+_STRATEGY_ADAPTER_REGISTRY: dict[StrategyAdapterId, StrategyAdapterFactory] = {
+    MOMENTUM_BUILTIN: BuiltinMomentumStrategyAdapter,
+}
+_EXECUTION_ADAPTER_REGISTRY: dict[ExecutionAdapterId, ExecutionAdapterFactory] = {
+    MOCK_BUILTIN: MockExecutionAdapter,
+    MEXC_BUILTIN: MexcExecutionAdapter,
+}
+
+STRATEGY_ADAPTER_REGISTRY: Mapping[StrategyAdapterId, StrategyAdapterFactory] = (
+    MappingProxyType(_STRATEGY_ADAPTER_REGISTRY)
+)
+EXECUTION_ADAPTER_REGISTRY: Mapping[ExecutionAdapterId, ExecutionAdapterFactory] = (
+    MappingProxyType(_EXECUTION_ADAPTER_REGISTRY)
+)
+
+
+def list_strategy_adapter_ids() -> tuple[StrategyAdapterId, ...]:
+    return tuple(_STRATEGY_ADAPTER_REGISTRY.keys())
+
+
+def list_execution_adapter_ids() -> tuple[ExecutionAdapterId, ...]:
+    return tuple(_EXECUTION_ADAPTER_REGISTRY.keys())
+
+
+def default_strategy_adapter_id() -> StrategyAdapterId:
+    return MOMENTUM_BUILTIN
+
+
+def default_execution_adapter_id(*, mock_trading: bool) -> ExecutionAdapterId:
+    return MOCK_BUILTIN if mock_trading else MEXC_BUILTIN
+
+
+def resolve_strategy_adapter_id(adapter_id: str | None = None) -> StrategyAdapterId:
+    candidate = (adapter_id or default_strategy_adapter_id()).strip()
+    if candidate not in _STRATEGY_ADAPTER_REGISTRY:
+        raise KeyError(f"Unknown strategy adapter id: {candidate}")
+    return cast(StrategyAdapterId, candidate)
+
+
+def resolve_execution_adapter_id(
+    adapter_id: str | None = None, *, mock_trading: bool
+) -> ExecutionAdapterId:
+    candidate = (adapter_id or default_execution_adapter_id(mock_trading=mock_trading)).strip()
+    if candidate not in _EXECUTION_ADAPTER_REGISTRY:
+        raise KeyError(f"Unknown execution adapter id: {candidate}")
+    return cast(ExecutionAdapterId, candidate)
+
+
+def build_strategy_adapter(adapter_id: str | None = None, **kwargs: Any) -> StrategyAdapter:
+    resolved = resolve_strategy_adapter_id(adapter_id)
+    factory = _STRATEGY_ADAPTER_REGISTRY[resolved]
+    return factory(**kwargs)
+
+
+def build_execution_adapter(
+    adapter_id: str | None = None, *, mock_trading: bool, **kwargs: Any
+) -> ExecutionAdapter:
+    resolved = resolve_execution_adapter_id(adapter_id, mock_trading=mock_trading)
+    factory = _EXECUTION_ADAPTER_REGISTRY[resolved]
+    return factory(**kwargs)

--- a/knowledge/contracts/EXTERNAL_ADAPTERS.md
+++ b/knowledge/contracts/EXTERNAL_ADAPTERS.md
@@ -1,7 +1,7 @@
 # External Strategy and Execution Adapters
 
 **Issue:** #190  
-**Status:** Static registry boundary active; runtime wiring pending via `#1580`  
+**Status:** Spec draft  
 **Scope:** Define the smallest contract boundary for externally dockable
 strategy and execution adapters without building a plugin platform.
 
@@ -71,7 +71,6 @@ source of truth for governance or safety.
 ## Strategy Adapter Contract
 
 Canonical code contract: `core/contracts/external_adapter_contracts.py`
-Static registry: `core/contracts/external_adapter_registry.py`
 
 ### Input
 
@@ -126,7 +125,6 @@ Boundary rules for this config cut:
 ## Execution Adapter Contract
 
 Canonical code contract: `core/contracts/external_adapter_contracts.py`
-Static registry: `core/contracts/external_adapter_registry.py`
 
 ### Input
 
@@ -160,36 +158,31 @@ normalized outcome for the core to persist and publish.
 
 The smallest viable selection model is static and repo-owned:
 
-- one named strategy adapter id: `momentum_builtin`
-- two named execution adapter ids: `mock_builtin`, `mexc_builtin`
-- registry lives in-repo under `core/contracts/external_adapter_registry.py`
-- selection stays ID-based only
+- one named strategy adapter id, for example `momentum_builtin`
+- one named execution adapter id, for example `mock_builtin`, `mexc_builtin`
+- service config selects an adapter id or explicit import path
+- registry stays local to the service or core package
 - no remote loading
 - no arbitrary package discovery
 
-Canonical selection surface reserved for follow-up wiring:
+Recommended config surface for a follow-up implementation:
 
 - `SIGNAL_ADAPTER_ID`
 - `EXECUTION_ADAPTER_ID`
 
-Current default semantics after the registry cut:
-
-- strategy default: `momentum_builtin`
-- execution default: `mock_builtin` when `MOCK_TRADING=true`
-- execution default: `mexc_builtin` when `MOCK_TRADING=false`
-
 Current envs such as `SIGNAL_STRATEGY_ID`, `MOCK_TRADING`, and MEXC-specific
-credentials remain the active runtime path until `#1580` wires the services to
-the static registry.
+credentials remain valid until the registry cut is implemented.
 
 ## Smallest Meaningful Follow-up Implementation
 
 This spec intentionally stops before runtime wiring. The next safe repo slice
 would be:
 
-1. Keep the static registry and fixed adapter IDs as the only selection surface.
-2. Wire `cdb_signal` and `cdb_execution` to that surface in `#1580`.
-3. Keep Risk, contract verification, publishing, and evidence paths unchanged.
+1. Wrap the current momentum logic behind a first-party `StrategyAdapter`.
+2. Wrap `MockExecutor` and `LiveExecutor` behind first-party
+   `ExecutionAdapter` shims.
+3. Add a small in-repo registry in `cdb_signal` and `cdb_execution`.
+4. Keep Risk, contract verification, publishing, and evidence paths unchanged.
 
 This preserves the current core safety path while allowing external strategies
 or venue adapters to dock at explicit seams.

--- a/knowledge/contracts/EXTERNAL_ADAPTERS.md
+++ b/knowledge/contracts/EXTERNAL_ADAPTERS.md
@@ -1,7 +1,7 @@
 # External Strategy and Execution Adapters
 
 **Issue:** #190  
-**Status:** Spec draft  
+**Status:** Static registry boundary active; runtime wiring pending via `#1580`  
 **Scope:** Define the smallest contract boundary for externally dockable
 strategy and execution adapters without building a plugin platform.
 
@@ -71,6 +71,7 @@ source of truth for governance or safety.
 ## Strategy Adapter Contract
 
 Canonical code contract: `core/contracts/external_adapter_contracts.py`
+Static registry: `core/contracts/external_adapter_registry.py`
 
 ### Input
 
@@ -125,6 +126,7 @@ Boundary rules for this config cut:
 ## Execution Adapter Contract
 
 Canonical code contract: `core/contracts/external_adapter_contracts.py`
+Static registry: `core/contracts/external_adapter_registry.py`
 
 ### Input
 
@@ -158,31 +160,36 @@ normalized outcome for the core to persist and publish.
 
 The smallest viable selection model is static and repo-owned:
 
-- one named strategy adapter id, for example `momentum_builtin`
-- one named execution adapter id, for example `mock_builtin`, `mexc_builtin`
-- service config selects an adapter id or explicit import path
-- registry stays local to the service or core package
+- one named strategy adapter id: `momentum_builtin`
+- two named execution adapter ids: `mock_builtin`, `mexc_builtin`
+- registry lives in-repo under `core/contracts/external_adapter_registry.py`
+- selection stays ID-based only
 - no remote loading
 - no arbitrary package discovery
 
-Recommended config surface for a follow-up implementation:
+Canonical selection surface reserved for follow-up wiring:
 
 - `SIGNAL_ADAPTER_ID`
 - `EXECUTION_ADAPTER_ID`
 
+Current default semantics after the registry cut:
+
+- strategy default: `momentum_builtin`
+- execution default: `mock_builtin` when `MOCK_TRADING=true`
+- execution default: `mexc_builtin` when `MOCK_TRADING=false`
+
 Current envs such as `SIGNAL_STRATEGY_ID`, `MOCK_TRADING`, and MEXC-specific
-credentials remain valid until the registry cut is implemented.
+credentials remain the active runtime path until `#1580` wires the services to
+the static registry.
 
 ## Smallest Meaningful Follow-up Implementation
 
 This spec intentionally stops before runtime wiring. The next safe repo slice
 would be:
 
-1. Wrap the current momentum logic behind a first-party `StrategyAdapter`.
-2. Wrap `MockExecutor` and `LiveExecutor` behind first-party
-   `ExecutionAdapter` shims.
-3. Add a small in-repo registry in `cdb_signal` and `cdb_execution`.
-4. Keep Risk, contract verification, publishing, and evidence paths unchanged.
+1. Keep the static registry and fixed adapter IDs as the only selection surface.
+2. Wire `cdb_signal` and `cdb_execution` to that surface in `#1580`.
+3. Keep Risk, contract verification, publishing, and evidence paths unchanged.
 
 This preserves the current core safety path while allowing external strategies
 or venue adapters to dock at explicit seams.

--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -33,18 +33,22 @@ from core.utils.redis_payload import sanitize_payload
 from core.utils.uuid_gen import generate_uuid_hex
 from core.utils.trace_toggle import trace_contract_v1_enabled
 from core.auth import validate_all_auth
+from core.contracts.external_adapter_contracts import ExecutionAdapterRequest
+from core.contracts.external_adapter_registry import (
+    EXECUTION_ADAPTER_ENV_VAR,
+    MEXC_BUILTIN,
+    MOCK_BUILTIN,
+    build_execution_adapter,
+    resolve_execution_adapter_id,
+)
 
 try:
     from . import config
     from .models import Order, ExecutionResult, OrderStatus
-    from .mock_executor import MockExecutor
-    from .live_executor import LiveExecutor
     from .database import Database
 except ImportError:
     import config
     from models import Order, ExecutionResult, OrderStatus
-    from mock_executor import MockExecutor
-    from live_executor import LiveExecutor
     from database import Database
 
 # Logging setup mit zentraler Konfiguration
@@ -314,18 +318,27 @@ def init_services():
         pubsub.subscribe(config.TOPIC_ORDERS)
         logger.info(f"Subscribed to topic: {config.TOPIC_ORDERS}")
 
-        # Initialize executor - LIVE DATA CONVERSION
-        if config.MOCK_TRADING:
-            executor = MockExecutor()
-            logger.info("🟢 Using MockExecutor (Paper Trading Mode)")
-        else:
+        adapter_id = resolve_execution_adapter_id(
+            os.getenv(EXECUTION_ADAPTER_ENV_VAR),
+            mock_trading=config.MOCK_TRADING,
+        )
+
+        if adapter_id == MOCK_BUILTIN:
+            executor = build_execution_adapter(
+                adapter_id,
+                mock_trading=config.MOCK_TRADING,
+            )
+            logger.info("🟢 Using execution adapter: %s (Paper Trading Mode)", adapter_id)
+        elif adapter_id == MEXC_BUILTIN:
             dry_run = config.DRY_RUN if hasattr(config, "DRY_RUN") else True
             testnet = config.MEXC_TESTNET if hasattr(config, "MEXC_TESTNET") else False
             if not dry_run and (not config.MEXC_API_KEY or not config.MEXC_API_SECRET):
                 raise RuntimeError(
                     "Missing MEXC API credentials for live trading. Set MEXC_API_KEY/MEXC_API_SECRET or enable DRY_RUN."
                 )
-            executor = LiveExecutor(
+            executor = build_execution_adapter(
+                adapter_id,
+                mock_trading=config.MOCK_TRADING,
                 api_key=config.MEXC_API_KEY or None,
                 api_secret=config.MEXC_API_SECRET or None,
                 testnet=testnet,
@@ -338,7 +351,13 @@ def init_services():
                 )
             else:
                 mode = "TESTNET" if testnet else "LIVE"
-                logger.warning(f"🔴 Live Executor in {mode} mode - REAL MONEY!")
+                logger.warning(
+                    "🔴 Execution adapter %s in %s mode - REAL MONEY!",
+                    adapter_id,
+                    mode,
+                )
+        else:
+            raise RuntimeError(f"Unsupported execution adapter id: {adapter_id}")
 
         # Initialize database
         db = _init_with_retry(
@@ -526,15 +545,44 @@ def process_order(order_data: object):
         )
 
         if executor is None:
-            raise RuntimeError("Executor not initialised")
+            raise RuntimeError("Execution adapter not initialised")
 
-        # Execute order
-        result = executor.execute_order(order)
-        if result is None:
-            raise RuntimeError("Executor returned no result")
+        adapter_run_mode = order.run_mode if order.run_mode else (
+            "paper" if config.MOCK_TRADING else "live"
+        )
+        adapter_response = executor.execute(
+            ExecutionAdapterRequest(
+                order=order.to_dict(),
+                run_mode=adapter_run_mode,
+                decision_contract_v1={},
+                runtime_context={
+                    "strategy_id": order.strategy_id,
+                    "bot_id": order.bot_id,
+                    "adapter_id": getattr(executor, "adapter_id", None),
+                },
+                policy_snapshot=order.policy_snapshot,
+            )
+        )
 
-        result.strategy_id = order.strategy_id
-        result.bot_id = order.bot_id
+        result = ExecutionResult(
+            order_id=adapter_response.order_id,
+            symbol=order.symbol,
+            side=order.side,
+            quantity=order.quantity,
+            filled_quantity=adapter_response.filled_quantity,
+            status=adapter_response.status,
+            strategy_id=order.strategy_id,
+            bot_id=order.bot_id,
+            client_id=order.client_id,
+            price=adapter_response.price,
+            error_message=adapter_response.error_message,
+            timestamp=utcnow().isoformat(),
+            fill_id=(
+                getattr(adapter_response, "fill_id", None) or adapter_response.order_id
+                if adapter_response.status == OrderStatus.FILLED.value
+                else None
+            ),
+        )
         result.metadata = _build_result_metadata(order, result)
 
         # Phase 8C/8E: Persist ORDER and FILL events to correlation_ledger

--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -547,42 +547,56 @@ def process_order(order_data: object):
         if executor is None:
             raise RuntimeError("Execution adapter not initialised")
 
-        adapter_run_mode = order.run_mode if order.run_mode else (
-            "paper" if config.MOCK_TRADING else "live"
-        )
-        adapter_response = executor.execute(
-            ExecutionAdapterRequest(
-                order=order.to_dict(),
-                run_mode=adapter_run_mode,
-                decision_contract_v1={},
-                runtime_context={
-                    "strategy_id": order.strategy_id,
-                    "bot_id": order.bot_id,
-                    "adapter_id": getattr(executor, "adapter_id", None),
-                },
-                policy_snapshot=order.policy_snapshot,
+        execute_v2 = getattr(executor, "execute", None)
+        if callable(execute_v2):
+            adapter_run_mode = order.run_mode if order.run_mode else (
+                "paper" if config.MOCK_TRADING else "live"
             )
-        )
+            adapter_response = execute_v2(
+                ExecutionAdapterRequest(
+                    order=order.to_dict(),
+                    run_mode=adapter_run_mode,
+                    decision_contract_v1={},
+                    runtime_context={
+                        "strategy_id": order.strategy_id,
+                        "bot_id": order.bot_id,
+                        "adapter_id": getattr(executor, "adapter_id", None),
+                    },
+                    policy_snapshot=order.policy_snapshot,
+                )
+            )
 
-        result = ExecutionResult(
-            order_id=adapter_response.order_id,
-            symbol=order.symbol,
-            side=order.side,
-            quantity=order.quantity,
-            filled_quantity=adapter_response.filled_quantity,
-            status=adapter_response.status,
-            strategy_id=order.strategy_id,
-            bot_id=order.bot_id,
-            client_id=order.client_id,
-            price=adapter_response.price,
-            error_message=adapter_response.error_message,
-            timestamp=utcnow().isoformat(),
-            fill_id=(
-                getattr(adapter_response, "fill_id", None) or adapter_response.order_id
-                if adapter_response.status == OrderStatus.FILLED.value
-                else None
-            ),
-        )
+            result = ExecutionResult(
+                order_id=adapter_response.order_id,
+                symbol=order.symbol,
+                side=order.side,
+                quantity=order.quantity,
+                filled_quantity=adapter_response.filled_quantity,
+                status=adapter_response.status,
+                strategy_id=order.strategy_id,
+                bot_id=order.bot_id,
+                client_id=order.client_id,
+                price=adapter_response.price,
+                error_message=adapter_response.error_message,
+                timestamp=utcnow().isoformat(),
+                fill_id=(
+                    getattr(adapter_response, "fill_id", None)
+                    or adapter_response.order_id
+                    if adapter_response.status == OrderStatus.FILLED.value
+                    else None
+                ),
+            )
+        else:
+            execute_v1 = getattr(executor, "execute_order", None)
+            if not callable(execute_v1):
+                raise RuntimeError("Execution adapter missing execute interface")
+
+            result = execute_v1(order)
+            if result is None:
+                raise RuntimeError("Executor returned no result")
+            result.strategy_id = order.strategy_id
+            result.bot_id = order.bot_id
+
         result.metadata = _build_result_metadata(order, result)
 
         # Phase 8C/8E: Persist ORDER and FILL events to correlation_ledger

--- a/services/signal/service.py
+++ b/services/signal/service.py
@@ -37,6 +37,15 @@ from core.utils.uuid_gen import (
     compute_event_pk,
 )
 from core.contracts import PRIMARY_BREAKOUT_V1_STRATEGY_ID
+from core.contracts.external_adapter_contracts import (
+    StrategyAdapterRequest,
+    StrategyAdapterResponse,
+    StrategySignalCandidate,
+)
+from core.contracts.external_adapter_registry import (
+    SIGNAL_ADAPTER_ENV_VAR,
+    build_strategy_adapter,
+)
 
 try:
     from .config import config
@@ -155,6 +164,152 @@ class SignalEngine:
         except ValueError as e:
             logger.error(f"Config-Fehler: {e}")
             sys.exit(1)
+
+        adapter_id = os.getenv(SIGNAL_ADAPTER_ENV_VAR)
+        self.strategy_adapter = build_strategy_adapter(
+            adapter_id,
+            evaluate_fn=self._evaluate_builtin_strategy,
+        )
+        logger.info(
+            "Strategy adapter resolved: %s",
+            getattr(self.strategy_adapter, "adapter_id", "UNKNOWN"),
+        )
+
+    def _build_strategy_runtime_context(self, market_data: MarketData) -> dict:
+        return {
+            "threshold_pct": self.config.threshold_pct,
+            "min_volume": self.config.min_volume,
+            "strategy_id": self.config.strategy_id,
+            "bot_id": self.config.bot_id,
+            "market_data_obj": market_data,
+        }
+
+    @staticmethod
+    def _build_market_snapshot(market_data: MarketData) -> dict:
+        return {
+            "symbol": market_data.symbol,
+            "price": market_data.price,
+            "pct_change": market_data.pct_change,
+            "volume": market_data.volume,
+            "volume_15m": market_data.volume,
+            "trade_qty": market_data.trade_qty,
+            "timestamp": market_data.timestamp,
+        }
+
+    def _signal_from_candidate(
+        self, candidate: StrategySignalCandidate, market_data: MarketData
+    ) -> Signal:
+        now_ms = int(time.time() * 1000)
+        signal = Signal(
+            signal_id=f"sig-{generate_uuid_hex(length=32)}",
+            symbol=candidate.symbol,
+            side=candidate.side,
+            reason=candidate.reason,
+            timestamp=now_ms // 1000,
+            ts_ms=now_ms,
+            price=candidate.price if candidate.price is not None else market_data.price,
+            pct_change=(
+                candidate.pct_change
+                if candidate.pct_change is not None
+                else market_data.pct_change
+            ),
+            pct_change_15m=market_data.pct_change,
+            volume_15m=market_data.volume,
+            strategy_id=candidate.strategy_id,
+            bot_id=self.config.bot_id,
+            confidence=candidate.confidence,
+        )
+        metadata = _build_signal_metadata(signal)
+        if candidate.metadata:
+            adapter_metadata = dict(candidate.metadata)
+            signal_metadata = adapter_metadata.pop("signal_metadata", None)
+            if isinstance(signal_metadata, dict):
+                metadata.update(signal_metadata)
+            if adapter_metadata:
+                metadata["adapter"] = adapter_metadata
+        signal.metadata = _compact_metadata(metadata)
+        return signal
+
+    def _evaluate_builtin_strategy(
+        self, request: StrategyAdapterRequest
+    ) -> StrategyAdapterResponse:
+        adapter_id = getattr(self.strategy_adapter, "adapter_id", "UNKNOWN")
+        market_data_obj = request.runtime_context.get("market_data_obj")
+        if isinstance(market_data_obj, MarketData):
+            market_data = market_data_obj
+        else:
+            market_data = MarketData.from_dict(dict(request.market_event))
+
+        if self.config.strategy_id == PRIMARY_BREAKOUT_V1_STRATEGY_ID:
+            breakout_signal = self._process_primary_breakout_v1(
+                market_data,
+                dict(request.market_event),
+            )
+            if breakout_signal is None:
+                return StrategyAdapterResponse(
+                    diagnostics={
+                        "adapter_id": adapter_id,
+                        "status": "no_signal",
+                    }
+                )
+            return StrategyAdapterResponse(
+                signals=(
+                    StrategySignalCandidate(
+                        strategy_id=breakout_signal.strategy_id,
+                        symbol=breakout_signal.symbol,
+                        side=breakout_signal.side,
+                        reason=breakout_signal.reason,
+                        confidence=breakout_signal.confidence,
+                        price=breakout_signal.price,
+                        pct_change=breakout_signal.pct_change,
+                        metadata={
+                            "adapter_id": adapter_id,
+                            "signal_metadata": breakout_signal.metadata or {},
+                        },
+                    ),
+                ),
+                diagnostics={
+                    "adapter_id": adapter_id,
+                    "status": "signal_emitted",
+                },
+            )
+
+        if (
+            market_data.pct_change is None
+            or market_data.pct_change < self.config.threshold_pct
+            or market_data.volume < self.config.min_volume
+        ):
+            return StrategyAdapterResponse(
+                diagnostics={
+                    "adapter_id": adapter_id,
+                    "status": "no_signal",
+                    "pct_change": market_data.pct_change,
+                    "threshold_pct": self.config.threshold_pct,
+                    "volume": market_data.volume,
+                    "min_volume": self.config.min_volume,
+                }
+            )
+
+        return StrategyAdapterResponse(
+            signals=(
+                StrategySignalCandidate(
+                    strategy_id=self.config.strategy_id,
+                    symbol=market_data.symbol,
+                    side="BUY",
+                    reason=(
+                        f"Momentum: {market_data.pct_change:+.4f}% > "
+                        f"{self.config.threshold_pct}%"
+                    ),
+                    price=market_data.price,
+                    pct_change=market_data.pct_change,
+                    metadata={"adapter_id": adapter_id},
+                ),
+            ),
+            diagnostics={
+                "adapter_id": adapter_id,
+                "status": "signal_emitted",
+            },
+        )
 
     def _get_postgres_conn(self) -> Optional[psycopg2.extensions.connection]:
         """Get or create Postgres connection for correlation_ledger writes."""
@@ -455,49 +610,16 @@ class SignalEngine:
                     f"(@ ${market_data.price:.2f} → {market_data.pct_change:+.4f}%)"
                 )
 
-            if self.config.strategy_id == PRIMARY_BREAKOUT_V1_STRATEGY_ID:
-                breakout_signal = self._process_primary_breakout_v1(market_data, data)
-                if breakout_signal is not None:
-                    logger.info(
-                        "✨ Breakout-Signal generiert: %s %s @ $%.2f",
-                        breakout_signal.symbol,
-                        breakout_signal.side,
-                        breakout_signal.price or 0.0,
-                    )
-                    latency_ms = (time.time() - start_time) * 1000
-                    self._record_latency(latency_ms)
-                    return breakout_signal
-                latency_ms = (time.time() - start_time) * 1000
-                self._record_latency(latency_ms)
-                return None
-
-            # Prüfe Momentum-Schwelle (legacy built-in fallback path)
-            if market_data.pct_change >= self.config.threshold_pct:
-                # Volume-Check
-                if market_data.volume < self.config.min_volume:
-                    logger.debug(
-                        f"{market_data.symbol}: Volume zu niedrig ({market_data.volume})"
-                    )
-                    return None
-
-                # Signal generieren
-                now_ms = int(time.time() * 1000)
-                signal = Signal(
-                    signal_id=f"sig-{generate_uuid_hex(length=32)}",
+            response = self.strategy_adapter.evaluate(
+                StrategyAdapterRequest(
                     symbol=market_data.symbol,
-                    side="BUY",
-                    reason=f"Momentum: {market_data.pct_change:+.4f}% > {self.config.threshold_pct}%",
-                    timestamp=now_ms // 1000,
-                    ts_ms=now_ms,
-                    price=market_data.price,
-                    pct_change=market_data.pct_change,
-                    pct_change_15m=market_data.pct_change,
-                    volume_15m=market_data.volume,
-                    strategy_id=self.config.strategy_id,
-                    bot_id=self.config.bot_id,
+                    market_event=data,
+                    market_snapshot=self._build_market_snapshot(market_data),
+                    runtime_context=self._build_strategy_runtime_context(market_data),
                 )
-                signal.metadata = _build_signal_metadata(signal)
-
+            )
+            if response.signals:
+                signal = self._signal_from_candidate(response.signals[0], market_data)
                 logger.info(
                     f"✨ Signal generiert: {signal.symbol} {signal.side} @ ${signal.price:.2f} "
                     f"({signal.pct_change:+.2f}%)"

--- a/tests/unit/core/test_external_adapter_registry.py
+++ b/tests/unit/core/test_external_adapter_registry.py
@@ -1,0 +1,179 @@
+"""Unit tests for the static external adapter registry (#1579)."""
+
+import pytest
+
+from core.contracts.external_adapter_contracts import (
+    ExecutionAdapterRequest,
+    StrategyAdapterRequest,
+)
+from core.contracts.external_adapter_registry import (
+    EXECUTION_ADAPTER_ENV_VAR,
+    MEXC_BUILTIN,
+    MOCK_BUILTIN,
+    MOMENTUM_BUILTIN,
+    SIGNAL_ADAPTER_ENV_VAR,
+    BuiltinMomentumStrategyAdapter,
+    MexcExecutionAdapter,
+    MockExecutionAdapter,
+    build_execution_adapter,
+    build_strategy_adapter,
+    default_execution_adapter_id,
+    default_strategy_adapter_id,
+    list_execution_adapter_ids,
+    list_strategy_adapter_ids,
+    resolve_execution_adapter_id,
+    resolve_strategy_adapter_id,
+)
+from services.execution.mock_executor import MockExecutor
+
+
+def test_registry_exposes_fixed_adapter_env_names() -> None:
+    assert SIGNAL_ADAPTER_ENV_VAR == "SIGNAL_ADAPTER_ID"
+    assert EXECUTION_ADAPTER_ENV_VAR == "EXECUTION_ADAPTER_ID"
+
+
+def test_strategy_registry_is_static_and_defaulted_to_momentum_builtin() -> None:
+    assert list_strategy_adapter_ids() == (MOMENTUM_BUILTIN,)
+    assert default_strategy_adapter_id() == MOMENTUM_BUILTIN
+    assert resolve_strategy_adapter_id(None) == MOMENTUM_BUILTIN
+
+
+def test_execution_registry_is_static_and_defaults_follow_mock_trading() -> None:
+    assert list_execution_adapter_ids() == (MOCK_BUILTIN, MEXC_BUILTIN)
+    assert default_execution_adapter_id(mock_trading=True) == MOCK_BUILTIN
+    assert default_execution_adapter_id(mock_trading=False) == MEXC_BUILTIN
+    assert resolve_execution_adapter_id(None, mock_trading=True) == MOCK_BUILTIN
+    assert resolve_execution_adapter_id(None, mock_trading=False) == MEXC_BUILTIN
+
+
+def test_unknown_adapter_ids_fail_closed() -> None:
+    with pytest.raises(KeyError, match="Unknown strategy adapter id"):
+        resolve_strategy_adapter_id("does_not_exist")
+
+    with pytest.raises(KeyError, match="Unknown execution adapter id"):
+        resolve_execution_adapter_id("does_not_exist", mock_trading=True)
+
+
+def test_built_in_momentum_strategy_adapter_emits_buy_candidate() -> None:
+    adapter = build_strategy_adapter()
+    assert isinstance(adapter, BuiltinMomentumStrategyAdapter)
+
+    response = adapter.evaluate(
+        StrategyAdapterRequest(
+            symbol="BTCUSDT",
+            market_event={"price": 50000.0},
+            market_snapshot={"pct_change": 3.5, "volume": 200000.0},
+            runtime_context={
+                "threshold_pct": 3.0,
+                "min_volume": 100000.0,
+                "strategy_id": "paper",
+                "bot_id": "bot-1",
+            },
+        )
+    )
+
+    assert len(response.signals) == 1
+    signal = response.signals[0]
+    assert signal.strategy_id == "paper"
+    assert signal.symbol == "BTCUSDT"
+    assert signal.side == "BUY"
+    assert signal.reason == "Momentum: +3.5000% > 3.0%"
+    assert signal.pct_change == pytest.approx(3.5)
+    assert signal.metadata == {"adapter_id": MOMENTUM_BUILTIN, "bot_id": "bot-1"}
+    assert response.diagnostics == {
+        "adapter_id": MOMENTUM_BUILTIN,
+        "status": "signal_emitted",
+    }
+
+
+def test_built_in_momentum_strategy_adapter_returns_no_signal_below_threshold() -> None:
+    adapter = BuiltinMomentumStrategyAdapter()
+    response = adapter.evaluate(
+        StrategyAdapterRequest(
+            symbol="BTCUSDT",
+            market_event={},
+            market_snapshot={"pct_change": 2.0, "volume": 200000.0},
+            runtime_context={
+                "threshold_pct": 3.0,
+                "min_volume": 100000.0,
+                "strategy_id": "paper",
+            },
+        )
+    )
+
+    assert response.signals == ()
+    assert response.diagnostics == {
+        "adapter_id": MOMENTUM_BUILTIN,
+        "status": "no_signal",
+        "pct_change": 2.0,
+        "threshold_pct": 3.0,
+        "volume": 200000.0,
+        "min_volume": 100000.0,
+    }
+
+
+def test_mock_execution_adapter_wraps_current_mock_executor_path() -> None:
+    adapter = MockExecutionAdapter(
+        executor=MockExecutor(
+            success_rate=1.0,
+            min_latency_ms=0,
+            max_latency_ms=0,
+            base_slippage_pct=0.0,
+        )
+    )
+    response = adapter.execute(
+        ExecutionAdapterRequest(
+            order={
+                "symbol": "BTCUSDT",
+                "side": "BUY",
+                "quantity": 0.01,
+                "timestamp": 1700000000,
+            },
+            run_mode="paper",
+            decision_contract_v1={"contract_version": "decision_contract_v1"},
+            runtime_context={},
+        )
+    )
+
+    assert response.status == "FILLED"
+    assert response.order_id.startswith("MOCK_")
+    assert response.filled_quantity == pytest.approx(0.01)
+    assert response.raw_venue_payload == {"adapter_id": MOCK_BUILTIN}
+
+
+def test_execution_registry_can_build_mexc_adapter_without_wiring_service() -> None:
+    class DummyExecutor:
+        def execute_order(self, order):
+            class DummyResult:
+                status = "FILLED"
+                order_id = "MEXC_123"
+                filled_quantity = order.quantity
+                price = order.price
+                error_message = None
+
+            return DummyResult()
+
+    adapter = build_execution_adapter(
+        MEXC_BUILTIN, mock_trading=False, executor=DummyExecutor()
+    )
+    assert isinstance(adapter, MexcExecutionAdapter)
+
+    response = adapter.execute(
+        ExecutionAdapterRequest(
+            order={
+                "symbol": "BTCUSDT",
+                "side": "BUY",
+                "quantity": 0.02,
+                "price": 50000.0,
+                "timestamp": 1700000000,
+            },
+            run_mode="paper",
+            decision_contract_v1={"contract_version": "decision_contract_v1"},
+            runtime_context={},
+        )
+    )
+
+    assert response.status == "FILLED"
+    assert response.order_id == "MEXC_123"
+    assert response.venue_order_id == "MEXC_123"
+    assert response.filled_quantity == pytest.approx(0.02)

--- a/tests/unit/services/test_execution_shadow_gate.py
+++ b/tests/unit/services/test_execution_shadow_gate.py
@@ -103,7 +103,7 @@ def test_shadow_mode_blocks_execution(
     assert result is not None
     assert result.status == "REJECTED"
     assert "shadow mode" in result.error_message
-    execution_harness.executor.execute_order.assert_not_called()
+    execution_harness.executor.execute.assert_not_called()
     assert service.stats["shadow_blocked"] == 1
     assert service.stats["orders_rejected"] == 1
     assert "SHADOW-BLOCKED" in caplog.text
@@ -130,7 +130,7 @@ def test_paper_mode_not_blocked(
     execution_harness: _Harness,
 ) -> None:
     """Order with run_mode='paper' must NOT be blocked by shadow gate."""
-    execution_harness.executor.execute_order.return_value = MagicMock(
+    execution_harness.executor.execute.return_value = MagicMock(
         status="FILLED",
         filled_quantity=0.001,
         fill_id="f1",
@@ -143,7 +143,7 @@ def test_paper_mode_not_blocked(
     result = service.process_order(_valid_order_payload(run_mode="paper"))
 
     assert result is not None
-    execution_harness.executor.execute_order.assert_called_once()
+    execution_harness.executor.execute.assert_called_once()
     assert service.stats["shadow_blocked"] == 0
 
 
@@ -152,7 +152,7 @@ def test_none_mode_not_blocked(
     execution_harness: _Harness,
 ) -> None:
     """Order with run_mode=None (legacy) must NOT be blocked."""
-    execution_harness.executor.execute_order.return_value = MagicMock(
+    execution_harness.executor.execute.return_value = MagicMock(
         status="FILLED",
         filled_quantity=0.001,
         fill_id="f1",
@@ -165,7 +165,7 @@ def test_none_mode_not_blocked(
     result = service.process_order(_valid_order_payload())  # no run_mode
 
     assert result is not None
-    execution_harness.executor.execute_order.assert_called_once()
+    execution_harness.executor.execute.assert_called_once()
     assert service.stats["shadow_blocked"] == 0
 
 
@@ -174,7 +174,7 @@ def test_live_mode_not_blocked(
     execution_harness: _Harness,
 ) -> None:
     """Order with run_mode='live' must NOT be blocked by shadow gate."""
-    execution_harness.executor.execute_order.return_value = MagicMock(
+    execution_harness.executor.execute.return_value = MagicMock(
         status="FILLED",
         filled_quantity=0.001,
         fill_id="f1",
@@ -187,7 +187,7 @@ def test_live_mode_not_blocked(
     result = service.process_order(_valid_order_payload(run_mode="live"))
 
     assert result is not None
-    execution_harness.executor.execute_order.assert_called_once()
+    execution_harness.executor.execute.assert_called_once()
     assert service.stats["shadow_blocked"] == 0
 
 
@@ -195,7 +195,7 @@ def test_live_mode_not_blocked(
 def test_execution_result_inherits_order_decision_metadata(
     execution_harness: _Harness,
 ) -> None:
-    execution_harness.executor.execute_order.return_value = MagicMock(
+    execution_harness.executor.execute.return_value = MagicMock(
         status="FILLED",
         filled_quantity=0.001,
         fill_id="fill-1",
@@ -272,7 +272,7 @@ def test_shadow_gate_independent_of_mock_trading(
 
     assert result is not None
     assert result.status == "REJECTED"
-    execution_harness.executor.execute_order.assert_not_called()
+    execution_harness.executor.execute.assert_not_called()
     assert service.stats["shadow_blocked"] == 1
 
 
@@ -339,7 +339,7 @@ def test_kill_switch_active_blocks_execution(
     assert result is not None
     assert result.status == "REJECTED"
     assert "kill-switch" in result.error_message.lower()
-    execution_harness.executor.execute_order.assert_not_called()
+    execution_harness.executor.execute.assert_not_called()
     assert "KILL-SWITCH-BLOCKED" in caplog.text
 
 
@@ -363,7 +363,7 @@ def test_kill_switch_eval_error_fails_closed(
     assert result is not None
     assert result.status == "REJECTED"
     assert "kill-switch" in result.error_message.lower()
-    execution_harness.executor.execute_order.assert_not_called()
+    execution_harness.executor.execute.assert_not_called()
 
 
 @pytest.mark.unit
@@ -371,7 +371,7 @@ def test_kill_switch_inactive_passes(
     execution_harness: _Harness,
 ) -> None:
     """Kill-switch inactive must not block order (fixture default)."""
-    execution_harness.executor.execute_order.return_value = MagicMock(
+    execution_harness.executor.execute.return_value = MagicMock(
         status="FILLED",
         filled_quantity=0.001,
         fill_id="f1",
@@ -384,7 +384,7 @@ def test_kill_switch_inactive_passes(
     result = service.process_order(_valid_order_payload(run_mode="paper"))
 
     assert result is not None
-    execution_harness.executor.execute_order.assert_called_once()
+    execution_harness.executor.execute.assert_called_once()
 
 
 @pytest.mark.unit
@@ -392,7 +392,7 @@ def test_execution_result_propagates_fill_context(
     execution_harness: _Harness,
 ) -> None:
     """Execution result must preserve signal timing in fill_context metadata."""
-    execution_harness.executor.execute_order.return_value = MagicMock(
+    execution_harness.executor.execute.return_value = MagicMock(
         status="FILLED",
         filled_quantity=0.001,
         fill_id="f1",
@@ -436,7 +436,7 @@ def test_execution_result_keeps_missing_signal_ts_explicit(
 ) -> None:
     """Missing upstream signal_ts_ms must remain explicit null, not synthetic."""
     caplog.set_level(logging.WARNING)
-    execution_harness.executor.execute_order.return_value = MagicMock(
+    execution_harness.executor.execute.return_value = MagicMock(
         status="FILLED",
         filled_quantity=0.001,
         fill_id="f1",
@@ -465,3 +465,17 @@ def test_execution_result_keeps_missing_signal_ts_explicit(
     assert result.metadata is not None
     assert result.metadata["fill_context"]["signal_ts_ms"] is None
     assert "missing canonical signal_ts_ms" in caplog.text
+
+
+@pytest.mark.unit
+def test_init_services_fails_closed_on_unknown_execution_adapter_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EXECUTION_ADAPTER_ID", "does_not_exist")
+    monkeypatch.setattr(service, "_init_with_retry", MagicMock())
+    monkeypatch.setattr(service, "redis_client", None)
+    monkeypatch.setattr(service, "pubsub", None)
+    monkeypatch.setattr(service, "executor", None)
+    monkeypatch.setattr(service, "db", None)
+
+    assert service.init_services() is False

--- a/tests/unit/services/test_execution_shadow_gate.py
+++ b/tests/unit/services/test_execution_shadow_gate.py
@@ -468,6 +468,34 @@ def test_execution_result_keeps_missing_signal_ts_explicit(
 
 
 @pytest.mark.unit
+def test_process_order_supports_legacy_execute_order_executor(
+    execution_harness: _Harness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _LegacyExecutor:
+        def execute_order(self, order):
+            return MagicMock(
+                status="FILLED",
+                filled_quantity=order.quantity,
+                fill_id="legacy-fill-1",
+                order_id="legacy-order-1",
+                symbol=order.symbol,
+                side=order.side,
+                price=50000.0,
+                error_message=None,
+            )
+
+    monkeypatch.setattr(service, "executor", _LegacyExecutor())
+    result = service.process_order(_valid_order_payload(run_mode="paper"))
+
+    assert result is not None
+    assert result.status == "FILLED"
+    assert result.order_id == "legacy-order-1"
+    assert result.fill_id == "legacy-fill-1"
+    assert result.strategy_id == "test"
+
+
+@pytest.mark.unit
 def test_init_services_fails_closed_on_unknown_execution_adapter_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/signal/test_service.py
+++ b/tests/unit/signal/test_service.py
@@ -19,6 +19,10 @@ if str(services_path) not in sys.path:
 from service import SignalEngine
 from config import SignalConfig
 from models import MarketData, Signal
+from core.contracts.external_adapter_contracts import (
+    StrategyAdapterResponse,
+    StrategySignalCandidate,
+)
 
 
 @pytest.mark.unit
@@ -409,3 +413,62 @@ def test_primary_breakout_v1_emits_sell_even_when_entry_is_blocked():
         assert exit_signal is not None
         assert exit_signal.side == "SELL"
         assert exit_signal.reason == "channel_exit"
+
+
+@pytest.mark.unit
+def test_signal_engine_uses_registry_selected_adapter():
+    test_config = SignalConfig(
+        strategy_id="test_strategy",
+        bot_id="test_bot",
+        threshold_pct=3.0,
+        min_volume=100000.0,
+    )
+    adapter = MagicMock()
+    adapter.adapter_id = "momentum_builtin"
+    adapter.evaluate.return_value = StrategyAdapterResponse(
+        signals=(
+            StrategySignalCandidate(
+                strategy_id="test_strategy",
+                symbol="BTCUSDT",
+                side="BUY",
+                reason="Momentum: +3.5000% > 3.0%",
+                price=50000.0,
+                pct_change=3.5,
+                metadata={"adapter_id": "momentum_builtin"},
+            ),
+        )
+    )
+
+    with patch("service.config", test_config), patch(
+        "service.build_strategy_adapter", return_value=adapter
+    ):
+        engine = SignalEngine()
+        signal = engine.process_market_data(
+            {
+                "symbol": "BTCUSDT",
+                "price": 50000.0,
+                "timestamp": 1609459200,
+                "pct_change": 3.5,
+                "volume": 200000.0,
+            }
+        )
+
+    assert signal is not None
+    adapter.evaluate.assert_called_once()
+    assert signal.strategy_id == "test_strategy"
+    assert signal.metadata["adapter"] == {"adapter_id": "momentum_builtin"}
+
+
+@pytest.mark.unit
+def test_signal_engine_fails_closed_on_unknown_adapter_id(monkeypatch):
+    test_config = SignalConfig(
+        strategy_id="test_strategy",
+        threshold_pct=3.0,
+        lookback_minutes=15,
+        min_volume=100000.0,
+    )
+    monkeypatch.setenv("SIGNAL_ADAPTER_ID", "does_not_exist")
+
+    with patch("service.config", test_config):
+        with pytest.raises(KeyError, match="Unknown strategy adapter id"):
+            SignalEngine()


### PR DESCRIPTION
## Summary
- add a static in-repo adapter registry and ID contract aliases for strategy/execution selection
- wire `cdb_signal` and `cdb_execution` through the static selection boundary while keeping existing first-party behavior fail-closed
- add focused unit tests for registry behavior, signal adapter selection, and execution adapter fail-closed handling

## Scope guardrails
- no backtest/paper bridge expansion (#207/#1573)
- no plugin discovery or remote loading
- no LR/live-readiness statement changes

## Validation
- pytest -q tests/unit/core/test_external_adapter_registry.py tests/unit/signal/test_service.py tests/unit/services/test_execution_shadow_gate.py
- git diff --check origin/main..HEAD