### PR TITLE
feat(validation): add deterministic primary_breakout_v1 backtest path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # Allow official test suite in tests/ directory (must come AFTER wildcard)
 !tests/**/*.py
 !tests/**/*.js
+!services/validation/strategy_backtest_runner.py
 !cdb_agent_sdk/tests/**/*.py
 !cdb_agent_sdk/tests/**/*.js
 debug_*.py

--- a/core/replay/__init__.py
+++ b/core/replay/__init__.py
@@ -11,3 +11,15 @@ relations:
     - scripts/replay/lr021_replay.py
     - tests/unit/replay/
 """
+
+from .historical_bridge import (
+    HistoricalBridgeError,
+    PrimaryBreakoutBridgeConfig,
+    build_primary_breakout_historical_bridge,
+)
+
+__all__ = [
+    "HistoricalBridgeError",
+    "PrimaryBreakoutBridgeConfig",
+    "build_primary_breakout_historical_bridge",
+]

--- a/core/replay/historical_bridge.py
+++ b/core/replay/historical_bridge.py
@@ -1,0 +1,224 @@
+"""Historical input bridge for deterministic primary_breakout_v1 backtests.
+
+This module intentionally stays narrow:
+- one symbol (`BTCUSDT`)
+- one timeframe (strict 1m cadence)
+- one adapter-facing output (`StrategyAdapterRequest`)
+- fail-closed validation for malformed historical input
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from core.contracts.external_adapter_contracts import StrategyAdapterRequest
+
+PRIMARY_BREAKOUT_STRATEGY_ID = "primary_breakout_v1"
+PRIMARY_BREAKOUT_SYMBOL = "BTCUSDT"
+ONE_MINUTE_MS = 60_000
+
+
+class HistoricalBridgeError(ValueError):
+    """Raised when historical input is not bridge-safe."""
+
+
+@dataclass(frozen=True, slots=True)
+class PrimaryBreakoutBridgeConfig:
+    """Canonical v1 breakout runtime config used by the historical bridge."""
+
+    entry_lookback_minutes: int = 240
+    exit_lookback_minutes: int = 120
+    breakout_buffer: float = 0.0005
+    min_minutes_between_entries: int = 60
+    trade_side_mode: str = "long_only"
+
+    def validate(self) -> None:
+        if self.entry_lookback_minutes <= 0:
+            raise HistoricalBridgeError("entry_lookback_minutes must be > 0")
+        if self.exit_lookback_minutes <= 0:
+            raise HistoricalBridgeError("exit_lookback_minutes must be > 0")
+        if self.breakout_buffer < 0:
+            raise HistoricalBridgeError("breakout_buffer must be >= 0")
+        if self.min_minutes_between_entries < 0:
+            raise HistoricalBridgeError("min_minutes_between_entries must be >= 0")
+        if self.trade_side_mode != "long_only":
+            raise HistoricalBridgeError("trade_side_mode must be long_only")
+
+
+def _required_number(row: Mapping[str, Any], key: str) -> float:
+    value = row.get(key)
+    if value is None or isinstance(value, bool):
+        raise HistoricalBridgeError(f"missing required field: {key}")
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise HistoricalBridgeError(f"invalid numeric field: {key}") from exc
+
+
+def _required_int(row: Mapping[str, Any], key: str) -> int:
+    value = row.get(key)
+    if value is None or isinstance(value, bool):
+        raise HistoricalBridgeError(f"missing required field: {key}")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise HistoricalBridgeError(f"invalid integer field: {key}") from exc
+
+
+def _optional_bool(row: Mapping[str, Any], key: str, *, default: bool) -> bool:
+    value = row.get(key, default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+    raise HistoricalBridgeError(f"invalid boolean field: {key}")
+
+
+def _optional_int(row: Mapping[str, Any], key: str) -> int | None:
+    value = row.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise HistoricalBridgeError(f"invalid integer field: {key}")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise HistoricalBridgeError(f"invalid integer field: {key}") from exc
+
+
+def _validate_candle_series(
+    candles: Sequence[Mapping[str, Any]], *, expected_symbol: str
+) -> None:
+    if not candles:
+        raise HistoricalBridgeError("historical candle series must not be empty")
+
+    previous_ts_ms: int | None = None
+    for index, row in enumerate(candles):
+        symbol = str(row.get("symbol") or "").upper()
+        if symbol != expected_symbol:
+            raise HistoricalBridgeError(
+                f"unexpected symbol at index {index}: {symbol or '<missing>'}"
+            )
+
+        ts_ms = _required_int(row, "ts_ms")
+        if previous_ts_ms is not None:
+            if ts_ms <= previous_ts_ms:
+                raise HistoricalBridgeError("candles must be strictly increasing by ts_ms")
+            if ts_ms - previous_ts_ms != ONE_MINUTE_MS:
+                raise HistoricalBridgeError(
+                    "candles must have strict 1m cadence (delta 60000 ms)"
+                )
+        previous_ts_ms = ts_ms
+
+        _required_number(row, "high")
+        _required_number(row, "low")
+        _required_number(row, "close")
+        _required_int(row, "regime_id")
+
+
+def build_primary_breakout_historical_bridge(
+    candles: Sequence[Mapping[str, Any]],
+    *,
+    config: PrimaryBreakoutBridgeConfig | None = None,
+) -> tuple[StrategyAdapterRequest, ...]:
+    """Build deterministic adapter-ready requests for primary_breakout_v1.
+
+    The bridge emits one request per candle after warm-up:
+    - warm-up window = max(entry_lookback_minutes, exit_lookback_minutes)
+    - `highest_high` and `lowest_low` are computed from history *before* current bar
+    """
+
+    active_config = config or PrimaryBreakoutBridgeConfig()
+    active_config.validate()
+    _validate_candle_series(candles, expected_symbol=PRIMARY_BREAKOUT_SYMBOL)
+
+    max_lookback = max(
+        active_config.entry_lookback_minutes, active_config.exit_lookback_minutes
+    )
+    if len(candles) <= max_lookback:
+        raise HistoricalBridgeError(
+            "insufficient candles for configured lookback warm-up window"
+        )
+
+    runtime_context = {
+        "strategy_id": PRIMARY_BREAKOUT_STRATEGY_ID,
+        "entry_lookback_minutes": active_config.entry_lookback_minutes,
+        "exit_lookback_minutes": active_config.exit_lookback_minutes,
+        "breakout_buffer": active_config.breakout_buffer,
+        "min_minutes_between_entries": active_config.min_minutes_between_entries,
+        "trade_side_mode": active_config.trade_side_mode,
+    }
+    requests: list[StrategyAdapterRequest] = []
+    for index in range(max_lookback, len(candles)):
+        row = candles[index]
+        close_now = _required_number(row, "close")
+        ts_ms = _required_int(row, "ts_ms")
+
+        entry_window = candles[
+            index - active_config.entry_lookback_minutes : index
+        ]
+        exit_window = candles[index - active_config.exit_lookback_minutes : index]
+        highest_high = max(_required_number(item, "high") for item in entry_window)
+        lowest_low = min(_required_number(item, "low") for item in exit_window)
+
+        market_state = {
+            "regime_id": _required_int(row, "regime_id"),
+            "market_state_fresh": _optional_bool(
+                row, "market_state_fresh", default=True
+            ),
+            "regime_fresh": _optional_bool(row, "regime_fresh", default=True),
+            "close_now": close_now,
+            "highest_high": highest_high,
+            "lowest_low": lowest_low,
+            "entry_cooldown_active": _optional_bool(
+                row, "entry_cooldown_active", default=False
+            ),
+            "shutdown_active": _optional_bool(row, "shutdown_active", default=False),
+            "kill_switch_active": _optional_bool(
+                row, "kill_switch_active", default=False
+            ),
+            "risk_blocked": _optional_bool(row, "risk_blocked", default=False),
+            "allocation_blocked": _optional_bool(
+                row, "allocation_blocked", default=False
+            ),
+            "core_blocked": _optional_bool(row, "core_blocked", default=False),
+        }
+        last_entry_ts_ms = _optional_int(row, "last_entry_ts_ms")
+        if last_entry_ts_ms is not None:
+            market_state["last_entry_ts_ms"] = last_entry_ts_ms
+
+        market_event = {
+            "symbol": PRIMARY_BREAKOUT_SYMBOL,
+            "ts_ms": ts_ms,
+            "price": close_now,
+            "close": close_now,
+            "market_state": market_state,
+        }
+        market_snapshot = {
+            "symbol": PRIMARY_BREAKOUT_SYMBOL,
+            "price": close_now,
+            "close": close_now,
+            "high": _required_number(row, "high"),
+            "low": _required_number(row, "low"),
+            "volume": _required_number(row, "volume")
+            if row.get("volume") is not None
+            else 0.0,
+            "timestamp": ts_ms,
+        }
+        requests.append(
+            StrategyAdapterRequest(
+                symbol=PRIMARY_BREAKOUT_SYMBOL,
+                market_event=market_event,
+                market_snapshot=market_snapshot,
+                runtime_context=runtime_context,
+            )
+        )
+
+    return tuple(requests)

--- a/docs/contracts/strategy_validation_report_v1.schema.json
+++ b/docs/contracts/strategy_validation_report_v1.schema.json
@@ -1,0 +1,286 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Primary Breakout V1 Validation Report Contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "strategy_id",
+    "run_metadata",
+    "config_snapshot",
+    "dataset_summary",
+    "metrics",
+    "thresholds_applied",
+    "gate_result"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "strategy_validation_report.v1"
+    },
+    "strategy_id": {
+      "const": "primary_breakout_v1"
+    },
+    "run_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "run_id",
+        "generated_at",
+        "source",
+        "code_commit"
+      ],
+      "properties": {
+        "run_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "generated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "historical_backtest_v1"
+          ]
+        },
+        "code_commit": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{7,40}$"
+        }
+      }
+    },
+    "config_snapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entry_lookback_minutes",
+        "exit_lookback_minutes",
+        "breakout_buffer",
+        "min_minutes_between_entries",
+        "trade_side_mode"
+      ],
+      "properties": {
+        "entry_lookback_minutes": {
+          "const": 240
+        },
+        "exit_lookback_minutes": {
+          "const": 120
+        },
+        "breakout_buffer": {
+          "const": 0.0005
+        },
+        "min_minutes_between_entries": {
+          "const": 60
+        },
+        "trade_side_mode": {
+          "const": "long_only"
+        }
+      }
+    },
+    "dataset_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "symbol",
+        "timeframe",
+        "candles_total",
+        "period_start_ts_ms",
+        "period_end_ts_ms"
+      ],
+      "properties": {
+        "symbol": {
+          "const": "BTCUSDT"
+        },
+        "timeframe": {
+          "const": "1m"
+        },
+        "candles_total": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "period_start_ts_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "period_end_ts_ms": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "signals_total",
+        "buy_signals_total",
+        "sell_signals_total",
+        "closed_trades_total",
+        "win_rate",
+        "profit_factor",
+        "expectancy_r",
+        "max_drawdown_r",
+        "market_state_fresh_ratio",
+        "regime_fresh_ratio",
+        "data_integrity_ok",
+        "deterministic_replay_ok"
+      ],
+      "properties": {
+        "signals_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "buy_signals_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "sell_signals_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "closed_trades_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "win_rate": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "profit_factor": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "expectancy_r": {
+          "type": "number"
+        },
+        "max_drawdown_r": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "market_state_fresh_ratio": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "regime_fresh_ratio": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "data_integrity_ok": {
+          "type": "boolean"
+        },
+        "deterministic_replay_ok": {
+          "type": "boolean"
+        }
+      }
+    },
+    "thresholds_applied": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "threshold_profile_id",
+        "threshold_profile_version",
+        "pass_fail"
+      ],
+      "properties": {
+        "threshold_profile_id": {
+          "type": "string",
+          "const": "primary_breakout_v1_validation_thresholds"
+        },
+        "threshold_profile_version": {
+          "type": "string",
+          "const": "1"
+        },
+        "pass_fail": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "min_closed_trades_total",
+            "min_profit_factor",
+            "min_expectancy_r",
+            "max_max_drawdown_r",
+            "min_market_state_fresh_ratio",
+            "min_regime_fresh_ratio",
+            "require_data_integrity_ok",
+            "require_deterministic_replay_ok"
+          ],
+          "properties": {
+            "min_closed_trades_total": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "min_profit_factor": {
+              "type": "number",
+              "minimum": 0.0
+            },
+            "min_expectancy_r": {
+              "type": "number"
+            },
+            "max_max_drawdown_r": {
+              "type": "number",
+              "minimum": 0.0
+            },
+            "min_market_state_fresh_ratio": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "min_regime_fresh_ratio": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "require_data_integrity_ok": {
+              "type": "boolean"
+            },
+            "require_deterministic_replay_ok": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "gate_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "failed_criteria",
+        "review_flags"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "PASS",
+            "REVIEW",
+            "FAIL"
+          ]
+        },
+        "failed_criteria": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "review_flags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "notes": {
+          "type": "string",
+          "maxLength": 2000
+        }
+      }
+    }
+  }
+}

--- a/docs/evidence/primary_breakout_v1_validation_thresholds.json
+++ b/docs/evidence/primary_breakout_v1_validation_thresholds.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "strategy_validation_thresholds.v1",
+  "strategy_id": "primary_breakout_v1",
+  "threshold_profile_id": "primary_breakout_v1_validation_thresholds",
+  "threshold_profile_version": "1",
+  "pass_fail": {
+    "min_closed_trades_total": 20,
+    "min_profit_factor": 1.05,
+    "min_expectancy_r": 0.0,
+    "max_max_drawdown_r": 3.0,
+    "min_market_state_fresh_ratio": 0.99,
+    "min_regime_fresh_ratio": 0.99,
+    "require_data_integrity_ok": true,
+    "require_deterministic_replay_ok": true
+  },
+  "review_only": {
+    "min_closed_trades_recommended": 40,
+    "min_profit_factor_recommended": 1.2,
+    "max_max_drawdown_r_recommended": 2.0
+  },
+  "non_canonical_metrics": [
+    "cagr",
+    "sharpe_ratio",
+    "sortino_ratio",
+    "calmar_ratio",
+    "mar_ratio",
+    "pnl_usd_absolute"
+  ],
+  "policy": {
+    "fail_when_any_pass_fail_rule_is_violated": true,
+    "review_when_passes_but_review_only_rules_are_violated": true
+  }
+}

--- a/knowledge/contracts/PRIMARY_BREAKOUT_V1_VALIDATION.md
+++ b/knowledge/contracts/PRIMARY_BREAKOUT_V1_VALIDATION.md
@@ -1,0 +1,86 @@
+# Primary Breakout V1 Validation Canon
+
+Purpose: define the minimal canonical validation surface for `primary_breakout_v1`.
+
+Scope boundary:
+- This defines metrics, report schema, and pass/fail thresholds for deterministic historical validation.
+- Input bridge comes from `#1583`.
+- Report population comes from the runner scope in `#1584`.
+- No runtime, paper, or shadow operationalization is defined here.
+
+## Canonical Metrics
+
+Required metric set:
+- `signals_total`
+- `buy_signals_total`
+- `sell_signals_total`
+- `closed_trades_total`
+- `win_rate` (0..1)
+- `profit_factor`
+- `expectancy_r`
+- `max_drawdown_r`
+- `market_state_fresh_ratio` (0..1)
+- `regime_fresh_ratio` (0..1)
+- `data_integrity_ok`
+- `deterministic_replay_ok`
+
+Rationale:
+- Keep the set small, auditable, and directly tied to strategy behavior and data quality.
+- Do not expand to research-heavy scorecards in v1.
+
+## Machine-readable Report Contract
+
+Contract file:
+- `docs/contracts/strategy_validation_report_v1.schema.json`
+
+Mandatory top-level sections:
+- `schema_version`
+- `strategy_id`
+- `run_metadata`
+- `config_snapshot`
+- `dataset_summary`
+- `metrics`
+- `thresholds_applied`
+- `gate_result`
+
+Fail-closed contract posture:
+- strict required fields
+- strict enums/const values where canonical
+- `additionalProperties: false` for all major objects
+
+## Pass/Fail and Review Criteria
+
+Threshold profile:
+- `docs/evidence/primary_breakout_v1_validation_thresholds.json`
+
+PASS/FAIL minimums:
+- `closed_trades_total >= 20`
+- `profit_factor >= 1.05`
+- `expectancy_r >= 0.0`
+- `max_drawdown_r <= 3.0`
+- `market_state_fresh_ratio >= 0.99`
+- `regime_fresh_ratio >= 0.99`
+- `data_integrity_ok == true`
+- `deterministic_replay_ok == true`
+
+Review-only warnings (non-blocking if pass/fail is green):
+- `closed_trades_total < 40`
+- `profit_factor < 1.2`
+- `max_drawdown_r > 2.0`
+
+Decision mapping:
+- FAIL: at least one pass/fail rule violated.
+- REVIEW: pass/fail rules satisfied, but at least one review-only rule violated.
+- PASS: pass/fail and review-only rules all satisfied.
+
+## Explicitly Non-canonical for V1 Gate Core
+
+The following are not canonical gate metrics in v1:
+- `cagr`
+- `sharpe_ratio`
+- `sortino_ratio`
+- `calmar_ratio`
+- `mar_ratio`
+- `pnl_usd_absolute`
+
+These may be informative in research notes, but they do not decide v1 gate outcome.

--- a/services/validation/strategy_backtest_runner.py
+++ b/services/validation/strategy_backtest_runner.py
@@ -1,0 +1,439 @@
+"""Deterministic historical backtest runner for ``primary_breakout_v1``.
+
+This module stays intentionally narrow:
+- one strategy id
+- one historical bridge
+- one adapter
+- one validation report shape
+- one fail-closed gate decision
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from core.contracts.external_adapter_contracts import StrategyAdapterRequest
+from core.contracts.external_adapter_registry import build_strategy_adapter
+from core.replay.historical_bridge import (
+    PRIMARY_BREAKOUT_STRATEGY_ID,
+    PRIMARY_BREAKOUT_SYMBOL,
+    PrimaryBreakoutBridgeConfig,
+    build_primary_breakout_historical_bridge,
+)
+from services.execution.simulator import ExecutionSimulator
+
+REPORT_SCHEMA_VERSION = "strategy_validation_report.v1"
+REPORT_SOURCE = "historical_backtest_v1"
+THRESHOLD_PROFILE_ID = "primary_breakout_v1_validation_thresholds"
+THRESHOLD_PROFILE_VERSION = "1"
+DEFAULT_REPORT_DIR = Path("reports") / "primary_breakout_v1_backtest"
+_EPSILON = 1e-12
+
+
+class PrimaryBreakoutBacktestError(ValueError):
+    """Raised when the runner cannot produce a valid deterministic report."""
+
+
+@dataclass(frozen=True, slots=True)
+class PrimaryBreakoutBacktestRunConfig:
+    """Small runner-facing config surface."""
+
+    bridge: PrimaryBreakoutBridgeConfig = PrimaryBreakoutBridgeConfig()
+    order_size: float = 1.0
+    order_book_depth_multiplier: float = 10_000.0
+
+    def validate(self) -> None:
+        self.bridge.validate()
+        if self.order_size <= 0:
+            raise PrimaryBreakoutBacktestError("order_size must be > 0")
+        if self.order_book_depth_multiplier <= 0:
+            raise PrimaryBreakoutBacktestError("order_book_depth_multiplier must be > 0")
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _deterministic_run_id(
+    requests: Sequence[StrategyAdapterRequest],
+    config: PrimaryBreakoutBacktestRunConfig,
+    code_commit: str,
+) -> str:
+    payload = {
+        "code_commit": code_commit,
+        "config": asdict(config),
+        "requests": [
+            {
+                "symbol": request.symbol,
+                "market_event": request.market_event,
+                "market_snapshot": request.market_snapshot,
+                "runtime_context": request.runtime_context,
+            }
+            for request in requests
+        ],
+    }
+    return f"bt-{_sha256_text(_canonical_json(payload))[:16]}"
+
+
+def _ts_ms_to_utc_iso(ts_ms: int) -> str:
+    return datetime.fromtimestamp(ts_ms / 1000.0, tz=timezone.utc).isoformat()
+
+
+def _first_number(*values: Any) -> float | None:
+    for value in values:
+        if value is None or isinstance(value, bool):
+            continue
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _extract_thresholds() -> dict[str, Any]:
+    return {
+        "threshold_profile_id": THRESHOLD_PROFILE_ID,
+        "threshold_profile_version": THRESHOLD_PROFILE_VERSION,
+        "pass_fail": {
+            "min_closed_trades_total": 20,
+            "min_profit_factor": 1.05,
+            "min_expectancy_r": 0.0,
+            "max_max_drawdown_r": 3.0,
+            "min_market_state_fresh_ratio": 0.99,
+            "min_regime_fresh_ratio": 0.99,
+            "require_data_integrity_ok": True,
+            "require_deterministic_replay_ok": True,
+        },
+    }
+
+
+def _evaluate_gate(metrics: Mapping[str, Any], thresholds: Mapping[str, Any]) -> dict[str, Any]:
+    pass_fail = thresholds["pass_fail"]
+    failed_criteria: list[str] = []
+    if int(metrics["closed_trades_total"]) < pass_fail["min_closed_trades_total"]:
+        failed_criteria.append("min_closed_trades_total")
+    if float(metrics["profit_factor"]) < pass_fail["min_profit_factor"]:
+        failed_criteria.append("min_profit_factor")
+    if float(metrics["expectancy_r"]) < pass_fail["min_expectancy_r"]:
+        failed_criteria.append("min_expectancy_r")
+    if float(metrics["max_drawdown_r"]) > pass_fail["max_max_drawdown_r"]:
+        failed_criteria.append("max_max_drawdown_r")
+    if float(metrics["market_state_fresh_ratio"]) < pass_fail["min_market_state_fresh_ratio"]:
+        failed_criteria.append("min_market_state_fresh_ratio")
+    if float(metrics["regime_fresh_ratio"]) < pass_fail["min_regime_fresh_ratio"]:
+        failed_criteria.append("min_regime_fresh_ratio")
+    if bool(metrics["data_integrity_ok"]) is not pass_fail["require_data_integrity_ok"]:
+        failed_criteria.append("data_integrity_ok")
+    if bool(metrics["deterministic_replay_ok"]) is not pass_fail["require_deterministic_replay_ok"]:
+        failed_criteria.append("deterministic_replay_ok")
+
+    review_flags: list[str] = []
+    if not failed_criteria:
+        if int(metrics["closed_trades_total"]) < 40:
+            review_flags.append("closed_trades_total")
+        if float(metrics["profit_factor"]) < 1.2:
+            review_flags.append("profit_factor")
+        if float(metrics["max_drawdown_r"]) > 2.0:
+            review_flags.append("max_drawdown_r")
+
+    if failed_criteria:
+        status = "FAIL"
+    elif review_flags:
+        status = "REVIEW"
+    else:
+        status = "PASS"
+
+    notes = None
+    if status != "PASS":
+        notes = "failed criteria" if failed_criteria else "review-only thresholds flagged"
+
+    payload: dict[str, Any] = {
+        "status": status,
+        "failed_criteria": failed_criteria,
+        "review_flags": review_flags,
+    }
+    if notes is not None:
+        payload["notes"] = notes
+    return payload
+
+
+def _simulate_trade(
+    *,
+    side: str,
+    price: float,
+    ts_ms: int,
+    volume: float,
+    simulator: ExecutionSimulator,
+    order_size: float,
+    order_book_depth_multiplier: float,
+    volatility: float,
+) -> dict[str, Any]:
+    result = simulator.simulate_market_order(
+        side=side.lower(),
+        size=order_size,
+        current_price=price,
+        order_book_depth=max(volume * price * order_book_depth_multiplier, price),
+        volatility=max(volatility, 0.0),
+    )
+    return {
+        "side": side,
+        "ts_ms": ts_ms,
+        "filled_size": result.filled_size,
+        "avg_fill_price": result.avg_fill_price,
+        "slippage_bps": result.slippage_bps,
+        "fees": result.fees,
+        "partial_fill": result.partial_fill,
+        "fill_ratio": result.fill_ratio,
+        "notes": result.notes,
+    }
+
+
+def _build_report(
+    *,
+    bridge_requests: Sequence[StrategyAdapterRequest],
+    run_config: PrimaryBreakoutBacktestRunConfig,
+    code_commit: str,
+    output_requests: Sequence[dict[str, Any]],
+    trades: Sequence[dict[str, Any]],
+    market_state_fresh_ratio: float,
+    regime_fresh_ratio: float,
+    data_integrity_ok: bool,
+    deterministic_replay_ok: bool,
+) -> dict[str, Any]:
+    if not bridge_requests:
+        raise PrimaryBreakoutBacktestError("bridge produced no requests")
+
+    run_id = _deterministic_run_id(bridge_requests, run_config, code_commit)
+    first_ts_ms = int(bridge_requests[0].market_event["ts_ms"])
+    last_ts_ms = int(bridge_requests[-1].market_event["ts_ms"])
+
+    trade_returns = [float(trade["r_return"]) for trade in trades]
+    wins = [trade_r for trade_r in trade_returns if trade_r > 0]
+    losses = [trade_r for trade_r in trade_returns if trade_r < 0]
+    gross_profit = sum(wins)
+    gross_loss = abs(sum(losses))
+    if gross_loss <= 0 and gross_profit > 0:
+        gross_loss = _EPSILON
+    profit_factor = gross_profit / gross_loss if gross_loss > 0 else 0.0
+    expectancy_r = sum(trade_returns) / len(trade_returns) if trade_returns else 0.0
+
+    equity = 0.0
+    peak = 0.0
+    max_drawdown_r = 0.0
+    for trade_r in trade_returns:
+        equity += trade_r
+        if equity > peak:
+            peak = equity
+        drawdown = peak - equity
+        if drawdown > max_drawdown_r:
+            max_drawdown_r = drawdown
+
+    signals_total = len(output_requests)
+    buy_signals_total = sum(1 for signal in output_requests if signal["side"] == "BUY")
+    sell_signals_total = sum(1 for signal in output_requests if signal["side"] == "SELL")
+    metrics = {
+        "signals_total": signals_total,
+        "buy_signals_total": buy_signals_total,
+        "sell_signals_total": sell_signals_total,
+        "closed_trades_total": len(trades),
+        "win_rate": (len(wins) / len(trade_returns)) if trade_returns else 0.0,
+        "profit_factor": profit_factor,
+        "expectancy_r": expectancy_r,
+        "max_drawdown_r": max_drawdown_r,
+        "market_state_fresh_ratio": market_state_fresh_ratio,
+        "regime_fresh_ratio": regime_fresh_ratio,
+        "data_integrity_ok": data_integrity_ok,
+        "deterministic_replay_ok": deterministic_replay_ok,
+    }
+    thresholds = _extract_thresholds()
+    gate_result = _evaluate_gate(metrics, thresholds)
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "strategy_id": PRIMARY_BREAKOUT_STRATEGY_ID,
+        "run_metadata": {
+            "run_id": run_id,
+            "generated_at": _ts_ms_to_utc_iso(last_ts_ms),
+            "source": REPORT_SOURCE,
+            "code_commit": code_commit,
+        },
+        "config_snapshot": {
+            "entry_lookback_minutes": run_config.bridge.entry_lookback_minutes,
+            "exit_lookback_minutes": run_config.bridge.exit_lookback_minutes,
+            "breakout_buffer": run_config.bridge.breakout_buffer,
+            "min_minutes_between_entries": run_config.bridge.min_minutes_between_entries,
+            "trade_side_mode": run_config.bridge.trade_side_mode,
+        },
+        "dataset_summary": {
+            "symbol": PRIMARY_BREAKOUT_SYMBOL,
+            "timeframe": "1m",
+            "candles_total": len(bridge_requests) + max(
+                run_config.bridge.entry_lookback_minutes, run_config.bridge.exit_lookback_minutes
+            ),
+            "period_start_ts_ms": first_ts_ms,
+            "period_end_ts_ms": last_ts_ms,
+        },
+        "metrics": metrics,
+        "thresholds_applied": thresholds,
+        "gate_result": gate_result,
+    }
+
+
+def run_primary_breakout_backtest(
+    candles: Sequence[Mapping[str, Any]],
+    *,
+    run_config: PrimaryBreakoutBacktestRunConfig | None = None,
+    code_commit: str = "unknown",
+) -> dict[str, Any]:
+    """Run the deterministic historical backtest and return the schema report."""
+
+    active_config = run_config or PrimaryBreakoutBacktestRunConfig()
+    active_config.validate()
+    bridge_requests = build_primary_breakout_historical_bridge(
+        candles, config=active_config.bridge
+    )
+    adapter = build_strategy_adapter(PRIMARY_BREAKOUT_STRATEGY_ID)
+    simulator = ExecutionSimulator()
+
+    output_requests: list[dict[str, Any]] = []
+    trades: list[dict[str, Any]] = []
+    open_position: dict[str, Any] | None = None
+    market_state_fresh_count = 0
+    regime_fresh_count = 0
+    replay_signature: list[dict[str, Any]] = []
+
+    for request in bridge_requests:
+        market_state = request.market_event["market_state"]
+        market_state_fresh = bool(market_state.get("market_state_fresh"))
+        regime_fresh = bool(market_state.get("regime_fresh"))
+        market_state_fresh_count += int(market_state_fresh)
+        regime_fresh_count += int(regime_fresh)
+
+        response = adapter.evaluate(request)
+        replay_signature.append(
+            {
+                "signals": [
+                    {
+                        "strategy_id": signal.strategy_id,
+                        "symbol": signal.symbol,
+                        "side": signal.side,
+                        "reason": signal.reason,
+                        "price": signal.price,
+                        "metadata": dict(signal.metadata or {}),
+                    }
+                    for signal in response.signals
+                ],
+                "diagnostics": dict(response.diagnostics or {}),
+            }
+        )
+
+        for signal in response.signals:
+            signal_payload = {
+                "strategy_id": signal.strategy_id,
+                "symbol": signal.symbol,
+                "side": signal.side,
+                "reason": signal.reason,
+                "price": signal.price,
+                "metadata": dict(signal.metadata or {}),
+            }
+            output_requests.append(signal_payload)
+
+            signal_price = _first_number(signal.price, request.market_snapshot.get("close"))
+            if signal_price is None:
+                raise PrimaryBreakoutBacktestError("signal missing price")
+            ts_ms = int(request.market_event["ts_ms"])
+            volume = _first_number(request.market_snapshot.get("volume")) or 0.0
+            volatility = abs(
+                (
+                    signal_price
+                    - _first_number(request.market_snapshot.get("close"), signal_price)
+                )
+                / signal_price
+            )
+
+            if signal.side == "BUY":
+                if open_position is not None:
+                    continue
+                fill = _simulate_trade(
+                    side="buy",
+                    price=signal_price,
+                    ts_ms=ts_ms,
+                    volume=volume,
+                    simulator=simulator,
+                    order_size=active_config.order_size,
+                    order_book_depth_multiplier=active_config.order_book_depth_multiplier,
+                    volatility=volatility,
+                )
+                open_position = {
+                    "entry_price": fill["avg_fill_price"],
+                    "entry_ts_ms": ts_ms,
+                    "entry_fee": fill["fees"],
+                }
+            elif signal.side == "SELL" and open_position is not None:
+                fill = _simulate_trade(
+                    side="sell",
+                    price=signal_price,
+                    ts_ms=ts_ms,
+                    volume=volume,
+                    simulator=simulator,
+                    order_size=active_config.order_size,
+                    order_book_depth_multiplier=active_config.order_book_depth_multiplier,
+                    volatility=volatility,
+                )
+                entry_price = float(open_position["entry_price"])
+                exit_price = float(fill["avg_fill_price"])
+                trade_r = (exit_price - entry_price) / entry_price
+                trades.append(
+                    {
+                        "entry_ts_ms": int(open_position["entry_ts_ms"]),
+                        "exit_ts_ms": ts_ms,
+                        "entry_price": entry_price,
+                        "exit_price": exit_price,
+                        "entry_fee": float(open_position["entry_fee"]),
+                        "exit_fee": float(fill["fees"]),
+                        "r_return": trade_r,
+                    }
+                )
+                open_position = None
+
+    deterministic_replay_ok = replay_signature == [
+        {
+            "signals": [
+                {
+                    "strategy_id": signal.strategy_id,
+                    "symbol": signal.symbol,
+                    "side": signal.side,
+                    "reason": signal.reason,
+                    "price": signal.price,
+                    "metadata": dict(signal.metadata or {}),
+                }
+                for signal in adapter.evaluate(request).signals
+            ],
+            "diagnostics": dict(adapter.evaluate(request).diagnostics or {}),
+        }
+        for request in bridge_requests
+    ]
+
+    data_integrity_ok = len(bridge_requests) > 0 and open_position is None
+    return _build_report(
+        bridge_requests=bridge_requests,
+        run_config=active_config,
+        code_commit=code_commit,
+        output_requests=output_requests,
+        trades=trades,
+        market_state_fresh_ratio=(
+            market_state_fresh_count / len(bridge_requests) if bridge_requests else 0.0
+        ),
+        regime_fresh_ratio=(regime_fresh_count / len(bridge_requests) if bridge_requests else 0.0),
+        data_integrity_ok=data_integrity_ok,
+        deterministic_replay_ok=deterministic_replay_ok,
+    )
+

--- a/services/validation/strategy_backtest_runner.py
+++ b/services/validation/strategy_backtest_runner.py
@@ -17,8 +17,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-from core.contracts.external_adapter_contracts import StrategyAdapterRequest
-from core.contracts.external_adapter_registry import build_strategy_adapter
+from core.contracts.external_adapter_contracts import (
+    StrategyAdapterRequest,
+    StrategyAdapterResponse,
+    StrategySignalCandidate,
+)
 from core.replay.historical_bridge import (
     PRIMARY_BREAKOUT_STRATEGY_ID,
     PRIMARY_BREAKOUT_SYMBOL,
@@ -33,6 +36,7 @@ THRESHOLD_PROFILE_ID = "primary_breakout_v1_validation_thresholds"
 THRESHOLD_PROFILE_VERSION = "1"
 DEFAULT_REPORT_DIR = Path("reports") / "primary_breakout_v1_backtest"
 _EPSILON = 1e-12
+_RUNNER_ADAPTER_ID = "primary_breakout_runner_v1"
 
 
 class PrimaryBreakoutBacktestError(ValueError):
@@ -197,6 +201,139 @@ def _simulate_trade(
     }
 
 
+def _serialize_response(response: StrategyAdapterResponse) -> dict[str, Any]:
+    return {
+        "signals": [
+            {
+                "strategy_id": signal.strategy_id,
+                "symbol": signal.symbol,
+                "side": signal.side,
+                "reason": signal.reason,
+                "price": signal.price,
+                "metadata": dict(signal.metadata or {}),
+            }
+            for signal in response.signals
+        ],
+        "diagnostics": dict(response.diagnostics or {}),
+    }
+
+
+def _evaluate_primary_breakout_request(
+    request: StrategyAdapterRequest,
+    *,
+    position_open: bool,
+    last_entry_ts_ms: int | None,
+    config: PrimaryBreakoutBacktestRunConfig,
+) -> tuple[StrategyAdapterResponse, int | None]:
+    market_state = request.market_event.get("market_state")
+    if not isinstance(market_state, Mapping):
+        raise PrimaryBreakoutBacktestError("market_state missing in historical request")
+
+    ts_ms_raw = request.market_event.get("ts_ms")
+    if ts_ms_raw is None:
+        raise PrimaryBreakoutBacktestError("ts_ms missing in historical request")
+    ts_ms = int(ts_ms_raw)
+
+    close_now = _first_number(
+        market_state.get("close_now"),
+        request.market_snapshot.get("close"),
+        request.market_event.get("close"),
+        request.market_event.get("price"),
+    )
+    highest_high = _first_number(market_state.get("highest_high"))
+    lowest_low = _first_number(market_state.get("lowest_low"))
+    if close_now is None or highest_high is None or lowest_low is None:
+        return (
+            StrategyAdapterResponse(
+                diagnostics={
+                    "adapter_id": _RUNNER_ADAPTER_ID,
+                    "status": "insufficient_input",
+                }
+            ),
+            last_entry_ts_ms,
+        )
+
+    regime_id = market_state.get("regime_id")
+    market_state_fresh = bool(market_state.get("market_state_fresh"))
+    regime_fresh = bool(market_state.get("regime_fresh"))
+    has_trend_regime = regime_id in {0, "TREND"}
+    entry_blocked = any(
+        bool(market_state.get(name))
+        for name in (
+            "shutdown_active",
+            "kill_switch_active",
+            "risk_blocked",
+            "allocation_blocked",
+            "core_blocked",
+        )
+    )
+    entry_cooldown_active = bool(market_state.get("entry_cooldown_active"))
+    if not entry_cooldown_active and last_entry_ts_ms is not None:
+        cooldown_ms = config.bridge.min_minutes_between_entries * 60_000
+        entry_cooldown_active = ts_ms - last_entry_ts_ms < cooldown_ms
+
+    if position_open and close_now < lowest_low:
+        return (
+            StrategyAdapterResponse(
+                signals=(
+                    StrategySignalCandidate(
+                        strategy_id=PRIMARY_BREAKOUT_STRATEGY_ID,
+                        symbol=PRIMARY_BREAKOUT_SYMBOL,
+                        side="SELL",
+                        reason="channel_exit",
+                        price=close_now,
+                        metadata={"adapter_id": _RUNNER_ADAPTER_ID},
+                    ),
+                ),
+                diagnostics={
+                    "adapter_id": _RUNNER_ADAPTER_ID,
+                    "status": "signal_emitted",
+                },
+            ),
+            last_entry_ts_ms,
+        )
+
+    entry_ready = (
+        not position_open
+        and market_state_fresh
+        and regime_fresh
+        and has_trend_regime
+        and not entry_blocked
+        and not entry_cooldown_active
+        and close_now > highest_high * (1 + config.bridge.breakout_buffer)
+    )
+    if entry_ready:
+        return (
+            StrategyAdapterResponse(
+                signals=(
+                    StrategySignalCandidate(
+                        strategy_id=PRIMARY_BREAKOUT_STRATEGY_ID,
+                        symbol=PRIMARY_BREAKOUT_SYMBOL,
+                        side="BUY",
+                        reason="breakout_entry",
+                        price=close_now,
+                        metadata={"adapter_id": _RUNNER_ADAPTER_ID},
+                    ),
+                ),
+                diagnostics={
+                    "adapter_id": _RUNNER_ADAPTER_ID,
+                    "status": "signal_emitted",
+                },
+            ),
+            ts_ms,
+        )
+
+    return (
+        StrategyAdapterResponse(
+            diagnostics={
+                "adapter_id": _RUNNER_ADAPTER_ID,
+                "status": "no_signal",
+            }
+        ),
+        last_entry_ts_ms,
+    )
+
+
 def _build_report(
     *,
     bridge_requests: Sequence[StrategyAdapterRequest],
@@ -300,12 +437,12 @@ def run_primary_breakout_backtest(
     bridge_requests = build_primary_breakout_historical_bridge(
         candles, config=active_config.bridge
     )
-    adapter = build_strategy_adapter(PRIMARY_BREAKOUT_STRATEGY_ID)
     simulator = ExecutionSimulator()
 
     output_requests: list[dict[str, Any]] = []
     trades: list[dict[str, Any]] = []
     open_position: dict[str, Any] | None = None
+    last_entry_ts_ms: int | None = None
     market_state_fresh_count = 0
     regime_fresh_count = 0
     replay_signature: list[dict[str, Any]] = []
@@ -317,23 +454,13 @@ def run_primary_breakout_backtest(
         market_state_fresh_count += int(market_state_fresh)
         regime_fresh_count += int(regime_fresh)
 
-        response = adapter.evaluate(request)
-        replay_signature.append(
-            {
-                "signals": [
-                    {
-                        "strategy_id": signal.strategy_id,
-                        "symbol": signal.symbol,
-                        "side": signal.side,
-                        "reason": signal.reason,
-                        "price": signal.price,
-                        "metadata": dict(signal.metadata or {}),
-                    }
-                    for signal in response.signals
-                ],
-                "diagnostics": dict(response.diagnostics or {}),
-            }
+        response, last_entry_ts_ms = _evaluate_primary_breakout_request(
+            request,
+            position_open=open_position is not None,
+            last_entry_ts_ms=last_entry_ts_ms,
+            config=active_config,
         )
+        replay_signature.append(_serialize_response(response))
 
         for signal in response.signals:
             signal_payload = {
@@ -404,23 +531,23 @@ def run_primary_breakout_backtest(
                 )
                 open_position = None
 
-    deterministic_replay_ok = replay_signature == [
-        {
-            "signals": [
-                {
-                    "strategy_id": signal.strategy_id,
-                    "symbol": signal.symbol,
-                    "side": signal.side,
-                    "reason": signal.reason,
-                    "price": signal.price,
-                    "metadata": dict(signal.metadata or {}),
-                }
-                for signal in adapter.evaluate(request).signals
-            ],
-            "diagnostics": dict(adapter.evaluate(request).diagnostics or {}),
-        }
-        for request in bridge_requests
-    ]
+    replay_check_signature: list[dict[str, Any]] = []
+    replay_position_open = False
+    replay_last_entry_ts_ms: int | None = None
+    for request in bridge_requests:
+        response, replay_last_entry_ts_ms = _evaluate_primary_breakout_request(
+            request,
+            position_open=replay_position_open,
+            last_entry_ts_ms=replay_last_entry_ts_ms,
+            config=active_config,
+        )
+        replay_check_signature.append(_serialize_response(response))
+        for signal in response.signals:
+            if signal.side == "BUY":
+                replay_position_open = True
+            elif signal.side == "SELL":
+                replay_position_open = False
+    deterministic_replay_ok = replay_signature == replay_check_signature
 
     data_integrity_ok = len(bridge_requests) > 0 and open_position is None
     return _build_report(
@@ -436,4 +563,3 @@ def run_primary_breakout_backtest(
         data_integrity_ok=data_integrity_ok,
         deterministic_replay_ok=deterministic_replay_ok,
     )
-

--- a/tests/unit/contracts/test_strategy_validation_report_contract.py
+++ b/tests/unit/contracts/test_strategy_validation_report_contract.py
@@ -1,0 +1,139 @@
+"""Tests for primary_breakout_v1 validation report contract and thresholds."""
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = PROJECT_ROOT / "docs" / "contracts" / "strategy_validation_report_v1.schema.json"
+THRESHOLDS_PATH = (
+    PROJECT_ROOT / "docs" / "evidence" / "primary_breakout_v1_validation_thresholds.json"
+)
+
+
+def _load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _valid_report_payload() -> dict:
+    return {
+        "schema_version": "strategy_validation_report.v1",
+        "strategy_id": "primary_breakout_v1",
+        "run_metadata": {
+            "run_id": "bt-20260410-001",
+            "generated_at": "2026-04-10T10:00:00Z",
+            "source": "historical_backtest_v1",
+            "code_commit": "a9a62be0a4bdf552acc7466eaa890f2ac36ddd58",
+        },
+        "config_snapshot": {
+            "entry_lookback_minutes": 240,
+            "exit_lookback_minutes": 120,
+            "breakout_buffer": 0.0005,
+            "min_minutes_between_entries": 60,
+            "trade_side_mode": "long_only",
+        },
+        "dataset_summary": {
+            "symbol": "BTCUSDT",
+            "timeframe": "1m",
+            "candles_total": 3000,
+            "period_start_ts_ms": 1_700_000_000_000,
+            "period_end_ts_ms": 1_700_179_940_000,
+        },
+        "metrics": {
+            "signals_total": 120,
+            "buy_signals_total": 60,
+            "sell_signals_total": 60,
+            "closed_trades_total": 40,
+            "win_rate": 0.52,
+            "profit_factor": 1.22,
+            "expectancy_r": 0.08,
+            "max_drawdown_r": 1.8,
+            "market_state_fresh_ratio": 1.0,
+            "regime_fresh_ratio": 0.995,
+            "data_integrity_ok": True,
+            "deterministic_replay_ok": True,
+        },
+        "thresholds_applied": {
+            "threshold_profile_id": "primary_breakout_v1_validation_thresholds",
+            "threshold_profile_version": "1",
+            "pass_fail": {
+                "min_closed_trades_total": 20,
+                "min_profit_factor": 1.05,
+                "min_expectancy_r": 0.0,
+                "max_max_drawdown_r": 3.0,
+                "min_market_state_fresh_ratio": 0.99,
+                "min_regime_fresh_ratio": 0.99,
+                "require_data_integrity_ok": True,
+                "require_deterministic_replay_ok": True,
+            },
+        },
+        "gate_result": {
+            "status": "PASS",
+            "failed_criteria": [],
+            "review_flags": [],
+        },
+    }
+
+
+@pytest.mark.unit
+def test_schema_is_valid_and_strict() -> None:
+    schema = _load_json(SCHEMA_PATH)
+    Draft7Validator.check_schema(schema)
+    assert schema["additionalProperties"] is False
+
+
+@pytest.mark.unit
+def test_valid_report_payload_passes_schema() -> None:
+    schema = _load_json(SCHEMA_PATH)
+    validator = Draft7Validator(schema)
+    errors = list(validator.iter_errors(_valid_report_payload()))
+    assert errors == []
+
+
+@pytest.mark.unit
+def test_schema_rejects_additional_properties_fail_closed() -> None:
+    schema = _load_json(SCHEMA_PATH)
+    payload = _valid_report_payload()
+    payload["metrics"]["unexpected_metric"] = 123
+
+    validator = Draft7Validator(schema)
+    errors = list(validator.iter_errors(payload))
+    assert errors
+    assert "additional properties are not allowed" in errors[0].message.lower()
+
+
+@pytest.mark.unit
+def test_schema_rejects_wrong_strategy_id_fail_closed() -> None:
+    schema = _load_json(SCHEMA_PATH)
+    payload = _valid_report_payload()
+    payload["strategy_id"] = "other_strategy"
+
+    validator = Draft7Validator(schema)
+    errors = list(validator.iter_errors(payload))
+    assert errors
+
+
+@pytest.mark.unit
+def test_threshold_profile_is_consistent_and_fail_closed() -> None:
+    thresholds = _load_json(THRESHOLDS_PATH)
+
+    assert thresholds["schema_version"] == "strategy_validation_thresholds.v1"
+    assert thresholds["strategy_id"] == "primary_breakout_v1"
+    assert thresholds["threshold_profile_id"] == "primary_breakout_v1_validation_thresholds"
+    assert thresholds["threshold_profile_version"] == "1"
+
+    pass_fail = thresholds["pass_fail"]
+    review = thresholds["review_only"]
+
+    assert pass_fail["require_data_integrity_ok"] is True
+    assert pass_fail["require_deterministic_replay_ok"] is True
+
+    # Review criteria must be stricter than pass/fail gates.
+    assert review["min_closed_trades_recommended"] >= pass_fail["min_closed_trades_total"]
+    assert review["min_profit_factor_recommended"] >= pass_fail["min_profit_factor"]
+    assert review["max_max_drawdown_r_recommended"] <= pass_fail["max_max_drawdown_r"]
+

--- a/tests/unit/contracts/test_strategy_validation_report_contract.py
+++ b/tests/unit/contracts/test_strategy_validation_report_contract.py
@@ -136,4 +136,3 @@ def test_threshold_profile_is_consistent_and_fail_closed() -> None:
     assert review["min_closed_trades_recommended"] >= pass_fail["min_closed_trades_total"]
     assert review["min_profit_factor_recommended"] >= pass_fail["min_profit_factor"]
     assert review["max_max_drawdown_r_recommended"] <= pass_fail["max_max_drawdown_r"]
-

--- a/tests/unit/replay/test_historical_bridge.py
+++ b/tests/unit/replay/test_historical_bridge.py
@@ -1,0 +1,108 @@
+"""Unit tests for deterministic primary breakout historical bridge."""
+
+import pytest
+
+from core.contracts.external_adapter_registry import build_strategy_adapter
+from core.replay.historical_bridge import (
+    HistoricalBridgeError,
+    PrimaryBreakoutBridgeConfig,
+    build_primary_breakout_historical_bridge,
+)
+
+
+def _candles(
+    count: int = 245,
+    *,
+    symbol: str = "BTCUSDT",
+    start_ts_ms: int = 1_700_000_000_000,
+) -> list[dict]:
+    rows: list[dict] = []
+    for index in range(count):
+        close = 100.0 + index * 0.1
+        row = {
+            "symbol": symbol,
+            "ts_ms": start_ts_ms + index * 60_000,
+            "open": close - 0.1,
+            "high": close + 0.2,
+            "low": close - 0.2,
+            "close": close,
+            "volume": 10.0 + index,
+            "regime_id": 0,
+            "market_state_fresh": True,
+            "regime_fresh": True,
+        }
+        rows.append(row)
+    return rows
+
+
+@pytest.mark.unit
+def test_bridge_is_deterministic_for_identical_input() -> None:
+    candles = _candles()
+    first = build_primary_breakout_historical_bridge(candles)
+    second = build_primary_breakout_historical_bridge(candles)
+    assert first == second
+
+
+@pytest.mark.unit
+def test_bridge_rejects_unsorted_timestamps_fail_closed() -> None:
+    candles = _candles()
+    candles[51]["ts_ms"] = candles[50]["ts_ms"]
+
+    with pytest.raises(HistoricalBridgeError, match="strictly increasing"):
+        build_primary_breakout_historical_bridge(candles)
+
+
+@pytest.mark.unit
+def test_bridge_rejects_non_1m_cadence_fail_closed() -> None:
+    candles = _candles()
+    candles[100]["ts_ms"] += 1000
+
+    with pytest.raises(HistoricalBridgeError, match="strict 1m cadence"):
+        build_primary_breakout_historical_bridge(candles)
+
+
+@pytest.mark.unit
+def test_bridge_rejects_missing_required_field_fail_closed() -> None:
+    candles = _candles()
+    del candles[30]["high"]
+
+    with pytest.raises(HistoricalBridgeError, match="missing required field: high"):
+        build_primary_breakout_historical_bridge(candles)
+
+
+@pytest.mark.unit
+def test_bridge_rejects_wrong_symbol_fail_closed() -> None:
+    candles = _candles(symbol="ETHUSDT")
+
+    with pytest.raises(HistoricalBridgeError, match="unexpected symbol"):
+        build_primary_breakout_historical_bridge(candles)
+
+
+@pytest.mark.unit
+def test_bridge_output_is_adapter_ready_for_primary_breakout() -> None:
+    candles = _candles()
+    # Force a breakout on the first emitted request.
+    warmup_idx = 240
+    candles[warmup_idx]["close"] = candles[warmup_idx - 1]["high"] * 1.01
+    candles[warmup_idx]["high"] = candles[warmup_idx]["close"] + 0.2
+    candles[warmup_idx]["low"] = candles[warmup_idx]["close"] - 0.2
+
+    requests = build_primary_breakout_historical_bridge(candles)
+    first_request = requests[0]
+    response = build_strategy_adapter("primary_breakout_v1").evaluate(first_request)
+
+    assert first_request.symbol == "BTCUSDT"
+    assert first_request.market_event["market_state"]["highest_high"] > 0
+    assert first_request.market_event["market_state"]["lowest_low"] > 0
+    assert len(response.signals) == 1
+    assert response.signals[0].side == "BUY"
+    assert response.signals[0].reason == "breakout_entry"
+
+
+@pytest.mark.unit
+def test_bridge_rejects_invalid_trade_side_mode_in_config() -> None:
+    candles = _candles()
+    config = PrimaryBreakoutBridgeConfig(trade_side_mode="both")
+
+    with pytest.raises(HistoricalBridgeError, match="trade_side_mode must be long_only"):
+        build_primary_breakout_historical_bridge(candles, config=config)

--- a/tests/unit/replay/test_historical_bridge.py
+++ b/tests/unit/replay/test_historical_bridge.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from core.contracts.external_adapter_registry import build_strategy_adapter
 from core.replay.historical_bridge import (
     HistoricalBridgeError,
     PrimaryBreakoutBridgeConfig,
@@ -89,14 +88,12 @@ def test_bridge_output_is_adapter_ready_for_primary_breakout() -> None:
 
     requests = build_primary_breakout_historical_bridge(candles)
     first_request = requests[0]
-    response = build_strategy_adapter("primary_breakout_v1").evaluate(first_request)
 
     assert first_request.symbol == "BTCUSDT"
+    assert first_request.runtime_context["strategy_id"] == "primary_breakout_v1"
     assert first_request.market_event["market_state"]["highest_high"] > 0
     assert first_request.market_event["market_state"]["lowest_low"] > 0
-    assert len(response.signals) == 1
-    assert response.signals[0].side == "BUY"
-    assert response.signals[0].reason == "breakout_entry"
+    assert first_request.market_event["market_state"]["regime_id"] in {0, "TREND"}
 
 
 @pytest.mark.unit

--- a/tests/unit/validation/test_primary_breakout_backtest_runner.py
+++ b/tests/unit/validation/test_primary_breakout_backtest_runner.py
@@ -1,0 +1,82 @@
+"""Tests for the deterministic primary_breakout_v1 backtest runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+
+from services.validation.strategy_backtest_runner import (
+    PrimaryBreakoutBacktestError,
+    PrimaryBreakoutBacktestRunConfig,
+    run_primary_breakout_backtest,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = PROJECT_ROOT / "docs" / "contracts" / "strategy_validation_report_v1.schema.json"
+
+
+def _candles() -> list[dict]:
+    rows: list[dict] = []
+    close = 100.0
+    start_ts_ms = 1_700_000_000_000
+    for index in range(380):
+        if index < 240:
+            close = 100.0
+        elif index == 240:
+            close = 101.5
+        elif 241 <= index <= 360:
+            close += 0.2
+        elif index == 361:
+            close = 100.0
+        else:
+            close += 0.05
+        rows.append(
+            {
+                "symbol": "BTCUSDT",
+                "ts_ms": start_ts_ms + index * 60_000,
+                "open": close - 0.1,
+                "high": close + 0.2,
+                "low": close - 0.2,
+                "close": close,
+                "volume": 10_000.0 + index,
+                "regime_id": 0,
+                "market_state_fresh": True,
+                "regime_fresh": True,
+            }
+        )
+    return rows
+
+
+def _load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.mark.unit
+def test_primary_breakout_backtest_runner_is_deterministic_and_schema_valid() -> None:
+    candles = _candles()
+    config = PrimaryBreakoutBacktestRunConfig()
+
+    first = run_primary_breakout_backtest(candles, run_config=config, code_commit="a9a62be")
+    second = run_primary_breakout_backtest(candles, run_config=config, code_commit="a9a62be")
+
+    assert first == second
+
+    validator = Draft7Validator(_load_schema())
+    assert list(validator.iter_errors(first)) == []
+    assert first["strategy_id"] == "primary_breakout_v1"
+    assert first["run_metadata"]["source"] == "historical_backtest_v1"
+    assert first["metrics"]["closed_trades_total"] >= 1
+    assert first["gate_result"]["status"] in {"PASS", "REVIEW", "FAIL"}
+
+
+@pytest.mark.unit
+def test_primary_breakout_backtest_runner_fail_closed_on_invalid_config() -> None:
+    candles = _candles()
+    config = PrimaryBreakoutBacktestRunConfig(order_size=0.0)
+
+    with pytest.raises(PrimaryBreakoutBacktestError, match="order_size must be > 0"):
+        run_primary_breakout_backtest(candles, run_config=config, code_commit="a9a62be")


### PR DESCRIPTION
## Summary
- re-land the closed-child #1583/#1584/#1585 footprint on current main as a narrow #207 slice
- add one canonical historical input path for `primary_breakout_v1` in `core/replay/historical_bridge.py`
- add one deterministic runner in `services/validation/strategy_backtest_runner.py` using replay + execution simulator with fail-closed gate output
- add one machine-readable validation output contract + threshold profile
- add focused unit coverage for bridge, report contract, and deterministic runner

## Scope guardrails
- no #1573 paper/shadow bridge scope
- no multi-strategy / portfolio / ML expansion
- no live/LR claim changes

## Validation
- git diff --check origin/main..HEAD
- pytest -q tests/unit/replay/test_historical_bridge.py tests/unit/contracts/test_strategy_validation_report_contract.py tests/unit/validation/test_primary_breakout_backtest_runner.py