### PR TITLE
docs(architecture): reconcile strategy-v1 runtime drift across architecture surfaces

### DIFF
--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -56,7 +56,7 @@ Claire de Binare ist ein **event-getriebenes Krypto-Trading-System** mit:
 | Service | Container | Port | Funktion |
 |---------|-----------|------|----------|
 | WebSocket | cdb_ws | 8000 | MEXC Market Data Stream |
-| Signal | cdb_signal | 8005 | Signal Generation |
+| Signal | cdb_signal | 8005 | Signal Generation (`primary_breakout_v1` footprint + `momentum_builtin` via static adapter boundary) |
 | Prometheus | cdb_prometheus | 19090→9090 | Metrics |
 | Grafana | cdb_grafana | 3000 | Dashboards |
 | Postgres Exporter | cdb_postgres_exporter | 9187 | PG Metrics |
@@ -132,6 +132,14 @@ cdb_reports           Up (healthy)
 - `ORDER_PLACED` - Order an Exchange gesendet
 - `POSITION_OPENED` - Position eroeffnet
 
+### Strategy-v1 Runtime Boundaries (current main)
+- **Signal**: traegt den minimalen `primary_breakout_v1`-Pfad (entry/exit/cooldown) und den bestehenden `momentum_builtin`-Pfad; die Auswahl erfolgt statisch ueber repo-owned Adapter-IDs (`SIGNAL_ADAPTER_ID`), nicht ueber Plugin-Discovery.
+- **Execution**: waehlt statisch zwischen `mock_builtin` und `mexc_builtin` (`EXECUTION_ADAPTER_ID`) und bleibt fail-closed bei unbekannter Adapter-ID.
+- **Risk**: bleibt zentrale Core-Grenze fuer Decision-, Run-Mode- und Policy-Logik; keine Adapter-Selektion umgeht diese Grenze.
+- **Persistence**: `cdb_db_writer` bleibt kanonischer Persistenzpfad fuer Runtime-Events; Validation-/Replay-Artefakte sind davon getrennt.
+- **Deterministischer Validation-Pfad**: `core/replay/historical_bridge.py` + `services/validation/strategy_backtest_runner.py` bilden den repo-backed Backtest-/Validation-Pfad fuer `primary_breakout_v1`.
+- **Unit-/Scale-Canon**: aktive Market-State-/Signal-/Risk-Surfaces fuehren Prozentpunkt-Semantik (`3.0 == 3%`) als current-main-Contract.
+
 ---
 
 ## 5. Invariants (nicht verhandelbar)
@@ -142,6 +150,7 @@ cdb_reports           Up (healthy)
 4. **Determinismus**: Reproduzierbare Ergebnisse via Event Replay
 5. **TLS Optional**: Aktivierbar via `-TLS` Flag (Redis + PostgreSQL)
 6. **Localhost Binding**: Alle Ports auf 127.0.0.1 (keine externe Exposition)
+7. **Static Adapter Selection**: Strategy-/Execution-Selection ist statisch und repo-owned; keine dynamische Adapter-Discovery
 
 ---
 
@@ -175,3 +184,4 @@ Legacy-Layer (base.yml, dev.yml, tls.yml, etc.) existieren noch, sind nicht mehr
 | 2026-03-29 | market_data Subscriber-Liste: cdb_market, cdb_candles, cdb_paper_runner ergaenzt (#1323) | Claude |
 | 2026-03-29 | BLUE/RED reconciliation: alle Services nach Compose-Realitaet, Known Drifts bereinigt, Compose-Referenzen aktualisiert (#1302) | Claude |
 | 2026-04-01 | Logging Overlay: Aktivierungsspalte auf compose-Datei-Referenz umgestellt (war: -Logging Flag); Compose-Referenzblock präzisiert (#1409) | Claude |
+| 2026-04-11 | Strategy-v1 Drift-Batch nach #1598/#1600/#1602/#1613: Signal-/Execution-Boundary, deterministischer Replay-/Validation-Pfad und Unit-/Scale-Canon auf current-main nachgezogen | Codex |

--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -133,7 +133,7 @@ cdb_reports           Up (healthy)
 - `POSITION_OPENED` - Position eroeffnet
 
 ### Strategy-v1 Runtime Boundaries (current main)
-- **Signal**: traegt den minimalen `primary_breakout_v1`-Pfad (entry/exit/cooldown) und den bestehenden `momentum_builtin`-Pfad; die Auswahl erfolgt statisch ueber repo-owned Adapter-IDs (`SIGNAL_ADAPTER_ID`), nicht ueber Plugin-Discovery.
+- **Signal**: traegt den minimalen `primary_breakout_v1`-Pfad (entry/exit/cooldown) und den bestehenden `momentum_builtin`-Pfad; die Strategieauswahl erfolgt ueber `SIGNAL_STRATEGY_ID`, die Adaptergrenze bleibt statisch/repo-owned (`SIGNAL_ADAPTER_ID`), ohne Plugin-Discovery.
 - **Execution**: waehlt statisch zwischen `mock_builtin` und `mexc_builtin` (`EXECUTION_ADAPTER_ID`) und bleibt fail-closed bei unbekannter Adapter-ID.
 - **Risk**: bleibt zentrale Core-Grenze fuer Decision-, Run-Mode- und Policy-Logik; keine Adapter-Selektion umgeht diese Grenze.
 - **Persistence**: `cdb_db_writer` bleibt kanonischer Persistenzpfad fuer Runtime-Events; Validation-/Replay-Artefakte sind davon getrennt.

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -29,9 +29,9 @@
 | **Candles** | cdb_candles | 8007 | services/candles/ | **AKTIV** | Tick→1-min Candle Aggregation |
 | **Regime** | cdb_regime | 8008 | services/regime/ | **AKTIV** | ADX/ATR Regime Classification |
 | **Allocation** | cdb_allocation | 8006 | services/allocation/ | **AKTIV** | Regime→Allocation Mapping |
-| **Risk** | cdb_risk | 8002 | services/risk/ | **AKTIV** | Risk Gate, Circuit Breaker, Kill-Switch |
-| **Execution** | cdb_execution | 8003 | services/execution/ | **AKTIV** | Order Execution (MOCK_TRADING=true default) |
-| **DB Writer** | cdb_db_writer | — | services/db_writer/ | **AKTIV** | Redis→PostgreSQL Persistenz |
+| **Risk** | cdb_risk | 8002 | services/risk/ | **AKTIV** | Zentrale Decision-/Run-Mode-/Policy-Grenze (Risk Gate, Circuit Breaker, Kill-Switch) |
+| **Execution** | cdb_execution | 8003 | services/execution/ | **AKTIV** | Order Execution ueber statische Adapter-Selektion (`mock_builtin`/`mexc_builtin`) |
+| **DB Writer** | cdb_db_writer | — | services/db_writer/ | **AKTIV** | Kanonische Redis→PostgreSQL Persistenz (`signals`/`orders`/`order_results`/`portfolio_snapshots`) |
 | **Paper Runner** | cdb_paper_runner | 8004 | tools/paper_trading/ | **AKTIV** | Paper Trading Orchestrator |
 
 ### RED Stack (compose.red.yml) — Signal + Monitoring, failure-isolated from BLUE
@@ -39,8 +39,30 @@
 | Service | Container | Port | Code | Status | Funktion |
 |---------|-----------|------|------|--------|----------|
 | **WebSocket** | cdb_ws | 8000 | services/ws/ | **AKTIV** | MEXC Market Data Stream (protobuf) |
-| **Signal** | cdb_signal | 8005 | services/signal/ | **AKTIV** | Signal Generation, Momentum-Strategie |
+| **Signal** | cdb_signal | 8005 | services/signal/ | **AKTIV** | Signal Generation mit minimalem `primary_breakout_v1`-Footprint und `momentum_builtin` ueber statische Adapter-Grenze |
 | **Reports** | cdb_reports | — | services/reports/ | **AKTIV** | Daily Order Summary + Email |
+
+---
+
+## Validation / Replay Surface (current main)
+
+| Surface | Code | Status | Funktion |
+|---------|------|--------|----------|
+| **Replay Historical Bridge** | core/replay/historical_bridge.py | **AKTIV (code-level)** | Deterministischer 1m-BTCUSDT Input-Bridge fuer `primary_breakout_v1` |
+| **Strategy Backtest Runner** | services/validation/strategy_backtest_runner.py | **AKTIV (code-level)** | Deterministischer Validation-Runner mit schema-basiertem Gate-Report |
+
+Hinweis: Diese Surfaces sind Validation-/Replay-Pfade und keine Runtime-Publisher fuer die Persistenzkanaele des DB Writers.
+
+---
+
+## Service Ownership Boundaries (current main, kanonisch)
+
+- **Signal**: erzeugt Signalkandidaten (`primary_breakout_v1` + `momentum_builtin`) ueber statische, repo-owned Adapterwahl; keine Plugin-Discovery.
+- **Execution**: fuehrt nur bereits risk-gegate-te Orders aus; Adapter-Selektion statisch/fail-closed (`EXECUTION_ADAPTER_ID`).
+- **Risk**: bleibt zentrale Entscheidungsgrenze fuer Run-Mode, Decision, Thresholds und Policy-Kontext.
+- **DB Writer**: bleibt reine Persistenzschicht; keine Vermischung mit Validation- oder Replay-Gating.
+- **Replay/Validation**: historischer Bridge + Backtest-Runner als separater deterministischer Validationspfad.
+- **Unit-/Scale-Canon**: aktive Surfaces nutzen Prozentpunkt-Semantik fuer die betroffenen Return-/Pct- und Schwellenfelder (`3.0 == 3%`).
 
 ---
 
@@ -148,3 +170,4 @@ docker compose -f infrastructure/compose/compose.red.yml up -d
 | 2025-12-28 | Signal Service aktiviert: cdb_core → cdb_signal (Port 8005) | Claude |
 | 2026-03-29 | BLUE/RED-Split reconciliation: market/candles/regime/allocation→AKTIV, Exporter/Reports/Alertmanager ergänzt, Image-Versionen aktualisiert, Compose-Referenzen auf compose.blue/red.yml (#1302) | Claude |
 | 2026-04-01 | Logging Overlay: Status AKTIV→OVERLAY für Loki/Promtail/Alertmanager; Status-Definition OVERLAY ergänzt; Aktivierungsbefehl explizit; Compose-Architektur-Notation präzisiert (#1409) | Claude |
+| 2026-04-11 | Strategy-v1 Drift-Batch nach #1598/#1600/#1602/#1613: Service-Boundaries fuer Signal/Execution/Risk/DB Writer sowie Replay-/Validation-Surfaces current-main-wahr nachgezogen | Codex |

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -48,10 +48,10 @@
 
 | Surface | Code | Status | Funktion |
 |---------|------|--------|----------|
-| **Replay Historical Bridge** | core/replay/historical_bridge.py | **AKTIV (code-level)** | Deterministischer 1m-BTCUSDT Input-Bridge fuer `primary_breakout_v1` |
-| **Strategy Backtest Runner** | services/validation/strategy_backtest_runner.py | **AKTIV (code-level)** | Deterministischer Validation-Runner mit schema-basiertem Gate-Report |
+| **Replay Historical Bridge** | core/replay/historical_bridge.py | **BEREIT** | Deterministischer 1m-BTCUSDT Input-Bridge fuer `primary_breakout_v1` |
+| **Strategy Backtest Runner** | services/validation/strategy_backtest_runner.py | **BEREIT** | Deterministischer Validation-Runner mit schema-basiertem Gate-Report |
 
-Hinweis: Diese Surfaces sind Validation-/Replay-Pfade und keine Runtime-Publisher fuer die Persistenzkanaele des DB Writers.
+Hinweis: Diese Surfaces sind im Code nutzbar, werden aber nicht als eigenstaendige Compose-Services deployed. Sie sind Validation-/Replay-Pfade und keine Runtime-Publisher fuer die Persistenzkanaele des DB Writers.
 
 ---
 


### PR DESCRIPTION
## Summary
- reconciles architecture/service-catalog wording against current `main` for the landed strategy-v1 cluster
- applies one narrow docs-only batch across both architecture surfaces instead of four micro follow-ups
- keeps LR/live statements unchanged and preserves Stage/LR separation (`trade-capable` vs `NO-GO`)

## Scope
- updated only:
  - `knowledge/ARCHITECTURE_MAP.md`
  - `knowledge/governance/SERVICE_CATALOG.md`
- no runtime or contract code changes

## Reconciled drift (repo-backed)
- `#1598`: unit/scale canon wording reflected as percentage-point unit boundary (`3.0 == 3%`) on active surfaces
- `#1600`: Signal wording updated from generic momentum-only to include minimal `primary_breakout_v1` footprint
- `#1602`: strategy/execution selection boundary documented as static, repo-owned adapter selection (no plugin discovery)
- `#1613`: deterministic replay/validation path documented via `core/replay/historical_bridge.py` + `services/validation/strategy_backtest_runner.py`

## Validation
- `git diff --check`
- `git diff --name-only` contains only the two target docs
- reviewed diffs to ensure no LR/live verdict wording changed
- verified boundary language is consistent across `ARCHITECTURE_MAP` and `SERVICE_CATALOG`

## Issue coverage
- closes `#1599`
- closes `#1601`
- closes `#1603`
- closes `#1614`