### PR TITLE
chore(hygiene): ignore local session and codex worktree artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ yarn-error.log*
 # Temporary files
 *.tmp
 *.temp
+tmp*/
+tmp_*/
+tmp-*/
 
 # Local development
 .env
@@ -145,6 +148,9 @@ Claire_de_Binare_Docs/
 .claude/
 .gemini/
 gha-creds-*.json
+.codex-worktree-*/
+codex-worktree-*/
+evals/
 
 # Auto Claude data directory
 .auto-claude/


### PR DESCRIPTION
## Summary
- adds narrow ignore rules for common local session/worktree leftovers
- keeps the change strictly hygiene-only and fail-closed

## Changed
- `.gitignore`
  - `tmp*/`, `tmp_*/`, `tmp-*/`
  - `.codex-worktree-*/`, `codex-worktree-*/`
  - `evals/`

## Why
Issue #1608 requests reducing visible root/main-tree noise from temporary session artifacts, caches, and worktree remnants.

## Validation
- `git diff --check`
- `git diff --name-only` -> only `.gitignore`

Closes #1608