### PR TITLE
chore(github): remove stale trigger and pointer stubs

### DIFF
--- a/.github/.trigger
+++ b/.github/.trigger
@@ -1,1 +1,0 @@
-# Trigger CI

--- a/.github/ARCHITECTURE_ISSUE_144.md
+++ b/.github/ARCHITECTURE_ISSUE_144.md
@@ -1,4 +1,0 @@
-# ARCHITECTURE_ISSUE_144.md
-
-Historical architecture document archived locally at:
-`docs/archive/github/ARCHITECTURE_ISSUE_144.md`

--- a/.github/BRANCH_TRIAGE_2026-01-08.md
+++ b/.github/BRANCH_TRIAGE_2026-01-08.md
@@ -1,4 +1,0 @@
-# BRANCH_TRIAGE_2026-01-08.md
-
-Historical branch triage document archived locally at:
-`docs/archive/github/BRANCH_TRIAGE_2026-01-08.md`

--- a/.github/TRIGGER_CI.txt
+++ b/.github/TRIGGER_CI.txt
@@ -1,1 +1,0 @@
-# Trigger CI


### PR DESCRIPTION
## Summary\n- remove stale trigger stubs under .github (.trigger, TRIGGER_CI.txt)\n- remove two .github historical pointer files now covered by docs archive paths\n- keep slice intentionally narrow to reduce .github noise without touching active workflows\n\n## Validation\n- git diff --check\n- git diff --name-only (only four .github stub/pointer files)\n\nCloses #1610