### PR TITLE
chore(minimize): remove obsolete root redirect stubs

### DIFF
--- a/DOCS_MOVED_TO_DOCS_HUB.md
+++ b/DOCS_MOVED_TO_DOCS_HUB.md
@@ -1,8 +1,0 @@
-# Docs Moved To Docs Hub (Legacy Redirect)
-
-This file name is a legacy artifact from the former split-repo model.
-All active documentation now lives in this working repo.
-
-The split-repo model was retired in #1140.
-See `docs/meta/WORKING_REPO_CANON.md` for the current canonical layout.
-A read-only archive of the former external content is at `docs/archive/docs_hub_snapshot/`.

--- a/ORCHESTRATOR_PACK_144.md
+++ b/ORCHESTRATOR_PACK_144.md
@@ -1,6 +1,0 @@
-# ORCHESTRATOR_PACK_144
-
-Archive copy:
-`docs/archive/ORCHESTRATOR_PACK_144.md`
-
-This root file exists only as a local discoverability pointer.

--- a/docs/meta/WORKING_REPO_CANON.md
+++ b/docs/meta/WORKING_REPO_CANON.md
@@ -63,8 +63,6 @@ einzigen generischen "Current Status"-Datei gebuendelt.
 | `CDB_CONSTITUTION.md` | `knowledge/governance/CDB_CONSTITUTION.md` |
 | `CDB_GOVERNANCE.md` | `knowledge/governance/CDB_GOVERNANCE.md` |
 | `LEGACY_FILES.md` | `docs/archive/LEGACY_FILES.md` |
-| `ORCHESTRATOR_PACK_144.md` | `docs/archive/ORCHESTRATOR_PACK_144.md` |
-| `DOCS_MOVED_TO_DOCS_HUB.md` | this file |
 
 ## Repo Rules
 


### PR DESCRIPTION
## Summary
- remove two obsolete root redirect stubs (`DOCS_MOVED_TO_DOCS_HUB.md`, `ORCHESTRATOR_PACK_144.md`)
- keep durable root governance pointers untouched for follow-up root-anchor reconcile
- reconcile internal redirect map in `docs/meta/WORKING_REPO_CANON.md`

## Validation
- `git diff --check`
- `rg -n --glob '!docs/archive/**' --glob '!**/docs_hub_snapshot/**' "DOCS_MOVED_TO_DOCS_HUB.md|ORCHESTRATOR_PACK_144.md"` (only archive/log/navpack traces remain)

Closes #1606