### PR TITLE
feat(hygiene): add branch/worktree obsolescence scan and manual cleanup path

### DIFF
--- a/.github/scripts/weekly_control_hygiene_classifier.py
+++ b/.github/scripts/weekly_control_hygiene_classifier.py
@@ -11,7 +11,7 @@ from dataclasses import asdict, dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
-
+from urllib.parse import quote
 
 CONTROL_ISSUE_NUMBER = 1445
 COMMENT_MARKER = "<!-- cdb-weekly-hygiene:{week_key} -->"
@@ -19,6 +19,7 @@ FOLLOWUP_MARKER = "<!-- cdb-weekly-hygiene-followup:{fingerprint} -->"
 REPORT_WINDOW_DAYS = 21
 STALE_DAYS = 60
 MAX_FOLLOWUP_DEFAULT = 2
+BASE_BRANCH = "main"
 
 
 @dataclass
@@ -30,6 +31,7 @@ class Candidate:
     affected_artifacts: list[str]
     suggested_next_step: str
     evidence: str
+    cleanup_state: str | None = None
     issue_title: str | None = None
     issue_labels: list[str] | None = None
     fingerprint: str | None = None
@@ -47,7 +49,9 @@ def run(args: list[str], *, input_text: str | None = None) -> str:
         check=False,
     )
     if proc.returncode != 0:
-        raise RuntimeError(f"command failed ({proc.returncode}): {' '.join(args)}\n{proc.stderr.strip()}")
+        raise RuntimeError(
+            f"command failed ({proc.returncode}): {' '.join(args)}\n{proc.stderr.strip()}"
+        )
     return proc.stdout
 
 
@@ -116,6 +120,250 @@ def make_fingerprint(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
 
 
+def extract_issue_number_from_branch(branch_name: str) -> int | None:
+    match = re.search(
+        r"(?:^|[-_/])(issue|ops|bug|feat|feature|codex)[-_/]?(\d+)(?:$|[-_/])",
+        branch_name,
+    )
+    if not match:
+        return None
+    try:
+        return int(match.group(2))
+    except ValueError:
+        return None
+
+
+def branch_obsolescence_candidates(
+    repo: str, open_issues: list[dict[str, Any]]
+) -> list[Candidate]:
+    try:
+        branches = gh_api_json([f"repos/{repo}/branches?per_page=100"])
+        open_prs = gh_json(
+            repo,
+            [
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--limit",
+                "200",
+                "--json",
+                "headRefName",
+            ],
+        )
+        closed_prs = gh_json(
+            repo,
+            [
+                "pr",
+                "list",
+                "--state",
+                "closed",
+                "--limit",
+                "200",
+                "--json",
+                "number,headRefName,url,mergedAt,closedAt",
+            ],
+        )
+    except Exception as exc:
+        return [
+            Candidate(
+                rule_id="branch_obsolescence",
+                title="Branch obsolescence scan unavailable",
+                classification="unclear",
+                confidence=0.55,
+                affected_artifacts=["refs/heads/*"],
+                suggested_next_step=(
+                    "Treat branch cleanup as blocked for this run and inspect scanner access/auth before any deletion decision."
+                ),
+                evidence=f"Repo-backed branch scan failed: {exc}",
+                cleanup_state="unclear",
+            )
+        ]
+
+    if not isinstance(branches, list):
+        return [
+            Candidate(
+                rule_id="branch_obsolescence",
+                title="Branch obsolescence scan returned unexpected payload",
+                classification="unclear",
+                confidence=0.52,
+                affected_artifacts=["refs/heads/*"],
+                suggested_next_step="Fail closed and inspect branch API response shape before acting on cleanup decisions.",
+                evidence="Expected a list of branches from GitHub API.",
+                cleanup_state="unclear",
+            )
+        ]
+
+    open_pr_heads = {
+        item.get("headRefName") for item in open_prs if isinstance(item, dict)
+    }
+    latest_closed_by_head: dict[str, dict[str, Any]] = {}
+    for item in closed_prs:
+        if not isinstance(item, dict):
+            continue
+        head = item.get("headRefName")
+        if not head or head in latest_closed_by_head:
+            continue
+        latest_closed_by_head[head] = item
+
+    open_issue_numbers = {
+        int(item["number"])
+        for item in open_issues
+        if isinstance(item.get("number"), int)
+    }
+    findings: list[Candidate] = []
+    for raw_branch in sorted(
+        branches, key=lambda x: x.get("name", "") if isinstance(x, dict) else ""
+    ):
+        if not isinstance(raw_branch, dict):
+            continue
+        branch_name = raw_branch.get("name")
+        if not isinstance(branch_name, str):
+            continue
+        if branch_name in {BASE_BRANCH, "master"}:
+            continue
+        if raw_branch.get("protected") is True:
+            continue
+        if branch_name in open_pr_heads:
+            continue
+
+        compare_ref = f"{quote(BASE_BRANCH, safe='')}...{quote(branch_name, safe='')}"
+        try:
+            compare = gh_api_json([f"repos/{repo}/compare/{compare_ref}"])
+        except Exception:
+            findings.append(
+                Candidate(
+                    rule_id="branch_obsolescence",
+                    title=f"Branch obsolescence unclear: {branch_name}",
+                    classification="unclear",
+                    confidence=0.58,
+                    affected_artifacts=[f"branch:{branch_name}"],
+                    suggested_next_step=(
+                        "Keep branch untouched and inspect compare API state manually before classifying cleanup readiness."
+                    ),
+                    evidence=f"Could not compare {branch_name} against {BASE_BRANCH}.",
+                    cleanup_state="unclear",
+                )
+            )
+            continue
+
+        ahead_by = int(compare.get("ahead_by", 0))
+        behind_by = int(compare.get("behind_by", 0))
+        status = str(compare.get("status", "unknown"))
+        if ahead_by > 0:
+            continue
+
+        linked_issue = extract_issue_number_from_branch(branch_name)
+        closed_pr = latest_closed_by_head.get(branch_name)
+        pr_hint = "no closed PR metadata found"
+        if closed_pr and closed_pr.get("mergedAt"):
+            pr_hint = (
+                f"last PR #{closed_pr.get('number')} merged ({closed_pr.get('url')})"
+            )
+        elif closed_pr and closed_pr.get("closedAt"):
+            pr_hint = f"last PR #{closed_pr.get('number')} closed without merge ({closed_pr.get('url')})"
+
+        if linked_issue is not None and linked_issue in open_issue_numbers:
+            findings.append(
+                Candidate(
+                    rule_id="branch_obsolescence",
+                    title=f"Branch cleanup unclear due to open linked issue: {branch_name}",
+                    classification="unclear",
+                    confidence=0.66,
+                    affected_artifacts=[
+                        f"branch:{branch_name}",
+                        f"issue #{linked_issue}",
+                    ],
+                    suggested_next_step=(
+                        "Do not delete this branch yet; reconcile linked open issue ownership/status first."
+                    ),
+                    evidence=(
+                        f"Branch {branch_name} has no unique commits vs {BASE_BRANCH} "
+                        f"(status={status}, ahead={ahead_by}, behind={behind_by}) but appears linked to open issue #{linked_issue}; "
+                        f"{pr_hint}."
+                    ),
+                    cleanup_state="unclear",
+                )
+            )
+            continue
+
+        fingerprint = make_fingerprint(
+            f"branch_cleanup_ready:{branch_name}:{status}:{ahead_by}:{behind_by}"
+        )
+        findings.append(
+            Candidate(
+                rule_id="branch_obsolescence",
+                title=f"Branch cleanup-ready candidate: {branch_name}",
+                classification="follow_up_issue",
+                confidence=0.88,
+                affected_artifacts=[
+                    f"branch:{branch_name}",
+                    f"refs/heads/{branch_name}",
+                ],
+                suggested_next_step=(
+                    "Run report-first confirmation in the weekly lane and perform branch deletion only via explicit manual approval."
+                ),
+                evidence=(
+                    f"Branch {branch_name} has no unique commits vs {BASE_BRANCH} "
+                    f"(status={status}, ahead={ahead_by}, behind={behind_by}), no open PR, and no linked open issue signal; {pr_hint}."
+                ),
+                cleanup_state="cleanup_ready",
+                issue_title=f"Weekly hygiene: review deletion of obsolete branch {branch_name}",
+                issue_labels=[
+                    "scope:ci",
+                    "type:chore",
+                    "agent:codex",
+                    "manual-approval",
+                ],
+                fingerprint=fingerprint,
+            )
+        )
+
+    if findings:
+        return findings
+    return [
+        Candidate(
+            rule_id="branch_obsolescence",
+            title="No cleanup-ready obsolete branch candidates in this run",
+            classification="report_only",
+            confidence=0.8,
+            affected_artifacts=["refs/heads/*"],
+            suggested_next_step="Keep weekly branch obsolescence scan active; no branch delete candidate this week.",
+            evidence="No non-protected branch without open PR met the cleanup-ready gate in this run.",
+            cleanup_state="report_only",
+        )
+    ]
+
+
+def local_worktree_boundary_candidate() -> Candidate:
+    return Candidate(
+        rule_id="worktree_obsolescence_boundary",
+        title="Local worktree cleanup remains manual/local-only",
+        classification="report_only",
+        confidence=0.95,
+        affected_artifacts=[
+            "tools/cleanup/worktree_obsolescence_cleanup.ps1",
+            "docs/runbooks/CDB_WEEKLY_CONTROL_HYGIENE_CLASSIFIER.md",
+        ],
+        suggested_next_step=(
+            "Run local worktree cleanup in dry_run mode first and execute only after explicit manual approval."
+        ),
+        evidence=(
+            "GitHub-hosted Actions cannot inspect or delete workstation-local worktrees (for example D:\\Dev\\...). "
+            "Weekly hosted scan publishes classification only; local cleanup is a separate manual path."
+        ),
+        cleanup_state="report_only",
+    )
+
+
+def cleanup_state_counts(candidates: list[Candidate]) -> dict[str, int]:
+    counts = {"cleanup_ready": 0, "report_only": 0, "unclear": 0}
+    for cand in candidates:
+        if cand.cleanup_state in counts:
+            counts[cand.cleanup_state] += 1
+    return counts
+
+
 def parked_active_drift(open_issues: list[dict[str, Any]]) -> list[Candidate]:
     candidates: list[Candidate] = []
     active_explicit = {"prio:must", "prio:should"}
@@ -136,7 +384,9 @@ def parked_active_drift(open_issues: list[dict[str, Any]]) -> list[Candidate]:
             f"Issue #{issue_no} is labeled status:parked but still has active delivery labels "
             f"{', '.join(active_labels)}."
         )
-        fingerprint = make_fingerprint(f"parked_active:{issue_no}:{','.join(sorted(active_labels))}")
+        fingerprint = make_fingerprint(
+            f"parked_active:{issue_no}:{','.join(sorted(active_labels))}"
+        )
         candidates.append(
             Candidate(
                 rule_id="parked_active_drift",
@@ -157,7 +407,9 @@ def parked_active_drift(open_issues: list[dict[str, Any]]) -> list[Candidate]:
     return candidates
 
 
-def stale_open_issue_candidates(open_issues: list[dict[str, Any]], now: datetime) -> list[Candidate]:
+def stale_open_issue_candidates(
+    open_issues: list[dict[str, Any]], now: datetime
+) -> list[Candidate]:
     cutoff = now - timedelta(days=STALE_DAYS)
     stale: list[dict[str, Any]] = []
     for issue in open_issues:
@@ -195,7 +447,9 @@ def stale_open_issue_candidates(open_issues: list[dict[str, Any]], now: datetime
     ]
 
 
-def workflow_register_drift(workflow_dir: Path, register_map: dict[str, str]) -> list[Candidate]:
+def workflow_register_drift(
+    workflow_dir: Path, register_map: dict[str, str]
+) -> list[Candidate]:
     candidates: list[Candidate] = []
     for workflow_name, trigger_note in register_map.items():
         file_path = workflow_dir / workflow_name
@@ -208,7 +462,10 @@ def workflow_register_drift(workflow_dir: Path, register_map: dict[str, str]) ->
                     title=f"Workflow listed but file missing: {workflow_name}",
                     classification="follow_up_issue",
                     confidence=0.95,
-                    affected_artifacts=["docs/runbooks/CONTROL_REGISTER.md", f".github/workflows/{workflow_name}"],
+                    affected_artifacts=[
+                        "docs/runbooks/CONTROL_REGISTER.md",
+                        f".github/workflows/{workflow_name}",
+                    ],
                     suggested_next_step=(
                         "Open a small follow-up to either restore the workflow file or remove/update "
                         "the CONTROL_REGISTER entry."
@@ -225,12 +482,22 @@ def workflow_register_drift(workflow_dir: Path, register_map: dict[str, str]) ->
         triggers = extract_triggers(wf_text)
         note = trigger_note.lower()
         manual_only_note = "manuell" in note and not any(
-            word in note for word in ("mo", "di", "mi", "do", "fr", "sa", "so", "wöchentlich", "taeglich", "täglich")
+            word in note
+            for word in (
+                "mo",
+                "di",
+                "mi",
+                "do",
+                "fr",
+                "sa",
+                "so",
+                "wöchentlich",
+                "taeglich",
+                "täglich",
+            )
         )
         if manual_only_note and "schedule" in triggers:
-            evidence = (
-                f"{workflow_name} is marked manual in CONTROL_REGISTER but workflow still defines schedule trigger."
-            )
+            evidence = f"{workflow_name} is marked manual in CONTROL_REGISTER but workflow still defines schedule trigger."
             fingerprint = make_fingerprint(f"workflow_manual_schedule:{workflow_name}")
             candidates.append(
                 Candidate(
@@ -238,7 +505,10 @@ def workflow_register_drift(workflow_dir: Path, register_map: dict[str, str]) ->
                     title=f"Manual-vs-schedule drift: {workflow_name}",
                     classification="follow_up_issue",
                     confidence=0.94,
-                    affected_artifacts=["docs/runbooks/CONTROL_REGISTER.md", f".github/workflows/{workflow_name}"],
+                    affected_artifacts=[
+                        "docs/runbooks/CONTROL_REGISTER.md",
+                        f".github/workflows/{workflow_name}",
+                    ],
                     suggested_next_step=(
                         "Open a narrow follow-up to align workflow triggers and CONTROL_REGISTER note."
                     ),
@@ -249,16 +519,17 @@ def workflow_register_drift(workflow_dir: Path, register_map: dict[str, str]) ->
                 )
             )
         if "wöchentlich" in note and "schedule" not in triggers:
-            evidence = (
-                f"{workflow_name} is marked weekly in CONTROL_REGISTER but has no schedule trigger."
-            )
+            evidence = f"{workflow_name} is marked weekly in CONTROL_REGISTER but has no schedule trigger."
             candidates.append(
                 Candidate(
                     rule_id="workflow_register_drift",
                     title=f"Weekly trigger note drift: {workflow_name}",
                     classification="unclear",
                     confidence=0.64,
-                    affected_artifacts=["docs/runbooks/CONTROL_REGISTER.md", f".github/workflows/{workflow_name}"],
+                    affected_artifacts=[
+                        "docs/runbooks/CONTROL_REGISTER.md",
+                        f".github/workflows/{workflow_name}",
+                    ],
                     suggested_next_step=(
                         "Verify intent in control thread first; if weekly execution is still required, open a small "
                         "trigger-note reconciliation follow-up."
@@ -269,7 +540,9 @@ def workflow_register_drift(workflow_dir: Path, register_map: dict[str, str]) ->
     return candidates
 
 
-def recent_workflow_noise(repo: str, register_map: dict[str, str], now: datetime) -> list[Candidate]:
+def recent_workflow_noise(
+    repo: str, register_map: dict[str, str], now: datetime
+) -> list[Candidate]:
     candidates: list[Candidate] = []
     since = now - timedelta(days=REPORT_WINDOW_DAYS)
     for workflow_name in register_map:
@@ -337,7 +610,11 @@ def ensure_followup_issue(repo: str, candidate: Candidate) -> dict[str, Any]:
     marker = FOLLOWUP_MARKER.format(fingerprint=candidate.fingerprint)
     found = existing_followup(repo, marker)
     if found:
-        return {"action": "existing", "number": found["number"], "url": found["html_url"]}
+        return {
+            "action": "existing",
+            "number": found["number"],
+            "url": found["html_url"],
+        }
 
     body = (
         "## Weekly Control Hygiene Follow-up\n\n"
@@ -359,7 +636,10 @@ def ensure_followup_issue(repo: str, candidate: Candidate) -> dict[str, Any]:
     return {"action": "created", "number": issue_no, "url": url}
 
 
-def build_comment(week: str, candidates: list[Candidate], issue_events: list[dict[str, Any]]) -> str:
+def build_comment(
+    week: str, candidates: list[Candidate], issue_events: list[dict[str, Any]]
+) -> str:
+    counts = cleanup_state_counts(candidates)
     lines = [
         "## Weekly Control Hygiene Classifier",
         "",
@@ -367,6 +647,12 @@ def build_comment(week: str, candidates: list[Candidate], issue_events: list[dic
         "",
         f"- Week: `{week}`",
         f"- Findings: `{len(candidates)}`",
+        (
+            "- Cleanup states: "
+            f"`cleanup_ready={counts['cleanup_ready']}`, "
+            f"`report_only={counts['report_only']}`, "
+            f"`unclear={counts['unclear']}`"
+        ),
         f"- Follow-up issues emitted: `{len(issue_events)}`",
         "",
     ]
@@ -383,6 +669,11 @@ def build_comment(week: str, candidates: list[Candidate], issue_events: list[dic
                 f"### {cand.title}",
                 f"- Rule: `{cand.rule_id}`",
                 f"- Classification: `{cand.classification}`",
+                (
+                    f"- Cleanup state: `{cand.cleanup_state}`"
+                    if cand.cleanup_state is not None
+                    else "- Cleanup state: `n/a`"
+                ),
                 f"- Confidence: `{cand.confidence}`",
                 f"- Affected artifacts: `{', '.join(cand.affected_artifacts)}`",
                 f"- Suggested next step: {cand.suggested_next_step}",
@@ -400,7 +691,9 @@ def build_comment(week: str, candidates: list[Candidate], issue_events: list[dic
 
 def upsert_control_comment(repo: str, week: str, body: str) -> dict[str, Any]:
     marker = COMMENT_MARKER.format(week_key=week)
-    comments = gh_api_json([f"repos/{repo}/issues/{CONTROL_ISSUE_NUMBER}/comments?per_page=100"])
+    comments = gh_api_json(
+        [f"repos/{repo}/issues/{CONTROL_ISSUE_NUMBER}/comments?per_page=100"]
+    )
     existing = None
     if isinstance(comments, list):
         for item in comments:
@@ -410,12 +703,24 @@ def upsert_control_comment(repo: str, week: str, body: str) -> dict[str, Any]:
     payload = json.dumps({"body": body})
     if existing is None:
         created = gh_api_json(
-            ["--method", "POST", f"repos/{repo}/issues/{CONTROL_ISSUE_NUMBER}/comments", "--input", "-"],
+            [
+                "--method",
+                "POST",
+                f"repos/{repo}/issues/{CONTROL_ISSUE_NUMBER}/comments",
+                "--input",
+                "-",
+            ],
             input_text=payload,
         )
         return {"action": "created", "url": created.get("html_url")}
     updated = gh_api_json(
-        ["--method", "PATCH", f"repos/{repo}/issues/comments/{existing['id']}", "--input", "-"],
+        [
+            "--method",
+            "PATCH",
+            f"repos/{repo}/issues/comments/{existing['id']}",
+            "--input",
+            "-",
+        ],
         input_text=payload,
     )
     return {"action": "updated", "url": updated.get("html_url")}
@@ -458,6 +763,8 @@ def main() -> int:
     findings.extend(stale_open_issue_candidates(open_issues, now))
     findings.extend(workflow_register_drift(args.workflow_dir, register_map))
     findings.extend(recent_workflow_noise(args.repo, register_map, now))
+    findings.extend(branch_obsolescence_candidates(args.repo, open_issues))
+    findings.append(local_worktree_boundary_candidate())
 
     # keep deterministic order: follow_up_issue first, then unclear, then report_only
     order = {"follow_up_issue": 0, "unclear": 1, "report_only": 2}
@@ -465,7 +772,9 @@ def main() -> int:
 
     issue_events: list[dict[str, Any]] = []
     if args.publish_mode == "publish":
-        followups = [f for f in findings if f.classification == "follow_up_issue"][: args.max_followup_issues]
+        followups = [f for f in findings if f.classification == "follow_up_issue"][
+            : args.max_followup_issues
+        ]
         for cand in followups:
             issue_events.append(ensure_followup_issue(args.repo, cand))
 
@@ -479,6 +788,7 @@ def main() -> int:
         "week_key": wk,
         "publish_mode": args.publish_mode,
         "findings_count": len(findings),
+        "cleanup_state_counts": cleanup_state_counts(findings),
         "findings": [asdict(item) for item in findings],
         "issue_events": issue_events,
         "control_comment": comment_event,

--- a/docs/runbooks/CDB_WEEKLY_CONTROL_HYGIENE_CLASSIFIER.md
+++ b/docs/runbooks/CDB_WEEKLY_CONTROL_HYGIENE_CLASSIFIER.md
@@ -10,6 +10,7 @@ Zweck: kleiner weekly hygiene/reconciliation Layer fuer den operativen Control-T
 - Output:
   - ein dedupe-sicherer Wochenkommentar unter `#1445`
   - optional enge Follow-up-Issues, hart gecappt auf `0..2` pro Run
+  - branch/worktree-obsolescence Klassifikation mit `cleanup_ready` / `report_only` / `unclear`
 
 ## Abgrenzung
 
@@ -29,6 +30,10 @@ Zweck: kleiner weekly hygiene/reconciliation Layer fuer den operativen Control-T
    - Drift zwischen `docs/runbooks/CONTROL_REGISTER.md` Trigger-Note und realen Workflow-Triggers
 4. `workflow_noise`
    - wiederholte Failure-Muster auf aktiven Workflows im 21-Tage-Fenster
+5. `branch_obsolescence`
+   - repo-/GitHub-backed Branch-Kandidaten ohne Open-PR und ohne unique Delta vs `main`
+6. `worktree_obsolescence_boundary`
+   - explizite Boundary: Hosted Actions klassifizieren nur, lokale Worktree-Loeschung bleibt manuell
 
 ## Klassifikation und Guardrails
 
@@ -36,11 +41,26 @@ Zweck: kleiner weekly hygiene/reconciliation Layer fuer den operativen Control-T
   - `report_only`
   - `follow_up_issue`
   - `unclear`
+- Cleanup-Status fuer Obsolescence-Kandidaten:
+  - `cleanup_ready`
+  - `report_only`
+  - `unclear`
 - harte Regeln:
   - kein Auto-Repo-Change
   - kein Issue-Flood
   - Follow-up-Issues pro Run max `2`
   - dedupe ueber stabile Marker im Kommentar und im Folge-Issue
+  - branch-cleanup Follow-up-Issues tragen `manual-approval` als primaeren Gate-Label
+
+## Environment Boundary (hosted vs local)
+
+- GitHub-hosted Actions koennen **keine** lokalen Worktrees unter `D:\Dev\...` inspizieren oder loeschen.
+- Weekly workflow liefert deshalb nur repo-backed Detection + Klassifikation.
+- Lokale Worktree-Loeschung laeuft ausschliesslich ueber den manuellen/local path:
+  - `tools/cleanup/worktree_obsolescence_cleanup.ps1`
+- Dieser lokale Path ist strikt report-first:
+  1. `dry_run` ausfuehren und Report sichern
+  2. nur bei `cleanup_ready` + explizitem Human-Entscheid `execute` ausfuehren
 
 ## Trigger
 
@@ -58,3 +78,13 @@ Zweck: kleiner weekly hygiene/reconciliation Layer fuer den operativen Control-T
 - bei `publish`:
   - Wochenkommentar unter `#1445` wird erstellt/aktualisiert
   - Follow-up-Issues nur fuer klare, kleine Pakete und nur innerhalb des Caps
+
+## Lokaler Cleanup-Path (manual)
+
+```powershell
+# report-first (default)
+.\tools\cleanup\worktree_obsolescence_cleanup.ps1
+
+# execute nur nach expliziter Freigabe
+.\tools\cleanup\worktree_obsolescence_cleanup.ps1 -Mode execute -ApprovalIssue 1589
+```

--- a/docs/runbooks/CONTROL_REGISTER.md
+++ b/docs/runbooks/CONTROL_REGISTER.md
@@ -72,7 +72,7 @@ Kontext-Issue-Nummern sind historische Anker (alle CLOSED) — nicht als offene 
 |---|---|---|
 | `weekly_digest.yml` | wöchentlich | Issue-/Status-Digest |
 | `weekly_digest_failure_alert.yml` | nach `weekly_digest.yml` | Failure-Eskalation als `report:weekly-fail` Issue nur bei echtem Fehler |
-| `cdb-weekly-control-hygiene-classifier.yml` | Mo/Do/Fr 07:30 UTC + manuell | Weekly hygiene/reconciliation fuer `#1445`; dedupe-sicherer Wochenkommentar und optional max 0..2 enge Follow-up-Issues |
+| `cdb-weekly-control-hygiene-classifier.yml` | Mo/Do/Fr 07:30 UTC + manuell | Weekly hygiene/reconciliation fuer `#1445`; dedupe-sicherer Wochenkommentar, branch-obsolescence Klassifikation (repo-backed) und lokaler/manual worktree-cleanup handoff; optional max 0..2 enge Follow-up-Issues |
 | `cdb-daily-delta-triage.yml` | Di/Mi/Fr/So 06:20 UTC + manuell | Daily fresh-delta triage fuer `#1445`; delta-only gegen letzten Daily-Marker, optional max 0..1 enges Follow-up-Issue |
 | `governance-audit.yml` | manuell | Governance-Audit |
 | `cdb-control-followup-classifier.yml` | manuell | Human-in-the-loop Klassifikation repo-backed Control-Findings |

--- a/tests/unit/scripts/test_weekly_control_hygiene_classifier.py
+++ b/tests/unit/scripts/test_weekly_control_hygiene_classifier.py
@@ -1,0 +1,146 @@
+"""Unit tests for .github/scripts/weekly_control_hygiene_classifier.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / ".github"
+        / "scripts"
+        / "weekly_control_hygiene_classifier.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "weekly_control_hygiene_classifier", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_branch_obsolescence_marks_cleanup_ready(monkeypatch):
+    mod = _load_module()
+
+    def fake_api(args, input_text=None):  # noqa: ARG001
+        endpoint = args[0]
+        if endpoint.startswith("repos/test/repo/branches"):
+            return [
+                {"name": "main", "protected": True},
+                {"name": "issue-4242-cleanup-candidate", "protected": False},
+            ]
+        if endpoint.startswith("repos/test/repo/compare/"):
+            return {"ahead_by": 0, "behind_by": 3, "status": "behind"}
+        raise AssertionError(f"Unexpected API call: {args}")
+
+    def fake_gh(repo, args):  # noqa: ARG001
+        if args[:4] == ["pr", "list", "--state", "open"]:
+            return []
+        if args[:4] == ["pr", "list", "--state", "closed"]:
+            return [
+                {
+                    "number": 9001,
+                    "headRefName": "issue-4242-cleanup-candidate",
+                    "url": "https://example/pr/9001",
+                    "mergedAt": "2026-04-10T00:00:00Z",
+                    "closedAt": "2026-04-10T00:00:00Z",
+                }
+            ]
+        raise AssertionError(f"Unexpected gh_json call: {args}")
+
+    monkeypatch.setattr(mod, "gh_api_json", fake_api)
+    monkeypatch.setattr(mod, "gh_json", fake_gh)
+
+    candidates = mod.branch_obsolescence_candidates("test/repo", open_issues=[])
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.rule_id == "branch_obsolescence"
+    assert candidate.cleanup_state == "cleanup_ready"
+    assert candidate.classification == "follow_up_issue"
+    assert "manual-approval" in (candidate.issue_labels or [])
+
+
+def test_branch_obsolescence_stays_unclear_when_issue_open(monkeypatch):
+    mod = _load_module()
+
+    def fake_api(args, input_text=None):  # noqa: ARG001
+        endpoint = args[0]
+        if endpoint.startswith("repos/test/repo/branches"):
+            return [
+                {"name": "main", "protected": True},
+                {"name": "issue-1589-weekly-hygiene", "protected": False},
+            ]
+        if endpoint.startswith("repos/test/repo/compare/"):
+            return {"ahead_by": 0, "behind_by": 2, "status": "behind"}
+        raise AssertionError(f"Unexpected API call: {args}")
+
+    def fake_gh(repo, args):  # noqa: ARG001
+        if args[:4] == ["pr", "list", "--state", "open"]:
+            return []
+        if args[:4] == ["pr", "list", "--state", "closed"]:
+            return []
+        raise AssertionError(f"Unexpected gh_json call: {args}")
+
+    monkeypatch.setattr(mod, "gh_api_json", fake_api)
+    monkeypatch.setattr(mod, "gh_json", fake_gh)
+
+    candidates = mod.branch_obsolescence_candidates(
+        "test/repo", open_issues=[{"number": 1589}]
+    )
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.cleanup_state == "unclear"
+    assert candidate.classification == "unclear"
+    assert "open issue #1589" in candidate.evidence
+
+
+def test_local_worktree_boundary_candidate():
+    mod = _load_module()
+    candidate = mod.local_worktree_boundary_candidate()
+    assert candidate.rule_id == "worktree_obsolescence_boundary"
+    assert candidate.classification == "report_only"
+    assert candidate.cleanup_state == "report_only"
+
+
+def test_cleanup_state_counts():
+    mod = _load_module()
+    candidates = [
+        mod.Candidate(
+            rule_id="r1",
+            title="t1",
+            classification="report_only",
+            confidence=0.5,
+            affected_artifacts=[],
+            suggested_next_step="n/a",
+            evidence="e1",
+            cleanup_state="cleanup_ready",
+        ),
+        mod.Candidate(
+            rule_id="r2",
+            title="t2",
+            classification="report_only",
+            confidence=0.5,
+            affected_artifacts=[],
+            suggested_next_step="n/a",
+            evidence="e2",
+            cleanup_state="report_only",
+        ),
+        mod.Candidate(
+            rule_id="r3",
+            title="t3",
+            classification="unclear",
+            confidence=0.5,
+            affected_artifacts=[],
+            suggested_next_step="n/a",
+            evidence="e3",
+            cleanup_state="unclear",
+        ),
+    ]
+    counts = mod.cleanup_state_counts(candidates)
+    assert counts == {"cleanup_ready": 1, "report_only": 1, "unclear": 1}

--- a/tools/cleanup/worktree_obsolescence_cleanup.ps1
+++ b/tools/cleanup/worktree_obsolescence_cleanup.ps1
@@ -1,0 +1,254 @@
+<#
+.SYNOPSIS
+    Safe local worktree obsolescence cleanup for Claire de Binare.
+
+.DESCRIPTION
+    Scans local git worktrees and classifies each entry into:
+    - cleanup_ready
+    - report_only
+    - unclear
+
+    Guardrails:
+    - Dry-run by default.
+    - Execute mode requires explicit ApprovalIssue.
+    - Never deletes the current worktree path.
+    - Never performs blind recursive deletion.
+    - Designed for local/manual execution only.
+
+.PARAMETER Mode
+    dry_run (default) or execute.
+
+.PARAMETER RepoPath
+    Path to the local git repository.
+
+.PARAMETER BaseBranch
+    Base branch used for merged checks (default: main).
+
+.PARAMETER ReportPath
+    JSON report output path.
+
+.PARAMETER ApprovalIssue
+    Required in execute mode. Numeric issue id documenting manual approval.
+
+.EXAMPLE
+    .\tools\cleanup\worktree_obsolescence_cleanup.ps1
+
+.EXAMPLE
+    .\tools\cleanup\worktree_obsolescence_cleanup.ps1 -Mode execute -ApprovalIssue 1589
+#>
+
+[CmdletBinding()]
+param(
+    [ValidateSet("dry_run", "execute")]
+    [string]$Mode = "dry_run",
+    [string]$RepoPath = ".",
+    [string]$BaseBranch = "main",
+    [string]$ReportPath = "artifacts\local-worktree-cleanup\report.json",
+    [string]$ApprovalIssue = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-Git {
+    param(
+        [string[]]$Args,
+        [switch]$AllowFail
+    )
+
+    $output = & git -C $ResolvedRepoPath @Args 2>&1
+    $exitCode = $LASTEXITCODE
+    if (-not $AllowFail -and $exitCode -ne 0) {
+        throw "git $($Args -join ' ') failed: $output"
+    }
+    return [pscustomobject]@{
+        ExitCode = $exitCode
+        Output   = ($output -join "`n")
+    }
+}
+
+function Normalize-Path {
+    param([string]$PathValue)
+    try {
+        return (Resolve-Path -LiteralPath $PathValue -ErrorAction Stop).Path
+    } catch {
+        return [System.IO.Path]::GetFullPath($PathValue)
+    }
+}
+
+function Parse-WorktreeList {
+    param([string]$RawText)
+    $entries = @()
+    $current = [ordered]@{}
+
+    foreach ($line in ($RawText -split "`r?`n")) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            if ($current.Count -gt 0) {
+                $entries += [pscustomobject]$current
+                $current = [ordered]@{}
+            }
+            continue
+        }
+
+        if ($line.StartsWith("worktree ")) {
+            $current["path"] = $line.Substring(9).Trim()
+            continue
+        }
+        if ($line.StartsWith("HEAD ")) {
+            $current["head"] = $line.Substring(5).Trim()
+            continue
+        }
+        if ($line.StartsWith("branch ")) {
+            $branchRef = $line.Substring(7).Trim()
+            $current["branch"] = $branchRef.Replace("refs/heads/", "")
+            continue
+        }
+        if ($line.StartsWith("prunable")) {
+            $current["prunable"] = $true
+            continue
+        }
+    }
+
+    if ($current.Count -gt 0) {
+        $entries += [pscustomobject]$current
+    }
+
+    return $entries
+}
+
+$ResolvedRepoPath = Normalize-Path -PathValue $RepoPath
+if (-not (Test-Path -LiteralPath $ResolvedRepoPath)) {
+    throw "RepoPath not found: $ResolvedRepoPath"
+}
+
+$repoCheck = Invoke-Git -Args @("rev-parse", "--is-inside-work-tree") -AllowFail
+if ($repoCheck.ExitCode -ne 0 -or $repoCheck.Output.Trim() -ne "true") {
+    throw "RepoPath is not a git repository: $ResolvedRepoPath"
+}
+
+if ($Mode -eq "execute" -and ($ApprovalIssue -notmatch "^\d+$")) {
+    throw "ApprovalIssue must be numeric in execute mode."
+}
+
+Write-Host "=== Local Worktree Obsolescence Cleanup ===" -ForegroundColor Cyan
+Write-Host "RepoPath: $ResolvedRepoPath"
+Write-Host "Mode: $Mode"
+Write-Host "BaseBranch: $BaseBranch"
+
+Invoke-Git -Args @("fetch", "origin", "--prune") | Out-Null
+
+$currentPath = Normalize-Path -PathValue $ResolvedRepoPath
+$worktreeRaw = Invoke-Git -Args @("worktree", "list", "--porcelain")
+$worktrees = Parse-WorktreeList -RawText $worktreeRaw.Output
+$candidates = @()
+$executedActions = @()
+$needsPrune = $false
+
+foreach ($entry in $worktrees) {
+    $entryPath = [string]$entry.path
+    $entryBranch = if ($entry.PSObject.Properties.Name -contains "branch") { [string]$entry.branch } else { "" }
+    $entryPrunable = ($entry.PSObject.Properties.Name -contains "prunable") -and [bool]$entry.prunable
+    $entryPathExists = Test-Path -LiteralPath $entryPath
+    $normalizedEntryPath = Normalize-Path -PathValue $entryPath
+    $isCurrent = ($normalizedEntryPath -eq $currentPath)
+
+    $cleanupState = "report_only"
+    $evidence = "No cleanup action required."
+
+    if ($isCurrent) {
+        $cleanupState = "report_only"
+        $evidence = "Current worktree path is always excluded from cleanup."
+    } elseif ($entryPrunable) {
+        $cleanupState = "cleanup_ready"
+        $evidence = "Git marks this worktree as prunable."
+    } elseif (-not $entryPathExists) {
+        $cleanupState = "unclear"
+        $evidence = "Worktree path is missing but not marked prunable."
+    } else {
+        $statusResult = & git -C $entryPath status --porcelain 2>&1
+        $statusExit = $LASTEXITCODE
+        if ($statusExit -ne 0) {
+            $cleanupState = "unclear"
+            $evidence = "Could not inspect worktree status."
+        } elseif (-not [string]::IsNullOrWhiteSpace(($statusResult -join "`n"))) {
+            $cleanupState = "unclear"
+            $evidence = "Worktree has local modifications and is not safe to remove automatically."
+        } elseif ([string]::IsNullOrWhiteSpace($entryBranch)) {
+            $cleanupState = "unclear"
+            $evidence = "Worktree has no branch metadata; keep for manual inspection."
+        } elseif ($entryBranch -in @($BaseBranch, "main", "master")) {
+            $cleanupState = "report_only"
+            $evidence = "Base/default branch worktree is excluded from cleanup."
+        } else {
+            $mergeCheck = & git -C $ResolvedRepoPath merge-base --is-ancestor "refs/heads/$entryBranch" "refs/remotes/origin/$BaseBranch" 2>&1
+            $mergeExit = $LASTEXITCODE
+            if ($mergeExit -eq 0) {
+                $cleanupState = "cleanup_ready"
+                $evidence = "Worktree is clean and branch is fully merged into origin/$BaseBranch."
+            } else {
+                $cleanupState = "report_only"
+                $evidence = "Branch is not merged into origin/$BaseBranch."
+            }
+        }
+    }
+
+    $candidate = [ordered]@{
+        path          = $entryPath
+        branch        = $entryBranch
+        prunable      = $entryPrunable
+        cleanup_state = $cleanupState
+        evidence      = $evidence
+    }
+    $candidates += [pscustomobject]$candidate
+
+    if ($Mode -eq "execute" -and $cleanupState -eq "cleanup_ready") {
+        if ($isCurrent) {
+            continue
+        }
+        if ($entryPrunable -and -not $entryPathExists) {
+            $needsPrune = $true
+            continue
+        }
+        if ($entryPathExists) {
+            Invoke-Git -Args @("worktree", "remove", $entryPath) | Out-Null
+            $executedActions += "git worktree remove $entryPath"
+        }
+    }
+}
+
+if ($Mode -eq "execute" -and $needsPrune) {
+    Invoke-Git -Args @("worktree", "prune", "--verbose") | Out-Null
+    $executedActions += "git worktree prune --verbose"
+}
+
+$summary = [ordered]@{
+    cleanup_ready = (@($candidates | Where-Object { $_.cleanup_state -eq "cleanup_ready" })).Count
+    report_only   = (@($candidates | Where-Object { $_.cleanup_state -eq "report_only" })).Count
+    unclear       = (@($candidates | Where-Object { $_.cleanup_state -eq "unclear" })).Count
+}
+
+$report = [ordered]@{
+    generated_at_utc = [DateTime]::UtcNow.ToString("o")
+    repo_path        = $ResolvedRepoPath
+    base_branch      = $BaseBranch
+    mode             = $Mode
+    approval_issue   = $(if ($Mode -eq "execute") { $ApprovalIssue } else { $null })
+    boundary_note    = "This script is local/manual by design. Hosted GitHub Actions cannot manage D:\\Dev\\... workstation worktrees."
+    summary          = $summary
+    candidates       = $candidates
+    executed_actions = $executedActions
+}
+
+$reportDirectory = Split-Path -Parent $ReportPath
+if ($reportDirectory) {
+    New-Item -ItemType Directory -Path $reportDirectory -Force | Out-Null
+}
+$report | ConvertTo-Json -Depth 8 | Set-Content -Path $ReportPath -Encoding UTF8
+
+Write-Host ""
+Write-Host "Summary: cleanup_ready=$($summary.cleanup_ready), report_only=$($summary.report_only), unclear=$($summary.unclear)" -ForegroundColor Yellow
+Write-Host "Report written to: $ReportPath"
+if ($Mode -eq "dry_run") {
+    Write-Host "Dry-run only. Re-run with -Mode execute -ApprovalIssue <issue> to apply cleanup-ready actions." -ForegroundColor Green
+} else {
+    Write-Host "Execute mode completed. Actions: $($executedActions.Count)" -ForegroundColor Green
+}


### PR DESCRIPTION
## Summary
- extend weekly hygiene classifier with repo-backed branch obsolescence detection and explicit cleanup_state buckets (cleanup_ready / report_only / unclear)
- keep hosted workflow fail-closed for local worktrees by adding an explicit boundary candidate and local/manual-only cleanup path
- add local script tools/cleanup/worktree_obsolescence_cleanup.ps1 with dry-run default and execute-mode approval gate
- label cleanup-ready branch follow-up issues with manual-approval and keep weekly follow-up cap at 0..2
- add unit tests for the new weekly classifier branch/worktree logic

## Scope boundary
GitHub-hosted Actions classify repo-backed branch/worktree hygiene only; workstation-local worktree deletion remains local/manual and report-first.

## Links
- Closes #1589
