### PR TITLE
docs(control): reconcile remaining workflow and runtime drift surfaces

### DIFF
--- a/docs/runbooks/CDB_CONTROL_FOLLOWUP_CLASSIFIER.md
+++ b/docs/runbooks/CDB_CONTROL_FOLLOWUP_CLASSIFIER.md
@@ -17,7 +17,7 @@ Zweck: Duenne Human-in-the-loop Operationalisierung fuer repo-backed Control-Fin
 
 1. GitHub Actions -> `CDB Control Follow-up Classifier`
 2. `finding_text` mit einem konkreten repo-backed Finding fuellen
-3. optional `issue_number` setzen, wenn das Ergebnis auch als Kommentar auf ein bestehendes Issue soll
+3. `issue_number` setzen, wenn `output_target=summary_and_issue_comment` (bei `summary_only` bleibt es optional)
 4. `output_target`:
    - `summary_only`
    - `summary_and_issue_comment`
@@ -33,5 +33,6 @@ Zweck: Duenne Human-in-the-loop Operationalisierung fuer repo-backed Control-Fin
 ## Guardrails
 
 - fail-closed bei ungueltigem JSON
+- fail-closed wenn `summary_and_issue_comment` ohne `issue_number` gestartet wird
 - fail-closed bei nicht numerischer `issue_number`
 - `follow_up_issue` nur bei kleinem, getrennt bearbeitbarem Fixpaket

--- a/docs/runbooks/CONTROL_REGISTER.md
+++ b/docs/runbooks/CONTROL_REGISTER.md
@@ -1,6 +1,6 @@
 # Control Register
 
-**Letzte Aktualisierung:** 2026-04-09
+**Letzte Aktualisierung:** 2026-04-11
 **SSOT Live-Readiness:** `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
 **Verdict:** NO-GO
 **Control-Board Stage:** `trade-capable` (ratifiziert 2026-04-08 via Issue `#1492`)
@@ -89,7 +89,7 @@ Kontext-Issue-Nummern sind historische Anker (alle CLOSED) — nicht als offene 
 - Prompt-Canon: `.github/prompts/cdb-control-followup.prompt.yml`
 - Ausführung: nur `workflow_dispatch`, kein Auto-Issueing, keine automatische Repo-Mutation
 - Ausgabe: immer Step Summary + Artefakt; optional zusätzlicher Kommentar auf ein bewusst gesetztes Ziel-Issue
-- Guardrail: fail-closed bei ungültigem JSON oder nicht numerischer `issue_number`
+- Guardrail: fail-closed bei ungueltigem JSON, bei `summary_and_issue_comment` ohne `issue_number`, oder bei nicht numerischer `issue_number`
 
 ---
 

--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -42,7 +42,7 @@ Claire de Binare ist ein **event-getriebenes Krypto-Trading-System** mit:
 |---------|-----------|------|----------|
 | PostgreSQL | cdb_postgres | 5432 | Persistenz |
 | Redis | cdb_redis | 6379 | Cache, Pub/Sub, Streams |
-| Market | cdb_market | 8009 | market_state:{symbol} Owner |
+| Market | cdb_market | 8009 | market_state:{symbol} Owner; Redis-subscription mit Retry/Reconnect, /health fail-closed bei Redis-Ausfall |
 | Candles | cdb_candles | 8007 | Tick→1-min Candle Aggregation |
 | Regime | cdb_regime | 8008 | ADX/ATR Regime Classification |
 | Allocation | cdb_allocation | 8006 | Regime→Allocation Mapping |
@@ -185,3 +185,4 @@ Legacy-Layer (base.yml, dev.yml, tls.yml, etc.) existieren noch, sind nicht mehr
 | 2026-03-29 | BLUE/RED reconciliation: alle Services nach Compose-Realitaet, Known Drifts bereinigt, Compose-Referenzen aktualisiert (#1302) | Claude |
 | 2026-04-01 | Logging Overlay: Aktivierungsspalte auf compose-Datei-Referenz umgestellt (war: -Logging Flag); Compose-Referenzblock präzisiert (#1409) | Claude |
 | 2026-04-11 | Strategy-v1 Drift-Batch nach #1598/#1600/#1602/#1613: Signal-/Execution-Boundary, deterministischer Replay-/Validation-Pfad und Unit-/Scale-Canon auf current-main nachgezogen | Codex |
+| 2026-04-11 | Market runtime reconcile nach #1630: Redis-Reconnect-Verhalten und fail-closed /health-Semantik fuer `cdb_market` dokumentiert | Codex |

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -25,7 +25,7 @@
 
 | Service | Container | Port | Code | Status | Funktion |
 |---------|-----------|------|------|--------|----------|
-| **Market** | cdb_market | 8009 | services/market/ | **AKTIV** | market_state:{symbol} Owner (Issue #1201) |
+| **Market** | cdb_market | 8009 | services/market/ | **AKTIV** | market_state:{symbol} Owner; Redis-subscription mit Retry/Reconnect, /health fail-closed bei Redis-Ausfall (Issue #1201) |
 | **Candles** | cdb_candles | 8007 | services/candles/ | **AKTIV** | Tick→1-min Candle Aggregation |
 | **Regime** | cdb_regime | 8008 | services/regime/ | **AKTIV** | ADX/ATR Regime Classification |
 | **Allocation** | cdb_allocation | 8006 | services/allocation/ | **AKTIV** | Regime→Allocation Mapping |
@@ -58,6 +58,7 @@ Hinweis: Diese Surfaces sind im Code nutzbar, werden aber nicht als eigenstaendi
 ## Service Ownership Boundaries (current main, kanonisch)
 
 - **Signal**: erzeugt Signalkandidaten (`primary_breakout_v1` + `momentum_builtin`) ueber statische, repo-owned Adapterwahl; keine Plugin-Discovery.
+- **Market**: konsumiert `market_data` via Redis Pub/Sub mit Retry/Reconnect; solange Redis/Subscription fehlt, bleibt die Health-Surface fail-closed (`503 degraded`).
 - **Execution**: fuehrt nur bereits risk-gegate-te Orders aus; Adapter-Selektion statisch/fail-closed (`EXECUTION_ADAPTER_ID`).
 - **Risk**: bleibt zentrale Entscheidungsgrenze fuer Run-Mode, Decision, Thresholds und Policy-Kontext.
 - **DB Writer**: bleibt reine Persistenzschicht; keine Vermischung mit Validation- oder Replay-Gating.
@@ -171,3 +172,4 @@ docker compose -f infrastructure/compose/compose.red.yml up -d
 | 2026-03-29 | BLUE/RED-Split reconciliation: market/candles/regime/allocation→AKTIV, Exporter/Reports/Alertmanager ergänzt, Image-Versionen aktualisiert, Compose-Referenzen auf compose.blue/red.yml (#1302) | Claude |
 | 2026-04-01 | Logging Overlay: Status AKTIV→OVERLAY für Loki/Promtail/Alertmanager; Status-Definition OVERLAY ergänzt; Aktivierungsbefehl explizit; Compose-Architektur-Notation präzisiert (#1409) | Claude |
 | 2026-04-11 | Strategy-v1 Drift-Batch nach #1598/#1600/#1602/#1613: Service-Boundaries fuer Signal/Execution/Risk/DB Writer sowie Replay-/Validation-Surfaces current-main-wahr nachgezogen | Codex |
+| 2026-04-11 | Runtime-reconcile nach #1630: Market-Service-Beschreibung auf Redis-Retry/Reconnect und fail-closed Health-Semantik nachgezogen | Codex |


### PR DESCRIPTION
## Summary
- reconcile control-runbook guardrails with #1626 fail-closed workflow input validation
- reconcile architecture/service-catalog market runtime semantics with #1630 redis reconnect behavior

## Links
- Closes #1627
- Closes #1631