### PR TITLE
docs(readme): reconcile root and active README surfaces with current main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,193 +1,81 @@
-Welcome to the Claire de Binare repository. This project is a complex system for algorithmic trading, featuring a microservices-based architecture, advanced data analysis, and a sophisticated governance framework.
+# Claire de Binare
 
----
-## 🚦 Live Readiness (Operational Gate)
+Deterministisches, governance-first Trading-System im Working Repo Canon.
+Der aktive Pfad bleibt Shadow/Paper-first; Live-Kapital ist nicht freigegeben.
 
-**Status:** ❌ **NO-GO**<br>
-**Canonical source:** `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+## Current Operating Reality (current main)
 
-- **Scope basis:** `ROADMAP.yaml` + `LR-001..LR-007-STATE.yaml` + aktuelle GitHub-LR-Issues
-- **Last reconciliation:** 2026-04-07
-- **Roadmap status:** `P0` DONE; `P1` PARTIAL; `P2` DONE; `P3` PARTIAL; `P4` DONE; `P5` NO-GO
-- **Human gate:** Keine Echtgeld-Freigabe ohne vollstaendige Evidenz und explizite menschliche Freigabe
+- **Control-Board Stage:** `trade-capable` (Board-Kontext, nicht LR-Freigabe)
+- **Live-Readiness Verdict:** **NO-GO** (SSOT: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`)
+- **Status-Trennung bleibt hart:**
 
-**Einordnung:**<br>
-`CURRENT_STATUS.md` beschreibt den aktuellen Repo-/Main-/Testzustand.<br>
-`docs/runbooks/CONTROL_REGISTER.md` beschreibt den aktuellen Board-/Stage-Fokus; aktuell `trade-capable` (ratifiziert 2026-04-08), weiterhin ohne Live-Kapital und orthogonal zum LR-System.<br>
-`PROJECT_STATUS.md` ist ein historischer Implementierungs-Snapshot und kein operativer Go/No-Go-Status.<br>
-`knowledge/CURRENT_STATUS.md` ist nur ein historischer Knowledge-Snapshot und keine aktuelle Repo-/Ops-Quelle.
+| Quelle | Zweck |
+|---|---|
+| `docs/runbooks/CONTROL_REGISTER.md` | Board-Stage und operativer Fokus |
+| `CURRENT_STATUS.md` | Repo-/Engineering-Ledger |
+| `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` | Echtgeld Go/No-Go |
 
----
+Stage und LR sind orthogonale Systeme: `trade-capable` autorisiert kein Live-Trading.
 
-## 🧭 Geplante Erweiterungen (nicht gate-relevant)
+## Current-main Landing Snapshot
 
-**Ausbaugrad:** **~72 %**
-*(Backlog, Optimierungen, Erweiterungen – kein Einfluss auf Live-Betrieb)*
-Diese Kennzahl beschreibt **geplante Weiterentwicklung ausserhalb des LR-Gates**, z. B.:
+Auf `origin/main` sind die juengsten Kern-Cluster gelandet, u. a.:
 
-- Performance-Optimierungen  
-- Zusätzliche Tests (Chaos / Perf)  
-- Komfort-Features  
-- ML-Vorbereitung & Experimente  
-- Dokumentations-Verdichtung
+- Strategy-v1-Cluster: `primary_breakout_v1` Signal-Footprint, statische Adapter-Grenze, deterministischer Validation-Pfad, Paper/Shadow-Bridge.
+- Repo-/Workflow-/Docs-/Hygiene-Cluster: Root-Minimierung, Workflow-Reconcile, Control-Register-/Status-Nachzuege.
 
-**Wichtig:**  
-Dieser Fortschritt ist **optional, iterativ und nicht zeitkritisch**.  
-Er ist **kein Maß für Betriebsreife** und **kein Release-Gate**.
+Operativ offen im Control-Kontext: `#1445` sowie die geparkten `#197`, `#205`, `#211`.
 
----
+## Canonical Entrypoints
 
-### Kurzfassung (fuer Leser mit wenig Zeit)
+1. `docs/runbooks/CONTROL_REGISTER.md`
+2. GitHub Issue `#1445` (inkl. neuestem Wochenkommentar)
+3. `CURRENT_STATUS.md`
+4. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+5. `docs/meta/WORKING_REPO_CANON.md`
+6. `agents/AGENTS.md`
 
-- **Live Readiness:** NO-GO (siehe `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`)
-- **Control-Board Stage:** `trade-capable` (siehe `docs/runbooks/CONTROL_REGISTER.md`) bei weiterhin `LR-050 = NO-GO`
-- **Systemstatus:** Runtime migriert auf BLUE+RED; base.yml + dev.yml sind CI/Legacy-only
-- **Repo-/Teststatus:** siehe `CURRENT_STATUS.md`
-- **Historischer Implementierungsstand:** siehe `PROJECT_STATUS.md` (historischer Snapshot)
+## Active Main Paths
 
----
+- `core/` - gemeinsame Domain-/Contract-Logik
+- `services/` - laufende Runtime-Services (Signal/Risk/Execution/etc.)
+- `infrastructure/compose/` - Compose-Canon (`compose.blue.yml` + `compose.red.yml`)
+- `docs/runbooks/` - operative Runbooks inkl. Control Register
+- `docs/live-readiness/` - LR-Audit- und Gate-Artefakte
+- `knowledge/` - aktive Knowledge-/Governance-Flaeche
+- `tools/` - PowerShell Front Doors und Ops-Helfer
+- `tests/` - Unit/Integration/E2E/Replay/Chaos
 
-## Overview
+## Runtime / Ops Entry
 
-This repository contains all the necessary components to run and develop Claire de Binare, including:
-
-- **Microservices:** A suite of services for handling different aspects of the trading process, such as signal generation, execution, risk management, and data persistence.
-- **Infrastructure:** Infrastructure-as-Code (IaC) for setting up the required environment, including database schemas, monitoring dashboards, and deployment configurations.
-- **Governance:** A comprehensive set of documents defining the project's constitution, policies, and operational guidelines.
-- **Tooling:** A collection of scripts and tools to aid in development, deployment, and maintenance.
-
-## PowerShell Toolchain
-
-Der autoritative repo-weite PowerShell-Index liegt in [`tools/README.md`](tools/README.md).
-
-Dort ist die Discovery in `Canonical v1 Front Door`, `Canonical v1 Scripts`, `Secondary` und `Legacy/Stale` konsolidiert.
-
-Bevorzugter Windows/PowerShell-v1-Einstiegspunkt:
+Windows/PowerShell v1 Front Door:
 
 ```powershell
 .\tools\cdb.ps1 secrets init
 .\tools\cdb.ps1 runtime up
 .\tools\cdb.ps1 stack verify
-.\tools\cdb.ps1 service logs -ServiceName cdb_risk -Lines 100
 .\tools\cdb.ps1 runtime smoke
 ```
 
-Der Dispatcher ist bewusst duenn und ruft nur den fixierten v1-Korridor auf: `init-secrets.ps1`, `setup_blue_red.ps1`, `verify_stack.ps1`, `cdb-service-logs.ps1` und `smoke_test.ps1`.
+Compose Runtime Canon:
 
-`Makefile` bleibt die operative Front Door fuer haeufige Ablaufe wie `make docker-up`, `make docker-health` und `make docker-down`, ist aber nicht selbst Teil der PowerShell-v1-Toolchain.
+```bash
+docker compose -f infrastructure/compose/compose.blue.yml up -d
+docker compose -f infrastructure/compose/compose.red.yml up -d
+```
 
-## Docker CI Lab Baseline
-
-Kanonische 431B-Linie:
+Docker CI Lab Baseline:
 
 ```bash
 docker compose -f infrastructure/compose/base.yml -f infrastructure/compose/test.yml up --abort-on-container-exit
 ```
 
-Rollentrennung:
-- `base.yml + test.yml` = kanonische Docker-CI-Lab-Baseline fuer isolierte Test-/E2E-Labs
-- `base.yml + dev.yml` = CI/Testing-only; kein normaler Runtime-Pfad
-- `compose.blue.yml + compose.red.yml` = lokale Operator-Runtime, nicht die CI-Lab-Baseline
+## Navigation
 
-## Security Simulation Source of Truth
+- `mcp_navpack_working_repo/ENTRYPOINTS.yaml`
+- `mcp_navpack_working_repo/CHEATSHEET.md`
+- `docs/meta/WORKING_REPO_CANON.md`
 
-Kanonische 431C-Linie:
+## Boundary
 
-- `scripts/drills/` plus `tests/chaos/` = repo-native Source of Truth fuer deterministische Drill-/Chaos-Ausfuehrung und Gate-Tests
-- `tools/test_pack/` = sekundaerer experimenteller/importierter Bestand; nicht die repo-weite Default-Linie
-- `infrastructure/scripts/security_audit.sh` = Legacy-/Stale-Helper mit alten Repo-Annahmen; nur Referenz, nicht Harness-Canon
-
-## 📚 Statusquellen
-
-> **Kein aktueller Status hier.** Diese Section ist kein Go/No-Go-Indikator und kein operativer Readiness-Stand.
->
-> | Quelle | Inhalt |
-> |---|---|
-> | [`docs/runbooks/CONTROL_REGISTER.md`](docs/runbooks/CONTROL_REGISTER.md) | Board-/Stage-Status und operativer Fokus |
-> | [`CURRENT_STATUS.md`](CURRENT_STATUS.md) | Aktueller Repo-/Engineering-/Teststatus |
-> | [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md) | Operativer Go/No-Go (Live Readiness) |
-> | [`PROJECT_STATUS.md`](PROJECT_STATUS.md) | Historischer Implementierungs-Snapshot (Stand 2026-01-15, archiviert) |
-
----
-
-## Getting Started
-
-**New Developer?** See **[DEVELOPER_ONBOARDING.md](DEVELOPER_ONBOARDING.md)** for comprehensive setup instructions.
-
-### Quick Setup (5 minutes)
-
-**Prerequisites**: Docker, Python 3.12+, Git
-
-```bash
-# 1. Clone repository
-git clone https://github.com/jannekbuengener/Claire_de_Binare.git
-cd Claire_de_Binare
-
-# 2. Setup environment
-cp .env.example .env
-
-# 3. Initialize secrets (Linux/Mac)
-./infrastructure/scripts/init-secrets.sh
-
-# Windows (PowerShell, canonical v1 front door):
-# .\tools\cdb.ps1 secrets init
-
-# 4. Validate environment (Linux/Mac)
-./infrastructure/scripts/validate-environment.sh
-
-# 5. Start the stack (canonical BLUE+RED runtime)
-docker network create cdb_network 2>/dev/null || true
-docker compose -f infrastructure/compose/compose.blue.yml up -d
-docker compose -f infrastructure/compose/compose.red.yml up -d
-
-# Windows (PowerShell, canonical v1 front door):
-# .\tools\cdb.ps1 runtime up
-
-# 6. Verify health
-make docker-health
-
-# PowerShell v1 front door:
-# .\tools\cdb.ps1 stack verify
-
-# Focused BLUE core-path smoke:
-# .\tools\cdb.ps1 runtime smoke
-
-# 7. Access Grafana
-# http://localhost:3000 (admin / see GRAFANA_PASSWORD in secrets)
-```
-
-Repo-weite PowerShell-Discovery: [`tools/README.md`](tools/README.md). `bootstrap_local.ps1` und `bootstrap_local.sh` bleiben Secondary Convenience Wrapper und sind nicht der kanonische Windows/PowerShell-v1-Einstieg.
-
-## Navigation (MCP)
-
-Für schnelle Orientierung im Working Repo: [`mcp_navpack_working_repo/`][navpack]
-
-- Einstieg/Lesereihenfolge: [`ENTRYPOINTS.yaml`](mcp_navpack_working_repo/ENTRYPOINTS.yaml)
-- Such-/Read-Presets: [`QUERIES.snippets.yaml`](mcp_navpack_working_repo/QUERIES.snippets.yaml)
-- Repo-Map: [`REPO.map.json`](mcp_navpack_working_repo/REPO.map.json)
-- Cheat-Sheet: [`CHEATSHEET.md`](mcp_navpack_working_repo/CHEATSHEET.md)
-
-Die lokale Canon-Matrix fuer aktive Doku liegt im Working Repo: [`docs/meta/WORKING_REPO_CANON.md`][working_repo_canon]
-
-[navpack]: mcp_navpack_working_repo/
-[working_repo_canon]: docs/meta/WORKING_REPO_CANON.md
-
-
-### Troubleshooting
-
-If you encounter issues:
-
-1. **Missing .env**: Run `cp .env.example .env`
-2. **Secret errors**: Run `./infrastructure/scripts/init-secrets.sh` on Linux/Mac or `.\tools\cdb.ps1 secrets init` on Windows
-3. **Port conflicts**: Check for services using ports 6379, 5432, 3000, 9090, 8000
-4. **Permission denied**: Fix secrets permissions: `chmod 700 ~/Documents/.secrets/.cdb && chmod 600 ~/Documents/.secrets/.cdb/*`
-
-See **[DEVELOPER_ONBOARDING.md](DEVELOPER_ONBOARDING.md)** for detailed troubleshooting.
-
-### Documentation
-
-- **Setup Guide**: [DEVELOPER_ONBOARDING.md](DEVELOPER_ONBOARDING.md) - Comprehensive onboarding
-- **Service Audit (2026-01-15)**: [PROJECT_STATUS.md](PROJECT_STATUS.md) - Historical service implementation audit
-- **Governance**: [Governance Audit](docs/archive/governance-audit-2026-01-15.md) - Historical governance audit snapshot
-- **Agent Registry**: [agents/AGENTS.md](agents/AGENTS.md) - Local agent entrypoint
-- **Policies**: `knowledge/governance/` - Canonical governance and policy documents
+Archiv-/Snapshot-Flaechen (`docs/archive/**`, `knowledge/archive/**`) sind historischer Rueckgriff und kein aktiver Pflegepfad.

--- a/knowledge/contracts/README.md
+++ b/knowledge/contracts/README.md
@@ -1,240 +1,29 @@
-# Canonical Message Contracts
+# Knowledge Contracts
 
-**Issue:** #356
-**Status:** ✅ Active (v1.0)
-**Owner:** Team B (Engineering)
+Aktive Contract-Flaeche fuer Nachrichten-, Adapter- und Strategie-Vertraege im Working Repo.
 
-## Übersicht
+## Purpose
 
-Dieses Verzeichnis definiert die **kanonischen Message Contracts** für alle Redis Pub/Sub und Stream Messages in Claire de Binare. Contracts garantieren:
+Dieses Verzeichnis dokumentiert die derzeit verwendeten Contract-Artefakte fuer:
 
-- **Typ-Sicherheit**: Klare Feldtypen und Constraints
-- **Versionierung**: Schema Evolution via `schema_version` Field
-- **Validierung**: Automatische CI-Tests gegen JSON Schemas
-- **Migration**: Klare Upgrade-Pfade für Breaking Changes
+- Markt- und Signal-Payloads (`market_data`, `signal`)
+- Adapter-/Boundary-Verhalten
+- `primary_breakout_v1`-Spezifikation und Validation-Pfad
+- Replay-/Health-Vertragsflaechen
 
----
+## Active Files
 
-## Contracts (v1.0)
+- `CONTRACTS.md` - Gesamtueberblick der Message Contracts
+- `market_data.schema.json`, `signal.schema.json` - JSON Schemas
+- `EXTERNAL_ADAPTERS.md` - Adapter- und Boundary-Canon
+- `PRIMARY_BREAKOUT_V1.md` - Strategievertrag
+- `PRIMARY_BREAKOUT_V1_VALIDATION.md` - deterministischer Validation-Vertrag
+- `REPLAY_CONTRACT.md`, `HEALTH_CONTRACT.md` - Replay-/Health-Vertraege
 
-### 1. market_data (Pub/Sub Topic)
+## SSOT Boundary
 
-**Schema:** [`market_data.schema.json`](./market_data.schema.json)
-**Topic:** `market_data` (Redis Pub/Sub)
-**Publisher:** `cdb_ws` (WebSocket Service)
-**Consumers:** `cdb_signal` (Signal Engine), `cdb_paper` (Paper Trading)
+Dieses Verzeichnis ist Contract-Wissen, nicht Status-SSOT.
 
-**Required Fields:**
-- `schema_version`: `"v1.0"`
-- `source`: `"mexc"` | `"binance"` | `"bybit"` | `"stub"`
-- `symbol`: Trading pair (z.B. `"BTCUSDT"`)
-- `ts_ms`: Timestamp (milliseconds, integer)
-- `price`: Trade price (string für Precision)
-- `trade_qty`: Trade quantity (string für Precision) ⚠️ **NEU in v1.0** (war `qty`)
-- `side`: `"buy"` | `"sell"` | `"unknown"` (lowercase)
-
-**Beispiel:**
-```json
-{
-  "schema_version": "v1.0",
-  "source": "mexc",
-  "symbol": "BTCUSDT",
-  "ts_ms": 1735574400000,
-  "price": "50000.50",
-  "trade_qty": "1.5",
-  "side": "buy"
-}
-```
-
-**Migration Notes:**
-- `qty` → `trade_qty` (Breaking Change in v1.0)
-- `volume` field wurde entfernt (Aggregation downstream)
-
----
-
-### 2. signal (Redis Stream)
-
-**Schema:** [`signal.schema.json`](./signal.schema.json)
-**Stream:** `trading_signals` (Redis Stream via XADD)
-**Publisher:** `cdb_signal` (Signal Engine)
-**Consumers:** `cdb_risk` (Risk Manager), `cdb_paper` (Paper Trading)
-
-**Required Fields:**
-- `schema_version`: `"v1.0"`
-- `signal_id`: Unique identifier (UUID/Hash)
-- `strategy_id`: Strategy identifier
-- `symbol`: Trading pair
-- `side`: `"BUY"` | `"SELL"` (uppercase)
-- `timestamp`: Signal generation time (seconds, integer)
-
-**Optional Fields:**
-- `bot_id`: Bot instance identifier
-- `strength`: Signal strength (0.0-1.0)
-- `confidence`: Confidence level (0.0-1.0)
-- `price`: Price at signal time
-- `reason`: Human-readable justification
-- `pct_change`: Percentage change
-- `type`: Event type discriminator (`"signal"`)
-
-**Beispiel:**
-```json
-{
-  "schema_version": "v1.0",
-  "signal_id": "sig-20251230-btcusdt-001",
-  "strategy_id": "momentum-v2",
-  "bot_id": "bot-alpha-1",
-  "symbol": "BTCUSDT",
-  "side": "BUY",
-  "timestamp": 1735574400,
-  "strength": 0.85,
-  "confidence": 0.92,
-  "price": 50100.50,
-  "reason": "Strong uptrend momentum detected",
-  "type": "signal"
-}
-```
-
-**Migration Notes:**
-- `direction` → `side` (Breaking Change in v1.0)
-- `timestamp`: Changed from float to integer (seconds)
-- **None-Werte MÜSSEN vor Redis XADD gefiltert werden** (siehe Issue #349)
-
----
-
-## Verwendung
-
-### 1. Validierung (Python)
-
-```python
-import json
-from pathlib import Path
-from jsonschema import validate, ValidationError
-
-# Schema laden
-schema_path = Path("docs/contracts/market_data.schema.json")
-with open(schema_path) as f:
-    schema = json.load(f)
-
-# Message validieren
-message = {
-    "schema_version": "v1.0",
-    "source": "mexc",
-    "symbol": "BTCUSDT",
-    "ts_ms": 1735574400000,
-    "price": "50000.50",
-    "trade_qty": "1.5",
-    "side": "buy"
-}
-
-try:
-    validate(instance=message, schema=schema)
-    print("✅ Message is valid")
-except ValidationError as e:
-    print(f"❌ Validation failed: {e.message}")
-```
-
-### 2. Tests ausführen
-
-```bash
-# Alle Contract-Tests
-pytest tests/unit/contracts/test_contracts.py -v
-
-# Nur market_data Tests
-pytest tests/unit/contracts/test_contracts.py::TestMarketDataContract -v
-
-# Nur signal Tests
-pytest tests/unit/contracts/test_contracts.py::TestSignalContract -v
-```
-
-### 3. CI/CD Integration
-
-Contracts werden automatisch validiert via `.github/workflows/contracts.yml`:
-- Bei Push auf `main` (Änderungen in `docs/contracts/**`)
-- Bei Pull Requests
-- **Required Check:** `validate-contracts` muss grün sein vor Merge
-
----
-
-## Schema Evolution
-
-### Versionierung
-
-Alle Schemas nutzen **Semantic Versioning** im `schema_version` Field:
-- `v1.0`: Initiale Version (Breaking Changes: `qty→trade_qty`, `direction→side`)
-- `v1.1`: Minor Changes (neue optionale Fields)
-- `v2.0`: Major Changes (Breaking Changes)
-
-### Breaking Changes
-
-**Wenn ein Breaking Change notwendig ist:**
-1. Neue Schema-Version erstellen (z.B. `v2.0`)
-2. Migration Guide schreiben (siehe [`MIGRATION.md`](./MIGRATION.md))
-3. **Dual Publishing** für 2 Wochen (Publisher senden beide Versionen)
-4. Consumers updaten auf neue Version
-5. Alte Version deprecaten + entfernen
-
-**Beispiel Dual Publishing (market_data v1.0 → v2.0):**
-```python
-# Publisher sendet BEIDE Versionen für 2 Wochen
-redis.publish("market_data", json.dumps({
-    "schema_version": "v1.0",
-    "qty": "1.5",           # OLD field
-    "trade_qty": "1.5",     # NEW field
-    ...
-}))
-```
-
----
-
-## Migration Guides
-
-- [v1.0 Migration Guide](./MIGRATION.md) - `qty→trade_qty`, `direction→side`
-
----
-
-## Beispiele
-
-- **Valid Examples:** [`examples/market_data_valid.json`](market_data_valid.json), [`examples/signal_valid.json`](signal_valid.json)
-- **Invalid Examples:** [`examples/market_data_invalid.json`](market_data_invalid.json), [`examples/signal_invalid.json`](signal_invalid.json)
-
-Alle Beispiele werden automatisch gegen Schemas validiert in `tests/unit/contracts/test_contracts.py`.
-
----
-
-## Troubleshooting
-
-### ❌ "additionalProperties not allowed"
-
-**Problem:** Message enthält Field, das nicht im Schema definiert ist.
-
-**Lösung:**
-- Prüfen ob Field in Schema existiert
-- Legacy Fields entfernen (`qty`, `direction`, `volume`)
-- Bei Bedarf Schema erweitern (Minor Version Bump)
-
-### ❌ "trade_qty is required"
-
-**Problem:** Publisher verwendet noch altes `qty` Field.
-
-**Lösung:**
-- Code updaten: `qty` → `trade_qty`
-- Migration Guide beachten: [`MIGRATION.md`](./MIGRATION.md)
-
-### ❌ "side must be lowercase"
-
-**Problem:** market_data erwartet `"buy"/"sell"`, nicht `"BUY"/"SELL"`.
-
-**Lösung:**
-- `side.lower()` vor Publish (market_data)
-- Signals behalten `"BUY"/"SELL"` (uppercase)
-
----
-
-## Ownership & Governance
-
-- **Schema Changes:** Require PR Review + CI green
-- **Breaking Changes:** Require Migration Guide + 2-week Dual Publishing
-- **Version Bumps:** Update `schema_version` const in `.schema.json` files
-
-**Contact:** Team B (Engineering)
-**Issue Tracker:** [#356](https://github.com/jannekbuengener/Claire_de_Binare/issues/356)
+- Repo-/Engineering-Status: `CURRENT_STATUS.md`
+- Board-Stage/Fokus: `docs/runbooks/CONTROL_REGISTER.md`
+- Live-Readiness Go/No-Go: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`

--- a/services/risk/README.md
+++ b/services/risk/README.md
@@ -1,76 +1,43 @@
-# CDB Risk Manager
+# Risk Service (`cdb_risk`)
 
-## 🚀 Überblick
-Mehrlagiger Risikofilter, der Signale gegen Limits prüft, Orders freigibt oder
-blockiert und Alerts auf das Topic `alerts` schreibt.
+Deterministischer, fail-closed Risk-Gate-Service zwischen Signal und Execution.
 
-## 🧩 Architektur-Einordnung
+## Current-main Scope
 
-- Eingehende Topics: `signals`
-- Ausgehende Topics: `orders`, `alerts`
-- Port/Endpoints: `8002` (`/health`, `/status`, `/metrics`)
-- Abhängigkeiten: Redis (`cdb_redis`), Signal Engine (`cdb_signal`)
+- Prueft eingehende Signale gegen harte Limits und Reason-Code-Regeln.
+- Publiziert Orders nur bei explizitem `ALLOW`; Default ist `BLOCK`.
+- Schreibt Block-Ereignisse als eigene Artefakte (`stream.orders_blocked`).
+- Bleibt orthogonal zu Live-Readiness: Stage `trade-capable` ist keine Live-Freigabe.
 
-```mermaid
-flowchart LR
-  SIGNAL[Signal Engine] -->|signals| RISK[Risk Manager]
-  RISK -->|orders| EXEC[Execution Service]
-  RISK -->|alerts| PUB[Redis Pub/Sub, kein verifizierter Subscriber]
-```
+## Topics / Streams
 
-## ⚙️ Installation & Start
+- Input Topics: `signals`, `order_results`
+- Output Topics: `orders`, `alerts`
+- Input Streams: `stream.regime_signals`, `stream.allocation_decisions`, `stream.bot_shutdown`
+- Output Streams: `stream.orders`, `stream.orders_blocked`
 
-Risk ist Teil des **BLUE**-Stacks (Core):
+## Runtime Surface
+
+- Endpoint-Port: `RISK_PORT` (Default `8002`)
+- HTTP Endpoints: `/health`, `/status`, `/metrics`
+
+Start im BLUE-Stack:
+
 ```powershell
 docker compose -f infrastructure/compose/compose.blue.yml up -d cdb_risk
-curl http://localhost:8002/health
 ```
 
-- Health-Endpoint: `http://localhost:8002/health`
-- Metrics: `http://localhost:8002/metrics`
+## Key Config
 
-## 📊 Monitoring & Health
+- `MAX_POSITION_PCT`
+- `MAX_TOTAL_EXPOSURE_PCT` / `MAX_EXPOSURE_PCT`
+- `MAX_DAILY_DRAWDOWN_PCT`
+- `EARLY_LIVE_MAX_ALLOC`
+- `USE_LIVE_BALANCE`, `USE_REAL_BALANCE`
 
-| Endpoint  | Beschreibung                      |
-|-----------|-----------------------------------|
-| `/health` | Alive-Check inkl. Timestamp        |
-| `/status` | Aktive Limits, Circuit-Breaker     |
-| `/metrics`| `risk_alert_total`, Exposure Gauge |
+## Canonical References
 
-## 🧠 Logik / Features
-
-- Validiert Signals anhand `MAX_POSITION_PCT`, `MAX_EXPOSURE_PCT`,
-  `MAX_DAILY_DRAWDOWN_PCT`
-- Circuit Breaker bei Drawdown oder Marktanomalien (Slippage, Datenstille)
-- Order-Trimming: reduziert Positionsgröße statt kompletter Ablehnung
-- Alerts je Level (`INFO`, `WARNING`, `CRITICAL`) auf Redis Topic `alerts`
-
-### Decision Contract 0/1 v1 (deterministisch)
-- Default: **BLOCK**. Allow nur bei A ∧ B ∧ C.
-- First-Fail Reihenfolge: Safety/Anomaly → Data Freshness → Regime → Signal → Portfolio/Execution
-- Reason Codes (exakt): RC_002, RC_003, RC_004, RC_001, RC_010, RC_020, RC_021, RC_022
-- **Confidence ist kein Gate** (keine Scores/Probabilistik)
-
-## 🧾 Konfiguration
-
-| Variable                 | Default | Beschreibung                      |
-|--------------------------|---------|-----------------------------------|
-| `MAX_POSITION_PCT`       | `0.10`  | Max. Kapital pro Trade            |
-| `MAX_EXPOSURE_PCT`       | `0.50`  | Gesamt-Exposure Limit             |
-| `MAX_DAILY_DRAWDOWN_PCT` | `0.05`  | Tagesverlust Limit                |
-| `STOP_LOSS_PCT`          | `0.02`  | Stop-Loss pro Position            |
-| `REDIS_HOST/PORT`        | `redis/6379` | Verbindung zum Bus            |
-
-## 🧪 Tests & Validierung
-
-```powershell
-pytest backoffice/services/risk_manager/tests -q
-redis-cli -a $REDIS_PASSWORD subscribe alerts
-```
-
-- Weitere Schritte: `backoffice/docs/Risikomanagement-Logik.md`
-
-## 🪶 Lizenz & Credits
-
-- Maintainer: Risk Team (Claire de Binare Core Team)
-- Status: ✅ Production Ready (v1.0)
+- `services/risk/service.py`
+- `services/risk/config.py`
+- `core/contracts/decision_contract_v1.py`
+- `docs/governance/MARKET_STATE_CONTRACT_V1.md`

--- a/services/signal/README.md
+++ b/services/signal/README.md
@@ -1,68 +1,43 @@
-# CDB Signal Engine
+# Signal Service (`cdb_signal`)
 
-## 🚀 Überblick
-Event-getriebener Microservice, der Momentum-Signale aus Live-Marktdaten
-generiert und auf das Redis-Topic `signals` publiziert.
+Event-getriebene Signal-Erzeugung aus `market_data` mit statischer Adapter-Grenze.
 
-## 🧩 Architektur-Einordnung
+## Current-main Scope
 
-- Eingehende Topics: `market_data`
-- Ausgehende Topics: `signals`
-- Port/Endpoints: `8005` (`/health`, `/status`, `/metrics`)
-- Abhängigkeiten: Redis (`cdb_redis`), Bot WS Screener (`cdb_ws`)
+- Erzeugt Signale fuer den Risk Service (`cdb_risk`).
+- Default-Strategiepfad ist `primary_breakout_v1`.
+- Adapter-Auswahl bleibt fail-closed und statisch (kein dynamisches Runtime-Routing).
+- Kein Live-Authorization-Gate: Stage/LR-Gates bleiben ausserhalb dieses Service.
 
-```mermaid
-flowchart LR
-   FEED[Bot WS Screener] -->|market_data| SIGNAL[Signal Engine]
-   SIGNAL -->|signals| RISK[Risk Manager]
-```
+## Topics / Streams
 
-## ⚙️ Installation & Start
+- Input Topic: `market_data`
+- Output Topic: `signals`
+- Output Stream: `stream.signals` (konfigurierbar via `SIGNAL_OUTPUT_STREAM`)
 
-Signal ist Teil des **RED**-Stacks:
+## Runtime Surface
+
+- Endpoint-Port: `SIGNAL_PORT` (Default `8001`)
+- HTTP Endpoints: `/health`, `/status`, `/metrics`
+
+Start im RED-Stack:
+
 ```powershell
 docker compose -f infrastructure/compose/compose.red.yml up -d cdb_signal
-curl http://localhost:8005/health
 ```
 
-- Health-Endpoint: `http://localhost:8005/health`
-- Metrics: `http://localhost:8005/metrics` (Prometheus Format)
+## Key Config
 
-## 📊 Monitoring & Health
+- `SIGNAL_STRATEGY_ID`
+- `SIGNAL_SYMBOL`
+- `SIGNAL_ENTRY_LOOKBACK_MIN`
+- `SIGNAL_EXIT_LOOKBACK_MIN`
+- `SIGNAL_BREAKOUT_BUFFER`
+- `SIGNAL_MIN_MINUTES_BETWEEN_ENTRIES`
 
-| Endpoint  | Beschreibung                |
-|-----------|-----------------------------|
-| `/health` | JSON Status mit Timestamp   |
-| `/status` | Letztes Signal, Queue-Status|
-| `/metrics`| `signals_generated_total`, Latenzen |
+## Canonical References
 
-## 🧠 Logik / Features
-
-- Top-Mover Analyse (`TOP_N`, `LOOKBACK_MINUTES` aus `.env`)
-- Momentum-Score (prozentuale Veränderung, Volumenfilter)
-- Konfigurierbare Mindestliquidität (`SIGNAL_MIN_VOLUME`, optional)
-- Glitch-Schutz: Idle-Timeout (geplant, nicht implementiert — kein Publish auf `alerts` durch Signal-Service)
-
-## 🧾 Konfiguration
-
-| Variable               | Default | Beschreibung                    |
-|------------------------|---------|---------------------------------|
-| `LOOKBACK_MINUTES`     | `15`    | Candlestick-Fenster             |
-| `TOP_N`                | `5`     | Anzahl beobachteter Symbole     |
-| `SYMBOL_WHITELIST`     | `.env`  | Override für Symbolauswahl      |
-| `MAX_POSITION_PCT`     | `.env`  | Limit, das an Risk weitergereicht wird |
-| `REDIS_HOST/PORT`      | `redis/6379` | Pub/Sub Verbindung         |
-
-## 🧪 Tests & Validierung
-
-```powershell
-pytest backoffice/services/signal_engine/tests -q
-redis-cli -a $REDIS_PASSWORD monitor  # kurzfristig zum Trace
-```
-
-- Verweis auf `backoffice/docs/END_TO_END_TEST_GUIDE.md`
-
-## 🪶 Lizenz & Credits
-
-- Maintainer: Signal Squad (Claire de Binare Core Team)
-- Nutzung intern, Source proprietär
+- `services/signal/service.py`
+- `services/signal/config.py`
+- `knowledge/contracts/PRIMARY_BREAKOUT_V1.md`
+- `knowledge/contracts/PRIMARY_BREAKOUT_V1_VALIDATION.md`


### PR DESCRIPTION
## Scope
- reconcile root README to current-main operational truth
- review active README surfaces and update only where real drift existed
- keep slice strictly on active README/doc surfaces

## What changed
- README.md: rebuilt around current SSOT split, stage/LR separation, current-main landed clusters, active entrypoints and paths
- services/signal/README.md: removed stale team/backoffice language and aligned with current strategy-v1 and runtime surface
- services/risk/README.md: removed stale wording and aligned with fail-closed gate role + current topics/streams/runtime surface
- knowledge/contracts/README.md: replaced stale ownership/version narrative with current contract surface + SSOT boundaries

## Explicitly out of scope
- runtime code changes
- archive/historical/snapshot surface edits
- .codex* artifacts