### PR TITLE
docs: reconcile signal/risk runtime drift (#1635)

### DIFF
--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -42,7 +42,7 @@ Claire de Binare ist ein **event-getriebenes Krypto-Trading-System** mit:
 |---------|-----------|------|----------|
 | PostgreSQL | cdb_postgres | 5432 | Persistenz |
 | Redis | cdb_redis | 6379 | Cache, Pub/Sub, Streams |
-| Market | cdb_market | 8009 | market_state:{symbol} Owner; Redis-subscription mit Retry/Reconnect, /health fail-closed bei Redis-Ausfall |
+| Market | cdb_market | 8009 | market_state:{symbol} Owner |
 | Candles | cdb_candles | 8007 | Tick→1-min Candle Aggregation |
 | Regime | cdb_regime | 8008 | ADX/ATR Regime Classification |
 | Allocation | cdb_allocation | 8006 | Regime→Allocation Mapping |
@@ -56,13 +56,15 @@ Claire de Binare ist ein **event-getriebenes Krypto-Trading-System** mit:
 | Service | Container | Port | Funktion |
 |---------|-----------|------|----------|
 | WebSocket | cdb_ws | 8000 | MEXC Market Data Stream |
-| Signal | cdb_signal | 8005 | Signal Generation (`primary_breakout_v1` footprint + `momentum_builtin` via static adapter boundary) |
+| Signal | cdb_signal | 8005 (Runtime) | Signal Generation |
 | Prometheus | cdb_prometheus | 19090→9090 | Metrics |
 | Grafana | cdb_grafana | 3000 | Dashboards |
 | Postgres Exporter | cdb_postgres_exporter | 9187 | PG Metrics |
 | Redis Exporter | cdb_redis_exporter | 9121 | Redis Metrics |
 | cAdvisor | cdb_cadvisor | — | Container Metrics |
 | Reports | cdb_reports | — | Daily Order Summary |
+
+Hinweis: `services/signal/config.py` hat `SIGNAL_PORT`-Default `8001`; der kanonische Runtime-Port ist `8005`, weil `infrastructure/compose/compose.red.yml` fuer `cdb_signal` `SIGNAL_PORT=8005` setzt.
 
 ### Logging Overlay (logging.yml) — separates Overlay, nicht Teil des Standard-BLUE/RED-Starts
 
@@ -132,14 +134,6 @@ cdb_reports           Up (healthy)
 - `ORDER_PLACED` - Order an Exchange gesendet
 - `POSITION_OPENED` - Position eroeffnet
 
-### Strategy-v1 Runtime Boundaries (current main)
-- **Signal**: traegt den minimalen `primary_breakout_v1`-Pfad (entry/exit/cooldown) und den bestehenden `momentum_builtin`-Pfad; die Strategieauswahl erfolgt ueber `SIGNAL_STRATEGY_ID`, die Adaptergrenze bleibt statisch/repo-owned (`SIGNAL_ADAPTER_ID`), ohne Plugin-Discovery.
-- **Execution**: waehlt statisch zwischen `mock_builtin` und `mexc_builtin` (`EXECUTION_ADAPTER_ID`) und bleibt fail-closed bei unbekannter Adapter-ID.
-- **Risk**: bleibt zentrale Core-Grenze fuer Decision-, Run-Mode- und Policy-Logik; keine Adapter-Selektion umgeht diese Grenze.
-- **Persistence**: `cdb_db_writer` bleibt kanonischer Persistenzpfad fuer Runtime-Events; Validation-/Replay-Artefakte sind davon getrennt.
-- **Deterministischer Validation-Pfad**: `core/replay/historical_bridge.py` + `services/validation/strategy_backtest_runner.py` bilden den repo-backed Backtest-/Validation-Pfad fuer `primary_breakout_v1`.
-- **Unit-/Scale-Canon**: aktive Market-State-/Signal-/Risk-Surfaces fuehren Prozentpunkt-Semantik (`3.0 == 3%`) als current-main-Contract.
-
 ---
 
 ## 5. Invariants (nicht verhandelbar)
@@ -150,7 +144,6 @@ cdb_reports           Up (healthy)
 4. **Determinismus**: Reproduzierbare Ergebnisse via Event Replay
 5. **TLS Optional**: Aktivierbar via `-TLS` Flag (Redis + PostgreSQL)
 6. **Localhost Binding**: Alle Ports auf 127.0.0.1 (keine externe Exposition)
-7. **Static Adapter Selection**: Strategy-/Execution-Selection ist statisch und repo-owned; keine dynamische Adapter-Discovery
 
 ---
 
@@ -184,5 +177,4 @@ Legacy-Layer (base.yml, dev.yml, tls.yml, etc.) existieren noch, sind nicht mehr
 | 2026-03-29 | market_data Subscriber-Liste: cdb_market, cdb_candles, cdb_paper_runner ergaenzt (#1323) | Claude |
 | 2026-03-29 | BLUE/RED reconciliation: alle Services nach Compose-Realitaet, Known Drifts bereinigt, Compose-Referenzen aktualisiert (#1302) | Claude |
 | 2026-04-01 | Logging Overlay: Aktivierungsspalte auf compose-Datei-Referenz umgestellt (war: -Logging Flag); Compose-Referenzblock präzisiert (#1409) | Claude |
-| 2026-04-11 | Strategy-v1 Drift-Batch nach #1598/#1600/#1602/#1613: Signal-/Execution-Boundary, deterministischer Replay-/Validation-Pfad und Unit-/Scale-Canon auf current-main nachgezogen | Codex |
-| 2026-04-11 | Market runtime reconcile nach #1630: Redis-Reconnect-Verhalten und fail-closed /health-Semantik fuer `cdb_market` dokumentiert | Codex |
+| 2026-04-11 | Signal-Port-Semantik präzisiert: Config-Default `SIGNAL_PORT=8001`, kanonischer Runtime-Port `8005` via `compose.red.yml` | Codex |

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -25,13 +25,13 @@
 
 | Service | Container | Port | Code | Status | Funktion |
 |---------|-----------|------|------|--------|----------|
-| **Market** | cdb_market | 8009 | services/market/ | **AKTIV** | market_state:{symbol} Owner; Redis-subscription mit Retry/Reconnect, /health fail-closed bei Redis-Ausfall (Issue #1201) |
+| **Market** | cdb_market | 8009 | services/market/ | **AKTIV** | market_state:{symbol} Owner (Issue #1201) |
 | **Candles** | cdb_candles | 8007 | services/candles/ | **AKTIV** | Tick→1-min Candle Aggregation |
 | **Regime** | cdb_regime | 8008 | services/regime/ | **AKTIV** | ADX/ATR Regime Classification |
 | **Allocation** | cdb_allocation | 8006 | services/allocation/ | **AKTIV** | Regime→Allocation Mapping |
-| **Risk** | cdb_risk | 8002 | services/risk/ | **AKTIV** | Zentrale Decision-/Run-Mode-/Policy-Grenze (Risk Gate, Circuit Breaker, Kill-Switch) |
-| **Execution** | cdb_execution | 8003 | services/execution/ | **AKTIV** | Order Execution ueber statische Adapter-Selektion (`mock_builtin`/`mexc_builtin`) |
-| **DB Writer** | cdb_db_writer | — | services/db_writer/ | **AKTIV** | Kanonische Redis→PostgreSQL Persistenz (`signals`/`orders`/`order_results`/`portfolio_snapshots`) |
+| **Risk** | cdb_risk | 8002 | services/risk/ | **AKTIV** | Risk Gate, Circuit Breaker, Kill-Switch |
+| **Execution** | cdb_execution | 8003 | services/execution/ | **AKTIV** | Order Execution (MOCK_TRADING=true default) |
+| **DB Writer** | cdb_db_writer | — | services/db_writer/ | **AKTIV** | Redis→PostgreSQL Persistenz |
 | **Paper Runner** | cdb_paper_runner | 8004 | tools/paper_trading/ | **AKTIV** | Paper Trading Orchestrator |
 
 ### RED Stack (compose.red.yml) — Signal + Monitoring, failure-isolated from BLUE
@@ -39,31 +39,10 @@
 | Service | Container | Port | Code | Status | Funktion |
 |---------|-----------|------|------|--------|----------|
 | **WebSocket** | cdb_ws | 8000 | services/ws/ | **AKTIV** | MEXC Market Data Stream (protobuf) |
-| **Signal** | cdb_signal | 8005 | services/signal/ | **AKTIV** | Signal Generation mit minimalem `primary_breakout_v1`-Footprint und `momentum_builtin` ueber statische Adapter-Grenze |
+| **Signal** | cdb_signal | 8005 (Runtime) | services/signal/ | **AKTIV** | Signal Generation (`primary_breakout_v1` default, `momentum_builtin` statische Adapter-Grenze) |
 | **Reports** | cdb_reports | — | services/reports/ | **AKTIV** | Daily Order Summary + Email |
 
----
-
-## Validation / Replay Surface (current main)
-
-| Surface | Code | Status | Funktion |
-|---------|------|--------|----------|
-| **Replay Historical Bridge** | core/replay/historical_bridge.py | **BEREIT** | Deterministischer 1m-BTCUSDT Input-Bridge fuer `primary_breakout_v1` |
-| **Strategy Backtest Runner** | services/validation/strategy_backtest_runner.py | **BEREIT** | Deterministischer Validation-Runner mit schema-basiertem Gate-Report |
-
-Hinweis: Diese Surfaces sind im Code nutzbar, werden aber nicht als eigenstaendige Compose-Services deployed. Sie sind Validation-/Replay-Pfade und keine Runtime-Publisher fuer die Persistenzkanaele des DB Writers.
-
----
-
-## Service Ownership Boundaries (current main, kanonisch)
-
-- **Signal**: erzeugt Signalkandidaten (`primary_breakout_v1` + `momentum_builtin`) ueber statische, repo-owned Adapterwahl; keine Plugin-Discovery.
-- **Market**: konsumiert `market_data` via Redis Pub/Sub mit Retry/Reconnect; solange Redis/Subscription fehlt, bleibt die Health-Surface fail-closed (`503 degraded`).
-- **Execution**: fuehrt nur bereits risk-gegate-te Orders aus; Adapter-Selektion statisch/fail-closed (`EXECUTION_ADAPTER_ID`).
-- **Risk**: bleibt zentrale Entscheidungsgrenze fuer Run-Mode, Decision, Thresholds und Policy-Kontext.
-- **DB Writer**: bleibt reine Persistenzschicht; keine Vermischung mit Validation- oder Replay-Gating.
-- **Replay/Validation**: historischer Bridge + Backtest-Runner als separater deterministischer Validationspfad.
-- **Unit-/Scale-Canon**: aktive Surfaces nutzen Prozentpunkt-Semantik fuer die betroffenen Return-/Pct- und Schwellenfelder (`3.0 == 3%`).
+Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.py` bei `8001`; im kanonischen RED-Runtime-Pfad wird fuer `cdb_signal` in `infrastructure/compose/compose.red.yml` explizit `SIGNAL_PORT=8005` gesetzt.
 
 ---
 
@@ -171,5 +150,5 @@ docker compose -f infrastructure/compose/compose.red.yml up -d
 | 2025-12-28 | Signal Service aktiviert: cdb_core → cdb_signal (Port 8005) | Claude |
 | 2026-03-29 | BLUE/RED-Split reconciliation: market/candles/regime/allocation→AKTIV, Exporter/Reports/Alertmanager ergänzt, Image-Versionen aktualisiert, Compose-Referenzen auf compose.blue/red.yml (#1302) | Claude |
 | 2026-04-01 | Logging Overlay: Status AKTIV→OVERLAY für Loki/Promtail/Alertmanager; Status-Definition OVERLAY ergänzt; Aktivierungsbefehl explizit; Compose-Architektur-Notation präzisiert (#1409) | Claude |
-| 2026-04-11 | Strategy-v1 Drift-Batch nach #1598/#1600/#1602/#1613: Service-Boundaries fuer Signal/Execution/Risk/DB Writer sowie Replay-/Validation-Surfaces current-main-wahr nachgezogen | Codex |
-| 2026-04-11 | Runtime-reconcile nach #1630: Market-Service-Beschreibung auf Redis-Retry/Reconnect und fail-closed Health-Semantik nachgezogen | Codex |
+| 2026-04-11 | Signal-Port-Semantik präzisiert: Config-Default `SIGNAL_PORT=8001`, kanonischer Runtime-Port `8005` via `compose.red.yml` | Codex |
+| 2026-04-11 | Signal/Risk Runtime-Drift bereinigt: Signal-Strategie-/Stream-Semantik und Risk-Input-/Metric-Semantik auf current-main präzisiert | Codex |

--- a/services/risk/README.md
+++ b/services/risk/README.md
@@ -20,6 +20,7 @@ Deterministischer, fail-closed Risk-Gate-Service zwischen Signal und Execution.
 
 - Endpoint-Port: `RISK_PORT` (Default `8002`)
 - HTTP Endpoints: `/health`, `/status`, `/metrics`
+- Relevante Metrics: `signals_received_total`, `orders_blocked_total`, `risk_alerts_generated_total`
 
 Start im BLUE-Stack:
 
@@ -30,7 +31,7 @@ docker compose -f infrastructure/compose/compose.blue.yml up -d cdb_risk
 ## Key Config
 
 - `MAX_POSITION_PCT`
-- `MAX_TOTAL_EXPOSURE_PCT` / `MAX_EXPOSURE_PCT`
+- `MAX_TOTAL_EXPOSURE_PCT` / `MAX_EXPOSURE_PCT` (Default effektiv `0.30`)
 - `MAX_DAILY_DRAWDOWN_PCT`
 - `EARLY_LIVE_MAX_ALLOC`
 - `USE_LIVE_BALANCE`, `USE_REAL_BALANCE`

--- a/services/signal/README.md
+++ b/services/signal/README.md
@@ -17,7 +17,7 @@ Event-getriebene Signal-Erzeugung aus `market_data` mit statischer Adapter-Grenz
 
 ## Runtime Surface
 
-- Endpoint-Port: `SIGNAL_PORT` (Default `8001`)
+- Endpoint-Port: `SIGNAL_PORT` (Config-Default `8001`; RED-Runtime `8005` via `compose.red.yml`)
 - HTTP Endpoints: `/health`, `/status`, `/metrics`
 
 Start im RED-Stack:
@@ -34,6 +34,7 @@ docker compose -f infrastructure/compose/compose.red.yml up -d cdb_signal
 - `SIGNAL_EXIT_LOOKBACK_MIN`
 - `SIGNAL_BREAKOUT_BUFFER`
 - `SIGNAL_MIN_MINUTES_BETWEEN_ENTRIES`
+- `SIGNAL_OUTPUT_STREAM`
 
 ## Canonical References
 


### PR DESCRIPTION
## Summary
- align services/signal README with current strategy/runtime (primary_breakout_v1, stream.signals, SIGNAL_PORT semantics)
- align services/risk README with current topics/streams/metrics/config defaults
- reconcile architecture/governance docs for signal runtime wording and port semantics
- remove obsolete backoffice references from active service docs

## Context
Follow-up to issue #1635 (drift between runtime/service docs and current main).