### PR TITLE
docs(github): close #1659 residual control-plane gaps

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -139,7 +139,6 @@ This folder and its docs make it navigable.
 
 | Command file | Backing workflow |
 |---|---|
-| `commands/gemini-dispatch.toml` | `gemini-dispatch.yml` |
 | `commands/gemini-invoke.toml` | `gemini-invoke.yml` (reusable) |
 | `commands/gemini-review.toml` | `gemini-review.yml` (reusable) |
 | `commands/gemini-scheduled-triage.toml` | `gemini-scheduled-triage.yml` (parked) |

--- a/.github/README.md
+++ b/.github/README.md
@@ -147,6 +147,34 @@ This folder and its docs make it navigable.
 
 ---
 
+## Issue templates as control-plane surface (in scope)
+
+Issue templates are not decorative text files; they are part of the `.github` control plane because they define intake shape, governance expectations, and downstream label/state signals.
+
+| Template family | Files | Role in control plane |
+|---|---|---|
+| Intake-first | `bug_report.yml`, `feature_request.yml` | Captures problem/request intake; may later be promoted to tracked work |
+| Tracked-work | `task.yml`, `live-readiness.yml` | Implementation/gate-oriented intake with explicit closure + bookkeeping contract |
+| Governance-heavy / meta | `standard.md`, `meta_cluster.md`, `meta_phase.md`, `meta_tracking.md`, `meta_governance.md` | Coordination/policy framing with merge-gated closure semantics and governance obligations |
+| Template config | `config.yml` | Controls issue-template UX and contact links |
+
+**Intake-only vs tracked/governance-heavy**
+- Intake-only forms can remain discussion/intake artifacts.
+- Tracked-work and governance-heavy forms explicitly define merge-gated closure and bookkeeping expectations.
+
+**Relation to PR/merge closure semantics**
+- Template text defines that issue closure is tied to merged target-branch reality.
+- This is a governance contract for humans/reviewers; workflows do not currently parse template files directly at runtime.
+
+**Relation to bookkeeping/governance expectations**
+- Tracked templates carry checklist expectations (status sync, ledger hygiene, control-surface updates when relevant).
+- These expectations align with `pull_request_template.md`, `docs/governance/GITHUB_CONTROL_PLANE_SEAL.md`, and the operational runbooks.
+
+**Relation to workflows, root files, and governance surfaces**
+- Issue-event workflows consume issue labels/state shaped at intake (routing, project sync, triage).
+- Root governance files (`CODEOWNERS`, `pull_request_template.md`, `SECURITY.md`, labels/milestones docs) provide adjacent policy rails.
+- Relationship model and boundaries: `docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md` (§ `Workflow → Issue Template Relationships`).
+
 ## Root-file reference
 
 | File | Purpose |

--- a/docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md
+++ b/docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md
@@ -41,7 +41,6 @@ This document maps the dependency and coupling relationships across the `.github
 
 | Workflow | Command file(s) |
 |---|---|
-| `gemini-dispatch.yml` | `commands/gemini-dispatch.toml` |
 | `gemini-invoke.yml` (reusable) | `commands/gemini-invoke.toml` |
 | `gemini-review.yml` (reusable) | `commands/gemini-review.toml` |
 | `gemini-triage.yml` (reusable) | `commands/gemini-triage.toml` |
@@ -101,10 +100,9 @@ graph TD
     end
 
     subgraph "Commands"
-        C1[gemini-dispatch.toml]
-        C2[gemini-invoke.toml]
-        C3[gemini-review.toml]
-        C4[gemini-triage.toml]
+        C1[gemini-invoke.toml]
+        C2[gemini-review.toml]
+        C3[gemini-triage.toml]
     end
 
     subgraph "Output Surfaces"
@@ -167,10 +165,9 @@ graph TD
     S2 --> P1
 
     %% Command connections
-    GD --> C1
-    GI --> C2
-    GR --> C3
-    GT --> C4
+    GI --> C1
+    GR --> C2
+    GT --> C3
 
     %% Gemini call chain
     GD -- workflow_call --> GI

--- a/docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md
+++ b/docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md
@@ -65,6 +65,23 @@ This document maps the dependency and coupling relationships across the `.github
 
 ---
 
+## 4a. Workflow → Issue Template Relationships
+
+This section models the `workflow -> issue template` relationship in three explicit classes to avoid fake runtime edges.
+
+**Runtime fact (repo scan):** no workflow YAML currently references `.github/ISSUE_TEMPLATE/*` directly.
+
+| Coupling class | Repo-true status | Workflow side | Template side |
+|---|---|---|---|
+| **Direct runtime coupling** | **None at present** | No workflow reads template files at runtime | Templates are rendered by GitHub UI, not by workflow steps |
+| **Governance/intake coupling** | **Present** | Issue-event flows consume issue labels/state created at intake (`issues` triggers like `auto-milestone*`, `project_status_*`, `control_board_auto_routing`, `triage_guard`, `add_to_project`) | Intake forms (`bug_report.yml`, `feature_request.yml`, `task.yml`, `live-readiness.yml`) pre-shape labels/scope and therefore downstream routing |
+| **Policy/bookkeeping coupling (human gate)** | **Present** | Workflows do not enforce merge-gated closure/bookkeeping checklists by themselves | Governance-heavy templates (`standard.md`, `meta_cluster.md`, `meta_phase.md`, `meta_tracking.md`, `meta_governance.md`) define closure/bookkeeping expectations that operators apply during PR/issue handling |
+| **No direct runtime relationship** | **Explicitly true for most non-issue workflows** | `push` / `pull_request` / `schedule` / `workflow_call` flows execute independently of template files | Templates do not alter those runtime paths unless issue metadata later enters workflow triggers |
+
+**Fail-closed interpretation:** do not infer template-enforcement automation where no direct runtime edge exists. Treat template semantics as governance contract unless a workflow explicitly parses/enforces them.
+
+---
+
 ## 5. Mermaid: Coupling Graph
 
 ```mermaid
@@ -317,5 +334,6 @@ Legacy copy of `ci.yml`. Coexists silently. Risk of accidental activation. Shoul
 - `.github/README.md` — canonical entrypoint
 - `docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md` — how to read and debug workflows
 - `docs/runbooks/GITHUB_WORKFLOW_REGISTER.md` — full 65-workflow register
+- `docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md` § "Issue templates as control-plane surface" — intake/policy depth
 - `.github/control-plane/README.md` — manifest collection layer
 - `docs/runbooks/CONTROL_REGISTER.md` — board stage, LR verdict, active infra list

--- a/docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md
+++ b/docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md
@@ -40,6 +40,33 @@ Layer 4: Documentation (introduced #1640)
 
 ---
 
+## 1a. Issue templates as control-plane surface
+
+Issue templates under `.github/ISSUE_TEMPLATE/` are in-scope control-plane assets, not passive docs.
+
+| Family | Files | Operational meaning |
+|---|---|---|
+| Intake-first | `bug_report.yml`, `feature_request.yml` | Initial intake surface; may remain intake-only |
+| Tracked-work | `task.yml`, `live-readiness.yml` | Work contract surface with explicit closure/bookkeeping expectations |
+| Governance-heavy / meta | `standard.md`, `meta_cluster.md`, `meta_phase.md`, `meta_tracking.md`, `meta_governance.md` | Coordination/policy framing for issue lifecycle and decision gates |
+| Config | `config.yml` | Template UX and routing links |
+
+**Runtime boundary (important):**
+- Workflows do not currently read `.github/ISSUE_TEMPLATE/*` files directly.
+- Template semantics therefore act as governance/intake contract first, runtime coupling second (via issue metadata and labels after issue creation).
+
+**How templates connect to workflows and merge semantics:**
+1. Templates shape labels/scope/state at intake.
+2. Issue-event workflows consume that state for routing/label/project automation.
+3. Merge-gated closure/bookkeeping expectations are enforced by human review and governance process, not by implicit workflow parsing.
+
+Cross-reference:
+- `docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md` (`Workflow -> Issue Template Relationships`)
+- `.github/README.md` (`Issue templates as control-plane surface (in scope)`)
+- `docs/runbooks/GITHUB_WORKFLOW_REGISTER.md` (`#1640 minimum-field coverage model`)
+
+---
+
 ## 2. How to Read a Workflow Safely
 
 For every workflow you open, extract these fields in order:

--- a/docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
+++ b/docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
@@ -67,6 +67,9 @@ If a field cannot be resolved from row + profile + override, treat it as **not s
 - `perm:w-security` — includes `security-events:write`
 - `perm:oidc` — includes `id-token:write`
 - `perm:models-read` — includes `models:read`
+- `perm:checks-read` — includes `checks:read`
+- `perm:actions-read` — includes `actions:read`
+- `perm:pr-read` — includes `pull-requests:read`
 - `perm:implicit` — no explicit top-level permissions block (evaluate YAML/job-level scopes directly)
 
 **Primary-input profiles**
@@ -115,7 +118,7 @@ Only entries that differ materially from their group baseline are listed.
 | `claude.yml` | `perm:oidc` | — |
 | `claude-code-review.yml` | `perm:oidc` | — |
 | `opencode.yml` | `perm:oidc` | — |
-| `gemini-dispatch.yml` | `perm:implicit` | `in:command:gemini-dispatch.toml` |
+| `gemini-dispatch.yml` | `perm:implicit` | — |
 | `gemini-invoke.yml` | `perm:w-issues`, `perm:w-pr`, `perm:oidc` | `in:wcall`, `in:command:gemini-invoke.toml` |
 | `gemini-review.yml` | `perm:w-issues`, `perm:w-pr`, `perm:oidc` | `in:wcall`, `in:command:gemini-review.toml` |
 | `gemini-triage.yml` | `perm:w-issues`, `perm:w-pr`, `perm:oidc` | `in:wcall`, `in:command:gemini-triage.toml` |
@@ -128,11 +131,11 @@ Only entries that differ materially from their group baseline are listed.
 | `bulk-issue-labeling.yml` | `perm:w-issues` | — |
 | `comprehensive-issue-labeling.yml` | `perm:w-issues` | — |
 | `milestone-assignment.yml` | `perm:w-issues` | — |
-| `required-checks-audit.yml` | `checks:read` (plus read-only scopes) | — |
-| `governance-audit.yml` | `actions:read` (plus read-only scopes) | — |
+| `required-checks-audit.yml` | `perm:checks-read` (plus read-only scopes) | — |
+| `governance-audit.yml` | `perm:actions-read` (plus read-only scopes) | — |
 | `ai-review-router.yml` | `perm:w-pr` | — |
 | `smart-insights.yml` | `perm:implicit` | — |
-| `delivery-gate.yml` | `pull-requests:read` (plus read-only scopes) | — |
+| `delivery-gate.yml` | `perm:pr-read` (plus read-only scopes) | — |
 | `docker-publish.yml` | `perm:w-packages` | — |
 | `gitleaks.yml` | `perm:w-security` | — |
 | `trivy.yml` | `perm:w-security` | — |
@@ -203,7 +206,7 @@ AI-backed review, triage, agent invocation, emoji automation, and MCP runtime.
 | `claude.yml` | aktiv | PR, issues | Invoke Claude AI for issue/PR assistance | — | Issue/PR comment from Claude | O | AI-assisted; review response |
 | `claude-code-review.yml` | aktiv | PR | Claude automated code review on PRs | — | PR review comment | O | Review AI feedback |
 | `opencode.yml` | aktiv | PRcomment | Invoke OpenCode AI on PR review comment | — | PR follow-up comment | O | Review AI feedback |
-| `gemini-dispatch.yml` | aktiv | dispatch | Dispatch Gemini AI tasks (routes to invoke/review/triage) | `commands/gemini-dispatch.toml` | Routes to reusable Gemini flow | O | Manual trigger |
+| `gemini-dispatch.yml` | aktiv | dispatch | Dispatch Gemini AI tasks (routes to invoke/review/triage) | — | Routes to reusable Gemini flow | O | Manual trigger |
 | `gemini-invoke.yml` | aktiv | wcall | **Reusable:** Invoke Gemini AI on issue/PR | `commands/gemini-invoke.toml` | Issue/PR comment from Gemini | O | Called via gemini-dispatch |
 | `gemini-review.yml` | aktiv | wcall | **Reusable:** Gemini AI code review | `commands/gemini-review.toml` | PR review comment | O | Called via gemini-dispatch |
 | `gemini-triage.yml` | aktiv | wcall | **Reusable:** Gemini AI issue triage + labeling | `commands/gemini-triage.toml` | Issue labels + triage comment | O | Called via gemini-dispatch |

--- a/docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
+++ b/docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
@@ -21,10 +21,123 @@
 | **Status** | `aktiv` / `manual-only` / `parked` / `historisch` |
 | **Trigger(s)** | Abbreviated: `push`, `PR`, `sched`, `dispatch`, `wrun` (workflow_run), `wcall` (workflow_call), `issues`, `PRcomment` |
 | **Purpose** | One-line description |
-| **Scripts / Prompts** | Supporting files from `.github/scripts/` or `.github/prompts/` |
-| **Key outputs** | What it mutates or produces |
+| **Scripts / Prompts** | Supporting files from `.github/scripts/`, `.github/prompts/`, or `.github/commands/` where applicable |
+| **Key outputs** | Primary outputs / artifacts / mutation surfaces |
 | **FP** | Fail posture: `C` = fail-closed (blocks CI/merge), `O` = fail-open (advisory) |
 | **HT** | Human touchpoint |
+
+---
+
+## #1640 minimum-field coverage model (repo-true, fail-closed)
+
+This register intentionally uses a compact two-layer model:
+1. **Workflow row layer** (`File`, `Purpose`, `Trigger(s)`, support links, outputs/mutations, `FP`, `HT`)
+2. **Profile layer** (permissions, primary inputs, owner/canon) with explicit defaults + explicit overrides
+
+If a field cannot be resolved from row + profile + override, treat it as **not satisfied** and inspect the workflow YAML directly before making governance claims.
+
+| #1640 minimum field | Where modeled |
+|---|---|
+| file path | `File` column |
+| purpose | `Purpose` column |
+| trigger(s) | `Trigger(s)` column |
+| permissions | Profile layer below (`perm:*`) + workflow override table |
+| primary inputs | Profile layer below (`in:*`) + workflow override table |
+| primary outputs / artifacts | `Key outputs` column |
+| linked prompts / scripts / commands | `Scripts / Prompts` column |
+| linked issues / project surfaces / labels / comments / repo mutations | `Key outputs` column (surface terms) |
+| fail posture | `FP` column |
+| human touchpoint | `HT` column |
+| owner / canonical doc link | Register-wide defaults below |
+
+### Register-wide defaults (all workflow entries)
+
+- **Owner:** `@jannekbuengener` via `.github/CODEOWNERS`
+- **Canonical doc set:** `.github/README.md`, this register, `docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md`, `docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md`
+- **Human review rule:** merge/closure decisions are human-gated; no automatic acceptance inference from this document alone
+
+### Permission and primary-input profiles
+
+**Permission profiles**
+- `perm:r` — explicit read-only scopes (or no explicit write scopes)
+- `perm:w-issues` — includes `issues:write`
+- `perm:w-pr` — includes `pull-requests:write`
+- `perm:w-contents` — includes `contents:write`
+- `perm:w-packages` — includes `packages:write`
+- `perm:w-security` — includes `security-events:write`
+- `perm:oidc` — includes `id-token:write`
+- `perm:models-read` — includes `models:read`
+- `perm:implicit` — no explicit top-level permissions block (evaluate YAML/job-level scopes directly)
+
+**Primary-input profiles**
+- `in:event` — GitHub event payload for declared trigger
+- `in:dispatch` — explicit `workflow_dispatch` inputs
+- `in:schedule` — cron/time-based trigger input
+- `in:wrun` / `in:wcall` — upstream workflow context
+- `in:labels-spec` — `.github/workflows/labels.json`
+- `in:script:*` / `in:prompt:*` / `in:command:*` — linked support artifacts
+- `in:control-register` — `docs/runbooks/CONTROL_REGISTER.md` consumed at runtime
+
+### Group baselines (inherit unless overridden below)
+
+| Group | Permission baseline | Primary-input baseline |
+|---|---|---|
+| Group 1 Reconcile | `perm:r` | `in:event` / `in:dispatch` / `in:schedule` |
+| Group 2 CI / Quality | `perm:r` | `in:event` / `in:dispatch` / `in:schedule` |
+| Group 3 Spezialpfad / AI / Agent | `perm:r` | `in:event` / `in:dispatch` |
+| Group 4 Hygiene | `perm:r` | `in:event` / `in:dispatch` / `in:schedule` |
+| Group 5 Reporting / Control | `perm:r` | `in:event` / `in:dispatch` / `in:schedule` |
+| Group 6 Audit / Governance | `perm:r` | `in:event` / `in:dispatch` / `in:schedule` |
+| Group 7 Delivery / Gates | `perm:r` | `in:event` / `in:dispatch` / `in:schedule` |
+| Group 8 Security | `perm:r` | `in:event` / `in:dispatch` / `in:schedule` |
+| Group 9 Historisch / Unklar | `perm:r` | `in:event` / `in:dispatch` |
+
+### Workflow-specific permission/input overrides
+
+Only entries that differ materially from their group baseline are listed.
+
+| Workflow | Permission override | Primary-input override |
+|---|---|---|
+| `sync-labels.yml` | `perm:w-issues` | `in:labels-spec` |
+| `label-bootstrap.yml` | `perm:w-issues`, `perm:w-pr` | `in:labels-spec` |
+| `auto-label.yml` | `perm:w-issues` | — |
+| `auto-milestone.yml` | `perm:w-issues` | — |
+| `auto-milestone-label-dispatch.yml` | `perm:w-contents` | — |
+| `auto-milestone-pr-apply.yml` | `perm:w-issues` | `in:wrun` |
+| `control_board_auto_routing.yml` | `perm:w-issues` | — |
+| `control-board-routing-label-dispatch.yml` | `perm:w-contents` | — |
+| `cdb-daily-delta-triage.yml` | `perm:w-issues` | `in:script:daily_delta_triage.py`, `in:control-register` |
+| `cdb-weekly-control-hygiene-classifier.yml` | `perm:w-issues` | `in:script:weekly_control_hygiene_classifier.py` |
+| `cdb-post-merge-followup-scanner.yml` | `perm:w-issues`, `perm:models-read` | `in:script:post_merge_followup_scanner.py`, `in:prompt:cdb-control-followup.prompt.yml` |
+| `cdb-control-followup-classifier.yml` | `perm:w-issues`, `perm:models-read` | `in:script:run_cdb_control_followup.sh`, `in:prompt:cdb-control-followup.prompt.yml` |
+| `weekly_digest.yml` | `perm:implicit` | — |
+| `weekly_digest_failure_alert.yml` | `perm:w-issues` | `in:wrun` |
+| `claude.yml` | `perm:oidc` | — |
+| `claude-code-review.yml` | `perm:oidc` | — |
+| `opencode.yml` | `perm:oidc` | — |
+| `gemini-dispatch.yml` | `perm:implicit` | `in:command:gemini-dispatch.toml` |
+| `gemini-invoke.yml` | `perm:w-issues`, `perm:w-pr`, `perm:oidc` | `in:wcall`, `in:command:gemini-invoke.toml` |
+| `gemini-review.yml` | `perm:w-issues`, `perm:w-pr`, `perm:oidc` | `in:wcall`, `in:command:gemini-review.toml` |
+| `gemini-triage.yml` | `perm:w-issues`, `perm:w-pr`, `perm:oidc` | `in:wcall`, `in:command:gemini-triage.toml` |
+| `gemini-scheduled-triage.yml` | `perm:w-issues`, `perm:w-pr`, `perm:oidc` | `in:command:gemini-scheduled-triage.toml` |
+| `emoji-filter.yml` | `perm:w-issues` | `in:script:advanced-emoji-filter.py` |
+| `emoji-bot.yml` | `perm:w-contents` | `in:script:advanced-emoji-filter.py` |
+| `e2e-tests.yml` | `perm:w-issues` | — |
+| `root-session-hygiene-warning.yml` | — | `in:script:root_session_hygiene_warn.py` |
+| `copilot-housekeeping.yml` | `perm:w-issues`, `perm:w-pr` | — |
+| `bulk-issue-labeling.yml` | `perm:w-issues` | — |
+| `comprehensive-issue-labeling.yml` | `perm:w-issues` | — |
+| `milestone-assignment.yml` | `perm:w-issues` | — |
+| `required-checks-audit.yml` | `checks:read` (plus read-only scopes) | — |
+| `governance-audit.yml` | `actions:read` (plus read-only scopes) | — |
+| `ai-review-router.yml` | `perm:w-pr` | — |
+| `smart-insights.yml` | `perm:implicit` | — |
+| `delivery-gate.yml` | `pull-requests:read` (plus read-only scopes) | — |
+| `docker-publish.yml` | `perm:w-packages` | — |
+| `gitleaks.yml` | `perm:w-security` | — |
+| `trivy.yml` | `perm:w-security` | — |
+| `security-scan.yml` | `perm:w-security` | — |
+| `stale.yml` | `perm:implicit` | — |
 
 ---
 


### PR DESCRIPTION
## Scope
- Implements only the documented residual slice from #1659.
- No side-track changes (`CURRENT_STATUS.md`, session logs, `#1645` hygiene) included.
- No workflow logic/runtime behavior changed; docs/control-plane canon only.

## Exact changed files
- `.github/README.md`
- `docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md`
- `docs/runbooks/GITHUB_WORKFLOW_REGISTER.md`
- `docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md`

## #1659 residual gaps closed

### A) Register minimum fields
- Added a strict `#1640` minimum-field coverage model in `GITHUB_WORKFLOW_REGISTER.md`.
- Added explicit modeling for permissions and primary inputs via profile defaults + workflow-specific overrides.
- Made owner/canonical linkage explicit (`CODEOWNERS` + canon docs) and documented fail-closed resolution when fields are ambiguous.
- Clarified primary outputs/mutation-surface semantics and support-link scope (scripts/prompts/commands).

### B) `workflow -> issue template` mapping
- Added an explicit relationship section in `GITHUB_CONTROL_PLANE_GRAPH.md`.
- Distinguished:
  - direct runtime coupling (currently none),
  - governance/intake coupling,
  - policy/bookkeeping coupling,
  - explicit no-direct-runtime cases.
- Added a fail-closed interpretation rule to avoid over-claiming automation coupling.

### C) Template-scope depth
- Added in-scope template-surface documentation to:
  - `.github/README.md`
  - `GITHUB_CONTROL_PLANE_RUNBOOK.md`
- Covered template families, intake-only vs tracked/governance-heavy usage, PR/merge closure semantics, bookkeeping expectations, and placement relative to workflows/root/governance surfaces.

## Validation
- Cross-checked consistency across README / runbook / register / graph after edits.
- Verified branch started from current `origin/main` (`f89984d1`) before applying this slice.
- Verified scope is limited to the four files above.

## Residual uncertainties (fail-closed)
- Issue-template closure/bookkeeping semantics remain a human governance contract; there is still no direct runtime parser/enforcer workflow for template files.
- Permission/input coverage is intentionally modeled via profile+override to stay maintainable; if row+profile is insufficient for a decision, workflow YAML remains the authority.
- `#1640` is intentionally **not** auto-closed here; closure should be decided only after merge and a fresh `main` check.

Closes #1659
Refs #1640
