### PR TITLE
governance: implement Option A and disable repo auto-merge (#1661)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -222,5 +222,8 @@ See `control-plane/README.md` for full usage.
 2. Sync duties for that class satisfied? (seal doc § 3)
 3. New or changed automation side effects declared in PR body?
 4. PR template `.github` section checked?
+5. Repo policy respected? Auto-merge is disabled repo-wide (`allow_auto_merge=false`), so do not use `gh pr merge --auto`.
+6. Final human review completed before merge for control-plane/meta/governance/closure-sensitive work.
+7. Closure semantics preserved? Merge state is not completion state; issue closure remains acceptance + merged-`main` based.
 
-Typo fixes and harmless comment updates (`doc-only`) only need rules 1 and 4.
+Typo fixes and harmless comment updates (`doc-only`) still require rules 1, 4, and 5.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,5 +23,10 @@
 - [ ] **Sync duties** checked per [seal policy](../docs/governance/GITHUB_CONTROL_PLANE_SEAL.md) § 3
 - [ ] **Side effects** — any new or changed automation outputs declared in Summary/Validation above
 
+## Merge / Closure Guardrails
+- [ ] No auto-merge used (`gh pr merge --auto` is forbidden in this repo)
+- [ ] Final human review completed before merge
+- [ ] `Closes #...` used only when acceptance is satisfied against merged `main` (`merge_state != completion_state`)
+
 ## Breaking Changes
 None / list

--- a/docs/governance/BRANCH_PROTECTION_LOG.md
+++ b/docs/governance/BRANCH_PROTECTION_LOG.md
@@ -4,6 +4,40 @@ This document records governance interventions on branch protection rules for au
 
 ---
 
+## 2026-04-12T11:35:24Z - Disable Repo Auto-Merge (Issue #1661, Option A)
+
+**Context:** Issue #1661 mandated Option A: disable GitHub Auto-Merge repo-wide to remove
+merge-state/closure-state race risk for control-plane, meta, governance, and other closure-sensitive work.
+
+**Action Taken:**
+```bash
+gh api repos/jannekbuengener/Claire_de_Binare \
+  --method PATCH \
+  --field allow_auto_merge=false
+```
+
+**Verification:**
+```bash
+gh api repos/jannekbuengener/Claire_de_Binare --jq '{"allow_auto_merge":.allow_auto_merge}'
+gh api graphql -f query='query { repository(owner:"jannekbuengener", name:"Claire_de_Binare") { autoMergeAllowed } }'
+```
+
+**Final State:**
+| Setting | Before | After |
+|---------|--------|-------|
+| `allow_auto_merge` | `true` | `false` |
+| `autoMergeAllowed` (GraphQL) | `true` | `false` |
+
+**Rationale:**
+- Control-plane/meta/governance and closure-sensitive PRs require deterministic final human review before merge.
+- Merge state must not be treated as completion proof; closure semantics remain acceptance + merged-`main` based.
+
+**Decision:** Repo-wide Auto-Merge is disabled and not allowed for this repository.
+
+**Approver:** jannekbuengener (repo owner)
+
+---
+
 ## 2026-04-08T12:16:03Z - Disable Code-Owner Review Self-Deadlock (PR #1505)
 
 **Context:** The repo still uses `.github/CODEOWNERS` with `* @jannekbuengener`, while `main` is operated in solo-maintainer mode with `required_approving_review_count: 0`.

--- a/docs/governance/GITHUB_CONTROL_PLANE_SEAL.md
+++ b/docs/governance/GITHUB_CONTROL_PLANE_SEAL.md
@@ -93,6 +93,13 @@ A `.github/` PR is merge-ready when **all** of the following are true:
 **Exception for `doc-only`:** A pure typo fix or comment clarification that changes no documented
 field satisfies merge-readiness by completing rules 1 and 7 only.
 
+### Global merge/closure guardrail (all classes)
+
+- Repo-wide GitHub Auto-Merge is disabled (`allow_auto_merge=false`); never use `gh pr merge --auto`.
+- `.github`, meta, governance, and closure-sensitive PRs are merged manually only after final human review.
+- Merge state is transport state only and must not replace completion/acceptance state.
+- `Closes #...` remains valid only when acceptance is satisfied against merged `main`.
+
 ---
 
 ## 5. Review Depth
@@ -119,7 +126,8 @@ Three lightweight, real enforcement paths:
 ### 6.1 PR Template Checklist (primary)
 
 `.github/pull_request_template.md` contains a `.github` control-plane section. Every PR author
-explicitly identifies the change class and confirms sync duties before merging.
+explicitly identifies the change class, confirms sync duties, and applies the merge/closure
+guardrails before merging.
 This is the day-to-day gate.
 
 ### 6.2 Collection Layer Validator (secondary)

--- a/docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md
+++ b/docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md
@@ -65,6 +65,13 @@ Cross-reference:
 - `.github/README.md` (`Issue templates as control-plane surface (in scope)`)
 - `docs/runbooks/GITHUB_WORKFLOW_REGISTER.md` (`#1640 minimum-field coverage model`)
 
+## 1b. Merge and closure guardrail (Option A / #1661)
+
+- Repo-wide GitHub Auto-Merge is disabled (`allow_auto_merge=false`).
+- Never use `gh pr merge --auto` in this repository.
+- For `.github`, meta, governance, and closure-sensitive PRs: merge manually only after final human review.
+- Merge state does not prove completion state; issue/PR closure semantics remain acceptance-first and merged-`main` based.
+
 ---
 
 ## 2. How to Read a Workflow Safely

--- a/docs/runbooks/merge_policy_ci_gate.md
+++ b/docs/runbooks/merge_policy_ci_gate.md
@@ -12,7 +12,7 @@ for the policy rationale.
 Merge-method guidance for proof/slice PRs is documented in
 [merge_strategy_squash_vs_merge.md](./merge_strategy_squash_vs_merge.md).
 
-## Current State (as of 2026-04-08)
+## Current State (as of 2026-04-12)
 
 - Repo Actions workflow permissions: `Read and write`
 - Canonical PR gate workflow: `.github/workflows/ci.yml` (`name: ci`)
@@ -22,6 +22,7 @@ Merge-method guidance for proof/slice PRs is documented in
 - Governance decision: the PR gate wins, not the larger workflow. `ci.yaml` is not merge-relevant until explicitly consolidated into the PR contract.
 - Live branch protection review settings: `required_approving_review_count=0`, `require_code_owner_reviews=false`, `dismiss_stale_reviews=true`
 - Live branch protection safety settings also include `required_linear_history=true`, `required_conversation_resolution=true`, `enforce_admins=true`
+- Repo-level auto-merge setting: `allow_auto_merge=false` (Option A, issue #1661)
 
 ## Review Signal vs Merge Rights
 
@@ -30,6 +31,7 @@ Merge-method guidance for proof/slice PRs is documented in
 - AI/Jules review output is advisory signal only and does not approve or merge PRs.
 - `.github/CODEOWNERS` remains review-routing metadata only; code-owner review is not an active merge requirement on `main`.
 - Six-Eyes is not technically enforced by the current PR template or branch protection configuration in this repo.
+- Auto-merge is not allowed in this repo. Merge only after final human review; do not use `gh pr merge --auto`.
 
 ## Blocked PR Diagnosis Order
 
@@ -248,20 +250,36 @@ gh api repos/jannekbuengener/Claire_de_Binare/branches/main/protection/required_
   --field required_approving_review_count=0
 ```
 
-### Enable Auto-merge (optional)
+### Auto-Merge Policy (Option A - required)
 
 ```bash
-# Enable auto-merge at repo level (PRs merge when checks pass):
+# Enforce repo-wide no-auto-merge policy:
 gh api repos/jannekbuengener/Claire_de_Binare \
   --method PATCH \
-  --field allow_auto_merge=true
+  --field allow_auto_merge=false
 ```
 
-Then per PR:
+Verify:
 
 ```bash
-gh pr merge <number> --auto --squash
+gh api repos/jannekbuengener/Claire_de_Binare \
+  --jq '{"allow_auto_merge":.allow_auto_merge}'
 ```
+
+Expected output:
+
+```json
+{"allow_auto_merge":false}
+```
+
+Merge execution rule:
+
+```bash
+# Final human review first; then manual merge (no --auto):
+gh pr merge <number> --squash --delete-branch
+```
+
+Merge state must not replace completion state. Use `Closes #...` only when acceptance is satisfied against merged `main`.
 
 ### Adding Required Checks
 

--- a/docs/runbooks/merge_strategy_squash_vs_merge.md
+++ b/docs/runbooks/merge_strategy_squash_vs_merge.md
@@ -12,11 +12,12 @@ Scope: proof/slice PRs, evidence PRs, and CI/governance changes.
   - Keeps `main` linear and easy to audit.
   - Reduces noisy intermediate commits from slice work.
   - Matches evidence-first workflow (evidence lives in PR/issue links, not commit chains).
+  - Repo policy (#1661 Option A): GitHub Auto-Merge is disabled (`allow_auto_merge=false`).
 
 CLI default:
 
 ```bash
-gh pr merge <number> --auto --squash --delete-branch
+gh pr merge <number> --squash --delete-branch
 ```
 
 ## Decision Rules
@@ -66,6 +67,7 @@ gh pr merge <number> --rebase --delete-branch
 - If policy-gate category prefixes are used (`docs-only:`, `workflows-only:`, `infra-only:`), keep them consistent with changed files.
 - Put evidence links in PR body and/or linked issue comments.
 - Do not rely on commit history as the primary evidence carrier.
+- Merge state is not completion state; closure claims remain acceptance-first and merged-`main` based.
 
 ## Notes
 

--- a/docs/runbooks/project_board_automation.md
+++ b/docs/runbooks/project_board_automation.md
@@ -52,6 +52,8 @@ Kurzer Betriebsleitfaden für die Repo-Organisation über Milestones, Labels und
   `Review`, `Blocked`, `Done`) sind Board-Feldwerte, keine Labels.
 - **Abgrenzung:** `stage:*` Labels bilden das Board-Stage-System ab und sind
   orthogonal zum LR-System in `docs/live-readiness/`.
+- **Merge-Governance:** Repo-weites Auto-Merge ist deaktiviert (`allow_auto_merge=false`);
+  Merges erfolgen manuell nach finalem Human-Review.
 
 ## Automationen (Workflow-Dateien)
 
@@ -120,9 +122,9 @@ Symptome:
 Fix:
 1. Runbook nutzen: `docs/runbooks/resolve_review_threads_via_graphql.md`
 2. Offene Review-Threads per GraphQL resolve.
-3. Merge erneut setzen:
+3. Nach finalem Human-Review manuell mergen:
    ```bash
-   gh pr merge <PR_NR> --auto --squash --delete-branch
+   gh pr merge <PR_NR> --squash --delete-branch
    ```
 
 ### 3) Project-Scopes fehlen / falscher Token aktiv (`GH_TOKEN` vs `GITHUB_TOKEN`)


### PR DESCRIPTION
## Delivery contract

- Decision: **Option A** is implemented for `jannekbuengener/Claire_de_Binare`: repo-wide GitHub Auto-Merge is disabled.
- Scope is intentionally narrow: only control-plane/governance surfaces directly required to close #1661.

## Technical implementation

1. **Repo-level setting flip (performed):**
   - Before: `allow_auto_merge=true`
   - Applied: `gh api repos/jannekbuengener/Claire_de_Binare --method PATCH --field allow_auto_merge=false`
   - Verified: `allow_auto_merge=false` (REST) and `autoMergeAllowed=false` (GraphQL)
2. **Repo-backed governance codification:**
   - `.github/pull_request_template.md`
   - `.github/README.md`
   - `docs/governance/GITHUB_CONTROL_PLANE_SEAL.md`
   - `docs/governance/BRANCH_PROTECTION_LOG.md`
   - `docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md`
   - `docs/runbooks/merge_policy_ci_gate.md`
   - `docs/runbooks/merge_strategy_squash_vs_merge.md`
   - `docs/runbooks/project_board_automation.md`

## What is technical vs normative

- **Technical (live GitHub state):** repo setting flip to `allow_auto_merge=false` is executed and verified.
- **Normative (repo-backed):** no-auto-merge policy, final human review requirement, and closure semantics (`merge_state != completion_state`, main-based closure truth) are now explicit across template/seal/runbooks.

## Validation

- `gh api repos/jannekbuengener/Claire_de_Binare --jq '{"allow_auto_merge":.allow_auto_merge}'` -> `false`
- `gh api graphql` (`repository.autoMergeAllowed`) -> `false`
- Changed files are limited to the eight governance/control-plane docs listed above.

## Residual uncertainties / manual steps

- None for Option A. The repo-wide setting flip is already executed and verified.
- Policy remains fail-closed: no `gh pr merge --auto`; merge only after final human review.

Closes #1661