### PR TITLE
fix(workflow): avoid jq arg limit in weekly digest pagination

### DIFF
--- a/.github/workflows/weekly_digest.yml
+++ b/.github/workflows/weekly_digest.yml
@@ -260,10 +260,9 @@ jobs:
               ]
             ' <<<"$items_json")"
 
-            project_items_json="$(jq -cn \
-              --argjson cur "$project_items_json" \
-              --argjson add "$page_entries_json" \
-              '$cur + $add'
+            project_items_json="$(
+              printf '%s\n' "$project_items_json" "$page_entries_json" |
+              jq -sc '.[0] + .[1]'
             )"
 
             has_next="$(jq -r '.data.user.projectV2.items.pageInfo.hasNextPage // false' <<<"$items_json")"


### PR DESCRIPTION
## Root Cause

`exit 126 / Argument list too long` im Pagination-Loop von `weekly_digest.yml`.

`--argjson cur "$project_items_json"` übergibt den akkumulierten Items-Array als `execve()`-Argument an den externen Prozess `jq`. Der Linux-Kernel begrenzt die Gesamtgröße aller Argumente + Umgebungsvariablen via `ARG_MAX` (~2 MB auf Ubuntu-Runnern). Mit wachsendem Project-Board überschreitet der Array diesen Wert → `E2BIG` → Exit 126. Kein Auth-/Secret-/Project-v2-Zugriffsfehler; Preflight war erfolgreich.

## Fix

**Datei:** `.github/workflows/weekly_digest.yml` — exakt eine Stelle (Zeilen 263–267 alt):

```diff
-            project_items_json="$(jq -cn \
-              --argjson cur "$project_items_json" \
-              --argjson add "$page_entries_json" \
-              '$cur + $add'
+            project_items_json="$(
+              printf '%s\n' "$project_items_json" "$page_entries_json" |
+              jq -sc '.[0] + .[1]'
             )"
```

`printf '%s\n'` ist ein bash-Builtin — kein `execve()`, kein ARG_MAX. Die Daten fließen via Pipe an `jq`. `jq -sc` liest beide JSON-Arrays von stdin, `-s` bündelt zu `[[…],[…]]`, `.[0] + .[1]` konkateniert. Kein Argument-Pfad, kein ARG_MAX-Risiko.

## Validierung

```
printf '%s\n' '[]' '[]' | jq -sc '.[0] + .[1]'
→ []   ✓

printf '%s\n' '[]' '[{"type":"Issue","number":1}]' | jq -sc '.[0] + .[1]'
→ [{"type":"Issue","number":1}]   ✓
```

## Scope

Ausschließlich `.github/workflows/weekly_digest.yml`, Akkumulationsstelle im Pagination-Loop. Kein weiterer Workflow-Scope angefasst.

Closes #1681 (nach erfolgreicher Verifikation via Workflow-Run).