### PR TITLE
feat(agents): add cdb-session-start fail-closed skill

### DIFF
--- a/.codex/cdb_skills/cdb-session-start/SKILL.md
+++ b/.codex/cdb_skills/cdb-session-start/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: cdb-session-start
+description: >
+  Enforce a fail-closed session start for Claire_de_Binare repo work. Use when
+  any agent must begin implementation, planning, or triage work in the working
+  repo. Verifies Git truth before any other action, detects risky starting
+  conditions such as stale local main, dirty worktree, gone-upstream branches,
+  or branch-local state mistaken for merged truth, verifies issue state against
+  GitHub, then delegates control-context reading to cdb-control-intake. Produces
+  a verified execution surface and a conservative go/no-go gate before any repo
+  change is made.
+---
+
+# CDB session start
+
+Establish a verified, fail-closed starting state before any repo work begins.
+
+## Inputs
+
+- Session goal, issue number, or user request.
+- Working repo at `D:\Dev\Workspaces\Repos\Claire_de_Binare`.
+- Access to git CLI and GitHub CLI (`gh`).
+
+## Workflow
+
+1. Verify Git truth before reading anything else:
+
+   ```bash
+   git fetch origin main
+   git rev-parse --abbrev-ref HEAD          # which branch am I on?
+   git status                               # clean or dirty?
+   git log --oneline origin/main..HEAD      # commits above main?
+   ```
+
+   Interpret the output:
+   - If HEAD is on a named branch that is not `main`: confirm whether this branch
+     has a known purpose or is leftover. If unclear, treat as stale and do not
+     use it as the work surface.
+   - If the worktree is dirty (unstaged or staged changes): stop and identify what
+     the changes are and whether they belong to the current task.
+   - If local `main` is behind `origin/main`: do not start branching from stale
+     local main; use `origin/main` as the base explicitly.
+   - If the branch has commits above `origin/main` with no corresponding open PR:
+     surface this as an unreported delivery candidate before continuing.
+
+2. Detect risky starting conditions and apply the gates below before any planning:
+
+   | Condition | Gate |
+   |---|---|
+   | Dirty worktree with unknown changes | STOP — identify origin, stash or resolve |
+   | Local main behind origin/main | Do not start from stale local main; refresh or use origin/main explicitly |
+   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it |
+   | Old local worktree from a prior session | Do not read as implicit active progress |
+   | Branch-local commits presented as merged truth | Verify via `gh pr list --state merged` |
+   | Auto-merge enabled on repo during closure-sensitive work | State `Closes #N` vs `Refs #N` explicitly |
+
+3. Verify issue state — not just issue prose:
+
+   ```bash
+   gh issue view <N>                                         # open or closed? labels?
+   gh pr list --search "Closes #<N>" --state merged         # already landed?
+   ```
+
+   Determine:
+   - Is the target issue still open, or was it closed (possibly prematurely)?
+   - Does a merged PR already deliver what the issue asks for?
+   - Is the issue superseded by a related issue that is now the active delivery
+     vehicle?
+   - Was a prior closure valid, or should the issue be reopened?
+
+   If the issue is already closed and no reopening is justified, stop and report
+   the session as pre-empted rather than inventing new work.
+
+4. Run `cdb-control-intake` to rebuild the control context:
+
+   Do not continue past this point without the output of `cdb-control-intake`.
+   The Git truth checks in steps 1-3 do not replace the control-context read; they
+   precede it.
+
+5. Create a clean execution surface:
+
+   Once steps 1-4 are complete and no gate has fired, create the working surface:
+   - Branch from current `origin/main` (never from stale local main).
+   - Clean worktree confirmed.
+   - Explicit target issue identified and open.
+   - Scope stated: what is IN, what is OUT.
+   - Closure semantics confirmed: `Closes #N` (full delivery) vs. `Refs #N`
+     (partial or scoped delivery).
+
+## Fail-Closed Rules
+
+- If `git fetch origin main` fails, stop and report the session as blocked.
+- If the worktree is dirty and the changes cannot be attributed, stop.
+- If local main is stale and the correct base cannot be confirmed, stop.
+- If the target issue cannot be read via `gh issue view`, stop.
+- If `cdb-control-intake` cannot be completed, stop.
+- If any of the risky conditions in step 2 cannot be resolved, stop and report
+  what remains unresolved before any file is touched.
+
+## Output
+
+Return the result in this structure:
+
+```md
+Git-Wahrheit
+- Branch:
+- Worktree:
+- Commits ueber origin/main:
+- Risky conditions gefunden: ja / nein -- <Detail>
+
+Issue-Wahrheit
+- Issue #N: offen / geschlossen
+- Merged PR gefunden: ja / nein -- <PR-Nummer oder keiner>
+- Bewertung: gueltige Startbasis / pre-empted / Klaerungsbedarf
+
+Control-Snapshot (via cdb-control-intake)
+- Board stage:
+- LR verdict:
+- Weekly focus:
+
+Arbeitsflaeche
+- Branch:
+- Scope:
+- Closure-Semantik:
+- Gate: go | no-go -- <Grund wenn no-go>
+```
+
+## Anti-Patterns
+
+- Do not read control docs or the target issue before verifying Git state.
+- Do not assume local main is current without an explicit fetch.
+- Do not treat branch-local commits as merged truth.
+- Do not start work on a dirty worktree without identifying the changes.
+- Do not use `git add .` at any point during session start.
+- Do not mark the gate as `go` when any of the fail-closed conditions is unresolved.
+- Do not invent reviewer, approver, or merge-authority roles; this is a
+  solo-maintainer repo.


### PR DESCRIPTION
## Summary

- Adds `.codex/cdb_skills/cdb-session-start/SKILL.md` to the existing CDB skill pack alongside `cdb-session-close` and `cdb-control-intake`
- Fail-closed session start: Git truth verification first, risky-conditions gate, issue state check via `gh`, delegation to `cdb-control-intake`, clean execution surface
- docs/skill-only change — no code, no runtime effect

## Closes

Closes #1663

## Test plan

- [ ] Skill file present at `.codex/cdb_skills/cdb-session-start/SKILL.md`
- [ ] `## Fail-Closed Rules` enthält 6 Regeln, keine Duplikate
- [ ] Referenz auf `cdb-control-intake` korrekt (Schritt 4)
- [ ] Kein paralleler Landepunkt unter `agents/skills/`
- [ ] Nur diese eine Datei im Commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)