### PR TITLE
docs(control): document expected GitHub Actions workflow count drift

### DIFF
--- a/docs/runbooks/CONTROL_REGISTER.md
+++ b/docs/runbooks/CONTROL_REGISTER.md
@@ -53,6 +53,7 @@ Regel: Phasen-Status nie in CURRENT_STATUS eintragen. LR-Verdikt nie aus einer B
 | Runbook legacy stack_up | keine base+dev Referenz in aktiven Runbooks | #1410 |
 | Discovery-Surfaces | ENTRYPOINTS.yaml / CHEATSHEET aktuell | #1413 |
 | ARCHITECTURE_MAP | bei Service-Change nachziehen | #1409 |
+| GitHub Actions UI Workflow-Count > Repo-Count | `state: active` in API ≠ ausführbar; gelöschte Dateien behalten historische Registrierung; platform-managed dynamic Workflows (Copilot/Dependabot/CodeQL) zählen zusätzlich; erwartet, kein Risiko | #1666 |
 
 Kontext-Issue-Nummern sind historische Anker (alle CLOSED) — nicht als offene Aufgaben interpretieren.
 


### PR DESCRIPTION
## Summary

- Adds one row to `## Wiederkehrende Drift-Vektoren` in `docs/runbooks/CONTROL_REGISTER.md`
- Documents why GitHub Actions UI/API workflow count (76) exceeds repo-backed file count (65)
- No workflow changes, no API mutations, no further scope

## Root cause documented

- **6 phantom workflows**: files deleted from repo, but GitHub retains their registration as long as historical run data exists (`state: active` ≠ currently executable)
- **5 platform-managed dynamic workflows**: Copilot PR Reviewer, Copilot SWE, Dependabot, Dependency Graph, CodeQL — appear in the API but have never been repo files

## Risk

None. Expected platform behavior. No operational impact.

Closes #1666

🤖 Generated with [Claude Code](https://claude.com/claude-code)