### PR TITLE
docs(claude): wire cdb-session-start/close as mandatory session-boundary skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ The authoritative role definition for Claude is at `agents/roles/CLAUDE.md`. Rea
 **Live-Readiness: NO-GO** — no real trades without explicit human gate. See `docs/live-readiness/`.
 **Control Board Stage:** `trade-capable` (ratified 2026-04-08) — orthogonal to LR `NO-GO`; no live capital, no Grafana gate, no strategy validation.
 
+**Session-Boundary Skills (Pflicht, fail-closed):** Lesen und anwenden — kein Überspringen.
+- **Vor** jeder Repo-/GitHub-/Planungs-/Implementierungsarbeit: `.codex/cdb_skills/cdb-session-start/SKILL.md`
+- **Nach** Implementierung/Validierung/Repo-Arbeit, vor Abschluss: `.codex/cdb_skills/cdb-session-close/SKILL.md`
+
 **Session-Ende (Pflicht):** Session-Log unter `knowledge/logs/sessions/YYYY-MM-DD-<topic>.md` ablegen. `CURRENT_STATUS.md` aktualisieren wenn sich Repo-/Engineering-Status geändert hat.
 
 ---


### PR DESCRIPTION
## Summary

Closes #1688

Adds permanent, repo-backed routing for the two canonical session-boundary skills in `CLAUDE.md`.

**Change (docs only — 4 lines in CLAUDE.md):**

```
Session-Boundary Skills (Pflicht, fail-closed): Lesen und anwenden — kein Überspringen.
- Vor jeder Repo-/GitHub-/Planungs-/Implementierungsarbeit: .codex/cdb_skills/cdb-session-start/SKILL.md
- Nach Implementierung/Validierung/Repo-Arbeit, vor Abschluss: .codex/cdb_skills/cdb-session-close/SKILL.md
```

**Why CLAUDE.md and not `.codex/agents/`:**

`.codex/agents/` is excluded from git via `.git/info/exclude` — it is local-only, not repo-backed. `CLAUDE.md` is the only repo-backed routing surface for Claude Code session boundaries. The skills themselves are already repo-backed under `.codex/cdb_skills/` (PRs #1684/#1685).

**No content duplication:** The routing entry points to the skill files; it does not reproduce their content.

## Test plan

- [ ] Docs-only: no runtime impact
- [ ] `CLAUDE.md` diff reviewed: +4 lines, minimal, no parallel truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)