### PR TITLE
docs(ledger): pip-bump-Batch #1668-#1674 Closeout

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -3,7 +3,7 @@
 **Status Class**: Working Repo / Engineering Status
 **Authority**: Current repo/main/test/dependency snapshot; not the canonical live-readiness or Echtgeld Go/No-Go source.
 **Operational Canon**: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-**Last Updated**: 2026-04-13
+**Last Updated**: 2026-04-15
 **GitHub Boundary**: The live commit and PR state is tracked in GitHub (UI/API or `gh`); this file is a curated repo/engineering ledger, not a live mirror.
 
 ---
@@ -64,6 +64,7 @@
 - **Merged (Session 51-55, 2026-04-10)**: Strategy-v1-Cluster current-main-wahr gelandet: PR #1598 (unit/scale reland, `8309f6fc`), PR #1600 (minimaler `primary_breakout_v1` Footprint, `192a8f32`), PR #1602 (statische Strategy-/Execution-Adapter-Grenze, `b1bac4ad`), PR #1613 (deterministischer `primary_breakout_v1` Backtest-/Validation-Pfad, `c0004ed4`), PR #1615 (Paper-/Shadow-Evidence-Bridge, `b3c5ccca`). Danach Issues #1572/#190/#207/#1573 gegen `origin/main` geschlossen; Board-Stage bleibt `trade-capable`, LR bleibt `NO-GO`.
 - **Merged (2026-04-11)**: PR #1682 (`aee8685f`) — fix(workflow): weekly_digest.yml jq-Arg-Limit bei Pagination behoben.
 - **Merged (2026-04-13)**: PR #1684 (`01cb574f`) — feat(agents): cdb-session-start fail-closed Skill hinzugefuegt (`.codex/cdb_skills/cdb-session-start/`). PR #1685 (`7b5f748e`) — feat(agents): cdb-session-close mit Hard-Complete-Delivery-Verifikation erweitert (`.codex/cdb_skills/cdb-session-close/`). PR #1686 (`9b037ae8`) — docs(control): erwarteten GitHub-Actions-Workflow-Count-Drift in CONTROL_REGISTER.md dokumentiert. Issue #1666 geschlossen. PR #1689 (`8932e25c`) — docs(workflows): Gemini-Command-TOML-Coupling-Modell dokumentiert, Dispatch-Status klargestellt. Issue #1667 geschlossen. PR #1690 (`2b839f9c`) — docs(claude): cdb-session-start/cdb-session-close als Pflicht-Session-Boundary-Skills in CLAUDE.md verdrahtet. Issue #1688 geschlossen.
+- **Merged (2026-04-15)**: pip-bump-Batch #1668–#1674 — 7 PRs: #1674 mcp 1.26.0→1.27.0 (`52da3a17`), #1673 requests 2.33.0→2.33.1 (`1a38d57b`), #1672 pytest 9.0.2→9.0.3 (`c89f060d`), #1671 ruff 0.15.9→0.15.10 (`c72dc23b`), #1670 python-json-logger 4.0.0→4.1.0 (`753e094e`), #1669 mypy 1.8.0→1.20.0 (`4adc88a5`), #1668 prometheus-client 0.21.1→0.25.0 (`bfbb015b`). Alle 7 gemergt, CI gruen.
 
 ---
 

--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -8,7 +8,7 @@
 
 ---
 
-## Repo / Engineering Status (2026-04-13)
+## Repo / Engineering Status (2026-04-15)
 
 - **main**: green
 - **Active GitHub focus (manual, non-exhaustive)**:

--- a/knowledge/logs/sessions/2026-04-15-pip-bump-batch.md
+++ b/knowledge/logs/sessions/2026-04-15-pip-bump-batch.md
@@ -45,4 +45,4 @@ Alle 7 PRs: state=MERGED. Kein PR aus dem Batch offen.
 
 ## Restunsicherheiten
 
-keine
+- Keine.

--- a/knowledge/logs/sessions/2026-04-15-pip-bump-batch.md
+++ b/knowledge/logs/sessions/2026-04-15-pip-bump-batch.md
@@ -1,0 +1,48 @@
+# Session Log — 2026-04-15 — pip-bump-Batch #1668–#1674
+
+**Datum:** 2026-04-15
+**Scope:** pip-bump-Batch — 7 Dependabot-PRs (#1668–#1674) abgeschlossen
+
+---
+
+## Ziel
+
+Repo-backed Closeout des pip-bump-Batches #1668–#1674: Live-Verifikation aller 7 PRs, minimale Ledger-Nachführung, Issue-Kommentar in #1445.
+
+---
+
+## Batch-Befund (live verifiziert via `gh pr view`)
+
+| PR | Titel | mergedAt (UTC) | mergeCommit |
+|---|---|---|---|
+| #1674 | deps(pip): bump mcp 1.26.0→1.27.0 | 2026-04-15T17:50:46Z | `52da3a17` |
+| #1673 | deps(pip): bump requests 2.33.0→2.33.1 | 2026-04-15T18:08:46Z | `1a38d57b` |
+| #1672 | deps(pip): bump pytest 9.0.2→9.0.3 | 2026-04-15T18:18:06Z | `c89f060d` |
+| #1671 | deps(pip): bump ruff 0.15.9→0.15.10 | 2026-04-15T18:06:25Z | `c72dc23b` |
+| #1670 | deps(pip): bump python-json-logger 4.0.0→4.1.0 | 2026-04-15T18:29:49Z | `753e094e` |
+| #1669 | deps(pip): bump mypy 1.8.0→1.20.0 | 2026-04-15T18:24:31Z | `4adc88a5` |
+| #1668 | deps(pip): bump prometheus-client 0.21.1→0.25.0 | 2026-04-15T18:37:44Z | `bfbb015b` |
+
+Alle 7 PRs: state=MERGED. Kein PR aus dem Batch offen.
+
+---
+
+## Control-Lage
+
+- Stage: `trade-capable` (ratifiziert 2026-04-08, #1492)
+- LR-Verdikt: `NO-GO` (unverändert, SSOT: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`)
+- Guardrails: shadow/mock only, kein Live-Kapital, kein Grafana-Gate
+
+---
+
+## Ausgefuehrte Aenderungen
+
+- `CURRENT_STATUS.md` — Ledger-Eintrag fuer den Batch hinzugefuegt; Last Updated auf 2026-04-15 nachgezogen
+- `knowledge/logs/sessions/2026-04-15-pip-bump-batch.md` — dieser Session-Log (neu, Konvention repo-backed belegt)
+- `#1445` — Abschlusskommentar gepostet
+
+---
+
+## Restunsicherheiten
+
+keine


### PR DESCRIPTION
Minimaler Repo-backed Closeout des pip-bump-Batches #1668-#1674.

## Inhalt

- \CURRENT_STATUS.md\: Ledger-Eintrag fuer die 7 gemergten pip-bump-PRs; Last Updated auf 2026-04-15 nachgezogen
- \knowledge/logs/sessions/2026-04-15-pip-bump-batch.md\: Session-Log (Konvention repo-backed belegt)

## Verifizierte PRs (alle MERGED 2026-04-15)

| PR | Paket | mergeCommit |
|---|---|---|
| #1674 | mcp 1.26.0→1.27.0 | \52da3a17\ |
| #1673 | requests 2.33.0→2.33.1 | \1a38d57b\ |
| #1672 | pytest 9.0.2→9.0.3 | \c89f060d\ |
| #1671 | ruff 0.15.9→0.15.10 | \c72dc23b\ |
| #1670 | python-json-logger 4.0.0→4.1.0 | \753e094e\ |
| #1669 | mypy 1.8.0→1.20.0 | \4adc88a5\ |
| #1668 | prometheus-client 0.21.1→0.25.0 | \fbb015b\ |

docs-only, kein Runtime-/CI-Eingriff.