### PR TITLE
docs(status): remove stale #1603 ledger reference

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -11,8 +11,7 @@
 ## Repo / Engineering Status (2026-04-15)
 
 - **main**: green
-- **Active GitHub focus (manual, non-exhaustive)**:
-  - #1603 (Architektur-Doku-Reconcile nach PR #1602) — offen, wartet auf engen Doku-Fix
+- **Active GitHub focus (manual, non-exhaustive)**: keine
 - **Boundary**: Nur aktuell relevante offene PRs gehoeren in den Fokusblock oben. Merged, closed oder rein historische Hinweise gehoeren in den Session-Ledger darunter.
 
 ---


### PR DESCRIPTION
## Zweck

Entfernt den veralteten `#1603`-Eintrag aus dem Aktiv-Fokus-Block in `CURRENT_STATUS.md`.

## Befund

Issue `#1603` (Architektur-Doku-Reconcile nach PR `#1602`) ist CLOSED (live verifiziert via `gh issue view 1603 --json state`). Der Eintrag suggerierte faelschlicherweise, dass `#1603` noch aktiv/offen sei.

## Aenderung

- `CURRENT_STATUS.md`: 2 Zeilen (Header + Bullet) durch 1 Zeile `- **Active GitHub focus (manual, non-exhaustive)**: keine` ersetzt.

## Scope

docs-only, nur `CURRENT_STATUS.md`. Kein Runtime-, CI- oder Governance-Eingriff.

## Verifikation

- `gh issue view 1603 --json state` -> CLOSED
- `git diff --stat` -> 1 file changed, 1 insertion(+), 2 deletions(-)