### PR TITLE
docs: reconcile Signal/Risk/Market canon after runtime-drift patch (#1646)

### DIFF
--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -42,7 +42,7 @@ Claire de Binare ist ein **event-getriebenes Krypto-Trading-System** mit:
 |---------|-----------|------|----------|
 | PostgreSQL | cdb_postgres | 5432 | Persistenz |
 | Redis | cdb_redis | 6379 | Cache, Pub/Sub, Streams |
-| Market | cdb_market | 8009 | market_state:{symbol} Owner |
+| Market | cdb_market | 8009 | market_state:{symbol} Owner; Redis retry/reconnect bis verfügbar, /health fail-closed |
 | Candles | cdb_candles | 8007 | Tick→1-min Candle Aggregation |
 | Regime | cdb_regime | 8008 | ADX/ATR Regime Classification |
 | Allocation | cdb_allocation | 8006 | Regime→Allocation Mapping |
@@ -154,6 +154,7 @@ Keine offenen Drifts.
 Historisch behoben:
 - prod.yml/tls.yml referenzierten `cdb_core` statt `cdb_signal` → behoben
 - CLAUDE.md hatte Signal als Port 8001 → korrigiert auf 8005
+- Market-Zeile Section 2: Retry/Reconnect + fail-closed /health Semantik ergänzt (issue #1646, 2026-04-16)
 
 ---
 

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -25,7 +25,7 @@
 
 | Service | Container | Port | Code | Status | Funktion |
 |---------|-----------|------|------|--------|----------|
-| **Market** | cdb_market | 8009 | services/market/ | **AKTIV** | market_state:{symbol} Owner (Issue #1201) |
+| **Market** | cdb_market | 8009 | services/market/ | **AKTIV** | market_state:{symbol} Owner (Issue #1201); Redis retry/reconnect bis verfügbar, /health fail-closed |
 | **Candles** | cdb_candles | 8007 | services/candles/ | **AKTIV** | Tick→1-min Candle Aggregation |
 | **Regime** | cdb_regime | 8008 | services/regime/ | **AKTIV** | ADX/ATR Regime Classification |
 | **Allocation** | cdb_allocation | 8006 | services/allocation/ | **AKTIV** | Regime→Allocation Mapping |

--- a/knowledge/governance/SYSTEM_INVARIANTS.md
+++ b/knowledge/governance/SYSTEM_INVARIANTS.md
@@ -3,7 +3,7 @@
 
 **Version:** 1.0
 **Status:** Active
-**Last Updated:** 2026-02-09
+**Last Updated:** 2026-04-16
 **Canonical Location:** `knowledge/governance/SYSTEM_INVARIANTS.md`
 
 ---
@@ -50,11 +50,11 @@ This is not a redesign proposal, implementation guide, or "nice to have" require
 **Enforcement:**
 - Test: `tests/contract/test_decision_contract.py::test_decision_allow` (baseline ALLOW requires all checks)
 - Code: `services/risk/service.py::decide_trade()` returns `DECISION_BLOCK` by default
-- Spec: Working Repo `services/risk/README.md` documents "Default: BLOCK. Allow only if A ∧ B ∧ C"
+- Spec: Working Repo `core/contracts/decision_contract_v1.py` definiert Decision Contract v1 Interface
 
 **References:**
 - Working Repo: `tests/contract/test_decision_contract.py` (16 deterministic tests)
-- Working Repo: `services/risk/README.md` §Decision Contract 0/1 v1
+- Working Repo: `core/contracts/decision_contract_v1.py` (Decision Contract v1 Interface)
 - Working Repo: `services/risk/service.py::decide_trade()`
 
 ---
@@ -66,12 +66,11 @@ This is not a redesign proposal, implementation guide, or "nice to have" require
 **Rationale:** Risk controls are the critical safety layer. Execution without risk validation violates fail-closed principle.
 
 **Enforcement:**
-- Architecture: Working Repo `services/risk/README.md` documents stream topology (signals → Risk → orders → Execution)
+- Architecture: Working Repo `services/risk/README.md` §Topics / Streams (signals → Risk → orders → Execution)
 - Healthcheck: Working Repo `infrastructure/compose/healthchecks-strict.yml` (Execution depends_on Risk service_healthy)
 - Docker: Working Repo `infrastructure/compose/base.yml` defines service dependencies
 
 **References:**
-- Working Repo: `services/risk/README.md` (architecture diagram flowchart lines 16-21)
 - Working Repo: `infrastructure/compose/healthchecks-strict.yml::cdb_execution.depends_on`
 - Working Repo: `infrastructure/compose/base.yml`
 
@@ -90,7 +89,6 @@ This is not a redesign proposal, implementation guide, or "nice to have" require
 
 **References:**
 - Working Repo: `tests/contract/test_decision_contract.py::test_decision_first_fail_*` (4 ordering tests)
-- Working Repo: `services/risk/README.md` §Decision Contract (First-Fail Reihenfolge line 52)
 - Working Repo: `services/risk/service.py::decide_trade()`
 
 ---
@@ -398,11 +396,9 @@ This is not a redesign proposal, implementation guide, or "nice to have" require
 
 **Enforcement:**
 - Code: Working Repo `services/risk/service.py::decide_trade()` does not reference confidence field
-- Contract: Working Repo `services/risk/README.md` §Decision Contract "Confidence ist kein Gate"
 - Model: Working Repo `services/signal/models.py` defines confidence as optional informational field
 
 **References:**
-- Working Repo: `services/risk/README.md` line 54 (Confidence ist kein Gate)
 - Working Repo: `services/risk/service.py::decide_trade()`
 - Working Repo: `services/signal/models.py` (Signal dataclass)
 
@@ -431,7 +427,7 @@ This is not a redesign proposal, implementation guide, or "nice to have" require
 | INV-017: Reason Code Taxonomy Completeness | `docs/live-readiness/LR-004-SPEC.md` §5.2 + lr004_completion_guard.py |
 | INV-018: Manifest Immutability | `docs/live-readiness/LR-004-SPEC.md` §3.4 |
 | INV-019: Deterministic Replay-Verifiability | `docs/live-readiness/LR-006-EVIDENCE.md` Example 1 walkthrough |
-| INV-020: No Confidence-Based Gating | `services/risk/README.md` + decide_trade() implementation |
+| INV-020: No Confidence-Based Gating | `services/risk/service.py::decide_trade()` (confidence nicht referenziert) |
 
 **Note:** All paths in Canonical Map refer to Working Repo (`Claire_de_Binare`) unless explicitly prefixed.
 


### PR DESCRIPTION
## Summary

Closes #1646

Docs-only reconcile of three concrete drifts left open after PR #1637 (Codex patchset 2026-04-11).

## Track A — `knowledge/governance/SYSTEM_INVARIANTS.md`

PR #1637 rewrote `services/risk/README.md` to a compact canonical form and moved
the Decision Contract v1 anchor to `core/contracts/decision_contract_v1.py`.
`SYSTEM_INVARIANTS.md` was not updated — 5 reference lines in 4 INVs pointed to
removed README sections:

- INV-001: `§Decision Contract 0/1 v1` ref → `core/contracts/decision_contract_v1.py`
- INV-001: Spec bullet README paraphrase → `core/contracts/decision_contract_v1.py`
- INV-002: `architecture diagram flowchart lines 16-21` → removed (no such diagram)
- INV-002: Architecture enforcement bullet → `§Topics / Streams` (real section)
- INV-003: `§Decision Contract (First-Fail Reihenfolge line 52)` → removed
- INV-020: `§Decision Contract "Confidence ist kein Gate"` enforcement bullet → removed
- INV-020: `line 54 (Confidence ist kein Gate)` reference → removed
- Canonical Map INV-020: `services/risk/README.md + decide_trade()` → `service.py::decide_trade()`

All invariants remain fully enforced by `services/risk/service.py::decide_trade()`
and 16 contract tests. No semantic gap — broken-reference noise only.

## Track B — `knowledge/ARCHITECTURE_MAP.md` + `knowledge/governance/SERVICE_CATALOG.md`

PR #1637 trimmed Market service descriptions, losing safety-relevant semantics that
are code-backed in `services/market/service.py:98`. Both Market rows updated with:
_Redis retry/reconnect bis verfügbar, /health fail-closed_

ARCHITECTURE_MAP Section 6 historical log updated.

## Validation

```bash
# No broken references remain
grep -n 'Decision Contract 0/1 v1\|flowchart lines 16-21\|First-Fail Reihenfolge line 52\|Confidence ist kein Gate' knowledge/governance/SYSTEM_INVARIANTS.md
# Market semantics present
grep -i 'retry\|reconnect\|fail-closed' knowledge/ARCHITECTURE_MAP.md
```

No code changes. No runtime changes. No workflow changes. Docs-only.
