### PR TITLE
fix(validation): separate requested vs effective period window in backtest report (#1706)

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -3,15 +3,15 @@
 **Status Class**: Working Repo / Engineering Status
 **Authority**: Current repo/main/test/dependency snapshot; not the canonical live-readiness or Echtgeld Go/No-Go source.
 **Operational Canon**: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-**Last Updated**: 2026-04-15
+**Last Updated**: 2026-04-16
 **GitHub Boundary**: The live commit and PR state is tracked in GitHub (UI/API or `gh`); this file is a curated repo/engineering ledger, not a live mirror.
 
 ---
 
-## Repo / Engineering Status (2026-04-15)
+## Repo / Engineering Status (2026-04-16)
 
 - **main**: green
-- **Active GitHub focus (manual, non-exhaustive)**: keine
+- **Active GitHub focus (manual, non-exhaustive)**: PR #1707 (fix/1706-period-window-semantics) — offen, review-bereit
 - **Boundary**: Nur aktuell relevante offene PRs gehoeren in den Fokusblock oben. Merged, closed oder rein historische Hinweise gehoeren in den Session-Ledger darunter.
 
 ---
@@ -64,6 +64,7 @@
 - **Merged (2026-04-11)**: PR #1682 (`aee8685f`) — fix(workflow): weekly_digest.yml jq-Arg-Limit bei Pagination behoben.
 - **Merged (2026-04-13)**: PR #1684 (`01cb574f`) — feat(agents): cdb-session-start fail-closed Skill hinzugefuegt (`.codex/cdb_skills/cdb-session-start/`). PR #1685 (`7b5f748e`) — feat(agents): cdb-session-close mit Hard-Complete-Delivery-Verifikation erweitert (`.codex/cdb_skills/cdb-session-close/`). PR #1686 (`9b037ae8`) — docs(control): erwarteten GitHub-Actions-Workflow-Count-Drift in CONTROL_REGISTER.md dokumentiert. Issue #1666 geschlossen. PR #1689 (`8932e25c`) — docs(workflows): Gemini-Command-TOML-Coupling-Modell dokumentiert, Dispatch-Status klargestellt. Issue #1667 geschlossen. PR #1690 (`2b839f9c`) — docs(claude): cdb-session-start/cdb-session-close als Pflicht-Session-Boundary-Skills in CLAUDE.md verdrahtet. Issue #1688 geschlossen.
 - **Merged (2026-04-15)**: pip-bump-Batch #1668–#1674 — 7 PRs: #1674 mcp 1.26.0→1.27.0 (`52da3a17`), #1673 requests 2.33.0→2.33.1 (`1a38d57b`), #1672 pytest 9.0.2→9.0.3 (`c89f060d`), #1671 ruff 0.15.9→0.15.10 (`c72dc23b`), #1670 python-json-logger 4.0.0→4.1.0 (`753e094e`), #1669 mypy 1.8.0→1.20.0 (`4adc88a5`), #1668 prometheus-client 0.21.1→0.25.0 (`bfbb015b`). Alle 7 gemergt, CI gruen.
+- **Session 2026-04-16 (aktuelle Session)**: #1706 — Period-Window-Semantik in `primary_breakout_v1` Backtest-Runner/Report geklaert. Explizite Feldtrennung `requested_period_*` vs effektive `period_*` in `dataset_summary`. PR #1707 (`fix/1706-period-window-semantics`) offen, review-bereit. 5 Dateien, 8/8 Unit-Tests gruen.
 
 ---
 

--- a/docs/contracts/strategy_validation_report_v1.schema.json
+++ b/docs/contracts/strategy_validation_report_v1.schema.json
@@ -112,7 +112,7 @@
           "minimum": 0
         },
         "period_start_ts_ms": {
-          "description": "First effective bridge evaluation timestamp — after warm-up consumption of max(entry_lookback, exit_lookback) candles. Offset from requested_period_start_ts_ms by max_lookback * 60_000 ms.",
+          "description": "First effective bridge evaluation timestamp — after warm-up consumption of max(entry_lookback_minutes, exit_lookback_minutes) candles. Offset from requested_period_start_ts_ms by max(entry_lookback_minutes, exit_lookback_minutes) * 60_000 ms.",
           "type": "integer",
           "minimum": 0
         },

--- a/docs/contracts/strategy_validation_report_v1.schema.json
+++ b/docs/contracts/strategy_validation_report_v1.schema.json
@@ -85,6 +85,8 @@
         "symbol",
         "timeframe",
         "candles_total",
+        "requested_period_start_ts_ms",
+        "requested_period_end_ts_ms",
         "period_start_ts_ms",
         "period_end_ts_ms"
       ],
@@ -99,11 +101,23 @@
           "type": "integer",
           "minimum": 1
         },
+        "requested_period_start_ts_ms": {
+          "description": "First candle timestamp in the raw input series passed to the runner (requested window start).",
+          "type": "integer",
+          "minimum": 0
+        },
+        "requested_period_end_ts_ms": {
+          "description": "Last candle timestamp in the raw input series passed to the runner (requested window end).",
+          "type": "integer",
+          "minimum": 0
+        },
         "period_start_ts_ms": {
+          "description": "First effective bridge evaluation timestamp — after warm-up consumption of max(entry_lookback, exit_lookback) candles. Offset from requested_period_start_ts_ms by max_lookback * 60_000 ms.",
           "type": "integer",
           "minimum": 0
         },
         "period_end_ts_ms": {
+          "description": "Last effective bridge evaluation timestamp. Aligns with requested_period_end_ts_ms.",
           "type": "integer",
           "minimum": 0
         }

--- a/knowledge/contracts/PRIMARY_BREAKOUT_V1_VALIDATION.md
+++ b/knowledge/contracts/PRIMARY_BREAKOUT_V1_VALIDATION.md
@@ -84,3 +84,19 @@ The following are not canonical gate metrics in v1:
 - `pnl_usd_absolute`
 
 These may be informative in research notes, but they do not decide v1 gate outcome.
+
+## Dataset Summary — Period Window Semantics
+
+The `dataset_summary` block distinguishes two timestamp boundaries:
+
+| Field | Meaning |
+|---|---|
+| `requested_period_start_ts_ms` | First candle `ts_ms` in the raw input series passed to the runner |
+| `requested_period_end_ts_ms` | Last candle `ts_ms` in the raw input series passed to the runner |
+| `period_start_ts_ms` | First **effective** bridge evaluation timestamp — after warm-up consumption of `max(entry_lookback_minutes, exit_lookback_minutes)` candles |
+| `period_end_ts_ms` | Last effective bridge evaluation timestamp (aligns with `requested_period_end_ts_ms`) |
+
+With default config (`entry_lookback_minutes=240`, `exit_lookback_minutes=120`), the effective
+period start is offset by exactly `240 × 60,000 ms = 14,400,000 ms` from the requested start.
+This offset is expected and is not a data error — it reflects the warm-up window consumed by the
+bridge before the first evaluable candle.

--- a/services/validation/strategy_backtest_runner.py
+++ b/services/validation/strategy_backtest_runner.py
@@ -345,11 +345,16 @@ def _build_report(
     regime_fresh_ratio: float,
     data_integrity_ok: bool,
     deterministic_replay_ok: bool,
+    requested_period_start_ts_ms: int,
+    requested_period_end_ts_ms: int,
 ) -> dict[str, Any]:
     if not bridge_requests:
         raise PrimaryBreakoutBacktestError("bridge produced no requests")
 
     run_id = _deterministic_run_id(bridge_requests, run_config, code_commit)
+    # Effective bridge start: first candle after the warm-up window
+    # (max(entry_lookback, exit_lookback) candles consumed as lookback).
+    # Offset from requested_period_start_ts_ms by max_lookback * 60_000 ms.
     first_ts_ms = int(bridge_requests[0].market_event["ts_ms"])
     last_ts_ms = int(bridge_requests[-1].market_event["ts_ms"])
 
@@ -415,6 +420,8 @@ def _build_report(
             "candles_total": len(bridge_requests) + max(
                 run_config.bridge.entry_lookback_minutes, run_config.bridge.exit_lookback_minutes
             ),
+            "requested_period_start_ts_ms": requested_period_start_ts_ms,
+            "requested_period_end_ts_ms": requested_period_end_ts_ms,
             "period_start_ts_ms": first_ts_ms,
             "period_end_ts_ms": last_ts_ms,
         },
@@ -437,6 +444,9 @@ def run_primary_breakout_backtest(
     bridge_requests = build_primary_breakout_historical_bridge(
         candles, config=active_config.bridge
     )
+    # Extract raw candle boundaries after bridge validation succeeds (guarantees non-empty + valid).
+    requested_period_start_ts_ms = int(candles[0]["ts_ms"])
+    requested_period_end_ts_ms = int(candles[-1]["ts_ms"])
     simulator = ExecutionSimulator()
 
     output_requests: list[dict[str, Any]] = []
@@ -562,4 +572,6 @@ def run_primary_breakout_backtest(
         regime_fresh_ratio=(regime_fresh_count / len(bridge_requests) if bridge_requests else 0.0),
         data_integrity_ok=data_integrity_ok,
         deterministic_replay_ok=deterministic_replay_ok,
+        requested_period_start_ts_ms=requested_period_start_ts_ms,
+        requested_period_end_ts_ms=requested_period_end_ts_ms,
     )

--- a/tests/unit/contracts/test_strategy_validation_report_contract.py
+++ b/tests/unit/contracts/test_strategy_validation_report_contract.py
@@ -40,6 +40,8 @@ def _valid_report_payload() -> dict:
             "symbol": "BTCUSDT",
             "timeframe": "1m",
             "candles_total": 3000,
+            "requested_period_start_ts_ms": 1_699_985_600_000,
+            "requested_period_end_ts_ms": 1_700_179_940_000,
             "period_start_ts_ms": 1_700_000_000_000,
             "period_end_ts_ms": 1_700_179_940_000,
         },

--- a/tests/unit/validation/test_primary_breakout_backtest_runner.py
+++ b/tests/unit/validation/test_primary_breakout_backtest_runner.py
@@ -74,6 +74,35 @@ def test_primary_breakout_backtest_runner_is_deterministic_and_schema_valid() ->
 
 
 @pytest.mark.unit
+def test_primary_breakout_backtest_runner_period_window_semantics() -> None:
+    """Requested vs effective period boundaries are distinct and correctly related.
+
+    _candles() produces 380 candles starting at ts_ms=1_700_000_000_000 with 1m cadence.
+    With entry_lookback_minutes=240 the bridge warm-up consumes candles[0..239], so the
+    first effective bridge request corresponds to candles[240].
+    """
+    candles = _candles()
+    config = PrimaryBreakoutBacktestRunConfig()
+    report = run_primary_breakout_backtest(candles, run_config=config, code_commit="a9a62be")
+
+    ds = report["dataset_summary"]
+    start_ts = 1_700_000_000_000
+    end_ts = start_ts + 379 * 60_000
+    max_lookback = max(
+        config.bridge.entry_lookback_minutes, config.bridge.exit_lookback_minutes
+    )
+
+    assert ds["requested_period_start_ts_ms"] == start_ts
+    assert ds["requested_period_end_ts_ms"] == end_ts
+    # Effective start is offset by exactly max_lookback * 60_000 ms from requested start.
+    assert ds["period_start_ts_ms"] == start_ts + max_lookback * 60_000
+    # Effective end aligns with the last raw candle.
+    assert ds["period_end_ts_ms"] == end_ts
+    # Invariant: effective start must be strictly after requested start.
+    assert ds["period_start_ts_ms"] > ds["requested_period_start_ts_ms"]
+
+
+@pytest.mark.unit
 def test_primary_breakout_backtest_runner_fail_closed_on_invalid_config() -> None:
     candles = _candles()
     config = PrimaryBreakoutBacktestRunConfig(order_size=0.0)


### PR DESCRIPTION
## Summary

Closes #1706.

Separates `requested` vs `effective` period-window boundaries in the `dataset_summary` block of the `primary_breakout_v1` validation report. Previously only the effective bridge start was recorded under `period_start_ts_ms`, with no way to distinguish it from the requested input window.

## Changes

| File | Change |
|---|---|
| `services/validation/strategy_backtest_runner.py` | Add `requested_period_start_ts_ms` / `requested_period_end_ts_ms` params to `_build_report`; derive after bridge validation; inline comment on warm-up offset |
| `docs/contracts/strategy_validation_report_v1.schema.json` | Add two new required fields to `dataset_summary` with description annotations |
| `knowledge/contracts/PRIMARY_BREAKOUT_V1_VALIDATION.md` | Add period-window semantics section with field table and offset explanation |
| `tests/unit/validation/test_primary_breakout_backtest_runner.py` | New dedicated test locking requested/effective relationship with exact ts assertions |
| `tests/unit/contracts/test_strategy_validation_report_contract.py` | Update `_valid_report_payload` fixture with new required fields |

## Scope

- **No** threshold changes
- **No** strategy changes
- **No** runtime / live scope
- **No** new evidence run
- Track 2 (#1636) remains open

## Tests

All 8 affected unit tests green.