### PR TITLE
fix(scanner): fail closed on empty gh models response (#1712)

### DIFF
--- a/.github/scripts/post_merge_followup_scanner.py
+++ b/.github/scripts/post_merge_followup_scanner.py
@@ -329,6 +329,10 @@ def classify_finding(
             f"input={finding.classification_input}",
         ]
     )
+    if not raw.strip():
+        raise RuntimeError(
+            "gh models run returned empty response — models API unavailable or quota exceeded"
+        )
     payload = json.loads(raw)
     if payload.get("classification") not in {"report_only", "follow_up_issue", "unclear"}:
         raise RuntimeError("classifier returned invalid classification")


### PR DESCRIPTION
## Summary

Closes #1712

Minimal fail-closed guard in `.github/scripts/post_merge_followup_scanner.py` — `classify_finding()`.

## Change

Directly after `run_command(...)` for `gh models run`, before `json.loads()`:

```python
if not raw.strip():
    raise RuntimeError(
        "gh models run returned empty response — models API unavailable or quota exceeded"
    )
```

## Behaviour

| Path | Before | After |
|---|---|---|
| Valid model response | JSON parsed → classification proceeds | Unchanged |
| Empty stdout (exit 0) | Opaque `JSONDecodeError` | Explicit `RuntimeError` with operator-actionable message |

## Scope

**3 files changed:**
- `.github/scripts/post_merge_followup_scanner.py` — 4 lines: fail-closed empty-response guard (#1712 fix)
- `CURRENT_STATUS.md` — session ledger entry for #1709 closeout (bundled from same session)
- `knowledge/logs/sessions/2026-04-16-issue-1709-arch-drift-verification.md` — session log for #1709 (bundled from same session)

## Validation

- `ruff check .github/scripts/post_merge_followup_scanner.py` → clean
- No existing test suite for this script; no new test apparatus added per guardrail