### PR TITLE
fix(security): pin postgres:15.17-alpine to 2026-04-16 rebuild digest (#1717)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         image:
           - redis:7.4.8-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065
-          - postgres:15.17-alpine
+          - postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
           - prom/prometheus:v3.10.0@sha256:4a61322ac1103a0e3aea2a61ef1718422a48fa046441f299d71e660a3bc71ae9
           - grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
       fail-fast: false
@@ -246,7 +246,7 @@ jobs:
       matrix:
         image:
           - redis:7.4.8-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065
-          - postgres:15.17-alpine
+          - postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
       fail-fast: false
 
     env:

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -31,7 +31,7 @@ services:
       - cdb_network
 
   cdb_postgres:
-    image: postgres:15.17-alpine
+    image: postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
     container_name: cdb_postgres
     restart: unless-stopped
     environment:

--- a/infrastructure/compose/compose.blue.yml
+++ b/infrastructure/compose/compose.blue.yml
@@ -17,7 +17,7 @@ services:
   # ==================== DATA LAYER ====================
 
   cdb_postgres:
-    image: postgres:15.17-alpine
+    image: postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
     container_name: cdb_postgres
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary

Security fix for #1717 (Epic #1649).

**This is not a tag bump.** The repo already uses \postgres:15.17-alpine\ (latest stable 15.x). The operative delta is adding a **digest pin** to lock the 2026-04-16 Alpine security rebuild, consistent with the existing redis pinning convention.

## Change Scope

Exactly 4 lines changed across 3 files:

| File | Line | Change |
|---|---|---|
| \infrastructure/compose/compose.blue.yml\ | 20 | + digest pin |
| \infrastructure/compose/base.yml\ | 34 | + digest pin |
| \.github/workflows/security-scan.yml\ | 43 | + digest pin |
| \.github/workflows/security-scan.yml\ | 249 | + digest pin |

Target: \postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed\
Image rebuilt: 2026-04-16T16:07Z (Alpine 3.23.4)

## Trivy Verification (pre-PR)

Scan: \	rivy image postgres:15.17-alpine@sha256:1c52f5ad... --severity CRITICAL,HIGH\

| Target | Type | CRITICAL | HIGH |
|---|---|---|---|
| Alpine OS (alpine 3.23.4) | alpine | **0** | **0** |
| usr/local/bin/gosu | gobinary | 1 | 7 |

**Alpine OS layer: 0 findings.** libssl3, libcrypto3, libxml2 CVEs are resolved in this build.

**Remaining 8 findings in \gosu\** (Go stdlib CVEs): these are embedded in the \gosu\ binary, not addressable by Alpine package update. Not introduced by this PR; require upstream \gosu\ release.

**Issue body alert count discrepancy**: Issue states 58 alerts; prior triage doc states 49. Both counts were from an earlier \15.17-alpine\ build predating the 2026-04-15/16 Alpine security rebuild.

## Out of Scope

- No redis / Grafana / Prometheus / cdb-base-image touch
- No Docker/Compose cosmetics
- No archive/knowledge doc changes

Closes #1717