### PR TITLE
fix(security): pin python:3.11-slim-trixie to 2026-04-07 rebuild digest (#1716)

### DIFF
--- a/services/allocation/Dockerfile
+++ b/services/allocation/Dockerfile
@@ -1,6 +1,6 @@
 # Allocation Service - Dockerfile
 
-FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
+FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/services/db_writer/Dockerfile
+++ b/services/db_writer/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile - DB Writer Service
 # Claire de Binare Trading Bot
 
-FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
+FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/services/execution/Dockerfile
+++ b/services/execution/Dockerfile
@@ -1,6 +1,6 @@
 # Execution Service - Gehärtetes Image
 # Claire de Binare Trading Bot
-FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39 AS build
+FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf AS build
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
@@ -21,7 +21,7 @@ RUN python -m venv /venv \
     && /venv/bin/pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2 \
     && /venv/bin/pip install --no-cache-dir -r requirements.txt
 
-FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
+FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1

--- a/services/market/Dockerfile
+++ b/services/market/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
+FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/services/regime/Dockerfile
+++ b/services/regime/Dockerfile
@@ -1,6 +1,6 @@
 # Regime Service - Dockerfile
 
-FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
+FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/services/risk/Dockerfile
+++ b/services/risk/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
+FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/services/signal/Dockerfile
+++ b/services/signal/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
+FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 

--- a/services/ws/Dockerfile
+++ b/services/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
+FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Atomic security slice for issue #1716 (Epic #1649).

Updates the pinned sha256 digest for python:3.11-slim-trixie from the stale 2026-03-03 build to the 2026-04-07 Docker Hub rebuild across all 8 affected cdb service Dockerfiles.

**Old digest:** \sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39\
**New digest:** \sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf\ (multi-arch manifest, amd64: sha256:ad65166a…, pushed 2026-04-07)

## Affected files (9 FROM lines in 8 Dockerfiles)

| File | FROM lines changed |
|---|---|
| \services/allocation/Dockerfile\ | 1 |
| \services/db_writer/Dockerfile\ | 1 |
| \services/execution/Dockerfile\ | **2** (multi-stage build + runtime) |
| \services/market/Dockerfile\ | 1 |
| \services/regime/Dockerfile\ | 1 |
| \services/risk/Dockerfile\ | 1 |
| \services/signal/Dockerfile\ | 1 |
| \services/ws/Dockerfile\ | 1 |

## Why cdb_ws is included

\cdb_ws\ was missing from the original #1716 service list but carries the same stale trixie digest and shows open Trivy alerts. It is in scope for this update.

## Why cdb_candles is excluded

\cdb_candles\ uses \python:3.11-slim-bookworm@sha256:65a93d69…\ (a separate image line, not trixie). It has **zero open Trivy alerts** and must not be touched in this slice. The bookworm→trixie migration for candles is a separate concern outside this security scope.

## Issue description note

The #1716 description references \python:3.12-slim-bookworm\ — this was stale. The actual base images in production are \python:3.11-slim-trixie\. The trixie migration happened 2026-03-03 via commit 3fe81d83 (PR #1074); candles and reports were not migrated at that time.

## Expected CVE reduction (pending post-merge Trivy scan)

This PR **may** reduce the following Trivy alerts:
- **CVE-2026-0861** (libc6 \2.41-12+deb13u1\ → \2.41-12+deb13u2\) — ERROR severity
- **CVE-2026-28390** and related openssl cluster (\3.5.4-1~deb13u2\ → \3.5.5-1~deb13u2\) — ERROR severity

⚠️ **Not claimed as fixed until Trivy scan against new builds confirms it.** If the 2026-04-07 rebuild does not include the patched Debian packages, this will be fail-closed documented.

**Not resolved by this PR (no upstream fix):**
- CVE-2025-69720 (ncurses-bin)
- CVE-2026-27456 (util-linux)
- CVE-2026-29111 / CVE-2026-40225/226 (libudev1/libsystemd0)
- CVE-2026-1965 (curl/libcurl4)
- CVE-2026-4046 / 4437 / 4438 (libc6 additional cluster)

## Scope guardrails

- No tag change (still \3.11-slim-trixie\)
- No bookworm/trixie migration
- No changes to Redis, Postgres, Grafana, Prometheus, or reports images
- No refactoring, no formatting, no side-scope changes
- Only the 9 digest strings across 8 Dockerfiles

## Validation

\\\
git diff --stat → 8 files changed, 9 insertions(+), 9 deletions(-)
services/execution/Dockerfile → both FROM lines identical (sha256:233de067…)
services/candles/Dockerfile → unchanged (bookworm sha256:65a93d69…)
\\\

Post-merge: run Trivy scan against freshly built images to confirm CVE reduction.

Closes #1716
Epic: #1649