### PR TITLE
fix(workflows): suppress digest-only architecture follow-up noise (#1726)

### DIFF
--- a/.github/scripts/post_merge_followup_scanner.py
+++ b/.github/scripts/post_merge_followup_scanner.py
@@ -125,6 +125,24 @@ def parse_added_lines(diff_text: str) -> dict[str, list[str]]:
     return added
 
 
+def parse_changed_lines(diff_text: str) -> dict[str, list[tuple[str, str]]]:
+    changed: dict[str, list[tuple[str, str]]] = {}
+    current_file: str | None = None
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith("+++ b/"):
+            current_file = raw_line[6:]
+            changed.setdefault(current_file, [])
+            continue
+        if raw_line.startswith("diff --git "):
+            current_file = None
+            continue
+        if current_file is None:
+            continue
+        if raw_line.startswith(("+", "-")) and not raw_line.startswith(("+++", "---")):
+            changed[current_file].append((raw_line[0], raw_line[1:]))
+    return changed
+
+
 def relative_paths(files: list[dict[str, Any]]) -> list[str]:
     return [entry["path"] for entry in files]
 
@@ -142,6 +160,60 @@ def shortlist(paths: list[str], *, limit: int = 4) -> list[str]:
     if len(paths) <= limit:
         return paths
     return paths[:limit]
+
+
+def strip_image_digest(image_ref: str) -> str:
+    return re.sub(r"@sha256:[0-9a-f]{64}$", "", image_ref.strip(), flags=re.IGNORECASE)
+
+
+def normalize_image_change_line(line: str) -> str | None:
+    compose_match = re.match(r"^\s*image:\s*(?P<ref>\S+)\s*$", line)
+    if compose_match:
+        return f"image:{strip_image_digest(compose_match.group('ref'))}"
+
+    dockerfile_match = re.match(
+        r"^\s*FROM\s+(?P<ref>\S+)(?:\s+AS\s+(?P<alias>\S+))?\s*$",
+        line,
+        flags=re.IGNORECASE,
+    )
+    if dockerfile_match:
+        alias = dockerfile_match.group("alias")
+        suffix = f" AS {alias}" if alias else ""
+        return f"FROM {strip_image_digest(dockerfile_match.group('ref'))}{suffix}"
+
+    return None
+
+
+def is_digest_only_image_change(changes: list[tuple[str, str]]) -> bool:
+    if not changes:
+        return False
+
+    removed: list[str] = []
+    added: list[str] = []
+    saw_digest_reference = False
+
+    for sign, line in changes:
+        normalized = normalize_image_change_line(line)
+        if normalized is None:
+            return False
+        if "@sha256:" in line.lower():
+            saw_digest_reference = True
+        if sign == "-":
+            removed.append(normalized)
+        elif sign == "+":
+            added.append(normalized)
+
+    return saw_digest_reference and sorted(removed) == sorted(added)
+
+
+def service_runtime_changes_are_digest_only(
+    service_runtime_files: list[str],
+    *,
+    changed_lines: dict[str, list[tuple[str, str]]],
+) -> bool:
+    return bool(service_runtime_files) and all(
+        is_digest_only_image_change(changed_lines.get(path, [])) for path in service_runtime_files
+    )
 
 
 def build_finding(
@@ -178,6 +250,7 @@ def detect_findings(pr: dict[str, Any], diff_text: str) -> list[Finding]:
     pr_url = pr["url"]
     pr_title = pr["title"]
     added_lines = parse_added_lines(diff_text)
+    changed_lines = parse_changed_lines(diff_text)
 
     service_runtime_files = [
         path
@@ -193,7 +266,15 @@ def detect_findings(pr: dict[str, Any], diff_text: str) -> list[Finding]:
             "infrastructure/compose/COMPOSE_LAYERS.md",
         }
     ]
-    if service_runtime_files and not touched(active_files, ARCHITECTURE_DOCS):
+    digest_only_service_runtime_change = service_runtime_changes_are_digest_only(
+        service_runtime_files,
+        changed_lines=changed_lines,
+    )
+    if (
+        service_runtime_files
+        and not digest_only_service_runtime_change
+        and not touched(active_files, ARCHITECTURE_DOCS)
+    ):
         trigger_files = shortlist(service_runtime_files)
         affected_candidates = trigger_files + ARCHITECTURE_DOCS
         finding_input = f"""

--- a/.github/scripts/post_merge_followup_scanner.py
+++ b/.github/scripts/post_merge_followup_scanner.py
@@ -203,7 +203,7 @@ def is_digest_only_image_change(changes: list[tuple[str, str]]) -> bool:
         elif sign == "+":
             added.append(normalized)
 
-    return saw_digest_reference and sorted(removed) == sorted(added)
+    return saw_digest_reference and removed == added
 
 
 def service_runtime_changes_are_digest_only(

--- a/tests/unit/scripts/test_post_merge_followup_scanner.py
+++ b/tests/unit/scripts/test_post_merge_followup_scanner.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCANNER_PATH = REPO_ROOT / ".github" / "scripts" / "post_merge_followup_scanner.py"
+
+_SPEC = importlib.util.spec_from_file_location("post_merge_followup_scanner", SCANNER_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+scanner = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = scanner
+_SPEC.loader.exec_module(scanner)
+
+
+def _make_pr(number: int, title: str, *paths: str) -> dict[str, object]:
+    return {
+        "number": number,
+        "url": f"https://github.com/jannekbuengener/Claire_de_Binare/pull/{number}",
+        "title": title,
+        "files": [{"path": path} for path in paths],
+    }
+
+
+def _rule_ids(findings: list[object]) -> set[str]:
+    return {finding.rule_id for finding in findings}
+
+
+def test_digest_only_compose_pin_does_not_trigger_architecture_followup() -> None:
+    pr = _make_pr(
+        1719,
+        "fix(security): pin postgres:15.17-alpine to rebuild digest",
+        "infrastructure/compose/compose.blue.yml",
+        "infrastructure/compose/base.yml",
+        ".github/workflows/security-scan.yml",
+    )
+    diff_text = """\
+diff --git a/infrastructure/compose/compose.blue.yml b/infrastructure/compose/compose.blue.yml
++++ b/infrastructure/compose/compose.blue.yml
+@@ -17,7 +17,7 @@ services:
+-    image: postgres:15.17-alpine
++    image: postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
+"""
+
+    findings = scanner.detect_findings(pr, diff_text)
+
+    assert "architecture_service_catalog_drift" not in _rule_ids(findings)
+
+
+def test_digest_only_dockerfile_pin_does_not_trigger_architecture_followup() -> None:
+    pr = _make_pr(
+        1722,
+        "fix(security): pin python:3.11-slim-trixie to rebuild digest",
+        "services/allocation/Dockerfile",
+        "services/execution/Dockerfile",
+    )
+    diff_text = """\
+diff --git a/services/allocation/Dockerfile b/services/allocation/Dockerfile
++++ b/services/allocation/Dockerfile
+@@ -1,4 +1,4 @@
+-FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
++FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+diff --git a/services/execution/Dockerfile b/services/execution/Dockerfile
++++ b/services/execution/Dockerfile
+@@ -1,6 +1,6 @@
+-FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39 AS build
++FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf AS build
+@@ -21,7 +21,7 @@
+-FROM python:3.11-slim-trixie@sha256:c8271b1f627d0068857dce5b53e14a9558603b527e46f1f901722f935b786a39
++FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+"""
+
+    findings = scanner.detect_findings(pr, diff_text)
+
+    assert "architecture_service_catalog_drift" not in _rule_ids(findings)
+
+
+def test_tag_change_still_triggers_architecture_followup() -> None:
+    pr = _make_pr(
+        2001,
+        "fix(security): move postgres to new tag",
+        "infrastructure/compose/compose.blue.yml",
+    )
+    diff_text = """\
+diff --git a/infrastructure/compose/compose.blue.yml b/infrastructure/compose/compose.blue.yml
++++ b/infrastructure/compose/compose.blue.yml
+@@ -17,7 +17,7 @@ services:
+-    image: postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
++    image: postgres:15.18-alpine@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"""
+
+    findings = scanner.detect_findings(pr, diff_text)
+
+    assert "architecture_service_catalog_drift" in _rule_ids(findings)
+
+
+def test_new_service_surface_still_triggers_architecture_followup() -> None:
+    pr = _make_pr(
+        2002,
+        "feat(runtime): add operator sidecar",
+        "infrastructure/compose/compose.blue.yml",
+    )
+    diff_text = """\
+diff --git a/infrastructure/compose/compose.blue.yml b/infrastructure/compose/compose.blue.yml
++++ b/infrastructure/compose/compose.blue.yml
+@@ -30,0 +31,4 @@ services:
++  cdb_sidecar:
++    image: busybox:1.36.1@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
++    container_name: cdb_sidecar
++    restart: unless-stopped
+"""
+
+    findings = scanner.detect_findings(pr, diff_text)
+
+    assert "architecture_service_catalog_drift" in _rule_ids(findings)

--- a/tests/unit/scripts/test_post_merge_followup_scanner.py
+++ b/tests/unit/scripts/test_post_merge_followup_scanner.py
@@ -80,6 +80,27 @@ diff --git a/services/execution/Dockerfile b/services/execution/Dockerfile
     assert "architecture_service_catalog_drift" not in _rule_ids(findings)
 
 
+def test_image_swaps_do_not_count_as_digest_only_change() -> None:
+    pr = _make_pr(
+        2003,
+        "refactor(runtime): swap images between services",
+        "infrastructure/compose/compose.blue.yml",
+    )
+    diff_text = """\
+diff --git a/infrastructure/compose/compose.blue.yml b/infrastructure/compose/compose.blue.yml
++++ b/infrastructure/compose/compose.blue.yml
+@@ -10,8 +10,8 @@ services:
+-    image: service-a:1.0.0@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+-    image: service-b:2.0.0@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
++    image: service-b:2.0.0@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
++    image: service-a:1.0.0@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+"""
+
+    findings = scanner.detect_findings(pr, diff_text)
+
+    assert "architecture_service_catalog_drift" in _rule_ids(findings)
+
+
 def test_tag_change_still_triggers_architecture_followup() -> None:
     pr = _make_pr(
         2001,


### PR DESCRIPTION
## Summary
- suppress false-positive architecture_service_catalog_drift follow-up issues for digest-only image pin changes
- keep detection intact for semantic tag/version changes and new service/runtime surfaces
- add targeted regression tests for both false-positive patterns and the semantic-change guardrails

## Root Cause
The post-merge follow-up scanner treated any service/runtime-adjacent diff as a possible architecture/service-catalog drift candidate when knowledge/ARCHITECTURE_MAP.md and knowledge/governance/SERVICE_CATALOG.md were not touched in the same PR.

That was too broad for digest-only image pins:
- PR #1719 changed postgres:15.17-alpine to the same tag plus a digest
- PR #1722 changed python:3.11-slim-trixie@old to python:3.11-slim-trixie@new

In both cases the semantic image tag stayed unchanged and no new runtime surface was introduced.

## What Changed
- teach .github/scripts/post_merge_followup_scanner.py to recognize digest-only image and FROM changes with unchanged semantic tags
- suppress architecture_service_catalog_drift only for that narrow case
- keep existing follow-up detection for actual tag/version changes and new service/runtime surfaces
- add regression coverage in tests/unit/scripts/test_post_merge_followup_scanner.py

## Validation
- python -m pytest tests/unit/scripts/test_post_merge_followup_scanner.py tests/test_control_plane.py -q
- result: 15 passed

## Policy Gate Note
- allow-core-change label applied because this is a narrow .github/scripts code change, not a docs-only or workflows-only slice

Closes #1726