### PR TITLE
docs(security): reconcile stale baseline references for #1649 closeout

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -380,7 +380,7 @@ jobs:
           echo "**gosu Binary CVEs in Redis/Postgres base images:**" >> $GITHUB_STEP_SUMMARY
           echo "- 4 CRITICAL + 40 HIGH CVEs from Go stdlib 1.18.2" >> $GITHUB_STEP_SUMMARY
           echo "- Risk: LOW (startup-only, no network exposure)" >> $GITHUB_STEP_SUMMARY
-          echo "- Documented in: \`docs/security/TRIAGE_RUNBOOK.md\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Documented in: [docs/security/TRIAGE_RUNBOOK.md](docs/security/TRIAGE_RUNBOOK.md)" >> $GITHUB_STEP_SUMMARY
           echo "- Upstream tracking: docker-library/redis, docker-library/postgres" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Custom Images" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -380,7 +380,7 @@ jobs:
           echo "**gosu Binary CVEs in Redis/Postgres base images:**" >> $GITHUB_STEP_SUMMARY
           echo "- 4 CRITICAL + 40 HIGH CVEs from Go stdlib 1.18.2" >> $GITHUB_STEP_SUMMARY
           echo "- Risk: LOW (startup-only, no network exposure)" >> $GITHUB_STEP_SUMMARY
-          echo "- Documented in: \`docs/security/SECURITY_BASELINE.md\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Documented in: \`docs/security/TRIAGE_RUNBOOK.md\`" >> $GITHUB_STEP_SUMMARY
           echo "- Upstream tracking: docker-library/redis, docker-library/postgres" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Custom Images" >> $GITHUB_STEP_SUMMARY
@@ -391,7 +391,7 @@ jobs:
 
 # IMPORTANT NOTES:
 # 1. Base image scans (Redis/Postgres) set exit-code: false
-#    - gosu CVEs are documented as accepted risk in docs/security/SECURITY_BASELINE.md
+#    - gosu CVEs are documented in docs/security/TRIAGE_RUNBOOK.md
 #    - Attack surface: minimal (startup-only, no network exposure)
 #    - Weekly scans monitor for NEW vulnerabilities
 #

--- a/knowledge/operating_rules/ci_cd/TROUBLESHOOTING.md
+++ b/knowledge/operating_rules/ci_cd/TROUBLESHOOTING.md
@@ -77,7 +77,7 @@ docker run --rm aquasec/trivy image cdb_signal:latest
 
 ### Known Accepted Risks
 Base images (Redis, Postgres) have gosu CVEs that are documented as accepted risk.
-See `docs/security/TRIAGE_RUNBOOK.md`.
+See [docs/security/TRIAGE_RUNBOOK.md](../../../docs/security/TRIAGE_RUNBOOK.md).
 
 ---
 
@@ -309,7 +309,7 @@ pytest ...
 
 1. **Check existing issues:** Search for similar problems
 2. **CI/CD Documentation:** See `CI_PIPELINE_GUIDE.md`
-3. **Security Issues:** See `docs/security/TRIAGE_RUNBOOK.md`
+3. **Security Issues:** See [docs/security/TRIAGE_RUNBOOK.md](../../../docs/security/TRIAGE_RUNBOOK.md)
 4. **Create issue:** Use `type:bug` + `scope:ci` labels
 
 ---

--- a/knowledge/operating_rules/ci_cd/TROUBLESHOOTING.md
+++ b/knowledge/operating_rules/ci_cd/TROUBLESHOOTING.md
@@ -77,7 +77,7 @@ docker run --rm aquasec/trivy image cdb_signal:latest
 
 ### Known Accepted Risks
 Base images (Redis, Postgres) have gosu CVEs that are documented as accepted risk.
-See `docs/security/SECURITY_BASELINE.md`.
+See `docs/security/TRIAGE_RUNBOOK.md`.
 
 ---
 
@@ -309,7 +309,7 @@ pytest ...
 
 1. **Check existing issues:** Search for similar problems
 2. **CI/CD Documentation:** See `CI_PIPELINE_GUIDE.md`
-3. **Security Issues:** See `docs/security/SECURITY_BASELINE.md`
+3. **Security Issues:** See `docs/security/TRIAGE_RUNBOOK.md`
 4. **Create issue:** Use `type:bug` + `scope:ci` labels
 
 ---


### PR DESCRIPTION
## Summary
Reconciles the last active `docs/security/SECURITY_BASELINE.md` drift before epic #1649 closeout.

## Changes
- update `knowledge/operating_rules/ci_cd/TROUBLESHOOTING.md` to point to `docs/security/TRIAGE_RUNBOOK.md`
- update `.github/workflows/security-scan.yml` summary/comments to point to `docs/security/TRIAGE_RUNBOOK.md`
- no scanner logic changes, no workflow redesign, no security-model changes

## Why
`docs/security/SECURITY_BASELINE.md` no longer exists. `docs/security/TRIAGE_RUNBOOK.md` is the current generic security front-door; `docs/security/TRIVY_TRIAGE_1651.md` remains Trivy-specific supporting detail.

## Validation
- active references to `docs/security/SECURITY_BASELINE.md` removed from the touched active files
- no code changes
- narrow slice only, scoped to epic #1649

Part of #1649