### PR TITLE
security: fix code injection + stabilize SARIF categories (#1743)

### DIFF
--- a/.github/workflows/emoji-bot.yml
+++ b/.github/workflows/emoji-bot.yml
@@ -69,9 +69,9 @@ jobs:
     
     - name: 🤖 Process Bot Command
       id: bot-command
+      env:
+        COMMENT_BODY: ${{ github.event.comment.body }}
       run: |
-        COMMENT_BODY="${{ github.event.comment.body }}"
-        
         if [[ "$COMMENT_BODY" == *"/emoji-fix"* ]]; then
           echo "command=fix" >> $GITHUB_OUTPUT
           echo "🔧 Auto-Fix Befehl erkannt"
@@ -127,10 +127,10 @@ jobs:
     
     - name: 📝 Update Whitelist
       if: steps.bot-command.outputs.command == 'whitelist'
+      env:
+        EMOJIS: ${{ steps.bot-command.outputs.whitelist_emojis }}
       run: |
         echo "📝 Update Whitelist..."
-        
-        EMOJIS="${{ steps.bot-command.outputs.whitelist_emojis }}"
         
         if [ -n "$EMOJIS" ]; then
           # Backup Config
@@ -140,9 +140,10 @@ jobs:
           python -c "
         import yaml
         import sys
+        import os
 
         config_path = '.github/emoji-config.yaml'
-        emojis = '$EMOJIS'.strip().split()
+        emojis = os.environ.get('EMOJIS', '').strip().split()
 
         with open(config_path, 'r') as f:
             config = yaml.safe_load(f)

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -38,11 +38,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image:
-          - redis:7.4.8-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065
-          - postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
-          - prom/prometheus:v3.10.0@sha256:4a61322ac1103a0e3aea2a61ef1718422a48fa046441f299d71e660a3bc71ae9
-          - grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
+        include:
+          - image: redis:7.4.8-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065
+            scan_name: redis
+          - image: postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
+            scan_name: postgres
+          - image: prom/prometheus:v3.10.0@sha256:4a61322ac1103a0e3aea2a61ef1718422a48fa046441f299d71e660a3bc71ae9
+            scan_name: prometheus
+          - image: grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
+            scan_name: grafana
       fail-fast: false
 
     steps:
@@ -98,6 +102,7 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-${{ env.TRIVY_SAFE_IMAGE }}.sarif'
+          category: 'trivy-base-${{ matrix.scan_name }}'
 
   trivy-scan-custom:
     name: Trivy - Custom Services
@@ -234,6 +239,7 @@ jobs:
         if: always() && steps.build_custom_image.outcome == 'success'
         with:
           sarif_file: 'trivy-cdb_${{ matrix.service }}.sarif'
+          category: 'trivy-custom-${{ matrix.service }}'
 
   # ============================================================================
   # DOCKER SCOUT SCANNING (Original)


### PR DESCRIPTION
## Summary

Addresses **Phase 1 + Phase 2** of #1743 (stale code-scanning baseline reset).

### Phase 1: CRITICAL code injection fix (emoji-bot.yml)

Mitigates CodeQL alert #1511 (actions/code-injection/critical):

- **Site 1 (line 73):** github.event.comment.body was interpolated directly into a run: shell block. Moved to env: block; shell reads from COMMENT_BODY.
- **Site 2 (line 133):** Step output whitelist_emojis was re-interpolated into shell. Moved to env: block.
- **Site 3 (line 145):** Shell variable EMOJIS was embedded in inline Python via string interpolation. Changed to os.environ.get.

All three sites now use environment variables, preventing shell injection from untrusted PR comment content.

### Phase 2: Stable SARIF categories (security-scan.yml)

Root cause of the stale baseline: upload-sarif auto-derives its category from workflow path + matrix values. When matrix values contain image refs with tags/digests, every version bump creates a new category. Old-category alerts are never auto-closed.

Fix:
- Restructured trivy-scan-base matrix to include format with stable scan_name property
- Added explicit category to both base image and custom service SARIF uploads

Category schema: trivy-base-redis, trivy-base-postgres, trivy-base-prometheus, trivy-base-grafana, trivy-custom-allocation, trivy-custom-db_writer, trivy-custom-execution, trivy-custom-market, trivy-custom-regime, trivy-custom-risk, trivy-custom-signal, trivy-custom-ws

### Next steps (after merge)

- Phase 4: Delete orphaned SARIF analyses from old volatile categories
- Phase 3: Gitleaks allowlist hardening (separate slice)
- Phase 5: Document new baseline

Relates to #1743
