### PR TITLE
fix(workflow): avoid inline whitelist interpolation in emoji bot

### DIFF
--- a/.github/workflows/emoji-bot.yml
+++ b/.github/workflows/emoji-bot.yml
@@ -207,6 +207,12 @@ jobs:
           const whitelistUpdated = process.env.whitelist_updated === 'true';
           const whitelistEmojis = process.env.WHITELIST_EMOJIS || '';
           const blockedCount = process.env.blocked_count || '0';
+          const sanitizeReflectedText = (value) => {
+            const compactValue = value.replace(/\r?\n+/g, ' ').trim();
+            if (!compactValue) return '(leer)';
+            return compactValue.replace(/@/g, '@\u200b').replace(/`/g, "'");
+          };
+          const safeWhitelistEmojis = sanitizeReflectedText(whitelistEmojis);
           
           let replyText = `🤖 **Emoji Bot Response**\n\n`;
           
@@ -228,7 +234,7 @@ jobs:
           } else if (command === 'whitelist') {
             if (whitelistUpdated) {
               replyText += `✅ **Whitelist erfolgreich aktualisiert!**\n\n`;
-              replyText += `📝 Emojis wurden zur Whitelist hinzugefügt: ${whitelistEmojis}\n`;
+              replyText += `📝 Emojis wurden zur Whitelist hinzugefügt: \`${safeWhitelistEmojis}\`\n`;
               replyText += `📋 Verbleibende blockierte Emojis: ${blockedCount}\n`;
             } else {
               replyText += `❌ **Whitelist-Update fehlgeschlagen.**\n\n`;

--- a/.github/workflows/emoji-bot.yml
+++ b/.github/workflows/emoji-bot.yml
@@ -198,11 +198,14 @@ jobs:
     
     - name: 💬 Reply to Comment
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        WHITELIST_EMOJIS: ${{ steps.bot-command.outputs.whitelist_emojis }}
       with:
         script: |
           const command = '${{ steps.bot-command.outputs.command }}';
           const fixApplied = process.env.fix_applied === 'true';
           const whitelistUpdated = process.env.whitelist_updated === 'true';
+          const whitelistEmojis = process.env.WHITELIST_EMOJIS || '';
           const blockedCount = process.env.blocked_count || '0';
           
           let replyText = `🤖 **Emoji Bot Response**\n\n`;
@@ -225,7 +228,7 @@ jobs:
           } else if (command === 'whitelist') {
             if (whitelistUpdated) {
               replyText += `✅ **Whitelist erfolgreich aktualisiert!**\n\n`;
-              replyText += `📝 Emojis wurden zur Whitelist hinzugefügt: ${{ steps.bot-command.outputs.whitelist_emojis }}\n`;
+              replyText += `📝 Emojis wurden zur Whitelist hinzugefügt: ${whitelistEmojis}\n`;
               replyText += `📋 Verbleibende blockierte Emojis: ${blockedCount}\n`;
             } else {
               replyText += `❌ **Whitelist-Update fehlgeschlagen.**\n\n`;


### PR DESCRIPTION
## Summary
- address current-main-backed CodeQL alert `#3616` in `.github/workflows/emoji-bot.yml`
- pass `whitelist_emojis` through step `env` instead of interpolating `${{ ... }}` directly into the `github-script` block
- keep the slice narrow to the reply step only

## Validation
- live Code Scanning alert `#3616` verified as open on `main` at `f13f3ccb76588d5f73070aa0be2174e033ebbf6b`
- local diff limited to `.github/workflows/emoji-bot.yml`
- staged diff verified before commit

Closes #1747