### PR TITLE
fix(workflows): set explicit token permissions for CodeQL residuals

### DIFF
--- a/.github/workflows/emoji-bot.yml
+++ b/.github/workflows/emoji-bot.yml
@@ -301,6 +301,8 @@ jobs:
   help-command:
     name: ❓ Bot Help
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     if: |
       github.event.issue.pull_request && 
       (contains(github.event.comment.body, '/emoji-help') || 

--- a/.github/workflows/emoji-filter.yml
+++ b/.github/workflows/emoji-filter.yml
@@ -19,6 +19,9 @@ on:
         default: '.'
         type: string
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.11'
 
@@ -26,6 +29,8 @@ jobs:
   emoji-detection:
     name: 🔍 Emoji Detection
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     outputs:
       emojis-found: ${{ steps.scan.outputs.emojis-found }}

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -3,6 +3,8 @@ name: Gemini Dispatch
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   noop:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 0 * * *'  # Daily at midnight UTC
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- address the `actions/missing-workflow-permissions` residual cluster on current `main`
- add explicit minimal `permissions` in affected workflows/jobs only
- keep slice limited to 4 workflow files and no other CodeQL groups

## Targeted residual alerts
- `.github/workflows/stale.yml` (#3617)
- `.github/workflows/gemini-dispatch.yml` (#1868)
- `.github/workflows/emoji-bot.yml` help-command job (#2210)
- `.github/workflows/emoji-filter.yml` jobs at lines 27/158/399 (#1531, #1532, #1835)

## Notes
- no Trivy/Gitleaks scope
- no broad backlog sweep
- baseline test suite already has one unrelated known failure in `tests/unit/test_clock.py::test_guardrails_no_forbidden_calls`