### PR TITLE
fix(codeql): harden testnet host assertion

### DIFF
--- a/tests/integration/test_mexc_testnet.py
+++ b/tests/integration/test_mexc_testnet.py
@@ -175,7 +175,9 @@ class TestMexcTestnetExternal:
     def test_testnet_client_initialization(self, external_client):
         """Verify testnet client is properly initialized."""
         assert external_client is not None
-        assert "testnet" in external_client.base_url.lower() or "contract.mexc.com" in external_client.base_url
+        parsed_url = urlparse(external_client.base_url)
+        hostname = (parsed_url.hostname or "").lower()
+        assert "testnet" in hostname or hostname == "contract.mexc.com"
         logger.info("Testnet client initialized")
 
     def test_get_account_balance(self, external_client):

--- a/tests/integration/test_mexc_testnet.py
+++ b/tests/integration/test_mexc_testnet.py
@@ -177,7 +177,8 @@ class TestMexcTestnetExternal:
         assert external_client is not None
         parsed_url = urlparse(external_client.base_url)
         hostname = (parsed_url.hostname or "").lower()
-        assert "testnet" in hostname or hostname == "contract.mexc.com"
+        assert parsed_url.scheme == "https"
+        assert hostname == "contract.mexc.com"
         logger.info("Testnet client initialized")
 
     def test_get_account_balance(self, external_client):


### PR DESCRIPTION
## Summary
- replace substring-based URL assertion in testnet integration test
- parse URL and validate hostname explicitly

## Scope
- single finding slice: py/incomplete-url-substring-sanitization (#1776)
- no Trivy, no Gitleaks, no broad sweep
- no docs scope (#1746 untouched)
