### PR TITLE
fix(codeql): remove stack-trace exposure from service responses

### DIFF
--- a/core/safety/kill_switch.py
+++ b/core/safety/kill_switch.py
@@ -108,7 +108,7 @@ class KillSwitch:
             return {
                 "state": KillSwitchState.ACTIVE.value,
                 "reason": KillSwitchReason.SYSTEM_ERROR.value,
-                "message": f"State file read error: {e}",
+                "message": "State file read error",
                 "activated_at": utcnow().isoformat(),
             }
 

--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -912,7 +912,7 @@ if _FLASK_AVAILABLE:
             return jsonify({"count": len(recent_orders), "orders": recent_orders}), 200
         except Exception as e:
             logger.error(f"Error retrieving orders: {e}")
-            return jsonify({"error": str(e)}), 500
+            return jsonify({"error": "internal_server_error"}), 500
 
 else:
     app = None

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -2523,7 +2523,8 @@ if _FLASK_AVAILABLE:
                 state_file=state_file, create_if_missing=False
             )
         except Exception as exc:
-            return jsonify({"error": f"state read failed: {exc}"}), 500
+            logger.error(f"Kill-switch state read failed: {exc}")
+            return jsonify({"error": "state_read_failed"}), 500
         return jsonify(
             {
                 "active": active,


### PR DESCRIPTION
## Summary
- replace raw exception payloads in execution/risk HTTP error responses with safe error codes
- remove exception text from kill-switch state fallback message to prevent propagation to API responses

## Scope
- cluster slice: py/stack-trace-exposure (5)
- no Trivy, no Gitleaks, no broad sweep
- docs PR #1746 untouched
