### PR TITLE
docs(control): reconcile workflow note after PR #1757

### DIFF
--- a/docs/runbooks/CONTROL_REGISTER.md
+++ b/docs/runbooks/CONTROL_REGISTER.md
@@ -88,7 +88,7 @@ Kontext-Issue-Nummern sind historische Anker (alle CLOSED) — nicht als offene 
 
 - `security-scan.yml`: Trivy-SARIF-Uploads muessen explizit stabile Kategorien verwenden (`trivy-base-*`, `trivy-custom-*`), damit Digest-/Tag-Bumps keine neuen Code-Scanning-Baselines aufspalten. Security-Triage und Dismiss-Cluster bleiben im `docs/security/TRIAGE_RUNBOOK.md` verankert.
 - `emoji-bot.yml`: Kommentarinhalt aus `issue_comment` bleibt untrusted Input und darf nur ueber `env`/kontrollierte Uebergaben in Shell- oder Python-Schritte fliessen. Der Workflow ist ein Operator-Helfer, keine Evidenz- oder Freigabe-Surface. Bekannte Residual-Haertung fuer multiline-Outputs an `$GITHUB_OUTPUT` bleibt separater Folgescope und wird hier nicht ueberdehnt.
-- `.github/scripts/advanced-emoji-filter.py`: Emoji-Erkennung laeuft fail-closed ueber `emoji.emoji_list(...)` statt ueber breite Unicode-Range-Regexe (CodeQL `py/overly-large-range` Nachzug aus PR #1757). Der Script bleibt ein Operator-Helper fuer Kommentarhygiene; keine LR-/Freigabe-Evidenz ableiten.
+- `.github/scripts/advanced-emoji-filter.py`: Emoji-Erkennung laeuft fail-closed primaer ueber `emoji.emoji_list(...)`; die frueheren breiten Unicode-Range-Regexe wurden im CodeQL-Nachzug aus PR #1757 entfernt. Der Script bleibt ein Operator-Helper fuer Kommentarhygiene; keine LR-/Freigabe-Evidenz ableiten.
 
 ---
 

--- a/docs/runbooks/CONTROL_REGISTER.md
+++ b/docs/runbooks/CONTROL_REGISTER.md
@@ -88,6 +88,7 @@ Kontext-Issue-Nummern sind historische Anker (alle CLOSED) — nicht als offene 
 
 - `security-scan.yml`: Trivy-SARIF-Uploads muessen explizit stabile Kategorien verwenden (`trivy-base-*`, `trivy-custom-*`), damit Digest-/Tag-Bumps keine neuen Code-Scanning-Baselines aufspalten. Security-Triage und Dismiss-Cluster bleiben im `docs/security/TRIAGE_RUNBOOK.md` verankert.
 - `emoji-bot.yml`: Kommentarinhalt aus `issue_comment` bleibt untrusted Input und darf nur ueber `env`/kontrollierte Uebergaben in Shell- oder Python-Schritte fliessen. Der Workflow ist ein Operator-Helfer, keine Evidenz- oder Freigabe-Surface. Bekannte Residual-Haertung fuer multiline-Outputs an `$GITHUB_OUTPUT` bleibt separater Folgescope und wird hier nicht ueberdehnt.
+- `.github/scripts/advanced-emoji-filter.py`: Emoji-Erkennung laeuft fail-closed ueber `emoji.emoji_list(...)` statt ueber breite Unicode-Range-Regexe (CodeQL `py/overly-large-range` Nachzug aus PR #1757). Der Script bleibt ein Operator-Helper fuer Kommentarhygiene; keine LR-/Freigabe-Evidenz ableiten.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a focused control note for the #1757 change in .github/scripts/advanced-emoji-filter.py
- document that emoji detection now uses moji.emoji_list(...) instead of broad Unicode range regexes
- keep scope strictly on control/runbook reconciliation for this single follow-up slice

## Scope
- narrow docs/control follow-up only
- no Trivy, no Gitleaks, no security broad-sweep
- no architecture/runtime/docs bundle

## Validation
- control-first read order completed: CONTROL_REGISTER.md -> #1445 -> CURRENT_STATUS.md -> LR-AUDIT status -> live GitHub
- verified #1757 touched only .github/scripts/advanced-emoji-filter.py
- verified #1758 follow-up target is docs/runbooks/CONTROL_REGISTER.md

Closes #1758