### PR TITLE
docs(control): reconcile workflow permissions note after PR #1749

### DIFF
--- a/docs/runbooks/CONTROL_REGISTER.md
+++ b/docs/runbooks/CONTROL_REGISTER.md
@@ -89,6 +89,7 @@ Kontext-Issue-Nummern sind historische Anker (alle CLOSED) — nicht als offene 
 - `security-scan.yml`: Trivy-SARIF-Uploads muessen explizit stabile Kategorien verwenden (`trivy-base-*`, `trivy-custom-*`), damit Digest-/Tag-Bumps keine neuen Code-Scanning-Baselines aufspalten. Security-Triage und Dismiss-Cluster bleiben im `docs/security/TRIAGE_RUNBOOK.md` verankert.
 - `emoji-bot.yml`: Kommentarinhalt aus `issue_comment` bleibt untrusted Input und darf nur ueber `env`/kontrollierte Uebergaben in Shell- oder Python-Schritte fliessen. Der Workflow ist ein Operator-Helfer, keine Evidenz- oder Freigabe-Surface. Bekannte Residual-Haertung fuer multiline-Outputs an `$GITHUB_OUTPUT` bleibt separater Folgescope und wird hier nicht ueberdehnt.
 - `.github/scripts/advanced-emoji-filter.py`: Emoji-Erkennung laeuft fail-closed primaer ueber `emoji.emoji_list(...)`; die frueheren breiten Unicode-Range-Regexe wurden im CodeQL-Nachzug aus PR #1757 entfernt. Der Script bleibt ein Operator-Helper fuer Kommentarhygiene; keine LR-/Freigabe-Evidenz ableiten.
+- Workflow-Permissions aus PR #1749: `.github/workflows/stale.yml` nutzt explizit `issues: write` + `pull-requests: write`, `emoji-filter.yml` fuehrt top-level `contents: read` plus job-spezifisches `contents: write`, `emoji-bot.yml` setzt fuer `help-command` explizit `issues: write`, `gemini-dispatch.yml` bleibt mit `permissions: {}` fail-closed. Diese Grants sind eng auf den jeweiligen Automationszweck begrenzt.
 
 ---
 


### PR DESCRIPTION
## Summary
- document the explicit workflow token-permission changes introduced in PR #1749
- record the fail-closed scope for stale.yml, moji-filter.yml, moji-bot.yml, and gemini-dispatch.yml
- keep this follow-up strictly within the control register slice

## Scope
- minimal docs/control follow-up only
- no Trivy/Gitleaks/security broad sweep
- no architecture/runtime expansion

## Validation
- control-first read order completed before live GitHub reconciliation
- verified #1749 changed only workflow permission surfaces in the four referenced workflow files
- verified missing control-note drift in docs/runbooks/CONTROL_REGISTER.md

Closes #1750