### PR TITLE
security: narrow Prometheus base-image refresh for Trivy

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -43,7 +43,7 @@ jobs:
             scan_name: redis
           - image: postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
             scan_name: postgres
-          - image: prom/prometheus:v3.10.0@sha256:4a61322ac1103a0e3aea2a61ef1718422a48fa046441f299d71e660a3bc71ae9
+          - image: prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78
             scan_name: prometheus
           - image: grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
             scan_name: grafana

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -56,7 +56,7 @@ services:
       - cdb_network
 
   cdb_prometheus:
-    image: prom/prometheus:v3.10.0@sha256:4a61322ac1103a0e3aea2a61ef1718422a48fa046441f299d71e660a3bc71ae9
+    image: prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78
     container_name: cdb_prometheus
     restart: unless-stopped
     volumes:

--- a/infrastructure/compose/compose.prometheus-v3.yml
+++ b/infrastructure/compose/compose.prometheus-v3.yml
@@ -4,7 +4,7 @@
 #
 # Scope:
 # - Adds an optional parallel Prometheus v3 canary service
-# - Does not change default runtime service cdb_prometheus (v2.55.0)
+# - Does not change default runtime service cdb_prometheus (v3.11.2)
 
 services:
   cdb_prometheus_v3:

--- a/infrastructure/compose/compose.prometheus-v3.yml
+++ b/infrastructure/compose/compose.prometheus-v3.yml
@@ -8,7 +8,7 @@
 
 services:
   cdb_prometheus_v3:
-    image: prom/prometheus:v3.10.0@sha256:4a61322ac1103a0e3aea2a61ef1718422a48fa046441f299d71e660a3bc71ae9
+    image: prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78
     container_name: cdb_prometheus_v3
     restart: unless-stopped
     profiles:

--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -92,7 +92,7 @@ services:
   # ==================== MONITORING ====================
 
   cdb_prometheus:
-    image: prom/prometheus:v3.10.0@sha256:4a61322ac1103a0e3aea2a61ef1718422a48fa046441f299d71e660a3bc71ae9
+    image: prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78
     container_name: cdb_prometheus
     restart: unless-stopped
     volumes:

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -59,7 +59,7 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 
 | Service | Container | Image | Port | Status | Funktion |
 |---------|-----------|-------|------|--------|----------|
-| **Prometheus** | cdb_prometheus | prom/prometheus:v3.10.0 | 19090→9090 | **AKTIV** | Metrics Collection |
+| **Prometheus** | cdb_prometheus | prom/prometheus:v3.11.2 | 19090→9090 | **AKTIV** | Metrics Collection |
 | **Grafana** | cdb_grafana | grafana/grafana:11.4.7 | 3000 | **AKTIV** | Dashboards |
 | **Postgres Exporter** | cdb_postgres_exporter | prometheuscommunity/postgres-exporter | 9187 | **AKTIV** | PG Metrics |
 | **Redis Exporter** | cdb_redis_exporter | bitnami/redis-exporter | 9121 | **AKTIV** | Redis Metrics |


### PR DESCRIPTION
## Summary\n- bump Prometheus image refs from 3.10.0@sha256:4a61322... to 3.11.2@sha256:5550dc63...\n- keep scope strictly on Prometheus surfaces used by runtime compose + Trivy base-image scanning\n- align service catalog image version entry\n\n## Why\n- Prometheus release 3.11.2 includes the fix for CVE-2026-40179\n- this is the smallest forward update path from current 3.10.0 without broad base-image sweep\n\n## Scope guardrails\n- no Grafana/Redis/Postgres changes\n- no workflow category changes\n- no policy/governance expansion\n\nRefs #1445