### PR TITLE
security: narrow Redis digest refresh for Trivy reduction

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -251,7 +251,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - redis:7.4.8-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065
+          - redis:7.4.8-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6
           - postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
       fail-fast: false
 
@@ -411,6 +411,6 @@ jobs:
 #    - Re-scan after base image updates
 #
 # 4. For manual scans:
-#    docker scout cves redis:7.4.8-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065 --only-severities critical,high
+#    docker scout cves redis:7.4.8-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6 --only-severities critical,high
 #    docker scout cves postgres:15.17-alpine --only-severities critical,high
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - image: redis:7.4.8-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065
+          - image: redis:7.4.8-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6
             scan_name: redis
           - image: postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
             scan_name: postgres

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -13,7 +13,7 @@ name: ${STACK_NAME:-cdb}
 
 services:
   cdb_redis:
-    image: redis:7.4.8-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065
+    image: redis:7.4.8-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6
     container_name: cdb_redis
     restart: unless-stopped
     volumes:

--- a/infrastructure/compose/compose.blue.yml
+++ b/infrastructure/compose/compose.blue.yml
@@ -42,7 +42,7 @@ services:
       - cdb_network
 
   cdb_redis:
-    image: redis:7.4.8-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065
+    image: redis:7.4.8-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6
     container_name: cdb_redis
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary\n- refresh pinned digest for edis:7.4.8-alpine from sha256:8b81dd37... to sha256:7aec734b...\n- keep semantic tag unchanged (digest-only slice)\n- update only Redis scan/runtime surfaces\n\n## Scope\n- .github/workflows/security-scan.yml\n- infrastructure/compose/base.yml\n- infrastructure/compose/compose.blue.yml\n\n## Evidence (live)\n- fresh main scan after PR #1767: Trivy open total 625, 	rivy-base-redis=15\n- candidate branch scan (24627734152): Trivy open total 610, 	rivy-base-redis=0\n\n## Guardrails\n- no Grafana/Postgres/Prometheus changes in this slice\n- no #1725 touch\n\nRefs #1445