### PR TITLE
docs(roadmap): reorient ACTIVE_ROADMAP to validation and backtesting focus

### DIFF
--- a/knowledge/ACTIVE_ROADMAP.md
+++ b/knowledge/ACTIVE_ROADMAP.md
@@ -11,6 +11,9 @@ start. It now resolves only to local working-repo sources.
 
 - Working repo / engineering status: `CURRENT_STATUS.md`
 - Operational live-readiness status: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- Control board status + workflow controls: `docs/runbooks/CONTROL_REGISTER.md`
+- Strategy specification: `knowledge/contracts/PRIMARY_BREAKOUT_V1.md`
+- Validation canon + deterministic runner: `knowledge/contracts/PRIMARY_BREAKOUT_V1_VALIDATION.md` / `services/validation/strategy_backtest_runner.py`
 - Historical knowledge snapshot: `knowledge/CURRENT_STATUS.md` (context only)
 - Canon and archive policy: `docs/meta/WORKING_REPO_CANON.md`
 
@@ -23,11 +26,15 @@ start. It now resolves only to local working-repo sources.
 
 ## Current Focus
 
-- stabilize core runtime and governance checks
-- keep evidence tied to local docs, not a sibling repo
-- maintain a deletable posture for the retired docs archive source
+- deterministic validation and backtesting for `primary_breakout_v1`
+- shadow/mock-only operation with reproducible, repo-backed evidence
+- data substance, run reproducibility, and evidence chain integrity
 
 ## Working Rule
+
+Board stage `trade-capable` does not imply LR-Go. Live-readiness verdict remains
+NO-GO. Real-capital operation requires explicit human gate and passing LR-SSOT
+criteria. See `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`.
 
 No default path in the roadmap should require an external docs repository. Use
 the local archive snapshot only for historical lookup.


### PR DESCRIPTION
Narrow pointer-page reorientation of ACTIVE_ROADMAP.md.

## Changes
- **Canonical Locations**: +3 pointers — \CONTROL_REGISTER.md\, \PRIMARY_BREAKOUT_V1.md\, validation canon + \strategy_backtest_runner.py\
- **Current Focus**: replace stale 'stabilize core runtime' bullets with backtesting/validation/evidence-chain focus
- **Working Rule**: prepend explicit \	rade-capable ≠ LR-Go\ guardrail; archive-lookup sentence retained

## Guardrails
- LR verdict remains NO-GO; SSOT: \docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md\
- No LR-Go, no Echtgeld-Go, no live-enable claims
- No Runtime/Compose/Dockerfile/Workflow/Catalog changes
- All new pointers are repo-backed canonical surfaces

Closes #1772