### PR TITLE
docs: reconcile architecture docs after replay stack (PR #1808, Issue #1809)

### DIFF
--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -136,15 +136,39 @@ cdb_reports           Up (healthy)
 
 ---
 
-## 5. Invariants (nicht verhandelbar)
+## 5. Core Libraries (nicht runtime-services, sondern shared infrastruktur)
+
+### Replay Infrastructure (LR-021, PR #1808)
+
+| Module | File | Funktion | Status |
+|--------|------|----------|--------|
+| **Replay Contracts** | `core/replay/replay_contracts.py` | Frozen dataclasses für Replay-Input/Output; determinism envelope tracking | **AKTIV** (PR #1808) |
+| **Replay Determinism** | `core/replay/determinism.py` | Canonical JSON hashing, integrity verification, error validation | **AKTIV** (PR #1808) |
+| **Replay Clock Context** | `core/replay/clock_context.py` | Deterministic, wall-clock-free time handling für replay events | **AKTIV** (PR #1808) |
+| **Replay Execution** | `core/replay/execution.py` | Envelope chain emission, order/fill wrapping für replay runs | **AKTIV** (PR #1808) |
+| **Deterministic Loop** | `core/replay/deterministic_loop.py` | Tick-by-tick replay orchestration mit integrity gate | **AKTIV** (PR #1808) |
+| **Envelopes** | `core/replay/envelopes.py` | Decision/Order/Fill envelope types + replay metadata fields | **AKTIV** (PR #1808) |
+
+**Nutzung:** Shadow replay (accelerated backtesting, validation, gate evaluation offline) ohne live/paper/Redis/DB-Integration.
+
+**Reporter & CLI:**
+| Component | File | Funktion | Status |
+|-----------|------|----------|--------|
+| **Replay Reporter** | `services/validation/replay_reporter.py` | Deterministic artifact bundle writer (report.json, manifest.json, audit.log) | **AKTIV** (PR #1808) |
+| **Replay CLI** | `services/validation/strategy_replay_runner.py` | Thin operator entry-point, config validation, exit codes | **AKTIV** (PR #1808) |
+
+---
+
+## 6. Invariants (nicht verhandelbar)
 
 1. **Paper Trading Default**: Live Trading erfordert explizites Delivery Gate
 2. **Event Sourcing**: Alle State-Aenderungen ueber Events (Replay-faehig)
 3. **Circuit Breaker**: Risk Service gated alle Order Execution
-4. **Determinismus**: Reproduzierbare Ergebnisse via Event Replay
+4. **Determinismus**: Reproduzierbare Ergebnisse via Event Replay (LR-021: deterministic shadow replay via `core/replay/` stack)
 5. **TLS Optional**: Aktivierbar via `-TLS` Flag (Redis + PostgreSQL)
 6. **Localhost Binding**: Alle Ports auf 127.0.0.1 (keine externe Exposition)
 7. **Secrets/Logging Hygiene**: Secret-Loader und SMTP-Alerter protokollieren keine secret-abgeleiteten Identifikatoren oder Empfaengeradressen im Klartext; Service-API-Fehlerantworten bleiben auf sichere Fehlercodes ohne Exception-/Stacktrace-Details begrenzt.
+8. **Canonical Determinism**: Alle kanonischen Report-Felder sind frei von Wall-Clock-Zeit; deterministische JSON-Serialisierung via `core/replay/canonical_json.py` (LR-021)
 
 ---
 
@@ -182,3 +206,4 @@ Legacy-Layer (base.yml, dev.yml, tls.yml, etc.) existieren noch, sind nicht mehr
 | 2026-04-11 | Signal-Port-Semantik präzisiert: Config-Default `SIGNAL_PORT=8001`, kanonischer Runtime-Port `8005` via `compose.red.yml` | Codex |
 | 2026-04-18 | Security-Hygiene nach PR #1752 ergänzt: Secret-/SMTP-Logging ohne secret-abgeleitete Klartext-Details dokumentiert | Codex |
 | 2026-04-18 | PR #1755 Nachzug: fail-closed Fehlerantworten ohne Stacktrace-/Exception-Text für Risk/Execution/Kill-Switch dokumentiert | Codex |
+| 2026-04-20 | PR #1808 Nachzug: LR-021 deterministic replay infrastructure (core/replay + services/validation reporter/CLI) als Core Libraries dokumentiert (Issue #1809) | Codex |

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -46,6 +46,33 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 
 ---
 
+## Core Libraries (nicht runtime-services)
+
+### Replay Infrastructure (LR-021, PR #1808)
+
+**Pfad:** `core/replay/`, `services/validation/` (reporter + CLI)
+
+**Funktion:** Deterministic shadow replay stack für accelerated backtesting, validation und gate evaluation offline (keine live/paper/Redis/DB-Integration).
+
+| Module/Component | Code-Pfad | Status | Beschreibung |
+|---|---|---|---|
+| **Replay Contracts** | `core/replay/replay_contracts.py` | **AKTIV** (PR #1808) | Frozen dataclasses für deterministic input/output tracking |
+| **Replay Determinism** | `core/replay/determinism.py` | **AKTIV** (PR #1808) | Canonical JSON hashing, integrity verification |
+| **Replay Clock Context** | `core/replay/clock_context.py` | **AKTIV** (PR #1808) | Deterministic, wall-clock-free time handling |
+| **Replay Execution** | `core/replay/execution.py` | **AKTIV** (PR #1808) | Envelope chain emission, order/fill wrapping |
+| **Deterministic Loop** | `core/replay/deterministic_loop.py` | **AKTIV** (PR #1808) | Tick-by-tick replay orchestration mit integrity gate |
+| **Envelopes** | `core/replay/envelopes.py` | **AKTIV** (PR #1808) | Decision/Order/Fill envelope types + replay metadata |
+| **Replay Reporter** | `services/validation/replay_reporter.py` | **AKTIV** (PR #1808) | Artifact bundle writer (report.json, manifest.json, audit.log) |
+| **Replay CLI** | `services/validation/strategy_replay_runner.py` | **AKTIV** (PR #1808) | Thin operator entry-point, config validation, exit codes 0/1/2 |
+
+**Interne Abhängigkeiten:** Nutzen `core/replay/canonical_json.py` (deterministic serialization), `core/replay/envelopes.py` (envelope tracking).
+
+**Externe Abhängigkeiten:** `core/domain/` (models, events), `core/clients/` (MEXC API), `core/indicators/` (technical indicators), `core/contracts/` (decision contracts).
+
+**Tests:** 453 unit tests (core/replay/ + services/validation/ replay-specific tests), alle grün.
+
+---
+
 ## Infrastruktur-Services
 
 ### BLUE Stack (compose.blue.yml)
@@ -155,3 +182,4 @@ docker compose -f infrastructure/compose/compose.red.yml up -d
 | 2026-04-18 | PR #1752 Nachzug: Market Email-Alerter-Init ohne Empfaenger-Klartext-Logging in Katalogfunktion nachgezogen | Codex |
 | 2026-04-18 | PR #1755 Nachzug: Risk-/Execution-Fehlerantworten und Kill-Switch-Fallback auf stacktrace-freie Fehlercodes/Safemessages dokumentiert | Codex |
 | 2026-04-19 | Prometheus-Image-Version nachgezogen: v3.10.0 → v3.11.2 (PR #1767, Issue #1771); enger Katalog-Nachzug gegen current-main | Codex |
+| 2026-04-20 | PR #1808 Nachzug: LR-021 deterministic replay infrastructure (core/replay/ + services/validation/) als Core Libraries dokumentiert; 6 Modules + 2 Components + 453 Tests (Issue #1809) | Codex |


### PR DESCRIPTION
## Post-Merge Architecture Reconciliation

After PR #1808 (deterministic replay infrastructure stack landed), update:

- **knowledge/ARCHITECTURE_MAP.md**: Add Section 5 (Core Libraries) documenting LR-021 replay modules + reporter/CLI
- **knowledge/governance/SERVICE_CATALOG.md**: Add Core Libraries section with status/dependencies for replay infrastructure

### Changes

| File | Change |
|------|--------|
| ARCHITECTURE_MAP.md | + Section 5 Core Libraries (6 replay modules + reporter + CLI); + Invariant #8 (Canonical Determinism); + Changelog entry |
| SERVICE_CATALOG.md | + Core Libraries section (LR-021 replay infrastructure); + Dependencies; + Changelog entry (2026-04-20) |

### Related

- PR #1808 (feat(replay): LR-021 deterministic replay infrastructure — full stack)
- Issue #1809 (Post-merge follow-up: Reconcile architecture docs)

Closes #1809
