### PR TITLE
fix(infra): replace wget with nc-based healthcheck for redis_exporter (Issue #1796)

### DIFF
--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -152,11 +152,11 @@ services:
     command: ["exec redis_exporter --redis.addr=redis://cdb_redis:6379 --redis.password=$$(cat /run/secrets/redis_password | tr -d '\\n')"]
     depends_on:
       - cdb_redis
-    healthcheck:
-      test: ["CMD-SHELL", "kill -0 1"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
+     healthcheck:
+       test: ["CMD-SHELL", "nc -z localhost 9121 || exit 1"]
+       interval: 30s
+       timeout: 5s
+       retries: 3
     networks:
       - cdb_network
 

--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -179,7 +179,7 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command: ["exec redis_exporter --redis.addr=redis://cdb_redis:6379 --redis.password=$$(cat /run/secrets/redis_password | tr -d '\\n')"]
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:9121/health"]
+      test: ["CMD-SHELL", "nc -z localhost 9121 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Problem

During paper checkpoint, `cdb_redis_exporter` remained persistently unhealthy:
- Healthcheck error: `exec: "wget": executable not found in $PATH`
- Image: `bitnami/redis-exporter:latest` lacks wget

## Solution

Replace `wget`-based HTTP health probe with `nc -z localhost 9121` (netcat port check):
- **Image-safe**: netcat is typically available in base Alpine images  
- **Functionally equivalent**: verifies port 9121 is listening
- **Consistent with goals**: monitoring-only observability fix

## Changes

| File | Old | New |
|------|-----|-----|
| base.yml (line 156) | `["CMD-SHELL", "kill -0 1"]` | `["CMD-SHELL", "nc -z localhost 9121 \|\| exit 1"]` |
| compose.red.yml (line 182) | `["CMD", "wget", "-qO-", "http://localhost:9121/health"]` | `["CMD-SHELL", "nc -z localhost 9121 \|\| exit 1"]` |

## Impact

- **Scope**: Non-core fix (observability/monitoring only)
- **Paper path**: Unaffected; core services remain healthy during paper runs
- **Post-fix**: `docker compose ps` should show cdb_redis_exporter as **healthy** (not unhealthy)
- **Runtime behavior**: No changes to core trading or data flows

## Testing

After merge, verify:
```bash
docker compose ps
# cdb_redis_exporter should show "Up (healthy)"
```

Closes #1796
