### PR TITLE
fix(ci): add replay-shadow-run target for LR-021 smoke

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,15 @@
 # This Makefile remains focused on local/runtime-oriented operator flows and does not define that baseline.
 
 MCP_CONFIG_PATHS ?=
+REPLAY_INPUT_CANDLES ?=
+REPLAY_OUTPUT_DIR ?= artifacts/replay_reports
+REPLAY_STRATEGY_ID ?= primary_breakout_v1
+REPLAY_SYMBOL ?= BTCUSDT
+REPLAY_ADAPTER_ID ?= primary_breakout_runner_v1
+REPLAY_DRY_RUN ?= 0
+REPLAY_DETERMINISTIC_VERIFY ?= 1
 
-.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop rollback cleanup mcp-config-validate security-scan pre-close
+.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close
 
 help:
 	@echo "Claire de Binare - Test Commands"
@@ -233,6 +240,47 @@ paper-trading-stop:
 	@echo "🛑 Stoppe Paper Trading Runner..."
 	docker compose -f infrastructure/compose/compose.blue.yml stop cdb_paper_runner
 	@echo "✅ Paper Trading Runner gestoppt"
+
+ifeq ($(OS),Windows_NT)
+replay-shadow-run:
+	@pwsh -NoProfile -Command "$$input='$(REPLAY_INPUT_CANDLES)'; if ([string]::IsNullOrWhiteSpace($$input)) { Write-Error 'REPLAY_INPUT_CANDLES is required'; Write-Host 'Usage: make replay-shadow-run REPLAY_INPUT_CANDLES=<candles.json|candles.jsonl> [REPLAY_OUTPUT_DIR=artifacts/replay_reports]'; exit 1 }; if (-not (Test-Path $$input)) { Write-Error ('input candles file not found: ' + $$input); exit 1 }; $$out='$(REPLAY_OUTPUT_DIR)'; New-Item -ItemType Directory -Force -Path $$out | Out-Null; $$args=@('-m','services.validation.strategy_replay_runner','--input-candles',$$input,'--output-dir',$$out,'--strategy-id','$(REPLAY_STRATEGY_ID)','--symbol','$(REPLAY_SYMBOL)','--adapter-id','$(REPLAY_ADAPTER_ID)'); if ('$(REPLAY_DRY_RUN)' -eq '1') { $$args += '--dry-run' }; if ('$(REPLAY_DETERMINISTIC_VERIFY)' -eq '1') { $$args += '--deterministic-verify' }; Write-Host '▶ replay-shadow-run'; Write-Host ('  input_candles=' + $$input); Write-Host ('  output_dir=' + $$out); Write-Host '  strategy_id=$(REPLAY_STRATEGY_ID) symbol=$(REPLAY_SYMBOL) adapter_id=$(REPLAY_ADAPTER_ID)'; Write-Host '  dry_run=$(REPLAY_DRY_RUN) deterministic_verify=$(REPLAY_DETERMINISTIC_VERIFY)'; & python @args; $$rc=$$LASTEXITCODE; if ($$rc -eq 0) { Write-Host '✅ replay-shadow-run completed (bundle_dir is printed by the runner)' } else { Write-Error ('replay-shadow-run failed with exit code ' + $$rc) }; exit $$rc"
+else
+replay-shadow-run:
+	@if [ -z "$(REPLAY_INPUT_CANDLES)" ]; then \
+		echo "ERROR: REPLAY_INPUT_CANDLES is required"; \
+		echo "Usage: make replay-shadow-run REPLAY_INPUT_CANDLES=<candles.json|candles.jsonl> [REPLAY_OUTPUT_DIR=artifacts/replay_reports]"; \
+		exit 1; \
+	fi
+	@if [ ! -f "$(REPLAY_INPUT_CANDLES)" ]; then \
+		echo "ERROR: input candles file not found: $(REPLAY_INPUT_CANDLES)"; \
+		exit 1; \
+	fi
+	@mkdir -p "$(REPLAY_OUTPUT_DIR)"
+	@dry_flag=""; \
+	if [ "$(REPLAY_DRY_RUN)" = "1" ]; then dry_flag="--dry-run"; fi; \
+	det_flag=""; \
+	if [ "$(REPLAY_DETERMINISTIC_VERIFY)" = "1" ]; then det_flag="--deterministic-verify"; fi; \
+	echo "▶ replay-shadow-run"; \
+	echo "  input_candles=$(REPLAY_INPUT_CANDLES)"; \
+	echo "  output_dir=$(REPLAY_OUTPUT_DIR)"; \
+	echo "  strategy_id=$(REPLAY_STRATEGY_ID) symbol=$(REPLAY_SYMBOL) adapter_id=$(REPLAY_ADAPTER_ID)"; \
+	echo "  dry_run=$(REPLAY_DRY_RUN) deterministic_verify=$(REPLAY_DETERMINISTIC_VERIFY)"; \
+	python -m services.validation.strategy_replay_runner \
+		--input-candles "$(REPLAY_INPUT_CANDLES)" \
+		--output-dir "$(REPLAY_OUTPUT_DIR)" \
+		--strategy-id "$(REPLAY_STRATEGY_ID)" \
+		--symbol "$(REPLAY_SYMBOL)" \
+		--adapter-id "$(REPLAY_ADAPTER_ID)" \
+		$$dry_flag \
+		$$det_flag; \
+	rc=$$?; \
+	if [ $$rc -eq 0 ]; then \
+		echo "✅ replay-shadow-run completed (bundle_dir is printed by the runner)"; \
+	else \
+		echo "❌ replay-shadow-run failed with exit code $$rc" >&2; \
+	fi; \
+	exit $$rc
+endif
 
 # ============================================================================
 # Zusätzliche Hilfsfunktionen


### PR DESCRIPTION
## Summary
- add missing `replay-shadow-run` Makefile target expected by `.github/workflows/lr021_replay_smoke.yml`
- wire replay env defaults and target invocation to `python -m services.validation.strategy_replay_runner`
- keep scope tight to replay-smoke entrypoint recovery

## Why
After dispatch-enable merge (#1821), live workflow execution failed at step `Run canonical replay smoke` with:

`make: *** No rule to make target 'replay-shadow-run'. Stop.`

This PR restores the canonical Makefile entrypoint used by the workflow.

## Scope
- one file only: `Makefile`
- no replay logic changes, no runner infra changes