### PR TITLE
feat(arvp): add ARVP dataset spec and file-backed provider (#1841)

### DIFF
--- a/core/replay/dataset_provider.py
+++ b/core/replay/dataset_provider.py
@@ -1,0 +1,228 @@
+"""ARVP dataset provider: load historical candle data for replay.
+
+Part of ARVP §4.2 — Historical Data Access layer.
+See docs/governance/arvp_platform.md for module boundary definitions.
+
+Providers in this module are responsible for resolving a ``DatasetSpec`` into
+an ordered, validated candle series ready for replay injection.
+
+Current implementation status
+------------------------------
+``FileBackedDatasetProvider`` — **implemented**.
+    Loads from a local JSON-array or JSONL file. Validates ordering, 1-minute
+    cadence, required fields, and warmup sufficiency.
+
+``DBBackedDatasetProvider`` — **not implemented**.
+    Raises ``NotImplementedError``. The Postgres schema
+    (``infrastructure/database/schema.sql``) has no candles table.
+    ``cdb_db_writer`` does not persist candle data — candles flow through Redis
+    ``stream.candles_1m`` and are ephemeral. DB-backed replay input requires a
+    candles persistence layer. Tracked in GitHub Issue #1841.
+
+Boundary note
+-------------
+This provider layer validates *transport and data-shape* concerns only:
+ordering, cadence, required field presence. It does NOT enforce bridge-level
+semantics such as ``regime_id`` (added by ``historical_bridge.py``) or
+window boundary alignment (enforced by the runner layer, #1842/#1843).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from core.replay.dataset_spec import DatasetSpec, DatasetSpecError  # noqa: F401 — re-exported for caller convenience
+
+_REQUIRED_CANDLE_FIELDS: frozenset[str] = frozenset({"ts_ms", "high", "low", "close"})
+_ONE_MINUTE_MS: int = 60_000
+
+
+class DatasetLoadError(ValueError):
+    """Raised when a dataset cannot be loaded or fails data-shape validation."""
+
+
+@dataclass(frozen=True, slots=True)
+class DatasetResult:
+    """Immutable result of a successful dataset load operation.
+
+    ``candles`` is a tuple of dicts (shallow-immutable at the container level).
+    Inner dict values are all numeric primitives (int/float) and are effectively
+    immutable. Do not mutate candle dicts after construction.
+
+    ``fingerprint`` is the spec-level request fingerprint (not content hash).
+    See ``DatasetSpec.fingerprint()`` for the distinction.
+    """
+
+    spec: DatasetSpec
+    candles: tuple  # tuple[dict, ...] — full series including warmup rows
+    fingerprint: str
+    warmup_count: int
+    effective_candle_count: int
+
+
+class DatasetProvider(Protocol):
+    """Protocol for all ARVP dataset providers."""
+
+    def load(self, spec: DatasetSpec) -> DatasetResult: ...
+
+
+class FileBackedDatasetProvider:
+    """Load historical candle data from a local JSON-array or JSONL file.
+
+    Accepts:
+      - JSON array (``[{...}, ...]``) — all objects in one file
+      - JSONL — one JSON object per line; blank lines are skipped
+
+    Validates:
+      - Non-empty series after parsing
+      - All required fields present in each row: ``ts_ms``, ``high``, ``low``,
+        ``close``
+      - ``ts_ms`` strictly increasing across consecutive rows
+      - Exactly 1-minute (60 000 ms) cadence between consecutive rows
+      - ``len(candles) > spec.warmup_candles`` (sufficient data for warmup)
+
+    The file is taken as the authoritative dataset. ``spec.start_ts_ms`` and
+    ``spec.end_ts_ms`` are not used to slice the file — window boundary
+    enforcement is deferred to the runner/scheduler layer (#1842/#1843).
+    """
+
+    def load(self, spec: DatasetSpec) -> DatasetResult:
+        spec.validate()
+
+        if spec.source != "file":
+            raise DatasetLoadError(
+                f"FileBackedDatasetProvider requires source='file', "
+                f"got source={spec.source!r}."
+            )
+
+        file_path = Path(spec.file_path)  # type: ignore[arg-type]  # validated non-None above
+
+        if not file_path.exists():
+            raise DatasetLoadError(f"Dataset file not found: {file_path}")
+
+        try:
+            raw = file_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise DatasetLoadError(
+                f"Cannot read dataset file {file_path}: {exc}"
+            ) from exc
+
+        candles = self._parse(raw, file_path)
+        self._validate_series(candles, file_path)
+
+        if len(candles) <= spec.warmup_candles:
+            raise DatasetLoadError(
+                f"Insufficient candles: {len(candles)} total, "
+                f"{spec.warmup_candles} warmup required. "
+                f"Need at least {spec.warmup_candles + 1} candles."
+            )
+
+        return DatasetResult(
+            spec=spec,
+            candles=tuple(dict(c) for c in candles),
+            fingerprint=spec.fingerprint(),
+            warmup_count=spec.warmup_candles,
+            effective_candle_count=len(candles) - spec.warmup_candles,
+        )
+
+    def _parse(self, raw: str, file_path: Path) -> list[dict]:
+        text = raw.strip()
+        if not text:
+            raise DatasetLoadError(f"Dataset file is empty: {file_path}")
+
+        if text.startswith("["):
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise DatasetLoadError(
+                    f"Invalid JSON in dataset file {file_path}: {exc}"
+                ) from exc
+            if not isinstance(data, list):
+                raise DatasetLoadError(
+                    f"Expected JSON array in {file_path}, got {type(data).__name__}."
+                )
+            if not data:
+                raise DatasetLoadError(f"Dataset file contains an empty array: {file_path}")
+            return data
+
+        # JSONL: one JSON object per line
+        rows: list[dict] = []
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise DatasetLoadError(
+                    f"Invalid JSON on line {lineno} of {file_path}: {exc}"
+                ) from exc
+            if not isinstance(row, dict):
+                raise DatasetLoadError(
+                    f"Expected JSON object on line {lineno} of {file_path}, "
+                    f"got {type(row).__name__}."
+                )
+            rows.append(row)
+
+        if not rows:
+            raise DatasetLoadError(f"Dataset file contains no candle rows: {file_path}")
+        return rows
+
+    def _validate_series(self, candles: list[dict], file_path: Path) -> None:
+        if not candles:
+            raise DatasetLoadError(f"No candles in dataset: {file_path}")
+
+        for idx, candle in enumerate(candles):
+            missing = _REQUIRED_CANDLE_FIELDS - candle.keys()
+            if missing:
+                raise DatasetLoadError(
+                    f"Candle at index {idx} is missing required fields "
+                    f"{sorted(missing)}: {candle!r}"
+                )
+
+        for idx in range(1, len(candles)):
+            prev_ts = candles[idx - 1]["ts_ms"]
+            curr_ts = candles[idx]["ts_ms"]
+            if curr_ts <= prev_ts:
+                raise DatasetLoadError(
+                    f"ts_ms must be strictly increasing: "
+                    f"candle[{idx - 1}]={prev_ts}, candle[{idx}]={curr_ts}. "
+                    f"File: {file_path}"
+                )
+            delta = curr_ts - prev_ts
+            if delta != _ONE_MINUTE_MS:
+                raise DatasetLoadError(
+                    f"1m cadence violation: expected {_ONE_MINUTE_MS}ms gap, "
+                    f"got {delta}ms between candle[{idx - 1}] (ts={prev_ts}) "
+                    f"and candle[{idx}] (ts={curr_ts}). File: {file_path}"
+                )
+
+
+class DBBackedDatasetProvider:
+    """Placeholder for DB-backed historical replay input.
+
+    NOT IMPLEMENTED in this phase.
+
+    Reason: The Postgres schema (``infrastructure/database/schema.sql``) has no
+    candles table. The ``cdb_db_writer`` service does not persist candle data —
+    candles flow through Redis ``stream.candles_1m`` (ephemeral) and are never
+    written to Postgres. Until a candles persistence layer exists, DB-backed
+    replay input is not repo-backed implementable.
+
+    This gap is tracked in GitHub Issue #1841.
+    """
+
+    def load(self, spec: DatasetSpec) -> DatasetResult:
+        spec.validate()
+        raise NotImplementedError(
+            "DB-backed dataset loading is not implemented. "
+            "The Postgres schema has no candles table "
+            "(see infrastructure/database/schema.sql). "
+            "cdb_db_writer does not persist candle data — "
+            "candles are ephemeral in Redis stream.candles_1m. "
+            "DB-backed replay input requires a candles persistence layer. "
+            "Tracked in GitHub Issue #1841."
+        )

--- a/core/replay/dataset_spec.py
+++ b/core/replay/dataset_spec.py
@@ -1,0 +1,132 @@
+"""ARVP dataset specification: frozen contract for historical replay data requests.
+
+Part of ARVP §4.2 — Historical Data Access layer.
+See docs/governance/arvp_platform.md for module boundary definitions.
+
+This module defines the immutable spec that callers use to declare *what* data
+they want for a replay run. Providers (dataset_provider.py) are responsible for
+*how* that data is loaded and validated.
+
+Fingerprint note: ``DatasetSpec.fingerprint()`` is a *request* identity hash,
+not a *dataset content* hash. Two specs with identical fields produce the same
+fingerprint regardless of the file content at ``file_path``. Content-based
+hashing is deferred to the runner/reporting layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from core.replay.canonical_json import canonical_hash
+
+_VALID_SYMBOLS: frozenset[str] = frozenset({"BTCUSDT"})
+_VALID_TIMEFRAMES: frozenset[str] = frozenset({"1m"})
+
+
+class DatasetSpecError(ValueError):
+    """Raised when a ``DatasetSpec`` fails invariant validation."""
+
+
+@dataclass(frozen=True, slots=True)
+class DatasetSpec:
+    """Immutable specification for a historical replay dataset request.
+
+    Fields
+    ------
+    symbol:
+        Trading pair. Must be in the allowed symbol set (currently ``BTCUSDT``).
+    timeframe:
+        Candle interval. Only ``"1m"`` is supported in this ARVP phase.
+    start_ts_ms:
+        Inclusive start of the requested window in milliseconds (UTC epoch).
+    end_ts_ms:
+        Inclusive end of the requested window in milliseconds (UTC epoch).
+    warmup_candles:
+        Number of candles at the head of the series reserved for indicator
+        warm-up. Must be >= 0.
+    source:
+        ``"file"`` — load from a local file (``file_path`` required).
+        ``"db"``  — load from Postgres (``db_dataset_id`` required; not yet
+        implemented — see ``DBBackedDatasetProvider``).
+    file_path:
+        Absolute path to a JSON-array or JSONL file. Required when
+        ``source="file"``; must be ``None`` when ``source="db"``.
+    db_dataset_id:
+        Identifier for a persisted dataset record. Required when
+        ``source="db"``; must be ``None`` when ``source="file"``.
+    """
+
+    symbol: str
+    timeframe: str
+    start_ts_ms: int
+    end_ts_ms: int
+    warmup_candles: int
+    source: Literal["file", "db"]
+    file_path: str | None = None
+    db_dataset_id: str | None = None
+
+    def validate(self) -> None:
+        """Fail-closed invariant check. Raises ``DatasetSpecError`` on any violation."""
+        if self.symbol not in _VALID_SYMBOLS:
+            raise DatasetSpecError(
+                f"Invalid symbol {self.symbol!r}. Allowed: {sorted(_VALID_SYMBOLS)}"
+            )
+        if self.timeframe not in _VALID_TIMEFRAMES:
+            raise DatasetSpecError(
+                f"Invalid timeframe {self.timeframe!r}. Only '1m' is supported in this phase."
+            )
+        if self.start_ts_ms > self.end_ts_ms:
+            raise DatasetSpecError(
+                f"start_ts_ms ({self.start_ts_ms}) must be <= end_ts_ms ({self.end_ts_ms})."
+            )
+        if self.warmup_candles < 0:
+            raise DatasetSpecError(
+                f"warmup_candles must be >= 0, got {self.warmup_candles}."
+            )
+        if self.source == "file":
+            if self.file_path is None:
+                raise DatasetSpecError("source='file' requires file_path.")
+            if self.db_dataset_id is not None:
+                raise DatasetSpecError(
+                    "source='file' and source='db' fields are mutually exclusive: "
+                    "db_dataset_id must be None when source='file'."
+                )
+        elif self.source == "db":
+            if self.db_dataset_id is None:
+                raise DatasetSpecError("source='db' requires db_dataset_id.")
+            if self.file_path is not None:
+                raise DatasetSpecError(
+                    "source='file' and source='db' fields are mutually exclusive: "
+                    "file_path must be None when source='db'."
+                )
+        else:
+            raise DatasetSpecError(
+                f"Unknown source {self.source!r}. Must be 'file' or 'db'."
+            )
+
+    def to_dict(self) -> dict:
+        """Serialize to dict, omitting ``None``-valued optional fields."""
+        d: dict = {
+            "symbol": self.symbol,
+            "timeframe": self.timeframe,
+            "start_ts_ms": self.start_ts_ms,
+            "end_ts_ms": self.end_ts_ms,
+            "warmup_candles": self.warmup_candles,
+            "source": self.source,
+        }
+        if self.file_path is not None:
+            d["file_path"] = self.file_path
+        if self.db_dataset_id is not None:
+            d["db_dataset_id"] = self.db_dataset_id
+        return d
+
+    def fingerprint(self) -> str:
+        """Deterministic 64-char SHA-256 hex of the spec (request identity).
+
+        Two ``DatasetSpec`` instances with identical field values always produce
+        the same fingerprint. This is a *request* fingerprint, not a *content*
+        fingerprint — it does not depend on what the file at ``file_path``
+        actually contains.
+        """
+        return canonical_hash(self.to_dict())

--- a/tests/unit/replay/test_dataset_provider.py
+++ b/tests/unit/replay/test_dataset_provider.py
@@ -1,0 +1,404 @@
+"""Unit tests for ARVP DatasetSpec and DatasetProvider.
+
+Tests validate:
+- DatasetSpec invariants (all fail-closed rules)
+- DatasetSpec fingerprint determinism and serialization
+- FileBackedDatasetProvider: JSON array and JSONL loading, all error paths
+- DBBackedDatasetProvider: raises NotImplementedError with schema gap message
+
+Part of ARVP §4.2 — Historical Data Access layer.
+Tracked in GitHub Issue #1841.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from core.replay.dataset_provider import (
+    DBBackedDatasetProvider,
+    DatasetLoadError,
+    DatasetResult,
+    FileBackedDatasetProvider,
+)
+from core.replay.dataset_spec import DatasetSpec, DatasetSpecError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASE_START_MS = 1_700_000_000_000
+
+
+def _make_spec(
+    *,
+    symbol: str = "BTCUSDT",
+    timeframe: str = "1m",
+    start_ts_ms: int = _BASE_START_MS,
+    end_ts_ms: int = _BASE_START_MS + 600_000,
+    warmup_candles: int = 3,
+    source: str = "file",
+    file_path: str | None = "/tmp/data.json",
+    db_dataset_id: str | None = None,
+) -> DatasetSpec:
+    return DatasetSpec(
+        symbol=symbol,
+        timeframe=timeframe,
+        start_ts_ms=start_ts_ms,
+        end_ts_ms=end_ts_ms,
+        warmup_candles=warmup_candles,
+        source=source,
+        file_path=file_path,
+        db_dataset_id=db_dataset_id,
+    )
+
+
+def _make_candles(count: int, start_ts_ms: int = _BASE_START_MS) -> list[dict]:
+    return [
+        {
+            "ts_ms": start_ts_ms + i * 60_000,
+            "high": 50_000.0 + i,
+            "low": 49_000.0 + i,
+            "close": 49_500.0 + i,
+        }
+        for i in range(count)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# DatasetSpec — validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_valid_file_spec_validates_without_error() -> None:
+    spec = _make_spec()
+    spec.validate()
+
+
+@pytest.mark.unit
+def test_valid_db_spec_validates_without_error() -> None:
+    spec = _make_spec(source="db", file_path=None, db_dataset_id="ds-001")
+    spec.validate()
+
+
+@pytest.mark.unit
+def test_invalid_symbol_rejected() -> None:
+    spec = _make_spec(symbol="ETHUSDT")
+    with pytest.raises(DatasetSpecError, match="Invalid symbol"):
+        spec.validate()
+
+
+@pytest.mark.unit
+def test_invalid_timeframe_rejected() -> None:
+    spec = _make_spec(timeframe="5m")
+    with pytest.raises(DatasetSpecError, match="Invalid timeframe"):
+        spec.validate()
+
+
+@pytest.mark.unit
+def test_start_greater_than_end_rejected() -> None:
+    spec = _make_spec(start_ts_ms=_BASE_START_MS + 120_000, end_ts_ms=_BASE_START_MS)
+    with pytest.raises(DatasetSpecError, match="start_ts_ms"):
+        spec.validate()
+
+
+@pytest.mark.unit
+def test_start_equals_end_accepted() -> None:
+    spec = _make_spec(start_ts_ms=_BASE_START_MS, end_ts_ms=_BASE_START_MS, warmup_candles=0)
+    spec.validate()
+
+
+@pytest.mark.unit
+def test_negative_warmup_rejected() -> None:
+    spec = _make_spec(warmup_candles=-1)
+    with pytest.raises(DatasetSpecError, match="warmup_candles"):
+        spec.validate()
+
+
+@pytest.mark.unit
+def test_zero_warmup_accepted() -> None:
+    spec = _make_spec(warmup_candles=0)
+    spec.validate()
+
+
+@pytest.mark.unit
+def test_file_source_missing_file_path_rejected() -> None:
+    spec = _make_spec(source="file", file_path=None)
+    with pytest.raises(DatasetSpecError, match="file_path"):
+        spec.validate()
+
+
+@pytest.mark.unit
+def test_file_source_with_db_dataset_id_rejected() -> None:
+    spec = _make_spec(source="file", file_path="/tmp/f.json", db_dataset_id="ds-001")
+    with pytest.raises(DatasetSpecError, match="mutually exclusive"):
+        spec.validate()
+
+
+@pytest.mark.unit
+def test_db_source_missing_db_dataset_id_rejected() -> None:
+    spec = _make_spec(source="db", file_path=None, db_dataset_id=None)
+    with pytest.raises(DatasetSpecError, match="db_dataset_id"):
+        spec.validate()
+
+
+@pytest.mark.unit
+def test_db_source_with_file_path_rejected() -> None:
+    spec = _make_spec(source="db", file_path="/tmp/f.json", db_dataset_id="ds-001")
+    with pytest.raises(DatasetSpecError, match="mutually exclusive"):
+        spec.validate()
+
+
+# ---------------------------------------------------------------------------
+# DatasetSpec — to_dict and fingerprint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_to_dict_omits_none_optional_fields() -> None:
+    spec = _make_spec(source="file", file_path="/tmp/f.json", db_dataset_id=None)
+    d = spec.to_dict()
+    assert "db_dataset_id" not in d
+    assert d["file_path"] == "/tmp/f.json"
+
+
+@pytest.mark.unit
+def test_to_dict_includes_db_dataset_id_when_set() -> None:
+    spec = _make_spec(source="db", file_path=None, db_dataset_id="ds-abc")
+    d = spec.to_dict()
+    assert "file_path" not in d
+    assert d["db_dataset_id"] == "ds-abc"
+
+
+@pytest.mark.unit
+def test_fingerprint_is_deterministic() -> None:
+    spec_a = _make_spec()
+    spec_b = _make_spec()
+    assert spec_a.fingerprint() == spec_b.fingerprint()
+
+
+@pytest.mark.unit
+def test_different_specs_produce_different_fingerprints() -> None:
+    spec_a = _make_spec(start_ts_ms=_BASE_START_MS)
+    spec_b = _make_spec(start_ts_ms=_BASE_START_MS + 60_000)
+    assert spec_a.fingerprint() != spec_b.fingerprint()
+
+
+@pytest.mark.unit
+def test_fingerprint_is_64_char_lowercase_hex() -> None:
+    fp = _make_spec().fingerprint()
+    assert len(fp) == 64
+    assert all(c in "0123456789abcdef" for c in fp)
+
+
+# ---------------------------------------------------------------------------
+# FileBackedDatasetProvider — happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_file_backed_loads_json_array(tmp_path: object) -> None:
+    candles = _make_candles(10)
+    f = tmp_path / "data.json"
+    f.write_text(json.dumps(candles), encoding="utf-8")
+
+    spec = _make_spec(file_path=str(f), warmup_candles=3)
+    result = FileBackedDatasetProvider().load(spec)
+
+    assert isinstance(result, DatasetResult)
+    assert len(result.candles) == 10
+    assert result.warmup_count == 3
+    assert result.effective_candle_count == 7
+    assert result.fingerprint == spec.fingerprint()
+    assert result.spec is spec
+
+
+@pytest.mark.unit
+def test_file_backed_loads_jsonl(tmp_path: object) -> None:
+    candles = _make_candles(5)
+    f = tmp_path / "data.jsonl"
+    f.write_text("\n".join(json.dumps(c) for c in candles), encoding="utf-8")
+
+    spec = _make_spec(file_path=str(f), warmup_candles=2)
+    result = FileBackedDatasetProvider().load(spec)
+
+    assert len(result.candles) == 5
+    assert result.effective_candle_count == 3
+
+
+@pytest.mark.unit
+def test_file_backed_jsonl_with_blank_lines_ignored(tmp_path: object) -> None:
+    candles = _make_candles(4)
+    lines = [json.dumps(c) for c in candles]
+    content = "\n\n".join(lines) + "\n"
+    f = tmp_path / "data.jsonl"
+    f.write_text(content, encoding="utf-8")
+
+    spec = _make_spec(file_path=str(f), warmup_candles=1)
+    result = FileBackedDatasetProvider().load(spec)
+    assert len(result.candles) == 4
+
+
+@pytest.mark.unit
+def test_file_backed_result_is_deterministic(tmp_path: object) -> None:
+    candles = _make_candles(5)
+    f = tmp_path / "data.json"
+    f.write_text(json.dumps(candles), encoding="utf-8")
+    spec = _make_spec(file_path=str(f), warmup_candles=1)
+
+    provider = FileBackedDatasetProvider()
+    r1 = provider.load(spec)
+    r2 = provider.load(spec)
+    assert r1.candles == r2.candles
+    assert r1.fingerprint == r2.fingerprint
+    assert r1.effective_candle_count == r2.effective_candle_count
+
+
+@pytest.mark.unit
+def test_file_backed_zero_warmup_accepted(tmp_path: object) -> None:
+    candles = _make_candles(3)
+    f = tmp_path / "data.json"
+    f.write_text(json.dumps(candles), encoding="utf-8")
+    spec = _make_spec(file_path=str(f), warmup_candles=0)
+    result = FileBackedDatasetProvider().load(spec)
+    assert result.warmup_count == 0
+    assert result.effective_candle_count == 3
+
+
+# ---------------------------------------------------------------------------
+# FileBackedDatasetProvider — error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_file_backed_missing_file_raises(tmp_path: object) -> None:
+    spec = _make_spec(file_path=str(tmp_path / "missing.json"))
+    with pytest.raises(DatasetLoadError, match="not found"):
+        FileBackedDatasetProvider().load(spec)
+
+
+@pytest.mark.unit
+def test_file_backed_empty_file_raises(tmp_path: object) -> None:
+    f = tmp_path / "empty.json"
+    f.write_text("", encoding="utf-8")
+    spec = _make_spec(file_path=str(f), warmup_candles=0)
+    with pytest.raises(DatasetLoadError):
+        FileBackedDatasetProvider().load(spec)
+
+
+@pytest.mark.unit
+def test_file_backed_malformed_json_array_raises(tmp_path: object) -> None:
+    f = tmp_path / "bad.json"
+    f.write_text("[{not valid", encoding="utf-8")
+    spec = _make_spec(file_path=str(f))
+    with pytest.raises(DatasetLoadError, match="JSON"):
+        FileBackedDatasetProvider().load(spec)
+
+
+@pytest.mark.unit
+def test_file_backed_malformed_jsonl_line_raises(tmp_path: object) -> None:
+    candles = _make_candles(3)
+    lines = [json.dumps(c) for c in candles]
+    lines[1] = "{bad json"
+    f = tmp_path / "data.jsonl"
+    f.write_text("\n".join(lines), encoding="utf-8")
+    spec = _make_spec(file_path=str(f))
+    with pytest.raises(DatasetLoadError, match="JSON"):
+        FileBackedDatasetProvider().load(spec)
+
+
+@pytest.mark.unit
+def test_file_backed_missing_close_field_raises(tmp_path: object) -> None:
+    candles = _make_candles(5)
+    del candles[2]["close"]
+    f = tmp_path / "data.json"
+    f.write_text(json.dumps(candles), encoding="utf-8")
+    spec = _make_spec(file_path=str(f))
+    with pytest.raises(DatasetLoadError, match="close"):
+        FileBackedDatasetProvider().load(spec)
+
+
+@pytest.mark.unit
+def test_file_backed_missing_ts_ms_field_raises(tmp_path: object) -> None:
+    candles = _make_candles(3)
+    del candles[0]["ts_ms"]
+    f = tmp_path / "data.json"
+    f.write_text(json.dumps(candles), encoding="utf-8")
+    spec = _make_spec(file_path=str(f))
+    with pytest.raises(DatasetLoadError, match="ts_ms"):
+        FileBackedDatasetProvider().load(spec)
+
+
+@pytest.mark.unit
+def test_file_backed_duplicate_ts_ms_raises(tmp_path: object) -> None:
+    """Duplicate ts_ms values violate strictly-increasing invariant."""
+    candles = _make_candles(5)
+    candles[3]["ts_ms"] = candles[2]["ts_ms"]  # make [3] == [2], not strictly increasing
+    f = tmp_path / "data.json"
+    f.write_text(json.dumps(candles), encoding="utf-8")
+    spec = _make_spec(file_path=str(f))
+    with pytest.raises(DatasetLoadError, match="strictly increasing"):
+        FileBackedDatasetProvider().load(spec)
+
+
+@pytest.mark.unit
+def test_file_backed_non_1m_cadence_raises(tmp_path: object) -> None:
+    candles = _make_candles(5)
+    candles[1]["ts_ms"] += 30_000  # 90 000 ms gap from candle[0] → 1m cadence violation
+    f = tmp_path / "data.json"
+    f.write_text(json.dumps(candles), encoding="utf-8")
+    spec = _make_spec(file_path=str(f))
+    with pytest.raises(DatasetLoadError, match="1m cadence"):
+        FileBackedDatasetProvider().load(spec)
+
+
+@pytest.mark.unit
+def test_file_backed_warmup_equals_candle_count_raises(tmp_path: object) -> None:
+    """len(candles) must be strictly greater than warmup_candles."""
+    candles = _make_candles(3)
+    f = tmp_path / "data.json"
+    f.write_text(json.dumps(candles), encoding="utf-8")
+    spec = _make_spec(file_path=str(f), warmup_candles=3)  # equal, not strictly greater
+    with pytest.raises(DatasetLoadError, match="Insufficient candles"):
+        FileBackedDatasetProvider().load(spec)
+
+
+@pytest.mark.unit
+def test_file_backed_warmup_exceeds_candle_count_raises(tmp_path: object) -> None:
+    candles = _make_candles(2)
+    f = tmp_path / "data.json"
+    f.write_text(json.dumps(candles), encoding="utf-8")
+    spec = _make_spec(file_path=str(f), warmup_candles=5)
+    with pytest.raises(DatasetLoadError, match="Insufficient candles"):
+        FileBackedDatasetProvider().load(spec)
+
+
+@pytest.mark.unit
+def test_file_backed_source_mismatch_raises() -> None:
+    """FileBackedDatasetProvider refuses a db-source spec."""
+    spec = _make_spec(source="db", file_path=None, db_dataset_id="ds-001")
+    with pytest.raises(DatasetLoadError, match="source='file'"):
+        FileBackedDatasetProvider().load(spec)
+
+
+# ---------------------------------------------------------------------------
+# DBBackedDatasetProvider
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_db_backed_raises_not_implemented_with_schema_gap_message() -> None:
+    spec = _make_spec(source="db", file_path=None, db_dataset_id="ds-001")
+    with pytest.raises(NotImplementedError, match="candles table"):
+        DBBackedDatasetProvider().load(spec)
+
+
+@pytest.mark.unit
+def test_db_backed_validates_spec_before_raising() -> None:
+    """A bad db spec should raise DatasetSpecError, not NotImplementedError."""
+    spec = _make_spec(source="db", file_path=None, db_dataset_id=None)  # missing db_dataset_id
+    with pytest.raises(DatasetSpecError, match="db_dataset_id"):
+        DBBackedDatasetProvider().load(spec)


### PR DESCRIPTION
## Summary

Partial implementation of ARVP §4.2 Historical Data Access layer (Issue #1841).

## What lands

- **\core/replay/dataset_spec.py\** — Frozen \DatasetSpec\ dataclass with fail-closed \alidate()\, deterministic \ingerprint()\ (request identity via \canonical_hash\), and \	o_dict()\. Introduces \DatasetSpecError\. Enforces mutual exclusivity of \ile_path\/\db_dataset_id\; restricts to symbol \BTCUSDT\ and timeframe \1m\ in this phase.
- **\core/replay/dataset_provider.py\** — \DatasetLoadError\, immutable \DatasetResult\, \DatasetProvider\ Protocol, \FileBackedDatasetProvider\ (JSON array + JSONL, strict ordering, 1-minute cadence, required field validation, warmup sufficiency), \DBBackedDatasetProvider\ (explicit \NotImplementedError\ — no candles table in \infrastructure/database/schema.sql\).
- **\	ests/unit/replay/test_dataset_provider.py\** — 35 unit tests: all spec invariants, fingerprint determinism, file-load happy paths (JSON array / JSONL / blank-line tolerance), and all fail-closed error paths including the DB gap assertion.

## Explicit non-implementation

\DBBackedDatasetProvider.load()\ raises \NotImplementedError\ — this is intentional and repo-backed:
- \infrastructure/database/schema.sql\ has no candles table
- \cdb_db_writer\ does not persist candle data (candles are ephemeral in Redis \stream.candles_1m\)

## What does NOT land in this slice

- Runner wiring in \strategy_replay_runner.py\ (deferred — would add scope)
- DB persistence / candles table migration (deferred — #1841 gap)
- Scheduler integration (#1842) or runner orchestration (#1843)

## Status

**Partial slice — #1841 is not closed.** Status on Issue #1841: \weitere Zuarbeit noetig\.

## Governance

- No code changes to \historical_bridge.py\ or \strategy_replay_runner.py\
- All changes are additive (3 new files)
- 35/35 tests pass; full replay unit suite (177 tests) green

Closes: not applicable — partial slice, see Issue #1841