### PR TITLE
docs(arvp): reconcile architecture docs after PR #1856 service changes

### DIFF
--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -151,7 +151,7 @@ cdb_reports           Up (healthy)
 | **Dataset Spec** | `core/replay/dataset_spec.py` | Frozen request-spec für historische Replay-Datasets (ARVP §4.2); Fingerprint via canonical_hash | **AKTIV** (PR #1856) |
 | **Dataset Provider** | `core/replay/dataset_provider.py` | FileBackedDatasetProvider (JSON/JSONL) + DBBackedDatasetProvider (candles_1m Postgres); ARVP §4.2 | **AKTIV** (PR #1856) |
 
-**Nutzung:**Shadow replay (accelerated backtesting, validation, gate evaluation offline) ohne live/paper/Redis/DB-Integration.
+**Nutzung:** Shadow replay (accelerated backtesting, validation, gate evaluation offline) ohne live/paper/Redis-Runtime-Integration; ARVP §4.2 datasets können über `DBBackedDatasetProvider` aus `candles_1m` (Postgres) bezogen werden.
 
 **Reporter & CLI:**
 | Component | File | Funktion | Status |

--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -148,8 +148,10 @@ cdb_reports           Up (healthy)
 | **Replay Execution** | `core/replay/execution.py` | Envelope chain emission, order/fill wrapping für replay runs | **AKTIV** (PR #1808) |
 | **Deterministic Loop** | `core/replay/deterministic_loop.py` | Tick-by-tick replay orchestration mit integrity gate | **AKTIV** (PR #1808) |
 | **Envelopes** | `core/replay/envelopes.py` | Decision/Order/Fill envelope types + replay metadata fields | **AKTIV** (PR #1808) |
+| **Dataset Spec** | `core/replay/dataset_spec.py` | Frozen request-spec für historische Replay-Datasets (ARVP §4.2); Fingerprint via canonical_hash | **AKTIV** (PR #1856) |
+| **Dataset Provider** | `core/replay/dataset_provider.py` | FileBackedDatasetProvider (JSON/JSONL) + DBBackedDatasetProvider (candles_1m Postgres); ARVP §4.2 | **AKTIV** (PR #1856) |
 
-**Nutzung:** Shadow replay (accelerated backtesting, validation, gate evaluation offline) ohne live/paper/Redis/DB-Integration.
+**Nutzung:**Shadow replay (accelerated backtesting, validation, gate evaluation offline) ohne live/paper/Redis/DB-Integration.
 
 **Reporter & CLI:**
 | Component | File | Funktion | Status |
@@ -207,3 +209,4 @@ Legacy-Layer (base.yml, dev.yml, tls.yml, etc.) existieren noch, sind nicht mehr
 | 2026-04-18 | Security-Hygiene nach PR #1752 ergänzt: Secret-/SMTP-Logging ohne secret-abgeleitete Klartext-Details dokumentiert | Codex |
 | 2026-04-18 | PR #1755 Nachzug: fail-closed Fehlerantworten ohne Stacktrace-/Exception-Text für Risk/Execution/Kill-Switch dokumentiert | Codex |
 | 2026-04-20 | PR #1808 Nachzug: LR-021 deterministic replay infrastructure (core/replay + services/validation reporter/CLI) als Core Libraries dokumentiert (Issue #1809) | Codex |
+| 2026-04-22 | PR #1856 Nachzug: ARVP §4.2 DatasetSpec + DatasetProvider (FileBackedDatasetProvider + DBBackedDatasetProvider) ergänzt (Issue #1857) | Codex |

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -31,7 +31,7 @@
 | **Allocation** | cdb_allocation | 8006 | services/allocation/ | **AKTIV** | Regime→Allocation Mapping |
 | **Risk** | cdb_risk | 8002 | services/risk/ | **AKTIV** | Risk Gate, Circuit Breaker, Kill-Switch; `/kill-switch` Fehlerantworten fail-closed ohne Exception-Details |
 | **Execution** | cdb_execution | 8003 | services/execution/ | **AKTIV** | Order Execution (MOCK_TRADING=true default); `/orders` Fehlerantworten nur mit sicherem Fehlercode |
-| **DB Writer** | cdb_db_writer | — | services/db_writer/ | **AKTIV** | Redis→PostgreSQL Persistenz |
+| **DB Writer** | cdb_db_writer | — | services/db_writer/ | **AKTIV** | Redis→PostgreSQL Persistenz; `candle_normalizer.py` persistiert `stream.candles_1m` → `candles_1m` Postgres-Tabelle (PR #1856) |
 | **Paper Runner** | cdb_paper_runner | 8004 | tools/paper_trading/ | **AKTIV** | Paper Trading Orchestrator |
 
 ### RED Stack (compose.red.yml) — Signal + Monitoring, failure-isolated from BLUE
@@ -64,6 +64,8 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 | **Envelopes** | `core/replay/envelopes.py` | **AKTIV** (PR #1808) | Decision/Order/Fill envelope types + replay metadata |
 | **Replay Reporter** | `services/validation/replay_reporter.py` | **AKTIV** (PR #1808) | Artifact bundle writer (report.json, manifest.json, audit.log) |
 | **Replay CLI** | `services/validation/strategy_replay_runner.py` | **AKTIV** (PR #1808) | Thin operator entry-point, config validation, exit codes 0/1/2 |
+| **Dataset Spec** | `core/replay/dataset_spec.py` | **AKTIV** (PR #1856) | Frozen request-spec für historische Replay-Datasets (ARVP §4.2); Fingerprint via canonical_hash |
+| **Dataset Provider** | `core/replay/dataset_provider.py` | **AKTIV** (PR #1856) | FileBackedDatasetProvider (JSON/JSONL) + DBBackedDatasetProvider (candles_1m Postgres); ARVP §4.2 |
 
 **Interne Abhängigkeiten:** Nutzen `core/replay/canonical_json.py` (deterministic serialization), `core/replay/envelopes.py` (envelope tracking).
 
@@ -183,3 +185,4 @@ docker compose -f infrastructure/compose/compose.red.yml up -d
 | 2026-04-18 | PR #1755 Nachzug: Risk-/Execution-Fehlerantworten und Kill-Switch-Fallback auf stacktrace-freie Fehlercodes/Safemessages dokumentiert | Codex |
 | 2026-04-19 | Prometheus-Image-Version nachgezogen: v3.10.0 → v3.11.2 (PR #1767, Issue #1771); enger Katalog-Nachzug gegen current-main | Codex |
 | 2026-04-20 | PR #1808 Nachzug: LR-021 deterministic replay infrastructure (core/replay/ + services/validation/) als Core Libraries dokumentiert; 6 Modules + 2 Components + 453 Tests (Issue #1809) | Codex |
+| 2026-04-22 | PR #1856 Nachzug: ARVP §4.2 DatasetSpec + DatasetProvider (FileBackedDatasetProvider + DBBackedDatasetProvider) in Core Libraries ergänzt; DB-Writer Candle-Persistence (candle_normalizer.py → candles_1m) nachgezogen (Issue #1857) | Codex |

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -31,7 +31,7 @@
 | **Allocation** | cdb_allocation | 8006 | services/allocation/ | **AKTIV** | Regime→Allocation Mapping |
 | **Risk** | cdb_risk | 8002 | services/risk/ | **AKTIV** | Risk Gate, Circuit Breaker, Kill-Switch; `/kill-switch` Fehlerantworten fail-closed ohne Exception-Details |
 | **Execution** | cdb_execution | 8003 | services/execution/ | **AKTIV** | Order Execution (MOCK_TRADING=true default); `/orders` Fehlerantworten nur mit sicherem Fehlercode |
-| **DB Writer** | cdb_db_writer | — | services/db_writer/ | **AKTIV** | Redis→PostgreSQL Persistenz; `candle_normalizer.py` persistiert `stream.candles_1m` → `candles_1m` Postgres-Tabelle (PR #1856) |
+| **DB Writer** | cdb_db_writer | — | services/db_writer/ | **AKTIV** | Redis→PostgreSQL Persistenz; `db_writer.py` schreibt `stream.candles_1m` in `candles_1m` (Postgres), `candle_normalizer.py` normalisiert die Stream-Payloads auf dem Write-Pfad (PR #1856) |
 | **Paper Runner** | cdb_paper_runner | 8004 | tools/paper_trading/ | **AKTIV** | Paper Trading Orchestrator |
 
 ### RED Stack (compose.red.yml) — Signal + Monitoring, failure-isolated from BLUE
@@ -52,7 +52,7 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 
 **Pfad:** `core/replay/`, `services/validation/` (reporter + CLI)
 
-**Funktion:** Deterministic shadow replay stack für accelerated backtesting, validation und gate evaluation offline (keine live/paper/Redis/DB-Integration).
+**Funktion:** Deterministic shadow replay stack für accelerated backtesting, validation und gate evaluation offline, ohne live/paper/Redis-Runtime-Integration; ARVP §4.2 datasets können über `DBBackedDatasetProvider` aus `candles_1m` (Postgres) bezogen werden.
 
 | Module/Component | Code-Pfad | Status | Beschreibung |
 |---|---|---|---|


### PR DESCRIPTION
## Summary

Closes #1857.

Reconciles \knowledge/ARCHITECTURE_MAP.md\ and \knowledge/governance/SERVICE_CATALOG.md\ against the service/runtime surfaces landed in PR #1856 (candles_1m persistence layer + DBBackedDatasetProvider).

## Changes

- **\knowledge/ARCHITECTURE_MAP.md\** (§5 Replay Infrastructure): +2 module rows for \core/replay/dataset_spec.py\ and \core/replay/dataset_provider.py\; +changelog entry
- **\knowledge/governance/SERVICE_CATALOG.md\** (Core Libraries): +2 matching rows; DB Writer description updated to reflect \candle_normalizer.py\ and \candles_1m\ persistence surface; +changelog entry

## Guardrails

- No code changes
- No new files
- No invariants, ports, or compose changes
- All new entries are directly repo-backed from PR #1856 diff

## Acceptance criteria met

- [x] \core/replay/dataset_spec.py\ documented in both surfaces
- [x] \core/replay/dataset_provider.py\ (FileBackedDatasetProvider + DBBackedDatasetProvider + candles_1m) documented
- [x] \services/db_writer/candle_normalizer.py\ reflected in DB Writer catalog entry
- [x] Both surfaces have changelog entries referencing PR #1856 / Issue #1857