### PR TITLE
feat(arvp): add deterministic replay scheduler with speed profiles (#1842)

### DIFF
--- a/core/replay/scheduler.py
+++ b/core/replay/scheduler.py
@@ -1,0 +1,117 @@
+"""ARVP Replay Scheduler — event-time metadata and warmup/live split.
+
+Scope (#1842): deterministic speed profiles, window boundary validation,
+warmup/live partitioning. No wall-clock pacing, no threading, no I/O.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from core.replay.dataset_provider import DatasetResult
+
+_VALID_PROFILES: frozenset[str] = frozenset({"instant", "1x", "2x", "5x", "10x"})
+_PROFILE_SPEEDUP: dict[str, float | None] = {
+    "instant": None,
+    "1x": 1.0,
+    "2x": 2.0,
+    "5x": 5.0,
+    "10x": 10.0,
+}
+
+
+class SchedulerError(ValueError):
+    """Raised when scheduler configuration or dataset invariants fail validation."""
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulerConfig:
+    profile: str
+
+    def validate(self) -> None:
+        if not self.profile or self.profile not in _VALID_PROFILES:
+            raise SchedulerError(
+                f"Unknown speedup profile {self.profile!r}. "
+                f"Valid profiles: {sorted(_VALID_PROFILES)}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulerResult:
+    profile: str
+    warmup_candles: tuple
+    live_candles: tuple
+    warmup_count: int
+    live_candle_count: int
+    event_time_span_ms: int
+    simulated_elapsed_ms: int | None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "profile": self.profile,
+            "warmup_count": self.warmup_count,
+            "live_candle_count": self.live_candle_count,
+            "event_time_span_ms": self.event_time_span_ms,
+        }
+        if self.simulated_elapsed_ms is not None:
+            d["simulated_elapsed_ms"] = self.simulated_elapsed_ms
+        return d
+
+
+class ReplayScheduler:
+    """Partitions a DatasetResult into warmup/live windows and derives timing metadata."""
+
+    def schedule(
+        self, dataset: DatasetResult, config: SchedulerConfig
+    ) -> SchedulerResult:
+        config.validate()
+
+        spec = dataset.spec
+        all_candles = dataset.candles
+        warmup_count = dataset.warmup_count
+
+        if warmup_count > len(all_candles):
+            raise SchedulerError(
+                f"warmup_count {warmup_count} exceeds total candles {len(all_candles)}"
+            )
+
+        warmup_candles: tuple = all_candles[:warmup_count]
+        live_candles: tuple = all_candles[warmup_count:]
+
+        if not live_candles:
+            raise SchedulerError("No live candles remain after warmup split")
+
+        if warmup_count != dataset.warmup_count:  # pragma: no cover — tautology guard
+            raise SchedulerError("Inconsistent warmup_count between dataset and split")
+
+        first_live_ts: int = int(live_candles[0]["ts_ms"])
+        last_live_ts: int = int(live_candles[-1]["ts_ms"])
+
+        if first_live_ts != spec.start_ts_ms:
+            raise SchedulerError(
+                f"Live window start mismatch: first live candle ts_ms={first_live_ts} "
+                f"!= spec.start_ts_ms={spec.start_ts_ms}"
+            )
+        if last_live_ts != spec.end_ts_ms:
+            raise SchedulerError(
+                f"Live window end mismatch: last live candle ts_ms={last_live_ts} "
+                f"!= spec.end_ts_ms={spec.end_ts_ms}"
+            )
+
+        event_time_span_ms: int = last_live_ts - first_live_ts
+
+        speedup = _PROFILE_SPEEDUP[config.profile]
+        simulated_elapsed_ms: int | None = (
+            None if speedup is None else int(event_time_span_ms / speedup)
+        )
+
+        return SchedulerResult(
+            profile=config.profile,
+            warmup_candles=warmup_candles,
+            live_candles=live_candles,
+            warmup_count=warmup_count,
+            live_candle_count=len(live_candles),
+            event_time_span_ms=event_time_span_ms,
+            simulated_elapsed_ms=simulated_elapsed_ms,
+        )

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -22,6 +22,7 @@ Usage:
         [--strategy-id primary_breakout_v1] \\
         [--symbol BTCUSDT] \\
         [--adapter-id primary_breakout_runner_v1] \\
+        [--speedup-profile instant|1x|2x|5x|10x] \\
         [--dry-run] \\
         [--deterministic-verify]
 
@@ -53,6 +54,8 @@ from pathlib import Path
 from typing import Any
 
 from core.replay.canonical_json import canonical_hash
+from core.replay.dataset_provider import DatasetResult
+from core.replay.dataset_spec import DatasetSpec
 from core.replay.historical_bridge import (
     HistoricalBridgeError,
     PrimaryBreakoutBridgeConfig,
@@ -66,6 +69,11 @@ from core.replay.replay_contracts import (
     ReplayReportArtifactManifest,
     ReplayReportInput,
     ReplayRunSpec,
+)
+from core.replay.scheduler import (
+    ReplayScheduler,
+    SchedulerConfig,
+    SchedulerError,
 )
 from services.validation.replay_reporter import ReplayReporter, ReplayReporterError
 from services.validation.strategy_backtest_runner import (
@@ -139,6 +147,9 @@ class AcceleratedShadowReplayConfig:
     adapter_id: str = _DEFAULT_ADAPTER_ID
     """Adapter identifier. Must be in _SUPPORTED_ADAPTER_IDS."""
 
+    speedup_profile: str = "instant"
+    """Deterministic replay scheduler speed profile."""
+
     output_directory: str = _DEFAULT_OUTPUT_DIR
     """Root output directory for replay artifact bundles."""
 
@@ -185,6 +196,10 @@ class AcceleratedShadowReplayConfig:
                 f"unsupported adapter_id {self.adapter_id!r}; "
                 f"supported: {sorted(_SUPPORTED_ADAPTER_IDS)}"
             )
+        try:
+            SchedulerConfig(profile=self.speedup_profile).validate()
+        except SchedulerError as exc:
+            raise ValueError(str(exc)) from exc
         if self.order_size <= 0:
             raise ValueError("order_size must be > 0")
         if self.order_book_depth_multiplier <= 0:
@@ -268,11 +283,60 @@ def _redact_env() -> dict[str, str]:
     return {k: v for k, v in os.environ.items() if k in _SAFE_ENV_KEYS}
 
 
+def _build_scheduler_metadata(
+    candles: list[dict[str, Any]],
+    *,
+    input_path: Path,
+    config: AcceleratedShadowReplayConfig,
+    warmup_count: int,
+) -> dict[str, Any]:
+    """Derive deterministic scheduler metadata from the loaded candle series."""
+    if len(candles) <= warmup_count:
+        raise ReplayRunnerError(
+            f"scheduler requires at least {warmup_count + 1} candles for "
+            f"warmup_count={warmup_count}; got {len(candles)}"
+        )
+
+    try:
+        start_ts_ms = int(candles[warmup_count]["ts_ms"])
+        end_ts_ms = int(candles[-1]["ts_ms"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ReplayRunnerError(
+            "scheduler requires numeric ts_ms on the first live candle and last candle"
+        ) from exc
+
+    spec = DatasetSpec(
+        symbol=config.symbol,
+        timeframe="1m",
+        start_ts_ms=start_ts_ms,
+        end_ts_ms=end_ts_ms,
+        warmup_candles=warmup_count,
+        source="file",
+        file_path=str(input_path),
+    )
+    try:
+        spec.validate()
+        dataset_result = DatasetResult(
+            spec=spec,
+            candles=tuple(dict(candle) for candle in candles),
+            fingerprint=spec.fingerprint(),
+            warmup_count=warmup_count,
+            effective_candle_count=len(candles) - warmup_count,
+        )
+        return ReplayScheduler().schedule(
+            dataset_result,
+            SchedulerConfig(profile=config.speedup_profile),
+        ).to_dict()
+    except ValueError as exc:
+        raise ReplayRunnerError(f"scheduler validation failed: {exc}") from exc
+
+
 def _build_replay_report_input(
     backtest_report: dict[str, Any],
     config: AcceleratedShadowReplayConfig,
     code_commit: str,
     output_dir: Path,
+    scheduler_metadata: dict[str, Any] | None = None,
 ) -> ReplayReportInput:
     """Bridge a backtest runner report to a ReplayReportInput.
 
@@ -283,7 +347,9 @@ def _build_replay_report_input(
     No metrics are recalculated; all values are derived from the backtest report.
     """
     run_id: str = backtest_report["run_metadata"]["run_id"]
-    dataset: dict[str, Any] = backtest_report["dataset_summary"]
+    dataset: dict[str, Any] = dict(backtest_report["dataset_summary"])
+    if scheduler_metadata is not None:
+        dataset["scheduler"] = dict(scheduler_metadata)
     metrics: dict[str, Any] = backtest_report["metrics"]
 
     run_spec = ReplayRunSpec(
@@ -347,7 +413,7 @@ def _build_replay_report_input(
         envelope_summary=envelope_summary,
         artifact_manifest=artifact_manifest,
         config_snapshot=backtest_report.get("config_snapshot"),
-        dataset_summary=backtest_report.get("dataset_summary"),
+        dataset_summary=dataset,
         metrics=metrics,
         thresholds_applied=backtest_report.get("thresholds_applied"),
         # gate_result already computed by the backtest runner; reporter will skip evaluation.
@@ -373,6 +439,7 @@ def _write_supplementary_artifacts(
         "strategy_id": config.strategy_id,
         "symbol": config.symbol,
         "adapter_id": config.adapter_id,
+        "speedup_profile": config.speedup_profile,
         "output_directory": config.output_directory,
         "order_size": config.order_size,
         "order_book_depth_multiplier": config.order_book_depth_multiplier,
@@ -421,21 +488,36 @@ def run_accelerated_shadow_replay(config: AcceleratedShadowReplayConfig) -> int:
         )
         return 0
 
+    run_cfg = PrimaryBreakoutBacktestRunConfig(
+        bridge=PrimaryBreakoutBridgeConfig(
+            entry_lookback_minutes=config.entry_lookback_minutes,
+            exit_lookback_minutes=config.exit_lookback_minutes,
+            breakout_buffer=config.breakout_buffer,
+            min_minutes_between_entries=config.min_minutes_between_entries,
+        ),
+        order_size=config.order_size,
+        order_book_depth_multiplier=config.order_book_depth_multiplier,
+    )
+    warmup_count = max(
+        run_cfg.bridge.entry_lookback_minutes,
+        run_cfg.bridge.exit_lookback_minutes,
+    )
+    try:
+        scheduler_metadata = _build_scheduler_metadata(
+            candles,
+            input_path=input_path,
+            config=config,
+            warmup_count=warmup_count,
+        )
+    except ReplayRunnerError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
     output_dir = Path(config.output_directory)
     code_commit = _get_code_commit()
 
     # Delegate to the existing backtest surface (business logic lives here)
     try:
-        run_cfg = PrimaryBreakoutBacktestRunConfig(
-            bridge=PrimaryBreakoutBridgeConfig(
-                entry_lookback_minutes=config.entry_lookback_minutes,
-                exit_lookback_minutes=config.exit_lookback_minutes,
-                breakout_buffer=config.breakout_buffer,
-                min_minutes_between_entries=config.min_minutes_between_entries,
-            ),
-            order_size=config.order_size,
-            order_book_depth_multiplier=config.order_book_depth_multiplier,
-        )
         backtest_report = run_primary_breakout_backtest(
             candles,
             run_config=run_cfg,
@@ -451,7 +533,11 @@ def run_accelerated_shadow_replay(config: AcceleratedShadowReplayConfig) -> int:
     # Bridge backtest report → replay contract shape
     try:
         report_input = _build_replay_report_input(
-            backtest_report, config, code_commit, output_dir
+            backtest_report,
+            config,
+            code_commit,
+            output_dir,
+            scheduler_metadata=scheduler_metadata,
         )
     except Exception as exc:
         print(f"ERROR: Failed to build replay report input: {exc}", file=sys.stderr)
@@ -544,6 +630,12 @@ def _build_argument_parser() -> argparse.ArgumentParser:
         help=f"Adapter identifier. Default: {_DEFAULT_ADAPTER_ID!r}",
     )
     parser.add_argument(
+        "--speedup-profile",
+        default="instant",
+        metavar="PROFILE",
+        help="Deterministic scheduler speed profile. Default: 'instant'.",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         default=False,
@@ -569,6 +661,7 @@ def main() -> int:
             strategy_id=args.strategy_id,
             symbol=args.symbol,
             adapter_id=args.adapter_id,
+            speedup_profile=args.speedup_profile,
             output_directory=args.output_dir,
             dry_run=args.dry_run,
             deterministic_verify=args.deterministic_verify,

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -257,6 +257,11 @@ def _load_candles(path: Path) -> list[dict[str, Any]]:
             raise ReplayRunnerError("candles JSON root must be an array")
         if not data:
             raise ReplayRunnerError("candles array is empty")
+        for idx, row in enumerate(data):
+            if not isinstance(row, dict):
+                raise ReplayRunnerError(
+                    f"candles JSON array item at index {idx} must be a JSON object"
+                )
         return data
 
     # JSONL (one JSON object per line)
@@ -327,7 +332,7 @@ def _build_scheduler_metadata(
             dataset_result,
             SchedulerConfig(profile=config.speedup_profile),
         ).to_dict()
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         raise ReplayRunnerError(f"scheduler validation failed: {exc}") from exc
 
 

--- a/tests/unit/replay/test_scheduler.py
+++ b/tests/unit/replay/test_scheduler.py
@@ -1,0 +1,357 @@
+"""Unit tests for core/replay/scheduler.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.replay.dataset_provider import DatasetResult
+from core.replay.dataset_spec import DatasetSpec
+from core.replay.scheduler import (
+    ReplayScheduler,
+    SchedulerConfig,
+    SchedulerError,
+    SchedulerResult,
+    _PROFILE_SPEEDUP,
+    _VALID_PROFILES,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+_ONE_MIN_MS = 60_000
+_BASE_TS = 1_000_000
+
+
+def _make_candles(n: int, start_ts_ms: int = _BASE_TS) -> tuple:
+    return tuple(
+        {
+            "ts_ms": start_ts_ms + i * _ONE_MIN_MS,
+            "high": 100.0,
+            "low": 99.0,
+            "close": 99.5,
+        }
+        for i in range(n)
+    )
+
+
+def _make_dataset(warmup_count: int, live_count: int, start_ts_ms: int = _BASE_TS) -> DatasetResult:
+    all_candles = _make_candles(warmup_count + live_count, start_ts_ms=start_ts_ms)
+    first_live_ts = all_candles[warmup_count]["ts_ms"]
+    last_live_ts = all_candles[-1]["ts_ms"]
+    spec = DatasetSpec(
+        symbol="BTCUSDT",
+        timeframe="1m",
+        start_ts_ms=first_live_ts,
+        end_ts_ms=last_live_ts,
+        warmup_candles=warmup_count,
+        source="file",
+        file_path="/fake/test_candles.json",
+    )
+    return DatasetResult(
+        spec=spec,
+        candles=all_candles,
+        fingerprint=spec.fingerprint(),
+        warmup_count=warmup_count,
+        effective_candle_count=live_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestSchedulerConfigValidation
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSchedulerConfigValidation:
+    @pytest.mark.parametrize("profile", sorted(_VALID_PROFILES))
+    def test_all_valid_profiles_pass(self, profile: str):
+        SchedulerConfig(profile=profile).validate()  # must not raise
+
+    def test_unknown_profile_raises(self):
+        with pytest.raises(SchedulerError, match="Unknown speedup profile"):
+            SchedulerConfig(profile="100x").validate()
+
+    def test_empty_profile_raises(self):
+        with pytest.raises(SchedulerError, match="Unknown speedup profile"):
+            SchedulerConfig(profile="").validate()
+
+    def test_case_sensitive_rejection(self):
+        with pytest.raises(SchedulerError):
+            SchedulerConfig(profile="INSTANT").validate()
+
+
+# ---------------------------------------------------------------------------
+# TestSchedulerInstantProfile
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSchedulerInstantProfile:
+    def test_instant_simulated_elapsed_is_none(self):
+        dataset = _make_dataset(warmup_count=5, live_count=10)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+        assert result.simulated_elapsed_ms is None
+
+    def test_instant_has_correct_live_count(self):
+        dataset = _make_dataset(warmup_count=5, live_count=10)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+        assert result.live_candle_count == 10
+
+    def test_instant_event_time_span(self):
+        dataset = _make_dataset(warmup_count=0, live_count=5)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+        expected_span = (5 - 1) * _ONE_MIN_MS
+        assert result.event_time_span_ms == expected_span
+
+    def test_single_live_candle_span_is_zero(self):
+        dataset = _make_dataset(warmup_count=0, live_count=1)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+        assert result.event_time_span_ms == 0
+        assert result.simulated_elapsed_ms is None
+
+
+# ---------------------------------------------------------------------------
+# TestSchedulerNxProfiles
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSchedulerNxProfiles:
+    def test_1x_elapsed_equals_span(self):
+        dataset = _make_dataset(warmup_count=0, live_count=11)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="1x"))
+        assert result.simulated_elapsed_ms == result.event_time_span_ms
+
+    def test_2x_elapsed_is_half_of_1x(self):
+        dataset = _make_dataset(warmup_count=0, live_count=11)
+        r1x = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="1x"))
+        r2x = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="2x"))
+        assert r2x.simulated_elapsed_ms == r1x.simulated_elapsed_ms // 2
+
+    def test_5x_elapsed_correct(self):
+        dataset = _make_dataset(warmup_count=0, live_count=11)
+        r1x = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="1x"))
+        r5x = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="5x"))
+        expected = int(r1x.event_time_span_ms / _PROFILE_SPEEDUP["5x"])
+        assert r5x.simulated_elapsed_ms == expected
+
+    def test_10x_elapsed_correct(self):
+        dataset = _make_dataset(warmup_count=0, live_count=11)
+        r1x = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="1x"))
+        r10x = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="10x"))
+        expected = int(r1x.event_time_span_ms / _PROFILE_SPEEDUP["10x"])
+        assert r10x.simulated_elapsed_ms == expected
+
+    def test_higher_speedup_lower_elapsed(self):
+        dataset = _make_dataset(warmup_count=0, live_count=61)
+        r1x = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="1x"))
+        r10x = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="10x"))
+        assert r10x.simulated_elapsed_ms < r1x.simulated_elapsed_ms
+
+    def test_single_live_candle_nx_elapsed_zero(self):
+        dataset = _make_dataset(warmup_count=0, live_count=1)
+        for profile in ("1x", "2x", "5x", "10x"):
+            result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile=profile))
+            assert result.simulated_elapsed_ms == 0, f"profile={profile}"
+
+
+# ---------------------------------------------------------------------------
+# TestSchedulerWindowBoundary
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSchedulerWindowBoundary:
+    def test_warmup_live_split_content(self):
+        dataset = _make_dataset(warmup_count=3, live_count=7)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+        assert result.warmup_count == 3
+        assert len(result.warmup_candles) == 3
+        assert result.live_candle_count == 7
+        assert len(result.live_candles) == 7
+
+    def test_warmup_and_live_are_disjoint(self):
+        dataset = _make_dataset(warmup_count=3, live_count=7)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+        warmup_ts = {c["ts_ms"] for c in result.warmup_candles}
+        live_ts = {c["ts_ms"] for c in result.live_candles}
+        assert warmup_ts.isdisjoint(live_ts)
+
+    def test_warmup_plus_live_equals_total(self):
+        dataset = _make_dataset(warmup_count=4, live_count=6)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+        assert len(result.warmup_candles) + len(result.live_candles) == len(dataset.candles)
+
+    def test_live_window_starts_at_spec_start_ts(self):
+        dataset = _make_dataset(warmup_count=5, live_count=10)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+        assert result.live_candles[0]["ts_ms"] == dataset.spec.start_ts_ms
+
+    def test_live_window_ends_at_spec_end_ts(self):
+        dataset = _make_dataset(warmup_count=5, live_count=10)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+        assert result.live_candles[-1]["ts_ms"] == dataset.spec.end_ts_ms
+
+    def test_zero_warmup_all_live(self):
+        dataset = _make_dataset(warmup_count=0, live_count=10)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+        assert result.warmup_count == 0
+        assert result.live_candle_count == 10
+        assert len(result.warmup_candles) == 0
+
+    def test_start_ts_mismatch_raises(self):
+        all_candles = _make_candles(5)
+        spec = DatasetSpec(
+            symbol="BTCUSDT",
+            timeframe="1m",
+            start_ts_ms=all_candles[0]["ts_ms"] + 99,  # deliberate mismatch
+            end_ts_ms=all_candles[-1]["ts_ms"],
+            warmup_candles=0,
+            source="file",
+            file_path="/fake/mismatch.json",
+        )
+        dataset = DatasetResult(
+            spec=spec,
+            candles=all_candles,
+            fingerprint=spec.fingerprint(),
+            warmup_count=0,
+            effective_candle_count=5,
+        )
+        with pytest.raises(SchedulerError, match="Live window start mismatch"):
+            ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+
+    def test_end_ts_mismatch_raises(self):
+        all_candles = _make_candles(5)
+        spec = DatasetSpec(
+            symbol="BTCUSDT",
+            timeframe="1m",
+            start_ts_ms=all_candles[0]["ts_ms"],
+            end_ts_ms=all_candles[-1]["ts_ms"] + 99,  # deliberate mismatch
+            warmup_candles=0,
+            source="file",
+            file_path="/fake/mismatch.json",
+        )
+        dataset = DatasetResult(
+            spec=spec,
+            candles=all_candles,
+            fingerprint=spec.fingerprint(),
+            warmup_count=0,
+            effective_candle_count=5,
+        )
+        with pytest.raises(SchedulerError, match="Live window end mismatch"):
+            ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+
+    def test_all_warmup_empty_live_raises(self):
+        all_candles = _make_candles(5)
+        # spec.start_ts_ms = all_candles[0] but warmup_count=5 → empty live
+        spec = DatasetSpec(
+            symbol="BTCUSDT",
+            timeframe="1m",
+            start_ts_ms=all_candles[0]["ts_ms"],
+            end_ts_ms=all_candles[-1]["ts_ms"],
+            warmup_candles=5,
+            source="file",
+            file_path="/fake/all_warmup.json",
+        )
+        dataset = DatasetResult(
+            spec=spec,
+            candles=all_candles,
+            fingerprint=spec.fingerprint(),
+            warmup_count=5,
+            effective_candle_count=0,
+        )
+        with pytest.raises(SchedulerError, match="No live candles"):
+            ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+
+    def test_warmup_count_exceeds_candles_raises(self):
+        all_candles = _make_candles(3)
+        spec = DatasetSpec(
+            symbol="BTCUSDT",
+            timeframe="1m",
+            start_ts_ms=all_candles[0]["ts_ms"],
+            end_ts_ms=all_candles[-1]["ts_ms"],
+            warmup_candles=3,
+            source="file",
+            file_path="/fake/overflow.json",
+        )
+        dataset = DatasetResult(
+            spec=spec,
+            candles=all_candles,
+            fingerprint=spec.fingerprint(),
+            warmup_count=10,  # larger than len(candles)
+            effective_candle_count=0,
+        )
+        with pytest.raises(SchedulerError, match="warmup_count"):
+            ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+
+
+# ---------------------------------------------------------------------------
+# TestSchedulerDeterminism
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSchedulerDeterminism:
+    def test_same_inputs_produce_identical_result(self):
+        dataset = _make_dataset(warmup_count=5, live_count=10)
+        config = SchedulerConfig(profile="2x")
+        r1 = ReplayScheduler().schedule(dataset, config)
+        r2 = ReplayScheduler().schedule(dataset, config)
+        assert r1 == r2
+
+    def test_to_dict_is_deterministic(self):
+        dataset = _make_dataset(warmup_count=5, live_count=10)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="2x"))
+        assert result.to_dict() == result.to_dict()
+
+    def test_instant_to_dict_has_no_simulated_elapsed_key(self):
+        dataset = _make_dataset(warmup_count=0, live_count=5)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+        assert "simulated_elapsed_ms" not in result.to_dict()
+
+    def test_nx_to_dict_has_simulated_elapsed_key(self):
+        dataset = _make_dataset(warmup_count=0, live_count=5)
+        for profile in ("1x", "2x", "5x", "10x"):
+            result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile=profile))
+            assert "simulated_elapsed_ms" in result.to_dict(), f"profile={profile}"
+
+    def test_to_dict_required_keys_present(self):
+        dataset = _make_dataset(warmup_count=0, live_count=5)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="2x"))
+        d = result.to_dict()
+        for key in ("profile", "warmup_count", "live_candle_count", "event_time_span_ms"):
+            assert key in d, f"missing key: {key}"
+
+    def test_result_is_frozen(self):
+        dataset = _make_dataset(warmup_count=0, live_count=5)
+        result = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="instant"))
+        with pytest.raises((AttributeError, TypeError)):
+            result.profile = "2x"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# TestSchedulerProfileNeutrality
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSchedulerProfileNeutrality:
+    def test_live_candles_order_same_across_profiles(self):
+        dataset = _make_dataset(warmup_count=5, live_count=10)
+        results = {
+            profile: ReplayScheduler().schedule(dataset, SchedulerConfig(profile=profile))
+            for profile in _VALID_PROFILES
+        }
+        reference_live = results["instant"].live_candles
+        for profile, result in results.items():
+            assert result.live_candles == reference_live, (
+                f"live_candles differ for profile={profile}"
+            )
+
+    def test_warmup_split_same_across_profiles(self):
+        dataset = _make_dataset(warmup_count=5, live_count=10)
+        results = {
+            profile: ReplayScheduler().schedule(dataset, SchedulerConfig(profile=profile))
+            for profile in _VALID_PROFILES
+        }
+        reference_warmup = results["instant"].warmup_candles
+        for profile, result in results.items():
+            assert result.warmup_candles == reference_warmup, (
+                f"warmup_candles differ for profile={profile}"
+            )
+
+    def test_different_profiles_different_simulated_elapsed(self):
+        dataset = _make_dataset(warmup_count=0, live_count=61)
+        r1x = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="1x"))
+        r5x = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="5x"))
+        r10x = ReplayScheduler().schedule(dataset, SchedulerConfig(profile="10x"))
+        assert r1x.simulated_elapsed_ms > r5x.simulated_elapsed_ms
+        assert r5x.simulated_elapsed_ms > r10x.simulated_elapsed_ms

--- a/tests/unit/validation/test_strategy_replay_runner.py
+++ b/tests/unit/validation/test_strategy_replay_runner.py
@@ -237,6 +237,12 @@ class TestLoadCandles:
         with pytest.raises(ReplayRunnerError, match="parse error"):
             _load_candles(f)
 
+    def test_json_array_non_object_row_raises(self, tmp_path):
+        f = tmp_path / "bad_row.json"
+        f.write_text(json.dumps([{"ts_ms": 1_000_000}, 123]), encoding="utf-8")
+        with pytest.raises(ReplayRunnerError, match="must be a JSON object"):
+            _load_candles(f)
+
     def test_malformed_jsonl_raises(self, tmp_path):
         f = tmp_path / "bad.jsonl"
         f.write_text('{"ts_ms": 1}\nbad line\n', encoding="utf-8")
@@ -447,6 +453,16 @@ class TestRunAcceleratedShadowReplay:
     def test_missing_input_file_returns_2(self, tmp_path):
         cfg = AcceleratedShadowReplayConfig(
             input_candles_file=str(tmp_path / "missing.json"),
+            output_directory=str(tmp_path),
+        )
+        exit_code = run_accelerated_shadow_replay(cfg)
+        assert exit_code == 2
+
+    def test_non_object_json_array_row_returns_2(self, tmp_path):
+        f = tmp_path / "bad_row.json"
+        f.write_text(json.dumps([{"ts_ms": 1_000_000}, 123]), encoding="utf-8")
+        cfg = AcceleratedShadowReplayConfig(
+            input_candles_file=str(f),
             output_directory=str(tmp_path),
         )
         exit_code = run_accelerated_shadow_replay(cfg)

--- a/tests/unit/validation/test_strategy_replay_runner.py
+++ b/tests/unit/validation/test_strategy_replay_runner.py
@@ -11,9 +11,8 @@ Tests cover:
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -23,7 +22,6 @@ from services.validation.strategy_replay_runner import (
     _DEFAULT_OUTPUT_DIR,
     _DEFAULT_STRATEGY_ID,
     _DEFAULT_SYMBOL,
-    _FALLBACK_CODE_COMMIT,
     AcceleratedShadowReplayConfig,
     ReplayRunnerError,
     _build_replay_report_input,
@@ -122,6 +120,7 @@ class TestAcceleratedShadowReplayConfig:
         assert cfg.strategy_id == _DEFAULT_STRATEGY_ID
         assert cfg.symbol == _DEFAULT_SYMBOL
         assert cfg.adapter_id == _DEFAULT_ADAPTER_ID
+        assert cfg.speedup_profile == "instant"
         assert cfg.output_directory == _DEFAULT_OUTPUT_DIR
         assert cfg.order_size == 1.0
         assert cfg.order_book_depth_multiplier == 10_000.0
@@ -160,6 +159,14 @@ class TestAcceleratedShadowReplayConfig:
             input_candles_file="x.json", adapter_id="unknown_adapter"
         )
         with pytest.raises(ValueError, match="unsupported adapter_id"):
+            cfg.validate()
+
+    def test_validate_fails_unsupported_speedup_profile(self):
+        cfg = AcceleratedShadowReplayConfig(
+            input_candles_file="x.json",
+            speedup_profile="100x",
+        )
+        with pytest.raises(ValueError, match="Unknown speedup profile"):
             cfg.validate()
 
     def test_validate_fails_zero_order_size(self):
@@ -342,6 +349,28 @@ class TestBuildReplayReportInput:
         assert r1.replay_integrity.envelope_chain_hash == r2.replay_integrity.envelope_chain_hash
         assert r1.replay_integrity.envelope_chain_hash == canonical_hash([])
 
+    def test_embeds_scheduler_metadata_in_dataset_summary(self, tmp_path):
+        report = _minimal_backtest_report()
+        cfg = _minimal_valid_config(speedup_profile="2x")
+        scheduler_metadata = {
+            "profile": "2x",
+            "warmup_count": 240,
+            "live_candle_count": 60,
+            "event_time_span_ms": 3_540_000,
+            "simulated_elapsed_ms": 1_770_000,
+        }
+
+        result = _build_replay_report_input(
+            report,
+            cfg,
+            "abc1234",
+            tmp_path,
+            scheduler_metadata=scheduler_metadata,
+        )
+
+        assert result.dataset_summary is not None
+        assert result.dataset_summary["scheduler"] == scheduler_metadata
+
 
 # ---------------------------------------------------------------------------
 # TestRunAcceleratedShadowReplay
@@ -350,10 +379,10 @@ class TestBuildReplayReportInput:
 class TestRunAcceleratedShadowReplay:
     """Full-flow tests with run_primary_breakout_backtest and ReplayReporter mocked."""
 
-    def _make_candles_file(self, tmp_path: Path) -> Path:
+    def _make_candles_file(self, tmp_path: Path, count: int = 300) -> Path:
         candles = [{"ts_ms": 1_000_000 + i * 60_000, "close": 50000.0,
                     "high": 51000.0, "low": 49000.0, "regime_id": 0,
-                    "symbol": "BTCUSDT"} for i in range(3)]
+                    "symbol": "BTCUSDT"} for i in range(count)]
         f = tmp_path / "candles.json"
         f.write_text(json.dumps(candles), encoding="utf-8")
         return f
@@ -390,6 +419,30 @@ class TestRunAcceleratedShadowReplay:
 
         assert (bundle_dir / "config.resolved.json").exists()
         assert (bundle_dir / "env_redacted.txt").exists()
+
+    @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
+    @patch.object(ReplayReporter, "write_bundle")
+    def test_scheduler_metadata_embedded_in_report_input(
+        self, mock_write, mock_backtest, tmp_path
+    ):
+        bundle_dir = tmp_path / "bt-abc1234567890123"
+        bundle_dir.mkdir()
+        mock_backtest.return_value = _minimal_backtest_report()
+        mock_write.return_value = bundle_dir
+
+        f = self._make_candles_file(tmp_path)
+        cfg = AcceleratedShadowReplayConfig(
+            input_candles_file=str(f),
+            output_directory=str(tmp_path),
+            speedup_profile="2x",
+        )
+        exit_code = run_accelerated_shadow_replay(cfg)
+
+        assert exit_code == 0
+        report_input = mock_write.call_args.args[0]
+        assert report_input.dataset_summary is not None
+        assert report_input.dataset_summary["scheduler"]["profile"] == "2x"
+        assert report_input.dataset_summary["scheduler"]["warmup_count"] == 240
 
     def test_missing_input_file_returns_2(self, tmp_path):
         cfg = AcceleratedShadowReplayConfig(
@@ -710,6 +763,25 @@ class TestMainArgParse:
                 main()
 
         assert captured[0].deterministic_verify is True
+
+    def test_speedup_profile_flag_applied(self, tmp_path):
+        candles = [{"ts_ms": 1_000_000}]
+        f = tmp_path / "c.json"
+        f.write_text(json.dumps(candles))
+        captured = []
+
+        def capture(cfg):
+            captured.append(cfg)
+            return 0
+
+        with patch(
+            "services.validation.strategy_replay_runner.run_accelerated_shadow_replay",
+            side_effect=capture,
+        ):
+            with patch("sys.argv", ["prog", "--input-candles", str(f), "--speedup-profile", "5x"]):
+                main()
+
+        assert captured[0].speedup_profile == "5x"
 
     def test_exit_code_semantics_0(self, tmp_path):
         candles = [{"ts_ms": 1_000_000}]


### PR DESCRIPTION
## Summary
- add new core/replay/scheduler.py for deterministic event-time replay scheduling with validated speed profiles
- add focused scheduler unit tests for profiles, boundaries, determinism, and artifact metadata
- wire the scheduler minimally into strategy_replay_runner with backward-compatible default speedup_profile="instant"
- keep scope tight: no runner orchestration, scenario, or reporting expansion

## Validation
- python -m pytest tests/unit/replay/test_scheduler.py tests/unit/validation/test_strategy_replay_runner.py -q

Closes #1842
