### PR TITLE
feat(arvp): add scenario harness for multi-variant replay runs (#1844)

### DIFF
--- a/core/replay/run_registry.py
+++ b/core/replay/run_registry.py
@@ -1,0 +1,295 @@
+"""ARVP replay run registry: runner identity, lifecycle, and small summaries.
+
+Scope (#1843): file-backed run registry, runner-owned run ids, lifecycle status,
+and concise operator-facing per-run summaries.
+
+Non-goals:
+  - scenario orchestration
+  - database-backed registries
+  - multi-process locking
+  - scheduler logic
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from core.replay.canonical_json import canonical_hash, canonical_json_dumps
+from core.replay.scheduler import SchedulerConfig, SchedulerError
+
+_DEFAULT_REGISTRY_PATH = Path("artifacts") / "replay_reports" / "run_registry.jsonl"
+_VALID_STATUSES: frozenset[str] = frozenset({"running", "completed", "failed"})
+_VALID_MODES: frozenset[str] = frozenset({"baseline"})
+_HEX_64_RE = re.compile(r"^[a-f0-9]{64}$")
+_RUN_ID_RE = re.compile(r"^replay-[a-f0-9]{12}-\d{4}$")
+_EXECUTION_PROVENANCE_ID_RE = re.compile(r"^bt-[a-f0-9]{16}$")
+
+
+class RunRegistryError(ValueError):
+    """Raised when replay run registry data fails validation."""
+
+
+def _require_non_empty_string(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise RunRegistryError(f"{field_name} must be a non-empty string")
+
+
+def _parse_utc_iso(value: str, field_name: str) -> datetime:
+    _require_non_empty_string(value, field_name)
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise RunRegistryError(f"{field_name} must be a valid ISO-8601 datetime") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise RunRegistryError(f"{field_name} must include an explicit UTC offset")
+    if parsed.utcoffset() != timedelta(0):
+        raise RunRegistryError(f"{field_name} must be a UTC timestamp")
+    return parsed
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayRunRecord:
+    run_id: str
+    status: str
+    mode: str
+    strategy_id: str
+    symbol: str
+    dataset_fingerprint: str
+    scheduler_profile: str
+    execution_provenance_id: str
+    artifact_root: str
+    gate_status: str | None = None
+    deterministic_replay_ok: bool = False
+    failure_reason: str | None = None
+    started_at_utc: str = ""
+    finished_at_utc: str | None = None
+
+    def __post_init__(self) -> None:
+        if not _RUN_ID_RE.match(self.run_id):
+            raise RunRegistryError(
+                "run_id must match 'replay-<12 hex>-<4 digit attempt>'"
+            )
+        if self.status not in _VALID_STATUSES:
+            raise RunRegistryError(
+                f"Invalid status {self.status!r}. Valid: {sorted(_VALID_STATUSES)}"
+            )
+        if self.mode not in _VALID_MODES:
+            raise RunRegistryError(
+                f"Invalid mode {self.mode!r}. Valid: {sorted(_VALID_MODES)}"
+            )
+        _require_non_empty_string(self.strategy_id, "strategy_id")
+        _require_non_empty_string(self.symbol, "symbol")
+        if not _HEX_64_RE.match(self.dataset_fingerprint):
+            raise RunRegistryError("dataset_fingerprint must be a 64-char lowercase hex hash")
+        try:
+            SchedulerConfig(profile=self.scheduler_profile).validate()
+        except SchedulerError as exc:
+            raise RunRegistryError(str(exc)) from exc
+        if not _EXECUTION_PROVENANCE_ID_RE.match(self.execution_provenance_id):
+            raise RunRegistryError(
+                "execution_provenance_id must match 'bt-<16 hex>'"
+            )
+        _require_non_empty_string(self.artifact_root, "artifact_root")
+        if not isinstance(self.deterministic_replay_ok, bool):
+            raise RunRegistryError("deterministic_replay_ok must be bool")
+        started = _parse_utc_iso(self.started_at_utc, "started_at_utc")
+        finished: datetime | None = None
+        if self.finished_at_utc is not None:
+            finished = _parse_utc_iso(self.finished_at_utc, "finished_at_utc")
+            if finished < started:
+                raise RunRegistryError("finished_at_utc must be >= started_at_utc")
+
+        if self.gate_status is not None:
+            _require_non_empty_string(self.gate_status, "gate_status")
+        if self.failure_reason is not None:
+            _require_non_empty_string(self.failure_reason, "failure_reason")
+
+        if self.status == "running":
+            if self.finished_at_utc is not None:
+                raise RunRegistryError("running records must not set finished_at_utc")
+            if self.failure_reason is not None:
+                raise RunRegistryError("running records must not set failure_reason")
+        elif self.status == "completed":
+            if self.finished_at_utc is None:
+                raise RunRegistryError("completed records require finished_at_utc")
+            if self.failure_reason is not None:
+                raise RunRegistryError("completed records must not set failure_reason")
+        elif self.status == "failed":
+            if self.finished_at_utc is None:
+                raise RunRegistryError("failed records require finished_at_utc")
+            if self.failure_reason is None:
+                raise RunRegistryError("failed records require failure_reason")
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "run_id": self.run_id,
+            "status": self.status,
+            "mode": self.mode,
+            "strategy_id": self.strategy_id,
+            "symbol": self.symbol,
+            "dataset_fingerprint": self.dataset_fingerprint,
+            "scheduler_profile": self.scheduler_profile,
+            "execution_provenance_id": self.execution_provenance_id,
+            "artifact_root": self.artifact_root,
+            "deterministic_replay_ok": self.deterministic_replay_ok,
+            "started_at_utc": self.started_at_utc,
+        }
+        if self.gate_status is not None:
+            result["gate_status"] = self.gate_status
+        if self.failure_reason is not None:
+            result["failure_reason"] = self.failure_reason
+        if self.finished_at_utc is not None:
+            result["finished_at_utc"] = self.finished_at_utc
+        return result
+
+
+def build_replay_provenance_fingerprint(
+    *,
+    strategy_id: str,
+    symbol: str,
+    adapter_id: str,
+    dataset_fingerprint: str,
+    scheduler_profile: str,
+    execution_provenance_id: str,
+    code_commit: str,
+    mode: str = "baseline",
+    config_snapshot: dict[str, Any] | None = None,
+) -> str:
+    if mode not in _VALID_MODES:
+        raise RunRegistryError(f"Invalid mode {mode!r}. Valid: {sorted(_VALID_MODES)}")
+    if not _HEX_64_RE.match(dataset_fingerprint):
+        raise RunRegistryError("dataset_fingerprint must be a 64-char lowercase hex hash")
+    try:
+        SchedulerConfig(profile=scheduler_profile).validate()
+    except SchedulerError as exc:
+        raise RunRegistryError(str(exc)) from exc
+    if not _EXECUTION_PROVENANCE_ID_RE.match(execution_provenance_id):
+        raise RunRegistryError(
+            "execution_provenance_id must match 'bt-<16 hex>'"
+        )
+    payload: dict[str, Any] = {
+        "mode": mode,
+        "strategy_id": strategy_id,
+        "symbol": symbol,
+        "adapter_id": adapter_id,
+        "dataset_fingerprint": dataset_fingerprint,
+        "scheduler_profile": scheduler_profile,
+        "execution_provenance_id": execution_provenance_id,
+        "code_commit": code_commit,
+    }
+    if config_snapshot is not None:
+        payload["config_snapshot"] = config_snapshot
+    return canonical_hash(payload)
+
+
+def build_replay_run_id(provenance_fingerprint: str, attempt: int) -> str:
+    if not _HEX_64_RE.match(provenance_fingerprint):
+        raise RunRegistryError(
+            "provenance_fingerprint must be a 64-char lowercase hex hash"
+        )
+    if attempt <= 0:
+        raise RunRegistryError("attempt must be >= 1")
+    return f"replay-{provenance_fingerprint[:12]}-{attempt:04d}"
+
+
+def build_operator_summary(record: ReplayRunRecord) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "run_id": record.run_id,
+        "status": record.status,
+        "mode": record.mode,
+        "strategy_id": record.strategy_id,
+        "symbol": record.symbol,
+        "dataset_fingerprint": record.dataset_fingerprint,
+        "scheduler_profile": record.scheduler_profile,
+        "execution_provenance_id": record.execution_provenance_id,
+        "artifact_root": record.artifact_root,
+        "deterministic_replay_ok": record.deterministic_replay_ok,
+        "started_at_utc": record.started_at_utc,
+    }
+    if record.gate_status is not None:
+        summary["gate_status"] = record.gate_status
+    if record.failure_reason is not None:
+        summary["failure_reason"] = record.failure_reason
+    if record.finished_at_utc is not None:
+        summary["finished_at_utc"] = record.finished_at_utc
+    return summary
+
+
+class ReplayRunRegistry:
+    """Append-only JSONL registry for ARVP replay runs."""
+
+    def __init__(self, registry_path: str | Path = _DEFAULT_REGISTRY_PATH) -> None:
+        self._registry_path = Path(registry_path)
+
+    @property
+    def path(self) -> Path:
+        return self._registry_path
+
+    def append(self, record: ReplayRunRecord) -> None:
+        if not isinstance(record, ReplayRunRecord):
+            raise RunRegistryError(
+                f"Expected ReplayRunRecord, got {type(record).__name__}"
+            )
+        try:
+            self._registry_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._registry_path.open("a", encoding="utf-8", newline="\n") as handle:
+                handle.write(canonical_json_dumps(record.to_dict()))
+                handle.write("\n")
+        except OSError as exc:
+            raise RunRegistryError(
+                f"Failed to append run registry entry to {self._registry_path}: {exc}"
+            ) from exc
+
+    def load_all(self) -> list[ReplayRunRecord]:
+        if not self._registry_path.exists():
+            return []
+        try:
+            raw = self._registry_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise RunRegistryError(
+                f"Failed to read run registry {self._registry_path}: {exc}"
+            ) from exc
+        if not raw:
+            return []
+
+        records: list[ReplayRunRecord] = []
+        for lineno, line in enumerate(raw.splitlines(), start=1):
+            if not line.strip():
+                raise RunRegistryError(
+                    f"Malformed run registry {self._registry_path}: empty line at {lineno}"
+                )
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise RunRegistryError(
+                    f"Malformed JSON in run registry {self._registry_path} line {lineno}: {exc}"
+                ) from exc
+            if not isinstance(data, dict):
+                raise RunRegistryError(
+                    f"Malformed run registry {self._registry_path} line {lineno}: JSON root must be an object"
+                )
+            try:
+                records.append(ReplayRunRecord(**data))
+            except (TypeError, RunRegistryError) as exc:
+                raise RunRegistryError(
+                    f"Invalid run registry record in {self._registry_path} line {lineno}: {exc}"
+                ) from exc
+        return records
+
+    def next_attempt(self, provenance_fingerprint: str) -> int:
+        run_id_prefix = build_replay_run_id(provenance_fingerprint, 1)[:-4]
+        attempts: set[int] = set()
+        for record in self.load_all():
+            if record.run_id.startswith(run_id_prefix):
+                suffix = record.run_id.rsplit("-", maxsplit=1)[-1]
+                if not suffix.isdigit():
+                    raise RunRegistryError(
+                        f"Existing run_id has invalid attempt suffix: {record.run_id}"
+                    )
+                attempts.add(int(suffix))
+        return max(attempts, default=0) + 1

--- a/core/replay/scenario_harness.py
+++ b/core/replay/scenario_harness.py
@@ -1,0 +1,311 @@
+"""ARVP scenario harness: multi-variant replay run orchestration.
+
+Scope (#1844): scenario abstraction, group orchestration, and manifest.
+
+Non-goals:
+  - built-in scenario packs (defined in #1845)
+  - regime analytics or scorecards (#1846)
+  - management-grade UX reports (#1847)
+  - database-backed manifests or multi-process locking
+  - strategy or execution business logic
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from core.replay.canonical_json import canonical_hash, canonical_json_dumps
+from core.utils.clock import utcnow
+
+_GROUP_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
+class ScenarioHarnessError(ValueError):
+    """Raised when scenario harness validation or orchestration fails."""
+
+
+def _utc_now_iso() -> str:
+    return utcnow().replace(tzinfo=timezone.utc).isoformat()
+
+
+def _require_non_empty_string(value: object, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ScenarioHarnessError(f"{field_name} must be a non-empty string")
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioSpec:
+    """Specification for a single scenario variant in a group.
+
+    config_overrides is an opaque dict of parameter overrides applied on top of
+    the base config at the runner layer.  The harness does not validate specific
+    override keys; that is the caller's responsibility.
+    """
+
+    scenario_id: str
+    description: str
+    config_overrides: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.scenario_id, "scenario_id")
+        _require_non_empty_string(self.description, "description")
+        if not isinstance(self.config_overrides, dict):
+            raise ScenarioHarnessError("config_overrides must be a dict")
+        # Defensive copy: prevents external mutation from affecting harness
+        # determinism after construction.
+        object.__setattr__(self, "config_overrides", dict(self.config_overrides))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "description": self.description,
+            "config_overrides": dict(self.config_overrides),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioRunResult:
+    """Result of executing a single scenario variant.
+
+    Invariants:
+    - failure_reason is required when exit_code != 0
+    - failure_reason must be None when exit_code == 0
+    - run_id, when set, must be a non-empty string
+    """
+
+    scenario_id: str
+    exit_code: int
+    run_id: str | None = None
+    failure_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.scenario_id, "scenario_id")
+        if isinstance(self.exit_code, bool) or not isinstance(self.exit_code, int):
+            raise ScenarioHarnessError("exit_code must be an int (not bool)")
+        if self.exit_code != 0 and self.failure_reason is None:
+            raise ScenarioHarnessError(
+                "failure_reason is required when exit_code != 0"
+            )
+        if self.exit_code == 0 and self.failure_reason is not None:
+            raise ScenarioHarnessError(
+                "failure_reason must be None when exit_code == 0"
+            )
+        if self.failure_reason is not None:
+            _require_non_empty_string(self.failure_reason, "failure_reason")
+        if self.run_id is not None:
+            _require_non_empty_string(self.run_id, "run_id")
+
+    @property
+    def succeeded(self) -> bool:
+        return self.exit_code == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "scenario_id": self.scenario_id,
+            "exit_code": self.exit_code,
+        }
+        if self.run_id is not None:
+            result["run_id"] = self.run_id
+        if self.failure_reason is not None:
+            result["failure_reason"] = self.failure_reason
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioGroupManifest:
+    """Manifest for a completed scenario group execution."""
+
+    group_id: str
+    scenario_results: tuple[ScenarioRunResult, ...]
+    artifact_root: str
+    group_fingerprint: str
+    started_at_utc: str
+    finished_at_utc: str
+    total_scenarios: int
+    succeeded_count: int
+    failed_count: int
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.group_id, "group_id")
+        _require_non_empty_string(self.artifact_root, "artifact_root")
+        if not isinstance(self.scenario_results, tuple):
+            raise ScenarioHarnessError("scenario_results must be a tuple")
+        if self.total_scenarios != len(self.scenario_results):
+            raise ScenarioHarnessError(
+                "total_scenarios must equal len(scenario_results)"
+            )
+        if self.succeeded_count + self.failed_count != self.total_scenarios:
+            raise ScenarioHarnessError(
+                "succeeded_count + failed_count must equal total_scenarios"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "group_id": self.group_id,
+            "group_fingerprint": self.group_fingerprint,
+            "artifact_root": self.artifact_root,
+            "started_at_utc": self.started_at_utc,
+            "finished_at_utc": self.finished_at_utc,
+            "total_scenarios": self.total_scenarios,
+            "succeeded_count": self.succeeded_count,
+            "failed_count": self.failed_count,
+            "scenario_results": [r.to_dict() for r in self.scenario_results],
+        }
+
+
+def build_scenario_group_id(scenario_ids: Sequence[str]) -> str:
+    """Build a deterministic group ID from an ordered sequence of scenario IDs."""
+    if not scenario_ids:
+        raise ScenarioHarnessError("scenario_ids must not be empty")
+    for sid in scenario_ids:
+        if not isinstance(sid, str) or not sid.strip():
+            raise ScenarioHarnessError(
+                "each scenario_id in scenario_ids must be a non-empty string"
+            )
+    payload: dict[str, Any] = {"scenario_ids": list(scenario_ids)}
+    fingerprint = canonical_hash(payload)
+    return f"sg-{fingerprint[:12]}"
+
+
+def _build_group_fingerprint(
+    group_id: str,
+    results: Sequence[ScenarioRunResult],
+) -> str:
+    """Build a deterministic fingerprint from group_id and scenario outcomes.
+
+    Excludes wall-clock timestamps, filesystem paths, and attempt-based run_ids
+    so that the fingerprint is stable across reruns that produce identical outcomes.
+    """
+    payload: dict[str, Any] = {
+        "group_id": group_id,
+        "scenario_outcomes": [
+            {"scenario_id": r.scenario_id, "exit_code": r.exit_code}
+            for r in results
+        ],
+    }
+    return canonical_hash(payload)
+
+
+def _write_group_manifest(output_dir: Path, manifest: ScenarioGroupManifest) -> None:
+    group_dir = output_dir / manifest.group_id
+    try:
+        group_dir.mkdir(parents=True, exist_ok=True)
+        manifest_path = group_dir / "scenario_group_manifest.json"
+        manifest_path.write_text(
+            canonical_json_dumps(manifest.to_dict()),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        raise ScenarioHarnessError(
+            f"Failed to write scenario group manifest to {group_dir}: {exc}"
+        ) from exc
+
+
+def run_scenario_group(
+    scenario_specs: Sequence[ScenarioSpec],
+    *,
+    run_fn: Callable[[ScenarioSpec], ScenarioRunResult],
+    output_dir: Path | str,
+    group_id: str | None = None,
+) -> ScenarioGroupManifest:
+    """Orchestrate a group of scenario runs deterministically.
+
+    Executes each scenario in the order provided.  Scenario failures are captured
+    explicitly as ScenarioRunResult entries — no scenario is silently skipped.
+    Unexpected exceptions from run_fn are also caught and recorded as failures.
+
+    Args:
+        scenario_specs: Non-empty sequence of ScenarioSpec with unique scenario_ids.
+        run_fn: Callable that executes a single scenario and returns a
+            ScenarioRunResult whose scenario_id matches the input ScenarioSpec.
+            Must not return a different type; that is treated as a harness error.
+            Exceptions other than that contract violation are caught and recorded
+            as failed results.
+        output_dir: Root directory for group output.  The manifest is written
+            to output_dir / group_id / scenario_group_manifest.json.
+        group_id: Optional pre-computed group ID.  If None, derived
+            deterministically from the ordered scenario_ids.  When supplied,
+            must match ^[a-zA-Z0-9_-]{1,64}$.
+
+    Returns:
+        ScenarioGroupManifest with all results and a written manifest.
+
+    Raises:
+        ScenarioHarnessError: empty specs, duplicate scenario_ids, invalid
+            group_id, run_fn returning wrong type or wrong scenario_id, or
+            manifest write failure.
+    """
+    if not scenario_specs:
+        raise ScenarioHarnessError("scenario_specs must not be empty")
+
+    seen_ids: set[str] = set()
+    for spec in scenario_specs:
+        if not isinstance(spec, ScenarioSpec):
+            raise ScenarioHarnessError(
+                f"Expected ScenarioSpec, got {type(spec).__name__}"
+            )
+        if spec.scenario_id in seen_ids:
+            raise ScenarioHarnessError(
+                f"Duplicate scenario_id: {spec.scenario_id!r}"
+            )
+        seen_ids.add(spec.scenario_id)
+
+    if group_id is not None:
+        if not _GROUP_ID_RE.match(group_id):
+            raise ScenarioHarnessError(
+                "group_id must be a 1-64 character string of [a-zA-Z0-9_-]"
+            )
+
+    scenario_ids = [spec.scenario_id for spec in scenario_specs]
+    resolved_group_id = group_id if group_id is not None else build_scenario_group_id(scenario_ids)
+    output_path = Path(output_dir)
+    artifact_root = str(output_path / resolved_group_id)
+    started_at_utc = _utc_now_iso()
+
+    results: list[ScenarioRunResult] = []
+    for spec in scenario_specs:
+        try:
+            result = run_fn(spec)
+        except Exception as exc:
+            exc_msg = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
+            result = ScenarioRunResult(
+                scenario_id=spec.scenario_id,
+                exit_code=2,
+                failure_reason=f"Scenario run raised unexpected exception: {exc_msg}",
+            )
+        else:
+            if not isinstance(result, ScenarioRunResult):
+                raise ScenarioHarnessError(
+                    f"run_fn must return ScenarioRunResult for scenario "
+                    f"{spec.scenario_id!r}, got {type(result).__name__}"
+                )
+            if result.scenario_id != spec.scenario_id:
+                raise ScenarioHarnessError(
+                    f"run_fn returned result for wrong scenario: "
+                    f"expected {spec.scenario_id!r}, got {result.scenario_id!r}"
+                )
+        results.append(result)
+
+    finished_at_utc = _utc_now_iso()
+    succeeded_count = sum(1 for r in results if r.exit_code == 0)
+    failed_count = len(results) - succeeded_count
+    group_fingerprint = _build_group_fingerprint(resolved_group_id, results)
+
+    manifest = ScenarioGroupManifest(
+        group_id=resolved_group_id,
+        scenario_results=tuple(results),
+        artifact_root=artifact_root,
+        group_fingerprint=group_fingerprint,
+        started_at_utc=started_at_utc,
+        finished_at_utc=finished_at_utc,
+        total_scenarios=len(results),
+        succeeded_count=succeeded_count,
+        failed_count=failed_count,
+    )
+
+    _write_group_manifest(output_path, manifest)
+    return manifest

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -50,10 +50,11 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from core.replay.canonical_json import canonical_hash
+from core.replay.canonical_json import canonical_hash, canonical_json_dumps
 from core.replay.dataset_provider import DatasetResult
 from core.replay.dataset_spec import DatasetSpec
 from core.replay.historical_bridge import (
@@ -61,6 +62,7 @@ from core.replay.historical_bridge import (
     PrimaryBreakoutBridgeConfig,
     PRIMARY_BREAKOUT_STRATEGY_ID,
     PRIMARY_BREAKOUT_SYMBOL,
+    build_primary_breakout_historical_bridge,
 )
 from core.replay.replay_contracts import (
     EnvelopeSummary,
@@ -75,10 +77,19 @@ from core.replay.scheduler import (
     SchedulerConfig,
     SchedulerError,
 )
+from core.replay.run_registry import (
+    ReplayRunRecord,
+    ReplayRunRegistry,
+    RunRegistryError,
+    build_operator_summary,
+    build_replay_provenance_fingerprint,
+    build_replay_run_id,
+)
 from services.validation.replay_reporter import ReplayReporter, ReplayReporterError
 from services.validation.strategy_backtest_runner import (
     PrimaryBreakoutBacktestError,
     PrimaryBreakoutBacktestRunConfig,
+    _deterministic_run_id,
     run_primary_breakout_backtest,
 )
 
@@ -93,6 +104,7 @@ _DEFAULT_OUTPUT_DIR = "artifacts/replay_reports"
 _DEFAULT_STRATEGY_ID = PRIMARY_BREAKOUT_STRATEGY_ID
 _DEFAULT_SYMBOL = PRIMARY_BREAKOUT_SYMBOL
 _DEFAULT_ADAPTER_ID = "primary_breakout_runner_v1"
+_DEFAULT_REPLAY_MODE = "baseline"
 
 _CODE_COMMIT_RE = re.compile(r"^[a-f0-9]{7,40}$")
 _FALLBACK_CODE_COMMIT = "0000000"
@@ -288,14 +300,31 @@ def _redact_env() -> dict[str, str]:
     return {k: v for k, v in os.environ.items() if k in _SAFE_ENV_KEYS}
 
 
-def _build_scheduler_metadata(
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _build_provenance_config_snapshot(
+    config: AcceleratedShadowReplayConfig,
+) -> dict[str, Any]:
+    return {
+        "order_size": config.order_size,
+        "order_book_depth_multiplier": config.order_book_depth_multiplier,
+        "entry_lookback_minutes": config.entry_lookback_minutes,
+        "exit_lookback_minutes": config.exit_lookback_minutes,
+        "breakout_buffer": config.breakout_buffer,
+        "min_minutes_between_entries": config.min_minutes_between_entries,
+    }
+
+
+def _build_dataset_result(
     candles: list[dict[str, Any]],
     *,
     input_path: Path,
     config: AcceleratedShadowReplayConfig,
     warmup_count: int,
-) -> dict[str, Any]:
-    """Derive deterministic scheduler metadata from the loaded candle series."""
+) -> DatasetResult:
+    """Build the deterministic dataset result used by scheduler and runner layers."""
     if len(candles) <= warmup_count:
         raise ReplayRunnerError(
             f"scheduler requires at least {warmup_count + 1} candles for "
@@ -321,19 +350,94 @@ def _build_scheduler_metadata(
     )
     try:
         spec.validate()
-        dataset_result = DatasetResult(
+        return DatasetResult(
             spec=spec,
             candles=tuple(dict(candle) for candle in candles),
             fingerprint=spec.fingerprint(),
             warmup_count=warmup_count,
             effective_candle_count=len(candles) - warmup_count,
         )
+    except (TypeError, ValueError) as exc:
+        raise ReplayRunnerError(f"dataset validation failed: {exc}") from exc
+
+
+def _build_scheduler_metadata(
+    dataset_result: DatasetResult,
+    *,
+    speedup_profile: str,
+) -> dict[str, Any]:
+    """Derive deterministic scheduler metadata from a validated dataset result."""
+    try:
         return ReplayScheduler().schedule(
             dataset_result,
-            SchedulerConfig(profile=config.speedup_profile),
+            SchedulerConfig(profile=speedup_profile),
         ).to_dict()
     except (TypeError, ValueError) as exc:
         raise ReplayRunnerError(f"scheduler validation failed: {exc}") from exc
+
+
+def _build_execution_provenance_id(
+    candles: list[dict[str, Any]],
+    *,
+    run_config: PrimaryBreakoutBacktestRunConfig,
+    code_commit: str,
+) -> str:
+    """Precompute the deterministic backtest provenance id for the runner record."""
+    try:
+        bridge_requests = build_primary_breakout_historical_bridge(
+            candles, config=run_config.bridge
+        )
+        return _deterministic_run_id(bridge_requests, run_config, code_commit)
+    except Exception as exc:
+        raise ReplayRunnerError(
+            f"failed to derive execution provenance id: {exc}"
+        ) from exc
+
+
+def _write_operator_summary_artifact(
+    bundle_dir: Path,
+    record: ReplayRunRecord,
+) -> None:
+    summary_path = bundle_dir / "operator_summary.json"
+    summary_path.write_text(
+        canonical_json_dumps(build_operator_summary(record)),
+        encoding="utf-8",
+    )
+
+
+def _append_failed_record(
+    registry: ReplayRunRegistry,
+    *,
+    run_id: str,
+    strategy_id: str,
+    symbol: str,
+    dataset_fingerprint: str,
+    scheduler_profile: str,
+    execution_provenance_id: str,
+    artifact_root: str,
+    deterministic_replay_ok: bool,
+    started_at_utc: str,
+    failure_reason: str,
+    gate_status: str | None = None,
+) -> ReplayRunRecord:
+    record = ReplayRunRecord(
+        run_id=run_id,
+        status="failed",
+        mode=_DEFAULT_REPLAY_MODE,
+        strategy_id=strategy_id,
+        symbol=symbol,
+        dataset_fingerprint=dataset_fingerprint,
+        scheduler_profile=scheduler_profile,
+        execution_provenance_id=execution_provenance_id,
+        artifact_root=artifact_root,
+        gate_status=gate_status,
+        deterministic_replay_ok=deterministic_replay_ok,
+        failure_reason=failure_reason,
+        started_at_utc=started_at_utc,
+        finished_at_utc=_utc_now_iso(),
+    )
+    registry.append(record)
+    return record
 
 
 def _build_replay_report_input(
@@ -342,6 +446,10 @@ def _build_replay_report_input(
     code_commit: str,
     output_dir: Path,
     scheduler_metadata: dict[str, Any] | None = None,
+    *,
+    runner_run_id: str | None = None,
+    execution_provenance_id: str | None = None,
+    dataset_fingerprint: str | None = None,
 ) -> ReplayReportInput:
     """Bridge a backtest runner report to a ReplayReportInput.
 
@@ -351,11 +459,21 @@ def _build_replay_report_input(
 
     No metrics are recalculated; all values are derived from the backtest report.
     """
-    run_id: str = backtest_report["run_metadata"]["run_id"]
+    execution_run_id: str = execution_provenance_id or backtest_report["run_metadata"]["run_id"]
+    run_id: str = runner_run_id or execution_run_id
     dataset: dict[str, Any] = dict(backtest_report["dataset_summary"])
+    if dataset_fingerprint is not None:
+        dataset["dataset_fingerprint"] = dataset_fingerprint
     if scheduler_metadata is not None:
         dataset["scheduler"] = dict(scheduler_metadata)
     metrics: dict[str, Any] = backtest_report["metrics"]
+    run_spec_metadata: dict[str, Any] = {
+        "mode": _DEFAULT_REPLAY_MODE,
+        "execution_provenance_id": execution_run_id,
+        "scheduler_profile": config.speedup_profile,
+    }
+    if dataset_fingerprint is not None:
+        run_spec_metadata["dataset_fingerprint"] = dataset_fingerprint
 
     run_spec = ReplayRunSpec(
         replay_run_id=run_id,
@@ -365,6 +483,7 @@ def _build_replay_report_input(
         end_ts_ms=int(dataset["period_end_ts_ms"]),
         code_commit=code_commit,
         run_mode="shadow",
+        metadata=run_spec_metadata,
     )
 
     exec_result = ReplayExecutionResult(
@@ -406,6 +525,11 @@ def _build_replay_report_input(
         envelope_log_uri="none",
         event_loop_states_uri="none",
         report_artifact_uri=str(bundle_dir / "report.json"),
+        supplementary_artifacts={
+            "config_resolved_uri": str(bundle_dir / "config.resolved.json"),
+            "env_redacted_uri": str(bundle_dir / "env_redacted.txt"),
+            "operator_summary_uri": str(bundle_dir / "operator_summary.json"),
+        },
     )
 
     return ReplayReportInput(
@@ -493,6 +617,8 @@ def run_accelerated_shadow_replay(config: AcceleratedShadowReplayConfig) -> int:
         )
         return 0
 
+    output_dir = Path(config.output_directory)
+    code_commit = _get_code_commit()
     run_cfg = PrimaryBreakoutBacktestRunConfig(
         bridge=PrimaryBreakoutBridgeConfig(
             entry_lookback_minutes=config.entry_lookback_minutes,
@@ -508,18 +634,62 @@ def run_accelerated_shadow_replay(config: AcceleratedShadowReplayConfig) -> int:
         run_cfg.bridge.exit_lookback_minutes,
     )
     try:
-        scheduler_metadata = _build_scheduler_metadata(
+        dataset_result = _build_dataset_result(
             candles,
             input_path=input_path,
             config=config,
             warmup_count=warmup_count,
         )
-    except ReplayRunnerError as exc:
+        scheduler_metadata = _build_scheduler_metadata(
+            dataset_result,
+            speedup_profile=config.speedup_profile,
+        )
+        execution_provenance_id = _build_execution_provenance_id(
+            candles,
+            run_config=run_cfg,
+            code_commit=code_commit,
+        )
+        provenance_fingerprint = build_replay_provenance_fingerprint(
+            strategy_id=config.strategy_id,
+            symbol=config.symbol,
+            adapter_id=config.adapter_id,
+            dataset_fingerprint=dataset_result.fingerprint,
+            scheduler_profile=config.speedup_profile,
+            execution_provenance_id=execution_provenance_id,
+            code_commit=code_commit,
+            mode=_DEFAULT_REPLAY_MODE,
+            config_snapshot=_build_provenance_config_snapshot(config),
+        )
+        registry = ReplayRunRegistry(output_dir / "run_registry.jsonl")
+        run_id = build_replay_run_id(
+            provenance_fingerprint,
+            registry.next_attempt(provenance_fingerprint),
+        )
+    except (ReplayRunnerError, RunRegistryError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 
-    output_dir = Path(config.output_directory)
-    code_commit = _get_code_commit()
+    started_at_utc = _utc_now_iso()
+    artifact_root = str(output_dir / run_id)
+    try:
+        registry.append(
+            ReplayRunRecord(
+                run_id=run_id,
+                status="running",
+                mode=_DEFAULT_REPLAY_MODE,
+                strategy_id=config.strategy_id,
+                symbol=config.symbol,
+                dataset_fingerprint=dataset_result.fingerprint,
+                scheduler_profile=config.speedup_profile,
+                execution_provenance_id=execution_provenance_id,
+                artifact_root=artifact_root,
+                deterministic_replay_ok=False,
+                started_at_utc=started_at_utc,
+            )
+        )
+    except RunRegistryError as exc:
+        print(f"ERROR: Failed to write running run record: {exc}", file=sys.stderr)
+        return 2
 
     # Delegate to the existing backtest surface (business logic lives here)
     try:
@@ -529,9 +699,47 @@ def run_accelerated_shadow_replay(config: AcceleratedShadowReplayConfig) -> int:
             code_commit=code_commit,
         )
     except (HistoricalBridgeError, PrimaryBreakoutBacktestError) as exc:
+        try:
+            _append_failed_record(
+                registry,
+                run_id=run_id,
+                strategy_id=config.strategy_id,
+                symbol=config.symbol,
+                dataset_fingerprint=dataset_result.fingerprint,
+                scheduler_profile=config.speedup_profile,
+                execution_provenance_id=execution_provenance_id,
+                artifact_root=artifact_root,
+                deterministic_replay_ok=False,
+                started_at_utc=started_at_utc,
+                failure_reason=f"Replay execution failed: {exc}",
+            )
+        except RunRegistryError as registry_exc:
+            print(
+                f"ERROR: Failed to write failed run record: {registry_exc}",
+                file=sys.stderr,
+            )
         print(f"ERROR: Replay execution failed: {exc}", file=sys.stderr)
         return 2
     except Exception as exc:
+        try:
+            _append_failed_record(
+                registry,
+                run_id=run_id,
+                strategy_id=config.strategy_id,
+                symbol=config.symbol,
+                dataset_fingerprint=dataset_result.fingerprint,
+                scheduler_profile=config.speedup_profile,
+                execution_provenance_id=execution_provenance_id,
+                artifact_root=artifact_root,
+                deterministic_replay_ok=False,
+                started_at_utc=started_at_utc,
+                failure_reason=f"Unexpected runtime failure: {exc}",
+            )
+        except RunRegistryError as registry_exc:
+            print(
+                f"ERROR: Failed to write failed run record: {registry_exc}",
+                file=sys.stderr,
+            )
         print(f"ERROR: Unexpected runtime failure: {exc}", file=sys.stderr)
         return 2
 
@@ -543,8 +751,30 @@ def run_accelerated_shadow_replay(config: AcceleratedShadowReplayConfig) -> int:
             code_commit,
             output_dir,
             scheduler_metadata=scheduler_metadata,
+            runner_run_id=run_id,
+            execution_provenance_id=execution_provenance_id,
+            dataset_fingerprint=dataset_result.fingerprint,
         )
     except Exception as exc:
+        try:
+            _append_failed_record(
+                registry,
+                run_id=run_id,
+                strategy_id=config.strategy_id,
+                symbol=config.symbol,
+                dataset_fingerprint=dataset_result.fingerprint,
+                scheduler_profile=config.speedup_profile,
+                execution_provenance_id=execution_provenance_id,
+                artifact_root=artifact_root,
+                deterministic_replay_ok=False,
+                started_at_utc=started_at_utc,
+                failure_reason=f"Failed to build replay report input: {exc}",
+            )
+        except RunRegistryError as registry_exc:
+            print(
+                f"ERROR: Failed to write failed run record: {registry_exc}",
+                file=sys.stderr,
+            )
         print(f"ERROR: Failed to build replay report input: {exc}", file=sys.stderr)
         return 2
 
@@ -553,21 +783,59 @@ def run_accelerated_shadow_replay(config: AcceleratedShadowReplayConfig) -> int:
     try:
         bundle_dir = reporter.write_bundle(report_input, output_dir)
     except ReplayReporterError as exc:
+        try:
+            _append_failed_record(
+                registry,
+                run_id=run_id,
+                strategy_id=config.strategy_id,
+                symbol=config.symbol,
+                dataset_fingerprint=dataset_result.fingerprint,
+                scheduler_profile=config.speedup_profile,
+                execution_provenance_id=execution_provenance_id,
+                artifact_root=artifact_root,
+                deterministic_replay_ok=False,
+                started_at_utc=started_at_utc,
+                failure_reason=f"Replay reporter failed: {exc}",
+            )
+        except RunRegistryError as registry_exc:
+            print(
+                f"ERROR: Failed to write failed run record: {registry_exc}",
+                file=sys.stderr,
+            )
         print(f"ERROR: Replay reporter failed: {exc}", file=sys.stderr)
         return 2
 
     # Write supplementary artifacts (CLI layer, not part of canonical hash)
+    artifact_root = str(bundle_dir)
     try:
         _write_supplementary_artifacts(bundle_dir, config, code_commit)
     except OSError as exc:
+        try:
+            _append_failed_record(
+                registry,
+                run_id=run_id,
+                strategy_id=config.strategy_id,
+                symbol=config.symbol,
+                dataset_fingerprint=dataset_result.fingerprint,
+                scheduler_profile=config.speedup_profile,
+                execution_provenance_id=execution_provenance_id,
+                artifact_root=artifact_root,
+                deterministic_replay_ok=False,
+                started_at_utc=started_at_utc,
+                failure_reason=f"Failed to write supplementary artifacts: {exc}",
+            )
+        except RunRegistryError as registry_exc:
+            print(
+                f"ERROR: Failed to write failed run record: {registry_exc}",
+                file=sys.stderr,
+            )
         print(f"ERROR: Failed to write supplementary artifacts: {exc}", file=sys.stderr)
         return 2
 
     # Determinism check
     metrics = backtest_report.get("metrics", {})
     deterministic_replay_ok = bool(metrics.get("deterministic_replay_ok", False))
-    gate_status = (backtest_report.get("gate_result") or {}).get("status", "UNKNOWN")
-    run_id = report_input.run_spec.replay_run_id
+    gate_status = (backtest_report.get("gate_result") or {}).get("status")
 
     if not deterministic_replay_ok:
         print(
@@ -576,14 +844,97 @@ def run_accelerated_shadow_replay(config: AcceleratedShadowReplayConfig) -> int:
             file=sys.stderr,
         )
         if config.deterministic_verify:
+            failed_record: ReplayRunRecord | None = None
+            try:
+                failed_record = _append_failed_record(
+                    registry,
+                    run_id=run_id,
+                    strategy_id=config.strategy_id,
+                    symbol=config.symbol,
+                    dataset_fingerprint=dataset_result.fingerprint,
+                    scheduler_profile=config.speedup_profile,
+                    execution_provenance_id=execution_provenance_id,
+                    artifact_root=artifact_root,
+                    gate_status=gate_status,
+                    deterministic_replay_ok=False,
+                    started_at_utc=started_at_utc,
+                    failure_reason=(
+                        "--deterministic-verify set and deterministic_replay_ok=False"
+                    ),
+                )
+            except RunRegistryError as registry_exc:
+                print(
+                    f"ERROR: Failed to write failed run record: {registry_exc}",
+                    file=sys.stderr,
+                )
+            if failed_record is not None:
+                try:
+                    _write_operator_summary_artifact(bundle_dir, failed_record)
+                except OSError as exc:
+                    print(
+                        f"ERROR: Failed to write operator summary: {exc}",
+                        file=sys.stderr,
+                    )
             print(
                 "ERROR: --deterministic-verify is set; aborting with exit code 2.",
                 file=sys.stderr,
             )
             return 2
 
+    completed_record = ReplayRunRecord(
+        run_id=run_id,
+        status="completed",
+        mode=_DEFAULT_REPLAY_MODE,
+        strategy_id=config.strategy_id,
+        symbol=config.symbol,
+        dataset_fingerprint=dataset_result.fingerprint,
+        scheduler_profile=config.speedup_profile,
+        execution_provenance_id=execution_provenance_id,
+        artifact_root=artifact_root,
+        gate_status=gate_status,
+        deterministic_replay_ok=deterministic_replay_ok,
+        started_at_utc=started_at_utc,
+        finished_at_utc=_utc_now_iso(),
+    )
+    try:
+        registry.append(completed_record)
+    except RunRegistryError as exc:
+        print(f"ERROR: Failed to write completed run record: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        _write_operator_summary_artifact(bundle_dir, completed_record)
+    except OSError as exc:
+        try:
+            _append_failed_record(
+                registry,
+                run_id=run_id,
+                strategy_id=config.strategy_id,
+                symbol=config.symbol,
+                dataset_fingerprint=dataset_result.fingerprint,
+                scheduler_profile=config.speedup_profile,
+                execution_provenance_id=execution_provenance_id,
+                artifact_root=artifact_root,
+                gate_status=gate_status,
+                deterministic_replay_ok=deterministic_replay_ok,
+                started_at_utc=started_at_utc,
+                failure_reason=f"Failed to write operator summary: {exc}",
+            )
+        except RunRegistryError as registry_exc:
+            print(
+                f"ERROR: Failed to write failed run record: {registry_exc}",
+                file=sys.stderr,
+            )
+        print(f"ERROR: Failed to write operator summary: {exc}", file=sys.stderr)
+        return 2
+
     print(f"Shadow replay complete: run_id={run_id}")
-    print(f"  gate_result={gate_status}")
+    print("  status=completed")
+    print(f"  mode={_DEFAULT_REPLAY_MODE}")
+    print(f"  execution_provenance_id={execution_provenance_id}")
+    print(f"  dataset_fingerprint={dataset_result.fingerprint}")
+    print(f"  scheduler_profile={config.speedup_profile}")
+    print(f"  gate_result={gate_status or 'UNKNOWN'}")
     print(f"  deterministic_replay_ok={deterministic_replay_ok}")
     print(f"  bundle_dir={bundle_dir}")
     return 0

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -50,7 +50,7 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import timezone
 from pathlib import Path
 from typing import Any
 
@@ -85,6 +85,7 @@ from core.replay.run_registry import (
     build_replay_provenance_fingerprint,
     build_replay_run_id,
 )
+from core.utils.clock import utcnow
 from services.validation.replay_reporter import ReplayReporter, ReplayReporterError
 from services.validation.strategy_backtest_runner import (
     PrimaryBreakoutBacktestError,
@@ -301,7 +302,7 @@ def _redact_env() -> dict[str, str]:
 
 
 def _utc_now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return utcnow().replace(tzinfo=timezone.utc).isoformat()
 
 
 def _build_provenance_config_snapshot(

--- a/tests/unit/replay/test_run_registry.py
+++ b/tests/unit/replay/test_run_registry.py
@@ -1,0 +1,160 @@
+"""Unit tests for core/replay/run_registry.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.replay.run_registry import (
+    ReplayRunRecord,
+    ReplayRunRegistry,
+    RunRegistryError,
+    build_operator_summary,
+    build_replay_provenance_fingerprint,
+    build_replay_run_id,
+)
+
+
+def _make_record(**overrides) -> ReplayRunRecord:
+    defaults = {
+        "run_id": "replay-0123456789ab-0001",
+        "status": "completed",
+        "mode": "baseline",
+        "strategy_id": "primary_breakout_v1",
+        "symbol": "BTCUSDT",
+        "dataset_fingerprint": "a" * 64,
+        "scheduler_profile": "2x",
+        "execution_provenance_id": "bt-0123456789abcdef",
+        "artifact_root": "artifacts/replay_reports/replay-0123456789ab-0001",
+        "gate_status": "PASS",
+        "deterministic_replay_ok": True,
+        "failure_reason": None,
+        "started_at_utc": "2026-04-22T14:00:00+00:00",
+        "finished_at_utc": "2026-04-22T14:00:05+00:00",
+    }
+    defaults.update(overrides)
+    return ReplayRunRecord(**defaults)
+
+
+@pytest.mark.unit
+class TestReplayRunRecord:
+    def test_invalid_status_fails_closed(self) -> None:
+        with pytest.raises(RunRegistryError, match="Invalid status"):
+            _make_record(status="unknown")
+
+    def test_failed_record_requires_reason(self) -> None:
+        with pytest.raises(RunRegistryError, match="require failure_reason"):
+            _make_record(status="failed", failure_reason=None)
+
+    def test_to_dict_is_deterministic(self) -> None:
+        result = _make_record().to_dict()
+        assert list(result.keys()) == [
+            "run_id",
+            "status",
+            "mode",
+            "strategy_id",
+            "symbol",
+            "dataset_fingerprint",
+            "scheduler_profile",
+            "execution_provenance_id",
+            "artifact_root",
+            "deterministic_replay_ok",
+            "started_at_utc",
+            "gate_status",
+            "finished_at_utc",
+        ]
+
+
+@pytest.mark.unit
+class TestProvenanceHelpers:
+    def test_provenance_fingerprint_is_deterministic(self) -> None:
+        p1 = build_replay_provenance_fingerprint(
+            strategy_id="primary_breakout_v1",
+            symbol="BTCUSDT",
+            adapter_id="primary_breakout_runner_v1",
+            dataset_fingerprint="a" * 64,
+            scheduler_profile="5x",
+            execution_provenance_id="bt-0123456789abcdef",
+            code_commit="abc1234",
+            config_snapshot={"entry_lookback_minutes": 240},
+        )
+        p2 = build_replay_provenance_fingerprint(
+            strategy_id="primary_breakout_v1",
+            symbol="BTCUSDT",
+            adapter_id="primary_breakout_runner_v1",
+            dataset_fingerprint="a" * 64,
+            scheduler_profile="5x",
+            execution_provenance_id="bt-0123456789abcdef",
+            code_commit="abc1234",
+            config_snapshot={"entry_lookback_minutes": 240},
+        )
+        assert p1 == p2
+        assert len(p1) == 64
+
+    def test_run_ids_are_distinct_for_attempts(self) -> None:
+        provenance = "f" * 64
+        assert build_replay_run_id(provenance, 1) == "replay-ffffffffffff-0001"
+        assert build_replay_run_id(provenance, 2) == "replay-ffffffffffff-0002"
+
+
+@pytest.mark.unit
+class TestReplayRunRegistry:
+    def test_append_and_load_cycle(self, tmp_path: Path) -> None:
+        registry = ReplayRunRegistry(tmp_path / "run_registry.jsonl")
+        record = _make_record()
+
+        registry.append(record)
+        loaded = registry.load_all()
+
+        assert loaded == [record]
+
+    def test_malformed_registry_line_fails_closed(self, tmp_path: Path) -> None:
+        path = tmp_path / "run_registry.jsonl"
+        path.write_text("not-json\n", encoding="utf-8")
+        registry = ReplayRunRegistry(path)
+
+        with pytest.raises(RunRegistryError, match="Malformed JSON"):
+            registry.load_all()
+
+    def test_invalid_lifecycle_status_in_registry_fails_closed(self, tmp_path: Path) -> None:
+        path = tmp_path / "run_registry.jsonl"
+        path.write_text(
+            (
+                '{"run_id":"replay-0123456789ab-0001","status":"broken","mode":"baseline",'
+                '"strategy_id":"primary_breakout_v1","symbol":"BTCUSDT",'
+                '"dataset_fingerprint":"' + ("a" * 64) + '","scheduler_profile":"instant",'
+                '"execution_provenance_id":"bt-0123456789abcdef",'
+                '"artifact_root":"artifacts/replay_reports/replay-0123456789ab-0001",'
+                '"deterministic_replay_ok":false,"started_at_utc":"2026-04-22T14:00:00+00:00"}\n'
+            ),
+            encoding="utf-8",
+        )
+        registry = ReplayRunRegistry(path)
+
+        with pytest.raises(RunRegistryError, match="Invalid run registry record"):
+            registry.load_all()
+
+    def test_next_attempt_uses_existing_run_ids(self, tmp_path: Path) -> None:
+        registry = ReplayRunRegistry(tmp_path / "run_registry.jsonl")
+        provenance = "f" * 64
+        run_id = build_replay_run_id(provenance, 1)
+        registry.append(_make_record(run_id=run_id))
+        registry.append(_make_record(run_id=run_id, status="failed", failure_reason="boom"))
+
+        assert registry.next_attempt(provenance) == 2
+
+
+@pytest.mark.unit
+class TestOperatorSummary:
+    def test_summary_contains_required_fields(self) -> None:
+        summary = build_operator_summary(_make_record(status="failed", failure_reason="boom"))
+
+        assert summary["run_id"] == "replay-0123456789ab-0001"
+        assert summary["status"] == "failed"
+        assert summary["mode"] == "baseline"
+        assert summary["dataset_fingerprint"] == "a" * 64
+        assert summary["scheduler_profile"] == "2x"
+        assert summary["execution_provenance_id"] == "bt-0123456789abcdef"
+        assert summary["artifact_root"].endswith("replay-0123456789ab-0001")
+        assert summary["failure_reason"] == "boom"

--- a/tests/unit/replay/test_scenario_harness.py
+++ b/tests/unit/replay/test_scenario_harness.py
@@ -1,0 +1,349 @@
+"""Unit tests for core/replay/scenario_harness.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from core.replay.scenario_harness import (
+    ScenarioGroupManifest,
+    ScenarioHarnessError,
+    ScenarioRunResult,
+    ScenarioSpec,
+    build_scenario_group_id,
+    run_scenario_group,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _spec(
+    scenario_id: str = "baseline",
+    description: str = "Baseline scenario",
+    config_overrides: dict[str, Any] | None = None,
+) -> ScenarioSpec:
+    return ScenarioSpec(
+        scenario_id=scenario_id,
+        description=description,
+        config_overrides=config_overrides if config_overrides is not None else {},
+    )
+
+
+def _success_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+    return ScenarioRunResult(
+        scenario_id=spec.scenario_id,
+        exit_code=0,
+        run_id="replay-aabbccdd1122-0001",
+    )
+
+
+def _failure_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+    return ScenarioRunResult(
+        scenario_id=spec.scenario_id,
+        exit_code=2,
+        failure_reason="Simulated failure",
+    )
+
+
+# ---------------------------------------------------------------------------
+# ScenarioSpec
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestScenarioSpec:
+    def test_valid_construction(self) -> None:
+        spec = _spec(config_overrides={"order_size": 2.0})
+        assert spec.scenario_id == "baseline"
+        assert spec.description == "Baseline scenario"
+        assert spec.config_overrides == {"order_size": 2.0}
+
+    def test_empty_scenario_id_fails(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="scenario_id"):
+            _spec(scenario_id="")
+
+    def test_whitespace_scenario_id_fails(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="scenario_id"):
+            _spec(scenario_id="   ")
+
+    def test_empty_description_fails(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="description"):
+            _spec(description="")
+
+    def test_invalid_config_overrides_fails(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="config_overrides"):
+            ScenarioSpec(
+                scenario_id="baseline",
+                description="Baseline",
+                config_overrides="not_a_dict",  # type: ignore[arg-type]
+            )
+
+    def test_config_overrides_is_defensively_copied(self) -> None:
+        original: dict[str, Any] = {"order_size": 1.0}
+        spec = _spec(config_overrides=original)
+        original["injected"] = "evil"
+        assert "injected" not in spec.config_overrides
+
+    def test_to_dict_shape(self) -> None:
+        spec = _spec(config_overrides={"order_size": 2.0})
+        d = spec.to_dict()
+        assert d["scenario_id"] == "baseline"
+        assert d["description"] == "Baseline scenario"
+        assert d["config_overrides"] == {"order_size": 2.0}
+
+
+# ---------------------------------------------------------------------------
+# ScenarioRunResult
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestScenarioRunResult:
+    def test_success_result(self) -> None:
+        result = ScenarioRunResult(
+            scenario_id="baseline", exit_code=0, run_id="replay-aabb-0001"
+        )
+        assert result.succeeded is True
+
+    def test_failure_result(self) -> None:
+        result = ScenarioRunResult(
+            scenario_id="pessimistic", exit_code=2, failure_reason="timeout"
+        )
+        assert result.succeeded is False
+
+    def test_failure_requires_reason(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="failure_reason is required"):
+            ScenarioRunResult(scenario_id="baseline", exit_code=2)
+
+    def test_success_must_not_have_reason(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="failure_reason must be None"):
+            ScenarioRunResult(
+                scenario_id="baseline", exit_code=0, failure_reason="unexpected"
+            )
+
+    def test_exit_code_bool_rejected(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="not bool"):
+            ScenarioRunResult(scenario_id="baseline", exit_code=True)  # type: ignore[arg-type]
+
+    def test_to_dict_omits_none_fields(self) -> None:
+        result = ScenarioRunResult(scenario_id="baseline", exit_code=0)
+        d = result.to_dict()
+        assert "run_id" not in d
+        assert "failure_reason" not in d
+
+    def test_to_dict_includes_optional_fields(self) -> None:
+        result = ScenarioRunResult(
+            scenario_id="pessimistic",
+            exit_code=2,
+            run_id="replay-aabb-0001",
+            failure_reason="bridge error",
+        )
+        d = result.to_dict()
+        assert d["run_id"] == "replay-aabb-0001"
+        assert d["failure_reason"] == "bridge error"
+
+    def test_empty_run_id_rejected(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="run_id"):
+            ScenarioRunResult(scenario_id="baseline", exit_code=0, run_id="")
+
+    def test_empty_failure_reason_rejected(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="failure_reason"):
+            ScenarioRunResult(
+                scenario_id="baseline", exit_code=2, failure_reason="   "
+            )
+
+
+# ---------------------------------------------------------------------------
+# build_scenario_group_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestBuildScenarioGroupId:
+    def test_deterministic_for_same_inputs(self) -> None:
+        gid1 = build_scenario_group_id(["baseline", "pessimistic"])
+        gid2 = build_scenario_group_id(["baseline", "pessimistic"])
+        assert gid1 == gid2
+
+    def test_different_for_different_inputs(self) -> None:
+        gid1 = build_scenario_group_id(["baseline"])
+        gid2 = build_scenario_group_id(["pessimistic"])
+        assert gid1 != gid2
+
+    def test_order_sensitive(self) -> None:
+        gid1 = build_scenario_group_id(["baseline", "pessimistic"])
+        gid2 = build_scenario_group_id(["pessimistic", "baseline"])
+        assert gid1 != gid2
+
+    def test_empty_sequence_fails(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="must not be empty"):
+            build_scenario_group_id([])
+
+    def test_group_id_format(self) -> None:
+        gid = build_scenario_group_id(["baseline"])
+        assert gid.startswith("sg-")
+        assert len(gid) == len("sg-") + 12
+
+
+# ---------------------------------------------------------------------------
+# run_scenario_group
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestRunScenarioGroup:
+    def test_empty_specs_fail_closed(self, tmp_path: Path) -> None:
+        with pytest.raises(ScenarioHarnessError, match="must not be empty"):
+            run_scenario_group([], run_fn=_success_fn, output_dir=tmp_path)
+
+    def test_duplicate_ids_fail_closed(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline"), _spec("baseline")]
+        with pytest.raises(ScenarioHarnessError, match="Duplicate scenario_id"):
+            run_scenario_group(specs, run_fn=_success_fn, output_dir=tmp_path)
+
+    def test_invalid_custom_group_id_fails(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline")]
+        with pytest.raises(ScenarioHarnessError, match="group_id"):
+            run_scenario_group(
+                specs, run_fn=_success_fn, output_dir=tmp_path, group_id="../evil"
+            )
+
+    def test_custom_group_id_accepted(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline")]
+        manifest = run_scenario_group(
+            specs, run_fn=_success_fn, output_dir=tmp_path, group_id="my-group-01"
+        )
+        assert manifest.group_id == "my-group-01"
+        assert (tmp_path / "my-group-01" / "scenario_group_manifest.json").exists()
+
+    def test_single_scenario_success(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline")]
+        manifest = run_scenario_group(specs, run_fn=_success_fn, output_dir=tmp_path)
+        assert manifest.total_scenarios == 1
+        assert manifest.succeeded_count == 1
+        assert manifest.failed_count == 0
+        assert manifest.scenario_results[0].scenario_id == "baseline"
+        assert manifest.scenario_results[0].exit_code == 0
+
+    def test_multiple_scenarios_all_succeed(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline"), _spec("pessimistic"), _spec("delayed")]
+        manifest = run_scenario_group(specs, run_fn=_success_fn, output_dir=tmp_path)
+        assert manifest.total_scenarios == 3
+        assert manifest.succeeded_count == 3
+        assert manifest.failed_count == 0
+
+    def test_failed_scenario_explicit_not_skipped(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline"), _spec("pessimistic")]
+
+        def mixed_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+            if spec.scenario_id == "pessimistic":
+                return ScenarioRunResult(
+                    scenario_id=spec.scenario_id,
+                    exit_code=2,
+                    failure_reason="Simulated failure",
+                )
+            return ScenarioRunResult(scenario_id=spec.scenario_id, exit_code=0)
+
+        manifest = run_scenario_group(specs, run_fn=mixed_fn, output_dir=tmp_path)
+        assert manifest.total_scenarios == 2
+        assert manifest.succeeded_count == 1
+        assert manifest.failed_count == 1
+        failed = [r for r in manifest.scenario_results if r.exit_code != 0]
+        assert len(failed) == 1
+        assert failed[0].scenario_id == "pessimistic"
+        assert failed[0].failure_reason == "Simulated failure"
+
+    def test_run_fn_exception_captured_not_propagated(self, tmp_path: Path) -> None:
+        def exploding_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+            raise RuntimeError("unexpected crash")
+
+        specs = [_spec("baseline")]
+        manifest = run_scenario_group(specs, run_fn=exploding_fn, output_dir=tmp_path)
+        assert manifest.failed_count == 1
+        assert manifest.scenario_results[0].exit_code == 2
+        assert "RuntimeError" in (manifest.scenario_results[0].failure_reason or "")
+
+    def test_run_fn_wrong_return_type_raises(self, tmp_path: Path) -> None:
+        def bad_fn(spec: ScenarioSpec) -> int:  # type: ignore[return-value]
+            return 42
+
+        specs = [_spec("baseline")]
+        with pytest.raises(ScenarioHarnessError, match="must return ScenarioRunResult"):
+            run_scenario_group(specs, run_fn=bad_fn, output_dir=tmp_path)  # type: ignore[arg-type]
+
+    def test_run_fn_wrong_scenario_id_raises(self, tmp_path: Path) -> None:
+        def wrong_id_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+            return ScenarioRunResult(scenario_id="other-id", exit_code=0)
+
+        specs = [_spec("baseline")]
+        with pytest.raises(ScenarioHarnessError, match="wrong scenario"):
+            run_scenario_group(specs, run_fn=wrong_id_fn, output_dir=tmp_path)
+
+    def test_manifest_written_to_correct_path(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline")]
+        manifest = run_scenario_group(specs, run_fn=_success_fn, output_dir=tmp_path)
+        manifest_path = tmp_path / manifest.group_id / "scenario_group_manifest.json"
+        assert manifest_path.exists()
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert data["group_id"] == manifest.group_id
+        assert len(data["scenario_results"]) == 1
+
+    def test_group_fingerprint_stable_for_same_outcomes(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline"), _spec("pessimistic")]
+
+        def deterministic_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+            return ScenarioRunResult(scenario_id=spec.scenario_id, exit_code=0)
+
+        manifest1 = run_scenario_group(
+            specs, run_fn=deterministic_fn, output_dir=tmp_path / "run1"
+        )
+        manifest2 = run_scenario_group(
+            specs, run_fn=deterministic_fn, output_dir=tmp_path / "run2"
+        )
+        assert manifest1.group_fingerprint == manifest2.group_fingerprint
+
+    def test_group_fingerprint_differs_for_different_outcomes(
+        self, tmp_path: Path
+    ) -> None:
+        specs = [_spec("baseline")]
+
+        manifest_ok = run_scenario_group(
+            specs, run_fn=_success_fn, output_dir=tmp_path / "a"
+        )
+        manifest_fail = run_scenario_group(
+            specs, run_fn=_failure_fn, output_dir=tmp_path / "b"
+        )
+        assert manifest_ok.group_fingerprint != manifest_fail.group_fingerprint
+
+    def test_group_id_deterministic_across_runs(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline"), _spec("pessimistic")]
+        manifest1 = run_scenario_group(
+            specs, run_fn=_success_fn, output_dir=tmp_path / "a"
+        )
+        manifest2 = run_scenario_group(
+            specs, run_fn=_success_fn, output_dir=tmp_path / "b"
+        )
+        assert manifest1.group_id == manifest2.group_id
+
+    def test_execution_order_preserved(self, tmp_path: Path) -> None:
+        call_order: list[str] = []
+
+        def tracking_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+            call_order.append(spec.scenario_id)
+            return ScenarioRunResult(scenario_id=spec.scenario_id, exit_code=0)
+
+        specs = [_spec("z_last"), _spec("a_first"), _spec("m_middle")]
+        run_scenario_group(specs, run_fn=tracking_fn, output_dir=tmp_path)
+        assert call_order == ["z_last", "a_first", "m_middle"]
+
+    def test_manifest_to_dict_round_trips(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline"), _spec("pessimistic")]
+        manifest = run_scenario_group(specs, run_fn=_success_fn, output_dir=tmp_path)
+        d = manifest.to_dict()
+        assert d["total_scenarios"] == 2
+        assert d["succeeded_count"] == 2
+        assert d["failed_count"] == 0
+        assert len(d["scenario_results"]) == 2
+        ids = [r["scenario_id"] for r in d["scenario_results"]]
+        assert ids == ["baseline", "pessimistic"]

--- a/tests/unit/validation/test_strategy_replay_runner.py
+++ b/tests/unit/validation/test_strategy_replay_runner.py
@@ -16,6 +16,8 @@ from unittest.mock import patch
 
 import pytest
 
+from core.replay.run_registry import ReplayRunRegistry, RunRegistryError
+from core.replay.dataset_spec import DatasetSpec
 from services.validation.replay_reporter import ReplayReporter
 from services.validation.strategy_replay_runner import (
     _DEFAULT_ADAPTER_ID,
@@ -393,12 +395,19 @@ class TestRunAcceleratedShadowReplay:
         f.write_text(json.dumps(candles), encoding="utf-8")
         return f
 
+    def _mock_bundle_dir(self, mock_write, tmp_path: Path):
+        def _side_effect(report_input, output_dir):
+            bundle_dir = Path(output_dir) / report_input.run_spec.replay_run_id
+            bundle_dir.mkdir(parents=True, exist_ok=True)
+            return bundle_dir
+
+        mock_write.side_effect = _side_effect
+
     @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
     @patch.object(ReplayReporter, "write_bundle")
     def test_successful_run_returns_0(self, mock_write, mock_backtest, tmp_path):
         mock_backtest.return_value = _minimal_backtest_report()
-        mock_write.return_value = tmp_path / "bt-abc1234567890123"
-        (tmp_path / "bt-abc1234567890123").mkdir()
+        self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
         cfg = AcceleratedShadowReplayConfig(
@@ -411,10 +420,8 @@ class TestRunAcceleratedShadowReplay:
     @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
     @patch.object(ReplayReporter, "write_bundle")
     def test_supplementary_artifacts_written(self, mock_write, mock_backtest, tmp_path):
-        bundle_dir = tmp_path / "bt-abc1234567890123"
-        bundle_dir.mkdir()
         mock_backtest.return_value = _minimal_backtest_report()
-        mock_write.return_value = bundle_dir
+        self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
         cfg = AcceleratedShadowReplayConfig(
@@ -423,6 +430,8 @@ class TestRunAcceleratedShadowReplay:
         )
         run_accelerated_shadow_replay(cfg)
 
+        report_input = mock_write.call_args.args[0]
+        bundle_dir = Path(tmp_path) / report_input.run_spec.replay_run_id
         assert (bundle_dir / "config.resolved.json").exists()
         assert (bundle_dir / "env_redacted.txt").exists()
 
@@ -431,10 +440,8 @@ class TestRunAcceleratedShadowReplay:
     def test_scheduler_metadata_embedded_in_report_input(
         self, mock_write, mock_backtest, tmp_path
     ):
-        bundle_dir = tmp_path / "bt-abc1234567890123"
-        bundle_dir.mkdir()
         mock_backtest.return_value = _minimal_backtest_report()
-        mock_write.return_value = bundle_dir
+        self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
         cfg = AcceleratedShadowReplayConfig(
@@ -449,6 +456,142 @@ class TestRunAcceleratedShadowReplay:
         assert report_input.dataset_summary is not None
         assert report_input.dataset_summary["scheduler"]["profile"] == "2x"
         assert report_input.dataset_summary["scheduler"]["warmup_count"] == 240
+
+    @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
+    @patch.object(ReplayReporter, "write_bundle")
+    def test_successful_run_writes_running_completed_and_operator_summary(
+        self, mock_write, mock_backtest, tmp_path
+    ):
+        mock_backtest.return_value = _minimal_backtest_report(deterministic_ok=True)
+        self._mock_bundle_dir(mock_write, tmp_path)
+
+        f = self._make_candles_file(tmp_path)
+        cfg = AcceleratedShadowReplayConfig(
+            input_candles_file=str(f),
+            output_directory=str(tmp_path),
+            speedup_profile="5x",
+        )
+
+        exit_code = run_accelerated_shadow_replay(cfg)
+
+        assert exit_code == 0
+        report_input = mock_write.call_args.args[0]
+        run_id = report_input.run_spec.replay_run_id
+        registry = ReplayRunRegistry(tmp_path / "run_registry.jsonl")
+        records = registry.load_all()
+        assert [record.status for record in records] == ["running", "completed"]
+        assert all(record.run_id == run_id for record in records)
+        summary_path = tmp_path / run_id / "operator_summary.json"
+        assert summary_path.exists()
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        assert summary["run_id"] == run_id
+        assert summary["status"] == "completed"
+        assert summary["scheduler_profile"] == "5x"
+
+    @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
+    def test_failed_run_writes_failed_state_with_reason(self, mock_backtest, tmp_path):
+        from services.validation.strategy_backtest_runner import PrimaryBreakoutBacktestError
+
+        mock_backtest.side_effect = PrimaryBreakoutBacktestError("boom")
+        f = self._make_candles_file(tmp_path)
+        cfg = AcceleratedShadowReplayConfig(
+            input_candles_file=str(f),
+            output_directory=str(tmp_path),
+        )
+
+        exit_code = run_accelerated_shadow_replay(cfg)
+
+        assert exit_code == 2
+        records = ReplayRunRegistry(tmp_path / "run_registry.jsonl").load_all()
+        assert [record.status for record in records] == ["running", "failed"]
+        assert "boom" in records[-1].failure_reason
+
+    @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
+    @patch.object(ReplayReporter, "write_bundle")
+    def test_summary_and_registry_include_dataset_fingerprint_and_scheduler_profile(
+        self, mock_write, mock_backtest, tmp_path
+    ):
+        mock_backtest.return_value = _minimal_backtest_report()
+        self._mock_bundle_dir(mock_write, tmp_path)
+
+        f = self._make_candles_file(tmp_path)
+        cfg = AcceleratedShadowReplayConfig(
+            input_candles_file=str(f),
+            output_directory=str(tmp_path),
+            speedup_profile="10x",
+        )
+
+        exit_code = run_accelerated_shadow_replay(cfg)
+
+        assert exit_code == 0
+        registry = ReplayRunRegistry(tmp_path / "run_registry.jsonl")
+        completed = registry.load_all()[-1]
+        expected_fingerprint = DatasetSpec(
+            symbol="BTCUSDT",
+            timeframe="1m",
+            start_ts_ms=1_000_000 + 240 * 60_000,
+            end_ts_ms=1_000_000 + 299 * 60_000,
+            warmup_candles=240,
+            source="file",
+            file_path=str(f),
+        ).fingerprint()
+        assert completed.dataset_fingerprint == expected_fingerprint
+        assert completed.scheduler_profile == "10x"
+
+        summary_path = tmp_path / completed.run_id / "operator_summary.json"
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        assert summary["dataset_fingerprint"] == completed.dataset_fingerprint
+        assert summary["scheduler_profile"] == "10x"
+
+    @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
+    @patch.object(ReplayReporter, "write_bundle")
+    def test_existing_bundle_behavior_stays_compatible(
+        self, mock_write, mock_backtest, tmp_path
+    ):
+        mock_backtest.return_value = _minimal_backtest_report()
+        self._mock_bundle_dir(mock_write, tmp_path)
+
+        f = self._make_candles_file(tmp_path)
+        cfg = AcceleratedShadowReplayConfig(
+            input_candles_file=str(f),
+            output_directory=str(tmp_path),
+        )
+
+        exit_code = run_accelerated_shadow_replay(cfg)
+
+        assert exit_code == 0
+        report_input = mock_write.call_args.args[0]
+        assert report_input.run_spec.replay_run_id.startswith("replay-")
+        assert report_input.run_spec.metadata["execution_provenance_id"].startswith("bt-")
+        assert Path(report_input.artifact_manifest.report_artifact_uri).name == "report.json"
+        assert (
+            Path(
+                report_input.artifact_manifest.supplementary_artifacts[
+                    "operator_summary_uri"
+                ]
+            ).name
+            == "operator_summary.json"
+        )
+
+    @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
+    @patch.object(ReplayReporter, "write_bundle")
+    @patch("services.validation.strategy_replay_runner.ReplayRunRegistry.append")
+    def test_registry_write_failure_returns_2(
+        self, mock_append, mock_write, mock_backtest, tmp_path
+    ):
+        mock_backtest.return_value = _minimal_backtest_report()
+        self._mock_bundle_dir(mock_write, tmp_path)
+        mock_append.side_effect = [None, RunRegistryError("disk full")]
+
+        f = self._make_candles_file(tmp_path)
+        cfg = AcceleratedShadowReplayConfig(
+            input_candles_file=str(f),
+            output_directory=str(tmp_path),
+        )
+
+        exit_code = run_accelerated_shadow_replay(cfg)
+
+        assert exit_code == 2
 
     def test_missing_input_file_returns_2(self, tmp_path):
         cfg = AcceleratedShadowReplayConfig(
@@ -514,10 +657,8 @@ class TestRunAcceleratedShadowReplay:
     def test_determinism_warning_but_exit_0_without_flag(
         self, mock_write, mock_backtest, tmp_path, capsys
     ):
-        bundle_dir = tmp_path / "bt-abc1234567890123"
-        bundle_dir.mkdir()
         mock_backtest.return_value = _minimal_backtest_report(deterministic_ok=False)
-        mock_write.return_value = bundle_dir
+        self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
         cfg = AcceleratedShadowReplayConfig(
@@ -535,10 +676,8 @@ class TestRunAcceleratedShadowReplay:
     def test_deterministic_verify_flag_returns_2_on_failure(
         self, mock_write, mock_backtest, tmp_path
     ):
-        bundle_dir = tmp_path / "bt-abc1234567890123"
-        bundle_dir.mkdir()
         mock_backtest.return_value = _minimal_backtest_report(deterministic_ok=False)
-        mock_write.return_value = bundle_dir
+        self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
         cfg = AcceleratedShadowReplayConfig(
@@ -551,13 +690,38 @@ class TestRunAcceleratedShadowReplay:
 
     @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
     @patch.object(ReplayReporter, "write_bundle")
+    def test_deterministic_verify_failure_writes_failed_operator_summary(
+        self, mock_write, mock_backtest, tmp_path
+    ):
+        mock_backtest.return_value = _minimal_backtest_report(deterministic_ok=False)
+        self._mock_bundle_dir(mock_write, tmp_path)
+
+        f = self._make_candles_file(tmp_path)
+        cfg = AcceleratedShadowReplayConfig(
+            input_candles_file=str(f),
+            output_directory=str(tmp_path),
+            deterministic_verify=True,
+        )
+        exit_code = run_accelerated_shadow_replay(cfg)
+
+        assert exit_code == 2
+        registry = ReplayRunRegistry(tmp_path / "run_registry.jsonl")
+        records = registry.load_all()
+        assert [r.status for r in records] == ["running", "failed"]
+        failed = records[-1]
+        summary_path = tmp_path / failed.run_id / "operator_summary.json"
+        assert summary_path.exists()
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        assert summary["status"] == "failed"
+        assert "deterministic" in summary["failure_reason"].lower()
+
+    @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
+    @patch.object(ReplayReporter, "write_bundle")
     def test_deterministic_verify_flag_exit_0_on_ok(
         self, mock_write, mock_backtest, tmp_path
     ):
-        bundle_dir = tmp_path / "bt-abc1234567890123"
-        bundle_dir.mkdir()
         mock_backtest.return_value = _minimal_backtest_report(deterministic_ok=True)
-        mock_write.return_value = bundle_dir
+        self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
         cfg = AcceleratedShadowReplayConfig(
@@ -573,10 +737,8 @@ class TestRunAcceleratedShadowReplay:
     def test_backtest_called_with_correct_config(
         self, mock_write, mock_backtest, tmp_path
     ):
-        bundle_dir = tmp_path / "bt-abc1234567890123"
-        bundle_dir.mkdir()
         mock_backtest.return_value = _minimal_backtest_report()
-        mock_write.return_value = bundle_dir
+        self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
         cfg = AcceleratedShadowReplayConfig(


### PR DESCRIPTION
## Summary
- add a minimal scenario harness for deterministic multi-variant replay orchestration
- add canonical scenario/group result models and deterministic group fingerprinting
- fail closed on empty groups, duplicate scenario ids, invalid group ids, and invalid run function returns
- cover success and fail-closed behavior with focused unit tests

## Validation
- \python -m pytest tests/unit/replay/test_scenario_harness.py -q\
- \37 passed\

## Scope notes
- includes only the \#1844\ scenario harness slice
- no changes to existing files
- unrelated local untracked files were not touched

Closes #1844