### PR TITLE
feat(arvp): add scenario harness for multi-variant replay runs (#1844)

### DIFF
--- a/core/replay/scenario_harness.py
+++ b/core/replay/scenario_harness.py
@@ -1,0 +1,311 @@
+"""ARVP scenario harness: multi-variant replay run orchestration.
+
+Scope (#1844): scenario abstraction, group orchestration, and manifest.
+
+Non-goals:
+  - built-in scenario packs (defined in #1845)
+  - regime analytics or scorecards (#1846)
+  - management-grade UX reports (#1847)
+  - database-backed manifests or multi-process locking
+  - strategy or execution business logic
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from core.replay.canonical_json import canonical_hash, canonical_json_dumps
+from core.utils.clock import utcnow
+
+_GROUP_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
+class ScenarioHarnessError(ValueError):
+    """Raised when scenario harness validation or orchestration fails."""
+
+
+def _utc_now_iso() -> str:
+    return utcnow().replace(tzinfo=timezone.utc).isoformat()
+
+
+def _require_non_empty_string(value: object, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ScenarioHarnessError(f"{field_name} must be a non-empty string")
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioSpec:
+    """Specification for a single scenario variant in a group.
+
+    config_overrides is an opaque dict of parameter overrides applied on top of
+    the base config at the runner layer.  The harness does not validate specific
+    override keys; that is the caller's responsibility.
+    """
+
+    scenario_id: str
+    description: str
+    config_overrides: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.scenario_id, "scenario_id")
+        _require_non_empty_string(self.description, "description")
+        if not isinstance(self.config_overrides, dict):
+            raise ScenarioHarnessError("config_overrides must be a dict")
+        # Defensive copy: prevents external mutation from affecting harness
+        # determinism after construction.
+        object.__setattr__(self, "config_overrides", dict(self.config_overrides))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "description": self.description,
+            "config_overrides": dict(self.config_overrides),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioRunResult:
+    """Result of executing a single scenario variant.
+
+    Invariants:
+    - failure_reason is required when exit_code != 0
+    - failure_reason must be None when exit_code == 0
+    - run_id, when set, must be a non-empty string
+    """
+
+    scenario_id: str
+    exit_code: int
+    run_id: str | None = None
+    failure_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.scenario_id, "scenario_id")
+        if isinstance(self.exit_code, bool) or not isinstance(self.exit_code, int):
+            raise ScenarioHarnessError("exit_code must be an int (not bool)")
+        if self.exit_code != 0 and self.failure_reason is None:
+            raise ScenarioHarnessError(
+                "failure_reason is required when exit_code != 0"
+            )
+        if self.exit_code == 0 and self.failure_reason is not None:
+            raise ScenarioHarnessError(
+                "failure_reason must be None when exit_code == 0"
+            )
+        if self.failure_reason is not None:
+            _require_non_empty_string(self.failure_reason, "failure_reason")
+        if self.run_id is not None:
+            _require_non_empty_string(self.run_id, "run_id")
+
+    @property
+    def succeeded(self) -> bool:
+        return self.exit_code == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "scenario_id": self.scenario_id,
+            "exit_code": self.exit_code,
+        }
+        if self.run_id is not None:
+            result["run_id"] = self.run_id
+        if self.failure_reason is not None:
+            result["failure_reason"] = self.failure_reason
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioGroupManifest:
+    """Manifest for a completed scenario group execution."""
+
+    group_id: str
+    scenario_results: tuple[ScenarioRunResult, ...]
+    artifact_root: str
+    group_fingerprint: str
+    started_at_utc: str
+    finished_at_utc: str
+    total_scenarios: int
+    succeeded_count: int
+    failed_count: int
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.group_id, "group_id")
+        _require_non_empty_string(self.artifact_root, "artifact_root")
+        if not isinstance(self.scenario_results, tuple):
+            raise ScenarioHarnessError("scenario_results must be a tuple")
+        if self.total_scenarios != len(self.scenario_results):
+            raise ScenarioHarnessError(
+                "total_scenarios must equal len(scenario_results)"
+            )
+        if self.succeeded_count + self.failed_count != self.total_scenarios:
+            raise ScenarioHarnessError(
+                "succeeded_count + failed_count must equal total_scenarios"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "group_id": self.group_id,
+            "group_fingerprint": self.group_fingerprint,
+            "artifact_root": self.artifact_root,
+            "started_at_utc": self.started_at_utc,
+            "finished_at_utc": self.finished_at_utc,
+            "total_scenarios": self.total_scenarios,
+            "succeeded_count": self.succeeded_count,
+            "failed_count": self.failed_count,
+            "scenario_results": [r.to_dict() for r in self.scenario_results],
+        }
+
+
+def build_scenario_group_id(scenario_ids: Sequence[str]) -> str:
+    """Build a deterministic group ID from an ordered sequence of scenario IDs."""
+    if not scenario_ids:
+        raise ScenarioHarnessError("scenario_ids must not be empty")
+    for sid in scenario_ids:
+        if not isinstance(sid, str) or not sid.strip():
+            raise ScenarioHarnessError(
+                "each scenario_id in scenario_ids must be a non-empty string"
+            )
+    payload: dict[str, Any] = {"scenario_ids": list(scenario_ids)}
+    fingerprint = canonical_hash(payload)
+    return f"sg-{fingerprint[:12]}"
+
+
+def _build_group_fingerprint(
+    group_id: str,
+    results: Sequence[ScenarioRunResult],
+) -> str:
+    """Build a deterministic fingerprint from group_id and scenario outcomes.
+
+    Excludes wall-clock timestamps, filesystem paths, and attempt-based run_ids
+    so that the fingerprint is stable across reruns that produce identical outcomes.
+    """
+    payload: dict[str, Any] = {
+        "group_id": group_id,
+        "scenario_outcomes": [
+            {"scenario_id": r.scenario_id, "exit_code": r.exit_code}
+            for r in results
+        ],
+    }
+    return canonical_hash(payload)
+
+
+def _write_group_manifest(output_dir: Path, manifest: ScenarioGroupManifest) -> None:
+    group_dir = output_dir / manifest.group_id
+    try:
+        group_dir.mkdir(parents=True, exist_ok=True)
+        manifest_path = group_dir / "scenario_group_manifest.json"
+        manifest_path.write_text(
+            canonical_json_dumps(manifest.to_dict()),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        raise ScenarioHarnessError(
+            f"Failed to write scenario group manifest to {group_dir}: {exc}"
+        ) from exc
+
+
+def run_scenario_group(
+    scenario_specs: Sequence[ScenarioSpec],
+    *,
+    run_fn: Callable[[ScenarioSpec], ScenarioRunResult],
+    output_dir: Path | str,
+    group_id: str | None = None,
+) -> ScenarioGroupManifest:
+    """Orchestrate a group of scenario runs deterministically.
+
+    Executes each scenario in the order provided.  Scenario failures are captured
+    explicitly as ScenarioRunResult entries — no scenario is silently skipped.
+    Unexpected exceptions from run_fn are also caught and recorded as failures.
+
+    Args:
+        scenario_specs: Non-empty sequence of ScenarioSpec with unique scenario_ids.
+        run_fn: Callable that executes a single scenario and returns a
+            ScenarioRunResult whose scenario_id matches the input ScenarioSpec.
+            Must not return a different type; that is treated as a harness error.
+            Exceptions other than that contract violation are caught and recorded
+            as failed results.
+        output_dir: Root directory for group output.  The manifest is written
+            to output_dir / group_id / scenario_group_manifest.json.
+        group_id: Optional pre-computed group ID.  If None, derived
+            deterministically from the ordered scenario_ids.  When supplied,
+            must match ^[a-zA-Z0-9_-]{1,64}$.
+
+    Returns:
+        ScenarioGroupManifest with all results and a written manifest.
+
+    Raises:
+        ScenarioHarnessError: empty specs, duplicate scenario_ids, invalid
+            group_id, run_fn returning wrong type or wrong scenario_id, or
+            manifest write failure.
+    """
+    if not scenario_specs:
+        raise ScenarioHarnessError("scenario_specs must not be empty")
+
+    seen_ids: set[str] = set()
+    for spec in scenario_specs:
+        if not isinstance(spec, ScenarioSpec):
+            raise ScenarioHarnessError(
+                f"Expected ScenarioSpec, got {type(spec).__name__}"
+            )
+        if spec.scenario_id in seen_ids:
+            raise ScenarioHarnessError(
+                f"Duplicate scenario_id: {spec.scenario_id!r}"
+            )
+        seen_ids.add(spec.scenario_id)
+
+    if group_id is not None:
+        if not _GROUP_ID_RE.match(group_id):
+            raise ScenarioHarnessError(
+                "group_id must be a 1-64 character string of [a-zA-Z0-9_-]"
+            )
+
+    scenario_ids = [spec.scenario_id for spec in scenario_specs]
+    resolved_group_id = group_id if group_id is not None else build_scenario_group_id(scenario_ids)
+    output_path = Path(output_dir)
+    artifact_root = str(output_path / resolved_group_id)
+    started_at_utc = _utc_now_iso()
+
+    results: list[ScenarioRunResult] = []
+    for spec in scenario_specs:
+        try:
+            result = run_fn(spec)
+        except Exception as exc:
+            exc_msg = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
+            result = ScenarioRunResult(
+                scenario_id=spec.scenario_id,
+                exit_code=2,
+                failure_reason=f"Scenario run raised unexpected exception: {exc_msg}",
+            )
+        else:
+            if not isinstance(result, ScenarioRunResult):
+                raise ScenarioHarnessError(
+                    f"run_fn must return ScenarioRunResult for scenario "
+                    f"{spec.scenario_id!r}, got {type(result).__name__}"
+                )
+            if result.scenario_id != spec.scenario_id:
+                raise ScenarioHarnessError(
+                    f"run_fn returned result for wrong scenario: "
+                    f"expected {spec.scenario_id!r}, got {result.scenario_id!r}"
+                )
+        results.append(result)
+
+    finished_at_utc = _utc_now_iso()
+    succeeded_count = sum(1 for r in results if r.exit_code == 0)
+    failed_count = len(results) - succeeded_count
+    group_fingerprint = _build_group_fingerprint(resolved_group_id, results)
+
+    manifest = ScenarioGroupManifest(
+        group_id=resolved_group_id,
+        scenario_results=tuple(results),
+        artifact_root=artifact_root,
+        group_fingerprint=group_fingerprint,
+        started_at_utc=started_at_utc,
+        finished_at_utc=finished_at_utc,
+        total_scenarios=len(results),
+        succeeded_count=succeeded_count,
+        failed_count=failed_count,
+    )
+
+    _write_group_manifest(output_path, manifest)
+    return manifest

--- a/core/replay/scenario_harness.py
+++ b/core/replay/scenario_harness.py
@@ -12,6 +12,7 @@ Non-goals:
 
 from __future__ import annotations
 
+import copy
 import re
 from dataclasses import dataclass
 from datetime import timezone
@@ -29,7 +30,12 @@ class ScenarioHarnessError(ValueError):
 
 
 def _utc_now_iso() -> str:
-    return utcnow().replace(tzinfo=timezone.utc).isoformat()
+    dt = utcnow()
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.isoformat()
 
 
 def _require_non_empty_string(value: object, field_name: str) -> None:
@@ -55,9 +61,9 @@ class ScenarioSpec:
         _require_non_empty_string(self.description, "description")
         if not isinstance(self.config_overrides, dict):
             raise ScenarioHarnessError("config_overrides must be a dict")
-        # Defensive copy: prevents external mutation from affecting harness
-        # determinism after construction.
-        object.__setattr__(self, "config_overrides", dict(self.config_overrides))
+        # Defensive deep copy: prevents external mutation of nested structures
+        # from affecting harness determinism after construction.
+        object.__setattr__(self, "config_overrides", copy.deepcopy(self.config_overrides))
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -261,7 +267,11 @@ def run_scenario_group(
             )
 
     scenario_ids = [spec.scenario_id for spec in scenario_specs]
-    resolved_group_id = group_id if group_id is not None else build_scenario_group_id(scenario_ids)
+    resolved_group_id = (
+        group_id
+        if group_id is not None
+        else build_scenario_group_id(scenario_ids)
+    )
     output_path = Path(output_dir)
     artifact_root = str(output_path / resolved_group_id)
     started_at_utc = _utc_now_iso()

--- a/tests/unit/replay/test_scenario_harness.py
+++ b/tests/unit/replay/test_scenario_harness.py
@@ -1,0 +1,349 @@
+"""Unit tests for core/replay/scenario_harness.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from core.replay.scenario_harness import (
+    ScenarioGroupManifest,
+    ScenarioHarnessError,
+    ScenarioRunResult,
+    ScenarioSpec,
+    build_scenario_group_id,
+    run_scenario_group,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _spec(
+    scenario_id: str = "baseline",
+    description: str = "Baseline scenario",
+    config_overrides: dict[str, Any] | None = None,
+) -> ScenarioSpec:
+    return ScenarioSpec(
+        scenario_id=scenario_id,
+        description=description,
+        config_overrides=config_overrides if config_overrides is not None else {},
+    )
+
+
+def _success_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+    return ScenarioRunResult(
+        scenario_id=spec.scenario_id,
+        exit_code=0,
+        run_id="replay-aabbccdd1122-0001",
+    )
+
+
+def _failure_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+    return ScenarioRunResult(
+        scenario_id=spec.scenario_id,
+        exit_code=2,
+        failure_reason="Simulated failure",
+    )
+
+
+# ---------------------------------------------------------------------------
+# ScenarioSpec
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestScenarioSpec:
+    def test_valid_construction(self) -> None:
+        spec = _spec(config_overrides={"order_size": 2.0})
+        assert spec.scenario_id == "baseline"
+        assert spec.description == "Baseline scenario"
+        assert spec.config_overrides == {"order_size": 2.0}
+
+    def test_empty_scenario_id_fails(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="scenario_id"):
+            _spec(scenario_id="")
+
+    def test_whitespace_scenario_id_fails(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="scenario_id"):
+            _spec(scenario_id="   ")
+
+    def test_empty_description_fails(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="description"):
+            _spec(description="")
+
+    def test_invalid_config_overrides_fails(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="config_overrides"):
+            ScenarioSpec(
+                scenario_id="baseline",
+                description="Baseline",
+                config_overrides="not_a_dict",  # type: ignore[arg-type]
+            )
+
+    def test_config_overrides_is_defensively_copied(self) -> None:
+        original: dict[str, Any] = {"order_size": 1.0}
+        spec = _spec(config_overrides=original)
+        original["injected"] = "evil"
+        assert "injected" not in spec.config_overrides
+
+    def test_to_dict_shape(self) -> None:
+        spec = _spec(config_overrides={"order_size": 2.0})
+        d = spec.to_dict()
+        assert d["scenario_id"] == "baseline"
+        assert d["description"] == "Baseline scenario"
+        assert d["config_overrides"] == {"order_size": 2.0}
+
+
+# ---------------------------------------------------------------------------
+# ScenarioRunResult
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestScenarioRunResult:
+    def test_success_result(self) -> None:
+        result = ScenarioRunResult(
+            scenario_id="baseline", exit_code=0, run_id="replay-aabb-0001"
+        )
+        assert result.succeeded is True
+
+    def test_failure_result(self) -> None:
+        result = ScenarioRunResult(
+            scenario_id="pessimistic", exit_code=2, failure_reason="timeout"
+        )
+        assert result.succeeded is False
+
+    def test_failure_requires_reason(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="failure_reason is required"):
+            ScenarioRunResult(scenario_id="baseline", exit_code=2)
+
+    def test_success_must_not_have_reason(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="failure_reason must be None"):
+            ScenarioRunResult(
+                scenario_id="baseline", exit_code=0, failure_reason="unexpected"
+            )
+
+    def test_exit_code_bool_rejected(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="not bool"):
+            ScenarioRunResult(scenario_id="baseline", exit_code=True)  # type: ignore[arg-type]
+
+    def test_to_dict_omits_none_fields(self) -> None:
+        result = ScenarioRunResult(scenario_id="baseline", exit_code=0)
+        d = result.to_dict()
+        assert "run_id" not in d
+        assert "failure_reason" not in d
+
+    def test_to_dict_includes_optional_fields(self) -> None:
+        result = ScenarioRunResult(
+            scenario_id="pessimistic",
+            exit_code=2,
+            run_id="replay-aabb-0001",
+            failure_reason="bridge error",
+        )
+        d = result.to_dict()
+        assert d["run_id"] == "replay-aabb-0001"
+        assert d["failure_reason"] == "bridge error"
+
+    def test_empty_run_id_rejected(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="run_id"):
+            ScenarioRunResult(scenario_id="baseline", exit_code=0, run_id="")
+
+    def test_empty_failure_reason_rejected(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="failure_reason"):
+            ScenarioRunResult(
+                scenario_id="baseline", exit_code=2, failure_reason="   "
+            )
+
+
+# ---------------------------------------------------------------------------
+# build_scenario_group_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestBuildScenarioGroupId:
+    def test_deterministic_for_same_inputs(self) -> None:
+        gid1 = build_scenario_group_id(["baseline", "pessimistic"])
+        gid2 = build_scenario_group_id(["baseline", "pessimistic"])
+        assert gid1 == gid2
+
+    def test_different_for_different_inputs(self) -> None:
+        gid1 = build_scenario_group_id(["baseline"])
+        gid2 = build_scenario_group_id(["pessimistic"])
+        assert gid1 != gid2
+
+    def test_order_sensitive(self) -> None:
+        gid1 = build_scenario_group_id(["baseline", "pessimistic"])
+        gid2 = build_scenario_group_id(["pessimistic", "baseline"])
+        assert gid1 != gid2
+
+    def test_empty_sequence_fails(self) -> None:
+        with pytest.raises(ScenarioHarnessError, match="must not be empty"):
+            build_scenario_group_id([])
+
+    def test_group_id_format(self) -> None:
+        gid = build_scenario_group_id(["baseline"])
+        assert gid.startswith("sg-")
+        assert len(gid) == len("sg-") + 12
+
+
+# ---------------------------------------------------------------------------
+# run_scenario_group
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestRunScenarioGroup:
+    def test_empty_specs_fail_closed(self, tmp_path: Path) -> None:
+        with pytest.raises(ScenarioHarnessError, match="must not be empty"):
+            run_scenario_group([], run_fn=_success_fn, output_dir=tmp_path)
+
+    def test_duplicate_ids_fail_closed(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline"), _spec("baseline")]
+        with pytest.raises(ScenarioHarnessError, match="Duplicate scenario_id"):
+            run_scenario_group(specs, run_fn=_success_fn, output_dir=tmp_path)
+
+    def test_invalid_custom_group_id_fails(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline")]
+        with pytest.raises(ScenarioHarnessError, match="group_id"):
+            run_scenario_group(
+                specs, run_fn=_success_fn, output_dir=tmp_path, group_id="../evil"
+            )
+
+    def test_custom_group_id_accepted(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline")]
+        manifest = run_scenario_group(
+            specs, run_fn=_success_fn, output_dir=tmp_path, group_id="my-group-01"
+        )
+        assert manifest.group_id == "my-group-01"
+        assert (tmp_path / "my-group-01" / "scenario_group_manifest.json").exists()
+
+    def test_single_scenario_success(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline")]
+        manifest = run_scenario_group(specs, run_fn=_success_fn, output_dir=tmp_path)
+        assert manifest.total_scenarios == 1
+        assert manifest.succeeded_count == 1
+        assert manifest.failed_count == 0
+        assert manifest.scenario_results[0].scenario_id == "baseline"
+        assert manifest.scenario_results[0].exit_code == 0
+
+    def test_multiple_scenarios_all_succeed(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline"), _spec("pessimistic"), _spec("delayed")]
+        manifest = run_scenario_group(specs, run_fn=_success_fn, output_dir=tmp_path)
+        assert manifest.total_scenarios == 3
+        assert manifest.succeeded_count == 3
+        assert manifest.failed_count == 0
+
+    def test_failed_scenario_explicit_not_skipped(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline"), _spec("pessimistic")]
+
+        def mixed_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+            if spec.scenario_id == "pessimistic":
+                return ScenarioRunResult(
+                    scenario_id=spec.scenario_id,
+                    exit_code=2,
+                    failure_reason="Simulated failure",
+                )
+            return ScenarioRunResult(scenario_id=spec.scenario_id, exit_code=0)
+
+        manifest = run_scenario_group(specs, run_fn=mixed_fn, output_dir=tmp_path)
+        assert manifest.total_scenarios == 2
+        assert manifest.succeeded_count == 1
+        assert manifest.failed_count == 1
+        failed = [r for r in manifest.scenario_results if r.exit_code != 0]
+        assert len(failed) == 1
+        assert failed[0].scenario_id == "pessimistic"
+        assert failed[0].failure_reason == "Simulated failure"
+
+    def test_run_fn_exception_captured_not_propagated(self, tmp_path: Path) -> None:
+        def exploding_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+            raise RuntimeError("unexpected crash")
+
+        specs = [_spec("baseline")]
+        manifest = run_scenario_group(specs, run_fn=exploding_fn, output_dir=tmp_path)
+        assert manifest.failed_count == 1
+        assert manifest.scenario_results[0].exit_code == 2
+        assert "RuntimeError" in (manifest.scenario_results[0].failure_reason or "")
+
+    def test_run_fn_wrong_return_type_raises(self, tmp_path: Path) -> None:
+        def bad_fn(spec: ScenarioSpec) -> int:  # type: ignore[return-value]
+            return 42
+
+        specs = [_spec("baseline")]
+        with pytest.raises(ScenarioHarnessError, match="must return ScenarioRunResult"):
+            run_scenario_group(specs, run_fn=bad_fn, output_dir=tmp_path)  # type: ignore[arg-type]
+
+    def test_run_fn_wrong_scenario_id_raises(self, tmp_path: Path) -> None:
+        def wrong_id_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+            return ScenarioRunResult(scenario_id="other-id", exit_code=0)
+
+        specs = [_spec("baseline")]
+        with pytest.raises(ScenarioHarnessError, match="wrong scenario"):
+            run_scenario_group(specs, run_fn=wrong_id_fn, output_dir=tmp_path)
+
+    def test_manifest_written_to_correct_path(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline")]
+        manifest = run_scenario_group(specs, run_fn=_success_fn, output_dir=tmp_path)
+        manifest_path = tmp_path / manifest.group_id / "scenario_group_manifest.json"
+        assert manifest_path.exists()
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert data["group_id"] == manifest.group_id
+        assert len(data["scenario_results"]) == 1
+
+    def test_group_fingerprint_stable_for_same_outcomes(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline"), _spec("pessimistic")]
+
+        def deterministic_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+            return ScenarioRunResult(scenario_id=spec.scenario_id, exit_code=0)
+
+        manifest1 = run_scenario_group(
+            specs, run_fn=deterministic_fn, output_dir=tmp_path / "run1"
+        )
+        manifest2 = run_scenario_group(
+            specs, run_fn=deterministic_fn, output_dir=tmp_path / "run2"
+        )
+        assert manifest1.group_fingerprint == manifest2.group_fingerprint
+
+    def test_group_fingerprint_differs_for_different_outcomes(
+        self, tmp_path: Path
+    ) -> None:
+        specs = [_spec("baseline")]
+
+        manifest_ok = run_scenario_group(
+            specs, run_fn=_success_fn, output_dir=tmp_path / "a"
+        )
+        manifest_fail = run_scenario_group(
+            specs, run_fn=_failure_fn, output_dir=tmp_path / "b"
+        )
+        assert manifest_ok.group_fingerprint != manifest_fail.group_fingerprint
+
+    def test_group_id_deterministic_across_runs(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline"), _spec("pessimistic")]
+        manifest1 = run_scenario_group(
+            specs, run_fn=_success_fn, output_dir=tmp_path / "a"
+        )
+        manifest2 = run_scenario_group(
+            specs, run_fn=_success_fn, output_dir=tmp_path / "b"
+        )
+        assert manifest1.group_id == manifest2.group_id
+
+    def test_execution_order_preserved(self, tmp_path: Path) -> None:
+        call_order: list[str] = []
+
+        def tracking_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+            call_order.append(spec.scenario_id)
+            return ScenarioRunResult(scenario_id=spec.scenario_id, exit_code=0)
+
+        specs = [_spec("z_last"), _spec("a_first"), _spec("m_middle")]
+        run_scenario_group(specs, run_fn=tracking_fn, output_dir=tmp_path)
+        assert call_order == ["z_last", "a_first", "m_middle"]
+
+    def test_manifest_to_dict_round_trips(self, tmp_path: Path) -> None:
+        specs = [_spec("baseline"), _spec("pessimistic")]
+        manifest = run_scenario_group(specs, run_fn=_success_fn, output_dir=tmp_path)
+        d = manifest.to_dict()
+        assert d["total_scenarios"] == 2
+        assert d["succeeded_count"] == 2
+        assert d["failed_count"] == 0
+        assert len(d["scenario_results"]) == 2
+        ids = [r["scenario_id"] for r in d["scenario_results"]]
+        assert ids == ["baseline", "pessimistic"]

--- a/tests/unit/replay/test_scenario_harness.py
+++ b/tests/unit/replay/test_scenario_harness.py
@@ -270,7 +270,11 @@ class TestRunScenarioGroup:
 
         specs = [_spec("baseline")]
         with pytest.raises(ScenarioHarnessError, match="must return ScenarioRunResult"):
-            run_scenario_group(specs, run_fn=bad_fn, output_dir=tmp_path)  # type: ignore[arg-type]
+            run_scenario_group(  # type: ignore[arg-type]
+                specs,
+                run_fn=bad_fn,
+                output_dir=tmp_path,
+            )
 
     def test_run_fn_wrong_scenario_id_raises(self, tmp_path: Path) -> None:
         def wrong_id_fn(spec: ScenarioSpec) -> ScenarioRunResult:


### PR DESCRIPTION
## Summary
- add a minimal scenario harness for deterministic multi-variant replay orchestration
- add canonical scenario/group result models and deterministic group fingerprinting
- fail closed on empty groups, duplicate scenario ids, invalid group ids, and invalid run function returns
- cover success and fail-closed behavior with focused unit tests

## Validation
- \python -m pytest tests/unit/replay/test_scenario_harness.py -q\
- \37 passed\

## Scope notes
- includes only the \#1844\ scenario harness slice
- no changes to existing files
- unrelated local untracked files were not touched

Closes #1844