### PR TITLE
feat(arvp): add canonical scenario pack library for five built-in packs (#1845)

### DIFF
--- a/core/replay/scenario_packs.py
+++ b/core/replay/scenario_packs.py
@@ -1,0 +1,243 @@
+"""ARVP built-in scenario pack library.
+
+Scope (#1845): canonical scenario pack definitions and invocation wrapper.
+
+Non-goals:
+  - user-defined scenario DSLs
+  - regime analytics or scorecards (#1846)
+  - management-grade UX reports (#1847)
+  - replay-vs-paper comparison
+  - non-deterministic or random stress behaviour
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from core.replay.canonical_json import canonical_json_dumps
+from core.replay.scenario_harness import (
+    ScenarioGroupManifest,
+    ScenarioRunResult,
+    ScenarioSpec,
+    run_scenario_group,
+)
+
+# ---------------------------------------------------------------------------
+# Error type
+# ---------------------------------------------------------------------------
+
+
+class ScenarioPackError(ValueError):
+    """Raised when a scenario pack cannot be resolved or invoked."""
+
+
+# ---------------------------------------------------------------------------
+# Pack definitions
+# ---------------------------------------------------------------------------
+
+#: Ordered canonical built-in scenario IDs (order is part of the public API).
+BUILTIN_SCENARIO_IDS: tuple[str, ...] = (
+    "baseline",
+    "pessimistic_execution",
+    "delayed_execution",
+    "low_liquidity",
+    "feed_gap",
+)
+
+_PACK_VERSION = "1"
+
+
+def _make_spec(scenario_id: str, description: str, overrides: dict[str, Any]) -> ScenarioSpec:
+    """Build a ScenarioSpec with provenance keys injected into config_overrides."""
+    provenance: dict[str, Any] = {
+        "pack_id": scenario_id,
+        "pack_version": _PACK_VERSION,
+    }
+    return ScenarioSpec(
+        scenario_id=scenario_id,
+        description=description,
+        config_overrides={**provenance, **overrides},
+    )
+
+
+#: Internal pack registry.  Evaluated once at import time; immutable thereafter.
+_PACKS: dict[str, ScenarioSpec] = {
+    "baseline": _make_spec(
+        scenario_id="baseline",
+        description=(
+            "Undegraded baseline replay: no execution perturbation, "
+            "no data-quality degradation. Reference anchor for variant comparison."
+        ),
+        overrides={},
+    ),
+    "pessimistic_execution": _make_spec(
+        scenario_id="pessimistic_execution",
+        description=(
+            "Pessimistic execution: elevated slippage, reduced fill rate, "
+            "and pessimistic execution posture. Models adverse fill conditions."
+        ),
+        overrides={
+            "execution_slippage_bps": 30,
+            "fill_rate": 0.7,
+            "execution_posture": "pessimistic",
+        },
+    ),
+    "delayed_execution": _make_spec(
+        scenario_id="delayed_execution",
+        description=(
+            "Delayed execution: deterministic execution delay injected per order. "
+            "Models latency degradation and late-arrival execution conditions."
+        ),
+        overrides={
+            "execution_delay_ms": 500,
+            "execution_posture": "delayed",
+        },
+    ),
+    "low_liquidity": _make_spec(
+        scenario_id="low_liquidity",
+        description=(
+            "Low-liquidity: reduced available execution depth and degraded fill "
+            "conditions. Models thin-book or illiquid market conditions."
+        ),
+        overrides={
+            "fill_depth_factor": 0.3,
+            "execution_posture": "low_liquidity",
+        },
+    ),
+    "feed_gap": _make_spec(
+        scenario_id="feed_gap",
+        description=(
+            "Feed-gap: deterministic data-gap injection consistent with the replay "
+            "input model. Models feed interruptions and stale-tick conditions."
+        ),
+        overrides={
+            "feed_gap_seconds": 30,
+            "drop_ticks_on_gap": True,
+        },
+    ),
+}
+
+# Validate internal consistency at import time (unconditional: not skipped under -O).
+if set(_PACKS.keys()) != set(BUILTIN_SCENARIO_IDS):
+    raise ScenarioPackError(
+        "Mismatch between _PACKS keys and BUILTIN_SCENARIO_IDS"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def list_builtin_scenario_ids() -> tuple[str, ...]:
+    """Return the ordered tuple of canonical built-in scenario IDs."""
+    return BUILTIN_SCENARIO_IDS
+
+
+def get_scenario_pack(scenario_id: str) -> ScenarioSpec:
+    """Resolve a built-in scenario pack by ID.
+
+    Each call returns a fresh ScenarioSpec so callers cannot corrupt the
+    internal registry by mutating the returned config_overrides dict.
+
+    Args:
+        scenario_id: One of the canonical built-in scenario IDs.
+
+    Returns:
+        A fresh ScenarioSpec with provenance in config_overrides.
+
+    Raises:
+        ScenarioPackError: If scenario_id is not a known built-in pack.
+    """
+    if not isinstance(scenario_id, str) or not scenario_id.strip():
+        raise ScenarioPackError(
+            f"scenario_id must be a non-empty string, got {scenario_id!r}"
+        )
+    stored = _PACKS.get(scenario_id)
+    if stored is None:
+        known = ", ".join(repr(k) for k in BUILTIN_SCENARIO_IDS)
+        raise ScenarioPackError(
+            f"Unknown scenario pack {scenario_id!r}. "
+            f"Known built-in packs: {known}"
+        )
+    # Return a fresh copy; ScenarioSpec.__post_init__ deep-copies config_overrides.
+    return ScenarioSpec(
+        scenario_id=stored.scenario_id,
+        description=stored.description,
+        config_overrides=stored.config_overrides,
+    )
+
+
+def _write_specs_artifact(artifact_root: str, spec_dicts: Sequence[dict[str, Any]]) -> None:
+    """Write scenario_specs.json into the group artifact directory.
+
+    Accepts pre-captured spec dicts (snapshots taken before run_fn executes)
+    so that any mutation of config_overrides inside run_fn cannot corrupt
+    the provenance artifact.
+    """
+    artifact_dir = Path(artifact_root)
+    specs_path = artifact_dir / "scenario_specs.json"
+    payload: dict[str, Any] = {
+        "scenario_specs": list(spec_dicts),
+    }
+    try:
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        specs_path.write_text(canonical_json_dumps(payload), encoding="utf-8")
+    except OSError as exc:
+        raise ScenarioPackError(
+            f"Failed to write scenario_specs.json to {artifact_dir}: {exc}"
+        ) from exc
+
+
+def run_builtin_scenario_group(
+    scenario_ids: Sequence[str],
+    *,
+    run_fn: Callable[[ScenarioSpec], ScenarioRunResult],
+    output_dir: Path | str,
+    group_id: str | None = None,
+) -> ScenarioGroupManifest:
+    """Resolve built-in scenario packs and run them as a group.
+
+    Convenience wrapper over :func:`run_scenario_group` that:
+    1. Resolves each scenario_id to its canonical ScenarioSpec.
+    2. Executes the group via the harness.
+    3. Writes a ``scenario_specs.json`` provenance artifact into
+       ``manifest.artifact_root`` alongside the group manifest.
+
+    Args:
+        scenario_ids: Ordered sequence of built-in scenario IDs to run.
+            Must be non-empty and contain only known built-in IDs.
+        run_fn: Callable accepted by :func:`run_scenario_group`.
+        output_dir: Root directory for group output.
+        group_id: Optional pre-computed group ID (forwarded to harness).
+
+    Returns:
+        ScenarioGroupManifest from the harness, after provenance artifact write.
+
+    Raises:
+        ScenarioPackError: If ``scenario_ids`` is a bare str/bytes, is empty,
+            any scenario_id is unknown, or provenance write fails.
+        ScenarioHarnessError: Propagated from :func:`run_scenario_group` on
+            duplicate IDs, invalid group_id, or manifest write failure.
+    """
+    if isinstance(scenario_ids, (str, bytes)):
+        raise ScenarioPackError(
+            "scenario_ids must be a sequence of str, not a bare str or bytes; "
+            "wrap in a list, e.g. [scenario_id]"
+        )
+    if not scenario_ids:
+        raise ScenarioPackError("scenario_ids must not be empty")
+
+    specs = [get_scenario_pack(sid) for sid in scenario_ids]
+    # Snapshot spec dicts before run_fn executes so any in-flight mutation of
+    # config_overrides cannot corrupt the provenance artifact.
+    spec_snapshots = [spec.to_dict() for spec in specs]
+    manifest = run_scenario_group(
+        specs,
+        run_fn=run_fn,
+        output_dir=output_dir,
+        group_id=group_id,
+    )
+    _write_specs_artifact(manifest.artifact_root, spec_snapshots)
+    return manifest

--- a/tests/unit/replay/test_scenario_packs.py
+++ b/tests/unit/replay/test_scenario_packs.py
@@ -1,0 +1,272 @@
+"""Unit tests for core/replay/scenario_packs.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.replay.scenario_harness import ScenarioHarnessError, ScenarioRunResult, ScenarioSpec
+from core.replay.scenario_packs import (
+    BUILTIN_SCENARIO_IDS,
+    ScenarioPackError,
+    get_scenario_pack,
+    list_builtin_scenario_ids,
+    run_builtin_scenario_group,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _success_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+    return ScenarioRunResult(scenario_id=spec.scenario_id, exit_code=0)
+
+
+# ---------------------------------------------------------------------------
+# BUILTIN_SCENARIO_IDS / list_builtin_scenario_ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuiltinScenarioIds:
+    def test_contains_all_five_packs(self) -> None:
+        expected = {
+            "baseline",
+            "pessimistic_execution",
+            "delayed_execution",
+            "low_liquidity",
+            "feed_gap",
+        }
+        assert set(BUILTIN_SCENARIO_IDS) == expected
+
+    def test_order_is_stable(self) -> None:
+        assert list_builtin_scenario_ids() == BUILTIN_SCENARIO_IDS
+
+    def test_list_builtin_is_deterministic(self) -> None:
+        assert list_builtin_scenario_ids() == list_builtin_scenario_ids()
+
+    def test_baseline_is_first(self) -> None:
+        assert BUILTIN_SCENARIO_IDS[0] == "baseline"
+
+
+# ---------------------------------------------------------------------------
+# get_scenario_pack
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetScenarioPack:
+    def test_all_builtin_ids_resolve(self) -> None:
+        for sid in BUILTIN_SCENARIO_IDS:
+            spec = get_scenario_pack(sid)
+            assert isinstance(spec, ScenarioSpec)
+            assert spec.scenario_id == sid
+
+    def test_unknown_id_fails_closed(self) -> None:
+        with pytest.raises(ScenarioPackError, match="Unknown scenario pack"):
+            get_scenario_pack("not_a_real_pack")
+
+    def test_empty_string_fails_closed(self) -> None:
+        with pytest.raises(ScenarioPackError):
+            get_scenario_pack("")
+
+    def test_whitespace_only_fails_closed(self) -> None:
+        with pytest.raises(ScenarioPackError):
+            get_scenario_pack("   ")
+
+    def test_returns_consistent_spec_on_repeated_calls(self) -> None:
+        s1 = get_scenario_pack("baseline")
+        s2 = get_scenario_pack("baseline")
+        assert s1.scenario_id == s2.scenario_id
+        assert s1.config_overrides == s2.config_overrides
+
+    # --- baseline ---
+
+    def test_baseline_has_no_perturbation_keys(self) -> None:
+        spec = get_scenario_pack("baseline")
+        overrides = spec.config_overrides
+        perturbation_keys = {
+            "execution_slippage_bps",
+            "fill_rate",
+            "execution_posture",
+            "execution_delay_ms",
+            "fill_depth_factor",
+            "feed_gap_seconds",
+            "drop_ticks_on_gap",
+        }
+        assert not perturbation_keys.intersection(overrides.keys())
+
+    def test_baseline_carries_provenance(self) -> None:
+        spec = get_scenario_pack("baseline")
+        assert spec.config_overrides["pack_id"] == "baseline"
+        assert spec.config_overrides["pack_version"] == "1"
+
+    # --- pessimistic_execution ---
+
+    def test_pessimistic_execution_overrides(self) -> None:
+        spec = get_scenario_pack("pessimistic_execution")
+        o = spec.config_overrides
+        assert o["execution_slippage_bps"] == 30
+        assert o["fill_rate"] == 0.7
+        assert o["execution_posture"] == "pessimistic"
+        assert o["pack_id"] == "pessimistic_execution"
+        assert o["pack_version"] == "1"
+
+    # --- delayed_execution ---
+
+    def test_delayed_execution_overrides(self) -> None:
+        spec = get_scenario_pack("delayed_execution")
+        o = spec.config_overrides
+        assert o["execution_delay_ms"] == 500
+        assert o["execution_posture"] == "delayed"
+        assert o["pack_id"] == "delayed_execution"
+
+    # --- low_liquidity ---
+
+    def test_low_liquidity_overrides(self) -> None:
+        spec = get_scenario_pack("low_liquidity")
+        o = spec.config_overrides
+        assert o["fill_depth_factor"] == 0.3
+        assert o["execution_posture"] == "low_liquidity"
+        assert o["pack_id"] == "low_liquidity"
+
+    # --- feed_gap ---
+
+    def test_feed_gap_overrides(self) -> None:
+        spec = get_scenario_pack("feed_gap")
+        o = spec.config_overrides
+        assert o["feed_gap_seconds"] == 30
+        assert o["drop_ticks_on_gap"] is True
+        assert o["pack_id"] == "feed_gap"
+
+    # --- determinism ---
+
+    def test_overrides_are_stable_across_calls(self) -> None:
+        for sid in BUILTIN_SCENARIO_IDS:
+            s1 = get_scenario_pack(sid)
+            s2 = get_scenario_pack(sid)
+            assert s1.config_overrides == s2.config_overrides
+
+    def test_config_overrides_are_isolated(self) -> None:
+        spec = get_scenario_pack("pessimistic_execution")
+        # Mutating the returned dict must not affect the registry.
+        spec.config_overrides["injected"] = "evil"
+        fresh = get_scenario_pack("pessimistic_execution")
+        assert "injected" not in fresh.config_overrides
+
+
+# ---------------------------------------------------------------------------
+# run_builtin_scenario_group
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunBuiltinScenarioGroup:
+    def test_empty_scenario_ids_fails_closed(self, tmp_path: Path) -> None:
+        with pytest.raises(ScenarioPackError, match="must not be empty"):
+            run_builtin_scenario_group([], run_fn=_success_fn, output_dir=tmp_path)
+
+    def test_unknown_id_fails_closed(self, tmp_path: Path) -> None:
+        with pytest.raises(ScenarioPackError, match="Unknown scenario pack"):
+            run_builtin_scenario_group(
+                ["baseline", "not_real"], run_fn=_success_fn, output_dir=tmp_path
+            )
+
+    def test_single_pack_succeeds(self, tmp_path: Path) -> None:
+        manifest = run_builtin_scenario_group(
+            ["baseline"], run_fn=_success_fn, output_dir=tmp_path
+        )
+        assert manifest.total_scenarios == 1
+        assert manifest.succeeded_count == 1
+
+    def test_all_five_packs_succeed(self, tmp_path: Path) -> None:
+        manifest = run_builtin_scenario_group(
+            list(BUILTIN_SCENARIO_IDS), run_fn=_success_fn, output_dir=tmp_path
+        )
+        assert manifest.total_scenarios == 5
+        assert manifest.succeeded_count == 5
+        assert manifest.failed_count == 0
+
+    def test_scenario_specs_json_written(self, tmp_path: Path) -> None:
+        manifest = run_builtin_scenario_group(
+            ["baseline", "pessimistic_execution"],
+            run_fn=_success_fn,
+            output_dir=tmp_path,
+        )
+        specs_path = Path(manifest.artifact_root) / "scenario_specs.json"
+        assert specs_path.exists()
+
+    def test_scenario_specs_json_content(self, tmp_path: Path) -> None:
+        ids = ["baseline", "pessimistic_execution", "delayed_execution"]
+        manifest = run_builtin_scenario_group(
+            ids, run_fn=_success_fn, output_dir=tmp_path
+        )
+        specs_path = Path(manifest.artifact_root) / "scenario_specs.json"
+        data = json.loads(specs_path.read_text(encoding="utf-8"))
+        assert "scenario_specs" in data
+        written_ids = [s["scenario_id"] for s in data["scenario_specs"]]
+        assert written_ids == ids
+
+    def test_scenario_specs_json_contains_overrides(self, tmp_path: Path) -> None:
+        manifest = run_builtin_scenario_group(
+            ["pessimistic_execution"], run_fn=_success_fn, output_dir=tmp_path
+        )
+        specs_path = Path(manifest.artifact_root) / "scenario_specs.json"
+        data = json.loads(specs_path.read_text(encoding="utf-8"))
+        spec_dict = data["scenario_specs"][0]
+        assert spec_dict["config_overrides"]["pack_id"] == "pessimistic_execution"
+        assert spec_dict["config_overrides"]["pack_version"] == "1"
+        assert spec_dict["config_overrides"]["execution_slippage_bps"] == 30
+
+    def test_scenario_specs_json_stable_across_runs(self, tmp_path: Path) -> None:
+        ids = ["baseline", "feed_gap"]
+
+        manifest1 = run_builtin_scenario_group(
+            ids, run_fn=_success_fn, output_dir=tmp_path / "run1"
+        )
+        manifest2 = run_builtin_scenario_group(
+            ids, run_fn=_success_fn, output_dir=tmp_path / "run2"
+        )
+        specs1 = json.loads(
+            (Path(manifest1.artifact_root) / "scenario_specs.json").read_text(encoding="utf-8")
+        )
+        specs2 = json.loads(
+            (Path(manifest2.artifact_root) / "scenario_specs.json").read_text(encoding="utf-8")
+        )
+        assert specs1 == specs2
+
+    def test_custom_group_id_forwarded(self, tmp_path: Path) -> None:
+        manifest = run_builtin_scenario_group(
+            ["baseline"],
+            run_fn=_success_fn,
+            output_dir=tmp_path,
+            group_id="my-pack-run",
+        )
+        assert manifest.group_id == "my-pack-run"
+        assert (tmp_path / "my-pack-run" / "scenario_specs.json").exists()
+
+    def test_harness_duplicate_ids_still_fail_closed(self, tmp_path: Path) -> None:
+        # Duplicate resolution goes through harness; verify it surfaces correctly.
+        specs_direct = [
+            get_scenario_pack("baseline"),
+            get_scenario_pack("baseline"),
+        ]
+        with pytest.raises(ScenarioHarnessError, match="Duplicate scenario_id"):
+            from core.replay.scenario_harness import run_scenario_group
+
+            run_scenario_group(specs_direct, run_fn=_success_fn, output_dir=tmp_path)
+
+    def test_execution_order_matches_input(self, tmp_path: Path) -> None:
+        order: list[str] = []
+
+        def tracking_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+            order.append(spec.scenario_id)
+            return ScenarioRunResult(scenario_id=spec.scenario_id, exit_code=0)
+
+        ids = ["feed_gap", "baseline", "low_liquidity"]
+        run_builtin_scenario_group(ids, run_fn=tracking_fn, output_dir=tmp_path)
+        assert order == ids


### PR DESCRIPTION
## Summary
- add a canonical built-in scenario pack library for the five initial ARVP scenario packs
- expose deterministic pack resolution and built-in scenario id listing
- write \scenario_specs.json\ into the scenario group artifact root so pack provenance is present in artifacts
- cover built-in pack resolution, baseline invariants, and artifact writing with focused unit tests

## Validation
- \python -m pytest tests/unit/replay/test_scenario_packs.py -q\
- \28 passed\

## Scope notes
- includes only the \#1845\ scenario pack slice
- no changes to existing files
- unrelated local untracked files were not touched

Closes #1845