### PR TITLE
feat(arvp): add regime scorecard analytics core (#1846)

### DIFF
--- a/core/replay/regime_analytics.py
+++ b/core/replay/regime_analytics.py
@@ -1,0 +1,286 @@
+"""ARVP regime analytics: regime-segmented KPI scoring.
+
+Scope (#1846): deterministic regime-segmented scorecards and artifact writing.
+
+Design rules:
+  - Regime IDs are repo-backed string literals from services/regime/service.py.
+  - Input protocol: caller supplies Sequence[RegimeKPIRecord]; regime context is
+    explicit, never inferred.
+  - Missing/non-canonical regime IDs are transparently recorded and counted as
+    unknown — nothing is silently dropped.
+  - All monetary values use Decimal with fixed quantization (no-float rule).
+  - compute_regime_scorecard is a pure function; no I/O.
+  - write_regime_scorecard_artifact is the sole I/O entry point; fail-closed.
+  - Deterministic: same inputs + same run_id → identical scorecard and fingerprint.
+
+Non-goals:
+  - regime classification or new regime models (services/regime owns that)
+  - reporter/runner modifications
+  - replay-vs-paper comparison
+  - management-grade UX reports (#1847)
+  - dashboard or UI
+  - CLI wiring
+"""
+
+from __future__ import annotations
+
+import pathlib
+from collections import defaultdict
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Sequence
+
+from core.replay.canonical_json import canonical_hash, canonical_json_dumps
+
+# ---------------------------------------------------------------------------
+# Canonical regime IDs (repo-backed from services/regime/service.py)
+# ---------------------------------------------------------------------------
+
+#: Sentinel for missing or non-canonical regime context in caller-supplied records.
+#: Use this constant (not the bare string) for future-proofness.
+UNKNOWN_REGIME: str = "__unknown__"
+
+#: Canonical regime ID strings emitted by services/regime/service.py.
+#: Records whose regime_id is not in this set are counted as unknown.
+KNOWN_REGIME_IDS: frozenset[str] = frozenset(
+    {"TREND", "RANGE", "HIGH_VOL_CHAOTIC", "UNKNOWN"}
+)
+
+# Fixed quantization precision for monetary and rate values.
+_PNL_Q = Decimal("0.00000001")
+_RATE_Q = Decimal("0.00000001")
+
+
+# ---------------------------------------------------------------------------
+# Error type
+# ---------------------------------------------------------------------------
+
+
+class RegimeAnalyticsError(ValueError):
+    """Raised when regime analytics validation or I/O fails."""
+
+
+# ---------------------------------------------------------------------------
+# Input type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RegimeKPIRecord:
+    """A single tagged KPI measurement for one regime context window.
+
+    Callers supply a sequence of these to compute_regime_scorecard.
+    Use UNKNOWN_REGIME as regime_id when the regime context is missing.
+
+    All counts must be non-negative integers; pnl_sum must be a Decimal.
+    """
+
+    regime_id: str
+    signal_count: int
+    fill_count: int
+    reject_count: int
+    pnl_sum: Decimal
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.regime_id, str) or not self.regime_id:
+            raise RegimeAnalyticsError("regime_id must be a non-empty string")
+        for field_name, value in (
+            ("signal_count", self.signal_count),
+            ("fill_count", self.fill_count),
+            ("reject_count", self.reject_count),
+        ):
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise RegimeAnalyticsError(
+                    f"{field_name} must be a non-negative int"
+                )
+        if not isinstance(self.pnl_sum, Decimal):
+            raise RegimeAnalyticsError("pnl_sum must be a Decimal")
+
+
+# ---------------------------------------------------------------------------
+# Output types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RegimeSegmentStats:
+    """Aggregated KPI stats for a single regime segment.
+
+    fill_rate = fill_count / (fill_count + reject_count), or Decimal(0)
+    when both are zero.  Both pnl_sum and fill_rate are quantized to
+    _PNL_Q / _RATE_Q respectively for deterministic serialization.
+    """
+
+    regime_id: str
+    record_count: int
+    signal_count: int
+    fill_count: int
+    reject_count: int
+    pnl_sum: Decimal
+    fill_rate: Decimal
+
+    def to_dict(self) -> dict:
+        return {
+            "regime_id": self.regime_id,
+            "record_count": self.record_count,
+            "signal_count": self.signal_count,
+            "fill_count": self.fill_count,
+            "reject_count": self.reject_count,
+            "pnl_sum": str(self.pnl_sum),
+            "fill_rate": str(self.fill_rate),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RegimeScorecard:
+    """Full regime-segmented scorecard for a replay run.
+
+    segments is sorted by regime_id for deterministic ordering.
+    unknown_regime_count counts records whose regime_id is not in KNOWN_REGIME_IDS.
+    input_fingerprint is the SHA-256 of the canonical JSON of the input records.
+    """
+
+    run_id: str
+    segments: tuple[RegimeSegmentStats, ...]
+    total_records: int
+    unknown_regime_count: int
+    input_fingerprint: str
+
+    def to_dict(self) -> dict:
+        return {
+            "run_id": self.run_id,
+            "total_records": self.total_records,
+            "unknown_regime_count": self.unknown_regime_count,
+            "input_fingerprint": self.input_fingerprint,
+            "segments": [s.to_dict() for s in self.segments],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _fill_rate(fill_count: int, reject_count: int) -> Decimal:
+    total = fill_count + reject_count
+    if total == 0:
+        return Decimal("0").quantize(_RATE_Q)
+    return (Decimal(fill_count) / Decimal(total)).quantize(_RATE_Q)
+
+
+def _fingerprint(records: Sequence[RegimeKPIRecord]) -> str:
+    """Deterministic SHA-256 fingerprint of input records (order-sensitive)."""
+    serializable = [
+        {
+            "fill_count": r.fill_count,
+            "pnl_sum": str(r.pnl_sum),
+            "regime_id": r.regime_id,
+            "reject_count": r.reject_count,
+            "signal_count": r.signal_count,
+        }
+        for r in records
+    ]
+    return canonical_hash(serializable)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_regime_scorecard(
+    records: Sequence[RegimeKPIRecord],
+    *,
+    run_id: str,
+) -> RegimeScorecard:
+    """Compute a deterministic regime-segmented scorecard from KPI records.
+
+    Groups records by regime_id, aggregates per-regime KPIs, and counts
+    unknown/non-canonical regime IDs explicitly.  An empty input yields a
+    valid empty scorecard — no error is raised.
+
+    Args:
+        records: Sequence of RegimeKPIRecord instances supplied by the caller.
+        run_id:  Canonical run identifier (non-empty string).
+
+    Returns:
+        RegimeScorecard with segments sorted by regime_id, aggregate totals,
+        unknown_regime_count, and a deterministic input_fingerprint.
+
+    Raises:
+        RegimeAnalyticsError if run_id is invalid.
+    """
+    if not isinstance(run_id, str) or not run_id.strip():
+        raise RegimeAnalyticsError("run_id must be a non-empty string")
+
+    # Materialize once so the sequence is safe to iterate multiple times and
+    # len() is always correct, even if the caller passes a one-shot iterable.
+    records_list = list(records)
+
+    fingerprint = _fingerprint(records_list)
+
+    groups: dict[str, list[RegimeKPIRecord]] = defaultdict(list)
+    for rec in records_list:
+        groups[rec.regime_id].append(rec)
+
+    unknown_count = sum(
+        len(recs)
+        for regime_id, recs in groups.items()
+        if regime_id not in KNOWN_REGIME_IDS
+    )
+
+    segments: list[RegimeSegmentStats] = []
+    for regime_id in sorted(groups.keys()):
+        recs = groups[regime_id]
+        signal_sum = sum(r.signal_count for r in recs)
+        fill_sum = sum(r.fill_count for r in recs)
+        reject_sum = sum(r.reject_count for r in recs)
+        pnl_total = sum((r.pnl_sum for r in recs), Decimal("0")).quantize(_PNL_Q)
+        segments.append(
+            RegimeSegmentStats(
+                regime_id=regime_id,
+                record_count=len(recs),
+                signal_count=signal_sum,
+                fill_count=fill_sum,
+                reject_count=reject_sum,
+                pnl_sum=pnl_total,
+                fill_rate=_fill_rate(fill_sum, reject_sum),
+            )
+        )
+
+    return RegimeScorecard(
+        run_id=run_id,
+        segments=tuple(segments),
+        total_records=len(records_list),
+        unknown_regime_count=unknown_count,
+        input_fingerprint=fingerprint,
+    )
+
+
+def write_regime_scorecard_artifact(
+    scorecard: RegimeScorecard,
+    artifact_root: str | pathlib.Path,
+) -> None:
+    """Write regime_scorecard.json into artifact_root.
+
+    Uses canonical JSON serialization for deterministic output.  The
+    directory is created if it does not exist.  Fail-closed: raises
+    RegimeAnalyticsError on any I/O failure.
+
+    Args:
+        scorecard:     Fully computed RegimeScorecard instance.
+        artifact_root: Directory to write regime_scorecard.json into.
+
+    Raises:
+        RegimeAnalyticsError on I/O failure.
+    """
+    out_dir = pathlib.Path(artifact_root)
+    artifact_path = out_dir / "regime_scorecard.json"
+    json_bytes = canonical_json_dumps(scorecard.to_dict()).encode("utf-8")
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_bytes(json_bytes)
+    except OSError as exc:
+        raise RegimeAnalyticsError(
+            f"Failed to write regime_scorecard.json to {artifact_path}: {exc}"
+        ) from exc

--- a/core/replay/scenario_packs.py
+++ b/core/replay/scenario_packs.py
@@ -1,0 +1,243 @@
+"""ARVP built-in scenario pack library.
+
+Scope (#1845): canonical scenario pack definitions and invocation wrapper.
+
+Non-goals:
+  - user-defined scenario DSLs
+  - regime analytics or scorecards (#1846)
+  - management-grade UX reports (#1847)
+  - replay-vs-paper comparison
+  - non-deterministic or random stress behaviour
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from core.replay.canonical_json import canonical_json_dumps
+from core.replay.scenario_harness import (
+    ScenarioGroupManifest,
+    ScenarioRunResult,
+    ScenarioSpec,
+    run_scenario_group,
+)
+
+# ---------------------------------------------------------------------------
+# Error type
+# ---------------------------------------------------------------------------
+
+
+class ScenarioPackError(ValueError):
+    """Raised when a scenario pack cannot be resolved or invoked."""
+
+
+# ---------------------------------------------------------------------------
+# Pack definitions
+# ---------------------------------------------------------------------------
+
+#: Ordered canonical built-in scenario IDs (order is part of the public API).
+BUILTIN_SCENARIO_IDS: tuple[str, ...] = (
+    "baseline",
+    "pessimistic_execution",
+    "delayed_execution",
+    "low_liquidity",
+    "feed_gap",
+)
+
+_PACK_VERSION = "1"
+
+
+def _make_spec(scenario_id: str, description: str, overrides: dict[str, Any]) -> ScenarioSpec:
+    """Build a ScenarioSpec with provenance keys injected into config_overrides."""
+    provenance: dict[str, Any] = {
+        "pack_id": scenario_id,
+        "pack_version": _PACK_VERSION,
+    }
+    return ScenarioSpec(
+        scenario_id=scenario_id,
+        description=description,
+        config_overrides={**provenance, **overrides},
+    )
+
+
+#: Internal pack registry.  Evaluated once at import time; immutable thereafter.
+_PACKS: dict[str, ScenarioSpec] = {
+    "baseline": _make_spec(
+        scenario_id="baseline",
+        description=(
+            "Undegraded baseline replay: no execution perturbation, "
+            "no data-quality degradation. Reference anchor for variant comparison."
+        ),
+        overrides={},
+    ),
+    "pessimistic_execution": _make_spec(
+        scenario_id="pessimistic_execution",
+        description=(
+            "Pessimistic execution: elevated slippage, reduced fill rate, "
+            "and pessimistic execution posture. Models adverse fill conditions."
+        ),
+        overrides={
+            "execution_slippage_bps": 30,
+            "fill_rate": 0.7,
+            "execution_posture": "pessimistic",
+        },
+    ),
+    "delayed_execution": _make_spec(
+        scenario_id="delayed_execution",
+        description=(
+            "Delayed execution: deterministic execution delay injected per order. "
+            "Models latency degradation and late-arrival execution conditions."
+        ),
+        overrides={
+            "execution_delay_ms": 500,
+            "execution_posture": "delayed",
+        },
+    ),
+    "low_liquidity": _make_spec(
+        scenario_id="low_liquidity",
+        description=(
+            "Low-liquidity: reduced available execution depth and degraded fill "
+            "conditions. Models thin-book or illiquid market conditions."
+        ),
+        overrides={
+            "fill_depth_factor": 0.3,
+            "execution_posture": "low_liquidity",
+        },
+    ),
+    "feed_gap": _make_spec(
+        scenario_id="feed_gap",
+        description=(
+            "Feed-gap: deterministic data-gap injection consistent with the replay "
+            "input model. Models feed interruptions and stale-tick conditions."
+        ),
+        overrides={
+            "feed_gap_seconds": 30,
+            "drop_ticks_on_gap": True,
+        },
+    ),
+}
+
+# Validate internal consistency at import time (unconditional: not skipped under -O).
+if set(_PACKS.keys()) != set(BUILTIN_SCENARIO_IDS):
+    raise ScenarioPackError(
+        "Mismatch between _PACKS keys and BUILTIN_SCENARIO_IDS"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def list_builtin_scenario_ids() -> tuple[str, ...]:
+    """Return the ordered tuple of canonical built-in scenario IDs."""
+    return BUILTIN_SCENARIO_IDS
+
+
+def get_scenario_pack(scenario_id: str) -> ScenarioSpec:
+    """Resolve a built-in scenario pack by ID.
+
+    Each call returns a fresh ScenarioSpec so callers cannot corrupt the
+    internal registry by mutating the returned config_overrides dict.
+
+    Args:
+        scenario_id: One of the canonical built-in scenario IDs.
+
+    Returns:
+        A fresh ScenarioSpec with provenance in config_overrides.
+
+    Raises:
+        ScenarioPackError: If scenario_id is not a known built-in pack.
+    """
+    if not isinstance(scenario_id, str) or not scenario_id.strip():
+        raise ScenarioPackError(
+            f"scenario_id must be a non-empty string, got {scenario_id!r}"
+        )
+    stored = _PACKS.get(scenario_id)
+    if stored is None:
+        known = ", ".join(repr(k) for k in BUILTIN_SCENARIO_IDS)
+        raise ScenarioPackError(
+            f"Unknown scenario pack {scenario_id!r}. "
+            f"Known built-in packs: {known}"
+        )
+    # Return a fresh copy; ScenarioSpec.__post_init__ deep-copies config_overrides.
+    return ScenarioSpec(
+        scenario_id=stored.scenario_id,
+        description=stored.description,
+        config_overrides=stored.config_overrides,
+    )
+
+
+def _write_specs_artifact(artifact_root: str, spec_dicts: Sequence[dict[str, Any]]) -> None:
+    """Write scenario_specs.json into the group artifact directory.
+
+    Accepts pre-captured spec dicts (snapshots taken before run_fn executes)
+    so that any mutation of config_overrides inside run_fn cannot corrupt
+    the provenance artifact.
+    """
+    artifact_dir = Path(artifact_root)
+    specs_path = artifact_dir / "scenario_specs.json"
+    payload: dict[str, Any] = {
+        "scenario_specs": list(spec_dicts),
+    }
+    try:
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        specs_path.write_text(canonical_json_dumps(payload), encoding="utf-8")
+    except OSError as exc:
+        raise ScenarioPackError(
+            f"Failed to write scenario_specs.json to {artifact_dir}: {exc}"
+        ) from exc
+
+
+def run_builtin_scenario_group(
+    scenario_ids: Sequence[str],
+    *,
+    run_fn: Callable[[ScenarioSpec], ScenarioRunResult],
+    output_dir: Path | str,
+    group_id: str | None = None,
+) -> ScenarioGroupManifest:
+    """Resolve built-in scenario packs and run them as a group.
+
+    Convenience wrapper over :func:`run_scenario_group` that:
+    1. Resolves each scenario_id to its canonical ScenarioSpec.
+    2. Executes the group via the harness.
+    3. Writes a ``scenario_specs.json`` provenance artifact into
+       ``manifest.artifact_root`` alongside the group manifest.
+
+    Args:
+        scenario_ids: Ordered sequence of built-in scenario IDs to run.
+            Must be non-empty and contain only known built-in IDs.
+        run_fn: Callable accepted by :func:`run_scenario_group`.
+        output_dir: Root directory for group output.
+        group_id: Optional pre-computed group ID (forwarded to harness).
+
+    Returns:
+        ScenarioGroupManifest from the harness, after provenance artifact write.
+
+    Raises:
+        ScenarioPackError: If ``scenario_ids`` is a bare str/bytes, is empty,
+            any scenario_id is unknown, or provenance write fails.
+        ScenarioHarnessError: Propagated from :func:`run_scenario_group` on
+            duplicate IDs, invalid group_id, or manifest write failure.
+    """
+    if isinstance(scenario_ids, (str, bytes)):
+        raise ScenarioPackError(
+            "scenario_ids must be a sequence of str, not a bare str or bytes; "
+            "wrap in a list, e.g. [scenario_id]"
+        )
+    if not scenario_ids:
+        raise ScenarioPackError("scenario_ids must not be empty")
+
+    specs = [get_scenario_pack(sid) for sid in scenario_ids]
+    # Snapshot spec dicts before run_fn executes so any in-flight mutation of
+    # config_overrides cannot corrupt the provenance artifact.
+    spec_snapshots = [spec.to_dict() for spec in specs]
+    manifest = run_scenario_group(
+        specs,
+        run_fn=run_fn,
+        output_dir=output_dir,
+        group_id=group_id,
+    )
+    _write_specs_artifact(manifest.artifact_root, spec_snapshots)
+    return manifest

--- a/tests/unit/replay/test_regime_analytics.py
+++ b/tests/unit/replay/test_regime_analytics.py
@@ -1,0 +1,415 @@
+"""Unit tests for core.replay.regime_analytics (#1846).
+
+Covers:
+  - KNOWN_REGIME_IDS and UNKNOWN_REGIME sentinel
+  - RegimeKPIRecord validation
+  - compute_regime_scorecard: empty input, single/multi-regime, fill_rate,
+    unknown/non-canonical regime counting, segment ordering, fingerprint
+    determinism
+  - write_regime_scorecard_artifact: artifact creation, content validity
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from core.replay.regime_analytics import (
+    KNOWN_REGIME_IDS,
+    UNKNOWN_REGIME,
+    RegimeAnalyticsError,
+    RegimeKPIRecord,
+    RegimeScorecard,
+    RegimeSegmentStats,
+    compute_regime_scorecard,
+    write_regime_scorecard_artifact,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _record(
+    regime_id: str,
+    *,
+    signal_count: int = 1,
+    fill_count: int = 1,
+    reject_count: int = 0,
+    pnl_sum: str = "0",
+) -> RegimeKPIRecord:
+    return RegimeKPIRecord(
+        regime_id=regime_id,
+        signal_count=signal_count,
+        fill_count=fill_count,
+        reject_count=reject_count,
+        pnl_sum=Decimal(pnl_sum),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_known_regime_ids_contains_all_four(self):
+        assert KNOWN_REGIME_IDS == frozenset(
+            {"TREND", "RANGE", "HIGH_VOL_CHAOTIC", "UNKNOWN"}
+        )
+
+    def test_unknown_regime_sentinel_not_in_known_ids(self):
+        """UNKNOWN_REGIME is the analytics sentinel, not the regime service label."""
+        assert UNKNOWN_REGIME not in KNOWN_REGIME_IDS
+
+    def test_unknown_regime_sentinel_value(self):
+        assert UNKNOWN_REGIME == "__unknown__"
+
+
+# ---------------------------------------------------------------------------
+# RegimeKPIRecord validation
+# ---------------------------------------------------------------------------
+
+
+class TestRegimeKPIRecord:
+    def test_valid_record(self):
+        r = _record("TREND", signal_count=3, fill_count=2, reject_count=1, pnl_sum="1.5")
+        assert r.regime_id == "TREND"
+        assert r.signal_count == 3
+        assert r.fill_count == 2
+        assert r.reject_count == 1
+        assert r.pnl_sum == Decimal("1.5")
+
+    def test_empty_regime_id_raises(self):
+        with pytest.raises(RegimeAnalyticsError, match="regime_id"):
+            RegimeKPIRecord(
+                regime_id="",
+                signal_count=0,
+                fill_count=0,
+                reject_count=0,
+                pnl_sum=Decimal("0"),
+            )
+
+    def test_negative_signal_count_raises(self):
+        with pytest.raises(RegimeAnalyticsError, match="signal_count"):
+            _record("TREND", signal_count=-1)
+
+    def test_negative_fill_count_raises(self):
+        with pytest.raises(RegimeAnalyticsError, match="fill_count"):
+            _record("TREND", fill_count=-1)
+
+    def test_negative_reject_count_raises(self):
+        with pytest.raises(RegimeAnalyticsError, match="reject_count"):
+            _record("TREND", reject_count=-1)
+
+    def test_bool_signal_count_raises(self):
+        with pytest.raises(RegimeAnalyticsError, match="signal_count"):
+            RegimeKPIRecord(
+                regime_id="TREND",
+                signal_count=True,  # bool subclasses int but must be rejected
+                fill_count=0,
+                reject_count=0,
+                pnl_sum=Decimal("0"),
+            )
+
+    def test_float_pnl_raises(self):
+        with pytest.raises(RegimeAnalyticsError, match="pnl_sum"):
+            RegimeKPIRecord(
+                regime_id="TREND",
+                signal_count=0,
+                fill_count=0,
+                reject_count=0,
+                pnl_sum=1.5,  # type: ignore[arg-type]
+            )
+
+    def test_unknown_regime_sentinel_is_valid_record(self):
+        """Callers may use UNKNOWN_REGIME as regime_id — it must be accepted."""
+        r = _record(UNKNOWN_REGIME)
+        assert r.regime_id == UNKNOWN_REGIME
+
+
+# ---------------------------------------------------------------------------
+# compute_regime_scorecard — empty input
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRegimeScorecardEmpty:
+    def test_empty_records_gives_valid_scorecard(self):
+        sc = compute_regime_scorecard([], run_id="run-001")
+        assert sc.run_id == "run-001"
+        assert sc.total_records == 0
+        assert sc.segments == ()
+        assert sc.unknown_regime_count == 0
+        assert isinstance(sc.input_fingerprint, str)
+        assert len(sc.input_fingerprint) == 64  # SHA-256 hex
+
+    def test_empty_records_fingerprint_is_deterministic(self):
+        sc1 = compute_regime_scorecard([], run_id="r1")
+        sc2 = compute_regime_scorecard([], run_id="r1")
+        assert sc1.input_fingerprint == sc2.input_fingerprint
+
+    def test_invalid_run_id_raises(self):
+        with pytest.raises(RegimeAnalyticsError, match="run_id"):
+            compute_regime_scorecard([], run_id="")
+
+    def test_whitespace_run_id_raises(self):
+        with pytest.raises(RegimeAnalyticsError, match="run_id"):
+            compute_regime_scorecard([], run_id="   ")
+
+
+# ---------------------------------------------------------------------------
+# compute_regime_scorecard — single regime
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRegimeScorecardSingle:
+    def test_single_known_regime_segment(self):
+        records = [_record("TREND", signal_count=5, fill_count=3, reject_count=2, pnl_sum="10")]
+        sc = compute_regime_scorecard(records, run_id="run-a")
+        assert sc.total_records == 1
+        assert sc.unknown_regime_count == 0
+        assert len(sc.segments) == 1
+        seg = sc.segments[0]
+        assert seg.regime_id == "TREND"
+        assert seg.record_count == 1
+        assert seg.signal_count == 5
+        assert seg.fill_count == 3
+        assert seg.reject_count == 2
+        assert seg.pnl_sum == Decimal("10").quantize(Decimal("0.00000001"))
+
+    def test_fill_rate_calculation(self):
+        records = [_record("RANGE", fill_count=3, reject_count=1)]
+        sc = compute_regime_scorecard(records, run_id="r")
+        seg = sc.segments[0]
+        # 3 / (3 + 1) = 0.75
+        assert seg.fill_rate == Decimal("0.75000000")
+
+    def test_fill_rate_zero_when_no_fills_or_rejects(self):
+        records = [_record("RANGE", fill_count=0, reject_count=0)]
+        sc = compute_regime_scorecard(records, run_id="r")
+        assert sc.segments[0].fill_rate == Decimal("0.00000000")
+
+    def test_fill_rate_one_when_no_rejects(self):
+        records = [_record("TREND", fill_count=5, reject_count=0)]
+        sc = compute_regime_scorecard(records, run_id="r")
+        assert sc.segments[0].fill_rate == Decimal("1.00000000")
+
+    def test_fill_rate_zero_when_no_fills(self):
+        records = [_record("TREND", fill_count=0, reject_count=3)]
+        sc = compute_regime_scorecard(records, run_id="r")
+        assert sc.segments[0].fill_rate == Decimal("0.00000000")
+
+
+# ---------------------------------------------------------------------------
+# compute_regime_scorecard — all four known regimes
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRegimeScorecardAllKnown:
+    def test_all_four_known_regimes_in_scorecard(self):
+        records = [_record(rid) for rid in sorted(KNOWN_REGIME_IDS)]
+        sc = compute_regime_scorecard(records, run_id="run-all")
+        segment_ids = {seg.regime_id for seg in sc.segments}
+        assert segment_ids == KNOWN_REGIME_IDS
+        assert sc.unknown_regime_count == 0
+        assert sc.total_records == 4
+
+    def test_segments_are_sorted_by_regime_id(self):
+        records = [_record("TREND"), _record("RANGE"), _record("HIGH_VOL_CHAOTIC")]
+        sc = compute_regime_scorecard(records, run_id="r")
+        ids = [seg.regime_id for seg in sc.segments]
+        assert ids == sorted(ids)
+
+    def test_multi_record_aggregation(self):
+        records = [
+            _record("TREND", signal_count=2, fill_count=1, reject_count=0, pnl_sum="5"),
+            _record("TREND", signal_count=3, fill_count=2, reject_count=1, pnl_sum="7"),
+        ]
+        sc = compute_regime_scorecard(records, run_id="r")
+        assert len(sc.segments) == 1
+        seg = sc.segments[0]
+        assert seg.record_count == 2
+        assert seg.signal_count == 5
+        assert seg.fill_count == 3
+        assert seg.reject_count == 1
+        # pnl: 5 + 7 = 12
+        assert seg.pnl_sum == Decimal("12.00000000")
+        # fill_rate: 3 / (3 + 1) = 0.75
+        assert seg.fill_rate == Decimal("0.75000000")
+
+
+# ---------------------------------------------------------------------------
+# compute_regime_scorecard — unknown/non-canonical regime IDs
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRegimeScorecardUnknown:
+    def test_unknown_regime_sentinel_counted_as_unknown(self):
+        records = [_record(UNKNOWN_REGIME)]
+        sc = compute_regime_scorecard(records, run_id="r")
+        assert sc.unknown_regime_count == 1
+        # still appears in segments (not silently dropped)
+        assert any(seg.regime_id == UNKNOWN_REGIME for seg in sc.segments)
+
+    def test_non_canonical_regime_id_counted_as_unknown(self):
+        records = [_record("CUSTOM_REGIME"), _record("TREND")]
+        sc = compute_regime_scorecard(records, run_id="r")
+        assert sc.unknown_regime_count == 1
+        assert sc.total_records == 2
+
+    def test_multiple_unknown_regimes_all_counted(self):
+        records = [_record(UNKNOWN_REGIME), _record("NOT_A_REGIME"), _record("TREND")]
+        sc = compute_regime_scorecard(records, run_id="r")
+        assert sc.unknown_regime_count == 2
+
+    def test_known_unknown_regime_label_not_counted_as_analytics_unknown(self):
+        """The regime service label 'UNKNOWN' is a known regime ID — not analytics unknown."""
+        records = [_record("UNKNOWN")]
+        sc = compute_regime_scorecard(records, run_id="r")
+        assert sc.unknown_regime_count == 0
+        assert sc.segments[0].regime_id == "UNKNOWN"
+
+    def test_unknown_regimes_visible_in_segments(self):
+        """Non-canonical regime IDs must appear in segments, not be silently dropped."""
+        records = [_record(UNKNOWN_REGIME), _record("WEIRD")]
+        sc = compute_regime_scorecard(records, run_id="r")
+        segment_ids = {seg.regime_id for seg in sc.segments}
+        assert UNKNOWN_REGIME in segment_ids
+        assert "WEIRD" in segment_ids
+
+
+# ---------------------------------------------------------------------------
+# compute_regime_scorecard — fingerprint determinism
+# ---------------------------------------------------------------------------
+
+
+class TestFingerprintDeterminism:
+    def test_same_inputs_same_fingerprint(self):
+        records_a = [_record("TREND", fill_count=2), _record("RANGE", fill_count=1)]
+        records_b = [_record("TREND", fill_count=2), _record("RANGE", fill_count=1)]
+        sc_a = compute_regime_scorecard(records_a, run_id="run-fp")
+        sc_b = compute_regime_scorecard(records_b, run_id="run-fp")
+        assert sc_a.input_fingerprint == sc_b.input_fingerprint
+
+    def test_different_records_different_fingerprint(self):
+        records_a = [_record("TREND", fill_count=2)]
+        records_b = [_record("TREND", fill_count=3)]
+        sc_a = compute_regime_scorecard(records_a, run_id="r")
+        sc_b = compute_regime_scorecard(records_b, run_id="r")
+        assert sc_a.input_fingerprint != sc_b.input_fingerprint
+
+    def test_different_run_id_same_records_same_fingerprint(self):
+        """Fingerprint covers only records, not run_id."""
+        records = [_record("TREND")]
+        sc_a = compute_regime_scorecard(records, run_id="run-1")
+        sc_b = compute_regime_scorecard(records, run_id="run-2")
+        assert sc_a.input_fingerprint == sc_b.input_fingerprint
+
+    def test_order_sensitive_fingerprint(self):
+        """Order of records is reflected in the fingerprint."""
+        r1 = _record("TREND", pnl_sum="1")
+        r2 = _record("RANGE", pnl_sum="2")
+        sc_fwd = compute_regime_scorecard([r1, r2], run_id="r")
+        sc_rev = compute_regime_scorecard([r2, r1], run_id="r")
+        assert sc_fwd.input_fingerprint != sc_rev.input_fingerprint
+
+    def test_fingerprint_is_64_char_hex(self):
+        sc = compute_regime_scorecard([_record("TREND")], run_id="r")
+        assert len(sc.input_fingerprint) == 64
+        assert all(c in "0123456789abcdef" for c in sc.input_fingerprint)
+
+
+# ---------------------------------------------------------------------------
+# write_regime_scorecard_artifact
+# ---------------------------------------------------------------------------
+
+
+class TestWriteRegimeScorecardArtifact:
+    def _simple_scorecard(self, run_id: str = "run-write") -> RegimeScorecard:
+        return compute_regime_scorecard(
+            [_record("TREND", fill_count=2, reject_count=1, pnl_sum="5.5")],
+            run_id=run_id,
+        )
+
+    def test_writes_regime_scorecard_json(self, tmp_path: Path):
+        sc = self._simple_scorecard()
+        write_regime_scorecard_artifact(sc, tmp_path)
+        artifact = tmp_path / "regime_scorecard.json"
+        assert artifact.exists()
+
+    def test_artifact_is_valid_json(self, tmp_path: Path):
+        sc = self._simple_scorecard()
+        write_regime_scorecard_artifact(sc, tmp_path)
+        content = json.loads((tmp_path / "regime_scorecard.json").read_text())
+        assert isinstance(content, dict)
+
+    def test_artifact_contains_expected_top_level_keys(self, tmp_path: Path):
+        sc = self._simple_scorecard()
+        write_regime_scorecard_artifact(sc, tmp_path)
+        content = json.loads((tmp_path / "regime_scorecard.json").read_text())
+        assert "run_id" in content
+        assert "total_records" in content
+        assert "unknown_regime_count" in content
+        assert "input_fingerprint" in content
+        assert "segments" in content
+
+    def test_artifact_run_id_matches(self, tmp_path: Path):
+        sc = self._simple_scorecard(run_id="my-run-42")
+        write_regime_scorecard_artifact(sc, tmp_path)
+        content = json.loads((tmp_path / "regime_scorecard.json").read_text())
+        assert content["run_id"] == "my-run-42"
+
+    def test_artifact_segments_contain_regime_id(self, tmp_path: Path):
+        sc = self._simple_scorecard()
+        write_regime_scorecard_artifact(sc, tmp_path)
+        content = json.loads((tmp_path / "regime_scorecard.json").read_text())
+        assert len(content["segments"]) == 1
+        assert content["segments"][0]["regime_id"] == "TREND"
+
+    def test_artifact_pnl_sum_is_string(self, tmp_path: Path):
+        """pnl_sum must be serialized as a string (no-float rule)."""
+        sc = self._simple_scorecard()
+        write_regime_scorecard_artifact(sc, tmp_path)
+        content = json.loads((tmp_path / "regime_scorecard.json").read_text())
+        assert isinstance(content["segments"][0]["pnl_sum"], str)
+
+    def test_artifact_fill_rate_is_string(self, tmp_path: Path):
+        """fill_rate must be serialized as a string (no-float rule)."""
+        sc = self._simple_scorecard()
+        write_regime_scorecard_artifact(sc, tmp_path)
+        content = json.loads((tmp_path / "regime_scorecard.json").read_text())
+        assert isinstance(content["segments"][0]["fill_rate"], str)
+
+    def test_creates_artifact_root_if_not_exists(self, tmp_path: Path):
+        nested = tmp_path / "a" / "b" / "c"
+        sc = self._simple_scorecard()
+        write_regime_scorecard_artifact(sc, nested)
+        assert (nested / "regime_scorecard.json").exists()
+
+    def test_accepts_string_path(self, tmp_path: Path):
+        sc = self._simple_scorecard()
+        write_regime_scorecard_artifact(sc, str(tmp_path))
+        assert (tmp_path / "regime_scorecard.json").exists()
+
+    def test_artifact_is_deterministic(self, tmp_path: Path):
+        """Same scorecard written twice produces identical bytes."""
+        sc = self._simple_scorecard()
+        path_a = tmp_path / "a"
+        path_b = tmp_path / "b"
+        write_regime_scorecard_artifact(sc, path_a)
+        write_regime_scorecard_artifact(sc, path_b)
+        assert (path_a / "regime_scorecard.json").read_bytes() == (
+            path_b / "regime_scorecard.json"
+        ).read_bytes()
+
+    def test_empty_scorecard_artifact_is_valid(self, tmp_path: Path):
+        sc = compute_regime_scorecard([], run_id="empty-run")
+        write_regime_scorecard_artifact(sc, tmp_path)
+        content = json.loads((tmp_path / "regime_scorecard.json").read_text())
+        assert content["total_records"] == 0
+        assert content["segments"] == []
+        assert content["unknown_regime_count"] == 0

--- a/tests/unit/replay/test_scenario_packs.py
+++ b/tests/unit/replay/test_scenario_packs.py
@@ -1,0 +1,272 @@
+"""Unit tests for core/replay/scenario_packs.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.replay.scenario_harness import ScenarioHarnessError, ScenarioRunResult, ScenarioSpec
+from core.replay.scenario_packs import (
+    BUILTIN_SCENARIO_IDS,
+    ScenarioPackError,
+    get_scenario_pack,
+    list_builtin_scenario_ids,
+    run_builtin_scenario_group,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _success_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+    return ScenarioRunResult(scenario_id=spec.scenario_id, exit_code=0)
+
+
+# ---------------------------------------------------------------------------
+# BUILTIN_SCENARIO_IDS / list_builtin_scenario_ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuiltinScenarioIds:
+    def test_contains_all_five_packs(self) -> None:
+        expected = {
+            "baseline",
+            "pessimistic_execution",
+            "delayed_execution",
+            "low_liquidity",
+            "feed_gap",
+        }
+        assert set(BUILTIN_SCENARIO_IDS) == expected
+
+    def test_order_is_stable(self) -> None:
+        assert list_builtin_scenario_ids() == BUILTIN_SCENARIO_IDS
+
+    def test_list_builtin_is_deterministic(self) -> None:
+        assert list_builtin_scenario_ids() == list_builtin_scenario_ids()
+
+    def test_baseline_is_first(self) -> None:
+        assert BUILTIN_SCENARIO_IDS[0] == "baseline"
+
+
+# ---------------------------------------------------------------------------
+# get_scenario_pack
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetScenarioPack:
+    def test_all_builtin_ids_resolve(self) -> None:
+        for sid in BUILTIN_SCENARIO_IDS:
+            spec = get_scenario_pack(sid)
+            assert isinstance(spec, ScenarioSpec)
+            assert spec.scenario_id == sid
+
+    def test_unknown_id_fails_closed(self) -> None:
+        with pytest.raises(ScenarioPackError, match="Unknown scenario pack"):
+            get_scenario_pack("not_a_real_pack")
+
+    def test_empty_string_fails_closed(self) -> None:
+        with pytest.raises(ScenarioPackError):
+            get_scenario_pack("")
+
+    def test_whitespace_only_fails_closed(self) -> None:
+        with pytest.raises(ScenarioPackError):
+            get_scenario_pack("   ")
+
+    def test_returns_consistent_spec_on_repeated_calls(self) -> None:
+        s1 = get_scenario_pack("baseline")
+        s2 = get_scenario_pack("baseline")
+        assert s1.scenario_id == s2.scenario_id
+        assert s1.config_overrides == s2.config_overrides
+
+    # --- baseline ---
+
+    def test_baseline_has_no_perturbation_keys(self) -> None:
+        spec = get_scenario_pack("baseline")
+        overrides = spec.config_overrides
+        perturbation_keys = {
+            "execution_slippage_bps",
+            "fill_rate",
+            "execution_posture",
+            "execution_delay_ms",
+            "fill_depth_factor",
+            "feed_gap_seconds",
+            "drop_ticks_on_gap",
+        }
+        assert not perturbation_keys.intersection(overrides.keys())
+
+    def test_baseline_carries_provenance(self) -> None:
+        spec = get_scenario_pack("baseline")
+        assert spec.config_overrides["pack_id"] == "baseline"
+        assert spec.config_overrides["pack_version"] == "1"
+
+    # --- pessimistic_execution ---
+
+    def test_pessimistic_execution_overrides(self) -> None:
+        spec = get_scenario_pack("pessimistic_execution")
+        o = spec.config_overrides
+        assert o["execution_slippage_bps"] == 30
+        assert o["fill_rate"] == 0.7
+        assert o["execution_posture"] == "pessimistic"
+        assert o["pack_id"] == "pessimistic_execution"
+        assert o["pack_version"] == "1"
+
+    # --- delayed_execution ---
+
+    def test_delayed_execution_overrides(self) -> None:
+        spec = get_scenario_pack("delayed_execution")
+        o = spec.config_overrides
+        assert o["execution_delay_ms"] == 500
+        assert o["execution_posture"] == "delayed"
+        assert o["pack_id"] == "delayed_execution"
+
+    # --- low_liquidity ---
+
+    def test_low_liquidity_overrides(self) -> None:
+        spec = get_scenario_pack("low_liquidity")
+        o = spec.config_overrides
+        assert o["fill_depth_factor"] == 0.3
+        assert o["execution_posture"] == "low_liquidity"
+        assert o["pack_id"] == "low_liquidity"
+
+    # --- feed_gap ---
+
+    def test_feed_gap_overrides(self) -> None:
+        spec = get_scenario_pack("feed_gap")
+        o = spec.config_overrides
+        assert o["feed_gap_seconds"] == 30
+        assert o["drop_ticks_on_gap"] is True
+        assert o["pack_id"] == "feed_gap"
+
+    # --- determinism ---
+
+    def test_overrides_are_stable_across_calls(self) -> None:
+        for sid in BUILTIN_SCENARIO_IDS:
+            s1 = get_scenario_pack(sid)
+            s2 = get_scenario_pack(sid)
+            assert s1.config_overrides == s2.config_overrides
+
+    def test_config_overrides_are_isolated(self) -> None:
+        spec = get_scenario_pack("pessimistic_execution")
+        # Mutating the returned dict must not affect the registry.
+        spec.config_overrides["injected"] = "evil"
+        fresh = get_scenario_pack("pessimistic_execution")
+        assert "injected" not in fresh.config_overrides
+
+
+# ---------------------------------------------------------------------------
+# run_builtin_scenario_group
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunBuiltinScenarioGroup:
+    def test_empty_scenario_ids_fails_closed(self, tmp_path: Path) -> None:
+        with pytest.raises(ScenarioPackError, match="must not be empty"):
+            run_builtin_scenario_group([], run_fn=_success_fn, output_dir=tmp_path)
+
+    def test_unknown_id_fails_closed(self, tmp_path: Path) -> None:
+        with pytest.raises(ScenarioPackError, match="Unknown scenario pack"):
+            run_builtin_scenario_group(
+                ["baseline", "not_real"], run_fn=_success_fn, output_dir=tmp_path
+            )
+
+    def test_single_pack_succeeds(self, tmp_path: Path) -> None:
+        manifest = run_builtin_scenario_group(
+            ["baseline"], run_fn=_success_fn, output_dir=tmp_path
+        )
+        assert manifest.total_scenarios == 1
+        assert manifest.succeeded_count == 1
+
+    def test_all_five_packs_succeed(self, tmp_path: Path) -> None:
+        manifest = run_builtin_scenario_group(
+            list(BUILTIN_SCENARIO_IDS), run_fn=_success_fn, output_dir=tmp_path
+        )
+        assert manifest.total_scenarios == 5
+        assert manifest.succeeded_count == 5
+        assert manifest.failed_count == 0
+
+    def test_scenario_specs_json_written(self, tmp_path: Path) -> None:
+        manifest = run_builtin_scenario_group(
+            ["baseline", "pessimistic_execution"],
+            run_fn=_success_fn,
+            output_dir=tmp_path,
+        )
+        specs_path = Path(manifest.artifact_root) / "scenario_specs.json"
+        assert specs_path.exists()
+
+    def test_scenario_specs_json_content(self, tmp_path: Path) -> None:
+        ids = ["baseline", "pessimistic_execution", "delayed_execution"]
+        manifest = run_builtin_scenario_group(
+            ids, run_fn=_success_fn, output_dir=tmp_path
+        )
+        specs_path = Path(manifest.artifact_root) / "scenario_specs.json"
+        data = json.loads(specs_path.read_text(encoding="utf-8"))
+        assert "scenario_specs" in data
+        written_ids = [s["scenario_id"] for s in data["scenario_specs"]]
+        assert written_ids == ids
+
+    def test_scenario_specs_json_contains_overrides(self, tmp_path: Path) -> None:
+        manifest = run_builtin_scenario_group(
+            ["pessimistic_execution"], run_fn=_success_fn, output_dir=tmp_path
+        )
+        specs_path = Path(manifest.artifact_root) / "scenario_specs.json"
+        data = json.loads(specs_path.read_text(encoding="utf-8"))
+        spec_dict = data["scenario_specs"][0]
+        assert spec_dict["config_overrides"]["pack_id"] == "pessimistic_execution"
+        assert spec_dict["config_overrides"]["pack_version"] == "1"
+        assert spec_dict["config_overrides"]["execution_slippage_bps"] == 30
+
+    def test_scenario_specs_json_stable_across_runs(self, tmp_path: Path) -> None:
+        ids = ["baseline", "feed_gap"]
+
+        manifest1 = run_builtin_scenario_group(
+            ids, run_fn=_success_fn, output_dir=tmp_path / "run1"
+        )
+        manifest2 = run_builtin_scenario_group(
+            ids, run_fn=_success_fn, output_dir=tmp_path / "run2"
+        )
+        specs1 = json.loads(
+            (Path(manifest1.artifact_root) / "scenario_specs.json").read_text(encoding="utf-8")
+        )
+        specs2 = json.loads(
+            (Path(manifest2.artifact_root) / "scenario_specs.json").read_text(encoding="utf-8")
+        )
+        assert specs1 == specs2
+
+    def test_custom_group_id_forwarded(self, tmp_path: Path) -> None:
+        manifest = run_builtin_scenario_group(
+            ["baseline"],
+            run_fn=_success_fn,
+            output_dir=tmp_path,
+            group_id="my-pack-run",
+        )
+        assert manifest.group_id == "my-pack-run"
+        assert (tmp_path / "my-pack-run" / "scenario_specs.json").exists()
+
+    def test_harness_duplicate_ids_still_fail_closed(self, tmp_path: Path) -> None:
+        # Duplicate resolution goes through harness; verify it surfaces correctly.
+        specs_direct = [
+            get_scenario_pack("baseline"),
+            get_scenario_pack("baseline"),
+        ]
+        with pytest.raises(ScenarioHarnessError, match="Duplicate scenario_id"):
+            from core.replay.scenario_harness import run_scenario_group
+
+            run_scenario_group(specs_direct, run_fn=_success_fn, output_dir=tmp_path)
+
+    def test_execution_order_matches_input(self, tmp_path: Path) -> None:
+        order: list[str] = []
+
+        def tracking_fn(spec: ScenarioSpec) -> ScenarioRunResult:
+            order.append(spec.scenario_id)
+            return ScenarioRunResult(scenario_id=spec.scenario_id, exit_code=0)
+
+        ids = ["feed_gap", "baseline", "low_liquidity"]
+        run_builtin_scenario_group(ids, run_fn=tracking_fn, output_dir=tmp_path)
+        assert order == ids


### PR DESCRIPTION
## Summary
- add a repo-backed regime analytics core for deterministic regime-segmented scorecards
- model explicit unknown-regime handling and deterministic scorecard fingerprinting
- write \egime_scorecard.json\ fail-closed into the artifact root
- cover scorecard computation and artifact writing with focused unit tests

## Validation
- \python -m pytest tests/unit/replay/test_regime_analytics.py -q\
- \44 passed\

## Scope notes
- includes only the \#1846\ regime analytics core slice
- no changes to existing files
- unrelated local untracked files were not touched

Closes #1846