### PR TITLE
feat(arvp): add replay-vs-paper comparison core (#1848)

### DIFF
--- a/core/replay/shadow_compare.py
+++ b/core/replay/shadow_compare.py
@@ -1,0 +1,395 @@
+"""ARVP replay-vs-paper shadow comparison core.
+
+Scope (#1848): deterministic, offline comparison of replay output windows
+against explicit paper-trading reference windows.  No DB/Redis wiring.
+
+Design rules:
+  - Both sides are explicit, caller-supplied structs (no live data access).
+  - compare_windows() is a pure function; fails closed on misalignment or
+    missing reference.
+  - All rate values use Decimal with fixed quantization (no-float rule).
+  - Deterministic: same inputs produce identical comparison_fingerprint.
+  - write_shadow_comparison_artifact() is the sole I/O entry point; fail-closed.
+
+Fail-closed conditions:
+  - paper reference is None:  ShadowCompareError("missing_reference: …")
+  - symbol mismatch:          ShadowCompareError("misaligned: …")
+  - strategy_id mismatch:     ShadowCompareError("misaligned: …")
+  - no temporal overlap:      ShadowCompareError("misaligned: no temporal overlap …")
+
+Non-goals:
+  - DB/Redis collectors or live data access
+  - Event-level timing comparison (no offline event data surface in repo)
+  - Reporter/runner modifications
+  - Dashboard or management-grade UX reports (#1847)
+  - Regime analytics (#1846)
+  - CLI wiring
+
+relations:
+  domain: validation
+  upstream:
+    - core.replay.canonical_json  (canonical_hash, canonical_json_dumps)
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from core.replay.canonical_json import canonical_hash, canonical_json_dumps
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_RATE_Q = Decimal("0.00000001")
+_SHADOW_COMPARISON_FILENAME = "shadow_comparison.json"
+
+# Validation patterns (consistent with run_registry conventions)
+_RUN_ID_RE = re.compile(r"^replay-[a-f0-9]{12}-\d{4}$")
+_HEX_64_RE = re.compile(r"^[a-f0-9]{64}$")
+
+
+# ---------------------------------------------------------------------------
+# Error type
+# ---------------------------------------------------------------------------
+
+
+class ShadowCompareError(ValueError):
+    """Raised when shadow comparison fails validation, alignment, or I/O."""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_non_empty_string(value: object, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ShadowCompareError(f"{field_name} must be a non-empty string")
+
+
+def _require_non_negative_int(value: object, field_name: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ShadowCompareError(f"{field_name} must be a non-negative int")
+
+
+def _parse_utc_datetime(value: str, field_name: str) -> datetime:
+    _require_non_empty_string(value, field_name)
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ShadowCompareError(
+            f"{field_name} must be a valid ISO-8601 datetime: {exc}"
+        ) from exc
+    if dt.tzinfo is None:
+        raise ShadowCompareError(f"{field_name} must include timezone info")
+    return dt
+
+
+def _compute_fill_rate(fill_count: int, reject_count: int) -> Decimal:
+    total = fill_count + reject_count
+    if total == 0:
+        return Decimal("0").quantize(_RATE_Q)
+    return (Decimal(fill_count) / Decimal(total)).quantize(_RATE_Q)
+
+
+# ---------------------------------------------------------------------------
+# Input structs (caller-supplied; no live data access)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class PaperReferenceWindow:
+    """Explicit caller-supplied paper-trading reference window for comparison.
+
+    Callers are responsible for selecting a window that is meaningful for the
+    replay under comparison.  The comparison layer does not infer windows from
+    live DB or Redis.
+
+    provenance_id traces back to a specific paper run or export record and must
+    be non-empty; its format is not constrained beyond that.
+    """
+
+    symbol: str
+    strategy_id: str
+    window_start_utc: str
+    window_end_utc: str
+    signal_count: int
+    fill_count: int
+    reject_count: int
+    provenance_id: str
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.symbol, "symbol")
+        _require_non_empty_string(self.strategy_id, "strategy_id")
+        _require_non_empty_string(self.provenance_id, "provenance_id")
+        start = _parse_utc_datetime(self.window_start_utc, "window_start_utc")
+        end = _parse_utc_datetime(self.window_end_utc, "window_end_utc")
+        if end <= start:
+            raise ShadowCompareError(
+                "window_end_utc must be strictly after window_start_utc"
+            )
+        for name, val in (
+            ("signal_count", self.signal_count),
+            ("fill_count", self.fill_count),
+            ("reject_count", self.reject_count),
+        ):
+            _require_non_negative_int(val, name)
+
+    def to_dict(self) -> dict:
+        return {
+            "fill_count": self.fill_count,
+            "provenance_id": self.provenance_id,
+            "reject_count": self.reject_count,
+            "signal_count": self.signal_count,
+            "strategy_id": self.strategy_id,
+            "symbol": self.symbol,
+            "window_end_utc": self.window_end_utc,
+            "window_start_utc": self.window_start_utc,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayOutputWindow:
+    """Explicit caller-supplied replay output window for comparison.
+
+    Represents the observable output of a completed ARVP replay run,
+    distilled into count-oriented metrics for comparison against paper.
+    dataset_fingerprint must be the 64-char hex hash used in run_registry.
+    """
+
+    run_id: str
+    symbol: str
+    strategy_id: str
+    window_start_utc: str
+    window_end_utc: str
+    signal_count: int
+    fill_count: int
+    reject_count: int
+    dataset_fingerprint: str
+
+    def __post_init__(self) -> None:
+        if not _RUN_ID_RE.match(self.run_id):
+            raise ShadowCompareError(
+                "run_id must match 'replay-<12 hex>-<4 digit attempt>'"
+            )
+        _require_non_empty_string(self.symbol, "symbol")
+        _require_non_empty_string(self.strategy_id, "strategy_id")
+        start = _parse_utc_datetime(self.window_start_utc, "window_start_utc")
+        end = _parse_utc_datetime(self.window_end_utc, "window_end_utc")
+        if end <= start:
+            raise ShadowCompareError(
+                "window_end_utc must be strictly after window_start_utc"
+            )
+        for name, val in (
+            ("signal_count", self.signal_count),
+            ("fill_count", self.fill_count),
+            ("reject_count", self.reject_count),
+        ):
+            _require_non_negative_int(val, name)
+        if not _HEX_64_RE.match(self.dataset_fingerprint):
+            raise ShadowCompareError(
+                "dataset_fingerprint must be a 64-char lowercase hex hash"
+            )
+
+    def to_dict(self) -> dict:
+        return {
+            "dataset_fingerprint": self.dataset_fingerprint,
+            "fill_count": self.fill_count,
+            "reject_count": self.reject_count,
+            "run_id": self.run_id,
+            "signal_count": self.signal_count,
+            "strategy_id": self.strategy_id,
+            "symbol": self.symbol,
+            "window_end_utc": self.window_end_utc,
+            "window_start_utc": self.window_start_utc,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowComparisonResult:
+    """Machine-readable replay-vs-paper comparison result.
+
+    Produced by compare_windows() for aligned inputs only.
+    All count deltas are computed as (replay − paper).
+    fill_rate_delta = fill_rate_replay − fill_rate_paper.
+    comparison_fingerprint is a deterministic SHA-256 hash of both input windows.
+    alignment_issue is None for aligned results.
+    """
+
+    comparison_fingerprint: str
+    status: str  # always "aligned" when returned from compare_windows()
+    alignment_issue: str | None
+    replay_run_id: str
+    paper_provenance_id: str
+    symbol: str
+    strategy_id: str
+    signal_count_delta: int
+    fill_count_delta: int
+    reject_count_delta: int
+    fill_rate_replay: Decimal
+    fill_rate_paper: Decimal
+    fill_rate_delta: Decimal
+    window_start_utc_replay: str
+    window_end_utc_replay: str
+    window_start_utc_paper: str
+    window_end_utc_paper: str
+
+    def to_dict(self) -> dict:
+        result: dict = {
+            "comparison_fingerprint": self.comparison_fingerprint,
+            "fill_count_delta": self.fill_count_delta,
+            "fill_rate_delta": str(self.fill_rate_delta),
+            "fill_rate_paper": str(self.fill_rate_paper),
+            "fill_rate_replay": str(self.fill_rate_replay),
+            "paper_provenance_id": self.paper_provenance_id,
+            "reject_count_delta": self.reject_count_delta,
+            "replay_run_id": self.replay_run_id,
+            "signal_count_delta": self.signal_count_delta,
+            "status": self.status,
+            "strategy_id": self.strategy_id,
+            "symbol": self.symbol,
+            "window_end_utc_paper": self.window_end_utc_paper,
+            "window_end_utc_replay": self.window_end_utc_replay,
+            "window_start_utc_paper": self.window_start_utc_paper,
+            "window_start_utc_replay": self.window_start_utc_replay,
+        }
+        if self.alignment_issue is not None:
+            result["alignment_issue"] = self.alignment_issue
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compare_windows(
+    replay: ReplayOutputWindow,
+    paper: PaperReferenceWindow | None,
+) -> ShadowComparisonResult:
+    """Compare a replay output window against a paper-trading reference window.
+
+    Both sides must be explicitly provided by the caller.  The function is
+    pure and performs no I/O.
+
+    Raises:
+        ShadowCompareError: when paper is None (missing_reference), or when the
+            two windows cannot be meaningfully compared (misaligned) due to
+            symbol mismatch, strategy_id mismatch, or lack of temporal overlap.
+    """
+    if paper is None:
+        raise ShadowCompareError(
+            "missing_reference: no paper reference window supplied"
+        )
+    if replay.symbol != paper.symbol:
+        raise ShadowCompareError(
+            f"misaligned: symbol mismatch "
+            f"(replay={replay.symbol!r}, paper={paper.symbol!r})"
+        )
+    if replay.strategy_id != paper.strategy_id:
+        raise ShadowCompareError(
+            f"misaligned: strategy_id mismatch "
+            f"(replay={replay.strategy_id!r}, paper={paper.strategy_id!r})"
+        )
+
+    r_start = _parse_utc_datetime(replay.window_start_utc, "replay.window_start_utc")
+    r_end = _parse_utc_datetime(replay.window_end_utc, "replay.window_end_utc")
+    p_start = _parse_utc_datetime(paper.window_start_utc, "paper.window_start_utc")
+    p_end = _parse_utc_datetime(paper.window_end_utc, "paper.window_end_utc")
+
+    overlap_start = max(r_start, p_start)
+    overlap_end = min(r_end, p_end)
+    if overlap_end <= overlap_start:
+        raise ShadowCompareError(
+            f"misaligned: no temporal overlap between replay window "
+            f"({replay.window_start_utc} – {replay.window_end_utc}) "
+            f"and paper window "
+            f"({paper.window_start_utc} – {paper.window_end_utc})"
+        )
+
+    fill_rate_r = _compute_fill_rate(replay.fill_count, replay.reject_count)
+    fill_rate_p = _compute_fill_rate(paper.fill_count, paper.reject_count)
+    fill_rate_delta = (fill_rate_r - fill_rate_p).quantize(_RATE_Q)
+
+    fingerprint = canonical_hash({"paper": paper.to_dict(), "replay": replay.to_dict()})
+
+    return ShadowComparisonResult(
+        comparison_fingerprint=fingerprint,
+        status="aligned",
+        alignment_issue=None,
+        replay_run_id=replay.run_id,
+        paper_provenance_id=paper.provenance_id,
+        symbol=replay.symbol,
+        strategy_id=replay.strategy_id,
+        signal_count_delta=replay.signal_count - paper.signal_count,
+        fill_count_delta=replay.fill_count - paper.fill_count,
+        reject_count_delta=replay.reject_count - paper.reject_count,
+        fill_rate_replay=fill_rate_r,
+        fill_rate_paper=fill_rate_p,
+        fill_rate_delta=fill_rate_delta,
+        window_start_utc_replay=replay.window_start_utc,
+        window_end_utc_replay=replay.window_end_utc,
+        window_start_utc_paper=paper.window_start_utc,
+        window_end_utc_paper=paper.window_end_utc,
+    )
+
+
+def build_calibration_summary(result: ShadowComparisonResult) -> str:
+    """Build a concise operator-readable calibration summary.
+
+    Every line maps directly to a field in ShadowComparisonResult.
+    No invented narrative or subjective commentary.
+    """
+    lines = [
+        "# Replay-vs-Paper Calibration Summary",
+        "",
+        f"Status:           {result.status}",
+        f"Replay run:       {result.replay_run_id}",
+        f"Paper reference:  {result.paper_provenance_id}",
+        f"Symbol:           {result.symbol}",
+        f"Strategy:         {result.strategy_id}",
+        f"Fingerprint:      {result.comparison_fingerprint}",
+        "",
+        "## Window Alignment",
+        f"Replay:  {result.window_start_utc_replay} – {result.window_end_utc_replay}",
+        f"Paper:   {result.window_start_utc_paper} – {result.window_end_utc_paper}",
+        "",
+        "## Count Deltas (replay − paper)",
+        f"Signal count delta:  {result.signal_count_delta:+d}",
+        f"Fill count delta:    {result.fill_count_delta:+d}",
+        f"Reject count delta:  {result.reject_count_delta:+d}",
+        "",
+        "## Fill Rate",
+        f"Replay fill rate:  {result.fill_rate_replay}",
+        f"Paper fill rate:   {result.fill_rate_paper}",
+        f"Fill rate delta:   {result.fill_rate_delta:+}",
+    ]
+    if result.alignment_issue is not None:
+        lines += ["", f"Alignment issue: {result.alignment_issue}"]
+    return "\n".join(lines)
+
+
+def write_shadow_comparison_artifact(
+    result: ShadowComparisonResult,
+    artifact_root: str | pathlib.Path,
+) -> None:
+    """Write shadow_comparison.json into artifact_root.  Fail-closed on I/O errors."""
+    artifact_root = pathlib.Path(artifact_root)
+    try:
+        artifact_root.mkdir(parents=True, exist_ok=True)
+        out_path = artifact_root / _SHADOW_COMPARISON_FILENAME
+        out_path.write_text(canonical_json_dumps(result.to_dict()), encoding="utf-8")
+    except OSError as exc:
+        raise ShadowCompareError(
+            f"Failed to write {_SHADOW_COMPARISON_FILENAME} to {artifact_root}: {exc}"
+        ) from exc

--- a/tests/unit/replay/test_shadow_compare.py
+++ b/tests/unit/replay/test_shadow_compare.py
@@ -1,0 +1,453 @@
+"""Unit tests for core/replay/shadow_compare.py (#1848).
+
+Coverage:
+  - PaperReferenceWindow validation
+  - ReplayOutputWindow validation
+  - compare_windows: aligned, missing reference, symbol/strategy mismatch,
+    non-overlapping windows, partial overlap, adjacent windows, zero counts
+  - Deterministic fingerprint: identical inputs → same fingerprint;
+    different inputs → different fingerprint
+  - fill_rate_delta type and correctness
+  - build_calibration_summary: content grounding
+  - write_shadow_comparison_artifact: artifact written, fail-closed on I/O error
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from decimal import Decimal
+
+import pytest
+
+from core.replay.shadow_compare import (
+    PaperReferenceWindow,
+    ReplayOutputWindow,
+    ShadowCompareError,
+    ShadowComparisonResult,
+    build_calibration_summary,
+    compare_windows,
+    write_shadow_comparison_artifact,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_FP = "a" * 64  # valid 64-char hex dataset_fingerprint
+_RUN_ID = "replay-aabbccddee11-0001"
+
+_START = "2024-01-01T00:00:00+00:00"
+_END = "2024-01-02T00:00:00+00:00"
+_SYMBOL = "BTCUSDT"
+_STRATEGY = "momentum-v1"
+
+
+def _make_replay(**kw) -> ReplayOutputWindow:
+    defaults = dict(
+        run_id=_RUN_ID,
+        symbol=_SYMBOL,
+        strategy_id=_STRATEGY,
+        window_start_utc=_START,
+        window_end_utc=_END,
+        signal_count=10,
+        fill_count=8,
+        reject_count=2,
+        dataset_fingerprint=_FP,
+    )
+    defaults.update(kw)
+    return ReplayOutputWindow(**defaults)
+
+
+def _make_paper(**kw) -> PaperReferenceWindow:
+    defaults = dict(
+        symbol=_SYMBOL,
+        strategy_id=_STRATEGY,
+        window_start_utc=_START,
+        window_end_utc=_END,
+        signal_count=12,
+        fill_count=9,
+        reject_count=3,
+        provenance_id="paper-run-001",
+    )
+    defaults.update(kw)
+    return PaperReferenceWindow(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# PaperReferenceWindow validation
+# ---------------------------------------------------------------------------
+
+
+class TestPaperReferenceWindow:
+    def test_valid_construction(self):
+        w = _make_paper()
+        assert w.symbol == _SYMBOL
+        assert w.strategy_id == _STRATEGY
+        assert w.signal_count == 12
+
+    def test_empty_symbol_raises(self):
+        with pytest.raises(ShadowCompareError, match="symbol"):
+            _make_paper(symbol="")
+
+    def test_empty_strategy_id_raises(self):
+        with pytest.raises(ShadowCompareError, match="strategy_id"):
+            _make_paper(strategy_id="  ")
+
+    def test_empty_provenance_id_raises(self):
+        with pytest.raises(ShadowCompareError, match="provenance_id"):
+            _make_paper(provenance_id="")
+
+    def test_end_before_start_raises(self):
+        with pytest.raises(ShadowCompareError, match="strictly after"):
+            _make_paper(window_start_utc=_END, window_end_utc=_START)
+
+    def test_equal_start_end_raises(self):
+        with pytest.raises(ShadowCompareError, match="strictly after"):
+            _make_paper(window_start_utc=_START, window_end_utc=_START)
+
+    def test_missing_timezone_raises(self):
+        with pytest.raises(ShadowCompareError, match="timezone"):
+            _make_paper(window_start_utc="2024-01-01T00:00:00")
+
+    def test_negative_signal_count_raises(self):
+        with pytest.raises(ShadowCompareError, match="signal_count"):
+            _make_paper(signal_count=-1)
+
+    def test_negative_fill_count_raises(self):
+        with pytest.raises(ShadowCompareError, match="fill_count"):
+            _make_paper(fill_count=-1)
+
+    def test_negative_reject_count_raises(self):
+        with pytest.raises(ShadowCompareError, match="reject_count"):
+            _make_paper(reject_count=-1)
+
+    def test_bool_count_raises(self):
+        with pytest.raises(ShadowCompareError, match="signal_count"):
+            _make_paper(signal_count=True)
+
+
+# ---------------------------------------------------------------------------
+# ReplayOutputWindow validation
+# ---------------------------------------------------------------------------
+
+
+class TestReplayOutputWindow:
+    def test_valid_construction(self):
+        w = _make_replay()
+        assert w.run_id == _RUN_ID
+        assert w.dataset_fingerprint == _FP
+
+    def test_invalid_run_id_raises(self):
+        with pytest.raises(ShadowCompareError, match="run_id"):
+            _make_replay(run_id="not-valid")
+
+    def test_invalid_dataset_fingerprint_raises(self):
+        with pytest.raises(ShadowCompareError, match="dataset_fingerprint"):
+            _make_replay(dataset_fingerprint="short")
+
+    def test_uppercase_fingerprint_raises(self):
+        with pytest.raises(ShadowCompareError, match="dataset_fingerprint"):
+            _make_replay(dataset_fingerprint="A" * 64)
+
+    def test_end_before_start_raises(self):
+        with pytest.raises(ShadowCompareError, match="strictly after"):
+            _make_replay(window_start_utc=_END, window_end_utc=_START)
+
+    def test_negative_count_raises(self):
+        with pytest.raises(ShadowCompareError, match="fill_count"):
+            _make_replay(fill_count=-1)
+
+    def test_bool_count_raises(self):
+        with pytest.raises(ShadowCompareError, match="reject_count"):
+            _make_replay(reject_count=False)
+
+
+# ---------------------------------------------------------------------------
+# compare_windows: success path
+# ---------------------------------------------------------------------------
+
+
+class TestCompareWindowsAligned:
+    def test_status_is_aligned(self):
+        result = compare_windows(_make_replay(), _make_paper())
+        assert result.status == "aligned"
+
+    def test_alignment_issue_is_none(self):
+        result = compare_windows(_make_replay(), _make_paper())
+        assert result.alignment_issue is None
+
+    def test_signal_count_delta(self):
+        result = compare_windows(_make_replay(), _make_paper())
+        # replay=10, paper=12  →  10 - 12 = -2
+        assert result.signal_count_delta == -2
+
+    def test_fill_count_delta(self):
+        result = compare_windows(_make_replay(), _make_paper())
+        # replay=8, paper=9  →  8 - 9 = -1
+        assert result.fill_count_delta == -1
+
+    def test_reject_count_delta(self):
+        result = compare_windows(_make_replay(), _make_paper())
+        # replay=2, paper=3  →  2 - 3 = -1
+        assert result.reject_count_delta == -1
+
+    def test_fill_rate_replay(self):
+        result = compare_windows(_make_replay(), _make_paper())
+        # replay: 8 / (8+2) = 0.8
+        assert result.fill_rate_replay == Decimal("0.80000000")
+
+    def test_fill_rate_paper(self):
+        result = compare_windows(_make_replay(), _make_paper())
+        # paper: 9 / (9+3) = 0.75
+        assert result.fill_rate_paper == Decimal("0.75000000")
+
+    def test_fill_rate_delta_value(self):
+        result = compare_windows(_make_replay(), _make_paper())
+        # 0.80000000 - 0.75000000 = 0.05000000
+        assert result.fill_rate_delta == Decimal("0.05000000")
+
+    def test_fill_rate_delta_is_decimal(self):
+        result = compare_windows(_make_replay(), _make_paper())
+        assert isinstance(result.fill_rate_delta, Decimal)
+        assert isinstance(result.fill_rate_replay, Decimal)
+        assert isinstance(result.fill_rate_paper, Decimal)
+
+    def test_provenance_fields(self):
+        result = compare_windows(_make_replay(), _make_paper())
+        assert result.replay_run_id == _RUN_ID
+        assert result.paper_provenance_id == "paper-run-001"
+        assert result.symbol == _SYMBOL
+        assert result.strategy_id == _STRATEGY
+
+    def test_window_timestamps_preserved(self):
+        result = compare_windows(_make_replay(), _make_paper())
+        assert result.window_start_utc_replay == _START
+        assert result.window_end_utc_replay == _END
+        assert result.window_start_utc_paper == _START
+        assert result.window_end_utc_paper == _END
+
+    def test_comparison_fingerprint_is_hex_string(self):
+        result = compare_windows(_make_replay(), _make_paper())
+        assert isinstance(result.comparison_fingerprint, str)
+        assert len(result.comparison_fingerprint) == 64
+        assert all(c in "0123456789abcdef" for c in result.comparison_fingerprint)
+
+    def test_zero_counts_no_error(self):
+        # fill_rate must not divide by zero when counts are both 0
+        r = _make_replay(signal_count=0, fill_count=0, reject_count=0)
+        p = _make_paper(signal_count=0, fill_count=0, reject_count=0)
+        result = compare_windows(r, p)
+        assert result.fill_rate_replay == Decimal("0.00000000")
+        assert result.fill_rate_paper == Decimal("0.00000000")
+        assert result.fill_rate_delta == Decimal("0.00000000")
+
+    def test_partial_overlap_is_aligned(self):
+        # Replay: 2024-01-01 → 2024-01-03; Paper: 2024-01-02 → 2024-01-04
+        # They overlap on 2024-01-02 → 2024-01-03
+        r = _make_replay(
+            window_start_utc="2024-01-01T00:00:00+00:00",
+            window_end_utc="2024-01-03T00:00:00+00:00",
+        )
+        p = _make_paper(
+            window_start_utc="2024-01-02T00:00:00+00:00",
+            window_end_utc="2024-01-04T00:00:00+00:00",
+        )
+        result = compare_windows(r, p)
+        assert result.status == "aligned"
+
+
+# ---------------------------------------------------------------------------
+# compare_windows: fail-closed paths
+# ---------------------------------------------------------------------------
+
+
+class TestCompareWindowsFailClosed:
+    def test_missing_paper_raises(self):
+        with pytest.raises(ShadowCompareError, match="missing_reference"):
+            compare_windows(_make_replay(), None)
+
+    def test_symbol_mismatch_raises(self):
+        with pytest.raises(ShadowCompareError, match="misaligned.*symbol"):
+            compare_windows(_make_replay(), _make_paper(symbol="ETHUSDT"))
+
+    def test_strategy_mismatch_raises(self):
+        with pytest.raises(ShadowCompareError, match="misaligned.*strategy_id"):
+            compare_windows(_make_replay(), _make_paper(strategy_id="other-v2"))
+
+    def test_non_overlapping_windows_raises(self):
+        # Paper window is entirely before replay window
+        p = _make_paper(
+            window_start_utc="2023-12-01T00:00:00+00:00",
+            window_end_utc="2023-12-31T00:00:00+00:00",
+        )
+        with pytest.raises(ShadowCompareError, match="misaligned.*temporal overlap"):
+            compare_windows(_make_replay(), p)
+
+    def test_adjacent_windows_raises(self):
+        # Paper ends exactly where replay starts — no actual shared period
+        p = _make_paper(
+            window_start_utc="2023-12-31T00:00:00+00:00",
+            window_end_utc="2024-01-01T00:00:00+00:00",  # == replay start
+        )
+        with pytest.raises(ShadowCompareError, match="misaligned.*temporal overlap"):
+            compare_windows(_make_replay(), p)
+
+    def test_future_paper_window_raises(self):
+        p = _make_paper(
+            window_start_utc="2024-01-03T00:00:00+00:00",
+            window_end_utc="2024-01-04T00:00:00+00:00",
+        )
+        with pytest.raises(ShadowCompareError, match="misaligned.*temporal overlap"):
+            compare_windows(_make_replay(), p)
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_identical_inputs_produce_same_fingerprint(self):
+        r1 = compare_windows(_make_replay(), _make_paper())
+        r2 = compare_windows(_make_replay(), _make_paper())
+        assert r1.comparison_fingerprint == r2.comparison_fingerprint
+
+    def test_different_signal_counts_produce_different_fingerprint(self):
+        r1 = compare_windows(_make_replay(signal_count=10), _make_paper())
+        r2 = compare_windows(_make_replay(signal_count=99), _make_paper())
+        assert r1.comparison_fingerprint != r2.comparison_fingerprint
+
+    def test_different_paper_provenance_produces_different_fingerprint(self):
+        r1 = compare_windows(_make_replay(), _make_paper(provenance_id="paper-A"))
+        r2 = compare_windows(_make_replay(), _make_paper(provenance_id="paper-B"))
+        assert r1.comparison_fingerprint != r2.comparison_fingerprint
+
+    def test_all_result_fields_are_deterministic(self):
+        r1 = compare_windows(_make_replay(), _make_paper())
+        r2 = compare_windows(_make_replay(), _make_paper())
+        assert r1 == r2  # frozen dataclass equality
+
+
+# ---------------------------------------------------------------------------
+# build_calibration_summary
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCalibrationSummary:
+    @pytest.fixture
+    def result(self) -> ShadowComparisonResult:
+        return compare_windows(_make_replay(), _make_paper())
+
+    def test_contains_status(self, result):
+        summary = build_calibration_summary(result)
+        assert "aligned" in summary
+
+    def test_contains_replay_run_id(self, result):
+        summary = build_calibration_summary(result)
+        assert result.replay_run_id in summary
+
+    def test_contains_paper_provenance_id(self, result):
+        summary = build_calibration_summary(result)
+        assert result.paper_provenance_id in summary
+
+    def test_contains_symbol(self, result):
+        summary = build_calibration_summary(result)
+        assert result.symbol in summary
+
+    def test_contains_signal_count_delta(self, result):
+        summary = build_calibration_summary(result)
+        # delta is -2, formatted as -2
+        assert "-2" in summary
+
+    def test_contains_fill_count_delta(self, result):
+        summary = build_calibration_summary(result)
+        assert "-1" in summary
+
+    def test_contains_fill_rate_values(self, result):
+        summary = build_calibration_summary(result)
+        assert "0.80000000" in summary
+        assert "0.75000000" in summary
+
+    def test_contains_fill_rate_delta(self, result):
+        summary = build_calibration_summary(result)
+        assert "0.05000000" in summary
+
+    def test_contains_fingerprint(self, result):
+        summary = build_calibration_summary(result)
+        assert result.comparison_fingerprint in summary
+
+    def test_contains_window_timestamps(self, result):
+        summary = build_calibration_summary(result)
+        assert result.window_start_utc_replay in summary
+        assert result.window_start_utc_paper in summary
+
+    def test_returns_string(self, result):
+        assert isinstance(build_calibration_summary(result), str)
+
+
+# ---------------------------------------------------------------------------
+# write_shadow_comparison_artifact
+# ---------------------------------------------------------------------------
+
+
+class TestWriteShadowComparisonArtifact:
+    @pytest.fixture
+    def result(self) -> ShadowComparisonResult:
+        return compare_windows(_make_replay(), _make_paper())
+
+    def test_writes_file(self, tmp_path, result):
+        write_shadow_comparison_artifact(result, tmp_path)
+        artifact = tmp_path / "shadow_comparison.json"
+        assert artifact.exists()
+
+    def test_writes_valid_json(self, tmp_path, result):
+        write_shadow_comparison_artifact(result, tmp_path)
+        raw = (tmp_path / "shadow_comparison.json").read_text(encoding="utf-8")
+        data = json.loads(raw)
+        assert isinstance(data, dict)
+
+    def test_json_contains_required_keys(self, tmp_path, result):
+        write_shadow_comparison_artifact(result, tmp_path)
+        data = json.loads((tmp_path / "shadow_comparison.json").read_text())
+        for key in (
+            "comparison_fingerprint",
+            "status",
+            "replay_run_id",
+            "paper_provenance_id",
+            "symbol",
+            "strategy_id",
+            "signal_count_delta",
+            "fill_count_delta",
+            "reject_count_delta",
+            "fill_rate_replay",
+            "fill_rate_paper",
+            "fill_rate_delta",
+        ):
+            assert key in data, f"Missing key: {key}"
+
+    def test_json_fill_rate_delta_is_string(self, tmp_path, result):
+        write_shadow_comparison_artifact(result, tmp_path)
+        data = json.loads((tmp_path / "shadow_comparison.json").read_text())
+        assert isinstance(data["fill_rate_delta"], str)
+        assert isinstance(data["fill_rate_replay"], str)
+        assert isinstance(data["fill_rate_paper"], str)
+
+    def test_json_is_deterministic(self, tmp_path, result):
+        write_shadow_comparison_artifact(result, tmp_path / "a")
+        write_shadow_comparison_artifact(result, tmp_path / "b")
+        text_a = (tmp_path / "a" / "shadow_comparison.json").read_text()
+        text_b = (tmp_path / "b" / "shadow_comparison.json").read_text()
+        assert text_a == text_b
+
+    def test_creates_artifact_root_if_missing(self, tmp_path, result):
+        nested = tmp_path / "deep" / "nested"
+        write_shadow_comparison_artifact(result, nested)
+        assert (nested / "shadow_comparison.json").exists()
+
+    def test_fail_closed_on_io_error(self, tmp_path, result):
+        # Create a file where a directory is expected → mkdir raises OSError
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory")
+        with pytest.raises(ShadowCompareError, match="Failed to write"):
+            write_shadow_comparison_artifact(result, blocker)


### PR DESCRIPTION
## Summary
- add a pure, deterministic replay-vs-paper comparison core with explicit fail-closed semantics
- model both comparison sides as caller-supplied structs (PaperReferenceWindow, ReplayOutputWindow) with no DB/Redis dependency
- implement compare_windows() pure and fail-closed on missing reference, symbol/strategy mismatch, and non-overlapping windows
- produce deterministic comparison_fingerprint, ill_rate_delta as Decimal, and alignment classification
- add fail-closed shadow_comparison.json writing and operator-readable calibration summary builder
- cover all comparison paths with focused unit tests

## Validation
- \python -m pytest tests/unit/replay/test_shadow_compare.py -q\
- \60 passed\

## Scope notes
- includes only the \#1848\ shadow comparison core slice
- no changes to existing files
- no DB/Redis wiring, no reporter changes, no runtime changes
- unrelated local untracked files were not touched

Closes #1848