### PR TITLE
feat(arvp): add counterfactual replay perturbation core (#1850)

### DIFF
--- a/core/replay/counterfactual.py
+++ b/core/replay/counterfactual.py
@@ -1,0 +1,388 @@
+"""
+Counterfactual perturbation engine for ARVP (#1850).
+
+Pure, fail-closed, deterministic "same day, but..." perturbation analysis
+on caller-supplied replay baselines. No Runtime, DB, or Redis wiring.
+
+Perturbation types:
+  slippage_bps        [0, 10000]  -- fill attrition via spread shock
+  entry_delay_bars    [1, 1000]   -- signal loss via delayed entry
+  fill_rate_reduction [0, 1]      -- direct fill fraction reduction
+  feed_gap_bars       [1, 10000]  -- signal loss via feed outage
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import ROUND_DOWN, Decimal
+from pathlib import Path
+from typing import Sequence
+
+from core.replay.canonical_json import canonical_hash, canonical_json_dumps
+
+
+class CounterfactualError(Exception):
+    """Raised on invalid input, out-of-range magnitude, or I/O failure."""
+
+
+# ---------------------------------------------------------------------------
+# Perturbation type registry
+# ---------------------------------------------------------------------------
+
+_VALID_TYPES: frozenset[str] = frozenset(
+    {"slippage_bps", "entry_delay_bars", "fill_rate_reduction", "feed_gap_bars"}
+)
+
+_MAGNITUDE_BOUNDS: dict[str, tuple[Decimal, Decimal]] = {
+    "slippage_bps": (Decimal("0"), Decimal("10000")),
+    "entry_delay_bars": (Decimal("1"), Decimal("1000")),
+    "fill_rate_reduction": (Decimal("0"), Decimal("1")),
+    "feed_gap_bars": (Decimal("1"), Decimal("10000")),
+}
+
+
+# ---------------------------------------------------------------------------
+# Domain structs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PerturbationSpec:
+    """A single, validated perturbation instruction."""
+
+    perturbation_type: str
+    magnitude: Decimal
+
+    def __post_init__(self) -> None:
+        if self.perturbation_type not in _VALID_TYPES:
+            raise CounterfactualError(
+                f"unknown perturbation type: {self.perturbation_type!r}; "
+                f"valid types: {sorted(_VALID_TYPES)}"
+            )
+        lo, hi = _MAGNITUDE_BOUNDS[self.perturbation_type]
+        if not (lo <= self.magnitude <= hi):
+            raise CounterfactualError(
+                f"magnitude {self.magnitude} out of range [{lo}, {hi}] "
+                f"for type {self.perturbation_type!r}"
+            )
+
+    def to_dict(self) -> dict:
+        return {
+            "magnitude": str(self.magnitude),
+            "perturbation_type": self.perturbation_type,
+        }
+
+
+@dataclass(frozen=True)
+class CounterfactualBaseWindow:
+    """Caller-supplied replay baseline. Validated at construction time."""
+
+    symbol: str
+    strategy_id: str
+    window_start: str
+    window_end: str
+    signal_count: int
+    fill_count: int
+    reject_count: int
+    fill_rate: Decimal
+
+    def __post_init__(self) -> None:
+        if not self.symbol:
+            raise CounterfactualError("symbol must not be empty")
+        if not self.strategy_id:
+            raise CounterfactualError("strategy_id must not be empty")
+        if not self.window_start:
+            raise CounterfactualError("window_start must not be empty")
+        if not self.window_end:
+            raise CounterfactualError("window_end must not be empty")
+        if self.signal_count < 0:
+            raise CounterfactualError("signal_count must be >= 0")
+        if self.fill_count < 0:
+            raise CounterfactualError("fill_count must be >= 0")
+        if self.reject_count < 0:
+            raise CounterfactualError("reject_count must be >= 0")
+        if not (Decimal("0") <= self.fill_rate <= Decimal("1")):
+            raise CounterfactualError("fill_rate must be in [0, 1]")
+
+    def to_dict(self) -> dict:
+        return {
+            "fill_count": self.fill_count,
+            "fill_rate": str(self.fill_rate),
+            "reject_count": self.reject_count,
+            "signal_count": self.signal_count,
+            "strategy_id": self.strategy_id,
+            "symbol": self.symbol,
+            "window_end": self.window_end,
+            "window_start": self.window_start,
+        }
+
+
+@dataclass(frozen=True)
+class CounterfactualResult:
+    """Immutable result of applying a perturbation sequence to a base window."""
+
+    symbol: str
+    strategy_id: str
+    window_start: str
+    window_end: str
+    # Base (unperturbed) stats
+    base_signal_count: int
+    base_fill_count: int
+    base_reject_count: int
+    base_fill_rate: Decimal
+    # Perturbed stats
+    perturbed_signal_count: int
+    perturbed_fill_count: int
+    perturbed_reject_count: int
+    perturbed_fill_rate: Decimal
+    # Deltas (perturbed - base)
+    signal_count_delta: int
+    fill_count_delta: int
+    reject_count_delta: int
+    fill_rate_delta: Decimal
+    # Metadata
+    applied_perturbation_types: tuple  # sorted, deduplicated
+    provenance_fingerprint: str
+
+    def to_dict(self) -> dict:
+        return {
+            "applied_perturbation_types": list(self.applied_perturbation_types),
+            "base_fill_count": self.base_fill_count,
+            "base_fill_rate": str(self.base_fill_rate),
+            "base_reject_count": self.base_reject_count,
+            "base_signal_count": self.base_signal_count,
+            "fill_count_delta": self.fill_count_delta,
+            "fill_rate_delta": str(self.fill_rate_delta),
+            "perturbed_fill_count": self.perturbed_fill_count,
+            "perturbed_fill_rate": str(self.perturbed_fill_rate),
+            "perturbed_reject_count": self.perturbed_reject_count,
+            "perturbed_signal_count": self.perturbed_signal_count,
+            "provenance_fingerprint": self.provenance_fingerprint,
+            "reject_count_delta": self.reject_count_delta,
+            "signal_count_delta": self.signal_count_delta,
+            "strategy_id": self.strategy_id,
+            "symbol": self.symbol,
+            "window_end": self.window_end,
+            "window_start": self.window_start,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Internal perturbation handlers — pure functions
+# ---------------------------------------------------------------------------
+
+
+def _apply_slippage_bps(
+    signal: int, fill: int, reject: int, magnitude: Decimal
+) -> tuple[int, int, int]:
+    """Signal unchanged; fills lost proportionally to bps; lost fills become rejects."""
+    fills_lost = int(
+        (Decimal(fill) * magnitude / Decimal("10000")).to_integral_value(
+            rounding=ROUND_DOWN
+        )
+    )
+    return signal, max(0, fill - fills_lost), reject + fills_lost
+
+
+def _apply_entry_delay_bars(
+    signal: int, fill: int, reject: int, magnitude: Decimal
+) -> tuple[int, int, int]:
+    """Signal drops by 1% per bar; surviving signals retain original fill/reject ratio."""
+    fraction_retained = max(
+        Decimal("0"), Decimal("1") - magnitude * Decimal("0.01")
+    )
+    new_signal = int(
+        (Decimal(signal) * fraction_retained).to_integral_value(rounding=ROUND_DOWN)
+    )
+    new_signal = max(0, new_signal)
+    if signal > 0:
+        fill_fraction = Decimal(fill) / Decimal(signal)
+        new_fill = int(
+            (Decimal(new_signal) * fill_fraction).to_integral_value(rounding=ROUND_DOWN)
+        )
+    else:
+        new_fill = 0
+    new_fill = max(0, new_fill)
+    new_reject = max(0, new_signal - new_fill)
+    return new_signal, new_fill, new_reject
+
+
+def _apply_fill_rate_reduction(
+    signal: int, fill: int, reject: int, magnitude: Decimal
+) -> tuple[int, int, int]:
+    """Signal unchanged; magnitude fraction of fills converted to rejects."""
+    fills_lost = int(
+        (Decimal(fill) * magnitude).to_integral_value(rounding=ROUND_DOWN)
+    )
+    return signal, max(0, fill - fills_lost), reject + fills_lost
+
+
+def _apply_feed_gap_bars(
+    signal: int, fill: int, reject: int, magnitude: Decimal
+) -> tuple[int, int, int]:
+    """Signal drops by 0.5% per bar; surviving signals retain original fill/reject ratio."""
+    fraction_retained = max(
+        Decimal("0"), Decimal("1") - magnitude * Decimal("0.005")
+    )
+    new_signal = int(
+        (Decimal(signal) * fraction_retained).to_integral_value(rounding=ROUND_DOWN)
+    )
+    new_signal = max(0, new_signal)
+    if signal > 0:
+        fill_fraction = Decimal(fill) / Decimal(signal)
+        new_fill = int(
+            (Decimal(new_signal) * fill_fraction).to_integral_value(rounding=ROUND_DOWN)
+        )
+    else:
+        new_fill = 0
+    new_fill = max(0, new_fill)
+    new_reject = max(0, new_signal - new_fill)
+    return new_signal, new_fill, new_reject
+
+
+_PERTURBATION_HANDLERS: dict = {
+    "slippage_bps": _apply_slippage_bps,
+    "entry_delay_bars": _apply_entry_delay_bars,
+    "fill_rate_reduction": _apply_fill_rate_reduction,
+    "feed_gap_bars": _apply_feed_gap_bars,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def apply_perturbations(
+    base: CounterfactualBaseWindow,
+    specs: Sequence[PerturbationSpec],
+) -> CounterfactualResult:
+    """Apply a sequence of perturbations to the base window.
+
+    Pure and fail-closed. Perturbations are applied sequentially; each
+    handler receives the accumulated perturbed state from prior steps.
+    All counts are clamped to 0 after each step.
+
+    Args:
+        base: Validated baseline replay window.
+        specs: Non-empty sequence of perturbation specs to apply in order.
+
+    Returns:
+        CounterfactualResult with perturbed stats, deltas, and a
+        deterministic provenance fingerprint.
+
+    Raises:
+        CounterfactualError: If base is None, specs is empty, or any spec
+            is invalid (caught at PerturbationSpec construction time).
+    """
+    if base is None:
+        raise CounterfactualError("base must not be None")
+    if not specs:
+        raise CounterfactualError(
+            "no perturbations specified; provide at least one PerturbationSpec"
+        )
+
+    fingerprint = canonical_hash(
+        {
+            "base": base.to_dict(),
+            "perturbations": [s.to_dict() for s in specs],
+        }
+    )
+
+    signal = base.signal_count
+    fill = base.fill_count
+    reject = base.reject_count
+
+    applied_types: list[str] = []
+    for spec in specs:
+        handler = _PERTURBATION_HANDLERS[spec.perturbation_type]
+        signal, fill, reject = handler(signal, fill, reject, spec.magnitude)
+        # Safety clamp after each step
+        signal = max(0, signal)
+        fill = max(0, fill)
+        reject = max(0, reject)
+        applied_types.append(spec.perturbation_type)
+
+    perturbed_fill_rate = (
+        Decimal(fill) / Decimal(signal) if signal > 0 else Decimal("0")
+    )
+
+    return CounterfactualResult(
+        symbol=base.symbol,
+        strategy_id=base.strategy_id,
+        window_start=base.window_start,
+        window_end=base.window_end,
+        base_signal_count=base.signal_count,
+        base_fill_count=base.fill_count,
+        base_reject_count=base.reject_count,
+        base_fill_rate=base.fill_rate,
+        perturbed_signal_count=signal,
+        perturbed_fill_count=fill,
+        perturbed_reject_count=reject,
+        perturbed_fill_rate=perturbed_fill_rate,
+        signal_count_delta=signal - base.signal_count,
+        fill_count_delta=fill - base.fill_count,
+        reject_count_delta=reject - base.reject_count,
+        fill_rate_delta=perturbed_fill_rate - base.fill_rate,
+        applied_perturbation_types=tuple(sorted(set(applied_types))),
+        provenance_fingerprint=fingerprint,
+    )
+
+
+def build_perturbation_summary(result: CounterfactualResult) -> str:
+    """Return an operator-readable, metrically grounded perturbation summary.
+
+    Strictly metric — no ungrounded narrative. All deltas are explicit.
+    """
+    lines = [
+        "Counterfactual Perturbation Summary",
+        "===================================",
+        f"Symbol:              {result.symbol}",
+        f"Strategy:            {result.strategy_id}",
+        f"Window:              {result.window_start} -> {result.window_end}",
+        f"Applied types:       {', '.join(result.applied_perturbation_types)}",
+        "",
+        "Base stats:",
+        f"  signals:           {result.base_signal_count}",
+        f"  fills:             {result.base_fill_count}",
+        f"  rejects:           {result.base_reject_count}",
+        f"  fill_rate:         {result.base_fill_rate}",
+        "",
+        "Perturbed stats:",
+        f"  signals:           {result.perturbed_signal_count}",
+        f"  fills:             {result.perturbed_fill_count}",
+        f"  rejects:           {result.perturbed_reject_count}",
+        f"  fill_rate:         {result.perturbed_fill_rate}",
+        "",
+        "Deltas:",
+        f"  signal_delta:      {result.signal_count_delta:+d}",
+        f"  fill_delta:        {result.fill_count_delta:+d}",
+        f"  reject_delta:      {result.reject_count_delta:+d}",
+        f"  fill_rate_delta:   {result.fill_rate_delta}",
+        "",
+        f"Fingerprint:         {result.provenance_fingerprint}",
+    ]
+    return "\n".join(lines)
+
+
+def write_counterfactual_artifact(
+    result: CounterfactualResult, artifact_root: Path
+) -> None:
+    """Write counterfactual_result.json to artifact_root. Fail-closed on I/O error.
+
+    Args:
+        result: Completed CounterfactualResult to serialize.
+        artifact_root: Directory to write the artifact into (created if absent).
+
+    Raises:
+        CounterfactualError: On any I/O failure.
+    """
+    try:
+        artifact_root = Path(artifact_root)
+        artifact_root.mkdir(parents=True, exist_ok=True)
+        out_path = artifact_root / "counterfactual_result.json"
+        payload = canonical_json_dumps(result.to_dict())
+        out_path.write_text(payload, encoding="utf-8")
+    except (OSError, IOError) as exc:
+        raise CounterfactualError(
+            f"failed to write counterfactual artifact to {artifact_root}: {exc}"
+        ) from exc

--- a/tests/unit/replay/test_counterfactual.py
+++ b/tests/unit/replay/test_counterfactual.py
@@ -1,0 +1,654 @@
+"""Unit tests for core.replay.counterfactual (#1850).
+
+Covers: perturbation validation, all 4 perturbation types with exact deltas,
+sequential composition, fingerprint determinism, Decimal correctness,
+artifact writing (valid JSON + fail-closed), and summary content.
+"""
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from core.replay.counterfactual import (
+    CounterfactualBaseWindow,
+    CounterfactualError,
+    CounterfactualResult,
+    PerturbationSpec,
+    apply_perturbations,
+    build_perturbation_summary,
+    write_counterfactual_artifact,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_base(
+    symbol: str = "BTCUSDT",
+    strategy_id: str = "strat_test",
+    signal_count: int = 100,
+    fill_count: int = 80,
+    reject_count: int = 20,
+    fill_rate: str = "0.8",
+    window_start: str = "2024-01-01T00:00:00Z",
+    window_end: str = "2024-01-02T00:00:00Z",
+) -> CounterfactualBaseWindow:
+    return CounterfactualBaseWindow(
+        symbol=symbol,
+        strategy_id=strategy_id,
+        window_start=window_start,
+        window_end=window_end,
+        signal_count=signal_count,
+        fill_count=fill_count,
+        reject_count=reject_count,
+        fill_rate=Decimal(fill_rate),
+    )
+
+
+def _spec(perturbation_type: str, magnitude: str) -> PerturbationSpec:
+    return PerturbationSpec(
+        perturbation_type=perturbation_type, magnitude=Decimal(magnitude)
+    )
+
+
+# ===========================================================================
+# TestPerturbationSpecValidation
+# ===========================================================================
+
+
+class TestPerturbationSpecValidation:
+    def test_unknown_type_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="unknown perturbation type"):
+            _spec("random_perturbation", "1")
+
+    def test_slippage_bps_below_zero_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="out of range"):
+            _spec("slippage_bps", "-1")
+
+    def test_slippage_bps_above_max_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="out of range"):
+            _spec("slippage_bps", "10001")
+
+    def test_entry_delay_bars_below_one_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="out of range"):
+            _spec("entry_delay_bars", "0")
+
+    def test_entry_delay_bars_above_max_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="out of range"):
+            _spec("entry_delay_bars", "1001")
+
+    def test_fill_rate_reduction_below_zero_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="out of range"):
+            _spec("fill_rate_reduction", "-0.01")
+
+    def test_fill_rate_reduction_above_one_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="out of range"):
+            _spec("fill_rate_reduction", "1.001")
+
+    def test_feed_gap_bars_below_one_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="out of range"):
+            _spec("feed_gap_bars", "0")
+
+    def test_feed_gap_bars_above_max_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="out of range"):
+            _spec("feed_gap_bars", "10001")
+
+    def test_valid_spec_construction(self) -> None:
+        spec = _spec("slippage_bps", "500")
+        assert spec.perturbation_type == "slippage_bps"
+        assert spec.magnitude == Decimal("500")
+
+    def test_boundary_values_are_valid(self) -> None:
+        _spec("slippage_bps", "0")
+        _spec("slippage_bps", "10000")
+        _spec("fill_rate_reduction", "0")
+        _spec("fill_rate_reduction", "1")
+        _spec("entry_delay_bars", "1")
+        _spec("entry_delay_bars", "1000")
+        _spec("feed_gap_bars", "1")
+        _spec("feed_gap_bars", "10000")
+
+    def test_to_dict_has_string_magnitude(self) -> None:
+        spec = _spec("slippage_bps", "500")
+        d = spec.to_dict()
+        assert isinstance(d["magnitude"], str)
+        assert d["perturbation_type"] == "slippage_bps"
+
+
+# ===========================================================================
+# TestCounterfactualBaseWindowValidation
+# ===========================================================================
+
+
+class TestCounterfactualBaseWindowValidation:
+    def test_empty_symbol_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="symbol must not be empty"):
+            CounterfactualBaseWindow(
+                symbol="",
+                strategy_id="strat",
+                window_start="2024-01-01T00:00:00Z",
+                window_end="2024-01-02T00:00:00Z",
+                signal_count=100,
+                fill_count=80,
+                reject_count=20,
+                fill_rate=Decimal("0.8"),
+            )
+
+    def test_empty_strategy_id_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="strategy_id must not be empty"):
+            CounterfactualBaseWindow(
+                symbol="BTCUSDT",
+                strategy_id="",
+                window_start="2024-01-01T00:00:00Z",
+                window_end="2024-01-02T00:00:00Z",
+                signal_count=100,
+                fill_count=80,
+                reject_count=20,
+                fill_rate=Decimal("0.8"),
+            )
+
+    def test_negative_signal_count_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="signal_count must be >= 0"):
+            CounterfactualBaseWindow(
+                symbol="BTCUSDT",
+                strategy_id="strat",
+                window_start="2024-01-01T00:00:00Z",
+                window_end="2024-01-02T00:00:00Z",
+                signal_count=-1,
+                fill_count=0,
+                reject_count=0,
+                fill_rate=Decimal("0"),
+            )
+
+    def test_negative_fill_count_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="fill_count must be >= 0"):
+            CounterfactualBaseWindow(
+                symbol="BTCUSDT",
+                strategy_id="strat",
+                window_start="2024-01-01T00:00:00Z",
+                window_end="2024-01-02T00:00:00Z",
+                signal_count=100,
+                fill_count=-1,
+                reject_count=20,
+                fill_rate=Decimal("0.8"),
+            )
+
+    def test_fill_rate_above_one_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="fill_rate must be in"):
+            CounterfactualBaseWindow(
+                symbol="BTCUSDT",
+                strategy_id="strat",
+                window_start="2024-01-01T00:00:00Z",
+                window_end="2024-01-02T00:00:00Z",
+                signal_count=100,
+                fill_count=80,
+                reject_count=20,
+                fill_rate=Decimal("1.1"),
+            )
+
+    def test_valid_base_construction(self) -> None:
+        base = _make_base()
+        assert base.signal_count == 100
+        assert base.fill_count == 80
+        assert base.fill_rate == Decimal("0.8")
+
+    def test_to_dict_has_string_fill_rate(self) -> None:
+        base = _make_base()
+        d = base.to_dict()
+        assert isinstance(d["fill_rate"], str)
+        assert d["symbol"] == "BTCUSDT"
+
+
+# ===========================================================================
+# TestApplyPerturbationsFailClosed
+# ===========================================================================
+
+
+class TestApplyPerturbationsFailClosed:
+    def test_base_none_raises(self) -> None:
+        with pytest.raises(CounterfactualError, match="base must not be None"):
+            apply_perturbations(None, [_spec("slippage_bps", "100")])  # type: ignore[arg-type]
+
+    def test_empty_specs_raises(self) -> None:
+        base = _make_base()
+        with pytest.raises(CounterfactualError, match="no perturbations specified"):
+            apply_perturbations(base, [])
+
+
+# ===========================================================================
+# TestSlippageBps
+# ===========================================================================
+
+
+class TestSlippageBps:
+    def test_basic_delta_500_bps(self) -> None:
+        # fills_lost = floor(80 * 500 / 10000) = floor(4.0) = 4
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        result = apply_perturbations(base, [_spec("slippage_bps", "500")])
+        assert result.perturbed_signal_count == 100
+        assert result.perturbed_fill_count == 76
+        assert result.perturbed_reject_count == 24
+        assert result.signal_count_delta == 0
+        assert result.fill_count_delta == -4
+        assert result.reject_count_delta == 4
+
+    def test_zero_slippage_no_change(self) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("slippage_bps", "0")])
+        assert result.perturbed_fill_count == 80
+        assert result.perturbed_reject_count == 20
+        assert result.fill_count_delta == 0
+        assert result.signal_count_delta == 0
+
+    def test_max_slippage_empties_fills(self) -> None:
+        # fills_lost = floor(80 * 10000 / 10000) = 80
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        result = apply_perturbations(base, [_spec("slippage_bps", "10000")])
+        assert result.perturbed_fill_count == 0
+        assert result.perturbed_reject_count == 100
+        assert result.fill_count_delta == -80
+        assert result.reject_count_delta == 80
+
+    def test_applied_type_recorded(self) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("slippage_bps", "500")])
+        assert "slippage_bps" in result.applied_perturbation_types
+
+    def test_signal_unchanged(self) -> None:
+        base = _make_base(signal_count=200, fill_count=150, reject_count=50)
+        result = apply_perturbations(base, [_spec("slippage_bps", "1000")])
+        assert result.perturbed_signal_count == 200
+        assert result.signal_count_delta == 0
+
+
+# ===========================================================================
+# TestEntryDelayBars
+# ===========================================================================
+
+
+class TestEntryDelayBars:
+    def test_basic_delta_50_bars(self) -> None:
+        # fraction_retained = 1 - 50*0.01 = 0.5
+        # new_signal = floor(100 * 0.5) = 50
+        # fill_fraction = 80/100 = 0.8
+        # new_fill = floor(50 * 0.8) = 40
+        # new_reject = 50 - 40 = 10
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        result = apply_perturbations(base, [_spec("entry_delay_bars", "50")])
+        assert result.perturbed_signal_count == 50
+        assert result.perturbed_fill_count == 40
+        assert result.perturbed_reject_count == 10
+        assert result.signal_count_delta == -50
+        assert result.fill_count_delta == -40
+        assert result.reject_count_delta == -10
+
+    def test_100_bars_complete_signal_loss(self) -> None:
+        # fraction_retained = max(0, 1 - 100*0.01) = 0.0
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        result = apply_perturbations(base, [_spec("entry_delay_bars", "100")])
+        assert result.perturbed_signal_count == 0
+        assert result.perturbed_fill_count == 0
+        assert result.perturbed_reject_count == 0
+
+    def test_zero_signal_edge_case(self) -> None:
+        base = _make_base(signal_count=0, fill_count=0, reject_count=0, fill_rate="0")
+        result = apply_perturbations(base, [_spec("entry_delay_bars", "10")])
+        assert result.perturbed_signal_count == 0
+        assert result.perturbed_fill_count == 0
+        assert result.perturbed_reject_count == 0
+
+    def test_small_delay_10_bars(self) -> None:
+        # fraction_retained = 0.9, new_signal = 90
+        # fill_fraction = 0.8, new_fill = floor(90 * 0.8) = 72, new_reject = 18
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        result = apply_perturbations(base, [_spec("entry_delay_bars", "10")])
+        assert result.perturbed_signal_count == 90
+        assert result.perturbed_fill_count == 72
+        assert result.perturbed_reject_count == 18
+
+    def test_fill_reject_ratio_preserved(self) -> None:
+        # After delay, fill/signal ratio should match original fill_fraction
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        result = apply_perturbations(base, [_spec("entry_delay_bars", "50")])
+        # new_signal=50, new_fill=40 → ratio=0.8 = original fill_fraction
+        assert result.perturbed_fill_count == 40
+        assert result.perturbed_signal_count == 50
+
+
+# ===========================================================================
+# TestFillRateReduction
+# ===========================================================================
+
+
+class TestFillRateReduction:
+    def test_basic_delta_25_percent(self) -> None:
+        # fills_lost = floor(80 * 0.25) = 20
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        result = apply_perturbations(base, [_spec("fill_rate_reduction", "0.25")])
+        assert result.perturbed_signal_count == 100
+        assert result.perturbed_fill_count == 60
+        assert result.perturbed_reject_count == 40
+        assert result.signal_count_delta == 0
+        assert result.fill_count_delta == -20
+        assert result.reject_count_delta == 20
+
+    def test_zero_reduction_no_change(self) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("fill_rate_reduction", "0")])
+        assert result.perturbed_fill_count == 80
+        assert result.fill_count_delta == 0
+
+    def test_full_reduction_100_percent(self) -> None:
+        # fills_lost = 80, new_fill = 0, new_reject = 100
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        result = apply_perturbations(base, [_spec("fill_rate_reduction", "1")])
+        assert result.perturbed_fill_count == 0
+        assert result.perturbed_reject_count == 100
+        assert result.fill_count_delta == -80
+
+    def test_fill_rate_delta_is_decimal(self) -> None:
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        result = apply_perturbations(base, [_spec("fill_rate_reduction", "0.25")])
+        assert isinstance(result.fill_rate_delta, Decimal)
+
+    def test_perturbed_fill_rate_correct(self) -> None:
+        # perturbed: signal=100, fill=60 → fill_rate = 60/100 = 0.6
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        result = apply_perturbations(base, [_spec("fill_rate_reduction", "0.25")])
+        assert result.perturbed_fill_rate == Decimal("60") / Decimal("100")
+        expected_delta = Decimal("60") / Decimal("100") - Decimal("0.8")
+        assert result.fill_rate_delta == expected_delta
+
+
+# ===========================================================================
+# TestFeedGapBars
+# ===========================================================================
+
+
+class TestFeedGapBars:
+    def test_basic_delta_100_bars(self) -> None:
+        # fraction_retained = 1 - 100*0.005 = 0.5
+        # new_signal = floor(100 * 0.5) = 50
+        # fill_fraction = 0.8, new_fill = floor(50*0.8) = 40, new_reject = 10
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        result = apply_perturbations(base, [_spec("feed_gap_bars", "100")])
+        assert result.perturbed_signal_count == 50
+        assert result.perturbed_fill_count == 40
+        assert result.perturbed_reject_count == 10
+        assert result.signal_count_delta == -50
+
+    def test_200_bars_complete_signal_loss(self) -> None:
+        # fraction_retained = max(0, 1 - 200*0.005) = 0.0
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        result = apply_perturbations(base, [_spec("feed_gap_bars", "200")])
+        assert result.perturbed_signal_count == 0
+        assert result.perturbed_fill_count == 0
+        assert result.perturbed_reject_count == 0
+
+    def test_20_bar_gap_partial_loss(self) -> None:
+        # fraction_retained = 1 - 20*0.005 = 0.9
+        # new_signal = 90, new_fill = floor(90*0.8) = 72, new_reject = 18
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        result = apply_perturbations(base, [_spec("feed_gap_bars", "20")])
+        assert result.perturbed_signal_count == 90
+        assert result.perturbed_fill_count == 72
+        assert result.perturbed_reject_count == 18
+
+    def test_zero_signal_edge_case(self) -> None:
+        base = _make_base(signal_count=0, fill_count=0, reject_count=0, fill_rate="0")
+        result = apply_perturbations(base, [_spec("feed_gap_bars", "50")])
+        assert result.perturbed_signal_count == 0
+        assert result.perturbed_fill_count == 0
+
+
+# ===========================================================================
+# TestComposition
+# ===========================================================================
+
+
+class TestComposition:
+    def test_slippage_then_fill_rate_reduction(self) -> None:
+        # Step 1: slippage_bps=500 → fill=76, reject=24, signal=100
+        # Step 2: fill_rate_reduction=0.25 → fills_lost=floor(76*0.25)=19
+        #   new_fill=57, new_reject=43
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        specs = [_spec("slippage_bps", "500"), _spec("fill_rate_reduction", "0.25")]
+        result = apply_perturbations(base, specs)
+        assert result.perturbed_signal_count == 100
+        assert result.perturbed_fill_count == 57
+        assert result.perturbed_reject_count == 43
+        assert result.fill_count_delta == -23
+        assert result.reject_count_delta == 23
+
+    def test_signal_drop_then_slippage(self) -> None:
+        # Step 1: entry_delay_bars=50 → signal=50, fill=40, reject=10
+        # Step 2: slippage_bps=500 → fills_lost=floor(40*500/10000)=2
+        #   new_fill=38, new_reject=12, signal=50
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        specs = [_spec("entry_delay_bars", "50"), _spec("slippage_bps", "500")]
+        result = apply_perturbations(base, specs)
+        assert result.perturbed_signal_count == 50
+        assert result.perturbed_fill_count == 38
+        assert result.perturbed_reject_count == 12
+
+    def test_applied_types_sorted_and_deduplicated(self) -> None:
+        base = _make_base()
+        specs = [_spec("slippage_bps", "100"), _spec("slippage_bps", "200")]
+        result = apply_perturbations(base, specs)
+        assert result.applied_perturbation_types == ("slippage_bps",)
+
+    def test_applied_types_multiple_sorted(self) -> None:
+        base = _make_base()
+        specs = [
+            _spec("slippage_bps", "100"),
+            _spec("fill_rate_reduction", "0.1"),
+            _spec("entry_delay_bars", "10"),
+        ]
+        result = apply_perturbations(base, specs)
+        assert result.applied_perturbation_types == (
+            "entry_delay_bars",
+            "fill_rate_reduction",
+            "slippage_bps",
+        )
+
+
+# ===========================================================================
+# TestFingerprintDeterminism
+# ===========================================================================
+
+
+class TestFingerprintDeterminism:
+    def test_same_inputs_produce_identical_fingerprint(self) -> None:
+        base = _make_base()
+        specs = [_spec("slippage_bps", "500")]
+        r1 = apply_perturbations(base, specs)
+        r2 = apply_perturbations(base, specs)
+        assert r1.provenance_fingerprint == r2.provenance_fingerprint
+
+    def test_different_magnitude_different_fingerprint(self) -> None:
+        base = _make_base()
+        r1 = apply_perturbations(base, [_spec("slippage_bps", "500")])
+        r2 = apply_perturbations(base, [_spec("slippage_bps", "600")])
+        assert r1.provenance_fingerprint != r2.provenance_fingerprint
+
+    def test_different_base_different_fingerprint(self) -> None:
+        base1 = _make_base(signal_count=100)
+        base2 = _make_base(signal_count=200, fill_count=160, reject_count=40)
+        specs = [_spec("slippage_bps", "500")]
+        r1 = apply_perturbations(base1, specs)
+        r2 = apply_perturbations(base2, specs)
+        assert r1.provenance_fingerprint != r2.provenance_fingerprint
+
+    def test_different_type_different_fingerprint(self) -> None:
+        base = _make_base()
+        r1 = apply_perturbations(base, [_spec("slippage_bps", "100")])
+        r2 = apply_perturbations(base, [_spec("fill_rate_reduction", "0.1")])
+        assert r1.provenance_fingerprint != r2.provenance_fingerprint
+
+    def test_fingerprint_is_64_char_hex_string(self) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("slippage_bps", "100")])
+        fp = result.provenance_fingerprint
+        assert isinstance(fp, str)
+        assert len(fp) == 64
+        assert all(c in "0123456789abcdef" for c in fp)
+
+
+# ===========================================================================
+# TestDecimalCorrectness
+# ===========================================================================
+
+
+class TestDecimalCorrectness:
+    def test_fill_rate_delta_is_decimal_type(self) -> None:
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20)
+        result = apply_perturbations(base, [_spec("fill_rate_reduction", "0.25")])
+        assert isinstance(result.fill_rate_delta, Decimal)
+
+    def test_perturbed_fill_rate_is_decimal_type(self) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("slippage_bps", "500")])
+        assert isinstance(result.perturbed_fill_rate, Decimal)
+
+    def test_base_fill_rate_preserved_as_decimal(self) -> None:
+        base = _make_base(fill_rate="0.8")
+        result = apply_perturbations(base, [_spec("slippage_bps", "0")])
+        assert isinstance(result.base_fill_rate, Decimal)
+        assert result.base_fill_rate == Decimal("0.8")
+
+    def test_fill_rate_delta_exact_value(self) -> None:
+        # fill=60, signal=100 → fill_rate=0.6; delta = 0.6 - 0.8 = -0.2
+        base = _make_base(signal_count=100, fill_count=80, reject_count=20, fill_rate="0.8")
+        result = apply_perturbations(base, [_spec("fill_rate_reduction", "0.25")])
+        expected = Decimal("60") / Decimal("100") - Decimal("0.8")
+        assert result.fill_rate_delta == expected
+
+    def test_zero_signal_fill_rate_is_zero_decimal(self) -> None:
+        base = _make_base(signal_count=0, fill_count=0, reject_count=0, fill_rate="0")
+        result = apply_perturbations(base, [_spec("entry_delay_bars", "10")])
+        assert result.perturbed_fill_rate == Decimal("0")
+        assert isinstance(result.perturbed_fill_rate, Decimal)
+
+    def test_no_float_in_fill_rate_fields(self) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("slippage_bps", "500")])
+        assert not isinstance(result.base_fill_rate, float)
+        assert not isinstance(result.perturbed_fill_rate, float)
+        assert not isinstance(result.fill_rate_delta, float)
+
+
+# ===========================================================================
+# TestWriteArtifact
+# ===========================================================================
+
+
+class TestWriteArtifact:
+    def test_writes_json_file(self, tmp_path: Path) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("slippage_bps", "500")])
+        write_counterfactual_artifact(result, tmp_path)
+        out = tmp_path / "counterfactual_result.json"
+        assert out.exists()
+
+    def test_json_is_valid_and_contains_key_fields(self, tmp_path: Path) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("slippage_bps", "500")])
+        write_counterfactual_artifact(result, tmp_path)
+        data = json.loads((tmp_path / "counterfactual_result.json").read_text())
+        assert data["symbol"] == "BTCUSDT"
+        assert data["provenance_fingerprint"] == result.provenance_fingerprint
+        assert "fill_count_delta" in data
+        assert "fill_rate_delta" in data
+        assert "applied_perturbation_types" in data
+
+    def test_fill_rate_delta_serialized_as_string(self, tmp_path: Path) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("fill_rate_reduction", "0.25")])
+        write_counterfactual_artifact(result, tmp_path)
+        data = json.loads((tmp_path / "counterfactual_result.json").read_text())
+        assert isinstance(data["fill_rate_delta"], str)
+
+    def test_creates_nested_parent_dirs(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b" / "c"
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("slippage_bps", "100")])
+        write_counterfactual_artifact(result, nested)
+        assert (nested / "counterfactual_result.json").exists()
+
+    def test_fail_closed_on_io_error(self, tmp_path: Path) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("slippage_bps", "100")])
+        with patch("pathlib.Path.write_text", side_effect=OSError("disk full")):
+            with pytest.raises(CounterfactualError, match="failed to write"):
+                write_counterfactual_artifact(result, tmp_path)
+
+    def test_artifact_keys_are_sorted(self, tmp_path: Path) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("slippage_bps", "100")])
+        write_counterfactual_artifact(result, tmp_path)
+        raw = (tmp_path / "counterfactual_result.json").read_text()
+        data = json.loads(raw)
+        keys = list(data.keys())
+        assert keys == sorted(keys)
+
+
+# ===========================================================================
+# TestBuildSummary
+# ===========================================================================
+
+
+class TestBuildSummary:
+    def test_contains_symbol(self) -> None:
+        base = _make_base(symbol="ETHUSDT")
+        result = apply_perturbations(base, [_spec("slippage_bps", "500")])
+        summary = build_perturbation_summary(result)
+        assert "ETHUSDT" in summary
+
+    def test_contains_fill_delta(self) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("slippage_bps", "500")])
+        summary = build_perturbation_summary(result)
+        assert "fill_delta" in summary
+
+    def test_contains_signal_delta(self) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("entry_delay_bars", "50")])
+        summary = build_perturbation_summary(result)
+        assert "signal_delta" in summary
+
+    def test_contains_reject_delta(self) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("fill_rate_reduction", "0.25")])
+        summary = build_perturbation_summary(result)
+        assert "reject_delta" in summary
+
+    def test_contains_fill_rate_delta(self) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("fill_rate_reduction", "0.25")])
+        summary = build_perturbation_summary(result)
+        assert "fill_rate_delta" in summary
+
+    def test_contains_applied_type(self) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("slippage_bps", "500")])
+        summary = build_perturbation_summary(result)
+        assert "slippage_bps" in summary
+
+    def test_contains_fingerprint(self) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("slippage_bps", "500")])
+        summary = build_perturbation_summary(result)
+        assert result.provenance_fingerprint in summary
+
+    def test_summary_is_string(self) -> None:
+        base = _make_base()
+        result = apply_perturbations(base, [_spec("slippage_bps", "100")])
+        summary = build_perturbation_summary(result)
+        assert isinstance(summary, str)
+        assert len(summary) > 0


### PR DESCRIPTION
## Summary
- add a deterministic counterfactual replay core for \same day, but...\ perturbations
- model validated perturbation specs and a caller-supplied baseline window without runtime or DB coupling
- write \counterfactual_result.json\ fail-closed as the machine-readable artifact
- cover perturbation application, summaries, and artifact writing with focused unit tests

## Validation
- \python -m pytest tests/unit/replay/test_counterfactual.py -q\
- \69 passed\

## Scope notes
- includes only the \#1850\ counterfactual slice
- no changes to existing files
- unrelated local untracked files were not touched

Closes #1850