### PR TITLE
feat(arvp): add replay resampling stability core (#1852)

### DIFF
--- a/core/replay/replay_report_builder.py
+++ b/core/replay/replay_report_builder.py
@@ -23,6 +23,7 @@ relations:
     - core.replay.run_registry     (ReplayRunRecord)
     - core.replay.scenario_harness (ScenarioGroupManifest)
     - core.replay.regime_analytics (RegimeScorecard)
+    - core.replay.resampling       (ResamplingStabilityArtifact)
     - core.replay.canonical_json   (canonical_json_dumps)
 """
 
@@ -33,6 +34,7 @@ from typing import Sequence
 
 from core.replay.canonical_json import canonical_json_dumps
 from core.replay.regime_analytics import RegimeScorecard
+from core.replay.resampling import ResamplingStabilityArtifact
 from core.replay.run_registry import ReplayRunRecord
 from core.replay.scenario_harness import ScenarioGroupManifest
 
@@ -197,17 +199,65 @@ def build_regime_scorecard_summary(scorecard: RegimeScorecard) -> str:
     return "\n".join(lines)
 
 
+def build_resampling_stability_summary(stability: ResamplingStabilityArtifact) -> str:
+    """Build a markdown operator summary for a resampling stability artifact."""
+    if not isinstance(stability, ResamplingStabilityArtifact):
+        raise ReplayReportBuilderError(
+            f"Expected ResamplingStabilityArtifact, got {type(stability).__name__}"
+        )
+
+    provenance = stability.source_provenance
+    lines: list[str] = [
+        f"# Resampling Stability: {provenance.source_run_id}",
+        "",
+        "| Field | Value |",
+        "|-------|-------|",
+        f"| Method | {stability.resampling_method} |",
+        f"| Sample count | {stability.sample_count} |",
+        f"| Blocks per sample | {stability.sample_block_count} |",
+        f"| Source blocks | {provenance.block_count} |",
+        f"| Dataset fingerprint | {_trunc(provenance.dataset_fingerprint)}… |",
+        f"| Execution provenance | {provenance.execution_provenance_id} |",
+        f"| Config fingerprint | {_trunc(stability.config_fingerprint)}… |",
+        "",
+        "## Empirical KPI Bands",
+        "",
+        "| KPI | Baseline | Min | P05 | P50 | P95 | Max | Span |",
+        "|-----|----------|-----|-----|-----|-----|-----|------|",
+    ]
+
+    for summary in stability.kpi_summaries:
+        lines.append(
+            f"| {summary.kpi}"
+            f" | {summary.baseline}"
+            f" | {summary.minimum}"
+            f" | {summary.p05}"
+            f" | {summary.p50}"
+            f" | {summary.p95}"
+            f" | {summary.maximum}"
+            f" | {summary.empirical_span} |"
+        )
+
+    lines.extend(["", "## Operator Summary", ""])
+    for line in stability.operator_summary:
+        lines.append(f"- {line}")
+
+    return "\n".join(lines)
+
+
 def build_management_report(
     *,
     record: ReplayRunRecord,
     manifest: ScenarioGroupManifest | None = None,
     scorecard: RegimeScorecard | None = None,
+    stability: ResamplingStabilityArtifact | None = None,
 ) -> str:
     """Build a management-grade markdown report for a replay run.
 
     Combines a per-run operator summary with optional scenario comparison and
-    regime scorecard sections.  All content is grounded in the supplied domain
-    objects; no narrative is invented.  No I/O is performed.
+    regime scorecard / resampling stability sections.  All content is grounded
+    in the supplied domain objects; no narrative is invented.  No I/O is
+    performed.
     """
     if not isinstance(record, ReplayRunRecord):
         raise ReplayReportBuilderError(
@@ -223,6 +273,11 @@ def build_management_report(
             f"scorecard must be RegimeScorecard or None, "
             f"got {type(scorecard).__name__}"
         )
+    if stability is not None and not isinstance(stability, ResamplingStabilityArtifact):
+        raise ReplayReportBuilderError(
+            f"stability must be ResamplingStabilityArtifact or None, "
+            f"got {type(stability).__name__}"
+        )
 
     sections: list[str] = [build_run_summary_text(record)]
 
@@ -231,6 +286,9 @@ def build_management_report(
 
     if scorecard is not None:
         sections.extend(["", "---", "", build_regime_scorecard_summary(scorecard)])
+
+    if stability is not None:
+        sections.extend(["", "---", "", build_resampling_stability_summary(stability)])
 
     return "\n".join(sections)
 

--- a/core/replay/resampling.py
+++ b/core/replay/resampling.py
@@ -1,0 +1,508 @@
+"""Deterministic replay resampling for KPI stability analysis.
+
+Scope (#1852): a minimal, explicit bootstrap layer over caller-supplied replay
+KPI blocks. This slice intentionally does not infer blocks from runner outputs
+or add new replay execution modes.
+
+Design rules:
+  - Only explicit caller-supplied blocks are accepted; no hidden grouping
+    inference or silent fallback behavior.
+  - Deterministic: same blocks + same config => identical artifact payload.
+  - Fail-closed: unsupported modes, mixed provenance, and invalid KPI requests
+    raise ResamplingError immediately.
+  - No-float rule for canonical artifacts: Decimal values serialize as strings.
+  - Machine-readable outputs prefer empirical quantile summaries over broader
+    statistical claims.
+
+Non-goals:
+  - predictive simulation or synthetic market generation
+  - replay runner auto-wiring
+  - regime-weighted sampling in this first slice
+  - schema changes to replay_report.v1
+"""
+
+from __future__ import annotations
+
+import pathlib
+import random
+import re
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Sequence
+
+from core.replay.canonical_json import canonical_hash, canonical_json_dumps
+
+_PNL_Q = Decimal("0.00000001")
+_RATE_Q = Decimal("0.00000001")
+_RUN_ID_RE = re.compile(r"^replay-[a-f0-9]{12}-\d{4}$")
+_HEX_64_RE = re.compile(r"^[a-f0-9]{64}$")
+_EXECUTION_PROVENANCE_ID_RE = re.compile(r"^bt-[a-f0-9]{16}$")
+_SUPPORTED_METHODS: frozenset[str] = frozenset({"block_bootstrap"})
+_INT_KPIS: frozenset[str] = frozenset({"signal_count", "fill_count", "reject_count"})
+_DECIMAL_KPIS: frozenset[str] = frozenset({"pnl_sum", "fill_rate"})
+_SUPPORTED_KPIS: frozenset[str] = _INT_KPIS | _DECIMAL_KPIS
+_STABILITY_ARTIFACT_FILENAME = "resampling_stability.json"
+
+
+class ResamplingError(ValueError):
+    """Raised when resampling validation or artifact writing fails."""
+
+
+def _require_non_empty_string(value: object, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ResamplingError(f"{field_name} must be a non-empty string")
+
+
+def _require_non_negative_int(value: object, field_name: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ResamplingError(f"{field_name} must be a non-negative int")
+
+
+def _require_positive_int(value: object, field_name: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ResamplingError(f"{field_name} must be a positive int")
+
+
+def _quantize_decimal(value: Decimal, quantum: Decimal) -> Decimal:
+    return value.quantize(quantum)
+
+
+def _fill_rate(fill_count: int, reject_count: int) -> Decimal:
+    total = fill_count + reject_count
+    if total == 0:
+        return Decimal("0").quantize(_RATE_Q)
+    return (Decimal(fill_count) / Decimal(total)).quantize(_RATE_Q)
+
+
+def _serialize_metric(metric_name: str, value: int | Decimal) -> str:
+    if metric_name in _INT_KPIS:
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ResamplingError(f"{metric_name} must serialize from int")
+        return str(value)
+    if metric_name == "pnl_sum":
+        if not isinstance(value, Decimal):
+            raise ResamplingError("pnl_sum must serialize from Decimal")
+        return str(_quantize_decimal(value, _PNL_Q))
+    if metric_name == "fill_rate":
+        if not isinstance(value, Decimal):
+            raise ResamplingError("fill_rate must serialize from Decimal")
+        return str(_quantize_decimal(value, _RATE_Q))
+    raise ResamplingError(f"Unsupported KPI for serialization: {metric_name}")
+
+
+def _subtract_metric(metric_name: str, maximum: int | Decimal, minimum: int | Decimal) -> int | Decimal:
+    if metric_name in _INT_KPIS:
+        if not isinstance(maximum, int) or not isinstance(minimum, int):
+            raise ResamplingError(f"{metric_name} span requires int values")
+        return maximum - minimum
+    if metric_name == "pnl_sum":
+        if not isinstance(maximum, Decimal) or not isinstance(minimum, Decimal):
+            raise ResamplingError("pnl_sum span requires Decimal values")
+        return (maximum - minimum).quantize(_PNL_Q)
+    if metric_name == "fill_rate":
+        if not isinstance(maximum, Decimal) or not isinstance(minimum, Decimal):
+            raise ResamplingError("fill_rate span requires Decimal values")
+        return (maximum - minimum).quantize(_RATE_Q)
+    raise ResamplingError(f"Unsupported KPI for span calculation: {metric_name}")
+
+
+def _quantile(values: Sequence[int | Decimal], *, numerator: int, denominator: int) -> int | Decimal:
+    if not values:
+        raise ResamplingError("quantile values must not be empty")
+    index = ((len(values) - 1) * numerator) // denominator
+    return values[index]
+
+
+def _aggregate_blocks(blocks: Sequence["ReplayKPIBlock"]) -> dict[str, int | Decimal]:
+    signal_count = sum(block.signal_count for block in blocks)
+    fill_count = sum(block.fill_count for block in blocks)
+    reject_count = sum(block.reject_count for block in blocks)
+    pnl_sum = sum((block.pnl_sum for block in blocks), Decimal("0")).quantize(_PNL_Q)
+    return {
+        "signal_count": signal_count,
+        "fill_count": fill_count,
+        "reject_count": reject_count,
+        "pnl_sum": pnl_sum,
+        "fill_rate": _fill_rate(fill_count, reject_count),
+    }
+
+
+def _input_fingerprint(blocks: Sequence["ReplayKPIBlock"]) -> str:
+    return canonical_hash([block.to_dict() for block in blocks])
+
+
+def _validate_uniform_provenance(blocks: Sequence["ReplayKPIBlock"]) -> None:
+    run_ids = {block.source_run_id for block in blocks}
+    dataset_fingerprints = {block.dataset_fingerprint for block in blocks}
+    execution_ids = {block.execution_provenance_id for block in blocks}
+    if len(run_ids) != 1:
+        raise ResamplingError("All blocks must share the same source_run_id")
+    if len(dataset_fingerprints) != 1:
+        raise ResamplingError("All blocks must share the same dataset_fingerprint")
+    if len(execution_ids) != 1:
+        raise ResamplingError("All blocks must share the same execution_provenance_id")
+
+
+def _build_operator_summary(
+    *,
+    config: "ResamplingConfig",
+    summaries: Sequence["ResamplingKPISummary"],
+) -> tuple[str, ...]:
+    lines = [
+        (
+            f"method={config.method}; samples={config.sample_count}; "
+            f"blocks_per_sample={config.sample_block_count}; seed={config.seed}"
+        )
+    ]
+    for summary in summaries:
+        lines.append(
+            f"{summary.kpi}: baseline={summary.baseline}; "
+            f"empirical_band_p05_p95={summary.p05}..{summary.p95}; "
+            f"span={summary.empirical_span}"
+        )
+    return tuple(lines)
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingConfig:
+    """Explicit bootstrap configuration for replay KPI stability analysis."""
+
+    method: str
+    sample_count: int
+    sample_block_count: int
+    seed: int
+    selected_kpis: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.method not in _SUPPORTED_METHODS:
+            raise ResamplingError(
+                f"Unsupported resampling method {self.method!r}. "
+                f"Valid: {sorted(_SUPPORTED_METHODS)}"
+            )
+        _require_positive_int(self.sample_count, "sample_count")
+        _require_positive_int(self.sample_block_count, "sample_block_count")
+        if not isinstance(self.seed, int) or isinstance(self.seed, bool) or self.seed < 0:
+            raise ResamplingError("seed must be a non-negative int")
+        if not isinstance(self.selected_kpis, tuple) or not self.selected_kpis:
+            raise ResamplingError("selected_kpis must be a non-empty tuple")
+        seen: set[str] = set()
+        for kpi in self.selected_kpis:
+            if not isinstance(kpi, str):
+                raise ResamplingError("selected_kpis entries must be strings")
+            if kpi not in _SUPPORTED_KPIS:
+                raise ResamplingError(
+                    f"Unsupported KPI {kpi!r}. Valid: {sorted(_SUPPORTED_KPIS)}"
+                )
+            if kpi in seen:
+                raise ResamplingError(f"Duplicate KPI in selected_kpis: {kpi!r}")
+            seen.add(kpi)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "method": self.method,
+            "sample_count": self.sample_count,
+            "sample_block_count": self.sample_block_count,
+            "seed": self.seed,
+            "selected_kpis": list(self.selected_kpis),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayKPIBlock:
+    """A single replay-backed KPI block for deterministic resampling."""
+
+    block_id: str
+    source_run_id: str
+    dataset_fingerprint: str
+    execution_provenance_id: str
+    signal_count: int
+    fill_count: int
+    reject_count: int
+    pnl_sum: Decimal
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.block_id, "block_id")
+        if not _RUN_ID_RE.match(self.source_run_id):
+            raise ResamplingError(
+                "source_run_id must match 'replay-<12 hex>-<4 digit attempt>'"
+            )
+        if not _HEX_64_RE.match(self.dataset_fingerprint):
+            raise ResamplingError("dataset_fingerprint must be a 64-char lowercase hex hash")
+        if not _EXECUTION_PROVENANCE_ID_RE.match(self.execution_provenance_id):
+            raise ResamplingError(
+                "execution_provenance_id must match 'bt-<16 hex>'"
+            )
+        _require_non_negative_int(self.signal_count, "signal_count")
+        _require_non_negative_int(self.fill_count, "fill_count")
+        _require_non_negative_int(self.reject_count, "reject_count")
+        if not isinstance(self.pnl_sum, Decimal):
+            raise ResamplingError("pnl_sum must be a Decimal")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "block_id": self.block_id,
+            "source_run_id": self.source_run_id,
+            "dataset_fingerprint": self.dataset_fingerprint,
+            "execution_provenance_id": self.execution_provenance_id,
+            "signal_count": self.signal_count,
+            "fill_count": self.fill_count,
+            "reject_count": self.reject_count,
+            "pnl_sum": str(self.pnl_sum),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingSourceProvenance:
+    """Pinned provenance for a stability artifact."""
+
+    source_run_id: str
+    run_count: int
+    block_count: int
+    dataset_fingerprint: str
+    execution_provenance_id: str
+    input_fingerprint: str
+
+    def __post_init__(self) -> None:
+        if not _RUN_ID_RE.match(self.source_run_id):
+            raise ResamplingError(
+                "source_run_id must match 'replay-<12 hex>-<4 digit attempt>'"
+            )
+        _require_positive_int(self.run_count, "run_count")
+        _require_positive_int(self.block_count, "block_count")
+        if not _HEX_64_RE.match(self.dataset_fingerprint):
+            raise ResamplingError("dataset_fingerprint must be a 64-char lowercase hex hash")
+        if not _EXECUTION_PROVENANCE_ID_RE.match(self.execution_provenance_id):
+            raise ResamplingError(
+                "execution_provenance_id must match 'bt-<16 hex>'"
+            )
+        if not _HEX_64_RE.match(self.input_fingerprint):
+            raise ResamplingError("input_fingerprint must be a 64-char lowercase hex hash")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "source_run_id": self.source_run_id,
+            "run_count": self.run_count,
+            "block_count": self.block_count,
+            "dataset_fingerprint": self.dataset_fingerprint,
+            "execution_provenance_id": self.execution_provenance_id,
+            "input_fingerprint": self.input_fingerprint,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingKPISummary:
+    """Empirical quantile summary for one selected KPI."""
+
+    kpi: str
+    sample_count: int
+    baseline: str
+    minimum: str
+    p05: str
+    p50: str
+    p95: str
+    maximum: str
+    empirical_span: str
+
+    def __post_init__(self) -> None:
+        if self.kpi not in _SUPPORTED_KPIS:
+            raise ResamplingError(
+                f"Unsupported KPI summary {self.kpi!r}. Valid: {sorted(_SUPPORTED_KPIS)}"
+            )
+        _require_positive_int(self.sample_count, "sample_count")
+        for field_name in ("baseline", "minimum", "p05", "p50", "p95", "maximum", "empirical_span"):
+            _require_non_empty_string(getattr(self, field_name), field_name)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kpi": self.kpi,
+            "sample_count": self.sample_count,
+            "baseline": self.baseline,
+            "minimum": self.minimum,
+            "p05": self.p05,
+            "p50": self.p50,
+            "p95": self.p95,
+            "maximum": self.maximum,
+            "empirical_span": self.empirical_span,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ResamplingStabilityArtifact:
+    """Deterministic machine-readable replay stability artifact."""
+
+    schema_version: str
+    resampling_method: str
+    sample_count: int
+    sample_block_count: int
+    config: ResamplingConfig
+    config_fingerprint: str
+    source_provenance: ResamplingSourceProvenance
+    baseline_metrics: dict[str, str]
+    kpi_summaries: tuple[ResamplingKPISummary, ...]
+    operator_summary: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.schema_version != "replay_resampling_stability.v1":
+            raise ResamplingError("schema_version must be 'replay_resampling_stability.v1'")
+        if self.resampling_method not in _SUPPORTED_METHODS:
+            raise ResamplingError(
+                f"Unsupported resampling_method {self.resampling_method!r}. "
+                f"Valid: {sorted(_SUPPORTED_METHODS)}"
+            )
+        _require_positive_int(self.sample_count, "sample_count")
+        _require_positive_int(self.sample_block_count, "sample_block_count")
+        if self.resampling_method != self.config.method:
+            raise ResamplingError("resampling_method must match config.method")
+        if self.sample_count != self.config.sample_count:
+            raise ResamplingError("sample_count must match config.sample_count")
+        if self.sample_block_count != self.config.sample_block_count:
+            raise ResamplingError("sample_block_count must match config.sample_block_count")
+        if not _HEX_64_RE.match(self.config_fingerprint):
+            raise ResamplingError("config_fingerprint must be a 64-char lowercase hex hash")
+        if not isinstance(self.baseline_metrics, dict):
+            raise ResamplingError("baseline_metrics must be a dict")
+        if tuple(self.baseline_metrics.keys()) != self.config.selected_kpis:
+            raise ResamplingError("baseline_metrics keys must match config.selected_kpis order")
+        if len(self.kpi_summaries) != len(self.config.selected_kpis):
+            raise ResamplingError("kpi_summaries must align with config.selected_kpis")
+        summary_keys = tuple(summary.kpi for summary in self.kpi_summaries)
+        if summary_keys != self.config.selected_kpis:
+            raise ResamplingError("kpi_summaries must follow config.selected_kpis order")
+        if not isinstance(self.operator_summary, tuple) or not self.operator_summary:
+            raise ResamplingError("operator_summary must be a non-empty tuple")
+        for line in self.operator_summary:
+            _require_non_empty_string(line, "operator_summary entry")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "resampling_method": self.resampling_method,
+            "sample_count": self.sample_count,
+            "sample_block_count": self.sample_block_count,
+            "config": self.config.to_dict(),
+            "config_fingerprint": self.config_fingerprint,
+            "source_provenance": self.source_provenance.to_dict(),
+            "baseline_metrics": self.baseline_metrics,
+            "kpi_summaries": [summary.to_dict() for summary in self.kpi_summaries],
+            "operator_summary": list(self.operator_summary),
+        }
+
+
+def compute_resampling_stability(
+    blocks: Sequence[ReplayKPIBlock],
+    *,
+    config: ResamplingConfig,
+) -> ResamplingStabilityArtifact:
+    """Compute deterministic block-bootstrap stability summaries.
+
+    The minimal slice intentionally supports only a single explicit method:
+    ``block_bootstrap`` over caller-supplied ReplayKPIBlock records.
+    """
+    if not isinstance(config, ResamplingConfig):
+        raise ResamplingError(
+            f"config must be ResamplingConfig, got {type(config).__name__}"
+        )
+
+    blocks_list = list(blocks)
+    if not blocks_list:
+        raise ResamplingError("blocks must not be empty")
+    for index, block in enumerate(blocks_list):
+        if not isinstance(block, ReplayKPIBlock):
+            raise ResamplingError(
+                f"blocks[{index}] must be ReplayKPIBlock, got {type(block).__name__}"
+            )
+
+    _validate_uniform_provenance(blocks_list)
+    if config.sample_block_count != len(blocks_list):
+        raise ResamplingError(
+            "sample_block_count must equal len(blocks) for block_bootstrap in this slice"
+        )
+    baseline_metrics = _aggregate_blocks(blocks_list)
+    config_fingerprint = canonical_hash(config.to_dict())
+    input_fingerprint = _input_fingerprint(blocks_list)
+
+    source_provenance = ResamplingSourceProvenance(
+        source_run_id=blocks_list[0].source_run_id,
+        run_count=1,
+        block_count=len(blocks_list),
+        dataset_fingerprint=blocks_list[0].dataset_fingerprint,
+        execution_provenance_id=blocks_list[0].execution_provenance_id,
+        input_fingerprint=input_fingerprint,
+    )
+
+    rng = random.Random(config.seed)
+    sample_values: dict[str, list[int | Decimal]] = {
+        kpi: [] for kpi in config.selected_kpis
+    }
+    for _ in range(config.sample_count):
+        sampled_blocks = [
+            blocks_list[rng.randrange(len(blocks_list))]
+            for _ in range(config.sample_block_count)
+        ]
+        aggregate = _aggregate_blocks(sampled_blocks)
+        for kpi in config.selected_kpis:
+            sample_values[kpi].append(aggregate[kpi])
+
+    summaries: list[ResamplingKPISummary] = []
+    serialized_baseline: dict[str, str] = {}
+    for kpi in config.selected_kpis:
+        values = sorted(sample_values[kpi])
+        baseline = baseline_metrics[kpi]
+        minimum = values[0]
+        maximum = values[-1]
+        p05 = _quantile(values, numerator=5, denominator=100)
+        p50 = _quantile(values, numerator=50, denominator=100)
+        p95 = _quantile(values, numerator=95, denominator=100)
+        span = _subtract_metric(kpi, maximum, minimum)
+
+        serialized_baseline[kpi] = _serialize_metric(kpi, baseline)
+        summaries.append(
+            ResamplingKPISummary(
+                kpi=kpi,
+                sample_count=config.sample_count,
+                baseline=_serialize_metric(kpi, baseline),
+                minimum=_serialize_metric(kpi, minimum),
+                p05=_serialize_metric(kpi, p05),
+                p50=_serialize_metric(kpi, p50),
+                p95=_serialize_metric(kpi, p95),
+                maximum=_serialize_metric(kpi, maximum),
+                empirical_span=_serialize_metric(kpi, span),
+            )
+        )
+
+    return ResamplingStabilityArtifact(
+        schema_version="replay_resampling_stability.v1",
+        resampling_method=config.method,
+        sample_count=config.sample_count,
+        sample_block_count=config.sample_block_count,
+        config=config,
+        config_fingerprint=config_fingerprint,
+        source_provenance=source_provenance,
+        baseline_metrics=serialized_baseline,
+        kpi_summaries=tuple(summaries),
+        operator_summary=_build_operator_summary(config=config, summaries=summaries),
+    )
+
+
+def write_resampling_stability_artifact(
+    artifact: ResamplingStabilityArtifact,
+    artifact_root: str | pathlib.Path,
+) -> None:
+    """Write ``resampling_stability.json`` into artifact_root."""
+    if not isinstance(artifact, ResamplingStabilityArtifact):
+        raise ResamplingError(
+            f"artifact must be ResamplingStabilityArtifact, got {type(artifact).__name__}"
+        )
+
+    out_dir = pathlib.Path(artifact_root)
+    artifact_path = out_dir / _STABILITY_ARTIFACT_FILENAME
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text(
+            canonical_json_dumps(artifact.to_dict()),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        raise ResamplingError(
+            f"Failed to write {_STABILITY_ARTIFACT_FILENAME} to {artifact_path}: {exc}"
+        ) from exc

--- a/core/replay/resampling.py
+++ b/core/replay/resampling.py
@@ -24,13 +24,13 @@ Non-goals:
 from __future__ import annotations
 
 import pathlib
-import random
 import re
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Sequence
 
 from core.replay.canonical_json import canonical_hash, canonical_json_dumps
+from core.utils.seed import SeedManager
 
 _PNL_Q = Decimal("0.00000001")
 _RATE_Q = Decimal("0.00000001")
@@ -430,13 +430,13 @@ def compute_resampling_stability(
         input_fingerprint=input_fingerprint,
     )
 
-    rng = random.Random(config.seed)
+    rng = SeedManager(config.seed)
     sample_values: dict[str, list[int | Decimal]] = {
         kpi: [] for kpi in config.selected_kpis
     }
     for _ in range(config.sample_count):
         sampled_blocks = [
-            blocks_list[rng.randrange(len(blocks_list))]
+            blocks_list[rng.random_int(0, len(blocks_list) - 1)]
             for _ in range(config.sample_block_count)
         ]
         aggregate = _aggregate_blocks(sampled_blocks)

--- a/tests/unit/replay/test_replay_report_builder.py
+++ b/tests/unit/replay/test_replay_report_builder.py
@@ -14,12 +14,19 @@ from decimal import Decimal
 import pytest
 
 from core.replay.regime_analytics import RegimeScorecard, RegimeSegmentStats
+from core.replay.resampling import (
+    ResamplingConfig,
+    ResamplingKPISummary,
+    ResamplingSourceProvenance,
+    ResamplingStabilityArtifact,
+)
 from core.replay.replay_report_builder import (
     ReplayReportBuilderError,
     _MANAGEMENT_REPORT_FILENAME,
     _RUN_INDEX_FILENAME,
     build_management_report,
     build_regime_scorecard_summary,
+    build_resampling_stability_summary,
     build_run_summary_text,
     build_scenario_comparison_summary,
     write_management_report,
@@ -38,6 +45,7 @@ _FINISHED = "2026-04-01T10:05:00+00:00"
 _EXECUTION_PROV = "bt-" + "b" * 16
 _GROUP_FP = "c" * 64
 _INPUT_FP = "d" * 64
+_CONFIG_FP = "e" * 64
 
 
 # ---------------------------------------------------------------------------
@@ -121,6 +129,68 @@ def _scorecard(**overrides: object) -> RegimeScorecard:
     }
     fields.update(overrides)
     return RegimeScorecard(**fields)
+
+
+def _stability(**overrides: object) -> ResamplingStabilityArtifact:
+    config = ResamplingConfig(
+        method="block_bootstrap",
+        sample_count=32,
+        sample_block_count=4,
+        seed=7,
+        selected_kpis=("pnl_sum", "fill_rate"),
+    )
+    provenance = ResamplingSourceProvenance(
+        source_run_id="replay-aabbccddeeff-0001",
+        run_count=1,
+        block_count=4,
+        dataset_fingerprint=_DATASET_FP,
+        execution_provenance_id=_EXECUTION_PROV,
+        input_fingerprint=_INPUT_FP,
+    )
+    summaries = (
+        ResamplingKPISummary(
+            kpi="pnl_sum",
+            sample_count=32,
+            baseline="1.23456789",
+            minimum="0.50000000",
+            p05="0.80000000",
+            p50="1.20000000",
+            p95="1.70000000",
+            maximum="2.00000000",
+            empirical_span="1.50000000",
+        ),
+        ResamplingKPISummary(
+            kpi="fill_rate",
+            sample_count=32,
+            baseline="0.90000000",
+            minimum="0.50000000",
+            p05="0.66666667",
+            p50="0.83333333",
+            p95="1.00000000",
+            maximum="1.00000000",
+            empirical_span="0.50000000",
+        ),
+    )
+    fields: dict = {
+        "schema_version": "replay_resampling_stability.v1",
+        "resampling_method": "block_bootstrap",
+        "sample_count": 32,
+        "sample_block_count": 4,
+        "config": config,
+        "config_fingerprint": _CONFIG_FP,
+        "source_provenance": provenance,
+        "baseline_metrics": {
+            "pnl_sum": "1.23456789",
+            "fill_rate": "0.90000000",
+        },
+        "kpi_summaries": summaries,
+        "operator_summary": (
+            "method=block_bootstrap; samples=32; blocks_per_sample=4; seed=7",
+            "pnl_sum: baseline=1.23456789; empirical_band_p05_p95=0.80000000..1.70000000; span=1.50000000",
+        ),
+    }
+    fields.update(overrides)
+    return ResamplingStabilityArtifact(**fields)
 
 
 def _ok_result(scenario_id: str, run_id: str = "replay-aabbccddeeff-0001") -> ScenarioRunResult:
@@ -368,6 +438,40 @@ class TestBuildRegimeScorecardSummary:
 
 
 # ---------------------------------------------------------------------------
+# build_resampling_stability_summary
+# ---------------------------------------------------------------------------
+
+
+class TestBuildResamplingStabilitySummary:
+    def test_contains_run_id(self) -> None:
+        stability = _stability()
+        text = build_resampling_stability_summary(stability)
+        assert stability.source_provenance.source_run_id in text
+
+    def test_contains_method(self) -> None:
+        stability = _stability()
+        text = build_resampling_stability_summary(stability)
+        assert "block_bootstrap" in text
+
+    def test_contains_kpi_values(self) -> None:
+        stability = _stability()
+        text = build_resampling_stability_summary(stability)
+        assert "pnl_sum" in text
+        assert "0.80000000" in text
+        assert "0.90000000" in text
+
+    def test_contains_operator_summary(self) -> None:
+        stability = _stability()
+        text = build_resampling_stability_summary(stability)
+        assert "Operator Summary" in text
+        assert "samples=32" in text
+
+    def test_rejects_invalid_type(self) -> None:
+        with pytest.raises(ReplayReportBuilderError, match="Expected ResamplingStabilityArtifact"):
+            build_resampling_stability_summary("bad")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
 # build_management_report
 # ---------------------------------------------------------------------------
 
@@ -390,6 +494,13 @@ class TestBuildManagementReport:
         text = build_management_report(record=rec, scorecard=sc)
         assert "TREND" in text
 
+    def test_with_stability_contains_section(self) -> None:
+        rec = _completed_record()
+        stability = _stability()
+        text = build_management_report(record=rec, stability=stability)
+        assert "Resampling Stability" in text
+        assert "block_bootstrap" in text
+
     def test_all_three_sections(self) -> None:
         rec = _completed_record()
         m = _manifest((_ok_result("baseline"), _fail_result("feed_gap")))
@@ -398,6 +509,22 @@ class TestBuildManagementReport:
         assert rec.run_id in text
         assert m.group_id in text
         assert "TREND" in text
+
+    def test_all_optional_sections(self) -> None:
+        rec = _completed_record()
+        m = _manifest((_ok_result("baseline"), _fail_result("feed_gap")))
+        sc = _scorecard()
+        stability = _stability()
+        text = build_management_report(
+            record=rec,
+            manifest=m,
+            scorecard=sc,
+            stability=stability,
+        )
+        assert rec.run_id in text
+        assert m.group_id in text
+        assert "TREND" in text
+        assert "Resampling Stability" in text
 
     def test_failed_run_report_includes_failure_reason(self) -> None:
         rec = _failed_record()
@@ -415,6 +542,12 @@ class TestBuildManagementReport:
         rec = _completed_record()
         sc = _scorecard()
         text = build_management_report(record=rec, scorecard=sc)
+        assert "---" in text
+
+    def test_separator_present_with_stability(self) -> None:
+        rec = _completed_record()
+        stability = _stability()
+        text = build_management_report(record=rec, stability=stability)
         assert "---" in text
 
     def test_no_section_divider_without_optional_args(self) -> None:
@@ -444,6 +577,11 @@ class TestBuildManagementReport:
         rec = _completed_record()
         with pytest.raises(ReplayReportBuilderError, match="scorecard must be"):
             build_management_report(record=rec, scorecard=42)  # type: ignore[arg-type]
+
+    def test_rejects_invalid_stability(self) -> None:
+        rec = _completed_record()
+        with pytest.raises(ReplayReportBuilderError, match="stability must be"):
+            build_management_report(record=rec, stability=42)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/replay/test_resampling.py
+++ b/tests/unit/replay/test_resampling.py
@@ -1,0 +1,236 @@
+"""Unit tests for core.replay.resampling (#1852)."""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from core.replay.resampling import (
+    _STABILITY_ARTIFACT_FILENAME,
+    ReplayKPIBlock,
+    ResamplingConfig,
+    ResamplingError,
+    ResamplingStabilityArtifact,
+    compute_resampling_stability,
+    write_resampling_stability_artifact,
+)
+
+_RUN_ID = "replay-aabbccddeeff-0001"
+_DATASET_FP = "a" * 64
+_EXECUTION_PROV = "bt-" + "b" * 16
+
+
+def _block(
+    block_id: str,
+    *,
+    source_run_id: str = _RUN_ID,
+    dataset_fingerprint: str = _DATASET_FP,
+    execution_provenance_id: str = _EXECUTION_PROV,
+    signal_count: int = 4,
+    fill_count: int = 3,
+    reject_count: int = 1,
+    pnl_sum: str = "0.50000000",
+) -> ReplayKPIBlock:
+    return ReplayKPIBlock(
+        block_id=block_id,
+        source_run_id=source_run_id,
+        dataset_fingerprint=dataset_fingerprint,
+        execution_provenance_id=execution_provenance_id,
+        signal_count=signal_count,
+        fill_count=fill_count,
+        reject_count=reject_count,
+        pnl_sum=Decimal(pnl_sum),
+    )
+
+
+def _config(**overrides: object) -> ResamplingConfig:
+    fields: dict[str, object] = {
+        "method": "block_bootstrap",
+        "sample_count": 16,
+        "sample_block_count": 1,
+        "seed": 11,
+        "selected_kpis": ("signal_count", "pnl_sum", "fill_rate"),
+    }
+    fields.update(overrides)
+    return ResamplingConfig(**fields)
+
+
+class TestResamplingConfig:
+    def test_valid_config(self) -> None:
+        config = _config()
+        assert config.method == "block_bootstrap"
+        assert config.sample_count == 16
+
+    def test_unsupported_method_raises(self) -> None:
+        with pytest.raises(ResamplingError, match="Unsupported resampling method"):
+            _config(method="regime_weighted")
+
+    def test_empty_kpis_raises(self) -> None:
+        with pytest.raises(ResamplingError, match="selected_kpis must be a non-empty tuple"):
+            _config(selected_kpis=())
+
+    def test_duplicate_kpi_raises(self) -> None:
+        with pytest.raises(ResamplingError, match="Duplicate KPI"):
+            _config(selected_kpis=("pnl_sum", "pnl_sum"))
+
+    def test_unsupported_kpi_raises(self) -> None:
+        with pytest.raises(ResamplingError, match="Unsupported KPI"):
+            _config(selected_kpis=("win_rate",))
+
+    def test_negative_seed_raises(self) -> None:
+        with pytest.raises(ResamplingError, match="seed must be a non-negative int"):
+            _config(seed=-1)
+
+
+class TestReplayKPIBlock:
+    def test_valid_block(self) -> None:
+        block = _block("day-001")
+        assert block.block_id == "day-001"
+        assert block.pnl_sum == Decimal("0.50000000")
+
+    def test_invalid_run_id_raises(self) -> None:
+        with pytest.raises(ResamplingError, match="source_run_id"):
+            _block("day-001", source_run_id="bad-run")
+
+    def test_float_pnl_raises(self) -> None:
+        with pytest.raises(ResamplingError, match="pnl_sum must be a Decimal"):
+            ReplayKPIBlock(
+                block_id="day-001",
+                source_run_id=_RUN_ID,
+                dataset_fingerprint=_DATASET_FP,
+                execution_provenance_id=_EXECUTION_PROV,
+                signal_count=1,
+                fill_count=1,
+                reject_count=0,
+                pnl_sum=1.5,  # type: ignore[arg-type]
+            )
+
+
+class TestComputeResamplingStability:
+    def test_deterministic_same_inputs_same_output(self) -> None:
+        blocks = [
+            _block("day-001", signal_count=4, fill_count=3, reject_count=1, pnl_sum="0.5"),
+            _block("day-002", signal_count=5, fill_count=4, reject_count=1, pnl_sum="0.8"),
+            _block("day-003", signal_count=3, fill_count=1, reject_count=2, pnl_sum="-0.2"),
+            _block("day-004", signal_count=6, fill_count=5, reject_count=1, pnl_sum="1.1"),
+        ]
+        config = _config(sample_block_count=4)
+
+        first = compute_resampling_stability(blocks, config=config)
+        second = compute_resampling_stability(blocks, config=config)
+
+        assert first.to_dict() == second.to_dict()
+
+    def test_baseline_metrics_reflect_source_blocks(self) -> None:
+        blocks = [
+            _block("day-001", signal_count=4, fill_count=3, reject_count=1, pnl_sum="0.5"),
+            _block("day-002", signal_count=5, fill_count=4, reject_count=1, pnl_sum="0.8"),
+        ]
+        artifact = compute_resampling_stability(
+            blocks,
+            config=_config(sample_count=8, sample_block_count=2),
+        )
+
+        assert artifact.baseline_metrics["signal_count"] == "9"
+        assert artifact.baseline_metrics["pnl_sum"] == "1.30000000"
+        assert artifact.baseline_metrics["fill_rate"] == "0.77777778"
+
+    def test_source_provenance_pinned(self) -> None:
+        blocks = [_block("day-001"), _block("day-002")]
+        artifact = compute_resampling_stability(
+            blocks,
+            config=_config(sample_block_count=2),
+        )
+
+        assert artifact.source_provenance.source_run_id == _RUN_ID
+        assert artifact.source_provenance.run_count == 1
+        assert artifact.source_provenance.block_count == 2
+        assert len(artifact.source_provenance.input_fingerprint) == 64
+
+    def test_operator_summary_present(self) -> None:
+        blocks = [_block("day-001"), _block("day-002")]
+        artifact = compute_resampling_stability(
+            blocks,
+            config=_config(sample_block_count=2),
+        )
+
+        assert "method=block_bootstrap" in artifact.operator_summary[0]
+        assert any("fill_rate" in line for line in artifact.operator_summary)
+
+    def test_mixed_source_run_id_rejected(self) -> None:
+        blocks = [
+            _block("day-001", source_run_id=_RUN_ID),
+            _block("day-002", source_run_id="replay-ffffffffffff-0001"),
+        ]
+        with pytest.raises(ResamplingError, match="same source_run_id"):
+            compute_resampling_stability(blocks, config=_config(sample_block_count=2))
+
+    def test_mixed_dataset_fingerprint_rejected(self) -> None:
+        blocks = [
+            _block("day-001"),
+            _block("day-002", dataset_fingerprint="c" * 64),
+        ]
+        with pytest.raises(ResamplingError, match="same dataset_fingerprint"):
+            compute_resampling_stability(blocks, config=_config(sample_block_count=2))
+
+    def test_invalid_block_type_rejected(self) -> None:
+        with pytest.raises(ResamplingError, match="ReplayKPIBlock"):
+            compute_resampling_stability(["bad"], config=_config())  # type: ignore[list-item]
+
+    def test_empty_blocks_rejected(self) -> None:
+        with pytest.raises(ResamplingError, match="blocks must not be empty"):
+            compute_resampling_stability([], config=_config())
+
+    def test_output_type_is_artifact(self) -> None:
+        artifact = compute_resampling_stability([_block("day-001")], config=_config(sample_block_count=1))
+        assert isinstance(artifact, ResamplingStabilityArtifact)
+        assert artifact.resampling_method == "block_bootstrap"
+
+    def test_sample_block_count_must_match_input_size(self) -> None:
+        blocks = [_block("day-001"), _block("day-002")]
+        with pytest.raises(ResamplingError, match="sample_block_count must equal len\\(blocks\\)"):
+            compute_resampling_stability(blocks, config=_config(sample_block_count=1))
+
+
+class TestWriteResamplingStabilityArtifact:
+    def _artifact(self) -> ResamplingStabilityArtifact:
+        blocks = [
+            _block("day-001", signal_count=4, fill_count=3, reject_count=1, pnl_sum="0.5"),
+            _block("day-002", signal_count=5, fill_count=4, reject_count=1, pnl_sum="0.8"),
+            _block("day-003", signal_count=3, fill_count=1, reject_count=2, pnl_sum="-0.2"),
+        ]
+        return compute_resampling_stability(blocks, config=_config(sample_block_count=3))
+
+    def test_writes_json_artifact(self, tmp_path: Path) -> None:
+        artifact = self._artifact()
+        write_resampling_stability_artifact(artifact, tmp_path)
+
+        out = tmp_path / _STABILITY_ARTIFACT_FILENAME
+        assert out.exists()
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        assert payload["schema_version"] == "replay_resampling_stability.v1"
+        assert payload["resampling_method"] == "block_bootstrap"
+
+    def test_deterministic_file_content(self, tmp_path: Path) -> None:
+        artifact = self._artifact()
+        out = tmp_path / _STABILITY_ARTIFACT_FILENAME
+        write_resampling_stability_artifact(artifact, tmp_path)
+        content_one = out.read_text(encoding="utf-8")
+        out.unlink()
+        write_resampling_stability_artifact(artifact, tmp_path)
+        content_two = out.read_text(encoding="utf-8")
+        assert content_one == content_two
+
+    def test_fail_closed_on_io_error(self, tmp_path: Path) -> None:
+        artifact = self._artifact()
+        blocker = tmp_path / "blocker"
+        blocker.write_text("block", encoding="utf-8")
+        with pytest.raises(ResamplingError, match="Failed to write"):
+            write_resampling_stability_artifact(artifact, blocker)
+
+    def test_invalid_artifact_type_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ResamplingError, match="ResamplingStabilityArtifact"):
+            write_resampling_stability_artifact("bad", tmp_path)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- land the first narrow #1852 robustness slice: deterministic, fail-closed lock_bootstrap
- add an explicit resampling config contract and hard provenance pinning via ReplayKPIBlock
- emit machine-readable esampling_stability.json and an operator-facing stability section in the report builder
- add targeted tests for determinism, fail-closed validation, and provenance

## Not Included
- regime-weighted resampling
- runner auto-wiring
- broad replay-report schema expansion
- prediction or synthetic-market scope

## Validation
- pytest tests/unit/replay/test_resampling.py tests/unit/replay/test_replay_report_builder.py tests/unit/replay/test_replay_schema_validation.py tests/unit/validation/test_replay_reporter.py tests/unit/validation/test_strategy_replay_runner.py -q
- pytest tests/unit/replay/test_run_registry.py -q

Closes #1852