### PR TITLE
feat(github): add security quality readout (#1879)

### DIFF
--- a/scripts/audit/github_security_quality_readout.py
+++ b/scripts/audit/github_security_quality_readout.py
@@ -42,6 +42,10 @@ JSON_FILENAME = "github_security_quality_readout.json"
 MARKDOWN_FILENAME = "github_security_quality_summary.md"
 SCHEMA_VERSION = "github_security_quality_readout.v1"
 SOURCE_ORDER = ("code_scanning", "dependabot", "secret_scanning")
+REDACTED_SECRET_SUBJECT = "redacted_secret_alert"
+REDACTED_SECRET_RULE = "redacted_secret_type"
+REDACTED_SECRET_PATH = "redacted_secret_location"
+REDACTED_SECRET_COMPONENT = "secret_scanning_alert"
 SEVERITY_ORDER = (
     "critical",
     "high",
@@ -334,32 +338,20 @@ def normalize_dependabot_alert(
 def normalize_secret_scanning_alert(
     raw: dict[str, Any], *, reference_now: datetime
 ) -> dict[str, Any]:
-    location = (
-        raw.get("first_location_detected", {})
-        if isinstance(raw.get("first_location_detected"), dict)
-        else {}
-    )
-    secret_type = (
-        raw.get("secret_type_display_name")
-        if isinstance(raw.get("secret_type_display_name"), str)
-        and raw.get("secret_type_display_name")
-        else raw.get("secret_type")
-        if isinstance(raw.get("secret_type"), str)
-        else "unknown"
-    )
     created_at = raw.get("created_at") if isinstance(raw.get("created_at"), str) else None
     updated_at = raw.get("updated_at") if isinstance(raw.get("updated_at"), str) else None
-    path = location.get("path") if isinstance(location.get("path"), str) else None
     return {
         "source": "secret_scanning",
         "number": raw.get("number"),
         "state": raw.get("state", "unknown"),
         "severity": "not_provided",
-        "subject": secret_type,
-        "rule_or_advisory": raw.get("secret_type"),
+        # GitHub secret-scanning payloads may carry security-sensitive detail.
+        # Persist only redacted operator-safe placeholders in report artifacts.
+        "subject": REDACTED_SECRET_SUBJECT,
+        "rule_or_advisory": REDACTED_SECRET_RULE,
         "package": None,
-        "affected_path": path,
-        "affected_component": secret_type,
+        "affected_path": REDACTED_SECRET_PATH,
+        "affected_component": REDACTED_SECRET_COMPONENT,
         "branch": "not_provided",
         "created_at": created_at,
         "updated_at": updated_at,
@@ -368,7 +360,7 @@ def normalize_secret_scanning_alert(
             updated_at=updated_at,
             reference_now=reference_now,
         ),
-        "url": raw.get("html_url"),
+        "url": None,
         "tool": "Secret scanning",
     }
 
@@ -487,6 +479,7 @@ def build_markdown_report(readout: dict[str, Any]) -> str:
             "## Scope Note",
             "",
             "- Read-only GitHub-Readout; kein Auto-Fix, kein Dismiss, kein Close.",
+            "- Secret-Scanning-Detailfelder werden im Artefakt absichtlich redigiert, damit keine GitHub-seitigen Secret-Kontexte als Klartext persistiert werden.",
             "- `severity=not_provided` bedeutet: GitHub liefert fuer diese Surface keine native Severity.",
             "- `branch=not_provided` bedeutet: GitHub liefert fuer diese Alert-Surface keinen Branch-Kontext.",
             "",
@@ -626,8 +619,9 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_arg_parser().parse_args(argv)
+    repo = args.repo
     readout = generate_readout(
-        repo=args.repo,
+        repo=repo,
         out_dir=Path(args.out_dir),
         reference_now_utc=args.reference_now,
         gh_executable=args.gh_executable,
@@ -635,7 +629,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if readout["status"] == "PASS":
         print(
-            f"PASS: wrote {JSON_FILENAME} and {MARKDOWN_FILENAME} for {readout['repo']}.",
+            f"PASS: wrote {JSON_FILENAME} and {MARKDOWN_FILENAME} for {repo}.",
             file=sys.stderr,
         )
         return 0

--- a/scripts/audit/github_security_quality_readout.py
+++ b/scripts/audit/github_security_quality_readout.py
@@ -595,16 +595,111 @@ def build_readout(
     }
 
 
+def _copy_count_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    copied_rows: list[dict[str, Any]] = []
+    for row in rows:
+        copied_rows.append(
+            {
+                "value": str(row["value"]),
+                "count": int(row["count"]),
+            }
+        )
+    return copied_rows
+
+
+def build_exportable_readout(readout: dict[str, Any]) -> dict[str, Any]:
+    export_surfaces: list[dict[str, Any]] = []
+    for surface in readout["surfaces"]:
+        export_surface = {
+            "source": str(surface["source"]),
+            "endpoint": str(surface["endpoint"]),
+            "status": str(surface["status"]),
+            "alert_count": int(surface["alert_count"]),
+            "artifact_detail_status": str(surface["artifact_detail_status"]),
+        }
+        if isinstance(surface.get("note"), str):
+            export_surface["note"] = surface["note"]
+        export_surfaces.append(export_surface)
+
+    export_alerts: list[dict[str, Any]] = []
+    for alert in readout["alerts"]:
+        export_alerts.append(
+            {
+                "source": str(alert["source"]),
+                "number": alert.get("number"),
+                "state": str(alert["state"]),
+                "severity": str(alert["severity"]),
+                "subject": str(alert["subject"]),
+                "rule_or_advisory": (
+                    str(alert["rule_or_advisory"])
+                    if isinstance(alert.get("rule_or_advisory"), str)
+                    else None
+                ),
+                "package": (
+                    str(alert["package"])
+                    if isinstance(alert.get("package"), str)
+                    else None
+                ),
+                "affected_path": (
+                    str(alert["affected_path"])
+                    if isinstance(alert.get("affected_path"), str)
+                    else None
+                ),
+                "affected_component": (
+                    str(alert["affected_component"])
+                    if isinstance(alert.get("affected_component"), str)
+                    else None
+                ),
+                "branch": str(alert["branch"]),
+                "created_at": (
+                    str(alert["created_at"])
+                    if isinstance(alert.get("created_at"), str)
+                    else None
+                ),
+                "updated_at": (
+                    str(alert["updated_at"])
+                    if isinstance(alert.get("updated_at"), str)
+                    else None
+                ),
+                "age_bucket": str(alert["age_bucket"]),
+                "url": str(alert["url"]) if isinstance(alert.get("url"), str) else None,
+                "tool": str(alert["tool"]) if isinstance(alert.get("tool"), str) else None,
+            }
+        )
+
+    summary = readout["summary"]
+    export_summary = {
+        "total_alerts": int(summary["total_alerts"]),
+        "counts_by_source": _copy_count_rows(summary["counts_by_source"]),
+        "counts_by_state": _copy_count_rows(summary["counts_by_state"]),
+        "counts_by_severity": _copy_count_rows(summary["counts_by_severity"]),
+        "top_subjects": _copy_count_rows(summary["top_subjects"]),
+        "top_components": _copy_count_rows(summary["top_components"]),
+    }
+
+    return {
+        "schema_version": str(readout["schema_version"]),
+        "repo": str(readout["repo"]),
+        "reference_now_utc": str(readout["reference_now_utc"]),
+        "status": str(readout["status"]),
+        "readable_surface_count": int(readout["readable_surface_count"]),
+        "surfaces": export_surfaces,
+        "summary": export_summary,
+        "alerts": export_alerts,
+    }
+
+
 def write_report_artifacts(readout: dict[str, Any], out_dir: Path) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     json_path = out_dir / JSON_FILENAME
     markdown_path = out_dir / MARKDOWN_FILENAME
+    export_readout = build_exportable_readout(readout)
     json_path.write_text(
-        json.dumps(readout, indent=2, sort_keys=True) + "\n",
+        json.dumps(export_readout, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
     markdown_path.write_text(
-        build_markdown_report(readout),
+        build_markdown_report(export_readout),
         encoding="utf-8",
     )
 

--- a/scripts/audit/github_security_quality_readout.py
+++ b/scripts/audit/github_security_quality_readout.py
@@ -91,6 +91,13 @@ class SurfaceFetchResult:
             "endpoint": self.endpoint,
             "status": self.status,
             "alert_count": len(self.alerts),
+            "artifact_detail_status": (
+                "redacted"
+                if self.source == "secret_scanning" and self.status == "readable"
+                else "full"
+                if self.status == "readable"
+                else "none"
+            ),
         }
         if self.note is not None:
             result["note"] = self.note
@@ -127,6 +134,15 @@ def _normalize_severity(value: str | None) -> str:
     if not value:
         return "not_provided"
     return value.strip().lower() or "not_provided"
+
+
+def _normalize_state(value: str | None) -> str:
+    if not value:
+        return "unknown"
+    normalized = value.strip().lower()
+    if normalized in STATE_ORDER:
+        return normalized
+    return "unknown"
 
 
 def _age_bucket(
@@ -388,8 +404,13 @@ def _counter_items(counter: Counter[str], preferred_order: tuple[str, ...] = ())
     ]
 
 
-def build_summary(alerts: list[dict[str, Any]]) -> dict[str, Any]:
-    counts_by_source = Counter(alert["source"] for alert in alerts)
+def build_summary(
+    alerts: list[dict[str, Any]],
+    *,
+    readable_surface_counts: Counter[str],
+    redacted_state_counts: Counter[str] | None = None,
+) -> dict[str, Any]:
+    counts_by_source = Counter(readable_surface_counts)
     counts_by_state = Counter(alert["state"] for alert in alerts)
     counts_by_severity = Counter(alert["severity"] for alert in alerts)
     top_subjects = Counter(
@@ -410,8 +431,15 @@ def build_summary(alerts: list[dict[str, Any]]) -> dict[str, Any]:
             and alert.get("affected_component")
         )
     )
+    if redacted_state_counts:
+        redacted_count = sum(redacted_state_counts.values())
+        counts_by_state.update(redacted_state_counts)
+        if redacted_count > 0:
+            counts_by_severity["not_provided"] += redacted_count
+            top_subjects[REDACTED_SECRET_SUBJECT] += redacted_count
+            top_components[REDACTED_SECRET_PATH] += redacted_count
     return {
-        "total_alerts": len(alerts),
+        "total_alerts": sum(counts_by_source.values()),
         "counts_by_source": _counter_items(counts_by_source, SOURCE_ORDER),
         "counts_by_state": _counter_items(counts_by_state, STATE_ORDER),
         "counts_by_severity": _counter_items(counts_by_severity, SEVERITY_ORDER),
@@ -460,6 +488,11 @@ def build_markdown_report(readout: dict[str, Any]) -> str:
     unavailable = [
         surface for surface in readout["surfaces"] if surface["status"] != "readable"
     ]
+    redacted = [
+        surface
+        for surface in readout["surfaces"]
+        if surface.get("artifact_detail_status") == "redacted"
+    ]
     lines.extend(["", "## Coverage Notes", ""])
     if unavailable:
         lines.append(
@@ -472,6 +505,12 @@ def build_markdown_report(readout: dict[str, Any]) -> str:
             )
     else:
         lines.append("Alle angefragten GitHub-Surfaces waren lesbar.")
+    if redacted:
+        lines.append("")
+        lines.append(
+            "Secret-Scanning bleibt in Surface-, State- und Severity-Counts enthalten; "
+            "detaillierte Alert-Records werden im Artefakt bewusst redigiert."
+        )
 
     lines.extend(
         [
@@ -498,9 +537,18 @@ def build_readout(
     alerts: list[dict[str, Any]] = []
     surfaces_payload = [surface.to_dict() for surface in fetched_surfaces]
     readable_surfaces = 0
+    readable_surface_counts: Counter[str] = Counter()
+    redacted_state_counts: Counter[str] = Counter()
     for surface in fetched_surfaces:
         if surface.status == "readable":
             readable_surfaces += 1
+            if surface.alerts:
+                readable_surface_counts[surface.source] += len(surface.alerts)
+            if surface.source == "secret_scanning":
+                for raw in surface.alerts:
+                    state = raw.get("state") if isinstance(raw.get("state"), str) else None
+                    redacted_state_counts[_normalize_state(state)] += 1
+                continue
             for raw in surface.alerts:
                 alerts.append(
                     normalize_alert(
@@ -538,7 +586,11 @@ def build_readout(
         "status": status,
         "readable_surface_count": readable_surfaces,
         "surfaces": surfaces_payload,
-        "summary": build_summary(alerts),
+        "summary": build_summary(
+            alerts,
+            readable_surface_counts=readable_surface_counts,
+            redacted_state_counts=redacted_state_counts,
+        ),
         "alerts": alerts,
     }
 

--- a/scripts/audit/github_security_quality_readout.py
+++ b/scripts/audit/github_security_quality_readout.py
@@ -136,15 +136,6 @@ def _normalize_severity(value: str | None) -> str:
     return value.strip().lower() or "not_provided"
 
 
-def _normalize_state(value: str | None) -> str:
-    if not value:
-        return "unknown"
-    normalized = value.strip().lower()
-    if normalized in STATE_ORDER:
-        return normalized
-    return "unknown"
-
-
 def _age_bucket(
     *,
     created_at: str | None,
@@ -408,7 +399,6 @@ def build_summary(
     alerts: list[dict[str, Any]],
     *,
     readable_surface_counts: Counter[str],
-    redacted_state_counts: Counter[str] | None = None,
 ) -> dict[str, Any]:
     counts_by_source = Counter(readable_surface_counts)
     counts_by_state = Counter(alert["state"] for alert in alerts)
@@ -431,13 +421,6 @@ def build_summary(
             and alert.get("affected_component")
         )
     )
-    if redacted_state_counts:
-        redacted_count = sum(redacted_state_counts.values())
-        counts_by_state.update(redacted_state_counts)
-        if redacted_count > 0:
-            counts_by_severity["not_provided"] += redacted_count
-            top_subjects[REDACTED_SECRET_SUBJECT] += redacted_count
-            top_components[REDACTED_SECRET_PATH] += redacted_count
     return {
         "total_alerts": sum(counts_by_source.values()),
         "counts_by_source": _counter_items(counts_by_source, SOURCE_ORDER),
@@ -508,8 +491,8 @@ def build_markdown_report(readout: dict[str, Any]) -> str:
     if redacted:
         lines.append("")
         lines.append(
-            "Secret-Scanning bleibt in Surface-, State- und Severity-Counts enthalten; "
-            "detaillierte Alert-Records werden im Artefakt bewusst redigiert."
+            "Secret-Scanning bleibt in Surface-Coverage und Source-Counts enthalten; "
+            "State-/Severity- und Top-Breakdowns werden dafuer bewusst nicht exportiert."
         )
 
     lines.extend(
@@ -538,16 +521,12 @@ def build_readout(
     surfaces_payload = [surface.to_dict() for surface in fetched_surfaces]
     readable_surfaces = 0
     readable_surface_counts: Counter[str] = Counter()
-    redacted_state_counts: Counter[str] = Counter()
     for surface in fetched_surfaces:
         if surface.status == "readable":
             readable_surfaces += 1
             if surface.alerts:
                 readable_surface_counts[surface.source] += len(surface.alerts)
             if surface.source == "secret_scanning":
-                for raw in surface.alerts:
-                    state = raw.get("state") if isinstance(raw.get("state"), str) else None
-                    redacted_state_counts[_normalize_state(state)] += 1
                 continue
             for raw in surface.alerts:
                 alerts.append(
@@ -589,7 +568,6 @@ def build_readout(
         "summary": build_summary(
             alerts,
             readable_surface_counts=readable_surface_counts,
-            redacted_state_counts=redacted_state_counts,
         ),
         "alerts": alerts,
     }

--- a/scripts/audit/github_security_quality_readout.py
+++ b/scripts/audit/github_security_quality_readout.py
@@ -83,14 +83,16 @@ class SurfaceFetchResult:
     endpoint: str
     status: str
     alerts: tuple[dict[str, Any], ...]
+    alert_count: int | None = None
     note: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
+        alert_count = self.alert_count if self.alert_count is not None else len(self.alerts)
         result: dict[str, Any] = {
             "source": self.source,
             "endpoint": self.endpoint,
             "status": self.status,
-            "alert_count": len(self.alerts),
+            "alert_count": alert_count,
             "artifact_detail_status": (
                 "redacted"
                 if self.source == "secret_scanning" and self.status == "readable"
@@ -245,11 +247,22 @@ def fetch_surface(
                 )
             alerts.append(item)
 
+    alert_count = len(alerts)
+    if source == "secret_scanning":
+        return SurfaceFetchResult(
+            source=source,
+            endpoint=endpoint,
+            status="readable",
+            alerts=(),
+            alert_count=alert_count,
+        )
+
     return SurfaceFetchResult(
         source=source,
         endpoint=endpoint,
         status="readable",
         alerts=tuple(alerts),
+        alert_count=alert_count,
     )
 
 
@@ -524,8 +537,11 @@ def build_readout(
     for surface in fetched_surfaces:
         if surface.status == "readable":
             readable_surfaces += 1
-            if surface.alerts:
-                readable_surface_counts[surface.source] += len(surface.alerts)
+            surface_alert_count = (
+                surface.alert_count if surface.alert_count is not None else len(surface.alerts)
+            )
+            if surface_alert_count:
+                readable_surface_counts[surface.source] += surface_alert_count
             if surface.source == "secret_scanning":
                 continue
             for raw in surface.alerts:

--- a/scripts/audit/github_security_quality_readout.py
+++ b/scripts/audit/github_security_quality_readout.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+"""
+Read-only GitHub security and quality readout for the current repository.
+
+This script fetches GitHub Security-and-quality alert surfaces via `gh api`,
+normalizes them into a shared schema, and emits both machine-readable JSON and
+an operator-facing Markdown summary.
+
+Scope:
+  - code scanning alerts
+  - dependabot alerts
+  - secret scanning alerts
+
+Design rules:
+  - read-only GitHub access only
+  - fail-closed surface handling: unavailable APIs/permissions are explicit
+  - deterministic JSON/Markdown output for the same fetched payloads and
+    reference timestamp
+  - no raw alert payloads are persisted in the output artifacts
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+if __name__ == "__main__":
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from core.utils.clock import utcnow
+
+DEFAULT_REPO = "jannekbuengener/Claire_de_Binare"
+DEFAULT_GH_EXECUTABLE = "gh"
+JSON_FILENAME = "github_security_quality_readout.json"
+MARKDOWN_FILENAME = "github_security_quality_summary.md"
+SCHEMA_VERSION = "github_security_quality_readout.v1"
+SOURCE_ORDER = ("code_scanning", "dependabot", "secret_scanning")
+SEVERITY_ORDER = (
+    "critical",
+    "high",
+    "medium",
+    "low",
+    "warning",
+    "error",
+    "note",
+    "not_provided",
+    "unknown",
+)
+STATE_ORDER = (
+    "open",
+    "dismissed",
+    "fixed",
+    "resolved",
+    "auto_dismissed",
+    "closed",
+    "unknown",
+)
+SURFACE_ENDPOINTS = {
+    "code_scanning": "repos/{repo}/code-scanning/alerts?per_page=100",
+    "dependabot": "repos/{repo}/dependabot/alerts?per_page=100",
+    "secret_scanning": "repos/{repo}/secret-scanning/alerts?per_page=100",
+}
+
+
+class SecurityQualityReadoutError(ValueError):
+    """Raised when the readout configuration is invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class SurfaceFetchResult:
+    source: str
+    endpoint: str
+    status: str
+    alerts: tuple[dict[str, Any], ...]
+    note: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "source": self.source,
+            "endpoint": self.endpoint,
+            "status": self.status,
+            "alert_count": len(self.alerts),
+        }
+        if self.note is not None:
+            result["note"] = self.note
+        return result
+
+
+def _utc_now_iso() -> str:
+    current = utcnow()
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    else:
+        current = current.astimezone(timezone.utc)
+    return current.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso8601(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _normalize_branch(value: str | None) -> str:
+    if not value:
+        return "not_provided"
+    if value.startswith("refs/heads/"):
+        return value[len("refs/heads/") :]
+    return value
+
+
+def _normalize_severity(value: str | None) -> str:
+    if not value:
+        return "not_provided"
+    return value.strip().lower() or "not_provided"
+
+
+def _age_bucket(
+    *,
+    created_at: str | None,
+    updated_at: str | None,
+    reference_now: datetime,
+) -> str:
+    basis = updated_at or created_at
+    if basis is None:
+        return "unknown"
+    age_days = (reference_now - _parse_iso8601(basis)).days
+    if age_days < 0:
+        return "future"
+    if age_days <= 7:
+        return "0-7d"
+    if age_days <= 30:
+        return "8-30d"
+    if age_days <= 90:
+        return "31-90d"
+    return "91d+"
+
+
+def _completed_process_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=120,
+        check=False,
+    )
+
+
+def fetch_surface(
+    *,
+    source: str,
+    repo: str,
+    gh_executable: str = DEFAULT_GH_EXECUTABLE,
+    runner: Callable[[list[str]], subprocess.CompletedProcess[str]] = _completed_process_runner,
+) -> SurfaceFetchResult:
+    if source not in SURFACE_ENDPOINTS:
+        raise SecurityQualityReadoutError(f"Unsupported source: {source}")
+
+    endpoint = SURFACE_ENDPOINTS[source].format(repo=repo)
+    command = [gh_executable, "api", "--paginate", "--slurp", endpoint]
+    result = runner(command)
+    if result.returncode != 0:
+        note = (result.stderr or result.stdout).strip() or "gh api failed"
+        return SurfaceFetchResult(
+            source=source,
+            endpoint=endpoint,
+            status="unavailable",
+            alerts=(),
+            note=note,
+        )
+
+    if not isinstance(result.stdout, str):
+        return SurfaceFetchResult(
+            source=source,
+            endpoint=endpoint,
+            status="unavailable",
+            alerts=(),
+            note="gh api returned no stdout payload",
+        )
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return SurfaceFetchResult(
+            source=source,
+            endpoint=endpoint,
+            status="unavailable",
+            alerts=(),
+            note=f"invalid json from gh api: {exc}",
+        )
+
+    if not isinstance(payload, list):
+        return SurfaceFetchResult(
+            source=source,
+            endpoint=endpoint,
+            status="unavailable",
+            alerts=(),
+            note="gh api payload root must be a JSON array of pages",
+        )
+
+    alerts: list[dict[str, Any]] = []
+    for page_index, page in enumerate(payload):
+        if not isinstance(page, list):
+            return SurfaceFetchResult(
+                source=source,
+                endpoint=endpoint,
+                status="unavailable",
+                alerts=(),
+                note=f"gh api page {page_index} is not a JSON array",
+            )
+        for item_index, item in enumerate(page):
+            if not isinstance(item, dict):
+                return SurfaceFetchResult(
+                    source=source,
+                    endpoint=endpoint,
+                    status="unavailable",
+                    alerts=(),
+                    note=(
+                        f"gh api page {page_index} item {item_index} "
+                        f"is not a JSON object"
+                    ),
+                )
+            alerts.append(item)
+
+    return SurfaceFetchResult(
+        source=source,
+        endpoint=endpoint,
+        status="readable",
+        alerts=tuple(alerts),
+    )
+
+
+def normalize_code_scanning_alert(
+    raw: dict[str, Any], *, reference_now: datetime
+) -> dict[str, Any]:
+    rule = raw.get("rule", {}) if isinstance(raw.get("rule"), dict) else {}
+    most_recent = (
+        raw.get("most_recent_instance", {})
+        if isinstance(raw.get("most_recent_instance"), dict)
+        else {}
+    )
+    location = (
+        most_recent.get("location", {})
+        if isinstance(most_recent.get("location"), dict)
+        else {}
+    )
+    path = location.get("path") if isinstance(location.get("path"), str) else None
+    created_at = raw.get("created_at") if isinstance(raw.get("created_at"), str) else None
+    updated_at = raw.get("updated_at") if isinstance(raw.get("updated_at"), str) else None
+    subject = (
+        rule.get("id")
+        if isinstance(rule.get("id"), str) and rule.get("id")
+        else rule.get("name")
+        if isinstance(rule.get("name"), str)
+        else "unknown"
+    )
+    tool = raw.get("tool", {}) if isinstance(raw.get("tool"), dict) else {}
+    return {
+        "source": "code_scanning",
+        "number": raw.get("number"),
+        "state": raw.get("state", "unknown"),
+        "severity": _normalize_severity(
+            rule.get("security_severity_level") or rule.get("severity")
+        ),
+        "subject": subject,
+        "rule_or_advisory": subject,
+        "package": None,
+        "affected_path": path,
+        "affected_component": path,
+        "branch": _normalize_branch(
+            most_recent.get("ref") if isinstance(most_recent.get("ref"), str) else None
+        ),
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "age_bucket": _age_bucket(
+            created_at=created_at,
+            updated_at=updated_at,
+            reference_now=reference_now,
+        ),
+        "url": raw.get("html_url"),
+        "tool": tool.get("name"),
+    }
+
+
+def normalize_dependabot_alert(
+    raw: dict[str, Any], *, reference_now: datetime
+) -> dict[str, Any]:
+    dependency = raw.get("dependency", {}) if isinstance(raw.get("dependency"), dict) else {}
+    package = dependency.get("package", {}) if isinstance(dependency.get("package"), dict) else {}
+    advisory = (
+        raw.get("security_advisory", {})
+        if isinstance(raw.get("security_advisory"), dict)
+        else {}
+    )
+    package_name = package.get("name") if isinstance(package.get("name"), str) else None
+    ghsa_id = advisory.get("ghsa_id") if isinstance(advisory.get("ghsa_id"), str) else None
+    created_at = raw.get("created_at") if isinstance(raw.get("created_at"), str) else None
+    updated_at = raw.get("updated_at") if isinstance(raw.get("updated_at"), str) else None
+    return {
+        "source": "dependabot",
+        "number": raw.get("number"),
+        "state": raw.get("state", "unknown"),
+        "severity": _normalize_severity(advisory.get("severity")),
+        "subject": package_name or ghsa_id or "unknown",
+        "rule_or_advisory": ghsa_id,
+        "package": package_name,
+        "affected_path": dependency.get("manifest_path"),
+        "affected_component": package_name,
+        "branch": "not_provided",
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "age_bucket": _age_bucket(
+            created_at=created_at,
+            updated_at=updated_at,
+            reference_now=reference_now,
+        ),
+        "url": raw.get("html_url"),
+        "tool": "Dependabot",
+    }
+
+
+def normalize_secret_scanning_alert(
+    raw: dict[str, Any], *, reference_now: datetime
+) -> dict[str, Any]:
+    location = (
+        raw.get("first_location_detected", {})
+        if isinstance(raw.get("first_location_detected"), dict)
+        else {}
+    )
+    secret_type = (
+        raw.get("secret_type_display_name")
+        if isinstance(raw.get("secret_type_display_name"), str)
+        and raw.get("secret_type_display_name")
+        else raw.get("secret_type")
+        if isinstance(raw.get("secret_type"), str)
+        else "unknown"
+    )
+    created_at = raw.get("created_at") if isinstance(raw.get("created_at"), str) else None
+    updated_at = raw.get("updated_at") if isinstance(raw.get("updated_at"), str) else None
+    path = location.get("path") if isinstance(location.get("path"), str) else None
+    return {
+        "source": "secret_scanning",
+        "number": raw.get("number"),
+        "state": raw.get("state", "unknown"),
+        "severity": "not_provided",
+        "subject": secret_type,
+        "rule_or_advisory": raw.get("secret_type"),
+        "package": None,
+        "affected_path": path,
+        "affected_component": secret_type,
+        "branch": "not_provided",
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "age_bucket": _age_bucket(
+            created_at=created_at,
+            updated_at=updated_at,
+            reference_now=reference_now,
+        ),
+        "url": raw.get("html_url"),
+        "tool": "Secret scanning",
+    }
+
+
+def normalize_alert(
+    source: str, raw: dict[str, Any], *, reference_now: datetime
+) -> dict[str, Any]:
+    if source == "code_scanning":
+        return normalize_code_scanning_alert(raw, reference_now=reference_now)
+    if source == "dependabot":
+        return normalize_dependabot_alert(raw, reference_now=reference_now)
+    if source == "secret_scanning":
+        return normalize_secret_scanning_alert(raw, reference_now=reference_now)
+    raise SecurityQualityReadoutError(f"Unsupported source: {source}")
+
+
+def _counter_items(counter: Counter[str], preferred_order: tuple[str, ...] = ()) -> list[dict[str, Any]]:
+    order_map = {value: index for index, value in enumerate(preferred_order)}
+    return [
+        {"value": key, "count": count}
+        for key, count in sorted(
+            counter.items(),
+            key=lambda item: (-item[1], order_map.get(item[0], len(order_map)), item[0]),
+        )
+    ]
+
+
+def build_summary(alerts: list[dict[str, Any]]) -> dict[str, Any]:
+    counts_by_source = Counter(alert["source"] for alert in alerts)
+    counts_by_state = Counter(alert["state"] for alert in alerts)
+    counts_by_severity = Counter(alert["severity"] for alert in alerts)
+    top_subjects = Counter(
+        alert["subject"] for alert in alerts if isinstance(alert.get("subject"), str)
+    )
+    top_components = Counter(
+        (
+            alert.get("affected_path")
+            if isinstance(alert.get("affected_path"), str) and alert.get("affected_path")
+            else alert.get("affected_component")
+        )
+        for alert in alerts
+        if (
+            isinstance(alert.get("affected_path"), str) and alert.get("affected_path")
+        )
+        or (
+            isinstance(alert.get("affected_component"), str)
+            and alert.get("affected_component")
+        )
+    )
+    return {
+        "total_alerts": len(alerts),
+        "counts_by_source": _counter_items(counts_by_source, SOURCE_ORDER),
+        "counts_by_state": _counter_items(counts_by_state, STATE_ORDER),
+        "counts_by_severity": _counter_items(counts_by_severity, SEVERITY_ORDER),
+        "top_subjects": _counter_items(top_subjects)[:10],
+        "top_components": _counter_items(top_components)[:10],
+    }
+
+
+def build_markdown_report(readout: dict[str, Any]) -> str:
+    lines = [
+        "# GitHub Security and Quality Readout",
+        "",
+        f"- Repo: `{readout['repo']}`",
+        f"- Reference now (UTC): `{readout['reference_now_utc']}`",
+        f"- Overall status: **{readout['status']}**",
+        f"- Readable surfaces: `{readout['readable_surface_count']}/{len(readout['surfaces'])}`",
+        f"- Total normalized alerts: `{readout['summary']['total_alerts']}`",
+        "",
+        "## Surface Coverage",
+        "",
+        "| Source | Status | Alerts | Note |",
+        "|--------|--------|--------|------|",
+    ]
+
+    for surface in readout["surfaces"]:
+        note = surface.get("note") or "—"
+        lines.append(
+            f"| `{surface['source']}` | {surface['status']} | {surface['alert_count']} | {note} |"
+        )
+
+    def add_counter_section(title: str, rows: list[dict[str, Any]]) -> None:
+        lines.extend(["", f"## {title}", "", "| Value | Count |", "|-------|-------|"])
+        if rows:
+            for row in rows:
+                lines.append(f"| `{row['value']}` | {row['count']} |")
+        else:
+            lines.append("| `none` | 0 |")
+
+    summary = readout["summary"]
+    add_counter_section("Counts by Source", summary["counts_by_source"])
+    add_counter_section("Counts by Severity", summary["counts_by_severity"])
+    add_counter_section("Counts by State", summary["counts_by_state"])
+    add_counter_section("Top Subjects", summary["top_subjects"])
+    add_counter_section("Top Components or Paths", summary["top_components"])
+
+    unavailable = [
+        surface for surface in readout["surfaces"] if surface["status"] != "readable"
+    ]
+    lines.extend(["", "## Coverage Notes", ""])
+    if unavailable:
+        lines.append(
+            "Dieses Bild ist partiell. Mindestens eine GitHub-Surface war nicht lesbar:"
+        )
+        lines.append("")
+        for surface in unavailable:
+            lines.append(
+                f"- `{surface['source']}`: {surface.get('note') or 'unavailable'}"
+            )
+    else:
+        lines.append("Alle angefragten GitHub-Surfaces waren lesbar.")
+
+    lines.extend(
+        [
+            "",
+            "## Scope Note",
+            "",
+            "- Read-only GitHub-Readout; kein Auto-Fix, kein Dismiss, kein Close.",
+            "- `severity=not_provided` bedeutet: GitHub liefert fuer diese Surface keine native Severity.",
+            "- `branch=not_provided` bedeutet: GitHub liefert fuer diese Alert-Surface keinen Branch-Kontext.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_readout(
+    *,
+    repo: str,
+    reference_now_utc: str,
+    fetched_surfaces: list[SurfaceFetchResult],
+) -> dict[str, Any]:
+    reference_now = _parse_iso8601(reference_now_utc)
+    alerts: list[dict[str, Any]] = []
+    surfaces_payload = [surface.to_dict() for surface in fetched_surfaces]
+    readable_surfaces = 0
+    for surface in fetched_surfaces:
+        if surface.status == "readable":
+            readable_surfaces += 1
+            for raw in surface.alerts:
+                alerts.append(
+                    normalize_alert(
+                        surface.source,
+                        raw,
+                        reference_now=reference_now,
+                    )
+                )
+
+    alerts.sort(
+        key=lambda alert: (
+            alert["source"],
+            str(alert["state"]),
+            str(alert["severity"]),
+            str(alert["subject"]),
+            str(alert.get("affected_component")),
+            str(alert.get("affected_path")),
+            str(alert["branch"]),
+            str(alert.get("created_at")),
+            str(alert.get("number")),
+        )
+    )
+
+    if readable_surfaces == len(fetched_surfaces):
+        status = "PASS"
+    elif readable_surfaces == 0:
+        status = "FAIL"
+    else:
+        status = "PARTIAL"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "repo": repo,
+        "reference_now_utc": reference_now_utc,
+        "status": status,
+        "readable_surface_count": readable_surfaces,
+        "surfaces": surfaces_payload,
+        "summary": build_summary(alerts),
+        "alerts": alerts,
+    }
+
+
+def write_report_artifacts(readout: dict[str, Any], out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / JSON_FILENAME
+    markdown_path = out_dir / MARKDOWN_FILENAME
+    json_path.write_text(
+        json.dumps(readout, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(
+        build_markdown_report(readout),
+        encoding="utf-8",
+    )
+
+
+def generate_readout(
+    *,
+    repo: str,
+    out_dir: Path,
+    reference_now_utc: str | None = None,
+    gh_executable: str = DEFAULT_GH_EXECUTABLE,
+    runner: Callable[[list[str]], subprocess.CompletedProcess[str]] = _completed_process_runner,
+) -> dict[str, Any]:
+    if reference_now_utc is None:
+        reference_now_utc = _utc_now_iso()
+    _parse_iso8601(reference_now_utc)
+
+    surfaces = [
+        fetch_surface(
+            source=source,
+            repo=repo,
+            gh_executable=gh_executable,
+            runner=runner,
+        )
+        for source in SOURCE_ORDER
+    ]
+    readout = build_readout(
+        repo=repo,
+        reference_now_utc=reference_now_utc,
+        fetched_surfaces=surfaces,
+    )
+    write_report_artifacts(readout, out_dir)
+    return readout
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read-only GitHub Security and quality readout for code scanning, "
+            "Dependabot, and secret scanning."
+        )
+    )
+    parser.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help="owner/repo, default CDB repo",
+    )
+    parser.add_argument(
+        "--out-dir",
+        required=True,
+        help="Directory for JSON and Markdown output artifacts",
+    )
+    parser.add_argument(
+        "--reference-now",
+        default=None,
+        help="Optional UTC reference timestamp (ISO-8601) for deterministic age buckets",
+    )
+    parser.add_argument(
+        "--gh-executable",
+        default=DEFAULT_GH_EXECUTABLE,
+        help="gh executable path/name",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    readout = generate_readout(
+        repo=args.repo,
+        out_dir=Path(args.out_dir),
+        reference_now_utc=args.reference_now,
+        gh_executable=args.gh_executable,
+    )
+
+    if readout["status"] == "PASS":
+        print(
+            f"PASS: wrote {JSON_FILENAME} and {MARKDOWN_FILENAME} for {readout['repo']}.",
+            file=sys.stderr,
+        )
+        return 0
+    if readout["status"] == "PARTIAL":
+        print(
+            "PARTIAL: one or more GitHub Security surfaces were unavailable; "
+            "artifacts were still written fail-closed.",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        "FAIL: no GitHub Security surfaces were readable; artifacts were written "
+        "with explicit unavailable status.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit/github_security_quality_readout.py
+++ b/scripts/audit/github_security_quality_readout.py
@@ -688,10 +688,14 @@ def write_report_artifacts(readout: dict[str, Any], out_dir: Path) -> None:
     json_path = out_dir / JSON_FILENAME
     markdown_path = out_dir / MARKDOWN_FILENAME
     export_readout = build_exportable_readout(readout)
+    # codeql[py/clear-text-storage-sensitive-data]: export_readout contains only
+    # pre-redacted, export-safe fields; secret-scanning raw payload is discarded at fetch time.
     json_path.write_text(
         json.dumps(export_readout, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+    # codeql[py/clear-text-storage-sensitive-data]: export_readout contains only
+    # pre-redacted, export-safe fields; secret-scanning raw payload is discarded at fetch time.
     markdown_path.write_text(
         build_markdown_report(export_readout),
         encoding="utf-8",

--- a/scripts/audit/github_security_quality_readout.py
+++ b/scripts/audit/github_security_quality_readout.py
@@ -87,7 +87,12 @@ class SurfaceFetchResult:
     note: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        alert_count = self.alert_count if self.alert_count is not None else len(self.alerts)
+        if self.alert_count is not None:
+            alert_count: int | None = self.alert_count
+        elif self.source == "secret_scanning" and self.status == "readable":
+            alert_count = None
+        else:
+            alert_count = len(self.alerts)
         result: dict[str, Any] = {
             "source": self.source,
             "endpoint": self.endpoint,
@@ -247,14 +252,16 @@ def fetch_surface(
                 )
             alerts.append(item)
 
-    alert_count = len(alerts)
     if source == "secret_scanning":
         return SurfaceFetchResult(
             source=source,
             endpoint=endpoint,
             status="readable",
             alerts=(),
-            alert_count=alert_count,
+            note=(
+                "payload-redacted: alert details and counts are intentionally "
+                "excluded from persisted artifacts"
+            ),
         )
 
     return SurfaceFetchResult(
@@ -262,7 +269,7 @@ def fetch_surface(
         endpoint=endpoint,
         status="readable",
         alerts=tuple(alerts),
-        alert_count=alert_count,
+        alert_count=len(alerts),
     )
 
 
@@ -463,7 +470,8 @@ def build_markdown_report(readout: dict[str, Any]) -> str:
     for surface in readout["surfaces"]:
         note = surface.get("note") or "—"
         lines.append(
-            f"| `{surface['source']}` | {surface['status']} | {surface['alert_count']} | {note} |"
+            f"| `{surface['source']}` | {surface['status']} | "
+            f"{'redacted' if surface['alert_count'] is None else surface['alert_count']} | {note} |"
         )
 
     def add_counter_section(title: str, rows: list[dict[str, Any]]) -> None:
@@ -504,8 +512,8 @@ def build_markdown_report(readout: dict[str, Any]) -> str:
     if redacted:
         lines.append("")
         lines.append(
-            "Secret-Scanning bleibt in Surface-Coverage und Source-Counts enthalten; "
-            "State-/Severity- und Top-Breakdowns werden dafuer bewusst nicht exportiert."
+            "Secret-Scanning bleibt in der Surface-Coverage sichtbar; "
+            "payload-abgeleitete Counts und Breakdowns werden dafuer bewusst nicht persistiert."
         )
 
     lines.extend(
@@ -537,13 +545,13 @@ def build_readout(
     for surface in fetched_surfaces:
         if surface.status == "readable":
             readable_surfaces += 1
+            if surface.source == "secret_scanning":
+                continue
             surface_alert_count = (
                 surface.alert_count if surface.alert_count is not None else len(surface.alerts)
             )
             if surface_alert_count:
                 readable_surface_counts[surface.source] += surface_alert_count
-            if surface.source == "secret_scanning":
-                continue
             for raw in surface.alerts:
                 alerts.append(
                     normalize_alert(
@@ -608,7 +616,11 @@ def build_exportable_readout(readout: dict[str, Any]) -> dict[str, Any]:
             "source": str(surface["source"]),
             "endpoint": str(surface["endpoint"]),
             "status": str(surface["status"]),
-            "alert_count": int(surface["alert_count"]),
+            "alert_count": (
+                int(surface["alert_count"])
+                if surface["alert_count"] is not None
+                else None
+            ),
             "artifact_detail_status": str(surface["artifact_detail_status"]),
         }
         if isinstance(surface.get("note"), str):

--- a/tests/unit/audit/test_github_security_quality_readout.py
+++ b/tests/unit/audit/test_github_security_quality_readout.py
@@ -174,6 +174,29 @@ class TestFetchSurface:
         assert result.status == "unavailable"
         assert result.note == "gh api returned no stdout payload"
 
+    def test_fetch_surface_redacts_secret_scanning_payload_after_counting(self):
+        result = fetch_surface(
+            source="secret_scanning",
+            repo="octo/example",
+            runner=lambda command: _completed_process(
+                stdout=json.dumps(
+                    [[
+                        {
+                            "number": 9,
+                            "state": "resolved",
+                            "secret_type": "generic_api_key",
+                            "secret_type_display_name": "Generic API Key",
+                            "first_location_detected": {"path": ".env"},
+                        }
+                    ]]
+                )
+            ),
+        )
+
+        assert result.status == "readable"
+        assert result.alert_count == 1
+        assert result.alerts == ()
+
 
 class TestReadoutGeneration:
     def test_build_readout_is_partial_when_a_surface_is_unavailable(self):

--- a/tests/unit/audit/test_github_security_quality_readout.py
+++ b/tests/unit/audit/test_github_security_quality_readout.py
@@ -1,0 +1,306 @@
+"""Tests for scripts.audit.github_security_quality_readout."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+repo_root = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(repo_root / "scripts"))
+sys.path.insert(0, str(repo_root))
+
+from audit.github_security_quality_readout import (  # noqa: E402
+    JSON_FILENAME,
+    MARKDOWN_FILENAME,
+    SurfaceFetchResult,
+    build_markdown_report,
+    build_readout,
+    fetch_surface,
+    generate_readout,
+    normalize_code_scanning_alert,
+    normalize_dependabot_alert,
+    normalize_secret_scanning_alert,
+)
+
+
+def _completed_process(
+    *,
+    stdout: str = "",
+    stderr: str = "",
+    returncode: int = 0,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["gh", "api"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+class TestNormalizeAlerts:
+    def test_normalize_code_scanning_alert(self):
+        alert = normalize_code_scanning_alert(
+            {
+                "number": 12,
+                "state": "open",
+                "created_at": "2026-03-01T10:00:00Z",
+                "updated_at": "2026-03-20T10:00:00Z",
+                "html_url": "https://example.invalid/code/12",
+                "rule": {
+                    "id": "py/path-traversal",
+                    "security_severity_level": "high",
+                    "name": "Path traversal",
+                },
+                "most_recent_instance": {
+                    "ref": "refs/heads/main",
+                    "location": {"path": "core/security/check.py"},
+                },
+                "tool": {"name": "CodeQL"},
+            },
+            reference_now=generate_readout.__globals__["_parse_iso8601"](
+                "2026-04-23T00:00:00Z"
+            ),
+        )
+
+        assert alert["source"] == "code_scanning"
+        assert alert["severity"] == "high"
+        assert alert["rule_or_advisory"] == "py/path-traversal"
+        assert alert["affected_path"] == "core/security/check.py"
+        assert alert["branch"] == "main"
+        assert alert["age_bucket"] == "31-90d"
+        assert alert["tool"] == "CodeQL"
+
+    def test_normalize_dependabot_alert(self):
+        alert = normalize_dependabot_alert(
+            {
+                "number": 7,
+                "state": "fixed",
+                "created_at": "2026-04-20T12:00:00Z",
+                "updated_at": "2026-04-21T12:00:00Z",
+                "html_url": "https://example.invalid/dependabot/7",
+                "dependency": {
+                    "manifest_path": "requirements.txt",
+                    "package": {"name": "requests"},
+                },
+                "security_advisory": {
+                    "ghsa_id": "GHSA-test-1234",
+                    "severity": "medium",
+                },
+            },
+            reference_now=generate_readout.__globals__["_parse_iso8601"](
+                "2026-04-23T00:00:00Z"
+            ),
+        )
+
+        assert alert["source"] == "dependabot"
+        assert alert["subject"] == "requests"
+        assert alert["rule_or_advisory"] == "GHSA-test-1234"
+        assert alert["affected_path"] == "requirements.txt"
+        assert alert["branch"] == "not_provided"
+        assert alert["severity"] == "medium"
+        assert alert["age_bucket"] == "0-7d"
+
+    def test_normalize_secret_scanning_alert(self):
+        alert = normalize_secret_scanning_alert(
+            {
+                "number": 3,
+                "state": "resolved",
+                "created_at": "2025-12-01T00:00:00Z",
+                "updated_at": "2026-01-15T00:00:00Z",
+                "html_url": "https://example.invalid/secret/3",
+                "secret_type": "generic_api_key",
+                "secret_type_display_name": "Generic API Key",
+                "first_location_detected": {"path": ".env"},
+            },
+            reference_now=generate_readout.__globals__["_parse_iso8601"](
+                "2026-04-23T00:00:00Z"
+            ),
+        )
+
+        assert alert["source"] == "secret_scanning"
+        assert alert["subject"] == "Generic API Key"
+        assert alert["rule_or_advisory"] == "generic_api_key"
+        assert alert["affected_path"] == ".env"
+        assert alert["severity"] == "not_provided"
+        assert alert["branch"] == "not_provided"
+        assert alert["age_bucket"] == "91d+"
+
+
+class TestFetchSurface:
+    def test_fetch_surface_marks_permission_failure_unavailable(self):
+        result = fetch_surface(
+            source="dependabot",
+            repo="octo/example",
+            runner=lambda command: _completed_process(
+                returncode=1,
+                stderr="gh: HTTP 403: Resource not accessible by integration",
+            ),
+        )
+
+        assert result.status == "unavailable"
+        assert result.alerts == ()
+        assert "HTTP 403" in (result.note or "")
+
+    def test_fetch_surface_marks_invalid_page_shape_unavailable(self):
+        result = fetch_surface(
+            source="secret_scanning",
+            repo="octo/example",
+            runner=lambda command: _completed_process(stdout=json.dumps([{"bad": "shape"}])),
+        )
+
+        assert result.status == "unavailable"
+        assert "page 0 is not a JSON array" in (result.note or "")
+
+    def test_fetch_surface_marks_missing_stdout_unavailable(self):
+        result = fetch_surface(
+            source="code_scanning",
+            repo="octo/example",
+            runner=lambda command: subprocess.CompletedProcess(
+                args=["gh", "api"],
+                returncode=0,
+                stdout=None,
+                stderr="",
+            ),
+        )
+
+        assert result.status == "unavailable"
+        assert result.note == "gh api returned no stdout payload"
+
+
+class TestReadoutGeneration:
+    def test_build_readout_is_partial_when_a_surface_is_unavailable(self):
+        readout = build_readout(
+            repo="octo/example",
+            reference_now_utc="2026-04-23T00:00:00Z",
+            fetched_surfaces=[
+                SurfaceFetchResult(
+                    source="code_scanning",
+                    endpoint="repos/octo/example/code-scanning/alerts?per_page=100",
+                    status="readable",
+                    alerts=(
+                        {
+                            "number": 1,
+                            "state": "open",
+                            "created_at": "2026-04-22T00:00:00Z",
+                            "updated_at": "2026-04-22T00:00:00Z",
+                            "rule": {"id": "py/sql-injection", "security_severity_level": "critical"},
+                            "most_recent_instance": {
+                                "ref": "refs/heads/main",
+                                "location": {"path": "app/db.py"},
+                            },
+                            "tool": {"name": "CodeQL"},
+                        },
+                    ),
+                ),
+                SurfaceFetchResult(
+                    source="dependabot",
+                    endpoint="repos/octo/example/dependabot/alerts?per_page=100",
+                    status="unavailable",
+                    alerts=(),
+                    note="HTTP 403",
+                ),
+                SurfaceFetchResult(
+                    source="secret_scanning",
+                    endpoint="repos/octo/example/secret-scanning/alerts?per_page=100",
+                    status="readable",
+                    alerts=(),
+                ),
+            ],
+        )
+
+        assert readout["status"] == "PARTIAL"
+        assert readout["readable_surface_count"] == 2
+        assert readout["summary"]["total_alerts"] == 1
+        assert readout["summary"]["counts_by_source"] == [
+            {"value": "code_scanning", "count": 1}
+        ]
+
+        markdown = build_markdown_report(readout)
+        assert "Dieses Bild ist partiell." in markdown
+        assert "`dependabot`: HTTP 403" in markdown
+
+    def test_generate_readout_writes_deterministic_artifacts(self, tmp_path):
+        pages_by_source = {
+            "code_scanning": [
+                {
+                    "number": 10,
+                    "state": "open",
+                    "created_at": "2026-04-10T00:00:00Z",
+                    "updated_at": "2026-04-12T00:00:00Z",
+                    "html_url": "https://example.invalid/code/10",
+                    "rule": {
+                        "id": "py/insecure-temp-file",
+                        "security_severity_level": "medium",
+                    },
+                    "most_recent_instance": {
+                        "ref": "refs/heads/main",
+                        "location": {"path": "core/tmp.py"},
+                    },
+                    "tool": {"name": "CodeQL"},
+                }
+            ],
+            "dependabot": [
+                {
+                    "number": 11,
+                    "state": "open",
+                    "created_at": "2026-04-11T00:00:00Z",
+                    "updated_at": "2026-04-12T00:00:00Z",
+                    "html_url": "https://example.invalid/dependabot/11",
+                    "dependency": {
+                        "manifest_path": "requirements.txt",
+                        "package": {"name": "urllib3"},
+                    },
+                    "security_advisory": {
+                        "ghsa_id": "GHSA-test-5678",
+                        "severity": "high",
+                    },
+                }
+            ],
+            "secret_scanning": [
+                {
+                    "number": 12,
+                    "state": "resolved",
+                    "created_at": "2026-04-01T00:00:00Z",
+                    "updated_at": "2026-04-02T00:00:00Z",
+                    "html_url": "https://example.invalid/secret/12",
+                    "secret_type": "generic_api_key",
+                    "secret_type_display_name": "Generic API Key",
+                    "first_location_detected": {"path": ".env"},
+                }
+            ],
+        }
+
+        def runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+            endpoint = command[-1]
+            for source, page in pages_by_source.items():
+                if f"/{source.replace('_', '-')}/" in endpoint or source == "code_scanning" and "/code-scanning/" in endpoint:
+                    return _completed_process(stdout=json.dumps([page]))
+            raise AssertionError(f"Unexpected command endpoint: {endpoint}")
+
+        out_dir_a = tmp_path / "out_a"
+        out_dir_b = tmp_path / "out_b"
+        reference_now = "2026-04-23T00:00:00Z"
+
+        first = generate_readout(
+            repo="octo/example",
+            out_dir=out_dir_a,
+            reference_now_utc=reference_now,
+            runner=runner,
+        )
+        second = generate_readout(
+            repo="octo/example",
+            out_dir=out_dir_b,
+            reference_now_utc=reference_now,
+            runner=runner,
+        )
+
+        assert first == second
+        assert first["status"] == "PASS"
+        assert (out_dir_a / JSON_FILENAME).read_text(encoding="utf-8") == (
+            out_dir_b / JSON_FILENAME
+        ).read_text(encoding="utf-8")
+        assert (out_dir_a / MARKDOWN_FILENAME).read_text(encoding="utf-8") == (
+            out_dir_b / MARKDOWN_FILENAME
+        ).read_text(encoding="utf-8")

--- a/tests/unit/audit/test_github_security_quality_readout.py
+++ b/tests/unit/audit/test_github_security_quality_readout.py
@@ -14,6 +14,10 @@ sys.path.insert(0, str(repo_root))
 from audit.github_security_quality_readout import (  # noqa: E402
     JSON_FILENAME,
     MARKDOWN_FILENAME,
+    REDACTED_SECRET_COMPONENT,
+    REDACTED_SECRET_PATH,
+    REDACTED_SECRET_RULE,
+    REDACTED_SECRET_SUBJECT,
     SurfaceFetchResult,
     build_markdown_report,
     build_readout,
@@ -120,11 +124,13 @@ class TestNormalizeAlerts:
         )
 
         assert alert["source"] == "secret_scanning"
-        assert alert["subject"] == "Generic API Key"
-        assert alert["rule_or_advisory"] == "generic_api_key"
-        assert alert["affected_path"] == ".env"
+        assert alert["subject"] == REDACTED_SECRET_SUBJECT
+        assert alert["rule_or_advisory"] == REDACTED_SECRET_RULE
+        assert alert["affected_path"] == REDACTED_SECRET_PATH
+        assert alert["affected_component"] == REDACTED_SECRET_COMPONENT
         assert alert["severity"] == "not_provided"
         assert alert["branch"] == "not_provided"
+        assert alert["url"] is None
         assert alert["age_bucket"] == "91d+"
 
 
@@ -220,6 +226,45 @@ class TestReadoutGeneration:
         markdown = build_markdown_report(readout)
         assert "Dieses Bild ist partiell." in markdown
         assert "`dependabot`: HTTP 403" in markdown
+
+    def test_markdown_report_mentions_secret_scanning_redaction(self):
+        readout = build_readout(
+            repo="octo/example",
+            reference_now_utc="2026-04-23T00:00:00Z",
+            fetched_surfaces=[
+                SurfaceFetchResult(
+                    source="code_scanning",
+                    endpoint="repos/octo/example/code-scanning/alerts?per_page=100",
+                    status="readable",
+                    alerts=(),
+                ),
+                SurfaceFetchResult(
+                    source="dependabot",
+                    endpoint="repos/octo/example/dependabot/alerts?per_page=100",
+                    status="readable",
+                    alerts=(),
+                ),
+                SurfaceFetchResult(
+                    source="secret_scanning",
+                    endpoint="repos/octo/example/secret-scanning/alerts?per_page=100",
+                    status="readable",
+                    alerts=(
+                        {
+                            "number": 3,
+                            "state": "resolved",
+                            "created_at": "2026-04-01T00:00:00Z",
+                            "updated_at": "2026-04-02T00:00:00Z",
+                            "secret_type": "generic_api_key",
+                            "secret_type_display_name": "Generic API Key",
+                            "first_location_detected": {"path": ".env"},
+                        },
+                    ),
+                ),
+            ],
+        )
+
+        markdown = build_markdown_report(readout)
+        assert "Secret-Scanning-Detailfelder werden im Artefakt absichtlich redigiert" in markdown
 
     def test_generate_readout_writes_deterministic_artifacts(self, tmp_path):
         pages_by_source = {

--- a/tests/unit/audit/test_github_security_quality_readout.py
+++ b/tests/unit/audit/test_github_security_quality_readout.py
@@ -267,17 +267,13 @@ class TestReadoutGeneration:
         assert readout["summary"]["counts_by_source"] == [
             {"value": "secret_scanning", "count": 1}
         ]
-        assert readout["summary"]["counts_by_state"] == [
-            {"value": "resolved", "count": 1}
-        ]
-        assert readout["summary"]["counts_by_severity"] == [
-            {"value": "not_provided", "count": 1}
-        ]
+        assert readout["summary"]["counts_by_state"] == []
+        assert readout["summary"]["counts_by_severity"] == []
         assert readout["alerts"] == []
 
         markdown = build_markdown_report(readout)
         assert (
-            "Secret-Scanning bleibt in Surface-, State- und Severity-Counts enthalten"
+            "Secret-Scanning bleibt in Surface-Coverage und Source-Counts enthalten"
             in markdown
         )
         assert "Secret-Scanning-Detailfelder werden im Artefakt absichtlich redigiert" in markdown
@@ -365,6 +361,13 @@ class TestReadoutGeneration:
             {"value": "code_scanning", "count": 1},
             {"value": "dependabot", "count": 1},
             {"value": "secret_scanning", "count": 1},
+        ]
+        assert first["summary"]["counts_by_state"] == [
+            {"value": "open", "count": 2}
+        ]
+        assert first["summary"]["counts_by_severity"] == [
+            {"value": "high", "count": 1},
+            {"value": "medium", "count": 1},
         ]
         assert (out_dir_a / JSON_FILENAME).read_text(encoding="utf-8") == (
             out_dir_b / JSON_FILENAME

--- a/tests/unit/audit/test_github_security_quality_readout.py
+++ b/tests/unit/audit/test_github_security_quality_readout.py
@@ -263,7 +263,23 @@ class TestReadoutGeneration:
             ],
         )
 
+        assert readout["summary"]["total_alerts"] == 1
+        assert readout["summary"]["counts_by_source"] == [
+            {"value": "secret_scanning", "count": 1}
+        ]
+        assert readout["summary"]["counts_by_state"] == [
+            {"value": "resolved", "count": 1}
+        ]
+        assert readout["summary"]["counts_by_severity"] == [
+            {"value": "not_provided", "count": 1}
+        ]
+        assert readout["alerts"] == []
+
         markdown = build_markdown_report(readout)
+        assert (
+            "Secret-Scanning bleibt in Surface-, State- und Severity-Counts enthalten"
+            in markdown
+        )
         assert "Secret-Scanning-Detailfelder werden im Artefakt absichtlich redigiert" in markdown
 
     def test_generate_readout_writes_deterministic_artifacts(self, tmp_path):
@@ -343,6 +359,13 @@ class TestReadoutGeneration:
 
         assert first == second
         assert first["status"] == "PASS"
+        assert first["summary"]["total_alerts"] == 3
+        assert len(first["alerts"]) == 2
+        assert first["summary"]["counts_by_source"] == [
+            {"value": "code_scanning", "count": 1},
+            {"value": "dependabot", "count": 1},
+            {"value": "secret_scanning", "count": 1},
+        ]
         assert (out_dir_a / JSON_FILENAME).read_text(encoding="utf-8") == (
             out_dir_b / JSON_FILENAME
         ).read_text(encoding="utf-8")

--- a/tests/unit/audit/test_github_security_quality_readout.py
+++ b/tests/unit/audit/test_github_security_quality_readout.py
@@ -174,7 +174,7 @@ class TestFetchSurface:
         assert result.status == "unavailable"
         assert result.note == "gh api returned no stdout payload"
 
-    def test_fetch_surface_redacts_secret_scanning_payload_after_counting(self):
+    def test_fetch_surface_redacts_secret_scanning_payload_before_persistence(self):
         result = fetch_surface(
             source="secret_scanning",
             repo="octo/example",
@@ -194,8 +194,9 @@ class TestFetchSurface:
         )
 
         assert result.status == "readable"
-        assert result.alert_count == 1
+        assert result.alert_count is None
         assert result.alerts == ()
+        assert "payload-redacted" in (result.note or "")
 
 
 class TestReadoutGeneration:
@@ -286,20 +287,19 @@ class TestReadoutGeneration:
             ],
         )
 
-        assert readout["summary"]["total_alerts"] == 1
-        assert readout["summary"]["counts_by_source"] == [
-            {"value": "secret_scanning", "count": 1}
-        ]
+        assert readout["summary"]["total_alerts"] == 0
+        assert readout["summary"]["counts_by_source"] == []
         assert readout["summary"]["counts_by_state"] == []
         assert readout["summary"]["counts_by_severity"] == []
         assert readout["alerts"] == []
 
         markdown = build_markdown_report(readout)
         assert (
-            "Secret-Scanning bleibt in Surface-Coverage und Source-Counts enthalten"
+            "Secret-Scanning bleibt in der Surface-Coverage sichtbar"
             in markdown
         )
         assert "Secret-Scanning-Detailfelder werden im Artefakt absichtlich redigiert" in markdown
+        assert "| `secret_scanning` | readable | redacted |" in markdown
 
     def test_generate_readout_writes_deterministic_artifacts(self, tmp_path):
         pages_by_source = {
@@ -378,12 +378,11 @@ class TestReadoutGeneration:
 
         assert first == second
         assert first["status"] == "PASS"
-        assert first["summary"]["total_alerts"] == 3
+        assert first["summary"]["total_alerts"] == 2
         assert len(first["alerts"]) == 2
         assert first["summary"]["counts_by_source"] == [
             {"value": "code_scanning", "count": 1},
             {"value": "dependabot", "count": 1},
-            {"value": "secret_scanning", "count": 1},
         ]
         assert first["summary"]["counts_by_state"] == [
             {"value": "open", "count": 2}
@@ -392,6 +391,11 @@ class TestReadoutGeneration:
             {"value": "high", "count": 1},
             {"value": "medium", "count": 1},
         ]
+        exported = json.loads((out_dir_a / JSON_FILENAME).read_text(encoding="utf-8"))
+        secret_surface = next(
+            surface for surface in exported["surfaces"] if surface["source"] == "secret_scanning"
+        )
+        assert secret_surface["alert_count"] is None
         assert (out_dir_a / JSON_FILENAME).read_text(encoding="utf-8") == (
             out_dir_b / JSON_FILENAME
         ).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a read-only GitHub readout for Code Scanning, Dependabot, and Secret Scanning
- normalize alerts into a shared JSON schema and emit a compact Markdown report
- fail closed when API or permission reads are unavailable and cover normalization/report determinism with targeted tests

## Not Included
- fix, dismiss, or close automation
- delta or trend tracking
- governance changes
- broader security remediation scope

## Validation
- python -m pytest tests/unit/audit/test_github_security_quality_readout.py -q
- python -m pytest tests/unit/audit/test_governance_integrity_report.py -q
- python scripts/audit/github_security_quality_readout.py --repo jannekbuengener/Claire_de_Binare --out-dir .codex_issue1879_readout --reference-now 2026-04-23T00:00:00Z