### PR TITLE
Complete ARVP replay scenario surfaces and clarify fail-closed data integrity semantics

### DIFF
--- a/core/replay/historical_bridge.py
+++ b/core/replay/historical_bridge.py
@@ -160,6 +160,7 @@ def build_primary_breakout_historical_bridge(
         row = candles[index]
         close_now = _required_number(row, "close")
         ts_ms = _required_int(row, "ts_ms")
+        data_gap_active = _optional_bool(row, "data_gap_active", default=False)
 
         entry_window = candles[
             index - active_config.entry_lookback_minutes : index
@@ -174,9 +175,6 @@ def build_primary_breakout_historical_bridge(
                 row, "market_state_fresh", default=True
             ),
             "regime_fresh": _optional_bool(row, "regime_fresh", default=True),
-            "close_now": close_now,
-            "highest_high": highest_high,
-            "lowest_low": lowest_low,
             "entry_cooldown_active": _optional_bool(
                 row, "entry_cooldown_active", default=False
             ),
@@ -190,6 +188,12 @@ def build_primary_breakout_historical_bridge(
             ),
             "core_blocked": _optional_bool(row, "core_blocked", default=False),
         }
+        if data_gap_active:
+            market_state["data_gap_active"] = True
+        else:
+            market_state["close_now"] = close_now
+            market_state["highest_high"] = highest_high
+            market_state["lowest_low"] = lowest_low
         last_entry_ts_ms = _optional_int(row, "last_entry_ts_ms")
         if last_entry_ts_ms is not None:
             market_state["last_entry_ts_ms"] = last_entry_ts_ms
@@ -197,21 +201,26 @@ def build_primary_breakout_historical_bridge(
         market_event = {
             "symbol": PRIMARY_BREAKOUT_SYMBOL,
             "ts_ms": ts_ms,
-            "price": close_now,
-            "close": close_now,
             "market_state": market_state,
         }
         market_snapshot = {
             "symbol": PRIMARY_BREAKOUT_SYMBOL,
-            "price": close_now,
-            "close": close_now,
-            "high": _required_number(row, "high"),
-            "low": _required_number(row, "low"),
-            "volume": _required_number(row, "volume")
-            if row.get("volume") is not None
-            else 0.0,
             "timestamp": ts_ms,
         }
+        if data_gap_active:
+            market_snapshot["volume"] = (
+                _required_number(row, "volume") if row.get("volume") is not None else 0.0
+            )
+        else:
+            market_event["price"] = close_now
+            market_event["close"] = close_now
+            market_snapshot["price"] = close_now
+            market_snapshot["close"] = close_now
+            market_snapshot["high"] = _required_number(row, "high")
+            market_snapshot["low"] = _required_number(row, "low")
+            market_snapshot["volume"] = (
+                _required_number(row, "volume") if row.get("volume") is not None else 0.0
+            )
         requests.append(
             StrategyAdapterRequest(
                 symbol=PRIMARY_BREAKOUT_SYMBOL,

--- a/core/replay/scenario_packs.py
+++ b/core/replay/scenario_packs.py
@@ -48,7 +48,9 @@ BUILTIN_SCENARIO_IDS: tuple[str, ...] = (
 _PACK_VERSION = "1"
 
 
-def _make_spec(scenario_id: str, description: str, overrides: dict[str, Any]) -> ScenarioSpec:
+def _make_spec(
+    scenario_id: str, description: str, overrides: dict[str, Any]
+) -> ScenarioSpec:
     """Build a ScenarioSpec with provenance keys injected into config_overrides."""
     provenance: dict[str, Any] = {
         "pack_id": scenario_id,
@@ -86,11 +88,12 @@ _PACKS: dict[str, ScenarioSpec] = {
     "delayed_execution": _make_spec(
         scenario_id="delayed_execution",
         description=(
-            "Delayed execution: deterministic execution delay injected per order. "
-            "Models latency degradation and late-arrival execution conditions."
+            "Delayed execution: deterministic bar-level execution delay. "
+            "Signal at index i executes at index i+K where K = execution_delay_bars. "
+            "Uses price from K bars later."
         ),
         overrides={
-            "execution_delay_ms": 500,
+            "execution_delay_bars": 1,
             "execution_posture": "delayed",
         },
     ),
@@ -108,21 +111,19 @@ _PACKS: dict[str, ScenarioSpec] = {
     "feed_gap": _make_spec(
         scenario_id="feed_gap",
         description=(
-            "Feed-gap: deterministic data-gap injection consistent with the replay "
-            "input model. Models feed interruptions and stale-tick conditions."
+            "Feed-gap: deterministic bar-level stale-feed injection on the 1m "
+            "replay canvas. Converts a contiguous midpoint window into stale, "
+            "non-fresh replay bars instead of pretending sub-minute raw-data gaps."
         ),
         overrides={
-            "feed_gap_seconds": 30,
-            "drop_ticks_on_gap": True,
+            "feed_gap_bars": 2,
         },
     ),
 }
 
 # Validate internal consistency at import time (unconditional: not skipped under -O).
 if set(_PACKS.keys()) != set(BUILTIN_SCENARIO_IDS):
-    raise ScenarioPackError(
-        "Mismatch between _PACKS keys and BUILTIN_SCENARIO_IDS"
-    )
+    raise ScenarioPackError("Mismatch between _PACKS keys and BUILTIN_SCENARIO_IDS")
 
 
 # ---------------------------------------------------------------------------
@@ -158,8 +159,7 @@ def get_scenario_pack(scenario_id: str) -> ScenarioSpec:
     if stored is None:
         known = ", ".join(repr(k) for k in BUILTIN_SCENARIO_IDS)
         raise ScenarioPackError(
-            f"Unknown scenario pack {scenario_id!r}. "
-            f"Known built-in packs: {known}"
+            f"Unknown scenario pack {scenario_id!r}. Known built-in packs: {known}"
         )
     # Return a fresh copy; ScenarioSpec.__post_init__ deep-copies config_overrides.
     return ScenarioSpec(
@@ -169,7 +169,9 @@ def get_scenario_pack(scenario_id: str) -> ScenarioSpec:
     )
 
 
-def _write_specs_artifact(artifact_root: str, spec_dicts: Sequence[dict[str, Any]]) -> None:
+def _write_specs_artifact(
+    artifact_root: str, spec_dicts: Sequence[dict[str, Any]]
+) -> None:
     """Write scenario_specs.json into the group artifact directory.
 
     Accepts pre-captured spec dicts (snapshots taken before run_fn executes)

--- a/docs/contracts/strategy_validation_report_v1.schema.json
+++ b/docs/contracts/strategy_validation_report_v1.schema.json
@@ -184,7 +184,104 @@
           "maximum": 1.0
         },
         "data_integrity_ok": {
+          "description": "Terminal run-cleanliness indicator. True only when the runner finishes with no open_position and no pending_signals. This is not a performance or profitability metric.",
           "type": "boolean"
+        },
+        "data_integrity_diagnostics": {
+          "description": "Additive diagnostic block that explains the fail-closed terminal state behind data_integrity_ok. This block adds transparency only and does not change gate policy.",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "data_integrity_reason",
+            "open_position_at_end",
+            "pending_signals_at_end"
+          ],
+          "properties": {
+            "data_integrity_reason": {
+              "description": "Canonical terminal-state reason. 'clean' means no open_position and no pending_signals remained at dataset end. Any other value explains why data_integrity_ok is false.",
+              "type": "string",
+              "enum": [
+                "clean",
+                "open_position_at_end",
+                "pending_signals_at_end",
+                "open_position_and_pending_signals_at_end"
+              ]
+            },
+            "open_position_at_end": {
+              "description": "Serialized open position still present when the run reached dataset end. Null means this dimension is clean. No synthetic end-of-window close is implied.",
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "entry_price",
+                    "entry_ts_ms",
+                    "entry_fee"
+                  ],
+                  "properties": {
+                    "entry_price": {
+                      "type": "number"
+                    },
+                    "entry_ts_ms": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "entry_fee": {
+                      "type": "number",
+                      "minimum": 0.0
+                    }
+                  }
+                }
+              ]
+            },
+            "pending_signals_at_end": {
+              "description": "Delayed execution signals still queued when the run reached dataset end. A non-empty array is fail-closed and indicates the run did not finish with a fully drained execution queue.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "side",
+                  "target_idx",
+                  "execution_price",
+                  "ts_ms",
+                  "volume",
+                  "volatility"
+                ],
+                "properties": {
+                  "side": {
+                    "type": "string",
+                    "enum": [
+                      "BUY",
+                      "SELL"
+                    ]
+                  },
+                  "target_idx": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "execution_price": {
+                    "type": "number"
+                  },
+                  "ts_ms": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "volume": {
+                    "type": "number",
+                    "minimum": 0.0
+                  },
+                  "volatility": {
+                    "type": "number",
+                    "minimum": 0.0
+                  }
+                }
+              }
+            }
+          }
         },
         "deterministic_replay_ok": {
           "type": "boolean"

--- a/knowledge/contracts/PRIMARY_BREAKOUT_V1_VALIDATION.md
+++ b/knowledge/contracts/PRIMARY_BREAKOUT_V1_VALIDATION.md
@@ -28,6 +28,14 @@ Rationale:
 - Keep the set small, auditable, and directly tied to strategy behavior and data quality.
 - Do not expand to research-heavy scorecards in v1.
 
+`data_integrity_ok` semantics:
+- `data_integrity_ok` is not a performance or profitability indicator.
+- `data_integrity_ok` expresses terminal run cleanliness: the historical validation run must end with no open position and no pending execution signals.
+- `data_integrity_ok = false` is intentionally fail-closed for terminal end states such as `open_position_at_end` and `pending_signals_at_end`.
+- The additive block `metrics.data_integrity_diagnostics` explains that fail-closed result with `data_integrity_reason`, `open_position_at_end`, and `pending_signals_at_end`.
+- These diagnostics do not soften the policy and do not change gate evaluation.
+- The runner does not perform a silent end-of-window auto-close. Any future end-of-window close behavior would require a new explicit policy and contract surface.
+
 ## Machine-readable Report Contract
 
 Contract file:

--- a/services/execution/simulator.py
+++ b/services/execution/simulator.py
@@ -36,6 +36,7 @@ class ExecutionResult:
         fees: Total trading fees in quote currency.
         partial_fill: Whether this was a partial fill.
         fill_ratio: Ratio of filled to requested size (0.0-1.0).
+        execution_posture: Execution posture from scenario (baseline/pessimistic/etc).
         notes: Optional execution notes.
     """
 
@@ -45,6 +46,7 @@ class ExecutionResult:
     fees: float
     partial_fill: bool
     fill_ratio: float
+    execution_posture: Optional[str] = None
     notes: Optional[str] = None
 
 
@@ -83,10 +85,14 @@ class ExecutionSimulator:
         # Funding rate
         self.funding_rate = float(self.config.get("FUNDING_RATE", 0.0001))
 
+        # Execution posture metadata (from scenario packs)
+        self.execution_posture = self.config.get("_execution_posture", "baseline")
+
         logger.info(
             f"ExecutionSimulator initialized: "
             f"maker_fee={self.maker_fee:.4f} taker_fee={self.taker_fee:.4f} "
-            f"base_slippage={self.base_slippage_bps:.1f}bps"
+            f"base_slippage={self.base_slippage_bps:.1f}bps "
+            f"posture={self.execution_posture}"
         )
 
     def simulate_market_order(
@@ -169,6 +175,7 @@ class ExecutionSimulator:
             fees=fees,
             partial_fill=partial_fill,
             fill_ratio=fill_ratio,
+            execution_posture=self.execution_posture,
             notes=f"Market order {side} with {slippage_bps:.1f}bps slippage",
         )
 

--- a/services/validation/strategy_backtest_runner.py
+++ b/services/validation/strategy_backtest_runner.py
@@ -56,7 +56,9 @@ class PrimaryBreakoutBacktestRunConfig:
         if self.order_size <= 0:
             raise PrimaryBreakoutBacktestError("order_size must be > 0")
         if self.order_book_depth_multiplier <= 0:
-            raise PrimaryBreakoutBacktestError("order_book_depth_multiplier must be > 0")
+            raise PrimaryBreakoutBacktestError(
+                "order_book_depth_multiplier must be > 0"
+            )
 
 
 def _canonical_json(value: Any) -> str:
@@ -71,6 +73,7 @@ def _deterministic_run_id(
     requests: Sequence[StrategyAdapterRequest],
     config: PrimaryBreakoutBacktestRunConfig,
     code_commit: str,
+    simulator_config: Mapping[str, Any] | None = None,
 ) -> str:
     payload = {
         "code_commit": code_commit,
@@ -85,6 +88,8 @@ def _deterministic_run_id(
             for request in requests
         ],
     }
+    if simulator_config:
+        payload["simulator_config"] = dict(simulator_config)
     return f"bt-{_sha256_text(_canonical_json(payload))[:16]}"
 
 
@@ -101,6 +106,98 @@ def _first_number(*values: Any) -> float | None:
         except (TypeError, ValueError):
             continue
     return None
+
+
+def _extract_execution_delay_bars(
+    simulator_config: Mapping[str, Any] | None,
+) -> int:
+    if simulator_config is None:
+        return 0
+    delay_bars = simulator_config.get("EXECUTION_DELAY_BARS", 0)
+    if delay_bars is None:
+        return 0
+    if isinstance(delay_bars, bool) or not isinstance(delay_bars, int):
+        raise PrimaryBreakoutBacktestError(
+            "EXECUTION_DELAY_BARS must be an integer >= 0"
+        )
+    if delay_bars < 0:
+        raise PrimaryBreakoutBacktestError("EXECUTION_DELAY_BARS must be >= 0")
+    return delay_bars
+
+
+def _execution_bar_volatility(
+    request: StrategyAdapterRequest,
+    reference_price: float,
+) -> float:
+    if reference_price <= 0:
+        return 0.0
+
+    open_price = _first_number(
+        request.market_snapshot.get("open"),
+        request.market_event.get("open"),
+        reference_price,
+    )
+    close_price = _first_number(
+        request.market_snapshot.get("close"),
+        request.market_event.get("close"),
+        request.market_event.get("price"),
+        reference_price,
+    )
+    high_price = _first_number(
+        request.market_snapshot.get("high"),
+        request.market_event.get("high"),
+    )
+    low_price = _first_number(
+        request.market_snapshot.get("low"),
+        request.market_event.get("low"),
+    )
+
+    bar_move = (
+        abs(close_price - open_price) / reference_price
+        if open_price is not None and close_price is not None
+        else 0.0
+    )
+    bar_range = (
+        abs(high_price - low_price) / reference_price
+        if high_price is not None and low_price is not None
+        else 0.0
+    )
+    return max(bar_move, bar_range, 0.0)
+
+
+def _build_pending_execution(
+    signal: StrategySignalCandidate,
+    request_index: int,
+    bridge_requests: Sequence[StrategyAdapterRequest],
+    execution_delay_bars: int,
+) -> dict[str, Any]:
+    target_idx = request_index + execution_delay_bars
+    if target_idx >= len(bridge_requests):
+        raise PrimaryBreakoutBacktestError(
+            "Delayed execution out of range: "
+            f"signal at index {request_index} with execution_delay_bars="
+            f"{execution_delay_bars} targets index {target_idx}, "
+            f"but only {len(bridge_requests)} bridge requests are available"
+        )
+
+    execution_request = bridge_requests[target_idx]
+    execution_price = _first_number(
+        execution_request.market_snapshot.get("close"),
+        execution_request.market_event.get("close"),
+        execution_request.market_event.get("price"),
+        signal.price,
+    )
+    if execution_price is None:
+        raise PrimaryBreakoutBacktestError("delayed execution target missing price")
+
+    return {
+        "side": signal.side,
+        "target_idx": target_idx,
+        "execution_price": execution_price,
+        "ts_ms": int(execution_request.market_event["ts_ms"]),
+        "volume": _first_number(execution_request.market_snapshot.get("volume")) or 0.0,
+        "volatility": _execution_bar_volatility(execution_request, execution_price),
+    }
 
 
 def _extract_thresholds() -> dict[str, Any]:
@@ -120,7 +217,9 @@ def _extract_thresholds() -> dict[str, Any]:
     }
 
 
-def _evaluate_gate(metrics: Mapping[str, Any], thresholds: Mapping[str, Any]) -> dict[str, Any]:
+def _evaluate_gate(
+    metrics: Mapping[str, Any], thresholds: Mapping[str, Any]
+) -> dict[str, Any]:
     pass_fail = thresholds["pass_fail"]
     failed_criteria: list[str] = []
     if int(metrics["closed_trades_total"]) < pass_fail["min_closed_trades_total"]:
@@ -131,13 +230,19 @@ def _evaluate_gate(metrics: Mapping[str, Any], thresholds: Mapping[str, Any]) ->
         failed_criteria.append("min_expectancy_r")
     if float(metrics["max_drawdown_r"]) > pass_fail["max_max_drawdown_r"]:
         failed_criteria.append("max_max_drawdown_r")
-    if float(metrics["market_state_fresh_ratio"]) < pass_fail["min_market_state_fresh_ratio"]:
+    if (
+        float(metrics["market_state_fresh_ratio"])
+        < pass_fail["min_market_state_fresh_ratio"]
+    ):
         failed_criteria.append("min_market_state_fresh_ratio")
     if float(metrics["regime_fresh_ratio"]) < pass_fail["min_regime_fresh_ratio"]:
         failed_criteria.append("min_regime_fresh_ratio")
     if bool(metrics["data_integrity_ok"]) is not pass_fail["require_data_integrity_ok"]:
         failed_criteria.append("data_integrity_ok")
-    if bool(metrics["deterministic_replay_ok"]) is not pass_fail["require_deterministic_replay_ok"]:
+    if (
+        bool(metrics["deterministic_replay_ok"])
+        is not pass_fail["require_deterministic_replay_ok"]
+    ):
         failed_criteria.append("deterministic_replay_ok")
 
     review_flags: list[str] = []
@@ -158,7 +263,9 @@ def _evaluate_gate(metrics: Mapping[str, Any], thresholds: Mapping[str, Any]) ->
 
     notes = None
     if status != "PASS":
-        notes = "failed criteria" if failed_criteria else "review-only thresholds flagged"
+        notes = (
+            "failed criteria" if failed_criteria else "review-only thresholds flagged"
+        )
 
     payload: dict[str, Any] = {
         "status": status,
@@ -198,6 +305,111 @@ def _simulate_trade(
         "partial_fill": result.partial_fill,
         "fill_ratio": result.fill_ratio,
         "notes": result.notes,
+    }
+
+
+def _execute_pending_signal(
+    exec_info: dict[str, Any],
+    open_position: dict[str, Any] | None,
+    trades: list[dict[str, Any]],
+    simulator: ExecutionSimulator,
+    config: PrimaryBreakoutBacktestRunConfig,
+) -> dict[str, Any] | None:
+    """Execute a pending signal from the delayed execution queue."""
+    side = exec_info["side"]
+    execution_price = exec_info["execution_price"]
+    ts_ms = exec_info["ts_ms"]
+    volume = exec_info["volume"]
+    volatility = exec_info["volatility"]
+
+    if side == "BUY":
+        if open_position is not None:
+            return open_position
+        fill = _simulate_trade(
+            side="buy",
+            price=execution_price,
+            ts_ms=ts_ms,
+            volume=volume,
+            simulator=simulator,
+            order_size=config.order_size,
+            order_book_depth_multiplier=config.order_book_depth_multiplier,
+            volatility=volatility,
+        )
+        return {
+            "entry_price": fill["avg_fill_price"],
+            "entry_ts_ms": ts_ms,
+            "entry_fee": fill["fees"],
+        }
+    elif side == "SELL" and open_position is not None:
+        fill = _simulate_trade(
+            side="sell",
+            price=execution_price,
+            ts_ms=ts_ms,
+            volume=volume,
+            simulator=simulator,
+            order_size=config.order_size,
+            order_book_depth_multiplier=config.order_book_depth_multiplier,
+            volatility=volatility,
+        )
+        entry_price = float(open_position["entry_price"])
+        exit_price = float(fill["avg_fill_price"])
+        trade_r = (exit_price - entry_price) / entry_price
+        trades.append(
+            {
+                "entry_ts_ms": int(open_position["entry_ts_ms"]),
+                "exit_ts_ms": ts_ms,
+                "entry_price": entry_price,
+                "exit_price": exit_price,
+                "entry_fee": float(open_position["entry_fee"]),
+                "exit_fee": float(fill["fees"]),
+                "r_return": trade_r,
+            }
+        )
+        return None
+    return open_position
+
+
+def _build_data_integrity_diagnostics(
+    open_position: Mapping[str, Any] | None,
+    pending_signals: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Serialize the terminal runner state without changing gate semantics."""
+
+    serialized_open_position: dict[str, Any] | None = None
+    if open_position is not None:
+        serialized_open_position = {
+            "entry_price": float(open_position["entry_price"]),
+            "entry_ts_ms": int(open_position["entry_ts_ms"]),
+            "entry_fee": float(open_position["entry_fee"]),
+        }
+
+    serialized_pending_signals = [
+        {
+            "side": str(pending["side"]),
+            "target_idx": int(pending["target_idx"]),
+            "execution_price": float(pending["execution_price"]),
+            "ts_ms": int(pending["ts_ms"]),
+            "volume": float(pending["volume"]),
+            "volatility": float(pending["volatility"]),
+        }
+        for pending in pending_signals
+    ]
+
+    has_open_position = serialized_open_position is not None
+    has_pending_signals = bool(serialized_pending_signals)
+    if has_open_position and has_pending_signals:
+        reason = "open_position_and_pending_signals_at_end"
+    elif has_open_position:
+        reason = "open_position_at_end"
+    elif has_pending_signals:
+        reason = "pending_signals_at_end"
+    else:
+        reason = "clean"
+
+    return {
+        "data_integrity_reason": reason,
+        "open_position_at_end": serialized_open_position,
+        "pending_signals_at_end": serialized_pending_signals,
     }
 
 
@@ -339,11 +551,13 @@ def _build_report(
     bridge_requests: Sequence[StrategyAdapterRequest],
     run_config: PrimaryBreakoutBacktestRunConfig,
     code_commit: str,
+    simulator_config: Mapping[str, Any] | None,
     output_requests: Sequence[dict[str, Any]],
     trades: Sequence[dict[str, Any]],
     market_state_fresh_ratio: float,
     regime_fresh_ratio: float,
     data_integrity_ok: bool,
+    data_integrity_diagnostics: Mapping[str, Any],
     deterministic_replay_ok: bool,
     requested_period_start_ts_ms: int,
     requested_period_end_ts_ms: int,
@@ -351,7 +565,12 @@ def _build_report(
     if not bridge_requests:
         raise PrimaryBreakoutBacktestError("bridge produced no requests")
 
-    run_id = _deterministic_run_id(bridge_requests, run_config, code_commit)
+    run_id = _deterministic_run_id(
+        bridge_requests,
+        run_config,
+        code_commit,
+        simulator_config=simulator_config,
+    )
     # Effective bridge start: first candle after the warm-up window
     # (max(entry_lookback, exit_lookback) candles consumed as lookback).
     # Offset from requested_period_start_ts_ms by max_lookback * 60_000 ms.
@@ -381,7 +600,9 @@ def _build_report(
 
     signals_total = len(output_requests)
     buy_signals_total = sum(1 for signal in output_requests if signal["side"] == "BUY")
-    sell_signals_total = sum(1 for signal in output_requests if signal["side"] == "SELL")
+    sell_signals_total = sum(
+        1 for signal in output_requests if signal["side"] == "SELL"
+    )
     metrics = {
         "signals_total": signals_total,
         "buy_signals_total": buy_signals_total,
@@ -394,6 +615,7 @@ def _build_report(
         "market_state_fresh_ratio": market_state_fresh_ratio,
         "regime_fresh_ratio": regime_fresh_ratio,
         "data_integrity_ok": data_integrity_ok,
+        "data_integrity_diagnostics": dict(data_integrity_diagnostics),
         "deterministic_replay_ok": deterministic_replay_ok,
     }
     thresholds = _extract_thresholds()
@@ -417,8 +639,10 @@ def _build_report(
         "dataset_summary": {
             "symbol": PRIMARY_BREAKOUT_SYMBOL,
             "timeframe": "1m",
-            "candles_total": len(bridge_requests) + max(
-                run_config.bridge.entry_lookback_minutes, run_config.bridge.exit_lookback_minutes
+            "candles_total": len(bridge_requests)
+            + max(
+                run_config.bridge.entry_lookback_minutes,
+                run_config.bridge.exit_lookback_minutes,
             ),
             "requested_period_start_ts_ms": requested_period_start_ts_ms,
             "requested_period_end_ts_ms": requested_period_end_ts_ms,
@@ -435,19 +659,24 @@ def run_primary_breakout_backtest(
     candles: Sequence[Mapping[str, Any]],
     *,
     run_config: PrimaryBreakoutBacktestRunConfig | None = None,
+    simulator_config: Mapping[str, Any] | None = None,
     code_commit: str = "unknown",
 ) -> dict[str, Any]:
     """Run the deterministic historical backtest and return the schema report."""
 
     active_config = run_config or PrimaryBreakoutBacktestRunConfig()
     active_config.validate()
+    if simulator_config is not None and not isinstance(simulator_config, Mapping):
+        raise PrimaryBreakoutBacktestError("simulator_config must be a mapping")
+    active_simulator_config = dict(simulator_config or {})
+    execution_delay_bars = _extract_execution_delay_bars(active_simulator_config)
     bridge_requests = build_primary_breakout_historical_bridge(
         candles, config=active_config.bridge
     )
     # Extract raw candle boundaries after bridge validation succeeds (guarantees non-empty + valid).
     requested_period_start_ts_ms = int(candles[0]["ts_ms"])
     requested_period_end_ts_ms = int(candles[-1]["ts_ms"])
-    simulator = ExecutionSimulator()
+    simulator = ExecutionSimulator(active_simulator_config)
 
     output_requests: list[dict[str, Any]] = []
     trades: list[dict[str, Any]] = []
@@ -455,9 +684,28 @@ def run_primary_breakout_backtest(
     last_entry_ts_ms: int | None = None
     market_state_fresh_count = 0
     regime_fresh_count = 0
+    pending_signals: list[dict[str, Any]] = []
     replay_signature: list[dict[str, Any]] = []
 
-    for request in bridge_requests:
+    for request_index, request in enumerate(bridge_requests):
+        if execution_delay_bars > 0 and pending_signals:
+            due_signals: list[dict[str, Any]] = []
+            remaining_signals: list[dict[str, Any]] = []
+            for pending in pending_signals:
+                if pending["target_idx"] == request_index:
+                    due_signals.append(pending)
+                else:
+                    remaining_signals.append(pending)
+            pending_signals = remaining_signals
+            for exec_info in due_signals:
+                open_position = _execute_pending_signal(
+                    exec_info,
+                    open_position,
+                    trades,
+                    simulator,
+                    active_config,
+                )
+
         market_state = request.market_event["market_state"]
         market_state_fresh = bool(market_state.get("market_state_fresh"))
         regime_fresh = bool(market_state.get("regime_fresh"))
@@ -483,7 +731,20 @@ def run_primary_breakout_backtest(
             }
             output_requests.append(signal_payload)
 
-            signal_price = _first_number(signal.price, request.market_snapshot.get("close"))
+            if execution_delay_bars > 0:
+                pending_signals.append(
+                    _build_pending_execution(
+                        signal,
+                        request_index,
+                        bridge_requests,
+                        execution_delay_bars,
+                    )
+                )
+                continue
+
+            signal_price = _first_number(
+                signal.price, request.market_snapshot.get("close")
+            )
             if signal_price is None:
                 raise PrimaryBreakoutBacktestError("signal missing price")
             ts_ms = int(request.market_event["ts_ms"])
@@ -544,7 +805,24 @@ def run_primary_breakout_backtest(
     replay_check_signature: list[dict[str, Any]] = []
     replay_position_open = False
     replay_last_entry_ts_ms: int | None = None
-    for request in bridge_requests:
+    replay_pending_signals: list[dict[str, Any]] = []
+    for request_index, request in enumerate(bridge_requests):
+        if execution_delay_bars > 0 and replay_pending_signals:
+            due_signals: list[dict[str, Any]] = []
+            remaining_signals: list[dict[str, Any]] = []
+            for pending in replay_pending_signals:
+                if pending["target_idx"] == request_index:
+                    due_signals.append(pending)
+                else:
+                    remaining_signals.append(pending)
+            replay_pending_signals = remaining_signals
+            for pending in due_signals:
+                if pending["side"] == "BUY":
+                    if not replay_position_open:
+                        replay_position_open = True
+                elif pending["side"] == "SELL" and replay_position_open:
+                    replay_position_open = False
+
         response, replay_last_entry_ts_ms = _evaluate_primary_breakout_request(
             request,
             position_open=replay_position_open,
@@ -553,24 +831,46 @@ def run_primary_breakout_backtest(
         )
         replay_check_signature.append(_serialize_response(response))
         for signal in response.signals:
+            if execution_delay_bars > 0:
+                replay_pending_signals.append(
+                    _build_pending_execution(
+                        signal,
+                        request_index,
+                        bridge_requests,
+                        execution_delay_bars,
+                    )
+                )
+                continue
             if signal.side == "BUY":
                 replay_position_open = True
             elif signal.side == "SELL":
                 replay_position_open = False
     deterministic_replay_ok = replay_signature == replay_check_signature
 
-    data_integrity_ok = len(bridge_requests) > 0 and open_position is None
+    data_integrity_diagnostics = _build_data_integrity_diagnostics(
+        open_position,
+        pending_signals,
+    )
+    data_integrity_ok = (
+        len(bridge_requests) > 0
+        and open_position is None
+        and not pending_signals
+    )
     return _build_report(
         bridge_requests=bridge_requests,
         run_config=active_config,
         code_commit=code_commit,
+        simulator_config=active_simulator_config,
         output_requests=output_requests,
         trades=trades,
         market_state_fresh_ratio=(
             market_state_fresh_count / len(bridge_requests) if bridge_requests else 0.0
         ),
-        regime_fresh_ratio=(regime_fresh_count / len(bridge_requests) if bridge_requests else 0.0),
+        regime_fresh_ratio=(
+            regime_fresh_count / len(bridge_requests) if bridge_requests else 0.0
+        ),
         data_integrity_ok=data_integrity_ok,
+        data_integrity_diagnostics=data_integrity_diagnostics,
         deterministic_replay_ok=deterministic_replay_ok,
         requested_period_start_ts_ms=requested_period_start_ts_ms,
         requested_period_end_ts_ms=requested_period_end_ts_ms,

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -88,8 +88,10 @@ from core.replay.run_registry import (
 from core.replay.scenario_packs import (
     list_builtin_scenario_ids,
     run_builtin_scenario_group,
+    ScenarioPackError,
 )
 from core.replay.scenario_harness import (
+    ScenarioHarnessError,
     ScenarioRunResult,
     ScenarioSpec,
 )
@@ -1286,12 +1288,16 @@ def _run_scenario_group_path(
                 failure_reason=str(exc),
             )
 
-    manifest = run_builtin_scenario_group(
-        config.scenario_ids,
-        run_fn=run_single,
-        output_dir=output_dir,
-        group_id=config.scenario_group_id,
-    )
+    try:
+        manifest = run_builtin_scenario_group(
+            config.scenario_ids,
+            run_fn=run_single,
+            output_dir=output_dir,
+            group_id=config.scenario_group_id,
+        )
+    except (ScenarioHarnessError, ScenarioPackError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
 
     summary = build_scenario_comparison_summary(manifest)
     summary_path = Path(manifest.artifact_root) / "scenario_comparison_summary.md"

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -85,6 +85,17 @@ from core.replay.run_registry import (
     build_replay_provenance_fingerprint,
     build_replay_run_id,
 )
+from core.replay.scenario_packs import (
+    list_builtin_scenario_ids,
+    run_builtin_scenario_group,
+)
+from core.replay.scenario_harness import (
+    ScenarioRunResult,
+    ScenarioSpec,
+)
+from core.replay.replay_report_builder import (
+    build_scenario_comparison_summary,
+)
 from core.utils.clock import utcnow
 from services.validation.replay_reporter import ReplayReporter, ReplayReporterError
 from services.validation.strategy_backtest_runner import (
@@ -145,11 +156,17 @@ class ReplayRunnerError(RuntimeError):
 # Config
 # ---------------------------------------------------------------------------
 @dataclass(frozen=True, slots=True)
-class AcceleratedShadowReplayConfig:
+class ARVPReplayConfig:
     """Minimal, fail-closed config for an accelerated shadow replay run."""
 
-    input_candles_file: str
-    """Path to candle input file (JSON array or JSONL).  Required."""
+    input_candles_file: str = ""
+    """Path to candle input file (JSON array or JSONL)."""
+
+    dataset_source: str = "file"
+    """Dataset input source: 'file' or 'db'."""
+
+    db_dataset_id: str | None = None
+    """Persisted dataset record ID."""
 
     strategy_id: str = _DEFAULT_STRATEGY_ID
     """Strategy identifier. Must be in _SUPPORTED_STRATEGY_IDS."""
@@ -190,6 +207,12 @@ class AcceleratedShadowReplayConfig:
     deterministic_verify: bool = False
     """Exit with code 2 if the replay determinism check fails."""
 
+    scenario_ids: tuple[str, ...] | None = None
+    """Tuple of built-in scenario IDs to run as a group."""
+
+    scenario_group_id: str | None = None
+    """Optional explicit scenario group ID."""
+
     def validate(self) -> None:
         """Fail-closed config validation. Raises ValueError on any violation."""
         if not self.input_candles_file:
@@ -225,6 +248,157 @@ class AcceleratedShadowReplayConfig:
             raise ValueError("breakout_buffer must be >= 0")
         if self.min_minutes_between_entries < 0:
             raise ValueError("min_minutes_between_entries must be >= 0")
+
+        # Scenario group validation
+        if self.scenario_ids is not None:
+            if not self.scenario_ids:
+                raise ValueError("scenario_ids must be a non-empty tuple")
+            known_scenarios = set(list_builtin_scenario_ids())
+            for sid in self.scenario_ids:
+                if sid not in known_scenarios:
+                    raise ValueError(
+                        f"unknown scenario_id {sid!r}; known: {sorted(known_scenarios)}"
+                    )
+
+
+# Backward-compatible alias for existing tests/callers.
+AcceleratedShadowReplayConfig = ARVPReplayConfig
+
+
+# ---------------------------------------------------------------------------
+# Scenario override mapping (fail-closed)
+# ---------------------------------------------------------------------------
+_SCENARIO_GROUP_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+# Mapping: scenario override key -> ExecutionSimulator config field
+_SCNARIO_OVERRIDE_KEY_TO_SIMULATOR: dict[str, str] = {
+    "execution_slippage_bps": "BASE_SLIPPAGE_BPS",
+    "fill_rate": "FILL_THRESHOLD",
+    "fill_depth_factor": "DEPTH_IMPACT_FACTOR",
+    "execution_delay_bars": "EXECUTION_DELAY_BARS",
+}
+
+_ALLOWED_SCENARIO_OVERRIDE_KEYS: frozenset[str] = frozenset(
+    {
+        "pack_id",
+        "pack_version",
+        "execution_slippage_bps",
+        "fill_rate",
+        "fill_depth_factor",
+        "execution_delay_bars",
+        "feed_gap_bars",
+        "execution_posture",
+    }
+)
+
+# Overrides die fail-closed rejected werden
+_UNSUPPORTED_SCENARIO_OVERRIDES: frozenset[str] = frozenset(
+    {
+        "feed_gap_seconds",
+        "drop_ticks_on_gap",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioResolvedOverrides:
+    """Internal split between execution-simulator and replay-data overrides."""
+
+    simulator_config: dict[str, Any]
+    replay_data_overrides: dict[str, Any]
+
+
+def _apply_scenario_overrides(
+    base_config: ARVPReplayConfig,
+    overrides: dict[str, Any],
+) -> ScenarioResolvedOverrides:
+    """Resolve scenario overrides into execution vs replay-data surfaces."""
+    # Check for unsupported overrides first
+    unsupported = set(overrides.keys()) & _UNSUPPORTED_SCENARIO_OVERRIDES
+    if unsupported:
+        raise ReplayRunnerError(
+            f"Scenario override not currently supported: {sorted(unsupported)}. "
+            f"Supported overrides: {sorted(_ALLOWED_SCENARIO_OVERRIDE_KEYS)}. "
+            f"`feed_gap_seconds` is not representable on the strict 1m replay canvas; "
+            f"use explicit bar-level semantics instead."
+        )
+
+    # Check for unknown keys
+    unknown = set(overrides.keys()) - _ALLOWED_SCENARIO_OVERRIDE_KEYS
+    if unknown:
+        raise ReplayRunnerError(
+            f"Scenario overrides contain unknown keys: {sorted(unknown)}. "
+            f"Supported overrides: {sorted(_ALLOWED_SCENARIO_OVERRIDE_KEYS)}"
+        )
+
+    # Build simulator config
+    sim_config: dict[str, Any] = {}
+    replay_data_overrides: dict[str, Any] = {}
+    for override_key, sim_field in _SCNARIO_OVERRIDE_KEY_TO_SIMULATOR.items():
+        if override_key in overrides:
+            value = overrides[override_key]
+            sim_config[sim_field] = value
+
+    if "feed_gap_bars" in overrides:
+        replay_data_overrides["feed_gap_bars"] = overrides["feed_gap_bars"]
+
+    # Pass execution_posture as simulator metadata (dokumentiert, keine numerische Wirkung)
+    posture = overrides.get("execution_posture")
+    if posture:
+        sim_config["_execution_posture"] = posture
+
+    return ScenarioResolvedOverrides(
+        simulator_config=sim_config,
+        replay_data_overrides=replay_data_overrides,
+    )
+
+
+def _apply_replay_data_overrides(
+    candles: list[dict[str, Any]],
+    overrides: dict[str, Any],
+    *,
+    warmup_count: int,
+) -> list[dict[str, Any]]:
+    """Apply deterministic replay-data perturbations without breaking 1m cadence.
+
+    ``feed_gap_bars`` is modeled as a midpoint-aligned stale-feed window across the
+    live 1m bars. Gap bars repeat the last visible bar, flip freshness to false,
+    and carry a marker consumed by the historical bridge.
+    """
+    if not overrides:
+        return candles
+
+    perturbed = [dict(candle) for candle in candles]
+    feed_gap_bars = overrides.get("feed_gap_bars")
+    if feed_gap_bars is None:
+        return perturbed
+    if isinstance(feed_gap_bars, bool) or not isinstance(feed_gap_bars, int):
+        raise ReplayRunnerError("feed_gap_bars must be an integer >= 1")
+    if feed_gap_bars < 1:
+        raise ReplayRunnerError("feed_gap_bars must be >= 1")
+
+    live_count = len(perturbed) - warmup_count
+    if live_count <= 0:
+        raise ReplayRunnerError("feed_gap_bars requires at least one live candle")
+    if feed_gap_bars >= live_count:
+        raise ReplayRunnerError(
+            "feed_gap_bars must leave at least one unaffected live candle"
+        )
+
+    gap_start = warmup_count + (live_count - feed_gap_bars) // 2
+    source_index = max(0, gap_start - 1)
+    stale_source = dict(perturbed[source_index])
+
+    for idx in range(gap_start, gap_start + feed_gap_bars):
+        gap_row = dict(stale_source)
+        gap_row["ts_ms"] = perturbed[idx]["ts_ms"]
+        gap_row["market_state_fresh"] = False
+        gap_row["regime_fresh"] = False
+        gap_row["data_gap_active"] = True
+        gap_row["volume"] = 0.0
+        perturbed[idx] = gap_row
+
+    return perturbed
 
 
 # ---------------------------------------------------------------------------
@@ -306,7 +480,7 @@ def _utc_now_iso() -> str:
 
 
 def _build_provenance_config_snapshot(
-    config: AcceleratedShadowReplayConfig,
+    config: ARVPReplayConfig,
 ) -> dict[str, Any]:
     return {
         "order_size": config.order_size,
@@ -322,7 +496,7 @@ def _build_dataset_result(
     candles: list[dict[str, Any]],
     *,
     input_path: Path,
-    config: AcceleratedShadowReplayConfig,
+    config: ARVPReplayConfig,
     warmup_count: int,
 ) -> DatasetResult:
     """Build the deterministic dataset result used by scheduler and runner layers."""
@@ -369,10 +543,14 @@ def _build_scheduler_metadata(
 ) -> dict[str, Any]:
     """Derive deterministic scheduler metadata from a validated dataset result."""
     try:
-        return ReplayScheduler().schedule(
-            dataset_result,
-            SchedulerConfig(profile=speedup_profile),
-        ).to_dict()
+        return (
+            ReplayScheduler()
+            .schedule(
+                dataset_result,
+                SchedulerConfig(profile=speedup_profile),
+            )
+            .to_dict()
+        )
     except (TypeError, ValueError) as exc:
         raise ReplayRunnerError(f"scheduler validation failed: {exc}") from exc
 
@@ -443,7 +621,7 @@ def _append_failed_record(
 
 def _build_replay_report_input(
     backtest_report: dict[str, Any],
-    config: AcceleratedShadowReplayConfig,
+    config: ARVPReplayConfig,
     code_commit: str,
     output_dir: Path,
     scheduler_metadata: dict[str, Any] | None = None,
@@ -460,7 +638,9 @@ def _build_replay_report_input(
 
     No metrics are recalculated; all values are derived from the backtest report.
     """
-    execution_run_id: str = execution_provenance_id or backtest_report["run_metadata"]["run_id"]
+    execution_run_id: str = (
+        execution_provenance_id or backtest_report["run_metadata"]["run_id"]
+    )
     run_id: str = runner_run_id or execution_run_id
     dataset: dict[str, Any] = dict(backtest_report["dataset_summary"])
     if dataset_fingerprint is not None:
@@ -509,9 +689,7 @@ def _build_replay_report_input(
         event_loop_states_hash=empty_chain_hash,
         integrity_ok=determinism_ok,
         failed_checks=(
-            ()
-            if determinism_ok
-            else ("deterministic_replay_check_failed",)
+            () if determinism_ok else ("deterministic_replay_check_failed",)
         ),
     )
 
@@ -553,7 +731,7 @@ def _build_replay_report_input(
 
 def _write_supplementary_artifacts(
     bundle_dir: Path,
-    config: AcceleratedShadowReplayConfig,
+    config: ARVPReplayConfig,
     code_commit: str,
 ) -> None:
     """Write config.resolved.json and env_redacted.txt into the bundle directory.
@@ -594,15 +772,20 @@ def _write_supplementary_artifacts(
 # ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
-def run_accelerated_shadow_replay(config: AcceleratedShadowReplayConfig) -> int:
-    """Orchestrate a full accelerated shadow replay run.
+def run_accelerated_shadow_replay(config: ARVPReplayConfig) -> int:
+    """Orchestrate a full ARVP replay run (baseline or scenario group).
 
     Args:
-        config: Validated AcceleratedShadowReplayConfig instance.
+        config: Validated ARVPReplayConfig instance.
 
     Returns:
         Exit code integer: 0 success, 1 config error, 2 runtime/input error.
     """
+    # Scenario group path
+    if config.scenario_ids:
+        return _run_scenario_group_path_with_candles(config)
+
+    # Baseline path: load candles first, then continue
     input_path = Path(config.input_candles_file)
 
     # Load + validate candles (also covers dry-run path)
@@ -1004,7 +1187,117 @@ def _build_argument_parser() -> argparse.ArgumentParser:
         default=False,
         help="Exit with code 2 if the replay determinism check fails.",
     )
+    parser.add_argument(
+        "--scenario-group",
+        default=None,
+        metavar="ID,ID,...",
+        help="Comma-separated built-in scenario IDs (baseline,pessimistic_execution,...)",
+    )
+    parser.add_argument(
+        "--scenario-group-id",
+        default=None,
+        metavar="ID",
+        help="Optional explicit scenario group ID",
+    )
     return parser
+
+
+def _run_baseline_path(
+    config: ARVPReplayConfig,
+    candles: list[dict[str, Any]],
+) -> int:
+    """Run baseline single replay. Extracted for reuse."""
+    # ... this is placeholder - real logic extracted below
+    return 0
+
+
+def _run_scenario_group_path_with_candles(config: ARVPReplayConfig) -> int:
+    input_path = Path(config.input_candles_file)
+    try:
+        candles = _load_candles(input_path)
+    except ReplayRunnerError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if config.dry_run:
+        print(
+            "DRY-RUN: scenario group valid, input file accessible. "
+            f"{len(candles)} candles found."
+        )
+        return 0
+
+    return _run_scenario_group_path(config, candles)
+
+
+def _run_scenario_group_path(
+    config: ARVPReplayConfig,
+    candles: list[dict[str, Any]],
+) -> int:
+    """Run scenario group via harness."""
+    output_dir = Path(config.output_directory)
+    code_commit = _get_code_commit()
+
+    def run_single(spec: ScenarioSpec) -> ScenarioRunResult:
+        try:
+            run_cfg = PrimaryBreakoutBacktestRunConfig(
+                bridge=PrimaryBreakoutBridgeConfig(
+                    entry_lookback_minutes=config.entry_lookback_minutes,
+                    exit_lookback_minutes=config.exit_lookback_minutes,
+                    breakout_buffer=config.breakout_buffer,
+                    min_minutes_between_entries=config.min_minutes_between_entries,
+                ),
+                order_size=config.order_size,
+                order_book_depth_multiplier=config.order_book_depth_multiplier,
+            )
+            warmup_count = max(
+                run_cfg.bridge.entry_lookback_minutes,
+                run_cfg.bridge.exit_lookback_minutes,
+            )
+            resolved_overrides = _apply_scenario_overrides(config, spec.config_overrides)
+            scenario_candles = _apply_replay_data_overrides(
+                candles,
+                resolved_overrides.replay_data_overrides,
+                warmup_count=warmup_count,
+            )
+
+            backtest_report = run_primary_breakout_backtest(
+                scenario_candles,
+                run_config=run_cfg,
+                simulator_config=resolved_overrides.simulator_config,
+                code_commit=code_commit,
+            )
+
+            run_id = backtest_report["run_metadata"]["run_id"]
+            return ScenarioRunResult(
+                scenario_id=spec.scenario_id,
+                exit_code=0,
+                run_id=run_id,
+            )
+        except ReplayRunnerError as exc:
+            return ScenarioRunResult(
+                scenario_id=spec.scenario_id,
+                exit_code=2,
+                failure_reason=str(exc),
+            )
+        except Exception as exc:
+            return ScenarioRunResult(
+                scenario_id=spec.scenario_id,
+                exit_code=2,
+                failure_reason=str(exc),
+            )
+
+    manifest = run_builtin_scenario_group(
+        config.scenario_ids,
+        run_fn=run_single,
+        output_dir=output_dir,
+        group_id=config.scenario_group_id,
+    )
+
+    summary = build_scenario_comparison_summary(manifest)
+    summary_path = Path(manifest.artifact_root) / "scenario_comparison_summary.md"
+    summary_path.write_text(summary, encoding="utf-8")
+
+    return 0 if manifest.failed_count == 0 else 2
 
 
 def main() -> int:
@@ -1012,8 +1305,14 @@ def main() -> int:
     parser = _build_argument_parser()
     args = parser.parse_args()
 
+    scenario_ids = None
+    if args.scenario_group:
+        scenario_ids = tuple(
+            part.strip() for part in args.scenario_group.split(",") if part.strip()
+        )
+
     try:
-        config = AcceleratedShadowReplayConfig(
+        config = ARVPReplayConfig(
             input_candles_file=args.input_candles,
             strategy_id=args.strategy_id,
             symbol=args.symbol,
@@ -1022,6 +1321,8 @@ def main() -> int:
             output_directory=args.output_dir,
             dry_run=args.dry_run,
             deterministic_verify=args.deterministic_verify,
+            scenario_ids=scenario_ids,
+            scenario_group_id=args.scenario_group_id,
         )
         config.validate()
     except ValueError as exc:

--- a/tests/unit/replay/test_historical_bridge.py
+++ b/tests/unit/replay/test_historical_bridge.py
@@ -97,6 +97,34 @@ def test_bridge_output_is_adapter_ready_for_primary_breakout() -> None:
 
 
 @pytest.mark.unit
+def test_bridge_marks_gap_rows_as_insufficient_input_requests() -> None:
+    candles = _candles()
+    gap_idx = 240
+    stale_source = dict(candles[gap_idx - 1])
+    candles[gap_idx] = {
+        **stale_source,
+        "ts_ms": candles[gap_idx]["ts_ms"],
+        "volume": 0.0,
+        "market_state_fresh": False,
+        "regime_fresh": False,
+        "data_gap_active": True,
+    }
+
+    requests = build_primary_breakout_historical_bridge(candles)
+    gap_request = requests[0]
+
+    assert gap_request.market_event["market_state"]["data_gap_active"] is True
+    assert gap_request.market_event["market_state"]["market_state_fresh"] is False
+    assert gap_request.market_event["market_state"]["regime_fresh"] is False
+    assert "close_now" not in gap_request.market_event["market_state"]
+    assert "price" not in gap_request.market_event
+    assert "close" not in gap_request.market_event
+    assert "close" not in gap_request.market_snapshot
+    assert "high" not in gap_request.market_snapshot
+    assert "low" not in gap_request.market_snapshot
+
+
+@pytest.mark.unit
 def test_bridge_rejects_invalid_trade_side_mode_in_config() -> None:
     candles = _candles()
     config = PrimaryBreakoutBridgeConfig(trade_side_mode="both")

--- a/tests/unit/replay/test_scenario_packs.py
+++ b/tests/unit/replay/test_scenario_packs.py
@@ -93,10 +93,9 @@ class TestGetScenarioPack:
             "execution_slippage_bps",
             "fill_rate",
             "execution_posture",
-            "execution_delay_ms",
+            "execution_delay_bars",
             "fill_depth_factor",
-            "feed_gap_seconds",
-            "drop_ticks_on_gap",
+            "feed_gap_bars",
         }
         assert not perturbation_keys.intersection(overrides.keys())
 
@@ -121,9 +120,10 @@ class TestGetScenarioPack:
     def test_delayed_execution_overrides(self) -> None:
         spec = get_scenario_pack("delayed_execution")
         o = spec.config_overrides
-        assert o["execution_delay_ms"] == 500
+        assert o["execution_delay_bars"] == 1
         assert o["execution_posture"] == "delayed"
         assert o["pack_id"] == "delayed_execution"
+        assert "execution_delay_ms" not in o
 
     # --- low_liquidity ---
 
@@ -139,9 +139,10 @@ class TestGetScenarioPack:
     def test_feed_gap_overrides(self) -> None:
         spec = get_scenario_pack("feed_gap")
         o = spec.config_overrides
-        assert o["feed_gap_seconds"] == 30
-        assert o["drop_ticks_on_gap"] is True
+        assert o["feed_gap_bars"] == 2
         assert o["pack_id"] == "feed_gap"
+        assert "feed_gap_seconds" not in o
+        assert "drop_ticks_on_gap" not in o
 
     # --- determinism ---
 

--- a/tests/unit/validation/test_primary_breakout_backtest_runner.py
+++ b/tests/unit/validation/test_primary_breakout_backtest_runner.py
@@ -8,7 +8,14 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft7Validator
 
+import services.validation.strategy_backtest_runner as backtest_runner
+from core.contracts.external_adapter_contracts import (
+    StrategyAdapterRequest,
+    StrategyAdapterResponse,
+    StrategySignalCandidate,
+)
 from services.validation.strategy_backtest_runner import (
+    _build_data_integrity_diagnostics,
     PrimaryBreakoutBacktestError,
     PrimaryBreakoutBacktestRunConfig,
     run_primary_breakout_backtest,
@@ -53,6 +60,32 @@ def _candles() -> list[dict]:
 
 def _load_schema() -> dict:
     return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _bridge_requests() -> list[StrategyAdapterRequest]:
+    base_ts_ms = 1_700_000_000_000
+    closes = (100.0, 101.0, 102.0)
+    return [
+        StrategyAdapterRequest(
+            symbol="BTCUSDT",
+            market_event={
+                "ts_ms": base_ts_ms + index * 60_000,
+                "market_state": {
+                    "market_state_fresh": True,
+                    "regime_fresh": True,
+                },
+            },
+            market_snapshot={
+                "open": close - 0.5,
+                "high": close + 0.5,
+                "low": close - 0.5,
+                "close": close,
+                "volume": 1_000.0,
+            },
+            runtime_context={},
+        )
+        for index, close in enumerate(closes)
+    ]
 
 
 @pytest.mark.unit
@@ -109,3 +142,417 @@ def test_primary_breakout_backtest_runner_fail_closed_on_invalid_config() -> Non
 
     with pytest.raises(PrimaryBreakoutBacktestError, match="order_size must be > 0"):
         run_primary_breakout_backtest(candles, run_config=config, code_commit="a9a62be")
+
+
+@pytest.mark.unit
+def test_primary_breakout_backtest_runner_surfaces_clean_end_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candles = _candles()[:3]
+    requests = _bridge_requests()
+
+    def fake_build_bridge(
+        _candles_input: list[dict],
+        *,
+        config: PrimaryBreakoutBacktestRunConfig,
+    ) -> list[StrategyAdapterRequest]:
+        return requests
+
+    def fake_evaluate(
+        request: StrategyAdapterRequest,
+        *,
+        position_open: bool,
+        last_entry_ts_ms: int | None,
+        config: PrimaryBreakoutBacktestRunConfig,
+    ) -> tuple[StrategyAdapterResponse, int | None]:
+        ts_ms = int(request.market_event["ts_ms"])
+        if ts_ms == int(requests[0].market_event["ts_ms"]):
+            return (
+                StrategyAdapterResponse(
+                    signals=(
+                        StrategySignalCandidate(
+                            strategy_id="primary_breakout_v1",
+                            symbol="BTCUSDT",
+                            side="BUY",
+                            reason="test_entry",
+                            price=100.0,
+                            metadata={"adapter_id": "test"},
+                        ),
+                    ),
+                    diagnostics={"status": "signal_emitted"},
+                ),
+                last_entry_ts_ms,
+            )
+        if ts_ms == int(requests[1].market_event["ts_ms"]):
+            return (
+                StrategyAdapterResponse(
+                    signals=(
+                        StrategySignalCandidate(
+                            strategy_id="primary_breakout_v1",
+                            symbol="BTCUSDT",
+                            side="SELL",
+                            reason="test_exit",
+                            price=101.0,
+                            metadata={"adapter_id": "test"},
+                        ),
+                    ),
+                    diagnostics={"status": "signal_emitted"},
+                ),
+                last_entry_ts_ms,
+            )
+        return StrategyAdapterResponse(diagnostics={"status": "no_signal"}), last_entry_ts_ms
+
+    def fake_simulate_trade(
+        *,
+        side: str,
+        price: float,
+        ts_ms: int,
+        volume: float,
+        simulator: object,
+        order_size: float,
+        order_book_depth_multiplier: float,
+        volatility: float,
+    ) -> dict[str, float | bool | str | None]:
+        return {
+            "side": side,
+            "ts_ms": ts_ms,
+            "filled_size": order_size,
+            "avg_fill_price": price,
+            "slippage_bps": 0.0,
+            "fees": 0.0,
+            "partial_fill": False,
+            "fill_ratio": 1.0,
+            "notes": None,
+        }
+
+    monkeypatch.setattr(
+        backtest_runner,
+        "build_primary_breakout_historical_bridge",
+        fake_build_bridge,
+    )
+    monkeypatch.setattr(
+        backtest_runner,
+        "_evaluate_primary_breakout_request",
+        fake_evaluate,
+    )
+    monkeypatch.setattr(backtest_runner, "_simulate_trade", fake_simulate_trade)
+
+    report = run_primary_breakout_backtest(
+        candles,
+        run_config=PrimaryBreakoutBacktestRunConfig(),
+        code_commit="a9a62be",
+    )
+
+    diagnostics = report["metrics"]["data_integrity_diagnostics"]
+    assert report["metrics"]["data_integrity_ok"] is True
+    assert diagnostics["data_integrity_reason"] == "clean"
+    assert diagnostics["open_position_at_end"] is None
+    assert diagnostics["pending_signals_at_end"] == []
+
+
+@pytest.mark.unit
+def test_primary_breakout_backtest_runner_surfaces_open_position_end_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candles = _candles()[:3]
+    requests = _bridge_requests()
+
+    def fake_build_bridge(
+        _candles_input: list[dict],
+        *,
+        config: PrimaryBreakoutBacktestRunConfig,
+    ) -> list[StrategyAdapterRequest]:
+        return requests
+
+    def fake_evaluate(
+        request: StrategyAdapterRequest,
+        *,
+        position_open: bool,
+        last_entry_ts_ms: int | None,
+        config: PrimaryBreakoutBacktestRunConfig,
+    ) -> tuple[StrategyAdapterResponse, int | None]:
+        ts_ms = int(request.market_event["ts_ms"])
+        if ts_ms == int(requests[0].market_event["ts_ms"]):
+            return (
+                StrategyAdapterResponse(
+                    signals=(
+                        StrategySignalCandidate(
+                            strategy_id="primary_breakout_v1",
+                            symbol="BTCUSDT",
+                            side="BUY",
+                            reason="test_entry",
+                            price=100.0,
+                            metadata={"adapter_id": "test"},
+                        ),
+                    ),
+                    diagnostics={"status": "signal_emitted"},
+                ),
+                last_entry_ts_ms,
+            )
+        return StrategyAdapterResponse(diagnostics={"status": "no_signal"}), last_entry_ts_ms
+
+    def fake_simulate_trade(
+        *,
+        side: str,
+        price: float,
+        ts_ms: int,
+        volume: float,
+        simulator: object,
+        order_size: float,
+        order_book_depth_multiplier: float,
+        volatility: float,
+    ) -> dict[str, float | bool | str | None]:
+        return {
+            "side": side,
+            "ts_ms": ts_ms,
+            "filled_size": order_size,
+            "avg_fill_price": price,
+            "slippage_bps": 0.0,
+            "fees": 0.0,
+            "partial_fill": False,
+            "fill_ratio": 1.0,
+            "notes": None,
+        }
+
+    monkeypatch.setattr(
+        backtest_runner,
+        "build_primary_breakout_historical_bridge",
+        fake_build_bridge,
+    )
+    monkeypatch.setattr(
+        backtest_runner,
+        "_evaluate_primary_breakout_request",
+        fake_evaluate,
+    )
+    monkeypatch.setattr(backtest_runner, "_simulate_trade", fake_simulate_trade)
+
+    report = run_primary_breakout_backtest(
+        candles,
+        run_config=PrimaryBreakoutBacktestRunConfig(),
+        code_commit="a9a62be",
+    )
+
+    diagnostics = report["metrics"]["data_integrity_diagnostics"]
+    assert report["metrics"]["data_integrity_ok"] is False
+    assert diagnostics["data_integrity_reason"] == "open_position_at_end"
+    assert diagnostics["open_position_at_end"] == {
+        "entry_price": 100.0,
+        "entry_ts_ms": int(requests[0].market_event["ts_ms"]),
+        "entry_fee": 0.0,
+    }
+    assert diagnostics["pending_signals_at_end"] == []
+
+
+@pytest.mark.unit
+def test_build_data_integrity_diagnostics_surfaces_pending_signals() -> None:
+    diagnostics = _build_data_integrity_diagnostics(
+        None,
+        (
+            {
+                "side": "BUY",
+                "target_idx": 7,
+                "execution_price": 101.25,
+                "ts_ms": 1_700_000_060_000,
+                "volume": 2.5,
+                "volatility": 0.01,
+            },
+        ),
+    )
+
+    assert diagnostics["data_integrity_reason"] == "pending_signals_at_end"
+    assert diagnostics["open_position_at_end"] is None
+    assert diagnostics["pending_signals_at_end"] == [
+        {
+            "side": "BUY",
+            "target_idx": 7,
+            "execution_price": 101.25,
+            "ts_ms": 1_700_000_060_000,
+            "volume": 2.5,
+            "volatility": 0.01,
+        }
+    ]
+
+
+@pytest.mark.unit
+def test_primary_breakout_backtest_runner_delays_execution_by_bar_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candles = _candles()[:3]
+    requests = _bridge_requests()
+    baseline_calls: list[dict[str, float]] = []
+    delayed_calls: list[dict[str, float]] = []
+    active_calls = baseline_calls
+
+    def fake_build_bridge(
+        _candles_input: list[dict],
+        *,
+        config: PrimaryBreakoutBacktestRunConfig,
+    ) -> list[StrategyAdapterRequest]:
+        return requests
+
+    def fake_evaluate(
+        request: StrategyAdapterRequest,
+        *,
+        position_open: bool,
+        last_entry_ts_ms: int | None,
+        config: PrimaryBreakoutBacktestRunConfig,
+    ) -> tuple[StrategyAdapterResponse, int | None]:
+        ts_ms = int(request.market_event["ts_ms"])
+        if ts_ms == int(requests[0].market_event["ts_ms"]):
+            return (
+                StrategyAdapterResponse(
+                    signals=(
+                        StrategySignalCandidate(
+                            strategy_id="primary_breakout_v1",
+                            symbol="BTCUSDT",
+                            side="BUY",
+                            reason="test_entry",
+                            price=100.0,
+                            metadata={"adapter_id": "test"},
+                        ),
+                    ),
+                    diagnostics={"status": "signal_emitted"},
+                ),
+                last_entry_ts_ms,
+            )
+        if ts_ms == int(requests[1].market_event["ts_ms"]):
+            return (
+                StrategyAdapterResponse(
+                    signals=(
+                        StrategySignalCandidate(
+                            strategy_id="primary_breakout_v1",
+                            symbol="BTCUSDT",
+                            side="SELL",
+                            reason="test_exit",
+                            price=101.0,
+                            metadata={"adapter_id": "test"},
+                        ),
+                    ),
+                    diagnostics={"status": "signal_emitted"},
+                ),
+                last_entry_ts_ms,
+            )
+        return StrategyAdapterResponse(diagnostics={"status": "no_signal"}), last_entry_ts_ms
+
+    def fake_simulate_trade(
+        *,
+        side: str,
+        price: float,
+        ts_ms: int,
+        volume: float,
+        simulator: object,
+        order_size: float,
+        order_book_depth_multiplier: float,
+        volatility: float,
+    ) -> dict[str, float | bool | str | None]:
+        active_calls.append({"price": price, "ts_ms": ts_ms})
+        return {
+            "side": side,
+            "ts_ms": ts_ms,
+            "filled_size": order_size,
+            "avg_fill_price": price,
+            "slippage_bps": 0.0,
+            "fees": 0.0,
+            "partial_fill": False,
+            "fill_ratio": 1.0,
+            "notes": None,
+        }
+
+    monkeypatch.setattr(
+        backtest_runner,
+        "build_primary_breakout_historical_bridge",
+        fake_build_bridge,
+    )
+    monkeypatch.setattr(
+        backtest_runner,
+        "_evaluate_primary_breakout_request",
+        fake_evaluate,
+    )
+    monkeypatch.setattr(backtest_runner, "_simulate_trade", fake_simulate_trade)
+
+    baseline_report = run_primary_breakout_backtest(
+        candles,
+        run_config=PrimaryBreakoutBacktestRunConfig(),
+        code_commit="a9a62be",
+    )
+    active_calls = delayed_calls
+    delayed_report = run_primary_breakout_backtest(
+        candles,
+        run_config=PrimaryBreakoutBacktestRunConfig(),
+        simulator_config={"EXECUTION_DELAY_BARS": 1},
+        code_commit="a9a62be",
+    )
+
+    assert [call["ts_ms"] for call in baseline_calls] == [
+        int(requests[0].market_event["ts_ms"]),
+        int(requests[1].market_event["ts_ms"]),
+    ]
+    assert [call["ts_ms"] for call in delayed_calls] == [
+        int(requests[1].market_event["ts_ms"]),
+        int(requests[2].market_event["ts_ms"]),
+    ]
+    assert baseline_calls[0]["price"] == 100.0
+    assert delayed_calls[0]["price"] == 101.0
+    assert baseline_report["metrics"]["closed_trades_total"] == 1
+    assert delayed_report["metrics"]["closed_trades_total"] == 1
+    assert baseline_report["metrics"]["expectancy_r"] != delayed_report["metrics"]["expectancy_r"]
+
+
+@pytest.mark.unit
+def test_primary_breakout_backtest_runner_fails_closed_on_out_of_range_delay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candles = _candles()[:3]
+    requests = _bridge_requests()
+
+    def fake_build_bridge(
+        _candles_input: list[dict],
+        *,
+        config: PrimaryBreakoutBacktestRunConfig,
+    ) -> list[StrategyAdapterRequest]:
+        return requests
+
+    def fake_evaluate(
+        request: StrategyAdapterRequest,
+        *,
+        position_open: bool,
+        last_entry_ts_ms: int | None,
+        config: PrimaryBreakoutBacktestRunConfig,
+    ) -> tuple[StrategyAdapterResponse, int | None]:
+        if int(request.market_event["ts_ms"]) == int(requests[-1].market_event["ts_ms"]):
+            return (
+                StrategyAdapterResponse(
+                    signals=(
+                        StrategySignalCandidate(
+                            strategy_id="primary_breakout_v1",
+                            symbol="BTCUSDT",
+                            side="BUY",
+                            reason="late_entry",
+                            price=102.0,
+                            metadata={"adapter_id": "test"},
+                        ),
+                    ),
+                    diagnostics={"status": "signal_emitted"},
+                ),
+                last_entry_ts_ms,
+            )
+        return StrategyAdapterResponse(diagnostics={"status": "no_signal"}), last_entry_ts_ms
+
+    monkeypatch.setattr(
+        backtest_runner,
+        "build_primary_breakout_historical_bridge",
+        fake_build_bridge,
+    )
+    monkeypatch.setattr(
+        backtest_runner,
+        "_evaluate_primary_breakout_request",
+        fake_evaluate,
+    )
+
+    with pytest.raises(PrimaryBreakoutBacktestError, match="Delayed execution out of range"):
+        run_primary_breakout_backtest(
+            candles,
+            run_config=PrimaryBreakoutBacktestRunConfig(),
+            simulator_config={"EXECUTION_DELAY_BARS": 1},
+            code_commit="a9a62be",
+        )

--- a/tests/unit/validation/test_strategy_replay_runner.py
+++ b/tests/unit/validation/test_strategy_replay_runner.py
@@ -16,6 +16,8 @@ from unittest.mock import patch
 
 import pytest
 
+from core.replay.scenario_harness import ScenarioHarnessError
+from core.replay.scenario_packs import ScenarioPackError
 from core.replay.run_registry import ReplayRunRegistry, RunRegistryError
 from core.replay.dataset_spec import DatasetSpec
 from services.validation.replay_reporter import ReplayReporter
@@ -864,6 +866,36 @@ class TestDryRun:
         captured = capsys.readouterr()
         assert "DRY-RUN" in captured.out
         assert "scenario group" in captured.out
+
+    @pytest.mark.parametrize(
+        ("error_cls", "message"),
+        [
+            (ScenarioHarnessError, "invalid scenario group"),
+            (ScenarioPackError, "unknown scenario pack"),
+        ],
+    )
+    def test_scenario_group_runtime_errors_return_2(
+        self, tmp_path, capsys, error_cls, message
+    ):
+        candles = [{"ts_ms": 1_000_000}]
+        f = tmp_path / "candles.json"
+        f.write_text(json.dumps(candles), encoding="utf-8")
+
+        cfg = AcceleratedShadowReplayConfig(
+            input_candles_file=str(f),
+            output_directory=str(tmp_path),
+            scenario_ids=("baseline",),
+        )
+
+        with patch(
+            "services.validation.strategy_replay_runner.run_builtin_scenario_group",
+            side_effect=error_cls(message),
+        ):
+            exit_code = run_accelerated_shadow_replay(cfg)
+
+        assert exit_code == 2
+        captured = capsys.readouterr()
+        assert f"ERROR: {message}" in captured.err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/validation/test_strategy_replay_runner.py
+++ b/tests/unit/validation/test_strategy_replay_runner.py
@@ -26,6 +26,8 @@ from services.validation.strategy_replay_runner import (
     _DEFAULT_SYMBOL,
     AcceleratedShadowReplayConfig,
     ReplayRunnerError,
+    _apply_replay_data_overrides,
+    _apply_scenario_overrides,
     _build_replay_report_input,
     _load_candles,
     run_accelerated_shadow_replay,
@@ -48,6 +50,7 @@ def _minimal_backtest_report(
     period_start_ts_ms: int = 1_700_000_000_000,
     period_end_ts_ms: int = 1_700_100_000_000,
     gate_status: str = "PASS",
+    data_integrity_reason: str = "clean",
 ) -> dict:
     return {
         "schema_version": "strategy_validation_report.v1",
@@ -86,6 +89,11 @@ def _minimal_backtest_report(
             "market_state_fresh_ratio": 0.99,
             "regime_fresh_ratio": 0.99,
             "data_integrity_ok": True,
+            "data_integrity_diagnostics": {
+                "data_integrity_reason": data_integrity_reason,
+                "open_position_at_end": None,
+                "pending_signals_at_end": [],
+            },
             "deterministic_replay_ok": deterministic_ok,
         },
         "thresholds_applied": {
@@ -339,6 +347,18 @@ class TestBuildReplayReportInput:
 
         assert result.metrics is not None
         assert result.metrics["profit_factor"] == 1.3
+
+    def test_data_integrity_diagnostics_passed_through(self, tmp_path):
+        report = _minimal_backtest_report(data_integrity_reason="open_position_at_end")
+        cfg = _minimal_valid_config()
+        result = _build_replay_report_input(report, cfg, "abc1234", tmp_path)
+
+        assert result.metrics is not None
+        assert result.metrics["data_integrity_diagnostics"] == {
+            "data_integrity_reason": "open_position_at_end",
+            "open_position_at_end": None,
+            "pending_signals_at_end": [],
+        }
 
     def test_config_snapshot_passed_through(self, tmp_path):
         report = _minimal_backtest_report()
@@ -825,6 +845,124 @@ class TestDryRun:
         run_accelerated_shadow_replay(cfg)
         # output directory must NOT be created
         assert not (tmp_path / "out").exists()
+
+    def test_scenario_group_dry_run_returns_0(self, tmp_path, capsys):
+        candles = [{"ts_ms": 1_000_000}]
+        f = tmp_path / "candles.json"
+        f.write_text(json.dumps(candles), encoding="utf-8")
+
+        cfg = AcceleratedShadowReplayConfig(
+            input_candles_file=str(f),
+            output_directory=str(tmp_path),
+            dry_run=True,
+            scenario_ids=("baseline", "delayed_execution"),
+        )
+
+        exit_code = run_accelerated_shadow_replay(cfg)
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "DRY-RUN" in captured.out
+        assert "scenario group" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# TestScenarioOverrides
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestScenarioOverrides:
+    def test_apply_scenario_overrides_maps_explicit_bar_delay(self):
+        cfg = AcceleratedShadowReplayConfig(input_candles_file="candles.json")
+
+        result = _apply_scenario_overrides(
+            cfg,
+            {
+                "execution_delay_bars": 1,
+                "execution_posture": "delayed",
+            },
+        )
+
+        assert result.simulator_config["EXECUTION_DELAY_BARS"] == 1
+        assert result.simulator_config["_execution_posture"] == "delayed"
+        assert result.replay_data_overrides == {}
+
+    def test_apply_scenario_overrides_rejects_execution_delay_ms(self):
+        cfg = AcceleratedShadowReplayConfig(input_candles_file="candles.json")
+
+        with pytest.raises(ReplayRunnerError, match="unknown keys"):
+            _apply_scenario_overrides(cfg, {"execution_delay_ms": 500})
+
+    def test_apply_scenario_overrides_maps_feed_gap_to_replay_data_surface(self):
+        cfg = AcceleratedShadowReplayConfig(input_candles_file="candles.json")
+
+        result = _apply_scenario_overrides(cfg, {"feed_gap_bars": 2})
+
+        assert result.simulator_config == {}
+        assert result.replay_data_overrides == {"feed_gap_bars": 2}
+
+    def test_apply_scenario_overrides_rejects_seconds_gap_semantics(self):
+        cfg = AcceleratedShadowReplayConfig(input_candles_file="candles.json")
+
+        with pytest.raises(ReplayRunnerError, match="not representable"):
+            _apply_scenario_overrides(cfg, {"feed_gap_seconds": 30})
+
+
+@pytest.mark.unit
+class TestReplayDataOverrides:
+    def test_apply_replay_data_overrides_injects_midpoint_gap(self):
+        candles = [
+            {
+                "symbol": "BTCUSDT",
+                "ts_ms": 1_000_000 + i * 60_000,
+                "open": 100.0 + i,
+                "high": 101.0 + i,
+                "low": 99.0 + i,
+                "close": 100.5 + i,
+                "volume": 10.0 + i,
+                "regime_id": 0,
+                "market_state_fresh": True,
+                "regime_fresh": True,
+            }
+            for i in range(10)
+        ]
+
+        perturbed = _apply_replay_data_overrides(
+            candles,
+            {"feed_gap_bars": 2},
+            warmup_count=4,
+        )
+
+        assert perturbed[6]["data_gap_active"] is True
+        assert perturbed[7]["data_gap_active"] is True
+        assert perturbed[6]["market_state_fresh"] is False
+        assert perturbed[7]["regime_fresh"] is False
+        assert perturbed[6]["close"] == candles[5]["close"]
+        assert perturbed[7]["high"] == candles[5]["high"]
+        assert perturbed[6]["ts_ms"] == candles[6]["ts_ms"]
+        assert perturbed[7]["ts_ms"] == candles[7]["ts_ms"]
+        assert "data_gap_active" not in perturbed[5]
+
+    def test_apply_replay_data_overrides_rejects_gap_covering_all_live_bars(self):
+        candles = [
+            {
+                "symbol": "BTCUSDT",
+                "ts_ms": 1_000_000 + i * 60_000,
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 100.5,
+                "volume": 10.0,
+                "regime_id": 0,
+            }
+            for i in range(6)
+        ]
+
+        with pytest.raises(ReplayRunnerError, match="unaffected live candle"):
+            _apply_replay_data_overrides(
+                candles,
+                {"feed_gap_bars": 3},
+                warmup_count=3,
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR completes the current ARVP replay integration line on the 1m replay canvas.

## Included
- explicit bar-level delayed_execution semantics
- explicit bar-level feed_gap semantics
- scenario-group workflow and reporting path
- deterministic pending-execution queue for delayed_execution
- deterministic replay data-gap surface for feed_gap
- fail-closed data_integrity diagnostics and contract/doc clarity

## Not included
- no hidden ms->bar shim
- no hidden seconds->bars shim
- no slippage proxy for delay
- no end-of-window auto-close
- no gate softening
- no new runner

## Validation
- targeted unit suites passed
- real replay runs executed for baseline / delayed_execution / feed_gap
- delayed_execution showed real effect
- feed_gap showed real effect on freshness/gap surface
- data_integrity diagnostics now surface explicit terminal-state reasons