### PR TITLE
Finalize ARVP operator front door, naming, runner cleanup, and governance docs

### DIFF
--- a/core/replay/dataset_provider.py
+++ b/core/replay/dataset_provider.py
@@ -236,9 +236,9 @@ class DBBackedDatasetProvider:
       - All required fields present and non-None in each row
       - ``ts_ms`` strictly increasing at exactly 1-minute cadence
 
-    Note on ``db_dataset_id``
+    Note on ``db_dataset_window``
     -------------------------
-    ``spec.db_dataset_id`` is a **caller-provided logical label** used for
+    ``spec.db_dataset_window`` is a **caller-provided logical label** used for
     audit trail and deterministic fingerprinting via ``DatasetSpec.fingerprint()``.
     It does NOT resolve to a persisted dataset record and does NOT constrain
     the DB query. The query is keyed solely on ``spec.symbol`` and the time
@@ -268,7 +268,7 @@ class DBBackedDatasetProvider:
             cursor = self._db_conn.cursor()
             cursor.execute(
                 """
-                SELECT ts_ms, open, high, low, close, volume, trade_count
+                SELECT ts_ms, open, high, low, close, volume, trade_count, COALESCE(regime_id, 0)
                 FROM candles_1m
                 WHERE symbol = %s
                   AND ts_ms >= %s
@@ -301,6 +301,7 @@ class DBBackedDatasetProvider:
 
         candles: list[dict] = [
             {
+                "symbol": spec.symbol,
                 "ts_ms": row[0],
                 "open": row[1],
                 "high": row[2],
@@ -308,6 +309,7 @@ class DBBackedDatasetProvider:
                 "close": row[4],
                 "volume": row[5],
                 "trade_count": row[6],
+                "regime_id": row[7],
             }
             for row in rows
         ]

--- a/core/replay/dataset_spec.py
+++ b/core/replay/dataset_spec.py
@@ -16,12 +16,14 @@ hashing is deferred to the runner/reporting layer.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 from typing import Literal
 
 from core.replay.canonical_json import canonical_hash
 
 _VALID_SYMBOLS: frozenset[str] = frozenset({"BTCUSDT"})
 _VALID_TIMEFRAMES: frozenset[str] = frozenset({"1m"})
+_DB_DATASET_WINDOW_RE = re.compile(r"^(?P<start>\d+):(?P<end>\d+)$")
 
 
 class DatasetSpecError(ValueError):
@@ -47,13 +49,13 @@ class DatasetSpec:
         warm-up. Must be >= 0.
     source:
         ``"file"`` — load from a local file (``file_path`` required).
-        ``"db"``  — load from Postgres (``db_dataset_id`` required; not yet
-        implemented — see ``DBBackedDatasetProvider``).
+        ``"db"``  — load from Postgres (``db_dataset_window`` required; see
+        ``DBBackedDatasetProvider``).
     file_path:
         Absolute path to a JSON-array or JSONL file. Required when
         ``source="file"``; must be ``None`` when ``source="db"``.
-    db_dataset_id:
-        Identifier for a persisted dataset record. Required when
+    db_dataset_window:
+        Explicit dataset window label (``START_TS_MS:END_TS_MS``). Required when
         ``source="db"``; must be ``None`` when ``source="file"``.
     """
 
@@ -64,7 +66,7 @@ class DatasetSpec:
     warmup_candles: int
     source: Literal["file", "db"]
     file_path: str | None = None
-    db_dataset_id: str | None = None
+    db_dataset_window: str | None = None
 
     def validate(self) -> None:
         """Fail-closed invariant check. Raises ``DatasetSpecError`` on any violation."""
@@ -87,18 +89,42 @@ class DatasetSpec:
         if self.source == "file":
             if self.file_path is None:
                 raise DatasetSpecError("source='file' requires file_path.")
-            if self.db_dataset_id is not None:
+            if self.db_dataset_window is not None:
                 raise DatasetSpecError(
                     "source='file' and source='db' fields are mutually exclusive: "
-                    "db_dataset_id must be None when source='file'."
+                    "db_dataset_window must be None when source='file'."
                 )
         elif self.source == "db":
-            if self.db_dataset_id is None:
-                raise DatasetSpecError("source='db' requires db_dataset_id.")
+            if self.db_dataset_window is None:
+                raise DatasetSpecError("source='db' requires db_dataset_window.")
             if self.file_path is not None:
                 raise DatasetSpecError(
                     "source='file' and source='db' fields are mutually exclusive: "
                     "file_path must be None when source='db'."
+                )
+            if self.start_ts_ms >= self.end_ts_ms:
+                raise DatasetSpecError(
+                    f"db dataset window requires start_ts_ms < end_ts_ms, "
+                    f"got start_ts_ms={self.start_ts_ms}, end_ts_ms={self.end_ts_ms}."
+                )
+            raw = str(self.db_dataset_window).strip()
+            match = _DB_DATASET_WINDOW_RE.match(raw)
+            if not match:
+                raise DatasetSpecError(
+                    "db_dataset_window must be in the form 'START_TS_MS:END_TS_MS' (epoch millis)."
+                )
+            try:
+                label_start = int(match.group("start"))
+                label_end = int(match.group("end"))
+            except ValueError as exc:
+                raise DatasetSpecError(
+                    "db_dataset_window must contain integer START_TS_MS and END_TS_MS."
+                ) from exc
+            if label_start != self.start_ts_ms or label_end != self.end_ts_ms:
+                raise DatasetSpecError(
+                    "db_dataset_window must match start_ts_ms and end_ts_ms: "
+                    f"db_dataset_window={self.db_dataset_window!r}, "
+                    f"start_ts_ms={self.start_ts_ms}, end_ts_ms={self.end_ts_ms}."
                 )
         else:
             raise DatasetSpecError(
@@ -117,8 +143,8 @@ class DatasetSpec:
         }
         if self.file_path is not None:
             d["file_path"] = self.file_path
-        if self.db_dataset_id is not None:
-            d["db_dataset_id"] = self.db_dataset_id
+        if self.db_dataset_window is not None:
+            d["db_dataset_window"] = self.db_dataset_window
         return d
 
     def fingerprint(self) -> str:

--- a/docs/governance/arvp_platform.md
+++ b/docs/governance/arvp_platform.md
@@ -1,20 +1,24 @@
 # ARVP — Accelerated Replay Validation Platform
 
-**Status:** Governance anchor (foundation DONE; productization in progress)
+**Status:** Governance anchor (core merged; operator front door + MUST layers implemented on the 1m replay canvas)
 **Canonical term:** `ARVP` — Accelerated Replay Validation Platform
 **Foundation PR:** `#1808` (merged 2026-04-20)
 **Foundation issues:** `#1801`, `#1802`, `#1803`, `#1804`, `#1805`, `#1806`
 **Productization epic:** `#1839`
+**Repo snapshot date:** 2026-04-23
 
 ---
 
 ## 1. Why this document exists
 
-The ARVP replay foundation landed in full via PR `#1808`. The codebase now
-contains a strong deterministic replay core, but the product-level vocabulary
-is fragmented. The same capability appears under "deterministic replay loop",
-"shadow replay", "offline replay", "LR-021 replay", and "accelerated shadow
-replay" depending on the source file.
+The ARVP replay foundation landed in full via PR `#1808`, and the repo now
+contains a merged, operator-facing ARVP entry point plus the core MUST layers
+(historical dataset access, scheduler, run registry, scenario harness, scenario packs)
+on the strict 1m replay canvas.
+
+Historically, the product-level vocabulary was fragmented. This document
+establishes the canonical name and module map and records the current merged
+capabilities vs. explicit non-goals.
 
 This document establishes the single canonical name and module map so that:
 - all future issues, PRs, and docs can reference one unambiguous term
@@ -32,7 +36,7 @@ layer-specific module names (see §4) for narrower references.
 |---|---|
 | **ARVP** | Accelerated Replay Validation Platform — the full productized capability |
 | **ARVP foundation** | The deterministic replay core landed via PR `#1808` |
-| **ARVP productization** | The platform layers not yet implemented (see §5) |
+| **ARVP productization** | Ongoing layering beyond the merged core (see §4/§5); do not treat merged MUST layers as "not yet implemented" |
 
 **Do not use** as primary names: "shadow replay", "offline replay",
 "LR-021 replay", "deterministic replay platform". These terms may appear in
@@ -70,6 +74,18 @@ Supporting utilities (present before PR `#1808`, part of the foundation layer):
 **These foundation modules are complete.** Productization issues must not
 re-implement or silently replace any of them.
 
+### 3.1 Current merged operator-facing capability (repo-true)
+
+The following capabilities are **implemented and merged** (as of 2026-04-23):
+
+- Operator-facing ARVP replay entry point (`services/validation/strategy_replay_runner.py`)
+- Explicit dataset source handling (`file` / `db`) via the canonical dataset layer
+- Scenario-group workflow (multi-variant execution over one historical window)
+- Thin reporting + scenario artifacts (bundle + scenario comparison summary)
+- `delayed_execution` as explicit bar-level surface (no ms→bar shim)
+- `feed_gap` as explicit bar-level replay data-gap surface
+- Fail-closed data-integrity diagnostics surfaced via the report/metrics pipeline
+
 ---
 
 ## 4. Module boundaries
@@ -89,6 +105,7 @@ Supports file-backed and DB-backed providers under one canonical dataset spec.
 Produces a deterministic dataset fingerprint.
 **Not in scope:** Live/paper/Redis data. Synthetic generation.
 **Issue:** `#1841`
+**Status:** Implemented (merged; used by operator entry point)
 
 ### 4.3 Replay Scheduler
 
@@ -96,6 +113,7 @@ Produces a deterministic dataset fingerprint.
 (1×, 2×, 5×, 10×, instant). Deterministic tick delivery to the replay loop.
 **Not in scope:** Wall-clock scheduling of live services. Async frameworks.
 **Issue:** `#1842`
+**Status:** Implemented (merged; used by operator entry point)
 
 ### 4.4 Replay Run Orchestration / Run Registry
 
@@ -103,6 +121,7 @@ Produces a deterministic dataset fingerprint.
 concise operator summaries per run.
 **Not in scope:** Scenario orchestration (that is §4.5). Parallel execution.
 **Issue:** `#1843`
+**Status:** Implemented (merged; used by operator entry point)
 
 ### 4.5 Scenario Harness
 
@@ -110,6 +129,7 @@ concise operator summaries per run.
 Scenario identity, parameter binding, grouped output per scenario set.
 **Not in scope:** Scenario pack definitions (those are §4.6).
 **Issue:** `#1844`
+**Status:** Implemented (merged; used by operator entry point)
 
 ### 4.6 Scenario Packs
 
@@ -119,6 +139,7 @@ Each pack has a stable id, explicit parameters, documented perturbation intent,
 and deterministic behavior.
 **Not in scope:** Arbitrary user-defined DSLs. Counterfactual free-form perturbation.
 **Issue:** `#1845`
+**Status:** Implemented (merged; used by operator entry point)
 
 ### 4.7 Regime Analytics / Scorecards
 
@@ -175,9 +196,11 @@ NICE (robustness extensions, only after MUST+SHOULD):
   #1850 → #1851 → #1852
 ```
 
-The correct cutoff when capacity is limited: finish MUST first, then
-SHOULD in order, then NICE. Robustness layers before the scenario baseline
-is in place is optimization theater.
+The correct cutoff when capacity is limited: finish MUST first, then SHOULD in order,
+then NICE.
+
+Repo note (2026-04-23): The MUST chain is present and exercised by the canonical
+operator entry point. Remaining work is SHOULD/NICE layering, not "core missing."
 
 ---
 
@@ -189,6 +212,9 @@ The following are explicitly out of scope for ARVP productization:
 - Refactoring live trading or paper trading runtime services
 - ML-first strategy research
 - Multi-strategy generalization beyond `primary_breakout_v1`
+- Sub-minute replay canvas (the current canvas is strict 1m)
+- Any hidden ms→bar / seconds→bars shims (bar-level surfaces must be explicit)
+- Any implicit end-of-window auto-close semantics
 - Replacing genuine paper runs with replay
 - Building a heavyweight UI/dashboard before core productization slices exist
 - LR phase decisions, Echtgeld authorization, or live-capital enablement

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -1,8 +1,8 @@
-"""Accelerated shadow replay CLI entry point for primary_breakout_v1.
+"""ARVP replay CLI entry point for primary_breakout_v1.
 
 Thin operator-facing CLI that:
   - validates a minimal replay config fail-closed
-  - loads historical candle input from file (JSON array or JSONL)
+  - loads historical candle input from file or db via the canonical dataset layer
   - delegates to the existing backtest surface (strategy_backtest_runner)
   - builds a ReplayReportInput and writes the artifact bundle via ReplayReporter
   - writes supplementary artifacts (config.resolved.json, env_redacted.txt)
@@ -15,16 +15,27 @@ Exit codes:
     2  Input / runtime error (malformed candles, bridge failure, execution
        failure, reporter failure, or determinism failure with --deterministic-verify).
 
-Usage:
-    python -m services.validation.strategy_replay_runner \\
-        --input-candles candles.json \\
-        [--output-dir artifacts/replay_reports] \\
-        [--strategy-id primary_breakout_v1] \\
-        [--symbol BTCUSDT] \\
-        [--adapter-id primary_breakout_runner_v1] \\
-        [--speedup-profile instant|1x|2x|5x|10x] \\
-        [--dry-run] \\
-        [--deterministic-verify]
+ Usage:
+     python -m services.validation.strategy_replay_runner \\
+         --dataset-source file \\
+         --input-candles candles.json \\
+         [--output-dir artifacts/replay_reports] \\
+         [--strategy-id primary_breakout_v1] \\
+         [--symbol BTCUSDT] \\
+         [--adapter-id primary_breakout_runner_v1] \\
+         [--speedup-profile instant|1x|2x|5x|10x] \\
+         [--dry-run] \\
+         [--deterministic-verify]
+     python -m services.validation.strategy_replay_runner \\
+         --dataset-source db \\
+         --db-dataset-window START_TS_MS:END_TS_MS \\
+         [--output-dir artifacts/replay_reports] \\
+         [--strategy-id primary_breakout_v1] \\
+         [--symbol BTCUSDT] \\
+         [--adapter-id primary_breakout_runner_v1] \\
+         [--speedup-profile instant|1x|2x|5x|10x] \\
+         [--dry-run] \\
+         [--deterministic-verify]
 
 Governance: Issue #1804 (LR-021 Replay CLI Slice)
 
@@ -55,8 +66,13 @@ from pathlib import Path
 from typing import Any
 
 from core.replay.canonical_json import canonical_hash, canonical_json_dumps
-from core.replay.dataset_provider import DatasetResult
-from core.replay.dataset_spec import DatasetSpec
+from core.replay.dataset_provider import (
+    DBBackedDatasetProvider,
+    DatasetLoadError,
+    DatasetResult,
+    FileBackedDatasetProvider,
+)
+from core.replay.dataset_spec import DatasetSpec, DatasetSpecError
 from core.replay.historical_bridge import (
     HistoricalBridgeError,
     PrimaryBreakoutBridgeConfig,
@@ -99,6 +115,7 @@ from core.replay.replay_report_builder import (
     build_scenario_comparison_summary,
 )
 from core.utils.clock import utcnow
+from core.utils.postgres_client import create_postgres_connection
 from services.validation.replay_reporter import ReplayReporter, ReplayReporterError
 from services.validation.strategy_backtest_runner import (
     PrimaryBreakoutBacktestError,
@@ -159,7 +176,7 @@ class ReplayRunnerError(RuntimeError):
 # ---------------------------------------------------------------------------
 @dataclass(frozen=True, slots=True)
 class ARVPReplayConfig:
-    """Minimal, fail-closed config for an accelerated shadow replay run."""
+    """Minimal, fail-closed config for an ARVP replay run."""
 
     input_candles_file: str = ""
     """Path to candle input file (JSON array or JSONL)."""
@@ -167,8 +184,8 @@ class ARVPReplayConfig:
     dataset_source: str = "file"
     """Dataset input source: 'file' or 'db'."""
 
-    db_dataset_id: str | None = None
-    """Persisted dataset record ID."""
+    db_dataset_window: str | None = None
+    """DB-backed dataset window: 'START_TS_MS:END_TS_MS' (epoch millis)."""
 
     strategy_id: str = _DEFAULT_STRATEGY_ID
     """Strategy identifier. Must be in _SUPPORTED_STRATEGY_IDS."""
@@ -217,8 +234,36 @@ class ARVPReplayConfig:
 
     def validate(self) -> None:
         """Fail-closed config validation. Raises ValueError on any violation."""
-        if not self.input_candles_file:
-            raise ValueError("input_candles_file is required")
+        dataset_source = (self.dataset_source or "").strip()
+        if dataset_source not in {"file", "db"}:
+            raise ValueError(
+                f"dataset_source must be 'file' or 'db', got {self.dataset_source!r}"
+            )
+
+        if dataset_source == "file":
+            if not self.input_candles_file:
+                raise ValueError(
+                    "dataset_source='file' requires input_candles_file "
+                    "(use --input-candles)"
+                )
+            if self.db_dataset_window is not None:
+                raise ValueError(
+                    "dataset_source='file' and dataset_source='db' are mutually exclusive: "
+                    "db_dataset_window must be None when dataset_source='file'."
+                )
+        else:
+            if self.db_dataset_window is None or not str(self.db_dataset_window).strip():
+                raise ValueError(
+                    "dataset_source='db' requires db_dataset_window (use --db-dataset-window)"
+                )
+            if self.input_candles_file:
+                raise ValueError(
+                    "dataset_source='db' and dataset_source='file' are mutually exclusive: "
+                    "input_candles_file must be empty when dataset_source='db'."
+                )
+
+            # Fail-closed: db_dataset_window must include an explicit window.
+            _parse_db_dataset_window(self.db_dataset_window)
         if self.strategy_id not in _SUPPORTED_STRATEGY_IDS:
             raise ValueError(
                 f"unsupported strategy_id {self.strategy_id!r}; "
@@ -263,8 +308,39 @@ class ARVPReplayConfig:
                     )
 
 
-# Backward-compatible alias for existing tests/callers.
-AcceleratedShadowReplayConfig = ARVPReplayConfig
+_DB_DATASET_WINDOW_RE = re.compile(r"^(?P<start>\d+):(?P<end>\d+)$")
+
+
+def _parse_db_dataset_window(db_dataset_window: str) -> tuple[int, int]:
+    """Parse ``db_dataset_window`` into an explicit (start_ts_ms, end_ts_ms) window.
+
+    Front-door contract: for DB-backed datasets, operators must provide the
+    replay window explicitly as ``START_TS_MS:END_TS_MS`` (UTC epoch millis).
+    """
+    raw = str(db_dataset_window).strip()
+    match = _DB_DATASET_WINDOW_RE.match(raw)
+    if not match:
+        raise ValueError(
+            "db_dataset_window must be in the form 'START_TS_MS:END_TS_MS' (epoch millis), "
+            f"got {db_dataset_window!r}"
+        )
+    try:
+        start_ts_ms = int(match.group("start"))
+        end_ts_ms = int(match.group("end"))
+    except ValueError as exc:
+        raise ValueError(
+            "db_dataset_window must contain integer START_TS_MS and END_TS_MS, "
+            f"got {db_dataset_window!r}"
+        ) from exc
+    if start_ts_ms <= 0 or end_ts_ms <= 0:
+        raise ValueError(
+            f"db_dataset_window timestamps must be > 0, got {db_dataset_window!r}"
+        )
+    if start_ts_ms >= end_ts_ms:
+        raise ValueError(
+            f"db_dataset_window start must be < end, got {db_dataset_window!r}"
+        )
+    return start_ts_ms, end_ts_ms
 
 
 # ---------------------------------------------------------------------------
@@ -424,54 +500,6 @@ def _get_code_commit() -> str:
     return _FALLBACK_CODE_COMMIT
 
 
-def _load_candles(path: Path) -> list[dict[str, Any]]:
-    """Load candles from a JSON array or JSONL file. Raises ReplayRunnerError on failure."""
-    if not path.exists():
-        raise ReplayRunnerError(f"input candles file not found: {path}")
-    try:
-        text = path.read_text(encoding="utf-8").strip()
-    except OSError as exc:
-        raise ReplayRunnerError(f"cannot read candles file: {exc}") from exc
-
-    if not text:
-        raise ReplayRunnerError("input candles file is empty")
-
-    # JSON array
-    if text.startswith("["):
-        try:
-            data = json.loads(text)
-        except json.JSONDecodeError as exc:
-            raise ReplayRunnerError(f"candles JSON parse error: {exc}") from exc
-        if not isinstance(data, list):
-            raise ReplayRunnerError("candles JSON root must be an array")
-        if not data:
-            raise ReplayRunnerError("candles array is empty")
-        for idx, row in enumerate(data):
-            if not isinstance(row, dict):
-                raise ReplayRunnerError(
-                    f"candles JSON array item at index {idx} must be a JSON object"
-                )
-        return data
-
-    # JSONL (one JSON object per line)
-    rows: list[dict[str, Any]] = []
-    for i, line in enumerate(text.splitlines(), start=1):
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            row = json.loads(line)
-        except json.JSONDecodeError as exc:
-            raise ReplayRunnerError(f"JSONL parse error at line {i}: {exc}") from exc
-        if not isinstance(row, dict):
-            raise ReplayRunnerError(f"JSONL line {i} must be a JSON object")
-        rows.append(row)
-
-    if not rows:
-        raise ReplayRunnerError("candles file contains no valid rows")
-    return rows
-
-
 def _redact_env() -> dict[str, str]:
     """Return a small subset of environment variables safe to surface in logs."""
     return {k: v for k, v in os.environ.items() if k in _SAFE_ENV_KEYS}
@@ -494,48 +522,89 @@ def _build_provenance_config_snapshot(
     }
 
 
-def _build_dataset_result(
-    candles: list[dict[str, Any]],
-    *,
-    input_path: Path,
+def _load_dataset_result(
     config: ARVPReplayConfig,
+    *,
     warmup_count: int,
 ) -> DatasetResult:
-    """Build the deterministic dataset result used by scheduler and runner layers."""
-    if len(candles) <= warmup_count:
-        raise ReplayRunnerError(
-            f"scheduler requires at least {warmup_count + 1} candles for "
-            f"warmup_count={warmup_count}; got {len(candles)}"
+    """Load + validate dataset via the canonical dataset provider layer."""
+    dataset_source = (config.dataset_source or "").strip()
+    if dataset_source == "file":
+        input_path = Path(config.input_candles_file)
+        temp_spec = DatasetSpec(
+            symbol=config.symbol,
+            timeframe="1m",
+            start_ts_ms=0,
+            end_ts_ms=0,
+            warmup_candles=warmup_count,
+            source="file",
+            file_path=str(input_path),
         )
+        try:
+            temp_result = FileBackedDatasetProvider().load(temp_spec)
+        except (DatasetLoadError, DatasetSpecError) as exc:
+            raise ReplayRunnerError(str(exc)) from exc
 
-    try:
-        start_ts_ms = int(candles[warmup_count]["ts_ms"])
-        end_ts_ms = int(candles[-1]["ts_ms"])
-    except (KeyError, TypeError, ValueError) as exc:
-        raise ReplayRunnerError(
-            "scheduler requires numeric ts_ms on the first live candle and last candle"
-        ) from exc
+        candles = list(temp_result.candles)
+        try:
+            start_ts_ms = int(candles[warmup_count]["ts_ms"])
+            end_ts_ms = int(candles[-1]["ts_ms"])
+        except (KeyError, TypeError, ValueError, IndexError) as exc:
+            raise ReplayRunnerError(
+                "dataset requires numeric ts_ms on the first live candle and last candle"
+            ) from exc
 
-    spec = DatasetSpec(
-        symbol=config.symbol,
-        timeframe="1m",
-        start_ts_ms=start_ts_ms,
-        end_ts_ms=end_ts_ms,
-        warmup_candles=warmup_count,
-        source="file",
-        file_path=str(input_path),
-    )
-    try:
-        spec.validate()
+        spec = DatasetSpec(
+            symbol=config.symbol,
+            timeframe="1m",
+            start_ts_ms=start_ts_ms,
+            end_ts_ms=end_ts_ms,
+            warmup_candles=warmup_count,
+            source="file",
+            file_path=str(input_path),
+        )
+        try:
+            spec.validate()
+        except DatasetSpecError as exc:
+            raise ReplayRunnerError(f"dataset spec validation failed: {exc}") from exc
+
         return DatasetResult(
             spec=spec,
-            candles=tuple(dict(candle) for candle in candles),
+            candles=temp_result.candles,
             fingerprint=spec.fingerprint(),
             warmup_count=warmup_count,
             effective_candle_count=len(candles) - warmup_count,
         )
-    except (TypeError, ValueError) as exc:
-        raise ReplayRunnerError(f"dataset validation failed: {exc}") from exc
+
+    if dataset_source == "db":
+        start_ts_ms, end_ts_ms = _parse_db_dataset_window(
+            str(config.db_dataset_window)
+        )
+        spec = DatasetSpec(
+            symbol=config.symbol,
+            timeframe="1m",
+            start_ts_ms=start_ts_ms,
+            end_ts_ms=end_ts_ms,
+            warmup_candles=warmup_count,
+            source="db",
+            file_path=None,
+            db_dataset_window=str(config.db_dataset_window),
+        )
+        try:
+            conn = create_postgres_connection()
+        except Exception as exc:
+            raise ReplayRunnerError(f"failed to connect to Postgres: {exc}") from exc
+        try:
+            return DBBackedDatasetProvider(conn).load(spec)
+        except (DatasetLoadError, DatasetSpecError) as exc:
+            raise ReplayRunnerError(str(exc)) from exc
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    raise ReplayRunnerError(f"unsupported dataset_source: {config.dataset_source!r}")
 
 
 def _build_scheduler_metadata(
@@ -746,6 +815,9 @@ def _write_supplementary_artifacts(
         OSError if either file cannot be written.
     """
     resolved_config: dict[str, Any] = {
+        "dataset_source": config.dataset_source,
+        "input_candles_file": config.input_candles_file,
+        "db_dataset_window": config.db_dataset_window,
         "strategy_id": config.strategy_id,
         "symbol": config.symbol,
         "adapter_id": config.adapter_id,
@@ -774,7 +846,7 @@ def _write_supplementary_artifacts(
 # ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
-def run_accelerated_shadow_replay(config: ARVPReplayConfig) -> int:
+def run_arvp_replay(config: ARVPReplayConfig) -> int:
     """Orchestrate a full ARVP replay run (baseline or scenario group).
 
     Args:
@@ -783,28 +855,6 @@ def run_accelerated_shadow_replay(config: ARVPReplayConfig) -> int:
     Returns:
         Exit code integer: 0 success, 1 config error, 2 runtime/input error.
     """
-    # Scenario group path
-    if config.scenario_ids:
-        return _run_scenario_group_path_with_candles(config)
-
-    # Baseline path: load candles first, then continue
-    input_path = Path(config.input_candles_file)
-
-    # Load + validate candles (also covers dry-run path)
-    try:
-        candles = _load_candles(input_path)
-    except ReplayRunnerError as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
-        return 2
-
-    if config.dry_run:
-        print(
-            f"DRY-RUN: config valid, input file accessible. {len(candles)} candles found."
-        )
-        return 0
-
-    output_dir = Path(config.output_directory)
-    code_commit = _get_code_commit()
     run_cfg = PrimaryBreakoutBacktestRunConfig(
         bridge=PrimaryBreakoutBridgeConfig(
             entry_lookback_minutes=config.entry_lookback_minutes,
@@ -819,13 +869,29 @@ def run_accelerated_shadow_replay(config: ARVPReplayConfig) -> int:
         run_cfg.bridge.entry_lookback_minutes,
         run_cfg.bridge.exit_lookback_minutes,
     )
+
+    # Scenario group path
+    if config.scenario_ids:
+        return _run_scenario_group_path_with_candles(config, warmup_count=warmup_count)
+
     try:
-        dataset_result = _build_dataset_result(
-            candles,
-            input_path=input_path,
-            config=config,
-            warmup_count=warmup_count,
+        dataset_result = _load_dataset_result(config, warmup_count=warmup_count)
+    except ReplayRunnerError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    candles: list[dict[str, Any]] = [dict(candle) for candle in dataset_result.candles]
+
+    if config.dry_run:
+        print(
+            "DRY-RUN: config valid, dataset loaded. "
+            f"source={config.dataset_source!r}, candles_total={len(candles)}."
         )
+        return 0
+
+    output_dir = Path(config.output_directory)
+    code_commit = _get_code_commit()
+    try:
         scheduler_metadata = _build_scheduler_metadata(
             dataset_result,
             speedup_profile=config.speedup_profile,
@@ -1132,7 +1198,7 @@ def run_accelerated_shadow_replay(config: ARVPReplayConfig) -> int:
 def _build_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="strategy_replay_runner",
-        description="Accelerated shadow replay CLI for primary_breakout_v1.",
+        description="ARVP replay CLI for primary_breakout_v1.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
             "Exit codes:\n"
@@ -1142,10 +1208,23 @@ def _build_argument_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--dataset-source",
+        default="file",
+        choices=("file", "db"),
+        metavar="SOURCE",
+        help="Dataset input source. Default: 'file'.",
+    )
+    parser.add_argument(
         "--input-candles",
-        required=True,
+        default="",
         metavar="FILE",
-        help="Path to candle input file (JSON array or JSONL). Required.",
+        help="Path to candle input file (JSON array or JSONL). Required when --dataset-source=file.",
+    )
+    parser.add_argument(
+        "--db-dataset-window",
+        default=None,
+        metavar="START_TS_MS:END_TS_MS",
+        help="DB-backed dataset window (epoch millis). Required when --dataset-source=db.",
     )
     parser.add_argument(
         "--output-dir",
@@ -1204,27 +1283,23 @@ def _build_argument_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _run_baseline_path(
+def _run_scenario_group_path_with_candles(
     config: ARVPReplayConfig,
-    candles: list[dict[str, Any]],
+    *,
+    warmup_count: int,
 ) -> int:
-    """Run baseline single replay. Extracted for reuse."""
-    # ... this is placeholder - real logic extracted below
-    return 0
-
-
-def _run_scenario_group_path_with_candles(config: ARVPReplayConfig) -> int:
-    input_path = Path(config.input_candles_file)
     try:
-        candles = _load_candles(input_path)
+        dataset_result = _load_dataset_result(config, warmup_count=warmup_count)
     except ReplayRunnerError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 
+    candles: list[dict[str, Any]] = [dict(candle) for candle in dataset_result.candles]
+
     if config.dry_run:
         print(
-            "DRY-RUN: scenario group valid, input file accessible. "
-            f"{len(candles)} candles found."
+            "DRY-RUN: scenario group valid, dataset loaded. "
+            f"source={config.dataset_source!r}, candles_total={len(candles)}."
         )
         return 0
 
@@ -1320,6 +1395,8 @@ def main() -> int:
     try:
         config = ARVPReplayConfig(
             input_candles_file=args.input_candles,
+            dataset_source=args.dataset_source,
+            db_dataset_window=args.db_dataset_window,
             strategy_id=args.strategy_id,
             symbol=args.symbol,
             adapter_id=args.adapter_id,
@@ -1335,7 +1412,7 @@ def main() -> int:
         print(f"ERROR: Config validation failed: {exc}", file=sys.stderr)
         return 1
 
-    return run_accelerated_shadow_replay(config)
+    return run_arvp_replay(config)
 
 
 if __name__ == "__main__":

--- a/tests/unit/replay/test_dataset_provider.py
+++ b/tests/unit/replay/test_dataset_provider.py
@@ -43,7 +43,7 @@ def _make_spec(
     warmup_candles: int = 3,
     source: str = "file",
     file_path: str | None = "/tmp/data.json",
-    db_dataset_id: str | None = None,
+    db_dataset_window: str | None = None,
 ) -> DatasetSpec:
     return DatasetSpec(
         symbol=symbol,
@@ -53,7 +53,7 @@ def _make_spec(
         warmup_candles=warmup_candles,
         source=source,
         file_path=file_path,
-        db_dataset_id=db_dataset_id,
+        db_dataset_window=db_dataset_window,
     )
 
 
@@ -74,7 +74,7 @@ def _make_db_rows(count: int, start_ts_ms: int = _BASE_START_MS) -> list[tuple]:
 
     Column order matches SELECT in DBBackedDatasetProvider:
     ts_ms (int), open (Decimal), high (Decimal), low (Decimal),
-    close (Decimal), volume (Decimal), trade_count (int).
+    close (Decimal), volume (Decimal), trade_count (int), regime_id (int).
     """
     return [
         (
@@ -85,6 +85,7 @@ def _make_db_rows(count: int, start_ts_ms: int = _BASE_START_MS) -> list[tuple]:
             Decimal("50000.50000001"),
             Decimal("10.50000001"),
             100 + i,
+            0,
         )
         for i in range(count)
     ]
@@ -103,7 +104,11 @@ def test_valid_file_spec_validates_without_error() -> None:
 
 @pytest.mark.unit
 def test_valid_db_spec_validates_without_error() -> None:
-    spec = _make_spec(source="db", file_path=None, db_dataset_id="ds-001")
+    spec = _make_spec(
+        source="db",
+        file_path=None,
+        db_dataset_window=f"{_BASE_START_MS}:{_BASE_START_MS + 600_000}",
+    )
     spec.validate()
 
 
@@ -155,22 +160,26 @@ def test_file_source_missing_file_path_rejected() -> None:
 
 
 @pytest.mark.unit
-def test_file_source_with_db_dataset_id_rejected() -> None:
-    spec = _make_spec(source="file", file_path="/tmp/f.json", db_dataset_id="ds-001")
+def test_file_source_with_db_dataset_window_rejected() -> None:
+    spec = _make_spec(
+        source="file", file_path="/tmp/f.json", db_dataset_window="1180000:1540000"
+    )
     with pytest.raises(DatasetSpecError, match="mutually exclusive"):
         spec.validate()
 
 
 @pytest.mark.unit
-def test_db_source_missing_db_dataset_id_rejected() -> None:
-    spec = _make_spec(source="db", file_path=None, db_dataset_id=None)
-    with pytest.raises(DatasetSpecError, match="db_dataset_id"):
+def test_db_source_missing_db_dataset_window_rejected() -> None:
+    spec = _make_spec(source="db", file_path=None, db_dataset_window=None)
+    with pytest.raises(DatasetSpecError, match="db_dataset_window"):
         spec.validate()
 
 
 @pytest.mark.unit
 def test_db_source_with_file_path_rejected() -> None:
-    spec = _make_spec(source="db", file_path="/tmp/f.json", db_dataset_id="ds-001")
+    spec = _make_spec(
+        source="db", file_path="/tmp/f.json", db_dataset_window="1180000:1540000"
+    )
     with pytest.raises(DatasetSpecError, match="mutually exclusive"):
         spec.validate()
 
@@ -182,18 +191,22 @@ def test_db_source_with_file_path_rejected() -> None:
 
 @pytest.mark.unit
 def test_to_dict_omits_none_optional_fields() -> None:
-    spec = _make_spec(source="file", file_path="/tmp/f.json", db_dataset_id=None)
+    spec = _make_spec(source="file", file_path="/tmp/f.json", db_dataset_window=None)
     d = spec.to_dict()
-    assert "db_dataset_id" not in d
+    assert "db_dataset_window" not in d
     assert d["file_path"] == "/tmp/f.json"
 
 
 @pytest.mark.unit
-def test_to_dict_includes_db_dataset_id_when_set() -> None:
-    spec = _make_spec(source="db", file_path=None, db_dataset_id="ds-abc")
+def test_to_dict_includes_db_dataset_window_when_set() -> None:
+    spec = _make_spec(
+        source="db",
+        file_path=None,
+        db_dataset_window=f"{_BASE_START_MS}:{_BASE_START_MS + 600_000}",
+    )
     d = spec.to_dict()
     assert "file_path" not in d
-    assert d["db_dataset_id"] == "ds-abc"
+    assert d["db_dataset_window"] == f"{_BASE_START_MS}:{_BASE_START_MS + 600_000}"
 
 
 @pytest.mark.unit
@@ -402,7 +415,11 @@ def test_file_backed_warmup_exceeds_candle_count_raises(tmp_path: object) -> Non
 @pytest.mark.unit
 def test_file_backed_source_mismatch_raises() -> None:
     """FileBackedDatasetProvider refuses a db-source spec."""
-    spec = _make_spec(source="db", file_path=None, db_dataset_id="ds-001")
+    spec = _make_spec(
+        source="db",
+        file_path=None,
+        db_dataset_window=f"{_BASE_START_MS}:{_BASE_START_MS + 600_000}",
+    )
     with pytest.raises(DatasetLoadError, match="source='file'"):
         FileBackedDatasetProvider().load(spec)
 
@@ -447,7 +464,7 @@ def _make_db_spec(**overrides) -> DatasetSpec:
     defaults = dict(
         source="db",
         file_path=None,
-        db_dataset_id="ds-001",
+        db_dataset_window=f"{_BASE_START_MS}:{_DB_END_MS}",
         warmup_candles=_DB_WARMUP,
         end_ts_ms=_DB_END_MS,
     )
@@ -601,10 +618,10 @@ def test_db_backed_deterministic_output() -> None:
 
 @pytest.mark.unit
 def test_db_backed_invalid_spec_fails_before_db_query() -> None:
-    """Invalid spec (missing db_dataset_id) raises DatasetSpecError before any query."""
+    """Invalid spec (missing db_dataset_window) raises DatasetSpecError before any query."""
     conn = _make_mock_conn([])
-    spec = _make_spec(source="db", file_path=None, db_dataset_id=None)
-    with pytest.raises(DatasetSpecError, match="db_dataset_id"):
+    spec = _make_spec(source="db", file_path=None, db_dataset_window=None)
+    with pytest.raises(DatasetSpecError, match="db_dataset_window"):
         DBBackedDatasetProvider(conn).load(spec)
     conn.cursor.assert_not_called()
 

--- a/tests/unit/validation/test_strategy_replay_runner.py
+++ b/tests/unit/validation/test_strategy_replay_runner.py
@@ -1,10 +1,9 @@
 """Unit tests for services/validation/strategy_replay_runner.py.
 
 Tests cover:
-  - AcceleratedShadowReplayConfig defaults and fail-closed validation
-  - _load_candles: JSON array, JSONL, missing file, empty file, malformed JSON
+  - ARVPReplayConfig defaults and fail-closed validation
   - _build_replay_report_input: correct field mapping, determinism toggle
-  - run_accelerated_shadow_replay: exit codes 0/1/2, dry-run, bundle written
+  - run_arvp_replay: exit codes 0/1/2, dry-run, bundle written
   - main(): arg parsing, defaults, exit codes
 """
 
@@ -12,7 +11,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -26,13 +25,12 @@ from services.validation.strategy_replay_runner import (
     _DEFAULT_OUTPUT_DIR,
     _DEFAULT_STRATEGY_ID,
     _DEFAULT_SYMBOL,
-    AcceleratedShadowReplayConfig,
+    ARVPReplayConfig,
     ReplayRunnerError,
     _apply_replay_data_overrides,
     _apply_scenario_overrides,
     _build_replay_report_input,
-    _load_candles,
-    run_accelerated_shadow_replay,
+    run_arvp_replay,
     main,
 )
 from core.replay.canonical_json import canonical_hash
@@ -116,19 +114,21 @@ def _minimal_backtest_report(
     }
 
 
-def _minimal_valid_config(**overrides) -> AcceleratedShadowReplayConfig:
+def _minimal_valid_config(**overrides) -> ARVPReplayConfig:
     defaults = {"input_candles_file": "candles.json"}
     defaults.update(overrides)
-    return AcceleratedShadowReplayConfig(**defaults)
+    return ARVPReplayConfig(**defaults)
 
 
 # ---------------------------------------------------------------------------
-# TestAcceleratedShadowReplayConfig
+# TestARVPReplayConfig
 # ---------------------------------------------------------------------------
 @pytest.mark.unit
-class TestAcceleratedShadowReplayConfig:
+class TestARVPReplayConfig:
     def test_defaults_are_set(self):
-        cfg = AcceleratedShadowReplayConfig(input_candles_file="input.json")
+        cfg = ARVPReplayConfig(input_candles_file="input.json")
+        assert cfg.dataset_source == "file"
+        assert cfg.db_dataset_window is None
         assert cfg.strategy_id == _DEFAULT_STRATEGY_ID
         assert cfg.symbol == _DEFAULT_SYMBOL
         assert cfg.adapter_id == _DEFAULT_ADAPTER_ID
@@ -144,37 +144,100 @@ class TestAcceleratedShadowReplayConfig:
         assert cfg.deterministic_verify is False
 
     def test_validate_passes_valid_config(self):
-        cfg = AcceleratedShadowReplayConfig(input_candles_file="candles.json")
+        cfg = ARVPReplayConfig(input_candles_file="candles.json")
         cfg.validate()  # Must not raise
 
     def test_validate_fails_missing_input_file(self):
-        cfg = AcceleratedShadowReplayConfig(input_candles_file="")
-        with pytest.raises(ValueError, match="input_candles_file is required"):
+        cfg = ARVPReplayConfig(input_candles_file="")
+        with pytest.raises(ValueError, match="dataset_source='file' requires input_candles_file"):
+            cfg.validate()
+
+    def test_validate_passes_db_source_with_db_dataset_window(self):
+        cfg = ARVPReplayConfig(
+            dataset_source="db",
+            db_dataset_window="1180000:1540000",
+        )
+        cfg.validate()  # Must not raise
+
+    def test_validate_fails_db_source_missing_db_dataset_window(self):
+        cfg = ARVPReplayConfig(dataset_source="db", db_dataset_window=None)
+        with pytest.raises(
+            ValueError, match="dataset_source='db' requires db_dataset_window"
+        ):
+            cfg.validate()
+
+    def test_validate_fails_db_source_with_input_candles_file(self):
+        cfg = ARVPReplayConfig(
+            dataset_source="db",
+            db_dataset_window="1180000:1540000",
+            input_candles_file="candles.json",
+        )
+        with pytest.raises(ValueError, match="input_candles_file must be empty"):
+            cfg.validate()
+
+    def test_validate_fails_file_source_with_db_dataset_window(self):
+        cfg = ARVPReplayConfig(
+            dataset_source="file",
+            input_candles_file="candles.json",
+            db_dataset_window="1180000:1540000",
+        )
+        with pytest.raises(ValueError, match="db_dataset_window must be None"):
+            cfg.validate()
+
+    def test_validate_fails_unknown_dataset_source(self):
+        cfg = ARVPReplayConfig(
+            dataset_source="s3",
+            input_candles_file="candles.json",
+        )
+        with pytest.raises(ValueError, match="dataset_source must be 'file' or 'db'"):
+            cfg.validate()
+
+    def test_db_dataset_id_field_is_not_supported(self):
+        with pytest.raises(TypeError):
+            ARVPReplayConfig(  # type: ignore[call-arg]
+                dataset_source="db",
+                db_dataset_id="1180000:1540000",
+            )
+
+    def test_validate_fails_db_dataset_window_without_explicit_window(self):
+        cfg = ARVPReplayConfig(
+            dataset_source="db",
+            db_dataset_window="ds-001",
+        )
+        with pytest.raises(ValueError, match="START_TS_MS:END_TS_MS"):
+            cfg.validate()
+
+    def test_validate_fails_db_dataset_window_with_start_gte_end(self):
+        cfg = ARVPReplayConfig(
+            dataset_source="db",
+            db_dataset_window="1540000:1540000",
+        )
+        with pytest.raises(ValueError, match="start must be < end"):
             cfg.validate()
 
     def test_validate_fails_unsupported_strategy_id(self):
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file="x.json", strategy_id="unsupported_strategy"
         )
         with pytest.raises(ValueError, match="unsupported strategy_id"):
             cfg.validate()
 
     def test_validate_fails_unsupported_symbol(self):
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file="x.json", symbol="ETHUSDT"
         )
         with pytest.raises(ValueError, match="unsupported symbol"):
             cfg.validate()
 
     def test_validate_fails_unsupported_adapter_id(self):
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file="x.json", adapter_id="unknown_adapter"
         )
         with pytest.raises(ValueError, match="unsupported adapter_id"):
             cfg.validate()
 
     def test_validate_fails_unsupported_speedup_profile(self):
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file="x.json",
             speedup_profile="100x",
         )
@@ -182,98 +245,30 @@ class TestAcceleratedShadowReplayConfig:
             cfg.validate()
 
     def test_validate_fails_zero_order_size(self):
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file="x.json", order_size=0.0
         )
         with pytest.raises(ValueError, match="order_size must be > 0"):
             cfg.validate()
 
     def test_validate_fails_negative_order_size(self):
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file="x.json", order_size=-1.0
         )
         with pytest.raises(ValueError, match="order_size must be > 0"):
             cfg.validate()
 
     def test_validate_fails_zero_depth_multiplier(self):
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file="x.json", order_book_depth_multiplier=0.0
         )
         with pytest.raises(ValueError, match="order_book_depth_multiplier must be > 0"):
             cfg.validate()
 
     def test_config_is_frozen(self):
-        cfg = AcceleratedShadowReplayConfig(input_candles_file="x.json")
+        cfg = ARVPReplayConfig(input_candles_file="x.json")
         with pytest.raises((AttributeError, TypeError)):
             cfg.order_size = 99.0  # type: ignore[misc]
-
-
-# ---------------------------------------------------------------------------
-# TestLoadCandles
-# ---------------------------------------------------------------------------
-@pytest.mark.unit
-class TestLoadCandles:
-    def test_load_json_array(self, tmp_path):
-        data = [{"ts_ms": 1_000_000, "close": 50000.0, "high": 51000.0, "low": 49000.0,
-                 "regime_id": 0, "symbol": "BTCUSDT"}]
-        f = tmp_path / "candles.json"
-        f.write_text(json.dumps(data), encoding="utf-8")
-        result = _load_candles(f)
-        assert len(result) == 1
-        assert result[0]["ts_ms"] == 1_000_000
-
-    def test_load_jsonl(self, tmp_path):
-        rows = [
-            {"ts_ms": 1_000_000, "close": 50000.0},
-            {"ts_ms": 1_060_000, "close": 50100.0},
-        ]
-        f = tmp_path / "candles.jsonl"
-        f.write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
-        result = _load_candles(f)
-        assert len(result) == 2
-        assert result[1]["ts_ms"] == 1_060_000
-
-    def test_missing_file_raises(self, tmp_path):
-        with pytest.raises(ReplayRunnerError, match="not found"):
-            _load_candles(tmp_path / "nonexistent.json")
-
-    def test_empty_file_raises(self, tmp_path):
-        f = tmp_path / "empty.json"
-        f.write_text("", encoding="utf-8")
-        with pytest.raises(ReplayRunnerError, match="empty"):
-            _load_candles(f)
-
-    def test_malformed_json_array_raises(self, tmp_path):
-        f = tmp_path / "bad.json"
-        f.write_text("[{bad json", encoding="utf-8")
-        with pytest.raises(ReplayRunnerError, match="parse error"):
-            _load_candles(f)
-
-    def test_json_array_non_object_row_raises(self, tmp_path):
-        f = tmp_path / "bad_row.json"
-        f.write_text(json.dumps([{"ts_ms": 1_000_000}, 123]), encoding="utf-8")
-        with pytest.raises(ReplayRunnerError, match="must be a JSON object"):
-            _load_candles(f)
-
-    def test_malformed_jsonl_raises(self, tmp_path):
-        f = tmp_path / "bad.jsonl"
-        f.write_text('{"ts_ms": 1}\nbad line\n', encoding="utf-8")
-        with pytest.raises(ReplayRunnerError, match="JSONL parse error"):
-            _load_candles(f)
-
-    def test_json_non_array_raises(self, tmp_path):
-        f = tmp_path / "obj.json"
-        f.write_text('{"key": "value"}', encoding="utf-8")
-        # Does not start with "[" → treated as JSONL; single line is valid dict
-        result = _load_candles(f)
-        assert isinstance(result, list)
-        assert len(result) == 1
-
-    def test_empty_array_raises(self, tmp_path):
-        f = tmp_path / "empty_arr.json"
-        f.write_text("[]", encoding="utf-8")
-        with pytest.raises(ReplayRunnerError, match="empty"):
-            _load_candles(f)
 
 
 # ---------------------------------------------------------------------------
@@ -403,10 +398,10 @@ class TestBuildReplayReportInput:
 
 
 # ---------------------------------------------------------------------------
-# TestRunAcceleratedShadowReplay
+# TestRunARVPReplay
 # ---------------------------------------------------------------------------
 @pytest.mark.unit
-class TestRunAcceleratedShadowReplay:
+class TestRunARVPReplay:
     """Full-flow tests with run_primary_breakout_backtest and ReplayReporter mocked."""
 
     def _make_candles_file(self, tmp_path: Path, count: int = 300) -> Path:
@@ -432,12 +427,56 @@ class TestRunAcceleratedShadowReplay:
         self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
         )
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
         assert exit_code == 0
+
+    @patch("services.validation.strategy_replay_runner.create_postgres_connection")
+    @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
+    @patch.object(ReplayReporter, "write_bundle")
+    def test_successful_run_db_dataset_returns_0(
+        self, mock_write, mock_backtest, mock_pg, tmp_path
+    ):
+        mock_backtest.return_value = _minimal_backtest_report()
+        self._mock_bundle_dir(mock_write, tmp_path)
+
+        warmup_count = 3
+        warmup_start = 1_000_000
+        start_ts_ms = warmup_start + warmup_count * 60_000
+        rows = [
+            (
+                warmup_start + i * 60_000,
+                100.0,
+                101.0,
+                99.0,
+                100.5,
+                10.0,
+                100 + i,
+                0,
+            )
+            for i in range(10)
+        ]
+        end_ts_ms = rows[-1][0]
+
+        cursor = MagicMock()
+        cursor.fetchall.return_value = rows
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+        mock_pg.return_value = conn
+
+        cfg = ARVPReplayConfig(
+            dataset_source="db",
+            db_dataset_window=f"{start_ts_ms}:{end_ts_ms}",
+            output_directory=str(tmp_path),
+            entry_lookback_minutes=warmup_count,
+            exit_lookback_minutes=2,
+        )
+        exit_code = run_arvp_replay(cfg)
+        assert exit_code == 0
+        conn.close.assert_called()
 
     @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
     @patch.object(ReplayReporter, "write_bundle")
@@ -446,11 +485,11 @@ class TestRunAcceleratedShadowReplay:
         self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
         )
-        run_accelerated_shadow_replay(cfg)
+        run_arvp_replay(cfg)
 
         report_input = mock_write.call_args.args[0]
         bundle_dir = Path(tmp_path) / report_input.run_spec.replay_run_id
@@ -466,12 +505,12 @@ class TestRunAcceleratedShadowReplay:
         self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
             speedup_profile="2x",
         )
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
 
         assert exit_code == 0
         report_input = mock_write.call_args.args[0]
@@ -488,13 +527,13 @@ class TestRunAcceleratedShadowReplay:
         self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
             speedup_profile="5x",
         )
 
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
 
         assert exit_code == 0
         report_input = mock_write.call_args.args[0]
@@ -516,12 +555,12 @@ class TestRunAcceleratedShadowReplay:
 
         mock_backtest.side_effect = PrimaryBreakoutBacktestError("boom")
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
         )
 
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
 
         assert exit_code == 2
         records = ReplayRunRegistry(tmp_path / "run_registry.jsonl").load_all()
@@ -537,13 +576,13 @@ class TestRunAcceleratedShadowReplay:
         self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
             speedup_profile="10x",
         )
 
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
 
         assert exit_code == 0
         registry = ReplayRunRegistry(tmp_path / "run_registry.jsonl")
@@ -574,12 +613,12 @@ class TestRunAcceleratedShadowReplay:
         self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
         )
 
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
 
         assert exit_code == 0
         report_input = mock_write.call_args.args[0]
@@ -606,31 +645,31 @@ class TestRunAcceleratedShadowReplay:
         mock_append.side_effect = [None, RunRegistryError("disk full")]
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
         )
 
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
 
         assert exit_code == 2
 
     def test_missing_input_file_returns_2(self, tmp_path):
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(tmp_path / "missing.json"),
             output_directory=str(tmp_path),
         )
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
         assert exit_code == 2
 
     def test_non_object_json_array_row_returns_2(self, tmp_path):
         f = tmp_path / "bad_row.json"
         f.write_text(json.dumps([{"ts_ms": 1_000_000}, 123]), encoding="utf-8")
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
         )
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
         assert exit_code == 2
 
     @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
@@ -639,11 +678,11 @@ class TestRunAcceleratedShadowReplay:
         mock_backtest.side_effect = HistoricalBridgeError("bad candles")
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
         )
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
         assert exit_code == 2
 
     @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
@@ -652,11 +691,11 @@ class TestRunAcceleratedShadowReplay:
         mock_backtest.side_effect = PrimaryBreakoutBacktestError("boom")
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
         )
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
         assert exit_code == 2
 
     @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
@@ -667,11 +706,11 @@ class TestRunAcceleratedShadowReplay:
         mock_write.side_effect = ReplayReporterError("schema fail")
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
         )
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
         assert exit_code == 2
 
     @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
@@ -683,12 +722,12 @@ class TestRunAcceleratedShadowReplay:
         self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
             deterministic_verify=False,
         )
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
         assert exit_code == 0
         captured = capsys.readouterr()
         assert "WARNING" in captured.err
@@ -702,12 +741,12 @@ class TestRunAcceleratedShadowReplay:
         self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
             deterministic_verify=True,
         )
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
         assert exit_code == 2
 
     @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
@@ -719,12 +758,12 @@ class TestRunAcceleratedShadowReplay:
         self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
             deterministic_verify=True,
         )
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
 
         assert exit_code == 2
         registry = ReplayRunRegistry(tmp_path / "run_registry.jsonl")
@@ -746,12 +785,12 @@ class TestRunAcceleratedShadowReplay:
         self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
             deterministic_verify=True,
         )
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
         assert exit_code == 0
 
     @patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest")
@@ -763,13 +802,13 @@ class TestRunAcceleratedShadowReplay:
         self._mock_bundle_dir(mock_write, tmp_path)
 
         f = self._make_candles_file(tmp_path)
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
             order_size=2.0,
             entry_lookback_minutes=180,
         )
-        run_accelerated_shadow_replay(cfg)
+        run_arvp_replay(cfg)
 
         mock_backtest.assert_called_once()
         call_kwargs = mock_backtest.call_args
@@ -783,89 +822,151 @@ class TestRunAcceleratedShadowReplay:
 # ---------------------------------------------------------------------------
 @pytest.mark.unit
 class TestDryRun:
-    def test_dry_run_returns_0_with_valid_input(self, tmp_path):
-        candles = [{"ts_ms": 1_000_000}]
+    def _make_valid_candles_file(self, tmp_path: Path, count: int = 10) -> Path:
+        candles = [
+            {
+                "symbol": "BTCUSDT",
+                "ts_ms": 1_000_000 + i * 60_000,
+                "high": 51000.0,
+                "low": 49000.0,
+                "close": 50000.0,
+                "regime_id": 0,
+            }
+            for i in range(count)
+        ]
         f = tmp_path / "candles.json"
         f.write_text(json.dumps(candles), encoding="utf-8")
+        return f
 
-        cfg = AcceleratedShadowReplayConfig(
+    def test_dry_run_returns_0_with_valid_input(self, tmp_path):
+        f = self._make_valid_candles_file(tmp_path, count=5)
+
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
             dry_run=True,
+            entry_lookback_minutes=1,
+            exit_lookback_minutes=1,
         )
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
         assert exit_code == 0
 
     def test_dry_run_prints_candle_count(self, tmp_path, capsys):
-        candles = [{"ts_ms": 1_000_000 + i * 60_000} for i in range(5)]
-        f = tmp_path / "candles.json"
-        f.write_text(json.dumps(candles), encoding="utf-8")
+        f = self._make_valid_candles_file(tmp_path, count=5)
 
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
             dry_run=True,
+            entry_lookback_minutes=1,
+            exit_lookback_minutes=1,
         )
-        run_accelerated_shadow_replay(cfg)
+        run_arvp_replay(cfg)
         captured = capsys.readouterr()
-        assert "5" in captured.out
+        assert "candles_total=5" in captured.out
         assert "DRY-RUN" in captured.out
 
     def test_dry_run_does_not_call_backtest(self, tmp_path):
-        candles = [{"ts_ms": 1_000_000}]
-        f = tmp_path / "candles.json"
-        f.write_text(json.dumps(candles), encoding="utf-8")
+        f = self._make_valid_candles_file(tmp_path, count=5)
 
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             dry_run=True,
+            entry_lookback_minutes=1,
+            exit_lookback_minutes=1,
         )
         with patch(
             "services.validation.strategy_replay_runner.run_primary_breakout_backtest"
         ) as mock_bt:
-            run_accelerated_shadow_replay(cfg)
+            run_arvp_replay(cfg)
             mock_bt.assert_not_called()
 
     def test_dry_run_missing_file_returns_2(self, tmp_path):
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(tmp_path / "missing.json"),
             dry_run=True,
         )
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
         assert exit_code == 2
 
     def test_dry_run_does_not_write_bundle(self, tmp_path):
-        candles = [{"ts_ms": 1_000_000}]
-        f = tmp_path / "candles.json"
-        f.write_text(json.dumps(candles), encoding="utf-8")
+        f = self._make_valid_candles_file(tmp_path, count=5)
 
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path / "out"),
             dry_run=True,
+            entry_lookback_minutes=1,
+            exit_lookback_minutes=1,
         )
-        run_accelerated_shadow_replay(cfg)
+        run_arvp_replay(cfg)
         # output directory must NOT be created
         assert not (tmp_path / "out").exists()
 
     def test_scenario_group_dry_run_returns_0(self, tmp_path, capsys):
-        candles = [{"ts_ms": 1_000_000}]
-        f = tmp_path / "candles.json"
-        f.write_text(json.dumps(candles), encoding="utf-8")
+        f = self._make_valid_candles_file(tmp_path, count=5)
 
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
             dry_run=True,
             scenario_ids=("baseline", "delayed_execution"),
+            entry_lookback_minutes=1,
+            exit_lookback_minutes=1,
         )
 
-        exit_code = run_accelerated_shadow_replay(cfg)
+        exit_code = run_arvp_replay(cfg)
 
         assert exit_code == 0
         captured = capsys.readouterr()
         assert "DRY-RUN" in captured.out
         assert "scenario group" in captured.out
+
+    def test_scenario_group_dry_run_db_dataset_window_returns_0(self, tmp_path, capsys):
+        warmup_count = 3
+        warmup_start = 1_000_000
+        start_ts_ms = warmup_start + warmup_count * 60_000
+        rows = [
+            (
+                warmup_start + i * 60_000,
+                100.0,
+                101.0,
+                99.0,
+                100.5,
+                10.0,
+                100 + i,
+                0,
+            )
+            for i in range(10)
+        ]
+        end_ts_ms = rows[-1][0]
+
+        cursor = MagicMock()
+        cursor.fetchall.return_value = rows
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        cfg = ARVPReplayConfig(
+            dataset_source="db",
+            db_dataset_window=f"{start_ts_ms}:{end_ts_ms}",
+            output_directory=str(tmp_path),
+            dry_run=True,
+            scenario_ids=("baseline", "delayed_execution"),
+            entry_lookback_minutes=warmup_count,
+            exit_lookback_minutes=2,
+        )
+
+        with patch(
+            "services.validation.strategy_replay_runner.create_postgres_connection",
+            return_value=conn,
+        ):
+            exit_code = run_arvp_replay(cfg)
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "DRY-RUN" in captured.out
+        assert "scenario group" in captured.out
+        assert "source='db'" in captured.out
 
     @pytest.mark.parametrize(
         ("error_cls", "message"),
@@ -877,21 +978,21 @@ class TestDryRun:
     def test_scenario_group_runtime_errors_return_2(
         self, tmp_path, capsys, error_cls, message
     ):
-        candles = [{"ts_ms": 1_000_000}]
-        f = tmp_path / "candles.json"
-        f.write_text(json.dumps(candles), encoding="utf-8")
+        f = self._make_valid_candles_file(tmp_path, count=5)
 
-        cfg = AcceleratedShadowReplayConfig(
+        cfg = ARVPReplayConfig(
             input_candles_file=str(f),
             output_directory=str(tmp_path),
             scenario_ids=("baseline",),
+            entry_lookback_minutes=1,
+            exit_lookback_minutes=1,
         )
 
         with patch(
             "services.validation.strategy_replay_runner.run_builtin_scenario_group",
             side_effect=error_cls(message),
         ):
-            exit_code = run_accelerated_shadow_replay(cfg)
+            exit_code = run_arvp_replay(cfg)
 
         assert exit_code == 2
         captured = capsys.readouterr()
@@ -904,7 +1005,7 @@ class TestDryRun:
 @pytest.mark.unit
 class TestScenarioOverrides:
     def test_apply_scenario_overrides_maps_explicit_bar_delay(self):
-        cfg = AcceleratedShadowReplayConfig(input_candles_file="candles.json")
+        cfg = ARVPReplayConfig(input_candles_file="candles.json")
 
         result = _apply_scenario_overrides(
             cfg,
@@ -919,13 +1020,13 @@ class TestScenarioOverrides:
         assert result.replay_data_overrides == {}
 
     def test_apply_scenario_overrides_rejects_execution_delay_ms(self):
-        cfg = AcceleratedShadowReplayConfig(input_candles_file="candles.json")
+        cfg = ARVPReplayConfig(input_candles_file="candles.json")
 
         with pytest.raises(ReplayRunnerError, match="unknown keys"):
             _apply_scenario_overrides(cfg, {"execution_delay_ms": 500})
 
     def test_apply_scenario_overrides_maps_feed_gap_to_replay_data_surface(self):
-        cfg = AcceleratedShadowReplayConfig(input_candles_file="candles.json")
+        cfg = ARVPReplayConfig(input_candles_file="candles.json")
 
         result = _apply_scenario_overrides(cfg, {"feed_gap_bars": 2})
 
@@ -933,7 +1034,7 @@ class TestScenarioOverrides:
         assert result.replay_data_overrides == {"feed_gap_bars": 2}
 
     def test_apply_scenario_overrides_rejects_seconds_gap_semantics(self):
-        cfg = AcceleratedShadowReplayConfig(input_candles_file="candles.json")
+        cfg = ARVPReplayConfig(input_candles_file="candles.json")
 
         with pytest.raises(ReplayRunnerError, match="not representable"):
             _apply_scenario_overrides(cfg, {"feed_gap_seconds": 30})
@@ -1004,10 +1105,7 @@ class TestReplayDataOverrides:
 class TestMainArgParse:
     def test_missing_input_candles_exits_1_or_2(self, tmp_path):
         with patch("sys.argv", ["prog"]):
-            with pytest.raises(SystemExit) as exc_info:
-                main()
-            # argparse exits with 2 on missing required arg
-            assert exc_info.value.code != 0
+            assert main() == 1
 
     def test_unsupported_strategy_exits_1(self, tmp_path, capsys):
         candles = [{"ts_ms": 1_000_000}]
@@ -1023,13 +1121,75 @@ class TestMainArgParse:
         f = tmp_path / "c.json"
         f.write_text(json.dumps(candles))
         with patch(
-            "services.validation.strategy_replay_runner.run_accelerated_shadow_replay",
+            "services.validation.strategy_replay_runner.run_arvp_replay",
             return_value=0,
         ) as mock_run:
             with patch("sys.argv", ["prog", "--input-candles", str(f)]):
                 result = main()
         assert result == 0
         mock_run.assert_called_once()
+
+    def test_db_invocation_calls_runner(self, tmp_path):
+        with patch(
+            "services.validation.strategy_replay_runner.run_arvp_replay",
+            return_value=0,
+        ) as mock_run:
+            with patch(
+                "sys.argv",
+                [
+                    "prog",
+                    "--dataset-source",
+                    "db",
+                    "--db-dataset-window",
+                    "1180000:1540000",
+                ],
+            ):
+                result = main()
+        assert result == 0
+        mock_run.assert_called_once()
+
+    def test_db_missing_db_dataset_window_exits_1(self, tmp_path):
+        with patch(
+            "sys.argv",
+            [
+                "prog",
+                "--dataset-source",
+                "db",
+            ],
+        ):
+            assert main() == 1
+
+    def test_db_with_input_candles_is_rejected(self, tmp_path):
+        candles = [{"ts_ms": 1_000_000}]
+        f = tmp_path / "c.json"
+        f.write_text(json.dumps(candles))
+        with patch(
+            "sys.argv",
+            [
+                "prog",
+                "--dataset-source",
+                "db",
+                "--db-dataset-window",
+                "1180000:1540000",
+                "--input-candles",
+                str(f),
+            ],
+        ):
+            assert main() == 1
+
+    def test_db_dataset_id_flag_is_not_supported(self, tmp_path):
+        with patch(
+            "sys.argv",
+            [
+                "prog",
+                "--dataset-source",
+                "db",
+                "--db-dataset-id",
+                "1180000:1540000",
+            ],
+        ):
+            with pytest.raises(SystemExit):
+                main()
 
     def test_default_strategy_id_is_set(self, tmp_path):
         candles = [{"ts_ms": 1_000_000}]
@@ -1042,7 +1202,7 @@ class TestMainArgParse:
             return 0
 
         with patch(
-            "services.validation.strategy_replay_runner.run_accelerated_shadow_replay",
+            "services.validation.strategy_replay_runner.run_arvp_replay",
             side_effect=capture,
         ):
             with patch("sys.argv", ["prog", "--input-candles", str(f)]):
@@ -1062,7 +1222,7 @@ class TestMainArgParse:
 
         custom_dir = str(tmp_path / "custom_out")
         with patch(
-            "services.validation.strategy_replay_runner.run_accelerated_shadow_replay",
+            "services.validation.strategy_replay_runner.run_arvp_replay",
             side_effect=capture,
         ):
             with patch("sys.argv", [
@@ -1083,7 +1243,7 @@ class TestMainArgParse:
             return 0
 
         with patch(
-            "services.validation.strategy_replay_runner.run_accelerated_shadow_replay",
+            "services.validation.strategy_replay_runner.run_arvp_replay",
             side_effect=capture,
         ):
             with patch("sys.argv", ["prog", "--input-candles", str(f), "--dry-run"]):
@@ -1102,7 +1262,7 @@ class TestMainArgParse:
             return 0
 
         with patch(
-            "services.validation.strategy_replay_runner.run_accelerated_shadow_replay",
+            "services.validation.strategy_replay_runner.run_arvp_replay",
             side_effect=capture,
         ):
             with patch("sys.argv", [
@@ -1123,7 +1283,7 @@ class TestMainArgParse:
             return 0
 
         with patch(
-            "services.validation.strategy_replay_runner.run_accelerated_shadow_replay",
+            "services.validation.strategy_replay_runner.run_arvp_replay",
             side_effect=capture,
         ):
             with patch("sys.argv", ["prog", "--input-candles", str(f), "--speedup-profile", "5x"]):
@@ -1136,7 +1296,7 @@ class TestMainArgParse:
         f = tmp_path / "c.json"
         f.write_text(json.dumps(candles))
         with patch(
-            "services.validation.strategy_replay_runner.run_accelerated_shadow_replay",
+            "services.validation.strategy_replay_runner.run_arvp_replay",
             return_value=0,
         ):
             with patch("sys.argv", ["prog", "--input-candles", str(f)]):
@@ -1148,7 +1308,7 @@ class TestMainArgParse:
         f = tmp_path / "c.json"
         f.write_text(json.dumps(candles))
         with patch(
-            "services.validation.strategy_replay_runner.run_accelerated_shadow_replay",
+            "services.validation.strategy_replay_runner.run_arvp_replay",
             return_value=2,
         ):
             with patch("sys.argv", ["prog", "--input-candles", str(f)]):


### PR DESCRIPTION
# ARVP Finalization PR (Issues #1887-#1890)

This PR brings four closely-related ARVP finalization slices to completion.

## Scope

### #1887 - Restore canonical dataset-source operator front door
- Explicit \--dataset-source file|db\ with default \ile\
- **File mode:** \--input-candles FILE\ (required)
- **DB mode:** \--db-dataset-window START_TS_MS:END_TS_MS\ (required)
- Removed non-canonical \db_dataset_id\ alias
- Strict fail-closed validation per spec
- Both baseline and scenario-group paths remain source-aware
- Runtime uses canonical \FileBackedDatasetProvider\ and \DBBackedDatasetProvider\

### #1888 - Remove legacy 'accelerated shadow replay' naming
- Main orchestration function: \un_accelerated_shadow_replay()\ → \un_arvp_replay()\
- ARVP as canonical platform name throughout operator-facing surfaces
- No alias for backward compatibility (external callers will break cleanly)

### #1889 - Remove dead alias/placeholder remnants
- Removed \_run_baseline_path()\ placeholder function
- Removed \_build_dataset_result()\ dead code path
- Removed \_load_candles()\ after Dataset-Layer migration
- Cleaned up coupled test blocks (e.g., \	est_load_candles\)

### #1890 - Update governance/docs to current merged state
- \docs/governance/arvp_platform.md\ now reflects true repository state (post-merge)
- Documented current operator-facing capability:
  - Dataset source: file/db
  - Scenario-group workflow
  - Delayed execution as explicit bar-level surface
  - Feed gap as explicit bar-level replay data-gap surface
  - Fail-closed data integrity diagnostics
- Explicit non-goals (1m canvas, no hidden ms→bar shims, no implicit auto-close)

## What is NOT changed

- Foundation modules in \core/replay/\ remain stable
- Live trading runtime services untouched
- No new registry, lookup layer, or dataset persistence ID scheme
- No sub-minute surface, no policy changes for end-of-window semantics
- No new reporting offensive outside finalization scope
- No extra cleanup beyond the specified dead code

## Testing

✅ **125 tests passed**
- \	ests/unit/validation/test_strategy_replay_runner.py\ → 75 passed
- \	ests/unit/replay/test_dataset_provider.py\ → 50 passed

## Nature of work

This is **finalization only** — not new platform layering, not scope expansion.
The changes lock down the operator-facing contract and clean up dead code from 
the previous iteration.

Closes #1887, #1888, #1889, #1890