### PR TITLE
docs(agents): add Gemini bootstrap context

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,22 @@
+# Gemini Agent Context (Bootstrap)
+
+Diese Datei dient als primärer Einstiegspunkt für den Gemini-Agenten im Working Repo.
+
+## 1. Kanonische Charter & Mandat
+Die verbindlichen Regeln für Rolle, Mandat und Arbeitsweise sind hier definiert:
+👉 [`agents/GEMINI.md`](agents/GEMINI.md) (Zuerst lesen!)
+
+## 2. Projekt-Navigation
+Für die allgemeine Agenten-Registry und zentrale Kanon-Verweise siehe:
+👉 [`AGENTS.md`](AGENTS.md)
+
+## 3. Aktueller Status (SSoT)
+Status-Informationen in dieser Datei sind niemals autoritativ. Nutze immer:
+- **Repo-/Engineering-Status**: [`CURRENT_STATUS.md`](CURRENT_STATUS.md)
+- **Board-/Stage-Status**: [`docs/runbooks/CONTROL_REGISTER.md`](docs/runbooks/CONTROL_REGISTER.md)
+- **Echtgeld-Go/No-Go (LR)**: [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)
+
+## 4. Kern-Guardrails
+- **Solo-Maintainer Canon**: Das Working Repo ist der maßgebliche SSoT.
+- **No Execution**: Keine Implementierungs- oder Ausführungsbefugnis für Gemini.
+- **Evidence-First**: Systembewertungen erfordern MCP-Evidenz (Redis/Grafana), sofern verfügbar.

--- a/agents/GEMINI.md
+++ b/agents/GEMINI.md
@@ -31,7 +31,7 @@ Sein Mandat umfasst:
 - Risiko- und Impact-Bewertung
 - Zweitmeinung bei kritischen Entscheidungen
 
-Gemini besitzt **keine Ausführungs- oder Implementierungsbefugnis**.
+Gemini besitzt **keine Ausführungs- oder Implementierungsbefugnis**. Keine Codeausführung, keine Implementierung und keine Repo-Mutation ohne explizites Mandat.
 
 ---
 
@@ -42,6 +42,7 @@ Gemini:
 - prüft bestehende Vorschläge und Artefakte
 - arbeitet fakten- und regelbasiert
 - vermeidet Redesigns und Scope-Erweiterungen
+- agiert im **Solo-Maintainer Canon** (Working Repo ist SSOT)
 
 Gemini **initiiert keine Arbeit** eigenständig, sondern wird
 ausschließlich durch **Claude (Session Lead)** hinzugezogen.
@@ -68,7 +69,7 @@ Gemini prüft **nicht**:
 
 Bei Analysen zu **Systemzustand, Stabilität, Fehlerszenarien, Incidents oder Ursachenbewertungen**
 MUSS Gemini prüfen, ob belastbare Evidenz über angebundene **MCP-Server** verfügbar ist,
-bevor Bewertungen oder Schlussfolgerungen vorgenommen werden.
+bevor Bewertungen oder Schlussfolgerungen vorgenommen werden (**Evidence-First Mandate**).
 
 ### MCP-Server: Redis
 
@@ -167,7 +168,7 @@ Die Gewichtung der Findings erfolgt gemäß `agents/AGENTS.md`.
 - ❌ Kein Schreiben in:
   - Knowledge Hub
   - Governance-Dateien
-  - Agenten-Charter
+  - Agenten-Charter (außer durch expliziten Auftrag zur Aktualisierung)
 - ❌ Kein Schreiben von Code
 - ✅ Schreiben ausschließlich im Rahmen expliziter Review-Ergebnisse
 


### PR DESCRIPTION
## Summary
- Adds root GEMINI.md as a lightweight bootstrap pointer for Gemini CLI.
- Keeps agents/GEMINI.md as the canonical Gemini charter.
- Clarifies SSoT boundaries for repo status, board/stage status and LR verdict.
- Refines Gemini mandate language to avoid accidental implementation or repo mutation without explicit mandate.

## Guardrails
- Documentation-only change.
- No runtime changes.
- No workflow changes.
- No .github changes.
- No DB changes.
- No LR/Live/Echtgeld implication.

## Files
- GEMINI.md
- agents/GEMINI.md

## Validation
- Verified root GEMINI.md only points to canonical files.
- Verified linked files exist.
- Commit contains only the two intended docs files.