### PR TITLE
fix(paper): initialize email alerter before connections

### DIFF
--- a/tools/paper_trading/service.py
+++ b/tools/paper_trading/service.py
@@ -73,10 +73,14 @@ class PaperTradingRunner:
         self.event_count = 0
         self.alert_sent_times = {}  # Debounce alerts
 
+        # Initialize email alerter first to avoid AttributeError in connection error paths
+        self.email_alerter = EmailAlerter()
+        self.redis_client = None
+        self.postgres_conn = None
+
         # Initialize connections
         self.redis_client = self._init_redis()
         self.postgres_conn = self._init_postgres()
-        self.email_alerter = EmailAlerter()
 
         # Ensure logs directory
         Path("logs").mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- Fixes #1936.
- Initializes PaperTradingRunner.email_alerter before Redis/Postgres connection attempts.
- Sets redis_client and postgres_conn to None before connection initialization for safer partial-init diagnostics.
- Prevents AttributeError from masking the original Redis/Postgres connection failure.

## Root cause
PaperTradingRunner.__init__ initialized Redis and Postgres before assigning email_alerter.
The _init_redis and _init_postgres error paths call email_alerter.send_alert.
If either connection failed during initialization, the error handler itself could raise AttributeError.

## Validation
- Reproduced the AttributeError before the fix with a local repro script.
- Confirmed the AttributeError is gone after the fix.
- Ran python -m py_compile tools/paper_trading/service.py.

## Guardrails
- No trading behavior change.
- No DB schema change.
- No Compose/Dockerfile change.
- No runtime/Docker actions.
- No #1905 change.
- No LR/Live/Echtgeld implication.

Refs #1936