### PR TITLE
docs(arvp): reconcile #1905 label status in pilot evidence

### DIFF
--- a/docs/evidence/arvp_calibration_pilot_1932_2026-04-26.md
+++ b/docs/evidence/arvp_calibration_pilot_1932_2026-04-26.md
@@ -89,7 +89,7 @@ This evidence does not imply:
 
 ## Remaining red checks
 
-#1905 currently still carries the conflicting label combination status:parked plus stage:strategy-validated.
+The previously identified label conflict on #1905 (status:parked plus stage:strategy-validated) was a historical tracker-hygiene point and has since been cleansed; live status is now status:parked only.
 
 The source artifacts are local, not committed.
 


### PR DESCRIPTION
## Summary
- reconciles stale #1905 label-conflict wording in ARVP pilot evidence
- marks the status:parked / stage:strategy-validated conflict as historical and live-cleansed
- keeps #1905 parked/evidence-blocked and does not deliver execution-realism scope

## Validation
- git status checked before PR
- commit contains only \docs/evidence/arvp_calibration_pilot_1932_2026-04-26.md\
- #1941 handoff comment corrected

## Guardrails
- no #1905 unpark
- no calibration implementation
- no execution-realism implementation
- no Live-Readiness / Echtgeld implication

Refs #1941
Refs #1905