### PR TITLE
feat(validation): add opt-in primary breakout gate trace

### DIFF
--- a/services/validation/strategy_backtest_runner.py
+++ b/services/validation/strategy_backtest_runner.py
@@ -15,7 +15,7 @@ import json
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Mapping, Optional, Sequence
 
 from core.contracts.external_adapter_contracts import (
     StrategyAdapterRequest,
@@ -436,6 +436,7 @@ def _evaluate_primary_breakout_request(
     position_open: bool,
     last_entry_ts_ms: int | None,
     config: PrimaryBreakoutBacktestRunConfig,
+    gate_trace_callback: Optional[Callable[[Mapping[str, Any]], None]] = None,
 ) -> tuple[StrategyAdapterResponse, int | None]:
     market_state = request.market_event.get("market_state")
     if not isinstance(market_state, Mapping):
@@ -514,6 +515,29 @@ def _evaluate_primary_breakout_request(
         and not entry_cooldown_active
         and close_now > highest_high * (1 + config.bridge.breakout_buffer)
     )
+
+    if gate_trace_callback:
+        gate_trace_callback(
+            {
+                "ts_ms": ts_ms,
+                "symbol": request.symbol,
+                "close_now": close_now,
+                "highest_high": highest_high,
+                "breakout_threshold": highest_high * (1 + config.bridge.breakout_buffer),
+                "breakout_buffer": config.bridge.breakout_buffer,
+                "market_state_fresh": market_state_fresh,
+                "regime_fresh": regime_fresh,
+                "regime_id": regime_id,
+                "has_trend_regime": has_trend_regime,
+                "entry_blocked": entry_blocked,
+                "entry_cooldown_active": entry_cooldown_active,
+                "position_open": position_open,
+                "last_entry_ts_ms": last_entry_ts_ms,
+                "entry_ready": entry_ready,
+                "status": "signal_emitted" if entry_ready else "no_signal",
+            }
+        )
+
     if entry_ready:
         return (
             StrategyAdapterResponse(
@@ -661,6 +685,7 @@ def run_primary_breakout_backtest(
     run_config: PrimaryBreakoutBacktestRunConfig | None = None,
     simulator_config: Mapping[str, Any] | None = None,
     code_commit: str = "unknown",
+    gate_trace_path: Path | None = None,
 ) -> dict[str, Any]:
     """Run the deterministic historical backtest and return the schema report."""
 
@@ -687,120 +712,144 @@ def run_primary_breakout_backtest(
     pending_signals: list[dict[str, Any]] = []
     replay_signature: list[dict[str, Any]] = []
 
-    for request_index, request in enumerate(bridge_requests):
-        if execution_delay_bars > 0 and pending_signals:
-            due_signals: list[dict[str, Any]] = []
-            remaining_signals: list[dict[str, Any]] = []
-            for pending in pending_signals:
-                if pending["target_idx"] == request_index:
-                    due_signals.append(pending)
-                else:
-                    remaining_signals.append(pending)
-            pending_signals = remaining_signals
-            for exec_info in due_signals:
-                open_position = _execute_pending_signal(
-                    exec_info,
-                    open_position,
-                    trades,
-                    simulator,
-                    active_config,
-                )
+    trace_writer = None
+    if gate_trace_path:
+        try:
+            trace_writer = open(gate_trace_path, "w", encoding="utf-8")
+        except OSError as exc:
+            raise PrimaryBreakoutBacktestError(
+                f"Failed to open gate trace path {gate_trace_path}: {exc}"
+            ) from exc
 
-        market_state = request.market_event["market_state"]
-        market_state_fresh = bool(market_state.get("market_state_fresh"))
-        regime_fresh = bool(market_state.get("regime_fresh"))
-        market_state_fresh_count += int(market_state_fresh)
-        regime_fresh_count += int(regime_fresh)
-
-        response, last_entry_ts_ms = _evaluate_primary_breakout_request(
-            request,
-            position_open=open_position is not None,
-            last_entry_ts_ms=last_entry_ts_ms,
-            config=active_config,
-        )
-        replay_signature.append(_serialize_response(response))
-
-        for signal in response.signals:
-            signal_payload = {
-                "strategy_id": signal.strategy_id,
-                "symbol": signal.symbol,
-                "side": signal.side,
-                "reason": signal.reason,
-                "price": signal.price,
-                "metadata": dict(signal.metadata or {}),
-            }
-            output_requests.append(signal_payload)
-
-            if execution_delay_bars > 0:
-                pending_signals.append(
-                    _build_pending_execution(
-                        signal,
-                        request_index,
-                        bridge_requests,
-                        execution_delay_bars,
+    try:
+        for request_index, request in enumerate(bridge_requests):
+            if execution_delay_bars > 0 and pending_signals:
+                due_signals: list[dict[str, Any]] = []
+                remaining_signals: list[dict[str, Any]] = []
+                for pending in pending_signals:
+                    if pending["target_idx"] == request_index:
+                        due_signals.append(pending)
+                    else:
+                        remaining_signals.append(pending)
+                pending_signals = remaining_signals
+                for exec_info in due_signals:
+                    open_position = _execute_pending_signal(
+                        exec_info,
+                        open_position,
+                        trades,
+                        simulator,
+                        active_config,
                     )
-                )
-                continue
 
-            signal_price = _first_number(
-                signal.price, request.market_snapshot.get("close")
-            )
-            if signal_price is None:
-                raise PrimaryBreakoutBacktestError("signal missing price")
-            ts_ms = int(request.market_event["ts_ms"])
-            volume = _first_number(request.market_snapshot.get("volume")) or 0.0
-            volatility = abs(
-                (
-                    signal_price
-                    - _first_number(request.market_snapshot.get("close"), signal_price)
-                )
-                / signal_price
-            )
+            market_state = request.market_event["market_state"]
+            market_state_fresh = bool(market_state.get("market_state_fresh"))
+            regime_fresh = bool(market_state.get("regime_fresh"))
+            market_state_fresh_count += int(market_state_fresh)
+            regime_fresh_count += int(regime_fresh)
 
-            if signal.side == "BUY":
-                if open_position is not None:
-                    continue
-                fill = _simulate_trade(
-                    side="buy",
-                    price=signal_price,
-                    ts_ms=ts_ms,
-                    volume=volume,
-                    simulator=simulator,
-                    order_size=active_config.order_size,
-                    order_book_depth_multiplier=active_config.order_book_depth_multiplier,
-                    volatility=volatility,
-                )
-                open_position = {
-                    "entry_price": fill["avg_fill_price"],
-                    "entry_ts_ms": ts_ms,
-                    "entry_fee": fill["fees"],
+            gate_trace_callback = None
+            if trace_writer:
+
+                def gate_trace_callback(data: Mapping[str, Any]) -> None:
+                    trace_writer.write(
+                        json.dumps({**data, "request_index": request_index}) + "\n"
+                    )
+
+            response, last_entry_ts_ms = _evaluate_primary_breakout_request(
+                request,
+                position_open=open_position is not None,
+                last_entry_ts_ms=last_entry_ts_ms,
+                config=active_config,
+                gate_trace_callback=gate_trace_callback,
+            )
+            replay_signature.append(_serialize_response(response))
+
+            for signal in response.signals:
+                signal_payload = {
+                    "strategy_id": signal.strategy_id,
+                    "symbol": signal.symbol,
+                    "side": signal.side,
+                    "reason": signal.reason,
+                    "price": signal.price,
+                    "metadata": dict(signal.metadata or {}),
                 }
-            elif signal.side == "SELL" and open_position is not None:
-                fill = _simulate_trade(
-                    side="sell",
-                    price=signal_price,
-                    ts_ms=ts_ms,
-                    volume=volume,
-                    simulator=simulator,
-                    order_size=active_config.order_size,
-                    order_book_depth_multiplier=active_config.order_book_depth_multiplier,
-                    volatility=volatility,
+                output_requests.append(signal_payload)
+
+                if execution_delay_bars > 0:
+                    pending_signals.append(
+                        _build_pending_execution(
+                            signal,
+                            request_index,
+                            bridge_requests,
+                            execution_delay_bars,
+                        )
+                    )
+                    continue
+
+                signal_price = _first_number(
+                    signal.price, request.market_snapshot.get("close")
                 )
-                entry_price = float(open_position["entry_price"])
-                exit_price = float(fill["avg_fill_price"])
-                trade_r = (exit_price - entry_price) / entry_price
-                trades.append(
-                    {
-                        "entry_ts_ms": int(open_position["entry_ts_ms"]),
-                        "exit_ts_ms": ts_ms,
-                        "entry_price": entry_price,
-                        "exit_price": exit_price,
-                        "entry_fee": float(open_position["entry_fee"]),
-                        "exit_fee": float(fill["fees"]),
-                        "r_return": trade_r,
+                if signal_price is None:
+                    raise PrimaryBreakoutBacktestError("signal missing price")
+                ts_ms = int(request.market_event["ts_ms"])
+                volume = _first_number(request.market_snapshot.get("volume")) or 0.0
+                volatility = abs(
+                    (
+                        signal_price
+                        - _first_number(
+                            request.market_snapshot.get("close"), signal_price
+                        )
+                    )
+                    / signal_price
+                )
+
+                if signal.side == "BUY":
+                    if open_position is not None:
+                        continue
+                    fill = _simulate_trade(
+                        side="buy",
+                        price=signal_price,
+                        ts_ms=ts_ms,
+                        volume=volume,
+                        simulator=simulator,
+                        order_size=active_config.order_size,
+                        order_book_depth_multiplier=active_config.order_book_depth_multiplier,
+                        volatility=volatility,
+                    )
+                    open_position = {
+                        "entry_price": fill["avg_fill_price"],
+                        "entry_ts_ms": ts_ms,
+                        "entry_fee": fill["fees"],
                     }
-                )
-                open_position = None
+                elif signal.side == "SELL" and open_position is not None:
+                    fill = _simulate_trade(
+                        side="sell",
+                        price=signal_price,
+                        ts_ms=ts_ms,
+                        volume=volume,
+                        simulator=simulator,
+                        order_size=active_config.order_size,
+                        order_book_depth_multiplier=active_config.order_book_depth_multiplier,
+                        volatility=volatility,
+                    )
+                    entry_price = float(open_position["entry_price"])
+                    exit_price = float(fill["avg_fill_price"])
+                    trade_r = (exit_price - entry_price) / entry_price
+                    trades.append(
+                        {
+                            "entry_ts_ms": int(open_position["entry_ts_ms"]),
+                            "exit_ts_ms": ts_ms,
+                            "entry_price": entry_price,
+                            "exit_price": exit_price,
+                            "entry_fee": float(open_position["entry_fee"]),
+                            "exit_fee": float(fill["fees"]),
+                            "r_return": trade_r,
+                        }
+                    )
+                    open_position = None
+    finally:
+        if trace_writer:
+            trace_writer.close()
 
     replay_check_signature: list[dict[str, Any]] = []
     replay_position_open = False
@@ -828,6 +877,7 @@ def run_primary_breakout_backtest(
             position_open=replay_position_open,
             last_entry_ts_ms=replay_last_entry_ts_ms,
             config=active_config,
+            gate_trace_callback=None,  # Do not trace in second pass
         )
         replay_check_signature.append(_serialize_response(response))
         for signal in response.signals:
@@ -852,9 +902,7 @@ def run_primary_breakout_backtest(
         pending_signals,
     )
     data_integrity_ok = (
-        len(bridge_requests) > 0
-        and open_position is None
-        and not pending_signals
+        len(bridge_requests) > 0 and open_position is None and not pending_signals
     )
     return _build_report(
         bridge_requests=bridge_requests,

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -220,6 +220,9 @@ class ARVPReplayConfig:
     min_minutes_between_entries: int = 60
     """Minimum cooldown between entry signals."""
 
+    gate_trace_path: Path | None = None
+    """Optional path for entry gate trace JSONL."""
+
     dry_run: bool = False
     """Validate config + input only; do not execute or write artifacts."""
 
@@ -295,6 +298,12 @@ class ARVPReplayConfig:
             raise ValueError("breakout_buffer must be >= 0")
         if self.min_minutes_between_entries < 0:
             raise ValueError("min_minutes_between_entries must be >= 0")
+
+        if self.scenario_ids and self.gate_trace_path:
+            raise ValueError(
+                "--gate-trace-path is not supported with --scenario-group (multiple scenarios "
+                "would overwrite the same trace file). Run scenarios individually to use tracing."
+            )
 
         # Scenario group validation
         if self.scenario_ids is not None:
@@ -949,6 +958,7 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
             candles,
             run_config=run_cfg,
             code_commit=code_commit,
+            gate_trace_path=config.gate_trace_path,
         )
     except (HistoricalBridgeError, PrimaryBreakoutBacktestError) as exc:
         try:
@@ -1251,6 +1261,13 @@ def _build_argument_parser() -> argparse.ArgumentParser:
         help=f"Adapter identifier. Default: {_DEFAULT_ADAPTER_ID!r}",
     )
     parser.add_argument(
+        "--gate-trace-path",
+        default=None,
+        metavar="PATH",
+        type=Path,
+        help="Optional path for entry gate trace JSONL.",
+    )
+    parser.add_argument(
         "--speedup-profile",
         default="instant",
         metavar="PROFILE",
@@ -1402,6 +1419,7 @@ def main() -> int:
             adapter_id=args.adapter_id,
             speedup_profile=args.speedup_profile,
             output_directory=args.output_dir,
+            gate_trace_path=args.gate_trace_path,
             dry_run=args.dry_run,
             deterministic_verify=args.deterministic_verify,
             scenario_ids=scenario_ids,

--- a/tests/unit/validation/test_primary_breakout_backtest_runner.py
+++ b/tests/unit/validation/test_primary_breakout_backtest_runner.py
@@ -164,6 +164,7 @@ def test_primary_breakout_backtest_runner_surfaces_clean_end_state(
         position_open: bool,
         last_entry_ts_ms: int | None,
         config: PrimaryBreakoutBacktestRunConfig,
+        gate_trace_callback: object = None,
     ) -> tuple[StrategyAdapterResponse, int | None]:
         ts_ms = int(request.market_event["ts_ms"])
         if ts_ms == int(requests[0].market_event["ts_ms"]):
@@ -270,6 +271,7 @@ def test_primary_breakout_backtest_runner_surfaces_open_position_end_state(
         position_open: bool,
         last_entry_ts_ms: int | None,
         config: PrimaryBreakoutBacktestRunConfig,
+        gate_trace_callback: object = None,
     ) -> tuple[StrategyAdapterResponse, int | None]:
         ts_ms = int(request.market_event["ts_ms"])
         if ts_ms == int(requests[0].market_event["ts_ms"]):
@@ -396,6 +398,7 @@ def test_primary_breakout_backtest_runner_delays_execution_by_bar_index(
         position_open: bool,
         last_entry_ts_ms: int | None,
         config: PrimaryBreakoutBacktestRunConfig,
+        gate_trace_callback: object = None,
     ) -> tuple[StrategyAdapterResponse, int | None]:
         ts_ms = int(request.market_event["ts_ms"])
         if ts_ms == int(requests[0].market_event["ts_ms"]):
@@ -518,6 +521,7 @@ def test_primary_breakout_backtest_runner_fails_closed_on_out_of_range_delay(
         position_open: bool,
         last_entry_ts_ms: int | None,
         config: PrimaryBreakoutBacktestRunConfig,
+        gate_trace_callback: object = None,
     ) -> tuple[StrategyAdapterResponse, int | None]:
         if int(request.market_event["ts_ms"]) == int(requests[-1].market_event["ts_ms"]):
             return (
@@ -556,3 +560,58 @@ def test_primary_breakout_backtest_runner_fails_closed_on_out_of_range_delay(
             simulator_config={"EXECUTION_DELAY_BARS": 1},
             code_commit="a9a62be",
         )
+
+
+@pytest.mark.unit
+def test_primary_breakout_backtest_runner_gate_trace_path_is_opt_in(tmp_path: Path) -> None:
+    """Verify that without gate_trace_path, no file is created and results remain stable."""
+    candles = _candles()[:250]
+    trace_path = tmp_path / "not_created.jsonl"
+
+    # Run twice to ensure no side effects
+    report_1 = run_primary_breakout_backtest(
+        candles,
+        run_config=PrimaryBreakoutBacktestRunConfig(),
+        code_commit="opt-in-test",
+    )
+    report_2 = run_primary_breakout_backtest(
+        candles,
+        run_config=PrimaryBreakoutBacktestRunConfig(),
+        code_commit="opt-in-test",
+    )
+
+    assert not trace_path.exists()
+    assert report_1 == report_2
+
+
+@pytest.mark.unit
+def test_primary_breakout_backtest_runner_gate_trace_schema_and_single_pass(tmp_path: Path) -> None:
+    """Verify JSONL schema and ensure determinism pass does not double-write traces."""
+    candles = _candles()[:250]
+    trace_path = tmp_path / "gate_trace.jsonl"
+
+    run_primary_breakout_backtest(
+        candles,
+        run_config=PrimaryBreakoutBacktestRunConfig(),
+        code_commit="trace-schema-test",
+        gate_trace_path=trace_path,
+    )
+
+    assert trace_path.exists()
+    lines = trace_path.read_text(encoding="utf-8").strip().split("\n")
+
+    # Count should match bridge requests (250 candles - 240 warmup = 10 requests)
+    assert len(lines) == 10
+
+    required_fields = {
+        "request_index", "ts_ms", "symbol", "close_now", "highest_high",
+        "breakout_threshold", "breakout_buffer", "market_state_fresh",
+        "regime_fresh", "regime_id", "has_trend_regime", "entry_blocked",
+        "entry_cooldown_active", "position_open", "last_entry_ts_ms",
+        "entry_ready", "status"
+    }
+
+    for line in lines:
+        record = json.loads(line)
+        missing = required_fields - set(record.keys())
+        assert not missing, f"Missing fields in trace record: {missing}"

--- a/tests/unit/validation/test_strategy_replay_runner.py
+++ b/tests/unit/validation/test_strategy_replay_runner.py
@@ -1291,6 +1291,60 @@ class TestMainArgParse:
 
         assert captured[0].speedup_profile == "5x"
 
+    def test_gate_trace_path_flag_applied(self, tmp_path):
+        candles = [{"ts_ms": 1_000_000}]
+        f = tmp_path / "c.json"
+        f.write_text(json.dumps(candles))
+        captured = []
+        trace_path = tmp_path / "gate.jsonl"
+
+        def capture(cfg):
+            captured.append(cfg)
+            return 0
+
+        with patch(
+            "services.validation.strategy_replay_runner.run_arvp_replay",
+            side_effect=capture,
+        ):
+            with patch("sys.argv", [
+                "prog", "--input-candles", str(f), "--gate-trace-path", str(trace_path)
+            ]):
+                main()
+
+        assert captured[0].gate_trace_path == trace_path
+
+    def test_validate_fails_on_gate_trace_with_scenario_group(self):
+        cfg = ARVPReplayConfig(
+            input_candles_file="c.json",
+            scenario_ids=("baseline",),
+            gate_trace_path=Path("trace.jsonl"),
+        )
+        with pytest.raises(ValueError, match="not supported with --scenario-group"):
+            cfg.validate()
+
+    def test_run_arvp_replay_propagates_gate_trace_path(self, tmp_path):
+        from services.validation.strategy_replay_runner import run_arvp_replay
+
+        f = tmp_path / "c.json"
+        candles = [{"ts_ms": 1_000_000 + i * 60_000, "close": 100.0, "high": 101.0,
+                   "low": 99.0, "regime_id": 0, "symbol": "BTCUSDT"} for i in range(250)]
+        f.write_text(json.dumps(candles))
+
+        trace_path = tmp_path / "gate.jsonl"
+        cfg = ARVPReplayConfig(
+            input_candles_file=str(f),
+            output_directory=str(tmp_path),
+            gate_trace_path=trace_path,
+        )
+
+        with patch("services.validation.strategy_replay_runner.run_primary_breakout_backtest") as mock_bt:
+            mock_bt.return_value = _minimal_backtest_report()
+            with patch.object(ReplayReporter, "write_bundle") as mock_write:
+                mock_write.return_value = tmp_path / "bundle"
+                run_arvp_replay(cfg)
+
+                assert mock_bt.call_args.kwargs["gate_trace_path"] == trace_path
+
     def test_exit_code_semantics_0(self, tmp_path):
         candles = [{"ts_ms": 1_000_000}]
         f = tmp_path / "c.json"


### PR DESCRIPTION
## Summary
- adds an explicit opt-in JSONL gate trace for <code>primary_breakout_v1</code> validation runs
- wires <code>--gate-trace-path</code> through <code>strategy_replay_runner</code>
- keeps <code>PrimaryBreakoutBacktestRunConfig</code>, default reports, run IDs, deterministic hashes, and strategy behavior unchanged
- fails closed for <code>--scenario-group</code> plus <code>--gate-trace-path</code>
- covers opt-in behavior, schema, single-pass trace writing, CLI parsing, and propagation with unit tests

## Validation
- <code>git diff --check</code>
- <code>pytest tests/unit/validation/test_primary_breakout_backtest_runner.py</code>
- <code>pytest tests/unit/validation/test_strategy_replay_runner.py</code>

## Guardrails
- no changes to <code>services/signal/service.py</code>
- no trading/strategy behavior change
- no #1905 unpark
- no calibration or execution-realism implementation
- no Live-Readiness / Echtgeld implication
- #1943 remains a hypothesis pending event-level trace evidence

Refs #1941
Refs #1943