### PR TITLE
fix(signal): use time-windowed breakout lookback

### DIFF
--- a/services/signal/service.py
+++ b/services/signal/service.py
@@ -153,8 +153,8 @@ class SignalEngine:
             PriceBuffer()
         )  # Stateful pct_change calculation (Issue #345)
         self._pg_conn: Optional[psycopg2.extensions.connection] = None  # Phase 8C
-        self._high_history: dict[str, list[float]] = defaultdict(list)
-        self._low_history: dict[str, list[float]] = defaultdict(list)
+        self._high_history: dict[str, list[tuple[int, float]]] = defaultdict(list)
+        self._low_history: dict[str, list[tuple[int, float]]] = defaultdict(list)
         self._last_entry_ts_ms: dict[str, int] = {}
         self._position_open_by_symbol: dict[str, bool] = defaultdict(bool)
 
@@ -443,18 +443,25 @@ class SignalEngine:
                 return parsed
         return {}
 
-    def _append_breakout_history(self, symbol: str, high_now: float, low_now: float) -> None:
-        max_lookback = max(
+    def _update_breakout_history(
+        self, symbol: str, high_now: float, low_now: float, now_ms: int
+    ) -> None:
+        max_lookback_min = max(
             self.config.entry_lookback_minutes, self.config.exit_lookback_minutes
         )
+        limit_ms = now_ms - max_lookback_min * 60 * 1000
+
         highs = self._high_history[symbol]
         lows = self._low_history[symbol]
-        highs.append(high_now)
-        lows.append(low_now)
-        if len(highs) > max_lookback:
-            del highs[:-max_lookback]
-        if len(lows) > max_lookback:
-            del lows[:-max_lookback]
+
+        highs.append((now_ms, high_now))
+        lows.append((now_ms, low_now))
+
+        # Prune old entries
+        while highs and highs[0][0] < limit_ms:
+            highs.pop(0)
+        while lows and lows[0][0] < limit_ms:
+            lows.pop(0)
 
     def _process_primary_breakout_v1(
         self, market_data: MarketData, raw_data: dict[str, Any]
@@ -468,19 +475,37 @@ class SignalEngine:
         low_now = float(market_data.low or close_now)
         now_ms = int((market_data.timestamp or int(time.time())) * 1000)
 
-        highs = self._high_history[symbol]
-        lows = self._low_history[symbol]
-        prior_highs = highs[-self.config.entry_lookback_minutes :]
-        prior_lows = lows[-self.config.exit_lookback_minutes :]
+        # Time-based windowing
+        entry_lookback_ms = self.config.entry_lookback_minutes * 60_000
+        exit_lookback_ms = self.config.exit_lookback_minutes * 60_000
+
+        entry_limit = now_ms - entry_lookback_ms
+        exit_limit = now_ms - exit_lookback_ms
+
+        prior_high_entries = [e for e in self._high_history[symbol] if e[0] >= entry_limit]
+        prior_low_entries = [e for e in self._low_history[symbol] if e[0] >= exit_limit]
+
+        prior_highs = [p for ts, p in prior_high_entries]
+        prior_lows = [p for ts, p in prior_low_entries]
+
+        # Warmup check: Do we have at least the required history span in the CURRENT window?
+        entry_warmup_ok = (
+            bool(prior_high_entries)
+            and (now_ms - min(ts for ts, _ in prior_high_entries)) >= entry_lookback_ms
+        )
+        exit_warmup_ok = (
+            bool(prior_low_entries)
+            and (now_ms - min(ts for ts, _ in prior_low_entries)) >= exit_lookback_ms
+        )
 
         highest_high = (
             max(prior_highs)
-            if len(prior_highs) >= self.config.entry_lookback_minutes
+            if prior_highs and entry_warmup_ok
             else None
         )
         lowest_low = (
             min(prior_lows)
-            if len(prior_lows) >= self.config.exit_lookback_minutes
+            if prior_lows and exit_warmup_ok
             else None
         )
 
@@ -517,13 +542,16 @@ class SignalEngine:
             cooldown_ms = self.config.min_minutes_between_entries * 60 * 1000
             cooldown_active = now_ms - self._last_entry_ts_ms[symbol] < cooldown_ms
 
+        # Signal Logic
+        result_signal = None
+
         # Exits are allowed even when entry gates are blocked.
         if (
             self._position_open_by_symbol[symbol]
             and lowest_low is not None
             and close_now < lowest_low
         ):
-            breakout_signal = Signal(
+            result_signal = Signal(
                 signal_id=f"sig-{generate_uuid_hex(length=32)}",
                 symbol=symbol,
                 side="SELL",
@@ -537,7 +565,7 @@ class SignalEngine:
                 strategy_id=self.config.strategy_id,
                 bot_id=self.config.bot_id,
             )
-            breakout_signal.metadata = _compact_metadata(
+            result_signal.metadata = _compact_metadata(
                 {
                     "strategy_id": self.config.strategy_id,
                     "signal_reason": "channel_exit",
@@ -551,53 +579,51 @@ class SignalEngine:
                 }
             )
             self._position_open_by_symbol[symbol] = False
-            self._append_breakout_history(symbol, high_now, low_now)
-            return breakout_signal
 
-        entry_ready = (
-            highest_high is not None
-            and market_state_fresh
-            and regime_fresh
-            and has_trend_regime
-            and not entry_blocked
-            and not cooldown_active
-            and close_now > highest_high * (1 + self.config.breakout_buffer)
-        )
-        if entry_ready:
-            breakout_signal = Signal(
-                signal_id=f"sig-{generate_uuid_hex(length=32)}",
-                symbol=symbol,
-                side="BUY",
-                reason="breakout_entry",
-                timestamp=now_ms // 1000,
-                ts_ms=now_ms,
-                price=close_now,
-                pct_change=market_data.pct_change,
-                pct_change_15m=market_data.pct_change,
-                volume_15m=market_data.volume,
-                strategy_id=self.config.strategy_id,
-                bot_id=self.config.bot_id,
+        else:
+            entry_ready = (
+                highest_high is not None
+                and market_state_fresh
+                and regime_fresh
+                and has_trend_regime
+                and not entry_blocked
+                and not cooldown_active
+                and close_now > highest_high * (1 + self.config.breakout_buffer)
             )
-            breakout_signal.metadata = _compact_metadata(
-                {
-                    "strategy_id": self.config.strategy_id,
-                    "signal_reason": "breakout_entry",
-                    "regime_id": regime_id,
-                    "close_now": close_now,
-                    "highest_high": highest_high,
-                    "lowest_low": lowest_low,
-                    "entry_lookback_minutes": self.config.entry_lookback_minutes,
-                    "exit_lookback_minutes": self.config.exit_lookback_minutes,
-                    "breakout_buffer": self.config.breakout_buffer,
-                }
-            )
-            self._last_entry_ts_ms[symbol] = now_ms
-            self._position_open_by_symbol[symbol] = True
-            self._append_breakout_history(symbol, high_now, low_now)
-            return breakout_signal
+            if entry_ready:
+                result_signal = Signal(
+                    signal_id=f"sig-{generate_uuid_hex(length=32)}",
+                    symbol=symbol,
+                    side="BUY",
+                    reason="breakout_entry",
+                    timestamp=now_ms // 1000,
+                    ts_ms=now_ms,
+                    price=close_now,
+                    pct_change=market_data.pct_change,
+                    pct_change_15m=market_data.pct_change,
+                    volume_15m=market_data.volume,
+                    strategy_id=self.config.strategy_id,
+                    bot_id=self.config.bot_id,
+                )
+                result_signal.metadata = _compact_metadata(
+                    {
+                        "strategy_id": self.config.strategy_id,
+                        "signal_reason": "breakout_entry",
+                        "regime_id": regime_id,
+                        "close_now": close_now,
+                        "highest_high": highest_high,
+                        "lowest_low": lowest_low,
+                        "entry_lookback_minutes": self.config.entry_lookback_minutes,
+                        "exit_lookback_minutes": self.config.exit_lookback_minutes,
+                        "breakout_buffer": self.config.breakout_buffer,
+                    }
+                )
+                self._last_entry_ts_ms[symbol] = now_ms
+                self._position_open_by_symbol[symbol] = True
 
-        self._append_breakout_history(symbol, high_now, low_now)
-        return None
+        # Append AFTER decision
+        self._update_breakout_history(symbol, high_now, low_now, now_ms)
+        return result_signal
 
     def process_market_data(self, data: dict) -> Optional[Signal]:
         """

--- a/tests/unit/signal/test_service.py
+++ b/tests/unit/signal/test_service.py
@@ -489,3 +489,162 @@ def test_signal_engine_fails_closed_on_unknown_adapter_id(monkeypatch):
     with patch("service.config", test_config):
         with pytest.raises(KeyError, match="Unknown strategy adapter id"):
             SignalEngine()
+
+
+@pytest.mark.unit
+def test_lookback_time_vs_trade_count():
+    """
+    Regression: Hohe Trade-Frequenz innerhalb von Sekunden darf Lookback-Fenster (Minuten) nicht füllen.
+    """
+    test_config = SignalConfig(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        min_volume=100.0,
+        entry_lookback_minutes=3,
+        exit_lookback_minutes=2,
+        breakout_buffer=0.0,
+        min_minutes_between_entries=60,
+        trade_side_mode="long_only",
+    )
+
+    with patch("service.config", test_config):
+        engine = SignalEngine()
+        symbol = "BTCUSDT"
+
+        # Sende 10 Trades innerhalb von 10 Sekunden (alle > Vorheriger High)
+        # Aber alle innerhalb derselben Minute.
+        for i in range(10):
+            payload = {
+                "symbol": symbol,
+                "timestamp": 1700000000 + i,  # +1s Schritte
+                "price": 100.0 + i,
+                "high": 100.0 + i,
+                "low": 99.0 + i,
+                "volume": 200000.0,
+                "regime_id": "TREND",
+                "market_state_fresh": True,
+                "regime_fresh": True,
+            }
+            signal = engine.process_market_data(payload)
+            # Erwartung: Kein Signal, da Lookback 3 Min erfordert, wir aber erst 10s Historie haben.
+            # Im alten (fehlerhaften) Code waere len(highs) >= 3 erfuellt gewesen.
+            assert signal is None, f"Signal fälschlicherweise bei Trade {i} generiert (Trade-Count Drift)"
+
+
+@pytest.mark.unit
+def test_lookback_positive_time_trigger():
+    """
+    Test: Nach ausreichendem Zeitfenster (Minuten) löst Breakout BUY aus.
+    """
+    test_config = SignalConfig(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        min_volume=100.0,
+        entry_lookback_minutes=3,
+        exit_lookback_minutes=2,
+        breakout_buffer=0.0,
+        min_minutes_between_entries=60,
+        trade_side_mode="long_only",
+    )
+
+    with patch("service.config", test_config):
+        engine = SignalEngine()
+        symbol = "BTCUSDT"
+        base_ts = 1700000000
+
+        # Fülle Historie über 4 Minuten (1 Trade pro Minute)
+        for i in range(4):
+            payload = {
+                "symbol": symbol,
+                "timestamp": base_ts + (i * 60),  # +1m Schritte
+                "price": 100.0 + i,
+                "high": 100.0 + i,
+                "low": 99.0 + i,
+                "volume": 200000.0,
+                "regime_id": "TREND",
+                "market_state_fresh": True,
+                "regime_fresh": True,
+            }
+            signal = engine.process_market_data(payload)
+            if i < 3:
+                assert signal is None
+            else:
+                # Nach 3 Minuten (4. Trade bei T+3m) sollte ein Breakout möglich sein,
+                # sofern der Preis das High der letzten 3m (102.0) schlägt.
+                # Aber hier ist price=103.0 und max(prior_highs) = max(100, 101, 102) = 102.0.
+                assert signal is not None
+                assert signal.side == "BUY"
+
+
+@pytest.mark.unit
+def test_lookback_gap_regression():
+    """
+    Regression: Nach einer langen Datenlücke darf erst dann ein Signal erfolgen,
+    wenn das aktuelle Fenster zeitlich wieder gefüllt ist.
+    """
+    test_config = SignalConfig(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        min_volume=100.0,
+        entry_lookback_minutes=3,
+        exit_lookback_minutes=2,
+        breakout_buffer=0.0,
+        min_minutes_between_entries=60,
+        trade_side_mode="long_only",
+    )
+
+    with patch("service.config", test_config):
+        engine = SignalEngine()
+        symbol = "BTCUSDT"
+        t0 = 1700000000
+
+        # 1. Initialer Aufbau (alt, wird später gepruned)
+        for i in range(5):
+            payload = {
+                "symbol": symbol,
+                "timestamp": t0 + i,
+                "price": 100.0,
+                "high": 100.0,
+                "low": 99.0,
+                "volume": 200000.0,
+                "risk_blocked": True,  # Verhindere BUY
+            }
+            engine.process_market_data(payload)
+
+        # 2. Lange Datenlücke (1 Stunde)
+        t_gap = t0 + 3600
+
+        # 3. Neue Trades innerhalb weniger Sekunden
+        # Erwartung: Kein BUY, da das Fenster [t_gap - 3m, t_gap] nur Daten von vor 1 Sekunde enthält.
+        for i in range(3):
+            payload = {
+                "symbol": symbol,
+                "timestamp": t_gap + i,
+                "price": 110.0,  # Deutlicher Breakout gegenüber 100.0
+                "high": 110.0,
+                "low": 109.0,
+                "volume": 200000.0,
+                "regime_id": "TREND",
+                "market_state_fresh": True,
+                "regime_fresh": True,
+            }
+            signal = engine.process_market_data(payload)
+            assert (
+                signal is None
+            ), f"Signal fälschlicherweise nach Gap bei Trade {i} generiert (Warmup Drift)"
+
+        # 4. Nach 3 Minuten (t_gap + 180s) sollte es wieder gehen
+        payload_final = {
+            "symbol": symbol,
+            "timestamp": t_gap + 180,
+            "price": 115.0,
+            "high": 115.0,
+            "low": 114.0,
+            "volume": 200000.0,
+            "regime_id": "TREND",
+            "market_state_fresh": True,
+            "regime_fresh": True,
+        }
+        signal = engine.process_market_data(payload_final)
+        assert signal is not None
+        assert signal.side == "BUY"


### PR DESCRIPTION
﻿Fix für #1943.

### Befund
Die SignalEngine (Paper) interpretierte entry_lookback_minutes / exit_lookback_minutes fälschlicherweise als Event-/Trade-Count (Slicing via [-N:]), was bei hoher Tick-Dichte zu rausch-anfälligen Signalen führte.

### Änderungen
- **Zeitgestempelte Historie**: Umstellung auf (ts_ms, price)-Tupel.
- **Zeitbasierte Fenster**: Filterung der Historie basierend auf Event-Zeitstempeln.
- **Deterministischer Warmup**: Validierung der zeitlichen Spanne im aktuellen Fenster vor Signal-Generierung (behebt auch Gap-Drift).
- **Integrity**: Entscheidung erfolgt auf Vor-Historie (vor Append).
- **Zeitbasiertes Pruning**: Begrenzung der Historie auf das maximale Lookback-Fenster.

### Tests
- pytest tests/unit/signal/test_service.py (inkl. Burst- und Gap-Regression)
- pytest tests/unit/validation/test_primary_breakout_backtest_runner.py
- pytest tests/unit/validation/test_strategy_replay_runner.py

### Scope-Grenze
- Keine Candle-Bucket-Aggregation in dieser Engine-Stufe.
- Keine Execution-/Calibration-Arbeit.
- Keine Live-/LR-Ableitung.
- #1905 bleibt parked.
