### PR TITLE
docs(gemini): enforce bootloader and live-tool guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,224 @@ Status-Regel:
 Hinweis:
 - Das Working Repo ist der produktive Standardpfad fuer Agenten-, Governance- und Navigationsdoku.
 - Das lokale Archiv unter `docs/archive/docs_hub_snapshot/` ist nur noch historischer Rueckgriff und nicht mehr Canon.
+
+---
+
+## Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `make test-unit` | Run unit tests (`pytest -v -m unit`) |
+| `make test-integration` | Run integration tests with mocks |
+| `make test-e2e` | Run E2E tests (requires running stack) |
+| `make test-coverage` | Run tests with 80% coverage enforcement |
+| `ruff check .` | Lint with Ruff |
+| `black .` | Format with Black |
+| `mypy core/ services/` | Type check |
+
+---
+
+## Build / Lint / Test Commands
+
+### Running Tests
+
+```bash
+# All CI tests (unit + integration)
+make test
+# or via specific targets:
+make test-unit && make test-integration
+
+# Run a single test file
+pytest -v tests/unit/risk/test_risk_service.py
+
+# Run a single test function
+pytest -v tests/unit/risk/test_risk_service.py::test_exposure_limit_bypassed_for_reduce_only_sell
+
+# Run tests matching a keyword
+pytest -v -k "exposure"
+
+# Run with coverage (enforced via make test-coverage)
+pytest --cov=core --cov=services --cov=infrastructure/scripts --cov-report=html --cov-report=term --cov-fail-under=80 -m "not e2e and not local_only"
+
+# E2E tests (requires: make docker-up)
+pytest -v -m e2e
+
+# Local-only tests (requires running stack)
+pytest -v -m local_only
+```
+
+### Common Test Markers (pytest.ini - not exhaustive)
+
+- `@pytest.mark.unit` - Fast, isolated unit tests (CI)
+- `@pytest.mark.integration` - Tests with mocks (CI)
+- `@pytest.mark.contract` - Validate API/service contracts
+- `@pytest.mark.external` - Tests requiring external network
+- `@pytest.mark.e2e` - End-to-End with real containers
+- `@pytest.mark.local_only` - Explicitly local only (not CI)
+- `@pytest.mark.slow` - Tests with >10s runtime
+- `@pytest.mark.chaos` - Chaos/Resilience tests (DESTRUCTIVE)
+- `@pytest.mark.performance` - Performance/Latency tests
+- `@pytest.mark.resilience` - Recovery/DR tests
+- `@pytest.mark.feature` - Feature-specific tests
+- `@pytest.mark.mandatory` - Critical path tests
+- `@pytest.mark.load` - Load/Stress tests
+- `@pytest.mark.smoke` - Sanity checks
+
+### Linting & Formatting
+
+```bash
+# Lint (Ruff)
+ruff check .
+
+# Format (Black) - line length 88, target Python 3.12
+black .
+
+# Type checking (mypy)
+mypy core/ services/
+
+# Security scan
+make security-scan
+# runs: gitleaks detect, ruff check, bandit -r core/ services/
+```
+
+### Docker Operations
+
+```bash
+# Start canonical BLUE+RED stack
+make docker-up
+# or:
+docker compose -f infrastructure/compose/compose.blue.yml up -d
+docker compose -f infrastructure/compose/compose.red.yml up -d
+
+# Health check
+make docker-health
+
+# Stop
+make docker-down
+```
+
+---
+
+## Code Style Guidelines
+
+### Formatting
+- **Formatter:** Black (line-length=88, target-version=py312)
+- **Linter:** Ruff (select=["E", "F"], ignore=["E501", "F401", "F541"])
+- No line length enforcement (E501 ignored), soft limit 88 chars
+
+### Imports
+```python
+from __future__ import annotations
+
+import copy
+from decimal import Decimal
+import json
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+import redis
+import psycopg2
+
+from core.utils.redis_client import create_redis_client
+from core.utils.uuid_gen import generate_uuid
+```
+
+Rules:
+1. `from __future__ import annotations` first
+2. Standard library (alphabetical)
+3. Third-party libraries
+4. Local modules (`core.*`, `services.*`, `infrastructure.*`)
+5. One import per line; no `import os, sys`
+
+### Type Hints
+- Type hints are expected for new or touched production Python APIs.
+- Tests, fixtures, scripts and legacy code should follow local style unless the task explicitly hardens typing.
+- Use `typing.TYPE_CHECKING` for circular imports.
+- Use `Optional[X]` or `X | None` (with future annotations).
+- Use `Decimal` for money, order quantities, accounting, risk-/execution-relevant financial values.
+- `float` is acceptable for non-financial metrics, indicators, percentages, telemetry, or existing contracts where already established. Do not silently change numeric semantics.
+
+```python
+def process_order(order_id: str, quantity: Decimal) -> Optional[dict]:
+    ...
+```
+
+### Naming Conventions
+| Element | Convention | Example |
+|---------|-------------|---------|
+| Files | `snake_case` | `service.py`, `test_risk_service.py` |
+| Classes | `PascalCase` | `RiskManager`, `OrderValidator` |
+| Functions/Variables | `snake_case` | `compute_hash`, `order_count` |
+| Constants | `UPPER_SNAKE_CASE` | `MAX_RETRY_COUNT`, `DEFAULT_TIMEOUT` |
+| Private members | `_leading_underscore` | `_internal_state` |
+
+### Error Handling
+- Use explicit exception types, avoid bare `except:`
+- Log errors with context before re-raising
+- Use `Decimal` exceptions for financial math: `InvalidOperation`
+- Fail-closed for security-critical paths
+
+```python
+try:
+    result = Decimal(raw_value)
+except InvalidOperation:
+    logger.error("Invalid decimal value", extra={"raw": raw_value})
+    raise ValueError(f"Cannot parse decimal: {raw_value}")
+```
+
+### Testing Requirements
+- **Coverage:** 80% minimum (enforced via `--cov-fail-under=80`)
+- **Markers:** Use `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.e2e`
+- **File location:** `tests/unit/`, `tests/integration/`, `tests/e2e/`, `tests/local/`
+- **Naming:** `test_<module>_<description>.py` or `test_<description>.py`
+- **Fixtures:** Prefer module-level fixtures in `conftest.py`
+
+### Security Rules
+- **No hardcoded secrets** (enforced via gitleaks)
+- **No `float` for financial values** (use `Decimal`)
+- **Input validation** on all external data (Redis streams, API responses)
+- **Secrets via environment:** `SECRETS_PATH` or environment variables
+- **No Tresor access** (see `CDB_TRESOR_POLICY.md`)
+
+### Determinism & Auditability
+- All system state must be **reproducible** (CDB_CONSTITUTION.md).
+- Use `core.utils.uuid_gen` for event-/decision-/audit-relevant IDs where CDB-owned deterministic IDs are required.
+- Do not replace external IDs or test fixture IDs without explicit scope.
+- Log decision context (Decision Events for governance-critical paths).
+- No blackbox decisions; all logic must be traceable.
+
+---
+
+## Selected repo skills (not exhaustive)
+
+Located in `.codex/cdb_skills/`:
+
+| Skill | Purpose |
+|-------|---------|
+| `cdb-session-start` | Fail-closed session start (verifies Git truth first) |
+| `cdb-session-close` | Disciplined session close with honest summary |
+| `cdb-issue-to-session-plan` | Convert issue to session plan |
+| `cdb-control-intake` | Control context reading |
+| `cdb-shadow-validation` | Shadow validation workflows |
+| `cdb-backtest-engine` | Backtest engine operations |
+| `cdb-ci-cd-guard` | CI/CD guardrails |
+| `cdb-contract-evidence-gatekeeper` | Contract evidence gating |
+| `cdb-drift-reconcile` | Drift reconciliation |
+| `cdb-exchange-adapters` | Exchange adapter operations |
+| `cdb-risk-governance` | Risk governance operations |
+| `cdb-trading-core` | Trading core operations |
+| `cdb-docs-ops` | Documentation and ops-doc maintenance |
+| `codex-primary-runtime` | Core runtime operations |
+| `ctb-docker-stack` | Docker stack operations |
+| `gh-address-comments` | GitHub comment handling |
+| `gh-fix-ci` | CI fix operations |
+
+---
+
+## Agent Operating Rules
+
+- Read `knowledge/governance/CDB_AGENT_POLICY.md` section 4 before any write.
+- Respect single-writer locks, explicit stop signals, and write gates.
+- `DELIVERY_APPROVED.yaml` is human-controlled; agents must not modify it.
+- LR status remains NO-GO for live trading unless explicitly changed by canon/human approval.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,3 +1,39 @@
+# CDB Gemini Bootloader
+
+1. **Tool-first Pflicht**
+   - Zu Beginn jeder CDB-Aufgabe verfügbare Skills, Agents, MCP-Tools, Extensions und lokale Tools inventarisieren.
+   - Wenn die Aufgabe GitHub-/Repo-Wahrheit braucht, sind MCP oder `gh`/`git` Pflicht.
+   - Web-Fetch ist kein Ersatz für MCP/`gh`/`git` bei PR-/Issue-/Repo-Hygiene.
+
+2. **Kanonische Read-Order**
+   - `agents/GEMINI.md`
+   - `agents/AGENTS.md`
+   - `knowledge/governance/CDB_CONSTITUTION.md`
+   - `knowledge/governance/CDB_GOVERNANCE.md`
+   - `knowledge/governance/CDB_AGENT_POLICY.md`
+   - `knowledge/governance/SYSTEM_INVARIANTS.md`
+   - `docs/runbooks/CONTROL_REGISTER.md`
+   - `CURRENT_STATUS.md` (nur als Repo-/Engineering-Ledger)
+   - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+
+3. **Live-Wahrheit**
+   - PR-/Issue-/Branch-/CI-Fragen müssen live per MCP oder `gh`/`git` geprüft werden.
+   - `CURRENT_STATUS.md`, Memory, alte Snapshots und Web-HTML reichen dafür nicht.
+   - Wenn Live-Tools fehlen: fail-closed stoppen.
+
+4. **Plan-Mode-Regel**
+   - Wenn Plan Mode keine Live-Kommandos oder Dateiänderungen erlaubt, darf Gemini keine operative Repo-/PR-Hygiene, keine GitHub-Writes und keine Docs-Änderungen simulieren.
+   - Dann stoppen statt Plan-Dateien schreiben.
+
+5. **Antwort-Standard**
+   Jede CDB-Antwort beginnt mit:
+   - Tool-/Skill-/Agent-/MCP-/Extensions-Check
+   - Gelesene Canon-Dateien
+   - Live-Wahrheit geprüft: ja/nein
+   - Stop-Grund, falls nein
+
+---
+
 # Gemini Agent Context (Bootstrap)
 
 Diese Datei dient als primärer Einstiegspunkt für den Gemini-Agenten im Working Repo.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -2,6 +2,21 @@
 
 1. **Tool-first Pflicht**
    - Zu Beginn jeder CDB-Aufgabe verfügbare Skills, Agents, MCP-Tools, Extensions und lokale Tools inventarisieren.
+   - Die lokale Gemini-Runtime-Fläche und die repo-kanonische CDB-Skill-Fläche sind getrennt zu prüfen.
+   - Repo-kanonische CDB Skills liegen unter:
+     - `.codex/cdb_skills/`
+     - Windows-Beispiel: `D:\Dev\Workspaces\Repos\Claire_de_Binare\.codex\cdb_skills`
+   - Falls die Umgebung lokalen Zugriff erlaubt, sind zudem folgende Pfade der lokalen Runtime zwingend zu prüfen:
+     - `C:\Users\janne\.gemini\skills`
+     - `C:\Users\janne\.gemini\extensions`
+     - `C:\Users\janne\.gemini\extensions\system-agents\system-agents`
+     - `C:\Users\janne\.gemini\extensions\system-agents\custom`
+     - `C:\Users\janne\.gemini\extensions\extension-enablement.json`
+   - Wenn einer dieser Pfade nicht zugreifbar ist, muss Gemini dies im Tool-Check offen angeben.
+   - Für CDB-Repo-/PR-/Governance-Arbeit sind besonders folgende Skills/Agents (falls verfügbar) heranzuziehen:
+     - `cdb-session-start`, `cdb-control-intake`, `cdb-ci-cd-guard`, `cdb-contract-evidence-gatekeeper`
+     - `gh-fix-ci`, `gh-address-comments`
+     - `diff-auditor`, `evidence-scout`, `scope-sentinel`, `secret-gatekeeper`, `supply-chain-watchdog`
    - Wenn die Aufgabe GitHub-/Repo-Wahrheit braucht, sind MCP oder `gh`/`git` Pflicht.
    - Web-Fetch ist kein Ersatz für MCP/`gh`/`git` bei PR-/Issue-/Repo-Hygiene.
 

--- a/agents/GEMINI.md
+++ b/agents/GEMINI.md
@@ -215,5 +215,11 @@ Es gibt **keinen Zwang** zur Issue-Erstellung am Session-Ende.
 
 ### RULES
 - Keine internen Thought-/Reasoning-Fragmente ausgeben.
+- Bei Review-/Governance-/PR-Hygiene muss Gemini passende Custom-System-Agents (falls lokal verfügbar) aktiv prüfen oder begründen, warum sie nicht verfügbar sind.
+  - `diff-auditor`: Diffs, Scope, unerwartete Dateien
+  - `evidence-scout`: Live-Evidence, GitHub/Repo-Fakten
+  - `scope-sentinel`: Scope-Grenzen, No-Go-Flächen
+  - `secret-gatekeeper`: Secrets/credential risk
+  - `supply-chain-watchdog`: Dependency-/Supply-Chain-PRs
 - Findings weiterhin strikt in MUST/SHOULD/NICE klassifizieren.
 - Kein vages Brainstorming ohne evidenzfähige Prüfung.

--- a/agents/GEMINI.md
+++ b/agents/GEMINI.md
@@ -43,6 +43,8 @@ Gemini:
 - arbeitet fakten- und regelbasiert
 - vermeidet Redesigns und Scope-Erweiterungen
 - agiert im **Solo-Maintainer Canon** (Working Repo ist SSOT)
+- **Stoppt bei fehlender Live-Wahrheit**: Bei GitHub-/PR-/Issue-Hygiene sind MCP, `gh` oder `git` Pflicht. Web-Fetch ist kein Ersatz für Governance-relevante Live-Daten.
+- **Kein "HTML-Guessing"**: Keine Ergebnisse basierend auf Web-Fetch oder HTML-Scraping, wenn operative Tools (gh/git/mcp) zwingend sind.
 
 Gemini **initiiert keine Arbeit** eigenständig, sondern wird
 ausschließlich durch **Claude (Session Lead)** hinzugezogen.
@@ -201,24 +203,17 @@ Current State: see `CURRENT_STATUS.md` (Repo/Engineering) and `docs/live-readine
 Analysiere Repository, CI-Status, offene PRs, Docs und bekannte technische Schulden.  
 Fokussiere auf Zusammenhänge, Lücken, Risiken und Optimierungspotenziale.
 
-### SESSION-END RULE (MANDATORY)
-Am Ende **jeder** Session muss **mindestens ein GitHub Issue** erstellt werden.
+### Session-End Follow-up Rule
+Es gibt **keinen Zwang** zur Issue-Erstellung am Session-Ende.
 
-**Das Issue MUSS:**
-- Einen klaren, umsetzbaren Titel haben
-- Einen prägnanten Kontext-Abschnitt enthalten
-- Konkrete Aufgaben definieren
-- Aufgaben **explizit an ANDERE Agents** zuweisen (Claude, Codex, Copilot, Docs, Governance, etc.)
-- Geeignete Labels nutzen: `analysis`, `follow-up`, `governance`, `ci`, `docs`, `agent`
-
-### ISSUE STRUCTURE (REQUIRED)
-- **Summary**
-- **Context**
-- **Tasks for other Agents** (klar nach Agent getrennt)
-- **Optional:** Risks, Dependencies, Priority
+**Regeln für Issues:**
+- Keine neuen Issues ohne expliziten Auftrag oder echtes repo-backed Follow-up.
+- Wenn kein neues Issue nötig ist: „Kein neues Issue nötig“ ausgeben.
+- Issue-Erstellung nur nach Human-GO oder bei ausdrücklicher Beauftragung.
+- Keine Self-only Tasks.
+- Keine künstlichen Follow-ups zur Erfüllung veralteter Regeln.
 
 ### RULES
-- Kein vages Brainstorming ohne Output
-- Keine Self-only Tasks
-- Falls nichts offensichtlich kaputt: **Insight-, Risk- oder Improvement-Issue** anlegen
-- Lieber mehrere kleine Issues als ein großes
+- Keine internen Thought-/Reasoning-Fragmente ausgeben.
+- Findings weiterhin strikt in MUST/SHOULD/NICE klassifizieren.
+- Kein vages Brainstorming ohne evidenzfähige Prüfung.


### PR DESCRIPTION
- Root GEMINI.md erhält CDB Gemini Bootloader.
- Tool-first Pflicht für Skills, Agents, MCP, Extensions und lokale Tools.
- GitHub-/Repo-Hygiene braucht MCP oder gh/git; Web-Fetch ist kein Ersatz.
- Plan Mode muss fail-closed stoppen, wenn Live-Kommandos oder Dateiänderungen nötig sind.
- agents/GEMINI.md entschärft alte Session-End-Issue-Pflicht.
- Keine neuen Issues ohne expliziten Auftrag oder repo-backed Follow-up.
- Scope: docs-only, keine Code-/Workflow-Änderungen.
- Restfolgefund: knowledge/SYSTEM_INVARIANTS.md enthält noch alte Session-End-Issue-Regel und braucht separaten Governance-Reconcile-Slice.