### PR TITLE
docs(governance): remove obsolete session issue invariant

### DIFF
--- a/knowledge/SYSTEM_INVARIANTS.md
+++ b/knowledge/SYSTEM_INVARIANTS.md
@@ -102,11 +102,6 @@ Ein Verstoss gegen diese Regeln bedeutet **Systembruch**.
 **Pfad:** `knowledge/`, `docs/`, `agents/`, `.github/` im Repo `Claire_de_Binare`.
 **Pruefung:** Keine Default-Navigation oder Resolver duerfen ein externes Docs Repo als Pflicht voraussetzen.
 
-### INV-052: Session Hygiene
-**Regel:** Keine Session ohne Issue-Pflege.
-**Umsetzung:** Am Session-Ende mindestens ein GitHub Issue.
-**Pruefung:** CURRENT_STATUS.md referenziert aktive Issues.
-
 ---
 
 ## Verletzungsprotokoll


### PR DESCRIPTION
- Entfernt INV-052: Session Hygiene aus knowledge/SYSTEM_INVARIANTS.md.
- Grund: Die alte Regel erzwang künstliche GitHub-Issues am Session-Ende.
- Session-End-Follow-ups werden seit PR #1950 über Bootloader und agents/GEMINI.md geregelt.
- Keine Ersatzregel hinzugefügt.
- Scope: docs-only / governance-only.
- Keine Code-/Workflow-Änderungen.
- Keine neuen Issues.
- Keine LR-/Live-/Echtgeld-Ableitung.