### PR TITLE
fix(ci): allow runbook evidence logs in docs hub guard

### DIFF
--- a/.github/workflows/docs-hub-guard.yml
+++ b/.github/workflows/docs-hub-guard.yml
@@ -22,7 +22,12 @@ jobs:
         run: |
           set -euo pipefail
           echo "Scanning for runtime artifacts..."
-          bad="$(git ls-files | grep -E '(^|/)(__pycache__/|\.pytest_cache/|.*\.pyc$|.*\.pyo$|.*\.log$|(^|/)logs/)' || true)"
+          bad="$(
+            {
+              git ls-files | grep -E '(^|/)(__pycache__/|\.pytest_cache/|.*\.pyc$|.*\.pyo$|(^|/)logs/)' || true
+              git ls-files | grep -E '.*\.log$' | grep -vE '^docs/runbooks/evidence/.*\.log$' || true
+            } | sort -u
+          )"
           if [ -n "$bad" ]; then
             echo "Found forbidden runtime artifacts tracked in git:"
             echo "$bad"


### PR DESCRIPTION
## Summary
- **Root Cause:** Docs Hub Guard blocked all `*.log` globally, including historical evidence files.
- **Affected red main run:** #25008387149
- **Fix:** Evidence logs under `docs/runbooks/evidence/` explicitly allowed via two-stage filter.
- Guard remains active for runtime artifacts: `logs/`, cache dirs, `*.pyc`, `*.pyo`, `*.log` outside evidence path.
- No evidence files deleted.
- No LR/Live/Echtgeld derivation.

## Validation
- **Allowed (not in bad):**
  - `docs/runbooks/evidence/2026-03-19_issue-639_surrealdb_restore_drill/10_backup_run.log`
  - `docs/runbooks/evidence/2026-03-19_issue-639_surrealdb_restore_drill/20_destructive_step.log`
  - `docs/runbooks/evidence/2026-03-19_issue-639_surrealdb_restore_drill/30_restore_run.log`

- **Still blocked (appear in bad):**
  - `logs/runtime.log`
  - `tmp/test.log`
  - `docs/random.log`
  - `docs/runbooks/evidence/foo/logs/runtime.log` (logs/ subdir)
  - `*.pyc`, `*.pyo`, `__pycache__/`, `.pytest_cache/`
