### PR TITLE
fix(signal): normalize market data timestamps to milliseconds

### DIFF
--- a/services/signal/models.py
+++ b/services/signal/models.py
@@ -3,8 +3,26 @@ Signal Engine - Data Models
 Datenklassen für Market-Data (signal_engine specific)
 """
 
+import time
 from dataclasses import dataclass
 from typing import Literal, Optional
+
+
+def normalize_ts_ms(ts: int | float | None) -> int:
+    """
+    Normalizes a timestamp to milliseconds.
+    - None/0 -> current wallclock ms
+    - < 4e9 -> seconds (normalized to ms)
+    - >= 4e9 -> already ms (kept as is)
+    """
+    if ts is None or ts == 0:
+        return int(time.time() * 1000)
+
+    # Threshold 4e9 covers seconds up to year 2096
+    if ts < 4_000_000_000:
+        return int(ts * 1000)
+
+    return int(ts)
 
 
 @dataclass
@@ -119,14 +137,12 @@ class MarketData:
             if isinstance(data.get("symbol"), str)
             else data["symbol"]
         )
-        timestamp = data.get("timestamp")
-        if timestamp is None:
-            timestamp = data.get("ts_ms", 0)
+        timestamp = normalize_ts_ms(data.get("timestamp") or data.get("ts_ms"))
 
         return cls(
             symbol=symbol,
             price=float(data["price"]),
-            timestamp=int(timestamp or 0),
+            timestamp=timestamp,
             schema_version=data.get("schema_version"),
             source=data.get("source"),
             trade_qty=trade_qty,

--- a/services/signal/service.py
+++ b/services/signal/service.py
@@ -473,7 +473,7 @@ class SignalEngine:
         close_now = float(market_data.close or market_data.price)
         high_now = float(market_data.high or close_now)
         low_now = float(market_data.low or close_now)
-        now_ms = int((market_data.timestamp or int(time.time())) * 1000)
+        now_ms = int(market_data.timestamp or int(time.time() * 1000))
 
         # Time-based windowing
         entry_lookback_ms = self.config.entry_lookback_minutes * 60_000

--- a/tests/unit/signal/test_normalization.py
+++ b/tests/unit/signal/test_normalization.py
@@ -1,0 +1,17 @@
+from services.signal import models as signal_models
+from services.signal.models import normalize_ts_ms
+
+
+def test_normalize_ts_ms_seconds_to_ms():
+    assert normalize_ts_ms(1713916800) == 1713916800000
+
+
+def test_normalize_ts_ms_keeps_milliseconds():
+    assert normalize_ts_ms(1713916800000) == 1713916800000
+
+
+def test_normalize_ts_ms_fallback_uses_wallclock_ms(monkeypatch):
+    monkeypatch.setattr(signal_models.time, "time", lambda: 1713916800.123)
+
+    assert normalize_ts_ms(None) == 1713916800123
+    assert normalize_ts_ms(0) == 1713916800123


### PR DESCRIPTION
## Kontext
Beim ARVP/P3 Source-Time-Integrity Audit wurde ein Timestamp-Unit-Bug im Signal-Pfad gefunden: cdb_ws liefert ts_ms bereits in Millisekunden, während cdb_signal den Wert im primary_breakout_v1-Pfad erneut mit 1000 multiplizierte.

## Änderung
- MarketData.from_dict() normalisiert timestamp/ts_ms jetzt eindeutig auf Millisekunden.
- _process_primary_breakout_v1() nutzt die bereits normalisierte Millisekunden-Zeitbasis ohne erneute Multiplikation.
- Unit-Tests decken Sekunden-, Millisekunden- und Fallback-Fälle ab.

## Scope-Grenze
- Keine Strategieparameter geändert.
- Keine Risk-/Execution-/db_writer-/cdb_ws-Änderung.
- Kein stale-event-gate.
- Keine bot_id-/Experiment-Metadata-Änderung.
- Kein Track-B-Run.
- Keine LR-/Live-/Echtgeld-Ableitung.
- #1905 bleibt parked.

## Validierung
- pytest -q tests/unit/signal/test_normalization.py tests/unit/signal/test_service.py
- git diff --check
- git diff --cached --check