### PR TITLE
feat(arvp): guard paper reference exports by signal audit context

### DIFF
--- a/core/replay/paper_reference_window_export.py
+++ b/core/replay/paper_reference_window_export.py
@@ -54,6 +54,64 @@ def _require_mapping(value: object, name: str) -> Mapping[str, Any]:
     return value
 
 
+def _optional_non_empty_string(value: object, name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise PaperReferenceExportError(f"{name} must be a string when provided")
+    stripped = value.strip()
+    if not stripped:
+        raise PaperReferenceExportError(f"{name} must be non-empty when provided")
+    return stripped
+
+
+def _optional_string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    return value.strip()
+
+
+def _require_signal_metadata(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    metadata = payload.get("metadata")
+    return _require_mapping(metadata, "payload.metadata")
+
+
+def _resolve_signal_bot_id(payload: Mapping[str, Any]) -> str:
+    payload_bot_id = _optional_string(payload.get("bot_id"))
+    if payload_bot_id:
+        return payload_bot_id
+
+    metadata = _require_signal_metadata(payload)
+    metadata_bot_id = _optional_string(metadata.get("bot_id"))
+    if metadata_bot_id:
+        return metadata_bot_id
+
+    config_snapshot = _require_mapping(
+        metadata.get("config_snapshot"), "payload.metadata.config_snapshot"
+    )
+    snapshot_bot_id = config_snapshot.get("bot_id")
+    if not isinstance(snapshot_bot_id, str):
+        raise PaperReferenceExportError(
+            "payload.metadata.config_snapshot.bot_id must be a string"
+        )
+    return snapshot_bot_id
+
+
+def _resolve_signal_config_hash(payload: Mapping[str, Any]) -> str:
+    metadata = _require_signal_metadata(payload)
+    return _require_non_empty_string(
+        metadata.get("config_hash"), "payload.metadata.config_hash"
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class SignalAnchor:
+    correlation_id: str
+    signal_id: str
+    bot_id: str
+    config_hash: str
+
+
 @dataclass(frozen=True, slots=True)
 class ExportRequest:
     strategy_id: str
@@ -63,6 +121,8 @@ class ExportRequest:
     extracted_by: str
     extracted_at_utc: str
     source_query_intent: str
+    bot_id: str | None = None
+    config_hash: str | None = None
 
 
 def build_export_request(
@@ -74,15 +134,23 @@ def build_export_request(
     extracted_by: str,
     source_query_intent: str,
     extracted_at_utc: str | None = None,
+    bot_id: str | None = None,
+    config_hash: str | None = None,
 ) -> ExportRequest:
     strategy_id = _require_non_empty_string(strategy_id, "strategy_id")
     symbol = _require_non_empty_string(symbol, "symbol").upper()
     start_ts_ms_utc = int(start_ts_ms_utc)
     end_ts_ms_utc = int(end_ts_ms_utc)
     if start_ts_ms_utc <= 0 or end_ts_ms_utc <= 0 or end_ts_ms_utc <= start_ts_ms_utc:
-        raise PaperReferenceExportError("start_ts_ms_utc and end_ts_ms_utc must define a positive window")
+        raise PaperReferenceExportError(
+            "start_ts_ms_utc and end_ts_ms_utc must define a positive window"
+        )
     extracted_by = _require_non_empty_string(extracted_by, "extracted_by")
-    source_query_intent = _require_non_empty_string(source_query_intent, "source_query_intent")
+    source_query_intent = _require_non_empty_string(
+        source_query_intent, "source_query_intent"
+    )
+    bot_id = _optional_non_empty_string(bot_id, "bot_id")
+    config_hash = _optional_non_empty_string(config_hash, "config_hash")
     if extracted_at_utc is None:
         dt = utcnow()
         if dt.tzinfo is None:
@@ -90,7 +158,9 @@ def build_export_request(
         else:
             extracted_at_utc = dt.astimezone(timezone.utc).isoformat()
     else:
-        extracted_at_utc = _require_non_empty_string(extracted_at_utc, "extracted_at_utc")
+        extracted_at_utc = _require_non_empty_string(
+            extracted_at_utc, "extracted_at_utc"
+        )
     return ExportRequest(
         strategy_id=strategy_id,
         symbol=symbol,
@@ -99,6 +169,8 @@ def build_export_request(
         extracted_by=extracted_by,
         extracted_at_utc=extracted_at_utc,
         source_query_intent=source_query_intent,
+        bot_id=bot_id,
+        config_hash=config_hash,
     )
 
 
@@ -113,27 +185,39 @@ def export_paper_reference_window(
     if not rows:
         raise PaperReferenceExportError("rows must be non-empty")
 
-    events: list[dict[str, Any]] = []
-    saw_paper_order = False
-    saw_paper_fill = False
+    all_events: list[dict[str, Any]] = []
+    signal_anchors: dict[str, SignalAnchor] = {}
 
     for idx, raw in enumerate(rows):
         row = _require_mapping(raw, f"rows[{idx}]")
         event_pk = _require_non_empty_string(row.get("event_pk"), "event_pk")
-        correlation_id = _require_non_empty_string(row.get("correlation_id"), "correlation_id")
-        event_type = _require_non_empty_string(row.get("event_type"), "event_type").upper()
+        correlation_id = _require_non_empty_string(
+            row.get("correlation_id"), "correlation_id"
+        )
+        event_type = _require_non_empty_string(
+            row.get("event_type"), "event_type"
+        ).upper()
         if event_type not in _ALLOWED_EVENT_TYPES:
-            raise PaperReferenceExportError(f"event_type must be one of {_ALLOWED_EVENT_TYPES}, got {event_type!r}")
+            raise PaperReferenceExportError(
+                f"event_type must be one of {_ALLOWED_EVENT_TYPES}, got {event_type!r}"
+            )
         symbol = _require_non_empty_string(row.get("symbol"), "symbol").upper()
         if symbol != request.symbol:
-            raise PaperReferenceExportError(f"symbol mismatch in row: expected {request.symbol!r}, got {symbol!r}")
+            raise PaperReferenceExportError(
+                f"symbol mismatch in row: expected {request.symbol!r}, got {symbol!r}"
+            )
         timestamp_ms = _require_int(row.get("timestamp_ms"), "timestamp_ms")
-        if timestamp_ms < request.start_ts_ms_utc or timestamp_ms > request.end_ts_ms_utc:
+        if (
+            timestamp_ms < request.start_ts_ms_utc
+            or timestamp_ms > request.end_ts_ms_utc
+        ):
             raise PaperReferenceExportError("timestamp_ms out of requested window")
 
         payload = row.get("payload")
         payload = {} if payload is None else _require_mapping(payload, "payload")
-        payload_strategy = _require_non_empty_string(payload.get("strategy_id"), "payload.strategy_id")
+        payload_strategy = _require_non_empty_string(
+            payload.get("strategy_id"), "payload.strategy_id"
+        )
         if payload_strategy != request.strategy_id:
             raise PaperReferenceExportError(
                 f"payload.strategy_id mismatch: expected {request.strategy_id!r}, got {payload_strategy!r}"
@@ -157,14 +241,28 @@ def export_paper_reference_window(
         if event_type == "SIGNAL":
             if "signal_id" not in ev:
                 raise PaperReferenceExportError("SIGNAL event missing signal_id")
+            anchor = SignalAnchor(
+                correlation_id=correlation_id,
+                signal_id=str(ev["signal_id"]),
+                bot_id=_resolve_signal_bot_id(payload),
+                config_hash=_resolve_signal_config_hash(payload),
+            )
+            existing = signal_anchors.get(correlation_id)
+            if existing is not None:
+                raise PaperReferenceExportError(
+                    f"correlation_id {correlation_id!r} has multiple SIGNAL anchors"
+                )
+            signal_anchors[correlation_id] = anchor
         elif event_type == "DECISION":
             if "signal_id" not in ev or "decision_id" not in ev:
-                raise PaperReferenceExportError("DECISION event missing signal_id/decision_id")
+                raise PaperReferenceExportError(
+                    "DECISION event missing signal_id/decision_id"
+                )
         elif event_type == "ORDER":
             if "signal_id" not in ev or "decision_id" not in ev or "order_id" not in ev:
-                raise PaperReferenceExportError("ORDER event missing signal_id/decision_id/order_id")
-            if str(ev["order_id"]).startswith(_PAPER_PREFIX):
-                saw_paper_order = True
+                raise PaperReferenceExportError(
+                    "ORDER event missing signal_id/decision_id/order_id"
+                )
         elif event_type == "FILL":
             if (
                 "signal_id" not in ev
@@ -172,16 +270,96 @@ def export_paper_reference_window(
                 or "order_id" not in ev
                 or "fill_id" not in ev
             ):
-                raise PaperReferenceExportError("FILL event missing signal_id/decision_id/order_id/fill_id")
-            if str(ev["order_id"]).startswith(_PAPER_PREFIX):
-                saw_paper_fill = True
+                raise PaperReferenceExportError(
+                    "FILL event missing signal_id/decision_id/order_id/fill_id"
+                )
+
+        all_events.append(ev)
+
+    if not signal_anchors:
+        raise PaperReferenceExportError(
+            "chain-integrity failed: window contains no SIGNAL anchors"
+        )
+
+    for ev in all_events:
+        if ev["event_type"] == "SIGNAL":
+            continue
+        correlation_id = str(ev["correlation_id"])
+        anchor = signal_anchors.get(correlation_id)
+        if anchor is None:
+            raise PaperReferenceExportError(
+                f"chain-integrity failed: missing SIGNAL anchor for correlation_id {correlation_id!r}"
+            )
+        event_signal_id = _require_non_empty_string(
+            ev.get("signal_id"), f"events[{correlation_id}].signal_id"
+        )
+        if event_signal_id != anchor.signal_id:
+            raise PaperReferenceExportError(
+                "chain-integrity failed: event signal_id does not match SIGNAL anchor "
+                f"for correlation_id {correlation_id!r}"
+            )
+
+    selected_correlation_ids: set[str] = set()
+    for correlation_id, anchor in signal_anchors.items():
+        if request.bot_id is not None and anchor.bot_id != request.bot_id:
+            continue
+        if (
+            request.config_hash is not None
+            and anchor.config_hash != request.config_hash
+        ):
+            continue
+        selected_correlation_ids.add(correlation_id)
+
+    if request.bot_id is not None or request.config_hash is not None:
+        if not selected_correlation_ids:
+            raise PaperReferenceExportError(
+                "no SIGNAL anchors matched requested bot_id/config_hash filters"
+            )
+    else:
+        selected_correlation_ids = set(signal_anchors)
+
+    events: list[dict[str, Any]] = []
+    saw_paper_order = False
+    saw_paper_fill = False
+    selected_bot_ids: set[str] = set()
+    selected_config_hashes: set[str] = set()
+
+    for correlation_id in selected_correlation_ids:
+        anchor = signal_anchors[correlation_id]
+        selected_bot_ids.add(anchor.bot_id)
+        selected_config_hashes.add(anchor.config_hash)
+
+    for ev in all_events:
+        correlation_id = str(ev["correlation_id"])
+        if correlation_id not in selected_correlation_ids:
+            continue
+
+        if ev["event_type"] == "ORDER" and str(ev["order_id"]).startswith(
+            _PAPER_PREFIX
+        ):
+            saw_paper_order = True
+        if ev["event_type"] == "FILL" and str(ev["order_id"]).startswith(_PAPER_PREFIX):
+            saw_paper_fill = True
 
         events.append(ev)
 
+    if len(selected_bot_ids) != 1:
+        raise PaperReferenceExportError(
+            "homogeneity guard failed: mixed bot_id across SIGNAL anchors in export window"
+        )
+    if len(selected_config_hashes) != 1:
+        raise PaperReferenceExportError(
+            "homogeneity guard failed: mixed metadata.config_hash across SIGNAL anchors in export window"
+        )
+
     if not saw_paper_order:
-        raise PaperReferenceExportError("paper qualification failed: no ORDER with paper_ prefix")
+        raise PaperReferenceExportError(
+            "paper qualification failed: no ORDER with paper_ prefix"
+        )
     if not saw_paper_fill:
-        raise PaperReferenceExportError("paper qualification failed: no FILL with paper_ prefix")
+        raise PaperReferenceExportError(
+            "paper qualification failed: no FILL with paper_ prefix"
+        )
 
     events.sort(key=lambda e: (int(e["timestamp_ms"]), str(e["event_pk"])))
 
@@ -197,7 +375,3 @@ def export_paper_reference_window(
         "extracted_by": request.extracted_by,
         "events": events,
     }
-
-
-
-

--- a/core/replay/paper_reference_window_export.py
+++ b/core/replay/paper_reference_window_export.py
@@ -94,7 +94,7 @@ def _resolve_signal_bot_id(payload: Mapping[str, Any]) -> str:
         raise PaperReferenceExportError(
             "payload.metadata.config_snapshot.bot_id must be a string"
         )
-    return snapshot_bot_id
+    return snapshot_bot_id.strip()
 
 
 def _resolve_signal_config_hash(payload: Mapping[str, Any]) -> str:

--- a/services/validation/paper_reference_window_runner.py
+++ b/services/validation/paper_reference_window_runner.py
@@ -35,6 +35,14 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     p.add_argument("--start-ts-ms", required=True, type=int)
     p.add_argument("--end-ts-ms", required=True, type=int)
     p.add_argument(
+        "--bot-id",
+        help="Optional bot_id filter applied via SIGNAL anchor metadata.",
+    )
+    p.add_argument(
+        "--config-hash",
+        help="Optional config_hash filter applied via SIGNAL anchor metadata.",
+    )
+    p.add_argument(
         "--output",
         default="artifacts/paper_reference_windows/paper_reference_window.json",
         help="Output path for paper_reference_window JSON.",
@@ -45,6 +53,21 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         help="Extractor identifier (non-empty).",
     )
     return p.parse_args(argv)
+
+
+def _build_source_query_intent(args: argparse.Namespace) -> str:
+    qualifiers = [
+        "select correlation_ledger events by symbol+timestamp_ms window",
+        "validate payload.strategy_id",
+        "resolve bot_id/config_hash via SIGNAL anchors",
+        "enforce homogeneity+chain-integrity fail-closed",
+        "qualify paper via order_id prefix",
+    ]
+    if args.bot_id:
+        qualifiers.append(f"filter bot_id={args.bot_id}")
+    if args.config_hash:
+        qualifiers.append(f"filter config_hash={args.config_hash}")
+    return "; ".join(qualifiers)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -65,7 +88,9 @@ def main(argv: list[str] | None = None) -> int:
             start_ts_ms_utc=int(args.start_ts_ms),
             end_ts_ms_utc=int(args.end_ts_ms),
             extracted_by=str(args.extracted_by),
-            source_query_intent="select correlation_ledger events by symbol+timestamp_ms window; qualify paper via order_id prefix; validate payload.strategy_id",
+            source_query_intent=_build_source_query_intent(args),
+            bot_id=str(args.bot_id) if args.bot_id is not None else None,
+            config_hash=str(args.config_hash) if args.config_hash is not None else None,
         )
 
         conn = create_postgres_connection()
@@ -109,11 +134,11 @@ def main(argv: list[str] | None = None) -> int:
     print(
         "OK: paper_reference_window exported "
         f"(strategy_id={request.strategy_id}, symbol={request.symbol}, "
-        f"window=[{request.start_ts_ms_utc},{request.end_ts_ms_utc}])"
+        f"window=[{request.start_ts_ms_utc},{request.end_ts_ms_utc}], "
+        f"bot_id={request.bot_id or '*'}, config_hash={request.config_hash or '*'})"
     )
     return 0
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tests/unit/replay/test_paper_reference_window_export.py
+++ b/tests/unit/replay/test_paper_reference_window_export.py
@@ -489,6 +489,70 @@ def test_filters_export_by_bot_id_only() -> None:
     ]
 
 
+def test_filters_export_by_trimmed_config_snapshot_bot_id_fallback() -> None:
+    request = build_export_request(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        start_ts_ms_utc=1000,
+        end_ts_ms_utc=2000,
+        extracted_by="unit-test",
+        extracted_at_utc="2026-04-24T00:00:00+00:00",
+        source_query_intent="unit-test",
+        bot_id="bot-a",
+    )
+    rows = [
+        _signal_row(
+            event_pk="sig-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1100,
+            bot_id="bot-a",
+            config_hash="cfg-a",
+        ),
+        _order_row(
+            event_pk="ord-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1200,
+        ),
+        _fill_row(
+            event_pk="fill-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1300,
+        ),
+        _signal_row(
+            event_pk="sig-b",
+            correlation_id="c2",
+            signal_id="sig2",
+            timestamp_ms=1400,
+            bot_id="bot-b",
+            config_hash="cfg-a",
+        ),
+    ]
+    rows[0]["payload"].pop("bot_id")
+    rows[0]["payload"]["metadata"].pop("bot_id")
+    rows[0]["payload"]["metadata"]["config_snapshot"]["bot_id"] = "  bot-a  "
+
+    payload = export_paper_reference_window(request=request, rows=rows)
+
+    assert [event["correlation_id"] for event in payload["events"]] == [
+        "c1",
+        "c1",
+        "c1",
+    ]
+    assert [event["event_type"] for event in payload["events"]] == [
+        "SIGNAL",
+        "ORDER",
+        "FILL",
+    ]
+
+
 def test_filters_export_by_config_hash_only() -> None:
     request = build_export_request(
         strategy_id="primary_breakout_v1",

--- a/tests/unit/replay/test_paper_reference_window_export.py
+++ b/tests/unit/replay/test_paper_reference_window_export.py
@@ -23,45 +23,129 @@ def _req():
     )
 
 
+def _signal_payload(
+    *,
+    strategy_id: str = "primary_breakout_v1",
+    bot_id: str = "bot-a",
+    config_hash: str = "cfg-a",
+) -> dict:
+    return {
+        "strategy_id": strategy_id,
+        "bot_id": bot_id,
+        "metadata": {
+            "bot_id": bot_id,
+            "config_hash": config_hash,
+            "config_snapshot": {
+                "strategy_id": strategy_id,
+                "bot_id": bot_id,
+            },
+        },
+    }
+
+
+def _signal_row(
+    *,
+    event_pk: str,
+    correlation_id: str,
+    signal_id: str,
+    timestamp_ms: int,
+    strategy_id: str = "primary_breakout_v1",
+    bot_id: str = "bot-a",
+    config_hash: str = "cfg-a",
+) -> dict:
+    return {
+        "event_pk": event_pk,
+        "correlation_id": correlation_id,
+        "signal_id": signal_id,
+        "decision_id": None,
+        "order_id": None,
+        "fill_id": None,
+        "event_type": "SIGNAL",
+        "symbol": "BTCUSDT",
+        "timestamp_ms": timestamp_ms,
+        "payload": _signal_payload(
+            strategy_id=strategy_id,
+            bot_id=bot_id,
+            config_hash=config_hash,
+        ),
+    }
+
+
+def _order_row(
+    *,
+    event_pk: str,
+    correlation_id: str,
+    signal_id: str,
+    decision_id: str,
+    order_id: str,
+    timestamp_ms: int,
+    strategy_id: str = "primary_breakout_v1",
+) -> dict:
+    return {
+        "event_pk": event_pk,
+        "correlation_id": correlation_id,
+        "signal_id": signal_id,
+        "decision_id": decision_id,
+        "order_id": order_id,
+        "fill_id": None,
+        "event_type": "ORDER",
+        "symbol": "BTCUSDT",
+        "timestamp_ms": timestamp_ms,
+        "payload": {"strategy_id": strategy_id},
+    }
+
+
+def _fill_row(
+    *,
+    event_pk: str,
+    correlation_id: str,
+    signal_id: str,
+    decision_id: str,
+    order_id: str,
+    fill_id: str,
+    timestamp_ms: int,
+    strategy_id: str = "primary_breakout_v1",
+) -> dict:
+    return {
+        "event_pk": event_pk,
+        "correlation_id": correlation_id,
+        "signal_id": signal_id,
+        "decision_id": decision_id,
+        "order_id": order_id,
+        "fill_id": fill_id,
+        "event_type": "FILL",
+        "symbol": "BTCUSDT",
+        "timestamp_ms": timestamp_ms,
+        "payload": {"strategy_id": strategy_id},
+    }
+
+
 def test_exports_sorted_events_and_requires_paper_order_fill() -> None:
     request = _req()
     rows = [
-        {
-            "event_pk": "b",
-            "correlation_id": "c1",
-            "signal_id": "sig1",
-            "decision_id": None,
-            "order_id": None,
-            "fill_id": None,
-            "event_type": "SIGNAL",
-            "symbol": "BTCUSDT",
-            "timestamp_ms": 1500,
-            "payload": {"strategy_id": "primary_breakout_v1"},
-        },
-        {
-            "event_pk": "a",
-            "correlation_id": "c1",
-            "signal_id": "sig1",
-            "decision_id": "dec1",
-            "order_id": "paper_001",
-            "fill_id": None,
-            "event_type": "ORDER",
-            "symbol": "BTCUSDT",
-            "timestamp_ms": 1400,
-            "payload": {"strategy_id": "primary_breakout_v1"},
-        },
-        {
-            "event_pk": "c",
-            "correlation_id": "c1",
-            "signal_id": "sig1",
-            "decision_id": "dec1",
-            "order_id": "paper_001",
-            "fill_id": "fill1",
-            "event_type": "FILL",
-            "symbol": "BTCUSDT",
-            "timestamp_ms": 1600,
-            "payload": {"strategy_id": "primary_breakout_v1"},
-        },
+        _signal_row(
+            event_pk="b",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1500,
+        ),
+        _order_row(
+            event_pk="a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1400,
+        ),
+        _fill_row(
+            event_pk="c",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1600,
+        ),
     ]
     payload = export_paper_reference_window(request=request, rows=rows)
     assert payload["contract_version"] == "arvp_paper_reference_window.v1"
@@ -73,18 +157,20 @@ def test_exports_sorted_events_and_requires_paper_order_fill() -> None:
 def test_fails_closed_when_no_paper_fill() -> None:
     request = _req()
     rows = [
-        {
-            "event_pk": "a",
-            "correlation_id": "c1",
-            "signal_id": "sig1",
-            "decision_id": "dec1",
-            "order_id": "paper_001",
-            "fill_id": None,
-            "event_type": "ORDER",
-            "symbol": "BTCUSDT",
-            "timestamp_ms": 1400,
-            "payload": {"strategy_id": "primary_breakout_v1"},
-        }
+        _signal_row(
+            event_pk="sig",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1300,
+        ),
+        _order_row(
+            event_pk="a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1400,
+        ),
     ]
     with pytest.raises(PaperReferenceExportError, match="no FILL"):
         export_paper_reference_window(request=request, rows=rows)
@@ -93,19 +179,372 @@ def test_fails_closed_when_no_paper_fill() -> None:
 def test_fails_closed_on_strategy_mismatch() -> None:
     request = _req()
     rows = [
-        {
-            "event_pk": "a",
-            "correlation_id": "c1",
-            "signal_id": "sig1",
-            "decision_id": "dec1",
-            "order_id": "paper_001",
-            "fill_id": "fill1",
-            "event_type": "FILL",
-            "symbol": "BTCUSDT",
-            "timestamp_ms": 1500,
-            "payload": {"strategy_id": "other"},
-        }
+        _signal_row(
+            event_pk="sig",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1400,
+        ),
+        _fill_row(
+            event_pk="a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1500,
+            strategy_id="other",
+        ),
     ]
-    with pytest.raises(PaperReferenceExportError, match="payload\\.strategy_id mismatch"):
+    with pytest.raises(
+        PaperReferenceExportError, match="payload\\.strategy_id mismatch"
+    ):
         export_paper_reference_window(request=request, rows=rows)
 
+
+def test_fails_closed_on_mixed_config_hash() -> None:
+    request = _req()
+    rows = [
+        _signal_row(
+            event_pk="sig-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1100,
+            config_hash="cfg-a",
+        ),
+        _order_row(
+            event_pk="ord-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1200,
+        ),
+        _fill_row(
+            event_pk="fill-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1300,
+        ),
+        _signal_row(
+            event_pk="sig-b",
+            correlation_id="c2",
+            signal_id="sig2",
+            timestamp_ms=1400,
+            config_hash="cfg-b",
+        ),
+    ]
+    with pytest.raises(PaperReferenceExportError, match="mixed metadata\\.config_hash"):
+        export_paper_reference_window(request=request, rows=rows)
+
+
+def test_fails_closed_on_mixed_bot_id() -> None:
+    request = _req()
+    rows = [
+        _signal_row(
+            event_pk="sig-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1100,
+            bot_id="bot-a",
+        ),
+        _order_row(
+            event_pk="ord-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1200,
+        ),
+        _fill_row(
+            event_pk="fill-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1300,
+        ),
+        _signal_row(
+            event_pk="sig-b",
+            correlation_id="c2",
+            signal_id="sig2",
+            timestamp_ms=1400,
+            bot_id="bot-b",
+        ),
+    ]
+    with pytest.raises(PaperReferenceExportError, match="mixed bot_id"):
+        export_paper_reference_window(request=request, rows=rows)
+
+
+def test_fails_closed_when_signal_config_hash_missing() -> None:
+    request = _req()
+    rows = [
+        _signal_row(
+            event_pk="sig-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1100,
+        ),
+        _order_row(
+            event_pk="ord-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1200,
+        ),
+        _fill_row(
+            event_pk="fill-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1300,
+        ),
+    ]
+    rows[0]["payload"]["metadata"].pop("config_hash")
+
+    with pytest.raises(
+        PaperReferenceExportError, match="payload\\.metadata\\.config_hash"
+    ):
+        export_paper_reference_window(request=request, rows=rows)
+
+
+def test_fails_closed_when_order_chain_has_no_signal_anchor() -> None:
+    request = _req()
+    rows = [
+        _order_row(
+            event_pk="ord-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1200,
+        ),
+        _fill_row(
+            event_pk="fill-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1300,
+        ),
+    ]
+    with pytest.raises(PaperReferenceExportError, match="no SIGNAL anchors"):
+        export_paper_reference_window(request=request, rows=rows)
+
+
+def test_fails_closed_when_chain_signal_id_mismatches_anchor() -> None:
+    request = _req()
+    rows = [
+        _signal_row(
+            event_pk="sig-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1100,
+        ),
+        _order_row(
+            event_pk="ord-a",
+            correlation_id="c1",
+            signal_id="sig-X",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1200,
+        ),
+        _fill_row(
+            event_pk="fill-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1300,
+        ),
+    ]
+    with pytest.raises(PaperReferenceExportError, match="does not match SIGNAL anchor"):
+        export_paper_reference_window(request=request, rows=rows)
+
+
+def test_filters_export_by_config_hash_and_bot_id() -> None:
+    request = build_export_request(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        start_ts_ms_utc=1000,
+        end_ts_ms_utc=2000,
+        extracted_by="unit-test",
+        extracted_at_utc="2026-04-24T00:00:00+00:00",
+        source_query_intent="unit-test",
+        bot_id="bot-a",
+        config_hash="cfg-a",
+    )
+    rows = [
+        _signal_row(
+            event_pk="sig-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1100,
+            bot_id="bot-a",
+            config_hash="cfg-a",
+        ),
+        _order_row(
+            event_pk="ord-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1200,
+        ),
+        _fill_row(
+            event_pk="fill-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1300,
+        ),
+        _signal_row(
+            event_pk="sig-b",
+            correlation_id="c2",
+            signal_id="sig2",
+            timestamp_ms=1400,
+            bot_id="bot-b",
+            config_hash="cfg-b",
+        ),
+    ]
+
+    payload = export_paper_reference_window(request=request, rows=rows)
+
+    assert [event["correlation_id"] for event in payload["events"]] == [
+        "c1",
+        "c1",
+        "c1",
+    ]
+
+
+def test_filters_export_by_bot_id_only() -> None:
+    request = build_export_request(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        start_ts_ms_utc=1000,
+        end_ts_ms_utc=2000,
+        extracted_by="unit-test",
+        extracted_at_utc="2026-04-24T00:00:00+00:00",
+        source_query_intent="unit-test",
+        bot_id="bot-a",
+    )
+    rows = [
+        _signal_row(
+            event_pk="sig-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1100,
+            bot_id="bot-a",
+            config_hash="cfg-a",
+        ),
+        _order_row(
+            event_pk="ord-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1200,
+        ),
+        _fill_row(
+            event_pk="fill-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1300,
+        ),
+        _signal_row(
+            event_pk="sig-b",
+            correlation_id="c2",
+            signal_id="sig2",
+            timestamp_ms=1400,
+            bot_id="bot-b",
+            config_hash="cfg-a",
+        ),
+    ]
+
+    payload = export_paper_reference_window(request=request, rows=rows)
+
+    assert [event["correlation_id"] for event in payload["events"]] == [
+        "c1",
+        "c1",
+        "c1",
+    ]
+    assert [event["event_type"] for event in payload["events"]] == [
+        "SIGNAL",
+        "ORDER",
+        "FILL",
+    ]
+
+
+def test_filters_export_by_config_hash_only() -> None:
+    request = build_export_request(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        start_ts_ms_utc=1000,
+        end_ts_ms_utc=2000,
+        extracted_by="unit-test",
+        extracted_at_utc="2026-04-24T00:00:00+00:00",
+        source_query_intent="unit-test",
+        config_hash="cfg-a",
+    )
+    rows = [
+        _signal_row(
+            event_pk="sig-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1100,
+            bot_id="bot-a",
+            config_hash="cfg-a",
+        ),
+        _order_row(
+            event_pk="ord-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1200,
+        ),
+        _fill_row(
+            event_pk="fill-a",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1300,
+        ),
+        _signal_row(
+            event_pk="sig-b",
+            correlation_id="c2",
+            signal_id="sig2",
+            timestamp_ms=1400,
+            bot_id="bot-a",
+            config_hash="cfg-b",
+        ),
+    ]
+
+    payload = export_paper_reference_window(request=request, rows=rows)
+
+    assert [event["correlation_id"] for event in payload["events"]] == [
+        "c1",
+        "c1",
+        "c1",
+    ]
+    assert [event["event_type"] for event in payload["events"]] == [
+        "SIGNAL",
+        "ORDER",
+        "FILL",
+    ]


### PR DESCRIPTION
## Kontext
#1974 Phase 2: Nach PR #2129 tragen SIGNAL-Events `metadata.config_snapshot` und `metadata.config_hash`. Der Paper Reference Exporter war weiterhin der Chokepoint, an dem Standard-P1 und Calibration-Px Evidence versehentlich gemischt werden konnten.

## Änderung
- `paper_reference_window_runner.py` unterstützt optionale Filter:
  - `--bot-id`
  - `--config-hash`
- Paper Reference Exporter bildet SIGNAL-Anker je Chain.
- ORDER/FILL/DECISION Events müssen eindeutig auf einen SIGNAL-Anker rückführbar sein.
- Export fail-closed bei:
  - mixed `config_hash`
  - mixed `bot_id`
  - fehlendem SIGNAL-Anker
  - fehlendem `metadata.config_hash`
  - signal_id-Mismatch innerhalb einer Chain
- Filter werden auf SIGNAL-Anker angewendet, nicht naiv auf jede Event-Row.

## Scope-Grenze
- Keine DB-Migration.
- Keine Compare-/Calibration-Änderung.
- Keine Risk-/Execution-/Signal-Runtime-Änderung.
- Kein P3-Restart.
- Kein Track-B-Run.
- Kein #1905-Unpark.
- Keine LR-/Live-/Echtgeld-Ableitung.

## Validierung
- `pytest -q tests/unit/replay/test_paper_reference_window_export.py`
- `pytest -q tests/unit/signal/test_metadata.py tests/unit/signal/test_service.py tests/unit/signal/test_compose_red.py`
- `git diff --check`
- `git diff --cached --check`