### PR TITLE
feat(paper): gate paper evidence probe mode for chain generation (#2141)

### DIFF
--- a/core/utils/paper_probe_toggle.py
+++ b/core/utils/paper_probe_toggle.py
@@ -1,0 +1,26 @@
+"""
+Paper Evidence Probe Toggle.
+
+Aktiviert die Paper-Evidence-Probe, wenn BEIDE Bedingungen erfuellt sind:
+  - PAPER_EVIDENCE_PROBE_MODE=1
+  - MOCK_TRADING=true
+
+Dual-Guard: Kann nicht ohne explizite Paper/Mock-Konfiguration aktiviert werden.
+Betrifft ausschliesslich Paper-Betrieb; nie fuer Live-/Echtgeld-Pfade.
+
+Governance: Issue #2141 / Phase 3
+Default: OFF (0). Alle Probe-Bypasses MUESSEN hinter dieser Funktion stehen.
+
+Liest os.getenv bei jedem Aufruf (kein Modul-Level-Cache),
+damit Tests via monkeypatch.setenv umschalten koennen.
+"""
+
+import os
+
+
+def paper_evidence_probe_enabled() -> bool:
+    """True nur wenn PAPER_EVIDENCE_PROBE_MODE=1 UND MOCK_TRADING=true."""
+    return (
+        os.getenv("PAPER_EVIDENCE_PROBE_MODE", "0") == "1"
+        and os.getenv("MOCK_TRADING", "false").lower() == "true"
+    )

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -49,6 +49,7 @@ from core.utils.clock import utcnow
 from core.utils.redis_payload import sanitize_payload
 from core.utils.redis_client import create_redis_client
 from core.utils.trace_toggle import trace_contract_v1_enabled, allow_evidence_debt
+from core.utils.paper_probe_toggle import paper_evidence_probe_enabled
 
 if TYPE_CHECKING:
     from core.replay.publisher import EnvelopePublisher
@@ -349,7 +350,8 @@ def decide_trade(
     if regime_id is None or regime_id not in {0, 1, 2, 3}:
         return DECISION_BLOCK, RC_001, evidence
     if regime_id in {2, 3}:
-        return DECISION_BLOCK, RC_001, evidence
+        if not paper_evidence_probe_enabled():
+            return DECISION_BLOCK, RC_001, evidence
 
     # 4) Signal
     if symbol is None or symbol == "" or pct_change_15m is None or volume_15m is None:
@@ -358,15 +360,22 @@ def decide_trade(
         pct_change_15m < DECISION_THRESHOLDS["signal_pct_change_15m_min"]
         or volume_15m < DECISION_THRESHOLDS["signal_volume_15m_min"]
     ):
-        return DECISION_BLOCK, RC_010, evidence
+        if not paper_evidence_probe_enabled():
+            return DECISION_BLOCK, RC_010, evidence
 
     # 5) Portfolio/Execution
     if daily_drawdown_pct is None:
-        return DECISION_BLOCK, RC_020, evidence
+        if paper_evidence_probe_enabled():
+            daily_drawdown_pct = 0.0
+        else:
+            return DECISION_BLOCK, RC_020, evidence
     if daily_drawdown_pct >= DECISION_THRESHOLDS["daily_drawdown_pct_max"]:
         return DECISION_BLOCK, RC_020, evidence
     if total_exposure_pct is None:
-        return DECISION_BLOCK, RC_021, evidence
+        if paper_evidence_probe_enabled():
+            total_exposure_pct = 0.0
+        else:
+            return DECISION_BLOCK, RC_021, evidence
     if total_exposure_pct >= DECISION_THRESHOLDS["total_exposure_pct_max"]:
         return DECISION_BLOCK, RC_021, evidence
     # RC_022: Slippage check - skip ONLY if market_health not available
@@ -1761,10 +1770,11 @@ class RiskManager:
         if risk_off_active and not self._is_reduce_only_allowed(signal):
             # Early-Live exception: allow small allocations despite risk_off
             if not self._is_early_live_exception(signal.strategy_id):
-                logger.warning("Signal blockiert: Risk-Off Reduce-Only")
-                stats["orders_blocked"] += 1
-                risk_state.signals_blocked += 1
-                return None
+                if not paper_evidence_probe_enabled():
+                    logger.warning("Signal blockiert: Risk-Off Reduce-Only")
+                    stats["orders_blocked"] += 1
+                    risk_state.signals_blocked += 1
+                    return None
 
         # Layer 1: Circuit Breaker
         ok, reason = self.check_drawdown_limit()

--- a/services/signal/service.py
+++ b/services/signal/service.py
@@ -38,6 +38,7 @@ from core.utils.uuid_gen import (
     compute_event_pk,
 )
 from core.contracts import PRIMARY_BREAKOUT_V1_STRATEGY_ID
+from core.utils.paper_probe_toggle import paper_evidence_probe_enabled
 from core.contracts.external_adapter_contracts import (
     StrategyAdapterRequest,
     StrategyAdapterResponse,
@@ -588,7 +589,7 @@ class SignalEngine:
         if not regime_fresh and "regime_fresh" in raw_data:
             regime_fresh = _as_bool(raw_data["regime_fresh"])
 
-        has_trend_regime = regime_id in {0, "TREND"}
+        has_trend_regime = regime_id in {0, "TREND"} or paper_evidence_probe_enabled()
         entry_blocked = any(
             _as_bool(raw_data.get(name))
             or _as_bool(market_state.get(name))

--- a/tests/unit/risk/test_paper_probe_decide_trade.py
+++ b/tests/unit/risk/test_paper_probe_decide_trade.py
@@ -1,0 +1,284 @@
+"""
+Unit-Tests fuer decide_trade() Paper Evidence Probe Bypasses.
+
+Verifies:
+- Probe OFF: RC_001/010/020/021 block as normal
+- Probe ON:  RC_001/010/020/021 allow through
+- Probe ON:  RC_002/003/004 still enforce (never bypassed)
+- Probe ON:  threshold limits still enforce (values too high still block)
+
+Governance: Issue #2141 / Phase 3
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repo root is on sys.path
+repo_root = Path(__file__).resolve().parents[3]
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+
+risk_service = importlib.import_module("services.risk.service")
+decide_trade = risk_service.decide_trade
+
+DECISION_ALLOW = risk_service.DECISION_ALLOW
+DECISION_BLOCK = risk_service.DECISION_BLOCK
+
+# Reason-code constants
+RC_001 = "RC_001"
+RC_002 = "RC_002"
+RC_003 = "RC_003"
+RC_004 = "RC_004"
+RC_010 = "RC_010"
+RC_020 = "RC_020"
+RC_021 = "RC_021"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+NOW_MS = 1_700_000_000_000  # Fixed reference timestamp
+
+
+@pytest.fixture
+def probe_on(monkeypatch):
+    """Activate the paper evidence probe (both guards)."""
+    monkeypatch.setenv("PAPER_EVIDENCE_PROBE_MODE", "1")
+    monkeypatch.setenv("MOCK_TRADING", "true")
+
+
+@pytest.fixture
+def probe_off(monkeypatch):
+    """Ensure the paper evidence probe is OFF (default)."""
+    monkeypatch.delenv("PAPER_EVIDENCE_PROBE_MODE", raising=False)
+    monkeypatch.delenv("MOCK_TRADING", raising=False)
+
+
+def _base_signal(now_ms=NOW_MS, pct_change_15m=0.5, volume_15m=0.01):
+    """Minimal signal dict — values intentionally below RC_010 thresholds."""
+    return {
+        "signal_id": "sig-probe-test-001",
+        "symbol": "BTCUSDT",
+        "pct_change_15m": pct_change_15m,
+        "volume_15m": volume_15m,
+        "ts_ms": now_ms - 500,
+    }
+
+
+def _base_market_state(now_ms=NOW_MS, regime_id=2):
+    """Market state with regime=2 (HIGH_VOL_CHAOTIC) and healthy return/price values."""
+    return {
+        "regime_id": regime_id,
+        "return_1m": 0.3,
+        "return_5m": 0.5,
+        "price_change_5m": 0.5,
+        "ts_ms": now_ms - 500,
+        "last_tick_ts_ms": now_ms - 500,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Probe OFF — baseline blocking behaviour unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDecideTradeProbeOff:
+    def test_rc001_blocks_when_regime_2(self, probe_off):
+        """RC_001: regime=2 blocks when probe is OFF."""
+        decision, reason, _ = decide_trade(
+            signal=_base_signal(),
+            market_state=_base_market_state(regime_id=2),
+            account_state=None,
+            market_health=None,
+            now_ms=NOW_MS,
+        )
+        assert decision == DECISION_BLOCK
+        assert reason == RC_001
+
+    def test_rc001_blocks_when_regime_3(self, probe_off):
+        """RC_001: regime=3 blocks when probe is OFF."""
+        decision, reason, _ = decide_trade(
+            signal=_base_signal(),
+            market_state=_base_market_state(regime_id=3),
+            account_state=None,
+            market_health=None,
+            now_ms=NOW_MS,
+        )
+        assert decision == DECISION_BLOCK
+        assert reason == RC_001
+
+
+# ---------------------------------------------------------------------------
+# Probe ON — RC_001 bypassed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDecideTradeProbeOnRegime:
+    def test_probe_bypasses_rc001_regime_2(self, probe_on):
+        """Probe ON: regime=2 does not produce RC_001 block."""
+        decision, reason, _ = decide_trade(
+            signal=_base_signal(),
+            market_state=_base_market_state(regime_id=2),
+            account_state=None,
+            market_health=None,
+            now_ms=NOW_MS,
+        )
+        # RC_001 is bypassed; chain proceeds to ALLOW (RC_020/021 defaulted to 0.0)
+        assert decision == DECISION_ALLOW
+        assert reason is None
+
+    def test_probe_bypasses_rc001_regime_3(self, probe_on):
+        """Probe ON: regime=3 does not produce RC_001 block."""
+        decision, reason, _ = decide_trade(
+            signal=_base_signal(),
+            market_state=_base_market_state(regime_id=3),
+            account_state=None,
+            market_health=None,
+            now_ms=NOW_MS,
+        )
+        assert decision == DECISION_ALLOW
+        assert reason is None
+
+
+# ---------------------------------------------------------------------------
+# Probe ON — RC_010 bypassed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDecideTradeProbeOnSignal:
+    def test_probe_bypasses_rc010_low_pct_change(self, probe_on):
+        """Probe ON: pct_change_15m below threshold does not produce RC_010 block."""
+        decision, reason, _ = decide_trade(
+            signal=_base_signal(pct_change_15m=0.001),  # << 3.0 threshold
+            market_state=_base_market_state(regime_id=0),  # regime OK
+            account_state=None,
+            market_health=None,
+            now_ms=NOW_MS,
+        )
+        assert decision == DECISION_ALLOW
+        assert reason is None
+
+    def test_probe_bypasses_rc010_low_volume(self, probe_on):
+        """Probe ON: volume_15m below threshold does not produce RC_010 block."""
+        decision, reason, _ = decide_trade(
+            signal=_base_signal(volume_15m=0.0001),  # << 0.165 threshold
+            market_state=_base_market_state(regime_id=0),
+            account_state=None,
+            market_health=None,
+            now_ms=NOW_MS,
+        )
+        assert decision == DECISION_ALLOW
+        assert reason is None
+
+
+# ---------------------------------------------------------------------------
+# Probe ON — RC_020/021 None defaults
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDecideTradeProbeOnAccountState:
+    def test_probe_defaults_daily_drawdown_none(self, probe_on):
+        """Probe ON: daily_drawdown_pct=None is defaulted to 0.0, not blocked."""
+        # account_state=None → daily_drawdown_pct=None → defaulted to 0.0 in probe
+        decision, reason, _ = decide_trade(
+            signal=_base_signal(),
+            market_state=_base_market_state(regime_id=2),
+            account_state=None,
+            market_health=None,
+            now_ms=NOW_MS,
+        )
+        assert decision == DECISION_ALLOW
+        assert reason is None
+
+    def test_probe_defaults_total_exposure_none(self, probe_on):
+        """Probe ON: total_exposure_pct=None is defaulted to 0.0, not blocked."""
+        account_state = {
+            "daily_drawdown_pct": 0.5,
+            "total_exposure_pct": None,  # explicitly None
+            "ts_ms": NOW_MS - 500,
+        }
+        decision, reason, _ = decide_trade(
+            signal=_base_signal(),
+            market_state=_base_market_state(regime_id=2),
+            account_state=account_state,
+            market_health=None,
+            now_ms=NOW_MS,
+        )
+        assert decision == DECISION_ALLOW
+        assert reason is None
+
+
+# ---------------------------------------------------------------------------
+# Probe ON — safety/freshness gates still enforced
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDecideTradeProbeOnSafetyGatesStillEnforced:
+    def test_rc002_still_blocks_when_return_1m_none(self, probe_on):
+        """RC_002 is never bypassed: return_1m=None still blocks."""
+        market_state = _base_market_state(regime_id=2)
+        market_state["return_1m"] = None
+        decision, reason, _ = decide_trade(
+            signal=_base_signal(),
+            market_state=market_state,
+            account_state=None,
+            market_health=None,
+            now_ms=NOW_MS,
+        )
+        assert decision == DECISION_BLOCK
+        assert reason == RC_002
+
+    def test_rc003_still_blocks_when_staleness_exceeded(self, probe_on):
+        """RC_003 is never bypassed: stale signal still blocks."""
+        stale_now_ms = NOW_MS + 10_000  # signal is 10s old, limit is 5s
+        decision, reason, _ = decide_trade(
+            signal=_base_signal(now_ms=NOW_MS),
+            market_state=_base_market_state(regime_id=2, now_ms=NOW_MS),
+            account_state=None,
+            market_health=None,
+            now_ms=stale_now_ms,
+        )
+        assert decision == DECISION_BLOCK
+        assert reason == RC_003
+
+    def test_rc020_limit_still_enforced(self, probe_on):
+        """RC_020 limit still blocks when daily_drawdown_pct >= 5%."""
+        account_state = {
+            "daily_drawdown_pct": 6.0,  # > 5.0 threshold
+            "total_exposure_pct": 10.0,
+            "ts_ms": NOW_MS - 500,
+        }
+        decision, reason, _ = decide_trade(
+            signal=_base_signal(),
+            market_state=_base_market_state(regime_id=2),
+            account_state=account_state,
+            market_health=None,
+            now_ms=NOW_MS,
+        )
+        assert decision == DECISION_BLOCK
+        assert reason == RC_020
+
+    def test_rc021_limit_still_enforced(self, probe_on):
+        """RC_021 limit still blocks when total_exposure_pct >= 50%."""
+        account_state = {
+            "daily_drawdown_pct": 1.0,
+            "total_exposure_pct": 55.0,  # > 50.0 threshold
+            "ts_ms": NOW_MS - 500,
+        }
+        decision, reason, _ = decide_trade(
+            signal=_base_signal(),
+            market_state=_base_market_state(regime_id=2),
+            account_state=account_state,
+            market_health=None,
+            now_ms=NOW_MS,
+        )
+        assert decision == DECISION_BLOCK
+        assert reason == RC_021

--- a/tests/unit/test_paper_probe_toggle.py
+++ b/tests/unit/test_paper_probe_toggle.py
@@ -1,0 +1,70 @@
+"""
+Unit-Tests fuer Paper Evidence Probe Toggle.
+
+Governance: Issue #2141 / Phase 3
+"""
+
+import pytest
+
+from core.utils.paper_probe_toggle import paper_evidence_probe_enabled
+
+
+@pytest.mark.unit
+class TestPaperProbeToggle:
+    def test_off_by_default(self, monkeypatch):
+        """Toggle is OFF when neither ENV var is set."""
+        monkeypatch.delenv("PAPER_EVIDENCE_PROBE_MODE", raising=False)
+        monkeypatch.delenv("MOCK_TRADING", raising=False)
+        assert paper_evidence_probe_enabled() is False
+
+    def test_off_when_only_probe_mode_set(self, monkeypatch):
+        """Toggle is OFF when PAPER_EVIDENCE_PROBE_MODE=1 but MOCK_TRADING not set."""
+        monkeypatch.setenv("PAPER_EVIDENCE_PROBE_MODE", "1")
+        monkeypatch.delenv("MOCK_TRADING", raising=False)
+        assert paper_evidence_probe_enabled() is False
+
+    def test_off_when_only_mock_trading_set(self, monkeypatch):
+        """Toggle is OFF when MOCK_TRADING=true but PAPER_EVIDENCE_PROBE_MODE not set."""
+        monkeypatch.delenv("PAPER_EVIDENCE_PROBE_MODE", raising=False)
+        monkeypatch.setenv("MOCK_TRADING", "true")
+        assert paper_evidence_probe_enabled() is False
+
+    def test_on_when_both_set(self, monkeypatch):
+        """Toggle is ON only when BOTH PAPER_EVIDENCE_PROBE_MODE=1 AND MOCK_TRADING=true."""
+        monkeypatch.setenv("PAPER_EVIDENCE_PROBE_MODE", "1")
+        monkeypatch.setenv("MOCK_TRADING", "true")
+        assert paper_evidence_probe_enabled() is True
+
+    def test_off_when_probe_mode_zero(self, monkeypatch):
+        """Toggle is OFF when PAPER_EVIDENCE_PROBE_MODE=0 even with MOCK_TRADING=true."""
+        monkeypatch.setenv("PAPER_EVIDENCE_PROBE_MODE", "0")
+        monkeypatch.setenv("MOCK_TRADING", "true")
+        assert paper_evidence_probe_enabled() is False
+
+    def test_off_when_mock_trading_false(self, monkeypatch):
+        """Toggle is OFF when MOCK_TRADING=false even with PAPER_EVIDENCE_PROBE_MODE=1."""
+        monkeypatch.setenv("PAPER_EVIDENCE_PROBE_MODE", "1")
+        monkeypatch.setenv("MOCK_TRADING", "false")
+        assert paper_evidence_probe_enabled() is False
+
+    def test_on_mock_trading_case_insensitive(self, monkeypatch):
+        """MOCK_TRADING is matched case-insensitively (TRUE, True, true all valid)."""
+        for value in ("TRUE", "True", "true"):
+            monkeypatch.setenv("PAPER_EVIDENCE_PROBE_MODE", "1")
+            monkeypatch.setenv("MOCK_TRADING", value)
+            assert paper_evidence_probe_enabled() is True, f"Failed for MOCK_TRADING={value}"
+
+    def test_off_mock_trading_garbage_value(self, monkeypatch):
+        """Toggle is OFF for unexpected MOCK_TRADING values."""
+        monkeypatch.setenv("PAPER_EVIDENCE_PROBE_MODE", "1")
+        monkeypatch.setenv("MOCK_TRADING", "yes")
+        assert paper_evidence_probe_enabled() is False
+
+    def test_reads_env_on_every_call(self, monkeypatch):
+        """No module-level cache: toggle reflects ENV change between calls."""
+        monkeypatch.setenv("PAPER_EVIDENCE_PROBE_MODE", "1")
+        monkeypatch.setenv("MOCK_TRADING", "true")
+        assert paper_evidence_probe_enabled() is True
+
+        monkeypatch.setenv("MOCK_TRADING", "false")
+        assert paper_evidence_probe_enabled() is False


### PR DESCRIPTION
## Summary

Implements the minimum code slice required to unblock organic SIGNAL→DECISION→ORDER→FILL chain generation in Paper-Betrieb (Issue #2141).

Three simultaneous hardcoded blockers prevented any chain from reaching `correlation_ledger`. This PR introduces a dual-guarded probe toggle that bypasses those blockers exclusively in paper/mock mode.

## Changes

### `core/utils/paper_probe_toggle.py` (new)
- `paper_evidence_probe_enabled()` — returns `True` only when **both** `PAPER_EVIDENCE_PROBE_MODE=1` **and** `MOCK_TRADING=true` are set
- Dual-guard: cannot activate without explicit paper/mock configuration
- No module-level cache — monkeypatch-friendly for tests (same pattern as `trace_toggle.py`)

### `services/risk/service.py`
- RC_001 regime bypass: `regime_id in {2,3}` no longer blocks in probe mode
- RC_010 signal bypass: low `pct_change_15m` / `volume_15m` no longer blocks in probe mode
- RC_020 None default: `daily_drawdown_pct=None` → `0.0` in probe mode (arithmetic check still runs)
- RC_021 None default: `total_exposure_pct=None` → `0.0` in probe mode (arithmetic check still runs)
- `risk_off_active` order gate: not applied in probe mode

### `services/signal/service.py`
- `has_trend_regime` bypass: regime gate relaxed in probe mode
- Organic breakout condition (`close_now > highest_high * (1 + breakout_buffer)`) is **never bypassed**

### Tests (new, 21/21 pass, 0 regressions)
- `tests/unit/test_paper_probe_toggle.py` — 9 tests: all toggle combinations, dual-guard, cache-free behaviour
- `tests/unit/risk/test_paper_probe_decide_trade.py` — 12 tests: probe ON/OFF per bypass; RC_002/003 and threshold limits still enforce

## Activation (NOT in this PR)

This PR ships the **code only**. No compose or runtime files are modified. To activate:

```yaml
# compose.blue.yml — cdb_risk environment
MOCK_TRADING: "true"
PAPER_EVIDENCE_PROBE_MODE: "1"

# compose.red.yml — cdb_signal environment
PAPER_EVIDENCE_PROBE_MODE: "1"
```

## Safety properties

| Property | Status |
|---|---|
| Default state | **OFF** — toggle is fail-closed; no ENV vars set = no bypass |
| Requires MOCK_TRADING=true | Yes — dual guard; cannot fire on live path |
| Requires PAPER_EVIDENCE_PROBE_MODE=1 | Yes — dual guard |
| RC_002 safety/anomaly gates | Always enforced |
| RC_003 staleness gate | Always enforced |
| RC_004 data silence gate | Always enforced |
| RC_020/021 threshold limits (>=5%/50%) | Always enforced |
| Organic breakout price condition | Always enforced |
| compose.blue.yml / compose.red.yml | **Not modified in this PR** |
| No Live/Echtgeld implication | Confirmed — MOCK_TRADING guard prevents live activation |

## Governance

- Closes #2141
- Issue #1905 remains `status:parked` — downstream of #2141, not unparked by this PR
- LR-Status: **NO-GO** unchanged — this PR has no live/Echtgeld implication
- Board-Stage `trade-capable` orthogonal — not affected
