### PR TITLE
Ignore local OpenCode skill quarantine residues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,14 @@ reports/decision_contract/
 # Local nested repo — mock exchange dependency candidate (github.com/didac-crst/mockexchange)
 # Intentionally kept local; must not be staged as gitlink or committed as submodule (#1645)
 tools/test_pack/mock_exchange/
+
+# OpenCode skills quarantine (local bulk/tooling/third-party leftovers)
+# Keep tracked PR #2156 skills untouched; only hide known untracked residues.
+/.opencode/skills/.system/
+/.opencode/skills/Anthropic-Cybersecurity-Skills/
+/.opencode/skills/jMerta/
+/.opencode/skills/skillforge/
+/.opencode/skills/mockexchange/
+/.opencode/skills/cdb-control-intake/assets/
+/.opencode/skills/cdb-control-intake/references/
+/.opencode/skills/cdb-control-intake/scripts/


### PR DESCRIPTION
## Summary
- add targeted .gitignore rules for local OpenCode bulk/tooling/third-party skill residues
- keep PR #2156 tracked OpenCode skills untouched
- keep candidate CDB-core skills visible for later review

## Validation
- committed only .gitignore
- verified ignored bulk/tooling/third-party paths no longer appear in git status
- verified candidate CDB-core skill paths remain visible and untracked

## Notes
- This PR does not add, remove, or modify any .opencode/skills files.
- Remaining candidate CDB-core skills should be handled in a separate review slice.