### PR TITLE
Add OpenCode CI and session-close skills

### DIFF
--- a/.opencode/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.opencode/skills/cdb-ci-cd-guard/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: ci-cd-guard
+description: CDB CI/CD governance audit and hardening for the working repo. Use when GitHub Actions, rulesets, required checks, secret guards, or fake-green behavior need to be verified or fixed. Derive protected refs, required checks, and enforcement behavior from current repo evidence and GitHub state instead of assuming old branch patterns or legacy docs-hub paths.
+---
+
+# CI/CD Guard
+
+## Canon first
+- Use the working repo as the only default source.
+- Start control-first:
+  1. GitHub control issue `#1445`
+  2. newest weekly comment on `#1445`
+  3. stage-ratification issue `#1492` as Board context only
+  4. `docs/runbooks/CONTROL_REGISTER.md`
+  5. `CURRENT_STATUS.md`
+  6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+  7. only then inspect rulesets, issues, PRs, and workflows
+- Read `docs/index.md` and `docs/runbooks/merge_policy_ci_gate.md` for local CI canon after the control-first chain.
+- Treat GitHub rulesets and required checks as evidence-bearing runtime state. If they are not observable, report the gap instead of inventing a result.
+- Treat `#1492` only as current Board context, not as any CI or LR override.
+
+## Use this when
+- a run is green but hidden stub, mock, skip, or fallback behavior is suspected
+- required checks, branch protection, secret guards, or delivery gates look inconsistent
+- workflow behavior changes by branch or secret availability
+
+## Hard rules
+- Do not assume protected branch patterns. Derive them from current rulesets, workflows, or explicit user input.
+- No silent stub or mock path on protected refs.
+- Missing critical secrets on protected refs must fail closed.
+- Without explicit approval, default to audit plus fix plan rather than mutation.
+
+## Workflow
+1. Inventory active workflows and identify gate-bearing jobs.
+2. Derive protected refs, required checks, and enforcement scope from repo evidence plus GitHub state.
+3. Search for fake-green vectors: stub, mock, fallback, skipped gates, soft-fail secret handling.
+4. Verify that guard decisions are visible in logs and outputs.
+5. Produce deterministic evidence per workflow: protected behavior, unprotected behavior, secret handling, merge-blocking effect.
+6. If fixes are needed, propose the smallest reversible patchset first.
+
+## Output
+- PASS or FAIL
+- concrete enforcement gaps, grouped by workflow or ruleset
+- mapping table: workflow -> trigger/ref scope -> secret behavior -> merge effect
+- minimal fix plan, or patchset if explicit approval exists
+- use `scripts/skill_pack_drift_lint.py <skills-root>` for package-level canon drift checks when validating the local skill pack itself

--- a/.opencode/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.opencode/skills/cdb-ci-cd-guard/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ci-cd-guard
+name: cdb-ci-cd-guard
 description: CDB CI/CD governance audit and hardening for the working repo. Use when GitHub Actions, rulesets, required checks, secret guards, or fake-green behavior need to be verified or fixed. Derive protected refs, required checks, and enforcement behavior from current repo evidence and GitHub state instead of assuming old branch patterns or legacy docs-hub paths.
 ---
 
@@ -43,4 +43,3 @@ description: CDB CI/CD governance audit and hardening for the working repo. Use 
 - concrete enforcement gaps, grouped by workflow or ruleset
 - mapping table: workflow -> trigger/ref scope -> secret behavior -> merge effect
 - minimal fix plan, or patchset if explicit approval exists
-- use `scripts/skill_pack_drift_lint.py <skills-root>` for package-level canon drift checks when validating the local skill pack itself

--- a/.opencode/skills/cdb-session-close/SKILL.md
+++ b/.opencode/skills/cdb-session-close/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: cdb-session-close
+description: >
+  Enforce a disciplined Claire_de_Binare session close. Use when Codex must
+  turn completed or partially completed local work into a clean closing state:
+  determine whether the session was issue-driven, capture actual changes and
+  verification, stage only intended files, prepare a scoped commit, account for
+  push and issue-status follow-through, and generate an issue-ready closing
+  comment without overstating completion. Use after implementation,
+  reconciliation, or validation work when the session needs an honest close.
+  When a PR was merged during the session, also verifies delivery on main,
+  normalizes local main, and classifies temporary git surfaces before marking
+  the session complete.
+---
+
+# CDB session close
+
+Close a working session so the repo, git state, and issue thread reflect reality instead of intention.
+
+## Inputs
+
+- Current working tree and session context.
+- Optional issue number, PR, branch context, or prior session goal.
+- Optional prior outputs from `cdb-control-intake`, `cdb-issue-to-session-plan`, or `cdb-shadow-validation`.
+- Access to git status, diffs, staged state, and issue or PR context when relevant.
+
+## Workflow
+
+1. Determine session scope before touching git:
+   - Decide whether the session was issue-bezogen.
+   - Identify the intended deliverable, the files actually changed, and any unrelated local residue.
+   - If the issue link is unclear, keep the close-out generic and mark the missing linkage.
+2. Reconstruct what was really done:
+   - Capture changed files and artifacts.
+   - Capture verification actually performed, not verification that was planned.
+   - Capture anything intentionally left undone, blocked, or uncertain.
+3. Gate the working tree:
+   - Inspect `git status`, unstaged diff, and staged diff.
+   - Separate intended session changes from unrelated or half-finished residue.
+   - Never use `git add .`.
+   - Stage only the files or hunks that belong to the session close, using targeted file staging or patch staging.
+4. Prepare the commit conservatively:
+   - Prefer one small, testable, reversible commit per coherent topic.
+   - If the work is not commit-worthy yet, say so explicitly and stop short of artificial closure.
+   - Write a commit message that describes what changed and why.
+5. Consider push and issue follow-through as part of the close:
+   - If a clean commit exists and push is appropriate, include push in the close path.
+   - If push is not done, say so explicitly in the rest status.
+   - If the issue state should change, describe the correct next state rather than claiming it changed when it did not.
+   - If the work is still local-only, make that explicit in the issue-facing close-out instead of implying landed or review-ready state.
+   - If a PR was merged during this session, proceed to step 6. If no PR exists or the PR is still open, skip steps 6–7 and record `pending main-verification` or `n.a.` in the rest status.
+6. Verify delivery on `main` — only when a PR was merged in this session:
+
+   ```bash
+   gh pr view <PR> --json state,mergedAt,mergeCommit
+   git fetch origin main
+   git log origin/main --oneline -5
+   git checkout main
+   git merge --ff-only origin/main
+   ```
+
+   Determine:
+   - PR merged + merge commit visible on `origin/main` + `--ff-only` succeeded → proceed to step 7.
+   - PR merged but merge commit absent from `origin/main` → STOP, session = incomplete.
+   - `--ff-only` fails → report as pending, do not force.
+   - No PR in this session → mark as `n.a.`, skip this step.
+7. Classify temporary git surfaces — only when applicable:
+
+   ```bash
+   git worktree list                       # any session worktrees?
+   git branch -v --merged origin/main      # any merged feature branch?
+   ```
+
+   - If a session worktree is present and unambiguously from this session: `git worktree remove <path>`.
+   - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
+   - Otherwise: record as `n.a.` or `pending` — no blind deletes.
+   - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
+8. Produce the close-out summary:
+   - State the factual result.
+   - Name changed files and artifacts.
+   - Name the root cause or central insight if one exists.
+   - Name checks that actually ran and their outcomes.
+   - Name real remaining work and uncertainties.
+   - Set the final status conservatively.
+
+## Decision Rules
+
+- Do not mark a session as complete if verification, staging, commit scope, or issue linkage is still unclear.
+- Do not stage unrelated local changes just to get to a clean tree.
+- Do not create a commit that mixes logic, docs, refactors, and residue unless they are one coherent change.
+- Prefer leaving honest local residue uncommitted over forcing a misleading close.
+- Use `bereit fuer Claude Code` only when there is a concrete handoff reason that another agent should continue from.
+- Use `erledigt` only when the issue-facing work is actually verified and the claimed git or GitHub state is real.
+- Do not imply LR uplift, live approval, or a Board-stage interpretation from a successful session close.
+- Respect solo-maintainer reality; do not invent reviewer, approver, or handoff ceremonies.
+
+## Fail-Closed Rules
+
+- If intended session changes cannot be separated from unrelated local changes, stop and report the close as incomplete.
+- If verification is missing or ambiguous, report exactly that instead of implying confidence.
+- If the session was issue-driven but the issue mapping is uncertain, do not fabricate an issue-ready completion claim.
+- If no clean commit boundary exists, do not force a commit.
+- If push or issue-status updates were not performed, keep them as pending actions in the close-out.
+- If the issue comment would overstate what landed, what was pushed, or what is actually done, downgrade the final status and state the pending step explicitly.
+- If a PR was merged but the merge commit cannot be verified on `origin/main`: the session is incomplete; do not set status to `erledigt`.
+- If `git merge --ff-only origin/main` fails: report as pending; do not force a merge or ignore the divergence.
+
+## Output
+
+Return the result in this structure:
+
+```md
+Session-Befund
+- ...
+
+Betroffene Dateien / Artefakte
+- ...
+
+Verifikation / Checks
+- ...
+
+Reststatus
+- ...
+
+Main-Verifikation (nur wenn PR gemergt, sonst n.a.)
+- PR-State: gemergt / offen / n.a.
+- Merge-Commit auf origin/main: ja / nein / n.a.
+- Lokales main normalisiert: ja / nein / pending / n.a.
+
+Surface-Cleanup (nur wenn applicable, sonst n.a.)
+- Worktrees: entfernt: <liste> / n.a. / pending
+- Feature-Branch: gelöscht: <name> / n.a. / pending
+- Leftover-Files: <klassifikation> / keine / n.a.
+
+Issue-Kommentar
+Befund
+- ...
+
+betroffene Dateien / Artefakte
+- ...
+
+Root Cause oder zentrale Erkenntnis
+- ...
+
+empfohlene naechste Schritte
+- ...
+
+Validierung / Checks
+- ...
+
+Restunsicherheiten
+- ...
+
+Status
+- erledigt | weitere Zuarbeit noetig | bereit fuer Claude Code
+```
+
+## Anti-Patterns
+
+- Do not use `git add .`.
+- Do not beautify an incomplete session into a finished one.
+- Do not claim checks ran when they did not.
+- Do not hide uncommitted residue.
+- Do not label work as `bereit fuer Claude Code` without a real continuation need.

--- a/.opencode/skills/cdb-session-close/SKILL.md
+++ b/.opencode/skills/cdb-session-close/SKILL.md
@@ -21,7 +21,7 @@ Close a working session so the repo, git state, and issue thread reflect reality
 
 - Current working tree and session context.
 - Optional issue number, PR, branch context, or prior session goal.
-- Optional prior outputs from `cdb-control-intake`, `cdb-issue-to-session-plan`, or `cdb-shadow-validation`.
+- Optional prior outputs from `cdb-control-intake` or `cdb-issue-to-session-plan`.
 - Access to git status, diffs, staged state, and issue or PR context when relevant.
 
 ## Workflow

--- a/.opencode/skills/gh-fix-ci/SKILL.md
+++ b/.opencode/skills/gh-fix-ci/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: gh-fix-ci
+description: Inspect failing GitHub PR checks in the current repo with `gh`, pull actionable GitHub Actions logs, summarize the failure context, then propose a fix plan and implement after explicit user approval. Use for GitHub Actions-based PR CI failures; for external checks, report the URL and keep them out of scope.
+---
+
+# GitHub CI Fix
+
+## Overview
+Use `gh` to locate failing PR checks, fetch GitHub Actions logs for actionable failures, summarize the failure snippet, then draft a concise plan in the current thread and implement after explicit approval.
+
+## Inputs
+- `repo`: path inside the repo, default `.`
+- `pr`: PR number or URL, optional
+- authenticated `gh`
+
+## Workflow
+1. Rebuild context control-first:
+   - inspect GitHub control issue `#1445`
+   - inspect the newest weekly comment on `#1445`
+   - treat issue `#1492` only as current stage context
+   - read `docs/runbooks/CONTROL_REGISTER.md`
+   - read `CURRENT_STATUS.md`
+   - read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+2. Verify `gh` authentication with `gh auth status`.
+3. Resolve the PR:
+   - prefer the current branch PR if present
+   - otherwise use the PR the user specified
+4. Inspect failing GitHub Actions checks:
+   - prefer `scripts/inspect_pr_checks.py`
+   - fall back to `gh pr checks`, `gh run view`, and log fetches if needed
+5. Separate GitHub Actions failures from external checks and mark external systems as out of scope.
+6. Summarize the failure with the check name, URL, and short log snippet.
+7. Draft a short fix plan in the current thread and wait for approval if the user asked for plan-first behavior.
+8. Implement the fix, run relevant verification, and suggest rechecking PR status.
+
+## Rules
+- Do not depend on a separate `plan` skill.
+- Do not assume a fixed required-check count; use the current repo and GitHub state.
+- If logs are missing or the run is still active, say so explicitly.
+- Do not read `#1492` as LR clearance.
+
+## Bundled resource
+`scripts/inspect_pr_checks.py` fetches failing PR checks, extracts log snippets, and can emit JSON for summarization.

--- a/.opencode/skills/gh-fix-ci/SKILL.md
+++ b/.opencode/skills/gh-fix-ci/SKILL.md
@@ -26,12 +26,12 @@ Use `gh` to locate failing PR checks, fetch GitHub Actions logs for actionable f
    - prefer the current branch PR if present
    - otherwise use the PR the user specified
 4. Inspect failing GitHub Actions checks:
-   - prefer `scripts/inspect_pr_checks.py`
+   - prefer `docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py`
    - fall back to `gh pr checks`, `gh run view`, and log fetches if needed
 5. Separate GitHub Actions failures from external checks and mark external systems as out of scope.
 6. Summarize the failure with the check name, URL, and short log snippet.
-7. Draft a short fix plan in the current thread and wait for approval if the user asked for plan-first behavior.
-8. Implement the fix, run relevant verification, and suggest rechecking PR status.
+7. Draft a short fix plan in the current thread and wait for explicit user approval before implementation.
+8. After explicit approval, implement the fix, run relevant verification, and suggest rechecking PR status.
 
 ## Rules
 - Do not depend on a separate `plan` skill.
@@ -40,4 +40,4 @@ Use `gh` to locate failing PR checks, fetch GitHub Actions logs for actionable f
 - Do not read `#1492` as LR clearance.
 
 ## Bundled resource
-`scripts/inspect_pr_checks.py` fetches failing PR checks, extracts log snippets, and can emit JSON for summarization.
+`docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py` fetches failing PR checks, extracts log snippets, and can emit JSON for summarization.


### PR DESCRIPTION
## Summary
- add OpenCode cdb-session-close skill
- add OpenCode cdb-ci-cd-guard skill
- add OpenCode gh-fix-ci skill

## Validation
- verified SKILL.md frontmatter
- verified name and description fields
- checked for escaped Markdown artifacts and placeholder content
- staged only the three approved skill files

## Scope
- no runtime code changes
- no trading/risk/execution/strategy changes
- no third-party skill packs
- remaining candidate CDB-core skills stay untracked for later slices