### PR TITLE
Add governance validation skills for OpenCode

### DIFF
--- a/.opencode/skills/cdb-contract-evidence-gatekeeper/SKILL.md
+++ b/.opencode/skills/cdb-contract-evidence-gatekeeper/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: cdb-contract-evidence-gatekeeper
+description: 'Hard gatekeeper for Claire_de_Binare acceptance and evidence decisions. Use when the task is deciding `freigabefaehig`, `closure-ready`, `wirklich erledigt`, `go/no-go`, `accept/reject`, `PASS/BLOCKED`, blocker vs non-blocking gap, report artifact vs real defect, canon drift vs evidence gap, Stage-System vs LR-System vs Repo/Engineering-Status, or cross-service contract ambiguity around producer, owner, unit, metadata, persistence, or proof. Do not use for broad implementation work.'
+---
+
+# CDB Contract Evidence Gatekeeper
+
+## Purpose
+Use this skill for hard gate decisions, not for implementation.
+
+This skill exists to decide whether a claim, issue, PR, report, status change, or proposed conclusion is actually justified under the current Claire_de_Binare canon.
+
+Use it to stop:
+- fake closure
+- status inflation
+- stage/LR confusion
+- narrative replacing evidence
+- contract claims passing without producer, owner, unit, or persistence clarity
+
+## Use this skill when
+- the user asks `freigabefaehig?`
+- the user asks `closure-ready?`
+- the user asks `wirklich erledigt?`
+- the user asks for go/no-go, accept/reject, PASS/BLOCKED
+- the user asks whether something is a blocker or only a non-blocking gap
+- the user asks to separate Stage-System, LR-System, and Repo/Engineering-Status
+- the user asks whether a claim is repo-backed or only narrative
+- the user asks whether a problem is canon drift, contract drift, evidence gap, policy ambiguity, or only a reporting artifact
+- the user asks whether cross-service metadata, payload, producer, owner, unit, or persistence claims are actually proven
+
+## Do NOT use this skill when
+- the task is mainly feature implementation
+- the task is broad coding work without a gate decision
+- the task is routine documentation editing without an acceptance question
+- the task is a straightforward CI repair with no canon, evidence, or gate ambiguity
+- the task is future architecture brainstorming without a current closure or acceptance decision
+
+If the hard decision is complete and the remaining work becomes implementation, hand off to the relevant execution skill.
+
+## Mandatory canon sources
+Before making a gate decision, use this control-first order:
+
+1. `#1445`
+2. newest weekly comment in `#1445`
+3. `#1492` only when Stage-/`trade-capable`-context is involved
+4. `docs/runbooks/CONTROL_REGISTER.md`
+5. `CURRENT_STATUS.md`
+6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+7. only then directly relevant issues, PRs, files, tests, and committed evidence artifacts
+
+If the task does not touch GitHub, stage, LR, or status claims, scale this down conservatively. If it does touch those surfaces, skipping the canon is forbidden.
+
+## Hard rules
+### 1. Status-class first
+Classify every decision surface before judging it:
+- Stage-System
+- LR-System
+- Repo/Engineering-Status
+- Runtime/Operator-Reality
+- CI/Workflow-Reality
+- Data-contract/persistence-reality
+- Documentation/reporting quality
+
+If more than one class is involved, split them. Never let one system silently overwrite another.
+
+### 2. SSOT boundaries are mandatory
+- `CURRENT_STATUS.md` = repo and engineering status
+- `docs/runbooks/CONTROL_REGISTER.md` = control-board focus, stage context, cockpit memory
+- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` = LR verdict and LR phase status
+- `#1445` = operational control umbrella
+- `#1492` = ratified stage context only when `trade-capable` is relevant
+
+Never derive LR go/no-go from Board stage.
+Never read `trade-capable` as implicit live-readiness.
+Never treat issue closure by itself as proof.
+
+### 3. Evidence over narrative
+Split every claim into these buckets:
+- direct repo-backed evidence
+- indirect evidence
+- policy decision
+- assumption or interpretation
+- missing evidence
+
+Do not blend them into one soft conclusion.
+
+### 4. Fail closed on unresolved ambiguity
+Do not produce a fake PASS if any required gate depends on unresolved ambiguity such as:
+- unclear producer
+- unclear owner of truth
+- unclear units or semantics
+- unclear source of truth
+- unclear Stage-vs-LR scope
+- ambiguous evidence wording
+- memory-backed criteria with no repo anchor
+
+Use `BLOCKED` or `NON-BLOCKING GAP` instead.
+
+### 5. Separate policy from proof
+A maintainer policy decision can be valid, but it is not the same as repo-backed proof.
+If the conclusion depends on policy, say so explicitly.
+
+### 6. No fake closure
+Do not recommend full closure when the truthful result is one of these:
+- closure-ready with explicit limits
+- stage-ratified but LR-still-partial
+- fixed in code but not evidenced enough
+- report corrected, underlying system unchanged
+- non-blocking residual still needs to stay explicit
+
+### 7. Cross-service claims require contract checking
+If the task touches payload propagation, metadata, persistence, replayability, or cross-service meaning, inspect explicitly:
+- producer
+- consumer
+- owner of truth
+- units and semantics
+- propagation path
+- persisted surface
+- test coverage
+- fail-closed behavior
+
+Do not accept a cross-service claim just because one layer mentions the field.
+
+## Decision workflow
+1. Classify the decision surface.
+2. State the exact claim under review.
+3. Pull the canon and only the artifacts that can change the verdict.
+4. Build the evidence map.
+5. Classify each gap exactly once.
+6. Issue one verdict from the allowed verdict classes.
+7. Recommend exactly one next move.
+
+## Allowed verdict classes
+- `PASS`
+- `PASS WITH EXPLICIT LIMITS`
+- `NON-BLOCKING GAP`
+- `BLOCKED`
+- `OUT OF SCOPE`
+
+Use the narrowest truthful verdict.
+
+## Required output format
+1. `Decision surface`
+2. `Claim under review`
+3. `Canon anchors`
+4. `Evidence map`
+5. `Verdict`
+6. `Why`
+7. `Recommended next move`
+
+Optional:
+8. `Issue comment draft`
+
+## Special decision patterns
+### Report vs real system defect
+If the problem is only wording or reporting, say so directly.
+Use the smallest truthful label:
+- reporting artifact
+- canon drift
+- runtime defect
+- contract defect
+- evidence gap
+- policy ambiguity
+
+### Stage vs LR
+If Stage and LR diverge:
+- state both statuses explicitly
+- state which one is under review
+- forbid implicit promotion from one system into the other
+
+Typical pattern:
+- Stage: ratified or acceptable
+- LR: still partial or still NO-GO
+- conclusion: stage decision may pass with limits while LR cannot be upgraded
+
+### Code fixed, proof incomplete
+If implementation exists but proof for the claimed status is incomplete:
+- do not call it fully done
+- prefer `PASS WITH EXPLICIT LIMITS` or `NON-BLOCKING GAP`
+
+### Contract ambiguity
+If a field exists somewhere but producer, owner, unit, or meaning is unclear:
+- treat it as contract ambiguity
+- do not pass the claim as canonically clean
+
+## Repo-specific guardrails
+- `trade-capable` is a stage label, not live-capital authorization
+- `LR-050` remaining `NO-GO` is orthogonal to stage ratification
+- Grafana is not automatically a gate surface
+- Solo-maintainer reality applies; do not invent teams, reviewers, or escalation chains
+- evidence beats storytelling
+- non-blocking residuals must remain explicit instead of disappearing into comments
+- the working repo is canon
+- historical docs are not active proof unless explicitly relevant
+
+## Tooling posture
+- read-only first
+- inspect before action
+- prefer file reads, grep, issue reads, PR reads, tests, and committed artifacts
+- only propose writes, updates, or closure after the verdict is stable
+
+This skill should feel like a gate review, not like opportunistic implementation.
+
+## Anti-patterns
+Do not:
+- claim `PASS` because wording sounds convincing
+- treat issue closure as proof by itself
+- use remembered thresholds with no repo match
+- merge Stage, LR, and Repo status into one blended judgement
+- call something a blocker without naming the blocking system
+- call something done when it is really a non-blocking residual
+- accept field propagation without producer, owner, unit, and semantics clarity
+- rewrite scope just to avoid a hard verdict
+
+## References
+- Read [references/CDB_DECISION_SURFACE_MATRIX.md](references/CDB_DECISION_SURFACE_MATRIX.md) when the task spans multiple status classes.
+- Read [references/CDB_VERDICT_CLASSES.md](references/CDB_VERDICT_CLASSES.md) when the verdict boundary is tight.
+- Read [references/CDB_ISSUE_COMMENT_PATTERNS.md](references/CDB_ISSUE_COMMENT_PATTERNS.md) when the result should be posted back to GitHub.

--- a/.opencode/skills/cdb-contract-evidence-gatekeeper/references/CDB_DECISION_SURFACE_MATRIX.md
+++ b/.opencode/skills/cdb-contract-evidence-gatekeeper/references/CDB_DECISION_SURFACE_MATRIX.md
@@ -1,0 +1,17 @@
+# CDB Decision Surface Matrix
+
+Use this matrix before issuing a verdict.
+
+| Surface | Primary question | Canon anchor | Typical failure mode |
+|---|---|---|---|
+| Stage-System | Is a Board-stage claim or transition justified? | `#1445`, newest weekly comment, `#1492` when relevant, `docs/runbooks/CONTROL_REGISTER.md` | Stage is silently promoted into LR |
+| LR-System | Is a live-readiness claim justified? | `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` | `CURRENT_STATUS.md` is misread as LR authority |
+| Repo/Engineering-Status | Is the repo, PR, or engineering ledger claim justified? | `CURRENT_STATUS.md` | closed issue or merged code is overstated as broader proof |
+| Runtime/Operator-Reality | Is the system operable or fail-closed in practice? | current runbooks, committed artifacts, direct runtime evidence | dashboards or stories substitute for technical checks |
+| CI/Workflow-Reality | Is a workflow, gate, or ruleset claim justified? | workflows, rulesets, current GitHub state | green status hides skipped or soft-failed gates |
+| Data-contract/persistence-reality | Is a field or metadata claim proven end-to-end? | producer, consumer, tests, persisted artifacts | one layer mentions a field and the rest is assumed |
+| Documentation/reporting quality | Is the defect only phrasing or actually technical? | report text plus the canon it references | reporting artifact is inflated into system defect |
+
+Rule:
+- If more than one surface is involved, separate them.
+- Never let one verdict class overwrite another surface.

--- a/.opencode/skills/cdb-contract-evidence-gatekeeper/references/CDB_ISSUE_COMMENT_PATTERNS.md
+++ b/.opencode/skills/cdb-contract-evidence-gatekeeper/references/CDB_ISSUE_COMMENT_PATTERNS.md
@@ -1,0 +1,48 @@
+# CDB Issue Comment Patterns
+
+Use short issue-ready comments after the gate verdict is stable.
+
+## PASS WITH EXPLICIT LIMITS
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: PASS WITH EXPLICIT LIMITS
+
+Why:
+- Direct evidence: <artifact>
+- Limits: <explicit residual>
+- Not upgraded: <surface that remains unchanged>
+
+Next move:
+- <one concrete action>
+```
+
+## NON-BLOCKING GAP
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: NON-BLOCKING GAP
+
+Why:
+- The core claim is supportable for this surface.
+- Residual gap: <explicit gap>
+- This does not block: <named surface>
+
+Next move:
+- <one concrete action>
+```
+
+## BLOCKED
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: BLOCKED
+
+Why:
+- Missing or ambiguous proof: <artifact or contract gap>
+- Blocking system: <surface>
+- No fake PASS issued.
+
+Next move:
+- <one concrete action>
+```

--- a/.opencode/skills/cdb-contract-evidence-gatekeeper/references/CDB_VERDICT_CLASSES.md
+++ b/.opencode/skills/cdb-contract-evidence-gatekeeper/references/CDB_VERDICT_CLASSES.md
@@ -1,0 +1,26 @@
+# CDB Verdict Classes
+
+Use exactly one primary verdict.
+
+## PASS
+Use only when the claim is directly supported by the relevant canon and evidence.
+
+## PASS WITH EXPLICIT LIMITS
+Use when the claim is acceptable only with named boundaries that must stay visible.
+
+## NON-BLOCKING GAP
+Use when a real gap exists, but it does not block the decision surface under review.
+Keep the residual explicit.
+
+## BLOCKED
+Use when a required condition, proof basis, or source-of-truth boundary is unresolved.
+Do not soften this into narrative.
+
+## OUT OF SCOPE
+Use when the finding is real but not part of the current decision surface.
+Do not silently absorb it into the verdict.
+
+## Fast checks
+- If proof depends on memory, use `BLOCKED` or `NON-BLOCKING GAP`.
+- If Stage is acceptable but LR is still `NO-GO`, do not use `PASS` for LR.
+- If code is fixed but closure proof is incomplete, prefer `PASS WITH EXPLICIT LIMITS` or `NON-BLOCKING GAP`.

--- a/.opencode/skills/cdb-risk-governance/SKILL.md
+++ b/.opencode/skills/cdb-risk-governance/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: cdb-risk-governance
+description: CDB risk-governance changes for the current Risk Service (`cdb_risk`). Use when Codex needs to implement or harden enforceable limits, kill-switches, drawdown or exposure caps, fail-closed gating, or human-approval semantics. Respect the current repo canon, the `Risk Service` naming, and the fact that Board stage does not clear live trading.
+---
+
+# Risk Governance
+
+## Canon first
+- Use the working repo and current `Risk Service` / `cdb_risk` terminology.
+- Read `CURRENT_STATUS.md` for recent risk and runtime changes.
+- Read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` before making any claim about live readiness.
+- Never interpret `trade-capable` as permission to resume or enable live trading.
+
+## Trigger phrases
+- risk limits, daily loss, drawdown
+- kill switch, circuit breaker, stop trading
+- exposure cap, position cap, leverage guard
+- no-trade mode, human approval, fail-closed gate
+
+## Non-negotiables
+- Critical breaches must produce a machine-checkable stop state.
+- Resume paths require explicit human approval where policy demands it.
+- Add tests for breach and non-breach paths.
+- If thresholds or policy intent are unclear, stop and surface the ambiguity instead of guessing.
+
+## Deliverables
+- guard logic and config changes
+- tests for breach and non-breach scenarios
+- concise evidence table mapping scenario to expected gate state

--- a/.opencode/skills/cdb-shadow-validation/SKILL.md
+++ b/.opencode/skills/cdb-shadow-validation/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: cdb-shadow-validation
+description: >
+  Decide the conservative validation path for Claire_de_Binare strategy,
+  signal, execution, dataflow, contract, persistence, observability, or
+  shadow-relevant changes. Use when Codex must classify a change, assess blast
+  radius and risk against current control status, and choose exactly one
+  outcome: unit tests only, replay needed, mock exchange or emulator needed,
+  shadow evidence needed, or stop and do not release. Use after planning or
+  before session close when a concrete change needs a validation decision.
+---
+
+# CDB shadow validation
+
+Use this after planning narrows to a concrete change or before `cdb-session-close` when validation depth is still undecided. Choose the minimum safe validation path for a concrete change and fail closed when the evidence is incomplete.
+
+## Inputs
+
+- A concrete change, diff, PR, issue, commit, or scoped work description.
+- Working repo at `D:\Dev\Workspaces\Repos\Claire_de_Binare`.
+- Access to `docs/runbooks/CONTROL_REGISTER.md`, `CURRENT_STATUS.md`, and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`.
+
+## Required Outcomes
+
+Choose exactly one:
+
+- `nur Unit Tests`
+- `Replay noetig`
+- `MockExchange / Emulator noetig`
+- `Shadow-Evidence noetig`
+- `stoppen / nicht freigeben`
+
+## Workflow
+
+1. Read control status first, before looking at the change details in depth:
+   - Read `docs/runbooks/CONTROL_REGISTER.md`.
+   - Read `CURRENT_STATUS.md`.
+   - Read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`.
+   - Extract the current control boundary: Board stage may be `trade-capable`, but LR remains `NO-GO` and work stays shadow/mock only unless an explicit source proves otherwise.
+2. Determine the change class from evidence, not from intent:
+   - Strategy or signal logic.
+   - Execution, order, trade, routing, or exchange path.
+   - Interface, API, schema, or contract boundary.
+   - Data model, persistence, storage, or migration path.
+   - Observability, alerting, monitoring, or operator signal path.
+   - Purely local and isolated internal logic.
+3. Identify affected systems and contracts:
+   - Name the touched services, modules, adapters, reports, or persistence layers.
+   - Name any producer-consumer or request-response contracts affected.
+   - Name whether the change can influence orders, fills, positions, balances, signals, or operator decisions.
+4. Assess risk and blast radius conservatively:
+   - Low: isolated internal logic with no contract, execution, persistence, or control-signal effect.
+   - Medium: cross-module or contract-adjacent change without direct execution exposure.
+   - High: strategy, signal, execution, order, trade, persistence, or operator control path.
+   - Critical: ambiguous or multi-surface change, or any change where the blast radius cannot be bounded confidently.
+5. Select the validation path:
+   - `nur Unit Tests` only for low-risk isolated logic with no shadow, LR, contract, persistence, execution, or observability relevance.
+   - `Replay noetig` for strategy, signal, deterministic decision logic, contract-adjacent, or dataflow changes that can be validated offline without exchange behavior.
+   - `MockExchange / Emulator noetig` for execution, order lifecycle, adapter, fill-handling, or exchange-facing changes.
+   - `Shadow-Evidence noetig` for changes that can alter operational behavior, confidence, or release posture beyond replay or emulation alone, especially when strategy, signal, execution, observability, or cross-service interactions remain behaviorally relevant.
+   - `stoppen / nicht freigeben` if the change is ambiguous, unbounded, under-specified, conflicts with control status, or needs validation evidence that is unavailable.
+6. Escalate upward when uncertain:
+   - If two outcomes seem plausible, choose the stricter one.
+   - If the required validation environment or evidence cannot be confirmed, choose `stoppen / nicht freigeben`.
+   - If LR or shadow relevance is uncertain, treat the change as shadow-relevant.
+
+## Decision Rules
+
+- Never infer LR-GO from Board stage, repo status, or successful local tests.
+- Never allow live-capital reasoning or live-release implications.
+- Never mix unrelated scope into the validation decision.
+- Derive test depth from blast radius and risk, not from developer convenience.
+- Treat strategy and signal changes as behavior changes even when the diff looks small.
+- Treat contract, persistence, and observability changes as potentially cross-service until proven otherwise.
+- Treat missing evidence as increased risk, not as neutral.
+- Treat current `trade-capable` Board stage as orthogonal to validation strictness; it does not justify a lighter path.
+- If the selected path is anything other than `nur Unit Tests` for a truly isolated internal change, default the operational posture to shadow/mock only.
+
+## Fail-Closed Rules
+
+- If any required control file cannot be read, stop and return `stoppen / nicht freigeben`.
+- If the change scope cannot be bounded confidently, stop and return `stoppen / nicht freigeben`.
+- If execution, order, or trade paths may be touched but the boundary is unclear, require at least `MockExchange / Emulator noetig`; if even that scope is unclear, stop.
+- If cross-service contracts or persistence may be affected and offline evidence is insufficient, require at least `Replay noetig`; escalate to `Shadow-Evidence noetig` when behavior remains operationally relevant.
+- If observability or alerting changes could alter operator understanding, do not downgrade below the highest validation level justified by the affected operational path.
+- If the change has possible LR or shadow relevance and that relevance cannot be excluded, keep it shadow/mock only.
+
+## Output
+
+Return the result in this structure:
+
+```md
+Befund
+- ...
+
+Aenderungsklasse
+- ...
+
+Empfohlener Validierungspfad
+- one of: nur Unit Tests | Replay noetig | MockExchange / Emulator noetig | Shadow-Evidence noetig | stoppen / nicht freigeben
+
+Notwendige Checks
+- ...
+
+Stop-Kriterien
+- ...
+
+Restunsicherheiten
+- ...
+
+Shadow/mock only
+- yes/no + why
+```
+
+## Anti-Patterns
+
+- Do not guess the lightest validation path.
+- Do not reduce validation depth because the diff is small.
+- Do not treat passing unit tests as sufficient for strategy, signal, execution, contract, persistence, or observability changes.
+- Do not imply deployment or release approval from a validation-path decision.
+- Do not blur replay, emulation, and shadow evidence into one bucket.


### PR DESCRIPTION
## Summary
- add cdb-shadow-validation skill guidance for conservative validation-path decisions
- add cdb-contract-evidence-gatekeeper skill plus focused gatekeeping reference docs
- normalize risk governance skill frontmatter to 
ame: cdb-risk-governance and add scoped governance guidance

## Validation
- verified referenced gatekeeper files exist under .opencode/skills/cdb-contract-evidence-gatekeeper/references/
- checked skill files for placeholder and escape-artifact patterns
- confirmed staged scope only includes the three target skill surfaces and required gatekeeper references