### PR TITLE
Add OpenCode docs drift and PR comment skills

### DIFF
--- a/.opencode/skills/cdb-docs-ops/SKILL.md
+++ b/.opencode/skills/cdb-docs-ops/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: cdb-docs-ops
+description: 'Create or update CDB operational documentation from the working-repo canon. Use when Codex needs to capture system state, derive a health/status digest, write a tactical runbook, or build a crisis playbook. Keep the current SSOT split explicit: `CURRENT_STATUS.md` for repo state, `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for Echtgeld Go/No-Go, and `docs/runbooks/CONTROL_REGISTER.md` for Board stage and operating focus.'
+---
+
+# CDB Ops Docs
+
+## Canon first
+- Working repo only. Do not default to retired external docs repos.
+- Start control-first:
+  1. GitHub control issue `#1445`
+  2. newest weekly comment on `#1445`
+  3. stage-ratification issue `#1492` as Board context only
+  4. `docs/runbooks/CONTROL_REGISTER.md`
+  5. `CURRENT_STATUS.md`
+  6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+  7. only then supporting issues, PRs, or repo artifacts
+- Keep status classes separate:
+  - `CURRENT_STATUS.md` = repo and engineering state
+  - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` = live-readiness verdict
+  - `docs/runbooks/CONTROL_REGISTER.md` = Board stage and operating focus
+- Never restate `trade-capable` as live authorization. LR is still `NO-GO`.
+- Treat `#1492` strictly as ratified stage context, never as LR clearance.
+
+## Modes
+1. Create a source doc from raw operational knowledge.
+2. Derive exactly one artifact from source docs or canon docs:
+   - status digest
+   - runbook
+   - playbook
+
+## Source doc rules
+- Use deterministic wording only.
+- Capture facts, constraints, dependencies, downstream impact, and invalidation triggers.
+- If the request mixes repo state, LR verdict, and Board stage, split them explicitly instead of collapsing them into one status claim.
+- If evidence is missing, stop and ask targeted questions rather than filling gaps with assumptions.
+
+## Artifact rules
+- Status digest for health or "where do we stand?"
+- Runbook for tactical recovery steps
+- Playbook for multi-step incidents or human-gated crisis handling
+- Use semantic colors only for gates, verdicts, triggers, and expected results.
+
+## Safety
+- No real trades.
+- No irreversible action without explicit human approval.
+- For any live-trading topic, treat `knowledge/operating_rules/LIVE_TRADING_RUNBOOK.md` as procedure shape only and `LR-AUDIT-STATUS` as the verdict authority.

--- a/.opencode/skills/cdb-drift-reconcile/SKILL.md
+++ b/.opencode/skills/cdb-drift-reconcile/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: cdb-drift-reconcile
+description: >
+  Reconcile known Claire_de_Binare drift vectors against the current canon and
+  produce a conservative findings report. Use when Codex must inspect
+  documentation, runbooks, discovery surfaces, architecture maps, stack and
+  secrets references, or service catalogs for canon drift, classify each area
+  as belegt, unklar, or kein Befund, and separate documentation drift from
+  operational drift without expanding scope. Use this for bounded canon-drift
+  reconciliation, not for generic docs cleanup.
+---
+
+# CDB drift reconcile
+
+Check known drift vectors against the current canon and return a bounded reconciliation finding, not a broad cleanup campaign.
+
+## Inputs
+
+- A drift-check request, drift suspicion, or maintenance pass over canon surfaces.
+- Working repo at `D:\Dev\Workspaces\Repos\Claire_de_Binare`.
+- Access to `docs/runbooks/CONTROL_REGISTER.md` and the repo surfaces it points to.
+
+## Required Drift Areas
+
+Always check these areas unless the request explicitly narrows scope further:
+
+- Solo-Maintainer-Drift in SOPs
+- Terminologie-Drift: `Risk Service` / `cdb_risk` instead of legacy `BLACK`
+- Stack-Canon-Drift: `BLUE/RED` instead of legacy single-compose language
+- Secrets-Canon-Drift
+- SSOT-Grenzen between `CURRENT_STATUS.md` and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- Discovery-Surfaces / EntryPoints / Cheatsheets
+- `ARCHITECTURE_MAP` / `SERVICE_CATALOG` when service changes are implicated
+
+## Workflow
+
+1. Read `docs/runbooks/CONTROL_REGISTER.md` first.
+2. Build the search and review matrix from the drift vectors defined there:
+   - Do not invent new drift categories unless the control source itself requires them.
+   - Use the required drift areas above as the minimum matrix.
+3. Inspect only the repo surfaces needed to evaluate the active matrix:
+   - Runbooks, SOPs, status files, architecture maps, service catalogs, discovery docs, cheatsheets, and stack or secrets references.
+   - Pull service maps only when the suspected drift touches service naming, boundaries, or runtime topology.
+   - Keep historical snapshots and archive paths out of scope unless needed to confirm that something is merely historical.
+4. Classify every checked area with exactly one finding state:
+   - `belegt`
+   - `unklar`
+   - `kein Befund`
+5. For every `belegt` or `unklar` finding, separate the impact type:
+   - Documentation drift only
+   - Operational drift
+   - Blocker-relevant operational drift
+6. Reconcile conservatively:
+   - Treat historical anchors as historical unless current canon still points to them as active.
+   - Treat canon-boundary uncertainty as unresolved, not as clean.
+   - Do not convert every drift finding into a follow-up issue or workflow change.
+   - Keep Board stage separate from LR status at all times.
+
+## Classification Rules
+
+- `belegt` means the repo surface directly contradicts or lags the current canon.
+- `unklar` means the evidence is incomplete, ambiguous, or canon boundaries are not stable enough to call clean.
+- `kein Befund` means the checked surface matches the current canon closely enough for the reviewed vector.
+- Documentation drift only means wording, pointers, naming, or navigation are stale but the live operational path or enforced runtime behavior is not changed by the drift.
+- Operational drift means the stale canon can misroute execution, verification, secrets handling, stack invocation, or service understanding in current work.
+- Blocker-relevant operational drift means the drift can directly compromise safe operation, safe validation, or correct control interpretation and should be treated as a blocker until reconciled.
+
+## Fail-Closed Rules
+
+- If `CONTROL_REGISTER.md` cannot be read, stop and report reconciliation blocked.
+- If canon boundaries between active docs and historical snapshots cannot be determined confidently, classify the area as `unklar`.
+- If a surface looks stale but the active canon source is not identifiable, do not normalize it away; keep the finding conservative.
+- If service topology, secrets canon, or status-source boundaries may be affected and the relevant maps cannot be confirmed, do not downgrade below `unklar`.
+- If a finding appears historical only, but current entrypoints still route users there, classify it as active drift rather than archive noise.
+
+## Output
+
+Return the result in this structure:
+
+```md
+Drift-Befund
+- Area: belegt | unklar | kein Befund
+
+Betroffene Dateien / Artefakte
+- ...
+
+Schweregrad
+- low | medium | high
+
+Drift-Typ
+- Dokumentationsdrift | operative Drift | blocker-relevante operative Drift
+
+Empfohlene naechste Schritte
+- ...
+
+Nicht im Scope
+- ...
+```
+
+## Anti-Patterns
+
+- Do not turn every stale reference into a new issue.
+- Do not create meta-management work that is not justified by current canon.
+- Do not treat historical anchors as active tasks by default.
+- Do not expand from one drift vector into a full repo rewrite.
+- Do not read Board stage as LR-GO or use LR files to redefine Board stage.

--- a/.opencode/skills/gh-address-comments/SKILL.md
+++ b/.opencode/skills/gh-address-comments/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: gh-address-comments
+description: Address GitHub PR review comments in the current repo with `gh`. Use when the user wants comment triage, replies, or code changes for review feedback on the current-branch PR or a specified PR. Verify `gh` authentication first, rebuild context control-first, and do not assume an open PR exists. This skill does not handle generic issue-comment threads unless a separate workflow is added.
+---
+
+# GitHub Comment Handler
+
+Run `gh` commands with escalated network access when needed.
+
+## Workflow
+1. Rebuild context control-first:
+   - inspect GitHub control issue `#1445`
+   - inspect the newest weekly comment on `#1445`
+   - treat issue `#1492` only as current stage context
+   - read `docs/runbooks/CONTROL_REGISTER.md`
+   - read `CURRENT_STATUS.md`
+   - read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+2. Verify `gh` authentication with `gh auth status`.
+3. Resolve the target PR:
+   - prefer the current branch PR when one exists
+   - otherwise use the explicit PR number or URL the user provided
+   - if no PR is discoverable, stop and ask for it
+4. Fetch comments and review threads with `gh` directly:
+   - `gh pr view <PR> --json reviewThreads,comments,reviews`
+   - `gh api /repos/{owner}/{repo}/pulls/<PR>/comments`
+   - optional: use a repo-provided helper script only if it exists locally
+5. Summarize actionable comments in numbered form.
+6. If the user selected comments to address, implement the changes or draft the replies.
+
+## Rules
+- Do not assume there is an open PR for the current branch.
+- Do not imply support for generic issue-comment threads; this pack is PR-focused.
+- If auth or rate limits fail, ask the user to re-authenticate and retry.
+- Keep code changes scoped to the selected comments.
+- Do not read `#1492` as LR clearance.


### PR DESCRIPTION
## Summary
- add OpenCode cdb-docs-ops skill
- add OpenCode cdb-drift-reconcile skill
- add OpenCode gh-address-comments skill

## Validation
- verified SKILL.md frontmatter
- verified name and description fields
- checked for escaped Markdown artifacts and placeholder content
- checked for broken script/skill references
- staged only the approved docs/drift/comment skill slice

## Scope
- no runtime code changes
- no trading/risk/execution/strategy implementation changes
- no scripts, references, assets, or third-party skill packs
- remaining candidate CDB-core skills stay untracked for later slices