### PR TITLE
Add OpenCode runtime boundary skills

### DIFF
--- a/.opencode/skills/cdb-backtest-engine/SKILL.md
+++ b/.opencode/skills/cdb-backtest-engine/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: cdb-backtest-engine
+description: Deterministic CDB backtesting and strategy evaluation in the working repo. Use when Codex needs to run or update offline backtests, parameter sweeps, walk-forward tests, baseline comparisons, or PR-ready evidence packs. Treat the local working repo as canon, not the retired external docs repo; never infer live readiness from Board stage; no live keys, no live or testnet execution.
+---
+
+# Backtest Engine
+
+## Canon first
+- Use local working-repo paths only.
+- Read `CURRENT_STATUS.md` for repo and engineering context.
+- Read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for Echtgeld guardrails and current `NO-GO`.
+- Read `docs/runbooks/CONTROL_REGISTER.md` for Board stage, but never treat `trade-capable` as live authorization.
+
+## Use this when you see
+- backtest, walk-forward, parameter sweep
+- baseline comparison or regression check
+- equity curve, drawdown, Sharpe, profit factor
+- evidence pack, report, or gate-supporting metrics
+
+## Hard rules
+- Evidence over assumptions: if the dataset, baseline, or configuration is ambiguous, stop and surface the missing artifact.
+- Determinism required: freeze dataset window, seed, parameters, and code reference.
+- Offline replay only. Do not call live or testnet endpoints.
+- Always print output artifact paths in the final response.
+
+## Default deliverables
+1. `results.json` for raw run output when available
+2. `metrics.json` for computed summary
+3. `report.md` for human-readable evidence
+4. `compare.md` only when a baseline is provided

--- a/.opencode/skills/cdb-exchange-adapters/SKILL.md
+++ b/.opencode/skills/cdb-exchange-adapters/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: cdb-exchange-adapters
+description: CDB exchange-adapter work in the current working repo. Use when Codex needs to implement or harden REST or websocket adapters, order or market-data normalization, rate-limit handling, reconnect logic, or idempotent exchange boundaries. Prefer current repo realities and active integrations; treat MEXC as the default exchange only when the repo context proves it, and keep all work in paper or testnet-safe scope.
+---
+
+# Exchange Adapters
+
+## Canon first
+- Use the working repo as canon. Do not reference the retired external docs repo.
+- Read `CURRENT_STATUS.md` and local adapter code before assuming the active exchange scope.
+- Stage `trade-capable` is not a license for live endpoints or live keys.
+
+## Trigger phrases
+- exchange adapter, REST client, websocket client
+- MEXC, Binance, Crypto.com, market data, order schema
+- rate limit, retry, backoff, reconnect, heartbeat
+- idempotency, auth failure, timeout taxonomy
+
+## Non-negotiables
+- No real keys in code.
+- No live endpoints by default; paper or testnet only when explicitly needed.
+- Normalize to the repo's current internal schema instead of inventing a new one.
+- Add tests for happy path plus failure taxonomy.
+- Include one simulated failure case that proves retry or backoff behavior.
+
+## Deliverables
+- adapter module or boundary patch
+- tests for success and failure paths
+- short evidence snippet for the user or PR

--- a/.opencode/skills/cdb-trading-core/SKILL.md
+++ b/.opencode/skills/cdb-trading-core/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: cdb-trading-core
+description: 'Trading-system development for Claire de Binare in the current working repo. Use when Codex needs cross-cutting work over strategy logic, backtesting, market-data flow, Risk Service integration, shadow or paper evidence, or performance reporting. Respect the current canon: the working repo is authoritative, `trade-capable` does not imply LR-GO, and no action may place live orders or use live credentials.'
+---
+
+# Claire de Binare Trading
+
+## Canon first
+- Use the working repo as canon; do not use the retired external docs repo.
+- Separate status classes:
+  - `CURRENT_STATUS.md` for repo and engineering state
+  - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for live-readiness verdict
+  - `docs/runbooks/CONTROL_REGISTER.md` for Board stage
+- Current reality: Board stage can be `trade-capable` while LR remains `NO-GO`.
+
+## Scope
+- strategy logic and evaluation
+- market-data and decision-flow plumbing
+- shadow or paper execution evidence
+- performance reporting
+- coordination across backtesting, exchange boundaries, and risk gates
+
+## Routing rule
+- If the task is mainly backtesting, prefer `cdb-backtest-engine`.
+- If the task is mainly exchange-boundary work, prefer `cdb-exchange-adapters`.
+- If the task is mainly gating or limits, prefer `risk-governance`.
+- Use this skill when the request spans multiple of those areas.
+
+## Working rules
+- Evidence over assumptions. If a strategy, exchange, or runtime mode is unclear, derive it from the repo or ask.
+- Prefer paper, replay, or shadow evidence.
+- Do not introduce live-order behavior.
+- Keep credentials in secret storage only and never print them.
+
+## Safety
+- No live orders.
+- No live-credential changes.
+- If the request implies enabling live trading, stop and point to `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` plus `knowledge/operating_rules/LIVE_TRADING_RUNBOOK.md` as procedure shape only.


### PR DESCRIPTION
## Summary
- add OpenCode cdb-backtest-engine skill
- add OpenCode cdb-exchange-adapters skill
- add OpenCode cdb-trading-core skill

## Validation
- verified SKILL.md frontmatter
- verified name and description fields
- checked for escaped Markdown artifacts and placeholder content
- checked runtime/live-readiness safety wording
- staged only the approved runtime-boundary skill slice

## Scope
- no runtime code changes
- no trading/risk/execution/strategy implementation changes
- no config changes
- no scripts, references, assets, or third-party skill packs
- remaining candidate CDB-core skills stay untracked for later slices