### PR TITLE
Improve OpenCode skill routing and naming clarity

### DIFF
--- a/.opencode/skills/cdb-trading-core/SKILL.md
+++ b/.opencode/skills/cdb-trading-core/SKILL.md
@@ -23,7 +23,7 @@ description: 'Trading-system development for Claire de Binare in the current wor
 ## Routing rule
 - If the task is mainly backtesting, prefer `cdb-backtest-engine`.
 - If the task is mainly exchange-boundary work, prefer `cdb-exchange-adapters`.
-- If the task is mainly gating or limits, prefer `risk-governance`.
+- If the task is mainly gating or limits, prefer `cdb-risk-governance`.
 - Use this skill when the request spans multiple of those areas.
 
 ## Working rules

--- a/.opencode/skills/ctb-docker-stack/SKILL.md
+++ b/.opencode/skills/ctb-docker-stack/SKILL.md
@@ -5,6 +5,11 @@ description: Ops skillpack for the current CDB stack. Use when Codex needs comma
 
 # CDB Ops Stack Skillpack
 
+## Discovery mapping
+- Folder: ctb-docker-stack
+- Skill name: ctb-ops-stack-skillpack
+- Treat these as the same OpenCode skill surface; do not rename the folder or the skill in this patch.
+
 ## Canon first
 - Working repo only.
 - Start control-first:


### PR DESCRIPTION
## Summary
- update cdb-trading-core routing reference to cdb-risk-governance
- document ctb-docker-stack folder/name mapping for discoverability

## Validation
- verified changes are limited to two OpenCode SKILL.md files
- checked frontmatter and descriptions
- checked for placeholder/escape artifacts
- preserved live-readiness and no-live-trading guardrails

## Scope
- no runtime code changes
- no trading/risk/execution/strategy implementation changes
- no scripts, assets, references, or licenses
- unrelated PRs/branches remain untouched