### PR TITLE
[SURREALDB][CONTEXT][INDEX] Update Wave 7-B docs index (#2038 #2041)

### DIFF
--- a/docs/db/index.md
+++ b/docs/db/index.md
@@ -62,6 +62,11 @@ Postgres ist der Canon fuer Runtime-Daten; SurrealDB ist eine optionale Mirror-S
 - Architektur & Roadmap:
   - [docs/surrealdb/context-intelligence-system.md](../surrealdb/context-intelligence-system.md)
   - [docs/surrealdb/context-intelligence-roadmap.md](../surrealdb/context-intelligence-roadmap.md)
+- Ontology & Schema:
+  - [docs/surrealdb/context-ontology-v0.yaml](../surrealdb/context-ontology-v0.yaml)
+  - [`infrastructure/surrealdb/context_intelligence_v0.surql`](../../infrastructure/surrealdb/context_intelligence_v0.surql)
+- Validation & Gates:
+  - [docs/surrealdb/context-intelligence-validation.md](../surrealdb/context-intelligence-validation.md)
 - Planung & Governance (Wave 21):
   - [docs/surrealdb/context-wave21-cross-cutting-hardening.md](../surrealdb/context-wave21-cross-cutting-hardening.md)
   - [docs/surrealdb/context-wave21-completion-gates.md](../surrealdb/context-wave21-completion-gates.md)


### PR DESCRIPTION
Refs #1976
Refs #2034
Closes #2038
Closes #2041

## Summary

This PR lands the minimal Wave 7-B index update for the Context Intelligence epic.

It updates the existing DB documentation index so the Context Intelligence artifacts are discoverable from the active index surface:

- `docs/db/index.md`

This is a docs-only PR.

## Scope

Included:

- add the Context Intelligence ontology seed link
- add the Context Intelligence SurrealQL schema draft link
- add the Context Intelligence validation document link
- keep existing architecture, roadmap, handoff, and Wave 7 completion-gate links
- preserve the separation between SurrealDB Governance Mirror documentation and Context Intelligence documentation

Excluded:

- no changes to #1986
- no changes to PR #2223
- no changes to PR #2216
- no changes to the ontology seed itself
- no changes to the SurrealQL schema itself
- no code changes
- no tests
- no workflow changes
- no SurrealDB connection
- no runtime, trading, risk, execution, broker, order, fill, position, or live-state changes
- no Live-Readiness change

## Evidence

The ontology seed already exists at:

- `docs/surrealdb/context-ontology-v0.yaml`

The active index surface is:

- `docs/db/index.md`

This PR only adds the missing index links required by #2041 and makes the already-landed #2038 ontology seed discoverable.

## Explicit non-approval note

This PR does **not** approve, merge, update, replace, or unblock PR #2223.

This PR does **not** approve, merge, update, replace, or unblock PR #2216.

Both remain frozen until reviewed separately.

## Validation checklist

- [ ] Diff is limited to `docs/db/index.md`
- [ ] Context Intelligence architecture link remains present
- [ ] Context Intelligence roadmap link remains present
- [ ] Context ontology seed link is present
- [ ] Context SurrealQL schema draft link is present
- [ ] Context validation document link is present
- [ ] Context agent handoff link remains present
- [ ] Governance Mirror section remains present
- [ ] Context Intelligence section remains present
- [ ] Governance Mirror and Context Intelligence remain separated
- [ ] No runtime behavior changed
- [ ] No trading behavior changed
- [ ] No live SurrealDB activation added
- [ ] Live-Readiness remains NO-GO
- [ ] PR checks reviewed

## Follow-ups

After this PR lands:

- continue Wave 7 with W07-C
- review PR #2223 disposition separately
- review PR #2216 disposition separately