### PR TITLE
[SURREALDB][CONTEXT] Add context indexer CLI scaffold (#2045)

### DIFF
--- a/tests/unit/surrealdb/test_context_indexer.py
+++ b/tests/unit/surrealdb/test_context_indexer.py
@@ -128,6 +128,67 @@ def test_apply_writes_allows_approved_output_roots(output: Path) -> None:
 
 
 @pytest.mark.unit
+def test_apply_writes_reports_not_dry_run_and_writes_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    scope_config = tmp_path / SCOPE_CONFIG
+    scope_config.parent.mkdir(parents=True)
+    source_config = Path(__file__).parents[3] / SCOPE_CONFIG
+    scope_config.write_text(source_config.read_text(encoding="utf-8"), encoding="utf-8")
+    output = Path("artifacts/context-indexer/result.json")
+
+    exit_code = main(
+        [
+            "scan",
+            "--scope-config",
+            str(scope_config),
+            "--apply-writes",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    written_payload = json.loads((tmp_path / output).read_text(encoding="utf-8"))
+    assert payload["dry_run"] is False
+    assert payload["write_requested"] is True
+    assert written_payload["dry_run"] is False
+    assert written_payload["write_requested"] is True
+
+
+@pytest.mark.unit
+def test_explicit_dry_run_suppresses_apply_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    scope_config = tmp_path / SCOPE_CONFIG
+    scope_config.parent.mkdir(parents=True)
+    source_config = Path(__file__).parents[3] / SCOPE_CONFIG
+    scope_config.write_text(source_config.read_text(encoding="utf-8"), encoding="utf-8")
+    output = Path("artifacts/context-indexer/result.json")
+
+    exit_code = main(
+        [
+            "scan",
+            "--scope-config",
+            str(scope_config),
+            "--apply-writes",
+            "--dry-run",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dry_run"] is True
+    assert payload["write_requested"] is True
+    assert not (tmp_path / output).exists()
+
+
+@pytest.mark.unit
 def test_missing_scope_config_returns_input_not_found(capsys) -> None:
     exit_code = main(
         ["scan", "--scope-config", "missing/context_ingestion_scope.yaml"]
@@ -136,6 +197,21 @@ def test_missing_scope_config_returns_input_not_found(capsys) -> None:
     assert exit_code == 3
     payload = json.loads(capsys.readouterr().out)
     assert payload["error"] == "scope_config_not_found"
+
+
+@pytest.mark.unit
+def test_directory_scope_config_returns_structured_validation_error(
+    tmp_path: Path, capsys
+) -> None:
+    config_dir = tmp_path / "scope-dir"
+    config_dir.mkdir()
+
+    exit_code = main(["validate", "--scope-config", str(config_dir)])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] == "scope_config_invalid"
+    assert "scope config is not a file" in payload["message"]
 
 
 @pytest.mark.unit

--- a/tests/unit/surrealdb/test_context_indexer.py
+++ b/tests/unit/surrealdb/test_context_indexer.py
@@ -1,0 +1,163 @@
+"""Unit tests for the Context Indexer CLI scaffold."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.surrealdb.context_indexer import (
+    SCHEMA_VERSION,
+    WriteDeniedError,
+    load_scope_config,
+    main,
+    validate_output_path,
+)
+
+
+SCOPE_CONFIG = Path("infrastructure/config/surrealdb/context_ingestion_scope.yaml")
+
+
+@pytest.mark.unit
+def test_scope_config_loads_canonical_file() -> None:
+    summary = load_scope_config(SCOPE_CONFIG)
+
+    assert summary.schema_version == "context-ingestion-scope/v0"
+    assert summary.sensitivity_classes == [
+        "forbidden",
+        "internal_context",
+        "public_context",
+        "sensitive_metadata",
+    ]
+    assert "docs/" in summary.include_paths
+    assert "tmp/" in summary.exclude_paths
+
+
+@pytest.mark.unit
+def test_scan_defaults_to_dry_run_and_never_connects_to_surrealdb(capsys) -> None:
+    exit_code = main(["scan", "--scope-config", str(SCOPE_CONFIG)])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["command"] == "scan"
+    assert payload["status"] == "scaffolded"
+    assert payload["dry_run"] is True
+    assert payload["write_requested"] is False
+    assert payload["surrealdb_connection"] == "disabled"
+    assert "full_file_discovery" in payload["deferred"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "command", ["scan", "plan", "export-jsonl", "snapshot", "validate"]
+)
+def test_all_command_stubs_return_scaffold_payload(command: str, capsys) -> None:
+    exit_code = main([command, "--scope-config", str(SCOPE_CONFIG), "--dry-run"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["command"] == command
+    assert payload["status"] == "scaffolded"
+    assert payload["surrealdb_connection"] == "disabled"
+
+
+@pytest.mark.unit
+def test_markdown_format_renders_without_writing(capsys) -> None:
+    exit_code = main(
+        [
+            "validate",
+            "--scope-config",
+            str(SCOPE_CONFIG),
+            "--format",
+            "markdown",
+        ]
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "# Context Indexer validate" in output
+    assert "SurrealDB connection: disabled" in output
+
+
+@pytest.mark.unit
+def test_help_works_for_top_level_and_command(capsys) -> None:
+    with pytest.raises(SystemExit) as top_level:
+        main(["--help"])
+    assert top_level.value.code == 0
+    assert "Context Indexer CLI scaffold" in capsys.readouterr().out
+
+    with pytest.raises(SystemExit) as command_help:
+        main(["scan", "--help"])
+    assert command_help.value.code == 0
+    assert "Path to context_ingestion_scope.yaml" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+def test_apply_writes_requires_explicit_output() -> None:
+    with pytest.raises(WriteDeniedError):
+        validate_output_path(None, apply_writes=True)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "output",
+    [
+        Path("tmp/context-indexer/result.json"),
+        Path("reports/context-indexer/result.json"),
+        Path("../artifacts/result.json"),
+        Path("C:/temp/context-indexer/result.json"),
+    ],
+)
+def test_apply_writes_rejects_unapproved_output_roots(output: Path) -> None:
+    with pytest.raises(WriteDeniedError):
+        validate_output_path(output, apply_writes=True)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "output",
+    [
+        Path("artifacts/context-indexer/result.json"),
+        Path("temp/context-indexer/result.json"),
+    ],
+)
+def test_apply_writes_allows_approved_output_roots(output: Path) -> None:
+    assert validate_output_path(output, apply_writes=True) == output
+
+
+@pytest.mark.unit
+def test_missing_scope_config_returns_input_not_found(capsys) -> None:
+    exit_code = main(
+        ["scan", "--scope-config", "missing/context_ingestion_scope.yaml"]
+    )
+
+    assert exit_code == 3
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] == "scope_config_not_found"
+
+
+@pytest.mark.unit
+def test_invalid_sensitivity_classes_fail_closed(tmp_path: Path, capsys) -> None:
+    config = tmp_path / "scope.yaml"
+    config.write_text(
+        """
+schema_version: context-ingestion-scope/v0
+include_paths: []
+conditional_paths: []
+exclude_paths: []
+allowed_file_types: []
+sensitivity_classes:
+  public_context: {}
+guardrails: []
+""".strip(),
+        encoding="utf-8",
+    )
+
+    exit_code = main(["validate", "--scope-config", str(config)])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] == "scope_config_invalid"
+    assert "sensitivity classes mismatch" in payload["message"]

--- a/tests/unit/surrealdb/test_context_indexer.py
+++ b/tests/unit/surrealdb/test_context_indexer.py
@@ -128,6 +128,41 @@ def test_apply_writes_allows_approved_output_roots(output: Path) -> None:
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("output", [Path("artifacts"), Path("temp")])
+def test_apply_writes_rejects_directory_only_output_paths(output: Path) -> None:
+    with pytest.raises(WriteDeniedError):
+        validate_output_path(output, apply_writes=True)
+
+
+@pytest.mark.unit
+def test_apply_writes_directory_output_returns_structured_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    scope_config = tmp_path / SCOPE_CONFIG
+    scope_config.parent.mkdir(parents=True)
+    source_config = Path(__file__).parents[3] / SCOPE_CONFIG
+    scope_config.write_text(source_config.read_text(encoding="utf-8"), encoding="utf-8")
+    Path("artifacts").mkdir()
+
+    exit_code = main(
+        [
+            "scan",
+            "--scope-config",
+            str(scope_config),
+            "--apply-writes",
+            "--output",
+            "artifacts",
+        ]
+    )
+
+    assert exit_code == 5
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] == "write_denied"
+    assert "output must include a file name" in payload["message"]
+
+
+@pytest.mark.unit
 def test_apply_writes_reports_not_dry_run_and_writes_output(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:

--- a/tools/surrealdb/context_indexer.py
+++ b/tools/surrealdb/context_indexer.py
@@ -141,9 +141,13 @@ def _path_entries(value: Any, key: str) -> list[str]:
 def load_scope_config(path: Path) -> ScopeConfigSummary:
     if not path.exists():
         raise ScopeConfigNotFoundError(f"scope config not found: {path}")
+    if not path.is_file():
+        raise ScopeConfigValidationError(f"scope config is not a file: {path}")
 
     try:
         data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ScopeConfigValidationError(f"scope config read failed: {exc}") from exc
     except yaml.YAMLError as exc:
         raise ScopeConfigValidationError(f"scope config YAML parse failed: {exc}") from exc
 
@@ -242,7 +246,7 @@ def render_payload(payload: dict[str, Any], output_format: str) -> str:
 
 
 def write_if_requested(result: CommandResult, rendered: str) -> None:
-    if not result.write_requested:
+    if not result.write_requested or result.dry_run:
         return
     if result.output is None:
         raise WriteDeniedError("writes require an explicit --output path")
@@ -283,7 +287,6 @@ def build_parser() -> argparse.ArgumentParser:
         subparser.add_argument(
             "--dry-run",
             action="store_true",
-            default=True,
             help="Simulate only. This is the default scaffold behavior.",
         )
         subparser.add_argument(

--- a/tools/surrealdb/context_indexer.py
+++ b/tools/surrealdb/context_indexer.py
@@ -1,0 +1,330 @@
+"""Context Indexer CLI scaffold for read-only scope-config validation.
+
+This module intentionally does not connect to SurrealDB and does not implement
+the full discovery, hashing, chunking, export, or snapshot pipeline. Those
+behaviors belong to later Context Intelligence slices.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+SCHEMA_VERSION = "context-indexer/v0"
+SCOPE_CONFIG_SCHEMA_VERSION = "context-ingestion-scope/v0"
+REQUIRED_SCOPE_KEYS = {
+    "schema_version",
+    "include_paths",
+    "conditional_paths",
+    "exclude_paths",
+    "allowed_file_types",
+    "sensitivity_classes",
+    "guardrails",
+}
+EXPECTED_SENSITIVITY_CLASSES = {
+    "public_context",
+    "internal_context",
+    "sensitive_metadata",
+    "forbidden",
+}
+SUPPORTED_FORMATS = {"json", "markdown", "text"}
+APPROVED_OUTPUT_ROOTS = ("artifacts", "temp")
+
+EXIT_VALIDATION_ERROR = 1
+EXIT_INPUT_NOT_FOUND = 3
+EXIT_UNSUPPORTED_FORMAT = 4
+EXIT_WRITE_DENIED = 5
+EXIT_INTERNAL_ERROR = 6
+
+
+class ContextIndexerError(Exception):
+    """Base error that maps to a stable CLI exit code."""
+
+    exit_code = EXIT_INTERNAL_ERROR
+
+    code = "internal_error"
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class ScopeConfigNotFoundError(ContextIndexerError):
+    exit_code = EXIT_INPUT_NOT_FOUND
+    code = "scope_config_not_found"
+
+
+class ScopeConfigValidationError(ContextIndexerError):
+    exit_code = EXIT_VALIDATION_ERROR
+    code = "scope_config_invalid"
+
+
+class UnsupportedFormatError(ContextIndexerError):
+    exit_code = EXIT_UNSUPPORTED_FORMAT
+    code = "unsupported_format"
+
+
+class WriteDeniedError(ContextIndexerError):
+    exit_code = EXIT_WRITE_DENIED
+    code = "write_denied"
+
+
+@dataclass(frozen=True)
+class ScopeConfigSummary:
+    path: str
+    schema_version: str
+    include_paths: list[str]
+    conditional_paths: list[str]
+    exclude_paths: list[str]
+    sensitivity_classes: list[str]
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    command: str
+    dry_run: bool
+    write_requested: bool
+    output: str | None
+    format: str
+    scope_config: ScopeConfigSummary
+    status: str = "scaffolded"
+    surrealdb_connection: str = "disabled"
+    message: str = "Command scaffold only; deeper indexer behavior is deferred."
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "command": self.command,
+            "status": self.status,
+            "message": self.message,
+            "dry_run": self.dry_run,
+            "write_requested": self.write_requested,
+            "output": self.output,
+            "format": self.format,
+            "surrealdb_connection": self.surrealdb_connection,
+            "scope_config": {
+                "path": self.scope_config.path,
+                "schema_version": self.scope_config.schema_version,
+                "include_paths": self.scope_config.include_paths,
+                "conditional_paths": self.scope_config.conditional_paths,
+                "exclude_paths": self.scope_config.exclude_paths,
+                "sensitivity_classes": self.scope_config.sensitivity_classes,
+            },
+            "deferred": [
+                "full_file_discovery",
+                "content_hashing",
+                "markdown_chunking",
+                "jsonl_artifact_export",
+                "snapshot_report_generation",
+                "surrealdb_import_apply_reconcile",
+            ],
+        }
+
+
+def _path_entries(value: Any, key: str) -> list[str]:
+    if not isinstance(value, list):
+        raise ScopeConfigValidationError(f"{key} must be a list")
+    paths: list[str] = []
+    for item in value:
+        if not isinstance(item, dict) or not item.get("path"):
+            raise ScopeConfigValidationError(f"{key} entries must contain path")
+        paths.append(str(item["path"]))
+    return sorted(paths)
+
+
+def load_scope_config(path: Path) -> ScopeConfigSummary:
+    if not path.exists():
+        raise ScopeConfigNotFoundError(f"scope config not found: {path}")
+
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ScopeConfigValidationError(f"scope config YAML parse failed: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ScopeConfigValidationError("scope config must be a YAML mapping")
+
+    missing = sorted(REQUIRED_SCOPE_KEYS - set(data))
+    if missing:
+        raise ScopeConfigValidationError(
+            f"scope config missing required keys: {', '.join(missing)}"
+        )
+
+    schema_version = data.get("schema_version")
+    if not schema_version:
+        raise ScopeConfigValidationError("scope config schema_version is required")
+    if schema_version != SCOPE_CONFIG_SCHEMA_VERSION:
+        raise ScopeConfigValidationError(
+            f"unsupported scope config schema_version: {schema_version}"
+        )
+
+    sensitivity_classes = data.get("sensitivity_classes")
+    if not isinstance(sensitivity_classes, dict):
+        raise ScopeConfigValidationError("sensitivity_classes must be a mapping")
+    found_classes = set(str(key) for key in sensitivity_classes)
+    if found_classes != EXPECTED_SENSITIVITY_CLASSES:
+        expected = ", ".join(sorted(EXPECTED_SENSITIVITY_CLASSES))
+        found = ", ".join(sorted(found_classes))
+        raise ScopeConfigValidationError(
+            f"sensitivity classes mismatch: expected {expected}; found {found}"
+        )
+
+    return ScopeConfigSummary(
+        path=path.as_posix(),
+        schema_version=str(schema_version),
+        include_paths=_path_entries(data["include_paths"], "include_paths"),
+        conditional_paths=_path_entries(data["conditional_paths"], "conditional_paths"),
+        exclude_paths=_path_entries(data["exclude_paths"], "exclude_paths"),
+        sensitivity_classes=sorted(found_classes),
+    )
+
+
+def validate_output_path(output: Path | None, apply_writes: bool) -> Path | None:
+    if not apply_writes:
+        return output
+    if output is None:
+        raise WriteDeniedError("writes require an explicit --output path")
+    if output.is_absolute() or output.drive or str(output).startswith("\\\\"):
+        raise WriteDeniedError("output must be a repo-relative path")
+
+    normalized = Path(*output.parts)
+    if ".." in normalized.parts:
+        raise WriteDeniedError("output path traversal is not allowed")
+    if not normalized.parts or normalized.parts[0] not in APPROVED_OUTPUT_ROOTS:
+        approved = ", ".join(f"{root}/" for root in APPROVED_OUTPUT_ROOTS)
+        raise WriteDeniedError(f"output must be under one of: {approved}")
+    return normalized
+
+
+def build_result(args: argparse.Namespace) -> CommandResult:
+    output = validate_output_path(args.output, args.apply_writes)
+    scope_summary = load_scope_config(args.scope_config)
+    return CommandResult(
+        command=args.command,
+        dry_run=not args.apply_writes or args.dry_run,
+        write_requested=args.apply_writes,
+        output=output.as_posix() if output is not None else None,
+        format=args.format,
+        scope_config=scope_summary,
+    )
+
+
+def render_payload(payload: dict[str, Any], output_format: str) -> str:
+    if output_format == "json":
+        return json.dumps(payload, sort_keys=True, indent=2)
+    if output_format == "markdown":
+        return "\n".join(
+            [
+                f"# Context Indexer {payload['command']}",
+                "",
+                f"Status: {payload['status']}",
+                f"Schema: {payload['schema_version']}",
+                f"Dry run: {payload['dry_run']}",
+                f"SurrealDB connection: {payload['surrealdb_connection']}",
+                f"Scope config: {payload['scope_config']['path']}",
+                "",
+                payload["message"],
+            ]
+        )
+    if output_format == "text":
+        return (
+            f"{payload['command']}: {payload['status']} "
+            f"(dry_run={payload['dry_run']}, "
+            f"surrealdb_connection={payload['surrealdb_connection']})"
+        )
+    raise UnsupportedFormatError(f"unsupported format: {output_format}")
+
+
+def write_if_requested(result: CommandResult, rendered: str) -> None:
+    if not result.write_requested:
+        return
+    if result.output is None:
+        raise WriteDeniedError("writes require an explicit --output path")
+    output_path = Path(result.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(rendered + "\n", encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Context Indexer CLI scaffold (read-only/dry-run by default)."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for command in ("scan", "plan", "export-jsonl", "snapshot", "validate"):
+        subparser = subparsers.add_parser(
+            command,
+            help=f"{command} scaffold; deeper behavior is deferred",
+        )
+        subparser.add_argument(
+            "--root",
+            type=Path,
+            default=Path("."),
+            help="Repo root for future scans (currently recorded only).",
+        )
+        subparser.add_argument(
+            "--scope-config",
+            type=Path,
+            required=True,
+            help="Path to context_ingestion_scope.yaml.",
+        )
+        subparser.add_argument(
+            "--output",
+            type=Path,
+            default=None,
+            help="Explicit output path. Writes require --apply-writes.",
+        )
+        subparser.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=True,
+            help="Simulate only. This is the default scaffold behavior.",
+        )
+        subparser.add_argument(
+            "--apply-writes",
+            action="store_true",
+            help="Opt in to writing an explicit --output under artifacts/ or temp/.",
+        )
+        subparser.add_argument(
+            "--format",
+            choices=sorted(SUPPORTED_FORMATS),
+            default="json",
+            help="Render format for scaffold output.",
+        )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        result = build_result(args)
+        rendered = render_payload(result.to_payload(), result.format)
+        write_if_requested(result, rendered)
+    except ContextIndexerError as exc:
+        print(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "status": "error",
+                    "error": exc.code,
+                    "message": exc.message,
+                },
+                sort_keys=True,
+            )
+        )
+        return exc.exit_code
+
+    print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/surrealdb/context_indexer.py
+++ b/tools/surrealdb/context_indexer.py
@@ -203,6 +203,8 @@ def validate_output_path(output: Path | None, apply_writes: bool) -> Path | None
     if not normalized.parts or normalized.parts[0] not in APPROVED_OUTPUT_ROOTS:
         approved = ", ".join(f"{root}/" for root in APPROVED_OUTPUT_ROOTS)
         raise WriteDeniedError(f"output must be under one of: {approved}")
+    if len(normalized.parts) == 1 or normalized.suffix == "":
+        raise WriteDeniedError("output must include a file name under an approved root")
     return normalized
 
 


### PR DESCRIPTION
Refs #2045
Refs #2046

## Summary
- Adds the Context Indexer CLI scaffold at tools/surrealdb/context_indexer.py.
- Validates/parses infrastructure/config/surrealdb/context_ingestion_scope.yaml and reports scaffold payloads for scan, plan, export-jsonl, snapshot, and validate.
- Keeps the CLI dry-run/read-only by default with approved output-root enforcement for artifacts/ and temp/.

## Scope
- CLI scaffold only.
- Does not implement full discovery, hashing, chunking, JSONL export, or snapshot generation.
- Does not connect, import, apply, or reconcile SurrealDB.
- No runtime, trading, risk, execution, Docker, compose, CI, DELIVERY_APPROVED, MCP, or Live-Readiness behavior change.
- Live-Readiness remains NO-GO.

## Validation
- python tools/surrealdb/context_indexer.py --help
- python tools/surrealdb/context_indexer.py scan --scope-config infrastructure/config/surrealdb/context_ingestion_scope.yaml --dry-run
- python tools/surrealdb/context_indexer.py validate --scope-config infrastructure/config/surrealdb/context_ingestion_scope.yaml --dry-run
- pytest -v tests/unit/surrealdb/test_context_indexer.py
- ruff check tools/surrealdb/context_indexer.py tests/unit/surrealdb/test_context_indexer.py
- git diff --check
- conflict-marker grep on changed files