### PR TITLE
fix: harden context indexer output writes

### DIFF
--- a/tests/unit/surrealdb/test_context_indexer.py
+++ b/tests/unit/surrealdb/test_context_indexer.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import pytest
 
 from tools.surrealdb.context_indexer import (
+    CommandResult,
+    ScopeConfigSummary,
     SCHEMA_VERSION,
     WriteDeniedError,
     load_scope_config,
@@ -128,6 +130,22 @@ def test_apply_writes_allows_approved_output_roots(output: Path) -> None:
 
 
 @pytest.mark.unit
+def test_apply_writes_rejects_symlink_escape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    try:
+        Path("artifacts").symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    with pytest.raises(WriteDeniedError):
+        validate_output_path(Path("artifacts/result.json"), apply_writes=True)
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("output", [Path("artifacts"), Path("temp")])
 def test_apply_writes_rejects_directory_only_output_paths(output: Path) -> None:
     with pytest.raises(WriteDeniedError):
@@ -221,6 +239,51 @@ def test_explicit_dry_run_suppresses_apply_writes(
     assert payload["dry_run"] is True
     assert payload["write_requested"] is True
     assert not (tmp_path / output).exists()
+
+
+@pytest.mark.unit
+def test_write_error_returns_structured_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    output_parent = Path("artifacts/context-indexer")
+    output_parent.parent.mkdir()
+    output_parent.write_text("not a directory", encoding="utf-8")
+    scope_config = ScopeConfigSummary(
+        path="scope.yaml",
+        schema_version="context-ingestion-scope/v0",
+        include_paths=[],
+        conditional_paths=[],
+        exclude_paths=[],
+        sensitivity_classes=[],
+    )
+    result = CommandResult(
+        command="scan",
+        dry_run=False,
+        write_requested=True,
+        output="artifacts/context-indexer/result.json",
+        format="json",
+        scope_config=scope_config,
+    )
+    monkeypatch.setattr(
+        "tools.surrealdb.context_indexer.build_result", lambda args: result
+    )
+
+    exit_code = main(
+        [
+            "scan",
+            "--scope-config",
+            "unused.yaml",
+            "--apply-writes",
+            "--output",
+            result.output,
+        ]
+    )
+
+    assert exit_code == 5
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] == "output_write_failed"
+    assert "output write failed" in payload["message"]
 
 
 @pytest.mark.unit

--- a/tools/surrealdb/context_indexer.py
+++ b/tools/surrealdb/context_indexer.py
@@ -75,6 +75,11 @@ class WriteDeniedError(ContextIndexerError):
     code = "write_denied"
 
 
+class OutputWriteError(ContextIndexerError):
+    exit_code = EXIT_WRITE_DENIED
+    code = "output_write_failed"
+
+
 @dataclass(frozen=True)
 class ScopeConfigSummary:
     path: str
@@ -205,6 +210,16 @@ def validate_output_path(output: Path | None, apply_writes: bool) -> Path | None
         raise WriteDeniedError(f"output must be under one of: {approved}")
     if len(normalized.parts) == 1 or normalized.suffix == "":
         raise WriteDeniedError("output must include a file name under an approved root")
+
+    repo_root = Path.cwd().resolve()
+    approved_root = repo_root / normalized.parts[0]
+    resolved_output = (repo_root / normalized).resolve(strict=False)
+    try:
+        resolved_output.relative_to(approved_root)
+    except ValueError as exc:
+        raise WriteDeniedError(
+            "output path must resolve under its approved repo-local root"
+        ) from exc
     return normalized
 
 
@@ -252,9 +267,14 @@ def write_if_requested(result: CommandResult, rendered: str) -> None:
         return
     if result.output is None:
         raise WriteDeniedError("writes require an explicit --output path")
-    output_path = Path(result.output)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(rendered + "\n", encoding="utf-8")
+    output_path = validate_output_path(Path(result.output), apply_writes=True)
+    if output_path is None:
+        raise WriteDeniedError("writes require an explicit --output path")
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(rendered + "\n", encoding="utf-8")
+    except OSError as exc:
+        raise OutputWriteError(f"output write failed: {exc}") from exc
 
 
 def build_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
## Summary
- Resolve context-indexer output paths against approved repo-local roots before write-enabled output.
- Return structured `output_write_failed` errors for filesystem write failures instead of tracebacks.
- Add regressions for symlink escape blocking and write failure envelopes.

## Why
Follow-up to #2045 and merged PR #2230 review feedback. PR #2230 is already merged, so these hardening fixes are carried on a new follow-up branch.

## How to validate
- `pytest -v tests/unit/surrealdb/test_context_indexer.py`
- `ruff check tools/surrealdb/context_indexer.py tests/unit/surrealdb/test_context_indexer.py`
- `git diff --check`
- `python tools/surrealdb/context_indexer.py scan --scope-config "."`

## Screenshots / GIF (if UI changes)
- n.a.

## Risk / rollout notes
- Scope is limited to the offline context-indexer CLI and unit tests.
- No runtime, trading, risk, broker, order, live-state, secrets, SurrealDB production activation, or Live-Readiness change.
