### PR TITLE
ci: remove core/service label gate

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -85,12 +85,13 @@ Zusätzlich:
 | `testing` | Test-Coverage, E2E |
 | `dependencies` | Dependabot Updates |
 
-> **Hinweis:** `dependencies` ist kein policy-gate Override. Dependabot-PRs, die
-> Python-Abhängigkeiten oder App-Code berühren, fallen in `core/service` und brauchen
-> `manual-approval` oder `allow-core-change`.
+> **Hinweis:** `dependencies` ist kein eigener `policy-gate`-Pfad. Dependabot-PRs,
+> die Python-Abhängigkeiten oder App-Code berühren, fallen in `core/service`, brauchen
+> aber kein `manual-approval` oder `allow-core-change`, um `policy-gate` zu bestehen.
 >
-> `manual-approval` und `allow-core-change` sind **Governance-only Labels** — sie werden
-> außerhalb des synced Label-Sets verwaltet und erscheinen nicht in `labels.json`.
+> `manual-approval` und `allow-core-change` sind **Governance-only Labels** für
+> optionale Triage/Review-Zwecke — sie werden außerhalb des synced Label-Sets
+> verwaltet und erscheinen nicht in `labels.json`.
 
 ---
 

--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -167,12 +167,8 @@ jobs:
               } else {
                 passes.push('infra-only scope validated');
               }
-            } else if (!hasLabel('manual-approval') && !hasLabel('allow-core-change')) {
-              failures.push(
-                'core/service changes require the label manual-approval or allow-core-change'
-              );
             } else {
-              passes.push('core/service override label present');
+              passes.push('core/service scope classified; no manual label required');
             }
 
             const workflowFiles = files.filter(

--- a/docs/runbooks/merge_policy_ci_gate.md
+++ b/docs/runbooks/merge_policy_ci_gate.md
@@ -131,7 +131,7 @@ and changed files:
 | `docs-only` | `docs-only` | `[docs-only]` or `docs-only:` | `docs/**` and `*.md` |
 | `workflows-only` | `workflows-only` | `[workflows-only]` or `workflows-only:` | `.github/workflows/*.yml` and `.github/workflows/*.yaml` plus the fixed companion docs `docs/runbooks/project_board_automation.md`, `docs/runbooks/merge_policy_ci_gate.md`, `docs/runbooks/CONTROL_REGISTER.md` |
 | `infra-only` | `infra-only` | `[infra-only]` or `infra-only:` | `infrastructure/**` and `.github/workflows/**` |
-| `core/service` | none | none | Any other diff; requires `manual-approval` or `allow-core-change` |
+| `core/service` | none | none | Any other diff; no override label required |
 
 > **Auto-inference:** `infra-only` is inferred automatically only when **all** changed files
 > are pure `infrastructure/**` paths. Mixed diffs (e.g. `infrastructure/**` +
@@ -152,16 +152,19 @@ Hard-fails for workflow changes in `.github/workflows/**`:
 - Any workflow missing an explicit `permissions:` section
 - Any workflow containing `write-all`
 
-`manual-approval` and `allow-core-change` are explicit override labels for
-`core/service` PRs. They do not bypass the workflow safety checks above.
+`manual-approval` and `allow-core-change` are optional triage/review labels for
+`core/service` PRs. They are not required for `policy-gate` to pass and they do
+not bypass the workflow safety checks above.
 
 ### Dependabot / Bot PRs
 
 Dependabot-PRs für Python-Abhängigkeiten oder App-Code (z.B. `requirements*.txt`,
-`pyproject.toml`) fallen in `core/service`, weil das `dependencies`-Label **kein Gate-Override**
-ist und diese Dateien nicht unter `docs/**`, `.github/workflows/**` oder `infrastructure/**`
-liegen. Sicherer Operator-Pfad: PR prüfen, dann `manual-approval` oder `allow-core-change`
-setzen. Keine Automatik. Das Gate bleibt fail-closed.
+`pyproject.toml`) fallen in `core/service`, weil das `dependencies`-Label keine
+eigene Kategorie auslöst und diese Dateien nicht unter `docs/**`,
+`.github/workflows/**` oder `infrastructure/**` liegen. Diese PRs brauchen kein
+`manual-approval` oder `allow-core-change`, bleiben aber normale
+Implementierungs-PRs mit Pflicht zu CI und menschlicher Merge-Prüfung. Keine
+Automatik.
 
 Dependabot-PRs, die **ausschließlich** `.github/workflows/**` oder `infrastructure/**` berühren,
 werden als `workflows-only` bzw. `infra-only` auto-inferred und benötigen keinen Override.
@@ -176,6 +179,23 @@ sauber mergebar, wenn die Dependency für aktive Service-Buildpfade nicht runtim
 
 The gate reevaluates on `opened`, `synchronize`, `reopened`, `labeled`,
 `unlabeled`, and `edited` so label removals cannot leave a stale PASS behind.
+
+## Guardrails After This Change
+
+- `policy-gate` bleibt ein erforderlicher PR-Context auf `main`.
+- `policy-gate` klassifiziert PRs weiter nach `docs-only`, `workflows-only`,
+  `infra-only` und `core/service`.
+- `core/service` braucht keine Override-Labels mehr, um `policy-gate` zu
+  bestehen.
+- `manual-approval` und `allow-core-change` bleiben optionale Triage- und
+  Review-Labels; sie sind keine erforderlichen Merge-Gate-Labels mehr.
+- Workflow-Sicherheits-Hard-Fails für `pull_request_target`, fehlendes
+  explizites `permissions:`, `write-all` und unsicheres `workflow_run`-Checkout
+  bleiben unverändert erzwungen.
+- Normale Implementierungs-PRs müssen weiterhin die übrige CI und die
+  menschliche Merge-Prüfung bestehen.
+- Live-Readiness bleibt `NO-GO`; diese Policy-Änderung autorisiert kein
+  Runtime-, Trading- oder Live-Verhalten.
 
 ## Workflow Permissions
 


### PR DESCRIPTION
## What changed
- Removed the `policy-gate` failure path that required `manual-approval` or `allow-core-change` for ordinary `core/service` PRs.
- Kept `policy-gate` as a required PR context that still classifies PR scope and writes the policy summary.
- Updated `docs/runbooks/merge_policy_ci_gate.md` and `.github/LABELS.md` so the labels are documented as optional triage/review labels only.

## Why the label gate was removed
- Normal implementation PRs were repeatedly blocked even when they only needed standard CI and human review.
- The label requirement added false blockers without adding workflow-file safety.

## What safety checks remain
- `policy-gate` still exists and remains the same required check name.
- Workflow hard-fails remain in place for `pull_request_target`, missing explicit `permissions:`, `write-all`, and unsafe `workflow_run` checkout behavior.
- Scope classification for `docs-only`, `workflows-only`, `infra-only`, and `core/service` remains intact.
- Normal implementation PRs still require CI and human merge review.

## Validation performed
- `git diff --check`
- `python .github/scripts/control_plane_validate.py`
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/policy-gate.yml', encoding='utf-8').read())"`
- `rg -n "manual-approval|allow-core-change|core/service changes require|override label|Gate-Override|gate override" .github docs knowledge scripts tools tests`

## Confirmation
- No Live-Readiness change
- No SurrealDB production activation
- No trading runtime change
- No branch protection change
- No merge performed
