### PR TITLE
[ARVP][TEST] Characterize primary breakout lookback semantics (#1941)

### DIFF
--- a/tests/unit/replay/test_historical_bridge.py
+++ b/tests/unit/replay/test_historical_bridge.py
@@ -1,5 +1,9 @@
 """Unit tests for deterministic primary breakout historical bridge."""
 
+from __future__ import annotations
+
+from unittest.mock import patch
+
 import pytest
 
 from core.replay.historical_bridge import (
@@ -7,6 +11,8 @@ from core.replay.historical_bridge import (
     PrimaryBreakoutBridgeConfig,
     build_primary_breakout_historical_bridge,
 )
+from services.signal.config import SignalConfig
+from services.signal.service import SignalEngine
 
 
 def _candles(
@@ -32,6 +38,11 @@ def _candles(
         }
         rows.append(row)
     return rows
+
+
+def _make_runtime_engine(config: SignalConfig) -> SignalEngine:
+    with patch("services.signal.service.config", config):
+        return SignalEngine()
 
 
 @pytest.mark.unit
@@ -131,3 +142,78 @@ def test_bridge_rejects_invalid_trade_side_mode_in_config() -> None:
 
     with pytest.raises(HistoricalBridgeError, match="trade_side_mode must be long_only"):
         build_primary_breakout_historical_bridge(candles, config=config)
+
+
+@pytest.mark.unit
+def test_runtime_and_historical_bridge_align_on_first_evaluable_breakout() -> None:
+    bridge_config = PrimaryBreakoutBridgeConfig(
+        entry_lookback_minutes=3,
+        exit_lookback_minutes=2,
+        breakout_buffer=0.0,
+        min_minutes_between_entries=0,
+    )
+    signal_config = SignalConfig(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        min_volume=100.0,
+        entry_lookback_minutes=3,
+        exit_lookback_minutes=2,
+        breakout_buffer=0.0,
+        min_minutes_between_entries=0,
+        trade_side_mode="long_only",
+    )
+    base_ts_ms = 1_700_000_000_000
+    candles = [
+        {
+            "symbol": "BTCUSDT",
+            "ts_ms": base_ts_ms + index * 60_000,
+            "open": 99.5 + index,
+            "high": 100.0 + index,
+            "low": 99.0 + index,
+            "close": 100.0 + index,
+            "volume": 10_000.0 + index,
+            "regime_id": 0,
+            "market_state_fresh": True,
+            "regime_fresh": True,
+        }
+        for index in range(4)
+    ]
+
+    runtime_engine = _make_runtime_engine(signal_config)
+    runtime_signal = None
+    runtime_signal_index = None
+    for index, candle in enumerate(candles):
+        signal = runtime_engine.process_market_data(
+            {
+                "symbol": candle["symbol"],
+                "timestamp": candle["ts_ms"] // 1000,
+                "price": candle["close"],
+                "close": candle["close"],
+                "high": candle["high"],
+                "low": candle["low"],
+                "volume": candle["volume"],
+                "regime_id": candle["regime_id"],
+                "market_state_fresh": candle["market_state_fresh"],
+                "regime_fresh": candle["regime_fresh"],
+            }
+        )
+        if signal is not None:
+            runtime_signal = signal
+            runtime_signal_index = index
+
+    requests = build_primary_breakout_historical_bridge(candles, config=bridge_config)
+
+    assert len(requests) == 1
+    assert runtime_signal is not None
+    assert runtime_signal_index == 3
+    assert runtime_signal.side == "BUY"
+    assert runtime_signal.reason == "breakout_entry"
+
+    first_request = requests[0]
+    assert int(first_request.market_event["ts_ms"]) == candles[runtime_signal_index]["ts_ms"]
+    assert first_request.market_event["market_state"]["close_now"] == runtime_signal.price
+    assert (
+        first_request.market_event["market_state"]["highest_high"]
+        == runtime_signal.metadata["highest_high"]
+        == 102.0
+    )

--- a/tests/unit/signal/test_breakout_v1_deterministic.py
+++ b/tests/unit/signal/test_breakout_v1_deterministic.py
@@ -172,6 +172,45 @@ def test_no_signal_before_warmup():
 
 
 @pytest.mark.unit
+def test_runtime_lookback_is_elapsed_time_not_sample_count_regression():
+    """
+    Regression for #1941: dense observations must not satisfy the warmup span
+    unless the elapsed wall-clock time covers the configured lookback window.
+    """
+    config = _make_config()
+    engine = _make_engine(config)
+    base_ts = 1_700_000_000
+
+    # 180 one-second ticks produce far more observations than the 3-minute
+    # lookback value, but they still span only 179 seconds of wall-clock time.
+    for second_offset in range(180):
+        signal = _tick(
+            engine,
+            ts=base_ts + second_offset,
+            price=100.0,
+            high=100.0,
+            low=99.0,
+        )
+        assert signal is None, (
+            "Dense ticks below the elapsed-time warmup span must not emit a BUY"
+        )
+
+    # The next tick reaches the full 3-minute span and becomes the first
+    # evaluable breakout boundary.
+    signal = _tick(
+        engine,
+        ts=base_ts + 180,
+        price=101.0,
+        high=101.0,
+        low=100.0,
+    )
+
+    assert signal is not None
+    assert signal.side == "BUY"
+    assert signal.reason == "breakout_entry"
+
+
+@pytest.mark.unit
 def test_no_signal_price_at_exactly_highest_high():
     """
     Boundary: close_now == highest_high must NOT fire (strict >, buffer=0.0).

--- a/tests/unit/validation/test_primary_breakout_backtest_runner.py
+++ b/tests/unit/validation/test_primary_breakout_backtest_runner.py
@@ -615,3 +615,42 @@ def test_primary_breakout_backtest_runner_gate_trace_schema_and_single_pass(tmp_
         record = json.loads(line)
         missing = required_fields - set(record.keys())
         assert not missing, f"Missing fields in trace record: {missing}"
+
+
+@pytest.mark.unit
+def test_gate_trace_shows_fresh_trend_but_not_entry_ready_when_breakout_not_met(
+    tmp_path: Path,
+) -> None:
+    candles = _candles()[:250]
+    for candle in candles:
+        candle["open"] = 99.9
+        candle["high"] = 100.2
+        candle["low"] = 99.8
+        candle["close"] = 100.0
+        candle["market_state_fresh"] = True
+        candle["regime_fresh"] = True
+        candle["regime_id"] = 0
+
+    trace_path = tmp_path / "fresh_trend_no_breakout.jsonl"
+
+    report = run_primary_breakout_backtest(
+        candles,
+        run_config=PrimaryBreakoutBacktestRunConfig(),
+        code_commit="trace-no-breakout-test",
+        gate_trace_path=trace_path,
+    )
+
+    assert report["metrics"]["signals_total"] == 0
+    lines = trace_path.read_text(encoding="utf-8").strip().split("\n")
+    assert lines
+
+    first_record = json.loads(lines[0])
+    assert first_record["market_state_fresh"] is True
+    assert first_record["regime_fresh"] is True
+    assert first_record["regime_id"] == 0
+    assert first_record["has_trend_regime"] is True
+    assert first_record["entry_blocked"] is False
+    assert first_record["entry_cooldown_active"] is False
+    assert first_record["entry_ready"] is False
+    assert first_record["status"] == "no_signal"
+    assert first_record["close_now"] < first_record["breakout_threshold"]


### PR DESCRIPTION
Follow-up to #1941.

Test-only characterization PR.

What semantics are locked:
- Primary Breakout lookback semantics are elapsed-time/window based, not dense sample-count based.
- Runtime SignalEngine and Historical Bridge align on the first evaluable breakout boundary under strict 1m cadence.
- Gate trace explains a fresh TREND case where entry is still not ready because breakout/warm-up conditions are not met.

Files changed:
- tests/unit/signal/test_breakout_v1_deterministic.py
- tests/unit/replay/test_historical_bridge.py
- tests/unit/validation/test_primary_breakout_backtest_runner.py

Validation commands and raw results:
- pytest -v tests/unit/signal/test_breakout_v1_deterministic.py -> 12 passed in 0.30s
- pytest -v tests/unit/replay/test_historical_bridge.py -> 9 passed in 0.26s
- pytest -v tests/unit/validation/test_primary_breakout_backtest_runner.py -> 11 passed in 0.29s
- pytest -v tests/unit/validation/test_strategy_replay_runner.py -k gate_trace -> 3 passed, 77 deselected, 2 warnings in 0.38s
- uff check tests/unit/signal/test_breakout_v1_deterministic.py tests/unit/replay/test_historical_bridge.py tests/unit/validation/test_primary_breakout_backtest_runner.py -> All checks passed!
- git diff --check -> xit 0; LF/CRLF warnings only, no diff-check errors

Confirmation:
- No production code changed.
- No signal/runtime behavior changed.
- No execution-realism implementation.
- No calibration implementation.
- #1905 remains parked.
- No Live-Readiness change.
- No Echtgeld / real-money implication.
- No SurrealDB production activation.
- No merge performed.