### PR TITLE
docs: remove cdb drift reconcile canon drift (#2210)

### DIFF
--- a/.opencode/skills/cdb-drift-reconcile/SKILL.md
+++ b/.opencode/skills/cdb-drift-reconcile/SKILL.md
@@ -25,7 +25,7 @@ Check known drift vectors against the current canon and return a bounded reconci
 Always check these areas unless the request explicitly narrows scope further:
 
 - Solo-Maintainer-Drift in SOPs
-- Terminologie-Drift: `Risk Service` / `cdb_risk` instead of legacy `BLACK`
+- Terminologie-Drift: use `Risk Service` / `cdb_risk` consistently; avoid stale service terminology
 - Stack-Canon-Drift: `BLUE/RED` instead of legacy single-compose language
 - Secrets-Canon-Drift
 - SSOT-Grenzen between `CURRENT_STATUS.md` and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`


### PR DESCRIPTION
Refs #2210

Was geaendert wurde
- In `.opencode/skills/cdb-drift-reconcile/SKILL.md` die Drift-Bullet so umformuliert, dass keine legacy-Terminologie mehr referenziert wird; aktuelle Terminologie `Risk Service` / `cdb_risk` bleibt explizit.

Betroffene Datei
- `.opencode/skills/cdb-drift-reconcile/SKILL.md`

Validierung (raw)
- `git diff -- .opencode/skills/cdb-drift-reconcile/SKILL.md`
```diff
diff --git a/.opencode/skills/cdb-drift-reconcile/SKILL.md b/.opencode/skills/cdb-drift-reconcile/SKILL.md
index 54b20483..aa7a2c64 100644
--- a/.opencode/skills/cdb-drift-reconcile/SKILL.md
+++ b/.opencode/skills/cdb-drift-reconcile/SKILL.md
@@ -25,7 +25,7 @@ Check known drift vectors against the current canon and return a bounded reconci
 Always check these areas unless the request explicitly narrows scope further:
 
 - Solo-Maintainer-Drift in SOPs
-- Terminologie-Drift: `Risk Service` / `cdb_risk` instead of legacy `BLACK`
+- Terminologie-Drift: use `Risk Service` / `cdb_risk` consistently; avoid stale service terminology
 - Stack-Canon-Drift: `BLUE/RED` instead of legacy single-compose language
 - Secrets-Canon-Drift
 - SSOT-Grenzen between `CURRENT_STATUS.md` and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
```
- `rg -n "BLACK|legacy BLACK|Risk Service|cdb_risk" .opencode/skills/cdb-drift-reconcile/SKILL.md`
```text
28:- Terminologie-Drift: use `Risk Service` / `cdb_risk` consistently; avoid stale service terminology
```
- `git diff --check`
```text
warning: in the working copy of '.opencode/skills/cdb-drift-reconcile/SKILL.md', LF will be replaced by CRLF the next time Git touches it
```

Bestaetigung
- Docs/Skill-Text only
- No production code changed
- No runtime/trading/risk/execution behavior changed
- No Live-Readiness change
- No Echtgeld implication
- No merge performed