### PR TITLE
feat(surrealdb): scaffold context_importer CLI (#2068)

### DIFF
--- a/docs/surrealdb/context-importer-cli-contract.md
+++ b/docs/surrealdb/context-importer-cli-contract.md
@@ -1,0 +1,142 @@
+# Context Importer CLI Contract
+
+**Status**: Draft (Scaffold-Slice)
+**Authority**: Issue #2068 / Wave 10 Parent #2067 / Epic #1976
+**Target**: `tools/surrealdb/context_importer.py`
+**Scope**: CLI scaffold only — no SurrealDB connection, no writes, no JSONL parsing.
+
+---
+
+## 1. Zweck
+
+Dieser Vertrag beschreibt die CLI-Oberflaeche fuer den zukuenftigen
+Context-Import-Pfad (JSONL-Artefakte aus dem Context Indexer nach SurrealDB).
+In #2068 wird ausschliesslich das Scaffold geliefert: Argument-Parsing,
+Help-Text, Default-Verhalten und Safety-Gates. Jede echte Logik (JSONL-Validation,
+Plan-Berechnung, Apply, Audit, Rollback-Plan) gehoert zu separaten Folge-Slices.
+
+---
+
+## 2. Command-Modell (v0, Scaffold)
+
+| Command | Zweck (Endziel) | Verhalten in #2068 |
+|---|---|---|
+| `validate-jsonl` | JSONL-Artefakte gegen Schema pruefen | Stub: `scaffold-ack`, Exit `0` |
+| `plan` | Diff JSONL ↔ SurrealDB berechnen | Stub: `scaffold-ack`, Exit `0` |
+| `dry-run` | End-to-End-Lauf ohne Schreiben | Stub: `scaffold-ack`, Exit `0` |
+| `apply` | Schreiben nach SurrealDB | Hart geblockt: Exit `5` (`WRITE_DENIED`) |
+| `audit` | Audit-Trail-Export | Stub: `scaffold-ack`, Exit `0` |
+| `rollback-plan` | Rollback-Plan generieren | Stub: `scaffold-ack`, Exit `0` |
+
+`apply` existiert als Subcommand und auch als globales Flag `--apply`. Beide
+Pfade fuehren in #2068 zu Exit-Code `5`. Die Tests bestaetigen das als
+hartes Sicherheitsnetz; das Verhalten darf erst durch einen expliziten
+Folge-Slice (Apply-Implementation) entfernt werden.
+
+---
+
+## 3. Sicherheitsmodell und Guardrails
+
+- **Read-only Default**: Alle Subcommands sind Stubs, die nur eine
+  deterministische JSON-Antwort drucken.
+- **Dry-run Default**: Ohne explizites `--apply` ist `dry_run = true`.
+- **Apply hart geblockt**: `--apply` und `apply` exit `5` (`WRITE_DENIED`).
+- **Keine SurrealDB-Verbindung**: `--surreal-url`, `--namespace`,
+  `--database` werden geparsed, aber nie verwendet. Die Antwort enthaelt
+  immer `surrealdb_connection: "disabled"`.
+- **Output-Pfad-Whitelist**: `--report-output` muss unter `artifacts/`
+  oder `temp/` liegen. Absolute Pfade (`/...`, `C:\...`, UNC) und
+  Traversal (`..`) werden mit Exit `5` verworfen. Der Scaffold schreibt
+  selbst nichts.
+- **Keine Config-Loader-Logik**: gehoert zu #2069.
+- **Keine JSONL-Validation-Logik**: gehoert zu Folge-Slice.
+- **Keine Plan-/Audit-/Rollback-Logik**: jeweils eigene Folge-Slices.
+
+---
+
+## 4. Argument-Vertrag (pro Subcommand)
+
+| Argument | Default | Pflicht? | Verhalten im Scaffold |
+|---|---|---|---|
+| `--input-dir` | `None` | nein | nicht gelesen |
+| `--surreal-url` | `""` | nein | nicht verwendet |
+| `--namespace` | `None` | nein | nicht verwendet |
+| `--database` | `None` | nein | nicht verwendet |
+| `--run-id` | `None` | nein | nur geparsed |
+| `--report-output` | `None` | nein | Whitelist-Check, kein Write |
+| `--dry-run` | `False` (Default-Verhalten ist dennoch dry-run) | nein | redundant; explizit erlaubt |
+| `--apply` | `False` | nein | `True` ⇒ Exit `5` |
+| `--format` | `json` | nein | `json` / `jsonl` / `markdown` |
+
+---
+
+## 5. Exit-Codes
+
+| Code | Bedeutung |
+|---|---|
+| 0 | Erfolg / Scaffold acknowledged |
+| 1 | Validierungsfehler (reserviert; im Scaffold nicht ausgeloest) |
+| 2 | CLI-Usage / argparse-Fehler |
+| 3 | Input-Datei nicht gefunden (reserviert) |
+| 4 | Unsupported Format (defensiv; argparse faengt das frueher) |
+| 5 | Write denied (Pfad-Verstoss ODER Apply im Scaffold) |
+| 6 | Interner Fehler |
+
+---
+
+## 6. Antwort-Schema
+
+Erfolgsantwort (Subcommand-Stub):
+
+```json
+{
+  "schema_version": "context-importer/v0",
+  "command": "<subcommand>",
+  "status": "scaffold-ack",
+  "dry_run": true,
+  "apply_requested": false,
+  "surrealdb_connection": "disabled",
+  "implemented": false,
+  "note": "scaffold only; ..."
+}
+```
+
+Fehlerantwort:
+
+```json
+{
+  "schema_version": "context-importer/v0",
+  "status": "error",
+  "error": "WRITE_DENIED",
+  "message": "..."
+}
+```
+
+`schema_version` ist Vertragskonstante (`context-importer/v0`) und wird
+weder aus CLI-Args noch aus der Umgebung abgeleitet.
+
+---
+
+## 7. Anforderungen fuer Folge-Slices
+
+- `validate-jsonl`-Implementierung darf das Antwort-Schema erweitern,
+  aber `schema_version`, `command`, `status`, `dry_run`,
+  `apply_requested`, `surrealdb_connection` muessen erhalten bleiben.
+- Die Apply-Implementierung muss den Hard-Block ersetzen, NICHT lediglich
+  umgehen, und muss zwingend einen Two-Step-Gate (`--apply`
+  + zusaetzliche explizite Bestaetigung) bewahren.
+- Jeder Slice, der eine SurrealDB-Verbindung einfuehrt, muss
+  `surrealdb_connection` korrekt setzen und mindestens einen Test
+  liefern, der den Connection-Pfad explizit verifiziert.
+
+---
+
+## 8. Nicht-Ziele in #2068
+
+- Keine SurrealDB-Verbindung.
+- Kein SurrealDB-Write.
+- Keine JSONL-Validierung.
+- Keine Plan-/Apply-/Audit-/Rollback-Logik.
+- Keine Aenderung an Trading-, Risk-, Execution-, Secrets- oder
+  Live-Readiness-Pfaden.
+- Kein Echtgeld-/Live-Enable.

--- a/tests/unit/surrealdb/test_context_importer.py
+++ b/tests/unit/surrealdb/test_context_importer.py
@@ -1,0 +1,240 @@
+"""Unit tests for the Context Importer CLI scaffold (#2068)."""
+
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+
+import pytest
+
+from tools.surrealdb.context_importer import (
+    ALLOWED_OUTPUT_PREFIXES,
+    EXIT_OK,
+    EXIT_UNSUPPORTED_FORMAT,
+    EXIT_USAGE_ERROR,
+    EXIT_WRITE_DENIED,
+    SCHEMA_VERSION,
+    SUPPORTED_COMMANDS,
+    WriteDeniedError,
+    build_parser,
+    main,
+)
+
+
+SCAFFOLD_COMMANDS_WITHOUT_APPLY = tuple(c for c in SUPPORTED_COMMANDS if c != "apply")
+
+
+def _read_json(capsys) -> dict:
+    out = capsys.readouterr().out.strip()
+    return json.loads(out)
+
+
+@pytest.mark.unit
+def test_schema_version_constant_is_pinned() -> None:
+    assert SCHEMA_VERSION == "context-importer/v0"
+
+
+@pytest.mark.unit
+def test_supported_commands_match_issue_2068_spec() -> None:
+    assert SUPPORTED_COMMANDS == (
+        "validate-jsonl",
+        "plan",
+        "dry-run",
+        "apply",
+        "audit",
+        "rollback-plan",
+    )
+
+
+@pytest.mark.unit
+def test_top_level_help_exits_zero(capsys) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--help"])
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr().out
+    assert "context_importer" in captured
+    # All v0 commands must appear in help output.
+    for command in SUPPORTED_COMMANDS:
+        assert command in captured
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("command", SUPPORTED_COMMANDS)
+def test_subcommand_help_exits_zero(command: str, capsys) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main([command, "--help"])
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert command in out
+    assert "--dry-run" in out
+    assert "--apply" in out
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("command", SCAFFOLD_COMMANDS_WITHOUT_APPLY)
+def test_scaffold_commands_default_to_dry_run(command: str, capsys) -> None:
+    exit_code = main([command])
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["command"] == command
+    assert payload["status"] == "scaffold-ack"
+    assert payload["dry_run"] is True
+    assert payload["apply_requested"] is False
+    assert payload["surrealdb_connection"] == "disabled"
+    assert payload["implemented"] is False
+
+
+@pytest.mark.unit
+def test_apply_subcommand_is_hard_blocked(capsys) -> None:
+    exit_code = main(["apply"])
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["status"] == "error"
+    assert payload["error"] == "WRITE_DENIED"
+    assert "apply" in payload["message"].lower()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("command", SCAFFOLD_COMMANDS_WITHOUT_APPLY)
+def test_apply_flag_is_hard_blocked_on_any_command(command: str, capsys) -> None:
+    exit_code = main([command, "--apply"])
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+
+
+@pytest.mark.unit
+def test_unknown_subcommand_exits_with_argparse_usage_error(capsys) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["does-not-exist"])
+    # argparse uses exit code 2 for usage errors, which matches our contract.
+    assert excinfo.value.code == EXIT_USAGE_ERROR
+
+
+@pytest.mark.unit
+def test_unsupported_format_is_rejected_by_argparse(capsys) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["plan", "--format", "xml"])
+    # argparse rejects choices before we ever reach our handler.
+    assert excinfo.value.code == EXIT_USAGE_ERROR
+
+
+@pytest.mark.unit
+def test_jsonl_format_renders_single_line(capsys) -> None:
+    exit_code = main(["plan", "--format", "jsonl"])
+    assert exit_code == EXIT_OK
+    out = capsys.readouterr().out.strip()
+    assert "\n" not in out
+    payload = json.loads(out)
+    assert payload["command"] == "plan"
+
+
+@pytest.mark.unit
+def test_markdown_format_renders_human_readable(capsys) -> None:
+    exit_code = main(["plan", "--format", "markdown"])
+    assert exit_code == EXIT_OK
+    out = capsys.readouterr().out
+    assert out.startswith("# context_importer: plan")
+    assert "**status**" in out
+
+
+@pytest.mark.unit
+def test_report_output_path_outside_whitelist_is_rejected(capsys) -> None:
+    exit_code = main(["plan", "--report-output", "etc/foo.json"])
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("prefix", ALLOWED_OUTPUT_PREFIXES)
+def test_report_output_path_in_whitelist_is_accepted(prefix: str, capsys) -> None:
+    exit_code = main(["plan", "--report-output", f"{prefix}/run/report.json"])
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert payload["status"] == "scaffold-ack"
+
+
+@pytest.mark.unit
+def test_report_output_traversal_is_rejected(capsys) -> None:
+    exit_code = main(
+        ["plan", "--report-output", str(Path("artifacts") / ".." / "secret.json")]
+    )
+    assert exit_code == EXIT_WRITE_DENIED
+
+
+@pytest.mark.unit
+def test_absolute_report_output_is_rejected(capsys) -> None:
+    # Use a path that is absolute on every platform.
+    abs_path = "/etc/foo.json"
+    exit_code = main(["plan", "--report-output", abs_path])
+    assert exit_code == EXIT_WRITE_DENIED
+
+
+@pytest.mark.unit
+def test_no_socket_connection_is_attempted(monkeypatch, capsys) -> None:
+    """The scaffold must not open any network socket."""
+
+    def _boom(*args, **kwargs):  # pragma: no cover - safety net
+        raise AssertionError(
+            "context_importer scaffold must not open network sockets"
+        )
+
+    monkeypatch.setattr(socket.socket, "connect", _boom)
+    monkeypatch.setattr(socket.socket, "connect_ex", _boom)
+
+    for command in SCAFFOLD_COMMANDS_WITHOUT_APPLY:
+        exit_code = main(
+            [
+                command,
+                "--surreal-url",
+                "ws://example.invalid:8000/rpc",
+                "--namespace",
+                "ns",
+                "--database",
+                "db",
+            ]
+        )
+        assert exit_code == EXIT_OK
+        payload = _read_json(capsys)
+        assert payload["surrealdb_connection"] == "disabled"
+
+
+@pytest.mark.unit
+def test_no_filesystem_writes_in_scaffold(tmp_path, monkeypatch, capsys) -> None:
+    """The scaffold must not create files even when --report-output is given."""
+
+    target = tmp_path / "artifacts" / "report.json"
+    monkeypatch.chdir(tmp_path)
+    # Use a relative whitelisted path.
+    rel = Path("artifacts") / "report.json"
+    exit_code = main(["plan", "--report-output", str(rel)])
+    assert exit_code == EXIT_OK
+    assert not target.exists()
+    assert not (tmp_path / "artifacts").exists()
+
+
+@pytest.mark.unit
+def test_write_denied_error_carries_exit_code() -> None:
+    exc = WriteDeniedError("nope")
+    assert exc.code == "WRITE_DENIED"
+    assert exc.exit_code == EXIT_WRITE_DENIED
+
+
+@pytest.mark.unit
+def test_unsupported_format_exit_code_constant_is_unused_by_argparse() -> None:
+    # argparse handles --format choices itself, but our internal renderer
+    # keeps an UnsupportedFormatError path. The constant must stay distinct.
+    assert EXIT_UNSUPPORTED_FORMAT == 4
+    assert EXIT_USAGE_ERROR == 2
+
+
+@pytest.mark.unit
+def test_build_parser_returns_argparse_parser() -> None:
+    parser = build_parser()
+    # Smoke check: the parser knows about every documented command.
+    helps = parser.format_help()
+    for command in SUPPORTED_COMMANDS:
+        assert command in helps

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -1,0 +1,332 @@
+"""SurrealDB context importer CLI scaffold (offline, dry-run by default).
+
+Issue: #2068 (Wave 10, Slice 1)
+Parent: #2067 / Epic #1976
+
+This module implements ONLY the CLI scaffold for the future
+context-import pipeline. It is intentionally a no-op for all
+business commands and is hard-blocked from performing any write,
+network, or SurrealDB operation.
+
+Design rules enforced here:
+
+* Default behavior is dry-run / no-write.
+* The ``apply`` subcommand and the global ``--apply`` flag exist
+  so that downstream slices can wire real behavior, but in this
+  scaffold any apply attempt is hard-blocked with exit code 5
+  (``WRITE_DENIED``) and a deterministic error payload.
+* No SurrealDB connection is opened. ``--surreal-url``,
+  ``--namespace``, and ``--database`` are parsed but never used.
+* No JSONL is read, parsed, or validated.
+* No config loader is invoked (that belongs to #2069).
+* No real plan / audit / rollback-plan logic exists.
+
+Subcommands implemented as scaffold stubs (per #2068 spec):
+    validate-jsonl, plan, dry-run, apply, audit, rollback-plan
+
+Exit codes (aligned with the context-indexer contract):
+    0 = success / scaffold acknowledged
+    1 = validation failure (reserved; not raised in scaffold)
+    2 = argparse usage error (raised by argparse itself)
+    3 = input-not-found (reserved; not raised in scaffold)
+    4 = unsupported format
+    5 = write denied (path violation OR apply attempt in scaffold)
+    6 = internal error / scaffold anomaly
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+SCHEMA_VERSION = "context-importer/v0"
+
+SUPPORTED_COMMANDS = (
+    "validate-jsonl",
+    "plan",
+    "dry-run",
+    "apply",
+    "audit",
+    "rollback-plan",
+)
+
+SUPPORTED_FORMATS = frozenset({"json", "jsonl", "markdown"})
+
+ALLOWED_OUTPUT_PREFIXES = ("artifacts", "temp")
+
+EXIT_OK = 0
+EXIT_VALIDATION_ERROR = 1
+EXIT_USAGE_ERROR = 2
+EXIT_INPUT_NOT_FOUND = 3
+EXIT_UNSUPPORTED_FORMAT = 4
+EXIT_WRITE_DENIED = 5
+EXIT_INTERNAL = 6
+
+
+class ContextImporterError(Exception):
+    """Base error for the context_importer scaffold."""
+
+    code: str = "CONTEXT_IMPORTER_ERROR"
+    exit_code: int = EXIT_INTERNAL
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class WriteDeniedError(ContextImporterError):
+    """Raised when a write or apply path is attempted in the scaffold."""
+
+    code = "WRITE_DENIED"
+    exit_code = EXIT_WRITE_DENIED
+
+
+class UnsupportedFormatError(ContextImporterError):
+    """Raised when an unsupported --format value is supplied."""
+
+    code = "UNSUPPORTED_FORMAT"
+    exit_code = EXIT_UNSUPPORTED_FORMAT
+
+
+def _validate_format(fmt: str) -> str:
+    if fmt not in SUPPORTED_FORMATS:
+        raise UnsupportedFormatError(
+            f"unsupported format: {fmt!r}; allowed: {sorted(SUPPORTED_FORMATS)}"
+        )
+    return fmt
+
+
+def _validate_output_path(output: Path | None) -> Path | None:
+    """Whitelist output paths to ``artifacts/`` and ``temp/`` only.
+
+    Even though the scaffold never writes anything, we validate the
+    flag eagerly so that downstream slices inherit the guard.
+    """
+
+    if output is None:
+        return None
+    if output.is_absolute():
+        raise WriteDeniedError(
+            f"absolute output paths are forbidden: {output}"
+        )
+    parts = output.parts
+    if not parts or parts[0] not in ALLOWED_OUTPUT_PREFIXES:
+        raise WriteDeniedError(
+            "output path must live under "
+            f"{ALLOWED_OUTPUT_PREFIXES}, got: {output}"
+        )
+    if ".." in parts:
+        raise WriteDeniedError(
+            f"output path may not traverse with '..': {output}"
+        )
+    return output
+
+
+def _build_payload(
+    command: str,
+    *,
+    dry_run: bool,
+    apply_requested: bool,
+    status: str = "scaffold-ack",
+    note: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "command": command,
+        "status": status,
+        "dry_run": dry_run,
+        "apply_requested": apply_requested,
+        "surrealdb_connection": "disabled",
+        "implemented": False,
+    }
+    if note is not None:
+        payload["note"] = note
+    return payload
+
+
+def _render(payload: dict[str, Any], fmt: str) -> str:
+    if fmt == "json":
+        return json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2)
+    if fmt == "jsonl":
+        return json.dumps(payload, ensure_ascii=True, sort_keys=True)
+    if fmt == "markdown":
+        lines = [f"# context_importer: {payload['command']}"]
+        for key in sorted(payload.keys()):
+            lines.append(f"- **{key}**: `{payload[key]}`")
+        return "\n".join(lines)
+    raise UnsupportedFormatError(f"unsupported format: {fmt!r}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="context_importer",
+        description=(
+            "Context Importer CLI scaffold (#2068). Offline, dry-run-only "
+            "in this slice. No SurrealDB connection, no writes."
+        ),
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for command in SUPPORTED_COMMANDS:
+        sub = subparsers.add_parser(
+            command,
+            help=f"{command} (scaffold; not implemented in #2068)",
+            description=(
+                f"Scaffold stub for `{command}`. Implementation will land "
+                "in a follow-up slice."
+            ),
+        )
+        sub.add_argument(
+            "--input-dir",
+            type=Path,
+            default=None,
+            help="Directory containing JSONL artefacts (read-only; unused in scaffold).",
+        )
+        sub.add_argument(
+            "--surreal-url",
+            type=str,
+            default="",
+            help="SurrealDB URL (parsed but never used in scaffold).",
+        )
+        sub.add_argument(
+            "--namespace",
+            type=str,
+            default=None,
+            help="SurrealDB namespace (parsed but never used in scaffold).",
+        )
+        sub.add_argument(
+            "--database",
+            type=str,
+            default=None,
+            help="SurrealDB database (parsed but never used in scaffold).",
+        )
+        sub.add_argument(
+            "--run-id",
+            type=str,
+            default=None,
+            help="Optional deterministic run identifier (echoed only).",
+        )
+        sub.add_argument(
+            "--report-output",
+            type=Path,
+            default=None,
+            help=(
+                "Optional report output path. Must live under artifacts/ or "
+                "temp/. Scaffold never writes; the path is only validated."
+            ),
+        )
+        sub.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Simulate only. This is the default behavior.",
+        )
+        sub.add_argument(
+            "--apply",
+            action="store_true",
+            help=(
+                "Opt in to write/apply. HARD-BLOCKED in #2068; any use of "
+                "this flag exits with code 5 (WRITE_DENIED)."
+            ),
+        )
+        sub.add_argument(
+            "--format",
+            choices=sorted(SUPPORTED_FORMATS),
+            default="json",
+            help="Render format for command output (default: json).",
+        )
+
+    return parser
+
+
+def _handle(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
+    """Resolve command behavior for the scaffold.
+
+    Returns ``(payload, exit_code)``. The scaffold never performs the
+    real action; it only acknowledges the call or refuses it.
+    """
+
+    command: str = args.command
+    apply_requested: bool = bool(args.apply)
+    # Default is dry-run; --apply is the only opt-in surface.
+    dry_run: bool = not apply_requested or bool(args.dry_run)
+
+    # Validate format and output path defensively even though we do not
+    # write. This makes the safety contract verifiable from tests.
+    _validate_format(args.format)
+    _validate_output_path(args.report_output)
+
+    if command == "apply" or apply_requested:
+        raise WriteDeniedError(
+            "apply path is not implemented in scaffold (#2068); "
+            "writes will land in a follow-up slice."
+        )
+
+    payload = _build_payload(
+        command,
+        dry_run=dry_run,
+        apply_requested=apply_requested,
+        status="scaffold-ack",
+        note=(
+            "scaffold only; no JSONL parsing, no SurrealDB connection, "
+            "no writes performed."
+        ),
+    )
+    return payload, EXIT_OK
+
+
+def _emit_error(exc: ContextImporterError) -> str:
+    return json.dumps(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "status": "error",
+            "error": exc.code,
+            "message": exc.message,
+        },
+        ensure_ascii=True,
+        sort_keys=True,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        payload, exit_code = _handle(args)
+    except ContextImporterError as exc:
+        print(_emit_error(exc))
+        return exc.exit_code
+    except Exception as exc:  # noqa: BLE001 - scaffold safety net
+        logger.exception("context_importer internal error")
+        print(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "status": "error",
+                    "error": "INTERNAL",
+                    "message": str(exc),
+                },
+                ensure_ascii=True,
+                sort_keys=True,
+            )
+        )
+        return EXIT_INTERNAL
+
+    try:
+        rendered = _render(payload, args.format)
+    except ContextImporterError as exc:
+        print(_emit_error(exc))
+        return exc.exit_code
+
+    print(rendered)
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Scaffold-only CLI for the future SurrealDB context-import pipeline.
This slice ships argument parsing, help text, exit-code contract, and
hard safety gates. **No** SurrealDB connection, **no** writes, **no**
JSONL parsing, **no** plan / apply / audit / rollback logic.

- Parent: #1976 (Master Epic)
- Wave 10 Parent: #2067
- Closes #2068

## Scope

- New CLI module: ``tools/surrealdb/context_importer.py``
- New unit tests: ``tests/unit/surrealdb/test_context_importer.py``
- New CLI contract doc: ``docs/surrealdb/context-importer-cli-contract.md``

Subcommands per #2068 spec:
``validate-jsonl``, ``plan``, ``dry-run``, ``apply``, ``audit``, ``rollback-plan``.

Scaffold subcommands return a deterministic ``scaffold-ack`` JSON payload
with ``surrealdb_connection: "disabled"`` and ``implemented: false``.
``apply`` (subcommand) and ``--apply`` (flag) are hard-blocked with
exit code 5 (``WRITE_DENIED``).

## Files

- ``tools/surrealdb/context_importer.py`` — argparse-based CLI scaffold,
  Sentinel exceptions (``ContextImporterError``, ``WriteDeniedError``,
  ``UnsupportedFormatError``), output-path whitelist (``artifacts/``,
  ``temp/``), JSON / JSONL / Markdown rendering.
- ``tests/unit/surrealdb/test_context_importer.py`` — 34 unit tests
  (``@pytest.mark.unit``) covering: help on every subcommand, dry-run
  default, apply hard-block (subcommand and flag), output-path
  whitelist, traversal rejection, no-socket assertion, no-filesystem-write
  assertion, format renderers, schema-version pin.
- ``docs/surrealdb/context-importer-cli-contract.md`` — formal CLI
  contract analogous to ``docs/surrealdb/context-indexer-cli-contract.md``.

## Tests

- ``ruff check tools/surrealdb/context_importer.py tests/unit/surrealdb/test_context_importer.py``
  — All checks passed.
- ``pytest -q tests/unit/surrealdb/test_context_importer.py`` —
  **34 passed**.
- ``pytest -q tests/unit/surrealdb/`` —
  **134 passed**, no regressions in indexer / symbol-extraction /
  drift-report / ledger-importer suites.

## Guardrails (in this slice)

- **No SurrealDB connection.** ``--surreal-url`` / ``--namespace`` /
  ``--database`` are parsed but never used; payload always reports
  ``surrealdb_connection: "disabled"``. A test patches
  ``socket.socket.connect`` / ``connect_ex`` to assert no socket call.
- **No SurrealDB write.** No client library is imported; no network or
  DB operation is performed.
- **No filesystem writes.** ``--report-output`` is whitelist-validated
  (``artifacts/`` or ``temp/``, no absolutes, no ``..`` traversal),
  but the scaffold itself does not write any file. A test confirms this.
- **No runtime / trading / risk / execution / secrets / live-readiness
  changes.**
- **No live / real-money enable.**
- **Apply is hard-blocked.** Both the ``apply`` subcommand and the
  ``--apply`` flag exit with code 5 (``WRITE_DENIED``). Tests pin this
  as a safety net so future slices cannot silently remove the block.

## Out of scope (explicitly deferred)

- Config loader (#2069).
- JSONL validation logic.
- Plan / Reconcile / Apply / Tombstone / Audit / Rollback-Plan
  implementations (each their own slice).
- Any change to ``main`` outside the three new files.