### PR TITLE
Harden OpenCode skill GO gates

### DIFF
--- a/.opencode/skills/cdb-exchange-adapters/SKILL.md
+++ b/.opencode/skills/cdb-exchange-adapters/SKILL.md
@@ -18,7 +18,9 @@ description: CDB exchange-adapter work in the current working repo. Use when Cod
 
 ## Non-negotiables
 - No real keys in code.
-- No live endpoints by default; paper or testnet only when explicitly needed.
+- Default-safe scope is paper/mock only.
+- Testnet is allowed only with explicit user GO and an explicit reason.
+- Live endpoints / real keys are never the default; do not derive any live-trading authorization from this skill text.
 - Normalize to the repo's current internal schema instead of inventing a new one.
 - Add tests for happy path plus failure taxonomy.
 - Include one simulated failure case that proves retry or backoff behavior.

--- a/.opencode/skills/cdb-session-close/SKILL.md
+++ b/.opencode/skills/cdb-session-close/SKILL.md
@@ -28,11 +28,17 @@ Close a working session so the repo, git state, and issue thread reflect reality
 
 0. Human-GO gate (hard):
    - Default mode is read-only analysis.
-   - Require explicit user GO before any of these actions:
+   - Require explicit user GO before any action that mutates repository, working tree, index, branch, remote, GitHub, or worktree state, including:
      - staging changes (any `git add` / patch staging)
+     - branch switching or checkout/switch operations
+     - pull, merge, rebase, or fast-forward update operations
+     - stash/apply operations
      - creating a commit
      - pushing to any remote
-     - writing to GitHub (issue/PR comment, status update, label/state change)
+     - removing worktrees
+     - deleting local or remote branches
+     - cleanup/delete operations
+     - writing to GitHub (issue/PR comment, review reply/resolve, status update, label/state change)
    - If GO is not granted: stop after producing the close-out summary draft.
 
 1. Determine session scope before touching git:

--- a/.opencode/skills/cdb-session-close/SKILL.md
+++ b/.opencode/skills/cdb-session-close/SKILL.md
@@ -26,6 +26,15 @@ Close a working session so the repo, git state, and issue thread reflect reality
 
 ## Workflow
 
+0. Human-GO gate (hard):
+   - Default mode is read-only analysis.
+   - Require explicit user GO before any of these actions:
+     - staging changes (any `git add` / patch staging)
+     - creating a commit
+     - pushing to any remote
+     - writing to GitHub (issue/PR comment, status update, label/state change)
+   - If GO is not granted: stop after producing the close-out summary draft.
+
 1. Determine session scope before touching git:
    - Decide whether the session was issue-bezogen.
    - Identify the intended deliverable, the files actually changed, and any unrelated local residue.
@@ -96,6 +105,10 @@ Close a working session so the repo, git state, and issue thread reflect reality
 
 ## Fail-Closed Rules
 
+- If any write step would exceed the agreed scope (unexpected files/hunks, scope growth): STOP and ask for clarification + explicit GO.
+- If checks are red/failed/unknown for the claimed result: STOP; do not stage/commit/push; report the failing check(s).
+- If the PR/review/writer/lock situation is unclear or conflicting: STOP; do not stage/commit/push or write to GitHub; ask for explicit handoff/GO.
+- If there is an active PR or lock collision touching the same files/scope: STOP; no further actions until clarified.
 - If intended session changes cannot be separated from unrelated local changes, stop and report the close as incomplete.
 - If verification is missing or ambiguous, report exactly that instead of implying confidence.
 - If the session was issue-driven but the issue mapping is uncertain, do not fabricate an issue-ready completion claim.

--- a/.opencode/skills/gh-address-comments/SKILL.md
+++ b/.opencode/skills/gh-address-comments/SKILL.md
@@ -25,7 +25,10 @@ Run `gh` commands with escalated network access when needed.
    - `gh api /repos/{owner}/{repo}/pulls/<PR>/comments`
    - optional: use a repo-provided helper script only if it exists locally
 5. Summarize actionable comments in numbered form.
-6. If the user selected comments to address, implement the changes or draft the replies.
+6. Stop and ask for explicit user GO, separately for:
+   - code changes (repo writes)
+   - GitHub writes (reply, review, resolve threads)
+7. Only after explicit GO: implement the selected code changes and/or draft the selected replies/resolves.
 
 ## Rules
 - Do not assume there is an open PR for the current branch.
@@ -33,3 +36,7 @@ Run `gh` commands with escalated network access when needed.
 - If auth or rate limits fail, ask the user to re-authenticate and retry.
 - Keep code changes scoped to the selected comments.
 - Do not read `#1492` as LR clearance.
+- Default is read-only: first read, then plan, then wait for explicit GO.
+- No code changes without explicit user GO.
+- No GitHub writes without explicit user GO (reply/review/resolve).
+- Never resolve review threads blindly; show the planned replies/resolves first and why.


### PR DESCRIPTION
Refs #2221

## Summary
- Adds explicit Human-GO gates to `cdb-session-close` before staging, commit, push, and GitHub writes.
- Hardens `gh-address-comments` so code changes, replies, reviews, and resolves require explicit user GO.
- Narrows `cdb-exchange-adapters` default-safe scope to paper/mock; testnet requires explicit user GO; live endpoints/real keys are never default.

## Scope
- Skill text only.
- No runtime, trading, risk, execution, strategy, script, asset, AGENTS, or governance-canon changes.

## Validation
- `git status -sb`
- `git diff --name-only`
- `git diff -- .opencode/skills/cdb-session-close/SKILL.md .opencode/skills/gh-address-comments/SKILL.md .opencode/skills/cdb-exchange-adapters/SKILL.md`
- Open PR overlap check: no open PRs before commit/PR creation.