### PR TITLE
Refresh python trixie digest for OpenSSL fix

### DIFF
--- a/services/allocation/Dockerfile
+++ b/services/allocation/Dockerfile
@@ -1,6 +1,6 @@
 # Allocation Service - Dockerfile
 
-FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM python:3.11-slim-trixie@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2
 
 WORKDIR /app
 

--- a/services/db_writer/Dockerfile
+++ b/services/db_writer/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile - DB Writer Service
 # Claire de Binare Trading Bot
 
-FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM python:3.11-slim-trixie@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2
 
 WORKDIR /app
 

--- a/services/execution/Dockerfile
+++ b/services/execution/Dockerfile
@@ -1,6 +1,6 @@
 # Execution Service - Gehärtetes Image
 # Claire de Binare Trading Bot
-FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf AS build
+FROM python:3.11-slim-trixie@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2 AS build
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
@@ -21,7 +21,7 @@ RUN python -m venv /venv \
     && /venv/bin/pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2 \
     && /venv/bin/pip install --no-cache-dir -r requirements.txt
 
-FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM python:3.11-slim-trixie@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1

--- a/services/market/Dockerfile
+++ b/services/market/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM python:3.11-slim-trixie@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2
 
 WORKDIR /app
 

--- a/services/regime/Dockerfile
+++ b/services/regime/Dockerfile
@@ -1,6 +1,6 @@
 # Regime Service - Dockerfile
 
-FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM python:3.11-slim-trixie@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2
 
 WORKDIR /app
 

--- a/services/risk/Dockerfile
+++ b/services/risk/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM python:3.11-slim-trixie@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2
 
 WORKDIR /app
 

--- a/services/signal/Dockerfile
+++ b/services/signal/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM python:3.11-slim-trixie@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2
 
 WORKDIR /app
 

--- a/services/ws/Dockerfile
+++ b/services/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-trixie@sha256:233de06753d30d120b1a3ce359d8d3be8bda78524cd8f520c99883bfe33964cf
+FROM python:3.11-slim-trixie@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2
 
 WORKDIR /app
 


### PR DESCRIPTION
Refs #1725

## Summary
- Refreshes `python:3.11-slim-trixie` digest from `sha256:233de067...` to `sha256:6d85378d...`.
- Updates the same 8 Dockerfiles / 9 `FROM` lines as the prior #1716/#1722 digest-refresh scope.
- Keeps `services/candles/Dockerfile` out of scope.

## Upstream evidence
- New `linux/amd64` payload: `sha256:ff71127c215572121f1991bacf17f39ec5fcfd2de1f1c01a595835495bb9adfc`
- New tag/index digest: `sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2`
- Verified package level in new amd64 payload:
  - `openssl 3.5.5-1~deb13u2`
  - `libssl3t64:amd64 3.5.5-1~deb13u2`

## Scope
- Dockerfile digest-only update.
- No Dockerfile refactor.
- No package changes.
- No `apt upgrade` workaround.
- No runtime/trading logic change.

## Validation
- `git diff --name-only`
- Digest occurrence checks: old digest removed, new digest appears 9 times
- Docker manifest/package read-only verification
- GitHub checks after PR creation
