### PR TITLE
feat(surrealdb): add context importer local config

### DIFF
--- a/docs/surrealdb/context-importer-cli-contract.md
+++ b/docs/surrealdb/context-importer-cli-contract.md
@@ -1,9 +1,9 @@
 # Context Importer CLI Contract
 
-**Status**: Draft (Scaffold-Slice)
-**Authority**: Issue #2068 / Wave 10 Parent #2067 / Epic #1976
+**Status**: Draft (Scaffold + Local Config Slice)
+**Authority**: Issue #2068 + #2069 / Wave 10 Parent #2067 / Epic #1976
 **Target**: `tools/surrealdb/context_importer.py`
-**Scope**: CLI scaffold only — no SurrealDB connection, no writes, no JSONL parsing.
+**Scope**: CLI scaffold plus explicit local config validation — no SurrealDB connection, no writes, no JSONL parsing.
 
 ---
 
@@ -11,9 +11,12 @@
 
 Dieser Vertrag beschreibt die CLI-Oberflaeche fuer den zukuenftigen
 Context-Import-Pfad (JSONL-Artefakte aus dem Context Indexer nach SurrealDB).
-In #2068 wird ausschliesslich das Scaffold geliefert: Argument-Parsing,
-Help-Text, Default-Verhalten und Safety-Gates. Jede echte Logik (JSONL-Validation,
-Plan-Berechnung, Apply, Audit, Rollback-Plan) gehoert zu separaten Folge-Slices.
+In #2068 wurde ausschliesslich das Scaffold geliefert: Argument-Parsing,
+Help-Text, Default-Verhalten und Safety-Gates. #2069 ergaenzt eine explizite
+lokale Config-Lade- und Validierungsschicht fuer
+`infrastructure/config/surrealdb/context_import.local.example.yaml`.
+Jede echte Logik (JSONL-Validation, Plan-Berechnung, Apply, Audit,
+Rollback-Plan) gehoert weiterhin zu separaten Folge-Slices.
 
 ---
 
@@ -48,7 +51,15 @@ Folge-Slice (Apply-Implementation) entfernt werden.
   oder `temp/` liegen. Absolute Pfade (`/...`, `C:\...`, UNC) und
   Traversal (`..`) werden mit Exit `5` verworfen. Der Scaffold schreibt
   selbst nichts.
-- **Keine Config-Loader-Logik**: gehoert zu #2069.
+- **Config nur explizit**: `--config` wird nur geladen, wenn der Pfad explizit
+  uebergeben wird. Ohne `--config` laeuft der Scaffold weiter ohne Config.
+- **Config fail-closed**: `allow_apply_default` muss `false` sein; Trading-
+  State-Tabellen und Governance-Mirror-Tabellen duerfen nicht in
+  `allowed_tables` erscheinen und muessen in `forbidden_tables` enthalten sein.
+- **Keine Secrets in Beispiel-Config**:
+  `infrastructure/config/surrealdb/context_import.local.example.yaml` enthaelt
+  nur lokale Platzhalter. Reale Credentials muessen aus `SECRETS_PATH` oder
+  der Laufzeitumgebung kommen, nicht aus dieser YAML.
 - **Keine JSONL-Validation-Logik**: gehoert zu Folge-Slice.
 - **Keine Plan-/Audit-/Rollback-Logik**: jeweils eigene Folge-Slices.
 
@@ -63,10 +74,45 @@ Folge-Slice (Apply-Implementation) entfernt werden.
 | `--namespace` | `None` | nein | nicht verwendet |
 | `--database` | `None` | nein | nicht verwendet |
 | `--run-id` | `None` | nein | nur geparsed |
+| `--config` | `None` | nein | explizite lokale YAML laden und validieren, kein Write |
 | `--report-output` | `None` | nein | Whitelist-Check, kein Write |
 | `--dry-run` | `False` (Default-Verhalten ist dennoch dry-run) | nein | redundant; explizit erlaubt |
 | `--apply` | `False` | nein | `True` ⇒ Exit `5` |
 | `--format` | `json` | nein | `json` / `jsonl` / `markdown` |
+
+---
+
+## 4.1 Lokaler Config-Vertrag (#2069)
+
+Kanonische Beispiel-Datei:
+
+```text
+infrastructure/config/surrealdb/context_import.local.example.yaml
+```
+
+Erwartete Felder:
+
+| Feld | Pflicht? | Vertrag |
+|---|---|---|
+| `schema_version` | ja | muss `context-import-local/v0` sein |
+| `surreal_url` | ja | nicht-leerer String, nur validiert/echoed |
+| `namespace` | ja | nicht-leerer String, nur validiert/echoed |
+| `database` | ja | nicht-leerer String, nur validiert/echoed |
+| `auth_mode` | ja | `none` / `root` / `scope`; Beispiel nutzt `none` |
+| `timeout` | ja | positiver Integer |
+| `allow_apply_default` | ja | muss `false` sein |
+| `allowed_tables` | ja | nicht-leere Liste nur fuer Context-Intelligence-Tabellen |
+| `forbidden_tables` | ja | muss Trading-State- und Governance-Mirror-Tabellen enthalten |
+
+Explizit blockierte Tabellen fuer `allowed_tables`:
+
+```text
+orders, fills, positions, balances, pnl, risk_state, execution_state,
+governance_event, governance_decision, governance_state
+```
+
+Diese Tabellen muessen in `forbidden_tables` stehen. Ueberschneidungen zwischen
+`allowed_tables` und `forbidden_tables` sind ungueltig.
 
 ---
 
@@ -77,7 +123,7 @@ Folge-Slice (Apply-Implementation) entfernt werden.
 | 0 | Erfolg / Scaffold acknowledged |
 | 1 | Validierungsfehler (reserviert; im Scaffold nicht ausgeloest) |
 | 2 | CLI-Usage / argparse-Fehler |
-| 3 | Input-Datei nicht gefunden (reserviert) |
+| 3 | Input-/Config-Datei nicht gefunden |
 | 4 | Unsupported Format (defensiv; argparse faengt das frueher) |
 | 5 | Write denied (Pfad-Verstoss ODER Apply im Scaffold) |
 | 6 | Interner Fehler |
@@ -96,10 +142,16 @@ Erfolgsantwort (Subcommand-Stub):
   "dry_run": true,
   "apply_requested": false,
   "surrealdb_connection": "disabled",
+  "config_loaded": false,
   "implemented": false,
   "note": "scaffold only; ..."
 }
 ```
+
+Wenn `--config` gesetzt ist, wird die Antwort um `config_loaded: true` und ein
+`config`-Objekt mit den validierten lokalen Config-Feldern erweitert. Das
+Objekt ist Audit-/Debug-Ausgabe fuer lokale Entwicklung; es darf keine Secrets
+enthalten.
 
 Fehlerantwort:
 
@@ -128,6 +180,9 @@ weder aus CLI-Args noch aus der Umgebung abgeleitet.
 - Jeder Slice, der eine SurrealDB-Verbindung einfuehrt, muss
   `surrealdb_connection` korrekt setzen und mindestens einen Test
   liefern, der den Connection-Pfad explizit verifiziert.
+- Jeder Slice, der Secrets oder Authentifizierung nutzt, muss die
+  Beispiel-Config secret-frei halten und echte Credentials ausserhalb der
+  versionierten YAML laden.
 
 ---
 

--- a/infrastructure/config/surrealdb/context_import.local.example.yaml
+++ b/infrastructure/config/surrealdb/context_import.local.example.yaml
@@ -1,0 +1,100 @@
+# context_import.local.example.yaml
+#
+# Example / template configuration for the local SurrealDB Context
+# Intelligence importer (tools/surrealdb/context_importer.py).
+#
+# This file is an EXAMPLE ONLY. It MUST NOT contain real secrets,
+# real production URLs, or any trading-state table names. Copy this
+# file to `context_import.local.yaml` (gitignored) and fill in local
+# values for development use.
+#
+# Source authority:
+#   issue:  #2069 (Context Importer: local config loader + example)
+#   parent: #2067
+#   epic:   #1976
+#   depends-on: #1979, #2037
+#
+# Guardrails:
+#   - The Context Intelligence DB is SEPARATE from the Governance Mirror.
+#   - `allow_apply_default` MUST remain false in this example.
+#   - The importer's `apply` subcommand remains hard-blocked
+#     (exit code 5 = WRITE_DENIED) regardless of this config.
+#   - Trading-state tables (orders, fills, positions, balances, pnl,
+#     risk_state, execution_state) MUST NOT appear in `allowed_tables`
+#     and MUST be listed under `forbidden_tables`.
+#   - Live-readiness verdict for this surface: NO-GO.
+
+schema_version: context-import-local/v0
+
+source_document:
+  authority:
+    issue: "#2069"
+    role: "context-importer-local-config-example"
+  issue_refs:
+    epic: "#1976"
+    parent: "#2067"
+    target: "#2069"
+    dependencies:
+      - "#1979"
+      - "#2037"
+    deferred: []
+
+mode:
+  surrealdb_apply: forbidden
+  live_readiness_verdict: NO-GO
+  human_gate_required: true
+
+# ---------------------------------------------------------------------------
+# SurrealDB connection (LOCAL DEV PLACEHOLDERS ONLY)
+# ---------------------------------------------------------------------------
+# Replace with values from your local dev SurrealDB instance.
+# Do NOT point this at a production or shared environment.
+surreal_url: "ws://127.0.0.1:8000/rpc"
+namespace: "cdb_context_local"
+database: "cdb_context_intel"
+
+# Authentication mode for the local importer.
+# Allowed values: "none" | "root" | "scope"
+# For the example/template, we default to "none" because no real
+# credentials may be embedded here. Real credentials must be loaded
+# from SECRETS_PATH at runtime, never from this YAML.
+auth_mode: "none"
+
+# Connection timeout in seconds for the local importer.
+timeout: 10
+
+# ---------------------------------------------------------------------------
+# Apply gating
+# ---------------------------------------------------------------------------
+# MUST remain false in this example. The importer also enforces a
+# hard block on the `apply` subcommand (exit 5) independently of this flag.
+allow_apply_default: false
+
+# ---------------------------------------------------------------------------
+# Table allow/deny lists
+# ---------------------------------------------------------------------------
+# Only Context Intelligence tables may appear under `allowed_tables`.
+# Trading-state tables are explicitly forbidden and listed below so the
+# config loader can fail-closed if they are ever moved into `allowed_tables`.
+
+allowed_tables:
+  - context_document
+  - context_chunk
+  - context_embedding
+  - context_source
+  - context_tag
+  - context_link
+
+forbidden_tables:
+  # Trading-state tables — never allowed in the Context Intelligence DB.
+  - orders
+  - fills
+  - positions
+  - balances
+  - pnl
+  - risk_state
+  - execution_state
+  # Governance Mirror tables — separate surface, not this importer.
+  - governance_event
+  - governance_decision
+  - governance_state

--- a/tests/unit/surrealdb/test_context_import_config.py
+++ b/tests/unit/surrealdb/test_context_import_config.py
@@ -87,6 +87,29 @@ def test_apply_paths_short_circuit_before_config_is_read(capsys) -> None:
 
 
 @pytest.mark.unit
+def test_config_stat_permission_error_is_user_input_error(
+    monkeypatch, capsys
+) -> None:
+    def _raise_permission_error(self) -> bool:
+        raise PermissionError("stat denied")
+
+    monkeypatch.setattr(Path, "exists", _raise_permission_error)
+
+    exit_code = main(["plan", "--config", "blocked.yaml"])
+
+    assert exit_code == EXIT_INPUT_NOT_FOUND
+    payload = _read_json(capsys)
+    assert payload["status"] == "error"
+    assert payload["error"] == "INPUT_NOT_FOUND"
+    assert payload["error"] != "INTERNAL"
+
+    exit_code = main(["plan", "--apply", "--config", "blocked.yaml"])
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+
+
+@pytest.mark.unit
 def test_config_rejects_apply_default_true(tmp_path: Path, capsys) -> None:
     path = _write_config(
         tmp_path,

--- a/tests/unit/surrealdb/test_context_import_config.py
+++ b/tests/unit/surrealdb/test_context_import_config.py
@@ -1,0 +1,184 @@
+"""Unit tests for the Context Importer local config loader (#2069)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.surrealdb.context_importer import (
+    CONFIG_SCHEMA_VERSION,
+    EXIT_INPUT_NOT_FOUND,
+    EXIT_OK,
+    EXIT_VALIDATION_ERROR,
+    EXIT_WRITE_DENIED,
+    FORBIDDEN_CONTEXT_IMPORT_TABLES,
+    load_config,
+    main,
+)
+
+
+EXAMPLE_CONFIG = Path("infrastructure/config/surrealdb/context_import.local.example.yaml")
+
+
+def _read_json(capsys) -> dict:
+    out = capsys.readouterr().out.strip()
+    return json.loads(out)
+
+
+def _write_config(tmp_path: Path, text: str) -> Path:
+    path = tmp_path / "context_import.local.yaml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+@pytest.mark.unit
+def test_example_config_loads_with_fail_closed_defaults() -> None:
+    config = load_config(EXAMPLE_CONFIG)
+
+    assert config.schema_version == CONFIG_SCHEMA_VERSION
+    assert config.allow_apply_default is False
+    assert config.auth_mode == "none"
+    assert config.surreal_url == "ws://127.0.0.1:8000/rpc"
+    assert config.namespace == "cdb_context_local"
+    assert config.database == "cdb_context_intel"
+    assert set(FORBIDDEN_CONTEXT_IMPORT_TABLES).issubset(config.forbidden_tables)
+    assert not set(config.allowed_tables).intersection(FORBIDDEN_CONTEXT_IMPORT_TABLES)
+
+
+@pytest.mark.unit
+def test_cli_loads_config_only_when_explicitly_supplied(capsys) -> None:
+    exit_code = main(["plan"])
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert payload["config_loaded"] is False
+    assert "config" not in payload
+
+    exit_code = main(["plan", "--config", str(EXAMPLE_CONFIG)])
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert payload["config_loaded"] is True
+    assert payload["config"]["schema_version"] == CONFIG_SCHEMA_VERSION
+    assert payload["config"]["allow_apply_default"] is False
+
+
+@pytest.mark.unit
+def test_missing_explicit_config_returns_input_not_found(capsys) -> None:
+    exit_code = main(["plan", "--config", "does-not-exist.yaml"])
+
+    assert exit_code == EXIT_INPUT_NOT_FOUND
+    payload = _read_json(capsys)
+    assert payload["status"] == "error"
+    assert payload["error"] == "INPUT_NOT_FOUND"
+
+
+@pytest.mark.unit
+def test_config_rejects_apply_default_true(tmp_path: Path, capsys) -> None:
+    path = _write_config(
+        tmp_path,
+        """
+schema_version: context-import-local/v0
+surreal_url: ws://127.0.0.1:8000/rpc
+namespace: cdb_context_local
+database: cdb_context_intel
+auth_mode: none
+timeout: 10
+allow_apply_default: true
+allowed_tables:
+  - context_document
+forbidden_tables:
+  - orders
+  - fills
+  - positions
+  - balances
+  - pnl
+  - risk_state
+  - execution_state
+  - governance_event
+  - governance_decision
+  - governance_state
+""",
+    )
+
+    exit_code = main(["plan", "--config", str(path)])
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    assert payload["error"] == "CONFIG_VALIDATION_ERROR"
+    assert "allow_apply_default" in payload["message"]
+
+
+@pytest.mark.unit
+def test_config_rejects_forbidden_table_in_allowed_tables(
+    tmp_path: Path, capsys
+) -> None:
+    path = _write_config(
+        tmp_path,
+        """
+schema_version: context-import-local/v0
+surreal_url: ws://127.0.0.1:8000/rpc
+namespace: cdb_context_local
+database: cdb_context_intel
+auth_mode: none
+timeout: 10
+allow_apply_default: false
+allowed_tables:
+  - context_document
+  - orders
+forbidden_tables:
+  - orders
+  - fills
+  - positions
+  - balances
+  - pnl
+  - risk_state
+  - execution_state
+  - governance_event
+  - governance_decision
+  - governance_state
+""",
+    )
+
+    exit_code = main(["plan", "--config", str(path)])
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    assert payload["error"] == "CONFIG_VALIDATION_ERROR"
+    assert "orders" in payload["message"]
+
+
+@pytest.mark.unit
+def test_config_requires_explicit_forbidden_tables(tmp_path: Path, capsys) -> None:
+    path = _write_config(
+        tmp_path,
+        """
+schema_version: context-import-local/v0
+surreal_url: ws://127.0.0.1:8000/rpc
+namespace: cdb_context_local
+database: cdb_context_intel
+auth_mode: none
+timeout: 10
+allow_apply_default: false
+allowed_tables:
+  - context_document
+forbidden_tables:
+  - orders
+""",
+    )
+
+    exit_code = main(["plan", "--config", str(path)])
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    assert payload["error"] == "CONFIG_VALIDATION_ERROR"
+    assert "missing" in payload["message"]
+
+
+@pytest.mark.unit
+def test_apply_remains_hard_blocked_even_with_valid_config(capsys) -> None:
+    exit_code = main(["apply", "--config", str(EXAMPLE_CONFIG)])
+
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"

--- a/tests/unit/surrealdb/test_context_import_config.py
+++ b/tests/unit/surrealdb/test_context_import_config.py
@@ -74,6 +74,19 @@ def test_missing_explicit_config_returns_input_not_found(capsys) -> None:
 
 
 @pytest.mark.unit
+def test_apply_paths_short_circuit_before_config_is_read(capsys) -> None:
+    exit_code = main(["apply", "--config", "missing.yaml"])
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+
+    exit_code = main(["plan", "--apply", "--config", "missing.yaml"])
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+
+
+@pytest.mark.unit
 def test_config_rejects_apply_default_true(tmp_path: Path, capsys) -> None:
     path = _write_config(
         tmp_path,

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -251,9 +251,15 @@ def load_config(path: Path) -> ContextImportConfig:
     never opens a SurrealDB connection in this scaffold.
     """
 
-    if not path.exists():
+    try:
+        exists = path.exists()
+        is_file = path.is_file() if exists else False
+    except OSError as exc:
+        raise InputNotFoundError(f"cannot stat config file: {path}: {exc}") from exc
+
+    if not exists:
         raise InputNotFoundError(f"config file not found: {path}")
-    if not path.is_file():
+    if not is_file:
         raise ConfigValidationError(f"config path is not a file: {path}")
 
     try:

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -464,17 +464,17 @@ def _handle(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
     # Default is dry-run; --apply is the only opt-in surface.
     dry_run: bool = not apply_requested or bool(args.dry_run)
 
-    # Validate format and output path defensively even though we do not
-    # write. This makes the safety contract verifiable from tests.
-    _validate_format(args.format)
-    _validate_output_path(args.report_output)
-    config = load_config(args.config) if args.config is not None else None
-
     if command == "apply" or apply_requested:
         raise WriteDeniedError(
             "apply path is not implemented in scaffold (#2068); "
             "writes will land in a follow-up slice."
         )
+
+    # Validate format and output path defensively even though we do not
+    # write. This makes the safety contract verifiable from tests.
+    _validate_format(args.format)
+    _validate_output_path(args.report_output)
+    config = load_config(args.config) if args.config is not None else None
 
     payload = _build_payload(
         command,

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -37,10 +37,13 @@ Exit codes (aligned with the context-indexer contract):
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import json
 import logging
 from pathlib import Path
 from typing import Any
+
+import yaml
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +62,32 @@ SUPPORTED_COMMANDS = (
 SUPPORTED_FORMATS = frozenset({"json", "jsonl", "markdown"})
 
 ALLOWED_OUTPUT_PREFIXES = ("artifacts", "temp")
+
+CONFIG_SCHEMA_VERSION = "context-import-local/v0"
+
+TRADING_STATE_TABLES = frozenset(
+    {
+        "orders",
+        "fills",
+        "positions",
+        "balances",
+        "pnl",
+        "risk_state",
+        "execution_state",
+    }
+)
+
+GOVERNANCE_MIRROR_TABLES = frozenset(
+    {
+        "governance_event",
+        "governance_decision",
+        "governance_state",
+    }
+)
+
+FORBIDDEN_CONTEXT_IMPORT_TABLES = TRADING_STATE_TABLES | GOVERNANCE_MIRROR_TABLES
+
+ALLOWED_AUTH_MODES = frozenset({"none", "root", "scope"})
 
 EXIT_OK = 0
 EXIT_VALIDATION_ERROR = 1
@@ -92,6 +121,50 @@ class UnsupportedFormatError(ContextImporterError):
 
     code = "UNSUPPORTED_FORMAT"
     exit_code = EXIT_UNSUPPORTED_FORMAT
+
+
+class InputNotFoundError(ContextImporterError):
+    """Raised when an explicitly supplied input/config path does not exist."""
+
+    code = "INPUT_NOT_FOUND"
+    exit_code = EXIT_INPUT_NOT_FOUND
+
+
+class ConfigValidationError(ContextImporterError):
+    """Raised when the local importer config is invalid or unsafe."""
+
+    code = "CONFIG_VALIDATION_ERROR"
+    exit_code = EXIT_VALIDATION_ERROR
+
+
+@dataclass(frozen=True)
+class ContextImportConfig:
+    """Validated local config for the context importer."""
+
+    path: Path
+    schema_version: str
+    surreal_url: str
+    namespace: str
+    database: str
+    auth_mode: str
+    timeout: int
+    allow_apply_default: bool
+    allowed_tables: tuple[str, ...]
+    forbidden_tables: tuple[str, ...]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "schema_version": self.schema_version,
+            "surreal_url": self.surreal_url,
+            "namespace": self.namespace,
+            "database": self.database,
+            "auth_mode": self.auth_mode,
+            "timeout": self.timeout,
+            "allow_apply_default": self.allow_apply_default,
+            "allowed_tables": list(self.allowed_tables),
+            "forbidden_tables": list(self.forbidden_tables),
+        }
 
 
 def _validate_format(fmt: str) -> str:
@@ -128,11 +201,134 @@ def _validate_output_path(output: Path | None) -> Path | None:
     return output
 
 
+def _require_mapping(raw: Any, *, path: Path) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ConfigValidationError(f"config must be a YAML mapping: {path}")
+    return raw
+
+
+def _require_str(raw: dict[str, Any], key: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigValidationError(f"config field {key!r} must be a non-empty string")
+    return value
+
+
+def _require_int(raw: dict[str, Any], key: str) -> int:
+    value = raw.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ConfigValidationError(f"config field {key!r} must be a positive integer")
+    return value
+
+
+def _require_bool(raw: dict[str, Any], key: str) -> bool:
+    value = raw.get(key)
+    if not isinstance(value, bool):
+        raise ConfigValidationError(f"config field {key!r} must be a boolean")
+    return value
+
+
+def _require_str_list(raw: dict[str, Any], key: str) -> tuple[str, ...]:
+    value = raw.get(key)
+    if not isinstance(value, list) or not value:
+        raise ConfigValidationError(f"config field {key!r} must be a non-empty list")
+    normalized: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise ConfigValidationError(
+                f"config field {key!r} must contain only non-empty strings"
+            )
+        normalized.append(item.strip())
+    if len(normalized) != len(set(normalized)):
+        raise ConfigValidationError(f"config field {key!r} contains duplicates")
+    return tuple(normalized)
+
+
+def load_config(path: Path) -> ContextImportConfig:
+    """Load and validate the explicit local importer config.
+
+    The config is a local development input only. It never enables writes and
+    never opens a SurrealDB connection in this scaffold.
+    """
+
+    if not path.exists():
+        raise InputNotFoundError(f"config file not found: {path}")
+    if not path.is_file():
+        raise ConfigValidationError(f"config path is not a file: {path}")
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ConfigValidationError(f"invalid YAML config: {path}: {exc}") from exc
+    except OSError as exc:
+        raise InputNotFoundError(f"cannot read config file: {path}: {exc}") from exc
+
+    data = _require_mapping(raw, path=path)
+
+    schema_version = _require_str(data, "schema_version")
+    if schema_version != CONFIG_SCHEMA_VERSION:
+        raise ConfigValidationError(
+            "unsupported config schema_version: "
+            f"{schema_version!r}; expected {CONFIG_SCHEMA_VERSION!r}"
+        )
+
+    auth_mode = _require_str(data, "auth_mode")
+    if auth_mode not in ALLOWED_AUTH_MODES:
+        raise ConfigValidationError(
+            f"unsupported auth_mode: {auth_mode!r}; allowed: {sorted(ALLOWED_AUTH_MODES)}"
+        )
+
+    allow_apply_default = _require_bool(data, "allow_apply_default")
+    if allow_apply_default:
+        raise ConfigValidationError(
+            "allow_apply_default must remain false for the context importer"
+        )
+
+    allowed_tables = _require_str_list(data, "allowed_tables")
+    forbidden_tables = _require_str_list(data, "forbidden_tables")
+
+    forbidden_in_allowed = sorted(
+        set(allowed_tables).intersection(FORBIDDEN_CONTEXT_IMPORT_TABLES)
+    )
+    if forbidden_in_allowed:
+        raise ConfigValidationError(
+            "allowed_tables contains forbidden trading/governance tables: "
+            f"{forbidden_in_allowed}"
+        )
+
+    missing_forbidden = sorted(FORBIDDEN_CONTEXT_IMPORT_TABLES.difference(forbidden_tables))
+    if missing_forbidden:
+        raise ConfigValidationError(
+            "forbidden_tables must explicitly include all blocked "
+            f"trading/governance tables; missing: {missing_forbidden}"
+        )
+
+    overlap = sorted(set(allowed_tables).intersection(forbidden_tables))
+    if overlap:
+        raise ConfigValidationError(
+            f"tables may not appear in both allowed_tables and forbidden_tables: {overlap}"
+        )
+
+    return ContextImportConfig(
+        path=path,
+        schema_version=schema_version,
+        surreal_url=_require_str(data, "surreal_url"),
+        namespace=_require_str(data, "namespace"),
+        database=_require_str(data, "database"),
+        auth_mode=auth_mode,
+        timeout=_require_int(data, "timeout"),
+        allow_apply_default=allow_apply_default,
+        allowed_tables=allowed_tables,
+        forbidden_tables=forbidden_tables,
+    )
+
+
 def _build_payload(
     command: str,
     *,
     dry_run: bool,
     apply_requested: bool,
+    config: ContextImportConfig | None = None,
     status: str = "scaffold-ack",
     note: str | None = None,
 ) -> dict[str, Any]:
@@ -144,7 +340,10 @@ def _build_payload(
         "apply_requested": apply_requested,
         "surrealdb_connection": "disabled",
         "implemented": False,
+        "config_loaded": config is not None,
     }
+    if config is not None:
+        payload["config"] = config.to_payload()
     if note is not None:
         payload["note"] = note
     return payload
@@ -213,6 +412,15 @@ def build_parser() -> argparse.ArgumentParser:
             help="Optional deterministic run identifier (echoed only).",
         )
         sub.add_argument(
+            "--config",
+            type=Path,
+            default=None,
+            help=(
+                "Optional local importer config YAML. Loaded and validated only "
+                "when supplied; it never enables writes in this scaffold."
+            ),
+        )
+        sub.add_argument(
             "--report-output",
             type=Path,
             default=None,
@@ -260,6 +468,7 @@ def _handle(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
     # write. This makes the safety contract verifiable from tests.
     _validate_format(args.format)
     _validate_output_path(args.report_output)
+    config = load_config(args.config) if args.config is not None else None
 
     if command == "apply" or apply_requested:
         raise WriteDeniedError(
@@ -271,10 +480,11 @@ def _handle(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
         command,
         dry_run=dry_run,
         apply_requested=apply_requested,
+        config=config,
         status="scaffold-ack",
         note=(
-            "scaffold only; no JSONL parsing, no SurrealDB connection, "
-            "no writes performed."
+            "scaffold only; optional local config validation only; "
+            "no JSONL parsing, no SurrealDB connection, no writes performed."
         ),
     )
     return payload, EXIT_OK


### PR DESCRIPTION
## Kurzbefund
- Ergaenzt fuer #2069 eine explizite lokale Config-Schicht fuer den Context Importer: secret-freie Beispiel-YAML, fail-closed Loader/Validator, Unit-Tests und aktualisierten CLI-Vertrag.

## Warum jetzt
- #2068 hat den Importer-Scaffold geliefert. #2069 setzt darauf die lokale Konfigurationsoberflaeche, ohne SurrealDB-Verbindungen oder Writes zu aktivieren.

## Scope
- in: lokale Beispiel-Config, explizites Config-Laden via CLI, Fail-closed-Validierung fuer Apply-Defaults und verbotene Tabellen, Tests, CLI-Vertrag
- out: SurrealDB-Verbindung, JSONL-Validierung, Plan/Apply/Audit/Rollback-Implementierung, Live-/Trading-Freigabe

## Betroffene Dateien / Artefakte
- infrastructure/config/surrealdb/context_import.local.example.yaml
- tools/surrealdb/context_importer.py
- tests/unit/surrealdb/test_context_import_config.py
- docs/surrealdb/context-importer-cli-contract.md

## Validierung / Checks
- ruff check tools/surrealdb/context_importer.py tests/unit/surrealdb/test_context_importer.py tests/unit/surrealdb/test_context_import_config.py -> passed
- python -m pytest -q tests/unit/surrealdb/test_context_importer.py tests/unit/surrealdb/test_context_import_config.py -> 41 passed

## Risiken / Guardrails
- apply bleibt im Scaffold hart geblockt mit WRITE_DENIED.
- Config wird nur bei expliziter Pfadangabe geladen.
- Beispiel-Config enthaelt keine Secrets und autorisiert keine Live-/Trading-Pfade.
- Trading-State- und Governance-Mirror-Tabellen sind fuer allowed_tables geblockt.

## Restunsicherheiten
- Die Sandbox konnte eigene Pytest-Temp-Verzeichnisse mit ACL-Problemen nicht entfernen; sie sind nicht Bestandteil des Commits/PRs.

## Issue-Bezug
- Refs #2069
