### PR TITLE
feat(surrealdb): validate context import jsonl artifacts

### DIFF
--- a/docs/surrealdb/context-importer-cli-contract.md
+++ b/docs/surrealdb/context-importer-cli-contract.md
@@ -1,9 +1,9 @@
 # Context Importer CLI Contract
 
-**Status**: Draft (Scaffold + Local Config Slice)
-**Authority**: Issue #2068 + #2069 / Wave 10 Parent #2067 / Epic #1976
+**Status**: Draft (Scaffold + Local Config + JSONL Validation Slice)
+**Authority**: Issue #2068 + #2069 + #2070 / Wave 10 Parent #2067 / Epic #1976
 **Target**: `tools/surrealdb/context_importer.py`
-**Scope**: CLI scaffold plus explicit local config validation — no SurrealDB connection, no writes, no JSONL parsing.
+**Scope**: CLI scaffold plus explicit local config validation and read-only JSONL validation — no SurrealDB connection, no SurrealDB writes.
 
 ---
 
@@ -15,8 +15,9 @@ In #2068 wurde ausschliesslich das Scaffold geliefert: Argument-Parsing,
 Help-Text, Default-Verhalten und Safety-Gates. #2069 ergaenzt eine explizite
 lokale Config-Lade- und Validierungsschicht fuer
 `infrastructure/config/surrealdb/context_import.local.example.yaml`.
-Jede echte Logik (JSONL-Validation, Plan-Berechnung, Apply, Audit,
-Rollback-Plan) gehoert weiterhin zu separaten Folge-Slices.
+Die JSONL-Validation fuer `validate-jsonl` ist in #2070 read-only implementiert.
+Plan-Berechnung, Apply, Audit und Rollback-Plan gehoeren weiterhin zu separaten
+Folge-Slices.
 
 ---
 
@@ -24,7 +25,7 @@ Rollback-Plan) gehoert weiterhin zu separaten Folge-Slices.
 
 | Command | Zweck (Endziel) | Verhalten in #2068 |
 |---|---|---|
-| `validate-jsonl` | JSONL-Artefakte gegen Schema pruefen | Stub: `scaffold-ack`, Exit `0` |
+| `validate-jsonl` | JSONL-Artefakte gegen Schema pruefen | Read-only Validation, Exit `0` ohne Blocking Findings, Exit `1` mit Blocking Findings |
 | `plan` | Diff JSONL ↔ SurrealDB berechnen | Stub: `scaffold-ack`, Exit `0` |
 | `dry-run` | End-to-End-Lauf ohne Schreiben | Stub: `scaffold-ack`, Exit `0` |
 | `apply` | Schreiben nach SurrealDB | Hart geblockt: Exit `5` (`WRITE_DENIED`) |
@@ -40,8 +41,9 @@ Folge-Slice (Apply-Implementation) entfernt werden.
 
 ## 3. Sicherheitsmodell und Guardrails
 
-- **Read-only Default**: Alle Subcommands sind Stubs, die nur eine
-  deterministische JSON-Antwort drucken.
+- **Read-only Default**: Alle nicht implementierten Subcommands sind Stubs, die
+  nur eine deterministische JSON-Antwort drucken. `validate-jsonl` liest lokale
+  JSONL-Dateien, validiert sie und bleibt ohne SurrealDB-Zugriff.
 - **Dry-run Default**: Ohne explizites `--apply` ist `dry_run = true`.
 - **Apply hart geblockt**: `--apply` und `apply` exit `5` (`WRITE_DENIED`).
 - **Keine SurrealDB-Verbindung**: `--surreal-url`, `--namespace`,
@@ -49,8 +51,8 @@ Folge-Slice (Apply-Implementation) entfernt werden.
   immer `surrealdb_connection: "disabled"`.
 - **Output-Pfad-Whitelist**: `--report-output` muss unter `artifacts/`
   oder `temp/` liegen. Absolute Pfade (`/...`, `C:\...`, UNC) und
-  Traversal (`..`) werden mit Exit `5` verworfen. Der Scaffold schreibt
-  selbst nichts.
+  Traversal (`..`) werden mit Exit `5` verworfen. `validate-jsonl` schreibt
+  nur bei explizitem `--report-output`; andere Subcommands schreiben nichts.
 - **Config nur explizit**: `--config` wird nur geladen, wenn der Pfad explizit
   uebergeben wird. Ohne `--config` laeuft der Scaffold weiter ohne Config.
 - **Config fail-closed**: `allow_apply_default` muss `false` sein; Trading-
@@ -60,7 +62,8 @@ Folge-Slice (Apply-Implementation) entfernt werden.
   `infrastructure/config/surrealdb/context_import.local.example.yaml` enthaelt
   nur lokale Platzhalter. Reale Credentials muessen aus `SECRETS_PATH` oder
   der Laufzeitumgebung kommen, nicht aus dieser YAML.
-- **Keine JSONL-Validation-Logik**: gehoert zu Folge-Slice.
+- **Secret-Redaction**: Findings melden secret-like Inhalte nur mit Code und
+  Pfad/Zeile; erkannte Werte werden nicht in Reports oder stdout echoed.
 - **Keine Plan-/Audit-/Rollback-Logik**: jeweils eigene Folge-Slices.
 
 ---
@@ -69,13 +72,13 @@ Folge-Slice (Apply-Implementation) entfernt werden.
 
 | Argument | Default | Pflicht? | Verhalten im Scaffold |
 |---|---|---|---|
-| `--input-dir` | `None` | nein | nicht gelesen |
+| `--input-dir` | `None` | fuer `validate-jsonl` ja | lokales JSONL-Verzeichnis lesen/validieren; andere Subcommands ignorieren es |
 | `--surreal-url` | `""` | nein | nicht verwendet |
 | `--namespace` | `None` | nein | nicht verwendet |
 | `--database` | `None` | nein | nicht verwendet |
-| `--run-id` | `None` | nein | nur geparsed |
+| `--run-id` | `None` | nein | `validate-jsonl` prueft optional auf einheitlichen Run; andere Subcommands parsen nur |
 | `--config` | `None` | nein | explizite lokale YAML laden und validieren, kein Write |
-| `--report-output` | `None` | nein | Whitelist-Check, kein Write |
+| `--report-output` | `None` | nein | Whitelist-Check; `validate-jsonl` schreibt Report nur wenn explizit gesetzt |
 | `--dry-run` | `False` (Default-Verhalten ist dennoch dry-run) | nein | redundant; explizit erlaubt |
 | `--apply` | `False` | nein | `True` ⇒ Exit `5` |
 | `--format` | `json` | nein | `json` / `jsonl` / `markdown` |
@@ -120,8 +123,8 @@ Diese Tabellen muessen in `forbidden_tables` stehen. Ueberschneidungen zwischen
 
 | Code | Bedeutung |
 |---|---|
-| 0 | Erfolg / Scaffold acknowledged |
-| 1 | Validierungsfehler (reserviert; im Scaffold nicht ausgeloest) |
+| 0 | Erfolg / Scaffold acknowledged oder `validate-jsonl` ohne Blocking Findings |
+| 1 | Validierungsfehler mit Blocking Findings |
 | 2 | CLI-Usage / argparse-Fehler |
 | 3 | Input-/Config-Datei nicht gefunden |
 | 4 | Unsupported Format (defensiv; argparse faengt das frueher) |
@@ -148,6 +151,54 @@ Erfolgsantwort (Subcommand-Stub):
 }
 ```
 
+`validate-jsonl`-Antwort:
+
+```json
+{
+  "schema_version": "context-importer/v0",
+  "command": "validate-jsonl",
+  "status": "passed",
+  "dry_run": true,
+  "apply_requested": false,
+  "surrealdb_connection": "disabled",
+  "implemented": true,
+  "input_dir": "artifacts/context-index/run",
+  "run_id": "run-id-or-null",
+  "artifact_counts": {"repo_artifacts": 1},
+  "validation": {
+    "blocking_count": 0,
+    "warning_count": 0,
+    "info_count": 0,
+    "finding_count": 0
+  },
+  "findings": []
+}
+```
+
+Bei Blocking Findings ist `status` `blocked` und Exit-Code `1`. Findings
+enthalten nur `severity`, `code`, `message`, optional `artifact`, `line` und
+`source_path`; erkannte secret-like Werte werden nicht ausgegeben.
+
+Validierte JSONL-Artefakte:
+
+```text
+repo_artifacts.jsonl, doc_pages.jsonl, doc_sections.jsonl, doc_chunks.jsonl,
+code_symbols.jsonl, import_references.jsonl, test_cases.jsonl,
+config_references.jsonl, doc_code_links.jsonl, dependency_edges.jsonl
+```
+
+Validierung umfasst:
+
+- JSONL-Syntax und Objekt-Records.
+- Artefakt-spezifische Pflichtfelder.
+- `schema_version == context-indexer/v0`.
+- Einheitlichen bzw. per `--run-id` erwarteten `run_id`.
+- `sha256`-Hashformate fuer Hash-Felder.
+- Relative, nicht traversierende `source_path`-Werte.
+- Trading-/Runtime-State-Pfadteile als Blocking Finding.
+- Cross-References fuer `source_hash`, Page/Section/Chunk/Symbol-Verweise.
+- Secret-like Keys/Werte als Blocking Finding ohne Wert-Echo.
+
 Wenn `--config` gesetzt ist, wird die Antwort um `config_loaded: true` und ein
 `config`-Objekt mit den validierten lokalen Config-Feldern erweitert. Das
 Objekt ist Audit-/Debug-Ausgabe fuer lokale Entwicklung; es darf keine Secrets
@@ -171,9 +222,9 @@ weder aus CLI-Args noch aus der Umgebung abgeleitet.
 
 ## 7. Anforderungen fuer Folge-Slices
 
-- `validate-jsonl`-Implementierung darf das Antwort-Schema erweitern,
-  aber `schema_version`, `command`, `status`, `dry_run`,
-  `apply_requested`, `surrealdb_connection` muessen erhalten bleiben.
+- Folge-Slices duerfen das `validate-jsonl`-Antwort-Schema erweitern, aber
+  `schema_version`, `command`, `status`, `dry_run`, `apply_requested`,
+  `surrealdb_connection`, `validation` und `findings` muessen erhalten bleiben.
 - Die Apply-Implementierung muss den Hard-Block ersetzen, NICHT lediglich
   umgehen, und muss zwingend einen Two-Step-Gate (`--apply`
   + zusaetzliche explizite Bestaetigung) bewahren.
@@ -190,7 +241,7 @@ weder aus CLI-Args noch aus der Umgebung abgeleitet.
 
 - Keine SurrealDB-Verbindung.
 - Kein SurrealDB-Write.
-- Keine JSONL-Validierung.
+- Kein Import-/Plan-/Apply-Verhalten aus validierten JSONL-Artefakten.
 - Keine Plan-/Apply-/Audit-/Rollback-Logik.
 - Keine Aenderung an Trading-, Risk-, Execution-, Secrets- oder
   Live-Readiness-Pfaden.

--- a/tests/unit/surrealdb/test_context_import_jsonl_validation.py
+++ b/tests/unit/surrealdb/test_context_import_jsonl_validation.py
@@ -1,0 +1,303 @@
+"""Unit tests for Context Importer JSONL validation (#2070)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.surrealdb.context_importer import (
+    EXIT_INPUT_NOT_FOUND,
+    EXIT_OK,
+    EXIT_VALIDATION_ERROR,
+    EXIT_WRITE_DENIED,
+    EXPECTED_JSONL_FILES,
+    INDEXER_SCHEMA_VERSION,
+    main,
+)
+
+
+HASH = "a" * 64
+RUN_ID = "run-2070"
+
+
+def _read_json(capsys) -> dict:
+    out = capsys.readouterr().out.strip()
+    return json.loads(out)
+
+
+def _write_jsonl(input_dir: Path, artifact: str, records: list[dict]) -> None:
+    path = input_dir / EXPECTED_JSONL_FILES[artifact]
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _base_record(**updates) -> dict:
+    record = {"schema_version": INDEXER_SCHEMA_VERSION, "run_id": RUN_ID}
+    record.update(updates)
+    return record
+
+
+def _write_valid_artifacts(input_dir: Path) -> None:
+    records = {
+        "repo_artifacts": [
+            _base_record(
+                artifact_id="artifact:1",
+                source_path="docs/example.md",
+                file_type="markdown",
+                raw_sha256=HASH,
+                normalized_sha256=HASH,
+                source_hash=HASH,
+                integrity_algo="sha256",
+                size_bytes=12,
+                sensitivity="internal_context",
+            )
+        ],
+        "doc_pages": [
+            _base_record(
+                page_id="page:1",
+                source_path="docs/example.md",
+                source_hash=HASH,
+                title="Example",
+                doc_format="markdown",
+            )
+        ],
+        "doc_sections": [
+            _base_record(
+                section_id="section:1",
+                page_id="page:1",
+                source_path="docs/example.md",
+                source_hash=HASH,
+                heading="Example",
+                heading_path=["Example"],
+                section_level=1,
+                section_index=0,
+                span_start_line=1,
+                span_end_line=3,
+            )
+        ],
+        "doc_chunks": [
+            _base_record(
+                chunk_id="chunk:1",
+                page_id="page:1",
+                section_id="section:1",
+                source_path="docs/example.md",
+                source_hash=HASH,
+                heading_path=["Example"],
+                chunk_index=0,
+                content="safe context",
+                content_hash=HASH,
+            )
+        ],
+        "code_symbols": [
+            _base_record(
+                symbol_id="symbol:1",
+                source_path="tools/example.py",
+                source_hash=HASH,
+                symbol_type="function",
+                name="example",
+                qualified_name="example",
+            )
+        ],
+        "import_references": [
+            _base_record(
+                import_id="import:1",
+                source_path="tools/example.py",
+                source_hash=HASH,
+                module="json",
+            )
+        ],
+        "test_cases": [
+            _base_record(
+                test_id="test:1",
+                source_path="tests/test_example.py",
+                source_hash=HASH,
+                symbol_id="symbol:1",
+                name="test_example",
+            )
+        ],
+        "config_references": [
+            _base_record(
+                config_ref_id="config:1",
+                source_path="infrastructure/config/example.yaml",
+                source_hash=HASH,
+                config_key="safe_key",
+                config_value="safe-value",
+                sensitive=False,
+            )
+        ],
+        "doc_code_links": [
+            _base_record(
+                link_id="link:1",
+                source_path="docs/example.md",
+                source_hash=HASH,
+                target_symbol="example",
+                source_chunk_id="chunk:1",
+            )
+        ],
+        "dependency_edges": [
+            _base_record(
+                edge_id="edge:1",
+                from_id="symbol:1",
+                to_id="import:1",
+                edge_type="imports",
+            )
+        ],
+    }
+    for artifact, items in records.items():
+        _write_jsonl(input_dir, artifact, items)
+
+
+@pytest.mark.unit
+def test_validate_jsonl_passes_valid_artifacts(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path), "--run-id", RUN_ID])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert payload["status"] == "passed"
+    assert payload["implemented"] is True
+    assert payload["surrealdb_connection"] == "disabled"
+    assert payload["validation"]["blocking_count"] == 0
+    assert payload["artifact_counts"]["repo_artifacts"] == 1
+
+
+@pytest.mark.unit
+def test_validate_jsonl_blocks_missing_required_file(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+    (tmp_path / EXPECTED_JSONL_FILES["doc_chunks"]).unlink()
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path)])
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    assert payload["status"] == "blocked"
+    assert any(
+        finding["code"] == "jsonl_file_missing"
+        and finding["artifact"] == "doc_chunks"
+        for finding in payload["findings"]
+    )
+
+
+@pytest.mark.unit
+def test_validate_jsonl_blocks_bad_schema_and_missing_ref(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path,
+        "doc_pages",
+        [
+            _base_record(
+                schema_version="wrong/v0",
+                page_id="page:1",
+                source_path="docs/example.md",
+                source_hash="b" * 64,
+                title="Example",
+            )
+        ],
+    )
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path)])
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    codes = {finding["code"] for finding in payload["findings"]}
+    assert "schema_version_mismatch" in codes
+    assert "source_hash_ref_missing" in codes
+
+
+@pytest.mark.unit
+def test_validate_jsonl_redacts_secret_like_values(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path,
+        "doc_chunks",
+        [
+            _base_record(
+                chunk_id="chunk:1",
+                page_id="page:1",
+                section_id="section:1",
+                source_path="docs/example.md",
+                source_hash=HASH,
+                content="api_key=abcdefghijklmnopqrstuvwxyz",
+                content_hash=HASH,
+            )
+        ],
+    )
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path)])
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    out = capsys.readouterr().out
+    assert "abcdefghijklmnopqrstuvwxyz" not in out
+    payload = json.loads(out)
+    assert any(
+        finding["code"] == "secret_like_value_in_jsonl"
+        for finding in payload["findings"]
+    )
+
+
+@pytest.mark.unit
+def test_validate_jsonl_writes_report_only_when_requested(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = main(
+        [
+            "validate-jsonl",
+            "--input-dir",
+            str(tmp_path),
+            "--report-output",
+            "artifacts/report.md",
+            "--format",
+            "markdown",
+        ]
+    )
+
+    assert exit_code == EXIT_OK
+    assert capsys.readouterr().out.startswith("# context_importer: validate-jsonl")
+    report = tmp_path / "artifacts" / "report.md"
+    assert report.exists()
+    assert report.read_text(encoding="utf-8").startswith(
+        "# context_importer: validate-jsonl"
+    )
+
+
+@pytest.mark.unit
+def test_validate_jsonl_rejects_report_output_outside_whitelist(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+
+    exit_code = main(
+        ["validate-jsonl", "--input-dir", str(tmp_path), "--report-output", "out/report.json"]
+    )
+
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+
+
+@pytest.mark.unit
+def test_validate_jsonl_requires_input_dir(capsys) -> None:
+    exit_code = main(["validate-jsonl"])
+
+    assert exit_code == EXIT_INPUT_NOT_FOUND
+    payload = _read_json(capsys)
+    assert payload["error"] == "INPUT_NOT_FOUND"
+
+
+@pytest.mark.unit
+def test_apply_short_circuits_before_jsonl_validation(capsys) -> None:
+    exit_code = main(["validate-jsonl", "--apply", "--input-dir", "missing"])
+
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"

--- a/tests/unit/surrealdb/test_context_import_jsonl_validation.py
+++ b/tests/unit/surrealdb/test_context_import_jsonl_validation.py
@@ -167,6 +167,41 @@ def test_validate_jsonl_passes_valid_artifacts(tmp_path: Path, capsys) -> None:
 
 
 @pytest.mark.unit
+def test_validate_jsonl_allows_doc_chunk_tokens_estimate(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path,
+        "doc_chunks",
+        [
+            _base_record(
+                chunk_id="chunk:1",
+                page_id="page:1",
+                section_id="section:1",
+                source_path="docs/example.md",
+                source_hash=HASH,
+                heading_path=["Example"],
+                chunk_index=0,
+                content="safe context",
+                content_hash=HASH,
+                tokens_estimate=42,
+            )
+        ],
+    )
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path)])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert payload["status"] == "passed"
+    assert not any(
+        finding["code"] == "secret_like_value_in_jsonl"
+        for finding in payload["findings"]
+    )
+
+
+@pytest.mark.unit
 def test_validate_jsonl_blocks_missing_required_file(tmp_path: Path, capsys) -> None:
     _write_valid_artifacts(tmp_path)
     (tmp_path / EXPECTED_JSONL_FILES["doc_chunks"]).unlink()
@@ -212,29 +247,33 @@ def test_validate_jsonl_blocks_bad_schema_and_missing_ref(
 
 
 @pytest.mark.unit
-def test_validate_jsonl_redacts_secret_like_values(tmp_path: Path, capsys) -> None:
+@pytest.mark.parametrize(
+    ("secret_key", "secret_value"),
+    (
+        ("access_token", "access-token-value-1234567890"),
+        ("api_key", "api-key-value-1234567890"),
+    ),
+)
+def test_validate_jsonl_blocks_secret_like_keys_without_leaking_values(
+    tmp_path: Path, capsys, secret_key: str, secret_value: str
+) -> None:
     _write_valid_artifacts(tmp_path)
-    _write_jsonl(
-        tmp_path,
-        "doc_chunks",
-        [
-            _base_record(
-                chunk_id="chunk:1",
-                page_id="page:1",
-                section_id="section:1",
-                source_path="docs/example.md",
-                source_hash=HASH,
-                content="api_key=abcdefghijklmnopqrstuvwxyz",
-                content_hash=HASH,
-            )
-        ],
+    config_record = _base_record(
+        config_ref_id="config:1",
+        source_path="infrastructure/config/example.yaml",
+        source_hash=HASH,
+        config_key="safe_key",
+        config_value="safe-value",
+        sensitive=False,
     )
+    config_record[secret_key] = secret_value
+    _write_jsonl(tmp_path, "config_references", [config_record])
 
     exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path)])
 
     assert exit_code == EXIT_VALIDATION_ERROR
     out = capsys.readouterr().out
-    assert "abcdefghijklmnopqrstuvwxyz" not in out
+    assert secret_value not in out
     payload = json.loads(out)
     assert any(
         finding["code"] == "secret_like_value_in_jsonl"

--- a/tests/unit/surrealdb/test_context_import_jsonl_validation.py
+++ b/tests/unit/surrealdb/test_context_import_jsonl_validation.py
@@ -572,6 +572,44 @@ def test_validate_jsonl_rejects_report_output_outside_whitelist(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("link_path", "report_output"),
+    (
+        (Path("artifacts"), "artifacts/report.json"),
+        (Path("artifacts/linked"), "artifacts/linked/report.json"),
+    ),
+)
+def test_validate_jsonl_rejects_report_output_symlink_escape(
+    tmp_path: Path, monkeypatch, capsys, link_path: Path, report_output: str
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    artifacts_link = tmp_path / link_path
+    artifacts_link.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        artifacts_link.symlink_to(outside_dir, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable on this platform: {exc}")
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = main(
+        [
+            "validate-jsonl",
+            "--input-dir",
+            str(tmp_path),
+            "--report-output",
+            report_output,
+        ]
+    )
+
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+    assert not (outside_dir / "report.json").exists()
+
+
+@pytest.mark.unit
 def test_validate_jsonl_requires_input_dir(capsys) -> None:
     exit_code = main(["validate-jsonl"])
 

--- a/tests/unit/surrealdb/test_context_import_jsonl_validation.py
+++ b/tests/unit/surrealdb/test_context_import_jsonl_validation.py
@@ -151,6 +151,10 @@ def _write_valid_artifacts(input_dir: Path) -> None:
         _write_jsonl(input_dir, artifact, items)
 
 
+def _read_jsonl_report(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
 @pytest.mark.unit
 def test_validate_jsonl_passes_valid_artifacts(tmp_path: Path, capsys) -> None:
     _write_valid_artifacts(tmp_path)
@@ -382,6 +386,107 @@ def test_validate_jsonl_writes_report_only_when_requested(
     assert report.read_text(encoding="utf-8").startswith(
         "# context_importer: validate-jsonl"
     )
+
+
+@pytest.mark.unit
+def test_validate_jsonl_jsonl_report_pass_contains_summary(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = main(
+        [
+            "validate-jsonl",
+            "--input-dir",
+            str(tmp_path),
+            "--run-id",
+            RUN_ID,
+            "--report-output",
+            "artifacts/report.jsonl",
+            "--format",
+            "jsonl",
+        ]
+    )
+
+    assert exit_code == EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "passed"
+    records = _read_jsonl_report(tmp_path / "artifacts" / "report.jsonl")
+    assert len(records) == 1
+    summary = records[0]
+    assert summary["record_type"] == "summary"
+    assert summary["status"] == "passed"
+    assert summary["run_id"] == RUN_ID
+    assert summary["artifact_count"] == len(EXPECTED_JSONL_FILES)
+    assert summary["checked_records"] == len(EXPECTED_JSONL_FILES)
+    assert summary["has_blocking"] is False
+
+
+@pytest.mark.unit
+def test_validate_jsonl_jsonl_report_blocks_with_summary_first(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    (tmp_path / EXPECTED_JSONL_FILES["doc_chunks"]).unlink()
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = main(
+        [
+            "validate-jsonl",
+            "--input-dir",
+            str(tmp_path),
+            "--report-output",
+            "artifacts/report.jsonl",
+            "--format",
+            "jsonl",
+        ]
+    )
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "blocked"
+    records = _read_jsonl_report(tmp_path / "artifacts" / "report.jsonl")
+    assert records[0]["record_type"] == "summary"
+    assert records[0]["status"] == "blocked"
+    assert records[0]["finding_count"] >= 1
+    assert records[0]["has_blocking"] is True
+    assert all(record["record_type"] == "finding" for record in records[1:])
+    assert any(
+        record["code"] == "jsonl_file_missing"
+        and record["artifact"] == "doc_chunks"
+        for record in records[1:]
+    )
+
+
+@pytest.mark.unit
+def test_validate_jsonl_json_report_shape_remains_unchanged(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = main(
+        [
+            "validate-jsonl",
+            "--input-dir",
+            str(tmp_path),
+            "--report-output",
+            "artifacts/report.json",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == EXIT_OK
+    stdout_payload = json.loads(capsys.readouterr().out)
+    report = json.loads((tmp_path / "artifacts" / "report.json").read_text(encoding="utf-8"))
+    assert stdout_payload["report_output"].replace("\\", "/") == "artifacts/report.json"
+    assert "record_type" not in report
+    assert report["command"] == "validate-jsonl"
+    assert report["findings"] == []
+    assert report["status"] == "passed"
+    assert report["validation"]["blocking_count"] == 0
 
 
 @pytest.mark.unit

--- a/tests/unit/surrealdb/test_context_import_jsonl_validation.py
+++ b/tests/unit/surrealdb/test_context_import_jsonl_validation.py
@@ -251,6 +251,73 @@ def test_validate_jsonl_blocks_forbidden_source_paths(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "source_path",
+    (123, ["docs/foo.md"], {"path": "docs/foo.md"}),
+)
+def test_validate_jsonl_blocks_invalid_source_path_types(
+    tmp_path: Path, capsys, source_path
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path,
+        "doc_pages",
+        [
+            _base_record(
+                page_id="page:1",
+                source_path=source_path,
+                source_hash=HASH,
+                title="Example",
+                doc_format="markdown",
+            )
+        ],
+    )
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path)])
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    out = capsys.readouterr().out
+    assert "docs/foo.md" not in out
+    payload = json.loads(out)
+    assert any(
+        finding["code"] == "source_path_invalid_type"
+        and "source_path" not in finding
+        for finding in payload["findings"]
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("source_path", ("", "   "))
+def test_validate_jsonl_blocks_blank_required_source_paths(
+    tmp_path: Path, capsys, source_path: str
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path,
+        "doc_pages",
+        [
+            _base_record(
+                page_id="page:1",
+                source_path=source_path,
+                source_hash=HASH,
+                title="Example",
+                doc_format="markdown",
+            )
+        ],
+    )
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path)])
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    expected_code = "required_field_missing" if source_path == "" else "source_path_blank"
+    assert any(
+        finding["code"] == expected_code and finding["artifact"] == "doc_pages"
+        for finding in payload["findings"]
+    )
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("source_path", ("docs/foo.md", r"docs\foo.md"))
 def test_validate_jsonl_allows_safe_relative_source_paths(
     tmp_path: Path, capsys, source_path: str

--- a/tests/unit/surrealdb/test_context_import_jsonl_validation.py
+++ b/tests/unit/surrealdb/test_context_import_jsonl_validation.py
@@ -202,6 +202,81 @@ def test_validate_jsonl_allows_doc_chunk_tokens_estimate(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "source_path",
+    (
+        "/etc/passwd",
+        "../secrets.md",
+        "docs/../secrets.md",
+        r"C:\repo\file.md",
+        "C:/repo/file.md",
+        r"\\server\share\file.md",
+        "//server/share/file.md",
+        r"..\secrets.md",
+        r"docs\..\secrets.md",
+        r"C:..\secrets.md",
+    ),
+)
+def test_validate_jsonl_blocks_forbidden_source_paths(
+    tmp_path: Path, capsys, source_path: str
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path,
+        "doc_pages",
+        [
+            _base_record(
+                page_id="page:1",
+                source_path=source_path,
+                source_hash=HASH,
+                title="Example",
+                doc_format="markdown",
+            )
+        ],
+    )
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path)])
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    assert any(
+        finding["code"] == "forbidden_source_path"
+        and finding["source_path"] == source_path
+        for finding in payload["findings"]
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("source_path", ("docs/foo.md", r"docs\foo.md"))
+def test_validate_jsonl_allows_safe_relative_source_paths(
+    tmp_path: Path, capsys, source_path: str
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path,
+        "doc_pages",
+        [
+            _base_record(
+                page_id="page:1",
+                source_path=source_path,
+                source_hash=HASH,
+                title="Example",
+                doc_format="markdown",
+            )
+        ],
+    )
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path)])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert not any(
+        finding["code"] == "forbidden_source_path"
+        for finding in payload["findings"]
+    )
+
+
+@pytest.mark.unit
 def test_validate_jsonl_blocks_missing_required_file(tmp_path: Path, capsys) -> None:
     _write_valid_artifacts(tmp_path)
     (tmp_path / EXPECTED_JSONL_FILES["doc_chunks"]).unlink()

--- a/tests/unit/surrealdb/test_context_importer.py
+++ b/tests/unit/surrealdb/test_context_importer.py
@@ -22,7 +22,9 @@ from tools.surrealdb.context_importer import (
 )
 
 
-SCAFFOLD_COMMANDS_WITHOUT_APPLY = tuple(c for c in SUPPORTED_COMMANDS if c != "apply")
+SCAFFOLD_COMMANDS_WITHOUT_APPLY = tuple(
+    c for c in SUPPORTED_COMMANDS if c not in {"apply", "validate-jsonl"}
+)
 
 
 def _read_json(capsys) -> dict:

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -3,10 +3,9 @@
 Issue: #2068 (Wave 10, Slice 1)
 Parent: #2067 / Epic #1976
 
-This module implements ONLY the CLI scaffold for the future
-context-import pipeline. It is intentionally a no-op for all
-business commands and is hard-blocked from performing any write,
-network, or SurrealDB operation.
+This module implements the offline CLI scaffold for the future
+context-import pipeline plus the read-only JSONL validation slice.
+It is hard-blocked from performing any SurrealDB operation.
 
 Design rules enforced here:
 
@@ -17,7 +16,6 @@ Design rules enforced here:
   (``WRITE_DENIED``) and a deterministic error payload.
 * No SurrealDB connection is opened. ``--surreal-url``,
   ``--namespace``, and ``--database`` are parsed but never used.
-* No JSONL is read, parsed, or validated.
 * No config loader is invoked (that belongs to #2069).
 * No real plan / audit / rollback-plan logic exists.
 
@@ -41,6 +39,7 @@ from dataclasses import dataclass
 import json
 import logging
 from pathlib import Path
+import re
 from typing import Any
 
 import yaml
@@ -64,6 +63,92 @@ SUPPORTED_FORMATS = frozenset({"json", "jsonl", "markdown"})
 ALLOWED_OUTPUT_PREFIXES = ("artifacts", "temp")
 
 CONFIG_SCHEMA_VERSION = "context-import-local/v0"
+INDEXER_SCHEMA_VERSION = "context-indexer/v0"
+
+EXPECTED_JSONL_FILES = {
+    "repo_artifacts": "repo_artifacts.jsonl",
+    "doc_pages": "doc_pages.jsonl",
+    "doc_sections": "doc_sections.jsonl",
+    "doc_chunks": "doc_chunks.jsonl",
+    "code_symbols": "code_symbols.jsonl",
+    "import_references": "import_references.jsonl",
+    "test_cases": "test_cases.jsonl",
+    "config_references": "config_references.jsonl",
+    "doc_code_links": "doc_code_links.jsonl",
+    "dependency_edges": "dependency_edges.jsonl",
+}
+
+REQUIRED_JSONL_FIELDS: dict[str, frozenset[str]] = {
+    "repo_artifacts": frozenset(
+        {
+            "schema_version",
+            "run_id",
+            "artifact_id",
+            "source_path",
+            "file_type",
+            "raw_sha256",
+            "normalized_sha256",
+            "source_hash",
+            "integrity_algo",
+            "size_bytes",
+            "sensitivity",
+        }
+    ),
+    "doc_pages": frozenset(
+        {"schema_version", "run_id", "page_id", "source_path", "source_hash", "title"}
+    ),
+    "doc_sections": frozenset(
+        {
+            "schema_version",
+            "run_id",
+            "section_id",
+            "page_id",
+            "source_path",
+            "source_hash",
+            "heading",
+            "section_level",
+        }
+    ),
+    "doc_chunks": frozenset(
+        {
+            "schema_version",
+            "run_id",
+            "chunk_id",
+            "page_id",
+            "section_id",
+            "source_path",
+            "source_hash",
+            "content",
+            "content_hash",
+        }
+    ),
+    "code_symbols": frozenset(
+        {"schema_version", "run_id", "symbol_id", "source_path", "source_hash", "name"}
+    ),
+    "import_references": frozenset(
+        {"schema_version", "run_id", "import_id", "source_path", "source_hash", "module"}
+    ),
+    "test_cases": frozenset(
+        {"schema_version", "run_id", "test_id", "source_path", "source_hash", "symbol_id", "name"}
+    ),
+    "config_references": frozenset(
+        {
+            "schema_version",
+            "run_id",
+            "config_ref_id",
+            "source_path",
+            "source_hash",
+            "config_key",
+            "sensitive",
+        }
+    ),
+    "doc_code_links": frozenset(
+        {"schema_version", "run_id", "link_id", "source_path", "source_hash", "target_symbol"}
+    ),
+    "dependency_edges": frozenset(
+        {"schema_version", "run_id", "edge_id", "from_id", "to_id", "edge_type"}
+    ),
+}
 
 TRADING_STATE_TABLES = frozenset(
     {
@@ -88,6 +173,30 @@ GOVERNANCE_MIRROR_TABLES = frozenset(
 FORBIDDEN_CONTEXT_IMPORT_TABLES = TRADING_STATE_TABLES | GOVERNANCE_MIRROR_TABLES
 
 ALLOWED_AUTH_MODES = frozenset({"none", "root", "scope"})
+
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+SECRET_KEY_RE = re.compile(
+    r"(?i)(api[_\-]?key|private[_\-]?key|password|passwd|secret|token|credential"
+    r"|auth[_\-]?key|access[_\-]?key|signing[_\-]?key|encryption[_\-]?key)"
+)
+SECRET_VALUE_RE = re.compile(
+    r"(?i)\b(api[_-]?key|private[_-]?key|password|passwd|secret|token|credential)"
+    r"\b\s*[:=]\s*[\"']?[A-Za-z0-9_.+/=@:-]{12,}"
+)
+AWS_ACCESS_KEY_RE = re.compile(r"\bAKIA[0-9A-Z]{16}\b")
+PRIVATE_KEY_RE = re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")
+TRADING_STATE_PATH_PARTS = frozenset(
+    {
+        "orders",
+        "positions",
+        "fills",
+        "balances",
+        "exposures",
+        "live_risk_state",
+        "broker_state",
+        "execution_state",
+    }
+)
 
 EXIT_OK = 0
 EXIT_VALIDATION_ERROR = 1
@@ -135,6 +244,77 @@ class ConfigValidationError(ContextImporterError):
 
     code = "CONFIG_VALIDATION_ERROR"
     exit_code = EXIT_VALIDATION_ERROR
+
+
+@dataclass(frozen=True)
+class JsonlValidationFinding:
+    severity: str
+    code: str
+    message: str
+    artifact: str | None = None
+    line: int | None = None
+    source_path: str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "severity": self.severity,
+            "code": self.code,
+            "message": self.message,
+        }
+        if self.artifact is not None:
+            payload["artifact"] = self.artifact
+        if self.line is not None:
+            payload["line"] = self.line
+        if self.source_path is not None:
+            payload["source_path"] = self.source_path
+        return payload
+
+
+@dataclass(frozen=True)
+class JsonlValidationReport:
+    input_dir: Path
+    run_id: str | None
+    records: dict[str, list[dict[str, Any]]]
+    findings: tuple[JsonlValidationFinding, ...]
+
+    @property
+    def blocking_count(self) -> int:
+        return sum(1 for finding in self.findings if finding.severity == "blocking")
+
+    @property
+    def warning_count(self) -> int:
+        return sum(1 for finding in self.findings if finding.severity == "warning")
+
+    @property
+    def info_count(self) -> int:
+        return sum(1 for finding in self.findings if finding.severity == "info")
+
+    @property
+    def status(self) -> str:
+        return "blocked" if self.blocking_count else "passed"
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "command": "validate-jsonl",
+            "status": self.status,
+            "dry_run": True,
+            "apply_requested": False,
+            "surrealdb_connection": "disabled",
+            "implemented": True,
+            "input_dir": str(self.input_dir),
+            "run_id": self.run_id,
+            "artifact_counts": {
+                artifact: len(items) for artifact, items in sorted(self.records.items())
+            },
+            "validation": {
+                "blocking_count": self.blocking_count,
+                "warning_count": self.warning_count,
+                "info_count": self.info_count,
+                "finding_count": len(self.findings),
+            },
+            "findings": [finding.to_payload() for finding in self.findings],
+        }
 
 
 @dataclass(frozen=True)
@@ -199,6 +379,462 @@ def _validate_output_path(output: Path | None) -> Path | None:
             f"output path may not traverse with '..': {output}"
         )
     return output
+
+
+def _validate_input_dir(input_dir: Path | None) -> Path:
+    if input_dir is None:
+        raise InputNotFoundError("validate-jsonl requires --input-dir")
+    try:
+        exists = input_dir.exists()
+        is_dir = input_dir.is_dir() if exists else False
+    except OSError as exc:
+        raise InputNotFoundError(f"cannot stat input directory: {input_dir}: {exc}") from exc
+    if not exists:
+        raise InputNotFoundError(f"input directory not found: {input_dir}")
+    if not is_dir:
+        raise InputNotFoundError(f"input path is not a directory: {input_dir}")
+    return input_dir
+
+
+def _path_contains_trading_state(source_path: str) -> bool:
+    parts = {part.lower() for part in source_path.replace("\\", "/").split("/")}
+    return bool(parts & TRADING_STATE_PATH_PARTS)
+
+
+def _contains_secret_like_value(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(
+            SECRET_VALUE_RE.search(value)
+            or AWS_ACCESS_KEY_RE.search(value)
+            or PRIVATE_KEY_RE.search(value)
+        )
+    if isinstance(value, list):
+        return any(_contains_secret_like_value(item) for item in value)
+    if isinstance(value, dict):
+        return any(
+            SECRET_KEY_RE.search(str(key)) or _contains_secret_like_value(item)
+            for key, item in value.items()
+        )
+    return False
+
+
+def _record_source_path(record: dict[str, Any]) -> str | None:
+    value = record.get("source_path")
+    return value if isinstance(value, str) else None
+
+
+def _finding(
+    severity: str,
+    code: str,
+    message: str,
+    *,
+    artifact: str | None = None,
+    line: int | None = None,
+    record: dict[str, Any] | None = None,
+) -> JsonlValidationFinding:
+    return JsonlValidationFinding(
+        severity=severity,
+        code=code,
+        message=message,
+        artifact=artifact,
+        line=line,
+        source_path=_record_source_path(record) if record is not None else None,
+    )
+
+
+def _read_jsonl_file(
+    input_dir: Path,
+    artifact: str,
+    filename: str,
+    findings: list[JsonlValidationFinding],
+) -> list[dict[str, Any]]:
+    path = input_dir / filename
+    try:
+        exists = path.exists()
+        is_file = path.is_file() if exists else False
+    except OSError as exc:
+        findings.append(
+            _finding("blocking", "jsonl_file_stat_failed", str(exc), artifact=artifact)
+        )
+        return []
+
+    if not exists:
+        findings.append(
+            _finding(
+                "blocking",
+                "jsonl_file_missing",
+                f"required JSONL artifact is missing: {filename}",
+                artifact=artifact,
+            )
+        )
+        return []
+    if not is_file:
+        findings.append(
+            _finding(
+                "blocking",
+                "jsonl_path_not_file",
+                f"JSONL artifact path is not a file: {filename}",
+                artifact=artifact,
+            )
+        )
+        return []
+
+    records: list[dict[str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        findings.append(
+            _finding("blocking", "jsonl_file_read_failed", str(exc), artifact=artifact)
+        )
+        return []
+
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            findings.append(
+                _finding(
+                    "warning",
+                    "jsonl_blank_line",
+                    "blank JSONL lines are ignored",
+                    artifact=artifact,
+                    line=line_number,
+                )
+            )
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            findings.append(
+                _finding(
+                    "blocking",
+                    "jsonl_invalid_json",
+                    f"invalid JSON at line {line_number}: {exc.msg}",
+                    artifact=artifact,
+                    line=line_number,
+                )
+            )
+            continue
+        if not isinstance(record, dict):
+            findings.append(
+                _finding(
+                    "blocking",
+                    "jsonl_record_not_object",
+                    "JSONL record must be an object",
+                    artifact=artifact,
+                    line=line_number,
+                )
+            )
+            continue
+        record["__line"] = line_number
+        records.append(record)
+    return records
+
+
+def _validate_record_fields(
+    artifact: str,
+    record: dict[str, Any],
+    findings: list[JsonlValidationFinding],
+    expected_run_id: str | None,
+) -> str | None:
+    line = record.get("__line") if isinstance(record.get("__line"), int) else None
+    required = REQUIRED_JSONL_FIELDS[artifact]
+    missing = sorted(field for field in required if record.get(field) in (None, ""))
+    for field in missing:
+        findings.append(
+            _finding(
+                "blocking",
+                "required_field_missing",
+                f"missing required field: {field}",
+                artifact=artifact,
+                line=line,
+                record=record,
+            )
+        )
+
+    schema_version = record.get("schema_version")
+    if schema_version != INDEXER_SCHEMA_VERSION:
+        findings.append(
+            _finding(
+                "blocking",
+                "schema_version_mismatch",
+                "record schema_version must match context-indexer/v0",
+                artifact=artifact,
+                line=line,
+                record=record,
+            )
+        )
+
+    run_id = record.get("run_id")
+    if not isinstance(run_id, str) or not run_id.strip():
+        findings.append(
+            _finding(
+                "blocking",
+                "run_id_missing",
+                "record run_id must be a non-empty string",
+                artifact=artifact,
+                line=line,
+                record=record,
+            )
+        )
+    elif expected_run_id is not None and run_id != expected_run_id:
+        findings.append(
+            _finding(
+                "blocking",
+                "run_id_mismatch",
+                "record run_id differs from CLI --run-id",
+                artifact=artifact,
+                line=line,
+                record=record,
+            )
+        )
+
+    source_path = _record_source_path(record)
+    if source_path is not None:
+        if Path(source_path).is_absolute() or ".." in Path(source_path).parts:
+            findings.append(
+                _finding(
+                    "blocking",
+                    "forbidden_source_path",
+                    "source_path must be relative and may not traverse",
+                    artifact=artifact,
+                    line=line,
+                    record=record,
+                )
+            )
+        if _path_contains_trading_state(source_path):
+            findings.append(
+                _finding(
+                    "blocking",
+                    "trading_state_path_in_jsonl",
+                    "source_path looks like trading/runtime state",
+                    artifact=artifact,
+                    line=line,
+                    record=record,
+                )
+            )
+
+    for hash_field in ("source_hash", "raw_sha256", "normalized_sha256", "content_hash"):
+        value = record.get(hash_field)
+        if value is not None and (not isinstance(value, str) or not SHA256_RE.match(value)):
+            findings.append(
+                _finding(
+                    "blocking",
+                    "hash_field_invalid",
+                    f"{hash_field} must be lowercase sha256 hex",
+                    artifact=artifact,
+                    line=line,
+                    record=record,
+                )
+            )
+
+    if artifact == "repo_artifacts":
+        if record.get("integrity_algo") != "sha256":
+            findings.append(
+                _finding(
+                    "blocking",
+                    "integrity_algo_invalid",
+                    "repo_artifact integrity_algo must be sha256",
+                    artifact=artifact,
+                    line=line,
+                    record=record,
+                )
+            )
+        if record.get("source_hash") != record.get("normalized_sha256"):
+            findings.append(
+                _finding(
+                    "blocking",
+                    "source_hash_mismatch",
+                    "repo_artifact source_hash must equal normalized_sha256",
+                    artifact=artifact,
+                    line=line,
+                    record=record,
+                )
+            )
+
+    if _contains_secret_like_value(record):
+        findings.append(
+            _finding(
+                "blocking",
+                "secret_like_value_in_jsonl",
+                "record contains a secret-like key or high-confidence secret pattern",
+                artifact=artifact,
+                line=line,
+                record=record,
+            )
+        )
+
+    return run_id if isinstance(run_id, str) and run_id.strip() else None
+
+
+def _validate_cross_references(
+    records: dict[str, list[dict[str, Any]]],
+    findings: list[JsonlValidationFinding],
+) -> None:
+    artifact_hashes = {
+        item.get("normalized_sha256")
+        for item in records["repo_artifacts"]
+        if isinstance(item.get("normalized_sha256"), str)
+    }
+    page_ids = {
+        item.get("page_id") for item in records["doc_pages"] if isinstance(item.get("page_id"), str)
+    }
+    section_ids = {
+        item.get("section_id")
+        for item in records["doc_sections"]
+        if isinstance(item.get("section_id"), str)
+    }
+    chunk_ids = {
+        item.get("chunk_id")
+        for item in records["doc_chunks"]
+        if isinstance(item.get("chunk_id"), str)
+    }
+    symbol_ids = {
+        item.get("symbol_id")
+        for item in records["code_symbols"]
+        if isinstance(item.get("symbol_id"), str)
+    }
+
+    source_hash_artifacts = (
+        "doc_pages",
+        "doc_sections",
+        "doc_chunks",
+        "code_symbols",
+        "import_references",
+        "test_cases",
+        "config_references",
+        "doc_code_links",
+    )
+    for artifact in source_hash_artifacts:
+        for record in records[artifact]:
+            if record.get("source_hash") not in artifact_hashes:
+                findings.append(
+                    _finding(
+                        "blocking",
+                        "source_hash_ref_missing",
+                        "source_hash does not reference a repo_artifact normalized_sha256",
+                        artifact=artifact,
+                        line=record.get("__line"),
+                        record=record,
+                    )
+                )
+
+    for record in records["doc_sections"]:
+        if record.get("page_id") not in page_ids:
+            findings.append(
+                _finding(
+                    "blocking",
+                    "doc_section_page_ref_missing",
+                    "page_id does not reference doc_pages",
+                    artifact="doc_sections",
+                    line=record.get("__line"),
+                    record=record,
+                )
+            )
+    for record in records["doc_chunks"]:
+        if record.get("page_id") not in page_ids:
+            findings.append(
+                _finding(
+                    "blocking",
+                    "doc_chunk_page_ref_missing",
+                    "page_id does not reference doc_pages",
+                    artifact="doc_chunks",
+                    line=record.get("__line"),
+                    record=record,
+                )
+            )
+        if record.get("section_id") not in section_ids:
+            findings.append(
+                _finding(
+                    "blocking",
+                    "doc_chunk_section_ref_missing",
+                    "section_id does not reference doc_sections",
+                    artifact="doc_chunks",
+                    line=record.get("__line"),
+                    record=record,
+                )
+            )
+        for field_name in ("previous_chunk_id", "next_chunk_id"):
+            value = record.get(field_name)
+            if value is not None and value not in chunk_ids:
+                findings.append(
+                    _finding(
+                        "blocking",
+                        "doc_chunk_neighbor_ref_missing",
+                        f"{field_name} does not reference doc_chunks",
+                        artifact="doc_chunks",
+                        line=record.get("__line"),
+                        record=record,
+                    )
+                )
+    for record in records["test_cases"]:
+        if record.get("symbol_id") not in symbol_ids:
+            findings.append(
+                _finding(
+                    "blocking",
+                    "test_case_symbol_ref_missing",
+                    "symbol_id does not reference code_symbols",
+                    artifact="test_cases",
+                    line=record.get("__line"),
+                    record=record,
+                )
+            )
+    for record in records["doc_code_links"]:
+        value = record.get("source_chunk_id")
+        if value is not None and value not in chunk_ids:
+            findings.append(
+                _finding(
+                    "blocking",
+                    "doc_code_link_chunk_ref_missing",
+                    "source_chunk_id does not reference doc_chunks",
+                    artifact="doc_code_links",
+                    line=record.get("__line"),
+                    record=record,
+                )
+            )
+
+
+def validate_jsonl(input_dir: Path, expected_run_id: str | None = None) -> JsonlValidationReport:
+    findings: list[JsonlValidationFinding] = []
+    records = {
+        artifact: _read_jsonl_file(input_dir, artifact, filename, findings)
+        for artifact, filename in EXPECTED_JSONL_FILES.items()
+    }
+
+    observed_run_ids: set[str] = set()
+    for artifact, items in records.items():
+        for record in items:
+            run_id = _validate_record_fields(artifact, record, findings, expected_run_id)
+            if run_id is not None:
+                observed_run_ids.add(run_id)
+
+    if expected_run_id is None and len(observed_run_ids) > 1:
+        findings.append(
+            _finding(
+                "blocking",
+                "run_id_inconsistent",
+                "JSONL artifacts contain more than one run_id",
+            )
+        )
+
+    _validate_cross_references(records, findings)
+
+    for items in records.values():
+        for record in items:
+            record.pop("__line", None)
+
+    run_id = expected_run_id or (next(iter(observed_run_ids)) if len(observed_run_ids) == 1 else None)
+    ordered_findings = tuple(
+        sorted(
+            findings,
+            key=lambda item: (
+                item.severity,
+                item.code,
+                item.artifact or "",
+                item.line or 0,
+                item.source_path or "",
+            ),
+        )
+    )
+    return JsonlValidationReport(input_dir=input_dir, run_id=run_id, records=records, findings=ordered_findings)
 
 
 def _require_mapping(raw: Any, *, path: Path) -> dict[str, Any]:
@@ -368,6 +1004,54 @@ def _render(payload: dict[str, Any], fmt: str) -> str:
     raise UnsupportedFormatError(f"unsupported format: {fmt!r}")
 
 
+def _render_jsonl_report(report: JsonlValidationReport, fmt: str) -> str:
+    payload = report.to_payload()
+    if fmt == "json":
+        return json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2)
+    if fmt == "jsonl":
+        return "\n".join(
+            json.dumps(finding.to_payload(), ensure_ascii=True, sort_keys=True)
+            for finding in report.findings
+        )
+    if fmt == "markdown":
+        lines = ["# context_importer: validate-jsonl"]
+        lines.extend(
+            [
+                f"- **status**: `{report.status}`",
+                f"- **input_dir**: `{report.input_dir}`",
+                f"- **run_id**: `{report.run_id}`",
+                f"- **blocking_count**: `{report.blocking_count}`",
+                f"- **warning_count**: `{report.warning_count}`",
+                f"- **info_count**: `{report.info_count}`",
+                "",
+                "## Artifact Counts",
+            ]
+        )
+        for artifact, items in sorted(report.records.items()):
+            lines.append(f"- **{artifact}**: `{len(items)}`")
+        lines.extend(["", "## Findings"])
+        if not report.findings:
+            lines.append("- No findings.")
+        for finding in report.findings:
+            location = finding.artifact or "global"
+            if finding.line is not None:
+                location = f"{location}:{finding.line}"
+            source = f" `{finding.source_path}`" if finding.source_path else ""
+            lines.append(
+                f"- **{finding.severity}** `{finding.code}` ({location}){source}: {finding.message}"
+            )
+        return "\n".join(lines)
+    raise UnsupportedFormatError(f"unsupported format: {fmt!r}")
+
+
+def _write_report(path: Path, rendered: str) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(rendered + "\n", encoding="utf-8")
+    except OSError as exc:
+        raise WriteDeniedError(f"cannot write report output: {path}: {exc}") from exc
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="context_importer",
@@ -391,7 +1075,7 @@ def build_parser() -> argparse.ArgumentParser:
             "--input-dir",
             type=Path,
             default=None,
-            help="Directory containing JSONL artefacts (read-only; unused in scaffold).",
+            help="Directory containing JSONL artefacts (read-only).",
         )
         sub.add_argument(
             "--surreal-url",
@@ -431,8 +1115,8 @@ def build_parser() -> argparse.ArgumentParser:
             type=Path,
             default=None,
             help=(
-                "Optional report output path. Must live under artifacts/ or "
-                "temp/. Scaffold never writes; the path is only validated."
+                "Optional report output path. Must live under artifacts/ or temp/. "
+                "Only validate-jsonl writes a report, and only when supplied."
             ),
         )
         sub.add_argument(
@@ -479,8 +1163,20 @@ def _handle(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
     # Validate format and output path defensively even though we do not
     # write. This makes the safety contract verifiable from tests.
     _validate_format(args.format)
-    _validate_output_path(args.report_output)
+    report_output = _validate_output_path(args.report_output)
     config = load_config(args.config) if args.config is not None else None
+
+    if command == "validate-jsonl":
+        input_dir = _validate_input_dir(args.input_dir)
+        report = validate_jsonl(input_dir, args.run_id)
+        payload = report.to_payload()
+        payload["config_loaded"] = config is not None
+        if config is not None:
+            payload["config"] = config.to_payload()
+        if report_output is not None:
+            _write_report(report_output, _render_jsonl_report(report, args.format))
+            payload["report_output"] = str(report_output)
+        return payload, EXIT_VALIDATION_ERROR if report.blocking_count else EXIT_OK
 
     payload = _build_payload(
         command,

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -1153,7 +1153,17 @@ def _render_jsonl_report(report: JsonlValidationReport, fmt: str) -> str:
 def _write_report(path: Path, rendered: str) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
+        target = path.resolve(strict=False)
+        cwd = Path.cwd().resolve()
+        allowed_roots = tuple(cwd / prefix for prefix in ALLOWED_OUTPUT_PREFIXES)
+        if not any(target.is_relative_to(root) for root in allowed_roots):
+            raise WriteDeniedError(
+                "report output must resolve under "
+                f"{ALLOWED_OUTPUT_PREFIXES}, got: {path}"
+            )
         path.write_text(rendered + "\n", encoding="utf-8")
+    except WriteDeniedError:
+        raise
     except OSError as exc:
         raise WriteDeniedError(f"cannot write report output: {path}: {exc}") from exc
 

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -175,6 +175,7 @@ FORBIDDEN_CONTEXT_IMPORT_TABLES = TRADING_STATE_TABLES | GOVERNANCE_MIRROR_TABLE
 ALLOWED_AUTH_MODES = frozenset({"none", "root", "scope"})
 
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+WINDOWS_DRIVE_PREFIX_RE = re.compile(r"^[A-Za-z]:")
 SECRET_LIKE_KEYS = frozenset(
     {
         "token",
@@ -427,6 +428,17 @@ def _path_contains_trading_state(source_path: str) -> bool:
     return bool(parts & TRADING_STATE_PATH_PARTS)
 
 
+def _is_forbidden_source_path(source_path: str) -> bool:
+    normalized = source_path.strip().replace("\\", "/")
+    if not normalized:
+        return True
+    if normalized.startswith("//") or normalized.startswith("/"):
+        return True
+    if WINDOWS_DRIVE_PREFIX_RE.match(normalized):
+        return True
+    return any(part == ".." for part in normalized.split("/"))
+
+
 def _contains_secret_like_value(value: Any) -> bool:
     if isinstance(value, str):
         return bool(
@@ -620,7 +632,7 @@ def _validate_record_fields(
 
     source_path = _record_source_path(record)
     if source_path is not None:
-        if Path(source_path).is_absolute() or ".." in Path(source_path).parts:
+        if _is_forbidden_source_path(source_path):
             findings.append(
                 _finding(
                     "blocking",

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -1052,10 +1052,32 @@ def _render_jsonl_report(report: JsonlValidationReport, fmt: str) -> str:
     if fmt == "json":
         return json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2)
     if fmt == "jsonl":
-        return "\n".join(
-            json.dumps(finding.to_payload(), ensure_ascii=True, sort_keys=True)
+        artifact_counts = {
+            artifact: len(items) for artifact, items in sorted(report.records.items())
+        }
+        summary = {
+            "record_type": "summary",
+            "schema_version": SCHEMA_VERSION,
+            "command": "validate-jsonl",
+            "status": report.status,
+            "input_dir": str(report.input_dir),
+            "run_id": report.run_id,
+            "artifact_count": len(report.records),
+            "artifact_counts": artifact_counts,
+            "checked_records": sum(artifact_counts.values()),
+            "finding_count": len(report.findings),
+            "has_blocking": report.blocking_count > 0,
+        }
+        lines = [json.dumps(summary, ensure_ascii=True, sort_keys=True)]
+        lines.extend(
+            json.dumps(
+                {"record_type": "finding", **finding.to_payload()},
+                ensure_ascii=True,
+                sort_keys=True,
+            )
             for finding in report.findings
         )
+        return "\n".join(lines)
     if fmt == "markdown":
         lines = ["# context_importer: validate-jsonl"]
         lines.extend(

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -466,6 +466,47 @@ def _record_source_path(record: dict[str, Any]) -> str | None:
     return value if isinstance(value, str) else None
 
 
+def _validated_source_path(
+    artifact: str,
+    record: dict[str, Any],
+    findings: list[JsonlValidationFinding],
+    line: int | None,
+) -> str | None:
+    source_path_required = "source_path" in REQUIRED_JSONL_FIELDS[artifact]
+    if "source_path" not in record:
+        return None
+    value = record["source_path"]
+    if value is None and source_path_required:
+        return None
+    if not isinstance(value, str):
+        findings.append(
+            _finding(
+                "blocking",
+                "source_path_invalid_type",
+                "source_path must be a non-empty string",
+                artifact=artifact,
+                line=line,
+                record=record,
+            )
+        )
+        return None
+    if value == "" and source_path_required:
+        return None
+    if not value.strip():
+        findings.append(
+            _finding(
+                "blocking",
+                "source_path_blank",
+                "source_path must be a non-empty string",
+                artifact=artifact,
+                line=line,
+                record=record,
+            )
+        )
+        return None
+    return value
+
+
 def _finding(
     severity: str,
     code: str,
@@ -630,7 +671,7 @@ def _validate_record_fields(
             )
         )
 
-    source_path = _record_source_path(record)
+    source_path = _validated_source_path(artifact, record, findings, line)
     if source_path is not None:
         if _is_forbidden_source_path(source_path):
             findings.append(

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -175,9 +175,35 @@ FORBIDDEN_CONTEXT_IMPORT_TABLES = TRADING_STATE_TABLES | GOVERNANCE_MIRROR_TABLE
 ALLOWED_AUTH_MODES = frozenset({"none", "root", "scope"})
 
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
-SECRET_KEY_RE = re.compile(
-    r"(?i)(api[_\-]?key|private[_\-]?key|password|passwd|secret|token|credential"
-    r"|auth[_\-]?key|access[_\-]?key|signing[_\-]?key|encryption[_\-]?key)"
+SECRET_LIKE_KEYS = frozenset(
+    {
+        "token",
+        "access_token",
+        "refresh_token",
+        "auth_token",
+        "bearer_token",
+        "secret_token",
+        "api_key",
+        "private_key",
+        "password",
+        "passwd",
+        "secret",
+        "credential",
+        "auth_key",
+        "access_key",
+        "signing_key",
+        "encryption_key",
+    }
+)
+BENIGN_TOKEN_KEYS = frozenset(
+    {
+        "tokens_estimate",
+        "token_count",
+        "max_tokens",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+    }
 )
 SECRET_VALUE_RE = re.compile(
     r"(?i)\b(api[_-]?key|private[_-]?key|password|passwd|secret|token|credential)"
@@ -412,10 +438,15 @@ def _contains_secret_like_value(value: Any) -> bool:
         return any(_contains_secret_like_value(item) for item in value)
     if isinstance(value, dict):
         return any(
-            SECRET_KEY_RE.search(str(key)) or _contains_secret_like_value(item)
+            _is_secret_like_key(str(key)) or _contains_secret_like_value(item)
             for key, item in value.items()
         )
     return False
+
+
+def _is_secret_like_key(key: str) -> bool:
+    normalized = key.strip().lower().replace("-", "_")
+    return normalized in SECRET_LIKE_KEYS and normalized not in BENIGN_TOKEN_KEYS
 
 
 def _record_source_path(record: dict[str, Any]) -> str | None:


### PR DESCRIPTION
## Summary
- Implements read-only alidate-jsonl parsing and validation for the 10 context-indexer JSONL artifact files from #2070.
- Adds blocking findings for schema/run-id/required-field/hash/path/secret-like/cross-reference violations while keeping SurrealDB connection and apply paths disabled.
- Updates the importer CLI contract and adds focused unit coverage for pass, block, report, redaction, and guardrail cases.

## Validation
- uff check "tools/surrealdb/context_importer.py" "tests/unit/surrealdb/test_context_importer.py" "tests/unit/surrealdb/test_context_import_config.py" "tests/unit/surrealdb/test_context_import_jsonl_validation.py"
- python -m pytest -q "tests/unit/surrealdb/test_context_importer.py" "tests/unit/surrealdb/test_context_import_config.py" "tests/unit/surrealdb/test_context_import_jsonl_validation.py" --basetemp "C:\tmp\pytest-2070" -p no:cacheprovider
- python -m pytest -q "tests/unit/surrealdb/" --basetemp "C:\tmp\pytest-2070" -p no:cacheprovider

Issue: #2070