### PR TITLE
feat(surrealdb): generate deterministic context import plan

### DIFF
--- a/docs/surrealdb/context-importer-cli-contract.md
+++ b/docs/surrealdb/context-importer-cli-contract.md
@@ -1,9 +1,9 @@
 # Context Importer CLI Contract
 
-**Status**: Draft (Scaffold + Local Config + JSONL Validation Slice)
-**Authority**: Issue #2068 + #2069 + #2070 / Wave 10 Parent #2067 / Epic #1976
+**Status**: Draft (Scaffold + Local Config + JSONL Validation + Import Plan Slice)
+**Authority**: Issue #2068 + #2069 + #2070 + #2071 / Wave 10 Parent #2067 / Epic #1976
 **Target**: `tools/surrealdb/context_importer.py`
-**Scope**: CLI scaffold plus explicit local config validation and read-only JSONL validation — no SurrealDB connection, no SurrealDB writes.
+**Scope**: CLI scaffold plus explicit local config validation, read-only JSONL validation, and deterministic import plan generation — no SurrealDB connection, no SurrealDB writes.
 
 ---
 
@@ -16,17 +16,18 @@ Help-Text, Default-Verhalten und Safety-Gates. #2069 ergaenzt eine explizite
 lokale Config-Lade- und Validierungsschicht fuer
 `infrastructure/config/surrealdb/context_import.local.example.yaml`.
 Die JSONL-Validation fuer `validate-jsonl` ist in #2070 read-only implementiert.
-Plan-Berechnung, Apply, Audit und Rollback-Plan gehoeren weiterhin zu separaten
-Folge-Slices.
+#2071 ergaenzt `plan --input-dir`: validierte JSONL-Artefakte werden zu einem
+deterministischen, DB-unabhaengigen Importplan geroutet. Dry-run-Reconcile,
+Apply, Audit und Rollback-Plan gehoeren weiterhin zu separaten Folge-Slices.
 
 ---
 
-## 2. Command-Modell (v0, Scaffold)
+## 2. Command-Modell (v0)
 
-| Command | Zweck (Endziel) | Verhalten in #2068 |
+| Command | Zweck (Endziel) | Aktuelles Verhalten |
 |---|---|---|
 | `validate-jsonl` | JSONL-Artefakte gegen Schema pruefen | Read-only Validation, Exit `0` ohne Blocking Findings, Exit `1` mit Blocking Findings |
-| `plan` | Diff JSONL ↔ SurrealDB berechnen | Stub: `scaffold-ack`, Exit `0` |
+| `plan` | Importplan aus JSONL-Artefakten berechnen | Mit `--input-dir`: deterministic candidate import plan, Exit `0` oder `1`; ohne `--input-dir`: Scaffold-Stub |
 | `dry-run` | End-to-End-Lauf ohne Schreiben | Stub: `scaffold-ack`, Exit `0` |
 | `apply` | Schreiben nach SurrealDB | Hart geblockt: Exit `5` (`WRITE_DENIED`) |
 | `audit` | Audit-Trail-Export | Stub: `scaffold-ack`, Exit `0` |
@@ -43,7 +44,8 @@ Folge-Slice (Apply-Implementation) entfernt werden.
 
 - **Read-only Default**: Alle nicht implementierten Subcommands sind Stubs, die
   nur eine deterministische JSON-Antwort drucken. `validate-jsonl` liest lokale
-  JSONL-Dateien, validiert sie und bleibt ohne SurrealDB-Zugriff.
+  JSONL-Dateien, validiert sie und bleibt ohne SurrealDB-Zugriff. `plan --input-dir`
+  nutzt dieselbe Validation und erzeugt nur lokale Plan-Ausgabe.
 - **Dry-run Default**: Ohne explizites `--apply` ist `dry_run = true`.
 - **Apply hart geblockt**: `--apply` und `apply` exit `5` (`WRITE_DENIED`).
 - **Keine SurrealDB-Verbindung**: `--surreal-url`, `--namespace`,
@@ -52,7 +54,8 @@ Folge-Slice (Apply-Implementation) entfernt werden.
 - **Output-Pfad-Whitelist**: `--report-output` muss unter `artifacts/`
   oder `temp/` liegen. Absolute Pfade (`/...`, `C:\...`, UNC) und
   Traversal (`..`) werden mit Exit `5` verworfen. `validate-jsonl` schreibt
-  nur bei explizitem `--report-output`; andere Subcommands schreiben nichts.
+  nur bei explizitem `--report-output`; `plan --input-dir` schreibt nur bei
+  explizitem `--report-output`; andere Subcommands schreiben nichts.
 - **Config nur explizit**: `--config` wird nur geladen, wenn der Pfad explizit
   uebergeben wird. Ohne `--config` laeuft der Scaffold weiter ohne Config.
 - **Config fail-closed**: `allow_apply_default` muss `false` sein; Trading-
@@ -64,7 +67,7 @@ Folge-Slice (Apply-Implementation) entfernt werden.
   der Laufzeitumgebung kommen, nicht aus dieser YAML.
 - **Secret-Redaction**: Findings melden secret-like Inhalte nur mit Code und
   Pfad/Zeile; erkannte Werte werden nicht in Reports oder stdout echoed.
-- **Keine Plan-/Audit-/Rollback-Logik**: jeweils eigene Folge-Slices.
+- **Keine Reconcile-/Apply-/Audit-/Rollback-Logik**: jeweils eigene Folge-Slices.
 
 ---
 
@@ -72,13 +75,13 @@ Folge-Slice (Apply-Implementation) entfernt werden.
 
 | Argument | Default | Pflicht? | Verhalten im Scaffold |
 |---|---|---|---|
-| `--input-dir` | `None` | fuer `validate-jsonl` ja | lokales JSONL-Verzeichnis lesen/validieren; andere Subcommands ignorieren es |
+| `--input-dir` | `None` | fuer `validate-jsonl` ja; fuer implementierten `plan` ja | lokales JSONL-Verzeichnis lesen/validieren; `plan` erzeugt daraus einen Importplan; andere Subcommands ignorieren es |
 | `--surreal-url` | `""` | nein | nicht verwendet |
 | `--namespace` | `None` | nein | nicht verwendet |
 | `--database` | `None` | nein | nicht verwendet |
 | `--run-id` | `None` | nein | `validate-jsonl` prueft optional auf einheitlichen Run; andere Subcommands parsen nur |
 | `--config` | `None` | nein | explizite lokale YAML laden und validieren, kein Write |
-| `--report-output` | `None` | nein | Whitelist-Check; `validate-jsonl` schreibt Report nur wenn explizit gesetzt |
+| `--report-output` | `None` | nein | Whitelist-Check; `validate-jsonl` und `plan --input-dir` schreiben Report nur wenn explizit gesetzt |
 | `--dry-run` | `False` (Default-Verhalten ist dennoch dry-run) | nein | redundant; explizit erlaubt |
 | `--apply` | `False` | nein | `True` ⇒ Exit `5` |
 | `--format` | `json` | nein | `json` / `jsonl` / `markdown` |
@@ -179,6 +182,89 @@ Bei Blocking Findings ist `status` `blocked` und Exit-Code `1`. Findings
 enthalten nur `severity`, `code`, `message`, optional `artifact`, `line` und
 `source_path`; erkannte secret-like Werte werden nicht ausgegeben.
 
+`plan --input-dir`-Antwort (#2071):
+
+```json
+{
+  "schema_version": "context-importer/v0",
+  "command": "plan",
+  "run_id": "run-id-or-null",
+  "input_dir": "artifacts/context-index/run",
+  "status": "planned",
+  "dry_run": true,
+  "apply_requested": false,
+  "surrealdb_connection": "disabled",
+  "implemented": true,
+  "actions": [
+    {
+      "action": "create",
+      "table": "doc_page",
+      "record_id": "doc_page:page-id",
+      "artifact": "doc_pages",
+      "source_ref": "docs/example.md",
+      "depends_on": [],
+      "reason": "validated JSONL record; DB-independent candidate create",
+      "payload_hash": "sha256-hex"
+    }
+  ],
+  "warnings": [],
+  "counts": {
+    "actions": 1,
+    "warnings": 0,
+    "tables": 1,
+    "validation_findings": 0
+  },
+  "table_counts": {"doc_page": 1},
+  "action_counts": {"create": 1},
+  "has_blocking_validation_findings": false,
+  "validation_summary": {
+    "blocking_count": 0,
+    "warning_count": 0,
+    "info_count": 0,
+    "finding_count": 0
+  },
+  "import_order": ["repo_artifact", "doc_page", "doc_section"]
+}
+```
+
+Plan-Vertrag:
+
+- `plan` ist DB-unabhaengig: es liest keinen SurrealDB-Zustand und fuehrt keinen
+  Reconcile gegen bestehende Records aus.
+- Ohne Blocking-Validation-Findings erzeugt jeder neue validierte Record eine
+  `create`-Candidate-Action. Innerhalb derselben Eingabe doppelte `record_id`s
+  werden deterministisch als `skip` markiert (First occurrence wins).
+- `update` und `tombstone` sind strukturell reserviert, werden in #2071 aber
+  nicht erzeugt, weil dafuer DB-/State-Vergleich oder explizite Tombstone-
+  Artefakte erforderlich waeren.
+- Bei Blocking-Validation-Findings ist `status` `blocked`, `actions` ist leer,
+  `has_blocking_validation_findings` ist `true`, und Exit-Code ist `1`.
+- `payload_hash` ist ein stabiler SHA-256 ueber den JSONL-Record mit sortierten
+  Keys; er enthaelt keine SurrealDB-State- oder Secret-Werte.
+- `--format json` gibt das vollstaendige Plan-Objekt aus. `--format markdown`
+  ist diff-freundlich fuer Review. `--format jsonl` gibt eine Summary-Zeile plus
+  je eine Zeile pro Action/Warning aus.
+
+Artifact-zu-Table-Routing in #2071:
+
+| JSONL-Artefakt | Ziel-Tabelle |
+|---|---|
+| `repo_artifacts.jsonl` | `repo_artifact` |
+| `doc_pages.jsonl` | `doc_page` |
+| `doc_sections.jsonl` | `doc_section` |
+| `doc_chunks.jsonl` | `doc_chunk` |
+| `code_symbols.jsonl` | `code_symbol` |
+| `import_references.jsonl` | `import_reference` |
+| `test_cases.jsonl` | `test_case` |
+| `config_references.jsonl` | `config_reference` |
+| `doc_code_links.jsonl` | `doc_code_link` |
+| `dependency_edges.jsonl` | `dependency_edge` |
+
+Die ersten fuenf Tabellen plus `dependency_edge` sind in
+`infrastructure/surrealdb/context_intelligence_v0.surql` belegt. Die vier
+Indexer-spezifischen Referenz-/Test-/Config-/Doc-Link-Tabellen werden in #2071
+als import-plan-Ziele gefuehrt, aber nicht produktiv erstellt oder geschrieben.
+
 Validierte JSONL-Artefakte:
 
 ```text
@@ -237,12 +323,16 @@ weder aus CLI-Args noch aus der Umgebung abgeleitet.
 
 ---
 
-## 8. Nicht-Ziele in #2068
+## 8. Nicht-Ziele
+
+#2071 aendert diese Nicht-Ziele nur fuer `plan --input-dir`: Die
+Plan-Berechnung ist implementiert, bleibt aber read-only und DB-unabhaengig.
+Dry-run-Reconcile, Apply, Audit und Rollback-Plan bleiben Nicht-Ziele.
 
 - Keine SurrealDB-Verbindung.
 - Kein SurrealDB-Write.
-- Kein Import-/Plan-/Apply-Verhalten aus validierten JSONL-Artefakten.
-- Keine Plan-/Apply-/Audit-/Rollback-Logik.
+- Kein Apply-Verhalten aus validierten JSONL-Artefakten.
+- Keine Dry-run-Reconcile-/Apply-/Audit-/Rollback-Logik.
 - Keine Aenderung an Trading-, Risk-, Execution-, Secrets- oder
   Live-Readiness-Pfaden.
 - Kein Echtgeld-/Live-Enable.

--- a/tests/unit/surrealdb/test_context_import_plan.py
+++ b/tests/unit/surrealdb/test_context_import_plan.py
@@ -1,0 +1,292 @@
+"""Unit tests for deterministic Context Importer plans (#2071)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.surrealdb.context_importer import (
+    EXIT_OK,
+    EXIT_VALIDATION_ERROR,
+    EXIT_WRITE_DENIED,
+    EXPECTED_JSONL_FILES,
+    INDEXER_SCHEMA_VERSION,
+    main,
+)
+
+HASH = "b" * 64
+RUN_ID = "run-2071"
+
+
+def _read_json(capsys) -> dict:
+    out = capsys.readouterr().out.strip()
+    return json.loads(out)
+
+
+def _base_record(**updates) -> dict:
+    record = {"schema_version": INDEXER_SCHEMA_VERSION, "run_id": RUN_ID}
+    record.update(updates)
+    return record
+
+
+def _write_jsonl(input_dir: Path, artifact: str, records: list[dict]) -> None:
+    path = input_dir / EXPECTED_JSONL_FILES[artifact]
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _valid_records() -> dict[str, list[dict]]:
+    return {
+        "repo_artifacts": [
+            _base_record(
+                artifact_id="artifact-doc",
+                source_path="docs/example.md",
+                file_type="markdown",
+                raw_sha256=HASH,
+                normalized_sha256=HASH,
+                source_hash=HASH,
+                integrity_algo="sha256",
+                size_bytes=12,
+                sensitivity="internal_context",
+            )
+        ],
+        "doc_pages": [
+            _base_record(
+                page_id="page-example",
+                source_path="docs/example.md",
+                source_hash=HASH,
+                title="Example",
+                doc_format="markdown",
+            )
+        ],
+        "doc_sections": [
+            _base_record(
+                section_id="section-example",
+                page_id="page-example",
+                source_path="docs/example.md",
+                source_hash=HASH,
+                heading="Example",
+                heading_path=["Example"],
+                section_level=1,
+                section_index=0,
+            )
+        ],
+        "doc_chunks": [
+            _base_record(
+                chunk_id="chunk-example",
+                page_id="page-example",
+                section_id="section-example",
+                source_path="docs/example.md",
+                source_hash=HASH,
+                heading_path=["Example"],
+                chunk_index=0,
+                content="safe context",
+                content_hash=HASH,
+            )
+        ],
+        "code_symbols": [
+            _base_record(
+                symbol_id="symbol-example",
+                source_path="tools/example.py",
+                source_hash=HASH,
+                symbol_type="function",
+                name="example",
+                qualified_name="example",
+            )
+        ],
+        "import_references": [
+            _base_record(
+                import_id="import-json",
+                source_path="tools/example.py",
+                source_hash=HASH,
+                module="json",
+            )
+        ],
+        "test_cases": [
+            _base_record(
+                test_id="test-example",
+                source_path="tests/test_example.py",
+                source_hash=HASH,
+                symbol_id="symbol-example",
+                name="test_example",
+            )
+        ],
+        "config_references": [
+            _base_record(
+                config_ref_id="config-safe",
+                source_path="infrastructure/config/example.yaml",
+                source_hash=HASH,
+                config_key="safe_key",
+                config_value="safe-value",
+                sensitive=False,
+            )
+        ],
+        "doc_code_links": [
+            _base_record(
+                link_id="link-example",
+                source_path="docs/example.md",
+                source_hash=HASH,
+                target_symbol="example",
+                source_chunk_id="chunk-example",
+            )
+        ],
+        "dependency_edges": [
+            _base_record(
+                edge_id="edge-example",
+                from_id="symbol-example",
+                to_id="import-json",
+                edge_type="imports",
+            )
+        ],
+    }
+
+
+def _write_valid_artifacts(input_dir: Path) -> None:
+    for artifact, records in _valid_records().items():
+        _write_jsonl(input_dir, artifact, records)
+
+
+@pytest.mark.unit
+def test_plan_generates_deterministic_create_actions(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+
+    exit_code = main(["plan", "--input-dir", str(tmp_path), "--run-id", RUN_ID])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert payload["status"] == "planned"
+    assert payload["implemented"] is True
+    assert payload["surrealdb_connection"] == "disabled"
+    assert payload["has_blocking_validation_findings"] is False
+    assert payload["action_counts"] == {"create": 10}
+    assert payload["import_order"] == [
+        "repo_artifact",
+        "doc_page",
+        "doc_section",
+        "doc_chunk",
+        "code_symbol",
+        "import_reference",
+        "test_case",
+        "config_reference",
+        "doc_code_link",
+        "dependency_edge",
+    ]
+    assert [action["record_id"] for action in payload["actions"]] == [
+        "repo_artifact:artifact-doc",
+        "doc_page:page-example",
+        "doc_section:section-example",
+        "doc_chunk:chunk-example",
+        "code_symbol:symbol-example",
+        "import_reference:import-json",
+        "test_case:test-example",
+        "config_reference:config-safe",
+        "doc_code_link:link-example",
+        "dependency_edge:edge-example",
+    ]
+    section_action = payload["actions"][2]
+    assert section_action["depends_on"] == ["doc_page:page-example"]
+    chunk_action = payload["actions"][3]
+    assert chunk_action["depends_on"] == [
+        "doc_page:page-example",
+        "doc_section:section-example",
+    ]
+    assert all(len(action["payload_hash"]) == 64 for action in payload["actions"])
+
+
+@pytest.mark.unit
+def test_plan_output_is_stable_for_same_input(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+
+    assert main(["plan", "--input-dir", str(tmp_path)]) == EXIT_OK
+    first = capsys.readouterr().out
+    assert main(["plan", "--input-dir", str(tmp_path)]) == EXIT_OK
+    second = capsys.readouterr().out
+
+    assert first == second
+
+
+@pytest.mark.unit
+def test_plan_blocks_actions_when_validation_blocks(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+    records = _valid_records()["doc_pages"]
+    records[0]["source_path"] = "../secrets.md"
+    _write_jsonl(tmp_path, "doc_pages", records)
+
+    exit_code = main(["plan", "--input-dir", str(tmp_path)])
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    assert payload["status"] == "blocked"
+    assert payload["has_blocking_validation_findings"] is True
+    assert payload["actions"] == []
+    assert payload["action_counts"] == {}
+    assert any(
+        warning["code"] == "forbidden_source_path" and warning["severity"] == "blocking"
+        for warning in payload["warnings"]
+    )
+
+
+@pytest.mark.unit
+def test_plan_marks_duplicate_input_record_as_skip(tmp_path: Path, capsys) -> None:
+    records = _valid_records()
+    records["repo_artifacts"] = records["repo_artifacts"] * 2
+    for artifact, items in records.items():
+        _write_jsonl(tmp_path, artifact, items)
+
+    exit_code = main(["plan", "--input-dir", str(tmp_path)])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    repo_actions = [
+        action for action in payload["actions"] if action["table"] == "repo_artifact"
+    ]
+    assert [action["action"] for action in repo_actions] == ["create", "skip"]
+    assert payload["action_counts"] == {"create": 10, "skip": 1}
+
+
+@pytest.mark.unit
+def test_plan_markdown_report_output_is_written_under_whitelist(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    _write_valid_artifacts(input_dir)
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = main(
+        [
+            "plan",
+            "--input-dir",
+            str(input_dir),
+            "--format",
+            "markdown",
+            "--report-output",
+            "artifacts/plan.md",
+        ]
+    )
+
+    assert exit_code == EXIT_OK
+    stdout = capsys.readouterr().out
+    assert stdout.startswith("# context_importer: plan")
+    report = tmp_path / "artifacts" / "plan.md"
+    assert report.exists()
+    assert report.read_text(encoding="utf-8").startswith("# context_importer: plan")
+
+
+@pytest.mark.unit
+def test_plan_report_output_outside_whitelist_is_rejected(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+
+    exit_code = main(
+        ["plan", "--input-dir", str(tmp_path), "--report-output", "etc/plan.json"]
+    )
+
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import hashlib
 import json
 import logging
 from pathlib import Path
@@ -76,6 +77,45 @@ EXPECTED_JSONL_FILES = {
     "config_references": "config_references.jsonl",
     "doc_code_links": "doc_code_links.jsonl",
     "dependency_edges": "dependency_edges.jsonl",
+}
+
+IMPORT_ORDER = (
+    "repo_artifacts",
+    "doc_pages",
+    "doc_sections",
+    "doc_chunks",
+    "code_symbols",
+    "import_references",
+    "test_cases",
+    "config_references",
+    "doc_code_links",
+    "dependency_edges",
+)
+
+TABLE_BY_ARTIFACT = {
+    "repo_artifacts": "repo_artifact",
+    "doc_pages": "doc_page",
+    "doc_sections": "doc_section",
+    "doc_chunks": "doc_chunk",
+    "code_symbols": "code_symbol",
+    "import_references": "import_reference",
+    "test_cases": "test_case",
+    "config_references": "config_reference",
+    "doc_code_links": "doc_code_link",
+    "dependency_edges": "dependency_edge",
+}
+
+ID_FIELD_BY_ARTIFACT = {
+    "repo_artifacts": "artifact_id",
+    "doc_pages": "page_id",
+    "doc_sections": "section_id",
+    "doc_chunks": "chunk_id",
+    "code_symbols": "symbol_id",
+    "import_references": "import_id",
+    "test_cases": "test_id",
+    "config_references": "config_ref_id",
+    "doc_code_links": "link_id",
+    "dependency_edges": "edge_id",
 }
 
 REQUIRED_JSONL_FIELDS: dict[str, frozenset[str]] = {
@@ -126,10 +166,25 @@ REQUIRED_JSONL_FIELDS: dict[str, frozenset[str]] = {
         {"schema_version", "run_id", "symbol_id", "source_path", "source_hash", "name"}
     ),
     "import_references": frozenset(
-        {"schema_version", "run_id", "import_id", "source_path", "source_hash", "module"}
+        {
+            "schema_version",
+            "run_id",
+            "import_id",
+            "source_path",
+            "source_hash",
+            "module",
+        }
     ),
     "test_cases": frozenset(
-        {"schema_version", "run_id", "test_id", "source_path", "source_hash", "symbol_id", "name"}
+        {
+            "schema_version",
+            "run_id",
+            "test_id",
+            "source_path",
+            "source_hash",
+            "symbol_id",
+            "name",
+        }
     ),
     "config_references": frozenset(
         {
@@ -143,7 +198,14 @@ REQUIRED_JSONL_FIELDS: dict[str, frozenset[str]] = {
         }
     ),
     "doc_code_links": frozenset(
-        {"schema_version", "run_id", "link_id", "source_path", "source_hash", "target_symbol"}
+        {
+            "schema_version",
+            "run_id",
+            "link_id",
+            "source_path",
+            "source_hash",
+            "target_symbol",
+        }
     ),
     "dependency_edges": frozenset(
         {"schema_version", "run_id", "edge_id", "from_id", "to_id", "edge_type"}
@@ -345,6 +407,98 @@ class JsonlValidationReport:
 
 
 @dataclass(frozen=True)
+class ImportPlanAction:
+    action: str
+    table: str
+    record_id: str
+    artifact: str
+    source_ref: str | None
+    depends_on: tuple[str, ...]
+    reason: str
+    payload_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "table": self.table,
+            "record_id": self.record_id,
+            "artifact": self.artifact,
+            "source_ref": self.source_ref,
+            "depends_on": list(self.depends_on),
+            "reason": self.reason,
+            "payload_hash": self.payload_hash,
+        }
+
+
+@dataclass(frozen=True)
+class ImportPlanWarning:
+    code: str
+    message: str
+    artifact: str | None = None
+    source_ref: str | None = None
+    severity: str = "warning"
+
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "code": self.code,
+            "message": self.message,
+            "severity": self.severity,
+        }
+        if self.artifact is not None:
+            payload["artifact"] = self.artifact
+        if self.source_ref is not None:
+            payload["source_ref"] = self.source_ref
+        return payload
+
+
+@dataclass(frozen=True)
+class ImportPlan:
+    schema_version: str
+    run_id: str | None
+    input_dir: Path
+    status: str
+    actions: tuple[ImportPlanAction, ...]
+    warnings: tuple[ImportPlanWarning, ...]
+    table_counts: dict[str, int]
+    action_counts: dict[str, int]
+    has_blocking_validation_findings: bool
+    validation_report: JsonlValidationReport
+    import_order: tuple[str, ...]
+
+    def to_payload(self) -> dict[str, Any]:
+        validation_summary = {
+            "blocking_count": self.validation_report.blocking_count,
+            "warning_count": self.validation_report.warning_count,
+            "info_count": self.validation_report.info_count,
+            "finding_count": len(self.validation_report.findings),
+        }
+        return {
+            "schema_version": self.schema_version,
+            "command": "plan",
+            "run_id": self.run_id,
+            "input_dir": str(self.input_dir),
+            "status": self.status,
+            "dry_run": True,
+            "apply_requested": False,
+            "surrealdb_connection": "disabled",
+            "implemented": True,
+            "actions": [action.to_payload() for action in self.actions],
+            "warnings": [warning.to_payload() for warning in self.warnings],
+            "counts": {
+                "actions": len(self.actions),
+                "warnings": len(self.warnings),
+                "tables": len(self.table_counts),
+                "validation_findings": len(self.validation_report.findings),
+            },
+            "table_counts": dict(sorted(self.table_counts.items())),
+            "action_counts": dict(sorted(self.action_counts.items())),
+            "has_blocking_validation_findings": self.has_blocking_validation_findings,
+            "validation_summary": validation_summary,
+            "import_order": list(self.import_order),
+        }
+
+
+@dataclass(frozen=True)
 class ContextImportConfig:
     """Validated local config for the context importer."""
 
@@ -392,19 +546,14 @@ def _validate_output_path(output: Path | None) -> Path | None:
     if output is None:
         return None
     if output.is_absolute():
-        raise WriteDeniedError(
-            f"absolute output paths are forbidden: {output}"
-        )
+        raise WriteDeniedError(f"absolute output paths are forbidden: {output}")
     parts = output.parts
     if not parts or parts[0] not in ALLOWED_OUTPUT_PREFIXES:
         raise WriteDeniedError(
-            "output path must live under "
-            f"{ALLOWED_OUTPUT_PREFIXES}, got: {output}"
+            "output path must live under " f"{ALLOWED_OUTPUT_PREFIXES}, got: {output}"
         )
     if ".." in parts:
-        raise WriteDeniedError(
-            f"output path may not traverse with '..': {output}"
-        )
+        raise WriteDeniedError(f"output path may not traverse with '..': {output}")
     return output
 
 
@@ -415,7 +564,9 @@ def _validate_input_dir(input_dir: Path | None) -> Path:
         exists = input_dir.exists()
         is_dir = input_dir.is_dir() if exists else False
     except OSError as exc:
-        raise InputNotFoundError(f"cannot stat input directory: {input_dir}: {exc}") from exc
+        raise InputNotFoundError(
+            f"cannot stat input directory: {input_dir}: {exc}"
+        ) from exc
     if not exists:
         raise InputNotFoundError(f"input directory not found: {input_dir}")
     if not is_dir:
@@ -696,9 +847,16 @@ def _validate_record_fields(
                 )
             )
 
-    for hash_field in ("source_hash", "raw_sha256", "normalized_sha256", "content_hash"):
+    for hash_field in (
+        "source_hash",
+        "raw_sha256",
+        "normalized_sha256",
+        "content_hash",
+    ):
         value = record.get(hash_field)
-        if value is not None and (not isinstance(value, str) or not SHA256_RE.match(value)):
+        if value is not None and (
+            not isinstance(value, str) or not SHA256_RE.match(value)
+        ):
             findings.append(
                 _finding(
                     "blocking",
@@ -759,7 +917,9 @@ def _validate_cross_references(
         if isinstance(item.get("normalized_sha256"), str)
     }
     page_ids = {
-        item.get("page_id") for item in records["doc_pages"] if isinstance(item.get("page_id"), str)
+        item.get("page_id")
+        for item in records["doc_pages"]
+        if isinstance(item.get("page_id"), str)
     }
     section_ids = {
         item.get("section_id")
@@ -876,7 +1036,9 @@ def _validate_cross_references(
             )
 
 
-def validate_jsonl(input_dir: Path, expected_run_id: str | None = None) -> JsonlValidationReport:
+def validate_jsonl(
+    input_dir: Path, expected_run_id: str | None = None
+) -> JsonlValidationReport:
     findings: list[JsonlValidationFinding] = []
     records = {
         artifact: _read_jsonl_file(input_dir, artifact, filename, findings)
@@ -886,7 +1048,9 @@ def validate_jsonl(input_dir: Path, expected_run_id: str | None = None) -> Jsonl
     observed_run_ids: set[str] = set()
     for artifact, items in records.items():
         for record in items:
-            run_id = _validate_record_fields(artifact, record, findings, expected_run_id)
+            run_id = _validate_record_fields(
+                artifact, record, findings, expected_run_id
+            )
             if run_id is not None:
                 observed_run_ids.add(run_id)
 
@@ -905,7 +1069,9 @@ def validate_jsonl(input_dir: Path, expected_run_id: str | None = None) -> Jsonl
         for record in items:
             record.pop("__line", None)
 
-    run_id = expected_run_id or (next(iter(observed_run_ids)) if len(observed_run_ids) == 1 else None)
+    run_id = expected_run_id or (
+        next(iter(observed_run_ids)) if len(observed_run_ids) == 1 else None
+    )
     ordered_findings = tuple(
         sorted(
             findings,
@@ -918,7 +1084,190 @@ def validate_jsonl(input_dir: Path, expected_run_id: str | None = None) -> Jsonl
             ),
         )
     )
-    return JsonlValidationReport(input_dir=input_dir, run_id=run_id, records=records, findings=ordered_findings)
+    return JsonlValidationReport(
+        input_dir=input_dir, run_id=run_id, records=records, findings=ordered_findings
+    )
+
+
+def _record_id(table: str, raw_id: str) -> str:
+    return f"{table}:{raw_id}"
+
+
+def _payload_hash(record: dict[str, Any]) -> str:
+    payload = {key: value for key, value in record.items() if key != "__line"}
+    encoded = json.dumps(
+        payload, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _source_ref(record: dict[str, Any]) -> str | None:
+    for field_name in (
+        "source_path",
+        "source_chunk_id",
+        "from_id",
+    ):
+        value = record.get(field_name)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _dependency_record_id(artifact: str, value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    table = TABLE_BY_ARTIFACT[artifact]
+    return _record_id(table, value)
+
+
+def _action_dependencies(artifact: str, record: dict[str, Any]) -> tuple[str, ...]:
+    dependencies: list[str] = []
+    if artifact == "doc_sections":
+        dependency = _dependency_record_id("doc_pages", record.get("page_id"))
+        if dependency is not None:
+            dependencies.append(dependency)
+    elif artifact == "doc_chunks":
+        for dependency_artifact, field_name in (
+            ("doc_pages", "page_id"),
+            ("doc_sections", "section_id"),
+            ("doc_chunks", "previous_chunk_id"),
+        ):
+            dependency = _dependency_record_id(
+                dependency_artifact, record.get(field_name)
+            )
+            if dependency is not None:
+                dependencies.append(dependency)
+    elif artifact == "test_cases":
+        dependency = _dependency_record_id("code_symbols", record.get("symbol_id"))
+        if dependency is not None:
+            dependencies.append(dependency)
+    elif artifact == "doc_code_links":
+        dependency = _dependency_record_id("doc_chunks", record.get("source_chunk_id"))
+        if dependency is not None:
+            dependencies.append(dependency)
+    elif artifact == "dependency_edges":
+        for field_name in ("from_id", "to_id"):
+            value = record.get(field_name)
+            if isinstance(value, str) and value.strip():
+                dependencies.append(value)
+    return tuple(sorted(dict.fromkeys(dependencies)))
+
+
+def build_import_plan(
+    input_dir: Path, expected_run_id: str | None = None
+) -> ImportPlan:
+    report = validate_jsonl(input_dir, expected_run_id)
+    if report.blocking_count:
+        warnings = tuple(
+            ImportPlanWarning(
+                code=finding.code,
+                message=finding.message,
+                artifact=finding.artifact,
+                source_ref=finding.source_path,
+                severity=finding.severity,
+            )
+            for finding in report.findings
+        )
+        return ImportPlan(
+            schema_version=SCHEMA_VERSION,
+            run_id=report.run_id,
+            input_dir=input_dir,
+            status="blocked",
+            actions=(),
+            warnings=warnings,
+            table_counts={},
+            action_counts={},
+            has_blocking_validation_findings=True,
+            validation_report=report,
+            import_order=tuple(
+                TABLE_BY_ARTIFACT[artifact] for artifact in IMPORT_ORDER
+            ),
+        )
+
+    actions: list[ImportPlanAction] = []
+    warnings: list[ImportPlanWarning] = []
+    seen_record_ids: set[str] = set()
+
+    for artifact in IMPORT_ORDER:
+        table = TABLE_BY_ARTIFACT[artifact]
+        id_field = ID_FIELD_BY_ARTIFACT[artifact]
+        records = sorted(
+            report.records[artifact],
+            key=lambda item: str(item.get(id_field, "")),
+        )
+        for record in records:
+            raw_id = record.get(id_field)
+            if not isinstance(raw_id, str) or not raw_id.strip():
+                warnings.append(
+                    ImportPlanWarning(
+                        code="missing_record_id",
+                        message=f"record missing deterministic id field: {id_field}",
+                        artifact=artifact,
+                        source_ref=_source_ref(record),
+                        severity="blocking",
+                    )
+                )
+                continue
+            record_id = _record_id(table, raw_id)
+            if record_id in seen_record_ids:
+                action = "skip"
+                reason = "duplicate record_id in validated input; first occurrence wins"
+            else:
+                action = "create"
+                reason = "validated JSONL record; DB-independent candidate create"
+                seen_record_ids.add(record_id)
+            actions.append(
+                ImportPlanAction(
+                    action=action,
+                    table=table,
+                    record_id=record_id,
+                    artifact=artifact,
+                    source_ref=_source_ref(record),
+                    depends_on=_action_dependencies(artifact, record),
+                    reason=reason,
+                    payload_hash=_payload_hash(record),
+                )
+            )
+
+    table_counts: dict[str, int] = {}
+    action_counts: dict[str, int] = {}
+    for action in actions:
+        table_counts[action.table] = table_counts.get(action.table, 0) + 1
+        action_counts[action.action] = action_counts.get(action.action, 0) + 1
+
+    return ImportPlan(
+        schema_version=SCHEMA_VERSION,
+        run_id=report.run_id,
+        input_dir=input_dir,
+        status="planned",
+        actions=tuple(
+            sorted(
+                actions,
+                key=lambda item: (
+                    IMPORT_ORDER.index(item.artifact),
+                    item.table,
+                    item.record_id,
+                    item.action,
+                ),
+            )
+        ),
+        warnings=tuple(
+            sorted(
+                warnings,
+                key=lambda item: (
+                    item.severity,
+                    item.code,
+                    item.artifact or "",
+                    item.source_ref or "",
+                ),
+            )
+        ),
+        table_counts=table_counts,
+        action_counts=action_counts,
+        has_blocking_validation_findings=False,
+        validation_report=report,
+        import_order=tuple(TABLE_BY_ARTIFACT[artifact] for artifact in IMPORT_ORDER),
+    )
 
 
 def _require_mapping(raw: Any, *, path: Path) -> dict[str, Any]:
@@ -1022,7 +1371,9 @@ def load_config(path: Path) -> ContextImportConfig:
             f"{forbidden_in_allowed}"
         )
 
-    missing_forbidden = sorted(FORBIDDEN_CONTEXT_IMPORT_TABLES.difference(forbidden_tables))
+    missing_forbidden = sorted(
+        FORBIDDEN_CONTEXT_IMPORT_TABLES.difference(forbidden_tables)
+    )
     if missing_forbidden:
         raise ConfigValidationError(
             "forbidden_tables must explicitly include all blocked "
@@ -1079,8 +1430,85 @@ def _render(payload: dict[str, Any], fmt: str) -> str:
     if fmt == "json":
         return json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2)
     if fmt == "jsonl":
+        if payload.get("command") == "plan" and payload.get("implemented") is True:
+            lines = [
+                json.dumps(
+                    {
+                        key: value
+                        for key, value in payload.items()
+                        if key not in {"actions", "warnings"}
+                    },
+                    ensure_ascii=True,
+                    sort_keys=True,
+                )
+            ]
+            lines.extend(
+                json.dumps(
+                    {"record_type": "action", **action},
+                    ensure_ascii=True,
+                    sort_keys=True,
+                )
+                for action in payload["actions"]
+            )
+            lines.extend(
+                json.dumps(
+                    {"record_type": "warning", **warning},
+                    ensure_ascii=True,
+                    sort_keys=True,
+                )
+                for warning in payload["warnings"]
+            )
+            return "\n".join(lines)
         return json.dumps(payload, ensure_ascii=True, sort_keys=True)
     if fmt == "markdown":
+        if payload.get("command") == "plan" and payload.get("implemented") is True:
+            lines = ["# context_importer: plan"]
+            lines.extend(
+                [
+                    f"- **status**: `{payload['status']}`",
+                    f"- **input_dir**: `{payload['input_dir']}`",
+                    f"- **run_id**: `{payload['run_id']}`",
+                    f"- **has_blocking_validation_findings**: `{payload['has_blocking_validation_findings']}`",
+                    f"- **actions**: `{payload['counts']['actions']}`",
+                    f"- **warnings**: `{payload['counts']['warnings']}`",
+                    "",
+                    "## Import Order",
+                ]
+            )
+            for table in payload["import_order"]:
+                lines.append(f"- `{table}`")
+            lines.extend(["", "## Table Counts"])
+            for table, count in payload["table_counts"].items():
+                lines.append(f"- `{table}`: `{count}`")
+            lines.extend(["", "## Action Counts"])
+            if payload["action_counts"]:
+                for action, count in payload["action_counts"].items():
+                    lines.append(f"- `{action}`: `{count}`")
+            else:
+                lines.append("- No write-ready actions.")
+            lines.extend(["", "## Actions"])
+            if not payload["actions"]:
+                lines.append("- No actions generated.")
+            for action in payload["actions"]:
+                depends_on = ", ".join(action["depends_on"]) or "none"
+                lines.append(
+                    "- "
+                    f"`{action['action']}` `{action['record_id']}` "
+                    f"({action['artifact']}, depends_on: `{depends_on}`, "
+                    f"payload_hash: `{action['payload_hash']}`)"
+                )
+            lines.extend(["", "## Warnings"])
+            if not payload["warnings"]:
+                lines.append("- No warnings.")
+            for warning in payload["warnings"]:
+                artifact = warning.get("artifact") or "global"
+                source_ref = warning.get("source_ref") or "none"
+                lines.append(
+                    "- "
+                    f"**{warning['severity']}** `{warning['code']}` "
+                    f"({artifact}, source_ref: `{source_ref}`): {warning['message']}"
+                )
+            return "\n".join(lines)
         lines = [f"# context_importer: {payload['command']}"]
         for key in sorted(payload.keys()):
             lines.append(f"- **{key}**: `{payload[key]}`")
@@ -1293,6 +1721,20 @@ def _handle(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
             _write_report(report_output, _render_jsonl_report(report, args.format))
             payload["report_output"] = str(report_output)
         return payload, EXIT_VALIDATION_ERROR if report.blocking_count else EXIT_OK
+
+    if command == "plan" and args.input_dir is not None:
+        input_dir = _validate_input_dir(args.input_dir)
+        plan = build_import_plan(input_dir, args.run_id)
+        payload = plan.to_payload()
+        payload["config_loaded"] = config is not None
+        if config is not None:
+            payload["config"] = config.to_payload()
+        if report_output is not None:
+            _write_report(report_output, _render(payload, args.format))
+            payload["report_output"] = str(report_output)
+        return payload, (
+            EXIT_VALIDATION_ERROR if plan.has_blocking_validation_findings else EXIT_OK
+        )
 
     payload = _build_payload(
         command,


### PR DESCRIPTION
## Summary
- Adds deterministic `context_importer plan --input-dir` generation for validated Wave 10 JSONL context artifacts.
- Keeps the plan DB-independent and read-only: no SurrealDB connection, no reconcile, no writes, and `apply` remains hard-blocked.
- Documents the #2071 CLI contract and adds unit coverage for determinism, blocker handling, duplicate skips, and whitelisted report output.

## Scope
- Parent: #1976
- Wave 10 Parent: #2067
- Depends on: #2068, #2069, #2070
- Closes #2071

## Files
- `tools/surrealdb/context_importer.py`
- `tests/unit/surrealdb/test_context_import_plan.py`
- `docs/surrealdb/context-importer-cli-contract.md`

## Tests
- `ruff check tools/surrealdb/context_importer.py tests/unit/surrealdb/test_context_importer.py tests/unit/surrealdb/test_context_import_config.py tests/unit/surrealdb/test_context_import_jsonl_validation.py tests/unit/surrealdb/test_context_import_plan.py`
- `python -m pytest -q tests/unit/surrealdb/test_context_importer.py tests/unit/surrealdb/test_context_import_config.py tests/unit/surrealdb/test_context_import_jsonl_validation.py tests/unit/surrealdb/test_context_import_plan.py --basetemp C:\tmp\pytest-2071 -p no:cacheprovider`
- `python -m pytest -q tests/unit/surrealdb/ --basetemp C:\tmp\pytest-2071 -p no:cacheprovider`

## Guardrails
- No SurrealDB read/write/connect behavior added.
- No `apply` or `--apply` enablement; write-denied guard remains enforced.
- Output writes remain limited to explicit `--report-output` under whitelisted `artifacts/` or `temp/` paths.
- No trading, risk, execution, secrets, or LR status changes.
- LR remains `NO-GO`; Board `trade-capable` is not live-trading approval.