### PR TITLE
feat(surrealdb): add dry-run context import reconcile

### DIFF
--- a/docs/surrealdb/context-importer-cli-contract.md
+++ b/docs/surrealdb/context-importer-cli-contract.md
@@ -321,6 +321,9 @@ Reconcile-Vertrag:
 - `forbidden_table` wird als Blocking Finding berichtet.
 - Importplan-Actions mit `action: skip` bleiben im Reconcile `skip`, sofern
   keine Table-Policy- oder Schema-Safety-Blockade fuer denselben Record vorliegt.
+- Wenn ein Plan fuer dieselbe `record_id` bereits eine fruehere Action enthaelt,
+  erzeugen nachfolgende Plan-`skip`-Duplikate keine zweite Reconcile-Action und
+  keine kuenstlichen create/update-Candidates.
 - Plan-Warnings behalten beim Mapping in Reconcile-Findings ihre urspruengliche
   Severity; `warning` bleibt `warning`, `blocking` bleibt `blocking`.
 - In blocked-plan Reconcile-Reports werden Plan-Warnings als Reconcile-Findings

--- a/docs/surrealdb/context-importer-cli-contract.md
+++ b/docs/surrealdb/context-importer-cli-contract.md
@@ -1,9 +1,9 @@
 # Context Importer CLI Contract
 
-**Status**: Draft (Scaffold + Local Config + JSONL Validation + Import Plan Slice)
-**Authority**: Issue #2068 + #2069 + #2070 + #2071 / Wave 10 Parent #2067 / Epic #1976
+**Status**: Draft (Scaffold + Local Config + JSONL Validation + Import Plan + Dry-run Reconcile Slice)
+**Authority**: Issue #2068 + #2069 + #2070 + #2071 + #2072 / Wave 10 Parent #2067 / Epic #1976
 **Target**: `tools/surrealdb/context_importer.py`
-**Scope**: CLI scaffold plus explicit local config validation, read-only JSONL validation, and deterministic import plan generation — no SurrealDB connection, no SurrealDB writes.
+**Scope**: CLI scaffold plus explicit local config validation, read-only JSONL validation, deterministic import plan generation, and dry-run reconcile against explicit read-only existing-record fixtures — no default SurrealDB connection, no SurrealDB writes.
 
 ---
 
@@ -17,8 +17,10 @@ lokale Config-Lade- und Validierungsschicht fuer
 `infrastructure/config/surrealdb/context_import.local.example.yaml`.
 Die JSONL-Validation fuer `validate-jsonl` ist in #2070 read-only implementiert.
 #2071 ergaenzt `plan --input-dir`: validierte JSONL-Artefakte werden zu einem
-deterministischen, DB-unabhaengigen Importplan geroutet. Dry-run-Reconcile,
-Apply, Audit und Rollback-Plan gehoeren weiterhin zu separaten Folge-Slices.
+  deterministischen, DB-unabhaengigen Importplan geroutet. #2072 ergaenzt
+  `dry-run --input-dir`: der Plan wird gegen einen expliziten read-only
+  Existing-Records-Zustand reconciled. Apply, Audit und Rollback-Plan gehoeren
+  weiterhin zu separaten Folge-Slices.
 
 ---
 
@@ -28,7 +30,7 @@ Apply, Audit und Rollback-Plan gehoeren weiterhin zu separaten Folge-Slices.
 |---|---|---|
 | `validate-jsonl` | JSONL-Artefakte gegen Schema pruefen | Read-only Validation, Exit `0` ohne Blocking Findings, Exit `1` mit Blocking Findings |
 | `plan` | Importplan aus JSONL-Artefakten berechnen | Mit `--input-dir`: deterministic candidate import plan, Exit `0` oder `1`; ohne `--input-dir`: Scaffold-Stub |
-| `dry-run` | End-to-End-Lauf ohne Schreiben | Stub: `scaffold-ack`, Exit `0` |
+| `dry-run` | End-to-End-Lauf ohne Schreiben | Mit `--input-dir`: dry-run reconcile gegen leeren oder expliziten Existing-Records-Zustand, Exit `0` oder `1`; ohne `--input-dir`: Scaffold-Stub |
 | `apply` | Schreiben nach SurrealDB | Hart geblockt: Exit `5` (`WRITE_DENIED`) |
 | `audit` | Audit-Trail-Export | Stub: `scaffold-ack`, Exit `0` |
 | `rollback-plan` | Rollback-Plan generieren | Stub: `scaffold-ack`, Exit `0` |
@@ -48,9 +50,10 @@ Folge-Slice (Apply-Implementation) entfernt werden.
   nutzt dieselbe Validation und erzeugt nur lokale Plan-Ausgabe.
 - **Dry-run Default**: Ohne explizites `--apply` ist `dry_run = true`.
 - **Apply hart geblockt**: `--apply` und `apply` exit `5` (`WRITE_DENIED`).
-- **Keine SurrealDB-Verbindung**: `--surreal-url`, `--namespace`,
-  `--database` werden geparsed, aber nie verwendet. Die Antwort enthaelt
-  immer `surrealdb_connection: "disabled"`.
+- **Keine Default-SurrealDB-Verbindung**: `--surreal-url`, `--namespace`,
+  `--database` werden geparsed, aber nie fuer Netzwerkzugriff verwendet.
+  `dry-run --input-dir` nutzt ausschliesslich `--existing-records` als lokale
+  read-only Boundary oder einen leeren Existing-State.
 - **Output-Pfad-Whitelist**: `--report-output` muss unter `artifacts/`
   oder `temp/` liegen. Absolute Pfade (`/...`, `C:\...`, UNC) und
   Traversal (`..`) werden mit Exit `5` verworfen. `validate-jsonl` schreibt
@@ -67,7 +70,8 @@ Folge-Slice (Apply-Implementation) entfernt werden.
   der Laufzeitumgebung kommen, nicht aus dieser YAML.
 - **Secret-Redaction**: Findings melden secret-like Inhalte nur mit Code und
   Pfad/Zeile; erkannte Werte werden nicht in Reports oder stdout echoed.
-- **Keine Reconcile-/Apply-/Audit-/Rollback-Logik**: jeweils eigene Folge-Slices.
+- **Kein Apply-/Audit-/Rollback-Verhalten**: jeweils eigene Folge-Slices.
+  Reconcile in #2072 bleibt dry-run-only und erzeugt nur Reports.
 
 ---
 
@@ -82,6 +86,7 @@ Folge-Slice (Apply-Implementation) entfernt werden.
 | `--run-id` | `None` | nein | `validate-jsonl` prueft optional auf einheitlichen Run; andere Subcommands parsen nur |
 | `--config` | `None` | nein | explizite lokale YAML laden und validieren, kein Write |
 | `--report-output` | `None` | nein | Whitelist-Check; `validate-jsonl` und `plan --input-dir` schreiben Report nur wenn explizit gesetzt |
+| `--existing-records` | `None` | nein | nur fuer `dry-run --input-dir`; lokale JSON-Datei mit Existing-Records-Fixture, kein DB-Client |
 | `--dry-run` | `False` (Default-Verhalten ist dennoch dry-run) | nein | redundant; explizit erlaubt |
 | `--apply` | `False` | nein | `True` ⇒ Exit `5` |
 | `--format` | `json` | nein | `json` / `jsonl` / `markdown` |
@@ -133,6 +138,40 @@ Diese Tabellen muessen in `forbidden_tables` stehen. Ueberschneidungen zwischen
 | 4 | Unsupported Format (defensiv; argparse faengt das frueher) |
 | 5 | Write denied (Pfad-Verstoss ODER Apply im Scaffold) |
 | 6 | Interner Fehler |
+
+---
+
+## 5.1 Existing-Records-Fixture-Vertrag (#2072)
+
+`dry-run --input-dir` kann optional einen vorhandenen DB-Zustand als lokale
+JSON-Fixture lesen:
+
+```json
+{
+  "records": [
+    {
+      "table": "doc_page",
+      "record_id": "doc_page:page-id",
+      "payload_hash": "lowercase-sha256-hex",
+      "schema_version": "context-importer/v0"
+    }
+  ]
+}
+```
+
+Alternativ darf die Datei direkt eine Liste solcher Records enthalten. Statt
+`payload_hash` kann ein objektfoermiges `payload` angegeben werden; der Importer
+berechnet dann denselben deterministischen SHA-256-Hash wie beim Importplan.
+
+Guardrails:
+
+- Die Fixture ist eine mockbare read-only Boundary; kein SurrealDB-Client wird
+  geoeffnet.
+- Tabellen muessen in der Context-Importer-Allowlist liegen und duerfen nicht in
+  `orders`, `fills`, `positions`, `balances`, `pnl`, `risk_state`,
+  `execution_state` oder Governance-Mirror-Tabellen liegen.
+- `schema_version` darf fehlen oder `context-importer/v0` sein. Andere Werte
+  erzeugen `schema_mismatch` als Blocking Finding.
 
 ---
 
@@ -244,6 +283,42 @@ Plan-Vertrag:
 - `--format json` gibt das vollstaendige Plan-Objekt aus. `--format markdown`
   ist diff-freundlich fuer Review. `--format jsonl` gibt eine Summary-Zeile plus
   je eine Zeile pro Action/Warning aus.
+
+`dry-run --input-dir`-Antwort (#2072):
+
+```json
+{
+  "schema_version": "context-importer/v0",
+  "command": "dry-run",
+  "status": "reconciled",
+  "dry_run": true,
+  "apply_requested": false,
+  "surrealdb_writes": "disabled",
+  "existing_records_source": "empty",
+  "counts": {
+    "creates": 1,
+    "skips": 0,
+    "update_candidates": 0,
+    "tombstone_candidates": 0,
+    "blocking": 0,
+    "warnings": 0
+  },
+  "actions": [],
+  "findings": []
+}
+```
+
+Reconcile-Vertrag:
+
+- `record_missing` wird als `create` berichtet.
+- `record_same` wird als `skip` berichtet.
+- `record_changed` wird als `update_candidate` berichtet.
+- `record_removed_from_snapshot` wird als `tombstone_candidate` berichtet.
+- `schema_mismatch` wird als Blocking Finding berichtet.
+- `forbidden_table` wird als Blocking Finding berichtet.
+- Tombstones bleiben Kandidaten; kein Hard Delete und kein Apply-Verhalten.
+- Blocking JSONL-/Plan-Findings blockieren auch den Reconcile-Report fail-closed
+  mit Exit-Code `1`.
 
 Artifact-zu-Table-Routing in #2071:
 

--- a/docs/surrealdb/context-importer-cli-contract.md
+++ b/docs/surrealdb/context-importer-cli-contract.md
@@ -319,6 +319,12 @@ Reconcile-Vertrag:
 - `record_removed_from_snapshot` wird als `tombstone_candidate` berichtet.
 - `schema_mismatch` wird als Blocking Finding berichtet.
 - `forbidden_table` wird als Blocking Finding berichtet.
+- Importplan-Actions mit `action: skip` bleiben im Reconcile `skip`, sofern
+  keine Table-Policy- oder Schema-Safety-Blockade fuer denselben Record vorliegt.
+- Plan-Warnings behalten beim Mapping in Reconcile-Findings ihre urspruengliche
+  Severity; `warning` bleibt `warning`, `blocking` bleibt `blocking`.
+- In blocked-plan Reconcile-Reports werden Plan-Warnings als Reconcile-Findings
+  gespiegelt und nicht zusaetzlich als `warnings` doppelt gezaehlt.
 - `counts.blocking` und `counts.warnings` bleiben getrennt: Blocking Findings
   oder blocking Plan-Warnings erhoehen nicht `counts.warnings`.
 - Tombstones bleiben Kandidaten; kein Hard Delete und kein Apply-Verhalten.

--- a/docs/surrealdb/context-importer-cli-contract.md
+++ b/docs/surrealdb/context-importer-cli-contract.md
@@ -167,6 +167,9 @@ Guardrails:
 
 - Die Fixture ist eine mockbare read-only Boundary; kein SurrealDB-Client wird
   geoeffnet.
+- Doppelte `record_id`-Werte in Existing-Records-Fixtures sind ungueltig und
+  werden fail-closed als deterministischer Input-Error abgelehnt. Es gibt keine
+  stille Ueberschreibung und keine Last-one-wins-Semantik.
 - Tabellen muessen in der Context-Importer-Allowlist liegen und duerfen nicht in
   `orders`, `fills`, `positions`, `balances`, `pnl`, `risk_state`,
   `execution_state` oder Governance-Mirror-Tabellen liegen.
@@ -316,6 +319,8 @@ Reconcile-Vertrag:
 - `record_removed_from_snapshot` wird als `tombstone_candidate` berichtet.
 - `schema_mismatch` wird als Blocking Finding berichtet.
 - `forbidden_table` wird als Blocking Finding berichtet.
+- `counts.blocking` und `counts.warnings` bleiben getrennt: Blocking Findings
+  oder blocking Plan-Warnings erhoehen nicht `counts.warnings`.
 - Tombstones bleiben Kandidaten; kein Hard Delete und kein Apply-Verhalten.
 - Blocking JSONL-/Plan-Findings blockieren auch den Reconcile-Report fail-closed
   mit Exit-Code `1`.

--- a/tests/unit/surrealdb/test_context_import_reconcile.py
+++ b/tests/unit/surrealdb/test_context_import_reconcile.py
@@ -366,6 +366,74 @@ def test_dry_run_rejects_duplicate_existing_record_ids(
 
 
 @pytest.mark.unit
+def test_dry_run_accepts_existing_record_id_with_matching_table(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(
+        existing,
+        [
+            {
+                "table": "doc_page",
+                "record_id": "doc_page:page-example",
+                "payload_hash": "a" * 64,
+                "schema_version": "context-importer/v0",
+            }
+        ],
+    )
+
+    exit_code = main(
+        ["dry-run", "--input-dir", str(tmp_path), "--existing-records", str(existing)]
+    )
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert payload["status"] == "reconciled"
+    assert any(action["action"] == "update_candidate" for action in payload["actions"])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("record_id", "expected_message"),
+    [
+        ("code_symbol:page-example", "matching table"),
+        ("page-example", "matching table"),
+        ("doc_page:", "matching table"),
+        (123, "existing record_id must be a string"),
+        (None, "existing record_id must be a string"),
+    ],
+)
+def test_dry_run_rejects_existing_record_id_without_matching_table(
+    tmp_path: Path, capsys, record_id, expected_message: str
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    secret_payload = "secret-token-value-1234567890"
+    raw_existing = {
+        "table": "doc_page",
+        "payload_hash": "a" * 64,
+        "payload": {"secret": secret_payload},
+        "schema_version": "context-importer/v0",
+    }
+    if record_id is not None:
+        raw_existing["record_id"] = record_id
+    _write_existing(existing, [raw_existing])
+
+    exit_code = main(
+        ["dry-run", "--input-dir", str(tmp_path), "--existing-records", str(existing)]
+    )
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    assert payload["status"] == "error"
+    assert payload["error"] == "EXISTING_RECORDS_VALIDATION_ERROR"
+    assert expected_message in payload["message"]
+    assert secret_payload not in json.dumps(payload)
+    assert "aaaaaaaa" not in json.dumps(payload)
+
+
+@pytest.mark.unit
 def test_dry_run_warning_count_excludes_blocking_plan_warnings(
     tmp_path: Path, capsys
 ) -> None:
@@ -455,10 +523,10 @@ def test_dry_run_plan_skip_still_blocks_on_schema_mismatch(
         existing,
         [
             {
-                "table": "doc_page",
+                "table": "repo_artifact",
                 "record_id": "repo_artifact:artifact-doc",
                 "payload_hash": "a" * 64,
-                "schema_version": "context-importer/v0",
+                "schema_version": "other/v0",
             }
         ],
     )

--- a/tests/unit/surrealdb/test_context_import_reconcile.py
+++ b/tests/unit/surrealdb/test_context_import_reconcile.py
@@ -1,0 +1,409 @@
+"""Unit tests for dry-run Context Importer reconcile (#2072)."""
+
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+
+import pytest
+
+from tools.surrealdb.context_importer import (
+    EXIT_OK,
+    EXIT_VALIDATION_ERROR,
+    EXIT_WRITE_DENIED,
+    EXPECTED_JSONL_FILES,
+    INDEXER_SCHEMA_VERSION,
+    main,
+)
+
+HASH = "c" * 64
+RUN_ID = "run-2072"
+
+
+def _read_json(capsys) -> dict:
+    out = capsys.readouterr().out.strip()
+    return json.loads(out)
+
+
+def _base_record(**updates) -> dict:
+    record = {"schema_version": INDEXER_SCHEMA_VERSION, "run_id": RUN_ID}
+    record.update(updates)
+    return record
+
+
+def _write_jsonl(input_dir: Path, artifact: str, records: list[dict]) -> None:
+    path = input_dir / EXPECTED_JSONL_FILES[artifact]
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _valid_records() -> dict[str, list[dict]]:
+    return {
+        "repo_artifacts": [
+            _base_record(
+                artifact_id="artifact-doc",
+                source_path="docs/example.md",
+                file_type="markdown",
+                raw_sha256=HASH,
+                normalized_sha256=HASH,
+                source_hash=HASH,
+                integrity_algo="sha256",
+                size_bytes=12,
+                sensitivity="internal_context",
+            )
+        ],
+        "doc_pages": [
+            _base_record(
+                page_id="page-example",
+                source_path="docs/example.md",
+                source_hash=HASH,
+                title="Example",
+                doc_format="markdown",
+            )
+        ],
+        "doc_sections": [
+            _base_record(
+                section_id="section-example",
+                page_id="page-example",
+                source_path="docs/example.md",
+                source_hash=HASH,
+                heading="Example",
+                heading_path=["Example"],
+                section_level=1,
+                section_index=0,
+            )
+        ],
+        "doc_chunks": [
+            _base_record(
+                chunk_id="chunk-example",
+                page_id="page-example",
+                section_id="section-example",
+                source_path="docs/example.md",
+                source_hash=HASH,
+                heading_path=["Example"],
+                chunk_index=0,
+                content="safe context",
+                content_hash=HASH,
+            )
+        ],
+        "code_symbols": [
+            _base_record(
+                symbol_id="symbol-example",
+                source_path="tools/example.py",
+                source_hash=HASH,
+                symbol_type="function",
+                name="example",
+                qualified_name="example",
+            )
+        ],
+        "import_references": [
+            _base_record(
+                import_id="import-json",
+                source_path="tools/example.py",
+                source_hash=HASH,
+                module="json",
+            )
+        ],
+        "test_cases": [
+            _base_record(
+                test_id="test-example",
+                source_path="tests/test_example.py",
+                source_hash=HASH,
+                symbol_id="symbol-example",
+                name="test_example",
+            )
+        ],
+        "config_references": [
+            _base_record(
+                config_ref_id="config-safe",
+                source_path="infrastructure/config/example.yaml",
+                source_hash=HASH,
+                config_key="safe_key",
+                config_value="safe-value",
+                sensitive=False,
+            )
+        ],
+        "doc_code_links": [
+            _base_record(
+                link_id="link-example",
+                source_path="docs/example.md",
+                source_hash=HASH,
+                target_symbol="example",
+                source_chunk_id="chunk-example",
+            )
+        ],
+        "dependency_edges": [
+            _base_record(
+                edge_id="edge-example",
+                from_id="symbol-example",
+                to_id="import-json",
+                edge_type="imports",
+            )
+        ],
+    }
+
+
+def _write_valid_artifacts(input_dir: Path) -> None:
+    for artifact, records in _valid_records().items():
+        _write_jsonl(input_dir, artifact, records)
+
+
+def _write_existing(path: Path, records: list[dict]) -> None:
+    path.write_text(json.dumps({"records": records}, sort_keys=True), encoding="utf-8")
+
+
+def _payload_hash_by_record_id(payload: dict) -> dict[str, str]:
+    return {action["record_id"]: action["payload_hash"] for action in payload["actions"]}
+
+
+@pytest.mark.unit
+def test_dry_run_empty_existing_state_creates_candidates(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+
+    exit_code = main(["dry-run", "--input-dir", str(tmp_path), "--run-id", RUN_ID])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert payload["status"] == "reconciled"
+    assert payload["surrealdb_writes"] == "disabled"
+    assert payload["counts"]["creates"] == 10
+    assert payload["counts"]["skips"] == 0
+    assert all(action["action"] == "create" for action in payload["actions"])
+
+
+@pytest.mark.unit
+def test_dry_run_identical_records_skip(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+    assert main(["plan", "--input-dir", str(tmp_path)]) == EXIT_OK
+    plan_payload = _read_json(capsys)
+    hashes = _payload_hash_by_record_id(plan_payload)
+    existing = tmp_path / "existing.json"
+    _write_existing(
+        existing,
+        [
+            {
+                "table": "doc_page",
+                "record_id": "doc_page:page-example",
+                "payload_hash": hashes["doc_page:page-example"],
+                "schema_version": "context-importer/v0",
+            }
+        ],
+    )
+
+    exit_code = main(
+        ["dry-run", "--input-dir", str(tmp_path), "--existing-records", str(existing)]
+    )
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    skip = next(action for action in payload["actions"] if action["action"] == "skip")
+    assert skip["record_id"] == "doc_page:page-example"
+    assert skip["reason"] == "record_same"
+    assert payload["counts"]["skips"] == 1
+
+
+@pytest.mark.unit
+def test_dry_run_changed_record_is_update_candidate(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(
+        existing,
+        [
+            {
+                "table": "doc_page",
+                "record_id": "doc_page:page-example",
+                "payload_hash": "d" * 64,
+                "schema_version": "context-importer/v0",
+            }
+        ],
+    )
+
+    exit_code = main(
+        ["dry-run", "--input-dir", str(tmp_path), "--existing-records", str(existing)]
+    )
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    update = next(
+        action for action in payload["actions"] if action["action"] == "update_candidate"
+    )
+    assert update["record_id"] == "doc_page:page-example"
+    assert update["reason"] == "record_changed"
+    assert payload["counts"]["update_candidates"] == 1
+
+
+@pytest.mark.unit
+def test_dry_run_existing_record_missing_from_plan_is_tombstone_candidate(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(
+        existing,
+        [
+            {
+                "table": "doc_page",
+                "record_id": "doc_page:stale",
+                "payload_hash": "e" * 64,
+                "schema_version": "context-importer/v0",
+            }
+        ],
+    )
+
+    exit_code = main(
+        ["dry-run", "--input-dir", str(tmp_path), "--existing-records", str(existing)]
+    )
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    tombstone = next(
+        action
+        for action in payload["actions"]
+        if action["action"] == "tombstone_candidate"
+    )
+    assert tombstone["record_id"] == "doc_page:stale"
+    assert tombstone["reason"] == "record_removed_from_snapshot"
+    assert payload["counts"]["tombstone_candidates"] == 1
+
+
+@pytest.mark.unit
+def test_dry_run_forbidden_table_blocks(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(
+        existing,
+        [
+            {
+                "table": "orders",
+                "record_id": "orders:1",
+                "payload_hash": "f" * 64,
+                "schema_version": "context-importer/v0",
+            }
+        ],
+    )
+
+    exit_code = main(
+        ["dry-run", "--input-dir", str(tmp_path), "--existing-records", str(existing)]
+    )
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    assert payload["status"] == "blocked"
+    assert payload["counts"]["blocking"] == 1
+    assert any(finding["code"] == "forbidden_table" for finding in payload["findings"])
+
+
+@pytest.mark.unit
+def test_dry_run_schema_mismatch_blocks(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(
+        existing,
+        [
+            {
+                "table": "doc_page",
+                "record_id": "doc_page:page-example",
+                "payload_hash": "a" * 64,
+                "schema_version": "other/v0",
+            }
+        ],
+    )
+
+    exit_code = main(
+        ["dry-run", "--input-dir", str(tmp_path), "--existing-records", str(existing)]
+    )
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    assert any(finding["code"] == "schema_mismatch" for finding in payload["findings"])
+    assert payload["counts"]["blocking"] == 1
+
+
+@pytest.mark.unit
+def test_dry_run_makes_no_writes_and_opens_no_socket(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    def _boom(*args, **kwargs):  # pragma: no cover - safety net
+        raise AssertionError("dry-run reconcile must not open network sockets")
+
+    monkeypatch.setattr(socket.socket, "connect", _boom)
+    monkeypatch.setattr(socket.socket, "connect_ex", _boom)
+
+    exit_code = main(
+        [
+            "dry-run",
+            "--input-dir",
+            str(tmp_path),
+            "--surreal-url",
+            "ws://example.invalid:8000/rpc",
+        ]
+    )
+
+    assert exit_code == EXIT_OK
+    assert not (tmp_path / "artifacts").exists()
+    payload = _read_json(capsys)
+    assert payload["surrealdb_writes"] == "disabled"
+
+
+@pytest.mark.unit
+def test_dry_run_report_is_deterministic_and_reviewable(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    args = [
+        "dry-run",
+        "--input-dir",
+        str(tmp_path),
+        "--format",
+        "markdown",
+        "--report-output",
+        "artifacts/reconcile.md",
+    ]
+    assert main(args) == EXIT_OK
+    first = (tmp_path / "artifacts" / "reconcile.md").read_text(encoding="utf-8")
+    capsys.readouterr()
+    assert main(args) == EXIT_OK
+    second = (tmp_path / "artifacts" / "reconcile.md").read_text(encoding="utf-8")
+
+    assert first == second
+    assert first.startswith("# context_importer: dry-run reconcile")
+    assert "## Counts" in first
+    assert "## Actions" in first
+
+
+@pytest.mark.unit
+def test_dry_run_does_not_echo_secret_values(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+    secret_value = "secret-token-value-1234567890"
+    records = _valid_records()["config_references"]
+    records[0]["access_token"] = secret_value
+    _write_jsonl(tmp_path, "config_references", records)
+
+    exit_code = main(["dry-run", "--input-dir", str(tmp_path)])
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    out = capsys.readouterr().out
+    assert secret_value not in out
+    payload = json.loads(out)
+    assert payload["status"] == "blocked"
+
+
+@pytest.mark.unit
+def test_apply_remains_hard_blocked_for_dry_run(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+
+    exit_code = main(["dry-run", "--input-dir", str(tmp_path), "--apply"])
+
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"

--- a/tests/unit/surrealdb/test_context_import_reconcile.py
+++ b/tests/unit/surrealdb/test_context_import_reconcile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 import json
 import socket
 from pathlib import Path
@@ -14,7 +15,10 @@ from tools.surrealdb.context_importer import (
     EXIT_WRITE_DENIED,
     EXPECTED_JSONL_FILES,
     INDEXER_SCHEMA_VERSION,
+    ReadOnlyExistingRecords,
+    build_import_plan,
     main,
+    reconcile_import_plan,
 )
 
 HASH = "c" * 64
@@ -382,8 +386,45 @@ def test_dry_run_warning_count_excludes_blocking_plan_warnings(
 
 @pytest.mark.unit
 def test_dry_run_preserves_import_plan_skip_actions(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+    plan = build_import_plan(tmp_path)
+    skipped_action = replace(
+        plan.actions[0],
+        action="skip",
+        reason="duplicate record_id in validated input; first occurrence wins",
+    )
+    report = reconcile_import_plan(
+        replace(plan, actions=(skipped_action,)),
+        ReadOnlyExistingRecords(records=(), source="empty"),
+    )
+    payload = report.to_payload()
+
+    assert payload["status"] == "reconciled"
+    assert payload["actions"] == [
+        {
+            "action": "skip",
+            "table": "repo_artifact",
+            "record_id": "repo_artifact:artifact-doc",
+            "source_ref": "docs/example.md",
+            "reason": "duplicate record_id in validated input; first occurrence wins",
+            "payload_hash": skipped_action.payload_hash,
+            "existing_payload_hash": None,
+        }
+    ]
+    assert payload["actions"][0]["reason"] == (
+        "duplicate record_id in validated input; first occurrence wins"
+    )
+    assert payload["counts"]["creates"] == 0
+    assert payload["counts"]["skips"] == 1
+    assert payload["counts"]["update_candidates"] == 0
+
+
+@pytest.mark.unit
+def test_dry_run_duplicate_plan_skip_does_not_emit_second_candidate(
+    tmp_path: Path, capsys
+) -> None:
     records = _valid_records()
-    records["repo_artifacts"] = records["repo_artifacts"] * 2
+    records["doc_pages"] = records["doc_pages"] * 2
     for artifact, items in records.items():
         _write_jsonl(tmp_path, artifact, items)
 
@@ -391,15 +432,13 @@ def test_dry_run_preserves_import_plan_skip_actions(tmp_path: Path, capsys) -> N
 
     assert exit_code == EXIT_OK
     payload = _read_json(capsys)
-    repo_actions = [
-        action for action in payload["actions"] if action["table"] == "repo_artifact"
+    page_actions = [
+        action for action in payload["actions"] if action["record_id"] == "doc_page:page-example"
     ]
-    assert [action["action"] for action in repo_actions] == ["create", "skip"]
-    assert repo_actions[1]["reason"] == (
-        "duplicate record_id in validated input; first occurrence wins"
-    )
+    assert len(page_actions) == 1
+    assert page_actions[0]["action"] == "create"
     assert payload["counts"]["creates"] == 10
-    assert payload["counts"]["skips"] == 1
+    assert payload["counts"]["skips"] == 0
     assert payload["counts"]["update_candidates"] == 0
 
 

--- a/tests/unit/surrealdb/test_context_import_reconcile.py
+++ b/tests/unit/surrealdb/test_context_import_reconcile.py
@@ -377,7 +377,83 @@ def test_dry_run_warning_count_excludes_blocking_plan_warnings(
     assert payload["status"] == "blocked"
     assert payload["counts"]["blocking"] > 0
     assert payload["counts"]["warnings"] == 0
-    assert any(warning["severity"] == "blocking" for warning in payload["warnings"])
+    assert any(finding["severity"] == "blocking" for finding in payload["findings"])
+
+
+@pytest.mark.unit
+def test_dry_run_preserves_import_plan_skip_actions(tmp_path: Path, capsys) -> None:
+    records = _valid_records()
+    records["repo_artifacts"] = records["repo_artifacts"] * 2
+    for artifact, items in records.items():
+        _write_jsonl(tmp_path, artifact, items)
+
+    exit_code = main(["dry-run", "--input-dir", str(tmp_path)])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    repo_actions = [
+        action for action in payload["actions"] if action["table"] == "repo_artifact"
+    ]
+    assert [action["action"] for action in repo_actions] == ["create", "skip"]
+    assert repo_actions[1]["reason"] == (
+        "duplicate record_id in validated input; first occurrence wins"
+    )
+    assert payload["counts"]["creates"] == 10
+    assert payload["counts"]["skips"] == 1
+    assert payload["counts"]["update_candidates"] == 0
+
+
+@pytest.mark.unit
+def test_dry_run_plan_skip_still_blocks_on_schema_mismatch(
+    tmp_path: Path, capsys
+) -> None:
+    records = _valid_records()
+    records["repo_artifacts"] = records["repo_artifacts"] * 2
+    for artifact, items in records.items():
+        _write_jsonl(tmp_path, artifact, items)
+    existing = tmp_path / "existing.json"
+    _write_existing(
+        existing,
+        [
+            {
+                "table": "doc_page",
+                "record_id": "repo_artifact:artifact-doc",
+                "payload_hash": "a" * 64,
+                "schema_version": "context-importer/v0",
+            }
+        ],
+    )
+
+    exit_code = main(
+        ["dry-run", "--input-dir", str(tmp_path), "--existing-records", str(existing)]
+    )
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    assert any(finding["code"] == "schema_mismatch" for finding in payload["findings"])
+
+
+@pytest.mark.unit
+def test_dry_run_preserves_plan_warning_severity_and_counts(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    doc_chunks = tmp_path / EXPECTED_JSONL_FILES["doc_chunks"]
+    doc_chunks.write_text(doc_chunks.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+    records = _valid_records()["doc_pages"]
+    records[0]["source_path"] = "../secrets.md"
+    _write_jsonl(tmp_path, "doc_pages", records)
+
+    exit_code = main(["dry-run", "--input-dir", str(tmp_path)])
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    finding_severities = {finding["code"]: finding["severity"] for finding in payload["findings"]}
+    assert finding_severities["forbidden_source_path"] == "blocking"
+    assert finding_severities["jsonl_blank_line"] == "warning"
+    assert payload["counts"]["blocking"] >= 1
+    assert payload["counts"]["warnings"] == 1
+    assert "secret-token-value" not in json.dumps(payload)
 
 
 @pytest.mark.unit

--- a/tests/unit/surrealdb/test_context_import_reconcile.py
+++ b/tests/unit/surrealdb/test_context_import_reconcile.py
@@ -564,6 +564,37 @@ def test_dry_run_preserves_plan_warning_severity_and_counts(
 
 
 @pytest.mark.unit
+def test_dry_run_blocked_plan_does_not_load_existing_records(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    records = _valid_records()["doc_pages"]
+    records[0]["source_path"] = "../secrets.md"
+    _write_jsonl(tmp_path, "doc_pages", records)
+    missing_existing = tmp_path / "missing-existing.json"
+
+    exit_code = main(
+        [
+            "dry-run",
+            "--input-dir",
+            str(tmp_path),
+            "--existing-records",
+            str(missing_existing),
+        ]
+    )
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    assert payload["status"] == "blocked"
+    assert payload["existing_records_source"] == "empty"
+    assert any(
+        finding["code"] == "forbidden_source_path"
+        for finding in payload["findings"]
+    )
+    assert "existing records fixture not found" not in json.dumps(payload)
+
+
+@pytest.mark.unit
 def test_dry_run_makes_no_writes_and_opens_no_socket(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:

--- a/tests/unit/surrealdb/test_context_import_reconcile.py
+++ b/tests/unit/surrealdb/test_context_import_reconcile.py
@@ -325,6 +325,62 @@ def test_dry_run_schema_mismatch_blocks(tmp_path: Path, capsys) -> None:
 
 
 @pytest.mark.unit
+def test_dry_run_rejects_duplicate_existing_record_ids(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(
+        existing,
+        [
+            {
+                "table": "doc_page",
+                "record_id": "doc_page:page-example",
+                "payload_hash": "a" * 64,
+                "schema_version": "context-importer/v0",
+            },
+            {
+                "table": "doc_page",
+                "record_id": "doc_page:page-example",
+                "payload_hash": "b" * 64,
+                "schema_version": "context-importer/v0",
+            },
+        ],
+    )
+
+    exit_code = main(
+        ["dry-run", "--input-dir", str(tmp_path), "--existing-records", str(existing)]
+    )
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    assert payload["status"] == "error"
+    assert payload["error"] == "EXISTING_RECORDS_VALIDATION_ERROR"
+    assert "duplicate existing record_id" in payload["message"]
+    assert "aaaaaaaa" not in payload["message"]
+    assert "bbbbbbbb" not in payload["message"]
+
+
+@pytest.mark.unit
+def test_dry_run_warning_count_excludes_blocking_plan_warnings(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    records = _valid_records()["doc_pages"]
+    records[0]["source_path"] = "../secrets.md"
+    _write_jsonl(tmp_path, "doc_pages", records)
+
+    exit_code = main(["dry-run", "--input-dir", str(tmp_path)])
+
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    assert payload["status"] == "blocked"
+    assert payload["counts"]["blocking"] > 0
+    assert payload["counts"]["warnings"] == 0
+    assert any(warning["severity"] == "blocking" for warning in payload["warnings"])
+
+
+@pytest.mark.unit
 def test_dry_run_makes_no_writes_and_opens_no_socket(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -2292,7 +2292,9 @@ def _handle(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
     if command == "dry-run" and args.input_dir is not None:
         input_dir = _validate_input_dir(args.input_dir)
         plan = build_import_plan(input_dir, args.run_id)
-        existing_records = load_existing_records(args.existing_records)
+        existing_records = load_existing_records(
+            None if plan.has_blocking_validation_findings else args.existing_records
+        )
         report = reconcile_import_plan(plan, existing_records)
         payload = report.to_payload()
         payload["config_loaded"] = config is not None

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -1573,6 +1573,7 @@ def reconcile_import_plan(
 
     existing_by_id = existing_records.by_record_id()
     planned_ids: set[str] = set()
+    reconciled_ids: set[str] = set()
     actions: list[ReconcileAction] = []
 
     for plan_action in plan.actions:
@@ -1581,6 +1582,9 @@ def reconcile_import_plan(
             plan_action.table, plan_action.record_id, findings
         ):
             continue
+        if plan_action.record_id in reconciled_ids:
+            continue
+        reconciled_ids.add(plan_action.record_id)
         if plan_action.action == "skip":
             existing = existing_by_id.get(plan_action.record_id)
             if existing is not None and (

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -233,6 +233,7 @@ GOVERNANCE_MIRROR_TABLES = frozenset(
 )
 
 FORBIDDEN_CONTEXT_IMPORT_TABLES = TRADING_STATE_TABLES | GOVERNANCE_MIRROR_TABLES
+ALLOWED_CONTEXT_IMPORT_TABLES = frozenset(TABLE_BY_ARTIFACT.values())
 
 ALLOWED_AUTH_MODES = frozenset({"none", "root", "scope"})
 
@@ -332,6 +333,13 @@ class ConfigValidationError(ContextImporterError):
     """Raised when the local importer config is invalid or unsafe."""
 
     code = "CONFIG_VALIDATION_ERROR"
+    exit_code = EXIT_VALIDATION_ERROR
+
+
+class ExistingRecordsValidationError(ContextImporterError):
+    """Raised when the read-only existing-records fixture is invalid."""
+
+    code = "EXISTING_RECORDS_VALIDATION_ERROR"
     exit_code = EXIT_VALIDATION_ERROR
 
 
@@ -495,6 +503,138 @@ class ImportPlan:
             "has_blocking_validation_findings": self.has_blocking_validation_findings,
             "validation_summary": validation_summary,
             "import_order": list(self.import_order),
+        }
+
+
+@dataclass(frozen=True)
+class ExistingRecord:
+    table: str
+    record_id: str
+    payload_hash: str | None
+    schema_version: str | None
+
+
+@dataclass(frozen=True)
+class ReadOnlyExistingRecords:
+    """Mockable read-only boundary for records already present in SurrealDB."""
+
+    records: tuple[ExistingRecord, ...]
+    source: str
+
+    def by_record_id(self) -> dict[str, ExistingRecord]:
+        return {record.record_id: record for record in self.records}
+
+
+@dataclass(frozen=True)
+class ReconcileAction:
+    action: str
+    table: str
+    record_id: str
+    source_ref: str | None
+    reason: str
+    payload_hash: str | None
+    existing_payload_hash: str | None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "table": self.table,
+            "record_id": self.record_id,
+            "source_ref": self.source_ref,
+            "reason": self.reason,
+            "payload_hash": self.payload_hash,
+            "existing_payload_hash": self.existing_payload_hash,
+        }
+
+
+@dataclass(frozen=True)
+class ReconcileFinding:
+    severity: str
+    code: str
+    message: str
+    table: str | None = None
+    record_id: str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "severity": self.severity,
+            "code": self.code,
+            "message": self.message,
+        }
+        if self.table is not None:
+            payload["table"] = self.table
+        if self.record_id is not None:
+            payload["record_id"] = self.record_id
+        return payload
+
+
+@dataclass(frozen=True)
+class ReconcileReport:
+    schema_version: str
+    run_id: str | None
+    input_dir: Path
+    status: str
+    existing_records_source: str
+    actions: tuple[ReconcileAction, ...]
+    findings: tuple[ReconcileFinding, ...]
+    warnings: tuple[ImportPlanWarning, ...]
+    plan: ImportPlan
+
+    @property
+    def blocking_count(self) -> int:
+        return sum(1 for finding in self.findings if finding.severity == "blocking")
+
+    @property
+    def warning_count(self) -> int:
+        return sum(1 for finding in self.findings if finding.severity == "warning") + len(
+            self.warnings
+        )
+
+    def action_counts(self) -> dict[str, int]:
+        counts = {
+            "creates": 0,
+            "skips": 0,
+            "update_candidates": 0,
+            "tombstone_candidates": 0,
+            "blocking": self.blocking_count,
+            "warnings": self.warning_count,
+        }
+        for action in self.actions:
+            if action.action == "create":
+                counts["creates"] += 1
+            elif action.action == "skip":
+                counts["skips"] += 1
+            elif action.action == "update_candidate":
+                counts["update_candidates"] += 1
+            elif action.action == "tombstone_candidate":
+                counts["tombstone_candidates"] += 1
+        return counts
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "command": "dry-run",
+            "run_id": self.run_id,
+            "input_dir": str(self.input_dir),
+            "status": self.status,
+            "dry_run": True,
+            "apply_requested": False,
+            "surrealdb_connection": "read-only-fixture"
+            if self.existing_records_source != "empty"
+            else "disabled",
+            "surrealdb_writes": "disabled",
+            "implemented": True,
+            "existing_records_source": self.existing_records_source,
+            "actions": [action.to_payload() for action in self.actions],
+            "findings": [finding.to_payload() for finding in self.findings],
+            "warnings": [warning.to_payload() for warning in self.warnings],
+            "counts": self.action_counts(),
+            "plan_summary": {
+                "status": self.plan.status,
+                "actions": len(self.plan.actions),
+                "warnings": len(self.plan.warnings),
+                "has_blocking_validation_findings": self.plan.has_blocking_validation_findings,
+            },
         }
 
 
@@ -1101,6 +1241,91 @@ def _payload_hash(record: dict[str, Any]) -> str:
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
+def _safe_payload_hash(record: dict[str, Any]) -> str | None:
+    value = record.get("payload_hash")
+    if isinstance(value, str) and SHA256_RE.match(value):
+        return value
+    payload = record.get("payload")
+    if isinstance(payload, dict):
+        return _payload_hash(payload)
+    return None
+
+
+def _existing_record_from_raw(raw: dict[str, Any]) -> ExistingRecord:
+    table = raw.get("table")
+    record_id = raw.get("record_id") or raw.get("id")
+    if not isinstance(table, str) or not table.strip():
+        raise ExistingRecordsValidationError("existing record table must be a string")
+    if not isinstance(record_id, str) or not record_id.strip():
+        raise ExistingRecordsValidationError("existing record_id must be a string")
+    schema_version = raw.get("schema_version")
+    if schema_version is not None and not isinstance(schema_version, str):
+        raise ExistingRecordsValidationError("existing record schema_version must be a string")
+    payload_hash = _safe_payload_hash(raw)
+    if payload_hash is None:
+        raise ExistingRecordsValidationError(
+            "existing record must provide payload_hash or object payload"
+        )
+    return ExistingRecord(
+        table=table,
+        record_id=record_id,
+        payload_hash=payload_hash,
+        schema_version=schema_version,
+    )
+
+
+def load_existing_records(path: Path | None) -> ReadOnlyExistingRecords:
+    """Load read-only existing DB state from an explicit local fixture.
+
+    This boundary models records fetched from SurrealDB without opening a client
+    or allowing writes. A future adapter can implement the same shape.
+    """
+
+    if path is None:
+        return ReadOnlyExistingRecords(records=(), source="empty")
+    try:
+        exists = path.exists()
+        is_file = path.is_file() if exists else False
+    except OSError as exc:
+        raise InputNotFoundError(
+            f"cannot stat existing records fixture: {path}: {exc}"
+        ) from exc
+    if not exists:
+        raise InputNotFoundError(f"existing records fixture not found: {path}")
+    if not is_file:
+        raise ExistingRecordsValidationError(
+            f"existing records fixture path is not a file: {path}"
+        )
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ExistingRecordsValidationError(
+            f"invalid existing records JSON: {path}: {exc.msg}"
+        ) from exc
+    except OSError as exc:
+        raise InputNotFoundError(
+            f"cannot read existing records fixture: {path}: {exc}"
+        ) from exc
+
+    if isinstance(raw, dict):
+        items = raw.get("records")
+    else:
+        items = raw
+    if not isinstance(items, list):
+        raise ExistingRecordsValidationError(
+            "existing records fixture must be a list or mapping with records list"
+        )
+    records: list[ExistingRecord] = []
+    for item in items:
+        if not isinstance(item, dict):
+            raise ExistingRecordsValidationError("existing record entries must be objects")
+        records.append(_existing_record_from_raw(item))
+    return ReadOnlyExistingRecords(
+        records=tuple(sorted(records, key=lambda item: (item.table, item.record_id))),
+        source=str(path),
+    )
+
+
 def _source_ref(record: dict[str, Any]) -> str | None:
     for field_name in (
         "source_path",
@@ -1270,6 +1495,182 @@ def build_import_plan(
     )
 
 
+def _blocking_from_plan_warning(warning: ImportPlanWarning) -> ReconcileFinding:
+    return ReconcileFinding(
+        severity="blocking",
+        code=warning.code,
+        message=warning.message,
+        record_id=warning.source_ref,
+    )
+
+
+def _validate_reconcile_table_policy(
+    table: str, record_id: str, findings: list[ReconcileFinding]
+) -> bool:
+    if table in FORBIDDEN_CONTEXT_IMPORT_TABLES:
+        findings.append(
+            ReconcileFinding(
+                severity="blocking",
+                code="forbidden_table",
+                message="table is forbidden for context import reconcile",
+                table=table,
+                record_id=record_id,
+            )
+        )
+        return False
+    if table not in ALLOWED_CONTEXT_IMPORT_TABLES:
+        findings.append(
+            ReconcileFinding(
+                severity="blocking",
+                code="forbidden_table",
+                message="table is not in the context import allow-list",
+                table=table,
+                record_id=record_id,
+            )
+        )
+        return False
+    return True
+
+
+def reconcile_import_plan(
+    plan: ImportPlan,
+    existing_records: ReadOnlyExistingRecords,
+) -> ReconcileReport:
+    findings: list[ReconcileFinding] = []
+    warnings = list(plan.warnings)
+
+    if plan.has_blocking_validation_findings:
+        findings.extend(_blocking_from_plan_warning(warning) for warning in plan.warnings)
+        return ReconcileReport(
+            schema_version=SCHEMA_VERSION,
+            run_id=plan.run_id,
+            input_dir=plan.input_dir,
+            status="blocked",
+            existing_records_source=existing_records.source,
+            actions=(),
+            findings=tuple(findings),
+            warnings=tuple(warnings),
+            plan=plan,
+        )
+
+    existing_by_id = existing_records.by_record_id()
+    planned_ids: set[str] = set()
+    actions: list[ReconcileAction] = []
+
+    for plan_action in plan.actions:
+        planned_ids.add(plan_action.record_id)
+        if not _validate_reconcile_table_policy(
+            plan_action.table, plan_action.record_id, findings
+        ):
+            continue
+        existing = existing_by_id.get(plan_action.record_id)
+        if existing is None:
+            actions.append(
+                ReconcileAction(
+                    action="create",
+                    table=plan_action.table,
+                    record_id=plan_action.record_id,
+                    source_ref=plan_action.source_ref,
+                    reason="record_missing",
+                    payload_hash=plan_action.payload_hash,
+                    existing_payload_hash=None,
+                )
+            )
+            continue
+        if existing.table != plan_action.table or existing.schema_version not in (
+            None,
+            SCHEMA_VERSION,
+        ):
+            findings.append(
+                ReconcileFinding(
+                    severity="blocking",
+                    code="schema_mismatch",
+                    message="existing record table or schema_version differs from import plan",
+                    table=existing.table,
+                    record_id=existing.record_id,
+                )
+            )
+            continue
+        if existing.payload_hash == plan_action.payload_hash:
+            actions.append(
+                ReconcileAction(
+                    action="skip",
+                    table=plan_action.table,
+                    record_id=plan_action.record_id,
+                    source_ref=plan_action.source_ref,
+                    reason="record_same",
+                    payload_hash=plan_action.payload_hash,
+                    existing_payload_hash=existing.payload_hash,
+                )
+            )
+        else:
+            actions.append(
+                ReconcileAction(
+                    action="update_candidate",
+                    table=plan_action.table,
+                    record_id=plan_action.record_id,
+                    source_ref=plan_action.source_ref,
+                    reason="record_changed",
+                    payload_hash=plan_action.payload_hash,
+                    existing_payload_hash=existing.payload_hash,
+                )
+            )
+
+    for existing in existing_records.records:
+        if existing.record_id in planned_ids:
+            continue
+        if not _validate_reconcile_table_policy(existing.table, existing.record_id, findings):
+            continue
+        if existing.schema_version not in (None, SCHEMA_VERSION):
+            findings.append(
+                ReconcileFinding(
+                    severity="blocking",
+                    code="schema_mismatch",
+                    message="existing record schema_version differs from context importer schema",
+                    table=existing.table,
+                    record_id=existing.record_id,
+                )
+            )
+            continue
+        actions.append(
+            ReconcileAction(
+                action="tombstone_candidate",
+                table=existing.table,
+                record_id=existing.record_id,
+                source_ref=None,
+                reason="record_removed_from_snapshot",
+                payload_hash=None,
+                existing_payload_hash=existing.payload_hash,
+            )
+        )
+
+    ordered_actions = tuple(
+        sorted(actions, key=lambda item: (item.table, item.record_id, item.action))
+    )
+    ordered_findings = tuple(
+        sorted(
+            findings,
+            key=lambda item: (
+                item.severity,
+                item.code,
+                item.table or "",
+                item.record_id or "",
+            ),
+        )
+    )
+    return ReconcileReport(
+        schema_version=SCHEMA_VERSION,
+        run_id=plan.run_id,
+        input_dir=plan.input_dir,
+        status="blocked" if ordered_findings else "reconciled",
+        existing_records_source=existing_records.source,
+        actions=ordered_actions,
+        findings=ordered_findings,
+        warnings=tuple(warnings),
+        plan=plan,
+    )
+
+
 def _require_mapping(raw: Any, *, path: Path) -> dict[str, Any]:
     if not isinstance(raw, dict):
         raise ConfigValidationError(f"config must be a YAML mapping: {path}")
@@ -1430,6 +1831,43 @@ def _render(payload: dict[str, Any], fmt: str) -> str:
     if fmt == "json":
         return json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2)
     if fmt == "jsonl":
+        if payload.get("command") == "dry-run" and payload.get("implemented") is True:
+            lines = [
+                json.dumps(
+                    {
+                        key: value
+                        for key, value in payload.items()
+                        if key not in {"actions", "findings", "warnings"}
+                    },
+                    ensure_ascii=True,
+                    sort_keys=True,
+                )
+            ]
+            lines.extend(
+                json.dumps(
+                    {"record_type": "action", **action},
+                    ensure_ascii=True,
+                    sort_keys=True,
+                )
+                for action in payload["actions"]
+            )
+            lines.extend(
+                json.dumps(
+                    {"record_type": "finding", **finding},
+                    ensure_ascii=True,
+                    sort_keys=True,
+                )
+                for finding in payload["findings"]
+            )
+            lines.extend(
+                json.dumps(
+                    {"record_type": "warning", **warning},
+                    ensure_ascii=True,
+                    sort_keys=True,
+                )
+                for warning in payload["warnings"]
+            )
+            return "\n".join(lines)
         if payload.get("command") == "plan" and payload.get("implemented") is True:
             lines = [
                 json.dumps(
@@ -1461,6 +1899,55 @@ def _render(payload: dict[str, Any], fmt: str) -> str:
             return "\n".join(lines)
         return json.dumps(payload, ensure_ascii=True, sort_keys=True)
     if fmt == "markdown":
+        if payload.get("command") == "dry-run" and payload.get("implemented") is True:
+            lines = ["# context_importer: dry-run reconcile"]
+            lines.extend(
+                [
+                    f"- **status**: `{payload['status']}`",
+                    f"- **input_dir**: `{payload['input_dir']}`",
+                    f"- **run_id**: `{payload['run_id']}`",
+                    f"- **existing_records_source**: `{payload['existing_records_source']}`",
+                    f"- **surrealdb_writes**: `{payload['surrealdb_writes']}`",
+                    "",
+                    "## Counts",
+                ]
+            )
+            for key, value in payload["counts"].items():
+                lines.append(f"- `{key}`: `{value}`")
+            lines.extend(["", "## Actions"])
+            if not payload["actions"]:
+                lines.append("- No reconcile actions generated.")
+            for action in payload["actions"]:
+                lines.append(
+                    "- "
+                    f"`{action['action']}` `{action['record_id']}` "
+                    f"({action['table']}, reason: `{action['reason']}`, "
+                    f"payload_hash: `{action['payload_hash']}`, "
+                    f"existing_payload_hash: `{action['existing_payload_hash']}`)"
+                )
+            lines.extend(["", "## Findings"])
+            if not payload["findings"]:
+                lines.append("- No findings.")
+            for finding in payload["findings"]:
+                table = finding.get("table") or "global"
+                record_id = finding.get("record_id") or "none"
+                lines.append(
+                    "- "
+                    f"**{finding['severity']}** `{finding['code']}` "
+                    f"({table}, record_id: `{record_id}`): {finding['message']}"
+                )
+            lines.extend(["", "## Warnings"])
+            if not payload["warnings"]:
+                lines.append("- No warnings.")
+            for warning in payload["warnings"]:
+                artifact = warning.get("artifact") or "global"
+                source_ref = warning.get("source_ref") or "none"
+                lines.append(
+                    "- "
+                    f"**{warning['severity']}** `{warning['code']}` "
+                    f"({artifact}, source_ref: `{source_ref}`): {warning['message']}"
+                )
+            return "\n".join(lines)
         if payload.get("command") == "plan" and payload.get("implemented") is True:
             lines = ["# context_importer: plan"]
             lines.extend(
@@ -1664,6 +2151,15 @@ def build_parser() -> argparse.ArgumentParser:
             ),
         )
         sub.add_argument(
+            "--existing-records",
+            type=Path,
+            default=None,
+            help=(
+                "Optional read-only JSON fixture representing existing SurrealDB "
+                "records for dry-run reconcile. No SurrealDB client is opened."
+            ),
+        )
+        sub.add_argument(
             "--dry-run",
             action="store_true",
             help="Simulate only. This is the default behavior.",
@@ -1735,6 +2231,20 @@ def _handle(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
         return payload, (
             EXIT_VALIDATION_ERROR if plan.has_blocking_validation_findings else EXIT_OK
         )
+
+    if command == "dry-run" and args.input_dir is not None:
+        input_dir = _validate_input_dir(args.input_dir)
+        plan = build_import_plan(input_dir, args.run_id)
+        existing_records = load_existing_records(args.existing_records)
+        report = reconcile_import_plan(plan, existing_records)
+        payload = report.to_payload()
+        payload["config_loaded"] = config is not None
+        if config is not None:
+            payload["config"] = config.to_payload()
+        if report_output is not None:
+            _write_report(report_output, _render(payload, args.format))
+            payload["report_output"] = str(report_output)
+        return payload, EXIT_VALIDATION_ERROR if report.blocking_count else EXIT_OK
 
     payload = _build_payload(
         command,

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -1513,9 +1513,9 @@ def build_import_plan(
     )
 
 
-def _blocking_from_plan_warning(warning: ImportPlanWarning) -> ReconcileFinding:
+def _finding_from_plan_warning(warning: ImportPlanWarning) -> ReconcileFinding:
     return ReconcileFinding(
-        severity="blocking",
+        severity=warning.severity,
         code=warning.code,
         message=warning.message,
         record_id=warning.source_ref,
@@ -1558,7 +1558,7 @@ def reconcile_import_plan(
     warnings = list(plan.warnings)
 
     if plan.has_blocking_validation_findings:
-        findings.extend(_blocking_from_plan_warning(warning) for warning in plan.warnings)
+        findings.extend(_finding_from_plan_warning(warning) for warning in plan.warnings)
         return ReconcileReport(
             schema_version=SCHEMA_VERSION,
             run_id=plan.run_id,
@@ -1567,7 +1567,7 @@ def reconcile_import_plan(
             existing_records_source=existing_records.source,
             actions=(),
             findings=tuple(findings),
-            warnings=tuple(warnings),
+            warnings=(),
             plan=plan,
         )
 
@@ -1580,6 +1580,36 @@ def reconcile_import_plan(
         if not _validate_reconcile_table_policy(
             plan_action.table, plan_action.record_id, findings
         ):
+            continue
+        if plan_action.action == "skip":
+            existing = existing_by_id.get(plan_action.record_id)
+            if existing is not None and (
+                existing.table != plan_action.table
+                or existing.schema_version not in (None, SCHEMA_VERSION)
+            ):
+                findings.append(
+                    ReconcileFinding(
+                        severity="blocking",
+                        code="schema_mismatch",
+                        message="existing record table or schema_version differs from import plan",
+                        table=existing.table,
+                        record_id=existing.record_id,
+                    )
+                )
+                continue
+            actions.append(
+                ReconcileAction(
+                    action="skip",
+                    table=plan_action.table,
+                    record_id=plan_action.record_id,
+                    source_ref=plan_action.source_ref,
+                    reason=plan_action.reason,
+                    payload_hash=plan_action.payload_hash,
+                    existing_payload_hash=existing.payload_hash
+                    if existing is not None
+                    else None,
+                )
+            )
             continue
         existing = existing_by_id.get(plan_action.record_id)
         if existing is None:

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -522,7 +522,14 @@ class ReadOnlyExistingRecords:
     source: str
 
     def by_record_id(self) -> dict[str, ExistingRecord]:
-        return {record.record_id: record for record in self.records}
+        records_by_id: dict[str, ExistingRecord] = {}
+        for record in self.records:
+            if record.record_id in records_by_id:
+                raise ExistingRecordsValidationError(
+                    "duplicate existing record_id in existing records fixture"
+                )
+            records_by_id[record.record_id] = record
+        return records_by_id
 
 
 @dataclass(frozen=True)
@@ -586,9 +593,13 @@ class ReconcileReport:
 
     @property
     def warning_count(self) -> int:
-        return sum(1 for finding in self.findings if finding.severity == "warning") + len(
-            self.warnings
+        finding_warnings = sum(
+            1 for finding in self.findings if finding.severity == "warning"
         )
+        plan_warnings = sum(
+            1 for warning in self.warnings if warning.severity == "warning"
+        )
+        return finding_warnings + plan_warnings
 
     def action_counts(self) -> dict[str, int]:
         counts = {
@@ -1316,10 +1327,17 @@ def load_existing_records(path: Path | None) -> ReadOnlyExistingRecords:
             "existing records fixture must be a list or mapping with records list"
         )
     records: list[ExistingRecord] = []
+    seen_record_ids: set[str] = set()
     for item in items:
         if not isinstance(item, dict):
             raise ExistingRecordsValidationError("existing record entries must be objects")
-        records.append(_existing_record_from_raw(item))
+        record = _existing_record_from_raw(item)
+        if record.record_id in seen_record_ids:
+            raise ExistingRecordsValidationError(
+                "duplicate existing record_id in existing records fixture"
+            )
+        seen_record_ids.add(record.record_id)
+        records.append(record)
     return ReadOnlyExistingRecords(
         records=tuple(sorted(records, key=lambda item: (item.table, item.record_id))),
         source=str(path),

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -1269,6 +1269,11 @@ def _existing_record_from_raw(raw: dict[str, Any]) -> ExistingRecord:
         raise ExistingRecordsValidationError("existing record table must be a string")
     if not isinstance(record_id, str) or not record_id.strip():
         raise ExistingRecordsValidationError("existing record_id must be a string")
+    record_table, _, raw_id = record_id.partition(":")
+    if not record_table or not raw_id or record_table != table:
+        raise ExistingRecordsValidationError(
+            "existing record_id must be prefixed with matching table"
+        )
     schema_version = raw.get("schema_version")
     if schema_version is not None and not isinstance(schema_version, str):
         raise ExistingRecordsValidationError("existing record schema_version must be a string")


### PR DESCRIPTION
## Ziel
- Implementiert den engen #2072-Slice: Dry-run-Reconcile fuer Context Importer gegen vorhandenen SurrealDB-Zustand als read-only Boundary.
- Betroffene Issues: Refs #2072, Parent #2067, Epic #1976.

## Umsetzung
- `dry-run --input-dir` baut auf dem validierten Importplan aus #2071 auf.
- Existing Records werden nur ueber `--existing-records` als lokale JSON-Fixture gelesen; ohne Fixture wird ein leerer Existing-State verwendet.
- Reconcile Cases: `record_missing -> create`, `record_same -> skip`, `record_changed -> update_candidate`, `record_removed_from_snapshot -> tombstone_candidate`, `schema_mismatch -> blocking`, `forbidden_table -> blocking`.
- JSON, JSONL und Markdown Rendering fuer den reviewbaren Reconcile-Report.
- CLI-Vertrag fuer `--existing-records` und Dry-run-Reconcile dokumentiert.

## Guardrails
- Keine SurrealDB-Verbindung als Default, kein produktiver Client, kein Docker/Testnet/Live-Zugriff.
- Dry-run macht keine Writes; `apply` und `--apply` bleiben hart mit `WRITE_DENIED` geblockt.
- Existing Records sind mockbar/read-only modelliert.
- Forbidden Tables werden fail-closed geblockt.
- Tombstones bleiben nur Kandidaten; kein Hard Delete und kein #2074-Vorgriff.
- Secret-like JSONL Findings leaken weiterhin keine erkannten Werte in stdout oder Reports.
- Keine Runtime-, Trading-, Risk-, Execution- oder Live-Readiness-Aenderung; LR bleibt NO-GO.

## Validierung
- `ruff check tools/surrealdb/context_importer.py tests/unit/surrealdb`
- `python -m pytest -q tests/unit/surrealdb/test_context_importer.py tests/unit/surrealdb/test_context_import_config.py tests/unit/surrealdb/test_context_import_jsonl_validation.py tests/unit/surrealdb/test_context_import_plan.py tests/unit/surrealdb/test_context_import_reconcile.py`
- `python -m pytest -q tests/unit/surrealdb/`

## Restunsicherheiten
- `--existing-records` ist bewusst nur lokale Fixture/Adapter-Grenze. Ein echter SurrealDB-read-only Client ist nicht Default und bleibt spaeterem Scope vorbehalten.
- `schema_mismatch` ist konservativ auf vorhandene Records mit abweichender `schema_version` oder Table/Record-Abweichung begrenzt.
- Keine Apply-Semantik; #2073 muss den bestehenden Hard-Block separat ersetzen, nicht umgehen.