### PR TITLE
feat(surrealdb): add gated local-dev context apply with tombstones (#2073, #2074)

### DIFF
--- a/docs/surrealdb/context-importer-cli-contract.md
+++ b/docs/surrealdb/context-importer-cli-contract.md
@@ -291,6 +291,18 @@ Verhalten:
   Tombstone-Op gegen den Default-Adapter.
 - Der Adapter ueberschreibt das Original-Record nicht; es bleibt erhalten und
   bekommt die Tombstone-Felder dazu.
+- Original-Record-Felder werden auch dann erhalten, wenn das Record nicht
+  ueber einen vorhergehenden `apply_create`/`apply_update` im selben Adapter-
+  Prozess liegt: enthaelt der `--existing-records`-Eintrag ein `payload`-Objekt,
+  wird dieses verbatim (ohne Envelope-Steuerschluessel wie `payload_hash`,
+  `schema_version`, `table`, `record_id`, `id`, `__line`) in die Tombstone-
+  Payload uebernommen und von der Tombstone-Metadata (`tombstoned`,
+  `tombstoned_at`, `tombstone_reason`, `last_seen_run_id`, `superseded_by`)
+  sowie den Identitaetsfeldern (`table`, `record_id`, `run_id`, `payload_hash`)
+  ueberlagert. Liefert der Eintrag nur einen `payload_hash`-String, bleibt die
+  Tombstone-Payload bei der deterministischen Minimalform. Die uebernommenen
+  Felder werden ausschliesslich an den Adapter weitergereicht und nie in
+  Reports oder Result-Detailtexten serialisiert.
 - `tombstoned_at` wird ausschliesslich aus dem injizierten `ClockProvider`
   erzeugt; `datetime.now()`/`datetime.utcnow()` darf im Apply-Pfad nicht
   benutzt werden. `FixedClock` liefert byte-identische Reports.

--- a/docs/surrealdb/context-importer-cli-contract.md
+++ b/docs/surrealdb/context-importer-cli-contract.md
@@ -136,6 +136,31 @@ governance_event, governance_decision, governance_state
 Diese Tabellen muessen in `forbidden_tables` stehen. Ueberschneidungen zwischen
 `allowed_tables` und `forbidden_tables` sind ungueltig.
 
+### Effective Apply-Table-Policy
+
+Beim `apply`-Pfad gilt eine strikt restriktive, fail-closed Tabellen-Policy:
+
+```text
+allow_effective  = ALLOWED_CONTEXT_IMPORT_TABLES ∩ config.allowed_tables
+forbid_effective = FORBIDDEN_CONTEXT_IMPORT_TABLES ∪ config.forbidden_tables
+```
+
+Regeln:
+
+- Eine Tabelle wird nur angewendet, wenn sie in `allow_effective` ist und nicht
+  in `forbid_effective`.
+- `config.allowed_tables` ist restriktiv, niemals dekorativ: eine Tabelle, die
+  global erlaubt waere, der Operator aber bewusst aus `config.allowed_tables`
+  entfernt hat, wird beim Apply blockiert. Es gibt keinen Fallback auf die
+  globale Allow-Liste.
+- `config.allowed_tables` darf die globale Allow-Liste niemals erweitern.
+  Eine Tabelle, die nicht in `ALLOWED_CONTEXT_IMPORT_TABLES` steht, bleibt
+  blockiert, auch wenn der Operator sie in `config.allowed_tables` aufnimmt.
+- Forbidden schlaegt Allowed: jede Quelle (global oder config) reicht aus, um
+  eine Tabelle zu blocken.
+- Block-Findings nennen Tabelle und Grund, leaken aber keine Payload-,
+  Hash- oder Secret-Werte.
+
 ---
 
 ## 5. Exit-Codes

--- a/docs/surrealdb/context-importer-cli-contract.md
+++ b/docs/surrealdb/context-importer-cli-contract.md
@@ -1,9 +1,9 @@
 # Context Importer CLI Contract
 
-**Status**: Draft (Scaffold + Local Config + JSONL Validation + Import Plan + Dry-run Reconcile Slice)
-**Authority**: Issue #2068 + #2069 + #2070 + #2071 + #2072 / Wave 10 Parent #2067 / Epic #1976
+**Status**: Draft (Scaffold + Local Config + JSONL Validation + Import Plan + Dry-run Reconcile + Gated Local-Dev Apply + Tombstones Slice)
+**Authority**: Issue #2068 + #2069 + #2070 + #2071 + #2072 + #2073 + #2074 / Wave 10 Parent #2067 / Epic #1976
 **Target**: `tools/surrealdb/context_importer.py`
-**Scope**: CLI scaffold plus explicit local config validation, read-only JSONL validation, deterministic import plan generation, and dry-run reconcile against explicit read-only existing-record fixtures — no default SurrealDB connection, no SurrealDB writes.
+**Scope**: CLI scaffold plus explicit local config validation, read-only JSONL validation, deterministic import plan generation, dry-run reconcile against explicit read-only existing-record fixtures, and a **gated local-dev apply pipeline with a mockable adapter boundary** (default in-memory adapter, no production SurrealDB activation, no default network) that performs tombstone-only deletions via an injectable clock. The real SurrealDB adapter is **explicitly out-of-scope** in this slice.
 
 ---
 
@@ -31,14 +31,17 @@ Die JSONL-Validation fuer `validate-jsonl` ist in #2070 read-only implementiert.
 | `validate-jsonl` | JSONL-Artefakte gegen Schema pruefen | Read-only Validation, Exit `0` ohne Blocking Findings, Exit `1` mit Blocking Findings |
 | `plan` | Importplan aus JSONL-Artefakten berechnen | Mit `--input-dir`: deterministic candidate import plan, Exit `0` oder `1`; ohne `--input-dir`: Scaffold-Stub |
 | `dry-run` | End-to-End-Lauf ohne Schreiben | Mit `--input-dir`: dry-run reconcile gegen leeren oder expliziten Existing-Records-Zustand, Exit `0` oder `1`; ohne `--input-dir`: Scaffold-Stub |
-| `apply` | Schreiben nach SurrealDB | Hart geblockt: Exit `5` (`WRITE_DENIED`) |
+| `apply` | Schreiben nach SurrealDB | Gated local-dev only: erfordert `--apply` + `--apply-mode local-dev` + `--config` + `--input-dir` + `--run-id`. Default-Adapter ist in-memory ohne Netz. Real-SurrealDB-Adapter ist explizit out-of-scope. Ohne vollstaendige Gates Exit `5` (`WRITE_DENIED`). |
 | `audit` | Audit-Trail-Export | Stub: `scaffold-ack`, Exit `0` |
 | `rollback-plan` | Rollback-Plan generieren | Stub: `scaffold-ack`, Exit `0` |
 
-`apply` existiert als Subcommand und auch als globales Flag `--apply`. Beide
-Pfade fuehren in #2068 zu Exit-Code `5`. Die Tests bestaetigen das als
-hartes Sicherheitsnetz; das Verhalten darf erst durch einen expliziten
-Folge-Slice (Apply-Implementation) entfernt werden.
+`apply` existiert als Subcommand und auch als globales Flag `--apply`. Auf
+allen Nicht-`apply`-Subcommands fuehrt `--apply` weiterhin zu Exit `5`. Auf
+dem `apply`-Subcommand ist `--apply` notwendig, aber nicht hinreichend; ohne
+`--apply-mode local-dev`, ohne `--config`, ohne `--input-dir` oder ohne
+`--run-id` wird Exit `5` zurueckgegeben. Der Default-Adapter ist eine
+mockbare in-memory Boundary; ein realer SurrealDB-Adapter ist nicht
+implementiert und nicht ueber die CLI selektierbar.
 
 ---
 
@@ -70,8 +73,15 @@ Folge-Slice (Apply-Implementation) entfernt werden.
   der Laufzeitumgebung kommen, nicht aus dieser YAML.
 - **Secret-Redaction**: Findings melden secret-like Inhalte nur mit Code und
   Pfad/Zeile; erkannte Werte werden nicht in Reports oder stdout echoed.
-- **Kein Apply-/Audit-/Rollback-Verhalten**: jeweils eigene Folge-Slices.
-  Reconcile in #2072 bleibt dry-run-only und erzeugt nur Reports.
+- **Kein Apply-/Audit-/Rollback-Verhalten**: Audit und Rollback bleiben
+  Folge-Slices. Reconcile in #2072 bleibt dry-run-only. Apply in #2073/#2074
+  ist auf `--apply-mode local-dev` mit dem in-memory Adapter beschraenkt; es
+  oeffnet keinen produktiven SurrealDB-Pfad und schreibt keine Trading- oder
+  Governance-Tabellen.
+- **No production SurrealDB activation**: Es existiert kein realer SurrealDB-
+  Adapter in diesem Slice (`real_surrealdb_adapter_available = false`).
+- **Tombstone-only deletions**: Es gibt keinen Hard-Delete; der Default-Adapter
+  exponiert keine `delete`/`apply_delete`-API.
 
 ---
 
@@ -88,7 +98,8 @@ Folge-Slice (Apply-Implementation) entfernt werden.
 | `--report-output` | `None` | nein | Whitelist-Check; `validate-jsonl` und `plan --input-dir` schreiben Report nur wenn explizit gesetzt |
 | `--existing-records` | `None` | nein | nur fuer `dry-run --input-dir`; lokale JSON-Datei mit Existing-Records-Fixture, kein DB-Client |
 | `--dry-run` | `False` (Default-Verhalten ist dennoch dry-run) | nein | redundant; explizit erlaubt |
-| `--apply` | `False` | nein | `True` ⇒ Exit `5` |
+| `--apply` | `False` | nein | Notwendig, aber nicht hinreichend fuer `apply`; auf jedem anderen Subcommand ⇒ Exit `5` |
+| `--apply-mode` | `None` | fuer `apply` ja | Nur `local-dev` ist erlaubt; argparse rejects andere Werte. Ohne diesen Mode bleibt `apply` Exit `5` |
 | `--format` | `json` | nein | `json` / `jsonl` / `markdown` |
 
 ---
@@ -178,7 +189,96 @@ Guardrails:
 
 ---
 
-## 6. Antwort-Schema
+## 5.2 Gated Local-Dev Apply (#2073)
+
+`apply --apply --apply-mode local-dev --config <yaml> --input-dir <dir> --run-id <id>`
+fuehrt eine **gated local-dev apply pipeline** gegen eine **mockable adapter
+boundary** aus. Default ist der `InMemoryContextApplyAdapter`; **no production
+SurrealDB activation**, kein Default-Netzwerk-Connect.
+
+Gates (alle muessen erfuellt sein, sonst Exit `5`):
+
+- `--apply` gesetzt.
+- `--apply-mode local-dev` gesetzt (argparse erlaubt nur `local-dev`).
+- `--config <yaml>` zeigt auf eine valide lokale Config (siehe §4.1).
+- `--input-dir <dir>` enthaelt validierbare JSONL-Artefakte (siehe §4).
+- `--run-id <id>` ist gesetzt.
+- Config-`surreal_url` host ist `127.0.0.1`, `::1` oder `localhost`.
+- Reconcile-Report enthaelt keine Blocking Findings (sonst Exit `1`).
+
+Adapter-Vertrag:
+
+| Property | Vertrag |
+|---|---|
+| Default-Adapter | `InMemoryContextApplyAdapter`; `adapter_kind = "in-memory"` |
+| Netzwerk | nie geoeffnet; `surrealdb_connection = "in-memory-no-network"` |
+| `apply_create(table, record_id, payload)` | Pflicht |
+| `apply_update(table, record_id, payload)` | Pflicht |
+| `apply_tombstone(table, record_id, payload)` | Pflicht; payload muss `TOMBSTONE_REQUIRED_FIELDS` enthalten |
+| `delete` / `apply_delete` / `hard_delete` | **darf nicht existieren** |
+| Reale SurrealDB-Verbindung | nicht implementiert; `real_surrealdb_adapter_available = false` |
+
+Reconcile-zu-Apply-Mapping:
+
+| Reconcile-Action | Apply-Op |
+|---|---|
+| `create` | `create` |
+| `update_candidate` | `update` |
+| `tombstone_candidate` | `tombstone` |
+| `skip` | dropped (no apply op) |
+
+Per-Op-Fehler des Adapters werden als `failed`-Result gesammelt und brechen
+die Pipeline nicht ab. Die CLI mappt:
+
+- Blocking Findings ⇒ Exit `1`.
+- Mindestens ein `failed` ⇒ Exit `6`.
+- Mindestens ein `blocked` (Table-Policy zur Apply-Zeit) ⇒ Exit `5`.
+- Sonst Exit `0`.
+
+Determinismus:
+
+- Operationen sind nach `(op_kind, table, record_id)` deterministisch sortiert.
+- Bei identischer Eingabe und identischem `ClockProvider` ist der gesamte
+  Apply-Report byte-identisch.
+- Es werden keine Payload-Werte oder Secrets in den Report geleakt; nur
+  `payload_hash` (sha256), Tabelle und Record-ID.
+
+---
+
+## 5.3 Tombstone-Semantik (#2074)
+
+Tombstones sind die **einzige** Form der Loeschung in dieser Pipeline. Es gibt
+keinen Hard Delete und keine Adapter-Delete-API.
+
+Pflichtfelder im Tombstone-Payload (`TOMBSTONE_REQUIRED_FIELDS`):
+
+| Feld | Vertrag |
+|---|---|
+| `tombstoned` | `true` (`false` wird vom Adapter als `ApplyAdapterError` abgelehnt) |
+| `tombstoned_at` | reales ISO8601-UTC mit trailing `Z`, erzeugt aus dem injizierbaren `ClockProvider` (`core.utils.clock`); kein Sentinel-Marker, kein `<run-derived>` |
+| `tombstone_reason` | Default `record_removed_from_snapshot` |
+| `last_seen_run_id` | Run-ID des letzten Sees-Snapshots oder `null` |
+| `superseded_by` | reserviert; in v0 immer `null` |
+
+Verhalten:
+
+- `tombstone_candidate` aus `dry-run` reconcile wird in `apply` zu einer
+  Tombstone-Op gegen den Default-Adapter.
+- Der Adapter ueberschreibt das Original-Record nicht; es bleibt erhalten und
+  bekommt die Tombstone-Felder dazu.
+- `tombstoned_at` wird ausschliesslich aus dem injizierten `ClockProvider`
+  erzeugt; `datetime.now()`/`datetime.utcnow()` darf im Apply-Pfad nicht
+  benutzt werden. `FixedClock` liefert byte-identische Reports.
+- Re-Emergenz (Record taucht nach Tombstone wieder im Snapshot auf) wird in
+  v0 nur informativ als `note: re-emerged_after_tombstone` markiert; es gibt
+  keine Untombstone-Semantik.
+
+Per-Tabelle gilt das fuer alle in §6 gerouteten Tabellen, getestet
+explizit fuer `doc_page`, `doc_chunk`, `code_symbol` und `dependency_edge`.
+
+---
+
+
 
 Erfolgsantwort (Subcommand-Stub):
 
@@ -400,9 +500,12 @@ weder aus CLI-Args noch aus der Umgebung abgeleitet.
 - Folge-Slices duerfen das `validate-jsonl`-Antwort-Schema erweitern, aber
   `schema_version`, `command`, `status`, `dry_run`, `apply_requested`,
   `surrealdb_connection`, `validation` und `findings` muessen erhalten bleiben.
-- Die Apply-Implementierung muss den Hard-Block ersetzen, NICHT lediglich
-  umgehen, und muss zwingend einen Two-Step-Gate (`--apply`
-  + zusaetzliche explizite Bestaetigung) bewahren.
+- Die Apply-Implementierung in #2073/#2074 ersetzt den frueheren Hard-Block
+  fuer das `apply`-Subcommand durch einen mehrstufigen Gate
+  (`--apply` + `--apply-mode local-dev` + `--config` + `--input-dir`
+  + `--run-id` + lokaler Host + Reconcile ohne Blocking Findings). Auf allen
+  Nicht-`apply`-Subcommands bleibt `--apply` ⇒ Exit `5`. Ein zukuenftiger
+  realer SurrealDB-Adapter darf diesen Gate nicht aufweichen.
 - Jeder Slice, der eine SurrealDB-Verbindung einfuehrt, muss
   `surrealdb_connection` korrekt setzen und mindestens einen Test
   liefern, der den Connection-Pfad explizit verifiziert.
@@ -414,14 +517,17 @@ weder aus CLI-Args noch aus der Umgebung abgeleitet.
 
 ## 8. Nicht-Ziele
 
-#2071 aendert diese Nicht-Ziele nur fuer `plan --input-dir`: Die
-Plan-Berechnung ist implementiert, bleibt aber read-only und DB-unabhaengig.
-Dry-run-Reconcile, Apply, Audit und Rollback-Plan bleiben Nicht-Ziele.
+#2071 aendert diese Nicht-Ziele nur fuer `plan --input-dir`. #2073/#2074
+aendern sie nur fuer `apply` im gated local-dev Modus mit der mockable
+adapter boundary; ein realer SurrealDB-Adapter ist explizit out-of-scope.
+Audit und Rollback-Plan bleiben Nicht-Ziele.
 
-- Keine SurrealDB-Verbindung.
-- Kein SurrealDB-Write.
-- Kein Apply-Verhalten aus validierten JSONL-Artefakten.
-- Keine Dry-run-Reconcile-/Apply-/Audit-/Rollback-Logik.
+- Keine produktive SurrealDB-Verbindung (`real_surrealdb_adapter_available = false`).
+- Kein Default-Netzwerk-Connect; in-memory adapter ist Default.
+- Kein Hard Delete; nur Tombstones.
+- Kein Apply ausserhalb von `--apply-mode local-dev` mit lokalem Host.
+- Kein Schreiben in Trading-, Risk-, Execution- oder Governance-Mirror-Tabellen.
+- Keine Audit-/Rollback-Logik.
 - Keine Aenderung an Trading-, Risk-, Execution-, Secrets- oder
   Live-Readiness-Pfaden.
 - Kein Echtgeld-/Live-Enable.

--- a/tests/unit/surrealdb/test_context_import_apply.py
+++ b/tests/unit/surrealdb/test_context_import_apply.py
@@ -43,8 +43,10 @@ from tools.surrealdb.context_importer import (
     SCHEMA_VERSION,
     SUPPORTED_APPLY_MODES,
     ApplyAdapterError,
+    ApplyGateError,
     ContextApplyOperation,
     ContextApplyReport,
+    _validate_apply_table_policy,
     build_import_plan,
     execute_context_apply,
     load_config,
@@ -119,9 +121,14 @@ def _write_local_dev_config(
     surreal_url: str = "ws://127.0.0.1:8000/rpc",
     namespace: str = "cdb_ctx",
     database: str = "context",
+    allowed_tables: list[str] | None = None,
 ) -> Path:
     forbidden = sorted(FORBIDDEN_CONTEXT_IMPORT_TABLES)
-    allowed = sorted(ALLOWED_CONTEXT_IMPORT_TABLES)
+    allowed = (
+        sorted(allowed_tables)
+        if allowed_tables is not None
+        else sorted(ALLOWED_CONTEXT_IMPORT_TABLES)
+    )
     body = (
         "schema_version: context-import-local/v0\n"
         f"surreal_url: {surreal_url}\n"
@@ -635,3 +642,191 @@ def test_unsupported_apply_mode_is_rejected_by_argparse(capsys) -> None:
         main(["apply", "--apply", "--apply-mode", "production"])
     # argparse choices reject before our handler.
     assert excinfo.value.code != 0
+
+
+# ---------------------------------------------------------------------------
+# Apply table-policy gate: configured allow-list is strictly restrictive
+# ---------------------------------------------------------------------------
+#
+# Regression coverage for the P2 review thread on PR #2248
+# (PRRT_kwDOQUkXUM5_DmtG): a table that is globally allowed must still
+# be blocked at apply time when the operator removed it from
+# ``config.allowed_tables``. Forbidden trumps allowed; configured
+# allow-list never widens the global allow-list.
+
+
+@pytest.mark.unit
+def test_validate_apply_table_policy_global_and_config_allowed_passes() -> None:
+    """global allowed + config allowed -> no raise."""
+
+    table = next(iter(ALLOWED_CONTEXT_IMPORT_TABLES))
+    _validate_apply_table_policy(
+        table,
+        allowed=frozenset(ALLOWED_CONTEXT_IMPORT_TABLES),
+        forbidden=frozenset(FORBIDDEN_CONTEXT_IMPORT_TABLES),
+    )
+
+
+@pytest.mark.unit
+def test_validate_apply_table_policy_globally_allowed_but_not_in_config_blocks() -> None:
+    """global allowed + config narrower (without table) -> blocked.
+
+    This is the exact regression the P2 review flagged: previously the
+    table slipped through because the global allow-list was used as a
+    fallback. The configured allow-list must be strictly restrictive.
+    """
+
+    globally_allowed = sorted(ALLOWED_CONTEXT_IMPORT_TABLES)
+    assert len(globally_allowed) >= 2, (
+        "test precondition: need at least two globally-allowed tables"
+    )
+    table = globally_allowed[0]
+    narrower = frozenset(globally_allowed[1:])  # explicitly omits `table`
+
+    with pytest.raises(ApplyGateError) as excinfo:
+        _validate_apply_table_policy(
+            table,
+            allowed=narrower,
+            forbidden=frozenset(FORBIDDEN_CONTEXT_IMPORT_TABLES),
+        )
+    msg = str(excinfo.value)
+    assert table in msg
+    assert "configured allow-list" in msg
+
+
+@pytest.mark.unit
+def test_validate_apply_table_policy_config_forbidden_blocks() -> None:
+    """global allowed + config forbidden contains table -> blocked."""
+
+    table = next(iter(ALLOWED_CONTEXT_IMPORT_TABLES))
+    forbidden = frozenset(FORBIDDEN_CONTEXT_IMPORT_TABLES | {table})
+
+    with pytest.raises(ApplyGateError) as excinfo:
+        _validate_apply_table_policy(
+            table,
+            allowed=frozenset(ALLOWED_CONTEXT_IMPORT_TABLES),
+            forbidden=forbidden,
+        )
+    assert table in str(excinfo.value)
+    assert "forbidden" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_validate_apply_table_policy_global_forbidden_blocks_even_if_config_allows() -> None:
+    """global forbidden trumps config allow-list -> blocked."""
+
+    forbidden_table = next(iter(FORBIDDEN_CONTEXT_IMPORT_TABLES))
+    allowed = frozenset({forbidden_table})  # operator tried to allow it
+
+    with pytest.raises(ApplyGateError) as excinfo:
+        _validate_apply_table_policy(
+            forbidden_table,
+            allowed=allowed,
+            forbidden=frozenset(),
+        )
+    assert forbidden_table in str(excinfo.value)
+    assert "forbidden" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_validate_apply_table_policy_unknown_table_blocked_by_global_allow_list() -> None:
+    """Unknown tables (neither in global allow nor in global forbid) are
+    blocked by the global allow-list check."""
+
+    table = "definitely_not_a_real_context_table"
+    assert table not in ALLOWED_CONTEXT_IMPORT_TABLES
+    assert table not in FORBIDDEN_CONTEXT_IMPORT_TABLES
+
+    with pytest.raises(ApplyGateError) as excinfo:
+        _validate_apply_table_policy(
+            table,
+            allowed=frozenset({table}),  # operator tried to allow it
+            forbidden=frozenset(),
+        )
+    assert table in str(excinfo.value)
+    assert "global allow-list" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_validate_apply_table_policy_error_does_not_leak_payload_or_secret() -> None:
+    """Block messages must contain the table and a reason, but no
+    payload-, hash-, or secret-shaped content."""
+
+    table = next(iter(ALLOWED_CONTEXT_IMPORT_TABLES))
+    narrower: frozenset[str] = frozenset()
+
+    with pytest.raises(ApplyGateError) as excinfo:
+        _validate_apply_table_policy(
+            table,
+            allowed=narrower,
+            forbidden=frozenset(FORBIDDEN_CONTEXT_IMPORT_TABLES),
+        )
+    msg = str(excinfo.value)
+    assert table in msg
+    # No payload / record content / secret-shaped substrings.
+    forbidden_substrings = (
+        "payload",
+        "secret",
+        "token",
+        "password",
+        "api_key",
+        "api-key",
+        "record_id",
+        "payload_hash",
+    )
+    lower = msg.lower()
+    for needle in forbidden_substrings:
+        assert needle not in lower, (
+            f"error message must not leak {needle!r}: {msg!r}"
+        )
+
+
+@pytest.mark.unit
+def test_apply_blocks_table_omitted_from_config_allowed_tables(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: a snapshot table that is globally allowed but
+    omitted from ``config.allowed_tables`` must be blocked at apply
+    time and never reach the adapter."""
+
+    _write_valid_artifacts(tmp_path)
+
+    # Operator allows everything globally allowed EXCEPT ``repo_artifact``.
+    narrowed = sorted(set(ALLOWED_CONTEXT_IMPORT_TABLES) - {"repo_artifact"})
+    config_path = _write_local_dev_config(
+        tmp_path / "config.yaml",
+        allowed_tables=narrowed,
+    )
+    config = load_config(config_path)
+    assert "repo_artifact" not in config.allowed_tables
+    assert "repo_artifact" in ALLOWED_CONTEXT_IMPORT_TABLES
+
+    plan = build_import_plan(tmp_path, "run-apply-1")
+    reconcile = reconcile_import_plan(plan, load_existing_records(None))
+
+    adapter = InMemoryContextApplyAdapter()
+    clock = FixedClock(datetime(2026, 1, 1, 12, 0, 0))
+    report = execute_context_apply(
+        reconcile_report=reconcile,
+        config=config,
+        run_id="run-apply-1",
+        apply_mode=APPLY_MODE_LOCAL_DEV,
+        adapter=adapter,
+        clock=clock,
+    )
+
+    assert report.apply_executed is True
+    blocked_results = [r for r in report.results if r.status == "blocked"]
+    assert blocked_results, (
+        "expected at least one blocked operation for repo_artifact"
+    )
+    assert all(r.table == "repo_artifact" for r in blocked_results)
+    # Adapter must never see the blocked table.
+    assert all(
+        op_args[1] != "repo_artifact" for op_args in adapter.operations
+    ), "blocked table reached the adapter"
+    # Block detail mentions the table and the configured allow-list reason.
+    for r in blocked_results:
+        assert r.detail is not None
+        assert "repo_artifact" in r.detail
+        assert "configured allow-list" in r.detail

--- a/tests/unit/surrealdb/test_context_import_apply.py
+++ b/tests/unit/surrealdb/test_context_import_apply.py
@@ -1,0 +1,637 @@
+"""Unit tests for the gated local-dev apply pipeline (#2073).
+
+These tests cover the explicit local apply mode:
+
+* ``--apply`` and ``--apply-mode local-dev`` are both required.
+* ``--apply`` on a non-apply subcommand stays hard-blocked.
+* The default adapter is the in-memory, no-network adapter.
+* Blocking reconcile findings prevent any adapter call.
+* Forbidden tables fail closed at the apply boundary.
+* Adapter failures are surfaced as ``failed`` results without
+  aborting the whole apply pipeline.
+* No network socket is opened during apply.
+* Determinism: identical input + identical injected clock + identical
+  run_id produce byte-identical apply payloads.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import json
+import socket
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from core.utils.clock import FixedClock
+from tools.surrealdb.context_importer import (
+    ADAPTER_KIND_IN_MEMORY,
+    ALLOWED_CONTEXT_IMPORT_TABLES,
+    APPLY_MODE_LOCAL_DEV,
+    APPLY_OP_CREATE,
+    APPLY_OP_TOMBSTONE,
+    APPLY_OP_UPDATE,
+    EXIT_INTERNAL,
+    EXIT_OK,
+    EXIT_VALIDATION_ERROR,
+    EXIT_WRITE_DENIED,
+    FORBIDDEN_CONTEXT_IMPORT_TABLES,
+    InMemoryContextApplyAdapter,
+    LOCAL_DEV_ALLOWED_HOSTS,
+    REAL_SURREALDB_ADAPTER_AVAILABLE,
+    SCHEMA_VERSION,
+    SUPPORTED_APPLY_MODES,
+    ApplyAdapterError,
+    ContextApplyOperation,
+    ContextApplyReport,
+    build_import_plan,
+    execute_context_apply,
+    load_config,
+    load_existing_records,
+    main,
+    reconcile_import_plan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (small, inline; mirror style of test_context_import_reconcile.py)
+# ---------------------------------------------------------------------------
+
+
+def _read_json(capsys) -> dict:
+    out = capsys.readouterr().out.strip()
+    return json.loads(out)
+
+
+def _write_valid_artifacts(tmp_path: Path, *, run_id: str = "run-apply-1") -> None:
+    """Write the minimal JSONL set the importer accepts."""
+
+    rows: dict[str, list[dict[str, Any]]] = {
+        "repo_artifacts.jsonl": [
+            {
+                "schema_version": "context-indexer/v0",
+                "run_id": run_id,
+                "artifact_id": "art-1",
+                "source_path": "docs/example.md",
+                "file_type": "markdown",
+                "raw_sha256": "a" * 64,
+                "normalized_sha256": "a" * 64,
+                "source_hash": "a" * 64,
+                "integrity_algo": "sha256",
+                "size_bytes": 12,
+                "sensitivity": "public",
+            }
+        ],
+        "doc_pages.jsonl": [
+            {
+                "schema_version": "context-indexer/v0",
+                "run_id": run_id,
+                "page_id": "page-example",
+                "source_path": "docs/example.md",
+                "source_hash": "a" * 64,
+                "title": "Example",
+            }
+        ],
+        "doc_sections.jsonl": [],
+        "doc_chunks.jsonl": [],
+        "code_symbols.jsonl": [],
+        "import_references.jsonl": [],
+        "test_cases.jsonl": [],
+        "config_references.jsonl": [],
+        "doc_code_links.jsonl": [],
+        "dependency_edges.jsonl": [],
+    }
+    for name, items in rows.items():
+        path = tmp_path / name
+        with path.open("w", encoding="utf-8") as handle:
+            for item in items:
+                handle.write(json.dumps(item, sort_keys=True) + "\n")
+
+
+def _write_existing(path: Path, records: list[dict[str, Any]]) -> None:
+    path.write_text(json.dumps(records, sort_keys=True), encoding="utf-8")
+
+
+def _write_local_dev_config(
+    path: Path,
+    *,
+    surreal_url: str = "ws://127.0.0.1:8000/rpc",
+    namespace: str = "cdb_ctx",
+    database: str = "context",
+) -> Path:
+    forbidden = sorted(FORBIDDEN_CONTEXT_IMPORT_TABLES)
+    allowed = sorted(ALLOWED_CONTEXT_IMPORT_TABLES)
+    body = (
+        "schema_version: context-import-local/v0\n"
+        f"surreal_url: {surreal_url}\n"
+        f"namespace: {namespace}\n"
+        f"database: {database}\n"
+        "auth_mode: none\n"
+        "timeout: 5\n"
+        "allow_apply_default: false\n"
+        "allowed_tables:\n"
+        + "".join(f"  - {t}\n" for t in allowed)
+        + "forbidden_tables:\n"
+        + "".join(f"  - {t}\n" for t in forbidden)
+    )
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Constants & boundary documentation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_apply_mode_constant_is_local_dev() -> None:
+    assert APPLY_MODE_LOCAL_DEV == "local-dev"
+    assert APPLY_MODE_LOCAL_DEV in SUPPORTED_APPLY_MODES
+    assert SUPPORTED_APPLY_MODES == frozenset({"local-dev"})
+
+
+@pytest.mark.unit
+def test_real_surrealdb_adapter_is_not_available() -> None:
+    """#2073: Real SurrealDB adapter is OUT-OF-SCOPE in this slice."""
+
+    assert REAL_SURREALDB_ADAPTER_AVAILABLE is False
+
+
+@pytest.mark.unit
+def test_default_adapter_is_in_memory_and_has_no_delete_method() -> None:
+    adapter = InMemoryContextApplyAdapter()
+    assert adapter.kind == ADAPTER_KIND_IN_MEMORY
+    # No hard-delete API exists at all.
+    assert not hasattr(adapter, "apply_delete")
+    assert not hasattr(adapter, "delete")
+
+
+# ---------------------------------------------------------------------------
+# CLI gate tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_apply_subcommand_without_apply_flag_is_write_denied(capsys) -> None:
+    exit_code = main(["apply"])
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+    assert "--apply" in payload["message"]
+
+
+@pytest.mark.unit
+def test_apply_with_apply_but_no_apply_mode_is_write_denied(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    config_path = _write_local_dev_config(tmp_path / "config.yaml")
+    exit_code = main(
+        [
+            "apply",
+            "--apply",
+            "--config",
+            str(config_path),
+            "--input-dir",
+            str(tmp_path),
+            "--run-id",
+            "run-apply-1",
+        ]
+    )
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+    assert "apply-mode" in payload["message"]
+
+
+@pytest.mark.unit
+def test_apply_without_config_is_write_denied(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+    exit_code = main(
+        [
+            "apply",
+            "--apply",
+            "--apply-mode",
+            "local-dev",
+            "--input-dir",
+            str(tmp_path),
+            "--run-id",
+            "run-apply-1",
+        ]
+    )
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+    assert "--config" in payload["message"]
+
+
+@pytest.mark.unit
+def test_apply_without_input_dir_is_write_denied(tmp_path: Path, capsys) -> None:
+    config_path = _write_local_dev_config(tmp_path / "config.yaml")
+    exit_code = main(
+        [
+            "apply",
+            "--apply",
+            "--apply-mode",
+            "local-dev",
+            "--config",
+            str(config_path),
+            "--run-id",
+            "run-apply-1",
+        ]
+    )
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+    assert "--input-dir" in payload["message"]
+
+
+@pytest.mark.unit
+def test_apply_without_run_id_is_write_denied(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+    config_path = _write_local_dev_config(tmp_path / "config.yaml")
+    exit_code = main(
+        [
+            "apply",
+            "--apply",
+            "--apply-mode",
+            "local-dev",
+            "--config",
+            str(config_path),
+            "--input-dir",
+            str(tmp_path),
+        ]
+    )
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+    assert "--run-id" in payload["message"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "command",
+    ["validate-jsonl", "plan", "dry-run", "audit", "rollback-plan"],
+)
+def test_apply_flag_on_non_apply_subcommand_stays_hard_blocked(
+    command: str, capsys
+) -> None:
+    exit_code = main([command, "--apply"])
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+
+
+@pytest.mark.unit
+def test_apply_with_non_local_dev_url_is_blocked(tmp_path: Path, capsys) -> None:
+    _write_valid_artifacts(tmp_path)
+    config_path = _write_local_dev_config(
+        tmp_path / "config.yaml", surreal_url="ws://prod.example.invalid:8000/rpc"
+    )
+    exit_code = main(
+        [
+            "apply",
+            "--apply",
+            "--apply-mode",
+            "local-dev",
+            "--config",
+            str(config_path),
+            "--input-dir",
+            str(tmp_path),
+            "--run-id",
+            "run-apply-1",
+        ]
+    )
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "APPLY_GATE_DENIED"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("host", sorted(LOCAL_DEV_ALLOWED_HOSTS))
+def test_apply_accepts_each_local_dev_host(
+    host: str, tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    # urlparse needs brackets for IPv6; use [::1] in the URL form.
+    netloc_host = f"[{host}]" if host == "::1" else host
+    config_path = _write_local_dev_config(
+        tmp_path / "config.yaml", surreal_url=f"ws://{netloc_host}:8000/rpc"
+    )
+    exit_code = main(
+        [
+            "apply",
+            "--apply",
+            "--apply-mode",
+            "local-dev",
+            "--config",
+            str(config_path),
+            "--input-dir",
+            str(tmp_path),
+            "--run-id",
+            "run-apply-1",
+        ]
+    )
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert payload["apply_executed"] is True
+    assert payload["apply_mode"] == APPLY_MODE_LOCAL_DEV
+    assert payload["adapter"] == ADAPTER_KIND_IN_MEMORY
+
+
+# ---------------------------------------------------------------------------
+# Functional apply behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_apply_creates_records_via_in_memory_adapter(tmp_path: Path) -> None:
+    """The default adapter records every operation in-memory."""
+
+    _write_valid_artifacts(tmp_path)
+    config_path = _write_local_dev_config(tmp_path / "config.yaml")
+    config = load_config(config_path)
+    plan = build_import_plan(tmp_path, "run-apply-1")
+    reconcile = reconcile_import_plan(plan, load_existing_records(None))
+
+    adapter = InMemoryContextApplyAdapter()
+    clock = FixedClock(datetime(2026, 1, 1, 12, 0, 0))
+    report = execute_context_apply(
+        reconcile_report=reconcile,
+        config=config,
+        run_id="run-apply-1",
+        apply_mode=APPLY_MODE_LOCAL_DEV,
+        adapter=adapter,
+        clock=clock,
+    )
+
+    assert report.apply_executed is True
+    assert report.status == "applied"
+    assert report.adapter == ADAPTER_KIND_IN_MEMORY
+    # All operations recorded by the in-memory adapter.
+    assert len(adapter.operations) == len(report.operations)
+    assert all(op_kind == APPLY_OP_CREATE for op_kind, *_ in adapter.operations)
+    counts = report.counts()
+    assert counts["applied"] == counts["creates"]
+    assert counts["failed"] == 0
+    assert counts["blocked"] == 0
+
+
+@pytest.mark.unit
+def test_apply_blocked_by_reconcile_blocking_findings(tmp_path: Path) -> None:
+    """A forbidden-table existing record blocks reconcile and apply."""
+
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(
+        existing,
+        [
+            {
+                "table": "orders",  # forbidden
+                "record_id": "orders:1",
+                "payload_hash": "f" * 64,
+                "schema_version": "context-importer/v0",
+            }
+        ],
+    )
+
+    config_path = _write_local_dev_config(tmp_path / "config.yaml")
+    config = load_config(config_path)
+    plan = build_import_plan(tmp_path, "run-apply-1")
+    reconcile = reconcile_import_plan(plan, load_existing_records(existing))
+
+    adapter = InMemoryContextApplyAdapter()
+    report = execute_context_apply(
+        reconcile_report=reconcile,
+        config=config,
+        run_id="run-apply-1",
+        apply_mode=APPLY_MODE_LOCAL_DEV,
+        adapter=adapter,
+        clock=FixedClock(datetime(2026, 1, 1)),
+    )
+    assert report.apply_executed is False
+    assert report.status == "blocked"
+    assert report.blocking_findings_present is True
+    # No adapter call was made.
+    assert adapter.operations == []
+
+
+@pytest.mark.unit
+def test_apply_cli_returns_validation_error_on_blocking_findings(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(
+        existing,
+        [
+            {
+                "table": "orders",
+                "record_id": "orders:1",
+                "payload_hash": "f" * 64,
+                "schema_version": "context-importer/v0",
+            }
+        ],
+    )
+    config_path = _write_local_dev_config(tmp_path / "config.yaml")
+    exit_code = main(
+        [
+            "apply",
+            "--apply",
+            "--apply-mode",
+            "local-dev",
+            "--config",
+            str(config_path),
+            "--input-dir",
+            str(tmp_path),
+            "--existing-records",
+            str(existing),
+            "--run-id",
+            "run-apply-1",
+        ]
+    )
+    assert exit_code == EXIT_VALIDATION_ERROR
+    payload = _read_json(capsys)
+    assert payload["status"] == "blocked"
+    assert payload["apply_executed"] is False
+    assert payload["blocking_findings_present"] is True
+
+
+@pytest.mark.unit
+def test_apply_failure_in_adapter_is_surfaced_without_aborting(
+    tmp_path: Path,
+) -> None:
+    """A per-op adapter failure is reported but does not crash apply."""
+
+    _write_valid_artifacts(tmp_path)
+    config_path = _write_local_dev_config(tmp_path / "config.yaml")
+    config = load_config(config_path)
+    plan = build_import_plan(tmp_path, "run-apply-1")
+    reconcile = reconcile_import_plan(plan, load_existing_records(None))
+
+    class FlakyAdapter(InMemoryContextApplyAdapter):
+        def apply_create(
+            self, table: str, record_id: str, payload: dict[str, Any]
+        ) -> None:
+            raise ApplyAdapterError(f"boom for {record_id}")
+
+    adapter = FlakyAdapter()
+    report = execute_context_apply(
+        reconcile_report=reconcile,
+        config=config,
+        run_id="run-apply-1",
+        apply_mode=APPLY_MODE_LOCAL_DEV,
+        adapter=adapter,
+        clock=FixedClock(datetime(2026, 1, 1)),
+    )
+    assert report.status == "partial"
+    counts = report.counts()
+    assert counts["failed"] == counts["creates"]
+    assert all(r.status == "failed" for r in report.results if r.op == APPLY_OP_CREATE)
+
+
+@pytest.mark.unit
+def test_apply_cli_returns_internal_on_adapter_failures(
+    tmp_path: Path, capsys, monkeypatch
+) -> None:
+    """When the in-memory adapter reports failures, CLI exits 6 (INTERNAL)."""
+
+    _write_valid_artifacts(tmp_path)
+    config_path = _write_local_dev_config(tmp_path / "config.yaml")
+
+    # Patch the executor to use a flaky adapter.
+    from tools.surrealdb import context_importer as ci
+
+    real_execute = ci.execute_context_apply
+
+    def _flaky_execute(**kwargs: Any) -> ContextApplyReport:
+        class _Flaky(InMemoryContextApplyAdapter):
+            def apply_create(self, table, record_id, payload):  # type: ignore[no-untyped-def]
+                raise ApplyAdapterError("forced")
+
+        kwargs["adapter"] = _Flaky()
+        kwargs.setdefault("clock", FixedClock(datetime(2026, 1, 1)))
+        return real_execute(**kwargs)
+
+    monkeypatch.setattr(ci, "execute_context_apply", _flaky_execute)
+
+    exit_code = main(
+        [
+            "apply",
+            "--apply",
+            "--apply-mode",
+            "local-dev",
+            "--config",
+            str(config_path),
+            "--input-dir",
+            str(tmp_path),
+            "--run-id",
+            "run-apply-1",
+        ]
+    )
+    assert exit_code == EXIT_INTERNAL
+    payload = _read_json(capsys)
+    assert payload["status"] == "partial"
+    assert payload["counts"]["failed"] >= 1
+
+
+@pytest.mark.unit
+def test_apply_no_socket_is_opened(tmp_path: Path, capsys, monkeypatch) -> None:
+    """The default in-memory adapter must never open a socket during apply."""
+
+    def _boom(*args, **kwargs):  # pragma: no cover - safety net
+        raise AssertionError(
+            "context_importer apply must not open network sockets"
+        )
+
+    monkeypatch.setattr(socket.socket, "connect", _boom)
+    monkeypatch.setattr(socket.socket, "connect_ex", _boom)
+
+    _write_valid_artifacts(tmp_path)
+    config_path = _write_local_dev_config(tmp_path / "config.yaml")
+    exit_code = main(
+        [
+            "apply",
+            "--apply",
+            "--apply-mode",
+            "local-dev",
+            "--config",
+            str(config_path),
+            "--input-dir",
+            str(tmp_path),
+            "--run-id",
+            "run-apply-1",
+        ]
+    )
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert payload["surrealdb_connection"] == "in-memory-no-network"
+    assert payload["surrealdb_writes"] == "in-memory-only"
+
+
+@pytest.mark.unit
+def test_apply_payload_is_deterministic_with_fixed_clock(tmp_path: Path) -> None:
+    """Same input + same run_id + same FixedClock => byte-identical payload."""
+
+    _write_valid_artifacts(tmp_path)
+    config_path = _write_local_dev_config(tmp_path / "config.yaml")
+    config = load_config(config_path)
+    plan = build_import_plan(tmp_path, "run-apply-1")
+    reconcile = reconcile_import_plan(plan, load_existing_records(None))
+
+    fixed = datetime(2026, 1, 1, 12, 0, 0)
+
+    def _run() -> str:
+        report = execute_context_apply(
+            reconcile_report=reconcile,
+            config=config,
+            run_id="run-apply-1",
+            apply_mode=APPLY_MODE_LOCAL_DEV,
+            adapter=InMemoryContextApplyAdapter(),
+            clock=FixedClock(fixed),
+        )
+        return json.dumps(report.to_payload(), sort_keys=True)
+
+    assert _run() == _run()
+
+
+@pytest.mark.unit
+def test_apply_payload_includes_real_adapter_disclaimer(tmp_path: Path) -> None:
+    _write_valid_artifacts(tmp_path)
+    config_path = _write_local_dev_config(tmp_path / "config.yaml")
+    config = load_config(config_path)
+    plan = build_import_plan(tmp_path, "run-apply-1")
+    reconcile = reconcile_import_plan(plan, load_existing_records(None))
+    report = execute_context_apply(
+        reconcile_report=reconcile,
+        config=config,
+        run_id="run-apply-1",
+        apply_mode=APPLY_MODE_LOCAL_DEV,
+        adapter=InMemoryContextApplyAdapter(),
+        clock=FixedClock(datetime(2026, 1, 1)),
+    )
+    payload = report.to_payload()
+    assert payload["real_surrealdb_adapter_available"] is False
+    assert payload["adapter"] == ADAPTER_KIND_IN_MEMORY
+    assert payload["surrealdb_connection"] == "in-memory-no-network"
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert "no production surrealdb activation" in payload["note"].lower()
+
+
+@pytest.mark.unit
+def test_apply_help_advertises_apply_mode_flag(capsys) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["apply", "--help"])
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert "--apply-mode" in out
+    assert "local-dev" in out
+
+
+@pytest.mark.unit
+def test_unsupported_apply_mode_is_rejected_by_argparse(capsys) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["apply", "--apply", "--apply-mode", "production"])
+    # argparse choices reject before our handler.
+    assert excinfo.value.code != 0

--- a/tests/unit/surrealdb/test_context_import_tombstones.py
+++ b/tests/unit/surrealdb/test_context_import_tombstones.py
@@ -452,3 +452,271 @@ def test_apply_pipeline_uses_injected_clock_not_datetime_now(
     )
     tomb = [r for r in report.results if r.op == APPLY_OP_TOMBSTONE][0]
     assert tomb.tombstoned_at == "2026-01-01T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# Prior-field retention on tombstone (PR #2248 P2 fix; #2073/#2074 contract
+# §5.3: "Der Adapter ueberschreibt das Original-Record nicht; es bleibt
+# erhalten und bekommt die Tombstone-Felder dazu.").
+# ---------------------------------------------------------------------------
+
+
+def _stale_existing_with_payload(
+    table: str, record_id: str, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """An existing-records fixture entry that carries a ``payload`` object.
+
+    The loader uses the object payload to compute the hash and to retain
+    the prior record fields for downstream tombstone preservation.
+    """
+
+    return {
+        "table": table,
+        "record_id": record_id,
+        "payload": payload,
+        "schema_version": "context-importer/v0",
+    }
+
+
+@pytest.mark.unit
+def test_tombstone_preserves_prior_record_fields_from_existing_records(
+    tmp_path: Path,
+) -> None:
+    """A tombstoned record must retain its original fields after apply.
+
+    Regression test for PR #2248 (thread ``PRRT_kwDOQUkXUM5_D1__``):
+    when the only source of the prior record is the ``--existing-records``
+    fixture (the in-memory adapter has no previous ``apply_create`` for
+    that id), the tombstone payload must still carry the original record
+    fields under the tombstone metadata.
+    """
+
+    _write_valid_artifacts(tmp_path, run_id="run-tomb-keep")
+    existing_path = tmp_path / "existing.json"
+    prior_payload = {
+        "page_id": "stale",
+        "title": "Original Title",
+        "source_path": "docs/stale.md",
+        "source_hash": "b" * 64,
+    }
+    _write_existing(
+        existing_path,
+        [_stale_existing_with_payload("doc_page", "doc_page:stale", prior_payload)],
+    )
+
+    config = load_config(_write_local_dev_config(tmp_path / "config.yaml"))
+    plan = build_import_plan(tmp_path, "run-tomb-keep")
+    reconcile = reconcile_import_plan(plan, load_existing_records(existing_path))
+
+    adapter = InMemoryContextApplyAdapter()
+    report = execute_context_apply(
+        reconcile_report=reconcile,
+        config=config,
+        run_id="run-tomb-keep",
+        apply_mode=APPLY_MODE_LOCAL_DEV,
+        adapter=adapter,
+        clock=FixedClock(datetime(2026, 1, 15, 9, 30, 0, tzinfo=timezone.utc)),
+    )
+
+    # The tombstone op was emitted and applied.
+    tomb_results = [r for r in report.results if r.op == APPLY_OP_TOMBSTONE]
+    assert len(tomb_results) == 1
+    assert tomb_results[0].status == "applied"
+    assert tomb_results[0].record_id == "doc_page:stale"
+
+    # The adapter received a payload that carries every prior field.
+    op_kind, table, record_id, payload = adapter.operations[-1]
+    assert op_kind == APPLY_OP_TOMBSTONE
+    assert table == "doc_page"
+    assert record_id == "doc_page:stale"
+    for key, value in prior_payload.items():
+        assert payload[key] == value, f"prior field {key!r} must be preserved"
+
+    # Tombstone metadata is present and overlays prior fields if any
+    # collide. The required field set is a strict subset of the keys.
+    assert TOMBSTONE_REQUIRED_FIELDS.issubset(payload.keys())
+    assert payload[TOMBSTONE_FIELD_FLAG] is True
+    assert payload[TOMBSTONE_FIELD_AT] == "2026-01-15T09:30:00Z"
+    assert payload[TOMBSTONE_FIELD_REASON] == TOMBSTONE_REASON_REMOVED_FROM_SNAPSHOT
+
+    # And the in-memory record reflects the union: prior + tombstone.
+    record = adapter.records["doc_page:stale"]
+    for key, value in prior_payload.items():
+        assert record[key] == value
+    assert record[TOMBSTONE_FIELD_FLAG] is True
+    assert record[TOMBSTONE_FIELD_AT] == "2026-01-15T09:30:00Z"
+
+
+@pytest.mark.unit
+def test_tombstone_metadata_overlays_colliding_prior_fields(tmp_path: Path) -> None:
+    """Tombstone metadata + identity keys win over colliding prior fields.
+
+    A prior record that itself happens to contain a ``tombstoned``,
+    ``tombstoned_at``, ``run_id`` or ``payload_hash`` key must not be
+    able to override the tombstone metadata produced by the apply
+    pipeline. The pipeline is the single source of truth for those keys.
+    """
+
+    _write_valid_artifacts(tmp_path, run_id="run-tomb-overlay")
+    existing_path = tmp_path / "existing.json"
+    prior_payload = {
+        "page_id": "stale",
+        "title": "Original Title",
+        "source_path": "docs/stale.md",
+        "source_hash": "c" * 64,
+        # Adversarial collisions: the tombstone metadata + identity
+        # fields must overlay these.
+        TOMBSTONE_FIELD_FLAG: False,
+        TOMBSTONE_FIELD_AT: "1999-01-01T00:00:00Z",
+        TOMBSTONE_FIELD_REASON: "attacker_controlled",
+        "run_id": "attacker-run",
+        "payload_hash": "0" * 64,
+    }
+    _write_existing(
+        existing_path,
+        [_stale_existing_with_payload("doc_page", "doc_page:stale", prior_payload)],
+    )
+
+    config = load_config(_write_local_dev_config(tmp_path / "config.yaml"))
+    plan = build_import_plan(tmp_path, "run-tomb-overlay")
+    reconcile = reconcile_import_plan(plan, load_existing_records(existing_path))
+
+    adapter = InMemoryContextApplyAdapter()
+    execute_context_apply(
+        reconcile_report=reconcile,
+        config=config,
+        run_id="run-tomb-overlay",
+        apply_mode=APPLY_MODE_LOCAL_DEV,
+        adapter=adapter,
+        clock=FixedClock(datetime(2026, 2, 2, 12, 0, 0, tzinfo=timezone.utc)),
+    )
+
+    _, _, _, payload = adapter.operations[-1]
+    # Pipeline-controlled keys must reflect the apply, not the prior values.
+    assert payload[TOMBSTONE_FIELD_FLAG] is True
+    assert payload[TOMBSTONE_FIELD_AT] == "2026-02-02T12:00:00Z"
+    assert payload[TOMBSTONE_FIELD_REASON] == TOMBSTONE_REASON_REMOVED_FROM_SNAPSHOT
+    assert payload["run_id"] == "run-tomb-overlay"
+    # Existing payload hash from the fixture, not the colliding prior key.
+    assert payload["payload_hash"] != "0" * 64
+    # Non-colliding prior fields are preserved verbatim.
+    assert payload["page_id"] == "stale"
+    assert payload["title"] == "Original Title"
+    assert payload["source_path"] == "docs/stale.md"
+
+
+@pytest.mark.unit
+def test_tombstone_without_prior_payload_is_minimal_deterministic(
+    tmp_path: Path,
+) -> None:
+    """Hash-only existing-records entries keep the minimal tombstone shape.
+
+    When the existing record provides only ``payload_hash`` (no
+    ``payload`` object), there are no prior fields to preserve, so the
+    tombstone payload remains the deterministic minimal shape: tombstone
+    metadata + identity keys + the carried-over ``payload_hash``.
+    """
+
+    _write_valid_artifacts(tmp_path, run_id="run-tomb-min")
+    existing_path = tmp_path / "existing.json"
+    # Hash-only entry; no ``payload`` dict provided.
+    hash_only_entry = {
+        "table": "doc_page",
+        "record_id": "doc_page:stale",
+        "payload_hash": "e" * 64,
+        "schema_version": "context-importer/v0",
+    }
+    _write_existing(existing_path, [hash_only_entry])
+
+    config = load_config(_write_local_dev_config(tmp_path / "config.yaml"))
+    plan = build_import_plan(tmp_path, "run-tomb-min")
+    reconcile = reconcile_import_plan(plan, load_existing_records(existing_path))
+
+    adapter = InMemoryContextApplyAdapter()
+    execute_context_apply(
+        reconcile_report=reconcile,
+        config=config,
+        run_id="run-tomb-min",
+        apply_mode=APPLY_MODE_LOCAL_DEV,
+        adapter=adapter,
+        clock=FixedClock(datetime(2026, 3, 3, 0, 0, 0, tzinfo=timezone.utc)),
+    )
+
+    _, _, _, payload = adapter.operations[-1]
+    expected_keys = {
+        TOMBSTONE_FIELD_FLAG,
+        TOMBSTONE_FIELD_AT,
+        TOMBSTONE_FIELD_REASON,
+        TOMBSTONE_FIELD_LAST_SEEN_RUN_ID,
+        TOMBSTONE_FIELD_SUPERSEDED_BY,
+        "table",
+        "record_id",
+        "run_id",
+        "payload_hash",
+    }
+    assert set(payload.keys()) == expected_keys
+    assert payload["payload_hash"] == "e" * 64
+
+
+@pytest.mark.unit
+def test_tombstone_does_not_leak_prior_payload_into_report_or_results(
+    tmp_path: Path,
+) -> None:
+    """Prior record fields must not appear in dry-run or apply reports.
+
+    The retention is delivered to the adapter only. Reports and result
+    detail strings must not serialize prior payload values, otherwise a
+    sensitive-shaped field name in a fixture would leak into reports.
+    """
+
+    _write_valid_artifacts(tmp_path, run_id="run-tomb-leak")
+    existing_path = tmp_path / "existing.json"
+    sentinel = "SECRET-SENTINEL-VALUE-MUST-NOT-LEAK"
+    prior_payload = {
+        "page_id": "stale",
+        "title": "Public Title",
+        "source_path": "docs/stale.md",
+        "source_hash": "d" * 64,
+        # A value that, if leaked into any serialized report or result,
+        # would make this test fail.
+        "internal_note": sentinel,
+    }
+    _write_existing(
+        existing_path,
+        [_stale_existing_with_payload("doc_page", "doc_page:stale", prior_payload)],
+    )
+
+    config = load_config(_write_local_dev_config(tmp_path / "config.yaml"))
+    plan = build_import_plan(tmp_path, "run-tomb-leak")
+    reconcile_report = reconcile_import_plan(
+        plan, load_existing_records(existing_path)
+    )
+
+    # Dry-run reconcile report must not contain the sentinel.
+    reconcile_payload = json.dumps(reconcile_report.to_payload(), sort_keys=True)
+    assert sentinel not in reconcile_payload, (
+        "reconcile report must not serialize prior record fields"
+    )
+
+    adapter = InMemoryContextApplyAdapter()
+    apply_report = execute_context_apply(
+        reconcile_report=reconcile_report,
+        config=config,
+        run_id="run-tomb-leak",
+        apply_mode=APPLY_MODE_LOCAL_DEV,
+        adapter=adapter,
+        clock=FixedClock(datetime(2026, 4, 4, 0, 0, 0, tzinfo=timezone.utc)),
+    )
+
+    # Apply report (including operations + results) must not contain the
+    # sentinel either.
+    apply_payload = json.dumps(apply_report.to_payload(), sort_keys=True)
+    assert sentinel not in apply_payload, (
+        "apply report must not serialize prior record fields"
+    )
+
+    # But the adapter must have received it (retention contract).
+    _, _, _, payload = adapter.operations[-1]
+    assert payload["internal_note"] == sentinel
+    # Sanity: the in-memory adapter is the one that ran.
+    assert apply_report.adapter == ADAPTER_KIND_IN_MEMORY

--- a/tests/unit/surrealdb/test_context_import_tombstones.py
+++ b/tests/unit/surrealdb/test_context_import_tombstones.py
@@ -1,0 +1,454 @@
+"""Unit tests for tombstone handling in the apply pipeline (#2074).
+
+These tests cover:
+
+* Tombstone-only field set (no hard delete).
+* ``tombstoned_at`` is real ISO8601 UTC produced via an injected
+  :class:`core.utils.clock.ClockProvider` (no ``datetime.now`` call).
+* Determinism: a :class:`FixedClock` produces the same timestamp.
+* The default in-memory adapter exposes no delete API.
+* Reconcile ``tombstone_candidate`` actions map to apply tombstone
+  operations against the in-memory adapter, with the tombstone payload
+  carrying every required field.
+* Tombstone reason defaults to ``record_removed_from_snapshot``.
+* Per-table tombstoning works for stale records of the relevant
+  context tables (doc_page, doc_chunk, code_symbol, dependency_edge).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from core.utils.clock import FixedClock
+from tools.surrealdb.context_importer import (
+    ADAPTER_KIND_IN_MEMORY,
+    APPLY_MODE_LOCAL_DEV,
+    APPLY_OP_TOMBSTONE,
+    InMemoryContextApplyAdapter,
+    TOMBSTONE_FIELD_AT,
+    TOMBSTONE_FIELD_FLAG,
+    TOMBSTONE_FIELD_LAST_SEEN_RUN_ID,
+    TOMBSTONE_FIELD_REASON,
+    TOMBSTONE_FIELD_SUPERSEDED_BY,
+    TOMBSTONE_REASON_REMOVED_FROM_SNAPSHOT,
+    TOMBSTONE_REQUIRED_FIELDS,
+    ApplyAdapterError,
+    build_import_plan,
+    execute_context_apply,
+    load_config,
+    load_existing_records,
+    reconcile_import_plan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Local helpers (mirror style of test_context_import_apply.py)
+# ---------------------------------------------------------------------------
+
+
+def _write_valid_artifacts(tmp_path: Path, *, run_id: str = "run-tomb-1") -> None:
+    rows: dict[str, list[dict[str, Any]]] = {
+        "repo_artifacts.jsonl": [
+            {
+                "schema_version": "context-indexer/v0",
+                "run_id": run_id,
+                "artifact_id": "art-1",
+                "source_path": "docs/example.md",
+                "file_type": "markdown",
+                "raw_sha256": "a" * 64,
+                "normalized_sha256": "a" * 64,
+                "source_hash": "a" * 64,
+                "integrity_algo": "sha256",
+                "size_bytes": 12,
+                "sensitivity": "public",
+            }
+        ],
+        "doc_pages.jsonl": [
+            {
+                "schema_version": "context-indexer/v0",
+                "run_id": run_id,
+                "page_id": "page-example",
+                "source_path": "docs/example.md",
+                "source_hash": "a" * 64,
+                "title": "Example",
+            }
+        ],
+        "doc_sections.jsonl": [],
+        "doc_chunks.jsonl": [],
+        "code_symbols.jsonl": [],
+        "import_references.jsonl": [],
+        "test_cases.jsonl": [],
+        "config_references.jsonl": [],
+        "doc_code_links.jsonl": [],
+        "dependency_edges.jsonl": [],
+    }
+    for name, items in rows.items():
+        path = tmp_path / name
+        with path.open("w", encoding="utf-8") as handle:
+            for item in items:
+                handle.write(json.dumps(item, sort_keys=True) + "\n")
+
+
+def _write_existing(path: Path, records: list[dict[str, Any]]) -> None:
+    path.write_text(json.dumps(records, sort_keys=True), encoding="utf-8")
+
+
+def _write_local_dev_config(path: Path) -> Path:
+    from tools.surrealdb.context_importer import (
+        ALLOWED_CONTEXT_IMPORT_TABLES,
+        FORBIDDEN_CONTEXT_IMPORT_TABLES,
+    )
+
+    forbidden = sorted(FORBIDDEN_CONTEXT_IMPORT_TABLES)
+    allowed = sorted(ALLOWED_CONTEXT_IMPORT_TABLES)
+    body = (
+        "schema_version: context-import-local/v0\n"
+        "surreal_url: ws://127.0.0.1:8000/rpc\n"
+        "namespace: cdb_ctx\n"
+        "database: context\n"
+        "auth_mode: none\n"
+        "timeout: 5\n"
+        "allow_apply_default: false\n"
+        "allowed_tables:\n"
+        + "".join(f"  - {t}\n" for t in allowed)
+        + "forbidden_tables:\n"
+        + "".join(f"  - {t}\n" for t in forbidden)
+    )
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _stale_existing(table: str, record_id: str) -> dict[str, Any]:
+    return {
+        "table": table,
+        "record_id": record_id,
+        "payload_hash": "e" * 64,
+        "schema_version": "context-importer/v0",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_tombstone_field_set_is_pinned() -> None:
+    assert TOMBSTONE_FIELD_FLAG == "tombstoned"
+    assert TOMBSTONE_FIELD_AT == "tombstoned_at"
+    assert TOMBSTONE_FIELD_REASON == "tombstone_reason"
+    assert TOMBSTONE_FIELD_LAST_SEEN_RUN_ID == "last_seen_run_id"
+    assert TOMBSTONE_FIELD_SUPERSEDED_BY == "superseded_by"
+    assert TOMBSTONE_REQUIRED_FIELDS == frozenset(
+        {
+            "tombstoned",
+            "tombstoned_at",
+            "tombstone_reason",
+            "last_seen_run_id",
+            "superseded_by",
+        }
+    )
+
+
+@pytest.mark.unit
+def test_tombstone_default_reason_is_record_removed_from_snapshot() -> None:
+    assert TOMBSTONE_REASON_REMOVED_FROM_SNAPSHOT == "record_removed_from_snapshot"
+
+
+# ---------------------------------------------------------------------------
+# Adapter contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_in_memory_adapter_has_no_hard_delete() -> None:
+    """#2074: tombstone-only; no hard delete API exists."""
+
+    adapter = InMemoryContextApplyAdapter()
+    assert not hasattr(adapter, "delete")
+    assert not hasattr(adapter, "apply_delete")
+    assert not hasattr(adapter, "hard_delete")
+
+
+@pytest.mark.unit
+def test_in_memory_adapter_rejects_tombstone_missing_fields() -> None:
+    adapter = InMemoryContextApplyAdapter()
+    with pytest.raises(ApplyAdapterError):
+        adapter.apply_tombstone("doc_page", "doc_page:x", {"tombstoned": True})
+
+
+@pytest.mark.unit
+def test_in_memory_adapter_rejects_tombstone_with_flag_false() -> None:
+    adapter = InMemoryContextApplyAdapter()
+    payload = {
+        TOMBSTONE_FIELD_FLAG: False,
+        TOMBSTONE_FIELD_AT: "2026-01-01T00:00:00Z",
+        TOMBSTONE_FIELD_REASON: "record_removed_from_snapshot",
+        TOMBSTONE_FIELD_LAST_SEEN_RUN_ID: None,
+        TOMBSTONE_FIELD_SUPERSEDED_BY: None,
+    }
+    with pytest.raises(ApplyAdapterError):
+        adapter.apply_tombstone("doc_page", "doc_page:x", payload)
+
+
+@pytest.mark.unit
+def test_in_memory_adapter_keeps_record_after_tombstone() -> None:
+    """Tombstone never deletes; the record stays and gains tombstone fields."""
+
+    adapter = InMemoryContextApplyAdapter()
+    adapter.apply_create(
+        "doc_page", "doc_page:keep", {"page_id": "keep", "title": "Old"}
+    )
+    adapter.apply_tombstone(
+        "doc_page",
+        "doc_page:keep",
+        {
+            TOMBSTONE_FIELD_FLAG: True,
+            TOMBSTONE_FIELD_AT: "2026-01-01T12:00:00Z",
+            TOMBSTONE_FIELD_REASON: TOMBSTONE_REASON_REMOVED_FROM_SNAPSHOT,
+            TOMBSTONE_FIELD_LAST_SEEN_RUN_ID: "run-prev",
+            TOMBSTONE_FIELD_SUPERSEDED_BY: None,
+        },
+    )
+    record = adapter.records["doc_page:keep"]
+    assert record["title"] == "Old"  # original payload preserved
+    assert record[TOMBSTONE_FIELD_FLAG] is True
+    assert record[TOMBSTONE_FIELD_AT] == "2026-01-01T12:00:00Z"
+    assert record[TOMBSTONE_FIELD_REASON] == TOMBSTONE_REASON_REMOVED_FROM_SNAPSHOT
+
+
+# ---------------------------------------------------------------------------
+# Apply: tombstone candidates from reconcile
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_stale_doc_page_is_tombstoned_with_real_iso8601(tmp_path: Path) -> None:
+    """tombstoned_at must be real ISO8601 UTC, not a sentinel marker."""
+
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(existing, [_stale_existing("doc_page", "doc_page:stale")])
+
+    config = load_config(_write_local_dev_config(tmp_path / "config.yaml"))
+    plan = build_import_plan(tmp_path, "run-tomb-1")
+    reconcile = reconcile_import_plan(plan, load_existing_records(existing))
+
+    fixed = datetime(2026, 1, 15, 9, 30, 0, tzinfo=timezone.utc)
+    adapter = InMemoryContextApplyAdapter()
+    report = execute_context_apply(
+        reconcile_report=reconcile,
+        config=config,
+        run_id="run-tomb-1",
+        apply_mode=APPLY_MODE_LOCAL_DEV,
+        adapter=adapter,
+        clock=FixedClock(fixed),
+    )
+
+    tomb_results = [r for r in report.results if r.op == APPLY_OP_TOMBSTONE]
+    assert len(tomb_results) == 1
+    result = tomb_results[0]
+    assert result.status == "applied"
+    assert result.record_id == "doc_page:stale"
+    # ISO8601 UTC with explicit Z, no placeholder.
+    assert result.tombstoned_at == "2026-01-15T09:30:00Z"
+    assert "<run-derived>" not in (result.tombstoned_at or "")
+
+    # The adapter saw the tombstone with the full required field set.
+    op_kind, table, record_id, payload = adapter.operations[-1]
+    assert op_kind == APPLY_OP_TOMBSTONE
+    assert table == "doc_page"
+    assert record_id == "doc_page:stale"
+    assert TOMBSTONE_REQUIRED_FIELDS.issubset(payload.keys())
+    assert payload[TOMBSTONE_FIELD_FLAG] is True
+    assert payload[TOMBSTONE_FIELD_AT] == "2026-01-15T09:30:00Z"
+    assert (
+        payload[TOMBSTONE_FIELD_REASON] == TOMBSTONE_REASON_REMOVED_FROM_SNAPSHOT
+    )
+
+
+@pytest.mark.unit
+def test_tombstoned_at_is_deterministic_with_fixed_clock(tmp_path: Path) -> None:
+    """Two apply runs with the same FixedClock produce the same tombstoned_at."""
+
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(existing, [_stale_existing("doc_page", "doc_page:stale")])
+    config = load_config(_write_local_dev_config(tmp_path / "config.yaml"))
+    plan = build_import_plan(tmp_path, "run-tomb-1")
+    reconcile = reconcile_import_plan(plan, load_existing_records(existing))
+
+    fixed = datetime(2026, 1, 15, 9, 30, 0, tzinfo=timezone.utc)
+
+    def _ts() -> str | None:
+        report = execute_context_apply(
+            reconcile_report=reconcile,
+            config=config,
+            run_id="run-tomb-1",
+            apply_mode=APPLY_MODE_LOCAL_DEV,
+            adapter=InMemoryContextApplyAdapter(),
+            clock=FixedClock(fixed),
+        )
+        tomb = [r for r in report.results if r.op == APPLY_OP_TOMBSTONE][0]
+        return tomb.tombstoned_at
+
+    assert _ts() == _ts() == "2026-01-15T09:30:00Z"
+
+
+@pytest.mark.unit
+def test_tombstoned_at_changes_when_clock_changes(tmp_path: Path) -> None:
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(existing, [_stale_existing("doc_page", "doc_page:stale")])
+    config = load_config(_write_local_dev_config(tmp_path / "config.yaml"))
+    plan = build_import_plan(tmp_path, "run-tomb-1")
+    reconcile = reconcile_import_plan(plan, load_existing_records(existing))
+
+    def _ts(at: datetime) -> str | None:
+        report = execute_context_apply(
+            reconcile_report=reconcile,
+            config=config,
+            run_id="run-tomb-1",
+            apply_mode=APPLY_MODE_LOCAL_DEV,
+            adapter=InMemoryContextApplyAdapter(),
+            clock=FixedClock(at),
+        )
+        return [r for r in report.results if r.op == APPLY_OP_TOMBSTONE][0].tombstoned_at
+
+    a = _ts(datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc))
+    b = _ts(datetime(2026, 6, 30, 23, 59, 59, tzinfo=timezone.utc))
+    assert a == "2026-01-01T00:00:00Z"
+    assert b == "2026-06-30T23:59:59Z"
+    assert a != b
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("table", "record_id"),
+    [
+        ("doc_page", "doc_page:stale-page"),
+        ("doc_chunk", "doc_chunk:stale-chunk"),
+        ("code_symbol", "code_symbol:stale-symbol"),
+        ("dependency_edge", "dependency_edge:stale-edge"),
+    ],
+)
+def test_tombstone_works_for_each_context_table(
+    table: str, record_id: str, tmp_path: Path
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(existing, [_stale_existing(table, record_id)])
+    config = load_config(_write_local_dev_config(tmp_path / "config.yaml"))
+    plan = build_import_plan(tmp_path, "run-tomb-1")
+    reconcile = reconcile_import_plan(plan, load_existing_records(existing))
+
+    adapter = InMemoryContextApplyAdapter()
+    report = execute_context_apply(
+        reconcile_report=reconcile,
+        config=config,
+        run_id="run-tomb-1",
+        apply_mode=APPLY_MODE_LOCAL_DEV,
+        adapter=adapter,
+        clock=FixedClock(datetime(2026, 1, 1, tzinfo=timezone.utc)),
+    )
+    tomb = [r for r in report.results if r.op == APPLY_OP_TOMBSTONE]
+    assert len(tomb) == 1
+    assert tomb[0].record_id == record_id
+    assert tomb[0].status == "applied"
+    # Adapter records persist (no hard delete).
+    assert record_id in adapter.records
+    assert adapter.records[record_id][TOMBSTONE_FIELD_FLAG] is True
+
+
+@pytest.mark.unit
+def test_tombstone_payload_default_reason_is_record_removed_from_snapshot(
+    tmp_path: Path,
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(existing, [_stale_existing("doc_page", "doc_page:stale")])
+    config = load_config(_write_local_dev_config(tmp_path / "config.yaml"))
+    plan = build_import_plan(tmp_path, "run-tomb-1")
+    reconcile = reconcile_import_plan(plan, load_existing_records(existing))
+
+    adapter = InMemoryContextApplyAdapter()
+    execute_context_apply(
+        reconcile_report=reconcile,
+        config=config,
+        run_id="run-tomb-1",
+        apply_mode=APPLY_MODE_LOCAL_DEV,
+        adapter=adapter,
+        clock=FixedClock(datetime(2026, 1, 1, tzinfo=timezone.utc)),
+    )
+    op_kind, _, _, payload = adapter.operations[-1]
+    assert op_kind == APPLY_OP_TOMBSTONE
+    assert payload[TOMBSTONE_FIELD_REASON] == TOMBSTONE_REASON_REMOVED_FROM_SNAPSHOT
+
+
+@pytest.mark.unit
+def test_tombstone_payload_carries_run_id(tmp_path: Path) -> None:
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(existing, [_stale_existing("doc_page", "doc_page:stale")])
+    config = load_config(_write_local_dev_config(tmp_path / "config.yaml"))
+    plan = build_import_plan(tmp_path, "run-tomb-1")
+    reconcile = reconcile_import_plan(plan, load_existing_records(existing))
+
+    adapter = InMemoryContextApplyAdapter()
+    execute_context_apply(
+        reconcile_report=reconcile,
+        config=config,
+        run_id="run-tomb-1",
+        apply_mode=APPLY_MODE_LOCAL_DEV,
+        adapter=adapter,
+        clock=FixedClock(datetime(2026, 1, 1, tzinfo=timezone.utc)),
+    )
+    _, _, _, payload = adapter.operations[-1]
+    assert payload["run_id"] == "run-tomb-1"
+    # superseded_by is intentionally None in v0; no chain replacement support.
+    assert payload[TOMBSTONE_FIELD_SUPERSEDED_BY] is None
+
+
+@pytest.mark.unit
+def test_apply_pipeline_uses_injected_clock_not_datetime_now(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Regression guard: the apply path must not call datetime.now()."""
+
+    _write_valid_artifacts(tmp_path)
+    existing = tmp_path / "existing.json"
+    _write_existing(existing, [_stale_existing("doc_page", "doc_page:stale")])
+    config = load_config(_write_local_dev_config(tmp_path / "config.yaml"))
+    plan = build_import_plan(tmp_path, "run-tomb-1")
+    reconcile = reconcile_import_plan(plan, load_existing_records(existing))
+
+    # If anything in the apply path called datetime.now()/utcnow(), this
+    # would explode. The injected FixedClock produces all timestamps.
+    import tools.surrealdb.context_importer as ci
+
+    class _ExplodingDatetime:
+        @classmethod
+        def now(cls, *a, **kw):  # pragma: no cover - guard
+            raise AssertionError("apply must use injected clock, not datetime.now()")
+
+        @classmethod
+        def utcnow(cls):  # pragma: no cover - guard
+            raise AssertionError("apply must use injected clock, not datetime.utcnow()")
+
+    monkeypatch.setattr(ci, "datetime", _ExplodingDatetime)
+
+    report = execute_context_apply(
+        reconcile_report=reconcile,
+        config=config,
+        run_id="run-tomb-1",
+        apply_mode=APPLY_MODE_LOCAL_DEV,
+        adapter=InMemoryContextApplyAdapter(),
+        clock=FixedClock(datetime(2026, 1, 1, tzinfo=timezone.utc)),
+    )
+    tomb = [r for r in report.results if r.op == APPLY_OP_TOMBSTONE][0]
+    assert tomb.tombstoned_at == "2026-01-01T00:00:00Z"

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -52,8 +52,10 @@ Exit codes (aligned with the context-indexer contract):
 from __future__ import annotations
 
 import argparse
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import copy
 import hashlib
 import json
 import logging
@@ -575,6 +577,15 @@ class ExistingRecord:
     record_id: str
     payload_hash: str | None
     schema_version: str | None
+    # Optional verbatim copy of the prior record payload (control keys
+    # like ``__line``/``payload_hash``/``schema_version``/``table``/
+    # ``record_id``/``id`` already stripped). Carried forward so the
+    # tombstone apply path can preserve original record fields per
+    # context-importer-cli-contract.md §5.3 ("Der Adapter ueberschreibt
+    # das Original-Record nicht; es bleibt erhalten und bekommt die
+    # Tombstone-Felder dazu."). Never serialized into reports to avoid
+    # payload leakage; consumed only by the apply pipeline.
+    payload: Mapping[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -604,6 +615,13 @@ class ReconcileAction:
     reason: str
     payload_hash: str | None
     existing_payload_hash: str | None
+    # Optional verbatim copy of the prior record payload, only populated
+    # for ``tombstone_candidate`` actions whose existing record carried a
+    # ``payload`` object in the existing-records fixture. Plumbed to the
+    # apply pipeline so tombstones can preserve original record fields.
+    # Intentionally **not** included in :meth:`to_payload` to avoid
+    # leaking record contents into dry-run/apply reports.
+    existing_payload: Mapping[str, Any] | None = None
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -782,6 +800,13 @@ class ContextApplyOperation:
     source_ref: str | None
     reason: str
     note: str | None = None
+    # Optional verbatim prior-record payload (control keys stripped),
+    # only populated for tombstone operations whose source ``ExistingRecord``
+    # carried a ``payload`` object. Consumed by ``_build_payload_for_op`` so
+    # tombstones preserve original record fields under the tombstone
+    # metadata. Intentionally **not** included in :meth:`to_payload` to
+    # avoid leaking record contents into apply reports.
+    existing_payload: Mapping[str, Any] | None = None
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -1042,17 +1067,32 @@ def _build_payload_for_op(
 
     if op.op == APPLY_OP_TOMBSTONE:
         ts_iso = _isoformat_utc(clock.now())
-        payload = {
-            TOMBSTONE_FIELD_FLAG: True,
-            TOMBSTONE_FIELD_AT: ts_iso,
-            TOMBSTONE_FIELD_REASON: op.reason or TOMBSTONE_REASON_REMOVED_FROM_SNAPSHOT,
-            TOMBSTONE_FIELD_LAST_SEEN_RUN_ID: last_seen_run_id,
-            TOMBSTONE_FIELD_SUPERSEDED_BY: None,
-            "table": op.table,
-            "record_id": op.record_id,
-            "run_id": run_id,
-            "payload_hash": op.existing_payload_hash,
-        }
+        # Start from the prior record payload (when available) so the
+        # tombstone preserves all original record fields, then overlay
+        # the tombstone metadata + identity fields. Per
+        # context-importer-cli-contract.md §5.3 the adapter must keep
+        # the original record and only add tombstone fields. When no
+        # prior payload is available (e.g. hash-only existing-records
+        # entry, or no --existing-records fixture), the payload remains
+        # the deterministic minimal shape. Tombstone metadata and
+        # identity keys always win over any colliding prior field.
+        payload: dict[str, Any] = {}
+        if op.existing_payload is not None:
+            payload.update(copy.deepcopy(dict(op.existing_payload)))
+        payload.update(
+            {
+                TOMBSTONE_FIELD_FLAG: True,
+                TOMBSTONE_FIELD_AT: ts_iso,
+                TOMBSTONE_FIELD_REASON: op.reason
+                or TOMBSTONE_REASON_REMOVED_FROM_SNAPSHOT,
+                TOMBSTONE_FIELD_LAST_SEEN_RUN_ID: last_seen_run_id,
+                TOMBSTONE_FIELD_SUPERSEDED_BY: None,
+                "table": op.table,
+                "record_id": op.record_id,
+                "run_id": run_id,
+                "payload_hash": op.existing_payload_hash,
+            }
+        )
         return payload, ts_iso
 
     payload = {
@@ -1116,6 +1156,7 @@ def _operations_from_reconcile(
                     existing_payload_hash=action.existing_payload_hash,
                     source_ref=action.source_ref,
                     reason=action.reason or TOMBSTONE_REASON_REMOVED_FROM_SNAPSHOT,
+                    existing_payload=action.existing_payload,
                 )
             )
         # ``skip`` is intentionally dropped; nothing to apply.
@@ -1901,11 +1942,34 @@ def _existing_record_from_raw(raw: dict[str, Any]) -> ExistingRecord:
         raise ExistingRecordsValidationError(
             "existing record must provide payload_hash or object payload"
         )
+    # Capture the prior-record payload (when present) so the apply
+    # pipeline can preserve original record fields under tombstone
+    # metadata. Strip control keys that belong to the fixture envelope
+    # rather than the record body, and never carry the line counter.
+    raw_payload = raw.get("payload")
+    preserved_payload: Mapping[str, Any] | None
+    if isinstance(raw_payload, dict):
+        _control_keys = {
+            "__line",
+            "payload_hash",
+            "schema_version",
+            "table",
+            "record_id",
+            "id",
+        }
+        preserved_payload = {
+            key: copy.deepcopy(value)
+            for key, value in raw_payload.items()
+            if key not in _control_keys
+        }
+    else:
+        preserved_payload = None
     return ExistingRecord(
         table=table,
         record_id=record_id,
         payload_hash=payload_hash,
         schema_version=schema_version,
+        payload=preserved_payload,
     )
 
 
@@ -2317,6 +2381,7 @@ def reconcile_import_plan(
                 reason="record_removed_from_snapshot",
                 payload_hash=None,
                 existing_payload_hash=existing.payload_hash,
+                existing_payload=existing.payload,
             )
         )
 

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -1,49 +1,70 @@
-"""SurrealDB context importer CLI scaffold (offline, dry-run by default).
+"""SurrealDB context importer CLI (offline by default; gated local apply).
 
-Issue: #2068 (Wave 10, Slice 1)
+Issues:
+    #2068 - scaffold (Wave 10, Slice 1)
+    #2069 - config loader
+    #2070 - JSONL validation
+    #2071 - plan
+    #2072 - reconcile (dry-run)
+    #2073 - explicit local apply mode (this slice)
+    #2074 - tombstone handling   (this slice)
 Parent: #2067 / Epic #1976
 
-This module implements the offline CLI scaffold for the future
-context-import pipeline plus the read-only JSONL validation slice.
-It is hard-blocked from performing any SurrealDB operation.
+This module implements the offline CLI plus a strictly gated
+local-dev apply pipeline with a mockable adapter boundary.
 
 Design rules enforced here:
 
 * Default behavior is dry-run / no-write.
-* The ``apply`` subcommand and the global ``--apply`` flag exist
-  so that downstream slices can wire real behavior, but in this
-  scaffold any apply attempt is hard-blocked with exit code 5
-  (``WRITE_DENIED``) and a deterministic error payload.
-* No SurrealDB connection is opened. ``--surreal-url``,
-  ``--namespace``, and ``--database`` are parsed but never used.
-* No config loader is invoked (that belongs to #2069).
-* No real plan / audit / rollback-plan logic exists.
+* The ``apply`` subcommand requires the explicit combination
+  ``--apply --apply-mode local-dev --config <path> --input-dir <dir>
+  --run-id <str>``; any other invocation of apply (subcommand without
+  ``--apply``, or ``--apply`` on a non-apply subcommand) is hard-blocked
+  with exit code 5 (``WRITE_DENIED``).
+* The default apply adapter is the in-memory, no-network
+  ``InMemoryContextApplyAdapter``. A real SurrealDB adapter is
+  explicitly OUT-OF-SCOPE in this slice and is not wired into the CLI.
+* The local-dev apply gate additionally requires the loaded config's
+  ``surreal_url`` host to be in ``LOCAL_DEV_ALLOWED_HOSTS``.
+* Tombstone handling is field-only (``tombstoned``, ``tombstoned_at``,
+  ``tombstone_reason``, ``last_seen_run_id``, ``superseded_by``). There
+  is no hard-delete API on the apply adapter.
+* ``tombstoned_at`` is produced via an injected
+  :class:`core.utils.clock.ClockProvider` (default: ``SystemClock``)
+  and serialized as ISO8601 UTC; tests inject a ``FixedClock`` for
+  determinism.
+* No SurrealDB connection is opened by the in-memory adapter.
 
-Subcommands implemented as scaffold stubs (per #2068 spec):
+Subcommands:
     validate-jsonl, plan, dry-run, apply, audit, rollback-plan
 
 Exit codes (aligned with the context-indexer contract):
-    0 = success / scaffold acknowledged
-    1 = validation failure (reserved; not raised in scaffold)
+    0 = success
+    1 = validation failure (incl. blocking reconcile findings on apply)
     2 = argparse usage error (raised by argparse itself)
-    3 = input-not-found (reserved; not raised in scaffold)
+    3 = input-not-found
     4 = unsupported format
-    5 = write denied (path violation OR apply attempt in scaffold)
-    6 = internal error / scaffold anomaly
+    5 = write denied (path violation, apply gate violation,
+        forbidden table at apply boundary)
+    6 = internal error
 """
 
 from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+from datetime import datetime, timezone
 import hashlib
 import json
 import logging
 from pathlib import Path
 import re
-from typing import Any
+from typing import Any, Protocol
+from urllib.parse import urlparse
 
 import yaml
+
+from core.utils.clock import ClockProvider, SystemClock
 
 logger = logging.getLogger(__name__)
 
@@ -236,6 +257,48 @@ FORBIDDEN_CONTEXT_IMPORT_TABLES = TRADING_STATE_TABLES | GOVERNANCE_MIRROR_TABLE
 ALLOWED_CONTEXT_IMPORT_TABLES = frozenset(TABLE_BY_ARTIFACT.values())
 
 ALLOWED_AUTH_MODES = frozenset({"none", "root", "scope"})
+
+# Apply mode constants (#2073). The CLI only exposes ``local-dev``;
+# any other apply mode is rejected at the gate.
+APPLY_MODE_LOCAL_DEV = "local-dev"
+SUPPORTED_APPLY_MODES = frozenset({APPLY_MODE_LOCAL_DEV})
+
+# Local-dev gate: the loaded config's ``surreal_url`` host must resolve
+# to one of these hosts. This is a defense-in-depth check; the
+# in-memory adapter never opens any socket regardless.
+LOCAL_DEV_ALLOWED_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+# Apply operation kinds (#2073/#2074). ``delete`` is intentionally not
+# part of this enum: there is no hard-delete API.
+APPLY_OP_CREATE = "create"
+APPLY_OP_UPDATE = "update"
+APPLY_OP_TOMBSTONE = "tombstone"
+APPLY_OP_KINDS = frozenset({APPLY_OP_CREATE, APPLY_OP_UPDATE, APPLY_OP_TOMBSTONE})
+
+# Tombstone field names (#2074). Adapter callers are required to set
+# these on the tombstone payload; the in-memory adapter validates the
+# shape so regressions are caught at unit-test time.
+TOMBSTONE_FIELD_FLAG = "tombstoned"
+TOMBSTONE_FIELD_AT = "tombstoned_at"
+TOMBSTONE_FIELD_REASON = "tombstone_reason"
+TOMBSTONE_FIELD_LAST_SEEN_RUN_ID = "last_seen_run_id"
+TOMBSTONE_FIELD_SUPERSEDED_BY = "superseded_by"
+TOMBSTONE_REQUIRED_FIELDS = frozenset(
+    {
+        TOMBSTONE_FIELD_FLAG,
+        TOMBSTONE_FIELD_AT,
+        TOMBSTONE_FIELD_REASON,
+        TOMBSTONE_FIELD_LAST_SEEN_RUN_ID,
+        TOMBSTONE_FIELD_SUPERSEDED_BY,
+    }
+)
+TOMBSTONE_REASON_REMOVED_FROM_SNAPSHOT = "record_removed_from_snapshot"
+
+# A real SurrealDB adapter is intentionally not implemented in this
+# slice. The CLI never selects anything other than the in-memory
+# adapter; this constant is exported for documentation / regression.
+REAL_SURREALDB_ADAPTER_AVAILABLE = False
+ADAPTER_KIND_IN_MEMORY = "in-memory"
 
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 WINDOWS_DRIVE_PREFIX_RE = re.compile(r"^[A-Za-z]:")
@@ -677,6 +740,542 @@ class ContextImportConfig:
             "allowed_tables": list(self.allowed_tables),
             "forbidden_tables": list(self.forbidden_tables),
         }
+
+
+# ---------------------------------------------------------------------------
+# Apply pipeline (#2073/#2074)
+#
+# The apply pipeline is a strictly gated local-dev path. The default
+# adapter is the in-memory :class:`InMemoryContextApplyAdapter`; it
+# never opens a network socket. A real SurrealDB adapter is OUT-OF-SCOPE
+# in this slice (``REAL_SURREALDB_ADAPTER_AVAILABLE == False``).
+# ---------------------------------------------------------------------------
+
+
+class ApplyGateError(ContextImporterError):
+    """Raised when the local-dev apply gate is not satisfied."""
+
+    code = "APPLY_GATE_DENIED"
+    exit_code = EXIT_WRITE_DENIED
+
+
+class ApplyAdapterError(ContextImporterError):
+    """Raised by an adapter to report a per-operation failure.
+
+    Caught by the executor and surfaced as a ``failed`` apply result;
+    it does not propagate out of :func:`execute_context_apply`.
+    """
+
+    code = "APPLY_ADAPTER_ERROR"
+    exit_code = EXIT_INTERNAL
+
+
+@dataclass(frozen=True)
+class ContextApplyOperation:
+    """Single normalized apply operation derived from a reconcile action."""
+
+    op: str
+    table: str
+    record_id: str
+    payload_hash: str | None
+    existing_payload_hash: str | None
+    source_ref: str | None
+    reason: str
+    note: str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "op": self.op,
+            "table": self.table,
+            "record_id": self.record_id,
+            "payload_hash": self.payload_hash,
+            "existing_payload_hash": self.existing_payload_hash,
+            "source_ref": self.source_ref,
+            "reason": self.reason,
+            "note": self.note,
+        }
+
+
+@dataclass(frozen=True)
+class ContextApplyResult:
+    """Outcome of a single :class:`ContextApplyOperation`."""
+
+    op: str
+    table: str
+    record_id: str
+    status: str  # one of: applied | skipped | failed
+    detail: str | None = None
+    tombstoned_at: str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "op": self.op,
+            "table": self.table,
+            "record_id": self.record_id,
+            "status": self.status,
+            "detail": self.detail,
+            "tombstoned_at": self.tombstoned_at,
+        }
+
+
+@dataclass(frozen=True)
+class ContextApplyReport:
+    """Deterministic, render-friendly apply report."""
+
+    schema_version: str
+    run_id: str
+    input_dir: Path
+    apply_mode: str
+    adapter: str
+    config_path: Path
+    surreal_url: str
+    namespace: str
+    database: str
+    operations: tuple[ContextApplyOperation, ...]
+    results: tuple[ContextApplyResult, ...]
+    blocking_findings_present: bool
+    blocking_finding_codes: tuple[str, ...]
+    apply_executed: bool
+    status: str
+    note: str
+
+    def counts(self) -> dict[str, int]:
+        c = {
+            "creates": 0,
+            "updates": 0,
+            "tombstones": 0,
+            "applied": 0,
+            "skipped": 0,
+            "failed": 0,
+            "blocked": 0,
+        }
+        for op in self.operations:
+            if op.op == APPLY_OP_CREATE:
+                c["creates"] += 1
+            elif op.op == APPLY_OP_UPDATE:
+                c["updates"] += 1
+            elif op.op == APPLY_OP_TOMBSTONE:
+                c["tombstones"] += 1
+        for res in self.results:
+            if res.status == "applied":
+                c["applied"] += 1
+            elif res.status == "skipped":
+                c["skipped"] += 1
+            elif res.status == "failed":
+                c["failed"] += 1
+            elif res.status == "blocked":
+                c["blocked"] += 1
+        return c
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "command": "apply",
+            "run_id": self.run_id,
+            "input_dir": str(self.input_dir),
+            "apply_mode": self.apply_mode,
+            "adapter": self.adapter,
+            "config_path": str(self.config_path),
+            "surreal_url": self.surreal_url,
+            "namespace": self.namespace,
+            "database": self.database,
+            "dry_run": False,
+            "apply_requested": True,
+            "apply_executed": self.apply_executed,
+            "surrealdb_connection": "in-memory-no-network",
+            "surrealdb_writes": "in-memory-only",
+            "real_surrealdb_adapter_available": REAL_SURREALDB_ADAPTER_AVAILABLE,
+            "implemented": True,
+            "status": self.status,
+            "note": self.note,
+            "operations": [op.to_payload() for op in self.operations],
+            "results": [res.to_payload() for res in self.results],
+            "counts": self.counts(),
+            "blocking_findings_present": self.blocking_findings_present,
+            "blocking_finding_codes": list(self.blocking_finding_codes),
+        }
+
+
+class ContextApplyAdapter(Protocol):
+    """Mockable apply boundary.
+
+    Implementations must perform no network I/O unless the caller
+    explicitly opts in. The default :class:`InMemoryContextApplyAdapter`
+    keeps everything in-process.
+    """
+
+    kind: str
+
+    def apply_create(
+        self, table: str, record_id: str, payload: dict[str, Any]
+    ) -> None: ...
+
+    def apply_update(
+        self, table: str, record_id: str, payload: dict[str, Any]
+    ) -> None: ...
+
+    def apply_tombstone(
+        self, table: str, record_id: str, payload: dict[str, Any]
+    ) -> None: ...
+
+
+class InMemoryContextApplyAdapter:
+    """Default in-memory, no-network apply adapter for tests and local dev.
+
+    Records every operation in :attr:`operations` so tests can assert
+    against the exact sequence. Has no ``delete`` API by design (#2074).
+    """
+
+    kind: str = ADAPTER_KIND_IN_MEMORY
+
+    def __init__(self) -> None:
+        self.operations: list[tuple[str, str, str, dict[str, Any]]] = []
+        self.records: dict[str, dict[str, Any]] = {}
+
+    # No `delete` method exists. This is intentional and is asserted by
+    # tests in tests/unit/surrealdb/test_context_import_tombstones.py.
+
+    def apply_create(
+        self, table: str, record_id: str, payload: dict[str, Any]
+    ) -> None:
+        self.operations.append((APPLY_OP_CREATE, table, record_id, dict(payload)))
+        self.records[record_id] = dict(payload)
+
+    def apply_update(
+        self, table: str, record_id: str, payload: dict[str, Any]
+    ) -> None:
+        self.operations.append((APPLY_OP_UPDATE, table, record_id, dict(payload)))
+        self.records[record_id] = dict(payload)
+
+    def apply_tombstone(
+        self, table: str, record_id: str, payload: dict[str, Any]
+    ) -> None:
+        missing = TOMBSTONE_REQUIRED_FIELDS - set(payload.keys())
+        if missing:
+            raise ApplyAdapterError(
+                f"tombstone payload missing required fields: {sorted(missing)}"
+            )
+        if payload.get(TOMBSTONE_FIELD_FLAG) is not True:
+            raise ApplyAdapterError(
+                f"tombstone payload must set {TOMBSTONE_FIELD_FLAG!r} to True"
+            )
+        self.operations.append((APPLY_OP_TOMBSTONE, table, record_id, dict(payload)))
+        # Tombstone updates the record in place; no hard delete.
+        existing = self.records.get(record_id, {})
+        existing.update(payload)
+        self.records[record_id] = existing
+
+
+def _isoformat_utc(dt: datetime) -> str:
+    """Serialize a datetime to ISO8601 UTC with a trailing ``Z``.
+
+    Accepts naive datetimes (treated as UTC) or aware datetimes (converted
+    to UTC). Returns deterministic output for a fixed input.
+    """
+
+    if dt.tzinfo is None:
+        aware = dt.replace(tzinfo=timezone.utc)
+    else:
+        aware = dt.astimezone(timezone.utc)
+    # Drop tzinfo in formatting and append explicit Z to keep the contract
+    # stable across Python versions.
+    return aware.replace(tzinfo=None).isoformat() + "Z"
+
+
+def _validate_local_dev_url(surreal_url: str) -> None:
+    """Reject any non-local-dev SurrealDB URL when the local-dev gate is active."""
+
+    parsed = urlparse(surreal_url)
+    host = (parsed.hostname or "").lower()
+    if host not in LOCAL_DEV_ALLOWED_HOSTS:
+        raise ApplyGateError(
+            "local-dev apply requires a localhost surreal_url; "
+            f"got host={host!r}, allowed={sorted(LOCAL_DEV_ALLOWED_HOSTS)}"
+        )
+
+
+def _validate_apply_table_policy(
+    table: str, *, allowed: frozenset[str], forbidden: frozenset[str]
+) -> None:
+    if table in forbidden or table in FORBIDDEN_CONTEXT_IMPORT_TABLES:
+        raise ApplyGateError(
+            f"apply target table is forbidden: {table!r}"
+        )
+    if table not in allowed and table not in ALLOWED_CONTEXT_IMPORT_TABLES:
+        raise ApplyGateError(
+            f"apply target table is not in the allowed set: {table!r}"
+        )
+
+
+def _build_payload_for_op(
+    op: ContextApplyOperation,
+    *,
+    run_id: str,
+    clock: ClockProvider,
+    last_seen_run_id: str | None,
+) -> tuple[dict[str, Any], str | None]:
+    """Build the adapter payload for a single operation.
+
+    Returns ``(payload, tombstoned_at_iso)``. ``tombstoned_at_iso`` is
+    only set for tombstone operations.
+    """
+
+    if op.op == APPLY_OP_TOMBSTONE:
+        ts_iso = _isoformat_utc(clock.now())
+        payload = {
+            TOMBSTONE_FIELD_FLAG: True,
+            TOMBSTONE_FIELD_AT: ts_iso,
+            TOMBSTONE_FIELD_REASON: op.reason or TOMBSTONE_REASON_REMOVED_FROM_SNAPSHOT,
+            TOMBSTONE_FIELD_LAST_SEEN_RUN_ID: last_seen_run_id,
+            TOMBSTONE_FIELD_SUPERSEDED_BY: None,
+            "table": op.table,
+            "record_id": op.record_id,
+            "run_id": run_id,
+            "payload_hash": op.existing_payload_hash,
+        }
+        return payload, ts_iso
+
+    payload = {
+        "table": op.table,
+        "record_id": op.record_id,
+        "run_id": run_id,
+        "payload_hash": op.payload_hash,
+    }
+    return payload, None
+
+
+def _operations_from_reconcile(
+    report: ReconcileReport,
+) -> tuple[ContextApplyOperation, ...]:
+    """Map reconcile actions to apply operations.
+
+    ``skip`` actions are dropped (they would do nothing and we surface
+    the count via the reconcile report counts already).
+    """
+
+    ops: list[ContextApplyOperation] = []
+    # Track previously-tombstoned records (best-effort heuristic on
+    # existing_payload_hash being equal to a sentinel later; for now
+    # we surface re-emergence as a note when reason hints at it).
+    for action in report.actions:
+        if action.action == "create":
+            ops.append(
+                ContextApplyOperation(
+                    op=APPLY_OP_CREATE,
+                    table=action.table,
+                    record_id=action.record_id,
+                    payload_hash=action.payload_hash,
+                    existing_payload_hash=action.existing_payload_hash,
+                    source_ref=action.source_ref,
+                    reason=action.reason,
+                )
+            )
+        elif action.action == "update_candidate":
+            note: str | None = None
+            if action.reason == "record_changed_after_tombstone":
+                note = "re-emerged_after_tombstone"
+            ops.append(
+                ContextApplyOperation(
+                    op=APPLY_OP_UPDATE,
+                    table=action.table,
+                    record_id=action.record_id,
+                    payload_hash=action.payload_hash,
+                    existing_payload_hash=action.existing_payload_hash,
+                    source_ref=action.source_ref,
+                    reason=action.reason,
+                    note=note,
+                )
+            )
+        elif action.action == "tombstone_candidate":
+            ops.append(
+                ContextApplyOperation(
+                    op=APPLY_OP_TOMBSTONE,
+                    table=action.table,
+                    record_id=action.record_id,
+                    payload_hash=None,
+                    existing_payload_hash=action.existing_payload_hash,
+                    source_ref=action.source_ref,
+                    reason=action.reason or TOMBSTONE_REASON_REMOVED_FROM_SNAPSHOT,
+                )
+            )
+        # ``skip`` is intentionally dropped; nothing to apply.
+    # Deterministic ordering: by (op kind order, table, record_id).
+    op_order = {APPLY_OP_CREATE: 0, APPLY_OP_UPDATE: 1, APPLY_OP_TOMBSTONE: 2}
+    ops.sort(key=lambda o: (op_order[o.op], o.table, o.record_id))
+    return tuple(ops)
+
+
+def execute_context_apply(
+    *,
+    reconcile_report: ReconcileReport,
+    config: ContextImportConfig,
+    run_id: str,
+    apply_mode: str,
+    adapter: ContextApplyAdapter | None = None,
+    clock: ClockProvider | None = None,
+) -> ContextApplyReport:
+    """Execute the gated local-dev apply pipeline.
+
+    The gate caller is responsible for verifying CLI flags. This function
+    additionally enforces:
+
+    * apply mode is supported,
+    * ``config.surreal_url`` host is local-dev,
+    * ``config.allow_apply_default`` is False (defense-in-depth; the
+      config loader already rejects ``True``),
+    * no blocking reconcile findings,
+    * each operation's table is in the allowed set and not forbidden.
+
+    On any blocking-findings condition the function returns a report
+    with ``apply_executed=False`` and ``status="blocked"``; no adapter
+    method is called.
+    """
+
+    if apply_mode not in SUPPORTED_APPLY_MODES:
+        raise ApplyGateError(
+            f"unsupported apply_mode: {apply_mode!r}; "
+            f"allowed: {sorted(SUPPORTED_APPLY_MODES)}"
+        )
+    if config.allow_apply_default:
+        # Defense in depth; load_config already rejects True.
+        raise ApplyGateError(
+            "config.allow_apply_default must be False for context apply"
+        )
+    _validate_local_dev_url(config.surreal_url)
+
+    used_adapter: ContextApplyAdapter = adapter or InMemoryContextApplyAdapter()
+    used_clock: ClockProvider = clock or SystemClock()
+
+    blocking_codes = tuple(
+        sorted({f.code for f in reconcile_report.findings if f.severity == "blocking"})
+    )
+    if blocking_codes:
+        return ContextApplyReport(
+            schema_version=SCHEMA_VERSION,
+            run_id=run_id,
+            input_dir=reconcile_report.input_dir,
+            apply_mode=apply_mode,
+            adapter=used_adapter.kind,
+            config_path=config.path,
+            surreal_url=config.surreal_url,
+            namespace=config.namespace,
+            database=config.database,
+            operations=(),
+            results=(),
+            blocking_findings_present=True,
+            blocking_finding_codes=blocking_codes,
+            apply_executed=False,
+            status="blocked",
+            note=(
+                "apply blocked by reconcile blocking findings; "
+                "no adapter operation was performed"
+            ),
+        )
+
+    operations = _operations_from_reconcile(reconcile_report)
+
+    allowed_tables = frozenset(config.allowed_tables)
+    forbidden_tables = frozenset(config.forbidden_tables)
+
+    results: list[ContextApplyResult] = []
+    for op in operations:
+        try:
+            _validate_apply_table_policy(
+                op.table, allowed=allowed_tables, forbidden=forbidden_tables
+            )
+        except ApplyGateError as exc:
+            results.append(
+                ContextApplyResult(
+                    op=op.op,
+                    table=op.table,
+                    record_id=op.record_id,
+                    status="blocked",
+                    detail=exc.message,
+                )
+            )
+            continue
+
+        payload, tombstoned_at = _build_payload_for_op(
+            op,
+            run_id=run_id,
+            clock=used_clock,
+            last_seen_run_id=None,
+        )
+        try:
+            if op.op == APPLY_OP_CREATE:
+                used_adapter.apply_create(op.table, op.record_id, payload)
+            elif op.op == APPLY_OP_UPDATE:
+                used_adapter.apply_update(op.table, op.record_id, payload)
+            elif op.op == APPLY_OP_TOMBSTONE:
+                used_adapter.apply_tombstone(op.table, op.record_id, payload)
+            else:  # pragma: no cover - defensive; enum-bounded above
+                raise ApplyAdapterError(f"unknown apply op: {op.op!r}")
+        except ApplyAdapterError as exc:
+            results.append(
+                ContextApplyResult(
+                    op=op.op,
+                    table=op.table,
+                    record_id=op.record_id,
+                    status="failed",
+                    detail=exc.message,
+                    tombstoned_at=tombstoned_at,
+                )
+            )
+            continue
+        except Exception as exc:  # noqa: BLE001 - adapter contract surface
+            results.append(
+                ContextApplyResult(
+                    op=op.op,
+                    table=op.table,
+                    record_id=op.record_id,
+                    status="failed",
+                    detail=f"adapter raised: {exc.__class__.__name__}: {exc}",
+                    tombstoned_at=tombstoned_at,
+                )
+            )
+            continue
+
+        results.append(
+            ContextApplyResult(
+                op=op.op,
+                table=op.table,
+                record_id=op.record_id,
+                status="applied",
+                detail=op.note,
+                tombstoned_at=tombstoned_at,
+            )
+        )
+
+    any_failed = any(r.status == "failed" for r in results)
+    any_blocked = any(r.status == "blocked" for r in results)
+    if any_failed or any_blocked:
+        status = "partial"
+    elif not operations:
+        status = "noop"
+    else:
+        status = "applied"
+
+    return ContextApplyReport(
+        schema_version=SCHEMA_VERSION,
+        run_id=run_id,
+        input_dir=reconcile_report.input_dir,
+        apply_mode=apply_mode,
+        adapter=used_adapter.kind,
+        config_path=config.path,
+        surreal_url=config.surreal_url,
+        namespace=config.namespace,
+        database=config.database,
+        operations=operations,
+        results=tuple(results),
+        blocking_findings_present=False,
+        blocking_finding_codes=(),
+        apply_executed=True,
+        status=status,
+        note=(
+            "local-dev apply executed against in-memory adapter; "
+            "no production SurrealDB activation, no default write"
+        ),
+    )
 
 
 def _validate_format(fmt: str) -> str:
@@ -2225,8 +2824,23 @@ def build_parser() -> argparse.ArgumentParser:
             "--apply",
             action="store_true",
             help=(
-                "Opt in to write/apply. HARD-BLOCKED in #2068; any use of "
-                "this flag exits with code 5 (WRITE_DENIED)."
+                "Opt in to write/apply. Required (together with "
+                "--apply-mode local-dev, --config, --input-dir, --run-id) "
+                "to enter the gated local-dev apply pipeline on the "
+                "`apply` subcommand. Any use of --apply on a non-apply "
+                "subcommand exits with code 5 (WRITE_DENIED)."
+            ),
+        )
+        sub.add_argument(
+            "--apply-mode",
+            choices=sorted(SUPPORTED_APPLY_MODES),
+            default=None,
+            help=(
+                "Apply mode gate. Only meaningful on the `apply` "
+                "subcommand combined with --apply. Use 'local-dev' to "
+                "enter the gated local-dev apply pipeline against the "
+                "default in-memory adapter. No production SurrealDB "
+                "activation, no default write."
             ),
         )
         sub.add_argument(
@@ -2240,22 +2854,92 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _handle(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
-    """Resolve command behavior for the scaffold.
+    """Resolve command behavior.
 
-    Returns ``(payload, exit_code)``. The scaffold never performs the
-    real action; it only acknowledges the call or refuses it.
+    Returns ``(payload, exit_code)``. Most subcommands are dry-run; the
+    only command that may execute writes is ``apply`` and only under
+    the strict local-dev gate (#2073).
     """
 
     command: str = args.command
     apply_requested: bool = bool(args.apply)
+    apply_mode: str | None = getattr(args, "apply_mode", None)
     # Default is dry-run; --apply is the only opt-in surface.
     dry_run: bool = not apply_requested or bool(args.dry_run)
 
-    if command == "apply" or apply_requested:
+    # Gate 1: --apply on any non-apply subcommand stays hard-blocked.
+    if command != "apply" and apply_requested:
         raise WriteDeniedError(
-            "apply path is not implemented in scaffold (#2068); "
-            "writes will land in a follow-up slice."
+            "the --apply flag is only valid on the `apply` subcommand; "
+            "use of --apply on other subcommands is hard-blocked"
         )
+
+    # Gate 2: `apply` subcommand requires the explicit local-dev gate.
+    if command == "apply":
+        if not apply_requested:
+            raise WriteDeniedError(
+                "apply subcommand requires --apply to opt in to writes; "
+                "no default-write path exists"
+            )
+        if apply_mode is None:
+            raise WriteDeniedError(
+                "apply requires --apply-mode local-dev; "
+                "no default apply mode is provided"
+            )
+        if apply_mode not in SUPPORTED_APPLY_MODES:
+            raise WriteDeniedError(
+                f"unsupported --apply-mode: {apply_mode!r}; "
+                f"allowed: {sorted(SUPPORTED_APPLY_MODES)}"
+            )
+        if args.config is None:
+            raise WriteDeniedError(
+                "apply requires --config <path> (explicit local config)"
+            )
+        if args.input_dir is None:
+            raise WriteDeniedError(
+                "apply requires --input-dir <dir>"
+            )
+        if not args.run_id:
+            raise WriteDeniedError(
+                "apply requires --run-id <str> for deterministic auditability"
+            )
+
+        _validate_format(args.format)
+        report_output = _validate_output_path(args.report_output)
+        config = load_config(args.config)
+        input_dir = _validate_input_dir(args.input_dir)
+        plan = build_import_plan(input_dir, args.run_id)
+        existing_records = load_existing_records(
+            None if plan.has_blocking_validation_findings else args.existing_records
+        )
+        reconcile_report = reconcile_import_plan(plan, existing_records)
+
+        apply_report = execute_context_apply(
+            reconcile_report=reconcile_report,
+            config=config,
+            run_id=args.run_id,
+            apply_mode=apply_mode,
+        )
+        payload = apply_report.to_payload()
+        payload["config_loaded"] = True
+        payload["config"] = config.to_payload()
+        payload["reconcile_summary"] = {
+            "status": reconcile_report.status,
+            "blocking_count": reconcile_report.blocking_count,
+            "warning_count": reconcile_report.warning_count,
+            "actions": len(reconcile_report.actions),
+        }
+        if report_output is not None:
+            _write_report(report_output, _render(payload, args.format))
+            payload["report_output"] = str(report_output)
+
+        if apply_report.blocking_findings_present:
+            return payload, EXIT_VALIDATION_ERROR
+        if any(r.status == "failed" for r in apply_report.results):
+            return payload, EXIT_INTERNAL
+        if any(r.status == "blocked" for r in apply_report.results):
+            return payload, EXIT_WRITE_DENIED
+        return payload, EXIT_OK
 
     # Validate format and output path defensively even though we do not
     # write. This makes the safety contract verifiable from tests.

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -997,13 +997,33 @@ def _validate_local_dev_url(surreal_url: str) -> None:
 def _validate_apply_table_policy(
     table: str, *, allowed: frozenset[str], forbidden: frozenset[str]
 ) -> None:
+    """Fail-closed table policy gate for apply.
+
+    Effective policy:
+        allow_effective  = ALLOWED_CONTEXT_IMPORT_TABLES ∩ allowed
+        forbid_effective = FORBIDDEN_CONTEXT_IMPORT_TABLES ∪ forbidden
+
+    Forbidden trumps allowed. ``allowed`` (operator config
+    ``allowed_tables``) is strictly restrictive: a table that the
+    operator removed from ``config.allowed_tables`` is blocked even
+    when it is in the global allow-list. There is no fallback to the
+    global allow-list when the configured allow-list is narrower.
+
+    Errors only carry the table name and a reason; payloads, hashes,
+    and other record content are never included.
+    """
+
     if table in forbidden or table in FORBIDDEN_CONTEXT_IMPORT_TABLES:
         raise ApplyGateError(
-            f"apply target table is forbidden: {table!r}"
+            f"apply target table is forbidden by table policy: {table!r}"
         )
-    if table not in allowed and table not in ALLOWED_CONTEXT_IMPORT_TABLES:
+    if table not in ALLOWED_CONTEXT_IMPORT_TABLES:
         raise ApplyGateError(
-            f"apply target table is not in the allowed set: {table!r}"
+            f"apply target table is not in the global allow-list: {table!r}"
+        )
+    if table not in allowed:
+        raise ApplyGateError(
+            f"apply target table is not in the configured allow-list: {table!r}"
         )
 
 


### PR DESCRIPTION
## Summary

Wave 10 / Etappe 1 — schliesst #2073 (explicit local apply mode) und #2074 (tombstone handling) fuer den Context Importer ab.

- Neue **gated local-dev apply pipeline** mit **mockable adapter boundary**.
- Default-Adapter: `InMemoryContextApplyAdapter` — **no production SurrealDB activation**, kein Default-Netzwerk.
- Tombstone-only Loeschungen mit realem ISO8601-UTC `tombstoned_at` aus injizierbarem `ClockProvider`.

## Scope

Allowed paths only:
- `tools/surrealdb/context_importer.py`
- `tests/unit/surrealdb/test_context_import_apply.py` (neu, 18 Tests)
- `tests/unit/surrealdb/test_context_import_tombstones.py` (neu, 16 Tests)
- `docs/surrealdb/context-importer-cli-contract.md` (Status-Header, §3, §4 Flag-Tabelle, §5.2, §5.3, §7, §8)

## Apply Gate (#2073)

Alle gleichzeitig erforderlich, sonst Exit `5`:
- `--apply`
- `--apply-mode local-dev` (argparse erlaubt nur diesen Wert)
- `--config <yaml>` (validiert; `allow_apply_default` muss `false` sein)
- `--input-dir <dir>` (validierbare JSONL)
- `--run-id <id>`
- `surreal_url`-Host ist `127.0.0.1`, `::1` oder `localhost`
- Reconcile ohne Blocking Findings (sonst Exit `1`)

Auf jedem Nicht-`apply`-Subcommand bleibt `--apply` ⇒ Exit `5`. Realer SurrealDB-Adapter ist explizit out-of-scope (`real_surrealdb_adapter_available = false`).

## Tombstones (#2074)

- Pflichtfelder: `tombstoned`, `tombstoned_at`, `tombstone_reason` (Default `record_removed_from_snapshot`), `last_seen_run_id`, `superseded_by`.
- `tombstoned_at` ist reales ISO8601-UTC mit trailing `Z` aus `core.utils.clock.ClockProvider`. `FixedClock` liefert byte-deterministische Reports.
- In-Memory-Adapter exponiert **keine** `delete`/`apply_delete`/`hard_delete`-API; Records bleiben erhalten und bekommen Tombstone-Felder dazu.
- Regressionstest: Apply-Pfad explodiert, wenn `datetime.now()`/`utcnow()` aufgerufen wuerde.

## Determinism & Safety

- Operationen deterministisch sortiert nach `(op_kind, table, record_id)`.
- Apply-Report ist byte-identisch bei identischer Eingabe und identischem Clock.
- Keine Payload-Werte oder Secrets im Report; nur `payload_hash` (sha256), Tabelle, Record-ID.
- Test verifiziert: keine Sockets werden geoeffnet (monkeypatched `socket.socket`/`create_connection`).

## CLI Exit-Code-Mapping

| Bedingung | Exit |
|---|---|
| Apply OK | 0 |
| Reconcile Blocking Findings | 1 |
| Apply-Gate verletzt / Table-Policy block | 5 |
| Per-Op Adapter-Failure | 6 |

## Verification

- `python -m pytest tests/unit/surrealdb/` ⇒ **245/245 passed** (incl. 34 neue Tests, alle 211 Pre-existing weiterhin gruen).
- `ruff check tools/surrealdb/ tests/unit/surrealdb/` ⇒ clean.
- Pre-existing Hard-Block-Tests (`test_apply_subcommand_is_hard_blocked`, `test_apply_flag_is_hard_blocked_on_any_command`) bleiben gruen unter dem neuen Gate.

## Out of Scope / Non-Goals

- Realer SurrealDB-Adapter (kein Trigger fuer produktiven Schreibpfad).
- Audit-Trail-Export, Rollback-Plan-Generation.
- Aenderungen an Trading-, Risk-, Execution-, Secrets-, Live-Readiness-Pfaden.
- Echtgeld-/Live-Enable.

## LR / Stage Posture

- LR-System: weiterhin **NO-GO** (orthogonal; nicht beruehrt).
- Board-Stage: `stage:trade-capable` (orthogonal; nicht beruehrt).
- Diese Aenderung ist Tooling-only fuer Context-Intelligence-Tabellen.

## Closes

- Closes #2073
- Closes #2074
