### PR TITLE
docs(surrealdb): wave 10 closeout - import runbook and completion gates (#2077, #2078)

### DIFF
--- a/docs/runbooks/surrealdb_context_import.md
+++ b/docs/runbooks/surrealdb_context_import.md
@@ -1,0 +1,323 @@
+# SurrealDB Context Import - Local Runbook
+
+**Status**: Draft
+**Authority**: Issue #2077 / Wave 10 Parent #2067 / Epic #1976
+**Scope**: Local/dev only. Document how to take Context Indexer JSONL artifacts through validate -> plan -> dry-run reconcile -> gated local-dev apply, with audit reports and tombstone-only delete semantics.
+
+This runbook is **not** a production activation guide. It does not authorize live trading, does not change Live-Readiness, and does not enable a real SurrealDB write path.
+
+---
+
+## 1. Purpose and Scope
+
+This runbook describes how to drive the Wave-10 Context Importer (`tools/surrealdb/context_importer.py`) end-to-end on a local/dev workstation:
+
+- Take JSONL artifacts produced by the Context Indexer.
+- Validate them as read-only input.
+- Build a deterministic import plan.
+- Reconcile the plan against an explicit local "existing records" snapshot in dry-run mode.
+- Optionally execute a **gated, in-memory local-dev apply** with tombstone-only deletions.
+- Inspect the audit report.
+
+Out of scope for this runbook:
+
+- Production SurrealDB activation.
+- Default writes to any SurrealDB instance.
+- Live-trading, risk, execution, governance, or runtime state.
+- A real SurrealDB adapter (`real_surrealdb_adapter_available = false` in this slice).
+- MCP bridge, Agent-Briefing engine, vector search, or query CLI (Wave 11+).
+
+---
+
+## 2. Non-Goals (Anti-Criteria)
+
+This runbook explicitly does **not** establish or imply any of the following:
+
+- No production default. The importer never reaches a real SurrealDB instance from this runbook.
+- No default-write. `dry-run` is the default; `apply` is hard-gated.
+- `apply` is local/dev only and requires multiple explicit flags.
+- No trading-state, risk, execution, or governance tables are touched (forbidden-tables list is fail-closed).
+- No Live-Readiness change. LR verdict remains **NO-GO** for live trading independent of this runbook.
+- No Echtgeld-Go. Wave-10 completion does not authorize real capital.
+- No real SurrealDB adapter is installed, registered, or selectable through CLI.
+- No secrets, real tokens, or production URLs are used in any example.
+
+If any of the steps below appear to require production credentials, a real SurrealDB endpoint, or a real network call, **stop**. The Wave-10 importer is intentionally local/dev only.
+
+---
+
+## 3. Prerequisites
+
+Required:
+
+- Python 3.12 (matches repo target; see `pyproject.toml`).
+- Local repository checkout of `Claire_de_Binare` on a Wave-10 or later commit (Wave 10 anchor: #2067).
+- A Context Indexer JSONL export under an approved repo-local directory (typically a `temp/` or `artifacts/` subtree). See `tools/surrealdb/context_indexer.py` and `docs/surrealdb/context-indexer-cli-contract.md`.
+- The local-only example config: `infrastructure/config/surrealdb/context_import.local.example.yaml`.
+
+Not required:
+
+- Docker is **not** required for the dry-run / local-dev apply paths. The default adapter is in-memory and offline.
+- A running SurrealDB instance is **not** required. The importer never opens a real network connection in this slice.
+- No production secrets, no live API keys.
+
+If you choose to run a local SurrealDB container later for Wave-11+ query work, that is **out of scope** here.
+
+---
+
+## 4. SurrealDB Local/Dev Posture
+
+Even though no real SurrealDB is contacted, the importer parses URL/namespace/database arguments and validates them against config. Use only local/dev placeholders:
+
+- `--surreal-url` and `surreal_url` in YAML must be a local/dev placeholder, e.g. `ws://127.0.0.1:8000/rpc`. Do not paste a production URL.
+- Namespace must be the Context Intelligence namespace (the example config uses `cdb_ctx`).
+- Database must be the Context Intelligence database (the example config uses `context`).
+- Allowed tables are restricted to the Context-Intelligence record kinds (e.g. `code_symbol`, `config_reference`, `dependency_edge`, `doc_chunk`, `doc_code_link`, `doc_page`, `doc_section`, `import_reference`, `repo_artifact`, `test_case`).
+- Forbidden tables (must never appear in `allowed_tables`) include trading-state and governance-mirror surfaces such as `balances`, `execution_state`, `fills`, `governance_decision`, `governance_event`, `governance_state`, `orders`, `pnl`, `positions`, `risk_state`.
+
+If a config tries to widen `allowed_tables` into any forbidden table, the loader fails closed (Exit `5`).
+
+Secrets must not be embedded in `infrastructure/config/surrealdb/context_import.local.example.yaml`. Real credentials, when ever needed (out of Wave-10 scope), come from the runtime environment / `SECRETS_PATH`, not from this YAML.
+
+---
+
+## 5. Step 1 - Produce a Context Indexer Export
+
+Generate JSONL artifacts with the Context Indexer. This step is described in `docs/surrealdb/context-indexer-cli-contract.md`; the importer treats those JSONL files as read-only input.
+
+Example (local/dev only):
+
+```bash
+# example, not production
+python tools/surrealdb/context_indexer.py export-jsonl \
+  --scope-config infrastructure/config/surrealdb/context_ingestion_scope.yaml \
+  --output-dir temp/context-index/run \
+  --format json
+```
+
+Verify that `temp/context-index/run/` (or wherever you point the indexer) contains the per-table JSONL files (`doc_pages.jsonl`, `code_symbols.jsonl`, etc.).
+
+---
+
+## 6. Step 2 - Validate the JSONL Artifacts
+
+Run the importer's read-only validation. No DB connection, no writes, no external calls.
+
+Example:
+
+```bash
+# example, not production
+python tools/surrealdb/context_importer.py validate-jsonl \
+  --input-dir temp/context-index/run \
+  --run-id wave10-local-dev-1 \
+  --report-output artifacts/import/validation.json
+```
+
+Notes:
+
+- Exit `0` means "no blocking findings".
+- Exit `1` means at least one blocking finding (e.g. malformed `record_id`, schema violation, secret-like content). Findings echo only the code and location, never the offending value.
+- `--report-output` must resolve under `artifacts/` or `temp/`. Absolute paths and `..` traversal are rejected with Exit `5`.
+
+---
+
+## 7. Step 3 - Build a Deterministic Import Plan
+
+Convert validated JSONL into a deterministic candidate plan. Still no DB calls.
+
+Example:
+
+```bash
+# example, not production
+python tools/surrealdb/context_importer.py plan \
+  --input-dir temp/context-index/run \
+  --run-id wave10-local-dev-1 \
+  --report-output artifacts/import/plan.json
+```
+
+The plan is determined by the input artifacts and is stable across runs with the same input.
+
+---
+
+## 8. Step 4 - Dry-Run Reconcile
+
+Reconcile the plan against an explicit local "existing records" JSON fixture (or against an empty existing-state). This is dry-run only and never writes.
+
+Existing-records fixture shape (read-only):
+
+```json
+{
+  "records": [
+    {
+      "table": "doc_page",
+      "record_id": "doc_page:page-id",
+      "payload_hash": "lowercase-sha256-hex",
+      "schema_version": "context-importer/v0"
+    }
+  ]
+}
+```
+
+Example:
+
+```bash
+# example, not production
+python tools/surrealdb/context_importer.py dry-run \
+  --input-dir temp/context-index/run \
+  --existing-records temp/context-index/existing.json \
+  --run-id wave10-local-dev-1 \
+  --report-output artifacts/import/reconcile.json
+```
+
+The reconcile output classifies each candidate as `create`, `update`, `skip` (unchanged), or `tombstone_candidate` (present in existing snapshot, missing in new export).
+
+---
+
+## 9. Step 5 - Gated Local-Dev Apply (Optional)
+
+Apply is **off by default** and requires four explicit flags simultaneously: `--apply`, `--apply-mode local-dev`, `--config`, plus `--input-dir` and `--run-id`. The default adapter is the **in-memory mock adapter**; no real SurrealDB instance is contacted, no real network is opened. Any missing gate yields Exit `5` (`WRITE_DENIED`).
+
+Example:
+
+```bash
+# example, not production - in-memory adapter, no network
+python tools/surrealdb/context_importer.py apply \
+  --apply \
+  --apply-mode local-dev \
+  --config infrastructure/config/surrealdb/context_import.local.example.yaml \
+  --input-dir temp/context-index/run \
+  --existing-records temp/context-index/existing.json \
+  --run-id wave10-local-dev-1 \
+  --report-output artifacts/apply/report.json \
+  --audit-output artifacts/audit/apply.json
+```
+
+Important:
+
+- `--apply-mode` accepts only `local-dev`. argparse rejects any other value.
+- The importer reports `real_surrealdb_adapter_available: false` and `surrealdb_writes: in-memory-only` in the apply report.
+- If the loaded config has `allow_apply_default: true`, the loader fails closed.
+- Forbidden-table writes are blocked at config load time, not at apply time.
+
+---
+
+## 10. Step 6 - Tombstone Semantics
+
+Wave-10 deletions are **tombstone-only**. There is no hard delete and no `delete`/`apply_delete` on the default adapter.
+
+- A tombstone is recorded by writing the record's existing payload back with a tombstone metadata field (`tombstoned_at`, ISO8601 UTC) so all original payload fields are preserved.
+- `tombstoned_at` is written by the runtime `SystemClock`. It is **not** affected by `--audit-generated-at`.
+- The plan stage marks records as `tombstone_candidate`; the apply stage materializes them into adapter writes; the apply report exposes them as `op: tombstone`, `status: applied`, with the `tombstoned_at` timestamp.
+- No record is physically removed by Wave 10. Recovery from a tombstone is therefore a metadata-level undo: the original payload remains addressable until a future curation step removes it. Wave-10 does not implement that curation step (see Section 12).
+
+---
+
+## 11. Step 7 - Inspect the Audit Report
+
+`--audit-output` produces two artifacts in deterministic order:
+
+- A JSON file at the given path (e.g. `artifacts/audit/apply.json`).
+- A Markdown summary alongside (e.g. `artifacts/audit/apply.md`). When the JSON path already ends in `.md`, the Markdown sibling is written as `<path>.md` (e.g. `report.md` -> `report.md.md`) so the two artifacts never collide.
+
+Audit fields to confirm:
+
+- `schema_version: context-import-audit/v0`.
+- `mode`: `plan`, `dry-run`, or `apply`.
+- `run_id` matches the `--run-id` you passed.
+- `counts`: metadata-only (`creates`, `updates`, `skips`, `tombstones`, etc.). No payload bodies are emitted.
+- `generated_at`: deterministic when `--audit-generated-at` is passed; otherwise from `SystemClock`. This timestamp affects only the audit report and **never** apply payload timestamps such as `tombstoned_at`.
+- `git_commit`: from `--git-commit` (test/CI injectable).
+- `duration_ms`: non-negative; 0 if not provided.
+
+Quick check (example):
+
+```bash
+# example, not production
+python -c "import json; print(json.load(open('artifacts/audit/apply.json'))['mode'])"
+```
+
+---
+
+## 12. Rollback / Recovery Notes
+
+Wave 10 does **not** ship an automated rollback implementation. The `rollback-plan` subcommand is present as a stub (`scaffold-ack`, Exit `0`) and is explicitly out of scope for this wave.
+
+Operational guidance for Wave-10 local/dev runs only:
+
+- Keep the pre-apply existing-records snapshot file (`--existing-records ... .json`). Combined with the import plan and apply report, this is sufficient evidence to reason about what was tombstoned.
+- Because deletions are tombstone-only, the original payload remains in the adapter state and can be re-affirmed by re-applying the prior export.
+- Any production rollback / undo design is deferred to a separate Wave (`rollback-plan` generation, real SurrealDB adapter, durable backups). Do not invent or claim it here.
+
+---
+
+## 13. Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| Exit `1` on `validate-jsonl` / `plan` / `dry-run` | Blocking findings present (schema, malformed `record_id`, forbidden-table reference, secret-like content) | Inspect `--report-output` JSON; the `findings` list contains the codes and locations. Fix the indexer export or the existing-records fixture and re-run. |
+| Exit `2` | argparse / CLI usage error | Re-check the subcommand and flags. Use `python tools/surrealdb/context_importer.py --help`. |
+| Exit `3` | Input or config file not found | Verify the path passed to `--input-dir`, `--config`, `--existing-records`, or `--report-output` directory. |
+| Exit `5` (`WRITE_DENIED`) on a non-`apply` subcommand | `--apply` was passed on a subcommand that is not `apply` | Drop `--apply` everywhere except the `apply` subcommand. |
+| Exit `5` on `apply` | One of the required gates is missing: `--apply`, `--apply-mode local-dev`, `--config`, `--input-dir`, `--run-id` | Add the missing gate. All five must be present for apply to proceed. |
+| Exit `5` with path-related code | `--report-output` or `--audit-output` is an absolute path, contains `..`, or resolves outside `artifacts/` and `temp/` | Use a path relative to the repo root under `artifacts/` or `temp/`. |
+| Apply runs but writes seem to vanish | Default adapter is in-memory and process-local. There is no real SurrealDB persistence. | This is expected. Wave 10 ships an in-memory adapter only (`real_surrealdb_adapter_available: false`). |
+| `run_id` missing | `--run-id` not passed where required | Provide a non-empty `--run-id`. The validator rejects missing/empty run ids on read-only validation when run-id consistency is checked. |
+| `record_id` rejected as malformed | The JSONL artifact violates `table:id` shape or table prefix mismatch | Fix the indexer export. The importer does not silently coerce record IDs. |
+| Config validation fails | `allow_apply_default: true`, missing `allowed_tables`, or a forbidden table is allow-listed | Use `infrastructure/config/surrealdb/context_import.local.example.yaml` as a template and keep `allow_apply_default: false`. |
+| `--audit-output foo.md` produced unexpected files | Markdown sibling is appended (`foo.md.md`) so the JSON artifact at `foo.md` is not overwritten | Both files are intentional; the JSON artifact is at the requested path, the Markdown render is at `<path>.md`. |
+| Hangs / network errors | Should not occur in this slice; default adapter is offline | Confirm you are on the local-dev path. There is no production SurrealDB code path in Wave 10. |
+
+---
+
+## 14. Example Command Bundle
+
+All examples below are local/dev illustrations. None of them are production commands. None of them require Docker or a live SurrealDB instance.
+
+```bash
+# example, not production - validate
+python tools/surrealdb/context_importer.py validate-jsonl \
+  --input-dir temp/context-index/run \
+  --run-id wave10-local-dev-1 \
+  --report-output artifacts/import/validation.json
+
+# example, not production - plan
+python tools/surrealdb/context_importer.py plan \
+  --input-dir temp/context-index/run \
+  --run-id wave10-local-dev-1 \
+  --report-output artifacts/import/plan.json
+
+# example, not production - dry-run reconcile
+python tools/surrealdb/context_importer.py dry-run \
+  --input-dir temp/context-index/run \
+  --existing-records temp/context-index/existing.json \
+  --run-id wave10-local-dev-1 \
+  --report-output artifacts/import/reconcile.json \
+  --audit-output artifacts/audit/dry-run.json
+
+# example, not production - gated local-dev apply (in-memory adapter)
+python tools/surrealdb/context_importer.py apply \
+  --apply \
+  --apply-mode local-dev \
+  --config infrastructure/config/surrealdb/context_import.local.example.yaml \
+  --input-dir temp/context-index/run \
+  --existing-records temp/context-index/existing.json \
+  --run-id wave10-local-dev-1 \
+  --report-output artifacts/apply/report.json \
+  --audit-output artifacts/audit/apply.json
+
+# example, not production - audit emit (read-only mode)
+python tools/surrealdb/context_importer.py audit \
+  --input-dir temp/context-index/run \
+  --audit-mode dry-run \
+  --run-id wave10-local-dev-1 \
+  --audit-output artifacts/audit/wave10-dry-run.json
+```
+
+---
+
+## 15. Closing Reminder
+
+- These commands are **examples**. Run them only against local/dev artifacts.
+- The importer never opens a real network connection in Wave 10.
+- Live-Readiness remains `NO-GO`. Wave-10 completion does not change Echtgeld posture.
+- Real SurrealDB adapter, real persistence, automated rollback, and query CLI are all separate, future-wave work and must not be implied by Wave-10 evidence.

--- a/docs/surrealdb/context-wave10-completion-gates.md
+++ b/docs/surrealdb/context-wave10-completion-gates.md
@@ -1,0 +1,166 @@
+# Context Intelligence - Wave 10 Completion Gates
+
+**Status**: Draft
+**Authority**: Issue #2078 / Wave 10 Parent #2067 / Epic #1976
+**Scope**: Local/dev SurrealDB Context Importer (validate -> plan -> dry-run reconcile -> gated local-dev apply -> tombstones -> audit). No production SurrealDB activation, no runtime trading change, no Live-Readiness change.
+
+This document defines the closure conditions for Wave 10 of the SurrealDB Context Intelligence roadmap. Wave-10 completion is not a live-trading, Live-Readiness, or Echtgeld authorization. It does not introduce a real SurrealDB write path.
+
+---
+
+## 1. Wave 10 Scope
+
+Wave 10 delivers a deterministic, dry-run-first, locally-gated context import pipeline driving Context Indexer JSONL output through the importer to an in-memory adapter, with audit reports, tombstone-only deletions, and tests/fixtures.
+
+In scope (delivered across the Wave-10 issue set below):
+
+- A CLI scaffold for `tools/surrealdb/context_importer.py` with safe defaults.
+- Local/dev configuration loading with fail-closed validation.
+- Read-only JSONL artifact validation.
+- Deterministic import plan generation.
+- Dry-run reconcile against an explicit local existing-records snapshot.
+- Gated local-dev apply with the in-memory mock adapter only.
+- Tombstone-only deletion semantics with payload-field retention.
+- Deterministic audit report (JSON + Markdown sibling).
+- Unit tests, fixtures, and a local import runbook.
+
+Out of scope (deferred to later waves):
+
+- Real SurrealDB adapter / production write path.
+- Production SurrealDB activation, default writes, or any runtime trading change.
+- Query CLI / SurrealDB query layer (Wave 11+).
+- Automated rollback-plan generation (stub only in Wave 10).
+- MCP bridge, Agent-Briefing engine, vector search.
+
+---
+
+## 2. Wave 10 Issue Matrix
+
+Each Wave-10 issue maps to a delivered slice. Status reflects merged-into-`main` evidence at the time this document is authored.
+
+| Issue | Title | Status | Delivered slice |
+|---|---|---|---|
+| #2068 | Context importer CLI scaffold | merged | Argument parsing, help text, dry-run default, fail-closed `--apply` and `apply` (Exit `5`), output-path whitelist. |
+| #2069 | Local SurrealDB context connection config | merged | Explicit YAML config loader (`context_import.local.example.yaml`); fail-closed `allow_apply_default=false`; allowed-/forbidden-tables enforcement; no secrets in YAML. |
+| #2070 | JSONL artifact validation before import | merged | Read-only `validate-jsonl` with schema, `record_id` and per-table checks; secret-redaction in findings; Exit `0` clean / Exit `1` with blocking findings. |
+| #2071 | Deterministic SurrealDB import plan | merged | `plan --input-dir` produces a stable candidate plan from validated artifacts; no DB calls. |
+| #2072 | Dry-run reconcile against SurrealDB | merged | `dry-run --input-dir` reconciles plan against an explicit read-only existing-records JSON fixture or empty state; classifies create / update / skip / tombstone_candidate. |
+| #2073 | Explicit local apply mode | merged | `apply` subcommand gated on `--apply` + `--apply-mode local-dev` + `--config` + `--input-dir` + `--run-id`; default in-memory adapter; no production SurrealDB and no real network. |
+| #2074 | Tombstone handling | merged | Tombstone-only deletions with payload-field retention; `tombstoned_at` written by runtime `SystemClock`; injectable clock for tests; no hard-delete API. |
+| #2075 | Context import audit report | merged | Audit schema `context-import-audit/v0` for plan/dry-run/apply; metadata-only counts; injectable `generated_at`/`duration_ms`/`git_commit`; JSON + Markdown sibling artifacts; audit clock isolated from apply payload timestamps. |
+| #2076 | Tests and fixtures for importer | merged | `tests/unit/surrealdb/test_context_import_audit.py` + 11 minimal JSONL fixtures and an `existing_mixed.json`; full `tests/unit/surrealdb/` suite is green locally. |
+| #2077 | Local import runbook | this PR | `docs/runbooks/surrealdb_context_import.md`. |
+| #2078 | Wave-10 completion gates | this PR | this document. |
+
+---
+
+## 3. PR / Merge-Commit Matrix
+
+| Issue(s) | PR | Merge commit |
+|---|---|---|
+| #2068 | #2239 | `6b9167bd012d705f0cb802e1bcd6ba7646972e11` |
+| #2069 | #2242 | `240035f4b17fbce39c2a64eb7010a6d0f6e553e3` |
+| #2070 | #2243 | `d69b62f76b4f282a1c253cd7032278b43949550d` |
+| #2071 | #2244 | `4a83a0b4d2299761f75cb1b413072186f6aa631a` |
+| #2072 | #2247 | `7b0bbd87fff67ab4301d9d4b8d8fc8659732cea7` |
+| #2073, #2074 | #2248 | `4f4a72e71d094df813bdfc297237aa5e998b4baa` |
+| #2075, #2076 | #2249 | `5e564c9b42dc9e044e72c0d9ab2b7b83540d53d5` |
+| #2077, #2078 | this PR | (assigned at merge) |
+
+---
+
+## 4. Completion Checklist (MUST)
+
+Wave 10 is complete when **all** of the following are true:
+
+- [x] Context Importer CLI scaffold exists in `tools/surrealdb/context_importer.py` with safe defaults and fail-closed `--apply` / `apply` semantics. (#2068 / PR #2239)
+- [x] Local/dev configuration exists at `infrastructure/config/surrealdb/context_import.local.example.yaml` and is loaded only with explicit `--config`. (#2069 / PR #2242)
+- [x] JSONL validation works for the per-table artifacts produced by the Context Indexer; blocking findings yield Exit `1`; no secret values are echoed. (#2070 / PR #2243)
+- [x] Deterministic import plan works: `plan --input-dir` returns a stable plan that depends only on the input artifacts. (#2071 / PR #2244)
+- [x] Dry-run reconcile works: `dry-run --input-dir [--existing-records ...]` classifies create / update / skip / tombstone_candidate without DB calls. (#2072 / PR #2247)
+- [x] Explicit apply mode works on the in-memory adapter only, requires all of `--apply` + `--apply-mode local-dev` + `--config` + `--input-dir` + `--run-id`, otherwise Exit `5`. (#2073 / PR #2248)
+- [x] Tombstone handling works: deletions are tombstone-only with payload-field retention; `tombstoned_at` from runtime `SystemClock`; no hard-delete API. (#2074 / PR #2248)
+- [x] Audit report exists: schema `context-import-audit/v0` for plan / dry-run / apply; deterministic JSON + Markdown sibling; audit clock cannot mutate apply payload timestamps. (#2075 / PR #2249)
+- [x] Tests and fixtures exist under `tests/unit/surrealdb/` and `tests/fixtures/surrealdb/context_importer/`. (#2076 / PR #2249)
+- [x] Local import runbook exists at `docs/runbooks/surrealdb_context_import.md`. (#2077 / this PR)
+- [x] Wave-10 completion gates document exists at `docs/surrealdb/context-wave10-completion-gates.md`. (#2078 / this PR)
+
+---
+
+## 5. Anti-Criteria (Wave-10 closure must not violate any)
+
+Wave 10 is **not** complete - and PRs claiming Wave-10 closure must be rejected - if any of the following appear:
+
+- Default writes to any SurrealDB instance.
+- Production SurrealDB activation or a registered real SurrealDB adapter on the CLI.
+- Any runtime, trading, risk, execution, or governance behavior change.
+- Trading-state or governance-mirror tables added to `allowed_tables`.
+- Removal or weakening of the `allow_apply_default: false` invariant in the loaded config.
+- A hard-delete code path on the apply boundary (only tombstones are allowed).
+- Inference of Live-Readiness GO from Wave-10 implementation status.
+- Inference of Echtgeld GO from Wave-10 implementation status.
+- Introduction of an MCP bridge, Agent-Briefing engine, or vector search as part of Wave-10 closure.
+- Docker as a hard requirement for Wave-10 unit-test validation.
+
+These anti-criteria hold across all Wave-10 PRs and across this closeout PR.
+
+---
+
+## 6. Validation Evidence
+
+Evidence is anchored to the merged Wave-10 PRs above; do not over-claim beyond what those PRs and the local repo state demonstrate.
+
+Local validation observed for the most recent Wave-10 slice (PR #2249, audit/tests) on commit `5e564c9b`:
+
+- `ruff check tools/surrealdb/context_importer.py tests/unit/surrealdb/test_context_import_audit.py` -> all checks passed.
+- `python -m pytest -q tests/unit/surrealdb/` -> 266 passed, 0 failed.
+- All required CI checks green on PR #2249 (capture-intent, docs conflict guard, ci unit/integration + lint, policy-gate, root-session-hygiene-warning, submit-pypi).
+
+Repository-side Wave-10 evidence:
+
+- `tools/surrealdb/context_importer.py` carries the CLI surface, config loader, validator, planner, reconciler, gated apply path, in-memory adapter boundary, tombstone semantics, and audit emitter.
+- `docs/surrealdb/context-importer-cli-contract.md` documents the CLI contract, including exit codes, gate semantics, audit schema, tombstone semantics, and forbidden-tables list.
+- `infrastructure/config/surrealdb/context_import.local.example.yaml` ships as the only sanctioned config template; it contains no secrets and no production URLs.
+- `tests/unit/surrealdb/` covers config, JSONL validation, plan, reconcile, apply, tombstones, audit, indexer, drift, ledger importer, and symbol extraction; full local suite green.
+- `tests/fixtures/surrealdb/context_importer/` ships minimal deterministic fixtures used by the audit / apply / tombstone tests.
+
+Anything beyond this list (e.g. real SurrealDB persistence evidence, production rollback evidence, query-layer evidence) is **not** Wave-10 evidence and must not be cited as such.
+
+---
+
+## 7. Known Follow-ups (Out of Wave-10 Scope)
+
+The following items are intentionally not delivered in Wave 10 and require their own scope and GO before any work begins:
+
+- **Wave 11 - Query CLI / SurrealDB query layer.** Building a read query surface on top of imported context records. Tracked separately; do not start without explicit GO.
+- **Real SurrealDB adapter.** Replacing the default in-memory adapter with a real, durable SurrealDB write boundary. Requires a separate design, separate guardrails, separate test posture, and separate authorization. Wave-10 reports `real_surrealdb_adapter_available: false`.
+- **Automated rollback-plan generation.** The `rollback-plan` subcommand is a stub (`scaffold-ack`, Exit `0`) in Wave 10. Producing real, machine-actionable rollback plans is a separate slice.
+- **Production SurrealDB activation, runtime ingestion, MCP bridge, Agent-Briefing engine, vector search.** None of these may be derived from Wave-10 closure. They each require their own canonical issue, design, and human GO.
+
+No scope expansion is implied by Wave-10 closure.
+
+---
+
+## 8. Closure Recommendation
+
+After this PR (the runbook + gates closeout PR) merges:
+
+1. Close issue **#2077** with a closeout comment linking to the merge commit and the new `docs/runbooks/surrealdb_context_import.md`.
+2. Close issue **#2078** with a closeout comment linking to the merge commit and to this document.
+3. Close Wave-10 anchor **#2067** with a closeout comment that:
+   - Summarises the Wave-10 scope.
+   - Lists the merged Wave-10 PRs (#2239, #2242, #2243, #2244, #2247, #2248, #2249, plus this closeout PR).
+   - Confirms each item in Section 4 above.
+   - Confirms each anti-criterion in Section 5 above.
+   - Explicitly restates: Wave-10 closure does **not** authorize live trading, does **not** change Live-Readiness, and does **not** change Echtgeld posture.
+4. Do **not** close Epic **#1976** as part of Wave-10 closure. The epic remains open while later waves (Wave 11+) are still expected.
+5. Do not start Wave-11 work as part of Wave-10 closeout. Wave 11 requires its own planning and GO.
+
+---
+
+## 9. Hand-off
+
+After all Wave-10 gates pass and Wave 10 is closed:
+
+- Wave 11+ can build a read-only query layer on top of the in-memory adapter or a future real SurrealDB adapter.
+- Live-Readiness, runtime trading, and any production-write decision remain governed by the LR-Audit / Control-Register surfaces and are unaffected by Wave-10 closure.


### PR DESCRIPTION
## Goal

Close out Wave 10 of the SurrealDB Context Intelligence roadmap (parent #2067, epic #1976) on the docs side by delivering the two remaining open Wave-10 issues:

- #2077 - Local SurrealDB context import runbook
- #2078 - Wave-10 completion gates

This PR is **docs-only**. It does not modify the importer code, does not touch any runtime, does not enable a real SurrealDB write path, and does not change Live-Readiness.

## What changed

- New: `docs/runbooks/surrealdb_context_import.md` (#2077)
  - Local/dev runbook for the Context Importer.
  - Covers prerequisites, SurrealDB local/dev posture (no prod URLs, no secrets), indexer-export, JSONL validation, deterministic plan, dry-run reconcile, gated local-dev apply (in-memory adapter only), tombstone-only deletes, audit report inspection (JSON + Markdown sibling, including `.md.md` sibling rule), rollback notes, troubleshooting, and an example command bundle marked explicitly as local/dev examples.
- New: `docs/surrealdb/context-wave10-completion-gates.md` (#2078)
  - Wave-10 scope, anti-scope, issue matrix (#2068-#2078) with status, PR -> merge-commit matrix, completion checklist, anti-criteria, validation evidence (anchored to merged PRs and local pytest run), known follow-ups, and a closure recommendation that closes #2077, #2078, and finally #2067 - while explicitly leaving epic #1976 open.

No code changes. No CLI / config / fixture changes. No test changes.

## Issues / PRs

- Closes (after merge): #2077, #2078
- Anchor: #2067 (Wave 10 parent, to be closed after this PR merges and gates are reverified)
- Epic: #1976 (stays open)
- Wave-10 evidence (already merged):
  - #2068 -> PR #2239 (`6b9167bd`)
  - #2069 -> PR #2242 (`240035f4`)
  - #2070 -> PR #2243 (`d69b62f7`)
  - #2071 -> PR #2244 (`4a83a0b4`)
  - #2072 -> PR #2247 (`7b0bbd87`)
  - #2073/#2074 -> PR #2248 (`4f4a72e7`)
  - #2075/#2076 -> PR #2249 (`5e564c9b`)

## Guardrails (anti-criteria honored)

- No production SurrealDB activation.
- No default-write; `dry-run` remains default; `apply` remains hard-gated on `--apply` + `--apply-mode local-dev` + `--config` + `--input-dir` + `--run-id`.
- No real SurrealDB adapter. Default adapter remains in-memory; `real_surrealdb_adapter_available: false` reflected in runbook + gates doc.
- No trading-state / risk / execution / governance table touched. Forbidden-tables list stays fail-closed.
- No hard-delete path. Deletions remain tombstone-only with payload-field retention; `tombstoned_at` from runtime `SystemClock`.
- No MCP bridge, no Agent-Briefing engine, no vector search, no query CLI - all explicitly deferred to Wave 11+.
- No Live-Readiness change. LR verdict stays **NO-GO** for live trading.
- No Echtgeld GO. Wave-10 closure does not authorize real capital.
- No Docker required for Wave-10 unit-test validation.
- No secrets, no production URLs, no real tokens in any example.

## Validation

- `git status -sb` clean before commit; only the two new docs added.
- `git diff --check` clean.
- `python -m pytest -q tests/unit/surrealdb/ --maxfail=1` -> **266 passed, 15 warnings** (pre-existing, unrelated to this PR).
- Docs-only; no lint/type changes expected.

## Open Restunsicherheiten

- This PR intentionally does **not** close #2077, #2078, or #2067. Closure happens only after this PR merges and the Wave-10 gates are reverified on `main`.
- Wave 11+ work (query CLI, real SurrealDB adapter, automated rollback-plan generation) is out of scope and not started.
