### PR TITLE
Add context query CLI scaffold

### DIFF
--- a/tests/unit/surrealdb/test_context_query_classifier.py
+++ b/tests/unit/surrealdb/test_context_query_classifier.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from tools.surrealdb.context_query import WriteDeniedError, classify_statement
+from tools.surrealdb.context_query import WriteDeniedError, classify_statement, load_config
+
+
+EXAMPLE_CONFIG = Path("infrastructure/config/surrealdb/context_query.local.example.yaml")
 
 
 @pytest.mark.unit
@@ -22,6 +27,32 @@ def test_read_only_statements_are_allowed(statement: str, operation: str) -> Non
 
     assert result.allowed is True
     assert result.operation == operation
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "SELECT * FROM orders",
+        "SELECT * FROM governance_event",
+        "INFO FOR TABLE orders",
+    ],
+)
+def test_forbidden_tables_are_blocked_with_config(statement: str) -> None:
+    config = load_config(EXAMPLE_CONFIG)
+
+    with pytest.raises(WriteDeniedError):
+        classify_statement(statement, config=config)
+
+
+@pytest.mark.unit
+def test_allowed_table_remains_allowed_with_config() -> None:
+    config = load_config(EXAMPLE_CONFIG)
+
+    result = classify_statement("SELECT * FROM doc_chunk", config=config)
+
+    assert result.allowed is True
+    assert result.operation == "SELECT"
 
 
 @pytest.mark.unit

--- a/tests/unit/surrealdb/test_context_query_classifier.py
+++ b/tests/unit/surrealdb/test_context_query_classifier.py
@@ -35,10 +35,12 @@ def test_read_only_statements_are_allowed(statement: str, operation: str) -> Non
     [
         "SELECT * FROM orders",
         "SELECT * FROM governance_event",
+        "SELECT * FROM unknown_sensitive_table",
         "INFO FOR TABLE orders",
+        "INFO FOR TABLE unknown_sensitive_table",
     ],
 )
-def test_forbidden_tables_are_blocked_with_config(statement: str) -> None:
+def test_forbidden_or_unknown_tables_are_blocked_with_config(statement: str) -> None:
     config = load_config(EXAMPLE_CONFIG)
 
     with pytest.raises(WriteDeniedError):
@@ -53,6 +55,10 @@ def test_allowed_table_remains_allowed_with_config() -> None:
 
     assert result.allowed is True
     assert result.operation == "SELECT"
+
+    info_result = classify_statement("INFO FOR TABLE doc_chunk", config=config)
+    assert info_result.allowed is True
+    assert info_result.operation == "INFO FOR TABLE"
 
 
 @pytest.mark.unit

--- a/tests/unit/surrealdb/test_context_query_classifier.py
+++ b/tests/unit/surrealdb/test_context_query_classifier.py
@@ -1,0 +1,95 @@
+"""Unit tests for Context Query statement classifier v0 (#2080)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.surrealdb.context_query import WriteDeniedError, classify_statement
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("statement", "operation"),
+    [
+        ("SELECT * FROM doc_chunk", "SELECT"),
+        ("INFO FOR DB", "INFO FOR DB"),
+        ("INFO FOR TABLE doc_chunk", "INFO FOR TABLE"),
+        ("INFO FOR NS", "INFO FOR NS"),
+    ],
+)
+def test_read_only_statements_are_allowed(statement: str, operation: str) -> None:
+    result = classify_statement(statement)
+
+    assert result.allowed is True
+    assert result.operation == operation
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "CREATE doc_chunk SET title = 'x'",
+        "INSERT INTO doc_chunk { title: 'x' }",
+        "UPDATE doc_chunk SET title = 'x'",
+        "UPSERT doc_chunk CONTENT {}",
+        "DELETE doc_chunk",
+        "RELATE a->edge->b",
+        "MERGE doc_chunk CONTENT {}",
+        "PATCH doc_chunk [{ op: 'replace' }]",
+        "DEFINE TABLE doc_chunk",
+        "REMOVE TABLE doc_chunk",
+        "ALTER TABLE doc_chunk",
+        "LIVE SELECT * FROM doc_chunk",
+        "KILL 'abc'",
+        "USE NS test DB test",
+        "BEGIN TRANSACTION",
+        "COMMIT TRANSACTION",
+        "CANCEL TRANSACTION",
+    ],
+)
+def test_write_schema_live_and_control_keywords_are_blocked(statement: str) -> None:
+    with pytest.raises(WriteDeniedError):
+        classify_statement(statement)
+
+
+@pytest.mark.unit
+def test_explain_is_blocked() -> None:
+    with pytest.raises(WriteDeniedError):
+        classify_statement("EXPLAIN SELECT * FROM doc_chunk")
+
+
+@pytest.mark.unit
+def test_show_changes_is_blocked() -> None:
+    with pytest.raises(WriteDeniedError):
+        classify_statement("SHOW CHANGES FOR TABLE doc_chunk")
+
+
+@pytest.mark.unit
+def test_info_for_root_is_blocked() -> None:
+    with pytest.raises(WriteDeniedError):
+        classify_statement("INFO FOR ROOT")
+
+
+@pytest.mark.unit
+def test_multi_statement_with_semicolon_is_blocked() -> None:
+    with pytest.raises(WriteDeniedError):
+        classify_statement("SELECT * FROM doc_chunk; SELECT * FROM repo_artifact")
+
+    with pytest.raises(WriteDeniedError):
+        classify_statement("SELECT * FROM doc_chunk;")
+
+
+@pytest.mark.unit
+def test_whitespace_and_case_variants_are_stable() -> None:
+    result = classify_statement("  select\n  *\tfrom   doc_chunk  ")
+
+    assert result.allowed is True
+    assert result.operation == "SELECT"
+    assert result.normalized == "SELECT * FROM DOC_CHUNK"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("statement", ["APPLY something", "MIGRATION run", "TRANSACTION start"])
+def test_transaction_migration_apply_flows_are_blocked(statement: str) -> None:
+    with pytest.raises(WriteDeniedError):
+        classify_statement(statement)

--- a/tests/unit/surrealdb/test_context_query_cli.py
+++ b/tests/unit/surrealdb/test_context_query_cli.py
@@ -81,6 +81,24 @@ def test_classify_forbidden_table_exits_write_denied(capsys) -> None:
 
 
 @pytest.mark.unit
+def test_classify_unknown_table_exits_write_denied(capsys) -> None:
+    exit_code = main(
+        [
+            "--config",
+            EXAMPLE_CONFIG,
+            "classify",
+            "--statement",
+            "SELECT * FROM unknown_sensitive_table",
+        ]
+    )
+
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+    assert "outside allowed_tables" in payload["message"]
+
+
+@pytest.mark.unit
 def test_classify_delete_exits_write_denied(capsys) -> None:
     exit_code = main(
         [

--- a/tests/unit/surrealdb/test_context_query_cli.py
+++ b/tests/unit/surrealdb/test_context_query_cli.py
@@ -1,0 +1,109 @@
+"""CLI smoke tests for Context Query scaffold (#2080)."""
+
+from __future__ import annotations
+
+import json
+import socket
+
+import pytest
+
+from tools.surrealdb.context_query import (
+    EXIT_INPUT_NOT_FOUND,
+    EXIT_OK,
+    EXIT_USAGE_ERROR,
+    EXIT_WRITE_DENIED,
+    main,
+)
+
+
+EXAMPLE_CONFIG = "infrastructure/config/surrealdb/context_query.local.example.yaml"
+
+
+def _read_json(capsys) -> dict:
+    out = capsys.readouterr().out.strip()
+    return json.loads(out)
+
+
+@pytest.mark.unit
+def test_help_exits_zero(capsys) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--help"])
+
+    assert excinfo.value.code == 0
+    assert "context_query" in capsys.readouterr().out
+
+
+@pytest.mark.unit
+def test_classify_requires_config(capsys) -> None:
+    exit_code = main(["classify", "--statement", "SELECT * FROM doc_chunk"])
+
+    assert exit_code == EXIT_INPUT_NOT_FOUND
+    payload = _read_json(capsys)
+    assert payload["error"] == "INPUT_NOT_FOUND"
+    assert "--config is required" in payload["message"]
+
+
+@pytest.mark.unit
+def test_classify_select_exits_zero(capsys) -> None:
+    exit_code = main(
+        [
+            "--config",
+            EXAMPLE_CONFIG,
+            "classify",
+            "--statement",
+            "SELECT * FROM doc_chunk",
+        ]
+    )
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert payload["status"] == "ok"
+    assert payload["surrealdb_connection"] == "noop-no-network"
+    assert payload["classification"]["operation"] == "SELECT"
+
+
+@pytest.mark.unit
+def test_classify_delete_exits_write_denied(capsys) -> None:
+    exit_code = main(
+        [
+            "--config",
+            EXAMPLE_CONFIG,
+            "classify",
+            "--statement",
+            "DELETE doc_chunk",
+        ]
+    )
+
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+
+
+@pytest.mark.unit
+def test_unsupported_format_exits_argparse_usage_error() -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--format", "xml", "classify", "--statement", "SELECT * FROM doc_chunk"])
+
+    assert excinfo.value.code == EXIT_USAGE_ERROR
+
+
+@pytest.mark.unit
+def test_no_network_socket_is_used(monkeypatch, capsys) -> None:
+    def _boom(*args, **kwargs):  # pragma: no cover - safety net
+        raise AssertionError("context_query must not open network sockets")
+
+    monkeypatch.setattr(socket.socket, "connect", _boom)
+    monkeypatch.setattr(socket.socket, "connect_ex", _boom)
+
+    exit_code = main(
+        [
+            "--config",
+            EXAMPLE_CONFIG,
+            "classify",
+            "--statement",
+            "INFO FOR TABLE doc_chunk",
+        ]
+    )
+
+    assert exit_code == EXIT_OK
+    assert _read_json(capsys)["surrealdb_connection"] == "noop-no-network"

--- a/tests/unit/surrealdb/test_context_query_cli.py
+++ b/tests/unit/surrealdb/test_context_query_cli.py
@@ -63,6 +63,24 @@ def test_classify_select_exits_zero(capsys) -> None:
 
 
 @pytest.mark.unit
+def test_classify_forbidden_table_exits_write_denied(capsys) -> None:
+    exit_code = main(
+        [
+            "--config",
+            EXAMPLE_CONFIG,
+            "classify",
+            "--statement",
+            "SELECT * FROM orders",
+        ]
+    )
+
+    assert exit_code == EXIT_WRITE_DENIED
+    payload = _read_json(capsys)
+    assert payload["error"] == "WRITE_DENIED"
+    assert "forbidden table" in payload["message"]
+
+
+@pytest.mark.unit
 def test_classify_delete_exits_write_denied(capsys) -> None:
     exit_code = main(
         [

--- a/tests/unit/surrealdb/test_context_query_config.py
+++ b/tests/unit/surrealdb/test_context_query_config.py
@@ -149,7 +149,20 @@ def test_mode_surrealdb_apply_must_be_forbidden(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("field", ["password", "token", "api_key", "secret", "credential"])
+@pytest.mark.parametrize(
+    "field",
+    [
+        "password",
+        "token",
+        "api_key",
+        "secret",
+        "credential",
+        "db_password",
+        "access_token",
+        "client_secret",
+        "credential_file",
+    ],
+)
 def test_secret_fields_are_rejected(tmp_path: Path, field: str) -> None:
     path = _write_config(tmp_path, _valid_config(extra=f"{field}: nope\n"))
 

--- a/tests/unit/surrealdb/test_context_query_config.py
+++ b/tests/unit/surrealdb/test_context_query_config.py
@@ -158,9 +158,15 @@ def test_mode_surrealdb_apply_must_be_forbidden(tmp_path: Path) -> None:
         "secret",
         "credential",
         "db_password",
+        "db-password",
+        "client.secret",
         "access_token",
+        "accessToken",
         "client_secret",
+        "clientSecret",
         "credential_file",
+        "credentialFile",
+        "apiKey",
     ],
 )
 def test_secret_fields_are_rejected(tmp_path: Path, field: str) -> None:

--- a/tests/unit/surrealdb/test_context_query_config.py
+++ b/tests/unit/surrealdb/test_context_query_config.py
@@ -1,0 +1,223 @@
+"""Unit tests for the Context Query local config loader (#2080/#2081)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.surrealdb.context_query import (
+    CONFIG_SCHEMA_VERSION,
+    EXIT_INPUT_NOT_FOUND,
+    EXIT_VALIDATION_ERROR,
+    FORBIDDEN_CONTEXT_QUERY_TABLES,
+    ConfigValidationError,
+    InputNotFoundError,
+    load_config,
+    main,
+)
+
+
+EXAMPLE_CONFIG = Path("infrastructure/config/surrealdb/context_query.local.example.yaml")
+
+
+def _write_config(tmp_path: Path, text: str) -> Path:
+    path = tmp_path / "context_query.local.yaml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _valid_config(extra: str = "") -> str:
+    return f"""
+schema_version: context-query-local/v0
+mode:
+  surrealdb_apply: forbidden
+  surrealdb_write: forbidden
+  read_only: true
+surreal_url: ws://127.0.0.1:8000/rpc
+namespace: cdb_context_local
+database: cdb_context_intel
+auth_mode: none
+timeout: 10
+read_only: true
+max_limit_default: 100
+max_limit_hard: 1000
+allowed_tables:
+  - repo_artifact
+  - doc_chunk
+forbidden_tables:
+  - orders
+  - fills
+  - positions
+  - balances
+  - pnl
+  - risk_state
+  - execution_state
+  - governance_event
+  - governance_decision
+  - governance_state
+{extra}
+"""
+
+
+@pytest.mark.unit
+def test_example_config_loads_successfully() -> None:
+    config = load_config(EXAMPLE_CONFIG)
+
+    assert config.schema_version == CONFIG_SCHEMA_VERSION
+    assert config.read_only is True
+    assert config.mode_read_only is True
+    assert config.surrealdb_write == "forbidden"
+    assert config.surrealdb_apply == "forbidden"
+    assert config.max_limit_default <= config.max_limit_hard
+    assert set(FORBIDDEN_CONTEXT_QUERY_TABLES).issubset(config.forbidden_tables)
+    assert not set(config.allowed_tables).intersection(FORBIDDEN_CONTEXT_QUERY_TABLES)
+
+
+@pytest.mark.unit
+def test_missing_config_returns_exit_3() -> None:
+    missing = Path("does-not-exist.yaml")
+
+    with pytest.raises(InputNotFoundError) as excinfo:
+        load_config(missing)
+
+    assert excinfo.value.exit_code == EXIT_INPUT_NOT_FOUND
+    assert main(["--config", str(missing), "classify", "--statement", "SELECT * FROM doc_chunk"]) == EXIT_INPUT_NOT_FOUND
+
+
+@pytest.mark.unit
+def test_wrong_schema_version_is_validation_failure(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        _valid_config().replace(
+            "schema_version: context-query-local/v0", "schema_version: wrong/v0"
+        ),
+    )
+
+    with pytest.raises(ConfigValidationError):
+        load_config(path)
+    assert main(["--config", str(path), "classify", "--statement", "SELECT * FROM doc_chunk"]) == EXIT_VALIDATION_ERROR
+
+
+@pytest.mark.unit
+def test_top_level_read_only_false_is_rejected(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, _valid_config().replace("read_only: true", "read_only: false", 1))
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        load_config(path)
+
+    assert "read_only" in excinfo.value.message
+
+
+@pytest.mark.unit
+def test_mode_read_only_false_is_rejected(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        _valid_config().replace("  read_only: true", "  read_only: false", 1),
+    )
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        load_config(path)
+
+    assert "mode.read_only" in excinfo.value.message
+
+
+@pytest.mark.unit
+def test_mode_surrealdb_write_must_be_forbidden(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        _valid_config().replace("surrealdb_write: forbidden", "surrealdb_write: allowed"),
+    )
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        load_config(path)
+
+    assert "surrealdb_write" in excinfo.value.message
+
+
+@pytest.mark.unit
+def test_mode_surrealdb_apply_must_be_forbidden(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        _valid_config().replace("surrealdb_apply: forbidden", "surrealdb_apply: allowed"),
+    )
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        load_config(path)
+
+    assert "surrealdb_apply" in excinfo.value.message
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("field", ["password", "token", "api_key", "secret", "credential"])
+def test_secret_fields_are_rejected(tmp_path: Path, field: str) -> None:
+    path = _write_config(tmp_path, _valid_config(extra=f"{field}: nope\n"))
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        load_config(path)
+
+    assert field in excinfo.value.message
+
+
+@pytest.mark.unit
+def test_allowed_forbidden_overlap_is_rejected(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        _valid_config().replace("  - governance_state", "  - governance_state\n  - doc_chunk"),
+    )
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        load_config(path)
+
+    assert "both allowed_tables and forbidden_tables" in excinfo.value.message
+
+
+@pytest.mark.unit
+def test_trading_state_in_allowed_tables_is_rejected(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        _valid_config().replace("  - doc_chunk", "  - doc_chunk\n  - orders", 1),
+    )
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        load_config(path)
+
+    assert "orders" in excinfo.value.message
+
+
+@pytest.mark.unit
+def test_governance_mirror_in_allowed_tables_is_rejected(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        _valid_config().replace(
+            "  - doc_chunk", "  - doc_chunk\n  - governance_event", 1
+        ),
+    )
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        load_config(path)
+
+    assert "governance_event" in excinfo.value.message
+
+
+@pytest.mark.unit
+def test_max_limit_default_may_not_exceed_hard_limit(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        _valid_config().replace("max_limit_default: 100", "max_limit_default: 1001"),
+    )
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        load_config(path)
+
+    assert "max_limit_default" in excinfo.value.message
+
+
+@pytest.mark.unit
+def test_forbidden_tables_must_include_all_blocked_tables(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, _valid_config().replace("  - execution_state\n", ""))
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        load_config(path)
+
+    assert "missing" in excinfo.value.message

--- a/tools/surrealdb/context_query.py
+++ b/tools/surrealdb/context_query.py
@@ -73,6 +73,7 @@ GOVERNANCE_MIRROR_TABLES = frozenset(
 FORBIDDEN_CONTEXT_QUERY_TABLES = TRADING_STATE_TABLES | GOVERNANCE_MIRROR_TABLES
 
 SECRET_FIELD_NAMES = frozenset({"password", "token", "api_key", "secret", "credential"})
+SECRET_FIELD_SEGMENTS = frozenset({"password", "token", "api", "key", "secret", "credential"})
 
 DENIED_KEYWORDS = frozenset(
     {
@@ -256,10 +257,8 @@ def _find_secret_fields(value: Any, *, prefix: str = "") -> list[str]:
         for raw_key, raw_item in value.items():
             key = str(raw_key)
             path = f"{prefix}.{key}" if prefix else key
-            key_segments = {segment for segment in key.lower().split("_") if segment}
-            if key.lower() in SECRET_FIELD_NAMES or key_segments.intersection(
-                SECRET_FIELD_NAMES
-            ):
+            key_segments = _secret_key_segments(key)
+            if key.lower() in SECRET_FIELD_NAMES or key_segments.intersection(SECRET_FIELD_SEGMENTS):
                 findings.append(path)
             findings.extend(_find_secret_fields(raw_item, prefix=path))
     elif isinstance(value, list):
@@ -376,25 +375,46 @@ def _normalize_statement(statement: str) -> str:
     return re.sub(r"\s+", " ", statement.strip()).upper()
 
 
+def _secret_key_segments(key: str) -> set[str]:
+    separated = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", key)
+    return {segment for segment in re.split(r"[_\-.]+", separated.lower()) if segment}
+
+
 def _statement_tokens(normalized: str) -> set[str]:
     return set(re.findall(r"[A-Z_][A-Z0-9_]*", normalized))
 
 
-def _enforce_forbidden_table_tokens(
-    normalized: str, config: ContextQueryConfig | None
-) -> None:
+def _extract_direct_table_references(normalized: str) -> set[str]:
+    refs: set[str] = set()
+    refs.update(re.findall(r"\bFROM\s+([A-Z_][A-Z0-9_]*)\b", normalized))
+    refs.update(re.findall(r"\bINFO\s+FOR\s+TABLE\s+([A-Z_][A-Z0-9_]*)\b", normalized))
+    return refs
+
+
+def _enforce_table_policy_tokens(normalized: str, config: ContextQueryConfig | None) -> None:
     if config is None:
         return
 
     # v0 uses conservative token-based forbidden table detection; this is not
     # a SurrealQL parser and intentionally fails closed for direct table tokens.
-    tokens = _statement_tokens(normalized)
+    table_refs = _extract_direct_table_references(normalized)
+    if not table_refs:
+        table_refs = _statement_tokens(normalized)
+    allowed_tables = {table.upper() for table in config.allowed_tables}
+    forbidden_tables = {table.upper() for table in config.forbidden_tables}
     forbidden_hits = sorted(
-        table for table in config.forbidden_tables if table.upper() in tokens
+        table for table in config.forbidden_tables if table.upper() in table_refs
     )
     if forbidden_hits:
         raise WriteDeniedError(
             "statement references forbidden table(s): " f"{forbidden_hits}"
+        )
+    unknown_hits = sorted(
+        table for table in table_refs if table not in allowed_tables and table not in forbidden_tables
+    )
+    if unknown_hits:
+        raise WriteDeniedError(
+            "statement references table(s) outside allowed_tables: " f"{unknown_hits}"
         )
 
 
@@ -423,7 +443,7 @@ def classify_statement(
 
     for prefix in ALLOWED_PREFIXES:
         if normalized == prefix or normalized.startswith(f"{prefix} "):
-            _enforce_forbidden_table_tokens(normalized, config)
+            _enforce_table_policy_tokens(normalized, config)
             return StatementClassification(
                 statement=statement,
                 normalized=normalized,

--- a/tools/surrealdb/context_query.py
+++ b/tools/surrealdb/context_query.py
@@ -1,0 +1,549 @@
+"""SurrealDB context query CLI scaffold (read-only, no-network).
+
+Issues:
+    #2080 - Context Query CLI scaffold + config loader + statement classifier v0
+    Parent: #2079
+    Epic: #1976
+    Depends on: #1992, #2068, #2069
+    Config basis: #2081
+
+This module implements only the first safe query slice:
+
+* a minimal ``classify`` CLI subcommand,
+* explicit local config loading and validation,
+* a fail-closed SurrealQL statement classifier,
+* a no-op query adapter boundary that never opens network sockets.
+
+There is no SurrealDB SDK usage, no real DB connection, no retrieval, no apply,
+and no write path in this slice.
+
+Exit codes:
+    0 = success
+    1 = validation failure
+    2 = argparse usage error
+    3 = input/config not found
+    4 = unsupported format
+    5 = write denied
+    6 = internal error
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+from dataclasses import dataclass
+import json
+import logging
+from pathlib import Path
+import re
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+SCHEMA_VERSION = "context-query/v0"
+CONFIG_SCHEMA_VERSION = "context-query-local/v0"
+
+EXIT_OK = 0
+EXIT_VALIDATION_ERROR = 1
+EXIT_USAGE_ERROR = 2
+EXIT_INPUT_NOT_FOUND = 3
+EXIT_UNSUPPORTED_FORMAT = 4
+EXIT_WRITE_DENIED = 5
+EXIT_INTERNAL = 6
+
+SUPPORTED_FORMATS = frozenset({"json", "markdown", "text"})
+
+TRADING_STATE_TABLES = frozenset(
+    {
+        "orders",
+        "fills",
+        "positions",
+        "balances",
+        "pnl",
+        "risk_state",
+        "execution_state",
+    }
+)
+GOVERNANCE_MIRROR_TABLES = frozenset(
+    {"governance_event", "governance_decision", "governance_state"}
+)
+FORBIDDEN_CONTEXT_QUERY_TABLES = TRADING_STATE_TABLES | GOVERNANCE_MIRROR_TABLES
+
+SECRET_FIELD_NAMES = frozenset({"password", "token", "api_key", "secret", "credential"})
+
+DENIED_KEYWORDS = frozenset(
+    {
+        "CREATE",
+        "INSERT",
+        "UPDATE",
+        "UPSERT",
+        "DELETE",
+        "RELATE",
+        "MERGE",
+        "PATCH",
+        "DEFINE",
+        "REMOVE",
+        "ALTER",
+        "LIVE",
+        "KILL",
+        "USE",
+        "BEGIN",
+        "COMMIT",
+        "CANCEL",
+        "EXPLAIN",
+        "SHOW CHANGES",
+        "INFO FOR ROOT",
+    }
+)
+ALLOWED_PREFIXES = ("SELECT", "INFO FOR DB", "INFO FOR TABLE", "INFO FOR NS")
+
+
+class ContextQueryError(Exception):
+    """Base error for context_query."""
+
+    code: str = "CONTEXT_QUERY_ERROR"
+    exit_code: int = EXIT_INTERNAL
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class ConfigValidationError(ContextQueryError):
+    """Raised when the local query config is invalid or unsafe."""
+
+    code = "CONFIG_VALIDATION_ERROR"
+    exit_code = EXIT_VALIDATION_ERROR
+
+
+class InputNotFoundError(ContextQueryError):
+    """Raised when an explicitly supplied config path does not exist."""
+
+    code = "INPUT_NOT_FOUND"
+    exit_code = EXIT_INPUT_NOT_FOUND
+
+
+class UnsupportedFormatError(ContextQueryError):
+    """Raised when an unsupported output format is requested internally."""
+
+    code = "UNSUPPORTED_FORMAT"
+    exit_code = EXIT_UNSUPPORTED_FORMAT
+
+
+class WriteDeniedError(ContextQueryError):
+    """Raised when a statement or flow would write or control state."""
+
+    code = "WRITE_DENIED"
+    exit_code = EXIT_WRITE_DENIED
+
+
+
+@dataclass(frozen=True)
+class ContextQueryConfig:
+    """Validated local config for context query classification."""
+
+    path: Path
+    schema_version: str
+    surreal_url: str
+    namespace: str
+    database: str
+    auth_mode: str
+    timeout: int
+    read_only: bool
+    mode_read_only: bool
+    surrealdb_write: str
+    surrealdb_apply: str
+    allowed_tables: tuple[str, ...]
+    forbidden_tables: tuple[str, ...]
+    max_limit_default: int
+    max_limit_hard: int
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "schema_version": self.schema_version,
+            "surreal_url": self.surreal_url,
+            "namespace": self.namespace,
+            "database": self.database,
+            "auth_mode": self.auth_mode,
+            "timeout": self.timeout,
+            "read_only": self.read_only,
+            "mode": {
+                "read_only": self.mode_read_only,
+                "surrealdb_write": self.surrealdb_write,
+                "surrealdb_apply": self.surrealdb_apply,
+            },
+            "allowed_tables": list(self.allowed_tables),
+            "forbidden_tables": list(self.forbidden_tables),
+            "max_limit_default": self.max_limit_default,
+            "max_limit_hard": self.max_limit_hard,
+        }
+
+
+@dataclass(frozen=True)
+class StatementClassification:
+    """Deterministic read-only classifier result."""
+
+    statement: str
+    normalized: str
+    allowed: bool
+    operation: str
+    reason: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "statement": self.statement,
+            "normalized": self.normalized,
+            "allowed": self.allowed,
+            "operation": self.operation,
+            "reason": self.reason,
+        }
+
+
+class NoopQueryAdapter:
+    """No-network query adapter placeholder for this scaffold."""
+
+    status = "noop-no-network"
+
+    def classify(self, statement: str) -> StatementClassification:
+        return classify_statement(statement)
+
+
+def _require_mapping(value: Any, *, path: Path | None = None) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        detail = f" in {path}" if path is not None else ""
+        raise ConfigValidationError(f"config root must be a mapping{detail}")
+    return value
+
+
+def _require_str(data: Mapping[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigValidationError(f"{key} must be a non-empty string")
+    return value
+
+
+def _require_bool(data: Mapping[str, Any], key: str) -> bool:
+    value = data.get(key)
+    if not isinstance(value, bool):
+        raise ConfigValidationError(f"{key} must be a boolean")
+    return value
+
+
+def _require_int(data: Mapping[str, Any], key: str) -> int:
+    value = data.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ConfigValidationError(f"{key} must be an integer")
+    return value
+
+
+def _require_str_list(data: Mapping[str, Any], key: str) -> tuple[str, ...]:
+    value = data.get(key)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ConfigValidationError(f"{key} must be a list of strings")
+    return tuple(value)
+
+
+def _find_secret_fields(value: Any, *, prefix: str = "") -> list[str]:
+    findings: list[str] = []
+    if isinstance(value, Mapping):
+        for raw_key, raw_item in value.items():
+            key = str(raw_key)
+            path = f"{prefix}.{key}" if prefix else key
+            if key.lower() in SECRET_FIELD_NAMES:
+                findings.append(path)
+            findings.extend(_find_secret_fields(raw_item, prefix=path))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            path = f"{prefix}[{index}]" if prefix else f"[{index}]"
+            findings.extend(_find_secret_fields(item, prefix=path))
+    return findings
+
+
+def load_config(path: Path) -> ContextQueryConfig:
+    """Load and validate an explicit local context query config."""
+
+    try:
+        exists = path.exists()
+        is_file = path.is_file() if exists else False
+    except OSError as exc:
+        raise InputNotFoundError(f"cannot stat config file: {path}: {exc}") from exc
+
+    if not exists:
+        raise InputNotFoundError(f"config file not found: {path}")
+    if not is_file:
+        raise ConfigValidationError(f"config path is not a file: {path}")
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ConfigValidationError(f"invalid YAML config: {path}: {exc}") from exc
+    except OSError as exc:
+        raise InputNotFoundError(f"cannot read config file: {path}: {exc}") from exc
+
+    data = _require_mapping(raw, path=path)
+    secret_fields = _find_secret_fields(data)
+    if secret_fields:
+        raise ConfigValidationError(
+            "config must not contain secret-bearing fields: " f"{sorted(secret_fields)}"
+        )
+
+    schema_version = _require_str(data, "schema_version")
+    if schema_version != CONFIG_SCHEMA_VERSION:
+        raise ConfigValidationError(
+            "unsupported config schema_version: "
+            f"{schema_version!r}; expected {CONFIG_SCHEMA_VERSION!r}"
+        )
+
+    read_only = _require_bool(data, "read_only")
+    if read_only is not True:
+        raise ConfigValidationError("read_only must be true for context query config")
+
+    mode = _require_mapping(data.get("mode"))
+    mode_read_only = _require_bool(mode, "read_only")
+    if mode_read_only is not True:
+        raise ConfigValidationError("mode.read_only must be true")
+
+    surrealdb_write = _require_str(mode, "surrealdb_write")
+    if surrealdb_write != "forbidden":
+        raise ConfigValidationError("mode.surrealdb_write must be 'forbidden'")
+
+    surrealdb_apply = _require_str(mode, "surrealdb_apply")
+    if surrealdb_apply != "forbidden":
+        raise ConfigValidationError("mode.surrealdb_apply must be 'forbidden'")
+
+    allowed_tables = _require_str_list(data, "allowed_tables")
+    forbidden_tables = _require_str_list(data, "forbidden_tables")
+
+    forbidden_in_allowed = sorted(
+        set(allowed_tables).intersection(FORBIDDEN_CONTEXT_QUERY_TABLES)
+    )
+    if forbidden_in_allowed:
+        raise ConfigValidationError(
+            "allowed_tables contains forbidden trading/governance tables: "
+            f"{forbidden_in_allowed}"
+        )
+
+    missing_forbidden = sorted(
+        FORBIDDEN_CONTEXT_QUERY_TABLES.difference(forbidden_tables)
+    )
+    if missing_forbidden:
+        raise ConfigValidationError(
+            "forbidden_tables must explicitly include all blocked "
+            f"trading/governance tables; missing: {missing_forbidden}"
+        )
+
+    overlap = sorted(set(allowed_tables).intersection(forbidden_tables))
+    if overlap:
+        raise ConfigValidationError(
+            f"tables may not appear in both allowed_tables and forbidden_tables: {overlap}"
+        )
+
+    max_limit_default = _require_int(data, "max_limit_default")
+    max_limit_hard = _require_int(data, "max_limit_hard")
+    if max_limit_default > max_limit_hard:
+        raise ConfigValidationError("max_limit_default must be <= max_limit_hard")
+
+    return ContextQueryConfig(
+        path=path,
+        schema_version=schema_version,
+        surreal_url=_require_str(data, "surreal_url"),
+        namespace=_require_str(data, "namespace"),
+        database=_require_str(data, "database"),
+        auth_mode=_require_str(data, "auth_mode"),
+        timeout=_require_int(data, "timeout"),
+        read_only=read_only,
+        mode_read_only=mode_read_only,
+        surrealdb_write=surrealdb_write,
+        surrealdb_apply=surrealdb_apply,
+        allowed_tables=allowed_tables,
+        forbidden_tables=forbidden_tables,
+        max_limit_default=max_limit_default,
+        max_limit_hard=max_limit_hard,
+    )
+
+
+def _normalize_statement(statement: str) -> str:
+    return re.sub(r"\s+", " ", statement.strip()).upper()
+
+
+def classify_statement(statement: str) -> StatementClassification:
+    """Classify a SurrealQL statement as allowed read-only or denied."""
+
+    normalized = _normalize_statement(statement)
+    if not normalized:
+        raise ConfigValidationError("statement must be non-empty")
+
+    if ";" in statement:
+        raise WriteDeniedError("multi-statement input is denied in v0")
+
+    if re.search(r"\b(APPLY|MIGRATION|TRANSACTION)\b", normalized):
+        raise WriteDeniedError("transaction/migration/apply flows are denied")
+
+    for keyword in sorted(DENIED_KEYWORDS, key=len, reverse=True):
+        if keyword in {"SHOW CHANGES", "INFO FOR ROOT"}:
+            if normalized.startswith(keyword):
+                raise WriteDeniedError(f"{keyword} statements are denied")
+            continue
+        if normalized == keyword or normalized.startswith(f"{keyword} "):
+            raise WriteDeniedError(f"{keyword} statements are denied")
+
+    for prefix in ALLOWED_PREFIXES:
+        if normalized == prefix or normalized.startswith(f"{prefix} "):
+            return StatementClassification(
+                statement=statement,
+                normalized=normalized,
+                allowed=True,
+                operation=prefix,
+                reason="read-only statement allowed by v0 classifier",
+            )
+
+    raise WriteDeniedError("statement is not in the v0 read-only allowlist")
+
+
+def _error_payload(exc: ContextQueryError) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "error",
+        "error": exc.code,
+        "message": exc.message,
+    }
+
+
+def _render(payload: dict[str, Any], fmt: str) -> str:
+    if fmt == "json":
+        return json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2)
+    if fmt == "text":
+        lines = [f"status: {payload.get('status', 'unknown')}"]
+        if "classification" in payload:
+            classification = payload["classification"]
+            lines.append(f"operation: {classification['operation']}")
+            lines.append(f"allowed: {classification['allowed']}")
+        if "error" in payload:
+            lines.append(f"error: {payload['error']}")
+            lines.append(f"message: {payload.get('message', '')}")
+        lines.append(f"surrealdb_connection: {payload.get('surrealdb_connection', 'n/a')}")
+        return "\n".join(lines)
+    if fmt == "markdown":
+        lines = ["# context_query: classify", f"- **status**: `{payload.get('status')}`"]
+        if "classification" in payload:
+            classification = payload["classification"]
+            lines.extend(
+                [
+                    f"- **operation**: `{classification['operation']}`",
+                    f"- **allowed**: `{classification['allowed']}`",
+                    f"- **surrealdb_connection**: `{payload.get('surrealdb_connection')}`",
+                ]
+            )
+        if "error" in payload:
+            lines.extend(
+                [
+                    f"- **error**: `{payload['error']}`",
+                    f"- **message**: `{payload.get('message', '')}`",
+                ]
+            )
+        return "\n".join(lines)
+    raise UnsupportedFormatError(f"unsupported format: {fmt!r}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="context_query",
+        description=(
+            "Context Query CLI scaffold (#2080). Read-only statement "
+            "classification only; no SurrealDB connection, no writes."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Local context query config YAML to load and validate.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=sorted(SUPPORTED_FORMATS),
+        default="json",
+        help="Render format for command output (default: json).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Optional query limit; validated against config hard limit when config is loaded.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    classify = subparsers.add_parser(
+        "classify",
+        help="Classify a SurrealQL statement without connecting to SurrealDB.",
+    )
+    classify.add_argument(
+        "--statement",
+        required=True,
+        help="Single SurrealQL statement to classify. Semicolons are denied in v0.",
+    )
+    return parser
+
+
+def _handle(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
+    if args.command == "classify" and args.config is None:
+        raise InputNotFoundError("--config is required for classify; no default config is searched")
+
+    config = load_config(args.config) if args.config is not None else None
+    if args.limit is not None and args.limit < 1:
+        raise ConfigValidationError("--limit must be >= 1")
+    if config is not None and args.limit is not None and args.limit > config.max_limit_hard:
+        raise ConfigValidationError("--limit may not exceed max_limit_hard from config")
+
+    adapter = NoopQueryAdapter()
+    classification = adapter.classify(args.statement)
+    return (
+        {
+            "schema_version": SCHEMA_VERSION,
+            "command": args.command,
+            "status": "ok",
+            "surrealdb_connection": adapter.status,
+            "config_loaded": config is not None,
+            "config": config.to_payload() if config is not None else None,
+            "limit": args.limit,
+            "classification": classification.to_payload(),
+        },
+        EXIT_OK,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        payload, exit_code = _handle(args)
+        rendered = _render(payload, args.format)
+    except ContextQueryError as exc:
+        print(json.dumps(_error_payload(exc), ensure_ascii=True, sort_keys=True))
+        return exc.exit_code
+    except Exception as exc:  # noqa: BLE001 - CLI scaffold safety net
+        logger.exception("context_query internal error")
+        print(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "status": "error",
+                    "error": "INTERNAL",
+                    "message": str(exc),
+                },
+                ensure_ascii=True,
+                sort_keys=True,
+            )
+        )
+        return EXIT_INTERNAL
+
+    print(rendered)
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tools/surrealdb/context_query.py
+++ b/tools/surrealdb/context_query.py
@@ -208,8 +208,11 @@ class NoopQueryAdapter:
 
     status = "noop-no-network"
 
+    def __init__(self, config: ContextQueryConfig | None = None) -> None:
+        self.config = config
+
     def classify(self, statement: str) -> StatementClassification:
-        return classify_statement(statement)
+        return classify_statement(statement, config=self.config)
 
 
 def _require_mapping(value: Any, *, path: Path | None = None) -> Mapping[str, Any]:
@@ -253,7 +256,10 @@ def _find_secret_fields(value: Any, *, prefix: str = "") -> list[str]:
         for raw_key, raw_item in value.items():
             key = str(raw_key)
             path = f"{prefix}.{key}" if prefix else key
-            if key.lower() in SECRET_FIELD_NAMES:
+            key_segments = {segment for segment in key.lower().split("_") if segment}
+            if key.lower() in SECRET_FIELD_NAMES or key_segments.intersection(
+                SECRET_FIELD_NAMES
+            ):
                 findings.append(path)
             findings.extend(_find_secret_fields(raw_item, prefix=path))
     elif isinstance(value, list):
@@ -370,7 +376,31 @@ def _normalize_statement(statement: str) -> str:
     return re.sub(r"\s+", " ", statement.strip()).upper()
 
 
-def classify_statement(statement: str) -> StatementClassification:
+def _statement_tokens(normalized: str) -> set[str]:
+    return set(re.findall(r"[A-Z_][A-Z0-9_]*", normalized))
+
+
+def _enforce_forbidden_table_tokens(
+    normalized: str, config: ContextQueryConfig | None
+) -> None:
+    if config is None:
+        return
+
+    # v0 uses conservative token-based forbidden table detection; this is not
+    # a SurrealQL parser and intentionally fails closed for direct table tokens.
+    tokens = _statement_tokens(normalized)
+    forbidden_hits = sorted(
+        table for table in config.forbidden_tables if table.upper() in tokens
+    )
+    if forbidden_hits:
+        raise WriteDeniedError(
+            "statement references forbidden table(s): " f"{forbidden_hits}"
+        )
+
+
+def classify_statement(
+    statement: str, config: ContextQueryConfig | None = None
+) -> StatementClassification:
     """Classify a SurrealQL statement as allowed read-only or denied."""
 
     normalized = _normalize_statement(statement)
@@ -393,6 +423,7 @@ def classify_statement(statement: str) -> StatementClassification:
 
     for prefix in ALLOWED_PREFIXES:
         if normalized == prefix or normalized.startswith(f"{prefix} "):
+            _enforce_forbidden_table_tokens(normalized, config)
             return StatementClassification(
                 statement=statement,
                 normalized=normalized,
@@ -498,7 +529,7 @@ def _handle(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
     if config is not None and args.limit is not None and args.limit > config.max_limit_hard:
         raise ConfigValidationError("--limit may not exceed max_limit_hard from config")
 
-    adapter = NoopQueryAdapter()
+    adapter = NoopQueryAdapter(config=config)
     classification = adapter.classify(args.statement)
     return (
         {


### PR DESCRIPTION
## Summary
- Adds the first read-only Context Query CLI scaffold for #2080.
- Adds config loading/validation based on #2081.
- Adds fail-closed Statement Classifier v0.
- Adds CLI/config/classifier unit tests.

## Closes
- Closes #2080

## References
- Parent: #2079
- Epic: #1976
- Depends on: #1992, #2068, #2069
- Config basis: #2081

## Scope
- New `tools/surrealdb/context_query.py`
- New unit tests for config, classifier, CLI
- No real SurrealDB connection
- No SDK usage
- No network/socket use
- No DB apply
- No migration
- No retrieval implementation
- No Agent tools
- No Runtime/Trading/Risk/Execution/Strategy changes
- No LR/live/Echtgeld implication

## Validation
- `python tools/surrealdb/context_query.py --help`
- classify without `--config` fails closed with `INPUT_NOT_FOUND`, exit 3
- SELECT classify with config exits 0
- DELETE classify with config fails `WRITE_DENIED`, exit 5
- `pytest -q tests/unit/surrealdb/test_context_query_config.py`
- `pytest -q tests/unit/surrealdb/test_context_query_classifier.py`
- `pytest -q tests/unit/surrealdb/test_context_query_cli.py`
- Expected total: 52 passed

## Guardrails
- `--config` is required for classify; no default config is searched
- Config validation requires `read_only: true`
- `mode.read_only` must be true
- `mode.surrealdb_write` and `mode.surrealdb_apply` must be `forbidden`
- Secret-bearing fields are rejected
- Trading-State and Governance-Mirror tables are forbidden in `allowed_tables`
- Multi-statement input is denied
- Write/schema/live/control statements are denied
- `EXPLAIN`, `SHOW CHANGES`, and `INFO FOR ROOT` are denied in v0