### PR TITLE
docs(architecture): reconcile signal audit metadata for #2131

### DIFF
--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -56,7 +56,7 @@ Claire de Binare ist ein **event-getriebenes Krypto-Trading-System** mit:
 | Service | Container | Port | Funktion |
 |---------|-----------|------|----------|
 | WebSocket | cdb_ws | 8000 | MEXC Market Data Stream |
-| Signal | cdb_signal | 8005 (Runtime) | Signal Generation (primary_breakout_v1: time-windowed lookback) |
+| Signal | cdb_signal | 8005 (Runtime) | Signal Generation (primary_breakout_v1: time-windowed lookback); audit metadata: `config_snapshot` (runtime params) + deterministic `config_hash` (SHA-256); SIGNAL_BOT_ID wired via compose.red.yml (PR #2129) for experiment identity; reserved metadata keys protected against override; used by Paper Reference Exporter (PR #2133) for signal-anchored bot_id/config_hash filtering in replay-vs-paper comparisons |
 | Prometheus | cdb_prometheus | 19090→9090 | Metrics |
 | Grafana | cdb_grafana | 3000 | Dashboards |
 | Postgres Exporter | cdb_postgres_exporter | 9187 | PG Metrics |

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -39,10 +39,10 @@
 | Service | Container | Port | Code | Status | Funktion |
 |---------|-----------|------|------|--------|----------|
 | **WebSocket** | cdb_ws | 8000 | services/ws/ | **AKTIV** | MEXC Market Data Stream (protobuf) |
-| **Signal** | cdb_signal | 8005 (Runtime) | services/signal/ | **AKTIV** | Signal Generation (`primary_breakout_v1` default nutzt zeitbasierte Lookback-Semantik, `momentum_builtin` statische Adapter-Grenze) |
+| **Signal** | cdb_signal | 8005 (Runtime) | services/signal/ | **AKTIV** | Signal Generation (`primary_breakout_v1` default nutzt zeitbasierte Lookback-Semantik, `momentum_builtin` statische Adapter-Grenze); audit metadata: `config_snapshot` (deterministic runtime params snapshot) + `config_hash` (full SHA-256); `SIGNAL_BOT_ID` environment variable wired via compose.red.yml (PR #2129) für Experiment-Identity; reserved metadata keys (strategy_id, bot_id, config_snapshot, config_hash, signal_reason, signal_inputs) sind immutable und können nicht durch Candidate-Signal-Metadata überschrieben werden |
 | **Reports** | cdb_reports | — | services/reports/ | **AKTIV** | Daily Order Summary + Email |
 
-Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.py` bei `8001`; im kanonischen RED-Runtime-Pfad wird fuer `cdb_signal` in `infrastructure/compose/compose.red.yml` explizit `SIGNAL_PORT=8005` gesetzt.
+Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.py` bei `8001`; im kanonischen RED-Runtime-Pfad wird fuer `cdb_signal` in `infrastructure/compose/compose.red.yml` explizit `SIGNAL_PORT=8005` gesetzt. Ebenso wird `SIGNAL_BOT_ID` (audit identity) explizit via `environment:` durchgereicht (PR #2129).
 
 ---
 
@@ -77,7 +77,7 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 | **Compare CLI Runner** | `services/validation/replay_vs_paper_compare_runner.py` | **AKTIV** (PR #1914) | Operator-facing CLI (`--replay-report FILE --paper-reference FILE --output-dir DIR`). Produces shadow_comparison artifacts. Exit codes: 0 aligned / 1 usage error / 2 parse/unusable. |
 | **Calibration Report CLI** | `services/validation/simulator_calibration_report_runner.py` | **AKTIV** (PR #1916) | Operator-facing CLI (`--comparison shadow_comparison.json --output-dir DIR`). Produces simulator_calibration_report.json + simulator_calibration_summary.md. Exit codes: 0 aligned / 1 usage error / 2 parse/unusable. |
 | **Regime Scorecard CLI** | `services/validation/arvp_regime_scorecard_runner.py` | **AKTIV** (PR #1918) | Operator-facing CLI (`--run-id ID --replay-trace FILE --comparison FILE --output-dir DIR`). Optional inputs; fail-closed on invalid JSON. Produces arvp_regime_scorecard.json + arvp_regime_scorecard_summary.md. Exit codes: 0 ok / 1 usage / 2 parse error. |
-| **Paper Reference Window CLI** | `services/validation/paper_reference_window_runner.py` | **AKTIV** (PR #1920) | Operator-facing CLI (`--strategy-id ID --symbol SYM --start-ts-ms TS --end-ts-ms TS --output FILE`). Reads correlation_ledger from Postgres; produces arvp_paper_reference_window.v1 JSON. Exit codes: 0 success / 1 usage / 2 DB/contract error. |
+| **Paper Reference Window CLI** | `services/validation/paper_reference_window_runner.py` | **AKTIV** (PR #1920, PR #2133) | Operator-facing CLI (`--strategy-id ID --symbol SYM --start-ts-ms TS --end-ts-ms TS --output FILE`). Reads correlation_ledger from Postgres; produces arvp_paper_reference_window.v1 JSON. Fail-closed validation: requires ≥1 ORDER + ≥1 FILL mit paper_-prefix. Signal audit context (`bot_id`, `config_hash`) wird durch PR #2133 Exporter Guards zur Chain-Validierung herangezogen. Exit codes: 0 success / 1 usage / 2 DB/contract error. |
 
 **Interne Abhängigkeiten:** Nutzen `core/replay/canonical_json.py` (deterministic serialization), `core/replay/envelopes.py` (envelope tracking).
 


### PR DESCRIPTION
## Summary
Docs-only reconciliation of architecture documentation after merged PR #2129 and PR #2133.

## References
Closes #2131

## Evidence
- PR #2129 merged: feat(signal): add auditability config snapshot to signal metadata
- PR #2133 merged: feat(arvp): guard paper reference exports by signal audit context
- Final diff limited to:
  - `knowledge/ARCHITECTURE_MAP.md`
  - `knowledge/governance/SERVICE_CATALOG.md`

## Changes
- Document PR #2129 signal audit metadata:
  - `config_snapshot` (runtime params)
  - deterministic `config_hash` (SHA-256)
  - `SIGNAL_BOT_ID` wired via compose.red.yml
  - reserved metadata keys protected from override
- Document PR #2133 paper reference export guard context:
  - Paper Reference Window CLI uses signal audit context (`bot_id`, `config_hash`)
  - Chain-validation context for replay-vs-paper comparisons

## Guardrails
- docs-only
- no runtime change
- no trading/risk/execution/strategy change
- no LR/live/echtgeld implication
- LR remains NO-GO
