### PR TITLE
docs(validation): define wave-11 completion gates for #2090

### DIFF
--- a/docs/surrealdb/context-wave11-completion-gates.md
+++ b/docs/surrealdb/context-wave11-completion-gates.md
@@ -1,0 +1,189 @@
+# Wave-11 Completion Gates
+
+**Status**: Draft
+**Authority**: Issue #2090 / Wave 11 / Epic #1976
+**Parent**: #2079
+
+This document defines the completion gates for Wave-11 (Context Query CLI and read-only retrieval foundation).
+
+---
+
+## 1. Scope Baseline
+
+### 1.1 Parent & Child Issues
+
+| Issue | Title | State |
+|-------|-------|-------|
+| #2079 | Wave-11 anchor | OPEN |
+| #2080 | Context query CLI scaffold | CLOSED |
+| #2081 | Read-only context query connection config | CLOSED |
+| #2082 | Artifact and documentation search v0 | CLOSED |
+| #2083 | Symbol and import query v0 | CLOSED |
+| #2084 | Dependency trace query v0 | CLOSED |
+| #2085 | Explain-source query v0 | CLOSED |
+| #2086 | Snapshot/drift/audit query views | CLOSED |
+| #2087 | Standard query output | CLOSED |
+| #2088 | Tests and fixtures for query CLI | CLOSED |
+| #2089 | Local query runbook | CLOSED |
+| #2090 | Wave-11 completion gates | CLOSED |
+
+### 1.2 Merged PRs
+
+| PR | Title | State |
+|----|-------|-------|
+| #2243 | feat(surrealdb): context query CLI scaffold for #2080 | MERGED |
+| #2247 | feat(surrealdb): add read-only context query config for #2081 | MERGED |
+| #2250 | feat(surrealdb): add read-only artifact and doc search for #2082 | MERGED |
+| #2253 | feat(surrealdb): add read-only symbol/import query v0 for #2083 | MERGED |
+| #2259 | feat(surrealdb): add read-only trace query v0 for #2084 | MERGED |
+| #2260 | feat(surrealdb): add read-only explain-source query v0 for #2085 | MERGED |
+| #2261 | feat(surrealdb): add read-only report query views for #2086 | MERGED |
+| #2262 | docs(surrealdb): document context query output contract for #2087 | MERGED |
+| #2263 | test(surrealdb): add context query CLI tests for #2088 | MERGED |
+| #2264 | docs(runbook): add local context query runbook for #2089 | MERGED |
+
+---
+
+## 2. Completion Gates
+
+### 2.1 Issue Closure Gate
+
+- [x] All child issues #2080-#2089 are CLOSED
+- [x] #2090 will be CLOSED upon this document merge
+- [x] #2079 remains OPEN (requires separate reconciliation, not in this run)
+
+### 2.2 PR Merge Gate
+
+- [x] All 10 PRs are MERGED
+- [x] No open PRs in the Wave-11 branch
+
+### 2.3 Read-Only Enforcement Gate
+
+- [x] All queries are SELECT-only
+- [x] Statement classifier denies write operations
+- [x] Forbidden tables enforced:
+  - Trading: orders, fills, positions, balances, pnl, risk_state, execution_state
+  - Governance: governance_event, governance_decision, governance_state
+
+### 2.4 No DB Write Gate
+
+- [x] No SurrealDB migrations required
+- [x] No DB writes in any PR
+- [x] Config enforces `surrealdb_write: forbidden` and `surrealdb_apply: forbidden`
+
+### 2.5 No Memory Write Gate
+
+- [x] No Memory (Nexus) writes in any PR
+- [x] CLI is read-only only
+
+### 2.6 No Trading/Risk/Execution/Strategy Change Gate
+
+- [x] No changes to trading-state tables
+- [x] No changes to risk service
+- [x] No changes to execution logic
+- [x] No changes to strategy behavior
+
+### 2.7 Live-Readiness Gate
+
+- [x] LR verdict remains **NO-GO** (unchanged)
+- [x] No Echtgeld implication
+- [x] Board stage remains `trade-capable` (unchanged)
+
+---
+
+## 3. Evidence Checklist
+
+### 3.1 PR/Issue State Verification Commands
+
+```bash
+# Verify all child issues are closed
+gh issue view 2080 --json state
+gh issue view 2081 --json state
+gh issue view 2082 --json state
+gh issue view 2083 --json state
+gh issue view 2084 --json state
+gh issue view 2085 --json state
+gh issue view 2086 --json state
+gh issue view 2087 --json state
+gh issue view 2088 --json state
+gh issue view 2089 --json state
+gh issue view 2090 --json state
+```
+
+### 3.2 Targeted Validation Commands
+
+```bash
+# Run all context query tests
+python -m pytest tests/unit/surrealdb/test_context_query*.py -q
+
+# Run lint
+ruff check tools/surrealdb/context_query.py tests/unit/surrealdb/
+
+# Check formatting
+black --check tools/surrealdb/context_query.py tests/unit/surrealdb/
+```
+
+### 3.3 Files & Artifacts to Inspect
+
+| File | Purpose |
+|------|---------|
+| `tools/surrealdb/context_query.py` | CLI implementation |
+| `infrastructure/config/surrealdb/context_query.local.example.yaml` | Read-only config |
+| `docs/surrealdb/context-query-output-contract.md` | Output contract |
+| `docs/runbooks/surrealdb_context_query.md` | Local runbook |
+| `tests/unit/surrealdb/test_context_query*.py` | Test coverage |
+
+---
+
+## 4. Non-Goals (Confirmed Out of Scope)
+
+- [x] No Wave-12 scope (MCP bridge, agent briefing engine, vector search)
+- [x] No production DB access
+- [x] No Live Readiness upgrade
+- [x] No Echtgeld-Go
+- [x] No trading-state changes
+- [x] No risk service changes
+- [x] No execution logic changes
+- [x] No strategy behavior changes
+
+---
+
+## 5. Residual Risks
+
+| Risk | Assessment |
+|------|-------------|
+| Mocked/noop adapter limits | Acceptable for v0; live DB validation deferred |
+| Schema assumptions | Based on existing allowed tables in config |
+| No live DB validation | Tests use mocked adapter; no network required |
+| Future integration | Belongs to later waves (Wave-12+) |
+
+---
+
+## 6. Recommended Next Step
+
+After #2090 closure:
+
+1. Perform separate read-only #2079 anchor reconciliation
+   - This should be done in a **separate run** after Wave-11 gates are fully merged
+   - Do NOT close #2079 from this run
+
+2. Consider future waves:
+   - Wave-12: MCP bridge for agent tooling
+   - Vector search integration
+   - Production DB activation (requires separate governance)
+
+---
+
+## 7. Gate Sign-Off
+
+| Gate | Status |
+|------|--------|
+| Issue Closure | PASS |
+| PR Merge | PASS |
+| Read-Only Enforcement | PASS |
+| No DB Write | PASS |
+| No Memory Write | PASS |
+| No Trading/Risk/Execution/Strategy Change | PASS |
+| Live-Readiness (LR NO-GO) | PASS |
+
+**Final Verdict**: Wave-11 completion gates PASSED


### PR DESCRIPTION
Closes #2090

Summary:
Defines Wave-11 completion gates for the Context Query CLI and read-only retrieval foundation.

Changes:
- Adds Wave-11 completion gate artifact.
- Covers child issue evidence, read-only guardrails, validation checklist, residual risks, and non-goals.
- Keeps #2079 Wave-11 anchor closeout explicitly out of scope.

Validation:
- git diff --check -> passed

Guardrails:
- docs-only
- no DB write/migration
- no Memory write
- no trading/risk/execution/strategy change
- no LR/live/echtgeld implication
- LR remains NO-GO

Out of scope:
- #2079 Wave-11 anchor closeout
- Wave-12+
- runtime/MCP/live DB integration