### PR TITLE
feat(surrealdb): add read-only context mcp bridge scaffold for #2093

### DIFF
--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -1,0 +1,97 @@
+"""
+Unit tests for Context MCP Bridge Scaffold.
+
+Tests the scaffold structure without requiring live SurrealDB or network.
+"""
+
+import pytest
+from tools.mcp.context_bridge import ContextBridge, create_bridge
+from tools.mcp.registry import ContextToolRegistry, ToolDefinition
+
+
+class TestContextToolRegistry:
+    """Tests for the Context Tool Registry."""
+
+    def test_registry_contains_v0_tools(self) -> None:
+        """Verify all v0 tools are registered."""
+        tool_names = ContextToolRegistry.list_tool_names()
+        expected_tools = [
+            "context.search",
+            "context.trace",
+            "context.explain_source",
+            "context.show_snapshot",
+            "context.show_audit",
+            "context.package",
+            "context.readiness",
+        ]
+        for expected in expected_tools:
+            assert expected in tool_names, f"Tool {expected} not registered"
+
+    def test_all_tools_are_read_only(self) -> None:
+        """Verify all registered tools are read-only."""
+        for tool in ContextToolRegistry.list_tools():
+            assert tool.read_only is True, f"Tool {tool.name} is not read-only"
+
+    def test_get_tool_returns_definition(self) -> None:
+        """Verify get_tool returns tool definition."""
+        tool = ContextToolRegistry.get_tool("context.search")
+        assert tool is not None
+        assert tool.name == "context.search"
+        assert "query" in tool.input_schema.get("properties", {})
+
+    def test_unknown_tool_returns_none(self) -> None:
+        """Verify unknown tool returns None."""
+        tool = ContextToolRegistry.get_tool("context.nonexistent")
+        assert tool is None
+
+
+class TestContextBridge:
+    """Tests for the Context Bridge."""
+
+    def test_bridge_creation(self) -> None:
+        """Verify bridge can be created."""
+        bridge = ContextBridge()
+        assert bridge is not None
+
+    def test_factory_function(self) -> None:
+        """Verify factory function creates bridge."""
+        bridge = create_bridge()
+        assert isinstance(bridge, ContextBridge)
+
+    def test_list_tools_returns_v0_tools(self) -> None:
+        """Verify list_tools returns all v0 tools."""
+        bridge = ContextBridge()
+        tools = bridge.list_tools()
+        assert len(tools) == 7
+        tool_names = [t["name"] for t in tools]
+        assert "context.search" in tool_names
+        assert "context.package" in tool_names
+
+    def test_get_tool_schema(self) -> None:
+        """Verify get_tool_schema returns schema."""
+        bridge = ContextBridge()
+        schema = bridge.get_tool_schema("context.search")
+        assert schema is not None
+        assert schema["name"] == "context.search"
+        assert schema["readOnly"] is True
+
+    def test_execute_not_implemented_tool(self) -> None:
+        """Verify executing stub tool returns not_implemented error."""
+        bridge = ContextBridge()
+        result = bridge.execute_tool("context.search", {"query": "test"})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "not_implemented"
+
+    def test_execute_unknown_tool(self) -> None:
+        """Verify executing unknown tool returns error."""
+        bridge = ContextBridge()
+        result = bridge.execute_tool("context.unknown")
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "unknown_tool"
+
+    def test_read_only_status(self) -> None:
+        """Verify read-only status is enforced."""
+        bridge = ContextBridge()
+        status = bridge.get_read_only_status()
+        assert status["enforced"] is True
+        assert len(status["read_only_tools"]) == 7

--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -95,3 +95,63 @@ class TestContextBridge:
         status = bridge.get_read_only_status()
         assert status["enforced"] is True
         assert len(status["read_only_tools"]) == 7
+
+
+class TestDefensiveSchemaCopies:
+    """Tests verifying that returned schemas are defensive copies."""
+
+    def test_list_tools_returns_defensive_copies(self) -> None:
+        """Verify list_tools returns defensive copies that caller can mutate."""
+        bridge = ContextBridge()
+        tools = bridge.list_tools()
+
+        caller_schema = tools[0]["inputSchema"]
+        original_properties = caller_schema.get("properties", {}).copy()
+
+        caller_schema["properties"]["caller_added_field"] = {"type": "string"}
+
+        tools_after = bridge.list_tools()
+        returned_schema = tools_after[0]["inputSchema"]
+
+        assert "caller_added_field" not in returned_schema.get(
+            "properties", {}
+        ), "Caller mutation should not affect returned schemas"
+
+    def test_get_tool_schema_returns_defensive_copy(self) -> None:
+        """Verify get_tool_schema returns defensive copy that caller can mutate."""
+        bridge = ContextBridge()
+        schema = bridge.get_tool_schema("context.search")
+
+        caller_input = schema["inputSchema"]
+        original_type = caller_input.get("type")
+
+        caller_input["type"] = "mutated_by_caller"
+
+        schema_after = bridge.get_tool_schema("context.search")
+        assert (
+            schema_after["inputSchema"]["type"] == original_type
+        ), "Caller mutation should not affect returned schema"
+
+    def test_mutation_of_returned_list_tools_does_not_affect_registry(self) -> None:
+        """Verify mutating returned list_tools does not affect registry."""
+        bridge = ContextBridge()
+
+        tools = bridge.list_tools()
+        tools[0]["name"] = "mutated_name"
+
+        tools_after = bridge.list_tools()
+        assert (
+            tools_after[0]["name"] != "mutated_name"
+        ), "Registry should not be affected by caller mutation"
+
+    def test_mutation_of_returned_schema_does_not_affect_registry(self) -> None:
+        """Verify mutating returned schema does not affect registry."""
+        bridge = ContextBridge()
+
+        schema = bridge.get_tool_schema("context.search")
+        schema["inputSchema"]["properties"]["new_field"] = {"type": "string"}
+
+        schema_after = bridge.get_tool_schema("context.search")
+        assert "new_field" not in schema_after["inputSchema"].get(
+            "properties", {}
+        ), "Registry schema should not be mutated by caller"

--- a/tools/mcp/__init__.py
+++ b/tools/mcp/__init__.py
@@ -1,0 +1,14 @@
+"""
+Context MCP Bridge - Read-only MCP bridge for SurrealDB Context Intelligence.
+
+This package provides an MCP-compatible interface to the Context Intelligence System,
+exposing read-only tools for agents without direct table access.
+
+Note: This is a scaffold implementation. Individual tool handlers are stubs
+that fail-closed until implemented in subsequent issues (#2094-#2097).
+"""
+
+from tools.mcp.context_bridge import ContextBridge
+
+__all__ = ["ContextBridge"]
+__version__ = "0.0.0"

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -1,0 +1,138 @@
+"""
+Context MCP Bridge - Read-only bridge for Context Intelligence.
+
+This module provides the MCP-compatible bridge to the SurrealDB Context Intelligence System.
+All tools are read-only and fail-closed.
+
+Reference:
+- Issue: #2093
+- Tool Contracts: docs/surrealdb/context-tool-contracts-v0.md
+- Parent: #2091 (Wave-12 MCP bridge)
+"""
+
+import logging
+from typing import Any, Optional
+
+from tools.mcp.registry import ContextToolRegistry, ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+
+class ContextBridge:
+    """
+    MCP Bridge for Context Intelligence System.
+
+    This bridge provides read-only access to Context Tools via MCP protocol.
+    All tools are fail-closed - they return errors rather than performing
+    unauthorized operations.
+
+    Important: This bridge does NOT provide:
+    - Live Readiness evaluation
+    - Echtgeld authorization
+    - Risk approval
+    - Execution clearance
+
+    The 'context.readiness' tool provides evaluation metadata only.
+    """
+
+    def __init__(self) -> None:
+        self._registry = ContextToolRegistry
+        logger.info(
+            f"ContextBridge initialized with tools: {self._registry.list_tool_names()}"
+        )
+
+    def list_tools(self) -> list[dict[str, Any]]:
+        """List all available tools with their definitions."""
+        tools = []
+        for tool in self._registry.list_tools():
+            tools.append(
+                {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "inputSchema": tool.input_schema,
+                    "outputSchema": tool.output_schema,
+                    "readOnly": tool.read_only,
+                }
+            )
+        return tools
+
+    def get_tool_schema(self, tool_name: str) -> Optional[dict[str, Any]]:
+        """Get the schema for a specific tool."""
+        tool = self._registry.get_tool(tool_name)
+        if tool is None:
+            return None
+        return {
+            "name": tool.name,
+            "description": tool.description,
+            "inputSchema": tool.input_schema,
+            "outputSchema": tool.output_schema,
+            "readOnly": tool.read_only,
+        }
+
+    def execute_tool(
+        self, tool_name: str, parameters: Optional[dict[str, Any]] = None
+    ) -> dict[str, Any]:
+        """
+        Execute a tool with the given parameters.
+
+        All tools are read-only and fail-closed.
+        If a tool is not yet implemented, it returns an error response.
+
+        Args:
+            tool_name: Name of the tool to execute
+            parameters: Tool-specific parameters
+
+        Returns:
+            Tool execution result
+        """
+        tool = self._registry.get_tool(tool_name)
+        if tool is None:
+            return {
+                "tool": tool_name,
+                "status": "error",
+                "error": {
+                    "code": "unknown_tool",
+                    "message": f"Unknown tool: {tool_name}",
+                },
+            }
+
+        if not tool.read_only:
+            return {
+                "tool": tool_name,
+                "status": "error",
+                "error": {
+                    "code": "write_not_allowed",
+                    "message": f"Tool {tool_name} is not read-only and cannot be executed",
+                },
+            }
+
+        parameters = parameters or {}
+        try:
+            result = tool.handler(**parameters)
+            return result
+        except Exception as e:
+            logger.exception(f"Error executing tool {tool_name}")
+            return {
+                "tool": tool_name,
+                "status": "error",
+                "error": {
+                    "code": "execution_error",
+                    "message": str(e),
+                },
+            }
+
+    def get_read_only_status(self) -> dict[str, Any]:
+        """Return the read-only enforcement status."""
+        return {
+            "enforced": True,
+            "description": "All Context MCP tools are read-only. Write operations are not permitted.",
+            "tools_count": len(self._registry.list_tools()),
+            "read_only_tools": [
+                t.name for t in self._registry.list_tools() if t.read_only
+            ],
+        }
+
+
+def create_bridge() -> ContextBridge:
+    """Factory function to create a ContextBridge instance."""
+    return ContextBridge()

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -11,6 +11,7 @@ Reference:
 """
 
 import logging
+from copy import deepcopy
 from typing import Any, Optional
 
 from tools.mcp.registry import ContextToolRegistry, ToolDefinition
@@ -42,30 +43,38 @@ class ContextBridge:
         )
 
     def list_tools(self) -> list[dict[str, Any]]:
-        """List all available tools with their definitions."""
+        """List all available tools with their definitions.
+
+        Returns defensive copies of schema dictionaries to prevent
+        caller mutations from affecting registry definitions.
+        """
         tools = []
         for tool in self._registry.list_tools():
             tools.append(
                 {
                     "name": tool.name,
                     "description": tool.description,
-                    "inputSchema": tool.input_schema,
-                    "outputSchema": tool.output_schema,
+                    "inputSchema": deepcopy(tool.input_schema),
+                    "outputSchema": deepcopy(tool.output_schema),
                     "readOnly": tool.read_only,
                 }
             )
         return tools
 
     def get_tool_schema(self, tool_name: str) -> Optional[dict[str, Any]]:
-        """Get the schema for a specific tool."""
+        """Get the schema for a specific tool.
+
+        Returns defensive copies of schema dictionaries to prevent
+        caller mutations from affecting registry definitions.
+        """
         tool = self._registry.get_tool(tool_name)
         if tool is None:
             return None
         return {
             "name": tool.name,
             "description": tool.description,
-            "inputSchema": tool.input_schema,
-            "outputSchema": tool.output_schema,
+            "inputSchema": deepcopy(tool.input_schema),
+            "outputSchema": deepcopy(tool.output_schema),
             "readOnly": tool.read_only,
         }
 

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -1,0 +1,251 @@
+"""
+Context MCP Tool Registry.
+
+Defines the registry of read-only Context Tools v0.
+Each tool is mapped to its contract and handler placeholder.
+
+Reference: docs/surrealdb/context-tool-contracts-v0.md
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+
+@dataclass(frozen=True)
+class ToolDefinition:
+    name: str
+    description: str
+    input_schema: dict
+    output_schema: dict
+    read_only: bool
+    handler: Optional[Callable] = None
+
+
+class ContextToolRegistry:
+    """
+    Registry for Context MCP tools.
+
+    All tools are read-only by default.
+    Write tools are not registered.
+    """
+
+    _tools: dict[str, ToolDefinition] = {}
+
+    @classmethod
+    def register(cls, tool: ToolDefinition) -> None:
+        if not tool.read_only:
+            raise ValueError(f"Cannot register non-read-only tool: {tool.name}")
+        cls._tools[tool.name] = tool
+
+    @classmethod
+    def get_tool(cls, name: str) -> Optional[ToolDefinition]:
+        return cls._tools.get(name)
+
+    @classmethod
+    def list_tools(cls) -> list[ToolDefinition]:
+        return list(cls._tools.values())
+
+    @classmethod
+    def list_tool_names(cls) -> list[str]:
+        return list(cls._tools.keys())
+
+
+def create_not_implemented_handler(tool_name: str) -> Callable:
+    """Create a fail-closed handler for not-yet-implemented tools."""
+
+    def not_implemented_handler(**kwargs) -> dict:
+        return {
+            "tool": tool_name,
+            "status": "error",
+            "error": {
+                "code": "not_implemented",
+                "message": f"Tool {tool_name} is not yet implemented. This is a scaffold placeholder.",
+            },
+        }
+
+    return not_implemented_handler
+
+
+# Tool definitions for Context Tools v0
+# Reference: docs/surrealdb/context-tool-contracts-v0.md
+
+TOOLS_V0 = [
+    ToolDefinition(
+        name="context.search",
+        description="Search the Context Intelligence knowledge base using keyword and structured queries.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "limit": {"type": "integer", "default": 10},
+                "filters": {
+                    "type": "object",
+                    "properties": {
+                        "source_types": {"type": "array", "items": {"type": "string"}},
+                        "date_from": {"type": "string"},
+                        "date_to": {"type": "string"},
+                    },
+                },
+            },
+            "required": ["query"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "status": {"type": "string"},
+                "results": {"type": "array"},
+                "metadata": {"type": "object"},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("context.search"),
+    ),
+    ToolDefinition(
+        name="context.trace",
+        description="Trace decision or event lineage through the Context Intelligence system.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "target_id": {"type": "string"},
+                "depth": {"type": "integer", "default": 5, "maximum": 20},
+            },
+            "required": ["target_id"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "status": {"type": "string"},
+                "trace": {"type": "object"},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("context.trace"),
+    ),
+    ToolDefinition(
+        name="context.explain_source",
+        description="Explain the provenance and reasoning behind a specific source or evidence item.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "source_ref": {"type": "string"},
+                "include_chain": {"type": "boolean", "default": True},
+            },
+            "required": ["source_ref"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "status": {"type": "string"},
+                "explanation": {"type": "object"},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("context.explain_source"),
+    ),
+    ToolDefinition(
+        name="context.show_snapshot",
+        description="Show a point-in-time snapshot of the context state.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "snapshot_id": {"type": "string"},
+                "include_details": {"type": "boolean", "default": True},
+            },
+            "required": ["snapshot_id"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "status": {"type": "string"},
+                "snapshot": {"type": "object"},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("context.show_snapshot"),
+    ),
+    ToolDefinition(
+        name="context.show_audit",
+        description="Show audit trail for a specific entity or action.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string"},
+                "audit_type": {"type": "string", "default": "all"},
+                "limit": {"type": "integer", "default": 50},
+            },
+            "required": ["entity_id"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "status": {"type": "string"},
+                "audit": {"type": "object"},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("context.show_audit"),
+    ),
+    ToolDefinition(
+        name="context.package",
+        description="Package context artifacts for handoff between agents or sessions.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "artifacts": {"type": "array", "items": {"type": "string"}},
+                "format": {
+                    "type": "string",
+                    "enum": ["json", "markdown"],
+                    "default": "json",
+                },
+                "include_metadata": {"type": "boolean", "default": True},
+            },
+            "required": ["artifacts"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "status": {"type": "string"},
+                "package": {"type": "object"},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("context.package"),
+    ),
+    ToolDefinition(
+        name="context.readiness",
+        description="Show read-only readiness evaluation metadata (NOT Live Readiness).",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "component": {"type": "string"},
+                "include_details": {"type": "boolean", "default": False},
+            },
+            "required": ["component"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "status": {"type": "string"},
+                "readiness": {"type": "object"},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("context.readiness"),
+    ),
+]
+
+
+def register_all_tools() -> None:
+    """Register all v0 tools with the registry."""
+    for tool in TOOLS_V0:
+        ContextToolRegistry.register(tool)
+
+
+register_all_tools()


### PR DESCRIPTION
## Summary

- Created Context MCP Bridge scaffold with read-only, fail-closed posture.
- Files created:
  - `tools/mcp/__init__.py` - Package init
  - `tools/mcp/registry.py` - Tool registry with all 7 v0 tools defined
  - `tools/mcp/context_bridge.py` - Main bridge implementation
  - `tests/unit/tools/mcp/test_context_bridge.py` - Unit tests (11 tests)

## Changes

- `tools/mcp/` (new directory with 3 Python files)
- `tests/unit/tools/mcp/test_context_bridge.py` (new test file)

## Validation

- `git diff --check` passed
- `ruff check` passed
- `black --check` passed
- `pytest -v tests/unit/tools/mcp/test_context_bridge.py` - 11 tests passed

## Guardrails

- scaffold only — no runtime implementation of individual tools
- read-only/fail-closed — all tools return errors rather than write
- no DB write/migration
- no Memory write
- no trading/risk/execution/strategy change
- no LR/live/echtgeld implication
- LR remains NO-GO

## Out of Scope

- #2094 search MCP tool implementation
- #2095 trace MCP tool implementation
- #2096 explain MCP tool implementation
- #2097 context package implementation
- #2100 tests/fixtures expansion
- #2101 runbook
- #2102 gates
- #2091 anchor closeout

## Live Evidence Checked

- Issue #2093: OPEN, labeled `agent:codex-5.2`
- Issue #2092: CLOSED (tool contracts v0)
- Issue #2022: OPEN (MCP bridge contract - dependency noted)
- No open PRs in queue
- All preconditions from mission met

## Status

This is a scaffold only. All tool handlers are stubs that fail-closed.
The bridge structure is in place and tests verify the registry and read-only enforcement.

Closes #2093