### PR TITLE
feat(surrealdb): implement read-only context search mcp tool for #2094

### DIFF
--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -39,6 +39,52 @@ class TestContextToolRegistry:
         assert tool.name == "context.search"
         assert "query" in tool.input_schema.get("properties", {})
 
+
+class TestContextSearchHandler:
+    """Tests for context.search tool handler."""
+
+    def test_missing_query_returns_error(self) -> None:
+        """Empty/missing query fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.search", {})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_query"
+
+    def test_empty_query_returns_error(self) -> None:
+        """Empty string query fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.search", {"query": ""})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_query"
+
+    def test_valid_query_returns_ok(self) -> None:
+        """Valid query returns ok status with empty results (mocked)."""
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.search", {"query": "test"})
+        assert result["status"] == "ok"
+        assert result["tool"] == "context.search"
+        assert "results" in result
+        assert "metadata" in result
+
+    def test_limit_is_respected(self) -> None:
+        """Limit parameter is accepted (mocked adapter returns empty)."""
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.search", {"query": "test", "limit": 5})
+        assert result["status"] == "ok"
+        assert result["metadata"]["total_hits"] == 0
+
+    def test_filters_are_accepted(self) -> None:
+        """Filters parameter is accepted without error."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.search",
+            {
+                "query": "test",
+                "filters": {"source_types": ["decision"], "date_from": "2026-01-01"},
+            },
+        )
+        assert result["status"] == "ok"
+
     def test_unknown_tool_returns_none(self) -> None:
         """Verify unknown tool returns None."""
         tool = ContextToolRegistry.get_tool("context.nonexistent")
@@ -78,7 +124,7 @@ class TestContextBridge:
     def test_execute_not_implemented_tool(self) -> None:
         """Verify executing stub tool returns not_implemented error."""
         bridge = ContextBridge()
-        result = bridge.execute_tool("context.search", {"query": "test"})
+        result = bridge.execute_tool("context.trace", {"target_id": "test"})
         assert result["status"] == "error"
         assert result["error"]["code"] == "not_implemented"
 

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -19,6 +19,79 @@ from tools.mcp.registry import ContextToolRegistry, ToolDefinition
 logger = logging.getLogger(__name__)
 
 
+def context_search_handler(**kwargs) -> dict[str, Any]:
+    """
+    Read-only handler for context.search tool.
+
+    Uses mocked NoopQueryAdapter (no live DB/network).
+    Fails closed on invalid inputs.
+    """
+    # Validate required query
+    query = kwargs.get("query")
+    if not query or not isinstance(query, str) or not query.strip():
+        return {
+            "tool": "context.search",
+            "status": "error",
+            "error": {
+                "code": "invalid_query",
+                "message": "query is required and must be a non-empty string",
+            },
+        }
+
+    # Validate limit
+    limit = kwargs.get("limit", 10)
+    if not isinstance(limit, int) or limit <= 0:
+        limit = 10
+
+    # Validate filters
+    filters = kwargs.get("filters", {})
+    if not isinstance(filters, dict):
+        filters = {}
+
+    # Use mocked NoopQueryAdapter (no live DB/network)
+    from tools.surrealdb.context_query import NoopQueryAdapter
+
+    adapter = NoopQueryAdapter()
+    # Mocked execution: returns empty results (override in tests)
+    try:
+        raw_results = adapter.execute(query)
+    except Exception as e:
+        logger.error(f"Search query failed: {e}")
+        return {
+            "tool": "context.search",
+            "status": "error",
+            "error": {
+                "code": "execution_error",
+                "message": str(e),
+            },
+        }
+
+    # Format results to match contract
+    results = []
+    for item in raw_results[:limit]:
+        results.append(
+            {
+                "id": item.get("id", ""),
+                "type": item.get("type", "unknown"),
+                "title": item.get("title", ""),
+                "summary": item.get("summary", ""),
+                "source_ref": item.get("source_ref", ""),
+                "confidence": item.get("confidence", 0.0),
+                "warnings": item.get("warnings", []),
+            }
+        )
+
+    return {
+        "tool": "context.search",
+        "status": "ok",
+        "results": results,
+        "metadata": {
+            "query_time_ms": 0,
+            "total_hits": len(results),
+        },
+    }
+
+
 class ContextBridge:
     """
     MCP Bridge for Context Intelligence System.
@@ -38,6 +111,18 @@ class ContextBridge:
 
     def __init__(self) -> None:
         self._registry = ContextToolRegistry
+        # Replace scaffold handler with real implementation
+        old_tool = self._registry.get_tool("context.search")
+        if old_tool:
+            new_tool = ToolDefinition(
+                name=old_tool.name,
+                description=old_tool.description,
+                input_schema=old_tool.input_schema,
+                output_schema=old_tool.output_schema,
+                read_only=old_tool.read_only,
+                handler=context_search_handler,
+            )
+            self._registry._tools["context.search"] = new_tool
         logger.info(
             f"ContextBridge initialized with tools: {self._registry.list_tool_names()}"
         )


### PR DESCRIPTION
## Summary
- Implements read-only `context.search` MCP tool v0 for #2094
- Replaces scaffold handler with mocked NoopQueryAdapter (no live DB/network)
- Adds unit tests for `context.search` handler

Closes #2094

## Live Evidence Checked
- #2093 is CLOSED (scaffold merged)
- #2094 is OPEN + labeled `agent:codex-5.2`
- No open PRs
- Working tree clean
- PR #2270 is MERGED

## Files Changed
- `tools/mcp/context_bridge.py`: Added `context_search_handler`, updated `ContextBridge.__init__` to use real handler
- `tests/unit/tools/mcp/test_context_bridge.py`: Added tests for `context.search` handler, updated not-implemented tool test

## Validation Run/Results
- `pytest tests/unit/tools/mcp/ -q`: 20 passed
- `ruff check tools/mcp/ tests/unit/tools/mcp/`: All checks passed
- `black --check tools/mcp/ tests/unit/tools/mcp/`: 4 files left unchanged
- `git diff --check`: No whitespace errors

## Guardrails
- Read-only/fail-closed: `context.search` returns error on invalid query, no write paths
- No DB write/migration: Uses `NoopQueryAdapter` with no network/DB access
- No Memory write: No memory operations
- No trading/risk/execution/strategy change: Only MCP tool implementation
- No LR/live/echtgeld implication: Tool does not evaluate readiness
- LR remains NO-GO: No changes to live readiness status

## Out of Scope
- #2095 trace MCP tool
- #2096 explain MCP tool
- #2097 context package implementation
- #2098 readiness check
- #2099 permission guardrails
- #2100 tests/fixtures expansion
- #2101 runbook
- #2102 gates
- #2091 anchor closeout
