### PR TITLE
feat(surrealdb): implement read-only context explain mcp tool for #2096

### DIFF
--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -139,6 +139,73 @@ class TestContextTraceHandler:
         assert result["trace"]["root"]["id"] == "evt_test"
 
 
+class TestContextExplainSourceHandler:
+    """Tests for context.explain_source tool handler."""
+
+    def test_missing_source_ref_returns_error(self) -> None:
+        """Empty/missing source_ref fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.explain_source", {})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_source_ref"
+
+    def test_empty_source_ref_returns_error(self) -> None:
+        """Empty string source_ref fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.explain_source", {"source_ref": ""})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_source_ref"
+
+    def test_valid_source_ref_returns_ok(self) -> None:
+        """Valid source_ref returns ok status with explanation (mocked)."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source", {"source_ref": "src_abc123"}
+        )
+        assert result["status"] == "ok"
+        assert result["tool"] == "context.explain_source"
+        assert "explanation" in result
+        assert result["explanation"]["source_ref"] == "src_abc123"
+
+    def test_include_chain_default_true(self) -> None:
+        """include_chain defaults to True."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source", {"source_ref": "src_abc123"}
+        )
+        assert result["status"] == "ok"
+        assert result["metadata"]["include_chain"] is True
+        assert "chain" in result["explanation"]["provenance"]
+
+    def test_include_chain_false(self) -> None:
+        """include_chain=False excludes chain."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source",
+            {"source_ref": "src_abc123", "include_chain": False},
+        )
+        assert result["status"] == "ok"
+        assert result["metadata"]["include_chain"] is False
+        assert "chain" not in result["explanation"]["provenance"]
+
+    def test_explanation_contains_required_fields(self) -> None:
+        """Explanation has all required fields per #2096."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source", {"source_ref": "src_abc123"}
+        )
+        assert result["status"] == "ok"
+        expl = result["explanation"]
+        assert "source_ref" in expl
+        assert "source_type" in expl
+        assert "provenance" in expl
+        assert "source_refs" in expl
+        assert "confidence" in expl
+        assert "warnings" in expl
+        assert "stale" in expl
+        assert "tombstone" in expl
+
+
 class TestContextBridge:
     """Tests for the Context Bridge."""
 
@@ -172,7 +239,7 @@ class TestContextBridge:
     def test_execute_not_implemented_tool(self) -> None:
         """Verify executing stub tool returns not_implemented error."""
         bridge = ContextBridge()
-        result = bridge.execute_tool("context.explain_source", {"source_ref": "test"})
+        result = bridge.execute_tool("context.package", {"artifacts": []})
         assert result["status"] == "error"
         assert result["error"]["code"] == "not_implemented"
 

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -155,6 +155,70 @@ def context_trace_handler(**kwargs) -> dict[str, Any]:
     }
 
 
+def context_explain_source_handler(**kwargs) -> dict[str, Any]:
+    """
+    Read-only handler for context.explain_source tool.
+
+    Explains provenance of a context source/evidence item.
+    Uses mocked responses (no live DB/network).
+    Fails closed on invalid inputs.
+    """
+    # Validate required source_ref
+    source_ref = kwargs.get("source_ref")
+    if not source_ref or not isinstance(source_ref, str) or not source_ref.strip():
+        return {
+            "tool": "context.explain_source",
+            "status": "error",
+            "error": {
+                "code": "invalid_source_ref",
+                "message": "source_ref is required and must be a non-empty string",
+            },
+        }
+
+    # Validate include_chain
+    include_chain = kwargs.get("include_chain", True)
+    if not isinstance(include_chain, bool):
+        include_chain = True
+
+    # Mocked explain result (no live DB/network)
+    mocked_explanation = {
+        "source_ref": source_ref,
+        "source_type": "evidence",
+        "provenance": {
+            "source_path": f"/mock/path/{source_ref}",
+            "hash": "mock_hash_123",
+            "commit": "mock_commit_456",
+            "run_id": "mock_run_789",
+            "import_audit_ref": "mock_audit_012",
+            "evidence_refs": ["mock_ev_1", "mock_ev_2"],
+        },
+        "source_refs": [
+            {"ref": "mock_audit_012", "type": "import_audit"},
+            {"ref": "mock_ev_1", "type": "evidence"},
+        ],
+        "confidence": 0.9,
+        "warnings": [],
+        "stale": False,
+        "tombstone": False,
+    }
+
+    if include_chain:
+        mocked_explanation["provenance"]["chain"] = [
+            {"level": 1, "ref": "mock_parent_1", "type": "derived"},
+            {"level": 2, "ref": "mock_parent_2", "type": "source"},
+        ]
+
+    return {
+        "tool": "context.explain_source",
+        "status": "ok",
+        "explanation": mocked_explanation,
+        "metadata": {
+            "explained_at": "2026-05-03T12:00:00Z",
+            "include_chain": include_chain,
+        },
+    }
+
+
 class ContextBridge:
     """
     MCP Bridge for Context Intelligence System.
@@ -197,6 +261,17 @@ class ContextBridge:
                 handler=context_trace_handler,
             )
             self._registry._tools["context.trace"] = new_trace
+        old_explain = self._registry.get_tool("context.explain_source")
+        if old_explain:
+            new_explain = ToolDefinition(
+                name=old_explain.name,
+                description=old_explain.description,
+                input_schema=old_explain.input_schema,
+                output_schema=old_explain.output_schema,
+                read_only=old_explain.read_only,
+                handler=context_explain_source_handler,
+            )
+            self._registry._tools["context.explain_source"] = new_explain
         logger.info(
             f"ContextBridge initialized with tools: {self._registry.list_tool_names()}"
         )


### PR DESCRIPTION
Closes #2096

Summary:
Implements the read-only context.explain_source MCP tool v0.

Changes:
- Adds context.explain_source handler.
- Keeps handler read-only and fail-closed.
- Adds focused unit tests for explain-source behavior.

Validation:
- python -m pytest tests/unit/tools/mcp/ -q
- ruff check tools/mcp tests/unit/tools/mcp/
- black --check tools/mcp tests/unit/tools/mcp/
- git diff --check

Guardrails:
- read-only/fail-closed
- no DB write/migration
- no Memory write
- no trading/risk/execution/strategy change
- no LR/live/echtgeld implication
- LR remains NO-GO

Out of scope:
- #2097 context package implementation
- #2098 readiness check
- #2099 permission guardrails
- #2100 tests/fixtures expansion
- #2101 runbook
- #2102 gates
- #2091 anchor closeout