### PR TITLE
docs(index): add context runbooks to db index for #1445

### DIFF
--- a/docs/db/index.md
+++ b/docs/db/index.md
@@ -73,3 +73,5 @@ Postgres ist der Canon fuer Runtime-Daten; SurrealDB ist eine optionale Mirror-S
 - Operational & Handoff:
   - [docs/surrealdb/context-agent-handoff.md](../surrealdb/context-agent-handoff.md)
   - [docs/surrealdb/context-wave7-completion-gates.md](../surrealdb/context-wave7-completion-gates.md)
+  - [docs/runbooks/surrealdb_context_import.md](../runbooks/surrealdb_context_import.md)
+  - [docs/runbooks/surrealdb_context_query.md](../runbooks/surrealdb_context_query.md)


### PR DESCRIPTION
## Summary
- add Context Import runbook link to docs/db/index.md
- add Context Query runbook link to docs/db/index.md
- resolves discovery-surface drift reported in #1445 after PR #2264

## Validation
- git diff confirmed docs-only index update
- rg confirms both runbook links in docs/db/index.md
- no runtime, SurrealDB apply, Trading, Risk, Execution, Strategy, LR, or Echtgeld impact

Refs #1445