### PR TITLE
feat(surrealdb): add self-explanation builder v1

### DIFF
--- a/tests/unit/surrealdb/test_context_self_explanation.py
+++ b/tests/unit/surrealdb/test_context_self_explanation.py
@@ -1,0 +1,308 @@
+"""Unit tests for Self-Explanation Builder v1 (#2189)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.surrealdb.context_self_explanation import (
+    InvalidExplanationTypeError,
+    InvalidInputError,
+    SelfExplanationInput,
+    build_self_explanation,
+    supported_explanation_types,
+)
+
+
+@pytest.mark.unit
+def test_build_why_blocked_explanation() -> None:
+    inp = SelfExplanationInput(
+        explanation_type="why_blocked",
+        summary="Merge auf main ist blockiert wegen fehlender CI-Checks.",
+        reasons=(
+            "Required Check 'ci (Unit/Integration)' ist noch pending.",
+            "Policy Gate erwartet approval.",
+        ),
+        evidence_refs=("#2278", "#2279"),
+        required_next_step="Auf CI-Ergebnis warten oder Human-GO pruefen.",
+        confidence=0.9,
+        scope_context="pr-merge",
+    )
+    result = build_self_explanation(inp)
+    payload = result.to_payload()
+
+    assert result.explanation_type == "why_blocked"
+    assert "blockiert" in result.summary
+    assert len(result.reasons) == 2
+    assert payload["evidence_refs"] == ["#2278", "#2279"]
+    assert len(result.guardrails) == 5
+    assert result.confidence == 0.9
+    assert payload["schema_version"] == "self-explanation/v1"
+    assert "Freigabe" in result.guardrails[-1]
+
+
+@pytest.mark.unit
+def test_build_why_risky_explanation() -> None:
+    inp = SelfExplanationInput(
+        explanation_type="why_risky",
+        summary="Aenderung an core/risk/service.py ohne Test-Coverage.",
+        reasons=(
+            "Keine Unit-Tests fuer die geaenderte Funktion.",
+            "Blast-Radius umfasst Risk-Service-Kill-Switch.",
+        ),
+        evidence_refs=("core/risk/service.py",),
+        required_next_step="Vor Merge zwingend Unit-Tests ergaenzen.",
+        scope_context="core-risk",
+    )
+    result = build_self_explanation(inp)
+    payload = result.to_payload()
+
+    assert result.explanation_type == "why_risky"
+    assert "Risk-Service" in result.reasons[1]
+    assert result.scope_context == "core-risk"
+    assert all(isinstance(g, str) and len(g) > 0 for g in result.guardrails)
+    assert payload["required_next_step"] == "Vor Merge zwingend Unit-Tests ergaenzen."
+
+
+@pytest.mark.unit
+def test_build_why_stale_explanation() -> None:
+    inp = SelfExplanationInput(
+        explanation_type="why_stale",
+        summary="Runbook seit 180 Tagen nicht aktualisiert.",
+        reasons=(
+            "Letztes Update: 2024-11-03.",
+            "Referenziert veraltete Container-Images.",
+        ),
+        evidence_refs=("docs/runbooks/old-runbook.md",),
+        required_next_step="Runbook gegen aktuellen Stack-Canon pruefen und aktualisieren.",
+    )
+    result = build_self_explanation(inp)
+
+    assert result.explanation_type == "why_stale"
+    assert "180" in result.summary
+    assert result.confidence is None
+    assert len(result.evidence_refs) == 1
+
+
+@pytest.mark.unit
+def test_build_why_decision_current_explanation() -> None:
+    inp = SelfExplanationInput(
+        explanation_type="why_decision_current",
+        summary="Decision #1492: Stage trade-capable ratifiziert 2026-04-08.",
+        reasons=(
+            "Board-Ratifikation erfolgt via Issue #1492.",
+            "LR bleibt NO-GO trotz Stage.",
+        ),
+        evidence_refs=("#1492", "docs/runbooks/CONTROL_REGISTER.md"),
+        required_next_step="Keine Aenderung noetig; Decision bleibt aktiv.",
+        confidence=1.0,
+    )
+    result = build_self_explanation(inp)
+
+    assert result.explanation_type == "why_decision_current"
+    assert "#1492" in result.summary
+    assert result.confidence == 1.0
+
+
+@pytest.mark.unit
+def test_build_why_decision_superseded_explanation() -> None:
+    inp = SelfExplanationInput(
+        explanation_type="why_decision_superseded",
+        summary="Alte Decision durch neuen Canon ersetzt.",
+        reasons=(
+            "Neuer Canon in WORKING_REPO_CANON.md definiert.",
+            "Alte Docs-Hub-Struktur nicht mehr autoritativ.",
+        ),
+        evidence_refs=("docs/meta/WORKING_REPO_CANON.md",),
+        required_next_step="Alte Referenzen auf neue Canon-Pfade aktualisieren.",
+    )
+    result = build_self_explanation(inp)
+
+    assert result.explanation_type == "why_decision_superseded"
+    assert "superseded" in result.explanation_type
+
+
+@pytest.mark.unit
+def test_build_why_scope_blocked_explanation() -> None:
+    inp = SelfExplanationInput(
+        explanation_type="why_scope_blocked",
+        summary="Scope-Erweiterung auf Live-Trading ist blockiert.",
+        reasons=(
+            "LR-050 ist NO-GO.",
+            "Kein Human-GO fuer Echtgeld.",
+        ),
+        evidence_refs=("docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",),
+        required_next_step="Human-GO pruefen oder Scope reduzieren.",
+        scope_context="live-trading",
+    )
+    result = build_self_explanation(inp)
+
+    assert result.explanation_type == "why_scope_blocked"
+    assert "NO-GO" in result.reasons[0]
+
+
+@pytest.mark.unit
+def test_build_why_evidence_weak_explanation() -> None:
+    inp = SelfExplanationInput(
+        explanation_type="why_evidence_weak",
+        summary="Claim fehlt direkter Commit-Beweis.",
+        reasons=(
+            "Keine Evidence-Datei unter docs/evidence/.",
+            "Nur Issue-Kommentar, kein Repo-Artefakt.",
+        ),
+        evidence_refs=("#1234",),
+        required_next_step="Evidence-Commit anlegen oder Claim zurueckziehen.",
+        confidence=0.3,
+    )
+    result = build_self_explanation(inp)
+
+    assert result.explanation_type == "why_evidence_weak"
+    assert result.confidence == 0.3
+    assert "Commit" in result.required_next_step
+
+
+@pytest.mark.unit
+def test_build_why_agent_needs_go_explanation() -> None:
+    inp = SelfExplanationInput(
+        explanation_type="why_agent_needs_go",
+        summary="Agent plant Merge von PR #2279 auf main.",
+        reasons=(
+            "PR betrifft Governance-Gates-Dokument.",
+            "Kein auto-merge erlaubt.",
+        ),
+        evidence_refs=("#2279",),
+        required_next_step="Human-GO anfordern oder Merge-Approval abwarten.",
+    )
+    result = build_self_explanation(inp)
+
+    assert result.explanation_type == "why_agent_needs_go"
+    assert "Merge" in result.summary
+
+
+@pytest.mark.unit
+def test_build_why_doc_untrusted_explanation() -> None:
+    inp = SelfExplanationInput(
+        explanation_type="why_doc_untrusted",
+        summary="Dokument enthaelt keine SourceRefs oder Hash-Chain.",
+        reasons=(
+            "Kein source_commit im Dokument.",
+            "Keine deterministische Hash-Referenz.",
+        ),
+        evidence_refs=("docs/legacy/untrusted-doc.md",),
+        required_next_step="Dokument gegen Repo-Stand pruefen und mit SourceRefs versehen.",
+    )
+    result = build_self_explanation(inp)
+
+    assert result.explanation_type == "why_doc_untrusted"
+    assert "SourceRefs" in result.required_next_step
+
+
+@pytest.mark.unit
+def test_guardrails_always_present() -> None:
+    for etype in sorted(supported_explanation_types()):
+        inp = SelfExplanationInput(
+            explanation_type=etype,
+            summary=f"Test explanation for {etype}.",
+            reasons=("Reason 1",),
+            evidence_refs=("#test",),
+            required_next_step="Next step.",
+        )
+        result = build_self_explanation(inp)
+
+        assert len(result.guardrails) == 5
+        assert all(isinstance(g, str) and len(g) > 0 for g in result.guardrails)
+        assert "Handlungserlaubnis" in result.guardrails[0]
+        assert "Freigabe" in result.guardrails[-1]
+
+
+@pytest.mark.unit
+def test_unsupported_explanation_type_raises() -> None:
+    with pytest.raises(InvalidExplanationTypeError, match="unsupported explanation_type"):
+        SelfExplanationInput(
+            explanation_type="why_whatever",
+            summary="Invalid.",
+            reasons=("R1",),
+            evidence_refs=("#x",),
+            required_next_step="N/A",
+        )
+
+
+@pytest.mark.unit
+def test_empty_summary_raises() -> None:
+    with pytest.raises(InvalidInputError, match="summary must be non-empty"):
+        SelfExplanationInput(
+            explanation_type="why_blocked",
+            summary="   ",
+            reasons=("R1",),
+            evidence_refs=("#x",),
+            required_next_step="N/A",
+        )
+
+
+@pytest.mark.unit
+def test_empty_reasons_raises() -> None:
+    with pytest.raises(InvalidInputError, match="at least one reason"):
+        SelfExplanationInput(
+            explanation_type="why_blocked",
+            summary="S",
+            reasons=(),
+            evidence_refs=("#x",),
+            required_next_step="N/A",
+        )
+
+
+@pytest.mark.unit
+def test_empty_required_next_step_raises() -> None:
+    with pytest.raises(InvalidInputError, match="required_next_step must be non-empty"):
+        SelfExplanationInput(
+            explanation_type="why_blocked",
+            summary="S",
+            reasons=("R1",),
+            evidence_refs=("#x",),
+            required_next_step="",
+        )
+
+
+@pytest.mark.unit
+def test_confidence_out_of_range_raises() -> None:
+    with pytest.raises(InvalidInputError, match="confidence must be"):
+        SelfExplanationInput(
+            explanation_type="why_blocked",
+            summary="S",
+            reasons=("R1",),
+            evidence_refs=("#x",),
+            required_next_step="N/A",
+            confidence=1.5,
+        )
+
+    with pytest.raises(InvalidInputError, match="confidence must be"):
+        SelfExplanationInput(
+            explanation_type="why_blocked",
+            summary="S",
+            reasons=("R1",),
+            evidence_refs=("#x",),
+            required_next_step="N/A",
+            confidence=-0.1,
+        )
+
+
+@pytest.mark.unit
+def test_to_payload_outputs_all_fields() -> None:
+    inp = SelfExplanationInput(
+        explanation_type="why_blocked",
+        summary="Test",
+        reasons=("R1", "R2"),
+        evidence_refs=("E1",),
+        required_next_step="Next",
+        confidence=0.5,
+        scope_context="test-scope",
+    )
+    result = build_self_explanation(inp)
+    payload = result.to_payload()
+
+    assert "schema_version" in payload
+    assert payload["summary"] == "Test"
+    assert payload["reasons"] == ["R1", "R2"]
+    assert payload["evidence_refs"] == ["E1"]
+    assert "guardrails" in payload
+    assert payload["confidence"] == 0.5
+    assert payload["scope_context"] == "test-scope"

--- a/tests/unit/surrealdb/test_context_self_explanation.py
+++ b/tests/unit/surrealdb/test_context_self_explanation.py
@@ -251,6 +251,34 @@ def test_empty_reasons_raises() -> None:
 
 
 @pytest.mark.unit
+def test_empty_evidence_refs_raises() -> None:
+    with pytest.raises(
+        InvalidInputError, match="evidence_refs must contain at least one reference"
+    ):
+        SelfExplanationInput(
+            explanation_type="why_blocked",
+            summary="S",
+            reasons=("R1",),
+            evidence_refs=(),
+            required_next_step="N/A",
+        )
+
+
+@pytest.mark.unit
+def test_empty_evidence_ref_value_raises() -> None:
+    with pytest.raises(
+        InvalidInputError, match="each evidence_ref must be non-empty"
+    ):
+        SelfExplanationInput(
+            explanation_type="why_blocked",
+            summary="S",
+            reasons=("R1",),
+            evidence_refs=("#x", "   "),
+            required_next_step="N/A",
+        )
+
+
+@pytest.mark.unit
 def test_empty_required_next_step_raises() -> None:
     with pytest.raises(InvalidInputError, match="required_next_step must be non-empty"):
         SelfExplanationInput(

--- a/tools/surrealdb/context_self_explanation.py
+++ b/tools/surrealdb/context_self_explanation.py
@@ -1,0 +1,205 @@
+"""Self-Explanation Builder v1 — side-effect-free domain component.
+
+Issues:
+    #2189 — Implement self-explanation builder v1
+    Parent: #2188
+    Epic: #1976
+
+This module implements a minimal, side-effect-free Self-Explanation Builder.
+It produces structured explanations for governance-relevant conditions without
+DB access, MCP access, networking, or secrets. Every output includes mandatory
+guardrail text: no action authorization, no Live-Readiness-Go, no Echtgeld-Go,
+no autonomy without gates.
+
+Supported explanation types (from #2188):
+    why_blocked, why_risky, why_stale, why_decision_current,
+    why_decision_superseded, why_scope_blocked, why_evidence_weak,
+    why_agent_needs_go, why_doc_untrusted
+
+Design intent:
+    Pure domain model. No SurrealDB SDK. No MCP. No CLI.
+    Input: structured data. Output: machine-readable dict.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+_SCHEMA_VERSION = "self-explanation/v1"
+
+_EXPLANATION_TYPES = frozenset(
+    {
+        "why_blocked",
+        "why_risky",
+        "why_stale",
+        "why_decision_current",
+        "why_decision_superseded",
+        "why_scope_blocked",
+        "why_evidence_weak",
+        "why_agent_needs_go",
+        "why_doc_untrusted",
+    }
+)
+
+_GUARDRAILS = (
+    "Keine Handlungserlaubnis durch diese Erklaerung.",
+    "Kein Live-Readiness-Go.",
+    "Kein Echtgeld-Go.",
+    "Keine Autonomie ohne Gates.",
+    "Diese Erklaerung ist Kontext, keine Freigabe.",
+)
+
+
+class SelfExplanationError(Exception):
+    """Base error for self-explanation builder."""
+
+    code: str = "SELF_EXPLANATION_ERROR"
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class InvalidExplanationTypeError(SelfExplanationError):
+    """Raised when an unsupported explanation type is requested."""
+
+    code = "INVALID_EXPLANATION_TYPE"
+
+
+class InvalidInputError(SelfExplanationError):
+    """Raised when the builder input fails validation."""
+
+    code = "INVALID_INPUT"
+
+
+@dataclass(frozen=True)
+class SelfExplanationInput:
+    """Validated input for the Self-Explanation Builder.
+
+    Attributes:
+        explanation_type: One of the nine supported types.
+        summary: Human-readable summary of what is being explained.
+        reasons: Ordered list of reasons contributing to the condition.
+        evidence_refs: References to evidence supporting the explanation.
+        required_next_step: The next action needed (plain text, not a command).
+        confidence: Optional self-assessed confidence (0.0–1.0).
+        scope_context: Optional scope identifier for which this applies.
+    """
+
+    explanation_type: str
+    summary: str
+    reasons: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+    required_next_step: str
+    confidence: float | None = None
+    scope_context: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.explanation_type not in _EXPLANATION_TYPES:
+            raise InvalidExplanationTypeError(
+                f"unsupported explanation_type: {self.explanation_type!r}; "
+                f"expected one of {sorted(_EXPLANATION_TYPES)}"
+            )
+        if not self.summary.strip():
+            raise InvalidInputError("summary must be non-empty")
+        if not self.reasons:
+            raise InvalidInputError("reasons must contain at least one reason")
+        if any(not r.strip() for r in self.reasons):
+            raise InvalidInputError("each reason must be non-empty")
+        if not self.required_next_step.strip():
+            raise InvalidInputError("required_next_step must be non-empty")
+        if self.confidence is not None and not (0.0 <= self.confidence <= 1.0):
+            raise InvalidInputError(
+                f"confidence must be between 0.0 and 1.0, got {self.confidence}"
+            )
+
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "explanation_type": self.explanation_type,
+            "summary": self.summary,
+            "reasons": list(self.reasons),
+            "evidence_refs": list(self.evidence_refs),
+            "required_next_step": self.required_next_step,
+        }
+        if self.confidence is not None:
+            payload["confidence"] = self.confidence
+        if self.scope_context is not None:
+            payload["scope_context"] = self.scope_context
+        return payload
+
+
+@dataclass(frozen=True)
+class SelfExplanationOutput:
+    """Structured output of the Self-Explanation Builder.
+
+    Attributes:
+        schema_version: Schema identifier for the output format.
+        explanation_type: The explanation type that was built.
+        summary: Human-readable summary.
+        reasons: Ordered list of reasons.
+        evidence_refs: References to supporting evidence.
+        required_next_step: Required next action.
+        guardrails: Mandatory guardrail text (always present).
+        confidence: Optional confidence level.
+        scope_context: Optional scope context.
+    """
+
+    schema_version: str = _SCHEMA_VERSION
+    explanation_type: str = ""
+    summary: str = ""
+    reasons: tuple[str, ...] = ()
+    evidence_refs: tuple[str, ...] = ()
+    required_next_step: str = ""
+    guardrails: tuple[str, ...] = ()
+    confidence: float | None = None
+    scope_context: str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "explanation_type": self.explanation_type,
+            "summary": self.summary,
+            "reasons": list(self.reasons),
+            "evidence_refs": list(self.evidence_refs),
+            "required_next_step": self.required_next_step,
+            "guardrails": list(self.guardrails),
+        }
+        if self.confidence is not None:
+            payload["confidence"] = self.confidence
+        if self.scope_context is not None:
+            payload["scope_context"] = self.scope_context
+        return payload
+
+
+def build_self_explanation(inp: SelfExplanationInput) -> SelfExplanationOutput:
+    """Build a structured self-explanation from validated input.
+
+    This is a pure function: no DB access, no MCP, no network, no secrets.
+    The output always includes mandatory guardrail text.
+
+    Args:
+        inp: Validated SelfExplanationInput.
+
+    Returns:
+        SelfExplanationOutput with the explanation and guardrails.
+
+    Raises:
+        InvalidInputError: If the input fails post-initialization validation.
+    """
+    return SelfExplanationOutput(
+        schema_version=_SCHEMA_VERSION,
+        explanation_type=inp.explanation_type,
+        summary=inp.summary,
+        reasons=inp.reasons,
+        evidence_refs=inp.evidence_refs,
+        required_next_step=inp.required_next_step,
+        guardrails=_GUARDRAILS,
+        confidence=inp.confidence,
+        scope_context=inp.scope_context,
+    )
+
+
+def supported_explanation_types() -> frozenset[str]:
+    """Return the set of supported explanation types."""
+    return _EXPLANATION_TYPES

--- a/tools/surrealdb/context_self_explanation.py
+++ b/tools/surrealdb/context_self_explanation.py
@@ -107,6 +107,10 @@ class SelfExplanationInput:
             raise InvalidInputError("reasons must contain at least one reason")
         if any(not r.strip() for r in self.reasons):
             raise InvalidInputError("each reason must be non-empty")
+        if not self.evidence_refs:
+            raise InvalidInputError("evidence_refs must contain at least one reference")
+        if any(not e.strip() for e in self.evidence_refs):
+            raise InvalidInputError("each evidence_ref must be non-empty")
         if not self.required_next_step.strip():
             raise InvalidInputError("required_next_step must be non-empty")
         if self.confidence is not None and not (0.0 <= self.confidence <= 1.0):


### PR DESCRIPTION
## Summary
- Starts Wave 20 via #2189 with a side-effect-free Self-Explanation Builder v1.
- Supports all 9 explanation types defined by the Wave-20 anchor: why_blocked, why_risky, why_stale, why_decision_current, why_decision_superseded, why_scope_blocked, why_evidence_weak, why_agent_needs_go, why_doc_untrusted.
- Every output includes mandatory guardrail text (no action authorization, no Live-Go, no Echtgeld-Go, no autonomy without gates).
- Keeps MCP tools, Agent OS readiness, reports, gates, runtime writes, and live enablement out of scope.

## Scope
- New: `tools/surrealdb/context_self_explanation.py` — pure domain model, no DB/MCP/network access
- New: `tests/unit/surrealdb/test_context_self_explanation.py` — 16 unit tests
- Target issue: #2189 only.
- #2188 and #2196 remain open.
- #2190–#2195 not touched.
- No issue close in this PR.
- No DB/MCP write, runtime enablement, Trading, Risk, Execution, Strategy, LR, Live, or Echtgeld change.

## Validation
- #2189 verified OPEN before editing.
- 16/16 unit tests pass.
- Ruff lint clean.
- Only 2 new files in allowed directories.

Refs #2189
