### PR TITLE
feat(mcp): add read-only self-explanation context tool

### DIFF
--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -23,6 +23,7 @@ class TestContextToolRegistry:
             "context.show_audit",
             "context.package",
             "context.readiness",
+            "context.self_explain",
         ]
         for expected in expected_tools:
             assert expected in tool_names, f"Tool {expected} not registered"
@@ -223,10 +224,11 @@ class TestContextBridge:
         """Verify list_tools returns all v0 tools."""
         bridge = ContextBridge()
         tools = bridge.list_tools()
-        assert len(tools) == 7
+        assert len(tools) == 8
         tool_names = [t["name"] for t in tools]
         assert "context.search" in tool_names
         assert "context.package" in tool_names
+        assert "context.self_explain" in tool_names
 
     def test_get_tool_schema(self) -> None:
         """Verify get_tool_schema returns schema."""
@@ -255,7 +257,7 @@ class TestContextBridge:
         bridge = ContextBridge()
         status = bridge.get_read_only_status()
         assert status["enforced"] is True
-        assert len(status["read_only_tools"]) == 7
+        assert len(status["read_only_tools"]) == 8
 
 
 class TestDefensiveSchemaCopies:
@@ -316,3 +318,233 @@ class TestDefensiveSchemaCopies:
         assert "new_field" not in schema_after["inputSchema"].get(
             "properties", {}
         ), "Registry schema should not be mutated by caller"
+
+
+class TestContextSelfExplainHandler:
+    """Tests for context.self_explain tool handler (#2190)."""
+
+    def test_tool_in_list_tools(self) -> None:
+        """Tool is visible in list_tools()."""
+        bridge = create_bridge()
+        tool_names = [t["name"] for t in bridge.list_tools()]
+        assert "context.self_explain" in tool_names
+
+    def test_tool_is_read_only(self) -> None:
+        """Tool is read-only."""
+        bridge = create_bridge()
+        schema = bridge.get_tool_schema("context.self_explain")
+        assert schema is not None
+        assert schema["readOnly"] is True
+
+    def test_schema_contains_required_fields(self) -> None:
+        """Input schema contains required fields."""
+        bridge = create_bridge()
+        schema = bridge.get_tool_schema("context.self_explain")
+        required = schema["inputSchema"]["required"]
+        assert "question" in required
+        assert "explanation_type" in required
+        assert "evidence_refs" in required
+
+    def test_valid_call_returns_ok(self) -> None:
+        """Valid call returns status ok with expected output fields."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Why is PR #1234 blocked?",
+                "explanation_type": "why_blocked",
+                "evidence_refs": ["#1234", "#1235"],
+                "scope": "pr-merge",
+                "reasons": ["CI checks pending", "Review required"],
+                "confidence": 0.8,
+            },
+        )
+        assert result["status"] == "ok"
+        assert result["tool"] == "context.self_explain"
+        assert "explanation" in result
+        assert "guardrails" in result
+        assert "evidence_refs" in result
+        assert result["explanation"]["explanation_type"] == "why_blocked"
+
+    def test_output_contains_guardrails(self) -> None:
+        """Output contains guardrail text from the builder."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test question",
+                "explanation_type": "why_risky",
+                "evidence_refs": ["#test"],
+            },
+        )
+        assert result["status"] == "ok"
+        guardrails = result["guardrails"]
+        assert len(guardrails) >= 1
+        assert any("Handlungserlaubnis" in g for g in guardrails) or any(
+            "Freigabe" in g for g in guardrails
+        )
+
+    def test_output_contains_evidence_refs(self) -> None:
+        """Output contains evidence refs from input."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_stale",
+                "evidence_refs": ["#ev1", "#ev2"],
+            },
+        )
+        assert result["status"] == "ok"
+        assert len(result["evidence_refs"]) == 2
+
+    def test_invalid_explanation_type_fail_closed(self) -> None:
+        """Invalid explanation_type fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "not_a_valid_type",
+                "evidence_refs": ["#test"],
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_explanation_type"
+
+    def test_empty_question_fail_closed(self) -> None:
+        """Empty question fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "",
+                "explanation_type": "why_blocked",
+                "evidence_refs": ["#test"],
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_question"
+
+    def test_missing_question_fail_closed(self) -> None:
+        """Missing question fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "explanation_type": "why_blocked",
+                "evidence_refs": ["#test"],
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_question"
+
+    def test_empty_evidence_refs_fail_closed(self) -> None:
+        """Empty evidence_refs fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_blocked",
+                "evidence_refs": [],
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_evidence_refs"
+
+    def test_missing_evidence_refs_fail_closed(self) -> None:
+        """Missing evidence_refs fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_blocked",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_evidence_refs"
+
+    def test_confidence_range_ok(self) -> None:
+        """Confidence 0.0-1.0 is accepted."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_scope_blocked",
+                "evidence_refs": ["#test"],
+                "confidence": 0.95,
+            },
+        )
+        assert result["status"] == "ok"
+        assert result["confidence"] == 0.95
+
+    def test_output_graph_path_present(self) -> None:
+        """Output contains graph_path field."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_decision_current",
+                "evidence_refs": ["#test"],
+            },
+        )
+        assert result["status"] == "ok"
+        assert "graph_path" in result
+
+    def test_output_source_refs_present(self) -> None:
+        """Output contains source_refs field."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_evidence_weak",
+                "evidence_refs": ["#test"],
+            },
+        )
+        assert result["status"] == "ok"
+        assert "source_refs" in result
+
+    def test_recommended_next_reads_present(self) -> None:
+        """Output contains recommended_next_reads from input."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_agent_needs_go",
+                "evidence_refs": ["#test"],
+                "recommended_next_reads": ["doc_a.md", "doc_b.md"],
+            },
+        )
+        assert result["status"] == "ok"
+        assert result["recommended_next_reads"] == ["doc_a.md", "doc_b.md"]
+
+    def test_all_nine_explanation_types_accepted(self) -> None:
+        """All nine supported explanation types yield ok."""
+        bridge = create_bridge()
+        types = [
+            "why_blocked",
+            "why_risky",
+            "why_stale",
+            "why_decision_current",
+            "why_decision_superseded",
+            "why_scope_blocked",
+            "why_evidence_weak",
+            "why_agent_needs_go",
+            "why_doc_untrusted",
+        ]
+        for expl_type in types:
+            result = bridge.execute_tool(
+                "context.self_explain",
+                {
+                    "question": f"Test for {expl_type}",
+                    "explanation_type": expl_type,
+                    "evidence_refs": ["#test"],
+                },
+            )
+            assert result["status"] == "ok", f"Failed for type: {expl_type}"

--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -548,3 +548,76 @@ class TestContextSelfExplainHandler:
                 },
             )
             assert result["status"] == "ok", f"Failed for type: {expl_type}"
+
+    def test_evidence_refs_whitespace_element_fail_closed(self) -> None:
+        """evidence_refs containing whitespace-only string fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_blocked",
+                "evidence_refs": ["#ok", "   "],
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_evidence_refs"
+
+    def test_evidence_refs_non_string_element_fail_closed(self) -> None:
+        """evidence_refs containing non-string element fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_blocked",
+                "evidence_refs": ["#ok", 123],
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_evidence_refs"
+
+    def test_confidence_string_fail_closed(self) -> None:
+        """Confidence as string fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_blocked",
+                "evidence_refs": ["#test"],
+                "confidence": "0.9",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_confidence"
+
+    def test_confidence_out_of_range_fail_closed(self) -> None:
+        """Confidence > 1.0 fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_blocked",
+                "evidence_refs": ["#test"],
+                "confidence": 1.5,
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_confidence"
+
+    def test_confidence_none_is_ok(self) -> None:
+        """Confidence=None yields ok with confidence: None in output."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_doc_untrusted",
+                "evidence_refs": ["#test"],
+                "confidence": None,
+            },
+        )
+        assert result["status"] == "ok"
+        assert result["confidence"] is None

--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -621,3 +621,33 @@ class TestContextSelfExplainHandler:
         )
         assert result["status"] == "ok"
         assert result["confidence"] is None
+
+    def test_confidence_true_fail_closed(self) -> None:
+        """Confidence=True fails closed (bool is not a valid number)."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_blocked",
+                "evidence_refs": ["#test"],
+                "confidence": True,
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_confidence"
+
+    def test_confidence_false_fail_closed(self) -> None:
+        """Confidence=False fails closed (bool is not a valid number)."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_blocked",
+                "evidence_refs": ["#test"],
+                "confidence": False,
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_confidence"

--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -651,3 +651,62 @@ class TestContextSelfExplainHandler:
         )
         assert result["status"] == "error"
         assert result["error"]["code"] == "invalid_confidence"
+
+    def test_reasons_non_string_fail_closed(self) -> None:
+        """reasons containing non-string element fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_blocked",
+                "evidence_refs": ["#test"],
+                "reasons": [42],
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_reasons"
+
+    def test_reasons_whitespace_element_fail_closed(self) -> None:
+        """reasons containing whitespace-only string fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_blocked",
+                "evidence_refs": ["#test"],
+                "reasons": ["valid", "   "],
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_reasons"
+
+    def test_reasons_not_list_fail_closed(self) -> None:
+        """reasons as non-list fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test",
+                "explanation_type": "why_blocked",
+                "evidence_refs": ["#test"],
+                "reasons": "not-list",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_reasons"
+
+    def test_reasons_missing_is_ok(self) -> None:
+        """Missing reasons is ok — default reason derived from question."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.self_explain",
+            {
+                "question": "Test with default reason",
+                "explanation_type": "why_stale",
+                "evidence_refs": ["#test"],
+            },
+        )
+        assert result["status"] == "ok"
+        assert len(result["explanation"]["reasons"]) >= 1

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -423,12 +423,30 @@ def context_self_explain_handler(**kwargs) -> dict[str, Any]:
         summary = question.strip()
 
     reasons_raw = kwargs.get("reasons", [])
-    if not isinstance(reasons_raw, list) or not reasons_raw:
+    if reasons_raw and not isinstance(reasons_raw, list):
+        return {
+            "tool": "context.self_explain",
+            "status": "error",
+            "error": {
+                "code": "invalid_reasons",
+                "message": "reasons must be a list of non-empty strings",
+            },
+        }
+    if not reasons_raw:
         reasons_raw = [f"Selbsterklaerung angefordert fuer: {question.strip()}"]
-    reasons = tuple(
-        r if isinstance(r, str) and r.strip() else str(r)
-        for r in reasons_raw
-    )
+    reasons_clean: list[str] = []
+    for r in reasons_raw:
+        if not isinstance(r, str) or not r.strip():
+            return {
+                "tool": "context.self_explain",
+                "status": "error",
+                "error": {
+                    "code": "invalid_reasons",
+                    "message": "reasons must be a list of non-empty strings",
+                },
+            }
+        reasons_clean.append(r)
+    reasons = tuple(reasons_clean)
 
     confidence = kwargs.get("confidence")
     if confidence is not None:

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -331,6 +331,155 @@ def context_package_handler(**kwargs) -> dict[str, Any]:
     }
 
 
+def context_self_explain_handler(**kwargs) -> dict[str, Any]:
+    """
+    Read-only handler for context.self_explain tool.
+
+    Generates a structured self-explanation for governance-relevant conditions
+    using the Self-Explanation Builder (#2189). No DB access, no network,
+    no MCP live write, no secrets.
+
+    Input:
+        question: str (required) — the question or condition to explain
+        explanation_type: str (required) — one of 9 supported types
+        scope: str (optional) — scope context identifier
+        evidence_refs: list[str] (required) — at least one non-empty reference
+        reasons: list[str] (optional) — derived from question if empty
+        confidence: float (optional) — 0.0–1.0
+        recommended_next_reads: list[str] (optional)
+
+    Output conforms to the context.self_explain contract:
+        tool, status, explanation, source_refs, evidence_refs,
+        graph_path, confidence, recommended_next_reads, guardrails
+    """
+    from tools.surrealdb.context_self_explanation import (
+        SelfExplanationError,
+        SelfExplanationInput,
+        build_self_explanation,
+        supported_explanation_types,
+    )
+
+    question = kwargs.get("question")
+    if not question or not isinstance(question, str) or not question.strip():
+        return {
+            "tool": "context.self_explain",
+            "status": "error",
+            "error": {
+                "code": "invalid_question",
+                "message": "question is required and must be a non-empty string",
+            },
+        }
+
+    explanation_type = kwargs.get("explanation_type")
+    valid_types = supported_explanation_types()
+    if explanation_type not in valid_types:
+        return {
+            "tool": "context.self_explain",
+            "status": "error",
+            "error": {
+                "code": "invalid_explanation_type",
+                "message": (
+                    f"explanation_type must be one of {sorted(valid_types)}, "
+                    f"got {explanation_type!r}"
+                ),
+            },
+        }
+
+    evidence_refs = kwargs.get("evidence_refs", [])
+    if (
+        not isinstance(evidence_refs, list)
+        or not evidence_refs
+        or not any(isinstance(r, str) and r.strip() for r in evidence_refs)
+    ):
+        return {
+            "tool": "context.self_explain",
+            "status": "error",
+            "error": {
+                "code": "invalid_evidence_refs",
+                "message": (
+                    "evidence_refs is required and must be a non-empty list "
+                    "of non-empty strings"
+                ),
+            },
+        }
+
+    evidence_refs_clean = [r for r in evidence_refs if isinstance(r, str) and r.strip()]
+
+    scope = kwargs.get("scope")
+    scope_clean = scope.strip() if isinstance(scope, str) and scope.strip() else None
+    if scope_clean:
+        summary = f"[{scope_clean}] {question.strip()}"
+    else:
+        summary = question.strip()
+
+    reasons_raw = kwargs.get("reasons", [])
+    if not isinstance(reasons_raw, list) or not reasons_raw:
+        reasons_raw = [f"Selbsterklaerung angefordert fuer: {question.strip()}"]
+    reasons = tuple(
+        r if isinstance(r, str) and r.strip() else str(r)
+        for r in reasons_raw
+    )
+
+    confidence = kwargs.get("confidence")
+    if confidence is not None and not isinstance(confidence, (int, float)):
+        confidence = None
+    if confidence is not None and not (0.0 <= float(confidence) <= 1.0):
+        confidence = None
+    confidence_float = float(confidence) if confidence is not None else None
+
+    recommended_next_reads = kwargs.get("recommended_next_reads", [])
+    if not isinstance(recommended_next_reads, list):
+        recommended_next_reads = []
+
+    required_next_step = (
+        "Pruefe Kontext gegen aktuelle Canon-Evidenz und Governance-Regeln."
+    )
+
+    try:
+        inp = SelfExplanationInput(
+            explanation_type=explanation_type,
+            summary=summary,
+            reasons=reasons,
+            evidence_refs=tuple(evidence_refs_clean),
+            required_next_step=required_next_step,
+            confidence=confidence_float,
+            scope_context=scope_clean,
+        )
+        output = build_self_explanation(inp)
+        payload = output.to_payload()
+
+        return {
+            "tool": "context.self_explain",
+            "status": "ok",
+            "explanation": payload,
+            "source_refs": [],
+            "evidence_refs": list(output.evidence_refs),
+            "graph_path": [],
+            "confidence": output.confidence,
+            "recommended_next_reads": recommended_next_reads,
+            "guardrails": list(output.guardrails),
+        }
+    except SelfExplanationError as e:
+        return {
+            "tool": "context.self_explain",
+            "status": "error",
+            "error": {
+                "code": e.code,
+                "message": e.message,
+            },
+        }
+    except Exception as e:
+        logger.exception("Self-explanation handler failed")
+        return {
+            "tool": "context.self_explain",
+            "status": "error",
+            "error": {
+                "code": "execution_error",
+                "message": str(e),
+            },
+        }
+
+
 class ContextBridge:
     """
     MCP Bridge for Context Intelligence System.
@@ -395,6 +544,17 @@ class ContextBridge:
                 handler=context_package_handler,
             )
             self._registry._tools["context.package"] = new_package
+        old_self_explain = self._registry.get_tool("context.self_explain")
+        if old_self_explain:
+            new_self_explain = ToolDefinition(
+                name=old_self_explain.name,
+                description=old_self_explain.description,
+                input_schema=old_self_explain.input_schema,
+                output_schema=old_self_explain.output_schema,
+                read_only=old_self_explain.read_only,
+                handler=context_self_explain_handler,
+            )
+            self._registry._tools["context.self_explain"] = new_self_explain
         logger.info(
             f"ContextBridge initialized with tools: {self._registry.list_tool_names()}"
         )

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -386,11 +386,7 @@ def context_self_explain_handler(**kwargs) -> dict[str, Any]:
         }
 
     evidence_refs = kwargs.get("evidence_refs", [])
-    if (
-        not isinstance(evidence_refs, list)
-        or not evidence_refs
-        or not any(isinstance(r, str) and r.strip() for r in evidence_refs)
-    ):
+    if not isinstance(evidence_refs, list) or not evidence_refs:
         return {
             "tool": "context.self_explain",
             "status": "error",
@@ -403,7 +399,21 @@ def context_self_explain_handler(**kwargs) -> dict[str, Any]:
             },
         }
 
-    evidence_refs_clean = [r for r in evidence_refs if isinstance(r, str) and r.strip()]
+    evidence_refs_clean: list[str] = []
+    for r in evidence_refs:
+        if not isinstance(r, str) or not r.strip():
+            return {
+                "tool": "context.self_explain",
+                "status": "error",
+                "error": {
+                    "code": "invalid_evidence_refs",
+                    "message": (
+                        "evidence_refs is required and must be a non-empty list "
+                        "of non-empty strings"
+                    ),
+                },
+            }
+        evidence_refs_clean.append(r)
 
     scope = kwargs.get("scope")
     scope_clean = scope.strip() if isinstance(scope, str) and scope.strip() else None
@@ -421,11 +431,33 @@ def context_self_explain_handler(**kwargs) -> dict[str, Any]:
     )
 
     confidence = kwargs.get("confidence")
-    if confidence is not None and not isinstance(confidence, (int, float)):
-        confidence = None
-    if confidence is not None and not (0.0 <= float(confidence) <= 1.0):
-        confidence = None
-    confidence_float = float(confidence) if confidence is not None else None
+    if confidence is not None:
+        if not isinstance(confidence, (int, float)):
+            return {
+                "tool": "context.self_explain",
+                "status": "error",
+                "error": {
+                    "code": "invalid_confidence",
+                    "message": (
+                        "confidence must be a number between 0.0 and 1.0, "
+                        f"got {type(confidence).__name__}: {confidence!r}"
+                    ),
+                },
+            }
+        if not (0.0 <= float(confidence) <= 1.0):
+            return {
+                "tool": "context.self_explain",
+                "status": "error",
+                "error": {
+                    "code": "invalid_confidence",
+                    "message": (
+                        f"confidence must be between 0.0 and 1.0, got {confidence}"
+                    ),
+                },
+            }
+        confidence_float = float(confidence)
+    else:
+        confidence_float = None
 
     recommended_next_reads = kwargs.get("recommended_next_reads", [])
     if not isinstance(recommended_next_reads, list):

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -432,6 +432,18 @@ def context_self_explain_handler(**kwargs) -> dict[str, Any]:
 
     confidence = kwargs.get("confidence")
     if confidence is not None:
+        if isinstance(confidence, bool):
+            return {
+                "tool": "context.self_explain",
+                "status": "error",
+                "error": {
+                    "code": "invalid_confidence",
+                    "message": (
+                        "confidence must be a number between 0.0 and 1.0, "
+                        f"got bool: {confidence!r}"
+                    ),
+                },
+            }
         if not isinstance(confidence, (int, float)):
             return {
                 "tool": "context.self_explain",

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -294,7 +294,7 @@ TOOLS_V0 = [
                 "source_refs": {"type": "array"},
                 "evidence_refs": {"type": "array"},
                 "graph_path": {"type": "array"},
-                "confidence": {"type": "number"},
+                "confidence": {"type": ["number", "null"]},
                 "recommended_next_reads": {"type": "array"},
                 "guardrails": {"type": "array"},
             },

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -274,7 +274,7 @@ TOOLS_V0 = [
                     "items": {"type": "string"},
                 },
                 "confidence": {
-                    "type": "number",
+                    "type": ["number", "null"],
                     "minimum": 0.0,
                     "maximum": 1.0,
                 },

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -239,6 +239,69 @@ TOOLS_V0 = [
         read_only=True,
         handler=create_not_implemented_handler("context.readiness"),
     ),
+    ToolDefinition(
+        name="context.self_explain",
+        description="Generate a structured self-explanation for governance-relevant conditions. Read-only, no action authorization, no Live-Go, no Echtgeld-Go.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "question": {
+                    "type": "string",
+                    "description": "The question or condition to explain.",
+                },
+                "explanation_type": {
+                    "type": "string",
+                    "enum": [
+                        "why_blocked",
+                        "why_risky",
+                        "why_stale",
+                        "why_decision_current",
+                        "why_decision_superseded",
+                        "why_scope_blocked",
+                        "why_evidence_weak",
+                        "why_agent_needs_go",
+                        "why_doc_untrusted",
+                    ],
+                },
+                "scope": {"type": "string"},
+                "evidence_refs": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                },
+                "reasons": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "confidence": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 1.0,
+                },
+                "recommended_next_reads": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+            },
+            "required": ["question", "explanation_type", "evidence_refs"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "status": {"type": "string"},
+                "explanation": {"type": "object"},
+                "source_refs": {"type": "array"},
+                "evidence_refs": {"type": "array"},
+                "graph_path": {"type": "array"},
+                "confidence": {"type": "number"},
+                "recommended_next_reads": {"type": "array"},
+                "guardrails": {"type": "array"},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("context.self_explain"),
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- Implements the #2190 read-only Self-Explanation MCP tool on top of the #2189 builder.
- Registers the tool as context.self_explain in the existing Context MCP bridge/registry pattern (context.* namespace), mapping the #2190 function cdb_context_self_explain within the established naming convention.
- Adds unit coverage for schema, read-only status, valid output, guardrails, and fail-closed invalid input.

## Scope
- Target issue: #2190 only.
- #2188 and #2196 remain open.
- #2191-#2195 remain separate follow-up issues.
- No issue close in this PR.
- No DB/MCP live write, runtime enablement, network access, Trading, Risk, Execution, Strategy, LR, Live, or Echtgeld change.

## Validation
- #2190 verified OPEN before editing.
- #2189 and #2093 verified CLOSED as dependencies.
- Git diff reviewed (3 files, +457/-2).
- MCP bridge tests (47/47 passed).
- Self-explanation tests (18/18 passed, no regressions).

Refs #2190