### PR TITLE
feat(context): implement agent readiness check v0

### DIFF
--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -710,3 +710,438 @@ class TestContextSelfExplainHandler:
         )
         assert result["status"] == "ok"
         assert len(result["explanation"]["reasons"]) >= 1
+
+
+class TestContextReadinessHandler:
+    """Tests for context.readiness tool handler (#2098)."""
+
+    # --- Blocked: missing_context ---
+
+    def test_missing_task_scope_returns_blocked_missing_context(self) -> None:
+        """Missing task_scope fails closed with blocked_missing_context."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        assert result["readiness"]["status"] == "blocked_missing_context"
+        assert "scope not defined" in result["readiness"]["missing_context"]
+
+    def test_empty_task_scope_whitespace_returns_blocked_missing_context(self) -> None:
+        """Whitespace-only task_scope fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "   ",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["readiness"]["status"] == "blocked_missing_context"
+
+    def test_invalid_operation_mode_returns_blocked_missing_context(self) -> None:
+        """Unknown operation_mode fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Test invalid mode.",
+                "operation_mode": "full_send",
+            },
+        )
+        assert result["readiness"]["status"] == "blocked_missing_context"
+        assert any(
+            "invalid operation_mode" in m
+            for m in result["readiness"]["missing_context"]
+        )
+
+    def test_missing_operation_mode_returns_blocked_missing_context(self) -> None:
+        """Missing operation_mode from kwargs fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Test missing mode.",
+            },
+        )
+        assert result["readiness"]["status"] == "blocked_missing_context"
+        assert any(
+            "invalid operation_mode" in m
+            for m in result["readiness"]["missing_context"]
+        )
+
+    def test_missing_required_reads_returns_blocked_missing_context(self) -> None:
+        """Missing minimum required reads blocks."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Inspect the risk engine.",
+                "operation_mode": "read_only",
+                "required_reads": ["AGENTS.md"],
+            },
+        )
+        assert result["readiness"]["status"] == "blocked_missing_context"
+        missing = result["readiness"]["missing_context"]
+        assert any("minimum required reads missing" in m for m in missing)
+
+    def test_no_context_package_and_no_reads_blocks(self) -> None:
+        """No context package and no required reads blocks."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Refactor something.",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["readiness"]["status"] == "blocked_missing_context"
+        assert any(
+            "no context package and no required reads" in m
+            for m in result["readiness"]["missing_context"]
+        )
+
+    def test_write_without_impact_report_returns_blocked_missing_context(self) -> None:
+        """Write operation without impact report blocks."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Fix a bug.",
+                "operation_mode": "write (code/docs)",
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+                "evidence_refs": ["#1234"],
+                "stop_conditions": ["S3: required reads unavailable"],
+            },
+        )
+        assert result["readiness"]["status"] == "blocked_missing_context"
+        assert any(
+            "write operation without impact report" in m
+            for m in result["readiness"]["missing_context"]
+        )
+
+    def test_no_stop_conditions_blocks(self) -> None:
+        """No stop conditions blocks."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Inspect logs.",
+                "operation_mode": "read_only",
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+            },
+        )
+        assert result["readiness"]["status"] == "blocked_missing_context"
+        assert any(
+            "no stop conditions" in m
+            for m in result["readiness"]["missing_context"]
+        )
+
+    # --- Blocked: missing_evidence ---
+
+    def test_write_without_evidence_returns_blocked_missing_evidence(self) -> None:
+        """Write operation without evidence refs blocks on missing evidence."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Fix a bug in the ws service.",
+                "operation_mode": "write (code/docs)",
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+                "impact_refs": ["services/ws/"],
+                "stop_conditions": ["S1: scope ambiguous"],
+            },
+        )
+        assert result["readiness"]["status"] == "blocked_missing_evidence"
+        assert any(
+            "write operation without evidence" in e
+            for e in result["readiness"]["missing_evidence"]
+        )
+
+    # --- Blocked: scope_drift ---
+
+    def test_live_claim_in_scope_returns_blocked_scope_drift(self) -> None:
+        """Task scope containing live/echtgeld claim is detected as scope drift."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Deploy system to production for go-live.",
+                "operation_mode": "read_only",
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+                "stop_conditions": ["S1: scope ambiguous"],
+            },
+        )
+        assert result["readiness"]["status"] == "blocked_scope_drift"
+        assert len(result["readiness"]["scope_drift_findings"]) >= 1
+
+    # --- Ready states ---
+
+    def test_read_only_with_minimum_inputs_returns_ready_for_read_only(self) -> None:
+        """Full minimum inputs for read-only returns ready_for_read_only."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Inspect how the execution service handles fills.",
+                "operation_mode": "read_only",
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+                "stop_conditions": ["S1: scope ambiguous"],
+            },
+        )
+        assert result["readiness"]["status"] == "ready_for_read_only"
+        assert result["readiness"]["human_go_required"] is False
+
+    def test_dry_run_returns_ready_for_dry_run(self) -> None:
+        """Dry-run mode returns ready_for_dry_run."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Plan a fix for reconnect timeout.",
+                "operation_mode": "dry_run",
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+                "stop_conditions": ["S1: scope ambiguous"],
+            },
+        )
+        assert result["readiness"]["status"] == "ready_for_dry_run"
+
+    def test_write_mode_with_context_returns_ready_for_human_go(self) -> None:
+        """Write mode with full context returns ready_for_human_go."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Fix decimal precision bug.",
+                "operation_mode": "write (code/docs)",
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+                "evidence_refs": ["#1983"],
+                "impact_refs": ["services/execution/"],
+                "stop_conditions": ["S1: scope ambiguous"],
+            },
+        )
+        assert result["readiness"]["status"] == "ready_for_human_go"
+        assert result["readiness"]["human_go_required"] is True
+
+    # --- human_go_required flag ---
+
+    def test_human_go_required_true_for_write(self) -> None:
+        """human_go_required is True for any write operation_mode."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Update config.",
+                "operation_mode": "write (config/infra)",
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+                "evidence_refs": ["#1234"],
+                "impact_refs": ["infrastructure/"],
+                "stop_conditions": ["S1: scope ambiguous"],
+            },
+        )
+        assert result["readiness"]["human_go_required"] is True
+
+    def test_human_go_required_false_for_read_only(self) -> None:
+        """human_go_required is False for pure read-only non-trading scope."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Read documentation.",
+                "operation_mode": "read_only",
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+                "stop_conditions": ["S1: scope ambiguous"],
+            },
+        )
+        assert result["readiness"]["human_go_required"] is False
+
+    # --- Uncertainties ---
+
+    def test_empty_uncertainties_is_ok(self) -> None:
+        """uncertainties=[] is not a blocker (per correction)."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Inspect log output.",
+                "operation_mode": "read_only",
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+                "stop_conditions": ["S1: scope ambiguous"],
+                "uncertainties": [],
+            },
+        )
+        assert result["readiness"]["status"] == "ready_for_read_only"
+
+    # --- Output contract compliance ---
+
+    def test_output_contains_all_contract_fields(self) -> None:
+        """Output contains all 10 contract fields."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Test output contract.",
+                "operation_mode": "read_only",
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+                "stop_conditions": ["S1: scope ambiguous"],
+            },
+        )
+        r = result["readiness"]
+        expected_fields = [
+            "status", "reasons", "required_next_reads",
+            "human_go_required", "stop_conditions",
+            "missing_context", "missing_evidence",
+            "scope_drift_findings", "uncertainties", "guardrails",
+        ]
+        for field in expected_fields:
+            assert field in r, f"Missing output field: {field}"
+
+    def test_guardrails_contain_boundary_text(self) -> None:
+        """Guardrails always contain the readiness-is-not-authorization boundary."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Any task.",
+                "operation_mode": "read_only",
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+                "stop_conditions": ["S1: scope ambiguous"],
+            },
+        )
+        guardrails = result["readiness"]["guardrails"]
+        assert len(guardrails) >= 2
+        assert any("not authorization" in g.lower() for g in guardrails)
+        assert any("lr remains no-go" in g.lower() for g in guardrails)
+
+    def test_readiness_not_authorization_explicit(self) -> None:
+        """Readiness status is not an authorization signal."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "Test authorization boundary.",
+                "operation_mode": "read_only",
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+                "stop_conditions": ["S1: scope ambiguous"],
+            },
+        )
+        r = result["readiness"]
+        assert r["status"] != "ready_for_human_go"  # read_only => ready_for_read_only
+
+    # --- Status determinism ---
+
+    def test_same_inputs_same_output(self) -> None:
+        """Same inputs produce identical readiness output."""
+        bridge = create_bridge()
+        inputs = {
+            "task_scope": "Verify determinism.",
+            "operation_mode": "read_only",
+            "required_reads": [
+                "AGENTS.md",
+                "agents/AGENTS.md",
+                "agents/OPEN_CODE_AGENTS.md",
+                "docs/runbooks/CONTROL_REGISTER.md",
+                "CURRENT_STATUS.md",
+                "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+            ],
+            "stop_conditions": ["S1: scope ambiguous"],
+            "uncertainties": [],
+        }
+        r1 = bridge.execute_tool("context.readiness", inputs)
+        r2 = bridge.execute_tool("context.readiness", inputs)
+        assert r1 == r2

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -542,6 +542,260 @@ def context_self_explain_handler(**kwargs) -> dict[str, Any]:
         }
 
 
+def context_readiness_handler(**kwargs) -> dict[str, Any]:
+    """
+    Read-only handler for context.readiness tool.
+
+    Implements Agent Action Readiness Check v0 per #2098.
+    Consumes the readiness contract from #2021:
+    docs/surrealdb/context-action-readiness-contract.md
+
+    Pure in-process evaluation. No DB/network. Fail-closed.
+    """
+    # --- Input extraction ---
+    task_scope = kwargs.get("task_scope")
+    target_issue = kwargs.get("target_issue")
+    target_paths = kwargs.get("target_paths", [])
+    operation_mode = kwargs.get("operation_mode", "")
+    context_package_ref = kwargs.get("context_package_ref")
+    required_reads = kwargs.get("required_reads", [])
+    evidence_refs = kwargs.get("evidence_refs", [])
+    impact_refs = kwargs.get("impact_refs", [])
+    stop_conditions_in = kwargs.get("stop_conditions", [])
+    uncertainties_in = kwargs.get("uncertainties")
+
+    # --- Normalize ---
+    if not isinstance(target_issue, str):
+        target_issue = None
+    if not isinstance(context_package_ref, str):
+        context_package_ref = None
+    if not isinstance(target_paths, list):
+        target_paths = []
+    if not isinstance(required_reads, list):
+        required_reads = []
+    if not isinstance(evidence_refs, list):
+        evidence_refs = []
+    if not isinstance(impact_refs, list):
+        impact_refs = []
+    if not isinstance(stop_conditions_in, list):
+        stop_conditions_in = []
+    if uncertainties_in is None:
+        uncertainties = []
+    elif not isinstance(uncertainties_in, list):
+        uncertainties = []
+    else:
+        uncertainties = [
+            u for u in uncertainties_in if isinstance(u, str) and u.strip()
+        ]
+
+    # --- Validate operation_mode against contract enum ---
+    VALID_OPERATION_MODES = frozenset({
+        "read_only",
+        "dry_run",
+        "write (code/docs)",
+        "write (config/infra)",
+        "write (DB/migration)",
+        "write (MCP live)",
+    })
+    if not isinstance(operation_mode, str) or operation_mode not in VALID_OPERATION_MODES:
+        return {
+            "tool": "context.readiness",
+            "status": "ok",
+            "readiness": {
+                "status": "blocked_missing_context",
+                "reasons": ["Invalid or missing operation_mode"],
+                "required_next_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+                "human_go_required": False,
+                "stop_conditions": [
+                    "S1: invalid operation_mode — must be one of: "
+                    + ", ".join(sorted(VALID_OPERATION_MODES)),
+                ],
+                "missing_context": [
+                    "invalid operation_mode: "
+                    + repr(operation_mode)
+                    + " — expected one of: "
+                    + ", ".join(sorted(VALID_OPERATION_MODES)),
+                ],
+                "missing_evidence": [],
+                "scope_drift_findings": [],
+                "uncertainties": [],
+                "guardrails": [
+                    "Do not proceed. Resolve missing context first.",
+                    "Readiness is not authorization. LR remains NO-GO. "
+                    "Board stage (trade-capable) is orthogonal.",
+                ],
+            },
+        }
+
+    # --- Accumulators ---
+    blocked_context: list[str] = []
+    blocked_evidence: list[str] = []
+    scope_drift_findings: list[str] = []
+    reasons: list[str] = []
+    required_next_reads: list[str] = []
+    guardrails: list[str] = []
+    output_stop_conditions: list[str] = []
+
+    MINIMUM_READS = [
+        "AGENTS.md",
+        "agents/AGENTS.md",
+        "agents/OPEN_CODE_AGENTS.md",
+        "docs/runbooks/CONTROL_REGISTER.md",
+        "CURRENT_STATUS.md",
+        "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+    ]
+
+    # --- Derive characteristics ---
+    is_write = isinstance(operation_mode, str) and operation_mode.startswith("write")
+    task_lower = task_scope.lower() if isinstance(task_scope, str) else ""
+    paths_lower = " ".join(target_paths).lower()
+
+    triggers = ["trading", "risk", "execution", "strategy"]
+    touches_trading_risk = any(
+        t in task_lower or t in paths_lower for t in triggers
+    )
+
+    live_kw = [
+        "live", "echtgeld", "production deploy", "go-live",
+        "live readiness", "lr-go", "live trading authorization",
+    ]
+    has_live_claim = any(kw in task_lower for kw in live_kw)
+
+    # --- Check 1: Scope defined ---
+    if not task_scope or not isinstance(task_scope, str) or not task_scope.strip():
+        blocked_context.append("scope not defined")
+
+    # --- Check 3: Required Reads (minimum baseline) ---
+    missing_reads = [r for r in MINIMUM_READS if r not in required_reads]
+    if missing_reads:
+        blocked_context.append(
+            f"minimum required reads missing: {', '.join(missing_reads)}"
+        )
+
+    # --- Check 2: Context Package or Required Reads ---
+    if not context_package_ref and not required_reads:
+        blocked_context.append("no context package and no required reads")
+
+    # --- Check 5: Impact Report for write operations ---
+    if is_write and not impact_refs:
+        blocked_context.append("write operation without impact report")
+
+    # --- Check 6: Stop Conditions ---
+    if not stop_conditions_in:
+        blocked_context.append("no stop conditions defined")
+
+    # --- Check 4: Evidence for core assumptions ---
+    if is_write and not evidence_refs:
+        blocked_evidence.append("write operation without evidence refs")
+
+    # --- Check 7: Human-GO required ---
+    # Human-GO is required for any write operation_mode (H1-H5),
+    # but read-only/dry-run inspections of trading/risk/execution
+    # scope do NOT require Human-GO (per contract Example 11.1).
+    human_go_required = is_write
+
+    # --- Check 8: Uncertainties ---
+    # uncertainties=[] is OK. For v0, detecting suppressed material
+    # uncertainties (governance/LR/Echtgeld) is deferred to Check 9;
+    # this check is informational-only at this stage.
+
+    # --- Check 9: No Live/Trading Derivation ---
+    if has_live_claim:
+        scope_drift_findings.append(
+            "task scope contains live/echtgeld/production claim — "
+            "readiness assessment must not derive or imply any Live-Readiness, "
+            "Echtgeld, or Trading authorization"
+        )
+
+    # --- Build output stop conditions from detected issues ---
+    if missing_reads:
+        for r in missing_reads:
+            output_stop_conditions.append(f"S3: minimum read unavailable: {r}")
+    if not context_package_ref and not required_reads:
+        output_stop_conditions.append(
+            "S2: no context package and no required reads"
+        )
+    if is_write and not impact_refs:
+        output_stop_conditions.append("S6: write without impact report")
+    if not stop_conditions_in:
+        output_stop_conditions.append("S1: no stop conditions — task_scope ambiguous")
+    if is_write and not evidence_refs:
+        output_stop_conditions.append("S4: core assumptions lack evidence")
+    if has_live_claim:
+        output_stop_conditions.append(
+            "S8: live/echtgeld claims outside LR SSOT"
+        )
+    if touches_trading_risk and is_write:
+        output_stop_conditions.append("S7: trading/risk/execution scope touched")
+
+    # Accumulate user-provided stop conditions
+    for sc in stop_conditions_in:
+        if sc not in output_stop_conditions:
+            output_stop_conditions.append(sc)
+
+    # --- Status derivation (deterministic, fail-closed) ---
+    if blocked_context:
+        status = "blocked_missing_context"
+        reasons.append("Missing required context")
+        required_next_reads = list(MINIMUM_READS)
+        guardrails.append("Do not proceed. Resolve missing context first.")
+    elif blocked_evidence:
+        status = "blocked_missing_evidence"
+        reasons.append("Missing evidence for core assumptions")
+        guardrails.append("Do not proceed. Evidence is missing.")
+    elif scope_drift_findings:
+        status = "blocked_scope_drift"
+        reasons.append("Scope drift detected")
+        guardrails.append("Do not proceed. Scope is not stable.")
+    elif human_go_required:
+        status = "ready_for_human_go"
+        reasons.append(
+            "Context sufficient. Write operation or trading/risk scope "
+            "requires Human-GO."
+        )
+        guardrails.append(
+            "Stop. Request Human-GO. Do not write until approved."
+        )
+    elif operation_mode == "dry_run":
+        status = "ready_for_dry_run"
+        reasons.append("Dry-run mode. Plan and preview, but do not execute.")
+        guardrails.append("Plan and diff only. No writes without Human-GO.")
+    else:
+        status = "ready_for_read_only"
+        reasons.append("Read-only scope, no writes required.")
+        guardrails.append("No writes. No issue comments. No PR creation.")
+
+    # Boundary guardrail — always present
+    guardrails.append(
+        "Readiness is not authorization. LR remains NO-GO. "
+        "Board stage (trade-capable) is orthogonal."
+    )
+
+    return {
+        "tool": "context.readiness",
+        "status": "ok",
+        "readiness": {
+            "status": status,
+            "reasons": reasons,
+            "required_next_reads": required_next_reads,
+            "human_go_required": human_go_required,
+            "stop_conditions": output_stop_conditions,
+            "missing_context": blocked_context if blocked_context else [],
+            "missing_evidence": blocked_evidence if blocked_evidence else [],
+            "scope_drift_findings": scope_drift_findings,
+            "uncertainties": uncertainties,
+            "guardrails": guardrails,
+        },
+    }
+
+
 class ContextBridge:
     """
     MCP Bridge for Context Intelligence System.
@@ -617,6 +871,17 @@ class ContextBridge:
                 handler=context_self_explain_handler,
             )
             self._registry._tools["context.self_explain"] = new_self_explain
+        old_readiness = self._registry.get_tool("context.readiness")
+        if old_readiness:
+            new_readiness = ToolDefinition(
+                name=old_readiness.name,
+                description=old_readiness.description,
+                input_schema=old_readiness.input_schema,
+                output_schema=old_readiness.output_schema,
+                read_only=old_readiness.read_only,
+                handler=context_readiness_handler,
+            )
+            self._registry._tools["context.readiness"] = new_readiness
         logger.info(
             f"ContextBridge initialized with tools: {self._registry.list_tool_names()}"
         )

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -219,21 +219,121 @@ TOOLS_V0 = [
     ),
     ToolDefinition(
         name="context.readiness",
-        description="Show read-only readiness evaluation metadata (NOT Live Readiness).",
+        description="Assess agent action readiness for a given task scope. Read-only, fails closed. Requires task_scope and operation_mode.",
         input_schema={
             "type": "object",
             "properties": {
-                "component": {"type": "string"},
-                "include_details": {"type": "boolean", "default": False},
+                "task_scope": {
+                    "type": "string",
+                    "description": "What the agent is asked to do (one concise sentence).",
+                },
+                "target_issue": {
+                    "type": ["string", "null"],
+                    "description": "GitHub issue driving the task, or null for exploratory.",
+                },
+                "target_paths": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "File paths or glob patterns in scope.",
+                },
+                "operation_mode": {
+                    "type": "string",
+                    "enum": [
+                        "read_only",
+                        "dry_run",
+                        "write (code/docs)",
+                        "write (config/infra)",
+                        "write (DB/migration)",
+                        "write (MCP live)",
+                    ],
+                    "description": "Operational mode for the task.",
+                },
+                "context_package_ref": {
+                    "type": ["string", "null"],
+                    "description": "Reference to an assembled Context Package.",
+                },
+                "required_reads": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Canonical files the agent must read before acting.",
+                },
+                "evidence_refs": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "References to evidence sources backing core assumptions.",
+                },
+                "impact_refs": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Issues/PRs/paths impacted by the proposed action.",
+                },
+                "stop_conditions": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Known stop conditions that would abort the task.",
+                },
+                "uncertainties": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Explicitly acknowledged unknowns or assumptions.",
+                },
             },
-            "required": ["component"],
+            "required": ["task_scope", "operation_mode"],
         },
         output_schema={
             "type": "object",
             "properties": {
                 "tool": {"type": "string"},
                 "status": {"type": "string"},
-                "readiness": {"type": "object"},
+                "readiness": {
+                    "type": "object",
+                    "properties": {
+                        "status": {
+                            "type": "string",
+                            "enum": [
+                                "ready_for_read_only",
+                                "ready_for_dry_run",
+                                "ready_for_human_go",
+                                "blocked_missing_context",
+                                "blocked_missing_evidence",
+                                "blocked_scope_drift",
+                            ],
+                        },
+                        "reasons": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "required_next_reads": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "human_go_required": {"type": "boolean"},
+                        "stop_conditions": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "missing_context": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "missing_evidence": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "scope_drift_findings": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "uncertainties": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "guardrails": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                    },
+                },
             },
         },
         read_only=True,


### PR DESCRIPTION
Closes #2098

---

## Summary

Implements the `context.readiness` MCP tool handler — a pure, read-only agent action readiness evaluator consuming the contract from #2021 (`docs/surrealdb/context-action-readiness-contract.md`).

### Files

| File | Change |
|------|--------|
| `tools/mcp/context_bridge.py` | `context_readiness_handler` (151 lines) + wiring in `ContextBridge.__init__` |
| `tools/mcp/registry.py` | Replaced scaffold with contract-based schema (10 inputs, 6 statuses, output contract) |
| `tests/unit/tools/mcp/test_context_bridge.py` | 20 new tests (validates blocked/ready states, contract fields, determinism) |

### Checks implemented (v0)

- **C1**: Scope defined (non-empty `task_scope`)
- **C2**: Context Package or Required Reads available
- **C3**: Minimum required reads (6 canonical files) present
- **C4**: Evidence refs required for write operations
- **C5**: Impact report required for write operations
- **C6**: Stop conditions present
- **C7**: `human_go_required` determined (write => true)
- **C8**: Uncertainties explicit (empty is OK)
- **C9**: Live/echtgeld/production claims detected as scope drift
- **Operation mode strict**: invalid/missing => `blocked_missing_context`

### Status derivation (fail-closed, deterministic)

```
blocked_missing_context → blocked_missing_evidence → blocked_scope_drift
→ ready_for_human_go → ready_for_dry_run → ready_for_read_only
```

### Verification

```
78 passed in 0.16s
Ruff: All checks passed!
```

### Guardrails

- Readiness is not authorization
- LR remains NO-GO (`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`)
- Board stage (`trade-capable`) is orthogonal
- No live-/echtgeld-/trading-Go derived or implied
