### PR TITLE
feat(context): implement agent briefing builder v1

### DIFF
--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -24,6 +24,7 @@ class TestContextToolRegistry:
             "context.package",
             "context.readiness",
             "context.self_explain",
+            "context.briefing",
         ]
         for expected in expected_tools:
             assert expected in tool_names, f"Tool {expected} not registered"
@@ -224,7 +225,7 @@ class TestContextBridge:
         """Verify list_tools returns all v0 tools."""
         bridge = ContextBridge()
         tools = bridge.list_tools()
-        assert len(tools) == 8
+        assert len(tools) == 9
         tool_names = [t["name"] for t in tools]
         assert "context.search" in tool_names
         assert "context.package" in tool_names
@@ -257,7 +258,7 @@ class TestContextBridge:
         bridge = ContextBridge()
         status = bridge.get_read_only_status()
         assert status["enforced"] is True
-        assert len(status["read_only_tools"]) == 8
+        assert len(status["read_only_tools"]) == 9
 
 
 class TestDefensiveSchemaCopies:
@@ -1145,3 +1146,444 @@ class TestContextReadinessHandler:
         r1 = bridge.execute_tool("context.readiness", inputs)
         r2 = bridge.execute_tool("context.readiness", inputs)
         assert r1 == r2
+
+
+class TestContextBriefingHandler:
+    """Tests for context.briefing tool handler (#2105)."""
+
+    def test_tool_in_list_tools(self) -> None:
+        """Tool is visible in list_tools()."""
+        bridge = create_bridge()
+        tool_names = [t["name"] for t in bridge.list_tools()]
+        assert "context.briefing" in tool_names
+
+    def test_tool_is_read_only(self) -> None:
+        """Tool is read-only."""
+        bridge = create_bridge()
+        schema = bridge.get_tool_schema("context.briefing")
+        assert schema is not None
+        assert schema["readOnly"] is True
+
+    def test_missing_task_id_fails_closed(self) -> None:
+        """Missing task_id fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_scope": "Test scope.",
+                "target_issue": None,
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_task_id"
+
+    def test_missing_task_scope_fails_closed(self) -> None:
+        """Missing task_scope fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-test",
+                "target_issue": None,
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_task_scope"
+
+    def test_invalid_depth_fails_closed(self) -> None:
+        """Invalid requested_depth fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-test",
+                "task_scope": "Test scope.",
+                "target_issue": None,
+                "requested_depth": "invalid",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_depth"
+
+    def test_invalid_operation_mode_fails_closed(self) -> None:
+        """Invalid operation_mode fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-test",
+                "task_scope": "Test scope.",
+                "target_issue": None,
+                "requested_depth": "quick",
+                "operation_mode": "invalid_mode",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_operation_mode"
+
+    def test_minimum_valid_request_returns_ok(self) -> None:
+        """Minimum valid request returns ok with briefing."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-2104-land-schema",
+                "task_scope": "Define the agent briefing schema v1.",
+                "target_issue": "#2104",
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        assert result["tool"] == "context.briefing"
+        assert "briefing" in result
+        b = result["briefing"]
+        assert b["briefing_id"] != ""
+        assert len(b["briefing_id"]) == 16
+
+    def test_output_contains_all_16_contract_fields(self) -> None:
+        """Output contains all 16 briefing contract fields per #2104 schema."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-test",
+                "task_scope": "Validate output contract.",
+                "target_issue": "#2104",
+                "requested_depth": "standard",
+                "operation_mode": "read_only",
+                "target_paths": ["docs/surrealdb/"],
+                "target_symbols": ["context_briefing_handler"],
+            },
+        )
+        assert result["status"] == "ok"
+        b = result["briefing"]
+        expected_fields = [
+            "briefing_id",
+            "scope_summary",
+            "context_package_ref",
+            "required_reads",
+            "relevant_artifacts",
+            "relevant_symbols",
+            "relevant_docs",
+            "relevant_decisions",
+            "relevant_evidence",
+            "dependency_paths",
+            "known_risks",
+            "guardrails",
+            "stop_conditions",
+            "validation_plan",
+            "unresolved_questions",
+            "human_go_required",
+        ]
+        for field in expected_fields:
+            assert field in b, f"Missing briefing field: {field}"
+
+    def test_depth_quick_returns_minimal(self) -> None:
+        """Quick depth returns minimal briefing (no package artifacts)."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-quick",
+                "task_scope": "Quick briefing test.",
+                "target_issue": None,
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        b = result["briefing"]
+        assert "quick — summary only" in b["scope_summary"].lower()
+        assert b["context_package_ref"] is None
+        assert b["relevant_artifacts"] == []
+        assert b["relevant_symbols"] == []
+
+    def test_depth_standard_returns_artifacts(self) -> None:
+        """Standard depth returns relevant artifacts/symbols/docs."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-standard",
+                "task_scope": "Standard briefing test.",
+                "target_issue": "#2105",
+                "requested_depth": "standard",
+                "operation_mode": "read_only",
+                "target_paths": ["tools/mcp/context_bridge.py"],
+                "target_symbols": ["context_briefing_handler"],
+            },
+        )
+        assert result["status"] == "ok"
+        b = result["briefing"]
+        assert "standard" in b["scope_summary"].lower()
+        assert b["context_package_ref"] is not None  # mocked package ref
+        assert len(b["relevant_artifacts"]) >= 1
+        assert len(b["relevant_symbols"]) >= 1
+        assert len(b["relevant_docs"]) >= 1
+
+    def test_depth_deep_flags_mock_uncertainty(self) -> None:
+        """Deep depth flags v0/mock/full-package uncertainty."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-deep",
+                "task_scope": "Deep briefing test.",
+                "target_issue": "#2105",
+                "requested_depth": "deep",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        b = result["briefing"]
+        assert "deep" in b["scope_summary"].lower()
+        assert any(
+            "mocked/synthetic" in q.lower() or "mock" in q.lower()
+            for q in b["unresolved_questions"]
+        ), "Deep depth should flag v0 mock/synthetic uncertainty"
+
+    def test_write_mode_sets_human_go_required_true(self) -> None:
+        """Write operation_mode sets human_go_required to True."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-write",
+                "task_scope": "Fix a bug in the execution service.",
+                "target_issue": "#1983",
+                "requested_depth": "standard",
+                "operation_mode": "write (code/docs)",
+                "target_paths": ["services/execution/"],
+            },
+        )
+        assert result["status"] == "ok"
+        b = result["briefing"]
+        assert b["human_go_required"] is True
+
+    def test_read_only_sets_human_go_required_false(self) -> None:
+        """read_only operation_mode sets human_go_required to False."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-read",
+                "task_scope": "Inspect the execution service.",
+                "target_issue": None,
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        b = result["briefing"]
+        assert b["human_go_required"] is False
+
+    def test_deterministic_briefing_id(self) -> None:
+        """Same request produces same briefing_id."""
+        bridge = create_bridge()
+        inputs = {
+            "task_id": "cdb-briefing-det-001",
+            "task_scope": "Determinism test.",
+            "target_issue": "#2105",
+            "requested_depth": "quick",
+            "operation_mode": "read_only",
+        }
+        r1 = bridge.execute_tool("context.briefing", inputs)
+        r2 = bridge.execute_tool("context.briefing", inputs)
+        assert r1["briefing"]["briefing_id"] == r2["briefing"]["briefing_id"]
+
+    def test_guardrails_contain_boundary_text_and_no_go(self) -> None:
+        """Guardrails contain boundary text and NO-GO."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-guard",
+                "task_scope": "Guardrail test.",
+                "target_issue": None,
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        guardrails = result["briefing"]["guardrails"]
+        assert len(guardrails) >= 7
+        assert any("not authorisation" in g.lower() for g in guardrails)
+        assert any("no-g" in g.lower() for g in guardrails)
+
+    def test_readiness_blocker_reflected(self) -> None:
+        """Readiness blocker is reflected in stop_conditions and unresolved_questions."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-blocked",
+                "task_scope": "Deploy to production for go-live.",
+                "target_issue": "#9999",
+                "requested_depth": "standard",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        b = result["briefing"]
+        # Readiness should detect scope drift (live claim)
+        stop_conditions = b["stop_conditions"]
+        all_text = " ".join(stop_conditions + b["unresolved_questions"])
+        assert (
+            "blocked" in all_text.lower()
+            or "scope" in all_text.lower()
+        ), "Readiness blocker should be reflected in output"
+
+    def test_known_risks_contains_mock_note(self) -> None:
+        """Known risks contains note about v0 synthetic/mock inputs."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-risks",
+                "task_scope": "Risk note test.",
+                "target_issue": None,
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        b = result["briefing"]
+        assert any(
+            "synthetic" in r.lower() or "mock" in r.lower()
+            for r in b["known_risks"]
+        ), "Known risks must surface v0 mock note"
+
+    def test_validation_plan_present_for_all_modes(self) -> None:
+        """Validation plan is present for all operation modes."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-val",
+                "task_scope": "Validation plan test.",
+                "target_issue": None,
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        vp = result["briefing"]["validation_plan"]
+        assert len(vp) >= 2
+        for step in vp:
+            assert "step" in step
+            assert "method" in step
+
+    def test_missing_target_issue_returns_error(self) -> None:
+        """Missing target_issue key fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-test",
+                "task_scope": "Test scope.",
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_target_issue"
+
+    def test_target_issue_null_is_ok(self) -> None:
+        """target_issue: null (None) is explicitly allowed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-null",
+                "task_scope": "Exploratory research.",
+                "target_issue": None,
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+
+    def test_missing_requested_depth_returns_error(self) -> None:
+        """Missing requested_depth key fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-test",
+                "task_scope": "Test scope.",
+                "target_issue": None,
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_depth"
+
+    def test_missing_operation_mode_returns_error(self) -> None:
+        """Missing operation_mode key fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-test",
+                "task_scope": "Test scope.",
+                "target_issue": None,
+                "requested_depth": "quick",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_operation_mode"
+
+    def test_valid_read_only_readiness_not_blocked(self) -> None:
+        """Valid read_only request does not get artificial missing-reads blocker."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-valid",
+                "task_scope": "Inspect the execution service.",
+                "target_issue": None,
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        b = result["briefing"]
+        assert b["human_go_required"] is False
+        assert len(b["required_reads"]) >= 6
+        # Must not contain blocked scope or artificial missing reads
+        assert "blocked" not in b["scope_summary"].lower().split("readiness status: ")[-1].split(".")[0]
+
+    def test_different_target_paths_produce_different_briefing_id(self) -> None:
+        """Different target_paths produce different briefing_id."""
+        bridge = create_bridge()
+        r1 = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-paths",
+                "task_scope": "Path test.",
+                "target_issue": None,
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+                "target_paths": ["docs/surrealdb/"],
+            },
+        )
+        r2 = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-paths",
+                "task_scope": "Path test.",
+                "target_issue": None,
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+                "target_paths": ["tools/mcp/"],
+            },
+        )
+        assert r1["status"] == "ok"
+        assert r2["status"] == "ok"
+        assert r1["briefing"]["briefing_id"] != r2["briefing"]["briefing_id"]

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -796,6 +796,387 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
     }
 
 
+def context_briefing_handler(**kwargs) -> dict[str, Any]:
+    """
+    Read-only handler for context.briefing tool.
+
+    Implements Agent Briefing Builder v1 per #2105.
+    Consumes the Briefing Schema v1 from #2104:
+    docs/surrealdb/context-agent-briefing-schema-v1.md
+
+    Delegates to context.readiness and context.package for context assembly.
+    Pure in-process evaluation. No DB/network. Fail-closed.
+    Generates deterministic briefing_id from request fields.
+
+    Guardrails: Briefing is context, not authorisation.
+    No Live/Echtgeld Go. LR remains NO-GO.
+    """
+    import hashlib
+    import json
+
+    _MISSING = object()
+
+    # --- Input extraction (no defaults for required fields) ---
+    task_id = kwargs.get("task_id")
+    task_scope = kwargs.get("task_scope")
+    target_issue = kwargs.get("target_issue", _MISSING)
+    requested_depth = kwargs.get("requested_depth", _MISSING)
+    operation_mode = kwargs.get("operation_mode", _MISSING)
+    target_paths = kwargs.get("target_paths", [])
+    target_symbols = kwargs.get("target_symbols", [])
+    target_concepts = kwargs.get("target_concepts", [])
+    agent_type = kwargs.get("agent_type", "")
+    risk_level = kwargs.get("risk_level", "medium")
+
+    # --- Validate required fields (fail-closed, sentinel for missing keys) ---
+    if not task_id or not isinstance(task_id, str) or not task_id.strip():
+        return {
+            "tool": "context.briefing",
+            "status": "error",
+            "error": {
+                "code": "invalid_task_id",
+                "message": "task_id is required and must be a non-empty string",
+            },
+        }
+
+    if not task_scope or not isinstance(task_scope, str) or not task_scope.strip():
+        return {
+            "tool": "context.briefing",
+            "status": "error",
+            "error": {
+                "code": "invalid_task_scope",
+                "message": "task_scope is required and must be a non-empty string",
+            },
+        }
+
+    if target_issue is _MISSING:
+        return {
+            "tool": "context.briefing",
+            "status": "error",
+            "error": {
+                "code": "invalid_target_issue",
+                "message": "target_issue is required (must be a string or null)",
+            },
+        }
+
+    if target_issue is not None and not isinstance(target_issue, str):
+        return {
+            "tool": "context.briefing",
+            "status": "error",
+            "error": {
+                "code": "invalid_target_issue",
+                "message": "target_issue must be a string or null",
+            },
+        }
+
+    if requested_depth is _MISSING:
+        return {
+            "tool": "context.briefing",
+            "status": "error",
+            "error": {
+                "code": "invalid_depth",
+                "message": "requested_depth is required",
+            },
+        }
+
+    valid_depths = frozenset({"quick", "standard", "deep"})
+    if not isinstance(requested_depth, str) or requested_depth not in valid_depths:
+        return {
+            "tool": "context.briefing",
+            "status": "error",
+            "error": {
+                "code": "invalid_depth",
+                "message": (
+                    f"requested_depth must be one of {sorted(valid_depths)}, "
+                    f"got {requested_depth!r}"
+                ),
+            },
+        }
+
+    if operation_mode is _MISSING:
+        return {
+            "tool": "context.briefing",
+            "status": "error",
+            "error": {
+                "code": "invalid_operation_mode",
+                "message": "operation_mode is required",
+            },
+        }
+
+    valid_modes = frozenset({
+        "read_only",
+        "dry_run",
+        "write (code/docs)",
+        "write (config/infra)",
+        "write (DB/migration)",
+        "write (MCP live)",
+    })
+    if not isinstance(operation_mode, str) or operation_mode not in valid_modes:
+        return {
+            "tool": "context.briefing",
+            "status": "error",
+            "error": {
+                "code": "invalid_operation_mode",
+                "message": (
+                    f"operation_mode must be one of {sorted(valid_modes)}, "
+                    f"got {operation_mode!r}"
+                ),
+            },
+        }
+
+    if risk_level not in frozenset({"low", "medium", "high"}):
+        risk_level = "medium"
+
+    # --- Normalize arrays ---
+    if not isinstance(target_paths, list):
+        target_paths = []
+    if not isinstance(target_symbols, list):
+        target_symbols = []
+    if not isinstance(target_concepts, list):
+        target_concepts = []
+
+    # --- Generate deterministic briefing_id from all request fields ---
+    target_paths_norm = [str(p) for p in target_paths if isinstance(p, str)]
+    target_symbols_norm = [str(s) for s in target_symbols if isinstance(s, str)]
+    target_concepts_norm = [str(c) for c in target_concepts if isinstance(c, str)]
+    agent_type_norm = agent_type.strip() if isinstance(agent_type, str) else ""
+    risk_level_norm = risk_level if risk_level in frozenset({"low", "medium", "high"}) else "medium"
+
+    request_for_hash: dict[str, Any] = {
+        "task_id": task_id.strip(),
+        "target_issue": target_issue if target_issue is not None else None,
+        "task_scope": task_scope.strip(),
+        "target_paths": target_paths_norm,
+        "target_symbols": target_symbols_norm,
+        "target_concepts": target_concepts_norm,
+        "requested_depth": requested_depth,
+        "operation_mode": operation_mode,
+        "agent_type": agent_type_norm,
+        "risk_level": risk_level_norm,
+    }
+    briefing_id = hashlib.sha256(
+        json.dumps(request_for_hash, sort_keys=True).encode()
+    ).hexdigest()[:16]
+
+    # --- Delegate to context.readiness with minimum reads ---
+    MINIMUM_READS = [
+        "AGENTS.md",
+        "agents/AGENTS.md",
+        "agents/OPEN_CODE_AGENTS.md",
+        "docs/runbooks/CONTROL_REGISTER.md",
+        "CURRENT_STATUS.md",
+        "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+    ]
+    readiness_result = context_readiness_handler(
+        task_scope=task_scope,
+        target_issue=target_issue,
+        target_paths=target_paths,
+        operation_mode=operation_mode,
+        required_reads=MINIMUM_READS,
+        stop_conditions=[
+            "S1: briefing scope ambiguous",
+            "S3: required canon reads unavailable",
+        ],
+    )
+    readiness = readiness_result.get("readiness", {})
+    human_go_required = readiness.get("human_go_required", False)
+    readiness_status = readiness.get("status", "ready_for_read_only")
+
+    # --- Derive stop conditions ---
+    stop_conditions = list(readiness.get("stop_conditions", []))
+    if human_go_required:
+        stop_conditions.append("H1: write action requires explicit Human-GO")
+    stop_conditions.append("S10: STOP if LR/Stage/Live claims surface")
+
+    # --- Guardrails (always present) ---
+    guardrails = [
+        "Briefing is context, not authorisation.",
+        "No Runtime write.",
+        "No MCP live action.",
+        "No DB/migration write.",
+        "No Trading/Risk/Execution decision.",
+        "No Live/Echtgeld Go.",
+        "LR remains NO-GO (SSOT: docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md).",
+    ]
+
+    # --- Required reads (from readiness, minimum baseline always present) ---
+    required_reads = readiness.get("required_next_reads", MINIMUM_READS) or MINIMUM_READS
+
+    # --- Delegate to context.package for standard/deep depth ---
+    package_artifacts: list[dict[str, Any]] = []
+    package_symbols: list[dict[str, Any]] = []
+    package_docs: list[dict[str, Any]] = []
+    dependency_paths: list[dict[str, Any]] = []
+    known_risks: list[str] = []
+    unresolved_questions: list[str] = []
+    context_package_ref: Optional[str] = None
+
+    if requested_depth in ("standard", "deep"):
+        package_result = context_package_handler(
+            artifacts=["briefing_artifact_001", "briefing_artifact_002"],
+            format="json",
+        )
+        pkg = package_result.get("package", {})
+        context_package_ref = pkg.get("package_id")
+
+        # Map package items to briefing fields
+        for item in pkg.get("items", []):
+            package_artifacts.append(
+                {
+                    "id": item.get("id", ""),
+                    "type": item.get("type", "doc"),
+                    "title": f"Artifact: {item.get('id', '')}",
+                    "source_ref": (
+                        item.get("source_refs", [""])[0]
+                        if item.get("source_refs")
+                        else ""
+                    ),
+                    "confidence": item.get("confidence", 0.5),
+                }
+            )
+
+        if target_symbols:
+            for sym in target_symbols[:10]:
+                package_symbols.append(
+                    {
+                        "symbol_name": sym,
+                        "symbol_type": "function",
+                        "file_path": f"<mocked>/path/to/{sym}",
+                        "dependents": [],
+                    }
+                )
+
+        if target_paths:
+            for path in target_paths[:5]:
+                package_docs.append(
+                    {
+                        "doc_id": f"doc_{hashlib.md5(path.encode()).hexdigest()[:8]}",
+                        "title": path,
+                        "path": path,
+                        "summary": f"Mocked documentation for {path}.",
+                    }
+                )
+
+        if target_paths and len(target_paths) > 1:
+            dependency_paths.append(
+                {
+                    "from": target_paths[0],
+                    "to": target_paths[1],
+                    "relationship": "references",
+                }
+            )
+
+    # --- Agent attribution for scope summary ---
+    agent_label = f" [{agent_type.strip()}]" if agent_type and agent_type.strip() else ""
+
+    # --- Depth-dependent content ---
+    if requested_depth == "quick":
+        scope_summary = (
+            f"Task {task_id}: {task_scope.strip()}{agent_label}. "
+            f"Depth: quick — summary only. "
+            f"Readiness status: {readiness_status}. "
+            f"Human-GO required: {human_go_required}."
+        )
+    elif requested_depth == "standard":
+        scope_summary = (
+            f"Task {task_id}: {task_scope.strip()}{agent_label}. "
+            f"Depth: standard — key artifacts + stop conditions. "
+            f"Readiness status: {readiness_status}. "
+            f"Context package: {context_package_ref or 'mocked-v0'}. "
+            f"Human-GO required: {human_go_required}."
+        )
+    else:  # deep
+        scope_summary = (
+            f"Task {task_id}: {task_scope.strip()}{agent_label}. "
+            f"Depth: deep — full context package requested. "
+            f"Readiness status: {readiness_status}. "
+            f"Context package: {context_package_ref or 'mocked-v0'}. "
+            f"Human-GO required: {human_go_required}. "
+            f"Note: deep depth requires full SurrealDB Context Package — "
+            f"mocked/synthetic in v0."
+        )
+        unresolved_questions.append(
+            "deep depth requires full Context Package from SurrealDB; "
+            "v0 uses synthetic/mock package inputs"
+        )
+
+    # --- Known risks ---
+    known_risks.append("v0 briefing builder uses synthetic/mock package inputs")
+    if readiness_status.startswith("blocked"):
+        known_risks.append(
+            f"Readiness check blocked: {readiness_status}; "
+            f"briefing may be incomplete"
+        )
+    if not target_paths and not target_symbols:
+        known_risks.append(
+            "no target_paths or target_symbols specified; "
+            "context may be minimal"
+        )
+
+    # --- Readiness blocker surfaced ---
+    if readiness_status.startswith("blocked"):
+        unresolved_questions.append(
+            f"readiness check returned {readiness_status}: "
+            f"{'; '.join(readiness.get('reasons', ['unknown']))}"
+        )
+        stop_conditions.append(
+            f"S2/S3: readiness blocked ({readiness_status}) — "
+            f"resolve missing context/evidence before proceeding"
+        )
+
+    # --- Validation plan ---
+    is_write = operation_mode.startswith("write")
+    validation_plan = []
+    if is_write:
+        validation_plan.append(
+            {
+                "step": "Verify Human-GO received",
+                "method": "Check that explicit GO was given for this specific action",
+                "evidence_required": "Human-GO confirmation (issue comment or explicit GO message)",
+            }
+        )
+    validation_plan.append(
+        {
+            "step": "Re-read required canon files",
+            "method": "Read AGENTS.md chain + CONTROL_REGISTER + CURRENT_STATUS + LR-AUDIT-STATUS",
+            "evidence_required": "Self-attestation that all required reads were completed",
+        }
+    )
+    validation_plan.append(
+        {
+            "step": "Verify all guardrails acknowledged",
+            "method": "Review guardrails list in this briefing",
+            "evidence_required": "Explicit acknowledgement in session log",
+        }
+    )
+
+    # --- Assemble briefing result ---
+    briefing: dict[str, Any] = {
+        "briefing_id": briefing_id,
+        "scope_summary": scope_summary,
+        "context_package_ref": context_package_ref,
+        "required_reads": required_reads,
+        "relevant_artifacts": package_artifacts[:10],
+        "relevant_symbols": package_symbols[:10],
+        "relevant_docs": package_docs[:5],
+        "relevant_decisions": [],
+        "relevant_evidence": [],
+        "dependency_paths": dependency_paths,
+        "known_risks": known_risks,
+        "guardrails": guardrails,
+        "stop_conditions": stop_conditions,
+        "validation_plan": validation_plan,
+        "unresolved_questions": unresolved_questions,
+        "human_go_required": human_go_required,
+    }
+
+    return {
+        "tool": "context.briefing",
+        "status": "ok",
+        "briefing": briefing,
+    }
+
+
 class ContextBridge:
     """
     MCP Bridge for Context Intelligence System.
@@ -882,6 +1263,17 @@ class ContextBridge:
                 handler=context_readiness_handler,
             )
             self._registry._tools["context.readiness"] = new_readiness
+        old_briefing = self._registry.get_tool("context.briefing")
+        if old_briefing:
+            new_briefing = ToolDefinition(
+                name=old_briefing.name,
+                description=old_briefing.description,
+                input_schema=old_briefing.input_schema,
+                output_schema=old_briefing.output_schema,
+                read_only=old_briefing.read_only,
+                handler=context_briefing_handler,
+            )
+            self._registry._tools["context.briefing"] = new_briefing
         logger.info(
             f"ContextBridge initialized with tools: {self._registry.list_tool_names()}"
         )

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -402,6 +402,99 @@ TOOLS_V0 = [
         read_only=True,
         handler=create_not_implemented_handler("context.self_explain"),
     ),
+    ToolDefinition(
+        name="context.briefing",
+        description="Generate a task-specific Agent Briefing v1 from Briefing Request schema (docs/surrealdb/context-agent-briefing-schema-v1.md). Delegates to context.readiness and context.package for context assembly. Read-only, no authorization, no Live/Echtgeld Go.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "Unique task identifier. Convention: cdb-briefing-<issue>-<short-slug>.",
+                },
+                "target_issue": {
+                    "type": ["string", "null"],
+                    "description": "GitHub issue number driving the task, or null for exploratory.",
+                },
+                "task_scope": {
+                    "type": "string",
+                    "description": "What the agent is asked to do (one concise sentence).",
+                },
+                "target_paths": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "File paths or glob patterns in scope.",
+                },
+                "target_symbols": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Code symbols relevant to the task.",
+                },
+                "target_concepts": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Domain concepts from the CIS ontology relevant to the task.",
+                },
+                "requested_depth": {
+                    "type": "string",
+                    "enum": ["quick", "standard", "deep"],
+                    "description": "Briefing depth.",
+                },
+                "operation_mode": {
+                    "type": "string",
+                    "enum": [
+                        "read_only",
+                        "dry_run",
+                        "write (code/docs)",
+                        "write (config/infra)",
+                        "write (DB/migration)",
+                        "write (MCP live)",
+                    ],
+                    "description": "Intended agent operation mode.",
+                },
+                "agent_type": {
+                    "type": "string",
+                    "description": "Agent identifier (e.g. OPENCODE/codex, GEMINI, CLAUDE).",
+                },
+                "risk_level": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high"],
+                    "description": "Pre-assessed risk level of the task.",
+                },
+            },
+            "required": ["task_id", "task_scope", "target_issue", "requested_depth", "operation_mode"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "status": {"type": "string"},
+                "briefing": {
+                    "type": "object",
+                    "properties": {
+                        "briefing_id": {"type": "string"},
+                        "scope_summary": {"type": "string"},
+                        "context_package_ref": {"type": ["string", "null"]},
+                        "required_reads": {"type": "array", "items": {"type": "string"}},
+                        "relevant_artifacts": {"type": "array"},
+                        "relevant_symbols": {"type": "array"},
+                        "relevant_docs": {"type": "array"},
+                        "relevant_decisions": {"type": "array"},
+                        "relevant_evidence": {"type": "array"},
+                        "dependency_paths": {"type": "array"},
+                        "known_risks": {"type": "array", "items": {"type": "string"}},
+                        "guardrails": {"type": "array", "items": {"type": "string"}},
+                        "stop_conditions": {"type": "array", "items": {"type": "string"}},
+                        "validation_plan": {"type": "array"},
+                        "unresolved_questions": {"type": "array", "items": {"type": "string"}},
+                        "human_go_required": {"type": "boolean"},
+                    },
+                },
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("context.briefing"),
+    ),
 ]
 
 


### PR DESCRIPTION
- Closes #2105
- Summary:
  - Registers read-only `context.briefing`
  - Implements deterministic `context_briefing_handler`
  - Wires handler into `ContextBridge`
  - Adds 24 briefing tests
  - Delegates to readiness/package handlers
  - Surfaces v0 mock/synthetic package limitations in `known_risks` / `unresolved_questions`
- Validation:
  - `pytest -v tests/unit/tools/mcp/test_context_bridge.py` -> `102 passed`
  - `ruff check tools/mcp/context_bridge.py tools/mcp/registry.py tests/unit/tools/mcp/test_context_bridge.py` -> clean
- Guardrails:
  - read-only only
  - no Runtime write
  - no DB/migration write
  - no MCP live action
  - no Trading/Risk/Execution decision
  - no Live-/Echtgeld-Go
  - LR remains NO-GO