### PR TITLE
feat(context): implement stop condition resolver v1

### DIFF
--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -25,6 +25,7 @@ class TestContextToolRegistry:
             "context.readiness",
             "context.self_explain",
             "context.briefing",
+            "context.stop_resolver",
         ]
         for expected in expected_tools:
             assert expected in tool_names, f"Tool {expected} not registered"
@@ -225,7 +226,7 @@ class TestContextBridge:
         """Verify list_tools returns all v0 tools."""
         bridge = ContextBridge()
         tools = bridge.list_tools()
-        assert len(tools) == 9
+        assert len(tools) == 10
         tool_names = [t["name"] for t in tools]
         assert "context.search" in tool_names
         assert "context.package" in tool_names
@@ -258,7 +259,7 @@ class TestContextBridge:
         bridge = ContextBridge()
         status = bridge.get_read_only_status()
         assert status["enforced"] is True
-        assert len(status["read_only_tools"]) == 9
+        assert len(status["read_only_tools"]) == 10
 
 
 class TestDefensiveSchemaCopies:
@@ -1587,3 +1588,443 @@ class TestContextBriefingHandler:
         assert r1["status"] == "ok"
         assert r2["status"] == "ok"
         assert r1["briefing"]["briefing_id"] != r2["briefing"]["briefing_id"]
+
+
+class TestContextStopResolverHandler:
+    """Tests for context.stop_resolver tool handler (#2107)."""
+
+    def test_tool_in_list_tools(self) -> None:
+        """Tool is visible in list_tools()."""
+        bridge = create_bridge()
+        tool_names = [t["name"] for t in bridge.list_tools()]
+        assert "context.stop_resolver" in tool_names
+
+    def test_tool_is_read_only(self) -> None:
+        """Tool is read-only."""
+        bridge = create_bridge()
+        schema = bridge.get_tool_schema("context.stop_resolver")
+        assert schema is not None
+        assert schema["readOnly"] is True
+
+    def test_missing_stop_conditions_returns_empty(self) -> None:
+        """Missing stop_conditions returns empty resolved list."""
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.stop_resolver", {})
+        assert result["status"] == "ok"
+        assert result["resolved"] == []
+
+    def test_empty_stop_conditions_returns_empty(self) -> None:
+        """Empty stop_conditions returns empty resolved list."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver", {"stop_conditions": []}
+        )
+        assert result["status"] == "ok"
+        assert result["resolved"] == []
+
+    def test_s1_maps_to_scope_drift_risk_blocking(self) -> None:
+        """S1 maps to scope_drift_risk with blocking severity."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["S1: scope ambiguous"]},
+        )
+        assert result["status"] == "ok"
+        assert len(result["resolved"]) == 1
+        r = result["resolved"][0]
+        assert r["type"] == "scope_drift_risk"
+        assert r["severity"] == "blocking"
+        assert r["human_go_required"] is True
+
+    def test_s2_maps_to_missing_context_blocking(self) -> None:
+        """S2 maps to missing_context with blocking severity."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["S2: no context package and no required reads"]},
+        )
+        assert result["status"] == "ok"
+        assert len(result["resolved"]) == 1
+        r = result["resolved"][0]
+        assert r["type"] == "missing_context"
+        assert r["severity"] == "blocking"
+
+    def test_s3_maps_to_missing_context_blocking(self) -> None:
+        """S3 maps to missing_context with blocking severity."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["S3: minimum read unavailable: AGENTS.md"]},
+        )
+        assert result["status"] == "ok"
+        assert len(result["resolved"]) == 1
+        r = result["resolved"][0]
+        assert r["type"] == "missing_context"
+        assert r["severity"] == "blocking"
+
+    def test_s4_maps_to_missing_evidence_blocking(self) -> None:
+        """S4 maps to missing_evidence with blocking severity."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["S4: core assumptions lack evidence"]},
+        )
+        assert result["status"] == "ok"
+        assert len(result["resolved"]) == 1
+        r = result["resolved"][0]
+        assert r["type"] == "missing_evidence"
+        assert r["severity"] == "blocking"
+
+    def test_s5_maps_to_scope_drift_risk_blocking(self) -> None:
+        """S5 maps to scope_drift_risk with blocking severity."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["S5: scope drift detected"]},
+        )
+        assert result["status"] == "ok"
+        assert len(result["resolved"]) == 1
+        r = result["resolved"][0]
+        assert r["type"] == "scope_drift_risk"
+        assert r["severity"] == "blocking"
+
+    def test_s6_maps_to_write_requires_human_go_blocking(self) -> None:
+        """S6 maps to write_requires_human_go with blocking severity."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["S6: write without impact report"]},
+        )
+        assert result["status"] == "ok"
+        assert len(result["resolved"]) == 1
+        r = result["resolved"][0]
+        assert r["type"] == "write_requires_human_go"
+        assert r["severity"] == "blocking"
+
+    def test_s7_trading_blocking_for_write(self) -> None:
+        """S7 is blocking for write operation_mode."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {
+                "stop_conditions": ["S7: trading/risk/execution scope touched"],
+                "operation_mode": "write (code/docs)",
+            },
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        assert r["type"] == "trading_surface_touched"
+        assert r["severity"] == "blocking"
+
+    def test_s7_trading_warning_for_read_only(self) -> None:
+        """S7 is warning for read_only operation_mode."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {
+                "stop_conditions": ["S7: trading/risk/execution scope touched"],
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        assert r["type"] == "trading_surface_touched"
+        assert r["severity"] == "warning"
+
+    def test_s8_maps_to_forbidden_path_blocking(self) -> None:
+        """S8 maps to forbidden_path with blocking severity."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["S8: live/echtgeld claims outside LR SSOT"]},
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        assert r["type"] == "forbidden_path"
+        assert r["severity"] == "blocking"
+        assert r["human_go_required"] is True
+
+    def test_s9_maps_to_contradiction_risk_warning(self) -> None:
+        """S9 maps to contradiction_risk with warning severity."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["S9: material governance uncertainty"]},
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        assert r["type"] == "contradiction_risk"
+        assert r["severity"] == "warning"
+
+    def test_s10_maps_to_stale_context_warning(self) -> None:
+        """S10 maps to stale_context with warning severity."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["S10: STOP in control surfaces"]},
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        assert r["type"] == "stale_context"
+        assert r["severity"] == "warning"
+
+    def test_h1_maps_to_write_requires_human_go_blocking(self) -> None:
+        """H1 maps to write_requires_human_go with blocking severity."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["H1: write action requires explicit Human-GO"]},
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        assert r["type"] == "write_requires_human_go"
+        assert r["severity"] == "blocking"
+        assert r["human_go_required"] is True
+
+    def test_h2_maps_to_runtime_surface_touched_blocking(self) -> None:
+        """H2 maps to runtime_surface_touched with blocking severity."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["H2: runtime or DB mutation requires Human-GO"]},
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        assert r["type"] == "runtime_surface_touched"
+        assert r["severity"] == "blocking"
+
+    def test_secrets_keyword_maps_to_secrets_risk_blocking(self) -> None:
+        """Condition containing secrets keyword maps to secrets_risk."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["tresor-zone access detected"]},
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        assert r["type"] == "secrets_risk"
+        assert r["severity"] == "blocking"
+        assert r["human_go_required"] is True
+
+    def test_token_keyword_maps_to_secrets_risk_blocking(self) -> None:
+        """Condition containing token keyword maps to secrets_risk."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["GITHUB_TOKEN exposed in logs"]},
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        assert r["type"] == "secrets_risk"
+        assert r["severity"] == "blocking"
+
+    def test_live_keyword_maps_to_forbidden_path_blocking(self) -> None:
+        """Condition containing live keyword without rule-ref maps to forbidden_path."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["go-live authorization missing"]},
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        assert r["type"] == "forbidden_path"
+        assert r["severity"] == "blocking"
+
+    def test_unknown_condition_maps_to_scope_drift_risk_warning(self) -> None:
+        """Unknown/unmapped condition maps to scope_drift_risk with warning."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["some unexpected condition"]},
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        assert r["type"] == "scope_drift_risk"
+        assert r["severity"] == "warning"
+
+    def test_runtime_keyword_maps_to_runtime_surface_touched(self) -> None:
+        """Condition containing runtime keyword without rule-ref maps correctly."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["docker compose service detected"]},
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        assert r["type"] == "runtime_surface_touched"
+        assert r["severity"] == "warning"
+
+    def test_non_string_stop_conditions_filtered(self) -> None:
+        """Non-string stop conditions are filtered without crash."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": [42, None, "S1: scope ambiguous", True]},
+        )
+        assert result["status"] == "ok"
+        assert len(result["resolved"]) == 1
+        assert result["resolved"][0]["type"] == "scope_drift_risk"
+
+    def test_output_contains_all_required_fields(self) -> None:
+        """Output dicts contain all five required fields."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["S1: scope ambiguous"]},
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        for field in ("type", "severity", "reason", "required_action", "human_go_required"):
+            assert field in r, f"Missing field: {field}"
+        assert r["type"] in {
+            "missing_context", "missing_evidence", "scope_drift_risk",
+            "runtime_surface_touched", "trading_surface_touched",
+            "write_requires_human_go", "stale_context",
+            "contradiction_risk", "forbidden_path", "secrets_risk",
+        }
+        assert r["severity"] in {"info", "warning", "blocking"}
+        assert isinstance(r["human_go_required"], bool)
+
+    def test_deterministic_same_input_same_output(self) -> None:
+        """Same inputs produce identical resolved output."""
+        bridge = create_bridge()
+        inputs = {
+            "stop_conditions": ["S1: scope ambiguous", "S4: no evidence"],
+            "operation_mode": "write (code/docs)",
+        }
+        r1 = bridge.execute_tool("context.stop_resolver", inputs)
+        r2 = bridge.execute_tool("context.stop_resolver", inputs)
+        assert r1 == r2
+
+    def test_multiple_conditions_all_resolved(self) -> None:
+        """Multiple conditions are all resolved."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {
+                "stop_conditions": [
+                    "S1: scope ambiguous",
+                    "S3: minimum read unavailable: CONTROL_REGISTER.md",
+                    "S4: core assumptions lack evidence",
+                    "S10: STOP in control surfaces",
+                ],
+            },
+        )
+        assert result["status"] == "ok"
+        assert len(result["resolved"]) == 4
+        types = [r["type"] for r in result["resolved"]]
+        assert "scope_drift_risk" in types
+        assert "missing_context" in types
+        assert "missing_evidence" in types
+        assert "stale_context" in types
+
+    def test_whitespace_only_stop_conditions_filtered(self) -> None:
+        """Whitespace-only strings in stop_conditions are filtered."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["   ", "\t", "S1: scope ambiguous"]},
+        )
+        assert result["status"] == "ok"
+        assert len(result["resolved"]) == 1
+
+    def test_warnings_input_accepted(self) -> None:
+        """Warnings parameter is accepted without error."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {
+                "stop_conditions": ["S1: scope ambiguous"],
+                "warnings": ["artifacts_limit_exceeded", "low confidence"],
+            },
+        )
+        assert result["status"] == "ok"
+        assert len(result["resolved"]) == 1
+
+    def test_readiness_result_input_accepted(self) -> None:
+        """readiness_result parameter is accepted and conditions extracted."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {
+                "stop_conditions": ["S1: scope ambiguous"],
+                "readiness_result": {
+                    "stop_conditions": [
+                        "S7: trading/risk/execution scope touched",
+                    ],
+                },
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        # S1 + S7 from readiness = 2 resolved
+        assert len(result["resolved"]) == 2
+
+    def test_briefing_stop_conditions_remain_string_array(self) -> None:
+        """Briefing result stop_conditions is still a flat string[]."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-2107-test",
+                "task_scope": "Test briefing stop conditions schema compliance.",
+                "target_issue": "#2107",
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        b = result["briefing"]
+        assert "stop_conditions" in b
+        assert isinstance(b["stop_conditions"], list)
+        for sc in b["stop_conditions"]:
+            assert isinstance(sc, str), (
+                f"stop_conditions must remain string[], got {type(sc).__name__}: {sc!r}"
+            )
+
+    def test_resolver_does_not_mutate_input_list(self) -> None:
+        """Input stop_conditions list is not mutated by resolve_stop_conditions."""
+        from tools.surrealdb.context_stop_resolver import resolve_stop_conditions
+
+        original = ["S1: scope ambiguous", "S4: no evidence"]
+        before = list(original)
+        _result = resolve_stop_conditions(stop_conditions=original)
+        assert original == before, (
+            f"Input list was mutated: {before} -> {original}"
+        )
+
+    def test_briefing_surfaces_resolver_failure(self) -> None:
+        """When the resolver raises, briefing surfaces it in known_risks
+        and unresolved_questions."""
+        from unittest.mock import patch
+
+        bridge = create_bridge()
+        params = {
+            "task_id": "cdb-briefing-err-test",
+            "task_scope": "Test resolver failure surfacing.",
+            "target_issue": None,
+            "requested_depth": "quick",
+            "operation_mode": "read_only",
+        }
+
+        with patch(
+            "tools.surrealdb.context_stop_resolver.resolve_stop_conditions",
+            side_effect=RuntimeError("mock resolver crash"),
+        ):
+            result = bridge.execute_tool("context.briefing", params)
+
+        assert result["status"] == "ok"
+        b = result["briefing"]
+        assert isinstance(b["stop_conditions"], list)
+        for sc in b["stop_conditions"]:
+            assert isinstance(sc, str), (
+                f"stop_conditions must remain string[] on failure"
+            )
+        risk_text = " ".join(b["known_risks"]).lower()
+        assert "resolver unavailable" in risk_text, (
+            f"known_risks should surface resolver failure, got: {b['known_risks']}"
+        )
+        unresolved_text = " ".join(b["unresolved_questions"]).lower()
+        assert "stop condition resolver failed" in unresolved_text, (
+            f"unresolved_questions should surface resolver failure, got: {b['unresolved_questions']}"
+        )

--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -2028,3 +2028,49 @@ class TestContextStopResolverHandler:
         assert "stop condition resolver failed" in unresolved_text, (
             f"unresolved_questions should surface resolver failure, got: {b['unresolved_questions']}"
         )
+
+    def test_live_substring_no_false_positive_deliverable(self) -> None:
+        """'deliverable' does NOT trigger forbidden_path (word-boundary fix)."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["deliverable pending review"]},
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        assert r["type"] != "forbidden_path", (
+            f"deliverable should not trigger forbidden_path, got {r['type']}"
+        )
+
+    def test_key_substring_no_false_positive_monkeypatch(self) -> None:
+        """'monkeypatch' etc. does NOT trigger secrets_risk (word-boundary fix)."""
+        from tools.surrealdb.context_stop_resolver import resolve_stop_conditions
+
+        for text in ("monkeypatch", "keyboard", "key result", "turkey"):
+            result = resolve_stop_conditions(stop_conditions=[text])
+            for r in result:
+                assert r["type"] != "secrets_risk", (
+                    f"{text!r} should not trigger secrets_risk, got {r['type']}"
+                )
+
+    def test_standalone_live_still_triggers_forbidden_path(self) -> None:
+        """Standalone word 'live' still triggers forbidden_path."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.stop_resolver",
+            {"stop_conditions": ["live deployment requested"]},
+        )
+        assert result["status"] == "ok"
+        r = result["resolved"][0]
+        assert r["type"] == "forbidden_path"
+
+    def test_api_key_still_triggers_secrets_risk(self) -> None:
+        """'api_key' still triggers secrets_risk."""
+        from tools.surrealdb.context_stop_resolver import resolve_stop_conditions
+
+        for text in ("api_key found", "private key exposed", "secret_key leaked"):
+            result = resolve_stop_conditions(stop_conditions=[text])
+            assert len(result) >= 1
+            assert result[0]["type"] == "secrets_risk", (
+                f"{text!r} should trigger secrets_risk"
+            )

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -988,6 +988,28 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
         stop_conditions.append("H1: write action requires explicit Human-GO")
     stop_conditions.append("S10: STOP if LR/Stage/Live claims surface")
 
+    # --- Internal resolver usage: enrich stop conditions without new fields ---
+    resolver_error: Optional[str] = None
+    try:
+        from tools.surrealdb.context_stop_resolver import resolve_stop_conditions
+
+        resolved = resolve_stop_conditions(
+            stop_conditions=stop_conditions,
+            operation_mode=operation_mode,
+        )
+        for rc in resolved:
+            sc_type = rc.get("type", "")
+            sc_text = (
+                f"{rc.get('severity', 'warning')}: {sc_type} — "
+                f"{rc.get('reason', '')}"
+            )
+            if sc_text not in stop_conditions:
+                stop_conditions.append(sc_text)
+    except Exception as e:
+        resolver_error = (
+            f"stop resolver unavailable: {type(e).__name__}: {e}"
+        )
+
     # --- Guardrails (always present) ---
     guardrails = [
         "Briefing is context, not authorisation.",
@@ -1113,6 +1135,13 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
             "context may be minimal"
         )
 
+    # --- Surface resolver failure ---
+    if resolver_error:
+        known_risks.append(resolver_error)
+        unresolved_questions.append(
+            "stop condition resolver failed; flat stop_conditions preserved"
+        )
+
     # --- Readiness blocker surfaced ---
     if readiness_status.startswith("blocked"):
         unresolved_questions.append(
@@ -1174,6 +1203,75 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
         "tool": "context.briefing",
         "status": "ok",
         "briefing": briefing,
+    }
+
+
+def context_stop_resolver_handler(**kwargs) -> dict[str, Any]:
+    """
+    Read-only handler for context.stop_resolver tool.
+
+    Resolves flat stop-condition strings to typed stop condition objects.
+    Delegates to tools.surrealdb.context_stop_resolver.resolve_stop_conditions.
+    Pure in-process evaluation. No DB/network. Fail-closed.
+
+    Input:
+        stop_conditions: list[str] — flat stop condition strings
+        warnings: list[str] (optional) — warning strings to scan
+        readiness_result: dict (optional) — readiness result for additional inputs
+        operation_mode: str (optional, default "read_only")
+
+    Output:
+        tool, status, resolved (list of typed conditions)
+    """
+    from tools.surrealdb.context_stop_resolver import resolve_stop_conditions
+
+    stop_conditions_in = kwargs.get("stop_conditions", [])
+    warnings_in = kwargs.get("warnings")
+    readiness_result_in = kwargs.get("readiness_result")
+    operation_mode = kwargs.get("operation_mode", "read_only")
+
+    if not isinstance(stop_conditions_in, list):
+        stop_conditions_in = []
+
+    if warnings_in is not None and not isinstance(warnings_in, list):
+        warnings_in = []
+
+    if readiness_result_in is not None and not isinstance(readiness_result_in, dict):
+        readiness_result_in = None
+
+    valid_modes = frozenset({
+        "read_only",
+        "dry_run",
+        "write (code/docs)",
+        "write (config/infra)",
+        "write (DB/migration)",
+        "write (MCP live)",
+    })
+    if not isinstance(operation_mode, str) or operation_mode not in valid_modes:
+        operation_mode = "read_only"
+
+    try:
+        resolved = resolve_stop_conditions(
+            stop_conditions=stop_conditions_in,
+            warnings=warnings_in,
+            readiness_result=readiness_result_in,
+            operation_mode=operation_mode,
+        )
+    except Exception as e:
+        logger.exception("Stop condition resolver failed")
+        return {
+            "tool": "context.stop_resolver",
+            "status": "error",
+            "error": {
+                "code": "execution_error",
+                "message": str(e),
+            },
+        }
+
+    return {
+        "tool": "context.stop_resolver",
+        "status": "ok",
+        "resolved": resolved,
     }
 
 
@@ -1274,6 +1372,17 @@ class ContextBridge:
                 handler=context_briefing_handler,
             )
             self._registry._tools["context.briefing"] = new_briefing
+        old_stop_resolver = self._registry.get_tool("context.stop_resolver")
+        if old_stop_resolver:
+            new_stop_resolver = ToolDefinition(
+                name=old_stop_resolver.name,
+                description=old_stop_resolver.description,
+                input_schema=old_stop_resolver.input_schema,
+                output_schema=old_stop_resolver.output_schema,
+                read_only=old_stop_resolver.read_only,
+                handler=context_stop_resolver_handler,
+            )
+            self._registry._tools["context.stop_resolver"] = new_stop_resolver
         logger.info(
             f"ContextBridge initialized with tools: {self._registry.list_tool_names()}"
         )

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -495,6 +495,82 @@ TOOLS_V0 = [
         read_only=True,
         handler=create_not_implemented_handler("context.briefing"),
     ),
+    ToolDefinition(
+        name="context.stop_resolver",
+        description="Resolve flat stop-condition strings to typed stop condition objects. Read-only, deterministic, fail-closed. No DB/network/GitHub access.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "stop_conditions": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Flat stop condition strings to resolve (S1-S10, H1-H8 patterns).",
+                },
+                "warnings": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional warning strings to scan for secrets/live/runtime keywords.",
+                },
+                "readiness_result": {
+                    "type": "object",
+                    "description": "Optional readiness result from context.readiness for additional stop conditions.",
+                },
+                "operation_mode": {
+                    "type": "string",
+                    "enum": [
+                        "read_only",
+                        "dry_run",
+                        "write (code/docs)",
+                        "write (config/infra)",
+                        "write (DB/migration)",
+                        "write (MCP live)",
+                    ],
+                    "description": "Operation mode affecting severity of some conditions.",
+                    "default": "read_only",
+                },
+            },
+            "required": [],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "status": {"type": "string"},
+                "resolved": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "missing_context",
+                                    "missing_evidence",
+                                    "scope_drift_risk",
+                                    "runtime_surface_touched",
+                                    "trading_surface_touched",
+                                    "write_requires_human_go",
+                                    "stale_context",
+                                    "contradiction_risk",
+                                    "forbidden_path",
+                                    "secrets_risk",
+                                ],
+                            },
+                            "severity": {
+                                "type": "string",
+                                "enum": ["info", "warning", "blocking"],
+                            },
+                            "reason": {"type": "string"},
+                            "required_action": {"type": "string"},
+                            "human_go_required": {"type": "boolean"},
+                        },
+                    },
+                },
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("context.stop_resolver"),
+    ),
 ]
 
 

--- a/tools/surrealdb/context_stop_resolver.py
+++ b/tools/surrealdb/context_stop_resolver.py
@@ -1,0 +1,360 @@
+"""Stop Condition Resolver v1 — side-effect-free domain component.
+
+Issues:
+    #2107 — Implement stop condition resolver v1
+    Parent: #2103
+    Epic: #1976
+
+This module implements a minimal, deterministic, fail-closed Stop Condition
+Resolver. It maps flat stop-condition strings (S1-S10, H1-H8) from the
+action-readiness contract to typed stop condition objects with type, severity,
+reason, required_action, and human_go_required.
+
+Design intent:
+    Pure domain logic. No DB access. No MCP. No networking.
+    Input: list of strings + optional context. Output: list of typed dicts.
+    Deterministic: same inputs → same outputs.
+    Fail-closed: unknown conditions → scope_drift_risk + warning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+_STOP_RULE_MAP: dict[str, tuple[str, str]] = {
+    "S1": ("scope_drift_risk", "blocking"),
+    "S2": ("missing_context", "blocking"),
+    "S3": ("missing_context", "blocking"),
+    "S4": ("missing_evidence", "blocking"),
+    "S5": ("scope_drift_risk", "blocking"),
+    "S6": ("write_requires_human_go", "blocking"),
+    "S7": ("trading_surface_touched", "blocking"),
+    "S8": ("forbidden_path", "blocking"),
+    "S9": ("contradiction_risk", "warning"),
+    "S10": ("stale_context", "warning"),
+}
+
+_HUMAN_GO_MAP: dict[str, tuple[str, str]] = {
+    "H1": ("write_requires_human_go", "blocking"),
+    "H2": ("runtime_surface_touched", "blocking"),
+    "H3": ("write_requires_human_go", "blocking"),
+    "H4": ("write_requires_human_go", "blocking"),
+    "H5": ("write_requires_human_go", "blocking"),
+    "H6": ("trading_surface_touched", "warning"),
+    "H7": ("scope_drift_risk", "warning"),
+    "H8": ("forbidden_path", "blocking"),
+}
+
+_SECRETS_KEYWORDS = (
+    "secrets", "tresor", "token", "key", "private-key",
+    "secret", "credential", "password",
+)
+
+_LIVE_KEYWORDS = (
+    "live", "echtgeld", "production deploy", "go-live",
+    "live readiness", "lr-go", "live trading authorization",
+)
+
+_VALID_TYPES = frozenset({
+    "missing_context",
+    "missing_evidence",
+    "scope_drift_risk",
+    "runtime_surface_touched",
+    "trading_surface_touched",
+    "write_requires_human_go",
+    "stale_context",
+    "contradiction_risk",
+    "forbidden_path",
+    "secrets_risk",
+})
+
+_VALID_SEVERITIES = frozenset({"info", "warning", "blocking"})
+
+
+_REQUIRED_ACTIONS: dict[str, str] = {
+    "missing_context": (
+        "Resolve missing context before proceeding. "
+        "Identify the absent input or read and close the gap."
+    ),
+    "missing_evidence": (
+        "Resolve missing evidence before proceeding. "
+        "Back every core assumption with a traceable evidence ref."
+    ),
+    "scope_drift_risk": (
+        "Clarify scope before proceeding. "
+        "Ensure task_scope, target_issue, and target_paths are consistent."
+    ),
+    "runtime_surface_touched": (
+        "Stop. Runtime access requires explicit Human-GO. "
+        "Do not modify services, containers, or processes without approval."
+    ),
+    "trading_surface_touched": (
+        "Stop. Trading/Risk/Execution surface requires explicit Human-GO. "
+        "Do not place orders, modify risk controls, or touch execution paths."
+    ),
+    "write_requires_human_go": (
+        "Stop. All write actions require explicit Human-GO. "
+        "Do not write files, push commits, or mutate state without approval."
+    ),
+    "stale_context": (
+        "Re-read canonical control surfaces before proceeding. "
+        "Verify CONTROL_REGISTER, CURRENT_STATUS, and LR-AUDIT-STATUS."
+    ),
+    "contradiction_risk": (
+        "Resolve the contradiction before proceeding. "
+        "Cross-reference governance documents and escalate to human."
+    ),
+    "forbidden_path": (
+        "Stop immediately. This path is forbidden. "
+        "Live/Echtgeld claims, LR-Go assertions, or governance bypass "
+        "attempts are not permitted without explicit human authorization."
+    ),
+    "secrets_risk": (
+        "Stop immediately. Secrets risk detected. "
+        "Never expose, log, or commit secrets. Validate inputs for "
+        "tresor-zone, token, credential, or key references."
+    ),
+}
+
+
+_REASONS: dict[str, str] = {
+    "S1": "Task scope is missing, empty, or ambiguous.",
+    "S2": "Context Package is absent and required reads are incomplete.",
+    "S3": "One or more minimum required reads are unavailable.",
+    "S4": "Core assumptions lack evidence (evidence_refs empty or untraceable).",
+    "S5": "Scope Drift detected: the task diverges from task_scope or target issue.",
+    "S6": "Write operation requested without impact report and Human-GO.",
+    "S7": "Task touches Trading, Risk, or Execution scope without explicit governance approval.",
+    "S8": "Task makes or implies Live-Readiness or Echtgeld claims outside of LR SSOT.",
+    "S9": "A material uncertainty exists in Governance scope (Constitution, Policy, Invariant).",
+    "S10": "A STOP signal is encountered in canonical control surfaces.",
+    "H1": "Any file write requires explicit Human-GO.",
+    "H2": "Any Runtime or DB mutation requires explicit Human-GO.",
+    "H3": "Any MCP live write requires explicit Human-GO.",
+    "H4": "Posting an issue comment requires explicit Human-GO.",
+    "H5": "Creating or merging a PR requires explicit Human-GO.",
+    "H6": "Action touches Trading, Risk, Execution, or Strategy scope.",
+    "H7": "Cross-agent memory handoff beyond read-only context sharing.",
+    "H8": "Claim or statement about Live-Readiness or Echtgeld status.",
+}
+
+
+def _parse_rule_ref(raw: str) -> str | None:
+    """Extract the rule reference (S1-S10 or H1-H8) from a condition string.
+
+    Matches patterns like:
+        "S1: scope ambiguous"
+        "S8: live/echtgeld claims outside LR SSOT"
+        "H1: write action requires explicit Human-GO"
+    """
+    stripped = raw.strip()
+    if not stripped:
+        return None
+    upper = stripped.upper()
+    for prefix in ("S10", "S9", "S8", "S7", "S6", "S5", "S4", "S3", "S2", "S1",
+                   "H8", "H7", "H6", "H5", "H4", "H3", "H2", "H1"):
+        if upper.startswith(prefix) and (len(stripped) == len(prefix) or
+                                         stripped[len(prefix)] in (":", " ")):
+            return prefix
+    return None
+
+
+def _check_secrets_keyword(text: str) -> bool:
+    """Check if the text contains a secrets-related keyword."""
+    lower = text.lower()
+    for kw in _SECRETS_KEYWORDS:
+        if kw in lower:
+            return True
+    return False
+
+
+def _check_live_keyword(text: str) -> bool:
+    """Check if the text contains a live/echtgeld keyword."""
+    lower = text.lower()
+    for kw in _LIVE_KEYWORDS:
+        if kw in lower:
+            return True
+    return False
+
+
+def _check_runtime_keyword(text: str) -> bool:
+    """Check if the text references runtime surfaces."""
+    lower = text.lower()
+    runtime_kw = ("runtime", "service", "container", "process", "docker", "compose")
+    return any(kw in lower for kw in runtime_kw)
+
+
+def _is_write_mode(operation_mode: str) -> bool:
+    """Determine if the operation mode is write-capable."""
+    if not isinstance(operation_mode, str):
+        return False
+    return operation_mode.lower().startswith("write")
+
+
+def _determine_severity(
+    rule_ref: str | None,
+    condition_type: str,
+    operation_mode: str,
+    has_secrets: bool,
+    has_live: bool,
+) -> str:
+    """Determine severity, potentially adjusting based on context."""
+    if has_secrets:
+        return "blocking"
+    if has_live:
+        return "blocking"
+
+    # Look up baseline severity from rule maps
+    if rule_ref in _STOP_RULE_MAP:
+        base_type, base_severity = _STOP_RULE_MAP[rule_ref]
+        if rule_ref == "S7" and not _is_write_mode(operation_mode):
+            return "warning"
+        return base_severity
+    if rule_ref in _HUMAN_GO_MAP:
+        base_type, base_severity = _HUMAN_GO_MAP[rule_ref]
+        return base_severity
+    return "warning"
+
+
+def _build_condition(
+    raw: str,
+    rule_ref: str | None,
+    condition_type: str,
+    severity: str,
+    is_write: bool,
+) -> dict[str, Any]:
+    """Build a typed stop condition dict."""
+    reason = (
+        _REASONS.get(rule_ref, f"Unknown or unmapped stop condition: {raw}")
+        if rule_ref
+        else f"Unknown or unmapped stop condition: {raw}"
+    )
+    required_action = _REQUIRED_ACTIONS.get(
+        condition_type,
+        "Stop and report this condition to the human operator.",
+    )
+
+    human_go_required = (
+        severity == "blocking"
+        or condition_type in (
+            "write_requires_human_go",
+            "forbidden_path",
+            "secrets_risk",
+            "trading_surface_touched",
+            "runtime_surface_touched",
+        )
+    )
+
+    return {
+        "type": condition_type,
+        "severity": severity,
+        "reason": reason,
+        "required_action": required_action,
+        "human_go_required": human_go_required,
+    }
+
+
+def resolve_stop_conditions(
+    stop_conditions: list[str] | None = None,
+    warnings: list[str] | None = None,
+    readiness_result: dict[str, Any] | None = None,
+    operation_mode: str = "read_only",
+) -> list[dict[str, Any]]:
+    """Resolve flat stop-condition strings to typed stop condition objects.
+
+    Args:
+        stop_conditions: List of stop condition strings (S1-S10, H1-H8 patterns).
+        warnings: Optional list of warning strings to scan for secrets/live keywords.
+        readiness_result: Optional readiness result from context.readiness.
+        operation_mode: One of read_only, dry_run, write (code/docs), etc.
+
+    Returns:
+        List of typed stop condition dicts with type, severity, reason,
+        required_action, and human_go_required.
+
+    Deterministic: same inputs produce the same outputs.
+    Fail-closed: unknown conditions → scope_drift_risk + warning.
+    """
+    resolved: list[dict[str, Any]] = []
+
+    conditions = list(stop_conditions) if isinstance(stop_conditions, list) else []
+    warning_list = list(warnings) if isinstance(warnings, list) else []
+    is_write = _is_write_mode(operation_mode)
+
+    # Scan warnings for secrets/live keywords and add as conditions
+    _warning_text = " ".join(warning_list).lower()
+    if _check_secrets_keyword(_warning_text):
+        conditions.append("SECRETS_RISK: secrets/tresor/credential detected in warnings")
+    if _check_live_keyword(_warning_text):
+        conditions.append("FORBIDDEN_PATH: live/echtgeld keywords in warnings")
+    if _check_runtime_keyword(_warning_text):
+        conditions.append("RUNTIME_SURFACE: runtime references in warnings")
+
+    # Collect conditions from readiness_result if provided
+    if isinstance(readiness_result, dict):
+        readiness_conditions = readiness_result.get("stop_conditions", [])
+        if isinstance(readiness_conditions, list):
+            for sc in readiness_conditions:
+                if isinstance(sc, str) and sc.strip():
+                    conditions.append(sc)
+
+    # Deduplicate while preserving order (first occurrence wins)
+    seen: set[str] = set()
+    unique_conditions: list[str] = []
+    for sc in conditions:
+        if not isinstance(sc, str) or not sc.strip():
+            continue
+        canonical = sc.strip()
+        if canonical.lower() not in seen:
+            seen.add(canonical.lower())
+            unique_conditions.append(canonical)
+
+    # Process each condition
+    for raw in unique_conditions:
+        rule_ref = _parse_rule_ref(raw)
+        has_secrets = _check_secrets_keyword(raw)
+        has_live = _check_live_keyword(raw)
+
+        if has_secrets and not (rule_ref and rule_ref in _STOP_RULE_MAP):
+            condition = _build_condition(
+                raw, rule_ref, "secrets_risk", "blocking", is_write
+            )
+            resolved.append(condition)
+            continue
+
+        if has_live and not rule_ref:
+            condition = _build_condition(
+                raw, rule_ref, "forbidden_path", "blocking", is_write
+            )
+            resolved.append(condition)
+            continue
+
+        if rule_ref:
+            if rule_ref in _STOP_RULE_MAP:
+                condition_type, _ = _STOP_RULE_MAP[rule_ref]
+            elif rule_ref in _HUMAN_GO_MAP:
+                condition_type, _ = _HUMAN_GO_MAP[rule_ref]
+            else:
+                condition_type = "scope_drift_risk"
+
+            severity = _determine_severity(
+                rule_ref, condition_type, operation_mode, has_secrets, has_live
+            )
+            condition = _build_condition(
+                raw, rule_ref, condition_type, severity, is_write
+            )
+            resolved.append(condition)
+        else:
+            # Unknown pattern – scanning for additional keyword hints
+            if _check_runtime_keyword(raw):
+                condition = _build_condition(
+                    raw, None, "runtime_surface_touched", "warning", is_write
+                )
+            else:
+                condition = _build_condition(
+                    raw, None, "scope_drift_risk", "warning", is_write
+                )
+            resolved.append(condition)
+
+    return resolved

--- a/tools/surrealdb/context_stop_resolver.py
+++ b/tools/surrealdb/context_stop_resolver.py
@@ -19,6 +19,8 @@ Design intent:
 
 from __future__ import annotations
 
+import re
+
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -47,13 +49,26 @@ _HUMAN_GO_MAP: dict[str, tuple[str, str]] = {
 }
 
 _SECRETS_KEYWORDS = (
-    "secrets", "tresor", "token", "key", "private-key",
+    "secrets", "tresor", "token", "private-key",
     "secret", "credential", "password",
 )
 
+_SECRETS_BOUNDARY_PATTERNS = (
+    r"\bapi[_\s]?key\b",
+    r"\bsecret[_\s]?key\b",
+    r"\baccess[_\s]?key\b",
+    r"\bauth[_\s]?key\b",
+    r"\bprivate[_\s]key\b",
+    r"\bcrypto[_\s]?key\b",
+)
+
 _LIVE_KEYWORDS = (
-    "live", "echtgeld", "production deploy", "go-live",
+    "echtgeld", "production deploy", "go-live",
     "live readiness", "lr-go", "live trading authorization",
+)
+
+_LIVE_BOUNDARY_PATTERNS = (
+    r"\blive\b",
 )
 
 _VALID_TYPES = frozenset({
@@ -161,19 +176,35 @@ def _parse_rule_ref(raw: str) -> str | None:
 
 
 def _check_secrets_keyword(text: str) -> bool:
-    """Check if the text contains a secrets-related keyword."""
+    """Check if the text contains a secrets-related keyword.
+
+    Uses substring matching for unambiguous keywords and word-boundary
+    regex for ambiguous tokens like 'key' (to avoid false positives
+    on 'monkeypatch', 'keyboard', 'key_result', etc.).
+    """
     lower = text.lower()
     for kw in _SECRETS_KEYWORDS:
         if kw in lower:
+            return True
+    for pattern in _SECRETS_BOUNDARY_PATTERNS:
+        if re.search(pattern, lower):
             return True
     return False
 
 
 def _check_live_keyword(text: str) -> bool:
-    """Check if the text contains a live/echtgeld keyword."""
+    """Check if the text contains a live/echtgeld keyword.
+
+    Multi-word phrases match as substrings. The bare 'live' token uses
+    word-boundary matching to avoid false positives on words like
+    'deliverable', 'relative', 'liveable'.
+    """
     lower = text.lower()
     for kw in _LIVE_KEYWORDS:
         if kw in lower:
+            return True
+    for pattern in _LIVE_BOUNDARY_PATTERNS:
+        if re.search(pattern, lower):
             return True
     return False
 


### PR DESCRIPTION
Closes #2107

## Summary
- Adds pure read-only stop condition resolver in `tools/surrealdb/context_stop_resolver.py`
- Registers `context.stop_resolver` MCP tool
- Wires MCP handler into `ContextBridge`
- Adds 32 Stop Resolver tests in `test_context_bridge.py`
- Keeps briefing schema-compatible: `stop_conditions` remains `string[]`

## Validation
- `134 passed`
- Ruff clean

## Guardrails
- read-only only
- no Runtime/DB/Service write
- no Memory write
- no autonomous action
- no Live/Echtgeld-Go
- LR remains NO-GO

## Changes
| File | Status |
|---|---|
| `tools/surrealdb/context_stop_resolver.py` | New |
| `tools/mcp/context_bridge.py` | Modified |
| `tools/mcp/registry.py` | Modified |
| `tests/unit/tools/mcp/test_context_bridge.py` | Modified |
