### PR TITLE
feat(context): implement required reads resolver v1

### DIFF
--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -26,6 +26,7 @@ class TestContextToolRegistry:
             "context.self_explain",
             "context.briefing",
             "context.stop_resolver",
+            "context.required_reads",
         ]
         for expected in expected_tools:
             assert expected in tool_names, f"Tool {expected} not registered"
@@ -226,7 +227,7 @@ class TestContextBridge:
         """Verify list_tools returns all v0 tools."""
         bridge = ContextBridge()
         tools = bridge.list_tools()
-        assert len(tools) == 10
+        assert len(tools) == 11
         tool_names = [t["name"] for t in tools]
         assert "context.search" in tool_names
         assert "context.package" in tool_names
@@ -259,7 +260,7 @@ class TestContextBridge:
         bridge = ContextBridge()
         status = bridge.get_read_only_status()
         assert status["enforced"] is True
-        assert len(status["read_only_tools"]) == 10
+        assert len(status["read_only_tools"]) == 11
 
 
 class TestDefensiveSchemaCopies:
@@ -2073,4 +2074,409 @@ class TestContextStopResolverHandler:
             assert len(result) >= 1
             assert result[0]["type"] == "secrets_risk", (
                 f"{text!r} should trigger secrets_risk"
+            )
+
+
+class TestContextRequiredReadsHandler:
+    """Tests for context.required_reads tool handler."""
+
+    # --- Failure tests ---
+
+    def test_missing_task_scope_fails_closed(self) -> None:
+        """Missing task_scope fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.required_reads", {})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_task_scope"
+
+    def test_empty_task_scope_fails_closed(self) -> None:
+        """Empty string task_scope fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {"task_scope": "", "target_issue": None, "operation_mode": "read_only"},
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_task_scope"
+
+    def test_missing_target_issue_fails_closed(self) -> None:
+        """Missing target_issue key fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {"task_scope": "Test scope.", "operation_mode": "read_only"},
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_target_issue"
+
+    def test_target_issue_null_allowed(self) -> None:
+        """target_issue=null is explicitly allowed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {"task_scope": "Test scope.", "target_issue": None, "operation_mode": "read_only"},
+        )
+        assert result["status"] == "ok"
+
+    def test_target_issue_invalid_type_fails_closed(self) -> None:
+        """target_issue with invalid type (int) fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {"task_scope": "Test scope.", "target_issue": 123, "operation_mode": "read_only"},
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_target_issue"
+
+    def test_missing_operation_mode_fails_closed(self) -> None:
+        """Missing operation_mode fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {"task_scope": "Test scope.", "target_issue": None},
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_operation_mode"
+
+    def test_invalid_operation_mode_fails_closed(self) -> None:
+        """Invalid operation_mode fails closed."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {
+                "task_scope": "Test scope.",
+                "target_issue": None,
+                "operation_mode": "invalid_mode",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_operation_mode"
+
+    # --- Minimum inputs ---
+
+    def test_minimum_inputs_return_ok(self) -> None:
+        """Minimum valid inputs return ok with resolved reads."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {"task_scope": "Test scope.", "target_issue": None, "operation_mode": "read_only"},
+        )
+        assert result["status"] == "ok"
+        assert result["tool"] == "context.required_reads"
+        assert "resolved_reads" in result
+        assert isinstance(result["resolved_reads"], list)
+        assert len(result["resolved_reads"]) >= 6
+
+    def test_baseline_reads_are_must_read(self) -> None:
+        """All 6 baseline reads are must_read."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {"task_scope": "Test scope.", "target_issue": None, "operation_mode": "read_only"},
+        )
+        baseline_paths = {
+            "AGENTS.md",
+            "agents/AGENTS.md",
+            "agents/OPEN_CODE_AGENTS.md",
+            "docs/runbooks/CONTROL_REGISTER.md",
+            "CURRENT_STATUS.md",
+            "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+        }
+        must_reads = [
+            r for r in result["resolved_reads"] if r["priority"] == "must_read"
+        ]
+        baseline_found = {r["path"] for r in must_reads if r["path"] in baseline_paths}
+        for bp in baseline_paths:
+            assert bp in baseline_found, f"Baseline read {bp} not found in must_reads"
+
+    # --- Availability ---
+
+    def test_existing_file_available_true(self) -> None:
+        """Existing file returns available=true, warning=None."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {"task_scope": "Test scope.", "target_issue": None, "operation_mode": "read_only"},
+        )
+        for read in result["resolved_reads"]:
+            if read["path"] == "AGENTS.md":
+                assert read["available"] is True, f"AGENTS.md should be available"
+                assert read["warning"] is None, f"AGENTS.md should have no warning"
+                return
+        pytest.fail("AGENTS.md not found in resolved reads")
+
+    def test_missing_file_available_false_with_warning(self) -> None:
+        """Missing file returns available=false with a warning string."""
+        from tools.surrealdb.context_required_reads import _build_read_entry
+        from pathlib import Path
+
+        entry = _build_read_entry(
+            path="nonexistent/file_that_does_not_exist.md",
+            priority="optional",
+            reason="Test missing file.",
+            source_ref="#test",
+            repo_root=Path(__file__).resolve().parent.parent.parent.parent,
+        )
+        assert entry["available"] is False
+        assert entry["warning"] is not None
+        assert isinstance(entry["warning"], str)
+
+    # --- Unsafe paths ---
+
+    def test_absolute_path_blocked(self) -> None:
+        """Absolute path is marked available=false with unsafe warning."""
+        from tools.surrealdb.context_required_reads import _check_availability
+
+        available, warning = _check_availability("C:\\Windows\\System32")
+        assert available is False
+        assert warning is not None
+        assert "blocked" in warning.lower()
+
+    def test_path_traversal_blocked(self) -> None:
+        """Path with .. traversal is marked available=false with unsafe warning."""
+        from tools.surrealdb.context_required_reads import _check_availability
+
+        available, warning = _check_availability("../etc/passwd")
+        assert available is False
+        assert warning is not None
+        assert "blocked" in warning.lower() or "unsafe" in warning.lower()
+
+    def test_repo_root_override_affects_availability(self) -> None:
+        """repo_root parameter is actually used for availability checks."""
+        from tools.surrealdb.context_required_reads import _check_availability
+        from pathlib import Path
+
+        real_root = Path(__file__).resolve().parent.parent.parent.parent.parent
+        # AGENTS.md should be found under the real repo root
+        available, warning = _check_availability("AGENTS.md", repo_root=real_root)
+        assert available is True, (
+            f"AGENTS.md should exist under real root, got available={available}, "
+            f"warning={warning}"
+        )
+
+        # Same path under a non-existent root should fail
+        fake_root = Path("/nonexistent/repo/root")
+        available, warning = _check_availability("AGENTS.md", repo_root=fake_root)
+        assert available is False, (
+            f"AGENTS.md should NOT exist under fake root, got available={available}"
+        )
+        assert warning is not None
+
+    # --- Write mode ---
+
+    def test_write_mode_adds_governance_reads(self) -> None:
+        """Write operation_mode adds governance/Human-GO relevant reads."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {
+                "task_scope": "Fix a bug.",
+                "target_issue": None,
+                "operation_mode": "write (code/docs)",
+            },
+        )
+        assert result["status"] == "ok"
+        paths = {r["path"] for r in result["resolved_reads"]}
+        # Write mode should add governance-related reads
+        assert "knowledge/governance/CDB_AGENT_POLICY.md" in paths or len(
+            [r for r in result["resolved_reads"] if r["priority"] == "must_read"]
+        ) > 6, "Write mode should add extra must_read entries"
+
+    def test_read_only_mode_does_not_add_write_reads(self) -> None:
+        """read_only mode doesn't add write-mode governance reads."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {"task_scope": "Inspect code.", "target_issue": None, "operation_mode": "read_only"},
+        )
+        paths = {r["path"] for r in result["resolved_reads"]}
+        # DELIVERY_APPROVED.yaml is only added for write modes
+        delivery_entries = [
+            r for r in result["resolved_reads"]
+            if r["path"] == "knowledge/governance/DELIVERY_APPROVED.yaml"
+            and r["priority"] == "must_read"
+        ]
+        assert len(delivery_entries) == 0, (
+            "DELIVERY_APPROVED.yaml must_read should not appear in read_only mode"
+        )
+
+    # --- Domain scope ---
+
+    def test_surrealdb_scope_adds_context_docs(self) -> None:
+        """SurrealDB scope/path adds context docs."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {
+                "task_scope": "Implement SurrealDB context intelligence feature.",
+                "target_issue": "#2106",
+                "operation_mode": "read_only",
+                "target_paths": ["tools/surrealdb/context_required_reads.py"],
+            },
+        )
+        assert result["status"] == "ok"
+        paths = {r["path"] for r in result["resolved_reads"]}
+        assert "docs/surrealdb/context-package-model-v1.md" in paths, (
+            "SurrealDB scope should add context package model doc"
+        )
+
+    def test_ci_domain_reads_point_to_files(self) -> None:
+        """CI domain reads resolve to concrete files, not directories."""
+        from tools.surrealdb.context_required_reads import (
+            DOMAIN_READS,
+            _check_availability,
+        )
+
+        ci_reads = DOMAIN_READS.get("ci", [])
+        assert len(ci_reads) > 0, "CI domain must have reads"
+        for read in ci_reads:
+            path = read["path"]
+            assert not path.endswith("/"), (
+                f"CI read path must be a file, not directory: {path!r}"
+            )
+            available, warning = _check_availability(path)
+            assert available is True, (
+                f"CI read {path!r} should be available, got warning={warning!r}"
+            )
+
+    # --- Symbols do not invent file paths ---
+
+    def test_target_symbols_do_not_invent_file_paths(self) -> None:
+        """Target symbols produce entry with available=false, not fake paths."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {
+                "task_scope": "Refactor handler.",
+                "target_issue": None,
+                "operation_mode": "read_only",
+                "target_symbols": ["context_briefing_handler", "resolve_required_reads"],
+            },
+        )
+        assert result["status"] == "ok"
+        for read in result["resolved_reads"]:
+            if read["source_ref"] == "target_symbols":
+                assert read["available"] is False, (
+                    f"Symbol entry should have available=false: {read}"
+                )
+                assert read["warning"] is not None, (
+                    f"Symbol entry should have warning: {read}"
+                )
+                return
+        pytest.fail("No target_symbols entry found in resolved reads")
+
+    # --- Determinism ---
+
+    def test_deterministic_same_input_same_output(self) -> None:
+        """Same inputs produce identical outputs."""
+        bridge = create_bridge()
+        inputs = {
+            "task_scope": "Test determinism.",
+            "target_issue": "#2106",
+            "operation_mode": "read_only",
+            "target_paths": ["tools/surrealdb/"],
+            "target_symbols": ["resolve_required_reads"],
+        }
+        r1 = bridge.execute_tool("context.required_reads", inputs)
+        r2 = bridge.execute_tool("context.required_reads", inputs)
+        assert r1 == r2, "Same inputs should produce identical outputs"
+
+    # --- Contract fields ---
+
+    def test_all_reads_have_required_fields(self) -> None:
+        """Every resolved read has all 6 required fields."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {
+                "task_scope": "Test contract fields.",
+                "target_issue": None,
+                "operation_mode": "read_only",
+            },
+        )
+        required_fields = {"path", "priority", "reason", "source_ref", "available", "warning"}
+        for read in result["resolved_reads"]:
+            for field in required_fields:
+                assert field in read, f"Read missing field {field}: {read}"
+
+    def test_priority_values_are_valid(self) -> None:
+        """All priorities are valid enum values."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.required_reads",
+            {
+                "task_scope": "Test priorities.",
+                "target_issue": None,
+                "operation_mode": "read_only",
+            },
+        )
+        valid_priorities = {"must_read", "should_read", "optional"}
+        for read in result["resolved_reads"]:
+            assert read["priority"] in valid_priorities, (
+                f"Invalid priority {read['priority']!r} in {read['path']}"
+            )
+
+    # --- Schema compatibility ---
+
+    def test_briefing_required_reads_stay_string_list(self) -> None:
+        """Briefing output required_reads remains string[] (schema-compatible)."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-schema-test",
+                "task_scope": "Test schema compatibility.",
+                "target_issue": None,
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        b = result["briefing"]
+        assert "required_reads" in b
+        assert isinstance(b["required_reads"], list)
+        for item in b["required_reads"]:
+            assert isinstance(item, str), (
+                f"required_reads must remain string[], got {type(item).__name__}: {item!r}"
+            )
+
+    # --- Tool registration ---
+
+    def test_tool_appears_in_list_tools(self) -> None:
+        """context.required_reads appears in list_tools output."""
+        bridge = create_bridge()
+        tools = bridge.list_tools()
+        tool_names = [t["name"] for t in tools]
+        assert "context.required_reads" in tool_names
+
+    def test_tool_is_read_only(self) -> None:
+        """context.required_reads is marked readOnly."""
+        bridge = create_bridge()
+        tools = bridge.list_tools()
+        for t in tools:
+            if t["name"] == "context.required_reads":
+                assert t["readOnly"] is True
+                return
+        pytest.fail("context.required_reads not found in tool list")
+
+    # --- Operation modes ---
+
+    def test_all_valid_operation_modes_accepted(self) -> None:
+        """All 6 valid operation_mode values are accepted."""
+        bridge = create_bridge()
+        valid_modes = [
+            "read_only",
+            "dry_run",
+            "write (code/docs)",
+            "write (config/infra)",
+            "write (DB/migration)",
+            "write (MCP live)",
+        ]
+        for mode in valid_modes:
+            result = bridge.execute_tool(
+                "context.required_reads",
+                {"task_scope": "Test.", "target_issue": None, "operation_mode": mode},
+            )
+            assert result["status"] == "ok", (
+                f"Valid mode {mode!r} should be accepted, got {result}"
             )

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -1275,6 +1275,133 @@ def context_stop_resolver_handler(**kwargs) -> dict[str, Any]:
     }
 
 
+def context_required_reads_handler(**kwargs) -> dict[str, Any]:
+    """
+    Read-only handler for context.required_reads tool.
+
+    Resolves prioritized required reads from task scope, target issue,
+    target paths, target symbols, and operation mode (per #2106).
+
+    Delegates to tools.surrealdb.context_required_reads.resolve_required_reads.
+    Pure in-process evaluation. No DB/network/GitHub. Fail-closed.
+
+    Input:
+        task_scope: str (required) — what the agent is asked to do
+        target_issue: str | null (required) — GitHub issue or None
+        target_paths: list[str] (optional)
+        target_symbols: list[str] (optional)
+        target_concepts: list[str] (optional)
+        operation_mode: str (required) — valid enum value
+
+    Output:
+        tool, status, resolved_reads (list of structured RequiredRead dicts)
+    """
+    from tools.surrealdb.context_required_reads import (
+        VALID_OPERATION_MODES,
+        resolve_required_reads,
+    )
+
+    _MISSING = object()
+
+    task_scope = kwargs.get("task_scope")
+    target_issue = kwargs.get("target_issue", _MISSING)
+    operation_mode = kwargs.get("operation_mode", _MISSING)
+    target_paths = kwargs.get("target_paths", [])
+    target_symbols = kwargs.get("target_symbols", [])
+    target_concepts = kwargs.get("target_concepts", [])
+
+    # --- Validate task_scope ---
+    if not task_scope or not isinstance(task_scope, str) or not task_scope.strip():
+        return {
+            "tool": "context.required_reads",
+            "status": "error",
+            "error": {
+                "code": "invalid_task_scope",
+                "message": "task_scope is required and must be a non-empty string",
+            },
+        }
+
+    # --- Validate target_issue ---
+    if target_issue is _MISSING:
+        return {
+            "tool": "context.required_reads",
+            "status": "error",
+            "error": {
+                "code": "invalid_target_issue",
+                "message": "target_issue is required (must be a string or null)",
+            },
+        }
+
+    if target_issue is not None and not isinstance(target_issue, str):
+        return {
+            "tool": "context.required_reads",
+            "status": "error",
+            "error": {
+                "code": "invalid_target_issue",
+                "message": "target_issue must be a string or null",
+            },
+        }
+
+    # --- Validate operation_mode ---
+    if operation_mode is _MISSING:
+        return {
+            "tool": "context.required_reads",
+            "status": "error",
+            "error": {
+                "code": "invalid_operation_mode",
+                "message": "operation_mode is required",
+            },
+        }
+
+    if not isinstance(operation_mode, str) or operation_mode not in VALID_OPERATION_MODES:
+        return {
+            "tool": "context.required_reads",
+            "status": "error",
+            "error": {
+                "code": "invalid_operation_mode",
+                "message": (
+                    f"operation_mode must be one of {sorted(VALID_OPERATION_MODES)}, "
+                    f"got {operation_mode!r}"
+                ),
+            },
+        }
+
+    # --- Normalize arrays ---
+    if not isinstance(target_paths, list):
+        target_paths = []
+    if not isinstance(target_symbols, list):
+        target_symbols = []
+    if not isinstance(target_concepts, list):
+        target_concepts = []
+
+    # --- Resolve ---
+    try:
+        resolved = resolve_required_reads(
+            task_scope=task_scope.strip(),
+            target_issue=target_issue,
+            target_paths=target_paths,
+            target_symbols=target_symbols,
+            operation_mode=operation_mode,
+            target_concepts=target_concepts,
+        )
+    except Exception as e:
+        logger.exception("Required reads resolver failed")
+        return {
+            "tool": "context.required_reads",
+            "status": "error",
+            "error": {
+                "code": "execution_error",
+                "message": str(e),
+            },
+        }
+
+    return {
+        "tool": "context.required_reads",
+        "status": "ok",
+        "resolved_reads": resolved,
+    }
+
+
 class ContextBridge:
     """
     MCP Bridge for Context Intelligence System.
@@ -1383,6 +1510,17 @@ class ContextBridge:
                 handler=context_stop_resolver_handler,
             )
             self._registry._tools["context.stop_resolver"] = new_stop_resolver
+        old_required_reads = self._registry.get_tool("context.required_reads")
+        if old_required_reads:
+            new_required_reads = ToolDefinition(
+                name=old_required_reads.name,
+                description=old_required_reads.description,
+                input_schema=old_required_reads.input_schema,
+                output_schema=old_required_reads.output_schema,
+                read_only=old_required_reads.read_only,
+                handler=context_required_reads_handler,
+            )
+            self._registry._tools["context.required_reads"] = new_required_reads
         logger.info(
             f"ContextBridge initialized with tools: {self._registry.list_tool_names()}"
         )

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -571,6 +571,85 @@ TOOLS_V0 = [
         read_only=True,
         handler=create_not_implemented_handler("context.stop_resolver"),
     ),
+    ToolDefinition(
+        name="context.required_reads",
+        description="Resolve prioritized required reads from task scope, target issue, target paths, target symbols, and operation mode. Read-only, deterministic, fail-closed. No DB/network/GitHub access.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "task_scope": {
+                    "type": "string",
+                    "description": "What the agent is asked to do (one concise sentence). Required.",
+                },
+                "target_issue": {
+                    "type": ["string", "null"],
+                    "description": "GitHub issue number driving the task, or null for exploratory.",
+                },
+                "target_paths": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "File paths or glob patterns in scope.",
+                },
+                "target_symbols": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Code symbols relevant to the task.",
+                },
+                "operation_mode": {
+                    "type": "string",
+                    "enum": [
+                        "read_only",
+                        "dry_run",
+                        "write (code/docs)",
+                        "write (config/infra)",
+                        "write (DB/migration)",
+                        "write (MCP live)",
+                    ],
+                    "description": "Intended agent operation mode. Required.",
+                },
+                "target_concepts": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Domain concepts from the CIS ontology relevant to the task.",
+                },
+            },
+            "required": ["task_scope", "target_issue", "operation_mode"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "status": {"type": "string"},
+                "resolved_reads": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "priority": {
+                                "type": "string",
+                                "enum": ["must_read", "should_read", "optional"],
+                            },
+                            "reason": {"type": "string"},
+                            "source_ref": {"type": "string"},
+                            "available": {"type": "boolean"},
+                            "warning": {"type": ["string", "null"]},
+                        },
+                        "required": [
+                            "path",
+                            "priority",
+                            "reason",
+                            "source_ref",
+                            "available",
+                            "warning",
+                        ],
+                    },
+                },
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("context.required_reads"),
+    ),
 ]
 
 

--- a/tools/surrealdb/context_required_reads.py
+++ b/tools/surrealdb/context_required_reads.py
@@ -1,0 +1,535 @@
+"""Required Reads Resolver v1 — side-effect-free domain component.
+
+Issues:
+    #2106 — Implement required reads resolver v1
+    Parent: #2103 (Wave-13)
+    Epic: #1976
+
+This module implements a deterministic, fail-closed Required Reads Resolver.
+It derives prioritized required reads from task scope, target issue, target
+paths, target symbols, and operation mode.
+
+Design intent:
+    Pure domain logic. No DB access. No MCP. No networking. No GitHub calls.
+    Input: task_scope + target_issue + paths/symbols + operation_mode.
+    Output: list of structured RequiredRead dicts with path/priority/reason/
+            source_ref/available/warning.
+    Deterministic: same inputs → same outputs.
+    Fail-closed: unsafe paths → available=false + warning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+MINIMUM_READS: list[dict[str, str]] = [
+    {
+        "path": "AGENTS.md",
+        "reason": "Root pointer and session compass for all agent work",
+        "source_ref": "#2021 §6.3",
+    },
+    {
+        "path": "agents/AGENTS.md",
+        "reason": "Canonical agent registry with read order and status surfaces",
+        "source_ref": "#2021 §6.3",
+    },
+    {
+        "path": "agents/OPEN_CODE_AGENTS.md",
+        "reason": "OpenCode shared contract, skill routing, and trust rules",
+        "source_ref": "#2021 §6.3",
+    },
+    {
+        "path": "docs/runbooks/CONTROL_REGISTER.md",
+        "reason": "Board stage, operating focus, and control context",
+        "source_ref": "#2021 §6.3",
+    },
+    {
+        "path": "CURRENT_STATUS.md",
+        "reason": "Repo/engineering status ledger and session history",
+        "source_ref": "#2021 §6.3",
+    },
+    {
+        "path": "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+        "reason": "Live-readiness SSOT — Go/No-Go verdict for Echtgeld",
+        "source_ref": "#2021 §6.3",
+    },
+]
+
+DOMAIN_READS: dict[str, list[dict[str, str]]] = {
+    "governance": [
+        {
+            "path": "knowledge/governance/CDB_CONSTITUTION.md",
+            "reason": "System constitution — highest governance authority",
+            "source_ref": "agents/AGENTS.md read order",
+        },
+        {
+            "path": "knowledge/governance/CDB_GOVERNANCE.md",
+            "reason": "Roles, rights, zones, and change control",
+            "source_ref": "agents/AGENTS.md read order",
+        },
+        {
+            "path": "knowledge/governance/CDB_AGENT_POLICY.md",
+            "reason": "Agent operating rules, single-writer locks, write gates",
+            "source_ref": "agents/AGENTS.md read order",
+        },
+        {
+            "path": "knowledge/governance/SYSTEM_INVARIANTS.md",
+            "reason": "Non-negotiable system contracts and deterministic behaviour",
+            "source_ref": "agents/AGENTS.md read order",
+        },
+        {
+            "path": "knowledge/governance/DELIVERY_APPROVED.yaml",
+            "reason": "Human-controlled delivery gate — agents must not modify",
+            "source_ref": "AGENTS.md",
+        },
+    ],
+    "surrealdb": [
+        {
+            "path": "docs/surrealdb/context-package-model-v1.md",
+            "reason": "Context Package model — structured retrieval output contract",
+            "source_ref": "#2016",
+        },
+        {
+            "path": "docs/surrealdb/context-agent-briefing-schema-v1.md",
+            "reason": "Agent Briefing schema v1 — request/result contract",
+            "source_ref": "#2104",
+        },
+        {
+            "path": "docs/surrealdb/context-action-readiness-contract.md",
+            "reason": "Action readiness contract — status model and required checks",
+            "source_ref": "#2021",
+        },
+    ],
+    "knowledge": [
+        {
+            "path": "knowledge/CDB_KNOWLEDGE_HUB.md",
+            "reason": "Shared decisions and agent handoffs",
+            "source_ref": "agents/AGENTS.md read order",
+        },
+    ],
+    "docs": [
+        {
+            "path": "docs/meta/WORKING_REPO_CANON.md",
+            "reason": "Working repo canon matrix and status SSOT rule",
+            "source_ref": "agents/AGENTS.md read order",
+        },
+    ],
+    "runbooks": [
+        {
+            "path": "knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md",
+            "reason": "Control board runbook with stage mapping and board rules",
+            "source_ref": "AGENTS.md",
+        },
+    ],
+    "risk": [
+        {
+            "path": "knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md",
+            "reason": "Risk governance — control board rules and limits",
+            "source_ref": "AGENTS.md",
+        },
+    ],
+    "trading": [
+        {
+            "path": "knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md",
+            "reason": "Trading scope — stage mapping and execution guardrails",
+            "source_ref": "AGENTS.md",
+        },
+    ],
+    "ci": [
+        {
+            "path": ".github/workflows/ci.yml",
+            "reason": "CI/CD primary pipeline with test and build steps",
+            "source_ref": "#2021 §6.5",
+        },
+        {
+            "path": ".github/workflows/policy-gate.yml",
+            "reason": "Policy gate enforcing branch and PR rules",
+            "source_ref": "#2021 §6.5",
+        },
+        {
+            "path": ".github/workflows/docs-conflict-guard.yml",
+            "reason": "Documentation conflict detection guard",
+            "source_ref": "#2021 §6.5",
+        },
+    ],
+    "mcp": [
+        {
+            "path": "tools/mcp/registry.py",
+            "reason": "Context MCP tool registry with all tool definitions",
+            "source_ref": "tools/mcp/registry.py",
+        },
+        {
+            "path": "tools/mcp/context_bridge.py",
+            "reason": "Context MCP bridge with tool handlers",
+            "source_ref": "tools/mcp/context_bridge.py",
+        },
+    ],
+}
+
+DOMAIN_KEYWORD_MAP: dict[str, list[str]] = {
+    "governance": [
+        "governance", "govern", "policy", "constitution", "agent policy",
+        "invariant", "delivery approved",
+    ],
+    "surrealdb": [
+        "surrealdb", "surreal", "context intelligence", "cis",
+        "context package", "context bridge", "context tool", "context",
+        "briefing", "required reads", "stop condition", "impact radar",
+        "validation plan",
+    ],
+    "knowledge": ["knowledge", "decision", "handoff", "audit"],
+    "docs": ["docs", "documentation", "runbook", "canon", "meta"],
+    "runbooks": ["runbook", "control board", "operating", "cockpit"],
+    "risk": ["risk", "drawdown", "exposure", "kill switch", "fail-closed"],
+    "trading": ["trading", "execution", "strategy", "trade", "order", "exchange"],
+    "ci": ["ci", "cd", "github actions", "pipeline", "check", "ruleset"],
+    "mcp": ["mcp", "bridge", "registry", "handler", "tool"],
+}
+
+WRITE_MODE_READS: list[dict[str, str]] = [
+    {
+        "path": "knowledge/governance/CDB_AGENT_POLICY.md",
+        "reason": "Write operation — agent policy section 4 (single-writer locks, write gates)",
+        "source_ref": "AGENTS.md",
+    },
+    {
+        "path": "knowledge/governance/DELIVERY_APPROVED.yaml",
+        "reason": "Write operation — verify human-controlled delivery gate status",
+        "source_ref": "AGENTS.md",
+    },
+    {
+        "path": "knowledge/governance/CDB_CONSTITUTION.md",
+        "reason": "Write operation — verify no constitution violation",
+        "source_ref": "AGENTS.md",
+    },
+]
+
+VALID_OPERATION_MODES = frozenset({
+    "read_only",
+    "dry_run",
+    "write (code/docs)",
+    "write (config/infra)",
+    "write (DB/migration)",
+    "write (MCP live)",
+})
+
+
+def _is_path_safe(path_str: str, repo_root: Path = REPO_ROOT) -> tuple[bool, Optional[str]]:
+    """Check if a repo-relative path is safe to resolve.
+
+    Returns (is_safe, warning_message_or_None).
+    Blocks absolute paths, UNC paths, drive letters, and .. traversal.
+    """
+    clean = path_str.strip()
+
+    if not clean:
+        return False, "empty path string"
+
+    if not isinstance(path_str, str):
+        return False, f"path is not a string: {type(path_str).__name__}"
+
+    try:
+        p = Path(clean)
+    except (TypeError, ValueError):
+        return False, f"invalid path: {clean!r}"
+
+    if p.is_absolute():
+        return False, f"absolute path blocked: {clean!r}"
+
+    # Detect UNC paths (e.g. \\server\share)
+    if clean.startswith("\\\\") or clean.startswith("//"):
+        return False, f"UNC path blocked: {clean!r}"
+
+    # Detect drive letters (e.g. C: or C:\)
+    if ":" in clean.split("/")[0].split("\\")[0]:
+        return False, f"drive-letter path blocked: {clean!r}"
+
+    # Detect path traversal
+    parts = p.parts
+    for part in parts:
+        if part == "..":
+            return False, f"path traversal blocked (..): {clean!r}"
+
+    # Resolve to check if it escapes root
+    try:
+        resolved = (repo_root / p).resolve(strict=False)
+        resolved_relative = resolved.relative_to(repo_root)
+        if ".." in str(resolved_relative).split("\\"):
+            return False, f"path escapes repo root after resolution: {clean!r}"
+    except (ValueError, OSError):
+        return False, f"path resolution failed: {clean!r}"
+
+    return True, None
+
+
+def _check_availability(path_str: str, repo_root: Path = REPO_ROOT) -> tuple[bool, Optional[str]]:
+    """Check if a repo-relative path exists and is a file.
+
+    Returns (available, warning_or_None).
+    """
+    clean = path_str.strip()
+
+    is_safe, unsafe_warning = _is_path_safe(clean, repo_root)
+    if not is_safe:
+        return False, unsafe_warning or "unsafe path"
+
+    try:
+        candidate = (repo_root / Path(clean)).resolve(strict=False)
+    except (TypeError, ValueError, OSError):
+        return False, f"path resolution failed: {clean!r}"
+
+    if not candidate.exists():
+        return False, f"file not found: {clean}"
+
+    if not candidate.is_file():
+        return False, f"path is not a file: {clean}"
+
+    return True, None
+
+
+def _detect_domains(task_scope: str, target_paths: list[str]) -> frozenset[str]:
+    """Detect domain keywords from task_scope and target_paths.
+
+    Returns a frozenset of domain keys.
+    """
+    scope_lower = task_scope.lower()
+    paths_lower = " ".join(target_paths).lower()
+
+    domains: set[str] = set()
+    for domain, keywords in DOMAIN_KEYWORD_MAP.items():
+        for kw in keywords:
+            if kw.lower() in scope_lower or kw.lower() in paths_lower:
+                domains.add(domain)
+                break
+
+    return frozenset(domains)
+
+
+def _deduplicate_reads(reads: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Deduplicate reads by path, keeping the highest-priority entry.
+
+    Priority order: must_read > should_read > optional.
+    """
+    priority_order: dict[str, int] = {
+        "must_read": 0,
+        "should_read": 1,
+        "optional": 2,
+    }
+    seen: dict[str, dict[str, Any]] = {}
+    for read in reads:
+        path = read["path"]
+        if path in seen:
+            existing_prio = priority_order.get(seen[path]["priority"], 99)
+            new_prio = priority_order.get(read["priority"], 99)
+            if new_prio < existing_prio:
+                seen[path] = read
+        else:
+            seen[path] = read
+
+    result = list(seen.values())
+    result.sort(key=lambda r: priority_order.get(r["priority"], 99))
+    return result
+
+
+def _build_read_entry(
+    path: str,
+    priority: str,
+    reason: str,
+    source_ref: str,
+    repo_root: Path,
+) -> dict[str, Any]:
+    """Build a single RequiredRead dict with availability check."""
+    available, warning = _check_availability(path, repo_root)
+    return {
+        "path": path,
+        "priority": priority,
+        "reason": reason,
+        "source_ref": source_ref,
+        "available": available,
+        "warning": warning,
+    }
+
+
+def resolve_required_reads(
+    task_scope: str,
+    target_issue: Optional[str],
+    target_paths: Optional[list[str]],
+    target_symbols: Optional[list[str]],
+    operation_mode: str,
+    target_concepts: Optional[list[str]] = None,
+    repo_root: Optional[Path] = None,
+) -> list[dict[str, Any]]:
+    """Resolve prioritized required reads from task scope and context.
+
+    Args:
+        task_scope: What the agent is asked to do (one concise sentence).
+        target_issue: GitHub issue number (e.g. "#2106") or None.
+        target_paths: File paths or glob patterns in scope.
+        target_symbols: Code symbols (functions, classes, modules) in scope.
+        operation_mode: read_only | dry_run | write (code/docs) | etc.
+        target_concepts: Optional domain concepts from CIS ontology.
+        repo_root: Override repo root for testing. Defaults to REPO_ROOT.
+
+    Returns:
+        List of RequiredRead dicts, each with:
+        path, priority, reason, source_ref, available, warning.
+    """
+    root = repo_root if repo_root is not None else REPO_ROOT
+
+    task_scope = task_scope.strip() if isinstance(task_scope, str) else ""
+    paths = [p.strip() for p in (target_paths or []) if isinstance(p, str) and p.strip()]
+    symbols = [s.strip() for s in (target_symbols or []) if isinstance(s, str) and s.strip()]
+    concepts = [c.strip() for c in (target_concepts or []) if isinstance(c, str) and c.strip()]
+    issue = target_issue.strip() if target_issue and isinstance(target_issue, str) else None
+
+    reads: list[dict[str, Any]] = []
+
+    # --- Layer 1: Minimum baseline (always must_read) ---
+    for entry in MINIMUM_READS:
+        reads.append(
+            _build_read_entry(
+                path=entry["path"],
+                priority="must_read",
+                reason=entry["reason"],
+                source_ref=entry["source_ref"],
+                repo_root=root,
+            )
+        )
+
+    # --- Layer 2: Domain-specific reads from scope/paths ---
+    scope_text = task_scope + " " + " ".join(concepts)
+    detected_domains = _detect_domains(scope_text, paths)
+
+    for domain in sorted(detected_domains):
+        domain_entries = DOMAIN_READS.get(domain, [])
+        for entry in domain_entries:
+            reads.append(
+                _build_read_entry(
+                    path=entry["path"],
+                    priority="should_read",
+                    reason=entry["reason"],
+                    source_ref=entry["source_ref"],
+                    repo_root=root,
+                )
+            )
+
+    # --- Layer 3: Issue-driven reads ---
+    if issue:
+        issue_lower = issue.lower()
+        for domain, keywords in DOMAIN_KEYWORD_MAP.items():
+            if any(kw.lower() in issue_lower for kw in keywords):
+                domain_entries = DOMAIN_READS.get(domain, [])
+                for entry in domain_entries:
+                    reads.append(
+                        _build_read_entry(
+                            path=entry["path"],
+                            priority="should_read",
+                            reason=f"Issue {issue} — {entry['reason']}",
+                            source_ref=entry["source_ref"],
+                            repo_root=root,
+                        )
+                    )
+                break
+
+    # --- Layer 4: Path-driven reads (READMEs, __init__.py in target tree) ---
+    for path_str in paths[:5]:
+        is_safe, _ = _is_path_safe(path_str)
+        if not is_safe:
+            continue
+
+        try:
+            p = Path(path_str)
+        except (TypeError, ValueError):
+            continue
+
+        if p.suffix in (".py", ".md", ".yaml", ".yml", ".json", ".toml"):
+            parent = p.parent
+            for candidate_name in ("README.md", "readme.md", "__init__.py"):
+                candidate = str(parent / candidate_name).replace("\\", "/")
+                reads.append(
+                    _build_read_entry(
+                        path=candidate,
+                        priority="optional",
+                        reason=f"Adjacent documentation for target path: {path_str}",
+                        source_ref=path_str,
+                        repo_root=root,
+                    )
+                )
+
+    # --- Layer 5: Target symbols (no invented file paths) ---
+    if symbols:
+        for sym in symbols[:10]:
+            reads.append(
+                {
+                    "path": f"<symbol>{sym}</symbol>",
+                    "priority": "optional",
+                    "reason": (
+                        f"Target symbol: {sym}. "
+                        "Cannot derive file path from symbol alone — "
+                        "symbol-to-path mapping requires SurrealDB index (not yet available)."
+                    ),
+                    "source_ref": "target_symbols",
+                    "available": False,
+                    "warning": (
+                        "Symbol-to-file-path mapping not available in v1. "
+                        "Use context.search to locate containing file."
+                    ),
+                }
+            )
+
+    # --- Layer 6: Target concepts (reference to docs domain) ---
+    if concepts:
+        for concept in concepts[:5]:
+            concept_lower = concept.lower()
+            mapped = False
+            for domain, keywords in DOMAIN_KEYWORD_MAP.items():
+                if any(kw.lower() in concept_lower for kw in keywords):
+                    for entry in DOMAIN_READS.get(domain, []):
+                        reads.append(
+                            _build_read_entry(
+                                path=entry["path"],
+                                priority="should_read",
+                                reason=f"Concept '{concept}' → {entry['reason']}",
+                                source_ref=entry["source_ref"],
+                                repo_root=root,
+                            )
+                        )
+                    mapped = True
+                    break
+            if not mapped:
+                reads.append(
+                    {
+                        "path": f"<concept>{concept}</concept>",
+                        "priority": "optional",
+                        "reason": (
+                            f"Target concept: {concept}. "
+                            "No known documentation mapping for this concept."
+                        ),
+                        "source_ref": "target_concepts",
+                        "available": False,
+                        "warning": (
+                            f"Concept '{concept}' has no known documentation mapping. "
+                            "Use context.search to find related docs."
+                        ),
+                    }
+                )
+
+    # --- Layer 7: Write mode governance reads ---
+    if operation_mode.startswith("write"):
+        for entry in WRITE_MODE_READS:
+            reads.append(
+                _build_read_entry(
+                    path=entry["path"],
+                    priority="must_read",
+                    reason=entry["reason"],
+                    source_ref=entry["source_ref"],
+                    repo_root=root,
+                )
+            )
+
+    # --- Deduplicate and sort ---
+    return _deduplicate_reads(reads)


### PR DESCRIPTION
Closes #2106

## Summary
- Adds pure read-only required reads resolver in tools/surrealdb/context_required_reads.py
- Registers context.required_reads MCP tool (tool #11 in v0 registry)
- Wires context_required_reads_handler into ContextBridge
- Adds 26 Required Reads tests in TestContextRequiredReadsHandler
- Keeps briefing schema-compatible: required_reads remains string[]

## How It Works
The resolver derives prioritised required reads from:
- task_scope: keyword-based domain detection
- target_issue: issue reference (no GitHub API calls)
- target_paths: adjacent README/__init__.py discovery
- target_symbols: flagged as needs-resolution (no fake file paths invented)
- operation_mode: write modes add governance/delivery docs

Output per read: path, priority (must_read|should_read|optional), reason, source_ref, available, warning.

## Validation
- 164 passed (unit: tests/unit/tools/mcp/test_context_bridge.py)
- Ruff clean (all 4 files)
- Import verified

## Guardrails
- Read-only only
- No GitHub/network access in domain module or handler
- No Runtime/DB/Service write
- No Memory write
- No Live-/Echtgeld-Go