### PR TITLE
docs(surrealdb): define context ownership boundaries

### DIFF
--- a/docs/surrealdb/data-ownership-matrix.md
+++ b/docs/surrealdb/data-ownership-matrix.md
@@ -10,21 +10,32 @@ Postgres remains the single source of truth for all trading state.
 | Trading state (orders, positions, risk, fills) | Postgres | None | Trading services only | Trading pipeline | **Never** mirrored into SurrealDB |
 | Governance docs/policies | Git (Working Repo canon) | Mirror | Docs owners (Git) | Governance queries | SurrealDB is read-only mirror |
 | Decision events + evidence | Git (ledger) | Append-only mirror | Agents -> ledger | Audit + analytics | SurrealDB ingest only |
-| Shared memory (scoped) | SurrealDB | Primary | Agents (scoped) | Agents | Scoped by namespace + TTL |
+| Shared memory (scoped) | SurrealDB | Primary | Agents (scoped) | Agents | Cross-agent interchange; namespace + TTL; lighter/shorter-lived than agent_memory; no trading state; no secrets |
 | Metrics / Observability | Prometheus / Grafana | None | Observability stack | Ops dashboards | SurrealDB excluded |
+| Context intelligence (CIS) | Git (Working Repo canon) | Mirror | Context indexer | Agents, CDB-MCP | Umbrella domain: metadata, knowledge graph edges, computed knowledge; hash-backed; no trading state; no secrets |
+| Repo knowledge | Git (Working Repo canon) | Mirror | Context indexer | Agents, CDB-MCP | Static code symbols, interfaces, types, dependency edges; source-hash required; conditional ingestion only |
+| Doc knowledge | Git (Working Repo canon) | Mirror | Context indexer | Agents, CDB-MCP | Markdown docs, governance, runbooks, agents; source-hash per chunk required; stale refs are drift |
+| Agent memory | SurrealDB | Primary | Agents (per-agent scoped) | Agents | Per-agent memory: agent_id + namespace + TTL; source-hash-backed evidence refs; audit-trailed; distinct from shared_memory |
+| Evidence fabric | SurrealDB | Primary | Context indexer, agents | Agents, CDB-MCP, audit | Queryable evidence graph; claims with source hashes; provenance trail; append-only; no trading-proofs |
+| Decision context | Git (ledger) | Append-only mirror | Agents -> ledger | Agents, audit | Decision events with rationale + evidence bundle refs; ingest only; no automatic trade execution |
 
 ## Write Permissions (Codified)
 
 - **Postgres**: trading services only (orders/positions/risk/fills).
 - **Git (Working Repo canon)**: human owners; agents via PR only.
-- **SurrealDB**: ingest-only for mirrors; **append-only** for decision events.
+- **SurrealDB**: ingest-only for mirrors; **append-only** for decision events and decision_context.
 - **Shared memory**: scoped agent writes; no backflow into Git or Postgres.
+- **Agent memory**: per-agent scoped writes (agent_id + namespace); no cross-agent bypass; no trading state; no secrets.
+- **Evidence fabric**: context indexer + agent writes; append-only; source-hash-backed claims.
+- **Context intelligence / Repo knowledge / Doc knowledge**: context indexer only; no direct agent writes; mirror of Git truth.
 
 ## Read Patterns
 
 - **Trading runtime** reads **Postgres** only.
 - **Governance queries** read **SurrealDB** (mirror) with fallback to Git.
-- **Audit/analytics** can read **SurrealDB** (decision events).
+- **Audit/analytics** can read **SurrealDB** (decision events, decision_context, evidence_fabric).
+- **Agents** read **SurrealDB** (context_intelligence, repo_knowledge, doc_knowledge, agent_memory, evidence_fabric, shared_memory).
+- **CDB-MCP** reads **SurrealDB** (context_intelligence, repo_knowledge, doc_knowledge, evidence_fabric).
 - **Observability** reads **Prometheus/Grafana** only.
 
 ## Drift Detection Rules
@@ -32,6 +43,28 @@ Postgres remains the single source of truth for all trading state.
 - SurrealDB doc nodes must reference a Git hash (missing hash = drift).
 - SurrealDB decision events must map to a ledger source file + event id.
 - Any SurrealDB record claiming trading-state ownership is invalid.
+- CIS records (repo_knowledge, doc_knowledge, evidence_fabric) MUST reference a source hash (git commit + path). Missing source hash = drift.
+- Claims in evidence_fabric and decision_context MUST reference ledger source + event_id. Missing evidence ref = drift.
+- Doc references in doc_knowledge MUST match current working-repo Git hash. Stale references = drift.
+- Any trading-state record (orders, positions, fills, balances, risk-state) in ANY SurrealDB domain is invalid (extends trading-state rule to all CIS domains).
+- Agent memory writes outside scoped namespace (agent_id + namespace) are invalid. Unscoped memory = drift.
+
+## Explicit Exclusions (guardrails)
+
+All SurrealDB domains — including context intelligence, repo knowledge, doc knowledge, agent memory, evidence fabric, decision context, and shared memory — MUST NEVER contain:
+
+- Orders (any form, any status)
+- Positions (open, closed, pending)
+- Fills (partial, complete)
+- Risk-State-Runtime-Daten (live exposure, drawdown, limits)
+- Secrets (API keys, passwords, private keys, credentials, tokens)
+- Broker-Credentials
+- Wallet-Secrets
+- Session-Secrets
+- Balance- oder Konto-Zustandsdaten
+- Productive Redis-/Postgres-Betriebszustandsdaten
+- Live-/Echtgeld-Go-Autorisierungen
+- Personenbezogene Daten (PII) beyond public repo metadata
 
 ## Audit Trail
 

--- a/infrastructure/config/surrealdb/ownership.yaml
+++ b/infrastructure/config/surrealdb/ownership.yaml
@@ -31,7 +31,7 @@ domains:
       - agents_scoped
     readers:
       - agents
-    notes: "Scoped by namespace + TTL."
+    notes: "Cross-agent scoped memory for interchange. Scoped by namespace + TTL. Lighter, shorter-lived persistence. Distinct from agent_memory (per-agent, audit-trailed, source-hash-backed). No trading state. No secrets. No direct governance/runtime writes."
   observability_metrics:
     canonical: prometheus_grafana
     surrealdb: none
@@ -40,6 +40,61 @@ domains:
     readers:
       - ops_dashboards
     notes: "Metrics stay in Prometheus/Grafana."
+  context_intelligence:
+    canonical: git_working_repo
+    surrealdb: mirror_read_only
+    writers:
+      - context_indexer
+    readers:
+      - agents
+      - cdb_mcp
+    notes: "Umbrella domain for CIS. Metadata, knowledge graph edges, computed knowledge. Derives from repo + docs + governance mirrors. No orders. No positions. No fills. No risk-state-runtime data. No secrets. No live-/echtgeld-go authorisation. Hash-backed references only."
+  repo_knowledge:
+    canonical: git_working_repo
+    surrealdb: mirror_read_only
+    writers:
+      - context_indexer
+    readers:
+      - agents
+      - cdb_mcp
+    notes: "Static code symbols, interfaces, types, dependency edges from core/services. Source-hash per artifact required. Conditional ingestion only (no runtime state, no generated artifacts). No trading state. No secrets."
+  doc_knowledge:
+    canonical: git_working_repo
+    surrealdb: mirror_read_only
+    writers:
+      - context_indexer
+    readers:
+      - agents
+      - cdb_mcp
+    notes: "Markdown docs, governance, runbooks, agents from docs/knowledge/agents. Source-hash per chunk required. Stale document references (hash mismatch vs. current working repo) are drift. No trading state. No secrets."
+  agent_memory:
+    canonical: surrealdb
+    surrealdb: primary_scoped
+    writers:
+      - agents
+    readers:
+      - agents
+    notes: "Per-agent memory scoped by agent_id + namespace + TTL. Source-hash-backed evidence refs and audit-trailed reads/writes required. Distinct from shared_memory (cross-agent, lighter, shorter-lived). No trading state. No secrets. No live-/echtgeld-go authorisation."
+  evidence_fabric:
+    canonical: surrealdb
+    surrealdb: primary_scoped
+    writers:
+      - context_indexer
+      - agents
+    readers:
+      - agents
+      - cdb_mcp
+      - audit_analytics
+    notes: "Queryable evidence graph. Claims linked to source hashes. Evidence bundles with provenance trail. Appended, never edited. No trading-performance proofs. No live-PnL. No orders. No positions. No fills."
+  decision_context:
+    canonical: git_ledger
+    surrealdb: append_only_mirror
+    writers:
+      - agents_via_ledger
+    readers:
+      - agents
+      - audit_analytics
+    notes: "Decision events with rationale, evidence bundle refs, and audit trail. References decision ledger source + event_id. Ingest only; no edits. No automatic trade execution. No trading state. No secrets."
 drift_rules:
   - id: doc_hash_missing
     description: "SurrealDB doc nodes must include Git hash reference."
@@ -47,3 +102,13 @@ drift_rules:
     description: "SurrealDB decision events must reference ledger source + event id."
   - id: trading_state_in_surrealdb
     description: "Any trading-state record in SurrealDB is invalid."
+  - id: missing_source_hash
+    description: "Context intelligence records (repo_knowledge, doc_knowledge, evidence_fabric) MUST reference a source hash (git commit + path). Records without source hash are drift."
+  - id: missing_evidence_ref
+    description: "Claims in evidence_fabric and decision_context entries MUST reference ledger source + event_id. Evidence fabric nodes without provenance reference are drift."
+  - id: stale_doc_reference
+    description: "Doc references in doc_knowledge MUST match current working-repo Git hash. Stale references (hash mismatch) are drift."
+  - id: trading_state_leak
+    description: "Any trading-state record (orders, positions, fills, balances, risk-state) in ANY SurrealDB domain is invalid. Extends trading_state_in_surrealdb to all domains including context_intelligence, repo_knowledge, doc_knowledge, agent_memory, evidence_fabric, decision_context, shared_memory."
+  - id: unscoped_memory
+    description: "Agent memory writes outside scoped namespace (agent_id + namespace) are invalid. No cross-agent memory bypass via direct writes. No unscoped memory access."


### PR DESCRIPTION
- Closes #1978
- Summary:
  - Extends `infrastructure/config/surrealdb/ownership.yaml` with Context Intelligence ownership domains
  - Updates `docs/surrealdb/data-ownership-matrix.md` to stay synced with the machine-readable ownership config
  - Defines shared_memory vs agent_memory separation
  - Adds drift rules for source hash, evidence refs, stale doc refs, trading-state leaks, and unscoped memory
- Validation:
  - YAML syntax valid
  - 2 files changed only
  - no new `surrealdb:` role values
  - no new YAML top-level keys
  - no code/runtime/DB/migration changes
- Guardrails:
  - no Trading-State in SurrealDB Context Intelligence
  - no Orders/Positions/Fills/Risk-State runtime data
  - no Secrets
  - no Live-/Echtgeld-Go
  - LR remains NO-GO