### PR TITLE
fix(security): refresh postgres 15.17 alpine digest (#2293)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -41,7 +41,7 @@ jobs:
         include:
           - image: redis:7.4.8-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6
             scan_name: redis
-          - image: postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
+          - image: postgres:15.17-alpine@sha256:09e4f20b14ddb3dfe3a0c825b206032aaf8f28300ba2070c0b60fc1c10c6abc7
             scan_name: postgres
           - image: prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78
             scan_name: prometheus
@@ -252,7 +252,7 @@ jobs:
       matrix:
         image:
           - redis:7.4.8-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6
-          - postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
+          - postgres:15.17-alpine@sha256:09e4f20b14ddb3dfe3a0c825b206032aaf8f28300ba2070c0b60fc1c10c6abc7
       fail-fast: false
 
     env:

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -31,7 +31,7 @@ services:
       - cdb_network
 
   cdb_postgres:
-    image: postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
+    image: postgres:15.17-alpine@sha256:09e4f20b14ddb3dfe3a0c825b206032aaf8f28300ba2070c0b60fc1c10c6abc7
     container_name: cdb_postgres
     restart: unless-stopped
     environment:

--- a/infrastructure/compose/compose.blue.yml
+++ b/infrastructure/compose/compose.blue.yml
@@ -17,7 +17,7 @@ services:
   # ==================== DATA LAYER ====================
 
   cdb_postgres:
-    image: postgres:15.17-alpine@sha256:1c52f5ad23db5d7648a63634444af76de48e63b860fccbe3e3a5458b2812eaed
+    image: postgres:15.17-alpine@sha256:09e4f20b14ddb3dfe3a0c825b206032aaf8f28300ba2070c0b60fc1c10c6abc7
     container_name: cdb_postgres
     restart: unless-stopped
     environment:


### PR DESCRIPTION
### Summary
- Refreshes the pinned `postgres:15.17-alpine` digest from `sha256:1c52f5ad...` to `sha256:09e4f20b...`.
- Keeps the semantic image tag unchanged.
- Updates the active runtime and security-scan references only.

### Scope
Changed:
- `infrastructure/compose/compose.blue.yml`
- `infrastructure/compose/base.yml`
- `.github/workflows/security-scan.yml`

Not changed:
- Grafana images
- Python base images
- Trivy dismissals
- Security policy
- Historical docs/examples
- Trading, LR, or Echtgeld surfaces

### Validation
- `git diff --stat`: 3 files changed, 4 insertions(+), 4 deletions(-)
- `rg "sha256:1c52f5ad" infrastructure .github`: 0 active matches
- `rg "sha256:09e4f20b" infrastructure .github`: 4 active matches
- CI/Trivy will verify whether CVE-2026-34743 disappears for the new digest.

### Notes
- This is a digest-only image-pin refresh.
- The exact `xz-libs` version inside the new layer was not locally inspected; post-PR security scanning is the verification surface.
- No Live-Readiness, live-trading, or real-money implication.

Refs #2293
