### PR TITLE
fix(security): refresh Grafana image for curl Trivy wave (#2292)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -45,7 +45,7 @@ jobs:
             scan_name: postgres
           - image: prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78
             scan_name: prometheus
-          - image: grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
+          - image: grafana/grafana:13.0.1-ubuntu@sha256:15baab58cbdcf288c36a20ea9e469fe6c60955e725ddc56060377b27e9eaa47c
             scan_name: grafana
       fail-fast: false
 

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -75,7 +75,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
+    image: grafana/grafana:13.0.1-ubuntu@sha256:15baab58cbdcf288c36a20ea9e469fe6c60955e725ddc56060377b27e9eaa47c
     container_name: cdb_grafana
     restart: unless-stopped
     environment:

--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -114,7 +114,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
+    image: grafana/grafana:13.0.1-ubuntu@sha256:15baab58cbdcf288c36a20ea9e469fe6c60955e725ddc56060377b27e9eaa47c
     container_name: cdb_grafana
     restart: unless-stopped
     environment:


### PR DESCRIPTION
### Summary
- Upgrades Grafana image from `grafana/grafana:11.4.7-ubuntu` to `grafana/grafana:13.0.1-ubuntu`.
- This is a narrow tag+digest image upgrade, not a digest-only refresh.
- It replaces the Ubuntu 22.04 (Jammy) base with Ubuntu 24.04 (Noble), bumping `curl` from `7.81.0-1ubuntu1.20` to `8.5.0-2ubuntu10.8`.
- Targets the 6-curl-CVE Trivy wave documented in #2292.

### Scope
Changed:
- `infrastructure/compose/compose.red.yml`
- `infrastructure/compose/base.yml`
- `.github/workflows/security-scan.yml`

Not changed:
- Dashboards, provisioning, alert rules, datasources
- SMTP config, entrypoint wrapper, healthcheck
- Trading, LR, or Echtgeld surfaces

### Compatibility
- Grafana 13.0.1 `/run.sh` is identical to 11.4.7 — custom `entrypoint-postgres-password.sh` wrapper works without changes.
- Provisioning format (`apiVersion: 1`), datasource config, and health endpoint (`/api/health`) are backward-compatible.
- Live smoke test: `docker run grafana/grafana:13.0.1-ubuntu` → HTTP 200, database ok, version 13.0.1.

### Old / New
- **Old**: `grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800`
- **New**: `grafana/grafana:13.0.1-ubuntu@sha256:15baab58cbdcf288c36a20ea9e469fe6c60955e725ddc56060377b27e9eaa47c`

### Validation
```
git diff --stat: 3 files changed, 3 insertions(+), 3 deletions(-)
rg "c20611d0" infrastructure/compose/ .github/workflows/: 0 matches
rg "15baab58" infrastructure/compose/ .github/workflows/: 3 matches
```

### Notes
- Post-merge Trivy scan (`trivy-base-grafana`) will verify whether the 6 curl CVEs disappear.
- No LR/live/Echtgeld implication.

Refs #2292
