### PR TITLE
revert: roll back Grafana 13.0.1 -> 11.4.7 (#2292 curl unfixed)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -45,7 +45,7 @@ jobs:
             scan_name: postgres
           - image: prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78
             scan_name: prometheus
-          - image: grafana/grafana:13.0.1-ubuntu@sha256:15baab58cbdcf288c36a20ea9e469fe6c60955e725ddc56060377b27e9eaa47c
+          - image: grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
             scan_name: grafana
       fail-fast: false
 

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -75,7 +75,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:13.0.1-ubuntu@sha256:15baab58cbdcf288c36a20ea9e469fe6c60955e725ddc56060377b27e9eaa47c
+    image: grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
     container_name: cdb_grafana
     restart: unless-stopped
     environment:

--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -114,7 +114,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:13.0.1-ubuntu@sha256:15baab58cbdcf288c36a20ea9e469fe6c60955e725ddc56060377b27e9eaa47c
+    image: grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
     container_name: cdb_grafana
     restart: unless-stopped
     environment:


### PR DESCRIPTION
### Summary
- Reverts PR #2305 (`ae490e2a`) because post-merge Trivy validation did not reduce the #2292 curl CVEs and introduced additional Grafana 13/Ubuntu 24.04 findings.
- Restores Grafana image to `grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800`.

### Post-merge evidence (from Run 25342443514)
- All 6 #2292 curl CVEs (CVE-2026-{4873,5545,5773,6253,6276,6429}) still present in `trivy-base-grafana` — **12 alerts unchanged**.
- 47 additional non-curl CVEs introduced (Ubuntu 24.04 Noble base).

### Revert scope
```
git revert ae490e2a
 .github/workflows/security-scan.yml    | 2 +-
 infrastructure/compose/base.yml        | 2 +-
 infrastructure/compose/compose.red.yml | 2 +-
 3 files changed, 3 insertions(+), 3 deletions(-)
```

### Notes
- #2292 remains OPEN — Grafana curl wave is upstream-blocked.
- No provisioning, alert, dashboard, or compose changes.
- No LR/live/Echtgeld implication.

Refs #2292
