### PR TITLE
test(context-mcp): add tests and fixtures for Context MCP tools

### DIFF
--- a/tests/unit/tools/mcp/fixtures/__init__.py
+++ b/tests/unit/tools/mcp/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Context MCP test fixtures package."""

--- a/tests/unit/tools/mcp/fixtures/context_fixtures.py
+++ b/tests/unit/tools/mcp/fixtures/context_fixtures.py
@@ -1,0 +1,46 @@
+"""
+Shared test fixtures for Context MCP tool tests.
+
+Reusable deterministic inputs for handler tests.
+#2100
+"""
+
+MINIMUM_REQUIRED_READS = [
+    "AGENTS.md",
+    "agents/AGENTS.md",
+    "agents/OPEN_CODE_AGENTS.md",
+    "docs/runbooks/CONTROL_REGISTER.md",
+    "CURRENT_STATUS.md",
+    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+]
+
+SAMPLE_QUERY = "risk decisions"
+SAMPLE_TARGET_ID = "evt_abc123"
+SAMPLE_SOURCE_REF = "src_test_001"
+SAMPLE_ARTIFACTS = ["art_001", "art_002", "art_003"]
+SAMPLE_TASK_SCOPE = "review documentation"
+SAMPLE_TASK_ID = "task_unit_test_001"
+
+VALID_OPERATION_MODES = [
+    "read_only",
+    "dry_run",
+    "write (code/docs)",
+    "write (config/infra)",
+    "write (DB/migration)",
+    "write (MCP live)",
+]
+
+VALID_EXPLANATION_TYPES = [
+    "why_blocked",
+    "why_risky",
+    "why_stale",
+    "why_decision_current",
+    "why_decision_superseded",
+    "why_scope_blocked",
+    "why_evidence_weak",
+    "why_agent_needs_go",
+    "why_doc_untrusted",
+]
+
+VALID_DEPTH_VALUES = ["quick", "standard", "deep"]
+VALID_PACKAGE_FORMATS = ["json", "markdown"]

--- a/tests/unit/tools/mcp/test_context_package_handler.py
+++ b/tests/unit/tools/mcp/test_context_package_handler.py
@@ -1,0 +1,172 @@
+"""
+Unit tests for context.package handler.
+
+Tests the package handler input validation, output structure,
+truncation, format handling, and contract compliance.
+#2100
+"""
+
+import pytest
+from tools.mcp.context_bridge import create_bridge
+
+
+class TestContextPackageHandler:
+    """Tests for context.package tool handler."""
+
+    def test_missing_artifacts_returns_error(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.package", {})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_artifacts"
+
+    def test_none_artifacts_returns_error(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.package", {"artifacts": None})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_artifacts"
+
+    def test_string_artifacts_returns_error(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.package", {"artifacts": "not_a_list"})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_artifacts"
+
+    def test_empty_artifacts_list_returns_error(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.package", {"artifacts": []})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_artifacts"
+
+    def test_valid_artifacts_returns_ok(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001", "art_002"]}
+        )
+        assert result["status"] == "ok"
+        assert result["tool"] == "context.package"
+        assert "package" in result
+
+    def test_package_items_capped_at_ten(self) -> None:
+        bridge = create_bridge()
+        many = [f"art_{i:03d}" for i in range(15)]
+        result = bridge.execute_tool("context.package", {"artifacts": many})
+        assert result["status"] == "ok"
+        assert len(result["package"]["items"]) <= 10
+
+    def test_truncation_warning_when_over_limit(self) -> None:
+        bridge = create_bridge()
+        many = [f"art_{i:03d}" for i in range(15)]
+        result = bridge.execute_tool("context.package", {"artifacts": many})
+        assert "artifacts_limit_exceeded_truncated" in result["package"]["warnings"]
+
+    def test_no_truncation_warning_within_limit(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001", "art_002"]}
+        )
+        assert "artifacts_limit_exceeded_truncated" not in result["package"]["warnings"]
+
+    def test_format_json_default(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001"]}
+        )
+        assert result["package"]["format"] == "json"
+
+    def test_format_markdown_accepted(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001"], "format": "markdown"}
+        )
+        assert result["status"] == "ok"
+        assert result["package"]["format"] == "markdown"
+
+    def test_invalid_format_returns_error(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001"], "format": "xml"}
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "format_unsupported"
+
+    def test_include_metadata_default_true(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001"]}
+        )
+        assert result["package"]["metadata"]["include_metadata"] is True
+
+    def test_include_metadata_false_omits_fields(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package",
+            {"artifacts": ["art_001"], "include_metadata": False},
+        )
+        assert result["package"]["metadata"] == {}
+
+    def test_include_metadata_non_bool_defaults_true(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package",
+            {"artifacts": ["art_001"], "include_metadata": "yes"},
+        )
+        assert result["package"]["metadata"]["include_metadata"] is True
+
+    def test_package_id_is_deterministic(self) -> None:
+        bridge = create_bridge()
+        result1 = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001", "art_002"]}
+        )
+        result2 = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001", "art_002"]}
+        )
+        assert result1["package"]["package_id"] == result2["package"]["package_id"]
+
+    def test_package_contains_stop_conditions(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001"]}
+        )
+        assert "stop_conditions" in result["package"]
+        assert isinstance(result["package"]["stop_conditions"], list)
+
+    def test_package_item_has_required_fields(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001"]}
+        )
+        item = result["package"]["items"][0]
+        for field in ("id", "type", "summary", "source_refs", "confidence", "freshness"):
+            assert field in item, f"Package item missing field: {field}"
+
+    def test_package_contains_created_at(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001"]}
+        )
+        assert "created_at" in result["package"]
+
+    def test_missing_context_present_in_ok_result(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001"]}
+        )
+        assert "missing_context" in result["package"]
+        assert isinstance(result["package"]["missing_context"], list)
+
+    def test_single_artifact_no_truncation_no_empty_warning(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001"]}
+        )
+        assert "artifacts_limit_exceeded_truncated" not in result["package"]["warnings"]
+        assert "empty_package" not in result["package"]["warnings"]
+
+    def test_error_response_has_required_structure(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.package", {})
+        assert result["status"] == "error"
+        assert "tool" in result
+        assert "error" in result
+        assert "code" in result["error"]
+        assert "message" in result["error"]

--- a/tests/unit/tools/mcp/test_error_cases.py
+++ b/tests/unit/tools/mcp/test_error_cases.py
@@ -1,0 +1,128 @@
+"""
+Unit tests for error cases in Context MCP Bridge.
+
+Tests execution errors, adapter failures, empty result handling,
+and handler-level exception propagation.
+#2100
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from tools.mcp.context_bridge import create_bridge
+
+
+class TestSearchExecutionError:
+    """Tests for search adapter execution errors."""
+
+    def test_adapter_exception_returns_execution_error(self) -> None:
+        bridge = create_bridge()
+        with patch(
+            "tools.surrealdb.context_query.NoopQueryAdapter"
+        ) as MockAdapter:
+            mock_instance = MagicMock()
+            mock_instance.execute.side_effect = RuntimeError("DB connection lost")
+            MockAdapter.return_value = mock_instance
+            result = bridge.execute_tool(
+                "context.search", {"query": "risk decisions"}
+            )
+            assert result["status"] == "error"
+            assert result["error"]["code"] == "execution_error"
+
+    def test_adapter_exception_includes_message(self) -> None:
+        bridge = create_bridge()
+        with patch(
+            "tools.surrealdb.context_query.NoopQueryAdapter"
+        ) as MockAdapter:
+            mock_instance = MagicMock()
+            mock_instance.execute.side_effect = RuntimeError("timeout exceeded")
+            MockAdapter.return_value = mock_instance
+            result = bridge.execute_tool(
+                "context.search", {"query": "risk decisions"}
+            )
+            assert "timeout exceeded" in result["error"]["message"]
+
+    def test_search_empty_results_has_zero_hits(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.search", {"query": "test"})
+        assert result["metadata"]["total_hits"] == 0
+        assert result["results"] == []
+
+
+class TestBridgeHandlerErrorPropagation:
+    """Tests for handler-level exception handling."""
+
+    def test_search_handler_type_error_caught(self) -> None:
+        bridge = create_bridge()
+        with patch(
+            "tools.surrealdb.context_query.NoopQueryAdapter"
+        ) as MockAdapter:
+            mock_instance = MagicMock()
+            mock_instance.execute.side_effect = TypeError("bad type")
+            MockAdapter.return_value = mock_instance
+            result = bridge.execute_tool(
+                "context.search", {"query": "test"}
+            )
+            assert result["status"] == "error"
+            assert result["error"]["code"] == "execution_error"
+
+    def test_search_handler_value_error_caught(self) -> None:
+        bridge = create_bridge()
+        with patch(
+            "tools.surrealdb.context_query.NoopQueryAdapter"
+        ) as MockAdapter:
+            mock_instance = MagicMock()
+            mock_instance.execute.side_effect = ValueError("bad value")
+            MockAdapter.return_value = mock_instance
+            result = bridge.execute_tool(
+                "context.search", {"query": "test"}
+            )
+            assert result["status"] == "error"
+            assert result["error"]["code"] == "execution_error"
+
+
+class TestHandlerEdgeCases:
+    """Edge case tests across handlers."""
+
+    def test_package_handler_with_integer_artifacts_fails_closed(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": 123}
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_artifacts"
+
+    def test_trace_depth_zero_resets_to_default(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.trace",
+            {"target_id": "evt_001", "depth": 0},
+        )
+        assert result["status"] == "ok"
+
+    def test_trace_depth_negative_resets_to_default(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.trace",
+            {"target_id": "evt_001", "depth": -1},
+        )
+        assert result["status"] == "ok"
+
+    def test_explain_source_whitespace_ref_fails_closed(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source", {"source_ref": "   "}
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_source_ref"
+
+    def test_search_whitespace_query_fails_closed(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.search", {"query": "  "})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_query"
+
+    def test_search_non_string_query_fails_closed(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.search", {"query": 42})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_query"

--- a/tests/unit/tools/mcp/test_output_contracts.py
+++ b/tests/unit/tools/mcp/test_output_contracts.py
@@ -1,0 +1,301 @@
+"""
+Unit tests for output contract compliance of Context MCP tools.
+
+Validates that handler outputs conform to the v1 contract structure
+defined in docs/surrealdb/context-tool-contracts-v1.md and the
+implemented v0 structure.
+#2100
+"""
+
+import pytest
+from tools.mcp.context_bridge import create_bridge
+
+
+COMMON_OK_FIELDS = {"tool", "status"}
+
+
+class TestSearchOutputContract:
+    """Verify context.search output matches contract structure."""
+
+    def test_ok_output_has_tool_field(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.search", {"query": "risk"})
+        assert result["tool"] == "context.search"
+
+    def test_ok_output_has_status_field(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.search", {"query": "risk"})
+        assert result["status"] == "ok"
+
+    def test_ok_results_have_required_item_fields(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.search",
+            {"query": "risk", "limit": 5},
+        )
+        assert "results" in result
+        assert "metadata" in result
+        assert "query_time_ms" in result["metadata"]
+        assert "total_hits" in result["metadata"]
+
+    def test_error_output_has_code_and_message(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.search", {})
+        assert result["status"] == "error"
+        assert "code" in result["error"]
+        assert "message" in result["error"]
+
+    def test_metadata_has_query_time_and_total_hits(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.search", {"query": "test"})
+        meta = result["metadata"]
+        assert isinstance(meta["query_time_ms"], int)
+        assert isinstance(meta["total_hits"], int)
+
+
+class TestTraceOutputContract:
+    """Verify context.trace output matches contract structure."""
+
+    def test_ok_output_has_tool_and_status(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.trace", {"target_id": "evt_001"}
+        )
+        assert result["tool"] == "context.trace"
+        assert result["status"] == "ok"
+
+    def test_trace_has_root_with_id_type_title(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.trace", {"target_id": "evt_001"}
+        )
+        root = result["trace"]["root"]
+        assert "id" in root
+        assert "type" in root
+        assert "title" in root
+
+    def test_trace_has_lineage_with_relationship(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.trace", {"target_id": "evt_001", "depth": 3}
+        )
+        for item in result["trace"]["lineage"]:
+            assert "id" in item
+            assert "relationship" in item
+            assert "depth" in item
+
+    def test_error_output_has_target_not_found_code(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.trace", {})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "target_not_found"
+
+
+class TestExplainSourceOutputContract:
+    """Verify context.explain_source output matches contract structure."""
+
+    def test_ok_output_has_tool_and_status(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source", {"source_ref": "src_001"}
+        )
+        assert result["tool"] == "context.explain_source"
+        assert result["status"] == "ok"
+
+    def test_explanation_has_source_ref_type_provenance(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source", {"source_ref": "src_001"}
+        )
+        expl = result["explanation"]
+        assert "source_ref" in expl
+        assert "source_type" in expl
+        assert "provenance" in expl
+
+    def test_explanation_has_confidence_warnings_stale_tombstone(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source", {"source_ref": "src_001"}
+        )
+        expl = result["explanation"]
+        assert "confidence" in expl
+        assert "warnings" in expl
+        assert "stale" in expl
+        assert "tombstone" in expl
+
+    def test_source_refs_is_list(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source", {"source_ref": "src_001"}
+        )
+        assert isinstance(result["explanation"]["source_refs"], list)
+
+    def test_include_chain_false_removes_chain(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source",
+            {"source_ref": "src_001", "include_chain": False},
+        )
+        provenance = result["explanation"]["provenance"]
+        assert "chain" not in provenance
+
+
+class TestPackageOutputContract:
+    """Verify context.package output matches contract structure."""
+
+    def test_ok_output_has_package_with_format_items_created_at(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001"]}
+        )
+        pkg = result["package"]
+        assert "format" in pkg
+        assert "items" in pkg
+        assert "created_at" in pkg
+        assert "package_id" in pkg
+
+    def test_package_id_is_string(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001"]}
+        )
+        assert isinstance(result["package"]["package_id"], str)
+
+    def test_error_output_has_invalid_artifacts_code(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.package", {})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_artifacts"
+
+
+class TestReadinessOutputContract:
+    """Verify context.readiness output matches contract structure."""
+
+    def test_ok_output_has_all_contract_fields(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "review documentation",
+                "operation_mode": "read_only",
+                "stop_conditions": ["S10"],
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+            },
+        )
+        for field in (
+            "status",
+            "reasons",
+            "required_next_reads",
+            "human_go_required",
+            "stop_conditions",
+            "missing_context",
+            "missing_evidence",
+            "scope_drift_findings",
+            "uncertainties",
+            "guardrails",
+        ):
+            assert field in result["readiness"], f"Missing field: {field}"
+
+    def test_status_values_are_valid(self) -> None:
+        bridge = create_bridge()
+        valid_statuses = {
+            "ready_for_read_only",
+            "ready_for_dry_run",
+            "ready_for_human_go",
+            "blocked_missing_context",
+            "blocked_missing_evidence",
+            "blocked_scope_drift",
+        }
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "review documentation",
+                "operation_mode": "read_only",
+                "stop_conditions": ["S10"],
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+            },
+        )
+        assert result["readiness"]["status"] in valid_statuses
+
+    def test_guardrails_contain_no_go_text(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.readiness",
+            {
+                "task_scope": "review documentation",
+                "operation_mode": "read_only",
+                "stop_conditions": ["S10"],
+                "required_reads": [
+                    "AGENTS.md",
+                    "agents/AGENTS.md",
+                    "agents/OPEN_CODE_AGENTS.md",
+                    "docs/runbooks/CONTROL_REGISTER.md",
+                    "CURRENT_STATUS.md",
+                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                ],
+            },
+        )
+        guardrails_text = " ".join(result["readiness"]["guardrails"])
+        assert "NO-GO" in guardrails_text or "No-Go" in guardrails_text or "no_go" in guardrails_text.lower()
+
+
+class TestBriefingOutputContract:
+    """Verify context.briefing output matches contract structure."""
+
+    def test_ok_output_has_briefing_id(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "task_001",
+                "target_issue": None,
+                "task_scope": "review docs",
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert "briefing" in result
+        assert "briefing_id" in result["briefing"]
+
+    def test_briefing_id_is_deterministic(self) -> None:
+        bridge = create_bridge()
+        params = {
+            "task_id": "task_002",
+            "target_issue": None,
+            "task_scope": "review docs",
+            "requested_depth": "standard",
+            "operation_mode": "write (code/docs)",
+        }
+        r1 = bridge.execute_tool("context.briefing", params)
+        r2 = bridge.execute_tool("context.briefing", params)
+        assert r1["briefing"]["briefing_id"] == r2["briefing"]["briefing_id"]
+
+    def test_briefing_has_guardrails(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "task_003",
+                "target_issue": None,
+                "task_scope": "check status",
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert "guardrails" in result["briefing"]
+        assert isinstance(result["briefing"]["guardrails"], list)
+        assert len(result["briefing"]["guardrails"]) > 0

--- a/tests/unit/tools/mcp/test_show_handlers.py
+++ b/tests/unit/tools/mcp/test_show_handlers.py
@@ -1,0 +1,96 @@
+"""
+Unit tests for context.show_snapshot and context.show_audit not_implemented handlers.
+
+Tests that stub handlers return correct not_implemented errors
+and have correct schema definitions in the registry.
+#2100
+"""
+
+import pytest
+from tools.mcp.context_bridge import create_bridge
+from tools.mcp.registry import ContextToolRegistry
+
+
+class TestShowSnapshotHandler:
+    """Tests for context.show_snapshot not-implemented handler."""
+
+    def test_show_snapshot_returns_not_implemented(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.show_snapshot", {"snapshot_id": "snap_001"})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "not_implemented"
+
+    def test_show_snapshot_error_mentions_tool_name(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.show_snapshot", {"snapshot_id": "snap_001"})
+        assert "context.show_snapshot" in result["error"]["message"]
+
+    def test_show_snapshot_in_registry(self) -> None:
+        tool = ContextToolRegistry.get_tool("context.show_snapshot")
+        assert tool is not None
+        assert tool.read_only is True
+        assert "snapshot_id" in tool.input_schema.get("properties", {})
+
+    def test_show_snapshot_schema_has_required_fields(self) -> None:
+        tool = ContextToolRegistry.get_tool("context.show_snapshot")
+        assert "snapshot_id" in tool.input_schema.get("required", [])
+        assert "tool" in tool.output_schema.get("properties", {})
+        assert "status" in tool.output_schema.get("properties", {})
+
+
+class TestShowAuditHandler:
+    """Tests for context.show_audit not-implemented handler."""
+
+    def test_show_audit_returns_not_implemented(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.show_audit", {"entity_id": "ent_001"})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "not_implemented"
+
+    def test_show_audit_error_mentions_tool_name(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.show_audit", {"entity_id": "ent_001"})
+        assert "context.show_audit" in result["error"]["message"]
+
+    def test_show_audit_in_registry(self) -> None:
+        tool = ContextToolRegistry.get_tool("context.show_audit")
+        assert tool is not None
+        assert tool.read_only is True
+        assert "entity_id" in tool.input_schema.get("properties", {})
+
+    def test_show_audit_schema_has_required_fields(self) -> None:
+        tool = ContextToolRegistry.get_tool("context.show_audit")
+        assert "entity_id" in tool.input_schema.get("required", [])
+        assert "tool" in tool.output_schema.get("properties", {})
+        assert "status" in tool.output_schema.get("properties", {})
+
+
+class TestNotImplementedErrorStructure:
+    """Tests for not_implemented error response structure."""
+
+    def test_not_implemented_error_has_tool_field(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.show_snapshot", {})
+        assert result["tool"] == "context.show_snapshot"
+
+    def test_not_implemented_error_has_status_error(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.show_snapshot", {})
+        assert result["status"] == "error"
+
+    def test_not_implemented_error_has_code_and_message(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.show_audit", {})
+        assert isinstance(result["error"]["code"], str)
+        assert isinstance(result["error"]["message"], str)
+        assert len(result["error"]["code"]) > 0
+        assert len(result["error"]["message"]) > 0
+
+    def test_not_implemented_handler_ignores_all_params(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.show_snapshot",
+            {"snapshot_id": "any", "include_details": True, "extra": "ignored"},
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "not_implemented"


### PR DESCRIPTION
## Summary

Add tests and fixtures for Context MCP tools per #2100 acceptance criteria.

- **Package handler tests** (21): input validation, format, truncation, determinism, contract structure, include_metadata, stop_conditions
- **Show handler stub tests** (12): 
ot_implemented error behavior, registry schema, error structure
- **Output contract tests** (17): systematic v0/v1 field verification for search, trace, explain_source, package, readiness, briefing
- **Error case tests** (11): adapter xecution_error propagation, type/value error handling, edge cases (depth 0/-1, whitespace, type coercion)
- **Shared fixtures**: deterministic test constants for operation modes, explanation types, depths, formats, required reads

Total: 67 new tests, 0 production code changes.

## Files Changed

| File | Change |
|------|--------|
| 	ests/unit/tools/mcp/fixtures/__init__.py | NEW — fixture package marker |
| 	ests/unit/tools/mcp/fixtures/context_fixtures.py | NEW — deterministic shared fixtures/constants |
| 	ests/unit/tools/mcp/test_context_package_handler.py | NEW — package handler tests |
| 	ests/unit/tools/mcp/test_show_handlers.py | NEW — show handler/stub tests |
| 	ests/unit/tools/mcp/test_output_contracts.py | NEW — output contract tests |
| 	ests/unit/tools/mcp/test_error_cases.py | NEW — error-case tests |

## Validation

- pytest -q tests/unit/tools/mcp: 366 passed
- uff check tests/unit/tools/mcp tools/mcp: All checks passed

## Scope Guardrails

- No production code changes
- No #2101 runbook
- No #2102 gate work
- No Runtime/Trading/DB/Memory write
- No Live/LR/Echtgeld implication

## No LR/Live/Echtgeld Implication

LR remains NO-GO. Board stage 	rade-capable is orthogonal. This PR adds Context MCP tests and fixtures only.

Closes #2100
