### PR TITLE
feat(context): implement Impact Radar v1

### DIFF
--- a/docs/surrealdb/context-impact-radar-contract-v1.md
+++ b/docs/surrealdb/context-impact-radar-contract-v1.md
@@ -1,0 +1,154 @@
+# Impact Radar v1 — Contract
+
+**Issues:** #2019, #2108
+**Epic:** #1976
+**Parent Wave:** Welle 13 (#2103–#2114)
+**Status:** Implemented (`tools/surrealdb/context_impact_radar.py`)
+**Schema Version:** 1.0.0
+
+## 1. Purpose
+
+Impact Radar v1 detects and assesses the downstream effects of a planned change
+across the CDB system. It answers: *If I touch this, what else could break?*
+
+## 2. Domain Model
+
+### 2.1 Impact Level
+
+| Level    | Criteria                                                |
+|----------|---------------------------------------------------------|
+| `low`    | Non-critical docs, minor non-code changes               |
+| `medium` | Core libraries, shared utilities, test infrastructure   |
+| `high`   | Services, contracts, schemas, infrastructure            |
+| `blocking`| Governance, secrets, risk, execution, trading surface   |
+
+### 2.2 Impact Type (Hard / Soft)
+
+- **HARD**: Changes code/runtime boundaries (services, core, infrastructure,
+  contracts). Has runtime implications.
+- **SOFT**: Documentation, tests, non-runtime metadata changes. No direct
+  runtime implications.
+
+Derived automatically from affected paths. If any affected artifact has a path
+in a hard-impact directory, the overall impact is HARD.
+
+### 2.3 Confidence
+
+| Confidence | Meaning                                                    |
+|------------|------------------------------------------------------------|
+| `high`     | Full indexer data; all edges resolved; no inferred edges   |
+| `medium`   | Real indexer data; some edges inferred                     |
+| `low`      | Mocked or minimal data; most edges unknown                 |
+
+### 2.4 Gate Risks
+
+Detected gaps that could violate governance or safety constraints:
+- `governance_touched` — governance/policy/constitution paths changed
+- `risk_surface_touched` — risk service / limits / kill-switch paths changed
+- `execution_surface_touched` — execution / trading paths changed
+- `contract_drift_possible` — contract/schema paths changed
+- `secrets_surface_touched` — secrets/tresor paths referenced
+- `lr_surface_touched` — live-readiness paths changed
+
+### 2.5 Required Validation
+
+Derived deterministically from affected paths and symbols:
+- Unit tests for affected modules
+- Contract tests for schema/interface changes
+- Docs to review
+- Evidence to collect
+- Commands to consider (never auto-run)
+- Manual review requirements
+- Blocking preconditions
+
+## 3. Input Contract
+
+```python
+@dataclass(frozen=True)
+class ImpactRadarInput:
+    target_paths: tuple[str, ...]       # Paths being changed
+    target_symbols: tuple[str, ...]     # Symbol names being changed
+    target_issue: str | None            # Related issue (e.g. "#2108")
+    target_concepts: tuple[str, ...]    # Ontology concepts in scope
+    operation_mode: str                 # read_only | dry_run | write (code/docs) | write (config/infra)
+    dependency_edges: tuple[DependencyEdge, ...]  # From indexer/context_graph
+    code_symbols: tuple[dict, ...]      # Flattened symbol data
+    artifacts: tuple[dict, ...]         # Flattened artifact data
+```
+
+## 4. Output Contract
+
+```python
+@dataclass(frozen=True)
+class ImpactReport:
+    impact_id: str                      # Deterministic ID
+    target_refs: tuple[str, ...]        # Canonical target references
+    impact_level: str                   # low | medium | high | blocking
+    impact_type: str                    # HARD | SOFT
+    affected_artifacts: tuple[dict, ...]    # {path, artifact_type, hash}
+    affected_symbols: tuple[dict, ...]      # {symbol_id, name, qualified_name, symbol_type, source_path}
+    affected_tests: tuple[dict, ...]        # {test_id, test_name, source_path, test_type}
+    affected_docs: tuple[dict, ...]         # {path, title, section_count}
+    affected_decisions: tuple[str, ...]     # Decision refs touched
+    affected_evidence: tuple[str, ...]      # Evidence refs potentially invalidated
+    affected_memory_refs_read_only: tuple[str, ...]  # Memory entries to re-check
+    graph_paths: tuple[list[str], ...]      # Traced dependency chains
+    gate_risks: tuple[str, ...]             # Detected gate risks
+    confidence: str                         # high | medium | low
+    required_validation: dict[str, Any]     # Structured validation requirements
+    stop_conditions: tuple[dict[str, Any], ...]  # Resolved stop conditions
+```
+
+## 5. Implementation
+
+Module: `tools/surrealdb/context_impact_radar.py`
+
+### 5.1 Core Function
+
+```python
+def compute_impact(input: ImpactRadarInput) -> ImpactReport
+```
+
+Pure function. Deterministic. No DB, no network, no file I/O. Delegates stop
+condition resolution to `context_stop_resolver.resolve_stop_conditions()`.
+
+### 5.2 Impact Level Computation
+
+```
+blocking >= governance OR risk OR execution OR secrets paths
+high     >= services OR contracts OR schemas OR infrastructure paths
+medium   >= core OR tools OR test infrastructure paths
+low      >= docs OR .github paths
+```
+
+Uses path-prefix matching against canonical CDB directory structure:
+- `knowledge/governance/` → blocking
+- `services/risk/`, `services/execution/` → blocking
+- `services/*` → high
+- `infrastructure/` → high
+- `core/`, `tools/`, `tests/` → medium
+- `docs/`, `.github/` → low
+
+### 5.3 Stop Condition Propagation
+
+Impact Radar delegates to `context_stop_resolver`:
+- If operation_mode is write-capable, S6 (write requires Human-GO) is added
+- If governance paths touched with write mode, H1-H5 conditions added
+- If trading/risk/execution paths touched, S7 condition added
+- Gate risks are mapped to appropriate stop conditions
+
+## 6. Guardrails
+
+- Impact is analysis, never a write-go
+- No automatic action permission derived from impact
+- No Live-Readiness upgrade
+- No Echtgeld-Go
+- No trading runtime, orders, positions, fills, secrets, broker/execution state
+- No SurrealDB production write
+- Same inputs always produce same outputs (deterministic)
+
+## 7. Compatibility
+
+- #2109 Validation Plan Generator: Consumes `required_validation` field
+- #2111 Impact Radar MCP Tool: Wraps `compute_impact()` as read-only MCP tool
+- #2112 Tests/Fixtures: Fixture-backed test suite in `test_context_impact_radar.py`

--- a/tests/unit/surrealdb/test_context_impact_radar.py
+++ b/tests/unit/surrealdb/test_context_impact_radar.py
@@ -1,0 +1,788 @@
+"""Unit tests for Impact Radar v1 (#2019, #2108)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.surrealdb.context_impact_radar import (
+    ImpactRadarInput,
+    ImpactReport,
+    compute_impact,
+)
+
+# ── Fixture builders ────────────────────────────────────────────────────────
+
+
+def _make_artifact(
+    artifact_id: str,
+    artifact_type: str,
+    source_path: str,
+    source_hash: str = "",
+) -> dict:
+    return {
+        "artifact_id": artifact_id,
+        "artifact_type": artifact_type,
+        "source_path": source_path,
+        "source_hash": source_hash,
+    }
+
+
+def _make_symbol(
+    symbol_id: str,
+    name: str,
+    source_path: str,
+    symbol_type: str = "function",
+    qualified_name: str = "",
+) -> dict:
+    return {
+        "symbol_id": symbol_id,
+        "name": name,
+        "qualified_name": qualified_name or name,
+        "symbol_type": symbol_type,
+        "source_path": source_path,
+    }
+
+
+def _make_edge(
+    edge_id: str,
+    from_id: str,
+    to_id: str,
+    edge_type: str = "contains",
+    inferred: bool = False,
+) -> dict:
+    return {
+        "edge_id": edge_id,
+        "from_id": from_id,
+        "to_id": to_id,
+        "edge_type": edge_type,
+        "source_path": None,
+        "confidence": "high",
+        "inferred": inferred,
+    }
+
+
+def _make_test_case(
+    test_id: str,
+    test_name: str,
+    source_path: str,
+    test_type: str = "unit",
+) -> dict:
+    return {
+        "test_id": test_id,
+        "test_name": test_name,
+        "source_path": source_path,
+        "test_type": test_type,
+    }
+
+
+# ── Basic input tests ───────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_empty_input_produces_low_impact() -> None:
+    inp = ImpactRadarInput()
+    result = compute_impact(inp)
+
+    assert result.impact_level == "low"
+    assert result.impact_type == "SOFT"
+    assert result.confidence == "low"
+    assert len(result.affected_artifacts) == 0
+    assert len(result.gate_risks) == 0
+    assert isinstance(result.impact_id, str)
+    assert len(result.impact_id) == 16
+
+
+@pytest.mark.unit
+def test_docs_path_is_low_soft() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("docs/surrealdb/some-doc.md",),
+        artifacts=(
+            _make_artifact("art-1", "documentation", "docs/surrealdb/some-doc.md"),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert result.impact_level == "low"
+    assert result.impact_type == "SOFT"
+    assert len(result.affected_artifacts) == 1
+
+
+@pytest.mark.unit
+def test_core_path_is_medium_hard() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("core/utils/clock.py",),
+        artifacts=(
+            _make_artifact("art-1", "source", "core/utils/clock.py"),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert result.impact_level == "medium"
+    assert result.impact_type == "HARD"
+
+
+@pytest.mark.unit
+def test_services_path_is_high_hard() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("services/signal/service.py",),
+        artifacts=(
+            _make_artifact("art-1", "source", "services/signal/service.py"),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert result.impact_level == "high"
+    assert result.impact_type == "HARD"
+
+
+@pytest.mark.unit
+def test_governance_path_is_blocking() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("knowledge/governance/CDB_AGENT_POLICY.md",),
+        artifacts=(
+            _make_artifact(
+                "art-1", "documentation",
+                "knowledge/governance/CDB_AGENT_POLICY.md",
+            ),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert result.impact_level == "blocking"
+
+
+@pytest.mark.unit
+def test_risk_service_path_is_blocking() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("services/risk/service.py",),
+        artifacts=(
+            _make_artifact("art-1", "source", "services/risk/service.py"),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert result.impact_level == "blocking"
+
+
+@pytest.mark.unit
+def test_execution_service_path_is_blocking() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("services/execution/service.py",),
+        artifacts=(
+            _make_artifact("art-1", "source", "services/execution/service.py"),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert result.impact_level == "blocking"
+
+
+# ── Dependency edge tracing ─────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_edge_tracing_propagates_affected_symbols() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("core/utils/clock.py",),
+        artifacts=(
+            _make_artifact("art-1", "source", "core/utils/clock.py"),
+            _make_artifact("art-2", "source", "services/signal/models.py"),
+        ),
+        code_symbols=(
+            _make_symbol("sym-1", "utcnow", "core/utils/clock.py"),
+            _make_symbol("sym-2", "Signal", "services/signal/models.py"),
+        ),
+        dependency_edges=(
+            _make_edge("e-1", "core/utils/clock.py", "sym-1", "contains"),
+            _make_edge(
+                "e-2", "core/utils/clock.py", "services/signal/models.py",
+                "imports",
+            ),
+        ),
+    )
+    result = compute_impact(inp)
+
+    # clock.py is medium + hard, but signal/models.py is in the affected set
+    # making the overall level high because services/signal/models.py is under
+    # services/
+    assert result.impact_level == "high"
+    assert len(result.affected_symbols) == 2
+    affected_sources = {s["source_path"] for s in result.affected_symbols}
+    assert "core/utils/clock.py" in affected_sources
+    assert "services/signal/models.py" in affected_sources
+
+
+@pytest.mark.unit
+def test_edge_tracing_shows_graph_paths() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("core/utils/clock.py",),
+        dependency_edges=(
+            _make_edge(
+                "e-1", "core/utils/clock.py",
+                "services/signal/models.py", "imports",
+            ),
+            _make_edge(
+                "e-2", "core/utils/clock.py",
+                "core/utils/uuid_gen.py", "imports",
+            ),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert len(result.graph_paths) >= 1
+    for gp in result.graph_paths:
+        assert "core/utils/clock.py" in gp
+
+
+# ── Gate risk detection ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_governance_path_emits_governance_touched_risk() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("knowledge/governance/CDB_CONSTITUTION.md",),
+        artifacts=(
+            _make_artifact(
+                "art-1", "documentation",
+                "knowledge/governance/CDB_CONSTITUTION.md",
+            ),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert "governance_touched" in result.gate_risks
+
+
+@pytest.mark.unit
+def test_risk_path_emits_risk_surface_risk() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("services/risk/service.py",),
+        artifacts=(
+            _make_artifact("art-1", "source", "services/risk/service.py"),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert "risk_surface_touched" in result.gate_risks
+
+
+@pytest.mark.unit
+def test_contract_path_emits_contract_drift_risk() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("docs/contracts/market_data.schema.json",),
+        artifacts=(
+            _make_artifact(
+                "art-1", "contract",
+                "docs/contracts/market_data.schema.json",
+            ),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert "contract_drift_possible" in result.gate_risks
+
+
+@pytest.mark.unit
+def test_lr_path_emits_lr_surface_risk() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",),
+        artifacts=(
+            _make_artifact(
+                "art-1", "documentation",
+                "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+            ),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert "lr_surface_touched" in result.gate_risks
+
+
+@ pytest.mark.unit
+def test_secrets_path_emits_secrets_risk() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("secrets/some.key",),
+        artifacts=(
+            _make_artifact("art-1", "secret", "secrets/some.key"),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert "secrets_surface_touched" in result.gate_risks
+
+
+# ── Affected tests ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_affected_tests_from_path() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("core/utils/clock.py",),
+        test_cases=(
+            _make_test_case("t-1", "test_utcnow", "tests/unit/core/test_clock.py"),
+            _make_test_case("t-2", "test_other", "tests/unit/other/test_other.py"),
+        ),
+        artifacts=(
+            _make_artifact("art-1", "source", "core/utils/clock.py"),
+        ),
+        dependency_edges=(
+            _make_edge(
+                "e-1", "core/utils/clock.py",
+                "tests/unit/core/test_clock.py", "imports",
+            ),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert len(result.affected_tests) >= 1
+    test_paths = {t["source_path"] for t in result.affected_tests}
+    assert "tests/unit/core/test_clock.py" in test_paths
+
+
+# ── Confidence ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_no_data_confidence_is_low() -> None:
+    inp = ImpactRadarInput(target_paths=("core/utils/foo.py",))
+    result = compute_impact(inp)
+
+    assert result.confidence == "low"
+
+
+@pytest.mark.unit
+def test_inferred_edges_confidence_is_medium() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("core/utils/clock.py",),
+        artifacts=(
+            _make_artifact("art-1", "source", "core/utils/clock.py"),
+        ),
+        dependency_edges=(
+            _make_edge("e-1", "core/utils/clock.py", "sym-1", "contains", inferred=True),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert result.confidence == "medium"
+
+
+@pytest.mark.unit
+def test_full_resolved_data_confidence_is_high() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("core/utils/clock.py",),
+        artifacts=(
+            _make_artifact("art-1", "source", "core/utils/clock.py"),
+        ),
+        code_symbols=(
+            _make_symbol("sym-1", "utcnow", "core/utils/clock.py"),
+        ),
+        dependency_edges=(
+            _make_edge("e-1", "core/utils/clock.py", "sym-1", "contains"),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert result.confidence == "high"
+
+
+# ── Stop condition propagation ──────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_write_mode_emits_s6_stop_condition() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("docs/surrealdb/doc.md",),
+        operation_mode="write (code/docs)",
+    )
+    result = compute_impact(inp)
+
+    types = {sc["type"] for sc in result.stop_conditions}
+    assert "write_requires_human_go" in types
+
+
+@pytest.mark.unit
+def test_blocking_impact_write_propagates_stop_conditions() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("knowledge/governance/CDB_CONSTITUTION.md",),
+        operation_mode="write (code/docs)",
+        artifacts=(
+            _make_artifact(
+                "art-1", "documentation",
+                "knowledge/governance/CDB_CONSTITUTION.md",
+            ),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert len(result.stop_conditions) >= 1
+    types = {sc["type"] for sc in result.stop_conditions}
+    assert "write_requires_human_go" in types
+
+
+@pytest.mark.unit
+def test_read_only_mode_no_write_stop_conditions() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("knowledge/governance/CDB_CONSTITUTION.md",),
+        operation_mode="read_only",
+        artifacts=(
+            _make_artifact(
+                "art-1", "documentation",
+                "knowledge/governance/CDB_CONSTITUTION.md",
+            ),
+        ),
+    )
+    result = compute_impact(inp)
+
+    types = {sc["type"] for sc in result.stop_conditions}
+    assert "write_requires_human_go" not in types
+
+
+# ── Required validation ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_required_validation_has_all_fields() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("core/utils/clock.py",),
+        operation_mode="write (code/docs)",
+    )
+    result = compute_impact(inp)
+
+    rv = result.required_validation
+    assert "docs_to_review" in rv
+    assert "suggested_tests" in rv
+    assert "evidence_to_collect" in rv
+    assert "commands_to_consider" in rv
+    assert "manual_review_needed" in rv
+    assert "blocking_preconditions" in rv
+
+
+@pytest.mark.unit
+def test_hard_impact_write_requires_manual_review() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("services/signal/service.py",),
+        operation_mode="write (code/docs)",
+        artifacts=(
+            _make_artifact("art-1", "source", "services/signal/service.py"),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert result.required_validation["manual_review_needed"] is True
+
+
+@pytest.mark.unit
+def test_blocking_precondition_for_blocking_impact() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("services/risk/service.py",),
+        operation_mode="write (code/docs)",
+        artifacts=(
+            _make_artifact("art-1", "source", "services/risk/service.py"),
+        ),
+    )
+    result = compute_impact(inp)
+
+    blocking = result.required_validation["blocking_preconditions"]
+    assert len(blocking) >= 1
+    assert any("Blocking impact" in bp for bp in blocking)
+
+
+# ── Determinism ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_determinism_same_input_same_output() -> None:
+    def _build() -> ImpactRadarInput:
+        return ImpactRadarInput(
+            target_paths=("core/utils/clock.py", "services/signal/models.py"),
+            target_issue="#2108",
+            operation_mode="dry_run",
+            artifacts=(
+                _make_artifact("art-1", "source", "core/utils/clock.py"),
+                _make_artifact("art-2", "source", "services/signal/models.py"),
+            ),
+            code_symbols=(
+                _make_symbol("sym-1", "utcnow", "core/utils/clock.py"),
+                _make_symbol("sym-2", "Signal", "services/signal/models.py"),
+            ),
+            dependency_edges=(
+                _make_edge("e-1", "core/utils/clock.py", "sym-1", "contains"),
+                _make_edge(
+                    "e-2", "core/utils/clock.py",
+                    "services/signal/models.py", "imports",
+                ),
+            ),
+        )
+
+    r1 = compute_impact(_build())
+    r2 = compute_impact(_build())
+
+    assert r1.impact_id == r2.impact_id
+    assert r1.impact_level == r2.impact_level
+    assert r1.impact_type == r2.impact_type
+    assert r1.gate_risks == r2.gate_risks
+    assert r1.confidence == r2.confidence
+    assert r1.stop_conditions == r2.stop_conditions
+
+
+@pytest.mark.unit
+def test_deterministic_id_changes_with_input() -> None:
+    r1 = compute_impact(ImpactRadarInput(target_paths=("a.py",)))
+    r2 = compute_impact(ImpactRadarInput(target_paths=("b.py",)))
+    r3 = compute_impact(ImpactRadarInput(target_paths=("a.py",), target_issue="#42"))
+
+    assert r1.impact_id != r2.impact_id
+    assert r1.impact_id != r3.impact_id
+
+
+# ── Output format ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_to_payload_returns_dict_with_all_fields() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("core/utils/clock.py",),
+        target_symbols=("utcnow",),
+        target_issue="#2108",
+        operation_mode="read_only",
+        artifacts=(
+            _make_artifact("art-1", "source", "core/utils/clock.py"),
+        ),
+        code_symbols=(
+            _make_symbol("sym-1", "utcnow", "core/utils/clock.py"),
+        ),
+    )
+    result = compute_impact(inp)
+    payload = result.to_payload()
+
+    required_keys = {
+        "schema_version", "impact_id", "target_refs", "impact_level",
+        "impact_type", "affected_artifacts", "affected_symbols",
+        "affected_tests", "affected_docs", "affected_decisions",
+        "affected_evidence", "affected_memory_refs_read_only",
+        "graph_paths", "gate_risks", "confidence", "required_validation",
+        "stop_conditions",
+    }
+    assert required_keys.issubset(set(payload.keys()))
+    assert payload["schema_version"] == "1.0.0"
+
+
+# ── Target symbols / concepts ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_target_symbols_in_refs() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("core/utils/clock.py",),
+        target_symbols=("utcnow", "now"),
+    )
+    result = compute_impact(inp)
+
+    assert "symbol:utcnow" in result.target_refs
+    assert "symbol:now" in result.target_refs
+
+
+@pytest.mark.unit
+def test_target_issue_in_refs() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("core/utils/clock.py",),
+        target_issue="#2108",
+    )
+    result = compute_impact(inp)
+
+    assert "issue:#2108" in result.target_refs
+
+
+# ── Affected docs / decisions / evidence / memory ───────────────────────────
+
+
+@pytest.mark.unit
+def test_doc_artifacts_in_affected_docs() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("docs/surrealdb/impact-radar.md",),
+        artifacts=(
+            _make_artifact("art-1", "documentation", "docs/surrealdb/impact-radar.md"),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert len(result.affected_docs) >= 1
+    assert any(
+        "impact-radar.md" in d["path"] for d in result.affected_docs
+    )
+
+
+@pytest.mark.unit
+def test_decision_paths_in_affected_decisions() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("knowledge/agent_trust/ledger/some-event.yaml",),
+        artifacts=(
+            _make_artifact(
+                "art-1", "decision",
+                "knowledge/agent_trust/ledger/some-event.yaml",
+            ),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert len(result.affected_decisions) >= 1
+
+
+@pytest.mark.unit
+def test_evidence_paths_in_affected_evidence() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("docs/evidence/LR-030.md",),
+        artifacts=(
+            _make_artifact("art-1", "evidence", "docs/evidence/LR-030.md"),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert len(result.affected_evidence) >= 1
+
+
+@pytest.mark.unit
+def test_memory_paths_in_affected_memory() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("knowledge/logs/sessions/session-log.md",),
+        artifacts=(
+            _make_artifact(
+                "art-1", "log", "knowledge/logs/sessions/session-log.md",
+            ),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert len(result.affected_memory_refs_read_only) >= 1
+
+
+# ── Impact type edge cases ──────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_github_path_is_soft() -> None:
+    inp = ImpactRadarInput(
+        target_paths=(".github/workflows/ci.yml",),
+        artifacts=(
+            _make_artifact("art-1", "workflow", ".github/workflows/ci.yml"),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert result.impact_type == "SOFT"
+
+
+@pytest.mark.unit
+def test_tools_path_is_hard() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("tools/surrealdb/context_indexer.py",),
+        artifacts=(
+            _make_artifact(
+                "art-1", "source", "tools/surrealdb/context_indexer.py",
+            ),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert result.impact_type == "HARD"
+
+
+# ── Suggested tests in required_validation ──────────────────────────────────
+
+
+@pytest.mark.unit
+def test_required_validation_has_suggested_tests_when_affected_tests_exist() -> (
+    None
+):
+    inp = ImpactRadarInput(
+        target_paths=("core/utils/clock.py",),
+        artifacts=(
+            _make_artifact("art-1", "source", "core/utils/clock.py"),
+        ),
+        test_cases=(
+            _make_test_case("t-1", "test_utcnow", "tests/unit/core/test_clock.py"),
+        ),
+        dependency_edges=(
+            _make_edge(
+                "e-1", "core/utils/clock.py",
+                "tests/unit/core/test_clock.py", "imports",
+            ),
+        ),
+    )
+    result = compute_impact(inp)
+
+    rv = result.required_validation
+    assert len(rv["suggested_tests"]) >= 1
+
+
+@pytest.mark.unit
+def test_required_validation_has_pytest_command_when_tests_exist() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("core/utils/clock.py",),
+        artifacts=(
+            _make_artifact("art-1", "source", "core/utils/clock.py"),
+        ),
+        test_cases=(
+            _make_test_case("t-1", "test_utcnow", "tests/unit/core/test_clock.py"),
+        ),
+        dependency_edges=(
+            _make_edge(
+                "e-1", "core/utils/clock.py",
+                "tests/unit/core/test_clock.py", "imports",
+            ),
+        ),
+    )
+    result = compute_impact(inp)
+
+    commands = result.required_validation["commands_to_consider"]
+    assert any("pytest" in c for c in commands)
+
+
+# ── ImpactReport is immutable ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_impact_report_is_hashable() -> None:
+    report = ImpactReport(
+        impact_id="test",
+        target_refs=(),
+        impact_level="low",
+        impact_type="SOFT",
+        affected_artifacts=(),
+        affected_symbols=(),
+        affected_tests=(),
+        affected_docs=(),
+        affected_decisions=(),
+        affected_evidence=(),
+        affected_memory_refs_read_only=(),
+        graph_paths=(),
+        gate_risks=(),
+        confidence="low",
+        required_validation={},
+        stop_conditions=(),
+    )
+    # frozenset/dict requires hashable; this should not raise
+    _ = hash(report)
+
+
+# ── Multiple paths ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_multiple_paths_highest_level_wins() -> None:
+    inp = ImpactRadarInput(
+        target_paths=(
+            "docs/surrealdb/doc.md",
+            "core/utils/clock.py",
+            "services/signal/service.py",
+        ),
+        artifacts=(
+            _make_artifact("art-1", "documentation", "docs/surrealdb/doc.md"),
+            _make_artifact("art-2", "source", "core/utils/clock.py"),
+            _make_artifact("art-3", "source", "services/signal/service.py"),
+        ),
+    )
+    result = compute_impact(inp)
+
+    assert result.impact_level == "high"
+    assert result.impact_type == "HARD"

--- a/tools/surrealdb/context_impact_radar.py
+++ b/tools/surrealdb/context_impact_radar.py
@@ -1,0 +1,611 @@
+"""Impact Radar v1 — deterministic impact analysis for planned changes.
+
+Issues:
+    #2019 — Define impact radar v1 model
+    #2108 — Implement impact radar v1
+    Parent: #2103 (Wave-13)
+    Epic: #1976
+
+This module implements a minimal, deterministic, fail-closed Impact Radar.
+It analyses which artifacts, symbols, tests, docs, decisions, evidence,
+and memory refs are affected by a planned change, derives an impact level,
+distinguishes hard vs soft impact, surfaces gate risks, and propagates
+stop conditions.
+
+Design intent:
+    Pure domain logic. No DB access. No MCP. No networking. No file I/O.
+    Input: target paths/symbols + dependency edges + artifact/symbol data.
+    Output: typed ImpactReport with level, type, confidence, gate risks,
+            required validation, and stop conditions.
+    Deterministic: same inputs → same outputs.
+    Fail-closed: blocking if governance/risk/execution/secrets touched.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+
+from tools.surrealdb.context_stop_resolver import resolve_stop_conditions
+
+SCHEMA_VERSION = "1.0.0"
+
+# ── Impact level thresholds ─────────────────────────────────────────────────
+
+_BLOCKING_DIRS: tuple[str, ...] = (
+    "knowledge/governance/",
+    "services/risk/",
+    "services/execution/",
+    "secrets/",
+    "tresor/",
+)
+
+_HIGH_DIRS: tuple[str, ...] = (
+    "services/",
+    "infrastructure/",
+    "core/contracts/",
+    "docs/contracts/",
+    "docs/live-readiness/",
+    "knowledge/runbooks/",
+)
+
+_MEDIUM_DIRS: tuple[str, ...] = (
+    "core/",
+    "tools/",
+    "tests/",
+    "scripts/",
+    "infrastructure/config/",
+    "knowledge/contracts/",
+)
+
+_LOW_DIRS: tuple[str, ...] = (
+    "docs/",
+    ".github/",
+)
+
+_HARD_DIRS: tuple[str, ...] = (
+    "core/",
+    "services/",
+    "infrastructure/",
+    "tools/",
+    "scripts/",
+)
+
+_GATE_RISK_MAP: dict[tuple[str, ...], str] = {
+    ("knowledge/governance/",): "governance_touched",
+    ("services/risk/",): "risk_surface_touched",
+    ("services/execution/",): "execution_surface_touched",
+    ("docs/contracts/", "core/contracts/"): "contract_drift_possible",
+    ("secrets/", "tresor/"): "secrets_surface_touched",
+    ("docs/live-readiness/",): "lr_surface_touched",
+}
+
+# ── Decision / evidence anchor directories ───────────────────────────────────
+
+_DECISION_DIRS: tuple[str, ...] = (
+    "knowledge/agent_trust/ledger/",
+    "knowledge/governance/",
+)
+
+_EVIDENCE_DIRS: tuple[str, ...] = (
+    "docs/evidence/",
+    "docs/live-readiness/",
+    "reports/",
+    "docs/runbooks/evidence/",
+)
+
+_MEMORY_DIRS: tuple[str, ...] = (
+    "knowledge/logs/",
+    "knowledge/agent_trust/",
+)
+
+
+# ── Input / Output types ────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class ImpactRadarInput:
+    """Deterministic input for impact analysis."""
+
+    target_paths: tuple[str, ...] = ()
+    target_symbols: tuple[str, ...] = ()
+    target_issue: str | None = None
+    target_concepts: tuple[str, ...] = ()
+    operation_mode: str = "read_only"
+    dependency_edges: tuple[dict[str, Any], ...] = ()
+    code_symbols: tuple[dict[str, Any], ...] = ()
+    test_cases: tuple[dict[str, Any], ...] = ()
+    artifacts: tuple[dict[str, Any], ...] = ()
+
+
+@dataclass(frozen=True)
+class ImpactReport:
+    """Deterministic impact report."""
+
+    impact_id: str
+    target_refs: tuple[str, ...]
+    impact_level: str
+    impact_type: str
+    affected_artifacts: tuple[dict[str, Any], ...]
+    affected_symbols: tuple[dict[str, Any], ...]
+    affected_tests: tuple[dict[str, Any], ...]
+    affected_docs: tuple[dict[str, Any], ...]
+    affected_decisions: tuple[str, ...]
+    affected_evidence: tuple[str, ...]
+    affected_memory_refs_read_only: tuple[str, ...]
+    graph_paths: tuple[tuple[str, ...], ...]
+    gate_risks: tuple[str, ...]
+    confidence: str
+    required_validation: dict[str, Any] = field(
+        hash=False, compare=False
+    )
+    stop_conditions: tuple[dict[str, Any], ...] = field(
+        hash=False, compare=False
+    )
+    schema_version: str = SCHEMA_VERSION
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "impact_id": self.impact_id,
+            "target_refs": list(self.target_refs),
+            "impact_level": self.impact_level,
+            "impact_type": self.impact_type,
+            "affected_artifacts": list(self.affected_artifacts),
+            "affected_symbols": list(self.affected_symbols),
+            "affected_tests": list(self.affected_tests),
+            "affected_docs": list(self.affected_docs),
+            "affected_decisions": list(self.affected_decisions),
+            "affected_evidence": list(self.affected_evidence),
+            "affected_memory_refs_read_only": list(
+                self.affected_memory_refs_read_only
+            ),
+            "graph_paths": [list(p) for p in self.graph_paths],
+            "gate_risks": list(self.gate_risks),
+            "confidence": self.confidence,
+            "required_validation": self.required_validation,
+            "stop_conditions": list(self.stop_conditions),
+        }
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+def _stable_id(*parts: str) -> str:
+    """Produce a deterministic, short ID from ordered parts."""
+    joined = "|".join(parts)
+    return hashlib.sha256(joined.encode()).hexdigest()[:16]
+
+
+def _path_matches(target_path: str, candidate_path: str) -> bool:
+    """Check if candidate_path is affected by target_path.
+
+    Matches: exact path, prefix (directory), or same module (Python path).
+    """
+    tn = target_path.replace("\\", "/").rstrip("/")
+    cn = candidate_path.replace("\\", "/").rstrip("/")
+
+    if tn == cn:
+        return True
+    if cn.startswith(tn + "/"):
+        return True
+
+    # Python module matching: core/utils/clock.py matches core/utils/clock
+    tn_module = tn.replace("/", ".")
+    cn_module = cn.replace("/", ".")
+    if cn_module.startswith(tn_module):
+        return True
+
+    return False
+
+
+def _classify_level(paths: tuple[str, ...]) -> str:
+    """Derive impact level from affected paths."""
+    for p in paths:
+        for d in _BLOCKING_DIRS:
+            if p.startswith(d):
+                return "blocking"
+    for p in paths:
+        for d in _HIGH_DIRS:
+            if p.startswith(d):
+                return "high"
+    for p in paths:
+        for d in _MEDIUM_DIRS:
+            if p.startswith(d):
+                return "medium"
+    return "low"
+
+
+def _classify_impact_type(paths: tuple[str, ...]) -> str:
+    for p in paths:
+        for d in _HARD_DIRS:
+            if p.startswith(d):
+                return "HARD"
+    return "SOFT"
+
+
+def _detect_gate_risks(paths: tuple[str, ...]) -> frozenset[str]:
+    risks: set[str] = set()
+    for p in paths:
+        for prefixes, risk_name in _GATE_RISK_MAP.items():
+            if any(p.startswith(prefix) for prefix in prefixes):
+                risks.add(risk_name)
+    return frozenset(risks)
+
+
+def _derived_confidence(
+    edges: tuple[dict[str, Any], ...],
+    symbols: tuple[dict[str, Any], ...],
+    artifacts: tuple[dict[str, Any], ...],
+) -> str:
+    data_count = len(edges) + len(symbols) + len(artifacts)
+    if data_count == 0:
+        return "low"
+    inferred = sum(1 for e in edges if e.get("inferred", False))
+    if inferred > 0:
+        return "medium"
+    return "high"
+
+
+def _build_stop_conditions(
+    impact_level: str,
+    impact_type: str,
+    operation_mode: str,
+    gate_risks: frozenset[str],
+    target_paths: tuple[str, ...],
+) -> tuple[dict[str, Any], ...]:
+    """Derive stop condition strings, then delegate to stop resolver."""
+    raw_conditions: list[str] = []
+
+    is_write = operation_mode.lower().startswith("write")
+
+    if is_write:
+        raw_conditions.append("S6: write requires impact report and Human-GO")
+
+    if impact_level == "blocking":
+        raw_conditions.append(
+            f"S5: blocking impact detected on {', '.join(target_paths[:3])}"
+        )
+
+    if impact_type == "HARD" and is_write:
+        raw_conditions.append(
+            "S7: hard-impact change touches runtime/code surface"
+        )
+
+    if "governance_touched" in gate_risks and is_write:
+        raw_conditions.append("H1: governance paths touched — write requires Human-GO")
+
+    if "secrets_surface_touched" in gate_risks:
+        raw_conditions.append("SECRETS_RISK: secrets/tresor paths in scope")
+
+    if "risk_surface_touched" in gate_risks:
+        raw_conditions.append(
+            "S7: risk service surface touched"
+        )
+
+    if "execution_surface_touched" in gate_risks:
+        raw_conditions.append(
+            "S7: execution surface touched"
+        )
+
+    if "lr_surface_touched" in gate_risks:
+        raw_conditions.append(
+            "S8: live-readiness surface touched — no LR-go claims without SSOT"
+        )
+
+    resolved = resolve_stop_conditions(
+        stop_conditions=raw_conditions,
+        warnings=[],
+        operation_mode=operation_mode,
+    )
+
+    return tuple(resolved)
+
+
+# ── Core computation ────────────────────────────────────────────────────────
+
+def _collect_affected_paths(
+    target_paths: tuple[str, ...],
+    edges: tuple[dict[str, Any], ...],
+    symbols: tuple[dict[str, Any], ...],
+    artifacts: tuple[dict[str, Any], ...],
+) -> frozenset[str]:
+    """Collect all paths affected by target_paths via dependency edges."""
+    affected: set[str] = set()
+
+    # Direct matches: artifacts whose source_path matches a target
+    for art in artifacts:
+        source = (art.get("source_path") or art.get("path") or "")
+        for tp in target_paths:
+            if _path_matches(tp, source):
+                affected.add(source)
+
+    # Edges FROM directly affected artifacts
+    for edge in edges:
+        from_art = edge.get("from_id", "")
+        to_art = edge.get("to_id", "")
+        for tp in target_paths:
+            if _path_matches(tp, from_art) and to_art:
+                affected.add(to_art)
+
+    # Symbol import tracing
+    for sym in symbols:
+        source = sym.get("source_path", "")
+        for tp in target_paths:
+            if _path_matches(tp, source):
+                affected.add(source)
+
+    return frozenset(affected)
+
+
+def compute_impact(input_data: ImpactRadarInput) -> ImpactReport:
+    """Compute an ImpactReport from deterministic input data.
+
+    Args:
+        input_data: Immutable ImpactRadarInput with target paths, symbols,
+                    dependency edges, code symbols, test cases, and artifacts.
+
+    Returns:
+        ImpactReport with impact_level, affected items, gate risks,
+        required validation, and stop conditions.
+
+    Deterministic. Same inputs always produce the same outputs.
+    """
+    target_paths = input_data.target_paths
+    target_symbols = input_data.target_symbols
+    edges = input_data.dependency_edges
+    symbols = input_data.code_symbols
+    tests_data = input_data.test_cases
+    artifacts = input_data.artifacts
+    operation_mode = input_data.operation_mode
+
+    # --- Build target_refs ---
+    refs: list[str] = []
+    for p in target_paths:
+        refs.append(f"path:{p}")
+    for s in target_symbols:
+        refs.append(f"symbol:{s}")
+    if input_data.target_issue:
+        refs.append(f"issue:{input_data.target_issue}")
+    target_refs = tuple(refs)
+
+    # --- Collect affected paths ---
+    affected_paths = _collect_affected_paths(
+        target_paths, edges, symbols, artifacts
+    )
+    all_paths = tuple(sorted(target_paths) + sorted(affected_paths))
+
+    # --- Impact level ---
+    impact_level = _classify_level(all_paths) if all_paths else "low"
+
+    # --- Impact type ---
+    impact_type = _classify_impact_type(all_paths) if all_paths else "SOFT"
+
+    # --- Affected artifacts ---
+    affected_artifacts_out: list[dict[str, Any]] = []
+    seen_artifacts: set[str] = set()
+    for art in artifacts:
+        source = (art.get("source_path") or art.get("path") or "")
+        if source in seen_artifacts:
+            continue
+        if source in affected_paths or any(
+            _path_matches(tp, source) for tp in target_paths
+        ):
+            seen_artifacts.add(source)
+            affected_artifacts_out.append(
+                {
+                    "artifact_id": art.get("artifact_id", ""),
+                    "artifact_type": art.get("artifact_type", ""),
+                    "source_path": source,
+                    "source_hash": art.get("source_hash", ""),
+                }
+            )
+
+    # --- Affected symbols ---
+    affected_symbols_out: list[dict[str, Any]] = []
+    seen_syms: set[str] = set()
+    for sym in symbols:
+        sym_id = sym.get("symbol_id", "")
+        source = sym.get("source_path", "")
+        if sym_id in seen_syms:
+            continue
+        if source in affected_paths or any(
+            _path_matches(tp, source) for tp in target_paths
+        ):
+            seen_syms.add(sym_id)
+            affected_symbols_out.append(
+                {
+                    "symbol_id": sym_id,
+                    "name": sym.get("name", ""),
+                    "qualified_name": sym.get("qualified_name", ""),
+                    "symbol_type": sym.get("symbol_type", ""),
+                    "source_path": source,
+                }
+            )
+
+    # --- Affected tests ---
+    affected_tests_out: list[dict[str, Any]] = []
+    seen_tests: set[str] = set()
+    for tc in tests_data:
+        test_id = tc.get("test_id", "")
+        source = tc.get("source_path", "")
+        if test_id in seen_tests:
+            continue
+        # Tests are affected if their source file matches a target or an
+        # affected path, OR if a target_symbol matches a test name
+        if source in affected_paths or any(
+            _path_matches(tp, source) for tp in target_paths
+        ):
+            seen_tests.add(test_id)
+            affected_tests_out.append(
+                {
+                    "test_id": test_id,
+                    "test_name": tc.get("test_name", tc.get("name", "")),
+                    "source_path": source,
+                    "test_type": tc.get("test_type", ""),
+                }
+            )
+
+    # --- Affected docs ---
+    affected_docs_out: list[dict[str, Any]] = []
+    seen_docs: set[str] = set()
+    for art in artifacts:
+        source = (art.get("source_path") or art.get("path") or "")
+        atype = art.get("artifact_type", "")
+        if source in seen_docs:
+            continue
+        if (
+            source.endswith(".md")
+            or atype == "documentation"
+            or source.startswith("docs/")
+            or source.startswith("knowledge/")
+        ):
+            if source in affected_paths or any(
+                _path_matches(tp, source) for tp in target_paths
+            ):
+                seen_docs.add(source)
+                affected_docs_out.append(
+                    {
+                        "path": source,
+                        "title": art.get("title", source),
+                        "section_count": 0,
+                    }
+                )
+
+    # --- Affected decisions ---
+    affected_decisions_out: tuple[str, ...] = ()
+    dec_refs: list[str] = []
+    for art in artifacts:
+        source = (art.get("source_path") or art.get("path") or "")
+        for dd in _DECISION_DIRS:
+            if source.startswith(dd) and (
+                source in affected_paths
+                or any(_path_matches(tp, source) for tp in target_paths)
+            ):
+                dec_refs.append(source)
+    affected_decisions_out = tuple(sorted(set(dec_refs)))
+
+    # --- Affected evidence ---
+    ev_refs: list[str] = []
+    for art in artifacts:
+        source = (art.get("source_path") or art.get("path") or "")
+        for ed in _EVIDENCE_DIRS:
+            if source.startswith(ed) and (
+                source in affected_paths
+                or any(_path_matches(tp, source) for tp in target_paths)
+            ):
+                ev_refs.append(source)
+    affected_evidence_out: tuple[str, ...] = tuple(sorted(set(ev_refs)))
+
+    # --- Affected memory refs ---
+    mem_refs: list[str] = []
+    for art in artifacts:
+        source = (art.get("source_path") or art.get("path") or "")
+        for md in _MEMORY_DIRS:
+            if source.startswith(md) and (
+                source in affected_paths
+                or any(_path_matches(tp, source) for tp in target_paths)
+            ):
+                mem_refs.append(source)
+    affected_memory_out: tuple[str, ...] = tuple(sorted(set(mem_refs)))
+
+    # --- Graph paths (dependency chains) ---
+    graph_paths_out: tuple[tuple[str, ...], ...] = ()
+    gpaths: list[tuple[str, ...]] = []
+    for tp in target_paths:
+        chain: list[str] = [tp]
+        for edge in edges:
+            from_art = edge.get("from_id", "")
+            to_art = edge.get("to_id", "")
+            if _path_matches(tp, from_art) and to_art:
+                chain.append(to_art)
+        if len(chain) > 1:
+            gpaths.append(tuple(chain))
+    graph_paths_out = tuple(gpaths)
+
+    # --- Gate risks ---
+    gate_risks_out = _detect_gate_risks(all_paths)
+
+    # --- Confidence ---
+    confidence = _derived_confidence(edges, symbols, artifacts)
+
+    # --- Required validation ---
+    docs_to_review: list[str] = [
+        d["path"] for d in affected_docs_out[:5]
+    ]
+    suggested_tests: list[str] = [
+        t["test_name"] or f"tests for {t['source_path']}"
+        for t in affected_tests_out[:10]
+    ]
+    evidence_to_collect: list[str] = list(affected_evidence_out[:5])
+
+    commands_to_consider: list[str] = []
+    if affected_tests_out:
+        test_paths = sorted({t["source_path"] for t in affected_tests_out})[:3]
+        if test_paths:
+            commands_to_consider.append(
+                f"pytest -v {' '.join(test_paths)}"
+            )
+    if any(p.startswith("services/") for p in all_paths):
+        commands_to_consider.append(
+            "mypy core/ services/"
+        )
+
+    manual_review_needed = (
+        impact_level in ("blocking", "high")
+        or impact_type == "HARD"
+        or bool(gate_risks_out)
+    )
+
+    blocking_preconditions: list[str] = []
+    if impact_level == "blocking":
+        blocking_preconditions.append(
+            "Blocking impact level — confirm change is authorized"
+        )
+    if "secrets_surface_touched" in gate_risks_out:
+        blocking_preconditions.append(
+            "Secrets surface touched — verify no credential exposure"
+        )
+
+    required_validation: dict[str, Any] = {
+        "docs_to_review": docs_to_review,
+        "suggested_tests": suggested_tests,
+        "evidence_to_collect": evidence_to_collect,
+        "commands_to_consider": commands_to_consider,
+        "manual_review_needed": manual_review_needed,
+        "blocking_preconditions": blocking_preconditions,
+    }
+
+    # --- Stop conditions ---
+    stop_cond = _build_stop_conditions(
+        impact_level=impact_level,
+        impact_type=impact_type,
+        operation_mode=operation_mode,
+        gate_risks=gate_risks_out,
+        target_paths=target_paths,
+    )
+
+    # --- Deterministic ID ---
+    id_parts = list(target_paths) + list(target_symbols)
+    if input_data.target_issue:
+        id_parts.append(input_data.target_issue)
+    id_parts.append(operation_mode)
+    impact_id = _stable_id("impact", *id_parts)
+
+    return ImpactReport(
+        impact_id=impact_id,
+        target_refs=target_refs,
+        impact_level=impact_level,
+        impact_type=impact_type,
+        affected_artifacts=tuple(affected_artifacts_out),
+        affected_symbols=tuple(affected_symbols_out),
+        affected_tests=tuple(affected_tests_out),
+        affected_docs=tuple(affected_docs_out),
+        affected_decisions=affected_decisions_out,
+        affected_evidence=affected_evidence_out,
+        affected_memory_refs_read_only=affected_memory_out,
+        graph_paths=graph_paths_out,
+        gate_risks=tuple(sorted(gate_risks_out)),
+        confidence=confidence,
+        required_validation=required_validation,
+        stop_conditions=stop_cond,
+    )


### PR DESCRIPTION
## Summary

Implements Impact Radar v1 for the CDB Context Intelligence System.

Closes #2019  
Closes #2108  
Prepares #2109 (Validation Plan Generator)  
Prepares #2111 (Impact Radar MCP Tool)

## Files

| File | Lines | Purpose |
|---|---|---|
| `docs/surrealdb/context-impact-radar-contract-v1.md` | 154 | Contract, domain model, input/output spec |
| `tools/surrealdb/context_impact_radar.py` | 611 | `compute_impact()` pure function + `ImpactRadarInput` / `ImpactReport` dataclasses |
| `tests/unit/surrealdb/test_context_impact_radar.py` | 788 | 39 deterministic unit tests |

## What Impact Radar v1 does

- **Impact Levels**: low / medium / high / blocking (path-based, fail-closed)
- **Impact Type**: HARD (code/runtime) vs SOFT (docs/tests)
- **Confidence**: high / medium / low (derived from edge inference and data quantity)
- **Dependency Edge Tracing**: `DependencyEdge` propagation to find affected artifacts, symbols, tests, docs, decisions, evidence, memory refs
- **Gate Risk Detection**: governance_touched, risk_surface_touched, execution_surface_touched, contract_drift_possible, secrets_surface_touched, lr_surface_touched
- **Required Validation**: docs_to_review, suggested_tests, evidence_to_collect, commands_to_consider (never auto-run), manual_review_needed, blocking_preconditions
- **Stop Condition Propagation**: delegates to existing `context_stop_resolver` (S5-S8, H1, secrets-risk)

## Design

- Pure domain logic. No DB access. No MCP. No network. No file I/O.
- Deterministic: same inputs produce the same outputs.
- Fail-closed: governance/risk/execution/secrets = blocking.
- Uses existing `DependencyEdge` data from `context_indexer`. Compatible with `context_stop_resolver` and `context_required_reads`.

## Validation

```
pytest -v tests/unit/surrealdb/test_context_impact_radar.py -m unit
→ 39 passed in 0.16s

pytest tests/unit/surrealdb/ -m unit --ignore=...test_context_impact_radar.py
→ 429 passed in 49.43s (zero regressions)
```

## Guardrails

- Impact is analysis, not a write-go
- No automatic action permission derived from impact
- No Live-Readiness upgrade, no Echtgeld-Go
- No trading runtime, orders, positions, fills, secrets, broker/execution state
- No SurrealDB production write
- `tmp_pr_body_2311.md` (pre-existing untracked) was not touched or staged