### PR TITLE
fix(security): resolve CodeQL alert trio from security readout

### DIFF
--- a/scripts/audit/github_security_quality_readout.py
+++ b/scripts/audit/github_security_quality_readout.py
@@ -799,17 +799,17 @@ def build_persistable_readout(readout: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def write_report_artifacts(readout: dict[str, Any], out_dir: Path) -> None:
+def write_report_artifacts(
+    persistable_readout: dict[str, Any], out_dir: Path
+) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     json_path = out_dir / JSON_FILENAME
     markdown_path = out_dir / MARKDOWN_FILENAME
-    persistable_readout = build_persistable_readout(readout)
-    # noqa: E501 S105 - build_persistable_readout filters secret_scanning payloads; output is safe
-    json_path.write_text(  # nosec
+    json_path.write_text(
         json.dumps(persistable_readout, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
-    markdown_path.write_text(  # nosec
+    markdown_path.write_text(
         build_markdown_report(persistable_readout),
         encoding="utf-8",
     )
@@ -841,7 +841,8 @@ def generate_readout(
         reference_now_utc=reference_now_utc,
         fetched_surfaces=surfaces,
     )
-    write_report_artifacts(readout, out_dir)
+    persistable_readout = build_persistable_readout(readout)
+    write_report_artifacts(persistable_readout, out_dir)
     return readout
 
 

--- a/tests/unit/scripts/test_backlog_curation.py
+++ b/tests/unit/scripts/test_backlog_curation.py
@@ -311,9 +311,7 @@ def test_extract_explicit_repo_paths_rejects_urls_and_windows_drives() -> None:
         "Check https://github.com/jannekbuengener/Claire_de_Binare/blob/main/docs/file.md, "
         "`C:\\Windows\\System32\\config.txt` and `docs/runbooks/CONTROL_REGISTER.md`."
     )
-    assert "docs/runbooks/CONTROL_REGISTER.md" in result
-    assert not any("github.com" in path for path in result)
-    assert not any("Windows" in path for path in result)
+    assert result == ["docs/runbooks/CONTROL_REGISTER.md"]
 
 
 def test_normalize_path_rejects_path_traversal_and_prefixed_windows_drives() -> None:


### PR DESCRIPTION
## Summary

Fixes three open CodeQL alerts from the 2026-05-05 Security Alert Inventory:

* #3659 — `py/clear-text-storage-sensitive-data`
* #3660 — `py/clear-text-storage-sensitive-data`
* #3650 — `py/incomplete-url-substring-sanitization`

## Changes

* Refactors `scripts/audit/github_security_quality_readout.py` so report writing receives already-persistable/redacted readout data instead of raw readout data.
* Keeps secret-scanning alert details redacted/non-persisted.
* Replaces substring-style URL assertion in `tests/unit/scripts/test_backlog_curation.py` with an exact expected-path assertion.

## Validation

* `python -m pytest -q tests/unit/scripts/test_backlog_curation.py` — 18 passed
* `python -m pytest -q tests/unit/audit/test_github_security_quality_readout.py` — 10 passed
* `python scripts/audit/github_security_quality_readout.py --repo jannekbuengener/Claire_de_Binare --out-dir artifacts/security-alert-readout/codeql-fix-smoke` — PARTIAL (expected, secret-scanning unavailable)

## Security posture

* No CodeQL alert dismissal.
* No suppression-based fix.
* No secret details persisted.
* No Trivy scope touched.
* No runtime, Docker, trading, risk, execution, or strategy change.
* No LR-/Live-/Echtgeld-Ableitung.
