### PR TITLE
feat(context): implement Validation Plan Generator v1

### DIFF
--- a/docs/surrealdb/context-validation-plan-contract-v1.md
+++ b/docs/surrealdb/context-validation-plan-contract-v1.md
@@ -1,0 +1,106 @@
+# Validation Plan Generator v1 — Contract
+
+**Issue:** #2109
+**Epic:** #1976
+**Parent Wave:** Welle 13 (#2103–#2114)
+**Depends on:** #2108 (Impact Radar v1)
+**Prepares:** #2111 (Impact Radar MCP Tool), #2112 (Tests and Fixtures)
+**Status:** Implemented (`tools/surrealdb/context_validation_plan.py`)
+**Schema Version:** 1.0.0
+
+## 1. Purpose
+
+The Validation Plan Generator consumes the output of the Impact Radar v1
+(`ImpactReport` or its `to_payload()` dict) and produces a concrete,
+agent-readable `ValidationPlan`. The plan translates impact analysis into
+actionable validation steps while maintaining all hard guardrails.
+
+## 2. Domain Model
+
+### 2.1 ValidationPlanInput
+
+| Field           | Type                | Description                                 |
+|-----------------|---------------------|---------------------------------------------|
+| `impact_report` | `ImpactReport\|None` | Direct ImpactReport reference               |
+| `payload`       | `dict\|None`         | `to_payload()` dict from ImpactReport       |
+
+Exactly one of `impact_report` or `payload` must be provided. Both `None` or
+both non-`None` raise `ValueError`.
+
+### 2.2 ValidationPlan
+
+| Field                    | Type                   | Description                                          |
+|--------------------------|------------------------|------------------------------------------------------|
+| `plan_id`                | `str`                  | Deterministic SHA256-derived ID                      |
+| `required_checks`        | `tuple[str, ...]`      | Checks that must pass before proceeding              |
+| `suggested_tests`        | `tuple[str, ...]`      | Suggested test suites/functions to run               |
+| `docs_to_review`         | `tuple[str, ...]`      | Documentation paths that need review                 |
+| `evidence_to_collect`    | `tuple[str, ...]`      | Evidence artifacts to collect                        |
+| `commands_to_consider`   | `tuple[str, ...]`      | Commands suggested (never auto-run)                  |
+| `manual_review_needed`   | `bool`                 | Whether manual/Human-GO review is required           |
+| `blocking_preconditions` | `tuple[str, ...]`      | Blocking conditions from impact analysis             |
+| `success_criteria`       | `tuple[str, ...]`      | Conditions that define validation success            |
+| `stop_conditions`        | `tuple[dict, ...]`     | Stop conditions propagated from ImpactReport         |
+| `schema_version`         | `str`                  | Schema version (`1.0.0`)                             |
+
+### 2.3 Required Checks
+
+Derived from:
+- Impact level (`blocking`/`high`/`medium`)
+- Gate risks (`governance_touched`, `risk_surface_touched`, etc.)
+- Blocking preconditions
+- Blocking stop conditions (`severity: blocking`)
+
+### 2.4 Success Criteria
+
+Derived from:
+- Impact level → appropriate validation depth
+- Confidence level (`low`/`medium`/`high`) → data quality requirements
+- Gate risks → governance/secrets/contract/live-readiness coverage
+- Presence of artifacts/symbols/tests/docs → verification requirements
+- Presence/absence of stop conditions
+
+### 2.5 Action Classification
+
+| Category              | Auto-Run | Human-GO Required | Example                              |
+|-----------------------|----------|-------------------|--------------------------------------|
+| `required_checks`     | No       | Yes               | "Blocking impact — seek Human-GO"    |
+| `suggested_tests`     | No       | No                | "test_clock"                         |
+| `commands_to_consider`| **Never**| **N/A**           | "pytest -v tests/"                   |
+| `docs_to_review`      | No       | No                | "docs/surrealdb/readme.md"           |
+| `blocking_preconditions` | No   | Yes               | "Secrets surface touched — verify"   |
+| `success_criteria`    | No       | No                | "All suggested tests passing"        |
+
+**Commands are suggestions only.** The generator never auto-executes anything.
+Read-only, dry-run, and Human-GO-sensitive actions are explicitly distinguished.
+
+## 3. Determinism Guarantee
+
+`build_validation_plan()` is a pure function:
+- Same inputs → same outputs (identical `plan_id`, identical field contents).
+- No randomness, no timestamps, no external state.
+- No DB, network, filesystem, GitHub, or MCP calls.
+- No command execution.
+
+## 4. Compatibility
+
+- Accepts `ImpactReport` directly (attribute-based access via `to_payload()`).
+- Accepts plain `dict` payload for MCP tool wrapping (#2111).
+- Same input via either path produces the identical `ValidationPlan`.
+
+## 5. Guardrails
+
+- No DB write. No command auto-run. No GitHub write from generator.
+- No runtime, trading, live, or Echtgeld implication.
+- Blocking preconditions from impact are always propagated.
+- Stop conditions are always propagated.
+- `manual_review_needed` is always visible.
+
+## 6. Testing
+
+- `tests/unit/surrealdb/test_context_validation_plan.py`
+- Covers: empty input, low/medium/high/blocking impact levels, all gate risks,
+  success criteria derivation, stop condition propagation, command-as-suggestion
+  semantics, full-impact-radar-to-plan pipeline.
+- All tests marked `@pytest.mark.unit`.
+- No Docker, no runtime, no secrets required.

--- a/tests/unit/surrealdb/test_context_validation_plan.py
+++ b/tests/unit/surrealdb/test_context_validation_plan.py
@@ -1,0 +1,897 @@
+"""Unit tests for Validation Plan Generator v1 (#2109)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.surrealdb.context_impact_radar import (
+    ImpactRadarInput,
+    compute_impact,
+)
+from tools.surrealdb.context_validation_plan import (
+    SCHEMA_VERSION,
+    ValidationPlan,
+    ValidationPlanInput,
+    build_validation_plan,
+)
+
+# ── Fixture builders ────────────────────────────────────────────────────────
+
+
+def _make_artifact(
+    artifact_id: str,
+    artifact_type: str,
+    source_path: str,
+    source_hash: str = "",
+) -> dict:
+    return {
+        "artifact_id": artifact_id,
+        "artifact_type": artifact_type,
+        "source_path": source_path,
+        "source_hash": source_hash,
+    }
+
+
+def _make_symbol(
+    symbol_id: str,
+    name: str,
+    source_path: str,
+    symbol_type: str = "function",
+    qualified_name: str = "",
+) -> dict:
+    return {
+        "symbol_id": symbol_id,
+        "name": name,
+        "qualified_name": qualified_name or name,
+        "symbol_type": symbol_type,
+        "source_path": source_path,
+    }
+
+
+def _make_edge(
+    edge_id: str,
+    from_id: str,
+    to_id: str,
+    edge_type: str = "contains",
+    inferred: bool = False,
+) -> dict:
+    return {
+        "edge_id": edge_id,
+        "from_id": from_id,
+        "to_id": to_id,
+        "edge_type": edge_type,
+        "source_path": None,
+        "confidence": "high",
+        "inferred": inferred,
+    }
+
+
+def _make_test_case(
+    test_id: str,
+    test_name: str,
+    source_path: str,
+    test_type: str = "unit",
+) -> dict:
+    return {
+        "test_id": test_id,
+        "test_name": test_name,
+        "source_path": source_path,
+        "test_type": test_type,
+    }
+
+
+# ── Input validation ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_input_requires_either_impact_report_or_payload() -> None:
+    with pytest.raises(ValueError, match="impact_report or payload"):
+        ValidationPlanInput()
+
+
+@pytest.mark.unit
+def test_input_rejects_both_impact_report_and_payload() -> None:
+    with pytest.raises(
+        ValueError, match="exactly one of impact_report or payload"
+    ):
+        ValidationPlanInput(impact_report={}, payload={})
+
+
+@pytest.mark.unit
+def test_input_accepts_payload_dict() -> None:
+    inp = ValidationPlanInput(payload={"impact_id": "test", "impact_level": "low"})
+    assert inp.payload is not None
+
+
+# ── Basic generation ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_empty_payload_produces_valid_plan() -> None:
+    inp = ValidationPlanInput(payload={})
+    plan = build_validation_plan(inp)
+
+    assert plan.schema_version == SCHEMA_VERSION
+    assert isinstance(plan.plan_id, str)
+    assert len(plan.plan_id) == 16
+    assert isinstance(plan.required_checks, tuple)
+    assert isinstance(plan.suggested_tests, tuple)
+    assert isinstance(plan.docs_to_review, tuple)
+    assert isinstance(plan.evidence_to_collect, tuple)
+    assert isinstance(plan.commands_to_consider, tuple)
+    assert isinstance(plan.manual_review_needed, bool)
+    assert isinstance(plan.blocking_preconditions, tuple)
+    assert isinstance(plan.success_criteria, tuple)
+    assert isinstance(plan.stop_conditions, tuple)
+
+
+@pytest.mark.unit
+def test_empty_payload_has_low_level_check_and_no_preconditions() -> None:
+    plan = build_validation_plan(ValidationPlanInput(payload={}))
+
+    assert len(plan.blocking_preconditions) == 0
+    assert plan.manual_review_needed is False
+    assert any("low impact" in c.lower() for c in plan.required_checks)
+
+
+@pytest.mark.unit
+def test_plan_produces_deterministic_id() -> None:
+    payload = {"impact_id": "abc123", "impact_level": "high", "confidence": "high"}
+    plan1 = build_validation_plan(ValidationPlanInput(payload=dict(payload)))
+    plan2 = build_validation_plan(ValidationPlanInput(payload=dict(payload)))
+
+    assert plan1.plan_id == plan2.plan_id
+
+
+@pytest.mark.unit
+def test_plan_to_payload_contains_all_fields() -> None:
+    plan = build_validation_plan(ValidationPlanInput(payload={}))
+    p = plan.to_payload()
+
+    assert "schema_version" in p
+    assert "plan_id" in p
+    assert "required_checks" in p
+    assert "suggested_tests" in p
+    assert "docs_to_review" in p
+    assert "evidence_to_collect" in p
+    assert "commands_to_consider" in p
+    assert "manual_review_needed" in p
+    assert "blocking_preconditions" in p
+    assert "success_criteria" in p
+    assert "stop_conditions" in p
+
+
+# ── ImpactReport integration ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_accepts_impact_report_from_radar() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("docs/surrealdb/some-doc.md",),
+        artifacts=(
+            _make_artifact(
+                "art-1", "documentation", "docs/surrealdb/some-doc.md"
+            ),
+        ),
+    )
+    report = compute_impact(inp)
+
+    plan_input = ValidationPlanInput(impact_report=report)
+    plan = build_validation_plan(plan_input)
+
+    assert plan.plan_id is not None
+    assert len(plan.docs_to_review) >= 0
+
+
+@pytest.mark.unit
+def test_accepts_impact_report_payload_dict() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("docs/surrealdb/some-doc.md",),
+        artifacts=(
+            _make_artifact(
+                "art-1", "documentation", "docs/surrealdb/some-doc.md"
+            ),
+        ),
+    )
+    report = compute_impact(inp)
+    payload = report.to_payload()
+
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert plan.plan_id is not None
+
+
+@pytest.mark.unit
+def test_report_and_payload_produce_same_plan() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("docs/surrealdb/some-doc.md",),
+        artifacts=(
+            _make_artifact(
+                "art-1", "documentation", "docs/surrealdb/some-doc.md"
+            ),
+        ),
+    )
+    report = compute_impact(inp)
+    payload = report.to_payload()
+
+    plan_from_report = build_validation_plan(
+        ValidationPlanInput(impact_report=report)
+    )
+    plan_from_payload = build_validation_plan(
+        ValidationPlanInput(payload=payload)
+    )
+
+    assert plan_from_report == plan_from_payload
+
+
+# ── Low impact ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_low_impact_has_appropriate_checks() -> None:
+    payload = {
+        "impact_id": "test-low",
+        "impact_level": "low",
+        "confidence": "high",
+        "gate_risks": [],
+        "affected_artifacts": [
+            {"source_path": "docs/readme.md", "artifact_type": "documentation"}
+        ],
+        "required_validation": {
+            "docs_to_review": ["docs/readme.md"],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": False,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert plan.manual_review_needed is False
+    assert len(plan.blocking_preconditions) == 0
+    assert len(plan.required_checks) == 1
+    assert any(
+        "affected modules" in c.lower() for c in plan.required_checks
+    )
+    assert any(
+        "affected artifacts" in c.lower() for c in plan.success_criteria
+    )
+
+
+# ── Medium impact ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_medium_impact_has_medium_check() -> None:
+    payload = {
+        "impact_id": "test-medium",
+        "impact_level": "medium",
+        "confidence": "high",
+        "gate_risks": [],
+        "affected_artifacts": [
+            {"source_path": "core/utils/clock.py", "artifact_type": "source"}
+        ],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": ["test_clock"],
+            "evidence_to_collect": [],
+            "commands_to_consider": ["pytest tests/unit/test_clock.py"],
+            "manual_review_needed": False,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert any(
+        "medium impact" in c.lower() for c in plan.required_checks
+    )
+    assert plan.commands_to_consider == ("pytest tests/unit/test_clock.py",)
+
+
+# ── High impact ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_high_impact_has_high_check_and_manual_review() -> None:
+    payload = {
+        "impact_id": "test-high",
+        "impact_level": "high",
+        "confidence": "high",
+        "gate_risks": [],
+        "affected_artifacts": [
+            {"source_path": "services/signal/service.py", "artifact_type": "source"}
+        ],
+        "affected_tests": [
+            {"test_id": "t1", "test_name": "test_signal", "source_path": "tests/unit/test_signal.py"}
+        ],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": ["test_signal"],
+            "evidence_to_collect": [],
+            "commands_to_consider": ["pytest tests/unit/test_signal.py"],
+            "manual_review_needed": True,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert plan.manual_review_needed is True
+    assert any(
+        "high impact" in c.lower() for c in plan.required_checks
+    )
+    assert any(
+        "services verified" in c.lower() for c in plan.success_criteria
+    )
+
+
+# ── Blocking impact ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_blocking_impact_propagates_all_checks() -> None:
+    payload = {
+        "impact_id": "test-blocking",
+        "impact_level": "blocking",
+        "confidence": "high",
+        "gate_risks": ["governance_touched", "secrets_surface_touched"],
+        "affected_artifacts": [
+            {"source_path": "knowledge/governance/CDB_AGENT_POLICY.md"}
+        ],
+        "stop_conditions": [
+            {
+                "type": "scope_drift_risk",
+                "severity": "blocking",
+                "reason": "S5: blocking impact detected on knowledge/governance/",
+                "required_action": "Seek Human-GO",
+                "human_go_required": True,
+            }
+        ],
+        "required_validation": {
+            "docs_to_review": ["knowledge/governance/CDB_AGENT_POLICY.md"],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": True,
+            "blocking_preconditions": [
+                "Blocking impact level — confirm change is authorized",
+                "Secrets surface touched — verify no credential exposure",
+            ],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert plan.manual_review_needed is True
+    assert len(plan.blocking_preconditions) == 2
+    assert len(plan.required_checks) >= 1
+    assert any(
+        "blocking impact" in c.lower() for c in plan.required_checks
+    )
+    assert any(
+        "governance" in c.lower() for c in plan.required_checks
+    )
+    assert any(
+        "secrets" in c.lower() for c in plan.required_checks
+    )
+    assert any(
+        "Human-GO" in c for c in plan.success_criteria
+    )
+    assert any(
+        "stop conditions" in c.lower() for c in plan.success_criteria
+    )
+
+
+# ── Gate risk propagation ───────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_governance_touched_adds_check() -> None:
+    payload = {
+        "impact_id": "test-gov",
+        "impact_level": "high",
+        "confidence": "high",
+        "gate_risks": ["governance_touched"],
+        "affected_artifacts": [
+            {"source_path": "knowledge/governance/CDB_CONSTITUTION.md"}
+        ],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": True,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert any(
+        "governance" in c.lower() for c in plan.required_checks
+    )
+
+
+@pytest.mark.unit
+def test_risk_surface_adds_check() -> None:
+    payload = {
+        "impact_id": "test-risk",
+        "impact_level": "blocking",
+        "confidence": "high",
+        "gate_risks": ["risk_surface_touched"],
+        "affected_artifacts": [
+            {"source_path": "services/risk/service.py"}
+        ],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": True,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert any(
+        "risk" in c.lower() for c in plan.required_checks
+    )
+
+
+@pytest.mark.unit
+def test_execution_surface_adds_check() -> None:
+    payload = {
+        "impact_id": "test-exec",
+        "impact_level": "high",
+        "confidence": "high",
+        "gate_risks": ["execution_surface_touched"],
+        "affected_artifacts": [
+            {"source_path": "services/execution/service.py"}
+        ],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": True,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert any(
+        "execution" in c.lower() for c in plan.required_checks
+    )
+
+
+@pytest.mark.unit
+def test_contract_drift_adds_check() -> None:
+    payload = {
+        "impact_id": "test-contract",
+        "impact_level": "high",
+        "confidence": "high",
+        "gate_risks": ["contract_drift_possible"],
+        "affected_artifacts": [
+            {"source_path": "docs/contracts/some-contract.md"}
+        ],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": True,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert any(
+        "contract" in c.lower() for c in plan.required_checks
+    )
+
+
+@pytest.mark.unit
+def test_lr_surface_adds_check() -> None:
+    payload = {
+        "impact_id": "test-lr",
+        "impact_level": "high",
+        "confidence": "high",
+        "gate_risks": ["lr_surface_touched"],
+        "affected_artifacts": [
+            {"source_path": "docs/live-readiness/LR-AUDIT-STATUS.md"}
+        ],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": True,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert any(
+        "live-readiness" in c.lower() for c in plan.required_checks
+    )
+
+
+# ── Success criteria ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_low_confidence_adds_criterion() -> None:
+    payload = {
+        "impact_id": "test",
+        "impact_level": "medium",
+        "confidence": "low",
+        "gate_risks": [],
+        "affected_artifacts": [],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": False,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert any(
+        "confidence is low" in c.lower() for c in plan.success_criteria
+    )
+
+
+@pytest.mark.unit
+def test_high_confidence_omits_low_confidence_criterion() -> None:
+    payload = {
+        "impact_id": "test",
+        "impact_level": "medium",
+        "confidence": "high",
+        "gate_risks": [],
+        "affected_artifacts": [],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": False,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert not any(
+        "confidence is low" in c.lower() for c in plan.success_criteria
+    )
+    assert any(
+        "standard review" in c.lower() for c in plan.success_criteria
+    )
+
+
+@pytest.mark.unit
+def test_governance_risk_adds_success_criterion() -> None:
+    payload = {
+        "impact_id": "test",
+        "impact_level": "high",
+        "confidence": "high",
+        "gate_risks": ["governance_touched"],
+        "affected_artifacts": [],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": True,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert any(
+        "governance review" in c.lower() for c in plan.success_criteria
+    )
+
+
+@pytest.mark.unit
+def test_secrets_risk_adds_success_criterion() -> None:
+    payload = {
+        "impact_id": "test",
+        "impact_level": "high",
+        "confidence": "high",
+        "gate_risks": ["secrets_surface_touched"],
+        "affected_artifacts": [],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": True,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert any(
+        "secrets audit" in c.lower() for c in plan.success_criteria
+    )
+
+
+# ── Stop condition propagation ──────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_stop_conditions_are_propagated() -> None:
+    stop_conditions = [
+        {
+            "type": "scope_drift_risk",
+            "severity": "blocking",
+            "reason": "S5: blocking impact detected",
+            "required_action": "Seek Human-GO",
+            "human_go_required": True,
+        }
+    ]
+    payload = {
+        "impact_id": "test-stop",
+        "impact_level": "blocking",
+        "confidence": "high",
+        "gate_risks": [],
+        "stop_conditions": stop_conditions,
+        "affected_artifacts": [],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": True,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert len(plan.stop_conditions) == 1
+    assert plan.stop_conditions[0]["type"] == "scope_drift_risk"
+    assert any(
+        "stop condition" in c.lower() for c in plan.required_checks
+    )
+
+
+@pytest.mark.unit
+def test_blocking_stop_conditions_become_checks() -> None:
+    stop_conditions = [
+        {
+            "type": "forbidden_path",
+            "severity": "blocking",
+            "reason": "S8: forbidden path touched",
+            "required_action": "Abort",
+            "human_go_required": True,
+        }
+    ]
+    payload = {
+        "impact_id": "test-bs",
+        "impact_level": "blocking",
+        "confidence": "high",
+        "gate_risks": [],
+        "stop_conditions": stop_conditions,
+        "affected_artifacts": [],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": True,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert any(
+        "S8" in c or "forbidden" in c.lower()
+        for c in plan.required_checks
+    )
+
+
+# ── Commands are suggestions ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_commands_are_preserved_as_suggestions() -> None:
+    payload = {
+        "impact_id": "test-cmd",
+        "impact_level": "medium",
+        "confidence": "high",
+        "gate_risks": [],
+        "affected_artifacts": [],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": ["test_a", "test_b"],
+            "evidence_to_collect": [],
+            "commands_to_consider": [
+                "pytest -v tests/unit/test_a.py",
+                "mypy core/ services/",
+            ],
+            "manual_review_needed": False,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert len(plan.commands_to_consider) == 2
+    assert plan.commands_to_consider[0].startswith("pytest")
+    assert plan.commands_to_consider[1].startswith("mypy")
+
+
+# ── Payload edge cases ──────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_missing_required_validation_defaults() -> None:
+    payload = {
+        "impact_id": "test",
+        "impact_level": "low",
+        "confidence": "high",
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert len(plan.docs_to_review) == 0
+    assert len(plan.suggested_tests) == 0
+    assert len(plan.evidence_to_collect) == 0
+    assert len(plan.commands_to_consider) == 0
+    assert plan.manual_review_needed is False
+    assert len(plan.blocking_preconditions) == 0
+
+
+@pytest.mark.unit
+def test_payload_with_nested_impact_report_dict() -> None:
+    report_payload = {
+        "impact_id": "nested-123",
+        "impact_level": "low",
+        "confidence": "high",
+        "gate_risks": [],
+        "required_validation": {
+            "docs_to_review": ["docs/x.md"],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": False,
+            "blocking_preconditions": [],
+        },
+    }
+    plan = build_validation_plan(
+        ValidationPlanInput(payload=report_payload)
+    )
+
+    assert plan.plan_id is not None
+    assert len(plan.docs_to_review) == 1
+    assert plan.docs_to_review[0] == "docs/x.md"
+
+
+# ── Blocking precondition integration ───────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_blocking_preconditions_become_checks() -> None:
+    payload = {
+        "impact_id": "test-bp",
+        "impact_level": "blocking",
+        "confidence": "high",
+        "gate_risks": ["secrets_surface_touched"],
+        "affected_artifacts": [],
+        "required_validation": {
+            "docs_to_review": [],
+            "suggested_tests": [],
+            "evidence_to_collect": [],
+            "commands_to_consider": [],
+            "manual_review_needed": True,
+            "blocking_preconditions": [
+                "Secrets surface touched — verify no credential exposure",
+            ],
+        },
+    }
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert any(
+        "BLOCKING:" in c for c in plan.required_checks
+    )
+    assert any(
+        "credential" in c.lower() for c in plan.required_checks
+    )
+
+
+# ── Full impact-radar-to-plan pipeline ──────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_full_pipeline_docs_change() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("docs/surrealdb/some-doc.md",),
+        artifacts=(
+            _make_artifact(
+                "art-1", "documentation", "docs/surrealdb/some-doc.md"
+            ),
+        ),
+    )
+    report = compute_impact(inp)
+    plan = build_validation_plan(ValidationPlanInput(impact_report=report))
+
+    assert plan.plan_id is not None
+    assert "docs/surrealdb/some-doc.md" in plan.docs_to_review
+    assert plan.manual_review_needed is False
+    assert len(plan.blocking_preconditions) == 0
+
+
+@pytest.mark.unit
+def test_full_pipeline_governance_change() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("knowledge/governance/CDB_AGENT_POLICY.md",),
+        artifacts=(
+            _make_artifact(
+                "art-1", "documentation",
+                "knowledge/governance/CDB_AGENT_POLICY.md",
+            ),
+        ),
+    )
+    report = compute_impact(inp)
+    plan = build_validation_plan(ValidationPlanInput(impact_report=report))
+
+    assert plan.manual_review_needed is True
+    assert len(plan.blocking_preconditions) > 0
+    assert any(
+        "blocking" in c.lower() for c in plan.required_checks
+    )
+
+
+@pytest.mark.unit
+def test_full_pipeline_service_change() -> None:
+    inp = ImpactRadarInput(
+        target_paths=("services/signal/service.py",),
+        artifacts=(
+            _make_artifact("art-1", "source", "services/signal/service.py"),
+        ),
+        test_cases=(
+            _make_test_case(
+                "t1", "test_signal", "tests/unit/test_signal.py"
+            ),
+        ),
+    )
+    report = compute_impact(inp)
+    plan = build_validation_plan(ValidationPlanInput(impact_report=report))
+
+    assert plan.manual_review_needed is True
+    assert any(
+        "services verified" in c.lower() for c in plan.success_criteria
+    )
+
+
+@pytest.mark.unit
+def test_full_pipeline_blocking_governance_plus_secrets() -> None:
+    inp = ImpactRadarInput(
+        target_paths=(
+            "knowledge/governance/CDB_AGENT_POLICY.md",
+            "secrets/some-secret.env",
+        ),
+        operation_mode="write",
+        artifacts=(
+            _make_artifact(
+                "art-1", "documentation",
+                "knowledge/governance/CDB_AGENT_POLICY.md",
+            ),
+            _make_artifact(
+                "art-2", "secret", "secrets/some-secret.env",
+            ),
+        ),
+    )
+    report = compute_impact(inp)
+    plan = build_validation_plan(ValidationPlanInput(impact_report=report))
+
+    assert plan.manual_review_needed is True
+    assert len(plan.blocking_preconditions) >= 1
+    assert any(
+        "governance" in c.lower() for c in plan.required_checks
+    )
+    assert any(
+        "secrets" in c.lower() for c in plan.required_checks
+    )
+    assert any(
+        "blocking" in c.lower() for c in plan.required_checks
+    )
+    assert len(plan.stop_conditions) > 0

--- a/tests/unit/surrealdb/test_context_validation_plan.py
+++ b/tests/unit/surrealdb/test_context_validation_plan.py
@@ -10,7 +10,6 @@ from tools.surrealdb.context_impact_radar import (
 )
 from tools.surrealdb.context_validation_plan import (
     SCHEMA_VERSION,
-    ValidationPlan,
     ValidationPlanInput,
     build_validation_plan,
 )
@@ -741,6 +740,29 @@ def test_missing_required_validation_defaults() -> None:
 
 
 @pytest.mark.unit
+def test_missing_required_validation_derives_manual_review_for_blocking() -> None:
+    payload = {
+        "impact_id": "test-blocking-default-review",
+        "impact_level": "blocking",
+        "confidence": "high",
+        "gate_risks": ["governance_touched"],
+        "stop_conditions": [
+            {
+                "type": "scope_drift_risk",
+                "severity": "blocking",
+                "reason": "S5: blocking impact detected",
+                "required_action": "Seek Human-GO",
+                "human_go_required": True,
+            }
+        ],
+    }
+
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert plan.manual_review_needed is True
+
+
+@pytest.mark.unit
 def test_payload_with_nested_impact_report_dict() -> None:
     report_payload = {
         "impact_id": "nested-123",
@@ -795,6 +817,112 @@ def test_blocking_preconditions_become_checks() -> None:
     assert any(
         "credential" in c.lower() for c in plan.required_checks
     )
+
+
+@pytest.mark.unit
+def test_stop_conditions_participate_in_equality() -> None:
+    payload = {
+        "impact_id": "test-equality",
+        "impact_level": "blocking",
+        "confidence": "high",
+        "stop_conditions": [
+            {
+                "type": "scope_drift_risk",
+                "severity": "blocking",
+                "reason": "S5: blocking impact detected",
+            }
+        ],
+    }
+
+    plan_a = build_validation_plan(ValidationPlanInput(payload=payload))
+    changed_payload = {
+        **payload,
+        "stop_conditions": [
+            {
+                "type": "scope_drift_risk",
+                "severity": "blocking",
+                "reason": "S8: forbidden path touched",
+            }
+        ],
+    }
+    plan_b = build_validation_plan(
+        ValidationPlanInput(payload=changed_payload)
+    )
+
+    assert plan_a != plan_b
+
+
+@pytest.mark.unit
+def test_plan_id_changes_when_stop_conditions_change() -> None:
+    base_payload = {
+        "impact_id": "test-plan-id",
+        "impact_level": "blocking",
+        "confidence": "high",
+        "gate_risks": [],
+        "stop_conditions": [
+            {
+                "type": "scope_drift_risk",
+                "severity": "blocking",
+                "reason": "S5: blocking impact detected",
+            }
+        ],
+    }
+
+    plan_a = build_validation_plan(ValidationPlanInput(payload=base_payload))
+    plan_b = build_validation_plan(
+        ValidationPlanInput(
+            payload={
+                **base_payload,
+                "gate_risks": ["secrets_surface_touched"],
+            }
+        )
+    )
+
+    assert plan_a.plan_id != plan_b.plan_id
+
+
+@pytest.mark.unit
+def test_stop_conditions_are_copied_on_plan_creation() -> None:
+    stop_conditions = [
+        {
+            "type": "scope_drift_risk",
+            "severity": "blocking",
+            "reason": "S5: blocking impact detected",
+        }
+    ]
+    payload = {
+        "impact_id": "test-copy-in",
+        "impact_level": "blocking",
+        "confidence": "high",
+        "stop_conditions": stop_conditions,
+    }
+
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+    stop_conditions[0]["severity"] = "warning"
+
+    assert plan.stop_conditions[0]["severity"] == "blocking"
+
+
+@pytest.mark.unit
+def test_to_payload_copies_stop_condition_dicts() -> None:
+    payload = {
+        "impact_id": "test-copy-out",
+        "impact_level": "blocking",
+        "confidence": "high",
+        "stop_conditions": [
+            {
+                "type": "scope_drift_risk",
+                "severity": "blocking",
+                "reason": "S5: blocking impact detected",
+            }
+        ],
+    }
+
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+    exported = plan.to_payload()
+    exported["stop_conditions"][0]["severity"] = "warning"
+
+    assert plan.stop_conditions[0]["severity"] == "blocking"
 
 
 # ── Full impact-radar-to-plan pipeline ──────────────────────────────────────

--- a/tests/unit/surrealdb/test_context_validation_plan.py
+++ b/tests/unit/surrealdb/test_context_validation_plan.py
@@ -925,6 +925,24 @@ def test_to_payload_copies_stop_condition_dicts() -> None:
     assert plan.stop_conditions[0]["severity"] == "blocking"
 
 
+@pytest.mark.unit
+def test_non_dict_stop_conditions_fail_closed_in_payload_mode() -> None:
+    payload = {
+        "impact_id": "test-invalid-stop-condition",
+        "impact_level": "low",
+        "confidence": "high",
+        "stop_conditions": ["S8: forbidden path touched"],
+    }
+
+    plan = build_validation_plan(ValidationPlanInput(payload=payload))
+
+    assert plan.manual_review_needed is True
+    assert len(plan.stop_conditions) == 1
+    assert plan.stop_conditions[0]["type"] == "invalid_stop_condition_payload"
+    assert plan.stop_conditions[0]["severity"] == "blocking"
+    assert "S8" in plan.stop_conditions[0]["reason"]
+
+
 # ── Full impact-radar-to-plan pipeline ──────────────────────────────────────
 
 

--- a/tools/surrealdb/context_validation_plan.py
+++ b/tools/surrealdb/context_validation_plan.py
@@ -1,0 +1,346 @@
+"""Validation Plan Generator v1 — deterministic agent-readable validation plan.
+
+Issues:
+    #2109 — Implement validation plan generator v1
+    Parent: #2103 (Wave-13)
+    Epic: #1976
+
+This module consumes an ImpactRadar `ImpactReport` (or its `to_payload()` dict)
+and produces a concrete, agent-readable `ValidationPlan` with required checks,
+suggested tests, docs to review, evidence to collect, commands to consider
+(never auto-run), manual review requirements, blocking preconditions, and
+success criteria.
+
+Design intent:
+    Pure domain logic. No DB access. No MCP. No networking. No file I/O.
+    No GitHub write. No command execution.
+    Input: ImpactReport or its payload dict.
+    Output: typed ValidationPlan.
+    Deterministic: same inputs → same outputs.
+    Fail-closed: blocking preconditions from impact are propagated.
+    Commands are suggestions only; never auto-run.
+    Read-only vs dry-run vs Human-GO distinction is explicit.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+
+SCHEMA_VERSION = "1.0.0"
+
+# ── Input / Output types ────────────────────────────────────────────────────
+
+
+@dataclass
+class ValidationPlanInput:
+    """Input for validation plan generation.
+
+    Accepts either an ImpactReport directly or its `to_payload()` dict.
+    Exactly one must be provided.
+    """
+
+    impact_report: Any = None
+    payload: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if self.impact_report is None and self.payload is None:
+            raise ValueError(
+                "Either impact_report or payload must be provided"
+            )
+        if self.impact_report is not None and self.payload is not None:
+            raise ValueError(
+                "Provide exactly one of impact_report or payload, not both"
+            )
+
+
+@dataclass(frozen=True)
+class ValidationPlan:
+    """Deterministic validation plan for agent consumption."""
+
+    plan_id: str
+    required_checks: tuple[str, ...]
+    suggested_tests: tuple[str, ...]
+    docs_to_review: tuple[str, ...]
+    evidence_to_collect: tuple[str, ...]
+    commands_to_consider: tuple[str, ...]
+    manual_review_needed: bool
+    blocking_preconditions: tuple[str, ...]
+    success_criteria: tuple[str, ...]
+    stop_conditions: tuple[dict[str, Any], ...] = field(
+        hash=False, compare=False
+    )
+    schema_version: str = SCHEMA_VERSION
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "plan_id": self.plan_id,
+            "required_checks": list(self.required_checks),
+            "suggested_tests": list(self.suggested_tests),
+            "docs_to_review": list(self.docs_to_review),
+            "evidence_to_collect": list(self.evidence_to_collect),
+            "commands_to_consider": list(self.commands_to_consider),
+            "manual_review_needed": self.manual_review_needed,
+            "blocking_preconditions": list(self.blocking_preconditions),
+            "success_criteria": list(self.success_criteria),
+            "stop_conditions": list(self.stop_conditions),
+        }
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _stable_id(*parts: str) -> str:
+    joined = "|".join(parts)
+    return hashlib.sha256(joined.encode()).hexdigest()[:16]
+
+
+def _resolve_payload(input_data: ValidationPlanInput) -> dict[str, Any]:
+    """Extract a payload dict from ValidationPlanInput."""
+    if input_data.payload is not None:
+        return input_data.payload
+    report = input_data.impact_report
+    if hasattr(report, "to_payload"):
+        return report.to_payload()
+    if isinstance(report, dict):
+        return report
+    raise TypeError(
+        "impact_report must be an ImpactReport or dict, "
+        f"got {type(report).__name__}"
+    )
+
+
+def _get_required_validation(payload: dict[str, Any]) -> dict[str, Any]:
+    """Extract required_validation from an ImpactReport payload."""
+    rv = payload.get("required_validation", {})
+    if isinstance(rv, dict):
+        return rv
+    return {}
+
+
+def _derive_required_checks(
+    impact_level: str,
+    gate_risks: list[str],
+    blocking_preconditions: list[str],
+    stop_conditions: list[dict[str, Any]],
+) -> list[str]:
+    checks: list[str] = []
+
+    if impact_level == "blocking":
+        checks.append(
+            "Blocking impact level — confirm change is authorized by Human-GO"
+        )
+    elif impact_level == "high":
+        checks.append(
+            "High impact level — verify change scope and invariants"
+        )
+    elif impact_level == "medium":
+        checks.append(
+            "Medium impact level — validate affected modules and tests"
+        )
+    else:
+        checks.append(
+            "Low impact level — validate affected modules with passing unit tests"
+        )
+
+    if "governance_touched" in gate_risks:
+        checks.append(
+            "Governance paths touched — review constitution and policies"
+        )
+    if "risk_surface_touched" in gate_risks:
+        checks.append(
+            "Risk service surface touched — verify risk limits unchanged"
+        )
+    if "execution_surface_touched" in gate_risks:
+        checks.append(
+            "Execution surface touched — verify no order/trade side-effects"
+        )
+    if "contract_drift_possible" in gate_risks:
+        checks.append(
+            "Contract drift possible — reconcile contracts and schemas"
+        )
+    if "secrets_surface_touched" in gate_risks:
+        checks.append(
+            "Secrets surface touched — verify no credential exposure"
+        )
+    if "lr_surface_touched" in gate_risks:
+        checks.append(
+            "Live-readiness surface touched — verify no false LR-go claim"
+        )
+
+    for bp in blocking_preconditions:
+        checks.append(f"BLOCKING: {bp}")
+
+    blocking_stops = [
+        s for s in stop_conditions
+        if isinstance(s, dict) and s.get("severity") == "blocking"
+    ]
+    for st in blocking_stops:
+        checks.append(
+            f"Stop condition: {st.get('reason', st.get('type', 'unknown'))}"
+        )
+
+    return checks
+
+
+def _derive_success_criteria(
+    impact_level: str,
+    confidence: str,
+    gate_risks: list[str],
+    has_artifacts: bool,
+    has_symbols: bool,
+    has_tests: bool,
+    has_docs: bool,
+    has_stop_conditions: bool,
+) -> list[str]:
+    criteria: list[str] = []
+
+    if impact_level == "blocking":
+        criteria.append(
+            "All blocking preconditions resolved with explicit Human-GO"
+        )
+        criteria.append(
+            "All stop conditions addressed and cleared"
+        )
+    elif impact_level == "high":
+        criteria.append(
+            "All affected services verified with passing unit tests"
+        )
+    elif impact_level in ("medium", "low"):
+        criteria.append(
+            "All affected modules verified with passing unit tests"
+        )
+
+    if confidence == "low":
+        criteria.append(
+            "Confidence is low — validate with real data before proceeding"
+        )
+    elif confidence == "medium":
+        criteria.append(
+            "Confidence is medium — cross-check inferred edges"
+        )
+
+    if "governance_touched" in gate_risks:
+        criteria.append(
+            "Governance review completed and signed off"
+        )
+    if "secrets_surface_touched" in gate_risks:
+        criteria.append(
+            "Secrets audit completed — no credentials exposed"
+        )
+    if "contract_drift_possible" in gate_risks:
+        criteria.append(
+            "Contract reconciliation completed — schemas match"
+        )
+    if "lr_surface_touched" in gate_risks:
+        criteria.append(
+            "Live-readiness SSOT reconciled — no false LR-go signals"
+        )
+
+    if not has_stop_conditions:
+        criteria.append(
+            "No stop conditions flagged — proceed with standard review"
+        )
+
+    if has_artifacts:
+        criteria.append(
+            "Affected artifacts identified and reviewed"
+        )
+    if has_symbols:
+        criteria.append(
+            "Affected symbols traced and verified"
+        )
+    if has_tests:
+        criteria.append(
+            "All suggested tests passing (unit + integration)"
+        )
+    if has_docs:
+        criteria.append(
+            "Documentation reviewed and updated as needed"
+        )
+
+    return criteria
+
+
+# ── Core computation ────────────────────────────────────────────────────────
+
+
+def build_validation_plan(input_data: ValidationPlanInput) -> ValidationPlan:
+    """Build a ValidationPlan from ImpactReport data.
+
+    Args:
+        input_data: ValidationPlanInput wrapping an ImpactReport or its
+                    to_payload() dict.
+
+    Returns:
+        ValidationPlan with required_checks, suggested_tests, docs_to_review,
+        evidence_to_collect, commands_to_consider, manual_review_needed,
+        blocking_preconditions, success_criteria, and stop_conditions.
+
+    Deterministic. Same inputs always produce the same outputs.
+    No DB, network, filesystem, GitHub, or MCP calls.
+    Commands are suggestions only — never auto-executed.
+    """
+    payload = _resolve_payload(input_data)
+
+    impact_level = payload.get("impact_level", "low")
+    impact_id = payload.get("impact_id", "unknown")
+    confidence = payload.get("confidence", "low")
+    gate_risks: list[str] = payload.get("gate_risks", [])
+    stop_conditions: list[dict[str, Any]] = payload.get("stop_conditions", [])
+
+    rv = _get_required_validation(payload)
+
+    docs_to_review: tuple[str, ...] = tuple(rv.get("docs_to_review", []))
+    suggested_tests: tuple[str, ...] = tuple(rv.get("suggested_tests", []))
+    evidence_to_collect: tuple[str, ...] = tuple(
+        rv.get("evidence_to_collect", [])
+    )
+    commands_to_consider: tuple[str, ...] = tuple(
+        rv.get("commands_to_consider", [])
+    )
+    manual_review_needed: bool = bool(rv.get("manual_review_needed", False))
+    blocking_preconditions: tuple[str, ...] = tuple(
+        rv.get("blocking_preconditions", [])
+    )
+
+    has_artifacts = bool(payload.get("affected_artifacts", []))
+    has_symbols = bool(payload.get("affected_symbols", []))
+    has_tests = bool(payload.get("affected_tests", []))
+    has_docs = bool(payload.get("affected_docs", []))
+    has_stop_conditions = bool(stop_conditions)
+
+    required_checks = _derive_required_checks(
+        impact_level=impact_level,
+        gate_risks=gate_risks,
+        blocking_preconditions=list(blocking_preconditions),
+        stop_conditions=stop_conditions,
+    )
+
+    success_criteria = _derive_success_criteria(
+        impact_level=impact_level,
+        confidence=confidence,
+        gate_risks=gate_risks,
+        has_artifacts=has_artifacts,
+        has_symbols=has_symbols,
+        has_tests=has_tests,
+        has_docs=has_docs,
+        has_stop_conditions=has_stop_conditions,
+    )
+
+    plan_id = _stable_id("plan", impact_id, impact_level, confidence)
+
+    return ValidationPlan(
+        plan_id=plan_id,
+        required_checks=tuple(required_checks),
+        suggested_tests=suggested_tests,
+        docs_to_review=docs_to_review,
+        evidence_to_collect=evidence_to_collect,
+        commands_to_consider=commands_to_consider,
+        manual_review_needed=manual_review_needed,
+        blocking_preconditions=blocking_preconditions,
+        success_criteria=tuple(success_criteria),
+        stop_conditions=tuple(stop_conditions),
+    )

--- a/tools/surrealdb/context_validation_plan.py
+++ b/tools/surrealdb/context_validation_plan.py
@@ -132,12 +132,24 @@ def _get_required_validation(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def _copy_stop_conditions(
-    stop_conditions: list[dict[str, Any]],
+    stop_conditions: list[Any],
 ) -> tuple[dict[str, Any], ...]:
     copied: list[dict[str, Any]] = []
     for stop_condition in stop_conditions:
         if isinstance(stop_condition, dict):
             copied.append(dict(stop_condition))
+            continue
+        copied.append(
+            {
+                "type": "invalid_stop_condition_payload",
+                "severity": "blocking",
+                "reason": str(stop_condition),
+                "required_action": (
+                    "Normalize stop_conditions to dict payload before proceed"
+                ),
+                "human_go_required": True,
+            }
+        )
     return tuple(copied)
 
 

--- a/tools/surrealdb/context_validation_plan.py
+++ b/tools/surrealdb/context_validation_plan.py
@@ -25,6 +25,7 @@ Design intent:
 from __future__ import annotations
 
 import hashlib
+import json
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -69,7 +70,7 @@ class ValidationPlan:
     blocking_preconditions: tuple[str, ...]
     success_criteria: tuple[str, ...]
     stop_conditions: tuple[dict[str, Any], ...] = field(
-        hash=False, compare=False
+        hash=False
     )
     schema_version: str = SCHEMA_VERSION
 
@@ -85,7 +86,7 @@ class ValidationPlan:
             "manual_review_needed": self.manual_review_needed,
             "blocking_preconditions": list(self.blocking_preconditions),
             "success_criteria": list(self.success_criteria),
-            "stop_conditions": list(self.stop_conditions),
+            "stop_conditions": [dict(stop) for stop in self.stop_conditions],
         }
 
 
@@ -95,6 +96,16 @@ class ValidationPlan:
 def _stable_id(*parts: str) -> str:
     joined = "|".join(parts)
     return hashlib.sha256(joined.encode()).hexdigest()[:16]
+
+
+def _stable_id_from_plan_content(content: dict[str, Any]) -> str:
+    payload = json.dumps(
+        content,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return _stable_id("plan", payload)
 
 
 def _resolve_payload(input_data: ValidationPlanInput) -> dict[str, Any]:
@@ -118,6 +129,36 @@ def _get_required_validation(payload: dict[str, Any]) -> dict[str, Any]:
     if isinstance(rv, dict):
         return rv
     return {}
+
+
+def _copy_stop_conditions(
+    stop_conditions: list[dict[str, Any]],
+) -> tuple[dict[str, Any], ...]:
+    copied: list[dict[str, Any]] = []
+    for stop_condition in stop_conditions:
+        if isinstance(stop_condition, dict):
+            copied.append(dict(stop_condition))
+    return tuple(copied)
+
+
+def _derive_manual_review_needed(
+    required_validation: dict[str, Any],
+    impact_level: str,
+    gate_risks: list[str],
+    blocking_preconditions: tuple[str, ...],
+    stop_conditions: tuple[dict[str, Any], ...],
+) -> bool:
+    explicit_flag = bool(required_validation.get("manual_review_needed", False))
+    blocking_stop_present = any(
+        stop.get("severity") == "blocking" for stop in stop_conditions
+    )
+    fail_closed_signals = (
+        impact_level in {"high", "blocking"}
+        or bool(gate_risks)
+        or bool(blocking_preconditions)
+        or blocking_stop_present
+    )
+    return explicit_flag or fail_closed_signals
 
 
 def _derive_required_checks(
@@ -289,7 +330,9 @@ def build_validation_plan(input_data: ValidationPlanInput) -> ValidationPlan:
     impact_id = payload.get("impact_id", "unknown")
     confidence = payload.get("confidence", "low")
     gate_risks: list[str] = payload.get("gate_risks", [])
-    stop_conditions: list[dict[str, Any]] = payload.get("stop_conditions", [])
+    raw_stop_conditions: list[dict[str, Any]] = payload.get(
+        "stop_conditions", []
+    )
 
     rv = _get_required_validation(payload)
 
@@ -301,9 +344,16 @@ def build_validation_plan(input_data: ValidationPlanInput) -> ValidationPlan:
     commands_to_consider: tuple[str, ...] = tuple(
         rv.get("commands_to_consider", [])
     )
-    manual_review_needed: bool = bool(rv.get("manual_review_needed", False))
     blocking_preconditions: tuple[str, ...] = tuple(
         rv.get("blocking_preconditions", [])
+    )
+    stop_conditions = _copy_stop_conditions(raw_stop_conditions)
+    manual_review_needed = _derive_manual_review_needed(
+        required_validation=rv,
+        impact_level=impact_level,
+        gate_risks=gate_risks,
+        blocking_preconditions=blocking_preconditions,
+        stop_conditions=stop_conditions,
     )
 
     has_artifacts = bool(payload.get("affected_artifacts", []))
@@ -316,7 +366,7 @@ def build_validation_plan(input_data: ValidationPlanInput) -> ValidationPlan:
         impact_level=impact_level,
         gate_risks=gate_risks,
         blocking_preconditions=list(blocking_preconditions),
-        stop_conditions=stop_conditions,
+        stop_conditions=list(stop_conditions),
     )
 
     success_criteria = _derive_success_criteria(
@@ -330,7 +380,22 @@ def build_validation_plan(input_data: ValidationPlanInput) -> ValidationPlan:
         has_stop_conditions=has_stop_conditions,
     )
 
-    plan_id = _stable_id("plan", impact_id, impact_level, confidence)
+    plan_id = _stable_id_from_plan_content(
+        {
+            "impact_id": impact_id,
+            "impact_level": impact_level,
+            "confidence": confidence,
+            "required_checks": required_checks,
+            "suggested_tests": suggested_tests,
+            "docs_to_review": docs_to_review,
+            "evidence_to_collect": evidence_to_collect,
+            "commands_to_consider": commands_to_consider,
+            "manual_review_needed": manual_review_needed,
+            "blocking_preconditions": blocking_preconditions,
+            "success_criteria": success_criteria,
+            "stop_conditions": stop_conditions,
+        }
+    )
 
     return ValidationPlan(
         plan_id=plan_id,
@@ -342,5 +407,5 @@ def build_validation_plan(input_data: ValidationPlanInput) -> ValidationPlan:
         manual_review_needed=manual_review_needed,
         blocking_preconditions=blocking_preconditions,
         success_criteria=tuple(success_criteria),
-        stop_conditions=tuple(stop_conditions),
+        stop_conditions=stop_conditions,
     )


### PR DESCRIPTION
## Summary

- Implements deterministic Validation Plan Generator v1 that consumes `ImpactReport` output from #2108 / PR #2319
- Produces `ValidationPlan` with required_checks, suggested_tests, docs_to_review, evidence_to_collect, commands_to_consider, manual_review_needed, blocking_preconditions, success_criteria, and stop_conditions
- Pure module — no DB, network, filesystem, GitHub write, MCP, or command execution
- Deterministic — same inputs always produce same outputs

Closes #2109
References #2108 / PR #2319 as input dependency
Prepares #2111 and #2112

## Files changed

- `tools/surrealdb/context_validation_plan.py` — Validation Plan Generator module (346 lines)
- `tests/unit/surrealdb/test_context_validation_plan.py` — 33 unit tests (897 lines)
- `docs/surrealdb/context-validation-plan-contract-v1.md` — Contract documentation (106 lines)

## Validation

```
pytest -v tests/unit/surrealdb/test_context_validation_plan.py -m unit  → 33 passed
pytest -v tests/unit/surrealdb/test_context_impact_radar.py -m unit      → 39 passed (regression)
pytest tests/unit/surrealdb/ -m unit                                     → 501 passed (full subset)
```

## Guardrails

- No DB write
- No command auto-run
- No GitHub write from generator
- No runtime/trading/live/echtgeld implication
- Blocking preconditions and stop conditions always propagated
- Commands are suggestions only (never auto-executed)