### PR TITLE
fix(workflows): trigger control board routing on PR updates

### DIFF
--- a/.github/workflows/control_board_auto_routing.yml
+++ b/.github/workflows/control_board_auto_routing.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [opened]
   pull_request:
-    types: [opened, closed]
+    types: [opened, reopened, synchronize, closed]
   repository_dispatch:
     types: [control_board_route_issue_label]
 


### PR DESCRIPTION
## Summary
- Adds `reopened` and `synchronize` to the `Control Board Auto Routing` pull_request trigger.
- Preserves existing `opened` and `closed` behavior.
- Fixes missing `route-control-board` status on rebased/force-pushed PR heads, observed on #2321.

## Why
PR #2321 became BLOCKED after rebase/force-push because `route-control-board` disappeared from the latest check rollup. The workflow currently only runs on `opened` and `closed`, not `synchronize`.

## Validation
- YAML parse check passed locally.
- Workflow diff only — one trigger line.
- No runtime, trading, SurrealDB production, LR, live or Echtgeld implication.

## Scope
- Only `.github/workflows/control_board_auto_routing.yml`