### PR TITLE
ci(security): enable CodeQL Python analysis

### DIFF
--- a/.github/workflows/codeql-python.yml
+++ b/.github/workflows/codeql-python.yml
@@ -28,7 +28,7 @@ jobs:
         uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v3
         with:
           languages: python
-          queries: default
+          queries: security-and-quality
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v3

--- a/.github/workflows/codeql-python.yml
+++ b/.github/workflows/codeql-python.yml
@@ -1,0 +1,36 @@
+name: CodeQL Python
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "21 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v3
+        with:
+          languages: python
+          queries: default
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v3
+        with:
+          category: "/language:python"


### PR DESCRIPTION
## Summary

Adds a repo-backed CodeQL Python workflow.

Current Security Inventory found three open CodeQL alerts that remain pinned to old commit `f7080af` because CodeQL default setup is currently `not-configured` and no CodeQL analysis workflow is running.

This PR enables explicit Python CodeQL analysis so the existing fixes from PR #2320/#2322 can be re-evaluated on current `main`.

## Scope

- Adds `.github/workflows/codeql-python.yml`
- No Trivy/Gitleaks/SARIF workflow changes
- No alert dismissals
- No security alert state mutation

## Validation

- `gh api repos/jannekbuengener/Claire_de_Binare/code-scanning/default-setup`
- `rg -n "CodeQL Python|github/codeql-action/init|github/codeql-action/analyze|languages: python|security-events: write" .github/workflows/codeql-python.yml`
- `git diff --stat`

## Security posture

- Repo-backed CodeQL enablement instead of UI-only default setup.
- No runtime, Docker, trading, risk, execution, or strategy change.
- No LR-/Live-/Echtgeld-Ableitung.