### PR TITLE
fix(security): avoid fetching secret scanning payloads in readout

### DIFF
--- a/scripts/audit/github_security_quality_readout.py
+++ b/scripts/audit/github_security_quality_readout.py
@@ -89,7 +89,7 @@ class SurfaceFetchResult:
     def to_dict(self) -> dict[str, Any]:
         if self.alert_count is not None:
             alert_count: int | None = self.alert_count
-        elif self.source == "secret_scanning" and self.status == "readable":
+        elif self.source == "secret_scanning":
             alert_count = None
         else:
             alert_count = len(self.alerts)
@@ -100,10 +100,8 @@ class SurfaceFetchResult:
             "alert_count": alert_count,
             "artifact_detail_status": (
                 "redacted"
-                if self.source == "secret_scanning" and self.status == "readable"
-                else "full"
-                if self.status == "readable"
-                else "none"
+                if self.source == "secret_scanning"
+                else "full" if self.status == "readable" else "none"
             ),
         }
         if self.note is not None:
@@ -181,10 +179,25 @@ def fetch_surface(
     source: str,
     repo: str,
     gh_executable: str = DEFAULT_GH_EXECUTABLE,
-    runner: Callable[[list[str]], subprocess.CompletedProcess[str]] = _completed_process_runner,
+    runner: Callable[
+        [list[str]], subprocess.CompletedProcess[str]
+    ] = _completed_process_runner,
 ) -> SurfaceFetchResult:
     if source not in SURFACE_ENDPOINTS:
         raise SecurityQualityReadoutError(f"Unsupported source: {source}")
+
+    if source == "secret_scanning":
+        return SurfaceFetchResult(
+            source="secret_scanning",
+            endpoint=SURFACE_ENDPOINTS[source].format(repo=repo),
+            status="redacted",
+            alerts=(),
+            alert_count=None,
+            note=(
+                "not-fetched: secret-scanning alert payloads are intentionally "
+                "not requested or persisted"
+            ),
+        )
 
     endpoint = SURFACE_ENDPOINTS[source].format(repo=repo)
     command = [gh_executable, "api", "--paginate", "--slurp", endpoint]
@@ -252,18 +265,6 @@ def fetch_surface(
                 )
             alerts.append(item)
 
-    if source == "secret_scanning":
-        return SurfaceFetchResult(
-            source=source,
-            endpoint=endpoint,
-            status="readable",
-            alerts=(),
-            note=(
-                "payload-redacted: alert details and counts are intentionally "
-                "excluded from persisted artifacts"
-            ),
-        )
-
     return SurfaceFetchResult(
         source=source,
         endpoint=endpoint,
@@ -288,14 +289,16 @@ def normalize_code_scanning_alert(
         else {}
     )
     path = location.get("path") if isinstance(location.get("path"), str) else None
-    created_at = raw.get("created_at") if isinstance(raw.get("created_at"), str) else None
-    updated_at = raw.get("updated_at") if isinstance(raw.get("updated_at"), str) else None
+    created_at = (
+        raw.get("created_at") if isinstance(raw.get("created_at"), str) else None
+    )
+    updated_at = (
+        raw.get("updated_at") if isinstance(raw.get("updated_at"), str) else None
+    )
     subject = (
         rule.get("id")
         if isinstance(rule.get("id"), str) and rule.get("id")
-        else rule.get("name")
-        if isinstance(rule.get("name"), str)
-        else "unknown"
+        else rule.get("name") if isinstance(rule.get("name"), str) else "unknown"
     )
     tool = raw.get("tool", {}) if isinstance(raw.get("tool"), dict) else {}
     return {
@@ -328,17 +331,29 @@ def normalize_code_scanning_alert(
 def normalize_dependabot_alert(
     raw: dict[str, Any], *, reference_now: datetime
 ) -> dict[str, Any]:
-    dependency = raw.get("dependency", {}) if isinstance(raw.get("dependency"), dict) else {}
-    package = dependency.get("package", {}) if isinstance(dependency.get("package"), dict) else {}
+    dependency = (
+        raw.get("dependency", {}) if isinstance(raw.get("dependency"), dict) else {}
+    )
+    package = (
+        dependency.get("package", {})
+        if isinstance(dependency.get("package"), dict)
+        else {}
+    )
     advisory = (
         raw.get("security_advisory", {})
         if isinstance(raw.get("security_advisory"), dict)
         else {}
     )
     package_name = package.get("name") if isinstance(package.get("name"), str) else None
-    ghsa_id = advisory.get("ghsa_id") if isinstance(advisory.get("ghsa_id"), str) else None
-    created_at = raw.get("created_at") if isinstance(raw.get("created_at"), str) else None
-    updated_at = raw.get("updated_at") if isinstance(raw.get("updated_at"), str) else None
+    ghsa_id = (
+        advisory.get("ghsa_id") if isinstance(advisory.get("ghsa_id"), str) else None
+    )
+    created_at = (
+        raw.get("created_at") if isinstance(raw.get("created_at"), str) else None
+    )
+    updated_at = (
+        raw.get("updated_at") if isinstance(raw.get("updated_at"), str) else None
+    )
     return {
         "source": "dependabot",
         "number": raw.get("number"),
@@ -365,8 +380,12 @@ def normalize_dependabot_alert(
 def normalize_secret_scanning_alert(
     raw: dict[str, Any], *, reference_now: datetime
 ) -> dict[str, Any]:
-    created_at = raw.get("created_at") if isinstance(raw.get("created_at"), str) else None
-    updated_at = raw.get("updated_at") if isinstance(raw.get("updated_at"), str) else None
+    created_at = (
+        raw.get("created_at") if isinstance(raw.get("created_at"), str) else None
+    )
+    updated_at = (
+        raw.get("updated_at") if isinstance(raw.get("updated_at"), str) else None
+    )
     return {
         "source": "secret_scanning",
         "number": raw.get("number"),
@@ -404,13 +423,19 @@ def normalize_alert(
     raise SecurityQualityReadoutError(f"Unsupported source: {source}")
 
 
-def _counter_items(counter: Counter[str], preferred_order: tuple[str, ...] = ()) -> list[dict[str, Any]]:
+def _counter_items(
+    counter: Counter[str], preferred_order: tuple[str, ...] = ()
+) -> list[dict[str, Any]]:
     order_map = {value: index for index, value in enumerate(preferred_order)}
     return [
         {"value": key, "count": count}
         for key, count in sorted(
             counter.items(),
-            key=lambda item: (-item[1], order_map.get(item[0], len(order_map)), item[0]),
+            key=lambda item: (
+                -item[1],
+                order_map.get(item[0], len(order_map)),
+                item[0],
+            ),
         )
     ]
 
@@ -429,13 +454,12 @@ def build_summary(
     top_components = Counter(
         (
             alert.get("affected_path")
-            if isinstance(alert.get("affected_path"), str) and alert.get("affected_path")
+            if isinstance(alert.get("affected_path"), str)
+            and alert.get("affected_path")
             else alert.get("affected_component")
         )
         for alert in alerts
-        if (
-            isinstance(alert.get("affected_path"), str) and alert.get("affected_path")
-        )
+        if (isinstance(alert.get("affected_path"), str) and alert.get("affected_path"))
         or (
             isinstance(alert.get("affected_component"), str)
             and alert.get("affected_component")
@@ -490,7 +514,9 @@ def build_markdown_report(readout: dict[str, Any]) -> str:
     add_counter_section("Top Components or Paths", summary["top_components"])
 
     unavailable = [
-        surface for surface in readout["surfaces"] if surface["status"] != "readable"
+        surface
+        for surface in readout["surfaces"]
+        if surface["status"] not in ("readable", "redacted")
     ]
     redacted = [
         surface
@@ -543,12 +569,14 @@ def build_readout(
     readable_surfaces = 0
     readable_surface_counts: Counter[str] = Counter()
     for surface in fetched_surfaces:
-        if surface.status == "readable":
+        if surface.status in ("readable", "redacted"):
             readable_surfaces += 1
             if surface.source == "secret_scanning":
                 continue
             surface_alert_count = (
-                surface.alert_count if surface.alert_count is not None else len(surface.alerts)
+                surface.alert_count
+                if surface.alert_count is not None
+                else len(surface.alerts)
             )
             if surface_alert_count:
                 readable_surface_counts[surface.source] += surface_alert_count
@@ -669,7 +697,9 @@ def build_exportable_readout(readout: dict[str, Any]) -> dict[str, Any]:
                 ),
                 "age_bucket": str(alert["age_bucket"]),
                 "url": str(alert["url"]) if isinstance(alert.get("url"), str) else None,
-                "tool": str(alert["tool"]) if isinstance(alert.get("tool"), str) else None,
+                "tool": (
+                    str(alert["tool"]) if isinstance(alert.get("tool"), str) else None
+                ),
             }
         )
 
@@ -698,84 +728,96 @@ def build_exportable_readout(readout: dict[str, Any]) -> dict[str, Any]:
 def build_persistable_readout(readout: dict[str, Any]) -> dict[str, Any]:
     """
     Build a readout structure safe for persistence (JSON/Markdown export).
-    
+
     Excludes secret_scanning alerts entirely and replaces their summary
     entries with coverage-only markers to avoid taint tracking of secret
     payloads through to file I/O sinks.
-    
+
     Only code_scanning and dependabot alerts are included in the
     persisted output.
     """
     persistable_surfaces: list[dict[str, Any]] = []
     for surface in readout["surfaces"]:
         if surface["source"] == "secret_scanning":
-            persistable_surfaces.append({
-                "source": "secret_scanning",
-                "endpoint": str(surface["endpoint"]),
-                "status": str(surface["status"]),
-                "alert_count": None,
-                "artifact_detail_status": "redacted",
-                "note": "payload-redacted: secret scanning details excluded from artifacts",
-            })
+            persistable_surfaces.append(
+                {
+                    "source": "secret_scanning",
+                    "endpoint": str(surface["endpoint"]),
+                    "status": str(surface["status"]),
+                    "alert_count": None,
+                    "artifact_detail_status": "redacted",
+                    "note": "payload-redacted: secret scanning details excluded from artifacts",
+                }
+            )
         else:
-            persistable_surfaces.append({
-                "source": str(surface["source"]),
-                "endpoint": str(surface["endpoint"]),
-                "status": str(surface["status"]),
-                "alert_count": (
-                    int(surface["alert_count"])
-                    if surface["alert_count"] is not None
-                    else None
-                ),
-                "artifact_detail_status": str(surface["artifact_detail_status"]),
-            })
+            persistable_surfaces.append(
+                {
+                    "source": str(surface["source"]),
+                    "endpoint": str(surface["endpoint"]),
+                    "status": str(surface["status"]),
+                    "alert_count": (
+                        int(surface["alert_count"])
+                        if surface["alert_count"] is not None
+                        else None
+                    ),
+                    "artifact_detail_status": str(surface["artifact_detail_status"]),
+                }
+            )
             if isinstance(surface.get("note"), str):
                 persistable_surfaces[-1]["note"] = surface["note"]
 
     persistable_alerts: list[dict[str, Any]] = []
     for alert in readout["alerts"]:
         if alert["source"] != "secret_scanning":
-            persistable_alerts.append({
-                "source": str(alert["source"]),
-                "number": alert.get("number"),
-                "state": str(alert["state"]),
-                "severity": str(alert["severity"]),
-                "subject": str(alert["subject"]),
-                "rule_or_advisory": (
-                    str(alert["rule_or_advisory"])
-                    if isinstance(alert.get("rule_or_advisory"), str)
-                    else None
-                ),
-                "package": (
-                    str(alert["package"])
-                    if isinstance(alert.get("package"), str)
-                    else None
-                ),
-                "affected_path": (
-                    str(alert["affected_path"])
-                    if isinstance(alert.get("affected_path"), str)
-                    else None
-                ),
-                "affected_component": (
-                    str(alert["affected_component"])
-                    if isinstance(alert.get("affected_component"), str)
-                    else None
-                ),
-                "branch": str(alert["branch"]),
-                "created_at": (
-                    str(alert["created_at"])
-                    if isinstance(alert.get("created_at"), str)
-                    else None
-                ),
-                "updated_at": (
-                    str(alert["updated_at"])
-                    if isinstance(alert.get("updated_at"), str)
-                    else None
-                ),
-                "age_bucket": str(alert["age_bucket"]),
-                "url": str(alert["url"]) if isinstance(alert.get("url"), str) else None,
-                "tool": str(alert["tool"]) if isinstance(alert.get("tool"), str) else None,
-            })
+            persistable_alerts.append(
+                {
+                    "source": str(alert["source"]),
+                    "number": alert.get("number"),
+                    "state": str(alert["state"]),
+                    "severity": str(alert["severity"]),
+                    "subject": str(alert["subject"]),
+                    "rule_or_advisory": (
+                        str(alert["rule_or_advisory"])
+                        if isinstance(alert.get("rule_or_advisory"), str)
+                        else None
+                    ),
+                    "package": (
+                        str(alert["package"])
+                        if isinstance(alert.get("package"), str)
+                        else None
+                    ),
+                    "affected_path": (
+                        str(alert["affected_path"])
+                        if isinstance(alert.get("affected_path"), str)
+                        else None
+                    ),
+                    "affected_component": (
+                        str(alert["affected_component"])
+                        if isinstance(alert.get("affected_component"), str)
+                        else None
+                    ),
+                    "branch": str(alert["branch"]),
+                    "created_at": (
+                        str(alert["created_at"])
+                        if isinstance(alert.get("created_at"), str)
+                        else None
+                    ),
+                    "updated_at": (
+                        str(alert["updated_at"])
+                        if isinstance(alert.get("updated_at"), str)
+                        else None
+                    ),
+                    "age_bucket": str(alert["age_bucket"]),
+                    "url": (
+                        str(alert["url"]) if isinstance(alert.get("url"), str) else None
+                    ),
+                    "tool": (
+                        str(alert["tool"])
+                        if isinstance(alert.get("tool"), str)
+                        else None
+                    ),
+                }
+            )
 
     summary = readout["summary"]
     persistable_summary = {
@@ -799,9 +841,7 @@ def build_persistable_readout(readout: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def write_report_artifacts(
-    persistable_readout: dict[str, Any], out_dir: Path
-) -> None:
+def write_report_artifacts(persistable_readout: dict[str, Any], out_dir: Path) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     json_path = out_dir / JSON_FILENAME
     markdown_path = out_dir / MARKDOWN_FILENAME
@@ -821,7 +861,9 @@ def generate_readout(
     out_dir: Path,
     reference_now_utc: str | None = None,
     gh_executable: str = DEFAULT_GH_EXECUTABLE,
-    runner: Callable[[list[str]], subprocess.CompletedProcess[str]] = _completed_process_runner,
+    runner: Callable[
+        [list[str]], subprocess.CompletedProcess[str]
+    ] = _completed_process_runner,
 ) -> dict[str, Any]:
     if reference_now_utc is None:
         reference_now_utc = _utc_now_iso()

--- a/tests/unit/audit/test_github_security_quality_readout.py
+++ b/tests/unit/audit/test_github_security_quality_readout.py
@@ -151,9 +151,11 @@ class TestFetchSurface:
 
     def test_fetch_surface_marks_invalid_page_shape_unavailable(self):
         result = fetch_surface(
-            source="secret_scanning",
+            source="code_scanning",
             repo="octo/example",
-            runner=lambda command: _completed_process(stdout=json.dumps([{"bad": "shape"}])),
+            runner=lambda command: _completed_process(
+                stdout=json.dumps([{"bad": "shape"}])
+            ),
         )
 
         assert result.status == "unavailable"
@@ -175,28 +177,19 @@ class TestFetchSurface:
         assert result.note == "gh api returned no stdout payload"
 
     def test_fetch_surface_redacts_secret_scanning_payload_before_persistence(self):
+        def _runner_must_not_be_called(*_args, **_kwargs):
+            raise AssertionError("runner must not be called for secret_scanning")
+
         result = fetch_surface(
             source="secret_scanning",
             repo="octo/example",
-            runner=lambda command: _completed_process(
-                stdout=json.dumps(
-                    [[
-                        {
-                            "number": 9,
-                            "state": "resolved",
-                            "secret_type": "generic_api_key",
-                            "secret_type_display_name": "Generic API Key",
-                            "first_location_detected": {"path": ".env"},
-                        }
-                    ]]
-                )
-            ),
+            runner=_runner_must_not_be_called,
         )
 
-        assert result.status == "readable"
+        assert result.status == "redacted"
         assert result.alert_count is None
         assert result.alerts == ()
-        assert "payload-redacted" in (result.note or "")
+        assert "not-fetched" in (result.note or "")
 
 
 class TestReadoutGeneration:
@@ -215,7 +208,10 @@ class TestReadoutGeneration:
                             "state": "open",
                             "created_at": "2026-04-22T00:00:00Z",
                             "updated_at": "2026-04-22T00:00:00Z",
-                            "rule": {"id": "py/sql-injection", "security_severity_level": "critical"},
+                            "rule": {
+                                "id": "py/sql-injection",
+                                "security_severity_level": "critical",
+                            },
                             "most_recent_instance": {
                                 "ref": "refs/heads/main",
                                 "location": {"path": "app/db.py"},
@@ -271,18 +267,8 @@ class TestReadoutGeneration:
                 SurfaceFetchResult(
                     source="secret_scanning",
                     endpoint="repos/octo/example/secret-scanning/alerts?per_page=100",
-                    status="readable",
-                    alerts=(
-                        {
-                            "number": 3,
-                            "state": "resolved",
-                            "created_at": "2026-04-01T00:00:00Z",
-                            "updated_at": "2026-04-02T00:00:00Z",
-                            "secret_type": "generic_api_key",
-                            "secret_type_display_name": "Generic API Key",
-                            "first_location_detected": {"path": ".env"},
-                        },
-                    ),
+                    status="redacted",
+                    alerts=(),
                 ),
             ],
         )
@@ -294,12 +280,12 @@ class TestReadoutGeneration:
         assert readout["alerts"] == []
 
         markdown = build_markdown_report(readout)
+        assert "Secret-Scanning bleibt in der Surface-Coverage sichtbar" in markdown
         assert (
-            "Secret-Scanning bleibt in der Surface-Coverage sichtbar"
+            "Secret-Scanning-Detailfelder werden im Artefakt absichtlich redigiert"
             in markdown
         )
-        assert "Secret-Scanning-Detailfelder werden im Artefakt absichtlich redigiert" in markdown
-        assert "| `secret_scanning` | readable | redacted |" in markdown
+        assert "| `secret_scanning` | redacted | redacted |" in markdown
 
     def test_generate_readout_writes_deterministic_artifacts(self, tmp_path):
         pages_by_source = {
@@ -338,24 +324,21 @@ class TestReadoutGeneration:
                     },
                 }
             ],
-            "secret_scanning": [
-                {
-                    "number": 12,
-                    "state": "resolved",
-                    "created_at": "2026-04-01T00:00:00Z",
-                    "updated_at": "2026-04-02T00:00:00Z",
-                    "html_url": "https://example.invalid/secret/12",
-                    "secret_type": "generic_api_key",
-                    "secret_type_display_name": "Generic API Key",
-                    "first_location_detected": {"path": ".env"},
-                }
-            ],
         }
+
+        _secret_scanning_calls = []
 
         def runner(command: list[str]) -> subprocess.CompletedProcess[str]:
             endpoint = command[-1]
+            if "secret-scanning" in endpoint:
+                _secret_scanning_calls.append(command)
+                raise AssertionError("secret_scanning must not call runner")
             for source, page in pages_by_source.items():
-                if f"/{source.replace('_', '-')}/" in endpoint or source == "code_scanning" and "/code-scanning/" in endpoint:
+                if (
+                    f"/{source.replace('_', '-')}/" in endpoint
+                    or source == "code_scanning"
+                    and "/code-scanning/" in endpoint
+                ):
                     return _completed_process(stdout=json.dumps([page]))
             raise AssertionError(f"Unexpected command endpoint: {endpoint}")
 
@@ -379,21 +362,22 @@ class TestReadoutGeneration:
         assert first == second
         assert first["status"] == "PASS"
         assert first["summary"]["total_alerts"] == 2
+        assert not _secret_scanning_calls
         assert len(first["alerts"]) == 2
         assert first["summary"]["counts_by_source"] == [
             {"value": "code_scanning", "count": 1},
             {"value": "dependabot", "count": 1},
         ]
-        assert first["summary"]["counts_by_state"] == [
-            {"value": "open", "count": 2}
-        ]
+        assert first["summary"]["counts_by_state"] == [{"value": "open", "count": 2}]
         assert first["summary"]["counts_by_severity"] == [
             {"value": "high", "count": 1},
             {"value": "medium", "count": 1},
         ]
         exported = json.loads((out_dir_a / JSON_FILENAME).read_text(encoding="utf-8"))
         secret_surface = next(
-            surface for surface in exported["surfaces"] if surface["source"] == "secret_scanning"
+            surface
+            for surface in exported["surfaces"]
+            if surface["source"] == "secret_scanning"
         )
         assert secret_surface["alert_count"] is None
         assert (out_dir_a / JSON_FILENAME).read_text(encoding="utf-8") == (


### PR DESCRIPTION
## Summary

Follow-up for CodeQL alerts #3659 and #3660.

The previous redaction approach still fetched Secret-Scanning alert payloads before producing redacted artifacts. CodeQL continued to identify a sensitive-data flow into JSON/Markdown file writes.

This PR changes the readout behavior so Secret-Scanning alert payloads are not requested at all. The report keeps a coverage-only Secret-Scanning surface marker, but does not fetch, normalize, count, or persist Secret-Scanning details.

## Alerts

- #3659 — `py/clear-text-storage-sensitive-data`
- #3660 — `py/clear-text-storage-sensitive-data`

## Scope

- `scripts/audit/github_security_quality_readout.py`
- `tests/unit/audit/test_github_security_quality_readout.py`

## Validation

- `python -m pytest -q tests/unit/audit/test_github_security_quality_readout.py`
- `python scripts/audit/github_security_quality_readout.py --repo jannekbuengener/Claire_de_Binare --out-dir artifacts/security-alert-readout/codeql-secret-flow-followup`
- `python -m black --check scripts/audit/github_security_quality_readout.py tests/unit/audit/test_github_security_quality_readout.py`

## Security posture

- No alert dismissals.
- No CodeQL suppressions.
- No Secret-Scanning alert payload fetch.
- No Secret-Scanning details persisted.
- No Trivy/Gitleaks/SARIF workflow changes.
- No runtime, Docker, trading, risk, execution, or strategy change.
- No LR-/Live-/Echtgeld-Ableitung.