### PR TITLE
feat(context): add cdb context briefing MCP alias

### DIFF
--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -8,6 +8,8 @@ import pytest
 from tools.mcp.context_bridge import ContextBridge, create_bridge
 from tools.mcp.registry import ContextToolRegistry, ToolDefinition
 
+pytestmark = pytest.mark.unit
+
 
 class TestContextToolRegistry:
     """Tests for the Context Tool Registry."""
@@ -227,11 +229,13 @@ class TestContextBridge:
         """Verify list_tools returns all v0 tools."""
         bridge = ContextBridge()
         tools = bridge.list_tools()
-        assert len(tools) == 11
+        # v0 tool set (11) + #2110 alias (cdb_context_briefing)
+        assert len(tools) == 12
         tool_names = [t["name"] for t in tools]
         assert "context.search" in tool_names
         assert "context.package" in tool_names
         assert "context.self_explain" in tool_names
+        assert "cdb_context_briefing" in tool_names
 
     def test_get_tool_schema(self) -> None:
         """Verify get_tool_schema returns schema."""
@@ -260,7 +264,7 @@ class TestContextBridge:
         bridge = ContextBridge()
         status = bridge.get_read_only_status()
         assert status["enforced"] is True
-        assert len(status["read_only_tools"]) == 11
+        assert len(status["read_only_tools"]) == 12
 
 
 class TestDefensiveSchemaCopies:
@@ -1589,6 +1593,79 @@ class TestContextBriefingHandler:
         assert r1["status"] == "ok"
         assert r2["status"] == "ok"
         assert r1["briefing"]["briefing_id"] != r2["briefing"]["briefing_id"]
+
+
+class TestCdbContextBriefingAlias:
+    """Tests for cdb_context_briefing alias tool handler (#2110)."""
+
+    def test_alias_tool_in_list_tools(self) -> None:
+        bridge = create_bridge()
+        tool_names = [t["name"] for t in bridge.list_tools()]
+        assert "cdb_context_briefing" in tool_names
+
+    def test_alias_schema_is_present_and_read_only(self) -> None:
+        bridge = create_bridge()
+        schema = bridge.get_tool_schema("cdb_context_briefing")
+        assert schema is not None
+        assert schema["readOnly"] is True
+
+    def test_quick_standard_deep_execute_via_alias(self) -> None:
+        bridge = create_bridge()
+        base = {
+            "task_id": "cdb-briefing-2110-alias",
+            "task_scope": "Implement context briefing MCP tool alias wrapper.",
+            "target_issue": "#2110",
+            "operation_mode": "read_only",
+        }
+        for depth in ("quick", "standard", "deep"):
+            result = bridge.execute_tool(
+                "cdb_context_briefing",
+                {**base, "requested_depth": depth},
+            )
+            assert result["status"] == "ok"
+            assert result["tool"] == "cdb_context_briefing"
+            briefing = result["briefing"]
+            assert "stop_conditions" in briefing
+            assert "guardrails" in briefing
+            assert "human_go_required" in briefing
+
+    def test_alias_preserves_stop_conditions_guardrails_human_go_visibility(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_briefing",
+            {
+                "task_id": "cdb-briefing-2110-visibility",
+                "task_scope": "Scope: read-only; stop if Human-GO required.",
+                "target_issue": "#2110",
+                "requested_depth": "standard",
+                "operation_mode": "write (MCP live)",
+                "target_paths": ["tools/mcp/context_bridge.py"],
+                "target_symbols": ["cdb_context_briefing_handler"],
+            },
+        )
+        assert result["status"] == "ok"
+        assert result["tool"] == "cdb_context_briefing"
+        briefing = result["briefing"]
+        assert isinstance(briefing["guardrails"], list) and briefing["guardrails"]
+        assert isinstance(briefing["stop_conditions"], list)
+        assert isinstance(briefing["known_risks"], list)
+        assert isinstance(briefing["human_go_required"], bool)
+
+    def test_alias_payload_limit_fails_closed(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_briefing",
+            {
+                "task_id": "cdb-briefing-2110-too-large",
+                "task_scope": "x" * 250_000,
+                "target_issue": "#2110",
+                "requested_depth": "deep",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["tool"] == "cdb_context_briefing"
+        assert result["error"]["code"] == "payload_too_large"
 
 
 class TestContextStopResolverHandler:

--- a/tests/unit/tools/mcp/test_output_contracts.py
+++ b/tests/unit/tools/mcp/test_output_contracts.py
@@ -10,6 +10,8 @@ implemented v0 structure.
 import pytest
 from tools.mcp.context_bridge import create_bridge
 
+pytestmark = pytest.mark.unit
+
 
 COMMON_OK_FIELDS = {"tool", "status"}
 
@@ -296,6 +298,43 @@ class TestBriefingOutputContract:
                 "operation_mode": "read_only",
             },
         )
+        assert "guardrails" in result["briefing"]
+        assert isinstance(result["briefing"]["guardrails"], list)
+        assert len(result["briefing"]["guardrails"]) > 0
+
+
+class TestCdbContextBriefingAliasOutputContract:
+    """Verify cdb_context_briefing alias output matches briefing contract."""
+
+    def test_ok_output_has_briefing_id_and_alias_tool_name(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_briefing",
+            {
+                "task_id": "task_alias_001",
+                "target_issue": None,
+                "task_scope": "review docs",
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["tool"] == "cdb_context_briefing"
+        assert "briefing" in result
+        assert "briefing_id" in result["briefing"]
+
+    def test_alias_briefing_has_guardrails(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_briefing",
+            {
+                "task_id": "task_alias_002",
+                "target_issue": None,
+                "task_scope": "check status",
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["tool"] == "cdb_context_briefing"
         assert "guardrails" in result["briefing"]
         assert isinstance(result["briefing"]["guardrails"], list)
         assert len(result["briefing"]["guardrails"]) > 0

--- a/tests/unit/tools/mcp/test_permission_guard.py
+++ b/tests/unit/tools/mcp/test_permission_guard.py
@@ -29,6 +29,8 @@ from tools.mcp.permission_guard import (
 )
 from tools.mcp.registry import ContextToolRegistry, ToolDefinition
 
+pytestmark = pytest.mark.unit
+
 
 # ---------------------------------------------------------------------------
 # 1. Registry Gate
@@ -238,6 +240,7 @@ class TestInputGateToolClassification:
         """Structural tools are in INPUT_SCAN_EXEMPT_TOOLS."""
         assert "context.readiness" in INPUT_SCAN_EXEMPT_TOOLS
         assert "context.briefing" in INPUT_SCAN_EXEMPT_TOOLS
+        assert "cdb_context_briefing" in INPUT_SCAN_EXEMPT_TOOLS
         assert "context.self_explain" in INPUT_SCAN_EXEMPT_TOOLS
         assert "context.stop_resolver" in INPUT_SCAN_EXEMPT_TOOLS
         assert "context.required_reads" in INPUT_SCAN_EXEMPT_TOOLS
@@ -260,6 +263,19 @@ class TestInputGateToolClassification:
         results = PermissionGuard.check_tool_inputs(
             "context.briefing",
             {"task_scope": "Update config infrastructure"},
+        )
+        assert len(results) == 0
+
+    def test_cdb_context_briefing_exempt_tool_returns_empty_violations(self) -> None:
+        """cdb_context_briefing is exempt from input scanning (alias)."""
+        results = PermissionGuard.check_tool_inputs(
+            "cdb_context_briefing",
+            {
+                "task_scope": (
+                    "Plan: write (code/docs) only with Human-GO; "
+                    "no docker compose up; no DB writes."
+                )
+            },
         )
         assert len(results) == 0
 

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -11,6 +11,7 @@ Reference:
 """
 
 import logging
+import json
 from copy import deepcopy
 from typing import Any, Optional
 
@@ -18,6 +19,8 @@ from tools.mcp.permission_guard import PermissionGuard
 from tools.mcp.registry import ContextToolRegistry, ToolDefinition
 
 logger = logging.getLogger(__name__)
+
+CDB_CONTEXT_BRIEFING_MAX_RESPONSE_BYTES = 200_000
 
 
 def context_search_handler(**kwargs) -> dict[str, Any]:
@@ -1207,6 +1210,66 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
     }
 
 
+def cdb_context_briefing_handler(**kwargs) -> dict[str, Any]:
+    """Alias wrapper for context.briefing (#2110).
+
+    - Delegates to context_briefing_handler(**kwargs)
+    - Rewrites tool name to cdb_context_briefing
+    - Enforces a deterministic byte-size limit fail-closed
+    """
+    result = context_briefing_handler(**kwargs)
+    if not isinstance(result, dict):
+        return {
+            "tool": "cdb_context_briefing",
+            "status": "error",
+            "error": {
+                "code": "execution_error",
+                "message": "context_briefing_handler returned non-dict result",
+            },
+        }
+
+    result["tool"] = "cdb_context_briefing"
+
+    try:
+        response_bytes = len(
+            json.dumps(
+                result,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            ).encode("utf-8")
+        )
+    except Exception as e:
+        logger.exception("Failed to measure cdb_context_briefing payload size")
+        return {
+            "tool": "cdb_context_briefing",
+            "status": "error",
+            "error": {
+                "code": "execution_error",
+                "message": str(e),
+            },
+        }
+
+    if response_bytes > CDB_CONTEXT_BRIEFING_MAX_RESPONSE_BYTES:
+        return {
+            "tool": "cdb_context_briefing",
+            "status": "error",
+            "error": {
+                "code": "payload_too_large",
+                "message": (
+                    "cdb_context_briefing response exceeds byte limit; "
+                    "reduce requested_depth or narrow scope."
+                ),
+                "details": {
+                    "max_bytes": CDB_CONTEXT_BRIEFING_MAX_RESPONSE_BYTES,
+                    "actual_bytes": response_bytes,
+                },
+            },
+        }
+
+    return result
+
+
 def context_stop_resolver_handler(**kwargs) -> dict[str, Any]:
     """
     Read-only handler for context.stop_resolver tool.
@@ -1500,6 +1563,17 @@ class ContextBridge:
                 handler=context_briefing_handler,
             )
             self._registry._tools["context.briefing"] = new_briefing
+        old_cdb_briefing = self._registry.get_tool("cdb_context_briefing")
+        if old_cdb_briefing:
+            new_cdb_briefing = ToolDefinition(
+                name=old_cdb_briefing.name,
+                description=old_cdb_briefing.description,
+                input_schema=old_cdb_briefing.input_schema,
+                output_schema=old_cdb_briefing.output_schema,
+                read_only=old_cdb_briefing.read_only,
+                handler=cdb_context_briefing_handler,
+            )
+            self._registry._tools["cdb_context_briefing"] = new_cdb_briefing
         old_stop_resolver = self._registry.get_tool("context.stop_resolver")
         if old_stop_resolver:
             new_stop_resolver = ToolDefinition(

--- a/tools/mcp/permission_guard.py
+++ b/tools/mcp/permission_guard.py
@@ -124,6 +124,7 @@ INPUT_SCAN_TOOLS: frozenset[str] = frozenset({
 INPUT_SCAN_EXEMPT_TOOLS: frozenset[str] = frozenset({
     "context.readiness",
     "context.briefing",
+    "cdb_context_briefing",
     "context.self_explain",
     "context.stop_resolver",
     "context.required_reads",

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -7,6 +7,7 @@ Each tool is mapped to its contract and handler placeholder.
 Reference: docs/surrealdb/context-tool-contracts-v0.md
 """
 
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Callable, Optional
 
@@ -682,6 +683,26 @@ def register_all_tools() -> None:
     """Register all v0 tools with the registry."""
     for tool in TOOLS_V0:
         ContextToolRegistry.register(tool)
+
+    # #2110: Provide a stable alias for the briefing tool without renaming it.
+    # The alias schema is deep-copied from context.briefing to prevent drift.
+    base = ContextToolRegistry.get_tool("context.briefing")
+    if base is not None and ContextToolRegistry.get_tool("cdb_context_briefing") is None:
+        ContextToolRegistry.register(
+            ToolDefinition(
+                name="cdb_context_briefing",
+                description=(
+                    "Alias for context.briefing. Generate a task-specific Agent "
+                    "Briefing v1 from Briefing Request schema "
+                    "(docs/surrealdb/context-agent-briefing-schema-v1.md). "
+                    "Read-only, no authorization, no Live/Echtgeld Go."
+                ),
+                input_schema=deepcopy(base.input_schema),
+                output_schema=deepcopy(base.output_schema),
+                read_only=True,
+                handler=create_not_implemented_handler("cdb_context_briefing"),
+            )
+        )
 
 
 register_all_tools()


### PR DESCRIPTION
## Summary

- Adds `cdb_context_briefing` as a read-only alias for the existing `context.briefing` MCP tool.
- Reuses the existing `context.briefing` schema via deepcopy to avoid alias/schema drift.
- Wires the alias through `ContextBridge` to delegate to `context_briefing_handler`.
- Enforces a fail-closed response byte limit with `payload_too_large`.
- Keeps stop conditions, guardrails, known risks, and `human_go_required` visible in the briefing output.
- Adds permission-guard exemption for the structural alias tool.

Closes #2110

## Validation

- `pytest -v tests/unit/tools/mcp/test_context_bridge.py -m unit` → 169 passed
- `pytest -v tests/unit/tools/mcp/test_output_contracts.py -m unit` → 25 passed
- `pytest tests/unit/tools/mcp/ -m unit` → 330 passed, 44 deselected

## Guardrails

- Read-only MCP alias only.
- No DB write.
- No memory write.
- No runtime/trading/live/echtgeld implication.
- No Security-scope changes.