### PR TITLE
fix(security): sanitize kill-switch log fields

### DIFF
--- a/core/safety/kill_switch.py
+++ b/core/safety/kill_switch.py
@@ -11,6 +11,7 @@ CRITICAL SAFETY:
 
 import os
 import logging
+import re
 from pathlib import Path
 from typing import Optional, Tuple
 from enum import Enum
@@ -18,6 +19,17 @@ from enum import Enum
 from core.utils.clock import utcnow
 
 logger = logging.getLogger(__name__)
+
+
+def _sanitize_for_log(value: str) -> str:
+    """Neutralize CR, LF, and control characters for safe log output.
+
+    Replaces \\r and \\n with escaped literal sequences and strips
+    other control characters (0x00-0x08, 0x0b, 0x0c, 0x0e-0x1f)
+    to prevent log injection attacks.
+    """
+    value = value.replace("\r", "\\r").replace("\n", "\\n")
+    return re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", "", value)
 
 
 class KillSwitchState(Enum):
@@ -146,7 +158,7 @@ class KillSwitch:
             logger.critical(f"CRITICAL: Failed to write kill-switch state: {e}")
             # If we can't write state, log loudly
             logger.critical(
-                f"Intended state: {state.value}, reason: {reason}, message: {message}"
+                f"Intended state: {state.value}, reason: {reason}, message: {_sanitize_for_log(message)}"
             )
 
     def is_active(self) -> bool:
@@ -239,7 +251,7 @@ class KillSwitch:
         logger.warning("=" * 80)
         logger.warning("🚨 KILL-SWITCH ACTIVATED - ALL TRADING STOPPED 🚨")
         logger.warning(f"Reason: {reason.value}")
-        logger.warning(f"Message: {full_message}")
+        logger.warning(f"Message: {_sanitize_for_log(full_message)}")
         logger.warning(f"Activated at: {activated_at}")
         logger.warning("=" * 80)
 
@@ -280,8 +292,8 @@ class KillSwitch:
 
         logger.warning("=" * 80)
         logger.warning("✅ KILL-SWITCH DEACTIVATED - TRADING RESUMED")
-        logger.warning(f"Operator: {operator}")
-        logger.warning(f"Justification: {justification}")
+        logger.warning(f"Operator: {_sanitize_for_log(operator)}")
+        logger.warning(f"Justification: {_sanitize_for_log(justification)}")
         logger.warning("=" * 80)
 
         return True

--- a/tests/unit/safety/test_kill_switch.py
+++ b/tests/unit/safety/test_kill_switch.py
@@ -13,6 +13,7 @@ from core.safety.kill_switch import (
     KillSwitchReason,
     get_kill_switch_state,
     activate_kill_switch,
+    _sanitize_for_log,
 )
 
 
@@ -325,3 +326,148 @@ class TestRealWorldScenarios:
         state, reason, message, activated_at = ks.get_state()
         assert "trader@example.com" in message
         assert reason == KillSwitchReason.MANUAL.value
+
+
+class TestLogInjectionSanitization:
+    """Tests for log injection prevention via _sanitize_for_log."""
+
+    def test_sanitize_cr_in_message(self, tmp_path, caplog):
+        """CR in message is neutralized in log output (alert #4051)."""
+        import logging
+
+        state_file = tmp_path / "test_sanitize.state"
+        ks = KillSwitch(state_file=str(state_file))
+
+        with caplog.at_level(logging.WARNING):
+            ks.activate(
+                KillSwitchReason.MANUAL, "Emergency\rstop"
+            )
+
+        logged_messages = [r.message for r in caplog.records]
+        assert not any("\r" in m for m in logged_messages)
+        assert any("Emergency\\rstop" in m for m in logged_messages)
+
+    def test_sanitize_lf_in_message(self, tmp_path, caplog):
+        """LF in message is neutralized in log output (alert #4051)."""
+        import logging
+
+        state_file = tmp_path / "test_sanitize.state"
+        ks = KillSwitch(state_file=str(state_file))
+
+        with caplog.at_level(logging.WARNING):
+            ks.activate(
+                KillSwitchReason.MANUAL, "Emergency\nstop"
+            )
+
+        logged_messages = [r.message for r in caplog.records]
+        assert not any("\n" in m for m in logged_messages)
+        assert any("Emergency\\nstop" in m for m in logged_messages)
+
+    def test_sanitize_crlf_in_operator(self, tmp_path, caplog):
+        """CRLF in operator is neutralized in log output (alert #4052)."""
+        import logging
+
+        state_file = tmp_path / "test_sanitize.state"
+        ks = KillSwitch(state_file=str(state_file))
+
+        with caplog.at_level(logging.WARNING):
+            ks.activate(
+                KillSwitchReason.MANUAL,
+                "Test",
+                operator="admin\r\nEVIL",
+            )
+
+        logged_messages = [r.message for r in caplog.records]
+        assert not any("\r" in m or "\n" in m for m in logged_messages)
+
+    def test_sanitize_control_chars_in_justification(self, tmp_path, caplog):
+        """Control chars in justification are stripped in log output (alert #4053)."""
+        import logging
+
+        state_file = tmp_path / "test_sanitize.state"
+        ks = KillSwitch(state_file=str(state_file))
+        ks.activate(KillSwitchReason.MANUAL, "Test")
+
+        with caplog.at_level(logging.WARNING):
+            ks.deactivate("admin", "OK\x00\x01\x02\x03")
+
+        logged_messages = [r.message for r in caplog.records]
+        assert not any("\x00" in m or "\x01" in m or "\x02" in m or "\x03" in m for m in logged_messages)
+        assert any("OK" in m for m in logged_messages)
+
+    def test_sanitize_multiline_injection(self, tmp_path, caplog):
+        """Multiline injection payload in message is neutralized (alert #4050)."""
+        import logging
+
+        state_file = tmp_path / "test_sanitize.state"
+        ks = KillSwitch(state_file=str(state_file))
+
+        with caplog.at_level(logging.WARNING):
+            ks.activate(
+                KillSwitchReason.CIRCUIT_BREAKER,
+                "Real message\r\nFAKE: CRITICAL: system compromised",
+            )
+
+        logged_messages = [r.message for r in caplog.records]
+        assert not any("\r" in m or "\n" in m for m in logged_messages)
+        assert any("Real message\\r\\nFAKE" in m for m in logged_messages)
+
+    def test_sanitize_function_directly(self):
+        """_sanitize_for_log directly neutralizes CR, LF, and control chars."""
+        assert _sanitize_for_log("hello\rworld") == "hello\\rworld"
+        assert _sanitize_for_log("hello\nworld") == "hello\\nworld"
+        assert _sanitize_for_log("hello\r\nworld") == "hello\\r\\nworld"
+        assert _sanitize_for_log("ok\x00\x01\x02") == "ok"
+        assert _sanitize_for_log("clean message") == "clean message"
+        assert _sanitize_for_log("") == ""
+
+    def test_state_file_content_unaffected_by_log_sanitization(self, tmp_path, caplog):
+        """Sanitization is log-only; state file stores message as-is (no \n breakage).
+
+        The state file format is key=value\\n so messages containing literal newlines
+        corrupt the format. That is a pre-existing limitation, not introduced by this
+        fix. This test verifies that sanitization targets log output, not the
+        state file write path.
+        """
+        import logging
+
+        state_file = tmp_path / "test_state_preserved.state"
+        ks = KillSwitch(state_file=str(state_file))
+
+        injection_msg = "Dangerous\rmessage"
+        with caplog.at_level(logging.WARNING):
+            ks.activate(KillSwitchReason.MANUAL, injection_msg)
+
+        logged_messages = [r.message for r in caplog.records]
+        assert not any("\r" in m for m in logged_messages)
+
+        _state, _reason, stored_message, _activated_at = ks.get_state()
+        assert "Dangerous" in stored_message
+
+    def test_write_state_error_log_sanitized(self, tmp_path, caplog):
+        """_write_state exception log sanitizes message (alert #4050).
+
+        Force a write failure by pointing state_file at a path whose parent
+        directory does not exist, so the temp-file write raises. The error
+        handler logs message content which must be sanitized.
+        """
+        import logging
+        import shutil
+
+        nested_dir = tmp_path / "nonexistent_sub"
+        state_file = nested_dir / "kill.state"
+
+        ks = KillSwitch.__new__(KillSwitch)
+        ks.state_file = state_file
+
+        with caplog.at_level(logging.CRITICAL):
+            ks._write_state(
+                KillSwitchState.ACTIVE,
+                KillSwitchReason.MANUAL,
+                "Real\r\nFAKE",
+                None,
+            )
+
+        logged_messages = [r.message for r in caplog.records]
+        assert not any("\r" in m or "\n" in m for m in logged_messages)
+        assert any("Real\\r\\nFAKE" in m for m in logged_messages)


### PR DESCRIPTION
## Summary

- Fix 4 open CodeQL `py/log-injection` alerts (#4050–#4053) in `core/safety/kill_switch.py`
- Add `_sanitize_for_log()` to neutralize CR, LF, and control characters in user-influenced log fields (`message`, `full_message`, `operator`, `justification`)
- Add 8 unit tests in `TestLogInjectionSanitization` covering CR/LF/CRLF injection, control-char stripping, multiline injection payloads, direct sanitizer verification, state-file non-interference, and `_write_state` error-path sanitization

## Alerts addressed

| Alert | Line | Field | Fix |
|-------|------|-------|-----|
| #4050 | 149 → 158 | `message` in `_write_state` error log | `_sanitize_for_log(message)` |
| #4051 | 242 → 251 | `full_message` in `activate` log | `_sanitize_for_log(full_message)` |
| #4052 | 283 → 292 | `operator` in `deactivate` log | `_sanitize_for_log(operator)` |
| #4053 | 284 → 293 | `justification` in `deactivate` log | `_sanitize_for_log(justification)` |

## Scope

- `core/safety/kill_switch.py` — sanitizer function + 4 call-site changes
- `tests/unit/safety/test_kill_switch.py` — 8 new tests
- No state-file semantic changes
- No runtime/trading/risk/execution/strategy changes
- No SurrealDB/Context/MCP touch

## Validation

- 29/29 kill-switch unit tests PASS
- ruff check PASS
- Issue context: #2289