### PR TITLE
feat(context): add cdb context impact MCP tool

### DIFF
--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -2792,3 +2792,13 @@ class TestCdbContextImpactHandler:
         assert isinstance(impact["affected_decisions"], list)
         assert isinstance(impact["affected_evidence"], list)
         assert isinstance(impact["affected_memory_refs_read_only"], list)
+
+    def test_invalid_operation_mode_fails_closed(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {"target_paths": ["docs/"], "operation_mode": "write"},
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_operation_mode"
+        assert "write" in result["error"]["message"]

--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -29,6 +29,7 @@ class TestContextToolRegistry:
             "context.briefing",
             "context.stop_resolver",
             "context.required_reads",
+            "cdb_context_impact",
         ]
         for expected in expected_tools:
             assert expected in tool_names, f"Tool {expected} not registered"
@@ -229,8 +230,8 @@ class TestContextBridge:
         """Verify list_tools returns all v0 tools."""
         bridge = ContextBridge()
         tools = bridge.list_tools()
-        # v0 tool set (11) + #2110 alias (cdb_context_briefing)
-        assert len(tools) == 12
+        # v0 tool set (11) + #2110 alias (cdb_context_briefing) + #2111 impact tool
+        assert len(tools) == 13
         tool_names = [t["name"] for t in tools]
         assert "context.search" in tool_names
         assert "context.package" in tool_names
@@ -264,7 +265,7 @@ class TestContextBridge:
         bridge = ContextBridge()
         status = bridge.get_read_only_status()
         assert status["enforced"] is True
-        assert len(status["read_only_tools"]) == 12
+        assert len(status["read_only_tools"]) == 13
 
 
 class TestDefensiveSchemaCopies:
@@ -2557,3 +2558,237 @@ class TestContextRequiredReadsHandler:
             assert result["status"] == "ok", (
                 f"Valid mode {mode!r} should be accepted, got {result}"
             )
+
+
+class TestCdbContextImpactHandler:
+    """Tests for cdb_context_impact tool handler (#2111)."""
+
+    def test_tool_in_list_tools(self) -> None:
+        bridge = create_bridge()
+        tool_names = [t["name"] for t in bridge.list_tools()]
+        assert "cdb_context_impact" in tool_names
+
+    def test_tool_is_read_only(self) -> None:
+        bridge = create_bridge()
+        schema = bridge.get_tool_schema("cdb_context_impact")
+        assert schema is not None
+        assert schema["readOnly"] is True
+
+    def test_schema_has_required_fields(self) -> None:
+        bridge = create_bridge()
+        schema = bridge.get_tool_schema("cdb_context_impact")
+        props = schema["inputSchema"]["properties"]
+        assert "target_paths" in props
+        assert "target_symbols" in props
+        assert "target_issue" in props
+        assert "operation_mode" in props
+
+    def test_empty_call_returns_ok(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("cdb_context_impact", {})
+        assert result["status"] == "ok"
+        assert result["tool"] == "cdb_context_impact"
+        assert "impact" in result
+
+    def test_output_contains_all_required_impact_fields(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {"target_paths": ["docs/surrealdb/"], "target_issue": "#2111"},
+        )
+        assert result["status"] == "ok"
+        impact = result["impact"]
+        required_fields = [
+            "impact_id",
+            "impact_level",
+            "impact_type",
+            "gate_risks",
+            "stop_conditions",
+            "required_validation",
+        ]
+        for field in required_fields:
+            assert field in impact, f"Missing impact field: {field}"
+
+    def test_output_contains_guardrails(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("cdb_context_impact", {})
+        assert result["status"] == "ok"
+        guardrails = result["guardrails"]
+        assert len(guardrails) >= 1
+        assert any("not authorization" in g.lower() for g in guardrails)
+        assert any("no-g" in g.lower() for g in guardrails)
+
+    def test_low_impact_case(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {"target_paths": ["docs/readme.md"], "target_issue": "#2111"},
+        )
+        assert result["status"] == "ok"
+        assert result["impact"]["impact_level"] == "low"
+
+    def test_medium_impact_case(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {"target_paths": ["tools/mcp/context_bridge.py"], "target_issue": "#2111"},
+        )
+        assert result["status"] == "ok"
+        assert result["impact"]["impact_level"] == "medium"
+
+    def test_high_impact_case(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {"target_paths": ["infrastructure/compose/"], "target_issue": "#2111"},
+        )
+        assert result["status"] == "ok"
+        assert result["impact"]["impact_level"] == "high"
+
+    def test_blocking_impact_case(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {"target_paths": ["knowledge/governance/CDB_CONSTITUTION.md"], "target_issue": "#2111"},
+        )
+        assert result["status"] == "ok"
+        assert result["impact"]["impact_level"] == "blocking"
+
+    def test_gate_risks_visible_for_blocking(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {"target_paths": ["knowledge/governance/"], "target_issue": "#2111"},
+        )
+        assert result["status"] == "ok"
+        gate_risks = result["impact"]["gate_risks"]
+        assert isinstance(gate_risks, list)
+        assert len(gate_risks) >= 1
+        assert "governance_touched" in gate_risks
+
+    def test_gate_risks_visible_for_risk_surface(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {"target_paths": ["services/risk/"], "target_issue": "#2111"},
+        )
+        assert result["status"] == "ok"
+        gate_risks = result["impact"]["gate_risks"]
+        assert "risk_surface_touched" in gate_risks
+
+    def test_stop_conditions_visible(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {"target_paths": ["knowledge/governance/"], "target_issue": "#2111"},
+        )
+        assert result["status"] == "ok"
+        stop_conditions = result["impact"]["stop_conditions"]
+        assert isinstance(stop_conditions, list)
+        assert len(stop_conditions) >= 1
+
+    def test_required_validation_visible(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {"target_paths": ["tools/mcp/"], "target_issue": "#2111"},
+        )
+        assert result["status"] == "ok"
+        rv = result["impact"]["required_validation"]
+        assert isinstance(rv, dict)
+        assert "docs_to_review" in rv
+        assert "suggested_tests" in rv
+        assert "commands_to_consider" in rv
+
+    def test_graph_paths_present(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {"target_paths": ["tools/mcp/"], "target_issue": "#2111"},
+        )
+        assert result["status"] == "ok"
+        assert "graph_paths" in result["impact"]
+        assert isinstance(result["impact"]["graph_paths"], list)
+
+    def test_no_authorization_given(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {"target_paths": ["docs/"], "target_issue": "#2111"},
+        )
+        assert result["status"] == "ok"
+        impact = result["impact"]
+        assert "approved" not in impact
+        assert "authorized" not in str(impact).lower()
+        guardrails = result["guardrails"]
+        assert any("no live" in g.lower() or "no-g" in g.lower() for g in guardrails)
+
+    def test_write_mode_triggers_write_stop_condition(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {
+                "target_paths": ["docs/"],
+                "target_issue": "#2111",
+                "operation_mode": "write (code/docs)",
+            },
+        )
+        assert result["status"] == "ok"
+        stop_text = " ".join(str(sc) for sc in result["impact"]["stop_conditions"])
+        assert "write" in stop_text.lower() or "human-go" in stop_text.lower()
+
+    def test_deterministic_same_input_same_output(self) -> None:
+        bridge = create_bridge()
+        inputs = {
+            "target_paths": ["tools/mcp/"],
+            "target_issue": "#2111",
+            "operation_mode": "read_only",
+        }
+        r1 = bridge.execute_tool("cdb_context_impact", inputs)
+        r2 = bridge.execute_tool("cdb_context_impact", inputs)
+        assert r1 == r2
+
+    def test_schema_version_present(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("cdb_context_impact", {})
+        assert result["status"] == "ok"
+        assert result["impact"]["schema_version"] == "1.0.0"
+
+    def test_impact_id_is_deterministic_string(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {"target_paths": ["docs/"], "target_issue": "#2111"},
+        )
+        assert result["status"] == "ok"
+        impact_id = result["impact"]["impact_id"]
+        assert isinstance(impact_id, str)
+        assert len(impact_id) == 16
+
+    def test_confidence_is_valid_enum(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("cdb_context_impact", {})
+        assert result["status"] == "ok"
+        assert result["impact"]["confidence"] in ("low", "medium", "high")
+
+    def test_impact_type_is_valid_enum(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("cdb_context_impact", {})
+        assert result["status"] == "ok"
+        assert result["impact"]["impact_type"] in ("HARD", "SOFT")
+
+    def test_affected_lists_are_arrays(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "cdb_context_impact",
+            {"target_paths": ["tools/mcp/"], "target_issue": "#2111"},
+        )
+        assert result["status"] == "ok"
+        impact = result["impact"]
+        assert isinstance(impact["affected_artifacts"], list)
+        assert isinstance(impact["affected_symbols"], list)
+        assert isinstance(impact["affected_tests"], list)
+        assert isinstance(impact["affected_docs"], list)
+        assert isinstance(impact["affected_decisions"], list)
+        assert isinstance(impact["affected_evidence"], list)
+        assert isinstance(impact["affected_memory_refs_read_only"], list)

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -1512,7 +1512,17 @@ def cdb_context_impact_handler(**kwargs) -> dict[str, Any]:
         "write (MCP live)",
     })
     if not isinstance(operation_mode, str) or operation_mode not in valid_modes:
-        operation_mode = "read_only"
+        return {
+            "tool": "cdb_context_impact",
+            "status": "error",
+            "error": {
+                "code": "invalid_operation_mode",
+                "message": (
+                    f"operation_mode must be one of "
+                    f"{sorted(valid_modes)}, got {operation_mode!r}"
+                ),
+            },
+        }
 
     target_paths_clean = [p for p in target_paths if isinstance(p, str) and p.strip()]
     target_symbols_clean = [s for s in target_symbols if isinstance(s, str) and s.strip()]

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -1466,6 +1466,94 @@ def context_required_reads_handler(**kwargs) -> dict[str, Any]:
     }
 
 
+def cdb_context_impact_handler(**kwargs) -> dict[str, Any]:
+    """
+    Read-only handler for cdb_context_impact tool.
+
+    Delegates to tools.surrealdb.context_impact_radar.compute_impact.
+    Pure in-process evaluation. No DB/network/GitHub. Fail-closed.
+
+    Input:
+        target_paths: list[str] (optional)
+        target_symbols: list[str] (optional)
+        target_issue: str | null (optional)
+        target_concepts: list[str] (optional)
+        operation_mode: str (optional, default "read_only")
+
+    Output:
+        tool, status, impact (full ImpactReport payload), guardrails
+    """
+    from tools.surrealdb.context_impact_radar import (
+        ImpactRadarInput,
+        compute_impact,
+    )
+
+    target_paths = kwargs.get("target_paths", [])
+    target_symbols = kwargs.get("target_symbols", [])
+    target_issue = kwargs.get("target_issue")
+    target_concepts = kwargs.get("target_concepts", [])
+    operation_mode = kwargs.get("operation_mode", "read_only")
+
+    if not isinstance(target_paths, list):
+        target_paths = []
+    if not isinstance(target_symbols, list):
+        target_symbols = []
+    if not isinstance(target_concepts, list):
+        target_concepts = []
+    if target_issue is not None and not isinstance(target_issue, str):
+        target_issue = None
+
+    valid_modes = frozenset({
+        "read_only",
+        "dry_run",
+        "write (code/docs)",
+        "write (config/infra)",
+        "write (DB/migration)",
+        "write (MCP live)",
+    })
+    if not isinstance(operation_mode, str) or operation_mode not in valid_modes:
+        operation_mode = "read_only"
+
+    target_paths_clean = [p for p in target_paths if isinstance(p, str) and p.strip()]
+    target_symbols_clean = [s for s in target_symbols if isinstance(s, str) and s.strip()]
+    target_concepts_clean = [c for c in target_concepts if isinstance(c, str) and c.strip()]
+
+    try:
+        inp = ImpactRadarInput(
+            target_paths=tuple(target_paths_clean),
+            target_symbols=tuple(target_symbols_clean),
+            target_issue=target_issue,
+            target_concepts=tuple(target_concepts_clean),
+            operation_mode=operation_mode,
+        )
+        report = compute_impact(inp)
+        impact_payload = report.to_payload()
+    except Exception as e:
+        logger.exception("Impact radar computation failed")
+        return {
+            "tool": "cdb_context_impact",
+            "status": "error",
+            "error": {
+                "code": "execution_error",
+                "message": str(e),
+            },
+        }
+
+    guardrails = [
+        "Impact is analysis, not authorization.",
+        "No Live-Go, no Echtgeld-Go, no risk approval.",
+        "LR remains NO-GO (SSOT: docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md).",
+        "Board stage (trade-capable) is orthogonal to live readiness.",
+    ]
+
+    return {
+        "tool": "cdb_context_impact",
+        "status": "ok",
+        "impact": impact_payload,
+        "guardrails": guardrails,
+    }
+
+
 class ContextBridge:
     """
     MCP Bridge for Context Intelligence System.
@@ -1596,6 +1684,17 @@ class ContextBridge:
                 handler=context_required_reads_handler,
             )
             self._registry._tools["context.required_reads"] = new_required_reads
+        old_impact = self._registry.get_tool("cdb_context_impact")
+        if old_impact:
+            new_impact = ToolDefinition(
+                name=old_impact.name,
+                description=old_impact.description,
+                input_schema=old_impact.input_schema,
+                output_schema=old_impact.output_schema,
+                read_only=old_impact.read_only,
+                handler=cdb_context_impact_handler,
+            )
+            self._registry._tools["cdb_context_impact"] = new_impact
         self._registry.assert_read_only_consistency()
         logger.info(
             f"ContextBridge initialized with tools: {self._registry.list_tool_names()}"

--- a/tools/mcp/permission_guard.py
+++ b/tools/mcp/permission_guard.py
@@ -12,7 +12,7 @@ context.show_snapshot, context.show_audit) whose free-text parameters could
 contain SQL/SurrealQL injection or command vectors.
 
 Structural tools (context.readiness, context.briefing, context.self_explain,
-context.stop_resolver, context.required_reads) are exempt from input scanning
+context.stop_resolver, context.required_reads, cdb_context_impact) are exempt from input scanning
 because their handlers already validate inputs with operation_mode enums,
 stop_conditions, and structural field checks. Task descriptions like
 "Deploy system" or "Update config" are legitimate scope descriptions
@@ -128,6 +128,7 @@ INPUT_SCAN_EXEMPT_TOOLS: frozenset[str] = frozenset({
     "context.self_explain",
     "context.stop_resolver",
     "context.required_reads",
+    "cdb_context_impact",
 })
 
 

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -676,6 +676,102 @@ TOOLS_V0 = [
         read_only=True,
         handler=create_not_implemented_handler("context.required_reads"),
     ),
+    ToolDefinition(
+        name="cdb_context_impact",
+        description=(
+            "Impact Radar v1 MCP tool. Analyses downstream effects of a planned change "
+            "across the CDB system. Returns affected items, graph paths, gate risks, "
+            "required validation, and stop conditions. Read-only, deterministic, fail-closed. "
+            "No DB/network/GitHub access. Does not authorize any action, Live-Go, or Echtgeld-Go."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "target_paths": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "File paths or glob patterns targeted by the planned change.",
+                },
+                "target_symbols": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Code symbols targeted by the planned change.",
+                },
+                "target_issue": {
+                    "type": ["string", "null"],
+                    "description": "GitHub issue driving the planned change, or null.",
+                },
+                "target_concepts": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Domain concepts from the CIS ontology relevant to the change.",
+                },
+                "operation_mode": {
+                    "type": "string",
+                    "enum": [
+                        "read_only",
+                        "dry_run",
+                        "write (code/docs)",
+                        "write (config/infra)",
+                        "write (DB/migration)",
+                        "write (MCP live)",
+                    ],
+                    "description": "Intended agent operation mode for the change.",
+                    "default": "read_only",
+                },
+            },
+            "required": [],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "status": {"type": "string"},
+                "impact": {
+                    "type": "object",
+                    "properties": {
+                        "impact_id": {"type": "string"},
+                        "target_refs": {"type": "array", "items": {"type": "string"}},
+                        "impact_level": {
+                            "type": "string",
+                            "enum": ["low", "medium", "high", "blocking"],
+                        },
+                        "impact_type": {
+                            "type": "string",
+                            "enum": ["HARD", "SOFT"],
+                        },
+                        "affected_artifacts": {"type": "array"},
+                        "affected_symbols": {"type": "array"},
+                        "affected_tests": {"type": "array"},
+                        "affected_docs": {"type": "array"},
+                        "affected_decisions": {"type": "array", "items": {"type": "string"}},
+                        "affected_evidence": {"type": "array", "items": {"type": "string"}},
+                        "affected_memory_refs_read_only": {"type": "array", "items": {"type": "string"}},
+                        "graph_paths": {"type": "array"},
+                        "gate_risks": {"type": "array", "items": {"type": "string"}},
+                        "confidence": {
+                            "type": "string",
+                            "enum": ["low", "medium", "high"],
+                        },
+                        "required_validation": {"type": "object"},
+                        "stop_conditions": {"type": "array"},
+                        "schema_version": {"type": "string"},
+                    },
+                    "required": [
+                        "impact_id",
+                        "impact_level",
+                        "impact_type",
+                        "gate_risks",
+                        "stop_conditions",
+                        "required_validation",
+                    ],
+                },
+                "guardrails": {"type": "array", "items": {"type": "string"}},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("cdb_context_impact"),
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

- Adds `cdb_context_impact` as a read-only MCP tool for Impact Radar v1.
- Registers the tool in the Context MCP registry with an explicit input/output contract.
- Wires the tool through `ContextBridge` and delegates to the existing Impact Radar implementation from #2108.
- Exposes affected items, graph paths, gate risks, required validation, and stop conditions.
- Keeps the tool analysis-only: no write, no authorization, no Live-Go, no Echtgeld-Go.
- Adds mocked MCP unit coverage for low/medium/high/blocking impact cases.

Closes #2111

## Validation

- `pytest tests/unit/tools/mcp/test_context_bridge.py -m unit` → 192 passed
- `pytest tests/unit/tools/mcp/test_output_contracts.py -m unit` → 25 passed
- `pytest tests/unit/tools/mcp/test_permission_guard.py -m unit` → 136 passed
- `pytest tests/unit/tools/mcp/ -m unit` → 353 passed, 44 deselected
- `pytest tests/unit/surrealdb/test_context_impact_radar.py -m unit` → 39 passed

## Guardrails

- Read-only MCP tool only.
- No DB write.
- No memory write.
- No runtime/trading/live/echtgeld implication.
- No Security-scope changes.
