### PR TITLE
test(context): add wave 13 briefing and impact coverage

### DIFF
--- a/tests/fixtures/surrealdb/briefing/sample_briefing_request.json
+++ b/tests/fixtures/surrealdb/briefing/sample_briefing_request.json
@@ -1,0 +1,12 @@
+{
+    "task_id": "cdb-briefing-2112-test",
+    "task_scope": "Add tests and fixtures for briefing and impact radar",
+    "target_issue": "#2112",
+    "target_paths": ["tests/unit/surrealdb/"],
+    "target_symbols": [],
+    "target_concepts": ["briefing", "impact radar"],
+    "requested_depth": "standard",
+    "operation_mode": "read_only",
+    "agent_type": "OPENCODE/codex",
+    "risk_level": "medium"
+}

--- a/tests/fixtures/surrealdb/impact/sample_impact_input.json
+++ b/tests/fixtures/surrealdb/impact/sample_impact_input.json
@@ -1,0 +1,10 @@
+{
+    "target_paths": ["core/utils/clock.py"],
+    "target_symbols": ["utcnow"],
+    "target_issue": "#2108",
+    "target_concepts": ["impact", "radar"],
+    "operation_mode": "read_only",
+    "dependency_edges": [],
+    "code_symbols": [],
+    "artifacts": []
+}

--- a/tests/unit/surrealdb/test_context_required_reads.py
+++ b/tests/unit/surrealdb/test_context_required_reads.py
@@ -1,0 +1,260 @@
+"""
+Unit tests for Required Reads Resolver v1 (#2106).
+
+Tests the resolve_required_reads function from tools.surrealdb.context_required_reads.
+Pure unit tests: no DB, no network, no live repo access.
+"""
+
+import pytest
+from pathlib import Path
+
+from tools.surrealdb.context_required_reads import (
+    resolve_required_reads,
+    MINIMUM_READS,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestMinimumReads:
+    """Verify minimum baseline reads are always included."""
+
+    def test_minimum_reads_always_present(self) -> None:
+        """Minimum reads (must_read) appear in output."""
+        reads = resolve_required_reads(
+            task_scope="test scope",
+            target_issue=None,
+            target_paths=[],
+            target_symbols=[],
+            operation_mode="read_only",
+            repo_root=Path("/nonexistent"),
+        )
+        min_paths = {entry["path"] for entry in MINIMUM_READS}
+        result_paths = {r["path"] for r in reads}
+        assert min_paths.issubset(result_paths), f"Missing minimum reads: {min_paths - result_paths}"
+
+    def test_minimum_reads_have_priority_must_read(self) -> None:
+        """Minimum reads have priority 'must_read'."""
+        reads = resolve_required_reads(
+            task_scope="test scope",
+            target_issue=None,
+            target_paths=[],
+            target_symbols=[],
+            operation_mode="read_only",
+            repo_root=Path("/nonexistent"),
+        )
+        for entry in MINIMUM_READS:
+            matches = [r for r in reads if r["path"] == entry["path"]]
+            assert matches, f"Minimum read missing: {entry['path']}"
+            assert matches[0]["priority"] == "must_read", (
+                f"Expected must_read for {entry['path']}, "
+                f"got {matches[0]['priority']}"
+            )
+
+
+class TestDomainDetection:
+    """Test domain detection from task_scope and target_paths."""
+
+    def test_governance_domain_from_scope(self) -> None:
+        """Governance keywords in task_scope add governance reads."""
+        reads = resolve_required_reads(
+            task_scope="update governance policy",
+            target_issue=None,
+            target_paths=[],
+            target_symbols=[],
+            operation_mode="read_only",
+            repo_root=Path("/nonexistent"),
+        )
+        paths = [r["path"] for r in reads]
+        assert any("governance" in p.lower() for p in paths), (
+            "Governance domain not detected"
+        )
+
+    def test_surrealdb_domain_from_scope(self) -> None:
+        """SurrealDB keywords in task_scope add surrealdb reads."""
+        reads = resolve_required_reads(
+            task_scope="implement context briefing for surrealdb",
+            target_issue=None,
+            target_paths=[],
+            target_symbols=[],
+            operation_mode="read_only",
+            repo_root=Path("/nonexistent"),
+        )
+        paths = [r["path"] for r in reads]
+        assert any("context" in p.lower() for p in paths), (
+            "SurrealDB domain not detected"
+        )
+
+    def test_trading_domain_from_paths(self) -> None:
+        """Trading-related paths add trading reads."""
+        reads = resolve_required_reads(
+            task_scope="update trading strategy",
+            target_issue=None,
+            target_paths=["services/execution/service.py"],
+            target_symbols=[],
+            operation_mode="read_only",
+            repo_root=Path("/nonexistent"),
+        )
+        paths = [r["path"] for r in reads]
+        assert any("CONTROL_REGISTER" in p for p in paths), (
+            "Trading domain not detected"
+        )
+
+
+class TestWriteMode:
+    """Test that write operation_mode adds governance reads."""
+
+    def test_write_mode_adds_governance_reads(self) -> None:
+        """Write modes add extra must_read entries."""
+        reads = resolve_required_reads(
+            task_scope="update docs",
+            target_issue=None,
+            target_paths=[],
+            target_symbols=[],
+            operation_mode="write (code/docs)",
+            repo_root=Path("/nonexistent"),
+        )
+        write_reads = [r for r in reads if r["priority"] == "must_read"]
+        # At least one write-specific read (e.g., DELIVERY_APPROVED.yaml)
+        write_paths = {r["path"] for r in write_reads}
+        assert any("DELIVERY_APPROVED" in p for p in write_paths), (
+            "Write-mode governance reads missing"
+        )
+
+    def test_non_write_mode_does_not_add_write_reads(self) -> None:
+        """Read-only mode should not add write-specific reads."""
+        reads_read = resolve_required_reads(
+            task_scope="update docs",
+            target_issue=None,
+            target_paths=[],
+            target_symbols=[],
+            operation_mode="read_only",
+            repo_root=Path("/nonexistent"),
+        )
+        reads_write = resolve_required_reads(
+            task_scope="update docs",
+            target_issue=None,
+            target_paths=[],
+            target_symbols=[],
+            operation_mode="write (code/docs)",
+            repo_root=Path("/nonexistent"),
+        )
+        # Write mode should have more must_read entries
+        must_read_read = [r for r in reads_read if r["priority"] == "must_read"]
+        must_read_write = [r for r in reads_write if r["priority"] == "must_read"]
+        assert len(must_read_write) > len(must_read_read), (
+            "Write mode should add extra must_read entries"
+        )
+
+
+class TestTargetIssue:
+    """Test that target_issue triggers domain reads."""
+
+    def test_issue_with_governance_keyword(self) -> None:
+        """Issue string containing governance keywords adds governance reads."""
+        reads = resolve_required_reads(
+            task_scope="fix issue",
+            target_issue="#1234 governance policy update",
+            target_paths=[],
+            target_symbols=[],
+            operation_mode="read_only",
+            repo_root=Path("/nonexistent"),
+        )
+        paths = [r["path"] for r in reads]
+        assert any("governance" in p.lower() for p in paths), (
+            "Issue-driven governance domain not detected"
+        )
+
+
+class TestDeduplication:
+    """Test that duplicate reads are deduplicated."""
+
+    def test_duplicate_paths_deduplicated(self) -> None:
+        """Same path appearing multiple times is deduplicated."""
+        reads = resolve_required_reads(
+            task_scope="governance update",
+            target_issue=None,
+            target_paths=[],
+            target_symbols=[],
+            operation_mode="read_only",
+            repo_root=Path("/nonexistent"),
+        )
+        paths = [r["path"] for r in reads]
+        assert len(paths) == len(set(paths)), "Duplicate paths found in output"
+
+
+class TestOutputStructure:
+    """Test that each returned dict has required keys."""
+
+    def test_each_read_has_required_keys(self) -> None:
+        """Each read dict contains path, priority, reason, source_ref, available, warning."""
+        reads = resolve_required_reads(
+            task_scope="test",
+            target_issue=None,
+            target_paths=[],
+            target_symbols=[],
+            operation_mode="read_only",
+            repo_root=Path("/nonexistent"),
+        )
+        required_keys = {"path", "priority", "reason", "source_ref", "available", "warning"}
+        for r in reads:
+            assert required_keys.issubset(r.keys()), (
+                f"Missing keys in read dict: {required_keys - set(r.keys())}"
+            )
+
+    def test_available_is_bool(self) -> None:
+        """Available field is boolean."""
+        reads = resolve_required_reads(
+            task_scope="test",
+            target_issue=None,
+            target_paths=[],
+            target_symbols=[],
+            operation_mode="read_only",
+            repo_root=Path("/nonexistent"),
+        )
+        for r in reads:
+            assert isinstance(r["available"], bool), (
+                f"available is not bool for {r['path']}"
+            )
+
+
+class TestEdgeCases:
+    """Test edge cases and invalid inputs."""
+
+    def test_empty_task_scope(self) -> None:
+        """Empty task_scope still returns minimum reads."""
+        reads = resolve_required_reads(
+            task_scope="",
+            target_issue=None,
+            target_paths=[],
+            target_symbols=[],
+            operation_mode="read_only",
+            repo_root=Path("/nonexistent"),
+        )
+        assert len(reads) >= len(MINIMUM_READS), "Minimum reads missing for empty scope"
+
+    def test_none_target_paths(self) -> None:
+        """None target_paths treated as empty list."""
+        reads = resolve_required_reads(
+            task_scope="test",
+            target_issue=None,
+            target_paths=None,  # type: ignore
+            target_symbols=[],
+            operation_mode="read_only",
+            repo_root=Path("/nonexistent"),
+        )
+        assert len(reads) >= len(MINIMUM_READS)
+
+    def test_invalid_operation_mode(self) -> None:
+        """Invalid operation_mode does not cause crash."""
+        reads = resolve_required_reads(
+            task_scope="test",
+            target_issue=None,
+            target_paths=[],
+            target_symbols=[],
+            operation_mode="invalid_mode",
+            repo_root=Path("/nonexistent"),
+        )
+        # Should still return minimum reads
+        assert len(reads) >= len(MINIMUM_READS)

--- a/tests/unit/surrealdb/test_context_stop_resolver.py
+++ b/tests/unit/surrealdb/test_context_stop_resolver.py
@@ -1,0 +1,223 @@
+"""
+Unit tests for Stop Condition Resolver v1 (#2107).
+
+Tests the resolve_stop_conditions function from tools.surrealdb.context_stop_resolver.
+Pure unit tests: no DB, no network.
+"""
+
+import pytest
+
+from tools.surrealdb.context_stop_resolver import (
+    resolve_stop_conditions,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestKnownStopCodes:
+    """Test that known S1-S10 and H1-H8 codes resolve correctly."""
+
+    def test_S1_missing_scope(self) -> None:
+        """S1: missing scope -> scope_drift_risk, blocking."""
+        resolved = resolve_stop_conditions(
+            stop_conditions=["S1: scope ambiguous"],
+            warnings=[],
+            operation_mode="read_only",
+        )
+        assert len(resolved) >= 1
+        cond = resolved[0]
+        assert cond["type"] == "scope_drift_risk"
+        assert cond["severity"] == "blocking"
+        # Reason should mention scope
+        assert "scope" in cond["reason"].lower()
+
+    def test_S6_write_requires_human_go(self) -> None:
+        """S6: write without impact report -> write_requires_human_go, blocking."""
+        resolved = resolve_stop_conditions(
+            stop_conditions=["S6: write without impact report"],
+            warnings=[],
+            operation_mode="write (code/docs)",
+        )
+        assert len(resolved) >= 1
+        cond = resolved[0]
+        assert cond["type"] == "write_requires_human_go"
+        assert cond["severity"] == "blocking"
+        assert cond["human_go_required"] is True
+
+    def test_H1_write_action_requires_go(self) -> None:
+        """H1: write action requires explicit Human-GO."""
+        resolved = resolve_stop_conditions(
+            stop_conditions=["H1: write action requires explicit Human-GO"],
+            warnings=[],
+            operation_mode="write (code/docs)",
+        )
+        assert len(resolved) >= 1
+        cond = resolved[0]
+        assert cond["type"] == "write_requires_human_go"
+        assert cond["severity"] == "blocking"
+        assert cond["human_go_required"] is True
+
+    def test_S10_stop_if_lr_claims(self) -> None:
+        """S10: STOP if LR/Stage/Live claims surface -> blocking due to live keywords."""
+        resolved = resolve_stop_conditions(
+            stop_conditions=["S10: STOP if LR/Stage/Live claims surface"],
+            warnings=[],
+            operation_mode="read_only",
+        )
+        assert len(resolved) >= 1
+        cond = resolved[0]
+        assert cond["type"] == "stale_context"
+        # Live keywords in condition escalate severity to blocking
+        assert cond["severity"] == "blocking"
+
+
+class TestUnknownConditions:
+    """Test that unknown conditions are handled safely."""
+
+    def test_unknown_condition_becomes_scope_drift_risk(self) -> None:
+        """Unknown condition string -> scope_drift_risk warning."""
+        resolved = resolve_stop_conditions(
+            stop_conditions=["some random stop condition"],
+            warnings=[],
+            operation_mode="read_only",
+        )
+        # Should produce at least one condition
+        assert len(resolved) >= 1
+        # The unknown condition should be mapped to scope_drift_risk or runtime_surface_touched
+        types = [c["type"] for c in resolved]
+        assert any(t in ("scope_drift_risk", "runtime_surface_touched") for t in types)
+
+    def test_empty_stop_conditions_returns_empty(self) -> None:
+        """Empty list returns empty list."""
+        resolved = resolve_stop_conditions(
+            stop_conditions=[],
+            warnings=[],
+            operation_mode="read_only",
+        )
+        assert resolved == []
+
+
+class TestWarningsScanning:
+    """Test that warnings are scanned for secrets/live/runtime keywords."""
+
+    def test_secrets_keyword_in_warnings(self) -> None:
+        """Warnings containing 'secrets' trigger secrets_risk."""
+        resolved = resolve_stop_conditions(
+            stop_conditions=[],
+            warnings=["found secrets in config"],
+            operation_mode="read_only",
+        )
+        types = [c["type"] for c in resolved]
+        assert "secrets_risk" in types
+
+    def test_live_keyword_in_warnings(self) -> None:
+        """Warnings containing 'live' trigger forbidden_path."""
+        resolved = resolve_stop_conditions(
+            stop_conditions=[],
+            warnings=["live readiness check passed"],
+            operation_mode="read_only",
+        )
+        types = [c["type"] for c in resolved]
+        assert "forbidden_path" in types
+
+    def test_runtime_keyword_in_warnings(self) -> None:
+        """Warnings containing 'runtime' trigger runtime_surface_touched."""
+        resolved = resolve_stop_conditions(
+            stop_conditions=[],
+            warnings=["runtime service modified"],
+            operation_mode="read_only",
+        )
+        types = [c["type"] for c in resolved]
+        assert "runtime_surface_touched" in types
+
+
+class TestOperationMode:
+    """Test that operation_mode influences severity."""
+
+    def test_S7_non_write_mode_becomes_warning(self) -> None:
+        """S7 (trading surface touched) with read_only -> warning."""
+        resolved = resolve_stop_conditions(
+            stop_conditions=["S7: trading/risk/execution scope touched"],
+            warnings=[],
+            operation_mode="read_only",
+        )
+        cond = [c for c in resolved if c["type"] == "trading_surface_touched"]
+        assert len(cond) == 1
+        assert cond[0]["severity"] == "warning"
+
+    def test_S7_write_mode_stays_blocking(self) -> None:
+        """S7 with write mode -> blocking."""
+        resolved = resolve_stop_conditions(
+            stop_conditions=["S7: trading/risk/execution scope touched"],
+            warnings=[],
+            operation_mode="write (code/docs)",
+        )
+        cond = [c for c in resolved if c["type"] == "trading_surface_touched"]
+        assert len(cond) == 1
+        assert cond[0]["severity"] == "blocking"
+
+
+class TestDeduplication:
+    """Test that duplicate conditions are deduplicated."""
+
+    def test_duplicate_same_condition_deduplicated(self) -> None:
+        """Same stop condition string appears only once."""
+        resolved = resolve_stop_conditions(
+            stop_conditions=["S1: scope ambiguous", "S1: scope ambiguous"],
+            warnings=[],
+            operation_mode="read_only",
+        )
+        # Should have only one S1 condition
+        s1_conds = [c for c in resolved if "S1" in c.get("reason", "")]
+        assert len(s1_conds) <= 1
+
+
+class TestOutputStructure:
+    """Test that each resolved condition has required keys."""
+
+    def test_each_condition_has_required_keys(self) -> None:
+        """Each condition dict contains type, severity, reason, required_action, human_go_required."""
+        resolved = resolve_stop_conditions(
+            stop_conditions=["S1: scope ambiguous"],
+            warnings=[],
+            operation_mode="read_only",
+        )
+        required_keys = {"type", "severity", "reason", "required_action", "human_go_required"}
+        for cond in resolved:
+            assert required_keys.issubset(cond.keys()), (
+                f"Missing keys in condition: {required_keys - set(cond.keys())}"
+            )
+
+    def test_human_go_required_is_bool(self) -> None:
+        """human_go_required field is boolean."""
+        resolved = resolve_stop_conditions(
+            stop_conditions=["H1: write action requires Human-GO"],
+            warnings=[],
+            operation_mode="write (code/docs)",
+        )
+        for cond in resolved:
+            assert isinstance(cond["human_go_required"], bool), (
+                f"human_go_required is not bool: {type(cond['human_go_required'])}"
+            )
+
+
+class TestReadinessResult:
+    """Test that readiness_result can provide additional stop conditions."""
+
+    def test_readiness_result_stop_conditions_added(self) -> None:
+        """stop_conditions from readiness_result are included."""
+        readiness = {
+            "stop_conditions": ["S2: no context package and no required reads"],
+        }
+        resolved = resolve_stop_conditions(
+            stop_conditions=[],
+            warnings=[],
+            readiness_result=readiness,
+            operation_mode="read_only",
+        )
+        # Should include at least one condition from readiness_result
+        assert len(resolved) >= 1
+        # Check that the condition about missing context is present
+        reasons = [c.get("reason", "") for c in resolved]
+        assert any("context" in r.lower() for r in reasons)

--- a/tests/unit/tools/mcp/test_mcp_briefing_tool.py
+++ b/tests/unit/tools/mcp/test_mcp_briefing_tool.py
@@ -1,0 +1,234 @@
+"""
+Unit tests for MCP Briefing Tool (context.briefing and cdb_context_briefing).
+
+Tests the briefing handlers from tools.mcp.context_bridge.
+Pure unit tests: no DB, no network, no live repo access.
+"""
+
+import pytest
+
+from tools.mcp.context_bridge import (
+    context_briefing_handler,
+    cdb_context_briefing_handler,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestContextBriefingHandler:
+    """Tests for context.briefing handler."""
+
+    def test_missing_task_id_returns_error(self) -> None:
+        """Missing task_id fails closed."""
+        result = context_briefing_handler()
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_task_id"
+
+    def test_empty_task_id_returns_error(self) -> None:
+        """Empty task_id fails closed."""
+        result = context_briefing_handler(task_id="", task_scope="test", target_issue=None, requested_depth="quick", operation_mode="read_only")
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_task_id"
+
+    def test_missing_task_scope_returns_error(self) -> None:
+        """Missing task_scope fails closed."""
+        result = context_briefing_handler(task_id="test-1", requested_depth="quick", operation_mode="read_only")
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_task_scope"
+
+    def test_missing_target_issue_returns_error(self) -> None:
+        """Missing target_issue (not provided) fails closed."""
+        result = context_briefing_handler(task_id="test-1", task_scope="test", requested_depth="quick", operation_mode="read_only")
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_target_issue"
+
+    def test_valid_request_returns_ok(self) -> None:
+        """Valid inputs produce ok status with briefing."""
+        result = context_briefing_handler(
+            task_id="test-1",
+            task_scope="test scope",
+            target_issue="#2112",
+            requested_depth="quick",
+            operation_mode="read_only",
+        )
+        assert result["status"] == "ok"
+        assert "briefing" in result
+        briefing = result["briefing"]
+        assert "briefing_id" in briefing
+        assert "scope_summary" in briefing
+        assert "guardrails" in briefing
+        assert "stop_conditions" in briefing
+        assert "human_go_required" in briefing
+        assert briefing["human_go_required"] is False
+
+    def test_write_mode_sets_human_go_required(self) -> None:
+        """Write operation mode sets human_go_required=True."""
+        result = context_briefing_handler(
+            task_id="test-2",
+            task_scope="write docs",
+            target_issue=None,
+            requested_depth="standard",
+            operation_mode="write (code/docs)",
+        )
+        assert result["status"] == "ok"
+        assert result["briefing"]["human_go_required"] is True
+
+    def test_deep_depth_includes_context_package_ref(self) -> None:
+        """Deep depth should include context_package_ref (mocked)."""
+        result = context_briefing_handler(
+            task_id="test-3",
+            task_scope="deep briefing",
+            target_issue=None,
+            requested_depth="deep",
+            operation_mode="read_only",
+        )
+        assert result["status"] == "ok"
+        # context_package_ref may be None or a string; not asserting specific value
+        assert "context_package_ref" in result["briefing"]
+
+    def test_quick_depth_summary(self) -> None:
+        """Quick depth produces summary with quick tag."""
+        result = context_briefing_handler(
+            task_id="test-4",
+            task_scope="quick test",
+            target_issue=None,
+            requested_depth="quick",
+            operation_mode="read_only",
+        )
+        assert result["status"] == "ok"
+        summary = result["briefing"]["scope_summary"]
+        assert "quick" in summary.lower()
+
+    def test_invalid_depth_returns_error(self) -> None:
+        """Invalid requested_depth fails closed."""
+        result = context_briefing_handler(
+            task_id="test-5",
+            task_scope="test",
+            target_issue=None,
+            requested_depth="invalid",
+            operation_mode="read_only",
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_depth"
+
+
+class TestCdbContextBriefingHandler:
+    """Tests for cdb_context_briefing handler (alias with byte limit)."""
+
+    def test_cdb_briefing_calls_context_briefing(self) -> None:
+        """cdb_context_briefing delegates to context_briefing_handler."""
+        result = cdb_context_briefing_handler(
+            task_id="test-6",
+            task_scope="cdb test",
+            target_issue=None,
+            requested_depth="quick",
+            operation_mode="read_only",
+        )
+        # Should return ok or error from underlying handler
+        assert result["status"] in ("ok", "error")
+        if result["status"] == "ok":
+            assert result["tool"] == "cdb_context_briefing"
+            assert "briefing" in result
+
+    def test_cdb_briefing_returns_error_on_failure(self) -> None:
+        """cdb_context_briefing returns error if underlying fails."""
+        result = cdb_context_briefing_handler()  # missing required args
+        assert result["status"] == "error"
+        assert result["tool"] == "cdb_context_briefing"
+
+    def test_cdb_briefing_tool_name_rewritten(self) -> None:
+        """Tool name is rewritten to cdb_context_briefing."""
+        result = cdb_context_briefing_handler(
+            task_id="test-7",
+            task_scope="test",
+            target_issue=None,
+            requested_depth="quick",
+            operation_mode="read_only",
+        )
+        if result["status"] == "ok":
+            assert result["tool"] == "cdb_context_briefing"
+
+
+class TestBriefingOutputStructure:
+    """Test that briefing output conforms to v1 schema."""
+
+    def test_required_fields_present(self) -> None:
+        """Briefing has all required fields."""
+        result = context_briefing_handler(
+            task_id="test-8",
+            task_scope="test",
+            target_issue=None,
+            requested_depth="quick",
+            operation_mode="read_only",
+        )
+        if result["status"] == "ok":
+            briefing = result["briefing"]
+            required = {"briefing_id", "scope_summary", "human_go_required", "guardrails", "stop_conditions"}
+            assert required.issubset(briefing.keys()), (
+                f"Missing required fields: {required - set(briefing.keys())}"
+            )
+
+    def test_guardrails_non_empty(self) -> None:
+        """Guardrails list is non-empty."""
+        result = context_briefing_handler(
+            task_id="test-9",
+            task_scope="test",
+            target_issue=None,
+            requested_depth="quick",
+            operation_mode="read_only",
+        )
+        if result["status"] == "ok":
+            guardrails = result["briefing"]["guardrails"]
+            assert isinstance(guardrails, list)
+            assert len(guardrails) > 0
+
+    def test_stop_conditions_non_empty(self) -> None:
+        """Stop conditions list is non-empty (minimum present)."""
+        result = context_briefing_handler(
+            task_id="test-10",
+            task_scope="test",
+            target_issue=None,
+            requested_depth="quick",
+            operation_mode="read_only",
+        )
+        if result["status"] == "ok":
+            stop_conditions = result["briefing"]["stop_conditions"]
+            assert isinstance(stop_conditions, list)
+            assert len(stop_conditions) > 0
+
+    def test_briefing_id_is_deterministic(self) -> None:
+        """Same inputs produce same briefing_id."""
+        kwargs = dict(
+            task_id="test-11",
+            task_scope="deterministic test",
+            target_issue="#2112",
+            requested_depth="standard",
+            operation_mode="read_only",
+        )
+        result1 = context_briefing_handler(**kwargs)
+        result2 = context_briefing_handler(**kwargs)
+        if result1["status"] == "ok" and result2["status"] == "ok":
+            id1 = result1["briefing"]["briefing_id"]
+            id2 = result2["briefing"]["briefing_id"]
+            assert id1 == id2, "briefing_id not deterministic"
+
+
+class TestRequiredReadsInBriefing:
+    """Test that required reads are present in briefing."""
+
+    def test_required_reads_contain_minimum_set(self) -> None:
+        """Briefing includes minimum required reads."""
+        result = context_briefing_handler(
+            task_id="test-12",
+            task_scope="test",
+            target_issue=None,
+            requested_depth="standard",
+            operation_mode="read_only",
+        )
+        if result["status"] == "ok":
+            required_reads = result["briefing"].get("required_reads", [])
+            paths = [r for r in required_reads]
+            min_paths = ["AGENTS.md", "agents/AGENTS.md", "CURRENT_STATUS.md"]
+            for mp in min_paths:
+                assert any(mp in p for p in paths), f"Missing minimum read: {mp}"

--- a/tests/unit/tools/mcp/test_mcp_impact_tool.py
+++ b/tests/unit/tools/mcp/test_mcp_impact_tool.py
@@ -1,0 +1,244 @@
+"""
+Unit tests for MCP Impact Tool (cdb_context_impact).
+
+Tests the cdb_context_impact_handler from tools.mcp.context_bridge.
+Pure unit tests: no DB, no network.
+"""
+
+import pytest
+
+from tools.mcp.context_bridge import cdb_context_impact_handler
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestCdbContextImpactHandler:
+    """Tests for cdb_context_impact handler."""
+
+    def test_missing_inputs_returns_ok_with_low_impact(self) -> None:
+        """No inputs returns ok with low impact (defaults)."""
+        result = cdb_context_impact_handler()
+        assert result["status"] == "ok"
+        impact = result["impact"]
+        assert impact["impact_level"] == "low"
+        assert impact["impact_type"] == "SOFT"
+
+    def test_valid_inputs_returns_ok(self) -> None:
+        """Valid inputs produce ok status with impact."""
+        result = cdb_context_impact_handler(
+            target_paths=["core/utils/clock.py"],
+            target_symbols=[],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="read_only",
+        )
+        assert result["status"] == "ok"
+        assert "impact" in result
+        impact = result["impact"]
+        assert "impact_id" in impact
+        assert "impact_level" in impact
+        assert "impact_type" in impact
+        assert "affected_artifacts" in impact
+        assert "stop_conditions" in impact
+
+    def test_impact_level_for_core_path(self) -> None:
+        """Core path yields medium impact."""
+        result = cdb_context_impact_handler(
+            target_paths=["core/utils/clock.py"],
+            target_symbols=[],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="read_only",
+        )
+        if result["status"] == "ok":
+            impact = result["impact"]
+            assert impact["impact_level"] == "medium"
+            assert impact["impact_type"] == "HARD"
+
+    def test_impact_level_for_docs_path(self) -> None:
+        """Docs path yields low impact."""
+        result = cdb_context_impact_handler(
+            target_paths=["docs/some-doc.md"],
+            target_symbols=[],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="read_only",
+        )
+        if result["status"] == "ok":
+            impact = result["impact"]
+            assert impact["impact_level"] == "low"
+            assert impact["impact_type"] == "SOFT"
+
+    def test_impact_level_for_services_path(self) -> None:
+        """Services path yields high impact."""
+        result = cdb_context_impact_handler(
+            target_paths=["services/signal/service.py"],
+            target_symbols=[],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="read_only",
+        )
+        if result["status"] == "ok":
+            impact = result["impact"]
+            assert impact["impact_level"] == "high"
+            assert impact["impact_type"] == "HARD"
+
+    def test_impact_level_for_governance_path(self) -> None:
+        """Governance path yields blocking impact."""
+        result = cdb_context_impact_handler(
+            target_paths=["knowledge/governance/CDB_CONSTITUTION.md"],
+            target_symbols=[],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="read_only",
+        )
+        if result["status"] == "ok":
+            impact = result["impact"]
+            assert impact["impact_level"] == "blocking"
+
+    def test_write_mode_adds_stop_conditions(self) -> None:
+        """Write mode adds stop condition about write."""
+        result = cdb_context_impact_handler(
+            target_paths=["core/utils/clock.py"],
+            target_symbols=[],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="write (code/docs)",
+        )
+        if result["status"] == "ok":
+            impact = result["impact"]
+            stop_conditions = impact.get("stop_conditions", [])
+            # Should have at least one condition related to write
+            write_conds = [
+                sc for sc in stop_conditions
+                if sc.get("type") == "write_requires_human_go"
+                or "write" in sc.get("reason", "").lower()
+            ]
+            assert len(write_conds) >= 1
+
+    def test_invalid_operation_mode_returns_error(self) -> None:
+        """Invalid operation_mode returns error."""
+        result = cdb_context_impact_handler(
+            target_paths=[],
+            target_symbols=[],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="invalid_mode",
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_operation_mode"
+
+    def test_empty_inputs_produce_low_impact(self) -> None:
+        """Empty inputs produce low impact."""
+        result = cdb_context_impact_handler(
+            target_paths=[],
+            target_symbols=[],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="read_only",
+        )
+        if result["status"] == "ok":
+            impact = result["impact"]
+            assert impact["impact_level"] == "low"
+            assert impact["impact_type"] == "SOFT"
+
+    def test_confidence_field_present(self) -> None:
+        """Confidence field is present."""
+        result = cdb_context_impact_handler(
+            target_paths=["core/utils/clock.py"],
+            target_symbols=[],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="read_only",
+        )
+        if result["status"] == "ok":
+            impact = result["impact"]
+            assert "confidence" in impact
+            assert impact["confidence"] in ("high", "medium", "low")
+
+    def test_required_validation_present(self) -> None:
+        """Required validation section present."""
+        result = cdb_context_impact_handler(
+            target_paths=["services/risk/service.py"],
+            target_symbols=[],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="read_only",
+        )
+        if result["status"] == "ok":
+            impact = result["impact"]
+            assert "required_validation" in impact
+            validation = impact["required_validation"]
+            assert isinstance(validation, dict)
+
+    def test_guardrails_present(self) -> None:
+        """Guardrails list is present and non-empty."""
+        result = cdb_context_impact_handler(
+            target_paths=[],
+            target_symbols=[],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="read_only",
+        )
+        assert "guardrails" in result
+        guardrails = result["guardrails"]
+        assert isinstance(guardrails, list)
+        assert len(guardrails) > 0
+
+    def test_tool_name_is_cdb_context_impact(self) -> None:
+        """Tool name is cdb_context_impact."""
+        result = cdb_context_impact_handler(
+            target_paths=[],
+            target_symbols=[],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="read_only",
+        )
+        assert result["tool"] == "cdb_context_impact"
+
+    def test_impact_id_is_deterministic(self) -> None:
+        """Same inputs produce same impact_id."""
+        kwargs = dict(
+            target_paths=["core/utils/clock.py"],
+            target_symbols=[],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="read_only",
+        )
+        result1 = cdb_context_impact_handler(**kwargs)
+        result2 = cdb_context_impact_handler(**kwargs)
+        if result1["status"] == "ok" and result2["status"] == "ok":
+            id1 = result1["impact"]["impact_id"]
+            id2 = result2["impact"]["impact_id"]
+            assert id1 == id2, "impact_id not deterministic"
+
+    def test_affected_items_are_lists(self) -> None:
+        """Affected artifacts, symbols, tests, docs are lists."""
+        result = cdb_context_impact_handler(
+            target_paths=["core/utils/clock.py"],
+            target_symbols=["utcnow"],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="read_only",
+        )
+        if result["status"] == "ok":
+            impact = result["impact"]
+            assert isinstance(impact.get("affected_artifacts", []), list)
+            assert isinstance(impact.get("affected_symbols", []), list)
+            assert isinstance(impact.get("affected_tests", []), list)
+            assert isinstance(impact.get("affected_docs", []), list)
+
+    def test_gate_risks_for_governance_path(self) -> None:
+        """Governance path triggers governance_touched gate risk."""
+        result = cdb_context_impact_handler(
+            target_paths=["knowledge/governance/CDB_GOVERNANCE.md"],
+            target_symbols=[],
+            target_issue=None,
+            target_concepts=[],
+            operation_mode="read_only",
+        )
+        if result["status"] == "ok":
+            impact = result["impact"]
+            gate_risks = impact.get("gate_risks", [])
+            assert any("governance_touched" in r for r in gate_risks)


### PR DESCRIPTION
## Summary

- Adds Wave 13 test coverage for SurrealDB Context required reads and stop condition resolvers.
- Adds MCP-level tests for `context.briefing`, `cdb_context_briefing`, and `cdb_context_impact`.
- Adds small deterministic fixtures for briefing and impact inputs.
- Keeps the slice test/fixture-only with no production-code changes.

Closes #2112

## Validation

- `pytest tests/unit/surrealdb/test_context_required_reads.py -v -m unit` → 14 passed
- `pytest tests/unit/surrealdb/test_context_stop_resolver.py -v -m unit` → 15 passed
- `pytest tests/unit/tools/mcp/test_mcp_briefing_tool.py -v -m unit` → 17 passed
- `pytest tests/unit/tools/mcp/test_mcp_impact_tool.py -v -m unit` → 16 passed
- `pytest tests/unit/surrealdb/ -m unit` → 536 passed (no regressions)
- `pytest tests/unit/tools/mcp/ -m unit` → 387 passed (no regressions)

## Guardrails

- Tests and fixtures only.
- No production-code changes.
- No Docker or runtime service required.
- No productive SurrealDB required.
- No secrets in fixtures.
- No LR/Live/Echtgeld/Trading implication.
- No route-control-board or branch-protection changes.
