### PR TITLE
docs(surrealdb): document context input scan exemptions for #2337

### DIFF
--- a/docs/surrealdb/context-mcp-bridge-contract.md
+++ b/docs/surrealdb/context-mcp-bridge-contract.md
@@ -160,6 +160,8 @@ Spezifisches Error-Modell Für #2022:
    - Registry Gate: Schreibende Tools werden registration blockiert
    - Execute Gate: `read_only` + Input Gate vor Handler-Dispatch
    - Input Gate: Mutation-Keywords in Parametern blockiert
+     - Exemption: Structural read-only context tools that must carry governance or readiness terms as data are exempt from mutation-keyword scanning per `permission_guard.py`, currently: `context.readiness`, `context.briefing`, `cdb_context_briefing`, `cdb_context_impact`.
+     - Die Exemption gewährt NICHT write authority; diese Tools bleiben read-only und durchlaufen weiterhin Allowlist und Handler-Grenze.
 3. **Keine GitHub-Writes**: CDB-MCP bleibt Gatekeeper Für Repo/GitHub
 4. **Keine SurrealDB-Writes**: Tools nutzen `NoopQueryAdapter` (in-memory) oder read-only SurrealDB-Adapter
 5. **Namespace-Isolation**: Memory-Tools sind auf `agent_id` + Namespace beschränkt


### PR DESCRIPTION
Addresses the unresolved #2337 review thread about Input Gate exemptions.

- document mutation-keyword scan exemptions for structural read-only context tools
- clarify that exemptions do not grant write authority
- preserve allowlist, handler boundary and no-live/no-runtime-write guardrails

Fixes #2337