### PR TITLE
docs(surrealdb): define wave-13 completion gates

### DIFF
--- a/docs/surrealdb/context-wave13-completion-gates.md
+++ b/docs/surrealdb/context-wave13-completion-gates.md
@@ -1,0 +1,113 @@
+# Wave-13 Completion Gates
+
+**Status**: Closed
+**Authority**: Issue #2114 / Wave 13 / Epic #1976
+**Parent**: #2103
+
+This document defines the completion gates for Wave-13 (Agent briefing and impact radar v1).
+
+---
+
+## 1. Scope Baseline
+
+### 1.1 Parent & Child Issues
+
+| Issue | Title | State |
+|-------|-------|-------|
+| #2103 | Wave-13 anchor: Agent briefing and impact radar v1 | CLOSED |
+| #2104 | Define agent briefing schema v1 | CLOSED |
+| #2105 | Implement briefing builder service v1 | CLOSED |
+| #2106 | Implement context required-reads resolver v1 | CLOSED |
+| #2107 | Implement stop-condition resolver v1 | CLOSED |
+| #2108 | Implement context impact radar v1 | CLOSED |
+| #2109 | Implement validation plan generator v1 | CLOSED |
+| #2110 | Implement briefing MCP tool v1 | CLOSED |
+| #2111 | Implement impact radar MCP tool v1 | CLOSED |
+| #2112 | Add Wave-13 tests and fixtures | CLOSED |
+| #2113 | Add Wave-13 runbook | CLOSED |
+| #2114 | Define Wave-13 completion gates | CLOSED |
+
+### 1.2 Merged PRs
+
+| PR | Title | SHA |
+|----|-------|-----|
+| #2287 | docs(context): define agent briefing schema v1 | `96658be` |
+| #2294 | feat(context): implement stop condition resolver v1 | `b6904f0` |
+| #2295 | feat(context): implement required reads resolver v1 | `335dd7a` |
+| #2319 | feat(context): implement Impact Radar v1 | `6917a95` |
+| #2321 | feat(context): implement Validation Plan Generator v1 | `c4e3c1e` |
+| #2335 | test(context): add wave 13 briefing and impact coverage | `5390cac` |
+| #2336 | docs(context): add briefing and impact radar runbook | `50a0555` |
+
+---
+
+## 2. Deliverables
+
+### 2.1 Service Implementations
+
+| File | Description | State |
+|------|-------------|-------|
+| `tools/surrealdb/context_stop_resolver.py` | Stop-condition resolver v1 | MERGED (b6904f0) |
+| `tools/surrealdb/context_required_reads.py` | Required-reads resolver v1 | MERGED (335dd7a) |
+| `tools/surrealdb/context_impact_radar.py` | Impact radar v1 | MERGED (6917a95) |
+| `tools/surrealdb/context_validation_plan.py` | Validation plan generator v1 | MERGED (c4e3c1e) |
+
+All services are read-only, fail-closed, in-memory (NoopAdapter pattern). No SurrealDB writes.
+
+### 2.2 MCP Bridge (context_bridge.py)
+
+`tools/mcp/context_bridge.py` includes `context_briefing_handler` and `context_impact_handler`
+wired to all Wave-13 services. Registry (`tools/mcp/registry.py`) exposes:
+
+- `context.briefing`
+- `context.impact_radar`
+- `context.stop_resolver`
+- `context.required_reads`
+- `context.validation_plan`
+
+All registered with `read_only=True` enforced by `PermissionGuard`.
+
+### 2.3 Schema & Docs
+
+| File | PR |
+|------|----|
+| `docs/surrealdb/context-agent-briefing-schema-v1.md` | #2287 |
+| `docs/surrealdb/context-briefing-impact-runbook.md` | #2336 |
+
+### 2.4 Tests (140 pass)
+
+| Test File | Tests |
+|-----------|-------|
+| `tests/unit/surrealdb/test_context_stop_resolver.py` | ✓ |
+| `tests/unit/surrealdb/test_context_required_reads.py` | ✓ |
+| `tests/unit/surrealdb/test_context_impact_radar.py` | ✓ |
+| `tests/unit/surrealdb/test_context_validation_plan.py` | ✓ |
+| `tests/unit/tools/mcp/test_mcp_briefing_tool.py` | ✓ |
+| `tests/unit/tools/mcp/test_mcp_impact_tool.py` | ✓ |
+
+`pytest tests/unit/surrealdb/ tests/unit/tools/mcp/ --tb=no -q` → **140 passed**
+
+---
+
+## 3. Completion Gate Criteria
+
+| Gate | Status |
+|------|--------|
+| All child issues CLOSED | ✅ #2104–#2113 CLOSED |
+| All PRs merged to main | ✅ PRs #2287, #2294, #2295, #2319, #2321, #2335, #2336 MERGED |
+| Unit tests pass (140 total) | ✅ 140 passed, 0 failed |
+| All tools read-only, fail-closed | ✅ PermissionGuard enforced |
+| No SurrealDB writes | ✅ NoopAdapter pattern throughout |
+| No live capital, no Echtgeld | ✅ LR remains NO-GO |
+| Gates doc committed | ✅ This document |
+
+**Wave 13 is COMPLETE. All gates satisfied.**
+
+---
+
+## 4. Governance Notes
+
+- LR-STATUS: NO-GO (unchanged — this is context tooling, not trading)
+- Board-Stage: `trade-capable` (orthogonal to LR, does not authorize Echtgeld)
+- `approval_semantics.no_echtgeld_go: true` — every context tool response carries this flag
+- All decision events are read-only traces; no mutation of system state


### PR DESCRIPTION
## Summary

Closes #2114
Closes #2103

Adds the Wave-13 completion gates document
(`docs/surrealdb/context-wave13-completion-gates.md`).

## Evidence

All Wave-13 child issues (#2104–#2113) are CLOSED.
All 7 Wave-13 PRs are merged to main:
- #2287 — agent briefing schema
- #2294 — stop condition resolver
- #2295 — required reads resolver
- #2319 — impact radar
- #2321 — validation plan generator
- #2335 — wave 13 tests (140 tests pass)
- #2336 — briefing + impact runbook

## Gates

- All child issues CLOSED ✅
- All PRs merged ✅
- 140 unit tests pass ✅
- All tools read-only, fail-closed ✅
- No SurrealDB writes ✅
- LR remains NO-GO ✅

## Governance

- LR-STATUS: NO-GO (unchanged)
- Board-Stage: `trade-capable` (orthogonal to LR)
- `approval_semantics.no_echtgeld_go: true`