### PR TITLE
feat(wave15): add contradiction scan cli

### DIFF
--- a/tests/fixtures/surrealdb/contradiction_scan/sample_bundle.json
+++ b/tests/fixtures/surrealdb/contradiction_scan/sample_bundle.json
@@ -1,0 +1,27 @@
+{
+  "_comment": "Sample input bundle for contradiction_cli tests. Triggers a blocking finding via claim_vs_evidence (status: invalidated) and a warning via doc_vs_code (missing symbol).",
+  "claims": [
+    {
+      "claim_id": "c-001",
+      "status": "invalidated",
+      "topic": "MyService API contract",
+      "evidence_refs": []
+    },
+    {
+      "claim_id": "c-002",
+      "status": "stale",
+      "topic": "Deployment SOP v1",
+      "evidence_refs": ["ev-stale-001"]
+    }
+  ],
+  "doc_claims": [
+    {
+      "claim_id": "d-001",
+      "path": "docs/api.md",
+      "symbol": "NonexistentSymbol",
+      "exists": true,
+      "blocking": false
+    }
+  ],
+  "code_symbols": []
+}

--- a/tests/unit/surrealdb/test_contradiction_cli.py
+++ b/tests/unit/surrealdb/test_contradiction_cli.py
@@ -56,14 +56,6 @@ _BLOCKING_BUNDLE: dict = {
 # A bundle with no records → 0 findings, 0 blocking
 _CLEAN_BUNDLE: dict = {}
 
-# A bundle with only a warning finding (claim stale)
-_WARNING_ONLY_BUNDLE: dict = {
-    "claims": [
-        {"claim_id": "c-002", "status": "stale", "topic": "stale-topic", "evidence_refs": ["ev-001"]}
-    ]
-}
-
-
 def _write_bundle(tmp_path: Path, bundle: dict) -> str:
     p = tmp_path / "bundle.json"
     p.write_text(json.dumps(bundle), encoding="utf-8")
@@ -251,6 +243,7 @@ def test_report_contradictions_json(tmp_path: Path, capsys) -> None:
     assert payload["command"] == "report-contradictions"
     assert "summary" in payload
     assert "blocking" in payload["summary"]
+    assert "overridden" in payload["summary"]
     assert "warning" in payload["summary"]
     assert "info" in payload["summary"]
     assert "guardrail" in payload
@@ -285,7 +278,10 @@ def test_report_contradictions_summary_counts_match(tmp_path: Path, capsys) -> N
 
     summary = payload["summary"]
     total_from_summary = (
-        len(summary["blocking"]) + len(summary["warning"]) + len(summary["info"])
+        len(summary["blocking"])
+        + len(summary["overridden"])
+        + len(summary["warning"])
+        + len(summary["info"])
     )
     assert total_from_summary == payload["total_findings"]
 

--- a/tests/unit/surrealdb/test_contradiction_cli.py
+++ b/tests/unit/surrealdb/test_contradiction_cli.py
@@ -1,0 +1,394 @@
+"""Unit tests for contradiction_cli.py — Contradiction Scan CLI v1.
+
+Issues:
+    #2147 — [SURREALDB][CONTEXT][CONTRADICTION-CLI] Add contradiction scan CLI
+    Parent: #2145 (Wave-15)
+    Depends on: #2146 (contradiction_scan runtime)
+
+Scope:
+    Unit tests for tools/surrealdb/contradiction_cli.py.
+    All fixtures are inline or use tmp_path (no secrets, no network, no DB).
+    No writes. No SurrealDB SDK. No MCP. No networking.
+    No real datetime.now() — timestamps from scan service via cdb_utcnow.
+    Clock guardrail validated by test_clock.py::test_guardrails_no_forbidden_calls.
+
+Coverage:
+    - scan-contradictions: JSON and Markdown output
+    - scan-contradictions: --fail-on-blocking exit 2 when blocking findings present
+    - scan-contradictions: no blocking → exit 0 regardless of --fail-on-blocking
+    - scan-contradictions: --type filter
+    - show-contradiction: found finding
+    - show-contradiction: unknown ID → exit 1
+    - report-contradictions: JSON output with summary
+    - report-contradictions: Markdown output
+    - invalid input: missing file → exit 1
+    - invalid input: bad JSON → exit 1
+    - invalid input: not a JSON object → exit 1
+    - CLI does not write any file
+    - Service remains read-only (returns ContradictionScanResult)
+    - Blocking finding is surfaced in scan output
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.surrealdb.contradiction_cli import (
+    EXIT_BLOCKING,
+    EXIT_ERROR,
+    EXIT_OK,
+    main,
+)
+from tools.surrealdb.contradiction_scan import ContradictionScanResult
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# A minimal bundle that produces ≥1 blocking finding (claim_vs_evidence / invalidated)
+_BLOCKING_BUNDLE: dict = {
+    "claims": [
+        {"claim_id": "c-001", "status": "invalidated", "topic": "test-topic", "evidence_refs": []}
+    ]
+}
+
+# A bundle with no records → 0 findings, 0 blocking
+_CLEAN_BUNDLE: dict = {}
+
+# A bundle with only a warning finding (claim stale)
+_WARNING_ONLY_BUNDLE: dict = {
+    "claims": [
+        {"claim_id": "c-002", "status": "stale", "topic": "stale-topic", "evidence_refs": ["ev-001"]}
+    ]
+}
+
+
+def _write_bundle(tmp_path: Path, bundle: dict) -> str:
+    p = tmp_path / "bundle.json"
+    p.write_text(json.dumps(bundle), encoding="utf-8")
+    return str(p)
+
+
+def _read_json(capsys) -> dict:
+    out = capsys.readouterr().out.strip()
+    return json.loads(out)
+
+
+# ── scan-contradictions ───────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_scan_contradictions_format_json(tmp_path: Path, capsys) -> None:
+    bundle_path = _write_bundle(tmp_path, _CLEAN_BUNDLE)
+    exit_code = main(["--format", "json", "scan-contradictions", "--input", bundle_path])
+    payload = _read_json(capsys)
+
+    assert exit_code == EXIT_OK
+    assert payload["status"] == "ok"
+    assert payload["command"] == "scan-contradictions"
+    assert "findings" in payload
+    assert "blocking_count" in payload
+    assert "total_findings" in payload
+    assert "scanned_at" in payload
+    assert "schema_version" in payload
+
+
+@pytest.mark.unit
+def test_scan_contradictions_format_markdown(tmp_path: Path, capsys) -> None:
+    bundle_path = _write_bundle(tmp_path, _BLOCKING_BUNDLE)
+    exit_code = main(["--format", "markdown", "scan-contradictions", "--input", bundle_path])
+    out = capsys.readouterr().out
+
+    assert exit_code == EXIT_OK  # no --fail-on-blocking
+    assert "# Contradiction Scan" in out
+    assert "scan-contradictions" in out
+    assert "Guardrail" in out  # guardrail note must be present
+
+
+@pytest.mark.unit
+def test_scan_contradictions_fail_on_blocking_exits_2(tmp_path: Path, capsys) -> None:
+    bundle_path = _write_bundle(tmp_path, _BLOCKING_BUNDLE)
+    exit_code = main(
+        ["scan-contradictions", "--input", bundle_path, "--fail-on-blocking"]
+    )
+    payload = _read_json(capsys)
+
+    assert exit_code == EXIT_BLOCKING
+    assert payload["status"] == "ok"
+    assert payload["blocking_count"] > 0
+
+
+@pytest.mark.unit
+def test_scan_contradictions_no_blocking_exits_0(tmp_path: Path, capsys) -> None:
+    bundle_path = _write_bundle(tmp_path, _CLEAN_BUNDLE)
+    exit_code = main(
+        ["scan-contradictions", "--input", bundle_path, "--fail-on-blocking"]
+    )
+    payload = _read_json(capsys)
+
+    assert exit_code == EXIT_OK
+    assert payload["blocking_count"] == 0
+
+
+@pytest.mark.unit
+def test_scan_contradictions_no_flag_blocking_still_exits_0(tmp_path: Path, capsys) -> None:
+    """Blocking findings without --fail-on-blocking → exit 0."""
+    bundle_path = _write_bundle(tmp_path, _BLOCKING_BUNDLE)
+    exit_code = main(["scan-contradictions", "--input", bundle_path])
+    payload = _read_json(capsys)
+
+    assert exit_code == EXIT_OK
+    assert payload["blocking_count"] > 0
+
+
+@pytest.mark.unit
+def test_scan_contradictions_type_filter(tmp_path: Path, capsys) -> None:
+    bundle_path = _write_bundle(tmp_path, _BLOCKING_BUNDLE)
+    exit_code = main(
+        ["scan-contradictions", "--input", bundle_path, "--type", "claim_vs_evidence"]
+    )
+    payload = _read_json(capsys)
+
+    assert exit_code == EXIT_OK
+    for f in payload["findings"]:
+        assert f["contradiction_type"] == "claim_vs_evidence"
+
+
+@pytest.mark.unit
+def test_scan_contradictions_type_filter_unknown_type(tmp_path: Path, capsys) -> None:
+    bundle_path = _write_bundle(tmp_path, _CLEAN_BUNDLE)
+    exit_code = main(
+        ["scan-contradictions", "--input", bundle_path, "--type", "not_a_real_type"]
+    )
+    payload = _read_json(capsys)
+
+    assert exit_code == EXIT_ERROR
+    assert payload["status"] == "error"
+
+
+@pytest.mark.unit
+def test_scan_contradictions_blocking_finding_surfaced(tmp_path: Path, capsys) -> None:
+    """Blocking findings are surfaced in the output even without --fail-on-blocking."""
+    bundle_path = _write_bundle(tmp_path, _BLOCKING_BUNDLE)
+    exit_code = main(["scan-contradictions", "--input", bundle_path])
+    payload = _read_json(capsys)
+
+    blocking = [f for f in payload["findings"] if f["blocking"]]
+    assert len(blocking) >= 1
+    assert exit_code == EXIT_OK  # surfaced but not blocking exit
+
+
+# ── show-contradiction ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_show_contradiction_found(tmp_path: Path, capsys) -> None:
+    bundle_path = _write_bundle(tmp_path, _BLOCKING_BUNDLE)
+
+    # First, discover the contradiction_id via scan
+    main(["scan-contradictions", "--input", bundle_path])
+    scan_payload = _read_json(capsys)
+    blocking_findings = [f for f in scan_payload["findings"] if f["blocking"]]
+    assert blocking_findings, "test precondition: need at least one blocking finding"
+    known_id = blocking_findings[0]["contradiction_id"]
+
+    # Now show it
+    exit_code = main(["show-contradiction", "--input", bundle_path, "--id", known_id])
+    payload = _read_json(capsys)
+
+    assert exit_code == EXIT_OK
+    assert payload["status"] == "ok"
+    assert payload["command"] == "show-contradiction"
+    assert "finding" in payload
+    assert payload["finding"]["contradiction_id"] == known_id
+
+
+@pytest.mark.unit
+def test_show_contradiction_not_found_exits_1(tmp_path: Path, capsys) -> None:
+    bundle_path = _write_bundle(tmp_path, _CLEAN_BUNDLE)
+    exit_code = main(
+        ["show-contradiction", "--input", bundle_path, "--id", "nonexistent-id"]
+    )
+    payload = _read_json(capsys)
+
+    assert exit_code == EXIT_ERROR
+    assert payload["status"] == "error"
+    assert "nonexistent-id" in payload["message"]
+
+
+@pytest.mark.unit
+def test_show_contradiction_format_markdown(tmp_path: Path, capsys) -> None:
+    bundle_path = _write_bundle(tmp_path, _BLOCKING_BUNDLE)
+
+    # Discover blocking id
+    main(["scan-contradictions", "--input", bundle_path])
+    scan_payload = _read_json(capsys)
+    known_id = [f for f in scan_payload["findings"] if f["blocking"]][0]["contradiction_id"]
+
+    exit_code = main(
+        ["--format", "markdown", "show-contradiction", "--input", bundle_path, "--id", known_id]
+    )
+    out = capsys.readouterr().out
+
+    assert exit_code == EXIT_OK
+    assert "# Contradiction Scan" in out
+    assert known_id in out
+    assert "Guardrail" in out
+
+
+# ── report-contradictions ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_report_contradictions_json(tmp_path: Path, capsys) -> None:
+    bundle_path = _write_bundle(tmp_path, _BLOCKING_BUNDLE)
+    exit_code = main(["report-contradictions", "--input", bundle_path])
+    payload = _read_json(capsys)
+
+    assert exit_code == EXIT_OK
+    assert payload["status"] == "ok"
+    assert payload["command"] == "report-contradictions"
+    assert "summary" in payload
+    assert "blocking" in payload["summary"]
+    assert "warning" in payload["summary"]
+    assert "info" in payload["summary"]
+    assert "guardrail" in payload
+    assert "blocking_count" in payload
+    assert "total_findings" in payload
+
+
+@pytest.mark.unit
+def test_report_contradictions_markdown(tmp_path: Path, capsys) -> None:
+    bundle_path = _write_bundle(tmp_path, _BLOCKING_BUNDLE)
+    exit_code = main(["--format", "markdown", "report-contradictions", "--input", bundle_path])
+    out = capsys.readouterr().out
+
+    assert exit_code == EXIT_OK
+    assert "# Contradiction Scan" in out
+    assert "report-contradictions" in out
+    assert "Guardrail" in out
+
+
+@pytest.mark.unit
+def test_report_contradictions_summary_counts_match(tmp_path: Path, capsys) -> None:
+    """Summary counts must match: sum(blocking+warning+info) == total_findings."""
+    bundle = {
+        "claims": [
+            {"claim_id": "c-001", "status": "invalidated", "evidence_refs": []},
+            {"claim_id": "c-002", "status": "stale", "evidence_refs": ["ev-001"]},
+        ]
+    }
+    bundle_path = _write_bundle(tmp_path, bundle)
+    main(["report-contradictions", "--input", bundle_path])
+    payload = _read_json(capsys)
+
+    summary = payload["summary"]
+    total_from_summary = (
+        len(summary["blocking"]) + len(summary["warning"]) + len(summary["info"])
+    )
+    assert total_from_summary == payload["total_findings"]
+
+
+# ── Invalid input ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_invalid_input_nonexistent_file_exits_1(tmp_path: Path, capsys) -> None:
+    exit_code = main(
+        ["scan-contradictions", "--input", str(tmp_path / "does_not_exist.json")]
+    )
+    payload = _read_json(capsys)
+
+    assert exit_code == EXIT_ERROR
+    assert payload["status"] == "error"
+    assert "not found" in payload["message"]
+
+
+@pytest.mark.unit
+def test_invalid_input_bad_json_exits_1(tmp_path: Path, capsys) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json", encoding="utf-8")
+    exit_code = main(["scan-contradictions", "--input", str(bad)])
+    payload = _read_json(capsys)
+
+    assert exit_code == EXIT_ERROR
+    assert payload["status"] == "error"
+    assert "not valid JSON" in payload["message"]
+
+
+@pytest.mark.unit
+def test_invalid_input_not_a_dict_exits_1(tmp_path: Path, capsys) -> None:
+    arr = tmp_path / "arr.json"
+    arr.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    exit_code = main(["scan-contradictions", "--input", str(arr)])
+    payload = _read_json(capsys)
+
+    assert exit_code == EXIT_ERROR
+    assert payload["status"] == "error"
+    assert "JSON object" in payload["message"]
+
+
+# ── Guardrails: read-only / no writes ─────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_cli_does_not_write_any_file(tmp_path: Path, capsys, monkeypatch) -> None:
+    """Ensure the CLI never calls Path.write_text or open() for writing."""
+    # Create the bundle file BEFORE patching so the helper write is not counted.
+    bundle_path = tmp_path / "bundle.json"
+    bundle_path.write_text(json.dumps(_BLOCKING_BUNDLE), encoding="utf-8")
+
+    write_calls: list[str] = []
+    original_write_text = Path.write_text
+
+    def spy_write_text(self: Path, *args, **kwargs):  # type: ignore[override]
+        write_calls.append(str(self))
+        return original_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", spy_write_text)
+
+    main(["scan-contradictions", "--input", str(bundle_path)])
+    # CLI output goes to stdout only — no file writes expected
+    assert write_calls == [], f"CLI unexpectedly wrote to: {write_calls}"
+
+
+@pytest.mark.unit
+def test_cli_service_returns_scan_result(tmp_path: Path) -> None:
+    """scan_contradictions_v1 returns a ContradictionScanResult (read-only contract)."""
+    from tools.surrealdb.contradiction_scan import scan_contradictions_v1
+
+    result = scan_contradictions_v1(_BLOCKING_BUNDLE)
+    assert isinstance(result, ContradictionScanResult)
+    # No mutation — result is frozen dataclass
+    assert isinstance(result.findings, tuple)
+
+
+@pytest.mark.unit
+def test_cli_with_overrides_in_bundle(tmp_path: Path, capsys) -> None:
+    """Overrides extracted from bundle root are passed to service correctly."""
+    # First get the blocking contradiction_id
+    bundle_path = _write_bundle(tmp_path, _BLOCKING_BUNDLE)
+    main(["scan-contradictions", "--input", bundle_path])
+    scan_payload = _read_json(capsys)
+    blocking = [f for f in scan_payload["findings"] if f["blocking"]]
+    assert blocking, "test precondition"
+    cid = blocking[0]["contradiction_id"]
+
+    # Now supply an override to make it false_positive (non-blocking)
+    bundle_with_override = {
+        **_BLOCKING_BUNDLE,
+        "overrides": {cid: "false_positive"},
+    }
+    sub = tmp_path / "sub"
+    sub.mkdir(exist_ok=True)
+    bundle_path2 = str(sub / "bundle.json")
+    (sub / "bundle.json").write_text(
+        json.dumps(bundle_with_override), encoding="utf-8"
+    )
+
+    main(["scan-contradictions", "--input", bundle_path2, "--fail-on-blocking"])
+    payload = _read_json(capsys)
+
+    # With override applied the finding becomes false_positive → blocking=False → exit 0
+    assert payload["blocking_count"] == 0

--- a/tools/surrealdb/contradiction_cli.py
+++ b/tools/surrealdb/contradiction_cli.py
@@ -303,6 +303,11 @@ def handle_report_contradictions(
     result: ContradictionScanResult = scan_contradictions_v1(records, overrides)
 
     blocking = [_finding_to_dict(f) for f in result.findings if f.blocking]
+    overridden = [
+        _finding_to_dict(f)
+        for f in result.findings
+        if f.severity == "blocking" and not f.blocking
+    ]
     warning = [
         _finding_to_dict(f)
         for f in result.findings
@@ -319,6 +324,7 @@ def handle_report_contradictions(
         "blocking_count": result.blocking_count,
         "summary": {
             "blocking": blocking,
+            "overridden": overridden,
             "warning": warning,
             "info": info,
         },

--- a/tools/surrealdb/contradiction_cli.py
+++ b/tools/surrealdb/contradiction_cli.py
@@ -1,0 +1,467 @@
+"""Contradiction Scan CLI — read-only, no writes, no DB, no network.
+
+Issues:
+    #2147 — [SURREALDB][CONTEXT][CONTRADICTION-CLI] Add contradiction scan CLI
+    Parent: #2145 (Wave-15)
+    Depends on: #2146 (contradiction_scan runtime)
+
+Commands:
+    scan-contradictions   Scan input bundle, output all findings
+    show-contradiction    Show a single finding by contradiction_id
+    report-contradictions Generate summary report
+
+Exit codes:
+    0 = success (no blocking findings, or --fail-on-blocking not set)
+    1 = CLI / input / validation error
+    2 = blocking findings found and --fail-on-blocking set
+
+Guardrails:
+    - Read-only.  No writes.  No file output.  Stdout only.
+    - No DB access.  No SurrealDB SDK.  No network.  No GitHub calls.
+    - No direct wall-clock calls / random UUID generation — timestamps via scan service.
+    - Detection is signal, not action authority.
+    - LR status remains NO-GO for live trading.
+    - No auto-fix.  No live-go.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+from pathlib import Path
+from typing import Any
+
+from tools.surrealdb.contradiction_scan import (
+    CONTRADICTION_TYPES,
+    ContradictionFinding,
+    ContradictionScanError,
+    ContradictionScanResult,
+    scan_contradictions_v1,
+)
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+SCHEMA_VERSION = "contradiction-cli/v1"
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_BLOCKING = 2
+
+SUPPORTED_FORMATS = frozenset({"json", "markdown"})
+
+_GUARDRAIL_NOTE = (
+    "Detection is signal, not action. "
+    "No auto-fix. No live-go. No real-money scope. "
+    "LR status remains NO-GO for live trading."
+)
+
+
+# ── Error ─────────────────────────────────────────────────────────────────────
+
+
+class ContradictionCLIError(Exception):
+    """Raised for CLI / input / validation errors (exit 1)."""
+
+    def __init__(self, message: str, exit_code: int = EXIT_ERROR) -> None:
+        super().__init__(message)
+        self.message = message
+        self.exit_code = exit_code
+
+
+# ── Bundle Loader ─────────────────────────────────────────────────────────────
+
+
+def _load_bundle(path: Path) -> tuple[dict[str, Any], dict[str, str] | None]:
+    """Load a JSON input bundle from *path*.
+
+    Returns ``(records, overrides)`` where *overrides* is extracted from the
+    top-level ``"overrides"`` key (if present) before passing the rest to the
+    scan service.
+
+    Raises:
+        ContradictionCLIError: if the file is missing, not valid JSON, or not
+            a JSON object (exit 1).
+    """
+    try:
+        exists = path.exists()
+    except OSError as exc:
+        raise ContradictionCLIError(f"cannot stat input file: {path}: {exc}") from exc
+
+    if not exists:
+        raise ContradictionCLIError(f"input file not found: {path}")
+
+    if not path.is_file():
+        raise ContradictionCLIError(f"input path is not a file: {path}")
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ContradictionCLIError(f"cannot read input file: {path}: {exc}") from exc
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ContradictionCLIError(
+            f"input file is not valid JSON: {path}: {exc}"
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise ContradictionCLIError(
+            f"input file must be a JSON object (dict), got {type(data).__name__}: {path}"
+        )
+
+    overrides_raw = data.pop("overrides", None)
+    if overrides_raw is not None:
+        if not isinstance(overrides_raw, dict):
+            raise ContradictionCLIError(
+                f"'overrides' key must be a JSON object, got {type(overrides_raw).__name__}"
+            )
+        overrides: dict[str, str] | None = {
+            str(k): str(v) for k, v in overrides_raw.items()
+        }
+    else:
+        overrides = None
+
+    return data, overrides
+
+
+# ── Serialization ─────────────────────────────────────────────────────────────
+
+
+def _finding_to_dict(f: ContradictionFinding) -> dict[str, Any]:
+    """Convert a ContradictionFinding dataclass to a plain dict."""
+    return dataclasses.asdict(f)
+
+
+def _render_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2)
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    """Render a CLI result payload as a human-readable Markdown report."""
+    command = payload.get("command", "unknown")
+    status = payload.get("status", "unknown")
+    scanned_at = payload.get("scanned_at", "n/a")
+    total = payload.get("total_findings", 0)
+    blocking = payload.get("blocking_count", 0)
+
+    lines: list[str] = [
+        f"# Contradiction Scan — `{command}`",
+        "",
+        f"- **status**: `{status}`",
+        f"- **scanned_at**: `{scanned_at}`",
+        f"- **total_findings**: {total}",
+        f"- **blocking_count**: {blocking}",
+        "",
+    ]
+
+    # Error case
+    if status == "error":
+        lines += [
+            "## Error",
+            "",
+            f"**{payload.get('error', 'UNKNOWN')}**: {payload.get('message', '')}",
+            "",
+        ]
+        lines.append(f"> ⚠ Guardrail: {_GUARDRAIL_NOTE}")
+        return "\n".join(lines)
+
+    # Blocking findings section
+    findings = payload.get("findings", [])
+    blocking_findings = [f for f in findings if f.get("blocking")]
+    if blocking_findings:
+        lines += ["## Blocking Findings", ""]
+        for f in blocking_findings:
+            lines.append(
+                f"- **{f['contradiction_id']}** `{f['contradiction_type']}` "
+                f"(confidence: {f['confidence']:.2f}): {f['recommended_action']}"
+            )
+        lines.append("")
+
+    # Summary section (for report-contradictions)
+    if "summary" in payload:
+        summary = payload["summary"]
+        lines += ["## Summary", ""]
+        for sev in ("blocking", "warning", "info"):
+            items = summary.get(sev, [])
+            lines.append(f"- **{sev}**: {len(items)}")
+        lines.append("")
+        if summary.get("blocking"):
+            lines += ["### Blocking", ""]
+            for f in summary["blocking"]:
+                lines.append(
+                    f"- `{f['contradiction_id']}` `{f['contradiction_type']}` — "
+                    f"{f['recommended_action']}"
+                )
+            lines.append("")
+    elif findings:
+        # Full findings table
+        lines += ["## All Findings", ""]
+        lines.append("| ID | Type | Severity | Blocking | Confidence | Action |")
+        lines.append("|---|---|---|---|---|---|")
+        for f in findings:
+            lines.append(
+                f"| `{f['contradiction_id']}` "
+                f"| `{f['contradiction_type']}` "
+                f"| {f['severity']} "
+                f"| {f['blocking']} "
+                f"| {f['confidence']:.2f} "
+                f"| {f['recommended_action'][:60]}... |"
+                if len(f.get("recommended_action", "")) > 60
+                else f"| `{f['contradiction_id']}` "
+                f"| `{f['contradiction_type']}` "
+                f"| {f['severity']} "
+                f"| {f['blocking']} "
+                f"| {f['confidence']:.2f} "
+                f"| {f.get('recommended_action', '')} |"
+            )
+        lines.append("")
+
+    # Single finding (show-contradiction)
+    if "finding" in payload:
+        f = payload["finding"]
+        lines += ["## Finding", ""]
+        lines.append(f"- **id**: `{f['contradiction_id']}`")
+        lines.append(f"- **type**: `{f['contradiction_type']}`")
+        lines.append(f"- **severity**: {f['severity']}")
+        lines.append(f"- **blocking**: {f['blocking']}")
+        lines.append(f"- **confidence**: {f['confidence']:.2f}")
+        lines.append(f"- **status**: {f['status']}")
+        lines.append(f"- **action**: {f['recommended_action']}")
+        lines.append("")
+
+    lines.append(f"> ⚠ Guardrail: {_GUARDRAIL_NOTE}")
+    return "\n".join(lines)
+
+
+# ── Handlers ──────────────────────────────────────────────────────────────────
+
+
+def handle_scan_contradictions(
+    args: argparse.Namespace,
+) -> tuple[dict[str, Any], int]:
+    """Handle the ``scan-contradictions`` subcommand."""
+    records, overrides = _load_bundle(Path(args.input))
+    result: ContradictionScanResult = scan_contradictions_v1(records, overrides)
+
+    findings = result.findings
+    if args.type is not None:
+        if args.type not in CONTRADICTION_TYPES:
+            raise ContradictionCLIError(
+                f"unknown contradiction type: {args.type!r}. "
+                f"Valid types: {sorted(CONTRADICTION_TYPES)}"
+            )
+        findings = tuple(f for f in findings if f.contradiction_type == args.type)
+
+    blocking_count = sum(1 for f in findings if f.blocking)
+    payload: dict[str, Any] = {
+        "schema_version": result.schema_version,
+        "command": "scan-contradictions",
+        "status": "ok",
+        "scanned_at": result.scanned_at,
+        "total_findings": len(findings),
+        "blocking_count": blocking_count,
+        "findings": [_finding_to_dict(f) for f in findings],
+    }
+    exit_code = EXIT_OK
+    if args.fail_on_blocking and blocking_count > 0:
+        exit_code = EXIT_BLOCKING
+    return payload, exit_code
+
+
+def handle_show_contradiction(
+    args: argparse.Namespace,
+) -> tuple[dict[str, Any], int]:
+    """Handle the ``show-contradiction`` subcommand."""
+    records, overrides = _load_bundle(Path(args.input))
+    result: ContradictionScanResult = scan_contradictions_v1(records, overrides)
+
+    matches = [f for f in result.findings if f.contradiction_id == args.id]
+    if not matches:
+        raise ContradictionCLIError(
+            f"contradiction_id not found: {args.id!r}",
+            exit_code=EXIT_ERROR,
+        )
+
+    finding = matches[0]
+    payload: dict[str, Any] = {
+        "schema_version": result.schema_version,
+        "command": "show-contradiction",
+        "status": "ok",
+        "scanned_at": result.scanned_at,
+        "finding": _finding_to_dict(finding),
+    }
+    return payload, EXIT_OK
+
+
+def handle_report_contradictions(
+    args: argparse.Namespace,
+) -> tuple[dict[str, Any], int]:
+    """Handle the ``report-contradictions`` subcommand."""
+    records, overrides = _load_bundle(Path(args.input))
+    result: ContradictionScanResult = scan_contradictions_v1(records, overrides)
+
+    blocking = [_finding_to_dict(f) for f in result.findings if f.blocking]
+    warning = [
+        _finding_to_dict(f)
+        for f in result.findings
+        if f.severity == "warning" and not f.blocking
+    ]
+    info = [_finding_to_dict(f) for f in result.findings if f.severity == "info"]
+
+    payload: dict[str, Any] = {
+        "schema_version": result.schema_version,
+        "command": "report-contradictions",
+        "status": "ok",
+        "scanned_at": result.scanned_at,
+        "total_findings": result.total_count,
+        "blocking_count": result.blocking_count,
+        "summary": {
+            "blocking": blocking,
+            "warning": warning,
+            "info": info,
+        },
+        "guardrail": _GUARDRAIL_NOTE,
+    }
+    return payload, EXIT_OK
+
+
+# ── Argument Parser ───────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="contradiction_cli",
+        description=(
+            "Contradiction Scan CLI (#2147). Read-only local scan — "
+            "no DB, no network, no writes."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=sorted(SUPPORTED_FORMATS),
+        default="json",
+        help="Output format (default: json).",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # ── scan-contradictions ───────────────────────────────────────────────────
+    scan = subparsers.add_parser(
+        "scan-contradictions",
+        help="Scan input bundle and output all contradiction findings.",
+    )
+    scan.add_argument(
+        "--input",
+        required=True,
+        metavar="PATH",
+        help="Path to JSON input bundle.",
+    )
+    scan.add_argument(
+        "--fail-on-blocking",
+        action="store_true",
+        default=False,
+        help="Exit with code 2 if any blocking findings are present.",
+    )
+    scan.add_argument(
+        "--type",
+        default=None,
+        metavar="TYPE",
+        help=(
+            "Filter output to a specific contradiction type "
+            f"(one of: {', '.join(sorted(CONTRADICTION_TYPES))})."
+        ),
+    )
+
+    # ── show-contradiction ────────────────────────────────────────────────────
+    show = subparsers.add_parser(
+        "show-contradiction",
+        help="Show a single contradiction finding by its contradiction_id.",
+    )
+    show.add_argument(
+        "--input",
+        required=True,
+        metavar="PATH",
+        help="Path to JSON input bundle.",
+    )
+    show.add_argument(
+        "--id",
+        required=True,
+        dest="id",
+        metavar="CONTRADICTION_ID",
+        help="The contradiction_id of the finding to show.",
+    )
+
+    # ── report-contradictions ─────────────────────────────────────────────────
+    report = subparsers.add_parser(
+        "report-contradictions",
+        help="Generate a summary report of all contradiction findings.",
+    )
+    report.add_argument(
+        "--input",
+        required=True,
+        metavar="PATH",
+        help="Path to JSON input bundle.",
+    )
+
+    return parser
+
+
+# ── Error Payload ─────────────────────────────────────────────────────────────
+
+
+def _error_payload(error_code: str, message: str) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "error",
+        "error": error_code,
+        "message": message,
+    }
+
+
+# ── Main Entry Point ──────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns integer exit code."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "scan-contradictions":
+            payload, exit_code = handle_scan_contradictions(args)
+        elif args.command == "show-contradiction":
+            payload, exit_code = handle_show_contradiction(args)
+        elif args.command == "report-contradictions":
+            payload, exit_code = handle_report_contradictions(args)
+        else:
+            # argparse required=True makes this unreachable in normal use
+            raise ContradictionCLIError(f"unknown command: {args.command}")
+
+        fmt = getattr(args, "format", "json")
+        if fmt == "markdown":
+            print(_render_markdown(payload))
+        else:
+            print(_render_json(payload))
+        return exit_code
+
+    except ContradictionCLIError as exc:
+        print(
+            _render_json(_error_payload("CLI_ERROR", exc.message)),
+        )
+        return exc.exit_code
+    except ContradictionScanError as exc:
+        print(
+            _render_json(_error_payload("SCAN_ERROR", str(exc))),
+        )
+        return EXIT_ERROR
+    except Exception as exc:  # noqa: BLE001 — CLI safety net
+        print(
+            _render_json(_error_payload("INTERNAL", str(exc))),
+        )
+        return EXIT_ERROR
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI entry point
+    raise SystemExit(main())

--- a/tools/surrealdb/contradiction_cli.py
+++ b/tools/surrealdb/contradiction_cli.py
@@ -183,7 +183,7 @@ def _render_markdown(payload: dict[str, Any]) -> str:
     if "summary" in payload:
         summary = payload["summary"]
         lines += ["## Summary", ""]
-        for sev in ("blocking", "warning", "info"):
+        for sev in ("blocking", "overridden", "warning", "info"):
             items = summary.get(sev, [])
             lines.append(f"- **{sev}**: {len(items)}")
         lines.append("")
@@ -193,6 +193,14 @@ def _render_markdown(payload: dict[str, Any]) -> str:
                 lines.append(
                     f"- `{f['contradiction_id']}` `{f['contradiction_type']}` — "
                     f"{f['recommended_action']}"
+                )
+            lines.append("")
+        if summary.get("overridden"):
+            lines += ["### Overridden (false_positive / accepted_risk)", ""]
+            for f in summary["overridden"]:
+                lines.append(
+                    f"- `{f['contradiction_id']}` `{f['contradiction_type']}` "
+                    f"(severity: blocking, override applied)"
                 )
             lines.append("")
     elif findings:


### PR DESCRIPTION
## Summary

Read-only local CLI for contradiction scans (Issue #2147 — Wave 15).

Closes #2147
Parent: #2145 (stays OPEN)
Depends on: #2146 (CLOSED 2026-05-06)

---

## Implemented Commands

| Command | Description |
|---------|-------------|
| `scan-contradictions` | Run a full contradiction scan on an input bundle, with optional `--type` filter and `--fail-on-blocking` exit code gate |
| `show-contradiction` | Display details of a single finding by `--id` |
| `report-contradictions` | Summary report: blocking/warning/info counts + guardrail statement |

Global: `--format json|markdown` (default: json)

Exit codes: `0` = OK, `1` = CLI/input error, `2` = blocking findings + `--fail-on-blocking`

---

## Files Changed

| File | Type |
|------|------|
| `tools/surrealdb/contradiction_cli.py` | New — CLI entry point (argparse, stdlib only) |
| `tests/unit/surrealdb/test_contradiction_cli.py` | New — 20 unit tests (`@pytest.mark.unit`) |
| `tests/fixtures/surrealdb/contradiction_scan/sample_bundle.json` | New — deterministic test fixture |

---

## Tests Run

- `pytest tests/unit/surrealdb/test_contradiction_cli.py` — **20/20 passed**
- `pytest tests/unit/surrealdb/test_contradiction_scan.py` — **31/31 passed**
- `pytest tests/unit/test_clock.py::test_guardrails_no_forbidden_calls` — **passed** (no forbidden datetime/uuid calls in new code)
- `pytest tests/unit/surrealdb` — **654/654 passed**
- `ruff check tools/surrealdb/contradiction_cli.py tests/unit/surrealdb/test_contradiction_cli.py` — **clean**

---

## Guardrails

- CLI is **read-only**: no DB writes, no GitHub writes, no network calls
- No auto-fix, no live-go, no real-money/trading scope
- LR status remains **NO-GO** for live trading (orthogonal to this PR)
- No `datetime.now()`, `uuid.uuid4()`, or `random.` in new code — all timestamps via `scan_contradictions_v1` which uses `cdb_utcnow`
- Output: stdout only (json or markdown). No file writes.

---

## Remaining Issues (Out of Scope for This PR)

- #2148 — MCP integration
- #2149 — Report generation
- #2150 — Additional fixtures
- #2151 — Runbook
- #2152 — Gates
