### PR TITLE
feat(wave15): add contradiction MCP tool cdb_context_contradictions

### DIFF
--- a/tests/unit/tools/mcp/test_mcp_contradiction_tool.py
+++ b/tests/unit/tools/mcp/test_mcp_contradiction_tool.py
@@ -25,7 +25,6 @@ from tools.mcp.context_contradiction_tools import (
     TOOL_CDB_CONTEXT_CONTRADICTIONS,
     handle_cdb_context_contradictions,
     _derive_recommended_next_reads,
-    _finding_to_dict,
 )
 from tools.mcp.permission_guard import INPUT_SCAN_EXEMPT_TOOLS, PermissionGuard
 from tools.mcp.registry import ContextToolRegistry
@@ -161,7 +160,7 @@ def test_handler_calls_scan_service_and_returns_findings() -> None:
     assert result["status"] == "ok"
     assert result["total_findings"] >= 1
     assert isinstance(result["findings"], list)
-    assert len(result["findings"]) == result["total_findings"]
+    assert len(result["findings"]) == result["returned_findings"]
 
 
 # ── 5. SourceRefs ─────────────────────────────────────────────────────────────
@@ -445,13 +444,26 @@ def test_types_filter_empty_list_treated_as_no_filter() -> None:
 
 @pytest.mark.unit
 def test_limit_truncates_findings() -> None:
-    """limit param must restrict the number of returned findings."""
-    # Use records that produce at least 1 finding and set limit=1
-    result = handle_cdb_context_contradictions(
+    """limit param caps returned findings but blocking_count reflects full scan."""
+    full = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records())
+    )
+    assert full["status"] == "ok"
+    assert full["blocking_count"] >= 1
+
+    limited = handle_cdb_context_contradictions(
         _base_request(_doc_vs_code_records(), limit=1)
     )
-    assert result["status"] == "ok"
-    assert len(result["findings"]) <= 1
+    assert limited["status"] == "ok"
+    # returned count capped
+    assert len(limited["findings"]) <= 1
+    assert limited["returned_findings"] <= 1
+    # total_findings and blocking_count reflect the FULL scan, not the truncated set
+    assert limited["total_findings"] == full["total_findings"]
+    assert limited["blocking_count"] == full["blocking_count"]
+    # truncated flag set when findings were capped
+    if full["total_findings"] > 1:
+        assert limited["truncated"] is True
 
 
 # ── 19. recommended_next_reads derivation ────────────────────────────────────

--- a/tests/unit/tools/mcp/test_mcp_contradiction_tool.py
+++ b/tests/unit/tools/mcp/test_mcp_contradiction_tool.py
@@ -1,0 +1,543 @@
+"""Unit tests for Wave-15 MCP tool: cdb_context_contradictions.
+
+Issues:
+    #2148 — [SURREALDB][CONTEXT][CONTRADICTION-MCP] Implement contradiction MCP tool
+    Parent: #2145 (Wave-15)
+    Epic: #1976
+
+Scope:
+    Unit tests for tools/mcp/context_contradiction_tools.py and its integration
+    with the MCP registry, context bridge, and permission guard.
+    All fixtures are inline — no file loading.
+    No DB access. No SurrealDB SDK. No network. No writes.
+    No real datetime.now() — timestamps come from contradiction_scan.py via
+    core.utils.clock (validated by test_clock.py::test_guardrails_no_forbidden_calls).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tools.mcp.context_bridge import ContextBridge
+from tools.mcp.context_contradiction_tools import (
+    TOOL_CDB_CONTEXT_CONTRADICTIONS,
+    handle_cdb_context_contradictions,
+    _derive_recommended_next_reads,
+    _finding_to_dict,
+)
+from tools.mcp.permission_guard import INPUT_SCAN_EXEMPT_TOOLS, PermissionGuard
+from tools.mcp.registry import ContextToolRegistry
+
+
+# ── Inline Fixtures ───────────────────────────────────────────────────────────
+
+
+def _doc_vs_code_records() -> dict[str, Any]:
+    """Records that trigger a doc_vs_code contradiction (blocking)."""
+    return {
+        "doc_claims": [
+            {
+                "claim_id": "c-mcp-001",
+                "path": "docs/api.md",
+                "symbol": "ContradictionService",
+                "exists": True,
+                "blocking": True,
+            }
+        ],
+        "code_symbols": [],  # symbol absent → contradiction
+    }
+
+
+def _claim_vs_evidence_records() -> dict[str, Any]:
+    """Records that trigger a claim_vs_evidence contradiction (blocking)."""
+    return {
+        "claims": [
+            {
+                "claim_id": "cl-mcp-001",
+                "status": "disputed",
+                "topic": "wave15",
+                "evidence_refs": ["ev-mcp-001"],
+            }
+        ]
+    }
+
+
+def _non_blocking_records() -> dict[str, Any]:
+    """Records that trigger a doc_vs_decision contradiction (warning, non-blocking)."""
+    return {
+        "doc_rules": [
+            {
+                "rule_id": "rule-mcp-001",
+                "path": "docs/governance.md",
+                "rule_text": "Use old pattern",
+            }
+        ],
+        "decisions": [
+            {
+                "decision_id": "dec-mcp-001",
+                "supersedes": ["rule-mcp-001"],
+                "status": "active",
+            }
+        ],
+    }
+
+
+def _base_request(records: dict[str, Any], **extra_params: Any) -> dict[str, Any]:
+    params: dict[str, Any] = {"records": records}
+    params.update(extra_params)
+    return {
+        "tool": TOOL_CDB_CONTEXT_CONTRADICTIONS,
+        "parameters": params,
+    }
+
+
+# ── 1. Registry ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_tool_in_registry_is_read_only() -> None:
+    """Tool must be registered and read_only=True."""
+    tool = ContextToolRegistry.get_tool(TOOL_CDB_CONTEXT_CONTRADICTIONS)
+    assert tool is not None, f"{TOOL_CDB_CONTEXT_CONTRADICTIONS} not found in registry"
+    assert tool.read_only is True
+    assert tool.name == TOOL_CDB_CONTEXT_CONTRADICTIONS
+
+
+@pytest.mark.unit
+def test_tool_in_registry_tool_names() -> None:
+    """Tool name appears in registry tool list."""
+    names = ContextToolRegistry.list_tool_names()
+    assert TOOL_CDB_CONTEXT_CONTRADICTIONS in names
+
+
+# ── 2. Bridge ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_tool_executable_via_bridge() -> None:
+    """Tool can be executed via ContextBridge.execute_tool and returns status ok."""
+    bridge = ContextBridge()
+    result = bridge.execute_tool(
+        TOOL_CDB_CONTEXT_CONTRADICTIONS,
+        parameters={"records": _doc_vs_code_records()},
+    )
+    assert result["status"] == "ok"
+    assert result["tool"] == TOOL_CDB_CONTEXT_CONTRADICTIONS
+
+
+# ── 3. Input Schema ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_input_schema_accepts_scope_artifact_decision_claim() -> None:
+    """scope, artifact, decision, claim params are accepted without error."""
+    result = handle_cdb_context_contradictions(
+        _base_request(
+            _claim_vs_evidence_records(),
+            scope="wave15",
+            artifact="tools/mcp/context_contradiction_tools.py",
+            decision="dec-2148",
+            claim="cl-001",
+        )
+    )
+    assert result["status"] == "ok"
+    assert result["scope"] == "wave15"
+    assert result["artifact"] == "tools/mcp/context_contradiction_tools.py"
+    assert result["decision"] == "dec-2148"
+    assert result["claim"] == "cl-001"
+
+
+# ── 4. Handler calls scan service and returns findings ────────────────────────
+
+
+@pytest.mark.unit
+def test_handler_calls_scan_service_and_returns_findings() -> None:
+    """Handler calls scan_contradictions_v1 and returns findings for contradictory records."""
+    result = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records())
+    )
+    assert result["status"] == "ok"
+    assert result["total_findings"] >= 1
+    assert isinstance(result["findings"], list)
+    assert len(result["findings"]) == result["total_findings"]
+
+
+# ── 5. SourceRefs ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_output_contains_source_refs() -> None:
+    """Each finding must contain source_a_ref and source_b_ref with ref_id and ref_type."""
+    result = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records())
+    )
+    assert result["status"] == "ok"
+    assert len(result["findings"]) >= 1
+    for finding in result["findings"]:
+        assert "source_a_ref" in finding
+        assert "source_b_ref" in finding
+        for ref_key in ("source_a_ref", "source_b_ref"):
+            ref = finding[ref_key]
+            assert "ref_id" in ref
+            assert "ref_type" in ref
+            assert isinstance(ref["ref_id"], str) and ref["ref_id"]
+
+
+# ── 6. EvidenceRefs ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_output_contains_evidence_refs() -> None:
+    """Each finding must contain evidence_refs (list, may be empty but present)."""
+    result = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records())
+    )
+    assert result["status"] == "ok"
+    for finding in result["findings"]:
+        assert "evidence_refs" in finding
+        assert isinstance(finding["evidence_refs"], list)
+        for ev in finding["evidence_refs"]:
+            assert "evidence_id" in ev
+            assert "evidence_type" in ev
+            assert "strength" in ev
+
+
+# ── 7. Severity + Confidence ──────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_output_contains_severity_confidence() -> None:
+    """Each finding must have severity (str) and confidence (float in [0, 1])."""
+    result = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records())
+    )
+    assert result["status"] == "ok"
+    for finding in result["findings"]:
+        assert "severity" in finding
+        assert finding["severity"] in ("info", "warning", "blocking")
+        assert "confidence" in finding
+        assert isinstance(finding["confidence"], float)
+        assert 0.0 <= finding["confidence"] <= 1.0
+
+
+# ── 8. recommended_next_reads ─────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_output_contains_recommended_next_reads() -> None:
+    """Output must contain recommended_next_reads as a list of strings."""
+    result = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records())
+    )
+    assert result["status"] == "ok"
+    assert "recommended_next_reads" in result
+    assert isinstance(result["recommended_next_reads"], list)
+    for item in result["recommended_next_reads"]:
+        assert isinstance(item, str) and item.strip()
+
+
+# ── 9. Blocking findings / blocking_count ────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_blocking_findings_counted() -> None:
+    """blocking_count must equal the number of blocking=True findings."""
+    result = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records())
+    )
+    assert result["status"] == "ok"
+    manual_count = sum(1 for f in result["findings"] if f["blocking"])
+    assert result["blocking_count"] == manual_count
+    assert result["blocking_count"] >= 1  # doc_vs_code with blocking=True in fixture
+
+
+@pytest.mark.unit
+def test_blocking_findings_visible() -> None:
+    """Blocking findings have blocking=True and severity=blocking."""
+    result = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records())
+    )
+    blocking_findings = [f for f in result["findings"] if f["blocking"]]
+    assert len(blocking_findings) >= 1
+    for f in blocking_findings:
+        assert f["severity"] == "blocking"
+
+
+# ── 10. false_positive override ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_false_positive_override_non_blocking() -> None:
+    """false_positive override: finding retained but blocking=False, status updated."""
+    # First get the contradiction_id without override
+    base_result = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records())
+    )
+    assert base_result["status"] == "ok"
+    blocking = [f for f in base_result["findings"] if f["blocking"]]
+    assert len(blocking) >= 1
+    cid = blocking[0]["contradiction_id"]
+
+    # Now apply false_positive override
+    result = handle_cdb_context_contradictions(
+        _base_request(
+            _doc_vs_code_records(),
+            overrides={cid: "false_positive"},
+        )
+    )
+    assert result["status"] == "ok"
+    # finding must still be present
+    matched = [f for f in result["findings"] if f["contradiction_id"] == cid]
+    assert len(matched) == 1
+    # but must be non-blocking
+    assert matched[0]["blocking"] is False
+    assert matched[0]["status"] == "false_positive"
+
+
+# ── 11. accepted_risk override ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_accepted_risk_override_non_blocking() -> None:
+    """accepted_risk override: finding retained but blocking=False, status updated."""
+    base_result = handle_cdb_context_contradictions(
+        _base_request(_claim_vs_evidence_records())
+    )
+    assert base_result["status"] == "ok"
+    blocking = [f for f in base_result["findings"] if f["blocking"]]
+    assert len(blocking) >= 1
+    cid = blocking[0]["contradiction_id"]
+
+    result = handle_cdb_context_contradictions(
+        _base_request(
+            _claim_vs_evidence_records(),
+            overrides={cid: "accepted_risk"},
+        )
+    )
+    assert result["status"] == "ok"
+    matched = [f for f in result["findings"] if f["contradiction_id"] == cid]
+    assert len(matched) == 1
+    assert matched[0]["blocking"] is False
+    assert matched[0]["status"] == "accepted_risk"
+
+
+# ── 12. no_live_go ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_no_live_go_in_output() -> None:
+    """no_live_go=True must be present in every successful response."""
+    for records in (_doc_vs_code_records(), _claim_vs_evidence_records(), {}):
+        result = handle_cdb_context_contradictions({"records": records})
+        assert result.get("no_live_go") is True, f"no_live_go missing for records={records!r}"
+        assert result.get("no_write") is True
+
+
+# ── 13. Permission Guard ──────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_permission_guard_allows_legitimate_read_only_use() -> None:
+    """Permission guard must not block legitimate scope/artifact/claim field content."""
+    assert TOOL_CDB_CONTEXT_CONTRADICTIONS in INPUT_SCAN_EXEMPT_TOOLS
+
+    violations = PermissionGuard.check_tool_inputs(
+        TOOL_CDB_CONTEXT_CONTRADICTIONS,
+        {
+            "records": {"doc_claims": [{"claim_id": "c1", "symbol": "CreateOrder"}]},
+            "scope": "wave15",
+            "artifact": "docs/operations/runbook.md",
+            "claim": "Claim: system must not DELETE records without audit trail",
+        },
+    )
+    assert violations == [], f"Unexpected violations: {violations}"
+
+
+@pytest.mark.unit
+def test_permission_guard_tool_is_exempt_from_input_scan() -> None:
+    """cdb_context_contradictions must be in INPUT_SCAN_EXEMPT_TOOLS."""
+    assert TOOL_CDB_CONTEXT_CONTRADICTIONS in INPUT_SCAN_EXEMPT_TOOLS
+
+
+# ── 14. Missing records → fail-closed ────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_no_records_returns_error_closed() -> None:
+    """Handler must return error (fail-closed) when records is missing."""
+    result = handle_cdb_context_contradictions(
+        {"tool": TOOL_CDB_CONTEXT_CONTRADICTIONS, "parameters": {"scope": "test"}}
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "missing_records"
+
+
+@pytest.mark.unit
+def test_wrong_tool_name_returns_error() -> None:
+    """Handler must return error when tool name does not match."""
+    result = handle_cdb_context_contradictions(
+        {"tool": "wrong_tool", "parameters": {"records": {}}}
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "invalid_tool"
+
+
+# ── 15. Guardrails present ────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_guardrails_present_in_output() -> None:
+    """Output must contain a non-empty guardrails list."""
+    result = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records())
+    )
+    assert result["status"] == "ok"
+    assert "guardrails" in result
+    assert isinstance(result["guardrails"], list)
+    assert len(result["guardrails"]) >= 1
+    # Must state detection is signal not action
+    joined = " ".join(result["guardrails"]).lower()
+    assert "signal" in joined or "action" in joined
+
+
+# ── 16. include_non_blocking=False ───────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_include_non_blocking_false_filters_non_blocking() -> None:
+    """include_non_blocking=False must return only blocking findings."""
+    result = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records(), include_non_blocking=False)
+    )
+    assert result["status"] == "ok"
+    for finding in result["findings"]:
+        assert finding["blocking"] is True
+
+
+# ── 17. types filter ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_types_filter_limits_to_requested_type() -> None:
+    """types filter must restrict findings to the specified contradiction_type."""
+    result = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records(), types=["doc_vs_code"])
+    )
+    assert result["status"] == "ok"
+    for finding in result["findings"]:
+        assert finding["contradiction_type"] == "doc_vs_code"
+
+
+@pytest.mark.unit
+def test_types_filter_empty_list_treated_as_no_filter() -> None:
+    """Empty types list must not apply any filter."""
+    full = handle_cdb_context_contradictions(_base_request(_doc_vs_code_records()))
+    filtered = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records(), types=[])
+    )
+    assert full["total_findings"] == filtered["total_findings"]
+
+
+# ── 18. limit param ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_limit_truncates_findings() -> None:
+    """limit param must restrict the number of returned findings."""
+    # Use records that produce at least 1 finding and set limit=1
+    result = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records(), limit=1)
+    )
+    assert result["status"] == "ok"
+    assert len(result["findings"]) <= 1
+
+
+# ── 19. recommended_next_reads derivation ────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_recommended_next_reads_prioritises_blocking_findings() -> None:
+    """recommended_next_reads from blocking findings must appear before non-blocking."""
+    # doc_vs_code_records produces a blocking finding whose source_a_ref.path is docs/api.md
+    result = handle_cdb_context_contradictions(
+        _base_request(_doc_vs_code_records())
+    )
+    assert result["status"] == "ok"
+    reads = result["recommended_next_reads"]
+    # docs/api.md is the path in the blocking finding's source_a_ref
+    if "docs/api.md" in reads:
+        # It must appear (blocking findings come first)
+        assert reads.index("docs/api.md") < 20
+
+
+@pytest.mark.unit
+def test_derive_recommended_next_reads_max_20() -> None:
+    """_derive_recommended_next_reads must return at most 20 entries."""
+    from tools.surrealdb.contradiction_scan import (
+        ContradictionFinding,
+        EvidenceRef,
+        SourceRef,
+    )
+
+    # Build synthetic findings with many refs
+    findings = []
+    for i in range(25):
+        f = ContradictionFinding(
+            contradiction_id=f"id{i:02d}",
+            contradiction_type="doc_vs_code",
+            source_a_ref=SourceRef(ref_id=f"a{i}", ref_type="doc", path=f"docs/f{i}.md"),
+            source_b_ref=SourceRef(ref_id=f"b{i}", ref_type="code_symbol", path=None),
+            claim_refs=(f"cr{i}",),
+            evidence_refs=(
+                EvidenceRef(evidence_id=f"ev{i}", evidence_type="code_symbol_absence"),
+            ),
+            severity="blocking",
+            confidence=0.9,
+            detected_by="test",
+            detected_at="2026-05-06T00:00:00",
+            status="open",
+            recommended_action="test",
+            blocking=True,
+        )
+        findings.append(f)
+
+    reads = _derive_recommended_next_reads(findings)
+    assert len(reads) <= 20
+
+
+# ── 20. Wave-14 tests still pass (smoke import) ───────────────────────────────
+
+
+@pytest.mark.unit
+def test_wave14_tools_still_importable() -> None:
+    """Wave-14 handler modules must still be importable after Wave-15 changes."""
+    from tools.mcp.context_evidence_memory_tools import (
+        TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+        handle_cdb_context_evidence_resolve,
+    )
+    from tools.mcp.context_decision_tools import (
+        TOOL_CDB_CONTEXT_DECISION_HISTORY,
+        handle_cdb_context_decision_history,
+    )
+
+    assert TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE == "cdb_context_evidence_resolve"
+    assert TOOL_CDB_CONTEXT_DECISION_HISTORY == "cdb_context_decision_history"
+
+
+@pytest.mark.unit
+def test_bridge_registers_all_wave14_tools() -> None:
+    """Wave-14 tools must still be accessible via the bridge after Wave-15 init."""
+    bridge = ContextBridge()
+    wave14_tools = [
+        "cdb_context_evidence_resolve",
+        "cdb_context_claim_resolve",
+        "cdb_context_memory_get",
+        "cdb_context_trust_summary",
+        "cdb_context_decision_history",
+        "cdb_context_decision_replay",
+    ]
+    names = [t["name"] for t in bridge.list_tools()]
+    for tool_name in wave14_tools:
+        assert tool_name in names, f"Wave-14 tool missing after Wave-15 init: {tool_name}"

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -1958,6 +1958,20 @@ def cdb_context_decision_replay_handler(**kwargs) -> dict[str, Any]:
     return handle_cdb_context_decision_replay(kwargs)
 
 
+# ── Wave-15 MCP Tool Handlers (#2148 Contradiction MCP) ──────────────────────
+
+
+def cdb_context_contradictions_handler(**kwargs) -> dict[str, Any]:
+    """Read-only MCP handler for cdb_context_contradictions.
+
+    Thin adapter: passes **kwargs as the request mapping to the Wave-15 adapter.
+    Fail-closed. No DB/network/write. Detection is signal, not action permission.
+    """
+    from tools.mcp.context_contradiction_tools import handle_cdb_context_contradictions
+
+    return handle_cdb_context_contradictions(kwargs)
+
+
 class ContextBridge:
     """
     MCP Bridge for Context Intelligence System.
@@ -2109,6 +2123,21 @@ class ContextBridge:
             "cdb_context_decision_replay": cdb_context_decision_replay_handler,
         }
         for _tool_name, _handler_fn in _wave14_handler_map.items():
+            _old = self._registry.get_tool(_tool_name)
+            if _old:
+                self._registry._tools[_tool_name] = ToolDefinition(
+                    name=_old.name,
+                    description=_old.description,
+                    input_schema=_old.input_schema,
+                    output_schema=_old.output_schema,
+                    read_only=_old.read_only,
+                    handler=_handler_fn,
+                )
+        # Wave-15 handlers (#2148 Contradiction MCP)
+        _wave15_handler_map = {
+            "cdb_context_contradictions": cdb_context_contradictions_handler,
+        }
+        for _tool_name, _handler_fn in _wave15_handler_map.items():
             _old = self._registry.get_tool(_tool_name)
             if _old:
                 self._registry._tools[_tool_name] = ToolDefinition(

--- a/tools/mcp/context_contradiction_tools.py
+++ b/tools/mcp/context_contradiction_tools.py
@@ -281,18 +281,19 @@ def handle_cdb_context_contradictions(request: Mapping[str, Any]) -> dict[str, A
     if not include_non_blocking:
         findings = [f for f in findings if f.blocking]
 
-    # Compute blocking_count from the full filtered set BEFORE applying limit so
-    # that callers always get the true scan result even when output is capped.
+    # Compute blocking_count and recommended_next_reads from the full filtered
+    # set BEFORE applying limit so that callers always get the true scan result
+    # even when output is capped.
     blocking_count = sum(1 for f in findings if f.blocking)
     total_findings_before_limit = len(findings)
+    # Derive recommended_next_reads from all filtered findings (pre-limit) so
+    # that blocking paths are never dropped from the read list by a cap.
+    recommended_next_reads = _derive_recommended_next_reads(findings)
 
     truncated = False
     if findings_limit is not None:
         truncated = len(findings) > findings_limit
         findings = findings[:findings_limit]
-
-    # Derive recommended_next_reads deterministically from filtered findings
-    recommended_next_reads = _derive_recommended_next_reads(findings)
 
     guardrails = [
         "Detection is signal, not action permission.",

--- a/tools/mcp/context_contradiction_tools.py
+++ b/tools/mcp/context_contradiction_tools.py
@@ -281,10 +281,15 @@ def handle_cdb_context_contradictions(request: Mapping[str, Any]) -> dict[str, A
     if not include_non_blocking:
         findings = [f for f in findings if f.blocking]
 
-    if findings_limit is not None:
-        findings = findings[:findings_limit]
-
+    # Compute blocking_count from the full filtered set BEFORE applying limit so
+    # that callers always get the true scan result even when output is capped.
     blocking_count = sum(1 for f in findings if f.blocking)
+    total_findings_before_limit = len(findings)
+
+    truncated = False
+    if findings_limit is not None:
+        truncated = len(findings) > findings_limit
+        findings = findings[:findings_limit]
 
     # Derive recommended_next_reads deterministically from filtered findings
     recommended_next_reads = _derive_recommended_next_reads(findings)
@@ -308,8 +313,10 @@ def handle_cdb_context_contradictions(request: Mapping[str, Any]) -> dict[str, A
         "artifact": artifact,
         "decision": decision,
         "claim": claim,
-        "total_findings": len(findings),
+        "total_findings": total_findings_before_limit,
+        "returned_findings": len(findings),
         "blocking_count": blocking_count,
+        "truncated": truncated,
         "findings": [_finding_to_dict(f) for f in findings],
         "recommended_next_reads": recommended_next_reads,
         "guardrails": guardrails,

--- a/tools/mcp/context_contradiction_tools.py
+++ b/tools/mcp/context_contradiction_tools.py
@@ -1,0 +1,319 @@
+"""MCP adapter layer for Wave-15 contradiction scan tool.
+
+Issues:
+    #2148 — [SURREALDB][CONTEXT][CONTRADICTION-MCP] Implement contradiction MCP tool
+    Parent: #2145 (Wave-15)
+    Epic: #1976
+
+Adapts the Wave-15 contradiction scan domain service for the MCP tool surface.
+The tool is read-only, fail-closed, and carries explicit no-live-go semantics.
+No DB access. No SurrealDB SDK. No network. No writes. No auto-fix. No live-go.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from tools.surrealdb.contradiction_scan import (
+    ContradictionFinding,
+    ContradictionScanError,
+    EvidenceRef,
+    SourceRef,
+    scan_contradictions_v1,
+)
+
+TOOL_CDB_CONTEXT_CONTRADICTIONS = "cdb_context_contradictions"
+
+_MAX_RECOMMENDED_READS = 20
+
+
+@dataclass(frozen=True)
+class _ToolRequest:
+    tool: str
+    parameters: Mapping[str, Any]
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        return value
+    return None
+
+
+def _as_str_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text if text else None
+
+
+def _metadata(*, source: str = "in_memory", query_time_ms: int = 0) -> dict[str, Any]:
+    return {
+        "query_time_ms": query_time_ms,
+        "source": source,
+        "read_only": True,
+    }
+
+
+def _error_response(
+    tool: str,
+    *,
+    code: str,
+    message: str,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "tool": tool,
+        "status": "error",
+        "error": {"code": code, "message": message},
+        "metadata": _metadata(),
+    }
+    if details:
+        payload["error"]["details"] = dict(details)
+    return payload
+
+
+def _parse_tool_request(
+    request: Mapping[str, Any],
+    *,
+    expected_tool: str,
+) -> _ToolRequest | dict[str, Any]:
+    tool = request.get("tool")
+    if tool is None:
+        tool = expected_tool
+    if tool != expected_tool:
+        return _error_response(
+            expected_tool,
+            code="invalid_tool",
+            message=f"expected tool {expected_tool!r}, got {tool!r}",
+        )
+    parameters = _as_mapping(request.get("parameters")) or request
+    return _ToolRequest(tool=expected_tool, parameters=parameters)
+
+
+def _source_ref_to_dict(src: SourceRef) -> dict[str, Any]:
+    return {
+        "ref_id": src.ref_id,
+        "ref_type": src.ref_type,
+        "path": src.path,
+        "description": src.description,
+    }
+
+
+def _evidence_ref_to_dict(ev: EvidenceRef) -> dict[str, Any]:
+    return {
+        "evidence_id": ev.evidence_id,
+        "evidence_type": ev.evidence_type,
+        "strength": ev.strength,
+        "description": ev.description,
+    }
+
+
+def _finding_to_dict(f: ContradictionFinding) -> dict[str, Any]:
+    return {
+        "contradiction_id": f.contradiction_id,
+        "contradiction_type": f.contradiction_type,
+        "source_a_ref": _source_ref_to_dict(f.source_a_ref),
+        "source_b_ref": _source_ref_to_dict(f.source_b_ref),
+        "claim_refs": list(f.claim_refs),
+        "evidence_refs": [_evidence_ref_to_dict(ev) for ev in f.evidence_refs],
+        "severity": f.severity,
+        "confidence": f.confidence,
+        "detected_by": f.detected_by,
+        "detected_at": f.detected_at,
+        "status": f.status,
+        "recommended_action": f.recommended_action,
+        "blocking": f.blocking,
+    }
+
+
+def _derive_recommended_next_reads(
+    findings: Sequence[ContradictionFinding],
+    limit: int = _MAX_RECOMMENDED_READS,
+) -> list[str]:
+    """Derive a deduplicated, priority-sorted list of recommended next reads.
+
+    Priority:
+        1. Paths/refs from blocking findings (source_a_ref.path, source_b_ref.path,
+           claim_refs)
+        2. Evidence IDs from blocking findings
+        3. Paths/refs from non-blocking findings
+        4. Evidence IDs from non-blocking findings
+
+    Returns at most `limit` non-empty, deduplicated strings.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+
+    def _add(ref: str | None) -> None:
+        if ref and ref.strip() and ref not in seen:
+            seen.add(ref)
+            result.append(ref)
+
+    # Priority 1 & 2: blocking findings first
+    for f in findings:
+        if not f.blocking:
+            continue
+        _add(f.source_a_ref.path)
+        _add(f.source_b_ref.path)
+        for cr in f.claim_refs:
+            _add(cr)
+        for er in f.evidence_refs:
+            _add(er.evidence_id)
+
+    # Priority 3 & 4: non-blocking findings
+    for f in findings:
+        if f.blocking:
+            continue
+        _add(f.source_a_ref.path)
+        _add(f.source_b_ref.path)
+        for cr in f.claim_refs:
+            _add(cr)
+        for er in f.evidence_refs:
+            _add(er.evidence_id)
+
+    return result[:limit]
+
+
+def handle_cdb_context_contradictions(request: Mapping[str, Any]) -> dict[str, Any]:
+    """MCP handler: detect contradictions over in-memory records.
+
+    Tool: cdb_context_contradictions
+    Read-only, fail-closed, no writes, no DB/network/GitHub access.
+    Detection is signal, not action permission. No live-go.
+
+    Input:
+        records (required): dict of in-memory input bundles keyed by domain
+            (e.g. doc_claims, code_symbols, decisions, claims, evidence_records, etc.)
+        scope (optional): scope context identifier for output traceability
+        artifact (optional): artifact identifier for output traceability
+        decision (optional): decision identifier for output traceability
+        claim (optional): claim identifier for output traceability
+        overrides (optional): dict[contradiction_id → "false_positive"|"accepted_risk"]
+        include_non_blocking (optional, default True): include non-blocking findings
+        types (optional): list[str] — filter to these contradiction_type values
+        limit (optional): int — max number of findings to return
+        format (optional): "json" — reserved, no effect (always returns dict)
+
+    Output:
+        tool, status, scope, artifact, decision, claim,
+        total_findings, blocking_count, findings, recommended_next_reads,
+        guardrails, no_live_go, no_write, metadata
+    """
+    parsed = _parse_tool_request(request, expected_tool=TOOL_CDB_CONTEXT_CONTRADICTIONS)
+    if isinstance(parsed, dict):
+        return parsed
+
+    params = parsed.parameters
+
+    # records — required, must be a Mapping
+    raw_records = params.get("records")
+    records = _as_mapping(raw_records)
+    if records is None:
+        return _error_response(
+            TOOL_CDB_CONTEXT_CONTRADICTIONS,
+            code="missing_records",
+            message=(
+                "records is required (object/dict of in-memory input bundles) "
+                "for the contradiction scan adapter. Supply a records object with "
+                "domain-specific keys (e.g. doc_claims, code_symbols, decisions, "
+                "claims, evidence_records, etc.)."
+            ),
+        )
+
+    # Optional traceability parameters (passed through to output, not used for filtering)
+    scope = _as_str_or_none(params.get("scope"))
+    artifact = _as_str_or_none(params.get("artifact"))
+    decision = _as_str_or_none(params.get("decision"))
+    claim = _as_str_or_none(params.get("claim"))
+
+    # overrides: dict[contradiction_id → override_status]
+    raw_overrides = params.get("overrides")
+    overrides: dict[str, str] | None = None
+    if raw_overrides is not None:
+        mapped = _as_mapping(raw_overrides)
+        if mapped is not None:
+            overrides = {
+                str(k): str(v)
+                for k, v in mapped.items()
+                if isinstance(k, str) and isinstance(v, str)
+            }
+
+    include_non_blocking: bool = bool(params.get("include_non_blocking", True))
+
+    raw_types = params.get("types")
+    types_filter: list[str] | None = None
+    if isinstance(raw_types, list):
+        types_filter = [str(t) for t in raw_types if isinstance(t, str) and t.strip()]
+        if not types_filter:
+            types_filter = None
+
+    raw_limit = params.get("limit")
+    findings_limit: int | None = None
+    if raw_limit is not None:
+        try:
+            findings_limit = max(1, int(raw_limit))
+        except (TypeError, ValueError):
+            findings_limit = None
+
+    # Run the contradiction scan — read-only, no writes, no network
+    try:
+        scan_result = scan_contradictions_v1(records, overrides)
+    except ContradictionScanError as exc:
+        return _error_response(
+            TOOL_CDB_CONTEXT_CONTRADICTIONS,
+            code="scan_error",
+            message=str(exc),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _error_response(
+            TOOL_CDB_CONTEXT_CONTRADICTIONS,
+            code="execution_error",
+            message=str(exc),
+        )
+
+    # Post-scan filtering
+    findings = list(scan_result.findings)
+
+    if types_filter is not None:
+        findings = [f for f in findings if f.contradiction_type in types_filter]
+
+    if not include_non_blocking:
+        findings = [f for f in findings if f.blocking]
+
+    if findings_limit is not None:
+        findings = findings[:findings_limit]
+
+    blocking_count = sum(1 for f in findings if f.blocking)
+
+    # Derive recommended_next_reads deterministically from filtered findings
+    recommended_next_reads = _derive_recommended_next_reads(findings)
+
+    guardrails = [
+        "Detection is signal, not action permission.",
+        "No write. No DB access. No network. No GitHub access.",
+        "No auto-fix. No live-go. No real-money scope.",
+        "Blocking findings are visible but grant no action authority.",
+        (
+            "LR status remains NO-GO for live trading "
+            "(SSOT: docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)."
+        ),
+        "Board stage (trade-capable) is orthogonal to live readiness.",
+    ]
+
+    return {
+        "tool": TOOL_CDB_CONTEXT_CONTRADICTIONS,
+        "status": "ok",
+        "scope": scope,
+        "artifact": artifact,
+        "decision": decision,
+        "claim": claim,
+        "total_findings": len(findings),
+        "blocking_count": blocking_count,
+        "findings": [_finding_to_dict(f) for f in findings],
+        "recommended_next_reads": recommended_next_reads,
+        "guardrails": guardrails,
+        "no_live_go": True,
+        "no_write": True,
+        "metadata": _metadata(),
+    }

--- a/tools/mcp/permission_guard.py
+++ b/tools/mcp/permission_guard.py
@@ -140,6 +140,12 @@ INPUT_SCAN_EXEMPT_TOOLS: frozenset[str] = frozenset({
     "cdb_context_trust_summary",
     "cdb_context_decision_history",
     "cdb_context_decision_replay",
+    # Wave-15 contradiction scan MCP tool (#2148).
+    # Processes doc/code/decision/claim/evidence records whose content legitimately
+    # contains words like "Create", "Update", "Delete", "migration", "runbook".
+    # The tool is read-only and fail-closed; the scan service itself enforces
+    # no-write, no-network, no-auto-fix guardrails.
+    "cdb_context_contradictions",
 })
 
 

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -1006,6 +1006,88 @@ TOOLS_V0 = [
         read_only=True,
         handler=create_not_implemented_handler("cdb_context_decision_replay"),
     ),
+    # ── Wave-15 Tools (#2148 Contradiction MCP) ─────────────────────────────
+    ToolDefinition(
+        name="cdb_context_contradictions",
+        description=(
+            "Wave-15 contradiction scan MCP tool. Detects contradictions between "
+            "doc/code/decisions/evidence/claims/memory over in-memory records. "
+            "Surfaces SourceRefs, EvidenceRefs, severity, confidence, and "
+            "recommended_next_reads. Read-only, fail-closed, no DB/network/write. "
+            "No Live-Go, no Echtgeld-Go. Detection is signal, not action permission."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "records": {
+                            "type": "object",
+                            "description": (
+                                "In-memory input bundles keyed by domain "
+                                "(e.g. doc_claims, code_symbols, decisions, claims, "
+                                "evidence_records, etc.). Required."
+                            ),
+                        },
+                        "scope": {"type": "string"},
+                        "artifact": {"type": "string"},
+                        "decision": {"type": "string"},
+                        "claim": {"type": "string"},
+                        "overrides": {
+                            "type": "object",
+                            "description": (
+                                "Optional dict[contradiction_id → "
+                                "'false_positive'|'accepted_risk'] to mark known "
+                                "overrides. Findings are retained but set non-blocking."
+                            ),
+                        },
+                        "include_non_blocking": {
+                            "type": "boolean",
+                            "default": True,
+                        },
+                        "types": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Filter to these contradiction_type values.",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Max number of findings to return.",
+                        },
+                        "format": {
+                            "type": "string",
+                            "enum": ["json"],
+                            "description": "Output format. Reserved; always returns dict.",
+                        },
+                    },
+                    "required": ["records"],
+                },
+            },
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "status": {"type": "string"},
+                "scope": {"type": ["string", "null"]},
+                "artifact": {"type": ["string", "null"]},
+                "decision": {"type": ["string", "null"]},
+                "claim": {"type": ["string", "null"]},
+                "total_findings": {"type": "integer"},
+                "blocking_count": {"type": "integer"},
+                "findings": {"type": "array"},
+                "recommended_next_reads": {"type": "array"},
+                "guardrails": {"type": "array"},
+                "no_live_go": {"type": "boolean"},
+                "no_write": {"type": "boolean"},
+                "metadata": {"type": "object"},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("cdb_context_contradictions"),
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

Implements the Wave-15 read-only MCP tool `cdb_context_contradictions` (Issue #2148).

The tool calls `scan_contradictions_v1()` from `tools/surrealdb/contradiction_scan.py` and returns a structured finding set with full source/evidence references, severity/confidence, blocking counts, recommended_next_reads, and fail-closed guardrails.

Closes #2148
Parent: #2145
Depends on: #2146 #2093

---

## Tool: `cdb_context_contradictions`

**Read-only. Wave-15. No writes. No live trading scope.**

### Input (required)
- `records` (object, required) — in-memory records to scan (doc_claims, code_symbols, claims, decisions, etc.)

### Input (optional)
- `scope` / `artifact` / `decision` / `claim` — filter/context labels
- `overrides` — map of `{contradiction_id: "false_positive" | "accepted_risk"}`
- `include_non_blocking` (bool, default true) — filter non-blocking findings
- `types` (string[]) — filter by contradiction_type
- `limit` (int) — cap total findings returned

### Output
```
tool, status, scope, artifact, decision, claim,
total_findings, blocking_count, findings[],
recommended_next_reads[], guardrails[],
no_live_go (always true), no_write (always true), metadata
```

Each finding: `contradiction_id`, `contradiction_type`, `source_a_ref`, `source_b_ref`, `claim_refs`, `evidence_refs`, `severity`, `confidence`, `detected_by`, `detected_at`, `status`, `recommended_action`, `blocking`

---

## Files Changed

| File | Change |
|------|--------|
| `tools/mcp/context_contradiction_tools.py` | NEW — domain handler module |
| `tools/mcp/registry.py` | MOD — Wave-15 ToolDefinition in TOOLS_V0 |
| `tools/mcp/context_bridge.py` | MOD — handler fn + Wave-15 init registration |
| `tools/mcp/permission_guard.py` | MOD — INPUT_SCAN_EXEMPT_TOOLS |
| `tests/unit/tools/mcp/test_mcp_contradiction_tool.py` | NEW — 27 unit tests |

---

## Tests

| Suite | Result |
|-------|--------|
| New: test_mcp_contradiction_tool.py | 27/27 PASSED |
| MCP suite (all): tests/unit/tools/mcp/ | 527/527 PASSED |
| Scan + CLI: tests/unit/surrealdb/ | 51/51 PASSED |
| Clock guardrails: test_guardrails_no_forbidden_calls | PASSED |
| Ruff: 5 changed files | All checks passed |

---

## Guardrails
- `no_live_go: true` always present — no real trades, no live capital
- `no_write: true` always present — pure read-only scan
- Tool registered with `read_only=True` in registry
- Permission guard exempts tool from mutation input scan (records may contain Create/Delete/migration text legitimately)
- Fail-closed: missing `records` returns `{"status": "error", "error": {"code": "missing_records"}}`

---

## Remaining Open Issues (NOT in scope)
- #2145 — Wave-15 parent epic (remains OPEN)
- #2149, #2150, #2151, #2152 — future Wave-15 sub-issues (not touched)