### PR TITLE
fix(codeql): address py/uninitialized-local-variable wave (#2359)

### DIFF
--- a/scripts/lr020_tier2_evidence_capture.py
+++ b/scripts/lr020_tier2_evidence_capture.py
@@ -666,7 +666,7 @@ def main() -> None:
 
     # --- Publish ---
     publish_payload = signal_payload if inject_via == "signals" else order_payload
-    probe_label = signal_id if inject_via == "signals" else order_id  # type: ignore[possibly-undefined]
+    probe_label = filter_value
     print(f"Publishing probe {probe_label!r} to '{inject_channel}'...")
     subscribers = client.publish(inject_channel, json.dumps(publish_payload))
     print(f"  -> {subscribers} subscriber(s) on '{inject_channel}'")

--- a/tests/e2e/test_kill_switch_live.py
+++ b/tests/e2e/test_kill_switch_live.py
@@ -52,6 +52,7 @@ def redis_client():
     if not password:
         pytest.fail("Redis password file is empty.")
 
+    client = None
     for host in ("cdb_redis", "localhost"):
         try:
             client = redis.Redis(
@@ -68,6 +69,7 @@ def redis_client():
             continue
 
     pytest.fail("Could not connect to Redis (tried cdb_redis:6379 and localhost:6379)")
+    assert client is not None
 
 
 @pytest.fixture(autouse=True)

--- a/tests/e2e/test_paper_trading_p0.py
+++ b/tests/e2e/test_paper_trading_p0.py
@@ -310,6 +310,7 @@ def test_stream_persistence(redis_client, unique_order_id):
     time.sleep(3)
 
     # Check stream length increased
+    final_entries = -1
     try:
         final_entries = redis_client.xlen(stream_name)
     except redis.ResponseError:
@@ -408,6 +409,7 @@ def test_replay_determinism(redis_client, unique_order_id, tmp_path):
 
     # Verify stream has data
     stream_name = "stream.fills"
+    stream_length = -1
     try:
         stream_length = redis_client.xlen(stream_name)
     except redis.ResponseError:
@@ -885,6 +887,7 @@ def test_tc_p0_005_data_persistence_check(redis_client, unique_order_id):
     time.sleep(3)
 
     # Verify stream length increased
+    final_length = -1
     try:
         final_length = redis_client.xlen(stream_name)
     except redis.ResponseError:

--- a/tests/integration/verlosung/test_redis_postgres_integration.py
+++ b/tests/integration/verlosung/test_redis_postgres_integration.py
@@ -43,6 +43,7 @@ def postgres_conn():
     pg_password = os.getenv("POSTGRES_PASSWORD", "claire_db_secret_2024")
     pg_db = os.getenv("POSTGRES_DB", "claire_de_binare")
 
+    conn = None
     try:
         conn = psycopg2.connect(
             host="localhost",
@@ -54,6 +55,7 @@ def postgres_conn():
     except psycopg2.OperationalError as e:
         pytest.skip(f"PostgreSQL nicht erreichbar: {e}. Starte: docker compose up -d")
 
+    assert conn is not None
     yield conn
     conn.close()
 

--- a/tests/unit/verlosung/test_event_flow_pipeline.py
+++ b/tests/unit/verlosung/test_event_flow_pipeline.py
@@ -43,6 +43,7 @@ def postgres_conn():
     pg_password = os.getenv("POSTGRES_PASSWORD", "claire_db_secret_2024")
     pg_db = os.getenv("POSTGRES_DB", "claire_de_binare")
 
+    conn = None
     try:
         conn = psycopg2.connect(
             host="localhost",
@@ -54,6 +55,7 @@ def postgres_conn():
     except psycopg2.OperationalError as e:
         pytest.skip(f"PostgreSQL nicht erreichbar: {e}")
 
+    assert conn is not None
     yield conn
     conn.close()
 


### PR DESCRIPTION
Refs #2289
Refs #2359

## Scope
- Slice A only: #2359 (`py/uninitialized-local-variable`)
- Minimal fail-closed initializations / guards for the 7 reported instances

## Changes
- Use `filter_value` as probe label in `lr020_tier2_evidence_capture.py` to avoid branch-only variable usage.
- Initialize connection variables before `try` in PostgreSQL fixtures and assert non-null before yield.
- Initialize stream length variables before `try` blocks in E2E tests.
- Initialize Redis client variable before host loop in kill-switch E2E fixture.

## Validation
- `ruff check` on all changed files: PASS
- `pytest -q tests/integration/verlosung/test_redis_postgres_integration.py -k "not slow"`: 7 skipped, 1 deselected
- `pytest -q tests/unit/verlosung/test_event_flow_pipeline.py -k "not slow"`: 1 failed due to local service health (`cdb_core` not healthy), unrelated to variable-init patch

## Notes
- No alert dismissals
- No issue close
- No merge action
