### PR TITLE
fix(codeql): address remaining py/uninitialized-local-variable alert 4305

### DIFF
--- a/tests/e2e/test_kill_switch_live.py
+++ b/tests/e2e/test_kill_switch_live.py
@@ -40,6 +40,7 @@ def redis_client():
     Redis client — same connection strategy as test_paper_trading_p0.
     Reads password from Docker secret mount; falls back to localhost.
     """
+    password = ""
     try:
         with open("/run/secrets/redis_password", "r") as f:
             password = f.read().strip()


### PR DESCRIPTION
Refs #2289
Refs #2359

Follow-up for CodeQL Alert #4305.

## Scope
- Only \	ests/e2e/test_kill_switch_live.py\
- Initialize \password\ before the guarded Docker secret read so the local variable is always defined on all control-flow paths

## Validation
- \uff check tests/e2e/test_kill_switch_live.py\ : PASS
- \pytest -q tests/e2e/test_kill_switch_live.py\ : skipped locally; not claimed as pass