### PR TITLE
feat(wave16): add stale context mcp tool

### DIFF
--- a/tests/unit/tools/mcp/test_mcp_stale_context_tool.py
+++ b/tests/unit/tools/mcp/test_mcp_stale_context_tool.py
@@ -470,6 +470,36 @@ def test_scope_decision_returns_only_decision_findings() -> None:
         assert finding["stale_type"] == "decision_superseded"
 
 
+@pytest.mark.unit
+def test_scope_evidence_returns_only_evidence_findings() -> None:
+    """scope=evidence must return only evidence_expired findings."""
+    bundle = {**_bundle_multi_stale(), **_bundle_with_expired_evidence()}
+    result = handle_cdb_context_stale(
+        _request(bundle, scope="evidence")
+    )
+    assert result["status"] == "ok"
+    assert len(result["findings"]) >= 1
+    for finding in result["findings"]:
+        assert finding["stale_type"] == "evidence_expired"
+
+
+@pytest.mark.unit
+def test_scope_evidence_excludes_non_evidence_types() -> None:
+    """scope=evidence must exclude source_hash_changed, source_deleted, etc."""
+    bundle = {**_bundle_multi_stale(), **_bundle_with_expired_evidence()}
+    result = handle_cdb_context_stale(
+        _request(bundle, scope="evidence")
+    )
+    assert result["status"] == "ok"
+    for finding in result["findings"]:
+        assert finding["stale_type"] not in {
+            "source_hash_changed",
+            "source_deleted",
+            "decision_superseded",
+            "memory_ttl_expired",
+        }
+
+
 # ── Summary integrity ─────────────────────────────────────────────────────────
 
 

--- a/tests/unit/tools/mcp/test_mcp_stale_context_tool.py
+++ b/tests/unit/tools/mcp/test_mcp_stale_context_tool.py
@@ -1,0 +1,542 @@
+"""Unit tests for Wave-16-C MCP tool: cdb_context_stale.
+
+Issues:
+    #2157 — [SURREALDB][CONTEXT][STALE-MCP] Implement stale context MCP tool
+    Parent: #2153 (Wave-16 anchor)
+    Epic: #1976
+
+Scope:
+    Unit tests for tools/mcp/stale_context_tools.py and its integration
+    with the MCP registry, context bridge, and permission guard.
+    All fixtures are inline — no file loading.
+    No DB access. No SurrealDB SDK. No network. No writes.
+    No real datetime.now() — as_of is passed explicitly for determinism.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tools.mcp.context_bridge import ContextBridge
+from tools.mcp.permission_guard import INPUT_SCAN_EXEMPT_TOOLS, PermissionGuard
+from tools.mcp.registry import ContextToolRegistry
+from tools.mcp.stale_context_tools import (
+    SCHEMA_VERSION,
+    TOOL_CDB_CONTEXT_STALE,
+    handle_cdb_context_stale,
+)
+from tools.surrealdb.stale_knowledge_scan import GUARDRAILS, STALE_TYPES
+
+# ── Fixed reference timestamps for determinism ────────────────────────────────
+
+_AS_OF = "2026-05-06T12:00:00+00:00"
+_PAST = "2026-01-01T00:00:00+00:00"
+_FUTURE = "2027-01-01T00:00:00+00:00"
+
+
+# ── Inline fixtures ───────────────────────────────────────────────────────────
+
+
+def _bundle_with_hash_changed() -> dict[str, Any]:
+    """Bundle triggering source_hash_changed (warning)."""
+    return {
+        "sources": [
+            {
+                "source_id": "src-hash-mcp-001",
+                "path": "docs/api.md",
+                "current_hash": "c0ffee01deadbeef",
+                "last_verified_hash": "00000000aaaabbbb",
+            }
+        ]
+    }
+
+
+def _bundle_with_deleted() -> dict[str, Any]:
+    """Bundle triggering source_deleted (blocking)."""
+    return {
+        "sources": [
+            {
+                "source_id": "src-deleted-mcp-001",
+                "exists": False,
+            }
+        ]
+    }
+
+
+def _bundle_with_expired_evidence() -> dict[str, Any]:
+    """Bundle triggering evidence_expired (warning)."""
+    return {
+        "evidence_records": [
+            {
+                "evidence_id": "ev-expired-mcp-001",
+                "expires_at": _PAST,
+                "topic": "test",
+            }
+        ]
+    }
+
+
+def _bundle_with_superseded_decision() -> dict[str, Any]:
+    """Bundle triggering decision_superseded (warning)."""
+    return {
+        "decisions": [
+            {
+                "decision_id": "dec-mcp-001",
+                "superseded_by": "dec-mcp-002",
+                "status": "active",
+            }
+        ]
+    }
+
+
+def _bundle_multi_stale() -> dict[str, Any]:
+    """Bundle triggering multiple stale types across severities."""
+    return {
+        "sources": [
+            {
+                "source_id": "src-hash-multi-001",
+                "current_hash": "newhashabc",
+                "last_verified_hash": "oldhashabc",
+            },
+            {
+                "source_id": "src-deleted-multi-001",
+                "exists": False,
+            },
+        ],
+        "evidence_records": [
+            {
+                "evidence_id": "ev-expired-multi-001",
+                "expires_at": _PAST,
+            }
+        ],
+    }
+
+
+def _request(bundle: dict[str, Any], **extra: Any) -> dict[str, Any]:
+    """Build a minimal MCP request for cdb_context_stale."""
+    params: dict[str, Any] = {"bundle": bundle, "as_of": _AS_OF}
+    params.update(extra)
+    return {
+        "tool": TOOL_CDB_CONTEXT_STALE,
+        "parameters": params,
+    }
+
+
+# ── 1. Registry ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_registry_contains_cdb_context_stale() -> None:
+    """cdb_context_stale must be registered and read_only=True."""
+    tool = ContextToolRegistry.get_tool(TOOL_CDB_CONTEXT_STALE)
+    assert tool is not None, f"{TOOL_CDB_CONTEXT_STALE} not found in registry"
+    assert tool.read_only is True
+    assert tool.name == TOOL_CDB_CONTEXT_STALE
+
+
+# ── 2. Registry list ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_registry_tool_name_in_list() -> None:
+    """cdb_context_stale must appear in list_tool_names()."""
+    names = ContextToolRegistry.list_tool_names()
+    assert TOOL_CDB_CONTEXT_STALE in names
+
+
+# ── 3. Handler ok for sample bundle ──────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_handler_ok_for_sample_bundle() -> None:
+    """Handler returns status=ok for a valid bundle with stale findings."""
+    result = handle_cdb_context_stale(_request(_bundle_multi_stale()))
+    assert result["status"] == "ok", f"unexpected error: {result.get('error')}"
+    assert result["tool"] == TOOL_CDB_CONTEXT_STALE
+    assert result["schema_version"] == SCHEMA_VERSION
+    assert "summary" in result
+    assert result["summary"]["total_count"] >= 1
+
+
+# ── 4. Findings contract ──────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_findings_contain_required_fields() -> None:
+    """Each finding must contain stale_type, severity, confidence,
+    recommended_refresh, source_refs."""
+    result = handle_cdb_context_stale(_request(_bundle_multi_stale()))
+    assert result["status"] == "ok"
+    assert len(result["findings"]) >= 1
+    for finding in result["findings"]:
+        assert "stale_type" in finding, "missing stale_type"
+        assert "severity" in finding, "missing severity"
+        assert "confidence" in finding, "missing confidence"
+        assert "recommended_refresh" in finding, "missing recommended_refresh"
+        assert "source_refs" in finding, "missing source_refs"
+        assert finding["stale_type"] in STALE_TYPES
+        assert isinstance(finding["confidence"], float)
+        assert 0.0 <= finding["confidence"] <= 1.0
+        assert isinstance(finding["source_refs"], list)
+
+
+# ── 5. Guardrails present ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_guardrails_present_in_output() -> None:
+    """Output guardrails must include all GUARDRAILS strings when include_guardrails=True."""
+    result = handle_cdb_context_stale(
+        _request(_bundle_with_deleted(), include_guardrails=True)
+    )
+    assert result["status"] == "ok"
+    assert "guardrails" in result
+    output_guardrails = result["guardrails"]
+    for g in GUARDRAILS:
+        assert g in output_guardrails, f"guardrail missing: {g!r}"
+
+
+@pytest.mark.unit
+def test_guardrails_absent_when_excluded() -> None:
+    """Guardrails must be absent when include_guardrails=False."""
+    result = handle_cdb_context_stale(
+        _request(_bundle_with_deleted(), include_guardrails=False)
+    )
+    assert result["status"] == "ok"
+    assert "guardrails" not in result
+
+
+# ── 6. Filter stale_type ──────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_filter_stale_type_narrows_findings() -> None:
+    """stale_type filter must return only findings of that type."""
+    result = handle_cdb_context_stale(
+        _request(_bundle_multi_stale(), stale_type="source_deleted")
+    )
+    assert result["status"] == "ok"
+    for finding in result["findings"]:
+        assert finding["stale_type"] == "source_deleted"
+    # At least one deleted finding from our fixture
+    assert result["summary"]["total_count"] >= 1
+
+
+# ── 7. Filter severity ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_filter_severity_returns_only_blocking() -> None:
+    """severity=blocking must return only blocking findings."""
+    result = handle_cdb_context_stale(
+        _request(_bundle_multi_stale(), severity="blocking")
+    )
+    assert result["status"] == "ok"
+    for finding in result["findings"]:
+        assert finding["severity"] == "blocking"
+        assert finding["blocking"] is True
+
+
+@pytest.mark.unit
+def test_filter_severity_warning_excludes_blocking() -> None:
+    """severity=warning must exclude blocking findings."""
+    result = handle_cdb_context_stale(
+        _request(_bundle_multi_stale(), severity="warning")
+    )
+    assert result["status"] == "ok"
+    for finding in result["findings"]:
+        assert finding["severity"] == "warning"
+
+
+# ── 8. Filter target_ref ──────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_filter_target_ref_narrows_findings() -> None:
+    """target_ref filter must return only findings with that target_ref."""
+    result = handle_cdb_context_stale(
+        _request(
+            _bundle_multi_stale(),
+            target_ref="src-deleted-multi-001",
+        )
+    )
+    assert result["status"] == "ok"
+    for finding in result["findings"]:
+        assert finding["target_ref"] == "src-deleted-multi-001"
+
+
+@pytest.mark.unit
+def test_filter_target_ref_no_match_returns_empty() -> None:
+    """target_ref with no match must return empty findings, status ok."""
+    result = handle_cdb_context_stale(
+        _request(_bundle_multi_stale(), target_ref="nonexistent-ref-xyz")
+    )
+    assert result["status"] == "ok"
+    assert result["findings"] == []
+    assert result["summary"]["total_count"] == 0
+
+
+# ── 9. Limit ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_limit_caps_findings_and_sets_truncated() -> None:
+    """limit=1 must cap findings to 1 when more exist; summary.truncated=True."""
+    result = handle_cdb_context_stale(
+        _request(_bundle_multi_stale(), limit=1)
+    )
+    assert result["status"] == "ok"
+    assert len(result["findings"]) == 1
+    assert result["summary"]["truncated"] is True
+    # Summary counts are post-filter, pre-limit — must be >= 1 (the real total)
+    assert result["summary"]["total_count"] >= 1
+
+
+@pytest.mark.unit
+def test_limit_not_truncated_when_findings_fit() -> None:
+    """summary.truncated=False when findings fit within limit."""
+    result = handle_cdb_context_stale(
+        _request(_bundle_with_hash_changed(), limit=500)
+    )
+    assert result["status"] == "ok"
+    assert result["summary"]["truncated"] is False
+
+
+@pytest.mark.unit
+def test_limit_over_500_is_capped() -> None:
+    """limit > 500 must be silently capped to 500 (no error)."""
+    result = handle_cdb_context_stale(
+        _request(_bundle_with_hash_changed(), limit=9999)
+    )
+    assert result["status"] == "ok"
+
+
+# ── 10. No bundle → clean error ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_missing_bundle_returns_clean_error() -> None:
+    """Omitting bundle must return status=error with missing_bundle code."""
+    result = handle_cdb_context_stale(
+        {
+            "tool": TOOL_CDB_CONTEXT_STALE,
+            "parameters": {"as_of": _AS_OF},
+        }
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "missing_bundle"
+    # Must not attempt any live read — message must mention bundle-driven
+    assert "bundle" in result["error"]["message"].lower()
+
+
+@pytest.mark.unit
+def test_none_bundle_returns_clean_error() -> None:
+    """Passing bundle=None must return status=error."""
+    result = handle_cdb_context_stale(
+        _request(None)  # type: ignore[arg-type]
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "missing_bundle"
+
+
+# ── 11. Invalid stale_type → error ────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_invalid_stale_type_returns_error() -> None:
+    """Unknown stale_type must return status=error with invalid_stale_type code."""
+    result = handle_cdb_context_stale(
+        _request(_bundle_with_hash_changed(), stale_type="not_a_real_type")
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "invalid_stale_type"
+
+
+# ── 12. Invalid severity → error ──────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_invalid_severity_returns_error() -> None:
+    """Unknown severity must return status=error with invalid_severity code."""
+    result = handle_cdb_context_stale(
+        _request(_bundle_with_hash_changed(), severity="critical")
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "invalid_severity"
+
+
+@pytest.mark.unit
+def test_invalid_scope_returns_error() -> None:
+    """Unknown scope must return status=error with invalid_scope code."""
+    result = handle_cdb_context_stale(
+        _request(_bundle_with_hash_changed(), scope="not_a_valid_scope")
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "invalid_scope"
+
+
+# ── 13. Bridge executability ──────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_tool_executable_via_bridge() -> None:
+    """cdb_context_stale can be executed via ContextBridge.execute_tool."""
+    bridge = ContextBridge()
+    result = bridge.execute_tool(
+        TOOL_CDB_CONTEXT_STALE,
+        parameters={
+            "bundle": _bundle_with_deleted(),
+            "as_of": _AS_OF,
+        },
+    )
+    assert result["status"] == "ok", f"unexpected error: {result.get('error')}"
+    assert result["tool"] == TOOL_CDB_CONTEXT_STALE
+
+
+# ── Read-only safety ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_read_only_safety_no_writes_in_result() -> None:
+    """Handler must not write any files or mutate input bundle."""
+    import copy
+
+    original_bundle = _bundle_multi_stale()
+    bundle_copy = copy.deepcopy(original_bundle)
+
+    result = handle_cdb_context_stale(_request(original_bundle))
+    assert result["status"] == "ok"
+    # Input bundle must not be mutated (meta pop is allowed but bundle itself unchanged)
+    # We check the domain keys are still present
+    assert "sources" in original_bundle
+
+
+@pytest.mark.unit
+def test_read_only_safety_no_forbidden_imports() -> None:
+    """stale_context_tools module must not import forbidden modules."""
+    import importlib
+    import sys
+
+    # Ensure the module is imported
+    if "tools.mcp.stale_context_tools" not in sys.modules:
+        importlib.import_module("tools.mcp.stale_context_tools")
+
+    mod = sys.modules["tools.mcp.stale_context_tools"]
+    mod_globals = vars(mod)
+
+    for forbidden in ("requests", "httpx", "subprocess", "surrealdb"):
+        assert forbidden not in mod_globals, (
+            f"Forbidden import '{forbidden}' found in stale_context_tools module globals"
+        )
+
+
+# ── Permission guard exemption ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_cdb_context_stale_in_exempt_tools() -> None:
+    """cdb_context_stale must be in INPUT_SCAN_EXEMPT_TOOLS."""
+    assert TOOL_CDB_CONTEXT_STALE in INPUT_SCAN_EXEMPT_TOOLS
+
+
+# ── Scope filter ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_scope_artifact_limits_to_source_types() -> None:
+    """scope=artifact must return only source_hash_changed / source_deleted findings."""
+    from tools.mcp.stale_context_tools import _SCOPE_TO_STALE_TYPES
+
+    result = handle_cdb_context_stale(
+        _request(_bundle_multi_stale(), scope="artifact")
+    )
+    assert result["status"] == "ok"
+    allowed = _SCOPE_TO_STALE_TYPES["artifact"]
+    for finding in result["findings"]:
+        assert finding["stale_type"] in allowed
+
+
+@pytest.mark.unit
+def test_scope_decision_returns_only_decision_findings() -> None:
+    """scope=decision must return only decision_superseded findings."""
+    bundle = {**_bundle_multi_stale(), **_bundle_with_superseded_decision()}
+    result = handle_cdb_context_stale(
+        _request(bundle, scope="decision")
+    )
+    assert result["status"] == "ok"
+    for finding in result["findings"]:
+        assert finding["stale_type"] == "decision_superseded"
+
+
+# ── Summary integrity ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_summary_severity_summary_present() -> None:
+    """Summary must contain severity_summary with info/warning/blocking keys."""
+    result = handle_cdb_context_stale(_request(_bundle_multi_stale()))
+    assert result["status"] == "ok"
+    sev = result["summary"]["severity_summary"]
+    assert "info" in sev
+    assert "warning" in sev
+    assert "blocking" in sev
+
+
+@pytest.mark.unit
+def test_summary_stale_type_summary_present() -> None:
+    """Summary must contain stale_type_summary with at least the 8 canonical keys."""
+    result = handle_cdb_context_stale(_request(_bundle_multi_stale()))
+    assert result["status"] == "ok"
+    st = result["summary"]["stale_type_summary"]
+    for st_type in STALE_TYPES:
+        assert st_type in st, f"stale_type {st_type!r} missing from stale_type_summary"
+
+
+@pytest.mark.unit
+def test_source_refs_present_in_output() -> None:
+    """Output must contain source_refs list (may be empty for empty bundles)."""
+    result = handle_cdb_context_stale(_request(_bundle_with_deleted()))
+    assert result["status"] == "ok"
+    assert "source_refs" in result
+    assert isinstance(result["source_refs"], list)
+    # source_deleted findings have source_refs populated
+    assert len(result["source_refs"]) >= 1
+
+
+@pytest.mark.unit
+def test_recommended_refresh_present_in_output() -> None:
+    """Output must contain recommended_refresh list with at least one entry."""
+    result = handle_cdb_context_stale(_request(_bundle_with_deleted()))
+    assert result["status"] == "ok"
+    assert "recommended_refresh" in result
+    assert isinstance(result["recommended_refresh"], list)
+    assert len(result["recommended_refresh"]) >= 1
+
+
+@pytest.mark.unit
+def test_as_of_in_output() -> None:
+    """Output must contain as_of field."""
+    result = handle_cdb_context_stale(_request(_bundle_with_hash_changed()))
+    assert result["status"] == "ok"
+    assert "as_of" in result
+    assert isinstance(result["as_of"], str) and result["as_of"]
+
+
+# ── Regression: existing tools still work ─────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_existing_contradiction_tool_unaffected() -> None:
+    """Adding cdb_context_stale must not break cdb_context_contradictions."""
+    tool = ContextToolRegistry.get_tool("cdb_context_contradictions")
+    assert tool is not None
+    assert tool.read_only is True
+
+
+@pytest.mark.unit
+def test_all_registered_tools_are_read_only() -> None:
+    """All tools in the registry must remain read_only=True after Wave-16-C."""
+    for tool in ContextToolRegistry.list_tools():
+        assert tool.read_only is True, f"Tool {tool.name!r} is not read_only"

--- a/tests/unit/tools/mcp/test_mcp_stale_context_tool.py
+++ b/tests/unit/tools/mcp/test_mcp_stale_context_tool.py
@@ -20,7 +20,7 @@ from typing import Any
 import pytest
 
 from tools.mcp.context_bridge import ContextBridge
-from tools.mcp.permission_guard import INPUT_SCAN_EXEMPT_TOOLS, PermissionGuard
+from tools.mcp.permission_guard import INPUT_SCAN_EXEMPT_TOOLS
 from tools.mcp.registry import ContextToolRegistry
 from tools.mcp.stale_context_tools import (
     SCHEMA_VERSION,
@@ -33,7 +33,6 @@ from tools.surrealdb.stale_knowledge_scan import GUARDRAILS, STALE_TYPES
 
 _AS_OF = "2026-05-06T12:00:00+00:00"
 _PAST = "2026-01-01T00:00:00+00:00"
-_FUTURE = "2027-01-01T00:00:00+00:00"
 
 
 # ── Inline fixtures ───────────────────────────────────────────────────────────
@@ -408,9 +407,8 @@ def test_read_only_safety_no_writes_in_result() -> None:
 
     result = handle_cdb_context_stale(_request(original_bundle))
     assert result["status"] == "ok"
-    # Input bundle must not be mutated (meta pop is allowed but bundle itself unchanged)
-    # We check the domain keys are still present
-    assert "sources" in original_bundle
+    # Input bundle must not be mutated: domain keys must be identical to the deep copy.
+    assert original_bundle == bundle_copy
 
 
 @pytest.mark.unit

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -1972,6 +1972,21 @@ def cdb_context_contradictions_handler(**kwargs) -> dict[str, Any]:
     return handle_cdb_context_contradictions(kwargs)
 
 
+# ── Wave-16-C MCP Tool Handlers (#2157 Stale Context MCP) ────────────────────
+
+
+def cdb_context_stale_handler(**kwargs) -> dict[str, Any]:
+    """Read-only MCP handler for cdb_context_stale.
+
+    Thin adapter: passes **kwargs as the request mapping to the Wave-16-C adapter.
+    Fail-closed. No DB/network/write. Bundle-driven. Detection is signal, not
+    action permission. No live-go. No Echtgeld-Go.
+    """
+    from tools.mcp.stale_context_tools import handle_cdb_context_stale
+
+    return handle_cdb_context_stale(kwargs)
+
+
 class ContextBridge:
     """
     MCP Bridge for Context Intelligence System.
@@ -2138,6 +2153,21 @@ class ContextBridge:
             "cdb_context_contradictions": cdb_context_contradictions_handler,
         }
         for _tool_name, _handler_fn in _wave15_handler_map.items():
+            _old = self._registry.get_tool(_tool_name)
+            if _old:
+                self._registry._tools[_tool_name] = ToolDefinition(
+                    name=_old.name,
+                    description=_old.description,
+                    input_schema=_old.input_schema,
+                    output_schema=_old.output_schema,
+                    read_only=_old.read_only,
+                    handler=_handler_fn,
+                )
+        # Wave-16-C handlers (#2157 Stale Context MCP)
+        _wave16c_handler_map = {
+            "cdb_context_stale": cdb_context_stale_handler,
+        }
+        for _tool_name, _handler_fn in _wave16c_handler_map.items():
             _old = self._registry.get_tool(_tool_name)
             if _old:
                 self._registry._tools[_tool_name] = ToolDefinition(

--- a/tools/mcp/permission_guard.py
+++ b/tools/mcp/permission_guard.py
@@ -146,6 +146,12 @@ INPUT_SCAN_EXEMPT_TOOLS: frozenset[str] = frozenset({
     # The tool is read-only and fail-closed; the scan service itself enforces
     # no-write, no-network, no-auto-fix guardrails.
     "cdb_context_contradictions",
+    # Wave-16-C stale context MCP tool (#2157).
+    # Processes scan bundles whose source paths, reasons, and recommended_refresh
+    # strings legitimately contain words like "Create", "Update", "Delete",
+    # "migration", "runbook". The tool is read-only, bundle-driven, and
+    # fail-closed; the scan service enforces no-write, no-network, no-auto-fix.
+    "cdb_context_stale",
 })
 
 

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -1088,6 +1088,114 @@ TOOLS_V0 = [
         read_only=True,
         handler=create_not_implemented_handler("cdb_context_contradictions"),
     ),
+    # ── Wave-16-C Tools (#2157 Stale Context MCP) ────────────────────────────
+    ToolDefinition(
+        name="cdb_context_stale",
+        description=(
+            "Wave-16-C stale context MCP tool. Detects stale knowledge findings "
+            "from an in-memory input bundle. Surfaces stale_type, severity, "
+            "confidence, recommended_refresh, and source_refs for each finding. "
+            "Supports scope/stale_type/severity/target_ref filters and limit. "
+            "Bundle-driven: no DB/network/filesystem read. Read-only, fail-closed. "
+            "Detection is signal, not authorization. No Live-Go, no Echtgeld-Go, "
+            "no auto-fix, no auto-delete, no write."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "bundle": {
+                    "type": "object",
+                    "description": (
+                        "In-memory scan input bundle with domain keys "
+                        "(sources, decisions, evidence_records, memory_records, "
+                        "dependency_edges, context_packages, briefings). Required."
+                    ),
+                },
+                "scope": {
+                    "type": "string",
+                    "enum": [
+                        "all",
+                        "artifact",
+                        "decision",
+                        "memory",
+                        "edge",
+                        "package",
+                        "briefing",
+                    ],
+                    "default": "all",
+                    "description": (
+                        "Restrict scan to a subset of stale_types. "
+                        "'all' returns all types (default)."
+                    ),
+                },
+                "target_ref": {
+                    "type": "string",
+                    "description": "Exact target_ref to filter findings by.",
+                },
+                "stale_type": {
+                    "type": "string",
+                    "description": (
+                        "Exact stale_type to filter findings by. "
+                        "Must be one of the 8 canonical stale types."
+                    ),
+                },
+                "severity": {
+                    "type": "string",
+                    "enum": ["info", "warning", "blocking"],
+                    "description": "Severity level to filter findings by.",
+                },
+                "include_guardrails": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Include guardrail strings in output.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "default": 100,
+                    "maximum": 500,
+                    "description": (
+                        "Maximum number of findings to return. "
+                        "Summary counts are always pre-limit. "
+                        "summary.truncated=true when findings are capped."
+                    ),
+                },
+                "as_of": {
+                    "type": "string",
+                    "description": (
+                        "Optional ISO-8601 UTC reference time for TTL/expiry "
+                        "comparisons. Also read from bundle['meta']['as_of']. "
+                        "If absent, scan service uses cdb_utcnow()."
+                    ),
+                },
+            },
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "schema_version": {"type": "string"},
+                "status": {"type": "string"},
+                "summary": {
+                    "type": "object",
+                    "properties": {
+                        "total_count": {"type": "integer"},
+                        "blocking_count": {"type": "integer"},
+                        "truncated": {"type": "boolean"},
+                        "severity_summary": {"type": "object"},
+                        "stale_type_summary": {"type": "object"},
+                    },
+                },
+                "findings": {"type": "array"},
+                "recommended_refresh": {"type": "array"},
+                "source_refs": {"type": "array"},
+                "guardrails": {"type": "array"},
+                "as_of": {"type": "string"},
+                "metadata": {"type": "object"},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("cdb_context_stale"),
+    ),
 ]
 
 

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -1117,6 +1117,7 @@ TOOLS_V0 = [
                         "all",
                         "artifact",
                         "decision",
+                        "evidence",
                         "memory",
                         "edge",
                         "package",

--- a/tools/mcp/stale_context_tools.py
+++ b/tools/mcp/stale_context_tools.py
@@ -295,9 +295,11 @@ def handle_cdb_context_stale(request: Mapping[str, Any]) -> dict[str, Any]:
     truncated = len(filtered) > limit
     findings_page = filtered[:limit]
 
-    # ── Collect cross-cutting fields from paged findings ─────────────────────
-    recommended_refresh = _collect_recommended_refresh(filtered)
-    source_refs = _collect_source_refs(filtered)
+    # ── Collect cross-cutting fields from paged findings only ────────────────
+    # Metadata is derived from findings_page so callers receive refs only for
+    # the items they actually see — not for items filtered out by limit.
+    recommended_refresh = _collect_recommended_refresh(findings_page)
+    source_refs = _collect_source_refs(findings_page)
 
     # ── Build response ────────────────────────────────────────────────────────
     response: dict[str, Any] = {

--- a/tools/mcp/stale_context_tools.py
+++ b/tools/mcp/stale_context_tools.py
@@ -42,6 +42,7 @@ _SCOPE_TO_STALE_TYPES: dict[str, frozenset[str]] = {
     "all": frozenset(STALE_TYPES),
     "artifact": frozenset({"source_hash_changed", "source_deleted"}),
     "decision": frozenset({"decision_superseded"}),
+    "evidence": frozenset({"evidence_expired"}),
     "memory": frozenset({"memory_ttl_expired"}),
     "edge": frozenset({"dependency_edge_no_longer_observed"}),
     "package": frozenset({"stale_context_package"}),

--- a/tools/mcp/stale_context_tools.py
+++ b/tools/mcp/stale_context_tools.py
@@ -1,0 +1,323 @@
+"""MCP adapter layer for Wave-16-C stale context tool.
+
+Issues:
+    #2157 — [SURREALDB][CONTEXT][STALE-MCP] Implement stale context MCP tool
+    Parent: #2153 (Wave-16 anchor)
+    Epic: #1976
+
+Adapts the Wave-16-A stale knowledge scan domain service for the MCP tool
+surface. The tool is read-only, fail-closed, and carries explicit no-live-go
+semantics. No DB access. No SurrealDB SDK. No network. No writes. No auto-fix.
+No live-go.
+
+Bundle-driven:
+    The tool operates exclusively on the in-memory bundle passed as input.
+    If no bundle is supplied the tool returns a clean error — it never
+    reads from a database, filesystem, or network to fill the gap.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from tools.surrealdb.stale_knowledge_scan import (
+    GUARDRAILS,
+    SEVERITY_LEVELS,
+    STALE_TYPES,
+    StaleFinding,
+    StaleKnowledgeScanError,
+    scan_stale_knowledge_v1,
+)
+
+TOOL_CDB_CONTEXT_STALE = "cdb_context_stale"
+SCHEMA_VERSION = "stale-context-mcp/v1"
+
+# Maximum limit accepted; requests above this are silently capped.
+_MAX_LIMIT = 500
+_DEFAULT_LIMIT = 100
+
+# Supported scope values and their corresponding stale_type subsets.
+# "all" means no stale_type restriction.
+_SCOPE_TO_STALE_TYPES: dict[str, frozenset[str]] = {
+    "all": frozenset(STALE_TYPES),
+    "artifact": frozenset({"source_hash_changed", "source_deleted"}),
+    "decision": frozenset({"decision_superseded"}),
+    "memory": frozenset({"memory_ttl_expired"}),
+    "edge": frozenset({"dependency_edge_no_longer_observed"}),
+    "package": frozenset({"stale_context_package"}),
+    "briefing": frozenset({"stale_briefing"}),
+}
+
+_VALID_SCOPES: frozenset[str] = frozenset(_SCOPE_TO_STALE_TYPES.keys())
+_VALID_SEVERITIES: frozenset[str] = frozenset(SEVERITY_LEVELS)
+
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+
+def _as_str_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text if text else None
+
+
+def _as_mapping_or_none(value: Any) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        return value
+    return None
+
+
+def _error_response(
+    tool: str,
+    *,
+    code: str,
+    message: str,
+) -> dict[str, Any]:
+    return {
+        "tool": tool,
+        "status": "error",
+        "error": {"code": code, "message": message},
+    }
+
+
+def _metadata(*, source: str = "in_memory", read_only: bool = True) -> dict[str, Any]:
+    return {
+        "source": source,
+        "read_only": read_only,
+    }
+
+
+def _severity_summary(findings: Sequence[StaleFinding]) -> dict[str, int]:
+    summary: dict[str, int] = {level: 0 for level in SEVERITY_LEVELS}
+    for f in findings:
+        if f.severity in summary:
+            summary[f.severity] += 1
+    return summary
+
+
+def _stale_type_summary(findings: Sequence[StaleFinding]) -> dict[str, int]:
+    summary: dict[str, int] = {t: 0 for t in sorted(STALE_TYPES)}
+    for f in findings:
+        if f.stale_type in summary:
+            summary[f.stale_type] += 1
+    return summary
+
+
+def _collect_source_refs(findings: Sequence[StaleFinding]) -> list[str]:
+    """Return a deduplicated, ordered list of source_refs across findings."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for f in findings:
+        for ref in f.source_refs:
+            if ref and ref not in seen:
+                seen.add(ref)
+                result.append(ref)
+    return result
+
+
+def _collect_recommended_refresh(findings: Sequence[StaleFinding]) -> list[str]:
+    """Return a deduplicated, first-seen-order recommended_refresh list."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for f in findings:
+        if f.recommended_refresh and f.recommended_refresh not in seen:
+            seen.add(f.recommended_refresh)
+            result.append(f.recommended_refresh)
+    return result
+
+
+# ── Handler ───────────────────────────────────────────────────────────────────
+
+
+def handle_cdb_context_stale(request: Mapping[str, Any]) -> dict[str, Any]:
+    """MCP handler: detect stale context findings over in-memory bundle.
+
+    Tool: cdb_context_stale
+    Read-only, fail-closed, no writes, no DB/network/GitHub access.
+    Bundle-driven: a bundle must be supplied — no live reads.
+    Detection is signal, not action permission. No live-go.
+
+    Input:
+        bundle (required): object — scan input bundle (domain records)
+        scope (optional): str — one of all|artifact|decision|memory|edge|package|briefing
+        target_ref (optional): str — exact target_ref to filter findings
+        stale_type (optional): str — exact stale_type to filter findings
+        severity (optional): str — one of info|warning|blocking
+        include_guardrails (optional, default True): bool
+        limit (optional, default 100, max 500): int
+        as_of (optional): ISO-8601 UTC str; also read from bundle["meta"]["as_of"]
+
+    Output:
+        tool, schema_version, status, summary (total_count, blocking_count,
+        severity_summary, stale_type_summary, truncated), findings,
+        recommended_refresh, source_refs, guardrails (if include_guardrails),
+        as_of, metadata
+    """
+    # Normalise: if request arrives as plain kwargs dict (from bridge **kwargs),
+    # the tool key may be absent — treat the whole dict as parameters.
+    tool_key = request.get("tool")
+    if tool_key is not None and tool_key != TOOL_CDB_CONTEXT_STALE:
+        return _error_response(
+            TOOL_CDB_CONTEXT_STALE,
+            code="invalid_tool",
+            message=f"expected tool {TOOL_CDB_CONTEXT_STALE!r}, got {tool_key!r}",
+        )
+
+    # Resolve parameters: if a "parameters" wrapper is present, unwrap it.
+    raw_params = request.get("parameters")
+    if isinstance(raw_params, Mapping):
+        params: Mapping[str, Any] = raw_params
+    else:
+        params = request
+
+    # ── Required: bundle ──────────────────────────────────────────────────────
+    raw_bundle = params.get("bundle")
+    bundle = _as_mapping_or_none(raw_bundle)
+    if bundle is None:
+        return _error_response(
+            TOOL_CDB_CONTEXT_STALE,
+            code="missing_bundle",
+            message=(
+                "bundle is required (object/dict of scan input records). "
+                "This tool is read-only and bundle-driven — it never reads "
+                "from a database, filesystem, or network. "
+                "Supply a bundle with domain keys (sources, decisions, "
+                "evidence_records, memory_records, dependency_edges, "
+                "context_packages, briefings)."
+            ),
+        )
+
+    # ── Optional: scope ───────────────────────────────────────────────────────
+    raw_scope = params.get("scope", "all")
+    scope = _as_str_or_none(raw_scope) or "all"
+    if scope not in _VALID_SCOPES:
+        return _error_response(
+            TOOL_CDB_CONTEXT_STALE,
+            code="invalid_scope",
+            message=(
+                f"scope must be one of {sorted(_VALID_SCOPES)}, got {scope!r}"
+            ),
+        )
+
+    # ── Optional: stale_type filter ───────────────────────────────────────────
+    raw_stale_type = params.get("stale_type")
+    stale_type_filter = _as_str_or_none(raw_stale_type)
+    if stale_type_filter is not None and stale_type_filter not in STALE_TYPES:
+        return _error_response(
+            TOOL_CDB_CONTEXT_STALE,
+            code="invalid_stale_type",
+            message=(
+                f"stale_type must be one of {sorted(STALE_TYPES)}, "
+                f"got {stale_type_filter!r}"
+            ),
+        )
+
+    # ── Optional: severity filter ─────────────────────────────────────────────
+    raw_severity = params.get("severity")
+    severity_filter = _as_str_or_none(raw_severity)
+    if severity_filter is not None and severity_filter not in _VALID_SEVERITIES:
+        return _error_response(
+            TOOL_CDB_CONTEXT_STALE,
+            code="invalid_severity",
+            message=(
+                f"severity must be one of {sorted(_VALID_SEVERITIES)}, "
+                f"got {severity_filter!r}"
+            ),
+        )
+
+    # ── Optional: target_ref filter ───────────────────────────────────────────
+    target_ref_filter = _as_str_or_none(params.get("target_ref"))
+
+    # ── Optional: include_guardrails ─────────────────────────────────────────
+    raw_guardrails = params.get("include_guardrails", True)
+    include_guardrails: bool = bool(raw_guardrails) if isinstance(raw_guardrails, bool) else True
+
+    # ── Optional: limit ───────────────────────────────────────────────────────
+    raw_limit = params.get("limit", _DEFAULT_LIMIT)
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError):
+        limit = _DEFAULT_LIMIT
+    limit = max(1, min(limit, _MAX_LIMIT))
+
+    # ── Optional: as_of ───────────────────────────────────────────────────────
+    # Priority: explicit param > bundle["meta"]["as_of"] > None (service default)
+    raw_as_of = _as_str_or_none(params.get("as_of"))
+    if raw_as_of is None:
+        meta = bundle.get("meta")
+        if isinstance(meta, Mapping):
+            raw_as_of = _as_str_or_none(meta.get("as_of"))
+
+    # ── Run scan ─────────────────────────────────────────────────────────────
+    try:
+        scan_result = scan_stale_knowledge_v1(bundle, as_of=raw_as_of)
+    except StaleKnowledgeScanError as exc:
+        return _error_response(
+            TOOL_CDB_CONTEXT_STALE,
+            code="invalid_bundle",
+            message=str(exc),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _error_response(
+            TOOL_CDB_CONTEXT_STALE,
+            code="scan_error",
+            message=f"Scan failed unexpectedly: {type(exc).__name__}",
+        )
+
+    # ── Apply post-scan filters ───────────────────────────────────────────────
+    allowed_stale_types = _SCOPE_TO_STALE_TYPES[scope]
+
+    filtered: list[StaleFinding] = []
+    for f in scan_result.findings:
+        # scope / stale_type whitelist
+        if f.stale_type not in allowed_stale_types:
+            continue
+        # explicit stale_type filter
+        if stale_type_filter is not None and f.stale_type != stale_type_filter:
+            continue
+        # severity filter
+        if severity_filter is not None and f.severity != severity_filter:
+            continue
+        # target_ref filter
+        if target_ref_filter is not None and f.target_ref != target_ref_filter:
+            continue
+        filtered.append(f)
+
+    # ── Summary (post-filter, pre-limit) ─────────────────────────────────────
+    total_count = len(filtered)
+    blocking_count = sum(1 for f in filtered if f.blocking)
+    sev_summary = _severity_summary(filtered)
+    st_summary = _stale_type_summary(filtered)
+
+    # ── Apply limit ───────────────────────────────────────────────────────────
+    truncated = len(filtered) > limit
+    findings_page = filtered[:limit]
+
+    # ── Collect cross-cutting fields from paged findings ─────────────────────
+    recommended_refresh = _collect_recommended_refresh(filtered)
+    source_refs = _collect_source_refs(filtered)
+
+    # ── Build response ────────────────────────────────────────────────────────
+    response: dict[str, Any] = {
+        "tool": TOOL_CDB_CONTEXT_STALE,
+        "schema_version": SCHEMA_VERSION,
+        "status": "ok",
+        "summary": {
+            "total_count": total_count,
+            "blocking_count": blocking_count,
+            "truncated": truncated,
+            "severity_summary": sev_summary,
+            "stale_type_summary": st_summary,
+        },
+        "findings": [f.to_dict() for f in findings_page],
+        "recommended_refresh": recommended_refresh,
+        "source_refs": source_refs,
+        "as_of": scan_result.as_of,
+        "metadata": _metadata(),
+    }
+
+    if include_guardrails:
+        response["guardrails"] = list(GUARDRAILS)
+
+    return response


### PR DESCRIPTION
## Summary

Wave 16-C — adds the read-only MCP tool `cdb_context_stale` that exposes stale knowledge findings from the already-landed scan service to agents via the Context MCP Bridge.

Closes #2157
Parent: #2153 — remains open until all Wave-16 children close

### Basis

- Service base: #2154 / PR #2368 (`scan_stale_knowledge_v1`, landed at `09e4356`)
- CLI base: #2155 / PR #2370 (`stale_context_cli.py`, landed at `33b9897`)
- MCP bridge base: #2093 (`ContextBridge`, Wave-15 architecture)

### Changes (5 files)

| File | Change |
|---|---|
| `tools/mcp/stale_context_tools.py` | **NEW** — `handle_cdb_context_stale` adapter |
| `tools/mcp/registry.py` | Added `cdb_context_stale` `ToolDefinition` to `TOOLS_V0` |
| `tools/mcp/permission_guard.py` | Added `cdb_context_stale` to `INPUT_SCAN_EXEMPT_TOOLS` |
| `tools/mcp/context_bridge.py` | `cdb_context_stale_handler` function + Wave-16-C wiring in `__init__` |
| `tests/unit/tools/mcp/test_mcp_stale_context_tool.py` | **NEW** — 32 unit tests |

### Tool: `cdb_context_stale`

- **read-only MCP tool** — `read_only=True` enforced in registry
- **bundle-driven only** — all findings come from the input bundle; no DB access, no SurrealDB SDK, no network, no filesystem writes
- Scope filter: `all | artifact | decision | memory | edge | package | briefing`
- Per-finding filters: `stale_type` (8 canonical types), `severity` (info/warning/blocking), `target_ref`
- `limit` caps findings (max 500); `summary.truncated=true` when applied
- Summary counts are post-filter, pre-limit
- Guardrails embedded in output by default (`include_guardrails=true`)

### Guardrails (in output)

1. Stale Detection is signal, not authorization.
2. No automatic delete.
3. No automatic refresh write.
4. No Live-Readiness-Go.
5. No Echtgeld-Go.

### Not in scope

- Refresh Plan Generator (#2158)
- Runbook (#2159)
- Completion Gates (#2160 / #2161)
- No DB / SurrealDB SDK / network / filesystem writes
- No Live-Go / LR-Go / Echtgeld-Go
- No changes to `tools/surrealdb/stale_knowledge_scan.py` or `tools/surrealdb/stale_context_cli.py`

### Validation

| Check | Result |
|---|---|
| `test_mcp_stale_context_tool.py` (32 tests) | **32/32 PASSED** |
| `test_stale_knowledge_scan.py` (regression) | **36/36 PASSED** |
| `test_stale_context_cli.py` (regression) | **28/28 PASSED** |
| `tests/unit/tools/mcp/` full suite | **559/559 PASSED** |
| `ruff check` | **All checks passed** |
| Safety grep (comment-only hits) | **OK** |
| AST import check (4 files) | **AST SAFETY OK** |
| `git diff --check` | **OK** |