### PR TITLE
feat(surrealdb): implement scope drift firewall service v1

### DIFF
--- a/tests/fixtures/surrealdb/scope_drift/sample_bundle.json
+++ b/tests/fixtures/surrealdb/scope_drift/sample_bundle.json
@@ -1,0 +1,43 @@
+{
+  "_comment": "Sample input bundle for scope_drift_firewall tests and integration use. Triggers exactly 3 drift types: path_out_of_scope (path outside declared target_paths), runtime_surface_touched (surface_type=runtime), and missing_human_go (operation_mode=write, no human_go_token). The meta.as_of field is advisory only — the service accepts as_of as a direct parameter.",
+  "meta": {
+    "as_of": "2026-05-06T00:00:00+00:00",
+    "session_id": "wave17-sample-session-001",
+    "operation_mode": "write",
+    "human_go_token": null,
+    "description": "Wave 17-A sample bundle — deterministic, no live data"
+  },
+  "declared_scope": {
+    "task_scope": "Implement scope drift firewall service for Wave 17-A",
+    "target_issue": "2163",
+    "target_paths": [
+      "tools/surrealdb/",
+      "tests/unit/surrealdb/",
+      "tests/fixtures/surrealdb/scope_drift/"
+    ]
+  },
+  "touched_artifacts": [
+    {
+      "path": "tools/surrealdb/scope_drift_firewall.py",
+      "surface_type": "tools"
+    },
+    {
+      "path": "services/cdb_market/service.py",
+      "surface_type": "runtime"
+    }
+  ],
+  "issue_refs": [
+    {
+      "issue_id": "2163",
+      "state": "OPEN",
+      "label": "Wave-17"
+    },
+    {
+      "issue_id": "2162",
+      "state": "OPEN",
+      "label": "Wave-17-anchor"
+    }
+  ],
+  "generated_findings": [],
+  "forbidden_surfaces": []
+}

--- a/tests/unit/surrealdb/test_scope_drift_firewall.py
+++ b/tests/unit/surrealdb/test_scope_drift_firewall.py
@@ -864,3 +864,59 @@ def test_path_in_scope_with_no_trailing_slash_target() -> None:
     assert "path_out_of_scope" not in types, (
         "tools/surrealdb/scope_drift_firewall.py must be in scope for target 'tools/surrealdb'"
     )
+
+
+# ── Thread A hardening: glob pattern target_paths ────────────────────────────
+
+
+@pytest.mark.unit
+def test_path_in_scope_glob_pattern() -> None:
+    """Schema documents target_paths as glob patterns; fnmatch must apply."""
+    bundle = {
+        "declared_scope": {"target_paths": ["tools/surrealdb/*.py"]},
+        "touched_artifacts": [
+            {"path": "tools/surrealdb/scope_drift_firewall.py", "surface_type": "tools"},
+        ],
+    }
+    result = _scan(bundle, as_of=_AS_OF)
+    types = {f.drift_type for f in result.findings}
+    assert "path_out_of_scope" not in types, (
+        "tools/surrealdb/scope_drift_firewall.py must match glob 'tools/surrealdb/*.py'"
+    )
+
+
+@pytest.mark.unit
+def test_path_out_of_scope_glob_no_match() -> None:
+    """Paths outside the glob scope must be flagged."""
+    bundle = {
+        "declared_scope": {"target_paths": ["tools/surrealdb/*.py"]},
+        "touched_artifacts": [
+            {"path": "services/risk/other.py", "surface_type": "service"},
+        ],
+    }
+    result = _scan(bundle, as_of=_AS_OF)
+    types = {f.drift_type for f in result.findings}
+    assert "path_out_of_scope" in types, (
+        "services/risk/other.py must not match glob 'tools/surrealdb/*.py'"
+    )
+
+
+# ── Thread B hardening: parked surface sibling-prefix boundary ───────────────
+
+
+@pytest.mark.unit
+def test_parked_topic_activated_sibling_prefix_not_flagged() -> None:
+    """Sibling paths that only share a prefix must NOT trigger parked_topic_activated."""
+    bundle = {
+        "forbidden_surfaces": [
+            {"surface": "docs/runbooks", "reason": "production runbooks"}
+        ],
+        "touched_artifacts": [
+            {"path": "docs/runbooks_old/a.md", "surface_type": "docs"},
+        ],
+    }
+    result = _scan(bundle, as_of=_AS_OF)
+    types = {f.drift_type for f in result.findings}
+    assert "parked_topic_activated" not in types, (
+        "docs/runbooks_old/a.md must NOT be flagged for forbidden surface 'docs/runbooks'"
+    )

--- a/tests/unit/surrealdb/test_scope_drift_firewall.py
+++ b/tests/unit/surrealdb/test_scope_drift_firewall.py
@@ -30,12 +30,11 @@ from __future__ import annotations
 
 import hashlib
 import inspect
+import sys
 
 import pytest
 
-import tools.surrealdb.scope_drift_firewall as _mod
 from tools.surrealdb.scope_drift_firewall import (
-    DETECTED_BY,
     DRIFT_TYPES,
     GUARDRAILS,
     REQUIRED_ACTIONS,
@@ -49,6 +48,9 @@ from tools.surrealdb.scope_drift_firewall import (
     _make_drift_id,
     scan_scope_drift_v1,
 )
+
+# Module reference for inspect.getsource in guardrail tests
+_mod = sys.modules["tools.surrealdb.scope_drift_firewall"]
 
 # Fixed reference timestamp used across all tests for determinism
 _AS_OF = "2026-05-06T12:00:00+00:00"

--- a/tests/unit/surrealdb/test_scope_drift_firewall.py
+++ b/tests/unit/surrealdb/test_scope_drift_firewall.py
@@ -1,0 +1,790 @@
+"""Unit tests for scope_drift_firewall.py — Scope Drift Firewall Service v1.
+
+Issues:
+    #2163 — [SURREALDB][CONTEXT][SCOPE-FIREWALL] Implement scope drift firewall service v1
+    Parent: #2162 (Wave-17 anchor)
+    Epic: #1976
+
+Scope:
+    Unit tests for tools/surrealdb/scope_drift_firewall.py.
+    All fixtures are inline (no file loading — keeps slice narrow).
+    No DB access. No SurrealDB SDK. No MCP. No networking. No writes.
+    No real datetime.now() — validated by test_no_wall_clock_direct.
+
+Coverage:
+    - All 9 drift_type rules produce at least one finding with triggering input.
+    - All 9 drift_type rules produce no finding with non-triggering input.
+    - Blocking findings have human_go_required=True.
+    - Deterministic IDs: same input → same drift_id.
+    - blocking_count aggregation is correct.
+    - Empty bundle → empty ScopeDriftScanResult (no error).
+    - Invalid bundle → ScopeDriftFirewallError.
+    - All 5 guardrail strings present in result.
+    - Output does not grant live-go, write, or delete authorization.
+    - to_dict() produces severity_summary with all severity levels.
+    - status is 'blocked_scope_drift' when blocking findings present.
+    - status is 'ok' when no blocking findings present.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+
+import pytest
+
+import tools.surrealdb.scope_drift_firewall as _mod
+from tools.surrealdb.scope_drift_firewall import (
+    DETECTED_BY,
+    DRIFT_TYPES,
+    GUARDRAILS,
+    REQUIRED_ACTIONS,
+    SCHEMA_VERSION,
+    SEVERITY_LEVELS,
+    STATUS_VALUES,
+    TOOL_NAME,
+    ScopeDriftFinding,
+    ScopeDriftFirewallError,
+    ScopeDriftScanResult,
+    _make_drift_id,
+    scan_scope_drift_v1,
+)
+
+# Fixed reference timestamp used across all tests for determinism
+_AS_OF = "2026-05-06T12:00:00+00:00"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _assert_valid_finding(f: ScopeDriftFinding) -> None:
+    """Assert all mandatory fields on a ScopeDriftFinding are valid."""
+    assert isinstance(f.drift_id, str) and len(f.drift_id) > 0
+    assert f.drift_type in DRIFT_TYPES, f"unexpected drift_type: {f.drift_type!r}"
+    assert f.severity in SEVERITY_LEVELS, f"unexpected severity: {f.severity!r}"
+    assert isinstance(f.allowed_scope, str) and len(f.allowed_scope) > 0
+    assert isinstance(f.observed_scope, str) and len(f.observed_scope) > 0
+    assert isinstance(f.affected_artifacts, tuple)
+    assert f.required_action in REQUIRED_ACTIONS, f"unexpected action: {f.required_action!r}"
+    assert isinstance(f.human_go_required, bool)
+    assert isinstance(f.stop_conditions, tuple)
+    assert isinstance(f.recommended_next_reads, tuple) and len(f.recommended_next_reads) > 0
+    assert isinstance(f.detected_by, str) and len(f.detected_by) > 0
+    assert isinstance(f.detected_at, str) and len(f.detected_at) > 0
+    assert f.status in STATUS_VALUES, f"unexpected status: {f.status!r}"
+
+
+def _scan(bundle: dict, as_of: str = _AS_OF) -> ScopeDriftScanResult:
+    """Convenience wrapper with fixed as_of for deterministic tests."""
+    return scan_scope_drift_v1(bundle, as_of=as_of)
+
+
+# ── Constants / Schema Guards ─────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_drift_types_count() -> None:
+    assert len(DRIFT_TYPES) == 9
+
+
+@pytest.mark.unit
+def test_drift_types_all_present() -> None:
+    expected = {
+        "path_out_of_scope",
+        "domain_out_of_scope",
+        "issue_out_of_scope",
+        "parked_topic_activated",
+        "runtime_surface_touched",
+        "trading_surface_touched",
+        "unexpected_dependency_expansion",
+        "unauthorized_write_intent",
+        "missing_human_go",
+    }
+    assert DRIFT_TYPES == expected
+
+
+@pytest.mark.unit
+def test_guardrails_count() -> None:
+    assert len(GUARDRAILS) == 5
+
+
+@pytest.mark.unit
+def test_guardrails_all_present() -> None:
+    guardrail_set = set(GUARDRAILS)
+    assert "Scope Drift Detection is signal, not authorization." in guardrail_set
+    assert "No auto-fix. No auto-write." in guardrail_set
+    assert "No Live-Readiness-Go." in guardrail_set
+    assert "No Echtgeld-Go." in guardrail_set
+    assert "Human-GO required for any write after blocking scope drift." in guardrail_set
+
+
+@pytest.mark.unit
+def test_schema_version() -> None:
+    assert SCHEMA_VERSION == "scope-drift-firewall/v1"
+
+
+@pytest.mark.unit
+def test_required_actions_set() -> None:
+    assert REQUIRED_ACTIONS == frozenset({"stop", "review", "split_scope", "request_go"})
+
+
+# ── No-wall-clock guardrail ───────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_no_wall_clock_direct() -> None:
+    """Service module must not call datetime.now() or datetime.utcnow() directly."""
+    source = inspect.getsource(_mod)
+    assert "datetime.now()" not in source, "datetime.now() found — use cdb_utcnow"
+    assert "datetime.utcnow()" not in source, "datetime.utcnow() found — use cdb_utcnow"
+
+
+@pytest.mark.unit
+def test_no_write_authorized_field() -> None:
+    """write_authorized must not appear in the service module (no refresh-plan pattern)."""
+    source = inspect.getsource(_mod)
+    assert "write_authorized" not in source
+
+
+# ── Empty bundle ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_empty_bundle_returns_empty_result() -> None:
+    result = _scan({})
+    assert isinstance(result, ScopeDriftScanResult)
+    assert result.findings == ()
+    assert result.blocking_count == 0
+    assert result.status == "ok"
+
+
+@pytest.mark.unit
+def test_empty_bundle_has_guardrails() -> None:
+    result = _scan({})
+    assert result.guardrails == GUARDRAILS
+
+
+@pytest.mark.unit
+def test_empty_bundle_schema_version() -> None:
+    result = _scan({})
+    assert result.schema_version == SCHEMA_VERSION
+    assert result.tool == TOOL_NAME
+
+
+# ── Invalid bundle ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_invalid_bundle_none_raises() -> None:
+    with pytest.raises(ScopeDriftFirewallError):
+        scan_scope_drift_v1(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_invalid_bundle_list_raises() -> None:
+    with pytest.raises(ScopeDriftFirewallError):
+        scan_scope_drift_v1([])  # type: ignore[arg-type]
+
+
+# ── Deterministic IDs ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_make_drift_id_is_deterministic() -> None:
+    id1 = _make_drift_id("path_out_of_scope", "tools/bad/", "tools/bad/file.py")
+    id2 = _make_drift_id("path_out_of_scope", "tools/bad/", "tools/bad/file.py")
+    assert id1 == id2
+
+
+@pytest.mark.unit
+def test_make_drift_id_differs_for_different_inputs() -> None:
+    id1 = _make_drift_id("path_out_of_scope", "tools/bad/", "tools/bad/file.py")
+    id2 = _make_drift_id("domain_out_of_scope", "runtime", "services/foo.py")
+    assert id1 != id2
+
+
+@pytest.mark.unit
+def test_make_drift_id_is_sha256_prefix() -> None:
+    raw = "path_out_of_scope|observed|affected"
+    expected = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    assert _make_drift_id("path_out_of_scope", "observed", "affected") == expected
+
+
+# ── blocking_count and status aggregation ────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_blocking_count_correct_for_multiple_violations() -> None:
+    bundle = {
+        "declared_scope": {
+            "target_paths": ["tools/surrealdb/"],
+            "target_issue": "2163",
+        },
+        "touched_artifacts": [
+            {"path": "services/risk/risk_service.py", "surface_type": "runtime"},
+        ],
+        "meta": {"operation_mode": "write"},
+    }
+    result = _scan(bundle)
+    # Expect: path_out_of_scope (blocking) + parked_topic (blocking) +
+    #         runtime_surface (blocking) + trading_surface (blocking) +
+    #         missing_human_go (blocking) — all blocking
+    assert result.blocking_count > 0
+    assert result.status == "blocked_scope_drift"
+    assert all(f.human_go_required for f in result.findings if f.severity == "blocking")
+
+
+@pytest.mark.unit
+def test_status_ok_when_no_blocking() -> None:
+    bundle = {
+        "declared_scope": {
+            "target_paths": ["tools/surrealdb/"],
+            "target_issue": "2163",
+        },
+        "touched_artifacts": [
+            {"path": "tools/surrealdb/scope_drift_firewall.py", "surface_type": "tools"},
+        ],
+        "issue_refs": [{"issue_id": "2163", "state": "OPEN", "label": "Wave-17"}],
+    }
+    result = _scan(bundle)
+    assert result.blocking_count == 0
+    assert result.status == "ok"
+
+
+# ── to_dict() contract ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_to_dict_has_severity_summary() -> None:
+    bundle = {
+        "declared_scope": {"target_paths": ["tools/"], "target_issue": "2163"},
+        "touched_artifacts": [
+            {"path": "services/bad.py", "surface_type": "runtime"},
+        ],
+    }
+    d = _scan(bundle).to_dict()
+    assert "severity_summary" in d
+    for level in SEVERITY_LEVELS:
+        assert level in d["severity_summary"]
+
+
+@pytest.mark.unit
+def test_to_dict_has_no_live_go_field_in_guardrails() -> None:
+    result = _scan({})
+    d = result.to_dict()
+    guardrails_text = " ".join(d["guardrails"])
+    assert "Live-Readiness-Go" in guardrails_text
+    assert "Echtgeld-Go" in guardrails_text
+
+
+# ── Rule 1: path_out_of_scope ─────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_path_out_of_scope_triggers() -> None:
+    bundle = {
+        "declared_scope": {"target_paths": ["tools/surrealdb/"]},
+        "touched_artifacts": [
+            {"path": "services/risk/risk_service.py", "surface_type": "service"}
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "path_out_of_scope" in types
+    finding = next(f for f in result.findings if f.drift_type == "path_out_of_scope")
+    _assert_valid_finding(finding)
+    assert finding.severity == "blocking"
+    assert finding.human_go_required is True
+    assert finding.required_action == "stop"
+    assert len(finding.stop_conditions) > 0
+
+
+@pytest.mark.unit
+def test_path_out_of_scope_no_trigger_within_scope() -> None:
+    bundle = {
+        "declared_scope": {"target_paths": ["tools/surrealdb/"]},
+        "touched_artifacts": [
+            {"path": "tools/surrealdb/scope_drift_firewall.py", "surface_type": "tools"}
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "path_out_of_scope" not in types
+
+
+@pytest.mark.unit
+def test_path_out_of_scope_no_trigger_when_no_target_paths() -> None:
+    bundle = {
+        "declared_scope": {"target_issue": "2163"},
+        "touched_artifacts": [
+            {"path": "services/risk/anything.py", "surface_type": "service"}
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "path_out_of_scope" not in types
+
+
+# ── Rule 2: domain_out_of_scope ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_domain_out_of_scope_triggers() -> None:
+    bundle = {
+        "declared_scope": {"allowed_domains": ["tools", "tests"]},
+        "touched_artifacts": [
+            {"path": "services/signal/signal.py", "surface_type": "service"}
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "domain_out_of_scope" in types
+    finding = next(f for f in result.findings if f.drift_type == "domain_out_of_scope")
+    _assert_valid_finding(finding)
+    assert finding.severity == "warning"
+
+
+@pytest.mark.unit
+def test_domain_out_of_scope_no_trigger_within_allowed() -> None:
+    bundle = {
+        "declared_scope": {"allowed_domains": ["tools", "tests", "service"]},
+        "touched_artifacts": [
+            {"path": "services/signal/signal.py", "surface_type": "service"}
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "domain_out_of_scope" not in types
+
+
+@pytest.mark.unit
+def test_domain_out_of_scope_no_trigger_when_no_allowed_domains() -> None:
+    bundle = {
+        "declared_scope": {"target_paths": ["tools/"]},
+        "touched_artifacts": [
+            {"path": "services/x.py", "surface_type": "runtime"}
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "domain_out_of_scope" not in types
+
+
+# ── Rule 3: issue_out_of_scope ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_issue_out_of_scope_triggers() -> None:
+    bundle = {
+        "declared_scope": {"target_issue": "2163"},
+        "issue_refs": [{"issue_id": "9999", "state": "OPEN", "label": "unrelated"}],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "issue_out_of_scope" in types
+    finding = next(f for f in result.findings if f.drift_type == "issue_out_of_scope")
+    _assert_valid_finding(finding)
+    assert finding.severity == "warning"
+
+
+@pytest.mark.unit
+def test_issue_out_of_scope_no_trigger_for_target_issue() -> None:
+    bundle = {
+        "declared_scope": {"target_issue": "2163"},
+        "issue_refs": [{"issue_id": "2163", "state": "OPEN", "label": "Wave-17"}],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "issue_out_of_scope" not in types
+
+
+@pytest.mark.unit
+def test_issue_out_of_scope_no_trigger_when_no_target_issue() -> None:
+    bundle = {
+        "declared_scope": {},
+        "issue_refs": [{"issue_id": "9999", "state": "OPEN"}],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "issue_out_of_scope" not in types
+
+
+# ── Rule 4: parked_topic_activated ────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_parked_topic_activated_triggers_hardcoded_pattern() -> None:
+    bundle = {
+        "touched_artifacts": [
+            {"path": "services/risk/risk_service.py", "surface_type": "service"}
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "parked_topic_activated" in types
+    finding = next(f for f in result.findings if f.drift_type == "parked_topic_activated")
+    _assert_valid_finding(finding)
+    assert finding.severity == "blocking"
+    assert finding.human_go_required is True
+
+
+@pytest.mark.unit
+def test_parked_topic_activated_triggers_bundle_forbidden_surface() -> None:
+    bundle = {
+        "touched_artifacts": [
+            {"path": "docs/special-secret/file.md", "surface_type": "docs"}
+        ],
+        "forbidden_surfaces": [
+            {"surface": "docs/special-secret/", "reason": "locked by governance"}
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "parked_topic_activated" in types
+
+
+@pytest.mark.unit
+def test_parked_topic_activated_no_trigger_for_safe_path() -> None:
+    bundle = {
+        "touched_artifacts": [
+            {"path": "tools/surrealdb/scope_drift_firewall.py", "surface_type": "tools"}
+        ],
+        "forbidden_surfaces": [],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "parked_topic_activated" not in types
+
+
+# ── Rule 5: runtime_surface_touched ──────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_runtime_surface_touched_triggers_runtime() -> None:
+    bundle = {
+        "touched_artifacts": [
+            {"path": "services/cdb_market/service.py", "surface_type": "runtime"}
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "runtime_surface_touched" in types
+    finding = next(f for f in result.findings if f.drift_type == "runtime_surface_touched")
+    _assert_valid_finding(finding)
+    assert finding.severity == "blocking"
+    assert finding.human_go_required is True
+    assert finding.required_action == "stop"
+
+
+@pytest.mark.unit
+def test_runtime_surface_touched_triggers_service_type() -> None:
+    bundle = {
+        "touched_artifacts": [
+            {"path": "services/cdb_signal/signal.py", "surface_type": "service"}
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "runtime_surface_touched" in types
+
+
+@pytest.mark.unit
+def test_runtime_surface_touched_no_trigger_for_tools() -> None:
+    bundle = {
+        "touched_artifacts": [
+            {"path": "tools/surrealdb/scope_drift_firewall.py", "surface_type": "tools"}
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "runtime_surface_touched" not in types
+
+
+# ── Rule 6: trading_surface_touched ──────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_trading_surface_touched_triggers_by_surface_type() -> None:
+    bundle = {
+        "touched_artifacts": [
+            {"path": "some/path.py", "surface_type": "trading"}
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "trading_surface_touched" in types
+    finding = next(f for f in result.findings if f.drift_type == "trading_surface_touched")
+    _assert_valid_finding(finding)
+    assert finding.severity == "blocking"
+    assert finding.human_go_required is True
+    assert "NO-GO" in " ".join(finding.stop_conditions)
+
+
+@pytest.mark.unit
+def test_trading_surface_touched_triggers_by_risk_path() -> None:
+    bundle = {
+        "touched_artifacts": [
+            {"path": "services/risk/models.py", "surface_type": "tools"}
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "trading_surface_touched" in types
+
+
+@pytest.mark.unit
+def test_trading_surface_touched_no_trigger_for_docs() -> None:
+    bundle = {
+        "touched_artifacts": [
+            {"path": "docs/surrealdb/wave17-gates.md", "surface_type": "docs"}
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "trading_surface_touched" not in types
+
+
+# ── Rule 7: unexpected_dependency_expansion ───────────────────────────────────
+
+
+@pytest.mark.unit
+def test_unexpected_dependency_expansion_triggers_over_max() -> None:
+    bundle = {
+        "declared_scope": {
+            "target_paths": ["tools/surrealdb/"],
+            "max_artifact_count": 2,
+        },
+        "touched_artifacts": [
+            {"path": "tools/surrealdb/a.py", "surface_type": "tools"},
+            {"path": "tools/surrealdb/b.py", "surface_type": "tools"},
+            {"path": "tools/surrealdb/c.py", "surface_type": "tools"},
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "unexpected_dependency_expansion" in types
+    finding = next(f for f in result.findings if f.drift_type == "unexpected_dependency_expansion")
+    _assert_valid_finding(finding)
+    assert finding.severity == "warning"
+    assert finding.required_action == "split_scope"
+
+
+@pytest.mark.unit
+def test_unexpected_dependency_expansion_no_trigger_within_max() -> None:
+    bundle = {
+        "declared_scope": {
+            "target_paths": ["tools/surrealdb/"],
+            "max_artifact_count": 5,
+        },
+        "touched_artifacts": [
+            {"path": "tools/surrealdb/a.py", "surface_type": "tools"},
+            {"path": "tools/surrealdb/b.py", "surface_type": "tools"},
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "unexpected_dependency_expansion" not in types
+
+
+@pytest.mark.unit
+def test_unexpected_dependency_expansion_no_trigger_without_scope() -> None:
+    """No target_paths AND no max_artifact_count → no expansion finding."""
+    bundle = {
+        "declared_scope": {},
+        "touched_artifacts": [
+            {"path": f"tools/file{i}.py", "surface_type": "tools"}
+            for i in range(50)
+        ],
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "unexpected_dependency_expansion" not in types
+
+
+# ── Rule 8: unauthorized_write_intent ─────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_unauthorized_write_intent_triggers_explicit_flag() -> None:
+    bundle = {
+        "generated_findings": [
+            {
+                "type": "plan",
+                "content": "Implement the feature",
+                "source": "agent",
+                "write_intent": True,
+                "human_go_token": None,
+            }
+        ]
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "unauthorized_write_intent" in types
+    finding = next(f for f in result.findings if f.drift_type == "unauthorized_write_intent")
+    _assert_valid_finding(finding)
+    assert finding.severity == "blocking"
+    assert finding.human_go_required is True
+    assert finding.required_action == "stop"
+
+
+@pytest.mark.unit
+def test_unauthorized_write_intent_triggers_keyword_detection() -> None:
+    bundle = {
+        "generated_findings": [
+            {
+                "type": "analysis",
+                "content": "We should commit the changes and push to main.",
+                "source": "agent",
+                "write_intent": False,
+                "human_go_token": None,
+            }
+        ]
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "unauthorized_write_intent" in types
+
+
+@pytest.mark.unit
+def test_unauthorized_write_intent_no_trigger_with_go_token() -> None:
+    bundle = {
+        "generated_findings": [
+            {
+                "type": "plan",
+                "content": "Write file to disk",
+                "source": "agent",
+                "write_intent": True,
+                "human_go_token": "GO-2026-05-06-WAVE17",
+            }
+        ]
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "unauthorized_write_intent" not in types
+
+
+@pytest.mark.unit
+def test_unauthorized_write_intent_no_trigger_for_read_only_content() -> None:
+    bundle = {
+        "generated_findings": [
+            {
+                "type": "analysis",
+                "content": "Reading the file to understand the structure.",
+                "source": "agent",
+                "write_intent": False,
+                "human_go_token": None,
+            }
+        ]
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "unauthorized_write_intent" not in types
+
+
+# ── Rule 9: missing_human_go ──────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_missing_human_go_triggers_write_mode() -> None:
+    bundle = {
+        "meta": {"operation_mode": "write", "human_go_token": None},
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "missing_human_go" in types
+    finding = next(f for f in result.findings if f.drift_type == "missing_human_go")
+    _assert_valid_finding(finding)
+    assert finding.severity == "blocking"
+    assert finding.human_go_required is True
+    assert finding.required_action == "request_go"
+
+
+@pytest.mark.unit
+def test_missing_human_go_triggers_commit_mode() -> None:
+    bundle = {
+        "meta": {"operation_mode": "commit", "human_go_token": ""},
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "missing_human_go" in types
+
+
+@pytest.mark.unit
+def test_missing_human_go_no_trigger_with_go_token() -> None:
+    bundle = {
+        "meta": {"operation_mode": "write", "human_go_token": "GO-2026-05-06"},
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "missing_human_go" not in types
+
+
+@pytest.mark.unit
+def test_missing_human_go_no_trigger_for_read_mode() -> None:
+    bundle = {
+        "meta": {"operation_mode": "read", "human_go_token": None},
+    }
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "missing_human_go" not in types
+
+
+@pytest.mark.unit
+def test_missing_human_go_no_trigger_when_no_meta() -> None:
+    bundle: dict = {}
+    result = _scan(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "missing_human_go" not in types
+
+
+# ── human_go_required contract ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_human_go_required_true_for_all_blocking() -> None:
+    """All blocking findings must have human_go_required=True."""
+    bundle = {
+        "meta": {"operation_mode": "write"},
+        "touched_artifacts": [
+            {"path": "services/risk/risk_service.py", "surface_type": "runtime"},
+        ],
+    }
+    result = _scan(bundle)
+    blocking = [f for f in result.findings if f.severity == "blocking"]
+    assert len(blocking) > 0
+    assert all(f.human_go_required for f in blocking)
+
+
+@pytest.mark.unit
+def test_human_go_required_false_for_warnings() -> None:
+    """Warning-severity findings must have human_go_required=False."""
+    bundle = {
+        "declared_scope": {
+            "target_paths": ["tools/surrealdb/"],
+            "max_artifact_count": 1,
+        },
+        "touched_artifacts": [
+            {"path": "tools/surrealdb/a.py", "surface_type": "tools"},
+            {"path": "tools/surrealdb/b.py", "surface_type": "tools"},
+            {"path": "tools/surrealdb/c.py", "surface_type": "tools"},
+        ],
+    }
+    result = _scan(bundle)
+    warnings = [f for f in result.findings if f.severity == "warning"]
+    assert len(warnings) > 0
+    assert all(not f.human_go_required for f in warnings)
+
+
+# ── recommended_next_reads defaults ──────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_recommended_next_reads_always_contains_agents_md() -> None:
+    bundle = {
+        "declared_scope": {"target_paths": ["tools/"]},
+        "touched_artifacts": [{"path": "services/bad.py", "surface_type": "tools"}],
+    }
+    result = _scan(bundle)
+    assert len(result.findings) > 0
+    for f in result.findings:
+        assert "AGENTS.md" in f.recommended_next_reads

--- a/tests/unit/surrealdb/test_scope_drift_firewall.py
+++ b/tests/unit/surrealdb/test_scope_drift_firewall.py
@@ -790,3 +790,77 @@ def test_recommended_next_reads_always_contains_agents_md() -> None:
     assert len(result.findings) > 0
     for f in result.findings:
         assert "AGENTS.md" in f.recommended_next_reads
+
+
+# ── P1 hardening: prefixed write modes ───────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_missing_human_go_triggers_write_prefixed_mode() -> None:
+    """Prefixed write modes like 'write_code', 'write_docs' must trigger without GO."""
+    for mode in ("write_code", "write_docs", "write_authorized", "commit_staged"):
+        bundle = {"meta": {"operation_mode": mode, "human_go_token": None}}
+        result = _scan(bundle, as_of=_AS_OF)
+        types = {f.drift_type for f in result.findings}
+        assert "missing_human_go" in types, f"Expected finding for mode={mode!r}"
+
+
+@pytest.mark.unit
+def test_missing_human_go_no_trigger_for_non_write_prefixed_mode() -> None:
+    """Non-write prefixed modes like 'readonly', 'analyze', 'inspect' must not trigger."""
+    for mode in ("readonly", "analyze", "inspect"):
+        bundle = {"meta": {"operation_mode": mode, "human_go_token": None}}
+        result = _scan(bundle, as_of=_AS_OF)
+        types = {f.drift_type for f in result.findings}
+        assert "missing_human_go" not in types, f"Unexpected finding for mode={mode!r}"
+
+
+# ── P2 hardening: sibling-prefix path boundary ───────────────────────────────
+
+
+@pytest.mark.unit
+def test_path_out_of_scope_sibling_prefix_detected() -> None:
+    """Sibling paths sharing only a non-slash prefix must be out of scope."""
+    bundle = {
+        "declared_scope": {"target_paths": ["tools/surrealdb"]},
+        "touched_artifacts": [
+            {"path": "tools/surrealdb_extra/file.py", "surface_type": "tools"},
+        ],
+    }
+    result = _scan(bundle, as_of=_AS_OF)
+    types = {f.drift_type for f in result.findings}
+    assert "path_out_of_scope" in types, (
+        "tools/surrealdb_extra/ must be out of scope for target 'tools/surrealdb'"
+    )
+
+
+@pytest.mark.unit
+def test_path_out_of_scope_exact_file_sibling_detected() -> None:
+    """A .bak extension file must not match the original file as scope."""
+    bundle = {
+        "declared_scope": {"target_paths": ["core/utils/clock.py"]},
+        "touched_artifacts": [
+            {"path": "core/utils/clock.py.bak", "surface_type": "tools"},
+        ],
+    }
+    result = _scan(bundle, as_of=_AS_OF)
+    types = {f.drift_type for f in result.findings}
+    assert "path_out_of_scope" in types, (
+        "core/utils/clock.py.bak must be out of scope for target 'core/utils/clock.py'"
+    )
+
+
+@pytest.mark.unit
+def test_path_in_scope_with_no_trailing_slash_target() -> None:
+    """A real subpath must still be in scope for a non-slash-terminated target."""
+    bundle = {
+        "declared_scope": {"target_paths": ["tools/surrealdb"]},
+        "touched_artifacts": [
+            {"path": "tools/surrealdb/scope_drift_firewall.py", "surface_type": "tools"},
+        ],
+    }
+    result = _scan(bundle, as_of=_AS_OF)
+    types = {f.drift_type for f in result.findings}
+    assert "path_out_of_scope" not in types, (
+        "tools/surrealdb/scope_drift_firewall.py must be in scope for target 'tools/surrealdb'"
+    )

--- a/tools/surrealdb/scope_drift_firewall.py
+++ b/tools/surrealdb/scope_drift_firewall.py
@@ -614,8 +614,7 @@ def _rule_trading_surface_touched(
                     affected_artifacts=[artifact_ref],
                     required_action="stop",
                     stop_conditions=[
-                        "Trading surface touched. LR status is NO-GO. "
-                        "No changes to trading surfaces (risk, execution) without Human-GO.",
+                        "Trading surface touched. LR status is NO-GO. No changes to trading surfaces (risk, execution) without Human-GO.",
                         "Board stage 'trade-capable' is NOT a live-go.",
                     ],
                     recommended_next_reads=[

--- a/tools/surrealdb/scope_drift_firewall.py
+++ b/tools/surrealdb/scope_drift_firewall.py
@@ -28,6 +28,7 @@ Guardrails:
 
 from __future__ import annotations
 
+import fnmatch
 import hashlib
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
@@ -282,6 +283,9 @@ def _path_is_within_scope(path: str, target_paths: list[str]) -> bool:
 
     Requires a directory-boundary match to avoid sibling-prefix false negatives:
     e.g. 'tools/surrealdb_extra/f.py' must NOT match target 'tools/surrealdb'.
+
+    Supports glob patterns (schema: target_paths accepts "glob patterns"):
+    e.g. 'tools/surrealdb/*.py' matches 'tools/surrealdb/scope_drift_firewall.py'.
     """
     if not target_paths:
         return True  # no constraint declared → not a violation
@@ -289,6 +293,10 @@ def _path_is_within_scope(path: str, target_paths: list[str]) -> bool:
         norm = prefix.rstrip("/")
         if path == norm or path.startswith(norm + "/"):
             return True
+        # Glob pattern support (schema documents target_paths as "glob patterns")
+        if any(c in prefix for c in ("*", "?", "[")):
+            if fnmatch.fnmatch(path, prefix):
+                return True
     return False
 
 
@@ -504,7 +512,7 @@ def _rule_parked_topic_activated(
 
         # Check bundle-declared forbidden surfaces
         for surface, reason in bundle_forbidden:
-            if path == surface or path.startswith(surface.rstrip("/") + "/") or path.startswith(surface):
+            if path == surface or path.startswith(surface.rstrip("/") + "/"):
                 # Avoid duplicate if already flagged by hardcoded pattern
                 already = any(
                     f.drift_type == "parked_topic_activated"

--- a/tools/surrealdb/scope_drift_firewall.py
+++ b/tools/surrealdb/scope_drift_firewall.py
@@ -1,0 +1,861 @@
+"""Scope Drift Firewall Service v1 — side-effect-free domain component.
+
+Issues:
+    #2163 — [SURREALDB][CONTEXT][SCOPE-FIREWALL] Implement scope drift firewall service v1
+    Parent: #2162 (Wave-17 anchor)
+    Epic: #1976
+
+Scope:
+    Implements a minimal, deterministic scope-drift-firewall service that works
+    purely on in-memory records (input bundles as dicts). No DB access. No
+    SurrealDB SDK. No MCP. No networking. No writes. No auto-fix. No live-go.
+
+    Detects scope drift for:
+        path_out_of_scope, domain_out_of_scope, issue_out_of_scope,
+        parked_topic_activated, runtime_surface_touched,
+        trading_surface_touched, unexpected_dependency_expansion,
+        unauthorized_write_intent, missing_human_go
+
+Guardrails:
+    - Detection only: never implies approval, live-go, or decision authority.
+    - Blocking findings are surfaced explicitly but do NOT grant permission to act.
+    - No write, no mutation, no GitHub/runtime write from this module.
+    - No direct wall-clock calls or random UUID generation (use core.utils.clock).
+    - LR status remains NO-GO for live trading.
+    - Scope Drift Detection is signal, not authorization.
+    - Human-GO required for any write after blocking scope drift.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+SCHEMA_VERSION = "scope-drift-firewall/v1"
+TOOL_NAME = "scope_drift_firewall"
+DETECTED_BY = "scope-drift-firewall/v1"
+
+DRIFT_TYPES = frozenset(
+    {
+        "path_out_of_scope",
+        "domain_out_of_scope",
+        "issue_out_of_scope",
+        "parked_topic_activated",
+        "runtime_surface_touched",
+        "trading_surface_touched",
+        "unexpected_dependency_expansion",
+        "unauthorized_write_intent",
+        "missing_human_go",
+    }
+)
+
+SEVERITY_LEVELS = ("info", "warning", "blocking")
+
+STATUS_VALUES = frozenset(
+    {
+        "open",
+        "acknowledged",
+        "false_positive",
+        "accepted_risk",
+        "resolved",
+    }
+)
+
+REQUIRED_ACTIONS = frozenset({"stop", "review", "split_scope", "request_go"})
+
+GUARDRAILS: tuple[str, ...] = (
+    "Scope Drift Detection is signal, not authorization.",
+    "No auto-fix. No auto-write.",
+    "No Live-Readiness-Go.",
+    "No Echtgeld-Go.",
+    "Human-GO required for any write after blocking scope drift.",
+)
+
+# Surface types that indicate runtime/service scope
+_RUNTIME_SURFACE_TYPES = frozenset({"runtime", "service"})
+
+# Surface types that indicate trading scope
+_TRADING_SURFACE_TYPES = frozenset({"trading"})
+
+# Path prefixes that indicate trading scope (in addition to surface_type check)
+_TRADING_PATH_PREFIXES = (
+    "services/risk/",
+    "services/execution/",
+)
+
+# Known parked/dangerous path patterns that must not be activated outside explicit GO
+_PARKED_PATH_PATTERNS = (
+    "services/risk/",
+    "services/execution/",
+    "governance/DELIVERY_APPROVED",
+    "core/safety/",
+    "infrastructure/database/",
+    "infrastructure/compose/",
+)
+
+# Operation modes that imply write intent → require human_go_token
+_WRITE_LIKE_MODES = frozenset({"write", "plan_write", "commit", "push", "create_pr"})
+
+# Default max artifact count before unexpected_dependency_expansion triggers
+_DEFAULT_MAX_ARTIFACT_COUNT = 20
+
+# Write-intent keywords in generated_findings content
+_WRITE_INTENT_KEYWORDS = (
+    "write ",
+    "create file",
+    "modify file",
+    "delete file",
+    "push to",
+    "commit ",
+    "open pr",
+    "create pr",
+    "git push",
+    "git commit",
+)
+
+
+class ScopeDriftFirewallError(ValueError):
+    """Raised when scope drift firewall inputs are invalid or unsafe."""
+
+
+# ── Data Models ───────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ScopeDriftFinding:
+    """A single detected scope drift finding.
+
+    Output contract — all fields guaranteed to be present:
+        drift_id                deterministic, stable identifier (SHA256 prefix)
+        drift_type              one of DRIFT_TYPES
+        severity                info | warning | blocking
+        allowed_scope           human-readable description of what was allowed
+        observed_scope          human-readable description of what was observed
+        affected_artifacts      tuple of affected artifact paths/IDs
+        required_action         stop | review | split_scope | request_go
+        human_go_required       bool — true iff severity=blocking
+        stop_conditions         tuple of stop conditions (non-empty for blocking)
+        recommended_next_reads  tuple of suggested files/docs to review
+        detected_by             str — service/version that detected this
+        detected_at             ISO-8601 UTC string — via cdb_utcnow (not wall-clock)
+        status                  one of STATUS_VALUES
+    """
+
+    drift_id: str
+    drift_type: str
+    severity: str
+    allowed_scope: str
+    observed_scope: str
+    affected_artifacts: tuple[str, ...]
+    required_action: str
+    human_go_required: bool
+    stop_conditions: tuple[str, ...]
+    recommended_next_reads: tuple[str, ...]
+    detected_by: str
+    detected_at: str
+    status: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "drift_id": self.drift_id,
+            "drift_type": self.drift_type,
+            "severity": self.severity,
+            "allowed_scope": self.allowed_scope,
+            "observed_scope": self.observed_scope,
+            "affected_artifacts": list(self.affected_artifacts),
+            "required_action": self.required_action,
+            "human_go_required": self.human_go_required,
+            "stop_conditions": list(self.stop_conditions),
+            "recommended_next_reads": list(self.recommended_next_reads),
+            "detected_by": self.detected_by,
+            "detected_at": self.detected_at,
+            "status": self.status,
+        }
+
+
+@dataclass(frozen=True)
+class ScopeDriftScanResult:
+    """Result of a full scope drift firewall scan run."""
+
+    tool: str
+    schema_version: str
+    status: str
+    scanned_at: str
+    blocking_count: int
+    findings: tuple[ScopeDriftFinding, ...]
+    guardrails: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        severity_summary: dict[str, int] = {level: 0 for level in SEVERITY_LEVELS}
+        for f in self.findings:
+            if f.severity in severity_summary:
+                severity_summary[f.severity] += 1
+
+        return {
+            "tool": self.tool,
+            "schema_version": self.schema_version,
+            "status": self.status,
+            "scanned_at": self.scanned_at,
+            "total_count": len(self.findings),
+            "blocking_count": self.blocking_count,
+            "severity_summary": severity_summary,
+            "findings": [f.to_dict() for f in self.findings],
+            "guardrails": list(self.guardrails),
+        }
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_drift_id(drift_type: str, observed_scope: str, affected: str) -> str:
+    """Generate a deterministic, stable drift finding ID.
+
+    Uses SHA256 of the canonical string (drift_type|observed_scope|affected).
+    No random UUID generation — guardrails-compliant.
+    """
+    raw = f"{drift_type}|{observed_scope}|{affected}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _as_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        return text if text else None
+    return str(value).strip() or None
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
+def _make_finding(
+    *,
+    drift_type: str,
+    severity: str,
+    allowed_scope: str,
+    observed_scope: str,
+    affected_artifacts: Sequence[str] = (),
+    required_action: str,
+    stop_conditions: Sequence[str] = (),
+    recommended_next_reads: Sequence[str] = (),
+    detected_at: str,
+    status: str = "open",
+) -> ScopeDriftFinding:
+    affected_str = "; ".join(affected_artifacts) if affected_artifacts else observed_scope
+    did = _make_drift_id(drift_type, observed_scope, affected_str)
+    human_go_required = severity == "blocking"
+    _default_reads = ("AGENTS.md", "docs/runbooks/CONTROL_REGISTER.md")
+    merged_reads: list[str] = list(recommended_next_reads)
+    for r in _default_reads:
+        if r not in merged_reads:
+            merged_reads.append(r)
+    return ScopeDriftFinding(
+        drift_id=did,
+        drift_type=drift_type,
+        severity=severity,
+        allowed_scope=allowed_scope,
+        observed_scope=observed_scope,
+        affected_artifacts=tuple(affected_artifacts),
+        required_action=required_action,
+        human_go_required=human_go_required,
+        stop_conditions=tuple(stop_conditions),
+        recommended_next_reads=tuple(merged_reads),
+        detected_by=DETECTED_BY,
+        detected_at=detected_at,
+        status=status,
+    )
+
+
+def _path_is_within_scope(path: str, target_paths: list[str]) -> bool:
+    """Return True if path starts with any of the declared target_paths."""
+    if not target_paths:
+        return True  # no constraint declared → not a violation
+    for prefix in target_paths:
+        if path == prefix or path.startswith(prefix.rstrip("/") + "/") or path.startswith(prefix):
+            return True
+    return False
+
+
+# ── Detection Rules ───────────────────────────────────────────────────────────
+
+
+def _rule_path_out_of_scope(
+    bundle: Mapping[str, Any],
+    detected_at: str,
+) -> list[ScopeDriftFinding]:
+    """Rule: touched artifact path is outside declared_scope.target_paths.
+
+    Input contract:
+        declared_scope.target_paths: list[str]  — allowed path prefixes
+        touched_artifacts[].path: str
+    """
+    findings: list[ScopeDriftFinding] = []
+    declared_scope = bundle.get("declared_scope") or {}
+    target_paths = _as_list(declared_scope.get("target_paths"))
+    touched = _as_list(bundle.get("touched_artifacts"))
+
+    if not target_paths:
+        return findings  # no path constraint declared — not a violation
+
+    for artifact in touched:
+        if not artifact:
+            continue
+        path = _as_str(artifact.get("path"))
+        if not path:
+            continue
+        if not _path_is_within_scope(path, target_paths):
+            allowed_scope_str = ", ".join(target_paths)
+            findings.append(
+                _make_finding(
+                    drift_type="path_out_of_scope",
+                    severity="blocking",
+                    allowed_scope=f"Paths under: {allowed_scope_str}",
+                    observed_scope=path,
+                    affected_artifacts=[path],
+                    required_action="stop",
+                    stop_conditions=[
+                        f"Path '{path}' is outside declared scope. Do not proceed until scope is clarified.",
+                        "No writes outside declared target_paths without explicit Human-GO.",
+                    ],
+                    recommended_next_reads=[
+                        "knowledge/governance/CDB_AGENT_POLICY.md",
+                    ],
+                    detected_at=detected_at,
+                )
+            )
+    return findings
+
+
+def _rule_domain_out_of_scope(
+    bundle: Mapping[str, Any],
+    detected_at: str,
+) -> list[ScopeDriftFinding]:
+    """Rule: artifact surface_type is not in declared_scope.allowed_domains.
+
+    Only fires when declared_scope.allowed_domains is explicitly provided.
+
+    Input contract:
+        declared_scope.allowed_domains: list[str]  — optional allowed surface types
+        touched_artifacts[].surface_type: str
+    """
+    findings: list[ScopeDriftFinding] = []
+    declared_scope = bundle.get("declared_scope") or {}
+    allowed_domains = _as_list(declared_scope.get("allowed_domains"))
+    touched = _as_list(bundle.get("touched_artifacts"))
+
+    if not allowed_domains:
+        return findings  # no domain constraint declared — not a violation
+
+    allowed_set = frozenset(d.lower() for d in allowed_domains if d)
+
+    for artifact in touched:
+        if not artifact:
+            continue
+        surface_type = _as_str(artifact.get("surface_type"))
+        if not surface_type:
+            continue
+        if surface_type.lower() not in allowed_set:
+            path = _as_str(artifact.get("path")) or "(unknown path)"
+            findings.append(
+                _make_finding(
+                    drift_type="domain_out_of_scope",
+                    severity="warning",
+                    allowed_scope=f"Domains: {', '.join(allowed_domains)}",
+                    observed_scope=f"surface_type='{surface_type}' for path='{path}'",
+                    affected_artifacts=[path],
+                    required_action="review",
+                    stop_conditions=[],
+                    recommended_next_reads=[
+                        "knowledge/governance/CDB_AGENT_POLICY.md",
+                    ],
+                    detected_at=detected_at,
+                )
+            )
+    return findings
+
+
+def _rule_issue_out_of_scope(
+    bundle: Mapping[str, Any],
+    detected_at: str,
+) -> list[ScopeDriftFinding]:
+    """Rule: issue_refs contains an issue not related to target_issue or allowed_issues.
+
+    Input contract:
+        declared_scope.target_issue: str  — primary issue (e.g. "2163")
+        declared_scope.allowed_issues: list[str]  — optional additional allowed issues
+        issue_refs[].issue_id: str
+        issue_refs[].state: str
+        issue_refs[].label: str  — optional
+    """
+    findings: list[ScopeDriftFinding] = []
+    declared_scope = bundle.get("declared_scope") or {}
+    target_issue = _as_str(declared_scope.get("target_issue"))
+    allowed_issues_raw = _as_list(declared_scope.get("allowed_issues"))
+    issue_refs = _as_list(bundle.get("issue_refs"))
+
+    if not target_issue:
+        return findings  # no target issue declared — not a violation
+
+    allowed_set: set[str] = {target_issue}
+    for iss in allowed_issues_raw:
+        s = _as_str(iss)
+        if s:
+            allowed_set.add(s)
+
+    for ref in issue_refs:
+        if not ref:
+            continue
+        issue_id = _as_str(ref.get("issue_id"))
+        if not issue_id:
+            continue
+        if issue_id not in allowed_set:
+            findings.append(
+                _make_finding(
+                    drift_type="issue_out_of_scope",
+                    severity="warning",
+                    allowed_scope=f"Issues: {', '.join(sorted(allowed_set))}",
+                    observed_scope=f"issue #{issue_id}",
+                    affected_artifacts=[f"issue#{issue_id}"],
+                    required_action="review",
+                    stop_conditions=[],
+                    recommended_next_reads=[
+                        "knowledge/governance/CDB_AGENT_POLICY.md",
+                    ],
+                    detected_at=detected_at,
+                )
+            )
+    return findings
+
+
+def _rule_parked_topic_activated(
+    bundle: Mapping[str, Any],
+    detected_at: str,
+) -> list[ScopeDriftFinding]:
+    """Rule: a touched artifact path matches a known parked/dangerous surface.
+
+    Checks against both the hardcoded _PARKED_PATH_PATTERNS and the
+    bundle's forbidden_surfaces list.
+
+    Input contract:
+        touched_artifacts[].path: str
+        forbidden_surfaces[].surface: str
+        forbidden_surfaces[].reason: str
+    """
+    findings: list[ScopeDriftFinding] = []
+    touched = _as_list(bundle.get("touched_artifacts"))
+    forbidden_surfaces = _as_list(bundle.get("forbidden_surfaces"))
+
+    # Build set of forbidden surface prefixes from bundle
+    bundle_forbidden: list[tuple[str, str]] = []
+    for fs in forbidden_surfaces:
+        if not fs:
+            continue
+        surface = _as_str(fs.get("surface"))
+        reason = _as_str(fs.get("reason")) or "declared forbidden surface"
+        if surface:
+            bundle_forbidden.append((surface, reason))
+
+    for artifact in touched:
+        if not artifact:
+            continue
+        path = _as_str(artifact.get("path"))
+        if not path:
+            continue
+
+        # Check hardcoded parked patterns
+        for pattern in _PARKED_PATH_PATTERNS:
+            if path == pattern or path.startswith(pattern):
+                findings.append(
+                    _make_finding(
+                        drift_type="parked_topic_activated",
+                        severity="blocking",
+                        allowed_scope="Paths outside known-parked surfaces",
+                        observed_scope=f"path='{path}' matches parked pattern '{pattern}'",
+                        affected_artifacts=[path],
+                        required_action="stop",
+                        stop_conditions=[
+                            f"Path '{path}' activates a known-parked surface ('{pattern}'). "
+                            "Human-GO required before proceeding.",
+                        ],
+                        recommended_next_reads=[
+                            "knowledge/governance/CDB_AGENT_POLICY.md",
+                            "knowledge/governance/SYSTEM_INVARIANTS.md",
+                        ],
+                        detected_at=detected_at,
+                    )
+                )
+                break  # one finding per artifact
+
+        # Check bundle-declared forbidden surfaces
+        for surface, reason in bundle_forbidden:
+            if path == surface or path.startswith(surface.rstrip("/") + "/") or path.startswith(surface):
+                # Avoid duplicate if already flagged by hardcoded pattern
+                already = any(
+                    f.drift_type == "parked_topic_activated"
+                    and path in f.affected_artifacts
+                    for f in findings
+                )
+                if not already:
+                    findings.append(
+                        _make_finding(
+                            drift_type="parked_topic_activated",
+                            severity="blocking",
+                            allowed_scope="Paths outside declared forbidden surfaces",
+                            observed_scope=f"path='{path}' matches forbidden surface '{surface}'",
+                            affected_artifacts=[path],
+                            required_action="stop",
+                            stop_conditions=[
+                                f"Path '{path}' activates declared forbidden surface: {reason}. "
+                                "Human-GO required before proceeding.",
+                            ],
+                            recommended_next_reads=[
+                                "knowledge/governance/CDB_AGENT_POLICY.md",
+                            ],
+                            detected_at=detected_at,
+                        )
+                    )
+                break
+
+    return findings
+
+
+def _rule_runtime_surface_touched(
+    bundle: Mapping[str, Any],
+    detected_at: str,
+) -> list[ScopeDriftFinding]:
+    """Rule: a touched artifact has surface_type == 'runtime' or 'service'.
+
+    Input contract:
+        touched_artifacts[].path: str
+        touched_artifacts[].surface_type: str
+    """
+    findings: list[ScopeDriftFinding] = []
+    touched = _as_list(bundle.get("touched_artifacts"))
+
+    for artifact in touched:
+        if not artifact:
+            continue
+        surface_type = _as_str(artifact.get("surface_type"))
+        if not surface_type:
+            continue
+        if surface_type.lower() in _RUNTIME_SURFACE_TYPES:
+            path = _as_str(artifact.get("path")) or "(unknown path)"
+            findings.append(
+                _make_finding(
+                    drift_type="runtime_surface_touched",
+                    severity="blocking",
+                    allowed_scope="Non-runtime, non-service surfaces",
+                    observed_scope=f"surface_type='{surface_type}' for path='{path}'",
+                    affected_artifacts=[path],
+                    required_action="stop",
+                    stop_conditions=[
+                        f"Runtime surface '{surface_type}' was touched at path '{path}'. "
+                        "Runtime surfaces require explicit Human-GO.",
+                        "No changes to runtime or service surfaces without written authorization.",
+                    ],
+                    recommended_next_reads=[
+                        "knowledge/governance/SYSTEM_INVARIANTS.md",
+                        "knowledge/governance/CDB_AGENT_POLICY.md",
+                    ],
+                    detected_at=detected_at,
+                )
+            )
+    return findings
+
+
+def _rule_trading_surface_touched(
+    bundle: Mapping[str, Any],
+    detected_at: str,
+) -> list[ScopeDriftFinding]:
+    """Rule: a touched artifact is on the trading surface.
+
+    Triggers on surface_type == 'trading' OR path starting with
+    services/risk/ or services/execution/.
+
+    Input contract:
+        touched_artifacts[].path: str
+        touched_artifacts[].surface_type: str
+    """
+    findings: list[ScopeDriftFinding] = []
+    touched = _as_list(bundle.get("touched_artifacts"))
+
+    for artifact in touched:
+        if not artifact:
+            continue
+        surface_type = _as_str(artifact.get("surface_type")) or ""
+        path = _as_str(artifact.get("path")) or ""
+
+        is_trading_surface = surface_type.lower() in _TRADING_SURFACE_TYPES
+        is_trading_path = any(path.startswith(p) for p in _TRADING_PATH_PREFIXES)
+
+        if is_trading_surface or is_trading_path:
+            artifact_ref = path or surface_type or "(unknown)"
+            findings.append(
+                _make_finding(
+                    drift_type="trading_surface_touched",
+                    severity="blocking",
+                    allowed_scope="Non-trading surfaces and paths",
+                    observed_scope=(
+                        f"surface_type='{surface_type}', path='{path}'"
+                        if path
+                        else f"surface_type='{surface_type}'"
+                    ),
+                    affected_artifacts=[artifact_ref],
+                    required_action="stop",
+                    stop_conditions=[
+                        "Trading surface touched. LR status is NO-GO. "
+                        "No changes to trading surfaces (risk, execution) without Human-GO.",
+                        "Board stage 'trade-capable' is NOT a live-go.",
+                    ],
+                    recommended_next_reads=[
+                        "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                        "knowledge/governance/SYSTEM_INVARIANTS.md",
+                        "knowledge/governance/CDB_AGENT_POLICY.md",
+                    ],
+                    detected_at=detected_at,
+                )
+            )
+    return findings
+
+
+def _rule_unexpected_dependency_expansion(
+    bundle: Mapping[str, Any],
+    detected_at: str,
+) -> list[ScopeDriftFinding]:
+    """Rule: touched_artifacts count significantly exceeds declared scope.
+
+    Fires when:
+        len(touched_artifacts) > declared_scope.max_artifact_count
+    or
+        len(touched_artifacts) > _DEFAULT_MAX_ARTIFACT_COUNT (when max not declared)
+        AND target_paths is declared (i.e., there is an explicit scope)
+
+    Input contract:
+        declared_scope.max_artifact_count: int  — optional
+        declared_scope.target_paths: list[str]  — optional
+        touched_artifacts: list[dict]
+    """
+    findings: list[ScopeDriftFinding] = []
+    declared_scope = bundle.get("declared_scope") or {}
+    touched = _as_list(bundle.get("touched_artifacts"))
+    target_paths = _as_list(declared_scope.get("target_paths"))
+
+    raw_max = declared_scope.get("max_artifact_count")
+    try:
+        max_count = int(raw_max) if raw_max is not None else None
+    except (TypeError, ValueError):
+        max_count = None
+
+    effective_max: int | None = None
+    if max_count is not None:
+        effective_max = max_count
+    elif target_paths:
+        # Use default threshold only when explicit path scope is declared
+        effective_max = _DEFAULT_MAX_ARTIFACT_COUNT
+
+    if effective_max is None:
+        return findings  # no constraint basis
+
+    artifact_count = len([a for a in touched if a])
+    if artifact_count > effective_max:
+        paths = [
+            _as_str(a.get("path")) or "(no-path)"
+            for a in touched
+            if a
+        ]
+        findings.append(
+            _make_finding(
+                drift_type="unexpected_dependency_expansion",
+                severity="warning",
+                allowed_scope=f"At most {effective_max} artifacts",
+                observed_scope=f"{artifact_count} artifacts touched",
+                affected_artifacts=paths[:10],  # cap to keep output manageable
+                required_action="split_scope",
+                stop_conditions=[],
+                recommended_next_reads=[
+                    "knowledge/governance/CDB_AGENT_POLICY.md",
+                ],
+                detected_at=detected_at,
+            )
+        )
+    return findings
+
+
+def _rule_unauthorized_write_intent(
+    bundle: Mapping[str, Any],
+    detected_at: str,
+) -> list[ScopeDriftFinding]:
+    """Rule: generated_findings contains write-intent without human_go_token.
+
+    Triggers when:
+        generated_findings[].write_intent == True AND human_go_token is falsy
+    or
+        generated_findings[].content contains write-intent keywords AND human_go_token is falsy
+
+    Input contract:
+        generated_findings[].type: str
+        generated_findings[].content: str
+        generated_findings[].source: str
+        generated_findings[].write_intent: bool  — optional, explicit flag
+        generated_findings[].human_go_token: str | None  — present when GO was given
+    """
+    findings: list[ScopeDriftFinding] = []
+    generated = _as_list(bundle.get("generated_findings"))
+
+    for item in generated:
+        if not item:
+            continue
+        write_intent_flag = item.get("write_intent", False)
+        human_go_token = _as_str(item.get("human_go_token"))
+        content = (_as_str(item.get("content")) or "").lower()
+        source = _as_str(item.get("source")) or "unknown"
+        finding_type = _as_str(item.get("type")) or "unknown"
+
+        has_keyword = any(kw in content for kw in _WRITE_INTENT_KEYWORDS)
+        is_write_intent = bool(write_intent_flag) or has_keyword
+        has_go = bool(human_go_token)
+
+        if is_write_intent and not has_go:
+            snippet = content[:80] if content else "(no content)"
+            findings.append(
+                _make_finding(
+                    drift_type="unauthorized_write_intent",
+                    severity="blocking",
+                    allowed_scope="Write intent only when human_go_token is present",
+                    observed_scope=(
+                        f"type='{finding_type}', source='{source}', content='{snippet}...'"
+                    ),
+                    affected_artifacts=[f"finding:{finding_type}:{source}"],
+                    required_action="stop",
+                    stop_conditions=[
+                        "Write intent detected without Human-GO token. Stop immediately.",
+                        "No writes, commits, or pushes without explicit Human-GO.",
+                    ],
+                    recommended_next_reads=[
+                        "knowledge/governance/CDB_AGENT_POLICY.md",
+                        "knowledge/governance/CDB_CONSTITUTION.md",
+                    ],
+                    detected_at=detected_at,
+                )
+            )
+    return findings
+
+
+def _rule_missing_human_go(
+    bundle: Mapping[str, Any],
+    detected_at: str,
+) -> list[ScopeDriftFinding]:
+    """Rule: operation_mode is write-like but no human_go_token present in bundle.
+
+    Input contract:
+        meta.operation_mode: str  — optional; one of _WRITE_LIKE_MODES → requires GO
+        meta.human_go_token: str | None  — explicit GO token
+    """
+    findings: list[ScopeDriftFinding] = []
+    meta = bundle.get("meta") or {}
+    operation_mode = _as_str(meta.get("operation_mode")) or ""
+    human_go_token = _as_str(meta.get("human_go_token"))
+
+    if operation_mode.lower() not in _WRITE_LIKE_MODES:
+        return findings
+
+    if bool(human_go_token):
+        return findings
+
+    findings.append(
+        _make_finding(
+            drift_type="missing_human_go",
+            severity="blocking",
+            allowed_scope=f"Write-like operations ({', '.join(sorted(_WRITE_LIKE_MODES))}) only with human_go_token",
+            observed_scope=f"operation_mode='{operation_mode}', human_go_token=None",
+            affected_artifacts=[f"operation:{operation_mode}"],
+            required_action="request_go",
+            stop_conditions=[
+                f"Operation mode '{operation_mode}' requires explicit Human-GO. "
+                "Set meta.human_go_token before proceeding.",
+            ],
+            recommended_next_reads=[
+                "knowledge/governance/CDB_AGENT_POLICY.md",
+                "knowledge/governance/CDB_CONSTITUTION.md",
+            ],
+            detected_at=detected_at,
+        )
+    )
+    return findings
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def scan_scope_drift_v1(
+    bundle: Mapping[str, Any],
+    as_of: str | None = None,
+) -> ScopeDriftScanResult:
+    """Run all scope drift detection rules on the provided input bundle.
+
+    This is the primary public entry point. Read-only. No writes. No network.
+    No DB access. No GitHub calls. No auto-fix. No auto-repair.
+
+    Args:
+        bundle:  Dict of input records describing declared scope, touched
+                 artifacts, issue refs, generated findings, and forbidden
+                 surfaces. Unknown keys are ignored.
+        as_of:   Optional ISO-8601 UTC string representing the reference time.
+                 Defaults to cdb_utcnow().isoformat().
+
+    Returns:
+        ScopeDriftScanResult with all findings, blocking_count, severity_summary,
+        guardrails, and metadata.
+
+    Guardrails:
+        - No write operations anywhere in this call chain.
+        - All timestamps via cdb_utcnow (clock-injected, not wall-clock).
+        - No random UUID generation — IDs are SHA256-based and deterministic.
+        - Blocking findings are surfaced but grant no action authority.
+        - LR status remains NO-GO for live trading.
+        - Scope Drift Detection is signal, not authorization.
+        - Human-GO required for any write after blocking scope drift.
+    """
+    if not isinstance(bundle, Mapping):
+        raise ScopeDriftFirewallError(
+            f"bundle must be a Mapping, got {type(bundle).__name__}"
+        )
+
+    resolved_as_of: str = as_of if as_of is not None else cdb_utcnow().isoformat()
+    detected_at = resolved_as_of
+
+    all_findings: list[ScopeDriftFinding] = []
+
+    all_findings.extend(_rule_path_out_of_scope(bundle, detected_at))
+    all_findings.extend(_rule_domain_out_of_scope(bundle, detected_at))
+    all_findings.extend(_rule_issue_out_of_scope(bundle, detected_at))
+    all_findings.extend(_rule_parked_topic_activated(bundle, detected_at))
+    all_findings.extend(_rule_runtime_surface_touched(bundle, detected_at))
+    all_findings.extend(_rule_trading_surface_touched(bundle, detected_at))
+    all_findings.extend(_rule_unexpected_dependency_expansion(bundle, detected_at))
+    all_findings.extend(_rule_unauthorized_write_intent(bundle, detected_at))
+    all_findings.extend(_rule_missing_human_go(bundle, detected_at))
+
+    blocking_count = sum(1 for f in all_findings if f.human_go_required)
+    overall_status = "blocked_scope_drift" if blocking_count > 0 else "ok"
+
+    return ScopeDriftScanResult(
+        tool=TOOL_NAME,
+        schema_version=SCHEMA_VERSION,
+        status=overall_status,
+        scanned_at=resolved_as_of,
+        blocking_count=blocking_count,
+        findings=tuple(all_findings),
+        guardrails=GUARDRAILS,
+    )

--- a/tools/surrealdb/scope_drift_firewall.py
+++ b/tools/surrealdb/scope_drift_firewall.py
@@ -278,11 +278,16 @@ def _make_finding(
 
 
 def _path_is_within_scope(path: str, target_paths: list[str]) -> bool:
-    """Return True if path starts with any of the declared target_paths."""
+    """Return True if path starts with any of the declared target_paths.
+
+    Requires a directory-boundary match to avoid sibling-prefix false negatives:
+    e.g. 'tools/surrealdb_extra/f.py' must NOT match target 'tools/surrealdb'.
+    """
     if not target_paths:
         return True  # no constraint declared → not a violation
     for prefix in target_paths:
-        if path == prefix or path.startswith(prefix.rstrip("/") + "/") or path.startswith(prefix):
+        norm = prefix.rstrip("/")
+        if path == norm or path.startswith(norm + "/"):
             return True
     return False
 
@@ -766,7 +771,10 @@ def _rule_missing_human_go(
     operation_mode = _as_str(meta.get("operation_mode")) or ""
     human_go_token = _as_str(meta.get("human_go_token"))
 
-    if operation_mode.lower() not in _WRITE_LIKE_MODES:
+    _mode = operation_mode.lower()
+    if _mode not in _WRITE_LIKE_MODES and not any(
+        _mode.startswith(w) for w in _WRITE_LIKE_MODES
+    ):
         return findings
 
     if bool(human_go_token):


### PR DESCRIPTION
## Summary
Implements Wave 17-A / #2163 Scope Drift Firewall Service v1.

## Scope
- Adds pure Python, side-effect-free scope drift firewall service.
- Adds deterministic unit coverage.
- Adds sample bundle fixture.

## Files
- `tools/surrealdb/scope_drift_firewall.py`
- `tests/unit/surrealdb/test_scope_drift_firewall.py`
- `tests/fixtures/surrealdb/scope_drift/sample_bundle.json`

## Safety
- No DB access.
- No network access.
- No writes.
- No CLI.
- No MCP wiring.
- No runbook.
- No gates.
- No runtime changes.
- No Live-Readiness / Echtgeld scope.

## Validation
- `python -m pytest -v -m unit tests/unit/surrealdb/test_scope_drift_firewall.py`
- `ruff check tools/surrealdb/scope_drift_firewall.py tests/unit/surrealdb/test_scope_drift_firewall.py`

Closes #2163.