### PR TITLE
feat(mcp): add scope drift tool

### DIFF
--- a/tests/unit/tools/mcp/test_scope_drift_tools.py
+++ b/tests/unit/tools/mcp/test_scope_drift_tools.py
@@ -1,0 +1,509 @@
+"""Unit tests for Wave-17-C MCP tool: cdb_context_scope_drift.
+
+Issues:
+    #2165 — [SURREALDB][CONTEXT][SCOPE-MCP] Implement scope drift MCP tool
+    Parent: #2162 (Wave-17 anchor)
+    Epic: #1976
+
+Scope:
+    Unit tests for tools/mcp/scope_drift_tools.py and its integration
+    with the MCP registry, context bridge, and permission guard.
+    All fixtures are inline — no file loading.
+    No DB access. No SurrealDB SDK. No network. No writes.
+    No real datetime.now() — as_of is passed explicitly for determinism.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tools.mcp.context_bridge import ContextBridge
+from tools.mcp.permission_guard import INPUT_SCAN_EXEMPT_TOOLS
+from tools.mcp.registry import ContextToolRegistry
+from tools.mcp.scope_drift_tools import (
+    SCHEMA_VERSION,
+    TOOL_CDB_CONTEXT_SCOPE_DRIFT,
+    handle_cdb_context_scope_drift,
+)
+from tools.surrealdb.scope_drift_firewall import DRIFT_TYPES, GUARDRAILS
+
+# ── Fixed reference timestamps for determinism ────────────────────────────────
+
+_AS_OF = "2026-05-06T12:00:00+00:00"
+
+
+# ── Inline bundle fixtures ────────────────────────────────────────────────────
+
+
+def _bundle_clean() -> dict[str, Any]:
+    """Empty bundle — no touched artifacts, no issues — produces zero findings."""
+    return {}
+
+
+def _bundle_path_out_of_scope() -> dict[str, Any]:
+    """Bundle with an out-of-scope path → path_out_of_scope (blocking)."""
+    return {
+        "declared_scope": {
+            "target_paths": ["tools/mcp/"],
+        },
+        "touched_artifacts": [
+            {"path": "services/risk/some_file.py"},
+        ],
+    }
+
+
+def _bundle_domain_out_of_scope() -> dict[str, Any]:
+    """Bundle with a mismatched domain → domain_out_of_scope (warning)."""
+    return {
+        "declared_scope": {
+            "allowed_domains": ["docs"],
+        },
+        "touched_artifacts": [
+            {"path": "services/risk/some_file.py", "surface_type": "runtime"},
+        ],
+    }
+
+
+def _bundle_issue_out_of_scope() -> dict[str, Any]:
+    """Bundle with an out-of-scope issue ref → issue_out_of_scope (warning)."""
+    return {
+        "declared_scope": {
+            "target_issue": "2165",
+        },
+        "issue_refs": [
+            {"issue_id": "9999"},
+        ],
+    }
+
+
+def _bundle_multi() -> dict[str, Any]:
+    """Bundle triggering multiple findings of different types and severities."""
+    return {
+        "declared_scope": {
+            "target_paths": ["tools/mcp/"],
+            "allowed_domains": ["docs"],
+            "target_issue": "2165",
+        },
+        "touched_artifacts": [
+            # path_out_of_scope (blocking) + runtime_surface_touched (blocking)
+            {"path": "services/risk/some_file.py", "surface_type": "runtime"},
+            # domain_out_of_scope (warning) for a docs-declared scope
+            {"path": "tools/mcp/widget.py", "surface_type": "service"},
+        ],
+        "issue_refs": [
+            {"issue_id": "9999"},  # issue_out_of_scope (warning)
+        ],
+    }
+
+
+def _bundle_with_write_intent() -> dict[str, Any]:
+    """Bundle whose generated_findings contain write-intent keyword without GO token.
+
+    This exercises the unauthorized_write_intent rule (blocking).
+    """
+    return {
+        "generated_findings": [
+            {
+                "type": "suggestion",
+                "content": "git push origin main",
+                "source": "agent",
+                "write_intent": True,
+                "human_go_token": None,
+            }
+        ]
+    }
+
+
+def _request(bundle: dict[str, Any], **extra: Any) -> dict[str, Any]:
+    """Build a minimal MCP request for cdb_context_scope_drift."""
+    params: dict[str, Any] = {"bundle": bundle, "as_of": _AS_OF}
+    params.update(extra)
+    return {
+        "tool": TOOL_CDB_CONTEXT_SCOPE_DRIFT,
+        "parameters": params,
+    }
+
+
+# ── 1. Registry ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_tool_in_registry_is_read_only() -> None:
+    """Tool must be registered and read_only=True."""
+    tool = ContextToolRegistry.get_tool(TOOL_CDB_CONTEXT_SCOPE_DRIFT)
+    assert tool is not None, f"{TOOL_CDB_CONTEXT_SCOPE_DRIFT} not found in registry"
+    assert tool.read_only is True
+    assert tool.name == TOOL_CDB_CONTEXT_SCOPE_DRIFT
+
+
+@pytest.mark.unit
+def test_tool_in_registry_tool_names() -> None:
+    """Tool name appears in registry tool list."""
+    names = ContextToolRegistry.list_tool_names()
+    assert TOOL_CDB_CONTEXT_SCOPE_DRIFT in names
+
+
+# ── 2. Bridge ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_tool_executable_via_bridge() -> None:
+    """Tool can be executed via ContextBridge.execute_tool and returns status ok."""
+    bridge = ContextBridge()
+    result = bridge.execute_tool(TOOL_CDB_CONTEXT_SCOPE_DRIFT, {"bundle": {}, "as_of": _AS_OF})
+    assert isinstance(result, dict)
+    assert result.get("status") == "ok", f"expected ok, got: {result}"
+    assert result.get("tool") == TOOL_CDB_CONTEXT_SCOPE_DRIFT
+
+
+# ── 3. Permission guard ───────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_tool_in_permission_guard_exempt() -> None:
+    """Tool must be in INPUT_SCAN_EXEMPT_TOOLS (bundle content contains write-intent keywords)."""
+    assert TOOL_CDB_CONTEXT_SCOPE_DRIFT in INPUT_SCAN_EXEMPT_TOOLS
+
+
+# ── 4. Clean bundle → ok result ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_clean_bundle_returns_ok() -> None:
+    """Empty bundle produces a valid ok response with zero findings."""
+    result = handle_cdb_context_scope_drift(_request(_bundle_clean()))
+    assert result["status"] == "ok"
+    assert result["tool"] == TOOL_CDB_CONTEXT_SCOPE_DRIFT
+    assert result["schema_version"] == SCHEMA_VERSION
+    assert result["summary"]["total_count"] == 0
+    assert result["summary"]["blocking_count"] == 0
+    assert result["findings"] == []
+    assert isinstance(result["guardrails"], list)
+    assert len(result["guardrails"]) > 0
+
+
+# ── 5. Blocking bundle → blocking findings ────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_blocking_bundle_returns_blocking_findings() -> None:
+    """Bundle with out-of-scope path produces a blocking finding."""
+    result = handle_cdb_context_scope_drift(_request(_bundle_path_out_of_scope()))
+    assert result["status"] == "ok"
+    assert result["summary"]["blocking_count"] > 0
+    assert any(f["severity"] == "blocking" for f in result["findings"])
+    assert any(f["human_go_required"] is True for f in result["findings"])
+
+
+# ── 6. severity filter ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_severity_filter_blocking_only() -> None:
+    """severity=blocking returns only blocking findings."""
+    result = handle_cdb_context_scope_drift(
+        _request(_bundle_multi(), severity="blocking")
+    )
+    assert result["status"] == "ok"
+    for f in result["findings"]:
+        assert f["severity"] == "blocking", f"unexpected severity in finding: {f}"
+
+
+@pytest.mark.unit
+def test_severity_filter_warning_only() -> None:
+    """severity=warning returns only warning findings."""
+    result = handle_cdb_context_scope_drift(
+        _request(_bundle_multi(), severity="warning")
+    )
+    assert result["status"] == "ok"
+    for f in result["findings"]:
+        assert f["severity"] == "warning", f"unexpected severity in finding: {f}"
+
+
+@pytest.mark.unit
+def test_severity_filter_excludes_others() -> None:
+    """When severity=blocking, no warning or info findings are returned."""
+    result = handle_cdb_context_scope_drift(
+        _request(_bundle_multi(), severity="blocking")
+    )
+    assert not any(f["severity"] in ("warning", "info") for f in result["findings"])
+
+
+# ── 7. scope_type filter ──────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_scope_type_filter_path_out_of_scope() -> None:
+    """scope_type=path_out_of_scope returns only path_out_of_scope findings."""
+    result = handle_cdb_context_scope_drift(
+        _request(_bundle_multi(), scope_type="path_out_of_scope")
+    )
+    assert result["status"] == "ok"
+    for f in result["findings"]:
+        assert f["drift_type"] == "path_out_of_scope", f"unexpected drift_type: {f}"
+
+
+@pytest.mark.unit
+def test_scope_type_filter_issue_out_of_scope() -> None:
+    """scope_type=issue_out_of_scope filters to only those drift types."""
+    result = handle_cdb_context_scope_drift(
+        _request(_bundle_multi(), scope_type="issue_out_of_scope")
+    )
+    assert result["status"] == "ok"
+    for f in result["findings"]:
+        assert f["drift_type"] == "issue_out_of_scope"
+
+
+# ── 8. target_ref filter ──────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_target_ref_filter_match() -> None:
+    """target_ref filters to findings where affected_artifacts contains the ref."""
+    bundle = _bundle_path_out_of_scope()
+    result = handle_cdb_context_scope_drift(
+        _request(bundle, target_ref="services/risk/some_file.py")
+    )
+    assert result["status"] == "ok"
+    assert result["summary"]["total_count"] > 0
+    for f in result["findings"]:
+        assert "services/risk/some_file.py" in f["affected_artifacts"]
+
+
+@pytest.mark.unit
+def test_target_ref_filter_no_match() -> None:
+    """target_ref that matches nothing returns zero findings (not an error)."""
+    bundle = _bundle_path_out_of_scope()
+    result = handle_cdb_context_scope_drift(
+        _request(bundle, target_ref="totally/unrelated/path.py")
+    )
+    assert result["status"] == "ok"
+    assert result["summary"]["total_count"] == 0
+    assert result["findings"] == []
+
+
+# ── 9. blocking filter ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_blocking_true_filter() -> None:
+    """blocking=True returns only findings with human_go_required=True."""
+    result = handle_cdb_context_scope_drift(
+        _request(_bundle_multi(), blocking=True)
+    )
+    assert result["status"] == "ok"
+    for f in result["findings"]:
+        assert f["human_go_required"] is True, f"unexpected non-blocking finding: {f}"
+
+
+@pytest.mark.unit
+def test_blocking_false_filter() -> None:
+    """blocking=False returns only findings with human_go_required=False."""
+    result = handle_cdb_context_scope_drift(
+        _request(_bundle_multi(), blocking=False)
+    )
+    assert result["status"] == "ok"
+    for f in result["findings"]:
+        assert f["human_go_required"] is False, f"unexpected blocking finding: {f}"
+
+
+@pytest.mark.unit
+def test_blocking_true_filter_string_input() -> None:
+    """blocking='true' (string) is treated the same as blocking=True."""
+    result_bool = handle_cdb_context_scope_drift(
+        _request(_bundle_multi(), blocking=True)
+    )
+    result_str = handle_cdb_context_scope_drift(
+        _request(_bundle_multi(), blocking="true")
+    )
+    assert result_bool["summary"]["total_count"] == result_str["summary"]["total_count"]
+
+
+# ── 10. limit / truncation ────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_limit_truncates_findings() -> None:
+    """limit=1 returns at most 1 finding and sets truncated=True when more exist."""
+    result = handle_cdb_context_scope_drift(
+        _request(_bundle_multi(), limit=1)
+    )
+    assert result["status"] == "ok"
+    assert len(result["findings"]) <= 1
+    # multi bundle produces >1 finding; if so truncated must be True
+    if result["summary"]["total_count"] > 1:
+        assert result["summary"]["truncated"] is True
+
+
+@pytest.mark.unit
+def test_limit_no_truncation_when_few_findings() -> None:
+    """limit above total finding count → truncated=False."""
+    result = handle_cdb_context_scope_drift(
+        _request(_bundle_path_out_of_scope(), limit=500)
+    )
+    assert result["status"] == "ok"
+    assert result["summary"]["truncated"] is False
+
+
+@pytest.mark.unit
+def test_truncation_total_count_is_pre_limit() -> None:
+    """summary.total_count reflects pre-limit count even when truncated."""
+    result_unlimited = handle_cdb_context_scope_drift(
+        _request(_bundle_multi(), as_of=_AS_OF)
+    )
+    total = result_unlimited["summary"]["total_count"]
+
+    if total >= 2:
+        result_limited = handle_cdb_context_scope_drift(
+            _request(_bundle_multi(), limit=1)
+        )
+        assert result_limited["summary"]["total_count"] == total
+        assert len(result_limited["findings"]) == 1
+        assert result_limited["summary"]["truncated"] is True
+
+
+# ── 11. Error handling ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_missing_bundle_returns_error() -> None:
+    """Missing bundle produces a structured error response, not an exception."""
+    result = handle_cdb_context_scope_drift(
+        {"tool": TOOL_CDB_CONTEXT_SCOPE_DRIFT, "parameters": {}}
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "missing_bundle"
+    assert "bundle" in result["error"]["message"]
+
+
+@pytest.mark.unit
+def test_invalid_bundle_non_dict_returns_error() -> None:
+    """Non-dict bundle produces a structured error response, not an exception."""
+    result = handle_cdb_context_scope_drift(
+        {"tool": TOOL_CDB_CONTEXT_SCOPE_DRIFT, "parameters": {"bundle": "not-a-dict"}}
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "missing_bundle"
+
+
+@pytest.mark.unit
+def test_invalid_severity_returns_error() -> None:
+    """Unknown severity value returns a structured error response."""
+    result = handle_cdb_context_scope_drift(
+        _request(_bundle_clean(), severity="critical")
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "invalid_severity"
+
+
+@pytest.mark.unit
+def test_invalid_scope_type_returns_error() -> None:
+    """Unknown scope_type value returns a structured error response."""
+    result = handle_cdb_context_scope_drift(
+        _request(_bundle_clean(), scope_type="not_a_real_drift_type")
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "invalid_scope_type"
+
+
+@pytest.mark.unit
+def test_wrong_tool_name_returns_error() -> None:
+    """Mismatched tool name returns an invalid_tool error."""
+    result = handle_cdb_context_scope_drift(
+        {"tool": "some_other_tool", "parameters": {"bundle": {}}}
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "invalid_tool"
+
+
+# ── 12. Guardrails ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_guardrails_present_in_response() -> None:
+    """Guardrail strings are always present in a successful response."""
+    result = handle_cdb_context_scope_drift(_request(_bundle_clean()))
+    assert result["status"] == "ok"
+    assert "guardrails" in result
+    guardrails = result["guardrails"]
+    assert isinstance(guardrails, list)
+    assert len(guardrails) > 0
+    # All canonical guardrails from the service must be present
+    for g in GUARDRAILS:
+        assert g in guardrails, f"missing guardrail: {g!r}"
+
+
+# ── 13. Output contract / metadata ────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_response_metadata_read_only_true() -> None:
+    """metadata.read_only must be True in every successful response."""
+    result = handle_cdb_context_scope_drift(_request(_bundle_clean()))
+    assert result["status"] == "ok"
+    assert result["metadata"]["read_only"] is True
+    assert result["metadata"]["source"] == "in_memory"
+
+
+@pytest.mark.unit
+def test_response_includes_scan_status_and_scanned_at() -> None:
+    """scan_status and scanned_at must be present in a successful response."""
+    result = handle_cdb_context_scope_drift(_request(_bundle_clean()))
+    assert result["status"] == "ok"
+    assert "scan_status" in result
+    assert result["scan_status"] in ("ok", "blocked_scope_drift")
+    assert "scanned_at" in result
+    assert isinstance(result["scanned_at"], str)
+
+
+@pytest.mark.unit
+def test_response_schema_version() -> None:
+    """schema_version must match the adapter constant."""
+    result = handle_cdb_context_scope_drift(_request(_bundle_clean()))
+    assert result.get("schema_version") == SCHEMA_VERSION
+
+
+@pytest.mark.unit
+def test_filters_applied_populated_when_filter_active() -> None:
+    """summary.filters_applied must reflect every active filter."""
+    result = handle_cdb_context_scope_drift(
+        _request(_bundle_clean(), severity="blocking", scope_type="path_out_of_scope")
+    )
+    assert result["status"] == "ok"
+    fa = result["summary"]["filters_applied"]
+    assert fa.get("severity") == "blocking"
+    assert fa.get("scope_type") == "path_out_of_scope"
+
+
+@pytest.mark.unit
+def test_filters_applied_empty_when_no_filter() -> None:
+    """summary.filters_applied is empty dict when no optional filters are set."""
+    result = handle_cdb_context_scope_drift(_request(_bundle_clean()))
+    assert result["status"] == "ok"
+    assert result["summary"]["filters_applied"] == {}
+
+
+# ── 14. Safety: no writes, no network, no subprocess ─────────────────────────
+
+
+@pytest.mark.unit
+def test_response_is_plain_dict_no_side_effects() -> None:
+    """Tool returns a plain serialisable dict; no exceptions escape."""
+    result = handle_cdb_context_scope_drift(_request(_bundle_multi()))
+    assert isinstance(result, dict)
+    # Verify findings are plain dicts (not dataclass instances)
+    for f in result.get("findings", []):
+        assert isinstance(f, dict)
+
+
+@pytest.mark.unit
+def test_no_db_no_network_no_write_bundle_write_keywords() -> None:
+    """Bundle with write-intent keywords is handled safely (no leak, no crash)."""
+    result = handle_cdb_context_scope_drift(
+        _request(_bundle_with_write_intent())
+    )
+    # Must return a valid dict response (error or ok — no exception)
+    assert isinstance(result, dict)
+    assert "status" in result

--- a/tests/unit/tools/mcp/test_scope_drift_tools.py
+++ b/tests/unit/tools/mcp/test_scope_drift_tools.py
@@ -27,7 +27,7 @@ from tools.mcp.scope_drift_tools import (
     TOOL_CDB_CONTEXT_SCOPE_DRIFT,
     handle_cdb_context_scope_drift,
 )
-from tools.surrealdb.scope_drift_firewall import DRIFT_TYPES, GUARDRAILS
+from tools.surrealdb.scope_drift_firewall import GUARDRAILS
 
 # ── Fixed reference timestamps for determinism ────────────────────────────────
 

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -1987,6 +1987,21 @@ def cdb_context_stale_handler(**kwargs) -> dict[str, Any]:
     return handle_cdb_context_stale(kwargs)
 
 
+# ── Wave-17-C MCP Tool Handlers (#2165 Scope Drift MCP) ──────────────────────
+
+
+def cdb_context_scope_drift_handler(**kwargs) -> dict[str, Any]:
+    """Read-only MCP handler for cdb_context_scope_drift.
+
+    Thin adapter: passes **kwargs as the request mapping to the Wave-17-C adapter.
+    Fail-closed. No DB/network/write. Bundle-driven. Detection is signal, not
+    action permission. No live-go. No Echtgeld-Go.
+    """
+    from tools.mcp.scope_drift_tools import handle_cdb_context_scope_drift
+
+    return handle_cdb_context_scope_drift(kwargs)
+
+
 class ContextBridge:
     """
     MCP Bridge for Context Intelligence System.
@@ -2168,6 +2183,21 @@ class ContextBridge:
             "cdb_context_stale": cdb_context_stale_handler,
         }
         for _tool_name, _handler_fn in _wave16c_handler_map.items():
+            _old = self._registry.get_tool(_tool_name)
+            if _old:
+                self._registry._tools[_tool_name] = ToolDefinition(
+                    name=_old.name,
+                    description=_old.description,
+                    input_schema=_old.input_schema,
+                    output_schema=_old.output_schema,
+                    read_only=_old.read_only,
+                    handler=_handler_fn,
+                )
+        # Wave-17-C handlers (#2165 Scope Drift MCP)
+        _wave17c_handler_map = {
+            "cdb_context_scope_drift": cdb_context_scope_drift_handler,
+        }
+        for _tool_name, _handler_fn in _wave17c_handler_map.items():
             _old = self._registry.get_tool(_tool_name)
             if _old:
                 self._registry._tools[_tool_name] = ToolDefinition(

--- a/tools/mcp/permission_guard.py
+++ b/tools/mcp/permission_guard.py
@@ -152,6 +152,13 @@ INPUT_SCAN_EXEMPT_TOOLS: frozenset[str] = frozenset({
     # "migration", "runbook". The tool is read-only, bundle-driven, and
     # fail-closed; the scan service enforces no-write, no-network, no-auto-fix.
     "cdb_context_stale",
+    # Wave-17-C scope drift MCP tool (#2165).
+    # Processes scan bundles including generated_findings.content whose
+    # legitimate values are exactly the write-intent strings the firewall
+    # scans for (e.g. "commit", "push", "create file", "git push").
+    # The tool is read-only, bundle-driven, and fail-closed; the scope drift
+    # firewall service enforces no-write, no-network, no-auto-fix guardrails.
+    "cdb_context_scope_drift",
 })
 
 

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -1197,6 +1197,102 @@ TOOLS_V0 = [
         read_only=True,
         handler=create_not_implemented_handler("cdb_context_stale"),
     ),
+    # ── Wave-17-C Tools (#2165 Scope Drift MCP) ──────────────────────────────
+    ToolDefinition(
+        name="cdb_context_scope_drift",
+        description=(
+            "Wave-17-C scope drift MCP tool. Detects scope drift findings "
+            "from an in-memory input bundle using the Wave-17-A firewall service. "
+            "Supports filters for severity, scope_type (drift type), target_ref, "
+            "and blocking state. Supports deterministic limit/truncation. "
+            "Bundle-driven: no DB/network/filesystem read. Read-only, fail-closed. "
+            "Detection is signal, not authorization. No Live-Go, no Echtgeld-Go, "
+            "no auto-fix, no write."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "bundle": {
+                    "type": "object",
+                    "description": (
+                        "In-memory scan input bundle with domain keys "
+                        "(declared_scope, touched_artifacts, issue_refs, "
+                        "generated_findings, forbidden_surfaces). Required."
+                    ),
+                },
+                "severity": {
+                    "type": "string",
+                    "enum": ["info", "warning", "blocking"],
+                    "description": "Severity level to filter findings by.",
+                },
+                "scope_type": {
+                    "type": "string",
+                    "description": (
+                        "Exact drift_type to filter findings by. "
+                        "Must be one of the 9 canonical drift types."
+                    ),
+                },
+                "target_ref": {
+                    "type": "string",
+                    "description": (
+                        "Filter to findings whose affected_artifacts contains "
+                        "this reference string."
+                    ),
+                },
+                "blocking": {
+                    "type": "boolean",
+                    "description": (
+                        "true: return only blocking findings (human_go_required=true). "
+                        "false: return only non-blocking findings."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "default": 100,
+                    "maximum": 500,
+                    "description": (
+                        "Maximum number of findings to return. "
+                        "Summary counts are always pre-limit. "
+                        "summary.truncated=true when findings are capped."
+                    ),
+                },
+                "as_of": {
+                    "type": "string",
+                    "description": (
+                        "Optional ISO-8601 UTC reference time. "
+                        "Also read from bundle['meta']['as_of']. "
+                        "If absent, scan service uses cdb_utcnow()."
+                    ),
+                },
+            },
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "schema_version": {"type": "string"},
+                "status": {"type": "string"},
+                "summary": {
+                    "type": "object",
+                    "properties": {
+                        "total_count": {"type": "integer"},
+                        "blocking_count": {"type": "integer"},
+                        "truncated": {"type": "boolean"},
+                        "severity_summary": {"type": "object"},
+                        "drift_type_summary": {"type": "object"},
+                        "filters_applied": {"type": "object"},
+                    },
+                },
+                "findings": {"type": "array"},
+                "guardrails": {"type": "array"},
+                "scan_status": {"type": "string"},
+                "scanned_at": {"type": "string"},
+                "metadata": {"type": "object"},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("cdb_context_scope_drift"),
+    ),
 ]
 
 

--- a/tools/mcp/scope_drift_tools.py
+++ b/tools/mcp/scope_drift_tools.py
@@ -1,0 +1,284 @@
+"""MCP adapter layer for Wave-17-C scope drift tool.
+
+Issues:
+    #2165 — [SURREALDB][CONTEXT][SCOPE-MCP] Implement scope drift MCP tool
+    Parent: #2162 (Wave-17 anchor)
+    Epic: #1976
+
+Adapts the Wave-17-A scope drift firewall domain service for the MCP tool
+surface. The tool is read-only, fail-closed, and carries explicit no-live-go
+semantics. No DB access. No SurrealDB SDK. No network. No writes. No auto-fix.
+No live-go.
+
+Bundle-driven:
+    The tool operates exclusively on the in-memory bundle passed as input.
+    If no bundle is supplied the tool returns a clean error — it never
+    reads from a database, filesystem, or network to fill the gap.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from tools.surrealdb.scope_drift_firewall import (
+    DRIFT_TYPES,
+    GUARDRAILS,
+    SEVERITY_LEVELS,
+    ScopeDriftFinding,
+    ScopeDriftFirewallError,
+    scan_scope_drift_v1,
+)
+
+TOOL_CDB_CONTEXT_SCOPE_DRIFT = "cdb_context_scope_drift"
+SCHEMA_VERSION = "scope-drift-mcp/v1"
+
+# Maximum limit accepted; requests above this are silently capped.
+_MAX_LIMIT = 500
+_DEFAULT_LIMIT = 100
+
+_VALID_SEVERITIES: frozenset[str] = frozenset(SEVERITY_LEVELS)
+_VALID_SCOPE_TYPES: frozenset[str] = frozenset(DRIFT_TYPES)
+
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+
+def _as_str_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text if text else None
+
+
+def _as_mapping_or_none(value: Any) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        return value
+    return None
+
+
+def _error_response(
+    tool: str,
+    *,
+    code: str,
+    message: str,
+) -> dict[str, Any]:
+    return {
+        "tool": tool,
+        "status": "error",
+        "error": {"code": code, "message": message},
+    }
+
+
+def _metadata(*, source: str = "in_memory", read_only: bool = True) -> dict[str, Any]:
+    return {
+        "source": source,
+        "read_only": read_only,
+    }
+
+
+def _severity_summary(findings: Sequence[ScopeDriftFinding]) -> dict[str, int]:
+    summary: dict[str, int] = {level: 0 for level in SEVERITY_LEVELS}
+    for f in findings:
+        if f.severity in summary:
+            summary[f.severity] += 1
+    return summary
+
+
+def _drift_type_summary(findings: Sequence[ScopeDriftFinding]) -> dict[str, int]:
+    summary: dict[str, int] = {t: 0 for t in sorted(DRIFT_TYPES)}
+    for f in findings:
+        if f.drift_type in summary:
+            summary[f.drift_type] += 1
+    return summary
+
+
+# ── Handler ───────────────────────────────────────────────────────────────────
+
+
+def handle_cdb_context_scope_drift(request: Mapping[str, Any]) -> dict[str, Any]:
+    """MCP handler: detect scope drift findings over in-memory bundle.
+
+    Tool: cdb_context_scope_drift
+    Read-only, fail-closed, no writes, no DB/network/GitHub access.
+    Bundle-driven: a bundle must be supplied — no live reads.
+    Detection is signal, not action permission. No live-go.
+
+    Input:
+        bundle (required): object — scan input bundle (declared_scope, touched_artifacts, etc.)
+        severity (optional): str — one of info|warning|blocking
+        scope_type (optional): str — one of the 9 canonical drift types
+        target_ref (optional): str — filter to findings whose affected_artifacts contains this ref
+        blocking (optional): bool — true: only blocking findings; false: only non-blocking
+        limit (optional, default 100, max 500): int
+        as_of (optional): ISO-8601 UTC str; also read from bundle["meta"]["as_of"]
+
+    Output:
+        tool, schema_version, status, summary (total_count, blocking_count,
+        severity_summary, drift_type_summary, truncated, filters_applied),
+        findings, guardrails, scan_status, scanned_at, metadata
+    """
+    # Normalise: if request arrives as plain kwargs dict (from bridge **kwargs),
+    # the tool key may be absent — treat the whole dict as parameters.
+    tool_key = request.get("tool")
+    if tool_key is not None and tool_key != TOOL_CDB_CONTEXT_SCOPE_DRIFT:
+        return _error_response(
+            TOOL_CDB_CONTEXT_SCOPE_DRIFT,
+            code="invalid_tool",
+            message=f"expected tool {TOOL_CDB_CONTEXT_SCOPE_DRIFT!r}, got {tool_key!r}",
+        )
+
+    # Resolve parameters: if a "parameters" wrapper is present, unwrap it.
+    raw_params = request.get("parameters")
+    if isinstance(raw_params, Mapping):
+        params: Mapping[str, Any] = raw_params
+    else:
+        params = request
+
+    # ── Required: bundle ──────────────────────────────────────────────────────
+    raw_bundle = params.get("bundle")
+    bundle = _as_mapping_or_none(raw_bundle)
+    if bundle is None:
+        return _error_response(
+            TOOL_CDB_CONTEXT_SCOPE_DRIFT,
+            code="missing_bundle",
+            message=(
+                "bundle is required (object/dict of scan input records). "
+                "This tool is read-only and bundle-driven — it never reads "
+                "from a database, filesystem, or network. "
+                "Supply a bundle with domain keys (declared_scope, touched_artifacts, "
+                "issue_refs, generated_findings, forbidden_surfaces)."
+            ),
+        )
+
+    # ── Optional: severity filter ─────────────────────────────────────────────
+    raw_severity = params.get("severity")
+    severity_filter = _as_str_or_none(raw_severity)
+    if severity_filter is not None and severity_filter not in _VALID_SEVERITIES:
+        return _error_response(
+            TOOL_CDB_CONTEXT_SCOPE_DRIFT,
+            code="invalid_severity",
+            message=(
+                f"severity must be one of {sorted(_VALID_SEVERITIES)}, "
+                f"got {severity_filter!r}"
+            ),
+        )
+
+    # ── Optional: scope_type filter ───────────────────────────────────────────
+    raw_scope_type = params.get("scope_type")
+    scope_type_filter = _as_str_or_none(raw_scope_type)
+    if scope_type_filter is not None and scope_type_filter not in _VALID_SCOPE_TYPES:
+        return _error_response(
+            TOOL_CDB_CONTEXT_SCOPE_DRIFT,
+            code="invalid_scope_type",
+            message=(
+                f"scope_type must be one of {sorted(_VALID_SCOPE_TYPES)}, "
+                f"got {scope_type_filter!r}"
+            ),
+        )
+
+    # ── Optional: target_ref filter ───────────────────────────────────────────
+    target_ref_filter = _as_str_or_none(params.get("target_ref"))
+
+    # ── Optional: blocking filter ─────────────────────────────────────────────
+    raw_blocking = params.get("blocking")
+    blocking_filter: bool | None = None
+    if raw_blocking is not None:
+        if isinstance(raw_blocking, bool):
+            blocking_filter = raw_blocking
+        else:
+            s = str(raw_blocking).strip().lower()
+            if s == "true":
+                blocking_filter = True
+            elif s == "false":
+                blocking_filter = False
+            # else: unrecognised value — ignore (treat as absent)
+
+    # ── Optional: limit ───────────────────────────────────────────────────────
+    raw_limit = params.get("limit", _DEFAULT_LIMIT)
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError):
+        limit = _DEFAULT_LIMIT
+    limit = max(1, min(limit, _MAX_LIMIT))
+
+    # ── Optional: as_of ───────────────────────────────────────────────────────
+    # Priority: explicit param > bundle["meta"]["as_of"] > None (service default)
+    raw_as_of = _as_str_or_none(params.get("as_of"))
+    if raw_as_of is None:
+        meta = bundle.get("meta")
+        if isinstance(meta, Mapping):
+            raw_as_of = _as_str_or_none(meta.get("as_of"))
+
+    # ── Run scan ─────────────────────────────────────────────────────────────
+    try:
+        scan_result = scan_scope_drift_v1(bundle, as_of=raw_as_of)
+    except ScopeDriftFirewallError as exc:
+        return _error_response(
+            TOOL_CDB_CONTEXT_SCOPE_DRIFT,
+            code="invalid_bundle",
+            message=str(exc),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _error_response(
+            TOOL_CDB_CONTEXT_SCOPE_DRIFT,
+            code="scan_error",
+            message=f"Scan failed unexpectedly: {type(exc).__name__}",
+        )
+
+    # ── Apply post-scan filters ───────────────────────────────────────────────
+    filtered: list[ScopeDriftFinding] = []
+    for f in scan_result.findings:
+        # severity filter
+        if severity_filter is not None and f.severity != severity_filter:
+            continue
+        # scope_type filter (maps to drift_type field)
+        if scope_type_filter is not None and f.drift_type != scope_type_filter:
+            continue
+        # target_ref filter: membership in affected_artifacts
+        if target_ref_filter is not None and target_ref_filter not in f.affected_artifacts:
+            continue
+        # blocking filter: maps to human_go_required
+        if blocking_filter is not None and f.human_go_required != blocking_filter:
+            continue
+        filtered.append(f)
+
+    # ── Summary (post-filter, pre-limit) ─────────────────────────────────────
+    total_count = len(filtered)
+    blocking_count = sum(1 for f in filtered if f.human_go_required)
+    sev_summary = _severity_summary(filtered)
+    dt_summary = _drift_type_summary(filtered)
+
+    # Build filters_applied for traceability
+    filters_applied: dict[str, Any] = {}
+    if severity_filter is not None:
+        filters_applied["severity"] = severity_filter
+    if scope_type_filter is not None:
+        filters_applied["scope_type"] = scope_type_filter
+    if target_ref_filter is not None:
+        filters_applied["target_ref"] = target_ref_filter
+    if blocking_filter is not None:
+        filters_applied["blocking"] = blocking_filter
+
+    # ── Apply limit ───────────────────────────────────────────────────────────
+    truncated = len(filtered) > limit
+    findings_page = filtered[:limit]
+
+    # ── Build response ────────────────────────────────────────────────────────
+    return {
+        "tool": TOOL_CDB_CONTEXT_SCOPE_DRIFT,
+        "schema_version": SCHEMA_VERSION,
+        "status": "ok",
+        "summary": {
+            "total_count": total_count,
+            "blocking_count": blocking_count,
+            "truncated": truncated,
+            "severity_summary": sev_summary,
+            "drift_type_summary": dt_summary,
+            "filters_applied": filters_applied,
+        },
+        "findings": [f.to_dict() for f in findings_page],
+        "guardrails": list(GUARDRAILS),
+        "scan_status": scan_result.status,
+        "scanned_at": scan_result.scanned_at,
+        "metadata": _metadata(),
+    }


### PR DESCRIPTION
## Summary
Implements Wave 17-C / #2165 Scope Drift MCP Tool.

## Scope
- Adds read-only MCP wrapper for the Wave 17-A scope drift firewall service.
- Supports bundle-driven scan execution.
- Supports filters for severity, scope type, target reference and blocking state.
- Supports deterministic limit/truncation behavior.
- Adds unit coverage for MCP behavior.

## Files
- `tools/mcp/scope_drift_tools.py`
- `tests/unit/tools/mcp/test_scope_drift_tools.py`
- Registry/bridge files only if required by existing MCP pattern.

## Safety
- No DB access.
- No network access.
- No GitHub access.
- No file writes.
- No runbook.
- No gates.
- No runtime changes.
- No Live-Readiness / Echtgeld scope.

## Validation
- `python -m pytest -v -m unit tests/unit/tools/mcp/test_scope_drift_tools.py`
- `python -m pytest -v -m unit tests/unit/surrealdb/test_scope_drift_firewall.py tests/unit/surrealdb/test_scope_drift_cli.py`
- `ruff check tools/mcp/scope_drift_tools.py tests/unit/tools/mcp/test_scope_drift_tools.py`
- `git diff --check`

Closes #2165.