### PR TITLE
feat(surrealdb): standardize blocking scope drift output

### DIFF
--- a/tests/unit/surrealdb/test_scope_drift_blocking.py
+++ b/tests/unit/surrealdb/test_scope_drift_blocking.py
@@ -95,24 +95,6 @@ _BLOCKING_BUNDLE: dict[str, Any] = {
     "forbidden_surfaces": [],
 }
 
-# Triggers domain_out_of_scope (warning only) — non-blocking:
-_WARNING_BUNDLE: dict[str, Any] = {
-    "meta": {"as_of": _AS_OF},
-    "declared_scope": {
-        "target_issue": "2166",
-        "allowed_domains": ["tools"],
-    },
-    "touched_artifacts": [
-        {
-            "path": "docs/some/file.md",
-            "surface_type": "docs",
-        },
-    ],
-    "issue_refs": [],
-    "generated_findings": [],
-    "forbidden_surfaces": [],
-}
-
 # Triggers no findings at all — clean bundle:
 _CLEAN_BUNDLE: dict[str, Any] = {
     "meta": {"as_of": _AS_OF},

--- a/tests/unit/surrealdb/test_scope_drift_blocking.py
+++ b/tests/unit/surrealdb/test_scope_drift_blocking.py
@@ -1,0 +1,567 @@
+"""Unit tests for scope_drift_blocking.py — Wave 17-D Blocking Scope Drift Output.
+
+Issues:
+    #2166 — [SURREALDB][CONTEXT][SCOPE-BLOCKING] Blocking Scope Drift Output
+    Parent: #2162 (Wave-17 anchor)
+    Depends on: #2163 scope_drift_firewall, #2164 scope_drift_cli, #2165 scope_drift_tools
+    Epic: #1976
+
+Scope:
+    Unit tests for tools/surrealdb/scope_drift_blocking.py.
+    All fixtures are inline — no file loading, no DB, no network, no writes.
+    No real datetime.now() — as_of fixed for determinism.
+
+Coverage:
+    1.  Full schema present when blocking findings present.
+    2.  blocking=False when no blocking findings.
+    3.  operator_action is one of the valid output values.
+    4.  operator_action="stop" when highest-priority finding has required_action="stop".
+    5.  operator_action="request_human_go" when only request_go findings.
+    6.  operator_action="split_scope" when only split_scope findings.
+    7.  operator_action="review" when only review findings.
+    8.  affected_artifacts is sorted and deduplicated.
+    9.  recommended_next_reads is stable-order and deduplicated.
+    10. anti_actions contains all 8 required entries (no auto-fix, no live-go, etc.).
+    11. guardrails fully propagated (all 5 GUARDRAILS strings).
+    12. JSON serialisation is stable (sort_keys produces consistent output).
+    13. Markdown output contains all required sections.
+    14. Safety: no DB/network/write access in module source.
+    15. CLI handle_report_scope_drift includes blocking_output key when blocking findings.
+    16. CLI blocking_output absent when no blocking findings.
+    17. MCP response includes blocking_output when blocking_count > 0.
+    18. MCP response blocking_output is None when no blocking findings.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tools.surrealdb.scope_drift_blocking import (
+    ANTI_ACTIONS,
+    SCHEMA_VERSION,
+    _collect_affected_artifacts,
+    _collect_recommended_next_reads,
+    _derive_operator_action,
+    build_blocking_output,
+    render_blocking_markdown,
+)
+from tools.surrealdb.scope_drift_firewall import (
+    GUARDRAILS,
+    ScopeDriftFinding,
+    ScopeDriftScanResult,
+    scan_scope_drift_v1,
+)
+
+# ── Fixed timestamp for determinism ──────────────────────────────────────────
+
+_AS_OF = "2026-05-06T12:00:00+00:00"
+
+# ── Shared bundles ────────────────────────────────────────────────────────────
+
+# Triggers path_out_of_scope (blocking) + missing_human_go (blocking):
+#   - declared target_paths set; touched artifact is outside declared paths
+#   - operation_mode=write with no human_go_token
+_BLOCKING_BUNDLE: dict[str, Any] = {
+    "meta": {
+        "as_of": _AS_OF,
+        "session_id": "blocking-test-001",
+        "operation_mode": "write",
+        "human_go_token": None,
+    },
+    "declared_scope": {
+        "task_scope": "Test blocking scope",
+        "target_issue": "2166",
+        "target_paths": [
+            "tools/surrealdb/",
+            "tests/unit/surrealdb/",
+        ],
+    },
+    "touched_artifacts": [
+        {
+            "path": "services/cdb_risk/service.py",
+            "surface_type": "runtime",
+        },
+    ],
+    "issue_refs": [
+        {"issue_id": "2166", "state": "OPEN", "label": "Wave-17"},
+    ],
+    "generated_findings": [],
+    "forbidden_surfaces": [],
+}
+
+# Triggers domain_out_of_scope (warning only) — non-blocking:
+_WARNING_BUNDLE: dict[str, Any] = {
+    "meta": {"as_of": _AS_OF},
+    "declared_scope": {
+        "target_issue": "2166",
+        "allowed_domains": ["tools"],
+    },
+    "touched_artifacts": [
+        {
+            "path": "docs/some/file.md",
+            "surface_type": "docs",
+        },
+    ],
+    "issue_refs": [],
+    "generated_findings": [],
+    "forbidden_surfaces": [],
+}
+
+# Triggers no findings at all — clean bundle:
+_CLEAN_BUNDLE: dict[str, Any] = {
+    "meta": {"as_of": _AS_OF},
+    "declared_scope": {"target_issue": "2166", "target_paths": ["tools/surrealdb/"]},
+    "touched_artifacts": [
+        {"path": "tools/surrealdb/scope_drift_blocking.py", "surface_type": "tools"},
+    ],
+    "issue_refs": [{"issue_id": "2166", "state": "OPEN", "label": "Wave-17"}],
+    "generated_findings": [],
+    "forbidden_surfaces": [],
+}
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_BLOCKING_REQUIRED_ACTIONS = frozenset({"stop", "request_human_go", "split_scope", "review"})
+
+_REQUIRED_SCHEMA_KEYS = frozenset(
+    {
+        "status",
+        "blocking",
+        "blocking_count",
+        "summary",
+        "operator_action",
+        "affected_artifacts",
+        "recommended_next_reads",
+        "guardrails",
+        "findings",
+        "anti_actions",
+    }
+)
+
+
+def _scan(bundle: dict[str, Any]) -> ScopeDriftScanResult:
+    return scan_scope_drift_v1(bundle, as_of=_AS_OF)
+
+
+def _make_fake_finding(
+    *,
+    required_action: str = "stop",
+    affected_artifacts: tuple[str, ...] = ("tools/foo.py",),
+    recommended_next_reads: tuple[str, ...] = ("AGENTS.md",),
+) -> ScopeDriftFinding:
+    """Create a minimal fake blocking ScopeDriftFinding for unit isolation."""
+    return ScopeDriftFinding(
+        drift_id="aabbccdd00000001",
+        drift_type="path_out_of_scope",
+        severity="blocking",
+        allowed_scope="tools/surrealdb/",
+        observed_scope="services/cdb_risk/service.py",
+        affected_artifacts=affected_artifacts,
+        required_action=required_action,
+        human_go_required=True,
+        stop_conditions=("Artefact is outside declared scope.",),
+        recommended_next_reads=recommended_next_reads,
+        detected_by="scope-drift-firewall/v1",
+        detected_at=_AS_OF,
+        status="open",
+    )
+
+
+def _make_fake_scan_result(
+    findings: tuple[ScopeDriftFinding, ...] = (),
+    blocking_count: int = 0,
+    status: str = "ok",
+) -> ScopeDriftScanResult:
+    return ScopeDriftScanResult(
+        tool="scope_drift_firewall",
+        schema_version="scope-drift-firewall/v1",
+        status=status,
+        scanned_at=_AS_OF,
+        blocking_count=blocking_count,
+        findings=findings,
+        guardrails=GUARDRAILS,
+    )
+
+
+# ── 1. Full schema present when blocking findings present ─────────────────────
+
+
+@pytest.mark.unit
+def test_blocking_output_full_schema_when_blocking() -> None:
+    result = _scan(_BLOCKING_BUNDLE)
+    assert result.blocking_count > 0, "Test requires blocking findings"
+    out = build_blocking_output(result)
+    missing = _REQUIRED_SCHEMA_KEYS - set(out.keys())
+    assert not missing, f"Missing keys: {missing}"
+
+
+# ── 2. blocking=False when no blocking findings ───────────────────────────────
+
+
+@pytest.mark.unit
+def test_blocking_false_when_no_blocking_findings() -> None:
+    result = _scan(_CLEAN_BUNDLE)
+    out = build_blocking_output(result)
+    assert out["blocking"] is False
+    assert out["blocking_count"] == 0
+    assert out["findings"] == []
+
+
+# ── 3. operator_action is one of the valid output values ─────────────────────
+
+
+@pytest.mark.unit
+def test_operator_action_is_valid_value_when_blocking() -> None:
+    result = _scan(_BLOCKING_BUNDLE)
+    assert result.blocking_count > 0
+    out = build_blocking_output(result)
+    assert out["operator_action"] in _BLOCKING_REQUIRED_ACTIONS
+
+
+# ── 4. operator_action="stop" for stop findings ───────────────────────────────
+
+
+@pytest.mark.unit
+def test_operator_action_stop_priority() -> None:
+    f_stop = _make_fake_finding(required_action="stop")
+    f_review = _make_fake_finding(required_action="review")
+    result = _make_fake_scan_result(
+        findings=(f_stop, f_review), blocking_count=2, status="blocked_scope_drift"
+    )
+    out = build_blocking_output(result)
+    assert out["operator_action"] == "stop"
+
+
+# ── 5. operator_action="request_human_go" when only request_go findings ───────
+
+
+@pytest.mark.unit
+def test_operator_action_request_human_go() -> None:
+    f = _make_fake_finding(required_action="request_go")
+    result = _make_fake_scan_result(findings=(f,), blocking_count=1, status="blocked_scope_drift")
+    out = build_blocking_output(result)
+    assert out["operator_action"] == "request_human_go"
+
+
+# ── 6. operator_action="split_scope" when only split_scope findings ───────────
+
+
+@pytest.mark.unit
+def test_operator_action_split_scope() -> None:
+    f = _make_fake_finding(required_action="split_scope")
+    result = _make_fake_scan_result(findings=(f,), blocking_count=1, status="blocked_scope_drift")
+    out = build_blocking_output(result)
+    assert out["operator_action"] == "split_scope"
+
+
+# ── 7. operator_action="review" when no blocking findings ─────────────────────
+
+
+@pytest.mark.unit
+def test_operator_action_review_when_no_blocking_findings() -> None:
+    result = _make_fake_scan_result()
+    out = build_blocking_output(result)
+    assert out["operator_action"] == "review"
+
+
+# ── 8. affected_artifacts sorted and deduplicated ─────────────────────────────
+
+
+@pytest.mark.unit
+def test_affected_artifacts_sorted_and_deduped() -> None:
+    f1 = _make_fake_finding(affected_artifacts=("tools/z.py", "tools/a.py"))
+    f2 = _make_fake_finding(affected_artifacts=("tools/a.py", "tools/m.py"))
+    findings = (f1, f2)
+    result = _collect_affected_artifacts(findings)
+    # deduplicated
+    assert len(result) == len(set(result))
+    # sorted
+    assert result == sorted(result)
+    # all entries present
+    assert "tools/a.py" in result
+    assert "tools/z.py" in result
+    assert "tools/m.py" in result
+
+
+# ── 9. recommended_next_reads stable order and deduped ────────────────────────
+
+
+@pytest.mark.unit
+def test_recommended_next_reads_stable_and_deduped() -> None:
+    f1 = _make_fake_finding(recommended_next_reads=("AGENTS.md", "docs/CONTROL_REGISTER.md"))
+    f2 = _make_fake_finding(recommended_next_reads=("AGENTS.md", "knowledge/GOVERNANCE.md"))
+    findings = (f1, f2)
+    result = _collect_recommended_next_reads(findings)
+    # deduplicated
+    assert len(result) == len(set(result))
+    # stable: first-seen order — AGENTS.md must appear before knowledge/GOVERNANCE.md
+    assert result.index("AGENTS.md") < result.index("knowledge/GOVERNANCE.md")
+    # all entries present
+    assert "AGENTS.md" in result
+    assert "docs/CONTROL_REGISTER.md" in result
+    assert "knowledge/GOVERNANCE.md" in result
+
+
+# ── 10. anti_actions contains all 8 required entries ─────────────────────────
+
+
+@pytest.mark.unit
+def test_anti_actions_all_entries_present() -> None:
+    result = _scan(_CLEAN_BUNDLE)
+    out = build_blocking_output(result)
+    expected = {
+        "no_auto_fix",
+        "no_auto_write",
+        "no_auto_merge",
+        "no_auto_close",
+        "no_live_go",
+        "no_lr_go",
+        "no_echtgeld_go",
+        "no_runtime_enable",
+    }
+    assert expected.issubset(set(out["anti_actions"]))
+
+
+@pytest.mark.unit
+def test_anti_actions_constant_matches_module() -> None:
+    assert len(ANTI_ACTIONS) == 8
+    for entry in ANTI_ACTIONS:
+        assert isinstance(entry, str) and entry
+
+
+# ── 11. guardrails fully propagated ──────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_guardrails_fully_propagated() -> None:
+    result = _scan(_BLOCKING_BUNDLE)
+    out = build_blocking_output(result)
+    for guardrail in GUARDRAILS:
+        assert guardrail in out["guardrails"], f"Missing guardrail: {guardrail!r}"
+
+
+# ── 12. JSON serialisation stable ────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_json_output_is_stable() -> None:
+    result = _scan(_BLOCKING_BUNDLE)
+    out1 = build_blocking_output(result)
+    out2 = build_blocking_output(result)
+    assert json.dumps(out1, sort_keys=True) == json.dumps(out2, sort_keys=True)
+
+
+@pytest.mark.unit
+def test_json_output_is_serialisable() -> None:
+    result = _scan(_BLOCKING_BUNDLE)
+    out = build_blocking_output(result)
+    serialised = json.dumps(out, sort_keys=True)
+    restored = json.loads(serialised)
+    assert restored["blocking"] == out["blocking"]
+    assert restored["blocking_count"] == out["blocking_count"]
+
+
+# ── 13. Markdown output contains all required sections ────────────────────────
+
+
+@pytest.mark.unit
+def test_markdown_contains_required_sections_when_blocking() -> None:
+    result = _scan(_BLOCKING_BUNDLE)
+    out = build_blocking_output(result)
+    md = render_blocking_markdown(out)
+    assert "## Blocking Output" in md
+    assert "**Summary:**" in md
+    assert "**Operator Action:**" in md
+    assert "### Anti-Actions (Prohibited)" in md
+    assert "### Recommended Next Reads" in md
+    assert "### Guardrails" in md
+
+
+@pytest.mark.unit
+def test_markdown_contains_blocking_findings_table_when_blocking() -> None:
+    result = _scan(_BLOCKING_BUNDLE)
+    out = build_blocking_output(result)
+    md = render_blocking_markdown(out)
+    assert "### Blocking Findings" in md
+
+
+@pytest.mark.unit
+def test_markdown_no_blocking_findings_section_when_clean() -> None:
+    result = _scan(_CLEAN_BUNDLE)
+    out = build_blocking_output(result)
+    md = render_blocking_markdown(out)
+    assert "## Blocking Output" in md
+    # No blocking findings table if no blocking findings
+    assert "### Blocking Findings" not in md
+
+
+@pytest.mark.unit
+def test_markdown_anti_actions_listed() -> None:
+    result = _scan(_BLOCKING_BUNDLE)
+    out = build_blocking_output(result)
+    md = render_blocking_markdown(out)
+    for aa in ANTI_ACTIONS:
+        assert aa in md, f"anti_action {aa!r} missing from Markdown"
+
+
+# ── 14. Safety: no DB/network/write access in module source ───────────────────
+
+
+@pytest.mark.unit
+def test_no_db_access_in_module() -> None:
+    module = sys.modules["tools.surrealdb.scope_drift_blocking"]
+    src = inspect.getsource(module)
+    forbidden = [
+        "Surreal(",
+        "surreal.",
+        "requests.",
+        "httpx.",
+        "urllib.",
+        "subprocess.",
+        "socket.",
+        "open(",
+        "write_text",
+        "write_bytes",
+        "os.system",
+        "datetime.now",
+        "utcnow()",
+        "LIVE_TRADING",
+        "api_key",
+        "password",
+        "token",
+    ]
+    violations = [term for term in forbidden if term in src]
+    assert not violations, f"Forbidden terms found in module source: {violations}"
+
+
+# ── 15. CLI handle_report_scope_drift includes blocking_output ─────────────────
+
+
+@pytest.mark.unit
+def test_cli_report_includes_blocking_output_when_blocking(tmp_path: Path) -> None:
+    import json as _json
+    from tools.surrealdb.scope_drift_cli import handle_report_scope_drift
+
+    bundle_file = tmp_path / "bundle.json"
+    bundle_file.write_text(_json.dumps(_BLOCKING_BUNDLE), encoding="utf-8")
+
+    import argparse
+    args = argparse.Namespace(input=str(bundle_file))
+    payload, exit_code = handle_report_scope_drift(args)
+
+    assert "blocking_output" in payload
+    bo = payload["blocking_output"]
+    assert bo["blocking"] is True
+    assert bo["blocking_count"] > 0
+    assert set(bo.keys()) >= _REQUIRED_SCHEMA_KEYS
+
+
+# ── 16. CLI blocking_output absent when no blocking findings ──────────────────
+
+
+@pytest.mark.unit
+def test_cli_report_no_blocking_output_when_clean(tmp_path: Path) -> None:
+    import json as _json
+    from tools.surrealdb.scope_drift_cli import handle_report_scope_drift
+
+    bundle_file = tmp_path / "bundle.json"
+    bundle_file.write_text(_json.dumps(_CLEAN_BUNDLE), encoding="utf-8")
+
+    import argparse
+    args = argparse.Namespace(input=str(bundle_file))
+    payload, exit_code = handle_report_scope_drift(args)
+
+    assert "blocking_output" not in payload
+
+
+# ── 17. MCP response includes blocking_output when blocking_count > 0 ─────────
+
+
+@pytest.mark.unit
+def test_mcp_response_includes_blocking_output_when_blocking() -> None:
+    from tools.mcp.scope_drift_tools import handle_cdb_context_scope_drift
+
+    request = {"bundle": _BLOCKING_BUNDLE}
+    response = handle_cdb_context_scope_drift(request)
+
+    assert response["status"] == "ok"
+    assert response["summary"]["blocking_count"] > 0
+    assert "blocking_output" in response
+    bo = response["blocking_output"]
+    assert bo is not None
+    assert bo["blocking"] is True
+    assert set(bo.keys()) >= _REQUIRED_SCHEMA_KEYS
+
+
+# ── 18. MCP response blocking_output is None when no blocking findings ─────────
+
+
+@pytest.mark.unit
+def test_mcp_response_blocking_output_none_when_clean() -> None:
+    from tools.mcp.scope_drift_tools import handle_cdb_context_scope_drift
+
+    request = {"bundle": _CLEAN_BUNDLE}
+    response = handle_cdb_context_scope_drift(request)
+
+    assert response["status"] == "ok"
+    assert response["summary"]["blocking_count"] == 0
+    assert "blocking_output" in response
+    assert response["blocking_output"] is None
+
+
+# ── Extra: _derive_operator_action with multiple actions picks highest priority ─
+
+
+@pytest.mark.unit
+def test_derive_operator_action_stop_beats_request_go() -> None:
+    f_request_go = _make_fake_finding(required_action="request_go")
+    f_stop = _make_fake_finding(required_action="stop")
+    result = _derive_operator_action([f_request_go, f_stop])
+    assert result == "stop"
+
+
+@pytest.mark.unit
+def test_derive_operator_action_request_go_beats_split_scope() -> None:
+    f_split = _make_fake_finding(required_action="split_scope")
+    f_rg = _make_fake_finding(required_action="request_go")
+    result = _derive_operator_action([f_split, f_rg])
+    assert result == "request_human_go"
+
+
+@pytest.mark.unit
+def test_derive_operator_action_empty_returns_review() -> None:
+    result = _derive_operator_action([])
+    assert result == "review"
+
+
+# ── Extra: build_blocking_output summary string ───────────────────────────────
+
+
+@pytest.mark.unit
+def test_blocking_output_summary_mentions_count_when_blocking() -> None:
+    result = _scan(_BLOCKING_BUNDLE)
+    assert result.blocking_count > 0
+    out = build_blocking_output(result)
+    assert str(result.blocking_count) in out["summary"]
+    assert "blocking" in out["summary"].lower()
+
+
+@pytest.mark.unit
+def test_blocking_output_summary_no_blocking_message_when_clean() -> None:
+    result = _scan(_CLEAN_BUNDLE)
+    out = build_blocking_output(result)
+    assert "No blocking" in out["summary"]
+
+
+# ── Extra: SCHEMA_VERSION constant ───────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_schema_version_format() -> None:
+    assert SCHEMA_VERSION.startswith("scope-drift-blocking/")

--- a/tools/mcp/scope_drift_tools.py
+++ b/tools/mcp/scope_drift_tools.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Sequence
 
+from tools.surrealdb.scope_drift_blocking import build_blocking_output
 from tools.surrealdb.scope_drift_firewall import (
     DRIFT_TYPES,
     GUARDRAILS,
@@ -281,4 +282,5 @@ def handle_cdb_context_scope_drift(request: Mapping[str, Any]) -> dict[str, Any]
         "scan_status": scan_result.status,
         "scanned_at": scan_result.scanned_at,
         "metadata": _metadata(),
+        "blocking_output": build_blocking_output(scan_result) if scan_result.blocking_count > 0 else None,
     }

--- a/tools/surrealdb/scope_drift_blocking.py
+++ b/tools/surrealdb/scope_drift_blocking.py
@@ -1,0 +1,265 @@
+"""Blocking Scope Drift Output Helper — Wave 17-D.
+
+Issues:
+    #2166 — [SURREALDB][CONTEXT][SCOPE-BLOCKING] Blocking Scope Drift Output
+    Parent: #2162 (Wave-17 anchor)
+    Depends on: #2163 (scope_drift_firewall, merged via PR #2376)
+    Epic: #1976
+
+Scope:
+    Standardised blocking-output helper for Scope Drift findings.
+    Produces the full #2166 output schema so that Operator and Agent
+    can clearly see:
+        - why execution is being stopped
+        - which artefacts are affected
+        - which guardrails apply
+        - which next reads are recommended
+        - which operator action is expected
+        - that no auto-fixes or auto-writes are permitted
+
+    This module is read-only, side-effect-free, and purely in-memory.
+    No DB access. No SurrealDB SDK. No MCP. No networking. No writes.
+    No auto-fix. No auto-write. No live-go. No Echtgeld-Go.
+
+Output schema (produced by ``build_blocking_output``):
+    status                  str — scan status from ScopeDriftScanResult
+    blocking                bool — True iff blocking_count > 0
+    blocking_count          int — number of blocking findings
+    summary                 str — human-readable summary line
+    operator_action         str — one of: stop, review, split_scope, request_human_go
+    affected_artifacts      list[str] — sorted, deduplicated
+    recommended_next_reads  list[str] — stable-order, deduplicated
+    guardrails              list[str] — all guardrails from the scan result
+    findings                list[dict] — blocking findings only (to_dict())
+    anti_actions            list[str] — explicit prohibitions (always present)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Sequence
+
+if TYPE_CHECKING:
+    from tools.surrealdb.scope_drift_firewall import ScopeDriftFinding, ScopeDriftScanResult
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+SCHEMA_VERSION = "scope-drift-blocking/v1"
+
+# Explicit prohibitions — always present in blocking output regardless of findings.
+ANTI_ACTIONS: tuple[str, ...] = (
+    "no_auto_fix",
+    "no_auto_write",
+    "no_auto_merge",
+    "no_auto_close",
+    "no_live_go",
+    "no_lr_go",
+    "no_echtgeld_go",
+    "no_runtime_enable",
+)
+
+# Operator-action priority — lower value = higher priority (stop wins).
+# Maps internal required_action values to canonical output operator_action labels.
+_ACTION_LABEL: dict[str, str] = {
+    "stop": "stop",
+    "request_go": "request_human_go",
+    "split_scope": "split_scope",
+    "review": "review",
+}
+
+_ACTION_PRIORITY: dict[str, int] = {
+    "stop": 0,
+    "request_go": 1,
+    "split_scope": 2,
+    "review": 3,
+}
+
+# Sentinel returned when there are no blocking findings.
+_DEFAULT_OPERATOR_ACTION = "review"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _blocking_findings(
+    scan_result: "ScopeDriftScanResult",
+) -> list["ScopeDriftFinding"]:
+    """Return only the blocking findings from a scan result."""
+    return [f for f in scan_result.findings if f.human_go_required]
+
+
+def _derive_operator_action(findings: Sequence["ScopeDriftFinding"]) -> str:
+    """Derive the highest-priority operator action from a set of findings.
+
+    Findings with ``required_action="stop"`` have highest priority.
+    Returns ``_DEFAULT_OPERATOR_ACTION`` when *findings* is empty.
+    """
+    if not findings:
+        return _DEFAULT_OPERATOR_ACTION
+    best_priority = len(_ACTION_PRIORITY)  # start above worst
+    best_action = _DEFAULT_OPERATOR_ACTION
+    for f in findings:
+        priority = _ACTION_PRIORITY.get(f.required_action, len(_ACTION_PRIORITY))
+        if priority < best_priority:
+            best_priority = priority
+            best_action = f.required_action
+    return _ACTION_LABEL.get(best_action, best_action)
+
+
+def _collect_affected_artifacts(findings: Sequence["ScopeDriftFinding"]) -> list[str]:
+    """Return a sorted, deduplicated list of affected artifact paths/IDs.
+
+    Sourced exclusively from ``ScopeDriftFinding.affected_artifacts``.
+    Sorting ensures deterministic output regardless of finding order.
+    """
+    seen: set[str] = set()
+    artifacts: list[str] = []
+    for f in findings:
+        for artifact in f.affected_artifacts:
+            artifact = artifact.strip()
+            if artifact and artifact not in seen:
+                seen.add(artifact)
+                artifacts.append(artifact)
+    return sorted(artifacts)
+
+
+def _collect_recommended_next_reads(findings: Sequence["ScopeDriftFinding"]) -> list[str]:
+    """Return a stable-order, deduplicated list of recommended next reads.
+
+    Preserves first-seen order across blocking findings.  Stable order is
+    important so that operator tooling produces repeatable output.
+    """
+    seen: set[str] = set()
+    reads: list[str] = []
+    for f in findings:
+        for read in f.recommended_next_reads:
+            read = read.strip()
+            if read and read not in seen:
+                seen.add(read)
+                reads.append(read)
+    return reads
+
+
+def _build_summary_str(blocking_count: int, operator_action: str) -> str:
+    """Build a human-readable summary line for blocking output."""
+    if blocking_count == 0:
+        return "No blocking scope drift findings detected."
+    noun = "finding" if blocking_count == 1 else "findings"
+    return (
+        f"{blocking_count} blocking scope drift {noun} detected. "
+        f"Operator action required: {operator_action}. "
+        "No auto-fix. No auto-write. Human-GO required for any write."
+    )
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def build_blocking_output(scan_result: "ScopeDriftScanResult") -> dict[str, Any]:
+    """Build the standardised blocking-output dict from a scan result.
+
+    Always safe to call — returns a stable schema regardless of whether any
+    blocking findings are present.  When ``blocking_count == 0`` the result
+    has ``blocking=False`` and an empty ``findings`` list.
+
+    Output keys:
+        status                  str
+        blocking                bool
+        blocking_count          int
+        summary                 str
+        operator_action         str
+        affected_artifacts      list[str]  — sorted, deduplicated
+        recommended_next_reads  list[str]  — stable-order, deduplicated
+        guardrails              list[str]
+        findings                list[dict] — blocking findings only
+        anti_actions            list[str]
+    """
+    bf = _blocking_findings(scan_result)
+    operator_action = _derive_operator_action(bf)
+    return {
+        "status": scan_result.status,
+        "blocking": scan_result.blocking_count > 0,
+        "blocking_count": scan_result.blocking_count,
+        "summary": _build_summary_str(scan_result.blocking_count, operator_action),
+        "operator_action": operator_action,
+        "affected_artifacts": _collect_affected_artifacts(bf),
+        "recommended_next_reads": _collect_recommended_next_reads(bf),
+        "guardrails": list(scan_result.guardrails),
+        "findings": [f.to_dict() for f in bf],
+        "anti_actions": list(ANTI_ACTIONS),
+    }
+
+
+def render_blocking_markdown(blocking_output: dict[str, Any]) -> str:
+    """Render a blocking-output dict as a Markdown section.
+
+    Suitable for embedding in a larger CLI Markdown report.
+    Contains: Summary, Operator Action, Affected Artefacts, Anti-Actions,
+    Recommended Next Reads, Guardrails, and the Blocking Findings table.
+    """
+    lines: list[str] = ["## Blocking Output", ""]
+
+    status = blocking_output.get("status", "unknown")
+    blocking = blocking_output.get("blocking", False)
+    blocking_count = blocking_output.get("blocking_count", 0)
+    summary = blocking_output.get("summary", "")
+    operator_action = blocking_output.get("operator_action", "review")
+
+    lines += [
+        f"- **status**: `{status}`",
+        f"- **blocking**: {blocking}",
+        f"- **blocking_count**: {blocking_count}",
+        "",
+        f"**Summary:** {summary}",
+        "",
+        f"**Operator Action:** `{operator_action}`",
+        "",
+    ]
+
+    # Affected Artefacts
+    artifacts = blocking_output.get("affected_artifacts", [])
+    if artifacts:
+        lines += ["### Affected Artefacts", ""]
+        for a in artifacts:
+            lines.append(f"- `{a}`")
+        lines.append("")
+
+    # Anti-Actions — always shown
+    anti_actions = blocking_output.get("anti_actions", list(ANTI_ACTIONS))
+    lines += ["### Anti-Actions (Prohibited)", ""]
+    for aa in anti_actions:
+        lines.append(f"- `{aa}`")
+    lines.append("")
+
+    # Recommended Next Reads
+    next_reads = blocking_output.get("recommended_next_reads", [])
+    if next_reads:
+        lines += ["### Recommended Next Reads", ""]
+        for r in next_reads:
+            lines.append(f"- `{r}`")
+        lines.append("")
+
+    # Guardrails
+    guardrails = blocking_output.get("guardrails", [])
+    if guardrails:
+        lines += ["### Guardrails", ""]
+        for g in guardrails:
+            lines.append(f"- {g}")
+        lines.append("")
+
+    # Blocking Findings table
+    findings = blocking_output.get("findings", [])
+    if findings:
+        lines += ["### Blocking Findings", ""]
+        lines.append("| ID | Type | Action | Stop Condition |")
+        lines.append("|---|---|---|---|")
+        for f in findings:
+            stop = f.get("stop_conditions", [])
+            stop_str = stop[0] if stop else ""
+            lines.append(
+                f"| `{f['drift_id']}` "
+                f"| `{f['drift_type']}` "
+                f"| {f['required_action']} "
+                f"| {stop_str} |"
+            )
+        lines.append("")
+
+    return "\n".join(lines)

--- a/tools/surrealdb/scope_drift_cli.py
+++ b/tools/surrealdb/scope_drift_cli.py
@@ -33,6 +33,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from tools.surrealdb.scope_drift_blocking import build_blocking_output, render_blocking_markdown
 from tools.surrealdb.scope_drift_firewall import (
     DRIFT_TYPES,
     GUARDRAILS,
@@ -260,6 +261,11 @@ def _render_markdown(payload: dict[str, Any]) -> str:
             lines.append(f"- {r}")
         lines.append("")
 
+    # Blocking output section (Wave 17-D — report command only)
+    blocking_output = payload.get("blocking_output")
+    if blocking_output:
+        lines.append(render_blocking_markdown(blocking_output))
+
     # Guardrails — always present
     guardrails = payload.get("guardrails", list(GUARDRAILS))
     lines += ["## Guardrails", ""]
@@ -360,6 +366,8 @@ def handle_report_scope_drift(
         "recommended_next_reads": agg_reads,
         "guardrails": list(result.guardrails),
     }
+    if result.blocking_count > 0:
+        payload["blocking_output"] = build_blocking_output(result)
     return payload, EXIT_OK
 
 


### PR DESCRIPTION
## Summary
Implements Wave 17-D / #2166 Blocking Scope Drift Output.

## Scope
- Adds standardized blocking-output format for scope drift findings.
- Adds operator actions, affected artifacts, recommended next reads, guardrails and anti-actions.
- Integrates blocking output with existing service/CLI/MCP surfaces where needed.
- Adds deterministic unit coverage (29 tests).

## Files
- `tools/surrealdb/scope_drift_blocking.py` — new helper module (main deliverable)
- `tests/unit/surrealdb/test_scope_drift_blocking.py` — 29 unit tests
- `tools/surrealdb/scope_drift_cli.py` — additive: `blocking_output` key in `report-scope-drift` payload + Markdown section
- `tools/mcp/scope_drift_tools.py` — additive: `blocking_output` key in MCP response

## Blocking Output Schema
```json
{
  "status": "blocked_scope_drift",
  "blocking": true,
  "blocking_count": 2,
  "summary": "2 blocking scope drift findings detected. Operator action required: stop. No auto-fix. No auto-write. Human-GO required for any write.",
  "operator_action": "stop",
  "affected_artifacts": ["services/cdb_risk/service.py"],
  "recommended_next_reads": ["AGENTS.md", "docs/runbooks/CONTROL_REGISTER.md"],
  "guardrails": ["Scope Drift Detection is signal, not authorization.", "..."],
  "findings": [...],
  "anti_actions": ["no_auto_fix", "no_auto_write", "no_auto_merge", "no_auto_close", "no_live_go", "no_lr_go", "no_echtgeld_go", "no_runtime_enable"]
}
```

## Safety
- No DB access.
- No network access.
- No GitHub access from code.
- No file writes.
- No auto-fixes.
- No auto-writes.
- No runtime changes.
- No Live-Readiness / Echtgeld scope.

## Validation
- `python -m pytest -v -m unit tests/unit/surrealdb/test_scope_drift_blocking.py` → 29 passed
- `python -m pytest -v -m unit tests/unit/surrealdb/test_scope_drift_firewall.py tests/unit/surrealdb/test_scope_drift_cli.py tests/unit/surrealdb/test_scope_drift_blocking.py tests/unit/tools/mcp/test_scope_drift_tools.py` → 142 passed
- `ruff check` → clean
- `git diff --check` → clean
- Safety grep on production module → clean

Closes #2166.