### PR TITLE
docs(surrealdb): add wave-17 scope drift runbook and completion gates

### DIFF
--- a/docs/surrealdb/context-wave17-completion-gates.md
+++ b/docs/surrealdb/context-wave17-completion-gates.md
@@ -1,0 +1,187 @@
+# Wave-17 Completion Gates
+
+**Status**: OPEN — awaiting PR merge (all child-issue gates satisfied)  
+**Authority**: Issue #2169 / Wave-17 / Epic #1976  
+**Parent**: #2162
+
+This document defines and tracks the completion gates for Wave-17
+(Scope Drift Firewall Runtime v1).
+
+---
+
+## 1. Scope / Purpose
+
+Wave-17 delivers a complete, read-only Scope Drift Firewall runtime for the
+Context Intelligence Epic (#1976). The runtime consists of:
+
+- A deterministic scan service detecting 9 scope drift types
+- A CLI for local, read-only execution of scans and reports
+- An MCP tool (`cdb_context_scope_drift`) for agent access
+- A blocking output helper for standardised stop-and-explain responses
+- Test coverage across all four components via inline and file-backed fixtures
+- An operator/agent runbook
+
+Wave-17 completion does **not** constitute a Live-Readiness authorisation,
+an Echtgeld-Go, or any trading/runtime change. LR status remains **NO-GO**.
+
+---
+
+## 2. Wave-17 Completion Verdict
+
+| Criterion | Status |
+|-----------|--------|
+| All child issues #2163–#2168 delivered and CLOSED | **PASS** |
+| All PRs #2376–#2379 merged to `main` | **PASS** |
+| #2169 (this gate) open until this PR merges | **EXPECTED** |
+| #2162 (parent anchor) remains open until #2169 PR merges | **CORRECT** |
+| All artifacts read-only, fail-closed, no writes | **PASS** |
+| All 9 drift types detected and covered by tests | **PASS** |
+| `ANTI_ACTIONS` explicitly defined in blocking output | **PASS** |
+| LR status unchanged at NO-GO | **PASS** |
+| No Echtgeld scope, no Live-Go, no runtime change | **PASS** |
+| No auto-fix, no auto-write in any component | **PASS** |
+
+**Wave-17 is COMPLETE** — all child delivery gates satisfied.
+
+**#2169 is ready for closure** pending human review and merge of this PR.  
+**#2162 must remain open** until this PR is merged; it may be closed separately thereafter.
+
+---
+
+## 3. Evidence Matrix
+
+| Issue | Title | PR | Merge-SHA | Delivered Artifacts | Validation Evidence |
+|-------|-------|----|-----------|---------------------|---------------------|
+| #2163 | Implement scope drift firewall service v1 | #2376 | `4aeb24c` | `tools/surrealdb/scope_drift_firewall.py` (876 lines) · `tests/unit/surrealdb/test_scope_drift_firewall.py` (922 lines, 60+ tests) · `tests/fixtures/surrealdb/scope_drift/sample_bundle.json` | 60+ unit tests PASS · ruff clean · all 9 drift types covered (trigger + no-trigger) · deterministic SHA256 IDs · no wall-clock calls · no writes |
+| #2164 | Add scope drift check CLI | #2377 | `bd2531f` | `tools/surrealdb/scope_drift_cli.py` (488 lines) · `tests/unit/surrealdb/test_scope_drift_cli.py` (416 lines, 30+ tests) | CLI unit tests PASS · all 3 subcommands covered · JSON/Markdown output validated · exit-code contract verified · `--fail-on-blocking` tested |
+| #2165 | Add scope drift MCP tool | #2378 | `b5a2e78` | `tools/mcp/scope_drift_tools.py` (284 lines) · `tools/mcp/registry.py` (updated) · `tools/mcp/context_bridge.py` (updated) · `tools/mcp/permission_guard.py` (updated) · `tests/unit/tools/mcp/test_scope_drift_tools.py` (509 lines, 40+ tests) | MCP unit tests PASS · registry entry confirmed (`cdb_context_scope_drift`, `read_only=True`) · permission guard exemption confirmed · bridge routing verified · `metadata.read_only=True` in every response |
+| #2166 | Blocking scope drift output | #2379 | `8f9a89e` | `tools/surrealdb/scope_drift_blocking.py` (265 lines) · `tests/unit/surrealdb/test_scope_drift_blocking.py` (549 lines, 29 tests) · additive patches: `scope_drift_cli.py`, `scope_drift_tools.py` | 29 unit tests PASS (142 total across all Wave-17 files) · all 8 `ANTI_ACTIONS` present · operator_action priority verified · `blocking_output` integrated in CLI `report-scope-drift` and MCP response · ruff clean |
+| #2167 | Add scope drift fixtures and tests | via #2376–#2379 | — | `tests/unit/surrealdb/test_scope_drift_firewall.py` · `tests/unit/surrealdb/test_scope_drift_cli.py` · `tests/unit/surrealdb/test_scope_drift_blocking.py` · `tests/unit/tools/mcp/test_scope_drift_tools.py` · `tests/fixtures/surrealdb/scope_drift/sample_bundle.json` | All 9 drift types covered (trigger + no-trigger) · Blocking output tests · fixture deterministic · no secrets · no SurrealDB runtime · 142+ total unit tests PASS |
+| #2168 | Add scope drift runbook | this PR | — | `docs/surrealdb/scope-drift-runbook.md` | Runbook covers: scope check execution (CLI + MCP), finding field reference, `allowed_scope` vs `observed_scope` reading, `blocked_scope_drift` interpretation, runtime and trading surface recognition, Human-GO escalation, stop conditions, anti-actions, guardrails |
+| #2169 | Define wave-17 completion gates | this PR | — | `docs/surrealdb/context-wave17-completion-gates.md` (this document) | Gate criteria verified against live GitHub state |
+
+---
+
+## 4. Child-Issue Status
+
+| Issue | Title | State |
+|-------|-------|-------|
+| #2163 | [SURREALDB][CONTEXT][SCOPE-FIREWALL] Implement scope drift firewall service v1 | **CLOSED** (PR #2376) |
+| #2164 | [SURREALDB][CONTEXT][SCOPE-CLI] Add scope drift check CLI | **CLOSED** (PR #2377) |
+| #2165 | [SURREALDB][CONTEXT][SCOPE-MCP] Add scope drift MCP tool | **CLOSED** (PR #2378) |
+| #2166 | [SURREALDB][CONTEXT][SCOPE-BLOCKING] Blocking scope drift output | **CLOSED** (PR #2379) |
+| #2167 | [SURREALDB][CONTEXT][SCOPE-TESTS] Add scope drift fixtures and tests | **CLOSED** (via #2376–#2379) |
+| #2168 | [SURREALDB][CONTEXT][SCOPE-RUNBOOK] Add scope drift runbook | **OPEN** — closes when this PR merges |
+| #2169 | [SURREALDB][CONTEXT][VALIDATION] Define wave-17 completion gates | **OPEN** — closes when this PR merges |
+| #2162 | [SURREALDB][CONTEXT][WAVE-17] Scope drift firewall runtime v1 | **OPEN** — closes separately after #2169 PR merges |
+
+---
+
+## 5. Artifact Inventory
+
+### 5.1 Production Tools
+
+| File | Description | Merged via |
+|------|-------------|------------|
+| `tools/surrealdb/scope_drift_firewall.py` | Scope Drift Firewall Service v1 — 9 detection rules, deterministic SHA256[:16] IDs, `scan_scope_drift_v1()` public API, `GUARDRAILS` tuple | PR #2376 (`4aeb24c`) |
+| `tools/surrealdb/scope_drift_cli.py` | Scope Drift CLI — `scan-scope-drift`, `show-scope-drift`, `report-scope-drift`; JSON/Markdown output; exit codes 0/1/2/3; blocking output integration | PR #2377 (`bd2531f`), additive: PR #2379 (`8f9a89e`) |
+| `tools/mcp/scope_drift_tools.py` | MCP adapter — `cdb_context_scope_drift` tool; scope-filtered, read-only, fail-closed; `metadata.read_only=True` on every response | PR #2378 (`b5a2e78`), additive: PR #2379 (`8f9a89e`) |
+| `tools/surrealdb/scope_drift_blocking.py` | Blocking Output Helper — standardised blocking response; `ANTI_ACTIONS` tuple; `build_blocking_output()`, `render_blocking_markdown()` | PR #2379 (`8f9a89e`) |
+
+### 5.2 MCP Registry Updates
+
+| File | Change | Merged via |
+|------|--------|------------|
+| `tools/mcp/registry.py` | Wave-17 `cdb_context_scope_drift` entry added (`read_only=True`) | PR #2378 (`b5a2e78`) |
+| `tools/mcp/context_bridge.py` | Routing for Wave-17 scope drift tool (`cdb_context_scope_drift_handler`) | PR #2378 (`b5a2e78`) |
+| `tools/mcp/permission_guard.py` | `cdb_context_scope_drift` added to `INPUT_SCAN_EXEMPT_TOOLS` | PR #2378 (`b5a2e78`) |
+
+### 5.3 Tests
+
+| File | Tests | Merged via |
+|------|-------|------------|
+| `tests/unit/surrealdb/test_scope_drift_firewall.py` | 60+ unit tests — all 9 drift types, determinism, guardrails, blocking aggregation, P1/P2 hardening, Thread A/B hardening, wall-clock guardrail | PR #2376 (`4aeb24c`) |
+| `tests/unit/surrealdb/test_scope_drift_cli.py` | 30+ unit tests — all 3 subcommands, exit codes, JSON/Markdown, `--fail-on-blocking`, determinism, error cases, no-write guardrail | PR #2377 (`bd2531f`) |
+| `tests/unit/tools/mcp/test_scope_drift_tools.py` | 40+ unit tests — registry (read_only, name), bridge execution, permission guard exempt, clean/blocking bundles, all filter parameters, error handling, guardrails, `blocking_output` | PR #2378 (`b5a2e78`) |
+| `tests/unit/surrealdb/test_scope_drift_blocking.py` | 29 unit tests — full schema, blocking=False when clean, operator_action priority, artifacts sorted/deduped, reads stable/deduped, all 8 anti_actions, all 5 guardrails, Markdown sections, CLI/MCP integration | PR #2379 (`8f9a89e`) |
+
+### 5.4 Fixtures
+
+| File | Description | Merged via |
+|------|-------------|------------|
+| `tests/fixtures/surrealdb/scope_drift/sample_bundle.json` | Deterministic sample bundle triggering exactly 3 drift types: `path_out_of_scope`, `runtime_surface_touched`, `missing_human_go` | PR #2376 (`4aeb24c`) |
+
+### 5.5 Documentation
+
+| File | Description | Merged via |
+|------|-------------|------------|
+| `docs/surrealdb/scope-drift-runbook.md` | Operator/agent runbook: scope check execution, finding field reference, allowed vs observed scope, blocking drift interpretation, runtime/trading surface recognition, Human-GO escalation, stop conditions, anti-actions, guardrails | this PR |
+| `docs/surrealdb/context-wave17-completion-gates.md` | This document | this PR |
+
+---
+
+## 6. Blocking Response Contract
+
+The blocking output schema (`scope-drift-blocking/v1`) is:
+
+```json
+{
+  "status": "blocked_scope_drift",
+  "blocking": true,
+  "blocking_count": 2,
+  "summary": "2 blocking scope drift findings detected. Operator action required: stop. No auto-fix. No auto-write. Human-GO required for any write.",
+  "operator_action": "stop",
+  "affected_artifacts": ["<target_ref>"],
+  "recommended_next_reads": ["AGENTS.md", "docs/runbooks/CONTROL_REGISTER.md"],
+  "guardrails": [
+    "Scope Drift Detection is signal, not authorization.",
+    "No auto-fix. No auto-write.",
+    "No Live-Readiness-Go.",
+    "No Echtgeld-Go.",
+    "Human-GO required for any write after blocking scope drift."
+  ],
+  "findings": [],
+  "anti_actions": [
+    "no_auto_fix", "no_auto_write", "no_auto_merge", "no_auto_close",
+    "no_live_go", "no_lr_go", "no_echtgeld_go", "no_runtime_enable"
+  ]
+}
+```
+
+`build_blocking_output` is always safe to call. When no blocking findings exist,
+`blocking=false` and `findings=[]` are returned.
+
+---
+
+## 7. Human-GO Escalation Guidance
+
+Human-GO is required when **any** of the following conditions are true:
+
+- `overall_status == "blocked_scope_drift"`
+- Any finding has `human_go_required: true`
+- `drift_type` is `unauthorized_write_intent` or `missing_human_go`
+- Any finding has `severity == "blocking"`
+
+**Escalation procedure**: Stop all writes → read blocking output and
+`affected_artifacts` → read canonical governance files (AGENTS.md,
+CONTROL_REGISTER.md, LR-AUDIT-STATUS) → produce dry-run preview → wait for
+explicit Human-GO → do not self-approve.
+
+**Board stage `trade-capable` is not a Human-GO**. It is orthogonal to LR and
+does not authorise writes, merges, or deployments.
+
+---
+
+## 8. Anti-Criteria (What Wave-17 is NOT)
+
+| Anti-criterion | Confirmed |
+|----------------|-----------|
+| No auto-fix | ✅ confirmed — `no_auto_fix` in ANTI_ACTIONS |
+| No auto-write | ✅ confirmed — `no_auto_write` in ANTI_ACTIONS |
+| No Repo-/GitHub-/Runtime-Write from any tool | ✅ confirmed |
+| No Live-Readiness-Go | ✅ confirmed — `no_live_go` + `no_lr_go` in ANTI_ACTIONS |
+| No Echtgeld-Go | ✅ confirmed — `no_echtgeld_go` in ANTI_ACTIONS |
+| No runtime enable | ✅ confirmed — `no_runtime_enable` in ANTI_ACTIONS |
+| No SurrealDB SDK usage in scope drift tools | ✅ confirmed |
+| No direct network access | ✅ confirmed |
+| No direct DB access | ✅ confirmed |

--- a/docs/surrealdb/scope-drift-runbook.md
+++ b/docs/surrealdb/scope-drift-runbook.md
@@ -1,0 +1,413 @@
+# Scope Drift Firewall Runbook
+
+**Status**: Operational  
+**Authority**: Issue #2168 / Wave-17 / Epic #1976  
+**Parent**: #2162
+
+This runbook describes how operators and agents use the Scope Drift Firewall
+(Wave-17) to scan, read, interpret, and act on scope drift findings.
+
+**LR-Status: NO-GO** — this runbook covers read-only detection tooling only.
+No live capital, no Echtgeld-Go, no trading implication.
+
+---
+
+## 1. Purpose and Scope
+
+The Scope Drift Firewall detects when an agent or operator's current work
+deviates from a defined, authorised scope. Detected findings cover nine
+drift types:
+
+| Drift type | Meaning |
+|------------|---------|
+| `path_out_of_scope` | A file or directory path is outside the allowed scope |
+| `domain_out_of_scope` | A domain or conceptual area is outside the allowed scope |
+| `issue_out_of_scope` | A referenced GitHub issue is outside the issue scope |
+| `parked_topic_activated` | A parked or restricted topic has been activated without GO |
+| `runtime_surface_touched` | A runtime or service surface has been touched |
+| `trading_surface_touched` | A trading, risk, or execution surface has been touched |
+| `unexpected_dependency_expansion` | Dependency graph expanded beyond allowed scope |
+| `unauthorized_write_intent` | Write operation attempted without Human-GO token |
+| `missing_human_go` | A Human-GO gate is required but not present |
+
+**Detection is signal, not action authority.** No finding authorises any
+automated action, write, deployment, trade, or live-go.
+
+---
+
+## 2. Non-Goals
+
+The following are explicitly out of scope for this system:
+
+- **No auto-fix** — the firewall detects and reports; it never corrects automatically.
+- **No auto-write** — no DB, filesystem, GitHub, or runtime write from any of these tools.
+- **No auto-merge** — the firewall does not open, approve, or merge pull requests.
+- **No auto-close** — the firewall does not close issues or milestones.
+- **No Live-Readiness-Go** — scope drift findings do not change the LR verdict.
+  The current verdict remains **NO-GO**.
+- **No Echtgeld-Go** — scope drift findings do not authorise real capital operations.
+- **No runtime enable** — the firewall does not enable, start, or configure any
+  runtime service or container.
+- **No CI gate on its own** — `--fail-on-blocking` is available for operator-controlled
+  CI integration but is not automatically enforced in any active workflow.
+
+---
+
+## 3. Tool Overview
+
+### 3.1 Scan Service — `scan_scope_drift_v1`
+
+- **Module**: `tools/surrealdb/scope_drift_firewall.py`
+- **Schema version**: `scope-drift-firewall/v1`
+- **API**: `scan_scope_drift_v1(bundle, as_of=None) → ScopeDriftScanResult`
+- **Read-only**. No DB access. No network. No file output. No writes.
+- **Deterministic**: SHA256[:16]-based `drift_id` generation, clock via
+  `core.utils.clock.utcnow` (no direct wall-clock calls).
+- **Input**: a `Mapping[str, Any]` bundle with scope context and work items.
+- **Output**: `ScopeDriftScanResult` containing `findings`, `blocking_count`,
+  `overall_status`, `severity_summary`, and `guardrails`.
+
+### 3.2 CLI — `scope_drift_cli.py`
+
+- **Module**: `tools/surrealdb/scope_drift_cli.py`
+- **Invocation**: `python -m tools.surrealdb.scope_drift_cli`
+
+Three subcommands:
+
+| Command | Purpose |
+|---------|---------|
+| `scan-scope-drift` | Scan input bundle, output all scope drift findings |
+| `show-scope-drift` | Show a single finding by `--drift-id` |
+| `report-scope-drift` | Generate a structured summary report |
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success (no blocking findings, or `--fail-on-blocking` not set) |
+| `1` | Blocking findings present and `--fail-on-blocking` flag was set |
+| `2` | CLI or input/validation error |
+| `3` | `show-scope-drift`: `drift_id` not found in bundle |
+
+Output formats: `--format json` (default) or `--format markdown`.
+
+### 3.3 MCP Tool — `cdb_context_scope_drift`
+
+- **Handler**: `tools/mcp/scope_drift_tools.py`
+- **Tool name**: `cdb_context_scope_drift`
+- **Schema version**: `scope-drift-mcp/v1`
+- **Bundle-driven**: a `bundle` object must be supplied in the request — the tool
+  never reads from a database, filesystem, or network.
+- **Read-only**. No DB. No network. No GitHub calls.
+
+Supported filter parameters:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `bundle` | Input scan bundle (required) | — |
+| `severity` | Filter by severity: `info`, `warning`, `blocking` | all |
+| `scope_type` | Filter by drift type (any of the 9 types) | all |
+| `target_ref` | Filter by target artifact reference | all |
+| `blocking` | If `true`, return blocking findings only | `false` |
+| `limit` | Maximum findings returned | `100` (max `500`) |
+| `as_of` | Advisory ISO-8601 UTC timestamp | from bundle `meta` |
+
+### 3.4 Blocking Output Helper — `build_blocking_output`
+
+- **Module**: `tools/surrealdb/scope_drift_blocking.py`
+- **Schema version**: `scope-drift-blocking/v1`
+- **API**: `build_blocking_output(scan_result) → dict`
+- Always safe to call. Returns `blocking: false` and empty `findings` when
+  no blocking findings are present.
+- **Rendered in CLI** via `report-scope-drift` (when `blocking_count > 0`).
+- **Returned in MCP** under the `blocking_output` key (when `blocking_count > 0`).
+
+---
+
+## 4. How to Run a Scope Check
+
+### 4.1 Prepare a Bundle
+
+A bundle is a JSON object describing the current work scope. Minimum structure:
+
+```json
+{
+  "meta": {
+    "as_of": "2026-05-08T00:00:00+00:00",
+    "task_id": "task-example-001"
+  },
+  "scope": {
+    "task_scope": "Human-readable description of the allowed scope",
+    "allowed_issue_refs": ["#2162", "#2167", "#2168", "#2169"],
+    "allowed_paths": ["docs/surrealdb/", "tests/"],
+    "allowed_domains": ["surrealdb", "context-intelligence"],
+    "operation_mode": "write (code/docs)"
+  },
+  "work_items": [
+    {
+      "item_id": "work-item-001",
+      "description": "Create scope drift runbook",
+      "target_path": "docs/surrealdb/scope-drift-runbook.md",
+      "domain": "surrealdb",
+      "issue_ref": "#2168"
+    }
+  ]
+}
+```
+
+A deterministic fixture is available at:
+`tests/fixtures/surrealdb/scope_drift/sample_bundle.json`
+
+### 4.2 CLI Scan
+
+```bash
+# Full scan — JSON output (default)
+python -m tools.surrealdb.scope_drift_cli scan-scope-drift --bundle <path/to/bundle.json>
+
+# Full scan — Markdown output
+python -m tools.surrealdb.scope_drift_cli scan-scope-drift \
+    --bundle <path/to/bundle.json> \
+    --format markdown
+
+# Full scan with blocking exit code (for operator-controlled CI)
+python -m tools.surrealdb.scope_drift_cli scan-scope-drift \
+    --bundle <path/to/bundle.json> \
+    --fail-on-blocking
+
+# Structured report including blocking output section
+python -m tools.surrealdb.scope_drift_cli report-scope-drift \
+    --bundle <path/to/bundle.json> \
+    --format markdown
+
+# Show a specific finding by drift_id
+python -m tools.surrealdb.scope_drift_cli show-scope-drift \
+    --bundle <path/to/bundle.json> \
+    --drift-id <16-char-hex>
+```
+
+### 4.3 MCP Tool Call
+
+```python
+result = bridge.execute_tool("cdb_context_scope_drift", {
+    "bundle": bundle_dict,           # required
+    "severity": "blocking",          # optional filter
+    "blocking": True,                # optional: blocking findings only
+    "limit": 50                      # optional: cap findings returned
+})
+```
+
+The response includes `status`, `summary` (counts, severity breakdown),
+`findings`, `guardrails`, `scan_status`, `scanned_at`, and `blocking_output`
+(when blocking findings are present).
+
+---
+
+## 5. Reading a Finding
+
+Each `ScopeDriftFinding` has the following fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `drift_id` | str | Deterministic SHA256[:16] identifier |
+| `drift_type` | str | One of the 9 drift types (see Section 1) |
+| `severity` | str | `info`, `warning`, or `blocking` |
+| `allowed_scope` | str | Human-readable description of what was allowed |
+| `observed_scope` | str | Human-readable description of what was observed |
+| `required_action` | str | `stop`, `review`, `split_scope`, or `request_go` |
+| `target_ref` | str | The artifact, path, or item that triggered the finding |
+| `human_go_required` | bool | Whether Human-GO is required before proceeding |
+| `detected_by` | str | Schema version string of the detecting component |
+| `detected_at` | str | ISO-8601 UTC timestamp |
+| `status` | str | `open`, `acknowledged`, `false_positive`, `accepted_risk`, `resolved` |
+| `metadata` | dict | Additional context (optional) |
+
+### 5.1 Reading `allowed_scope` vs `observed_scope`
+
+`allowed_scope` describes what the current task was authorised to touch. Compare it
+with `observed_scope` to understand the deviation:
+
+```
+allowed_scope: "docs/surrealdb/ and tests/"
+observed_scope: "services/risk/service.py"
+```
+
+This indicates the work item targeted a path outside the allowed scope. The
+`drift_type` `path_out_of_scope` confirms this. The `required_action` `stop`
+means the operator must halt and reassess before continuing.
+
+---
+
+## 6. Interpreting Drift Status
+
+### 6.1 `overall_status` Values
+
+| Status | Meaning | Required action |
+|--------|---------|-----------------|
+| `ok` | No scope drift findings | Continue within scope |
+| `blocked_scope_drift` | One or more blocking findings | **Stop. Do not proceed.** Request Human-GO if write intent. |
+
+Any `overall_status` of `blocked_scope_drift` is a hard stop signal.
+
+### 6.2 Severity Levels
+
+| Severity | Description | Default action |
+|----------|-------------|----------------|
+| `blocking` | Scope boundary crossed, write intent present, or Human-GO missing | **Stop** |
+| `warning` | Scope boundary approached; no confirmed violation | Review and narrow scope |
+| `info` | Informational note — scope is clear but adjacent context noted | Note and continue |
+
+Blocking findings must be resolved before any write, merge, or deployment.
+They do not resolve automatically.
+
+---
+
+## 7. Recognising Runtime and Trading Surfaces
+
+Two drift types specifically protect critical system surfaces:
+
+### 7.1 `runtime_surface_touched`
+
+Triggered when a work item targets a path or domain associated with runtime
+or service operation:
+
+- Surface type `runtime` or `service` in the work item
+- Paths under `services/`, `infrastructure/compose/`, `infrastructure/database/`,
+  `core/safety/`
+
+**Required action**: `stop`. Human-GO required before any write.
+
+### 7.2 `trading_surface_touched`
+
+Triggered when a work item targets a path or domain associated with trading,
+risk, or execution:
+
+- Surface type `trading` in the work item
+- Paths under `services/risk/` or `services/execution/`
+
+**Required action**: `stop`. Human-GO required before any write.
+Board stage `trade-capable` does **not** authorise this. LR verdict remains **NO-GO**.
+
+---
+
+## 8. Human-GO Escalation
+
+### 8.1 When Human-GO Is Required
+
+Human-GO is required whenever:
+
+- Any finding has `human_go_required: true`
+- `overall_status` is `blocked_scope_drift`
+- `drift_type` is `unauthorized_write_intent` or `missing_human_go`
+- Any blocking finding is present
+
+### 8.2 Escalation Procedure
+
+1. **Stop all writes** — do not commit, push, merge, or deploy.
+2. **Read the blocking output** — review `operator_action`, `affected_artifacts`,
+   and `recommended_next_reads` from `build_blocking_output`.
+3. **Read canonical governance files**:
+   - `AGENTS.md`
+   - `docs/runbooks/CONTROL_REGISTER.md`
+   - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+   - `knowledge/governance/CDB_AGENT_POLICY.md`
+4. **Produce a dry-run preview** — document proposed changes with full scope analysis.
+5. **Wait for explicit Human-GO** — the operator or human reviewer must issue
+   an explicit `GO IMPLEMENT` or equivalent authorisation.
+6. **Do not self-approve** — agents must not interpret a blocking drift finding
+   as permission to proceed after self-assessment.
+
+---
+
+## 9. Stop Conditions
+
+The following stop conditions apply when using the Scope Drift Firewall.
+Stop immediately if any of these are true:
+
+| Condition | Action |
+|-----------|--------|
+| `overall_status == "blocked_scope_drift"` | Stop. No write. No merge. No deploy. |
+| `drift_type == "runtime_surface_touched"` | Stop. Human-GO required. |
+| `drift_type == "trading_surface_touched"` | Stop. Human-GO required. LR NO-GO. |
+| `drift_type == "unauthorized_write_intent"` | Stop. Human-GO required. |
+| `drift_type == "missing_human_go"` | Stop. Obtain Human-GO first. |
+| `drift_type == "parked_topic_activated"` | Stop. Read governance canon. |
+| Any `severity == "blocking"` finding | Stop. Resolve before proceeding. |
+
+---
+
+## 10. Anti-Actions (Prohibited)
+
+The following actions are **explicitly prohibited** and must never be performed
+in response to a scope drift finding:
+
+| Anti-action | Description |
+|-------------|-------------|
+| `no_auto_fix` | Do not automatically fix the scope violation |
+| `no_auto_write` | Do not write to any file, DB, or GitHub resource |
+| `no_auto_merge` | Do not merge pull requests |
+| `no_auto_close` | Do not close issues or milestones |
+| `no_live_go` | Do not issue a Live-Readiness-Go |
+| `no_lr_go` | Do not change the LR verdict |
+| `no_echtgeld_go` | Do not authorise real capital operations |
+| `no_runtime_enable` | Do not start, enable, or configure runtime services |
+
+---
+
+## 11. Guardrails
+
+The following guardrails are embedded in every scan result and MCP response:
+
+1. Scope Drift Detection is signal, not authorization.
+2. No auto-fix. No auto-write.
+3. No Live-Readiness-Go.
+4. No Echtgeld-Go.
+5. Human-GO required for any write after blocking scope drift.
+
+---
+
+## 12. Troubleshooting
+
+| Symptom | Cause | Action |
+|---------|-------|--------|
+| `overall_status: ok` but work seems out of scope | Bundle may be missing work items or scope definition | Review bundle `scope.allowed_paths` and `work_items` |
+| All findings have `severity: info` | Scope boundaries are well-defined; items are within bounds | Proceed within scope |
+| `drift_type: path_out_of_scope` on expected path | `allowed_paths` list is too narrow | Expand `allowed_paths` with Human-GO if needed |
+| `drift_type: missing_human_go` on write operation | `operation_mode` contains `write` but no `human_go_token` in bundle | Add explicit `human_go_token` after obtaining Human-GO |
+| CLI exits with code `1` | `--fail-on-blocking` set and blocking findings present | Review and resolve blocking findings |
+| MCP returns `"unknown_tool"` | Tool not registered or wrong name | Confirm `cdb_context_scope_drift` is in registry |
+
+---
+
+## 13. References
+
+| Resource | Path |
+|----------|------|
+| Scope Drift Firewall Service | `tools/surrealdb/scope_drift_firewall.py` |
+| Scope Drift CLI | `tools/surrealdb/scope_drift_cli.py` |
+| Scope Drift Blocking Helper | `tools/surrealdb/scope_drift_blocking.py` |
+| MCP Scope Drift Tool | `tools/mcp/scope_drift_tools.py` |
+| MCP Registry | `tools/mcp/registry.py` |
+| Permission Guard | `tools/mcp/permission_guard.py` |
+| Context Bridge | `tools/mcp/context_bridge.py` |
+| Firewall Tests | `tests/unit/surrealdb/test_scope_drift_firewall.py` |
+| CLI Tests | `tests/unit/surrealdb/test_scope_drift_cli.py` |
+| Blocking Tests | `tests/unit/surrealdb/test_scope_drift_blocking.py` |
+| MCP Tests | `tests/unit/tools/mcp/test_scope_drift_tools.py` |
+| Sample Fixture | `tests/fixtures/surrealdb/scope_drift/sample_bundle.json` |
+| Wave-17 Completion Gates | `docs/surrealdb/context-wave17-completion-gates.md` |
+| Context Tool Contracts v1 | `docs/surrealdb/context-tool-contracts-v1.md` |
+| MCP Access Runbook | `docs/runbooks/surrealdb_context_mcp_access.md` |
+| Control Register | `docs/runbooks/CONTROL_REGISTER.md` |
+
+---
+
+## 14. Clearances and Verdict
+
+| Item | Status |
+|------|--------|
+| LR Verdict | **NO-GO** (unchanged) |
+| Board Stage | `trade-capable` (orthogonal) |
+| Echtgeld | Not authorized |
+| Write Path | Disabled (no auto-write, no auto-fix) |
+| Runtime/MCP Live | Not authorized |
+| Auto-Fix | Not authorized |


### PR DESCRIPTION
## Summary

Adds the Wave 17 closure documentation for SurrealDB Context Intelligence Scope Drift Firewall.

This PR adds:
- `docs/surrealdb/scope-drift-runbook.md`
- `docs/surrealdb/context-wave17-completion-gates.md`

## Scope

Closes #2168  
Closes #2169  
Refs #2162  
Refs #2167  

## Details

### #2168 Scope Drift Runbook

Adds an operator/agent-readable runbook covering:
- scope check execution via CLI and MCP
- `allowed_scope` vs `observed_scope`
- blocked scope drift interpretation
- runtime/trading surface recognition
- Human-GO escalation procedure
- stop conditions
- anti-actions
- guardrails

### #2169 Wave-17 Completion Gates

Adds a Wave-17 completion gates document covering:
- Wave-17 verdict table
- evidence matrix for PRs #2376–#2379
- child-issue status table
- artifact inventory
- blocking response contract
- Human-GO escalation guidance
- anti-criteria confirmation

## Validation

- `git status -sb`
- `git diff --stat HEAD~1`
- grep guardrail checks for: scope drift, `allowed_scope`, `observed_scope`, Human-GO, Live-Go, Echtgeld, Auto-Fix, Runtime

## Non-goals / Guardrails

- No code changes
- No runtime changes
- No SurrealDB production activation
- No Wave-18 work
- No Quality Scoring work
- No Architect Signals work
- No Auto-Fix
- No Live-Readiness upgrade
- No Echtgeld-Go
- Live-Readiness remains NO-GO
