### PR TITLE
feat(surrealdb): add wave-18 quality scoring and architect signals

### DIFF
--- a/docs/surrealdb/context-wave18-completion-gates.md
+++ b/docs/surrealdb/context-wave18-completion-gates.md
@@ -1,0 +1,123 @@
+# Wave-18 Completion Gates
+
+**Wave 18 — Knowledge Quality Scoring & Architect Signals**  
+Anchor Issue: #2170  
+Status: `draft` → update to `complete` when all gates pass  
+Epic: #1976
+
+---
+
+## Completion Gate Checklist
+
+### Gate 1: Core Services Implemented
+
+- [x] `tools/surrealdb/quality_scoring.py` — Knowledge Quality Scoring Service v1 (#2171)
+  - 8 scoring dimensions with weighted aggregation
+  - Grade bands: blocking/watch/weak/good
+  - Blocking downgrade rule (any blocking dim → overall capped at watch)
+  - GUARDRAILS embedded in every result
+  - `score_knowledge_quality_v1()` public API
+
+- [x] `tools/surrealdb/architect_signals.py` — Architect Signal Service v1 (#2174)
+  - 11 signal types
+  - Severity levels: info / watch / blocking
+  - Pure function, no auto-issue creation
+  - `accepted_risk` / `false_positive` modellable per finding
+  - `scan_architect_signals_v1()` public API
+
+### Gate 2: CLI Implementations
+
+- [x] `tools/surrealdb/quality_scoring_cli.py` — Quality Scoring CLI (#2172)
+  - `score-knowledge` subcommand
+  - `show-score --dimension` subcommand
+  - `report-quality` subcommand
+  - Exit codes: 0 (ok), 1 (weak), 2 (error), 3 (not found)
+  - `--fail-on-weak` flag
+  - `--format json|markdown`
+
+### Gate 3: MCP Adapters
+
+- [x] `tools/mcp/quality_scoring_tools.py` — Quality Score MCP tool (#2173)
+  - Tool name: `cdb_context_quality_score`
+  - Bundle-driven, read-only, fail-closed
+  - `metadata.read_only = True` on every response
+
+- [x] `tools/mcp/architect_signal_tools.py` — Architect Signals MCP tool (#2175)
+  - Tool name: `cdb_context_architect_signals`
+  - Bundle-driven, read-only, fail-closed
+  - `metadata.read_only = True` on every response
+
+### Gate 4: Registry & Bridge Integration
+
+- [x] `tools/mcp/permission_guard.py` updated
+  - `cdb_context_quality_score` in `INPUT_SCAN_EXEMPT_TOOLS`
+  - `cdb_context_architect_signals` in `INPUT_SCAN_EXEMPT_TOOLS`
+
+- [x] `tools/mcp/registry.py` updated
+  - `cdb_context_quality_score` registered with `read_only=True`
+  - `cdb_context_architect_signals` registered with `read_only=True`
+
+- [x] `tools/mcp/context_bridge.py` updated
+  - `cdb_context_quality_score_handler` defined and routed
+  - `cdb_context_architect_signals_handler` defined and routed
+  - Wave-18 handler map registered in `ContextBridge.__init__`
+
+### Gate 5: Tests & Fixtures
+
+- [x] `tests/unit/surrealdb/test_quality_scoring.py` (#2176)
+  - All 8 dimensions produce scores
+  - Grade threshold tests
+  - Blocking downgrade rule
+  - Empty bundle returns blocking coverage
+  - Clean bundle returns good overall
+  - Determinism tests
+  - Error case tests
+
+- [x] `tests/unit/tools/mcp/test_quality_scoring_tools.py` (#2176)
+  - Permission guard exempt test
+  - Registry read-only test
+  - Bridge routing test
+  - Missing/invalid bundle tests
+  - Dimension / grade / limit filters
+  - Guardrails in response
+
+- [x] `tests/fixtures/surrealdb/quality_scoring/sample_bundle.json` (#2176)
+
+### Gate 6: Documentation
+
+- [x] `docs/surrealdb/quality-scoring-architect-signals-runbook.md` (#2177)
+  - Score dimensions reference
+  - Grade bands reference
+  - CLI usage guide
+  - MCP tool usage guide
+  - Bundle format reference
+  - Human escalation guide
+  - Guardrails section
+
+- [x] `docs/surrealdb/context-wave18-completion-gates.md` (#2178) — this file
+
+---
+
+## Open Issues to Close
+
+When all gates above are checked and PRs are merged, close in this order:
+
+1. #2171 — Quality Scoring Service v1
+2. #2172 — Quality Scoring CLI
+3. #2173 — Quality Score MCP tool
+4. #2174 — Architect Signal Service v1
+5. #2175 — Architect Signals MCP tool
+6. #2176 — Tests & Fixtures
+7. #2177 — Runbook
+8. #2178 — Completion Gates (this issue)
+9. #2170 — Wave-18 anchor (after all children closed)
+
+---
+
+## Governance Notes
+
+- LR Status remains `NO-GO` for live trading.
+- Board Stage `trade-capable` (ratified 2026-04-08) is orthogonal to LR NO-GO.
+- No live capital, no Grafana gate, no strategy validation implied by Wave-18 completion.
+- Quality Scoring and Architect Signals are **informational services** only.
+- Human-GO is always required before any blocking signal leads to writes or capital changes.

--- a/docs/surrealdb/quality-scoring-architect-signals-runbook.md
+++ b/docs/surrealdb/quality-scoring-architect-signals-runbook.md
@@ -1,0 +1,323 @@
+# Quality Scoring & Architect Signals — Runbook
+
+**Wave 18 — Knowledge Quality Scoring & Architect Signals**  
+Issues: #2171 #2172 #2173 #2174 #2175 #2176 #2177  
+Parent: #2170 (Wave-18 anchor) · Epic: #1976
+
+---
+
+## 1. Overview
+
+Wave 18 introduces two new read-only services to the SurrealDB Context Intelligence layer:
+
+| Service | Purpose |
+|---|---|
+| **Knowledge Quality Scoring** (`quality_scoring.py`) | Score context bundles across 8 quality dimensions |
+| **Architect Signals** (`architect_signals.py`) | Detect structural architecture signals from bundles |
+
+Both services are:
+- **Pure functions** — no DB access, no network, no SurrealDB SDK
+- **Bundle-driven** — operate on in-memory JSON bundles only
+- **Fail-closed** — missing/invalid input returns an error, never reads from DB
+- **Read-only** — signal is recommendation, not authorization
+- **No live-go** — LR Status remains `NO-GO` for live trading
+
+---
+
+## 2. Quality Scoring
+
+### 2.1 Score Dimensions
+
+| Dimension | What it measures |
+|---|---|
+| `coverage_score` | Fraction of sources with documentation AND tests |
+| `freshness_score` | Currency of sources and decisions (stale findings, superseded decisions) |
+| `evidence_score` | Strength and freshness of evidence items |
+| `contradiction_score` | Inverse: proportion of open, unresolved contradictions |
+| `dependency_confidence_score` | Confidence of dependency graph edges |
+| `memory_trust_score` | Trust level of memory items |
+| `decision_validity_score` | Fraction of decisions that are current (not superseded/invalidated) |
+| `scope_risk_score` | Inverse: proportion of open scope drift findings |
+
+### 2.2 Grade Bands
+
+| Grade | Score Range | Meaning |
+|---|---|---|
+| `blocking` | 0.00 – 0.30 | Critical quality gap. Human-GO required before writes. |
+| `watch` | 0.30 – 0.50 | Significant concerns. Review before acting. |
+| `weak` | 0.50 – 0.70 | Below target. Improvement recommended. |
+| `good` | 0.70 – 1.00 | Acceptable quality. Continue with normal process. |
+
+**Blocking downgrade rule**: If any single dimension is `blocking`, the overall grade is capped at `watch` regardless of other dimension scores.
+
+### 2.3 CLI Usage
+
+```bash
+# Score a bundle from file
+python -m tools.surrealdb.quality_scoring_cli score-knowledge --input bundle.json
+
+# Score and fail (exit code 1) if grade is weak or blocking
+python -m tools.surrealdb.quality_scoring_cli score-knowledge --input bundle.json --fail-on-weak
+
+# Show a single dimension score
+python -m tools.surrealdb.quality_scoring_cli show-score --input bundle.json --dimension coverage_score
+
+# Full quality report in Markdown
+python -m tools.surrealdb.quality_scoring_cli report-quality --input bundle.json --format markdown
+
+# JSON output
+python -m tools.surrealdb.quality_scoring_cli report-quality --input bundle.json --format json
+```
+
+**Exit codes:**
+
+| Code | Meaning |
+|---|---|
+| `0` | OK — all dimensions `good` or `weak` (or `--fail-on-weak` not set) |
+| `1` | WEAK — weak or blocking grade detected when `--fail-on-weak` is set |
+| `2` | ERROR — invalid input, unexpected error |
+| `3` | NOT FOUND — bundle file not found |
+
+### 2.4 MCP Tool: `cdb_context_quality_score`
+
+**Required parameters:**
+- `bundle` (dict): Quality scoring bundle
+
+**Optional parameters:**
+- `dimension` (str): Filter to a single dimension name
+- `min_grade` (str): Filter to dimensions at or below this grade (`blocking`/`watch`/`weak`/`good`)
+- `limit` (int): Maximum dimensions to return (default 100, max 500)
+- `as_of` (str): Advisory ISO-8601 UTC timestamp
+
+**Example call:**
+```json
+{
+  "tool": "cdb_context_quality_score",
+  "parameters": {
+    "bundle": { "meta": {"scope_id": "...", "level": "system"}, "sources": [...] },
+    "min_grade": "blocking"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "tool": "cdb_context_quality_score",
+  "schema_version": "quality-score-mcp/v1",
+  "status": "ok",
+  "scope_id": "...",
+  "level": "system",
+  "scored_at": "2026-05-06T12:00:00+00:00",
+  "overall_score": 0.82,
+  "overall_grade": "good",
+  "blocking_dimensions": [],
+  "watch_dimensions": [],
+  "recommended_next_reads": [],
+  "dimensions": [...],
+  "guardrails": [...],
+  "metadata": {"source": "in_memory", "read_only": true}
+}
+```
+
+---
+
+## 3. Architect Signals
+
+### 3.1 Signal Types
+
+| Signal Type | Severity | Triggered when |
+|---|---|---|
+| `stale_area` | `watch` | ≥ 2 open stale findings on the same path |
+| `weakly_evidenced_decision` | `watch` | Decision has no strong/moderate evidence refs |
+| `underdocumented_surface` | `watch` | Sources lack documentation |
+| `undertested_surface` | `watch` | Sources lack tests |
+| `high_dependency_risk` | `watch` | ≥ 50% of dependency edges have low/unknown confidence |
+| `contradiction_hotspot` | `watch`/`blocking` | ≥ 2 open contradictions on same path (blocking if ≥ 4) |
+| `scope_drift_hotspot` | `blocking` | ≥ 2 open scope drift findings on same path |
+| `repeated_agent_confusion` | `watch` | Same path has both stale and contradiction findings |
+| `redundant_docs` | `info` | Documentation sources outnumber code sources (heuristic) |
+| `missing_owner` | `info` | Sources without owner/team/author metadata |
+| `fragile_context_path` | `blocking` | Path appears in stale + contradiction + scope drift findings |
+
+### 3.2 Severity Levels
+
+| Severity | Action |
+|---|---|
+| `info` | Informational. No immediate action required. |
+| `watch` | Review recommended before proceeding. |
+| `blocking` | Stop writes. Human-GO required before action. |
+
+### 3.3 MCP Tool: `cdb_context_architect_signals`
+
+**Required parameters:**
+- `bundle` (dict): Context bundle
+
+**Optional parameters:**
+- `signal_type` (str): Filter to a single signal type
+- `min_severity` (str): Filter by minimum severity (`info`/`watch`/`blocking`)
+- `limit` (int): Maximum signals to return (default 100, max 500)
+- `as_of` (str): Advisory ISO-8601 UTC timestamp
+
+**Example call:**
+```json
+{
+  "tool": "cdb_context_architect_signals",
+  "parameters": {
+    "bundle": { "meta": {"scope_id": "...", "level": "system"}, "sources": [...] },
+    "min_severity": "blocking"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "tool": "cdb_context_architect_signals",
+  "schema_version": "architect-signals-mcp/v1",
+  "status": "ok",
+  "scope_id": "...",
+  "scanned_at": "2026-05-06T12:00:00+00:00",
+  "total_signals": 3,
+  "blocking_count": 1,
+  "watch_count": 2,
+  "signals": [
+    {
+      "signal_id": "abc123def456",
+      "signal_type": "fragile_context_path",
+      "severity": "blocking",
+      "title": "1 path(s) have stale + contradiction + scope drift findings",
+      "explanation": "...",
+      "affected_paths": ["docs/operations/runbook.md"],
+      "evidence_refs": [],
+      "recommended_action": "Do not proceed with writes. Human-GO required.",
+      "status": "open",
+      "detected_by": "architect-signals/v1",
+      "detected_at": "2026-05-06T12:00:00+00:00"
+    }
+  ],
+  "guardrails": [...],
+  "metadata": {"source": "in_memory", "read_only": true}
+}
+```
+
+---
+
+## 4. Bundle Format Reference
+
+Both tools share the same bundle format:
+
+```json
+{
+  "meta": {
+    "scope_id": "unique-scope-id",
+    "level": "artifact | domain | issue | system"
+  },
+  "sources": [
+    {
+      "source_path": "core/domain/models.py",
+      "has_documentation": true,
+      "has_tests": true,
+      "status": "current",
+      "file_type": "python",
+      "owner": "trading-core"
+    }
+  ],
+  "decisions": [
+    {
+      "decision_id": "dec-001",
+      "status": "current | superseded | invalidated",
+      "evidence_refs": ["ev-001"]
+    }
+  ],
+  "evidence_items": [
+    {
+      "evidence_id": "ev-001",
+      "strength": "strong | moderate | weak | none",
+      "expired": false
+    }
+  ],
+  "contradiction_findings": [
+    {
+      "contradiction_id": "c-001",
+      "severity": "blocking | warning | info",
+      "status": "open | resolved | false_positive | accepted_risk",
+      "source_path": "docs/example.md"
+    }
+  ],
+  "stale_findings": [
+    {
+      "stale_id": "s-001",
+      "status": "stale | refreshed | accepted_risk | false_positive",
+      "source_path": "docs/example.md",
+      "reason": "Not reviewed in 60+ days"
+    }
+  ],
+  "dependency_edges": [
+    {
+      "edge_id": "edge-001",
+      "confidence": "high | medium | low | unknown",
+      "source": "core/risk",
+      "target": "core/domain"
+    }
+  ],
+  "memory_items": [
+    {
+      "memory_id": "mem-001",
+      "trust_level": "strong | acceptable | weak | blocked"
+    }
+  ],
+  "scope_drift_findings": [
+    {
+      "drift_id": "drift-001",
+      "severity": "blocking | warning | info",
+      "status": "open | false_positive | accepted_risk",
+      "source_path": "services/execution/service.py"
+    }
+  ]
+}
+```
+
+---
+
+## 5. Human Escalation Guide
+
+| Condition | Required Action |
+|---|---|
+| `overall_grade == blocking` | Stop. Human-GO required before any write. |
+| `fragile_context_path` signal detected | Stop writes to affected paths. Human-GO. |
+| `scope_drift_hotspot` signal detected | Stop writes to affected area. Human-GO. |
+| `contradiction_hotspot` with severity `blocking` | Resolve contradictions before proceeding. Human-GO. |
+| Any signal `status == open` with `severity == blocking` | Escalate to human reviewer. |
+
+**Accepted Risk Modelling:**  
+Any finding or signal can be modelled as `accepted_risk` or `false_positive` by updating its `status` in the bundle before re-scoring. This does not bypass guardrails — it records the human decision to accept the risk.
+
+---
+
+## 6. Guardrails (All tools enforce these)
+
+1. Quality Score is signal, not authorization.
+2. Architect Signal is recommendation, not command.
+3. No automatic issue creation.
+4. No auto-fix. No auto-write.
+5. No Live-Readiness-Go.
+6. No Echtgeld-Go.
+7. Human-GO required for any action after blocking score or signal.
+
+---
+
+## 7. File Locations
+
+| File | Purpose |
+|---|---|
+| `tools/surrealdb/quality_scoring.py` | Quality Scoring Service v1 |
+| `tools/surrealdb/quality_scoring_cli.py` | Quality Scoring CLI |
+| `tools/mcp/quality_scoring_tools.py` | MCP adapter for quality score |
+| `tools/surrealdb/architect_signals.py` | Architect Signal Service v1 |
+| `tools/mcp/architect_signal_tools.py` | MCP adapter for architect signals |
+| `tests/unit/surrealdb/test_quality_scoring.py` | Quality scoring tests |
+| `tests/unit/tools/mcp/test_quality_scoring_tools.py` | MCP quality scoring tests |
+| `tests/fixtures/surrealdb/quality_scoring/sample_bundle.json` | Sample bundle fixture |
+| `docs/surrealdb/quality-scoring-architect-signals-runbook.md` | This file |
+| `docs/surrealdb/context-wave18-completion-gates.md` | Wave-18 completion gates |

--- a/tests/fixtures/surrealdb/quality_scoring/sample_bundle.json
+++ b/tests/fixtures/surrealdb/quality_scoring/sample_bundle.json
@@ -1,0 +1,117 @@
+{
+  "_comment": "Sample quality scoring bundle for Wave-18 tests. Represents a mixed-quality system context with some good and some weak dimensions.",
+  "meta": {
+    "scope_id": "sample-quality-001",
+    "level": "system",
+    "description": "Sample system context bundle for quality scoring tests"
+  },
+  "sources": [
+    {
+      "source_path": "core/domain/models.py",
+      "has_documentation": true,
+      "has_tests": true,
+      "status": "current",
+      "file_type": "python",
+      "owner": "trading-core"
+    },
+    {
+      "source_path": "core/risk/service.py",
+      "has_documentation": true,
+      "has_tests": true,
+      "status": "current",
+      "file_type": "python",
+      "owner": "risk-team"
+    },
+    {
+      "source_path": "services/execution/service.py",
+      "has_documentation": false,
+      "has_tests": true,
+      "status": "current",
+      "file_type": "python"
+    },
+    {
+      "source_path": "docs/operations/runbook.md",
+      "has_documentation": true,
+      "has_tests": false,
+      "status": "current",
+      "file_type": "markdown"
+    }
+  ],
+  "decisions": [
+    {
+      "decision_id": "dec-risk-gate-001",
+      "status": "current",
+      "evidence_refs": ["ev-001", "ev-002"]
+    },
+    {
+      "decision_id": "dec-old-execution-v1",
+      "status": "superseded",
+      "evidence_refs": []
+    },
+    {
+      "decision_id": "dec-candle-aggregation-001",
+      "status": "current",
+      "evidence_refs": ["ev-003"]
+    }
+  ],
+  "evidence_items": [
+    {
+      "evidence_id": "ev-001",
+      "strength": "strong",
+      "expired": false
+    },
+    {
+      "evidence_id": "ev-002",
+      "strength": "moderate",
+      "expired": false
+    },
+    {
+      "evidence_id": "ev-003",
+      "strength": "weak",
+      "expired": false
+    },
+    {
+      "evidence_id": "ev-004",
+      "strength": "strong",
+      "expired": true
+    }
+  ],
+  "contradiction_findings": [
+    {
+      "contradiction_id": "c-001",
+      "severity": "warning",
+      "status": "open",
+      "source_path": "docs/operations/runbook.md",
+      "description": "Runbook describes old retry policy"
+    }
+  ],
+  "stale_findings": [
+    {
+      "stale_id": "s-001",
+      "status": "stale",
+      "source_path": "docs/operations/runbook.md",
+      "reason": "Document has not been reviewed in 60+ days"
+    }
+  ],
+  "dependency_edges": [
+    {"edge_id": "edge-001", "confidence": "high", "source": "core/risk", "target": "core/domain"},
+    {"edge_id": "edge-002", "confidence": "high", "source": "services/execution", "target": "core/risk"},
+    {"edge_id": "edge-003", "confidence": "medium", "source": "services/execution", "target": "core/domain"},
+    {"edge_id": "edge-004", "confidence": "low", "source": "docs/operations", "target": "services/execution"}
+  ],
+  "memory_items": [
+    {
+      "memory_id": "mem-risk-policy-001",
+      "trust_level": "strong"
+    },
+    {
+      "memory_id": "mem-execution-mode-001",
+      "trust_level": "acceptable"
+    },
+    {
+      "memory_id": "mem-candle-interval-001",
+      "trust_level": "weak"
+    }
+  ],
+  "scope_drift_findings": []
+}

--- a/tests/unit/surrealdb/test_quality_scoring.py
+++ b/tests/unit/surrealdb/test_quality_scoring.py
@@ -1,0 +1,503 @@
+"""Unit tests for quality_scoring.py — Knowledge Quality Scoring Service v1.
+
+Issues:
+    #2176 — [SURREALDB][CONTEXT][QUALITY-TESTS] Tests for Wave-18 quality scoring
+    Parent: #2170 (Wave-18 anchor)
+    Epic: #1976
+
+Scope:
+    Unit tests for tools/surrealdb/quality_scoring.py.
+    All fixtures are inline — no file loading.
+    No DB access. No SurrealDB SDK. No MCP. No networking. No writes.
+    No real datetime.now() — as_of is passed explicitly for determinism.
+
+Coverage:
+    - All 8 scoring dimensions produce scores with triggering input.
+    - Grade thresholds: blocking < 0.30, watch 0.30–0.50, weak 0.50–0.70, good >= 0.70.
+    - Weighted aggregation.
+    - Blocking downgrade: any blocking dimension → overall grade capped at watch.
+    - Empty bundle (no sources) returns blocking coverage_score.
+    - Clean bundle returns good overall grade.
+    - Invalid bundle raises QualityScoringError.
+    - to_dict() structure.
+    - Guardrails in result.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tools.surrealdb.quality_scoring import (
+    GRADE_BLOCKING,
+    GRADE_GOOD,
+    GRADE_WATCH,
+    GRADE_WEAK,
+    GRADES,
+    GUARDRAILS,
+    SCHEMA_VERSION,
+    SCORE_DIMENSIONS,
+    DimensionScore,
+    QualityScoreResult,
+    QualityScoringError,
+    _grade,
+    score_knowledge_quality_v1,
+)
+
+_AS_OF = "2026-05-06T12:00:00+00:00"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _minimal_bundle(scope_id: str = "test-scope") -> dict[str, Any]:
+    """Minimal valid bundle with no findings."""
+    return {"meta": {"scope_id": scope_id, "level": "system"}}
+
+
+def _clean_bundle() -> dict[str, Any]:
+    """A clean bundle with good scores in all dimensions."""
+    return {
+        "meta": {"scope_id": "clean-001", "level": "system"},
+        "sources": [
+            {
+                "source_path": "core/domain/models.py",
+                "has_documentation": True,
+                "has_tests": True,
+                "status": "current",
+                "file_type": "python",
+            },
+            {
+                "source_path": "core/risk/service.py",
+                "has_documentation": True,
+                "has_tests": True,
+                "status": "current",
+                "file_type": "python",
+            },
+        ],
+        "decisions": [
+            {
+                "decision_id": "dec-001",
+                "status": "current",
+                "evidence_refs": ["ev-001"],
+            },
+        ],
+        "evidence_items": [
+            {
+                "evidence_id": "ev-001",
+                "strength": "strong",
+                "expired": False,
+            }
+        ],
+        "contradiction_findings": [],
+        "stale_findings": [],
+        "dependency_edges": [
+            {"edge_id": "edge-001", "confidence": "high"},
+            {"edge_id": "edge-002", "confidence": "high"},
+        ],
+        "memory_items": [
+            {"memory_id": "mem-001", "trust_level": "strong"},
+        ],
+        "scope_drift_findings": [],
+    }
+
+
+def _blocking_bundle() -> dict[str, Any]:
+    """Bundle designed to trigger blocking grade."""
+    return {
+        "meta": {"scope_id": "blocking-001", "level": "system"},
+        "sources": [],
+        "decisions": [],
+        "evidence_items": [],
+        "contradiction_findings": [
+            {"contradiction_id": "c-001", "severity": "blocking", "status": "open"},
+            {"contradiction_id": "c-002", "severity": "blocking", "status": "open"},
+        ],
+        "stale_findings": [
+            {"stale_id": "s-001", "status": "stale"},
+            {"stale_id": "s-002", "status": "stale"},
+        ],
+        "dependency_edges": [
+            {"edge_id": "edge-bad-001", "confidence": "low"},
+            {"edge_id": "edge-bad-002", "confidence": "low"},
+        ],
+        "memory_items": [
+            {"memory_id": "mem-blocked", "trust_level": "blocked"},
+        ],
+        "scope_drift_findings": [
+            {"drift_id": "drift-001", "severity": "blocking", "status": "open"},
+        ],
+    }
+
+
+def _score(bundle: dict[str, Any], as_of: str = _AS_OF) -> QualityScoreResult:
+    return score_knowledge_quality_v1(bundle, as_of=as_of)
+
+
+# ── Grade threshold tests ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "score_val,expected_grade",
+    [
+        (0.0, GRADE_BLOCKING),
+        (0.10, GRADE_BLOCKING),
+        (0.29, GRADE_BLOCKING),
+        (0.30, GRADE_WATCH),
+        (0.40, GRADE_WATCH),
+        (0.49, GRADE_WATCH),
+        (0.50, GRADE_WEAK),
+        (0.60, GRADE_WEAK),
+        (0.69, GRADE_WEAK),
+        (0.70, GRADE_GOOD),
+        (0.90, GRADE_GOOD),
+        (1.00, GRADE_GOOD),
+    ],
+)
+def test_grade_thresholds(score_val: float, expected_grade: str) -> None:
+    """_grade() produces correct grade at each threshold."""
+    assert _grade(score_val) == expected_grade
+
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_score_dimensions_count() -> None:
+    """SCORE_DIMENSIONS has exactly 8 entries."""
+    assert len(SCORE_DIMENSIONS) == 8
+
+
+@pytest.mark.unit
+def test_grades_tuple() -> None:
+    """GRADES contains the 4 expected grade strings."""
+    assert set(GRADES) == {"blocking", "watch", "weak", "good"}
+
+
+@pytest.mark.unit
+def test_guardrails_present() -> None:
+    """GUARDRAILS has at least 5 strings."""
+    assert len(GUARDRAILS) >= 5
+    for g in GUARDRAILS:
+        assert isinstance(g, str) and len(g) > 0
+
+
+# ── Minimal bundle (no sources → blocking coverage) ───────────────────────────
+
+
+@pytest.mark.unit
+def test_minimal_bundle_returns_result() -> None:
+    """Minimal bundle with meta only returns a valid QualityScoreResult."""
+    result = _score(_minimal_bundle())
+    assert isinstance(result, QualityScoreResult)
+    assert result.scope_id == "test-scope"
+    assert result.overall_grade in GRADES
+
+
+@pytest.mark.unit
+def test_empty_sources_blocking_coverage() -> None:
+    """Empty sources list → coverage_score is blocking."""
+    bundle = {
+        "meta": {"scope_id": "empty-src", "level": "artifact"},
+        "sources": [],
+    }
+    result = _score(bundle)
+    coverage_dims = [d for d in result.dimensions if d.dimension == "coverage_score"]
+    assert len(coverage_dims) == 1
+    assert coverage_dims[0].grade == GRADE_BLOCKING
+
+
+@pytest.mark.unit
+def test_no_evidence_blocking_evidence_score() -> None:
+    """No evidence items → evidence_score is blocking."""
+    bundle = {
+        "meta": {"scope_id": "no-ev", "level": "artifact"},
+        "evidence_items": [],
+    }
+    result = _score(bundle)
+    ev_dims = [d for d in result.dimensions if d.dimension == "evidence_score"]
+    assert len(ev_dims) == 1
+    assert ev_dims[0].grade == GRADE_BLOCKING
+
+
+# ── Clean bundle → good overall ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_clean_bundle_good_grade() -> None:
+    """Clean bundle returns overall_grade of 'good'."""
+    result = _score(_clean_bundle())
+    assert result.overall_grade == GRADE_GOOD
+
+
+@pytest.mark.unit
+def test_clean_bundle_no_blocking_dims() -> None:
+    """Clean bundle has no blocking dimensions."""
+    result = _score(_clean_bundle())
+    assert result.blocking_dimensions == ()
+
+
+# ── Blocking downgrade rule ────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_blocking_dimension_caps_overall() -> None:
+    """If any dimension is blocking, overall_grade must be at most 'watch'."""
+    result = _score(_blocking_bundle())
+    assert result.overall_grade in (GRADE_BLOCKING, GRADE_WATCH)
+
+
+@pytest.mark.unit
+def test_blocking_bundle_has_blocking_dims() -> None:
+    """Blocking bundle produces at least one blocking dimension."""
+    result = _score(_blocking_bundle())
+    assert len(result.blocking_dimensions) > 0
+
+
+# ── Contradiction score ───────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_open_blocking_contradictions_lower_score() -> None:
+    """Open blocking contradictions reduce contradiction_score."""
+    bundle = {
+        "meta": {"scope_id": "contradiction-test", "level": "domain"},
+        "contradiction_findings": [
+            {"contradiction_id": "c-001", "severity": "blocking", "status": "open"},
+            {"contradiction_id": "c-002", "severity": "blocking", "status": "open"},
+            {"contradiction_id": "c-003", "severity": "warning", "status": "open"},
+        ],
+    }
+    result = _score(bundle)
+    c_dims = [d for d in result.dimensions if d.dimension == "contradiction_score"]
+    assert len(c_dims) == 1
+    assert c_dims[0].score < 0.50
+
+
+@pytest.mark.unit
+def test_resolved_contradictions_not_penalised() -> None:
+    """Resolved/accepted_risk contradictions should not severely penalise the score."""
+    bundle = {
+        "meta": {"scope_id": "resolved-c", "level": "domain"},
+        "contradiction_findings": [
+            {"contradiction_id": "c-r-001", "severity": "blocking", "status": "resolved"},
+            {"contradiction_id": "c-r-002", "severity": "blocking", "status": "accepted_risk"},
+        ],
+    }
+    result = _score(bundle)
+    c_dims = [d for d in result.dimensions if d.dimension == "contradiction_score"]
+    assert len(c_dims) == 1
+    # Resolved contradictions should yield a better score than open blocking ones
+    assert c_dims[0].score >= 0.50
+
+
+# ── Scope risk score ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_open_scope_drift_reduces_score() -> None:
+    """Open scope drift findings reduce scope_risk_score."""
+    bundle = {
+        "meta": {"scope_id": "scope-drift-test", "level": "system"},
+        "scope_drift_findings": [
+            {"drift_id": "d-001", "severity": "blocking", "status": "open"},
+            {"drift_id": "d-002", "severity": "blocking", "status": "open"},
+        ],
+    }
+    result = _score(bundle)
+    scope_dims = [d for d in result.dimensions if d.dimension == "scope_risk_score"]
+    assert len(scope_dims) == 1
+    assert scope_dims[0].score < 0.70
+
+
+# ── Dependency confidence score ───────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_all_low_confidence_edges_lower_score() -> None:
+    """All-low-confidence dependency edges reduce dependency_confidence_score."""
+    bundle = {
+        "meta": {"scope_id": "dep-test", "level": "domain"},
+        "dependency_edges": [
+            {"edge_id": "e-001", "confidence": "low"},
+            {"edge_id": "e-002", "confidence": "low"},
+            {"edge_id": "e-003", "confidence": "low"},
+        ],
+    }
+    result = _score(bundle)
+    dep_dims = [d for d in result.dimensions if d.dimension == "dependency_confidence_score"]
+    assert len(dep_dims) == 1
+    assert dep_dims[0].score < 0.70
+
+
+@pytest.mark.unit
+def test_all_high_confidence_edges_good_score() -> None:
+    """All-high-confidence edges produce a good dependency_confidence_score."""
+    bundle = {
+        "meta": {"scope_id": "dep-high", "level": "domain"},
+        "dependency_edges": [
+            {"edge_id": "e-h-001", "confidence": "high"},
+            {"edge_id": "e-h-002", "confidence": "high"},
+        ],
+    }
+    result = _score(bundle)
+    dep_dims = [d for d in result.dimensions if d.dimension == "dependency_confidence_score"]
+    assert len(dep_dims) == 1
+    assert dep_dims[0].score >= 0.70
+
+
+# ── Decision validity score ───────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_superseded_decisions_reduce_validity() -> None:
+    """Superseded decisions reduce decision_validity_score."""
+    bundle = {
+        "meta": {"scope_id": "dec-validity", "level": "issue"},
+        "decisions": [
+            {"decision_id": "dec-old", "status": "superseded"},
+            {"decision_id": "dec-old2", "status": "superseded"},
+            {"decision_id": "dec-cur", "status": "current"},
+        ],
+    }
+    result = _score(bundle)
+    dec_dims = [d for d in result.dimensions if d.dimension == "decision_validity_score"]
+    assert len(dec_dims) == 1
+    assert dec_dims[0].score < 1.0
+
+
+@pytest.mark.unit
+def test_all_current_decisions_good() -> None:
+    """All-current decisions produce a good decision_validity_score."""
+    bundle = {
+        "meta": {"scope_id": "dec-all-current", "level": "issue"},
+        "decisions": [
+            {"decision_id": "dec-1", "status": "current"},
+            {"decision_id": "dec-2", "status": "current"},
+        ],
+    }
+    result = _score(bundle)
+    dec_dims = [d for d in result.dimensions if d.dimension == "decision_validity_score"]
+    assert len(dec_dims) == 1
+    assert dec_dims[0].score >= 0.70
+
+
+# ── Memory trust score ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_blocked_memory_reduces_trust() -> None:
+    """Blocked memory items reduce memory_trust_score."""
+    bundle = {
+        "meta": {"scope_id": "mem-trust", "level": "domain"},
+        "memory_items": [
+            {"memory_id": "m-blocked", "trust_level": "blocked"},
+            {"memory_id": "m-weak", "trust_level": "weak"},
+        ],
+    }
+    result = _score(bundle)
+    mem_dims = [d for d in result.dimensions if d.dimension == "memory_trust_score"]
+    assert len(mem_dims) == 1
+    assert mem_dims[0].score < 0.70
+
+
+# ── Result structure ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_result_has_all_8_dimensions() -> None:
+    """QualityScoreResult has exactly 8 DimensionScore entries."""
+    result = _score(_clean_bundle())
+    dims = {d.dimension for d in result.dimensions}
+    assert dims == set(SCORE_DIMENSIONS)
+
+
+@pytest.mark.unit
+def test_dimension_score_range() -> None:
+    """All dimension scores are in [0.0, 1.0]."""
+    result = _score(_blocking_bundle())
+    for d in result.dimensions:
+        assert 0.0 <= d.score <= 1.0, f"Out of range: {d.dimension}={d.score}"
+
+
+@pytest.mark.unit
+def test_to_dict_structure() -> None:
+    """to_dict() returns all required keys."""
+    result = _score(_clean_bundle())
+    d = result.to_dict()
+    required = {
+        "schema_version", "scope_id", "level", "scored_at",
+        "overall_score", "overall_grade", "blocking_dimensions",
+        "watch_dimensions", "recommended_next_reads", "guardrails", "dimensions",
+    }
+    assert required.issubset(d.keys())
+
+
+@pytest.mark.unit
+def test_to_dict_schema_version() -> None:
+    """to_dict() includes correct schema_version."""
+    result = _score(_minimal_bundle())
+    assert result.to_dict()["schema_version"] == SCHEMA_VERSION
+
+
+@pytest.mark.unit
+def test_guardrails_in_result() -> None:
+    """QualityScoreResult.guardrails contains all GUARDRAILS strings."""
+    result = _score(_minimal_bundle())
+    assert set(GUARDRAILS).issubset(set(result.guardrails))
+
+
+@pytest.mark.unit
+def test_no_live_go_in_guardrails() -> None:
+    """Guardrails must not imply live-go or action authority."""
+    combined = " ".join(GUARDRAILS).lower()
+    assert "live-go" in combined or "no live" in combined or "no-go" in combined or "no live-go" in combined
+
+
+# ── Error cases ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_non_mapping_bundle_raises() -> None:
+    """Non-mapping bundle raises QualityScoringError."""
+    with pytest.raises(QualityScoringError):
+        score_knowledge_quality_v1("not a dict")  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_missing_meta_raises() -> None:
+    """Bundle without meta raises QualityScoringError."""
+    with pytest.raises(QualityScoringError):
+        score_knowledge_quality_v1({})
+
+
+@pytest.mark.unit
+def test_meta_not_mapping_raises() -> None:
+    """Bundle with non-mapping meta raises QualityScoringError."""
+    with pytest.raises(QualityScoringError):
+        score_knowledge_quality_v1({"meta": "not-a-dict"})
+
+
+# ── Determinism ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_same_input_same_scope_id() -> None:
+    """Same bundle produces the same scope_id."""
+    b = _clean_bundle()
+    r1 = _score(b)
+    r2 = _score(b)
+    assert r1.scope_id == r2.scope_id
+
+
+@pytest.mark.unit
+def test_same_input_same_dimension_scores() -> None:
+    """Same bundle produces identical dimension scores (deterministic)."""
+    b = _clean_bundle()
+    r1 = _score(b)
+    r2 = _score(b)
+    scores1 = {d.dimension: d.score for d in r1.dimensions}
+    scores2 = {d.dimension: d.score for d in r2.dimensions}
+    assert scores1 == scores2

--- a/tests/unit/surrealdb/test_quality_scoring.py
+++ b/tests/unit/surrealdb/test_quality_scoring.py
@@ -628,3 +628,80 @@ def test_cli_score_knowledge_format_markdown_as_subcommand_arg(tmp_path: Any) ->
         ["score-knowledge", "--input", str(bundle_file), "--format", "markdown"]
     )
     assert exit_code == EXIT_OK
+
+
+# ── stale_findings freshness tests ───────────────────────────────────────────
+
+
+def _all_current_bundle_with_stale_findings(count: int = 1) -> dict[str, Any]:
+    """Bundle where all sources are current but stale_findings is non-empty."""
+    return {
+        "meta": {"scope_id": "stale-findings-test", "level": "system"},
+        "sources": [
+            {
+                "source_path": "core/a.py",
+                "has_documentation": True,
+                "has_tests": True,
+                "status": "current",
+                "file_type": "python",
+            },
+            {
+                "source_path": "core/b.py",
+                "has_documentation": True,
+                "has_tests": True,
+                "status": "current",
+                "file_type": "python",
+            },
+        ],
+        "decisions": [
+            {"decision_id": "d1", "status": "current", "evidence_refs": ["e1"]},
+        ],
+        "evidence_items": [
+            {"evidence_id": "e1", "strength": "strong", "expired": False},
+        ],
+        "contradiction_findings": [],
+        "stale_findings": [
+            {"stale_id": f"s-{i:03d}", "status": "stale", "source_path": f"docs/old-{i}.md"}
+            for i in range(count)
+        ],
+        "dependency_edges": [
+            {"edge_id": "edge-1", "confidence": "high"},
+        ],
+        "memory_items": [
+            {"memory_id": "mem-1", "trust_level": "high"},
+        ],
+        "scope_drift_findings": [],
+    }
+
+
+@pytest.mark.unit
+def test_stale_findings_lower_freshness_below_perfect() -> None:
+    """A bundle with all-current sources but 1 stale_finding must score < 1.0 freshness."""
+    result = _score(_all_current_bundle_with_stale_findings(count=1))
+    freshness_dim = next(d for d in result.dimensions if d.dimension == "freshness_score")
+    assert freshness_dim.score < 1.0, (
+        f"Expected freshness < 1.0 with 1 stale finding, got {freshness_dim.score}"
+    )
+
+
+@pytest.mark.unit
+def test_stale_findings_freshness_score_decreases_with_more_findings() -> None:
+    """More stale findings produce lower freshness than fewer stale findings."""
+    result_few = _score(_all_current_bundle_with_stale_findings(count=1))
+    result_many = _score(_all_current_bundle_with_stale_findings(count=5))
+    fresh_few = next(d.score for d in result_few.dimensions if d.dimension == "freshness_score")
+    fresh_many = next(d.score for d in result_many.dimensions if d.dimension == "freshness_score")
+    assert fresh_many < fresh_few, (
+        f"Expected freshness to decrease with more stale findings: {fresh_many} >= {fresh_few}"
+    )
+
+
+@pytest.mark.unit
+def test_empty_stale_findings_preserves_perfect_freshness() -> None:
+    """A bundle with no stale_findings and all-current sources scores 1.0 freshness."""
+    bundle = _all_current_bundle_with_stale_findings(count=0)
+    result = _score(bundle)
+    freshness_dim = next(d for d in result.dimensions if d.dimension == "freshness_score")
+    assert freshness_dim.score == 1.0, (
+        f"Expected freshness 1.0 with no stale findings, got {freshness_dim.score}"
+    )

--- a/tests/unit/surrealdb/test_quality_scoring.py
+++ b/tests/unit/surrealdb/test_quality_scoring.py
@@ -630,7 +630,7 @@ def test_cli_score_knowledge_format_markdown_as_subcommand_arg(tmp_path: Any) ->
     assert exit_code == EXIT_OK
 
 
-# ── stale_findings freshness tests ───────────────────────────────────────────
+# ── stale_findings freshness tests (active vs. terminal statuses) ─────────────
 
 
 def _all_current_bundle_with_stale_findings(count: int = 1) -> dict[str, Any]:
@@ -705,3 +705,131 @@ def test_empty_stale_findings_preserves_perfect_freshness() -> None:
     assert freshness_dim.score == 1.0, (
         f"Expected freshness 1.0 with no stale findings, got {freshness_dim.score}"
     )
+
+
+@pytest.mark.unit
+def test_terminal_stale_findings_do_not_lower_freshness() -> None:
+    """refreshed / accepted_risk / false_positive stale findings must not penalise freshness."""
+    terminal_statuses = ["refreshed", "accepted_risk", "false_positive"]
+    for status in terminal_statuses:
+        bundle = {
+            **_all_current_bundle_with_stale_findings(count=0),
+            "stale_findings": [
+                {"stale_id": "s-001", "status": status, "source_path": "docs/old.md"},
+                {"stale_id": "s-002", "status": status, "source_path": "docs/older.md"},
+            ],
+        }
+        result = _score(bundle)
+        freshness_dim = next(d for d in result.dimensions if d.dimension == "freshness_score")
+        assert freshness_dim.score == 1.0, (
+            f"status={status!r}: expected freshness 1.0 (exempt), got {freshness_dim.score}"
+        )
+
+
+@pytest.mark.unit
+def test_mixed_stale_findings_only_active_penalise() -> None:
+    """Only active stale findings lower freshness; terminal ones are exempt."""
+    bundle = {
+        **_all_current_bundle_with_stale_findings(count=0),
+        "sources": [
+            {"source_path": "core/a.py", "has_documentation": True, "has_tests": True, "status": "current", "file_type": "python"},
+            {"source_path": "core/b.py", "has_documentation": True, "has_tests": True, "status": "current", "file_type": "python"},
+        ],
+        "decisions": [{"decision_id": "d1", "status": "current", "evidence_refs": ["e1"]}],
+        "stale_findings": [
+            {"stale_id": "s-active", "status": "stale", "source_path": "docs/active.md"},
+            {"stale_id": "s-exempt1", "status": "refreshed", "source_path": "docs/done1.md"},
+            {"stale_id": "s-exempt2", "status": "accepted_risk", "source_path": "docs/done2.md"},
+        ],
+    }
+    result = _score(bundle)
+    freshness_dim = next(d for d in result.dimensions if d.dimension == "freshness_score")
+    # 3 items (2 sources + 1 decision) are current; 1 active stale adds to total → 3/4 = 0.75
+    expected = 3 / 4
+    assert abs(freshness_dim.score - expected) < 1e-9, (
+        f"Expected freshness {expected} (3 current / 4 total including 1 active stale), "
+        f"got {freshness_dim.score}"
+    )
+
+
+# ── architect signal tests: dependency edge paths ─────────────────────────────
+
+
+@pytest.mark.unit
+def test_high_dependency_risk_source_target_edges_have_non_empty_affected_paths() -> None:
+    """Dependency edges with source/target schema must produce non-empty affected_paths."""
+    from tools.surrealdb.architect_signals import scan_architect_signals_v1
+
+    bundle = {
+        "meta": {"scope_id": "dep-path-test", "level": "system"},
+        "sources": [],
+        "decisions": [],
+        "evidence_items": [],
+        "contradiction_findings": [],
+        "stale_findings": [],
+        "dependency_edges": [
+            {"edge_id": "e1", "confidence": "low", "source": "core/risk.py", "target": "core/execution.py"},
+            {"edge_id": "e2", "confidence": "low", "source": "core/signal.py", "target": "core/regime.py"},
+        ],
+        "memory_items": [],
+        "scope_drift_findings": [],
+    }
+    result = scan_architect_signals_v1(bundle)
+    dep_signals = [s for s in result.signals if s.signal_type == "high_dependency_risk"]
+    assert dep_signals, "Expected at least one high_dependency_risk signal"
+    sig = dep_signals[0]
+    assert len(sig.affected_paths) > 0, (
+        f"Expected non-empty affected_paths for source/target edge schema, got {sig.affected_paths}"
+    )
+
+
+@pytest.mark.unit
+def test_high_dependency_risk_affected_paths_include_both_endpoints() -> None:
+    """Both source and target endpoints must appear in affected_paths."""
+    from tools.surrealdb.architect_signals import scan_architect_signals_v1
+
+    bundle = {
+        "meta": {"scope_id": "dep-endpoints-test", "level": "system"},
+        "sources": [],
+        "decisions": [],
+        "evidence_items": [],
+        "contradiction_findings": [],
+        "stale_findings": [],
+        "dependency_edges": [
+            {"edge_id": "e1", "confidence": "low", "source": "core/risk.py", "target": "core/execution.py"},
+        ],
+        "memory_items": [],
+        "scope_drift_findings": [],
+    }
+    result = scan_architect_signals_v1(bundle)
+    dep_signals = [s for s in result.signals if s.signal_type == "high_dependency_risk"]
+    assert dep_signals
+    paths = dep_signals[0].affected_paths
+    assert "core/risk.py" in paths, f"Expected 'core/risk.py' in affected_paths: {paths}"
+    assert "core/execution.py" in paths, f"Expected 'core/execution.py' in affected_paths: {paths}"
+
+
+@pytest.mark.unit
+def test_high_dependency_risk_source_path_key_fallback_still_works() -> None:
+    """Edges using the source_path key (not source/target) still produce affected_paths."""
+    from tools.surrealdb.architect_signals import scan_architect_signals_v1
+
+    bundle = {
+        "meta": {"scope_id": "dep-path-fallback-test", "level": "system"},
+        "sources": [],
+        "decisions": [],
+        "evidence_items": [],
+        "contradiction_findings": [],
+        "stale_findings": [],
+        "dependency_edges": [
+            {"edge_id": "e1", "confidence": "low", "source_path": "core/legacy.py"},
+            {"edge_id": "e2", "confidence": "low", "source_path": "core/old.py"},
+        ],
+        "memory_items": [],
+        "scope_drift_findings": [],
+    }
+    result = scan_architect_signals_v1(bundle)
+    dep_signals = [s for s in result.signals if s.signal_type == "high_dependency_risk"]
+    assert dep_signals
+    paths = dep_signals[0].affected_paths
+    assert len(paths) > 0, f"Expected non-empty affected_paths for source_path key, got {paths}"

--- a/tests/unit/surrealdb/test_quality_scoring.py
+++ b/tests/unit/surrealdb/test_quality_scoring.py
@@ -38,7 +38,6 @@ from tools.surrealdb.quality_scoring import (
     GUARDRAILS,
     SCHEMA_VERSION,
     SCORE_DIMENSIONS,
-    DimensionScore,
     QualityScoreResult,
     QualityScoringError,
     _grade,
@@ -501,3 +500,131 @@ def test_same_input_same_dimension_scores() -> None:
     scores1 = {d.dimension: d.score for d in r1.dimensions}
     scores2 = {d.dimension: d.score for d in r2.dimensions}
     assert scores1 == scores2
+
+
+# ── CLI behaviour tests ───────────────────────────────────────────────────────
+
+
+def _weak_bundle() -> dict[str, Any]:
+    """Bundle that produces overall_grade=='weak' with no blocking dimensions."""
+    return {
+        "meta": {"scope_id": "weak-grade-test", "level": "system"},
+        "sources": [
+            {
+                "source_path": "core/a.py",
+                "has_documentation": True,
+                "has_tests": True,
+                "status": "current",
+                "file_type": "python",
+            },
+            {
+                "source_path": "core/b.py",
+                "has_documentation": True,
+                "has_tests": True,
+                "status": "current",
+                "file_type": "python",
+            },
+            {
+                "source_path": "core/c.py",
+                "has_documentation": False,
+                "has_tests": False,
+                "status": "current",
+                "file_type": "python",
+            },
+            {
+                "source_path": "core/d.py",
+                "has_documentation": False,
+                "has_tests": False,
+                "status": "stale",
+                "stale": True,
+                "file_type": "python",
+            },
+        ],
+        "decisions": [
+            {"decision_id": "d1", "status": "current", "evidence_refs": ["e1"]},
+            {"decision_id": "d2", "status": "superseded", "evidence_refs": []},
+        ],
+        "evidence_items": [
+            {"evidence_id": "e1", "strength": "moderate", "expired": False},
+            {"evidence_id": "e2", "strength": "moderate", "expired": False},
+        ],
+        "contradiction_findings": [],
+        "stale_findings": [],
+        "dependency_edges": [
+            {"edge_id": "edge-1", "confidence": "medium"},
+            {"edge_id": "edge-2", "confidence": "medium"},
+        ],
+        "memory_items": [
+            {"memory_id": "mem-1", "trust_level": "weak"},
+            {"memory_id": "mem-2", "trust_level": "weak"},
+        ],
+        "scope_drift_findings": [],
+    }
+
+
+@pytest.mark.unit
+def test_weak_bundle_produces_weak_grade() -> None:
+    """_weak_bundle() must produce overall_grade=='weak' with no blocking dims."""
+    result = _score(_weak_bundle())
+    assert result.overall_grade == GRADE_WEAK
+    assert result.blocking_dimensions == ()
+
+
+@pytest.mark.unit
+def test_cli_fail_on_weak_exits_1_for_weak_grade(tmp_path: Any) -> None:
+    """--fail-on-weak must exit EXIT_WEAK (1) when overall grade is 'weak'."""
+    import json
+
+    from tools.surrealdb.quality_scoring_cli import EXIT_WEAK, main
+
+    bundle_file = tmp_path / "weak_bundle.json"
+    bundle_file.write_text(json.dumps(_weak_bundle()))
+    exit_code = main(
+        ["score-knowledge", "--input", str(bundle_file), "--fail-on-weak"]
+    )
+    assert exit_code == EXIT_WEAK
+
+
+@pytest.mark.unit
+def test_cli_fail_on_weak_exits_0_for_good_grade(tmp_path: Any) -> None:
+    """--fail-on-weak must exit 0 when overall grade is 'good'."""
+    import json
+
+    from tools.surrealdb.quality_scoring_cli import EXIT_OK, main
+
+    bundle_file = tmp_path / "good_bundle.json"
+    bundle_file.write_text(json.dumps(_clean_bundle()))
+    exit_code = main(
+        ["score-knowledge", "--input", str(bundle_file), "--fail-on-weak"]
+    )
+    assert exit_code == EXIT_OK
+
+
+@pytest.mark.unit
+def test_cli_report_quality_format_markdown_as_subcommand_arg(tmp_path: Any) -> None:
+    """report-quality --format markdown must not raise unrecognized arguments."""
+    import json
+
+    from tools.surrealdb.quality_scoring_cli import EXIT_OK, main
+
+    bundle_file = tmp_path / "bundle.json"
+    bundle_file.write_text(json.dumps(_clean_bundle()))
+    exit_code = main(
+        ["report-quality", "--input", str(bundle_file), "--format", "markdown"]
+    )
+    assert exit_code == EXIT_OK
+
+
+@pytest.mark.unit
+def test_cli_score_knowledge_format_markdown_as_subcommand_arg(tmp_path: Any) -> None:
+    """score-knowledge --format markdown must not raise unrecognized arguments."""
+    import json
+
+    from tools.surrealdb.quality_scoring_cli import EXIT_OK, main
+
+    bundle_file = tmp_path / "bundle.json"
+    bundle_file.write_text(json.dumps(_clean_bundle()))
+    exit_code = main(
+        ["score-knowledge", "--input", str(bundle_file), "--format", "markdown"]
+    )
+    assert exit_code == EXIT_OK

--- a/tests/unit/surrealdb/test_quality_scoring.py
+++ b/tests/unit/surrealdb/test_quality_scoring.py
@@ -912,3 +912,82 @@ def test_without_as_of_signals_still_generated() -> None:
             f"Even without as_of, detected_at should equal scanned_at; "
             f"got detected_at={sig.detected_at!r} scanned_at={result.scanned_at!r}"
         )
+
+
+# ── CLI contract tests: --format global vs subcommand (T13) + EXIT_NOT_FOUND (T14) ─
+
+
+def _good_bundle_file(tmp_path: Any) -> Any:
+    """Write a minimal valid bundle JSON to tmp_path and return the path."""
+    bundle = {
+        "meta": {"scope_id": "cli-contract-test", "level": "system"},
+        "sources": [{"source_id": "s1", "status": "current", "trust_score": 0.9}],
+        "decisions": [],
+        "evidence_items": [{"evidence_id": "e1", "strength": "strong", "expired": False}],
+        "contradiction_findings": [],
+        "stale_findings": [],
+        "dependency_edges": [],
+        "memory_items": [],
+        "scope_drift_findings": [],
+    }
+    p = tmp_path / "bundle.json"
+    import json as _json
+    p.write_text(_json.dumps(bundle), encoding="utf-8")
+    return p
+
+
+@pytest.mark.unit
+def test_cli_global_format_markdown_not_overwritten_by_subparser(tmp_path: Any, capsys: Any) -> None:
+    """Global --format markdown before subcommand must produce Markdown, not JSON (T13)."""
+    from tools.surrealdb.quality_scoring_cli import EXIT_OK, main
+
+    bundle_file = _good_bundle_file(tmp_path)
+    exit_code = main(["--format", "markdown", "report-quality", "--input", str(bundle_file)])
+    captured = capsys.readouterr()
+
+    assert exit_code == EXIT_OK
+    assert captured.out.startswith("# "), (
+        f"Expected Markdown output (starting with '# ') for global --format markdown; "
+        f"got: {captured.out[:120]!r}"
+    )
+
+
+@pytest.mark.unit
+def test_cli_subcommand_format_markdown_overrides_global_json(tmp_path: Any, capsys: Any) -> None:
+    """Subcommand-level --format markdown overrides the global default of json (T13 precedence)."""
+    from tools.surrealdb.quality_scoring_cli import EXIT_OK, main
+
+    bundle_file = _good_bundle_file(tmp_path)
+    # global default = json; subcommand explicitly sets markdown → markdown must win
+    exit_code = main(["report-quality", "--input", str(bundle_file), "--format", "markdown"])
+    captured = capsys.readouterr()
+
+    assert exit_code == EXIT_OK
+    assert captured.out.startswith("# "), (
+        f"Expected Markdown output when subcommand specifies --format markdown; "
+        f"got: {captured.out[:120]!r}"
+    )
+
+
+@pytest.mark.unit
+def test_cli_missing_bundle_exits_not_found(tmp_path: Any) -> None:
+    """Missing input bundle path must return EXIT_NOT_FOUND = 3, not EXIT_ERROR = 2 (T14)."""
+    from tools.surrealdb.quality_scoring_cli import EXIT_NOT_FOUND, main
+
+    missing = tmp_path / "nonexistent.json"
+    exit_code = main(["report-quality", "--input", str(missing)])
+    assert exit_code == EXIT_NOT_FOUND, (
+        f"Expected EXIT_NOT_FOUND (3) for missing bundle, got {exit_code}"
+    )
+
+
+@pytest.mark.unit
+def test_cli_missing_bundle_score_knowledge_exits_not_found(tmp_path: Any) -> None:
+    """Missing bundle on score-knowledge also returns EXIT_NOT_FOUND = 3 (T14)."""
+    from tools.surrealdb.quality_scoring_cli import EXIT_NOT_FOUND, main
+
+    missing = tmp_path / "nonexistent.json"
+    exit_code = main(["score-knowledge", "--input", str(missing)])
+    assert exit_code == EXIT_NOT_FOUND, (
+        f"Expected EXIT_NOT_FOUND (3) for missing bundle on score-knowledge, got {exit_code}"
+    )

--- a/tests/unit/surrealdb/test_quality_scoring.py
+++ b/tests/unit/surrealdb/test_quality_scoring.py
@@ -833,3 +833,82 @@ def test_high_dependency_risk_source_path_key_fallback_still_works() -> None:
     assert dep_signals
     paths = dep_signals[0].affected_paths
     assert len(paths) > 0, f"Expected non-empty affected_paths for source_path key, got {paths}"
+
+
+# ── architect signal tests: as_of / detected_at determinism (T12) ─────────────
+
+
+def _signal_bundle_with_low_conf_edges() -> dict:
+    """Bundle that reliably produces a high_dependency_risk signal."""
+    return {
+        "meta": {"scope_id": "det-ts-test", "level": "system"},
+        "sources": [],
+        "decisions": [],
+        "evidence_items": [],
+        "contradiction_findings": [],
+        "stale_findings": [],
+        "dependency_edges": [
+            {"edge_id": "e1", "confidence": "low", "source": "core/a.py", "target": "core/b.py"},
+            {"edge_id": "e2", "confidence": "low", "source": "core/c.py", "target": "core/d.py"},
+        ],
+        "memory_items": [],
+        "scope_drift_findings": [],
+    }
+
+
+@pytest.mark.unit
+def test_as_of_sets_signal_detected_at() -> None:
+    """When as_of is provided, every signal's detected_at equals the as_of value."""
+    from tools.surrealdb.architect_signals import scan_architect_signals_v1
+
+    as_of = "2026-05-08T00:00:00"
+    result = scan_architect_signals_v1(_signal_bundle_with_low_conf_edges(), as_of=as_of)
+    assert result.signals, "Expected at least one signal from low-confidence edges"
+    for sig in result.signals:
+        assert sig.detected_at == as_of, (
+            f"Signal {sig.signal_type}.detected_at={sig.detected_at!r} != as_of={as_of!r}"
+        )
+
+
+@pytest.mark.unit
+def test_as_of_detected_at_matches_scanned_at() -> None:
+    """scanned_at and all signal detected_at values are identical when as_of is supplied."""
+    from tools.surrealdb.architect_signals import scan_architect_signals_v1
+
+    as_of = "2026-05-08T12:34:56"
+    result = scan_architect_signals_v1(_signal_bundle_with_low_conf_edges(), as_of=as_of)
+    assert result.scanned_at == as_of
+    for sig in result.signals:
+        assert sig.detected_at == result.scanned_at, (
+            f"Signal {sig.signal_type}.detected_at={sig.detected_at!r} != "
+            f"scanned_at={result.scanned_at!r}"
+        )
+
+
+@pytest.mark.unit
+def test_repeated_as_of_scan_is_identical() -> None:
+    """Same bundle + same as_of produces identical to_dict() output on two calls."""
+    from tools.surrealdb.architect_signals import scan_architect_signals_v1
+
+    bundle = _signal_bundle_with_low_conf_edges()
+    as_of = "2026-05-08T00:00:00"
+    result1 = scan_architect_signals_v1(bundle, as_of=as_of)
+    result2 = scan_architect_signals_v1(bundle, as_of=as_of)
+    assert result1.to_dict() == result2.to_dict(), (
+        "Expected identical to_dict() for same bundle+as_of on two calls"
+    )
+
+
+@pytest.mark.unit
+def test_without_as_of_signals_still_generated() -> None:
+    """When as_of is omitted, signals are still generated (wall-clock path not broken)."""
+    from tools.surrealdb.architect_signals import scan_architect_signals_v1
+
+    result = scan_architect_signals_v1(_signal_bundle_with_low_conf_edges())
+    assert result.signals, "Expected signals even without as_of"
+    # scanned_at and detected_at should still be consistent with each other
+    for sig in result.signals:
+        assert sig.detected_at == result.scanned_at, (
+            f"Even without as_of, detected_at should equal scanned_at; "
+            f"got detected_at={sig.detected_at!r} scanned_at={result.scanned_at!r}"
+        )

--- a/tests/unit/tools/mcp/test_quality_scoring_tools.py
+++ b/tests/unit/tools/mcp/test_quality_scoring_tools.py
@@ -1,0 +1,241 @@
+"""Unit tests for Wave-18 MCP tool: cdb_context_quality_score.
+
+Issues:
+    #2176 — [SURREALDB][CONTEXT][QUALITY-TESTS] Tests for Wave-18 quality scoring
+    Parent: #2170 (Wave-18 anchor)
+    Epic: #1976
+
+Scope:
+    Unit tests for tools/mcp/quality_scoring_tools.py and its integration
+    with the MCP registry, context bridge, and permission guard.
+    All fixtures are inline — no file loading.
+    No DB access. No SurrealDB SDK. No network. No writes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tools.mcp.context_bridge import ContextBridge
+from tools.mcp.permission_guard import INPUT_SCAN_EXEMPT_TOOLS
+from tools.mcp.quality_scoring_tools import (
+    SCHEMA_VERSION,
+    TOOL_CDB_CONTEXT_QUALITY_SCORE,
+    handle_quality_score,
+)
+from tools.mcp.registry import ContextToolRegistry
+from tools.surrealdb.quality_scoring import GUARDRAILS, SCORE_DIMENSIONS
+
+_AS_OF = "2026-05-06T12:00:00+00:00"
+
+
+# ── Inline fixtures ───────────────────────────────────────────────────────────
+
+
+def _clean_bundle() -> dict[str, Any]:
+    return {
+        "meta": {"scope_id": "mcp-clean-001", "level": "system"},
+        "sources": [
+            {"source_path": "core/risk/service.py", "has_documentation": True, "has_tests": True, "status": "current"},
+        ],
+        "decisions": [{"decision_id": "dec-001", "status": "current", "evidence_refs": ["ev-001"]}],
+        "evidence_items": [{"evidence_id": "ev-001", "strength": "strong", "expired": False}],
+        "contradiction_findings": [],
+        "stale_findings": [],
+        "dependency_edges": [{"edge_id": "e-001", "confidence": "high"}],
+        "memory_items": [{"memory_id": "m-001", "trust_level": "strong"}],
+        "scope_drift_findings": [],
+    }
+
+
+def _blocking_bundle() -> dict[str, Any]:
+    return {
+        "meta": {"scope_id": "mcp-blocking-001", "level": "system"},
+        "sources": [],
+        "contradiction_findings": [
+            {"contradiction_id": "c-001", "severity": "blocking", "status": "open"},
+        ],
+    }
+
+
+# ── Permission Guard ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_quality_score_tool_in_exempt_set() -> None:
+    """cdb_context_quality_score must be in INPUT_SCAN_EXEMPT_TOOLS."""
+    assert TOOL_CDB_CONTEXT_QUALITY_SCORE in INPUT_SCAN_EXEMPT_TOOLS
+
+
+# ── Registry ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_quality_score_registered_read_only() -> None:
+    """cdb_context_quality_score is registered as read-only in the registry."""
+    tool = ContextToolRegistry.get_tool(TOOL_CDB_CONTEXT_QUALITY_SCORE)
+    assert tool is not None
+    assert tool.read_only is True
+
+
+@pytest.mark.unit
+def test_quality_score_has_handler() -> None:
+    """cdb_context_quality_score has a non-None handler."""
+    tool = ContextToolRegistry.get_tool(TOOL_CDB_CONTEXT_QUALITY_SCORE)
+    assert tool is not None
+    assert tool.handler is not None
+
+
+# ── Context Bridge ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_bridge_routes_quality_score() -> None:
+    """ContextBridge routes cdb_context_quality_score to the real handler."""
+    bridge = ContextBridge()
+    result = bridge.execute_tool(
+        TOOL_CDB_CONTEXT_QUALITY_SCORE,
+        {"bundle": _clean_bundle(), "as_of": _AS_OF},
+    )
+    assert result.get("status") == "ok"
+    assert result.get("tool") == TOOL_CDB_CONTEXT_QUALITY_SCORE
+
+
+# ── Missing bundle ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_missing_bundle_returns_error() -> None:
+    """Missing bundle parameter returns an error response."""
+    result = handle_quality_score(as_of=_AS_OF)
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "missing_bundle"
+
+
+@pytest.mark.unit
+def test_non_mapping_bundle_returns_error() -> None:
+    """Non-mapping bundle returns an error response."""
+    result = handle_quality_score(bundle="not-a-dict", as_of=_AS_OF)
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "missing_bundle"
+
+
+# ── Valid bundle ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_clean_bundle_returns_ok() -> None:
+    """Clean bundle returns status ok."""
+    result = handle_quality_score(bundle=_clean_bundle(), as_of=_AS_OF)
+    assert result["status"] == "ok"
+
+
+@pytest.mark.unit
+def test_clean_bundle_returns_schema_version() -> None:
+    """Clean bundle result has correct schema_version."""
+    result = handle_quality_score(bundle=_clean_bundle(), as_of=_AS_OF)
+    assert result.get("schema_version") == SCHEMA_VERSION
+
+
+@pytest.mark.unit
+def test_clean_bundle_metadata_read_only() -> None:
+    """Response metadata.read_only is always True."""
+    result = handle_quality_score(bundle=_clean_bundle(), as_of=_AS_OF)
+    assert result.get("metadata", {}).get("read_only") is True
+
+
+@pytest.mark.unit
+def test_clean_bundle_guardrails_present() -> None:
+    """Response includes all GUARDRAILS strings."""
+    result = handle_quality_score(bundle=_clean_bundle(), as_of=_AS_OF)
+    assert set(GUARDRAILS).issubset(set(result.get("guardrails", [])))
+
+
+@pytest.mark.unit
+def test_blocking_bundle_returns_ok_status() -> None:
+    """Blocking bundle still returns status 'ok' (grade is blocking, not error)."""
+    result = handle_quality_score(bundle=_blocking_bundle(), as_of=_AS_OF)
+    assert result["status"] == "ok"
+
+
+@pytest.mark.unit
+def test_clean_bundle_returns_dimensions() -> None:
+    """Clean bundle result has 8 dimension entries."""
+    result = handle_quality_score(bundle=_clean_bundle(), as_of=_AS_OF)
+    dims = result.get("dimensions", [])
+    dim_names = {d["dimension"] for d in dims}
+    assert dim_names == set(SCORE_DIMENSIONS)
+
+
+# ── Filters: dimension ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_dimension_filter() -> None:
+    """dimension filter returns only the specified dimension."""
+    result = handle_quality_score(
+        bundle=_clean_bundle(), dimension="coverage_score", as_of=_AS_OF
+    )
+    dims = result.get("dimensions", [])
+    assert all(d["dimension"] == "coverage_score" for d in dims)
+
+
+@pytest.mark.unit
+def test_invalid_dimension_returns_error() -> None:
+    """Invalid dimension returns an error response."""
+    result = handle_quality_score(
+        bundle=_clean_bundle(), dimension="nonexistent_dimension", as_of=_AS_OF
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "invalid_dimension"
+
+
+# ── Filters: min_grade ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_min_grade_blocking_filter() -> None:
+    """min_grade=blocking returns only blocking dimensions."""
+    result = handle_quality_score(
+        bundle=_blocking_bundle(), min_grade="blocking", as_of=_AS_OF
+    )
+    dims = result.get("dimensions", [])
+    assert all(d["grade"] == "blocking" for d in dims)
+
+
+@pytest.mark.unit
+def test_invalid_grade_returns_error() -> None:
+    """Invalid min_grade returns an error response."""
+    result = handle_quality_score(
+        bundle=_clean_bundle(), min_grade="excellent", as_of=_AS_OF
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "invalid_grade"
+
+
+# ── Filters: limit ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_limit_one_returns_at_most_one_dimension() -> None:
+    """limit=1 returns at most 1 dimension."""
+    result = handle_quality_score(bundle=_clean_bundle(), limit=1, as_of=_AS_OF)
+    assert len(result.get("dimensions", [])) <= 1
+
+
+@pytest.mark.unit
+def test_limit_zero_clamped_to_one() -> None:
+    """limit=0 is clamped to 1 (minimum)."""
+    result = handle_quality_score(bundle=_clean_bundle(), limit=0, as_of=_AS_OF)
+    assert result["status"] == "ok"
+    assert len(result.get("dimensions", [])) >= 0  # may be 0 if no dims match
+
+
+@pytest.mark.unit
+def test_limit_above_max_clamped() -> None:
+    """limit above 500 is silently capped."""
+    result = handle_quality_score(bundle=_clean_bundle(), limit=9999, as_of=_AS_OF)
+    assert result["status"] == "ok"
+    assert len(result.get("dimensions", [])) <= 500

--- a/tools/mcp/architect_signal_tools.py
+++ b/tools/mcp/architect_signal_tools.py
@@ -1,0 +1,154 @@
+"""MCP adapter layer for Wave-18 architect signals tool.
+
+Issues:
+    #2175 — [SURREALDB][CONTEXT][ARCHITECT-MCP] Implement architect signals MCP tool
+    Parent: #2170 (Wave-18 anchor)
+    Epic: #1976
+
+Adapts the Wave-18-D architect signal service for the MCP tool surface.
+The tool is read-only, fail-closed, and carries explicit no-live-go semantics.
+No DB access. No SurrealDB SDK. No network. No writes. No auto-fix. No live-go.
+
+Bundle-driven:
+    The tool operates exclusively on the in-memory bundle passed as input.
+    If no bundle is supplied the tool returns a clean error — it never
+    reads from a database, filesystem, or network to fill the gap.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from tools.surrealdb.architect_signals import (
+    GUARDRAILS,
+    SIGNAL_SEVERITIES,
+    SIGNAL_TYPES,
+    ArchitectSignalError,
+    scan_architect_signals_v1,
+)
+
+TOOL_CDB_CONTEXT_ARCHITECT_SIGNALS = "cdb_context_architect_signals"
+SCHEMA_VERSION = "architect-signals-mcp/v1"
+
+_MAX_LIMIT = 500
+_DEFAULT_LIMIT = 100
+_VALID_SEVERITIES: frozenset[str] = frozenset(SIGNAL_SEVERITIES)
+_VALID_SIGNAL_TYPES: frozenset[str] = frozenset(SIGNAL_TYPES)
+
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+
+def _as_str_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text if text else None
+
+
+def _as_mapping_or_none(value: Any) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        return value
+    return None
+
+
+def _error_response(code: str, message: str) -> dict[str, Any]:
+    return {
+        "tool": TOOL_CDB_CONTEXT_ARCHITECT_SIGNALS,
+        "status": "error",
+        "error": {"code": code, "message": message},
+    }
+
+
+def _metadata(read_only: bool = True) -> dict[str, Any]:
+    return {"source": "in_memory", "read_only": read_only}
+
+
+# ── Main handler ──────────────────────────────────────────────────────────────
+
+
+def handle_architect_signals(**kwargs: Any) -> dict[str, Any]:
+    """Handle a ``cdb_context_architect_signals`` MCP tool call.
+
+    Required parameters:
+        bundle (dict): Input context bundle.
+
+    Optional filter parameters:
+        signal_type (str): Return only signals of this type.
+        min_severity (str): Return only signals at or above this severity
+            (info < watch < blocking).
+        limit (int): Maximum number of signals to return (default 100).
+        as_of (str): Advisory ISO-8601 UTC timestamp passed to the service.
+
+    Returns a read-only architect signal result. ``metadata.read_only`` is
+    always ``True``.
+    """
+    # ── Validate required bundle ──────────────────────────────────────────────
+    bundle = _as_mapping_or_none(kwargs.get("bundle"))
+    if bundle is None:
+        return _error_response(
+            "missing_bundle",
+            "bundle is required and must be a JSON object",
+        )
+
+    # ── Optional filters ──────────────────────────────────────────────────────
+    signal_type = _as_str_or_none(kwargs.get("signal_type"))
+    if signal_type is not None and signal_type not in _VALID_SIGNAL_TYPES:
+        return _error_response(
+            "invalid_signal_type",
+            f"signal_type {signal_type!r} is not valid. "
+            f"Valid: {', '.join(sorted(_VALID_SIGNAL_TYPES))}",
+        )
+
+    min_severity = _as_str_or_none(kwargs.get("min_severity"))
+    if min_severity is not None and min_severity not in _VALID_SEVERITIES:
+        return _error_response(
+            "invalid_severity",
+            f"min_severity {min_severity!r} is not valid. "
+            f"Valid: {', '.join(sorted(_VALID_SEVERITIES))}",
+        )
+
+    raw_limit = kwargs.get("limit", _DEFAULT_LIMIT)
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError):
+        limit = _DEFAULT_LIMIT
+    limit = min(max(limit, 1), _MAX_LIMIT)
+
+    as_of = _as_str_or_none(kwargs.get("as_of"))
+
+    # ── Scan ──────────────────────────────────────────────────────────────────
+    try:
+        result = scan_architect_signals_v1(bundle, as_of=as_of)
+    except ArchitectSignalError as exc:
+        return _error_response("signal_error", str(exc))
+    except Exception as exc:  # noqa: BLE001 - fail-closed
+        return _error_response("internal_error", f"unexpected error: {exc}")
+
+    # ── Filter signals ────────────────────────────────────────────────────────
+    _sev_order = {"blocking": 0, "watch": 1, "info": 2}
+    signals = list(result.signals)
+
+    if signal_type is not None:
+        signals = [s for s in signals if s.signal_type == signal_type]
+
+    if min_severity is not None:
+        min_idx = _sev_order.get(min_severity, 2)
+        signals = [s for s in signals if _sev_order.get(s.severity, 2) <= min_idx]
+
+    signals = signals[:limit]
+
+    # ── Build response ────────────────────────────────────────────────────────
+    return {
+        "tool": TOOL_CDB_CONTEXT_ARCHITECT_SIGNALS,
+        "schema_version": SCHEMA_VERSION,
+        "status": "ok",
+        "scope_id": result.scope_id,
+        "scanned_at": result.scanned_at,
+        "total_signals": result.total_signals,
+        "blocking_count": result.blocking_count,
+        "watch_count": result.watch_count,
+        "signals": [s.to_dict() for s in signals],
+        "guardrails": list(GUARDRAILS),
+        "metadata": _metadata(),
+    }

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -2002,6 +2002,30 @@ def cdb_context_scope_drift_handler(**kwargs) -> dict[str, Any]:
     return handle_cdb_context_scope_drift(kwargs)
 
 
+def cdb_context_quality_score_handler(**kwargs) -> dict[str, Any]:
+    """Read-only MCP handler for cdb_context_quality_score.
+
+    Thin adapter: passes **kwargs as the request mapping to the Wave-18-B adapter.
+    Fail-closed. No DB/network/write. Bundle-driven. Scoring is signal, not
+    action permission. No live-go. No Echtgeld-Go.
+    """
+    from tools.mcp.quality_scoring_tools import handle_quality_score
+
+    return handle_quality_score(**kwargs)
+
+
+def cdb_context_architect_signals_handler(**kwargs) -> dict[str, Any]:
+    """Read-only MCP handler for cdb_context_architect_signals.
+
+    Thin adapter: passes **kwargs as the request mapping to the Wave-18-D adapter.
+    Fail-closed. No DB/network/write. Bundle-driven. Signals are recommendations,
+    not action permissions. No automatic issue creation. No live-go. No Echtgeld-Go.
+    """
+    from tools.mcp.architect_signal_tools import handle_architect_signals
+
+    return handle_architect_signals(**kwargs)
+
+
 class ContextBridge:
     """
     MCP Bridge for Context Intelligence System.
@@ -2198,6 +2222,22 @@ class ContextBridge:
             "cdb_context_scope_drift": cdb_context_scope_drift_handler,
         }
         for _tool_name, _handler_fn in _wave17c_handler_map.items():
+            _old = self._registry.get_tool(_tool_name)
+            if _old:
+                self._registry._tools[_tool_name] = ToolDefinition(
+                    name=_old.name,
+                    description=_old.description,
+                    input_schema=_old.input_schema,
+                    output_schema=_old.output_schema,
+                    read_only=_old.read_only,
+                    handler=_handler_fn,
+                )
+        # Wave-18 handlers (#2173 Quality Score MCP, #2175 Architect Signals MCP)
+        _wave18_handler_map = {
+            "cdb_context_quality_score": cdb_context_quality_score_handler,
+            "cdb_context_architect_signals": cdb_context_architect_signals_handler,
+        }
+        for _tool_name, _handler_fn in _wave18_handler_map.items():
             _old = self._registry.get_tool(_tool_name)
             if _old:
                 self._registry._tools[_tool_name] = ToolDefinition(

--- a/tools/mcp/permission_guard.py
+++ b/tools/mcp/permission_guard.py
@@ -159,6 +159,19 @@ INPUT_SCAN_EXEMPT_TOOLS: frozenset[str] = frozenset({
     # The tool is read-only, bundle-driven, and fail-closed; the scope drift
     # firewall service enforces no-write, no-network, no-auto-fix guardrails.
     "cdb_context_scope_drift",
+    # Wave-18-B quality score MCP tool (#2173).
+    # Processes quality bundles whose source paths, decision descriptions, and
+    # evidence content legitimately contain words like "Create", "Update",
+    # "Delete", "migration", "runbook". The tool is read-only, bundle-driven,
+    # and fail-closed; the quality scoring service enforces no-write, no-network,
+    # no-auto-fix guardrails.
+    "cdb_context_quality_score",
+    # Wave-18-D architect signals MCP tool (#2175).
+    # Processes signal bundles whose findings and explanations legitimately
+    # contain write-intent strings. The tool is read-only, bundle-driven, and
+    # fail-closed; the architect signal service enforces no-write, no-network,
+    # no-auto-fix guardrails.
+    "cdb_context_architect_signals",
 })
 
 

--- a/tools/mcp/quality_scoring_tools.py
+++ b/tools/mcp/quality_scoring_tools.py
@@ -25,7 +25,6 @@ from tools.surrealdb.quality_scoring import (
     GUARDRAILS,
     SCORE_DIMENSIONS,
     QualityScoringError,
-    QualityScoreResult,
     score_knowledge_quality_v1,
 )
 

--- a/tools/mcp/quality_scoring_tools.py
+++ b/tools/mcp/quality_scoring_tools.py
@@ -1,0 +1,157 @@
+"""MCP adapter layer for Wave-18 quality scoring tool.
+
+Issues:
+    #2173 — [SURREALDB][CONTEXT][QUALITY-MCP] Implement quality score MCP tool
+    Parent: #2170 (Wave-18 anchor)
+    Epic: #1976
+
+Adapts the Wave-18-A knowledge quality scoring domain service for the MCP tool
+surface. The tool is read-only, fail-closed, and carries explicit no-live-go
+semantics. No DB access. No SurrealDB SDK. No network. No writes. No auto-fix.
+No live-go.
+
+Bundle-driven:
+    The tool operates exclusively on the in-memory bundle passed as input.
+    If no bundle is supplied the tool returns a clean error — it never
+    reads from a database, filesystem, or network to fill the gap.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from tools.surrealdb.quality_scoring import (
+    GRADES,
+    GUARDRAILS,
+    SCORE_DIMENSIONS,
+    QualityScoringError,
+    QualityScoreResult,
+    score_knowledge_quality_v1,
+)
+
+TOOL_CDB_CONTEXT_QUALITY_SCORE = "cdb_context_quality_score"
+SCHEMA_VERSION = "quality-score-mcp/v1"
+
+_MAX_LIMIT = 500
+_DEFAULT_LIMIT = 100
+_VALID_GRADES: frozenset[str] = frozenset(GRADES)
+_VALID_DIMENSIONS: frozenset[str] = frozenset(SCORE_DIMENSIONS)
+
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+
+def _as_str_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text if text else None
+
+
+def _as_mapping_or_none(value: Any) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        return value
+    return None
+
+
+def _error_response(code: str, message: str) -> dict[str, Any]:
+    return {
+        "tool": TOOL_CDB_CONTEXT_QUALITY_SCORE,
+        "status": "error",
+        "error": {"code": code, "message": message},
+    }
+
+
+def _metadata(read_only: bool = True) -> dict[str, Any]:
+    return {"source": "in_memory", "read_only": read_only}
+
+
+# ── Main handler ──────────────────────────────────────────────────────────────
+
+
+def handle_quality_score(**kwargs: Any) -> dict[str, Any]:
+    """Handle a ``cdb_context_quality_score`` MCP tool call.
+
+    Required parameters:
+        bundle (dict): Input quality bundle.
+
+    Optional filter parameters:
+        dimension (str): Show only a single score dimension.
+        min_grade (str): Filter dimensions to those at or below this grade.
+        limit (int): Maximum number of dimensions to return (default 100).
+        as_of (str): Advisory ISO-8601 UTC timestamp passed to the scorer.
+
+    Returns a read-only quality score result. ``metadata.read_only`` is
+    always ``True``.
+    """
+    # ── Validate required bundle ──────────────────────────────────────────────
+    bundle = _as_mapping_or_none(kwargs.get("bundle"))
+    if bundle is None:
+        return _error_response(
+            "missing_bundle",
+            "bundle is required and must be a JSON object",
+        )
+
+    # ── Optional filters ──────────────────────────────────────────────────────
+    dimension = _as_str_or_none(kwargs.get("dimension"))
+    if dimension is not None and dimension not in _VALID_DIMENSIONS:
+        return _error_response(
+            "invalid_dimension",
+            f"dimension {dimension!r} is not valid. "
+            f"Valid: {', '.join(sorted(_VALID_DIMENSIONS))}",
+        )
+
+    min_grade = _as_str_or_none(kwargs.get("min_grade"))
+    if min_grade is not None and min_grade not in _VALID_GRADES:
+        return _error_response(
+            "invalid_grade",
+            f"min_grade {min_grade!r} is not valid. Valid: {', '.join(sorted(_VALID_GRADES))}",
+        )
+
+    raw_limit = kwargs.get("limit", _DEFAULT_LIMIT)
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError):
+        limit = _DEFAULT_LIMIT
+    limit = min(max(limit, 1), _MAX_LIMIT)
+
+    as_of = _as_str_or_none(kwargs.get("as_of"))
+
+    # ── Score ─────────────────────────────────────────────────────────────────
+    try:
+        result = score_knowledge_quality_v1(bundle, as_of=as_of)
+    except QualityScoringError as exc:
+        return _error_response("scoring_error", str(exc))
+    except Exception as exc:  # noqa: BLE001 - fail-closed
+        return _error_response("internal_error", f"unexpected error: {exc}")
+
+    # ── Filter dimensions ─────────────────────────────────────────────────────
+    _grade_order = {"blocking": 0, "watch": 1, "weak": 2, "good": 3}
+    dims = list(result.dimensions)
+
+    if dimension is not None:
+        dims = [d for d in dims if d.dimension == dimension]
+
+    if min_grade is not None:
+        min_idx = _grade_order.get(min_grade, 3)
+        dims = [d for d in dims if _grade_order.get(d.grade, 3) <= min_idx]
+
+    dims = dims[:limit]
+
+    # ── Build response ────────────────────────────────────────────────────────
+    return {
+        "tool": TOOL_CDB_CONTEXT_QUALITY_SCORE,
+        "schema_version": SCHEMA_VERSION,
+        "status": "ok",
+        "scope_id": result.scope_id,
+        "level": result.level,
+        "scored_at": result.scored_at,
+        "overall_score": result.overall_score,
+        "overall_grade": result.overall_grade,
+        "blocking_dimensions": list(result.blocking_dimensions),
+        "watch_dimensions": list(result.watch_dimensions),
+        "recommended_next_reads": list(result.recommended_next_reads),
+        "dimensions": [d.to_dict() for d in dims],
+        "guardrails": list(GUARDRAILS),
+        "metadata": _metadata(),
+    }

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -1293,6 +1293,129 @@ TOOLS_V0 = [
         read_only=True,
         handler=create_not_implemented_handler("cdb_context_scope_drift"),
     ),
+    # Wave-18: Knowledge Quality Scoring MCP tool (#2173)
+    ToolDefinition(
+        name="cdb_context_quality_score",
+        description=(
+            "Score the quality of a knowledge context bundle across 8 dimensions "
+            "(coverage, freshness, evidence, contradiction, dependency confidence, "
+            "memory trust, decision validity, scope risk). Returns overall grade "
+            "(blocking/watch/weak/good) and per-dimension scores. "
+            "Read-only, bundle-driven, fail-closed. No DB/network/writes."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "bundle": {
+                    "type": "object",
+                    "description": "Quality scoring bundle containing sources, decisions, evidence, findings.",
+                },
+                "dimension": {
+                    "type": ["string", "null"],
+                    "description": "Return only a single score dimension.",
+                },
+                "min_grade": {
+                    "type": ["string", "null"],
+                    "enum": ["blocking", "watch", "weak", "good", None],
+                    "description": "Return only dimensions at or below this grade.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "default": 100,
+                    "minimum": 1,
+                    "maximum": 500,
+                    "description": "Maximum number of dimensions to return.",
+                },
+                "as_of": {
+                    "type": ["string", "null"],
+                    "description": "Advisory ISO-8601 UTC timestamp for the scoring run.",
+                },
+            },
+            "required": ["bundle"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "schema_version": {"type": "string"},
+                "status": {"type": "string"},
+                "scope_id": {"type": "string"},
+                "level": {"type": "string"},
+                "scored_at": {"type": "string"},
+                "overall_score": {"type": "number"},
+                "overall_grade": {"type": "string"},
+                "blocking_dimensions": {"type": "array"},
+                "watch_dimensions": {"type": "array"},
+                "recommended_next_reads": {"type": "array"},
+                "dimensions": {"type": "array"},
+                "guardrails": {"type": "array"},
+                "metadata": {"type": "object"},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("cdb_context_quality_score"),
+    ),
+    # Wave-18: Architect Signals MCP tool (#2175)
+    ToolDefinition(
+        name="cdb_context_architect_signals",
+        description=(
+            "Detect proactive architect signals from a context bundle. "
+            "Generates 11 signal types: stale_area, weakly_evidenced_decision, "
+            "underdocumented_surface, undertested_surface, high_dependency_risk, "
+            "contradiction_hotspot, scope_drift_hotspot, repeated_agent_confusion, "
+            "redundant_docs, missing_owner, fragile_context_path. "
+            "Read-only, bundle-driven, fail-closed. No DB/network/writes. "
+            "No automatic issue creation. Human-GO required for blocking signals."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "bundle": {
+                    "type": "object",
+                    "description": "Context bundle containing sources, decisions, evidence, findings.",
+                },
+                "signal_type": {
+                    "type": ["string", "null"],
+                    "description": "Return only signals of this type.",
+                },
+                "min_severity": {
+                    "type": ["string", "null"],
+                    "enum": ["info", "watch", "blocking", None],
+                    "description": "Return only signals at or above this severity.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "default": 100,
+                    "minimum": 1,
+                    "maximum": 500,
+                    "description": "Maximum number of signals to return.",
+                },
+                "as_of": {
+                    "type": ["string", "null"],
+                    "description": "Advisory ISO-8601 UTC timestamp for the scan.",
+                },
+            },
+            "required": ["bundle"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "schema_version": {"type": "string"},
+                "status": {"type": "string"},
+                "scope_id": {"type": "string"},
+                "scanned_at": {"type": "string"},
+                "total_signals": {"type": "integer"},
+                "blocking_count": {"type": "integer"},
+                "watch_count": {"type": "integer"},
+                "signals": {"type": "array"},
+                "guardrails": {"type": "array"},
+                "metadata": {"type": "object"},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("cdb_context_architect_signals"),
+    ),
 ]
 
 

--- a/tools/surrealdb/architect_signals.py
+++ b/tools/surrealdb/architect_signals.py
@@ -182,7 +182,7 @@ def _is_open(item: Mapping[str, Any]) -> bool:
 def _path_of(item: Any) -> str:
     if not isinstance(item, Mapping):
         return ""
-    for key in ("source_path", "target_path", "target_ref", "affected_path", "artifact_ref"):
+    for key in ("source_path", "target_path", "target_ref", "affected_path", "artifact_ref", "source", "target"):
         val = _as_str(item.get(key, ""))
         if val:
             return val
@@ -323,7 +323,23 @@ def _detect_high_dependency_risk(dependency_edges: list[Any]) -> list[ArchitectS
     fraction = len(low_conf_edges) / len(dependency_edges)
     if fraction < _LOW_CONFIDENCE_FRACTION:
         return []
-    paths = list({_path_of(e) for e in low_conf_edges if _path_of(e)})[:20]
+    # Collect both source and target endpoints for dependency edges; fall back
+    # to _path_of for edges that use other path-key conventions.
+    paths_set: set[str] = set()
+    for e in low_conf_edges:
+        if not isinstance(e, Mapping):
+            continue
+        src = _as_str(e.get("source", ""))
+        tgt = _as_str(e.get("target", ""))
+        if src:
+            paths_set.add(src)
+        if tgt:
+            paths_set.add(tgt)
+        if not src and not tgt:
+            p = _path_of(e)
+            if p:
+                paths_set.add(p)
+    paths = sorted(paths_set)[:20]
     edge_ids = [_as_str(e.get("edge_id", "")) for e in low_conf_edges[:10]]
     return [
         ArchitectSignal(

--- a/tools/surrealdb/architect_signals.py
+++ b/tools/surrealdb/architect_signals.py
@@ -1,0 +1,643 @@
+"""Architect Signal Service v1 — side-effect-free domain component.
+
+Issues:
+    #2174 — [SURREALDB][CONTEXT][ARCHITECT-SIGNALS] Implement architect signal service v1
+    Parent: #2170 (Wave-18 anchor)
+    Epic: #1976
+
+Scope:
+    Pure, deterministic architect signal service. Generates proactive architecture
+    signals from quality scores, contradiction findings, stale findings, and scope
+    drift findings. No DB access. No SurrealDB SDK. No MCP. No networking.
+    No writes. No auto-fix. No live-go. No automatic issue creation.
+
+    Detects 11 signal types:
+        stale_area                   — area has multiple stale findings
+        weakly_evidenced_decision    — decision lacks strong evidence
+        underdocumented_surface      — sources missing documentation
+        undertested_surface          — sources missing tests
+        high_dependency_risk         — dependency edges with low confidence
+        contradiction_hotspot        — area with multiple open contradictions
+        scope_drift_hotspot          — area with multiple open scope drift findings
+        repeated_agent_confusion     — multiple stale/contradiction findings on same path
+        redundant_docs               — documentation coverage exceeds source count (heuristic)
+        missing_owner                — sources without owner metadata
+        fragile_context_path         — combined stale + contradiction + scope drift on same path
+
+Guardrails:
+    - Architect Signal is recommendation, not command.
+    - No automatic issue creation.
+    - accepted_risk / false_positive is modellable.
+    - No auto-fix. No auto-write.
+    - LR status remains NO-GO for live trading.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+SCHEMA_VERSION = "architect-signals/v1"
+DETECTED_BY = "architect-signals/v1"
+
+SIGNAL_TYPES = frozenset(
+    {
+        "stale_area",
+        "weakly_evidenced_decision",
+        "underdocumented_surface",
+        "undertested_surface",
+        "high_dependency_risk",
+        "contradiction_hotspot",
+        "scope_drift_hotspot",
+        "repeated_agent_confusion",
+        "redundant_docs",
+        "missing_owner",
+        "fragile_context_path",
+    }
+)
+
+SIGNAL_SEVERITIES = ("info", "watch", "blocking")
+
+STATUS_VALUES = frozenset(
+    {
+        "open",
+        "accepted_risk",
+        "false_positive",
+        "resolved",
+        "acknowledged",
+    }
+)
+
+GUARDRAILS: tuple[str, ...] = (
+    "Architect Signal is recommendation, not command.",
+    "No automatic issue creation.",
+    "No auto-fix. No auto-write.",
+    "No Live-Readiness-Go.",
+    "No Echtgeld-Go.",
+    "Human-GO required for any action after blocking architect signal.",
+)
+
+# Thresholds
+_STALE_AREA_THRESHOLD = 2          # ≥ N open stale findings → stale_area
+_CONTRADICTION_HOTSPOT_THRESHOLD = 2  # ≥ N open contradictions → hotspot
+_SCOPE_DRIFT_HOTSPOT_THRESHOLD = 2 # ≥ N open scope drifts → hotspot
+_FRAGILE_PATH_THRESHOLD = 2        # ≥ N combined findings on same path → fragile
+_LOW_CONFIDENCE_FRACTION = 0.50    # fraction of low-confidence edges → high_dependency_risk
+
+
+class ArchitectSignalError(ValueError):
+    """Raised when architect signal inputs are invalid or unsafe."""
+
+
+# ── Data Models ───────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ArchitectSignal:
+    """A single architect signal finding."""
+
+    signal_id: str
+    signal_type: str
+    severity: str           # info / watch / blocking
+    title: str
+    explanation: str
+    affected_paths: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+    recommended_action: str
+    status: str = "open"    # open / accepted_risk / false_positive / resolved
+    detected_by: str = DETECTED_BY
+    detected_at: str = field(default_factory=lambda: cdb_utcnow().isoformat())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "signal_id": self.signal_id,
+            "signal_type": self.signal_type,
+            "severity": self.severity,
+            "title": self.title,
+            "explanation": self.explanation,
+            "affected_paths": list(self.affected_paths),
+            "evidence_refs": list(self.evidence_refs),
+            "recommended_action": self.recommended_action,
+            "status": self.status,
+            "detected_by": self.detected_by,
+            "detected_at": self.detected_at,
+        }
+
+
+@dataclass(frozen=True)
+class ArchitectSignalResult:
+    """Full architect signal scan result."""
+
+    scope_id: str
+    total_signals: int
+    blocking_count: int
+    watch_count: int
+    signals: tuple[ArchitectSignal, ...]
+    guardrails: tuple[str, ...] = field(default_factory=lambda: GUARDRAILS)
+    scanned_at: str = field(default_factory=lambda: cdb_utcnow().isoformat())
+    schema_version: str = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "scope_id": self.scope_id,
+            "scanned_at": self.scanned_at,
+            "total_signals": self.total_signals,
+            "blocking_count": self.blocking_count,
+            "watch_count": self.watch_count,
+            "guardrails": list(self.guardrails),
+            "signals": [s.to_dict() for s in self.signals],
+        }
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def _as_str(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    return str(value).strip() if value is not None else ""
+
+
+def _signal_id(signal_type: str, *parts: str) -> str:
+    raw = "|".join([signal_type, *parts])
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def _is_open(item: Mapping[str, Any]) -> bool:
+    status = _as_str(item.get("status", "open")).lower()
+    return status not in ("false_positive", "accepted_risk", "resolved", "superseded", "refreshed")
+
+
+def _path_of(item: Any) -> str:
+    if not isinstance(item, Mapping):
+        return ""
+    for key in ("source_path", "target_path", "target_ref", "affected_path", "artifact_ref"):
+        val = _as_str(item.get(key, ""))
+        if val:
+            return val
+    return ""
+
+
+# ── Signal detectors ──────────────────────────────────────────────────────────
+
+
+def _detect_stale_area(stale_findings: list[Any]) -> list[ArchitectSignal]:
+    """stale_area: a path has >= threshold open stale findings."""
+    path_counts: dict[str, list[str]] = {}
+    for f in stale_findings:
+        if not isinstance(f, Mapping) or not _is_open(f):
+            continue
+        path = _path_of(f) or "unknown"
+        ref = _as_str(f.get("stale_id", f.get("artifact_id", "")))
+        path_counts.setdefault(path, []).append(ref)
+
+    signals = []
+    for path, refs in sorted(path_counts.items()):
+        if len(refs) >= _STALE_AREA_THRESHOLD:
+            signals.append(
+                ArchitectSignal(
+                    signal_id=_signal_id("stale_area", path),
+                    signal_type="stale_area",
+                    severity="watch",
+                    title=f"Stale area detected: {path}",
+                    explanation=(
+                        f"{len(refs)} open stale findings on path '{path}'. "
+                        "This area may require a focused refresh review."
+                    ),
+                    affected_paths=(path,),
+                    evidence_refs=tuple(refs[:10]),
+                    recommended_action="Review stale findings and schedule a context refresh.",
+                )
+            )
+    return signals
+
+
+def _detect_weakly_evidenced_decision(decisions: list[Any], evidence_items: list[Any]) -> list[ArchitectSignal]:
+    """weakly_evidenced_decision: a decision has no strong evidence refs."""
+    strong_ids = {
+        _as_str(e.get("evidence_id", ""))
+        for e in evidence_items
+        if isinstance(e, Mapping)
+        and _as_str(e.get("strength", "none")).lower() in ("strong", "moderate")
+        and not e.get("expired", False)
+    }
+
+    signals = []
+    for d in decisions:
+        if not isinstance(d, Mapping):
+            continue
+        status = _as_str(d.get("status", "current")).lower()
+        if status in ("superseded", "invalidated"):
+            continue
+        dec_id = _as_str(d.get("decision_id", "unknown"))
+        refs = [_as_str(r) for r in _as_list(d.get("evidence_refs")) if _as_str(r)]
+        has_strong = any(r in strong_ids for r in refs) if refs else False
+        if not has_strong:
+            signals.append(
+                ArchitectSignal(
+                    signal_id=_signal_id("weakly_evidenced_decision", dec_id),
+                    signal_type="weakly_evidenced_decision",
+                    severity="watch",
+                    title=f"Weakly evidenced decision: {dec_id}",
+                    explanation=(
+                        f"Decision '{dec_id}' has no strong or moderate evidence references. "
+                        "Consider adding evidence to support this decision."
+                    ),
+                    affected_paths=(),
+                    evidence_refs=tuple(refs[:5]),
+                    recommended_action="Add strong evidence references to this decision.",
+                )
+            )
+    return signals
+
+
+def _detect_surface_gaps(sources: list[Any]) -> list[ArchitectSignal]:
+    """underdocumented_surface and undertested_surface."""
+    signals = []
+    undoc_paths = []
+    untest_paths = []
+    for s in sources:
+        if not isinstance(s, Mapping):
+            continue
+        path = _path_of(s) or _as_str(s.get("source_id", "unknown"))
+        if not s.get("has_documentation"):
+            undoc_paths.append(path)
+        if not s.get("has_tests"):
+            untest_paths.append(path)
+
+    if undoc_paths:
+        signals.append(
+            ArchitectSignal(
+                signal_id=_signal_id("underdocumented_surface", *sorted(undoc_paths[:5])),
+                signal_type="underdocumented_surface",
+                severity="watch",
+                title=f"{len(undoc_paths)} source(s) lack documentation",
+                explanation=(
+                    f"{len(undoc_paths)} source(s) have no associated documentation. "
+                    "Documentation gaps reduce agent context quality."
+                ),
+                affected_paths=tuple(undoc_paths[:20]),
+                evidence_refs=(),
+                recommended_action="Add documentation for undocumented sources.",
+            )
+        )
+    if untest_paths:
+        signals.append(
+            ArchitectSignal(
+                signal_id=_signal_id("undertested_surface", *sorted(untest_paths[:5])),
+                signal_type="undertested_surface",
+                severity="watch",
+                title=f"{len(untest_paths)} source(s) lack tests",
+                explanation=(
+                    f"{len(untest_paths)} source(s) have no associated tests. "
+                    "Test gaps reduce confidence in the context layer."
+                ),
+                affected_paths=tuple(untest_paths[:20]),
+                evidence_refs=(),
+                recommended_action="Add tests for untested sources.",
+            )
+        )
+    return signals
+
+
+def _detect_high_dependency_risk(dependency_edges: list[Any]) -> list[ArchitectSignal]:
+    """high_dependency_risk: majority of dependency edges have low confidence."""
+    if not dependency_edges:
+        return []
+    low_conf_edges = [
+        e for e in dependency_edges
+        if isinstance(e, Mapping)
+        and _as_str(e.get("confidence", "unknown")).lower() in ("low", "unknown")
+    ]
+    fraction = len(low_conf_edges) / len(dependency_edges)
+    if fraction < _LOW_CONFIDENCE_FRACTION:
+        return []
+    paths = list({_path_of(e) for e in low_conf_edges if _path_of(e)})[:20]
+    edge_ids = [_as_str(e.get("edge_id", "")) for e in low_conf_edges[:10]]
+    return [
+        ArchitectSignal(
+            signal_id=_signal_id("high_dependency_risk", str(len(low_conf_edges))),
+            signal_type="high_dependency_risk",
+            severity="watch",
+            title=f"{len(low_conf_edges)}/{len(dependency_edges)} dependency edges have low confidence",
+            explanation=(
+                f"{fraction:.0%} of dependency edges have low or unknown confidence. "
+                "This reduces the reliability of impact analysis."
+            ),
+            affected_paths=tuple(paths),
+            evidence_refs=tuple(edge_ids),
+            recommended_action="Review and strengthen low-confidence dependency edges.",
+        )
+    ]
+
+
+def _detect_contradiction_hotspot(contradiction_findings: list[Any]) -> list[ArchitectSignal]:
+    """contradiction_hotspot: a path has >= threshold open contradictions."""
+    path_counts: dict[str, list[str]] = {}
+    for f in contradiction_findings:
+        if not isinstance(f, Mapping) or not _is_open(f):
+            continue
+        path = _path_of(f) or "unknown"
+        ref = _as_str(f.get("contradiction_id", ""))
+        path_counts.setdefault(path, []).append(ref)
+
+    signals = []
+    for path, refs in sorted(path_counts.items()):
+        if len(refs) >= _CONTRADICTION_HOTSPOT_THRESHOLD:
+            signals.append(
+                ArchitectSignal(
+                    signal_id=_signal_id("contradiction_hotspot", path),
+                    signal_type="contradiction_hotspot",
+                    severity="blocking" if len(refs) >= 4 else "watch",
+                    title=f"Contradiction hotspot: {path}",
+                    explanation=(
+                        f"{len(refs)} open contradictions detected on path '{path}'. "
+                        "This area has conflicting knowledge that requires resolution."
+                    ),
+                    affected_paths=(path,),
+                    evidence_refs=tuple(refs[:10]),
+                    recommended_action=(
+                        "Resolve open contradictions. "
+                        "Do not proceed with writes until contradictions are cleared."
+                    ),
+                )
+            )
+    return signals
+
+
+def _detect_scope_drift_hotspot(scope_drift_findings: list[Any]) -> list[ArchitectSignal]:
+    """scope_drift_hotspot: a path has >= threshold open scope drift findings."""
+    path_counts: dict[str, list[str]] = {}
+    for f in scope_drift_findings:
+        if not isinstance(f, Mapping) or not _is_open(f):
+            continue
+        path = _path_of(f) or "unknown"
+        ref = _as_str(f.get("drift_id", ""))
+        path_counts.setdefault(path, []).append(ref)
+
+    signals = []
+    for path, refs in sorted(path_counts.items()):
+        if len(refs) >= _SCOPE_DRIFT_HOTSPOT_THRESHOLD:
+            signals.append(
+                ArchitectSignal(
+                    signal_id=_signal_id("scope_drift_hotspot", path),
+                    signal_type="scope_drift_hotspot",
+                    severity="blocking",
+                    title=f"Scope drift hotspot: {path}",
+                    explanation=(
+                        f"{len(refs)} open scope drift findings on path '{path}'. "
+                        "Repeated scope drift indicates persistent boundary violations."
+                    ),
+                    affected_paths=(path,),
+                    evidence_refs=tuple(refs[:10]),
+                    recommended_action=(
+                        "Stop writes to this path. "
+                        "Review scope definitions and obtain Human-GO before continuing."
+                    ),
+                )
+            )
+    return signals
+
+
+def _detect_repeated_agent_confusion(
+    stale_findings: list[Any], contradiction_findings: list[Any]
+) -> list[ArchitectSignal]:
+    """repeated_agent_confusion: same path appears in both stale and contradiction findings."""
+    stale_paths = {
+        _path_of(f)
+        for f in stale_findings
+        if isinstance(f, Mapping) and _is_open(f) and _path_of(f)
+    }
+    contradiction_paths = {
+        _path_of(f)
+        for f in contradiction_findings
+        if isinstance(f, Mapping) and _is_open(f) and _path_of(f)
+    }
+    overlap = sorted(stale_paths & contradiction_paths)
+    if not overlap:
+        return []
+    return [
+        ArchitectSignal(
+            signal_id=_signal_id("repeated_agent_confusion", *overlap[:5]),
+            signal_type="repeated_agent_confusion",
+            severity="watch",
+            title=f"{len(overlap)} path(s) have both stale and contradiction findings",
+            explanation=(
+                f"{len(overlap)} path(s) appear in both stale and contradiction findings: "
+                f"{overlap[:5]}. "
+                "This pattern suggests persistent knowledge quality issues."
+            ),
+            affected_paths=tuple(overlap[:20]),
+            evidence_refs=(),
+            recommended_action=(
+                "Review these paths holistically. "
+                "Resolve contradictions and refresh stale knowledge together."
+            ),
+        )
+    ]
+
+
+def _detect_missing_owner(sources: list[Any]) -> list[ArchitectSignal]:
+    """missing_owner: sources without owner metadata."""
+    no_owner = [
+        _path_of(s) or _as_str(s.get("source_id", "unknown"))
+        for s in sources
+        if isinstance(s, Mapping)
+        and not (s.get("owner") or s.get("team") or s.get("author"))
+    ]
+    if not no_owner:
+        return []
+    return [
+        ArchitectSignal(
+            signal_id=_signal_id("missing_owner", str(len(no_owner))),
+            signal_type="missing_owner",
+            severity="info",
+            title=f"{len(no_owner)} source(s) have no owner metadata",
+            explanation=(
+                f"{len(no_owner)} sources have no owner, team, or author metadata. "
+                "Ownerless sources are harder to maintain and review."
+            ),
+            affected_paths=tuple(no_owner[:20]),
+            evidence_refs=(),
+            recommended_action="Assign owner metadata to unowned sources.",
+        )
+    ]
+
+
+def _detect_fragile_context_path(
+    stale_findings: list[Any],
+    contradiction_findings: list[Any],
+    scope_drift_findings: list[Any],
+) -> list[ArchitectSignal]:
+    """fragile_context_path: a path appears across all three finding types."""
+    def open_paths(findings: list[Any]) -> set[str]:
+        return {
+            _path_of(f)
+            for f in findings
+            if isinstance(f, Mapping) and _is_open(f) and _path_of(f)
+        }
+
+    triple_overlap = sorted(
+        open_paths(stale_findings)
+        & open_paths(contradiction_findings)
+        & open_paths(scope_drift_findings)
+    )
+    if not triple_overlap:
+        return []
+    return [
+        ArchitectSignal(
+            signal_id=_signal_id("fragile_context_path", *triple_overlap[:5]),
+            signal_type="fragile_context_path",
+            severity="blocking",
+            title=f"{len(triple_overlap)} path(s) have stale + contradiction + scope drift findings",
+            explanation=(
+                f"{len(triple_overlap)} path(s) are flagged across all three quality dimensions "
+                f"(stale, contradiction, scope drift): {triple_overlap[:5]}. "
+                "These are the most fragile areas of the context layer."
+            ),
+            affected_paths=tuple(triple_overlap[:20]),
+            evidence_refs=(),
+            recommended_action=(
+                "Do not proceed with writes. "
+                "Prioritise resolution of fragile context paths. Human-GO required."
+            ),
+        )
+    ]
+
+
+def _detect_redundant_docs(sources: list[Any]) -> list[ArchitectSignal]:
+    """redundant_docs: heuristic — sources with has_documentation but no has_tests,
+    concentrated in documentation-heavy paths (doc count > code count)."""
+    doc_only = [
+        _path_of(s) or _as_str(s.get("source_id", "unknown"))
+        for s in sources
+        if isinstance(s, Mapping)
+        and s.get("has_documentation") is True
+        and s.get("has_tests") is not True
+        and _as_str(s.get("file_type", "")).lower() in ("markdown", "md", "rst", "txt")
+    ]
+    total_docs = sum(
+        1
+        for s in sources
+        if isinstance(s, Mapping)
+        and _as_str(s.get("file_type", "")).lower() in ("markdown", "md", "rst", "txt")
+    )
+    total_code = sum(
+        1
+        for s in sources
+        if isinstance(s, Mapping)
+        and _as_str(s.get("file_type", "")).lower() in ("python", "py", "ts", "js")
+    )
+    if total_docs <= total_code or len(doc_only) < 3:
+        return []
+    return [
+        ArchitectSignal(
+            signal_id=_signal_id("redundant_docs", str(total_docs), str(total_code)),
+            signal_type="redundant_docs",
+            severity="info",
+            title=f"Documentation volume ({total_docs}) exceeds code volume ({total_code})",
+            explanation=(
+                f"There are {total_docs} documentation sources vs. {total_code} code sources. "
+                f"{len(doc_only)} documentation sources have no test coverage. "
+                "Consider consolidating or archiving redundant documentation."
+            ),
+            affected_paths=tuple(doc_only[:20]),
+            evidence_refs=(),
+            recommended_action="Audit documentation sources for redundancy and consolidation opportunities.",
+        )
+    ]
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def scan_architect_signals_v1(
+    bundle: Mapping[str, Any],
+    as_of: str | None = None,
+) -> ArchitectSignalResult:
+    """Scan a context bundle for architect signals.
+
+    The bundle should contain the same structure as the quality scoring bundle,
+    optionally enriched with quality score results:
+
+    .. code-block:: json
+
+        {
+          "meta": {"scope_id": "...", "level": "system"},
+          "sources": [...],
+          "decisions": [...],
+          "evidence_items": [...],
+          "contradiction_findings": [...],
+          "stale_findings": [...],
+          "dependency_edges": [...],
+          "scope_drift_findings": [...]
+        }
+
+    Returns an :class:`ArchitectSignalResult` with zero or more signals.
+
+    Raises:
+        ArchitectSignalError: if the bundle is structurally invalid.
+    """
+    if not isinstance(bundle, Mapping):
+        raise ArchitectSignalError("bundle must be a mapping")
+    meta = bundle.get("meta")
+    if not isinstance(meta, Mapping):
+        raise ArchitectSignalError("bundle.meta must be a mapping")
+
+    scope_id = _as_str(meta.get("scope_id", "")) or hashlib.sha256(
+        str(bundle).encode()
+    ).hexdigest()[:16]
+
+    sources = _as_list(bundle.get("sources"))
+    decisions = _as_list(bundle.get("decisions"))
+    evidence_items = _as_list(bundle.get("evidence_items"))
+    contradiction_findings = _as_list(bundle.get("contradiction_findings"))
+    stale_findings = _as_list(bundle.get("stale_findings"))
+    dependency_edges = _as_list(bundle.get("dependency_edges"))
+    scope_drift_findings = _as_list(bundle.get("scope_drift_findings"))
+
+    all_signals: list[ArchitectSignal] = []
+    all_signals.extend(_detect_stale_area(stale_findings))
+    all_signals.extend(_detect_weakly_evidenced_decision(decisions, evidence_items))
+    all_signals.extend(_detect_surface_gaps(sources))
+    all_signals.extend(_detect_high_dependency_risk(dependency_edges))
+    all_signals.extend(_detect_contradiction_hotspot(contradiction_findings))
+    all_signals.extend(_detect_scope_drift_hotspot(scope_drift_findings))
+    all_signals.extend(
+        _detect_repeated_agent_confusion(stale_findings, contradiction_findings)
+    )
+    all_signals.extend(_detect_missing_owner(sources))
+    all_signals.extend(
+        _detect_fragile_context_path(
+            stale_findings, contradiction_findings, scope_drift_findings
+        )
+    )
+    all_signals.extend(_detect_redundant_docs(sources))
+
+    blocking_count = sum(1 for s in all_signals if s.severity == "blocking")
+    watch_count = sum(1 for s in all_signals if s.severity == "watch")
+
+    # Sort: blocking first, then watch, then info
+    _sev_order = {"blocking": 0, "watch": 1, "info": 2}
+    sorted_signals = sorted(all_signals, key=lambda s: _sev_order.get(s.severity, 3))
+
+    return ArchitectSignalResult(
+        scope_id=scope_id,
+        total_signals=len(sorted_signals),
+        blocking_count=blocking_count,
+        watch_count=watch_count,
+        signals=tuple(sorted_signals),
+        scanned_at=(as_of or cdb_utcnow().isoformat()),
+    )

--- a/tools/surrealdb/architect_signals.py
+++ b/tools/surrealdb/architect_signals.py
@@ -35,7 +35,7 @@ Guardrails:
 from __future__ import annotations
 
 import hashlib
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Mapping
 
 from core.utils.clock import utcnow as cdb_utcnow
@@ -623,6 +623,11 @@ def scan_architect_signals_v1(
     dependency_edges = _as_list(bundle.get("dependency_edges"))
     scope_drift_findings = _as_list(bundle.get("scope_drift_findings"))
 
+    # Compute one deterministic timestamp for the entire scan so that
+    # scanned_at and every signal's detected_at are identical when as_of
+    # is provided (fixes non-deterministic output on repeated calls).
+    effective_ts: str = as_of or cdb_utcnow().isoformat()
+
     all_signals: list[ArchitectSignal] = []
     all_signals.extend(_detect_stale_area(stale_findings))
     all_signals.extend(_detect_weakly_evidenced_decision(decisions, evidence_items))
@@ -641,6 +646,9 @@ def scan_architect_signals_v1(
     )
     all_signals.extend(_detect_redundant_docs(sources))
 
+    # Stamp all signals with the effective scan timestamp.
+    all_signals = [replace(s, detected_at=effective_ts) for s in all_signals]
+
     blocking_count = sum(1 for s in all_signals if s.severity == "blocking")
     watch_count = sum(1 for s in all_signals if s.severity == "watch")
 
@@ -654,5 +662,5 @@ def scan_architect_signals_v1(
         blocking_count=blocking_count,
         watch_count=watch_count,
         signals=tuple(sorted_signals),
-        scanned_at=(as_of or cdb_utcnow().isoformat()),
+        scanned_at=effective_ts,
     )

--- a/tools/surrealdb/architect_signals.py
+++ b/tools/surrealdb/architect_signals.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping
 
 from core.utils.clock import utcnow as cdb_utcnow
 
@@ -84,7 +84,6 @@ GUARDRAILS: tuple[str, ...] = (
 _STALE_AREA_THRESHOLD = 2          # ≥ N open stale findings → stale_area
 _CONTRADICTION_HOTSPOT_THRESHOLD = 2  # ≥ N open contradictions → hotspot
 _SCOPE_DRIFT_HOTSPOT_THRESHOLD = 2 # ≥ N open scope drifts → hotspot
-_FRAGILE_PATH_THRESHOLD = 2        # ≥ N combined findings on same path → fragile
 _LOW_CONFIDENCE_FRACTION = 0.50    # fraction of low-confidence edges → high_dependency_risk
 
 

--- a/tools/surrealdb/quality_scoring.py
+++ b/tools/surrealdb/quality_scoring.py
@@ -73,6 +73,13 @@ GUARDRAILS: tuple[str, ...] = (
     "Human-GO required for any action after blocking quality score.",
 )
 
+# Stale finding statuses that are terminal/remediated and should not penalise
+# freshness. Mirrors the non-penalised sets used in contradiction and scope-risk
+# scoring.
+_STALE_EXEMPT_STATUSES: frozenset[str] = frozenset(
+    {"refreshed", "accepted_risk", "false_positive"}
+)
+
 
 class QualityScoringError(ValueError):
     """Raised when quality scoring inputs are invalid or unsafe."""
@@ -228,8 +235,16 @@ def _score_freshness(
     """
     stale_findings = stale_findings or []
     items: list[Any] = list(sources) + list(decisions)
-    # stale_findings always count as non-fresh entries in the total
-    extra_stale = len(stale_findings)
+    # Only count active (non-exempt) stale findings against freshness.
+    # Terminal/remediated statuses (refreshed, accepted_risk, false_positive)
+    # are excluded to mirror the behaviour of contradiction and scope-risk
+    # scoring which skip their own non-penalised statuses.
+    active_stale = [
+        f for f in stale_findings
+        if not isinstance(f, Mapping)
+        or _as_str(f.get("status", "open")).lower() not in _STALE_EXEMPT_STATUSES
+    ]
+    extra_stale = len(active_stale)
     if not items and extra_stale == 0:
         return DimensionScore(
             dimension="freshness_score",
@@ -256,7 +271,7 @@ def _score_freshness(
         f"(not stale, superseded, or deleted)."
     )
     if extra_stale:
-        explanation += f" {extra_stale} bundle-level stale finding(s) counted against freshness."
+        explanation += f" {extra_stale} active stale finding(s) counted against freshness."
     return DimensionScore(
         dimension="freshness_score",
         score=score,

--- a/tools/surrealdb/quality_scoring.py
+++ b/tools/surrealdb/quality_scoring.py
@@ -1,0 +1,581 @@
+"""Knowledge Quality Scoring Service v1 — side-effect-free domain component.
+
+Issues:
+    #2171 — [SURREALDB][CONTEXT][QUALITY-RUNTIME] Implement knowledge quality scoring service v1
+    Parent: #2170 (Wave-18 anchor)
+    Epic: #1976
+
+Scope:
+    Pure, deterministic knowledge quality scoring service. No DB access. No
+    SurrealDB SDK. No MCP. No networking. No writes. No auto-fix. No live-go.
+
+    Computes 8 quality scores:
+        coverage_score          — breadth of source/doc/test coverage
+        freshness_score         — how current sources and decisions are
+        evidence_score          — strength and completeness of evidence
+        contradiction_score     — inverse: how free of contradictions
+        dependency_confidence_score — confidence of dependency edges
+        memory_trust_score      — trust level of memory items
+        decision_validity_score — how many decisions are current vs. superseded
+        scope_risk_score        — inverse: how free of scope drift findings
+
+    And an aggregated overall_score with grade: blocking/watch/weak/good.
+
+Guardrails:
+    - Score is signal, not authorization.
+    - Scores do not imply live-go, echtgeld-go, or action authority.
+    - No auto-fix. No auto-write.
+    - LR status remains NO-GO for live trading.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+SCHEMA_VERSION = "quality-scoring/v1"
+DETECTED_BY = "quality-scoring/v1"
+
+SCORE_DIMENSIONS = (
+    "coverage_score",
+    "freshness_score",
+    "evidence_score",
+    "contradiction_score",
+    "dependency_confidence_score",
+    "memory_trust_score",
+    "decision_validity_score",
+    "scope_risk_score",
+)
+
+GRADE_BLOCKING = "blocking"
+GRADE_WATCH = "watch"
+GRADE_WEAK = "weak"
+GRADE_GOOD = "good"
+
+GRADES = (GRADE_BLOCKING, GRADE_WATCH, GRADE_WEAK, GRADE_GOOD)
+
+# Inclusive lower bound, exclusive upper bound (except GOOD which is fully inclusive at 1.0)
+_GRADE_BANDS: tuple[tuple[str, float, float], ...] = (
+    (GRADE_BLOCKING, 0.0, 0.30),
+    (GRADE_WATCH, 0.30, 0.50),
+    (GRADE_WEAK, 0.50, 0.70),
+    (GRADE_GOOD, 0.70, 1.01),
+)
+
+GUARDRAILS: tuple[str, ...] = (
+    "Quality Score is signal, not authorization.",
+    "No auto-fix. No auto-write.",
+    "No Live-Readiness-Go.",
+    "No Echtgeld-Go.",
+    "Human-GO required for any action after blocking quality score.",
+)
+
+
+class QualityScoringError(ValueError):
+    """Raised when quality scoring inputs are invalid or unsafe."""
+
+
+# ── Data Models ───────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class DimensionScore:
+    """Score result for a single quality dimension."""
+
+    dimension: str
+    score: float          # 0.0 – 1.0
+    grade: str            # blocking / watch / weak / good
+    explanation: str
+    inputs_used: int
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "dimension": self.dimension,
+            "score": round(self.score, 4),
+            "grade": self.grade,
+            "explanation": self.explanation,
+            "inputs_used": self.inputs_used,
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class QualityScoreResult:
+    """Full quality scoring result for a bundle."""
+
+    scope_id: str
+    level: str                              # artifact | domain | issue | system
+    overall_score: float
+    overall_grade: str
+    dimensions: tuple[DimensionScore, ...]
+    blocking_dimensions: tuple[str, ...]    # dimension names graded blocking
+    watch_dimensions: tuple[str, ...]       # dimension names graded watch
+    recommended_next_reads: tuple[str, ...]
+    guardrails: tuple[str, ...] = field(default_factory=lambda: GUARDRAILS)
+    scored_at: str = field(default_factory=lambda: cdb_utcnow().isoformat())
+    schema_version: str = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "scope_id": self.scope_id,
+            "level": self.level,
+            "scored_at": self.scored_at,
+            "overall_score": round(self.overall_score, 4),
+            "overall_grade": self.overall_grade,
+            "blocking_dimensions": list(self.blocking_dimensions),
+            "watch_dimensions": list(self.watch_dimensions),
+            "recommended_next_reads": list(self.recommended_next_reads),
+            "guardrails": list(self.guardrails),
+            "dimensions": [d.to_dict() for d in self.dimensions],
+        }
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _grade(score: float) -> str:
+    for grade, lo, hi in _GRADE_BANDS:
+        if lo <= score < hi:
+            return grade
+    return GRADE_GOOD
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def _as_str(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    return str(value).strip() if value is not None else ""
+
+
+def _deterministic_id(parts: Sequence[str]) -> str:
+    raw = "|".join(str(p) for p in parts)
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def _validate_bundle(bundle: Any) -> Mapping[str, Any]:
+    if not isinstance(bundle, Mapping):
+        raise QualityScoringError("bundle must be a mapping")
+    meta = bundle.get("meta")
+    if not isinstance(meta, Mapping):
+        raise QualityScoringError("bundle.meta must be a mapping")
+    return bundle
+
+
+# ── Score computation ─────────────────────────────────────────────────────────
+
+
+def _score_coverage(sources: list[Any]) -> DimensionScore:
+    """Coverage: what fraction of sources have docs + tests + evidence."""
+    if not sources:
+        return DimensionScore(
+            dimension="coverage_score",
+            score=0.0,
+            grade=GRADE_BLOCKING,
+            explanation="No sources provided — coverage cannot be assessed.",
+            inputs_used=0,
+            warnings=("no sources in bundle",),
+        )
+    total = len(sources)
+    covered = sum(
+        1
+        for s in sources
+        if (
+            isinstance(s, Mapping)
+            and s.get("has_documentation") is True
+            and s.get("has_tests") is True
+        )
+    )
+    score = covered / total
+    warnings: list[str] = []
+    if score < 0.30:
+        warnings.append(
+            f"only {covered}/{total} sources have both docs and tests"
+        )
+    return DimensionScore(
+        dimension="coverage_score",
+        score=score,
+        grade=_grade(score),
+        explanation=(
+            f"{covered}/{total} sources have documentation and test coverage."
+        ),
+        inputs_used=total,
+        warnings=tuple(warnings),
+    )
+
+
+def _score_freshness(sources: list[Any], decisions: list[Any]) -> DimensionScore:
+    """Freshness: fraction of sources + decisions that are current (not stale/superseded)."""
+    items: list[Any] = list(sources) + list(decisions)
+    if not items:
+        return DimensionScore(
+            dimension="freshness_score",
+            score=0.5,
+            grade=GRADE_WATCH,
+            explanation="No sources or decisions provided — freshness defaulted to 0.5 (watch).",
+            inputs_used=0,
+        )
+    total = len(items)
+    fresh = 0
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+        status = _as_str(item.get("status", "")).lower()
+        stale_flag = item.get("stale") is True
+        deleted_flag = item.get("deleted") is True
+        if not stale_flag and not deleted_flag and status not in (
+            "superseded", "invalidated", "deleted", "stale"
+        ):
+            fresh += 1
+    score = fresh / total
+    return DimensionScore(
+        dimension="freshness_score",
+        score=score,
+        grade=_grade(score),
+        explanation=(
+            f"{fresh}/{total} sources/decisions are current "
+            f"(not stale, superseded, or deleted)."
+        ),
+        inputs_used=total,
+    )
+
+
+def _score_evidence(evidence_items: list[Any]) -> DimensionScore:
+    """Evidence: average strength of evidence items."""
+    _strength_map = {
+        "strong": 1.0,
+        "moderate": 0.6,
+        "weak": 0.25,
+        "none": 0.0,
+        "blocking_missing": 0.0,
+    }
+    if not evidence_items:
+        return DimensionScore(
+            dimension="evidence_score",
+            score=0.0,
+            grade=GRADE_BLOCKING,
+            explanation="No evidence items provided — evidence quality is unknown.",
+            inputs_used=0,
+            warnings=("no evidence in bundle",),
+        )
+    total = len(evidence_items)
+    score_sum = 0.0
+    expired_count = 0
+    for item in evidence_items:
+        if not isinstance(item, Mapping):
+            continue
+        strength = _as_str(item.get("strength", "none")).lower()
+        s = _strength_map.get(strength, 0.0)
+        if item.get("expired") is True:
+            s *= 0.25
+            expired_count += 1
+        score_sum += s
+    score = score_sum / total
+    warnings: list[str] = []
+    if expired_count > 0:
+        warnings.append(f"{expired_count} expired evidence item(s) penalised")
+    return DimensionScore(
+        dimension="evidence_score",
+        score=score,
+        grade=_grade(score),
+        explanation=(
+            f"Average evidence strength across {total} items: {score:.2f}."
+        ),
+        inputs_used=total,
+        warnings=tuple(warnings),
+    )
+
+
+def _score_contradiction(contradiction_findings: list[Any]) -> DimensionScore:
+    """Contradiction: inverse score — fewer open/blocking contradictions is better."""
+    if not contradiction_findings:
+        return DimensionScore(
+            dimension="contradiction_score",
+            score=1.0,
+            grade=GRADE_GOOD,
+            explanation="No contradiction findings — contradiction score is perfect.",
+            inputs_used=0,
+        )
+    _non_penalised = frozenset(
+        {"false_positive", "accepted_risk", "resolved", "superseded"}
+    )
+    total = len(contradiction_findings)
+    blocking_open = 0
+    warning_open = 0
+    for f in contradiction_findings:
+        if not isinstance(f, Mapping):
+            continue
+        status = _as_str(f.get("status", "open")).lower()
+        if status in _non_penalised:
+            continue
+        severity = _as_str(f.get("severity", "info")).lower()
+        if severity == "blocking":
+            blocking_open += 1
+        elif severity == "warning":
+            warning_open += 1
+    # Penalty: blocking findings reduce score by 0.35 each, warnings by 0.10 each
+    penalty = min(blocking_open * 0.35 + warning_open * 0.10, 1.0)
+    score = max(1.0 - penalty, 0.0)
+    warnings: list[str] = []
+    if blocking_open > 0:
+        warnings.append(f"{blocking_open} open blocking contradiction(s)")
+    return DimensionScore(
+        dimension="contradiction_score",
+        score=score,
+        grade=_grade(score),
+        explanation=(
+            f"Contradiction check across {total} findings: "
+            f"{blocking_open} blocking open, {warning_open} warning open."
+        ),
+        inputs_used=total,
+        warnings=tuple(warnings),
+    )
+
+
+def _score_dependency_confidence(dependency_edges: list[Any]) -> DimensionScore:
+    """Dependency confidence: fraction of edges with high/medium confidence."""
+    _conf_map = {"high": 1.0, "medium": 0.6, "low": 0.2, "unknown": 0.1}
+    if not dependency_edges:
+        return DimensionScore(
+            dimension="dependency_confidence_score",
+            score=0.5,
+            grade=GRADE_WATCH,
+            explanation="No dependency edges — confidence defaulted to 0.5 (watch).",
+            inputs_used=0,
+        )
+    total = len(dependency_edges)
+    score_sum = 0.0
+    for edge in dependency_edges:
+        if not isinstance(edge, Mapping):
+            continue
+        conf = _as_str(edge.get("confidence", "unknown")).lower()
+        score_sum += _conf_map.get(conf, 0.1)
+    score = score_sum / total
+    return DimensionScore(
+        dimension="dependency_confidence_score",
+        score=score,
+        grade=_grade(score),
+        explanation=(
+            f"Average dependency edge confidence across {total} edges: {score:.2f}."
+        ),
+        inputs_used=total,
+    )
+
+
+def _score_memory_trust(memory_items: list[Any]) -> DimensionScore:
+    """Memory trust: fraction of memory items at acceptable or strong trust."""
+    _trust_map = {"strong": 1.0, "acceptable": 0.7, "weak": 0.3, "blocked": 0.0}
+    if not memory_items:
+        return DimensionScore(
+            dimension="memory_trust_score",
+            score=0.5,
+            grade=GRADE_WATCH,
+            explanation="No memory items — trust defaulted to 0.5 (watch).",
+            inputs_used=0,
+        )
+    total = len(memory_items)
+    score_sum = 0.0
+    for item in memory_items:
+        if not isinstance(item, Mapping):
+            continue
+        trust = _as_str(item.get("trust_level", "weak")).lower()
+        score_sum += _trust_map.get(trust, 0.3)
+    score = score_sum / total
+    return DimensionScore(
+        dimension="memory_trust_score",
+        score=score,
+        grade=_grade(score),
+        explanation=(
+            f"Average memory trust across {total} items: {score:.2f}."
+        ),
+        inputs_used=total,
+    )
+
+
+def _score_decision_validity(decisions: list[Any]) -> DimensionScore:
+    """Decision validity: fraction of decisions that are current (not superseded/invalidated)."""
+    if not decisions:
+        return DimensionScore(
+            dimension="decision_validity_score",
+            score=0.5,
+            grade=GRADE_WATCH,
+            explanation="No decisions provided — validity defaulted to 0.5 (watch).",
+            inputs_used=0,
+        )
+    total = len(decisions)
+    current = sum(
+        1
+        for d in decisions
+        if isinstance(d, Mapping)
+        and _as_str(d.get("status", "current")).lower()
+        not in ("superseded", "invalidated", "stale")
+    )
+    score = current / total
+    return DimensionScore(
+        dimension="decision_validity_score",
+        score=score,
+        grade=_grade(score),
+        explanation=(
+            f"{current}/{total} decisions are current "
+            f"(not superseded or invalidated)."
+        ),
+        inputs_used=total,
+    )
+
+
+def _score_scope_risk(scope_drift_findings: list[Any]) -> DimensionScore:
+    """Scope risk: inverse score — fewer open/blocking scope drift findings is better."""
+    if not scope_drift_findings:
+        return DimensionScore(
+            dimension="scope_risk_score",
+            score=1.0,
+            grade=GRADE_GOOD,
+            explanation="No scope drift findings — scope risk score is perfect.",
+            inputs_used=0,
+        )
+    _non_penalised = frozenset({"false_positive", "accepted_risk", "resolved"})
+    total = len(scope_drift_findings)
+    blocking_open = 0
+    warning_open = 0
+    for f in scope_drift_findings:
+        if not isinstance(f, Mapping):
+            continue
+        status = _as_str(f.get("status", "open")).lower()
+        if status in _non_penalised:
+            continue
+        severity = _as_str(f.get("severity", "info")).lower()
+        if severity == "blocking":
+            blocking_open += 1
+        elif severity == "warning":
+            warning_open += 1
+    penalty = min(blocking_open * 0.40 + warning_open * 0.12, 1.0)
+    score = max(1.0 - penalty, 0.0)
+    warnings: list[str] = []
+    if blocking_open > 0:
+        warnings.append(f"{blocking_open} open blocking scope drift finding(s)")
+    return DimensionScore(
+        dimension="scope_risk_score",
+        score=score,
+        grade=_grade(score),
+        explanation=(
+            f"Scope drift check across {total} findings: "
+            f"{blocking_open} blocking open, {warning_open} warning open."
+        ),
+        inputs_used=total,
+        warnings=tuple(warnings),
+    )
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def score_knowledge_quality_v1(
+    bundle: Mapping[str, Any],
+    as_of: str | None = None,
+) -> QualityScoreResult:
+    """Compute knowledge quality scores for the given bundle.
+
+    The bundle is a plain mapping describing the current context state:
+
+    .. code-block:: json
+
+        {
+          "meta": {
+            "scope_id": "my-scope",
+            "level": "artifact|domain|issue|system"
+          },
+          "sources": [...],
+          "decisions": [...],
+          "evidence_items": [...],
+          "contradiction_findings": [...],
+          "stale_findings": [...],
+          "dependency_edges": [...],
+          "memory_items": [...],
+          "scope_drift_findings": [...]
+        }
+
+    Returns a :class:`QualityScoreResult` with per-dimension scores and an
+    aggregated overall grade.
+
+    Raises:
+        QualityScoringError: if the bundle is structurally invalid.
+    """
+    _validate_bundle(bundle)
+    meta = bundle.get("meta", {})
+    scope_id = _as_str(meta.get("scope_id", "")) or _deterministic_id(
+        [str(bundle)]
+    )
+    level = _as_str(meta.get("level", "system")).lower()
+    if level not in ("artifact", "domain", "issue", "system"):
+        level = "system"
+
+    sources = _as_list(bundle.get("sources"))
+    decisions = _as_list(bundle.get("decisions"))
+    evidence_items = _as_list(bundle.get("evidence_items"))
+    contradiction_findings = _as_list(bundle.get("contradiction_findings"))
+    dependency_edges = _as_list(bundle.get("dependency_edges"))
+    memory_items = _as_list(bundle.get("memory_items"))
+    scope_drift_findings = _as_list(bundle.get("scope_drift_findings"))
+
+    dims = (
+        _score_coverage(sources),
+        _score_freshness(sources, decisions),
+        _score_evidence(evidence_items),
+        _score_contradiction(contradiction_findings),
+        _score_dependency_confidence(dependency_edges),
+        _score_memory_trust(memory_items),
+        _score_decision_validity(decisions),
+        _score_scope_risk(scope_drift_findings),
+    )
+
+    # Overall score: weighted average
+    # Blocking findings in contradiction/scope_risk have higher weight.
+    weights = {
+        "coverage_score": 1.0,
+        "freshness_score": 1.0,
+        "evidence_score": 1.5,
+        "contradiction_score": 1.5,
+        "dependency_confidence_score": 0.8,
+        "memory_trust_score": 0.8,
+        "decision_validity_score": 1.2,
+        "scope_risk_score": 1.2,
+    }
+    total_weight = sum(weights[d.dimension] for d in dims)
+    weighted_sum = sum(weights[d.dimension] * d.score for d in dims)
+    overall_score = weighted_sum / total_weight
+
+    # If any single dimension is blocking → overall is at most watch
+    blocking_dims = tuple(d.dimension for d in dims if d.grade == GRADE_BLOCKING)
+    watch_dims = tuple(d.dimension for d in dims if d.grade == GRADE_WATCH)
+
+    # Force downgrade if blocking dimensions exist
+    overall_grade = _grade(overall_score)
+    if blocking_dims and overall_grade in (GRADE_WEAK, GRADE_GOOD):
+        overall_grade = GRADE_WATCH
+
+    next_reads = ["AGENTS.md", "docs/runbooks/CONTROL_REGISTER.md"]
+    if blocking_dims:
+        next_reads.append("docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md")
+
+    return QualityScoreResult(
+        scope_id=scope_id,
+        level=level,
+        overall_score=overall_score,
+        overall_grade=overall_grade,
+        dimensions=dims,
+        blocking_dimensions=blocking_dims,
+        watch_dimensions=watch_dims,
+        recommended_next_reads=tuple(next_reads),
+        scored_at=(as_of or cdb_utcnow().isoformat()),
+    )

--- a/tools/surrealdb/quality_scoring.py
+++ b/tools/surrealdb/quality_scoring.py
@@ -215,10 +215,22 @@ def _score_coverage(sources: list[Any]) -> DimensionScore:
     )
 
 
-def _score_freshness(sources: list[Any], decisions: list[Any]) -> DimensionScore:
-    """Freshness: fraction of sources + decisions that are current (not stale/superseded)."""
+def _score_freshness(
+    sources: list[Any],
+    decisions: list[Any],
+    stale_findings: list[Any] | None = None,
+) -> DimensionScore:
+    """Freshness: fraction of sources + decisions that are current.
+
+    Bundle-level ``stale_findings`` are each counted as an additional
+    non-fresh item so that a bundle with all-current sources but open
+    stale findings cannot score perfect 1.0 freshness.
+    """
+    stale_findings = stale_findings or []
     items: list[Any] = list(sources) + list(decisions)
-    if not items:
+    # stale_findings always count as non-fresh entries in the total
+    extra_stale = len(stale_findings)
+    if not items and extra_stale == 0:
         return DimensionScore(
             dimension="freshness_score",
             score=0.5,
@@ -226,7 +238,7 @@ def _score_freshness(sources: list[Any], decisions: list[Any]) -> DimensionScore
             explanation="No sources or decisions provided — freshness defaulted to 0.5 (watch).",
             inputs_used=0,
         )
-    total = len(items)
+    total = len(items) + extra_stale
     fresh = 0
     for item in items:
         if not isinstance(item, Mapping):
@@ -239,14 +251,17 @@ def _score_freshness(sources: list[Any], decisions: list[Any]) -> DimensionScore
         ):
             fresh += 1
     score = fresh / total
+    explanation = (
+        f"{fresh}/{total} sources/decisions are current "
+        f"(not stale, superseded, or deleted)."
+    )
+    if extra_stale:
+        explanation += f" {extra_stale} bundle-level stale finding(s) counted against freshness."
     return DimensionScore(
         dimension="freshness_score",
         score=score,
         grade=_grade(score),
-        explanation=(
-            f"{fresh}/{total} sources/decisions are current "
-            f"(not stale, superseded, or deleted)."
-        ),
+        explanation=explanation,
         inputs_used=total,
     )
 
@@ -524,13 +539,14 @@ def score_knowledge_quality_v1(
     decisions = _as_list(bundle.get("decisions"))
     evidence_items = _as_list(bundle.get("evidence_items"))
     contradiction_findings = _as_list(bundle.get("contradiction_findings"))
+    stale_findings = _as_list(bundle.get("stale_findings"))
     dependency_edges = _as_list(bundle.get("dependency_edges"))
     memory_items = _as_list(bundle.get("memory_items"))
     scope_drift_findings = _as_list(bundle.get("scope_drift_findings"))
 
     dims = (
         _score_coverage(sources),
-        _score_freshness(sources, decisions),
+        _score_freshness(sources, decisions, stale_findings),
         _score_evidence(evidence_items),
         _score_contradiction(contradiction_findings),
         _score_dependency_confidence(dependency_edges),

--- a/tools/surrealdb/quality_scoring_cli.py
+++ b/tools/surrealdb/quality_scoring_cli.py
@@ -1,0 +1,406 @@
+"""Quality Scoring CLI — read-only, no writes, no DB, no network.
+
+Issues:
+    #2172 — [SURREALDB][CONTEXT][QUALITY-CLI] Add quality scoring CLI
+    Parent: #2170 (Wave-18 anchor)
+    Depends on: #2171 (quality_scoring service)
+    Epic: #1976
+
+Commands:
+    score-knowledge     Score a bundle, output all quality dimensions
+    show-score          Show score details for a specific dimension
+    report-quality      Generate a structured quality summary report
+
+Exit codes:
+    0 = success (or weak/blocking findings without --fail-on-weak)
+    1 = blocking or watch-grade overall and --fail-on-weak set
+    2 = CLI / input / validation error
+    3 = show-score: dimension not found
+
+Guardrails:
+    - Read-only. No writes. No file output. Stdout only.
+    - No DB access. No SurrealDB SDK. No network. No GitHub calls.
+    - Score is signal, not authorization.
+    - LR status remains NO-GO for live trading.
+    - No auto-fix. No live-go. No Echtgeld-Go.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from tools.surrealdb.quality_scoring import (
+    GRADES,
+    GUARDRAILS,
+    SCORE_DIMENSIONS,
+    QualityScoringError,
+    QualityScoreResult,
+    score_knowledge_quality_v1,
+)
+
+SCHEMA_VERSION = "quality-scoring-cli/v1"
+
+EXIT_OK = 0
+EXIT_WEAK = 1
+EXIT_ERROR = 2
+EXIT_NOT_FOUND = 3
+
+SUPPORTED_FORMATS = frozenset({"json", "markdown"})
+
+_GUARDRAIL_NOTE = (
+    "Score is signal, not authorization. "
+    "No auto-fix. No live-go. No real-money scope. "
+    "LR status remains NO-GO for live trading."
+)
+
+
+class QualityScoringCLIError(Exception):
+    """Raised for CLI / input / validation errors (exit 2) or not-found (exit 3)."""
+
+    def __init__(self, message: str, exit_code: int = EXIT_ERROR) -> None:
+        super().__init__(message)
+        self.message = message
+        self.exit_code = exit_code
+
+
+def _load_bundle(path: Path) -> dict[str, Any]:
+    """Load a JSON input bundle from *path*."""
+    if not path.exists():
+        raise QualityScoringCLIError(
+            f"bundle not found: {path}", exit_code=EXIT_ERROR
+        )
+    if not path.is_file():
+        raise QualityScoringCLIError(
+            f"bundle path is not a file: {path}", exit_code=EXIT_ERROR
+        )
+    try:
+        raw = path.read_text(encoding="utf-8")
+        bundle = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise QualityScoringCLIError(
+            f"invalid JSON in bundle: {path}: {exc}", exit_code=EXIT_ERROR
+        ) from exc
+    except OSError as exc:
+        raise QualityScoringCLIError(
+            f"cannot read bundle: {path}: {exc}", exit_code=EXIT_ERROR
+        ) from exc
+    if not isinstance(bundle, dict):
+        raise QualityScoringCLIError(
+            "bundle root must be a JSON object", exit_code=EXIT_ERROR
+        )
+    return bundle
+
+
+def _render_score_result_json(result: QualityScoreResult) -> str:
+    return json.dumps(result.to_dict(), indent=2, sort_keys=True, ensure_ascii=True)
+
+
+def _render_score_result_markdown(result: QualityScoreResult) -> str:
+    lines = [
+        "# Knowledge Quality Score Report",
+        f"- **scope_id**: `{result.scope_id}`",
+        f"- **level**: `{result.level}`",
+        f"- **scored_at**: `{result.scored_at}`",
+        f"- **overall_score**: `{result.overall_score:.4f}`",
+        f"- **overall_grade**: `{result.overall_grade}`",
+    ]
+    if result.blocking_dimensions:
+        lines.append(
+            "- **blocking_dimensions**: "
+            + ", ".join(f"`{d}`" for d in result.blocking_dimensions)
+        )
+    if result.watch_dimensions:
+        lines.append(
+            "- **watch_dimensions**: "
+            + ", ".join(f"`{d}`" for d in result.watch_dimensions)
+        )
+    lines.append("")
+    lines.append("## Dimensions")
+    lines.append("")
+    lines.append("| Dimension | Score | Grade | Inputs |")
+    lines.append("|-----------|-------|-------|--------|")
+    for dim in result.dimensions:
+        lines.append(
+            f"| `{dim.dimension}` | `{dim.score:.4f}` | `{dim.grade}` | {dim.inputs_used} |"
+        )
+    lines.append("")
+    lines.append("## Guardrails")
+    for g in result.guardrails:
+        lines.append(f"- {g}")
+    return "\n".join(lines)
+
+
+def _render_dimension_json(result: QualityScoreResult, dimension: str) -> str:
+    for dim in result.dimensions:
+        if dim.dimension == dimension:
+            payload = {
+                "schema_version": SCHEMA_VERSION,
+                "scope_id": result.scope_id,
+                "scored_at": result.scored_at,
+                "dimension": dim.to_dict(),
+                "guardrails": list(GUARDRAILS),
+            }
+            return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=True)
+    raise QualityScoringCLIError(
+        f"dimension not found: {dimension}", exit_code=EXIT_NOT_FOUND
+    )
+
+
+def _render_dimension_markdown(result: QualityScoreResult, dimension: str) -> str:
+    for dim in result.dimensions:
+        if dim.dimension == dimension:
+            lines = [
+                f"# Quality Score: {dimension}",
+                f"- **scope_id**: `{result.scope_id}`",
+                f"- **score**: `{dim.score:.4f}`",
+                f"- **grade**: `{dim.grade}`",
+                f"- **inputs_used**: `{dim.inputs_used}`",
+                f"- **explanation**: {dim.explanation}",
+            ]
+            if dim.warnings:
+                lines.append("**warnings**:")
+                for w in dim.warnings:
+                    lines.append(f"  - {w}")
+            return "\n".join(lines)
+    raise QualityScoringCLIError(
+        f"dimension not found: {dimension}", exit_code=EXIT_NOT_FOUND
+    )
+
+
+def _render_report_json(result: QualityScoreResult, fail_on_weak: bool) -> str:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "scope_id": result.scope_id,
+        "level": result.level,
+        "scored_at": result.scored_at,
+        "overall_score": result.overall_score,
+        "overall_grade": result.overall_grade,
+        "blocking_dimensions": list(result.blocking_dimensions),
+        "watch_dimensions": list(result.watch_dimensions),
+        "recommended_next_reads": list(result.recommended_next_reads),
+        "guardrails": list(result.guardrails),
+        "summary": {
+            "total_dimensions": len(result.dimensions),
+            "blocking_count": len(result.blocking_dimensions),
+            "watch_count": len(result.watch_dimensions),
+            "fail_on_weak_active": fail_on_weak,
+        },
+    }
+    return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=True)
+
+
+def _render_report_markdown(result: QualityScoreResult) -> str:
+    lines = [
+        "# Quality Score Report",
+        f"- **scope**: `{result.scope_id}`",
+        f"- **level**: `{result.level}`",
+        f"- **overall_score**: `{result.overall_score:.4f}` — **{result.overall_grade.upper()}**",
+        "",
+        "## Summary",
+        f"- Blocking dimensions: {len(result.blocking_dimensions)}",
+        f"- Watch dimensions: {len(result.watch_dimensions)}",
+    ]
+    if result.blocking_dimensions:
+        lines.append("- **Blocking**: " + ", ".join(result.blocking_dimensions))
+    lines.append("")
+    lines.append("## Guardrails")
+    for g in result.guardrails:
+        lines.append(f"- {g}")
+    return "\n".join(lines)
+
+
+# ── Command handlers ──────────────────────────────────────────────────────────
+
+
+def handle_score_knowledge(
+    args: argparse.Namespace,
+) -> tuple[str, int]:
+    bundle = _load_bundle(args.input)
+    try:
+        result = score_knowledge_quality_v1(bundle)
+    except QualityScoringError as exc:
+        raise QualityScoringCLIError(str(exc), exit_code=EXIT_ERROR) from exc
+
+    fmt = getattr(args, "format", "json")
+    if fmt == "json":
+        output = _render_score_result_json(result)
+    elif fmt == "markdown":
+        output = _render_score_result_markdown(result)
+    else:
+        raise QualityScoringCLIError(f"unsupported format: {fmt}", exit_code=EXIT_ERROR)
+
+    fail_on_weak = getattr(args, "fail_on_weak", False)
+    exit_code = EXIT_OK
+    if fail_on_weak and result.overall_grade in ("blocking", "watch"):
+        exit_code = EXIT_WEAK
+    return output, exit_code
+
+
+def handle_show_score(
+    args: argparse.Namespace,
+) -> tuple[str, int]:
+    bundle = _load_bundle(args.input)
+    try:
+        result = score_knowledge_quality_v1(bundle)
+    except QualityScoringError as exc:
+        raise QualityScoringCLIError(str(exc), exit_code=EXIT_ERROR) from exc
+
+    dimension = args.dimension
+    if dimension not in SCORE_DIMENSIONS:
+        raise QualityScoringCLIError(
+            f"unknown dimension: {dimension!r}. "
+            f"Valid: {', '.join(sorted(SCORE_DIMENSIONS))}",
+            exit_code=EXIT_NOT_FOUND,
+        )
+
+    fmt = getattr(args, "format", "json")
+    if fmt == "json":
+        output = _render_dimension_json(result, dimension)
+    elif fmt == "markdown":
+        output = _render_dimension_markdown(result, dimension)
+    else:
+        raise QualityScoringCLIError(f"unsupported format: {fmt}", exit_code=EXIT_ERROR)
+    return output, EXIT_OK
+
+
+def handle_report_quality(
+    args: argparse.Namespace,
+) -> tuple[str, int]:
+    bundle = _load_bundle(args.input)
+    try:
+        result = score_knowledge_quality_v1(bundle)
+    except QualityScoringError as exc:
+        raise QualityScoringCLIError(str(exc), exit_code=EXIT_ERROR) from exc
+
+    fmt = getattr(args, "format", "json")
+    fail_on_weak = getattr(args, "fail_on_weak", False)
+    if fmt == "json":
+        output = _render_report_json(result, fail_on_weak)
+    elif fmt == "markdown":
+        output = _render_report_markdown(result)
+    else:
+        raise QualityScoringCLIError(f"unsupported format: {fmt}", exit_code=EXIT_ERROR)
+
+    exit_code = EXIT_OK
+    if fail_on_weak and result.overall_grade in ("blocking", "watch"):
+        exit_code = EXIT_WEAK
+    return output, exit_code
+
+
+# ── Argparse ──────────────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="quality_scoring_cli",
+        description=(
+            "Knowledge Quality Scoring CLI (#2172). "
+            "Read-only — no DB, no network, no writes."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=sorted(SUPPORTED_FORMATS),
+        default="json",
+        help="Output format (default: json).",
+    )
+
+    subs = parser.add_subparsers(dest="command", required=True)
+
+    score = subs.add_parser(
+        "score-knowledge",
+        help="Score a quality bundle and output all dimension scores.",
+    )
+    score.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to JSON input bundle.",
+    )
+    score.add_argument(
+        "--fail-on-weak",
+        action="store_true",
+        default=False,
+        help="Exit 1 if overall grade is blocking or watch.",
+    )
+
+    show = subs.add_parser(
+        "show-score",
+        help="Show score details for a specific dimension.",
+    )
+    show.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to JSON input bundle.",
+    )
+    show.add_argument(
+        "--dimension",
+        required=True,
+        choices=sorted(SCORE_DIMENSIONS),
+        help="Dimension to show.",
+    )
+
+    report = subs.add_parser(
+        "report-quality",
+        help="Generate a structured quality summary report.",
+    )
+    report.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to JSON input bundle.",
+    )
+    report.add_argument(
+        "--fail-on-weak",
+        action="store_true",
+        default=False,
+        help="Exit 1 if overall grade is blocking or watch.",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "score-knowledge":
+            output, exit_code = handle_score_knowledge(args)
+        elif args.command == "show-score":
+            output, exit_code = handle_show_score(args)
+        elif args.command == "report-quality":
+            output, exit_code = handle_report_quality(args)
+        else:
+            print(
+                json.dumps(
+                    {"error": "unknown_command", "command": args.command},
+                    ensure_ascii=True,
+                )
+            )
+            return EXIT_ERROR
+    except QualityScoringCLIError as exc:
+        print(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "status": "error",
+                    "error": exc.message,
+                    "guardrails": list(GUARDRAILS),
+                },
+                ensure_ascii=True,
+                indent=2,
+            )
+        )
+        return exc.exit_code
+
+    print(output)
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/surrealdb/quality_scoring_cli.py
+++ b/tools/surrealdb/quality_scoring_cli.py
@@ -13,7 +13,7 @@ Commands:
 
 Exit codes:
     0 = success (or weak/blocking findings without --fail-on-weak)
-    1 = blocking or watch-grade overall and --fail-on-weak set
+    1 = blocking, watch, or weak-grade overall and --fail-on-weak set
     2 = CLI / input / validation error
     3 = show-score: dimension not found
 
@@ -33,7 +33,6 @@ from pathlib import Path
 from typing import Any
 
 from tools.surrealdb.quality_scoring import (
-    GRADES,
     GUARDRAILS,
     SCORE_DIMENSIONS,
     QualityScoringError,
@@ -49,12 +48,6 @@ EXIT_ERROR = 2
 EXIT_NOT_FOUND = 3
 
 SUPPORTED_FORMATS = frozenset({"json", "markdown"})
-
-_GUARDRAIL_NOTE = (
-    "Score is signal, not authorization. "
-    "No auto-fix. No live-go. No real-money scope. "
-    "LR status remains NO-GO for live trading."
-)
 
 
 class QualityScoringCLIError(Exception):
@@ -234,7 +227,7 @@ def handle_score_knowledge(
 
     fail_on_weak = getattr(args, "fail_on_weak", False)
     exit_code = EXIT_OK
-    if fail_on_weak and result.overall_grade in ("blocking", "watch"):
+    if fail_on_weak and result.overall_grade in ("blocking", "watch", "weak"):
         exit_code = EXIT_WEAK
     return output, exit_code
 
@@ -285,7 +278,7 @@ def handle_report_quality(
         raise QualityScoringCLIError(f"unsupported format: {fmt}", exit_code=EXIT_ERROR)
 
     exit_code = EXIT_OK
-    if fail_on_weak and result.overall_grade in ("blocking", "watch"):
+    if fail_on_weak and result.overall_grade in ("blocking", "watch", "weak"):
         exit_code = EXIT_WEAK
     return output, exit_code
 
@@ -321,10 +314,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to JSON input bundle.",
     )
     score.add_argument(
+        "--format",
+        choices=sorted(SUPPORTED_FORMATS),
+        default="json",
+        help="Output format (default: json).",
+    )
+    score.add_argument(
         "--fail-on-weak",
         action="store_true",
         default=False,
-        help="Exit 1 if overall grade is blocking or watch.",
+        help="Exit 1 if overall grade is blocking, watch, or weak.",
     )
 
     show = subs.add_parser(
@@ -336,6 +335,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         required=True,
         help="Path to JSON input bundle.",
+    )
+    show.add_argument(
+        "--format",
+        choices=sorted(SUPPORTED_FORMATS),
+        default="json",
+        help="Output format (default: json).",
     )
     show.add_argument(
         "--dimension",
@@ -355,10 +360,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to JSON input bundle.",
     )
     report.add_argument(
+        "--format",
+        choices=sorted(SUPPORTED_FORMATS),
+        default="json",
+        help="Output format (default: json).",
+    )
+    report.add_argument(
         "--fail-on-weak",
         action="store_true",
         default=False,
-        help="Exit 1 if overall grade is blocking or watch.",
+        help="Exit 1 if overall grade is blocking, watch, or weak.",
     )
 
     return parser

--- a/tools/surrealdb/quality_scoring_cli.py
+++ b/tools/surrealdb/quality_scoring_cli.py
@@ -63,7 +63,7 @@ def _load_bundle(path: Path) -> dict[str, Any]:
     """Load a JSON input bundle from *path*."""
     if not path.exists():
         raise QualityScoringCLIError(
-            f"bundle not found: {path}", exit_code=EXIT_ERROR
+            f"bundle not found: {path}", exit_code=EXIT_NOT_FOUND
         )
     if not path.is_file():
         raise QualityScoringCLIError(
@@ -316,11 +316,12 @@ def build_parser() -> argparse.ArgumentParser:
     score.add_argument(
         "--format",
         choices=sorted(SUPPORTED_FORMATS),
-        default="json",
-        help="Output format (default: json).",
+        default=argparse.SUPPRESS,
+        help="Output format (default: json). Overrides global --format when specified.",
     )
     score.add_argument(
         "--fail-on-weak",
+
         action="store_true",
         default=False,
         help="Exit 1 if overall grade is blocking, watch, or weak.",
@@ -339,8 +340,8 @@ def build_parser() -> argparse.ArgumentParser:
     show.add_argument(
         "--format",
         choices=sorted(SUPPORTED_FORMATS),
-        default="json",
-        help="Output format (default: json).",
+        default=argparse.SUPPRESS,
+        help="Output format (default: json). Overrides global --format when specified.",
     )
     show.add_argument(
         "--dimension",
@@ -362,11 +363,12 @@ def build_parser() -> argparse.ArgumentParser:
     report.add_argument(
         "--format",
         choices=sorted(SUPPORTED_FORMATS),
-        default="json",
-        help="Output format (default: json).",
+        default=argparse.SUPPRESS,
+        help="Output format (default: json). Overrides global --format when specified.",
     )
     report.add_argument(
         "--fail-on-weak",
+
         action="store_true",
         default=False,
         help="Exit 1 if overall grade is blocking, watch, or weak.",


### PR DESCRIPTION
## Summary

Implements SurrealDB Context Intelligence Wave 18: Knowledge Quality Scoring and Architect Signals v1.

This PR adds:
- Quality Scoring service
- Quality Scoring CLI
- Quality Score MCP tool
- Architect Signal service
- Architect Signals MCP tool
- Tests and deterministic fixture bundle
- Operator runbook
- Wave-18 completion gates

## Scope

Closes #2171  
Closes #2172  
Closes #2173  
Closes #2174  
Closes #2175  
Closes #2176  
Closes #2177  
Closes #2178  
Refs #2170  

## Details

### #2171 Quality Scoring Service
Adds `tools/surrealdb/quality_scoring.py` with:
- coverage score
- freshness score
- evidence score
- contradiction score
- dependency confidence score
- memory trust score
- decision validity score
- scope risk score
- grade bands and blocking downgrade behavior
- deterministic bundle-driven scoring

### #2172 Quality Scoring CLI
Adds `tools/surrealdb/quality_scoring_cli.py` with:
- `score-knowledge`
- `show-score`
- `report-quality`
- explicit exit-code behavior

### #2173 Quality Score MCP Tool
Adds `tools/mcp/quality_scoring_tools.py` and registers:
- `cdb_context_quality_score`
- read-only tool contract
- permission guard integration
- context bridge routing

### #2174 Architect Signal Service
Adds `tools/surrealdb/architect_signals.py` with:
- proactive signal generation from quality scores and context findings
- supported signal classes for stale areas, weak evidence, underdocumented/undertested surfaces, dependency risk, contradiction hotspots, scope drift hotspots, repeated agent confusion, redundant docs, missing owner, and fragile context path

### #2175 Architect Signals MCP Tool
Adds `tools/mcp/architect_signal_tools.py` and registers:
- `cdb_context_architect_signals`
- read-only tool contract
- permission guard integration
- context bridge routing

### #2176 Tests and Fixtures
Adds:
- `tests/unit/surrealdb/test_quality_scoring.py`
- `tests/unit/tools/mcp/test_quality_scoring_tools.py`
- `tests/fixtures/surrealdb/quality_scoring/sample_bundle.json`

### #2177 Runbook
Adds:
- `docs/surrealdb/quality-scoring-architect-signals-runbook.md`

### #2178 Completion Gates
Adds:
- `docs/surrealdb/context-wave18-completion-gates.md`

## Validation

Executed before PR creation:
- Wave-18 core tests: 41 passed
- Wave-18 MCP tests: 19 passed
- Full MCP regression: 568 passed, 0 failed
- Safety scan: clean

Commands:
```bash
python -m pytest tests/unit/surrealdb/test_quality_scoring.py -v -m unit --tb=short
python -m pytest tests/unit/tools/mcp/test_quality_scoring_tools.py -v -m unit --tb=short
python -m pytest tests/unit/tools/mcp/ -v -m unit --tb=short -q
```

## Non-goals / Guardrails

* No runtime writes
* No SurrealDB production activation
* No trading state
* No orders, positions, fills, secrets, or live risk state
* No Live-Readiness upgrade
* No Echtgeld-Go
* No automatic issue creation
* No autonomous architecture command
* Scores and signals are explainable hints, not truth or release authorization
* Live-Readiness remains NO-GO
