### PR TITLE
fix(security): update grafana image to 11.6.14-ubuntu

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -45,7 +45,7 @@ jobs:
             scan_name: postgres
           - image: prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78
             scan_name: prometheus
-          - image: grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
+          - image: grafana/grafana:11.6.14-ubuntu@sha256:d39d4352aad1df307dc4affa40aeadb1d8eaf34401914b269d70da1abf3973a5
             scan_name: grafana
       fail-fast: false
 

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -75,7 +75,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
+    image: grafana/grafana:11.6.14-ubuntu@sha256:d39d4352aad1df307dc4affa40aeadb1d8eaf34401914b269d70da1abf3973a5
     container_name: cdb_grafana
     restart: unless-stopped
     environment:

--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -114,7 +114,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800
+    image: grafana/grafana:11.6.14-ubuntu@sha256:d39d4352aad1df307dc4affa40aeadb1d8eaf34401914b269d70da1abf3973a5
     container_name: cdb_grafana
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary

Updates the pinned Grafana image from `grafana/grafana:11.4.7-ubuntu` to `grafana/grafana:11.6.14-ubuntu` to address the Trivy curl alert wave tracked in #2292.

This is a RED-stack Grafana image remediation only. No BLUE-stack service image, Python code, LR, Live, Echtgeld or trading scope is changed.

## Scope

Changed exactly 3 files:

- `infrastructure/compose/compose.red.yml`
- `infrastructure/compose/base.yml`
- `.github/workflows/security-scan.yml`

## Image Update

Old image:
`grafana/grafana:11.4.7-ubuntu@sha256:c20611d00f4ddeb8cb73d9b73ecfdaab9775c81c9df627a91a366d9e95bbd800`

New image:
`grafana/grafana:11.6.14-ubuntu@sha256:d39d4352aad1df307dc4affa40aeadb1d8eaf34401914b269d70da1abf3973a5`

Verification:
- `docker pull grafana/grafana:11.6.14-ubuntu`
- `docker inspect grafana/grafana:11.6.14-ubuntu --format '{{json .RepoDigests}}'`
- curl/libcurl changed from `7.81.0-1ubuntu1.20` to `7.81.0-1ubuntu1.23`

## Security Context

Refs #2289
Closes #2292

Representative issue-body CVEs/packages:
- `CVE-2026-6429` / `curl` / MEDIUM
- `CVE-2026-6253` / `curl` / MEDIUM
- `CVE-2026-5545` / `curl` / MEDIUM
- additional LOW curl findings

## Validation

- Verified target tag and digest.
- Verified old digest no longer appears in targeted Grafana references.
- Verified new digest appears in exactly 3 references.
- No CDB service Dockerfiles changed.
- No #2290 scope.
- No LR/Live/Echtgeld/trading scope.

Post-merge:
- Re-run `security-scan.yml`.
- Re-check GitHub code-scanning / Trivy alerts for #2292.
- Remaining no-fix/LOW findings, if any, stay under #2289.

## Guardrails

- No Live-Readiness-Go.
- No Echtgeld-Go.
- No runtime/trading behavior change.
- RED-stack Grafana image remediation only.