### PR TITLE
fix(surrealdb): complete self-explanation response model for #2031

### DIFF
--- a/tests/unit/surrealdb/test_context_self_explanation.py
+++ b/tests/unit/surrealdb/test_context_self_explanation.py
@@ -474,6 +474,44 @@ def test_why_evidence_weak_explicit_uncertainties_not_overridden() -> None:
 
 
 @pytest.mark.unit
+def test_blank_uncertainties_treated_as_empty_and_inference_fires() -> None:
+    """Blank/whitespace-only uncertainty strings are normalized out; inference then fires."""
+    inp = SelfExplanationInput(
+        explanation_type="why_evidence_weak",
+        summary="Evidence is weak.",
+        reasons=("No repo artefact.",),
+        evidence_refs=("#1234",),
+        required_next_step="Add evidence.",
+        uncertainties=("   ",),
+    )
+    result = build_self_explanation(inp)
+
+    # blank entry must be stripped; inference must have fired
+    assert len(result.uncertainties) >= 1
+    assert all(u.strip() for u in result.uncertainties)
+    assert any("unvollstaendig" in u.lower() or "evidence" in u.lower() for u in result.uncertainties)
+
+
+@pytest.mark.unit
+def test_empty_string_uncertainty_treated_as_absent_for_low_confidence() -> None:
+    """Empty-string uncertainty on low-confidence case is normalized; inference fires."""
+    inp = SelfExplanationInput(
+        explanation_type="why_stale",
+        summary="Possibly stale.",
+        reasons=("Not updated.",),
+        evidence_refs=("docs/some.md",),
+        required_next_step="Review.",
+        confidence=0.2,
+        uncertainties=("",),
+    )
+    result = build_self_explanation(inp)
+
+    # blank entry stripped; inference should have added a low-confidence warning
+    assert len(result.uncertainties) >= 1
+    assert all(u.strip() for u in result.uncertainties)
+
+
+@pytest.mark.unit
 def test_low_confidence_infers_uncertainty() -> None:
     """Confidence < 0.5 without explicit uncertainties triggers inference."""
     inp = SelfExplanationInput(

--- a/tests/unit/surrealdb/test_context_self_explanation.py
+++ b/tests/unit/surrealdb/test_context_self_explanation.py
@@ -8,6 +8,7 @@ from tools.surrealdb.context_self_explanation import (
     InvalidExplanationTypeError,
     InvalidInputError,
     SelfExplanationInput,
+    SelfExplanationOutput,
     build_self_explanation,
     supported_explanation_types,
 )
@@ -334,3 +335,309 @@ def test_to_payload_outputs_all_fields() -> None:
     assert "guardrails" in payload
     assert payload["confidence"] == 0.5
     assert payload["scope_context"] == "test-scope"
+    # AC #2031: graph_path and uncertainties always present in payload
+    assert "graph_path" in payload
+    assert "uncertainties" in payload
+    assert isinstance(payload["graph_path"], list)
+    assert isinstance(payload["uncertainties"], list)
+
+
+# ---------------------------------------------------------------------------
+# AC #2031 — Explanations contain graph-path and evidence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_output_contains_graph_path_field_default_empty() -> None:
+    """graph_path is always present on output, defaults to empty tuple."""
+    inp = SelfExplanationInput(
+        explanation_type="why_blocked",
+        summary="No graph path provided.",
+        reasons=("Reason.",),
+        evidence_refs=("#ref",),
+        required_next_step="Check.",
+    )
+    result = build_self_explanation(inp)
+
+    assert hasattr(result, "graph_path")
+    assert result.graph_path == ()
+    assert result.to_payload()["graph_path"] == []
+
+
+@pytest.mark.unit
+def test_output_graph_path_passes_through_from_input() -> None:
+    """graph_path provided in input is preserved in output."""
+    inp = SelfExplanationInput(
+        explanation_type="why_stale",
+        summary="Stale docs in context graph.",
+        reasons=("Last updated 2024.",),
+        evidence_refs=("docs/old.md",),
+        required_next_step="Refresh docs.",
+        graph_path=("context", "docs", "docs/old.md"),
+    )
+    result = build_self_explanation(inp)
+
+    assert result.graph_path == ("context", "docs", "docs/old.md")
+    assert result.to_payload()["graph_path"] == ["context", "docs", "docs/old.md"]
+
+
+@pytest.mark.unit
+def test_output_graph_path_included_in_payload_when_nonempty() -> None:
+    """graph_path appears in to_payload even when non-empty."""
+    inp = SelfExplanationInput(
+        explanation_type="why_decision_current",
+        summary="Decision is current.",
+        reasons=("Ratified via #1492.",),
+        evidence_refs=("#1492",),
+        required_next_step="None needed.",
+        graph_path=("governance", "decisions", "#1492"),
+    )
+    result = build_self_explanation(inp)
+    payload = result.to_payload()
+
+    assert payload["graph_path"] == ["governance", "decisions", "#1492"]
+
+
+# ---------------------------------------------------------------------------
+# AC #2031 — Uncertainties are visible
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_output_contains_uncertainties_field_default_empty() -> None:
+    """uncertainties is always present on output, defaults to empty tuple."""
+    inp = SelfExplanationInput(
+        explanation_type="why_blocked",
+        summary="No uncertainties.",
+        reasons=("Reason.",),
+        evidence_refs=("#ref",),
+        required_next_step="Check.",
+        confidence=0.95,
+    )
+    result = build_self_explanation(inp)
+
+    assert hasattr(result, "uncertainties")
+    assert result.uncertainties == ()
+    assert result.to_payload()["uncertainties"] == []
+
+
+@pytest.mark.unit
+def test_explicit_uncertainties_pass_through() -> None:
+    """Caller-supplied uncertainties are preserved as-is."""
+    inp = SelfExplanationInput(
+        explanation_type="why_risky",
+        summary="Risk assessment.",
+        reasons=("High blast radius.",),
+        evidence_refs=("core/risk/service.py",),
+        required_next_step="Add tests.",
+        uncertainties=("Blast radius not fully mapped.", "No rollback plan."),
+    )
+    result = build_self_explanation(inp)
+
+    assert result.uncertainties == ("Blast radius not fully mapped.", "No rollback plan.")
+    assert result.to_payload()["uncertainties"] == [
+        "Blast radius not fully mapped.",
+        "No rollback plan.",
+    ]
+
+
+@pytest.mark.unit
+def test_why_evidence_weak_infers_uncertainty_when_none_given() -> None:
+    """why_evidence_weak type auto-populates uncertainty when caller omits it."""
+    inp = SelfExplanationInput(
+        explanation_type="why_evidence_weak",
+        summary="Evidence is weak.",
+        reasons=("Only an issue comment, no repo artefact.",),
+        evidence_refs=("#1234",),
+        required_next_step="Add evidence commit.",
+    )
+    result = build_self_explanation(inp)
+
+    assert len(result.uncertainties) >= 1
+    assert any("unvollstaendig" in u.lower() or "evidence" in u.lower() for u in result.uncertainties)
+
+
+@pytest.mark.unit
+def test_why_evidence_weak_explicit_uncertainties_not_overridden() -> None:
+    """Explicit uncertainties on why_evidence_weak are not replaced by inference."""
+    inp = SelfExplanationInput(
+        explanation_type="why_evidence_weak",
+        summary="Evidence is weak.",
+        reasons=("No repo artefact.",),
+        evidence_refs=("#1234",),
+        required_next_step="Add evidence.",
+        uncertainties=("My custom uncertainty.",),
+    )
+    result = build_self_explanation(inp)
+
+    assert result.uncertainties == ("My custom uncertainty.",)
+
+
+@pytest.mark.unit
+def test_low_confidence_infers_uncertainty() -> None:
+    """Confidence < 0.5 without explicit uncertainties triggers inference."""
+    inp = SelfExplanationInput(
+        explanation_type="why_stale",
+        summary="Possibly stale.",
+        reasons=("Not recently updated.",),
+        evidence_refs=("docs/some.md",),
+        required_next_step="Review.",
+        confidence=0.3,
+    )
+    result = build_self_explanation(inp)
+
+    assert len(result.uncertainties) >= 1
+    uncertainty_text = " ".join(result.uncertainties)
+    assert "0.30" in uncertainty_text or "Konfidenz" in uncertainty_text
+
+
+@pytest.mark.unit
+def test_high_confidence_no_inferred_uncertainty() -> None:
+    """Confidence >= 0.5 without explicit uncertainties: no inference."""
+    inp = SelfExplanationInput(
+        explanation_type="why_blocked",
+        summary="Clearly blocked.",
+        reasons=("CI failing.",),
+        evidence_refs=("#ci-check",),
+        required_next_step="Fix CI.",
+        confidence=0.8,
+    )
+    result = build_self_explanation(inp)
+
+    assert result.uncertainties == ()
+
+
+@pytest.mark.unit
+def test_no_confidence_no_inferred_uncertainty_for_non_weak_type() -> None:
+    """Missing confidence on a non-why_evidence_weak type: no inference."""
+    inp = SelfExplanationInput(
+        explanation_type="why_blocked",
+        summary="Blocked.",
+        reasons=("Policy gate.",),
+        evidence_refs=("#policy",),
+        required_next_step="Request approval.",
+    )
+    result = build_self_explanation(inp)
+
+    assert result.uncertainties == ()
+
+
+# ---------------------------------------------------------------------------
+# AC #2031 — Explanation gives no live/Echtgeld-Go (explicit guardrail check)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_guardrail_no_live_readiness_go() -> None:
+    """Output guardrails explicitly prohibit Live-Readiness-Go."""
+    inp = SelfExplanationInput(
+        explanation_type="why_agent_needs_go",
+        summary="Agent needs GO for merge.",
+        reasons=("Governance gate active.",),
+        evidence_refs=("#2279",),
+        required_next_step="Human GO required.",
+    )
+    result = build_self_explanation(inp)
+
+    guardrail_text = " ".join(result.guardrails)
+    assert "Live-Readiness-Go" in guardrail_text
+    assert "Echtgeld-Go" in guardrail_text
+    assert "Handlungserlaubnis" in guardrail_text
+
+
+# ---------------------------------------------------------------------------
+# AC #2031 — Optional spec fields pass through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_optional_spec_fields_pass_through() -> None:
+    """decision_refs, claim_refs, memory_refs, contradictions, stale_context,
+    recommended_next_reads all pass through input → output."""
+    inp = SelfExplanationInput(
+        explanation_type="why_decision_current",
+        summary="Decision still current.",
+        reasons=("Ratified 2026-04-08.",),
+        evidence_refs=("#1492",),
+        required_next_step="No action needed.",
+        decision_refs=("#1492", "#2033"),
+        claim_refs=("claim:trade-capable-stage",),
+        memory_refs=("knowledge/ACTIVE_ROADMAP.md",),
+        contradictions=("old-decision:stage-blocked",),
+        stale_context=("docs/archive/old-stage.md",),
+        recommended_next_reads=(
+            "docs/runbooks/CONTROL_REGISTER.md",
+            "knowledge/governance/CDB_CONSTITUTION.md",
+        ),
+    )
+    result = build_self_explanation(inp)
+
+    assert result.decision_refs == ("#1492", "#2033")
+    assert result.claim_refs == ("claim:trade-capable-stage",)
+    assert result.memory_refs == ("knowledge/ACTIVE_ROADMAP.md",)
+    assert result.contradictions == ("old-decision:stage-blocked",)
+    assert result.stale_context == ("docs/archive/old-stage.md",)
+    assert result.recommended_next_reads == (
+        "docs/runbooks/CONTROL_REGISTER.md",
+        "knowledge/governance/CDB_CONSTITUTION.md",
+    )
+
+
+@pytest.mark.unit
+def test_optional_spec_fields_in_payload_when_nonempty() -> None:
+    """Non-empty optional fields appear in to_payload()."""
+    inp = SelfExplanationInput(
+        explanation_type="why_stale",
+        summary="Doc is stale.",
+        reasons=("Not updated.",),
+        evidence_refs=("docs/old.md",),
+        required_next_step="Update.",
+        decision_refs=("#999",),
+        recommended_next_reads=("docs/new.md",),
+    )
+    result = build_self_explanation(inp)
+    payload = result.to_payload()
+
+    assert "decision_refs" in payload
+    assert payload["decision_refs"] == ["#999"]
+    assert "recommended_next_reads" in payload
+    assert payload["recommended_next_reads"] == ["docs/new.md"]
+
+
+@pytest.mark.unit
+def test_optional_spec_fields_absent_from_payload_when_empty() -> None:
+    """Empty optional fields are omitted from to_payload()."""
+    inp = SelfExplanationInput(
+        explanation_type="why_blocked",
+        summary="Blocked.",
+        reasons=("Gate.",),
+        evidence_refs=("#ref",),
+        required_next_step="Approve.",
+    )
+    result = build_self_explanation(inp)
+    payload = result.to_payload()
+
+    for optional_key in (
+        "decision_refs",
+        "claim_refs",
+        "memory_refs",
+        "contradictions",
+        "stale_context",
+        "recommended_next_reads",
+    ):
+        assert optional_key not in payload, f"{optional_key} should be absent when empty"
+
+
+@pytest.mark.unit
+def test_output_is_selfexplanationoutput_instance() -> None:
+    """build_self_explanation always returns a SelfExplanationOutput."""
+    inp = SelfExplanationInput(
+        explanation_type="why_blocked",
+        summary="Blocked.",
+        reasons=("Reason.",),
+        evidence_refs=("#ref",),
+        required_next_step="Step.",
+    )
+    result = build_self_explanation(inp)
+
+    assert isinstance(result, SelfExplanationOutput)

--- a/tools/surrealdb/context_self_explanation.py
+++ b/tools/surrealdb/context_self_explanation.py
@@ -85,6 +85,17 @@ class SelfExplanationInput:
         required_next_step: The next action needed (plain text, not a command).
         confidence: Optional self-assessed confidence (0.0–1.0).
         scope_context: Optional scope identifier for which this applies.
+        graph_path: Ordered sequence of context-graph node references leading
+            to this explanation (e.g. topic → sub-topic → claim).
+        uncertainties: Known unknowns or weaknesses in this explanation.
+            Inferred by the builder when confidence is low or evidence is weak.
+        decision_refs: References to governance decisions relevant to this
+            explanation.
+        claim_refs: References to specific claims supporting the explanation.
+        memory_refs: References to memory/knowledge items consulted.
+        contradictions: Identifiers of contradicting evidence or claims.
+        stale_context: Context items known to be potentially outdated.
+        recommended_next_reads: Paths or IDs of documents to consult next.
     """
 
     explanation_type: str
@@ -94,6 +105,14 @@ class SelfExplanationInput:
     required_next_step: str
     confidence: float | None = None
     scope_context: str | None = None
+    graph_path: tuple[str, ...] = ()
+    uncertainties: tuple[str, ...] = ()
+    decision_refs: tuple[str, ...] = ()
+    claim_refs: tuple[str, ...] = ()
+    memory_refs: tuple[str, ...] = ()
+    contradictions: tuple[str, ...] = ()
+    stale_context: tuple[str, ...] = ()
+    recommended_next_reads: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if self.explanation_type not in _EXPLANATION_TYPES:
@@ -125,11 +144,25 @@ class SelfExplanationInput:
             "reasons": list(self.reasons),
             "evidence_refs": list(self.evidence_refs),
             "required_next_step": self.required_next_step,
+            "graph_path": list(self.graph_path),
+            "uncertainties": list(self.uncertainties),
         }
         if self.confidence is not None:
             payload["confidence"] = self.confidence
         if self.scope_context is not None:
             payload["scope_context"] = self.scope_context
+        if self.decision_refs:
+            payload["decision_refs"] = list(self.decision_refs)
+        if self.claim_refs:
+            payload["claim_refs"] = list(self.claim_refs)
+        if self.memory_refs:
+            payload["memory_refs"] = list(self.memory_refs)
+        if self.contradictions:
+            payload["contradictions"] = list(self.contradictions)
+        if self.stale_context:
+            payload["stale_context"] = list(self.stale_context)
+        if self.recommended_next_reads:
+            payload["recommended_next_reads"] = list(self.recommended_next_reads)
         return payload
 
 
@@ -147,6 +180,16 @@ class SelfExplanationOutput:
         guardrails: Mandatory guardrail text (always present).
         confidence: Optional confidence level.
         scope_context: Optional scope context.
+        graph_path: Ordered context-graph node references leading to this
+            explanation. Always present (may be empty).
+        uncertainties: Known unknowns or weaknesses. Always present; inferred
+            by the builder when evidence is weak or confidence is low.
+        decision_refs: Governance decisions referenced by this explanation.
+        claim_refs: Specific claims referenced.
+        memory_refs: Memory/knowledge items consulted.
+        contradictions: Contradicting evidence or claim identifiers.
+        stale_context: Context items known to be potentially outdated.
+        recommended_next_reads: Documents to consult for further context.
     """
 
     schema_version: str = _SCHEMA_VERSION
@@ -158,6 +201,14 @@ class SelfExplanationOutput:
     guardrails: tuple[str, ...] = ()
     confidence: float | None = None
     scope_context: str | None = None
+    graph_path: tuple[str, ...] = ()
+    uncertainties: tuple[str, ...] = ()
+    decision_refs: tuple[str, ...] = ()
+    claim_refs: tuple[str, ...] = ()
+    memory_refs: tuple[str, ...] = ()
+    contradictions: tuple[str, ...] = ()
+    stale_context: tuple[str, ...] = ()
+    recommended_next_reads: tuple[str, ...] = ()
 
     def to_payload(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -168,11 +219,25 @@ class SelfExplanationOutput:
             "evidence_refs": list(self.evidence_refs),
             "required_next_step": self.required_next_step,
             "guardrails": list(self.guardrails),
+            "graph_path": list(self.graph_path),
+            "uncertainties": list(self.uncertainties),
         }
         if self.confidence is not None:
             payload["confidence"] = self.confidence
         if self.scope_context is not None:
             payload["scope_context"] = self.scope_context
+        if self.decision_refs:
+            payload["decision_refs"] = list(self.decision_refs)
+        if self.claim_refs:
+            payload["claim_refs"] = list(self.claim_refs)
+        if self.memory_refs:
+            payload["memory_refs"] = list(self.memory_refs)
+        if self.contradictions:
+            payload["contradictions"] = list(self.contradictions)
+        if self.stale_context:
+            payload["stale_context"] = list(self.stale_context)
+        if self.recommended_next_reads:
+            payload["recommended_next_reads"] = list(self.recommended_next_reads)
         return payload
 
 
@@ -180,17 +245,31 @@ def build_self_explanation(inp: SelfExplanationInput) -> SelfExplanationOutput:
     """Build a structured self-explanation from validated input.
 
     This is a pure function: no DB access, no MCP, no network, no secrets.
-    The output always includes mandatory guardrail text.
+    The output always includes mandatory guardrail text, ``graph_path``, and
+    ``uncertainties``. Uncertainties are inferred when ``confidence < 0.5`` or
+    when the explanation type is ``why_evidence_weak`` and no uncertainties
+    were provided by the caller.
 
     Args:
         inp: Validated SelfExplanationInput.
 
     Returns:
-        SelfExplanationOutput with the explanation and guardrails.
+        SelfExplanationOutput with the explanation, guardrails, graph_path,
+        and uncertainties.
 
     Raises:
         InvalidInputError: If the input fails post-initialization validation.
     """
+    uncertainties = list(inp.uncertainties)
+    if not uncertainties:
+        if inp.explanation_type == "why_evidence_weak":
+            uncertainties.append("Evidence moeglicherweise unvollstaendig.")
+        elif inp.confidence is not None and inp.confidence < 0.5:
+            uncertainties.append(
+                f"Niedrige Konfidenz ({inp.confidence:.2f}):"
+                " Ausgabe mit Vorsicht interpretieren."
+            )
+
     return SelfExplanationOutput(
         schema_version=_SCHEMA_VERSION,
         explanation_type=inp.explanation_type,
@@ -201,6 +280,14 @@ def build_self_explanation(inp: SelfExplanationInput) -> SelfExplanationOutput:
         guardrails=_GUARDRAILS,
         confidence=inp.confidence,
         scope_context=inp.scope_context,
+        graph_path=inp.graph_path,
+        uncertainties=tuple(uncertainties),
+        decision_refs=inp.decision_refs,
+        claim_refs=inp.claim_refs,
+        memory_refs=inp.memory_refs,
+        contradictions=inp.contradictions,
+        stale_context=inp.stale_context,
+        recommended_next_reads=inp.recommended_next_reads,
     )
 
 

--- a/tools/surrealdb/context_self_explanation.py
+++ b/tools/surrealdb/context_self_explanation.py
@@ -260,7 +260,7 @@ def build_self_explanation(inp: SelfExplanationInput) -> SelfExplanationOutput:
     Raises:
         InvalidInputError: If the input fails post-initialization validation.
     """
-    uncertainties = list(inp.uncertainties)
+    uncertainties = [u for u in inp.uncertainties if u.strip()]
     if not uncertainties:
         if inp.explanation_type == "why_evidence_weak":
             uncertainties.append("Evidence moeglicherweise unvollstaendig.")


### PR DESCRIPTION
## Summary

Completes the Self-Explanation Response Model for #2031 by adding explicit graph-path and uncertainty surfaces to the self-explanation output.

## Changes

- Adds `graph_path` to `SelfExplanationInput` / `SelfExplanationOutput`.
- Adds `uncertainties` to `SelfExplanationInput` / `SelfExplanationOutput`.
- Keeps `graph_path` and `uncertainties` always present in serialized output.
- Infers visible uncertainty for weak evidence / low confidence cases.
- Adds optional spec-aligned reference fields:
  - `decision_refs`
  - `claim_refs`
  - `memory_refs`
  - `contradictions`
  - `stale_context`
  - `recommended_next_reads`
- Preserves existing guardrails: explanation is not a permission grant and does not authorize Live/LR/Echtgeld actions.

## Validation

- `ruff check tools/surrealdb/context_self_explanation.py tests/unit/surrealdb/test_context_self_explanation.py`
- `pytest tests/unit/surrealdb/test_context_self_explanation.py -v` — 33/33 passed
- `pytest tests/unit/tools/mcp/test_context_bridge.py -v` — 193/193 passed

## Guardrails

- No DB write.
- No MCP config write.
- No runtime start.
- No trading / LR / live / real-money scope.
- Does not close #2033 or #2024.
- #2031 should only be closed after PR merge and checks pass.

Closes #2031