### PR TITLE
feat(surrealdb): bootstrap local context runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ REPLAY_ADAPTER_ID ?= primary_breakout_runner_v1
 REPLAY_DRY_RUN ?= 0
 REPLAY_DETERMINISTIC_VERIFY ?= 1
 
-.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close
+.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-up context-down context-status context-logs context-restart
 
 help:
 	@echo "Claire de Binare - Test Commands"
@@ -73,6 +73,14 @@ help:
 	@echo "  make rollback MR=<number>    - Rollback eines Merge Requests"
 	@echo "  make cleanup                 - Aufräumen merged Branches (DRY-RUN)"
 	@echo "  make cleanup-live            - Aufräumen merged Branches (LIVE)"
+	@echo ""
+	@echo "Context (SurrealDB Local Runtime — kein Trading-Scope):"
+	@echo "  make context-env-check       - Env/Secrets-Guard pruefen (kein Secret-Leak)"
+	@echo "  make context-up              - SurrealDB Sidecar starten (BLUE/RED unangetastet)"
+	@echo "  make context-down            - SurrealDB Sidecar stoppen (BLUE/RED unangetastet)"
+	@echo "  make context-status          - Container/Volume/Port-Status (kein Secret-Leak)"
+	@echo "  make context-logs            - cdb_surrealdb Logs anzeigen (letzte 50 Zeilen)"
+	@echo "  make context-restart         - Sidecar neu starten (context-down + context-up)"
 
 # ============================================================================
 # CI-Tests (schnell, mit Mocks)
@@ -188,8 +196,105 @@ docker-health:
 	@echo "--- RED ---"
 	@docker compose -f infrastructure/compose/compose.red.yml ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null | grep cdb_ || true
 
+# ============================================================================# Context (SurrealDB Local Runtime) — #2393 / #2394
+# Context Infrastructure only. No Trading-Runtime. No BLUE/RED touch.
+# No schema apply. No import. No query smoke.
 # ============================================================================
-# Paper Trading (14-Tage Test)
+
+ifeq ($(OS),Windows_NT)
+context-env-check:
+	@pwsh -NoProfile -Command "\
+	$$sp = if ($$env:SECRETS_PATH) { $$env:SECRETS_PATH } else { Join-Path $$env:USERPROFILE 'Documents\.secrets\.cdb' }; \
+	$$f = Join-Path $$sp 'SURREALDB_ENV'; \
+	if (-not (Test-Path $$f)) { \
+	  Write-Error ('Missing local SurrealDB env file. Create it from infrastructure/config/surrealdb/SURREALDB_ENV.example and store the real file outside git. Expected: ' + $$f); \
+	  exit 1 \
+	}; \
+	$$content = Get-Content -Raw $$f; \
+	if ($$content -notmatch '(?m)^SURREAL_USER=') { Write-Error 'SURREALDB_ENV: missing field SURREAL_USER'; exit 1 }; \
+	if ($$content -notmatch '(?m)^SURREAL_PASS=') { Write-Error 'SURREALDB_ENV: missing field SURREAL_PASS'; exit 1 }; \
+	Write-Host '[OK] SurrealDB env file found.'; \
+	Write-Host '     SURREAL_USER=[REDACTED]'; \
+	Write-Host '     SURREAL_PASS=[REDACTED]'"
+else
+context-env-check:
+	@SECRETS_PATH=$${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}; \
+	 ENV_FILE="$$SECRETS_PATH/SURREALDB_ENV"; \
+	 if [ ! -f "$$ENV_FILE" ]; then \
+	   echo "ERROR: Missing local SurrealDB env file. Create it from infrastructure/config/surrealdb/SURREALDB_ENV.example and store the real file outside git."; \
+	   echo "       Expected: $$ENV_FILE"; \
+	   exit 1; \
+	 fi; \
+	 if ! grep -qE '^SURREAL_USER=' "$$ENV_FILE"; then \
+	   echo "ERROR: SURREALDB_ENV: missing field SURREAL_USER"; exit 1; \
+	 fi; \
+	 if ! grep -qE '^SURREAL_PASS=' "$$ENV_FILE"; then \
+	   echo "ERROR: SURREALDB_ENV: missing field SURREAL_PASS"; exit 1; \
+	 fi; \
+	 echo "[OK] SurrealDB env file found."; \
+	 echo "     SURREAL_USER=[REDACTED]"; \
+	 echo "     SURREAL_PASS=[REDACTED]"
+endif
+
+ifeq ($(OS),Windows_NT)
+context-up: context-env-check
+	@echo "Starting SurrealDB context sidecar..."
+	@pwsh -NoProfile -Command "docker network create cdb_network 2>&1 | Out-Null; Write-Host '[OK] cdb_network ready'"
+	@pwsh -NoProfile -Command "\
+	$$sp = if ($$env:SECRETS_PATH) { $$env:SECRETS_PATH } else { Join-Path $$env:USERPROFILE 'Documents\.secrets\.cdb' }; \
+	$$env:SECRETS_PATH = $$sp; \
+	docker compose -f 'infrastructure/compose/surrealdb.yml' -f 'infrastructure/compose/surrealdb-dev.yml' up -d"
+	@echo "[OK] cdb_surrealdb started. Port: 127.0.0.1:8010"
+else
+context-up: context-env-check
+	@echo "Starting SurrealDB context sidecar..."
+	@docker network create cdb_network 2>/dev/null || true
+	@echo "[OK] cdb_network ready"
+	@export SECRETS_PATH=$${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}; \
+	 docker compose \
+	   -f infrastructure/compose/surrealdb.yml \
+	   -f infrastructure/compose/surrealdb-dev.yml \
+	   up -d
+	@echo "[OK] cdb_surrealdb started. Port: 127.0.0.1:8010"
+endif
+
+context-down:
+	@echo "Stopping SurrealDB context sidecar (BLUE/RED untouched)..."
+	@docker compose \
+	  -f infrastructure/compose/surrealdb.yml \
+	  -f infrastructure/compose/surrealdb-dev.yml \
+	  down 2>/dev/null || true
+	@echo "[OK] cdb_surrealdb stopped."
+
+context-status:
+	@echo "=== SurrealDB Local Context Runtime — Status ==="
+	@echo ""
+	@echo "--- Container ---"
+	@if docker inspect cdb_surrealdb > /dev/null 2>&1; then \
+	  STATUS=$$(docker inspect --format '{{.State.Status}}' cdb_surrealdb 2>/dev/null); \
+	  HEALTH=$$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}n/a{{end}}' cdb_surrealdb 2>/dev/null); \
+	  PORTS=$$(docker port cdb_surrealdb 2>/dev/null || echo "none"); \
+	  echo "  cdb_surrealdb: $$STATUS (health: $$HEALTH)"; \
+	  echo "  Ports: $$PORTS"; \
+	else \
+	  echo "  cdb_surrealdb: not found (container does not exist)"; \
+	fi
+	@echo ""
+	@echo "--- Volume ---"
+	@if docker volume inspect surrealdb_data > /dev/null 2>&1; then \
+	  echo "  surrealdb_data: exists"; \
+	else \
+	  echo "  surrealdb_data: not found"; \
+	fi
+	@echo ""
+	@echo "NOTE: This is Context Infrastructure only — not a Live/Trading Go."
+
+context-logs:
+	@docker logs cdb_surrealdb --tail 50 2>/dev/null || echo "cdb_surrealdb is not running or not found."
+
+context-restart: context-down context-up
+
+# ============================================================================# Paper Trading (14-Tage Test)
 # ============================================================================
 
 pre-close:

--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,8 @@ endif
 
 context-down:
 	@echo "Stopping SurrealDB context sidecar (BLUE/RED untouched)..."
-	@docker compose \
+	@SECRETS_PATH=$${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb} \
+	 docker compose \
 	  -f infrastructure/compose/surrealdb.yml \
 	  -f infrastructure/compose/surrealdb-dev.yml \
 	  down 2>/dev/null || true
@@ -281,11 +282,12 @@ context-status:
 	fi
 	@echo ""
 	@echo "--- Volume ---"
-	@if docker volume inspect surrealdb_data > /dev/null 2>&1; then \
-	  echo "  surrealdb_data: exists"; \
-	else \
-	  echo "  surrealdb_data: not found"; \
-	fi
+	@VOLUME_NAME="$${STACK_NAME:-cdb_database}_surrealdb_data"; \
+	 if docker volume inspect "$$VOLUME_NAME" > /dev/null 2>&1; then \
+	   echo "  $$VOLUME_NAME: exists"; \
+	 else \
+	   echo "  $$VOLUME_NAME: not found"; \
+	 fi
 	@echo ""
 	@echo "NOTE: This is Context Infrastructure only — not a Live/Trading Go."
 

--- a/docs/surrealdb/local-context-runtime-contract.md
+++ b/docs/surrealdb/local-context-runtime-contract.md
@@ -1,0 +1,174 @@
+# SurrealDB Local Context Runtime — Stack Contract
+
+Status: `context-infra-only` | Scope: Local Development | Live-Readiness: NO-GO (unrelated to this runtime)
+
+> **SurrealDB Local Runtime is Context Infrastructure — not a Live/Trading Go.**
+>
+> Starting or stopping `cdb_surrealdb` has zero effect on live-readiness, LR-status,
+> real-money trading, BLUE/RED runtime, or any risk-/execution-path.
+
+---
+
+## 1. Docker Requirement
+
+**Yes — Docker must be running.**
+
+The `cdb_surrealdb` container is managed via Docker Compose.
+
+---
+
+## 2. What Runs Permanently
+
+| Component | Container | Note |
+|-----------|-----------|------|
+| SurrealDB server | `cdb_surrealdb` | Only permanent process in this stack |
+
+That is the complete list. No other container is part of the local Context stack.
+
+---
+
+## 3. Why Are There No More Containers?
+
+The Context Intelligence tools (`context_indexer`, `context_importer`, `context_query`) are
+**one-shot job runners**, not daemon processes. They run, do their work, and exit.
+They are never meant to be running containers.
+
+---
+
+## 4. One-Shot Tools (not containers)
+
+These scripts connect to `cdb_surrealdb` and exit when done:
+
+| Tool | Path | Purpose |
+|------|------|---------|
+| Context Indexer | `tools/surrealdb/context_indexer.py` | Build/refresh the context index |
+| Context Importer | `tools/surrealdb/context_importer.py` | Import context documents |
+| Context Query | `tools/surrealdb/context_query.py` | Query the context store |
+
+Run them manually when needed. They are not auto-started by the compose stack.
+
+---
+
+## 5. Network & Port
+
+| Item | Value |
+|------|-------|
+| Local dev port | `127.0.0.1:8010 → 8000` (via `surrealdb-dev.yml` overlay) |
+| Internal port | `8000` (inside container) |
+| Network | `cdb_network` (external — must pre-exist) |
+
+The port `8010` is used on localhost to avoid collision with `cdb_ws` which binds `127.0.0.1:8000`.
+
+---
+
+## 6. Volume
+
+| Item | Value |
+|------|-------|
+| Named volume | `surrealdb_data` |
+| Driver | `local` |
+| Purpose | Persistent SurrealDB data storage |
+
+The volume persists across container restarts. `context-down` does not destroy it.
+
+---
+
+## 7. Compose Files
+
+| File | Role |
+|------|------|
+| `infrastructure/compose/surrealdb.yml` | Base stack definition — container, volume, network, healthcheck |
+| `infrastructure/compose/surrealdb-dev.yml` | Dev overlay — adds `127.0.0.1:8010:8000` port binding |
+
+Always use both files together for local development:
+
+```bash
+docker compose \
+  -f infrastructure/compose/surrealdb.yml \
+  -f infrastructure/compose/surrealdb-dev.yml \
+  up -d
+```
+
+Or use the canonical operator shortcut (see Section 9):
+
+```bash
+make context-up
+```
+
+---
+
+## 8. Environment / Secrets
+
+| Item | Value |
+|------|-------|
+| Env file | `${SECRETS_PATH}/SURREALDB_ENV` |
+| Default path (Linux/Mac) | `~/Documents/.secrets/.cdb/SURREALDB_ENV` |
+| Default path (Windows) | `%USERPROFILE%\Documents\.secrets\.cdb\SURREALDB_ENV` |
+| Template (in repo) | `infrastructure/config/surrealdb/SURREALDB_ENV.example` |
+
+The real env file lives **outside the repository**. Never commit it. The template file contains
+only `REDACTED` placeholders.
+
+Required fields:
+
+```
+SURREAL_USER=<local_user>
+SURREAL_PASS=<local_password>
+```
+
+Use `make context-env-check` to verify the env file without exposing any values.
+
+---
+
+## 9. Operator Commands
+
+```bash
+make context-env-check   # Verify env/secrets guard (no secret output)
+make context-up          # Start cdb_surrealdb sidecar (runs env-check first)
+make context-status      # Container/volume/port status (no secret output)
+make context-logs        # Tail cdb_surrealdb logs (last 50 lines)
+make context-down        # Stop cdb_surrealdb sidecar (BLUE/RED untouched)
+make context-restart     # context-down then context-up
+```
+
+---
+
+## 10. What Is NOT Part of This Runtime
+
+The following are explicitly **outside** the SurrealDB local context stack:
+
+| Item | Reason |
+|------|--------|
+| Trading Runtime | Separate BLUE stack (`compose.blue.yml`) |
+| Live Execution | Separate BLUE service (`cdb_execution`) |
+| Real Money / Auto-Trade | Requires explicit LR-Go + Human Gate |
+| Live-Readiness (LR-Go) | Governed by `docs/live-readiness/` — independent |
+| Remote / Production DB | Never touched by local compose stack |
+| BLUE stack (Postgres, Redis, Risk, Execution, …) | Started via `make docker-up` — separate |
+| RED stack (Signal, WS, Grafana, …) | Started via `make docker-up` — separate |
+| MCP daemon (v1) | Not implemented in this version; decided separately if needed |
+| Schema apply | One-shot operation, not part of this bootstrap |
+| Context import | One-shot via `context_importer.py`, not auto-started |
+| Pipeline smoke | Out of scope for local runtime bootstrap |
+
+---
+
+## 11. Relationship to Epics
+
+| Issue | Role | State |
+|-------|------|-------|
+| #1976 | CDB Context Intelligence System — Ledger Anchor | OPEN (remains open) |
+| #2391 | Local Runtime Epic | OPEN (remains open) |
+| #2392 | This contract document | Closed via PR |
+| #2393 | One-command startup (Makefile targets) | Closed via PR |
+| #2394 | Env/secrets guard | Closed via PR |
+
+---
+
+## 12. Invariants
+
+- `cdb_surrealdb` is the only permanent container in this stack.
+- No secrets or credential values are ever printed by any `make context-*` target.
+- `context-down` never stops BLUE or RED runtime containers.
+- `context-up` always runs `context-env-check` first.
+- This runtime has no effect on live-readiness verdict.

--- a/infrastructure/compose/README.md
+++ b/infrastructure/compose/README.md
@@ -42,11 +42,27 @@ docker compose -f infrastructure/compose/base.yml -f infrastructure/compose/test
 ```
 
 ### SurrealDB Sidecar (Standalone)
+
+Kanonischer Operator-Weg (bevorzugt):
+
+```bash
+make context-env-check   # Env/Secrets-Guard pruefen (kein Secret-Leak)
+make context-up          # Sidecar starten (BLUE/RED unangetastet)
+make context-status      # Container/Volume/Port-Status
+make context-logs        # cdb_surrealdb Logs (letzte 50 Zeilen)
+make context-down        # Sidecar stoppen (BLUE/RED unangetastet)
+```
+
+Direkter Docker-Compose-Aufruf (Fallback, wenn Make nicht verfuegbar):
+
 ```bash
 docker compose -f infrastructure/compose/surrealdb.yml -f infrastructure/compose/surrealdb-dev.yml up -d
 ```
 
 Mit `surrealdb-dev.yml` liegt SurrealDB lokal auf `127.0.0.1:8010`, damit es nicht mit `cdb_ws` auf `127.0.0.1:8000` kollidiert.
+
+**Scope:** Context Infrastructure only — kein Trading-Scope, kein BLUE/RED-Touch, kein LR-Go.
+Vertrag: `docs/surrealdb/local-context-runtime-contract.md`
 
 ## Governance-Compliance
 

--- a/infrastructure/config/surrealdb/SURREALDB_ENV.example
+++ b/infrastructure/config/surrealdb/SURREALDB_ENV.example
@@ -1,0 +1,22 @@
+# SurrealDB Local Runtime — Env Template
+#
+# PURPOSE: Template only. Contains REDACTED placeholders — no real credentials.
+#
+# USAGE:
+#   1. Copy this file to ${SECRETS_PATH}/SURREALDB_ENV (outside the repository).
+#   2. Replace the REDACTED values with your actual local credentials.
+#   3. Never commit the real file to git.
+#
+# DEFAULT SECRETS_PATH:
+#   Linux / Mac:  ~/Documents/.secrets/.cdb/
+#   Windows:      %USERPROFILE%\Documents\.secrets\.cdb\
+#
+# VERIFY your env file is correct (without leaking values):
+#   make context-env-check
+#
+# NOTE: This file is for local development only.
+# The SurrealDB local runtime is Context Infrastructure — not a Live/Trading Go.
+# It has no effect on LR-status, real-money trading, or the BLUE/RED runtime.
+
+SURREAL_USER=REDACTED_LOCAL_USER
+SURREAL_PASS=REDACTED_LOCAL_PASSWORD


### PR DESCRIPTION
## SurrealDB Local Runtime Bootstrap

Implements the minimal local SurrealDB Context Intelligence runtime bootstrap slice.

### Changes

- **AP A (#2392):** `docs/surrealdb/local-context-runtime-contract.md` — stack contract defining what runs permanently (`cdb_surrealdb` only), what runs as one-shot tooling, and why; explicit exclusion of Trading/LR/BLUE/RED scope.
- **AP B (#2393):** Makefile `context-up`, `context-down`, `context-status`, `context-logs`, `context-restart` — one-command start/stop/status/logs with Windows/Linux handling.
- **AP C (#2394):** Makefile `context-env-check` plus `infrastructure/config/surrealdb/SURREALDB_ENV.example` — env/secrets guard with no secret value output and clear operator-facing failure message.
- **AP D:** `infrastructure/compose/README.md` updated with canonical `make context-*` references and scope boundaries.

### Scope Boundaries

- No pipeline smoke.
- No schema apply.
- No import.
- No query smoke.
- No MCP daemon container in v1.
- No Trading Runtime.
- No BLUE/RED runtime start.
- No Live-Readiness change.
- No real-money scope.
- No auto-trade scope.

### Validation

Performed before PR creation:

- `git diff --check`
- `make context-env-check`
  - expected graceful failure when `${SECRETS_PATH}/SURREALDB_ENV` is absent
  - no secret values printed
- `make context-status`
  - clean not-found/not-running output when `cdb_surrealdb` is absent
- `make context-logs`
  - clean not-running/not-found output when `cdb_surrealdb` is absent

Docker/env note:
The dev-container environment does not contain the local `${SECRETS_PATH}/SURREALDB_ENV`, so `context-up` was intentionally not executed. Schema/import/query smoke are intentionally out of scope for this PR.

### Issue Links

Closes #2392
Closes #2393
Closes #2394

### Anchors

- #2391 remains open as the Local Runtime Epic.
- #1976 remains open as the Context Intelligence Ledger Anchor.

### Live-Readiness

No LR-Go.
No Echtgeld-Go.
No Trading-Go.
This is local Context Infrastructure only.
