### PR TITLE
feat(surrealdb): add local schema workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ REPLAY_ADAPTER_ID ?= primary_breakout_runner_v1
 REPLAY_DRY_RUN ?= 0
 REPLAY_DETERMINISTIC_VERIFY ?= 1
 
-.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-up context-down context-status context-logs context-restart
+.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local
 
 help:
 	@echo "Claire de Binare - Test Commands"
@@ -81,6 +81,9 @@ help:
 	@echo "  make context-status          - Container/Volume/Port-Status (kein Secret-Leak)"
 	@echo "  make context-logs            - cdb_surrealdb Logs anzeigen (letzte 50 Zeilen)"
 	@echo "  make context-restart         - Sidecar neu starten (context-down + context-up)"
+	@echo "  make context-schema-apply    - Schema context_intelligence_v0 lokal anwenden"
+	@echo "  make context-schema-check    - Schema-Tabellen pruefen (graceful fail)"
+	@echo "  make context-reset-local     - DESTRUKTIV: Context-Daten lokal loeschen"
 
 # ============================================================================
 # CI-Tests (schnell, mit Mocks)
@@ -295,6 +298,23 @@ context-logs:
 	@docker logs cdb_surrealdb --tail 50 2>/dev/null || echo "cdb_surrealdb is not running or not found."
 
 context-restart: context-down context-up
+
+
+context-schema-apply:
+	@echo "=== SurrealDB Schema Apply: context_intelligence_v0 ==="
+	@python3 tools/surrealdb/local_schema_apply.py --secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}
+
+context-schema-check:
+	@echo "=== SurrealDB Schema Check: context_intelligence_v0 ==="
+	@python3 tools/surrealdb/local_schema_check.py --secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}
+
+context-reset-local:
+	@echo "=== SurrealDB Local Reset (DESTRUKTIV - nur Context-Intelligence-Daten) ==="
+	@echo "DESTRUKTIV: Alle Datensaetze in Context-Intelligence-Tabellen werden geloescht."
+	@echo "Trading/Live/Risk/Governance-Tabellen werden NICHT angefasst."
+	@echo "Schema-Definitionen bleiben erhalten."
+	@echo ""
+	@python3 tools/surrealdb/local_reset.py --confirm --secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}
 
 # ============================================================================# Paper Trading (14-Tage Test)
 # ============================================================================

--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,10 @@ context-reset-local:
 	@echo "Trading/Live/Risk/Governance-Tabellen werden NICHT angefasst."
 	@echo "Schema-Definitionen bleiben erhalten."
 	@echo ""
+	@if [ "$(CONFIRM)" != "1" ]; then \
+		echo "ERROR: Explicit confirmation required. Run: make context-reset-local CONFIRM=1"; \
+		exit 2; \
+	fi
 	@python3 tools/surrealdb/local_reset.py --confirm --secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}
 
 # ============================================================================# Paper Trading (14-Tage Test)

--- a/docs/surrealdb/local-context-runtime-contract.md
+++ b/docs/surrealdb/local-context-runtime-contract.md
@@ -123,13 +123,49 @@ Use `make context-env-check` to verify the env file without exposing any values.
 ## 9. Operator Commands
 
 ```bash
-make context-env-check   # Verify env/secrets guard (no secret output)
-make context-up          # Start cdb_surrealdb sidecar (runs env-check first)
-make context-status      # Container/volume/port status (no secret output)
-make context-logs        # Tail cdb_surrealdb logs (last 50 lines)
-make context-down        # Stop cdb_surrealdb sidecar (BLUE/RED untouched)
-make context-restart     # context-down then context-up
+make context-env-check      # Verify env/secrets guard (no secret output)
+make context-up             # Start cdb_surrealdb sidecar (runs env-check first)
+make context-status         # Container/volume/port status (no secret output)
+make context-logs           # Tail cdb_surrealdb logs (last 50 lines)
+make context-down           # Stop cdb_surrealdb sidecar (BLUE/RED untouched)
+make context-restart        # context-down then context-up
 ```
+
+### Schema Workflow (Issue #2395)
+
+```bash
+make context-schema-apply   # Apply context_intelligence_v0.surql to local DB
+make context-schema-check   # Verify all v0 tables exist (graceful fail if offline)
+make context-reset-local    # DESTRUCTIVE: clear all context-intelligence data
+```
+
+**Schema apply** (`context-schema-apply`):
+
+- Reads `infrastructure/surrealdb/context_intelligence_v0.surql`
+- Connects to `http://127.0.0.1:8010` (local dev port — hard-guarded)
+- Target namespace/database: `cdb_context_local` / `cdb_context_intel`
+- Runs `DEFINE TABLE ...` statements (idempotent — safe to re-apply)
+- Requires `cdb_surrealdb` running (`make context-up` first)
+- No trading/live tables are touched
+
+**Schema check** (`context-schema-check`):
+
+- Queries `INFO FOR DB` and compares against the 18 expected v0 tables
+- Exits 0 if all tables present or if container is offline (graceful)
+- Exits 1 if tables are missing — prints which ones
+- No secret output
+
+**Local reset** (`context-reset-local`):
+
+- **DESTRUCTIVE**: clears all record data in context-intelligence tables
+- Schema definitions (`DEFINE TABLE`) are preserved — only records are deleted
+- Hard guard: only executes against `127.0.0.1` / `localhost`
+- Hard guard: `--confirm` flag required (prevents accidental execution)
+- Trading/live/risk/governance tables (`orders`, `fills`, `positions`, etc.) are
+  explicitly forbidden and never touched
+- LR-Go remains NO-GO; this operation has no effect on live-readiness
+
+Scripts: `tools/surrealdb/local_schema_apply.py`, `local_schema_check.py`, `local_reset.py`
 
 ---
 
@@ -162,13 +198,16 @@ The following are explicitly **outside** the SurrealDB local context stack:
 | #2392 | This contract document | Closed via PR |
 | #2393 | One-command startup (Makefile targets) | Closed via PR |
 | #2394 | Env/secrets guard | Closed via PR |
+| #2395 | Local schema apply and reset workflow | Closed via PR |
 
 ---
 
 ## 12. Invariants
 
 - `cdb_surrealdb` is the only permanent container in this stack.
-- No secrets or credential values are ever printed by any `make context-*` target.
+- No secrets or credential values are ever printed by any `make context-*` target or helper script.
 - `context-down` never stops BLUE or RED runtime containers.
 - `context-up` always runs `context-env-check` first.
+- `context-schema-apply` and `context-schema-check` only connect to `127.0.0.1:8010` (local-dev port).
+- `context-reset-local` requires `--confirm` and never touches trading/live/risk/governance tables.
 - This runtime has no effect on live-readiness verdict.

--- a/tools/surrealdb/local_reset.py
+++ b/tools/surrealdb/local_reset.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import json
 import os
 import sys
 import urllib.error
@@ -74,6 +75,64 @@ FORBIDDEN_TABLES: frozenset[str] = frozenset(
         "governance_state",
     }
 )
+
+
+def _check_delete_result(table: str, body: bytes) -> None:
+    """Parse SurrealDB /sql response for a single DELETE statement.
+
+    SurrealDB returns HTTP 200 even when the statement fails (e.g. table not
+    defined, permission denied, incompatible version). Requires every result
+    item to carry ``status == "OK"``; any ``"ERR"`` or missing/unexpected
+    field is treated as a fatal failure for that table.
+
+    Raises ValueError with an operator-friendly message on any failure.
+    """
+    try:
+        raw = body.decode("utf-8", errors="replace")
+    except Exception as exc:
+        raise ValueError(f"response body not decodable: {exc}") from exc
+
+    if not raw.strip():
+        raise ValueError(
+            "response body is empty — expected JSON array from SurrealDB /sql"
+        )
+
+    try:
+        results = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"response body is not valid JSON: {exc} "
+            f"(first 400 chars: {raw[:400]!r})"
+        ) from exc
+
+    if not isinstance(results, list):
+        raise ValueError(
+            f"expected JSON array from /sql, got {type(results).__name__}: "
+            f"{raw[:400]!r}"
+        )
+
+    stmt_errors: list[str] = []
+    for idx, item in enumerate(results):
+        if not isinstance(item, dict):
+            stmt_errors.append(
+                f"statement {idx}: expected object, got {type(item).__name__}"
+            )
+            continue
+        stmt_status = item.get("status")
+        if stmt_status is None:
+            stmt_errors.append(
+                f"statement {idx}: missing 'status' field ({str(item)[:120]})"
+            )
+        elif stmt_status != "OK":
+            detail = item.get("detail") or item.get("result") or ""
+            stmt_errors.append(
+                f"statement {idx}: status={stmt_status!r} — {str(detail)[:200]}"
+            )
+
+    if stmt_errors:
+        raise ValueError(
+            f"DELETE {table} failed:\n" + "\n".join(f"  {e}" for e in stmt_errors)
+        )
 
 
 def _resolve_env_file(secrets_path: str | None = None) -> Path:
@@ -235,11 +294,18 @@ def main() -> None:
             print(f"  [GUARD] Skipping forbidden table: {table}", file=sys.stderr)
             continue
         sql = f"DELETE {table};"
-        status, _ = _sql_request(args.url, sql, user, password, args.ns, args.db)
-        if status in (200, 204):
+        status, body = _sql_request(args.url, sql, user, password, args.ns, args.db)
+        if status not in (200, 204):
+            print(f"  [WARN] {table}: unexpected HTTP status={status}", file=sys.stderr)
+            errors.append(table)
+            continue
+        # HTTP 200 is not sufficient — SurrealDB returns 200 even when the
+        # statement fails. Parse each result and require status == "OK".
+        try:
+            _check_delete_result(table, body)
             print(f"  [OK] {table}: cleared")
-        else:
-            print(f"  [WARN] {table}: unexpected status={status}", file=sys.stderr)
+        except ValueError as exc:
+            print(f"  [WARN] {table}: {exc}", file=sys.stderr)
             errors.append(table)
 
     print("")

--- a/tools/surrealdb/local_reset.py
+++ b/tools/surrealdb/local_reset.py
@@ -1,0 +1,258 @@
+"""Local SurrealDB reset — removes data from context-intelligence tables only.
+
+DESTRUCTIVE. Local-only guard enforced. Requires explicit --confirm flag.
+Trading/live/risk/governance tables are hard-blocked and never touched.
+Schema definitions (DEFINE TABLE) are preserved — only record data is cleared.
+
+Issues:
+    #2395 - Local schema apply and reset workflow
+    Parent: #2391
+    Epic: #1976
+
+Usage:
+    python tools/surrealdb/local_reset.py --confirm
+    python tools/surrealdb/local_reset.py --confirm --url http://127.0.0.1:8010
+
+Guardrails:
+    - Only connects to 127.0.0.1 or localhost (hard-reject)
+    - --confirm is REQUIRED; no silent destructive operations
+    - Only CONTEXT_INTELLIGENCE_TABLES are cleared (DELETE, not REMOVE TABLE)
+    - FORBIDDEN_TABLES are never touched — any attempt hard-exits with code 2
+    - No credential values are ever printed
+    - LR-Go remains NO-GO; this script has no effect on live-readiness
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+LOCAL_ALLOWED_HOSTS = {"127.0.0.1", "localhost"}
+DEFAULT_SURREAL_URL = "http://127.0.0.1:8010"
+DEFAULT_NS = "cdb_context_local"
+DEFAULT_DB = "cdb_context_intel"
+
+# ONLY these context-intelligence tables may be cleared.
+CONTEXT_INTELLIGENCE_TABLES = [
+    "repo_artifact",
+    "code_symbol",
+    "doc_page",
+    "doc_section",
+    "doc_chunk",
+    "concept",
+    "dependency_edge",
+    "evidence_ref",
+    "claim",
+    "decision_event",
+    "agent_memory",
+    "context_query",
+    "audit_observation",
+    "contradiction",
+    "stale_context",
+    "scope_drift_event",
+    "knowledge_quality_score",
+    "visual_control_view",
+]
+
+# Trading/live/governance tables that MUST NEVER be touched.
+FORBIDDEN_TABLES: frozenset[str] = frozenset(
+    {
+        "orders",
+        "fills",
+        "positions",
+        "balances",
+        "pnl",
+        "risk_state",
+        "execution_state",
+        "governance_event",
+        "governance_decision",
+        "governance_state",
+    }
+)
+
+
+def _resolve_env_file(secrets_path: str | None = None) -> Path:
+    if secrets_path is None:
+        secrets_path = os.environ.get(
+            "SECRETS_PATH",
+            str(Path.home() / "Documents" / ".secrets" / ".cdb"),
+        )
+    return Path(secrets_path) / "SURREALDB_ENV"
+
+
+def _load_credentials(env_file: Path) -> tuple[str, str]:
+    """Load credentials from env file. Never prints values."""
+    if not env_file.exists():
+        print(f"ERROR: SURREALDB_ENV not found at {env_file}", file=sys.stderr)
+        print(
+            "       Create it from infrastructure/config/surrealdb/SURREALDB_ENV.example",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    user: str | None = None
+    password: str | None = None
+    with env_file.open() as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped.startswith("SURREAL_USER="):
+                user = stripped[len("SURREAL_USER="):]
+            elif stripped.startswith("SURREAL_PASS="):
+                password = stripped[len("SURREAL_PASS="):]
+
+    if not user or not password:
+        print(
+            "ERROR: SURREALDB_ENV missing SURREAL_USER or SURREAL_PASS",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return user, password
+
+
+def _guard_local(url: str) -> None:
+    """Hard-reject any non-local target. Reset is local-dev only."""
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or ""
+    if host not in LOCAL_ALLOWED_HOSTS:
+        print(
+            f"ERROR: Remote/production target rejected: {host!r}",
+            file=sys.stderr,
+        )
+        print(
+            "       Reset is ONLY allowed on local dev instances (127.0.0.1 / localhost).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def _guard_no_forbidden(tables: list[str]) -> None:
+    """Hard-exit if any forbidden (trading/live) table is in the reset list."""
+    overlap = FORBIDDEN_TABLES & set(tables)
+    if overlap:
+        print(
+            f"ERROR: Forbidden tables in reset list: {sorted(overlap)}",
+            file=sys.stderr,
+        )
+        print(
+            "       Trading/live/governance tables must never be cleared by this script.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def _health_check(url: str) -> bool:
+    """Return True if SurrealDB health endpoint responds OK."""
+    try:
+        resp = urllib.request.urlopen(f"{url}/health", timeout=3)
+        return resp.status == 200
+    except Exception:
+        return False
+
+
+def _sql_request(
+    url: str,
+    sql: str,
+    user: str,
+    password: str,
+    ns: str,
+    db: str,
+) -> tuple[int, bytes]:
+    """Execute SQL via SurrealDB HTTP API. Returns (status_code, body)."""
+    token = base64.b64encode(f"{user}:{password}".encode()).decode()
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "text/plain",
+        "Authorization": f"Basic {token}",
+        "surreal-ns": ns,
+        "surreal-db": db,
+    }
+    req = urllib.request.Request(
+        f"{url}/sql", data=sql.encode(), headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "DESTRUCTIVE: Clear all record data from context-intelligence tables "
+            "in local SurrealDB. Trading/live tables are never touched. "
+            "Schema definitions (DEFINE TABLE) are preserved."
+        )
+    )
+    parser.add_argument("--url", default=DEFAULT_SURREAL_URL)
+    parser.add_argument("--ns", default=DEFAULT_NS)
+    parser.add_argument("--db", default=DEFAULT_DB)
+    parser.add_argument("--secrets-path", default=None)
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        required=True,
+        help="REQUIRED: Explicit confirmation that this is a destructive local reset.",
+    )
+    args = parser.parse_args()
+
+    # Hard guards
+    _guard_local(args.url)
+    _guard_no_forbidden(CONTEXT_INTELLIGENCE_TABLES)
+
+    print("=== LOCAL RESET: context_intelligence_v0 ===")
+    print("DESTRUCTIVE: All record data in context-intelligence tables will be cleared.")
+    print("Trading / live / risk / governance tables are NOT touched.")
+    print("Schema definitions (DEFINE TABLE) are preserved.")
+    print(f"Target : {args.url} / NS={args.ns} / DB={args.db}")
+    print("")
+
+    env_file = _resolve_env_file(args.secrets_path)
+    user, password = _load_credentials(env_file)
+
+    if not _health_check(args.url):
+        print(
+            f"ERROR: cdb_surrealdb not reachable at {args.url}/health",
+            file=sys.stderr,
+        )
+        print("       Run 'make context-up' to start the container.", file=sys.stderr)
+        sys.exit(4)
+
+    print("[OK] Container healthy.")
+    print(f"[INFO] Clearing {len(CONTEXT_INTELLIGENCE_TABLES)} context-intelligence tables...")
+    print("")
+
+    errors: list[str] = []
+    for table in CONTEXT_INTELLIGENCE_TABLES:
+        # Double-check: skip if somehow in forbidden set (belt-and-suspenders)
+        if table in FORBIDDEN_TABLES:
+            print(f"  [GUARD] Skipping forbidden table: {table}", file=sys.stderr)
+            continue
+        sql = f"DELETE {table};"
+        status, _ = _sql_request(args.url, sql, user, password, args.ns, args.db)
+        if status in (200, 204):
+            print(f"  [OK] {table}: cleared")
+        else:
+            print(f"  [WARN] {table}: unexpected status={status}", file=sys.stderr)
+            errors.append(table)
+
+    print("")
+    if errors:
+        print(f"[WARN] Some tables had errors: {errors}", file=sys.stderr)
+        print("       Schema definitions remain intact.", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print("[OK] Local context reset complete.")
+        print("     Schema definitions (DEFINE TABLE) preserved.")
+        print("     Run 'make context-schema-apply' to re-apply schema if needed.")
+        print("NOTE: This was a local context reset only — not a Live/Trading Go.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/surrealdb/local_schema_apply.py
+++ b/tools/surrealdb/local_schema_apply.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import json
 import os
 import sys
 import urllib.error
@@ -136,6 +137,61 @@ def _sql_request(
         return exc.code, exc.read()
 
 
+def _check_statement_results(body: bytes) -> list[dict]:
+    """Parse SurrealDB /sql response and fail on any non-OK statement.
+
+    SurrealDB returns HTTP 200 even when individual statements fail.
+    Each result item must have ``status: "OK"``; any ``"ERR"`` (or missing
+    status, malformed JSON, empty body) is treated as a fatal apply failure.
+
+    Returns the parsed results list on full success.
+    Raises ValueError with an operator-friendly message on any failure.
+    """
+    try:
+        raw = body.decode("utf-8", errors="replace")
+    except Exception as exc:
+        raise ValueError(f"Response body not decodable: {exc}") from exc
+
+    if not raw.strip():
+        raise ValueError("Response body is empty — expected JSON array from SurrealDB /sql")
+
+    try:
+        results = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        truncated = raw[:400]
+        raise ValueError(
+            f"Response body is not valid JSON: {exc}\n  Body (first 400 chars): {truncated}"
+        ) from exc
+
+    if not isinstance(results, list):
+        raise ValueError(
+            f"Expected JSON array from /sql, got {type(results).__name__}: {raw[:400]}"
+        )
+
+    errors: list[str] = []
+    for idx, item in enumerate(results):
+        if not isinstance(item, dict):
+            errors.append(f"  Statement {idx}: expected object, got {type(item).__name__}")
+            continue
+        stmt_status = item.get("status")
+        if stmt_status is None:
+            errors.append(
+                f"  Statement {idx}: missing 'status' field (item: {str(item)[:120]})"
+            )
+        elif stmt_status != "OK":
+            detail = item.get("detail") or item.get("result") or ""
+            errors.append(
+                f"  Statement {idx}: status={stmt_status!r} — {str(detail)[:200]}"
+            )
+
+    if errors:
+        raise ValueError(
+            "One or more schema statements failed:\n" + "\n".join(errors)
+        )
+
+    return results
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Apply context_intelligence_v0 schema to local SurrealDB (local-only)."
@@ -206,7 +262,15 @@ def main() -> None:
         print(f"       Response: {body_text}", file=sys.stderr)
         sys.exit(5)
 
-    print("[OK] Schema applied successfully.")
+    # HTTP 200 is not sufficient — SurrealDB returns 200 even when statements fail.
+    # Parse each statement result and fail if any status != "OK".
+    try:
+        results = _check_statement_results(body)
+    except ValueError as exc:
+        print(f"ERROR: Schema apply failed — {exc}", file=sys.stderr)
+        sys.exit(5)
+
+    print(f"[OK] Schema applied successfully ({len(results)} statement(s) — all OK).")
     print(f"     NS={args.ns}  DB={args.db}")
     print("NOTE: This is local context infrastructure only — not a Live/Trading Go.")
 

--- a/tools/surrealdb/local_schema_apply.py
+++ b/tools/surrealdb/local_schema_apply.py
@@ -1,0 +1,215 @@
+"""Local SurrealDB schema apply — context_intelligence_v0.
+
+Local-only guard enforced. Reads credentials from SECRETS_PATH.
+No credential output. No remote/production target allowed.
+
+Issues:
+    #2395 - Local schema apply and reset workflow
+    Parent: #2391
+    Epic: #1976
+
+Usage:
+    python tools/surrealdb/local_schema_apply.py
+    python tools/surrealdb/local_schema_apply.py --url http://127.0.0.1:8010
+    python tools/surrealdb/local_schema_apply.py --dry-run
+
+Guardrails:
+    - Only connects to 127.0.0.1 or localhost (hard-reject all other hosts)
+    - No credential values are ever printed
+    - No trading/live/risk tables are touched (schema is context-intelligence only)
+    - LR-Go remains NO-GO; this script has no effect on live-readiness
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+LOCAL_ALLOWED_HOSTS = {"127.0.0.1", "localhost"}
+DEFAULT_SURREAL_URL = "http://127.0.0.1:8010"
+DEFAULT_NS = "cdb_context_local"
+DEFAULT_DB = "cdb_context_intel"
+
+# Schema file path relative to repo root
+_REPO_ROOT = Path(__file__).parent.parent.parent
+SCHEMA_FILE = _REPO_ROOT / "infrastructure" / "surrealdb" / "context_intelligence_v0.surql"
+
+
+def _resolve_env_file(secrets_path: str | None = None) -> Path:
+    if secrets_path is None:
+        secrets_path = os.environ.get(
+            "SECRETS_PATH",
+            str(Path.home() / "Documents" / ".secrets" / ".cdb"),
+        )
+    return Path(secrets_path) / "SURREALDB_ENV"
+
+
+def _load_credentials(env_file: Path) -> tuple[str, str]:
+    """Load credentials from env file. Returns (user, pass). Never prints values."""
+    if not env_file.exists():
+        print(f"ERROR: SURREALDB_ENV not found at {env_file}", file=sys.stderr)
+        print(
+            "       Create it from infrastructure/config/surrealdb/SURREALDB_ENV.example",
+            file=sys.stderr,
+        )
+        print(
+            "       and store the real file outside the repository.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    user: str | None = None
+    password: str | None = None
+    with env_file.open() as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped.startswith("SURREAL_USER="):
+                user = stripped[len("SURREAL_USER="):]
+            elif stripped.startswith("SURREAL_PASS="):
+                password = stripped[len("SURREAL_PASS="):]
+
+    if not user:
+        print("ERROR: SURREALDB_ENV missing field SURREAL_USER", file=sys.stderr)
+        sys.exit(1)
+    if not password:
+        print("ERROR: SURREALDB_ENV missing field SURREAL_PASS", file=sys.stderr)
+        sys.exit(1)
+
+    return user, password
+
+
+def _guard_local(url: str) -> None:
+    """Hard-reject any non-local target. Remote/production URLs are always rejected."""
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or ""
+    if host not in LOCAL_ALLOWED_HOSTS:
+        print(
+            f"ERROR: Remote/production target rejected. Only local connections allowed.",
+            file=sys.stderr,
+        )
+        print(
+            f"       Got host: {host!r}  Allowed: {sorted(LOCAL_ALLOWED_HOSTS)}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def _health_check(url: str) -> bool:
+    """Return True if SurrealDB health endpoint responds OK."""
+    try:
+        resp = urllib.request.urlopen(f"{url}/health", timeout=3)
+        return resp.status == 200
+    except Exception:
+        return False
+
+
+def _sql_request(
+    url: str,
+    sql: str,
+    user: str,
+    password: str,
+    ns: str,
+    db: str,
+) -> tuple[int, bytes]:
+    """Execute SQL via SurrealDB HTTP API. Returns (status_code, body)."""
+    token = base64.b64encode(f"{user}:{password}".encode()).decode()
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "text/plain",
+        "Authorization": f"Basic {token}",
+        "surreal-ns": ns,
+        "surreal-db": db,
+    }
+    data = sql.encode("utf-8")
+    req = urllib.request.Request(
+        f"{url}/sql", data=data, headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Apply context_intelligence_v0 schema to local SurrealDB (local-only)."
+    )
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_SURREAL_URL,
+        help=f"SurrealDB HTTP URL (default: {DEFAULT_SURREAL_URL})",
+    )
+    parser.add_argument("--ns", default=DEFAULT_NS, help=f"SurrealDB namespace (default: {DEFAULT_NS})")
+    parser.add_argument("--db", default=DEFAULT_DB, help=f"SurrealDB database (default: {DEFAULT_DB})")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate schema file exists and is readable, but do not apply.",
+    )
+    parser.add_argument(
+        "--secrets-path",
+        default=None,
+        help="Override SECRETS_PATH directory.",
+    )
+    args = parser.parse_args()
+
+    # Hard guard: local only
+    _guard_local(args.url)
+
+    # Validate schema file exists
+    schema_path = SCHEMA_FILE
+    if not schema_path.exists():
+        print(f"ERROR: Schema file not found: {schema_path}", file=sys.stderr)
+        sys.exit(3)
+
+    schema_sql = schema_path.read_text(encoding="utf-8")
+    print(f"[INFO] Schema file: {schema_path.relative_to(_REPO_ROOT)} ({len(schema_sql)} bytes)")
+    print(f"[INFO] Target: {args.url} / NS={args.ns} / DB={args.db}")
+    print(f"[INFO] Scope: context-intelligence only (no trading/live tables)")
+
+    if args.dry_run:
+        print("[DRY-RUN] Schema file readable. No apply performed.")
+        sys.exit(0)
+
+    # Load credentials (after dry-run check so dry-run doesn't require env file)
+    env_file = _resolve_env_file(args.secrets_path)
+    user, password = _load_credentials(env_file)
+
+    # Check container health
+    print("[INFO] Checking container health...")
+    if not _health_check(args.url):
+        print(
+            f"ERROR: cdb_surrealdb not reachable at {args.url}/health",
+            file=sys.stderr,
+        )
+        print("       Run 'make context-up' to start the container.", file=sys.stderr)
+        sys.exit(4)
+    print("[OK] Container healthy.")
+
+    # Apply schema
+    print("[INFO] Applying schema...")
+    status, body = _sql_request(args.url, schema_sql, user, password, args.ns, args.db)
+
+    if status not in (200, 204):
+        print(f"ERROR: Schema apply failed (HTTP {status})", file=sys.stderr)
+        # Show response body but truncate (guard against accidental secret echo)
+        try:
+            body_text = body.decode("utf-8", errors="replace")[:800]
+        except Exception:
+            body_text = "<unreadable>"
+        print(f"       Response: {body_text}", file=sys.stderr)
+        sys.exit(5)
+
+    print("[OK] Schema applied successfully.")
+    print(f"     NS={args.ns}  DB={args.db}")
+    print("NOTE: This is local context infrastructure only — not a Live/Trading Go.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/surrealdb/local_schema_check.py
+++ b/tools/surrealdb/local_schema_check.py
@@ -1,0 +1,223 @@
+"""Local SurrealDB schema check — verifies context_intelligence_v0 tables exist.
+
+Local-only guard enforced. No credential output. Exits 0 if all expected tables
+are present, exits 1 if tables are missing. Exits 0 gracefully if container is
+offline (container absence is not an error condition during development).
+
+Issues:
+    #2395 - Local schema apply and reset workflow
+    Parent: #2391
+    Epic: #1976
+
+Usage:
+    python tools/surrealdb/local_schema_check.py
+    python tools/surrealdb/local_schema_check.py --url http://127.0.0.1:8010
+
+Guardrails:
+    - Only connects to 127.0.0.1 or localhost
+    - No credential values are ever printed
+    - Graceful exit when container is not running
+    - LR-Go remains NO-GO; this script has no effect on live-readiness
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+LOCAL_ALLOWED_HOSTS = {"127.0.0.1", "localhost"}
+DEFAULT_SURREAL_URL = "http://127.0.0.1:8010"
+DEFAULT_NS = "cdb_context_local"
+DEFAULT_DB = "cdb_context_intel"
+
+# Tables expected from context_intelligence_v0.surql
+EXPECTED_TABLES = [
+    "repo_artifact",
+    "code_symbol",
+    "doc_page",
+    "doc_section",
+    "doc_chunk",
+    "concept",
+    "dependency_edge",
+    "evidence_ref",
+    "claim",
+    "decision_event",
+    "agent_memory",
+    "context_query",
+    "audit_observation",
+    "contradiction",
+    "stale_context",
+    "scope_drift_event",
+    "knowledge_quality_score",
+    "visual_control_view",
+]
+
+
+def _resolve_env_file(secrets_path: str | None = None) -> Path:
+    if secrets_path is None:
+        secrets_path = os.environ.get(
+            "SECRETS_PATH",
+            str(Path.home() / "Documents" / ".secrets" / ".cdb"),
+        )
+    return Path(secrets_path) / "SURREALDB_ENV"
+
+
+def _load_credentials(env_file: Path) -> tuple[str, str]:
+    """Load credentials from env file. Never prints values."""
+    if not env_file.exists():
+        print(f"ERROR: SURREALDB_ENV not found at {env_file}", file=sys.stderr)
+        print(
+            "       Create it from infrastructure/config/surrealdb/SURREALDB_ENV.example",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    user: str | None = None
+    password: str | None = None
+    with env_file.open() as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped.startswith("SURREAL_USER="):
+                user = stripped[len("SURREAL_USER="):]
+            elif stripped.startswith("SURREAL_PASS="):
+                password = stripped[len("SURREAL_PASS="):]
+
+    if not user or not password:
+        print(
+            "ERROR: SURREALDB_ENV missing SURREAL_USER or SURREAL_PASS",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return user, password
+
+
+def _guard_local(url: str) -> None:
+    """Hard-reject any non-local target."""
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or ""
+    if host not in LOCAL_ALLOWED_HOSTS:
+        print(
+            f"ERROR: Non-local target rejected: {host!r}  Allowed: {sorted(LOCAL_ALLOWED_HOSTS)}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def _health_check(url: str) -> bool:
+    """Return True if SurrealDB health endpoint responds OK."""
+    try:
+        resp = urllib.request.urlopen(f"{url}/health", timeout=3)
+        return resp.status == 200
+    except Exception:
+        return False
+
+
+def _sql_request(
+    url: str,
+    sql: str,
+    user: str,
+    password: str,
+    ns: str,
+    db: str,
+) -> tuple[int, bytes]:
+    """Execute SQL via SurrealDB HTTP API. Returns (status_code, body)."""
+    token = base64.b64encode(f"{user}:{password}".encode()).decode()
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "text/plain",
+        "Authorization": f"Basic {token}",
+        "surreal-ns": ns,
+        "surreal-db": db,
+    }
+    req = urllib.request.Request(
+        f"{url}/sql", data=sql.encode(), headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Check context_intelligence_v0 schema presence in local SurrealDB."
+    )
+    parser.add_argument("--url", default=DEFAULT_SURREAL_URL)
+    parser.add_argument("--ns", default=DEFAULT_NS)
+    parser.add_argument("--db", default=DEFAULT_DB)
+    parser.add_argument("--secrets-path", default=None)
+    args = parser.parse_args()
+
+    _guard_local(args.url)
+
+    print(f"[INFO] Checking container at {args.url}/health...")
+    if not _health_check(args.url):
+        print("[WARN] cdb_surrealdb not reachable. Container may not be running.")
+        print("       Run 'make context-up' to start the container.")
+        print("[SKIP] Schema check skipped (container offline).")
+        sys.exit(0)
+
+    print("[OK] Container reachable.")
+
+    env_file = _resolve_env_file(args.secrets_path)
+    user, password = _load_credentials(env_file)
+
+    print(f"[INFO] Querying NS={args.ns}  DB={args.db}...")
+    status, body = _sql_request(
+        args.url, "INFO FOR DB;", user, password, args.ns, args.db
+    )
+
+    if status not in (200, 204):
+        print(f"ERROR: INFO FOR DB failed (HTTP {status})", file=sys.stderr)
+        sys.exit(5)
+
+    tables_in_db: set[str] = set()
+    try:
+        response = json.loads(body)
+        if isinstance(response, list) and response:
+            result = response[0].get("result", {})
+            if isinstance(result, dict):
+                tables_in_db = set(result.get("tables", {}).keys())
+    except (json.JSONDecodeError, KeyError, TypeError, IndexError):
+        print("ERROR: Could not parse INFO FOR DB response", file=sys.stderr)
+        sys.exit(5)
+
+    print(f"\n=== Schema Check: context_intelligence_v0 ===")
+    print(f"Target : {args.url} / NS={args.ns} / DB={args.db}")
+    print(f"Expected: {len(EXPECTED_TABLES)} tables\n")
+
+    missing = []
+    present = []
+    for table in EXPECTED_TABLES:
+        if table in tables_in_db:
+            print(f"  [OK]      {table}")
+            present.append(table)
+        else:
+            print(f"  [MISSING] {table}")
+            missing.append(table)
+
+    extra = sorted(tables_in_db - set(EXPECTED_TABLES))
+    if extra:
+        print(f"\n  Extra tables (not in v0 schema): {extra}")
+
+    print(f"\nSummary: {len(present)}/{len(EXPECTED_TABLES)} tables present")
+    if missing:
+        print(f"Missing : {missing}")
+        print("Action  : Run 'make context-schema-apply' to apply the schema.")
+        sys.exit(1)
+    else:
+        print("[OK] All expected v0 tables present.")
+        print("NOTE: This is local context infrastructure only — not a Live/Trading Go.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## SurrealDB Local Schema Workflow

Closes #2395

### Was wurde implementiert

- `make context-schema-apply` — wendet `infrastructure/surrealdb/context_intelligence_v0.surql` lokal an.
- `make context-schema-check` — prüft alle 18 v0-Tabellen und verhält sich offline graceful.
- `make context-reset-local` — destruktiver Local-Reset für Context-Daten, mit explizitem Confirm-Gate.
- `tools/surrealdb/local_schema_apply.py` — SurrealDB HTTP API via stdlib `urllib`, local-only guard.
- `tools/surrealdb/local_schema_check.py` — `INFO FOR DB`-basierter Schema-Check, defensive Response-Auswertung.
- `tools/surrealdb/local_reset.py` — `--confirm` erforderlich, forbidden-table guard, `DELETE` statt Schema-Removal.
- `docs/surrealdb/local-context-runtime-contract.md` — Schema-Workflow, Epic-Bezug und neue Invarianten ergänzt.

### Scope & Invarianten

- Nur lokale Ziele erlaubt: `127.0.0.1` / `localhost`.
- Remote-/Produktivziele werden hart abgelehnt.
- Reset erfordert `--confirm`.
- Reset löscht nur Daten aus Context-Intelligence-Tabellen; Schema bleibt erhalten.
- Forbidden list schützt Trading-/Live-/Risk-/Execution-nahe Tabellen.
- Keine Credentials-Ausgabe.
- Graceful Fail bei fehlender Env oder offline Container.
- Kein Pipeline-Smoke.
- Kein Import.
- Kein Query-Smoke.
- Kein MCP-Dauercontainer.
- Kein BLUE/RED Runtime Touch.
- Kein Trading-/Live-/Echtgeld-Scope.

### Validierung

Ausgeführt vor PR-Erstellung:

- `git diff --check`
- `make context-env-check`
- `make context-status`
- `make context-schema-check`
- `make context-schema-apply`
- `make context-reset-local`
- `python3 tools/surrealdb/local_schema_apply.py --dry-run`
- Remote-URL-Guard gegen nicht-lokale URLs
- Reset ohne `--confirm`
- `ruff check tools/surrealdb/local_schema_apply.py tools/surrealdb/local_schema_check.py tools/surrealdb/local_reset.py`

### Bekannte Restunsicherheit

Der Codespace hatte keinen laufenden `cdb_surrealdb` und keine `${SECRETS_PATH}/SURREALDB_ENV`. Daher wurden echte Apply-/Reset-Operationen gegen einen laufenden lokalen Container bewusst nicht ausgeführt. Die Guards wurden validiert; echter Docker/Env-Durchstich bleibt Folgearbeit.

### Anchors

- #2391 bleibt als Local-Runtime-Epic OPEN.
- #1976 bleibt als Context-Intelligence-Ledger-Anker OPEN.

### Live-Readiness

No LR-Go.
No Echtgeld-Go.
No Trading-Go.
This is local Context Infrastructure only.
