### PR TITLE
docs(surrealdb): document local MCP posture

### DIFF
--- a/docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md
+++ b/docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md
@@ -400,7 +400,10 @@ eigenen `cdb_context_mcp`-Service. Docker Desktop muss für diesen Stack ausschl
 
 - Weniger Container → weniger Fehlerquellen.
 - `cdb_surrealdb` ist der einzige erforderliche Dauercontainer für den lokalen Context-DB-Stack.
-- CLI-Smoke (`context-query-smoke`) reicht als Betriebsnachweis.
+- Harter lokaler Betriebsnachweis ist `make context-status` (Containerstatus/Health) und,
+  wenn Docker/Env/Schema verfügbar sind, der vollständige `make context-smoke`.
+  `context-query-smoke` ist ein read-only Komfortcheck mit graceful Notes und kein
+  verlässlicher Proof-of-Life — er kann `[OK]` melden, auch wenn `cdb_surrealdb` offline ist.
 - MCP kann Operator-Befehle orchestrieren, ist aber **nicht Voraussetzung** für lokalen Betrieb.
 - Ein MCP-Service kann später separat ergänzt werden, wenn der CLI-Betrieb stabil ist.
 

--- a/docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md
+++ b/docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md
@@ -386,6 +386,53 @@ make context-import-dry-run
 
 ---
 
+## MCP-Posture (v1)
+
+### Entscheidung
+
+**Kein separater Context-MCP-Dauercontainer in v1.**
+
+Der lokale Mindestbetrieb für SurrealDB Context Intelligence erfordert in v1 keinen
+eigenen `cdb_context_mcp`-Service. Docker Desktop muss für diesen Stack ausschließlich
+`cdb_surrealdb` zeigen — keinen weiteren dauerhaft laufenden Container.
+
+### Begründung
+
+- Weniger Container → weniger Fehlerquellen.
+- `cdb_surrealdb` ist der einzige erforderliche Dauercontainer für den lokalen Context-DB-Stack.
+- CLI-Smoke (`context-query-smoke`) reicht als Betriebsnachweis.
+- MCP kann Operator-Befehle orchestrieren, ist aber **nicht Voraussetzung** für lokalen Betrieb.
+- Ein MCP-Service kann später separat ergänzt werden, wenn der CLI-Betrieb stabil ist.
+
+### Was MCP nicht nötig ist
+
+- `cdb_surrealdb` starten → kein MCP nötig.
+- Schema anwenden → kein MCP nötig.
+- Scan/Import/Query ausführen → kein MCP nötig.
+- Smoke-Test bestehen → kein MCP nötig.
+
+CDB-MCP / OpenCode kann vorhandene Makefile-Targets orchestrieren, gehört aber
+nicht zur lokalen Runtime-Pflicht.
+
+### Optionale Zukunftsoption
+
+Ein späterer read-only `cdb_context_mcp`-Service ist denkbar, aber:
+
+| Bedingung | Wert |
+|---|---|
+| Eigenes Issue/PR/Gate | erforderlich |
+| Read-only | zwingend, kein DB-Apply, kein Reset |
+| Kein Trading-Scope | keine Verbindung zu Risk/Execution |
+| Kein Write-fähiger MCP | Schema-/Daten-Writes immer nur via CLI-Jobs |
+| Kein Remote-MCP | nur `127.0.0.1`/`localhost` als lokaler Betriebsweg |
+| Kein Live-Go | kein LR-Effekt durch MCP-Einführung |
+| Kein Echtgeld-Go | kein Auto-Trading via MCP |
+
+Dieser Entscheid gilt für v1 und wird in einem separaten Issue/PR geändert, falls
+eine spätere Implementierung gewünscht wird.
+
+---
+
 ## Sicherheitsgrenzen
 
 | Grenze | Regel |
@@ -417,4 +464,4 @@ make context-import-dry-run
 
 ---
 
-*Issue: #2397 | Epic: #2391 | Ledger: #1976 | LR: NO-GO*
+*Issue: #2397 #2398 | Epic: #2391 | Ledger: #1976 | LR: NO-GO*


### PR DESCRIPTION
## SurrealDB Local MCP Posture — v1 Entscheidung

Closes #2398

### Was wurde implementiert

Neuer Abschnitt `## MCP-Posture (v1)` in:

`docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md`

Dokumentiert:

- Entscheidung: kein separater `cdb_context_mcp`-Dauercontainer in v1.
- `cdb_surrealdb` bleibt einziger erwarteter Dauercontainer für lokalen Context-DB-Stack.
- MCP ist Orchestrierung/Operator-Ebene, nicht Runtime-Pflicht.
- Begründung: weniger Container, weniger Fehlerquellen, CLI-Smoke reicht.
- Klarstellung: MCP ist nicht nötig für DB-Start, Schema-Apply, Scan/Import/Query oder Smoke.
- Optionale Zukunftsoption: read-only `cdb_context_mcp` nur mit eigenem Issue/PR/Gate.
- Sicherheitsgrenzen: kein Live-Go, kein Echtgeld-Go, kein Write-MCP, kein Remote-MCP.

### Scope & Invarianten

- Nur Dokumentation.
- Kein Python-Code.
- Kein Makefile.
- Keine Config-Änderung.
- Kein MCP-Service implementiert.
- Kein Docker-MCP aktiviert.
- Kein Trading-Scope.
- Kein Live-/LR-/Echtgeld-Scope.
- #2391 bleibt als Local-Runtime-Epic OPEN.
- #1976 bleibt als Context-Intelligence-Ledger-Anker OPEN.

### Validierung

Ausgeführt vor PR-Erstellung:

- `git diff --check`
- Prüfung, dass nur `docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md` im PR-Diff liegt.
- Prüfung der Pflichtaussagen:
  - kein separater Context-MCP-Dauercontainer in v1
  - `cdb_surrealdb` bleibt einziger erforderlicher Dauercontainer
  - MCP ist Orchestrierung/Operator-Ebene, nicht Runtime-Pflicht

### Bekannte Restunsicherheit

Keine technische Restunsicherheit. Dies ist eine reine Doku-/Entscheidungsänderung. Eine spätere read-only MCP-Erweiterung braucht eigenes Issue, eigenen PR und eigenes Gate.

### Live-Readiness

No LR-Go.
No Echtgeld-Go.
No Trading-Go.
This is local Context Infrastructure documentation only.
