### PR TITLE
fix(security): resolve CodeQL wave A findings

### DIFF
--- a/core/replay/canonical_json.py
+++ b/core/replay/canonical_json.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from typing import Any
 
 
@@ -40,7 +41,7 @@ def _sanitize_float(value: Any) -> Any:
     - Recurses into dicts and lists.
     """
     if isinstance(value, float):
-        if value != value or value == float("inf") or value == float("-inf"):
+        if math.isnan(value) or math.isinf(value):
             return None
         rounded = round(value, 10)
         # Normalize -0.0 -> 0.0 (equal in Python but different JSON strings)

--- a/core/utils/uuid_gen.py
+++ b/core/utils/uuid_gen.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import uuid
 from typing import Any, Optional
 
@@ -90,7 +91,7 @@ DECISION_HASH_FIELDS = (
 def _sanitize_float(value: Any) -> Any:
     """Sanitize float values for deterministic JSON serialization."""
     if isinstance(value, float):
-        if value != value or value == float("inf") or value == float("-inf"):
+        if math.isnan(value) or math.isinf(value):
             return None
         return round(value, 10)
     if isinstance(value, dict):

--- a/scripts/drills/lr041_redis_postgres_failure_runner.py
+++ b/scripts/drills/lr041_redis_postgres_failure_runner.py
@@ -239,19 +239,20 @@ def _queue_length(stream_name: str = "stream.orders") -> int:
 
 
 def _collect_snapshot() -> dict[str, Any]:
-    runtime_mode = "unresolved"
-    runtime_mode_source = "unresolved"
-    try:
-        status_payload = _http_get_json("http://localhost:8003/status")
+    def _read_runtime_mode() -> tuple[str, str]:
+        try:
+            status_payload = _http_get_json("http://localhost:8003/status")
+        except (urllib.error.URLError, TimeoutError, ValueError, json.JSONDecodeError):
+            return "unresolved", "unresolved"
+
         raw_mode = status_payload.get("runtime_mode")
         runtime_mode_source = "runtime_mode"
         if raw_mode in (None, ""):
             raw_mode = status_payload.get("mode")
             runtime_mode_source = "mode"
-        runtime_mode = _normalize_runtime_mode(raw_mode)
-    except (urllib.error.URLError, TimeoutError, ValueError, json.JSONDecodeError):
-        runtime_mode = "unresolved"
-        runtime_mode_source = "unresolved"
+        return _normalize_runtime_mode(raw_mode), runtime_mode_source
+
+    runtime_mode, runtime_mode_source = _read_runtime_mode()
 
     execution_metrics: dict[str, float] = {}
     risk_metrics: dict[str, float] = {}
@@ -482,31 +483,25 @@ def _run_scenario(
         if svc != config.target_container and delta > 0
     }
 
-    # Determine overall scenario status
-    status = "PASS"
     reasons: list[str] = []
 
     if container_recovery < 0:
-        status = "FAIL"
         reasons.append("container_did_not_recover")
     elif container_recovery_class == "FAIL":
-        status = "FAIL"
         reasons.append("container_recovery_too_slow")
 
     if service_recovery < 0:
-        status = "FAIL"
         reasons.append("services_did_not_recover")
-    elif service_recovery_class == "FAIL" and status != "FAIL":
-        status = "FAIL"
+    elif service_recovery_class == "FAIL":
         reasons.append("service_recovery_too_slow")
 
     if runtime_mode_after != "shadow":
-        status = "FAIL"
         reasons.append("runtime_mode_not_shadow_after_recovery")
 
     if filled_delta != 0.0:
-        status = "FAIL"
         reasons.append("lr030_zero_execution_breach")
+
+    status = "FAIL" if reasons else "PASS"
 
     timeline.append(
         {

--- a/scripts/drills/lr042_network_latency_packet_loss_runner.py
+++ b/scripts/drills/lr042_network_latency_packet_loss_runner.py
@@ -298,34 +298,28 @@ def _normalize_runtime_mode(raw_mode: Any) -> str:
 
 
 def _collect_snapshot() -> dict[str, Any]:
-    runtime_mode = "unresolved"
-    runtime_mode_source = "unresolved"
-    try:
-        status_payload = _http_get_json("http://localhost:8003/status")
+    def _read_runtime_mode() -> tuple[str, str]:
+        try:
+            status_payload = _http_get_json("http://localhost:8003/status")
+        except (urllib.error.URLError, TimeoutError, ValueError, json.JSONDecodeError):
+            return "unresolved", "unresolved"
+
         raw_mode = status_payload.get("runtime_mode")
         runtime_mode_source = "runtime_mode"
         if raw_mode in (None, ""):
             raw_mode = status_payload.get("mode")
             runtime_mode_source = "mode"
-        runtime_mode = _normalize_runtime_mode(raw_mode)
-    except (urllib.error.URLError, TimeoutError, ValueError, json.JSONDecodeError):
-        runtime_mode = "unresolved"
-        runtime_mode_source = "unresolved"
+        return _normalize_runtime_mode(raw_mode), runtime_mode_source
 
-    execution_metrics: dict[str, float] = {}
-    risk_metrics: dict[str, float] = {}
-    try:
-        execution_metrics = _parse_prometheus_text(
-            _http_get_text("http://localhost:8003/metrics")
-        )
-    except (urllib.error.URLError, TimeoutError):
-        execution_metrics = {}
-    try:
-        risk_metrics = _parse_prometheus_text(
-            _http_get_text("http://localhost:8002/metrics")
-        )
-    except (urllib.error.URLError, TimeoutError):
-        risk_metrics = {}
+    def _read_metrics(url: str) -> dict[str, float]:
+        try:
+            return _parse_prometheus_text(_http_get_text(url))
+        except (urllib.error.URLError, TimeoutError):
+            return {}
+
+    runtime_mode, runtime_mode_source = _read_runtime_mode()
+    execution_metrics = _read_metrics("http://localhost:8003/metrics")
+    risk_metrics = _read_metrics("http://localhost:8002/metrics")
 
     return {
         "captured_at_utc": _utc_now(),

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -28,7 +28,7 @@ import importlib.util
 try:
     _FLASK_AVAILABLE = importlib.util.find_spec("flask") is not None
 except ModuleNotFoundError as e:
-    if e.name == "flask" or (e.name and e.name.startswith("flask.")):
+    if e.name and (e.name == "flask" or e.name.startswith("flask.")):
         _FLASK_AVAILABLE = False
     else:
         raise

--- a/tests/e2e/test_kill_switch_live.py
+++ b/tests/e2e/test_kill_switch_live.py
@@ -69,7 +69,6 @@ def redis_client():
             continue
 
     pytest.fail("Could not connect to Redis (tried cdb_redis:6379 and localhost:6379)")
-    assert client is not None
 
 
 @pytest.fixture(autouse=True)

--- a/tests/e2e/test_paper_trading_p0.py
+++ b/tests/e2e/test_paper_trading_p0.py
@@ -63,52 +63,25 @@ def redis_client():
     if not password:
         pytest.fail("Password file is empty. Check Docker volume mount.")
 
-    # Try internal docker network first
-    try:
-        client = redis.Redis(
-            host="cdb_redis",
-            port=6379,
-            password=password,
-            decode_responses=True,
-            socket_timeout=5,
-        )
-        client.ping()
-        yield client
-        return
-    except (redis.ConnectionError, redis.TimeoutError):
-        pass
+    client = None
+    for host in ("cdb_redis", "localhost"):
+        try:
+            client = redis.Redis(
+                host=host,
+                port=6379,
+                password=password,
+                decode_responses=True,
+                socket_timeout=5,
+            )
+            client.ping()
+            yield client
+            return
+        except (redis.ConnectionError, redis.TimeoutError):
+            continue
 
-    # Fallback to localhost (if port mapped)
-    try:
-        client = redis.Redis(
-            host="localhost",
-            port=6379,
-            password=password,
-            decode_responses=True,
-            socket_timeout=5,
-        )
-        client.ping()
-        yield client
-        return
-    except (redis.ConnectionError, redis.TimeoutError):
-        pass
-
-    # Fallback to localhost
-    try:
-        client = redis.Redis(
-            host="localhost",
-            port=6379,
-            password=password,
-            decode_responses=True,
-            socket_timeout=5,
-        )
-        client.ping()
-        yield client
-        return
-    except (redis.ConnectionError, redis.TimeoutError):
-        pytest.fail(
-            "Could not connect to Redis (tried cdb_redis:6379 and localhost:6379)"
-        )
+    pytest.fail(
+        "Could not connect to Redis (tried cdb_redis:6379 and localhost:6379)"
+    )
 
 
 @pytest.fixture

--- a/tests/integration/verlosung/test_redis_postgres_integration.py
+++ b/tests/integration/verlosung/test_redis_postgres_integration.py
@@ -55,7 +55,8 @@ def postgres_conn():
     except psycopg2.OperationalError as e:
         pytest.skip(f"PostgreSQL nicht erreichbar: {e}. Starte: docker compose up -d")
 
-    assert conn is not None
+    if conn is None:
+        pytest.fail("PostgreSQL connection was not initialized")
     yield conn
     conn.close()
 

--- a/tests/unit/verlosung/test_event_flow_pipeline.py
+++ b/tests/unit/verlosung/test_event_flow_pipeline.py
@@ -55,7 +55,8 @@ def postgres_conn():
     except psycopg2.OperationalError as e:
         pytest.skip(f"PostgreSQL nicht erreichbar: {e}")
 
-    assert conn is not None
+    if conn is None:
+        pytest.fail("PostgreSQL connection was not initialized")
     yield conn
     conn.close()
 

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -602,6 +602,14 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
         "write (MCP live)",
     })
     if not isinstance(operation_mode, str) or operation_mode not in VALID_OPERATION_MODES:
+        valid_operation_modes = ", ".join(sorted(VALID_OPERATION_MODES))
+        invalid_mode_stop = (
+            f"S1: invalid operation_mode — must be one of: {valid_operation_modes}"
+        )
+        invalid_mode_context = (
+            f"invalid operation_mode: {operation_mode!r} — expected one of: "
+            f"{valid_operation_modes}"
+        )
         return {
             "tool": "context.readiness",
             "status": "ok",
@@ -617,16 +625,8 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
                     "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
                 ],
                 "human_go_required": False,
-                "stop_conditions": [
-                    "S1: invalid operation_mode — must be one of: "
-                    + ", ".join(sorted(VALID_OPERATION_MODES)),
-                ],
-                "missing_context": [
-                    "invalid operation_mode: "
-                    + repr(operation_mode)
-                    + " — expected one of: "
-                    + ", ".join(sorted(VALID_OPERATION_MODES)),
-                ],
+                "stop_conditions": [invalid_mode_stop],
+                "missing_context": [invalid_mode_context],
                 "missing_evidence": [],
                 "scope_drift_findings": [],
                 "uncertainties": [],
@@ -816,7 +816,6 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
     No Live/Echtgeld Go. LR remains NO-GO.
     """
     import hashlib
-    import json
 
     _MISSING = object()
 

--- a/tools/test_pack/tools/mock_exchange/mock_exchange.py
+++ b/tools/test_pack/tools/mock_exchange/mock_exchange.py
@@ -64,10 +64,13 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:  # noqa: N802
         if self.path == "/health":
-            return _json(self, 200, {"ok": True, "uptime_s": round(time.time() - STATE["started_ts"], 3)})
+            _json(self, 200, {"ok": True, "uptime_s": round(time.time() - STATE["started_ts"], 3)})
+            return
         if self.path == "/state":
-            return _json(self, 200, {"orders": len(STATE["orders"]), "fills": len(STATE["fills"])})
-        return _json(self, 404, {"ok": False, "error": "not_found"})
+            _json(self, 200, {"orders": len(STATE["orders"]), "fills": len(STATE["fills"])})
+            return
+        _json(self, 404, {"ok": False, "error": "not_found"})
+        return
 
     def do_POST(self) -> None:  # noqa: N802
         length = int(self.headers.get("Content-Length", "0") or "0")
@@ -75,7 +78,8 @@ class Handler(BaseHTTPRequestHandler):
         try:
             body = json.loads(raw.decode("utf-8") or "{}")
         except Exception:
-            return _json(self, 400, {"ok": False, "error": "invalid_json"})
+            _json(self, 400, {"ok": False, "error": "invalid_json"})
+            return
 
         if self.path == "/order":
             # expected: {symbol, side, qty, price?}
@@ -88,7 +92,8 @@ class Handler(BaseHTTPRequestHandler):
                 if side not in {"BUY", "SELL"} or qty <= 0:
                     raise ValueError("bad_order")
             except Exception:
-                return _json(self, 400, {"ok": False, "error": "bad_order_payload"})
+                _json(self, 400, {"ok": False, "error": "bad_order_payload"})
+                return
 
             oid = _generate_uuid()
             order = Order(order_id=oid, symbol=symbol, side=side, qty=qty, price=price, status="NEW", ts=time.time())
@@ -99,24 +104,30 @@ class Handler(BaseHTTPRequestHandler):
                 STATE["orders"][oid]["status"] = "FILLED"
                 STATE["fills"].append({"order_id": oid, "qty": qty, "price": price, "ts": time.time()})
 
-            return _json(self, 200, {"ok": True, "order": STATE["orders"][oid]})
+            _json(self, 200, {"ok": True, "order": STATE["orders"][oid]})
+            return
 
         if self.path == "/cancel":
             try:
                 oid = str(body["order_id"])
             except Exception:
-                return _json(self, 400, {"ok": False, "error": "bad_cancel_payload"})
+                _json(self, 400, {"ok": False, "error": "bad_cancel_payload"})
+                return
 
             order = STATE["orders"].get(oid)
             if not order:
-                return _json(self, 404, {"ok": False, "error": "unknown_order"})
+                _json(self, 404, {"ok": False, "error": "unknown_order"})
+                return
             if order["status"] in {"FILLED", "CANCELED"}:
-                return _json(self, 200, {"ok": True, "order": order})
+                _json(self, 200, {"ok": True, "order": order})
+                return
 
             order["status"] = "CANCELED"
-            return _json(self, 200, {"ok": True, "order": order})
+            _json(self, 200, {"ok": True, "order": order})
+            return
 
-        return _json(self, 404, {"ok": False, "error": "not_found"})
+        _json(self, 404, {"ok": False, "error": "not_found"})
+        return
 
 def main() -> int:
     import argparse


### PR DESCRIPTION
Refs #2289
Refs #2358
Refs #2359
Refs #2360
Refs #2362
Refs #2363
Refs #2364
Refs #2365

## Summary
- remove uninitialized local / dead assertion patterns from the Redis and Postgres test fixtures used in the Wave A slice
- stop treating the mock exchange JSON helper as a value-returning procedure
- remove the repeated `json` import and finalize readiness messages before list construction in the MCP context bridge
- replace NaN/Inf self-comparison checks with explicit math-based float sanitization and keep Flask import-guard semantics intact
- reduce local rebindings in the LR041/LR042 drill runners where the CodeQL multiple-definition issue was locally justifiable

## Validation
- `ruff check tests/e2e/test_kill_switch_live.py tests/e2e/test_paper_trading_p0.py tests/integration/verlosung/test_redis_postgres_integration.py tests/unit/verlosung/test_event_flow_pipeline.py`
- `pytest -q tests/e2e/test_kill_switch_live.py tests/e2e/test_paper_trading_p0.py tests/integration/verlosung/test_redis_postgres_integration.py tests/unit/verlosung/test_event_flow_pipeline.py -k 'not test_all_services_are_healthy_for_event_flow'`
- `ruff check tools/test_pack/tools/mock_exchange/mock_exchange.py tools/mcp/context_bridge.py services/risk/service.py core/replay/canonical_json.py core/utils/uuid_gen.py scripts/drills/lr041_redis_postgres_failure_runner.py scripts/drills/lr042_network_latency_packet_loss_runner.py`
- `pytest -q tests/unit/tools/mcp/test_context_bridge.py tests/unit/tools/mcp/test_mcp_briefing_tool.py tests/unit/replay/test_canonical_json.py tests/unit/risk/test_flask_import_guard.py tests/replay/test_deterministic_replay.py`
- `python -m compileall tests/e2e/test_kill_switch_live.py tests/e2e/test_paper_trading_p0.py tests/integration/verlosung/test_redis_postgres_integration.py tests/unit/verlosung/test_event_flow_pipeline.py tools/test_pack/tools/mock_exchange/mock_exchange.py tools/mcp/context_bridge.py services/risk/service.py core/replay/canonical_json.py core/utils/uuid_gen.py scripts/drills/lr041_redis_postgres_failure_runner.py scripts/drills/lr042_network_latency_packet_loss_runner.py`
- `git diff --check`

## Notes
- No alert dismissals were used.
- No runtime, trading, LR, or Echtgeld behavior was changed or inferred.
- Live Code Scanning alert details were not readable in this session because `gh api /code-scanning/alerts` returned `403 Resource not accessible by integration`.
- Ambiguous `#2358` locations were handled fail-closed; `services/ws/mexc_v3_spike.py` and `tests/unit/validation/test_replay_reporter.py` were intentionally left untouched.
- The broader fixture pytest invocation hit an environment blocker outside this slice: `tests/unit/verlosung/test_event_flow_pipeline.py::test_all_services_are_healthy_for_event_flow` requires a healthy `cdb_ws` service.
