### PR TITLE
fix(security): resolve CodeQL py/empty-except alerts (#2355)

### DIFF
--- a/docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py
+++ b/docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py
@@ -16,6 +16,7 @@ Exit Codes:
 
 import argparse
 import json
+import logging
 import subprocess
 import sys
 import time
@@ -215,7 +216,7 @@ class PRCheckInspector:
             print("Current auth status:", file=sys.stderr)
             print(result.stderr, file=sys.stderr)
         except Exception:
-            pass
+            logging.getLogger(__name__).debug("Could not get auth status (ignored)", exc_info=True)
 
         print(file=sys.stderr)
         print("Remediation:", file=sys.stderr)

--- a/infrastructure/scripts/generate_evidence_index.py
+++ b/infrastructure/scripts/generate_evidence_index.py
@@ -16,6 +16,7 @@ shadow-soak profile. Canonical runtime-mode remains execution_status.mode.
 """
 
 import json
+import logging
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -221,7 +222,7 @@ def generate_index(evidence_dir: Path) -> dict:
             active = prom_targets.get("data", {}).get("activeTargets", [])
             prometheus_targets_up = sum(1 for t in active if t.get("health") == "up")
         except (AttributeError, TypeError):
-            pass
+            logging.getLogger(__name__).debug("Unexpected Prometheus targets structure (ignored)", exc_info=True)
 
     # --- Fetch failures ---
     fetch_failures = scan_fetch_failures(evidence_dir)

--- a/infrastructure/scripts/generate_shadow_digest.py
+++ b/infrastructure/scripts/generate_shadow_digest.py
@@ -13,6 +13,7 @@ Options:
 
 import argparse
 import json
+import logging
 import subprocess
 import sys
 from datetime import datetime, timezone, timedelta
@@ -46,7 +47,7 @@ def prometheus_query(query: str) -> Optional[float]:
         if data["status"] == "success" and data["data"]["result"]:
             return float(data["data"]["result"][0]["value"][1])
     except (json.JSONDecodeError, KeyError, IndexError, ValueError):
-        pass
+        logging.getLogger(__name__).debug("Prometheus query result parse failed, returning None", exc_info=True)
     return None
 
 
@@ -91,7 +92,7 @@ def get_active_alerts() -> List[Dict]:
         if data["status"] == "success":
             return data["data"]["alerts"]
     except (json.JSONDecodeError, KeyError):
-        pass
+        logging.getLogger(__name__).debug("Prometheus alerts parse failed, returning empty list", exc_info=True)
     return []
 
 

--- a/infrastructure/scripts/shadow_metrics_compare.py
+++ b/infrastructure/scripts/shadow_metrics_compare.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -230,7 +231,7 @@ def _error_report(evidence_dir: Path, message: str) -> None:
     try:
         _write_artefacts(evidence_dir, report, md)
     except OSError:
-        pass  # best-effort; do not mask the original error
+        logging.getLogger(__name__).debug("Failed to write error artefacts (best-effort, ignored)", exc_info=True)
 
 
 def main() -> None:

--- a/infrastructure/scripts/smart_startup.py
+++ b/infrastructure/scripts/smart_startup.py
@@ -14,6 +14,7 @@ COPILOT SMART STARTUP ORCHESTRATOR — LEGACY / NICHT KANONISCH
     Operator-Ablauf.
 """
 
+import logging
 import subprocess
 import time
 import sys
@@ -53,7 +54,7 @@ def wait_for_service(name, url, max_attempts=12, delay=10):
                 print(f"✅ {name} is healthy!")
                 return True
         except requests.RequestException:
-            pass
+            logging.getLogger(__name__).debug("Service not ready, retrying", exc_info=True)
 
         wait_time = min(delay * (1.5**attempt), 60)  # Exponential backoff, max 60s
         print(f"   Attempt {attempt + 1}/{max_attempts}, waiting {wait_time:.1f}s...")

--- a/scripts/drills/lr041_redis_postgres_failure_runner.py
+++ b/scripts/drills/lr041_redis_postgres_failure_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import logging
 import subprocess
 import sys
 import time
@@ -258,13 +259,13 @@ def _collect_snapshot() -> dict[str, Any]:
             _http_get_text("http://localhost:8003/metrics")
         )
     except (urllib.error.URLError, TimeoutError):
-        pass
+        logging.getLogger(__name__).debug("Execution service metrics not reachable (ignored)")
     try:
         risk_metrics = _parse_prometheus_text(
             _http_get_text("http://localhost:8002/metrics")
         )
     except (urllib.error.URLError, TimeoutError):
-        pass
+        logging.getLogger(__name__).debug("Risk service metrics not reachable (ignored)")
 
     return {
         "captured_at_utc": _utc_now(),

--- a/scripts/replay/lr021_export_redis.py
+++ b/scripts/replay/lr021_export_redis.py
@@ -94,7 +94,7 @@ def parse_stream_entry(entry_id: str, fields: Dict[str, str]) -> Optional[dict]:
                 if isinstance(obj, dict) and "schema_version" in obj:
                     return obj
             except (json.JSONDecodeError, TypeError):
-                pass
+                logger.debug("Redis value is not valid JSON, skipping", exc_info=True)
 
     # Strategy (c): flat fields
     if "schema_version" in fields and "event_type" in fields:

--- a/scripts/smart_startup.py
+++ b/scripts/smart_startup.py
@@ -14,6 +14,7 @@ COPILOT SMART STARTUP ORCHESTRATOR — LEGACY / NICHT KANONISCH
     Operator-Ablauf.
 """
 
+import logging
 import subprocess
 import time
 import sys
@@ -53,7 +54,7 @@ def wait_for_service(name, url, max_attempts=12, delay=10):
                 print(f"✅ {name} is healthy!")
                 return True
         except requests.RequestException:
-            pass
+            logging.getLogger(__name__).debug("Service not ready, retrying", exc_info=True)
 
         wait_time = min(delay * (1.5**attempt), 60)  # Exponential backoff, max 60s
         print(f"   Attempt {attempt + 1}/{max_attempts}, waiting {wait_time:.1f}s...")

--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -720,7 +720,7 @@ def process_order(order_data: object):
                     policy_snapshot=getattr(order, "policy_snapshot", None),
                 )
             except Exception:
-                pass  # Guardrail: never break execution path
+                logger.debug("Contract emission skipped (execution path guardrail)", exc_info=True)
 
         # Update stats (Thread-safe)
         schema_status = ExecutionResult._schema_status(result.status)

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -848,7 +848,7 @@ class RiskManager:
             try:
                 configure_envelope_emission(False, None)
             except NameError:
-                pass
+                logger.debug("configure_envelope_emission not available during cleanup")
             self._envelope_redis_client = None
             self._envelope_publisher = None
 
@@ -971,7 +971,7 @@ class RiskManager:
                 try:
                     conn.close()
                 except Exception:  # noqa: BLE001
-                    pass
+                    logger.debug("conn.close() raised during retry cleanup (ignored)", exc_info=True)
                 self._pg_conn = None
 
         return False
@@ -1617,7 +1617,7 @@ class RiskManager:
                     effective_at_ms=deterministic_ts_ms,
                 )
             except Exception:
-                pass  # Guardrail: never break trading path
+                logger.debug("build_policy_snapshot raised (guardrail active)", exc_info=True)
 
         if evidence.get("decision_id"):
             if _envelope_toggle_enabled():

--- a/services/validation/replay_reporter.py
+++ b/services/validation/replay_reporter.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import pathlib
 from typing import Any, Dict, List, Optional
 
@@ -307,7 +308,7 @@ class ReplayReporter:
                 try:
                     f.unlink(missing_ok=True)
                 except OSError:
-                    pass
+                    logging.getLogger(__name__).debug("Cleanup unlink failed (ignored)", exc_info=True)
             raise ReplayReporterError(
                 f"Failed to write artifact bundle to {bundle_dir}: {exc}"
             ) from exc

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import re
 import subprocess
@@ -505,7 +506,7 @@ def _get_code_commit() -> str:
             if _CODE_COMMIT_RE.match(commit):
                 return commit
     except Exception:
-        pass
+        logging.getLogger(__name__).debug("Could not read code commit from git, using fallback", exc_info=True)
     return _FALLBACK_CODE_COMMIT
 
 
@@ -611,7 +612,7 @@ def _load_dataset_result(
             try:
                 conn.close()
             except Exception:
-                pass
+                logging.getLogger(__name__).debug("conn.close() raised in finally block (ignored)", exc_info=True)
 
     raise ReplayRunnerError(f"unsupported dataset_source: {config.dataset_source!r}")
 

--- a/services/ws/mexc_v3_client.py
+++ b/services/ws/mexc_v3_client.py
@@ -262,7 +262,7 @@ class MexcV3Client:
                 try:
                     await ping_task
                 except asyncio.CancelledError:
-                    pass
+                    logger.debug("Ping task cancellation acknowledged")
 
             except Exception as e:
                 logger.error(f"[ws] connection error: {e}")

--- a/tests/e2e/test_kill_switch_live.py
+++ b/tests/e2e/test_kill_switch_live.py
@@ -19,6 +19,7 @@ Teardown:
 """
 
 import json
+import logging
 import os
 import time
 
@@ -89,7 +90,7 @@ def deactivate_kill_switch_after():
             timeout=5,
         )
     except Exception:
-        pass  # teardown must not mask real test failures
+        logging.debug("Kill-switch teardown error (ignored; must not mask test failures)", exc_info=True)
 
 
 @pytest.fixture

--- a/tests/e2e/test_paper_trading_p0.py
+++ b/tests/e2e/test_paper_trading_p0.py
@@ -25,6 +25,7 @@ E2E_RUN=1 pytest tests/e2e/test_paper_trading_p0.py -v
 """
 
 import json
+import logging
 import os
 import time
 from datetime import datetime
@@ -555,7 +556,7 @@ def test_tc_p0_001_happy_path_market_to_trade(redis_client, unique_order_id):
             _recv_oid = _rp.get("order_id", "")
             _recv_st = _rp.get("status", "")
         except Exception:
-            pass
+            logging.debug("Optional message JSON parse failed (ignored)", exc_info=True)
 
     try:
         # Assertions

--- a/tests/unit/verlosung/test_chaos_resilience.py
+++ b/tests/unit/verlosung/test_chaos_resilience.py
@@ -17,6 +17,7 @@ Ausführung:
 import pytest
 import subprocess
 import time
+import logging
 import redis
 import psycopg2
 import json
@@ -50,7 +51,7 @@ def is_service_healthy(service_name):
                 return "healthy" in status.lower() or service.get("Health") == "healthy"
 
         except json.JSONDecodeError:
-            pass
+            logging.getLogger(__name__).debug("JSON decode error for docker service line (ignored)")
 
     return False
 

--- a/tests/unit/verlosung/test_docker_lifecycle.py
+++ b/tests/unit/verlosung/test_docker_lifecycle.py
@@ -15,6 +15,7 @@ Ausführung:
 import pytest
 import subprocess
 import time
+import logging
 import json
 
 
@@ -33,7 +34,7 @@ def parse_docker_json(stdout):
             try:
                 services.append(json.loads(line))
             except json.JSONDecodeError:
-                pass
+                logging.getLogger(__name__).debug("JSON decode error for docker ps line (ignored)")
     return services
 
 

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -12,6 +12,8 @@ All tools are read-only, fail-closed, and carry explicit no-echtgeld-go semantic
 
 from __future__ import annotations
 
+import logging
+
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping
 
@@ -162,7 +164,7 @@ def handle_cdb_context_evidence_resolve(request: Mapping[str, Any]) -> dict[str,
         try:
             freshness_days = int(freshness_raw)
         except (TypeError, ValueError):
-            pass
+            logging.getLogger(__name__).debug("Invalid freshness_days value, ignoring", exc_info=True)
 
     min_confidence_raw = params.get("min_confidence")
     min_confidence: float | None = None
@@ -170,7 +172,7 @@ def handle_cdb_context_evidence_resolve(request: Mapping[str, Any]) -> dict[str,
         try:
             min_confidence = float(min_confidence_raw)
         except (TypeError, ValueError):
-            pass
+            logging.getLogger(__name__).debug("Invalid min_confidence value, ignoring", exc_info=True)
 
     try:
         ev_request = EvidenceLookupRequest(
@@ -294,7 +296,7 @@ def handle_cdb_context_memory_get(request: Mapping[str, Any]) -> dict[str, Any]:
         try:
             freshness_days = int(freshness_raw)
         except (TypeError, ValueError):
-            pass
+            logging.getLogger(__name__).debug("Invalid freshness_days param, ignoring", exc_info=True)
 
     try:
         mem_request = MemoryReadRequest(

--- a/tools/replay/replay.py
+++ b/tools/replay/replay.py
@@ -24,6 +24,7 @@ Supports: #258 (Deterministic Replay)
 import argparse
 import hashlib
 import json
+import logging
 import os
 import sys
 from typing import Optional
@@ -162,7 +163,7 @@ class ReplayRunner:
             print(f"✅ Connected to Redis (cdb_redis:6379)")
             return
         except (redis.ConnectionError, redis.TimeoutError):
-            pass
+            logging.getLogger(__name__).debug("Redis primary host not reachable, trying fallback host")
 
         # Fallback to configured host
         try:

--- a/tools/test_pack/tools/mock_exchange/mock_exchange.py
+++ b/tools/test_pack/tools/mock_exchange/mock_exchange.py
@@ -13,6 +13,7 @@ when you want realistic order-lifecycle tests without the real exchange.
 from __future__ import annotations
 
 import json
+import logging
 import sys
 import time
 from dataclasses import dataclass, asdict
@@ -141,7 +142,7 @@ def main() -> int:
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:
-        pass
+        logging.getLogger(__name__).debug("MockExchange shutdown via KeyboardInterrupt")
     return 0
 
 if __name__ == "__main__":

--- a/tools/validate_contract.py
+++ b/tools/validate_contract.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import sys
 from pathlib import Path
 from typing import Any, Dict
@@ -53,12 +54,12 @@ def coerce_payload_types(payload: Dict[str, Any], schema: Dict[str, Any]) -> Dic
             try:
                 payload[key] = int(value)
             except ValueError:
-                pass
+                logging.getLogger(__name__).debug("Could not coerce to int, keeping original", exc_info=True)
         elif "number" in expected_types:
             try:
                 payload[key] = float(value)
             except ValueError:
-                pass
+                logging.getLogger(__name__).debug("Could not coerce to float, keeping original", exc_info=True)
     return payload
 
 


### PR DESCRIPTION
## Summary

Fixes #2355 — CodeQL `py/empty-except` alerts.

Replaces all 29 empty `except` blocks (containing only `pass`) with explicit `logging.debug()` calls across 21 files. Each handler now emits a debug-level log message instead of silently swallowing exceptions.

## Changes

- **21 files changed**, 47 insertions, 29 deletions
- All empty `except ... pass` blocks replaced with `logger.debug(...)` or `logging.getLogger(__name__).debug(...)`
- Files needing `import logging` added: 14 files received the standard-library import
- **No behavioral changes** — all handlers preserve the same control flow; only observability is added
- Trading-path guardrails in `services/risk/service.py` and `services/execution/service.py` kept intact; now emit debug-level diagnostic on trigger

## Files affected (by scope)

| Scope | Files | Instances |
|-------|-------|-----------|
| services | risk, execution, validation (x2), ws | 8 |
| infrastructure/scripts | generate_shadow_digest, shadow_metrics_compare, generate_evidence_index, smart_startup | 6 |
| scripts | drills/lr041, replay/lr021, smart_startup | 4 |
| tools | mcp/context_evidence_memory_tools (x3), replay, mock_exchange, validate_contract (x2), inspect_pr_checks | 10 |
| tests | e2e/test_kill_switch_live, e2e/test_paper_trading_p0, unit/verlosung x2 | 4 |

**Total: 29 instances, 21 files**

## Validation

- `ruff check` — clean on all 21 changed files
- `python -m compileall` — clean on all 21 changed files
- `pytest -m unit` — **2649 passed, 12 skipped** (no regressions)

## Security note

Empty `except` blocks are flagged by CodeQL `py/empty-except` because they silently absorb exceptions, making debugging and monitoring difficult. This fix adds full observability without changing any exception-handling semantics.

Closes #2355