### PR TITLE
fix(security): resolve CodeQL py/mixed-returns alerts (#2361)

### DIFF
--- a/scripts/lr004_completion_guard.py
+++ b/scripts/lr004_completion_guard.py
@@ -499,13 +499,14 @@ Examples:
     try:
         if args.check:
             return guard.validate_all(task_id_filter=args.task_id)
-        elif args.report:
+        if args.report:
             return guard.generate_report()
     except Exception as e:
         print(f"[LR-004] FATAL ERROR: {e}", file=sys.stderr)
         import traceback
         traceback.print_exc()
         return 2
+    return 2
 
 
 if __name__ == "__main__":

--- a/scripts/lr020_tier2_evidence_capture.py
+++ b/scripts/lr020_tier2_evidence_capture.py
@@ -91,7 +91,7 @@ def _resolve_password(args: argparse.Namespace) -> str:
         if pw:
             return pw
 
-    sys.exit(
+    raise SystemExit(
         "ERROR: Redis password not found.\n"
         "Set REDIS_PASSWORD env var, use --redis-password-file, or place the\n"
         f"password in: {_DEFAULT_SECRETS_FILE}"

--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -290,6 +290,7 @@ def _init_with_retry(
             if attempt == retries:
                 raise
             time.sleep(delay)
+    raise RuntimeError(f"{name}: exhausted all {retries} retries without success")
 
 
 def init_services():


### PR DESCRIPTION
## Summary

Fixes 3 of 4 CodeQL `py/mixed-returns` alerts (issue #2361). The 4th file (`tests/fixtures/db_fixtures.py`) requires no change — `pytest.skip()` is typed as `NoReturn` in typeshed and both ruff and CodeQL should recognize it as such.

## Changes

### `services/execution/service.py` — `_init_with_retry()`
- Added `raise RuntimeError(...)` after the `for` loop
- Handles `retries=0` edge case (empty range, loop body never runs)
- Makes function termination explicit for static analysis (ruff RET503)

### `scripts/lr004_completion_guard.py` — `main()`
- `elif args.report:` → `if args.report:` (ruff RET505 fix)
- Added `return 2` after the `try/except` block to cover the implicit fall-through path

### `scripts/lr020_tier2_evidence_capture.py` — `_resolve_password()`
- Replaced `sys.exit(...)` with `raise SystemExit(...)`
- Behavior is identical (`sys.exit` raises `SystemExit` internally)
- Explicit `raise` is unambiguously noreturn for any static analyzer

## Validation

- `ruff check` — all checks passed
- `python -m compileall` — all files compile cleanly
- `pytest -q -m unit --ignore=tests/smoke` — 2649 passed, 12 skipped

Closes #2361