### PR TITLE
fix(security): resolve CodeQL py/ineffectual-statement alerts (#2356)

### DIFF
--- a/core/replay/clock_context.py
+++ b/core/replay/clock_context.py
@@ -45,11 +45,11 @@ class ClockContextProtocol(Protocol):
 
     def now_ts_ms(self) -> int:
         """Return current time as milliseconds since Unix epoch."""
-        ...
+        pass
 
     def now_iso(self) -> str:
         """Return current time as UTC ISO-8601 string with millisecond precision."""
-        ...
+        pass
 
 
 @dataclass(frozen=True, slots=True)

--- a/core/replay/dataset_provider.py
+++ b/core/replay/dataset_provider.py
@@ -63,7 +63,7 @@ class DatasetResult:
 class DatasetProvider(Protocol):
     """Protocol for all ARVP dataset providers."""
 
-    def load(self, spec: DatasetSpec) -> DatasetResult: ...
+    def load(self, spec: DatasetSpec) -> DatasetResult: pass
 
 
 def _validate_candle_series(candles: list[dict], source_label: str) -> None:

--- a/core/replay/publisher.py
+++ b/core/replay/publisher.py
@@ -4,9 +4,9 @@ from typing import Protocol
 
 
 class _RedisPublisher(Protocol):
-    def publish(self, channel: str, message: str) -> None: ...
+    def publish(self, channel: str, message: str) -> None: pass
 
-    def xadd(self, stream: str, values: dict[str, str], maxlen: int) -> None: ...
+    def xadd(self, stream: str, values: dict[str, str], maxlen: int) -> None: pass
 
 
 class EnvelopePublisher:

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -1002,15 +1002,15 @@ class ContextApplyAdapter(Protocol):
 
     def apply_create(
         self, table: str, record_id: str, payload: dict[str, Any]
-    ) -> None: ...
+    ) -> None: pass
 
     def apply_update(
         self, table: str, record_id: str, payload: dict[str, Any]
-    ) -> None: ...
+    ) -> None: pass
 
     def apply_tombstone(
         self, table: str, record_id: str, payload: dict[str, Any]
-    ) -> None: ...
+    ) -> None: pass
 
 
 class InMemoryContextApplyAdapter:


### PR DESCRIPTION
## Summary

Fixes all 8 CodeQL `py/ineffectual-statement` alerts (issue #2356).

## Root Cause

`py/ineffectual-statement` flags `Expr(Constant(Ellipsis))` AST nodes — standalone `...` used as the body of Protocol method stubs. While `...` is a common Python idiom for abstract/protocol bodies, it is an expression statement with no side effects, which CodeQL correctly identifies as ineffectual.

## Fix

Replace `...` with `pass` in all Protocol method bodies. `pass` is a `Pass` AST node (a genuine statement), not an `Expr` node — it eliminates the alert with **zero semantic change**.

## Files Changed

| File | Protocol Class | Methods Fixed |
|---|---|---|
| `core/replay/clock_context.py` | `ClockContextProtocol` | `now_ts_ms()`, `now_iso()` |
| `core/replay/dataset_provider.py` | `DatasetProvider` | `load()` |
| `core/replay/publisher.py` | `_RedisPublisher` | `publish()`, `xadd()` |
| `tools/surrealdb/context_importer.py` | `ContextApplyAdapter` | `apply_create()`, `apply_update()`, `apply_tombstone()` |

## Validation

- AST re-scan: 0 remaining ineffectual statements in all 4 files
- `ruff check` — all checks passed
- `python -m compileall` — all files compile cleanly
- `pytest -q -m unit --ignore=tests/smoke` — 2649 passed, 12 skipped

Closes #2356