### PR TITLE
fix(security): resolve CodeQL unused hygiene alerts (#2353 #2354)

### DIFF
--- a/tests/performance/test_baseline_measurements.py
+++ b/tests/performance/test_baseline_measurements.py
@@ -133,7 +133,6 @@ class TestLatencyBaselines:
         require_perf_run()
 
         def approve_signal():
-            signal = {"type": "BUY", "symbol": "BTCUSDT", "quantity": 0.01}
             # Simulate risk checks
             checks = {
                 "position_limit": True,
@@ -182,9 +181,6 @@ class TestLatencyBaselines:
         def full_pipeline():
             # Step 1: Market data
             market_data = {"symbol": "BTCUSDT", "price": 50000.0}
-
-            # Step 2: Signal generation
-            signal = {"type": "BUY", "symbol": market_data["symbol"]}
 
             # Step 3: Risk approval
             approved = True
@@ -266,7 +262,6 @@ class TestThroughputBaselines:
         require_perf_run()
 
         def process_order():
-            order = {"symbol": "BTCUSDT", "side": "BUY", "qty": 0.01}
             result = {"order_id": "test", "status": "FILLED"}
             return result
 

--- a/tests/unit/indicators/test_indicators.py
+++ b/tests/unit/indicators/test_indicators.py
@@ -79,8 +79,6 @@ class TestEMA:
         for price in [10, 20, 30]:
             ema.update(price)
 
-        prev_ema = ema.value  # 20.0
-
         ema.update(40)
         # EMA = 40 * 0.5 + 20 * 0.5 = 30
         assert ema.value == 30.0
@@ -199,7 +197,7 @@ class TestMACD:
             macd.update(price)
 
         for price in rising:
-            result = macd.update(price)
+            macd.update(price)
             if macd.is_bullish_crossover:
                 break
         else:

--- a/tests/unit/replay/test_dataset_provider.py
+++ b/tests/unit/replay/test_dataset_provider.py
@@ -556,7 +556,6 @@ def test_db_backed_missing_required_field_raises() -> None:
     # Drop 'close' (index 4) from row 5 by returning only 6 columns
     bad_row = rows[5][:4] + rows[5][5:]  # skip index 4 (close)
     rows = rows[:5] + [bad_row] + rows[6:]
-    conn = _make_mock_conn(rows)
     spec = _make_db_spec()
     # The mapping in load() uses positional indices, so missing column causes IndexError
     # which is caught by the try/except around cursor.execute/fetchall —

--- a/tests/unit/replay/test_lr021_export_redis.py
+++ b/tests/unit/replay/test_lr021_export_redis.py
@@ -378,7 +378,7 @@ class TestExportEnvelopesWithHashes:
         entries = [_stream_entry_json_blob("1-0", env)]
         output = io.StringIO()
 
-        summary = export_envelopes(
+        export_envelopes(
             iter(entries), output,
             include_hashes=False, compute_chain=True,
         )

--- a/tests/unit/replay/test_walk_forward.py
+++ b/tests/unit/replay/test_walk_forward.py
@@ -543,7 +543,7 @@ class TestRunWalkForwardManifestArtifact:
 
     def test_manifest_written_with_failed_windows(self, tmp_path: Path) -> None:
         spec = _spec(windows=(_window("w1", 0, 1000),))
-        manifest = run_walk_forward(spec, run_fn=_failure_fn, output_dir=tmp_path)
+        run_walk_forward(spec, run_fn=_failure_fn, output_dir=tmp_path)
         manifest_path = tmp_path / spec.walk_forward_id / "walk_forward_manifest.json"
         data = json.loads(manifest_path.read_text(encoding="utf-8"))
         assert data["failed_count"] == 1

--- a/tests/unit/surrealdb/test_stale_context_cli.py
+++ b/tests/unit/surrealdb/test_stale_context_cli.py
@@ -47,7 +47,6 @@ from tools.surrealdb.stale_knowledge_scan import StaleKnowledgeScanResult
 # ── Fixed timestamps for determinism ─────────────────────────────────────────
 
 _AS_OF = "2026-05-06T12:00:00+00:00"
-_PAST = "2026-01-01T00:00:00+00:00"
 
 # ── Inline fixtures ───────────────────────────────────────────────────────────
 

--- a/tools/surrealdb/claim_resolver.py
+++ b/tools/surrealdb/claim_resolver.py
@@ -49,11 +49,6 @@ CLAIM_STATUSES = frozenset(
     }
 )
 
-# Statuses that indicate a claim needs human attention
-_ATTENTION_STATUSES = frozenset({"disputed", "stale", "invalidated"})
-# Statuses that indicate a claim is weak
-_WEAK_STATUSES = frozenset({"proposed", "weakly_supported"})
-
 
 class ClaimResolverError(ValueError):
     """Raised when claim resolution inputs are invalid or unsafe."""

--- a/tools/surrealdb/memory_read.py
+++ b/tools/surrealdb/memory_read.py
@@ -38,12 +38,6 @@ SUPPORTED_MODES = frozenset(
     }
 )
 
-# Memory trust levels (ascending)
-MEMORY_TRUST_LEVELS = ("stale", "superseded", "weak", "evidence_backed", "source_backed")
-
-# Modes that REQUIRE scope for safety
-_SCOPE_REQUIRED_MODES = frozenset({"by_scope"})
-
 
 class MemoryReadError(ValueError):
     """Raised when memory read inputs are invalid or unsafe."""


### PR DESCRIPTION
## Summary

Closes two CodeQL hygiene issues from the 2026-05-05 scan wave as a controlled
package. The third issue (#2352 unused-import, 132 alerts across 89 files)
exceeds the 50-file split threshold and is deferred to a follow-up slice.

## Root Cause

CodeQL scan on `refs/heads/main` (2026-05-05T11:44:08Z) produced:
- **#2354** `py/unused-local-variable`: 23 alerts, concentrated in test helpers
  and performance benchmarks
- **#2353** `py/unused-global-variable`: 25 alerts, concentrated in surrealdb
  tools and one test file; proto-generated files also flagged (out of scope)
- **#2352** `py/unused-import`: 132 alerts across 89 files (deferred)

## Changes

### #2354 — py/unused-local-variable

| File | Fix |
|---|---|
| `tests/performance/test_baseline_measurements.py` | Remove `signal` x2, `order` (unused in benchmark helpers) |
| `tests/unit/indicators/test_indicators.py` | Remove `prev_ema` assignment; drop `result = macd.update()` |
| `tests/unit/replay/test_dataset_provider.py` | Remove `conn = _make_mock_conn(rows)` (test uses conn2 path) |
| `tests/unit/replay/test_lr021_export_redis.py` | Drop `summary =` from `export_envelopes()` (side-effect only) |
| `tests/unit/replay/test_walk_forward.py` | Drop `manifest =` from `run_walk_forward()` (result read from filesystem) |

### #2353 — py/unused-global-variable

| File | Fix |
|---|---|
| `tests/unit/surrealdb/test_stale_context_cli.py` | Remove `_PAST` (only `_AS_OF` referenced in all fixtures) |
| `tools/surrealdb/claim_resolver.py` | Remove `_ATTENTION_STATUSES` and `_WEAK_STATUSES` (grep: 0 reads anywhere in file or repo) |
| `tools/surrealdb/memory_read.py` | Remove `MEMORY_TRUST_LEVELS` and `_SCOPE_REQUIRED_MODES` (grep: 0 reads anywhere in file or repo) |

Explicitly **NOT touched**:
- `services/execution/service.py`: globals (`executor`, `redis_client`, etc.) are read/written via explicit `global` statements in functions — not unused
- `services/ws/mexc_proto_gen/*.py`: generated files, excluded from manual fix

### #2352 — py/unused-import (DEFERRED)

`ruff --select F401` identifies 89 affected files (>50-file threshold per
scope rules). Will be handled as a separate follow-up PR to avoid scope creep.

## Scope

| Dimension | Status |
|---|---|
| Generated/proto files | Not touched |
| Runtime / Trading / LR scope | None |
| Alert Dismissal | None |
| SurrealDB scope | tools/surrealdb/ (real CodeQL hits, grep-verified before removal) |
| services/execution/service.py | Not touched (globals actively used via global statements) |

## Validation

- `ruff check` on all changed files: **All checks passed**
- `python -m compileall` on all changed files: **OK**
- Targeted unit tests (indicators, walk_forward, lr021, stale_context_cli): **118 passed**
- Full unit suite: **2649 passed, 0 failed** (`pytest -q -m unit`)

Refs #2352
Closes #2353
Closes #2354