### PR TITLE
fix(security): resolve CodeQL py/unused-import in scripts/ (Batch B) (#2352)

### DIFF
--- a/scripts/alert_to_issue.py
+++ b/scripts/alert_to_issue.py
@@ -28,7 +28,6 @@ import json
 import logging
 import subprocess
 import sys
-from datetime import timezone
 
 from core.utils.clock import utcnow
 

--- a/scripts/lr004_completion_guard.py
+++ b/scripts/lr004_completion_guard.py
@@ -15,7 +15,7 @@ import argparse
 import re
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set
 
 try:
     import yaml

--- a/scripts/validate_paper_market_data_provenance.py
+++ b/scripts/validate_paper_market_data_provenance.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from collections import Counter, defaultdict
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable


### PR DESCRIPTION
## Summary

Batch B of the CodeQL `py/unused-import` (#2352) hygiene cleanup — **scripts/ directory only**.

Removes 3 unused imports across 3 files.

## Changes

| File | Import removed | Fix |
|------|---------------|-----|
| `scripts/alert_to_issue.py` | `from datetime import timezone` | Removed — file uses `utcnow` from `core.utils.clock` exclusively |
| `scripts/validate_paper_market_data_provenance.py` | `defaultdict` from `Counter, defaultdict` | Reduced to `Counter` only — `defaultdict` never referenced |
| `scripts/lr004_completion_guard.py` | `Tuple` from typing import | Removed — `Dict`, `List`, `Optional`, `Set` remain; `Tuple` never referenced |

## Validation

- `ruff check scripts/ tools/ .github/scripts/`: **All checks passed**
- `pytest -q -m unit --ignore=tests/smoke`: **2649 passed, 0 failed**

## Scope

This is **Batch B** (scripts/ only). No changes to `tools/` or `.github/scripts/` (verified clean).

Remaining:
- Batch C: `core/`, `services/` imports

Does **not** close #2352.

Refs #2352