### PR TITLE
fix(security): resolve CodeQL py/unused-import in core/ and services/ (Batch C) (#2352)

### DIFF
--- a/core/config/trading_mode.py
+++ b/core/config/trading_mode.py
@@ -12,7 +12,6 @@ import os
 import sys
 import logging
 from enum import Enum
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/core/indicators/base.py
+++ b/core/indicators/base.py
@@ -5,7 +5,7 @@ Abstrakte Basis für alle technischen Indikatoren.
 """
 
 from abc import ABC, abstractmethod
-from typing import Optional, List
+from typing import Optional
 from collections import deque
 
 

--- a/core/indicators/trend.py
+++ b/core/indicators/trend.py
@@ -6,7 +6,6 @@ Trend Indicators (Issue #204)
 """
 
 from typing import Optional
-from collections import deque
 
 from core.indicators.base import Indicator
 

--- a/core/replay/arvp_regime_scorecards.py
+++ b/core/replay/arvp_regime_scorecards.py
@@ -22,7 +22,7 @@ import json
 import pathlib
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping
 
 from core.replay.canonical_json import canonical_hash, canonical_json_dumps
 

--- a/core/replay/determinism.py
+++ b/core/replay/determinism.py
@@ -26,10 +26,9 @@ relations:
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, List, Optional, Sequence
 
-from core.replay.canonical_json import canonical_hash, canonical_json_dumps
-from core.replay.envelopes import DecisionEnvelopeV1, OrderEnvelopeV1, FillEnvelopeV1
+from core.replay.canonical_json import canonical_hash
 from core.replay.replay_contracts import (
     ReplayIntegrity,
     ReplayReportInput,

--- a/core/replay/replay_contracts.py
+++ b/core/replay/replay_contracts.py
@@ -27,7 +27,7 @@ relations:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict, field
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Literal
 
 

--- a/core/replay/walk_forward.py
+++ b/core/replay/walk_forward.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 import pathlib
 from dataclasses import dataclass
 from datetime import timezone
-from typing import Any, Callable, Literal, Sequence
+from typing import Any, Callable, Literal
 
 from core.replay.canonical_json import canonical_hash, canonical_json_dumps
 from core.utils.clock import utcnow

--- a/core/utils/rate_limiter.py
+++ b/core/utils/rate_limiter.py
@@ -19,7 +19,6 @@ import time
 import logging
 from collections import deque
 from threading import Lock
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/services/allocation/service.py
+++ b/services/allocation/service.py
@@ -7,7 +7,6 @@ import json
 import logging
 import logging.config
 import sys
-import time
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from datetime import datetime

--- a/services/candles/models.py
+++ b/services/candles/models.py
@@ -3,7 +3,6 @@ Candle Aggregator - Models and logic
 """
 
 import time
-from collections import defaultdict
 from dataclasses import dataclass
 from typing import Optional
 

--- a/services/execution/database.py
+++ b/services/execution/database.py
@@ -5,7 +5,6 @@ Claire de Binare Trading Bot
 
 import json
 import logging
-import os
 import psycopg2
 from psycopg2.extras import RealDictCursor
 from typing import Optional

--- a/services/market/service.py
+++ b/services/market/service.py
@@ -22,7 +22,6 @@ Market State V1 (Issue #1201 Delta 1 — shadow mode):
 import json
 import logging
 import os
-import sys
 import threading
 import time
 

--- a/services/regime/service.py
+++ b/services/regime/service.py
@@ -9,7 +9,6 @@ import logging.config
 import sys
 import time
 from collections import defaultdict, deque
-from datetime import datetime
 from pathlib import Path
 from typing import Optional
 

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -70,7 +70,6 @@ from core.safety.kill_switch import (
     KillSwitch,
     KillSwitchReason,
 )
-from core.auth import validate_all_auth
 from core.domain.models import Signal
 
 try:

--- a/services/signal/models.py
+++ b/services/signal/models.py
@@ -5,7 +5,7 @@ Datenklassen für Market-Data (signal_engine specific)
 
 import time
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import Literal
 
 
 def normalize_ts_ms(ts: int | float | None) -> int:

--- a/services/validation/collectors.py
+++ b/services/validation/collectors.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Iterable
+from typing import Any
 
 from psycopg2.extras import RealDictCursor
 

--- a/services/validation/paper_reference_window_runner.py
+++ b/services/validation/paper_reference_window_runner.py
@@ -15,7 +15,6 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from pathlib import Path
 

--- a/services/validation/replay_reporter.py
+++ b/services/validation/replay_reporter.py
@@ -46,7 +46,6 @@ import jsonschema
 
 from core.replay.canonical_json import canonical_json_dumps
 from core.replay.determinism import (
-    compute_replay_report_hash,
     verify_replay_execution_result,
     verify_replay_integrity_result,
     ReplayDeterminismError,


### PR DESCRIPTION
## Summary

Batch C of the CodeQL `py/unused-import` remediation tracked in #2352.

Removes 22 unused imports across `core/` and `services/`.

## Changes

### `core/` (8 files, 10 imports removed)

| File | Removed |
|---|---|
| `core/config/trading_mode.py` | `Optional` |
| `core/indicators/base.py` | `List` |
| `core/indicators/trend.py` | `deque` |
| `core/replay/arvp_regime_scorecards.py` | `Sequence` |
| `core/replay/determinism.py` | `Dict`, `canonical_json_dumps`, `DecisionEnvelopeV1`, `OrderEnvelopeV1`, `FillEnvelopeV1` |
| `core/replay/replay_contracts.py` | `asdict` |
| `core/replay/walk_forward.py` | `Sequence` |
| `core/utils/rate_limiter.py` | `Optional` |

### `services/` (10 files, 12 imports removed)

| File | Removed |
|---|---|
| `services/allocation/service.py` | `time` |
| `services/candles/models.py` | `defaultdict` |
| `services/execution/database.py` | `os` |
| `services/market/service.py` | `sys` |
| `services/regime/service.py` | `datetime` |
| `services/risk/service.py` | `validate_all_auth` |
| `services/signal/models.py` | `Optional` |
| `services/validation/collectors.py` | `Iterable` |
| `services/validation/paper_reference_window_runner.py` | `json` |
| `services/validation/replay_reporter.py` | `compute_replay_report_hash` |

## Validation

- `ruff check core/ services/ --select F401`: 0 violations
- `ruff check .`: all checks passed
- `pytest -q -m unit --ignore=tests/smoke`: 2649 passed, 0 failures

## Batch Progress

| Batch | Scope | PR | Status |
|---|---|---|---|
| Batch A | `tests/` | #2417 | ✅ merged |
| Batch B | `scripts/` | #2418 | ✅ merged |
| Batch C | `core/`, `services/` | this PR | 🔄 open |

Closes #2352