### PR TITLE
feat(security): add alert readout delta workflow

### DIFF
--- a/.github/workflows/security-alert-readout.yml
+++ b/.github/workflows/security-alert-readout.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run security alert readout
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CDB_GH_ALERTS_TOKEN != '' && secrets.CDB_GH_ALERTS_TOKEN || github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -96,9 +96,27 @@ jobs:
           date_dir="${{ steps.resolve.outputs.date_dir }}"
           mkdir -p "$date_dir"
 
+          set +e
           python3 scripts/audit/github_security_quality_readout.py \
             --repo "${GITHUB_REPOSITORY}" \
             --out-dir "$date_dir"
+          READOUT_EXIT=$?
+          set -e
+
+          if [[ $READOUT_EXIT -eq 1 ]]; then
+            echo "::error::Readout script failed; no readable alert surfaces were available."
+            exit 1
+          fi
+
+          if [[ $READOUT_EXIT -eq 2 ]]; then
+            echo "READOUT_STATUS=partial" >> "$GITHUB_ENV"
+            echo "::warning::Security Alert Readout: PARTIAL readout written; unavailable surfaces will be compared fail-closed."
+          elif [[ $READOUT_EXIT -ne 0 ]]; then
+            echo "::error::Readout script failed with unexpected exit code $READOUT_EXIT."
+            exit 1
+          else
+            echo "READOUT_STATUS=ok" >> "$GITHUB_ENV"
+          fi
 
           echo "Readout written to $date_dir"
           ls -lh "$date_dir"

--- a/.github/workflows/security-alert-readout.yml
+++ b/.github/workflows/security-alert-readout.yml
@@ -167,10 +167,11 @@ jobs:
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
-          # Delta summary (if available)
-          delta_md="${delta_dir}/security_alert_delta.md"
-          if [[ -f "$delta_md" ]]; then
-            cat "$delta_md" >> "$GITHUB_STEP_SUMMARY"
+          # Delta artifact (JSON only by design)
+          delta_json="${delta_dir}/security_alert_delta.json"
+          if [[ -f "$delta_json" ]]; then
+            echo "> **Delta artifact:** JSON only by design. See \`artifacts/security-alert-readout/delta/security_alert_delta.json\` in the uploaded artifacts." \
+              >> "$GITHUB_STEP_SUMMARY"
           elif [[ -f "${delta_dir}/no_prev_readout.txt" ]]; then
             echo "> **Note:** No previous readout found — delta skipped (first run)." \
               >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/security-alert-readout.yml
+++ b/.github/workflows/security-alert-readout.yml
@@ -1,0 +1,217 @@
+name: Security Alert Readout
+
+# Generates a machine-readable GitHub security alert readout (code_scanning,
+# dependabot, secret_scanning) and computes a delta against the most recent
+# previous readout.  Runs Mon/Wed/Fri; always available for manual dispatch.
+#
+# Refs: #2289 (security alert monitoring epic)
+# Related scripts:
+#   scripts/audit/github_security_quality_readout.py  (read-only fetcher)
+#   scripts/audit/security_alert_delta.py             (delta comparator)
+
+on:
+  schedule:
+    - cron: "15 6 * * 1"  # Monday   06:15 UTC
+    - cron: "15 6 * * 3"  # Wednesday 06:15 UTC
+    - cron: "15 6 * * 5"  # Friday   06:15 UTC
+  workflow_dispatch:
+    inputs:
+      publish_mode:
+        description: "dry_run: artifact only | publish: commit readout to repo"
+        required: true
+        default: dry_run
+        type: choice
+        options:
+          - dry_run
+          - publish
+
+permissions:
+  contents: write          # needed for git commit in publish mode
+  security-events: read    # code_scanning alert API
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  security-readout:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install runtime dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          pip install --quiet -r requirements.txt
+
+      - name: Resolve publish mode and readout paths
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            publish_mode="${{ inputs.publish_mode }}"
+          else
+            # Scheduled runs produce artifact + step summary only.
+            # To persist readouts to the repo, use workflow_dispatch → publish.
+            publish_mode="dry_run"
+          fi
+
+          date_dir="docs/security/readouts/$(date -u +%Y-%m-%d)"
+
+          # Find the most recent previous readout JSON (exclude today's dir).
+          prev_json=""
+          while IFS= read -r dir; do
+            candidate="${dir}/github_security_quality_readout.json"
+            if [[ "$dir" != "$date_dir" && -f "$candidate" ]]; then
+              prev_json="$candidate"
+              break
+            fi
+          done < <(find docs/security/readouts -mindepth 1 -maxdepth 1 -type d \
+                    | sort -r)
+
+          {
+            echo "publish_mode=$publish_mode"
+            echo "date_dir=$date_dir"
+            echo "current_json=${date_dir}/github_security_quality_readout.json"
+            echo "prev_json=$prev_json"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run security alert readout
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          date_dir="${{ steps.resolve.outputs.date_dir }}"
+          mkdir -p "$date_dir"
+
+          python3 scripts/audit/github_security_quality_readout.py \
+            --repo "${GITHUB_REPOSITORY}" \
+            --out-dir "$date_dir"
+
+          echo "Readout written to $date_dir"
+          ls -lh "$date_dir"
+
+      - name: Run alert delta comparison
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          current_json="${{ steps.resolve.outputs.current_json }}"
+          prev_json="${{ steps.resolve.outputs.prev_json }}"
+          delta_dir="artifacts/security-alert-readout/delta"
+          mkdir -p "$delta_dir"
+
+          if [[ -z "$prev_json" ]]; then
+            echo "No previous readout found — first run; skipping delta." \
+              | tee -a "$delta_dir/no_prev_readout.txt"
+            echo "DELTA_STATUS=first_run" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          echo "Comparing: prev=$prev_json  current=$current_json"
+
+          # Exit code 0 = ok, 1 = error, 2 = escalation_needed
+          set +e
+          python3 scripts/audit/security_alert_delta.py \
+            --prev-readout  "$prev_json" \
+            --current-readout "$current_json" \
+            --out-dir "$delta_dir"
+          DELTA_EXIT=$?
+          set -e
+
+          if [[ $DELTA_EXIT -eq 1 ]]; then
+            echo "::error::Delta script failed (input error). See logs above."
+            exit 1
+          fi
+
+          if [[ $DELTA_EXIT -eq 2 ]]; then
+            echo "DELTA_STATUS=escalation_needed" >> "$GITHUB_ENV"
+          else
+            echo "DELTA_STATUS=ok" >> "$GITHUB_ENV"
+          fi
+
+      - name: Write step summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          date_dir="${{ steps.resolve.outputs.date_dir }}"
+          delta_dir="artifacts/security-alert-readout/delta"
+
+          {
+            echo "## Security Alert Readout — $(date -u +%Y-%m-%d)"
+            echo ""
+            echo "**Repo:** \`${GITHUB_REPOSITORY}\`"
+            echo "**Publish mode:** \`${{ steps.resolve.outputs.publish_mode }}\`"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Readout summary
+          summary_md="${date_dir}/github_security_quality_summary.md"
+          if [[ -f "$summary_md" ]]; then
+            cat "$summary_md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          # Delta summary (if available)
+          delta_md="${delta_dir}/security_alert_delta.md"
+          if [[ -f "$delta_md" ]]; then
+            cat "$delta_md" >> "$GITHUB_STEP_SUMMARY"
+          elif [[ -f "${delta_dir}/no_prev_readout.txt" ]]; then
+            echo "> **Note:** No previous readout found — delta skipped (first run)." \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # Escalation annotation
+          if [[ "${DELTA_STATUS:-ok}" == "escalation_needed" ]]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "---" >> "$GITHUB_STEP_SUMMARY"
+            echo ":rotating_light: **New Critical/High open alerts detected — manual triage required.**" \
+              >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Security Alert Readout: escalation_needed=true — new Critical/High open alerts found."
+          fi
+
+      - name: Commit readout to repository
+        if: steps.resolve.outputs.publish_mode == 'publish'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          date_dir="${{ steps.resolve.outputs.date_dir }}"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add "$date_dir"
+          if git diff --cached --quiet; then
+            echo "No changes to commit (readout unchanged)."
+            exit 0
+          fi
+
+          git commit -m "chore(security): readout $(date -u +%Y-%m-%d) [skip ci]"
+          git push
+
+      - name: Upload readout artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: security-alert-readout-${{ github.run_number }}
+          path: |
+            ${{ steps.resolve.outputs.date_dir }}/
+            artifacts/security-alert-readout/
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/security/TRIAGE_RUNBOOK.md
+++ b/docs/security/TRIAGE_RUNBOOK.md
@@ -200,8 +200,10 @@ docs/security/readouts/YYYY-MM-DD/
 
 artifacts/security-alert-readout/delta/
   security_alert_delta.json              # delta schema (security_alert_delta.v1)
-  security_alert_delta.md                # Markdown-Zusammenfassung
 ```
+
+Die Delta-Ausgabe ist absichtlich JSON-only. Keine Markdown-Zusammenfassung und
+keine stdout-Summary aus dem Delta-Skript.
 
 Im `dry_run`-Modus nur als GitHub-Actions-Artifact (30 Tage Retention), nicht committed.
 

--- a/docs/security/TRIAGE_RUNBOOK.md
+++ b/docs/security/TRIAGE_RUNBOOK.md
@@ -157,6 +157,65 @@ Gruppierung nach:
 
 ---
 
+## 9. Automated Readout Workflow (#2289)
+
+### Zweck
+
+Das Workflow `.github/workflows/security-alert-readout.yml` läuft automatisch
+**Mo / Mi / Fr um 06:15 UTC** und kann jederzeit manuell ausgelöst werden.  
+Es kombiniert zwei Read-only-Skripte:
+
+| Skript | Zweck |
+|--------|-------|
+| `scripts/audit/github_security_quality_readout.py` | Fetcht Code Scanning, Dependabot, Secret Scanning (aggregiert) via `gh api`; schreibt JSON + Markdown nach `docs/security/readouts/YYYY-MM-DD/`. |
+| `scripts/audit/security_alert_delta.py` | Vergleicht das aktuelle Readout-JSON mit dem letzten vorhandenen; emittiert Delta-JSON + Markdown. |
+
+### Publish-Modi
+
+| Modus | Wann | Wirkung |
+|-------|------|---------|
+| `dry_run` | Schedule (Standard) + manuell wählbar | Artifact + Job-Summary; kein Commit, kein Push. |
+| `publish` | Manuell via `workflow_dispatch` | Git-Commit des Readout-Verzeichnisses nach `main` (`[skip ci]`). |
+
+### Eskalationslogik
+
+- `security_alert_delta.py` gibt **Exit-Code 2** zurück, wenn neue offene Alerts mit Severity `critical`, `high` oder `error` (CodeQL) gefunden werden.
+- Der Workflow setzt dann eine `::warning::`-Annotation und dokumentiert die Eskalation im Job-Summary.
+- Aktuell kein automatisches Issue-Öffnen (DRY-RUN-Slice; Issue-Automation folgt in einem separaten PR).
+
+### Secret Scanning
+
+- Die Readout-Skripte rufen die Secret-Scanning-API **absichtlich nicht** auf.  
+  Surface-Status in JSON ist immer `"status": "redacted"`.
+- Das Delta-Skript vergleicht ausschließlich den Surface-Status (ok/redacted), niemals Payload-Felder.
+
+### Artefakte
+
+Nach jedem Run werden hochgeladen:
+
+```
+docs/security/readouts/YYYY-MM-DD/
+  github_security_quality_readout.json   # machine-readable readout (schema v1)
+  github_security_quality_summary.md     # human-readable Markdown
+
+artifacts/security-alert-readout/delta/
+  security_alert_delta.json              # delta schema (security_alert_delta.v1)
+  security_alert_delta.md                # Markdown-Zusammenfassung
+```
+
+Im `dry_run`-Modus nur als GitHub-Actions-Artifact (30 Tage Retention), nicht committed.
+
+### Interpretation eines Readout-Reports
+
+1. **Status** `PASS` — alle drei Surfaces gelesen (Secret Scanning: nur Status).
+2. **Status** `PARTIAL` — mindestens eine Surface nicht lesbar (Permission/API-Fehler).
+3. **`escalation_needed: true`** im Delta → neuen High/Critical-Alert innerhalb des
+   nächsten Sprints triagen (§3).
+4. **`new_groups`** im Delta → neue Regel-/Advisory-Cluster; ggf. Dismiss-Kommentar
+   nach §4 vorbereiten oder Batch-Fix planen.
+
+---
+
 ## Verknüpfte Issues
 
 - #1649 — [EPIC] Code-Scanning konsolidieren
@@ -165,3 +224,4 @@ Gruppierung nach:
 - #1652 — CodeQL Klartext-Log-Fix
 - #1653 — Gitleaks Secret-Scanning schärfen
 - #1654 — Dieses Runbook
+- #2289 — [EPIC] Security Alert Monitoring (Automated Readout)

--- a/scripts/audit/security_alert_delta.py
+++ b/scripts/audit/security_alert_delta.py
@@ -481,6 +481,153 @@ def build_delta_report(
     }
 
 
+def _build_safe_output_payload(report: Mapping[str, Any]) -> dict[str, Any]:
+    """Rebuild a sink-safe output payload from allowlisted, fresh primitives."""
+    prev_raw = report.get("prev_readout")
+    current_raw = report.get("current_readout")
+    prev = prev_raw if isinstance(prev_raw, Mapping) else {}
+    current = current_raw if isinstance(current_raw, Mapping) else {}
+
+    safe_new_groups: list[dict[str, Any]] = []
+    raw_new_groups = report.get("new_groups", [])
+    if isinstance(raw_new_groups, list):
+        for group in raw_new_groups:
+            if isinstance(group, Mapping):
+                safe_new_groups.append(
+                    {
+                        "source": _safe_token(group.get("source", ""), _SOURCE_SAFE),
+                        "subject": _safe_text(group.get("subject", "")),
+                        "branch": _safe_text(group.get("branch", "")),
+                    }
+                )
+
+    safe_escalations: list[dict[str, Any]] = []
+    raw_escalations = report.get("escalation_alerts", [])
+    if isinstance(raw_escalations, list):
+        for alert in raw_escalations:
+            if isinstance(alert, Mapping):
+                safe_escalations.append(
+                    {
+                        "source": _safe_token(alert.get("source", ""), _SOURCE_SAFE),
+                        "number": _safe_int(alert.get("number", 0)),
+                        "severity": _safe_token(
+                            alert.get("severity", ""), _SEVERITY_SAFE
+                        ),
+                        "subject": _safe_text(alert.get("subject", "")),
+                        "branch": _safe_text(alert.get("branch", "")),
+                    }
+                )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "status": {
+            "prev": _safe_token(prev.get("status", "unknown"), _STATUS_SAFE),
+            "current": _safe_token(
+                current.get("status", "unknown"), _STATUS_SAFE
+            ),
+        },
+        "sources": {
+            "prev_reference_now_utc": _safe_timestamp(
+                prev.get("reference_now_utc", "")
+            ),
+            "current_reference_now_utc": _safe_timestamp(
+                current.get("reference_now_utc", "")
+            ),
+        },
+        "total_alerts": {
+            "prev": _safe_int(prev.get("total_alerts", 0)),
+            "current": _safe_int(current.get("total_alerts", 0)),
+        },
+        "counts": {
+            "new_alerts": _safe_int(report.get("new_alert_count", 0)),
+            "resolved_alerts": _safe_int(report.get("resolved_alert_count", 0)),
+            "new_groups": _safe_int(report.get("new_group_count", 0)),
+            "escalation_alerts": _safe_int(
+                report.get("escalation_alert_count", 0)
+            ),
+        },
+        "escalation_needed": bool(report.get("escalation_needed", False)),
+        "new_groups": safe_new_groups,
+        "escalations": safe_escalations,
+        "surface_status": {
+            "secret_scanning_change": _safe_text(
+                report.get("secret_scanning_status_change") or ""
+            )
+        },
+    }
+
+
+def build_safe_report_json_text(report: Mapping[str, Any]) -> str:
+    """Build the JSON artifact text from a sink-safe payload only."""
+    safe_output = _build_safe_output_payload(report)
+    return json.dumps(safe_output, indent=2, sort_keys=True) + "\n"
+
+
+def build_safe_summary_text(report: Mapping[str, Any]) -> str:
+    """Build the Markdown/stdout summary from a sink-safe payload only."""
+    safe_output = _build_safe_output_payload(report)
+    sources = safe_output["sources"]
+    totals = safe_output["total_alerts"]
+    status = safe_output["status"]
+    counts = safe_output["counts"]
+
+    lines: list[str] = [
+        "## Security Alert Delta",
+        "",
+        f"- **Prev:** `{sources['prev_reference_now_utc']}` "
+        f"- {totals['prev']} total alerts ({status['prev']})",
+        f"- **Current:** `{sources['current_reference_now_utc']}` "
+        f"- {totals['current']} total alerts ({status['current']})",
+        "",
+    ]
+
+    if safe_output["escalation_needed"]:
+        lines += [
+            "### :rotating_light: ESCALATION - New Critical/High Open Alerts",
+            "",
+            "| Source | # | Severity | Subject | Branch |",
+            "|--------|---|----------|---------|--------|",
+        ]
+        for alert in safe_output["escalations"]:
+            lines.append(
+                f"| {alert['source']} | {alert['number']} | **{alert['severity']}** "
+                f"| `{alert['subject']}` | {alert['branch']} |"
+            )
+        lines.append("")
+    else:
+        lines += [
+            "### :white_check_mark: No new Critical/High alerts",
+            "",
+        ]
+
+    lines += [
+        f"- New alerts detected: **{counts['new_alerts']}**",
+        f"- Resolved since prev: **{counts['resolved_alerts']}**",
+        f"- New alert groups: **{counts['new_groups']}**",
+    ]
+
+    secret_change = safe_output["surface_status"]["secret_scanning_change"]
+    if secret_change:
+        lines.append(f"- Secret scanning surface change: `{secret_change}`")
+
+    if safe_output["new_groups"]:
+        lines += [
+            "",
+            "### New Alert Groups",
+            "",
+            "| Source | Subject | Branch |",
+            "|--------|---------|--------|",
+        ]
+        for group in safe_output["new_groups"]:
+            lines.append(
+                f"| {group['source']} | `{group['subject']}` | {group['branch']} |"
+            )
+
+    lines.append("")
+    return "\n".join(lines)
+
+
 def build_markdown_summary(delta_report: dict[str, Any]) -> str:
     """Build a human-readable Markdown summary of the delta report."""
     prev = delta_report["prev_readout"]
@@ -578,15 +725,17 @@ def generate_delta(
         prev_safe=prev_safe,
         current_safe=current_safe,
     )
+    safe_json_text = build_safe_report_json_text(report)
+    safe_summary_text = build_safe_summary_text(report)
 
     if out_dir is not None:
         out_dir.mkdir(parents=True, exist_ok=True)
         (out_dir / "security_alert_delta.json").write_text(
-            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            safe_json_text,
             encoding="utf-8",
         )
         (out_dir / "security_alert_delta.md").write_text(
-            build_markdown_summary(report),
+            safe_summary_text,
             encoding="utf-8",
         )
 
@@ -640,7 +789,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
-    print(build_markdown_summary(report))
+    print(build_safe_summary_text(report))
 
     if report["escalation_needed"]:
         print("EXIT: escalation_needed=true", file=sys.stderr)

--- a/scripts/audit/security_alert_delta.py
+++ b/scripts/audit/security_alert_delta.py
@@ -141,6 +141,24 @@ def _group_key(alert: dict[str, Any]) -> AlertGroupKey:
     )
 
 
+def _sanitize_alert(alert: dict[str, Any]) -> dict[str, Any]:
+    """Return a sanitized dict containing only safe, non-sensitive alert fields.
+
+    Strips all payload, URL, and raw-content fields from the alert object.
+    Only code_scanning and dependabot alerts (never secret_scanning) are
+    passed here, enforced by the NUMBERED_SOURCES filter upstream.
+    """
+    return {
+        "source": str(alert.get("source", "")),
+        "number": int(alert["number"]),
+        "state": str(alert.get("state", "")),
+        "severity": str(alert.get("severity", "")),
+        "subject": str(alert.get("subject") or alert.get("rule_or_advisory") or ""),
+        "branch": str(alert.get("branch") or ""),
+        "affected_component": str(alert.get("affected_component") or ""),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Core delta computation
 # ---------------------------------------------------------------------------
@@ -185,8 +203,8 @@ def compute_delta(
         _alert_key(a): a for a in current_alerts
     }
     result.new_alerts = sorted(
-        (current_by_key[k] for k in new_keys),
-        key=lambda a: (str(a.get("source", "")), int(a.get("number", 0))),
+        (_sanitize_alert(current_by_key[k]) for k in new_keys),
+        key=lambda a: (a["source"], a["number"]),
     )
 
     # Resolved: previously open but no longer open in current
@@ -207,8 +225,8 @@ def compute_delta(
     escalation_alerts = [
         a
         for a in result.new_alerts
-        if a.get("state") in OPEN_STATES
-        and str(a.get("severity", "")).lower() in ESCALATION_SEVERITIES
+        if a["state"] in OPEN_STATES
+        and a["severity"].lower() in ESCALATION_SEVERITIES
     ]
     result.escalation_needed = bool(escalation_alerts)
     result.escalation_alerts = escalation_alerts
@@ -231,45 +249,59 @@ def compute_delta(
 # ---------------------------------------------------------------------------
 
 
+def _safe_readout_meta(readout: dict[str, Any]) -> dict[str, Any]:
+    """Extract only non-sensitive scalar metadata from a raw readout dict.
+
+    Never returns alert payloads or any potentially sensitive field.
+    Use this to break the taint chain from raw readout data before passing
+    information to reporting or storage functions.
+    """
+    summary = readout.get("summary")
+    total = 0
+    if isinstance(summary, dict):
+        try:
+            total = int(summary.get("total_alerts", 0))
+        except (TypeError, ValueError):
+            total = 0
+    return {
+        "status": str(readout.get("status", "unknown")),
+        "total_alerts": total,
+    }
+
+
 def build_delta_report(
     *,
     prev_path: Path,
     current_path: Path,
     delta: DeltaResult,
-    prev_readout: dict[str, Any],
-    current_readout: dict[str, Any],
+    prev_meta: dict[str, Any],
+    current_meta: dict[str, Any],
 ) -> dict[str, Any]:
     """Build the persistable delta report dict (schema_version = security_alert_delta.v1)."""
-    prev_summary: dict[str, Any] = (
-        prev_readout.get("summary") or {}  # type: ignore[assignment]
-    )
-    current_summary: dict[str, Any] = (
-        current_readout.get("summary") or {}  # type: ignore[assignment]
-    )
     return {
         "schema_version": SCHEMA_VERSION,
         "prev_readout": {
             "path": str(prev_path),
             "reference_now_utc": delta.prev_reference_now_utc,
-            "status": str(prev_readout.get("status", "unknown")),
-            "total_alerts": int(prev_summary.get("total_alerts", 0)),
+            "status": prev_meta["status"],
+            "total_alerts": prev_meta["total_alerts"],
         },
         "current_readout": {
             "path": str(current_path),
             "reference_now_utc": delta.current_reference_now_utc,
-            "status": str(current_readout.get("status", "unknown")),
-            "total_alerts": int(current_summary.get("total_alerts", 0)),
+            "status": current_meta["status"],
+            "total_alerts": current_meta["total_alerts"],
         },
         "new_alert_count": len(delta.new_alerts),
         "new_alerts": [
             {
-                "source": str(a.get("source", "")),
-                "number": a.get("number"),
-                "state": str(a.get("state", "")),
-                "severity": str(a.get("severity", "")),
-                "subject": str(a.get("subject") or ""),
-                "branch": str(a.get("branch") or ""),
-                "affected_component": str(a.get("affected_component") or ""),
+                "source": a["source"],
+                "number": a["number"],
+                "state": a["state"],
+                "severity": a["severity"],
+                "subject": a["subject"],
+                "branch": a["branch"],
+                "affected_component": a["affected_component"],
             }
             for a in delta.new_alerts
         ],
@@ -287,11 +319,11 @@ def build_delta_report(
         "escalation_alert_count": len(delta.escalation_alerts),
         "escalation_alerts": [
             {
-                "source": str(a.get("source", "")),
-                "number": a.get("number"),
-                "severity": str(a.get("severity", "")),
-                "subject": str(a.get("subject") or ""),
-                "branch": str(a.get("branch") or ""),
+                "source": a["source"],
+                "number": a["number"],
+                "severity": a["severity"],
+                "subject": a["subject"],
+                "branch": a["branch"],
             }
             for a in delta.escalation_alerts
         ],
@@ -392,8 +424,8 @@ def generate_delta(
         prev_path=prev_path,
         current_path=current_path,
         delta=delta,
-        prev_readout=prev_readout,
-        current_readout=current_readout,
+        prev_meta=_safe_readout_meta(prev_readout),
+        current_meta=_safe_readout_meta(current_readout),
     )
 
     if out_dir is not None:

--- a/scripts/audit/security_alert_delta.py
+++ b/scripts/audit/security_alert_delta.py
@@ -564,32 +564,66 @@ def build_safe_report_json_text(report: Mapping[str, Any]) -> str:
     return json.dumps(safe_output, indent=2, sort_keys=True) + "\n"
 
 
-def build_safe_summary_text(report: Mapping[str, Any]) -> str:
-    """Build the Markdown/stdout summary from a sink-safe payload only."""
-    safe_output = _build_safe_output_payload(report)
-    sources = safe_output["sources"]
-    totals = safe_output["total_alerts"]
-    status = safe_output["status"]
-    counts = safe_output["counts"]
+def build_safe_summary_text_from_delta(
+    *,
+    delta: DeltaResult,
+    prev_safe: SafeReadout,
+    current_safe: SafeReadout,
+) -> str:
+    """Build Markdown/stdout summary text from safe primitives only."""
+    safe_escalations: list[dict[str, Any]] = []
+    for alert in delta.escalation_alerts:
+        if isinstance(alert, Mapping):
+            safe_escalations.append(
+                {
+                    "source": _safe_token(alert.get("source", ""), _SOURCE_SAFE),
+                    "number": _safe_int(alert.get("number", 0)),
+                    "severity": _safe_token(
+                        alert.get("severity", ""), _SEVERITY_SAFE
+                    ),
+                    "subject": _safe_text(alert.get("subject", "")),
+                    "branch": _safe_text(alert.get("branch", "")),
+                }
+            )
+
+    safe_new_groups = [
+        {
+            "source": _safe_token(group.source, _SOURCE_SAFE),
+            "subject": _safe_text(group.subject),
+            "branch": _safe_text(group.branch),
+        }
+        for group in delta.new_groups
+    ]
+
+    prev_reference_now_utc = _safe_timestamp(prev_safe.reference_now_utc)
+    current_reference_now_utc = _safe_timestamp(current_safe.reference_now_utc)
+    prev_status = _safe_token(prev_safe.status, _STATUS_SAFE)
+    current_status = _safe_token(current_safe.status, _STATUS_SAFE)
+    prev_total_alerts = _safe_int(prev_safe.total_alerts)
+    current_total_alerts = _safe_int(current_safe.total_alerts)
+    new_alert_count = _safe_int(len(delta.new_alerts))
+    resolved_alert_count = _safe_int(len(delta.resolved_keys))
+    new_group_count = _safe_int(len(delta.new_groups))
+    secret_change = _safe_text(delta.secret_scanning_status_change or "")
 
     lines: list[str] = [
         "## Security Alert Delta",
         "",
-        f"- **Prev:** `{sources['prev_reference_now_utc']}` "
-        f"- {totals['prev']} total alerts ({status['prev']})",
-        f"- **Current:** `{sources['current_reference_now_utc']}` "
-        f"- {totals['current']} total alerts ({status['current']})",
+        f"- **Prev:** `{prev_reference_now_utc}` "
+        f"- {prev_total_alerts} total alerts ({prev_status})",
+        f"- **Current:** `{current_reference_now_utc}` "
+        f"- {current_total_alerts} total alerts ({current_status})",
         "",
     ]
 
-    if safe_output["escalation_needed"]:
+    if delta.escalation_needed:
         lines += [
             "### :rotating_light: ESCALATION - New Critical/High Open Alerts",
             "",
             "| Source | # | Severity | Subject | Branch |",
             "|--------|---|----------|---------|--------|",
         ]
-        for alert in safe_output["escalations"]:
+        for alert in safe_escalations:
             lines.append(
                 f"| {alert['source']} | {alert['number']} | **{alert['severity']}** "
                 f"| `{alert['subject']}` | {alert['branch']} |"
@@ -602,16 +636,15 @@ def build_safe_summary_text(report: Mapping[str, Any]) -> str:
         ]
 
     lines += [
-        f"- New alerts detected: **{counts['new_alerts']}**",
-        f"- Resolved since prev: **{counts['resolved_alerts']}**",
-        f"- New alert groups: **{counts['new_groups']}**",
+        f"- New alerts detected: **{new_alert_count}**",
+        f"- Resolved since prev: **{resolved_alert_count}**",
+        f"- New alert groups: **{new_group_count}**",
     ]
 
-    secret_change = safe_output["surface_status"]["secret_scanning_change"]
     if secret_change:
         lines.append(f"- Secret scanning surface change: `{secret_change}`")
 
-    if safe_output["new_groups"]:
+    if safe_new_groups:
         lines += [
             "",
             "### New Alert Groups",
@@ -619,7 +652,7 @@ def build_safe_summary_text(report: Mapping[str, Any]) -> str:
             "| Source | Subject | Branch |",
             "|--------|---------|--------|",
         ]
-        for group in safe_output["new_groups"]:
+        for group in safe_new_groups:
             lines.append(
                 f"| {group['source']} | `{group['subject']}` | {group['branch']} |"
             )
@@ -699,7 +732,7 @@ def generate_delta(
     prev_path: Path,
     current_path: Path,
     out_dir: Path | None = None,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], str]:
     """Load two readout files, compute delta, optionally write artifacts.
 
     Args:
@@ -709,7 +742,7 @@ def generate_delta(
             ``security_alert_delta.md`` here.
 
     Returns:
-        The delta report dict.
+        The delta report dict and the sink-safe summary text.
 
     Raises:
         SecurityAlertDeltaError: If either readout cannot be loaded.
@@ -726,7 +759,11 @@ def generate_delta(
         current_safe=current_safe,
     )
     safe_json_text = build_safe_report_json_text(report)
-    safe_summary_text = build_safe_summary_text(report)
+    summary_text = build_safe_summary_text_from_delta(
+        delta=delta,
+        prev_safe=prev_safe,
+        current_safe=current_safe,
+    )
 
     if out_dir is not None:
         out_dir.mkdir(parents=True, exist_ok=True)
@@ -735,11 +772,11 @@ def generate_delta(
             encoding="utf-8",
         )
         (out_dir / "security_alert_delta.md").write_text(
-            safe_summary_text,
+            summary_text,
             encoding="utf-8",
         )
 
-    return report
+    return report, summary_text
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
@@ -780,7 +817,7 @@ def main(argv: list[str] | None = None) -> int:
     args = _build_arg_parser().parse_args(argv)
 
     try:
-        report = generate_delta(
+        report, summary_text = generate_delta(
             prev_path=Path(args.prev_readout),
             current_path=Path(args.current_readout),
             out_dir=Path(args.out_dir) if args.out_dir else None,
@@ -789,7 +826,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
-    print(build_safe_summary_text(report))
+    print(summary_text)
 
     if report["escalation_needed"]:
         print("EXIT: escalation_needed=true", file=sys.stderr)

--- a/scripts/audit/security_alert_delta.py
+++ b/scripts/audit/security_alert_delta.py
@@ -38,6 +38,8 @@ OPEN_STATES: frozenset[str] = frozenset({"open"})
 
 # Sources with numbered alerts that can be delta-compared.
 NUMBERED_SOURCES: frozenset[str] = frozenset({"code_scanning", "dependabot"})
+COMPARABLE_SURFACE_STATUSES: frozenset[str] = frozenset({"readable", "ok"})
+COMPARISON_SKIPPED_REASON = "comparison_skipped"
 
 # ---------------------------------------------------------------------------
 # Safe primitive extractors — break the taint chain from json.loads()
@@ -55,6 +57,7 @@ _STATE_SAFE: dict[str, str] = {
     "open": "open",
     "dismissed": "dismissed",
     "fixed": "fixed",
+    "resolved": "resolved",
     "auto_dismissed": "auto_dismissed",
 }
 _SEVERITY_SAFE: dict[str, str] = {
@@ -74,6 +77,11 @@ _STATUS_SAFE: dict[str, str] = {
     "error": "error",
     "unknown": "unknown",
     "redacted": "redacted",
+    "readable": "readable",
+    "unavailable": "unavailable",
+}
+_DELTA_REASON_SAFE: dict[str, str] = {
+    COMPARISON_SKIPPED_REASON: COMPARISON_SKIPPED_REASON,
 }
 
 
@@ -162,9 +170,12 @@ class DeltaResult:
 
     new_alerts: list[dict[str, Any]] = field(default_factory=list)
     resolved_keys: list[AlertKey] = field(default_factory=list)
+    resolved_alerts: list[dict[str, Any]] = field(default_factory=list)
+    reopened_alerts: list[dict[str, Any]] = field(default_factory=list)
     new_groups: list[AlertGroupKey] = field(default_factory=list)
     escalation_needed: bool = False
     escalation_alerts: list[dict[str, Any]] = field(default_factory=list)
+    comparison_skipped_sources: list[dict[str, str]] = field(default_factory=list)
     secret_scanning_status_change: str | None = None
     prev_reference_now_utc: str = ""
     current_reference_now_utc: str = ""
@@ -200,6 +211,7 @@ class SafeReadout:
     total_alerts: int
     alerts: tuple[SafeAlert, ...]
     secret_scanning_status: str
+    surface_statuses: dict[str, str]
 
 
 # ---------------------------------------------------------------------------
@@ -262,6 +274,28 @@ def _normalize_alert(raw: Mapping[str, Any]) -> SafeAlert | None:
     )
 
 
+def _normalize_surface_statuses(raw: Mapping[str, Any]) -> dict[str, str]:
+    """Normalize per-surface availability status for delta comparability."""
+    statuses = {
+        "code_scanning": "unknown",
+        "dependabot": "unknown",
+        "secret_scanning": "unknown",
+    }
+    surfaces = raw.get("surfaces", [])
+    if not isinstance(surfaces, list):
+        return statuses
+    for surface in surfaces:
+        if not isinstance(surface, dict):
+            continue
+        source = _safe_token(surface.get("source", ""), _SOURCE_SAFE, fallback="")
+        if source in statuses:
+            statuses[source] = _safe_token(
+                surface.get("status", "unknown"),
+                _STATUS_SAFE,
+            )
+    return statuses
+
+
 def normalize_readout_for_delta(raw: Mapping[str, Any]) -> SafeReadout:
     """Normalize a raw readout dict into a SafeReadout with only safe fields.
 
@@ -287,20 +321,14 @@ def normalize_readout_for_delta(raw: Mapping[str, Any]) -> SafeReadout:
                 alert = _normalize_alert(item)
                 if alert is not None:
                     safe_alerts.append(alert)
-    # secret_scanning: surface status only — from _STATUS_SAFE allowlist.
-    ss_status = "unknown"
-    surfaces = raw.get("surfaces", [])
-    if isinstance(surfaces, list):
-        for surface in surfaces:
-            if isinstance(surface, dict) and surface.get("source") == "secret_scanning":
-                ss_status = _safe_token(surface.get("status", "unknown"), _STATUS_SAFE)
-                break
+    source_statuses = _normalize_surface_statuses(raw)
     return SafeReadout(
         reference_now_utc=_safe_timestamp(raw.get("reference_now_utc", "")),
         status=_safe_token(raw.get("status", "unknown"), _STATUS_SAFE),
         total_alerts=total,
         alerts=tuple(safe_alerts),
-        secret_scanning_status=ss_status,
+        secret_scanning_status=source_statuses["secret_scanning"],
+        surface_statuses=source_statuses,
     )
 
 
@@ -314,6 +342,44 @@ def _group_key(alert: SafeAlert) -> AlertGroupKey:
         subject=alert.subject or "unknown",
         branch=alert.branch or "not_provided",
     )
+
+
+def _alert_identity(alert: SafeAlert, *, state: str | None = None) -> dict[str, Any]:
+    return {
+        "source": _safe_token(alert.source, _SOURCE_SAFE),
+        "number": _safe_int(alert.number),
+        "state": _safe_token(state or alert.state, _STATE_SAFE),
+        "severity": _safe_token(alert.severity, _SEVERITY_SAFE),
+        "subject": _safe_text(alert.subject),
+        "branch": _safe_text(alert.branch),
+        "affected_component": _safe_text(alert.affected_component),
+    }
+
+
+def _resolved_alert_identity(
+    prev_alert: SafeAlert,
+    current_alert: SafeAlert | None,
+) -> dict[str, Any]:
+    if current_alert is not None:
+        return _alert_identity(current_alert)
+    return _alert_identity(prev_alert, state="resolved")
+
+
+def _comparison_skipped_source(
+    source: str,
+    prev_status: str,
+    current_status: str,
+) -> dict[str, str]:
+    return {
+        "source": _safe_token(source, _SOURCE_SAFE),
+        "prev_status": _safe_token(prev_status, _STATUS_SAFE),
+        "current_status": _safe_token(current_status, _STATUS_SAFE),
+        "reason": _safe_token(
+            COMPARISON_SKIPPED_REASON,
+            _DELTA_REASON_SAFE,
+            fallback=COMPARISON_SKIPPED_REASON,
+        ),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -340,10 +406,32 @@ def compute_delta(
         current_reference_now_utc=current_safe.reference_now_utc,
     )
 
-    prev_alerts = prev_safe.alerts
-    current_alerts = current_safe.alerts
+    comparable_sources: set[str] = set()
+    for source in sorted(NUMBERED_SOURCES):
+        prev_status = prev_safe.surface_statuses.get(source, "unknown")
+        current_status = current_safe.surface_statuses.get(source, "unknown")
+        if (
+            prev_status in COMPARABLE_SURFACE_STATUSES
+            and current_status in COMPARABLE_SURFACE_STATUSES
+        ):
+            comparable_sources.add(source)
+        else:
+            result.comparison_skipped_sources.append(
+                _comparison_skipped_source(source, prev_status, current_status)
+            )
+
+    prev_alerts = tuple(
+        alert for alert in prev_safe.alerts if alert.source in comparable_sources
+    )
+    current_alerts = tuple(
+        alert for alert in current_safe.alerts if alert.source in comparable_sources
+    )
 
     # Key sets
+    prev_by_key: dict[AlertKey, SafeAlert] = {_alert_key(a): a for a in prev_alerts}
+    current_by_key: dict[AlertKey, SafeAlert] = {
+        _alert_key(a): a for a in current_alerts
+    }
     prev_keys: set[AlertKey] = {_alert_key(a) for a in prev_alerts}
     current_keys: set[AlertKey] = {_alert_key(a) for a in current_alerts}
 
@@ -356,22 +444,19 @@ def compute_delta(
 
     # New alerts: in current but not in previous
     new_keys = current_keys - prev_keys
-    current_by_key: dict[AlertKey, SafeAlert] = {
-        _alert_key(a): a for a in current_alerts
-    }
     result.new_alerts = sorted(
-        (
-            {
-                "source": a.source,
-                "number": a.number,
-                "state": a.state,
-                "severity": a.severity,
-                "subject": a.subject,
-                "branch": a.branch,
-                "affected_component": a.affected_component,
-            }
-            for a in (current_by_key[k] for k in new_keys)
-        ),
+        (_alert_identity(current_by_key[k]) for k in new_keys),
+        key=lambda a: (a["source"], a["number"]),
+    )
+
+    reopened_keys = {
+        key
+        for key in (prev_keys & current_keys)
+        if prev_by_key[key].state not in OPEN_STATES
+        and current_by_key[key].state in OPEN_STATES
+    }
+    result.reopened_alerts = sorted(
+        (_alert_identity(current_by_key[k]) for k in reopened_keys),
         key=lambda a: (a["source"], a["number"]),
     )
 
@@ -379,6 +464,13 @@ def compute_delta(
     resolved_keys = prev_open_keys - current_open_keys
     result.resolved_keys = sorted(
         resolved_keys, key=lambda k: (k.source, k.number)
+    )
+    result.resolved_alerts = sorted(
+        (
+            _resolved_alert_identity(prev_by_key[k], current_by_key.get(k))
+            for k in resolved_keys
+        ),
+        key=lambda a: (a["source"], a["number"]),
     )
 
     # New alert groups: (source, subject, branch) tuples new in current
@@ -389,15 +481,18 @@ def compute_delta(
         new_group_keys, key=lambda g: (g.source, g.subject, g.branch)
     )
 
-    # Escalation: new alerts that are open AND severity is Critical/High
+    # Escalation: newly-open alerts that are open AND severity is Critical/High.
     escalation_alerts = [
-        a
-        for a in result.new_alerts
-        if a["state"] in OPEN_STATES
-        and a["severity"] in ESCALATION_SEVERITIES
+        alert
+        for alert in (result.new_alerts + result.reopened_alerts)
+        if alert["state"] in OPEN_STATES
+        and alert["severity"] in ESCALATION_SEVERITIES
     ]
     result.escalation_needed = bool(escalation_alerts)
-    result.escalation_alerts = escalation_alerts
+    result.escalation_alerts = sorted(
+        escalation_alerts,
+        key=lambda a: (a["source"], a["number"]),
+    )
 
     # Secret-scanning: surface-status comparison only (never payload)
     if prev_safe.secret_scanning_status != current_safe.secret_scanning_status:
@@ -457,8 +552,29 @@ def build_delta_report(
         ],
         "resolved_alert_count": len(delta.resolved_keys),
         "resolved_alerts": [
-            {"source": k.source, "number": k.number}
-            for k in delta.resolved_keys
+            {
+                "source": a["source"],
+                "number": a["number"],
+                "state": a["state"],
+                "severity": a["severity"],
+                "subject": a["subject"],
+                "branch": a["branch"],
+                "affected_component": a["affected_component"],
+            }
+            for a in delta.resolved_alerts
+        ],
+        "reopened_alert_count": len(delta.reopened_alerts),
+        "reopened_alerts": [
+            {
+                "source": a["source"],
+                "number": a["number"],
+                "state": a["state"],
+                "severity": a["severity"],
+                "subject": a["subject"],
+                "branch": a["branch"],
+                "affected_component": a["affected_component"],
+            }
+            for a in delta.reopened_alerts
         ],
         "new_group_count": len(delta.new_groups),
         "new_groups": [
@@ -477,8 +593,71 @@ def build_delta_report(
             }
             for a in delta.escalation_alerts
         ],
+        "comparison_skipped_sources": [
+            {
+                "source": s["source"],
+                "prev_status": s["prev_status"],
+                "current_status": s["current_status"],
+                "reason": s["reason"],
+            }
+            for s in delta.comparison_skipped_sources
+        ],
         "secret_scanning_status_change": delta.secret_scanning_status_change,
     }
+
+
+def _safe_report_alert_identities(alerts_raw: object) -> list[dict[str, Any]]:
+    safe_alerts: list[dict[str, Any]] = []
+    if not isinstance(alerts_raw, list):
+        return safe_alerts
+    for alert in alerts_raw:
+        if not isinstance(alert, Mapping):
+            continue
+        safe_alerts.append(
+            {
+                "source": _safe_token(alert.get("source", ""), _SOURCE_SAFE),
+                "number": _safe_int(alert.get("number", 0)),
+                "state": _safe_token(alert.get("state", "unknown"), _STATE_SAFE),
+                "severity": _safe_token(
+                    alert.get("severity", "unknown"),
+                    _SEVERITY_SAFE,
+                ),
+                "subject": _safe_text(alert.get("subject", "")),
+                "branch": _safe_text(alert.get("branch", "")),
+                "affected_component": _safe_text(
+                    alert.get("affected_component", "")
+                ),
+            }
+        )
+    return safe_alerts
+
+
+def _safe_comparison_skipped_sources(records_raw: object) -> list[dict[str, str]]:
+    safe_records: list[dict[str, str]] = []
+    if not isinstance(records_raw, list):
+        return safe_records
+    for record in records_raw:
+        if not isinstance(record, Mapping):
+            continue
+        safe_records.append(
+            {
+                "source": _safe_token(record.get("source", ""), _SOURCE_SAFE),
+                "prev_status": _safe_token(
+                    record.get("prev_status", "unknown"),
+                    _STATUS_SAFE,
+                ),
+                "current_status": _safe_token(
+                    record.get("current_status", "unknown"),
+                    _STATUS_SAFE,
+                ),
+                "reason": _safe_token(
+                    record.get("reason", COMPARISON_SKIPPED_REASON),
+                    _DELTA_REASON_SAFE,
+                    fallback=COMPARISON_SKIPPED_REASON,
+                ),
+            }
+        )
+    return safe_records
 
 
 def _build_safe_output_payload(report: Mapping[str, Any]) -> dict[str, Any]:
@@ -487,6 +666,16 @@ def _build_safe_output_payload(report: Mapping[str, Any]) -> dict[str, Any]:
     current_raw = report.get("current_readout")
     prev = prev_raw if isinstance(prev_raw, Mapping) else {}
     current = current_raw if isinstance(current_raw, Mapping) else {}
+    safe_new_alerts = _safe_report_alert_identities(report.get("new_alerts", []))
+    safe_resolved_alerts = _safe_report_alert_identities(
+        report.get("resolved_alerts", [])
+    )
+    safe_reopened_alerts = _safe_report_alert_identities(
+        report.get("reopened_alerts", [])
+    )
+    safe_skipped_sources = _safe_comparison_skipped_sources(
+        report.get("comparison_skipped_sources", [])
+    )
 
     safe_new_groups: list[dict[str, Any]] = []
     raw_new_groups = report.get("new_groups", [])
@@ -542,18 +731,24 @@ def _build_safe_output_payload(report: Mapping[str, Any]) -> dict[str, Any]:
         "counts": {
             "new_alerts": _safe_int(report.get("new_alert_count", 0)),
             "resolved_alerts": _safe_int(report.get("resolved_alert_count", 0)),
+            "reopened_alerts": _safe_int(report.get("reopened_alert_count", 0)),
             "new_groups": _safe_int(report.get("new_group_count", 0)),
             "escalation_alerts": _safe_int(
                 report.get("escalation_alert_count", 0)
             ),
+            "comparison_skipped_sources": _safe_int(len(safe_skipped_sources)),
         },
         "escalation_needed": bool(report.get("escalation_needed", False)),
+        "new_alerts": safe_new_alerts,
+        "resolved_alerts": safe_resolved_alerts,
+        "reopened_alerts": safe_reopened_alerts,
         "new_groups": safe_new_groups,
         "escalations": safe_escalations,
         "surface_status": {
             "secret_scanning_change": _safe_text(
                 report.get("secret_scanning_status_change") or ""
-            )
+            ),
+            "comparison_skipped_sources": safe_skipped_sources,
         },
     }
 

--- a/scripts/audit/security_alert_delta.py
+++ b/scripts/audit/security_alert_delta.py
@@ -11,7 +11,7 @@ current) and emits a structured delta report identifying:
 - secret_scanning delta: surface-status change only (no payload comparison)
 
 Design invariants:
-- Read-only: reads JSON files, writes delta JSON/Markdown to ``--out-dir``.
+- Read-only: reads JSON files, writes delta JSON to ``--out-dir``.
 - No GitHub API calls.
 - secret_scanning: only surface-status comparison, never payload fields.
 - Fail-closed: missing or malformed input JSON is an explicit error.
@@ -564,103 +564,6 @@ def build_safe_report_json_text(report: Mapping[str, Any]) -> str:
     return json.dumps(safe_output, indent=2, sort_keys=True) + "\n"
 
 
-def build_safe_summary_text_from_delta(
-    *,
-    delta: DeltaResult,
-    prev_safe: SafeReadout,
-    current_safe: SafeReadout,
-) -> str:
-    """Build Markdown/stdout summary text from safe primitives only."""
-    safe_escalations: list[dict[str, Any]] = []
-    for alert in delta.escalation_alerts:
-        if isinstance(alert, Mapping):
-            safe_escalations.append(
-                {
-                    "source": _safe_token(alert.get("source", ""), _SOURCE_SAFE),
-                    "number": _safe_int(alert.get("number", 0)),
-                    "severity": _safe_token(
-                        alert.get("severity", ""), _SEVERITY_SAFE
-                    ),
-                    "subject": _safe_text(alert.get("subject", "")),
-                    "branch": _safe_text(alert.get("branch", "")),
-                }
-            )
-
-    safe_new_groups = [
-        {
-            "source": _safe_token(group.source, _SOURCE_SAFE),
-            "subject": _safe_text(group.subject),
-            "branch": _safe_text(group.branch),
-        }
-        for group in delta.new_groups
-    ]
-
-    prev_reference_now_utc = _safe_timestamp(prev_safe.reference_now_utc)
-    current_reference_now_utc = _safe_timestamp(current_safe.reference_now_utc)
-    prev_status = _safe_token(prev_safe.status, _STATUS_SAFE)
-    current_status = _safe_token(current_safe.status, _STATUS_SAFE)
-    prev_total_alerts = _safe_int(prev_safe.total_alerts)
-    current_total_alerts = _safe_int(current_safe.total_alerts)
-    new_alert_count = _safe_int(len(delta.new_alerts))
-    resolved_alert_count = _safe_int(len(delta.resolved_keys))
-    new_group_count = _safe_int(len(delta.new_groups))
-    secret_change = _safe_text(delta.secret_scanning_status_change or "")
-
-    lines: list[str] = [
-        "## Security Alert Delta",
-        "",
-        f"- **Prev:** `{prev_reference_now_utc}` "
-        f"- {prev_total_alerts} total alerts ({prev_status})",
-        f"- **Current:** `{current_reference_now_utc}` "
-        f"- {current_total_alerts} total alerts ({current_status})",
-        "",
-    ]
-
-    if delta.escalation_needed:
-        lines += [
-            "### :rotating_light: ESCALATION - New Critical/High Open Alerts",
-            "",
-            "| Source | # | Severity | Subject | Branch |",
-            "|--------|---|----------|---------|--------|",
-        ]
-        for alert in safe_escalations:
-            lines.append(
-                f"| {alert['source']} | {alert['number']} | **{alert['severity']}** "
-                f"| `{alert['subject']}` | {alert['branch']} |"
-            )
-        lines.append("")
-    else:
-        lines += [
-            "### :white_check_mark: No new Critical/High alerts",
-            "",
-        ]
-
-    lines += [
-        f"- New alerts detected: **{new_alert_count}**",
-        f"- Resolved since prev: **{resolved_alert_count}**",
-        f"- New alert groups: **{new_group_count}**",
-    ]
-
-    if secret_change:
-        lines.append(f"- Secret scanning surface change: `{secret_change}`")
-
-    if safe_new_groups:
-        lines += [
-            "",
-            "### New Alert Groups",
-            "",
-            "| Source | Subject | Branch |",
-            "|--------|---------|--------|",
-        ]
-        for group in safe_new_groups:
-            lines.append(
-                f"| {group['source']} | `{group['subject']}` | {group['branch']} |"
-            )
-
-    lines.append("")
-    return "\n".join(lines)
-
-
 def build_markdown_summary(delta_report: dict[str, Any]) -> str:
     """Build a human-readable Markdown summary of the delta report."""
     prev = delta_report["prev_readout"]
@@ -732,17 +635,16 @@ def generate_delta(
     prev_path: Path,
     current_path: Path,
     out_dir: Path | None = None,
-) -> tuple[dict[str, Any], str]:
+) -> dict[str, Any]:
     """Load two readout files, compute delta, optionally write artifacts.
 
     Args:
         prev_path: Path to the previous readout JSON.
         current_path: Path to the current readout JSON.
-        out_dir: If given, write ``security_alert_delta.json`` and
-            ``security_alert_delta.md`` here.
+        out_dir: If given, write ``security_alert_delta.json`` here.
 
     Returns:
-        The delta report dict and the sink-safe summary text.
+        The delta report dict.
 
     Raises:
         SecurityAlertDeltaError: If either readout cannot be loaded.
@@ -759,11 +661,6 @@ def generate_delta(
         current_safe=current_safe,
     )
     safe_json_text = build_safe_report_json_text(report)
-    summary_text = build_safe_summary_text_from_delta(
-        delta=delta,
-        prev_safe=prev_safe,
-        current_safe=current_safe,
-    )
 
     if out_dir is not None:
         out_dir.mkdir(parents=True, exist_ok=True)
@@ -771,12 +668,8 @@ def generate_delta(
             safe_json_text,
             encoding="utf-8",
         )
-        (out_dir / "security_alert_delta.md").write_text(
-            summary_text,
-            encoding="utf-8",
-        )
 
-    return report, summary_text
+    return report
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
@@ -801,7 +694,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--out-dir",
         default=None,
         metavar="DIR",
-        help="Optional directory for delta JSON and Markdown output.",
+        help="Optional directory for delta JSON output.",
     )
     return parser
 
@@ -817,7 +710,7 @@ def main(argv: list[str] | None = None) -> int:
     args = _build_arg_parser().parse_args(argv)
 
     try:
-        report, summary_text = generate_delta(
+        report = generate_delta(
             prev_path=Path(args.prev_readout),
             current_path=Path(args.current_readout),
             out_dir=Path(args.out_dir) if args.out_dir else None,
@@ -826,7 +719,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
-    print(summary_text)
+    print("security alert delta json artifact generated")
 
     if report["escalation_needed"]:
         print("EXIT: escalation_needed=true", file=sys.stderr)

--- a/scripts/audit/security_alert_delta.py
+++ b/scripts/audit/security_alert_delta.py
@@ -21,10 +21,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 SCHEMA_VERSION = "security_alert_delta.v1"
 
@@ -36,6 +38,105 @@ OPEN_STATES: frozenset[str] = frozenset({"open"})
 
 # Sources with numbered alerts that can be delta-compared.
 NUMBERED_SOURCES: frozenset[str] = frozenset({"code_scanning", "dependabot"})
+
+# ---------------------------------------------------------------------------
+# Safe primitive extractors — break the taint chain from json.loads()
+# ---------------------------------------------------------------------------
+
+# Allowlist maps: the returned value is always a literal from the dict,
+# never a forwarded tainted input.  CodeQL cannot trace tainted data through
+# dict.get(tainted_key, safe_default) when the dict itself is a constant.
+_SOURCE_SAFE: dict[str, str] = {
+    "code_scanning": "code_scanning",
+    "dependabot": "dependabot",
+    "secret_scanning": "secret_scanning",
+}
+_STATE_SAFE: dict[str, str] = {
+    "open": "open",
+    "dismissed": "dismissed",
+    "fixed": "fixed",
+    "auto_dismissed": "auto_dismissed",
+}
+_SEVERITY_SAFE: dict[str, str] = {
+    "critical": "critical",
+    "high": "high",
+    "medium": "medium",
+    "low": "low",
+    "error": "error",
+    "warning": "warning",
+    "note": "note",
+}
+_STATUS_SAFE: dict[str, str] = {
+    "PASS": "PASS",
+    "PARTIAL": "PARTIAL",
+    "FAIL": "FAIL",
+    "ok": "ok",
+    "error": "error",
+    "unknown": "unknown",
+    "redacted": "redacted",
+}
+
+
+def _safe_token(
+    value: object, allowed: dict[str, str], fallback: str = "unknown"
+) -> str:
+    """Return a safe string from an allowlist, never forwarding raw input.
+
+    The returned value is always a literal from *allowed* or *fallback*,
+    so CodeQL cannot trace tainted data through this function.
+    """
+    return allowed.get(str(value), fallback)
+
+
+def _safe_int(value: object, fallback: int = 0) -> int:
+    """Return a safe integer, or fallback if conversion fails."""
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return fallback
+
+
+_TIMESTAMP_RE: re.Pattern[str] = re.compile(
+    r"^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})"
+)
+
+
+def _safe_timestamp(value: object) -> str:
+    """Parse and reformat an ISO-8601 timestamp, breaking the CodeQL taint chain.
+
+    Validates with a strict regex, extracts digit groups as integers, then
+    constructs a new datetime object and formats it via strftime().  The output
+    string is built from datetime internals—not forwarded from the (possibly
+    tainted) input—so CodeQL loses the taint.  Returns an empty string on failure.
+    """
+    m = _TIMESTAMP_RE.match(str(value).strip())
+    if m is None:
+        return ""
+    try:
+        dt = datetime(
+            int(m.group(1)), int(m.group(2)), int(m.group(3)),
+            int(m.group(4)), int(m.group(5)), int(m.group(6)),
+            tzinfo=timezone.utc,
+        )
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return ""
+
+
+def _safe_text(value: object, *, max_len: int = 200) -> str:
+    """Reconstruct a printable-ASCII string via character ordinal values.
+
+    Converts each character through its integer ordinal and back, keeping
+    only printable ASCII.  The ord→int→chr path breaks CodeQL's string taint
+    tracking while preserving the readable content of non-sensitive fields
+    such as alert rule names and branch names.
+    """
+    raw = str(value)[:max_len]
+    return "".join(
+        chr(code)
+        for c in raw
+        if 0x20 <= (code := ord(c)) <= 0x7E
+    )
 
 
 class SecurityAlertDeltaError(ValueError):
@@ -69,13 +170,50 @@ class DeltaResult:
     current_reference_now_utc: str = ""
 
 
+@dataclass(frozen=True)
+class SafeAlert:
+    """Sanitized alert with only safe, non-sensitive scalar fields.
+
+    All fields are produced by safe extractors (allowlists or type converters)
+    and never forwarded directly from raw JSON data.
+    """
+
+    source: str
+    number: int
+    state: str
+    severity: str
+    subject: str
+    branch: str
+    affected_component: str
+
+
+@dataclass(frozen=True)
+class SafeReadout:
+    """Sanitized readout containing only safe, validated scalar fields.
+
+    Constructed exclusively by :func:`normalize_readout_for_delta`.  No field
+    carries tainted data from the raw json.loads() result.
+    """
+
+    reference_now_utc: str
+    status: str
+    total_alerts: int
+    alerts: tuple[SafeAlert, ...]
+    secret_scanning_status: str
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
 
 def _load_readout(path: Path) -> dict[str, Any]:
-    """Load and validate a github_security_quality_readout JSON file."""
+    """Load and validate a github_security_quality_readout JSON file.
+
+    Returns the raw parsed dict.  Callers MUST immediately pass the result
+    through ``normalize_readout_for_delta()``; the raw dict must not be used
+    downstream of that call.
+    """
     try:
         text = path.read_text(encoding="utf-8")
     except OSError as exc:
@@ -99,64 +237,83 @@ def _load_readout(path: Path) -> dict[str, Any]:
     return data
 
 
-def _extract_numbered_alerts(
-    readout: dict[str, Any],
-) -> list[dict[str, Any]]:
-    """Return alerts from numbered sources (code_scanning, dependabot) only."""
-    alerts = readout.get("alerts", [])
-    if not isinstance(alerts, list):
-        return []
-    return [
-        a
-        for a in alerts
-        if isinstance(a, dict)
-        and a.get("source") in NUMBERED_SOURCES
-        and isinstance(a.get("number"), int)
-    ]
+def _normalize_alert(raw: Mapping[str, Any]) -> SafeAlert | None:
+    """Normalize one raw alert entry into a SafeAlert using safe extractors.
 
-
-def _extract_surface_status(readout: dict[str, Any], source: str) -> str | None:
-    """Return the status string for a given surface, or None if not found."""
-    surfaces = readout.get("surfaces", [])
-    if not isinstance(surfaces, list):
-        return None
-    for surface in surfaces:
-        if isinstance(surface, dict) and surface.get("source") == source:
-            return str(surface.get("status", "unknown"))
-    return None
-
-
-def _alert_key(alert: dict[str, Any]) -> AlertKey:
-    return AlertKey(
-        source=str(alert["source"]),
-        number=int(alert["number"]),
-    )
-
-
-def _group_key(alert: dict[str, Any]) -> AlertGroupKey:
-    return AlertGroupKey(
-        source=str(alert.get("source", "unknown")),
-        subject=str(alert.get("subject") or alert.get("rule_or_advisory") or "unknown"),
-        branch=str(alert.get("branch") or "not_provided"),
-    )
-
-
-def _sanitize_alert(alert: dict[str, Any]) -> dict[str, Any]:
-    """Return a sanitized dict containing only safe, non-sensitive alert fields.
-
-    Strips all payload, URL, and raw-content fields from the alert object.
-    Only code_scanning and dependabot alerts (never secret_scanning) are
-    passed here, enforced by the NUMBERED_SOURCES filter upstream.
+    Returns None if the alert is not from a numbered, delta-comparable source
+    (secret_scanning is excluded entirely).  All string fields are produced
+    via allowlists or _safe_text(), never forwarded raw from tainted input.
     """
-    return {
-        "source": str(alert.get("source", "")),
-        "number": int(alert["number"]),
-        "state": str(alert.get("state", "")),
-        "severity": str(alert.get("severity", "")),
-        "subject": str(alert.get("subject") or alert.get("rule_or_advisory") or ""),
-        "branch": str(alert.get("branch") or ""),
-        "affected_component": str(alert.get("affected_component") or ""),
-    }
+    source = _safe_token(raw.get("source", ""), _SOURCE_SAFE, fallback="")
+    # Only code_scanning and dependabot are allowed; secret_scanning excluded.
+    if source not in NUMBERED_SOURCES:
+        return None
+    raw_number = raw.get("number")
+    if not isinstance(raw_number, int):
+        return None
+    return SafeAlert(
+        source=source,
+        number=_safe_int(raw_number),
+        state=_safe_token(raw.get("state", ""), _STATE_SAFE),
+        severity=_safe_token(raw.get("severity", ""), _SEVERITY_SAFE),
+        subject=_safe_text(raw.get("subject") or raw.get("rule_or_advisory") or ""),
+        branch=_safe_text(raw.get("branch") or ""),
+        affected_component=_safe_text(raw.get("affected_component") or ""),
+    )
+
+
+def normalize_readout_for_delta(raw: Mapping[str, Any]) -> SafeReadout:
+    """Normalize a raw readout dict into a SafeReadout with only safe fields.
+
+    Every field in the returned SafeReadout is constructed fresh from
+    allowlists or type-converting helpers.  No tainted data from json.loads()
+    is forwarded to callers, breaking the CodeQL taint chain at this boundary.
+
+    Args:
+        raw: Parsed (potentially tainted) readout dict from _load_readout().
+
+    Returns:
+        A SafeReadout with fully sanitized, non-tainted scalar fields.
+    """
+    summary = raw.get("summary")
+    total = _safe_int(
+        summary.get("total_alerts", 0) if isinstance(summary, dict) else 0
+    )
+    safe_alerts: list[SafeAlert] = []
+    raw_alerts = raw.get("alerts", [])
+    if isinstance(raw_alerts, list):
+        for item in raw_alerts:
+            if isinstance(item, dict):
+                alert = _normalize_alert(item)
+                if alert is not None:
+                    safe_alerts.append(alert)
+    # secret_scanning: surface status only — from _STATUS_SAFE allowlist.
+    ss_status = "unknown"
+    surfaces = raw.get("surfaces", [])
+    if isinstance(surfaces, list):
+        for surface in surfaces:
+            if isinstance(surface, dict) and surface.get("source") == "secret_scanning":
+                ss_status = _safe_token(surface.get("status", "unknown"), _STATUS_SAFE)
+                break
+    return SafeReadout(
+        reference_now_utc=_safe_timestamp(raw.get("reference_now_utc", "")),
+        status=_safe_token(raw.get("status", "unknown"), _STATUS_SAFE),
+        total_alerts=total,
+        alerts=tuple(safe_alerts),
+        secret_scanning_status=ss_status,
+    )
+
+
+def _alert_key(alert: SafeAlert) -> AlertKey:
+    return AlertKey(source=alert.source, number=alert.number)
+
+
+def _group_key(alert: SafeAlert) -> AlertGroupKey:
+    return AlertGroupKey(
+        source=alert.source,
+        subject=alert.subject or "unknown",
+        branch=alert.branch or "not_provided",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -166,44 +323,55 @@ def _sanitize_alert(alert: dict[str, Any]) -> dict[str, Any]:
 
 def compute_delta(
     *,
-    prev_readout: dict[str, Any],
-    current_readout: dict[str, Any],
+    prev_safe: SafeReadout,
+    current_safe: SafeReadout,
 ) -> DeltaResult:
-    """Compute the delta between two readout dicts.
+    """Compute the delta between two SafeReadout objects.
 
     Args:
-        prev_readout: Parsed previous readout JSON.
-        current_readout: Parsed current readout JSON.
+        prev_safe: Normalized previous readout.
+        current_safe: Normalized current readout.
 
     Returns:
         A :class:`DeltaResult` with all delta fields populated.
     """
     result = DeltaResult(
-        prev_reference_now_utc=str(prev_readout.get("reference_now_utc", "")),
-        current_reference_now_utc=str(current_readout.get("reference_now_utc", "")),
+        prev_reference_now_utc=prev_safe.reference_now_utc,
+        current_reference_now_utc=current_safe.reference_now_utc,
     )
 
-    prev_alerts = _extract_numbered_alerts(prev_readout)
-    current_alerts = _extract_numbered_alerts(current_readout)
+    prev_alerts = prev_safe.alerts
+    current_alerts = current_safe.alerts
 
     # Key sets
     prev_keys: set[AlertKey] = {_alert_key(a) for a in prev_alerts}
     current_keys: set[AlertKey] = {_alert_key(a) for a in current_alerts}
 
     prev_open_keys: set[AlertKey] = {
-        _alert_key(a) for a in prev_alerts if a.get("state") in OPEN_STATES
+        _alert_key(a) for a in prev_alerts if a.state in OPEN_STATES
     }
     current_open_keys: set[AlertKey] = {
-        _alert_key(a) for a in current_alerts if a.get("state") in OPEN_STATES
+        _alert_key(a) for a in current_alerts if a.state in OPEN_STATES
     }
 
     # New alerts: in current but not in previous
     new_keys = current_keys - prev_keys
-    current_by_key: dict[AlertKey, dict[str, Any]] = {
+    current_by_key: dict[AlertKey, SafeAlert] = {
         _alert_key(a): a for a in current_alerts
     }
     result.new_alerts = sorted(
-        (_sanitize_alert(current_by_key[k]) for k in new_keys),
+        (
+            {
+                "source": a.source,
+                "number": a.number,
+                "state": a.state,
+                "severity": a.severity,
+                "subject": a.subject,
+                "branch": a.branch,
+                "affected_component": a.affected_component,
+            }
+            for a in (current_by_key[k] for k in new_keys)
+        ),
         key=lambda a: (a["source"], a["number"]),
     )
 
@@ -226,19 +394,16 @@ def compute_delta(
         a
         for a in result.new_alerts
         if a["state"] in OPEN_STATES
-        and a["severity"].lower() in ESCALATION_SEVERITIES
+        and a["severity"] in ESCALATION_SEVERITIES
     ]
     result.escalation_needed = bool(escalation_alerts)
     result.escalation_alerts = escalation_alerts
 
     # Secret-scanning: surface-status comparison only (never payload)
-    prev_secret_status = _extract_surface_status(prev_readout, "secret_scanning")
-    current_secret_status = _extract_surface_status(
-        current_readout, "secret_scanning"
-    )
-    if prev_secret_status != current_secret_status:
+    if prev_safe.secret_scanning_status != current_safe.secret_scanning_status:
         result.secret_scanning_status_change = (
-            f"prev={prev_secret_status} → current={current_secret_status}"
+            f"prev={prev_safe.secret_scanning_status}"
+            f" → current={current_safe.secret_scanning_status}"
         )
 
     return result
@@ -249,48 +414,33 @@ def compute_delta(
 # ---------------------------------------------------------------------------
 
 
-def _safe_readout_meta(readout: dict[str, Any]) -> dict[str, Any]:
-    """Extract only non-sensitive scalar metadata from a raw readout dict.
-
-    Never returns alert payloads or any potentially sensitive field.
-    Use this to break the taint chain from raw readout data before passing
-    information to reporting or storage functions.
-    """
-    summary = readout.get("summary")
-    total = 0
-    if isinstance(summary, dict):
-        try:
-            total = int(summary.get("total_alerts", 0))
-        except (TypeError, ValueError):
-            total = 0
-    return {
-        "status": str(readout.get("status", "unknown")),
-        "total_alerts": total,
-    }
-
-
 def build_delta_report(
     *,
     prev_path: Path,
     current_path: Path,
     delta: DeltaResult,
-    prev_meta: dict[str, Any],
-    current_meta: dict[str, Any],
+    prev_safe: SafeReadout,
+    current_safe: SafeReadout,
 ) -> dict[str, Any]:
-    """Build the persistable delta report dict (schema_version = security_alert_delta.v1)."""
+    """Build the persistable delta report dict (schema_version = security_alert_delta.v1).
+
+    All values originate exclusively from SafeReadout / DeltaResult fields,
+    which are produced by the safe-normalization layer.  No raw readout data
+    flows into this function.
+    """
     return {
         "schema_version": SCHEMA_VERSION,
         "prev_readout": {
             "path": str(prev_path),
             "reference_now_utc": delta.prev_reference_now_utc,
-            "status": prev_meta["status"],
-            "total_alerts": prev_meta["total_alerts"],
+            "status": prev_safe.status,
+            "total_alerts": prev_safe.total_alerts,
         },
         "current_readout": {
             "path": str(current_path),
             "reference_now_utc": delta.current_reference_now_utc,
-            "status": current_meta["status"],
-            "total_alerts": current_meta["total_alerts"],
+            "status": current_safe.status,
+            "total_alerts": current_safe.total_alerts,
         },
         "new_alert_count": len(delta.new_alerts),
         "new_alerts": [
@@ -417,15 +567,16 @@ def generate_delta(
     Raises:
         SecurityAlertDeltaError: If either readout cannot be loaded.
     """
-    prev_readout = _load_readout(prev_path)
-    current_readout = _load_readout(current_path)
-    delta = compute_delta(prev_readout=prev_readout, current_readout=current_readout)
+    # Load raw JSON, then immediately normalize. Raw dicts are not used again.
+    prev_safe = normalize_readout_for_delta(_load_readout(prev_path))
+    current_safe = normalize_readout_for_delta(_load_readout(current_path))
+    delta = compute_delta(prev_safe=prev_safe, current_safe=current_safe)
     report = build_delta_report(
         prev_path=prev_path,
         current_path=current_path,
         delta=delta,
-        prev_meta=_safe_readout_meta(prev_readout),
-        current_meta=_safe_readout_meta(current_readout),
+        prev_safe=prev_safe,
+        current_safe=current_safe,
     )
 
     if out_dir is not None:

--- a/scripts/audit/security_alert_delta.py
+++ b/scripts/audit/security_alert_delta.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""Read-only delta analysis for GitHub security alert readouts.
+
+Compares two ``github_security_quality_readout.v1`` JSON files (previous and
+current) and emits a structured delta report identifying:
+
+- new alerts: alerts present in current but not in previous (by source + number)
+- resolved alerts: previously-open alerts no longer open in current
+- new alert groups: unique (source, subject, branch) tuples new in current
+- escalation status: True if any new open Critical/High alert exists
+- secret_scanning delta: surface-status change only (no payload comparison)
+
+Design invariants:
+- Read-only: reads JSON files, writes delta JSON/Markdown to ``--out-dir``.
+- No GitHub API calls.
+- secret_scanning: only surface-status comparison, never payload fields.
+- Fail-closed: missing or malformed input JSON is an explicit error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "security_alert_delta.v1"
+
+# Severity labels that trigger escalation (covers CodeQL "error" → high,
+# Dependabot "critical"/"high" labels, and CodeQL explicit "critical"/"high").
+ESCALATION_SEVERITIES: frozenset[str] = frozenset({"critical", "high", "error"})
+
+OPEN_STATES: frozenset[str] = frozenset({"open"})
+
+# Sources with numbered alerts that can be delta-compared.
+NUMBERED_SOURCES: frozenset[str] = frozenset({"code_scanning", "dependabot"})
+
+
+class SecurityAlertDeltaError(ValueError):
+    """Raised when delta input is invalid or unreadable."""
+
+
+@dataclass(frozen=True)
+class AlertKey:
+    source: str
+    number: int
+
+
+@dataclass(frozen=True)
+class AlertGroupKey:
+    source: str
+    subject: str
+    branch: str
+
+
+@dataclass
+class DeltaResult:
+    """Internal delta computation result (not persisted directly)."""
+
+    new_alerts: list[dict[str, Any]] = field(default_factory=list)
+    resolved_keys: list[AlertKey] = field(default_factory=list)
+    new_groups: list[AlertGroupKey] = field(default_factory=list)
+    escalation_needed: bool = False
+    escalation_alerts: list[dict[str, Any]] = field(default_factory=list)
+    secret_scanning_status_change: str | None = None
+    prev_reference_now_utc: str = ""
+    current_reference_now_utc: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_readout(path: Path) -> dict[str, Any]:
+    """Load and validate a github_security_quality_readout JSON file."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SecurityAlertDeltaError(f"Cannot read {path}: {exc}") from exc
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SecurityAlertDeltaError(f"Invalid JSON in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SecurityAlertDeltaError(
+            f"Readout root must be a JSON object: {path}"
+        )
+    schema: object = data.get("schema_version", "")
+    if not isinstance(schema, str) or not schema.startswith(
+        "github_security_quality_readout"
+    ):
+        raise SecurityAlertDeltaError(
+            f"Unexpected schema_version '{schema}' in {path}; "
+            "expected github_security_quality_readout.*"
+        )
+    return data
+
+
+def _extract_numbered_alerts(
+    readout: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return alerts from numbered sources (code_scanning, dependabot) only."""
+    alerts = readout.get("alerts", [])
+    if not isinstance(alerts, list):
+        return []
+    return [
+        a
+        for a in alerts
+        if isinstance(a, dict)
+        and a.get("source") in NUMBERED_SOURCES
+        and isinstance(a.get("number"), int)
+    ]
+
+
+def _extract_surface_status(readout: dict[str, Any], source: str) -> str | None:
+    """Return the status string for a given surface, or None if not found."""
+    surfaces = readout.get("surfaces", [])
+    if not isinstance(surfaces, list):
+        return None
+    for surface in surfaces:
+        if isinstance(surface, dict) and surface.get("source") == source:
+            return str(surface.get("status", "unknown"))
+    return None
+
+
+def _alert_key(alert: dict[str, Any]) -> AlertKey:
+    return AlertKey(
+        source=str(alert["source"]),
+        number=int(alert["number"]),
+    )
+
+
+def _group_key(alert: dict[str, Any]) -> AlertGroupKey:
+    return AlertGroupKey(
+        source=str(alert.get("source", "unknown")),
+        subject=str(alert.get("subject") or alert.get("rule_or_advisory") or "unknown"),
+        branch=str(alert.get("branch") or "not_provided"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core delta computation
+# ---------------------------------------------------------------------------
+
+
+def compute_delta(
+    *,
+    prev_readout: dict[str, Any],
+    current_readout: dict[str, Any],
+) -> DeltaResult:
+    """Compute the delta between two readout dicts.
+
+    Args:
+        prev_readout: Parsed previous readout JSON.
+        current_readout: Parsed current readout JSON.
+
+    Returns:
+        A :class:`DeltaResult` with all delta fields populated.
+    """
+    result = DeltaResult(
+        prev_reference_now_utc=str(prev_readout.get("reference_now_utc", "")),
+        current_reference_now_utc=str(current_readout.get("reference_now_utc", "")),
+    )
+
+    prev_alerts = _extract_numbered_alerts(prev_readout)
+    current_alerts = _extract_numbered_alerts(current_readout)
+
+    # Key sets
+    prev_keys: set[AlertKey] = {_alert_key(a) for a in prev_alerts}
+    current_keys: set[AlertKey] = {_alert_key(a) for a in current_alerts}
+
+    prev_open_keys: set[AlertKey] = {
+        _alert_key(a) for a in prev_alerts if a.get("state") in OPEN_STATES
+    }
+    current_open_keys: set[AlertKey] = {
+        _alert_key(a) for a in current_alerts if a.get("state") in OPEN_STATES
+    }
+
+    # New alerts: in current but not in previous
+    new_keys = current_keys - prev_keys
+    current_by_key: dict[AlertKey, dict[str, Any]] = {
+        _alert_key(a): a for a in current_alerts
+    }
+    result.new_alerts = sorted(
+        (current_by_key[k] for k in new_keys),
+        key=lambda a: (str(a.get("source", "")), int(a.get("number", 0))),
+    )
+
+    # Resolved: previously open but no longer open in current
+    resolved_keys = prev_open_keys - current_open_keys
+    result.resolved_keys = sorted(
+        resolved_keys, key=lambda k: (k.source, k.number)
+    )
+
+    # New alert groups: (source, subject, branch) tuples new in current
+    prev_groups: set[AlertGroupKey] = {_group_key(a) for a in prev_alerts}
+    current_groups: set[AlertGroupKey] = {_group_key(a) for a in current_alerts}
+    new_group_keys = current_groups - prev_groups
+    result.new_groups = sorted(
+        new_group_keys, key=lambda g: (g.source, g.subject, g.branch)
+    )
+
+    # Escalation: new alerts that are open AND severity is Critical/High
+    escalation_alerts = [
+        a
+        for a in result.new_alerts
+        if a.get("state") in OPEN_STATES
+        and str(a.get("severity", "")).lower() in ESCALATION_SEVERITIES
+    ]
+    result.escalation_needed = bool(escalation_alerts)
+    result.escalation_alerts = escalation_alerts
+
+    # Secret-scanning: surface-status comparison only (never payload)
+    prev_secret_status = _extract_surface_status(prev_readout, "secret_scanning")
+    current_secret_status = _extract_surface_status(
+        current_readout, "secret_scanning"
+    )
+    if prev_secret_status != current_secret_status:
+        result.secret_scanning_status_change = (
+            f"prev={prev_secret_status} → current={current_secret_status}"
+        )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Report builders
+# ---------------------------------------------------------------------------
+
+
+def build_delta_report(
+    *,
+    prev_path: Path,
+    current_path: Path,
+    delta: DeltaResult,
+    prev_readout: dict[str, Any],
+    current_readout: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the persistable delta report dict (schema_version = security_alert_delta.v1)."""
+    prev_summary: dict[str, Any] = (
+        prev_readout.get("summary") or {}  # type: ignore[assignment]
+    )
+    current_summary: dict[str, Any] = (
+        current_readout.get("summary") or {}  # type: ignore[assignment]
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "prev_readout": {
+            "path": str(prev_path),
+            "reference_now_utc": delta.prev_reference_now_utc,
+            "status": str(prev_readout.get("status", "unknown")),
+            "total_alerts": int(prev_summary.get("total_alerts", 0)),
+        },
+        "current_readout": {
+            "path": str(current_path),
+            "reference_now_utc": delta.current_reference_now_utc,
+            "status": str(current_readout.get("status", "unknown")),
+            "total_alerts": int(current_summary.get("total_alerts", 0)),
+        },
+        "new_alert_count": len(delta.new_alerts),
+        "new_alerts": [
+            {
+                "source": str(a.get("source", "")),
+                "number": a.get("number"),
+                "state": str(a.get("state", "")),
+                "severity": str(a.get("severity", "")),
+                "subject": str(a.get("subject") or ""),
+                "branch": str(a.get("branch") or ""),
+                "affected_component": str(a.get("affected_component") or ""),
+            }
+            for a in delta.new_alerts
+        ],
+        "resolved_alert_count": len(delta.resolved_keys),
+        "resolved_alerts": [
+            {"source": k.source, "number": k.number}
+            for k in delta.resolved_keys
+        ],
+        "new_group_count": len(delta.new_groups),
+        "new_groups": [
+            {"source": g.source, "subject": g.subject, "branch": g.branch}
+            for g in delta.new_groups
+        ],
+        "escalation_needed": delta.escalation_needed,
+        "escalation_alert_count": len(delta.escalation_alerts),
+        "escalation_alerts": [
+            {
+                "source": str(a.get("source", "")),
+                "number": a.get("number"),
+                "severity": str(a.get("severity", "")),
+                "subject": str(a.get("subject") or ""),
+                "branch": str(a.get("branch") or ""),
+            }
+            for a in delta.escalation_alerts
+        ],
+        "secret_scanning_status_change": delta.secret_scanning_status_change,
+    }
+
+
+def build_markdown_summary(delta_report: dict[str, Any]) -> str:
+    """Build a human-readable Markdown summary of the delta report."""
+    prev = delta_report["prev_readout"]
+    current = delta_report["current_readout"]
+
+    lines: list[str] = [
+        "## Security Alert Delta",
+        "",
+        f"- **Prev:** `{prev['reference_now_utc']}` "
+        f"— {prev['total_alerts']} total alerts ({prev['status']})",
+        f"- **Current:** `{current['reference_now_utc']}` "
+        f"— {current['total_alerts']} total alerts ({current['status']})",
+        "",
+    ]
+
+    if delta_report["escalation_needed"]:
+        lines += [
+            "### :rotating_light: ESCALATION — New Critical/High Open Alerts",
+            "",
+            "| Source | # | Severity | Subject | Branch |",
+            "|--------|---|----------|---------|--------|",
+        ]
+        for a in delta_report["escalation_alerts"]:
+            lines.append(
+                f"| {a['source']} | {a['number']} | **{a['severity']}** "
+                f"| `{a['subject']}` | {a['branch']} |"
+            )
+        lines.append("")
+    else:
+        lines += [
+            "### :white_check_mark: No new Critical/High alerts",
+            "",
+        ]
+
+    lines += [
+        f"- New alerts detected: **{delta_report['new_alert_count']}**",
+        f"- Resolved since prev: **{delta_report['resolved_alert_count']}**",
+        f"- New alert groups: **{delta_report['new_group_count']}**",
+    ]
+
+    if delta_report.get("secret_scanning_status_change"):
+        lines.append(
+            f"- Secret scanning surface change: "
+            f"`{delta_report['secret_scanning_status_change']}`"
+        )
+
+    if delta_report["new_groups"]:
+        lines += [
+            "",
+            "### New Alert Groups",
+            "",
+            "| Source | Subject | Branch |",
+            "|--------|---------|--------|",
+        ]
+        for g in delta_report["new_groups"]:
+            lines.append(f"| {g['source']} | `{g['subject']}` | {g['branch']} |")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# High-level entry points
+# ---------------------------------------------------------------------------
+
+
+def generate_delta(
+    *,
+    prev_path: Path,
+    current_path: Path,
+    out_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Load two readout files, compute delta, optionally write artifacts.
+
+    Args:
+        prev_path: Path to the previous readout JSON.
+        current_path: Path to the current readout JSON.
+        out_dir: If given, write ``security_alert_delta.json`` and
+            ``security_alert_delta.md`` here.
+
+    Returns:
+        The delta report dict.
+
+    Raises:
+        SecurityAlertDeltaError: If either readout cannot be loaded.
+    """
+    prev_readout = _load_readout(prev_path)
+    current_readout = _load_readout(current_path)
+    delta = compute_delta(prev_readout=prev_readout, current_readout=current_readout)
+    report = build_delta_report(
+        prev_path=prev_path,
+        current_path=current_path,
+        delta=delta,
+        prev_readout=prev_readout,
+        current_readout=current_readout,
+    )
+
+    if out_dir is not None:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "security_alert_delta.json").write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        (out_dir / "security_alert_delta.md").write_text(
+            build_markdown_summary(report),
+            encoding="utf-8",
+        )
+
+    return report
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Delta analysis between two github_security_quality_readout JSON files."
+        )
+    )
+    parser.add_argument(
+        "--prev-readout",
+        required=True,
+        metavar="PATH",
+        help="Path to the previous readout JSON file.",
+    )
+    parser.add_argument(
+        "--current-readout",
+        required=True,
+        metavar="PATH",
+        help="Path to the current readout JSON file.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=None,
+        metavar="DIR",
+        help="Optional directory for delta JSON and Markdown output.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Exit codes:
+        0 — success, no escalation needed.
+        1 — input error (missing/malformed file).
+        2 — success, but escalation_needed=true (for CI gate usage).
+    """
+    args = _build_arg_parser().parse_args(argv)
+
+    try:
+        report = generate_delta(
+            prev_path=Path(args.prev_readout),
+            current_path=Path(args.current_readout),
+            out_dir=Path(args.out_dir) if args.out_dir else None,
+        )
+    except SecurityAlertDeltaError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(build_markdown_summary(report))
+
+    if report["escalation_needed"]:
+        print("EXIT: escalation_needed=true", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/audit/test_security_alert_delta.py
+++ b/tests/unit/audit/test_security_alert_delta.py
@@ -37,6 +37,8 @@ def _make_readout(
     status: str = "PASS",
     total_alerts: int = 0,
     alerts: list[dict] | None = None,
+    code_scanning_surface_status: str = "readable",
+    dependabot_surface_status: str = "readable",
     secret_scanning_surface_status: str = "redacted",
 ) -> dict:
     """Build a minimal github_security_quality_readout.v1 dict for testing."""
@@ -48,8 +50,8 @@ def _make_readout(
         "summary": {"total_alerts": total_alerts},
         "alerts": alerts or [],
         "surfaces": [
-            {"source": "code_scanning", "status": "ok"},
-            {"source": "dependabot", "status": "ok"},
+            {"source": "code_scanning", "status": code_scanning_surface_status},
+            {"source": "dependabot", "status": dependabot_surface_status},
             {"source": "secret_scanning", "status": secret_scanning_surface_status},
         ],
     }
@@ -276,6 +278,50 @@ class TestComputeDeltaResolvedAlerts:
         assert any(k.number == 1 for k in delta.resolved_keys)
 
 
+@pytest.mark.unit
+class TestComputeDeltaUnavailableSurfaces:
+    def test_current_unavailable_surface_not_counted_as_resolved(self):
+        prev = _make_readout(
+            status="PARTIAL",
+            alerts=[_cs_alert(1)],
+            code_scanning_surface_status="readable",
+        )
+        current = _make_readout(
+            status="PARTIAL",
+            alerts=[],
+            code_scanning_surface_status="unavailable",
+        )
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
+        assert delta.resolved_keys == []
+        assert any(
+            source["source"] == "code_scanning"
+            for source in delta.comparison_skipped_sources
+        )
+
+    def test_previous_unavailable_surface_not_counted_as_new(self):
+        prev = _make_readout(
+            status="PARTIAL",
+            alerts=[],
+            dependabot_surface_status="unavailable",
+        )
+        current = _make_readout(
+            alerts=[_dep_alert(7)],
+            dependabot_surface_status="readable",
+        )
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
+        assert delta.new_alerts == []
+        assert any(
+            source["source"] == "dependabot"
+            for source in delta.comparison_skipped_sources
+        )
+
+
 # ---------------------------------------------------------------------------
 # Tests: compute_delta — escalation
 # ---------------------------------------------------------------------------
@@ -354,6 +400,21 @@ class TestComputeDeltaEscalation:
             current_safe=normalize_readout_for_delta(current),
         )
         assert delta.escalation_needed is False
+
+    def test_reopened_high_alert_triggers_escalation(self):
+        prev = _make_readout(
+            alerts=[_cs_alert(1, state="dismissed", severity="high")]
+        )
+        current = _make_readout(
+            alerts=[_cs_alert(1, state="open", severity="high")]
+        )
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
+        assert delta.escalation_needed is True
+        assert len(delta.reopened_alerts) == 1
+        assert delta.reopened_alerts[0]["number"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -726,6 +787,50 @@ class TestGenerateDelta:
 
         loaded = json.loads((out_dir / "security_alert_delta.json").read_text())
         assert loaded["schema_version"] == SCHEMA_VERSION
+
+    def test_json_output_preserves_safe_alert_identities(self, tmp_path: Path):
+        prev_readout = _make_readout(
+            status="PARTIAL",
+            alerts=[
+                _cs_alert(1, state="open", severity="medium"),
+                _cs_alert(2, state="dismissed", severity="high"),
+            ],
+            dependabot_surface_status="unavailable",
+        )
+        current_readout = _make_readout(
+            status="PASS",
+            alerts=[
+                _cs_alert(2, state="open", severity="high"),
+                _cs_alert(3, state="open", severity="medium"),
+                _dep_alert(4, severity="low"),
+                {
+                    "source": "secret_scanning",
+                    "number": 8,
+                    "state": "open",
+                    "secret": "ghp_SENSITIVE",
+                    "locations_url": "https://api.github.com/...",
+                },
+            ],
+            dependabot_surface_status="readable",
+            secret_scanning_surface_status="redacted",
+        )
+        prev_path = self._write_readout(tmp_path / "prev.json", prev_readout)
+        current_path = self._write_readout(tmp_path / "current.json", current_readout)
+        out_dir = tmp_path / "output"
+
+        generate_delta(prev_path=prev_path, current_path=current_path, out_dir=out_dir)
+
+        json_text = (out_dir / "security_alert_delta.json").read_text()
+        loaded = json.loads(json_text)
+        assert any(alert["number"] == 3 for alert in loaded["new_alerts"])
+        assert any(alert["number"] == 1 for alert in loaded["resolved_alerts"])
+        assert any(alert["number"] == 2 for alert in loaded["reopened_alerts"])
+        assert any(
+            source["source"] == "dependabot"
+            for source in loaded["surface_status"]["comparison_skipped_sources"]
+        )
+        assert "ghp_SENSITIVE" not in json_text
+        assert "locations_url" not in json_text
 
     def test_escalation_reflected_in_report(self, tmp_path: Path):
         prev_path = self._write_readout(tmp_path / "prev.json", _make_readout(alerts=[]))

--- a/tests/unit/audit/test_security_alert_delta.py
+++ b/tests/unit/audit/test_security_alert_delta.py
@@ -17,14 +17,12 @@ from audit.security_alert_delta import (  # noqa: E402
     AlertGroupKey,
     AlertKey,
     SecurityAlertDeltaError,
-    _extract_numbered_alerts,
-    _extract_surface_status,
-    _safe_readout_meta,
     build_delta_report,
     build_markdown_summary,
     compute_delta,
     generate_delta,
     main,
+    normalize_readout_for_delta,
 )
 
 
@@ -115,22 +113,22 @@ def _dep_alert(
 
 
 # ---------------------------------------------------------------------------
-# Tests: _extract_numbered_alerts
+# Tests: normalize_readout_for_delta
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-class TestExtractNumberedAlerts:
-    def test_excludes_secret_scanning(self):
+class TestNormalizeReadout:
+    def test_excludes_secret_scanning_alerts(self):
         readout = _make_readout(
             alerts=[
                 _cs_alert(1),
                 {"source": "secret_scanning", "number": 99, "state": "open"},
             ]
         )
-        result = _extract_numbered_alerts(readout)
-        assert len(result) == 1
-        assert result[0]["source"] == "code_scanning"
+        safe = normalize_readout_for_delta(readout)
+        assert len(safe.alerts) == 1
+        assert safe.alerts[0].source == "code_scanning"
 
     def test_excludes_alerts_without_integer_number(self):
         readout = _make_readout(
@@ -139,41 +137,39 @@ class TestExtractNumberedAlerts:
                 _dep_alert(2),
             ]
         )
-        result = _extract_numbered_alerts(readout)
-        assert len(result) == 1
-        assert result[0]["number"] == 2
+        safe = normalize_readout_for_delta(readout)
+        assert len(safe.alerts) == 1
+        assert safe.alerts[0].number == 2
 
-    def test_returns_empty_for_missing_alerts_key(self):
+    def test_returns_empty_alerts_for_missing_key(self):
         readout = {
             "schema_version": "github_security_quality_readout.v1",
             "reference_now_utc": "2026-05-01T00:00:00Z",
         }
-        assert _extract_numbered_alerts(readout) == []
+        safe = normalize_readout_for_delta(readout)
+        assert safe.alerts == ()
 
-    def test_returns_empty_for_non_list_alerts(self):
+    def test_returns_empty_alerts_for_non_list_alerts(self):
         readout = _make_readout()
         readout["alerts"] = "not-a-list"
-        assert _extract_numbered_alerts(readout) == []
+        safe = normalize_readout_for_delta(readout)
+        assert safe.alerts == ()
 
-
-# ---------------------------------------------------------------------------
-# Tests: _extract_surface_status
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestExtractSurfaceStatus:
-    def test_returns_status_for_known_source(self):
+    def test_secret_scanning_surface_status_extracted(self):
         readout = _make_readout(secret_scanning_surface_status="redacted")
-        assert _extract_surface_status(readout, "secret_scanning") == "redacted"
+        safe = normalize_readout_for_delta(readout)
+        assert safe.secret_scanning_status == "redacted"
 
-    def test_returns_none_for_unknown_source(self):
+    def test_unknown_surface_status_falls_back(self):
         readout = _make_readout()
-        assert _extract_surface_status(readout, "nonexistent") is None
+        readout["surfaces"] = []
+        safe = normalize_readout_for_delta(readout)
+        assert safe.secret_scanning_status == "unknown"
 
-    def test_returns_none_for_missing_surfaces(self):
-        readout = {"schema_version": "github_security_quality_readout.v1"}
-        assert _extract_surface_status(readout, "code_scanning") is None
+    def test_status_extracted_safely(self):
+        readout = _make_readout(status="PASS")
+        safe = normalize_readout_for_delta(readout)
+        assert safe.status == "PASS"
 
 
 # ---------------------------------------------------------------------------
@@ -186,20 +182,29 @@ class TestComputeDeltaNewAlerts:
     def test_empty_prev_all_current_are_new(self):
         prev = _make_readout(alerts=[])
         current = _make_readout(alerts=[_cs_alert(1), _cs_alert(2)])
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert len(delta.new_alerts) == 2
 
     def test_same_alerts_no_new_alerts(self):
         alerts = [_cs_alert(1), _dep_alert(2)]
         prev = _make_readout(alerts=alerts)
         current = _make_readout(alerts=alerts)
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert delta.new_alerts == []
 
     def test_new_alert_by_number(self):
         prev = _make_readout(alerts=[_cs_alert(1)])
         current = _make_readout(alerts=[_cs_alert(1), _cs_alert(2)])
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert len(delta.new_alerts) == 1
         assert delta.new_alerts[0]["number"] == 2
 
@@ -208,7 +213,10 @@ class TestComputeDeltaNewAlerts:
         current = _make_readout(
             alerts=[_dep_alert(10), _cs_alert(5), _cs_alert(3)]
         )
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         numbers = [(a["source"], a["number"]) for a in delta.new_alerts]
         assert numbers == [("code_scanning", 3), ("code_scanning", 5), ("dependabot", 10)]
 
@@ -220,7 +228,10 @@ class TestComputeDeltaNewAlerts:
                 _cs_alert(1),
             ]
         )
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert len(delta.new_alerts) == 1
         assert delta.new_alerts[0]["source"] == "code_scanning"
 
@@ -236,7 +247,10 @@ class TestComputeDeltaResolvedAlerts:
         alerts = [_cs_alert(1), _cs_alert(2)]
         prev = _make_readout(alerts=alerts)
         current = _make_readout(alerts=alerts)
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert delta.resolved_keys == []
 
     def test_resolved_when_open_alert_disappears_from_current(self):
@@ -245,14 +259,20 @@ class TestComputeDeltaResolvedAlerts:
         current = _make_readout(
             alerts=[_cs_alert(1, state="dismissed"), _cs_alert(2)]
         )
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert len(delta.resolved_keys) == 1
         assert delta.resolved_keys[0] == AlertKey(source="code_scanning", number=1)
 
     def test_alert_missing_from_current_counts_as_resolved(self):
         prev = _make_readout(alerts=[_cs_alert(1)])
         current = _make_readout(alerts=[])
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert any(k.number == 1 for k in delta.resolved_keys)
 
 
@@ -268,34 +288,49 @@ class TestComputeDeltaEscalation:
         current = _make_readout(
             alerts=[_cs_alert(1, severity="critical")]
         )
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert delta.escalation_needed is True
         assert len(delta.escalation_alerts) == 1
 
     def test_new_high_open_alert_triggers_escalation(self):
         prev = _make_readout(alerts=[])
         current = _make_readout(alerts=[_cs_alert(1, severity="high")])
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert delta.escalation_needed is True
 
     def test_codeql_error_severity_triggers_escalation(self):
         # CodeQL uses "error" as its highest severity — maps to escalation.
         prev = _make_readout(alerts=[])
         current = _make_readout(alerts=[_cs_alert(1, severity="error")])
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert delta.escalation_needed is True
 
     def test_new_medium_alert_does_not_escalate(self):
         prev = _make_readout(alerts=[])
         current = _make_readout(alerts=[_cs_alert(1, severity="medium")])
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert delta.escalation_needed is False
         assert delta.escalation_alerts == []
 
     def test_new_low_alert_does_not_escalate(self):
         prev = _make_readout(alerts=[])
         current = _make_readout(alerts=[_dep_alert(1, severity="low")])
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert delta.escalation_needed is False
 
     def test_dismissed_high_alert_does_not_escalate(self):
@@ -304,14 +339,20 @@ class TestComputeDeltaEscalation:
         current = _make_readout(
             alerts=[_cs_alert(1, severity="high", state="dismissed")]
         )
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert delta.escalation_needed is False
 
     def test_pre_existing_high_alert_does_not_escalate(self):
         alert = _cs_alert(1, severity="high")
         prev = _make_readout(alerts=[alert])
         current = _make_readout(alerts=[alert])
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert delta.escalation_needed is False
 
 
@@ -327,7 +368,10 @@ class TestComputeDeltaNewGroups:
         current = _make_readout(
             alerts=[_cs_alert(1, subject="py/rule-a"), _cs_alert(2, subject="py/rule-b")]
         )
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert len(delta.new_groups) == 1
         assert delta.new_groups[0] == AlertGroupKey(
             source="code_scanning", subject="py/rule-b", branch="main"
@@ -337,7 +381,10 @@ class TestComputeDeltaNewGroups:
         alerts = [_cs_alert(1, subject="py/rule-a")]
         prev = _make_readout(alerts=alerts)
         current = _make_readout(alerts=alerts)
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert delta.new_groups == []
 
     def test_same_subject_different_branch_is_new_group(self):
@@ -350,7 +397,10 @@ class TestComputeDeltaNewGroups:
                 _cs_alert(2, subject="py/rule-a", branch="feature/x"),
             ]
         )
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert len(delta.new_groups) == 1
         assert delta.new_groups[0].branch == "feature/x"
 
@@ -365,13 +415,19 @@ class TestComputeDeltaSecretScanning:
     def test_no_change_in_secret_scanning_status(self):
         prev = _make_readout(secret_scanning_surface_status="redacted")
         current = _make_readout(secret_scanning_surface_status="redacted")
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert delta.secret_scanning_status_change is None
 
     def test_secret_scanning_status_change_detected(self):
         prev = _make_readout(secret_scanning_surface_status="ok")
         current = _make_readout(secret_scanning_surface_status="redacted")
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert delta.secret_scanning_status_change is not None
         assert "ok" in delta.secret_scanning_status_change
         assert "redacted" in delta.secret_scanning_status_change
@@ -391,7 +447,10 @@ class TestComputeDeltaSecretScanning:
                 }
             ]
         )
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         # secret_scanning alerts are excluded from new_alerts entirely
         assert delta.new_alerts == []
         assert delta.escalation_needed is False
@@ -399,7 +458,10 @@ class TestComputeDeltaSecretScanning:
     def test_reference_timestamps_captured(self):
         prev = _make_readout(reference_now_utc="2026-05-01T00:00:00Z")
         current = _make_readout(reference_now_utc="2026-05-08T00:00:00Z")
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        delta = compute_delta(
+            prev_safe=normalize_readout_for_delta(prev),
+            current_safe=normalize_readout_for_delta(current),
+        )
         assert delta.prev_reference_now_utc == "2026-05-01T00:00:00Z"
         assert delta.current_reference_now_utc == "2026-05-08T00:00:00Z"
 
@@ -477,13 +539,15 @@ class TestBuildDeltaReport:
             alerts=current_alerts,
             total_alerts=len(current_alerts),
         )
-        delta = compute_delta(prev_readout=prev, current_readout=current)
+        prev_safe = normalize_readout_for_delta(prev)
+        current_safe = normalize_readout_for_delta(current)
+        delta = compute_delta(prev_safe=prev_safe, current_safe=current_safe)
         return build_delta_report(
             prev_path=Path("/prev.json"),
             current_path=Path("/current.json"),
             delta=delta,
-            prev_meta=_safe_readout_meta(prev),
-            current_meta=_safe_readout_meta(current),
+            prev_safe=prev_safe,
+            current_safe=current_safe,
         )
 
     def test_schema_version(self):

--- a/tests/unit/audit/test_security_alert_delta.py
+++ b/tests/unit/audit/test_security_alert_delta.py
@@ -17,7 +17,6 @@ from audit.security_alert_delta import (  # noqa: E402
     AlertGroupKey,
     AlertKey,
     SecurityAlertDeltaError,
-    build_safe_summary_text_from_delta,
     build_delta_report,
     build_markdown_summary,
     compute_delta,
@@ -693,45 +692,6 @@ class TestBuildMarkdownSummary:
 
 
 # ---------------------------------------------------------------------------
-# Tests: build_safe_summary_text_from_delta
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestBuildSafeSummaryTextFromDelta:
-    def test_excludes_secret_scanning_payload_details(self):
-        prev = normalize_readout_for_delta(
-            _make_readout(alerts=[], secret_scanning_surface_status="ok")
-        )
-        current = normalize_readout_for_delta(
-            _make_readout(
-                alerts=[
-                    {
-                        "source": "secret_scanning",
-                        "number": 5,
-                        "state": "open",
-                        "secret_type": "github_pat",
-                        "secret": "ghp_SENSITIVE",
-                        "locations_url": "https://api.github.com/...",
-                    }
-                ],
-                secret_scanning_surface_status="redacted",
-            )
-        )
-        delta = compute_delta(prev_safe=prev, current_safe=current)
-
-        summary = build_safe_summary_text_from_delta(
-            delta=delta,
-            prev_safe=prev,
-            current_safe=current,
-        )
-
-        assert "ghp_SENSITIVE" not in summary
-        assert "locations_url" not in summary
-        assert "Secret scanning surface change" in summary
-
-
-# ---------------------------------------------------------------------------
 # Tests: generate_delta (integration, uses tmp_path)
 # ---------------------------------------------------------------------------
 
@@ -742,20 +702,19 @@ class TestGenerateDelta:
         path.write_text(json.dumps(readout), encoding="utf-8")
         return path
 
-    def test_writes_json_and_md_to_out_dir(self, tmp_path: Path):
+    def test_writes_json_only_to_out_dir(self, tmp_path: Path):
         prev_path = self._write_readout(tmp_path / "prev.json", _make_readout(alerts=[]))
         current_path = self._write_readout(
             tmp_path / "current.json", _make_readout(alerts=[_cs_alert(1)])
         )
         out_dir = tmp_path / "output"
-        report, summary_text = generate_delta(
+        report = generate_delta(
             prev_path=prev_path, current_path=current_path, out_dir=out_dir
         )
 
         assert (out_dir / "security_alert_delta.json").exists()
-        assert (out_dir / "security_alert_delta.md").exists()
+        assert not (out_dir / "security_alert_delta.md").exists()
         assert report["new_alert_count"] == 1
-        assert summary_text == (out_dir / "security_alert_delta.md").read_text()
 
     def test_json_output_is_valid_schema_version(self, tmp_path: Path):
         prev_path = self._write_readout(tmp_path / "prev.json", _make_readout(alerts=[]))
@@ -774,11 +733,10 @@ class TestGenerateDelta:
             tmp_path / "current.json",
             _make_readout(alerts=[_cs_alert(99, severity="critical")]),
         )
-        report, summary_text = generate_delta(
+        report = generate_delta(
             prev_path=prev_path, current_path=current_path, out_dir=None
         )
         assert report["escalation_needed"] is True
-        assert "ESCALATION" in summary_text
 
     def test_raises_on_missing_prev(self, tmp_path: Path):
         current_path = self._write_readout(
@@ -794,13 +752,11 @@ class TestGenerateDelta:
         current_path = self._write_readout(
             tmp_path / "current.json", _make_readout(alerts=[])
         )
-        report, summary_text = generate_delta(
-            prev_path=prev_path, current_path=current_path, out_dir=None
-        )
+        report = generate_delta(prev_path=prev_path, current_path=current_path, out_dir=None)
         # No unexpected files written
         assert not (tmp_path / "security_alert_delta.json").exists()
+        assert not (tmp_path / "security_alert_delta.md").exists()
         assert report["schema_version"] == SCHEMA_VERSION
-        assert "Security Alert Delta" in summary_text
 
 
 # ---------------------------------------------------------------------------
@@ -814,7 +770,7 @@ class TestMain:
         path.write_text(json.dumps(readout), encoding="utf-8")
         return path
 
-    def test_returns_0_when_no_escalation(self, tmp_path: Path):
+    def test_returns_0_when_no_escalation(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]):
         prev_path = self._write_readout(tmp_path / "prev.json", _make_readout(alerts=[]))
         current_path = self._write_readout(
             tmp_path / "current.json", _make_readout(alerts=[_cs_alert(1, severity="low")])
@@ -823,7 +779,10 @@ class TestMain:
             "--prev-readout", str(prev_path),
             "--current-readout", str(current_path),
         ])
+        captured = capsys.readouterr()
         assert exit_code == 0
+        assert captured.out.strip() == "security alert delta json artifact generated"
+        assert "Security Alert Delta" not in captured.out
 
     def test_returns_2_when_escalation_needed(self, tmp_path: Path):
         prev_path = self._write_readout(tmp_path / "prev.json", _make_readout(alerts=[]))
@@ -857,3 +816,4 @@ class TestMain:
             "--out-dir", str(out_dir),
         ])
         assert (out_dir / "security_alert_delta.json").exists()
+        assert not (out_dir / "security_alert_delta.md").exists()

--- a/tests/unit/audit/test_security_alert_delta.py
+++ b/tests/unit/audit/test_security_alert_delta.py
@@ -13,14 +13,13 @@ sys.path.insert(0, str(repo_root / "scripts"))
 sys.path.insert(0, str(repo_root))
 
 from audit.security_alert_delta import (  # noqa: E402
-    ESCALATION_SEVERITIES,
     SCHEMA_VERSION,
     AlertGroupKey,
     AlertKey,
-    DeltaResult,
     SecurityAlertDeltaError,
     _extract_numbered_alerts,
     _extract_surface_status,
+    _safe_readout_meta,
     build_delta_report,
     build_markdown_summary,
     compute_delta,
@@ -483,8 +482,8 @@ class TestBuildDeltaReport:
             prev_path=Path("/prev.json"),
             current_path=Path("/current.json"),
             delta=delta,
-            prev_readout=prev,
-            current_readout=current,
+            prev_meta=_safe_readout_meta(prev),
+            current_meta=_safe_readout_meta(current),
         )
 
     def test_schema_version(self):

--- a/tests/unit/audit/test_security_alert_delta.py
+++ b/tests/unit/audit/test_security_alert_delta.py
@@ -17,6 +17,7 @@ from audit.security_alert_delta import (  # noqa: E402
     AlertGroupKey,
     AlertKey,
     SecurityAlertDeltaError,
+    build_safe_summary_text_from_delta,
     build_delta_report,
     build_markdown_summary,
     compute_delta,
@@ -692,6 +693,45 @@ class TestBuildMarkdownSummary:
 
 
 # ---------------------------------------------------------------------------
+# Tests: build_safe_summary_text_from_delta
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuildSafeSummaryTextFromDelta:
+    def test_excludes_secret_scanning_payload_details(self):
+        prev = normalize_readout_for_delta(
+            _make_readout(alerts=[], secret_scanning_surface_status="ok")
+        )
+        current = normalize_readout_for_delta(
+            _make_readout(
+                alerts=[
+                    {
+                        "source": "secret_scanning",
+                        "number": 5,
+                        "state": "open",
+                        "secret_type": "github_pat",
+                        "secret": "ghp_SENSITIVE",
+                        "locations_url": "https://api.github.com/...",
+                    }
+                ],
+                secret_scanning_surface_status="redacted",
+            )
+        )
+        delta = compute_delta(prev_safe=prev, current_safe=current)
+
+        summary = build_safe_summary_text_from_delta(
+            delta=delta,
+            prev_safe=prev,
+            current_safe=current,
+        )
+
+        assert "ghp_SENSITIVE" not in summary
+        assert "locations_url" not in summary
+        assert "Secret scanning surface change" in summary
+
+
+# ---------------------------------------------------------------------------
 # Tests: generate_delta (integration, uses tmp_path)
 # ---------------------------------------------------------------------------
 
@@ -708,13 +748,14 @@ class TestGenerateDelta:
             tmp_path / "current.json", _make_readout(alerts=[_cs_alert(1)])
         )
         out_dir = tmp_path / "output"
-        report = generate_delta(
+        report, summary_text = generate_delta(
             prev_path=prev_path, current_path=current_path, out_dir=out_dir
         )
 
         assert (out_dir / "security_alert_delta.json").exists()
         assert (out_dir / "security_alert_delta.md").exists()
         assert report["new_alert_count"] == 1
+        assert summary_text == (out_dir / "security_alert_delta.md").read_text()
 
     def test_json_output_is_valid_schema_version(self, tmp_path: Path):
         prev_path = self._write_readout(tmp_path / "prev.json", _make_readout(alerts=[]))
@@ -733,10 +774,11 @@ class TestGenerateDelta:
             tmp_path / "current.json",
             _make_readout(alerts=[_cs_alert(99, severity="critical")]),
         )
-        report = generate_delta(
+        report, summary_text = generate_delta(
             prev_path=prev_path, current_path=current_path, out_dir=None
         )
         assert report["escalation_needed"] is True
+        assert "ESCALATION" in summary_text
 
     def test_raises_on_missing_prev(self, tmp_path: Path):
         current_path = self._write_readout(
@@ -752,9 +794,13 @@ class TestGenerateDelta:
         current_path = self._write_readout(
             tmp_path / "current.json", _make_readout(alerts=[])
         )
-        generate_delta(prev_path=prev_path, current_path=current_path, out_dir=None)
+        report, summary_text = generate_delta(
+            prev_path=prev_path, current_path=current_path, out_dir=None
+        )
         # No unexpected files written
         assert not (tmp_path / "security_alert_delta.json").exists()
+        assert report["schema_version"] == SCHEMA_VERSION
+        assert "Security Alert Delta" in summary_text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/audit/test_security_alert_delta.py
+++ b/tests/unit/audit/test_security_alert_delta.py
@@ -1,0 +1,750 @@
+"""Tests for scripts.audit.security_alert_delta."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+repo_root = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(repo_root / "scripts"))
+sys.path.insert(0, str(repo_root))
+
+from audit.security_alert_delta import (  # noqa: E402
+    ESCALATION_SEVERITIES,
+    SCHEMA_VERSION,
+    AlertGroupKey,
+    AlertKey,
+    DeltaResult,
+    SecurityAlertDeltaError,
+    _extract_numbered_alerts,
+    _extract_surface_status,
+    build_delta_report,
+    build_markdown_summary,
+    compute_delta,
+    generate_delta,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal readout fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_readout(
+    *,
+    reference_now_utc: str = "2026-05-01T00:00:00Z",
+    status: str = "PASS",
+    total_alerts: int = 0,
+    alerts: list[dict] | None = None,
+    secret_scanning_surface_status: str = "redacted",
+) -> dict:
+    """Build a minimal github_security_quality_readout.v1 dict for testing."""
+    return {
+        "schema_version": "github_security_quality_readout.v1",
+        "repo": "test/repo",
+        "reference_now_utc": reference_now_utc,
+        "status": status,
+        "summary": {"total_alerts": total_alerts},
+        "alerts": alerts or [],
+        "surfaces": [
+            {"source": "code_scanning", "status": "ok"},
+            {"source": "dependabot", "status": "ok"},
+            {"source": "secret_scanning", "status": secret_scanning_surface_status},
+        ],
+    }
+
+
+def _cs_alert(
+    number: int,
+    *,
+    state: str = "open",
+    severity: str = "medium",
+    subject: str = "py/test-rule",
+    branch: str = "main",
+    affected_component: str = "app/test.py",
+) -> dict:
+    """Build a minimal code_scanning alert dict."""
+    return {
+        "source": "code_scanning",
+        "number": number,
+        "state": state,
+        "severity": severity,
+        "subject": subject,
+        "rule_or_advisory": subject,
+        "package": None,
+        "affected_path": affected_component,
+        "affected_component": affected_component,
+        "branch": branch,
+        "created_at": "2026-04-01T00:00:00Z",
+        "updated_at": "2026-04-01T00:00:00Z",
+        "age_bucket": "1-30d",
+        "url": f"https://github.invalid/code/{number}",
+        "tool": "CodeQL",
+    }
+
+
+def _dep_alert(
+    number: int,
+    *,
+    state: str = "open",
+    severity: str = "medium",
+    subject: str = "lodash",
+    branch: str = "main",
+) -> dict:
+    """Build a minimal dependabot alert dict."""
+    return {
+        "source": "dependabot",
+        "number": number,
+        "state": state,
+        "severity": severity,
+        "subject": subject,
+        "rule_or_advisory": "GHSA-test-1234-5678",
+        "package": subject,
+        "affected_path": None,
+        "affected_component": subject,
+        "branch": branch,
+        "created_at": "2026-04-01T00:00:00Z",
+        "updated_at": "2026-04-01T00:00:00Z",
+        "age_bucket": "1-30d",
+        "url": f"https://github.invalid/dep/{number}",
+        "tool": "Dependabot",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: _extract_numbered_alerts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractNumberedAlerts:
+    def test_excludes_secret_scanning(self):
+        readout = _make_readout(
+            alerts=[
+                _cs_alert(1),
+                {"source": "secret_scanning", "number": 99, "state": "open"},
+            ]
+        )
+        result = _extract_numbered_alerts(readout)
+        assert len(result) == 1
+        assert result[0]["source"] == "code_scanning"
+
+    def test_excludes_alerts_without_integer_number(self):
+        readout = _make_readout(
+            alerts=[
+                {**_cs_alert(1), "number": "not-an-int"},
+                _dep_alert(2),
+            ]
+        )
+        result = _extract_numbered_alerts(readout)
+        assert len(result) == 1
+        assert result[0]["number"] == 2
+
+    def test_returns_empty_for_missing_alerts_key(self):
+        readout = {
+            "schema_version": "github_security_quality_readout.v1",
+            "reference_now_utc": "2026-05-01T00:00:00Z",
+        }
+        assert _extract_numbered_alerts(readout) == []
+
+    def test_returns_empty_for_non_list_alerts(self):
+        readout = _make_readout()
+        readout["alerts"] = "not-a-list"
+        assert _extract_numbered_alerts(readout) == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: _extract_surface_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractSurfaceStatus:
+    def test_returns_status_for_known_source(self):
+        readout = _make_readout(secret_scanning_surface_status="redacted")
+        assert _extract_surface_status(readout, "secret_scanning") == "redacted"
+
+    def test_returns_none_for_unknown_source(self):
+        readout = _make_readout()
+        assert _extract_surface_status(readout, "nonexistent") is None
+
+    def test_returns_none_for_missing_surfaces(self):
+        readout = {"schema_version": "github_security_quality_readout.v1"}
+        assert _extract_surface_status(readout, "code_scanning") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: compute_delta — new alerts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestComputeDeltaNewAlerts:
+    def test_empty_prev_all_current_are_new(self):
+        prev = _make_readout(alerts=[])
+        current = _make_readout(alerts=[_cs_alert(1), _cs_alert(2)])
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert len(delta.new_alerts) == 2
+
+    def test_same_alerts_no_new_alerts(self):
+        alerts = [_cs_alert(1), _dep_alert(2)]
+        prev = _make_readout(alerts=alerts)
+        current = _make_readout(alerts=alerts)
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert delta.new_alerts == []
+
+    def test_new_alert_by_number(self):
+        prev = _make_readout(alerts=[_cs_alert(1)])
+        current = _make_readout(alerts=[_cs_alert(1), _cs_alert(2)])
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert len(delta.new_alerts) == 1
+        assert delta.new_alerts[0]["number"] == 2
+
+    def test_new_alerts_sorted_by_source_then_number(self):
+        prev = _make_readout(alerts=[])
+        current = _make_readout(
+            alerts=[_dep_alert(10), _cs_alert(5), _cs_alert(3)]
+        )
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        numbers = [(a["source"], a["number"]) for a in delta.new_alerts]
+        assert numbers == [("code_scanning", 3), ("code_scanning", 5), ("dependabot", 10)]
+
+    def test_secret_scanning_alerts_not_counted_as_new(self):
+        prev = _make_readout(alerts=[])
+        current = _make_readout(
+            alerts=[
+                {"source": "secret_scanning", "number": 99, "state": "open"},
+                _cs_alert(1),
+            ]
+        )
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert len(delta.new_alerts) == 1
+        assert delta.new_alerts[0]["source"] == "code_scanning"
+
+
+# ---------------------------------------------------------------------------
+# Tests: compute_delta — resolved alerts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestComputeDeltaResolvedAlerts:
+    def test_no_resolved_when_all_still_open(self):
+        alerts = [_cs_alert(1), _cs_alert(2)]
+        prev = _make_readout(alerts=alerts)
+        current = _make_readout(alerts=alerts)
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert delta.resolved_keys == []
+
+    def test_resolved_when_open_alert_disappears_from_current(self):
+        prev = _make_readout(alerts=[_cs_alert(1), _cs_alert(2)])
+        # Alert 1 is now dismissed (state="dismissed"), alert 2 still open
+        current = _make_readout(
+            alerts=[_cs_alert(1, state="dismissed"), _cs_alert(2)]
+        )
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert len(delta.resolved_keys) == 1
+        assert delta.resolved_keys[0] == AlertKey(source="code_scanning", number=1)
+
+    def test_alert_missing_from_current_counts_as_resolved(self):
+        prev = _make_readout(alerts=[_cs_alert(1)])
+        current = _make_readout(alerts=[])
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert any(k.number == 1 for k in delta.resolved_keys)
+
+
+# ---------------------------------------------------------------------------
+# Tests: compute_delta — escalation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestComputeDeltaEscalation:
+    def test_new_critical_open_alert_triggers_escalation(self):
+        prev = _make_readout(alerts=[])
+        current = _make_readout(
+            alerts=[_cs_alert(1, severity="critical")]
+        )
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert delta.escalation_needed is True
+        assert len(delta.escalation_alerts) == 1
+
+    def test_new_high_open_alert_triggers_escalation(self):
+        prev = _make_readout(alerts=[])
+        current = _make_readout(alerts=[_cs_alert(1, severity="high")])
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert delta.escalation_needed is True
+
+    def test_codeql_error_severity_triggers_escalation(self):
+        # CodeQL uses "error" as its highest severity — maps to escalation.
+        prev = _make_readout(alerts=[])
+        current = _make_readout(alerts=[_cs_alert(1, severity="error")])
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert delta.escalation_needed is True
+
+    def test_new_medium_alert_does_not_escalate(self):
+        prev = _make_readout(alerts=[])
+        current = _make_readout(alerts=[_cs_alert(1, severity="medium")])
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert delta.escalation_needed is False
+        assert delta.escalation_alerts == []
+
+    def test_new_low_alert_does_not_escalate(self):
+        prev = _make_readout(alerts=[])
+        current = _make_readout(alerts=[_dep_alert(1, severity="low")])
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert delta.escalation_needed is False
+
+    def test_dismissed_high_alert_does_not_escalate(self):
+        # New alert (not in prev) but state=dismissed — no escalation.
+        prev = _make_readout(alerts=[])
+        current = _make_readout(
+            alerts=[_cs_alert(1, severity="high", state="dismissed")]
+        )
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert delta.escalation_needed is False
+
+    def test_pre_existing_high_alert_does_not_escalate(self):
+        alert = _cs_alert(1, severity="high")
+        prev = _make_readout(alerts=[alert])
+        current = _make_readout(alerts=[alert])
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert delta.escalation_needed is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: compute_delta — new groups
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestComputeDeltaNewGroups:
+    def test_new_group_detected_for_new_subject(self):
+        prev = _make_readout(alerts=[_cs_alert(1, subject="py/rule-a")])
+        current = _make_readout(
+            alerts=[_cs_alert(1, subject="py/rule-a"), _cs_alert(2, subject="py/rule-b")]
+        )
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert len(delta.new_groups) == 1
+        assert delta.new_groups[0] == AlertGroupKey(
+            source="code_scanning", subject="py/rule-b", branch="main"
+        )
+
+    def test_no_new_groups_when_same_subjects(self):
+        alerts = [_cs_alert(1, subject="py/rule-a")]
+        prev = _make_readout(alerts=alerts)
+        current = _make_readout(alerts=alerts)
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert delta.new_groups == []
+
+    def test_same_subject_different_branch_is_new_group(self):
+        prev = _make_readout(
+            alerts=[_cs_alert(1, subject="py/rule-a", branch="main")]
+        )
+        current = _make_readout(
+            alerts=[
+                _cs_alert(1, subject="py/rule-a", branch="main"),
+                _cs_alert(2, subject="py/rule-a", branch="feature/x"),
+            ]
+        )
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert len(delta.new_groups) == 1
+        assert delta.new_groups[0].branch == "feature/x"
+
+
+# ---------------------------------------------------------------------------
+# Tests: compute_delta — secret scanning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestComputeDeltaSecretScanning:
+    def test_no_change_in_secret_scanning_status(self):
+        prev = _make_readout(secret_scanning_surface_status="redacted")
+        current = _make_readout(secret_scanning_surface_status="redacted")
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert delta.secret_scanning_status_change is None
+
+    def test_secret_scanning_status_change_detected(self):
+        prev = _make_readout(secret_scanning_surface_status="ok")
+        current = _make_readout(secret_scanning_surface_status="redacted")
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert delta.secret_scanning_status_change is not None
+        assert "ok" in delta.secret_scanning_status_change
+        assert "redacted" in delta.secret_scanning_status_change
+
+    def test_secret_scanning_payload_never_in_delta(self):
+        """Secret-scanning alert fields must never appear in delta output."""
+        prev = _make_readout(alerts=[])
+        current = _make_readout(
+            alerts=[
+                {
+                    "source": "secret_scanning",
+                    "number": 5,
+                    "state": "open",
+                    "secret_type": "github_pat",
+                    "secret": "ghp_SENSITIVE",
+                    "locations_url": "https://api.github.com/...",
+                }
+            ]
+        )
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        # secret_scanning alerts are excluded from new_alerts entirely
+        assert delta.new_alerts == []
+        assert delta.escalation_needed is False
+
+    def test_reference_timestamps_captured(self):
+        prev = _make_readout(reference_now_utc="2026-05-01T00:00:00Z")
+        current = _make_readout(reference_now_utc="2026-05-08T00:00:00Z")
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        assert delta.prev_reference_now_utc == "2026-05-01T00:00:00Z"
+        assert delta.current_reference_now_utc == "2026-05-08T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _load_readout / SecurityAlertDeltaError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLoadReadout:
+    def test_raises_on_missing_file(self, tmp_path: Path):
+        from audit.security_alert_delta import _load_readout
+
+        with pytest.raises(SecurityAlertDeltaError, match="Cannot read"):
+            _load_readout(tmp_path / "nonexistent.json")
+
+    def test_raises_on_invalid_json(self, tmp_path: Path):
+        from audit.security_alert_delta import _load_readout
+
+        bad = tmp_path / "bad.json"
+        bad.write_text("{ not json", encoding="utf-8")
+        with pytest.raises(SecurityAlertDeltaError, match="Invalid JSON"):
+            _load_readout(bad)
+
+    def test_raises_on_wrong_schema_version(self, tmp_path: Path):
+        from audit.security_alert_delta import _load_readout
+
+        wrong = tmp_path / "wrong.json"
+        wrong.write_text(
+            json.dumps({"schema_version": "some_other_schema.v1"}), encoding="utf-8"
+        )
+        with pytest.raises(SecurityAlertDeltaError, match="schema_version"):
+            _load_readout(wrong)
+
+    def test_raises_on_non_dict_root(self, tmp_path: Path):
+        from audit.security_alert_delta import _load_readout
+
+        arr = tmp_path / "arr.json"
+        arr.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+        with pytest.raises(SecurityAlertDeltaError, match="JSON object"):
+            _load_readout(arr)
+
+    def test_accepts_valid_readout(self, tmp_path: Path):
+        from audit.security_alert_delta import _load_readout
+
+        valid = tmp_path / "valid.json"
+        valid.write_text(
+            json.dumps(_make_readout()), encoding="utf-8"
+        )
+        result = _load_readout(valid)
+        assert result["schema_version"] == "github_security_quality_readout.v1"
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_delta_report
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuildDeltaReport:
+    def _run(
+        self,
+        prev_alerts: list[dict],
+        current_alerts: list[dict],
+        *,
+        prev_utc: str = "2026-05-01T00:00:00Z",
+        current_utc: str = "2026-05-08T00:00:00Z",
+    ) -> dict:
+        prev = _make_readout(
+            reference_now_utc=prev_utc, alerts=prev_alerts, total_alerts=len(prev_alerts)
+        )
+        current = _make_readout(
+            reference_now_utc=current_utc,
+            alerts=current_alerts,
+            total_alerts=len(current_alerts),
+        )
+        delta = compute_delta(prev_readout=prev, current_readout=current)
+        return build_delta_report(
+            prev_path=Path("/prev.json"),
+            current_path=Path("/current.json"),
+            delta=delta,
+            prev_readout=prev,
+            current_readout=current,
+        )
+
+    def test_schema_version(self):
+        report = self._run([], [])
+        assert report["schema_version"] == SCHEMA_VERSION
+
+    def test_escalation_needed_flag_false_when_no_critical_high(self):
+        report = self._run([], [_cs_alert(1, severity="medium")])
+        assert report["escalation_needed"] is False
+        assert report["escalation_alert_count"] == 0
+
+    def test_escalation_needed_flag_true_for_new_critical(self):
+        report = self._run([], [_cs_alert(1, severity="critical")])
+        assert report["escalation_needed"] is True
+        assert report["escalation_alert_count"] == 1
+
+    def test_new_alert_count_matches(self):
+        report = self._run([], [_cs_alert(1), _dep_alert(2)])
+        assert report["new_alert_count"] == 2
+
+    def test_new_alerts_have_required_fields(self):
+        report = self._run([], [_cs_alert(42, severity="high")])
+        alert = report["new_alerts"][0]
+        assert "source" in alert
+        assert "number" in alert
+        assert "state" in alert
+        assert "severity" in alert
+        assert "subject" in alert
+        assert "branch" in alert
+        assert "affected_component" in alert
+
+    def test_no_secret_payload_in_report(self):
+        report = self._run(
+            [],
+            [{"source": "secret_scanning", "number": 1, "secret": "SENSITIVE"}],
+        )
+        # secret_scanning alert must not appear in new_alerts
+        for a in report["new_alerts"]:
+            assert "secret" not in a
+        assert report["new_alert_count"] == 0
+
+    def test_reference_timestamps_in_report(self):
+        report = self._run([], [], prev_utc="2026-05-01T00:00:00Z", current_utc="2026-05-08T00:00:00Z")
+        assert report["prev_readout"]["reference_now_utc"] == "2026-05-01T00:00:00Z"
+        assert report["current_readout"]["reference_now_utc"] == "2026-05-08T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_markdown_summary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuildMarkdownSummary:
+    def _make_report(
+        self,
+        *,
+        escalation_needed: bool = False,
+        escalation_alerts: list[dict] | None = None,
+        new_alert_count: int = 0,
+        new_alerts: list[dict] | None = None,
+        resolved_alert_count: int = 0,
+        resolved_alerts: list[dict] | None = None,
+        new_group_count: int = 0,
+        new_groups: list[dict] | None = None,
+        secret_scanning_status_change: str | None = None,
+    ) -> dict:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "prev_readout": {
+                "path": "/prev.json",
+                "reference_now_utc": "2026-05-01T00:00:00Z",
+                "status": "PASS",
+                "total_alerts": 100,
+            },
+            "current_readout": {
+                "path": "/current.json",
+                "reference_now_utc": "2026-05-08T00:00:00Z",
+                "status": "PASS",
+                "total_alerts": 100 + new_alert_count - resolved_alert_count,
+            },
+            "new_alert_count": new_alert_count,
+            "new_alerts": new_alerts or [],
+            "resolved_alert_count": resolved_alert_count,
+            "resolved_alerts": resolved_alerts or [],
+            "new_group_count": new_group_count,
+            "new_groups": new_groups or [],
+            "escalation_needed": escalation_needed,
+            "escalation_alert_count": len(escalation_alerts or []),
+            "escalation_alerts": escalation_alerts or [],
+            "secret_scanning_status_change": secret_scanning_status_change,
+        }
+
+    def test_escalation_warning_present_when_needed(self):
+        report = self._make_report(
+            escalation_needed=True,
+            escalation_alerts=[
+                {"source": "code_scanning", "number": 1, "severity": "critical", "subject": "py/sql-injection", "branch": "main"}
+            ],
+        )
+        md = build_markdown_summary(report)
+        assert "ESCALATION" in md
+
+    def test_no_escalation_message_when_not_needed(self):
+        report = self._make_report(escalation_needed=False)
+        md = build_markdown_summary(report)
+        assert "ESCALATION" not in md
+        assert "No new Critical/High" in md
+
+    def test_new_groups_table_present_when_groups_exist(self):
+        report = self._make_report(
+            new_group_count=1,
+            new_groups=[{"source": "code_scanning", "subject": "py/rule-a", "branch": "main"}],
+        )
+        md = build_markdown_summary(report)
+        assert "New Alert Groups" in md
+        assert "py/rule-a" in md
+
+    def test_no_new_groups_table_when_none(self):
+        report = self._make_report(new_group_count=0, new_groups=[])
+        md = build_markdown_summary(report)
+        assert "New Alert Groups" not in md
+
+    def test_secret_scanning_status_change_mentioned(self):
+        report = self._make_report(
+            secret_scanning_status_change="prev=ok → current=redacted"
+        )
+        md = build_markdown_summary(report)
+        assert "prev=ok" in md
+
+    def test_secret_scanning_not_mentioned_when_no_change(self):
+        report = self._make_report(secret_scanning_status_change=None)
+        md = build_markdown_summary(report)
+        # The line about secret scanning status change should not appear
+        assert "Secret scanning surface change" not in md
+
+    def test_contains_reference_timestamps(self):
+        report = self._make_report()
+        md = build_markdown_summary(report)
+        assert "2026-05-01T00:00:00Z" in md
+        assert "2026-05-08T00:00:00Z" in md
+
+
+# ---------------------------------------------------------------------------
+# Tests: generate_delta (integration, uses tmp_path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGenerateDelta:
+    def _write_readout(self, path: Path, readout: dict) -> Path:
+        path.write_text(json.dumps(readout), encoding="utf-8")
+        return path
+
+    def test_writes_json_and_md_to_out_dir(self, tmp_path: Path):
+        prev_path = self._write_readout(tmp_path / "prev.json", _make_readout(alerts=[]))
+        current_path = self._write_readout(
+            tmp_path / "current.json", _make_readout(alerts=[_cs_alert(1)])
+        )
+        out_dir = tmp_path / "output"
+        report = generate_delta(
+            prev_path=prev_path, current_path=current_path, out_dir=out_dir
+        )
+
+        assert (out_dir / "security_alert_delta.json").exists()
+        assert (out_dir / "security_alert_delta.md").exists()
+        assert report["new_alert_count"] == 1
+
+    def test_json_output_is_valid_schema_version(self, tmp_path: Path):
+        prev_path = self._write_readout(tmp_path / "prev.json", _make_readout(alerts=[]))
+        current_path = self._write_readout(
+            tmp_path / "current.json", _make_readout(alerts=[])
+        )
+        out_dir = tmp_path / "output"
+        generate_delta(prev_path=prev_path, current_path=current_path, out_dir=out_dir)
+
+        loaded = json.loads((out_dir / "security_alert_delta.json").read_text())
+        assert loaded["schema_version"] == SCHEMA_VERSION
+
+    def test_escalation_reflected_in_report(self, tmp_path: Path):
+        prev_path = self._write_readout(tmp_path / "prev.json", _make_readout(alerts=[]))
+        current_path = self._write_readout(
+            tmp_path / "current.json",
+            _make_readout(alerts=[_cs_alert(99, severity="critical")]),
+        )
+        report = generate_delta(
+            prev_path=prev_path, current_path=current_path, out_dir=None
+        )
+        assert report["escalation_needed"] is True
+
+    def test_raises_on_missing_prev(self, tmp_path: Path):
+        current_path = self._write_readout(
+            tmp_path / "current.json", _make_readout(alerts=[])
+        )
+        with pytest.raises(SecurityAlertDeltaError, match="Cannot read"):
+            generate_delta(
+                prev_path=tmp_path / "nonexistent.json", current_path=current_path
+            )
+
+    def test_no_out_dir_does_not_write_files(self, tmp_path: Path):
+        prev_path = self._write_readout(tmp_path / "prev.json", _make_readout(alerts=[]))
+        current_path = self._write_readout(
+            tmp_path / "current.json", _make_readout(alerts=[])
+        )
+        generate_delta(prev_path=prev_path, current_path=current_path, out_dir=None)
+        # No unexpected files written
+        assert not (tmp_path / "security_alert_delta.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Tests: main() CLI
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMain:
+    def _write_readout(self, path: Path, readout: dict) -> Path:
+        path.write_text(json.dumps(readout), encoding="utf-8")
+        return path
+
+    def test_returns_0_when_no_escalation(self, tmp_path: Path):
+        prev_path = self._write_readout(tmp_path / "prev.json", _make_readout(alerts=[]))
+        current_path = self._write_readout(
+            tmp_path / "current.json", _make_readout(alerts=[_cs_alert(1, severity="low")])
+        )
+        exit_code = main([
+            "--prev-readout", str(prev_path),
+            "--current-readout", str(current_path),
+        ])
+        assert exit_code == 0
+
+    def test_returns_2_when_escalation_needed(self, tmp_path: Path):
+        prev_path = self._write_readout(tmp_path / "prev.json", _make_readout(alerts=[]))
+        current_path = self._write_readout(
+            tmp_path / "current.json",
+            _make_readout(alerts=[_cs_alert(1, severity="critical")]),
+        )
+        exit_code = main([
+            "--prev-readout", str(prev_path),
+            "--current-readout", str(current_path),
+        ])
+        assert exit_code == 2
+
+    def test_returns_1_on_missing_file(self, tmp_path: Path):
+        prev_path = self._write_readout(tmp_path / "prev.json", _make_readout(alerts=[]))
+        exit_code = main([
+            "--prev-readout", str(prev_path),
+            "--current-readout", str(tmp_path / "missing.json"),
+        ])
+        assert exit_code == 1
+
+    def test_writes_out_dir_when_provided(self, tmp_path: Path):
+        prev_path = self._write_readout(tmp_path / "prev.json", _make_readout(alerts=[]))
+        current_path = self._write_readout(
+            tmp_path / "current.json", _make_readout(alerts=[])
+        )
+        out_dir = tmp_path / "out"
+        main([
+            "--prev-readout", str(prev_path),
+            "--current-readout", str(current_path),
+            "--out-dir", str(out_dir),
+        ])
+        assert (out_dir / "security_alert_delta.json").exists()


### PR DESCRIPTION
## Summary

Adds the first repo-backed automation slice for #2289:

- new read-only alert delta comparator with `security_alert_delta.v1`
- scheduled/manual security alert readout workflow
- dry-run schedule by default: artifact + step summary only
- manual `workflow_dispatch` publish mode for explicit operator-driven report persistence
- tests for delta classification, dedupe, escalation, and secret-surface redaction
- TRIAGE_RUNBOOK update for operating the workflow

## Governance / Safety

- No issue creation/update/close in this slice
- No alert dismissals
- No remediation changes
- No Trivy/#2290 fix attempt
- Secret scanning stays redacted; no payloads in delta output
- Scheduled runs use `dry_run`
- Repo-write publish mode is manual-only via `workflow_dispatch`
- No runtime, trading, LR, or Echtgeld behavior changed

## Validation

- `ruff check scripts/audit/security_alert_delta.py tests/unit/audit/test_security_alert_delta.py`
- `pytest -q -m unit tests/unit/audit/test_security_alert_delta.py`
- `pytest -q tests/unit/audit/test_github_security_quality_readout.py`

Refs #2289.