### PR TITLE
fix(security): disable direct publish in alert readout workflow

### DIFF
--- a/.github/workflows/security-alert-readout.yml
+++ b/.github/workflows/security-alert-readout.yml
@@ -4,6 +4,14 @@ name: Security Alert Readout
 # dependabot, secret_scanning) and computes a delta against the most recent
 # previous readout.  Runs Mon/Wed/Fri; always available for manual dispatch.
 #
+# Artifacts-only mode: readout and delta are uploaded as GitHub Actions
+# artifacts (retention: 30 days).  No direct commit to main is attempted.
+# Repository persistence requires a separate PR-based follow-up slice.
+#
+# Background: the direct-push publish path was removed after run 25632071704
+# failed with GH006 (protected branch — changes must be made via PR).  See
+# fix/security-readout-disable-direct-publish-2289 for details.
+#
 # Refs: #2289 (security alert monitoring epic)
 # Related scripts:
 #   scripts/audit/github_security_quality_readout.py  (read-only fetcher)
@@ -17,16 +25,15 @@ on:
   workflow_dispatch:
     inputs:
       publish_mode:
-        description: "dry_run: artifact only | publish: commit readout to repo"
-        required: true
+        description: "artifacts-only (dry_run); repo persistence requires a separate PR-based slice"
+        required: false
         default: dry_run
         type: choice
         options:
           - dry_run
-          - publish
 
 permissions:
-  contents: write          # needed for git commit in publish mode
+  contents: read           # no repo writes; read-only checkout
   security-events: read    # code_scanning alert API
 
 concurrency:
@@ -58,13 +65,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            publish_mode="${{ inputs.publish_mode }}"
-          else
-            # Scheduled runs produce artifact + step summary only.
-            # To persist readouts to the repo, use workflow_dispatch → publish.
-            publish_mode="dry_run"
-          fi
+          # Publish mode is always dry_run (artifacts-only).
+          # Direct push to main is not compatible with branch protection.
+          # Repository persistence requires a separate PR-based follow-up slice.
+          publish_mode="dry_run"
 
           date_dir="docs/security/readouts/$(date -u +%Y-%m-%d)"
 
@@ -203,26 +207,6 @@ jobs:
               >> "$GITHUB_STEP_SUMMARY"
             echo "::warning::Security Alert Readout: escalation_needed=true — new Critical/High open alerts found."
           fi
-
-      - name: Commit readout to repository
-        if: steps.resolve.outputs.publish_mode == 'publish'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          date_dir="${{ steps.resolve.outputs.date_dir }}"
-
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git add "$date_dir"
-          if git diff --cached --quiet; then
-            echo "No changes to commit (readout unchanged)."
-            exit 0
-          fi
-
-          git commit -m "chore(security): readout $(date -u +%Y-%m-%d) [skip ci]"
-          git push
 
       - name: Upload readout artifact
         if: always()

--- a/docs/security/TRIAGE_RUNBOOK.md
+++ b/docs/security/TRIAGE_RUNBOOK.md
@@ -170,12 +170,24 @@ Es kombiniert zwei Read-only-Skripte:
 | `scripts/audit/github_security_quality_readout.py` | Fetcht Code Scanning, Dependabot, Secret Scanning (aggregiert) via `gh api`; schreibt JSON + Markdown nach `docs/security/readouts/YYYY-MM-DD/`. |
 | `scripts/audit/security_alert_delta.py` | Vergleicht das aktuelle Readout-JSON mit dem letzten vorhandenen; emittiert Delta-JSON + Markdown. |
 
-### Publish-Modi
+### Publish-Modus (artifacts-only)
+
+Der Workflow operiert ausschließlich im **Artifacts-only-Modus** (`dry_run`).
+Kein direkter Commit, kein Push in `main`.
 
 | Modus | Wann | Wirkung |
 |-------|------|---------|
-| `dry_run` | Schedule (Standard) + manuell wählbar | Artifact + Job-Summary; kein Commit, kein Push. |
-| `publish` | Manuell via `workflow_dispatch` | Git-Commit des Readout-Verzeichnisses nach `main` (`[skip ci]`). |
+| `dry_run` | Schedule (Standard) + einzige manuell wählbare Option | Artifact + Job-Summary; kein Commit, kein Push. |
+| ~~`publish`~~ | ~~Manuell via `workflow_dispatch`~~ | **Entfernt** — Direct-Push auf `main` ist nicht governance-kompatibel (GH006: Branch Protection). Repository-Persistierung erfordert einen separaten PR-basierten Slice. |
+
+**Hintergrund:** Manueller Run `25632071704` (2026-05-10) scheiterte bei Schritt
+`Commit readout to repository` mit GH006 — geschützter Branch verlangt PR-Weg.
+Der Direct-Push-Pfad wurde in `fix/security-readout-disable-direct-publish-2289`
+entfernt.
+
+**Validierter Dry-Run:** Run `25632038888` (2026-05-10, `main@f227aa42`) —
+erfolgreich; 3 Artefakte, Schema `security_alert_delta.v1`, PARTIAL korrekt
+behandelt, kein Secret-Payload, kein Repo-Write, 6 High-Eskalationen.
 
 ### Eskalationslogik
 
@@ -205,7 +217,8 @@ artifacts/security-alert-readout/delta/
 Die Delta-Ausgabe ist absichtlich JSON-only. Keine Markdown-Zusammenfassung und
 keine stdout-Summary aus dem Delta-Skript.
 
-Im `dry_run`-Modus nur als GitHub-Actions-Artifact (30 Tage Retention), nicht committed.
+Alle Artefakte werden als GitHub-Actions-Artifacts hochgeladen (30 Tage Retention).
+Kein direkter Commit in das Repository (artifacts-only-Modus, siehe Publish-Modus-Tabelle oben).
 
 ### Interpretation eines Readout-Reports
 


### PR DESCRIPTION
## Summary

Disables the direct-push publish path in the Security Alert Readout workflow.

The validated dry-run path remains:
- workflow_dispatch / schedule
- JSON artifact upload
- PARTIAL surface handling
- secret-scanning redaction
- escalation annotation

## Why

Manual dry-run run `25632038888` succeeded and validated the artifact contract.

Manual publish run `25632071704` failed as expected because it attempted to push readout files directly to protected `main`:

`GH006: Protected branch update failed for refs/heads/main. Changes must be made through a pull request.`

Direct push from Actions is not governance-compatible for this repo.

## Changes

- Removes/deactivates direct repository publish mode
- Reduces workflow write surface where possible
- Documents artifact-only behavior in the triage runbook
- Leaves future PR-based persistence as a separate follow-up slice

## Validation

- `ruff check scripts/audit/security_alert_delta.py tests/unit/audit/test_security_alert_delta.py`
- `pytest -q -m unit tests/unit/audit/test_security_alert_delta.py`
- `pytest -q tests/unit/audit/test_github_security_quality_readout.py`
- `python scripts/audit/security_alert_delta.py --help`

Refs #2289.