### PR TITLE
feat(security): add persist_via_pr mode to alert readout workflow

### DIFF
--- a/.github/workflows/security-alert-readout.yml
+++ b/.github/workflows/security-alert-readout.yml
@@ -4,9 +4,10 @@ name: Security Alert Readout
 # dependabot, secret_scanning) and computes a delta against the most recent
 # previous readout.  Runs Mon/Wed/Fri; always available for manual dispatch.
 #
-# Artifacts-only mode: readout and delta are uploaded as GitHub Actions
+# Artifacts-only mode (default): readout and delta are uploaded as GitHub Actions
 # artifacts (retention: 30 days).  No direct commit to main is attempted.
-# Repository persistence requires a separate PR-based follow-up slice.
+# Optional: trigger workflow_dispatch with persist_via_pr=true to create a branch
+# + PR that persists the readout to the repo.  No auto-merge.  No direct push.
 #
 # Background: the direct-push publish path was removed after run 25632071704
 # failed with GH006 (protected branch — changes must be made via PR).  See
@@ -25,12 +26,17 @@ on:
   workflow_dispatch:
     inputs:
       publish_mode:
-        description: "artifacts-only (dry_run); repo persistence requires a separate PR-based slice"
+        description: "artifacts-only (dry_run); see persist_via_pr for repo persistence"
         required: false
         default: dry_run
         type: choice
         options:
           - dry_run
+      persist_via_pr:
+        description: "Create a branch + PR to persist the readout to the repo (no auto-merge, no direct push to main)"
+        required: false
+        default: "false"
+        type: boolean
 
 permissions:
   contents: read           # no repo writes; read-only checkout
@@ -43,6 +49,10 @@ concurrency:
 jobs:
   security-readout:
     runs-on: ubuntu-latest
+    outputs:
+      date_dir:       ${{ steps.resolve.outputs.date_dir }}
+      readout_status: ${{ steps.status.outputs.readout_status }}
+      delta_status:   ${{ steps.status.outputs.delta_status }}
 
     steps:
       - name: Checkout
@@ -218,3 +228,131 @@ jobs:
             artifacts/security-alert-readout/
           if-no-files-found: warn
           retention-days: 30
+
+      - name: Expose job outputs
+        id: status
+        if: always()
+        shell: bash
+        run: |
+          echo "readout_status=${READOUT_STATUS:-unknown}" >> "$GITHUB_OUTPUT"
+          echo "delta_status=${DELTA_STATUS:-unknown}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload readout for persist handoff
+        if: inputs.persist_via_pr == true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: readout-persist-${{ github.run_id }}
+          path: ${{ steps.resolve.outputs.date_dir }}/
+          if-no-files-found: error
+          retention-days: 1
+
+  persist-via-pr:
+    runs-on: ubuntu-latest
+    needs: security-readout
+    if: github.event_name == 'workflow_dispatch' && inputs.persist_via_pr == true
+    permissions:
+      contents: write      # create branch + commit
+      pull-requests: write # open PR
+    env:
+      DATE_DIR:        ${{ needs.security-readout.outputs.date_dir }}
+      READOUT_STATUS:  ${{ needs.security-readout.outputs.readout_status }}
+      DELTA_STATUS:    ${{ needs.security-readout.outputs.delta_status }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+
+      - name: Download readout artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: readout-persist-${{ github.run_id }}
+          path: /tmp/security-readout-handoff
+
+      - name: Create branch, commit, push and open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DATE="${DATE_DIR##*/}"
+          if [[ ! "$DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "::error::Invalid DATE derived from DATE_DIR: DATE_DIR=${DATE_DIR} DATE=${DATE}"
+            exit 1
+          fi
+          BRANCH_NAME="chore/security-readout/${DATE}"
+          PR_TITLE="chore(security): persist alert readout ${DATE}"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Check for an open PR for this date branch.
+          EXISTING_PR=$(gh pr list \
+            --head "${BRANCH_NAME}" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [[ -n "${EXISTING_PR}" ]]; then
+            # Open PR exists: check out its branch and update with new readout files.
+            echo "Open PR #${EXISTING_PR} found for ${BRANCH_NAME} — updating instead of skipping."
+            if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" > /dev/null 2>&1; then
+              git fetch origin "${BRANCH_NAME}"
+              git checkout -b "${BRANCH_NAME}" "origin/${BRANCH_NAME}"
+            else
+              # Remote branch gone but PR still open — fail closed, manual cleanup needed.
+              echo "::error::Remote branch ${BRANCH_NAME} not found but PR #${EXISTING_PR} is open. Manual cleanup required."
+              exit 1
+            fi
+          else
+            # No open PR. Guard against orphaned remote branch (closed PR, branch not deleted).
+            if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" > /dev/null 2>&1; then
+              echo "::error::Remote branch ${BRANCH_NAME} exists but no open PR found. Manual cleanup required before retrying."
+              exit 1
+            fi
+            git checkout -b "${BRANCH_NAME}"
+          fi
+
+          # Copy readout files from temp handoff into the worktree now that the correct branch is checked out.
+          HANDOFF_DIR="/tmp/security-readout-handoff"
+          if [[ ! -d "${HANDOFF_DIR}" ]] || [[ -z "$(ls -A "${HANDOFF_DIR}")" ]]; then
+            echo "::error::Handoff directory ${HANDOFF_DIR} is missing or empty. Cannot persist readout."
+            exit 1
+          fi
+          mkdir -p "${DATE_DIR}"
+          cp "${HANDOFF_DIR}/"* "${DATE_DIR}/"
+
+          git add "${DATE_DIR}"
+          if git diff --cached --quiet; then
+            echo "No new readout files staged — readout for ${DATE} is already up to date."
+            exit 0
+          fi
+
+          git commit -m "${PR_TITLE} [skip ci]"
+
+          PR_BODY=$(printf '%s\n' \
+            "Automated security alert readout persistence." \
+            "" \
+            "- Readout date: ${DATE}" \
+            "- Run ID: \`${GITHUB_RUN_ID}\`" \
+            "- Readout status: \`${READOUT_STATUS}\`" \
+            "- Delta status: \`${DELTA_STATUS}\`" \
+            "" \
+            "Refs #2289." \
+            "" \
+            "> [!NOTE]" \
+            "> Do not merge automatically. Human review required before merging.")
+
+          if [[ -n "${EXISTING_PR}" ]]; then
+            git push origin "${BRANCH_NAME}"
+            echo "Updated existing readout PR #${EXISTING_PR} with new readout for ${DATE}."
+          else
+            git push origin "${BRANCH_NAME}"
+            gh pr create \
+              --head "${BRANCH_NAME}" \
+              --base "main" \
+              --title "${PR_TITLE}" \
+              --body "${PR_BODY}"
+          fi

--- a/docs/security/TRIAGE_RUNBOOK.md
+++ b/docs/security/TRIAGE_RUNBOOK.md
@@ -170,15 +170,19 @@ Es kombiniert zwei Read-only-Skripte:
 | `scripts/audit/github_security_quality_readout.py` | Fetcht Code Scanning, Dependabot, Secret Scanning (aggregiert) via `gh api`; schreibt JSON + Markdown nach `docs/security/readouts/YYYY-MM-DD/`. |
 | `scripts/audit/security_alert_delta.py` | Vergleicht das aktuelle Readout-JSON mit dem letzten vorhandenen; emittiert Delta-JSON + Markdown. |
 
-### Publish-Modus (artifacts-only)
+### Publish-Modus (artifacts-only + optionale PR-Persistenz)
 
-Der Workflow operiert ausschließlich im **Artifacts-only-Modus** (`dry_run`).
+Der Workflow operiert standardmäßig im **Artifacts-only-Modus** (`dry_run`).
 Kein direkter Commit, kein Push in `main`.
+
+Optional kann via `workflow_dispatch` mit `persist_via_pr=true` ein Branch + PR erstellt werden,
+der den Readout in den Repo persistiert. Kein Auto-Merge. Kein Direct Push auf `main`.
 
 | Modus | Wann | Wirkung |
 |-------|------|---------|
-| `dry_run` | Schedule (Standard) + einzige manuell wählbare Option | Artifact + Job-Summary; kein Commit, kein Push. |
-| ~~`publish`~~ | ~~Manuell via `workflow_dispatch`~~ | **Entfernt** — Direct-Push auf `main` ist nicht governance-kompatibel (GH006: Branch Protection). Repository-Persistierung erfordert einen separaten PR-basierten Slice. |
+| `dry_run` | Schedule (Standard) + manuell wählbar | Artifact + Job-Summary; kein Commit, kein Push. |
+| ~~`publish`~~ | ~~Manuell via `workflow_dispatch`~~ | **Entfernt** — Direct-Push auf `main` ist nicht governance-kompatibel (GH006: Branch Protection). |
+| `persist_via_pr=true` | Manuell via `workflow_dispatch` | Branch `chore/security-readout/YYYY-MM-DD` + PR gegen `main`; kein Auto-Merge; Human-Review erforderlich. |
 
 **Hintergrund:** Manueller Run `25632071704` (2026-05-10) scheiterte bei Schritt
 `Commit readout to repository` mit GH006 — geschützter Branch verlangt PR-Weg.
@@ -188,6 +192,39 @@ entfernt.
 **Validierter Dry-Run:** Run `25632038888` (2026-05-10, `main@f227aa42`) —
 erfolgreich; 3 Artefakte, Schema `security_alert_delta.v1`, PARTIAL korrekt
 behandelt, kein Secret-Payload, kein Repo-Write, 6 High-Eskalationen.
+
+### PR-basierter Persistenzpfad (`persist_via_pr`)
+
+Auslösung:
+
+```
+workflow_dispatch → persist_via_pr = true
+```
+
+Ablauf:
+
+1. `security-readout`-Job läuft vollständig (Readout + Delta + Artifacts).
+2. `persist-via-pr`-Job (job-level `contents: write, pull-requests: write`) startet danach.
+3. Dedupe-Check: Falls ein offener PR für `chore/security-readout/YYYY-MM-DD` bereits
+   existiert, wird übersprungen (kein PR-Spam).
+4. Branch `chore/security-readout/YYYY-MM-DD` wird von `main` abgezweigt.
+5. Readout-JSON + Markdown werden committed (`[skip ci]`).
+6. Branch wird gepusht; PR wird via `gh pr create` eröffnet.
+
+PR-Eigenschaften:
+
+| Eigenschaft | Wert |
+|---|---|
+| Branch | `chore/security-readout/YYYY-MM-DD` |
+| Titel | `chore(security): persist alert readout YYYY-MM-DD` |
+| Base | `main` |
+| Auto-Merge | nein |
+| Direct Push | nein |
+| Issue-Close | nein |
+| Alert-Dismissal | nein |
+
+Permissions sind nur job-scoped und nur aktiv, wenn `persist_via_pr=true` gesetzt ist.
+Der `security-readout`-Job bleibt unverändert `contents: read`.
 
 ### Eskalationslogik
 


### PR DESCRIPTION
## Summary

Adds an optional PR-based repository persistence path to the Security Alert Readout workflow.

This keeps the validated artifacts-only dry-run path as default, while allowing a manual `workflow_dispatch` run to persist readout files via a pull request instead of direct-pushing to `main`.

## Changes

### `.github/workflows/security-alert-readout.yml`

- Adds manual `workflow_dispatch` boolean input: `persist_via_pr` default `false`
- Keeps scheduled runs artifacts-only
- Exposes `date_dir`, `readout_status`, and `delta_status` as job outputs
- Adds `persist-via-pr` job that only runs when:
  - event is `workflow_dispatch`
  - `persist_via_pr=true`
- Uses job-scoped permissions only:
  - `contents: write`
  - `pull-requests: write`
- Creates branch:
  - `chore/security-readout/YYYY-MM-DD`
- Opens PR:
  - `chore(security): persist alert readout YYYY-MM-DD`
- No direct push to `main`
- No auto-merge
- No issue writes
- No alert dismissals
- Dedupe guard skips if an open PR already exists for the same date branch
- Derives `DATE` from `DATE_DIR` to avoid UTC-midnight drift

### `docs/security/TRIAGE_RUNBOOK.md`

- Documents `persist_via_pr`
- Documents artifact-only default
- Documents PR-based persistence path
- Leaves future merge/review as a human-gated step

## Validation

- YAML parse OK
- `ruff check scripts/audit/security_alert_delta.py tests/unit/audit/test_security_alert_delta.py`
- `pytest -q -m unit tests/unit/audit/test_security_alert_delta.py`
- `pytest -q tests/unit/audit/test_github_security_quality_readout.py`
- `python3 scripts/audit/security_alert_delta.py --help`

Refs #2289.