### PR TITLE
chore(security): add alert issue candidate generator

### DIFF
--- a/scripts/audit/security_alert_issue_candidates.py
+++ b/scripts/audit/security_alert_issue_candidates.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Build local-only issue candidates from security_alert_delta artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+INPUT_FILENAME = "security_alert_delta.json"
+OUTPUT_FILENAME = "security_alert_issue_candidates.json"
+SCHEMA_VERSION = "security_alert_issue_candidates.v1"
+DEFAULT_INPUT_PATH = Path("artifacts/security-alert-readout/delta") / INPUT_FILENAME
+DEFAULT_OUT_DIR = Path("artifacts/security-alert-readout/delta")
+DEFAULT_LABELS = ["type:security", "triage:offen"]
+DEDUPE_MARKER_TEMPLATE = "<!-- cdb-security-alert-group:{fingerprint} -->"
+ALLOWED_SOURCES = frozenset({"code_scanning", "dependabot"})
+REF_2289 = "Refs #2289"
+REF_2290 = "Refs #2290"
+REF_2292 = "Refs #2292"
+
+_CVE_RE = re.compile(r"^cve-\d{4}-\d+$")
+
+
+class SecurityAlertIssueCandidatesError(ValueError):
+    """Raised when candidate generation input is invalid."""
+
+
+def _to_printable_ascii(value: object, *, max_len: int = 200) -> str:
+    raw = str(value)[:max_len]
+    return "".join(
+        chr(code) for char in raw if 0x20 <= (code := ord(char)) <= 0x7E
+    )
+
+
+def canonicalize(value: object, *, fallback: str = "unknown", max_len: int = 200) -> str:
+    if value is None:
+        return fallback
+    text = _to_printable_ascii(value, max_len=max_len).strip().lower()
+    text = " ".join(text.split())
+    return text or fallback
+
+
+def _bounded(value: str, *, limit: int) -> str:
+    trimmed = value.strip()
+    return trimmed[:limit] if len(trimmed) > limit else trimmed
+
+
+def severity_band_from(value: object) -> str:
+    severity = canonicalize(value)
+    if severity in {"critical", "high", "error"}:
+        return "high"
+    if severity in {"medium", "warning"}:
+        return "medium"
+    if severity in {"low", "note", "not_provided", "unknown"}:
+        return "low"
+    return "low"
+
+
+def _highest_severity(left: str, right: str) -> str:
+    rank = {"critical": 4, "high": 3, "error": 3, "medium": 2, "warning": 2, "low": 1, "note": 1}
+    left_rank = rank.get(left, 0)
+    right_rank = rank.get(right, 0)
+    return left if left_rank >= right_rank else right
+
+
+def _contains_cdb_python_service(component: str) -> bool:
+    return component.startswith("library/cdb_")
+
+
+def _looks_like_trivy_wave(source: str, subject: str, component: str) -> bool:
+    if source != "code_scanning":
+        return False
+    return bool(_CVE_RE.match(subject)) and _contains_cdb_python_service(component)
+
+
+def _looks_like_grafana_curl(component: str, subject: str) -> bool:
+    joined = f"{component} {subject}"
+    return "grafana" in joined or "curl" in joined or "libcurl" in joined
+
+
+def build_fingerprint(
+    *,
+    source: str,
+    severity_band: str,
+    subject: str,
+    affected_component: str,
+    branch: str,
+) -> str:
+    seed = "|".join(
+        (
+            canonicalize(source),
+            canonicalize(severity_band),
+            canonicalize(subject),
+            canonicalize(affected_component),
+            canonicalize(branch),
+        )
+    )
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _build_title(
+    *,
+    source: str,
+    severity: str,
+    subject: str,
+    affected_component: str,
+) -> str:
+    source_tag = _bounded(source, limit=24)
+    severity_tag = _bounded(severity, limit=16)
+    subject_part = _bounded(subject, limit=90)
+    component_part = _bounded(affected_component, limit=64)
+    return (
+        f"[Security][Alert][{source_tag}][{severity_tag}] "
+        f"{subject_part} — {component_part}"
+    )
+
+
+def _safe_counts(delta: dict[str, Any]) -> dict[str, int]:
+    counts_raw = delta.get("counts", {})
+    if not isinstance(counts_raw, dict):
+        return {
+            "new_alerts": 0,
+            "reopened_alerts": 0,
+            "new_groups": 0,
+            "escalation_alerts": 0,
+        }
+    return {
+        "new_alerts": int(counts_raw.get("new_alerts", 0)),
+        "reopened_alerts": int(counts_raw.get("reopened_alerts", 0)),
+        "new_groups": int(counts_raw.get("new_groups", 0)),
+        "escalation_alerts": int(counts_raw.get("escalation_alerts", 0)),
+    }
+
+
+def _base_candidate(
+    *,
+    source: str,
+    severity: str,
+    subject: str,
+    affected_component: str,
+    branch: str,
+    counts: dict[str, int],
+    current_reference_now_utc: str,
+) -> dict[str, Any]:
+    src = canonicalize(source)
+    sev = canonicalize(severity)
+    sev_band = severity_band_from(sev)
+    subj = canonicalize(subject, max_len=180)
+    component = canonicalize(affected_component, max_len=180)
+    br = canonicalize(branch, max_len=120)
+
+    fingerprint = build_fingerprint(
+        source=src,
+        severity_band=sev_band,
+        subject=subj,
+        affected_component=component,
+        branch=br,
+    )
+
+    references = [REF_2289]
+    labels = list(DEFAULT_LABELS)
+    if _looks_like_trivy_wave(src, subj, component):
+        references.append(REF_2290)
+        labels.append("status:blocked")
+    if _looks_like_grafana_curl(component, subj):
+        references.append(REF_2292)
+
+    dedupe_marker = DEDUPE_MARKER_TEMPLATE.format(fingerprint=fingerprint)
+    title = _build_title(
+        source=src,
+        severity=sev_band,
+        subject=subj,
+        affected_component=component,
+    )
+    safe_references = sorted(set(references))
+    safe_labels = sorted(set(labels))
+    return {
+        "fingerprint": fingerprint,
+        "source": src,
+        "severity": sev,
+        "severity_band": sev_band,
+        "subject": subj,
+        "affected_component": component,
+        "branch": br,
+        "suggested_title": title,
+        "suggested_labels": safe_labels,
+        "body_safe_fields": {
+            "generated_from_readout": True,
+            "current_reference_now_utc": current_reference_now_utc,
+            "source": src,
+            "severity": sev,
+            "severity_band": sev_band,
+            "counts": counts,
+            "subject": subj,
+            "affected_component": component,
+            "branch": br,
+            "fingerprint": fingerprint,
+            "next_action": "Human triage and bounded remediation planning.",
+            "references": safe_references,
+        },
+        "references": safe_references,
+        "dedupe_marker": dedupe_marker,
+    }
+
+
+def _extract_current_reference(delta: dict[str, Any]) -> str:
+    current = delta.get("sources", {})
+    if not isinstance(current, dict):
+        return ""
+    value = current.get("current_reference_now_utc", "")
+    return _to_printable_ascii(value, max_len=40).strip()
+
+
+def _candidate_from_group(
+    *,
+    group: dict[str, Any],
+    related_escalations: list[dict[str, Any]],
+    counts: dict[str, int],
+    current_reference_now_utc: str,
+) -> dict[str, Any] | None:
+    source = canonicalize(group.get("source"))
+    if source not in ALLOWED_SOURCES:
+        return None
+    subject = canonicalize(group.get("subject"))
+    branch = canonicalize(group.get("branch"), fallback="not_provided")
+
+    severity = "not_provided"
+    affected_component = "unknown"
+    if related_escalations:
+        severity = related_escalations[0].get("severity", "not_provided")
+        first_component = related_escalations[0].get("affected_component")
+        if isinstance(first_component, str):
+            affected_component = first_component
+
+    return _base_candidate(
+        source=source,
+        severity=severity,
+        subject=subject,
+        affected_component=affected_component,
+        branch=branch,
+        counts=counts,
+        current_reference_now_utc=current_reference_now_utc,
+    )
+
+
+def _candidate_from_escalation(
+    *,
+    escalation: dict[str, Any],
+    counts: dict[str, int],
+    current_reference_now_utc: str,
+) -> dict[str, Any] | None:
+    source = canonicalize(escalation.get("source"))
+    if source not in ALLOWED_SOURCES:
+        return None
+    return _base_candidate(
+        source=source,
+        severity=canonicalize(escalation.get("severity"), fallback="not_provided"),
+        subject=canonicalize(escalation.get("subject")),
+        affected_component=canonicalize(
+            escalation.get("affected_component"), fallback="unknown"
+        ),
+        branch=canonicalize(escalation.get("branch"), fallback="not_provided"),
+        counts=counts,
+        current_reference_now_utc=current_reference_now_utc,
+    )
+
+
+def _merge_candidates(existing: dict[str, Any], incoming: dict[str, Any]) -> None:
+    existing["severity"] = _highest_severity(
+        str(existing.get("severity", "unknown")),
+        str(incoming.get("severity", "unknown")),
+    )
+    existing["severity_band"] = severity_band_from(existing["severity"])
+    existing["suggested_labels"] = sorted(
+        set(existing.get("suggested_labels", [])) | set(incoming.get("suggested_labels", []))
+    )
+    merged_refs = sorted(set(existing.get("references", [])) | set(incoming.get("references", [])))
+    existing["references"] = merged_refs
+    existing["body_safe_fields"]["references"] = merged_refs
+    existing["body_safe_fields"]["severity"] = existing["severity"]
+    existing["body_safe_fields"]["severity_band"] = existing["severity_band"]
+    existing["suggested_title"] = _build_title(
+        source=existing["source"],
+        severity=existing["severity_band"],
+        subject=existing["subject"],
+        affected_component=existing["affected_component"],
+    )
+
+
+def _safe_list_dict(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def build_candidates(delta: dict[str, Any]) -> list[dict[str, Any]]:
+    schema = str(delta.get("schema_version", ""))
+    if not schema.startswith("security_alert_delta"):
+        raise SecurityAlertIssueCandidatesError(
+            "Invalid input schema; expected security_alert_delta.*"
+        )
+
+    counts = _safe_counts(delta)
+    current_reference = _extract_current_reference(delta)
+    new_groups = _safe_list_dict(delta.get("new_groups", []))
+    escalations = _safe_list_dict(delta.get("escalations", []))
+
+    by_fingerprint: dict[str, dict[str, Any]] = {}
+
+    for group in new_groups:
+        source = canonicalize(group.get("source"))
+        subject = canonicalize(group.get("subject"))
+        branch = canonicalize(group.get("branch"), fallback="not_provided")
+        related_escalations = [
+            item
+            for item in escalations
+            if canonicalize(item.get("source")) == source
+            and canonicalize(item.get("subject")) == subject
+            and canonicalize(item.get("branch"), fallback="not_provided") == branch
+        ]
+        candidate = _candidate_from_group(
+            group=group,
+            related_escalations=related_escalations,
+            counts=counts,
+            current_reference_now_utc=current_reference,
+        )
+        if candidate is None:
+            continue
+        by_fingerprint[candidate["fingerprint"]] = candidate
+
+    if bool(delta.get("escalation_needed", False)):
+        for escalation in escalations:
+            candidate = _candidate_from_escalation(
+                escalation=escalation,
+                counts=counts,
+                current_reference_now_utc=current_reference,
+            )
+            if candidate is None:
+                continue
+            fingerprint = candidate["fingerprint"]
+            if fingerprint in by_fingerprint:
+                _merge_candidates(by_fingerprint[fingerprint], candidate)
+            else:
+                by_fingerprint[fingerprint] = candidate
+
+    candidates = sorted(
+        by_fingerprint.values(),
+        key=lambda item: (
+            item["source"],
+            item["severity_band"],
+            item["subject"],
+            item["affected_component"],
+            item["branch"],
+        ),
+    )
+    return candidates
+
+
+def build_output_payload(*, delta: dict[str, Any], candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "input_schema_version": str(delta.get("schema_version", "")),
+        "candidate_count": len(candidates),
+        "candidates": candidates,
+    }
+
+
+def generate_candidates(*, input_path: Path, out_dir: Path) -> dict[str, Any]:
+    try:
+        delta = json.loads(input_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise SecurityAlertIssueCandidatesError(f"Cannot read input file: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise SecurityAlertIssueCandidatesError(f"Invalid JSON input: {exc}") from exc
+
+    if not isinstance(delta, dict):
+        raise SecurityAlertIssueCandidatesError("Input JSON root must be an object")
+
+    candidates = build_candidates(delta)
+    payload = build_output_payload(delta=delta, candidates=candidates)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / OUTPUT_FILENAME
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build local-only security alert issue candidates from delta JSON."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT_PATH),
+        metavar="PATH",
+        help="Path to security_alert_delta.json",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=str(DEFAULT_OUT_DIR),
+        metavar="DIR",
+        help="Output directory for security_alert_issue_candidates.json",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        payload = generate_candidates(
+            input_path=Path(args.input),
+            out_dir=Path(args.out_dir),
+        )
+    except SecurityAlertIssueCandidatesError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"security alert issue candidates generated: {payload['candidate_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/scripts/audit/security_alert_issue_candidates.py
+++ b/scripts/audit/security_alert_issue_candidates.py
@@ -25,6 +25,16 @@ REF_2290 = "Refs #2290"
 REF_2292 = "Refs #2292"
 
 _CVE_RE = re.compile(r"^cve-\d{4}-\d+$")
+_COMPONENT_KEYS = (
+    "affected_component",
+    "component",
+    "package",
+    "package_name",
+    "dependency",
+    "image",
+    "artifact",
+    "container_image",
+)
 
 
 class SecurityAlertIssueCandidatesError(ValueError):
@@ -82,6 +92,35 @@ def _looks_like_trivy_wave(source: str, subject: str, component: str) -> bool:
 def _looks_like_grafana_curl(component: str, subject: str) -> bool:
     joined = f"{component} {subject}"
     return "grafana" in joined or "curl" in joined or "libcurl" in joined
+
+
+def _safe_component_from_mapping(record: dict[str, Any]) -> str:
+    for key in _COMPONENT_KEYS:
+        raw_value = record.get(key)
+        if not isinstance(raw_value, str):
+            continue
+        candidate = canonicalize(raw_value, fallback="unknown", max_len=180)
+        if candidate == "unknown":
+            continue
+        if "://" in candidate:
+            continue
+        return candidate
+    return "unknown"
+
+
+def _build_component_index(delta: dict[str, Any]) -> dict[tuple[str, int], str]:
+    component_index: dict[tuple[str, int], str] = {}
+    for key in ("new_alerts", "reopened_alerts"):
+        for alert in _safe_list_dict(delta.get(key, [])):
+            source = canonicalize(alert.get("source"))
+            number_raw = alert.get("number")
+            if not isinstance(number_raw, int):
+                continue
+            component = _safe_component_from_mapping(alert)
+            if component == "unknown":
+                continue
+            component_index[(source, number_raw)] = component
+    return component_index
 
 
 def build_fingerprint(
@@ -252,19 +291,23 @@ def _candidate_from_group(
 def _candidate_from_escalation(
     *,
     escalation: dict[str, Any],
+    component_index: dict[tuple[str, int], str],
     counts: dict[str, int],
     current_reference_now_utc: str,
 ) -> dict[str, Any] | None:
     source = canonicalize(escalation.get("source"))
     if source not in ALLOWED_SOURCES:
         return None
+    affected_component = _safe_component_from_mapping(escalation)
+    if affected_component == "unknown":
+        number_raw = escalation.get("number")
+        if isinstance(number_raw, int):
+            affected_component = component_index.get((source, number_raw), "unknown")
     return _base_candidate(
         source=source,
         severity=canonicalize(escalation.get("severity"), fallback="not_provided"),
         subject=canonicalize(escalation.get("subject")),
-        affected_component=canonicalize(
-            escalation.get("affected_component"), fallback="unknown"
-        ),
+        affected_component=affected_component,
         branch=canonicalize(escalation.get("branch"), fallback="not_provided"),
         counts=counts,
         current_reference_now_utc=current_reference_now_utc,
@@ -310,6 +353,7 @@ def build_candidates(delta: dict[str, Any]) -> list[dict[str, Any]]:
     current_reference = _extract_current_reference(delta)
     new_groups = _safe_list_dict(delta.get("new_groups", []))
     escalations = _safe_list_dict(delta.get("escalations", []))
+    component_index = _build_component_index(delta)
 
     by_fingerprint: dict[str, dict[str, Any]] = {}
 
@@ -338,6 +382,7 @@ def build_candidates(delta: dict[str, Any]) -> list[dict[str, Any]]:
         for escalation in escalations:
             candidate = _candidate_from_escalation(
                 escalation=escalation,
+                component_index=component_index,
                 counts=counts,
                 current_reference_now_utc=current_reference,
             )

--- a/scripts/audit/security_alert_issue_candidates.py
+++ b/scripts/audit/security_alert_issue_candidates.py
@@ -123,6 +123,22 @@ def _build_component_index(delta: dict[str, Any]) -> dict[tuple[str, int], str]:
     return component_index
 
 
+def _resolve_escalation_component(
+    *,
+    escalation: dict[str, Any],
+    source: str,
+    component_index: dict[tuple[str, int], str],
+) -> str:
+    component = _safe_component_from_mapping(escalation)
+    if component != "unknown":
+        return component
+
+    number_raw = escalation.get("number")
+    if isinstance(number_raw, int):
+        return component_index.get((source, number_raw), "unknown")
+    return "unknown"
+
+
 def build_fingerprint(
     *,
     source: str,
@@ -260,6 +276,7 @@ def _candidate_from_group(
     *,
     group: dict[str, Any],
     related_escalations: list[dict[str, Any]],
+    component_index: dict[tuple[str, int], str],
     counts: dict[str, int],
     current_reference_now_utc: str,
 ) -> dict[str, Any] | None:
@@ -273,9 +290,11 @@ def _candidate_from_group(
     affected_component = "unknown"
     if related_escalations:
         severity = related_escalations[0].get("severity", "not_provided")
-        first_component = related_escalations[0].get("affected_component")
-        if isinstance(first_component, str):
-            affected_component = first_component
+        affected_component = _resolve_escalation_component(
+            escalation=related_escalations[0],
+            source=source,
+            component_index=component_index,
+        )
 
     return _base_candidate(
         source=source,
@@ -298,11 +317,11 @@ def _candidate_from_escalation(
     source = canonicalize(escalation.get("source"))
     if source not in ALLOWED_SOURCES:
         return None
-    affected_component = _safe_component_from_mapping(escalation)
-    if affected_component == "unknown":
-        number_raw = escalation.get("number")
-        if isinstance(number_raw, int):
-            affected_component = component_index.get((source, number_raw), "unknown")
+    affected_component = _resolve_escalation_component(
+        escalation=escalation,
+        source=source,
+        component_index=component_index,
+    )
     return _base_candidate(
         source=source,
         severity=canonicalize(escalation.get("severity"), fallback="not_provided"),
@@ -371,6 +390,7 @@ def build_candidates(delta: dict[str, Any]) -> list[dict[str, Any]]:
         candidate = _candidate_from_group(
             group=group,
             related_escalations=related_escalations,
+            component_index=component_index,
             counts=counts,
             current_reference_now_utc=current_reference,
         )

--- a/tests/unit/audit/test_security_alert_issue_candidates.py
+++ b/tests/unit/audit/test_security_alert_issue_candidates.py
@@ -149,18 +149,26 @@ def test_no_candidate_from_secret_scanning_payload() -> None:
 def test_reopened_high_critical_creates_candidate() -> None:
     delta = _base_delta()
     delta["escalation_needed"] = True
+    delta["reopened_alerts"] = [
+        {
+            "source": "code_scanning",
+            "number": 77,
+            "affected_component": "library/cdb_market",
+        }
+    ]
     delta["escalations"] = [
         {
             "source": "code_scanning",
+            "number": 77,
             "severity": "critical",
             "subject": "cve-2026-1111",
-            "affected_component": "library/cdb_market",
             "branch": "main",
         }
     ]
     candidates = mod.build_candidates(delta)
     assert len(candidates) == 1
     assert candidates[0]["severity"] == "critical"
+    assert candidates[0]["affected_component"] == "library/cdb_market"
     assert "Refs #2289" in candidates[0]["references"]
 
 
@@ -182,12 +190,19 @@ def test_new_groups_creates_candidate() -> None:
 def test_trivy_grafana_candidate_may_reference_2292_without_closing() -> None:
     delta = _base_delta()
     delta["escalation_needed"] = True
+    delta["new_alerts"] = [
+        {
+            "source": "code_scanning",
+            "number": 11,
+            "affected_component": "library/grafana-curl-layer",
+        }
+    ]
     delta["escalations"] = [
         {
             "source": "code_scanning",
+            "number": 11,
             "severity": "high",
             "subject": "cve-2026-3030",
-            "affected_component": "library/grafana-curl-layer",
             "branch": "main",
         }
     ]
@@ -199,12 +214,19 @@ def test_trivy_grafana_candidate_may_reference_2292_without_closing() -> None:
 def test_python_base_image_trivy_candidate_may_reference_2290_without_closing() -> None:
     delta = _base_delta()
     delta["escalation_needed"] = True
+    delta["new_alerts"] = [
+        {
+            "source": "code_scanning",
+            "number": 12,
+            "affected_component": "library/cdb_signal",
+        }
+    ]
     delta["escalations"] = [
         {
             "source": "code_scanning",
+            "number": 12,
             "severity": "high",
             "subject": "cve-2026-4545",
-            "affected_component": "library/cdb_signal",
             "branch": "main",
         }
     ]
@@ -232,6 +254,75 @@ def test_title_body_are_bounded_and_do_not_embed_raw_objects() -> None:
     assert len(candidate["suggested_title"]) <= 220
     assert isinstance(candidate["body_safe_fields"], dict)
     assert "raw" not in candidate["body_safe_fields"]
+
+
+def test_escalation_component_uses_package_name_or_image_when_safe() -> None:
+    delta = _base_delta()
+    delta["escalation_needed"] = True
+    delta["escalations"] = [
+        {
+            "source": "code_scanning",
+            "number": 1,
+            "severity": "high",
+            "subject": "urllib3-vuln",
+            "package_name": "urllib3",
+            "branch": "main",
+        },
+        {
+            "source": "dependabot",
+            "number": 2,
+            "severity": "high",
+            "subject": "base-image-vuln",
+            "image": "ghcr.io/acme/base:3.12",
+            "branch": "main",
+        },
+    ]
+    candidates = mod.build_candidates(delta)
+    components = {c["subject"]: c["affected_component"] for c in candidates}
+    assert components["urllib3-vuln"] == "urllib3"
+    assert components["base-image-vuln"] == "ghcr.io/acme/base:3.12"
+
+
+def test_escalation_component_stays_unknown_without_safe_source() -> None:
+    delta = _base_delta()
+    delta["escalation_needed"] = True
+    delta["escalations"] = [
+        {
+            "source": "dependabot",
+            "number": 9,
+            "severity": "high",
+            "subject": "jinja2",
+            "branch": "main",
+        }
+    ]
+    candidate = mod.build_candidates(delta)[0]
+    assert candidate["affected_component"] == "unknown"
+
+
+def test_component_mapping_rejects_location_and_raw_fields() -> None:
+    delta = _base_delta()
+    delta["escalation_needed"] = True
+    delta["new_alerts"] = [
+        {
+            "source": "code_scanning",
+            "number": 500,
+            "affected_component": "library/cdb_execution",
+        }
+    ]
+    delta["escalations"] = [
+        {
+            "source": "code_scanning",
+            "number": 500,
+            "severity": "high",
+            "subject": "cve-2026-5050",
+            "locations_url": "https://example.invalid/location/500",
+            "raw": {"affected_component": "sensitive"},
+            "branch": "main",
+        }
+    ]
+    candidate = mod.build_candidates(delta)[0]
+    assert candidate["affected_component"] == "library/cdb_execution"
+    assert "https://example.invalid/location/500" not in json.dumps(candidate)
 
 
 def test_cli_writes_output(tmp_path: Path) -> None:

--- a/tests/unit/audit/test_security_alert_issue_candidates.py
+++ b/tests/unit/audit/test_security_alert_issue_candidates.py
@@ -187,6 +187,106 @@ def test_new_groups_creates_candidate() -> None:
     assert candidates[0]["subject"] == "jinja2"
 
 
+def test_new_group_and_escalation_share_resolved_component_no_duplicates() -> None:
+    delta = _base_delta()
+    delta["escalation_needed"] = True
+    delta["new_groups"] = [
+        {
+            "source": "code_scanning",
+            "subject": "cve-2026-9999",
+            "branch": "main",
+        }
+    ]
+    delta["new_alerts"] = [
+        {
+            "source": "code_scanning",
+            "number": 88,
+            "affected_component": "library/cdb_signal",
+        }
+    ]
+    delta["escalations"] = [
+        {
+            "source": "code_scanning",
+            "number": 88,
+            "severity": "high",
+            "subject": "cve-2026-9999",
+            "branch": "main",
+        }
+    ]
+
+    candidates = mod.build_candidates(delta)
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate["affected_component"] == "library/cdb_signal"
+    assert candidate["fingerprint"] == mod.build_fingerprint(
+        source="code_scanning",
+        severity_band="high",
+        subject="cve-2026-9999",
+        affected_component="library/cdb_signal",
+        branch="main",
+    )
+
+
+def test_new_group_and_escalation_references_and_labels_remain_consistent() -> None:
+    delta = _base_delta()
+    delta["escalation_needed"] = True
+    delta["new_groups"] = [
+        {
+            "source": "code_scanning",
+            "subject": "cve-2026-4545",
+            "branch": "main",
+        },
+        {
+            "source": "code_scanning",
+            "subject": "cve-2026-3030",
+            "branch": "main",
+        },
+    ]
+    delta["new_alerts"] = [
+        {
+            "source": "code_scanning",
+            "number": 12,
+            "affected_component": "library/cdb_signal",
+        },
+        {
+            "source": "code_scanning",
+            "number": 11,
+            "affected_component": "library/grafana-curl-layer",
+        },
+    ]
+    delta["escalations"] = [
+        {
+            "source": "code_scanning",
+            "number": 12,
+            "severity": "high",
+            "subject": "cve-2026-4545",
+            "branch": "main",
+        },
+        {
+            "source": "code_scanning",
+            "number": 11,
+            "severity": "high",
+            "subject": "cve-2026-3030",
+            "branch": "main",
+        },
+    ]
+    candidates = mod.build_candidates(delta)
+    assert len(candidates) == 2
+
+    by_subject = {c["subject"]: c for c in candidates}
+    py_candidate = by_subject["cve-2026-4545"]
+    grafana_candidate = by_subject["cve-2026-3030"]
+
+    assert "Refs #2290" in py_candidate["references"]
+    assert "status:blocked" in py_candidate["suggested_labels"]
+    assert all(not ref.lower().startswith("closes ") for ref in py_candidate["references"])
+
+    assert "Refs #2292" in grafana_candidate["references"]
+    assert all(
+        not ref.lower().startswith("closes ") for ref in grafana_candidate["references"]
+    )
+
+
 def test_trivy_grafana_candidate_may_reference_2292_without_closing() -> None:
     delta = _base_delta()
     delta["escalation_needed"] = True

--- a/tests/unit/audit/test_security_alert_issue_candidates.py
+++ b/tests/unit/audit/test_security_alert_issue_candidates.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.audit import security_alert_issue_candidates as mod
+
+
+def _base_delta() -> dict:
+    return {
+        "schema_version": "security_alert_delta.v1",
+        "counts": {
+            "new_alerts": 2,
+            "reopened_alerts": 1,
+            "new_groups": 1,
+            "escalation_alerts": 1,
+        },
+        "sources": {
+            "current_reference_now_utc": "2026-05-10T12:00:00Z",
+        },
+        "comparison_skipped_sources": [
+            {"source": "dependabot", "reason": "permission denied"}
+        ],
+        "new_groups": [],
+        "escalations": [],
+    }
+
+
+def test_fingerprint_stability() -> None:
+    first = mod.build_fingerprint(
+        source="code_scanning",
+        severity_band="high",
+        subject="cve-2026-0001",
+        affected_component="library/cdb_signal",
+        branch="main",
+    )
+    second = mod.build_fingerprint(
+        source=" code_scanning ",
+        severity_band="HIGH",
+        subject="CVE-2026-0001",
+        affected_component="library/cdb_signal",
+        branch="main ",
+    )
+    assert first == second
+    assert len(first) == 16
+
+
+def test_canonicalization_empty_and_inconsistent_values() -> None:
+    assert mod.canonicalize("   ") == "unknown"
+    assert mod.canonicalize("  MiXeD   VALUE  ") == "mixed value"
+    assert mod.canonicalize(None) == "unknown"
+
+
+def test_secret_and_sensitive_fields_are_not_present() -> None:
+    delta = _base_delta()
+    delta["escalation_needed"] = True
+    delta["escalations"] = [
+        {
+            "source": "secret_scanning",
+            "severity": "critical",
+            "subject": "ghp_secret_token",
+            "affected_component": "repo",
+            "branch": "main",
+            "raw": {"token": "never"},
+            "locations_url": "https://example.invalid/location",
+        }
+    ]
+    payload = mod.build_output_payload(delta=delta, candidates=mod.build_candidates(delta))
+    serialized = json.dumps(payload)
+    assert payload["candidate_count"] == 0
+    assert "locations_url" not in serialized
+    assert "token" not in serialized
+
+
+def test_dedupe_marker_shape() -> None:
+    delta = _base_delta()
+    delta["new_groups"] = [
+        {
+            "source": "dependabot",
+            "subject": "openssl",
+            "branch": "main",
+        }
+    ]
+    candidate = mod.build_candidates(delta)[0]
+    marker = candidate["dedupe_marker"]
+    assert marker.startswith("<!-- cdb-security-alert-group:")
+    assert marker.endswith(" -->")
+    assert candidate["fingerprint"] in marker
+
+
+def test_body_safe_schema() -> None:
+    delta = _base_delta()
+    delta["new_groups"] = [
+        {
+            "source": "dependabot",
+            "subject": "urllib3",
+            "branch": "main",
+        }
+    ]
+    candidate = mod.build_candidates(delta)[0]
+    body = candidate["body_safe_fields"]
+    required = {
+        "generated_from_readout",
+        "current_reference_now_utc",
+        "source",
+        "severity",
+        "severity_band",
+        "counts",
+        "subject",
+        "affected_component",
+        "branch",
+        "fingerprint",
+        "next_action",
+        "references",
+    }
+    assert required <= set(body.keys())
+    assert "locations_url" not in body
+    assert "raw" not in body
+
+
+def test_no_candidate_from_comparison_skipped_sources_only() -> None:
+    delta = _base_delta()
+    candidates = mod.build_candidates(delta)
+    assert candidates == []
+
+
+def test_no_candidate_from_secret_scanning_payload() -> None:
+    delta = _base_delta()
+    delta["new_groups"] = [
+        {
+            "source": "secret_scanning",
+            "subject": "token leak",
+            "branch": "main",
+        }
+    ]
+    delta["escalation_needed"] = True
+    delta["escalations"] = [
+        {
+            "source": "secret_scanning",
+            "severity": "critical",
+            "subject": "token leak",
+            "affected_component": "repo",
+            "branch": "main",
+        }
+    ]
+    assert mod.build_candidates(delta) == []
+
+
+def test_reopened_high_critical_creates_candidate() -> None:
+    delta = _base_delta()
+    delta["escalation_needed"] = True
+    delta["escalations"] = [
+        {
+            "source": "code_scanning",
+            "severity": "critical",
+            "subject": "cve-2026-1111",
+            "affected_component": "library/cdb_market",
+            "branch": "main",
+        }
+    ]
+    candidates = mod.build_candidates(delta)
+    assert len(candidates) == 1
+    assert candidates[0]["severity"] == "critical"
+    assert "Refs #2289" in candidates[0]["references"]
+
+
+def test_new_groups_creates_candidate() -> None:
+    delta = _base_delta()
+    delta["new_groups"] = [
+        {
+            "source": "dependabot",
+            "subject": "jinja2",
+            "branch": "main",
+        }
+    ]
+    candidates = mod.build_candidates(delta)
+    assert len(candidates) == 1
+    assert candidates[0]["source"] == "dependabot"
+    assert candidates[0]["subject"] == "jinja2"
+
+
+def test_trivy_grafana_candidate_may_reference_2292_without_closing() -> None:
+    delta = _base_delta()
+    delta["escalation_needed"] = True
+    delta["escalations"] = [
+        {
+            "source": "code_scanning",
+            "severity": "high",
+            "subject": "cve-2026-3030",
+            "affected_component": "library/grafana-curl-layer",
+            "branch": "main",
+        }
+    ]
+    candidate = mod.build_candidates(delta)[0]
+    assert "Refs #2292" in candidate["references"]
+    assert all(not ref.lower().startswith("closes ") for ref in candidate["references"])
+
+
+def test_python_base_image_trivy_candidate_may_reference_2290_without_closing() -> None:
+    delta = _base_delta()
+    delta["escalation_needed"] = True
+    delta["escalations"] = [
+        {
+            "source": "code_scanning",
+            "severity": "high",
+            "subject": "cve-2026-4545",
+            "affected_component": "library/cdb_signal",
+            "branch": "main",
+        }
+    ]
+    candidate = mod.build_candidates(delta)[0]
+    assert "Refs #2290" in candidate["references"]
+    assert "status:blocked" in candidate["suggested_labels"]
+    assert all(not ref.lower().startswith("closes ") for ref in candidate["references"])
+
+
+def test_title_body_are_bounded_and_do_not_embed_raw_objects() -> None:
+    delta = _base_delta()
+    delta["escalation_needed"] = True
+    very_long_subject = "cve-2026-1212-" + ("x" * 300)
+    delta["escalations"] = [
+        {
+            "source": "code_scanning",
+            "severity": "critical",
+            "subject": very_long_subject,
+            "affected_component": "library/cdb_execution",
+            "branch": "main",
+            "raw": {"nested": "value"},
+        }
+    ]
+    candidate = mod.build_candidates(delta)[0]
+    assert len(candidate["suggested_title"]) <= 220
+    assert isinstance(candidate["body_safe_fields"], dict)
+    assert "raw" not in candidate["body_safe_fields"]
+
+
+def test_cli_writes_output(tmp_path: Path) -> None:
+    delta_path = tmp_path / mod.INPUT_FILENAME
+    out_dir = tmp_path / "out"
+    delta = _base_delta()
+    delta["new_groups"] = [
+        {"source": "dependabot", "subject": "urllib3", "branch": "main"}
+    ]
+    delta_path.write_text(json.dumps(delta), encoding="utf-8")
+    payload = mod.generate_candidates(input_path=delta_path, out_dir=out_dir)
+    out_path = out_dir / mod.OUTPUT_FILENAME
+    assert out_path.exists()
+    assert payload["candidate_count"] == 1
+


### PR DESCRIPTION
## Summary

Adds a local-only Security Alert issue candidate generator for #2289.

This creates candidate artifacts from existing security alert delta output without creating, editing, commenting on, or closing GitHub issues.

## Scope

- Adds scripts/audit/security_alert_issue_candidates.py
- Adds unit coverage in 	ests/unit/audit/test_security_alert_issue_candidates.py
- Builds candidates from:
  - 
ew_groups
  - escalation alerts when scalation_needed=true
- Excludes:
  - secret-scanning payload/details
  - raw alert objects
  - sensitive location fields
  - skipped-only surfaces without concrete groups

## Safety

- No GitHub writes from the script
- No workflow changes
- No alert dismissals
- No issue create/edit/comment/close behavior
- No secret payloads or raw alert objects in candidate bodies
- References use Refs #2289, optional Refs #2290 / Refs #2292
- No Closes ... references

## Validation

- pytest -q tests/unit/audit/test_security_alert_issue_candidates.py
- pytest -q tests/unit/audit/test_security_alert_delta.py tests/unit/audit/test_security_alert_issue_candidates.py

Refs #2289