### PR TITLE
ci(copilot-setup): skip node setup without root lockfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -34,19 +34,22 @@ jobs:
             pip install -r requirements.txt
           fi
 
-      # Optional: Node only if you really have JS tooling
+      # Optional: Node only if a lockfile exists at the repo root
       - name: Setup Node (optional)
+        if: ${{ hashFiles('package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock') != '' }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
-          cache: "npm"
+          node-version: "24"
 
       - name: Install Node deps (if present)
+        if: ${{ hashFiles('package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock') != '' }}
         shell: bash
         run: |
           set -euo pipefail
-          if [ -f package-lock.json ]; then
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
             npm ci
+          elif [ -f yarn.lock ]; then
+            yarn install --frozen-lockfile
           fi
 
       # Cheap sanity: confirm workflow context + versions


### PR DESCRIPTION
## Summary

Fixes the Copilot cloud agent setup failure where \ctions/setup-node\ tried to enable npm caching without any root Node lockfile.

Failed historical run:
https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/24293645089

## Changes

- Guard \Setup Node (optional)\ with a root lockfile check.
- Guard \Install Node deps (if present)\ with the same lockfile check.
- Remove \cache: \\\\
pm\\\\\ to avoid cache-type mismatch.
- Bump \
ode-version\ from \\\20\\\ to \\\24\\\.
- Extend install handling for:
  - \package-lock.json\
  - \
pm-shrinkwrap.json\
  - \yarn.lock\

## Scope

Only changes:

- \.github/workflows/copilot-setup-steps.yml\

## Non-goals

- No lockfile creation
- No package.json creation
- No dependency install
- No \ci.yaml\ change
- No issue writes
- No #1445 write
- No retargeting
- No Live-Readiness / Echtgeld / trading scope

## Validation

- \git diff -- .github/workflows/copilot-setup-steps.yml\ confirmed
- No root lockfiles exist
- \cache: \\\
pm\\\\ removed from Copilot setup
- \
ode-version: \\\24\\\\ confirmed
- Historical failing run \24293645089\ confirmed