### PR TITLE
fix(ws): export client counters via delta metrics

### DIFF
--- a/services/ws/service.py
+++ b/services/ws/service.py
@@ -47,6 +47,38 @@ ws_connected = Gauge("ws_connected", "WS connection status (0/1)")
 last_message_ts_ms = Gauge("last_message_ts_ms", "Last message timestamp (ms)")
 redis_publish_total = Counter("redis_publish_total", "Total Redis publishes")
 redis_publish_errors_total = Counter("redis_publish_errors_total", "Redis publish errors")
+_last_client_counter_values = {
+    "decoded_messages_total": None,
+    "decode_errors_total": None,
+}
+
+
+def _advance_counter_from_absolute(counter: Counter, counter_name: str, raw_value) -> None:
+    """
+    Advance a Prometheus Counter from an absolute client value using delta logic.
+
+    Prometheus Counters are monotonic and cannot be set directly. We keep the last
+    observed absolute value and only increment by positive deltas. On resets or
+    lower values we update the baseline without emitting negative increments.
+    """
+    try:
+        current_value = float(raw_value)
+    except (TypeError, ValueError):
+        return
+
+    if current_value < 0:
+        return
+
+    previous_value = _last_client_counter_values.get(counter_name)
+    if previous_value is None:
+        _last_client_counter_values[counter_name] = current_value
+        return
+
+    delta = current_value - previous_value
+    if delta > 0:
+        counter.inc(delta)
+
+    _last_client_counter_values[counter_name] = current_value
 
 
 @app.route("/health", methods=["GET"])
@@ -90,8 +122,16 @@ def metrics():
     client = ws_client  # Local copy, reduces race risk
     if client is not None:
         m = client.get_metrics()
-        decoded_messages_total.set(m.get("decoded_messages_total", 0))
-        decode_errors_total.set(m.get("decode_errors_total", 0))
+        _advance_counter_from_absolute(
+            decoded_messages_total,
+            "decoded_messages_total",
+            m.get("decoded_messages_total", 0),
+        )
+        _advance_counter_from_absolute(
+            decode_errors_total,
+            "decode_errors_total",
+            m.get("decode_errors_total", 0),
+        )
         ws_connected.set(m.get("ws_connected", 0))
         last_message_ts_ms.set(m.get("last_message_ts_ms", 0))
     return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)

--- a/services/ws/service.py
+++ b/services/ws/service.py
@@ -15,11 +15,11 @@ import logging
 import os
 import sys
 import threading
+from typing import Any
 from flask import Flask, jsonify, Response
 from prometheus_client import Counter, Gauge, generate_latest, CONTENT_TYPE_LATEST
 import redis
 
-from mexc_v3_client import MexcV3Client
 from core.utils.redis_payload import sanitize_market_data
 
 # Basic logging setup
@@ -79,6 +79,22 @@ def _advance_counter_from_absolute(counter: Counter, counter_name: str, raw_valu
         counter.inc(delta)
 
     _last_client_counter_values[counter_name] = current_value
+
+
+def _load_mexc_client_class() -> Any:
+    """
+    Load the MEXC client only for WS_SOURCE=mexc_pb execution paths.
+
+    This keeps /health and /metrics importable in environments that do not
+    install websocket-specific runtime dependencies.
+    """
+    try:
+        from mexc_v3_client import MexcV3Client
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "MEXC WS client dependencies are required for WS_SOURCE=mexc_pb"
+        ) from exc
+    return MexcV3Client
 
 
 @app.route("/health", methods=["GET"])
@@ -189,6 +205,7 @@ async def run_mexc_client():
         else:
             logger.warning(f"[redis] not connected, dropping trade: {event}")
 
+    MexcV3Client = _load_mexc_client_class()
     ws_client = MexcV3Client(
         symbol=symbol,
         interval=interval,

--- a/services/ws/service.py
+++ b/services/ws/service.py
@@ -71,6 +71,8 @@ def _advance_counter_from_absolute(counter: Counter, counter_name: str, raw_valu
 
     previous_value = _last_client_counter_values.get(counter_name)
     if previous_value is None:
+        if current_value > 0:
+            counter.inc(current_value)
         _last_client_counter_values[counter_name] = current_value
         return
 

--- a/tests/unit/ws/test_service_metrics.py
+++ b/tests/unit/ws/test_service_metrics.py
@@ -197,6 +197,26 @@ def test_counter_reset_lower_value_does_not_crash_or_negative_increment() -> Non
 
 
 @pytest.mark.unit
+def test_first_scrape_seeds_counter_from_absolute_client_value() -> None:
+    client = svc.app.test_client()
+    baseline = _metric_value(client.get("/metrics").data.decode(), "decoded_messages_total")
+
+    svc.ws_client = _DummyClient(
+        [
+            {
+                "decoded_messages_total": 12,
+                "decode_errors_total": 0,
+                "ws_connected": 1,
+                "last_message_ts_ms": 1700000000001,
+            }
+        ]
+    )
+
+    seeded = _metric_value(client.get("/metrics").data.decode(), "decoded_messages_total")
+    assert seeded == baseline + 12
+
+
+@pytest.mark.unit
 def test_load_mexc_client_class_raises_runtime_error_when_dependency_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/ws/test_service_metrics.py
+++ b/tests/unit/ws/test_service_metrics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 from pathlib import Path
 import re
 import sys
@@ -193,3 +194,22 @@ def test_counter_reset_lower_value_does_not_crash_or_negative_increment() -> Non
     assert second_errors == first_errors
     assert third_decoded == second_decoded + 1
     assert third_errors == second_errors
+
+
+@pytest.mark.unit
+def test_load_mexc_client_class_raises_runtime_error_when_dependency_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_import = builtins.__import__
+
+    def _blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "mexc_v3_client":
+            raise ModuleNotFoundError("No module named 'websockets'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+    with pytest.raises(
+        RuntimeError, match="MEXC WS client dependencies are required for WS_SOURCE=mexc_pb"
+    ):
+        svc._load_mexc_client_class()

--- a/tests/unit/ws/test_service_metrics.py
+++ b/tests/unit/ws/test_service_metrics.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WS_SERVICE_DIR = REPO_ROOT / "services" / "ws"
+if str(WS_SERVICE_DIR) not in sys.path:
+    sys.path.insert(0, str(WS_SERVICE_DIR))
+
+import services.ws.service as svc
+
+
+def _metric_value(metrics_text: str, metric_name: str) -> float:
+    match = re.search(rf"^{metric_name}\s+([0-9eE\.\+\-]+)$", metrics_text, re.MULTILINE)
+    assert match is not None, f"Metric {metric_name} not found in payload"
+    return float(match.group(1))
+
+
+class _DummyClient:
+    def __init__(self, snapshots: list[dict[str, int | float]]) -> None:
+        self._snapshots = snapshots
+        self._index = 0
+
+    def get_metrics(self) -> dict[str, int | float]:
+        if self._index >= len(self._snapshots):
+            return self._snapshots[-1]
+        value = self._snapshots[self._index]
+        self._index += 1
+        return value
+
+
+@pytest.fixture(autouse=True)
+def _reset_ws_metrics_state():
+    original_client = svc.ws_client
+    svc.ws_client = None
+    svc._last_client_counter_values["decoded_messages_total"] = None
+    svc._last_client_counter_values["decode_errors_total"] = None
+    yield
+    svc.ws_client = original_client
+    svc._last_client_counter_values["decoded_messages_total"] = None
+    svc._last_client_counter_values["decode_errors_total"] = None
+
+
+@pytest.mark.unit
+def test_metrics_stub_mode_without_ws_client_returns_200() -> None:
+    client = svc.app.test_client()
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert "text/plain" in response.content_type
+
+
+@pytest.mark.unit
+def test_metrics_with_dummy_client_returns_all_expected_metrics() -> None:
+    svc.ws_client = _DummyClient(
+        [
+            {
+                "decoded_messages_total": 12,
+                "decode_errors_total": 3,
+                "ws_connected": 1,
+                "last_message_ts_ms": 1700000000000,
+            }
+        ]
+    )
+
+    client = svc.app.test_client()
+    response = client.get("/metrics")
+
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert "decoded_messages_total" in body
+    assert "decode_errors_total" in body
+    assert "ws_connected" in body
+    assert "last_message_ts_ms" in body
+
+
+@pytest.mark.unit
+def test_repeated_scrape_same_absolute_values_does_not_double_increment() -> None:
+    svc.ws_client = _DummyClient(
+        [
+            {
+                "decoded_messages_total": 10,
+                "decode_errors_total": 2,
+                "ws_connected": 1,
+                "last_message_ts_ms": 1700000000100,
+            },
+            {
+                "decoded_messages_total": 10,
+                "decode_errors_total": 2,
+                "ws_connected": 1,
+                "last_message_ts_ms": 1700000000200,
+            },
+        ]
+    )
+
+    client = svc.app.test_client()
+    first = client.get("/metrics")
+    second = client.get("/metrics")
+
+    first_text = first.data.decode()
+    second_text = second.data.decode()
+    assert _metric_value(second_text, "decoded_messages_total") == _metric_value(
+        first_text, "decoded_messages_total"
+    )
+    assert _metric_value(second_text, "decode_errors_total") == _metric_value(
+        first_text, "decode_errors_total"
+    )
+
+
+@pytest.mark.unit
+def test_scrape_with_increasing_absolute_values_increments_by_delta() -> None:
+    svc.ws_client = _DummyClient(
+        [
+            {
+                "decoded_messages_total": 10,
+                "decode_errors_total": 2,
+                "ws_connected": 1,
+                "last_message_ts_ms": 1700000000100,
+            },
+            {
+                "decoded_messages_total": 15,
+                "decode_errors_total": 3,
+                "ws_connected": 1,
+                "last_message_ts_ms": 1700000000200,
+            },
+        ]
+    )
+
+    client = svc.app.test_client()
+    first = client.get("/metrics")
+    second = client.get("/metrics")
+
+    first_text = first.data.decode()
+    second_text = second.data.decode()
+    assert _metric_value(second_text, "decoded_messages_total") == _metric_value(
+        first_text, "decoded_messages_total"
+    ) + 5
+    assert _metric_value(second_text, "decode_errors_total") == _metric_value(
+        first_text, "decode_errors_total"
+    ) + 1
+
+
+@pytest.mark.unit
+def test_counter_reset_lower_value_does_not_crash_or_negative_increment() -> None:
+    svc.ws_client = _DummyClient(
+        [
+            {
+                "decoded_messages_total": 10,
+                "decode_errors_total": 2,
+                "ws_connected": 1,
+                "last_message_ts_ms": 1700000000100,
+            },
+            {
+                "decoded_messages_total": 3,
+                "decode_errors_total": 1,
+                "ws_connected": 1,
+                "last_message_ts_ms": 1700000000200,
+            },
+            {
+                "decoded_messages_total": 4,
+                "decode_errors_total": 1,
+                "ws_connected": 1,
+                "last_message_ts_ms": 1700000000300,
+            },
+        ]
+    )
+
+    client = svc.app.test_client()
+    first = client.get("/metrics")
+    second = client.get("/metrics")
+    third = client.get("/metrics")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert third.status_code == 200
+
+    first_text = first.data.decode()
+    second_text = second.data.decode()
+    third_text = third.data.decode()
+
+    first_decoded = _metric_value(first_text, "decoded_messages_total")
+    second_decoded = _metric_value(second_text, "decoded_messages_total")
+    third_decoded = _metric_value(third_text, "decoded_messages_total")
+    first_errors = _metric_value(first_text, "decode_errors_total")
+    second_errors = _metric_value(second_text, "decode_errors_total")
+    third_errors = _metric_value(third_text, "decode_errors_total")
+
+    assert second_decoded == first_decoded
+    assert second_errors == first_errors
+    assert third_decoded == second_decoded + 1
+    assert third_errors == second_errors


### PR DESCRIPTION
## Summary

- fix `cdb_ws` `/metrics` 500 caused by using `.set(...)` on Prometheus `Counter`
- export absolute client counters via counter-safe delta updates
- keep `ws_connected` and `last_message_ts_ms` as gauges
- add regression coverage for repeated scrapes and client counter resets

## Context

- LR-030 final runtime preflight for #2440 is blocked by live alert gates.
- RCA found `cdb_ws` healthy on `/health`, but `/metrics` returned 500 and Prometheus marked `cdb_ws` down.
- Historical context: #341 covered the same monitoring surface but is already closed; this PR does not reopen or close it.

## Validation

- `python -m pytest tests/unit -k "ws and metrics" -q`
- `python -m py_compile services/ws/service.py`
- `git diff --stat`
- `gh pr list --state open --limit 20`

Refs #2440