### PR TITLE
fix(compose): align postgres exporter DSN wiring

### DIFF
--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -157,10 +157,13 @@ services:
     image: prometheuscommunity/postgres-exporter:latest
     container_name: cdb_postgres_exporter
     restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-claire_user}
+      POSTGRES_DB: ${POSTGRES_DB:-claire_de_binare}
     secrets:
-      - postgres_password_dsn
+      - postgres_password
     entrypoint: ["/bin/sh", "-c"]
-    command: ["DATA_SOURCE_NAME=$$(cat /run/secrets/postgres_password_dsn) exec /bin/postgres_exporter"]
+    command: ["DATA_SOURCE_NAME=\"host=cdb_postgres port=5432 user=$${POSTGRES_USER} dbname=$${POSTGRES_DB} password=$$(cat /run/secrets/postgres_password | tr -d '\\n') sslmode=disable\" exec /bin/postgres_exporter"]
     healthcheck:
       test: ["CMD-SHELL", "nc -z localhost 9187 || exit 1"]
       interval: 30s

--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -163,7 +163,7 @@ services:
     secrets:
       - postgres_password
     entrypoint: ["/bin/sh", "-c"]
-    command: ["DATA_SOURCE_NAME=\"host=cdb_postgres port=5432 user=$${POSTGRES_USER} dbname=$${POSTGRES_DB} password=$$(cat /run/secrets/postgres_password | tr -d '\\n') sslmode=disable\" exec /bin/postgres_exporter"]
+    command: ["export PGPASSWORD=\"$$(cat /run/secrets/postgres_password | tr -d '\\n')\" && DATA_SOURCE_NAME=\"host=cdb_postgres port=5432 user=$${POSTGRES_USER} dbname=$${POSTGRES_DB} sslmode=disable\" exec /bin/postgres_exporter"]
     healthcheck:
       test: ["CMD-SHELL", "nc -z localhost 9187 || exit 1"]
       interval: 30s


### PR DESCRIPTION
## Summary

- align cdb_postgres_exporter in compose.red.yml with the password-based DSN contract used by base compose
- stop relying on ambiguous postgres_password_dsn input for exporter wiring
- build DATA_SOURCE_NAME from host/user/db plus the postgres_password secret
- keep secret values out of repo, logs, and PR output

## Context

- LR-030 final runtime preflight for #2440 remains blocked by alert gates.
- RCA found cdb_postgres healthy and reachable while pg_up=0 / DatabaseConnectionLost stayed firing.
- Exporter logs indicated malformed DSN / DSN interpretation issues; secret surface was redacted.
- PR #2453 already fixed the separate cdb_ws /metrics blocker.

## Validation

- python -m py_compile infrastructure/scripts/soak_gate_eval.py
- g -n "cdb_postgres_exporter|DATA_SOURCE_NAME|postgres_password_dsn|postgres_password|pg_up|DatabaseConnectionLost" infrastructure docs tests .github
- git diff --stat
- gh pr list --state open --limit 20

## Guardrails

- No runtime restart.
- No Docker/Compose execution.
- No secret values read or printed.
- No LR/live/echtgeld readiness claim.

Refs #2440