### PR TITLE
feat(surrealdb): add fail-closed db-backed context smoke

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ REPLAY_DETERMINISTIC_VERIFY ?= 1
 
 CONTEXT_SNAP_DIR ?= artifacts/context-intelligence/latest
 
-.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke
+.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke context-smoke-db
 
 help:
 	@echo "Claire de Binare - Test Commands"
@@ -91,6 +91,7 @@ help:
 	@echo "  make context-import-local    - Context-Daten in lokale SurrealDB importieren"
 	@echo "  make context-query-smoke     - Lese-Query-Smoke (graceful fail)"
 	@echo "  make context-smoke           - Komplette lokale Pipeline (smoke test)"
+	@echo "  make context-smoke-db        - Hard fail-closed DB-backed smoke (#2460)"
 # ============================================================================
 # CI-Tests (schnell, mit Mocks)
 # ============================================================================
@@ -364,6 +365,35 @@ context-smoke:
 	$(MAKE) context-query-smoke
 	@echo "[OK] context-smoke: vollstaendige Pipeline abgeschlossen"
 	@echo "Ziel: lokale SurrealDB (127.0.0.1:8010). LR-Verdict: NO-GO"
+
+context-smoke-db: context-env-check
+	@echo "=== Hard DB-backed Context Smoke (fail-closed) #2460 ==="
+	@echo "NOTE: Lokaler Scope nur. LR: NO-GO. Kein Echtgeld. Kein Trading-Start."
+	@echo "--- Schritt 1: Hard Schema-Check (Container + Schema, fail-closed) ---"
+	@python3 tools/surrealdb/local_schema_check.py --hard-mode \
+		--secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}
+	@echo "--- Schritt 2: Scan (Snapshot + JSONL erzeugen) ---"
+	$(MAKE) context-scan
+	@echo "--- Schritt 3: Import (echter SurrealDB-Adapter, fail-closed) ---"
+	@python3 -m tools.surrealdb.context_importer apply \
+		--input-dir $(CONTEXT_SNAP_DIR) \
+		--surreal-url http://127.0.0.1:8010 \
+		--namespace cdb_context_local \
+		--database cdb_context_intel \
+		--apply --apply-mode local-dev \
+		--config infrastructure/config/surrealdb/context_import.local.example.yaml \
+		--run-id $$(date +%Y%m%d%H%M%S) \
+		--adapter surrealdb-local \
+		--secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}
+	@echo "--- Schritt 4: Query-Smoke (hard, >= 1 Record, fail-closed) ---"
+	@python3 -m tools.surrealdb.context_query \
+		--adapter surrealdb-local \
+		--hard-mode \
+		--min-count 1 \
+		--config infrastructure/config/surrealdb/context_query.local.example.yaml \
+		--secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb} \
+		show-snapshot
+	@echo "[OK] context-smoke-db: fail-closed DB-backed smoke complete (LR: NO-GO)"
 
 # ============================================================================# Paper Trading (14-Tage Test)
 # ============================================================================

--- a/docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md
+++ b/docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md
@@ -261,6 +261,49 @@ CONTEXT_SNAP_DIR=/anderer/pfad make context-scan         # Override
 
 **Graceful fail:** `context-query-smoke` gibt `[NOTE]`-Meldungen aus wenn kein Container läuft — das ist kein Fehler, solange `context-scan` und `context-import-dry-run` grün waren.
 
+**Wichtiger Hinweis:** `make context-smoke` ist ein **Pfad-Smoke-only**. Der finale
+`[OK]` beweist nicht, dass `cdb_surrealdb` online ist oder Daten tatsächlich
+geschrieben wurden. Für echten DB-backed Nachweis → `make context-smoke-db`.
+
+---
+
+## Hard DB-backed Smoke (`context-smoke-db`)
+
+**Issue:** #2460 — fail-closed DB-backed context smoke.
+
+Beweist, dass der echte SurrealDB-Container läuft, das Schema vollständig ist,
+Daten importiert wurden und mindestens 1 Record lesbar ist. Schlägt fehl (Exit 1)
+wenn eine Bedingung nicht erfüllt ist.
+
+```bash
+make context-smoke-db
+```
+
+Voraussetzung: `cdb_surrealdb` muss laufen (`make context-up`).
+
+**Schritte:**
+
+| Schritt | Befehl / Flag | Fail-closed |
+|---|---|---|
+| 1 | `local_schema_check.py --hard-mode` | Exit 1 wenn Container offline oder Schema fehlt |
+| 2 | `make context-scan` | Scan + JSONL in `artifacts/context-intelligence/latest/` |
+| 3 | `context_importer apply --adapter surrealdb-local` | Exit 1 wenn DB-Write fehlschlägt |
+| 4 | `context_query --adapter surrealdb-local --hard-mode --min-count 1` | Exit 1 wenn DB offline oder 0 Records |
+
+**Unterschied zu `context-smoke`:**
+
+| Eigenschaft | `context-smoke` | `context-smoke-db` |
+|---|---|---|
+| Container erforderlich | nein (graceful skip) | **ja** (Exit 1 wenn offline) |
+| Echter DB-Write | nein (InMemory-Adapter) | **ja** (`surrealdb-local`-Adapter) |
+| Query-Ergebnis enforced | nein (`[NOTE]` graceful) | **ja** (`--min-count 1`, Exit 1 wenn 0 Records) |
+| CI-geeignet | ja (ohne Container) | nur mit laufendem `cdb_surrealdb` |
+
+**Erfolg:** `[OK] context-smoke-db: fail-closed DB-backed smoke complete (LR: NO-GO)`
+
+**LR-Hinweis:** Dieser Nachweis ist lokale Context-Infrastruktur. LR-Go bleibt
+**NO-GO**. Kein Trading-Start. Kein Echtgeld.
+
 ---
 
 ## Häufige Fehler

--- a/tests/unit/surrealdb/test_context_smoke_db_contracts.py
+++ b/tests/unit/surrealdb/test_context_smoke_db_contracts.py
@@ -1,0 +1,296 @@
+"""Contract tests for the fail-closed DB-backed context smoke (#2460).
+
+Verifies:
+- local_schema_check.py --hard-mode exits 1 when container is offline
+- local_schema_check.py without --hard-mode exits 0 gracefully when offline (regression)
+- context_query.py --min-count N exits 1 when count < N
+- context_query.py --min-count 0 (default) does not enforce a floor
+- context_query.py --min-count N exits 0 when count >= N
+- Makefile context-smoke-db is in .PHONY
+- Makefile context-smoke-db target uses --hard-mode for schema check
+- Makefile context-smoke-db target uses --adapter surrealdb-local
+- Makefile context-smoke-db target uses --hard-mode for query step
+- Makefile context-smoke-db target uses --min-count for query step
+
+No live DB, no Docker, no network. All assertions are unit-level or file-read
+checks.
+
+Issue: #2460
+Epic: #1976
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers / constants
+# ---------------------------------------------------------------------------
+
+_MAKEFILE = Path(__file__).parents[3] / "Makefile"
+_LOCAL_SCHEMA_CHECK = Path(__file__).parents[3] / "tools" / "surrealdb" / "local_schema_check.py"
+_EXAMPLE_QUERY_CONFIG = Path(
+    "infrastructure/config/surrealdb/context_query.local.example.yaml"
+)
+
+
+def _read_makefile() -> str:
+    assert _MAKEFILE.exists(), "Makefile not found"
+    return _MAKEFILE.read_text(encoding="utf-8")
+
+
+def _lines_for_target(content: str, target: str) -> list[str]:
+    """Return all indented recipe lines under a Makefile target."""
+    lines = content.splitlines()
+    in_target = False
+    recipe: list[str] = []
+    for line in lines:
+        if line.startswith(f"{target}:"):
+            in_target = True
+            continue
+        if in_target:
+            if line.startswith("\t"):
+                recipe.append(line)
+            elif line.strip() == "" or line.startswith("#"):
+                continue
+            else:
+                # New non-indented line = new target or variable; stop.
+                break
+    return recipe
+
+
+# ---------------------------------------------------------------------------
+# 1. local_schema_check: --hard-mode exits 1 if container offline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_local_schema_check_hard_mode_exits_nonzero_if_offline() -> None:
+    """--hard-mode must exit 1 when the container is unreachable (#2460)."""
+    from tools.surrealdb import local_schema_check
+
+    with (
+        patch.object(local_schema_check, "_health_check", return_value=False),
+        patch("sys.argv", ["local_schema_check.py", "--hard-mode"]),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        local_schema_check.main()
+
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. local_schema_check: without --hard-mode exits 0 gracefully (regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_local_schema_check_without_hard_mode_exits_zero_if_offline() -> None:
+    """Without --hard-mode, container offline must still exit 0 (regression guard)."""
+    from tools.surrealdb import local_schema_check
+
+    with (
+        patch.object(local_schema_check, "_health_check", return_value=False),
+        patch("sys.argv", ["local_schema_check.py"]),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        local_schema_check.main()
+
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. context_query --min-count exits 1 when count < threshold
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_context_query_min_count_exits_nonzero_if_below_threshold(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """--min-count 1 must cause exit 1 when query returns 0 records."""
+    from tools.surrealdb.context_query import main
+
+    empty_body = json.dumps([{"time": "0ns", "status": "OK", "result": []}]).encode()
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = empty_body
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_opener = MagicMock()
+    mock_opener.open.return_value = mock_resp
+
+    with patch(
+        "urllib.request.build_opener", return_value=mock_opener
+    ):
+        exit_code = main(
+            [
+                "--config",
+                str(_EXAMPLE_QUERY_CONFIG),
+                "--adapter",
+                "surrealdb-local",
+                "--hard-mode",
+                "--min-count",
+                "1",
+                "--secrets-path",
+                "/dev/null",
+                "show-snapshot",
+            ]
+        )
+
+    assert exit_code != 0, f"Expected non-zero exit when count=0 and --min-count=1, got {exit_code}"
+
+
+# ---------------------------------------------------------------------------
+# 4. context_query --min-count 0 (default) does not enforce a floor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_context_query_min_count_default_zero_no_effect(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Default --min-count=0 must not cause exit 1 on empty results."""
+    from tools.surrealdb.context_query import main, NoopQueryAdapter
+
+    with patch(
+        "tools.surrealdb.context_query.NoopQueryAdapter.execute",
+        return_value=[],
+    ):
+        exit_code = main(
+            [
+                "--config",
+                str(_EXAMPLE_QUERY_CONFIG),
+                "--adapter",
+                "noop",
+                "show-snapshot",
+            ]
+        )
+
+    assert exit_code == 0, f"Expected exit 0 with empty results and default --min-count, got {exit_code}"
+
+
+# ---------------------------------------------------------------------------
+# 5. context_query --min-count satisfied exits 0
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_context_query_min_count_satisfied_exits_zero(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """--min-count 1 must exit 0 when query returns >= 1 record."""
+    from tools.surrealdb.context_query import NoopQueryAdapter, main
+
+    one_row = [{"artifact_id": "a-1", "run_id": "r-1"}]
+
+    with patch.object(NoopQueryAdapter, "execute", return_value=one_row):
+        exit_code = main(
+            [
+                "--config",
+                str(_EXAMPLE_QUERY_CONFIG),
+                "--adapter",
+                "noop",
+                "--min-count",
+                "1",
+                "show-snapshot",
+            ]
+        )
+
+    assert exit_code == 0, (
+        f"Expected exit 0 when count=1 >= --min-count=1, got {exit_code}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Makefile: context-smoke-db in .PHONY
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_makefile_context_smoke_db_in_phony() -> None:
+    """context-smoke-db must be declared in .PHONY (#2460)."""
+    content = _read_makefile()
+    phony_lines = [line for line in content.splitlines() if line.startswith(".PHONY:")]
+    assert phony_lines, ".PHONY line not found in Makefile"
+    phony_text = " ".join(phony_lines)
+    assert "context-smoke-db" in phony_text, (
+        "context-smoke-db not found in .PHONY line(s)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. Makefile: context-smoke-db uses --hard-mode in schema check step
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_makefile_context_smoke_db_uses_hard_mode_schema_check() -> None:
+    """context-smoke-db target must invoke local_schema_check.py with --hard-mode."""
+    content = _read_makefile()
+    recipe = _lines_for_target(content, "context-smoke-db")
+    assert recipe, "context-smoke-db target has no recipe lines"
+    recipe_text = "\n".join(recipe)
+    assert "local_schema_check.py" in recipe_text, (
+        "local_schema_check.py not found in context-smoke-db recipe"
+    )
+    assert "--hard-mode" in recipe_text, (
+        "--hard-mode not found in context-smoke-db recipe (schema check step)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. Makefile: context-smoke-db uses --adapter surrealdb-local
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_makefile_context_smoke_db_uses_surrealdb_local_adapter() -> None:
+    """context-smoke-db target must pass --adapter surrealdb-local to the importer."""
+    content = _read_makefile()
+    recipe = _lines_for_target(content, "context-smoke-db")
+    recipe_text = "\n".join(recipe)
+    assert "--adapter surrealdb-local" in recipe_text, (
+        "--adapter surrealdb-local not found in context-smoke-db recipe (import step)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 9. Makefile: context-smoke-db uses --hard-mode in query step
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_makefile_context_smoke_db_uses_hard_mode_query() -> None:
+    """context-smoke-db target must pass --hard-mode to the query step."""
+    content = _read_makefile()
+    recipe = _lines_for_target(content, "context-smoke-db")
+    recipe_text = "\n".join(recipe)
+    assert "context_query" in recipe_text, (
+        "context_query invocation not found in context-smoke-db recipe"
+    )
+    # Count --hard-mode occurrences: must appear at least twice
+    # (once for schema check, once for query)
+    occurrences = recipe_text.count("--hard-mode")
+    assert occurrences >= 2, (
+        f"Expected --hard-mode at least twice in context-smoke-db recipe, found {occurrences}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 10. Makefile: context-smoke-db uses --min-count in query step
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_makefile_context_smoke_db_uses_min_count() -> None:
+    """context-smoke-db target must pass --min-count to the query step."""
+    content = _read_makefile()
+    recipe = _lines_for_target(content, "context-smoke-db")
+    recipe_text = "\n".join(recipe)
+    assert "--min-count" in recipe_text, (
+        "--min-count not found in context-smoke-db recipe (query step)"
+    )

--- a/tests/unit/surrealdb/test_context_smoke_db_contracts.py
+++ b/tests/unit/surrealdb/test_context_smoke_db_contracts.py
@@ -32,7 +32,6 @@ import pytest
 # ---------------------------------------------------------------------------
 
 _MAKEFILE = Path(__file__).parents[3] / "Makefile"
-_LOCAL_SCHEMA_CHECK = Path(__file__).parents[3] / "tools" / "surrealdb" / "local_schema_check.py"
 _EXAMPLE_QUERY_CONFIG = Path(
     "infrastructure/config/surrealdb/context_query.local.example.yaml"
 )

--- a/tools/surrealdb/context_query.py
+++ b/tools/surrealdb/context_query.py
@@ -1559,6 +1559,17 @@ def build_parser() -> argparse.ArgumentParser:
         dest="hard_mode",
         help="Non-zero exit if DB is unreachable (default: soft mode, returns empty results).",
     )
+    parser.add_argument(
+        "--min-count",
+        type=int,
+        default=0,
+        dest="min_count",
+        help=(
+            "Minimum number of records the query must return; exit 1 if count is below "
+            "this threshold (default: 0, no enforcement). Used by 'make context-smoke-db' "
+            "(#2460) to prove real DB records were written."
+        ),
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     classify = subparsers.add_parser(
@@ -1975,6 +1986,28 @@ def main(argv: list[str] | None = None) -> int:
         return EXIT_INTERNAL
 
     print(rendered)
+
+    min_count = getattr(args, "min_count", 0)
+    if exit_code == EXIT_OK and min_count > 0:
+        actual_count = payload.get("count", 0) if isinstance(payload, dict) else 0
+        if actual_count < min_count:
+            print(
+                json.dumps(
+                    {
+                        "schema_version": SCHEMA_VERSION,
+                        "status": "error",
+                        "error": "MIN_COUNT_NOT_MET",
+                        "message": (
+                            f"query returned {actual_count} record(s); "
+                            f"--min-count requires at least {min_count}"
+                        ),
+                    },
+                    ensure_ascii=True,
+                    sort_keys=True,
+                )
+            )
+            return EXIT_VALIDATION_ERROR
+
     return exit_code
 
 

--- a/tools/surrealdb/context_query.py
+++ b/tools/surrealdb/context_query.py
@@ -1985,8 +1985,6 @@ def main(argv: list[str] | None = None) -> int:
         )
         return EXIT_INTERNAL
 
-    print(rendered)
-
     min_count = getattr(args, "min_count", 0)
     if exit_code == EXIT_OK and min_count > 0:
         actual_count = payload.get("count", 0) if isinstance(payload, dict) else 0
@@ -2008,6 +2006,7 @@ def main(argv: list[str] | None = None) -> int:
             )
             return EXIT_VALIDATION_ERROR
 
+    print(rendered)
     return exit_code
 
 

--- a/tools/surrealdb/local_schema_check.py
+++ b/tools/surrealdb/local_schema_check.py
@@ -1,22 +1,29 @@
 """Local SurrealDB schema check — verifies context_intelligence_v0 tables exist.
 
 Local-only guard enforced. No credential output. Exits 0 if all expected tables
-are present, exits 1 if tables are missing. Exits 0 gracefully if container is
-offline (container absence is not an error condition during development).
+are present, exits 1 if tables are missing.
+
+Default (no --hard-mode): Exits 0 gracefully if container is offline (container
+absence is not an error condition during development).
+
+With --hard-mode: Exits 1 if container is offline. This is the authoritative
+fail-closed path used by ``make context-smoke-db`` (#2460).
 
 Issues:
     #2395 - Local schema apply and reset workflow
+    #2460 - fail-closed DB-backed context smoke (--hard-mode)
     Parent: #2391
     Epic: #1976
 
 Usage:
     python tools/surrealdb/local_schema_check.py
     python tools/surrealdb/local_schema_check.py --url http://127.0.0.1:8010
+    python tools/surrealdb/local_schema_check.py --hard-mode
 
 Guardrails:
     - Only connects to 127.0.0.1 or localhost
     - No credential values are ever printed
-    - Graceful exit when container is not running
+    - Graceful exit when container is not running (unless --hard-mode)
     - LR-Go remains NO-GO; this script has no effect on live-readiness
 """
 from __future__ import annotations
@@ -154,12 +161,29 @@ def main() -> None:
     parser.add_argument("--ns", default=DEFAULT_NS)
     parser.add_argument("--db", default=DEFAULT_DB)
     parser.add_argument("--secrets-path", default=None)
+    parser.add_argument(
+        "--hard-mode",
+        action="store_true",
+        default=False,
+        dest="hard_mode",
+        help=(
+            "Fail-closed mode: exit 1 if container is unreachable (default: graceful "
+            "exit 0). Used by 'make context-smoke-db' (#2460) to prove real DB presence."
+        ),
+    )
     args = parser.parse_args()
 
     _guard_local(args.url)
 
     print(f"[INFO] Checking container at {args.url}/health...")
     if not _health_check(args.url):
+        if args.hard_mode:
+            print(
+                "ERROR: cdb_surrealdb not reachable (--hard-mode). "
+                "Run 'make context-up' first.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         print("[WARN] cdb_surrealdb not reachable. Container may not be running.")
         print("       Run 'make context-up' to start the container.")
         print("[SKIP] Schema check skipped (container offline).")


### PR DESCRIPTION
## Summary

Implements #2460 by adding a hard DB-backed Context Intelligence smoke path.

Changes:
- adds `--hard-mode` to `local_schema_check.py`
- adds `--min-count` validation to `context_query.py`
- adds `make context-smoke-db`
- adds unit contract tests for fail-closed behavior
- updates the SurrealDB local runtime runbook to distinguish soft `context-smoke` from hard `context-smoke-db`

## Validation

- `python -m pytest -v -m unit tests/unit/surrealdb/test_context_smoke_db_contracts.py`
- `python -m pytest -q -m unit tests/unit/surrealdb/`
- `git diff --check origin/main...HEAD`

## Notes

`context-smoke-db` is a local-only DB-backed gate. It does not imply Live Readiness, live trading, Echtgeld, LR-GO, or any remote/production DB permission.

Closes #2460.