### PR TITLE
feat(mcp): add local surrealdb read-only context mode

### DIFF
--- a/infrastructure/config/surrealdb/context_query.local.example.yaml
+++ b/infrastructure/config/surrealdb/context_query.local.example.yaml
@@ -112,6 +112,11 @@ allowed_tables:
   - config_reference
   - doc_code_link
   - dependency_edge
+  # Wave-14 MCP context tables (Issue #2461)
+  - evidence_ref
+  - claim
+  - decision_event
+  - agent_memory
 
 forbidden_tables:
   # Trading-state tables -- never allowed in the Context Intelligence DB.

--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -139,7 +139,7 @@ def test_evidence_resolve_db_mode_ok(monkeypatch) -> None:
     assert result["result"]["approval_semantics"]["no_echtgeld_go"] is True
     mock_adapter.execute.assert_called_once()
     call_arg = mock_adapter.execute.call_args[0][0]
-    assert "evidence" in call_arg.lower()
+    assert "evidence_ref" in call_arg.lower()
     assert "SELECT" in call_arg.upper()
 
 
@@ -433,3 +433,68 @@ def test_evidence_resolve_adapter_query_error_propagates(monkeypatch) -> None:
     assert result["status"] == "error"
     assert result["error"]["code"] == "adapter_query_error"
     assert "denied" in result["error"]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Config alignment: allowed_tables covers all Wave-14 handler tables
+# ---------------------------------------------------------------------------
+
+_WAVE14_HANDLER_TABLES = {
+    "evidence_ref",
+    "claim",
+    "agent_memory",
+    "decision_event",
+}
+
+_EXAMPLE_CONFIG_PATH = (
+    "infrastructure/config/surrealdb/context_query.local.example.yaml"
+)
+
+
+@pytest.mark.unit
+def test_example_config_allows_all_wave14_tables() -> None:
+    """All tables queried by the DB-backed Wave-14 handlers must be in
+    the documented example config's allowed_tables list (Issue #2461).
+    """
+    import yaml  # stdlib-bundled via PyYAML; already a project dependency
+
+    with open(_EXAMPLE_CONFIG_PATH) as fh:
+        cfg = yaml.safe_load(fh)
+
+    allowed: set[str] = set(cfg.get("allowed_tables", []))
+    missing = _WAVE14_HANDLER_TABLES - allowed
+    assert missing == set(), (
+        f"Wave-14 tables missing from allowed_tables in {_EXAMPLE_CONFIG_PATH}: "
+        f"{sorted(missing)}"
+    )
+
+
+@pytest.mark.unit
+def test_evidence_handler_queries_evidence_ref_not_evidence(monkeypatch) -> None:
+    """evidence_resolve DB mode must query 'evidence_ref' (schema table name),
+    not 'evidence' (incorrect alias rejected by statement classifier).
+    """
+    mock_adapter = _make_mock_adapter([_EVIDENCE_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    handle_cdb_context_evidence_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "all",
+            },
+        }
+    )
+
+    call_arg = mock_adapter.execute.call_args[0][0]
+    assert (
+        "evidence_ref" in call_arg
+    ), f"Handler must query 'evidence_ref', got: {call_arg!r}"
+    assert "FROM evidence " not in call_arg and not call_arg.endswith(
+        "FROM evidence"
+    ), f"Handler must not query bare 'evidence' table, got: {call_arg!r}"

--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -100,6 +100,17 @@ _EVIDENCE_SCHEMA_RECORD: dict[str, Any] = {
     "freshness": "fresh",
 }
 
+# Record matching SurrealDB claim schema: no topic/topics/artifact_refs/decision_refs.
+_CLAIM_SCHEMA_RECORD: dict[str, Any] = {
+    "claim_id": "claim-schema-001",
+    "title": "Schema-format claim",
+    "statement": "evidence_lookup is read-only",
+    "scope": "wave14",
+    "status": "supported",
+    "evidence_refs": ["ev-db-001"],
+    "confidence": 0.9,
+}
+
 
 def _make_mock_adapter(
     records: list[dict[str, Any]], status: str = "surrealdb-local"
@@ -643,6 +654,107 @@ def test_decision_history_filter_pushdown_by_scope(monkeypatch) -> None:
             "parameters": {
                 "adapter_config_path": _FAKE_CONFIG_PATH,
                 "mode": "by_scope",
+                "scope": "wave14",
+            },
+        }
+    )
+
+    call_arg = mock_adapter.execute.call_args[0][0]
+    assert "WHERE" in call_arg.upper(), f"Expected WHERE clause, got: {call_arg!r}"
+    assert "scope" in call_arg, f"Expected 'scope' in WHERE clause, got: {call_arg!r}"
+    assert (
+        "wave14" in call_arg
+    ), f"Expected scope value in WHERE clause, got: {call_arg!r}"
+
+
+# ---------------------------------------------------------------------------
+# P2 (BuwCW): Claim schema projection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_claim_resolve_normalizes_schema_row(monkeypatch) -> None:
+    """DB rows without topic/artifact_refs/decision_refs must not crash the resolver.
+
+    The SurrealDB claim schema does not define those fields; _normalize_claim_row
+    must add empty defaults so resolve_claims_v1 can operate on them.
+    """
+    mock_adapter = _make_mock_adapter([_CLAIM_SCHEMA_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_claim_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_CLAIM_RESOLVE,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_scope",
+                "scope": "wave14",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    matched = result["result"]["matched_claims"]
+    assert (
+        len(matched) == 1
+    ), f"Expected 1 match after schema normalisation, got {matched}"
+    assert matched[0]["claim_id"] == "claim-schema-001"
+
+
+@pytest.mark.unit
+def test_claim_resolve_filter_pushdown_by_scope(monkeypatch) -> None:
+    """P2: by_scope mode on claim must push a WHERE scope = '...' clause."""
+    mock_adapter = _make_mock_adapter([_CLAIM_SCHEMA_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    handle_cdb_context_claim_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_CLAIM_RESOLVE,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_scope",
+                "scope": "wave14",
+            },
+        }
+    )
+
+    call_arg = mock_adapter.execute.call_args[0][0]
+    assert "WHERE" in call_arg.upper(), f"Expected WHERE clause, got: {call_arg!r}"
+    assert "scope" in call_arg, f"Expected 'scope' in WHERE clause, got: {call_arg!r}"
+    assert (
+        "wave14" in call_arg
+    ), f"Expected scope value in WHERE clause, got: {call_arg!r}"
+
+
+# ---------------------------------------------------------------------------
+# P2 (BuwCZ): Replay filter pushdown using replay_* mode names
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_decision_replay_filter_pushdown_by_scope(monkeypatch) -> None:
+    """P2: replay_by_scope mode must push a WHERE scope = '...' clause."""
+    mock_adapter = _make_mock_adapter([_DECISION_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_decision_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    handle_cdb_context_decision_replay(
+        {
+            "tool": TOOL_CDB_CONTEXT_DECISION_REPLAY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "replay_by_scope",
                 "scope": "wave14",
             },
         }

--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -111,6 +111,19 @@ _CLAIM_SCHEMA_RECORD: dict[str, Any] = {
     "confidence": 0.9,
 }
 
+# Record matching SurrealDB agent_memory schema: uses created_by (not agent),
+# ttl (not ttl_days), and omits topic/topics/artifact_refs/decision_refs.
+_MEMORY_SCHEMA_RECORD: dict[str, Any] = {
+    "memory_id": "mem-schema-001",
+    "scope": "wave14",
+    "namespace": "session",
+    "memory_type": "constraint",
+    "content": "All MCP tools are read-only",
+    "created_by": "agent-test-001",
+    "ttl": 7,
+    "source_refs": ["docs/AGENTS.md"],
+}
+
 
 def _make_mock_adapter(
     records: list[dict[str, Any]], status: str = "surrealdb-local"
@@ -766,3 +779,96 @@ def test_decision_replay_filter_pushdown_by_scope(monkeypatch) -> None:
     assert (
         "wave14" in call_arg
     ), f"Expected scope value in WHERE clause, got: {call_arg!r}"
+
+
+# ---------------------------------------------------------------------------
+# Bu_hB: invalid limit returns structured MCP error (not bare ValueError)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_evidence_resolve_db_limit_invalid_returns_error(monkeypatch) -> None:
+    """Bu_hB: limit='bad' must return invalid_parameters error, not raise ValueError."""
+    mock_adapter = _make_mock_adapter([_EVIDENCE_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_evidence_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_artifact",
+                "artifact": "some/path",
+                "limit": "bad",
+            },
+        }
+    )
+
+    assert result["status"] == "error", result
+    assert result["error"]["code"] == "invalid_parameters"
+    mock_adapter.execute.assert_not_called()
+
+
+@pytest.mark.unit
+def test_memory_get_db_limit_invalid_returns_error(monkeypatch) -> None:
+    """Bu_hB: limit=None (non-integer) in memory handler returns invalid_parameters."""
+    mock_adapter = _make_mock_adapter([_MEMORY_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_memory_get(
+        {
+            "tool": TOOL_CDB_CONTEXT_MEMORY_GET,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_scope",
+                "scope": "wave14",
+                "limit": "not-a-number",
+            },
+        }
+    )
+
+    assert result["status"] == "error", result
+    assert result["error"]["code"] == "invalid_parameters"
+    mock_adapter.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Bu_hE: _normalize_memory_row maps created_by → agent and ttl → ttl_days
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_memory_get_normalizes_schema_row(monkeypatch) -> None:
+    """Bu_hE: created_by maps to agent; by_agent mode returns schema-format record."""
+    mock_adapter = _make_mock_adapter([_MEMORY_SCHEMA_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_memory_get(
+        {
+            "tool": TOOL_CDB_CONTEXT_MEMORY_GET,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_agent",
+                "agent": "agent-test-001",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    matched = result["result"]["matched_memory"]
+    assert (
+        len(matched) == 1
+    ), f"Expected 1 match after schema normalisation, got {matched}"
+    assert matched[0]["memory_id"] == "mem-schema-001"

--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -85,6 +85,21 @@ _DECISION_RECORD: dict[str, Any] = {
     "decision_type": "architectural",
 }
 
+# Record using SurrealDB schema field names (validates, related_artifacts, etc.)
+# instead of the lookup-contract names (claim_refs, artifact_refs, etc.).
+_EVIDENCE_SCHEMA_RECORD: dict[str, Any] = {
+    "evidence_id": "ev-schema-001",
+    "evidence_type": "test_run",
+    "confidence": 0.9,
+    "validates": ["claim-db-001"],
+    "invalidates": [],
+    "related_artifacts": ["tools/surrealdb/evidence_lookup.py"],
+    "related_decisions": ["dec-db-001"],
+    "source_path": "tests/unit/test_foo.py",
+    "comment": "Schema-format evidence record for normalization tests",
+    "freshness": "fresh",
+}
+
 
 def _make_mock_adapter(
     records: list[dict[str, Any]], status: str = "surrealdb-local"
@@ -498,3 +513,144 @@ def test_evidence_handler_queries_evidence_ref_not_evidence(monkeypatch) -> None
     assert "FROM evidence " not in call_arg and not call_arg.endswith(
         "FROM evidence"
     ), f"Handler must not query bare 'evidence' table, got: {call_arg!r}"
+
+
+# ---------------------------------------------------------------------------
+# P1: Field normalization — schema rows must match lookup contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_evidence_resolve_normalizes_schema_fields(monkeypatch) -> None:
+    """P1: adapter returns a row with schema field names (validates, related_artifacts,
+    related_decisions, source_path) instead of the contract names; the handler must
+    normalise them so lookup_evidence_v1 can match.
+    """
+    mock_adapter = _make_mock_adapter([_EVIDENCE_SCHEMA_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_evidence_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_artifact",
+                "artifact": "tools/surrealdb/evidence_lookup.py",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    matched = result["result"]["matched_evidence"]
+    assert (
+        len(matched) == 1
+    ), f"Expected 1 match after schema-field normalisation, got {len(matched)}: {matched}"
+    ev = matched[0]
+    assert ev["evidence_id"] == "ev-schema-001"
+    # Verify normalization produced the contract field names
+    assert "artifact_refs" in ev
+    assert "tools/surrealdb/evidence_lookup.py" in ev["artifact_refs"]
+    assert "claim_refs" in ev
+    assert "claim-db-001" in ev["claim_refs"]
+    assert "decision_refs" in ev
+    assert "dec-db-001" in ev["decision_refs"]
+
+
+# ---------------------------------------------------------------------------
+# P2: Filter pushdown — WHERE clause must be present in the SurrealQL query
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_evidence_resolve_filter_pushdown_by_artifact(monkeypatch) -> None:
+    """P2: by_artifact mode must push a WHERE clause into the SurrealQL query
+    so that records are filtered at DB level, not only in RAM.
+    """
+    mock_adapter = _make_mock_adapter([_EVIDENCE_SCHEMA_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    handle_cdb_context_evidence_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_artifact",
+                "artifact": "tools/surrealdb/evidence_lookup.py",
+            },
+        }
+    )
+
+    call_arg = mock_adapter.execute.call_args[0][0]
+    assert "WHERE" in call_arg.upper(), f"Expected WHERE clause, got: {call_arg!r}"
+    assert (
+        "related_artifacts" in call_arg
+    ), f"Expected 'related_artifacts' in WHERE clause, got: {call_arg!r}"
+    assert (
+        "CONTAINS" in call_arg.upper()
+    ), f"Expected CONTAINS in WHERE clause, got: {call_arg!r}"
+
+
+@pytest.mark.unit
+def test_memory_get_filter_pushdown_by_scope(monkeypatch) -> None:
+    """P2: by_scope mode on agent_memory must push a WHERE scope = '...' clause."""
+    mock_adapter = _make_mock_adapter([_MEMORY_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    handle_cdb_context_memory_get(
+        {
+            "tool": TOOL_CDB_CONTEXT_MEMORY_GET,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_scope",
+                "scope": "wave14",
+            },
+        }
+    )
+
+    call_arg = mock_adapter.execute.call_args[0][0]
+    assert "WHERE" in call_arg.upper(), f"Expected WHERE clause, got: {call_arg!r}"
+    assert "scope" in call_arg, f"Expected 'scope' in WHERE clause, got: {call_arg!r}"
+    assert (
+        "wave14" in call_arg
+    ), f"Expected scope value in WHERE clause, got: {call_arg!r}"
+
+
+@pytest.mark.unit
+def test_decision_history_filter_pushdown_by_scope(monkeypatch) -> None:
+    """P2: by_scope mode on decision_event must push a WHERE scope = '...' clause."""
+    mock_adapter = _make_mock_adapter([_DECISION_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_decision_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    handle_cdb_context_decision_history(
+        {
+            "tool": TOOL_CDB_CONTEXT_DECISION_HISTORY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_scope",
+                "scope": "wave14",
+            },
+        }
+    )
+
+    call_arg = mock_adapter.execute.call_args[0][0]
+    assert "WHERE" in call_arg.upper(), f"Expected WHERE clause, got: {call_arg!r}"
+    assert "scope" in call_arg, f"Expected 'scope' in WHERE clause, got: {call_arg!r}"
+    assert (
+        "wave14" in call_arg
+    ), f"Expected scope value in WHERE clause, got: {call_arg!r}"

--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -1,0 +1,436 @@
+"""Unit tests for Wave-14 MCP tools in DB-backed (surrealdb-local) mode.
+
+Issue #2461 — Wire core context MCP tools to local SurrealDB read-only adapters.
+Parent: #1976
+
+Tests the explicit opt-in adapter path (adapter_config_path param).
+All HTTP / adapter calls are mocked — no real DB or network required.
+
+Markers: @pytest.mark.unit
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.mcp.context_evidence_memory_tools import (
+    TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+    TOOL_CDB_CONTEXT_CLAIM_RESOLVE,
+    TOOL_CDB_CONTEXT_MEMORY_GET,
+    TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+    handle_cdb_context_evidence_resolve,
+    handle_cdb_context_claim_resolve,
+    handle_cdb_context_memory_get,
+    handle_cdb_context_trust_summary,
+)
+from tools.mcp.context_decision_tools import (
+    TOOL_CDB_CONTEXT_DECISION_HISTORY,
+    TOOL_CDB_CONTEXT_DECISION_REPLAY,
+    handle_cdb_context_decision_history,
+    handle_cdb_context_decision_replay,
+)
+from tools.surrealdb.context_query import (
+    QueryAdapter,
+    ContextQueryError,
+    WriteDeniedError,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_CONFIG_PATH = "infrastructure/config/surrealdb/context_query.local.example.yaml"
+
+_EVIDENCE_RECORD: dict[str, Any] = {
+    "evidence_id": "ev-db-001",
+    "title": "DB evidence record",
+    "evidence_type": "test_run",
+    "confidence": 0.85,
+    "stale": False,
+    "blocking_missing": False,
+    "scope": "wave14",
+    "artifact_refs": ["tools/surrealdb/evidence_lookup.py"],
+    "claim_refs": [],
+    "decision_refs": [],
+}
+
+_CLAIM_RECORD: dict[str, Any] = {
+    "claim_id": "claim-db-001",
+    "title": "DB claim record",
+    "statement": "evidence_lookup is read-only",
+    "status": "supported",
+    "scope": "wave14",
+    "topic": "context_tools",
+    "evidence_refs": ["ev-db-001"],
+}
+
+_MEMORY_RECORD: dict[str, Any] = {
+    "memory_id": "mem-db-001",
+    "title": "DB memory record",
+    "content": "All MCP tools are read-only",
+    "memory_type": "constraint",
+    "scope": "wave14",
+    "agent": "copilot",
+    "topic": "context_tools",
+}
+
+_DECISION_RECORD: dict[str, Any] = {
+    "decision_id": "dec-db-001",
+    "title": "DB decision record",
+    "topic": "context_tools",
+    "scope": "wave14",
+    "status": "approved",
+    "decision_type": "architectural",
+}
+
+
+def _make_mock_adapter(
+    records: list[dict[str, Any]], status: str = "surrealdb-local"
+) -> MagicMock:
+    """Return a mock QueryAdapter that returns *records* from execute()."""
+    adapter = MagicMock(spec=QueryAdapter)
+    adapter.status = status
+    adapter.execute.return_value = records
+    return adapter
+
+
+def _patch_adapter_factory(
+    monkeypatch, module_path: str, adapter: MagicMock, config: Any = None
+) -> None:
+    """Patch build_adapter_from_params in *module_path* to return (adapter, config)."""
+    monkeypatch.setattr(
+        module_path,
+        lambda params, tool_name: (adapter, config),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Evidence Resolve — DB mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_evidence_resolve_db_mode_ok(monkeypatch) -> None:
+    """DB mode: adapter returns 1 evidence record → status=ok, source=surrealdb-local."""
+    mock_adapter = _make_mock_adapter([_EVIDENCE_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_evidence_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_artifact",
+                "artifact": "tools/surrealdb/evidence_lookup.py",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    assert result["tool"] == TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE
+    assert result["metadata"]["source"] == "surrealdb-local"
+    assert result["metadata"]["read_only"] is True
+    assert result["result"]["approval_semantics"]["no_echtgeld_go"] is True
+    mock_adapter.execute.assert_called_once()
+    call_arg = mock_adapter.execute.call_args[0][0]
+    assert "evidence" in call_arg.lower()
+    assert "SELECT" in call_arg.upper()
+
+
+@pytest.mark.unit
+def test_evidence_resolve_db_unavailable(monkeypatch) -> None:
+    """DB unavailable: adapter.status transitions to surrealdb-local-unavailable, returns empty result."""
+    mock_adapter = _make_mock_adapter([], status="surrealdb-local-unavailable")
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_evidence_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_artifact",
+                "artifact": "tools/surrealdb/evidence_lookup.py",
+            },
+        }
+    )
+
+    assert result["status"] == "ok"
+    assert result["metadata"]["source"] == "surrealdb-local-unavailable"
+
+
+@pytest.mark.unit
+def test_evidence_resolve_adapter_config_error(monkeypatch) -> None:
+    """Invalid adapter_config_path → status=error, code=adapter_config_error."""
+    monkeypatch.setattr(
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        lambda params, tool_name: {
+            "tool": tool_name,
+            "status": "error",
+            "error": {"code": "adapter_config_error", "message": "config not found"},
+            "metadata": {"query_time_ms": 0, "source": "in_memory", "read_only": True},
+        },
+    )
+
+    result = handle_cdb_context_evidence_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                "adapter_config_path": "/nonexistent/path/config.yaml",
+                "mode": "by_artifact",
+                "artifact": "some/path",
+            },
+        }
+    )
+
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "adapter_config_error"
+
+
+@pytest.mark.unit
+def test_evidence_resolve_in_memory_regression() -> None:
+    """No adapter_config_path → in-memory path unmodified, source=in_memory."""
+    result = handle_cdb_context_evidence_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                "mode": "by_artifact",
+                "artifact": "tools/surrealdb/evidence_lookup.py",
+                "evidence_records": [_EVIDENCE_RECORD],
+            },
+        }
+    )
+
+    assert result["status"] == "ok"
+    assert result["metadata"]["source"] == "in_memory"
+
+
+# ---------------------------------------------------------------------------
+# Claim Resolve — DB mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_claim_resolve_db_mode_ok(monkeypatch) -> None:
+    """DB mode: adapter returns 1 claim record → status=ok, source=surrealdb-local."""
+    mock_adapter = _make_mock_adapter([_CLAIM_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_claim_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_CLAIM_RESOLVE,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_topic",
+                "topic": "context_tools",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    assert result["metadata"]["source"] == "surrealdb-local"
+    assert result["metadata"]["read_only"] is True
+    assert result["result"]["approval_semantics"]["no_echtgeld_go"] is True
+    call_arg = mock_adapter.execute.call_args[0][0]
+    assert "claim" in call_arg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Memory Get — DB mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_memory_get_db_mode_ok(monkeypatch) -> None:
+    """DB mode: adapter returns 1 memory record → status=ok, source=surrealdb-local."""
+    mock_adapter = _make_mock_adapter([_MEMORY_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_memory_get(
+        {
+            "tool": TOOL_CDB_CONTEXT_MEMORY_GET,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_scope",
+                "scope": "wave14",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    assert result["metadata"]["source"] == "surrealdb-local"
+    call_arg = mock_adapter.execute.call_args[0][0]
+    assert "agent_memory" in call_arg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Trust Summary — DB mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_trust_summary_db_mode_ok(monkeypatch) -> None:
+    """DB mode: adapter returns records for all 4 tables → status=ok, source=surrealdb-local."""
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    # Returns different records based on the query (evidence, claim, agent_memory, decision_event)
+    mock_adapter.execute.side_effect = [
+        [_EVIDENCE_RECORD],  # evidence
+        [_CLAIM_RECORD],  # claim
+        [_MEMORY_RECORD],  # agent_memory
+        [_DECISION_RECORD],  # decision_event
+    ]
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "scope": "wave14",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    assert result["metadata"]["source"] == "surrealdb-local"
+    assert result["result"]["approval_semantics"]["no_echtgeld_go"] is True
+    assert mock_adapter.execute.call_count == 4
+
+
+# ---------------------------------------------------------------------------
+# Decision History — DB mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_decision_history_db_mode_ok(monkeypatch) -> None:
+    """DB mode: adapter returns 1 decision_event → status=ok, source=surrealdb-local."""
+    mock_adapter = _make_mock_adapter([_DECISION_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_decision_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_decision_history(
+        {
+            "tool": TOOL_CDB_CONTEXT_DECISION_HISTORY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_topic",
+                "topic": "context_tools",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    assert result["metadata"]["source"] == "surrealdb-local"
+    assert result["result"]["approval_semantics"]["no_echtgeld_go"] is True
+    call_arg = mock_adapter.execute.call_args[0][0]
+    assert "decision_event" in call_arg.lower()
+
+
+@pytest.mark.unit
+def test_decision_history_in_memory_regression() -> None:
+    """No adapter_config_path → in-memory path unmodified, source=in_memory."""
+    result = handle_cdb_context_decision_history(
+        {
+            "tool": TOOL_CDB_CONTEXT_DECISION_HISTORY,
+            "parameters": {
+                "mode": "by_topic",
+                "topic": "context_tools",
+                "decision_events": [_DECISION_RECORD],
+            },
+        }
+    )
+
+    assert result["status"] == "ok"
+    assert result["metadata"]["source"] == "in_memory"
+
+
+# ---------------------------------------------------------------------------
+# Decision Replay — DB mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_decision_replay_db_mode_ok(monkeypatch) -> None:
+    """DB mode: adapter returns 1 decision_event → status=ok, source=surrealdb-local."""
+    mock_adapter = _make_mock_adapter([_DECISION_RECORD])
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_decision_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_decision_replay(
+        {
+            "tool": TOOL_CDB_CONTEXT_DECISION_REPLAY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "replay_by_scope",
+                "scope": "wave14",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    assert result["metadata"]["source"] == "surrealdb-local"
+    call_arg = mock_adapter.execute.call_args[0][0]
+    assert "decision_event" in call_arg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Write-mode enforcement (via adapter query error)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_evidence_resolve_adapter_query_error_propagates(monkeypatch) -> None:
+    """When adapter.execute raises ContextQueryError → status=error, code=adapter_query_error."""
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    mock_adapter.execute.side_effect = WriteDeniedError("INSERT statements are denied")
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_evidence_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_artifact",
+                "artifact": "some/path",
+            },
+        }
+    )
+
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "adapter_query_error"
+    assert "denied" in result["error"]["message"].lower()

--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -34,7 +34,6 @@ from tools.mcp.context_decision_tools import (
 )
 from tools.surrealdb.context_query import (
     QueryAdapter,
-    ContextQueryError,
     WriteDeniedError,
 )
 

--- a/tools/mcp/context_decision_tools.py
+++ b/tools/mcp/context_decision_tools.py
@@ -13,7 +13,11 @@ from tools.surrealdb.decision_replay_builder import (
     DecisionReplayRequest,
     build_decision_replay_v1,
 )
-
+from tools.surrealdb.context_query import ContextQueryError
+from tools.mcp.surrealdb_adapter_factory import (
+    adapter_source,
+    build_adapter_from_params,
+)
 
 TOOL_CDB_CONTEXT_DECISION_HISTORY = "cdb_context_decision_history"
 TOOL_CDB_CONTEXT_DECISION_REPLAY = "cdb_context_decision_replay"
@@ -69,7 +73,9 @@ def _metadata(*, source: str, query_time_ms: int = 0) -> dict[str, Any]:
     }
 
 
-def _error_response(tool: str, *, code: str, message: str, details: Mapping[str, Any] | None = None) -> dict[str, Any]:
+def _error_response(
+    tool: str, *, code: str, message: str, details: Mapping[str, Any] | None = None
+) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "tool": tool,
         "status": "error",
@@ -81,7 +87,9 @@ def _error_response(tool: str, *, code: str, message: str, details: Mapping[str,
     return payload
 
 
-def _ok_response(tool: str, *, result: Mapping[str, Any], source: str = "in_memory") -> dict[str, Any]:
+def _ok_response(
+    tool: str, *, result: Mapping[str, Any], source: str = "in_memory"
+) -> dict[str, Any]:
     return {
         "tool": tool,
         "status": "ok",
@@ -90,7 +98,9 @@ def _ok_response(tool: str, *, result: Mapping[str, Any], source: str = "in_memo
     }
 
 
-def _extract_decision_events(parameters: Mapping[str, Any]) -> Iterable[Mapping[str, Any]] | dict[str, Any]:
+def _extract_decision_events(
+    parameters: Mapping[str, Any],
+) -> Iterable[Mapping[str, Any]] | dict[str, Any]:
     raw = parameters.get("decision_events")
     events = _as_list_of_mappings(raw)
     if events is None:
@@ -103,27 +113,77 @@ def _extract_decision_events(parameters: Mapping[str, Any]) -> Iterable[Mapping[
 
 
 def handle_cdb_context_decision_history(request: Mapping[str, Any]) -> dict[str, Any]:
-    parsed = _parse_tool_request(request, expected_tool=TOOL_CDB_CONTEXT_DECISION_HISTORY)
+    parsed = _parse_tool_request(
+        request, expected_tool=TOOL_CDB_CONTEXT_DECISION_HISTORY
+    )
     if isinstance(parsed, dict):
         return parsed
 
     params = parsed.parameters
 
-    decision_events = _extract_decision_events(params)
-    if isinstance(decision_events, dict):
-        decision_events["tool"] = TOOL_CDB_CONTEXT_DECISION_HISTORY
-        return decision_events
+    # Adapter opt-in (Issue #2461): DB-backed mode when adapter_config_path is set.
+    if params.get("adapter_config_path") is not None:
+        _adapter_result = build_adapter_from_params(
+            params, TOOL_CDB_CONTEXT_DECISION_HISTORY
+        )
+        if isinstance(_adapter_result, dict):
+            return _adapter_result
+        _adapter, _config = _adapter_result
+        _limit = min(
+            int(params.get("limit", 200)), _config.max_limit_hard if _config else 200
+        )
+        try:
+            decision_events: list[Mapping[str, Any]] = _adapter.execute(
+                f"SELECT * FROM decision_event LIMIT {_limit}"
+            )
+        except ContextQueryError as exc:
+            return _error_response(
+                TOOL_CDB_CONTEXT_DECISION_HISTORY,
+                code="adapter_query_error",
+                message=str(exc),
+            )
+        _source = adapter_source(_adapter)
+    else:
+        decision_events = _extract_decision_events(params)
+        if isinstance(decision_events, dict):
+            decision_events["tool"] = TOOL_CDB_CONTEXT_DECISION_HISTORY
+            return decision_events
+        _source = "in_memory"
 
     mode = params.get("mode")
     try:
         history_request = DecisionHistoryQueryRequest(
             mode=str(mode) if mode is not None else "",
-            decision_id=(str(params["decision_id"]).strip() if params.get("decision_id") is not None else None),
-            topic=(str(params["topic"]).strip() if params.get("topic") is not None else None),
-            scope=(str(params["scope"]).strip() if params.get("scope") is not None else None),
-            artifact=(str(params["artifact"]).strip() if params.get("artifact") is not None else None),
-            issue=(str(params["issue"]).strip() if params.get("issue") is not None else None),
-            status=(str(params["status"]).strip() if params.get("status") is not None else None),
+            decision_id=(
+                str(params["decision_id"]).strip()
+                if params.get("decision_id") is not None
+                else None
+            ),
+            topic=(
+                str(params["topic"]).strip()
+                if params.get("topic") is not None
+                else None
+            ),
+            scope=(
+                str(params["scope"]).strip()
+                if params.get("scope") is not None
+                else None
+            ),
+            artifact=(
+                str(params["artifact"]).strip()
+                if params.get("artifact") is not None
+                else None
+            ),
+            issue=(
+                str(params["issue"]).strip()
+                if params.get("issue") is not None
+                else None
+            ),
+            status=(
+                str(params["status"]).strip()
+                if params.get("status") is not None
+                else None
+            ),
             limit=int(params.get("limit", 200)),
         )
     except Exception as exc:
@@ -135,8 +195,14 @@ def handle_cdb_context_decision_history(request: Mapping[str, Any]) -> dict[str,
 
     known_evidence_ids_raw = params.get("known_evidence_ids")
     known_claim_ids_raw = params.get("known_claim_ids")
-    known_evidence_ids = set(known_evidence_ids_raw) if isinstance(known_evidence_ids_raw, list) else None
-    known_claim_ids = set(known_claim_ids_raw) if isinstance(known_claim_ids_raw, list) else None
+    known_evidence_ids = (
+        set(known_evidence_ids_raw)
+        if isinstance(known_evidence_ids_raw, list)
+        else None
+    )
+    known_claim_ids = (
+        set(known_claim_ids_raw) if isinstance(known_claim_ids_raw, list) else None
+    )
 
     try:
         result = query_decision_history_v1(
@@ -162,31 +228,83 @@ def handle_cdb_context_decision_history(request: Mapping[str, Any]) -> dict[str,
     )
     result["approval_semantics"] = semantics
 
-    return _ok_response(TOOL_CDB_CONTEXT_DECISION_HISTORY, result=result)
+    return _ok_response(
+        TOOL_CDB_CONTEXT_DECISION_HISTORY, result=result, source=_source
+    )
 
 
 def handle_cdb_context_decision_replay(request: Mapping[str, Any]) -> dict[str, Any]:
-    parsed = _parse_tool_request(request, expected_tool=TOOL_CDB_CONTEXT_DECISION_REPLAY)
+    parsed = _parse_tool_request(
+        request, expected_tool=TOOL_CDB_CONTEXT_DECISION_REPLAY
+    )
     if isinstance(parsed, dict):
         return parsed
 
     params = parsed.parameters
 
-    decision_events = _extract_decision_events(params)
-    if isinstance(decision_events, dict):
-        decision_events["tool"] = TOOL_CDB_CONTEXT_DECISION_REPLAY
-        return decision_events
+    # Adapter opt-in (Issue #2461)
+    if params.get("adapter_config_path") is not None:
+        _adapter_result = build_adapter_from_params(
+            params, TOOL_CDB_CONTEXT_DECISION_REPLAY
+        )
+        if isinstance(_adapter_result, dict):
+            return _adapter_result
+        _adapter, _config = _adapter_result
+        _limit = min(
+            int(params.get("limit", 50)), _config.max_limit_hard if _config else 50
+        )
+        try:
+            decision_events: list[Mapping[str, Any]] = _adapter.execute(
+                f"SELECT * FROM decision_event LIMIT {_limit}"
+            )
+        except ContextQueryError as exc:
+            return _error_response(
+                TOOL_CDB_CONTEXT_DECISION_REPLAY,
+                code="adapter_query_error",
+                message=str(exc),
+            )
+        _source = adapter_source(_adapter)
+    else:
+        decision_events = _extract_decision_events(params)
+        if isinstance(decision_events, dict):
+            decision_events["tool"] = TOOL_CDB_CONTEXT_DECISION_REPLAY
+            return decision_events
+        _source = "in_memory"
 
     mode = params.get("mode")
     try:
         replay_request = DecisionReplayRequest(
             mode=str(mode) if mode is not None else "",
-            decision_id=(str(params["decision_id"]).strip() if params.get("decision_id") is not None else None),
-            topic=(str(params["topic"]).strip() if params.get("topic") is not None else None),
-            scope=(str(params["scope"]).strip() if params.get("scope") is not None else None),
-            artifact=(str(params["artifact"]).strip() if params.get("artifact") is not None else None),
-            status=(str(params["status"]).strip() if params.get("status") is not None else None),
-            date_range=(_as_mapping(params.get("date_range")) if params.get("date_range") is not None else None),
+            decision_id=(
+                str(params["decision_id"]).strip()
+                if params.get("decision_id") is not None
+                else None
+            ),
+            topic=(
+                str(params["topic"]).strip()
+                if params.get("topic") is not None
+                else None
+            ),
+            scope=(
+                str(params["scope"]).strip()
+                if params.get("scope") is not None
+                else None
+            ),
+            artifact=(
+                str(params["artifact"]).strip()
+                if params.get("artifact") is not None
+                else None
+            ),
+            status=(
+                str(params["status"]).strip()
+                if params.get("status") is not None
+                else None
+            ),
+            date_range=(
+                _as_mapping(params.get("date_range"))
+                if params.get("date_range") is not None
+                else None
+            ),
             limit=int(params.get("limit", 50)),
         )
     except Exception as exc:
@@ -198,15 +316,23 @@ def handle_cdb_context_decision_replay(request: Mapping[str, Any]) -> dict[str, 
 
     known_evidence_ids_raw = params.get("known_evidence_ids")
     known_claim_ids_raw = params.get("known_claim_ids")
-    known_evidence_ids = set(known_evidence_ids_raw) if isinstance(known_evidence_ids_raw, list) else None
-    known_claim_ids = set(known_claim_ids_raw) if isinstance(known_claim_ids_raw, list) else None
+    known_evidence_ids = (
+        set(known_evidence_ids_raw)
+        if isinstance(known_evidence_ids_raw, list)
+        else None
+    )
+    known_claim_ids = (
+        set(known_claim_ids_raw) if isinstance(known_claim_ids_raw, list) else None
+    )
 
     evidence_summaries = _as_mapping(params.get("evidence_summaries"))
     claim_summaries = _as_mapping(params.get("claim_summaries"))
 
     stop_conditions_raw = params.get("stop_conditions")
     stop_conditions: list[dict[str, Any]] | None = None
-    if isinstance(stop_conditions_raw, list) and all(isinstance(x, Mapping) for x in stop_conditions_raw):
+    if isinstance(stop_conditions_raw, list) and all(
+        isinstance(x, Mapping) for x in stop_conditions_raw
+    ):
         stop_conditions = [dict(x) for x in stop_conditions_raw]
 
     try:
@@ -227,4 +353,4 @@ def handle_cdb_context_decision_replay(request: Mapping[str, Any]) -> dict[str, 
             details={"mode": replay_request.mode},
         )
 
-    return _ok_response(TOOL_CDB_CONTEXT_DECISION_REPLAY, result=result)
+    return _ok_response(TOOL_CDB_CONTEXT_DECISION_REPLAY, result=result, source=_source)

--- a/tools/mcp/context_decision_tools.py
+++ b/tools/mcp/context_decision_tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping
 
@@ -21,6 +22,44 @@ from tools.mcp.surrealdb_adapter_factory import (
 
 TOOL_CDB_CONTEXT_DECISION_HISTORY = "cdb_context_decision_history"
 TOOL_CDB_CONTEXT_DECISION_REPLAY = "cdb_context_decision_replay"
+
+# ── DB query helpers (Issue #2461: filter-pushdown) ────────────────────────────
+
+_SURQL_SAFE_RE = re.compile(r"^[a-zA-Z0-9/_.@:#+ \-]+$")
+
+
+def _safe_surql_str(value: str | None) -> str | None:
+    """Return *value* if safe for SurrealQL string embedding, else None."""
+    if not value:
+        return None
+    text = value.strip()
+    return text if (text and _SURQL_SAFE_RE.match(text)) else None
+
+
+def _build_decision_event_where(params: Mapping[str, Any]) -> str:
+    """Build a SurrealQL WHERE clause for the decision_event table."""
+
+    def _opt(key: str) -> str | None:
+        v = params.get(key)
+        if v is None:
+            return None
+        return _safe_surql_str(str(v).strip() or None)
+
+    mode_raw = params.get("mode")
+    mode = str(mode_raw).strip() if mode_raw is not None else ""
+    if mode == "by_scope":
+        val = _opt("scope")
+        if val:
+            return f"WHERE scope = '{val}'"
+    elif mode == "by_status":
+        val = _opt("status")
+        if val:
+            return f"WHERE status = '{val}'"
+    elif mode == "by_decision_id":
+        val = _opt("decision_id")
+        if val:
+            return f"WHERE decision_id = '{val}'"
+    return ""
 
 
 @dataclass(frozen=True)
@@ -132,9 +171,11 @@ def handle_cdb_context_decision_history(request: Mapping[str, Any]) -> dict[str,
         _limit = min(
             int(params.get("limit", 200)), _config.max_limit_hard if _config else 200
         )
+        _where = _build_decision_event_where(params)
+        _suffix = f" {_where}" if _where else ""
         try:
             decision_events: list[Mapping[str, Any]] = _adapter.execute(
-                f"SELECT * FROM decision_event LIMIT {_limit}"
+                f"SELECT * FROM decision_event{_suffix} LIMIT {_limit}"
             )
         except ContextQueryError as exc:
             return _error_response(
@@ -253,9 +294,11 @@ def handle_cdb_context_decision_replay(request: Mapping[str, Any]) -> dict[str, 
         _limit = min(
             int(params.get("limit", 50)), _config.max_limit_hard if _config else 50
         )
+        _where = _build_decision_event_where(params)
+        _suffix = f" {_where}" if _where else ""
         try:
             decision_events: list[Mapping[str, Any]] = _adapter.execute(
-                f"SELECT * FROM decision_event LIMIT {_limit}"
+                f"SELECT * FROM decision_event{_suffix} LIMIT {_limit}"
             )
         except ContextQueryError as exc:
             return _error_response(

--- a/tools/mcp/context_decision_tools.py
+++ b/tools/mcp/context_decision_tools.py
@@ -59,6 +59,26 @@ def _build_decision_event_where(params: Mapping[str, Any]) -> str:
         val = _opt("decision_id")
         if val:
             return f"WHERE decision_id = '{val}'"
+    # Replay mode aliases: decision_replay sends replay_* prefixed mode names.
+    elif mode == "replay_by_scope":
+        val = _opt("scope")
+        if val:
+            return f"WHERE scope = '{val}'"
+    elif mode == "replay_by_status":
+        val = _opt("status")
+        if val:
+            return f"WHERE status = '{val}'"
+    elif mode == "replay_by_decision_id":
+        val = _opt("decision_id")
+        if val:
+            return f"WHERE decision_id = '{val}'"
+    elif mode == "replay_by_artifact":
+        # decision_event schema uses affected_artifacts for artifact references
+        val = _opt("artifact")
+        if val:
+            return f"WHERE affected_artifacts CONTAINS '{val}'"
+    # replay_current_for_topic / replay_superseded_for_topic: no direct topic
+    # field in the decision_event DB schema; in-memory filter handles them.
     return ""
 
 

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -13,6 +13,7 @@ All tools are read-only, fail-closed, and carry explicit no-echtgeld-go semantic
 from __future__ import annotations
 
 import logging
+import re
 
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping
@@ -151,6 +152,123 @@ def _extract_records(
     return records
 
 
+# ── DB query helpers (Issue #2461: filter-pushdown + schema normalisation) ───
+
+# Strict allow-list for values embedded in SurrealQL WHERE clauses.
+# Fail-closed: values with characters outside this set → filter is omitted
+# and the full page is returned for in-memory filtering.
+_SURQL_SAFE_RE = re.compile(r"^[a-zA-Z0-9/_.@:#+ \-]+$")
+
+
+def _safe_surql_str(value: str | None) -> str | None:
+    """Return *value* if safe for SurrealQL string embedding, else None."""
+    if not value:
+        return None
+    text = value.strip()
+    return text if (text and _SURQL_SAFE_RE.match(text)) else None
+
+
+def _normalize_evidence_ref_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Project SurrealDB evidence_ref schema fields to the lookup-contract names.
+
+    SurrealDB schema  → Wave-14 lookup contract
+    ─────────────────────────────────────────────
+    validates         → claim_refs
+    related_artifacts → artifact_refs
+    related_decisions → decision_refs
+    source_path (str) → source_refs (list)
+
+    Contract fields already present in the row are preserved as-is so that
+    in-memory fixtures with pre-mapped field names pass through unchanged.
+    """
+    result = dict(row)
+    if "claim_refs" not in result:
+        result["claim_refs"] = list(result.get("validates") or [])
+    if "artifact_refs" not in result:
+        result["artifact_refs"] = list(result.get("related_artifacts") or [])
+    if "decision_refs" not in result:
+        result["decision_refs"] = list(result.get("related_decisions") or [])
+    if "source_refs" not in result and result.get("source_path"):
+        result["source_refs"] = [result["source_path"]]
+    return result
+
+
+def _build_evidence_ref_where(params: Mapping[str, Any]) -> str:
+    """Build a SurrealQL WHERE clause for the evidence_ref table.
+
+    Maps lookup-contract mode names to the SurrealDB schema field names.
+    Returns an empty string when no safe filter can be constructed;
+    the caller falls back to fetching the full page for in-memory filtering.
+    """
+    mode = _as_str_or_none(params.get("mode")) or "by_artifact"
+    if mode == "by_artifact":
+        val = _safe_surql_str(_as_str_or_none(params.get("artifact")))
+        if val:
+            return f"WHERE related_artifacts CONTAINS '{val}'"
+    elif mode == "by_claim":
+        val = _safe_surql_str(_as_str_or_none(params.get("claim")))
+        if val:
+            return f"WHERE validates CONTAINS '{val}'"
+    elif mode == "by_decision":
+        val = _safe_surql_str(_as_str_or_none(params.get("decision")))
+        if val:
+            return f"WHERE related_decisions CONTAINS '{val}'"
+    elif mode == "by_source_path":
+        val = _safe_surql_str(_as_str_or_none(params.get("source_path")))
+        if val:
+            return f"WHERE string::contains(source_path, '{val}')"
+    elif mode == "by_evidence_type":
+        val = _safe_surql_str(_as_str_or_none(params.get("evidence_type")))
+        if val:
+            return f"WHERE evidence_type = '{val}'"
+    elif mode == "by_confidence":
+        raw = params.get("min_confidence")
+        if raw is not None:
+            try:
+                conf = float(raw)
+                if 0.0 <= conf <= 1.0:
+                    return f"WHERE confidence >= {conf}"
+            except (TypeError, ValueError):
+                pass
+    return ""
+
+
+def _build_claim_where(params: Mapping[str, Any]) -> str:
+    """Build a SurrealQL WHERE clause for the claim table."""
+    mode = _as_str_or_none(params.get("mode")) or "by_topic"
+    if mode == "by_scope":
+        val = _safe_surql_str(_as_str_or_none(params.get("scope")))
+        if val:
+            return f"WHERE scope = '{val}'"
+    elif mode == "by_status":
+        val = _safe_surql_str(_as_str_or_none(params.get("status")))
+        if val:
+            return f"WHERE status = '{val}'"
+    elif mode == "by_claim_id":
+        val = _safe_surql_str(_as_str_or_none(params.get("claim_id")))
+        if val:
+            return f"WHERE claim_id = '{val}'"
+    elif mode == "by_evidence_ref":
+        val = _safe_surql_str(_as_str_or_none(params.get("evidence_ref")))
+        if val:
+            return f"WHERE evidence_refs CONTAINS '{val}'"
+    return ""
+
+
+def _build_memory_where(params: Mapping[str, Any]) -> str:
+    """Build a SurrealQL WHERE clause for the agent_memory table."""
+    mode = _as_str_or_none(params.get("mode")) or "by_scope"
+    if mode == "by_scope":
+        val = _safe_surql_str(_as_str_or_none(params.get("scope")))
+        if val:
+            return f"WHERE scope = '{val}'"
+    elif mode == "by_memory_type":
+        val = _safe_surql_str(_as_str_or_none(params.get("memory_type")))
+        if val:
+            return f"WHERE memory_type = '{val}'"
+    return ""
+
+
 # ── Evidence Resolve ─────────────────────────────────────────────────────────
 
 
@@ -179,9 +297,11 @@ def handle_cdb_context_evidence_resolve(request: Mapping[str, Any]) -> dict[str,
         _limit = min(
             int(params.get("limit", 200)), _config.max_limit_hard if _config else 200
         )
+        _where = _build_evidence_ref_where(params)
+        _suffix = f" {_where}" if _where else ""
         try:
-            evidence_records: list[Mapping[str, Any]] = _adapter.execute(
-                f"SELECT * FROM evidence_ref LIMIT {_limit}"
+            _raw_rows: list[Mapping[str, Any]] = _adapter.execute(
+                f"SELECT * FROM evidence_ref{_suffix} LIMIT {_limit}"
             )
         except ContextQueryError as exc:
             return _error_response(
@@ -189,6 +309,9 @@ def handle_cdb_context_evidence_resolve(request: Mapping[str, Any]) -> dict[str,
                 code="adapter_query_error",
                 message=str(exc),
             )
+        evidence_records: list[Mapping[str, Any]] = [
+            _normalize_evidence_ref_row(row) for row in _raw_rows
+        ]
         _source = adapter_source(_adapter)
     else:
         evidence_records = _extract_records(
@@ -284,9 +407,11 @@ def handle_cdb_context_claim_resolve(request: Mapping[str, Any]) -> dict[str, An
         _limit = min(
             int(params.get("limit", 200)), _config.max_limit_hard if _config else 200
         )
+        _where = _build_claim_where(params)
+        _suffix = f" {_where}" if _where else ""
         try:
             claim_records: list[Mapping[str, Any]] = _adapter.execute(
-                f"SELECT * FROM claim LIMIT {_limit}"
+                f"SELECT * FROM claim{_suffix} LIMIT {_limit}"
             )
         except ContextQueryError as exc:
             return _error_response(
@@ -373,9 +498,11 @@ def handle_cdb_context_memory_get(request: Mapping[str, Any]) -> dict[str, Any]:
         _limit = min(
             int(params.get("limit", 200)), _config.max_limit_hard if _config else 200
         )
+        _where = _build_memory_where(params)
+        _suffix = f" {_where}" if _where else ""
         try:
             memory_records: list[Mapping[str, Any]] = _adapter.execute(
-                f"SELECT * FROM agent_memory LIMIT {_limit}"
+                f"SELECT * FROM agent_memory{_suffix} LIMIT {_limit}"
             )
         except ContextQueryError as exc:
             return _error_response(
@@ -493,7 +620,7 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
         decision_result_raw: dict[str, Any] | None = None
         try:
             evidence_result_raw = lookup_evidence_v1(
-                _ev_raw,
+                [_normalize_evidence_ref_row(r) for r in _ev_raw],
                 EvidenceLookupRequest(
                     mode="by_artifact", artifact=_artifact, limit=_limit
                 ),

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -37,6 +37,16 @@ from tools.surrealdb.trust_summary import (
     TrustSummaryRequest,
     build_trust_summary_v1,
 )
+from tools.surrealdb.decision_history_query import (
+    DecisionHistoryQueryError,
+    DecisionHistoryQueryRequest,
+    query_decision_history_v1,
+)
+from tools.surrealdb.context_query import ContextQueryError
+from tools.mcp.surrealdb_adapter_factory import (
+    adapter_source,
+    build_adapter_from_params,
+)
 
 TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE = "cdb_context_evidence_resolve"
 TOOL_CDB_CONTEXT_CLAIM_RESOLVE = "cdb_context_claim_resolve"
@@ -82,7 +92,9 @@ def _metadata(*, source: str = "in_memory", query_time_ms: int = 0) -> dict[str,
     }
 
 
-def _error_response(tool: str, *, code: str, message: str, details: Mapping[str, Any] | None = None) -> dict[str, Any]:
+def _error_response(
+    tool: str, *, code: str, message: str, details: Mapping[str, Any] | None = None
+) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "tool": tool,
         "status": "error",
@@ -94,7 +106,9 @@ def _error_response(tool: str, *, code: str, message: str, details: Mapping[str,
     return payload
 
 
-def _ok_response(tool: str, *, result: Mapping[str, Any], source: str = "in_memory") -> dict[str, Any]:
+def _ok_response(
+    tool: str, *, result: Mapping[str, Any], source: str = "in_memory"
+) -> dict[str, Any]:
     return {
         "tool": tool,
         "status": "ok",
@@ -146,15 +160,43 @@ def handle_cdb_context_evidence_resolve(request: Mapping[str, Any]) -> dict[str,
     Tool: cdb_context_evidence_resolve
     Read-only, fail-closed, no writes.
     """
-    parsed = _parse_tool_request(request, expected_tool=TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE)
+    parsed = _parse_tool_request(
+        request, expected_tool=TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE
+    )
     if isinstance(parsed, dict):
         return parsed
 
     params = parsed.parameters
 
-    evidence_records = _extract_records(params, "evidence_records", TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE)
-    if isinstance(evidence_records, dict):
-        return evidence_records
+    # Adapter opt-in (Issue #2461): DB-backed mode when adapter_config_path is set.
+    if params.get("adapter_config_path") is not None:
+        _adapter_result = build_adapter_from_params(
+            params, TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE
+        )
+        if isinstance(_adapter_result, dict):
+            return _adapter_result
+        _adapter, _config = _adapter_result
+        _limit = min(
+            int(params.get("limit", 200)), _config.max_limit_hard if _config else 200
+        )
+        try:
+            evidence_records: list[Mapping[str, Any]] = _adapter.execute(
+                f"SELECT * FROM evidence LIMIT {_limit}"
+            )
+        except ContextQueryError as exc:
+            return _error_response(
+                TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+                code="adapter_query_error",
+                message=str(exc),
+            )
+        _source = adapter_source(_adapter)
+    else:
+        evidence_records = _extract_records(
+            params, "evidence_records", TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE
+        )
+        if isinstance(evidence_records, dict):
+            return evidence_records
+        _source = "in_memory"
 
     mode = _as_str_or_none(params.get("mode")) or "by_artifact"
 
@@ -164,7 +206,9 @@ def handle_cdb_context_evidence_resolve(request: Mapping[str, Any]) -> dict[str,
         try:
             freshness_days = int(freshness_raw)
         except (TypeError, ValueError):
-            logging.getLogger(__name__).debug("Invalid freshness_days value, ignoring", exc_info=True)
+            logging.getLogger(__name__).debug(
+                "Invalid freshness_days value, ignoring", exc_info=True
+            )
 
     min_confidence_raw = params.get("min_confidence")
     min_confidence: float | None = None
@@ -172,7 +216,9 @@ def handle_cdb_context_evidence_resolve(request: Mapping[str, Any]) -> dict[str,
         try:
             min_confidence = float(min_confidence_raw)
         except (TypeError, ValueError):
-            logging.getLogger(__name__).debug("Invalid min_confidence value, ignoring", exc_info=True)
+            logging.getLogger(__name__).debug(
+                "Invalid min_confidence value, ignoring", exc_info=True
+            )
 
     try:
         ev_request = EvidenceLookupRequest(
@@ -207,7 +253,9 @@ def handle_cdb_context_evidence_resolve(request: Mapping[str, Any]) -> dict[str,
     semantics["no_echtgeld_go"] = True
     result["approval_semantics"] = semantics
 
-    return _ok_response(TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE, result=result)
+    return _ok_response(
+        TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE, result=result, source=_source
+    )
 
 
 # ── Claim Resolve ────────────────────────────────────────────────────────────
@@ -225,9 +273,35 @@ def handle_cdb_context_claim_resolve(request: Mapping[str, Any]) -> dict[str, An
 
     params = parsed.parameters
 
-    claim_records = _extract_records(params, "claim_records", TOOL_CDB_CONTEXT_CLAIM_RESOLVE)
-    if isinstance(claim_records, dict):
-        return claim_records
+    # Adapter opt-in (Issue #2461)
+    if params.get("adapter_config_path") is not None:
+        _adapter_result = build_adapter_from_params(
+            params, TOOL_CDB_CONTEXT_CLAIM_RESOLVE
+        )
+        if isinstance(_adapter_result, dict):
+            return _adapter_result
+        _adapter, _config = _adapter_result
+        _limit = min(
+            int(params.get("limit", 200)), _config.max_limit_hard if _config else 200
+        )
+        try:
+            claim_records: list[Mapping[str, Any]] = _adapter.execute(
+                f"SELECT * FROM claim LIMIT {_limit}"
+            )
+        except ContextQueryError as exc:
+            return _error_response(
+                TOOL_CDB_CONTEXT_CLAIM_RESOLVE,
+                code="adapter_query_error",
+                message=str(exc),
+            )
+        _source = adapter_source(_adapter)
+    else:
+        claim_records = _extract_records(
+            params, "claim_records", TOOL_CDB_CONTEXT_CLAIM_RESOLVE
+        )
+        if isinstance(claim_records, dict):
+            return claim_records
+        _source = "in_memory"
 
     mode = _as_str_or_none(params.get("mode")) or "by_topic"
 
@@ -251,10 +325,16 @@ def handle_cdb_context_claim_resolve(request: Mapping[str, Any]) -> dict[str, An
         )
 
     known_evidence_ids_raw = params.get("known_evidence_ids")
-    known_evidence_ids = set(known_evidence_ids_raw) if isinstance(known_evidence_ids_raw, list) else None
+    known_evidence_ids = (
+        set(known_evidence_ids_raw)
+        if isinstance(known_evidence_ids_raw, list)
+        else None
+    )
 
     try:
-        result = resolve_claims_v1(claim_records, claim_request, known_evidence_ids=known_evidence_ids)
+        result = resolve_claims_v1(
+            claim_records, claim_request, known_evidence_ids=known_evidence_ids
+        )
     except ClaimResolverError as exc:
         return _error_response(
             TOOL_CDB_CONTEXT_CLAIM_RESOLVE,
@@ -266,7 +346,7 @@ def handle_cdb_context_claim_resolve(request: Mapping[str, Any]) -> dict[str, An
     semantics["no_echtgeld_go"] = True
     result["approval_semantics"] = semantics
 
-    return _ok_response(TOOL_CDB_CONTEXT_CLAIM_RESOLVE, result=result)
+    return _ok_response(TOOL_CDB_CONTEXT_CLAIM_RESOLVE, result=result, source=_source)
 
 
 # ── Memory Get ───────────────────────────────────────────────────────────────
@@ -284,9 +364,33 @@ def handle_cdb_context_memory_get(request: Mapping[str, Any]) -> dict[str, Any]:
 
     params = parsed.parameters
 
-    memory_records = _extract_records(params, "memory_records", TOOL_CDB_CONTEXT_MEMORY_GET)
-    if isinstance(memory_records, dict):
-        return memory_records
+    # Adapter opt-in (Issue #2461)
+    if params.get("adapter_config_path") is not None:
+        _adapter_result = build_adapter_from_params(params, TOOL_CDB_CONTEXT_MEMORY_GET)
+        if isinstance(_adapter_result, dict):
+            return _adapter_result
+        _adapter, _config = _adapter_result
+        _limit = min(
+            int(params.get("limit", 200)), _config.max_limit_hard if _config else 200
+        )
+        try:
+            memory_records: list[Mapping[str, Any]] = _adapter.execute(
+                f"SELECT * FROM agent_memory LIMIT {_limit}"
+            )
+        except ContextQueryError as exc:
+            return _error_response(
+                TOOL_CDB_CONTEXT_MEMORY_GET,
+                code="adapter_query_error",
+                message=str(exc),
+            )
+        _source = adapter_source(_adapter)
+    else:
+        memory_records = _extract_records(
+            params, "memory_records", TOOL_CDB_CONTEXT_MEMORY_GET
+        )
+        if isinstance(memory_records, dict):
+            return memory_records
+        _source = "in_memory"
 
     mode = _as_str_or_none(params.get("mode")) or "by_scope"
 
@@ -296,7 +400,9 @@ def handle_cdb_context_memory_get(request: Mapping[str, Any]) -> dict[str, Any]:
         try:
             freshness_days = int(freshness_raw)
         except (TypeError, ValueError):
-            logging.getLogger(__name__).debug("Invalid freshness_days param, ignoring", exc_info=True)
+            logging.getLogger(__name__).debug(
+                "Invalid freshness_days param, ignoring", exc_info=True
+            )
 
     try:
         mem_request = MemoryReadRequest(
@@ -330,7 +436,7 @@ def handle_cdb_context_memory_get(request: Mapping[str, Any]) -> dict[str, Any]:
     semantics["no_echtgeld_go"] = True
     result["approval_semantics"] = semantics
 
-    return _ok_response(TOOL_CDB_CONTEXT_MEMORY_GET, result=result)
+    return _ok_response(TOOL_CDB_CONTEXT_MEMORY_GET, result=result, source=_source)
 
 
 # ── Trust Summary ─────────────────────────────────────────────────────────────
@@ -356,10 +462,71 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
             message="scope is required for trust summary",
         )
 
-    evidence_result_raw = _as_mapping(params.get("evidence_result"))
-    claim_result_raw = _as_mapping(params.get("claim_result"))
-    decision_result_raw = _as_mapping(params.get("decision_result"))
-    memory_result_raw = _as_mapping(params.get("memory_result"))
+    # Adapter opt-in (Issue #2461): fetch all sub-data from local SurrealDB.
+    if params.get("adapter_config_path") is not None:
+        _adapter_result = build_adapter_from_params(
+            params, TOOL_CDB_CONTEXT_TRUST_SUMMARY
+        )
+        if isinstance(_adapter_result, dict):
+            return _adapter_result
+        _adapter, _config = _adapter_result
+        _limit = min(
+            int(params.get("limit", 200)), _config.max_limit_hard if _config else 200
+        )
+        try:
+            _ev_raw = _adapter.execute(f"SELECT * FROM evidence LIMIT {_limit}")
+            _cl_raw = _adapter.execute(f"SELECT * FROM claim LIMIT {_limit}")
+            _mem_raw = _adapter.execute(f"SELECT * FROM agent_memory LIMIT {_limit}")
+            _dec_raw = _adapter.execute(f"SELECT * FROM decision_event LIMIT {_limit}")
+        except ContextQueryError as exc:
+            return _error_response(
+                TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+                code="adapter_query_error",
+                message=str(exc),
+            )
+        _source = adapter_source(_adapter)
+        _topic = _as_str_or_none(params.get("topic"))
+        _artifact = _as_str_or_none(params.get("artifact"))
+        evidence_result_raw: dict[str, Any] | None = None
+        claim_result_raw: dict[str, Any] | None = None
+        memory_result_raw: dict[str, Any] | None = None
+        decision_result_raw: dict[str, Any] | None = None
+        try:
+            evidence_result_raw = lookup_evidence_v1(
+                _ev_raw,
+                EvidenceLookupRequest(
+                    mode="by_artifact", artifact=_artifact, limit=_limit
+                ),
+            )
+        except EvidenceLookupError:
+            pass
+        try:
+            claim_result_raw = resolve_claims_v1(
+                _cl_raw,
+                ClaimResolveRequest(mode="by_topic", topic=_topic, limit=_limit),
+            )
+        except ClaimResolverError:
+            pass
+        try:
+            memory_result_raw = read_memory_v1(
+                _mem_raw,
+                MemoryReadRequest(mode="by_scope", scope=scope, limit=_limit),
+            )
+        except MemoryReadError:
+            pass
+        try:
+            decision_result_raw = query_decision_history_v1(
+                _dec_raw,
+                DecisionHistoryQueryRequest(mode="by_scope", scope=scope, limit=_limit),
+            )
+        except DecisionHistoryQueryError:
+            pass
+    else:
+        _source = "in_memory"
+        evidence_result_raw = _as_mapping(params.get("evidence_result"))
+        claim_result_raw = _as_mapping(params.get("claim_result"))
+        decision_result_raw = _as_mapping(params.get("decision_result"))
+        memory_result_raw = _as_mapping(params.get("memory_result"))
 
     try:
         trust_request = TrustSummaryRequest(
@@ -393,4 +560,4 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
     semantics["no_echtgeld_go"] = True
     result["approval_semantics"] = semantics
 
-    return _ok_response(TOOL_CDB_CONTEXT_TRUST_SUMMARY, result=result)
+    return _ok_response(TOOL_CDB_CONTEXT_TRUST_SUMMARY, result=result, source=_source)

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -215,6 +215,58 @@ def _normalize_claim_row(row: Mapping[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _normalize_memory_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Project SurrealDB agent_memory schema fields to the memory-reader contract.
+
+    SurrealDB agent_memory schema  → memory reader contract
+    ─────────────────────────────────────────────────────────
+    created_by (str)  → agent    (str)
+    ttl        (int)  → ttl_days (int)   [unit assumed days; only int field present]
+    scope      (str)  → agent fallback if created_by is absent
+
+    Resolver-only fields absent from the schema receive empty defaults so that
+    ``read_memory_v1`` can operate without KeyErrors.  Modes ``by_topic``,
+    ``by_artifact``, and ``by_decision`` will return empty results for rows
+    loaded from a local DB that does not populate those fields.
+    """
+    result = dict(row)
+    if "agent" not in result:
+        result["agent"] = result.get("created_by") or result.get("scope") or ""
+    if "ttl_days" not in result and "ttl" in result:
+        result["ttl_days"] = result["ttl"]
+    if "topic" not in result:
+        result["topic"] = None
+    if "topics" not in result:
+        result["topics"] = []
+    if "artifact_refs" not in result:
+        result["artifact_refs"] = []
+    if "decision_refs" not in result:
+        result["decision_refs"] = []
+    return result
+
+
+def _parse_db_limit(
+    params: Mapping[str, Any], tool: str, *, default: int = 200
+) -> int | dict[str, Any]:
+    """Parse the *limit* parameter, returning a structured error on invalid input.
+
+    The DB-backed handlers compute ``_limit`` before the main ``try`` block, so
+    a raw ``int()`` call would raise ``ValueError`` for malformed client input
+    instead of returning the fail-closed MCP error payload.  This helper catches
+    the conversion error and returns the same ``invalid_parameters`` response
+    used by the rest of the MCP surface.
+    """
+    raw = params.get("limit", default)
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return _error_response(
+            tool,
+            code="invalid_parameters",
+            message=f"limit must be an integer, got {raw!r}",
+        )
+
+
 def _build_evidence_ref_where(params: Mapping[str, Any]) -> str:
     """Build a SurrealQL WHERE clause for the evidence_ref table.
 
@@ -316,9 +368,10 @@ def handle_cdb_context_evidence_resolve(request: Mapping[str, Any]) -> dict[str,
         if isinstance(_adapter_result, dict):
             return _adapter_result
         _adapter, _config = _adapter_result
-        _limit = min(
-            int(params.get("limit", 200)), _config.max_limit_hard if _config else 200
-        )
+        _limit_raw = _parse_db_limit(params, TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE)
+        if isinstance(_limit_raw, dict):
+            return _limit_raw
+        _limit = min(_limit_raw, _config.max_limit_hard if _config else 200)
         _where = _build_evidence_ref_where(params)
         _suffix = f" {_where}" if _where else ""
         try:
@@ -426,9 +479,10 @@ def handle_cdb_context_claim_resolve(request: Mapping[str, Any]) -> dict[str, An
         if isinstance(_adapter_result, dict):
             return _adapter_result
         _adapter, _config = _adapter_result
-        _limit = min(
-            int(params.get("limit", 200)), _config.max_limit_hard if _config else 200
-        )
+        _limit_raw = _parse_db_limit(params, TOOL_CDB_CONTEXT_CLAIM_RESOLVE)
+        if isinstance(_limit_raw, dict):
+            return _limit_raw
+        _limit = min(_limit_raw, _config.max_limit_hard if _config else 200)
         _where = _build_claim_where(params)
         _suffix = f" {_where}" if _where else ""
         try:
@@ -520,9 +574,10 @@ def handle_cdb_context_memory_get(request: Mapping[str, Any]) -> dict[str, Any]:
         if isinstance(_adapter_result, dict):
             return _adapter_result
         _adapter, _config = _adapter_result
-        _limit = min(
-            int(params.get("limit", 200)), _config.max_limit_hard if _config else 200
-        )
+        _limit_raw = _parse_db_limit(params, TOOL_CDB_CONTEXT_MEMORY_GET)
+        if isinstance(_limit_raw, dict):
+            return _limit_raw
+        _limit = min(_limit_raw, _config.max_limit_hard if _config else 200)
         _where = _build_memory_where(params)
         _suffix = f" {_where}" if _where else ""
         try:
@@ -535,6 +590,7 @@ def handle_cdb_context_memory_get(request: Mapping[str, Any]) -> dict[str, Any]:
                 code="adapter_query_error",
                 message=str(exc),
             )
+        memory_records = [_normalize_memory_row(r) for r in memory_records]
         _source = adapter_source(_adapter)
     else:
         memory_records = _extract_records(
@@ -622,9 +678,10 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
         if isinstance(_adapter_result, dict):
             return _adapter_result
         _adapter, _config = _adapter_result
-        _limit = min(
-            int(params.get("limit", 200)), _config.max_limit_hard if _config else 200
-        )
+        _limit_raw = _parse_db_limit(params, TOOL_CDB_CONTEXT_TRUST_SUMMARY)
+        if isinstance(_limit_raw, dict):
+            return _limit_raw
+        _limit = min(_limit_raw, _config.max_limit_hard if _config else 200)
         try:
             _ev_raw = _adapter.execute(f"SELECT * FROM evidence_ref LIMIT {_limit}")
             _cl_raw = _adapter.execute(f"SELECT * FROM claim LIMIT {_limit}")
@@ -665,7 +722,7 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
             )  # soft: available sub-results used
         try:
             memory_result_raw = read_memory_v1(
-                _mem_raw,
+                [_normalize_memory_row(r) for r in _mem_raw],
                 MemoryReadRequest(mode="by_scope", scope=scope, limit=_limit),
             )
         except MemoryReadError as _exc:

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -499,28 +499,28 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
                 ),
             )
         except EvidenceLookupError:
-            pass
+            pass  # soft: trust summary builds from available sub-results only
         try:
             claim_result_raw = resolve_claims_v1(
                 _cl_raw,
                 ClaimResolveRequest(mode="by_topic", topic=_topic, limit=_limit),
             )
         except ClaimResolverError:
-            pass
+            pass  # soft: trust summary builds from available sub-results only
         try:
             memory_result_raw = read_memory_v1(
                 _mem_raw,
                 MemoryReadRequest(mode="by_scope", scope=scope, limit=_limit),
             )
         except MemoryReadError:
-            pass
+            pass  # soft: trust summary builds from available sub-results only
         try:
             decision_result_raw = query_decision_history_v1(
                 _dec_raw,
                 DecisionHistoryQueryRequest(mode="by_scope", scope=scope, limit=_limit),
             )
         except DecisionHistoryQueryError:
-            pass
+            pass  # soft: trust summary builds from available sub-results only
     else:
         _source = "in_memory"
         evidence_result_raw = _as_mapping(params.get("evidence_result"))

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -193,6 +193,28 @@ def _normalize_evidence_ref_row(row: Mapping[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _normalize_claim_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Ensure claim rows have the fields the resolver contract expects.
+
+    The SurrealDB claim table (context_intelligence_v0.surql) does not define
+    ``topic``, ``topics``, ``artifact_refs``, or ``decision_refs``.  This
+    function adds empty defaults so the resolver never KeyErrors on absent
+    fields.  DB-backed lookups should use ``by_scope``, ``by_claim_id``, or
+    ``by_status``; ``by_topic``/``by_artifact``/``by_decision_ref`` modes will
+    return empty results for rows loaded from the local DB.
+    """
+    result = dict(row)
+    if "topics" not in result:
+        result["topics"] = []
+    if "topic" not in result:
+        result["topic"] = None
+    if "artifact_refs" not in result:
+        result["artifact_refs"] = []
+    if "decision_refs" not in result:
+        result["decision_refs"] = []
+    return result
+
+
 def _build_evidence_ref_where(params: Mapping[str, Any]) -> str:
     """Build a SurrealQL WHERE clause for the evidence_ref table.
 
@@ -410,7 +432,7 @@ def handle_cdb_context_claim_resolve(request: Mapping[str, Any]) -> dict[str, An
         _where = _build_claim_where(params)
         _suffix = f" {_where}" if _where else ""
         try:
-            claim_records: list[Mapping[str, Any]] = _adapter.execute(
+            _raw_claim_rows: list[Mapping[str, Any]] = _adapter.execute(
                 f"SELECT * FROM claim{_suffix} LIMIT {_limit}"
             )
         except ContextQueryError as exc:
@@ -419,6 +441,9 @@ def handle_cdb_context_claim_resolve(request: Mapping[str, Any]) -> dict[str, An
                 code="adapter_query_error",
                 message=str(exc),
             )
+        claim_records: list[Mapping[str, Any]] = [
+            _normalize_claim_row(row) for row in _raw_claim_rows
+        ]
         _source = adapter_source(_adapter)
     else:
         claim_records = _extract_records(
@@ -625,29 +650,37 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
                     mode="by_artifact", artifact=_artifact, limit=_limit
                 ),
             )
-        except EvidenceLookupError:
-            pass  # soft: trust summary builds from available sub-results only
+        except EvidenceLookupError as _exc:
+            logging.getLogger(__name__).debug(
+                "trust_summary: evidence lookup skipped (%s)", _exc
+            )  # soft: available sub-results used
         try:
             claim_result_raw = resolve_claims_v1(
-                _cl_raw,
+                [_normalize_claim_row(r) for r in _cl_raw],
                 ClaimResolveRequest(mode="by_topic", topic=_topic, limit=_limit),
             )
-        except ClaimResolverError:
-            pass  # soft: trust summary builds from available sub-results only
+        except ClaimResolverError as _exc:
+            logging.getLogger(__name__).debug(
+                "trust_summary: claim lookup skipped (%s)", _exc
+            )  # soft: available sub-results used
         try:
             memory_result_raw = read_memory_v1(
                 _mem_raw,
                 MemoryReadRequest(mode="by_scope", scope=scope, limit=_limit),
             )
-        except MemoryReadError:
-            pass  # soft: trust summary builds from available sub-results only
+        except MemoryReadError as _exc:
+            logging.getLogger(__name__).debug(
+                "trust_summary: memory lookup skipped (%s)", _exc
+            )  # soft: available sub-results used
         try:
             decision_result_raw = query_decision_history_v1(
                 _dec_raw,
                 DecisionHistoryQueryRequest(mode="by_scope", scope=scope, limit=_limit),
             )
-        except DecisionHistoryQueryError:
-            pass  # soft: trust summary builds from available sub-results only
+        except DecisionHistoryQueryError as _exc:
+            logging.getLogger(__name__).debug(
+                "trust_summary: decision lookup skipped (%s)", _exc
+            )  # soft: available sub-results used
     else:
         _source = "in_memory"
         evidence_result_raw = _as_mapping(params.get("evidence_result"))

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -181,7 +181,7 @@ def handle_cdb_context_evidence_resolve(request: Mapping[str, Any]) -> dict[str,
         )
         try:
             evidence_records: list[Mapping[str, Any]] = _adapter.execute(
-                f"SELECT * FROM evidence LIMIT {_limit}"
+                f"SELECT * FROM evidence_ref LIMIT {_limit}"
             )
         except ContextQueryError as exc:
             return _error_response(
@@ -474,7 +474,7 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
             int(params.get("limit", 200)), _config.max_limit_hard if _config else 200
         )
         try:
-            _ev_raw = _adapter.execute(f"SELECT * FROM evidence LIMIT {_limit}")
+            _ev_raw = _adapter.execute(f"SELECT * FROM evidence_ref LIMIT {_limit}")
             _cl_raw = _adapter.execute(f"SELECT * FROM claim LIMIT {_limit}")
             _mem_raw = _adapter.execute(f"SELECT * FROM agent_memory LIMIT {_limit}")
             _dec_raw = _adapter.execute(f"SELECT * FROM decision_event LIMIT {_limit}")

--- a/tools/mcp/surrealdb_adapter_factory.py
+++ b/tools/mcp/surrealdb_adapter_factory.py
@@ -1,0 +1,148 @@
+"""Adapter factory for DB-backed context MCP tools.
+
+Issue #2461 — Wire core context MCP tools to local SurrealDB read-only adapters.
+Parent: #1976
+
+Provides a single entry-point ``build_adapter_from_params`` that reads an
+optional ``adapter_config_path`` MCP parameter and returns either:
+
+* a ``NoopQueryAdapter`` (no network, ``source="in_memory"``) — the safe
+  default when no adapter config is supplied, or
+* a ``SurrealDBLocalQueryAdapter`` restricted to localhost-only HTTP access.
+
+All callers must check ``isinstance(result, dict)`` before destructuring the
+return value; a dict return means an error-response that should be forwarded
+directly to the MCP client.
+
+Guardrails:
+    - No writes.  ``SurrealDBLocalQueryAdapter`` enforces read-only at
+      statement-classification level independently of this module.
+    - Localhost-only.  ``load_config`` and ``SurrealDBLocalQueryAdapter``
+      both reject non-local URLs.
+    - Soft DB failures.  ``hard_mode=False`` means an unreachable DB returns
+      empty results and sets ``adapter.status = "surrealdb-local-unavailable"``
+      rather than raising.
+    - LR remains NO-GO.  This surface is context/read-only and does not
+      authorize live capital, trading actions, or strategy changes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+from tools.surrealdb.context_query import (
+    ConfigValidationError,
+    ContextQueryConfig,
+    InputNotFoundError,
+    NoopQueryAdapter,
+    QueryAdapter,
+    SurrealDBLocalQueryAdapter,
+    _load_query_credentials,
+    load_config,
+)
+
+logger = logging.getLogger(__name__)
+
+_IN_MEMORY_SOURCE = "in_memory"
+
+
+def _make_adapter_error(tool_name: str, message: str) -> dict[str, Any]:
+    """Build a well-formed MCP error-response dict for adapter config failures."""
+    return {
+        "tool": tool_name,
+        "status": "error",
+        "error": {
+            "code": "adapter_config_error",
+            "message": message,
+        },
+        "metadata": {
+            "query_time_ms": 0,
+            "source": _IN_MEMORY_SOURCE,
+            "read_only": True,
+        },
+    }
+
+
+def adapter_source(adapter: QueryAdapter) -> str:
+    """Map ``adapter.status`` to the MCP ``metadata.source`` label.
+
+    ``NoopQueryAdapter.status`` is ``"noop-no-network"``; all callers expect
+    the label ``"in_memory"`` on the MCP surface.
+    ``SurrealDBLocalQueryAdapter.status`` is already ``"surrealdb-local"`` or
+    ``"surrealdb-local-unavailable"`` — returned unchanged.
+    """
+    status = adapter.status
+    if status == "noop-no-network":
+        return _IN_MEMORY_SOURCE
+    return status
+
+
+def build_adapter_from_params(
+    params: Mapping[str, Any],
+    tool_name: str,
+) -> tuple[QueryAdapter, ContextQueryConfig | None] | dict[str, Any]:
+    """Return ``(adapter, config_or_none)`` or an error-response dict.
+
+    When ``adapter_config_path`` is absent from *params*, returns a
+    ``(NoopQueryAdapter(), None)`` pair — the safe, non-DB default.
+
+    When ``adapter_config_path`` is present:
+
+    1. Loads and validates the YAML config via ``load_config()``.
+    2. Resolves credentials via ``_load_query_credentials()``.
+    3. Instantiates ``SurrealDBLocalQueryAdapter`` with ``hard_mode=False``
+       (soft fallback — DB unreachable → empty results, never fatal for the
+       MCP surface).
+
+    Secrets path resolution order:
+        1. ``params["secrets_path"]``
+        2. Env var ``CDB_CONTEXT_SECRETS_PATH``
+        3. ``None`` (works for ``auth_mode="none"``)
+
+    Returns an error-response dict on any config or credential failure.
+    Callers must check ``isinstance(result, dict)`` before destructuring.
+    """
+    raw_path = params.get("adapter_config_path")
+    if raw_path is None:
+        return NoopQueryAdapter(), None
+
+    config_path = Path(str(raw_path))
+    try:
+        config = load_config(config_path)
+    except (ConfigValidationError, InputNotFoundError) as exc:
+        logger.warning("adapter config load failed (%s): %s", tool_name, exc)
+        return _make_adapter_error(tool_name, str(exc))
+    except Exception as exc:
+        logger.error(
+            "unexpected error loading adapter config (%s): %s",
+            tool_name,
+            exc,
+            exc_info=True,
+        )
+        return _make_adapter_error(tool_name, f"unexpected config error: {exc}")
+
+    raw_secrets = params.get("secrets_path") or os.environ.get(
+        "CDB_CONTEXT_SECRETS_PATH"
+    )
+    secrets_path = Path(str(raw_secrets)) if raw_secrets else None
+
+    try:
+        user, password = _load_query_credentials(config, secrets_path)
+    except (ConfigValidationError, InputNotFoundError) as exc:
+        logger.warning("credentials load failed (%s): %s", tool_name, exc)
+        return _make_adapter_error(tool_name, str(exc))
+
+    adapter = SurrealDBLocalQueryAdapter(
+        surreal_url=config.surreal_url,
+        namespace=config.namespace,
+        database=config.database,
+        user=user,
+        password=password,
+        timeout=config.timeout,
+        hard_mode=False,
+        config=config,
+    )
+    return adapter, config


### PR DESCRIPTION
## Summary

Implements #2461 by adding an explicit opt-in local SurrealDB read-only mode for core Context MCP tools.

Core tools covered:
- Evidence Lookup
- Claim Resolution
- Decision History
- Decision Replay
- Scoped Memory Read
- Trust Summary

## Design

- Default remains safe in-memory / non-DB-backed.
- DB-backed mode is opt-in via adapter config.
- Local SurrealDB read-only adapter is reused.
- No writes, no mutation/admin/apply/reset paths.
- Source metadata distinguishes in-memory, local SurrealDB, and unavailable DB-backed mode.

## Validation

- `ruff check tools/mcp/surrealdb_adapter_factory.py tools/mcp/context_evidence_memory_tools.py tools/mcp/context_decision_tools.py tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py`
- `black --check tools/mcp/surrealdb_adapter_factory.py tools/mcp/context_evidence_memory_tools.py tools/mcp/context_decision_tools.py tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py`
- `pytest -v -m unit tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py`
- `pytest -v -m unit tests/unit/tools/mcp/test_mcp_wave14_tools.py`
- `pytest -v -m unit --ignore=tests/smoke tests/unit/`

## Guardrails

No remote DB mode. No write-capable MCP. No production DB. No Trading Runtime change. No Live Readiness change. LR remains NO-GO.

Closes #2461.