### PR TITLE
docs(db): add readonly discovery login canon

### DIFF
--- a/docs/env/index.md
+++ b/docs/env/index.md
@@ -44,6 +44,23 @@ Canon-Pointer:
 - Self-hosted Runner Env:
   - [`infrastructure/actions-runner/.env.runner.example`](../../infrastructure/actions-runner/.env.runner.example)
 
+## Read-only DB discovery secrets
+
+For later Agent-/MCP-readonly discovery, prefer a dedicated DSN secret name:
+
+- `POSTGRES_READONLY_PASSWORD_DSN` - preferred DSN name for a dedicated readonly
+  login such as `cdb_readonly`
+- `POSTGRES_READONLY_PASSWORD` - optional raw password secret if the operator
+  path keeps password and DSN separately
+
+Guardrails:
+
+- Secret values stay outside the repo in the canonical secret store.
+- Runtime-service credentials such as `claire_user` / `POSTGRES_PASSWORD` are
+  not acceptable for Agent-/MCP-discovery.
+- The canonical readonly-login boundary is documented in
+  [`docs/runbooks/postgres_least_privilege_rls.md`](../runbooks/postgres_least_privilege_rls.md).
+
 ## Wenn du etwas nachschlagen willst
 
 - Defaults und Validierung fuer lokale Laufzeit: [`infrastructure/scripts/check_env.ps1`](../../infrastructure/scripts/check_env.ps1)

--- a/docs/runbooks/postgres_least_privilege_rls.md
+++ b/docs/runbooks/postgres_least_privilege_rls.md
@@ -50,9 +50,42 @@ All scripts are in `infrastructure/database/`:
 | Script | Purpose | Run as |
 |--------|---------|--------|
 | `roles_and_grants.sql` | Create roles + explicit grants (idempotent) | superuser |
+| `operator_create_readonly_login.sql` | Create optional operator-managed readonly login `cdb_readonly` | superuser |
 | `enforce_least_privilege.sql` | Revoke ALL from `claire_user`, assign `cdb_writer` | superuser |
 | `rollback_least_privilege.sql` | Restore `claire_user` ALL PRIVILEGES | superuser |
 | `verify_privileges.sql` | Show effective grants, memberships, ownership | superuser |
+
+## Optional readonly login canon (`cdb_readonly`)
+
+`cdb_reader` remains the canonical `NOLOGIN` read-grant foundation. A dedicated
+readonly login such as `cdb_readonly` is an **optional, operator-managed**
+follow-up for read-only discovery and MCP access.
+
+Guardrails:
+
+- `cdb_readonly` is **not** created by `roles_and_grants.sql`.
+- `cdb_readonly` must inherit read access **only** via `GRANT cdb_reader TO cdb_readonly`.
+- `cdb_readonly` must **not** be a member of `cdb_writer` or `cdb_admin`.
+- `cdb_readonly` must keep these flags: `NOSUPERUSER`, `NOCREATEDB`,
+  `NOCREATEROLE`, `NOREPLICATION`, `NOBYPASSRLS`.
+- The password / DSN must be managed outside the repo via the canonical secret
+  workflow. Do not commit or paste real credentials.
+- `claire_user` is a runtime credential and is **not acceptable** as a
+  readonly Agent-/MCP-discovery login.
+
+Operator entrypoint:
+
+- `infrastructure/database/operator_create_readonly_login.sql`
+
+Before any later `#1905` DB discovery, the operator path must prove a dedicated
+readonly session identity:
+
+```sql
+SELECT current_user, session_user;
+```
+
+Expected: `current_user` must show a dedicated readonly login, preferably
+`cdb_readonly`, or an explicitly approved equivalent readonly principal.
 
 ## Secret Policy
 
@@ -127,16 +160,36 @@ docker exec cdb_postgres psql -U postgres -d claire_de_binare \
 
 This is safe to run at any time. It does not revoke anything from `claire_user`.
 
-### Step 2: Verify roles exist
+### Step 2: Optionally create dedicated readonly login
+
+```bash
+docker exec cdb_postgres psql -U postgres -d claire_de_binare \
+  -v CDB_READONLY_PASSWORD="$CDB_READONLY_PASSWORD" \
+  -f /path/to/operator_create_readonly_login.sql
+```
+
+This is an operator-only step for a dedicated readonly login. It is separate
+from the additive role/grant foundation and must stay secret-free in the repo.
+Load `CDB_READONLY_PASSWORD` from the canonical secret store before invoking
+`psql`; never commit, paste, or log the real value.
+
+### Step 3: Verify roles exist
 
 ```bash
 docker exec cdb_postgres psql -U postgres -d claire_de_binare \
   -f /path/to/verify_privileges.sql
 ```
 
-Check output sections 1-4. Roles should exist, grants should be listed.
+Check output sections 1-8. The readonly verification must confirm:
 
-### Step 3: Enforce (deliberate operator step)
+- `cdb_readonly` has `rolcanlogin = true`
+- no superuser / createdb / createrole / replication / bypassrls flags
+- membership in `cdb_reader`
+- no membership in `cdb_writer` or `cdb_admin`
+- effective `SELECT` on `public.correlation_ledger`
+- no effective `INSERT`, `UPDATE`, or `DELETE` on `public.correlation_ledger`
+
+### Step 4: Enforce (deliberate operator step)
 
 ```bash
 docker exec cdb_postgres psql -U postgres -d claire_de_binare \
@@ -145,9 +198,9 @@ docker exec cdb_postgres psql -U postgres -d claire_de_binare \
 
 After this, `claire_user` can only do what `cdb_writer` allows.
 
-### Step 4: Verify enforcement
+### Step 5: Verify enforcement
 
-Run `verify_privileges.sql` again. Section 5 ("claire_user direct") should
+Run `verify_privileges.sql` again. Section 8 ("claire_user direct") should
 now be empty — all privileges come via `cdb_writer` inheritance.
 
 ## Verify: Denied Operations
@@ -172,6 +225,15 @@ UPDATE orders SET status = 'cancelled' WHERE id = 1;
 UPDATE positions SET current_price = 100.0 WHERE symbol = 'BTCUSDT';
 -- Expected: UPDATE 0 (or UPDATE 1 if row exists) — no permission error
 ```
+
+For readonly discovery, verify session identity separately:
+
+```sql
+SELECT current_database(), current_user, session_user;
+```
+
+Expected: the discovery session shows a dedicated readonly login, preferably
+`cdb_readonly`; `claire_user` is not acceptable for Agent-/MCP-discovery.
 
 ## Rollback
 

--- a/infrastructure/database/operator_create_readonly_login.sql
+++ b/infrastructure/database/operator_create_readonly_login.sql
@@ -1,0 +1,64 @@
+-- ============================================================================
+-- Operator-only readonly login creation
+-- ============================================================================
+-- Purpose:
+--   Create an optional dedicated readonly LOGIN role for discovery / MCP access.
+--
+-- Guardrails:
+--   - Do NOT wire this file into migrations, startup, or docker-entrypoint init.
+--   - Do NOT commit real passwords or secret values.
+--   - Run only as a deliberate operator step after roles_and_grants.sql created
+--     the NOLOGIN role foundation, especially cdb_reader.
+--
+-- Run as superuser:
+--   psql -U postgres -d claire_de_binare -f operator_create_readonly_login.sql
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+\if :{?CDB_READONLY_PASSWORD}
+\else
+\echo 'ERROR: CDB_READONLY_PASSWORD psql variable is required. Load it from the canonical secret store; do not commit or paste secrets.'
+\quit 3
+\endif
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cdb_reader') THEN
+        RAISE EXCEPTION 'cdb_reader role does not exist. Run roles_and_grants.sql first.';
+    END IF;
+END $$;
+
+-- \gexec creates the role only when missing.
+SELECT format(
+    'CREATE ROLE cdb_readonly LOGIN INHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD %L',
+    :'CDB_READONLY_PASSWORD'
+)
+WHERE NOT EXISTS (
+    SELECT 1 FROM pg_roles WHERE rolname = 'cdb_readonly'
+)
+\gexec
+
+ALTER ROLE cdb_readonly
+    INHERIT
+    NOSUPERUSER
+    NOCREATEDB
+    NOCREATEROLE
+    NOREPLICATION
+    NOBYPASSRLS;
+
+ALTER ROLE cdb_readonly
+    PASSWORD :'CDB_READONLY_PASSWORD';
+
+-- Existing role password is rotated by the ALTER ROLE statement above.
+GRANT cdb_reader TO cdb_readonly;
+
+DO $$
+BEGIN
+    RAISE NOTICE '---------------------------------------------';
+    RAISE NOTICE 'operator_create_readonly_login.sql applied';
+    RAISE NOTICE 'cdb_readonly remains operator-managed';
+    RAISE NOTICE 'Password was loaded via psql variable CDB_READONLY_PASSWORD';
+    RAISE NOTICE 'Verify via verify_privileges.sql before DB discovery';
+    RAISE NOTICE '---------------------------------------------';
+END $$;

--- a/infrastructure/database/operator_create_readonly_login.sql
+++ b/infrastructure/database/operator_create_readonly_login.sql
@@ -22,10 +22,28 @@
 \quit 3
 \endif
 
+SELECT CASE
+    WHEN length(btrim(:'CDB_READONLY_PASSWORD')) > 0 THEN 'true'
+    ELSE 'false'
+END AS cdb_readonly_password_non_empty
+\gset
+
+\if :cdb_readonly_password_non_empty
+\else
+\echo 'ERROR: CDB_READONLY_PASSWORD must not be empty or whitespace-only.'
+\quit 3
+\endif
+
 DO $$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cdb_reader') THEN
         RAISE EXCEPTION 'cdb_reader role does not exist. Run roles_and_grants.sql first.';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cdb_writer') THEN
+        RAISE EXCEPTION 'cdb_writer role does not exist. Run roles_and_grants.sql first.';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cdb_admin') THEN
+        RAISE EXCEPTION 'cdb_admin role does not exist. Run roles_and_grants.sql first.';
     END IF;
 END $$;
 
@@ -50,11 +68,26 @@ ALTER ROLE cdb_readonly
 ALTER ROLE cdb_readonly
     PASSWORD :'CDB_READONLY_PASSWORD';
 
+REVOKE cdb_writer FROM cdb_readonly;
+REVOKE cdb_admin FROM cdb_readonly;
+
 -- Existing role password is rotated by the ALTER ROLE statement above.
 GRANT cdb_reader TO cdb_readonly;
 
 DO $$
 BEGIN
+    IF pg_has_role('cdb_readonly', 'cdb_writer', 'MEMBER') THEN
+        RAISE EXCEPTION 'cdb_readonly must not be a member of cdb_writer';
+    END IF;
+
+    IF pg_has_role('cdb_readonly', 'cdb_admin', 'MEMBER') THEN
+        RAISE EXCEPTION 'cdb_readonly must not be a member of cdb_admin';
+    END IF;
+
+    IF NOT pg_has_role('cdb_readonly', 'cdb_reader', 'MEMBER') THEN
+        RAISE EXCEPTION 'cdb_readonly must be a member of cdb_reader';
+    END IF;
+
     RAISE NOTICE '---------------------------------------------';
     RAISE NOTICE 'operator_create_readonly_login.sql applied';
     RAISE NOTICE 'cdb_readonly remains operator-managed';

--- a/infrastructure/database/operator_create_readonly_login.sql
+++ b/infrastructure/database/operator_create_readonly_login.sql
@@ -68,6 +68,12 @@ ALTER ROLE cdb_readonly
 ALTER ROLE cdb_readonly
     PASSWORD :'CDB_READONLY_PASSWORD';
 
+-- Remove stale direct object grants. cdb_readonly must inherit read access only
+-- via cdb_reader.
+REVOKE ALL PRIVILEGES ON SCHEMA public FROM cdb_readonly;
+REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM cdb_readonly;
+REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM cdb_readonly;
+
 REVOKE cdb_writer FROM cdb_readonly;
 REVOKE cdb_admin FROM cdb_readonly;
 
@@ -86,6 +92,20 @@ BEGIN
 
     IF NOT pg_has_role('cdb_readonly', 'cdb_reader', 'MEMBER') THEN
         RAISE EXCEPTION 'cdb_readonly must be a member of cdb_reader';
+    END IF;
+
+    IF to_regclass('public.correlation_ledger') IS NULL THEN
+        RAISE EXCEPTION 'public.correlation_ledger must exist before readonly discovery verification';
+    END IF;
+
+    IF NOT has_table_privilege('cdb_readonly', 'public.correlation_ledger', 'SELECT') THEN
+        RAISE EXCEPTION 'cdb_readonly must have SELECT on public.correlation_ledger via cdb_reader';
+    END IF;
+
+    IF has_table_privilege('cdb_readonly', 'public.correlation_ledger', 'INSERT')
+       OR has_table_privilege('cdb_readonly', 'public.correlation_ledger', 'UPDATE')
+       OR has_table_privilege('cdb_readonly', 'public.correlation_ledger', 'DELETE') THEN
+        RAISE EXCEPTION 'cdb_readonly must not have write privileges on public.correlation_ledger';
     END IF;
 
     RAISE NOTICE '---------------------------------------------';

--- a/infrastructure/database/verify_privileges.sql
+++ b/infrastructure/database/verify_privileges.sql
@@ -12,16 +12,25 @@
 -- 1. Role existence
 -- ----------------------------------------------------------------------------
 \echo '=== 1. Role existence ==='
-SELECT rolname, rolcanlogin, rolsuper, rolinherit
+SELECT
+    rolname,
+    rolcanlogin,
+    rolsuper,
+    rolcreatedb,
+    rolcreaterole,
+    rolreplication,
+    rolbypassrls,
+    rolinherit
 FROM pg_roles
-WHERE rolname IN ('cdb_reader', 'cdb_writer', 'cdb_admin', 'claire_user')
+WHERE rolname IN ('cdb_reader', 'cdb_writer', 'cdb_admin', 'claire_user', 'cdb_readonly')
 ORDER BY rolname;
 
 -- Expected:
---   cdb_admin   | f | f | t
---   cdb_reader  | f | f | t
---   cdb_writer  | f | f | t
---   claire_user | t | f | t
+--   cdb_admin    | f | f | f | f | f | f | t
+--   cdb_reader   | f | f | f | f | f | f | t
+--   cdb_readonly | t | f | f | f | f | f | t
+--   cdb_writer   | f | f | f | f | f | f | t
+--   claire_user  | t | f | ... deployment-dependent ...
 
 -- ----------------------------------------------------------------------------
 -- 2. Role memberships (who inherits what)
@@ -37,18 +46,63 @@ ORDER BY r.rolname, m.rolname;
 -- After enforce: claire_user should appear as member of cdb_writer.
 
 -- ----------------------------------------------------------------------------
+-- 2b. Dedicated readonly login checks
+-- ----------------------------------------------------------------------------
+\echo '=== 3. Dedicated readonly login flags (cdb_readonly) ==='
+WITH readonly_role AS (
+    SELECT
+        oid,
+        rolcanlogin,
+        rolsuper,
+        rolcreatedb,
+        rolcreaterole,
+        rolreplication,
+        rolbypassrls
+    FROM pg_roles
+    WHERE rolname = 'cdb_readonly'
+)
+SELECT
+    EXISTS (SELECT 1 FROM readonly_role) AS cdb_readonly_exists,
+    COALESCE((SELECT rolcanlogin FROM readonly_role), false) AS rolcanlogin,
+    COALESCE((SELECT rolsuper FROM readonly_role), false) AS rolsuper,
+    COALESCE((SELECT rolcreatedb FROM readonly_role), false) AS rolcreatedb,
+    COALESCE((SELECT rolcreaterole FROM readonly_role), false) AS rolcreaterole,
+    COALESCE((SELECT rolreplication FROM readonly_role), false) AS rolreplication,
+    COALESCE((SELECT rolbypassrls FROM readonly_role), false) AS rolbypassrls;
+
+\echo '=== 4. Dedicated readonly memberships (cdb_readonly) ==='
+WITH readonly_role AS (
+    SELECT oid
+    FROM pg_roles
+    WHERE rolname = 'cdb_readonly'
+),
+target_roles AS (
+    SELECT rolname, oid
+    FROM pg_roles
+    WHERE rolname IN ('cdb_reader', 'cdb_writer', 'cdb_admin')
+)
+SELECT
+    tr.rolname AS target_role,
+    CASE
+        WHEN NOT EXISTS (SELECT 1 FROM readonly_role) THEN false
+        ELSE pg_has_role((SELECT oid FROM readonly_role), tr.oid, 'MEMBER')
+    END AS is_member
+FROM target_roles tr
+ORDER BY tr.rolname;
+
+-- ----------------------------------------------------------------------------
 -- 3. Table privileges per role
 -- ----------------------------------------------------------------------------
-\echo '=== 3. Table privileges (cdb_writer) ==='
+\echo '=== 5. Table privileges (cdb_writer) ==='
 SELECT table_name, privilege_type
 FROM information_schema.table_privileges
 WHERE grantee = 'cdb_writer'
   AND table_schema = 'public'
 ORDER BY table_name, privilege_type;
 
--- Expected: INSERT on 9 tables, SELECT on 10, UPDATE only on positions + validation_runs.
+-- Expected: INSERT on 8 tables, SELECT on 9, UPDATE only on positions.
 
-\echo '=== 4. Table privileges (cdb_reader) ==='
+\echo '=== 6. Table privileges (cdb_reader) ==='
 SELECT table_name, privilege_type
 FROM information_schema.table_privileges
 WHERE grantee = 'cdb_reader'
@@ -57,7 +111,24 @@ ORDER BY table_name, privilege_type;
 
 -- Expected: SELECT only on all listed tables.
 
-\echo '=== 5. Table privileges (claire_user direct) ==='
+\echo '=== 7. Effective privileges (cdb_readonly -> public.correlation_ledger) ==='
+WITH readonly_role AS (
+    SELECT oid
+    FROM pg_roles
+    WHERE rolname = 'cdb_readonly'
+)
+SELECT
+    EXISTS (SELECT 1 FROM readonly_role) AS cdb_readonly_exists,
+    COALESCE((SELECT has_table_privilege(oid, 'public.correlation_ledger', 'SELECT') FROM readonly_role), false) AS can_select,
+    COALESCE((SELECT has_table_privilege(oid, 'public.correlation_ledger', 'INSERT') FROM readonly_role), false) AS can_insert,
+    COALESCE((SELECT has_table_privilege(oid, 'public.correlation_ledger', 'UPDATE') FROM readonly_role), false) AS can_update,
+    COALESCE((SELECT has_table_privilege(oid, 'public.correlation_ledger', 'DELETE') FROM readonly_role), false) AS can_delete;
+
+-- NOTE: use has_table_privilege(...) here because inherited privileges via
+-- GRANT cdb_reader TO cdb_readonly are not reliably visible via
+-- information_schema.table_privileges WHERE grantee = 'cdb_readonly'.
+
+\echo '=== 8. Table privileges (claire_user direct) ==='
 SELECT table_name, privilege_type
 FROM information_schema.table_privileges
 WHERE grantee = 'claire_user'
@@ -70,7 +141,7 @@ ORDER BY table_name, privilege_type;
 -- ----------------------------------------------------------------------------
 -- 4. Sequence privileges for cdb_writer
 -- ----------------------------------------------------------------------------
-\echo '=== 6. Sequence privileges (cdb_writer) ==='
+\echo '=== 9. Sequence privileges (cdb_writer) ==='
 SELECT sequence_name, privilege_type
 FROM information_schema.usage_privileges
 WHERE grantee = 'cdb_writer'
@@ -81,7 +152,7 @@ ORDER BY sequence_name;
 -- ----------------------------------------------------------------------------
 -- 5. Table ownership (informational)
 -- ----------------------------------------------------------------------------
-\echo '=== 7. Table ownership ==='
+\echo '=== 10. Table ownership ==='
 SELECT tablename, tableowner
 FROM pg_tables
 WHERE schemaname = 'public'

--- a/knowledge/operations/MCP_CENTRAL_CONFIG.md
+++ b/knowledge/operations/MCP_CENTRAL_CONFIG.md
@@ -133,6 +133,35 @@ npx -y @leval/mcp-grafana  # Grafana server
 
 ---
 
+## Fail-closed rule for Postgres discovery
+
+For Agent-side Postgres discovery, `claire_user` is **not** an acceptable
+readonly identity. Postgres MCP must use a dedicated readonly login, preferably
+`cdb_readonly`, or an explicitly approved equivalent readonly principal.
+
+Minimum checks before any later `#1905` DB discovery:
+
+```sql
+SELECT current_database(), current_user;
+```
+
+Expected:
+
+- `current_user = cdb_readonly`, or an explicitly approved equivalent readonly login
+- effective `SELECT` on `public.correlation_ledger`
+- no effective `INSERT`, `UPDATE`, or `DELETE` on `public.correlation_ledger`
+
+If any of these checks fail, the discovery path is **fail-closed** and no DB
+discovery should proceed.
+
+The repo-backed readonly-login canon lives in:
+
+- `docs/runbooks/postgres_least_privilege_rls.md`
+- `infrastructure/database/operator_create_readonly_login.sql`
+- `infrastructure/database/verify_privileges.sql`
+
+---
+
 ## Git Handling
 
 **.mcp.json in .gitignore:**
@@ -157,7 +186,7 @@ npx -y @leval/mcp-grafana  # Grafana server
 
 **Access Control:**
 - Desktop Commander: `allowedDirectories` schützt File System
-- Postgres: Read-only user empfohlen für Agenten (TODO)
+- Postgres: Agent discovery must use a dedicated readonly login, not `claire_user`
 - Grafana: Admin role nötig für Dashboard-Änderungen
 
 ---

--- a/knowledge/operations/MCP_CENTRAL_CONFIG.md
+++ b/knowledge/operations/MCP_CENTRAL_CONFIG.md
@@ -142,14 +142,19 @@ readonly identity. Postgres MCP must use a dedicated readonly login, preferably
 Minimum checks before any later `#1905` DB discovery:
 
 ```sql
-SELECT current_database(), current_user;
+SELECT current_database(), current_user, session_user;
 ```
 
 Expected:
 
-- `current_user = cdb_readonly`, or an explicitly approved equivalent readonly login
+- `session_user = cdb_readonly`, or an explicitly approved equivalent readonly login
+- `current_user = session_user` for the discovery session, unless an explicitly documented readonly role-switch pattern is approved
 - effective `SELECT` on `public.correlation_ledger`
 - no effective `INSERT`, `UPDATE`, or `DELETE` on `public.correlation_ledger`
+
+`current_user` alone is not sufficient for Agent/MCP discovery acceptance,
+because role switching can change it inside a session. The login identity must
+also be readonly via `session_user`.
 
 If any of these checks fail, the discovery path is **fail-closed** and no DB
 discovery should proceed.


### PR DESCRIPTION
## Summary

Adds repo-backed canon and operator-only SQL for a dedicated readonly Postgres login used by later Agent/MCP DB discovery.

## Changes

- Documents `cdb_readonly` as an optional operator-managed readonly login.
- Adds `infrastructure/database/operator_create_readonly_login.sql`.
- Extends `verify_privileges.sql` with missing-role-safe `cdb_readonly` checks.
- Adds readonly DB discovery secret pointers.
- Adds a fail-closed MCP rule: no Agent/Postgres discovery with `claire_user`.

## Guardrails

- No DB role created live.
- No DB connection.
- No DB writes.
- No secrets committed.
- `roles_and_grants.sql` unchanged.
- No MCP runtime or master config changes.
- No #1905 unpark.
- No LR / Live / Echtgeld implication.

## Why

#1905 requires read-only `correlation_ledger` discovery before any implementation work. That discovery must not run through runtime/writer credentials.