### PR TITLE
fix(secrets): canonize readonly postgres secret path

### DIFF
--- a/docs/env/index.md
+++ b/docs/env/index.md
@@ -53,11 +53,20 @@ For later Agent-/MCP-readonly discovery, prefer a dedicated DSN secret name:
 - `POSTGRES_READONLY_PASSWORD` - optional raw password secret if the operator
   path keeps password and DSN separately
 
+Canonical operator bridge for the login-creation step:
+
+- secret store file: `POSTGRES_READONLY_PASSWORD`
+- temporary operator-shell variable: `CDB_READONLY_PASSWORD`
+- consumer: `psql -v CDB_READONLY_PASSWORD=...` for
+  `infrastructure/database/operator_create_readonly_login.sql`
+
 Guardrails:
 
 - Secret values stay outside the repo in the canonical secret store.
 - Runtime-service credentials such as `claire_user` / `POSTGRES_PASSWORD` are
   not acceptable for Agent-/MCP-discovery.
+- `CDB_READONLY_PASSWORD` is only a temporary operator bridge variable. The
+  canonical stored secret remains `POSTGRES_READONLY_PASSWORD`.
 - The canonical readonly-login boundary is documented in
   [`docs/runbooks/postgres_least_privilege_rls.md`](../runbooks/postgres_least_privilege_rls.md).
 

--- a/docs/runbooks/postgres_least_privilege_rls.md
+++ b/docs/runbooks/postgres_least_privilege_rls.md
@@ -92,6 +92,11 @@ Expected: `current_user` must show a dedicated readonly login, preferably
 - Canonical Secret Store: `C:\Users\janne\Documents\.secrets\.cdb`
 - Rotation / changes: rotator-only via `infrastructure/scripts/manage_secrets.ps1`; do not hand-edit secret files and do not create alternate secret copies inside the repo.
 - Connection env: export or load `POSTGRES_DSN`, `DATABASE_URL`, and related connection material via the rotator workflow before running these commands. Do not paste credentials directly into shells, docs, or committed config.
+- Dedicated readonly operator secrets:
+  - `POSTGRES_READONLY_PASSWORD` - canonical raw password file for the
+    operator-only `cdb_readonly` login step
+  - `POSTGRES_READONLY_PASSWORD_DSN` - optional dedicated DSN file for later
+    readonly discovery flows; not required for the login-creation SQL itself
 
 ## Rotator Proof of Use
 
@@ -103,14 +108,18 @@ non-mutating `list` and `validate` actions as proof-of-use commands.
 ```powershell
 pwsh -File infrastructure/scripts/manage_secrets.ps1 -Action list
 pwsh -File infrastructure/scripts/manage_secrets.ps1 -Action validate
-pwsh -File infrastructure/scripts/manage_secrets.ps1 -Action rotate -SecretName <secret-name>
+pwsh -File infrastructure/scripts/manage_secrets.ps1 -Action rotate -SecretName POSTGRES_READONLY_PASSWORD
+pwsh -File infrastructure/scripts/manage_secrets.ps1 -Action rotate -SecretName POSTGRES_READONLY_PASSWORD_DSN
 ```
 
 - `list`: confirms that the rotator can see the managed secret files without
   printing secret values.
 - `validate`: confirms that the required secret set is present and non-empty.
 - `rotate`: use only when an approved rotation is required; provide the secret
-  value through the rotator workflow, not by hand-editing files.
+  value through the rotator workflow, not by hand-editing files. For the
+  `cdb_readonly` login step, rotate `POSTGRES_READONLY_PASSWORD` in the secret
+  store and bridge it into the temporary shell variable
+  `CDB_READONLY_PASSWORD` only for the `psql -v` invocation.
 - Proof-of-use evidence should capture only timestamp, operator, command name,
   and outcome summary. Do not capture or paste secret values.
 
@@ -170,8 +179,21 @@ docker exec cdb_postgres psql -U postgres -d claire_de_binare \
 
 This is an operator-only step for a dedicated readonly login. It is separate
 from the additive role/grant foundation and must stay secret-free in the repo.
-Load `CDB_READONLY_PASSWORD` from the canonical secret store before invoking
-`psql`; never commit, paste, or log the real value.
+Load the canonical secret-store file `POSTGRES_READONLY_PASSWORD`, then bridge
+it into the temporary operator-shell variable `CDB_READONLY_PASSWORD` before
+invoking `psql`; never commit, paste, or log the real value.
+
+PowerShell example:
+
+```powershell
+$env:CDB_READONLY_PASSWORD = Get-Content `
+  (Join-Path $env:USERPROFILE 'Documents\.secrets\.cdb\POSTGRES_READONLY_PASSWORD') `
+  -Raw
+docker exec cdb_postgres psql -U postgres -d claire_de_binare `
+  -v CDB_READONLY_PASSWORD="$env:CDB_READONLY_PASSWORD" `
+  -f /path/to/operator_create_readonly_login.sql
+Remove-Item Env:CDB_READONLY_PASSWORD
+```
 
 ### Step 3: Verify roles exist
 

--- a/infrastructure/scripts/manage_secrets.ps1
+++ b/infrastructure/scripts/manage_secrets.ps1
@@ -19,7 +19,21 @@ param(
     [string]$Action,
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("mexc_api_key", "mexc_api_secret", "redis_password", "postgres_password", "grafana_password")]
+    [ValidateSet(
+        "mexc_api_key",
+        "mexc_api_secret",
+        "redis_password",
+        "postgres_password",
+        "grafana_password",
+        "REDIS_PASSWORD",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_PASSWORD_DSN",
+        "GRAFANA_PASSWORD",
+        "MEXC_API_KEY.txt",
+        "MEXC_API_SECRET.txt",
+        "POSTGRES_READONLY_PASSWORD",
+        "POSTGRES_READONLY_PASSWORD_DSN"
+    )]
     [string]$SecretName,
 
     [Parameter(Mandatory=$false)]
@@ -31,6 +45,30 @@ $ErrorActionPreference = "Stop"
 # Canonical secrets directory (Single Source of Truth)
 # Canonical: ~/Documents/.secrets/.cdb  (matches SECRETS_PATH in compose.blue.yml / compose.red.yml)
 $secretDir = Join-Path $env:USERPROFILE "Documents\.secrets\.cdb"
+
+function Resolve-SecretFileName {
+    param([string]$Name)
+
+    switch ($Name) {
+        "redis_password" { return "REDIS_PASSWORD" }
+        "REDIS_PASSWORD" { return "REDIS_PASSWORD" }
+        "postgres_password" { return "POSTGRES_PASSWORD" }
+        "POSTGRES_PASSWORD" { return "POSTGRES_PASSWORD" }
+        "postgres_password_dsn" { return "POSTGRES_PASSWORD_DSN" }
+        "POSTGRES_PASSWORD_DSN" { return "POSTGRES_PASSWORD_DSN" }
+        "grafana_password" { return "GRAFANA_PASSWORD" }
+        "GRAFANA_PASSWORD" { return "GRAFANA_PASSWORD" }
+        "mexc_api_key" { return "MEXC_API_KEY.txt" }
+        "MEXC_API_KEY" { return "MEXC_API_KEY.txt" }
+        "MEXC_API_KEY.txt" { return "MEXC_API_KEY.txt" }
+        "mexc_api_secret" { return "MEXC_API_SECRET.txt" }
+        "MEXC_API_SECRET" { return "MEXC_API_SECRET.txt" }
+        "MEXC_API_SECRET.txt" { return "MEXC_API_SECRET.txt" }
+        "POSTGRES_READONLY_PASSWORD" { return "POSTGRES_READONLY_PASSWORD" }
+        "POSTGRES_READONLY_PASSWORD_DSN" { return "POSTGRES_READONLY_PASSWORD_DSN" }
+        default { return $Name }
+    }
+}
 
 function Initialize-SecretDirectory {
     if (-not (Test-Path $secretDir)) {
@@ -56,7 +94,8 @@ function Set-Secret {
         [string]$SecretValue
     )
 
-    $secretPath = Join-Path $secretDir $Name
+    $secretFileName = Resolve-SecretFileName $Name
+    $secretPath = Join-Path $secretDir $secretFileName
 
     if (Test-Path $secretPath) {
         $backup = "${secretPath}.bak.$(Get-Date -Format 'yyyyMMdd_HHmmss')"
@@ -76,17 +115,58 @@ function Set-Secret {
     $acl.AddAccessRule($accessRule)
     Set-Acl $secretPath $acl
 
-    Write-Host "✅ Secret '$Name' saved securely" -ForegroundColor Green
+    Write-Host "✅ Secret '$secretFileName' saved securely" -ForegroundColor Green
 }
 
 function Get-SecretValue {
     param([string]$Name)
 
-    $secretPath = Join-Path $secretDir $Name
+    $secretFileName = Resolve-SecretFileName $Name
+    $secretPath = Join-Path $secretDir $secretFileName
     if (Test-Path $secretPath) {
         return Get-Content $secretPath -Raw
     }
     return $null
+}
+
+function Test-SecretPresence {
+    param(
+        [string]$Name,
+        [bool]$Required = $true
+    )
+
+    $secretFileName = Resolve-SecretFileName $Name
+    $secretPath = Join-Path $secretDir $secretFileName
+    $exists = Test-Path $secretPath
+
+    if ($exists) {
+        $content = Get-Content $secretPath -Raw
+        $isEmpty = [string]::IsNullOrWhiteSpace($content)
+
+        if ($isEmpty) {
+            if ($Required) {
+                Write-Host "  ❌ $secretFileName : EMPTY" -ForegroundColor Red
+            } else {
+                Write-Host "  ⚠️  $secretFileName : OPTIONAL / EMPTY" -ForegroundColor Yellow
+            }
+            return $false
+        }
+
+        $length = $content.Trim().Length
+        if ($Required) {
+            Write-Host "  ✅ $secretFileName : SET ($length chars)" -ForegroundColor Green
+        } else {
+            Write-Host "  ℹ️  $secretFileName : OPTIONAL / SET ($length chars)" -ForegroundColor Cyan
+        }
+        return $true
+    }
+
+    if ($Required) {
+        Write-Host "  ⚠️  $secretFileName : NOT FOUND" -ForegroundColor Yellow
+    } else {
+        Write-Host "  ℹ️  $secretFileName : OPTIONAL / ABSENT" -ForegroundColor Cyan
+    }
+    return $false
 }
 
 function Test-Secrets {
@@ -94,33 +174,32 @@ function Test-Secrets {
     Write-Host "=" * 60
 
     $requiredSecrets = @(
-        "redis_password",
-        "postgres_password",
-        "grafana_password",
-        "mexc_api_key",
-        "mexc_api_secret"
+        "REDIS_PASSWORD",
+        "POSTGRES_PASSWORD",
+        "GRAFANA_PASSWORD",
+        "MEXC_API_KEY.txt",
+        "MEXC_API_SECRET.txt"
+    )
+    $optionalSecrets = @(
+        "POSTGRES_PASSWORD_DSN",
+        "POSTGRES_READONLY_PASSWORD",
+        "POSTGRES_READONLY_PASSWORD_DSN"
     )
 
     $allValid = $true
 
     foreach ($secret in $requiredSecrets) {
-        $secretPath = Join-Path $secretDir $secret
-        $exists = Test-Path $secretPath
-
-        if ($exists) {
-            $content = Get-Content $secretPath -Raw
-            $isEmpty = [string]::IsNullOrWhiteSpace($content)
-
-            if ($isEmpty) {
-                Write-Host "  ❌ $secret : EMPTY" -ForegroundColor Red
-                $allValid = $false
-            } else {
-                $length = $content.Trim().Length
-                Write-Host "  ✅ $secret : SET ($length chars)" -ForegroundColor Green
-            }
-        } else {
-            Write-Host "  ⚠️  $secret : NOT FOUND" -ForegroundColor Yellow
+        if (-not (Test-SecretPresence -Name $secret -Required $true)) {
             $allValid = $false
+        }
+    }
+
+    if ($optionalSecrets.Count -gt 0) {
+        Write-Host ""
+        Write-Host "Optional secrets" -ForegroundColor Cyan
+        Write-Host "-" * 60
+        foreach ($secret in $optionalSecrets) {
+            Test-SecretPresence -Name $secret -Required $false | Out-Null
         }
     }
 
@@ -144,64 +223,64 @@ switch ($Action) {
         Initialize-SecretDirectory
 
         # Redis password
-        if (-not (Get-SecretValue "redis_password")) {
+        if (-not (Get-SecretValue "REDIS_PASSWORD")) {
             $redis_pw = Read-Host "Enter Redis password (or press Enter to generate)"
             if ([string]::IsNullOrWhiteSpace($redis_pw)) {
                 $redis_pw = -join ((48..57) + (65..90) + (97..122) | Get-Random -Count 32 | ForEach-Object {[char]$_})
             }
-            Set-Secret "redis_password" $redis_pw
+            Set-Secret "REDIS_PASSWORD" $redis_pw
         } else {
-            Write-Host "  ℹ️  redis_password already exists" -ForegroundColor Cyan
+            Write-Host "  ℹ️  REDIS_PASSWORD already exists" -ForegroundColor Cyan
         }
 
         # PostgreSQL password
-        if (-not (Get-SecretValue "postgres_password")) {
+        if (-not (Get-SecretValue "POSTGRES_PASSWORD")) {
             $pg_pw = Read-Host "Enter PostgreSQL password (or press Enter to generate)"
             if ([string]::IsNullOrWhiteSpace($pg_pw)) {
                 $pg_pw = -join ((48..57) + (65..90) + (97..122) | Get-Random -Count 32 | ForEach-Object {[char]$_})
             }
-            Set-Secret "postgres_password" $pg_pw
+            Set-Secret "POSTGRES_PASSWORD" $pg_pw
         } else {
-            Write-Host "  ℹ️  postgres_password already exists" -ForegroundColor Cyan
+            Write-Host "  ℹ️  POSTGRES_PASSWORD already exists" -ForegroundColor Cyan
         }
 
         # Grafana password
-        if (-not (Get-SecretValue "grafana_password")) {
+        if (-not (Get-SecretValue "GRAFANA_PASSWORD")) {
             $grafana_pw = Read-Host "Enter Grafana password (or press Enter to generate)"
             if ([string]::IsNullOrWhiteSpace($grafana_pw)) {
                 $grafana_pw = -join ((48..57) + (65..90) + (97..122) | Get-Random -Count 24 | ForEach-Object {[char]$_})
             }
-            Set-Secret "grafana_password" $grafana_pw
+            Set-Secret "GRAFANA_PASSWORD" $grafana_pw
         } else {
-            Write-Host "  ℹ️  grafana_password already exists" -ForegroundColor Cyan
+            Write-Host "  ℹ️  GRAFANA_PASSWORD already exists" -ForegroundColor Cyan
         }
 
         # MEXC API credentials
         Write-Host "`n🔑 MEXC API Credentials" -ForegroundColor Yellow
         Write-Host "   Get from: https://testnet.mexc.com/ (testnet) or https://www.mexc.com/ (live)" -ForegroundColor White
 
-        if (-not (Get-SecretValue "mexc_api_key")) {
+        if (-not (Get-SecretValue "MEXC_API_KEY.txt")) {
             $mexc_key = Read-Host "Enter MEXC API Key (or leave empty for now)"
             if (-not [string]::IsNullOrWhiteSpace($mexc_key)) {
-                Set-Secret "mexc_api_key" $mexc_key.Trim()
+                Set-Secret "MEXC_API_KEY.txt" $mexc_key.Trim()
             } else {
-                "" | Out-File -FilePath (Join-Path $secretDir "mexc_api_key") -NoNewline
-                Write-Host "  ⚠️  mexc_api_key left empty - configure before production!" -ForegroundColor Yellow
+                "" | Out-File -FilePath (Join-Path $secretDir "MEXC_API_KEY.txt") -NoNewline
+                Write-Host "  ⚠️  MEXC_API_KEY.txt left empty - configure before production!" -ForegroundColor Yellow
             }
         } else {
-            Write-Host "  ℹ️  mexc_api_key already exists" -ForegroundColor Cyan
+            Write-Host "  ℹ️  MEXC_API_KEY.txt already exists" -ForegroundColor Cyan
         }
 
-        if (-not (Get-SecretValue "mexc_api_secret")) {
+        if (-not (Get-SecretValue "MEXC_API_SECRET.txt")) {
             $mexc_secret = Read-Host "Enter MEXC API Secret (or leave empty for now)"
             if (-not [string]::IsNullOrWhiteSpace($mexc_secret)) {
-                Set-Secret "mexc_api_secret" $mexc_secret.Trim()
+                Set-Secret "MEXC_API_SECRET.txt" $mexc_secret.Trim()
             } else {
-                "" | Out-File -FilePath (Join-Path $secretDir "mexc_api_secret") -NoNewline
-                Write-Host "  ⚠️  mexc_api_secret left empty - configure before production!" -ForegroundColor Yellow
+                "" | Out-File -FilePath (Join-Path $secretDir "MEXC_API_SECRET.txt") -NoNewline
+                Write-Host "  ⚠️  MEXC_API_SECRET.txt left empty - configure before production!" -ForegroundColor Yellow
             }
         } else {
-            Write-Host "  ℹ️  mexc_api_secret already exists" -ForegroundColor Cyan
+            Write-Host "  ℹ️  MEXC_API_SECRET.txt already exists" -ForegroundColor Cyan
         }
 
         Write-Host "`n✅ Setup complete!" -ForegroundColor Green

--- a/scripts/manage_secrets.ps1
+++ b/scripts/manage_secrets.ps1
@@ -21,7 +21,21 @@ param(
     [string]$Action,
 
     [Parameter(Mandatory=$false)]
-    [ValidateSet("mexc_api_key", "mexc_api_secret", "redis_password", "postgres_password", "grafana_password")]
+    [ValidateSet(
+        "mexc_api_key",
+        "mexc_api_secret",
+        "redis_password",
+        "postgres_password",
+        "grafana_password",
+        "REDIS_PASSWORD",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_PASSWORD_DSN",
+        "GRAFANA_PASSWORD",
+        "MEXC_API_KEY.txt",
+        "MEXC_API_SECRET.txt",
+        "POSTGRES_READONLY_PASSWORD",
+        "POSTGRES_READONLY_PASSWORD_DSN"
+    )]
     [string]$SecretName,
 
     [Parameter(Mandatory=$false)]
@@ -32,6 +46,30 @@ $ErrorActionPreference = "Stop"
 
 # Canonical secrets directory (matches SECRETS_PATH in compose.blue.yml / compose.red.yml)
 $secretDir = Join-Path $env:USERPROFILE "Documents\.secrets\.cdb"
+
+function Resolve-SecretFileName {
+    param([string]$Name)
+
+    switch ($Name) {
+        "redis_password" { return "REDIS_PASSWORD" }
+        "REDIS_PASSWORD" { return "REDIS_PASSWORD" }
+        "postgres_password" { return "POSTGRES_PASSWORD" }
+        "POSTGRES_PASSWORD" { return "POSTGRES_PASSWORD" }
+        "postgres_password_dsn" { return "POSTGRES_PASSWORD_DSN" }
+        "POSTGRES_PASSWORD_DSN" { return "POSTGRES_PASSWORD_DSN" }
+        "grafana_password" { return "GRAFANA_PASSWORD" }
+        "GRAFANA_PASSWORD" { return "GRAFANA_PASSWORD" }
+        "mexc_api_key" { return "MEXC_API_KEY.txt" }
+        "MEXC_API_KEY" { return "MEXC_API_KEY.txt" }
+        "MEXC_API_KEY.txt" { return "MEXC_API_KEY.txt" }
+        "mexc_api_secret" { return "MEXC_API_SECRET.txt" }
+        "MEXC_API_SECRET" { return "MEXC_API_SECRET.txt" }
+        "MEXC_API_SECRET.txt" { return "MEXC_API_SECRET.txt" }
+        "POSTGRES_READONLY_PASSWORD" { return "POSTGRES_READONLY_PASSWORD" }
+        "POSTGRES_READONLY_PASSWORD_DSN" { return "POSTGRES_READONLY_PASSWORD_DSN" }
+        default { return $Name }
+    }
+}
 
 function Initialize-SecretDirectory {
     if (-not (Test-Path $secretDir)) {
@@ -57,7 +95,8 @@ function Set-Secret {
         [string]$SecretValue
     )
 
-    $secretPath = Join-Path $secretDir $Name
+    $secretFileName = Resolve-SecretFileName $Name
+    $secretPath = Join-Path $secretDir $secretFileName
 
     if (Test-Path $secretPath) {
         $backup = "${secretPath}.bak.$(Get-Date -Format 'yyyyMMdd_HHmmss')"
@@ -77,17 +116,58 @@ function Set-Secret {
     $acl.AddAccessRule($accessRule)
     Set-Acl $secretPath $acl
 
-    Write-Host "✅ Secret '$Name' saved securely" -ForegroundColor Green
+    Write-Host "✅ Secret '$secretFileName' saved securely" -ForegroundColor Green
 }
 
 function Get-SecretValue {
     param([string]$Name)
 
-    $secretPath = Join-Path $secretDir $Name
+    $secretFileName = Resolve-SecretFileName $Name
+    $secretPath = Join-Path $secretDir $secretFileName
     if (Test-Path $secretPath) {
         return Get-Content $secretPath -Raw
     }
     return $null
+}
+
+function Test-SecretPresence {
+    param(
+        [string]$Name,
+        [bool]$Required = $true
+    )
+
+    $secretFileName = Resolve-SecretFileName $Name
+    $secretPath = Join-Path $secretDir $secretFileName
+    $exists = Test-Path $secretPath
+
+    if ($exists) {
+        $content = Get-Content $secretPath -Raw
+        $isEmpty = [string]::IsNullOrWhiteSpace($content)
+
+        if ($isEmpty) {
+            if ($Required) {
+                Write-Host "  ❌ $secretFileName : EMPTY" -ForegroundColor Red
+            } else {
+                Write-Host "  ⚠️  $secretFileName : OPTIONAL / EMPTY" -ForegroundColor Yellow
+            }
+            return $false
+        }
+
+        $length = $content.Trim().Length
+        if ($Required) {
+            Write-Host "  ✅ $secretFileName : SET ($length chars)" -ForegroundColor Green
+        } else {
+            Write-Host "  ℹ️  $secretFileName : OPTIONAL / SET ($length chars)" -ForegroundColor Cyan
+        }
+        return $true
+    }
+
+    if ($Required) {
+        Write-Host "  ⚠️  $secretFileName : NOT FOUND" -ForegroundColor Yellow
+    } else {
+        Write-Host "  ℹ️  $secretFileName : OPTIONAL / ABSENT" -ForegroundColor Cyan
+    }
+    return $false
 }
 
 function Test-Secrets {
@@ -95,33 +175,32 @@ function Test-Secrets {
     Write-Host "=" * 60
 
     $requiredSecrets = @(
-        "redis_password",
-        "postgres_password",
-        "grafana_password",
-        "mexc_api_key",
-        "mexc_api_secret"
+        "REDIS_PASSWORD",
+        "POSTGRES_PASSWORD",
+        "GRAFANA_PASSWORD",
+        "MEXC_API_KEY.txt",
+        "MEXC_API_SECRET.txt"
+    )
+    $optionalSecrets = @(
+        "POSTGRES_PASSWORD_DSN",
+        "POSTGRES_READONLY_PASSWORD",
+        "POSTGRES_READONLY_PASSWORD_DSN"
     )
 
     $allValid = $true
 
     foreach ($secret in $requiredSecrets) {
-        $secretPath = Join-Path $secretDir $secret
-        $exists = Test-Path $secretPath
-
-        if ($exists) {
-            $content = Get-Content $secretPath -Raw
-            $isEmpty = [string]::IsNullOrWhiteSpace($content)
-
-            if ($isEmpty) {
-                Write-Host "  ❌ $secret : EMPTY" -ForegroundColor Red
-                $allValid = $false
-            } else {
-                $length = $content.Trim().Length
-                Write-Host "  ✅ $secret : SET ($length chars)" -ForegroundColor Green
-            }
-        } else {
-            Write-Host "  ⚠️  $secret : NOT FOUND" -ForegroundColor Yellow
+        if (-not (Test-SecretPresence -Name $secret -Required $true)) {
             $allValid = $false
+        }
+    }
+
+    if ($optionalSecrets.Count -gt 0) {
+        Write-Host ""
+        Write-Host "Optional secrets" -ForegroundColor Cyan
+        Write-Host "-" * 60
+        foreach ($secret in $optionalSecrets) {
+            Test-SecretPresence -Name $secret -Required $false | Out-Null
         }
     }
 
@@ -145,64 +224,64 @@ switch ($Action) {
         Initialize-SecretDirectory
 
         # Redis password
-        if (-not (Get-SecretValue "redis_password")) {
+        if (-not (Get-SecretValue "REDIS_PASSWORD")) {
             $redis_pw = Read-Host "Enter Redis password (or press Enter to generate)"
             if ([string]::IsNullOrWhiteSpace($redis_pw)) {
                 $redis_pw = -join ((48..57) + (65..90) + (97..122) | Get-Random -Count 32 | ForEach-Object {[char]$_})
             }
-            Set-Secret "redis_password" $redis_pw
+            Set-Secret "REDIS_PASSWORD" $redis_pw
         } else {
-            Write-Host "  ℹ️  redis_password already exists" -ForegroundColor Cyan
+            Write-Host "  ℹ️  REDIS_PASSWORD already exists" -ForegroundColor Cyan
         }
 
         # PostgreSQL password
-        if (-not (Get-SecretValue "postgres_password")) {
+        if (-not (Get-SecretValue "POSTGRES_PASSWORD")) {
             $pg_pw = Read-Host "Enter PostgreSQL password (or press Enter to generate)"
             if ([string]::IsNullOrWhiteSpace($pg_pw)) {
                 $pg_pw = -join ((48..57) + (65..90) + (97..122) | Get-Random -Count 32 | ForEach-Object {[char]$_})
             }
-            Set-Secret "postgres_password" $pg_pw
+            Set-Secret "POSTGRES_PASSWORD" $pg_pw
         } else {
-            Write-Host "  ℹ️  postgres_password already exists" -ForegroundColor Cyan
+            Write-Host "  ℹ️  POSTGRES_PASSWORD already exists" -ForegroundColor Cyan
         }
 
         # Grafana password
-        if (-not (Get-SecretValue "grafana_password")) {
+        if (-not (Get-SecretValue "GRAFANA_PASSWORD")) {
             $grafana_pw = Read-Host "Enter Grafana password (or press Enter to generate)"
             if ([string]::IsNullOrWhiteSpace($grafana_pw)) {
                 $grafana_pw = -join ((48..57) + (65..90) + (97..122) | Get-Random -Count 24 | ForEach-Object {[char]$_})
             }
-            Set-Secret "grafana_password" $grafana_pw
+            Set-Secret "GRAFANA_PASSWORD" $grafana_pw
         } else {
-            Write-Host "  ℹ️  grafana_password already exists" -ForegroundColor Cyan
+            Write-Host "  ℹ️  GRAFANA_PASSWORD already exists" -ForegroundColor Cyan
         }
 
         # MEXC API credentials
         Write-Host "`n🔑 MEXC API Credentials" -ForegroundColor Yellow
         Write-Host "   Get from: https://testnet.mexc.com/ (testnet) or https://www.mexc.com/ (live)" -ForegroundColor White
 
-        if (-not (Get-SecretValue "mexc_api_key")) {
+        if (-not (Get-SecretValue "MEXC_API_KEY.txt")) {
             $mexc_key = Read-Host "Enter MEXC API Key (or leave empty for now)"
             if (-not [string]::IsNullOrWhiteSpace($mexc_key)) {
-                Set-Secret "mexc_api_key" $mexc_key.Trim()
+                Set-Secret "MEXC_API_KEY.txt" $mexc_key.Trim()
             } else {
-                "" | Out-File -FilePath (Join-Path $secretDir "mexc_api_key") -NoNewline
-                Write-Host "  ⚠️  mexc_api_key left empty - configure before production!" -ForegroundColor Yellow
+                "" | Out-File -FilePath (Join-Path $secretDir "MEXC_API_KEY.txt") -NoNewline
+                Write-Host "  ⚠️  MEXC_API_KEY.txt left empty - configure before production!" -ForegroundColor Yellow
             }
         } else {
-            Write-Host "  ℹ️  mexc_api_key already exists" -ForegroundColor Cyan
+            Write-Host "  ℹ️  MEXC_API_KEY.txt already exists" -ForegroundColor Cyan
         }
 
-        if (-not (Get-SecretValue "mexc_api_secret")) {
+        if (-not (Get-SecretValue "MEXC_API_SECRET.txt")) {
             $mexc_secret = Read-Host "Enter MEXC API Secret (or leave empty for now)"
             if (-not [string]::IsNullOrWhiteSpace($mexc_secret)) {
-                Set-Secret "mexc_api_secret" $mexc_secret.Trim()
+                Set-Secret "MEXC_API_SECRET.txt" $mexc_secret.Trim()
             } else {
-                "" | Out-File -FilePath (Join-Path $secretDir "mexc_api_secret") -NoNewline
-                Write-Host "  ⚠️  mexc_api_secret left empty - configure before production!" -ForegroundColor Yellow
+                "" | Out-File -FilePath (Join-Path $secretDir "MEXC_API_SECRET.txt") -NoNewline
+                Write-Host "  ⚠️  MEXC_API_SECRET.txt left empty - configure before production!" -ForegroundColor Yellow
             }
         } else {
-            Write-Host "  ℹ️  mexc_api_secret already exists" -ForegroundColor Cyan
+            Write-Host "  ℹ️  MEXC_API_SECRET.txt already exists" -ForegroundColor Cyan
         }
 
         Write-Host "`n✅ Setup complete!" -ForegroundColor Green


### PR DESCRIPTION
## Lage
- Lokale Rollenbasis fuer Postgres ist vorhanden; cdb_readonly ist noch nicht angelegt.
- Der readonly-Login-Apply blieb blockiert, weil der kanonische Secret-/Rotator-Pfad fuer dedizierte readonly Postgres-Secrets im Repo driftete.
- Separater Hygiene-Rest bleibt bewusst ausserhalb dieses PRs: %F%, %MEM%, Issue #2474.
- #1905 bleibt OPEN, status:parked, und ist nicht Teil dieses Scopes.

## Problem
- docs/env/index.md und docs/runbooks/postgres_least_privilege_rls.md dokumentierten POSTGRES_READONLY_PASSWORD und POSTGRES_READONLY_PASSWORD_DSN als Canon.
- infrastructure/scripts/manage_secrets.ps1 und der Compat-Entrypoint scripts/manage_secrets.ps1 konnten diese readonly-Postgres-Secrets jedoch nicht verwalten oder validieren.
- Zusaetzlich war die Bridge zwischen kanonischem Secret-Store und der temporaeren CDB_READONLY_PASSWORD-psql-Variable nicht sauber und explizit beschrieben.

## Loesung
- Secret-Entrypoints auf die bestehende Uppercase-Datei-Canon ausgerichtet und readonly-Postgres-Secrets hinzugefuegt.
- POSTGRES_READONLY_PASSWORD und POSTGRES_READONLY_PASSWORD_DSN als optionale Secret-Namen in beiden Secret-Scripts verdrahtet.
- Legacy-Aliase bleiben weiter nutzbar ueber interne Aufloesung.
- alidate meldet readonly-Secrets explizit als optional (SET / EMPTY / ABSENT), ohne die Required-Baseline zu brechen.
- Doku auf einen klaren Bridge-Pfad ausgerichtet: kanonische Secret-Datei POSTGRES_READONLY_PASSWORD -> temporaere Shell-/psql-Variable CDB_READONLY_PASSWORD -> operator_create_readonly_login.sql.

## Geaenderte Dateien
- infrastructure/scripts/manage_secrets.ps1
- scripts/manage_secrets.ps1
- docs/env/index.md
- docs/runbooks/postgres_least_privilege_rls.md

## Validierung
- pwsh -File infrastructure/scripts/manage_secrets.ps1 -Action list
- pwsh -File infrastructure/scripts/manage_secrets.ps1 -Action validate
- pwsh -File scripts/manage_secrets.ps1 -Action list
- pwsh -File scripts/manage_secrets.ps1 -Action validate
- Parser-/Alias-Proben ueber -Action list -SecretName ... fuer:
  - postgres_password
  - edis_password
  - grafana_password
  - mexc_api_key
  - mexc_api_secret
  - POSTGRES_READONLY_PASSWORD
  - POSTGRES_READONLY_PASSWORD_DSN

## Explizit nicht getan
- keine Secret-Werte erzeugt
- keine Secret-Werte ausgegeben
- kein DB-Apply
- kein operator_create_readonly_login.sql
- kein erify_privileges.sql
- kein readonly Login angelegt
- keine #1905-Discovery
- keine LR-/Live-/Echtgeld-Ableitung

## Naechster Gate nach Merge
1. Dediziertes readonly Secret bereitstellen (POSTGRES_READONLY_PASSWORD, optional POSTGRES_READONLY_PASSWORD_DSN).
2. cdb-readonly-login-go-review.