### PR TITLE
fix(secrets): use resolvable identity for ACL assignment

### DIFF
--- a/infrastructure/scripts/manage_secrets.ps1
+++ b/infrastructure/scripts/manage_secrets.ps1
@@ -70,19 +70,45 @@ function Resolve-SecretFileName {
     }
 }
 
+function Get-CurrentWindowsIdentityName {
+    $currentIdentity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    if ($null -eq $currentIdentity) {
+        throw "Failed to resolve the current Windows identity for ACL assignment."
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($currentIdentity.Name)) {
+        return $currentIdentity.Name
+    }
+
+    if ($null -ne $currentIdentity.User) {
+        try {
+            return $currentIdentity.User.Translate([System.Security.Principal.NTAccount]).Value
+        } catch {
+            throw "Failed to translate the current Windows identity for ACL assignment: $($_.Exception.Message)"
+        }
+    }
+
+    throw "Failed to resolve the current Windows identity for ACL assignment."
+}
+
 function Initialize-SecretDirectory {
     if (-not (Test-Path $secretDir)) {
         Write-Host "📁 Creating secrets directory: $secretDir" -ForegroundColor Cyan
         New-Item -ItemType Directory -Path $secretDir -Force | Out-Null
 
         # Set restrictive permissions (Windows)
-        $acl = Get-Acl $secretDir
-        $acl.SetAccessRuleProtection($true, $false)  # Disable inheritance
-        $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-            $env:USERNAME, "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow"
-        )
-        $acl.AddAccessRule($accessRule)
-        Set-Acl $secretDir $acl
+        $currentIdentity = Get-CurrentWindowsIdentityName
+        try {
+            $acl = Get-Acl $secretDir
+            $acl.SetAccessRuleProtection($true, $false)  # Disable inheritance
+            $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+                $currentIdentity, "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow"
+            )
+            $acl.AddAccessRule($accessRule)
+            Set-Acl $secretDir $acl
+        } catch {
+            throw "Failed to set restrictive permissions on secrets directory '$secretDir' for identity '$currentIdentity': $($_.Exception.Message)"
+        }
 
         Write-Host "✅ Secrets directory created with restricted permissions" -ForegroundColor Green
     }
@@ -107,13 +133,18 @@ function Set-Secret {
     $SecretValue | Out-File -FilePath $secretPath -NoNewline -Encoding utf8
 
     # Set restrictive permissions
-    $acl = Get-Acl $secretPath
-    $acl.SetAccessRuleProtection($true, $false)
-    $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-        $env:USERNAME, "FullControl", "None", "None", "Allow"
-    )
-    $acl.AddAccessRule($accessRule)
-    Set-Acl $secretPath $acl
+    $currentIdentity = Get-CurrentWindowsIdentityName
+    try {
+        $acl = Get-Acl $secretPath
+        $acl.SetAccessRuleProtection($true, $false)
+        $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+            $currentIdentity, "FullControl", "None", "None", "Allow"
+        )
+        $acl.AddAccessRule($accessRule)
+        Set-Acl $secretPath $acl
+    } catch {
+        throw "Failed to set restrictive permissions on secret '$secretFileName' for identity '$currentIdentity': $($_.Exception.Message)"
+    }
 
     Write-Host "✅ Secret '$secretFileName' saved securely" -ForegroundColor Green
 }

--- a/scripts/manage_secrets.ps1
+++ b/scripts/manage_secrets.ps1
@@ -71,19 +71,45 @@ function Resolve-SecretFileName {
     }
 }
 
+function Get-CurrentWindowsIdentityName {
+    $currentIdentity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    if ($null -eq $currentIdentity) {
+        throw "Failed to resolve the current Windows identity for ACL assignment."
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($currentIdentity.Name)) {
+        return $currentIdentity.Name
+    }
+
+    if ($null -ne $currentIdentity.User) {
+        try {
+            return $currentIdentity.User.Translate([System.Security.Principal.NTAccount]).Value
+        } catch {
+            throw "Failed to translate the current Windows identity for ACL assignment: $($_.Exception.Message)"
+        }
+    }
+
+    throw "Failed to resolve the current Windows identity for ACL assignment."
+}
+
 function Initialize-SecretDirectory {
     if (-not (Test-Path $secretDir)) {
         Write-Host "📁 Creating secrets directory: $secretDir" -ForegroundColor Cyan
         New-Item -ItemType Directory -Path $secretDir -Force | Out-Null
 
         # Set restrictive permissions (Windows)
-        $acl = Get-Acl $secretDir
-        $acl.SetAccessRuleProtection($true, $false)  # Disable inheritance
-        $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-            $env:USERNAME, "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow"
-        )
-        $acl.AddAccessRule($accessRule)
-        Set-Acl $secretDir $acl
+        $currentIdentity = Get-CurrentWindowsIdentityName
+        try {
+            $acl = Get-Acl $secretDir
+            $acl.SetAccessRuleProtection($true, $false)  # Disable inheritance
+            $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+                $currentIdentity, "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow"
+            )
+            $acl.AddAccessRule($accessRule)
+            Set-Acl $secretDir $acl
+        } catch {
+            throw "Failed to set restrictive permissions on secrets directory '$secretDir' for identity '$currentIdentity': $($_.Exception.Message)"
+        }
 
         Write-Host "✅ Secrets directory created with restricted permissions" -ForegroundColor Green
     }
@@ -108,13 +134,18 @@ function Set-Secret {
     $SecretValue | Out-File -FilePath $secretPath -NoNewline -Encoding utf8
 
     # Set restrictive permissions
-    $acl = Get-Acl $secretPath
-    $acl.SetAccessRuleProtection($true, $false)
-    $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-        $env:USERNAME, "FullControl", "None", "None", "Allow"
-    )
-    $acl.AddAccessRule($accessRule)
-    Set-Acl $secretPath $acl
+    $currentIdentity = Get-CurrentWindowsIdentityName
+    try {
+        $acl = Get-Acl $secretPath
+        $acl.SetAccessRuleProtection($true, $false)
+        $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+            $currentIdentity, "FullControl", "None", "None", "Allow"
+        )
+        $acl.AddAccessRule($accessRule)
+        Set-Acl $secretPath $acl
+    } catch {
+        throw "Failed to set restrictive permissions on secret '$secretFileName' for identity '$currentIdentity': $($_.Exception.Message)"
+    }
 
     Write-Host "✅ Secret '$secretFileName' saved securely" -ForegroundColor Green
 }


### PR DESCRIPTION
## Lage
- POSTGRES_READONLY_PASSWORD war lokal teilprovisioniert, aber der Rotator-Lauf war nicht als PASS akzeptierbar.
- Der Fehler lag eng in der ACL-Zuweisung des Secret-Rotators auf Windows.
- %F% / %MEM% bleiben separater Hygiene-Scope unter #2474.
- #1905 bleibt OPEN mit status:parked und ist nicht Teil dieses PRs.

## Root Cause
- Beide Secret-Rotator-Skripte leiteten FileSystemAccessRule aus $env:USERNAME ab.
- Auf diesem Host brauchte die ACL-Aufloesung eine uebersetzbare Identitaet wie JANNEK\jannek.

## Loesung
- Fuehre Get-CurrentWindowsIdentityName in beiden Script-Pfaden ein.
- Nutze die aktuelle Windows-Identitaet statt $env:USERNAME fuer Directory- und File-ACLs.
- Lass ACL-Fehler explizit fehlschlagen, statt einen Erfolg vorzutäuschen.
- Halte Primary- und Compat-Script konsistent.

## Geaenderte Dateien
- infrastructure/scripts/manage_secrets.ps1
- scripts/manage_secrets.ps1

## Validierung
- pwsh -File infrastructure/scripts/manage_secrets.ps1 -Action validate
- pwsh -File scripts/manage_secrets.ps1 -Action validate
- enger Retry nur fuer POSTGRES_READONLY_PASSWORD
- ACL danach: JANNEK\jannek FullControl Allow
- kein Secret-Wert im Output

## Explizit nicht getan
- kein Secret-Wert ausgegeben
- kein DB-Apply
- kein operator_create_readonly_login.sql
- kein verify_privileges.sql
- kein #1905-Scope
- keine LR-/Live-/Echtgeld-Ableitung
- %F% / %MEM% nicht angefasst

## Naechster Gate
- readonly-secret-provisioning-retry