### PR TITLE
fix(db): correct verify sequence privilege query

### DIFF
--- a/infrastructure/database/verify_privileges.sql
+++ b/infrastructure/database/verify_privileges.sql
@@ -142,12 +142,12 @@ ORDER BY table_name, privilege_type;
 -- 4. Sequence privileges for cdb_writer
 -- ----------------------------------------------------------------------------
 \echo '=== 9. Sequence privileges (cdb_writer) ==='
-SELECT sequence_name, privilege_type
+SELECT object_name AS sequence_name, privilege_type
 FROM information_schema.usage_privileges
 WHERE grantee = 'cdb_writer'
   AND object_schema = 'public'
   AND object_type = 'SEQUENCE'
-ORDER BY sequence_name;
+ORDER BY object_name;
 
 -- ----------------------------------------------------------------------------
 -- 5. Table ownership (informational)


### PR DESCRIPTION
## Lage
- cdb_readonly wurde lokal erfolgreich erstellt und zielrelevant verifiziert.
- infrastructure/database/verify_privileges.sql hatte in einem spaeteren, separaten Abschnitt einen Sequence-Abfragefehler.
- %F% / %MEM% bleiben separater Hygiene-Scope unter #2474.
- #1905 bleibt OPEN, status:parked, und ist nicht Teil dieses PRs.

## Problem
- Die Query gegen information_schema.usage_privileges referenzierte sequence_name, obwohl dort object_name die relevante Spalte ist.
- Dadurch brach der Verify-Lauf im Abschnitt === 9. Sequence privileges (cdb_writer) === mit column "sequence_name" does not exist ab.

## Loesung
- Verwende object_name AS sequence_name in der Select-Liste.
- Sortiere konsistent mit ORDER BY object_name.
- Scope bleibt auf infrastructure/database/verify_privileges.sql begrenzt.

## Geaenderte Datei
- infrastructure/database/verify_privileges.sql

## Validierung
- Lesender Verify-Run gegen cdb_postgres / claire_de_binare
- Abschnitt === 9. Sequence privileges (cdb_writer) === liefert danach 8 USAGE-Zeilen statt des Spaltenfehlers
- Kein Secret-Wert im Output

## Explizit nicht getan
- kein Secret ausgegeben
- kein readonly Login neu erzeugt
- kein operator_create_readonly_login.sql
- kein #1905-Scope
- keine LR-/Live-/Echtgeld-Ableitung
- %F% / %MEM% nicht angefasst