### PR TITLE
fix(validation): require readonly postgres identity for paper reference window

### DIFF
--- a/services/validation/paper_reference_window_runner.py
+++ b/services/validation/paper_reference_window_runner.py
@@ -31,6 +31,13 @@ from core.replay.paper_reference_window_export import (
 _READONLY_DSN_ENV = "POSTGRES_READONLY_PASSWORD_DSN"
 _EXPECTED_READONLY_LOGIN = "cdb_readonly"
 _IDENTITY_PROBE_SQL = "SELECT current_database(), current_user, session_user;"
+_READONLY_PRIVILEGE_PROBE_SQL = """
+SELECT
+  has_table_privilege(current_user, 'public.correlation_ledger', 'SELECT'),
+  has_table_privilege(current_user, 'public.correlation_ledger', 'INSERT'),
+  has_table_privilege(current_user, 'public.correlation_ledger', 'UPDATE'),
+  has_table_privilege(current_user, 'public.correlation_ledger', 'DELETE')
+"""
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -108,6 +115,28 @@ def _verify_readonly_identity(conn) -> tuple[str, str, str]:
     return str(current_database), str(current_user), str(session_user)
 
 
+def _verify_readonly_privileges(conn) -> None:
+    with conn.cursor() as cursor:
+        cursor.execute(_READONLY_PRIVILEGE_PROBE_SQL)
+        privilege_row = cursor.fetchone()
+
+    if privilege_row is None or len(privilege_row) != 4:
+        raise RuntimeError(
+            "Readonly privilege probe did not return SELECT/INSERT/UPDATE/DELETE flags"
+        )
+
+    can_select, can_insert, can_update, can_delete = privilege_row
+    if not can_select:
+        raise RuntimeError(
+            "Readonly privilege probe failed: missing SELECT on public.correlation_ledger"
+        )
+    if can_insert or can_update or can_delete:
+        raise RuntimeError(
+            "Readonly privilege probe failed: write privileges detected on "
+            "public.correlation_ledger"
+        )
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     try:
@@ -135,6 +164,7 @@ def main(argv: list[str] | None = None) -> int:
         conn = _create_readonly_connection()
         try:
             readonly_identity = _verify_readonly_identity(conn)
+            _verify_readonly_privileges(conn)
             with conn.cursor() as cursor:
                 cursor.execute(
                     """

--- a/services/validation/paper_reference_window_runner.py
+++ b/services/validation/paper_reference_window_runner.py
@@ -15,8 +15,11 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
+
+import psycopg2
 
 from core.replay.canonical_json import canonical_json_dumps
 from core.replay.paper_reference_window_export import (
@@ -24,7 +27,10 @@ from core.replay.paper_reference_window_export import (
     build_export_request,
     export_paper_reference_window,
 )
-from core.utils.postgres_client import create_postgres_connection
+
+_READONLY_DSN_ENV = "POSTGRES_READONLY_PASSWORD_DSN"
+_EXPECTED_READONLY_LOGIN = "cdb_readonly"
+_IDENTITY_PROBE_SQL = "SELECT current_database(), current_user, session_user;"
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -69,6 +75,39 @@ def _build_source_query_intent(args: argparse.Namespace) -> str:
     return "; ".join(qualifiers)
 
 
+def _get_required_readonly_dsn() -> str:
+    readonly_dsn = os.getenv(_READONLY_DSN_ENV)
+    if readonly_dsn is None or not readonly_dsn.strip():
+        raise RuntimeError(
+            f"{_READONLY_DSN_ENV} is required for readonly paper_reference_window export"
+        )
+    return readonly_dsn.strip()
+
+
+def _create_readonly_connection():
+    readonly_dsn = _get_required_readonly_dsn()
+    return psycopg2.connect(readonly_dsn, connect_timeout=10)
+
+
+def _verify_readonly_identity(conn) -> tuple[str, str, str]:
+    with conn.cursor() as cursor:
+        cursor.execute(_IDENTITY_PROBE_SQL)
+        identity_row = cursor.fetchone()
+
+    if identity_row is None or len(identity_row) != 3:
+        raise RuntimeError("Readonly identity probe did not return current_database/current_user/session_user")
+
+    current_database, current_user, session_user = identity_row
+    if current_user != _EXPECTED_READONLY_LOGIN or session_user != _EXPECTED_READONLY_LOGIN:
+        raise RuntimeError(
+            "Readonly identity probe failed: "
+            f"current_user={current_user}, session_user={session_user}, "
+            f"expected={_EXPECTED_READONLY_LOGIN}"
+        )
+
+    return str(current_database), str(current_user), str(session_user)
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     try:
@@ -80,6 +119,7 @@ def main(argv: list[str] | None = None) -> int:
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
     request = None
+    readonly_identity: tuple[str, str, str] | None = None
     try:
         request = build_export_request(
             strategy_id=str(args.strategy_id),
@@ -92,8 +132,9 @@ def main(argv: list[str] | None = None) -> int:
             config_hash=str(args.config_hash) if args.config_hash is not None else None,
         )
 
-        conn = create_postgres_connection()
+        conn = _create_readonly_connection()
         try:
+            readonly_identity = _verify_readonly_identity(conn)
             with conn.cursor() as cursor:
                 cursor.execute(
                     """
@@ -130,11 +171,14 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: paper_reference_window export failed: {exc}", file=sys.stderr)
         return 2
 
+    readonly_database, readonly_current_user, readonly_session_user = readonly_identity
     print(
         "OK: paper_reference_window exported "
         f"(strategy_id={request.strategy_id}, symbol={request.symbol}, "
         f"window=[{request.start_ts_ms_utc},{request.end_ts_ms_utc}], "
-        f"bot_id={request.bot_id or '*'}, config_hash={request.config_hash or '*'})"
+        f"bot_id={request.bot_id or '*'}, config_hash={request.config_hash or '*'}, "
+        f"database={readonly_database}, current_user={readonly_current_user}, "
+        f"session_user={readonly_session_user})"
     )
     return 0
 

--- a/tests/unit/validation/test_paper_reference_window_runner.py
+++ b/tests/unit/validation/test_paper_reference_window_runner.py
@@ -31,6 +31,32 @@ def test_verify_readonly_identity_rejects_runtime_login():
 
 
 @pytest.mark.unit
+def test_verify_readonly_privileges_rejects_write_access():
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = (True, False, True, False)
+    conn.cursor.return_value.__enter__.return_value = cursor
+
+    with pytest.raises(
+        RuntimeError, match="Readonly privilege probe failed: write privileges detected"
+    ):
+        runner._verify_readonly_privileges(conn)
+
+
+@pytest.mark.unit
+def test_verify_readonly_privileges_requires_select():
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = (False, False, False, False)
+    conn.cursor.return_value.__enter__.return_value = cursor
+
+    with pytest.raises(
+        RuntimeError, match="Readonly privilege probe failed: missing SELECT"
+    ):
+        runner._verify_readonly_privileges(conn)
+
+
+@pytest.mark.unit
 def test_create_readonly_connection_uses_required_dsn(monkeypatch):
     connect_mock = MagicMock(return_value=MagicMock())
     monkeypatch.setenv(
@@ -73,6 +99,7 @@ def test_main_exports_with_verified_readonly_identity(
         "_verify_readonly_identity",
         lambda conn: ("claire_de_binare", "cdb_readonly", "cdb_readonly"),
     )
+    monkeypatch.setattr(runner, "_verify_readonly_privileges", lambda conn: None)
     monkeypatch.setattr(
         runner,
         "export_paper_reference_window",

--- a/tests/unit/validation/test_paper_reference_window_runner.py
+++ b/tests/unit/validation/test_paper_reference_window_runner.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.validation import paper_reference_window_runner as runner
+
+
+@pytest.mark.unit
+def test_get_required_readonly_dsn_rejects_missing_env(monkeypatch):
+    monkeypatch.delenv("POSTGRES_READONLY_PASSWORD_DSN", raising=False)
+
+    with pytest.raises(
+        RuntimeError, match="POSTGRES_READONLY_PASSWORD_DSN is required"
+    ):
+        runner._get_required_readonly_dsn()
+
+
+@pytest.mark.unit
+def test_verify_readonly_identity_rejects_runtime_login():
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = ("claire_de_binare", "claire_user", "claire_user")
+    conn.cursor.return_value.__enter__.return_value = cursor
+
+    with pytest.raises(RuntimeError, match="Readonly identity probe failed"):
+        runner._verify_readonly_identity(conn)
+
+
+@pytest.mark.unit
+def test_create_readonly_connection_uses_required_dsn(monkeypatch):
+    connect_mock = MagicMock(return_value=MagicMock())
+    monkeypatch.setenv(
+        "POSTGRES_READONLY_PASSWORD_DSN",
+        "postgresql://cdb_readonly:masked@localhost:5432/claire_de_binare",
+    )
+    monkeypatch.setattr(runner.psycopg2, "connect", connect_mock)
+
+    runner._create_readonly_connection()
+
+    connect_mock.assert_called_once_with(
+        "postgresql://cdb_readonly:masked@localhost:5432/claire_de_binare",
+        connect_timeout=10,
+    )
+
+
+@pytest.mark.unit
+def test_main_exports_with_verified_readonly_identity(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    output_path = tmp_path / "paper_reference_window.json"
+    request = SimpleNamespace(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        start_ts_ms_utc=1000,
+        end_ts_ms_utc=2000,
+        bot_id=None,
+        config_hash=None,
+    )
+    mock_conn = MagicMock()
+
+    monkeypatch.setattr(runner, "build_export_request", lambda **_: request)
+    monkeypatch.setattr(
+        runner,
+        "_create_readonly_connection",
+        lambda: mock_conn,
+    )
+    monkeypatch.setattr(
+        runner,
+        "_verify_readonly_identity",
+        lambda conn: ("claire_de_binare", "cdb_readonly", "cdb_readonly"),
+    )
+    monkeypatch.setattr(
+        runner,
+        "export_paper_reference_window",
+        lambda request, rows: {"schema_version": "arvp_paper_reference_window.v1"},
+    )
+    monkeypatch.setattr(
+        runner,
+        "canonical_json_dumps",
+        lambda payload: '{"schema_version":"arvp_paper_reference_window.v1"}',
+    )
+
+    query_cursor = MagicMock()
+    query_cursor.description = [SimpleNamespace(name="event_pk")]
+    query_cursor.fetchall.return_value = []
+    mock_conn.cursor.return_value.__enter__.return_value = query_cursor
+
+    exit_code = runner.main(
+        [
+            "--strategy-id",
+            "primary_breakout_v1",
+            "--symbol",
+            "BTCUSDT",
+            "--start-ts-ms",
+            "1000",
+            "--end-ts-ms",
+            "2000",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert output_path.read_text(encoding="utf-8") == (
+        '{"schema_version":"arvp_paper_reference_window.v1"}'
+    )
+    captured = capsys.readouterr()
+    assert "current_user=cdb_readonly" in captured.out
+    assert "session_user=cdb_readonly" in captured.out


### PR DESCRIPTION
## Problem
- services/validation/paper_reference_window_runner.py nutzte bisher create_postgres_connection() und konnte dadurch implizit Runtime-Credentials verwenden.
- Fuer einen spaeteren readonly Discovery-/Validation-Pfad ist das nicht akzeptabel, weil claire_user als Runtime-Login nicht als dedizierte readonly Identitaet gilt.

## Loesung
- Der Runner verlangt jetzt explizit POSTGRES_READONLY_PASSWORD_DSN.
- Kein Fallback auf POSTGRES_USER, POSTGRES_PASSWORD, DATABASE_URL oder claire_user.
- Direkt nach Connect wird SELECT current_database(), current_user, session_user; geprueft.
- Der Pfad failt closed, wenn nicht current_user = cdb_readonly und session_user = cdb_readonly.

## Geaenderte Dateien
- services/validation/paper_reference_window_runner.py
- 	ests/unit/validation/test_paper_reference_window_runner.py

## Validierung
- Unit-Test-Datei: 	ests/unit/validation/test_paper_reference_window_runner.py -> 4 passed
- Live-Consumer-Nachweis:
  - current_database=claire_de_binare
  - current_user=cdb_readonly
  - session_user=cdb_readonly
  - correlation_ledger_read_probe_ok
- Kein Secret-Wert im Output

## Nicht getan
- kein Secret-Wert ausgegeben
- kein DB-Apply
- kein neuer Rollen-/Grant-Step
- kein Discovery-/Auswertungs-Run
- kein #1905-Scope
- %F% / %MEM% nicht angefasst

## Naechster Gate nach Merge
- eadonly-access-wiring-merge-review
- danach erst erneuter kontrollierter Review fuer die naechste Anbindungsstufe