### PR TITLE
fix(cli): add argparse help to LR-030 evidence scripts

### DIFF
--- a/infrastructure/scripts/build_shadow_evidence_package.py
+++ b/infrastructure/scripts/build_shadow_evidence_package.py
@@ -8,6 +8,7 @@ anchored in execution_status.mode and evidence_index trading_mode.
 
 from __future__ import annotations
 
+import argparse
 import json
 import shutil
 import sys
@@ -218,12 +219,20 @@ def validate_shadow_evidence_package(package_root: Path) -> dict:
     }
 
 
-def main() -> None:
-    if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} <evidence-directory>", file=sys.stderr)
-        sys.exit(2)
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build and validate a canonical shadow-soak evidence package."
+    )
+    parser.add_argument(
+        "evidence_directory",
+        help="Path to the evidence directory containing the required shadow-soak artifacts.",
+    )
+    return parser
 
-    evidence_dir = Path(sys.argv[1])
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    evidence_dir = Path(args.evidence_directory)
     if not evidence_dir.is_dir():
         print(f"ERROR: not a directory: {evidence_dir}", file=sys.stderr)
         sys.exit(1)

--- a/infrastructure/scripts/soak_gate_eval.py
+++ b/infrastructure/scripts/soak_gate_eval.py
@@ -7,6 +7,7 @@ field ``mode``. Shadow probe semantics and soak-profile labels are separate.
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -125,12 +126,20 @@ def evaluate_shadow_soak_evidence(evidence_dir: Path) -> dict:
     }
 
 
-def main() -> None:
-    if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} <evidence-directory>", file=sys.stderr)
-        sys.exit(2)
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Evaluate shadow-soak evidence with hard LR-030/LR-031 gate criteria."
+    )
+    parser.add_argument(
+        "evidence_directory",
+        help="Path to the evidence directory containing the required shadow-soak artifacts.",
+    )
+    return parser
 
-    evidence_dir = Path(sys.argv[1])
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    evidence_dir = Path(args.evidence_directory)
     if not evidence_dir.is_dir():
         print(f"ERROR: not a directory: {evidence_dir}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary
- replace raw sys.argv checks with small local rgparse.ArgumentParser CLIs in the two LR-030 evidence scripts
- keep exactly one required positional argument: vidence_directory
- preserve existing evidence logic, outputs, and non-CLI failure semantics

## Validation
- python infrastructure/scripts/soak_gate_eval.py --help
- python infrastructure/scripts/build_shadow_evidence_package.py --help
- python infrastructure/scripts/soak_gate_eval.py
- python infrastructure/scripts/build_shadow_evidence_package.py
- pytest tests/unit/scripts/test_soak_gate_eval.py -v
- pytest tests/unit/scripts/test_build_shadow_evidence_package.py -v

Refs #2440