### PR TITLE
fix(soak): isolate lr030 monitor path from lr040 evidence

### DIFF
--- a/docs/operations/72H_SOAK_TEST_RUNBOOK.md
+++ b/docs/operations/72H_SOAK_TEST_RUNBOOK.md
@@ -249,13 +249,14 @@ SOAK_RUN_INTENT=validation ./infrastructure/scripts/soak_monitor.sh
 
 **Key differences from an LR-040 run:**
 
-| Aspect | LR-040 (`lr040`) | Validation (`validation`) |
-|---|---|---|
-| Artifact prefix | `artifacts/soak_test_*` | `artifacts/soak_validation_*` |
-| Active-run pointer | `soak_active_run_path_lr040.txt` (+ `soak_active_run_path.txt` synced, Issue #1283) | `soak_active_run_path_validation.txt` |
-| Intent marker | `run_intent.txt` = `lr040` | `run_intent.txt` = `validation` |
-| Gate evaluator verdict | PASS / FAIL / INCONCLUSIVE | NOT_APPLICABLE (exit 1) |
-| Monitor mechanics | identical | identical |
+| Aspect | LR-040 (`lr040`) | LR-030 local continuity (`lr030`) | Validation (`validation`) |
+|---|---|---|---|
+| Artifact prefix | `artifacts/soak_test_*` | `artifacts/soak_lr030_*` | `artifacts/soak_validation_*` |
+| Active-run pointer | `soak_active_run_path_lr040.txt` (+ `soak_active_run_path.txt` synced, Issue #1283) | `soak_active_run_path_lr030.txt` | `soak_active_run_path_validation.txt` |
+| Intent marker | `run_intent.txt` = `lr040` | `run_intent.txt` = `lr030` | `run_intent.txt` = `validation` |
+| Generic pointer sync | yes | no | no |
+| LR-040 gate evaluator verdict | PASS / FAIL / INCONCLUSIVE | NOT_APPLICABLE (exit 1) | NOT_APPLICABLE (exit 1) |
+| Monitor mechanics | canonical 72h soak | raw/operator continuity support only | identical mechanics, non-canonical |
 
 **Running the gate evaluator on a validation run:**
 
@@ -267,6 +268,24 @@ python infrastructure/scripts/lr040_soak_gate_eval.py artifacts/soak_validation_
 The gate evaluator reads `run_intent.txt` and refuses to produce a PASS
 for validation runs. This is intentional — validation artifacts are not
 canonical LR-040 evidence.
+
+## LR-030 Local Continuity Mode (#2440 prep slice)
+
+For a future local LR-030 shadow/soak rerun, the monitor can be invoked with:
+
+```bash
+SOAK_RUN_INTENT=lr030 ./infrastructure/scripts/soak_monitor.sh
+```
+
+Boundary:
+
+- This writes only to `artifacts/soak_lr030_*`.
+- It updates only `soak_active_run_path_lr030.txt`.
+- It must not reuse LR-040 generic pointer state or `soak_test_*` artifacts.
+- It is **raw/operator continuity support only** for the local rerun path.
+- The normative LR-030 evidence/package chain remains the existing
+  `.github/workflows/shadow-soak-evidence.yml` flow plus
+  `docs/evidence/SHADOW_SOAK_RUN_INDEX.md`.
 
 **Default behavior:** Without `SOAK_RUN_INTENT`, the monitor defaults to
 `lr040` (backwards-compatible with all existing runs).

--- a/docs/operations/SOAK_MONITOR_RUNBOOK.md
+++ b/docs/operations/SOAK_MONITOR_RUNBOOK.md
@@ -52,6 +52,18 @@ docker ps --filter name=cdb_ --format '{{.Names}}: {{.Status}}'
 #   soak_test_FAILED.txt — only if Zero Restart violated
 ```
 
+For the isolated LR-030 local monitor path:
+
+```bash
+SOAK_RUN_INTENT=lr030 ./infrastructure/scripts/soak_monitor.sh
+```
+
+- Artifacts land under `artifacts/soak_lr030_*`.
+- Only `soak_active_run_path_lr030.txt` is updated.
+- The generic pointer `soak_active_run_path.txt` stays LR-040-only.
+- This path is raw/operator continuity support only and does not replace the
+  workflow-backed LR-030 evidence chain.
+
 ## Cron Installation (Linux)
 
 ```bash

--- a/infrastructure/scripts/lr040_soak_gate_eval.py
+++ b/infrastructure/scripts/lr040_soak_gate_eval.py
@@ -107,23 +107,23 @@ def _read_run_intent(artifact_dir: Path) -> str | None:
 def evaluate_lr040_soak(artifact_dir: Path) -> dict:
     """Evaluate soak artifacts against LR-040 criteria. Fail-closed."""
 
-    # --- Run intent gate (Issue #1278) ---
-    # Validation runs must never produce an LR-040 PASS verdict.
+    # --- Run intent gate (Issue #1278 / #2440) ---
+    # Non-lr040 runs must never produce an LR-040 PASS verdict.
     # Return NOT_APPLICABLE immediately so the caller cannot mistake a
-    # validation run for canonical LR-040 evidence. exit 1 (fail-closed).
+    # non-lr040 run for canonical LR-040 evidence. exit 1 (fail-closed).
     run_intent = _read_run_intent(artifact_dir)
-    if run_intent == "validation":
+    if run_intent and run_intent != "lr040":
         return {
             "schema_version": "1.1",
             "control": "LR-040",
             "issue": "#786",
             "verdict": "NOT_APPLICABLE",
-            "reason": "Validation run — not canonical LR-040 evidence (Issue #1278)",
+            "reason": f"Run intent '{run_intent}' is not canonical LR-040 evidence",
             "run_intent": run_intent,
             "checks": {},
             "failures": [],
             "metrics": {},
-            "artifacts": {"run_intent": "validation"},
+            "artifacts": {"run_intent": run_intent},
         }
 
     hourly_log = artifact_dir / "hourly_checks.log"

--- a/infrastructure/scripts/soak_monitor.sh
+++ b/infrastructure/scripts/soak_monitor.sh
@@ -9,6 +9,7 @@
 #
 # Run intent (SOAK_RUN_INTENT env var):
 #   lr040      (default) — canonical 72h soak for LR-040 evidence
+#   lr030                — local raw/operator continuity path for LR-030 reruns
 #   validation           — short verification run for monitor mechanics
 #
 # Example:
@@ -40,29 +41,36 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Run intent: lr040 (default) or validation (Issue #1278)
+# Run intent: lr040 (default), lr030, or validation
 #
 # lr040      — canonical 72h soak run for LR-040 evidence
+# lr030      — local raw/operator continuity support for LR-030 reruns
 # validation — short verification run to test monitor mechanics
 #
 # Each intent uses its own artifact prefix and active-run pointer file so
-# validation runs can never be confused with canonical LR-040 evidence.
-# The gate evaluator refuses to produce a PASS verdict for validation runs.
+# lr030/validation runs can never be confused with canonical LR-040 evidence.
+# The LR-040 gate evaluator refuses to produce a PASS verdict for non-lr040 runs.
 # ---------------------------------------------------------------------------
 SOAK_RUN_INTENT="${SOAK_RUN_INTENT:-lr040}"
 case "$SOAK_RUN_INTENT" in
-  lr040|validation) ;;
+  lr040|lr030|validation) ;;
   *)
-    echo "ERROR: SOAK_RUN_INTENT must be 'lr040' or 'validation', got '$SOAK_RUN_INTENT'" >&2
+    echo "ERROR: SOAK_RUN_INTENT must be 'lr040', 'lr030', or 'validation', got '$SOAK_RUN_INTENT'" >&2
     exit 1
     ;;
 esac
 
-if [ "$SOAK_RUN_INTENT" = "validation" ]; then
-  ARTIFACT_PREFIX="soak_validation"
-else
-  ARTIFACT_PREFIX="soak_test"
-fi
+case "$SOAK_RUN_INTENT" in
+  lr040)
+    ARTIFACT_PREFIX="soak_test"
+    ;;
+  lr030)
+    ARTIFACT_PREFIX="soak_lr030"
+    ;;
+  validation)
+    ARTIFACT_PREFIX="soak_validation"
+    ;;
+esac
 
 # Intent-specific pointer file (Issue #1278): lr040 and validation runs
 # each have their own pointer so they never cross-contaminate.
@@ -90,6 +98,24 @@ _write_active_run_path() {
   if [ "$SOAK_RUN_INTENT" = "lr040" ]; then
     printf '%s\n' "$artifact_path" > "$ARTIFACT_ROOT/soak_active_run_path.txt"
   fi
+}
+
+_validate_existing_run_intent() {
+  local artifact_path="$1"
+  local run_intent_file="$artifact_path/run_intent.txt"
+  local existing_intent=""
+
+  if [ ! -f "$run_intent_file" ]; then
+    return 0
+  fi
+
+  existing_intent=$(head -n 1 "$run_intent_file" | tr -d '[:space:]')
+  if [ -z "$existing_intent" ] || [ "$existing_intent" = "$SOAK_RUN_INTENT" ]; then
+    return 0
+  fi
+
+  echo "ERROR: Refusing to reuse artifact dir '$artifact_path': run_intent.txt='$existing_intent' expected '$SOAK_RUN_INTENT'" >&2
+  return 1
 }
 
 _find_latest_artifact_dir() {
@@ -132,15 +158,20 @@ _resolve_artifact_path() {
 
 ARTIFACT_PATH=$(_resolve_artifact_path)
 mkdir -p "$ARTIFACT_PATH"
-_write_active_run_path "$ARTIFACT_PATH"
 
 if [ -z "$ARTIFACT_PATH" ] || [ ! -d "$ARTIFACT_PATH" ]; then
   echo "ERROR: artifact directory not available — aborting soak monitor" >&2
   exit 1
 fi
 
-# Write run intent marker (Issue #1278). Written once at directory creation;
-# subsequent invocations preserve the existing marker to prevent mid-run changes.
+if ! _validate_existing_run_intent "$ARTIFACT_PATH"; then
+  exit 1
+fi
+_write_active_run_path "$ARTIFACT_PATH"
+
+# Write run intent marker (Issue #1278). For existing directories, the
+# fail-closed check above guarantees the marker already matches the requested
+# intent before any pointer is updated.
 RUN_INTENT_FILE="$ARTIFACT_PATH/run_intent.txt"
 if [ ! -f "$RUN_INTENT_FILE" ]; then
   printf '%s\n' "$SOAK_RUN_INTENT" > "$RUN_INTENT_FILE"
@@ -164,7 +195,7 @@ fi
 RUN_START_FILE="$ARTIFACT_PATH/run_start.txt"
 if [ ! -f "$RUN_START_FILE" ]; then
   # Preferred source: parse UTC epoch from the artifact directory name.
-  # soak_test_YYYYMMDD_HHMMSS encodes the exact start time set by the operator
+  # <intent-prefix>_YYYYMMDD_HHMMSS encodes the exact start time set by the operator
   # at soak launch — more accurate than the first cron invocation, which may
   # arrive up to ~60 s late due to scheduling jitter or a delayed manual start.
   _ARTIFACT_NAME=$(basename "$ARTIFACT_PATH")
@@ -207,7 +238,7 @@ fi
 # Auto-stop guard: skip all checks after the monitoring window closes.
 # Prevents post-window Docker/host restarts from tainting a valid run.
 # SOAK_TARGET_HOURS defaults to 72 (LR-040 requirement).
-# Validation runs skip this guard (no fixed target duration).
+# lr030 and validation runs skip this guard (no fixed target duration here).
 # Issue #1419.
 # ---------------------------------------------------------------------------
 SOAK_TARGET_HOURS_RAW="${SOAK_TARGET_HOURS:-72}"
@@ -261,11 +292,17 @@ NC='\033[0m' # No Color
 SUT_SERVICES="cdb_postgres cdb_redis cdb_market cdb_candles cdb_regime cdb_allocation cdb_risk cdb_execution cdb_db_writer cdb_paper_runner cdb_ws cdb_signal"
 EXPECTED_SERVICES=12
 
-if [ "$SOAK_RUN_INTENT" = "validation" ]; then
-  _RUN_LABEL="VALIDATION Run"
-else
-  _RUN_LABEL="LR-040 Soak Test"
-fi
+case "$SOAK_RUN_INTENT" in
+  validation)
+    _RUN_LABEL="VALIDATION Run"
+    ;;
+  lr030)
+    _RUN_LABEL="LR-030 Shadow/Soak Run"
+    ;;
+  *)
+    _RUN_LABEL="LR-040 Soak Test"
+    ;;
+esac
 echo "========================================="
 echo "$_RUN_LABEL Monitoring - Checkpoint $ELAPSED_HOURS (elapsed hours)"
 echo "Run Intent: $SOAK_RUN_INTENT"

--- a/infrastructure/scripts/soak_telemetry_sidecar.sh
+++ b/infrastructure/scripts/soak_telemetry_sidecar.sh
@@ -11,6 +11,7 @@
 #   bash infrastructure/scripts/soak_telemetry_sidecar.sh
 #   bash infrastructure/scripts/soak_telemetry_sidecar.sh soak_test_20260401_114850
 #   SOAK_RUN_ID=soak_test_20260401_114850 bash infrastructure/scripts/soak_telemetry_sidecar.sh
+#   SOAK_RUN_INTENT=lr030 bash infrastructure/scripts/soak_telemetry_sidecar.sh
 #
 # Scheduling (Windows Task Scheduler):
 #   Use artifacts/run_soak_sidecar.cmd as launcher, schedule every 15 minutes.
@@ -18,9 +19,29 @@
 set -euo pipefail
 
 ARTIFACT_ROOT="${ARTIFACT_ROOT:-artifacts}"
+SOAK_RUN_INTENT="${SOAK_RUN_INTENT:-lr040}"
 TIMESTAMP_FILE=$(date -u +"%Y%m%d_%H%M%S")
 TIMESTAMP_HUMAN=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
 HOSTNAME_VAL=$(hostname 2>/dev/null || echo "unknown")
+
+case "$SOAK_RUN_INTENT" in
+    lr040)
+        SIDECAR_ARTIFACT_PREFIX="soak_test"
+        SIDECAR_POINTER_FILE="${ARTIFACT_ROOT}/soak_active_run_path_lr040.txt"
+        ;;
+    lr030)
+        SIDECAR_ARTIFACT_PREFIX="soak_lr030"
+        SIDECAR_POINTER_FILE="${ARTIFACT_ROOT}/soak_active_run_path_lr030.txt"
+        ;;
+    validation)
+        SIDECAR_ARTIFACT_PREFIX="soak_validation"
+        SIDECAR_POINTER_FILE="${ARTIFACT_ROOT}/soak_active_run_path_validation.txt"
+        ;;
+    *)
+        echo "ERROR: SOAK_RUN_INTENT must be lr040, lr030, or validation (got '${SOAK_RUN_INTENT}')." >&2
+        exit 1
+        ;;
+esac
 
 # ── Resolve repo root and Windows drive ──────────────────────────────────────
 
@@ -55,25 +76,28 @@ resolve_soak_run_id() {
         return 0
     fi
 
-    local pointer_file="${ARTIFACT_ROOT}/soak_active_run_path_lr040.txt"
+    local pointer_file="${SIDECAR_POINTER_FILE}"
     if [ -f "$pointer_file" ]; then
         local pointer_content
         pointer_content=$(cat "$pointer_file" | tr -d '[:space:]')
-        SOAK_RUN_ID=$(basename "$pointer_content")
-        RESOLVE_METHOD="pointer file ($pointer_file)"
-        return 0
+        if echo "$(basename "$pointer_content")" | grep -q "^${SIDECAR_ARTIFACT_PREFIX}_"; then
+            SOAK_RUN_ID=$(basename "$pointer_content")
+            RESOLVE_METHOD="pointer file ($pointer_file)"
+            return 0
+        fi
+        echo "WARNING: Ignoring pointer file '$pointer_file' with mismatched path '$pointer_content' for intent '${SOAK_RUN_INTENT}'." >&2
     fi
 
-    # Auto-detect: latest soak_test_* directory
+    # Auto-detect: latest intent-matching artifact directory
     local latest
-    latest=$(ls -1d "${ARTIFACT_ROOT}"/soak_test_* 2>/dev/null | sort | tail -1)
+    latest=$(ls -1d "${ARTIFACT_ROOT}"/${SIDECAR_ARTIFACT_PREFIX}_* 2>/dev/null | sort | tail -1)
     if [ -n "$latest" ]; then
         SOAK_RUN_ID=$(basename "$latest")
         RESOLVE_METHOD="auto-detect (latest)"
         return 0
     fi
 
-    echo "ERROR: Cannot resolve soak run ID. No argument, env var, pointer file, or soak_test_* directory found." >&2
+    echo "ERROR: Cannot resolve soak run ID. No argument, env var, intent-matching pointer file, or ${SIDECAR_ARTIFACT_PREFIX}_* directory found." >&2
     exit 1
 }
 

--- a/tests/unit/scripts/test_lr040_soak_gate_eval.py
+++ b/tests/unit/scripts/test_lr040_soak_gate_eval.py
@@ -288,6 +288,16 @@ class TestLR040SoakGateRunIntent:
         result = evaluate_lr040_soak(artifact_dir)
         assert result["verdict"] == "NOT_APPLICABLE"
 
+    def test_lr030_intent_returns_not_applicable(self, tmp_path: Path) -> None:
+        """run_intent.txt = lr030 -> NOT_APPLICABLE for LR-040 gate eval."""
+        artifact_dir = _write_passing_artifacts(tmp_path)
+        (artifact_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+        result = evaluate_lr040_soak(artifact_dir)
+        assert result["verdict"] == "NOT_APPLICABLE"
+        assert result["run_intent"] == "lr030"
+        assert result["checks"] == {}
+        assert result["failures"] == []
+
 
 class TestLR040SoakGateEdgeCases:
     def test_exactly_72h_passes(self, tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_soak_monitor_timeline.py
+++ b/tests/unit/scripts/test_soak_monitor_timeline.py
@@ -23,6 +23,8 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(
     0, str(Path(__file__).resolve().parents[3] / "infrastructure" / "scripts")
 )
@@ -61,16 +63,21 @@ def build_artifact_path(dt: datetime, intent: str = "lr040") -> str:
 
     Since Issue #1278, the prefix depends on SOAK_RUN_INTENT:
       lr040      -> artifacts/soak_test_YYYYMMDD_HHMMSS
+      lr030      -> artifacts/soak_lr030_YYYYMMDD_HHMMSS
       validation -> artifacts/soak_validation_YYYYMMDD_HHMMSS
     """
     dt = dt.astimezone(timezone.utc)
-    prefix = "soak_validation" if intent == "validation" else "soak_test"
+    prefix = _artifact_prefix_for_intent(intent)
     return f"artifacts/{prefix}_{dt:%Y%m%d_%H%M%S}"
 
 
 def _artifact_prefix_for_intent(intent: str) -> str:
     """Return the artifact directory prefix for a given run intent."""
-    return "soak_validation" if intent == "validation" else "soak_test"
+    if intent == "validation":
+        return "soak_validation"
+    if intent == "lr030":
+        return "soak_lr030"
+    return "soak_test"
 
 
 def resolve_active_artifact_path_with_intent(
@@ -288,6 +295,10 @@ class TestIntentAwareArtifactPath:
         path = build_artifact_path(self.NOW, intent="lr040")
         assert path == "artifacts/soak_test_20260325_100000"
 
+    def test_lr030_creates_soak_lr030_prefix(self) -> None:
+        path = build_artifact_path(self.NOW, intent="lr030")
+        assert path == "artifacts/soak_lr030_20260325_100000"
+
     def test_default_intent_is_lr040(self) -> None:
         path = build_artifact_path(self.NOW)
         assert "soak_test_" in path
@@ -316,6 +327,30 @@ class TestIntentAwareArtifactPath:
         assert resolved.startswith("artifacts/soak_test_")
         assert resolved not in existing
 
+    def test_lr030_ignores_soak_test_dirs(self) -> None:
+        """lr030 intent must never reuse a soak_test_* directory."""
+        existing = [
+            "artifacts/soak_test_20260324_220000",
+            "artifacts/soak_test_20260325_080000",
+        ]
+        resolved = resolve_active_artifact_path_with_intent(
+            self.NOW, existing, active_run_path=None, intent="lr030"
+        )
+        assert resolved.startswith("artifacts/soak_lr030_")
+        assert resolved not in existing
+
+    def test_lr030_ignores_soak_validation_dirs(self) -> None:
+        """lr030 intent must never reuse a soak_validation_* directory."""
+        existing = [
+            "artifacts/soak_validation_20260324_220000",
+            "artifacts/soak_validation_20260325_080000",
+        ]
+        resolved = resolve_active_artifact_path_with_intent(
+            self.NOW, existing, active_run_path=None, intent="lr030"
+        )
+        assert resolved.startswith("artifacts/soak_lr030_")
+        assert resolved not in existing
+
     def test_validation_pointer_to_soak_test_dir_rejected(self) -> None:
         """Active-run pointer pointing at soak_test_* must be ignored when intent=validation."""
         existing = [
@@ -339,6 +374,18 @@ class TestIntentAwareArtifactPath:
             self.NOW, existing, active_run_path=cross_pointer, intent="lr040"
         )
         assert resolved == "artifacts/soak_test_20260324_220000"
+
+    def test_lr030_pointer_to_soak_test_dir_rejected(self) -> None:
+        """Active-run pointer pointing at soak_test_* must be ignored when intent=lr030."""
+        existing = [
+            "artifacts/soak_test_20260324_220000",
+            "artifacts/soak_lr030_20260325_090000",
+        ]
+        cross_pointer = "artifacts/soak_test_20260324_220000"
+        resolved = resolve_active_artifact_path_with_intent(
+            self.NOW, existing, active_run_path=cross_pointer, intent="lr030"
+        )
+        assert resolved == "artifacts/soak_lr030_20260325_090000"
 
     def test_same_intent_pointer_accepted(self) -> None:
         """Pointer matching the intent prefix is accepted normally."""
@@ -380,6 +427,7 @@ class TestIntentAwareArtifactPath:
         """Empty directory list → new directory with intent-correct prefix."""
         for intent, expected_prefix in [
             ("lr040", "soak_test_"),
+            ("lr030", "soak_lr030_"),
             ("validation", "soak_validation_"),
         ]:
             resolved = resolve_active_artifact_path_with_intent(
@@ -439,6 +487,15 @@ class TestGenericPointerSync:
         ).read_text().strip() == artifact
         assert not (tmp_path / "soak_active_run_path.txt").exists()
 
+    def test_lr030_writes_only_intent_pointer(self, tmp_path: Path) -> None:
+        """lr030: only soak_active_run_path_lr030.txt; generic pointer not created."""
+        artifact = str(tmp_path / "soak_lr030_20260326_120000")
+        _simulate_write_active_run_path(artifact, tmp_path, "lr030")
+        assert (
+            tmp_path / "soak_active_run_path_lr030.txt"
+        ).read_text().strip() == artifact
+        assert not (tmp_path / "soak_active_run_path.txt").exists()
+
     def test_unknown_intent_does_not_write_generic_pointer(
         self, tmp_path: Path
     ) -> None:
@@ -461,6 +518,11 @@ class TestRunIntentMarker:
         intent_file.write_text("validation\n", encoding="utf-8")
         assert intent_file.read_text(encoding="utf-8").strip() == "validation"
 
+    def test_intent_file_content_lr030(self, tmp_path: Path) -> None:
+        intent_file = tmp_path / "run_intent.txt"
+        intent_file.write_text("lr030\n", encoding="utf-8")
+        assert intent_file.read_text(encoding="utf-8").strip() == "lr030"
+
     def test_intent_file_not_overwritten_on_rerun(self, tmp_path: Path) -> None:
         """Mirrors soak_monitor.sh: if run_intent.txt exists, don't overwrite."""
         intent_file = tmp_path / "run_intent.txt"
@@ -469,6 +531,99 @@ class TestRunIntentMarker:
         if not intent_file.exists():
             intent_file.write_text("lr040\n", encoding="utf-8")
         assert intent_file.read_text(encoding="utf-8").strip() == "validation"
+
+
+def validate_existing_run_intent(
+    existing_intent: str | None,
+    requested_intent: str,
+) -> bool:
+    """Mirror the fail-closed reuse guard in soak_monitor.sh."""
+    if existing_intent is None:
+        return True
+    return existing_intent == requested_intent
+
+
+class TestRunIntentReuseGuard:
+    def test_missing_run_intent_allows_new_directory(self) -> None:
+        assert validate_existing_run_intent(None, "lr030") is True
+
+    def test_matching_run_intent_allows_reuse(self) -> None:
+        assert validate_existing_run_intent("lr030", "lr030") is True
+
+    def test_lr030_rejects_lr040_directory(self) -> None:
+        assert validate_existing_run_intent("lr040", "lr030") is False
+
+    def test_lr040_rejects_lr030_directory(self) -> None:
+        assert validate_existing_run_intent("lr030", "lr040") is False
+
+    def test_guard_present_in_soak_monitor_sh(self) -> None:
+        content = _read_soak_monitor()
+        assert (
+            "Refusing to reuse artifact dir" in content
+        ), "run_intent mismatch guard missing from soak_monitor.sh"
+
+
+def _sidecar_pointer_file_for_intent(intent: str) -> str:
+    if intent == "validation":
+        return "artifacts/soak_active_run_path_validation.txt"
+    if intent == "lr030":
+        return "artifacts/soak_active_run_path_lr030.txt"
+    return "artifacts/soak_active_run_path_lr040.txt"
+
+
+def resolve_sidecar_run_id(
+    existing_dirs: list[str],
+    intent: str = "lr040",
+    arg_run_id: str | None = None,
+    env_run_id: str | None = None,
+    pointer_path: str | None = None,
+) -> str:
+    """Mirror sidecar run-id resolution for the intent-aware pointer path."""
+    if arg_run_id:
+        return arg_run_id
+    if env_run_id:
+        return env_run_id
+
+    prefix = f"artifacts/{_artifact_prefix_for_intent(intent)}_"
+    if pointer_path:
+        normalized = pointer_path.strip()
+        if normalized in existing_dirs and normalized.startswith(prefix):
+            return Path(normalized).name
+
+    matching = sorted(path for path in existing_dirs if path.startswith(prefix))
+    if matching:
+        return Path(matching[-1]).name
+
+    raise ValueError("no intent-matching sidecar run id could be resolved")
+
+
+class TestTelemetrySidecarResolution:
+    NOW = datetime(2026, 3, 25, 10, 0, 0, tzinfo=timezone.utc)
+
+    def test_sidecar_uses_lr030_pointer_name(self) -> None:
+        assert (
+            _sidecar_pointer_file_for_intent("lr030")
+            == "artifacts/soak_active_run_path_lr030.txt"
+        )
+
+    def test_sidecar_lr030_rejects_lr040_pointer(self) -> None:
+        existing = [
+            "artifacts/soak_test_20260325_080000",
+            "artifacts/soak_lr030_20260325_090000",
+        ]
+        resolved = resolve_sidecar_run_id(
+            existing,
+            intent="lr030",
+            pointer_path="artifacts/soak_test_20260325_080000",
+        )
+        assert resolved == "soak_lr030_20260325_090000"
+
+    def test_sidecar_lr030_requires_explicit_or_matching_artifact(self) -> None:
+        with pytest.raises(ValueError):
+            resolve_sidecar_run_id(
+                existing_dirs=["artifacts/soak_test_20260325_080000"],
+                intent="lr030",
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -1584,10 +1739,12 @@ class TestDiskCheckFallback:
     def test_bash_check5_contains_docker_df_valid_and_fallback_messages(self) -> None:
         """Semantic anchors that must survive in soak_monitor.sh Check 5."""
         content = _read_soak_monitor()
-        assert "DOCKER_DF_VALID" in content, "DOCKER_DF_VALID variable missing from Check 5"
-        assert "Host filesystem unavailable" in content, (
-            "Fallback console message missing — path B wording changed"
-        )
-        assert "Docker disk evidence also unavailable" in content, (
-            "Fail-closed message missing — path C wording changed"
-        )
+        assert (
+            "DOCKER_DF_VALID" in content
+        ), "DOCKER_DF_VALID variable missing from Check 5"
+        assert (
+            "Host filesystem unavailable" in content
+        ), "Fallback console message missing — path B wording changed"
+        assert (
+            "Docker disk evidence also unavailable" in content
+        ), "Fail-closed message missing — path C wording changed"


### PR DESCRIPTION
## Summary
- add isolated SOAK_RUN_INTENT=lr030 monitor namespace with soak_lr030_* artifacts
- keep generic soak_active_run_path.txt LR-040-only
- make telemetry sidecar intent-aware for lr040/lr030/validation
- make LR-040 gate evaluation fail closed for non-lr040 intents
- document LR-030 local monitor path as raw/operator continuity support only

## Validation
- pytest tests/unit/scripts/test_soak_monitor_timeline.py -v
- pytest tests/unit/scripts/test_lr040_soak_gate_eval.py -v
- bash -n infrastructure/scripts/soak_monitor.sh
- bash -n infrastructure/scripts/soak_telemetry_sidecar.sh

## Scope / Safety
- refs #2440
- related #1784
- no run started
- no runtime start/restart
- no artifact generation
- no LR status upgrade
- no live or real-money implication