### PR TITLE
chore(codeql): exclude generated mexc proto files from analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "Claire de Binare CodeQL config"
+
+paths-ignore:
+  - services/ws/mexc_proto_gen/**

--- a/.github/workflows/codeql-python.yml
+++ b/.github/workflows/codeql-python.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           languages: python
           queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3


### PR DESCRIPTION
## Summary
- Adds a dedicated CodeQL config file.
- Excludes generated `services/ws/mexc_proto_gen/**` files from Python CodeQL analysis.
- Keeps real CodeQL findings in hand-written production/tooling code visible.

## Issue
Closes part of #2289.

## Validation
- `git diff --check`
- Verified diff only touches:
  - `.github/workflows/codeql-python.yml`
  - `.github/codeql/codeql-config.yml`

## Scope Guard
- No Trivy changes.
- No Risk Service changes.
- No Shadow/LR/Paper/Live scope.
- No generated source edits.