### PR TITLE
fix(tools): resolve implicit string concatenation in context bridge

### DIFF
--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -632,8 +632,7 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
                 "uncertainties": [],
                 "guardrails": [
                     "Do not proceed. Resolve missing context first.",
-                    "Readiness is not authorization. LR remains NO-GO. "
-                    "Board stage (trade-capable) is orthogonal.",
+                    "Readiness is not authorization. LR remains NO-GO. Board stage (trade-capable) is orthogonal.",
                 ],
             },
         }
@@ -778,8 +777,7 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
 
     # Boundary guardrail — always present
     guardrails.append(
-        "Readiness is not authorization. LR remains NO-GO. "
-        "Board stage (trade-capable) is orthogonal."
+        "Readiness is not authorization. LR remains NO-GO. Board stage (trade-capable) is orthogonal."
     )
 
     return {


### PR DESCRIPTION
## Summary
- Collapses the implicit adjacent string literals in `context_bridge.py` guardrails into explicit single strings.
- Keeps the runtime guardrail text unchanged.
- Applies the same cleanup to the parallel `guardrails.append(...)` call for consistency.

## Issue
Part of #2289.

## CodeQL
Addresses CodeQL alert #4285: `py/implicit-string-concatenation-in-list`.

## Validation
- `git diff --check`
- `ruff check tools/mcp/context_bridge.py`
- `pytest tests/unit/tools/mcp/test_context_bridge.py -v -m unit`

## Scope Guard
- Tools-only change.
- No tests changed.
- No docs changed.
- No Trivy changes.
- No alert dismissals.
- No Slice 4.
- No Shadow/LR/Paper/Live scope.