### PR TITLE
fix(tools): remove unused CodeQL imports

### DIFF
--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -16,7 +16,7 @@ import logging
 import re
 
 from dataclasses import dataclass
-from typing import Any, Iterable, Mapping
+from typing import Any, Mapping
 
 from tools.surrealdb.evidence_lookup import (
     EvidenceLookupError,

--- a/tools/surrealdb/trust_summary.py
+++ b/tools/surrealdb/trust_summary.py
@@ -20,8 +20,8 @@ Guardrails:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Mapping
 
 SCHEMA_VERSION = "trust-summary/v1"
 


### PR DESCRIPTION
## Summary
- Removes unused imports from \	ools/surrealdb/trust_summary.py\.
- Removes unused \Iterable\ import from \	ools/mcp/context_evidence_memory_tools.py\.
- No runtime logic changed.

## Issue
Part of #2289.

## CodeQL
Addresses note-level CodeQL alerts:
- #4297: unused \ield\
- #4298: unused \Sequence\
- #4296: unused \Iterable\

## Validation
- \git diff --check\
- \uff check tools/surrealdb/trust_summary.py tools/mcp/context_evidence_memory_tools.py\
- \pytest -v tests/unit/tools/mcp/test_mcp_wave14_tools.py\

## Scope Guard
- Tools import cleanup only.
- No tests changed.
- No docs changed.
- No Trivy changes.
- No alert dismissals.
- No Slice 4B.
- No Shadow/LR/Paper/Live scope.