### PR TITLE
fix(tools): remove unused datetime import from verlosung validator

### DIFF
--- a/tools/misc/verlosung/validate_persistence.py
+++ b/tools/misc/verlosung/validate_persistence.py
@@ -6,7 +6,6 @@ Validates that test events were correctly persisted to PostgreSQL
 
 import os
 import sys
-from datetime import datetime
 
 import psycopg2
 


### PR DESCRIPTION
## Summary
- Removes the unused \datetime\ import from \	ools/misc/verlosung/validate_persistence.py\.
- No runtime logic changed.
- No tests or docs changed.

## Issue
Part of #2289.

## CodeQL
Addresses note-level CodeQL alert:
- #4246: unused \datetime\ import

## Validation
- \g -n "\bdatetime\b" tools/misc/verlosung/validate_persistence.py\
- \python -c "import ast; ast.parse(open('tools/misc/verlosung/validate_persistence.py', encoding='utf-8').read()); print('OK')"\
- \uff check tools/misc/verlosung/validate_persistence.py\
- \git diff --check\

## Scope Guard
- Single-file tools cleanup.
- No tests changed.
- No docs changed.
- No Trivy changes.
- No alert dismissals.
- No Slice 4C.
- No Shadow/LR/Paper/Live scope.