### PR TITLE
feat(security): add alert readout issue automation

### DIFF
--- a/.github/workflows/security-alert-readout.yml
+++ b/.github/workflows/security-alert-readout.yml
@@ -364,15 +364,17 @@ jobs:
 
   comment-epic:
     runs-on: ubuntu-latest
-    needs: security-readout
+    needs: [security-readout, issue-automation]
     if: always()
     permissions:
       contents: read
       issues: write
     env:
-      DATE_DIR:       ${{ needs.security-readout.outputs.date_dir }}
-      READOUT_STATUS: ${{ needs.security-readout.outputs.readout_status || 'unknown/failed' }}
-      DELTA_STATUS:   ${{ needs.security-readout.outputs.delta_status || 'unknown/failed' }}
+      DATE_DIR:         ${{ needs.security-readout.outputs.date_dir }}
+      READOUT_STATUS:   ${{ needs.security-readout.outputs.readout_status || 'unknown/failed' }}
+      DELTA_STATUS:     ${{ needs.security-readout.outputs.delta_status || 'unknown/failed' }}
+      AUTOMATION_MODE:  ${{ needs.issue-automation.outputs.automation_mode || 'skipped' }}
+      AUTOMATION_EXIT:  ${{ needs.issue-automation.outputs.automation_exit || 'skipped' }}
     steps:
       - name: Post compact ledger comment to epic #2289
         env:
@@ -439,6 +441,17 @@ jobs:
             escalation_note="manual triage required"
           fi
 
+          # Derive automation boundary line from the issue-automation job outputs.
+          automation_mode="${AUTOMATION_MODE:-skipped}"
+          automation_exit="${AUTOMATION_EXIT:-skipped}"
+          if [[ "${automation_mode}" == "live" ]]; then
+            automation_note="issue-automation: LIVE (exit: ${automation_exit}) — check run log for created/skipped/failed counts"
+          elif [[ "${automation_mode}" == "dry-run" ]]; then
+            automation_note="issue-automation: dry-run (exit: ${automation_exit}) — no GitHub writes"
+          else
+            automation_note="issue-automation: skipped/not-run"
+          fi
+
           comment_file="$(mktemp)"
           cat > "${comment_file}" <<EOF
           ${marker}
@@ -461,7 +474,7 @@ jobs:
           - \`artifacts/security-alert-readout/delta/security_alert_delta.json\`
 
           **Security boundaries**
-          - no new issues created
+          - ${automation_note}
           - no alert dismissals
           - no auto-merge
           - secret scanning remains redacted/status-only
@@ -490,6 +503,9 @@ jobs:
       contents: read
       actions: read
       issues: write
+    outputs:
+      automation_mode: ${{ steps.run-automation.outputs.automation_mode }}
+      automation_exit: ${{ steps.run-automation.outputs.automation_exit }}
 
     env:
       DATE_DIR:       ${{ needs.security-readout.outputs.date_dir }}
@@ -516,6 +532,7 @@ jobs:
           path: /tmp/security-readout-artifact
 
       - name: Run issue automation
+        id: run-automation
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
@@ -527,6 +544,8 @@ jobs:
           if [[ ! -f "${DELTA_JSON}" ]]; then
             echo "Delta JSON not found at ${DELTA_JSON}; skipping issue automation."
             echo "This is expected when security-readout failed or produced no delta."
+            echo "automation_mode=skipped" >> "${GITHUB_OUTPUT}"
+            echo "automation_exit=skipped" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
@@ -538,17 +557,24 @@ jobs:
           fi
 
           LIVE_FLAG=""
+          AUTOMATION_MODE="dry-run"
           if [[ "${LIVE_MODE}" == "true" ]]; then
             LIVE_FLAG="--live-mode"
+            AUTOMATION_MODE="live"
             echo "Issue automation: LIVE mode (will create real issues)"
           else
             echo "Issue automation: DRY-RUN mode (no GitHub writes)"
           fi
 
+          set +e
           python3 scripts/audit/security_issue_automation.py \
             --delta-json "${DELTA_JSON}" \
             --repo "${GITHUB_REPOSITORY}" \
             ${LIVE_FLAG}
+          SCRIPT_EXIT=$?
+          set -e
 
-          echo "issue_automation_exit=$?" >> "${GITHUB_OUTPUT}" || true
+          echo "automation_mode=${AUTOMATION_MODE}" >> "${GITHUB_OUTPUT}"
+          echo "automation_exit=${SCRIPT_EXIT}" >> "${GITHUB_OUTPUT}"
+          exit ${SCRIPT_EXIT}
 

--- a/.github/workflows/security-alert-readout.yml
+++ b/.github/workflows/security-alert-readout.yml
@@ -37,6 +37,11 @@ on:
         required: false
         default: "false"
         type: boolean
+      issue_automation_live:
+        description: "Enable live mode for issue-automation job (creates real GitHub issues). Defaults to false (dry-run). Scheduled runs always use dry-run."
+        required: false
+        default: "false"
+        type: boolean
 
 permissions:
   contents: read           # no repo writes; read-only checkout
@@ -466,3 +471,84 @@ jobs:
           gh issue comment "${ISSUE_NUMBER}" \
             --repo "${GITHUB_REPOSITORY}" \
             --body-file "${comment_file}"
+
+  issue-automation:
+    # Create GitHub issues for new high-severity alert groups detected in the
+    # delta JSON.  Dry-run by default; pass issue_automation_live=true via
+    # workflow_dispatch to enable live issue creation.
+    #
+    # Invariants:
+    # - Scheduled runs: always dry-run (no issue spam).
+    # - No auto-close, no alert dismissals, no LR derivation.
+    # - Dedupe is fail-closed: a lookup failure skips creation (exit 2).
+    # - Secret scanning candidates are excluded at the script layer.
+    # - comparison_skipped sources are excluded at the script layer.
+    runs-on: ubuntu-latest
+    needs: security-readout
+    if: always() && needs.security-readout.result != 'cancelled'
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+
+    env:
+      DATE_DIR:       ${{ needs.security-readout.outputs.date_dir }}
+      READOUT_STATUS: ${{ needs.security-readout.outputs.readout_status || 'unknown/failed' }}
+      DELTA_STATUS:   ${{ needs.security-readout.outputs.delta_status || 'unknown/failed' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install runtime dependencies
+        shell: bash
+        run: pip install --quiet -r requirements.txt
+
+      - name: Download security-alert-readout artifact
+        uses: actions/download-artifact@96a0b611a25419df80fce7e0ddf2b97cd4efdf6e # v4.1.8
+        with:
+          name: security-alert-readout-${{ github.run_number }}
+          path: /tmp/security-readout-artifact
+
+      - name: Run issue automation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DELTA_JSON="/tmp/security-readout-artifact/artifacts/security-alert-readout/delta/security_alert_delta.json"
+
+          if [[ ! -f "${DELTA_JSON}" ]]; then
+            echo "Delta JSON not found at ${DELTA_JSON}; skipping issue automation."
+            echo "This is expected when security-readout failed or produced no delta."
+            exit 0
+          fi
+
+          # Scheduled runs are always dry-run to prevent uncontrolled issue spam.
+          # Live mode requires explicit workflow_dispatch with issue_automation_live=true.
+          LIVE_MODE="false"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            LIVE_MODE="${{ inputs.issue_automation_live || 'false' }}"
+          fi
+
+          LIVE_FLAG=""
+          if [[ "${LIVE_MODE}" == "true" ]]; then
+            LIVE_FLAG="--live-mode"
+            echo "Issue automation: LIVE mode (will create real issues)"
+          else
+            echo "Issue automation: DRY-RUN mode (no GitHub writes)"
+          fi
+
+          python3 scripts/audit/security_issue_automation.py \
+            --delta-json "${DELTA_JSON}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            ${LIVE_FLAG}
+
+          echo "issue_automation_exit=$?" >> "${GITHUB_OUTPUT}" || true
+

--- a/docs/security/TRIAGE_RUNBOOK.md
+++ b/docs/security/TRIAGE_RUNBOOK.md
@@ -286,6 +286,97 @@ Kein direkter Commit in das Repository (artifacts-only-Modus, siehe Publish-Modu
 
 ---
 
+## 10. Issue Automation — Neue Alert-Gruppen (#2289)
+
+### Zweck
+
+Der `issue-automation`-Job in `.github/workflows/security-alert-readout.yml` liest
+`security_alert_delta.json` und erstellt pro neuer, eskalationsrelevanter Alert-Gruppe
+genau ein GitHub-Issue.  Er läuft nach dem `security-readout`-Job und ist fail-closed:
+ein Fehler beim Dedupe-Check verhindert die Erstellung (kein stillen Fehlern).
+
+### Invarianten
+
+- **Kein Auto-Close.** Einmal erstellte Issues werden nur durch menschliche Triage
+  geschlossen.
+- **Keine Alert-Dismissals** durch den Automation-Layer.
+- **Keine LR-/Live-/Echtgeld-Ableitung.**
+- **Secret-Scanning** wird im `security_alert_issue_candidates.py`-Layer gefiltert
+  und nie automatisiert als Issue angelegt.
+- **`comparison_skipped`-Quellen** (z. B. Dependabot ohne Token) werden im
+  Automation-Layer gefiltert — keine Issue-Erstellung für PARTIAL-Sources.
+
+### Eskalationsschwelle
+
+Nur Kandidaten mit `severity_band == "high"` (deckt `critical`, `high`, `error` ab)
+werden zu Issue-Kandidaten.  `medium`, `low`, `note`, `unknown` werden übersprungen.
+
+### Dedupe-Mechanismus
+
+Jedes Issue enthält einen HTML-Kommentar als Dedupe-Marker:
+
+```
+<!-- cdb-security-alert-group:<fingerprint> -->
+```
+
+Der Fingerprint ist ein SHA-256[:16] der kanonisierten Felder
+`source|severity_band|subject|affected_component|branch`.
+
+Vor jeder Issue-Erstellung prüft das Skript per GitHub-GraphQL-Suche, ob ein
+Issue mit diesem Marker bereits existiert.  Bei Lookup-Fehler: fail-closed (kein
+Create, Exit 2).
+
+**Hinweis:** GitHub-Suche ist eventually consistent (Indexierungs-Lag möglich).
+Der Marker ist primäre Dedupe-Wahrheit; die Suche ist ein Best-Effort-Guard.
+
+### Dry-run vs. Live-Modus
+
+| Trigger | Modus |
+|---------|-------|
+| `schedule` | immer dry-run — kein Issue-Spam auf geplanten Runs |
+| `workflow_dispatch` ohne `issue_automation_live=true` | dry-run |
+| `workflow_dispatch` mit `issue_automation_live=true` | live — erstellt echte Issues |
+
+Im Dry-run werden alle Candidates geloggt (`DRY-RUN: would create issue: …`),
+aber keine GitHub-Writes durchgeführt.
+
+### CLI-Referenz
+
+```bash
+# Dry-run (default)
+python3 scripts/audit/security_issue_automation.py \
+  --delta-json artifacts/security-alert-readout/delta/security_alert_delta.json \
+  --repo owner/repo
+
+# Live-Modus (nur bewusst aktivieren)
+python3 scripts/audit/security_issue_automation.py \
+  --delta-json artifacts/security-alert-readout/delta/security_alert_delta.json \
+  --repo owner/repo \
+  --live-mode
+```
+
+### Exit-Codes
+
+| Code | Bedeutung |
+|------|-----------|
+| `0` | ok — alle Candidates verarbeitet (erstellt oder übersprungen) |
+| `1` | Input-Fehler — Delta-JSON fehlt oder ungültig |
+| `2` | Partial-Failure — mindestens eine Issue-Erstellung oder ein Dedupe-Lookup fehlgeschlagen |
+
+### Verknüpfte Skripte
+
+- `scripts/audit/security_issue_automation.py` — CLI, Automation-Loop, GitHub-Writes
+- `scripts/audit/security_alert_issue_candidates.py` — Kandidatengenerierung (kein GitHub-API)
+
+### Stop-Regeln für manuellen Betrieb
+
+- Bei `exit 2`: Logs prüfen, betroffene Fingerprints identifizieren, manuell nacharbeiten.
+- Nie `--live-mode` auf geplanten Runs aktivieren — Workflow-Guard verhindert das, aber
+  auch manuell nicht umgehen.
+- Kein Commit der Ausgaben; das Skript schreibt keine Dateien.
+
+---
+
 ## Verknüpfte Issues
 
 - #1649 — [EPIC] Code-Scanning konsolidieren

--- a/scripts/audit/security_alert_issue_candidates.py
+++ b/scripts/audit/security_alert_issue_candidates.py
@@ -361,12 +361,48 @@ def _safe_list_dict(value: object) -> list[dict[str, Any]]:
     return [item for item in value if isinstance(item, dict)]
 
 
+def _normalize_delta_keys(raw: dict[str, Any]) -> dict[str, Any]:
+    """Bridge the real security_alert_delta.v1 JSON shape to the keys this module reads.
+
+    The delta module emits ``escalation_alerts`` (not ``escalations``) and flat
+    ``*_count`` integer fields (not a ``counts`` dict).  This normalizer adds the
+    expected keys when they are absent, leaving existing keys untouched so that
+    test fixtures that already use the canonical names are unaffected.
+    """
+    normalized = dict(raw)
+
+    # escalation_alerts (delta module) → escalations (this module)
+    if "escalation_alerts" in raw and "escalations" not in raw:
+        normalized["escalations"] = raw["escalation_alerts"]
+
+    # flat *_count ints → counts dict
+    if "counts" not in raw and any(
+        k in raw for k in ("new_alert_count", "new_group_count", "escalation_alert_count")
+    ):
+        normalized["counts"] = {
+            "new_alerts": int(raw.get("new_alert_count", 0)),
+            "reopened_alerts": int(raw.get("reopened_alert_count", 0)),
+            "new_groups": int(raw.get("new_group_count", 0)),
+            "escalation_alerts": int(raw.get("escalation_alert_count", 0)),
+        }
+
+    # current_readout.reference_now_utc → sources.current_reference_now_utc
+    if "sources" not in raw and isinstance(raw.get("current_readout"), dict):
+        normalized["sources"] = {
+            "current_reference_now_utc": raw["current_readout"].get("reference_now_utc", "")
+        }
+
+    return normalized
+
+
 def build_candidates(delta: dict[str, Any]) -> list[dict[str, Any]]:
     schema = str(delta.get("schema_version", ""))
     if not schema.startswith("security_alert_delta"):
         raise SecurityAlertIssueCandidatesError(
             "Invalid input schema; expected security_alert_delta.*"
         )
+
+    delta = _normalize_delta_keys(delta)
 
     counts = _safe_counts(delta)
     current_reference = _extract_current_reference(delta)

--- a/scripts/audit/security_issue_automation.py
+++ b/scripts/audit/security_issue_automation.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Create GitHub issues from security alert issue candidates.
+
+Read-only candidate analysis is delegated to security_alert_issue_candidates.
+This script handles the GitHub write path: dedupe check + issue creation.
+
+Design invariants:
+- ``--live-mode`` must be passed explicitly; dry-run is the default.
+- Dedupe: checks existing issues via GitHub GraphQL search for the dedupe
+  marker before creating any issue.  A failed dedupe lookup is treated as a
+  per-candidate partial failure (fail-closed — skip creation, exit 2).
+- Fingerprints are validated as 16-char hex before use in GraphQL queries.
+- secret_scanning: never processed (filtered in the candidates layer).
+- No auto-close.  No alert dismissals.  No LR derivation.
+
+Exit codes:
+  0  ok       — all candidates processed (created or skipped)
+  1  error    — input error or fatal configuration problem
+  2  partial  — one or more issue creates or dedupe lookups failed
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+# ---------------------------------------------------------------------------
+# Import sibling candidates module (robust regardless of invocation path)
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from audit.security_alert_issue_candidates import (  # noqa: E402
+    SecurityAlertIssueCandidatesError,
+    build_candidates,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Only candidates in the "high" severity band (covers critical / high / error)
+# are candidates for automated issue creation.
+AUTOMATION_SEVERITY_BANDS: frozenset[str] = frozenset({"high"})
+
+# Fingerprints are 16-char lowercase hex produced by build_fingerprint().
+_FINGERPRINT_RE: re.Pattern[str] = re.compile(r"^[0-9a-f]{16}$")
+
+CheckDedupeFn = Callable[..., bool]
+CreateIssueFn = Callable[..., bool]
+
+
+# ---------------------------------------------------------------------------
+# GitHub helpers (real implementations; injected in tests)
+# ---------------------------------------------------------------------------
+
+
+def _validate_fingerprint(fingerprint: str) -> str:
+    """Return fingerprint if it matches the expected hex format, raise ValueError otherwise."""
+    if not _FINGERPRINT_RE.match(fingerprint):
+        raise ValueError(f"Invalid fingerprint format: {fingerprint!r}")
+    return fingerprint
+
+
+def gh_check_dedupe(*, fingerprint: str, repo: str) -> bool:
+    """Return True if an issue containing the dedupe marker already exists.
+
+    Uses GitHub GraphQL body search.  Returns None-like errors as a
+    ``ValueError`` so callers can distinguish "not found" (False) from
+    "lookup failed" (raises).
+    """
+    _validate_fingerprint(fingerprint)
+    marker_fragment = f"cdb-security-alert-group:{fingerprint}"
+    query_string = f'repo:{repo} is:issue "{marker_fragment}" in:body'
+    graphql = (
+        "query($q:String!){"
+        "search(type:ISSUE,query:$q,first:5){"
+        "issueCount}}"
+    )
+    result = subprocess.run(
+        [
+            "gh", "api", "graphql",
+            "-f", f"query={graphql}",
+            "-F", f"q={query_string}",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh graphql dedupe check failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    try:
+        data = json.loads(result.stdout)
+        count = int(data["data"]["search"]["issueCount"])
+        return count > 0
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError(f"Unexpected gh graphql response: {exc}") from exc
+
+
+def _render_issue_body(candidate: dict[str, Any]) -> str:
+    """Render a safe, bounded issue body from candidate ``body_safe_fields``."""
+    fields = candidate["body_safe_fields"]
+    refs_line = " | ".join(candidate.get("references", []))
+    labels_hint = ", ".join(f"`{lbl}`" for lbl in candidate.get("suggested_labels", []))
+
+    lines: list[str] = [
+        candidate["dedupe_marker"],
+        "",
+        f"## Security Alert: {fields.get('severity_band', 'unknown').upper()}",
+        "",
+        f"**Source:** `{fields.get('source', 'unknown')}`",
+        f"**Severity:** `{fields.get('severity', 'unknown')}` (band: `{fields.get('severity_band', 'unknown')}`)",
+        f"**Subject:** `{fields.get('subject', 'unknown')}`",
+        f"**Affected component:** `{fields.get('affected_component', 'unknown')}`",
+        f"**Branch:** `{fields.get('branch', 'unknown')}`",
+        "",
+        f"**Fingerprint:** `{fields.get('fingerprint', 'unknown')}`",
+        f"**Generated from readout:** `{fields.get('current_reference_now_utc', 'unknown')}`",
+        "",
+        "### Next action",
+        "",
+        str(fields.get("next_action", "Human triage and bounded remediation planning.")),
+        "",
+        "### References",
+        "",
+        refs_line,
+        "",
+        "---",
+        "",
+        "> [!NOTE]",
+        "> Auto-generated by Security Alert Readout workflow. Human review required.",
+        "> No auto-close. No alert dismissals. No LR derivation.",
+    ]
+    if labels_hint:
+        lines += ["", f"**Suggested labels:** {labels_hint}"]
+    return "\n".join(lines)
+
+
+def gh_create_issue(*, candidate: dict[str, Any], repo: str) -> bool:
+    """Create a GitHub issue for the candidate via ``gh``. Return True on success."""
+    title = candidate.get("suggested_title", "Security alert")[:220]
+    body = _render_issue_body(candidate)
+    labels: list[str] = candidate.get("suggested_labels", [])
+
+    cmd = ["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body]
+    for label in labels:
+        cmd += ["--label", label]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        print(
+            f"  gh issue create failed: {result.stderr.strip()!r}",
+            file=sys.stderr,
+        )
+    return result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Core automation loop
+# ---------------------------------------------------------------------------
+
+
+def run_automation(
+    *,
+    delta_path: Path,
+    repo: str,
+    dry_run: bool,
+    _check_dedupe: CheckDedupeFn = gh_check_dedupe,
+    _create_issue: CreateIssueFn = gh_create_issue,
+) -> tuple[int, int, int]:
+    """Process candidates from the delta JSON.
+
+    Returns:
+        (created, skipped, failed) counts.
+
+    Raises:
+        SecurityAlertIssueCandidatesError: on unrecoverable input error.
+    """
+    try:
+        raw = json.loads(delta_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise SecurityAlertIssueCandidatesError(f"Cannot read {delta_path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise SecurityAlertIssueCandidatesError(f"Invalid JSON in {delta_path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise SecurityAlertIssueCandidatesError("Delta JSON root must be an object")
+
+    # Determine sources where comparison was skipped — never process these,
+    # even if the delta contains residual group entries for them.
+    skipped_raw = raw.get("comparison_skipped_sources") or []
+    if not isinstance(skipped_raw, list):
+        skipped_raw = []
+    skipped_sources: frozenset[str] = frozenset(
+        str(entry.get("source", "")).strip().lower()
+        for entry in skipped_raw
+        if isinstance(entry, dict) and entry.get("source")
+    )
+    if skipped_sources:
+        print(f"  Ignoring comparison_skipped sources: {sorted(skipped_sources)}")
+
+    candidates = build_candidates(raw)
+
+    # Remove candidates from skipped sources (defense-in-depth; delta should not
+    # emit them, but we guard here as well).
+    if skipped_sources:
+        candidates = [
+            c for c in candidates
+            if c.get("source", "").strip().lower() not in skipped_sources
+        ]
+
+    # Filter to escalation-severity candidates only.
+    automation_candidates = [
+        c for c in candidates
+        if c.get("severity_band") in AUTOMATION_SEVERITY_BANDS
+    ]
+    skipped_low = len(candidates) - len(automation_candidates)
+    if skipped_low:
+        print(f"  Skipped {skipped_low} candidate(s) below escalation threshold (severity_band not in {set(AUTOMATION_SEVERITY_BANDS)}).")
+
+    created = 0
+    skipped = 0
+    failed = 0
+
+    for candidate in automation_candidates:
+        fingerprint = candidate["fingerprint"]
+        title = candidate.get("suggested_title", "?")
+
+        # Dedupe check (fail-closed: skip on lookup failure).
+        try:
+            already_exists = _check_dedupe(fingerprint=fingerprint, repo=repo)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"  FAIL (dedupe error, fingerprint={fingerprint!r}): {exc}",
+                file=sys.stderr,
+            )
+            failed += 1
+            continue
+
+        if already_exists:
+            print(f"  SKIP (dedupe match): {title!r}")
+            skipped += 1
+            continue
+
+        if dry_run:
+            print(f"  DRY-RUN: would create issue: {title!r}")
+            skipped += 1
+            continue
+
+        # Live: create the issue.
+        success = _create_issue(candidate=candidate, repo=repo)
+        if success:
+            print(f"  CREATED: {title!r}")
+            created += 1
+        else:
+            print(f"  FAIL (issue create): {title!r}", file=sys.stderr)
+            failed += 1
+
+    return created, skipped, failed
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create GitHub issues from security alert issue candidates. "
+            "Dry-run by default; pass --live-mode to create real issues."
+        ),
+    )
+    parser.add_argument(
+        "--delta-json",
+        required=True,
+        metavar="PATH",
+        help="Path to security_alert_delta.json",
+    )
+    parser.add_argument(
+        "--repo",
+        required=True,
+        metavar="OWNER/REPO",
+        help="GitHub repository (owner/repo format)",
+    )
+    parser.add_argument(
+        "--live-mode",
+        action="store_true",
+        default=False,
+        help="Enable live mode: create real GitHub issues (default: dry-run)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    delta_path = Path(args.delta_json)
+
+    if not delta_path.exists():
+        print(f"ERROR: delta JSON not found: {delta_path}", file=sys.stderr)
+        return 1
+
+    dry_run = not args.live_mode
+    mode = "LIVE" if args.live_mode else "DRY-RUN"
+    print(f"security-issue-automation: mode={mode} repo={args.repo} delta={delta_path}")
+
+    try:
+        created, skipped, failed = run_automation(
+            delta_path=delta_path,
+            repo=args.repo,
+            dry_run=dry_run,
+        )
+    except SecurityAlertIssueCandidatesError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Done: created={created} skipped={skipped} failed={failed}")
+    return 2 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/audit/test_security_issue_automation.py
+++ b/tests/unit/audit/test_security_issue_automation.py
@@ -1,0 +1,605 @@
+"""Unit tests for security_issue_automation.py.
+
+Injected helpers simulate GitHub calls so no network / gh auth needed.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Use same import pattern as the existing audit tests.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from audit.security_issue_automation import (  # noqa: E402
+    AUTOMATION_SEVERITY_BANDS,
+    _FINGERPRINT_RE,
+    _validate_fingerprint,
+    _render_issue_body,
+    main,
+    run_automation,
+)
+from audit.security_alert_issue_candidates import build_fingerprint  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SCHEMA = "security_alert_delta.v1"
+
+
+def _base_delta(*, new_groups: list | None = None, escalations: list | None = None) -> dict:
+    """Canonical-key delta shape (already normalized — mirrors what candidates tests use)."""
+    return {
+        "schema_version": _SCHEMA,
+        "counts": {
+            "new_alerts": 0,
+            "reopened_alerts": 0,
+            "new_groups": len(new_groups or []),
+            "escalation_alerts": len(escalations or []),
+        },
+        "sources": {"current_reference_now_utc": "2026-05-15T06:15:00Z"},
+        "comparison_skipped_sources": [],
+        "new_groups": new_groups or [],
+        "escalations": escalations or [],
+    }
+
+
+def _real_delta_shape(*, new_groups: list | None = None, escalation_alerts: list | None = None) -> dict:
+    """Flat-count / escalation_alerts delta shape — as emitted by security_alert_delta.py."""
+    return {
+        "schema_version": _SCHEMA,
+        "new_alert_count": 0,
+        "reopened_alert_count": 0,
+        "new_group_count": len(new_groups or []),
+        "escalation_alert_count": len(escalation_alerts or []),
+        "comparison_skipped_sources": [],
+        "new_groups": new_groups or [],
+        "escalation_alerts": escalation_alerts or [],
+        "current_readout": {"reference_now_utc": "2026-05-15T06:15:00Z"},
+    }
+
+
+def _write_delta(tmp_path: Path, delta: dict) -> Path:
+    p = tmp_path / "security_alert_delta.json"
+    p.write_text(json.dumps(delta), encoding="utf-8")
+    return p
+
+
+# Injected stub factories.
+
+def _no_dedupe(**_kwargs: Any) -> bool:
+    """Simulate: no existing issue found."""
+    return False
+
+
+def _always_dedupe(**_kwargs: Any) -> bool:
+    """Simulate: issue already exists."""
+    return True
+
+
+def _create_ok(**_kwargs: Any) -> bool:
+    return True
+
+
+def _create_fail(**_kwargs: Any) -> bool:
+    return False
+
+
+def _dedupe_error(**_kwargs: Any) -> bool:
+    raise RuntimeError("graphql timeout")
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint / validation tests
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_re_accepts_valid() -> None:
+    assert _FINGERPRINT_RE.match("abcd1234ef567890")
+    assert _FINGERPRINT_RE.match("0000000000000000")
+
+
+def test_fingerprint_re_rejects_invalid() -> None:
+    assert not _FINGERPRINT_RE.match("ABCD1234EF56789")  # uppercase
+    assert not _FINGERPRINT_RE.match("too-short")
+    assert not _FINGERPRINT_RE.match("abcd1234ef567890a")  # 17 chars
+
+
+def test_validate_fingerprint_ok() -> None:
+    fp = "abcdef0123456789"
+    assert _validate_fingerprint(fp) == fp
+
+
+def test_validate_fingerprint_raises_on_invalid() -> None:
+    with pytest.raises(ValueError, match="Invalid fingerprint format"):
+        _validate_fingerprint("NOTHEX!")
+
+
+# ---------------------------------------------------------------------------
+# Automation severity band tests
+# ---------------------------------------------------------------------------
+
+
+def test_automation_bands_include_high_only() -> None:
+    assert "high" in AUTOMATION_SEVERITY_BANDS
+    assert "medium" not in AUTOMATION_SEVERITY_BANDS
+    assert "low" not in AUTOMATION_SEVERITY_BANDS
+
+
+# ---------------------------------------------------------------------------
+# run_automation — no candidates
+# ---------------------------------------------------------------------------
+
+
+def test_no_new_groups_produces_no_creates(tmp_path: Path) -> None:
+    delta_path = _write_delta(tmp_path, _base_delta())
+    created, skipped, failed = run_automation(
+        delta_path=delta_path,
+        repo="owner/repo",
+        dry_run=True,
+        _check_dedupe=_no_dedupe,
+        _create_issue=_create_ok,
+    )
+    assert created == 0
+    assert failed == 0
+
+
+# ---------------------------------------------------------------------------
+# run_automation — dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_does_not_call_create(tmp_path: Path) -> None:
+    """Dry-run must not invoke _create_issue even when a candidate would qualify."""
+    create_calls: list[dict] = []
+
+    def _capture_create(**kwargs: Any) -> bool:
+        create_calls.append(kwargs)
+        return True
+
+    delta = _base_delta(
+        new_groups=[
+            {"source": "code_scanning", "subject": "cve-2026-0001", "branch": "main"},
+        ],
+        escalations=[
+            {
+                "source": "code_scanning",
+                "severity": "critical",
+                "subject": "cve-2026-0001",
+                "affected_component": "core/risk",
+                "branch": "main",
+            }
+        ],
+    )
+    delta_path = _write_delta(tmp_path, delta)
+    created, skipped, failed = run_automation(
+        delta_path=delta_path,
+        repo="owner/repo",
+        dry_run=True,
+        _check_dedupe=_no_dedupe,
+        _create_issue=_capture_create,
+    )
+    assert create_calls == [], "dry-run must not call _create_issue"
+    assert created == 0
+    assert failed == 0
+
+
+# ---------------------------------------------------------------------------
+# run_automation — live mode
+# ---------------------------------------------------------------------------
+
+
+def test_live_mode_creates_for_critical_candidate(tmp_path: Path) -> None:
+    delta = _base_delta(
+        new_groups=[
+            {"source": "code_scanning", "subject": "cve-2026-0002", "branch": "main"},
+        ],
+        escalations=[
+            {
+                "source": "code_scanning",
+                "severity": "critical",
+                "subject": "cve-2026-0002",
+                "affected_component": "services/execution",
+                "branch": "main",
+            }
+        ],
+    )
+    delta_path = _write_delta(tmp_path, delta)
+    created, skipped, failed = run_automation(
+        delta_path=delta_path,
+        repo="owner/repo",
+        dry_run=False,
+        _check_dedupe=_no_dedupe,
+        _create_issue=_create_ok,
+    )
+    assert created == 1
+    assert failed == 0
+
+
+def test_live_mode_creates_for_high_candidate(tmp_path: Path) -> None:
+    delta = _base_delta(
+        new_groups=[
+            {"source": "dependabot", "subject": "urllib3", "branch": "main"},
+        ],
+        escalations=[
+            {
+                "source": "dependabot",
+                "severity": "high",
+                "subject": "urllib3",
+                "affected_component": "requirements.txt",
+                "branch": "main",
+            }
+        ],
+    )
+    delta_path = _write_delta(tmp_path, delta)
+    created, skipped, failed = run_automation(
+        delta_path=delta_path,
+        repo="owner/repo",
+        dry_run=False,
+        _check_dedupe=_no_dedupe,
+        _create_issue=_create_ok,
+    )
+    assert created == 1
+    assert failed == 0
+
+
+# ---------------------------------------------------------------------------
+# run_automation — medium/low filtered out
+# ---------------------------------------------------------------------------
+
+
+def test_medium_severity_candidate_not_created(tmp_path: Path) -> None:
+    delta = _base_delta(
+        new_groups=[
+            {"source": "code_scanning", "subject": "cve-2026-low", "branch": "main"},
+        ],
+        # No escalations → severity_band will be low/medium → filtered
+    )
+    delta_path = _write_delta(tmp_path, delta)
+    create_calls: list[dict] = []
+
+    def _capture(**kwargs: Any) -> bool:
+        create_calls.append(kwargs)
+        return True
+
+    created, skipped, failed = run_automation(
+        delta_path=delta_path,
+        repo="owner/repo",
+        dry_run=False,
+        _check_dedupe=_no_dedupe,
+        _create_issue=_capture,
+    )
+    assert create_calls == [], "medium/low should never trigger issue creation"
+    assert created == 0
+
+
+# ---------------------------------------------------------------------------
+# run_automation — dedupe match → skip
+# ---------------------------------------------------------------------------
+
+
+def test_existing_dedupe_marker_skips_create(tmp_path: Path) -> None:
+    delta = _base_delta(
+        new_groups=[
+            {"source": "code_scanning", "subject": "cve-2026-dup", "branch": "main"},
+        ],
+        escalations=[
+            {
+                "source": "code_scanning",
+                "severity": "critical",
+                "subject": "cve-2026-dup",
+                "affected_component": "core/safety",
+                "branch": "main",
+            }
+        ],
+    )
+    delta_path = _write_delta(tmp_path, delta)
+    create_calls: list[dict] = []
+
+    def _capture(**kwargs: Any) -> bool:
+        create_calls.append(kwargs)
+        return True
+
+    created, skipped, failed = run_automation(
+        delta_path=delta_path,
+        repo="owner/repo",
+        dry_run=False,
+        _check_dedupe=_always_dedupe,
+        _create_issue=_capture,
+    )
+    assert create_calls == [], "dedupe match must suppress issue creation"
+    assert created == 0
+    assert skipped >= 1
+    assert failed == 0
+
+
+# ---------------------------------------------------------------------------
+# run_automation — dedupe error → fail-closed (exit 2)
+# ---------------------------------------------------------------------------
+
+
+def test_dedupe_error_is_fail_closed(tmp_path: Path) -> None:
+    delta = _base_delta(
+        new_groups=[
+            {"source": "code_scanning", "subject": "cve-2026-err", "branch": "main"},
+        ],
+        escalations=[
+            {
+                "source": "code_scanning",
+                "severity": "critical",
+                "subject": "cve-2026-err",
+                "affected_component": "core/contracts",
+                "branch": "main",
+            }
+        ],
+    )
+    delta_path = _write_delta(tmp_path, delta)
+    create_calls: list[dict] = []
+
+    def _capture(**kwargs: Any) -> bool:
+        create_calls.append(kwargs)
+        return True
+
+    created, skipped, failed = run_automation(
+        delta_path=delta_path,
+        repo="owner/repo",
+        dry_run=False,
+        _check_dedupe=_dedupe_error,
+        _create_issue=_capture,
+    )
+    assert create_calls == [], "dedupe failure must not trigger issue creation"
+    assert created == 0
+    assert failed >= 1
+
+
+# ---------------------------------------------------------------------------
+# run_automation — issue create failure → exit 2
+# ---------------------------------------------------------------------------
+
+
+def test_failed_create_reports_exit_2(tmp_path: Path) -> None:
+    delta = _base_delta(
+        new_groups=[
+            {"source": "code_scanning", "subject": "cve-2026-cfail", "branch": "main"},
+        ],
+        escalations=[
+            {
+                "source": "code_scanning",
+                "severity": "critical",
+                "subject": "cve-2026-cfail",
+                "affected_component": "core/execution",
+                "branch": "main",
+            }
+        ],
+    )
+    delta_path = _write_delta(tmp_path, delta)
+    created, skipped, failed = run_automation(
+        delta_path=delta_path,
+        repo="owner/repo",
+        dry_run=False,
+        _check_dedupe=_no_dedupe,
+        _create_issue=_create_fail,
+    )
+    assert failed >= 1
+    assert created == 0
+
+
+# ---------------------------------------------------------------------------
+# run_automation — comparison_skipped source is excluded
+# ---------------------------------------------------------------------------
+
+
+def test_comparison_skipped_source_excluded(tmp_path: Path) -> None:
+    """Groups from a comparison_skipped source must not generate candidates."""
+    delta = {
+        "schema_version": _SCHEMA,
+        "counts": {
+            "new_alerts": 0,
+            "reopened_alerts": 0,
+            "new_groups": 0,
+            "escalation_alerts": 0,
+        },
+        "sources": {"current_reference_now_utc": "2026-05-15T06:15:00Z"},
+        "comparison_skipped_sources": [
+            {"source": "dependabot", "reason": "no token"}
+        ],
+        "new_groups": [
+            # This group's source is in comparison_skipped_sources — should be excluded.
+            {"source": "dependabot", "subject": "openssl", "branch": "main"},
+        ],
+        "escalations": [
+            {
+                "source": "dependabot",
+                "severity": "critical",
+                "subject": "openssl",
+                "affected_component": "requirements.txt",
+                "branch": "main",
+            }
+        ],
+    }
+    delta_path = _write_delta(tmp_path, delta)
+    create_calls: list[dict] = []
+
+    def _capture(**kwargs: Any) -> bool:
+        create_calls.append(kwargs)
+        return True
+
+    created, skipped, failed = run_automation(
+        delta_path=delta_path,
+        repo="owner/repo",
+        dry_run=False,
+        _check_dedupe=_no_dedupe,
+        _create_issue=_capture,
+    )
+    assert create_calls == [], "comparison_skipped source must be excluded"
+    assert created == 0
+
+
+# ---------------------------------------------------------------------------
+# run_automation — secret_scanning excluded
+# ---------------------------------------------------------------------------
+
+
+def test_secret_scanning_source_excluded(tmp_path: Path) -> None:
+    delta = _base_delta(
+        new_groups=[
+            {"source": "secret_scanning", "subject": "ghp_token", "branch": "main"},
+        ],
+        escalations=[
+            {
+                "source": "secret_scanning",
+                "severity": "critical",
+                "subject": "ghp_token",
+                "affected_component": "repo",
+                "branch": "main",
+            }
+        ],
+    )
+    delta_path = _write_delta(tmp_path, delta)
+    create_calls: list[dict] = []
+
+    def _capture(**kwargs: Any) -> bool:
+        create_calls.append(kwargs)
+        return True
+
+    created, skipped, failed = run_automation(
+        delta_path=delta_path,
+        repo="owner/repo",
+        dry_run=False,
+        _check_dedupe=_no_dedupe,
+        _create_issue=_capture,
+    )
+    assert create_calls == [], "secret_scanning must always be excluded"
+    assert created == 0
+
+
+# ---------------------------------------------------------------------------
+# run_automation — real delta JSON shape (normalization test)
+# ---------------------------------------------------------------------------
+
+
+def test_real_delta_json_shape_is_normalized(tmp_path: Path) -> None:
+    """Verify that the flat-count / escalation_alerts shape from the delta module
+    is correctly normalized before reaching the candidates layer."""
+    delta = _real_delta_shape(
+        new_groups=[
+            {
+                "source": "code_scanning",
+                "subject": "cve-2026-norm",
+                "branch": "main",
+                "affected_component": "core/risk",
+            }
+        ],
+        escalation_alerts=[
+            {
+                "source": "code_scanning",
+                "severity": "critical",
+                "subject": "cve-2026-norm",
+                "affected_component": "core/risk",
+                "branch": "main",
+            }
+        ],
+    )
+    delta_path = _write_delta(tmp_path, delta)
+    created, skipped, failed = run_automation(
+        delta_path=delta_path,
+        repo="owner/repo",
+        dry_run=True,
+        _check_dedupe=_no_dedupe,
+        _create_issue=_create_ok,
+    )
+    # With dry-run: created=0, skipped≥1 (the one escalation-severity candidate), failed=0
+    assert failed == 0
+    assert skipped >= 1
+
+
+# ---------------------------------------------------------------------------
+# run_automation — missing delta JSON
+# ---------------------------------------------------------------------------
+
+
+def test_missing_delta_json_returns_exit_1(tmp_path: Path) -> None:
+    result = main(["--delta-json", str(tmp_path / "does_not_exist.json"), "--repo", "owner/repo"])
+    assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI exit-code mapping
+# ---------------------------------------------------------------------------
+
+
+def test_cli_exit_0_when_no_candidates(tmp_path: Path) -> None:
+    delta_path = _write_delta(tmp_path, _base_delta())
+    result = main(["--delta-json", str(delta_path), "--repo", "owner/repo"])
+    assert result == 0
+
+
+def test_cli_requires_delta_json_and_repo(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--repo", "owner/repo"])
+    assert exc_info.value.code != 0
+
+
+# ---------------------------------------------------------------------------
+# Issue body contains dedupe marker
+# ---------------------------------------------------------------------------
+
+
+def test_render_issue_body_contains_dedupe_marker() -> None:
+    fp = build_fingerprint(
+        source="code_scanning",
+        severity_band="high",
+        subject="cve-test",
+        affected_component="core/utils",
+        branch="main",
+    )
+    candidate = {
+        "fingerprint": fp,
+        "dedupe_marker": f"<!-- cdb-security-alert-group:{fp} -->",
+        "suggested_title": "Security: cve-test",
+        "suggested_labels": ["type:security"],
+        "references": ["#2289"],
+        "body_safe_fields": {
+            "source": "code_scanning",
+            "severity": "critical",
+            "severity_band": "high",
+            "subject": "cve-test",
+            "affected_component": "core/utils",
+            "branch": "main",
+            "fingerprint": fp,
+            "current_reference_now_utc": "2026-05-15T06:15:00Z",
+            "generated_from_readout": "2026-05-15",
+            "counts": {"new_alerts": 1},
+            "next_action": "Triage required.",
+            "references": ["#2289"],
+        },
+    }
+    body = _render_issue_body(candidate)
+    assert fp in body
+    assert f"<!-- cdb-security-alert-group:{fp} -->" in body
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint stability across invocations
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_stability_across_invocations() -> None:
+    kwargs = dict(
+        source="dependabot",
+        severity_band="high",
+        subject="urllib3",
+        affected_component="requirements.txt",
+        branch="main",
+    )
+    fp1 = build_fingerprint(**kwargs)
+    fp2 = build_fingerprint(**kwargs)
+    assert fp1 == fp2
+    assert _FINGERPRINT_RE.match(fp1), "fingerprint must match 16-char hex pattern"


### PR DESCRIPTION
## Security Issue Automation — new-groups slice (#2289)

Implements `issue-automation` as a minimal, fail-closed automation layer on top of the existing candidate generator.

### Changes
- `scripts/audit/security_issue_automation.py` — new CLI: dedupe-checked GitHub issue creation, dry-run by default, `--live-mode` flag for explicit live activation
- `tests/unit/audit/test_security_issue_automation.py` — 21 new unit tests; injected stubs for all GitHub calls
- `scripts/audit/security_alert_issue_candidates.py` — added `_normalize_delta_keys()` to bridge real delta JSON field names to internal field names
- `.github/workflows/security-alert-readout.yml` — new `issue-automation` job + `issue_automation_live` dispatch input
- `docs/security/TRIAGE_RUNBOOK.md` — §10 Issue Automation contract

### Invariants enforced
- Scheduled runs: always dry-run
- Dedupe fail-closed: lookup error → skip candidate, exit 2
- No auto-close
- No alert dismissals
- No LR-/Live-/Echtgeld derivation
- `secret_scanning`: excluded at candidate layer
- `comparison_skipped` sources: excluded at automation layer

### Test results
- 156/156 passed

Refs #2289