### PR TITLE
docs(security): fix stale §9 note and add CDB_GH_ALERTS_TOKEN guidance

### DIFF
--- a/docs/security/TRIAGE_RUNBOOK.md
+++ b/docs/security/TRIAGE_RUNBOOK.md
@@ -248,7 +248,7 @@ Permissions:
 
 - `security_alert_delta.py` gibt **Exit-Code 2** zurück, wenn neue offene Alerts mit Severity `critical`, `high` oder `error` (CodeQL) gefunden werden.
 - Der Workflow setzt dann eine `::warning::`-Annotation und dokumentiert die Eskalation im Job-Summary.
-- Aktuell kein automatisches Issue-Öffnen (DRY-RUN-Slice; Issue-Automation folgt in einem separaten PR).
+- Issue-Automation ist implementiert (PR #2495); neue hochgradige Alert-Gruppen erzeugen automatisiert GitHub-Issues (dry-run by default). Siehe §10.
 
 ### Secret Scanning
 
@@ -279,6 +279,11 @@ Kein direkter Commit in das Repository (artifacts-only-Modus, siehe Publish-Modu
 
 1. **Status** `PASS` — alle drei Surfaces gelesen (Secret Scanning: nur Status).
 2. **Status** `PARTIAL` — mindestens eine Surface nicht lesbar (Permission/API-Fehler).
+   Häufigste Ursache: Dependabot-Surface nicht lesbar, weil `CDB_GH_ALERTS_TOKEN` nicht
+   gesetzt ist. Der Workflow fällt dann auf `github.token` zurück, das keinen
+   Dependabot-Alert-Lesezugriff hat. `comparison_skipped`-Quellen werden im
+   Automation-Layer gefiltert — kein Issue-Spam trotz PARTIAL. Fix: GitHub-Secret
+   `CDB_GH_ALERTS_TOKEN` mit `security_events: read`-Scope (Dependabot) anlegen.
 3. **`escalation_needed: true`** im Delta → neuen High/Critical-Alert innerhalb des
    nächsten Sprints triagen (§3).
 4. **`new_groups`** im Delta → neue Regel-/Advisory-Cluster; ggf. Dismiss-Kommentar


### PR DESCRIPTION
## TRIAGE_RUNBOOK §9 — staleness fix + PARTIAL-Status-Erklärung

### Änderungen
- §9 Eskalationslogik: stale Note entfernt (`Issue-Automation folgt in einem separaten PR`) → Verweis auf PR #2495 + §10
- §9 Interpretation PARTIAL: häufigste Ursache (`CDB_GH_ALERTS_TOKEN` fehlend) und Fix-Anweisung ergänzt

### Evidence
- PR #2495 merged 2026-05-15T11:52:26Z — Issue-Automation ist implementiert
- Letzte Scheduled-Runs zeigen `readout_status: partial`, weil die Dependabot-Surface nicht lesbar ist
- Kein Secret-Wert im Diff; nur Betriebsanweisung

### Scope
- docs-only
- keine Workflow-/Script-/Test-Änderung
- keine Runtime-/Docker-Aktion
- keine LR-/Live-/Echtgeld-Ableitung

Refs #2289