### PR TITLE
fix(ci): correct download-artifact action pin in issue-automation job

### DIFF
--- a/.github/workflows/security-alert-readout.yml
+++ b/.github/workflows/security-alert-readout.yml
@@ -526,7 +526,7 @@ jobs:
         run: pip install --quiet -r requirements.txt
 
       - name: Download security-alert-readout artifact
-        uses: actions/download-artifact@96a0b611a25419df80fce7e0ddf2b97cd4efdf6e # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: security-alert-readout-${{ github.run_number }}
           path: /tmp/security-readout-artifact


### PR DESCRIPTION
## Fix: unresolvable download-artifact pin (#2289)

The `issue-automation` job failed at "Set up job" in the first dry-run
(run 25917781046) with:

> Unable to resolve action `actions/download-artifact@96a0b611...`, unable to find version

### Change
- `.github/workflows/security-alert-readout.yml` — replaced unresolvable SHA
  `96a0b611a25419df80fce7e0ddf2b97cd4efdf6e` (v4.1.8) with working pin
  `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` (v8.0.1), matching the
  existing `persist-via-pr` job

### Scope
- 1-line workflow fix
- no logic change
- no script change
- no test change
- no runtime/docker action
- no LR-/Live-/Echtgeld derivation

Refs #2289