### PR TITLE
docs(security): add CDB_GH_ALERTS_TOKEN ops guide to TRIAGE_RUNBOOK §9

### DIFF
--- a/docs/security/TRIAGE_RUNBOOK.md
+++ b/docs/security/TRIAGE_RUNBOOK.md
@@ -301,8 +301,9 @@ Name:  CDB_GH_ALERTS_TOKEN
 Value: <PAT-Wert>
 ```
 
-Der PAT-Inhaber muss mindestens **Read-Zugriff** auf das Repository haben und Dependabot-Alerts dürfen
-für ihn sichtbar sein (typischerweise: Repository-Inhaber oder Kollaborator mit Admin/Write-Zugriff).
+Der PAT-Inhaber muss mindestens **Write**-, Maintain- oder Admin-Zugriff auf das Repository haben
+(oder Repository-/Org-Inhaber sein), damit Dependabot-Alerts für ihn sichtbar sind.
+Reiner Read-Zugriff reicht laut GitHub nicht aus.
 
 #### Validierung nach Secret-Setzung
 

--- a/docs/security/TRIAGE_RUNBOOK.md
+++ b/docs/security/TRIAGE_RUNBOOK.md
@@ -276,10 +276,17 @@ Folge: Die `dependabot`-Surface gibt `status: unavailable` zurück → `readout_
 
 #### Minimaler Token-Scope
 
-| Token-Typ | Erforderlicher Scope / Berechtigung |
-|-----------|--------------------------------------|
-| **Klassischer PAT** | `security_events` (Lesen aller Security-Alerts inkl. Dependabot) |
-| **Fine-grained PAT** | `Dependabot alerts: Read-only` |
+| Token-Typ | Scope / Berechtigung | Empfehlung |
+|-----------|----------------------|------------|
+| **Fine-grained PAT** | `Dependabot alerts: Read-only` | ✅ **Bevorzugt** — strikt read-only |
+| **Klassischer PAT** | `security_events` | ⚠️ Technisch möglich — **nicht strikt read-only** (siehe unten) |
+
+> **Warnung — klassischer PAT:** Der `security_events`-Scope ermöglicht neben dem Lesen auch
+> Schreiboperationen auf Dependabot-Alerts (dismiss/reopen via PATCH).  Ein klassischer PAT mit
+> diesem Scope ist damit **nicht strikt read-only** für Dependabot.  Ein kompromittierter oder
+> wiederverwendeter Token könnte Alerts dismissen.  **Fine-grained PAT mit
+> `Dependabot alerts: Read-only` ist die sicherere Wahl.**  Klassischen PAT nur verwenden,
+> wenn Fine-grained PATs in der Ziel-Org nicht unterstützt werden.
 
 Der Token braucht **keinen** Schreib-Zugriff auf das Repository.
 Kein `repo`-Full-Access, kein `admin:*`-Scope, kein `workflow`-Scope.
@@ -321,7 +328,8 @@ für ihn sichtbar sein (typischerweise: Repository-Inhaber oder Kollaborator mit
 
 #### Sicherheitsgrenzen
 
-- PAT ausschliesslich mit minimalem Scope (`security_events` bei klassischem PAT).
+- **Fine-grained PAT mit `Dependabot alerts: Read-only` bevorzugen** — strikt read-only, kein Dismiss/Reopen möglich.
+- Klassischen PAT mit `security_events` nur verwenden, wenn Fine-grained PATs nicht unterstützt werden; dieser Scope trägt Dependabot-Write-Capability.
 - Kein `repo`-Full-Access, kein `admin:*`-Scope.
 - Secret Scanning bleibt `redacted/status-only` — auch nach Token-Fix.
 - Kein Auto-Close, keine Alert-Dismissals, keine LR-/Live-/Echtgeld-Ableitung.

--- a/docs/security/TRIAGE_RUNBOOK.md
+++ b/docs/security/TRIAGE_RUNBOOK.md
@@ -256,6 +256,78 @@ Permissions:
   Surface-Status in JSON ist immer `"status": "redacted"`.
 - Das Delta-Skript vergleicht ausschließlich den Surface-Status (ok/redacted), niemals Payload-Felder.
 
+### Token-Anforderungen: `CDB_GH_ALERTS_TOKEN`
+
+#### Warum `github.token` nicht ausreicht
+
+Der Workflow-Step `Run security alert readout` nutzt die folgende Fallback-Logik:
+
+```yaml
+GH_TOKEN: ${{ secrets.CDB_GH_ALERTS_TOKEN != '' && secrets.CDB_GH_ALERTS_TOKEN || github.token }}
+```
+
+Solange `CDB_GH_ALERTS_TOKEN` im Repository-Secret nicht gesetzt ist, fällt der Workflow
+auf `github.token` (GITHUB_TOKEN) zurück.  Das GITHUB_TOKEN hat in GitHub Actions
+**keinen Zugriff auf die Dependabot-Alerts-API** (`/repos/{repo}/dependabot/alerts`) —
+auch wenn `security-events: read` im Workflow deklariert ist.  Die Dependabot-API
+erfordert einen separaten Personal Access Token.
+
+Folge: Die `dependabot`-Surface gibt `status: unavailable` zurück → `readout_status: PARTIAL`.
+
+#### Minimaler Token-Scope
+
+| Token-Typ | Erforderlicher Scope / Berechtigung |
+|-----------|--------------------------------------|
+| **Klassischer PAT** | `security_events` (Lesen aller Security-Alerts inkl. Dependabot) |
+| **Fine-grained PAT** | `Dependabot alerts: Read-only` |
+
+Der Token braucht **keinen** Schreib-Zugriff auf das Repository.
+Kein `repo`-Full-Access, kein `admin:*`-Scope, kein `workflow`-Scope.
+
+#### Wo setzen
+
+Repository-Secret in GitHub:
+
+```
+Settings > Secrets and variables > Actions > New repository secret
+Name:  CDB_GH_ALERTS_TOKEN
+Value: <PAT-Wert>
+```
+
+Der PAT-Inhaber muss mindestens **Read-Zugriff** auf das Repository haben und Dependabot-Alerts dürfen
+für ihn sichtbar sein (typischerweise: Repository-Inhaber oder Kollaborator mit Admin/Write-Zugriff).
+
+#### Validierung nach Secret-Setzung
+
+1. Manuellen `workflow_dispatch` auf `main` auslösen:
+   - `publish_mode`: `dry_run`
+   - `persist_via_pr`: `false`
+   - `issue_automation_live`: `false`
+
+2. Im Job-Log des `security-readout`-Steps prüfen:
+   - `READOUT_STATUS=ok` (war zuvor `partial`)
+   - Keine `::warning::Security Alert Readout: PARTIAL`-Annotation
+
+3. Im Job-Summary und Ledger-Kommentar auf #2289 prüfen:
+   - `readout_status: ok`
+   - `dependabot`-Surface zeigt `status: readable`
+
+4. **Erwartetes Ergebnis bei korrektem Token:**
+   - `readout_status`: `partial` → `ok`, sofern nur der Dependabot-Scope fehlte
+   - `delta_status`: bleibt auswertbar
+   - keine Issues erstellt (Dry-run)
+   - keine Alert-Dismissals
+   - Secret-Werte erscheinen nicht in Logs oder Artefakten
+
+#### Sicherheitsgrenzen
+
+- PAT ausschliesslich mit minimalem Scope (`security_events` bei klassischem PAT).
+- Kein `repo`-Full-Access, kein `admin:*`-Scope.
+- Secret Scanning bleibt `redacted/status-only` — auch nach Token-Fix.
+- Kein Auto-Close, keine Alert-Dismissals, keine LR-/Live-/Echtgeld-Ableitung.
+
+---
+
 ### Artefakte
 
 Nach jedem Run werden hochgeladen:


### PR DESCRIPTION
## CDB_GH_ALERTS_TOKEN Ops Guide (#2289)

Adds a dedicated TRIAGE_RUNBOOK §9 subsection for the Security Readout Dependabot-token gap.

### Changes
- Documents why `github.token` is insufficient for Dependabot alerts
- Documents where to set `CDB_GH_ALERTS_TOKEN`
- Documents minimal token scopes:
  - classic PAT: `security_events`
  - fine-grained PAT: Dependabot alerts read-only
- Documents dry-run validation after the secret is configured
- Documents safety boundaries for secret handling

### Scope
- docs-only
- no workflow change
- no script change
- no tests changed
- no secret value added
- no runtime/docker action
- no LR-/Live-/Echtgeld derivation

### Evidence
- Security Readout currently remains `partial` because the Dependabot surface is unavailable without a suitable token.
- PR #2498 added the brief PARTIAL hint; this PR adds the full ops-guide subsection.

Refs #2289