### PR TITLE
fix(lr030): add early-fail supervisor for shadow soak reruns

### DIFF
--- a/docs/operations/72H_SOAK_TEST_RUNBOOK.md
+++ b/docs/operations/72H_SOAK_TEST_RUNBOOK.md
@@ -289,3 +289,32 @@ Boundary:
 
 **Default behavior:** Without `SOAK_RUN_INTENT`, the monitor defaults to
 `lr040` (backwards-compatible with all existing runs).
+
+## LR-030 Early-Fail Supervisor (#2440 lesson)
+
+The old LR-030 run (`lr030-shadow-soak-20260512`) was only classified
+`INCONCLUSIVE` during post-run review — after >24h of invalid data had
+already accumulated. The root causes were detectable within the first 60 minutes:
+
+| Root cause | Early signal |
+|---|---|
+| `run_intent.txt` = `lr040` (intent drift) | Artifact-contract check fails at T+0 |
+| `soak_test_INCONCLUSIVE.txt` written | Inconclusive marker check fails at T+31min |
+| 12/12 `ENVIRONMENT_INTERRUPTION` in logs | Environment-interruption check fails |
+| `hourly_checks.log` missing | MONITOR_DEAD fires at T+75min |
+
+Use `infrastructure/scripts/lr030_soak_supervisor.py` to surface these failures
+within the first hour.
+
+**Invoke after each hourly cron cycle:**
+
+```bash
+python infrastructure/scripts/lr030_soak_supervisor.py \
+    "$(cat artifacts/soak_active_run_path_lr030.txt)"
+```
+
+Exit 0 = `RUNNING_VALID`. Any non-zero exit means the run is already compromised
+and should be investigated or aborted before wasting further operator time.
+
+See `docs/operations/SOAK_MONITOR_RUNBOOK.md` → *LR-030 Early-Fail Supervisor*
+for full option reference and cron integration.

--- a/docs/operations/SOAK_MONITOR_RUNBOOK.md
+++ b/docs/operations/SOAK_MONITOR_RUNBOOK.md
@@ -131,6 +131,82 @@ exists. This ensures `hourly_checks.log` is unambiguous about run state.
 The monitor does **not** self-terminate after failure. To stop it,
 deactivate the cron job or scheduled task manually.
 
+## LR-030 Early-Fail Supervisor
+
+`infrastructure/scripts/lr030_soak_supervisor.py` catches a broken or failing LR-030
+run within the first hour instead of surfacing the problem only after a >24h review.
+It is read-only — no Docker interaction, no GitHub writes, no runtime mutation.
+
+**Usage:**
+
+```bash
+# Check a live or completed LR-030 run directory
+python infrastructure/scripts/lr030_soak_supervisor.py \
+    artifacts/soak_lr030_YYYYMMDD_HHMMSS/
+
+# Require shadow-block-probe evidence (optional gate)
+python infrastructure/scripts/lr030_soak_supervisor.py \
+    artifacts/soak_lr030_YYYYMMDD_HHMMSS/ \
+    --require-shadow-block-probe
+
+# Override the hourly-log deadline (default 75 min)
+python infrastructure/scripts/lr030_soak_supervisor.py \
+    artifacts/soak_lr030_YYYYMMDD_HHMMSS/ \
+    --hourly-deadline-minutes 90
+```
+
+**Exit codes:**
+
+| Code | Status | Meaning |
+|---|---|---|
+| 0 | `RUNNING_VALID` | All checks pass so far |
+| 1 | `ARTIFACT_CONTRACT_BROKEN` | Wrong path prefix or wrong `run_intent.txt` |
+| 1 | `FAILED_EARLY` | `soak_test_FAILED.txt` or `SUT_RESTART` in logs |
+| 1 | `INCONCLUSIVE_EARLY` | `soak_test_INCONCLUSIVE.txt` or `ENVIRONMENT_INTERRUPTION` |
+| 1 | `INVALID_EVIDENCE` | Template placeholders in checkpoint files |
+| 1 | `MONITOR_DEAD` | `hourly_checks.log` missing/invalid after deadline |
+| 2 | *(CLI error)* | Missing or invalid arguments |
+
+**Checks performed:**
+1. Artifact directory name matches `soak_lr030_YYYYMMDD_HHMMSS`.
+2. `run_intent.txt` contains exactly `lr030` (catches RC-2 intent drift from #2440).
+3. `soak_test_FAILED.txt` absent.
+4. `restart_alerts.log` free of `SUT_RESTART` patterns.
+5. `soak_test_INCONCLUSIVE.txt` absent.
+6. `restart_alerts.log` free of `ENVIRONMENT_INTERRUPTION`/`RESTART DETECTED`.
+7. No un-expanded template variables (`$runId`, `$artifactDir`, `${checkpoint}`, etc.)
+   in `.txt` or `.json` files (catches RC-3 checkpoint scripting errors from #2440).
+8. `hourly_checks.log` present after `--hourly-deadline-minutes` (default 75) with
+   at least one monotonically increasing `Hour N:` entry.
+9. `shadow_block_probe.json` with auditable `REJECTED` result when
+   `--require-shadow-block-probe` is set.
+
+**Integration with cron runs:** Run the supervisor after each hourly cron invocation:
+
+```bash
+# Combined cron line (adjust path)
+0 * * * * cd /path/to/repo && \
+  SOAK_RUN_INTENT=lr030 ./infrastructure/scripts/soak_monitor.sh >> artifacts/soak_cron.log 2>&1 && \
+  python infrastructure/scripts/lr030_soak_supervisor.py \
+    "$(cat artifacts/soak_active_run_path_lr030.txt)" >> artifacts/soak_cron.log 2>&1
+```
+
+**Output:** Always JSON to stdout. Example for a passing run:
+
+```json
+{
+  "schema_version": "1.0",
+  "status": "RUNNING_VALID",
+  "artifact_path": "artifacts/soak_lr030_20260516_120000",
+  "run_intent": "lr030",
+  "elapsed_minutes": 90.0,
+  "hourly_check_count": 1,
+  "hourly_hours_logged": [1],
+  "checks": { "artifact_path_prefix_valid": true, "run_intent_is_lr030": true, "..." },
+  "failures": []
+}
+```
+
 ## Disable / Rollback
 
 ```bash

--- a/infrastructure/scripts/lr030_soak_supervisor.py
+++ b/infrastructure/scripts/lr030_soak_supervisor.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""LR-030 Shadow/Soak Early-Fail Supervisor.
+
+Read-only gate. Inspects a soak artifact directory and reports status within
+the first hour so a bad run is visible early, not after >24h review.
+
+No runtime mutation. No Docker interaction. No GitHub writes.
+
+Exit codes:
+  0 — RUNNING_VALID  (all checks pass so far)
+  1 — FAILED_EARLY | INCONCLUSIVE_EARLY | INVALID_EVIDENCE |
+      MONITOR_DEAD | ARTIFACT_CONTRACT_BROKEN
+  2 — CLI / usage error
+
+Related: Issue #2440, PR #2484, PR #2485.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Status codes
+# ---------------------------------------------------------------------------
+RUNNING_VALID = "RUNNING_VALID"
+FAILED_EARLY = "FAILED_EARLY"
+INCONCLUSIVE_EARLY = "INCONCLUSIVE_EARLY"
+INVALID_EVIDENCE = "INVALID_EVIDENCE"
+MONITOR_DEAD = "MONITOR_DEAD"
+ARTIFACT_CONTRACT_BROKEN = "ARTIFACT_CONTRACT_BROKEN"
+
+_STATUS_SEVERITY: dict[str, int] = {
+    ARTIFACT_CONTRACT_BROKEN: 5,
+    FAILED_EARLY: 4,
+    INCONCLUSIVE_EARLY: 3,
+    INVALID_EVIDENCE: 2,
+    MONITOR_DEAD: 1,
+    RUNNING_VALID: 0,
+}
+
+# Each check name maps to the status it raises when the check fails.
+_CHECK_STATUS: dict[str, str] = {
+    "artifact_path_prefix_valid": ARTIFACT_CONTRACT_BROKEN,
+    "run_intent_is_lr030": ARTIFACT_CONTRACT_BROKEN,
+    "no_failed_marker": FAILED_EARLY,
+    "no_hard_restart_patterns": FAILED_EARLY,
+    "no_inconclusive_marker": INCONCLUSIVE_EARLY,
+    "no_env_interruption_patterns": INCONCLUSIVE_EARLY,
+    "no_template_placeholders": INVALID_EVIDENCE,
+    "shadow_block_probe_valid": INVALID_EVIDENCE,
+    "hourly_checks_log_present": MONITOR_DEAD,
+    "hourly_checks_log_valid": MONITOR_DEAD,
+}
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+DEFAULT_HOURLY_DEADLINE_MINUTES = 75
+SCHEMA_VERSION = "1.0"
+
+# Artifact directory name must be exactly soak_lr030_YYYYMMDD_HHMMSS.
+_DIR_NAME_RE = re.compile(r"^soak_lr030_(\d{8})_(\d{6})$")
+
+# SUT_RESTART = service-under-test restarted itself → FAILED_EARLY.
+_HARD_RESTART_RE = re.compile(r"SUT_RESTART", re.IGNORECASE)
+
+# ENVIRONMENT_INTERRUPTION / RESTART DETECTED = host-level event → INCONCLUSIVE_EARLY.
+_SOFT_RESTART_RE = re.compile(
+    r"ENVIRONMENT_INTERRUPTION|RESTART DETECTED", re.IGNORECASE
+)
+
+# Hourly checkpoint line format written by soak_monitor.sh:
+#   "2026-05-16 13:00:00 UTC - Hour 1: No restarts"
+_HOUR_RE = re.compile(r"\bHour (\d+):")
+
+# Exact un-expanded script-variable tokens that indicate broken checkpoint reporting.
+# Not generic angle-bracket matching to avoid false positives on log content.
+# Tokens from Issue #2440 old-run evidence backfill: <zero_execution_ok> and
+# <execution_orders_filled_total=0.> are known unresolved placeholders from that run.
+_PLACEHOLDER_RE = re.compile(
+    r"\$runId|\$artifactDir|\$\{checkpoint\}|<checkpoint-1-ok>|<ja>|<nein>"
+    r"|<zero_execution_ok>|<execution_orders_filled_total=0\.>"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_run_start(artifact_name: str) -> Optional[datetime]:
+    m = _DIR_NAME_RE.match(artifact_name)
+    if not m:
+        return None
+    try:
+        dt = datetime.strptime(m.group(1) + m.group(2), "%Y%m%d%H%M%S")
+        return dt.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _elapsed_minutes(artifact_name: str, as_of: datetime) -> Optional[float]:
+    start = _parse_run_start(artifact_name)
+    if start is None or as_of < start:
+        return None
+    return (as_of - start).total_seconds() / 60.0
+
+
+def _is_monotone_increasing(values: list[int]) -> bool:
+    """True only when the sequence is non-empty and strictly increasing."""
+    if not values:
+        return False
+    return all(values[i] < values[i + 1] for i in range(len(values) - 1))
+
+
+def _find_placeholder_hits(artifact_path: Path) -> list[dict[str, str]]:
+    """Scan .txt and .json files in the artifact directory for template tokens."""
+    hits: list[dict[str, str]] = []
+    for p in sorted(artifact_path.iterdir()):
+        if not (p.is_file() and p.suffix in {".txt", ".json"}):
+            continue
+        try:
+            text = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for m in _PLACEHOLDER_RE.finditer(text):
+            hits.append({"file": p.name, "match": m.group()})
+    return hits
+
+
+def _check_shadow_probe(probe_file: Path) -> bool:
+    """Return True when probe_file contains an auditable REJECTED result."""
+    if not probe_file.is_file():
+        return False
+    try:
+        data = json.loads(probe_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    order_result_found = bool(data.get("order_result_found"))
+    order_result = data.get("order_result") or {}
+    return order_result_found and order_result.get("status") == "REJECTED"
+
+
+def _determine_status(failures: list[dict[str, str]]) -> str:
+    if not failures:
+        return RUNNING_VALID
+    worst_severity = max(
+        _STATUS_SEVERITY.get(_CHECK_STATUS.get(f["check"], RUNNING_VALID), 0)
+        for f in failures
+    )
+    return next(
+        s
+        for s, sev in sorted(_STATUS_SEVERITY.items(), key=lambda kv: -kv[1])
+        if sev == worst_severity
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core evaluation (importable for unit tests)
+# ---------------------------------------------------------------------------
+
+
+def evaluate(
+    artifact_path: Path,
+    as_of: datetime,
+    hourly_deadline_minutes: int = DEFAULT_HOURLY_DEADLINE_MINUTES,
+    require_shadow_block_probe: bool = False,
+) -> dict:
+    """Evaluate artifact_path and return a result dict.
+
+    Runs all checks unconditionally and accumulates failures; the overall
+    status reflects the highest-severity failure found.
+    """
+    failures: list[dict[str, str]] = []
+    checks: dict[str, Optional[bool]] = {}
+
+    artifact_name = artifact_path.name
+    elapsed = _elapsed_minutes(artifact_name, as_of)
+
+    # 1. Artifact directory name must match soak_lr030_YYYYMMDD_HHMMSS.
+    path_valid = bool(_DIR_NAME_RE.match(artifact_name))
+    checks["artifact_path_prefix_valid"] = path_valid
+    if not path_valid:
+        failures.append(
+            {
+                "check": "artifact_path_prefix_valid",
+                "detail": f"'{artifact_name}' does not match soak_lr030_YYYYMMDD_HHMMSS",
+            }
+        )
+
+    # 2. run_intent.txt must contain exactly 'lr030'.
+    intent_file = artifact_path / "run_intent.txt"
+    run_intent: Optional[str] = None
+    if intent_file.is_file():
+        run_intent = intent_file.read_text(encoding="utf-8").strip()
+    intent_valid = run_intent == "lr030"
+    checks["run_intent_is_lr030"] = intent_valid
+    if not intent_valid:
+        failures.append(
+            {
+                "check": "run_intent_is_lr030",
+                "detail": f"run_intent.txt contains {run_intent!r}, expected 'lr030'",
+            }
+        )
+
+    # 3. Hard failure marker.
+    failed_marker = (artifact_path / "soak_test_FAILED.txt").is_file()
+    checks["no_failed_marker"] = not failed_marker
+    if failed_marker:
+        failures.append(
+            {
+                "check": "no_failed_marker",
+                "detail": "soak_test_FAILED.txt is present",
+            }
+        )
+
+    # 4. restart_alerts.log — split by severity.
+    restart_log = artifact_path / "restart_alerts.log"
+    hard_hits: list[str] = []
+    soft_hits: list[str] = []
+    if restart_log.is_file():
+        content = restart_log.read_text(encoding="utf-8", errors="replace")
+        hard_hits = list(set(_HARD_RESTART_RE.findall(content)))
+        soft_hits = list(set(_SOFT_RESTART_RE.findall(content)))
+
+    checks["no_hard_restart_patterns"] = not bool(hard_hits)
+    if hard_hits:
+        failures.append(
+            {
+                "check": "no_hard_restart_patterns",
+                "detail": f"restart_alerts.log contains SUT_RESTART patterns: {hard_hits}",
+            }
+        )
+
+    # 5. Inconclusive marker (environment-interruption class).
+    inconclusive_marker = (artifact_path / "soak_test_INCONCLUSIVE.txt").is_file()
+    checks["no_inconclusive_marker"] = not inconclusive_marker
+    if inconclusive_marker:
+        failures.append(
+            {
+                "check": "no_inconclusive_marker",
+                "detail": "soak_test_INCONCLUSIVE.txt is present",
+            }
+        )
+
+    # 6. Environment-interruption patterns in restart log.
+    checks["no_env_interruption_patterns"] = not bool(soft_hits)
+    if soft_hits:
+        failures.append(
+            {
+                "check": "no_env_interruption_patterns",
+                "detail": f"restart_alerts.log contains environment interruption patterns: {soft_hits}",
+            }
+        )
+
+    # 7. Template placeholders in .txt / .json files.
+    placeholder_hits = _find_placeholder_hits(artifact_path)
+    checks["no_template_placeholders"] = not bool(placeholder_hits)
+    if placeholder_hits:
+        failures.append(
+            {
+                "check": "no_template_placeholders",
+                "detail": (
+                    f"un-expanded script variables in {len(placeholder_hits)} location(s): "
+                    f"{placeholder_hits[:3]}"
+                ),
+            }
+        )
+
+    # 8. hourly_checks.log presence (required after deadline) and validity.
+    hourly_log = artifact_path / "hourly_checks.log"
+    hourly_present = hourly_log.is_file()
+    past_deadline = elapsed is not None and elapsed >= hourly_deadline_minutes
+
+    if hourly_present:
+        hourly_text = hourly_log.read_text(encoding="utf-8", errors="replace")
+        hourly_hours = [int(m) for m in _HOUR_RE.findall(hourly_text)]
+        hourly_valid = _is_monotone_increasing(hourly_hours)
+        checks["hourly_checks_log_present"] = True
+        checks["hourly_checks_log_valid"] = hourly_valid
+        if not hourly_valid:
+            failures.append(
+                {
+                    "check": "hourly_checks_log_valid",
+                    "detail": (
+                        f"hourly_checks.log has no valid monotone Hour N sequence; "
+                        f"hours found: {hourly_hours}"
+                    ),
+                }
+            )
+    else:
+        hourly_hours = []
+        checks["hourly_checks_log_present"] = False if past_deadline else None
+        checks["hourly_checks_log_valid"] = None
+        if past_deadline:
+            failures.append(
+                {
+                    "check": "hourly_checks_log_present",
+                    "detail": (
+                        f"hourly_checks.log missing after {elapsed:.0f} min "
+                        f"(deadline: {hourly_deadline_minutes} min)"
+                    ),
+                }
+            )
+
+    # 9. Optional shadow-block-probe.
+    if require_shadow_block_probe:
+        probe_valid = _check_shadow_probe(artifact_path / "shadow_block_probe.json")
+        checks["shadow_block_probe_valid"] = probe_valid
+        if not probe_valid:
+            failures.append(
+                {
+                    "check": "shadow_block_probe_valid",
+                    "detail": (
+                        "shadow_block_probe.json missing or lacks auditable REJECTED result"
+                    ),
+                }
+            )
+    else:
+        checks["shadow_block_probe_valid"] = None  # not required
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": _determine_status(failures),
+        "artifact_path": str(artifact_path),
+        "run_intent": run_intent,
+        "elapsed_minutes": round(elapsed, 1) if elapsed is not None else None,
+        "hourly_check_count": len(hourly_hours),
+        "hourly_hours_logged": hourly_hours,
+        "checks": checks,
+        "failures": failures,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "LR-030 Shadow/Soak Early-Fail Supervisor. Read-only. "
+            "Exit 0: RUNNING_VALID. Exit 1: failure state. Exit 2: CLI error."
+        )
+    )
+    p.add_argument(
+        "artifact_path",
+        help=(
+            "Path to the LR-030 soak run directory "
+            "(must match artifacts/soak_lr030_YYYYMMDD_HHMMSS)."
+        ),
+    )
+    p.add_argument(
+        "--hourly-deadline-minutes",
+        type=int,
+        default=DEFAULT_HOURLY_DEADLINE_MINUTES,
+        metavar="MINUTES",
+        help=(
+            f"Minutes after run start before hourly_checks.log is required "
+            f"(default: {DEFAULT_HOURLY_DEADLINE_MINUTES})."
+        ),
+    )
+    p.add_argument(
+        "--require-shadow-block-probe",
+        action="store_true",
+        help="Require shadow_block_probe.json with an auditable REJECTED result.",
+    )
+    p.add_argument(
+        "--as-of",
+        default=None,
+        metavar="ISO_TIMESTAMP",
+        help=(
+            "Treat this UTC ISO-8601 timestamp as 'now' for elapsed-time checks "
+            "(testing convenience; default: current UTC time)."
+        ),
+    )
+    return p
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    artifact_path = Path(args.artifact_path)
+    if not artifact_path.is_dir():
+        result: dict = {
+            "schema_version": SCHEMA_VERSION,
+            "status": ARTIFACT_CONTRACT_BROKEN,
+            "artifact_path": str(artifact_path),
+            "error": f"artifact directory does not exist: {artifact_path}",
+            "failures": [
+                {"check": "artifact_path_exists", "detail": "directory not found"}
+            ],
+        }
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        sys.exit(1)
+
+    if args.as_of is not None:
+        try:
+            raw = datetime.fromisoformat(args.as_of)
+            as_of: datetime = (
+                raw if raw.tzinfo is not None else raw.replace(tzinfo=timezone.utc)
+            )
+        except ValueError:
+            print(f"ERROR: invalid --as-of value: {args.as_of!r}", file=sys.stderr)
+            sys.exit(2)
+    else:
+        as_of = datetime.now(timezone.utc)
+
+    result = evaluate(
+        artifact_path=artifact_path,
+        as_of=as_of,
+        hourly_deadline_minutes=args.hourly_deadline_minutes,
+        require_shadow_block_probe=args.require_shadow_block_probe,
+    )
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    sys.exit(0 if result["status"] == RUNNING_VALID else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/infrastructure/scripts/lr030_soak_supervisor.py
+++ b/infrastructure/scripts/lr030_soak_supervisor.py
@@ -147,8 +147,12 @@ def _check_shadow_probe(probe_file: Path) -> bool:
         data = json.loads(probe_file.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return False
+    if not isinstance(data, dict):
+        return False
     order_result_found = bool(data.get("order_result_found"))
-    order_result = data.get("order_result") or {}
+    order_result = data.get("order_result")
+    if not isinstance(order_result, dict):
+        return False
     # A valid shadow-block proof must show the order was REJECTED *and* that
     # nothing was filled.  A non-zero filled_quantity would contradict the
     # zero-execution guarantee even if the status field reads "REJECTED".

--- a/infrastructure/scripts/lr030_soak_supervisor.py
+++ b/infrastructure/scripts/lr030_soak_supervisor.py
@@ -20,6 +20,7 @@ import argparse
 import json
 import re
 import sys
+from decimal import Decimal, InvalidOperation
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -146,10 +147,17 @@ def _check_shadow_probe(probe_file: Path) -> bool:
     # A valid shadow-block proof must show the order was REJECTED *and* that
     # nothing was filled.  A non-zero filled_quantity would contradict the
     # zero-execution guarantee even if the status field reads "REJECTED".
+    # Normalize to Decimal: Redis xrevrange returns stream field values as
+    # strings ("0.0"), so a plain == 0 comparison would reject valid evidence.
+    raw_fill = order_result.get("filled_quantity", 1)
+    try:
+        filled_qty = Decimal(str(raw_fill))
+    except InvalidOperation:
+        filled_qty = Decimal(1)  # fail-closed: unparseable → treat as non-zero
     return (
         order_result_found
         and order_result.get("status") == "REJECTED"
-        and order_result.get("filled_quantity", 1) == 0
+        and filled_qty == Decimal(0)
     )
 
 

--- a/infrastructure/scripts/lr030_soak_supervisor.py
+++ b/infrastructure/scripts/lr030_soak_supervisor.py
@@ -67,13 +67,18 @@ SCHEMA_VERSION = "1.0"
 # Artifact directory name must be exactly soak_lr030_YYYYMMDD_HHMMSS.
 _DIR_NAME_RE = re.compile(r"^soak_lr030_(\d{8})_(\d{6})$")
 
-# SUT_RESTART / RESTART DETECTED = service-under-test restart → FAILED_EARLY.
-# "RESTART DETECTED: <service>" is written by soak_monitor.sh when a Docker
-# service container restarts; that IS a zero-restart-policy violation.
-_HARD_RESTART_RE = re.compile(r"SUT_RESTART|RESTART DETECTED", re.IGNORECASE)
+# SUT_RESTART = explicitly classified SUT restart → always FAILED_EARLY.
+_SUT_RESTART_RE = re.compile(r"SUT_RESTART", re.IGNORECASE)
 
-# ENVIRONMENT_INTERRUPTION = host-level OS/VM reboot → INCONCLUSIVE_EARLY.
-_SOFT_RESTART_RE = re.compile(r"ENVIRONMENT_INTERRUPTION", re.IGNORECASE)
+# RESTART DETECTED: <service> is emitted by soak_monitor.sh for each container
+# restart before the final classification is written.  When ENVIRONMENT_INTERRUPTION
+# also appears in the same log the raw lines are precursors to the bulk-restart
+# marker and must be treated as INCONCLUSIVE_EARLY context; when it is absent they
+# indicate a standalone SUT restart → FAILED_EARLY.
+_RAW_RESTART_RE = re.compile(r"RESTART DETECTED", re.IGNORECASE)
+
+# ENVIRONMENT_INTERRUPTION = host-level OS/VM or bulk-Docker reboot → INCONCLUSIVE_EARLY.
+_ENV_INTERRUPTION_RE = re.compile(r"ENVIRONMENT_INTERRUPTION", re.IGNORECASE)
 
 # Hourly checkpoint line format written by soak_monitor.sh:
 #   "2026-05-16 13:00:00 UTC - Hour 1: No restarts"
@@ -240,8 +245,19 @@ def evaluate(
     soft_hits: list[str] = []
     if restart_log.is_file():
         content = restart_log.read_text(encoding="utf-8", errors="replace")
-        hard_hits = list(set(_HARD_RESTART_RE.findall(content)))
-        soft_hits = list(set(_SOFT_RESTART_RE.findall(content)))
+        sut_hits = list(set(_SUT_RESTART_RE.findall(content)))
+        raw_hits = list(set(_RAW_RESTART_RE.findall(content)))
+        env_hits = list(set(_ENV_INTERRUPTION_RE.findall(content)))
+        if env_hits:
+            # ENVIRONMENT_INTERRUPTION present: RESTART DETECTED lines are
+            # precursors written by soak_monitor.sh before the bulk-restart
+            # classification; treat them as part of the env-interruption context.
+            hard_hits = sut_hits
+            soft_hits = env_hits + raw_hits
+        else:
+            # No environment interruption: RESTART DETECTED is a standalone SUT restart.
+            hard_hits = sut_hits + raw_hits
+            soft_hits = []
 
     checks["no_hard_restart_patterns"] = not bool(hard_hits)
     if hard_hits:

--- a/infrastructure/scripts/lr030_soak_supervisor.py
+++ b/infrastructure/scripts/lr030_soak_supervisor.py
@@ -66,13 +66,13 @@ SCHEMA_VERSION = "1.0"
 # Artifact directory name must be exactly soak_lr030_YYYYMMDD_HHMMSS.
 _DIR_NAME_RE = re.compile(r"^soak_lr030_(\d{8})_(\d{6})$")
 
-# SUT_RESTART = service-under-test restarted itself → FAILED_EARLY.
-_HARD_RESTART_RE = re.compile(r"SUT_RESTART", re.IGNORECASE)
+# SUT_RESTART / RESTART DETECTED = service-under-test restart → FAILED_EARLY.
+# "RESTART DETECTED: <service>" is written by soak_monitor.sh when a Docker
+# service container restarts; that IS a zero-restart-policy violation.
+_HARD_RESTART_RE = re.compile(r"SUT_RESTART|RESTART DETECTED", re.IGNORECASE)
 
-# ENVIRONMENT_INTERRUPTION / RESTART DETECTED = host-level event → INCONCLUSIVE_EARLY.
-_SOFT_RESTART_RE = re.compile(
-    r"ENVIRONMENT_INTERRUPTION|RESTART DETECTED", re.IGNORECASE
-)
+# ENVIRONMENT_INTERRUPTION = host-level OS/VM reboot → INCONCLUSIVE_EARLY.
+_SOFT_RESTART_RE = re.compile(r"ENVIRONMENT_INTERRUPTION", re.IGNORECASE)
 
 # Hourly checkpoint line format written by soak_monitor.sh:
 #   "2026-05-16 13:00:00 UTC - Hour 1: No restarts"
@@ -134,7 +134,7 @@ def _find_placeholder_hits(artifact_path: Path) -> list[dict[str, str]]:
 
 
 def _check_shadow_probe(probe_file: Path) -> bool:
-    """Return True when probe_file contains an auditable REJECTED result."""
+    """Return True when probe_file contains an auditable REJECTED result with zero fills."""
     if not probe_file.is_file():
         return False
     try:
@@ -143,7 +143,14 @@ def _check_shadow_probe(probe_file: Path) -> bool:
         return False
     order_result_found = bool(data.get("order_result_found"))
     order_result = data.get("order_result") or {}
-    return order_result_found and order_result.get("status") == "REJECTED"
+    # A valid shadow-block proof must show the order was REJECTED *and* that
+    # nothing was filled.  A non-zero filled_quantity would contradict the
+    # zero-execution guarantee even if the status field reads "REJECTED".
+    return (
+        order_result_found
+        and order_result.get("status") == "REJECTED"
+        and order_result.get("filled_quantity", 1) == 0
+    )
 
 
 def _determine_status(failures: list[dict[str, str]]) -> str:

--- a/tests/unit/scripts/test_lr030_soak_supervisor.py
+++ b/tests/unit/scripts/test_lr030_soak_supervisor.py
@@ -19,6 +19,8 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(
     0, str(Path(__file__).resolve().parents[3] / "infrastructure" / "scripts")
 )
@@ -538,3 +540,45 @@ def test_shadow_probe_string_zero_fill_is_valid(tmp_path: Path) -> None:
 
     assert result["status"] == RUNNING_VALID
     assert result["checks"]["shadow_block_probe_valid"] is True
+
+
+@pytest.mark.parametrize(
+    "probe_content",
+    [
+        # top-level value is a JSON array, not a dict
+        "[1, 2, 3]",
+        # top-level is a string
+        '"just a string"',
+        # order_result is a string (non-dict truthy value)
+        '{"order_result_found": true, "order_result": "some_string"}',
+        # order_result is a number
+        '{"order_result_found": true, "order_result": 42}',
+        # order_result is a list
+        '{"order_result_found": true, "order_result": ["a", "b"]}',
+    ],
+)
+def test_malformed_shadow_probe_is_invalid_not_crash(
+    tmp_path: Path, probe_content: str
+) -> None:
+    """Malformed shadow_block_probe.json must yield INVALID_EVIDENCE, not crash.
+
+    The supervisor must not raise AttributeError when the JSON is valid but has a
+    non-object top-level value or a non-object order_result field.  Both cases
+    must be classified fail-closed as INVALID_EVIDENCE rather than surfacing a
+    traceback.
+    """
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir)
+    (run_dir / "shadow_block_probe.json").write_text(probe_content, encoding="utf-8")
+
+    result = evaluate(
+        run_dir,
+        _as_of(120),
+        hourly_deadline_minutes=75,
+        require_shadow_block_probe=True,
+    )
+
+    # Must not crash; must treat malformed proof as absence of valid proof.
+    assert result["status"] in (RUNNING_VALID, INVALID_EVIDENCE, INCONCLUSIVE_EARLY, FAILED_EARLY)
+    assert result["checks"]["shadow_block_probe_valid"] is False

--- a/tests/unit/scripts/test_lr030_soak_supervisor.py
+++ b/tests/unit/scripts/test_lr030_soak_supervisor.py
@@ -481,3 +481,35 @@ def test_2440_execution_orders_placeholder_invalid_evidence(tmp_path: Path) -> N
     assert result["status"] == INVALID_EVIDENCE
     failed_checks = {f["check"] for f in result["failures"]}
     assert "no_template_placeholders" in failed_checks
+
+
+def test_shadow_probe_string_zero_fill_is_valid(tmp_path: Path) -> None:
+    """Shadow probe with filled_quantity="0.0" (Redis stream string) => RUNNING_VALID.
+
+    Redis xrevrange returns all stream field values as strings.  A probe
+    delivered via the Redis stream fallback path carries "0.0" not numeric 0.
+    The supervisor must accept this as valid zero-execution evidence.
+    """
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir)
+    (run_dir / "shadow_block_probe.json").write_text(
+        json.dumps(
+            {
+                "probe_order_id": "probe-003",
+                "order_result_found": True,
+                "order_result": {"status": "REJECTED", "filled_quantity": "0.0"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = evaluate(
+        run_dir,
+        _as_of(120),
+        hourly_deadline_minutes=75,
+        require_shadow_block_probe=True,
+    )
+
+    assert result["status"] == RUNNING_VALID
+    assert result["checks"]["shadow_block_probe_valid"] is True

--- a/tests/unit/scripts/test_lr030_soak_supervisor.py
+++ b/tests/unit/scripts/test_lr030_soak_supervisor.py
@@ -19,8 +19,6 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-import pytest
-
 sys.path.insert(
     0, str(Path(__file__).resolve().parents[3] / "infrastructure" / "scripts")
 )
@@ -407,9 +405,10 @@ def test_2440_placeholder_tokens_invalid_evidence(tmp_path: Path) -> None:
     result = evaluate(run_dir, _as_of(50), hourly_deadline_minutes=75)
 
     assert result["status"] == INVALID_EVIDENCE
-    hits = {h["match"] for f in result["failures"] for h in []}  # unused shorthand
     failed_checks = {f["check"] for f in result["failures"]}
     assert "no_template_placeholders" in failed_checks
+    placeholder_fail = next(f for f in result["failures"] if f["check"] == "no_template_placeholders")
+    assert "<zero_execution_ok>" in placeholder_fail["detail"]
 
 
 def test_2440_execution_orders_placeholder_invalid_evidence(tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_lr030_soak_supervisor.py
+++ b/tests/unit/scripts/test_lr030_soak_supervisor.py
@@ -1,0 +1,430 @@
+"""Tests for lr030_soak_supervisor.py — LR-030 Early-Fail Supervisor (Issue #2440).
+
+Coverage:
+  1. Old #2440 failure fixture: wrong intent + INCONCLUSIVE + env interruption + missing
+     hourly log => ARTIFACT_CONTRACT_BROKEN (highest-severity failure captured).
+  2. Missing hourly_checks.log after deadline => MONITOR_DEAD.
+  3. Template placeholder in checkpoint file => INVALID_EVIDENCE.
+  4. Clean LR-030 minimal run => RUNNING_VALID (exit 0).
+  5. --help => exit 0.
+  6. Missing positional argument => exit 2.
+  7. --require-shadow-block-probe with missing probe => INVALID_EVIDENCE.
+  8. Valid shadow-block-probe => RUNNING_VALID.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[3] / "infrastructure" / "scripts")
+)
+
+from lr030_soak_supervisor import (
+    ARTIFACT_CONTRACT_BROKEN,
+    FAILED_EARLY,
+    INCONCLUSIVE_EARLY,
+    INVALID_EVIDENCE,
+    MONITOR_DEAD,
+    RUNNING_VALID,
+    evaluate,
+)
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[3]
+    / "infrastructure"
+    / "scripts"
+    / "lr030_soak_supervisor.py"
+)
+
+# Canonical run name used by most fixtures (parses to 2026-05-16T12:00:00Z).
+_RUN_NAME = "soak_lr030_20260516_120000"
+
+
+def _start_dt() -> datetime:
+    return datetime(2026, 5, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _as_of(minutes: float) -> datetime:
+    return _start_dt() + timedelta(minutes=minutes)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_run_dir(tmp_path: Path, name: str = _RUN_NAME) -> Path:
+    d = tmp_path / name
+    d.mkdir()
+    return d
+
+
+def _write_valid_hourly_log(run_dir: Path, hours: list[int] | None = None) -> None:
+    if hours is None:
+        hours = [1]
+    lines = "\n".join(
+        f"2026-05-16 {12 + h}:00:00 UTC - Hour {h}: No restarts" for h in hours
+    )
+    (run_dir / "hourly_checks.log").write_text(lines + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — old #2440 failure fixture
+# ---------------------------------------------------------------------------
+
+
+def test_old_2440_failure_fixture_all_issues_caught(tmp_path: Path) -> None:
+    """Replicates the conditions of the failed lr030-shadow-soak-20260512 run.
+
+    Intent drift (lr040), INCONCLUSIVE marker, ENVIRONMENT_INTERRUPTION in
+    restart_alerts.log, and missing hourly_checks.log all appear simultaneously.
+    The supervisor must catch all four and report the highest-severity status.
+    """
+    run_dir = _make_run_dir(tmp_path, "soak_lr030_20260512_024819")
+
+    # RC-2: wrong intent (old soak_monitor wrote lr040 into run_intent.txt)
+    (run_dir / "run_intent.txt").write_text("lr040\n", encoding="utf-8")
+
+    # Run explicitly marked inconclusive by soak_monitor
+    (run_dir / "soak_test_INCONCLUSIVE.txt").write_text(
+        "environment_interruption: 12/12\n", encoding="utf-8"
+    )
+
+    # Bulk host restarts logged by soak_monitor (12/12 environment interruptions)
+    (run_dir / "restart_alerts.log").write_text(
+        "2026-05-12 02:51:00 UTC - 12/12 ENVIRONMENT_INTERRUPTION\n" * 3,
+        encoding="utf-8",
+    )
+
+    # hourly_checks.log is absent (run was killed at ~31 min, before first Hour entry)
+    # as_of = 2h after start → well past 75-min deadline
+    old_start = datetime(2026, 5, 12, 2, 48, 19, tzinfo=timezone.utc)
+    as_of = old_start + timedelta(minutes=120)
+
+    result = evaluate(run_dir, as_of)
+
+    # Overall verdict must be the highest-severity failure: ARTIFACT_CONTRACT_BROKEN
+    # (wrong run_intent.txt is a contract violation).
+    assert result["status"] == ARTIFACT_CONTRACT_BROKEN
+
+    # All four root causes must surface in the failures list.
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "run_intent_is_lr030" in failed_checks, "intent drift not caught"
+    assert "no_inconclusive_marker" in failed_checks, "INCONCLUSIVE marker not caught"
+    assert "no_env_interruption_patterns" in failed_checks, "ENVIRONMENT_INTERRUPTION not caught"
+    assert "hourly_checks_log_present" in failed_checks, "missing hourly log not caught"
+
+    # Exit 1 path: status is not RUNNING_VALID
+    assert result["status"] != RUNNING_VALID
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — MONITOR_DEAD after deadline
+# ---------------------------------------------------------------------------
+
+
+def test_monitor_dead_after_deadline(tmp_path: Path) -> None:
+    """hourly_checks.log absent after the deadline window => MONITOR_DEAD."""
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    # No hourly_checks.log written — monitor never fired or crashed.
+
+    result = evaluate(run_dir, _as_of(120), hourly_deadline_minutes=75)
+
+    assert result["status"] == MONITOR_DEAD
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "hourly_checks_log_present" in failed_checks
+
+
+def test_monitor_not_dead_before_deadline(tmp_path: Path) -> None:
+    """hourly_checks.log absent but within grace period => RUNNING_VALID."""
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+
+    result = evaluate(run_dir, _as_of(30), hourly_deadline_minutes=75)
+
+    assert result["status"] == RUNNING_VALID
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — INVALID_EVIDENCE: template placeholders
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_evidence_template_placeholder(tmp_path: Path) -> None:
+    """Un-expanded script variables in a checkpoint file => INVALID_EVIDENCE."""
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir)
+
+    # Checkpoint file still contains un-expanded bash variables.
+    (run_dir / "checkpoint_1_status.json").write_text(
+        json.dumps({"run_id": "$runId", "dir": "$artifactDir", "ok": True}),
+        encoding="utf-8",
+    )
+
+    result = evaluate(run_dir, _as_of(50), hourly_deadline_minutes=75)
+
+    assert result["status"] == INVALID_EVIDENCE
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "no_template_placeholders" in failed_checks
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — clean LR-030 minimal case => RUNNING_VALID
+# ---------------------------------------------------------------------------
+
+
+def test_clean_minimal_lr030_running_valid(tmp_path: Path) -> None:
+    """A minimal valid LR-030 run passes all checks and returns RUNNING_VALID."""
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir, hours=[1, 2])
+
+    result = evaluate(run_dir, _as_of(120), hourly_deadline_minutes=75)
+
+    assert result["status"] == RUNNING_VALID
+    assert result["failures"] == []
+    assert result["hourly_check_count"] == 2
+    assert result["hourly_hours_logged"] == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — CLI: --help exits 0
+# ---------------------------------------------------------------------------
+
+
+def test_cli_help_exits_zero() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert "RUNNING_VALID" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — CLI: missing required argument exits 2
+# ---------------------------------------------------------------------------
+
+
+def test_cli_missing_required_arg_exits_two() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 2
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — --require-shadow-block-probe: missing probe => INVALID_EVIDENCE
+# ---------------------------------------------------------------------------
+
+
+def test_require_shadow_probe_missing_fails(tmp_path: Path) -> None:
+    """--require-shadow-block-probe with no probe file => INVALID_EVIDENCE."""
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir)
+
+    result = evaluate(
+        run_dir,
+        _as_of(120),
+        hourly_deadline_minutes=75,
+        require_shadow_block_probe=True,
+    )
+
+    assert result["status"] == INVALID_EVIDENCE
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "shadow_block_probe_valid" in failed_checks
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — valid shadow-block-probe => RUNNING_VALID
+# ---------------------------------------------------------------------------
+
+
+def test_valid_shadow_probe_running_valid(tmp_path: Path) -> None:
+    """Valid shadow_block_probe.json with REJECTED result => RUNNING_VALID."""
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir)
+    (run_dir / "shadow_block_probe.json").write_text(
+        json.dumps(
+            {
+                "probe_order_id": "probe-001",
+                "order_result_found": True,
+                "order_result": {"status": "REJECTED", "filled_quantity": 0},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = evaluate(
+        run_dir,
+        _as_of(120),
+        hourly_deadline_minutes=75,
+        require_shadow_block_probe=True,
+    )
+
+    assert result["status"] == RUNNING_VALID
+    assert result["checks"]["shadow_block_probe_valid"] is True
+
+
+# ---------------------------------------------------------------------------
+# Additional edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_wrong_artifact_prefix_contract_broken(tmp_path: Path) -> None:
+    """Directory named soak_test_* (LR-040 prefix) => ARTIFACT_CONTRACT_BROKEN."""
+    run_dir = tmp_path / "soak_test_20260516_120000"
+    run_dir.mkdir()
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+
+    result = evaluate(run_dir, _as_of(30))
+
+    assert result["status"] == ARTIFACT_CONTRACT_BROKEN
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "artifact_path_prefix_valid" in failed_checks
+
+
+def test_soak_test_failed_marker_is_failed_early(tmp_path: Path) -> None:
+    """soak_test_FAILED.txt present => FAILED_EARLY."""
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    (run_dir / "soak_test_FAILED.txt").write_text("restart at hour 3\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir, hours=[1, 2, 3])
+
+    result = evaluate(run_dir, _as_of(200))
+
+    assert result["status"] == FAILED_EARLY
+
+
+def test_inconclusive_marker_alone_is_inconclusive_early(tmp_path: Path) -> None:
+    """INCONCLUSIVE marker with no other failures => INCONCLUSIVE_EARLY."""
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    (run_dir / "soak_test_INCONCLUSIVE.txt").write_text(
+        "environment_interruption: 3/8\n", encoding="utf-8"
+    )
+    _write_valid_hourly_log(run_dir)
+
+    result = evaluate(run_dir, _as_of(120))
+
+    assert result["status"] == INCONCLUSIVE_EARLY
+
+
+def test_sut_restart_pattern_is_failed_early(tmp_path: Path) -> None:
+    """SUT_RESTART in restart_alerts.log => FAILED_EARLY (not INCONCLUSIVE_EARLY)."""
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir)
+    (run_dir / "restart_alerts.log").write_text(
+        "2026-05-16 14:00:00 UTC - SUT_RESTART detected for cdb_risk\n",
+        encoding="utf-8",
+    )
+
+    result = evaluate(run_dir, _as_of(120))
+
+    assert result["status"] == FAILED_EARLY
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "no_hard_restart_patterns" in failed_checks
+
+
+def test_env_interruption_pattern_is_inconclusive_not_failed(tmp_path: Path) -> None:
+    """ENVIRONMENT_INTERRUPTION => INCONCLUSIVE_EARLY, not FAILED_EARLY."""
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir)
+    (run_dir / "restart_alerts.log").write_text(
+        "2026-05-16 14:00:00 UTC - ENVIRONMENT_INTERRUPTION (host reboot)\n",
+        encoding="utf-8",
+    )
+
+    result = evaluate(run_dir, _as_of(120))
+
+    assert result["status"] == INCONCLUSIVE_EARLY
+
+
+def test_non_monotone_hourly_log_is_monitor_dead(tmp_path: Path) -> None:
+    """Hourly log with non-monotone hours => MONITOR_DEAD (log corruption)."""
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    (run_dir / "hourly_checks.log").write_text(
+        "2026-05-16 13:00:00 UTC - Hour 1: No restarts\n"
+        "2026-05-16 15:00:00 UTC - Hour 3: No restarts\n"
+        "2026-05-16 14:00:00 UTC - Hour 2: No restarts\n",  # out of order
+        encoding="utf-8",
+    )
+
+    result = evaluate(run_dir, _as_of(250))
+
+    assert result["status"] == MONITOR_DEAD
+
+
+def test_empty_hourly_log_is_monitor_dead(tmp_path: Path) -> None:
+    """hourly_checks.log exists but has no Hour N: entries => MONITOR_DEAD."""
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    (run_dir / "hourly_checks.log").write_text(
+        "monitor started\n", encoding="utf-8"
+    )
+
+    result = evaluate(run_dir, _as_of(120))
+
+    assert result["status"] == MONITOR_DEAD
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "hourly_checks_log_valid" in failed_checks
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — #2440-specific placeholder tokens
+# ---------------------------------------------------------------------------
+
+
+def test_2440_placeholder_tokens_invalid_evidence(tmp_path: Path) -> None:
+    """Known #2440 backfill placeholder tokens => INVALID_EVIDENCE."""
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir)
+
+    # Evidence file still has un-expanded zero-execution proof placeholders
+    # from the old checkpoint-comment scripting error (#2440 RC-3).
+    (run_dir / "zero_execution_status.txt").write_text(
+        "execution_orders_filled_total: <zero_execution_ok>\n",
+        encoding="utf-8",
+    )
+
+    result = evaluate(run_dir, _as_of(50), hourly_deadline_minutes=75)
+
+    assert result["status"] == INVALID_EVIDENCE
+    hits = {h["match"] for f in result["failures"] for h in []}  # unused shorthand
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "no_template_placeholders" in failed_checks
+
+
+def test_2440_execution_orders_placeholder_invalid_evidence(tmp_path: Path) -> None:
+    """<execution_orders_filled_total=0.> placeholder => INVALID_EVIDENCE."""
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir)
+
+    (run_dir / "checkpoint_evidence.txt").write_text(
+        "zero_execution proof: <execution_orders_filled_total=0.>\n",
+        encoding="utf-8",
+    )
+
+    result = evaluate(run_dir, _as_of(50), hourly_deadline_minutes=75)
+
+    assert result["status"] == INVALID_EVIDENCE
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "no_template_placeholders" in failed_checks

--- a/tests/unit/scripts/test_lr030_soak_supervisor.py
+++ b/tests/unit/scripts/test_lr030_soak_supervisor.py
@@ -353,6 +353,60 @@ def test_env_interruption_pattern_is_inconclusive_not_failed(tmp_path: Path) -> 
     assert result["status"] == INCONCLUSIVE_EARLY
 
 
+def test_restart_detected_pattern_is_failed_early(tmp_path: Path) -> None:
+    """RESTART DETECTED: <service> is a SUT container restart => FAILED_EARLY.
+
+    This pattern is written by soak_monitor.sh when a Docker service container
+    restarts.  It is a zero-restart-policy violation and must not be classified
+    as host-level (INCONCLUSIVE_EARLY).
+    """
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir)
+    (run_dir / "restart_alerts.log").write_text(
+        "2026-05-16 14:00:00 UTC - RESTART DETECTED: cdb_risk\n",
+        encoding="utf-8",
+    )
+
+    result = evaluate(run_dir, _as_of(120))
+
+    assert result["status"] == FAILED_EARLY
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "no_hard_restart_patterns" in failed_checks
+
+
+def test_shadow_probe_with_nonzero_fill_is_invalid(tmp_path: Path) -> None:
+    """Shadow probe with REJECTED status but non-zero filled_quantity => INVALID_EVIDENCE.
+
+    A filled_quantity > 0 contradicts the zero-execution guarantee even when
+    the status field reads "REJECTED".
+    """
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir)
+    (run_dir / "shadow_block_probe.json").write_text(
+        json.dumps(
+            {
+                "probe_order_id": "probe-002",
+                "order_result_found": True,
+                "order_result": {"status": "REJECTED", "filled_quantity": 0.5},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = evaluate(
+        run_dir,
+        _as_of(120),
+        hourly_deadline_minutes=75,
+        require_shadow_block_probe=True,
+    )
+
+    assert result["status"] == INVALID_EVIDENCE
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "shadow_block_probe_valid" in failed_checks
+
+
 def test_non_monotone_hourly_log_is_monitor_dead(tmp_path: Path) -> None:
     """Hourly log with non-monotone hours => MONITOR_DEAD (log corruption)."""
     run_dir = _make_run_dir(tmp_path)

--- a/tests/unit/scripts/test_lr030_soak_supervisor.py
+++ b/tests/unit/scripts/test_lr030_soak_supervisor.py
@@ -356,9 +356,8 @@ def test_env_interruption_pattern_is_inconclusive_not_failed(tmp_path: Path) -> 
 def test_restart_detected_pattern_is_failed_early(tmp_path: Path) -> None:
     """RESTART DETECTED: <service> is a SUT container restart => FAILED_EARLY.
 
-    This pattern is written by soak_monitor.sh when a Docker service container
-    restarts.  It is a zero-restart-policy violation and must not be classified
-    as host-level (INCONCLUSIVE_EARLY).
+    When no ENVIRONMENT_INTERRUPTION is present, RESTART DETECTED is a standalone
+    SUT restart (zero-restart-policy violation).
     """
     run_dir = _make_run_dir(tmp_path)
     (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
@@ -373,6 +372,32 @@ def test_restart_detected_pattern_is_failed_early(tmp_path: Path) -> None:
     assert result["status"] == FAILED_EARLY
     failed_checks = {f["check"] for f in result["failures"]}
     assert "no_hard_restart_patterns" in failed_checks
+
+
+def test_restart_detected_with_env_interruption_is_inconclusive(tmp_path: Path) -> None:
+    """RESTART DETECTED + ENVIRONMENT_INTERRUPTION in same log => INCONCLUSIVE_EARLY.
+
+    soak_monitor.sh writes RESTART DETECTED precursor lines before writing the
+    ENVIRONMENT_INTERRUPTION bulk-restart classification.  When both appear in
+    the same log the raw lines are context, not standalone SUT failures, so the
+    verdict must be INCONCLUSIVE_EARLY, not FAILED_EARLY.
+    """
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir)
+    (run_dir / "restart_alerts.log").write_text(
+        "2026-05-16 14:00:00 UTC - RESTART DETECTED: cdb_risk\n"
+        "2026-05-16 14:00:00 UTC - RESTART DETECTED: cdb_execution\n"
+        "2026-05-16 14:00:01 UTC - ENVIRONMENT_INTERRUPTION (bulk host reboot)\n",
+        encoding="utf-8",
+    )
+
+    result = evaluate(run_dir, _as_of(120))
+
+    assert result["status"] == INCONCLUSIVE_EARLY
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "no_env_interruption_patterns" in failed_checks
+    assert "no_hard_restart_patterns" not in failed_checks
 
 
 def test_shadow_probe_with_nonzero_fill_is_invalid(tmp_path: Path) -> None:


### PR DESCRIPTION
Supports #2440.

Adds an LR-030 early-fail supervisor so invalid shadow/soak runs fail visibly before a >24h review window is wasted.

## Checks

- LR-030 artifact path contract (`soak_lr030_YYYYMMDD_HHMMSS`)
- `run_intent.txt == lr030`
- Failed / inconclusive markers
- Restart/environment interruption patterns:
  - `SUT_RESTART` → `FAILED_EARLY`
  - `ENVIRONMENT_INTERRUPTION` → `INCONCLUSIVE_EARLY`
- `hourly_checks.log` presence after deadline (default 75 min)
- Monotone `Hour N` sequence validation
- Template placeholder leakage:
  - `$runId`
  - `$artifactDir`
  - `${checkpoint}`
  - `<zero_execution_ok>`
  - `<execution_orders_filled_total=0.>`
- Optional `shadow_block_probe.json` rejected-proof via `--require-shadow-block-probe`

## Validation

- `python infrastructure/scripts/lr030_soak_supervisor.py --help` → exit 0
- `pytest tests/unit/scripts/test_lr030_soak_supervisor.py -v` → 18/18 passed
- `pytest tests/unit/scripts/test_soak_monitor_timeline.py -v` → 138/138 passed
- `ruff check infrastructure/scripts/lr030_soak_supervisor.py tests/unit/scripts/test_lr030_soak_supervisor.py` → passed

## Why this matters

The previous #2440 LR-030 run became non-PASS-capable early, but the failure was only made explicit during later evidence review.

This supervisor makes the failure state visible early by classifying:

- invalid artifact contract
- failed or inconclusive markers
- restart/environment interruption evidence
- missing hourly monitor evidence
- broken checkpoint timeline
- placeholder leakage in evidence files
- optional missing shadow-block proof

## Guardrails

- no runtime start
- no Docker start
- no workflow dispatch
- no LR status upgrade
- no live/echtgeld-go
- no auto-live
