### PR TITLE
fix(soak): avoid fresh-stack false positive on first monitor pass

### DIFF
--- a/infrastructure/scripts/soak_monitor.sh
+++ b/infrastructure/scripts/soak_monitor.sh
@@ -391,7 +391,7 @@ for _svc in $SUT_SERVICES; do
       echo "  Container: $_svc"
       echo "  Status: $_SVC_STATUS (initial startup uptime)"
       echo "  Detected At: $TIMESTAMP"
-      echo "$TIMESTAMP - FRESH_RESTART: $_svc ($_SVC_STATUS)" >> "$ARTIFACT_PATH/restart_alerts.log"
+      echo "$TIMESTAMP - FRESH_RESTART: $_svc ($_SVC_STATUS)" >> "$ARTIFACT_PATH/fresh_stack_baseline.log"
     else
       echo -e "${RED}ALERT: SUT container restart detected!${NC}"
       echo "  Container: $_svc"
@@ -512,9 +512,9 @@ if [ "$RESTART_DETECTED" -eq 1 ]; then
     # Fresh-stack baseline: all SUT services share initial startup uptime.
     # Write baseline evidence only — no verdict marker files.
     echo "$TIMESTAMP - FRESH_STACK_BASELINE: first monitor pass; all ${RESTART_COUNT}/${TOTAL_CONTAINERS} SUT services share fresh startup uptime (spread=${UPTIME_SPREAD}s, uptime_min=${UPTIME_MIN}s, run_elapsed=${_RUN_ELAPSED_S}s); classified as initial-start baseline, not environment interruption" \
-      >> "$ARTIFACT_PATH/restart_alerts.log"
+      >> "$ARTIFACT_PATH/fresh_stack_baseline.log"
     printf '%s\n' "$TIMESTAMP - FRESH_STACK_BASELINE: first-pass on freshly started stack; all SUT services healthy; not an environment interruption" \
-      > "$ARTIFACT_PATH/fresh_stack_baseline.txt"
+      >> "$ARTIFACT_PATH/fresh_stack_baseline.log"
     echo -e "${YELLOW}INFO: Fresh-stack first-pass baseline — not an environment interruption${NC}"
     echo "  All ${RESTART_COUNT}/${TOTAL_CONTAINERS} SUT services share initial startup uptime (spread=${UPTIME_SPREAD}s)."
     echo "  This is expected after 'make docker-up'. Run continues."

--- a/infrastructure/scripts/soak_monitor.sh
+++ b/infrastructure/scripts/soak_monitor.sh
@@ -500,8 +500,7 @@ if [ "$RESTART_DETECTED" -eq 1 ]; then
      && [ "$RESTART_COUNT" -eq "$EXPECTED_SERVICES" ] \
      && [ "$TOTAL_CONTAINERS" -eq "$EXPECTED_SERVICES" ]; then
     _NOW_EPOCH=$(date +%s)
-    _RUN_START_EPOCH=$(stat -c %Y "$ARTIFACT_PATH/run_intent.txt" 2>/dev/null || echo 0)
-    _RUN_ELAPSED_S=$((_NOW_EPOCH - _RUN_START_EPOCH))
+    _RUN_ELAPSED_S=$((_NOW_EPOCH - RUN_START_EPOCH))
     _COMPAT_THRESHOLD=$((_RUN_ELAPSED_S - 120))
     if [ "$UPTIME_MIN" -ge "$_COMPAT_THRESHOLD" ]; then
       _FRESH_PASS=1

--- a/infrastructure/scripts/soak_monitor.sh
+++ b/infrastructure/scripts/soak_monitor.sh
@@ -235,6 +235,23 @@ if [ -f "$LAST_CHECKPOINT_FILE" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Fresh-stack first-pass candidate detection (Issue #2440 re-run fix).
+# Set when the basic conditions suggest this is the very first monitor pass
+# on a freshly started stack. Final confirmation requires uptime-compatibility
+# with the run start, evaluated in the classification block after UPTIME_MIN
+# is known (guards against a real mid-run restart at < 60 min looking the
+# same as a fresh stack from the elapsed-hours perspective).
+# ---------------------------------------------------------------------------
+_FRESH_PASS_CANDIDATE=0
+if [ "$ELAPSED_HOURS" -eq 0 ] \
+   && [ "$LAST_CHECKPOINT" -eq -1 ] \
+   && [ ! -f "$ARTIFACT_PATH/soak_test_INCONCLUSIVE.txt" ] \
+   && [ ! -f "$ARTIFACT_PATH/soak_test_FAILED.txt" ]; then
+  _FRESH_PASS_CANDIDATE=1
+fi
+FRESH_STACK_BASELINE_APPLIED=0
+
+# ---------------------------------------------------------------------------
 # Auto-stop guard: skip all checks after the monitoring window closes.
 # Prevents post-window Docker/host restarts from tainting a valid run.
 # SOAK_TARGET_HOURS defaults to 72 (LR-040 requirement).
@@ -369,12 +386,19 @@ for _svc in $SUT_SERVICES; do
     [ "$UPTIME_S" -lt "$UPTIME_MIN" ] && UPTIME_MIN=$UPTIME_S
     [ "$UPTIME_S" -gt "$UPTIME_MAX" ] && UPTIME_MAX=$UPTIME_S
 
-    echo -e "${RED}ALERT: SUT container restart detected!${NC}"
-    echo "  Container: $_svc"
-    echo "  Status: $_SVC_STATUS"
-    echo "  Detected At: $TIMESTAMP"
-
-    echo "$TIMESTAMP - RESTART DETECTED: $_svc ($_SVC_STATUS)" >> "$ARTIFACT_PATH/restart_alerts.log"
+    if [ "$_FRESH_PASS_CANDIDATE" -eq 1 ]; then
+      echo -e "${YELLOW}INFO: Fresh-start uptime on first pass: $_svc${NC}"
+      echo "  Container: $_svc"
+      echo "  Status: $_SVC_STATUS (initial startup uptime)"
+      echo "  Detected At: $TIMESTAMP"
+      echo "$TIMESTAMP - FRESH_RESTART: $_svc ($_SVC_STATUS)" >> "$ARTIFACT_PATH/restart_alerts.log"
+    else
+      echo -e "${RED}ALERT: SUT container restart detected!${NC}"
+      echo "  Container: $_svc"
+      echo "  Status: $_SVC_STATUS"
+      echo "  Detected At: $TIMESTAMP"
+      echo "$TIMESTAMP - RESTART DETECTED: $_svc ($_SVC_STATUS)" >> "$ARTIFACT_PATH/restart_alerts.log"
+    fi
     RESTART_COUNT=$((RESTART_COUNT + 1))
     RESTART_DETECTED=1
   fi
@@ -397,10 +421,31 @@ done <<< "$_ALL_STATUS"
 # SUT filter above. If the monitor itself was restarted, that is the strongest
 # signal for an environment-level (Docker-daemon or host) restart.
 MONITOR_FRESH=0
-MONITOR_STATUS=$(docker ps --filter "name=lr040_soak_monitor" --format "{{.Status}}" 2>/dev/null | head -1)
+# Use intent-aware container name so lr030 runs check lr030_soak_monitor and
+# lr040 runs check lr040_soak_monitor. Exact name match avoids false positives
+# from substring-matching a differently-prefixed container.
+_MONITOR_CONTAINER_NAME="${SOAK_RUN_INTENT}_soak_monitor"
+MONITOR_STATUS=$(docker ps --format "{{.Names}} {{.Status}}" 2>/dev/null \
+  | awk -v n="$_MONITOR_CONTAINER_NAME" '$1 == n {print $0; exit}')
 if [ -n "$MONITOR_STATUS" ] && echo "$MONITOR_STATUS" | grep -qiE " second| minute"; then
   MONITOR_FRESH=1
 fi
+
+# ---------------------------------------------------------------------------
+# _checkpoint_write: write the hourly checkpoint entry (idempotent).
+# Defined here so it is available in both the "no restarts" path and the
+# fresh-stack baseline path (issue #2440 re-run fix).
+# ---------------------------------------------------------------------------
+_checkpoint_write() {
+  _CK=-1
+  [ -f "$LAST_CHECKPOINT_FILE" ] && _CK=$(cat "$LAST_CHECKPOINT_FILE")
+  if [ "$ELAPSED_HOURS" -le "$_CK" ]; then
+    echo "Checkpoint $ELAPSED_HOURS already written (last=$_CK) — skipping duplicate"
+  else
+    echo "$TIMESTAMP - Hour $ELAPSED_HOURS: No restarts" >> "$ARTIFACT_PATH/hourly_checks.log"
+    echo "$ELAPSED_HOURS" > "$LAST_CHECKPOINT_FILE"
+  fi
+}
 
 if [ "$RESTART_DETECTED" -eq 1 ]; then
   UPTIME_SPREAD=$((UPTIME_MAX - UPTIME_MIN))
@@ -434,7 +479,47 @@ if [ "$RESTART_DETECTED" -eq 1 ]; then
   [ "$TOTAL_CONTAINERS" -gt 0 ] && [ "$((RESTART_COUNT * 2))" -ge "$TOTAL_CONTAINERS" ] && FRACTION_MET=1
   [ "$RESTART_COUNT" -gt 0 ] && [ "$UPTIME_SPREAD" -le 30 ] && TIGHT_SPREAD_MET=1
 
-  if [ "$FRACTION_MET" -eq 1 ] && ( [ "$TIGHT_SPREAD_MET" -eq 1 ] || [ "$MONITOR_FRESH" -eq 1 ] ); then
+  # ---------------------------------------------------------------------------
+  # Fresh-stack baseline check (Issue #2440 re-run fix).
+  # Evaluated BEFORE spread-based classification so that a freshly started
+  # stack (all containers share startup uptime, spread≈0) is not misclassified
+  # as an environment interruption.
+  #
+  # Confirmation requires ALL of:
+  #   1. _FRESH_PASS_CANDIDATE=1 (first pass, no prior checkpoint, no markers)
+  #   2. Full SUT inventory (RESTART_COUNT == EXPECTED_SERVICES == TOTAL_CONTAINERS)
+  #   3. Uptime compatibility: UPTIME_MIN >= RUN_ELAPSED_SECONDS - 120
+  #      (containers started within 120 s of the run; a real mid-run restart
+  #      shows UPTIME_MIN << RUN_ELAPSED_SECONDS and will NOT qualify).
+  #
+  # If this check does NOT pass, fall through to the standard spread-based
+  # classification (environment_interruption or sut_restart).
+  # ---------------------------------------------------------------------------
+  _FRESH_PASS=0
+  if [ "$_FRESH_PASS_CANDIDATE" -eq 1 ] \
+     && [ "$RESTART_COUNT" -eq "$EXPECTED_SERVICES" ] \
+     && [ "$TOTAL_CONTAINERS" -eq "$EXPECTED_SERVICES" ]; then
+    _NOW_EPOCH=$(date +%s)
+    _RUN_START_EPOCH=$(stat -c %Y "$ARTIFACT_PATH/run_intent.txt" 2>/dev/null || echo 0)
+    _RUN_ELAPSED_S=$((_NOW_EPOCH - _RUN_START_EPOCH))
+    _COMPAT_THRESHOLD=$((_RUN_ELAPSED_S - 120))
+    if [ "$UPTIME_MIN" -ge "$_COMPAT_THRESHOLD" ]; then
+      _FRESH_PASS=1
+    fi
+  fi
+
+  if [ "$_FRESH_PASS" -eq 1 ]; then
+    # Fresh-stack baseline: all SUT services share initial startup uptime.
+    # Write baseline evidence only — no verdict marker files.
+    echo "$TIMESTAMP - FRESH_STACK_BASELINE: first monitor pass; all ${RESTART_COUNT}/${TOTAL_CONTAINERS} SUT services share fresh startup uptime (spread=${UPTIME_SPREAD}s, uptime_min=${UPTIME_MIN}s, run_elapsed=${_RUN_ELAPSED_S}s); classified as initial-start baseline, not environment interruption" \
+      >> "$ARTIFACT_PATH/restart_alerts.log"
+    printf '%s\n' "$TIMESTAMP - FRESH_STACK_BASELINE: first-pass on freshly started stack; all SUT services healthy; not an environment interruption" \
+      > "$ARTIFACT_PATH/fresh_stack_baseline.txt"
+    echo -e "${YELLOW}INFO: Fresh-stack first-pass baseline — not an environment interruption${NC}"
+    echo "  All ${RESTART_COUNT}/${TOTAL_CONTAINERS} SUT services share initial startup uptime (spread=${UPTIME_SPREAD}s)."
+    echo "  This is expected after 'make docker-up'. Run continues."
+    FRESH_STACK_BASELINE_APPLIED=1
+  elif [ "$FRACTION_MET" -eq 1 ] && ( [ "$TIGHT_SPREAD_MET" -eq 1 ] || [ "$MONITOR_FRESH" -eq 1 ] ); then
     # environment_interruption: remove any pre-existing FAILED marker so only
     # one verdict marker exists at a time (mutual exclusion).
     rm -f "$ARTIFACT_PATH/soak_test_FAILED.txt"
@@ -458,19 +543,21 @@ if [ "$RESTART_DETECTED" -eq 1 ]; then
     echo "Time: $TIMESTAMP"
   fi
 
-  # Capture failure evidence regardless of cause class.
-  echo "Capturing failure evidence..."
-  docker ps --all > "$ARTIFACT_PATH/failure_container_status.txt"
-  docker stats --no-stream > "$ARTIFACT_PATH/failure_resources.txt"
+  if [ "$FRESH_STACK_BASELINE_APPLIED" -eq 0 ]; then
+    # Capture failure evidence for real restarts only (not for fresh-stack baseline).
+    echo "Capturing failure evidence..."
+    docker ps --all > "$ARTIFACT_PATH/failure_container_status.txt"
+    docker stats --no-stream > "$ARTIFACT_PATH/failure_resources.txt"
 
-  for service in cdb_ws cdb_signal cdb_risk cdb_execution cdb_db_writer cdb_paper_runner; do
-    if docker ps -a --filter "name=$service" --format "{{.Names}}" | grep -q "$service"; then
-      echo "  Capturing logs: $service"
-      docker logs "$service" --tail 500 > "$ARTIFACT_PATH/failure_logs_${service}.txt" 2>&1 || true
-    fi
-  done
+    for service in cdb_ws cdb_signal cdb_risk cdb_execution cdb_db_writer cdb_paper_runner; do
+      if docker ps -a --filter "name=$service" --format "{{.Names}}" | grep -q "$service"; then
+        echo "  Capturing logs: $service"
+        docker logs "$service" --tail 500 > "$ARTIFACT_PATH/failure_logs_${service}.txt" 2>&1 || true
+      fi
+    done
 
-  echo -e "${RED}See $ARTIFACT_PATH for evidence.${NC}"
+    echo -e "${RED}See $ARTIFACT_PATH for evidence.${NC}"
+  fi
   # Don't exit - continue monitoring to capture full failure timeline
 else
   echo -e "${GREEN}✓ No restarts detected${NC}"
@@ -480,16 +567,23 @@ else
   # On platforms without flock (Git Bash / MSYS2 on Windows), the checkpoint
   # is written directly — safe for solo-maintainer setups with a single
   # cron instance (Issue #1420).
-  _checkpoint_write() {
-    _CK=-1
-    [ -f "$LAST_CHECKPOINT_FILE" ] && _CK=$(cat "$LAST_CHECKPOINT_FILE")
-    if [ "$ELAPSED_HOURS" -le "$_CK" ]; then
-      echo "Checkpoint $ELAPSED_HOURS already written (last=$_CK) — skipping duplicate"
-    else
-      echo "$TIMESTAMP - Hour $ELAPSED_HOURS: No restarts" >> "$ARTIFACT_PATH/hourly_checks.log"
-      echo "$ELAPSED_HOURS" > "$LAST_CHECKPOINT_FILE"
-    fi
-  }
+  if [ "$_HAS_FLOCK" -eq 1 ]; then
+    (
+      flock -x -w 30 200 || {
+        echo "WARNING: could not acquire checkpoint lock within 30 s — skipping hourly log write"
+        exit 0
+      }
+      _checkpoint_write
+    ) 200>"$ARTIFACT_PATH/checkpoint.lock"
+  else
+    _checkpoint_write
+  fi
+fi
+
+# Write hourly checkpoint for fresh-stack baseline pass. The run continues
+# normally — the baseline classification is not a failure.
+if [ "$FRESH_STACK_BASELINE_APPLIED" -eq 1 ]; then
+  echo -e "${YELLOW}INFO: Fresh-stack baseline — writing hour-0 checkpoint${NC}"
   if [ "$_HAS_FLOCK" -eq 1 ]; then
     (
       flock -x -w 30 200 || {

--- a/tests/unit/scripts/test_lr030_soak_supervisor.py
+++ b/tests/unit/scripts/test_lr030_soak_supervisor.py
@@ -590,17 +590,16 @@ def test_malformed_shadow_probe_is_invalid_not_crash(
 
 
 def test_fresh_stack_baseline_log_is_running_valid(tmp_path: Path) -> None:
-    """FRESH_RESTART: + FRESH_STACK_BASELINE: in log, no verdict markers => RUNNING_VALID.
+    """FRESH_RESTART: + FRESH_STACK_BASELINE: in fresh_stack_baseline.log => RUNNING_VALID.
 
-    After a fresh-stack first-pass, soak_monitor.sh writes only FRESH_RESTART:
-    per-container tags and a single FRESH_STACK_BASELINE: summary entry into
-    restart_alerts.log.  Neither pattern matches _RAW_RESTART_RE ("RESTART DETECTED")
-    nor _ENV_INTERRUPTION_RE ("ENVIRONMENT_INTERRUPTION"), so the supervisor must
-    report RUNNING_VALID (within the hourly deadline grace period).
+    After a fresh-stack first-pass, soak_monitor.sh writes FRESH_RESTART: per-container
+    tags and a FRESH_STACK_BASELINE: summary entry into fresh_stack_baseline.log (NOT
+    restart_alerts.log).  restart_alerts.log is absent.  Supervisor must report
+    RUNNING_VALID (within the hourly deadline grace period).
     """
     run_dir = _make_run_dir(tmp_path)
     (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
-    # Simulate 12 per-container FRESH_RESTART: lines + summary
+    # Simulate 12 per-container FRESH_RESTART: lines + summary in dedicated file
     fresh_lines = "".join(
         f"2026-05-16 19:24:10 UTC - FRESH_RESTART: cdb_svc_{i} (Up 5 minutes)\n"
         for i in range(12)
@@ -610,13 +609,11 @@ def test_fresh_stack_baseline_log_is_running_valid(tmp_path: Path) -> None:
         "all 12/12 SUT services share fresh startup uptime (spread=0s, "
         "uptime_min=300s, run_elapsed=305s); classified as initial-start baseline, "
         "not environment interruption\n"
-    )
-    (run_dir / "restart_alerts.log").write_text(fresh_lines, encoding="utf-8")
-    (run_dir / "fresh_stack_baseline.txt").write_text(
         "2026-05-16 19:24:10 UTC - FRESH_STACK_BASELINE: first-pass on freshly "
-        "started stack; all SUT services healthy; not an environment interruption\n",
-        encoding="utf-8",
+        "started stack; all SUT services healthy; not an environment interruption\n"
     )
+    (run_dir / "fresh_stack_baseline.log").write_text(fresh_lines, encoding="utf-8")
+    # restart_alerts.log must be absent — that is the P1 fix
 
     # Within 75-min deadline: no hourly_checks.log required yet
     result = evaluate(run_dir, _as_of(30), hourly_deadline_minutes=75)
@@ -629,14 +626,15 @@ def test_fresh_stack_baseline_log_is_running_valid(tmp_path: Path) -> None:
 
 
 def test_fresh_stack_baseline_with_hourly_log_is_running_valid(tmp_path: Path) -> None:
-    """FRESH_RESTART: log + hourly_checks.log Hour 0 + no markers => RUNNING_VALID.
+    """FRESH_RESTART: in fresh_stack_baseline.log + hourly_checks.log Hour 0 => RUNNING_VALID.
 
     After the fresh-stack baseline pass writes the hour-0 checkpoint, subsequent
     supervisor evaluations past the hourly deadline must still return RUNNING_VALID.
+    restart_alerts.log is absent — baseline evidence is only in fresh_stack_baseline.log.
     """
     run_dir = _make_run_dir(tmp_path)
     (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
-    (run_dir / "restart_alerts.log").write_text(
+    (run_dir / "fresh_stack_baseline.log").write_text(
         "2026-05-16 19:24:10 UTC - FRESH_RESTART: cdb_ws (Up 5 minutes)\n"
         "2026-05-16 19:24:10 UTC - FRESH_STACK_BASELINE: first monitor pass; "
         "all 12/12 SUT services share fresh startup uptime\n",
@@ -651,15 +649,16 @@ def test_fresh_stack_baseline_with_hourly_log_is_running_valid(tmp_path: Path) -
 
 
 def test_fresh_restart_tag_alone_does_not_fail(tmp_path: Path) -> None:
-    """FRESH_RESTART: tag must not match _RAW_RESTART_RE ('RESTART DETECTED').
+    """FRESH_RESTART: tag in fresh_stack_baseline.log must not cause supervisor failure.
 
-    Regression guard: ensures the literal string "FRESH_RESTART:" is not caught
-    by the supervisor's hard-restart pattern which matches "RESTART DETECTED".
+    Regression guard: ensures FRESH_RESTART: evidence in fresh_stack_baseline.log
+    does not trip any supervisor check.  restart_alerts.log is absent (P1 fix:
+    fresh-stack baseline writes only to fresh_stack_baseline.log).
     """
     run_dir = _make_run_dir(tmp_path)
     (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
     _write_valid_hourly_log(run_dir)
-    (run_dir / "restart_alerts.log").write_text(
+    (run_dir / "fresh_stack_baseline.log").write_text(
         "2026-05-16 19:24:10 UTC - FRESH_RESTART: cdb_risk (Up 3 minutes)\n",
         encoding="utf-8",
     )
@@ -674,15 +673,16 @@ def test_fresh_restart_tag_alone_does_not_fail(tmp_path: Path) -> None:
 def test_fresh_stack_baseline_tag_does_not_trigger_env_interruption(
     tmp_path: Path,
 ) -> None:
-    """FRESH_STACK_BASELINE: must not match _ENV_INTERRUPTION_RE ('ENVIRONMENT_INTERRUPTION').
+    """FRESH_STACK_BASELINE: in fresh_stack_baseline.log must not cause env-interruption failure.
 
-    Regression guard: ensures FRESH_STACK_BASELINE: in restart_alerts.log is not
-    mistakenly classified as an environment interruption.
+    Regression guard: ensures FRESH_STACK_BASELINE: evidence in fresh_stack_baseline.log
+    does not match _ENV_INTERRUPTION_RE ('ENVIRONMENT_INTERRUPTION').  restart_alerts.log
+    is absent (P1 fix: fresh-stack baseline writes only to fresh_stack_baseline.log).
     """
     run_dir = _make_run_dir(tmp_path)
     (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
     _write_valid_hourly_log(run_dir)
-    (run_dir / "restart_alerts.log").write_text(
+    (run_dir / "fresh_stack_baseline.log").write_text(
         "2026-05-16 19:24:10 UTC - FRESH_STACK_BASELINE: first monitor pass; "
         "all 12/12 SUT services; not an environment interruption\n",
         encoding="utf-8",
@@ -701,16 +701,22 @@ def test_environment_interruption_after_fresh_stack_baseline_is_inconclusive(
     """Real ENVIRONMENT_INTERRUPTION after first baseline => INCONCLUSIVE_EARLY.
 
     After the fresh-stack baseline is established, a real Docker-daemon restart
-    later in the run must still produce INCONCLUSIVE_EARLY. The FRESH_RESTART:
-    tags from the first pass must not suppress the ENVIRONMENT_INTERRUPTION verdict.
+    later in the run must still produce INCONCLUSIVE_EARLY.
+
+    P1 fix layout: baseline evidence is in fresh_stack_baseline.log; only the
+    real ENVIRONMENT_INTERRUPTION appears in restart_alerts.log.
     """
     run_dir = _make_run_dir(tmp_path)
     (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
     _write_valid_hourly_log(run_dir, hours=[0, 1, 2])
-    # Fresh-stack baseline from hour 0, real interruption at hour 3
-    (run_dir / "restart_alerts.log").write_text(
+    # Fresh-stack baseline from hour 0 — in dedicated file only
+    (run_dir / "fresh_stack_baseline.log").write_text(
         "2026-05-16 19:24:10 UTC - FRESH_RESTART: cdb_ws (Up 5 minutes)\n"
-        "2026-05-16 19:24:10 UTC - FRESH_STACK_BASELINE: initial-start baseline\n"
+        "2026-05-16 19:24:10 UTC - FRESH_STACK_BASELINE: initial-start baseline\n",
+        encoding="utf-8",
+    )
+    # Real environment interruption at hour 3 — in restart_alerts.log
+    (run_dir / "restart_alerts.log").write_text(
         "2026-05-16 22:30:00 UTC - ENVIRONMENT_INTERRUPTION: 12/12 host reboot\n",
         encoding="utf-8",
     )
@@ -724,4 +730,30 @@ def test_environment_interruption_after_fresh_stack_baseline_is_inconclusive(
     assert result["status"] == INCONCLUSIVE_EARLY
     failed_checks = {f["check"] for f in result["failures"]}
     assert "no_env_interruption_patterns" in failed_checks
+
+
+def test_fresh_stack_baseline_does_not_populate_restart_alerts(tmp_path: Path) -> None:
+    """LR-040 regression guard: fresh-stack baseline must leave restart_alerts.log absent.
+
+    P1 fix: soak_monitor.sh no longer writes FRESH_RESTART: or FRESH_STACK_BASELINE:
+    to restart_alerts.log.  Only fresh_stack_baseline.log is created on a fresh first
+    pass.  If restart_alerts.log is absent, the LR-040 gate (lr040_soak_gate_eval.py)
+    sees no_restart_alerts=true and does not fail a healthy run on benign baseline noise.
+    """
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    # Only fresh_stack_baseline.log — restart_alerts.log intentionally absent
+    (run_dir / "fresh_stack_baseline.log").write_text(
+        "2026-05-16 19:24:10 UTC - FRESH_RESTART: cdb_ws (Up 5 minutes)\n"
+        "2026-05-16 19:24:10 UTC - FRESH_STACK_BASELINE: first-pass baseline\n",
+        encoding="utf-8",
+    )
+
+    result = evaluate(run_dir, _as_of(30), hourly_deadline_minutes=75)
+
+    assert result["status"] == RUNNING_VALID
+    assert not (run_dir / "restart_alerts.log").exists(), (
+        "restart_alerts.log must not exist after a fresh-stack first pass — "
+        "it would cause lr040_soak_gate_eval.py to report no_restart_alerts=false"
+    )
 

--- a/tests/unit/scripts/test_lr030_soak_supervisor.py
+++ b/tests/unit/scripts/test_lr030_soak_supervisor.py
@@ -582,3 +582,146 @@ def test_malformed_shadow_probe_is_invalid_not_crash(
     # Must not crash; must treat malformed proof as absence of valid proof.
     assert result["status"] in (RUNNING_VALID, INVALID_EVIDENCE, INCONCLUSIVE_EARLY, FAILED_EARLY)
     assert result["checks"]["shadow_block_probe_valid"] is False
+
+
+# ---------------------------------------------------------------------------
+# Fresh-stack baseline tests (Issue #2440 re-run fix)
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_stack_baseline_log_is_running_valid(tmp_path: Path) -> None:
+    """FRESH_RESTART: + FRESH_STACK_BASELINE: in log, no verdict markers => RUNNING_VALID.
+
+    After a fresh-stack first-pass, soak_monitor.sh writes only FRESH_RESTART:
+    per-container tags and a single FRESH_STACK_BASELINE: summary entry into
+    restart_alerts.log.  Neither pattern matches _RAW_RESTART_RE ("RESTART DETECTED")
+    nor _ENV_INTERRUPTION_RE ("ENVIRONMENT_INTERRUPTION"), so the supervisor must
+    report RUNNING_VALID (within the hourly deadline grace period).
+    """
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    # Simulate 12 per-container FRESH_RESTART: lines + summary
+    fresh_lines = "".join(
+        f"2026-05-16 19:24:10 UTC - FRESH_RESTART: cdb_svc_{i} (Up 5 minutes)\n"
+        for i in range(12)
+    )
+    fresh_lines += (
+        "2026-05-16 19:24:10 UTC - FRESH_STACK_BASELINE: first monitor pass; "
+        "all 12/12 SUT services share fresh startup uptime (spread=0s, "
+        "uptime_min=300s, run_elapsed=305s); classified as initial-start baseline, "
+        "not environment interruption\n"
+    )
+    (run_dir / "restart_alerts.log").write_text(fresh_lines, encoding="utf-8")
+    (run_dir / "fresh_stack_baseline.txt").write_text(
+        "2026-05-16 19:24:10 UTC - FRESH_STACK_BASELINE: first-pass on freshly "
+        "started stack; all SUT services healthy; not an environment interruption\n",
+        encoding="utf-8",
+    )
+
+    # Within 75-min deadline: no hourly_checks.log required yet
+    result = evaluate(run_dir, _as_of(30), hourly_deadline_minutes=75)
+
+    assert result["status"] == RUNNING_VALID, (
+        f"Expected RUNNING_VALID for fresh-stack baseline log, got {result['status']}. "
+        f"Failures: {result['failures']}"
+    )
+    assert result["failures"] == []
+
+
+def test_fresh_stack_baseline_with_hourly_log_is_running_valid(tmp_path: Path) -> None:
+    """FRESH_RESTART: log + hourly_checks.log Hour 0 + no markers => RUNNING_VALID.
+
+    After the fresh-stack baseline pass writes the hour-0 checkpoint, subsequent
+    supervisor evaluations past the hourly deadline must still return RUNNING_VALID.
+    """
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    (run_dir / "restart_alerts.log").write_text(
+        "2026-05-16 19:24:10 UTC - FRESH_RESTART: cdb_ws (Up 5 minutes)\n"
+        "2026-05-16 19:24:10 UTC - FRESH_STACK_BASELINE: first monitor pass; "
+        "all 12/12 SUT services share fresh startup uptime\n",
+        encoding="utf-8",
+    )
+    # hour-0 checkpoint written by fresh-stack baseline path; subsequent clean check
+    _write_valid_hourly_log(run_dir, hours=[0, 1, 2])
+
+    result = evaluate(run_dir, _as_of(150), hourly_deadline_minutes=75)
+
+    assert result["status"] == RUNNING_VALID
+
+
+def test_fresh_restart_tag_alone_does_not_fail(tmp_path: Path) -> None:
+    """FRESH_RESTART: tag must not match _RAW_RESTART_RE ('RESTART DETECTED').
+
+    Regression guard: ensures the literal string "FRESH_RESTART:" is not caught
+    by the supervisor's hard-restart pattern which matches "RESTART DETECTED".
+    """
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir)
+    (run_dir / "restart_alerts.log").write_text(
+        "2026-05-16 19:24:10 UTC - FRESH_RESTART: cdb_risk (Up 3 minutes)\n",
+        encoding="utf-8",
+    )
+
+    result = evaluate(run_dir, _as_of(120))
+
+    assert result["status"] == RUNNING_VALID
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "no_hard_restart_patterns" not in failed_checks
+
+
+def test_fresh_stack_baseline_tag_does_not_trigger_env_interruption(
+    tmp_path: Path,
+) -> None:
+    """FRESH_STACK_BASELINE: must not match _ENV_INTERRUPTION_RE ('ENVIRONMENT_INTERRUPTION').
+
+    Regression guard: ensures FRESH_STACK_BASELINE: in restart_alerts.log is not
+    mistakenly classified as an environment interruption.
+    """
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir)
+    (run_dir / "restart_alerts.log").write_text(
+        "2026-05-16 19:24:10 UTC - FRESH_STACK_BASELINE: first monitor pass; "
+        "all 12/12 SUT services; not an environment interruption\n",
+        encoding="utf-8",
+    )
+
+    result = evaluate(run_dir, _as_of(120))
+
+    assert result["status"] == RUNNING_VALID
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "no_env_interruption_patterns" not in failed_checks
+
+
+def test_environment_interruption_after_fresh_stack_baseline_is_inconclusive(
+    tmp_path: Path,
+) -> None:
+    """Real ENVIRONMENT_INTERRUPTION after first baseline => INCONCLUSIVE_EARLY.
+
+    After the fresh-stack baseline is established, a real Docker-daemon restart
+    later in the run must still produce INCONCLUSIVE_EARLY. The FRESH_RESTART:
+    tags from the first pass must not suppress the ENVIRONMENT_INTERRUPTION verdict.
+    """
+    run_dir = _make_run_dir(tmp_path)
+    (run_dir / "run_intent.txt").write_text("lr030\n", encoding="utf-8")
+    _write_valid_hourly_log(run_dir, hours=[0, 1, 2])
+    # Fresh-stack baseline from hour 0, real interruption at hour 3
+    (run_dir / "restart_alerts.log").write_text(
+        "2026-05-16 19:24:10 UTC - FRESH_RESTART: cdb_ws (Up 5 minutes)\n"
+        "2026-05-16 19:24:10 UTC - FRESH_STACK_BASELINE: initial-start baseline\n"
+        "2026-05-16 22:30:00 UTC - ENVIRONMENT_INTERRUPTION: 12/12 host reboot\n",
+        encoding="utf-8",
+    )
+    (run_dir / "soak_test_INCONCLUSIVE.txt").write_text(
+        "2026-05-16 22:30:00 UTC - INCONCLUSIVE: Environment interruption at hour 3\n",
+        encoding="utf-8",
+    )
+
+    result = evaluate(run_dir, _as_of(200))
+
+    assert result["status"] == INCONCLUSIVE_EARLY
+    failed_checks = {f["check"] for f in result["failures"]}
+    assert "no_env_interruption_patterns" in failed_checks
+

--- a/tests/unit/scripts/test_soak_monitor_timeline.py
+++ b/tests/unit/scripts/test_soak_monitor_timeline.py
@@ -1748,3 +1748,128 @@ class TestDiskCheckFallback:
         assert (
             "Docker disk evidence also unavailable" in content
         ), "Fail-closed message missing — path C wording changed"
+
+
+# ---------------------------------------------------------------------------
+# Fresh-stack first-pass detection (Issue #2440 re-run fix)
+#
+# Root cause: soak_monitor.sh classified a freshly started, 100% healthy stack
+# as ENVIRONMENT_INTERRUPTION / INCONCLUSIVE on the very first monitor pass,
+# because all 12/12 SUT containers shared the same uptime (spread=0s, fresh
+# Docker launch).
+#
+# Fix: _FRESH_PASS_CANDIDATE + uptime-compatibility guard.  Grace is only applied
+# when elapsed_hours==0, last_checkpoint==-1, no existing markers, and uptime is
+# compatible with the run start timestamp derived from run_intent.txt mtime.
+# ---------------------------------------------------------------------------
+
+
+def is_fresh_stack_first_pass(
+    elapsed_hours: int,
+    last_checkpoint: int,
+    inconclusive_exists: bool,
+    failed_exists: bool,
+) -> bool:
+    """Mirror _FRESH_PASS_CANDIDATE detection in soak_monitor.sh (pre-uptime-compat check).
+
+    Returns True only when all four conditions hold:
+    - elapsed_hours == 0 (within the first hour)
+    - last_checkpoint == -1 (no checkpoint has been written yet)
+    - no soak_test_INCONCLUSIVE.txt present
+    - no soak_test_FAILED.txt present
+
+    This mirrors the bash _FRESH_PASS_CANDIDATE=1 logic before the uptime-compatibility
+    guard is evaluated.  The uptime guard (_FRESH_PASS vs _FRESH_PASS_CANDIDATE) requires
+    live container uptime data and is validated separately via soak_monitor.sh smoke guards.
+    """
+    return (
+        elapsed_hours == 0
+        and last_checkpoint == -1
+        and not inconclusive_exists
+        and not failed_exists
+    )
+
+
+class TestFreshStackFirstPassDetection:
+    """Issue #2440: first-pass candidate detection logic mirrors soak_monitor.sh.
+
+    These tests validate the Python model of the bash _FRESH_PASS_CANDIDATE guard.
+    They are paired with TestRestartDetectionScope for the scope-aware SUT counting.
+    """
+
+    def test_clean_first_pass_is_candidate(self) -> None:
+        """All four conditions met → True (fresh-stack grace candidate)."""
+        assert is_fresh_stack_first_pass(0, -1, False, False) is True
+
+    def test_beyond_first_hour_no_grace(self) -> None:
+        """elapsed_hours >= 1 → not a fresh-stack candidate, regardless of checkpoint."""
+        assert is_fresh_stack_first_pass(1, -1, False, False) is False
+        assert is_fresh_stack_first_pass(2, -1, False, False) is False
+        assert is_fresh_stack_first_pass(24, -1, False, False) is False
+
+    def test_checkpoint_already_written_no_grace(self) -> None:
+        """last_checkpoint >= 0 means a prior pass completed → not first pass."""
+        assert is_fresh_stack_first_pass(0, 0, False, False) is False
+        assert is_fresh_stack_first_pass(0, 5, False, False) is False
+
+    def test_inconclusive_marker_blocks_grace(self) -> None:
+        """soak_test_INCONCLUSIVE.txt present → grace blocked (fail-closed)."""
+        assert is_fresh_stack_first_pass(0, -1, True, False) is False
+
+    def test_failed_marker_blocks_grace(self) -> None:
+        """soak_test_FAILED.txt present → grace blocked (fail-closed)."""
+        assert is_fresh_stack_first_pass(0, -1, False, True) is False
+
+    def test_both_markers_block_grace(self) -> None:
+        """Both markers present → still blocked."""
+        assert is_fresh_stack_first_pass(0, -1, True, True) is False
+
+    def test_partial_12_of_12_sut_fresh_stack_is_candidate(self) -> None:
+        """Candidate check is independent of SUT count; full 12/12 is required at
+        a higher layer (the bash body checks RESTART_COUNT == EXPECTED_SERVICES == 12).
+        This test confirms the Python gate does not short-circuit on counts."""
+        assert is_fresh_stack_first_pass(0, -1, False, False) is True
+
+    def test_lr030_soak_monitor_bash_contains_fresh_pass_candidate_variable(
+        self,
+    ) -> None:
+        """Regression anchor: _FRESH_PASS_CANDIDATE must remain in soak_monitor.sh."""
+        content = _read_soak_monitor()
+        assert "_FRESH_PASS_CANDIDATE" in content, (
+            "_FRESH_PASS_CANDIDATE variable missing from soak_monitor.sh — "
+            "the fresh-stack first-pass grace guard has been removed or renamed"
+        )
+
+    def test_lr030_soak_monitor_bash_contains_fresh_stack_baseline_tag(self) -> None:
+        """Regression anchor: FRESH_STACK_BASELINE: log tag must remain in soak_monitor.sh."""
+        content = _read_soak_monitor()
+        assert "FRESH_STACK_BASELINE:" in content, (
+            "FRESH_STACK_BASELINE: log tag missing from soak_monitor.sh — "
+            "the benign fresh-stack classification path has been removed"
+        )
+
+    def test_lr030_soak_monitor_bash_contains_fresh_restart_tag(self) -> None:
+        """Regression anchor: FRESH_RESTART: log tag must remain in soak_monitor.sh."""
+        content = _read_soak_monitor()
+        assert "FRESH_RESTART:" in content, (
+            "FRESH_RESTART: log tag missing from soak_monitor.sh — "
+            "the per-container fresh-stack logging has been removed"
+        )
+
+    def test_lr030_soak_monitor_bash_uses_run_intent_mtime_for_uptime_compat(
+        self,
+    ) -> None:
+        """Regression anchor: uptime-compat guard must read run_intent.txt mtime.
+
+        This is the critical fix from the rubber-duck review: ELAPSED_HOURS==0 &&
+        LAST_CHECKPOINT==-1 alone cannot distinguish T+0 from a real Docker-daemon
+        restart at T+30min (before the first hourly checkpoint).  The mtime of
+        run_intent.txt gives a concrete run-start epoch for comparison.
+        """
+        content = _read_soak_monitor()
+        assert "run_intent.txt" in content, "run_intent.txt must appear in soak_monitor.sh"
+        # stat -c %Y provides the mtime epoch used for uptime-compat comparison
+        assert "stat -c %Y" in content or "RUN_START_EPOCH" in content, (
+            "Uptime-compatibility guard (stat -c %%Y run_intent.txt or RUN_START_EPOCH) "
+            "missing from soak_monitor.sh — the mid-run restart ambiguity fix is absent"
+        )

--- a/tests/unit/scripts/test_soak_monitor_timeline.py
+++ b/tests/unit/scripts/test_soak_monitor_timeline.py
@@ -1856,22 +1856,22 @@ class TestFreshStackFirstPassDetection:
             "the per-container fresh-stack logging has been removed"
         )
 
-    def test_lr030_soak_monitor_bash_uses_run_intent_mtime_for_uptime_compat(
+    def test_lr030_soak_monitor_bash_uses_run_start_epoch_for_uptime_compat(
         self,
     ) -> None:
-        """Regression anchor: uptime-compat guard must read run_intent.txt mtime.
+        """Regression anchor: uptime-compat guard must use RUN_START_EPOCH.
 
-        This is the critical fix from the rubber-duck review: ELAPSED_HOURS==0 &&
-        LAST_CHECKPOINT==-1 alone cannot distinguish T+0 from a real Docker-daemon
-        restart at T+30min (before the first hourly checkpoint).  The mtime of
-        run_intent.txt gives a concrete run-start epoch for comparison.
+        The global RUN_START_EPOCH is derived from the artifact directory name
+        (actual run launch time) or first-invocation fallback — NOT from
+        run_intent.txt mtime, which would be the monitor invocation time and
+        yield _RUN_ELAPSED_S ≈ 0, making the compat check trivially pass even
+        for containers that restarted mid-run.
         """
         content = _read_soak_monitor()
-        assert "run_intent.txt" in content, "run_intent.txt must appear in soak_monitor.sh"
-        # stat -c %Y provides the mtime epoch used for uptime-compat comparison
-        assert "stat -c %Y" in content or "RUN_START_EPOCH" in content, (
-            "Uptime-compatibility guard (stat -c %%Y run_intent.txt or RUN_START_EPOCH) "
-            "missing from soak_monitor.sh — the mid-run restart ambiguity fix is absent"
+        assert "RUN_START_EPOCH" in content, (
+            "Uptime-compatibility guard must use global RUN_START_EPOCH "
+            "(derived from artifact directory name / run_start.txt) instead of "
+            "run_intent.txt mtime — the mid-run restart ambiguity fix is absent"
         )
 
     def test_lr030_soak_monitor_bash_writes_fresh_tags_to_fresh_stack_baseline_log(
@@ -1900,7 +1900,6 @@ class TestFreshStackFirstPassDetection:
         no_restart_alerts gate.
         """
         content = _read_soak_monitor()
-        import re
 
         # Find all lines that both contain FRESH_RESTART: and restart_alerts.log
         bad_lines = [

--- a/tests/unit/scripts/test_soak_monitor_timeline.py
+++ b/tests/unit/scripts/test_soak_monitor_timeline.py
@@ -1873,3 +1873,61 @@ class TestFreshStackFirstPassDetection:
             "Uptime-compatibility guard (stat -c %%Y run_intent.txt or RUN_START_EPOCH) "
             "missing from soak_monitor.sh — the mid-run restart ambiguity fix is absent"
         )
+
+    def test_lr030_soak_monitor_bash_writes_fresh_tags_to_fresh_stack_baseline_log(
+        self,
+    ) -> None:
+        """P1 fix guard: fresh-stack evidence must target fresh_stack_baseline.log.
+
+        soak_monitor.sh must write FRESH_RESTART: and FRESH_STACK_BASELINE: entries
+        to fresh_stack_baseline.log, NOT to restart_alerts.log.  Writing baseline
+        notices to restart_alerts.log would cause lr040_soak_gate_eval.py to report
+        no_restart_alerts=false and fail a healthy LR-040 run.
+        """
+        content = _read_soak_monitor()
+        assert "fresh_stack_baseline.log" in content, (
+            "fresh_stack_baseline.log missing from soak_monitor.sh — "
+            "fresh-stack baseline evidence has no dedicated output file (P1 fix absent)"
+        )
+
+    def test_lr030_soak_monitor_bash_fresh_restart_not_in_restart_alerts(
+        self,
+    ) -> None:
+        """P1 fix guard: FRESH_RESTART: must NOT be written to restart_alerts.log.
+
+        Any FRESH_RESTART: line that appends to restart_alerts.log would make
+        that file non-empty after a clean fresh first pass, breaking the LR-040
+        no_restart_alerts gate.
+        """
+        content = _read_soak_monitor()
+        import re
+
+        # Find all lines that both contain FRESH_RESTART: and restart_alerts.log
+        bad_lines = [
+            line
+            for line in content.splitlines()
+            if "FRESH_RESTART:" in line and "restart_alerts.log" in line
+        ]
+        assert bad_lines == [], (
+            f"FRESH_RESTART: must not target restart_alerts.log — found:\n"
+            + "\n".join(bad_lines)
+        )
+
+    def test_lr030_soak_monitor_bash_fresh_stack_baseline_not_in_restart_alerts(
+        self,
+    ) -> None:
+        """P1 fix guard: FRESH_STACK_BASELINE: must NOT be written to restart_alerts.log.
+
+        Same rationale as above: any FRESH_STACK_BASELINE: in restart_alerts.log
+        makes the file non-empty, breaking the LR-040 gate.
+        """
+        content = _read_soak_monitor()
+        bad_lines = [
+            line
+            for line in content.splitlines()
+            if "FRESH_STACK_BASELINE:" in line and "restart_alerts.log" in line
+        ]
+        assert bad_lines == [], (
+            f"FRESH_STACK_BASELINE: must not target restart_alerts.log — found:\n"
+            + "\n".join(bad_lines)
+        )


### PR DESCRIPTION
Supports #2440.

Fixes a fresh-stack false positive in `soak_monitor.sh`.

## Problem

The first LR-030 monitor pass classified a freshly started, healthy BLUE+RED stack as `ENVIRONMENT_INTERRUPTION` because all 12/12 SUT containers shared the same fresh uptime and `monitor_fresh=1`.

That produced `soak_test_INCONCLUSIVE.txt` immediately, even though there was no actual crash, abort alert, or live/echtgeld risk.

## Fix

Adds first-pass Fresh-Stack-Baseline handling so a healthy freshly started stack is documented as baseline instead of being classified as an environment interruption.

The fix preserves fail-closed behavior:

- real SUT restarts after baseline still fail
- environment interruptions after baseline still classify as inconclusive
- partial restarts do not get fresh-stack grace
- existing markers are not overwritten
- ambiguous states stay conservative

## Files

- `infrastructure/scripts/soak_monitor.sh`
- `tests/unit/scripts/test_lr030_soak_supervisor.py`
- `tests/unit/scripts/test_soak_monitor_timeline.py`

## Validation

- `python infrastructure/scripts/lr030_soak_supervisor.py --help`
- `pytest tests/unit/scripts/test_lr030_soak_supervisor.py -v` → 32/32 passed
- `pytest tests/unit/scripts/test_soak_monitor_timeline.py -v` → 149/149 passed
- `ruff check ...` → passed

## Guardrails

- no run start
- no Docker restart
- no marker clearing
- no LR status upgrade
- no live/echtgeld-go
- no auto-live

The current early-inconclusive run remains non-PASS-capable and should not be rescued by marker deletion. A new clean LR-030 run is required after this fix is merged.
