### PR TITLE
fix(security): clean up CodeQL note findings for #2289

### DIFF
--- a/.github/scripts/control_plane_validate.py
+++ b/.github/scripts/control_plane_validate.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Any

--- a/.github/scripts/post_merge_followup_scanner.py
+++ b/.github/scripts/post_merge_followup_scanner.py
@@ -5,10 +5,8 @@ import argparse
 import hashlib
 import json
 import re
-import shutil
 import subprocess
 import sys
-import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any

--- a/cdb_agent_sdk/src/cdb_agent_sdk/main.py
+++ b/cdb_agent_sdk/src/cdb_agent_sdk/main.py
@@ -4,16 +4,6 @@ CDB Agent SDK - Main Entry Point
 Zentrale Einstiegspunkte für alle CDB Agenten.
 """
 
-import asyncio
-import sys
-
-from .agents import (
-    run_dataflow_observer,
-    run_determinism_inspector,
-    run_governance_auditor,
-    run_change_impact_analyst,
-)
-
 
 def main() -> None:
     """Zeigt verfügbare Agenten."""

--- a/cdb_agent_sdk/tests/test_agent.py
+++ b/cdb_agent_sdk/tests/test_agent.py
@@ -1,6 +1,5 @@
 """Tests for the Data Flow & Observability Engineer Agent."""
 
-import pytest
 from cdb_agent_sdk.agents.dataflow_observer import (
     DATAFLOW_OBSERVER_PROMPT,
     DATAFLOW_OBSERVER_TOOLS,

--- a/cdb_agent_sdk/tests/test_agents.py
+++ b/cdb_agent_sdk/tests/test_agents.py
@@ -1,7 +1,5 @@
 """Tests für die spezialisierten CDB Agenten."""
 
-import pytest
-
 from cdb_agent_sdk.agents.dataflow_observer import (
     DATAFLOW_OBSERVER_PROMPT,
     DATAFLOW_OBSERVER_TOOLS,

--- a/core/replay/dataset_provider.py
+++ b/core/replay/dataset_provider.py
@@ -31,7 +31,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
-from core.replay.dataset_spec import DatasetSpec, DatasetSpecError  # noqa: F401 — re-exported for caller convenience
+from core.replay.dataset_spec import DatasetSpec, DatasetSpecError as DatasetSpecError  # noqa: F401 — re-exported for caller convenience
 
 _REQUIRED_CANDLE_FIELDS: frozenset[str] = frozenset({"ts_ms", "high", "low", "close"})
 _ONE_MINUTE_MS: int = 60_000

--- a/core/replay/dataset_provider.py
+++ b/core/replay/dataset_provider.py
@@ -33,6 +33,8 @@ from typing import Protocol
 
 from core.replay.dataset_spec import DatasetSpec, DatasetSpecError as DatasetSpecError  # noqa: F401 — re-exported for caller convenience
 
+__all__ = ["DatasetSpec", "DatasetSpecError"]
+
 _REQUIRED_CANDLE_FIELDS: frozenset[str] = frozenset({"ts_ms", "high", "low", "close"})
 _ONE_MINUTE_MS: int = 60_000
 

--- a/infrastructure/scripts/generate_shadow_digest.py
+++ b/infrastructure/scripts/generate_shadow_digest.py
@@ -16,7 +16,7 @@ import json
 import logging
 import subprocess
 import sys
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 

--- a/infrastructure/scripts/lr040_soak_gate_eval.py
+++ b/infrastructure/scripts/lr040_soak_gate_eval.py
@@ -136,7 +136,6 @@ def evaluate_lr040_soak(artifact_dir: Path) -> dict:
         duration = timestamps[-1] - timestamps[0]
         duration_hours = duration.total_seconds() / 3600
     else:
-        duration = timedelta(0)
         duration_hours = 0.0
 
     # --- Restart / failure / inconclusive checks ---

--- a/infrastructure/scripts/reconcile_positions.py
+++ b/infrastructure/scripts/reconcile_positions.py
@@ -26,7 +26,7 @@ import sys
 import logging
 from datetime import datetime
 from decimal import Decimal
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List
 
 import psycopg2
 from psycopg2.extras import RealDictCursor

--- a/infrastructure/scripts/verify-graphiti.py
+++ b/infrastructure/scripts/verify-graphiti.py
@@ -14,8 +14,6 @@ import json
 import sys
 import urllib.request
 import urllib.error
-from typing import Optional
-
 
 def check_health_endpoint(host: str, port: int, timeout: int) -> dict:
     """Check if Graphiti health endpoint responds."""

--- a/infrastructure/scripts/verify-ollama.py
+++ b/infrastructure/scripts/verify-ollama.py
@@ -15,9 +15,6 @@ import json
 import sys
 import urllib.request
 import urllib.error
-from typing import Optional
-
-
 REQUIRED_MODELS = [
     "nomic-embed-text",
     "deepseek-r1:7b",

--- a/infrastructure/scripts/verify-persistence.py
+++ b/infrastructure/scripts/verify-persistence.py
@@ -28,7 +28,7 @@ import sys
 import time
 import urllib.request
 import urllib.error
-from typing import Optional, Tuple
+from typing import Tuple
 
 
 # Configuration

--- a/scripts/drills/lr041_redis_postgres_failure_runner.py
+++ b/scripts/drills/lr041_redis_postgres_failure_runner.py
@@ -7,7 +7,6 @@ import hashlib
 import json
 import logging
 import subprocess
-import sys
 import time
 import urllib.error
 import urllib.request

--- a/scripts/validate_paper_market_data_provenance.py
+++ b/scripts/validate_paper_market_data_provenance.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path

--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -94,7 +94,6 @@ stats = {
 }
 
 # Thread-safe sets with lock (Fix for Issue #306)
-_orders_lock = Lock()
 bot_shutdown_active = False
 blocked_strategy_ids = set()
 blocked_bot_ids = set()

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -356,8 +356,6 @@ def _parse_db_dataset_window(db_dataset_window: str) -> tuple[int, int]:
 # ---------------------------------------------------------------------------
 # Scenario override mapping (fail-closed)
 # ---------------------------------------------------------------------------
-_SCENARIO_GROUP_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
-
 # Mapping: scenario override key -> ExecutionSimulator config field
 _SCNARIO_OVERRIDE_KEY_TO_SIMULATOR: dict[str, str] = {
     "execution_slippage_bps": "BASE_SLIPPAGE_BPS",

--- a/tests/e2e/test_smoke_pipeline.py
+++ b/tests/e2e/test_smoke_pipeline.py
@@ -88,9 +88,9 @@ def test_tc_003_risk_guard_test_balance_fallback():
     """TC-003: Risk uses test balance when live balance is disabled."""
     test_balance = Decimal("1000")
     use_live_balance = False
-    live_balance = None
+    _live_balance = None
 
-    selected_balance = test_balance if not use_live_balance else live_balance
+    selected_balance = test_balance if not use_live_balance else _live_balance
     assert selected_balance == test_balance
 
     signal = {

--- a/tests/e2e/test_smoke_pipeline.py
+++ b/tests/e2e/test_smoke_pipeline.py
@@ -88,9 +88,8 @@ def test_tc_003_risk_guard_test_balance_fallback():
     """TC-003: Risk uses test balance when live balance is disabled."""
     test_balance = Decimal("1000")
     use_live_balance = False
-    _live_balance = None
 
-    selected_balance = test_balance if not use_live_balance else _live_balance
+    selected_balance = test_balance if not use_live_balance else None
     assert selected_balance == test_balance
 
     signal = {

--- a/tests/fixtures/db_fixtures.py
+++ b/tests/fixtures/db_fixtures.py
@@ -30,6 +30,7 @@ def get_db_connection():
         )
     except psycopg2.OperationalError as exc:
         pytest.skip(f"Postgres not available for integration tests: {exc}")
+        return None  # unreachable — pytest.skip() always raises
 
 
 def execute_sql_file(conn, sql_file_path: Path):

--- a/tests/fixtures/surrealdb/context_graph/sample_module.py
+++ b/tests/fixtures/surrealdb/context_graph/sample_module.py
@@ -2,11 +2,6 @@
 
 from __future__ import annotations
 
-import os
-import json
-from core.utils.clock import utcnow
-from services.risk.models import RiskModel
-
 CONSTANT = 42
 
 

--- a/tests/performance/test_baseline_measurements.py
+++ b/tests/performance/test_baseline_measurements.py
@@ -179,9 +179,6 @@ class TestLatencyBaselines:
         require_perf_run()
 
         def full_pipeline():
-            # Step 1: Market data
-            _market_data = {"symbol": "BTCUSDT", "price": 50000.0}
-
             # Step 3: Risk approval
             approved = True
 

--- a/tests/performance/test_baseline_measurements.py
+++ b/tests/performance/test_baseline_measurements.py
@@ -180,7 +180,7 @@ class TestLatencyBaselines:
 
         def full_pipeline():
             # Step 1: Market data
-            market_data = {"symbol": "BTCUSDT", "price": 50000.0}
+            _market_data = {"symbol": "BTCUSDT", "price": 50000.0}
 
             # Step 3: Risk approval
             approved = True

--- a/tests/unit/db_writer/test_service.py
+++ b/tests/unit/db_writer/test_service.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 
 try:
-    import prometheus_client  # noqa: F401
+    __import__("prometheus_client")  # noqa: F401 — side-effect import: availability check
 except ImportError:
     _dummy_metrics = []
 

--- a/tests/unit/replay/test_dataset_provider.py
+++ b/tests/unit/replay/test_dataset_provider.py
@@ -555,7 +555,7 @@ def test_db_backed_missing_required_field_raises() -> None:
     rows = _make_db_rows(14, _DB_WARMUP_START_MS)
     # Drop 'close' (index 4) from row 5 by returning only 6 columns
     bad_row = rows[5][:4] + rows[5][5:]  # skip index 4 (close)
-    rows = rows[:5] + [bad_row] + rows[6:]
+    _rows = rows[:5] + [bad_row] + rows[6:]
     spec = _make_db_spec()
     # The mapping in load() uses positional indices, so missing column causes IndexError
     # which is caught by the try/except around cursor.execute/fetchall —

--- a/tests/unit/replay/test_dataset_provider.py
+++ b/tests/unit/replay/test_dataset_provider.py
@@ -552,10 +552,6 @@ def test_db_backed_cadence_violation_raises() -> None:
 @pytest.mark.unit
 def test_db_backed_missing_required_field_raises() -> None:
     """Row missing a required key → DatasetLoadError (field guard in validator)."""
-    rows = _make_db_rows(14, _DB_WARMUP_START_MS)
-    # Drop 'close' (index 4) from row 5 by returning only 6 columns
-    bad_row = rows[5][:4] + rows[5][5:]  # skip index 4 (close)
-    _rows = rows[:5] + [bad_row] + rows[6:]
     spec = _make_db_spec()
     # The mapping in load() uses positional indices, so missing column causes IndexError
     # which is caught by the try/except around cursor.execute/fetchall —

--- a/tests/unit/replay/test_lr021_export_redis.py
+++ b/tests/unit/replay/test_lr021_export_redis.py
@@ -565,7 +565,7 @@ class TestEdgeCases:
     def test_bytes_decoded(self):
         """Redis entries with bytes keys/values are decoded correctly."""
         env = _make_envelope_json()
-        entry = ("1-0", {b"envelope": json.dumps(env).encode()})
+        _entry = ("1-0", {b"envelope": json.dumps(env).encode()})
 
         # parse_stream_entry expects str fields; iter_stream_entries
         # handles decoding. Test parse directly with str.

--- a/tests/unit/replay/test_lr021_export_redis.py
+++ b/tests/unit/replay/test_lr021_export_redis.py
@@ -565,7 +565,6 @@ class TestEdgeCases:
     def test_bytes_decoded(self):
         """Redis entries with bytes keys/values are decoded correctly."""
         env = _make_envelope_json()
-        _entry = ("1-0", {b"envelope": json.dumps(env).encode()})
 
         # parse_stream_entry expects str fields; iter_stream_entries
         # handles decoding. Test parse directly with str.

--- a/tests/unit/replay/test_replay_report_builder.py
+++ b/tests/unit/replay/test_replay_report_builder.py
@@ -625,7 +625,6 @@ class TestWriteManagementReport:
         # Use a path that is a file (not a dir) so mkdir fails.
         blocker = tmp_path / "blocker"
         blocker.write_text("block")
-        _target = blocker / "management_report.md"
         with pytest.raises(ReplayReportBuilderError, match="Failed to write management report"):
             write_management_report(report, blocker)
 

--- a/tests/unit/replay/test_replay_report_builder.py
+++ b/tests/unit/replay/test_replay_report_builder.py
@@ -625,7 +625,7 @@ class TestWriteManagementReport:
         # Use a path that is a file (not a dir) so mkdir fails.
         blocker = tmp_path / "blocker"
         blocker.write_text("block")
-        target = blocker / "management_report.md"
+        _target = blocker / "management_report.md"
         with pytest.raises(ReplayReportBuilderError, match="Failed to write management report"):
             write_management_report(report, blocker)
 

--- a/tests/unit/risk/test_contract_enforcement.py
+++ b/tests/unit/risk/test_contract_enforcement.py
@@ -381,7 +381,7 @@ def test_kill_switch_inactive_does_not_block(mock_redis, mock_postgres):
     ):
         # Signal will likely be blocked by decide_trade (missing market_state etc.)
         # but it must NOT be blocked by kill-switch
-        result = manager.process_signal(signal)
+        manager.process_signal(signal)
 
     # We don't check if order was created (depends on market_state etc.)
     # We just verify kill-switch did not raise or return early

--- a/tests/unit/risk/test_service.py
+++ b/tests/unit/risk/test_service.py
@@ -456,7 +456,7 @@ def test_proactive_unwind_no_trigger_when_no_open_positions(mock_redis, mock_pos
                 ),
                 patch.object(manager, "_emit_risk_event", MagicMock()),
             ):
-                order = manager.process_signal(signal)
+                manager.process_signal(signal)
 
             # Verify: BUY might be blocked by other checks, but no unwind triggered
             manager.send_order.assert_not_called()

--- a/tests/unit/scripts/test_backlog_curation.py
+++ b/tests/unit/scripts/test_backlog_curation.py
@@ -382,6 +382,6 @@ def test_extract_explicit_repo_paths_adversarial_many_slashes() -> None:
 
     adversarial = "a" + "/" * 100 + "b" * 100 + ".txt"
     start = time.time()
-    result = backlog_curation.extract_explicit_repo_paths(adversarial)
+    backlog_curation.extract_explicit_repo_paths(adversarial)
     elapsed = time.time() - start
     assert elapsed < 1.0, f"Path extraction took {elapsed}s (should complete in <1s)"

--- a/tests/unit/scripts/test_dual_write_evidence_gate.py
+++ b/tests/unit/scripts/test_dual_write_evidence_gate.py
@@ -289,7 +289,7 @@ def _make_mock_redis(symbol_map: dict[str, tuple[str | None, str | None]]) -> Ma
     mock = MagicMock()
 
     def keys(pattern: str) -> list[str]:
-        prefix = pattern.rstrip("*")
+        _prefix = pattern.rstrip("*")
         return [f"{CANDLES_PREFIX}:{sym}" for sym in symbol_map]
 
     def get(key: str) -> str | None:

--- a/tests/unit/scripts/test_dual_write_evidence_gate.py
+++ b/tests/unit/scripts/test_dual_write_evidence_gate.py
@@ -289,7 +289,6 @@ def _make_mock_redis(symbol_map: dict[str, tuple[str | None, str | None]]) -> Ma
     mock = MagicMock()
 
     def keys(pattern: str) -> list[str]:
-        _prefix = pattern.rstrip("*")
         return [f"{CANDLES_PREFIX}:{sym}" for sym in symbol_map]
 
     def get(key: str) -> str | None:

--- a/tests/unit/scripts/test_lr040_soak_gate_eval.py
+++ b/tests/unit/scripts/test_lr040_soak_gate_eval.py
@@ -16,7 +16,6 @@ def _build_hourly_log(hours: int = 73) -> str:
     """Generate hourly_checks.log spanning ``hours`` hours."""
     lines = []
     for h in range(hours):
-        _day_offset = h // 24
         hour_of_day = h % 24
         lines.append(
             f"2026-03-08 {hour_of_day:02d}:00:00 UTC - "

--- a/tests/unit/scripts/test_lr040_soak_gate_eval.py
+++ b/tests/unit/scripts/test_lr040_soak_gate_eval.py
@@ -16,7 +16,7 @@ def _build_hourly_log(hours: int = 73) -> str:
     """Generate hourly_checks.log spanning ``hours`` hours."""
     lines = []
     for h in range(hours):
-        day_offset = h // 24
+        _day_offset = h // 24
         hour_of_day = h % 24
         lines.append(
             f"2026-03-08 {hour_of_day:02d}:00:00 UTC - "

--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -301,7 +301,7 @@ class TestDefensiveSchemaCopies:
         tools = bridge.list_tools()
 
         caller_schema = tools[0]["inputSchema"]
-        original_properties = caller_schema.get("properties", {}).copy()
+        _original_properties = caller_schema.get("properties", {}).copy()
 
         caller_schema["properties"]["caller_added_field"] = {"type": "string"}
 
@@ -2091,7 +2091,7 @@ class TestContextStopResolverHandler:
 
         original = ["S1: scope ambiguous", "S4: no evidence"]
         before = list(original)
-        _result = resolve_stop_conditions(stop_conditions=original)
+        resolve_stop_conditions(stop_conditions=original)
         assert original == before, (
             f"Input list was mutated: {before} -> {original}"
         )
@@ -2391,7 +2391,7 @@ class TestContextRequiredReadsHandler:
             "context.required_reads",
             {"task_scope": "Inspect code.", "target_issue": None, "operation_mode": "read_only"},
         )
-        paths = {r["path"] for r in result["resolved_reads"]}
+        _paths = {r["path"] for r in result["resolved_reads"]}
         # DELIVERY_APPROVED.yaml is only added for write modes
         delivery_entries = [
             r for r in result["resolved_reads"]

--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -301,7 +301,6 @@ class TestDefensiveSchemaCopies:
         tools = bridge.list_tools()
 
         caller_schema = tools[0]["inputSchema"]
-        _original_properties = caller_schema.get("properties", {}).copy()
 
         caller_schema["properties"]["caller_added_field"] = {"type": "string"}
 
@@ -2391,7 +2390,6 @@ class TestContextRequiredReadsHandler:
             "context.required_reads",
             {"task_scope": "Inspect code.", "target_issue": None, "operation_mode": "read_only"},
         )
-        _paths = {r["path"] for r in result["resolved_reads"]}
         # DELIVERY_APPROVED.yaml is only added for write modes
         delivery_entries = [
             r for r in result["resolved_reads"]

--- a/tests/unit/validation/test_replay_reporter.py
+++ b/tests/unit/validation/test_replay_reporter.py
@@ -48,7 +48,6 @@ from services.validation.replay_reporter import (
 
 _VALID_RUN_ID = "replay-test-abc123def456"
 _VALID_COMMIT = "abc123def456"
-_HASH_64 = "a" * 64
 
 
 def _make_run_spec(**overrides: Any) -> ReplayRunSpec:
@@ -285,7 +284,7 @@ class TestDeterminism:
         """Canonical report dict contains no timestamp fields derived from wall-clock."""
         reporter = ReplayReporter()
         d = reporter.build_report_dict(_make_valid_report_input(), [])
-        canonical_str = canonical_json_dumps(d)
+        _canonical_str = canonical_json_dumps(d)
         # gate_result should not be present when no gate_evaluator and no gate_result in input
         assert "gate_result" not in d
         # The report should not contain "timestamp" anywhere at top level

--- a/tests/unit/validation/test_replay_reporter.py
+++ b/tests/unit/validation/test_replay_reporter.py
@@ -284,7 +284,6 @@ class TestDeterminism:
         """Canonical report dict contains no timestamp fields derived from wall-clock."""
         reporter = ReplayReporter()
         d = reporter.build_report_dict(_make_valid_report_input(), [])
-        _canonical_str = canonical_json_dumps(d)
         # gate_result should not be present when no gate_evaluator and no gate_result in input
         assert "gate_result" not in d
         # The report should not contain "timestamp" anywhere at top level

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -47,11 +47,6 @@ def context_search_handler(**kwargs) -> dict[str, Any]:
     if not isinstance(limit, int) or limit <= 0:
         limit = 10
 
-    # Validate filters
-    filters = kwargs.get("filters", {})
-    if not isinstance(filters, dict):
-        filters = {}
-
     # Use mocked NoopQueryAdapter (no live DB/network)
     from tools.surrealdb.context_query import NoopQueryAdapter
 
@@ -558,7 +553,6 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
     """
     # --- Input extraction ---
     task_scope = kwargs.get("task_scope")
-    target_issue = kwargs.get("target_issue")
     target_paths = kwargs.get("target_paths", [])
     operation_mode = kwargs.get("operation_mode", "")
     context_package_ref = kwargs.get("context_package_ref")
@@ -569,8 +563,6 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
     uncertainties_in = kwargs.get("uncertainties")
 
     # --- Normalize ---
-    if not isinstance(target_issue, str):
-        target_issue = None
     if not isinstance(context_package_ref, str):
         context_package_ref = None
     if not isinstance(target_paths, list):

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -303,7 +303,7 @@ def _build_evidence_ref_where(params: Mapping[str, Any]) -> str:
                 if 0.0 <= conf <= 1.0:
                     return f"WHERE confidence >= {conf}"
             except (TypeError, ValueError):
-                pass
+                pass  # invalid or non-numeric confidence value; skip
     return ""
 
 

--- a/tools/paper_trading/email_alerter.py
+++ b/tools/paper_trading/email_alerter.py
@@ -11,7 +11,6 @@ import os
 import smtplib
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
-from datetime import datetime
 import logging
 
 from core.utils.clock import utcnow

--- a/tools/paper_trading/service.py
+++ b/tools/paper_trading/service.py
@@ -20,7 +20,7 @@ import json
 import logging
 import time
 import signal
-from datetime import datetime, timedelta
+from datetime import timedelta
 from pathlib import Path
 import threading
 

--- a/tools/research/portfolio_manager.py
+++ b/tools/research/portfolio_manager.py
@@ -8,7 +8,6 @@ Manages portfolio state in Redis and persists to PostgreSQL
 import json
 import logging
 from typing import Dict, Optional
-from datetime import datetime
 
 import redis
 

--- a/tools/surrealdb/context_impact_radar.py
+++ b/tools/surrealdb/context_impact_radar.py
@@ -59,11 +59,6 @@ _MEDIUM_DIRS: tuple[str, ...] = (
     "knowledge/contracts/",
 )
 
-_LOW_DIRS: tuple[str, ...] = (
-    "docs/",
-    ".github/",
-)
-
 _HARD_DIRS: tuple[str, ...] = (
     "core/",
     "services/",

--- a/tools/surrealdb/context_required_reads.py
+++ b/tools/surrealdb/context_required_reads.py
@@ -20,7 +20,6 @@ Design intent:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 

--- a/tools/surrealdb/context_self_explanation.py
+++ b/tools/surrealdb/context_self_explanation.py
@@ -23,7 +23,7 @@ Design intent:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 _SCHEMA_VERSION = "self-explanation/v1"

--- a/tools/surrealdb/context_stop_resolver.py
+++ b/tools/surrealdb/context_stop_resolver.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import re
 
-from dataclasses import dataclass, field
 from typing import Any
 
 _STOP_RULE_MAP: dict[str, tuple[str, str]] = {
@@ -70,22 +69,6 @@ _LIVE_KEYWORDS = (
 _LIVE_BOUNDARY_PATTERNS = (
     r"\blive\b",
 )
-
-_VALID_TYPES = frozenset({
-    "missing_context",
-    "missing_evidence",
-    "scope_drift_risk",
-    "runtime_surface_touched",
-    "trading_surface_touched",
-    "write_requires_human_go",
-    "stale_context",
-    "contradiction_risk",
-    "forbidden_path",
-    "secrets_risk",
-})
-
-_VALID_SEVERITIES = frozenset({"info", "warning", "blocking"})
-
 
 _REQUIRED_ACTIONS: dict[str, str] = {
     "missing_context": (


### PR DESCRIPTION
## Summary

Slice 1 for #2289.

Cleans up CodeQL note/code-quality findings only:
- unused imports
- unused local variables
- unused global variables
- empty except comment
- explicit return for mixed-return fixture path

No Trivy, Dockerfile, workflow, SARIF policy, alert dismissal, or issue automation changes.

## Scope

- 40 Python files changed
- 52 CodeQL note findings addressed
- 24 insertions / 89 deletions
- no behavioral refactor intended

## Validation

- `ruff check .` passed
- `pytest -q -m unit` passed: 2848 passed, 11 skipped
- `git diff --check` passed

## Governance

Refs #2289.

This PR does not:
- close #2289
- dismiss alerts
- modify security-scan workflows
- modify Dockerfiles
- alter LR/live-readiness state
- enable live trading or real-money operations