### PR TITLE
fix(security): remove residual CodeQL unused import for #2289

### DIFF
--- a/infrastructure/scripts/lr040_soak_gate_eval.py
+++ b/infrastructure/scripts/lr040_soak_gate_eval.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import json
 import re
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 
 REQUIRED_DURATION_HOURS = 72


### PR DESCRIPTION
## Summary

Follow-up residual fix for #2289 after PR #2503.

Removes the final open CodeQL note finding:
- \py/unused-import\
- \infrastructure/scripts/lr040_soak_gate_eval.py\
- unused \	imedelta\ import

## Scope

- one file
- one-line import cleanup
- no behavioral change

## Validation

- \uff check infrastructure/scripts/lr040_soak_gate_eval.py\ passed
- \git diff --check\ passed
- \pytest -q -k lr040\: 35 passed

## Governance

Refs #2289.

This PR does not:
- close #2289
- dismiss alerts
- modify Trivy/Docker/workflows
- modify LR/live-readiness state
- enable live trading or real-money operations