### PR TITLE
fix(security): upgrade pip in Trivy-scanned service images for #2289

### DIFF
--- a/services/allocation/Dockerfile
+++ b/services/allocation/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.11-slim-trixie@sha256:6d85378d88a19cd4d76079817532d62232be95757cb4
 WORKDIR /app
 
 # Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
-RUN pip install --upgrade pip==25.3
+RUN pip install --upgrade pip==26.1
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 
 # System-Dependencies

--- a/services/db_writer/Dockerfile
+++ b/services/db_writer/Dockerfile
@@ -6,7 +6,7 @@ FROM python:3.11-slim-trixie@sha256:6d85378d88a19cd4d76079817532d62232be95757cb4
 WORKDIR /app
 
 # Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
-RUN pip install --upgrade pip==25.3
+RUN pip install --upgrade pip==26.1
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 
 # Install dependencies

--- a/services/execution/Dockerfile
+++ b/services/execution/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
 # Python Requirements
 COPY services/execution/requirements.txt ./
 RUN python -m venv /venv \
-    && /venv/bin/pip install --upgrade pip==25.3 \
+    && /venv/bin/pip install --upgrade pip==26.1 \
     && /venv/bin/pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2 \
     && /venv/bin/pip install --no-cache-dir -r requirements.txt
 
@@ -35,6 +35,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
+RUN pip install --upgrade pip==26.1
 
 COPY --from=build /venv /venv
 ENV PATH="/venv/bin:$PATH"

--- a/services/market/Dockerfile
+++ b/services/market/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
-RUN pip install --upgrade pip==25.3
+RUN pip install --upgrade pip==26.1
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 
 COPY services/market/requirements.txt .

--- a/services/regime/Dockerfile
+++ b/services/regime/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.11-slim-trixie@sha256:6d85378d88a19cd4d76079817532d62232be95757cb4
 WORKDIR /app
 
 # Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
-RUN pip install --upgrade pip==25.3
+RUN pip install --upgrade pip==26.1
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 
 # System-Dependencies

--- a/services/risk/Dockerfile
+++ b/services/risk/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
     curl \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip==25.3
+RUN pip install --upgrade pip==26.1
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 COPY services/risk/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/services/signal/Dockerfile
+++ b/services/signal/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Python deps
-RUN pip install --upgrade pip==25.3
+RUN pip install --upgrade pip==26.1
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 COPY services/signal/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/services/ws/Dockerfile
+++ b/services/ws/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim-trixie@sha256:6d85378d88a19cd4d76079817532d62232be95757cb4
 WORKDIR /app
 
 # Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
-RUN pip install --upgrade pip==25.3
+RUN pip install --upgrade pip==26.1
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 
 # System dependencies


### PR DESCRIPTION
## Summary

Slice 2 for #2289.

Upgrades pip in the Trivy-scanned custom service Dockerfiles:
- `pip==25.3` → `pip==26.1`
- adds a runtime-stage system-pip upgrade in `services/execution/Dockerfile`

This targets the pip-related Trivy cluster only.

## Scope

Changed files:
- `services/ws/Dockerfile`
- `services/risk/Dockerfile`
- `services/db_writer/Dockerfile`
- `services/market/Dockerfile`
- `services/signal/Dockerfile`
- `services/allocation/Dockerfile`
- `services/regime/Dockerfile`
- `services/execution/Dockerfile`

No changes to:
- base image tags or digests
- OS packages
- requirements files
- compose files
- workflows
- Trivy/SARIF policy
- Grafana/Prometheus/Postgres/Redis images
- live-readiness or runtime/deployment configuration

## Validation

Already run locally before PR:
- `git diff --check` passed
- `ruff check .` passed
- `pytest -q -m unit` passed: 2848 passed, 11 skipped
- all 8 scoped Docker image builds passed

No Docker/Compose/runtime commands were run during final review to protect the active soak run.

## Expected Alert Impact

Expected pip-related Trivy alerts:
- before: 7
- after: approximately 2

Expected closed:
- `CVE-2025-8869`
- `CVE-2026-6357`

Expected remaining:
- `CVE-2026-3219`, because no upstream fix is available.

## Soak Safety

This PR only changes Dockerfiles in git.

It does not:
- restart containers
- run Docker Compose
- deploy services
- modify running infrastructure
- alter live-readiness state
- enable live trading or real-money operations

Merging may trigger image builds/pushes in CI, but does not restart local soak containers.

## Governance

Refs #2289.

This PR does not close #2289.