### PR TITLE
fix(security): upgrade OS packages in service images for #2289

### DIFF
--- a/services/allocation/Dockerfile
+++ b/services/allocation/Dockerfile
@@ -4,6 +4,12 @@ FROM python:3.11-slim-trixie@sha256:e78299e55776ca065dcb769f80161f48465ad3520142
 
 WORKDIR /app
 
+# Security: upgrade OS packages with available Trixie security patches (#2289)
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
 RUN pip install --upgrade pip==26.1
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2

--- a/services/db_writer/Dockerfile
+++ b/services/db_writer/Dockerfile
@@ -5,6 +5,12 @@ FROM python:3.11-slim-trixie@sha256:e78299e55776ca065dcb769f80161f48465ad3520142
 
 WORKDIR /app
 
+# Security: upgrade OS packages with available Trixie security patches (#2289)
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
 RUN pip install --upgrade pip==26.1
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2

--- a/services/execution/Dockerfile
+++ b/services/execution/Dockerfile
@@ -7,6 +7,12 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+# Security: upgrade OS packages with available Trixie security patches (#2289)
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Build-Abhängigkeiten nur im Build-Stage
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -27,6 +33,12 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
 WORKDIR /app
+
+# Security: upgrade OS packages with available Trixie security patches (#2289)
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Runtime-Abhängigkeiten (kein build-essential/libpq-dev)
 RUN apt-get update \

--- a/services/market/Dockerfile
+++ b/services/market/Dockerfile
@@ -2,6 +2,12 @@ FROM python:3.11-slim-trixie@sha256:e78299e55776ca065dcb769f80161f48465ad3520142
 
 WORKDIR /app
 
+# Security: upgrade OS packages with available Trixie security patches (#2289)
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN apt-get update && apt-get install -y \
     curl \
   && rm -rf /var/lib/apt/lists/*

--- a/services/regime/Dockerfile
+++ b/services/regime/Dockerfile
@@ -4,6 +4,12 @@ FROM python:3.11-slim-trixie@sha256:e78299e55776ca065dcb769f80161f48465ad3520142
 
 WORKDIR /app
 
+# Security: upgrade OS packages with available Trixie security patches (#2289)
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
 RUN pip install --upgrade pip==26.1
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2

--- a/services/risk/Dockerfile
+++ b/services/risk/Dockerfile
@@ -2,6 +2,12 @@ FROM python:3.11-slim-trixie@sha256:e78299e55776ca065dcb769f80161f48465ad3520142
 
 WORKDIR /app
 
+# Security: upgrade OS packages with available Trixie security patches (#2289)
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN apt-get update && apt-get install -y \
     curl \
   && rm -rf /var/lib/apt/lists/*

--- a/services/signal/Dockerfile
+++ b/services/signal/Dockerfile
@@ -2,6 +2,12 @@ FROM python:3.11-slim-trixie@sha256:e78299e55776ca065dcb769f80161f48465ad3520142
 
 WORKDIR /app
 
+# Security: upgrade OS packages with available Trixie security patches (#2289)
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Base deps
 RUN apt-get update && apt-get install -y \
     curl \

--- a/services/ws/Dockerfile
+++ b/services/ws/Dockerfile
@@ -2,6 +2,12 @@ FROM python:3.11-slim-trixie@sha256:e78299e55776ca065dcb769f80161f48465ad3520142
 
 WORKDIR /app
 
+# Security: upgrade OS packages with available Trixie security patches (#2289)
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
 RUN pip install --upgrade pip==26.1
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2


### PR DESCRIPTION
## Summary

Slice 4 for #2289.

Adds a dedicated OS package upgrade layer to the Trivy-scanned custom service Dockerfiles:

```dockerfile
# Security: upgrade OS packages with available Trixie security patches (#2289)
RUN apt-get update \
    && apt-get upgrade -y \
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/*
```

This targets the fixable OS-package CVE cluster in the custom-service Trivy alerts.

## Motivation

Slice 3 refreshed the pinned `python:3.11-slim-trixie` digest but produced 0 alert reduction because the newer digest (2026-05-08) pre-dates the Debian security patches for the target packages. No newer amd64 digest is currently available (Docker Hub last updated 2026-05-13 for other architectures only).

The following packages have patched versions confirmed available in the Debian Trixie apt repository:

| Package | Installed | Fixed |
|---------|-----------|-------|
| `libudev1` | `257.9-1~deb13u1` | `257.13-1~deb13u1` |
| `libc6` | `2.41-12+deb13u2` | `2.41-12+deb13u3` |
| `libcap2` | `1:2.75-10+b8` | `1:2.75-10+deb13u1` |
| `sed` | `4.9-2` | `4.9-2+deb13u1` |

## Scope

Changed files:
- `services/ws/Dockerfile`
- `services/risk/Dockerfile`
- `services/signal/Dockerfile`
- `services/allocation/Dockerfile`
- `services/db_writer/Dockerfile`
- `services/market/Dockerfile`
- `services/regime/Dockerfile`
- `services/execution/Dockerfile`

Expected upgrade blocks:
- 9 total `apt-get upgrade -y` blocks
- `services/execution/Dockerfile` has both build-stage and runtime-stage blocks

No changes to:
- pip versions (remain `pip==26.1`)
- requirements files
- apt package installs (existing blocks unchanged)
- compose files
- workflows
- Trivy/SARIF policy
- base image digests (`sha256:e78299e5…` unchanged)
- Grafana/Prometheus/Redis/Postgres images
- runtime/deployment configuration

## Validation

Local validation before PR:
- `git diff --check` passed
- `apt-get upgrade -y` count: 9 (execution: 2, all others: 1 each)
- `ruff check .` passed
- `pytest -q -m unit` passed: 2848 passed, 11 skipped

No local Docker/Compose/runtime commands were run to protect the active soak run.

## Expected Alert Impact

Current open Code Scanning state before this slice:
- CodeQL: 0
- Trivy: 809
- Custom-service Trivy cluster: approximately 675
- Base-image Trivy cluster: approximately 134

Expected fixable alerts:
- `libudev1` CVEs: 64
- `libc6` CVEs: 48
- `libcap2` CVEs: 8
- `sed` CVEs: 8
- **Minimum: 128 alerts closed**

Expected result: Trivy custom-service cluster 675 → ~547, Trivy total 809 → ~681.

Upstream-blocked alerts (~547: curl, libcurl4t64, libgnutls30t64 etc.) have no fixed version available and are not addressed by this slice.

Exact impact is unknown until CI Security Scan rebuilds and uploads SARIF.

## Soak Safety

This PR only changes Dockerfile OS upgrade layers in git.

It does not:
- restart containers
- run Docker Compose
- deploy services
- modify running infrastructure
- alter live-readiness state
- enable live trading or real-money operations

Merging may trigger GitHub Actions image builds/pushes, but does not restart local soak containers.

## Governance

Refs #2289.

This PR does not close #2289.