### PR TITLE
fix(security): bump postgres and redis base images for #2513

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -39,9 +39,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - image: redis:7.4.8-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6
+          - image: redis:7.4.9-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
             scan_name: redis
-          - image: postgres:15.17-alpine@sha256:09e4f20b14ddb3dfe3a0c825b206032aaf8f28300ba2070c0b60fc1c10c6abc7
+          - image: postgres:15.18-alpine@sha256:df7bca0066e6f60cc3dd32faa70caddec20e2c22b58932f79498e5704b23854a
             scan_name: postgres
           - image: prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78
             scan_name: prometheus
@@ -251,8 +251,8 @@ jobs:
     strategy:
       matrix:
         image:
-          - redis:7.4.8-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6
-          - postgres:15.17-alpine@sha256:09e4f20b14ddb3dfe3a0c825b206032aaf8f28300ba2070c0b60fc1c10c6abc7
+          - redis:7.4.9-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
+          - postgres:15.18-alpine@sha256:df7bca0066e6f60cc3dd32faa70caddec20e2c22b58932f79498e5704b23854a
       fail-fast: false
 
     env:
@@ -411,6 +411,6 @@ jobs:
 #    - Re-scan after base image updates
 #
 # 4. For manual scans:
-#    docker scout cves redis:7.4.8-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6 --only-severities critical,high
-#    docker scout cves postgres:15.17-alpine --only-severities critical,high
+#    docker scout cves redis:7.4.9-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99 --only-severities critical,high
+#    docker scout cves postgres:15.18-alpine@sha256:df7bca0066e6f60cc3dd32faa70caddec20e2c22b58932f79498e5704b23854a --only-severities critical,high
 

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -13,7 +13,7 @@ name: ${STACK_NAME:-cdb}
 
 services:
   cdb_redis:
-    image: redis:7.4.8-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6
+    image: redis:7.4.9-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
     container_name: cdb_redis
     restart: unless-stopped
     volumes:
@@ -31,7 +31,7 @@ services:
       - cdb_network
 
   cdb_postgres:
-    image: postgres:15.17-alpine@sha256:09e4f20b14ddb3dfe3a0c825b206032aaf8f28300ba2070c0b60fc1c10c6abc7
+    image: postgres:15.18-alpine@sha256:df7bca0066e6f60cc3dd32faa70caddec20e2c22b58932f79498e5704b23854a
     container_name: cdb_postgres
     restart: unless-stopped
     environment:

--- a/infrastructure/compose/compose.blue.yml
+++ b/infrastructure/compose/compose.blue.yml
@@ -17,7 +17,7 @@ services:
   # ==================== DATA LAYER ====================
 
   cdb_postgres:
-    image: postgres:15.17-alpine@sha256:09e4f20b14ddb3dfe3a0c825b206032aaf8f28300ba2070c0b60fc1c10c6abc7
+    image: postgres:15.18-alpine@sha256:df7bca0066e6f60cc3dd32faa70caddec20e2c22b58932f79498e5704b23854a
     container_name: cdb_postgres
     restart: unless-stopped
     environment:
@@ -43,7 +43,7 @@ services:
       - cdb_network
 
   cdb_redis:
-    image: redis:7.4.8-alpine@sha256:7aec734b2bb298a1d769fd8729f13b8514a41bf90fcdd1f38ec52267fbaa8ee6
+    image: redis:7.4.9-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
     container_name: cdb_redis
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary

Slice 6C for #2513.

Bumps the pinned Postgres and Redis base images used by compose and Security Scan:

- `postgres:15.17-alpine` → `postgres:15.18-alpine`
- `redis:7.4.8-alpine` → `redis:7.4.9-alpine`

All image references remain pinned with `@sha256:` digests.

## Scope

Changed files:
- `infrastructure/compose/base.yml`
- `infrastructure/compose/compose.blue.yml`
- `.github/workflows/security-scan.yml`

No changes to:
- Grafana image refs
- Prometheus image refs
- custom-service Dockerfiles
- requirements
- SARIF policy / upload behavior
- runtime or deployment config beyond Postgres/Redis image refs

## Digest Evidence

Digests were resolved read-only via Docker Hub manifest API.

Postgres:
- `postgres:15.18-alpine@sha256:df7bca0066e6f60cc3dd32faa70caddec20e2c22b58932f79498e5704b23854a`

Redis:
- `redis:7.4.9-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99`

No `docker pull`, Docker daemon contact, local build, or compose command was used.

## Validation

Local/static validation:
- `git diff --check` passed
- old Postgres tag `postgres:15.17-alpine` removed
- old Redis tag `redis:7.4.8-alpine` removed
- new Postgres tag+digest appears consistently in 4 refs
- new Redis tag+digest appears consistently in 4 refs
- no unpinned Postgres/Redis tags
- Grafana/Prometheus refs unchanged
- Security Scan policy/upload behavior unchanged

## Expected Alert Impact

Before this slice:
- CodeQL open: 0
- Custom-service Trivy open: 0
- Base-image Trivy open: 134

Expected after Security Scan:
- `trivy-base-postgres`: 9 → 0
- `trivy-base-redis`: 1 → 0
- Trivy total: 134 → approximately 124

Exact impact depends on GitHub Actions Security Scan and SARIF upload.

## Soak Safety

This PR only changes pinned image refs in git.

It does not:
- restart containers
- run Docker Compose
- pull local images
- deploy services
- modify running infrastructure
- alter live-readiness state
- enable live trading or real-money operations

Merging may trigger GitHub Actions scans/builds remotely, but does not restart local soak containers.

Local deploy/pull/restart remains forbidden until the active soak run has ended.

## Governance

Refs #2513.

This PR does not close #2513.