### PR TITLE
fix(security): bump prometheus base image

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -43,7 +43,7 @@ jobs:
             scan_name: redis
           - image: postgres:15.18-alpine@sha256:df7bca0066e6f60cc3dd32faa70caddec20e2c22b58932f79498e5704b23854a
             scan_name: postgres
-          - image: prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78
+          - image: prom/prometheus:v3.11.3@sha256:e4254400b85610324913f0dc4acf92603d9984e7519414c5a12811aa6146acc3
             scan_name: prometheus
           - image: grafana/grafana:11.6.14-ubuntu@sha256:d39d4352aad1df307dc4affa40aeadb1d8eaf34401914b269d70da1abf3973a5
             scan_name: grafana

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -56,7 +56,7 @@ services:
       - cdb_network
 
   cdb_prometheus:
-    image: prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78
+    image: prom/prometheus:v3.11.3@sha256:e4254400b85610324913f0dc4acf92603d9984e7519414c5a12811aa6146acc3
     container_name: cdb_prometheus
     restart: unless-stopped
     volumes:

--- a/infrastructure/compose/compose.prometheus-v3.yml
+++ b/infrastructure/compose/compose.prometheus-v3.yml
@@ -4,11 +4,11 @@
 #
 # Scope:
 # - Adds an optional parallel Prometheus v3 canary service
-# - Does not change default runtime service cdb_prometheus (v3.11.2)
+# - Does not change default runtime service cdb_prometheus (v3.11.3)
 
 services:
   cdb_prometheus_v3:
-    image: prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78
+    image: prom/prometheus:v3.11.3@sha256:e4254400b85610324913f0dc4acf92603d9984e7519414c5a12811aa6146acc3
     container_name: cdb_prometheus_v3
     restart: unless-stopped
     profiles:

--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -93,7 +93,7 @@ services:
   # ==================== MONITORING ====================
 
   cdb_prometheus:
-    image: prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78
+    image: prom/prometheus:v3.11.3@sha256:e4254400b85610324913f0dc4acf92603d9984e7519414c5a12811aa6146acc3
     container_name: cdb_prometheus
     restart: unless-stopped
     volumes:

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -100,7 +100,7 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 
 | Service | Container | Image | Port | Status | Funktion |
 |---------|-----------|-------|------|--------|----------|
-| **Prometheus** | cdb_prometheus | prom/prometheus:v3.11.2 | 19090→9090 | **AKTIV** | Metrics Collection |
+| **Prometheus** | cdb_prometheus | prom/prometheus:v3.11.3 | 19090→9090 | **AKTIV** | Metrics Collection |
 | **Grafana** | cdb_grafana | grafana/grafana:11.6.14-ubuntu@sha256:d39d4352 | 3000 | **AKTIV** | Dashboards |
 | **Postgres Exporter** | cdb_postgres_exporter | prometheuscommunity/postgres-exporter | 9187 | **AKTIV** | PG Metrics; DSN-Wiring ueber `postgres_password` Secret + `PGPASSWORD`, `DATA_SOURCE_NAME` wird zur Laufzeit aus `POSTGRES_USER`/`POSTGRES_DB` und Host/Port zusammengesetzt |
 | **Redis Exporter** | cdb_redis_exporter | bitnami/redis-exporter | 9121 | **AKTIV** | Redis Metrics |


### PR DESCRIPTION
## Summary

Slice 6B.

Bumps the pinned Prometheus base image used by compose and Security Scan:

- `prom/prometheus:v3.11.2` → `prom/prometheus:v3.11.3`

All image references remain pinned with `@sha256:` digests.

Refs #2513.

## Scope

Changed files:
- `infrastructure/compose/base.yml`
- `infrastructure/compose/compose.red.yml`
- `infrastructure/compose/compose.prometheus-v3.yml`
- `.github/workflows/security-scan.yml`

No changes to:
- Grafana image refs
- Postgres image refs
- Redis image refs
- custom-service Dockerfiles
- requirements
- SARIF policy / upload behavior
- runtime or deployment config beyond Prometheus image refs

## Digest Evidence

Digest was resolved read-only via Docker Hub Registry API.

Prometheus:
- `prom/prometheus:v3.11.3@sha256:e4254400b85610324913f0dc4acf92603d9984e7519414c5a12811aa6146acc3`

No `docker pull`, Docker daemon contact, local build, or compose command was used.

## Validation

Local/static validation:
- `git diff --check` passed
- old Prometheus tag `prom/prometheus:v3.11.2` removed from affected files
- new Prometheus tag+digest appears consistently in all 4 affected files
- no unpinned Prometheus refs
- Grafana/Postgres/Redis refs unchanged
- Security Scan policy/upload behavior unchanged
- Commit title contains no issue number and no auto-close keyword

## Expected Alert Impact

Before this slice:
- CodeQL open: 0
- Custom-service Trivy open: 0
- Base-image Trivy open: 132
- `trivy-base-prometheus`: 23

Expected after Security Scan:
- `trivy-base-prometheus`: up to 23 alerts closed
- Trivy total: 132 → approximately 109

Exact impact depends on GitHub Actions Security Scan and SARIF upload.

## Soak Safety

This PR only changes pinned Prometheus image refs in git.

It does not:
- restart containers
- run Docker Compose
- pull local images
- deploy services
- modify running infrastructure
- alter live-readiness state
- enable live trading or real-money operations

Merging may trigger GitHub Actions scans/builds remotely, but does not restart local soak containers.

Local deploy/pull/restart remains forbidden until the active soak run has ended.