### PR TITLE
fix(security): bump grafana base image

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -45,7 +45,7 @@ jobs:
             scan_name: postgres
           - image: prom/prometheus:v3.11.3@sha256:e4254400b85610324913f0dc4acf92603d9984e7519414c5a12811aa6146acc3
             scan_name: prometheus
-          - image: grafana/grafana:11.6.14-ubuntu@sha256:d39d4352aad1df307dc4affa40aeadb1d8eaf34401914b269d70da1abf3973a5
+          - image: grafana/grafana:11.6.14-security-04-ubuntu@sha256:adeac4e7218222d9306f33ffe7e6f644c8ab7047a4f82f3fef60cdfbd71051d0
             scan_name: grafana
       fail-fast: false
 

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -75,7 +75,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:11.6.14-ubuntu@sha256:d39d4352aad1df307dc4affa40aeadb1d8eaf34401914b269d70da1abf3973a5
+    image: grafana/grafana:11.6.14-security-04-ubuntu@sha256:adeac4e7218222d9306f33ffe7e6f644c8ab7047a4f82f3fef60cdfbd71051d0
     container_name: cdb_grafana
     restart: unless-stopped
     environment:

--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -114,7 +114,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:11.6.14-ubuntu@sha256:d39d4352aad1df307dc4affa40aeadb1d8eaf34401914b269d70da1abf3973a5
+    image: grafana/grafana:11.6.14-security-04-ubuntu@sha256:adeac4e7218222d9306f33ffe7e6f644c8ab7047a4f82f3fef60cdfbd71051d0
     container_name: cdb_grafana
     restart: unless-stopped
     environment:

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -101,7 +101,7 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 | Service | Container | Image | Port | Status | Funktion |
 |---------|-----------|-------|------|--------|----------|
 | **Prometheus** | cdb_prometheus | prom/prometheus:v3.11.3 | 19090→9090 | **AKTIV** | Metrics Collection |
-| **Grafana** | cdb_grafana | grafana/grafana:11.6.14-ubuntu@sha256:d39d4352 | 3000 | **AKTIV** | Dashboards |
+| **Grafana** | cdb_grafana | grafana/grafana:11.6.14-security-04-ubuntu@sha256:adeac4e7 | 3000 | **AKTIV** | Dashboards |
 | **Postgres Exporter** | cdb_postgres_exporter | prometheuscommunity/postgres-exporter | 9187 | **AKTIV** | PG Metrics; DSN-Wiring ueber `postgres_password` Secret + `PGPASSWORD`, `DATA_SOURCE_NAME` wird zur Laufzeit aus `POSTGRES_USER`/`POSTGRES_DB` und Host/Port zusammengesetzt |
 | **Redis Exporter** | cdb_redis_exporter | bitnami/redis-exporter | 9121 | **AKTIV** | Redis Metrics |
 | **cAdvisor** | cdb_cadvisor | gcr.io/cadvisor/cadvisor:v0.49.2 | — | **AKTIV** | Container Metrics |


### PR DESCRIPTION
## Summary

Slice 6A.

Bumps the pinned Grafana base image used by compose and Security Scan:

- `grafana/grafana:11.6.14-ubuntu`
- to `grafana/grafana:11.6.14-security-04-ubuntu`

All compose/workflow image references remain pinned with `@sha256:` digests.

Refs #2513.

## Scope

Changed files:
- `infrastructure/compose/base.yml`
- `infrastructure/compose/compose.red.yml`
- `.github/workflows/security-scan.yml`
- `knowledge/governance/SERVICE_CATALOG.md`

No changes to:
- Prometheus image refs
- Postgres image refs
- Redis image refs
- custom-service Dockerfiles
- requirements
- SARIF policy / upload behavior
- runtime or deployment config beyond Grafana image refs

## Digest Evidence

Digest was resolved read-only via Docker Hub Registry API during Slice 6A research.

Grafana:
- `grafana/grafana:11.6.14-security-04-ubuntu@sha256:adeac4e7218222d9306f33ffe7e6f644c8ab7047a4f82f3fef60cdfbd71051d0`

No `docker pull`, Docker daemon contact, local build, or compose command was used.

## Validation

Local/static validation:
- `git diff --check` passed
- old Grafana ref `grafana/grafana:11.6.14-ubuntu@sha256:d39d4352...` removed from affected files
- new Grafana tag+digest appears consistently in compose/workflow refs
- no unpinned Grafana refs
- Service Catalog updated to `11.6.14-security-04-ubuntu`
- Service Catalog short digest updated from `d39d4352` to `adeac4e7`
- Prometheus/Postgres/Redis refs unchanged
- Security Scan policy/upload behavior unchanged
- Commit title contains no issue number and no auto-close keyword

## Expected Alert Impact

Before this slice:
- CodeQL open: 0
- Custom-service Trivy open: 0
- Base-image Trivy open: 132
- `trivy-base-grafana`: 101

Expected after Security Scan:
- Conservative: Grafana 101 → 80, total 132 → 111
- Optimistic: Grafana 101 → 14, total 132 → 45

Exact impact depends on GitHub Actions Security Scan and SARIF upload.

## Soak Safety

This PR only changes pinned Grafana image refs in git and syncs the Service Catalog.

It does not:
- restart containers
- run Docker Compose
- pull local images
- deploy services
- modify running infrastructure
- alter live-readiness state
- enable live trading or real-money operations

Merging may trigger GitHub Actions scans/builds remotely, but does not restart local soak containers.

Local deploy/pull/restart remains forbidden until the active soak run has ended.