### PR TITLE
fix(security): bump grafana major base image

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -45,7 +45,7 @@ jobs:
             scan_name: postgres
           - image: prom/prometheus:v3.11.3@sha256:e4254400b85610324913f0dc4acf92603d9984e7519414c5a12811aa6146acc3
             scan_name: prometheus
-          - image: grafana/grafana:11.6.14-security-04-ubuntu@sha256:adeac4e7218222d9306f33ffe7e6f644c8ab7047a4f82f3fef60cdfbd71051d0
+          - image: grafana/grafana:12.4.3-security-02-ubuntu@sha256:089f9dbbfa3c21e6989aab20f14f1a78cef54c04819af5e9deb2bd9c37966bc5
             scan_name: grafana
       fail-fast: false
 

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -75,7 +75,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:11.6.14-security-04-ubuntu@sha256:adeac4e7218222d9306f33ffe7e6f644c8ab7047a4f82f3fef60cdfbd71051d0
+    image: grafana/grafana:12.4.3-security-02-ubuntu@sha256:089f9dbbfa3c21e6989aab20f14f1a78cef54c04819af5e9deb2bd9c37966bc5
     container_name: cdb_grafana
     restart: unless-stopped
     environment:

--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -114,7 +114,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:11.6.14-security-04-ubuntu@sha256:adeac4e7218222d9306f33ffe7e6f644c8ab7047a4f82f3fef60cdfbd71051d0
+    image: grafana/grafana:12.4.3-security-02-ubuntu@sha256:089f9dbbfa3c21e6989aab20f14f1a78cef54c04819af5e9deb2bd9c37966bc5
     container_name: cdb_grafana
     restart: unless-stopped
     environment:

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -101,7 +101,7 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 | Service | Container | Image | Port | Status | Funktion |
 |---------|-----------|-------|------|--------|----------|
 | **Prometheus** | cdb_prometheus | prom/prometheus:v3.11.3 | 19090→9090 | **AKTIV** | Metrics Collection |
-| **Grafana** | cdb_grafana | grafana/grafana:11.6.14-security-04-ubuntu@sha256:adeac4e7 | 3000 | **AKTIV** | Dashboards |
+| **Grafana** | cdb_grafana | grafana/grafana:12.4.3-security-02-ubuntu@sha256:089f9dbb | 3000 | **AKTIV** | Dashboards |
 | **Postgres Exporter** | cdb_postgres_exporter | prometheuscommunity/postgres-exporter | 9187 | **AKTIV** | PG Metrics; DSN-Wiring ueber `postgres_password` Secret + `PGPASSWORD`, `DATA_SOURCE_NAME` wird zur Laufzeit aus `POSTGRES_USER`/`POSTGRES_DB` und Host/Port zusammengesetzt |
 | **Redis Exporter** | cdb_redis_exporter | bitnami/redis-exporter | 9121 | **AKTIV** | Redis Metrics |
 | **cAdvisor** | cdb_cadvisor | gcr.io/cadvisor/cadvisor:v0.49.2 | — | **AKTIV** | Container Metrics |


### PR DESCRIPTION
## Summary

Slice 6E-MAJOR.

Bumps the pinned Grafana base image used by compose and Security Scan:

- from `grafana/grafana:11.6.14-security-04-ubuntu`
- to `grafana/grafana:12.4.3-security-02-ubuntu`

All compose/workflow image references remain pinned with full `@sha256:` digests.

Refs #2513.

## Scope

Changed files:
- `infrastructure/compose/base.yml`
- `infrastructure/compose/compose.red.yml`
- `.github/workflows/security-scan.yml`
- `knowledge/governance/SERVICE_CATALOG.md`

No changes to:
- Prometheus image refs
- Postgres image refs
- Redis image refs
- Loki / Promtail / Alertmanager refs
- custom-service Dockerfiles
- requirements
- SARIF policy / upload behavior
- runtime or deployment config beyond Grafana image refs

## Digest Evidence

Grafana target image:

`grafana/grafana:12.4.3-security-02-ubuntu@sha256:089f9dbbfa3c21e6989aab20f14f1a78cef54c04819af5e9deb2bd9c37966bc5`

No `docker pull`, Docker daemon contact, local build, or compose command was used.

## Major Version Rationale

This is a Grafana 11 → 12 major-version bump.

Compatibility review found:
- no Angular panels
- no custom Grafana plugins
- provisioning remains `apiVersion: 1`
- datasource provisioning uses stable Prometheus/Postgres/Loki patterns
- existing `GF_` environment variables remain compatible
- Grafana is RED/monitoring stack only and not a trading-path service

Runtime rollout is still forbidden until the active soak run ends.

## Validation

Local/static validation:
- `git diff --check` passed
- exactly 4 files changed
- old Grafana ref removed from all changed files
- new Grafana tag+digest appears consistently in compose/workflow refs
- no unpinned Grafana refs
- Service Catalog updated to `12.4.3-security-02-ubuntu@sha256:089f9dbb`
- Prometheus/Postgres/Redis/Loki/Promtail/Alertmanager refs unchanged
- Security Scan policy/upload behavior unchanged
- YAML parse passed for changed YAML files
- Commit title contains no issue number and no auto-close keyword

## Expected Alert Impact

Before this slice:
- CodeQL open: 0
- Custom-service Trivy open: 0
- Total open Code Scanning alerts: 100
- `trivy-base-grafana`: 69

Expected after GitHub Security Scan:
- Grafana residuals should drop significantly
- H3 Go-module alerts: 66 likely reduced
- H2 OS with-fix alerts: 3 unknown
- exact impact depends on GitHub Security Scan and SARIF upload

## Soak Safety

This PR only changes pinned Grafana image refs in git and syncs the Service Catalog.

It does not:
- restart containers
- run Docker Compose
- pull local images
- build local images
- deploy services
- modify running infrastructure
- alter live-readiness state
- enable live trading or real-money operations

Merging may trigger GitHub Actions scans/builds remotely, but does not restart local soak containers.

Local deploy/pull/restart remains forbidden until the active soak run has ended.