### PR TITLE
docs(onboarding): add MCP capability resolution gate

### DIFF
--- a/.opencode/skills/cdb-session-start/SKILL.md
+++ b/.opencode/skills/cdb-session-start/SKILL.md
@@ -77,9 +77,38 @@ Establish a verified, fail-closed starting state before any repo work begins.
    The Git truth checks in steps 1-3 do not replace the control-context read; they
    precede it.
 
-5. Create a clean execution surface:
+5. MCP Capability Resolution Gate (conditional):
 
-   Once steps 1-4 are complete and no gate has fired, create the working surface:
+   When the session scope includes Context, SurrealDB, MCP tools, ContextBridge,
+   or DB-backed agent memory, verify capability before any implementation or
+   tool-dependent planning.
+
+   **Capability beats assumption.** Repo presence is not MCP availability. A tool
+   counts as available only if the active MCP surface exposes it and invocation
+   dispatches a real handler.
+
+   | # | Check | Pass criterion |
+   |---|---|---|
+   | 1 | Active inventory | Tool appears in the active MCP tool list |
+   | 2 | No `unknown_tool` | Tool call does not return `unknown_tool` |
+   | 3 | No `not_implemented` | Tool call does not return `not_implemented` |
+   | 4 | Real dispatch | Handler returns real behavior |
+   | 5 | Read-only contract | `metadata.read_only == true` where applicable |
+   | 6 | Explicit DB opt-in | DB-backed mode requires explicit `adapter_config_path` |
+   | 7 | Fail-closed boundaries | Remote DB URLs and write/admin statements are rejected |
+
+   If any check fails:
+   - STOP.
+   - Report the exact missing layer.
+   - Do not adopt raw/external SurrealDB MCP as a shortcut.
+   - Propose only the smallest CDB-native read-only slice after Human-GO.
+   - LR remains NO-GO. No Echtgeld-Go.
+
+   Reference: `docs/runbooks/surrealdb_context_mcp_access.md` § 1.5.
+
+6. Create a clean execution surface:
+
+   Once steps 1-5 are complete and no gate has fired, create the working surface:
    - Branch from current `origin/main` (never from stale local main).
    - Clean worktree confirmed.
    - Explicit target issue identified and open.
@@ -96,6 +125,8 @@ Establish a verified, fail-closed starting state before any repo work begins.
 - If `cdb-control-intake` cannot be completed, stop.
 - If any of the risky conditions in step 2 cannot be resolved, stop and report
   what remains unresolved before any file is touched.
+- If MCP capability cannot be verified for a Context/SurrealDB tool in scope,
+  stop and report the missing layer instead of implementing or calling around it.
 
 ## Output
 
@@ -135,3 +166,5 @@ Arbeitsflaeche
 - Do not mark the gate as `go` when any of the fail-closed conditions is unresolved.
 - Do not invent reviewer, approver, or merge-authority roles; this is a
   solo-maintainer repo.
+- Do not treat repo presence of MCP files, registry entries, or `tools/mcp/server.py`
+  as proof that a tool is callable through the active MCP surface.

--- a/agents/OPEN_CODE_AGENTS.md
+++ b/agents/OPEN_CODE_AGENTS.md
@@ -31,6 +31,7 @@ Gilt für **alle** OpenCode Agents (egal welcher Provider).
 - Für CDB-Repo-Arbeit danach `cdb-session-start`
 - Danach `cdb-control-intake`
 - Bei Issue-Arbeit danach `cdb-issue-to-session-plan`
+- Bei Context-, SurrealDB-, MCP-Tool-, ContextBridge- oder DB-backed-Memory-Scope: MCP Capability Resolution Gate ausführen vor Implementierung oder toolabhängiger Planung — Repo-Präsenz ist nicht gleich MCP-Verfügbarkeit. Referenz: `docs/runbooks/surrealdb_context_mcp_access.md` § 1.5.
 - Danach nur task-spezifische Skills laden
 - Keine pauschale Skill-Massenladung
 - Third-Party-/Cybersecurity-Skills nur bei explizitem Bedarf und nur defensiv/prüfend

--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -31,6 +31,47 @@ Out of scope for this runbook:
 
 ---
 
+## 1.5. MCP Capability Resolution Protocol
+
+**Before relying on any tool in this runbook, resolve capability explicitly.**
+
+Repo-defined tools are not automatically available to agents. A tool is available
+only when the active MCP surface exposes it and invocation dispatches a real handler.
+
+**Capability beats assumption. Repo presence is not MCP availability.**
+
+| Check | Pass criterion | Fail action |
+|---|---|---|
+| Active MCP inventory | Required tool appears in the active MCP tool list | Stop and report missing surface/config |
+| Dispatch | Tool call reaches a real handler | Stop on `unknown_tool` or `not_implemented` |
+| Read-only contract | Response reports `metadata.read_only == true` where applicable | Stop and report contract violation |
+| DB-backed mode | SurrealDB is accessed only when `adapter_config_path` is explicitly passed | Stop if DB access is implicit |
+| Local DB boundary | Remote DB URLs are rejected | Stop and report boundary failure |
+| Write/admin guard | Write/admin statements fail closed before network access | Stop and report guard failure |
+
+For repo-native Context MCP access, `claire-de-binare.mcp.json` must expose the
+`cdb_context` server entry:
+
+```json
+{
+  "command": "python",
+  "args": ["-m", "tools.mcp.server"],
+  "type": "stdio"
+}
+```
+
+The MCP host must invoke the server from the repository root so that `tools.*`
+module paths resolve correctly.
+
+If any capability check fails:
+- Do not switch to a raw/external SurrealDB MCP server.
+- Report the exact missing layer.
+- Propose the smallest CDB-native read-only fix after Human-GO.
+
+Established by PR #2559 (`a35d7728`). Cross-reference: `cdb-session-start` skill, step 5.
+
+---
+
 ## 2. Non-Goals (Anti-Criteria)
 
 This runbook explicitly does **not** establish or imply any of the following:


### PR DESCRIPTION
## Summary

Anchors the MCP Capability Resolution rule in the CDB onboarding/session-start flow.

This follows PR #2559, which added the repo-native read-only `cdb_context` MCP stdio server. The key lesson is now documented: repo presence is not MCP availability.

## Changes

- Update `.opencode/skills/cdb-session-start/SKILL.md`
  - Add conditional MCP Capability Resolution Gate as step 5
  - Add 7 required checks for Context/SurrealDB/MCP scopes
  - Add fail-closed rule
  - Add anti-pattern warning against treating repo files as active MCP availability

- Update `docs/runbooks/surrealdb_context_mcp_access.md`
  - Add pre-flight MCP Capability Resolution Protocol (§ 1.5)
  - Document active MCP inventory, dispatch, read-only contract, DB opt-in, local DB boundary, and write/admin guard checks
  - Document `cdb_context` MCP config expectation

- Update `agents/OPEN_CODE_AGENTS.md`
  - Add OpenCode routing rule for Context/SurrealDB/MCP sessions

## Validation

- `git diff --check` ✅ clean
- Scope checked: documentation/onboarding only

## Guardrails

- No runtime changes
- No MCP server code changes
- No SurrealDB schema/import/query code changes
- No Docker mutation
- No schema apply, no import, no reset
- LR remains NO-GO
- No Echtgeld scope
- No live trading approval

## Follow-up Context

This documents the operational rule established by PR #2559:

> Capability beats assumption. Repo presence is not MCP availability.

Agents must verify active MCP inventory and real handler dispatch before relying on Context/SurrealDB MCP tools.