### PR TITLE
docs(mcp): clarify context server config snippet

### DIFF
--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -50,13 +50,18 @@ only when the active MCP surface exposes it and invocation dispatches a real han
 | Write/admin guard | Write/admin statements fail closed before network access | Stop and report guard failure |
 
 For repo-native Context MCP access, `claire-de-binare.mcp.json` must expose the
-`cdb_context` server entry:
+`cdb_context` server entry under the top-level `mcpServers` object:
 
 ```json
 {
-  "command": "python",
-  "args": ["-m", "tools.mcp.server"],
-  "type": "stdio"
+  "mcpServers": {
+    "cdb_context": {
+      "enabled": true,
+      "command": "python",
+      "args": ["-m", "tools.mcp.server"],
+      "type": "stdio"
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

Clarifies the SurrealDB Context MCP runbook config snippet by showing the full `mcpServers` wrapper around the `cdb_context` entry.

This follows PR #2560, where a bot thread correctly noted that the snippet showed the inner server entry without the top-level config context.

## Changes

- Update `docs/runbooks/surrealdb_context_mcp_access.md`
  - Clarify that `cdb_context` lives under the top-level `mcpServers` object
  - Replace the partial JSON snippet with the full shape matching `claire-de-binare.mcp.json`
  - Include `enabled: true`

## Validation

- `git diff --check` ✅ clean
- Documentation-only scope

## Guardrails

- No runtime changes
- No MCP server code changes
- No SurrealDB schema/import/query code changes
- No Docker mutation
- No schema apply
- No import
- No reset
- LR remains NO-GO
- No Echtgeld scope
- No live trading approval