### PR TITLE
feat(surrealdb): warn on wave14 refs missing from batch

### DIFF
--- a/tests/unit/surrealdb/test_context_import_jsonl_validation.py
+++ b/tests/unit/surrealdb/test_context_import_jsonl_validation.py
@@ -693,3 +693,195 @@ def test_wave14_missing_pk_is_blocking(
         and finding["artifact"] == artifact
         for finding in payload["findings"]
     )
+
+
+# ---------------------------------------------------------------------------
+# Wave-14 cross-reference validation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_wave14_empty_evidence_refs_array_produces_no_findings(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path,
+        "claims",
+        [_base_record(claim_id="claim-001", created_at="2026-05-18T00:00:00Z", evidence_refs=[])],
+    )
+    _write_jsonl(
+        tmp_path,
+        "decision_events",
+        [
+            _base_record(
+                decision_id="decision-001",
+                created_at="2026-05-18T00:00:00Z",
+                evidence_refs=[],
+                claim_refs=[],
+            )
+        ],
+    )
+    _write_jsonl(
+        tmp_path,
+        "agent_memories",
+        [_base_record(memory_id="memory-001", created_at="2026-05-18T00:00:00Z", evidence_refs=[])],
+    )
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path), "--run-id", RUN_ID])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    cross_ref_codes = {
+        "claim_evidence_ref_not_in_batch",
+        "decision_evidence_ref_not_in_batch",
+        "decision_claim_ref_not_in_batch",
+        "memory_evidence_ref_not_in_batch",
+    }
+    assert not any(f["code"] in cross_ref_codes for f in payload["findings"])
+    assert payload["validation"]["blocking_count"] == 0
+
+
+@pytest.mark.unit
+def test_wave14_valid_within_batch_claim_evidence_ref_passes(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path,
+        "evidence_refs",
+        [_base_record(evidence_id="ev-001", created_at="2026-05-18T00:00:00Z")],
+    )
+    _write_jsonl(
+        tmp_path,
+        "claims",
+        [
+            _base_record(
+                claim_id="claim-001",
+                created_at="2026-05-18T00:00:00Z",
+                evidence_refs=["ev-001"],
+            )
+        ],
+    )
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path), "--run-id", RUN_ID])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert not any(f["code"] == "claim_evidence_ref_not_in_batch" for f in payload["findings"])
+
+
+@pytest.mark.unit
+def test_wave14_missing_claim_evidence_ref_is_warning(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path,
+        "claims",
+        [
+            _base_record(
+                claim_id="claim-001",
+                created_at="2026-05-18T00:00:00Z",
+                evidence_refs=["ev-missing"],
+            )
+        ],
+    )
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path), "--run-id", RUN_ID])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    matching = [f for f in payload["findings"] if f["code"] == "claim_evidence_ref_not_in_batch"]
+    assert len(matching) == 1
+    assert matching[0]["severity"] == "warning"
+    assert payload["validation"]["blocking_count"] == 0
+
+
+@pytest.mark.unit
+def test_wave14_missing_decision_claim_ref_is_warning(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path,
+        "decision_events",
+        [
+            _base_record(
+                decision_id="decision-001",
+                created_at="2026-05-18T00:00:00Z",
+                claim_refs=["claim-missing"],
+            )
+        ],
+    )
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path), "--run-id", RUN_ID])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    matching = [f for f in payload["findings"] if f["code"] == "decision_claim_ref_not_in_batch"]
+    assert len(matching) == 1
+    assert matching[0]["severity"] == "warning"
+    assert payload["validation"]["blocking_count"] == 0
+
+
+@pytest.mark.unit
+def test_wave14_missing_memory_evidence_ref_is_warning(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path,
+        "agent_memories",
+        [
+            _base_record(
+                memory_id="memory-001",
+                created_at="2026-05-18T00:00:00Z",
+                evidence_refs=["ev-missing"],
+            )
+        ],
+    )
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path), "--run-id", RUN_ID])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    matching = [f for f in payload["findings"] if f["code"] == "memory_evidence_ref_not_in_batch"]
+    assert len(matching) == 1
+    assert matching[0]["severity"] == "warning"
+    assert payload["validation"]["blocking_count"] == 0
+
+
+@pytest.mark.unit
+def test_wave14_indexer_generated_evidence_refs_pass_cross_ref_check(
+    tmp_path: Path, capsys
+) -> None:
+    _write_valid_artifacts(tmp_path)
+    _write_jsonl(
+        tmp_path,
+        "evidence_refs",
+        [
+            _base_record(
+                evidence_id="evidence_ref:abc123",
+                created_at="2026-05-18T00:00:00Z",
+                evidence_type="test_file",
+                source_path="tests/unit/surrealdb/test_context_indexer.py",
+                source_hash=HASH,
+                confidence=0.8,
+            )
+        ],
+    )
+    # claims/decision_events/agent_memories remain empty (no refs to validate)
+
+    exit_code = main(["validate-jsonl", "--input-dir", str(tmp_path), "--run-id", RUN_ID])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    cross_ref_codes = {
+        "claim_evidence_ref_not_in_batch",
+        "decision_evidence_ref_not_in_batch",
+        "decision_claim_ref_not_in_batch",
+        "memory_evidence_ref_not_in_batch",
+    }
+    assert not any(f["code"] in cross_ref_codes for f in payload["findings"])
+    assert payload["validation"]["blocking_count"] == 0

--- a/tests/unit/surrealdb/test_context_import_plan.py
+++ b/tests/unit/surrealdb/test_context_import_plan.py
@@ -280,6 +280,69 @@ def test_plan_marks_duplicate_input_record_as_skip(tmp_path: Path, capsys) -> No
     assert payload["action_counts"] == {"create": 14, "skip": 1}
 
 
+# ---------------------------------------------------------------------------
+# Wave-14 validation warning carry-through tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_build_import_plan_carries_wave14_validation_warnings(
+    tmp_path: Path, capsys
+) -> None:
+    records = _valid_records()
+    records["claims"] = [
+        _base_record(
+            claim_id="claim-001",
+            created_at="2026-05-18T00:00:00Z",
+            evidence_refs=["ev-missing"],
+        )
+    ]
+    for artifact, artifact_records in records.items():
+        _write_jsonl(tmp_path, artifact, artifact_records)
+
+    exit_code = main(["plan", "--input-dir", str(tmp_path), "--run-id", RUN_ID])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert payload["status"] == "planned"
+    assert payload["has_blocking_validation_findings"] is False
+    codes = [w["code"] for w in payload["warnings"]]
+    assert "claim_evidence_ref_not_in_batch" in codes
+    match = next(
+        w for w in payload["warnings"] if w["code"] == "claim_evidence_ref_not_in_batch"
+    )
+    assert match["severity"] == "warning"
+
+
+@pytest.mark.unit
+def test_build_import_plan_carries_decision_claim_validation_warnings(
+    tmp_path: Path, capsys
+) -> None:
+    records = _valid_records()
+    records["decision_events"] = [
+        _base_record(
+            decision_id="decision-001",
+            created_at="2026-05-18T00:00:00Z",
+            claim_refs=["claim-missing"],
+        )
+    ]
+    for artifact, artifact_records in records.items():
+        _write_jsonl(tmp_path, artifact, artifact_records)
+
+    exit_code = main(["plan", "--input-dir", str(tmp_path), "--run-id", RUN_ID])
+
+    assert exit_code == EXIT_OK
+    payload = _read_json(capsys)
+    assert payload["status"] == "planned"
+    assert payload["has_blocking_validation_findings"] is False
+    codes = [w["code"] for w in payload["warnings"]]
+    assert "decision_claim_ref_not_in_batch" in codes
+    match = next(
+        w for w in payload["warnings"] if w["code"] == "decision_claim_ref_not_in_batch"
+    )
+    assert match["severity"] == "warning"
+
+
 @pytest.mark.unit
 def test_plan_markdown_report_output_is_written_under_whitelist(
     tmp_path: Path, monkeypatch, capsys

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -2397,6 +2397,78 @@ def _validate_cross_references(
                 )
             )
 
+    # Wave-14 within-batch cross-reference checks (warning only).
+    # References across batches are valid (evidence may exist from prior imports),
+    # so missing IDs are warnings, never blocking.
+    evidence_ids = {
+        item.get("evidence_id")
+        for item in records["evidence_refs"]
+        if isinstance(item.get("evidence_id"), str)
+    }
+    claim_ids_w14 = {
+        item.get("claim_id")
+        for item in records["claims"]
+        if isinstance(item.get("claim_id"), str)
+    }
+
+    for record in records["claims"]:
+        for ref in record.get("evidence_refs") or []:
+            if isinstance(ref, str) and ref not in evidence_ids:
+                findings.append(
+                    _finding(
+                        "warning",
+                        "claim_evidence_ref_not_in_batch",
+                        "claim evidence_ref is not present in this JSONL batch;"
+                        " it may refer to existing DB evidence",
+                        artifact="claims",
+                        line=record.get("__line"),
+                        record=record,
+                    )
+                )
+
+    for record in records["decision_events"]:
+        for ref in record.get("evidence_refs") or []:
+            if isinstance(ref, str) and ref not in evidence_ids:
+                findings.append(
+                    _finding(
+                        "warning",
+                        "decision_evidence_ref_not_in_batch",
+                        "decision_event evidence_ref is not present in this JSONL batch;"
+                        " it may refer to existing DB evidence",
+                        artifact="decision_events",
+                        line=record.get("__line"),
+                        record=record,
+                    )
+                )
+        for ref in record.get("claim_refs") or []:
+            if isinstance(ref, str) and ref not in claim_ids_w14:
+                findings.append(
+                    _finding(
+                        "warning",
+                        "decision_claim_ref_not_in_batch",
+                        "decision_event claim_ref is not present in this JSONL batch;"
+                        " it may refer to existing DB claim",
+                        artifact="decision_events",
+                        line=record.get("__line"),
+                        record=record,
+                    )
+                )
+
+    for record in records["agent_memories"]:
+        for ref in record.get("evidence_refs") or []:
+            if isinstance(ref, str) and ref not in evidence_ids:
+                findings.append(
+                    _finding(
+                        "warning",
+                        "memory_evidence_ref_not_in_batch",
+                        "agent_memory evidence_ref is not present in this JSONL batch;"
+                        " it may refer to existing DB evidence",
+                        artifact="agent_memories",
+                        line=record.get("__line"),
+                        record=record,
+                    )
+                )
+
 
 def validate_jsonl(
     input_dir: Path, expected_run_id: str | None = None

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -2707,20 +2707,23 @@ def _action_dependencies(artifact: str, record: dict[str, Any]) -> tuple[str, ..
     return tuple(sorted(dict.fromkeys(dependencies)))
 
 
+def _plan_warning_from_finding(finding: JsonlValidationFinding) -> ImportPlanWarning:
+    return ImportPlanWarning(
+        code=finding.code,
+        message=finding.message,
+        artifact=finding.artifact,
+        source_ref=finding.source_path,
+        severity=finding.severity,
+    )
+
+
 def build_import_plan(
     input_dir: Path, expected_run_id: str | None = None
 ) -> ImportPlan:
     report = validate_jsonl(input_dir, expected_run_id)
     if report.blocking_count:
         warnings = tuple(
-            ImportPlanWarning(
-                code=finding.code,
-                message=finding.message,
-                artifact=finding.artifact,
-                source_ref=finding.source_path,
-                severity=finding.severity,
-            )
-            for finding in report.findings
+            _plan_warning_from_finding(finding) for finding in report.findings
         )
         return ImportPlan(
             schema_version=SCHEMA_VERSION,
@@ -2739,7 +2742,11 @@ def build_import_plan(
         )
 
     actions: list[ImportPlanAction] = []
-    warnings: list[ImportPlanWarning] = []
+    warnings: list[ImportPlanWarning] = [
+        _plan_warning_from_finding(finding)
+        for finding in report.findings
+        if finding.severity == "warning"
+    ]
     seen_record_ids: set[str] = set()
 
     for artifact in IMPORT_ORDER:


### PR DESCRIPTION
## Summary

Adds warning-level within-batch validation for Wave-14 Context references.

The importer now warns when `claim`, `decision_event`, or `agent_memory` records reference evidence or claim IDs that are not present in the current JSONL batch.

These findings are intentionally warnings, not blockers, because references may point to records from earlier imports and the importer has no DB context during JSONL validation.

## Changes

- Update `tools/surrealdb/context_importer.py`
  - Build Wave-14 `evidence_id` and `claim_id` sets from the current JSONL batch
  - Add warning-level validation for:
    - `claim.evidence_refs[*]` → `evidence_ref.evidence_id`
    - `decision_event.evidence_refs[*]` → `evidence_ref.evidence_id`
    - `decision_event.claim_refs[*]` → `claim.claim_id`
    - `agent_memory.evidence_refs[*]` → `evidence_ref.evidence_id`
  - Empty arrays and missing optional ref fields remain valid
  - No new blocking findings

- Update `tests/unit/surrealdb/test_context_import_jsonl_validation.py`
  - Add tests for empty ref arrays
  - Add tests for valid within-batch references
  - Add tests proving missing refs produce warnings, not blockers
  - Add test coverage for indexer-generated `evidence_ref` records

## Validation

- `pytest -v -m unit tests/unit/surrealdb/test_context_import_jsonl_validation.py` ✅ 43/43 passed
- `pytest -v -m unit tests/unit/surrealdb/` ✅ 1173/1173 passed
- `ruff check tools/surrealdb/context_importer.py tests/unit/surrealdb/test_context_import_jsonl_validation.py` ✅ clean
- `git diff --check` ✅ clean

## Guardrails

- No Docker
- No schema apply
- No real import
- No reset
- No DB/network access
- No SurrealDB schema changes
- No MCP changes
- No generator changes
- No new blocking validation for Wave-14 cross-batch refs
- Apply remains hard-blocked
- LR remains NO-GO
- No Echtgeld scope
- No live trading approval

## Out of Scope / Follow-ups

- DB-aware cross-batch reference resolution
- `evidence_ref.validates`
- `evidence_ref.invalidates`
- `evidence_ref.related_decisions`
- Claim generator
- Decision event generator
- Agent memory generator
