### PR TITLE
fix(surrealdb): make local context smoke pipeline importable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ REPLAY_DRY_RUN ?= 0
 REPLAY_DETERMINISTIC_VERIFY ?= 1
 
 CONTEXT_SNAP_DIR ?= artifacts/context-intelligence/latest
+CONTEXT_SCOPE_CONFIG ?= infrastructure/config/surrealdb/context_ingestion_scope.yaml
 
 .PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke context-smoke-db
 
@@ -358,8 +359,13 @@ context-reset-local:
 context-scan:
 	@echo "=== Context Scan: Repo-Artefakte und Doc-Chunks (kein DB-Write) ==="
 	@mkdir -p $(CONTEXT_SNAP_DIR)
-	@python3 -m tools.surrealdb.context_indexer scan --apply-writes --output $(CONTEXT_SNAP_DIR)/scan-report.json
-	@echo "[OK] Scan complete: $(CONTEXT_SNAP_DIR)/scan-report.json"
+	@python3 -m tools.surrealdb.context_indexer scan --apply-writes \
+		--scope-config $(CONTEXT_SCOPE_CONFIG) \
+		--output $(CONTEXT_SNAP_DIR)/scan-report.json
+	@python3 -m tools.surrealdb.context_indexer export-jsonl --apply-writes \
+		--scope-config $(CONTEXT_SCOPE_CONFIG) \
+		--output $(CONTEXT_SNAP_DIR)
+	@echo "[OK] Scan + JSONL export complete: $(CONTEXT_SNAP_DIR)"
 
 context-import-dry-run:
 	@echo "=== Context Import Dry-Run: geplante Aktionen, kein DB-Write ==="
@@ -410,7 +416,7 @@ context-smoke-db: context-env-check
 		--database cdb_context_intel \
 		--apply --apply-mode local-dev \
 		--config infrastructure/config/surrealdb/context_import.local.example.yaml \
-		--run-id $$(date +%Y%m%d%H%M%S) \
+		--run-id $$(python3 -c "import json; print(json.load(open('$(CONTEXT_SNAP_DIR)/snapshot.json'))['run_id'])") \
 		--adapter surrealdb-local \
 		--secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}
 	@echo "--- Schritt 4: Query-Smoke (hard, >= 1 Record, fail-closed) ---"

--- a/infrastructure/config/surrealdb/context_ingestion_scope.smoke.yaml
+++ b/infrastructure/config/surrealdb/context_ingestion_scope.smoke.yaml
@@ -1,0 +1,153 @@
+schema_version: context-ingestion-scope/v0
+
+# SMOKE-TEST-ONLY SCOPE — NOT the canonical ingestion scope.
+# Intentionally narrow: docs/, knowledge/ (minus deep-issues-lab), agents/, README.md.
+# Forbidden patterns are IDENTICAL to the canonical scope — no guardrail weakening.
+# Use with: --scope-config infrastructure/config/surrealdb/context_ingestion_scope.smoke.yaml
+# Canonical scope: infrastructure/config/surrealdb/context_ingestion_scope.yaml
+
+source_document:
+  path: infrastructure/config/surrealdb/context_ingestion_scope.smoke.yaml
+  status: smoke_test_only_not_canonical_ingestion_scope
+
+mode:
+  intent: smoke_test_only_narrow_context_ingestion_scope
+  smoke_test: true
+  canonical_scope: false
+  surrealdb_activation: forbidden
+  surrealdb_connect: forbidden
+  surrealdb_apply: forbidden
+  runtime_change: forbidden
+  live_readiness_verdict: NO-GO
+
+include_paths:
+  - path: docs/
+    sensitivity_class: public_context
+    purpose: Architecture, runbooks, governance-adjacent documentation.
+  - path: knowledge/
+    sensitivity_class: internal_context
+    purpose: Canonical knowledge, governance, and operating documents.
+    notes:
+      - knowledge/deep-issues-lab/ is excluded via exclude_paths.
+  - path: agents/
+    sensitivity_class: internal_context
+    purpose: Agent registry, roles, boot instructions, and operating boundaries.
+  - path: README.md
+    sensitivity_class: public_context
+    purpose: Repo-level entry context (root file only, not recursive).
+
+conditional_paths: []
+
+exclude_paths:
+  - path: .git/
+    reason: Internal Git data.
+  - path: .venv/
+    reason: Local build artifacts.
+  - path: .worktrees/
+    reason: Local work surfaces.
+  - path: logs/
+    reason: Potentially sensitive runtime data.
+  - path: artifacts/
+    reason: Generated outputs; not canonical.
+  - path: docs/archive/
+    reason: Historical fallback only.
+  - path: temp/
+    reason: Temporary output area.
+  - path: tmp/
+    reason: Temporary output area.
+  - path: DELIVERY_APPROVED.yaml
+    reason: Human-controlled delivery gate.
+  - path: knowledge/deep-issues-lab/
+    reason: Research scratch area; contains high-density forbidden-pattern keyword matches; not canonical knowledge for smoke ingestion.
+  - path: docs/surrealdb/context-wave21-cross-cutting-hardening.md
+    reason: Security-hardening doc that discusses forbidden-pattern keywords (secret, token) in documentation context; excluded from smoke scope to avoid false positives from lexical matching.
+
+allowed_file_types:
+  - extension: .md
+    type: markdown
+    purpose: Preferred documentation input.
+  - extension: .yaml
+    type: yaml
+    purpose: Ontologies, config, and structured specifications.
+  - extension: .yml
+    type: yaml
+    purpose: Ontologies, config, and structured specifications.
+  - extension: .json
+    type: json
+    purpose: Structured contracts, metadata, and schemas.
+
+sensitivity_classes:
+  public_context:
+    meaning: Publicly shareable repo context without sensitive operating metadata.
+    allowed_use: Normal read-only ingestion.
+  internal_context:
+    meaning: Internal repo or architecture context without secrets, not intended for arbitrary external sharing.
+    allowed_use: Read-only ingestion with internal context binding.
+  sensitive_metadata:
+    meaning: Non-secret metadata whose path, topology, or control meaning requires minimization.
+    allowed_use: Minimized read-only ingestion; capture metadata instead of full text when sufficient.
+  forbidden:
+    meaning: Not ingestible.
+    allowed_use: Never read, hash, chunk, export, or ingest.
+
+forbidden_patterns:
+  secrets:
+    - api_key
+    - private_key
+    - password
+    - passwd
+    - secret
+    - token
+    - credential
+    - broker_credential
+    - wallet_secret
+    - session_secret
+    - SECRETS_PATH values or secret file contents
+  trading_runtime_state:
+    - order state
+    - fill state
+    - position state
+    - balance state
+    - exposure state
+    - live risk state
+    - broker state
+    - execution state
+    - runtime Redis state
+    - runtime Postgres state
+    - productive external service state
+  generated_or_local:
+    - generated logs
+    - database dumps
+    - runtime captures
+    - local worktree data
+    - temporary files
+    - archive material without explicit reference and separate approval
+
+limits:
+  max_file_size_bytes: 1048576
+  binary_files: forbidden
+  database_dumps: forbidden
+  media_files: forbidden
+  notebook_outputs: forbidden
+  archive_policy:
+    default: forbidden
+    exception: Explicit canonical reference plus separate approval required.
+  output_roots:
+    approved_by_cli_contract:
+      - artifacts/
+      - temp/
+    notes:
+      - This config does not authorize writing outputs.
+
+guardrails:
+  - No productive SurrealDB enablement.
+  - No productive ingestion.
+  - Smoke-test scope only; not canonical ingestion scope.
+  - No secrets in scope.
+  - No orders, positions, fills, live risk state, broker state, execution state, or trading runtime state in scope.
+  - Forbidden files must not be read, hashed, chunked, exported, or ingested.
+  - Ambiguous content must fail closed as forbidden.
+  - Scope expansions require explicit canonical governance reference.
+  - Forbidden patterns are identical to canonical scope; no weakening.
+  - Live-Readiness remains NO-GO.
+  - Board stage trade-capable is not Live-Readiness GO.

--- a/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
+++ b/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
@@ -25,6 +25,7 @@ from tools.surrealdb.context_importer import (
     TOMBSTONE_FIELD_LAST_SEEN_RUN_ID,
     TOMBSTONE_FIELD_REASON,
     TOMBSTONE_FIELD_SUPERSEDED_BY,
+    _payload_to_surql_content,
     main,
 )
 
@@ -642,3 +643,159 @@ def test_example_config_auth_mode_is_root() -> None:
         "The local sidecar (cdb_surrealdb) requires SURREAL_USER/SURREAL_PASS; "
         "auth_mode must be 'root', not 'none'."
     )
+
+
+# ---------------------------------------------------------------------------
+# SurrealQL datetime literal serialization (#2573 / datetime coercion fix)
+# ---------------------------------------------------------------------------
+
+
+def _capture_sql(monkeypatch: pytest.MonkeyPatch) -> "list[str]":
+    """Return a list that will be populated with each SQL body sent via urlopen."""
+    sent: list[str] = []
+
+    def fake_urlopen(req, timeout=None):
+        sent.append(req.data.decode("utf-8"))
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        resp.status = 200
+        resp.read.return_value = _ok_body()
+        return resp
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    return sent
+
+
+@pytest.mark.unit
+def test_apply_create_observed_at_becomes_surql_literal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """apply_create must write observed_at as a SurrealQL datetime literal.
+
+    SurrealDB v2 SCHEMAFULL TYPE datetime rejects plain JSON strings; the
+    importer must emit d"..." syntax for allowlisted datetime fields.
+    """
+    sent = _capture_sql(monkeypatch)
+    adapter = _make_adapter()
+
+    adapter.apply_create(
+        "repo_artifact",
+        "art-ts-1",
+        {
+            "artifact_id": "art-ts-1",
+            "source_path": "docs/DESIGN.md",
+            "observed_at": "2026-05-18T19:50:12Z",
+            "confidence": 1.0,
+        },
+    )
+
+    assert len(sent) == 1
+    content_part = sent[0].split("CONTENT", 1)[1]
+    # observed_at must be a SurrealQL datetime literal, not a JSON string
+    assert 'd"2026-05-18T19:50:12Z"' in content_part
+    assert '"observed_at": "2026-05-18T19:50:12Z"' not in content_part
+    # Non-datetime fields must remain untouched
+    assert "DESIGN.md" in content_part
+    assert '"confidence": 1.0' in content_part
+
+
+@pytest.mark.unit
+def test_apply_create_non_allowlisted_iso_string_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-allowlisted fields with ISO-like string values must stay as JSON strings.
+
+    Only the explicit _SURQL_DATETIME_FIELDS allowlist is converted; arbitrary
+    text fields (e.g. description, notes) that happen to contain ISO timestamps
+    must not be rewritten.
+    """
+    sent = _capture_sql(monkeypatch)
+    adapter = _make_adapter()
+
+    adapter.apply_create(
+        "repo_artifact",
+        "art-ts-2",
+        {
+            "artifact_id": "art-ts-2",
+            "description": "2026-05-18T19:50:12Z",  # non-allowlisted field
+            "source_path": "README.md",
+        },
+    )
+
+    content_part = sent[0].split("CONTENT", 1)[1]
+    # The non-allowlisted field must remain a plain JSON string
+    assert '"description": "2026-05-18T19:50:12Z"' in content_part
+    assert 'description: d"' not in content_part
+
+
+@pytest.mark.unit
+def test_apply_update_collected_at_becomes_surql_literal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """apply_update must also convert allowlisted datetime fields (e.g. collected_at)."""
+    sent = _capture_sql(monkeypatch)
+    adapter = _make_adapter()
+
+    adapter.apply_update(
+        "evidence_ref",
+        "ev-1",
+        {
+            "evidence_id": "ev-1",
+            "collected_at": "2026-04-01T10:00:00Z",
+        },
+    )
+
+    content_part = sent[0].split("CONTENT", 1)[1]
+    assert 'd"2026-04-01T10:00:00Z"' in content_part
+    assert '"collected_at": "2026-04-01T10:00:00Z"' not in content_part
+
+
+@pytest.mark.unit
+def test_apply_tombstone_datetime_field_surql_literal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """apply_tombstone must use the same datetime literal serialization.
+
+    Tombstone meta-fields are stripped before writing; remaining domain fields
+    that contain allowlisted datetime values must be emitted as d"..." literals.
+    """
+    sent = _capture_sql(monkeypatch)
+    adapter = _make_adapter()
+
+    payload = _tombstone_payload()
+    # Add an allowlisted datetime field to the domain portion
+    payload["observed_at"] = "2026-03-15T08:30:00Z"
+
+    adapter.apply_tombstone("doc_chunk", "chunk-ts-1", payload)
+
+    assert len(sent) == 1
+    content_part = sent[0].split("CONTENT", 1)[1]
+    # Domain datetime field converted to literal
+    assert 'd"2026-03-15T08:30:00Z"' in content_part
+    # Tombstone meta-fields stripped as before
+    assert "record_removed_from_snapshot" not in content_part
+
+
+@pytest.mark.unit
+def test_payload_to_surql_content_roundtrip() -> None:
+    """_payload_to_surql_content unit tests: allowlist, non-allowlist, null, number."""
+    # Allowlisted field with Z-suffix ISO string → converted
+    result = _payload_to_surql_content({"observed_at": "2026-05-18T19:50:12Z", "x": "y"})
+    assert '"observed_at": d"2026-05-18T19:50:12Z"' in result
+    assert '"x": "y"' in result
+
+    # Non-allowlisted ISO-like field → not converted
+    result2 = _payload_to_surql_content({"timestamp_text": "2026-05-18T19:50:12Z"})
+    assert '"timestamp_text": "2026-05-18T19:50:12Z"' in result2
+    assert "d\"" not in result2
+
+    # Allowlisted field without Z suffix → not converted (no partial matches)
+    result3 = _payload_to_surql_content({"observed_at": "2026-05-18T19:50:12"})
+    assert '"observed_at": "2026-05-18T19:50:12"' in result3
+    assert "d\"" not in result3
+
+    # Null value for allowlisted field → not converted (null is not a string)
+    result4 = _payload_to_surql_content({"observed_at": None})
+    assert '"observed_at": null' in result4
+    assert "d\"" not in result4

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -411,9 +411,49 @@ TRADING_STATE_PATH_PARTS = frozenset(
     }
 )
 
-# Fields added internally by the importer's validator to JSONL records;
-# they are not part of the original JSONL and must not be written to SurrealDB.
-_JSONL_INTERNAL_FIELDS = frozenset({"__line"})
+# Fields stripped from JSONL records before writing to SurrealDB.
+# Includes importer-internal fields (__line) and JSONL envelope fields
+# (schema_version, run_id, sensitivity) that are not declared in any table
+# schema. SurrealDB v2 SCHEMAFULL tables reject undeclared fields; SCHEMALESS
+# tables accept them but these fields carry no domain meaning in the DB.
+_JSONL_INTERNAL_FIELDS = frozenset({"__line", "schema_version", "run_id", "sensitivity"})
+
+# Datetime field names declared as TYPE datetime in context_intelligence_v0.surql.
+# SurrealDB v2 SCHEMAFULL tables reject plain JSON strings for TYPE datetime fields
+# when records are written via the HTTP /sql endpoint.  The _payload_to_surql_content
+# helper converts only these allowlisted fields (when their value is an ISO-8601-Z
+# string) to SurrealQL datetime literals (d"...").
+_SURQL_DATETIME_FIELDS: frozenset[str] = frozenset({
+    "collected_at",
+    "computed_at",
+    "created_at",
+    "detected_at",
+    "expires_at",
+    "generated_at",
+    "observed_at",
+})
+_SURQL_DATETIME_RE: re.Pattern[str] = re.compile(
+    r'"('
+    + "|".join(sorted(_SURQL_DATETIME_FIELDS))
+    + r')":\s*"(\d{4}-\d{2}-\d{2}T[^"]+Z)"'
+)
+
+
+def _payload_to_surql_content(payload: dict[str, Any]) -> str:
+    """Serialize *payload* to a SurrealQL CONTENT string.
+
+    Behaves like ``json.dumps(payload, ensure_ascii=True, sort_keys=True)``
+    but additionally converts allowlisted ISO-8601-Z datetime string values to
+    SurrealQL datetime literals so that SurrealDB v2 SCHEMAFULL ``TYPE datetime``
+    fields accept them via the HTTP ``/sql`` endpoint.
+
+    Only field names in ``_SURQL_DATETIME_FIELDS`` are affected, and only when
+    the value matches an ISO-8601 timestamp ending in ``Z``.  All other string
+    values are left as plain JSON strings.
+    """
+    raw = json.dumps(payload, ensure_ascii=True, sort_keys=True)
+    return _SURQL_DATETIME_RE.sub(r'"\1": d"\2"', raw)
+
 
 EXIT_OK = 0
 EXIT_VALIDATION_ERROR = 1
@@ -1263,7 +1303,7 @@ class SurrealDBLocalContextApplyAdapter:
         self, table: str, record_id: str, payload: dict[str, Any]
     ) -> None:
         rid = self._surql_record_id(table, record_id)
-        payload_json = json.dumps(payload, ensure_ascii=True, sort_keys=True)
+        payload_json = _payload_to_surql_content(payload)
         sql = f"UPSERT {rid} CONTENT {payload_json};"
         self._sql_request(sql)
 
@@ -1271,7 +1311,7 @@ class SurrealDBLocalContextApplyAdapter:
         self, table: str, record_id: str, payload: dict[str, Any]
     ) -> None:
         rid = self._surql_record_id(table, record_id)
-        payload_json = json.dumps(payload, ensure_ascii=True, sort_keys=True)
+        payload_json = _payload_to_surql_content(payload)
         sql = f"UPSERT {rid} CONTENT {payload_json};"
         self._sql_request(sql)
 
@@ -1296,7 +1336,7 @@ class SurrealDBLocalContextApplyAdapter:
         )
         domain_payload = {k: v for k, v in payload.items() if k not in _meta}
         rid = self._surql_record_id(table, record_id)
-        payload_json = json.dumps(domain_payload, ensure_ascii=True, sort_keys=True)
+        payload_json = _payload_to_surql_content(domain_payload)
         sql = f"UPSERT {rid} CONTENT {payload_json};"
         self._sql_request(sql)
 
@@ -1646,9 +1686,9 @@ def _build_payload_for_op(
         return payload, ts_iso
 
     # For create/update: write the actual JSONL domain payload to the adapter.
-    # Internal importer fields (__line) are stripped at plan-build time;
-    # any remaining envelope fields (schema_version, run_id) are present
-    # in the payload but silently dropped by SCHEMAFULL tables in SurrealDB.
+    # Envelope fields (schema_version, run_id, sensitivity, __line) are stripped
+    # at plan-build time via _JSONL_INTERNAL_FIELDS; remaining fields are the
+    # domain payload declared in the table schema.
     db_payload = dict(op.payload) if op.payload is not None else {}
     return db_payload, None
 

--- a/tools/surrealdb/context_indexer.py
+++ b/tools/surrealdb/context_indexer.py
@@ -15,6 +15,7 @@ import re
 import subprocess
 import tomllib
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -231,14 +232,20 @@ class RepoArtifact:
             "artifact_id": self.artifact_id,
             "source_path": self.source_path,
             "file_type": self.file_type,
+            "artifact_type": self.file_type,
             "raw_sha256": self.raw_sha256,
             "normalized_sha256": self.normalized_sha256,
             "source_hash": self.normalized_sha256,
             "integrity_algo": "sha256",
             "size_bytes": self.size_bytes,
-            "git_commit": self.git_commit,
-            "observed_at": self.observed_at,
+            "observed_at": _normalize_observed_at(self.observed_at),
             "sensitivity": self.sensitivity,
+            "source_url": "",
+            "source_commit": self.git_commit or "",
+            "mime_type": "",
+            "freshness": "current",
+            "confidence": 1.0,
+            "comment": "",
         }
 
     def to_state_payload(self) -> dict[str, Any]:
@@ -273,9 +280,13 @@ class DocPage:
             "source_hash": self.source_hash,
             "title": self.title,
             "doc_format": self.doc_format,
-            "git_commit": self.git_commit,
-            "observed_at": self.observed_at,
+            "observed_at": _normalize_observed_at(self.observed_at),
             "sensitivity": self.sensitivity,
+            "source_url": "",
+            "source_commit": self.git_commit or "",
+            "freshness": "current",
+            "confidence": 1.0,
+            "comment": "",
         }
 
 
@@ -298,15 +309,16 @@ class DocSection:
             "run_id": run_id,
             "section_id": self.section_id,
             "page_id": self.page_id,
-            "page_ref": f"doc_page:{self.page_id}",
             "source_path": self.source_path,
             "source_hash": self.source_hash,
-            "heading": self.heading,
+            "heading": self.heading if self.heading else "[intro]",
             "heading_path": self.heading_path,
             "section_level": self.section_level,
             "section_index": self.section_index,
             "span_start_line": self.span_start_line,
             "span_end_line": self.span_end_line,
+            "confidence": 1.0,
+            "comment": "",
         }
 
 
@@ -330,9 +342,7 @@ class DocChunk:
             "run_id": run_id,
             "chunk_id": self.chunk_id,
             "page_id": self.page_id,
-            "page_ref": f"doc_page:{self.page_id}",
             "section_id": self.section_id,
-            "section_ref": f"doc_section:{self.section_id}",
             "source_path": self.source_path,
             "source_hash": self.source_hash,
             "heading_path": self.heading_path,
@@ -342,6 +352,8 @@ class DocChunk:
             "content": self.content,
             "content_hash": self.content_hash,
             "tokens_estimate": estimate_tokens(self.content),
+            "confidence": 1.0,
+            "comment": "",
         }
 
     def to_state_payload(self) -> dict[str, Any]:
@@ -566,8 +578,10 @@ class DependencyEdge:
             "to_id": self.to_id,
             "edge_type": self.edge_type,
             "source_path": self.source_path,
-            "confidence": self.confidence,
+            "confidence": {"high": 1.0, "medium": 0.7, "low": 0.3}.get(self.confidence, 1.0),
+            "evidence_level": "inferred",
             "inferred": self.inferred,
+            "comment": "",
         }
 
 
@@ -881,6 +895,17 @@ def _utc_now() -> str:
     dt = cdb_utcnow().replace(microsecond=0)
     iso = dt.isoformat().replace("+00:00", "")
     return iso if iso.endswith("Z") else iso + "Z"
+
+
+def _normalize_observed_at(value: str) -> str:
+    """Normalize any ISO 8601 datetime string to a UTC naive string for SurrealDB TYPE datetime."""
+    try:
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt.replace(microsecond=0).isoformat() + "Z"
+    except (ValueError, AttributeError):
+        return value
 
 
 def _resolve_existing_root(path: Path) -> Path:


### PR DESCRIPTION
## Summary

Makes the local SurrealDB Context/Wissens-Pipeline smoke test importable end-to-end with a smoke-only ingestion scope.

This PR:
- adds `CONTEXT_SCOPE_CONFIG` support for context scan
- exports JSONL during `context-scan`
- adds a smoke-only ingestion scope without weakening canonical forbidden patterns
- exports Markdown intro sections with a non-empty `[intro]` heading
- serializes allowlisted datetime fields as SurrealQL datetime literals for the `surrealdb-local` adapter
- adds unit coverage for datetime literal serialization

## Files

- `Makefile`
- `infrastructure/config/surrealdb/context_ingestion_scope.smoke.yaml`
- `tools/surrealdb/context_indexer.py`
- `tools/surrealdb/context_importer.py`
- `tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py`

## Validation

- `ruff check tools/surrealdb/context_importer.py tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py`
- `pytest tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py -v -m unit`
- `make CONTEXT_SCOPE_CONFIG=infrastructure/config/surrealdb/context_ingestion_scope.smoke.yaml context-smoke-db`

Local DB-backed smoke result:
- Schema: 18/18 tables OK
- Scan: JSONL generated, no blocking `content_forbidden_pattern`
- Import: 10,166 records applied
- Query smoke: PASS, `show-snapshot` count 100

## Safety

- Smoke-only scope, not canonical ingestion scope
- Canonical `context_ingestion_scope.yaml` unchanged
- Forbidden patterns are not weakened
- No schema change
- No DB reset
- No Docker volume delete
- No trading
- No real money
- LR remains NO-GO

## Known non-goals / follow-ups

- `doc_section`, `doc_chunk`, and `dependency_edge` TYPE record contract remains a separate follow-up
- 9 large `doc_page` HTTP 400 payload-size failures remain a separate follow-up
- Windows `python3` Makefile portability remains a separate follow-up if needed