### PR TITLE
fix(surrealdb): map doc record refs for local import

### DIFF
--- a/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
+++ b/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
@@ -799,3 +799,147 @@ def test_payload_to_surql_content_roundtrip() -> None:
     result4 = _payload_to_surql_content({"observed_at": None})
     assert '"observed_at": null' in result4
     assert "d\"" not in result4
+
+
+@pytest.mark.unit
+def test_payload_to_surql_content_record_ref_unquoted() -> None:
+    """page_ref / section_ref record-ref strings are unquoted in CONTENT (#2577)."""
+    result = _payload_to_surql_content({
+        "page_ref": "doc_page:\u27e8page-example\u27e9",
+        "title": "Example",
+    })
+    assert '"page_ref": doc_page:\u27e8page-example\u27e9' in result
+    assert '"title": "Example"' in result
+    # Must not appear quoted
+    assert '"page_ref": "doc_page:' not in result
+
+
+@pytest.mark.unit
+def test_payload_to_surql_content_section_ref_unquoted() -> None:
+    """section_ref record-ref strings are unquoted in CONTENT (#2577)."""
+    result = _payload_to_surql_content({
+        "section_ref": "doc_section:\u27e8section-example\u27e9",
+    })
+    assert '"section_ref": doc_section:\u27e8section-example\u27e9' in result
+    assert '"section_ref": "doc_section:' not in result
+
+
+@pytest.mark.unit
+def test_payload_to_surql_content_datetime_regression_after_ascii_change() -> None:
+    """ensure_ascii=False must not break the existing datetime literal conversion."""
+    result = _payload_to_surql_content({
+        "observed_at": "2026-05-18T19:50:12Z",
+        "title": "still works",
+    })
+    assert '"observed_at": d"2026-05-18T19:50:12Z"' in result
+    assert '"title": "still works"' in result
+
+
+@pytest.mark.unit
+def test_apply_create_doc_section_page_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """apply_create for doc_section: page_id is remapped to page_ref record ref (#2577).
+
+    Input payload uses page_id (JSONL contract); the SQL CONTENT must contain
+    an unquoted page_ref record ref and must NOT contain page_id.
+    """
+    sent = _capture_sql(monkeypatch)
+    adapter = _make_adapter()
+
+    adapter.apply_create(
+        "doc_section",
+        "section-example",
+        {
+            "section_id": "section-example",
+            "page_id": "page-example",
+            "heading": "Example",
+            "source_path": "docs/example.md",
+        },
+    )
+
+    assert len(sent) == 1
+    content_part = sent[0].split("CONTENT", 1)[1]
+    # page_ref must be an unquoted SurrealDB record ref
+    assert '"page_ref": doc_page:\u27e8page-example\u27e9' in content_part
+    # page_id must not appear in DB payload
+    assert '"page_id"' not in content_part
+    # page_ref value must NOT be a quoted JSON string
+    assert '"page_ref": "' not in content_part
+
+
+@pytest.mark.unit
+def test_apply_create_doc_chunk_page_ref_and_section_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """apply_create for doc_chunk: page_id + section_id remapped to record refs (#2577).
+
+    Input payload uses page_id and section_id (JSONL contract); the SQL CONTENT
+    must contain unquoted page_ref and section_ref record refs.
+    """
+    sent = _capture_sql(monkeypatch)
+    adapter = _make_adapter()
+
+    adapter.apply_create(
+        "doc_chunk",
+        "chunk-example",
+        {
+            "chunk_id": "chunk-example",
+            "page_id": "page-example",
+            "section_id": "section-example",
+            "content": "safe context",
+            "source_path": "docs/example.md",
+        },
+    )
+
+    assert len(sent) == 1
+    content_part = sent[0].split("CONTENT", 1)[1]
+    assert '"page_ref": doc_page:\u27e8page-example\u27e9' in content_part
+    assert '"section_ref": doc_section:\u27e8section-example\u27e9' in content_part
+    assert '"page_id"' not in content_part
+    assert '"section_id"' not in content_part
+    assert '"page_ref": "' not in content_part
+    assert '"section_ref": "' not in content_part
+
+
+@pytest.mark.unit
+def test_apply_update_doc_section_page_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """apply_update for doc_section also remaps page_id to page_ref (#2577)."""
+    sent = _capture_sql(monkeypatch)
+    adapter = _make_adapter()
+
+    adapter.apply_update(
+        "doc_section",
+        "section-upd",
+        {
+            "section_id": "section-upd",
+            "page_id": "page-upd",
+            "heading": "Updated",
+            "source_path": "docs/updated.md",
+        },
+    )
+
+    content_part = sent[0].split("CONTENT", 1)[1]
+    assert '"page_ref": doc_page:\u27e8page-upd\u27e9' in content_part
+    assert '"page_id"' not in content_part
+
+
+@pytest.mark.unit
+def test_apply_create_non_ref_table_payload_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tables without record-ref mappings must pass payload through unchanged (#2577 regression)."""
+    sent = _capture_sql(monkeypatch)
+    adapter = _make_adapter()
+
+    adapter.apply_create(
+        "repo_artifact",
+        "art-1",
+        {"artifact_id": "art-1", "source_path": "src/main.py"},
+    )
+
+    content_part = sent[0].split("CONTENT", 1)[1]
+    assert '"artifact_id": "art-1"' in content_part
+    assert '"source_path": "src/main.py"' in content_part

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -438,21 +438,89 @@ _SURQL_DATETIME_RE: re.Pattern[str] = re.compile(
     + r')":\s*"(\d{4}-\d{2}-\d{2}T[^"]+Z)"'
 )
 
+# Record-ref field names that must be written as unquoted SurrealDB record refs
+# rather than plain JSON strings.  doc_section.page_ref and doc_chunk.page_ref /
+# section_ref are in scope for this slice; dependency_edge.from_ref/to_ref require
+# indexer table-qualification and are handled in a separate follow-up slice.
+_SURQL_RECORD_REF_FIELDS: frozenset[str] = frozenset({"page_ref", "section_ref"})
+# Matches the JSON-serialised form of a record-ref value produced by
+# _remap_record_refs_for_db_payload after json.dumps(..., ensure_ascii=False).
+# ensure_ascii=False is required so that U+27E8/U+27E9 (⟨⟩) appear as literal
+# Unicode chars in the JSON output and can be matched by this pattern.
+# Example input:  "page_ref": "doc_page:⟨page-example⟩"
+# Capture groups: (1) field name, (2) table:⟨id⟩  (without quotes)
+_SURQL_RECORD_REF_RE: re.Pattern[str] = re.compile(
+    '"('
+    + "|".join(sorted(_SURQL_RECORD_REF_FIELDS))
+    + ')":\\s*"((?:doc_page|doc_section):\u27e8[^\u27e9]+\u27e9)"'
+)
+
+# Maps SurrealDB table name → [(src_field, dst_field, target_table), ...]
+# _remap_record_refs_for_db_payload uses this to convert plain-string ID fields
+# emitted by the indexer (e.g. page_id) into SurrealDB record-ref strings
+# (e.g. page_ref = "doc_page:⟨id⟩") before the DB-write payload is serialised.
+# The JSONL contract (page_id / section_id) is not changed; only the adapter
+# payload for create/update is remapped.
+_TABLE_RECORD_REF_REMAP: dict[str, list[tuple[str, str, str]]] = {
+    "doc_section": [("page_id", "page_ref", "doc_page")],
+    "doc_chunk": [
+        ("page_id", "page_ref", "doc_page"),
+        ("section_id", "section_ref", "doc_section"),
+    ],
+}
+
+
+def _remap_record_refs_for_db_payload(
+    table: str, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """Remap plain-string ID fields to SurrealDB record-ref strings for *table*.
+
+    For tables listed in ``_TABLE_RECORD_REF_REMAP``, pops the source field
+    (e.g. ``page_id``) and inserts the destination field (e.g. ``page_ref``)
+    with a record-ref string in the form ``"doc_page:\u27e8<id>\u27e9"``.
+    The ref string is later unquoted by ``_payload_to_surql_content`` via
+    ``_SURQL_RECORD_REF_RE``, producing a valid SurrealDB ``TYPE record`` value.
+
+    If a required source ID is absent or not a non-empty string the mapping is
+    skipped for that field; downstream SurrealDB ``TYPE record`` validation will
+    surface the missing ref rather than having the importer silently guess.
+
+    All other tables are returned unchanged (no-op).
+    """
+    mappings = _TABLE_RECORD_REF_REMAP.get(table)
+    if not mappings:
+        return payload
+    result = dict(payload)
+    for src_field, dst_field, target_table in mappings:
+        raw_id = result.pop(src_field, None)
+        if raw_id and isinstance(raw_id, str):
+            escaped = raw_id.replace("\u27e9", "\\u27e9")
+            result[dst_field] = f"{target_table}:\u27e8{escaped}\u27e9"
+    return result
+
 
 def _payload_to_surql_content(payload: dict[str, Any]) -> str:
     """Serialize *payload* to a SurrealQL CONTENT string.
 
-    Behaves like ``json.dumps(payload, ensure_ascii=True, sort_keys=True)``
-    but additionally converts allowlisted ISO-8601-Z datetime string values to
-    SurrealQL datetime literals so that SurrealDB v2 SCHEMAFULL ``TYPE datetime``
-    fields accept them via the HTTP ``/sql`` endpoint.
+    Behaves like ``json.dumps(payload, ensure_ascii=False, sort_keys=True)``
+    but additionally:
 
-    Only field names in ``_SURQL_DATETIME_FIELDS`` are affected, and only when
-    the value matches an ISO-8601 timestamp ending in ``Z``.  All other string
-    values are left as plain JSON strings.
+    - converts allowlisted ISO-8601-Z datetime string values to SurrealQL
+      datetime literals (``d"..."``) via ``_SURQL_DATETIME_RE``; and
+    - unquotes allowlisted record-ref string values (e.g.
+      ``"doc_page:\u27e8id\u27e9"``) so SurrealDB accepts them as
+      ``TYPE record`` values via ``_SURQL_RECORD_REF_RE``.
+
+    ``ensure_ascii=False`` is required so that SurrealDB bracket chars
+    U+27E8/U+27E9 (⟨⟩) appear as literal Unicode in the JSON output,
+    enabling the ``_SURQL_RECORD_REF_RE`` pattern to match them.
+    All existing field values are ASCII-safe, so this change is backward
+    compatible with the datetime-literal path.
     """
-    raw = json.dumps(payload, ensure_ascii=True, sort_keys=True)
-    return _SURQL_DATETIME_RE.sub(r'"\1": d"\2"', raw)
+    raw = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    raw = _SURQL_DATETIME_RE.sub(r'"\1": d"\2"', raw)
+    raw = _SURQL_RECORD_REF_RE.sub(r'"\1": \2', raw)
+    return raw
 
 
 EXIT_OK = 0
@@ -1303,7 +1371,8 @@ class SurrealDBLocalContextApplyAdapter:
         self, table: str, record_id: str, payload: dict[str, Any]
     ) -> None:
         rid = self._surql_record_id(table, record_id)
-        payload_json = _payload_to_surql_content(payload)
+        db_payload = _remap_record_refs_for_db_payload(table, payload)
+        payload_json = _payload_to_surql_content(db_payload)
         sql = f"UPSERT {rid} CONTENT {payload_json};"
         self._sql_request(sql)
 
@@ -1311,7 +1380,8 @@ class SurrealDBLocalContextApplyAdapter:
         self, table: str, record_id: str, payload: dict[str, Any]
     ) -> None:
         rid = self._surql_record_id(table, record_id)
-        payload_json = _payload_to_surql_content(payload)
+        db_payload = _remap_record_refs_for_db_payload(table, payload)
+        payload_json = _payload_to_surql_content(db_payload)
         sql = f"UPSERT {rid} CONTENT {payload_json};"
         self._sql_request(sql)
 


### PR DESCRIPTION
## Summary
Maps document JSONL IDs to SurrealDB `TYPE record` fields during local context import.

This PR:
- maps `doc_section.page_id` to `doc_section.page_ref`
- maps `doc_chunk.page_id` to `doc_chunk.page_ref`
- maps `doc_chunk.section_id` to `doc_chunk.section_ref`
- serializes those DB payload fields as SurrealQL record refs
- keeps the JSONL producer/input contract unchanged

## Scope
- `tools/surrealdb/context_importer.py`
- `tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py`
- doc_section/doc_chunk record refs only

## Explicit Non-Goals
- No `dependency_edge.from_ref` / `dependency_edge.to_ref` implementation
- No schema change
- No indexer change
- No DB reset
- No Docker restart
- No schema apply
- No trading/runtime scope
- No live-readiness change

`dependency_edge` remains intentionally open for a separate table-qualified follow-up slice.

## Validation
- `pytest -q tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py -m unit`
- `pytest -q tests/unit/surrealdb/test_context_import_plan.py -m unit`
- `pytest -q tests/unit/surrealdb/test_context_import_jsonl_validation.py -m unit`
- `pytest -q tests/unit/surrealdb/test_context_smoke_db_contracts.py -m unit`
- `ruff check tools/surrealdb/context_importer.py tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py`
- `make -n PYTHON=python context-smoke-db`

## Safety
- Context Infrastructure only
- LR remains NO-GO
- No Echtgeld / live trading implication

Refs #2577
