### PR TITLE
fix(surrealdb): map dependency_edge record refs for local import

### DIFF
--- a/tests/unit/surrealdb/test_context_symbol_extraction.py
+++ b/tests/unit/surrealdb/test_context_symbol_extraction.py
@@ -481,6 +481,8 @@ def test_derive_dependency_edges_contains() -> None:
     for edge in contains_edges:
         assert edge.from_id == artifact.artifact_id
         assert edge.inferred is False
+        assert edge.from_table == "repo_artifact"
+        assert edge.to_table == "code_symbol"
 
 
 @pytest.mark.unit
@@ -501,6 +503,8 @@ def test_derive_dependency_edges_imports_resolved() -> None:
     assert import_edges[0].from_id == src_artifact.artifact_id
     assert import_edges[0].to_id == target_artifact.artifact_id
     assert import_edges[0].inferred is False
+    assert import_edges[0].from_table == "repo_artifact"
+    assert import_edges[0].to_table == "repo_artifact"
 
 
 @pytest.mark.unit
@@ -513,9 +517,8 @@ def test_derive_dependency_edges_imports_inferred_when_not_resolved() -> None:
     import_edges = [e for e in edges if e.edge_type == "imports"]
     assert len(import_edges) == 1
     assert import_edges[0].inferred is True
-
-
-# ---------------------------------------------------------------------------
+    assert import_edges[0].from_table == "repo_artifact"
+    assert import_edges[0].to_table == "module"
 # Absolute import submodule resolution (Codex review fix — #2062 addendum P1)
 # ---------------------------------------------------------------------------
 
@@ -736,6 +739,8 @@ def test_derive_dependency_edges_documents_resolved() -> None:
     assert all(e.inferred is False for e in doc_edges)
     tf_sym = next(s for s in symbols if s.qualified_name == "top_level_function")
     assert any(e.to_id == tf_sym.symbol_id for e in doc_edges)
+    assert all(e.from_table == "repo_artifact" for e in doc_edges)
+    assert all(e.to_table == "code_symbol" for e in doc_edges)
 
 
 @pytest.mark.unit
@@ -748,9 +753,27 @@ def test_derive_dependency_edges_mentions_unresolved() -> None:
     mentions_edges = [e for e in edges if e.edge_type == "mentions"]
     assert len(mentions_edges) == 1
     assert mentions_edges[0].inferred is True
+    assert mentions_edges[0].from_table == "repo_artifact"
+    assert mentions_edges[0].to_table == "symbol_mention"
 
 
-# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_dependency_edge_to_payload_includes_from_to_table() -> None:
+    """to_payload() must emit from_table/to_table for importer record-ref remap."""
+    artifact = _make_artifact("services/svc.py")
+    symbols, _ = extract_code_symbols(artifact, _PYTHON_SAMPLE)
+    edges = derive_dependency_edges([artifact], symbols, [], [])
+
+    contains_edges = [e for e in edges if e.edge_type == "contains"]
+    assert contains_edges, "expected at least one contains edge"
+    payload = contains_edges[0].to_payload("run-test")
+    assert payload["from_table"] == "repo_artifact"
+    assert payload["to_table"] == "code_symbol"
+    assert "from_id" in payload
+    assert "to_id" in payload
+
+
+
 # Issue #2063: JSONL export extension
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
+++ b/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
@@ -943,3 +943,107 @@ def test_apply_create_non_ref_table_payload_unchanged(
     content_part = sent[0].split("CONTENT", 1)[1]
     assert '"artifact_id": "art-1"' in content_part
     assert '"source_path": "src/main.py"' in content_part
+
+
+# ---------------------------------------------------------------------------
+# dependency_edge record-ref remap (#2577 follow-up)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_apply_create_dependency_edge_with_real_tables_produces_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dependency_edge with real from_table/to_table produces from_ref/to_ref (#2577)."""
+    sent = _capture_sql(monkeypatch)
+    adapter = _make_adapter()
+
+    adapter.apply_create(
+        "dependency_edge",
+        "edge-contains-1",
+        {
+            "edge_id": "edge-contains-1",
+            "edge_type": "contains",
+            "from_id": "repo_artifact:abc123",
+            "from_table": "repo_artifact",
+            "to_id": "code_symbol:def456",
+            "to_table": "code_symbol",
+            "inferred": False,
+        },
+    )
+
+    content_part = sent[0].split("CONTENT", 1)[1]
+    assert "from_ref" in content_part
+    assert "to_ref" in content_part
+    assert '"from_ref": repo_artifact:\u27e8repo_artifact:abc123\u27e9' in content_part
+    assert '"to_ref": code_symbol:\u27e8code_symbol:def456\u27e9' in content_part
+    assert '"from_id"' not in content_part
+    assert '"to_id"' not in content_part
+    assert '"from_table"' not in content_part
+    assert '"to_table"' not in content_part
+
+
+@pytest.mark.unit
+def test_apply_create_dependency_edge_virtual_to_table_omits_to_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dependency_edge with virtual to_table (e.g. 'module') omits to_ref (#2577).
+
+    Virtual tables are not in _KNOWN_SURQL_RECORD_TABLES; the importer must not
+    produce a to_ref and must still pop from_id/to_id/from_table/to_table from
+    the payload (they are not SurrealDB schema fields).
+    """
+    sent = _capture_sql(monkeypatch)
+    adapter = _make_adapter()
+
+    adapter.apply_create(
+        "dependency_edge",
+        "edge-inferred-1",
+        {
+            "edge_id": "edge-inferred-1",
+            "edge_type": "imports",
+            "from_id": "repo_artifact:src123",
+            "from_table": "repo_artifact",
+            "to_id": "module:os",
+            "to_table": "module",  # virtual — not a schema table
+            "inferred": True,
+        },
+    )
+
+    content_part = sent[0].split("CONTENT", 1)[1]
+    assert "from_ref" in content_part
+    assert "to_ref" not in content_part
+    assert '"to_id"' not in content_part
+    assert '"from_id"' not in content_part
+    assert '"from_table"' not in content_part
+    assert '"to_table"' not in content_part
+
+
+@pytest.mark.unit
+def test_apply_create_dependency_edge_no_table_fields_no_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Old JSONL without from_table/to_table must not crash (#2577 backward compat)."""
+    sent = _capture_sql(monkeypatch)
+    adapter = _make_adapter()
+
+    adapter.apply_create(
+        "dependency_edge",
+        "edge-old-1",
+        {
+            "edge_id": "edge-old-1",
+            "edge_type": "contains",
+            "from_id": "repo_artifact:old123",
+            "to_id": "code_symbol:old456",
+            # no from_table / to_table
+            "inferred": False,
+        },
+    )
+
+    content_part = sent[0].split("CONTENT", 1)[1]
+    # No refs produced because table information is missing
+    assert "from_ref" not in content_part
+    assert "to_ref" not in content_part
+    # ID fields must still be popped (they are not schema fields)
+    assert '"from_id"' not in content_part
+    assert '"to_id"' not in content_part

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -438,21 +438,31 @@ _SURQL_DATETIME_RE: re.Pattern[str] = re.compile(
     + r')":\s*"(\d{4}-\d{2}-\d{2}T[^"]+Z)"'
 )
 
+# SurrealDB table names that have a real schema table (from TABLE_BY_ARTIFACT).
+# Used by _remap_record_refs_for_db_payload to gate dependency_edge ref building:
+# virtual nodes (e.g. "module", "symbol_mention") are absent and refs are skipped.
+_KNOWN_SURQL_RECORD_TABLES: frozenset[str] = frozenset(TABLE_BY_ARTIFACT.values())
+
 # Record-ref field names that must be written as unquoted SurrealDB record refs
-# rather than plain JSON strings.  doc_section.page_ref and doc_chunk.page_ref /
-# section_ref are in scope for this slice; dependency_edge.from_ref/to_ref require
-# indexer table-qualification and are handled in a separate follow-up slice.
-_SURQL_RECORD_REF_FIELDS: frozenset[str] = frozenset({"page_ref", "section_ref"})
+# rather than plain JSON strings.
+_SURQL_RECORD_REF_FIELDS: frozenset[str] = frozenset(
+    {"from_ref", "page_ref", "section_ref", "to_ref"}
+)
 # Matches the JSON-serialised form of a record-ref value produced by
 # _remap_record_refs_for_db_payload after json.dumps(..., ensure_ascii=False).
 # ensure_ascii=False is required so that U+27E8/U+27E9 (⟨⟩) appear as literal
 # Unicode chars in the JSON output and can be matched by this pattern.
 # Example input:  "page_ref": "doc_page:⟨page-example⟩"
 # Capture groups: (1) field name, (2) table:⟨id⟩  (without quotes)
+# Table prefix alternation is derived from _KNOWN_SURQL_RECORD_TABLES so that
+# doc_page/doc_section (existing) and repo_artifact/code_symbol (dependency_edge)
+# are all covered without hardcoding.
 _SURQL_RECORD_REF_RE: re.Pattern[str] = re.compile(
     '"('
     + "|".join(sorted(_SURQL_RECORD_REF_FIELDS))
-    + ')":\\s*"((?:doc_page|doc_section):\u27e8[^\u27e9]+\u27e9)"'
+    + ')":\\s*"((?:'
+    + "|".join(sorted(_KNOWN_SURQL_RECORD_TABLES))
+    + '):\u27e8[^\u27e9]+\u27e9)"'
 )
 
 # Maps SurrealDB table name → [(src_field, dst_field, target_table), ...]
@@ -478,25 +488,46 @@ def _remap_record_refs_for_db_payload(
     For tables listed in ``_TABLE_RECORD_REF_REMAP``, pops the source field
     (e.g. ``page_id``) and inserts the destination field (e.g. ``page_ref``)
     with a record-ref string in the form ``"doc_page:\u27e8<id>\u27e9"``.
+
+    For ``dependency_edge`` the source and target tables are dynamic and come
+    from ``from_table``/``to_table`` payload fields emitted by the indexer.
+    Both ``from_id``/``to_id`` and ``from_table``/``to_table`` are always
+    popped from the DB payload (they are not SurrealDB schema fields).  If
+    ``from_table``/``to_table`` name a real schema table (present in
+    ``_KNOWN_SURQL_RECORD_TABLES``) the corresponding ``from_ref``/``to_ref``
+    record-ref is built; otherwise the field is omitted and SurrealDB's own
+    ``TYPE record`` constraint will surface the gap.  Virtual/inferred nodes
+    (``module``, ``symbol_mention``) fall into this category — edges that
+    target them continue to fail import the same as before this change.
+
     The ref string is later unquoted by ``_payload_to_surql_content`` via
     ``_SURQL_RECORD_REF_RE``, producing a valid SurrealDB ``TYPE record`` value.
-
-    If a required source ID is absent or not a non-empty string the mapping is
-    skipped for that field; downstream SurrealDB ``TYPE record`` validation will
-    surface the missing ref rather than having the importer silently guess.
 
     All other tables are returned unchanged (no-op).
     """
     mappings = _TABLE_RECORD_REF_REMAP.get(table)
-    if not mappings:
-        return payload
-    result = dict(payload)
-    for src_field, dst_field, target_table in mappings:
-        raw_id = result.pop(src_field, None)
-        if raw_id and isinstance(raw_id, str):
-            escaped = raw_id.replace("\u27e9", "\\u27e9")
-            result[dst_field] = f"{target_table}:\u27e8{escaped}\u27e9"
-    return result
+    if mappings is not None:
+        result = dict(payload)
+        for src_field, dst_field, target_table in mappings:
+            raw_id = result.pop(src_field, None)
+            if raw_id and isinstance(raw_id, str):
+                escaped = raw_id.replace("\u27e9", "\\u27e9")
+                result[dst_field] = f"{target_table}:\u27e8{escaped}\u27e9"
+        return result
+    if table == "dependency_edge":
+        result = dict(payload)
+        from_table = result.pop("from_table", None)
+        to_table = result.pop("to_table", None)
+        from_id = result.pop("from_id", None)
+        to_id = result.pop("to_id", None)
+        if from_table in _KNOWN_SURQL_RECORD_TABLES and from_id and isinstance(from_id, str):
+            escaped = from_id.replace("\u27e9", "\\u27e9")
+            result["from_ref"] = f"{from_table}:\u27e8{escaped}\u27e9"
+        if to_table in _KNOWN_SURQL_RECORD_TABLES and to_id and isinstance(to_id, str):
+            escaped = to_id.replace("\u27e9", "\\u27e9")
+            result["to_ref"] = f"{to_table}:\u27e8{escaped}\u27e9"
+        return result
+    return payload
 
 
 def _payload_to_surql_content(payload: dict[str, Any]) -> str:

--- a/tools/surrealdb/context_indexer.py
+++ b/tools/surrealdb/context_indexer.py
@@ -568,6 +568,12 @@ class DependencyEdge:
     source_path: str | None
     confidence: str
     inferred: bool
+    # SurrealDB table names for from_id/to_id endpoints.  Empty string means
+    # the target is a virtual/inferred node (e.g. "module", "symbol_mention")
+    # that has no corresponding SurrealDB table; the importer skips record-ref
+    # construction for those endpoints.
+    from_table: str = ""
+    to_table: str = ""
 
     def to_payload(self, run_id: str) -> dict[str, Any]:
         return {
@@ -577,6 +583,8 @@ class DependencyEdge:
             "from_id": self.from_id,
             "to_id": self.to_id,
             "edge_type": self.edge_type,
+            "from_table": self.from_table,
+            "to_table": self.to_table,
             "source_path": self.source_path,
             "confidence": {"high": 1.0, "medium": 0.7, "low": 0.3}.get(self.confidence, 1.0),
             "evidence_level": "inferred",
@@ -1633,6 +1641,8 @@ def derive_dependency_edges(
                 source_path=symbol.source_path,
                 confidence="high",
                 inferred=False,
+                from_table="repo_artifact",
+                to_table="code_symbol",
             )
         )
 
@@ -1720,6 +1730,8 @@ def derive_dependency_edges(
                     source_path=imp_ref.source_path,
                     confidence="high",
                     inferred=False,
+                    from_table="repo_artifact",
+                    to_table="repo_artifact",
                 )
             )
         else:
@@ -1738,6 +1750,8 @@ def derive_dependency_edges(
                     source_path=imp_ref.source_path,
                     confidence="high",
                     inferred=True,
+                    from_table="repo_artifact",
+                    to_table="module",
                 )
             )
 
@@ -1762,6 +1776,8 @@ def derive_dependency_edges(
                     source_path=link.source_path,
                     confidence="high",
                     inferred=False,
+                    from_table="repo_artifact",
+                    to_table="code_symbol",
                 )
             )
         else:
@@ -1780,6 +1796,8 @@ def derive_dependency_edges(
                     source_path=link.source_path,
                     confidence="high",
                     inferred=True,
+                    from_table="repo_artifact",
+                    to_table="symbol_mention",
                 )
             )
 


### PR DESCRIPTION
## Summary
Maps \dependency_edge\ JSONL IDs to SurrealDB \TYPE record\ fields during local context import.

This PR:
- extends \DependencyEdge\ with \rom_table\/\	o_table\ fields (indexer)
- populates those fields at all 5 \DependencyEdge()\ call sites
- adds \_KNOWN_SURQL_RECORD_TABLES\ constant to the importer
- extends \_SURQL_RECORD_REF_FIELDS\/\_SURQL_RECORD_REF_RE\ to cover \rom_ref\/\	o_ref\
- adds \dependency_edge\ remap case to \_remap_record_refs_for_db_payload\
- skips virtual targets (\module\, \symbol_mention\) — not real schema tables
- keeps JSONL input contract unchanged (backward compatible)

## Scope
- \	ools/surrealdb/context_indexer.py\
- \	ools/surrealdb/context_importer.py\
- \	ests/unit/surrealdb/test_context_symbol_extraction.py\
- \	ests/unit/surrealdb/test_surrealdb_local_apply_adapter.py\

## Explicit Non-Goals
- No schema change (\context_intelligence_v0.surql\ unchanged)
- No \dependency_edge.from_ref\/\	o_ref\ for virtual targets (not schema tables)
- No doc changes
- No Makefile/workflow changes
- No DB reset / Docker restart / schema apply
- No trading/runtime scope
- No live-readiness change

## Validation
- \pytest -q tests/unit/surrealdb/ -m unit\ — 1193 passed
- \uff check tools/surrealdb/context_indexer.py tools/surrealdb/context_importer.py tests/unit/surrealdb/test_context_symbol_extraction.py tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py\ — all checks passed
- \make -n PYTHON=python context-smoke-db\ — dry-run clean

## Safety
- Context Infrastructure only
- LR remains NO-GO
- No Echtgeld / live trading implication

Refs #2577