### PR TITLE
fix(surrealdb): escape supplementary Unicode in doc_page SQL payloads

### DIFF
--- a/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
+++ b/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
@@ -836,6 +836,43 @@ def test_payload_to_surql_content_datetime_regression_after_ascii_change() -> No
 
 
 @pytest.mark.unit
+def test_payload_to_surql_content_escapes_supplementary_unicode() -> None:
+    """Supplementary-plane chars (emoji) are escaped as JSON surrogate pairs (#2578).
+
+    SurrealDB's HTTP /sql endpoint returns HTTP 400 for statements that contain
+    literal 4-byte UTF-8 codepoints (U+10000+).  _payload_to_surql_content must
+    convert them to \\uXXXX\\uYYYY surrogate pair escape sequences.
+    """
+    # 🚀 = U+1F680; surrogate pair: U+D83D U+DE80
+    result = _payload_to_surql_content({"title": "\U0001f680 QUICK START"})
+    assert "\\ud83d\\ude80" in result
+    assert "\U0001f680" not in result
+
+    # 🤖 = U+1F916; surrogate pair: U+D83E U+DD16
+    result2 = _payload_to_surql_content({"title": "\U0001f916 Agent Guide"})
+    assert "\\ud83e\\udd16" in result2
+    assert "\U0001f916" not in result2
+
+
+@pytest.mark.unit
+def test_payload_to_surql_content_bmp_unicode_unchanged() -> None:
+    """BMP Unicode (U+0000–U+FFFF) must NOT be escaped, especially ⟨⟩ for record refs.
+
+    The ⟨⟩ bracket chars (U+27E8/U+27E9) must remain as literal Unicode so that
+    _SURQL_RECORD_REF_RE can match and unquote record-ref values.
+    The em dash (—, U+2014) and similar BMP chars in titles must also pass through.
+    """
+    # ⟨⟩ chars in a record ref must stay literal so the regex can match and unquote
+    result = _payload_to_surql_content({"page_ref": "doc_page:\u27e8bmp-id\u27e9"})
+    assert '"page_ref": doc_page:\u27e8bmp-id\u27e9' in result
+    assert '"page_ref": "doc_page:' not in result  # must be unquoted
+
+    # BMP non-ASCII in title (e.g. em-dash) must appear literally
+    result2 = _payload_to_surql_content({"title": "Session \u2014 2026"})
+    assert '"title": "Session \u2014 2026"' in result2
+
+
+@pytest.mark.unit
 def test_apply_create_doc_section_page_ref(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -465,6 +465,22 @@ _SURQL_RECORD_REF_RE: re.Pattern[str] = re.compile(
     + '):\u27e8[^\u27e9]+\u27e9)"'
 )
 
+# Supplementary-plane Unicode characters (U+10000–U+10FFFF, e.g. emoji) are encoded
+# as 4-byte UTF-8 sequences when json.dumps(..., ensure_ascii=False) is used.
+# SurrealDB's HTTP /sql endpoint returns HTTP 400 for statements that contain literal
+# 4-byte UTF-8 code points in string values (confirmed by all 9 doc_page failures in
+# import-run10.json — every failing title contains emoji; all 593 passing ones do not).
+# BMP characters (U+0000–U+FFFF), including the ⟨⟩ bracket chars used for record refs,
+# are not affected and must remain as literal Unicode for _SURQL_RECORD_REF_RE to match.
+_SUPPLEMENTARY_UNICODE_RE: re.Pattern[str] = re.compile(r"[\U00010000-\U0010FFFF]")
+
+
+def _escape_supplementary(m: re.Match[str]) -> str:
+    """Convert a supplementary-plane code point to a JSON \\uXXXX\\uYYYY surrogate pair."""
+    cp = ord(m.group()) - 0x10000
+    return f"\\u{0xD800 | (cp >> 10):04x}\\u{0xDC00 | (cp & 0x3FF):04x}"
+
+
 # Maps SurrealDB table name → [(src_field, dst_field, target_table), ...]
 # _remap_record_refs_for_db_payload uses this to convert plain-string ID fields
 # emitted by the indexer (e.g. page_id) into SurrealDB record-ref strings
@@ -536,6 +552,12 @@ def _payload_to_surql_content(payload: dict[str, Any]) -> str:
     Behaves like ``json.dumps(payload, ensure_ascii=False, sort_keys=True)``
     but additionally:
 
+    - escapes supplementary-plane Unicode code points (U+10000–U+10FFFF,
+      e.g. emoji in ``title`` fields) as JSON ``\\uXXXX\\uYYYY`` surrogate
+      pairs via ``_SUPPLEMENTARY_UNICODE_RE``.  SurrealDB's HTTP ``/sql``
+      endpoint returns HTTP 400 for statements containing literal 4-byte
+      UTF-8 codepoints; BMP chars (U+0000–U+FFFF), including the ⟨⟩ bracket
+      chars used for record refs, are intentionally left as literal Unicode;
     - converts allowlisted ISO-8601-Z datetime string values to SurrealQL
       datetime literals (``d"..."``) via ``_SURQL_DATETIME_RE``; and
     - unquotes allowlisted record-ref string values (e.g.
@@ -545,10 +567,9 @@ def _payload_to_surql_content(payload: dict[str, Any]) -> str:
     ``ensure_ascii=False`` is required so that SurrealDB bracket chars
     U+27E8/U+27E9 (⟨⟩) appear as literal Unicode in the JSON output,
     enabling the ``_SURQL_RECORD_REF_RE`` pattern to match them.
-    All existing field values are ASCII-safe, so this change is backward
-    compatible with the datetime-literal path.
     """
     raw = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    raw = _SUPPLEMENTARY_UNICODE_RE.sub(_escape_supplementary, raw)
     raw = _SURQL_DATETIME_RE.sub(r'"\1": d"\2"', raw)
     raw = _SURQL_RECORD_REF_RE.sub(r'"\1": \2', raw)
     return raw


### PR DESCRIPTION
## Summary
Fixes the root cause of 9 recurring \doc_page\ HTTP 400 failures during local context import.

The issue title says 'oversized payloads' — that is a misdiagnosis.
The actual cause: \json.dumps(ensure_ascii=False)\ emits literal 4-byte UTF-8 for emoji (U+10000+) in \	itle\ fields; SurrealDB's HTTP \/sql\ endpoint returns HTTP 400 for such statements.
Evidence: all 9 failing pages have supplementary-plane emoji in \	itle\; all 593 passing pages do not. Correlation: 100%.

This PR:
- adds \_SUPPLEMENTARY_UNICODE_RE\ and \_escape_supplementary\ helper at module level
- applies surrogate-pair escaping in \_payload_to_surql_content\ after \json.dumps\
- BMP chars (U+0000–U+FFFF), including the ⟨⟩ bracket chars required for record refs, are intentionally left as literal Unicode
- emoji in fields like \doc_page.title\ (e.g. 🚀 U+1F680, 🤖 U+1F916) now emit \\uXXXX\uYYYY\ surrogate pair escapes
- fixes docstring: removes the false 'ASCII-safe' claim, documents emoji escaping behaviour

## Scope
- \	ools/surrealdb/context_importer.py\
- \	ests/unit/surrealdb/test_surrealdb_local_apply_adapter.py\

## Explicit Non-Goals
- No schema change (\doc_page.title TYPE string\ is correct; the fix is in the serializer layer)
- No indexer change
- No \doc_page\ oversized-content field (confirmed: \doc_pages.jsonl\ has no \content\ field)
- No DB reset
- No Docker restart
- No schema apply
- No trading/runtime scope
- No live-readiness change

## Validation
- \pytest -q tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py -m unit\ → 45 passed
- \pytest -q tests/unit/surrealdb/ -m unit\ → 1195 passed
- \uff check tools/surrealdb/context_importer.py tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py\ → clean
- \make -n PYTHON=python context-smoke-db\ → dry-run green

## Safety
- Context Infrastructure only
- LR remains NO-GO
- No Echtgeld / live trading implication

Refs #2578