### PR TITLE
fix(surrealdb): preserve literal UTF-8 emoji, strip doc_page JSONL-only fields

### DIFF
--- a/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
+++ b/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
@@ -304,6 +304,77 @@ def test_http_500_raises_apply_adapter_error(monkeypatch: pytest.MonkeyPatch) ->
 
 
 @pytest.mark.unit
+def test_http_400_error_includes_response_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HTTP 400 ApplyAdapterError must embed the SurrealDB response body for diagnosis."""
+    adapter = _make_adapter()
+    surrealdb_msg = b'{"code":400,"information":"Parse error near supplementary unicode"}'
+
+    class FakeHTTPError(urllib.error.HTTPError):
+        def read(self) -> bytes:
+            return surrealdb_msg
+
+    http_err = FakeHTTPError(
+        url=f"{_LOCAL_URL}/sql",
+        code=400,
+        msg="Bad Request",
+        hdrs=None,  # type: ignore[arg-type]
+        fp=None,  # type: ignore[arg-type]
+    )
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *a, **kw: (_ for _ in ()).throw(http_err),
+    )
+
+    with pytest.raises(ApplyAdapterError, match="Parse error near supplementary unicode"):
+        adapter.apply_create("doc_page", "abc", {"title": "test"})
+
+
+@pytest.mark.unit
+def test_apply_create_emoji_title_sends_literal_utf8(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SQL sent to SurrealDB must use literal UTF-8 for emoji titles, not surrogate pairs.
+
+    SurrealDB 3.0.4 accepts literal UTF-8 supplementary-plane chars and explicitly
+    rejects the JSON surrogate-pair escape notation (\\uXXXX\\uYYYY), returning HTTP 400
+    "Parse error: … not a valid unicode character".
+    """
+    adapter = _make_adapter()
+    captured: list[bytes] = []
+
+    def fake_urlopen(req, timeout=None):
+        captured.append(req.data)
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        resp.status = 200
+        resp.read.return_value = json.dumps([{"status": "OK", "result": []}]).encode()
+        return resp
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    adapter.apply_create(
+        "doc_page",
+        "sha256abc",
+        {
+            "title": "🚀 Launch doc",
+            "source_path": "/a.md",
+            "source_url": "file:///a.md",
+            "source_hash": "abc",
+            "source_hash_algo": "sha256",
+        },
+    )
+
+    assert captured, "urlopen was not called"
+    sql_bytes = captured[0]
+    sql_text = sql_bytes.decode("utf-8")
+    # Literal rocket emoji MUST appear in the SQL wire bytes (UTF-8 encoded)
+    assert "\U0001f680" in sql_text
+    # Surrogate-pair escapes must NOT be present — SurrealDB 3.0.4 rejects them
+    assert "\\ud83d\\ude80" not in sql_text
+
+
+@pytest.mark.unit
 def test_connection_refused_raises_apply_adapter_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -836,22 +907,23 @@ def test_payload_to_surql_content_datetime_regression_after_ascii_change() -> No
 
 
 @pytest.mark.unit
-def test_payload_to_surql_content_escapes_supplementary_unicode() -> None:
-    """Supplementary-plane chars (emoji) are escaped as JSON surrogate pairs (#2578).
+def test_payload_to_surql_content_preserves_supplementary_unicode() -> None:
+    """Supplementary-plane chars (emoji) must be preserved as literal UTF-8 (#2586).
 
-    SurrealDB's HTTP /sql endpoint returns HTTP 400 for statements that contain
-    literal 4-byte UTF-8 codepoints (U+10000+).  _payload_to_surql_content must
-    convert them to \\uXXXX\\uYYYY surrogate pair escape sequences.
+    SurrealDB 3.0.4 accepts literal UTF-8 supplementary-plane chars and explicitly
+    rejects the JSON surrogate-pair escape notation (\\uXXXX\\uYYYY), returning HTTP 400
+    "Parse error: … not a valid unicode character".  _payload_to_surql_content must
+    leave them as literal Unicode, not escape them.
     """
-    # 🚀 = U+1F680; surrogate pair: U+D83D U+DE80
+    # 🚀 = U+1F680 — must appear literally, no surrogate pairs
     result = _payload_to_surql_content({"title": "\U0001f680 QUICK START"})
-    assert "\\ud83d\\ude80" in result
-    assert "\U0001f680" not in result
+    assert "\U0001f680" in result
+    assert "\\ud83d\\ude80" not in result
 
-    # 🤖 = U+1F916; surrogate pair: U+D83E U+DD16
+    # 🤖 = U+1F916 — must appear literally, no surrogate pairs
     result2 = _payload_to_surql_content({"title": "\U0001f916 Agent Guide"})
-    assert "\\ud83e\\udd16" in result2
-    assert "\U0001f916" not in result2
+    assert "\U0001f916" in result2
+    assert "\\ud83e\\udd16" not in result2
 
 
 @pytest.mark.unit
@@ -983,10 +1055,58 @@ def test_apply_create_non_ref_table_payload_unchanged(
 
 
 # ---------------------------------------------------------------------------
-# SCHEMAFULL extra-field stripping (#2584)
+# SCHEMAFULL extra-field stripping (#2584, #2586)
+# doc_page:    schema_version, run_id, sensitivity
 # doc_section: section_level, source_path
 # doc_chunk:   source_path, heading_path, previous_chunk_id, next_chunk_id
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_apply_create_doc_page_schemafull_extra_fields_stripped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """apply_create for doc_page strips schema_version, run_id, sensitivity (#2586).
+
+    All three fields are emitted by the indexer but not declared in the SCHEMAFULL
+    schema (context_intelligence_v0.surql).  They must be absent from the SQL CONTENT
+    so SurrealDB does not reject the statement.
+    """
+    sent = _capture_sql(monkeypatch)
+    adapter = _make_adapter()
+
+    adapter.apply_create(
+        "doc_page",
+        "sha256-test-page",
+        {
+            "schema_version": "v0",
+            "run_id": "run-abc123",
+            "page_id": "sha256-test-page",
+            "source_path": "docs/example.md",
+            "source_hash": "abc123",
+            "source_hash_algo": "sha256",
+            "title": "Example Page",
+            "doc_format": "markdown",
+            "observed_at": "2026-05-19T14:00:00Z",
+            "sensitivity": "public",
+            "source_url": "file:///docs/example.md",
+            "source_commit": "abc",
+            "freshness": "fresh",
+            "confidence": 1.0,
+            "comment": "",
+        },
+    )
+
+    assert len(sent) == 1
+    content_part = sent[0].split("CONTENT", 1)[1]
+    # Schema-declared fields must be present
+    assert '"page_id": "sha256-test-page"' in content_part
+    assert '"title": "Example Page"' in content_part
+    assert '"source_path": "docs/example.md"' in content_part
+    # Extra fields not in schema must be absent
+    assert '"schema_version"' not in content_part
+    assert '"run_id"' not in content_part
+    assert '"sensitivity"' not in content_part
 
 
 @pytest.mark.unit

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -467,18 +467,14 @@ _SURQL_RECORD_REF_RE: re.Pattern[str] = re.compile(
 
 # Supplementary-plane Unicode characters (U+10000–U+10FFFF, e.g. emoji) are encoded
 # as 4-byte UTF-8 sequences when json.dumps(..., ensure_ascii=False) is used.
-# SurrealDB's HTTP /sql endpoint returns HTTP 400 for statements that contain literal
-# 4-byte UTF-8 code points in string values (confirmed by all 9 doc_page failures in
-# import-run10.json — every failing title contains emoji; all 593 passing ones do not).
+# SurrealDB 3.0.4's HTTP /sql endpoint accepts literal UTF-8 supplementary-plane code
+# points (U+10000–U+10FFFF, e.g. emoji) in string values.  It explicitly REJECTS the
+# JSON surrogate-pair escape notation (\uD83D\uDE80); the parser returns HTTP 400 with
+# "Parse error: String contains invalid escape sequence, unicode escape character is not
+# a valid unicode character."  Therefore literal UTF-8 (ensure_ascii=False) is the
+# correct serialisation and no supplementary-Unicode escaping is applied.
 # BMP characters (U+0000–U+FFFF), including the ⟨⟩ bracket chars used for record refs,
-# are not affected and must remain as literal Unicode for _SURQL_RECORD_REF_RE to match.
-_SUPPLEMENTARY_UNICODE_RE: re.Pattern[str] = re.compile(r"[\U00010000-\U0010FFFF]")
-
-
-def _escape_supplementary(m: re.Match[str]) -> str:
-    """Convert a supplementary-plane code point to a JSON \\uXXXX\\uYYYY surrogate pair."""
-    cp = ord(m.group()) - 0x10000
-    return f"\\u{0xD800 | (cp >> 10):04x}\\u{0xDC00 | (cp & 0x3FF):04x}"
+# remain as literal Unicode so that _SURQL_RECORD_REF_RE can match them.
 
 
 # Maps SurrealDB table name → [(src_field, dst_field, target_table), ...]
@@ -504,6 +500,10 @@ _TABLE_RECORD_REF_REMAP: dict[str, list[tuple[str, str, str]]] = {
 # happens only at DB-write time inside _remap_record_refs_for_db_payload and
 # apply_tombstone.
 _TABLE_DB_EXTRA_STRIP_FIELDS: dict[str, frozenset[str]] = {
+    # schema_version / run_id / sensitivity: indexer pipeline metadata emitted by
+    # context_indexer.py but not declared in the doc_page schema.  Stripped at
+    # DB-write time to avoid SCHEMAFULL rejection.
+    "doc_page": frozenset({"schema_version", "run_id", "sensitivity"}),
     # section_level: derivable from len(heading_path); not in schema.
     # source_path: accessible via page_ref -> doc_page; redundant in DB.
     "doc_section": frozenset({"section_level", "source_path"}),
@@ -543,7 +543,9 @@ def _remap_record_refs_for_db_payload(
     The ref string is later unquoted by ``_payload_to_surql_content`` via
     ``_SURQL_RECORD_REF_RE``, producing a valid SurrealDB ``TYPE record`` value.
 
-    All other tables are returned unchanged (no-op).
+    For any table listed in ``_TABLE_DB_EXTRA_STRIP_FIELDS``, the named fields
+    are stripped from the payload before returning so that SCHEMAFULL tables do
+    not reject the DB write.  All other tables are returned unchanged.
     """
     mappings = _TABLE_RECORD_REF_REMAP.get(table)
     if mappings is not None:
@@ -571,6 +573,10 @@ def _remap_record_refs_for_db_payload(
             escaped = to_id.replace("\u27e9", "\\u27e9")
             result["to_ref"] = f"{to_table}:\u27e8{escaped}\u27e9"
         return result
+    # For tables not covered above, apply any declared field stripping.
+    extra_strip = _TABLE_DB_EXTRA_STRIP_FIELDS.get(table)
+    if extra_strip:
+        return {k: v for k, v in payload.items() if k not in extra_strip}
     return payload
 
 
@@ -580,16 +586,15 @@ def _payload_to_surql_content(payload: dict[str, Any]) -> str:
     Behaves like ``json.dumps(payload, ensure_ascii=False, sort_keys=True)``
     but additionally:
 
-    - escapes supplementary-plane Unicode code points (U+10000–U+10FFFF,
-      e.g. emoji in ``title`` fields) as JSON ``\\uXXXX\\uYYYY`` surrogate
-      pairs via ``_SUPPLEMENTARY_UNICODE_RE``.  SurrealDB's HTTP ``/sql``
-      endpoint returns HTTP 400 for statements containing literal 4-byte
-      UTF-8 codepoints; BMP chars (U+0000–U+FFFF), including the ⟨⟩ bracket
-      chars used for record refs, are intentionally left as literal Unicode;
+    - preserves supplementary-plane Unicode code points (U+10000–U+10FFFF,
+      e.g. emoji in ``title`` fields) as literal UTF-8.  SurrealDB 3.0.4
+      accepts literal UTF-8 for supplementary chars and explicitly rejects
+      the JSON surrogate-pair escape notation (\\uXXXX\\uYYYY), returning
+      HTTP 400 "Parse error: … not a valid unicode character";
     - converts allowlisted ISO-8601-Z datetime string values to SurrealQL
       datetime literals (``d"..."``) via ``_SURQL_DATETIME_RE``; and
     - unquotes allowlisted record-ref string values (e.g.
-      ``"doc_page:\u27e8id\u27e9"``) so SurrealDB accepts them as
+      ``"doc_page:\\u27e8id\\u27e9"``) so SurrealDB accepts them as
       ``TYPE record`` values via ``_SURQL_RECORD_REF_RE``.
 
     ``ensure_ascii=False`` is required so that SurrealDB bracket chars
@@ -597,7 +602,6 @@ def _payload_to_surql_content(payload: dict[str, Any]) -> str:
     enabling the ``_SURQL_RECORD_REF_RE`` pattern to match them.
     """
     raw = json.dumps(payload, ensure_ascii=False, sort_keys=True)
-    raw = _SUPPLEMENTARY_UNICODE_RE.sub(_escape_supplementary, raw)
     raw = _SURQL_DATETIME_RE.sub(r'"\1": d"\2"', raw)
     raw = _SURQL_RECORD_REF_RE.sub(r'"\1": \2', raw)
     return raw
@@ -1401,8 +1405,10 @@ class SurrealDBLocalContextApplyAdapter:
             ) from exc
 
         if status not in (200, 204):
+            body_snippet = body.decode("utf-8", errors="replace")[:400].strip()
+            detail = f" — {body_snippet}" if body_snippet else ""
             raise ApplyAdapterError(
-                f"surrealdb-local HTTP {status} — check container is running"
+                f"surrealdb-local HTTP {status} — check container is running{detail}"
             )
 
         try:


### PR DESCRIPTION
## Summary

refs #2586 — 9 \doc_page\ records with emoji titles failed HTTP import.

### Root Causes

**1. Surrogate-pair regression (PR #2583)**
\_escape_supplementary\ converted emoji to surrogate-pair notation (\\uD83D\uDE80\).
SurrealDB 3.0.4 rejects this with HTTP 400: *'unicode escape character is not a valid unicode character'*.
Literal UTF-8 supplementary-plane characters are accepted — no escaping needed.

**2. SCHEMAFULL field mismatch: \un_id\ / \schema_version\ / \sensitivity\**
The current \doc_pages.jsonl\ (regenerated after #2583) includes three indexer-pipeline
fields that are not declared in the SCHEMAFULL \doc_page\ schema, causing SurrealDB to
reject ALL \doc_page\ UPSERT statements with \status=ERR\.

### Fixes

| Fix | File | Change |
|-----|------|--------|
| A — Remove surrogate escaping | \context_importer.py\ | Remove \_SUPPLEMENTARY_UNICODE_RE\ + \_escape_supplementary\; update docstring to explain literal-UTF-8 is correct |
| B — Strip \doc_page\ extra fields | \context_importer.py\ | Add \doc_page\ → \{schema_version, run_id, sensitivity}\ to \_TABLE_DB_EXTRA_STRIP_FIELDS\; add fallback strip branch in \_remap_record_refs_for_db_payload\ |
| C — HTTP error body in ApplyAdapterError | \context_importer.py\ | Embed SurrealDB HTTP 400 response body (truncated, no secrets) in error message |

### Tests

- \	est_apply_create_emoji_title_sends_literal_utf8\ — literal emoji in SQL, no surrogate pairs
- \	est_payload_to_surql_content_preserves_supplementary_unicode\ — emoji preserved literally
- \	est_apply_create_doc_page_schemafull_extra_fields_stripped\ — new: run_id/schema_version/sensitivity absent from CONTENT
- \	est_http_400_error_includes_response_body\ — new: HTTP 400 body surfaced in error

**1204/1204 unit tests pass, ruff clean.**

### Cascade

The 541 \doc_section\ + 355 \doc_chunk\ failures in Issue #2586 are expected to be
cascade from the 9 failed \doc_page\ parents. After this fix both root causes are
resolved; a real smoke run should confirm.

refs #2578, #2583, #2584, #2586