### PR TITLE
fix(surrealdb): defer virtual dependency edges during import

### DIFF
--- a/tests/unit/surrealdb/test_context_import_plan.py
+++ b/tests/unit/surrealdb/test_context_import_plan.py
@@ -412,3 +412,73 @@ def test_import_order_ends_with_wave14_in_dependency_order(tmp_path: Path, capsy
         "decision_event",
         "agent_memory",
     ]
+
+
+# ---------------------------------------------------------------------------
+# dependency_edge virtual-target skip (#2585)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_plan_dependency_edge_virtual_to_table_skipped(
+    tmp_path: Path, capsys
+) -> None:
+    """dep_edge with virtual to_table must produce action=skip, not create (#2585).
+
+    symbol_mention and similar virtual node types have no real SurrealDB table.
+    Attempting a DB write for such edges always fails with a schema constraint error.
+    The plan must mark them as skip with reason containing 'deferred_virtual_target'.
+    """
+    records = _valid_records()
+    records["dependency_edges"] = [
+        _base_record(
+            edge_id="edge-virtual-1",
+            from_id="repo_artifact:abc123",
+            to_id="symbol_mention:def456",
+            edge_type="mentions",
+            from_table="repo_artifact",
+            to_table="symbol_mention",  # virtual — not a real SurrealDB table
+        )
+    ]
+    for artifact, items in records.items():
+        _write_jsonl(tmp_path, artifact, items)
+
+    assert main(["plan", "--input-dir", str(tmp_path)]) == EXIT_OK
+    payload = _read_json(capsys)
+
+    dep_actions = [a for a in payload["actions"] if a["table"] == "dependency_edge"]
+    assert len(dep_actions) == 1
+    assert dep_actions[0]["action"] == "skip"
+    assert "deferred_virtual_target" in dep_actions[0]["reason"]
+    assert "symbol_mention" in dep_actions[0]["reason"]
+
+
+@pytest.mark.unit
+def test_plan_dependency_edge_real_to_table_creates(
+    tmp_path: Path, capsys
+) -> None:
+    """dep_edge with a real to_table must produce action=create, not skip (#2585).
+
+    When both from_table and to_table are real SurrealDB tables, the edge is
+    importable and must be planned as a create action.
+    """
+    records = _valid_records()
+    records["dependency_edges"] = [
+        _base_record(
+            edge_id="edge-real-1",
+            from_id="repo_artifact:abc123",
+            to_id="code_symbol:def456",
+            edge_type="contains",
+            from_table="repo_artifact",
+            to_table="code_symbol",  # real table
+        )
+    ]
+    for artifact, items in records.items():
+        _write_jsonl(tmp_path, artifact, items)
+
+    assert main(["plan", "--input-dir", str(tmp_path)]) == EXIT_OK
+    payload = _read_json(capsys)
+
+    dep_actions = [a for a in payload["actions"] if a["table"] == "dependency_edge"]
+    assert len(dep_actions) == 1
+    assert dep_actions[0]["action"] == "create"

--- a/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
+++ b/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
@@ -1449,3 +1449,73 @@ def test_apply_create_dependency_edge_no_table_fields_no_crash(
     # ID fields must still be popped (they are not schema fields)
     assert '"from_id"' not in content_part
     assert '"to_id"' not in content_part
+
+
+# ---------------------------------------------------------------------------
+# dependency_edge source_path → source_ref remap (#2585)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_apply_create_dependency_edge_source_path_remapped_to_source_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """source_path in dep_edge payload must be remapped to source_ref (#2585).
+
+    The indexer emits source_path; the schema declares source_ref TYPE string.
+    _remap_record_refs_for_db_payload must rename the field so SurrealDB's
+    SCHEMAFULL constraint is satisfied and the undeclared source_path key is removed.
+    """
+    sent = _capture_sql(monkeypatch)
+    adapter = _make_adapter()
+
+    adapter.apply_create(
+        "dependency_edge",
+        "edge-src-ref-1",
+        {
+            "edge_id": "edge-src-ref-1",
+            "edge_type": "contains",
+            "from_id": "repo_artifact:abc123",
+            "from_table": "repo_artifact",
+            "to_id": "code_symbol:def456",
+            "to_table": "code_symbol",
+            "source_path": "docs/live-readiness/LR-007.md",
+            "inferred": False,
+        },
+    )
+
+    content_part = sent[0].split("CONTENT", 1)[1]
+    assert '"source_ref": "docs/live-readiness/LR-007.md"' in content_part
+    assert '"source_path"' not in content_part
+
+
+@pytest.mark.unit
+def test_apply_create_dependency_edge_source_path_absent_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dep_edge without source_path must not have source_path in DB payload (#2585).
+
+    When source_path is absent the conditional remap is skipped entirely, so
+    source_path must not appear in the CONTENT. An existing source_ref (if any)
+    is preserved unchanged.
+    """
+    sent = _capture_sql(monkeypatch)
+    adapter = _make_adapter()
+
+    adapter.apply_create(
+        "dependency_edge",
+        "edge-no-src-1",
+        {
+            "edge_id": "edge-no-src-1",
+            "edge_type": "contains",
+            "from_id": "repo_artifact:abc123",
+            "from_table": "repo_artifact",
+            "to_id": "code_symbol:def456",
+            "to_table": "code_symbol",
+            "inferred": False,
+            # no source_path
+        },
+    )
+
+    content_part = sent[0].split("CONTENT", 1)[1]
+    assert '"source_path"' not in content_part

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -572,6 +572,10 @@ def _remap_record_refs_for_db_payload(
         if to_table in _KNOWN_SURQL_RECORD_TABLES and to_id and isinstance(to_id, str):
             escaped = to_id.replace("\u27e9", "\\u27e9")
             result["to_ref"] = f"{to_table}:\u27e8{escaped}\u27e9"
+        # Remap indexer field name to schema field name (source_path → source_ref).
+        # Only remap when source_path is present so an existing source_ref is not clobbered.
+        if "source_path" in result:
+            result["source_ref"] = result.pop("source_path")
         return result
     # For tables not covered above, apply any declared field stripping.
     extra_strip = _TABLE_DB_EXTRA_STRIP_FIELDS.get(table)
@@ -2975,6 +2979,17 @@ def build_import_plan(
             else:
                 action = "create"
                 reason = "validated JSONL record; DB-independent candidate create"
+                # Defer dependency_edge records whose to_table is a virtual node type
+                # (not a real SurrealDB table). These cannot have a to_ref built and
+                # would always fail DB writes with a schema constraint error.
+                if table == "dependency_edge":
+                    to_table_val = record.get("to_table")
+                    if to_table_val and to_table_val not in _KNOWN_SURQL_RECORD_TABLES:
+                        action = "skip"
+                        reason = (
+                            f"deferred_virtual_target: to_table '{to_table_val}' "
+                            "has no real SurrealDB record table"
+                        )
                 seen_record_ids.add(record_id)
             actions.append(
                 ImportPlanAction(


### PR DESCRIPTION
## Summary
Fixes the remaining real local Context-Smoke dependency_edge import failure mode.

The real smoke showed all 5,618 \dependency_edge\ records failing because virtual targets such as \symbol_mention\ do not have real SurrealDB record tables, while the DB write path still tried to create them as normal dependency edges.

This PR:
- maps \dependency_edge.source_path\ to schema field \source_ref\
- strips undeclared \source_path\ from DB payloads
- defers dependency edges whose \	o_table\ is not a real SurrealDB record table
- records a clear \deferred_virtual_target\ skip reason instead of producing DB failures

## Scope
- \	ools/surrealdb/context_importer.py\
- \	ests/unit/surrealdb/test_surrealdb_local_apply_adapter.py\
- \	ests/unit/surrealdb/test_context_import_plan.py\

## Non-goals
- No schema change
- No indexer change
- No Makefile / Windows #2587 scope
- No DB reset
- No Docker restart
- No schema apply
- No trading/runtime scope
- No live-readiness change

## Validation
- \pytest -q tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py -m unit\
- \pytest -q tests/unit/surrealdb/test_context_import_plan.py -m unit\
- \pytest -q tests/unit/surrealdb/test_context_import_jsonl_validation.py -m unit\
- \pytest -q tests/unit/surrealdb/test_context_smoke_db_contracts.py -m unit\
- \pytest -q tests/unit/surrealdb/ -m unit\
- \uff check tools/surrealdb/context_importer.py tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py tests/unit/surrealdb/test_context_import_plan.py\
- \make -n PYTHON=python context-smoke-db\

## Safety
- Context Infrastructure only
- LR remains NO-GO
- No Echtgeld / live trading implication

Refs #2585