### PR TITLE
fix(ops): make context smoke db Windows-compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,12 @@ CONTEXT_SNAP_DIR ?= artifacts/context-intelligence/latest
 CONTEXT_SCOPE_CONFIG ?= infrastructure/config/surrealdb/context_ingestion_scope.yaml
 PYTHON ?= python3
 
+ifeq ($(OS),Windows_NT)
+  SECRETS_PATH ?= $(USERPROFILE)/Documents/.secrets/.cdb
+else
+  SECRETS_PATH ?= $(HOME)/Documents/.secrets/.cdb
+endif
+
 .PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke context-smoke-db
 
 help:
@@ -339,11 +345,11 @@ context-restart: context-down context-up
 
 context-schema-apply:
 	@echo "=== SurrealDB Schema Apply: context_intelligence_v0 ==="
-	@$(PYTHON) tools/surrealdb/local_schema_apply.py --secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}
+	@$(PYTHON) tools/surrealdb/local_schema_apply.py --secrets-path "$(SECRETS_PATH)"
 
 context-schema-check:
 	@echo "=== SurrealDB Schema Check: context_intelligence_v0 ==="
-	@$(PYTHON) tools/surrealdb/local_schema_check.py --secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}
+	@$(PYTHON) tools/surrealdb/local_schema_check.py --secrets-path "$(SECRETS_PATH)"
 
 context-reset-local:
 	@echo "=== SurrealDB Local Reset (DESTRUKTIV - nur Context-Intelligence-Daten) ==="
@@ -359,7 +365,7 @@ context-reset-local:
 
 context-scan:
 	@echo "=== Context Scan: Repo-Artefakte und Doc-Chunks (kein DB-Write) ==="
-	@mkdir -p $(CONTEXT_SNAP_DIR)
+	@$(PYTHON) -c "import pathlib; pathlib.Path('$(CONTEXT_SNAP_DIR)').mkdir(parents=True, exist_ok=True)"
 	@$(PYTHON) -m tools.surrealdb.context_indexer scan --apply-writes \
 		--scope-config $(CONTEXT_SCOPE_CONFIG) \
 		--output $(CONTEXT_SNAP_DIR)/scan-report.json
@@ -375,8 +381,8 @@ context-import-dry-run:
 
 context-import-local:
 	@echo "=== Context Local Import: Schreiben in lokale SurrealDB ==="
-	@$(PYTHON) tools/surrealdb/local_schema_check.py --secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}
-	@$(PYTHON) -m tools.surrealdb.context_importer apply --input-dir $(CONTEXT_SNAP_DIR) --surreal-url http://127.0.0.1:8010 --namespace cdb_context_local --database cdb_context_intel --apply --apply-mode local-dev --config infrastructure/config/surrealdb/context_import.local.example.yaml --run-id $$(date +%Y%m%d%H%M%S) --adapter surrealdb-local --secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}
+	@$(PYTHON) tools/surrealdb/local_schema_check.py --secrets-path "$(SECRETS_PATH)"
+	@$(PYTHON) -m tools.surrealdb.context_importer apply --input-dir $(CONTEXT_SNAP_DIR) --surreal-url http://127.0.0.1:8010 --namespace cdb_context_local --database cdb_context_intel --apply --apply-mode local-dev --config infrastructure/config/surrealdb/context_import.local.example.yaml --run-id $(shell $(PYTHON) tools/surrealdb/gen_run_id.py) --adapter surrealdb-local --secrets-path "$(SECRETS_PATH)"
 
 context-query-smoke:
 	@echo "=== Context Query Smoke (read-only, graceful fail wenn kein Container) ==="
@@ -406,7 +412,7 @@ context-smoke-db: context-env-check
 	@echo "NOTE: Lokaler Scope nur. LR: NO-GO. Kein Echtgeld. Kein Trading-Start."
 	@echo "--- Schritt 1: Hard Schema-Check (Container + Schema, fail-closed) ---"
 	@$(PYTHON) tools/surrealdb/local_schema_check.py --hard-mode \
-		--secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}
+		--secrets-path "$(SECRETS_PATH)"
 	@echo "--- Schritt 2: Scan (Snapshot + JSONL erzeugen) ---"
 	$(MAKE) context-scan
 	@echo "--- Schritt 3: Import (echter SurrealDB-Adapter, fail-closed) ---"
@@ -417,16 +423,16 @@ context-smoke-db: context-env-check
 		--database cdb_context_intel \
 		--apply --apply-mode local-dev \
 		--config infrastructure/config/surrealdb/context_import.local.example.yaml \
-		--run-id $$($(PYTHON) -c "import json; print(json.load(open('$(CONTEXT_SNAP_DIR)/snapshot.json'))['run_id'])") \
+		--run-id $(shell $(PYTHON) tools/surrealdb/gen_run_id.py $(CONTEXT_SNAP_DIR)/snapshot.json) \
 		--adapter surrealdb-local \
-		--secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb}
+		--secrets-path "$(SECRETS_PATH)"
 	@echo "--- Schritt 4: Query-Smoke (hard, >= 1 Record, fail-closed) ---"
 	@$(PYTHON) -m tools.surrealdb.context_query \
 		--adapter surrealdb-local \
 		--hard-mode \
 		--min-count 1 \
 		--config infrastructure/config/surrealdb/context_query.local.example.yaml \
-		--secrets-path $${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb} \
+		--secrets-path "$(SECRETS_PATH)" \
 		show-snapshot
 	@echo "[OK] context-smoke-db: fail-closed DB-backed smoke complete (LR: NO-GO)"
 

--- a/tests/unit/surrealdb/test_context_smoke_db_contracts.py
+++ b/tests/unit/surrealdb/test_context_smoke_db_contracts.py
@@ -32,6 +32,7 @@ import pytest
 # ---------------------------------------------------------------------------
 
 _MAKEFILE = Path(__file__).parents[3] / "Makefile"
+_GEN_RUN_ID = Path(__file__).parents[3] / "tools" / "surrealdb" / "gen_run_id.py"
 _EXAMPLE_QUERY_CONFIG = Path(
     "infrastructure/config/surrealdb/context_query.local.example.yaml"
 )
@@ -295,3 +296,152 @@ def test_makefile_context_smoke_db_uses_min_count() -> None:
     assert (
         "--min-count" in recipe_text
     ), "--min-count not found in context-smoke-db recipe (query step)"
+
+
+# ===========================================================================
+# Windows-compatibility contract tests (#2587)
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# 11. Makefile: no POSIX ${SECRETS_PATH:-...} in affected context targets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_makefile_no_posix_secrets_path_expansion() -> None:
+    """No POSIX parameter-expansion default syntax in context smoke targets (#2587)."""
+    content = _read_makefile()
+    posix_pattern = "${SECRETS_PATH:-"
+    targets = [
+        "context-schema-apply",
+        "context-schema-check",
+        "context-import-local",
+        "context-smoke-db",
+    ]
+    for target in targets:
+        recipe = _lines_for_target(content, target)
+        recipe_text = "\n".join(recipe)
+        assert posix_pattern not in recipe_text, (
+            f"POSIX secrets-path expansion '{posix_pattern}' still present in "
+            f"'{target}' recipe — breaks cmd.exe"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 12. Makefile: SECRETS_PATH Make variable defined in preamble
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_makefile_secrets_path_make_variable_defined() -> None:
+    """SECRETS_PATH must be defined as a Make variable (not shell expansion) (#2587)."""
+    content = _read_makefile()
+    assert "SECRETS_PATH ?=" in content, (
+        "SECRETS_PATH Make variable not found — required for Windows cmd.exe compat"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 13. Makefile: context-scan uses Python pathlib, not mkdir -p
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_makefile_context_scan_no_mkdir_p() -> None:
+    """context-scan must not use 'mkdir -p' (POSIX only) (#2587)."""
+    content = _read_makefile()
+    recipe = _lines_for_target(content, "context-scan")
+    assert recipe, "context-scan target has no recipe lines"
+    recipe_text = "\n".join(recipe)
+    assert "mkdir -p" not in recipe_text, (
+        "'mkdir -p' found in context-scan recipe — use Python pathlib instead"
+    )
+    assert "pathlib" in recipe_text, (
+        "Python pathlib not found in context-scan recipe — needed to replace mkdir -p"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 14. Makefile: context-smoke-db uses gen_run_id.py for run-id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_makefile_context_smoke_db_run_id_uses_gen_run_id() -> None:
+    """context-smoke-db must use gen_run_id.py for run-id, not shell command substitution (#2587)."""
+    content = _read_makefile()
+    recipe = _lines_for_target(content, "context-smoke-db")
+    recipe_text = "\n".join(recipe)
+    assert "gen_run_id.py" in recipe_text, (
+        "gen_run_id.py not found in context-smoke-db recipe — required for Windows compat"
+    )
+    assert "$$($(PYTHON)" not in recipe_text, (
+        "Shell command substitution '$$($(PYTHON) -c ...)' still present in "
+        "context-smoke-db — breaks cmd.exe"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 15. Makefile: context-import-local uses gen_run_id.py, not $(date ...)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_makefile_context_import_local_no_posix_date() -> None:
+    """context-import-local must not use '$(date ...)' (POSIX only) (#2587)."""
+    content = _read_makefile()
+    recipe = _lines_for_target(content, "context-import-local")
+    assert recipe, "context-import-local target has no recipe lines"
+    recipe_text = "\n".join(recipe)
+    assert "$(date " not in recipe_text, (
+        "'$(date ...)' found in context-import-local recipe — 'date' not in cmd.exe"
+    )
+    assert "gen_run_id.py" in recipe_text, (
+        "gen_run_id.py not found in context-import-local recipe — needed to replace $(date)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 16–17. gen_run_id.py unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_gen_run_id_file_exists() -> None:
+    """tools/surrealdb/gen_run_id.py must exist (#2587)."""
+    assert _GEN_RUN_ID.exists(), f"gen_run_id.py not found at {_GEN_RUN_ID}"
+
+
+@pytest.mark.unit
+def test_gen_run_id_generates_timestamp_without_args() -> None:
+    """gen_run_id with no args must return a 14-digit YYYYMMDDHHMMSS string (#2587)."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("gen_run_id", _GEN_RUN_ID)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+    result = mod._timestamp_run_id()
+    assert result.isdigit(), f"Expected all-digits timestamp, got: {result!r}"
+    assert len(result) == 14, f"Expected 14-digit timestamp YYYYMMDDHHMMSS, got: {result!r}"
+    # No % characters (cmd.exe safety)
+    assert "%" not in result, f"Timestamp contains '%' character: {result!r}"
+
+
+@pytest.mark.unit
+def test_gen_run_id_reads_run_id_from_snapshot(tmp_path: Path) -> None:
+    """gen_run_id with a snapshot.json arg must return run_id from that file (#2587)."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("gen_run_id", _GEN_RUN_ID)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+    snapshot = tmp_path / "snapshot.json"
+    snapshot.write_text(
+        json.dumps({"run_id": "20260520120000", "scope": "smoke"}), encoding="utf-8"
+    )
+    result = mod._run_id_from_snapshot(str(snapshot))
+    assert result == "20260520120000", f"Unexpected run_id: {result!r}"

--- a/tools/surrealdb/gen_run_id.py
+++ b/tools/surrealdb/gen_run_id.py
@@ -1,0 +1,49 @@
+"""Portable run-id generator for Makefile ``$(shell ...)`` use.
+
+Usage (no arguments):
+    python tools/surrealdb/gen_run_id.py
+    → prints a YYYYMMDDHHMMSS timestamp.
+      Uses integer formatting, not strftime % codes, so cmd.exe cannot
+      misinterpret the output as environment-variable references.
+
+Usage (one argument — path to snapshot.json):
+    python tools/surrealdb/gen_run_id.py artifacts/context-intelligence/latest/snapshot.json
+    → prints the ``run_id`` field from snapshot.json.
+
+Both modes print exactly one line with no trailing whitespace beyond the newline,
+making them safe for ``$(shell ...)`` capture in GNU Make.
+
+Issue: #2587
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def _timestamp_run_id() -> str:
+    """Return YYYYMMDDHHMMSS using f-string formatting (no % chars)."""
+    now = datetime.now()
+    return (
+        f"{now.year:04d}{now.month:02d}{now.day:02d}"
+        f"{now.hour:02d}{now.minute:02d}{now.second:02d}"
+    )
+
+
+def _run_id_from_snapshot(snapshot_path: str) -> str:
+    """Read run_id from a snapshot.json produced by context_indexer."""
+    data = json.loads(Path(snapshot_path).read_text(encoding="utf-8"))
+    return str(data["run_id"])
+
+
+def main() -> None:
+    if len(sys.argv) >= 2:
+        print(_run_id_from_snapshot(sys.argv[1]))
+    else:
+        print(_timestamp_run_id())
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/surrealdb/gen_run_id.py
+++ b/tools/surrealdb/gen_run_id.py
@@ -19,16 +19,16 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import datetime
+import time
 from pathlib import Path
 
 
 def _timestamp_run_id() -> str:
     """Return YYYYMMDDHHMMSS using f-string formatting (no % chars)."""
-    now = datetime.now()
+    t = time.localtime()
     return (
-        f"{now.year:04d}{now.month:02d}{now.day:02d}"
-        f"{now.hour:02d}{now.minute:02d}{now.second:02d}"
+        f"{t.tm_year:04d}{t.tm_mon:02d}{t.tm_mday:02d}"
+        f"{t.tm_hour:02d}{t.tm_min:02d}{t.tm_sec:02d}"
     )
 
 


### PR DESCRIPTION
## Summary
Makes the local Context/SurrealDB smoke Makefile path Windows-compatible.

The real local smoke could only be run through a PowerShell fallback because several Context targets still used POSIX-only shell constructs. This PR removes those bash-isms from the Context smoke path.

## What changed
- adds an OS-aware \SECRETS_PATH ?=\ Make default
- replaces POSIX \\\ expansion with \\\
- replaces \mkdir -p\ with a Python \pathlib.mkdir\ call
- replaces shell \date\ / inline run-id generation with \	ools/surrealdb/gen_run_id.py\
- adds contract tests for Windows-safe context-smoke-db dry-runs

## Scope
- \Makefile\
- \	ools/surrealdb/gen_run_id.py\
- \	ests/unit/surrealdb/test_context_smoke_db_contracts.py\

## Non-goals
- No schema change
- No importer change
- No indexer change
- No DB reset
- No Docker restart
- No schema apply
- No BLUE/RED stack change
- No trading/runtime scope
- No live-readiness change

## Validation
- \pytest -q tests/unit/surrealdb/test_context_smoke_db_contracts.py -m unit\
- \uff check tools/surrealdb/gen_run_id.py tests/unit/surrealdb/test_context_smoke_db_contracts.py\
- \make -n PYTHON=python context-smoke-db\
- \make -n PYTHON=python context-schema-check\
- \make -n PYTHON=python context-scan\
- \make -n PYTHON=python context-import-local\
- \make -n PYTHON=python context-query-smoke\

## Safety
- Context Infrastructure only
- LR remains NO-GO
- No Echtgeld / live trading implication

Refs #2587