### PR TITLE
fix(surrealdb): use smoke scope in context smoke scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ context-smoke-db: context-env-check
 	@$(PYTHON) tools/surrealdb/local_schema_check.py --hard-mode \
 		--secrets-path "$(SECRETS_PATH)"
 	@echo "--- Schritt 2: Scan (Snapshot + JSONL erzeugen) ---"
-	$(MAKE) context-scan
+	$(MAKE) context-scan CONTEXT_SCOPE_CONFIG=infrastructure/config/surrealdb/context_ingestion_scope.smoke.yaml
 	@echo "--- Schritt 3: Import (echter SurrealDB-Adapter, fail-closed) ---"
 	@$(PYTHON) -m tools.surrealdb.context_importer apply \
 		--input-dir $(CONTEXT_SNAP_DIR) \

--- a/tests/unit/surrealdb/test_context_indexer.py
+++ b/tests/unit/surrealdb/test_context_indexer.py
@@ -573,6 +573,30 @@ def test_validation_blocks_secret_pattern_in_included_content(tmp_path: Path) ->
     assert "content_forbidden_pattern" in codes
 
 
+_SMOKE_SCOPE_CONFIG = Path(
+    "infrastructure/config/surrealdb/context_ingestion_scope.smoke.yaml"
+)
+
+
+@pytest.mark.unit
+def test_smoke_scope_has_zero_content_forbidden_pattern_findings() -> None:
+    """Smoke scope scan of the live repo must produce 0 content_forbidden_pattern findings (#2592).
+
+    Regression guard: ensures that context-smoke-db will not fail-close on
+    content_forbidden_pattern after the CONTEXT_SCOPE_CONFIG override in the Makefile.
+    The smoke scope excludes all paths known to contain credential-like patterns.
+    """
+    result = run_indexer(Path("."), _SMOKE_SCOPE_CONFIG)
+    forbidden = [
+        f for f in result.blocking_findings if f.code == "content_forbidden_pattern"
+    ]
+    assert forbidden == [], (
+        f"Smoke scope produced {len(forbidden)} content_forbidden_pattern "
+        "blocking finding(s):\n"
+        + "\n".join(f"  {f.source_path or '(no path)'}" for f in forbidden)
+    )
+
+
 @pytest.mark.unit
 def test_jsonl_records_and_snapshot_are_consistent(tmp_path: Path) -> None:
     fixture_root = _copy_fixture_repo(tmp_path, "repo_clean")

--- a/tests/unit/surrealdb/test_context_smoke_db_contracts.py
+++ b/tests/unit/surrealdb/test_context_smoke_db_contracts.py
@@ -429,6 +429,32 @@ def test_gen_run_id_generates_timestamp_without_args() -> None:
     assert "%" not in result, f"Timestamp contains '%' character: {result!r}"
 
 
+# ---------------------------------------------------------------------------
+# 18. Makefile: context-smoke-db passes smoke scope config to context-scan (#2592)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_makefile_context_smoke_db_uses_smoke_scope_config() -> None:
+    """context-smoke-db must override CONTEXT_SCOPE_CONFIG with the smoke scope file (#2592)."""
+    content = _read_makefile()
+    recipe = _lines_for_target(content, "context-smoke-db")
+    assert recipe, "context-smoke-db target has no recipe lines"
+    recipe_text = "\n".join(recipe)
+    assert "context_ingestion_scope.smoke.yaml" in recipe_text, (
+        "context-smoke-db does not pass context_ingestion_scope.smoke.yaml "
+        "to context-scan — canonical scope would scan test/service code and "
+        "block on content_forbidden_pattern (#2592)"
+    )
+    # The override must be on the context-scan line, not an unrelated step.
+    scan_lines = [line for line in recipe if "context-scan" in line]
+    assert scan_lines, "No context-scan call found in context-smoke-db recipe"
+    assert any("context_ingestion_scope.smoke.yaml" in line for line in scan_lines), (
+        "context-scan invocation in context-smoke-db does not include the "
+        "smoke scope config override"
+    )
+
+
 @pytest.mark.unit
 def test_gen_run_id_reads_run_id_from_snapshot(tmp_path: Path) -> None:
     """gen_run_id with a snapshot.json arg must return run_id from that file (#2587)."""


### PR DESCRIPTION
## Summary
Fixes the `content_forbidden_pattern` scan blocker in the local Context smoke path.

The real make smoke showed that `context-smoke-db` was invoking `context-scan` without passing the smoke scope override. As a result, the scan used the broader canonical scope and hit known forbidden-pattern content outside the smoke scope.

This PR:
- passes `CONTEXT_SCOPE_CONFIG=infrastructure/config/surrealdb/context_ingestion_scope.smoke.yaml` into the `context-smoke-db` scan step
- keeps the content firewall fail-closed
- does not add global allowlists
- adds contract coverage for the smoke-scope wiring
- adds regression coverage that the smoke scope produces zero `content_forbidden_pattern` blocking findings

## Scope
- `Makefile`
- `tests/unit/surrealdb/test_context_indexer.py`
- `tests/unit/surrealdb/test_context_smoke_db_contracts.py`

## Non-goals
- No global allowlisting
- No content-firewall weakening
- No secret dumping
- No schema change
- No importer change
- No DB reset
- No Docker restart
- No schema apply
- No trading/runtime scope
- No live-readiness change

## Validation
- `pytest -q tests/unit/surrealdb/test_context_indexer.py -m unit`
- `pytest -q tests/unit/surrealdb/test_context_smoke_db_contracts.py -m unit`
- `pytest -q tests/unit/surrealdb/ -m unit`
- `ruff check tests/unit/surrealdb/test_context_indexer.py tests/unit/surrealdb/test_context_smoke_db_contracts.py`
- `make -n PYTHON=python context-smoke-db`

## Safety
- Context Infrastructure only
- Content firewall remains fail-closed
- LR remains NO-GO
- No Echtgeld / live trading implication

Refs #2592