### PR TITLE
fix(surrealdb): exclude mock exchange docs from canonical context ingestion

### DIFF
--- a/infrastructure/config/surrealdb/context_ingestion_scope.yaml
+++ b/infrastructure/config/surrealdb/context_ingestion_scope.yaml
@@ -134,6 +134,14 @@ exclude_paths:
       Synthetic fixture repos used for indexer unit tests. Contains deliberate secret-like
       patterns (e.g. api_key = "ABCDEF...") that are true-positive test data for the scanner
       itself — not canonical documentation content to be ingested (#2594).
+  - path: .codex/cdb_skills/mockexchange/
+    reason: >
+      Mock-Exchange-Skill-Dokumentation mit Platzhalter-/Mock-Credential-Beispielen für
+      lokale Tests und Package-Dokumentation. Kein canonical Context-Ingestion-Content (#2596).
+  - path: tools/test_pack/mock_exchange/
+    reason: >
+      Mock-Exchange-Fixture-/Test-Pack-Dokumentation mit Platzhalter-Credential-Beispielen.
+      Kein canonical Context-Ingestion-Content (#2596).
 
 allowed_file_types:
   - extension: .md

--- a/tests/unit/surrealdb/test_context_indexer.py
+++ b/tests/unit/surrealdb/test_context_indexer.py
@@ -29,7 +29,6 @@ from tools.surrealdb.context_indexer import (
     EXPORT_FILES,
 )
 
-
 SCOPE_CONFIG = Path("infrastructure/config/surrealdb/context_ingestion_scope.yaml")
 FIXTURE_ROOT = Path("tests/fixtures/surrealdb/context_indexer")
 
@@ -65,12 +64,12 @@ def test_canonical_scope_excludes_mock_exchange_paths() -> None:
     and package documentation — not canonical context-ingestion content.
     """
     summary = load_scope_config(SCOPE_CONFIG)
-    assert ".codex/cdb_skills/mockexchange/" in summary.exclude_paths, (
-        "Mock skill path must be excluded from canonical scope"
-    )
-    assert "tools/test_pack/mock_exchange/" in summary.exclude_paths, (
-        "Mock exchange test pack path must be excluded from canonical scope"
-    )
+    assert (
+        ".codex/cdb_skills/mockexchange/" in summary.exclude_paths
+    ), "Mock skill path must be excluded from canonical scope"
+    assert (
+        "tools/test_pack/mock_exchange/" in summary.exclude_paths
+    ), "Mock exchange test pack path must be excluded from canonical scope"
 
 
 @pytest.mark.unit
@@ -88,9 +87,7 @@ def test_scan_defaults_to_dry_run_and_never_connects_to_surrealdb(capsys) -> Non
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize(
-    "command", ["scan", "plan", "snapshot"]
-)
+@pytest.mark.parametrize("command", ["scan", "plan", "snapshot"])
 def test_command_payloads_return_offline_results(command: str, capsys) -> None:
     exit_code = main([command, "--scope-config", str(SCOPE_CONFIG), "--dry-run"])
 
@@ -102,9 +99,7 @@ def test_command_payloads_return_offline_results(command: str, capsys) -> None:
 
 
 @pytest.mark.unit
-def test_markdown_format_renders_without_writing(
-    tmp_path: Path, capsys
-) -> None:
+def test_markdown_format_renders_without_writing(tmp_path: Path, capsys) -> None:
     fixture_root = _copy_fixture_repo(tmp_path, "repo_clean")
     exit_code = main(
         [
@@ -112,7 +107,10 @@ def test_markdown_format_renders_without_writing(
             "--root",
             str(fixture_root),
             "--scope-config",
-            str(fixture_root / "infrastructure/config/surrealdb/context_ingestion_scope.yaml"),
+            str(
+                fixture_root
+                / "infrastructure/config/surrealdb/context_ingestion_scope.yaml"
+            ),
             "--format",
             "markdown",
         ]
@@ -402,9 +400,7 @@ def test_parent_directory_creation_failure_returns_structured_error(
 
 @pytest.mark.unit
 def test_missing_scope_config_returns_input_not_found(capsys) -> None:
-    exit_code = main(
-        ["scan", "--scope-config", "missing/context_ingestion_scope.yaml"]
-    )
+    exit_code = main(["scan", "--scope-config", "missing/context_ingestion_scope.yaml"])
 
     assert exit_code == 3
     payload = json.loads(capsys.readouterr().out)
@@ -474,7 +470,9 @@ def test_discovery_classification_and_hashing_with_fixture_repo(tmp_path: Path) 
     assert len(result.skipped_files) == 1
     assert len(result.forbidden_files) == 1
 
-    artifact_map = {artifact.source_path: artifact for artifact in result.repo_artifacts}
+    artifact_map = {
+        artifact.source_path: artifact for artifact in result.repo_artifacts
+    }
     assert "docs/guide.md" in artifact_map
     assert "docs/eol_lf.md" in artifact_map
     assert "docs/eol_crlf.md" in artifact_map
@@ -482,18 +480,28 @@ def test_discovery_classification_and_hashing_with_fixture_repo(tmp_path: Path) 
 
 
 @pytest.mark.unit
-def test_markdown_chunking_keeps_heading_context_and_chunk_links(tmp_path: Path) -> None:
+def test_markdown_chunking_keeps_heading_context_and_chunk_links(
+    tmp_path: Path,
+) -> None:
     fixture_root = _copy_fixture_repo(tmp_path, "repo_clean")
     result = run_indexer(
         fixture_root,
         fixture_root / "infrastructure/config/surrealdb/context_ingestion_scope.yaml",
     )
 
-    guide_sections = [section for section in result.doc_sections if section.source_path == "docs/guide.md"]
+    guide_sections = [
+        section
+        for section in result.doc_sections
+        if section.source_path == "docs/guide.md"
+    ]
     assert guide_sections
-    assert any(section.heading_path == ["Guide", "Section Alpha"] for section in guide_sections)
+    assert any(
+        section.heading_path == ["Guide", "Section Alpha"] for section in guide_sections
+    )
 
-    chunks = [chunk for chunk in result.doc_chunks if chunk.source_path == "docs/guide.md"]
+    chunks = [
+        chunk for chunk in result.doc_chunks if chunk.source_path == "docs/guide.md"
+    ]
     assert chunks
     chunk_by_id = {chunk.chunk_id: chunk for chunk in chunks}
     for section in guide_sections:
@@ -554,12 +562,18 @@ def test_jsonl_export_snapshot_and_validation_in_fixture_repo(
     ):
         assert (fixture_root / output_dir / filename).exists()
 
-    lines = (fixture_root / output_dir / "repo_artifacts.jsonl").read_text(encoding="utf-8").splitlines()
+    lines = (
+        (fixture_root / output_dir / "repo_artifacts.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    )
     assert lines
     first_record = json.loads(lines[0])
     assert first_record["schema_version"] == SCHEMA_VERSION
 
-    snapshot = json.loads((fixture_root / output_dir / "snapshot.json").read_text(encoding="utf-8"))
+    snapshot = json.loads(
+        (fixture_root / output_dir / "snapshot.json").read_text(encoding="utf-8")
+    )
     assert snapshot["schema_version"] == SCHEMA_VERSION
     assert snapshot["validation"]["blocking_count"] == 0
 
@@ -629,9 +643,9 @@ def test_high_confidence_secret_re_matches_quoted_literals() -> None:
         'token = "eyJhbGciOiJIUzI1NiI"',
     ]
     for case in positive_cases:
-        assert HIGH_CONFIDENCE_SECRET_RE.search(case) is not None, (
-            f"Expected a match for quoted literal but got none: {case!r}"
-        )
+        assert (
+            HIGH_CONFIDENCE_SECRET_RE.search(case) is not None
+        ), f"Expected a match for quoted literal but got none: {case!r}"
 
 
 @pytest.mark.unit
@@ -648,13 +662,13 @@ def test_high_confidence_secret_re_matches_unquoted_literals() -> None:
         "api_key=sk-test-abc123xyz456",
         "secret=xK9mN2pQrT4vW7zA1cE",
         "credential=ABCDEF1234567890GHIJ",
-        "token=ghp_abc123xyz456def789",      # GitHub-style token with underscore prefix
-        "password=super_secret_value123",    # underscore mid-value
+        "token=ghp_abc123xyz456def789",  # GitHub-style token with underscore prefix
+        "password=super_secret_value123",  # underscore mid-value
     ]
     for case in unquoted_positive_cases:
-        assert HIGH_CONFIDENCE_SECRET_RE.search(case) is not None, (
-            f"Expected a match for unquoted literal credential but got none: {case!r}"
-        )
+        assert (
+            HIGH_CONFIDENCE_SECRET_RE.search(case) is not None
+        ), f"Expected a match for unquoted literal credential but got none: {case!r}"
 
 
 @pytest.mark.unit
@@ -673,13 +687,13 @@ def test_high_confidence_secret_re_rejects_false_positives() -> None:
         "user, password = _load_credentials(env_file)",
         "api_key=config.MEXC_API_KEY",
         "password=self.redis_password",
-        "password=os.environ[\"REDIS_PASSWORD\"]",
+        'password=os.environ["REDIS_PASSWORD"]',
         "token=settings.API_TOKEN",
     ]
     for case in negative_cases:
-        assert HIGH_CONFIDENCE_SECRET_RE.search(case) is None, (
-            f"Expected no match for code/config expression but got one: {case!r}"
-        )
+        assert (
+            HIGH_CONFIDENCE_SECRET_RE.search(case) is None
+        ), f"Expected no match for code/config expression but got one: {case!r}"
 
 
 @pytest.mark.unit
@@ -708,15 +722,22 @@ def test_hashing_normalizes_line_endings_in_fixture_repo(tmp_path: Path) -> None
         fixture_root,
         fixture_root / "infrastructure/config/surrealdb/context_ingestion_scope.yaml",
     )
-    artifact_map = {artifact.source_path: artifact for artifact in result.repo_artifacts}
-    assert artifact_map["docs/eol_lf.md"].raw_sha256 != artifact_map["docs/eol_crlf.md"].raw_sha256
+    artifact_map = {
+        artifact.source_path: artifact for artifact in result.repo_artifacts
+    }
+    assert (
+        artifact_map["docs/eol_lf.md"].raw_sha256
+        != artifact_map["docs/eol_crlf.md"].raw_sha256
+    )
     assert (
         artifact_map["docs/eol_lf.md"].normalized_sha256
         == artifact_map["docs/eol_crlf.md"].normalized_sha256
     )
 
 
-_SCOPE_CONFIG_RELATIVE = Path("infrastructure/config/surrealdb/context_ingestion_scope.yaml")
+_SCOPE_CONFIG_RELATIVE = Path(
+    "infrastructure/config/surrealdb/context_ingestion_scope.yaml"
+)
 
 _SCOPE_CONFIG_YAML_TEMPLATE = """\
 schema_version: context-ingestion-scope/v0
@@ -742,7 +763,9 @@ guardrails: []
 """
 
 
-def _make_minimal_repo(base: Path, include_path: str, max_file_size: int = 1048576) -> Path:
+def _make_minimal_repo(
+    base: Path, include_path: str, max_file_size: int = 1048576
+) -> Path:
     """Create a minimal repo-like directory with a scope config and one doc."""
     config_path = base / _SCOPE_CONFIG_RELATIVE
     config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -754,7 +777,9 @@ def _make_minimal_repo(base: Path, include_path: str, max_file_size: int = 10485
     )
     doc_dir = base / include_path.rstrip("/")
     doc_dir.mkdir(parents=True, exist_ok=True)
-    (doc_dir / "readme.md").write_text("# Hello\n\nThis is a test doc.\n", encoding="utf-8")
+    (doc_dir / "readme.md").write_text(
+        "# Hello\n\nThis is a test doc.\n", encoding="utf-8"
+    )
     return base
 
 
@@ -781,18 +806,18 @@ def test_resolve_input_path_prefers_root_over_cwd(
     resolved = resolve_input_path(_SCOPE_CONFIG_RELATIVE, target_repo)
 
     # Must resolve inside target_repo, not caller_repo
-    assert resolved.is_relative_to(target_repo), (
-        f"Expected path inside target_repo ({target_repo}), got {resolved}"
-    )
-    assert not resolved.is_relative_to(caller_repo), (
-        f"Path must not resolve to caller_repo ({caller_repo}), got {resolved}"
-    )
+    assert resolved.is_relative_to(
+        target_repo
+    ), f"Expected path inside target_repo ({target_repo}), got {resolved}"
+    assert not resolved.is_relative_to(
+        caller_repo
+    ), f"Path must not resolve to caller_repo ({caller_repo}), got {resolved}"
 
     # Loading the config proves the target repo policy is active, not caller's
     scope = load_scope_config(resolved)
-    assert scope.max_file_size_bytes == 999999, (
-        f"Expected target_repo max_file_size_bytes=999999, got {scope.max_file_size_bytes}"
-    )
+    assert (
+        scope.max_file_size_bytes == 999999
+    ), f"Expected target_repo max_file_size_bytes=999999, got {scope.max_file_size_bytes}"
 
 
 @pytest.mark.unit
@@ -803,7 +828,9 @@ def test_export_files_includes_wave14_artifacts() -> None:
 
 
 @pytest.mark.unit
-def test_jsonl_records_wave14_non_evidence_placeholders_are_always_empty(tmp_path: Path) -> None:
+def test_jsonl_records_wave14_non_evidence_placeholders_are_always_empty(
+    tmp_path: Path,
+) -> None:
     """claims, decision_events, agent_memories are always empty regardless of input."""
     fixture_root = _copy_fixture_repo(tmp_path, "repo_clean")
     result = run_indexer(
@@ -813,9 +840,9 @@ def test_jsonl_records_wave14_non_evidence_placeholders_are_always_empty(tmp_pat
     records = jsonl_records(result)
     for artifact in ("claims", "decision_events", "agent_memories"):
         assert artifact in records, f"jsonl_records() is missing key: {artifact}"
-        assert records[artifact] == [], (
-            f"expected empty list for {artifact}, got {records[artifact]!r}"
-        )
+        assert (
+            records[artifact] == []
+        ), f"expected empty list for {artifact}, got {records[artifact]!r}"
 
 
 @pytest.mark.unit
@@ -836,11 +863,15 @@ def test_write_jsonl_exports_writes_wave14_files(tmp_path: Path) -> None:
         path = output_dir / filename
         assert path.exists(), f"write_jsonl_exports() did not create {filename}"
         assert path.is_file(), f"{filename} is not a regular file"
-        assert path.read_bytes() == b"", f"{filename} should be empty for Wave-14 placeholder"
+        assert (
+            path.read_bytes() == b""
+        ), f"{filename} should be empty for Wave-14 placeholder"
 
 
 @pytest.mark.unit
-def test_indexer_output_passes_importer_jsonl_file_missing_check(tmp_path: Path) -> None:
+def test_indexer_output_passes_importer_jsonl_file_missing_check(
+    tmp_path: Path,
+) -> None:
     from tools.surrealdb.context_importer import validate_jsonl  # noqa: PLC0415
 
     fixture_root = _copy_fixture_repo(tmp_path, "repo_clean")
@@ -935,7 +966,9 @@ def test_evidence_refs_from_test_files_are_deterministic() -> None:
     records_b = _evidence_refs_from_test_cases(result)
 
     assert records_a == records_b
-    assert [r["evidence_id"] for r in records_a] == [r["evidence_id"] for r in records_b]
+    assert [r["evidence_id"] for r in records_a] == [
+        r["evidence_id"] for r in records_b
+    ]
 
 
 @pytest.mark.unit
@@ -983,16 +1016,21 @@ def test_evidence_refs_do_not_infer_claim_or_decision_links() -> None:
 
     assert records
     rec = records[0]
-    for forbidden_field in ("validates", "invalidates", "related_decisions", "claim_refs"):
+    for forbidden_field in (
+        "validates",
+        "invalidates",
+        "related_decisions",
+        "claim_refs",
+    ):
         value = rec.get(forbidden_field)
-        assert not value, (
-            f"evidence_ref must not infer {forbidden_field!r}, got {value!r}"
-        )
+        assert (
+            not value
+        ), f"evidence_ref must not infer {forbidden_field!r}, got {value!r}"
     comment = rec.get("comment", "")
     for forbidden_phrase in ("human-go", "lr-go", "echtgeld", "live", "approved"):
-        assert forbidden_phrase.lower() not in comment.lower(), (
-            f"comment must not contain {forbidden_phrase!r}: {comment!r}"
-        )
+        assert (
+            forbidden_phrase.lower() not in comment.lower()
+        ), f"comment must not contain {forbidden_phrase!r}: {comment!r}"
 
 
 @pytest.mark.unit
@@ -1045,7 +1083,6 @@ def test_generated_evidence_ref_records_pass_importer_field_validation(
 
     report = validate_jsonl(tmp_path, expected_run_id="run-unit-test-001")
     blocking = [f for f in report.findings if f.severity == "blocking"]
-    assert not blocking, (
-        f"Unexpected blocking findings for generated evidence_refs records: {blocking}"
-    )
-
+    assert (
+        not blocking
+    ), f"Unexpected blocking findings for generated evidence_refs records: {blocking}"

--- a/tests/unit/surrealdb/test_context_indexer.py
+++ b/tests/unit/surrealdb/test_context_indexer.py
@@ -58,6 +58,22 @@ def test_scope_config_loads_canonical_file() -> None:
 
 
 @pytest.mark.unit
+def test_canonical_scope_excludes_mock_exchange_paths() -> None:
+    """Mock exchange documentation paths must be excluded from canonical ingestion (#2596).
+
+    These paths contain placeholder/mock credential examples for local testing
+    and package documentation — not canonical context-ingestion content.
+    """
+    summary = load_scope_config(SCOPE_CONFIG)
+    assert ".codex/cdb_skills/mockexchange/" in summary.exclude_paths, (
+        "Mock skill path must be excluded from canonical scope"
+    )
+    assert "tools/test_pack/mock_exchange/" in summary.exclude_paths, (
+        "Mock exchange test pack path must be excluded from canonical scope"
+    )
+
+
+@pytest.mark.unit
 def test_scan_defaults_to_dry_run_and_never_connects_to_surrealdb(capsys) -> None:
     exit_code = main(["scan", "--scope-config", str(SCOPE_CONFIG)])
 

--- a/tools/surrealdb/context_indexer.py
+++ b/tools/surrealdb/context_indexer.py
@@ -23,7 +23,6 @@ import yaml
 
 from core.utils.clock import utcnow as cdb_utcnow
 
-
 SCHEMA_VERSION = "context-indexer/v0"
 SCOPE_CONFIG_SCHEMA_VERSION = "context-ingestion-scope/v0"
 DEFAULT_SCOPE_CONFIG = Path(
@@ -99,9 +98,9 @@ TRADING_STATE_PATH_PARTS = {
     "execution_state",
 }
 
-KNOWN_LOCAL_MODULE_PREFIXES: frozenset[str] = frozenset({
-    "core", "services", "tools", "infrastructure", "tests"
-})
+KNOWN_LOCAL_MODULE_PREFIXES: frozenset[str] = frozenset(
+    {"core", "services", "tools", "infrastructure", "tests"}
+)
 SECRET_CONFIG_KEY_RE = re.compile(
     r"(?i)(api[_\-]?key|private[_\-]?key|password|passwd|secret|token|credential"
     r"|auth[_\-]?key|access[_\-]?key|signing[_\-]?key|encryption[_\-]?key)"
@@ -591,7 +590,9 @@ class DependencyEdge:
             "from_table": self.from_table,
             "to_table": self.to_table,
             "source_path": self.source_path,
-            "confidence": {"high": 1.0, "medium": 0.7, "low": 0.3}.get(self.confidence, 1.0),
+            "confidence": {"high": 1.0, "medium": 0.7, "low": 0.3}.get(
+                self.confidence, 1.0
+            ),
             "evidence_level": "inferred",
             "inferred": self.inferred,
             "comment": "",
@@ -634,7 +635,9 @@ class IndexerResult:
 
     @property
     def blocking_findings(self) -> list[ValidationFinding]:
-        return [item for item in self.validation_findings if item.severity == "blocking"]
+        return [
+            item for item in self.validation_findings if item.severity == "blocking"
+        ]
 
 
 def _path_entries(value: Any, key: str) -> list[str]:
@@ -656,7 +659,10 @@ def _path_rules(value: Any, key: str) -> list[PathRule]:
         if not isinstance(item, dict) or not item.get("path"):
             raise ScopeConfigValidationError(f"{key} entries must contain path")
         sensitivity_class = item.get("sensitivity_class")
-        if sensitivity_class is not None and sensitivity_class not in EXPECTED_SENSITIVITY_CLASSES:
+        if (
+            sensitivity_class is not None
+            and sensitivity_class not in EXPECTED_SENSITIVITY_CLASSES
+        ):
             raise ScopeConfigValidationError(
                 f"{key} entry has unsupported sensitivity_class: {sensitivity_class}"
             )
@@ -676,7 +682,9 @@ def _file_type_rules(value: Any) -> list[FileTypeRule]:
     rules: list[FileTypeRule] = []
     for item in value:
         if not isinstance(item, dict) or not item.get("type"):
-            raise ScopeConfigValidationError("allowed_file_types entries must contain type")
+            raise ScopeConfigValidationError(
+                "allowed_file_types entries must contain type"
+            )
         extension = item.get("extension")
         pattern = item.get("pattern")
         if not extension and not pattern:
@@ -690,7 +698,9 @@ def _file_type_rules(value: Any) -> list[FileTypeRule]:
                 pattern=str(pattern) if pattern else None,
             )
         )
-    return sorted(rules, key=lambda rule: (rule.file_type, rule.extension or rule.pattern or ""))
+    return sorted(
+        rules, key=lambda rule: (rule.file_type, rule.extension or rule.pattern or "")
+    )
 
 
 def _flatten_forbidden_patterns(value: Any) -> list[str]:
@@ -715,7 +725,9 @@ def load_scope_config(path: Path) -> ScopeConfigSummary:
     except OSError as exc:
         raise ScopeConfigValidationError(f"scope config read failed: {exc}") from exc
     except yaml.YAMLError as exc:
-        raise ScopeConfigValidationError(f"scope config YAML parse failed: {exc}") from exc
+        raise ScopeConfigValidationError(
+            f"scope config YAML parse failed: {exc}"
+        ) from exc
 
     if not isinstance(data, dict):
         raise ScopeConfigValidationError("scope config must be a YAML mapping")
@@ -787,9 +799,9 @@ def _matches_rule(rel_path: str, rule_path: str) -> bool:
     normalized_rule = rule.strip("/")
     normalized_rel = rel_path.strip("/")
     if _has_glob_magic(rule):
-        return fnmatch.fnmatchcase(normalized_rel, normalized_rule) or fnmatch.fnmatchcase(
-            Path(normalized_rel).name, normalized_rule
-        )
+        return fnmatch.fnmatchcase(
+            normalized_rel, normalized_rule
+        ) or fnmatch.fnmatchcase(Path(normalized_rel).name, normalized_rule)
     return normalized_rel == normalized_rule or normalized_rel.startswith(
         f"{normalized_rule}/"
     )
@@ -818,7 +830,9 @@ def _safe_relative_to_root(path: Path, root: Path) -> str | None:
     return _normalize_relative_path(rel)
 
 
-def _detect_file_type(rel_path: str, path: Path, scope: ScopeConfigSummary) -> str | None:
+def _detect_file_type(
+    rel_path: str, path: Path, scope: ScopeConfigSummary
+) -> str | None:
     name = path.name
     suffix = path.suffix.lower()
     for rule in scope.file_type_rules:
@@ -833,7 +847,9 @@ def _detect_file_type(rel_path: str, path: Path, scope: ScopeConfigSummary) -> s
 
 
 def _matched_exclude_rule(rel_path: str, scope: ScopeConfigSummary) -> PathRule | None:
-    matches = [rule for rule in scope.exclude_rules if _matches_rule(rel_path, rule.path)]
+    matches = [
+        rule for rule in scope.exclude_rules if _matches_rule(rel_path, rule.path)
+    ]
     if not matches:
         return None
     return max(matches, key=lambda rule: len(rule.path))
@@ -864,7 +880,9 @@ def _sha256_text(text: str) -> str:
 
 
 def _stable_json_hash(value: Any) -> str:
-    encoded = json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    encoded = json.dumps(
+        value, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    )
     return _sha256_text(encoded)
 
 
@@ -1142,7 +1160,11 @@ def classify_and_hash_files(
         )
         normalized_text_by_path[rel_path] = normalized_text
 
-    return files, sorted(artifacts, key=lambda item: item.source_path), normalized_text_by_path
+    return (
+        files,
+        sorted(artifacts, key=lambda item: item.source_path),
+        normalized_text_by_path,
+    )
 
 
 def _safe_file_size(path: Path) -> int:
@@ -1241,14 +1263,19 @@ def build_markdown_records(
     chunks_without_links: list[DocChunk] = []
 
     for artifact in artifacts:
-        if artifact.file_type != "markdown" or artifact.sensitivity == "sensitive_metadata":
+        if (
+            artifact.file_type != "markdown"
+            or artifact.sensitivity == "sensitive_metadata"
+        ):
             continue
         text = normalized_text_by_path.get(artifact.source_path)
         if text is None:
             continue
         parsed_sections = _parse_markdown_sections(text)
         title = _markdown_title(parsed_sections, artifact.source_path)
-        page_id = stable_id("doc_page", artifact.source_path, artifact.normalized_sha256)
+        page_id = stable_id(
+            "doc_page", artifact.source_path, artifact.normalized_sha256
+        )
         pages.append(
             DocPage(
                 page_id=page_id,
@@ -1305,16 +1332,18 @@ def build_markdown_records(
                         content=content,
                         content_hash=content_hash,
                         previous_chunk_id=chunk_ids[index - 1] if index > 0 else None,
-                        next_chunk_id=chunk_ids[index + 1]
-                        if index + 1 < len(chunk_ids)
-                        else None,
+                        next_chunk_id=(
+                            chunk_ids[index + 1] if index + 1 < len(chunk_ids) else None
+                        ),
                     )
                 )
 
     return (
         sorted(pages, key=lambda item: item.source_path),
         sorted(sections, key=lambda item: (item.source_path, item.section_index)),
-        sorted(chunks_without_links, key=lambda item: (item.source_path, item.chunk_index)),
+        sorted(
+            chunks_without_links, key=lambda item: (item.source_path, item.chunk_index)
+        ),
     )
 
 
@@ -1490,10 +1519,16 @@ def extract_test_cases(code_symbols: list[CodeSymbol]) -> list[TestCase]:
             "function",
             "async_function",
         )
-        is_test_method = symbol.name.startswith("test_") and symbol.symbol_type in (
-            "method",
-            "async_method",
-        ) and symbol.parent_class is not None and symbol.parent_class.startswith("Test")
+        is_test_method = (
+            symbol.name.startswith("test_")
+            and symbol.symbol_type
+            in (
+                "method",
+                "async_method",
+            )
+            and symbol.parent_class is not None
+            and symbol.parent_class.startswith("Test")
+        )
         if is_test_func or is_test_method:
             test_type = "function" if symbol.parent_class is None else "method"
             test_cases.append(
@@ -1962,7 +1997,10 @@ def validate_indexer_result(result: IndexerResult) -> list[ValidationFinding]:
 
     for file_record in result.files:
         if file_record.status == "included":
-            if _matched_exclude_rule(file_record.source_path, result.scope_config) is not None:
+            if (
+                _matched_exclude_rule(file_record.source_path, result.scope_config)
+                is not None
+            ):
                 findings.append(
                     ValidationFinding(
                         severity="blocking",
@@ -2099,7 +2137,9 @@ def validate_indexer_result(result: IndexerResult) -> list[ValidationFinding]:
             )
         )
 
-    return sorted(findings, key=lambda item: (item.severity, item.code, item.source_path or ""))
+    return sorted(
+        findings, key=lambda item: (item.severity, item.code, item.source_path or "")
+    )
 
 
 def _path_contains_trading_state(source_path: str) -> bool:
@@ -2163,10 +2203,12 @@ def jsonl_records(result: IndexerResult) -> dict[str, list[dict[str, Any]]]:
         ],
         "doc_chunks": [chunk.to_payload(result.run_id) for chunk in result.doc_chunks],
         "skipped_files": [
-            file_record.to_payload(result.run_id) for file_record in result.skipped_files
+            file_record.to_payload(result.run_id)
+            for file_record in result.skipped_files
         ],
         "forbidden_files": [
-            file_record.to_payload(result.run_id) for file_record in result.forbidden_files
+            file_record.to_payload(result.run_id)
+            for file_record in result.forbidden_files
         ],
         "code_symbols": [sym.to_payload(result.run_id) for sym in result.code_symbols],
         "import_references": [
@@ -2268,7 +2310,10 @@ def build_command_payload(
             {
                 "status": "completed",
                 "counts": _counts(result),
-                "files": [file_record.to_payload(result.run_id) for file_record in result.files],
+                "files": [
+                    file_record.to_payload(result.run_id)
+                    for file_record in result.files
+                ],
             }
         )
         return base
@@ -2466,9 +2511,13 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         if args.command == "export-jsonl":
-            output = validate_output_directory(args.output, args.apply_writes and not dry_run)
+            output = validate_output_directory(
+                args.output, args.apply_writes and not dry_run
+            )
         else:
-            output = validate_output_path(args.output, args.apply_writes and not dry_run)
+            output = validate_output_path(
+                args.output, args.apply_writes and not dry_run
+            )
         result = run_indexer(args.root, args.scope_config)
         payload = build_command_payload(
             args.command,


### PR DESCRIPTION
## Summary
- Excludes mock exchange documentation paths from canonical Context ingestion scope.
- Adds a targeted unit regression test for the excluded paths.
- Keeps smoke scope and secret detector behavior unchanged.

## Scope
Closes #2596.

## Validation
- \pytest -q tests/unit/surrealdb/test_context_indexer.py\ → 52 passed

## Safety
- Context Infrastructure only.
- No scanner disable.
- No global allowlist.
- No DB/schema/importer changes.
- No trading/runtime scope.
- LR remains NO-GO.