### PR TITLE
fix(surrealdb): refine secret detector for service references

### DIFF
--- a/tests/unit/surrealdb/test_context_indexer.py
+++ b/tests/unit/surrealdb/test_context_indexer.py
@@ -678,6 +678,10 @@ def test_high_confidence_secret_re_rejects_false_positives() -> None:
     Dots (config attribute paths), underscores at start (function calls), colons
     at start (SurrealDB tokenizer) all result in < 12 char runs or non-matching
     characters, keeping these false positives excluded.
+
+    Added #2597: all-caps constants (SCREAMING_SNAKE_CASE) and snake_case variable
+    references must not match. These are variable/constant references, not literal
+    credential values. See services/execution/mexc_executor.py and services/ws/service.py.
     """
     negative_cases = [
         "token = base64.b64encode(",
@@ -689,6 +693,8 @@ def test_high_confidence_secret_re_rejects_false_positives() -> None:
         "password=self.redis_password",
         'password=os.environ["REDIS_PASSWORD"]',
         "token=settings.API_TOKEN",
+        "self.api_secret = MEXC_API_SECRET",  # all-caps constant reference (#2597)
+        "password=redis_password",            # snake_case variable reference (#2597)
     ]
     for case in negative_cases:
         assert (

--- a/tests/unit/surrealdb/test_context_indexer.py
+++ b/tests/unit/surrealdb/test_context_indexer.py
@@ -694,7 +694,7 @@ def test_high_confidence_secret_re_rejects_false_positives() -> None:
         'password=os.environ["REDIS_PASSWORD"]',
         "token=settings.API_TOKEN",
         "self.api_secret = MEXC_API_SECRET",  # all-caps constant reference (#2597)
-        "password=redis_password",            # snake_case variable reference (#2597)
+        "password=redis_password",  # snake_case variable reference (#2597)
     ]
     for case in negative_cases:
         assert (

--- a/tools/surrealdb/context_indexer.py
+++ b/tools/surrealdb/context_indexer.py
@@ -82,6 +82,7 @@ HIGH_CONFIDENCE_SECRET_RE = re.compile(
     r"(?:"
     r"[\"'][A-Za-z0-9_.+/=@:-]{12,}[\"']"  # quoted literal
     r"|"
+    r"(?![A-Za-z]+(?:_[A-Za-z]+)+\b)"  # exclude var-like unquoted (all-caps const, snake_case var)
     r"[A-Za-z0-9][A-Za-z0-9+/=@_-]{11,}"  # unquoted literal: alphanum-start + 11 more (12+ total); no dots/colons; underscore allowed mid-value but not at start (excludes _read_secret etc.)
     r")"
 )


### PR DESCRIPTION
## Summary
- Refines canonical high-confidence secret detection for service-code references.
- Keeps quoted and unquoted literal credential detection active.
- Adds regression coverage for constants, variables, config/settings references, and function-call expressions.

## Scope
Closes #2597.

## Validation
- \pytest -q tests/unit/surrealdb/test_context_indexer.py\ → 51 passed

## Safety
- Context Infrastructure only.
- No scanner disable.
- No global allowlist.
- No service runtime change.
- No DB/schema/importer changes.
- No trading/runtime scope.
- LR remains NO-GO.

## CI Note
GitHub Actions may remain blocked by billing/runner allocation. This PR is parked for later CI/merge once billing is resolved.