### PR TITLE
fix(tests): sanitize dummy credentials in test suites

### DIFF
--- a/tests/performance/verlosung/test_analytics_performance.py
+++ b/tests/performance/verlosung/test_analytics_performance.py
@@ -48,8 +48,7 @@ def test_query_performance_signals_aggregation(postgres_conn):
 
     start = time.time()
 
-    cursor.execute(
-        """
+    cursor.execute("""
         SELECT
             symbol,
             signal_type,
@@ -62,8 +61,7 @@ def test_query_performance_signals_aggregation(postgres_conn):
         GROUP BY symbol, signal_type
         ORDER BY signal_count DESC
         LIMIT 10
-    """
-    )
+    """)
 
     results = cursor.fetchall()
     elapsed = time.time() - start
@@ -99,8 +97,7 @@ def test_query_performance_portfolio_snapshots_timeseries(postgres_conn):
 
     start = time.time()
 
-    cursor.execute(
-        """
+    cursor.execute("""
         SELECT
             DATE(timestamp) as date,
             COUNT(*) as snapshot_count,
@@ -112,8 +109,7 @@ def test_query_performance_portfolio_snapshots_timeseries(postgres_conn):
         GROUP BY DATE(timestamp)
         ORDER BY date DESC
         LIMIT 30
-    """
-    )
+    """)
 
     results = cursor.fetchall()
     elapsed = time.time() - start
@@ -148,8 +144,7 @@ def test_query_performance_trades_join_orders(postgres_conn):
 
     start = time.time()
 
-    cursor.execute(
-        """
+    cursor.execute("""
         SELECT
             t.id as trade_id,
             t.symbol,
@@ -165,8 +160,7 @@ def test_query_performance_trades_join_orders(postgres_conn):
         WHERE t.timestamp >= NOW() - INTERVAL '24 hours'
         ORDER BY t.timestamp DESC
         LIMIT 100
-    """
-    )
+    """)
 
     results = cursor.fetchall()
     elapsed = time.time() - start
@@ -200,8 +194,7 @@ def test_query_performance_full_text_search(postgres_conn):
     start = time.time()
 
     # Search in JSONB metadata
-    cursor.execute(
-        """
+    cursor.execute("""
         SELECT
             symbol,
             signal_type,
@@ -211,8 +204,7 @@ def test_query_performance_full_text_search(postgres_conn):
         WHERE metadata ? 'strategy'
         ORDER BY timestamp DESC
         LIMIT 50
-    """
-    )
+    """)
 
     results = cursor.fetchall()
     elapsed = time.time() - start
@@ -238,8 +230,7 @@ def test_database_index_effectiveness(postgres_conn):
     cursor = postgres_conn.cursor(cursor_factory=RealDictCursor)
 
     # Check existing indices
-    cursor.execute(
-        """
+    cursor.execute("""
         SELECT
             schemaname,
             tablename,
@@ -248,8 +239,7 @@ def test_database_index_effectiveness(postgres_conn):
         FROM pg_indexes
         WHERE schemaname = 'public'
         ORDER BY tablename, indexname
-    """
-    )
+    """)
 
     indices = cursor.fetchall()
 
@@ -278,15 +268,13 @@ def test_database_index_effectiveness(postgres_conn):
     # EXPLAIN ANALYZE für wichtige Query
     print("\n📊 Checking index usage (EXPLAIN ANALYZE)...")
 
-    cursor.execute(
-        """
+    cursor.execute("""
         EXPLAIN (FORMAT JSON, ANALYZE TRUE)
         SELECT * FROM signals
         WHERE timestamp >= NOW() - INTERVAL '1 day'
         ORDER BY timestamp DESC
         LIMIT 10
-    """
-    )
+    """)
 
     # RealDictCursor returns dict, not tuple
     row = cursor.fetchone()

--- a/tests/performance/verlosung/test_analytics_performance.py
+++ b/tests/performance/verlosung/test_analytics_performance.py
@@ -26,7 +26,7 @@ def postgres_conn():
         port=5432,
         database="claire_de_binare",
         user="claire_user",
-        password="claire_db_secret_2024",
+        password="local_test",
     )
     yield conn
     conn.close()
@@ -338,7 +338,7 @@ def test_analytics_query_tool_integration(postgres_conn):
     # Prepare environment: copy current env and add PostgreSQL credentials
     test_env = os.environ.copy()
     test_env["POSTGRES_HOST"] = "localhost"
-    test_env["POSTGRES_PASSWORD"] = "claire_db_secret_2024"
+    test_env["POSTGRES_PASSWORD"] = "local_test"
 
     results = []
 

--- a/tests/performance/verlosung/test_full_system_stress.py
+++ b/tests/performance/verlosung/test_full_system_stress.py
@@ -26,7 +26,7 @@ def redis_client():
     client = redis.Redis(
         host="localhost",
         port=6379,
-        password="claire_redis_secret_2024",
+        password="local_test",
         decode_responses=True,
     )
     yield client
@@ -41,7 +41,7 @@ def postgres_conn():
         port=5432,
         database="claire_de_binare",
         user="claire_user",
-        password="claire_db_secret_2024",
+        password="local_test",
     )
     yield conn
     conn.close()

--- a/tests/unit/surrealdb/test_context_query_adapter.py
+++ b/tests/unit/surrealdb/test_context_query_adapter.py
@@ -21,12 +21,15 @@ from tools.surrealdb.context_query import (
     load_config,
 )
 
-EXAMPLE_CONFIG = Path("infrastructure/config/surrealdb/context_query.local.example.yaml")
+EXAMPLE_CONFIG = Path(
+    "infrastructure/config/surrealdb/context_query.local.example.yaml"
+)
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_adapter(
     url: str = "http://127.0.0.1:8010",
@@ -73,6 +76,7 @@ def _mock_opener_raising(exc: Exception) -> MagicMock:
 # URL validation
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 def test_http_localhost_ip_accepted() -> None:
     adapter = _make_adapter(url="http://127.0.0.1:8010")
@@ -116,10 +120,13 @@ def test_wss_url_rejected() -> None:
 # HTTP request structure
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 def test_execute_select_posts_to_sql_endpoint() -> None:
     adapter = _make_adapter()
-    with patch("urllib.request.build_opener", return_value=_mock_opener(_mock_response([]))) as mock_build:
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener(_mock_response([]))
+    ) as mock_build:
         result = adapter.execute("SELECT * FROM repo_artifact")
     assert result == []
     req = mock_build.return_value.open.call_args[0][0]
@@ -131,7 +138,9 @@ def test_execute_select_posts_to_sql_endpoint() -> None:
 @pytest.mark.unit
 def test_correct_headers_sent() -> None:
     adapter = _make_adapter()
-    with patch("urllib.request.build_opener", return_value=_mock_opener(_mock_response([]))) as mock_build:
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener(_mock_response([]))
+    ) as mock_build:
         adapter.execute("SELECT * FROM repo_artifact")
     req = mock_build.return_value.open.call_args[0][0]
     assert req.get_header("Accept") == "application/json"
@@ -143,7 +152,9 @@ def test_correct_headers_sent() -> None:
 @pytest.mark.unit
 def test_auth_none_sends_no_authorization_header() -> None:
     adapter = _make_adapter(user=None, password=None)
-    with patch("urllib.request.build_opener", return_value=_mock_opener(_mock_response([]))) as mock_build:
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener(_mock_response([]))
+    ) as mock_build:
         adapter.execute("SELECT * FROM doc_chunk")
     req = mock_build.return_value.open.call_args[0][0]
     assert req.get_header("Authorization") is None
@@ -152,7 +163,9 @@ def test_auth_none_sends_no_authorization_header() -> None:
 @pytest.mark.unit
 def test_auth_root_sends_basic_authorization() -> None:
     adapter = _make_adapter(user="admin", password="secret")
-    with patch("urllib.request.build_opener", return_value=_mock_opener(_mock_response([]))) as mock_build:
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener(_mock_response([]))
+    ) as mock_build:
         adapter.execute("SELECT * FROM doc_chunk")
     req = mock_build.return_value.open.call_args[0][0]
     auth = req.get_header("Authorization")
@@ -175,7 +188,9 @@ def test_secret_not_in_error_message() -> None:
         hdrs=MagicMock(),
         fp=None,
     )
-    with patch("urllib.request.build_opener", return_value=_mock_opener_raising(http_error)):
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener_raising(http_error)
+    ):
         with pytest.raises(QueryAdapterError) as excinfo:
             adapter.execute("SELECT * FROM repo_artifact")
     assert "local_test" not in excinfo.value.message
@@ -184,6 +199,7 @@ def test_secret_not_in_error_message() -> None:
 # ---------------------------------------------------------------------------
 # Write-denial BEFORE HTTP
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
@@ -220,6 +236,7 @@ def test_multi_statement_denied_before_http() -> None:
 # SurrealDB error responses
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 def test_surrealdb_err_response_raises_query_adapter_error() -> None:
     err_body = json.dumps(
@@ -249,7 +266,9 @@ def test_http_500_raises_query_adapter_error() -> None:
         fp=None,
     )
     adapter = _make_adapter()
-    with patch("urllib.request.build_opener", return_value=_mock_opener_raising(http_error)):
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener_raising(http_error)
+    ):
         with pytest.raises(QueryAdapterError) as excinfo:
             adapter.execute("SELECT * FROM repo_artifact")
     assert "500" in excinfo.value.message
@@ -259,13 +278,16 @@ def test_http_500_raises_query_adapter_error() -> None:
 # Unreachable DB — soft vs hard mode
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 def test_urlError_soft_mode_returns_empty_and_sets_unavailable() -> None:
     import urllib.error
 
     adapter = _make_adapter(hard_mode=False)
     url_error = urllib.error.URLError(reason="Connection refused")
-    with patch("urllib.request.build_opener", return_value=_mock_opener_raising(url_error)):
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener_raising(url_error)
+    ):
         result = adapter.execute("SELECT * FROM repo_artifact")
     assert result == []
     assert adapter.status == "surrealdb-local-unavailable"
@@ -277,7 +299,9 @@ def test_urlError_hard_mode_raises_query_adapter_error() -> None:
 
     adapter = _make_adapter(hard_mode=True)
     url_error = urllib.error.URLError(reason="Connection refused")
-    with patch("urllib.request.build_opener", return_value=_mock_opener_raising(url_error)):
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener_raising(url_error)
+    ):
         with pytest.raises(QueryAdapterError):
             adapter.execute("SELECT * FROM repo_artifact")
     assert adapter.status == "surrealdb-local-unavailable"
@@ -287,10 +311,13 @@ def test_urlError_hard_mode_raises_query_adapter_error() -> None:
 # Results
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 def test_empty_result_returns_empty_list() -> None:
     adapter = _make_adapter()
-    with patch("urllib.request.build_opener", return_value=_mock_opener(_mock_response([]))):
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener(_mock_response([]))
+    ):
         result = adapter.execute("SELECT * FROM repo_artifact")
     assert result == []
 
@@ -299,7 +326,9 @@ def test_empty_result_returns_empty_list() -> None:
 def test_rows_returned_correctly() -> None:
     rows = [{"id": "repo_artifact:1", "source_path": "core/foo.py"}]
     adapter = _make_adapter()
-    with patch("urllib.request.build_opener", return_value=_mock_opener(_mock_response(rows))):
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener(_mock_response(rows))
+    ):
         result = adapter.execute("SELECT * FROM repo_artifact")
     assert result == rows
 
@@ -307,7 +336,9 @@ def test_rows_returned_correctly() -> None:
 @pytest.mark.unit
 def test_adapter_status_connected_after_success() -> None:
     adapter = _make_adapter()
-    with patch("urllib.request.build_opener", return_value=_mock_opener(_mock_response([]))):
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener(_mock_response([]))
+    ):
         adapter.execute("SELECT * FROM repo_artifact")
     assert adapter.status == "surrealdb-local"
 
@@ -317,7 +348,10 @@ def test_adapter_status_unavailable_after_urlError() -> None:
     import urllib.error
 
     adapter = _make_adapter(hard_mode=False)
-    with patch("urllib.request.build_opener", return_value=_mock_opener_raising(urllib.error.URLError("refused"))):
+    with patch(
+        "urllib.request.build_opener",
+        return_value=_mock_opener_raising(urllib.error.URLError("refused")),
+    ):
         adapter.execute("SELECT * FROM repo_artifact")
     assert adapter.status == "surrealdb-local-unavailable"
 
@@ -325,6 +359,7 @@ def test_adapter_status_unavailable_after_urlError() -> None:
 # ---------------------------------------------------------------------------
 # Schema-compatibility: no tombstone = false in default queries
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.unit
 def test_build_artifact_query_default_no_tombstone_filter() -> None:
@@ -340,7 +375,9 @@ def test_build_doc_query_default_no_tombstone_filter() -> None:
 
 @pytest.mark.unit
 def test_build_artifact_query_with_filters_no_tombstone_filter() -> None:
-    query = build_artifact_query(source_path="src/", file_type="python", include_tombstoned=False)
+    query = build_artifact_query(
+        source_path="src/", file_type="python", include_tombstoned=False
+    )
     assert "tombstoned" not in query
 
 
@@ -348,11 +385,13 @@ def test_build_artifact_query_with_filters_no_tombstone_filter() -> None:
 # _load_query_credentials
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 def test_load_credentials_none_mode_returns_none_pair() -> None:
     config = load_config(EXAMPLE_CONFIG)
     # config has auth_mode = root from YAML; create a mock config-like object instead
     from dataclasses import replace
+
     config_none = replace(config, auth_mode="none")
     user, password = _load_query_credentials(config_none, secrets_path=None)
     assert user is None
@@ -378,7 +417,9 @@ def test_load_credentials_root_missing_env_file_raises(tmp_path: Path) -> None:
 def test_load_credentials_root_valid_env_file(tmp_path: Path) -> None:
     config = load_config(EXAMPLE_CONFIG)
     env_file = tmp_path / "SURREALDB_ENV"
-    env_file.write_text("SURREAL_USER=testuser\nSURREAL_PASS=testpass\n", encoding="utf-8")
+    env_file.write_text(
+        "SURREAL_USER=testuser\nSURREAL_PASS=testpass\n", encoding="utf-8"
+    )
     user, password = _load_query_credentials(config, secrets_path=tmp_path)
     assert user == "testuser"
     assert password == "testpass"
@@ -440,7 +481,9 @@ def test_redirect_response_is_denied_without_following() -> None:
     redirect_error = QueryAdapterError(
         "redirect denied for local SurrealDB query request (HTTP 302)"
     )
-    with patch("urllib.request.build_opener", return_value=_mock_opener_raising(redirect_error)):
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener_raising(redirect_error)
+    ):
         with pytest.raises(QueryAdapterError) as excinfo:
             adapter.execute("SELECT * FROM repo_artifact")
     assert "redirect denied" in excinfo.value.message
@@ -458,7 +501,9 @@ def test_redirect_does_not_leak_authorization_header() -> None:
     redirect_error = QueryAdapterError(
         "redirect denied for local SurrealDB query request (HTTP 301)"
     )
-    with patch("urllib.request.build_opener", return_value=_mock_opener_raising(redirect_error)) as mock_build:
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener_raising(redirect_error)
+    ) as mock_build:
         with pytest.raises(QueryAdapterError) as excinfo:
             adapter.execute("SELECT * FROM repo_artifact")
     # Must have attempted exactly one request, then stopped
@@ -472,7 +517,9 @@ def test_redirect_does_not_leak_authorization_header() -> None:
 def test_no_redirect_handler_is_passed_to_build_opener() -> None:
     """build_opener must be called with a _NoRedirectHandler instance."""
     adapter = _make_adapter()
-    with patch("urllib.request.build_opener", return_value=_mock_opener(_mock_response([]))) as mock_build:
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener(_mock_response([]))
+    ) as mock_build:
         adapter.execute("SELECT * FROM repo_artifact")
     call_args = mock_build.call_args
     assert len(call_args[0]) == 1
@@ -484,7 +531,9 @@ def test_success_still_posts_to_local_sql_endpoint() -> None:
     """Regression: successful SELECT still works correctly after redirect-block change."""
     rows = [{"id": "repo_artifact:1", "source_path": "core/foo.py"}]
     adapter = _make_adapter()
-    with patch("urllib.request.build_opener", return_value=_mock_opener(_mock_response(rows))) as mock_build:
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener(_mock_response(rows))
+    ) as mock_build:
         result = adapter.execute("SELECT * FROM repo_artifact")
     assert result == rows
     req = mock_build.return_value.open.call_args[0][0]
@@ -505,7 +554,9 @@ def test_http_500_still_raises_query_adapter_error() -> None:
         fp=None,
     )
     adapter = _make_adapter()
-    with patch("urllib.request.build_opener", return_value=_mock_opener_raising(http_error)):
+    with patch(
+        "urllib.request.build_opener", return_value=_mock_opener_raising(http_error)
+    ):
         with pytest.raises(QueryAdapterError) as excinfo:
             adapter.execute("SELECT * FROM repo_artifact")
     assert "500" in excinfo.value.message

--- a/tests/unit/surrealdb/test_context_query_adapter.py
+++ b/tests/unit/surrealdb/test_context_query_adapter.py
@@ -167,7 +167,7 @@ def test_secret_not_in_error_message() -> None:
     """Raw credentials must not appear in QueryAdapterError messages."""
     import urllib.error
 
-    adapter = _make_adapter(user="admin", password="s3cr3t_p@ssw0rd")
+    adapter = _make_adapter(user="admin", password="local_test")
     http_error = urllib.error.HTTPError(
         url="http://127.0.0.1:8010/sql",
         code=500,
@@ -178,7 +178,7 @@ def test_secret_not_in_error_message() -> None:
     with patch("urllib.request.build_opener", return_value=_mock_opener_raising(http_error)):
         with pytest.raises(QueryAdapterError) as excinfo:
             adapter.execute("SELECT * FROM repo_artifact")
-    assert "s3cr3t_p@ssw0rd" not in excinfo.value.message
+    assert "local_test" not in excinfo.value.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/surrealdb/test_context_symbol_extraction.py
+++ b/tests/unit/surrealdb/test_context_symbol_extraction.py
@@ -29,7 +29,6 @@ from tools.surrealdb.context_indexer import (
     stable_id,
 )
 
-
 SCOPE_CONFIG = Path("infrastructure/config/surrealdb/context_ingestion_scope.yaml")
 FIXTURE_ROOT = Path("tests/fixtures/surrealdb/context_graph")
 
@@ -489,15 +488,11 @@ def test_derive_dependency_edges_contains() -> None:
 def test_derive_dependency_edges_imports_resolved() -> None:
     src = "from core.utils.clock import utcnow\n"
     src_artifact = _make_artifact("services/myservice.py")
-    target_artifact = _make_artifact(
-        "core/utils/clock.py", normalized_sha256="b" * 64
-    )
+    target_artifact = _make_artifact("core/utils/clock.py", normalized_sha256="b" * 64)
     _, _ = extract_code_symbols(src_artifact, src)
     imp_refs, _ = extract_import_references(src_artifact, src)
 
-    edges = derive_dependency_edges(
-        [src_artifact, target_artifact], [], imp_refs, []
-    )
+    edges = derive_dependency_edges([src_artifact, target_artifact], [], imp_refs, [])
     import_edges = [e for e in edges if e.edge_type == "imports"]
     assert len(import_edges) == 1
     assert import_edges[0].from_id == src_artifact.artifact_id
@@ -519,6 +514,8 @@ def test_derive_dependency_edges_imports_inferred_when_not_resolved() -> None:
     assert import_edges[0].inferred is True
     assert import_edges[0].from_table == "repo_artifact"
     assert import_edges[0].to_table == "module"
+
+
 # Absolute import submodule resolution (Codex review fix — #2062 addendum P1)
 # ---------------------------------------------------------------------------
 
@@ -539,7 +536,9 @@ def test_derive_dependency_edges_absolute_submodule_resolved() -> None:
 
 
 @pytest.mark.unit
-def test_derive_dependency_edges_absolute_submodule_no_artifact_stays_inferred() -> None:
+def test_derive_dependency_edges_absolute_submodule_no_artifact_stays_inferred() -> (
+    None
+):
     """from core.utils import clock stays inferred when core/utils/clock.py is absent."""
     src = "from core.utils import clock\n"
     src_artifact = _make_artifact("services/myservice.py")
@@ -627,8 +626,8 @@ def test_extract_import_references_stores_import_level() -> None:
 
     by_module = {r.module: r for r in refs}
     assert by_module["os"].import_level == 0
-    assert by_module[""].import_level == 1       # from . import sibling
-    assert by_module["utils"].import_level == 2   # from ..utils import helper
+    assert by_module[""].import_level == 1  # from . import sibling
+    assert by_module["utils"].import_level == 2  # from ..utils import helper
 
 
 @pytest.mark.unit
@@ -712,9 +711,9 @@ def test_run_indexer_ast_error_paths_are_unique() -> None:
 
     result = run_indexer(Path("."), SCOPE_CONFIG)
     error_paths = [e.source_path for e in result.ast_parse_errors]
-    assert len(error_paths) == len(set(error_paths)), (
-        f"duplicate AstParseError paths: {[p for p in error_paths if error_paths.count(p) > 1]}"
-    )
+    assert len(error_paths) == len(
+        set(error_paths)
+    ), f"duplicate AstParseError paths: {[p for p in error_paths if error_paths.count(p) > 1]}"
     snapshot = build_snapshot(result)
     assert snapshot["ast_parse_error_count"] == len(result.ast_parse_errors)
 
@@ -771,7 +770,6 @@ def test_dependency_edge_to_payload_includes_from_to_table() -> None:
     assert payload["to_table"] == "code_symbol"
     assert "from_id" in payload
     assert "to_id" in payload
-
 
 
 # Issue #2063: JSONL export extension
@@ -838,7 +836,9 @@ def test_run_indexer_extracts_symbols_from_python_files() -> None:
     """Ensure that the live repo run finds code symbols in Python source files."""
     result = run_indexer(Path("."), SCOPE_CONFIG)
     # The real repo has Python files, so we expect symbols to be extracted
-    assert len(result.code_symbols) > 0, "expected code symbols from Python files in scope"
+    assert (
+        len(result.code_symbols) > 0
+    ), "expected code symbols from Python files in scope"
     for sym in result.code_symbols:
         assert sym.source_path
         assert sym.symbol_id.startswith("code_symbol:")

--- a/tests/unit/surrealdb/test_context_symbol_extraction.py
+++ b/tests/unit/surrealdb/test_context_symbol_extraction.py
@@ -334,7 +334,7 @@ host = "localhost"
 port = 8000
 
 [secrets]
-api_key = "abc123secret"
+api_key = "local_test"
 username = "admin"
 """
 

--- a/tests/unit/surrealdb/test_ledger_importer.py
+++ b/tests/unit/surrealdb/test_ledger_importer.py
@@ -56,7 +56,7 @@ action:
 scope:
   repo: "Claire_de_Binare"
 evidence:
-  - "token=test_secret_value_123"
+  - "token=dummy"
 ---
 event_id: "evt-2"
 timestamp: "2026-01-01T00:00:02Z"

--- a/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
+++ b/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
@@ -2,6 +2,7 @@
 
 All tests use mocked urllib; no real SurrealDB container is needed.
 """
+
 from __future__ import annotations
 
 import base64
@@ -174,7 +175,9 @@ def test_apply_create_no_auth_header_when_no_credentials(
 
 
 @pytest.mark.unit
-def test_apply_create_includes_basic_auth_header(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_create_includes_basic_auth_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     adapter = _make_adapter(user="root", password="s3cr3t")
     captured_req: list[Any] = []
 
@@ -307,7 +310,9 @@ def test_http_500_raises_apply_adapter_error(monkeypatch: pytest.MonkeyPatch) ->
 def test_http_400_error_includes_response_body(monkeypatch: pytest.MonkeyPatch) -> None:
     """HTTP 400 ApplyAdapterError must embed the SurrealDB response body for diagnosis."""
     adapter = _make_adapter()
-    surrealdb_msg = b'{"code":400,"information":"Parse error near supplementary unicode"}'
+    surrealdb_msg = (
+        b'{"code":400,"information":"Parse error near supplementary unicode"}'
+    )
 
     class FakeHTTPError(urllib.error.HTTPError):
         def read(self) -> bytes:
@@ -325,7 +330,9 @@ def test_http_400_error_includes_response_body(monkeypatch: pytest.MonkeyPatch) 
         lambda *a, **kw: (_ for _ in ()).throw(http_err),
     )
 
-    with pytest.raises(ApplyAdapterError, match="Parse error near supplementary unicode"):
+    with pytest.raises(
+        ApplyAdapterError, match="Parse error near supplementary unicode"
+    ):
         adapter.apply_create("doc_page", "abc", {"title": "test"})
 
 
@@ -690,9 +697,7 @@ def test_makefile_context_import_local_passes_secrets_path() -> None:
                 return
         elif in_target and not line.startswith("\t") and line.strip():
             break
-    pytest.fail(
-        "context-import-local target in Makefile does not pass --secrets-path"
-    )
+    pytest.fail("context-import-local target in Makefile does not pass --secrets-path")
 
 
 @pytest.mark.unit
@@ -852,33 +857,37 @@ def test_apply_tombstone_datetime_field_surql_literal(
 def test_payload_to_surql_content_roundtrip() -> None:
     """_payload_to_surql_content unit tests: allowlist, non-allowlist, null, number."""
     # Allowlisted field with Z-suffix ISO string → converted
-    result = _payload_to_surql_content({"observed_at": "2026-05-18T19:50:12Z", "x": "y"})
+    result = _payload_to_surql_content(
+        {"observed_at": "2026-05-18T19:50:12Z", "x": "y"}
+    )
     assert '"observed_at": d"2026-05-18T19:50:12Z"' in result
     assert '"x": "y"' in result
 
     # Non-allowlisted ISO-like field → not converted
     result2 = _payload_to_surql_content({"timestamp_text": "2026-05-18T19:50:12Z"})
     assert '"timestamp_text": "2026-05-18T19:50:12Z"' in result2
-    assert "d\"" not in result2
+    assert 'd"' not in result2
 
     # Allowlisted field without Z suffix → not converted (no partial matches)
     result3 = _payload_to_surql_content({"observed_at": "2026-05-18T19:50:12"})
     assert '"observed_at": "2026-05-18T19:50:12"' in result3
-    assert "d\"" not in result3
+    assert 'd"' not in result3
 
     # Null value for allowlisted field → not converted (null is not a string)
     result4 = _payload_to_surql_content({"observed_at": None})
     assert '"observed_at": null' in result4
-    assert "d\"" not in result4
+    assert 'd"' not in result4
 
 
 @pytest.mark.unit
 def test_payload_to_surql_content_record_ref_unquoted() -> None:
     """page_ref / section_ref record-ref strings are unquoted in CONTENT (#2577)."""
-    result = _payload_to_surql_content({
-        "page_ref": "doc_page:\u27e8page-example\u27e9",
-        "title": "Example",
-    })
+    result = _payload_to_surql_content(
+        {
+            "page_ref": "doc_page:\u27e8page-example\u27e9",
+            "title": "Example",
+        }
+    )
     assert '"page_ref": doc_page:\u27e8page-example\u27e9' in result
     assert '"title": "Example"' in result
     # Must not appear quoted
@@ -888,9 +897,11 @@ def test_payload_to_surql_content_record_ref_unquoted() -> None:
 @pytest.mark.unit
 def test_payload_to_surql_content_section_ref_unquoted() -> None:
     """section_ref record-ref strings are unquoted in CONTENT (#2577)."""
-    result = _payload_to_surql_content({
-        "section_ref": "doc_section:\u27e8section-example\u27e9",
-    })
+    result = _payload_to_surql_content(
+        {
+            "section_ref": "doc_section:\u27e8section-example\u27e9",
+        }
+    )
     assert '"section_ref": doc_section:\u27e8section-example\u27e9' in result
     assert '"section_ref": "doc_section:' not in result
 
@@ -898,10 +909,12 @@ def test_payload_to_surql_content_section_ref_unquoted() -> None:
 @pytest.mark.unit
 def test_payload_to_surql_content_datetime_regression_after_ascii_change() -> None:
     """ensure_ascii=False must not break the existing datetime literal conversion."""
-    result = _payload_to_surql_content({
-        "observed_at": "2026-05-18T19:50:12Z",
-        "title": "still works",
-    })
+    result = _payload_to_surql_content(
+        {
+            "observed_at": "2026-05-18T19:50:12Z",
+            "title": "still works",
+        }
+    )
     assert '"observed_at": d"2026-05-18T19:50:12Z"' in result
     assert '"title": "still works"' in result
 

--- a/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
+++ b/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
@@ -418,7 +418,7 @@ def test_surrealdb_err_response_raises_apply_adapter_error(
 
 @pytest.mark.unit
 def test_password_not_in_adapter_error_message(monkeypatch: pytest.MonkeyPatch) -> None:
-    adapter = _make_adapter(user="myuser", password="supersecret123")
+    adapter = _make_adapter(user="myuser", password="local_test")
     monkeypatch.setattr(
         "urllib.request.urlopen",
         lambda *a, **kw: (_ for _ in ()).throw(
@@ -429,7 +429,7 @@ def test_password_not_in_adapter_error_message(monkeypatch: pytest.MonkeyPatch) 
     with pytest.raises(ApplyAdapterError) as exc_info:
         adapter.apply_create("repo_artifact", "abc", {"k": "v"})
 
-    assert "supersecret123" not in str(exc_info.value)
+    assert "local_test" not in str(exc_info.value)
     assert "myuser" not in str(exc_info.value)
 
 

--- a/tests/unit/verlosung/test_backup_recovery.py
+++ b/tests/unit/verlosung/test_backup_recovery.py
@@ -35,7 +35,7 @@ def postgres_conn():
         port=5432,
         database="claire_de_binare",
         user="claire_user",
-        password="claire_db_secret_2024",
+        password="local_test",
     )
     yield conn
     conn.close()
@@ -214,7 +214,7 @@ def test_postgres_restore_from_backup(backup_dir, postgres_conn):
         port=5432,
         database="postgres",
         user="claire_user",
-        password="claire_db_secret_2024",
+        password="local_test",
     )
     admin_conn.autocommit = True
     admin_cursor = admin_conn.cursor()
@@ -289,7 +289,7 @@ def test_postgres_restore_from_backup(backup_dir, postgres_conn):
         port=5432,
         database="claire_de_binare",
         user="claire_user",
-        password="claire_db_secret_2024",
+        password="local_test",
     )
     restored_cursor = restored_conn.cursor()
 

--- a/tests/unit/verlosung/test_backup_recovery.py
+++ b/tests/unit/verlosung/test_backup_recovery.py
@@ -181,8 +181,7 @@ def test_postgres_restore_from_backup(backup_dir, postgres_conn):
     # Step 3: Insert Test Data (simulate new data after backup)
     print("  📝 Step 3: Insert test snapshot (after backup)...")
 
-    cursor.execute(
-        """
+    cursor.execute("""
         INSERT INTO portfolio_snapshots (
             timestamp, total_equity, available_balance, total_unrealized_pnl, total_realized_pnl,
             daily_pnl, total_exposure_pct, open_positions, metadata
@@ -190,17 +189,14 @@ def test_postgres_restore_from_backup(backup_dir, postgres_conn):
             NOW(), 100000.0, 95000.0, 500.0, 1000.0,
             200.0, 0.05, 2, '{"test": "restore_marker"}'::jsonb
         )
-    """
-    )
+    """)
     postgres_conn.commit()
 
     cursor.execute("SELECT COUNT(*) FROM portfolio_snapshots")
     after_insert_count = cursor.fetchone()[0]
 
     print(f"    ✓ After insert: {after_insert_count} snapshots")
-    assert (
-        after_insert_count == baseline_count + 1
-    ), "Test snapshot should be inserted"
+    assert after_insert_count == baseline_count + 1, "Test snapshot should be inserted"
 
     # Step 4: Drop and Recreate Database (simulate catastrophic failure)
     print("  💥 Step 4: Drop and recreate database (simulate disaster)...")
@@ -220,14 +216,12 @@ def test_postgres_restore_from_backup(backup_dir, postgres_conn):
     admin_cursor = admin_conn.cursor()
 
     # Terminate connections
-    admin_cursor.execute(
-        """
+    admin_cursor.execute("""
         SELECT pg_terminate_backend(pg_stat_activity.pid)
         FROM pg_stat_activity
         WHERE pg_stat_activity.datname = 'claire_de_binare'
           AND pid <> pg_backend_pid()
-    """
-    )
+    """)
 
     # Drop DB
     admin_cursor.execute("DROP DATABASE IF EXISTS claire_de_binare")
@@ -305,12 +299,10 @@ def test_postgres_restore_from_backup(backup_dir, postgres_conn):
     ), f"Data mismatch: expected {baseline_count}, got {restored_count}"
 
     # Validate test snapshot is NOT present
-    restored_cursor.execute(
-        """
+    restored_cursor.execute("""
         SELECT COUNT(*) FROM portfolio_snapshots
         WHERE metadata->>'test' = 'restore_marker'
-    """
-    )
+    """)
     test_marker_count = restored_cursor.fetchone()[0]
 
     assert (
@@ -460,8 +452,7 @@ def test_automated_backup_script_concept():
     """
     print("\n💡 Concept-Test: Automated Backup Script...")
 
-    print(
-        """
+    print("""
   📋 Beispiel für automatisiertes Backup-Script:
 
   #!/bin/bash
@@ -495,18 +486,15 @@ def test_automated_backup_script_concept():
     echo "❌ Backup failed!"
     exit 1
   fi
-  """
-    )
+  """)
 
     print("  ✅ Backup script concept documented")
 
-    print(
-        """
+    print("""
   📋 Beispiel für Cronjob (täglich um 02:00 Uhr):
 
   0 2 * * * /home/user/Claire_de_Binare_Cleanroom/backoffice/scripts/backup_postgres.sh >> /var/log/claire_backup.log 2>&1
-  """
-    )
+  """)
 
     print("\n✅ Concept test passed (no actual backup script created)")
 

--- a/tests/unit/verlosung/test_chaos_resilience.py
+++ b/tests/unit/verlosung/test_chaos_resilience.py
@@ -50,7 +50,9 @@ def is_service_healthy(service_name):
                 return "healthy" in status.lower() or service.get("Health") == "healthy"
 
         except json.JSONDecodeError:
-            logging.getLogger(__name__).debug("JSON decode error for docker service line (ignored)")
+            logging.getLogger(__name__).debug(
+                "JSON decode error for docker service line (ignored)"
+            )
 
     return False
 
@@ -81,9 +83,7 @@ def test_redis_crash_and_recovery():
 
     # Verify Redis ist erreichbar
     try:
-        redis_client = redis.Redis(
-            host="localhost", port=6379, password="local_test"
-        )
+        redis_client = redis.Redis(host="localhost", port=6379, password="local_test")
         assert redis_client.ping(), "Redis should respond to ping"
         print("    ✓ Redis is reachable")
     except Exception as e:
@@ -287,9 +287,7 @@ def test_postgres_crash_and_recovery():
     print(f"    ✓ After restart: {after_count} snapshots")
 
     # Data should be preserved (Volume-Persistence)
-    assert (
-        after_count == baseline_count
-    ), f"Data lost: {baseline_count} → {after_count}"
+    assert after_count == baseline_count, f"Data lost: {baseline_count} → {after_count}"
 
     print("    ✓ No data loss")
 
@@ -451,9 +449,7 @@ def test_concurrent_redis_and_postgres_crash():
 
     # Check Redis
     try:
-        redis_client = redis.Redis(
-            host="localhost", port=6379, password="local_test"
-        )
+        redis_client = redis.Redis(host="localhost", port=6379, password="local_test")
         if redis_client.ping():
             redis_recovered = True
             print("    ✓ Redis recovered")

--- a/tests/unit/verlosung/test_chaos_resilience.py
+++ b/tests/unit/verlosung/test_chaos_resilience.py
@@ -82,7 +82,7 @@ def test_redis_crash_and_recovery():
     # Verify Redis ist erreichbar
     try:
         redis_client = redis.Redis(
-            host="localhost", port=6379, password="claire_redis_secret_2024"
+            host="localhost", port=6379, password="local_test"
         )
         assert redis_client.ping(), "Redis should respond to ping"
         print("    ✓ Redis is reachable")
@@ -124,7 +124,7 @@ def test_redis_crash_and_recovery():
             redis_client = redis.Redis(
                 host="localhost",
                 port=6379,
-                password="claire_redis_secret_2024",
+                password="local_test",
                 socket_connect_timeout=5,
             )
 
@@ -187,7 +187,7 @@ def test_postgres_crash_and_recovery():
             port=5432,
             database="claire_de_binare",
             user="claire_user",
-            password="claire_db_secret_2024",
+            password="local_test",
         )
         cursor = conn.cursor()
         cursor.execute("SELECT COUNT(*) FROM portfolio_snapshots")
@@ -215,7 +215,7 @@ def test_postgres_crash_and_recovery():
             port=5432,
             database="claire_de_binare",
             user="claire_user",
-            password="claire_db_secret_2024",
+            password="local_test",
             connect_timeout=3,
         )
         conn.close()
@@ -246,7 +246,7 @@ def test_postgres_crash_and_recovery():
                 port=5432,
                 database="claire_de_binare",
                 user="claire_user",
-                password="claire_db_secret_2024",
+                password="local_test",
                 connect_timeout=5,
             )
 
@@ -277,7 +277,7 @@ def test_postgres_crash_and_recovery():
         port=5432,
         database="claire_de_binare",
         user="claire_user",
-        password="claire_db_secret_2024",
+        password="local_test",
     )
     cursor = conn.cursor()
     cursor.execute("SELECT COUNT(*) FROM portfolio_snapshots")
@@ -452,7 +452,7 @@ def test_concurrent_redis_and_postgres_crash():
     # Check Redis
     try:
         redis_client = redis.Redis(
-            host="localhost", port=6379, password="claire_redis_secret_2024"
+            host="localhost", port=6379, password="local_test"
         )
         if redis_client.ping():
             redis_recovered = True
@@ -467,7 +467,7 @@ def test_concurrent_redis_and_postgres_crash():
             port=5432,
             database="claire_de_binare",
             user="claire_user",
-            password="claire_db_secret_2024",
+            password="local_test",
         )
         cursor = conn.cursor()
         cursor.execute("SELECT 1")

--- a/tests/unit/verlosung/test_docker_lifecycle.py
+++ b/tests/unit/verlosung/test_docker_lifecycle.py
@@ -299,7 +299,7 @@ def test_docker_compose_volume_persistence():
             port=5432,
             database="claire_de_binare",
             user="claire_user",
-            password="claire_db_secret_2024",
+            password="local_test",
         )
         cursor = conn.cursor()
         cursor.execute("SELECT COUNT(*) FROM portfolio_snapshots")
@@ -325,7 +325,7 @@ def test_docker_compose_volume_persistence():
         port=5432,
         database="claire_de_binare",
         user="claire_user",
-        password="claire_db_secret_2024",
+        password="local_test",
     )
     cursor = conn.cursor()
     cursor.execute("SELECT COUNT(*) FROM portfolio_snapshots")

--- a/tests/unit/verlosung/test_docker_lifecycle.py
+++ b/tests/unit/verlosung/test_docker_lifecycle.py
@@ -34,7 +34,9 @@ def parse_docker_json(stdout):
             try:
                 services.append(json.loads(line))
             except json.JSONDecodeError:
-                logging.getLogger(__name__).debug("JSON decode error for docker ps line (ignored)")
+                logging.getLogger(__name__).debug(
+                    "JSON decode error for docker ps line (ignored)"
+                )
     return services
 
 


### PR DESCRIPTION
## Summary

Sanitizes 9 test files with hardcoded credential-like dummy values that triggered \HIGH_CONFIDENCE_SECRET_RE\ scanner flags.

## Changes

- Replaced all dummy password/secret literals with non-matching placeholders (\local_test\, \	oken=dummy\)
- All replacements are ≤10 chars inside quotes → do not match the ≥12 quoted literal rule
- Updated assertion strings in \	est_context_query_adapter.py\ and \	est_surrealdb_local_apply_adapter.py\

## Files (9)

- tests/unit/surrealdb/test_context_query_adapter.py
- tests/unit/surrealdb/test_context_symbol_extraction.py
- tests/unit/surrealdb/test_ledger_importer.py
- tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
- tests/unit/verlosung/test_backup_recovery.py
- tests/unit/verlosung/test_chaos_resilience.py
- tests/unit/verlosung/test_docker_lifecycle.py
- tests/performance/verlosung/test_analytics_performance.py
- tests/performance/verlosung/test_full_system_stress.py

## Verification

- Scanner re-scan: 0 matches in #2598-scope files
- All surrealdb unit tests pass (188 tests including indexer scanner fixtures)