### PR TITLE
docs(agents): require brain evidence gate for context-aware planning

### DIFF
--- a/.opencode/skills/cdb-session-start/SKILL.md
+++ b/.opencode/skills/cdb-session-start/SKILL.md
@@ -77,7 +77,28 @@ Establish a verified, fail-closed starting state before any repo work begins.
    The Git truth checks in steps 1-3 do not replace the control-context read; they
    precede it.
 
-5. MCP Capability Resolution Gate (conditional):
+5. Brain Evidence Gate (scope-abhängig):
+
+   If the session scope includes **Strategy, Runtime, Module, Service, Contract,
+   Context, SurrealDB, MCP tools, DB-backed Memory, or Evidence**, output the
+   Brain Evidence block from `agents/AGENTS.md` § Brain Evidence Gate **before
+   any plan**.
+
+   The block MUST contain all fields (`brain_source`, `brain_status`,
+   `tools_or_queries`, `records_or_results`, `repo_crosscheck`, `impact_on_plan`,
+   `limitations`) with honest values.
+
+   **No plan may claim Memory/Evidence/Decision consideration without
+   record/tool/query evidence.**
+
+   If the block is missing or incomplete:
+   - STOP.
+   - Report which fields are missing or which values are unsubstantiated.
+   - Do not proceed to implementation planning.
+
+   Reference: `agents/AGENTS.md` § Brain Evidence Gate.
+
+6. MCP Capability Resolution Gate (conditional):
 
    When the session scope includes Context, SurrealDB, MCP tools, ContextBridge,
    or DB-backed agent memory, verify capability before any implementation or
@@ -106,9 +127,9 @@ Establish a verified, fail-closed starting state before any repo work begins.
 
    Reference: `docs/runbooks/surrealdb_context_mcp_access.md` § 1.5.
 
-6. Create a clean execution surface:
+7. Create a clean execution surface:
 
-   Once steps 1-5 are complete and no gate has fired, create the working surface:
+   Once steps 1-6 are complete and no gate has fired, create the working surface:
    - Branch from current `origin/main` (never from stale local main).
    - Clean worktree confirmed.
    - Explicit target issue identified and open.
@@ -125,6 +146,8 @@ Establish a verified, fail-closed starting state before any repo work begins.
 - If `cdb-control-intake` cannot be completed, stop.
 - If any of the risky conditions in step 2 cannot be resolved, stop and report
   what remains unresolved before any file is touched.
+- If the Brain Evidence Gate block is missing or incomplete for a relevant
+  scope, stop and report which fields are missing or unsubstantiated.
 - If MCP capability cannot be verified for a Context/SurrealDB tool in scope,
   stop and report the missing layer instead of implementing or calling around it.
 
@@ -148,6 +171,15 @@ Control-Snapshot (via cdb-control-intake)
 - Board stage:
 - LR verdict:
 - Weekly focus:
+
+Brain Evidence (nur bei relevantem Scope)
+- brain_source:
+- brain_status:
+- tools_or_queries:
+- records_or_results:
+- repo_crosscheck:
+- impact_on_plan:
+- limitations:
 
 Arbeitsflaeche
 - Branch:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Wichtige kanonische Dateien:
 - [`docs/runbooks/CONTROL_REGISTER.md`](docs/runbooks/CONTROL_REGISTER.md)
 - [`knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md`](knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md)
 - [`PROJECT_STATUS.md`](PROJECT_STATUS.md)
+- [`agents/OPEN_CODE_AGENTS.md`](agents/OPEN_CODE_AGENTS.md)
 
 Aktueller Projektstand:
 - Working Repo ist der produktive Canon fuer Agenten-, Governance-, Knowledge- und Navigationsdoku.
@@ -263,4 +264,5 @@ OpenCode skill surface zusaetzlich: `.opencode/skills/` (gezielt laden, nicht pa
 - Read `knowledge/governance/CDB_AGENT_POLICY.md` section 4 before any write.
 - Respect single-writer locks, explicit stop signals, and write gates.
 - `DELIVERY_APPROVED.yaml` is human-controlled; agents must not modify it.
+- Before planning for strategy/runtime/module/service/contract/context scope, output a `Brain Evidence` block (see `agents/AGENTS.md` § Brain Evidence Gate).
 - LR status remains NO-GO for live trading unless explicitly changed by canon/human approval.

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -18,6 +18,7 @@ in einem separaten externen Doku-Repo gesucht wurde.
 7. `CURRENT_STATUS.md`
 8. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
 9. `docs/runbooks/CONTROL_REGISTER.md`
+10. `agents/OPEN_CODE_AGENTS.md` — OpenCode Agent Shared Contract (Brain Evidence Gate fuer OpenCode Agents)
 
 ## Canonical Domains
 
@@ -57,6 +58,47 @@ in einem separaten externen Doku-Repo gesucht wurde.
 - Eine Board-Stage darf nie als implizite Live-Freigabe oder Strategie-Validierung interpretiert werden.
 - Das lokale Archiv `docs/archive/docs_hub_snapshot/` ist nur noch ein optionaler historischer Rueckgriff.
 - Externe Docs-Repo-Pfade sind kein produktiver Default mehr.
+
+## Brain Evidence Gate
+
+For sessions whose scope includes **Strategy, Runtime, Module, Service, Contract,
+Context, SurrealDB, MCP tools, DB-backed Memory, or Evidence**, every agent
+MUST output the following block **before any plan**:
+
+```text
+## Brain Evidence
+brain_source: surrealdb-local | in_memory | repo-only | unavailable
+brain_status: used | partial | not-used | blocked
+tools_or_queries:
+  - <Tool/Command/Query>
+records_or_results:
+  - <Record-ID/Count/Source/Hash, falls vorhanden>
+repo_crosscheck:
+  - <Datei/Pfad/Symbol/Commit>
+impact_on_plan:
+  - <Was dadurch anders geplant wurde>
+limitations:
+  - <Was nicht bewiesen ist>
+```
+
+### Field Logic
+
+- `brain_source=surrealdb-local`: Brain-Claims sind erlaubt, aber nur mit
+  Tool-/Query-/Record-Evidence.
+- `brain_source=in_memory`: Nur Fixture/Noop/In-Memory-Kontext; keine DB-backed
+  Brain-Claims.
+- `brain_source=repo-only`: Klar `brain-not-used` melden.
+- `brain_source=unavailable`: Klar `blocked` oder `repo-only fallback` melden.
+
+### Rules
+
+- No plan may claim Memory/Evidence/Decision consideration without
+  record/tool/query evidence.
+- Strategy/Runtime/Module work MUST distinguish `repo-only` from brain-backed.
+- `CURRENT_STATUS.md` is a ledger, not live truth.
+- GitHub/Repo/Live evidence wins over Brain/CIS claims.
+- Board-Stage `trade-capable` is not Live-Go.
+- LR remains NO-GO.
 
 ## Legacy Note
 

--- a/agents/OPEN_CODE_AGENTS.md
+++ b/agents/OPEN_CODE_AGENTS.md
@@ -32,6 +32,7 @@ Gilt für **alle** OpenCode Agents (egal welcher Provider).
 - Danach `cdb-control-intake`
 - Bei Issue-Arbeit danach `cdb-issue-to-session-plan`
 - Bei Context-, SurrealDB-, MCP-Tool-, ContextBridge- oder DB-backed-Memory-Scope: MCP Capability Resolution Gate ausführen vor Implementierung oder toolabhängiger Planung — Repo-Präsenz ist nicht gleich MCP-Verfügbarkeit. Referenz: `docs/runbooks/surrealdb_context_mcp_access.md` § 1.5.
+- Bei Strategy-, Runtime-, Module-, Service-, Contract-, Context-, SurrealDB-, MCP-, Memory- oder Evidence-Scope: **Brain Evidence Gate** aus `agents/AGENTS.md` § Brain Evidence Gate ausführen **vor jeder Planung** — der Agent MUSS den vollständigen Brain-Evidence-Block mit `brain_source`, `brain_status`, `tools_or_queries`, `records_or_results`, `repo_crosscheck`, `impact_on_plan` und `limitations` ausgeben.
 - Danach nur task-spezifische Skills laden
 - Keine pauschale Skill-Massenladung
 - Third-Party-/Cybersecurity-Skills nur bei explizitem Bedarf und nur defensiv/prüfend


### PR DESCRIPTION
## Summary
- Adds a mandatory Brain Evidence Gate for strategy/runtime/module/service/contract/context-related planning.
- Requires agents to distinguish DB-backed \surrealdb-local\ context from \in_memory\, \epo-only\, or unavailable fallback.
- Prevents Memory/Evidence/Decision claims without tool/query/record evidence.

## Scope
Aligns agent bootloader behavior with the Context Intelligence expectations from #1976.

## Validation
- Searched for \Brain Evidence\, \rain_source\, \rain-not-used\, \surrealdb-local\, and \epo-only\.
- Docs/bootloader-only change; no runtime or DB mutation.

## Safety
- Documentation/agent-governance only.
- No SurrealDB runtime change.
- No DB writes/import/reset.
- No Context Query/Importer/Indexer change.
- No trading/runtime scope.
- LR remains NO-GO.

## CI Note
GitHub Actions may remain blocked by billing/runner allocation. This PR is parked for later CI/merge once billing is resolved.