### PR TITLE
build(surrealdb): make context python default windows-aware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,11 @@ REPLAY_DETERMINISTIC_VERIFY ?= 1
 
 CONTEXT_SNAP_DIR ?= artifacts/context-intelligence/latest
 CONTEXT_SCOPE_CONFIG ?= infrastructure/config/surrealdb/context_ingestion_scope.yaml
-PYTHON ?= python3
+ifeq ($(OS),Windows_NT)
+  PYTHON ?= python
+else
+  PYTHON ?= python3
+endif
 
 ifeq ($(OS),Windows_NT)
   SECRETS_PATH ?= $(USERPROFILE)/Documents/.secrets/.cdb


### PR DESCRIPTION
## Summary
- Makes the Makefile PYTHON default OS-aware for local Context/SurrealDB targets.
- Uses python on Windows and keeps python3 on Linux/Mac.
- Keeps context-smoke-db fail-closed and does not alter DB/runtime behavior.

## Scope
Refs #2603.

## Validation
- git diff --stat
- g -n "PYTHON \?=|ifeq \(\$\(OS\),Windows_NT\)" Makefile
- make -n context-smoke-db

## Safety
- Build/DevEx only.
- No SurrealDB schema change.
- No DB writes/import/reset.
- No MCP bridge change.
- No trading/runtime scope.
- LR remains NO-GO.

## CI Note
GitHub Actions may remain blocked by billing/runner allocation. This PR is parked for later CI/merge once billing is resolved.
