### PR TITLE
fix(infra): persist self-hosted runner credentials

### DIFF
--- a/infrastructure/actions-runner/.env.runner.example
+++ b/infrastructure/actions-runner/.env.runner.example
@@ -4,12 +4,20 @@
 #
 # Generate RUNNER_TOKEN at:
 #   https://github.com/jannekbuengener/Claire_de_Binare/settings/actions/runners/new
+#
+# RUNNER_TOKEN is only required for initial registration or re-registration.
+# If persistent state exists (runner-state volume), the token is not needed.
 
 REPO_URL=https://github.com/jannekbuengener/Claire_de_Binare
 RUNNER_TOKEN=__PASTE_TOKEN_FROM_GITHUB_UI__
 RUNNER_NAME=cdb-docker-runner-1
 RUNNER_LABELS=cdb,docker
 RUNNER_WORKDIR=_work
+
+# Deregister runner from GitHub on container stop (default: false).
+# Only set to true for intentional removal. Normal restarts/downs should keep
+# registration — the runner stays registered and reconnects on next start.
+RUNNER_DEREGISTER_ON_EXIT=false
 
 # Optional: match host docker-socket GID for non-root access
 # Run `stat -c '%g' /var/run/docker.sock` on the host to find the GID.

--- a/infrastructure/actions-runner/.env.runner2.example
+++ b/infrastructure/actions-runner/.env.runner2.example
@@ -7,12 +7,20 @@
 #
 # This is the dedicated merge-gate runner.
 # Do NOT reuse .env.runner — Runner 2 needs its own token, name, and labels.
+#
+# RUNNER_TOKEN is only required for initial registration or re-registration.
+# If persistent state exists (runner-state-2 volume), the token is not needed.
 
 REPO_URL=https://github.com/jannekbuengener/Claire_de_Binare
 RUNNER_TOKEN=__PASTE_TOKEN_FROM_GITHUB_UI__
 RUNNER_NAME=cdb-docker-runner-2
 RUNNER_LABELS=cdb,docker,merge-gate
 RUNNER_WORKDIR=_work
+
+# Deregister runner from GitHub on container stop (default: false).
+# Only set to true for intentional removal. Normal restarts/downs should keep
+# registration — the runner stays registered and reconnects on next start.
+RUNNER_DEREGISTER_ON_EXIT=false
 
 # Optional: match host docker-socket GID for non-root access
 # Run `stat -c '%g' /var/run/docker.sock` on the host to find the GID.

--- a/infrastructure/actions-runner/README.md
+++ b/infrastructure/actions-runner/README.md
@@ -61,6 +61,21 @@ rebuilds without re-registration.
 (`docker compose down && docker compose up -d --build`) do not need a
 new token.
 
+### Complete vs Partial State
+
+The entrypoint distinguishes three registration paths:
+
+| State | Condition | Behavior |
+|-------|-----------|----------|
+| **Complete** | `.runner` + `.credentials` + `.credentials_rsaparams` all present | Skip registration, reconnect |
+| **Partial** | Some but not all required files present | Require `RUNNER_TOKEN` for re-registration, or exit with clear error |
+| **None** | No state files present | Require `RUNNER_TOKEN` for initial registration, or exit with clear error |
+
+A **partial state** can occur if the state volume is corrupted or only
+partially restored. In this case the runner cannot self-heal without a
+fresh `RUNNER_TOKEN`. The entrypoint will print a descriptive error and
+exit rather than crash with an unbound-variable error.
+
 ## Deregistration
 
 By default, stopping the container (`docker compose down`) does **not**

--- a/infrastructure/actions-runner/README.md
+++ b/infrastructure/actions-runner/README.md
@@ -43,6 +43,42 @@ authenticates with its own credentials stored in `.runner`/`.credentials`.
 A new token is required only when the container is rebuilt from scratch
 or after a manual "Remove runner" in the GitHub UI.
 
+## State Persistence
+
+Runner credentials (`.runner`, `.credentials`, `.credentials_rsaparams`,
+`.path`) are persisted in a dedicated Docker volume (`runner-state` for
+Runner 1, `runner-state-2` for Runner 2). This allows container
+rebuilds without re-registration.
+
+**How it works**:
+- On startup, the entrypoint restores credentials from the state volume
+  before checking whether registration is needed.
+- After registration, credentials are copied to the state volume.
+- If the state volume contains valid credentials, `RUNNER_TOKEN` is not
+  required. The runner reconnects automatically.
+
+**First-time setup** still requires `RUNNER_TOKEN`. After that, rebuilds
+(`docker compose down && docker compose up -d --build`) do not need a
+new token.
+
+## Deregistration
+
+By default, stopping the container (`docker compose down`) does **not**
+deregister the runner from GitHub. The runner stays registered and
+reconnects on the next start.
+
+To intentionally deregister (e.g. before decommissioning a runner), set
+`RUNNER_DEREGISTER_ON_EXIT=true` in `.env.runner` / `.env.runner2`. This
+requires `RUNNER_TOKEN` to be present.
+
+```bash
+# Normal stop — runner stays registered
+docker compose -f infrastructure/actions-runner/docker-compose.runner.yml down
+
+# Intentional removal — set RUNNER_DEREGISTER_ON_EXIT=true first
+# Then stop the container. The runner will deregister from GitHub.
+```
+
 ## Stopping & Removing
 
 **Stop** (runner goes offline, stays registered):
@@ -51,10 +87,9 @@ or after a manual "Remove runner" in the GitHub UI.
 docker compose -f infrastructure/actions-runner/docker-compose.runner.yml down
 ```
 
-**Remove** (fully deregister): use the GitHub UI
-Settings > Actions > Runners > select runner > Remove, then follow the
-displayed removal command. If you rebuild the container without removing the
-old entry first, a duplicate runner may appear in the UI.
+**Remove** (fully deregister): set `RUNNER_DEREGISTER_ON_EXIT=true` in
+`.env.runner`, then stop the container; or use the GitHub UI
+Settings > Actions > Runners > select runner > Remove.
 
 ## Runner 2 — Dedicated Merge-Gate Runner
 
@@ -87,7 +122,8 @@ name, volume, and labels — completely independent from Runner 1.
 | Container name | `cdb_gh_runner` | `cdb_gh_runner_2` |
 | Env file | `.env.runner` | `.env.runner2` |
 | Runner name | `cdb-docker-runner-1` | `cdb-docker-runner-2` |
-| Volume | `runner-work` | `runner-work-2` |
+| Work volume | `runner-work` | `runner-work-2` |
+| State volume | `runner-state` | `runner-state-2` |
 | Labels | `self-hosted`, `cdb`, `docker` | `self-hosted`, `cdb`, `docker`, `merge-gate` |
 
 ### Labels
@@ -102,10 +138,44 @@ fallback to GitHub-hosted runners.
 
 ### Stopping & Removing Runner 2
 
-**Stop**:
+**Stop** (runner stays registered):
 ```bash
 docker compose -f infrastructure/actions-runner/docker-compose.runner2.yml down
 ```
 
-**Remove** (fully deregister): use the GitHub UI
+**Remove** (fully deregister): set `RUNNER_DEREGISTER_ON_EXIT=true` in
+`.env.runner2`, then stop the container; or use the GitHub UI
 Settings > Actions > Runners > select `cdb-docker-runner-2` > Remove.
+
+## Rebuild Without Token
+
+After the initial registration, the runner credentials are persisted in the
+state volume. Rebuilding the container does not require a new token:
+
+```bash
+# Rebuild without re-registration
+docker compose -f infrastructure/actions-runner/docker-compose.runner2.yml down
+docker compose -f infrastructure/actions-runner/docker-compose.runner2.yml up -d --build
+# Logs should show: "Restored .runner from persistent state"
+# or: "Runner already configured"
+```
+
+If the state volume is deleted or corrupted, a new `RUNNER_TOKEN` is required
+for re-registration.
+
+## Rollback
+
+If state persistence causes issues:
+
+1. Remove state volume mounts from compose files.
+2. Revert `entrypoint.sh` to the previous version.
+3. Volumes remain on disk — do not delete them unless intentionally
+   clearing state.
+4. If state is corrupted: generate a new `RUNNER_TOKEN`, remove the old
+   runner entry from the GitHub UI, and re-register.
+
+## Maintenance Window
+
+When restarting or rebuilding a runner that handles required merge checks
+(`ci`, `policy-gate`), avoid doing so while a check is running. Check
+the GitHub Actions queue or runner busy status before stopping.

--- a/infrastructure/actions-runner/docker-compose.runner.yml
+++ b/infrastructure/actions-runner/docker-compose.runner.yml
@@ -10,8 +10,10 @@ services:
     env_file: .env.runner
     volumes:
       - runner-work:/actions-runner/_work
+      - runner-state:/actions-runner/runner-state
       - /var/run/docker.sock:/var/run/docker.sock
     restart: unless-stopped
 
 volumes:
   runner-work:
+  runner-state:

--- a/infrastructure/actions-runner/docker-compose.runner2.yml
+++ b/infrastructure/actions-runner/docker-compose.runner2.yml
@@ -10,8 +10,10 @@ services:
     env_file: .env.runner2
     volumes:
       - runner-work-2:/actions-runner/_work
+      - runner-state-2:/actions-runner/runner-state
       - /var/run/docker.sock:/var/run/docker.sock
     restart: unless-stopped
 
 volumes:
   runner-work-2:
+  runner-state-2:

--- a/infrastructure/actions-runner/entrypoint.sh
+++ b/infrastructure/actions-runner/entrypoint.sh
@@ -3,10 +3,15 @@ set -euo pipefail
 
 STATE_DIR="/actions-runner/runner-state"
 
+# ── Guard all RUNNER_TOKEN access ────────────────────────────────
+# Single declared variable; never reference ${RUNNER_TOKEN} directly
+# under set -u — always use $runner_token instead.
+runner_token="${RUNNER_TOKEN:-}"
+
 # ── Required env ────────────────────────────────────────────────
 # REPO_URL is always required.
-# RUNNER_TOKEN is only required when no persistent state exists
-# (neither /actions-runner/.runner nor $STATE_DIR/.runner).
+# RUNNER_TOKEN is only required when no complete runner state exists
+# (complete = .runner + .credentials + .credentials_rsaparams all present).
 if [ -z "${REPO_URL:-}" ]; then
   echo "ERROR: REPO_URL is not set." >&2
   exit 1
@@ -36,25 +41,54 @@ sudo chown -R runner:runner /actions-runner/_work
 
 # ── Restore runner state from persistent volume ─────────────────
 if [ -d "$STATE_DIR" ]; then
-  for f in .runner .credentials .credentials_rsaparams .path; do
+  for f in .runner .credentials .credentials_rsaparams; do
     if [ -f "$STATE_DIR/$f" ] && [ ! -f "/actions-runner/$f" ]; then
       cp "$STATE_DIR/$f" "/actions-runner/$f"
       echo "Restored $f from persistent state"
     fi
   done
+  # .path is optional
+  if [ -f "$STATE_DIR/.path" ] && [ ! -f "/actions-runner/.path" ]; then
+    cp "$STATE_DIR/.path" "/actions-runner/.path"
+    echo "Restored .path from persistent state"
+  fi
 fi
 
-# ── Validate token requirement ──────────────────────────────────
-state_exists=false
-for f in .runner .credentials .credentials_rsaparams; do
-  if [ -f "/actions-runner/$f" ]; then
-    state_exists=true
-    break
-  fi
-done
+# ── Classify runner state ────────────────────────────────────────
+# Required files for a complete state: .runner, .credentials,
+# .credentials_rsaparams.  .path is optional.
+# complete_active  → all three required files present → skip registration
+# partial_state    → some but not all present → need token to re-register
+# (no state)       → need token for initial registration
+_has_runner=false
+_has_credentials=false
+_has_rsaparams=false
 
-if [ "$state_exists" = "false" ] && [ -z "${RUNNER_TOKEN:-}" ]; then
-  echo "ERROR: RUNNER_TOKEN is not set and no persistent runner state found." >&2
+[ -f "/actions-runner/.runner" ]                && _has_runner=true
+[ -f "/actions-runner/.credentials" ]          && _has_credentials=true
+[ -f "/actions-runner/.credentials_rsaparams" ] && _has_rsaparams=true
+
+_complete_state=false
+_partial_state=false
+
+if [ "$_has_runner" = "true" ] && [ "$_has_credentials" = "true" ] && [ "$_has_rsaparams" = "true" ]; then
+  _complete_state=true
+elif [ "$_has_runner" = "true" ] || [ "$_has_credentials" = "true" ] || [ "$_has_rsaparams" = "true" ]; then
+  _partial_state=true
+fi
+
+# ── Decide registration path ─────────────────────────────────────
+if [ "$_complete_state" = "true" ]; then
+  echo "Complete runner state found — skipping registration"
+elif [ "$_partial_state" = "true" ]; then
+  if [ -z "$runner_token" ]; then
+    echo "ERROR: Partial runner state detected but RUNNER_TOKEN is not set." >&2
+    echo "Provide RUNNER_TOKEN for re-registration, or remove partial state and provide a fresh token." >&2
+    exit 1
+  fi
+  echo "Partial runner state detected — re-registering with token"
+elif [ -z "$runner_token" ]; then
+  echo "ERROR: RUNNER_TOKEN is not set and no runner state found." >&2
   echo "Either provide RUNNER_TOKEN for initial registration or ensure state volume is mounted." >&2
   exit 1
 fi
@@ -62,12 +96,12 @@ fi
 # ── Configure runner ────────────────────────────────────────────
 cd /actions-runner
 
-if [ -f /actions-runner/.runner ]; then
+if [ "$_complete_state" = "true" ]; then
   echo "Runner already configured"
 else
   ./config.sh \
     --url "${REPO_URL}" \
-    --token "${RUNNER_TOKEN}" \
+    --token "$runner_token" \
     --name "${RUNNER_NAME:-cdb-docker-runner-1}" \
     --labels "${RUNNER_LABELS:-cdb,docker}" \
     --work "${RUNNER_WORKDIR:-_work}" \
@@ -86,9 +120,9 @@ sudo chown -R runner:runner "$STATE_DIR"
 
 # ── Graceful shutdown ───────────────────────────────────────────
 cleanup() {
-  if [ "${RUNNER_DEREGISTER_ON_EXIT:-false}" = "true" ] && [ -n "${RUNNER_TOKEN:-}" ]; then
+  if [ "${RUNNER_DEREGISTER_ON_EXIT:-false}" = "true" ] && [ -n "$runner_token" ]; then
     echo "Caught signal, deregistering runner (RUNNER_DEREGISTER_ON_EXIT=true)..."
-    ./config.sh remove --unattended --token "${RUNNER_TOKEN}" || true
+    ./config.sh remove --unattended --token "$runner_token" || true
   else
     echo "Caught signal, stopping runner (RUNNER_DEREGISTER_ON_EXIT=${RUNNER_DEREGISTER_ON_EXIT:-false})..."
   fi

--- a/infrastructure/actions-runner/entrypoint.sh
+++ b/infrastructure/actions-runner/entrypoint.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
+STATE_DIR="/actions-runner/runner-state"
+
 # ── Required env ────────────────────────────────────────────────
-for var in REPO_URL RUNNER_TOKEN; do
-  if [ -z "${!var:-}" ]; then
-    echo "ERROR: $var is not set." >&2
-    exit 1
-  fi
-done
+# REPO_URL is always required.
+# RUNNER_TOKEN is only required when no persistent state exists
+# (neither /actions-runner/.runner nor $STATE_DIR/.runner).
+if [ -z "${REPO_URL:-}" ]; then
+  echo "ERROR: REPO_URL is not set." >&2
+  exit 1
+fi
 
 # ── Docker socket GID alignment (optional) ──────────────────────
 # Pass DOCKER_GID matching the host's docker-socket group so the
@@ -31,6 +34,31 @@ fi
 sudo mkdir -p /actions-runner/_work/_tool /actions-runner/_work/_temp /actions-runner/_work/_update
 sudo chown -R runner:runner /actions-runner/_work
 
+# ── Restore runner state from persistent volume ─────────────────
+if [ -d "$STATE_DIR" ]; then
+  for f in .runner .credentials .credentials_rsaparams .path; do
+    if [ -f "$STATE_DIR/$f" ] && [ ! -f "/actions-runner/$f" ]; then
+      cp "$STATE_DIR/$f" "/actions-runner/$f"
+      echo "Restored $f from persistent state"
+    fi
+  done
+fi
+
+# ── Validate token requirement ──────────────────────────────────
+state_exists=false
+for f in .runner .credentials .credentials_rsaparams; do
+  if [ -f "/actions-runner/$f" ]; then
+    state_exists=true
+    break
+  fi
+done
+
+if [ "$state_exists" = "false" ] && [ -z "${RUNNER_TOKEN:-}" ]; then
+  echo "ERROR: RUNNER_TOKEN is not set and no persistent runner state found." >&2
+  echo "Either provide RUNNER_TOKEN for initial registration or ensure state volume is mounted." >&2
+  exit 1
+fi
+
 # ── Configure runner ────────────────────────────────────────────
 cd /actions-runner
 
@@ -47,10 +75,23 @@ else
     --replace
 fi
 
+# ── Persist runner state to volume ──────────────────────────────
+sudo mkdir -p "$STATE_DIR"
+for f in .runner .credentials .credentials_rsaparams .path; do
+  if [ -f "/actions-runner/$f" ]; then
+    cp "/actions-runner/$f" "$STATE_DIR/$f"
+  fi
+done
+sudo chown -R runner:runner "$STATE_DIR"
+
 # ── Graceful shutdown ───────────────────────────────────────────
 cleanup() {
-  echo "Caught signal, deregistering runner..."
-  ./config.sh remove --unattended --token "${RUNNER_TOKEN}" || true
+  if [ "${RUNNER_DEREGISTER_ON_EXIT:-false}" = "true" ] && [ -n "${RUNNER_TOKEN:-}" ]; then
+    echo "Caught signal, deregistering runner (RUNNER_DEREGISTER_ON_EXIT=true)..."
+    ./config.sh remove --unattended --token "${RUNNER_TOKEN}" || true
+  else
+    echo "Caught signal, stopping runner (RUNNER_DEREGISTER_ON_EXIT=${RUNNER_DEREGISTER_ON_EXIT:-false})..."
+  fi
   exit 0
 }
 trap cleanup SIGTERM SIGINT

--- a/infrastructure/actions-runner/entrypoint.sh
+++ b/infrastructure/actions-runner/entrypoint.sh
@@ -110,7 +110,11 @@ else
 fi
 
 # ── Persist runner state to volume ──────────────────────────────
+# On a fresh Docker volume the mount point is root:root, so we must
+# fix ownership *before* the unprivileged cp — otherwise set -e
+# kills the container before chown is ever reached.
 sudo mkdir -p "$STATE_DIR"
+sudo chown -R runner:runner "$STATE_DIR"
 for f in .runner .credentials .credentials_rsaparams .path; do
   if [ -f "/actions-runner/$f" ]; then
     cp "/actions-runner/$f" "$STATE_DIR/$f"


### PR DESCRIPTION
## fix(infra): persist self-hosted runner credentials

Closes #2611  
Refs #2609

### Problem

Runner 1 und Runner 2 verlieren ihre GitHub Actions Registrierung bei Container-Recreate/Rebuild, wenn die State-Dateien (`.runner`, `.credentials`, `.credentials_rsaparams`, `.path`) nur im Container-Dateisystem liegen. Ein neuer Registration-Token wäre dann nötig.

Zusätzlich war die bisherige Stop-/Cleanup-Logik nicht fail-safe genug für persistente long-lived Runner.

### Änderungen

- `entrypoint.sh`
  - `RUNNER_TOKEN` ist nur noch Pflicht, wenn kein aktiver oder persistierter State vorhanden ist.
  - Restore-Logik stellt State-Dateien aus `/actions-runner/runner-state/` wieder her, bevor Token/Registration geprüft werden.
  - Persist-Logik kopiert State-Dateien nach erfolgreicher Registrierung ins State-Volume.
  - Deregistration-Gate ergänzt: `RUNNER_DEREGISTER_ON_EXIT=false` als Default.
  - `config.sh remove` läuft nur bei explizitem `RUNNER_DEREGISTER_ON_EXIT=true` und vorhandenem Token.

- `docker-compose.runner.yml`
  - `runner-state` Volume ergänzt.

- `docker-compose.runner2.yml`
  - `runner-state-2` Volume ergänzt.

- `.env.runner.example` / `.env.runner2.example`
  - `RUNNER_DEREGISTER_ON_EXIT=false` ergänzt.
  - Token-Hinweis ergänzt: Token nur bei fehlendem State erforderlich.

- `README.md`
  - State Persistence dokumentiert.
  - Deregistration dokumentiert.
  - Rebuild ohne Token dokumentiert.
  - Rollback dokumentiert.
  - Maintenance-Window-Hinweis ergänzt.
  - Volume-Tabelle für Runner 1/2 ergänzt.

### Akzeptanzkriterien

- [x] Runner-State-Dateien sind identifiziert.
- [x] Runner 1 und Runner 2 haben getrennte State-Volumes.
- [x] `RUNNER_TOKEN` ist nur bei fehlendem State erforderlich.
- [x] Restore läuft vor tokenpflichtiger Re-Registration.
- [x] Normale Container-Stops deregistrieren den Runner nicht.
- [x] Bewusste Deregistration ist nur über explizites Env-Gate möglich.
- [x] Keine Secrets/Tokens werden committed oder ausgegeben.
- [x] Validierung und Rollback sind dokumentiert.

### Keine Änderungen an

- `.github/workflows/ci.yml`
- `.github/workflows/policy-gate.yml`
- Branch Protection
- `.env.runner`
- `.env.runner2`
- Runner-Live-Betrieb

### Validierung

- `bash -n infrastructure/actions-runner/entrypoint.sh`
- `docker compose -f infrastructure/actions-runner/docker-compose.runner.yml config`
- `docker compose -f infrastructure/actions-runner/docker-compose.runner2.yml config`
- Keine `.github/workflows/` im Diff
- Keine Secrets/Tokens im Diff
- Nur sechs erlaubte Dateien geändert

### Wichtig

Diese PR bereitet Persistenz repo-seitig vor. Sie stoppt, restartet, recreatet oder deregistriert keinen produktiven Runner. Die operative Migration/Validierung der bestehenden Runner-State-Daten erfolgt separat mit explizitem Human-GO.