### PR TITLE
fix(ci): disable legacy ci workflow auto-runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,15 +2,14 @@
 # This file is not the canonical PR gate and not the 431B Docker CI lab baseline.
 # LEGACY-FREEZE (2026-04-07): tool-version drift is acceptable.
 # Not parity-tracked with ci.yml. No version alignment required.
+# NOISE-FREEZE (2026-05-21): auto-triggers removed; workflow_dispatch only.
+# Refs #2613 — 15 non-required jobs on ubuntu-latest generate persistent
+# billing-/account-locked noise. Canonical required checks are served by
+# ci.yml (self-hosted, merge-gate). This workflow must not auto-run.
 name: CI/CD Pipeline
 
 on:
-  push:
-    branches: [ main ]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-  workflow_dispatch:  # Manueller Trigger
+  workflow_dispatch:  # Manueller Trigger — NO auto-runs
 
 env:
   PYTHON_VERSION: '3.12'


### PR DESCRIPTION
## Summary

Disable automatic triggers for the legacy `.github/workflows/ci.yaml` pipeline.

Refs #2613

## Context

The legacy `CI/CD Pipeline` (`ci.yaml`) runs 15 non-required jobs on `ubuntu-latest` on every push to `main`. With GitHub-hosted runners currently unavailable due to billing/account-lock issues, those jobs fail instantly and produce persistent `unstable` check noise.

The canonical required checks are served by:

- `ci (Unit/Integration + Lint gesammelt)` from `.github/workflows/ci.yml`
- `policy-gate` from `.github/workflows/policy-gate.yml`

No required check depends on `.github/workflows/ci.yaml`.

## Change

- Remove `push:` auto-trigger from `.github/workflows/ci.yaml`
- Keep `workflow_dispatch:` as the sole trigger
- Add `NOISE-FREEZE` comment with `Refs #2613` and rationale
- No job changes
- No `runs-on` changes
- No other workflow changes

## Files Changed

- `.github/workflows/ci.yaml`

## Required Checks Unchanged

- `ci (Unit/Integration + Lint gesammelt)` — from `.github/workflows/ci.yml`, self-hosted Runner 2
- `policy-gate` — from `.github/workflows/policy-gate.yml`, self-hosted Runner 2

## Not Changed

- `.github/workflows/ci.yml`
- `.github/workflows/policy-gate.yml`
- Branch protection
- Any jobs
- Any `runs-on` values
- Any other workflows
- Runner configuration
- Billing/payment settings

## Validation

- Only `workflow_dispatch` trigger remains
- No `push` auto-run remains
- No `pull_request` auto-run was added
- Workflow name `CI/CD Pipeline` remains stable
- All 15 job definitions remain intact
- YAML structure validated

## Nicht-Ziele

- No other workflow migrations
- No branch protection changes
- No runner operations
- No billing/payment changes
- No secrets/tokens
