### PR TITLE
fix(ci): disable low-value noise workflow auto-runs

### DIFF
--- a/.github/workflows/docs-conflict-guard.yml
+++ b/.github/workflows/docs-conflict-guard.yml
@@ -1,10 +1,8 @@
 name: Docs Conflict Guard
 
+# NOISE-FREEZE (#2613): auto-triggers disabled due to billing/account-locked
+# non-required check noise. Manual workflow_dispatch remains available.
 on:
-  pull_request:
-    branches: [main, master]
-  push:
-    branches: [main, master]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs-hub-guard.yml
+++ b/.github/workflows/docs-hub-guard.yml
@@ -1,11 +1,9 @@
 name: Docs Hub Guard
 
+# NOISE-FREEZE (#2613): auto-triggers disabled due to billing/account-locked
+# non-required check noise. Manual workflow_dispatch remains available.
 on:
-  push:
-    branches: [ "main" ]
   workflow_dispatch:
-  schedule:
-    - cron: '45 5 * * 0'
 
 permissions:
   contents: read

--- a/.github/workflows/emoji-filter.yml
+++ b/.github/workflows/emoji-filter.yml
@@ -1,11 +1,8 @@
 name: 🚫 Advanced Emoji Filter
 
+# NOISE-FREEZE (#2613): auto-triggers disabled due to billing/account-locked
+# non-required check noise. Manual workflow_dispatch remains available.
 on:
-  push:
-    branches: [ main ]
-  schedule:
-    # Täglich um 2 Uhr (UTC) scannen
-    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       auto_fix:

--- a/.github/workflows/performance-monitor.yml
+++ b/.github/workflows/performance-monitor.yml
@@ -1,11 +1,9 @@
 name: Performance Monitor
 
+# NOISE-FREEZE (#2613): auto-triggers disabled due to billing/account-locked
+# non-required check noise. Manual workflow_dispatch remains available.
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
-  schedule:
-    - cron: '0 6 * * 0'  # Weekly performance check
 
 permissions:
   contents: read

--- a/.github/workflows/root-session-hygiene-warning.yml
+++ b/.github/workflows/root-session-hygiene-warning.yml
@@ -1,8 +1,8 @@
 name: Root Session Hygiene Warning
 
+# NOISE-FREEZE (#2613): auto-triggers disabled due to billing/account-locked
+# non-required check noise. Manual workflow_dispatch remains available.
 on:
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Disable automatic triggers for 5 low-value/informational workflows that fail on GitHub-hosted runners due to billing/account-lock, producing persistent non-required check noise.

Refs #2613

## Context

After PR #2614 (legacy `ci.yaml` NOISE-FREEZE), there are still failing non-required checks. This slice addresses 5 low-value/informational workflows that provide cosmetic, guard, and performance functions not required for merge readiness.

Required checks remain unchanged:

- `ci (Unit/Integration + Lint gesammelt)` from `.github/workflows/ci.yml`, self-hosted Runner 2
- `policy-gate` from `.github/workflows/policy-gate.yml`, self-hosted Runner 2

## Changes

For each of 5 workflows:

- Remove automatic `push`, `pull_request`, and `schedule` triggers
- Keep `workflow_dispatch` as sole trigger (manual runs remain available)
- Add `NOISE-FREEZE (#2613)` comment
- No job changes
- No `runs-on` changes
- No other workflow changes

| Workflow | Triggers removed | `workflow_dispatch` kept |
|---|---|---|
| `emoji-filter.yml` | `push: main`, `schedule: daily 02:00 UTC` | Yes, with inputs |
| `docs-hub-guard.yml` | `push: main`, `schedule: weekly 05:45 UTC` | Yes |
| `docs-conflict-guard.yml` | `pull_request: main/master`, `push: main/master` | Yes |
| `root-session-hygiene-warning.yml` | `pull_request: main` | Yes |
| `performance-monitor.yml` | `push: main`, `schedule: weekly 06:00 UTC` | Yes |

## Files Changed

- `.github/workflows/emoji-filter.yml`
- `.github/workflows/docs-hub-guard.yml`
- `.github/workflows/docs-conflict-guard.yml`
- `.github/workflows/root-session-hygiene-warning.yml`
- `.github/workflows/performance-monitor.yml`

## Not Changed

- `.github/workflows/ci.yml`
- `.github/workflows/ci.yaml`
- `.github/workflows/policy-gate.yml`
- No security workflows:
  - `codeql-python.yml`
  - `gitleaks.yml`
  - `security-scan.yml`
  - `trivy.yml`
- Branch protection
- Any jobs
- Any `runs-on` values
- Runner configuration
- Billing/payment settings

## Validation

- Every changed workflow has only `workflow_dispatch` as trigger
- No `push`, `pull_request`, or `schedule` trigger remains in any changed workflow
- Workflow names remain stable
- All job definitions remain intact
- YAML structure validated

## Nicht-Ziele

- No other workflow migrations
- No security workflow changes
- No branch protection changes
- No runner operations
- No billing/payment changes
- No secrets/tokens
