### PR TITLE
fix(ci): disable heavy security workflow auto-runs

### DIFF
--- a/.github/workflows/codeql-python.yml
+++ b/.github/workflows/codeql-python.yml
@@ -1,10 +1,8 @@
 name: CodeQL Python
 
 on:
-  push:
-    branches: ["main"]
-  pull_request:
-    branches: ["main"]
+  # NOISE-FREEZE (#2613): push and pull_request auto-triggers disabled due to billing/account-locked
+  # non-required security check noise. Scheduled and manual runs remain available.
   schedule:
     - cron: "21 3 * * 1"
   workflow_dispatch:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -3,17 +3,11 @@ name: Security Scan
 # Weekly scan + PR trigger for infrastructure changes
 # Issue #97: Trivy Container Scanning
 on:
+  # NOISE-FREEZE (#2613): push auto-trigger disabled due to billing/account-locked
+  # non-required security check noise. Scheduled and manual runs remain available.
   schedule:
     - cron: '0 2 * * 1'  # Monday 02:00 UTC
-  push:
-    branches:
-      - main
-      - 'release/*'
-    paths:
-      - 'services/**/Dockerfile'
-      - 'infrastructure/compose/**'
-      - '.github/workflows/security-scan.yml'
-  workflow_dispatch:  # Manual trigger
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## fix(ci): disable heavy security workflow auto-runs

Refs #2613.

Disables automatic `push` and `pull_request` triggers for two heavy, non-required security workflows that fail on billing/account-locked GitHub-hosted runners.

### Affected Workflows

| Workflow | Removed Triggers | Retained Triggers |
|---|---|---|
| `codeql-python.yml` | `push: main`, `pull_request: main` | `schedule` weekly Monday 03:21 UTC, `workflow_dispatch` |
| `security-scan.yml` | `push: main/release/*` with paths | `schedule` weekly Monday 02:00 UTC, `workflow_dispatch` |

Both workflows remain available via `workflow_dispatch` for manual triggering and via `schedule` for periodic scans.

### Not Changed

- `gitleaks.yml` — not in scope
- `trivy.yml` — not in scope
- `.github/workflows/ci.yml` — required check, untouched
- `.github/workflows/policy-gate.yml` — required check, untouched
- `.github/workflows/ci.yaml` — already NOISE-FREEZE from PR #2614
- No jobs changed
- No steps changed
- No permissions changed
- No `runs-on` values changed
- No branch protection rules changed
- No runner configuration changed

### Context

All affected non-required security checks fail with the same billing/account-lock pattern on GitHub-hosted runners:

- `runner_name=""`
- `runner_id=0`
- `steps_count=0`

Required checks `ci` and `policy-gate` run on self-hosted Runner 2 and are unaffected.

This is the third NOISE-FREEZE slice for #2613, following:

- PR #2614 — legacy `ci.yaml`
- PR #2615 — low-value workflow auto-runs

### Validation

- Only `codeql-python.yml` and `security-scan.yml` changed
- `schedule` retained in both workflows
- `workflow_dispatch` retained in both workflows
- Automatic `push` / `pull_request` triggers removed only from target workflows
- No required-check workflow changed
- No security jobs, steps, permissions, or runner labels changed
- No secrets/tokens changed

### Nicht-Ziele

- No migration to Runner 2
- No branch protection changes
- No billing/payment changes
- No runner operations
- No changes to Gitleaks or Trivy
- No changes to required checks