### PR TITLE
fix(ci): disable remaining push-triggered noise workflow auto-runs

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,12 +1,8 @@
 name: Contract Validation
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'docs/contracts/**'
-      - 'tests/unit/contracts/**'
-      - '.github/workflows/contracts.yml'
+  # NOISE-FREEZE (#2613): push auto-trigger disabled due to billing/account-locked
+  # non-required check noise. Scheduled and manual runs remain available.
   workflow_dispatch:
   schedule:
     - cron: '45 4 * * *'

--- a/.github/workflows/core-guard.yml
+++ b/.github/workflows/core-guard.yml
@@ -1,8 +1,8 @@
 name: Core Guard
 
 on:
-  push:
-    branches: [main]
+  # NOISE-FREEZE (#2613): push auto-trigger disabled due to billing/account-locked
+  # non-required check noise. Scheduled and manual runs remain available.
   workflow_dispatch:
   schedule:
     - cron: '15 5 * * 0'

--- a/.github/workflows/e2e-happy-path.yaml
+++ b/.github/workflows/e2e-happy-path.yaml
@@ -4,9 +4,8 @@ name: E2E Happy Path
 # runs post-merge on main, on schedule, or manually via workflow_dispatch.
 
 on:
-  push:
-    branches: [ main ]
-    # No paths-ignore - always run
+  # NOISE-FREEZE (#2613): push auto-trigger disabled due to billing/account-locked
+  # non-required check noise. Scheduled and manual runs remain available.
   workflow_dispatch:
   schedule:
     - cron: '30 5 * * 0'

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -9,8 +9,8 @@
 name: Gitleaks Secret Scan
 
 on:
-  push:
-    branches: [main]
+  # NOISE-FREEZE (#2613): push auto-trigger disabled due to billing/account-locked
+  # non-required check noise. Scheduled and manual runs remain available.
   schedule:
     - cron: '0 3 * * 0'  # Weekly Sunday 03:00 UTC
   workflow_dispatch:

--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -4,8 +4,8 @@ on:
   schedule:
     - cron: '0 0 * * 0'
   workflow_dispatch:
-  push:
-    branches: [main]
+  # NOISE-FREEZE (#2613): push auto-trigger disabled due to billing/account-locked
+  # non-required check noise. Scheduled and manual runs remain available.
 
 permissions:
   contents: read

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,12 +1,8 @@
 name: trivy
 
 on:
-  push:
-    branches: ["main", "release/*"]
-    paths:
-      - "Dockerfile"
-      - "infrastructure/**"
-      - "services/**"
+  # NOISE-FREEZE (#2613): push auto-trigger disabled due to billing/account-locked
+  # non-required check noise. Scheduled and manual runs remain available.
   schedule:
     - cron: '0 6 * * 0'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Remove push auto-triggers from 6 remaining non-required workflows that fail on GitHub-hosted runners due to billing/account-lock, producing persistent check noise on every push to main.

Refs #2613

## Context

Follow-up to NOISE-FREEZE slices #2614, #2615, #2616. Those PRs removed push/PR/schedule triggers from 8 workflows. This slice addresses the remaining 6 push-triggered non-required workflows.

All 6 share the same root cause: GitHub-hosted runners are unavailable due to billing/account-lock, causing immediate failures with runner_name empty, runner_id=0, steps=[].

Required checks remain unchanged:
- ci (Unit/Integration + Lint gesammelt) from ci.yml, self-hosted Runner 2
- policy-gate from policy-gate.yml, self-hosted Runner 2

## Changes

For each of 6 workflows:
- Remove push: auto-trigger block
- Add NOISE-FREEZE (#2613) comment with rationale
- Keep schedule and workflow_dispatch as available triggers

| Workflow | Removed Trigger | Retained Triggers |
|---|---|---|
| gitleaks.yml | push: branches: [main] | schedule (weekly Sun 03:00), workflow_dispatch |
| core-guard.yml | push: branches: [main] | workflow_dispatch, schedule (weekly Sun 05:15) |
| e2e-happy-path.yaml | push: branches: [main] | workflow_dispatch, schedule (weekly Sun 05:30) |
| python-compat.yml | push: branches: [main] | schedule (weekly Sun 00:00), workflow_dispatch |
| contracts.yml | push: branches: [main] + paths filter | workflow_dispatch, schedule (daily 04:45) |
| trivy.yml | push: branches + paths filter | schedule (weekly Sun 06:00), workflow_dispatch |

## Files Changed

- .github/workflows/gitleaks.yml
- .github/workflows/core-guard.yml
- .github/workflows/e2e-happy-path.yaml
- .github/workflows/python-compat.yml
- .github/workflows/contracts.yml
- .github/workflows/trivy.yml

## Not Changed

- No jobs, steps, permissions, runs-on, or continue-on-error
- No schedule triggers removed
- No branch protection changes
- No required check changes
- No runner migrations
- No billing/payment changes
- No secrets/tokens

## Validation

- Every changed workflow has only schedule + workflow_dispatch as triggers
- No push or pull_request trigger remains in any changed workflow
- YAML structure validated for all 6 files
- Git diff shows exactly 6 workflow files, 12 insertions, 21 deletions
- Required checks unchanged: ci + policy-gate on self-hosted Runner 2

## Nicht-Ziele

- No other workflow migrations
- No branch protection changes
- No runner operations
- No billing/payment changes
- No secrets/tokens
- No Live-/Echtgeld-/Readiness-Ableitung (LR remains NO-GO)