### PR TITLE
feat(mcp): add readonly context.show_snapshot tool

### DIFF
--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -750,7 +750,7 @@ Even when `status: ready_for_human_go`, the agent MUST stop and wait for explici
 | Symptom | Error Code | Cause | Action |
 |---------|------------|-------|--------|
 | `"unknown_tool"` | `unknown_tool` | Tool name not in registry | Check spelling. Use `bridge.list_tool_names()`. |
-| `"not_implemented"` | `not_implemented` | Tool is a stub (show_snapshot, show_audit) | These tools are not yet implemented. Use the CLI or wait for future Wave. |
+| `"not_implemented"` | `not_implemented` | Tool is a stub (show_audit) | `context.show_audit` is not yet implemented. Use other tools or wait for a future Wave. `context.show_snapshot` is implemented and can be used to inspect registry truth without triggering Verify. |
 | `"invalid_query"` | `invalid_query` | Missing, empty, or non-string query | Provide a non-empty string in the `query` field. |
 | `"invalid_artifacts"` | `invalid_artifacts` | Missing or non-list artifacts | Provide a non-empty list of artifact ID strings. |
 | `"invalid_parameters"` | `invalid_parameters` | Parameters not a dict | Pass parameters as `dict`, not list/string/int. |

--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -267,7 +267,7 @@ class TestContextBridge:
     def test_execute_not_implemented_tool(self) -> None:
         """Verify executing stub tool returns not_implemented error."""
         bridge = ContextBridge()
-        result = bridge.execute_tool("context.show_snapshot", {"snapshot_id": "test"})
+        result = bridge.execute_tool("context.show_audit", {"entity_id": "test"})
         assert result["status"] == "error"
         assert result["error"]["code"] == "not_implemented"
 

--- a/tests/unit/tools/mcp/test_output_contracts.py
+++ b/tests/unit/tools/mcp/test_output_contracts.py
@@ -60,17 +60,13 @@ class TestTraceOutputContract:
 
     def test_ok_output_has_tool_and_status(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.trace", {"target_id": "evt_001"}
-        )
+        result = bridge.execute_tool("context.trace", {"target_id": "evt_001"})
         assert result["tool"] == "context.trace"
         assert result["status"] == "ok"
 
     def test_trace_has_root_with_id_type_title(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.trace", {"target_id": "evt_001"}
-        )
+        result = bridge.execute_tool("context.trace", {"target_id": "evt_001"})
         root = result["trace"]["root"]
         assert "id" in root
         assert "type" in root
@@ -147,9 +143,7 @@ class TestPackageOutputContract:
 
     def test_ok_output_has_package_with_format_items_created_at(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.package", {"artifacts": ["art_001"]}
-        )
+        result = bridge.execute_tool("context.package", {"artifacts": ["art_001"]})
         pkg = result["package"]
         assert "format" in pkg
         assert "items" in pkg
@@ -158,9 +152,7 @@ class TestPackageOutputContract:
 
     def test_package_id_is_string(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.package", {"artifacts": ["art_001"]}
-        )
+        result = bridge.execute_tool("context.package", {"artifacts": ["art_001"]})
         assert isinstance(result["package"]["package_id"], str)
 
     def test_error_output_has_invalid_artifacts_code(self) -> None:
@@ -252,7 +244,11 @@ class TestReadinessOutputContract:
             },
         )
         guardrails_text = " ".join(result["readiness"]["guardrails"])
-        assert "NO-GO" in guardrails_text or "No-Go" in guardrails_text or "no_go" in guardrails_text.lower()
+        assert (
+            "NO-GO" in guardrails_text
+            or "No-Go" in guardrails_text
+            or "no_go" in guardrails_text.lower()
+        )
 
 
 class TestBriefingOutputContract:

--- a/tests/unit/tools/mcp/test_output_contracts.py
+++ b/tests/unit/tools/mcp/test_output_contracts.py
@@ -338,3 +338,32 @@ class TestCdbContextBriefingAliasOutputContract:
         assert "guardrails" in result["briefing"]
         assert isinstance(result["briefing"]["guardrails"], list)
         assert len(result["briefing"]["guardrails"]) > 0
+
+
+class TestShowSnapshotOutputContract:
+    """Verify context.show_snapshot output matches contract structure."""
+
+    def test_ok_output_has_tool_and_status(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.show_snapshot", {"snapshot_id": "snap_contract_001"}
+        )
+        assert result["tool"] == "context.show_snapshot"
+        assert result["status"] == "ok"
+
+    def test_snapshot_has_required_fields(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.show_snapshot", {"snapshot_id": "snap_contract_001"}
+        )
+        snap = result["snapshot"]
+        assert snap["snapshot_id"] == "snap_contract_001"
+        assert isinstance(snap["tools_count"], int)
+        assert isinstance(snap["tool_names"], list)
+        assert "context.show_snapshot" in snap["tool_names"]
+
+    def test_invalid_snapshot_id_fails_closed(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.show_snapshot", {})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_snapshot_id"

--- a/tests/unit/tools/mcp/test_permission_guard.py
+++ b/tests/unit/tools/mcp/test_permission_guard.py
@@ -116,18 +116,14 @@ class TestExecuteGate:
     def test_execute_not_implemented_tool_returns_error(self) -> None:
         """Stub tool returns not_implemented error."""
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.show_snapshot", {"snapshot_id": "test"}
-        )
+        result = bridge.execute_tool("context.show_audit", {"entity_id": "test"})
         assert result["status"] == "error"
         assert result["error"]["code"] == "not_implemented"
 
     def test_execute_search_with_forbidden_keyword_blocked(self) -> None:
         """context.search with INSERT in query is blocked by input gate."""
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.search", {"query": "INSERT INTO table_x"}
-        )
+        result = bridge.execute_tool("context.search", {"query": "INSERT INTO table_x"})
         assert result["status"] == "error"
         assert result["error"]["code"] in (
             "forbidden_keyword",
@@ -168,9 +164,7 @@ class TestExecuteGate:
     def test_execute_search_with_deploy_keyword_blocked(self) -> None:
         """context.search with 'deploy' in query is blocked (query tool)."""
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.search", {"query": "deploy the service"}
-        )
+        result = bridge.execute_tool("context.search", {"query": "deploy the service"})
         assert result["status"] == "error"
         assert result["error"]["code"] == "forbidden_runtime_operation"
 
@@ -320,7 +314,10 @@ class TestInputGateWave14Exemption:
                 "evidence_records": [
                     {"evidence_id": "ev-1", "title": "Create migration evidence"},
                     {"evidence_id": "ev-2", "title": "Update runbook decision"},
-                    {"evidence_id": "ev-3", "title": "Delete branch warning in historical note"},
+                    {
+                        "evidence_id": "ev-3",
+                        "title": "Delete branch warning in historical note",
+                    },
                 ]
             },
         )
@@ -382,7 +379,12 @@ class TestInputGateForbiddenKeywords:
         """Keywords in nested dict parameters are detected in query tools."""
         results = PermissionGuard.check_tool_inputs(
             "context.search",
-            {"filters": {"source_types": ["decision"], "date_from": "DELETE FROM logs"}},
+            {
+                "filters": {
+                    "source_types": ["decision"],
+                    "date_from": "DELETE FROM logs",
+                }
+            },
         )
         assert len(results) >= 1
         assert results[0].code == "forbidden_keyword"
@@ -547,9 +549,7 @@ class TestToolDefinitionCheck:
     """check_tool_definition rejects non-read-only tools."""
 
     def test_read_only_tool_passes(self) -> None:
-        result = PermissionGuard.check_tool_definition(
-            "context.search", read_only=True
-        )
+        result = PermissionGuard.check_tool_definition("context.search", read_only=True)
         assert result is None
 
     def test_non_read_only_tool_blocked(self) -> None:
@@ -571,9 +571,7 @@ class TestRegistryConsistencyCheck:
     """check_registry_consistency detects non-read-only tools in the registry."""
 
     def test_all_read_only_registry_passes(self) -> None:
-        result = PermissionGuard.check_registry_consistency(
-            ContextToolRegistry._tools
-        )
+        result = PermissionGuard.check_registry_consistency(ContextToolRegistry._tools)
         assert result is None
 
     def test_registry_with_write_tool_fails(self) -> None:
@@ -646,9 +644,7 @@ class TestAllCurrentToolsPassInputGate:
         )
         assert result["status"] == "ok"
 
-    def test_context_explain_source_normal_passes(
-        self, bridge: ContextBridge
-    ) -> None:
+    def test_context_explain_source_normal_passes(self, bridge: ContextBridge) -> None:
         result = bridge.execute_tool(
             "context.explain_source", {"source_ref": "src_001"}
         )
@@ -679,9 +675,7 @@ class TestAllCurrentToolsPassInputGate:
         )
         assert result["status"] == "ok"
 
-    def test_context_self_explain_normal_passes(
-        self, bridge: ContextBridge
-    ) -> None:
+    def test_context_self_explain_normal_passes(self, bridge: ContextBridge) -> None:
         result = bridge.execute_tool(
             "context.self_explain",
             {
@@ -740,9 +734,7 @@ class TestErrorCodesAreAgentReadable:
         assert result["status"] == "error"
         error = result["error"]
         assert error["code"] == "forbidden_runtime_operation"
-        assert "git_commit" in error["message"] or "git_commit" in str(
-            error["details"]
-        )
+        assert "git_commit" in error["message"] or "git_commit" in str(error["details"])
 
     def test_non_read_only_error_structure(self) -> None:
         result = PermissionGuard.check_tool_definition(
@@ -751,7 +743,10 @@ class TestErrorCodesAreAgentReadable:
         assert result is not None
         assert result.code == "non_read_only_tool"
         assert "context.bad_tool" in result.message
-        assert "read-only" in result.message.lower() or "not read-only" in result.message.lower()
+        assert (
+            "read-only" in result.message.lower()
+            or "not read-only" in result.message.lower()
+        )
 
     def test_registry_inconsistency_error_structure(self) -> None:
         result = PermissionGuard.check_registry_consistency(
@@ -852,9 +847,7 @@ class TestAllowedReadOnlyInputsPass:
     )
     def test_read_only_queries_pass(self, query: str) -> None:
         """Common read-only queries produce no violations in search tool."""
-        results = PermissionGuard.check_tool_inputs(
-            "context.search", {"query": query}
-        )
+        results = PermissionGuard.check_tool_inputs("context.search", {"query": query})
         violations = [
             r
             for r in results
@@ -876,15 +869,10 @@ class TestAllowedReadOnlyInputsPass:
         results = PermissionGuard.check_tool_inputs(
             "context.search", {"query": "SELECT * FROM decisions WHERE id=1"}
         )
-        keyword_violations = [
-            r for r in results if r.code == "forbidden_keyword"
-        ]
-        pattern_violations = [
-            r for r in results if r.code == "forbidden_query_pattern"
-        ]
+        keyword_violations = [r for r in results if r.code == "forbidden_keyword"]
+        pattern_violations = [r for r in results if r.code == "forbidden_query_pattern"]
         assert len(keyword_violations) == 0, (
-            f"SELECT should not trigger forbidden_keyword: "
-            f"{keyword_violations}"
+            f"SELECT should not trigger forbidden_keyword: " f"{keyword_violations}"
         )
         assert len(pattern_violations) == 0, (
             f"SELECT should not trigger forbidden_query_pattern: "
@@ -897,9 +885,7 @@ class TestAllowedReadOnlyInputsPass:
             "context.readiness",
             {"operation_mode": "read_only"},
         )
-        violations = [
-            r for r in results if r.code == "forbidden_runtime_operation"
-        ]
+        violations = [r for r in results if r.code == "forbidden_runtime_operation"]
         assert len(violations) == 0
 
     def test_dry_run_operation_mode_not_flagged(self) -> None:
@@ -945,9 +931,7 @@ class TestBridgeIntegrationInputGate:
 
     def test_bridge_blocks_insert_query(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.search", {"query": "INSERT INTO context"}
-        )
+        result = bridge.execute_tool("context.search", {"query": "INSERT INTO context"})
         assert result["status"] == "error"
         assert result["error"]["code"] in (
             "forbidden_keyword",
@@ -956,9 +940,7 @@ class TestBridgeIntegrationInputGate:
 
     def test_bridge_blocks_delete_query(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.search", {"query": "DELETE FROM context"}
-        )
+        result = bridge.execute_tool("context.search", {"query": "DELETE FROM context"})
         assert result["status"] == "error"
         assert result["error"]["code"] in (
             "forbidden_keyword",
@@ -984,9 +966,7 @@ class TestBridgeIntegrationInputGate:
     def test_bridge_blocks_deploy_in_search(self) -> None:
         """Deploy in search query is blocked (query tool)."""
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.search", {"query": "deploy the service"}
-        )
+        result = bridge.execute_tool("context.search", {"query": "deploy the service"})
         assert result["status"] == "error"
         assert result["error"]["code"] == "forbidden_runtime_operation"
 
@@ -1013,16 +993,12 @@ class TestBridgeIntegrationInputGate:
 
     def test_bridge_allows_normal_trace(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.trace", {"target_id": "evt_abc123"}
-        )
+        result = bridge.execute_tool("context.trace", {"target_id": "evt_abc123"})
         assert result["status"] == "ok"
 
     def test_bridge_allows_normal_search(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.search", {"query": "risk decisions"}
-        )
+        result = bridge.execute_tool("context.search", {"query": "risk decisions"})
         assert result["status"] == "ok"
 
     def test_bridge_error_includes_all_violations(self) -> None:
@@ -1057,6 +1033,7 @@ class TestNoneParametersRegression:
         assert result["status"] == "error"
         assert result["error"]["code"] in (
             "not_implemented",
+            "invalid_snapshot_id",
             "invalid_query",
             "target_not_found",
             "invalid_source_ref",

--- a/tests/unit/tools/mcp/test_show_handlers.py
+++ b/tests/unit/tools/mcp/test_show_handlers.py
@@ -15,14 +15,18 @@ class TestShowSnapshotHandler:
 
     def test_show_snapshot_returns_ok(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool("context.show_snapshot", {"snapshot_id": "snap_001"})
+        result = bridge.execute_tool(
+            "context.show_snapshot", {"snapshot_id": "snap_001"}
+        )
         assert result["status"] == "ok"
         assert result["tool"] == "context.show_snapshot"
         assert result["snapshot"]["snapshot_id"] == "snap_001"
 
     def test_show_snapshot_includes_tool_names(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool("context.show_snapshot", {"snapshot_id": "snap_001"})
+        result = bridge.execute_tool(
+            "context.show_snapshot", {"snapshot_id": "snap_001"}
+        )
         assert result["status"] == "ok"
         assert isinstance(result["snapshot"]["tool_names"], list)
         assert "context.show_snapshot" in result["snapshot"]["tool_names"]

--- a/tests/unit/tools/mcp/test_show_handlers.py
+++ b/tests/unit/tools/mcp/test_show_handlers.py
@@ -1,9 +1,9 @@
 """
-Unit tests for context.show_snapshot and context.show_audit not_implemented handlers.
+Unit tests for context.show_snapshot and context.show_audit handlers.
 
-Tests that stub handlers return correct not_implemented errors
-and have correct schema definitions in the registry.
-#2100
+- context.show_snapshot: implemented, read-only, deterministic registry snapshot.
+- context.show_audit: still stubbed (not_implemented).
+#2100 / #2605 slice-1
 """
 
 from tools.mcp.context_bridge import create_bridge
@@ -11,18 +11,21 @@ from tools.mcp.registry import ContextToolRegistry
 
 
 class TestShowSnapshotHandler:
-    """Tests for context.show_snapshot not-implemented handler."""
+    """Tests for context.show_snapshot handler."""
 
-    def test_show_snapshot_returns_not_implemented(self) -> None:
+    def test_show_snapshot_returns_ok(self) -> None:
         bridge = create_bridge()
         result = bridge.execute_tool("context.show_snapshot", {"snapshot_id": "snap_001"})
-        assert result["status"] == "error"
-        assert result["error"]["code"] == "not_implemented"
+        assert result["status"] == "ok"
+        assert result["tool"] == "context.show_snapshot"
+        assert result["snapshot"]["snapshot_id"] == "snap_001"
 
-    def test_show_snapshot_error_mentions_tool_name(self) -> None:
+    def test_show_snapshot_includes_tool_names(self) -> None:
         bridge = create_bridge()
         result = bridge.execute_tool("context.show_snapshot", {"snapshot_id": "snap_001"})
-        assert "context.show_snapshot" in result["error"]["message"]
+        assert result["status"] == "ok"
+        assert isinstance(result["snapshot"]["tool_names"], list)
+        assert "context.show_snapshot" in result["snapshot"]["tool_names"]
 
     def test_show_snapshot_in_registry(self) -> None:
         tool = ContextToolRegistry.get_tool("context.show_snapshot")
@@ -35,6 +38,12 @@ class TestShowSnapshotHandler:
         assert "snapshot_id" in tool.input_schema.get("required", [])
         assert "tool" in tool.output_schema.get("properties", {})
         assert "status" in tool.output_schema.get("properties", {})
+
+    def test_show_snapshot_invalid_snapshot_id_fails_closed(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.show_snapshot", {})
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_snapshot_id"
 
 
 class TestShowAuditHandler:
@@ -65,16 +74,16 @@ class TestShowAuditHandler:
 
 
 class TestNotImplementedErrorStructure:
-    """Tests for not_implemented error response structure."""
+    """Tests for not_implemented error response structure (show_audit)."""
 
     def test_not_implemented_error_has_tool_field(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool("context.show_snapshot", {})
-        assert result["tool"] == "context.show_snapshot"
+        result = bridge.execute_tool("context.show_audit", {"entity_id": "ent_001"})
+        assert result["tool"] == "context.show_audit"
 
     def test_not_implemented_error_has_status_error(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool("context.show_snapshot", {})
+        result = bridge.execute_tool("context.show_audit", {"entity_id": "ent_001"})
         assert result["status"] == "error"
 
     def test_not_implemented_error_has_code_and_message(self) -> None:
@@ -88,8 +97,8 @@ class TestNotImplementedErrorStructure:
     def test_not_implemented_handler_ignores_all_params(self) -> None:
         bridge = create_bridge()
         result = bridge.execute_tool(
-            "context.show_snapshot",
-            {"snapshot_id": "any", "include_details": True, "extra": "ignored"},
+            "context.show_audit",
+            {"entity_id": "any", "audit_type": "all", "limit": 1, "extra": "ignored"},
         )
         assert result["status"] == "error"
         assert result["error"]["code"] == "not_implemented"

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -218,6 +218,65 @@ def context_explain_source_handler(**kwargs) -> dict[str, Any]:
     }
 
 
+def context_show_snapshot_handler(**kwargs) -> dict[str, Any]:
+    """
+    Read-only handler for context.show_snapshot tool.
+
+    Returns a deterministic in-memory snapshot of registry truth:
+    which Context MCP tools are currently registered and marked read-only.
+
+    No DB writes. No network. No GitHub. Fail-closed.
+    """
+    snapshot_id = kwargs.get("snapshot_id")
+    include_details = kwargs.get("include_details", True)
+
+    if not snapshot_id or not isinstance(snapshot_id, str) or not snapshot_id.strip():
+        return {
+            "tool": "context.show_snapshot",
+            "status": "error",
+            "error": {
+                "code": "invalid_snapshot_id",
+                "message": "snapshot_id is required and must be a non-empty string",
+            },
+        }
+
+    if not isinstance(include_details, bool):
+        include_details = True
+
+    tool_names = sorted(ContextToolRegistry.list_tool_names())
+    snapshot: dict[str, Any] = {
+        "snapshot_id": snapshot_id.strip(),
+        "tools_count": len(tool_names),
+        "tool_names": tool_names,
+        "read_only_enforced": True,
+        "guardrails": [
+            "Read-only snapshot of registry truth. No DB/network/GitHub access.",
+            "Snapshot is not authorization. LR remains NO-GO.",
+        ],
+    }
+
+    if include_details:
+        details: list[dict[str, Any]] = []
+        for name in tool_names:
+            tool = ContextToolRegistry.get_tool(name)
+            if tool is None:
+                continue
+            details.append(
+                {
+                    "name": tool.name,
+                    "read_only": tool.read_only,
+                    "description": tool.description,
+                }
+            )
+        snapshot["tools"] = details
+
+    return {
+        "tool": "context.show_snapshot",
+        "status": "ok",
+        "snapshot": snapshot,
+    }
+
+
 def context_package_handler(**kwargs) -> dict[str, Any]:
     """
     Read-only handler for context.package tool.
@@ -2291,6 +2350,17 @@ class ContextBridge:
                 handler=context_explain_source_handler,
             )
             self._registry._tools["context.explain_source"] = new_explain
+        old_show_snapshot = self._registry.get_tool("context.show_snapshot")
+        if old_show_snapshot:
+            new_show_snapshot = ToolDefinition(
+                name=old_show_snapshot.name,
+                description=old_show_snapshot.description,
+                input_schema=old_show_snapshot.input_schema,
+                output_schema=old_show_snapshot.output_schema,
+                read_only=old_show_snapshot.read_only,
+                handler=context_show_snapshot_handler,
+            )
+            self._registry._tools["context.show_snapshot"] = new_show_snapshot
         old_package = self._registry.get_tool("context.package")
         if old_package:
             new_package = ToolDefinition(


### PR DESCRIPTION
## Summary

Implements #2605 Slice-1 as the smallest complete read-only MCP contract/composition tool.

Adds context.show_snapshot as a deterministic read-only registry snapshot tool.

## Why this slice first

- Existing tool was present but 
ot_implemented
- Smallest safe #2605 slice
- Read-only
- Deterministic
- No DB writes
- No persistent memory
- Compatible with OpenCode MCP activation

## Changes

- Adds handler/wiring for context.show_snapshot
- Adds/updates unit tests
- Adds output contract coverage
- Updates MCP runbook documentation

## Validation

- pytest tests/unit/tools/mcp/test_context_bridge.py -v — pass
- pytest tests/unit/tools/mcp/test_mcp_briefing_tool.py tests/unit/tools/mcp/test_output_contracts.py -v — pass
- pytest tests/unit/tools/mcp/test_show_handlers.py -v — pass
- uff check tools/mcp/context_bridge.py tools/mcp/registry.py tests/unit/tools/mcp/test_context_bridge.py — pass
- lack --check tools/mcp/context_bridge.py tools/mcp/registry.py tests/unit/tools/mcp/test_context_bridge.py — pass
- Tool count remains 26
- context.show_snapshot status is now ok

## Safety

- Read-only
- No DB writes
- No MCP live mutation
- No persistent memory
- LR remains NO-GO

## Issue

First focused implementation slice for #2605. #2605 remains open.