### PR TITLE
feat(mcp): harden context.explain_source repo-only resolver

### DIFF
--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -252,7 +252,7 @@ print(result["status"])  # "ok" or "error"
 |------|--------|-------------|
 | `context.search` | Full | Search the context knowledge base (keyword + structured queries). Returns results with confidence scores and warnings. |
 | `context.trace` | Full | Trace decision or event lineage through the context graph. Returns root node and lineage chain. |
-| `context.explain_source` | Full | Explain provenance of a context source or evidence item. Returns source type, provenance chain, confidence, and stale/tombstone flags. |
+| `context.explain_source` | Full | Resolve provenance for a registered tool or existing repo-relative file path. Repo-/registry-only, deterministic, no DB/network, rejects absolute and traversal paths. |
 | `context.package` | Full | Package context artifacts for handoff between agents or sessions. Capped at 10 items. Includes stop conditions. |
 | `context.readiness` | Full | Assess agent action readiness for a given task scope. Returns one of 6 readiness status values. Requires task_scope and operation_mode. |
 | `context.self_explain` | Full | Generate structured self-explanation for governance-relevant conditions. 9 explanation types supported. |
@@ -262,7 +262,7 @@ print(result["status"])  # "ok" or "error"
 | `context.show_snapshot` | Full | Deterministic registry snapshot (tool inventory + read-only flags). No DB/network/GitHub. |
 | `context.show_audit` | Full | Deterministic registry audit snapshot for a target tool (schema keys + handler wiring status). No DB/network/GitHub. |
 
-All 11 tools are registered as `read_only: true`. Both `context.show_*` tools are implemented as registry-only snapshots (no DB-backed trail).
+All 11 tools are registered as `read_only: true`. `context.show_snapshot`, `context.show_audit`, and `context.explain_source` are deterministic repo-/registry-only views (no DB-backed trail).
 
 ---
 
@@ -294,7 +294,7 @@ Input scanning uses word-boundary regex and recursive parameter walking (dicts a
 
 ## 7. Tool Usage Examples
 
-All examples use mocked/in-memory responses. For real SurrealDB data, a future Wave will provide a real adapter.
+`context.search`, `context.trace`, and `context.package` examples below still use mocked/in-memory responses. `context.explain_source`, `context.show_snapshot`, and `context.show_audit` are already deterministic repo-/registry-only handlers. For real SurrealDB data, a future Wave will provide a real adapter where applicable.
 
 ### 7.1 context.search
 
@@ -358,10 +358,16 @@ Maximum depth is 20. `depth_exceeded` error returned above 20.
 
 ```python
 result = bridge.execute_tool("context.explain_source", {
-    "source_ref": "src_001",
+    "source_ref": "context.readiness",
     "include_chain": True
 })
 ```
+
+Supported refs: exact tool name, `tool:<tool-name>`, repo-relative file path, or
+`path:<repo-relative-path>`. Prefixes are strict: `tool:` only checks the registry,
+`path:` only checks repo files. Unknown refs fail closed with `source_not_found`.
+Absolute paths, Windows drive paths, UNC paths, and `..` traversal fail closed with
+`invalid_source_ref`. File outputs always use repo-relative paths only.
 
 Response:
 ```json
@@ -369,30 +375,45 @@ Response:
     "tool": "context.explain_source",
     "status": "ok",
     "explanation": {
-        "source_ref": "src_001",
-        "source_type": "evidence",
+        "source_ref": "context.readiness",
+        "source_type": "tool",
         "provenance": {
-            "source_path": "/mock/path/src_001",
-            "hash": "mock_hash_123",
-            "commit": "mock_commit_456",
-            "run_id": "mock_run_789",
-            "import_audit_ref": "mock_audit_012",
-            "evidence_refs": ["mock_ev_1", "mock_ev_2"],
+            "tool_name": "context.readiness",
+            "read_only": true,
+            "handler_status": "implemented",
+            "input_schema_keys": [
+                "operation_mode",
+                "required_reads",
+                "stop_conditions",
+                "task_scope"
+            ],
+            "output_schema_keys": [
+                "human_go_required",
+                "reasons",
+                "required_next_reads",
+                "status",
+                "warnings"
+            ],
+            "resolver": "registry",
             "chain": [
-                {"level": 1, "ref": "mock_parent_1", "type": "derived"},
-                {"level": 2, "ref": "mock_parent_2", "type": "source"}
+                {"step": "input_normalized", "source_ref": "context.readiness"},
+                {"step": "registry_checked", "tool_name": "context.readiness", "matched": true},
+                {"step": "resolved", "source_type": "tool", "resolver": "registry"}
             ]
         },
         "source_refs": [
-            {"ref": "mock_audit_012", "type": "import_audit"},
-            {"ref": "mock_ev_1", "type": "evidence"}
+            {"ref": "resolver:registry", "type": "resolver"},
+            {"ref": "tool:context.readiness", "type": "tool"}
         ],
-        "confidence": 0.9,
+        "confidence": 1.0,
         "warnings": [],
         "stale": false,
         "tombstone": false
     },
-    "metadata": {"explained_at": "2026-05-03T12:00:00Z", "include_chain": true}
+    "metadata": {
+        "include_chain": true,
+        "resolution_mode": "repo_registry_only"
+    }
 }
 ```
 

--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -4,6 +4,7 @@ Unit tests for Context MCP Bridge Scaffold.
 Tests the scaffold structure without requiring live SurrealDB or network.
 """
 
+from pathlib import Path
 import pytest
 from tools.mcp.context_bridge import ContextBridge, create_bridge
 from tools.mcp.registry import ContextToolRegistry
@@ -164,21 +165,22 @@ class TestContextExplainSourceHandler:
         assert result["error"]["code"] == "invalid_source_ref"
 
     def test_valid_source_ref_returns_ok(self) -> None:
-        """Valid source_ref returns ok status with explanation (mocked)."""
+        """Registered tool name resolves to repo-/registry-only explanation."""
         bridge = create_bridge()
         result = bridge.execute_tool(
-            "context.explain_source", {"source_ref": "src_abc123"}
+            "context.explain_source", {"source_ref": "context.readiness"}
         )
         assert result["status"] == "ok"
         assert result["tool"] == "context.explain_source"
         assert "explanation" in result
-        assert result["explanation"]["source_ref"] == "src_abc123"
+        assert result["explanation"]["source_ref"] == "context.readiness"
+        assert result["explanation"]["source_type"] == "tool"
 
     def test_include_chain_default_true(self) -> None:
         """include_chain defaults to True."""
         bridge = create_bridge()
         result = bridge.execute_tool(
-            "context.explain_source", {"source_ref": "src_abc123"}
+            "context.explain_source", {"source_ref": "context.readiness"}
         )
         assert result["status"] == "ok"
         assert result["metadata"]["include_chain"] is True
@@ -189,7 +191,7 @@ class TestContextExplainSourceHandler:
         bridge = create_bridge()
         result = bridge.execute_tool(
             "context.explain_source",
-            {"source_ref": "src_abc123", "include_chain": False},
+            {"source_ref": "context.readiness", "include_chain": False},
         )
         assert result["status"] == "ok"
         assert result["metadata"]["include_chain"] is False
@@ -199,7 +201,7 @@ class TestContextExplainSourceHandler:
         """Explanation has all required fields per #2096."""
         bridge = create_bridge()
         result = bridge.execute_tool(
-            "context.explain_source", {"source_ref": "src_abc123"}
+            "context.explain_source", {"source_ref": "context.readiness"}
         )
         assert result["status"] == "ok"
         expl = result["explanation"]
@@ -211,6 +213,150 @@ class TestContextExplainSourceHandler:
         assert "warnings" in expl
         assert "stale" in expl
         assert "tombstone" in expl
+
+    def test_tool_prefix_resolves_registered_tool(self) -> None:
+        """tool:<name> resolves exactly like the bare registered tool name."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source", {"source_ref": "tool:context.readiness"}
+        )
+        assert result["status"] == "ok"
+        assert result["explanation"]["source_ref"] == "tool:context.readiness"
+        assert result["explanation"]["source_type"] == "tool"
+
+    def test_repo_relative_path_returns_ok(self) -> None:
+        """Repo-relative paths resolve as file sources."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source",
+            {"source_ref": "docs/runbooks/surrealdb_context_mcp_access.md"},
+        )
+        assert result["status"] == "ok"
+        assert result["explanation"]["source_type"] == "file"
+        assert (
+            result["explanation"]["provenance"]["repo_relative_path"]
+            == "docs/runbooks/surrealdb_context_mcp_access.md"
+        )
+        assert result["explanation"]["provenance"]["exists"] is True
+        assert result["explanation"]["provenance"]["resolver"] == "repo"
+
+    def test_path_prefix_resolves_repo_relative_file(self) -> None:
+        """path:<path> only resolves repo files."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source",
+            {"source_ref": "path:docs/runbooks/surrealdb_context_mcp_access.md"},
+        )
+        assert result["status"] == "ok"
+        assert result["explanation"]["source_type"] == "file"
+
+    def test_backslash_path_normalizes_to_forward_slashes(self) -> None:
+        """Backslash separators normalize deterministically."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source",
+            {"source_ref": r"path:docs\runbooks\surrealdb_context_mcp_access.md"},
+        )
+        assert result["status"] == "ok"
+        assert (
+            result["explanation"]["provenance"]["repo_relative_path"]
+            == "docs/runbooks/surrealdb_context_mcp_access.md"
+        )
+
+    def test_tool_prefix_does_not_fallback_to_path_resolution(self) -> None:
+        """tool: only checks the registry."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source",
+            {"source_ref": "tool:docs/runbooks/surrealdb_context_mcp_access.md"},
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "source_not_found"
+
+    def test_path_prefix_does_not_fallback_to_tool_resolution(self) -> None:
+        """path: only checks repo-relative files."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source", {"source_ref": "path:context.readiness"}
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "source_not_found"
+
+    def test_unknown_source_ref_returns_source_not_found(self) -> None:
+        """Unknown non-empty refs fail closed with source_not_found."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source", {"source_ref": "context.__does_not_exist__"}
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "source_not_found"
+
+    def test_absolute_path_is_rejected(self) -> None:
+        """Absolute paths are rejected instead of being resolved."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source",
+            {"source_ref": r"C:\tmp\surrealdb_context_mcp_access.md"},
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_source_ref"
+
+    def test_unc_path_is_rejected(self) -> None:
+        """UNC paths are rejected instead of being resolved."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source",
+            {"source_ref": r"\\server\share\surrealdb_context_mcp_access.md"},
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_source_ref"
+
+    def test_parent_traversal_is_rejected(self) -> None:
+        """Parent traversal is rejected instead of being resolved."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source",
+            {"source_ref": "../docs/runbooks/surrealdb_context_mcp_access.md"},
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "invalid_source_ref"
+
+    def test_tool_provenance_uses_registry_truth(self) -> None:
+        """Tool provenance reports registry fields without dispatching the tool."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source", {"source_ref": "context.readiness"}
+        )
+        provenance = result["explanation"]["provenance"]
+        assert provenance["tool_name"] == "context.readiness"
+        assert provenance["read_only"] is True
+        assert provenance["handler_status"] == "implemented"
+        assert isinstance(provenance["input_schema_keys"], list)
+        assert isinstance(provenance["output_schema_keys"], list)
+
+    def test_include_chain_true_only_contains_internal_resolver_steps(self) -> None:
+        """Resolver chain stays internal and deterministic."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source", {"source_ref": "context.readiness"}
+        )
+        chain = result["explanation"]["provenance"]["chain"]
+        assert [step["step"] for step in chain] == [
+            "input_normalized",
+            "registry_checked",
+            "resolved",
+        ]
+
+    def test_file_output_uses_repo_relative_paths_only(self) -> None:
+        """File output never leaks absolute local paths."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source",
+            {"source_ref": "docs/runbooks/surrealdb_context_mcp_access.md"},
+        )
+        rendered = str(result["explanation"])
+        assert str(Path.cwd()) not in rendered
+        assert Path.cwd().as_posix() not in rendered
 
 
 class TestContextBridge:

--- a/tests/unit/tools/mcp/test_output_contracts.py
+++ b/tests/unit/tools/mcp/test_output_contracts.py
@@ -95,7 +95,7 @@ class TestExplainSourceOutputContract:
     def test_ok_output_has_tool_and_status(self) -> None:
         bridge = create_bridge()
         result = bridge.execute_tool(
-            "context.explain_source", {"source_ref": "src_001"}
+            "context.explain_source", {"source_ref": "context.readiness"}
         )
         assert result["tool"] == "context.explain_source"
         assert result["status"] == "ok"
@@ -103,7 +103,7 @@ class TestExplainSourceOutputContract:
     def test_explanation_has_source_ref_type_provenance(self) -> None:
         bridge = create_bridge()
         result = bridge.execute_tool(
-            "context.explain_source", {"source_ref": "src_001"}
+            "context.explain_source", {"source_ref": "context.readiness"}
         )
         expl = result["explanation"]
         assert "source_ref" in expl
@@ -113,7 +113,7 @@ class TestExplainSourceOutputContract:
     def test_explanation_has_confidence_warnings_stale_tombstone(self) -> None:
         bridge = create_bridge()
         result = bridge.execute_tool(
-            "context.explain_source", {"source_ref": "src_001"}
+            "context.explain_source", {"source_ref": "context.readiness"}
         )
         expl = result["explanation"]
         assert "confidence" in expl
@@ -124,7 +124,7 @@ class TestExplainSourceOutputContract:
     def test_source_refs_is_list(self) -> None:
         bridge = create_bridge()
         result = bridge.execute_tool(
-            "context.explain_source", {"source_ref": "src_001"}
+            "context.explain_source", {"source_ref": "context.readiness"}
         )
         assert isinstance(result["explanation"]["source_refs"], list)
 
@@ -132,10 +132,43 @@ class TestExplainSourceOutputContract:
         bridge = create_bridge()
         result = bridge.execute_tool(
             "context.explain_source",
-            {"source_ref": "src_001", "include_chain": False},
+            {"source_ref": "context.readiness", "include_chain": False},
         )
         provenance = result["explanation"]["provenance"]
         assert "chain" not in provenance
+
+    def test_file_source_uses_repo_relative_path_and_not_mock_values(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source",
+            {"source_ref": "docs/runbooks/surrealdb_context_mcp_access.md"},
+        )
+        expl = result["explanation"]
+        assert expl["source_type"] == "file"
+        assert (
+            expl["provenance"]["repo_relative_path"]
+            == "docs/runbooks/surrealdb_context_mcp_access.md"
+        )
+        assert "mock" not in str(expl).lower()
+
+    def test_source_refs_are_sorted_and_stable(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source", {"source_ref": "context.readiness"}
+        )
+        refs = result["explanation"]["source_refs"]
+        assert refs == sorted(refs, key=lambda item: (item["ref"], item["type"]))
+
+    def test_chain_omitted_when_include_chain_false(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.explain_source",
+            {
+                "source_ref": "docs/runbooks/surrealdb_context_mcp_access.md",
+                "include_chain": False,
+            },
+        )
+        assert "chain" not in result["explanation"]["provenance"]
 
 
 class TestPackageOutputContract:

--- a/tests/unit/tools/mcp/test_permission_guard.py
+++ b/tests/unit/tools/mcp/test_permission_guard.py
@@ -702,7 +702,7 @@ class TestAllCurrentToolsPassInputGate:
 
     def test_context_explain_source_normal_passes(self, bridge: ContextBridge) -> None:
         result = bridge.execute_tool(
-            "context.explain_source", {"source_ref": "src_001"}
+            "context.explain_source", {"source_ref": "context.readiness"}
         )
         assert result["status"] == "ok"
 

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -14,6 +14,8 @@ import logging
 import json
 import hashlib
 from copy import deepcopy
+from pathlib import Path, PurePosixPath
+import re
 from typing import Any, Optional
 
 from tools.mcp.permission_guard import PermissionGuard
@@ -22,6 +24,134 @@ from tools.mcp.registry import ContextToolRegistry, ToolDefinition
 logger = logging.getLogger(__name__)
 
 CDB_CONTEXT_BRIEFING_MAX_RESPONSE_BYTES = 200_000
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _explain_source_error(code: str, message: str) -> dict[str, Any]:
+    return {
+        "tool": "context.explain_source",
+        "status": "error",
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }
+
+
+def _normalize_repo_relative_path(path_value: str) -> str | None:
+    normalized = path_value.strip().replace("\\", "/")
+    if not normalized:
+        return None
+    if normalized.startswith("/") or normalized.startswith("//"):
+        return None
+    if re.match(r"^[A-Za-z]:", normalized):
+        return None
+
+    parts: list[str] = []
+    for part in PurePosixPath(normalized).parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            return None
+        parts.append(part)
+
+    if not parts:
+        return None
+
+    return PurePosixPath(*parts).as_posix()
+
+
+def _repo_relative_file_exists(repo_relative_path: str) -> bool:
+    return (REPO_ROOT / repo_relative_path).is_file()
+
+
+def _infer_handler_status(tool_def: ToolDefinition) -> str:
+    handler = tool_def.handler
+    if handler is None:
+        return "not_implemented"
+
+    handler_name = getattr(handler, "__name__", "")
+    if handler_name == "not_implemented_handler":
+        return "not_implemented"
+
+    return "implemented"
+
+
+def _sorted_source_refs(*entries: dict[str, str]) -> list[dict[str, str]]:
+    refs = [dict(entry) for entry in entries]
+    return sorted(refs, key=lambda item: (item["ref"], item["type"]))
+
+
+def _build_tool_source_explanation(
+    source_ref: str,
+    tool_name: str,
+    include_chain: bool,
+    resolution_chain: list[dict[str, Any]],
+) -> dict[str, Any]:
+    tool_def = ContextToolRegistry.get_tool(tool_name)
+    if tool_def is None:
+        raise KeyError(tool_name)
+
+    source_refs = _sorted_source_refs(
+        {"ref": "resolver:registry", "type": "resolver"},
+        {"ref": f"tool:{tool_name}", "type": "tool"},
+    )
+    provenance: dict[str, Any] = {
+        "tool_name": tool_name,
+        "read_only": bool(tool_def.read_only),
+        "handler_status": _infer_handler_status(tool_def),
+        "input_schema_keys": sorted(
+            list(tool_def.input_schema.get("properties", {}).keys())
+        ),
+        "output_schema_keys": sorted(
+            list(tool_def.output_schema.get("properties", {}).keys())
+        ),
+        "resolver": "registry",
+    }
+    if include_chain:
+        provenance["chain"] = [dict(step) for step in resolution_chain]
+
+    return {
+        "source_ref": source_ref,
+        "source_type": "tool",
+        "provenance": provenance,
+        "source_refs": source_refs,
+        "confidence": 1.0,
+        "warnings": [],
+        "stale": False,
+        "tombstone": False,
+    }
+
+
+def _build_file_source_explanation(
+    source_ref: str,
+    repo_relative_path: str,
+    include_chain: bool,
+    resolution_chain: list[dict[str, Any]],
+) -> dict[str, Any]:
+    source_refs = _sorted_source_refs(
+        {"ref": f"path:{repo_relative_path}", "type": "repo_file"},
+        {"ref": "resolver:repo", "type": "resolver"},
+    )
+    provenance: dict[str, Any] = {
+        "repo_relative_path": repo_relative_path,
+        "source_type": "file",
+        "exists": True,
+        "resolver": "repo",
+    }
+    if include_chain:
+        provenance["chain"] = [dict(step) for step in resolution_chain]
+
+    return {
+        "source_ref": source_ref,
+        "source_type": "file",
+        "provenance": provenance,
+        "source_refs": source_refs,
+        "confidence": 1.0,
+        "warnings": [],
+        "stale": False,
+        "tombstone": False,
+    }
 
 
 def context_search_handler(**kwargs) -> dict[str, Any]:
@@ -159,62 +289,186 @@ def context_explain_source_handler(**kwargs) -> dict[str, Any]:
     """
     Read-only handler for context.explain_source tool.
 
-    Explains provenance of a context source/evidence item.
-    Uses mocked responses (no live DB/network).
-    Fails closed on invalid inputs.
+    Explains provenance of a source using repo-/registry-only resolution.
+    Supports:
+    - exact registered tool names or tool:<tool-name>
+    - existing repo-relative file paths or path:<repo-relative-path>
+    No DB, MCP live, memory, or network resolution is performed.
     """
-    # Validate required source_ref
     source_ref = kwargs.get("source_ref")
     if not source_ref or not isinstance(source_ref, str) or not source_ref.strip():
-        return {
-            "tool": "context.explain_source",
-            "status": "error",
-            "error": {
-                "code": "invalid_source_ref",
-                "message": "source_ref is required and must be a non-empty string",
-            },
-        }
+        return _explain_source_error(
+            "invalid_source_ref",
+            "source_ref is required and must be a non-empty string",
+        )
 
-    # Validate include_chain
     include_chain = kwargs.get("include_chain", True)
     if not isinstance(include_chain, bool):
         include_chain = True
 
-    # Mocked explain result (no live DB/network)
-    mocked_explanation = {
-        "source_ref": source_ref,
-        "source_type": "evidence",
-        "provenance": {
-            "source_path": f"/mock/path/{source_ref}",
-            "hash": "mock_hash_123",
-            "commit": "mock_commit_456",
-            "run_id": "mock_run_789",
-            "import_audit_ref": "mock_audit_012",
-            "evidence_refs": ["mock_ev_1", "mock_ev_2"],
-        },
-        "source_refs": [
-            {"ref": "mock_audit_012", "type": "import_audit"},
-            {"ref": "mock_ev_1", "type": "evidence"},
-        ],
-        "confidence": 0.9,
-        "warnings": [],
-        "stale": False,
-        "tombstone": False,
-    }
-
+    source_ref_clean = source_ref.strip()
+    resolution_chain: list[dict[str, Any]] = []
     if include_chain:
-        mocked_explanation["provenance"]["chain"] = [
-            {"level": 1, "ref": "mock_parent_1", "type": "derived"},
-            {"level": 2, "ref": "mock_parent_2", "type": "source"},
-        ]
+        resolution_chain.append(
+            {
+                "step": "input_normalized",
+                "source_ref": source_ref_clean.replace("\\", "/"),
+            }
+        )
+
+    if source_ref_clean.startswith("tool:"):
+        bare_tool_name = source_ref_clean.split(":", 1)[1].strip()
+        if not bare_tool_name:
+            return _explain_source_error(
+                "invalid_source_ref",
+                "tool: references must include a non-empty registered tool name",
+            )
+
+        if include_chain:
+            resolution_chain.append(
+                {
+                    "step": "registry_checked",
+                    "tool_name": bare_tool_name,
+                    "matched": ContextToolRegistry.get_tool(bare_tool_name) is not None,
+                }
+            )
+
+        tool_def = ContextToolRegistry.get_tool(bare_tool_name)
+        if tool_def is None:
+            return _explain_source_error(
+                "source_not_found",
+                "source_ref did not match a registered tool",
+            )
+
+        if include_chain:
+            resolution_chain.append(
+                {
+                    "step": "resolved",
+                    "source_type": "tool",
+                    "resolver": "registry",
+                }
+            )
+
+        explanation = _build_tool_source_explanation(
+            source_ref=f"tool:{bare_tool_name}",
+            tool_name=bare_tool_name,
+            include_chain=include_chain,
+            resolution_chain=resolution_chain,
+        )
+    elif source_ref_clean.startswith("path:"):
+        bare_path = source_ref_clean.split(":", 1)[1].strip()
+        repo_relative_path = _normalize_repo_relative_path(bare_path)
+        if repo_relative_path is None:
+            return _explain_source_error(
+                "invalid_source_ref",
+                "path: references must use a repo-relative path without absolute prefixes or parent traversal",
+            )
+
+        exists = _repo_relative_file_exists(repo_relative_path)
+        if include_chain:
+            resolution_chain.append(
+                {
+                    "step": "repo_path_checked",
+                    "repo_relative_path": repo_relative_path,
+                    "exists": exists,
+                }
+            )
+
+        if not exists:
+            return _explain_source_error(
+                "source_not_found",
+                "source_ref did not match an existing repo-relative file path",
+            )
+
+        if include_chain:
+            resolution_chain.append(
+                {
+                    "step": "resolved",
+                    "source_type": "file",
+                    "resolver": "repo",
+                }
+            )
+
+        explanation = _build_file_source_explanation(
+            source_ref=f"path:{repo_relative_path}",
+            repo_relative_path=repo_relative_path,
+            include_chain=include_chain,
+            resolution_chain=resolution_chain,
+        )
+    else:
+        tool_def = ContextToolRegistry.get_tool(source_ref_clean)
+        if include_chain:
+            resolution_chain.append(
+                {
+                    "step": "registry_checked",
+                    "tool_name": source_ref_clean,
+                    "matched": tool_def is not None,
+                }
+            )
+
+        if tool_def is not None:
+            if include_chain:
+                resolution_chain.append(
+                    {
+                        "step": "resolved",
+                        "source_type": "tool",
+                        "resolver": "registry",
+                    }
+                )
+
+            explanation = _build_tool_source_explanation(
+                source_ref=source_ref_clean,
+                tool_name=source_ref_clean,
+                include_chain=include_chain,
+                resolution_chain=resolution_chain,
+            )
+        else:
+            repo_relative_path = _normalize_repo_relative_path(source_ref_clean)
+            if repo_relative_path is None:
+                return _explain_source_error(
+                    "invalid_source_ref",
+                    "source_ref path candidates must be repo-relative and must not use absolute prefixes or parent traversal",
+                )
+
+            exists = _repo_relative_file_exists(repo_relative_path)
+            if include_chain:
+                resolution_chain.append(
+                    {
+                        "step": "repo_path_checked",
+                        "repo_relative_path": repo_relative_path,
+                        "exists": exists,
+                    }
+                )
+
+            if not exists:
+                return _explain_source_error(
+                    "source_not_found",
+                    "source_ref must resolve to a registered tool or an existing repo-relative file path",
+                )
+
+            if include_chain:
+                resolution_chain.append(
+                    {
+                        "step": "resolved",
+                        "source_type": "file",
+                        "resolver": "repo",
+                    }
+                )
+
+            explanation = _build_file_source_explanation(
+                source_ref=repo_relative_path,
+                repo_relative_path=repo_relative_path,
+                include_chain=include_chain,
+                resolution_chain=resolution_chain,
+            )
 
     return {
         "tool": "context.explain_source",
         "status": "ok",
-        "explanation": mocked_explanation,
+        "explanation": explanation,
         "metadata": {
-            "explained_at": "2026-05-03T12:00:00Z",
             "include_chain": include_chain,
+            "resolution_mode": "repo_registry_only",
         },
     }
 


### PR DESCRIPTION
## Kurzbefund
- context.explain_source ist jetzt ein deterministischer repo-/registry-only Resolver (kein DB/SurrealDB, kein MCP-live, kein persistent memory).
- Strikte Prefix-Semantik: 	ool: nur Registry, path: nur Repo-Files; ohne Prefix: Tool zuerst, dann Repo-Path, sonst fail-closed.
- Path-Safety: reject absolute/UNC/Drive/.., normalisiert Separatoren deterministisch, keine absoluten Pfadlecks im Output.

## Warum jetzt
- Slice-3 schließt den kleinsten verbleibenden read-only Scaffold-Teil in #2605 mit unit-testbarer, OpenCode-kompatibler Semantik.

## Scope
- in: context.explain_source Handler + Tests + Runbook
- out: context.search/context.trace/context.package/context.briefing, Evidence/Decision/Memory-Tools, DB-Adapter

## Betroffene Dateien / Artefakte
- tools/mcp/context_bridge.py
- tests/unit/tools/mcp/test_context_bridge.py
- tests/unit/tools/mcp/test_output_contracts.py
- tests/unit/tools/mcp/test_permission_guard.py
- docs/runbooks/surrealdb_context_mcp_access.md

## Validierung / Checks
- pytest -v tests/unit/tools/mcp/test_context_bridge.py -m unit
- pytest -v tests/unit/tools/mcp/test_output_contracts.py -m unit
- pytest -v tests/unit/tools/mcp/test_permission_guard.py -m unit
- pytest tests/unit/tools/mcp/test_show_handlers.py -v
- pytest tests/unit/tools/mcp/test_mcp_briefing_tool.py tests/unit/tools/mcp/test_output_contracts.py -v
- ruff check tools/mcp/context_bridge.py tests/unit/tools/mcp/test_context_bridge.py tests/unit/tools/mcp/test_output_contracts.py tests/unit/tools/mcp/test_permission_guard.py
- black --check tools/mcp/context_bridge.py tests/unit/tools/mcp/test_context_bridge.py tests/unit/tools/mcp/test_output_contracts.py tests/unit/tools/mcp/test_permission_guard.py

## Risiken / Guardrails
- Kein Eingriff in Input-Gate Exemptions/Scan-Sets.
- Keine Writes außerhalb Repo/GitHub-Flow; LR bleibt NO-GO.

## Restunsicherheiten
- Keine bekannten; lokale CRLF-Warnungen beim Staging sind erwartbar unter Windows.

## Issue-Bezug
- Refs #2605
