### PR TITLE
feat(mcp): harden readonly context.package tool

### DIFF
--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -294,7 +294,7 @@ Input scanning uses word-boundary regex and recursive parameter walking (dicts a
 
 ## 7. Tool Usage Examples
 
-`context.search`, `context.trace`, and `context.package` examples below still use mocked/in-memory responses. `context.explain_source`, `context.show_snapshot`, and `context.show_audit` are already deterministic repo-/registry-only handlers. For real SurrealDB data, a future Wave will provide a real adapter where applicable.
+`context.search` and `context.trace` examples below still use mocked/in-memory responses. `context.package`, `context.explain_source`, `context.show_snapshot`, and `context.show_audit` are deterministic repo-/registry-only handlers. For real SurrealDB data, a future Wave will provide a real adapter where applicable.
 
 ### 7.1 context.search
 
@@ -421,7 +421,10 @@ Response:
 
 ```python
 result = bridge.execute_tool("context.package", {
-    "artifacts": ["art_001", "art_002"],
+    "artifacts": [
+        "context.readiness",
+        "docs/runbooks/surrealdb_context_mcp_access.md"
+    ],
     "format": "json",
     "include_metadata": True
 })
@@ -436,26 +439,57 @@ Response (ok):
         "format": "json",
         "items": [
             {
-                "id": "art_001",
-                "type": "evidence",
-                "summary": "Mock summary for art_001",
-                "source_refs": ["src_art_001_1", "src_art_001_2"],
-                "confidence": 0.85,
-                "freshness": "2026-05-03T00:00:00Z"
+                "id": "context.readiness",
+                "type": "tool",
+                "summary": "Registry tool context.readiness",
+                "source_refs": ["tool:context.readiness"],
+                "confidence": null,
+                "freshness": null,
+                "metadata": {
+                    "read_only": true,
+                    "handler_status": "implemented"
+                }
+            },
+            {
+                "id": "docs/runbooks/surrealdb_context_mcp_access.md",
+                "type": "file",
+                "summary": "Repo file docs/runbooks/surrealdb_context_mcp_access.md",
+                "source_refs": ["path:docs/runbooks/surrealdb_context_mcp_access.md"],
+                "confidence": null,
+                "freshness": null,
+                "metadata": {
+                    "repo_relative_path": "docs/runbooks/surrealdb_context_mcp_access.md"
+                }
             }
         ],
-        "created_at": "2026-05-03T12:00:00Z",
-        "package_id": "pkg_art_001-art_002",
+        "created_at": null,
+        "package_id": "pkg_<deterministic_hash_prefix>",
         "warnings": [],
         "stale_flags": [],
         "missing_context": [],
-        "stop_conditions": ["no_live_go", "no_echtgeld_authorization", "no_risk_approval"],
-        "metadata": {"include_metadata": true, "scope": "default", "truncated": false, "total_requested": 2}
+        "source_refs": [
+            "path:docs/runbooks/surrealdb_context_mcp_access.md",
+            "tool:context.readiness"
+        ],
+        "stop_conditions": [
+            "no_live_go",
+            "no_echtgeld_authorization",
+            "no_risk_approval"
+        ],
+        "metadata": {
+            "include_metadata": true,
+            "scope": "default",
+            "truncated": false,
+            "total_requested": 2,
+            "total_resolved": 2,
+            "total_missing": 0,
+            "resolver": "repo-registry"
+        }
     }
 }
 ```
 
-Artifacts are capped at 10 items (truncation warning added). Empty or missing artifacts returns `invalid_artifacts` error. Package ID is deterministic from sorted artifact IDs.
+Artifacts are capped at 10 items (truncation warning added). Missing/non-list/empty artifacts returns `invalid_artifacts`. The package is repo-/registry-only: it does not read or write SurrealDB, does not create persistent handoff records, and does not imply Live-Go/LR.
 
 ### 7.5 context.readiness
 

--- a/tests/unit/tools/mcp/test_context_package_handler.py
+++ b/tests/unit/tools/mcp/test_context_package_handler.py
@@ -253,6 +253,14 @@ class TestContextPackageHandler:
         assert result["package"]["items"] == []
         assert result["package"]["missing_context"][0]["code"] == "invalid_source_ref"
 
+    def test_package_id_includes_invalid_path_entries(self) -> None:
+        bridge = create_bridge()
+        r1 = bridge.execute_tool("context.package", {"artifacts": ["path:../foo"]})
+        r2 = bridge.execute_tool("context.package", {"artifacts": [r"path:C:\tmp\a"]})
+        assert r1["status"] == "ok"
+        assert r2["status"] == "ok"
+        assert r1["package"]["package_id"] != r2["package"]["package_id"]
+
     def test_non_string_artifact_rejected_without_crash(self) -> None:
         bridge = create_bridge()
         result = bridge.execute_tool(

--- a/tests/unit/tools/mcp/test_context_package_handler.py
+++ b/tests/unit/tools/mcp/test_context_package_handler.py
@@ -262,6 +262,14 @@ class TestContextPackageHandler:
         assert len(result["package"]["items"]) == 1
         assert len(result["package"]["missing_context"]) == 2
 
+    def test_package_id_includes_rejected_artifacts(self) -> None:
+        bridge = create_bridge()
+        r1 = bridge.execute_tool("context.package", {"artifacts": [None]})
+        r2 = bridge.execute_tool("context.package", {"artifacts": [123]})
+        assert r1["status"] == "ok"
+        assert r2["status"] == "ok"
+        assert r1["package"]["package_id"] != r2["package"]["package_id"]
+
     def test_source_refs_sorted_and_stable(self) -> None:
         bridge = create_bridge()
         result = bridge.execute_tool(

--- a/tests/unit/tools/mcp/test_context_package_handler.py
+++ b/tests/unit/tools/mcp/test_context_package_handler.py
@@ -67,9 +67,7 @@ class TestContextPackageHandler:
 
     def test_format_json_default(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.package", {"artifacts": ["art_001"]}
-        )
+        result = bridge.execute_tool("context.package", {"artifacts": ["art_001"]})
         assert result["package"]["format"] == "json"
 
     def test_format_markdown_accepted(self) -> None:
@@ -90,9 +88,7 @@ class TestContextPackageHandler:
 
     def test_include_metadata_default_true(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.package", {"artifacts": ["art_001"]}
-        )
+        result = bridge.execute_tool("context.package", {"artifacts": ["art_001"]})
         assert result["package"]["metadata"]["include_metadata"] is True
 
     def test_include_metadata_false_omits_fields(self) -> None:
@@ -121,45 +117,180 @@ class TestContextPackageHandler:
         )
         assert result1["package"]["package_id"] == result2["package"]["package_id"]
 
+    def test_package_id_changes_when_inputs_change(self) -> None:
+        bridge = create_bridge()
+        result1 = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001", "art_002"]}
+        )
+        result2 = bridge.execute_tool(
+            "context.package", {"artifacts": ["art_001", "art_003"]}
+        )
+        assert result1["package"]["package_id"] != result2["package"]["package_id"]
+
     def test_package_contains_stop_conditions(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.package", {"artifacts": ["art_001"]}
-        )
+        result = bridge.execute_tool("context.package", {"artifacts": ["art_001"]})
         assert "stop_conditions" in result["package"]
         assert isinstance(result["package"]["stop_conditions"], list)
 
     def test_package_item_has_required_fields(self) -> None:
         bridge = create_bridge()
         result = bridge.execute_tool(
-            "context.package", {"artifacts": ["art_001"]}
+            "context.package", {"artifacts": ["context.readiness"]}
         )
         item = result["package"]["items"][0]
-        for field in ("id", "type", "summary", "source_refs", "confidence", "freshness"):
+        for field in (
+            "id",
+            "type",
+            "summary",
+            "source_refs",
+            "confidence",
+            "freshness",
+        ):
             assert field in item, f"Package item missing field: {field}"
 
     def test_package_contains_created_at(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.package", {"artifacts": ["art_001"]}
-        )
+        result = bridge.execute_tool("context.package", {"artifacts": ["art_001"]})
         assert "created_at" in result["package"]
+        assert result["package"]["created_at"] is None
 
     def test_missing_context_present_in_ok_result(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.package", {"artifacts": ["art_001"]}
-        )
+        result = bridge.execute_tool("context.package", {"artifacts": ["art_001"]})
         assert "missing_context" in result["package"]
         assert isinstance(result["package"]["missing_context"], list)
 
     def test_single_artifact_no_truncation_no_empty_warning(self) -> None:
         bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.package", {"artifacts": ["art_001"]}
-        )
+        result = bridge.execute_tool("context.package", {"artifacts": ["art_001"]})
         assert "artifacts_limit_exceeded_truncated" not in result["package"]["warnings"]
         assert "empty_package" not in result["package"]["warnings"]
+
+    def test_tool_artifact_resolves(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["context.readiness"]}
+        )
+        assert result["status"] == "ok"
+        item = result["package"]["items"][0]
+        assert item["type"] == "tool"
+        assert item["id"] == "context.readiness"
+        assert "tool:context.readiness" in item["source_refs"]
+
+    def test_prefixed_tool_artifact_resolves(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["tool:context.readiness"]}
+        )
+        assert result["status"] == "ok"
+        item = result["package"]["items"][0]
+        assert item["type"] == "tool"
+        assert item["id"] == "context.readiness"
+        assert "tool:context.readiness" in item["source_refs"]
+
+    def test_path_artifact_resolves(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package",
+            {"artifacts": ["docs/runbooks/surrealdb_context_mcp_access.md"]},
+        )
+        assert result["status"] == "ok"
+        item = result["package"]["items"][0]
+        assert item["type"] == "file"
+        assert item["id"] == "docs/runbooks/surrealdb_context_mcp_access.md"
+        assert (
+            "path:docs/runbooks/surrealdb_context_mcp_access.md" in item["source_refs"]
+        )
+        assert ":\\" not in str(result).lower()
+
+    def test_prefixed_path_artifact_resolves(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package",
+            {"artifacts": ["path:docs/runbooks/surrealdb_context_mcp_access.md"]},
+        )
+        assert result["status"] == "ok"
+        item = result["package"]["items"][0]
+        assert item["type"] == "file"
+        assert item["id"] == "docs/runbooks/surrealdb_context_mcp_access.md"
+
+    def test_unknown_artifact_is_missing_context_and_not_mock_item(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["context.__does_not_exist__"]}
+        )
+        assert result["status"] == "ok"
+        assert result["package"]["items"] == []
+        assert len(result["package"]["missing_context"]) == 1
+        assert (
+            result["package"]["missing_context"][0]["artifact"]
+            == "context.__does_not_exist__"
+        )
+        rendered = str(result).lower()
+        assert "mock" not in rendered
+        assert "src_" not in rendered
+        assert "2026-" not in rendered
+
+    def test_absolute_path_is_rejected(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package",
+            {"artifacts": [r"C:\tmp\surrealdb_context_mcp_access.md"]},
+        )
+        assert result["status"] == "ok"
+        assert result["package"]["items"] == []
+        assert result["package"]["missing_context"][0]["code"] == "invalid_source_ref"
+        assert "c:\\" not in str(result).lower()
+
+    def test_traversal_path_is_rejected(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package",
+            {"artifacts": ["../docs/runbooks/surrealdb_context_mcp_access.md"]},
+        )
+        assert result["status"] == "ok"
+        assert result["package"]["items"] == []
+        assert result["package"]["missing_context"][0]["code"] == "invalid_source_ref"
+
+    def test_non_string_artifact_rejected_without_crash(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package", {"artifacts": ["context.readiness", 123, None]}
+        )
+        assert result["status"] == "ok"
+        assert len(result["package"]["items"]) == 1
+        assert len(result["package"]["missing_context"]) == 2
+
+    def test_source_refs_sorted_and_stable(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package",
+            {
+                "artifacts": [
+                    "docs/runbooks/surrealdb_context_mcp_access.md",
+                    "context.readiness",
+                ]
+            },
+        )
+        assert result["status"] == "ok"
+        refs = result["package"]["source_refs"]
+        assert refs == sorted(refs)
+
+    def test_include_metadata_true_metadata_is_deterministic(self) -> None:
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.package",
+            {
+                "artifacts": ["context.readiness"],
+                "include_metadata": True,
+                "scope": "default",
+            },
+        )
+        md = result["package"]["metadata"]
+        assert md["include_metadata"] is True
+        assert md["resolver"] == "repo-registry"
+        assert "created_at" not in md
 
     def test_error_response_has_required_structure(self) -> None:
         bridge = create_bridge()

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -656,12 +656,12 @@ def context_package_handler(**kwargs) -> dict[str, Any]:
     Read-only handler for context.package tool.
 
     Packages context artifacts for handoff between agents or sessions.
-    Uses mocked responses (no live DB/network).
-    Fails closed on invalid inputs.
+    Repo-/registry-only deterministic packaging (no DB/network).
+    Fails closed on invalid inputs and never invents mock artifacts.
     """
     # Validate required artifacts
     artifacts = kwargs.get("artifacts")
-    if not artifacts or not isinstance(artifacts, list):
+    if not artifacts or not isinstance(artifacts, list) or not artifacts:
         return {
             "tool": "context.package",
             "status": "error",
@@ -688,73 +688,267 @@ def context_package_handler(**kwargs) -> dict[str, Any]:
     if not isinstance(include_metadata, bool):
         include_metadata = True
 
-    # Mocked package result (no live DB/network)
-    # Follows #2097 requirements: bounded package, SourceRefs, confidence/freshness/warnings, stop_conditions
-    package_items = []
-    for artifact_id in artifacts[:10]:  # Limit to 10 items
-        package_items.append(
+    scope = kwargs.get("scope", "default")
+    if not isinstance(scope, str) or not scope.strip():
+        scope = "default"
+    scope = scope.strip()
+
+    warnings: list[str] = []
+    truncated = False
+    total_requested = len(artifacts)
+    artifacts_in = artifacts[:10]
+    if total_requested > 10:
+        truncated = True
+        warnings.append("artifacts_limit_exceeded_truncated")
+
+    package_items: list[dict[str, Any]] = []
+    missing_context: list[dict[str, Any]] = []
+    normalized_inputs: list[str] = []
+    package_source_refs: list[str] = []
+
+    def _safe_artifact_echo(value: str) -> str:
+        candidate = value.strip()
+        prefix: str | None = None
+        if candidate.startswith("tool:"):
+            prefix = "tool:"
+            candidate = candidate.split(":", 1)[1]
+        elif candidate.startswith("path:"):
+            prefix = "path:"
+            candidate = candidate.split(":", 1)[1]
+
+        candidate_norm = candidate.strip().replace("\\", "/")
+        if not candidate_norm:
+            safe = ""
+        elif candidate_norm.startswith("/") or candidate_norm.startswith("//"):
+            safe = "<rejected:absolute_path>"
+        elif candidate_norm.startswith("\\\\"):
+            safe = "<rejected:unc_path>"
+        elif re.match(r"^[A-Za-z]:", candidate_norm):
+            safe = "<rejected:drive_path>"
+        elif ".." in PurePosixPath(candidate_norm).parts:
+            safe = "<rejected:path_traversal>"
+        else:
+            safe = value
+
+        if prefix is None or safe == value:
+            return safe
+        return f"{prefix}{safe}"
+
+    def _reject_missing(artifact_value: Any, code: str, message: str) -> None:
+        artifact_text = (
+            artifact_value if isinstance(artifact_value, str) else str(artifact_value)
+        )
+        missing_context.append(
             {
-                "id": artifact_id,
-                "type": "evidence",
-                "summary": f"Mock summary for {artifact_id}",
-                "source_refs": [f"src_{artifact_id}_1", f"src_{artifact_id}_2"],
-                "confidence": 0.85,
-                "freshness": "2026-05-03T00:00:00Z",
+                "artifact": _safe_artifact_echo(artifact_text),
+                "code": code,
+                "message": message,
             }
         )
 
-    warnings = []
-    if len(artifacts) > 10:
-        warnings.append("artifacts_limit_exceeded_truncated")
-    if len(package_items) == 0:
-        warnings.append("empty_package")
+    for artifact in artifacts_in:
+        if not isinstance(artifact, str):
+            _reject_missing(
+                artifact,
+                "invalid_artifact_type",
+                "artifact entries must be strings",
+            )
+            continue
 
-    missing_context = []
-    if len(artifacts) == 0:
-        missing_context.append("no_artifacts_provided")
+        raw_ref = artifact.strip()
+        if not raw_ref:
+            _reject_missing(
+                artifact,
+                "invalid_source_ref",
+                "artifact reference must be a non-empty string",
+            )
+            continue
 
-    package = {
-        "request_scope": kwargs.get("scope", "default"),
-        "query_summary": f"Package request for {len(artifacts)} artifacts",
-        "top_artifacts": package_items[:5],
-        "top_docs": [],
-        "top_symbols": [],
-        "graph_paths": [],
-        "source_refs": [
-            item
-            for sub in [a.get("source_refs", []) for a in package_items]
-            for item in sub
-        ],
-        "confidence_summary": {"average": 0.85, "lowest": 0.8, "highest": 0.9},
-        "warnings": warnings,
-        "stale_flags": [],
-        "missing_context": missing_context,
-        "recommended_next_queries": [],
-        "stop_conditions": [
-            "no_live_go",
-            "no_echtgeld_authorization",
-            "no_risk_approval",
-        ],
-    }
+        # ---- tool: prefix (registry only) ----
+        if raw_ref.startswith("tool:"):
+            tool_name = raw_ref.split(":", 1)[1].strip()
+            normalized_inputs.append(f"tool:{tool_name}" if tool_name else "tool:")
+            if not tool_name:
+                _reject_missing(
+                    raw_ref,
+                    "invalid_source_ref",
+                    "tool: references must include a non-empty registered tool name",
+                )
+                continue
+
+            tool_def = ContextToolRegistry.get_tool(tool_name)
+            if tool_def is None:
+                _reject_missing(
+                    f"tool:{tool_name}",
+                    "source_not_found",
+                    "artifact did not match a registered tool",
+                )
+                continue
+
+            src_ref = f"tool:{tool_name}"
+            package_source_refs.append(src_ref)
+            package_items.append(
+                {
+                    "id": tool_name,
+                    "type": "tool",
+                    "summary": f"Registry tool {tool_name}",
+                    "source_refs": [src_ref],
+                    "confidence": None,
+                    "freshness": None,
+                    "metadata": {
+                        "read_only": bool(tool_def.read_only),
+                        "handler_status": _infer_handler_status(tool_def),
+                    },
+                }
+            )
+            continue
+
+        # ---- path: prefix (repo file only) ----
+        if raw_ref.startswith("path:"):
+            bare_path = raw_ref.split(":", 1)[1].strip()
+            repo_relative_path = _normalize_repo_relative_path(bare_path)
+            normalized_inputs.append(
+                f"path:{repo_relative_path}" if repo_relative_path else "path:"
+            )
+            if repo_relative_path is None:
+                _reject_missing(
+                    raw_ref,
+                    "invalid_source_ref",
+                    "path: references must use a repo-relative path without absolute prefixes or parent traversal",
+                )
+                continue
+
+            if not _repo_relative_file_exists(repo_relative_path):
+                _reject_missing(
+                    f"path:{repo_relative_path}",
+                    "source_not_found",
+                    "artifact did not match an existing repo-relative file path",
+                )
+                continue
+
+            src_ref = f"path:{repo_relative_path}"
+            package_source_refs.append(src_ref)
+            package_items.append(
+                {
+                    "id": repo_relative_path,
+                    "type": "file",
+                    "summary": f"Repo file {repo_relative_path}",
+                    "source_refs": [src_ref],
+                    "confidence": None,
+                    "freshness": None,
+                    "metadata": {
+                        "repo_relative_path": repo_relative_path,
+                    },
+                }
+            )
+            continue
+
+        # ---- no prefix: prefer exact tool match, else repo-relative file ----
+        tool_def = ContextToolRegistry.get_tool(raw_ref)
+        if tool_def is not None:
+            normalized_inputs.append(raw_ref)
+            src_ref = f"tool:{raw_ref}"
+            package_source_refs.append(src_ref)
+            package_items.append(
+                {
+                    "id": raw_ref,
+                    "type": "tool",
+                    "summary": f"Registry tool {raw_ref}",
+                    "source_refs": [src_ref],
+                    "confidence": None,
+                    "freshness": None,
+                    "metadata": {
+                        "read_only": bool(tool_def.read_only),
+                        "handler_status": _infer_handler_status(tool_def),
+                    },
+                }
+            )
+            continue
+
+        repo_relative_path = _normalize_repo_relative_path(raw_ref)
+        normalized_inputs.append(repo_relative_path or raw_ref.replace("\\", "/"))
+        if repo_relative_path is None:
+            _reject_missing(
+                raw_ref,
+                "invalid_source_ref",
+                "artifact path candidates must be repo-relative and must not use absolute prefixes or parent traversal",
+            )
+            continue
+
+        if not _repo_relative_file_exists(repo_relative_path):
+            _reject_missing(
+                repo_relative_path,
+                "source_not_found",
+                "artifact did not match a registered tool or an existing repo-relative file path",
+            )
+            continue
+
+        src_ref = f"path:{repo_relative_path}"
+        package_source_refs.append(src_ref)
+        package_items.append(
+            {
+                "id": repo_relative_path,
+                "type": "file",
+                "summary": f"Repo file {repo_relative_path}",
+                "source_refs": [src_ref],
+                "confidence": None,
+                "freshness": None,
+                "metadata": {
+                    "repo_relative_path": repo_relative_path,
+                },
+            }
+        )
+
+    if missing_context:
+        warnings.append("some_artifacts_unresolved")
+
+    # Deterministic, stable ordering
+    package_source_refs = sorted(set(package_source_refs))
+    missing_context = sorted(
+        [dict(entry) for entry in missing_context],
+        key=lambda item: (item.get("artifact", ""), item.get("code", "")),
+    )
 
     return {
         "tool": "context.package",
         "status": "ok",
         "package": {
             "format": format_opt,
-            "items": package_items[:10],
-            "created_at": "2026-05-03T12:00:00Z",
-            "package_id": f"pkg_{'-'.join(str(a) for a in sorted(artifacts[:10]))}",
+            "items": package_items,
+            "created_at": None,
+            "package_id": (
+                "pkg_"
+                + hashlib.sha256(
+                    json.dumps(
+                        {
+                            "scope": scope,
+                            "format": format_opt,
+                            "artifacts": normalized_inputs,
+                            "truncated": truncated,
+                        },
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                ).hexdigest()[:12]
+            ),
             "warnings": warnings,
-            "stale_flags": package.get("stale_flags", []),
+            "stale_flags": [],
             "missing_context": missing_context,
-            "stop_conditions": package["stop_conditions"],
+            "source_refs": package_source_refs,
+            "stop_conditions": [
+                "no_live_go",
+                "no_echtgeld_authorization",
+                "no_risk_approval",
+            ],
             "metadata": (
                 {
                     "include_metadata": include_metadata,
-                    "scope": package["request_scope"],
-                    "truncated": len(artifacts) > 10,
-                    "total_requested": len(artifacts),
+                    "scope": scope,
+                    "truncated": truncated,
+                    "total_requested": total_requested,
+                    "total_resolved": len(package_items),
+                    "total_missing": len(missing_context),
+                    "resolver": "repo-registry",
                 }
                 if include_metadata
                 else {}
@@ -1642,7 +1836,7 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
 
     if requested_depth in ("standard", "deep"):
         package_result = context_package_handler(
-            artifacts=["briefing_artifact_001", "briefing_artifact_002"],
+            artifacts=["context.readiness", "AGENTS.md"],
             format="json",
         )
         pkg = package_result.get("package", {})

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -748,6 +748,13 @@ def context_package_handler(**kwargs) -> dict[str, Any]:
 
     for artifact in artifacts_in:
         if not isinstance(artifact, str):
+            # Keep package_id unique even for rejected entries.
+            normalized_inputs.append(
+                "invalid_type:"
+                + type(artifact).__name__
+                + ":"
+                + _safe_artifact_echo(str(artifact))
+            )
             _reject_missing(
                 artifact,
                 "invalid_artifact_type",
@@ -757,6 +764,8 @@ def context_package_handler(**kwargs) -> dict[str, Any]:
 
         raw_ref = artifact.strip()
         if not raw_ref:
+            # Different empty/whitespace inputs should not collapse to the same package_id.
+            normalized_inputs.append(f"invalid_empty:{len(artifact)}")
             _reject_missing(
                 artifact,
                 "invalid_source_ref",

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -816,16 +816,18 @@ def context_package_handler(**kwargs) -> dict[str, Any]:
         if raw_ref.startswith("path:"):
             bare_path = raw_ref.split(":", 1)[1].strip()
             repo_relative_path = _normalize_repo_relative_path(bare_path)
-            normalized_inputs.append(
-                f"path:{repo_relative_path}" if repo_relative_path else "path:"
-            )
             if repo_relative_path is None:
+                # Keep package_id unique even for rejected path: entries without leaking absolute paths.
+                normalized_inputs.append(
+                    "path_invalid:" + _safe_artifact_echo(bare_path or "<empty>")
+                )
                 _reject_missing(
                     raw_ref,
                     "invalid_source_ref",
                     "path: references must use a repo-relative path without absolute prefixes or parent traversal",
                 )
                 continue
+            normalized_inputs.append(f"path:{repo_relative_path}")
 
             if not _repo_relative_file_exists(repo_relative_path):
                 _reject_missing(


### PR DESCRIPTION
## Summary

Implements #2605 Slice-4 by replacing mock `context.package` output with deterministic repo-/registry-only packaging.

## What changed

- Hardens `context.package` to resolve artifacts against:
  - registry tools
  - repo-relative files
- Supports:
  - exact tool names
  - `tool:<tool-name>`
  - repo-relative paths
  - `path:<repo-relative-path>`
- Adds deterministic `package_id`
- Rejects unsafe paths:
  - absolute paths
  - Windows drive paths
  - UNC paths
  - `..` traversal
- Reports unresolved/rejected artifacts in `missing_context`
- Keeps `include_metadata=false` compatibility with `metadata == {}`
- Updates package handler tests and runbook docs

## Validation

Local validation passed via `cmd.exe` because `pwsh.exe` WindowsApps stub currently fails with `CreateProcessAsUserW failed: 1312`.

- `pytest -v tests/unit/tools/mcp/test_context_package_handler.py` -- 32 passed
- `pytest -v tests/unit/tools/mcp/test_output_contracts.py -m unit` -- 38 passed
- `pytest -v tests/unit/tools/mcp/test_context_bridge.py -m unit` -- 251 passed
- `pytest -v tests/unit/tools/mcp/test_permission_guard.py -m unit` -- 151 passed
- `pytest -v tests/unit/tools/mcp/test_mcp_briefing_tool.py tests/unit/tools/mcp/test_output_contracts.py -v` -- 55 passed
- `ruff check ...` -- pass
- `black --check ...` -- pass
- Smoke:
  - `len(b.list_tools()) == 26`
  - `context.package(... )["status"] == "ok"`

## Safety

- Read-only
- Repo-/registry-only
- No DB writes
- No DB reads
- No MCP live mutation
- No persistent memory
- No workflow changes
- LR remains NO-GO

## Issue

Fourth focused implementation slice for #2605. #2605 remains open.

