### PR TITLE
fix(mcp): remove fake lineage from context.trace

### DIFF
--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -294,7 +294,7 @@ Input scanning uses word-boundary regex and recursive parameter walking (dicts a
 
 ## 7. Tool Usage Examples
 
-`context.search` and `context.trace` examples below still use mocked/in-memory responses. `context.package`, `context.explain_source`, `context.show_snapshot`, and `context.show_audit` are deterministic repo-/registry-only handlers. For real SurrealDB data, a future Wave will provide a real adapter where applicable.
+`context.search` examples below still use mocked/in-memory responses. `context.trace` is read-only and fail-closed, but in the current repo-/in-memory bridge mode it does not invent provenance or lineage. `context.package`, `context.explain_source`, `context.show_snapshot`, and `context.show_audit` are deterministic repo-/registry-only handlers. For real SurrealDB data, a future Wave will provide a real adapter where applicable.
 
 ### 7.1 context.search
 
@@ -343,16 +343,13 @@ Response:
     "tool": "context.trace",
     "status": "ok",
     "trace": {
-        "root": {"id": "evt_001", "type": "unknown", "title": "Mock trace target: evt_001"},
-        "lineage": [
-            {"id": "mock_related_0", "type": "derived", "relationship": "related_to", "depth": 1},
-            {"id": "mock_related_1", "type": "derived", "relationship": "related_to", "depth": 2}
-        ]
+        "root": {"id": "evt_001", "type": "unknown", "title": "Trace target: evt_001"},
+        "lineage": []
     }
 }
 ```
 
-Maximum depth is 20. `depth_exceeded` error returned above 20.
+Maximum depth is 20. `depth_exceeded` error returned above 20. In the current read-only bridge mode, lineage stays empty unless a future evidence-backed resolver is available.
 
 ### 7.3 context.explain_source
 

--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -112,7 +112,7 @@ class TestContextTraceHandler:
         assert result["error"]["code"] == "target_not_found"
 
     def test_valid_target_id_returns_ok(self) -> None:
-        """Valid target_id returns ok status with trace (mocked)."""
+        """Valid target_id returns ok status with trace payload."""
         bridge = create_bridge()
         result = bridge.execute_tool("context.trace", {"target_id": "evt_abc123"})
         assert result["status"] == "ok"
@@ -120,15 +120,16 @@ class TestContextTraceHandler:
         assert "trace" in result
         assert "root" in result["trace"]
         assert "lineage" in result["trace"]
+        assert result["trace"]["lineage"] == []
 
     def test_depth_parameter_accepted(self) -> None:
-        """Depth parameter is accepted and respected."""
+        """Depth parameter is accepted without inventing lineage."""
         bridge = create_bridge()
         result = bridge.execute_tool(
             "context.trace", {"target_id": "evt_abc123", "depth": 10}
         )
         assert result["status"] == "ok"
-        assert len(result["trace"]["lineage"]) <= 10
+        assert result["trace"]["lineage"] == []
 
     def test_depth_exceeds_max_returns_error(self) -> None:
         """Depth exceeding 20 returns error."""
@@ -145,6 +146,13 @@ class TestContextTraceHandler:
         result = bridge.execute_tool("context.trace", {"target_id": "evt_test"})
         assert result["status"] == "ok"
         assert result["trace"]["root"]["id"] == "evt_test"
+
+    def test_trace_root_title_is_neutral(self) -> None:
+        """Trace root title must not claim mock provenance."""
+        bridge = create_bridge()
+        result = bridge.execute_tool("context.trace", {"target_id": "evt_test"})
+        assert result["status"] == "ok"
+        assert result["trace"]["root"]["title"] == "Trace target: evt_test"
 
 
 class TestContextExplainSourceHandler:

--- a/tests/unit/tools/mcp/test_output_contracts.py
+++ b/tests/unit/tools/mcp/test_output_contracts.py
@@ -68,19 +68,16 @@ class TestTraceOutputContract:
         bridge = create_bridge()
         result = bridge.execute_tool("context.trace", {"target_id": "evt_001"})
         root = result["trace"]["root"]
-        assert "id" in root
-        assert "type" in root
-        assert "title" in root
+        assert root["id"] == "evt_001"
+        assert root["type"] == "unknown"
+        assert root["title"] == "Trace target: evt_001"
 
-    def test_trace_has_lineage_with_relationship(self) -> None:
+    def test_trace_lineage_empty_without_evidence(self) -> None:
         bridge = create_bridge()
         result = bridge.execute_tool(
             "context.trace", {"target_id": "evt_001", "depth": 3}
         )
-        for item in result["trace"]["lineage"]:
-            assert "id" in item
-            assert "relationship" in item
-            assert "depth" in item
+        assert result["trace"]["lineage"] == []
 
     def test_error_output_has_target_not_found_code(self) -> None:
         bridge = create_bridge()

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -256,31 +256,19 @@ def context_trace_handler(**kwargs) -> dict[str, Any]:
             },
         }
 
-    # Mocked trace results (no live DB/network)
-    # In production, this would query the context graph
+    # No evidence-backed lineage is available in the current read-only bridge mode.
     root = {
         "id": target_id,
         "type": "unknown",
-        "title": f"Mock trace target: {target_id}",
+        "title": f"Trace target: {target_id}",
     }
-
-    lineage = []
-    for i in range(min(depth, 3)):  # Mock up to 3 levels
-        lineage.append(
-            {
-                "id": f"mock_related_{i}",
-                "type": "derived",
-                "relationship": "related_to",
-                "depth": i + 1,
-            }
-        )
 
     return {
         "tool": "context.trace",
         "status": "ok",
         "trace": {
             "root": root,
-            "lineage": lineage,
+            "lineage": [],
         },
     }
 


### PR DESCRIPTION
## Summary

Implements #2605 Slice-5 by removing fake/mocked lineage from the read-only `context.trace` handler.

## What changed

- Replaces `Mock trace target: <id>` with neutral `Trace target: <id>`.
- Removes synthetic `mock_related_*` lineage entries.
- Keeps `target_id` fail-closed behavior.
- Keeps `depth > 20` fail-closed behavior.
- Updates trace unit tests and output-contract tests.
- Synchronizes the Context MCP runbook with the new read-only behavior.

## Validation

- `pytest -v tests/unit/tools/mcp/test_context_bridge.py` — 252 passed
- `pytest -v tests/unit/tools/mcp/test_output_contracts.py` — 38 passed
- `pytest -v tests/unit/tools/mcp/test_error_cases.py` — 11 passed
- `pytest -v tests/unit/tools/mcp/test_permission_guard.py -k trace` — 4 passed
- `ruff check --no-cache tools/mcp/context_bridge.py tests/unit/tools/mcp/test_context_bridge.py tests/unit/tools/mcp/test_output_contracts.py` — pass
- `black --check tools/mcp/context_bridge.py tests/unit/tools/mcp/test_context_bridge.py tests/unit/tools/mcp/test_output_contracts.py` — pass
- Bounded smoke: `context.trace({'target_id':'evt_001'})` returns `status=ok`, title `Trace target: evt_001`, and `lineage=[]`.

## Safety

- Read-only MCP behavior only.
- No DB reads.
- No DB writes.
- No SurrealDB-local claims.
- No MCP live mutation.
- No persistent memory writes.
- No workflow changes.
- No Live-Readiness change.
- No Echtgeld / no live trading / no runtime activation.
- LR remains NO-GO.

## Issue

Refs #2605. Slice-5 only. #2605 remains open.
