### PR TITLE
feat(mcp): derive briefing brain evidence from local context reads

### DIFF
--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -584,11 +584,16 @@ result = bridge.execute_tool("context.briefing", {
 })
 ```
 
-Response includes `briefing_id` (16-char hex, deterministic), `scope_summary`, `required_reads`, `guardrails` (7 mandatory), `stop_conditions`, `validation_plan`, `human_go_required`. Depths: `quick` (summary only), `standard` (with artifacts), `deep` (with mock uncertainty warnings).
+Response includes `briefing_id` (16-char hex, deterministic), `scope_summary`, `required_reads`, `guardrails` (7 mandatory), `stop_conditions`, `validation_plan`, `human_go_required`. Depths: `quick` (summary only), `standard` (with artifacts), `deep` (with mock uncertainty warnings). If `target_issue` is omitted it defaults to `null`; if `requested_depth` is omitted it defaults to `quick`.
 
-`briefing.session_context` is the canonical short-term/session-memory handoff surface for Context/MCP work. It is always `working_memory` with `session_only=true`, remains read-only, and must not be treated as persistent SurrealDB memory. DB-backed Brain or evidence claims require both `brain_source="surrealdb-local"` and a usable `brain_status` (`used` or `partial`). `blocked`, `not-used`, `repo-only`, `in_memory`, and `unavailable` stay fail-closed.
+`briefing.session_context` is the canonical short-term/session-memory handoff surface for Context/MCP work. It is always `working_memory` with `session_only=true`, remains read-only, and must not be treated as persistent SurrealDB memory. `brain_source` / `brain_status` are derived, not trusted from caller claims:
 
-Deterministic example with explicit session context inputs:
+- `adapter_config_path` (+ `secrets_path` when required by the config) triggers a real Wave-14 trust-summary read through the existing adapter layer. Only `metadata.source="surrealdb-local"` enables DB-backed briefing claims.
+- Inline `evidence_records` / `claim_records` / `decision_events` / `memory_records` derive `brain_source="in_memory"` with `db_claims_allowed=false`.
+- No DB path and no inline records derive `brain_source="repo-only"` and `brain_status="not-used"`.
+- Caller-supplied `brain_source` / `brain_status` are ignored and surfaced only as limitations when present.
+
+Deterministic repo-only example with explicit session state inputs:
 
 ```python
 result = bridge.execute_tool("context.briefing", {
@@ -597,8 +602,6 @@ result = bridge.execute_tool("context.briefing", {
     "task_scope": "review session-context handoff behavior",
     "requested_depth": "quick",
     "operation_mode": "read_only",
-    "brain_source": "repo-only",
-    "brain_status": "not-used",
     "repo_state": {
         "branch": "fix/2613-noise-freeze-remaining-push-triggers",
         "commit": "f345cf0c",
@@ -695,7 +698,7 @@ limitations:
 - `working_assumptions` are temporary session hints only because `session_only=true`.
 - `ttl_seconds` is bounded to `<= 14400` (4h) for this MCP handoff surface.
 - `repo-only` and `in_memory` are not DB-backed and must keep `db_claims_allowed=false`.
-- Persistent Brain or memory claims require `brain_source=surrealdb-local` and usable `brain_status` (`used` or `partial`); `blocked` always disables DB-backed claims.
+- Persistent Brain or memory claims require a real adapter-backed read that returns `metadata.source="surrealdb-local"`; briefing fails closed when DB-backed mode is requested but config/auth/adapter source cannot prove that path.
 - `session_context` does not authorize any automatic long-term memory write or persistent DB write.
 - A full Brain Evidence block can be generated from `briefing.session_context` plus the sibling briefing fields such as `required_reads`.
 

--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -1494,22 +1494,22 @@ class TestContextBriefingHandler:
         assert session_context["github_state"]["related_prs"] == []
         assert session_context["github_state"]["open_epics"] == []
 
-    def test_repo_only_brain_source_disables_db_claims(self) -> None:
-        """repo-only brain source forbids DB-backed claims."""
+    def test_default_brain_context_is_repo_only(self) -> None:
+        """Without DB or inline records, briefing stays repo-only and non-DB-backed."""
         bridge = create_bridge()
         result = bridge.execute_tool(
             "context.briefing",
             {
-                "task_id": "cdb-briefing-repo-only",
-                "task_scope": "Validate repo-only brain source handling.",
+                "task_id": "cdb-briefing-default-brain-context",
+                "task_scope": "Validate repo-only derived brain context.",
                 "target_issue": "#2607",
                 "requested_depth": "quick",
                 "operation_mode": "read_only",
-                "brain_source": "repo-only",
             },
         )
         session_context = result["briefing"]["session_context"]
         assert session_context["brain_source"] == "repo-only"
+        assert session_context["brain_status"] == "not-used"
         assert session_context["agent_operating_mode"]["db_claims_allowed"] is False
 
     def test_repo_only_session_context_matches_brain_evidence_gate_defaults(
@@ -1525,7 +1525,6 @@ class TestContextBriefingHandler:
                 "target_issue": "#2607",
                 "requested_depth": "quick",
                 "operation_mode": "read_only",
-                "brain_source": "repo-only",
             },
         )
         session_context = result["briefing"]["session_context"]
@@ -1536,19 +1535,20 @@ class TestContextBriefingHandler:
             for item in session_context["limitations"]
         )
 
-    def test_in_memory_brain_source_still_disables_db_claims(self) -> None:
-        """Non-SurrealDB brain sources do not permit DB-backed claims."""
+    def test_inline_records_derive_in_memory_brain_source(self) -> None:
+        """Inline enrichment records derive in-memory brain context without DB claims."""
         bridge = create_bridge()
         result = bridge.execute_tool(
             "context.briefing",
             {
-                "task_id": "cdb-briefing-in-memory-brain",
-                "task_scope": "Validate in-memory Brain Evidence compatibility.",
+                "task_id": "cdb-briefing-inline-in-memory",
+                "task_scope": "Validate in-memory derived Brain Evidence compatibility.",
                 "target_issue": None,
                 "requested_depth": "quick",
                 "operation_mode": "read_only",
-                "brain_source": "in_memory",
-                "brain_status": "used",
+                "memory_records": [
+                    {"memory_id": "mem-001", "scope": "wave14", "content": "test"}
+                ],
             },
         )
         session_context = result["briefing"]["session_context"]
@@ -1556,159 +1556,131 @@ class TestContextBriefingHandler:
         assert session_context["brain_status"] == "used"
         assert session_context["agent_operating_mode"]["db_claims_allowed"] is False
 
-    def test_surrealdb_local_used_allows_db_claims(self) -> None:
-        """surrealdb-local with used status enables DB-backed claim mode."""
+    def test_db_requested_briefing_uses_surrealdb_local_metadata(
+        self, monkeypatch
+    ) -> None:
+        """DB-backed briefing claims require real adapter metadata, not caller input."""
+        monkeypatch.setattr(
+            "tools.mcp.context_evidence_memory_tools.handle_cdb_context_trust_summary",
+            lambda request: {
+                "tool": "cdb_context_trust_summary",
+                "status": "ok",
+                "result": {"scope": request["parameters"]["scope"]},
+                "metadata": {
+                    "query_time_ms": 0,
+                    "source": "surrealdb-local",
+                    "read_only": True,
+                },
+            },
+        )
         bridge = create_bridge()
         result = bridge.execute_tool(
             "context.briefing",
             {
-                "task_id": "cdb-briefing-surrealdb-local",
-                "task_scope": "Validate surrealdb-local claim mode.",
+                "task_id": "cdb-briefing-surrealdb-derived",
+                "task_scope": "Validate surrealdb-local derived claim mode.",
                 "target_issue": "#2607",
                 "requested_depth": "quick",
                 "operation_mode": "read_only",
-                "brain_source": "surrealdb-local",
-                "brain_status": "used",
+                "adapter_config_path": "infrastructure/config/surrealdb/context_query.local.example.yaml",
+                "secrets_path": "D:/tmp/fake-secrets",
             },
         )
+        assert result["status"] == "ok"
         session_context = result["briefing"]["session_context"]
         assert session_context["brain_source"] == "surrealdb-local"
+        assert session_context["brain_status"] == "used"
         assert session_context["agent_operating_mode"]["db_claims_allowed"] is True
 
-    def test_surrealdb_local_partial_allows_db_claims(self) -> None:
-        """surrealdb-local with partial status still enables DB-backed claims."""
+    def test_db_requested_briefing_propagates_adapter_config_error(
+        self, monkeypatch
+    ) -> None:
+        """Config/auth failures on the DB-backed path fail closed on briefing."""
+        monkeypatch.setattr(
+            "tools.mcp.context_evidence_memory_tools.handle_cdb_context_trust_summary",
+            lambda request: {
+                "tool": "cdb_context_trust_summary",
+                "status": "error",
+                "error": {
+                    "code": "adapter_config_error",
+                    "message": "SURREALDB_ENV not found",
+                },
+                "metadata": {
+                    "query_time_ms": 0,
+                    "source": "in_memory",
+                    "read_only": True,
+                },
+            },
+        )
         bridge = create_bridge()
         result = bridge.execute_tool(
             "context.briefing",
             {
-                "task_id": "cdb-briefing-surrealdb-partial",
-                "task_scope": "Validate surrealdb-local partial claim mode.",
+                "task_id": "cdb-briefing-db-config-error",
+                "task_scope": "Validate fail-closed DB config handling.",
+                "target_issue": "#2607",
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+                "adapter_config_path": "infrastructure/config/surrealdb/context_query.local.example.yaml",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "adapter_config_error"
+
+    def test_db_requested_briefing_fails_closed_on_unavailable_source(
+        self, monkeypatch
+    ) -> None:
+        """Soft-unavailable DB status still fails closed on briefing."""
+        monkeypatch.setattr(
+            "tools.mcp.context_evidence_memory_tools.handle_cdb_context_trust_summary",
+            lambda request: {
+                "tool": "cdb_context_trust_summary",
+                "status": "ok",
+                "result": {"scope": request["parameters"]["scope"]},
+                "metadata": {
+                    "query_time_ms": 0,
+                    "source": "surrealdb-local-unavailable",
+                    "read_only": True,
+                },
+            },
+        )
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-db-unavailable",
+                "task_scope": "Validate unavailable surrealdb claim mode.",
+                "target_issue": "#2607",
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+                "adapter_config_path": "infrastructure/config/surrealdb/context_query.local.example.yaml",
+            },
+        )
+        assert result["status"] == "error"
+        assert result["error"]["code"] == "adapter_unavailable"
+
+    def test_caller_brain_source_is_ignored_without_db(self) -> None:
+        """Caller-supplied surrealdb-local claims cannot fake DB readiness."""
+        bridge = create_bridge()
+        result = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-ignore-caller-brain-source",
+                "task_scope": "Validate caller claim suppression.",
                 "target_issue": "#2607",
                 "requested_depth": "quick",
                 "operation_mode": "read_only",
                 "brain_source": "surrealdb-local",
-                "brain_status": "partial",
-            },
-        )
-        session_context = result["briefing"]["session_context"]
-        assert session_context["agent_operating_mode"]["db_claims_allowed"] is True
-
-    def test_surrealdb_local_blocked_disables_db_claims(self) -> None:
-        """Blocked brain status fail-closes DB-backed claims."""
-        bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.briefing",
-            {
-                "task_id": "cdb-briefing-surrealdb-blocked",
-                "task_scope": "Validate blocked surrealdb claim mode.",
-                "target_issue": "#2607",
-                "requested_depth": "quick",
-                "operation_mode": "read_only",
-                "brain_source": "surrealdb-local",
-                "brain_status": "blocked",
-            },
-        )
-        session_context = result["briefing"]["session_context"]
-        assert session_context["agent_operating_mode"]["db_claims_allowed"] is False
-
-    def test_surrealdb_local_not_used_disables_db_claims(self) -> None:
-        """Not-used surrealdb status fail-closes DB-backed claims."""
-        bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.briefing",
-            {
-                "task_id": "cdb-briefing-surrealdb-not-used",
-                "task_scope": "Validate not-used surrealdb claim mode.",
-                "target_issue": "#2607",
-                "requested_depth": "quick",
-                "operation_mode": "read_only",
-                "brain_source": "surrealdb-local",
-                "brain_status": "not-used",
-            },
-        )
-        session_context = result["briefing"]["session_context"]
-        assert session_context["agent_operating_mode"]["db_claims_allowed"] is False
-
-    def test_repo_only_used_still_disables_db_claims(self) -> None:
-        """repo-only stays non-DB-backed even with a usable status string."""
-        bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.briefing",
-            {
-                "task_id": "cdb-briefing-repo-only-used",
-                "task_scope": "Validate repo-only used claim mode.",
-                "target_issue": "#2607",
-                "requested_depth": "quick",
-                "operation_mode": "read_only",
-                "brain_source": "repo-only",
                 "brain_status": "used",
             },
         )
         session_context = result["briefing"]["session_context"]
+        assert session_context["brain_source"] == "repo-only"
         assert session_context["brain_status"] == "not-used"
         assert session_context["agent_operating_mode"]["db_claims_allowed"] is False
-
-    def test_repo_only_used_status_is_coerced_to_not_used(self) -> None:
-        """repo-only cannot preserve an impossible used brain status."""
-        bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.briefing",
-            {
-                "task_id": "cdb-briefing-repo-only-coerced-status",
-                "task_scope": "Validate repo-only brain status coercion.",
-                "target_issue": "#2607",
-                "requested_depth": "quick",
-                "operation_mode": "read_only",
-                "brain_source": "repo-only",
-                "brain_status": "used",
-            },
-        )
-        session_context = result["briefing"]["session_context"]
-        assert session_context["brain_status"] == "not-used"
         assert any(
-            "coerced to not-used" in item for item in session_context["limitations"]
+            "caller input ignored" in item for item in session_context["limitations"]
         )
-
-    def test_unavailable_used_status_is_coerced_to_blocked(self) -> None:
-        """Unavailable brain source cannot preserve a usable brain status."""
-        bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.briefing",
-            {
-                "task_id": "cdb-briefing-unavailable-coerced-status",
-                "task_scope": "Validate unavailable brain status coercion.",
-                "target_issue": "#2607",
-                "requested_depth": "quick",
-                "operation_mode": "read_only",
-                "brain_source": "unavailable",
-                "brain_status": "used",
-            },
-        )
-        session_context = result["briefing"]["session_context"]
-        assert session_context["brain_status"] == "blocked"
-        assert session_context["agent_operating_mode"]["db_claims_allowed"] is False
-        assert any(
-            "coerced to blocked" in item for item in session_context["limitations"]
-        )
-
-    def test_malformed_brain_status_disables_db_claims(self) -> None:
-        """Malformed brain_status fail-closes DB-backed claims."""
-        bridge = create_bridge()
-        result = bridge.execute_tool(
-            "context.briefing",
-            {
-                "task_id": "cdb-briefing-bad-brain-status",
-                "task_scope": "Validate malformed brain_status claim mode.",
-                "target_issue": "#2607",
-                "requested_depth": "quick",
-                "operation_mode": "read_only",
-                "brain_source": "surrealdb-local",
-                "brain_status": "bad-status",
-            },
-        )
-        session_context = result["briefing"]["session_context"]
-        assert session_context["brain_status"] == "blocked"
-        assert session_context["agent_operating_mode"]["db_claims_allowed"] is False
 
     def test_repo_state_values_are_preserved_when_provided(self) -> None:
         """Caller-provided repo_state values are preserved."""
@@ -1816,8 +1788,8 @@ class TestContextBriefingHandler:
         )
         assert r1["briefing"]["briefing_id"] != r2["briefing"]["briefing_id"]
 
-    def test_brain_source_changes_briefing_id(self) -> None:
-        """Different brain_source values change briefing_id."""
+    def test_derived_brain_context_changes_briefing_id(self) -> None:
+        """Different derived brain contexts change briefing_id."""
         bridge = create_bridge()
         base = {
             "task_id": "cdb-briefing-hash-brain-source",
@@ -1826,11 +1798,15 @@ class TestContextBriefingHandler:
             "requested_depth": "quick",
             "operation_mode": "read_only",
         }
-        r1 = bridge.execute_tool(
-            "context.briefing", {**base, "brain_source": "repo-only"}
-        )
+        r1 = bridge.execute_tool("context.briefing", base)
         r2 = bridge.execute_tool(
-            "context.briefing", {**base, "brain_source": "in_memory"}
+            "context.briefing",
+            {
+                **base,
+                "memory_records": [
+                    {"memory_id": "mem-001", "scope": "wave14", "content": "test"}
+                ],
+            },
         )
         assert r1["briefing"]["briefing_id"] != r2["briefing"]["briefing_id"]
 
@@ -1897,8 +1873,6 @@ class TestContextBriefingHandler:
                 "related_prs": ["#2618"],
                 "open_epics": ["#2607"],
             },
-            "brain_source": "repo-only",
-            "brain_status": "not-used",
             "working_assumptions": ["assumption"],
             "limitations": ["limit", "limit"],
         }
@@ -1918,8 +1892,6 @@ class TestContextBriefingHandler:
                 "related_prs": ["#2618"],
                 "open_epics": ["#2607"],
             },
-            "brain_source": "repo-only",
-            "brain_status": "not-used",
             "working_assumptions": ["assumption"],
             "limitations": ["limit"],
         }
@@ -1981,8 +1953,6 @@ class TestContextBriefingHandler:
                 "target_issue": "#2607",
                 "requested_depth": "quick",
                 "operation_mode": "read_only",
-                "brain_source": "repo-only",
-                "brain_status": "not-used",
                 "repo_state": {
                     "branch": "fix/2613-noise-freeze-remaining-push-triggers",
                     "commit": "f345cf0c",
@@ -2285,8 +2255,8 @@ class TestContextBriefingHandler:
             assert "step" in step
             assert "method" in step
 
-    def test_missing_target_issue_returns_error(self) -> None:
-        """Missing target_issue key fails closed."""
+    def test_missing_target_issue_defaults_to_none(self) -> None:
+        """Missing target_issue key now defaults to null/None."""
         bridge = create_bridge()
         result = bridge.execute_tool(
             "context.briefing",
@@ -2297,8 +2267,11 @@ class TestContextBriefingHandler:
                 "operation_mode": "read_only",
             },
         )
-        assert result["status"] == "error"
-        assert result["error"]["code"] == "invalid_target_issue"
+        assert result["status"] == "ok"
+        assert (
+            result["briefing"]["session_context"]["github_state"]["target_issue"]
+            is None
+        )
 
     def test_target_issue_null_is_ok(self) -> None:
         """target_issue: null (None) is explicitly allowed."""
@@ -2315,8 +2288,8 @@ class TestContextBriefingHandler:
         )
         assert result["status"] == "ok"
 
-    def test_missing_requested_depth_returns_error(self) -> None:
-        """Missing requested_depth key fails closed."""
+    def test_missing_requested_depth_defaults_to_quick(self) -> None:
+        """Missing requested_depth now defaults to quick."""
         bridge = create_bridge()
         result = bridge.execute_tool(
             "context.briefing",
@@ -2327,8 +2300,21 @@ class TestContextBriefingHandler:
                 "operation_mode": "read_only",
             },
         )
-        assert result["status"] == "error"
-        assert result["error"]["code"] == "invalid_depth"
+        explicit_quick = bridge.execute_tool(
+            "context.briefing",
+            {
+                "task_id": "cdb-briefing-test",
+                "task_scope": "Test scope.",
+                "target_issue": None,
+                "requested_depth": "quick",
+                "operation_mode": "read_only",
+            },
+        )
+        assert result["status"] == "ok"
+        assert (
+            result["briefing"]["briefing_id"]
+            == explicit_quick["briefing"]["briefing_id"]
+        )
 
     def test_missing_operation_mode_returns_error(self) -> None:
         """Missing operation_mode key fails closed."""

--- a/tests/unit/tools/mcp/test_mcp_briefing_tool.py
+++ b/tests/unit/tools/mcp/test_mcp_briefing_tool.py
@@ -12,7 +12,6 @@ from tools.mcp.context_bridge import (
     cdb_context_briefing_handler,
 )
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -27,21 +26,37 @@ class TestContextBriefingHandler:
 
     def test_empty_task_id_returns_error(self) -> None:
         """Empty task_id fails closed."""
-        result = context_briefing_handler(task_id="", task_scope="test", target_issue=None, requested_depth="quick", operation_mode="read_only")
+        result = context_briefing_handler(
+            task_id="",
+            task_scope="test",
+            target_issue=None,
+            requested_depth="quick",
+            operation_mode="read_only",
+        )
         assert result["status"] == "error"
         assert result["error"]["code"] == "invalid_task_id"
 
     def test_missing_task_scope_returns_error(self) -> None:
         """Missing task_scope fails closed."""
-        result = context_briefing_handler(task_id="test-1", requested_depth="quick", operation_mode="read_only")
+        result = context_briefing_handler(
+            task_id="test-1", requested_depth="quick", operation_mode="read_only"
+        )
         assert result["status"] == "error"
         assert result["error"]["code"] == "invalid_task_scope"
 
-    def test_missing_target_issue_returns_error(self) -> None:
-        """Missing target_issue (not provided) fails closed."""
-        result = context_briefing_handler(task_id="test-1", task_scope="test", requested_depth="quick", operation_mode="read_only")
-        assert result["status"] == "error"
-        assert result["error"]["code"] == "invalid_target_issue"
+    def test_missing_target_issue_defaults_to_none(self) -> None:
+        """Missing target_issue defaults to None (optional field)."""
+        result = context_briefing_handler(
+            task_id="test-1",
+            task_scope="test",
+            requested_depth="quick",
+            operation_mode="read_only",
+        )
+        assert result["status"] == "ok"
+        assert (
+            result["briefing"]["session_context"]["github_state"]["target_issue"]
+            is None
+        )
 
     def test_valid_request_returns_ok(self) -> None:
         """Valid inputs produce ok status with briefing."""
@@ -164,10 +179,16 @@ class TestBriefingOutputStructure:
         )
         if result["status"] == "ok":
             briefing = result["briefing"]
-            required = {"briefing_id", "scope_summary", "human_go_required", "guardrails", "stop_conditions"}
-            assert required.issubset(briefing.keys()), (
-                f"Missing required fields: {required - set(briefing.keys())}"
-            )
+            required = {
+                "briefing_id",
+                "scope_summary",
+                "human_go_required",
+                "guardrails",
+                "stop_conditions",
+            }
+            assert required.issubset(
+                briefing.keys()
+            ), f"Missing required fields: {required - set(briefing.keys())}"
 
     def test_guardrails_non_empty(self) -> None:
         """Guardrails list is non-empty."""

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -1418,6 +1418,124 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
     }
 
 
+def _briefing_error_from_inner_result(
+    result: dict[str, Any],
+    *,
+    tool_name: str = "context.briefing",
+) -> dict[str, Any]:
+    """Project an inner MCP-style error result onto the briefing tool surface."""
+    error = result.get("error", {}) if isinstance(result, dict) else {}
+    projected: dict[str, Any] = {
+        "tool": tool_name,
+        "status": "error",
+        "error": {
+            "code": error.get("code", "execution_error"),
+            "message": error.get(
+                "message", "briefing DB-backed preflight failed unexpectedly"
+            ),
+        },
+    }
+    details = error.get("details")
+    if isinstance(details, dict):
+        projected["error"]["details"] = deepcopy(details)
+
+    metadata = result.get("metadata")
+    if isinstance(metadata, dict):
+        projected["metadata"] = deepcopy(metadata)
+    return projected
+
+
+def _has_non_empty_record_list(value: Any) -> bool:
+    return isinstance(value, list) and bool(value)
+
+
+def _derive_briefing_brain_context(
+    *,
+    adapter_config_path: Any,
+    secrets_path: Any,
+    enrichment_scope: str,
+    evidence_records: Any,
+    claim_records: Any,
+    decision_events: Any,
+    memory_records: Any,
+    caller_brain_source: Any,
+    caller_brain_status: Any,
+) -> tuple[str, str, list[str]] | dict[str, Any]:
+    """Derive briefing brain context from real reads or conservative fallbacks."""
+    limitations: list[str] = []
+
+    if caller_brain_source is not None:
+        limitations.append(
+            "brain_source caller input ignored; derived from actual context source"
+        )
+    if caller_brain_status is not None:
+        limitations.append(
+            "brain_status caller input ignored; derived from actual context source"
+        )
+
+    if adapter_config_path is not None:
+        from tools.mcp.context_evidence_memory_tools import (
+            handle_cdb_context_trust_summary,
+        )
+
+        trust_summary_request: dict[str, Any] = {
+            "tool": "cdb_context_trust_summary",
+            "parameters": {
+                "adapter_config_path": adapter_config_path,
+                "scope": enrichment_scope,
+            },
+        }
+        if secrets_path is not None:
+            trust_summary_request["parameters"]["secrets_path"] = secrets_path
+
+        trust_summary_result = handle_cdb_context_trust_summary(trust_summary_request)
+        if trust_summary_result.get("status") != "ok":
+            return _briefing_error_from_inner_result(trust_summary_result)
+
+        metadata = trust_summary_result.get("metadata", {})
+        source = metadata.get("source")
+        if source != "surrealdb-local":
+            return {
+                "tool": "context.briefing",
+                "status": "error",
+                "error": {
+                    "code": "adapter_unavailable",
+                    "message": (
+                        "DB-backed briefing requested, but the Wave-14 adapter did "
+                        f"not return source='surrealdb-local' (got {source!r})"
+                    ),
+                    "details": {
+                        "expected_source": "surrealdb-local",
+                        "actual_source": source,
+                    },
+                },
+                "metadata": deepcopy(metadata) if isinstance(metadata, dict) else {},
+            }
+
+        limitations.append(
+            "brain context derived from Wave-14 trust summary adapter metadata"
+        )
+        return "surrealdb-local", "used", limitations
+
+    if any(
+        (
+            _has_non_empty_record_list(evidence_records),
+            _has_non_empty_record_list(claim_records),
+            _has_non_empty_record_list(decision_events),
+            _has_non_empty_record_list(memory_records),
+        )
+    ):
+        limitations.append(
+            "brain context derived from inline enrichment records (in-memory)"
+        )
+        return "in_memory", "used", limitations
+
+    limitations.append(
+        "brain_source derived as repo-only; no DB-backed memory or evidence claims"
+    )
+    return "repo-only", "not-used", limitations
+
+
 def context_briefing_handler(**kwargs) -> dict[str, Any]:
     """
     Read-only handler for context.briefing tool.
@@ -1437,11 +1555,11 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
 
     _MISSING = object()
 
-    # --- Input extraction (no defaults for required fields) ---
+    # --- Input extraction (defaults only for optional briefing context) ---
     task_id = kwargs.get("task_id")
     task_scope = kwargs.get("task_scope")
-    target_issue = kwargs.get("target_issue", _MISSING)
-    requested_depth = kwargs.get("requested_depth", _MISSING)
+    target_issue = kwargs.get("target_issue", None)
+    requested_depth = kwargs.get("requested_depth", "quick")
     operation_mode = kwargs.get("operation_mode", _MISSING)
     target_paths = kwargs.get("target_paths", [])
     target_symbols = kwargs.get("target_symbols", [])
@@ -1455,6 +1573,8 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
     _decision_events_raw = kwargs.get("decision_events")
     _memory_records_raw = kwargs.get("memory_records")
     _enrichment_scope = kwargs.get("enrichment_scope", "wave14")
+    _adapter_config_path = kwargs.get("adapter_config_path")
+    _secrets_path = kwargs.get("secrets_path")
     _repo_state_raw = kwargs.get("repo_state")
     _github_state_raw = kwargs.get("github_state")
     _brain_source_raw = kwargs.get("brain_source")
@@ -1487,16 +1607,6 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
             },
         }
 
-    if target_issue is _MISSING:
-        return {
-            "tool": "context.briefing",
-            "status": "error",
-            "error": {
-                "code": "invalid_target_issue",
-                "message": "target_issue is required (must be a string or null)",
-            },
-        }
-
     if target_issue is not None and not isinstance(target_issue, str):
         return {
             "tool": "context.briefing",
@@ -1504,16 +1614,6 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
             "error": {
                 "code": "invalid_target_issue",
                 "message": "target_issue must be a string or null",
-            },
-        }
-
-    if requested_depth is _MISSING:
-        return {
-            "tool": "context.briefing",
-            "status": "error",
-            "error": {
-                "code": "invalid_depth",
-                "message": "requested_depth is required",
             },
         }
 
@@ -1567,59 +1667,23 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
     if risk_level not in frozenset({"low", "medium", "high"}):
         risk_level = "medium"
 
-    valid_brain_sources = frozenset(
-        {
-            "repo-only",
-            "in_memory",
-            "surrealdb-local",
-            "unavailable",
-        }
-    )
-    valid_brain_statuses = frozenset({"used", "partial", "not-used", "blocked"})
     valid_working_tree_states = frozenset({"clean", "dirty", "unknown"})
     session_context_limitations: list[str] = []
-
-    if isinstance(_brain_source_raw, str) and _brain_source_raw in valid_brain_sources:
-        brain_source = _brain_source_raw
-    else:
-        brain_source = "repo-only"
-        if _brain_source_raw is not None:
-            session_context_limitations.append(
-                "brain_source malformed; defaulted to repo-only"
-            )
-        else:
-            session_context_limitations.append(
-                "brain_source not provided; defaulted to repo-only"
-            )
-
-    if isinstance(_brain_status_raw, str) and _brain_status_raw in valid_brain_statuses:
-        brain_status = _brain_status_raw
-    else:
-        brain_status = "not-used" if brain_source == "repo-only" else "blocked"
-        if _brain_status_raw is not None:
-            session_context_limitations.append(
-                "brain_status malformed; defaulted conservatively"
-            )
-        else:
-            session_context_limitations.append(
-                "brain_status not provided; defaulted conservatively"
-            )
-
-    if brain_source == "repo-only" and brain_status != "not-used":
-        brain_status = "not-used"
-        session_context_limitations.append(
-            "repo-only brain source cannot advertise used or partial brain status; coerced to not-used"
-        )
-    elif brain_source == "unavailable" and brain_status != "blocked":
-        brain_status = "blocked"
-        session_context_limitations.append(
-            "unavailable brain source cannot advertise usable brain status; coerced to blocked"
-        )
-
-    if brain_source == "repo-only":
-        session_context_limitations.append(
-            "repo-only brain source; no DB-backed memory or evidence claims"
-        )
+    brain_context = _derive_briefing_brain_context(
+        adapter_config_path=_adapter_config_path,
+        secrets_path=_secrets_path,
+        enrichment_scope=_enrichment_scope,
+        evidence_records=_evidence_records_raw,
+        claim_records=_claim_records_raw,
+        decision_events=_decision_events_raw,
+        memory_records=_memory_records_raw,
+        caller_brain_source=_brain_source_raw,
+        caller_brain_status=_brain_status_raw,
+    )
+    if isinstance(brain_context, dict):
+        return brain_context
+    brain_source, brain_status, derived_brain_limitations = brain_context
+    session_context_limitations.extend(derived_brain_limitations)
 
     repo_state = {
         "branch": "unknown",
@@ -2025,19 +2089,29 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
     )
 
     if not _has_records:
-        # Fail-closed: no records provided — controlled-empty enrichment
-        missing_evidence_notice = [
-            "no_evidence_records_provided",
-            "no_decision_events_provided",
-        ]
-        trust_summary = (
-            "Enrichment skipped: no evidence_records, claim_records, decision_events, "
-            "or memory_records provided. Supply records to enable evidence/decision enrichment."
-        )
-        stop_conditions.append(
-            "S5: no enrichment records provided — supply evidence_records, claim_records, "
-            "decision_events, or memory_records to enable enrichment"
-        )
+        if brain_source == "surrealdb-local":
+            trust_summary = (
+                "DB-backed session context established via Wave-14 trust summary. "
+                "Artifact enrichment skipped because no inline enrichment records "
+                "were provided to context.briefing."
+            )
+            recommended_next_reads_enrichment.append(
+                "Provide inline enrichment records if artifact-level enrichment is required in the briefing payload"
+            )
+        else:
+            # Fail-closed: no records provided — controlled-empty enrichment
+            missing_evidence_notice = [
+                "no_evidence_records_provided",
+                "no_decision_events_provided",
+            ]
+            trust_summary = (
+                "Enrichment skipped: no evidence_records, claim_records, decision_events, "
+                "or memory_records provided. Supply records to enable evidence/decision enrichment."
+            )
+            stop_conditions.append(
+                "S5: no enrichment records provided — supply evidence_records, claim_records, "
+                "decision_events, or memory_records to enable enrichment"
+            )
     else:
         # Real enrichment using Wave-14 services (#2122)
         # Read-only, fail-closed, no DB/network/write.


### PR DESCRIPTION
## Summary

Implements #2605 Slice-6 by deriving context.briefing Brain Evidence from real local context reads instead of caller-supplied claims.

## What changed

- Adds briefing brain-context derivation from the existing Wave-14 read path.
- Allows context.briefing to prove rain_source=surrealdb-local only when real adapter metadata supports it.
- Prevents caller-supplied rain_source / rain_status from faking DB-backed memory readiness.
- Keeps fallback behavior conservative: no DB claim without real local DB evidence.
- Updates tests and runbook documentation for the new behavior.

## Real DB proof

A local read-only SurrealDB smoke passed through the OpenCode/CDB path:

- rain_source: surrealdb-local
- rain_status: used
- db_claims_allowed: True

Secrets were not printed and were not committed. Local secrets remain outside the repository.

## Validation

- pytest -v tests/unit/tools/mcp/test_context_bridge.py -- 248/248 passed
- pytest -v tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py -- 23/23 passed
- pytest -v tests/unit/tools/mcp/test_permission_guard.py -k "briefing or memory or read_only or forbidden" -- 94/94 selected passed
- uff check -- pass
- lack --check -- pass
- Real SurrealDB smoke -- pass

## Safety

- Read-only MCP behavior only.
- No DB writes.
- No secret files committed.
- No Live-Readiness change.
- No Echtgeld / no live trading / no runtime activation.
- LR remains NO-GO.

## Issue

Refs #2605. Slice-6 only. #2605 remains open.
