### PR TITLE
fix(mcp): add Cursor project MCP config for cdb_context

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "cdb_context": {
+      "enabled": true,
+      "command": ".venv/Scripts/python.exe",
+      "args": ["-m", "tools.mcp.server"],
+      "type": "stdio"
+    },
+    "redis": {
+      "enabled": false,
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-redis"],
+      "env": {
+        "REDIS_PORT": "6379",
+        "REDIS_HOST": "127.0.0.1"
+      },
+      "type": "stdio"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Refs #2641 — minimal branch sync after #2638/#2639 landed on main.

This PR adds **only** the Cursor project MCP configuration for cdb_context L5 (.cursor/mcp.json).

### Branch strategy

- New clean branch eat/2605-mcp-l5-from-main from origin/main (4885b22)
- Cherry-pick of 65430d3e → 906a3e8e (no full rebase of legacy eat/2605-readonly-context-mcp-slice-4 commits)
- **No** old HOLD worktree WIP applied (stash 2641-pre-sync-hold not popped)

### Scope

| Included | Excluded |
|----------|----------|
| .cursor/mcp.json (cdb_context L5, redis disabled) | Prior 7-file HOLD set (runbook, tests, adapter/tools WIP) |
| | .cursor/settings.json (local-only, untracked) |

### Evidence

- **Tests:** pytest -q tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py tests/unit/tools/mcp/test_context_bridge.py -m unit — **296 passed** (post-sync; reported, not re-run in PR prep)
- **MCP L5:** context.briefing OK (cdb-2641-post-sync, cdb-2641-pr-prep)
- **LR:** NO-GO unchanged — no live trading / Echtgeld scope

## Test plan

- [ ] CI unit/integration + policy-gate
- [ ] Cursor MCP panel: cdb_context connected after checkout
- [ ] Optional: context.briefing smoke with read_only payload