### PR TITLE
chore(gitignore): ignore local Cursor IDE settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ Claire_de_Binare_Docs/
 .cdb_local/
 
 # AI tooling local state
+.cursor/settings.json
 .claude_settings.json
 .claude/
 .gemini/


### PR DESCRIPTION
## Summary

Exclude per-developer `.cursor/settings.json` from the worktree while keeping committed `.cursor/mcp.json` as the shared project MCP config.

Follow-up hygiene after #2641 / #2647.

## Test plan

- [ ] CI + policy-gate
- [ ] `git status` no longer shows `?? .cursor/settings.json` when file exists locally