### PR TITLE
test(wave14): add SurrealDB record and query contract tests

### DIFF
--- a/tests/unit/surrealdb/test_wave14_context_record_schemas.py
+++ b/tests/unit/surrealdb/test_wave14_context_record_schemas.py
@@ -1,0 +1,201 @@
+"""Wave-14 SurrealDB context record schema contract tests (#2643)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.surrealdb import wave14_contract_constants as contracts
+from tools.mcp.context_evidence_memory_tools import (
+    _normalize_claim_row,
+    _normalize_evidence_ref_row,
+    _normalize_memory_row,
+)
+from tools.surrealdb.context_importer import TABLE_BY_ARTIFACT
+from tools.surrealdb.decision_history_query import (
+    DecisionHistoryQueryRequest,
+    _normalize_decision,
+    query_decision_history_v1,
+)
+
+
+@pytest.fixture(scope="module")
+def surql_text() -> str:
+    return contracts.load_surql_text()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("table", contracts.WAVE14_TABLES)
+def test_surql_defines_wave14_table_and_pk_field(surql_text: str, table: str) -> None:
+    assert f"DEFINE TABLE {table} SCHEMAFULL;" in surql_text
+    pk_field = contracts.WAVE14_PK_FIELDS[table]
+    assert f"DEFINE FIELD {pk_field} ON TABLE {table}" in surql_text
+    assert f"ON TABLE {table} FIELDS {pk_field} UNIQUE" in surql_text
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("table", contracts.WAVE14_TABLES)
+def test_surql_declares_created_at_for_wave14_tables(
+    surql_text: str, table: str
+) -> None:
+    fields = contracts.parse_surql_table_fields(surql_text, table)
+    assert "created_at" in fields
+    for required in contracts.SURQL_REQUIRED_DRAFT_FIELDS[table]:
+        assert required in fields
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("artifact", "table"),
+    [(artifact, TABLE_BY_ARTIFACT[artifact]) for artifact in contracts.WAVE14_JSONL_ARTIFACTS],
+)
+def test_jsonl_required_fields_map_to_surql_columns(
+    surql_text: str, artifact: str, table: str
+) -> None:
+    surql_fields = contracts.parse_surql_table_fields(surql_text, table)
+    jsonl_required = contracts.WAVE14_JSONL_REQUIRED[artifact]
+    record_fields = jsonl_required - contracts.JSONL_ENVELOPE_FIELDS
+    missing = record_fields - surql_fields
+    assert not missing, f"{artifact} JSONL fields missing from {table} surql: {sorted(missing)}"
+
+
+@pytest.mark.unit
+def test_evidence_ref_normalization_aliases() -> None:
+    row = {
+        "evidence_id": "ev-schema-001",
+        "validates": ["claim-001"],
+        "related_artifacts": ["tools/surrealdb/evidence_lookup.py"],
+        "related_decisions": ["dec-001"],
+        "source_path": "tests/unit/test_foo.py",
+    }
+    normalized = _normalize_evidence_ref_row(row)
+
+    for schema_field, contract_field in contracts.EVIDENCE_SCHEMA_TO_LOOKUP_ALIASES.items():
+        if schema_field == "source_path":
+            assert normalized[contract_field] == [row[schema_field]]
+        else:
+            assert normalized[contract_field] == row[schema_field]
+
+    assert normalized["claim_refs"] == row["validates"]
+    assert normalized["artifact_refs"] == row["related_artifacts"]
+
+
+@pytest.mark.unit
+def test_evidence_ref_normalization_preserves_existing_contract_fields() -> None:
+    row = {
+        "evidence_id": "ev-fixture-001",
+        "claim_refs": ["claim-preexisting"],
+        "artifact_refs": ["tools/mcp/context_bridge.py"],
+        "decision_refs": [],
+        "source_refs": ["docs/example.md"],
+    }
+    normalized = _normalize_evidence_ref_row(row)
+    assert normalized["claim_refs"] == ["claim-preexisting"]
+    assert normalized["artifact_refs"] == ["tools/mcp/context_bridge.py"]
+    assert normalized["source_refs"] == ["docs/example.md"]
+
+
+@pytest.mark.unit
+def test_claim_normalization_adds_resolver_defaults() -> None:
+    row = {
+        "claim_id": "claim-schema-001",
+        "title": "Schema claim",
+        "statement": "read-only",
+        "scope": "wave14",
+        "status": "supported",
+        "evidence_refs": ["ev-001"],
+    }
+    normalized = _normalize_claim_row(row)
+    for field in contracts.CLAIM_SCHEMA_DEFAULTS:
+        assert field in normalized
+    assert normalized["topics"] == []
+    assert normalized["topic"] is None
+    assert normalized["artifact_refs"] == []
+    assert normalized["decision_refs"] == []
+
+
+@pytest.mark.unit
+def test_memory_normalization_maps_schema_aliases() -> None:
+    row = {
+        "memory_id": "mem-schema-001",
+        "scope": "wave14",
+        "namespace": "session",
+        "memory_type": "constraint",
+        "content": "read-only MCP",
+        "created_by": "agent-test-001",
+        "ttl": 7,
+    }
+    normalized = _normalize_memory_row(row)
+    assert normalized["agent"] == "agent-test-001"
+    assert normalized["ttl_days"] == 7
+    for field in contracts.MEMORY_SCHEMA_DEFAULTS:
+        assert field in normalized
+
+
+@pytest.mark.unit
+def test_memory_normalization_uses_scope_when_created_by_missing() -> None:
+    row = {
+        "memory_id": "mem-scope-fallback",
+        "scope": "wave14",
+        "memory_type": "note",
+        "content": "fallback agent",
+    }
+    normalized = _normalize_memory_row(row)
+    assert normalized["agent"] == "wave14"
+
+
+@pytest.mark.unit
+def test_decision_event_normalization_shape() -> None:
+    raw = {
+        "decision_id": "dec-schema-001",
+        "title": "Schema decision",
+        "question": "Use scope filter?",
+        "answer": "Yes",
+        "decision_type": "implementation",
+        "status": "accepted",
+        "scope": "wave14",
+        "evidence_refs": ["ev-001"],
+        "claim_refs": ["claim-001"],
+        "affected_artifacts": ["tools/mcp/context_decision_tools.py"],
+        "agent": "codex",
+        "human_go": False,
+        "created_at": "2026-05-25T00:00:00Z",
+    }
+    normalized = _normalize_decision(raw)
+    assert contracts.DECISION_EVENT_NORMALIZED_KEYS <= frozenset(normalized.keys())
+    assert normalized["decision_id"] == "dec-schema-001"
+    assert normalized["human_go"] is False
+    assert normalized["created_at"] == "2026-05-25T00:00:00+00:00"
+
+
+@pytest.mark.unit
+def test_decision_event_null_and_empty_fields_do_not_crash_history_query() -> None:
+    events = [
+        {
+            "decision_id": "dec-empty-001",
+            "title": None,
+            "question": "",
+            "answer": None,
+            "decision_type": "",
+            "status": "accepted",
+            "scope": "wave14",
+            "evidence_refs": [],
+            "claim_refs": None,
+            "affected_artifacts": [],
+            "agent": None,
+            "human_go": None,
+            "created_at": None,
+        }
+    ]
+    result = query_decision_history_v1(
+        events,
+        DecisionHistoryQueryRequest(mode="by_scope", scope="wave14"),
+    )
+    assert result["schema_version"] == contracts.SERVICE_SCHEMA_VERSIONS[
+        "cdb_context_decision_history"
+    ]
+    assert len(result["matched_decisions"]) == 1
+    decision = result["matched_decisions"][0]
+    assert decision["decision_id"] == "dec-empty-001"
+    assert decision["title"] == ""
+    assert decision["evidence_refs"] == []
+    assert decision["claim_refs"] == []

--- a/tests/unit/surrealdb/wave14_contract_constants.py
+++ b/tests/unit/surrealdb/wave14_contract_constants.py
@@ -1,0 +1,241 @@
+"""Test-local Wave-14 SurrealDB record and MCP query contract constants (#2643).
+
+Not a runtime surface — consumed only by Wave-14 contract tests.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tools.surrealdb.context_importer import (
+    ID_FIELD_BY_ARTIFACT,
+    REQUIRED_JSONL_FIELDS,
+    TABLE_BY_ARTIFACT,
+)
+
+SURQL_PATH = Path("infrastructure/surrealdb/context_intelligence_v0.surql")
+
+WAVE14_JSONL_ARTIFACTS: tuple[str, ...] = (
+    "evidence_refs",
+    "claims",
+    "decision_events",
+    "agent_memories",
+)
+
+WAVE14_TABLES: tuple[str, ...] = tuple(
+    TABLE_BY_ARTIFACT[artifact] for artifact in WAVE14_JSONL_ARTIFACTS
+)
+
+WAVE14_PK_FIELDS: dict[str, str] = {
+    TABLE_BY_ARTIFACT[artifact]: ID_FIELD_BY_ARTIFACT[artifact]
+    for artifact in WAVE14_JSONL_ARTIFACTS
+}
+
+WAVE14_JSONL_REQUIRED: dict[str, frozenset[str]] = {
+    artifact: REQUIRED_JSONL_FIELDS[artifact] for artifact in WAVE14_JSONL_ARTIFACTS
+}
+
+# Indexer envelope fields are required in JSONL but not stored as Surreal columns.
+JSONL_ENVELOPE_FIELDS: frozenset[str] = frozenset({"schema_version", "run_id"})
+
+# Schema draft marks these stable-id + created_at fields as REQUIRED(v0-draft).
+SURQL_REQUIRED_DRAFT_FIELDS: dict[str, frozenset[str]] = {
+    "evidence_ref": frozenset({"evidence_id", "created_at"}),
+    "claim": frozenset({"claim_id", "created_at"}),
+    "decision_event": frozenset({"decision_id", "created_at"}),
+    "agent_memory": frozenset({"memory_id", "created_at"}),
+}
+
+EVIDENCE_SCHEMA_TO_LOOKUP_ALIASES: dict[str, str] = {
+    "validates": "claim_refs",
+    "related_artifacts": "artifact_refs",
+    "related_decisions": "decision_refs",
+    "source_path": "source_refs",
+}
+
+CLAIM_SCHEMA_DEFAULTS: frozenset[str] = frozenset(
+    {"topics", "topic", "artifact_refs", "decision_refs"}
+)
+
+MEMORY_SCHEMA_TO_READER_ALIASES: dict[str, str] = {
+    "created_by": "agent",
+    "ttl": "ttl_days",
+}
+
+MEMORY_SCHEMA_DEFAULTS: frozenset[str] = frozenset(
+    {"topic", "topics", "artifact_refs", "decision_refs"}
+)
+
+DECISION_EVENT_NORMALIZED_KEYS: frozenset[str] = frozenset(
+    {
+        "decision_id",
+        "title",
+        "question",
+        "answer",
+        "decision_type",
+        "status",
+        "scope",
+        "topics",
+        "issue_refs",
+        "evidence_refs",
+        "claim_refs",
+        "affected_artifacts",
+        "agent",
+        "human_go",
+        "human_go_note",
+        "superseded_by",
+        "invalidated_by",
+        "uncertainty",
+        "comment",
+        "created_at",
+    }
+)
+
+MCP_OK_ENVELOPE_KEYS: frozenset[str] = frozenset({"tool", "status", "result", "metadata"})
+MCP_ERROR_ENVELOPE_KEYS: frozenset[str] = frozenset({"tool", "status", "error", "metadata"})
+MCP_METADATA_KEYS: frozenset[str] = frozenset({"query_time_ms", "source", "read_only"})
+ALLOWED_MCP_SOURCES: frozenset[str] = frozenset(
+    {"in_memory", "surrealdb-local", "surrealdb-local-unavailable"}
+)
+
+SERVICE_SCHEMA_VERSIONS: dict[str, str] = {
+    "cdb_context_evidence_resolve": "evidence-lookup/v1",
+    "cdb_context_claim_resolve": "claim-resolver/v1",
+    "cdb_context_memory_get": "memory-read/v1",
+    "cdb_context_trust_summary": "trust-summary/v1",
+    "cdb_context_decision_history": "decision-history-query/v1",
+    "cdb_context_decision_replay": "decision-replay-query/v1",
+}
+
+WAVE14_QUERY_RESULT_KEYS: dict[str, frozenset[str]] = {
+    "cdb_context_evidence_resolve": frozenset(
+        {
+            "schema_version",
+            "query",
+            "mode",
+            "matched_evidence",
+            "evidence_by_strength",
+            "stale_evidence_ids",
+            "blocking_missing_ids",
+            "evidence_summary",
+            "warnings",
+            "approval_semantics",
+        }
+    ),
+    "cdb_context_claim_resolve": frozenset(
+        {
+            "schema_version",
+            "query",
+            "mode",
+            "matched_claims",
+            "disputed_claim_ids",
+            "stale_claim_ids",
+            "invalidated_claim_ids",
+            "missing_evidence_claim_ids",
+            "all_evidence_refs",
+            "unresolved_evidence_refs",
+            "confidence_summary",
+            "status_counts",
+            "warnings",
+            "approval_semantics",
+        }
+    ),
+    "cdb_context_memory_get": frozenset(
+        {
+            "schema_version",
+            "query",
+            "mode",
+            "matched_memory",
+            "stale_memory_ids",
+            "superseded_memory_ids",
+            "trust_counts",
+            "memory_summary",
+            "warnings",
+            "approval_semantics",
+        }
+    ),
+    "cdb_context_trust_summary": frozenset(
+        {
+            "schema_version",
+            "scope",
+            "topic",
+            "artifact",
+            "trust_level",
+            "composite_score",
+            "evidence_strength",
+            "evidence_strength_score",
+            "claim_status_summary",
+            "claim_score",
+            "decision_currentness",
+            "decision_score",
+            "memory_trust_summary",
+            "memory_score",
+            "stale_flags",
+            "disputed_flags",
+            "missing_evidence",
+            "blocking_trust_findings",
+            "recommended_next_reads",
+            "confidence_summary",
+            "warnings",
+            "approval_semantics",
+        }
+    ),
+    "cdb_context_decision_history": frozenset(
+        {
+            "schema_version",
+            "query",
+            "mode",
+            "matched_decisions",
+            "current_decisions",
+            "superseded_decisions",
+            "invalidated_decisions",
+            "decision_chain",
+            "evidence_refs",
+            "claim_refs",
+            "unresolved_evidence_refs",
+            "unresolved_claim_refs",
+            "uncertainty",
+            "human_go",
+            "warnings",
+            "approval_semantics",
+        }
+    ),
+    "cdb_context_decision_replay": frozenset(
+        {
+            "schema_version",
+            "query",
+            "decision_summary",
+            "current_status",
+            "old_decisions",
+            "current_decisions",
+            "superseded_decisions",
+            "invalidated_decisions",
+            "decision_chain",
+            "evidence_chain",
+            "claim_chain",
+            "supersession_chain",
+            "uncertainty",
+            "stop_conditions",
+            "human_go",
+            "warnings",
+            "approval_semantics",
+        }
+    ),
+}
+
+_FIELD_RE = re.compile(r"^DEFINE FIELD (\w+) ON TABLE (\w+) ", re.MULTILINE)
+
+
+def parse_surql_table_fields(surql_text: str, table: str) -> frozenset[str]:
+    """Return all DEFINE FIELD names declared for *table* in the schema draft."""
+    fields = {
+        match.group(1)
+        for match in _FIELD_RE.finditer(surql_text)
+        if match.group(2) == table
+    }
+    return frozenset(fields)
+
+
+def load_surql_text(path: Path = SURQL_PATH) -> str:
+    return path.read_text(encoding="utf-8")

--- a/tests/unit/tools/mcp/test_wave14_query_contracts.py
+++ b/tests/unit/tools/mcp/test_wave14_query_contracts.py
@@ -1,0 +1,385 @@
+"""Wave-14 MCP query return contract tests (#2643)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.unit.surrealdb import wave14_contract_constants as contracts
+from tools.mcp.context_decision_tools import (
+    TOOL_CDB_CONTEXT_DECISION_HISTORY,
+    TOOL_CDB_CONTEXT_DECISION_REPLAY,
+    handle_cdb_context_decision_history,
+    handle_cdb_context_decision_replay,
+)
+from tools.mcp.context_evidence_memory_tools import (
+    TOOL_CDB_CONTEXT_CLAIM_RESOLVE,
+    TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+    TOOL_CDB_CONTEXT_MEMORY_GET,
+    TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+    handle_cdb_context_claim_resolve,
+    handle_cdb_context_evidence_resolve,
+    handle_cdb_context_memory_get,
+    handle_cdb_context_trust_summary,
+)
+from tools.surrealdb.context_query import QueryAdapter
+
+FIXTURE_PATH = Path("tests/fixtures/surrealdb/wave14/wave14_v1.json")
+_FAKE_CONFIG_PATH = "infrastructure/config/surrealdb/context_query.local.example.yaml"
+_DECISION_FIXTURE_RECORDS: list[dict[str, Any]] = [
+    {
+        "decision_id": "dec-001",
+        "title": "Wave-14 stop resolver gate",
+        "question": "Is context_stop_resolver fail-closed?",
+        "answer": "Yes — incomplete inputs block.",
+        "decision_type": "architectural",
+        "status": "approved",
+        "scope": "wave14",
+        "topic": "context_tools",
+        "topics": ["context_tools", "stop_conditions"],
+        "evidence_refs": ["ev-001"],
+        "claim_refs": ["claim-001"],
+        "affected_artifacts": ["tools/surrealdb/context_stop_resolver.py"],
+        "agent": "copilot",
+        "human_go": False,
+        "created_at": "2024-11-01T12:30:00Z",
+    },
+    {
+        "decision_id": "dec-002",
+        "title": "Decision history determinism gate",
+        "question": "Is decision history deterministic?",
+        "answer": "Yes for identical inputs.",
+        "decision_type": "implementation",
+        "status": "approved",
+        "scope": "wave14",
+        "topic": "context_tools",
+        "topics": ["context_tools", "decision_history"],
+        "evidence_refs": ["ev-002"],
+        "claim_refs": ["claim-002"],
+        "affected_artifacts": ["tools/surrealdb/decision_history_query.py"],
+        "agent": "codex",
+        "human_go": False,
+        "created_at": "2024-11-02T12:30:00Z",
+    },
+]
+_FORGED_DB_CLAIM_FIELDS: dict[str, Any] = {
+    "source": "surrealdb-local",
+    "brain_source": "surrealdb-local",
+    "brain_status": "used",
+    "metadata": {"source": "surrealdb-local"},
+}
+
+_WAVE14_HANDLERS: dict[str, Any] = {
+    TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE: handle_cdb_context_evidence_resolve,
+    TOOL_CDB_CONTEXT_CLAIM_RESOLVE: handle_cdb_context_claim_resolve,
+    TOOL_CDB_CONTEXT_MEMORY_GET: handle_cdb_context_memory_get,
+    TOOL_CDB_CONTEXT_TRUST_SUMMARY: handle_cdb_context_trust_summary,
+    TOOL_CDB_CONTEXT_DECISION_HISTORY: handle_cdb_context_decision_history,
+    TOOL_CDB_CONTEXT_DECISION_REPLAY: handle_cdb_context_decision_replay,
+}
+
+
+def _load_fixture() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _assert_mcp_ok_envelope(payload: dict[str, Any], *, tool: str) -> None:
+    assert contracts.MCP_OK_ENVELOPE_KEYS <= frozenset(payload.keys())
+    assert payload["tool"] == tool
+    assert payload["status"] == "ok"
+    assert isinstance(payload["result"], dict)
+    assert contracts.MCP_METADATA_KEYS <= frozenset(payload["metadata"].keys())
+    assert payload["metadata"]["read_only"] is True
+    assert payload["metadata"]["source"] in contracts.ALLOWED_MCP_SOURCES
+    assert isinstance(payload["metadata"]["query_time_ms"], int)
+
+
+def _assert_mcp_error_envelope(payload: dict[str, Any], *, tool: str) -> None:
+    assert contracts.MCP_ERROR_ENVELOPE_KEYS <= frozenset(payload.keys())
+    assert payload["tool"] == tool
+    assert payload["status"] == "error"
+    assert "code" in payload["error"]
+    assert "message" in payload["error"]
+    assert contracts.MCP_METADATA_KEYS <= frozenset(payload["metadata"].keys())
+    assert payload["metadata"]["read_only"] is True
+    assert payload["metadata"]["source"] in contracts.ALLOWED_MCP_SOURCES
+
+
+def _in_memory_parameters(tool: str, fx: dict[str, Any]) -> dict[str, Any]:
+    if tool == TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE:
+        return {
+            "mode": "by_artifact",
+            "artifact": "tools/surrealdb/context_stop_resolver.py",
+            "evidence_records": fx["evidence_records"],
+        }
+    if tool == TOOL_CDB_CONTEXT_CLAIM_RESOLVE:
+        return {
+            "mode": "by_topic",
+            "topic": "stop_conditions",
+            "claim_records": fx["claim_records"],
+        }
+    if tool == TOOL_CDB_CONTEXT_MEMORY_GET:
+        return {
+            "mode": "by_scope",
+            "scope": "wave14",
+            "memory_records": fx["memory_records"],
+        }
+    if tool == TOOL_CDB_CONTEXT_TRUST_SUMMARY:
+        return {"scope": "wave14", "topic": "context_tools"}
+    if tool == TOOL_CDB_CONTEXT_DECISION_HISTORY:
+        return {
+            "mode": "by_topic",
+            "topic": "context_tools",
+            "decision_events": _DECISION_FIXTURE_RECORDS,
+        }
+    if tool == TOOL_CDB_CONTEXT_DECISION_REPLAY:
+        return {
+            "mode": "replay_by_scope",
+            "scope": "wave14",
+            "decision_events": _DECISION_FIXTURE_RECORDS,
+        }
+    raise AssertionError(f"Unhandled Wave-14 tool: {tool}")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("tool", list(contracts.WAVE14_QUERY_RESULT_KEYS.keys()))
+def test_wave14_ok_response_matches_query_contract(tool: str) -> None:
+    fx = _load_fixture()
+    handler = _WAVE14_HANDLERS[tool]
+    result = handler({"tool": tool, "parameters": _in_memory_parameters(tool, fx)})
+
+    _assert_mcp_ok_envelope(result, tool=tool)
+    expected_keys = contracts.WAVE14_QUERY_RESULT_KEYS[tool]
+    missing = expected_keys - frozenset(result["result"].keys())
+    assert not missing, f"{tool} missing result keys: {sorted(missing)}"
+
+    if "schema_version" in result["result"]:
+        assert result["result"]["schema_version"] == contracts.SERVICE_SCHEMA_VERSIONS[tool]
+
+    semantics = result["result"].get("approval_semantics") or {}
+    assert semantics.get("no_echtgeld_go") is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("tool", "missing_key", "error_code"),
+    [
+        (TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE, "evidence_records", "missing_evidence_records"),
+        (TOOL_CDB_CONTEXT_CLAIM_RESOLVE, "claim_records", "missing_claim_records"),
+        (TOOL_CDB_CONTEXT_MEMORY_GET, "memory_records", "missing_memory_records"),
+        (TOOL_CDB_CONTEXT_DECISION_HISTORY, "decision_events", "missing_decision_events"),
+        (TOOL_CDB_CONTEXT_DECISION_REPLAY, "decision_events", "missing_decision_events"),
+    ],
+)
+def test_wave14_missing_record_lists_fail_closed(
+    tool: str, missing_key: str, error_code: str
+) -> None:
+    handler = _WAVE14_HANDLERS[tool]
+    params = {"mode": "by_scope", "scope": "wave14"}
+    if tool == TOOL_CDB_CONTEXT_CLAIM_RESOLVE:
+        params = {"mode": "by_topic", "topic": "x"}
+    if tool == TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE:
+        params = {"mode": "by_artifact", "artifact": "some/path"}
+    if tool in {TOOL_CDB_CONTEXT_DECISION_HISTORY, TOOL_CDB_CONTEXT_DECISION_REPLAY}:
+        params = {"mode": "by_topic", "topic": "context_tools"}
+
+    result = handler({"tool": tool, "parameters": params})
+    _assert_mcp_error_envelope(result, tool=tool)
+    assert result["error"]["code"] == error_code
+
+
+@pytest.mark.unit
+def test_trust_summary_missing_scope_is_structured_error() -> None:
+    result = handle_cdb_context_trust_summary(
+        {"tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY, "parameters": {}}
+    )
+    _assert_mcp_error_envelope(result, tool=TOOL_CDB_CONTEXT_TRUST_SUMMARY)
+    assert result["error"]["code"] == "missing_scope"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("tool", list(contracts.WAVE14_QUERY_RESULT_KEYS.keys()))
+def test_wave14_wrong_tool_name_returns_invalid_tool(tool: str) -> None:
+    handler = _WAVE14_HANDLERS[tool]
+    result = handler({"tool": "wrong_tool", "parameters": {}})
+    _assert_mcp_error_envelope(result, tool=tool)
+    assert result["error"]["code"] == "invalid_tool"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("tool", "records_key"),
+    [
+        (TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE, "evidence_records"),
+        (TOOL_CDB_CONTEXT_CLAIM_RESOLVE, "claim_records"),
+        (TOOL_CDB_CONTEXT_MEMORY_GET, "memory_records"),
+        (TOOL_CDB_CONTEXT_DECISION_HISTORY, "decision_events"),
+        (TOOL_CDB_CONTEXT_DECISION_REPLAY, "decision_events"),
+    ],
+)
+def test_wave14_malformed_record_list_returns_error(tool: str, records_key: str) -> None:
+    handler = _WAVE14_HANDLERS[tool]
+    result = handler(
+        {
+            "tool": tool,
+            "parameters": {
+                "mode": "by_scope",
+                "scope": "wave14",
+                records_key: ["not-a-mapping"],
+            },
+        }
+    )
+    _assert_mcp_error_envelope(result, tool=tool)
+    assert result["error"]["code"] == f"missing_{records_key}"
+
+
+@pytest.mark.unit
+def test_evidence_resolve_empty_match_is_ok_with_warning_not_fake_success() -> None:
+    fx = _load_fixture()
+    result = handle_cdb_context_evidence_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                "mode": "by_run_id",
+                "run_id": "run-does-not-exist",
+                "evidence_records": fx["evidence_records"],
+            },
+        }
+    )
+    _assert_mcp_ok_envelope(result, tool=TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE)
+    assert result["result"]["matched_evidence"] == []
+    assert "no_evidence_matched" in result["result"]["warnings"]
+
+
+@pytest.mark.unit
+def test_claim_resolve_empty_match_is_ok_with_warning_not_fake_success() -> None:
+    fx = _load_fixture()
+    result = handle_cdb_context_claim_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_CLAIM_RESOLVE,
+            "parameters": {
+                "mode": "by_topic",
+                "topic": "topic-with-no-claims",
+                "claim_records": fx["claim_records"],
+            },
+        }
+    )
+    _assert_mcp_ok_envelope(result, tool=TOOL_CDB_CONTEXT_CLAIM_RESOLVE)
+    assert result["result"]["matched_claims"] == []
+    assert "no_claims_matched" in result["result"]["warnings"]
+
+
+@pytest.mark.unit
+def test_memory_get_empty_match_is_ok_with_warning_not_fake_success() -> None:
+    fx = _load_fixture()
+    result = handle_cdb_context_memory_get(
+        {
+            "tool": TOOL_CDB_CONTEXT_MEMORY_GET,
+            "parameters": {
+                "mode": "by_scope",
+                "scope": "scope-with-no-memory",
+                "memory_records": fx["memory_records"],
+            },
+        }
+    )
+    _assert_mcp_ok_envelope(result, tool=TOOL_CDB_CONTEXT_MEMORY_GET)
+    assert result["result"]["matched_memory"] == []
+    assert "no_memory_matched" in result["result"]["warnings"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("tool", list(contracts.WAVE14_QUERY_RESULT_KEYS.keys()))
+def test_wave14_in_memory_ignores_forged_db_source_claims(
+    monkeypatch, tool: str
+) -> None:
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    mock_adapter.execute.return_value = []
+    patch_target = (
+        "tools.mcp.context_decision_tools.build_adapter_from_params"
+        if tool
+        in {TOOL_CDB_CONTEXT_DECISION_HISTORY, TOOL_CDB_CONTEXT_DECISION_REPLAY}
+        else "tools.mcp.context_evidence_memory_tools.build_adapter_from_params"
+    )
+    monkeypatch.setattr(patch_target, lambda params, tool_name: (mock_adapter, None))
+
+    fx = _load_fixture()
+    handler = _WAVE14_HANDLERS[tool]
+    result = handler(
+        {
+            "tool": tool,
+            "parameters": {
+                **_in_memory_parameters(tool, fx),
+                **_FORGED_DB_CLAIM_FIELDS,
+            },
+        }
+    )
+
+    _assert_mcp_ok_envelope(result, tool=tool)
+    assert result["metadata"]["source"] == "in_memory"
+    mock_adapter.execute.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("tool", list(contracts.WAVE14_QUERY_RESULT_KEYS.keys()))
+def test_wave14_invalid_adapter_config_stays_fail_closed(tool: str) -> None:
+    fx = _load_fixture()
+    handler = _WAVE14_HANDLERS[tool]
+    result = handler(
+        {
+            "tool": tool,
+            "parameters": {
+                "adapter_config_path": "/nonexistent/path/config.yaml",
+                **_in_memory_parameters(tool, fx),
+                **_FORGED_DB_CLAIM_FIELDS,
+            },
+        }
+    )
+    _assert_mcp_error_envelope(result, tool=tool)
+    assert result["error"]["code"] == "adapter_config_error"
+    assert result["metadata"]["source"] == "in_memory"
+
+
+@pytest.mark.unit
+def test_evidence_resolve_invalid_limit_returns_invalid_parameters(monkeypatch) -> None:
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    monkeypatch.setattr(
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        lambda params, tool_name: (mock_adapter, None),
+    )
+
+    result = handle_cdb_context_evidence_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "mode": "by_artifact",
+                "artifact": "some/path",
+                "limit": "bad",
+            },
+        }
+    )
+    _assert_mcp_error_envelope(result, tool=TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE)
+    assert result["error"]["code"] == "invalid_parameters"
+    mock_adapter.execute.assert_not_called()
+
+
+@pytest.mark.unit
+def test_decision_history_invalid_mode_returns_invalid_request() -> None:
+    fx = _load_fixture()
+    result = handle_cdb_context_decision_history(
+        {
+            "tool": TOOL_CDB_CONTEXT_DECISION_HISTORY,
+            "parameters": {
+                "mode": "bad_mode",
+                "decision_events": _DECISION_FIXTURE_RECORDS,
+            },
+        }
+    )
+    _assert_mcp_error_envelope(result, tool=TOOL_CDB_CONTEXT_DECISION_HISTORY)
+    assert result["error"]["code"] == "invalid_request"


### PR DESCRIPTION
## Summary
- Adds test-local Wave-14 contract constants.
- Adds SurrealDB context record schema contract tests.
- Adds Wave-14 MCP query return contract tests.
- Covers record/schema drift, normalization aliases, return envelopes, empty/null/malformed cases, and no fake DB-backed source claims.

## Scope
Refs #2643.

In scope:
- `evidence_ref`
- `claim`
- `agent_memory`
- `decision_event`
- Wave-14 query contracts for the six read-only context tools

Out of scope:
- #2644 real SurrealDB smoke idempotency/cleanup
- #2642 onboarding doctor
- #2637 epic body refresh
- Live-readiness / trading / runtime activation

## Validation
- `pytest` targeted Wave-14/schema/query suites: 207 passed
- `ruff check` on touched files: passed

## Safety
- Test-local only.
- No runtime code changes.
- No secrets.
- LR remains NO-GO.
