### PR TITLE
test(wave14): make real SurrealDB smoke idempotent and cleanup-safe

### DIFF
--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -644,21 +644,33 @@ pytest -v -m local_only tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.p
 What the local smoke does:
 
 1. Re-checks the same preflight gates and skips fail-closed if they are missing.
-2. Builds a temporary full JSONL bundle from the four committed Wave-14 seed files.
-3. Applies that bundle to the local Context DB through the existing importer using:
+2. Generates a unique `run_id` per invocation (`{timestamp}-{pid}` by default, or
+   optional override via `CDB_WAVE14_SMOKE_RUN_ID`).
+3. Materializes run-scoped record IDs from the four committed seed files (for example
+   `ev-wave14-real-{run_tag}-001`) without mutating committed fixtures.
+4. Asserts pre-import that run-scoped IDs and `.tmp/wave14-real-smoke/{run_id}` are
+   absent; fails closed if stale records remain.
+5. Builds a temporary full JSONL bundle from the materialized Wave-14 seed records.
+6. Applies that bundle to the local Context DB through the existing importer using:
    - `--adapter surrealdb-local`
    - `--apply --apply-mode local-dev`
    - `--config infrastructure/config/surrealdb/context_import.local.example.yaml`
    - explicit `--secrets-path`
-4. Calls all six Wave-14 MCP handlers with:
+7. Calls all six Wave-14 MCP handlers with:
    - `adapter_config_path=infrastructure/config/surrealdb/context_query.local.yaml`
    - `secrets_path=<resolved secrets dir>` (see resolution order above; `CDB_CONTEXT_SECRETS_PATH` is an override, not a new default)
-5. Asserts for each tool:
+8. Asserts for each tool:
    - `status == "ok"`
    - `metadata.source == "surrealdb-local"`
    - `metadata.read_only == true`
    - expected result payload is non-empty
    - no secret-like auth values are echoed back
+9. Cleans up only the run-scoped DB record IDs and removes
+   `.tmp/wave14-real-smoke/{run_id}` after the module finishes; repeated local runs
+   must not accumulate stale rows or temp artifacts.
+
+This smoke is `local_only`, opt-in via `CDB_RUN_REAL_SURREALDB_SMOKE=1`, and is not
+part of CI by default.
 
 Tool coverage in the real local smoke:
 

--- a/tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.py
+++ b/tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.py
@@ -6,9 +6,8 @@ Runs only when:
 - secrets path resolves (CDB canon, overridable via env)
 - local SurrealDB answers on ``127.0.0.1:8010``
 
-The committed fixture directory contains only the four Wave-14 JSONL seed files.
-At runtime this test materializes a temporary full importer bundle by adding the
-remaining expected JSONL files as empty companions.
+Each pytest invocation uses a unique run-scoped record ID set, pre-import
+absence checks, and post-run cleanup of DB rows plus ``.tmp`` artifacts.
 """
 
 from __future__ import annotations
@@ -16,13 +15,24 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-import time
 from typing import Any
 import urllib.error
 import urllib.request
 
 import pytest
 
+from tests.local.tools.mcp.wave14_smoke_helpers import (
+    Wave14SmokeRecordPlan,
+    Wave14SmokeSqlClient,
+    assert_run_records_absent,
+    assert_tmp_root_absent,
+    build_record_plan,
+    cleanup_run_records,
+    cleanup_tmp_root,
+    materialize_fixture_records,
+    resolve_smoke_run_id,
+    smoke_tmp_root,
+)
 from tools.mcp.context_decision_tools import (
     TOOL_CDB_CONTEXT_DECISION_HISTORY,
     TOOL_CDB_CONTEXT_DECISION_REPLAY,
@@ -69,14 +79,6 @@ _LOCAL_SURR_URLS = (
 )
 
 
-def _timestamp_run_id() -> str:
-    now = time.localtime()
-    return (
-        f"{now.tm_year:04d}{now.tm_mon:02d}{now.tm_mday:02d}"
-        f"{now.tm_hour:02d}{now.tm_min:02d}{now.tm_sec:02d}"
-    )
-
-
 def _http_status(url: str) -> int | None:
     try:
         with urllib.request.urlopen(url, timeout=5) as response:
@@ -100,7 +102,6 @@ def _candidate_secrets_paths() -> list[Path]:
     else:
         candidates.append(Path.home() / "Documents" / ".secrets" / ".cdb")
 
-    # Deduplicate while preserving order.
     seen: set[Path] = set()
     ordered: list[Path] = []
     for path in candidates:
@@ -121,7 +122,7 @@ def _resolve_secrets_path() -> Path | None:
     return None
 
 
-def _require_local_opt_in() -> str:
+def _require_local_opt_in() -> Path:
     if os.environ.get("CDB_RUN_REAL_SURREALDB_SMOKE") != "1":
         pytest.skip(
             "real surrealdb-local smoke disabled; set CDB_RUN_REAL_SURREALDB_SMOKE=1"
@@ -135,11 +136,10 @@ def _require_local_opt_in() -> str:
     secrets_dir = _resolve_secrets_path()
     if secrets_dir is None:
         pytest.skip(
-            "missing secrets dir for surrealdb-local auth (set CDB_CONTEXT_SECRETS_PATH or SECRETS_PATH, or provide canon secrets store)"
+            "missing secrets dir for surrealdb-local auth "
+            "(set CDB_CONTEXT_SECRETS_PATH or SECRETS_PATH, or provide canon secrets store)"
         )
 
-    # The importer/query layer expects credentials to be loaded from SURREALDB_ENV
-    # located in the secrets directory. We check existence only and never read it.
     if not (secrets_dir / "SURREALDB_ENV").is_file():
         pytest.skip("missing required secrets file SURREALDB_ENV in secrets dir")
 
@@ -148,36 +148,37 @@ def _require_local_opt_in() -> str:
         if status != 200:
             pytest.skip(f"local SurrealDB preflight failed for {url} (status={status})")
 
-    return str(secrets_dir)
+    return secrets_dir
 
 
-def _seed_lines(filename: str, run_id: str) -> str:
-    path = _FIXTURE_DIR / filename
-    records: list[str] = []
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        if not raw_line.strip():
-            continue
-        record = json.loads(raw_line)
-        record["run_id"] = run_id
-        records.append(json.dumps(record, ensure_ascii=True, sort_keys=True))
-    return "\n".join(records) + ("\n" if records else "")
-
-
-def _materialize_input_bundle(tmp_path: Path, run_id: str) -> Path:
+def _materialize_input_bundle(
+    tmp_path: Path,
+    *,
+    run_id: str,
+    plan: Wave14SmokeRecordPlan,
+) -> Path:
     bundle_dir = tmp_path / "wave14-real-smoke-bundle"
     bundle_dir.mkdir(parents=True, exist_ok=True)
 
     for filename in EXPECTED_JSONL_FILES.values():
         target = bundle_dir / filename
         if filename in _SEEDED_FILENAMES:
-            target.write_text(_seed_lines(filename, run_id), encoding="utf-8")
+            target.write_text(
+                materialize_fixture_records(filename, run_id=run_id, plan=plan),
+                encoding="utf-8",
+            )
         else:
             target.write_text("", encoding="utf-8")
 
     return bundle_dir
 
 
-def _seed_local_surrealdb(input_dir: Path, run_id: str, secrets_path: str) -> None:
+def _seed_local_surrealdb(
+    input_dir: Path,
+    *,
+    run_id: str,
+    secrets_path: Path,
+) -> None:
     exit_code = importer_main(
         [
             "apply",
@@ -199,28 +200,27 @@ def _seed_local_surrealdb(input_dir: Path, run_id: str, secrets_path: str) -> No
             "--adapter",
             "surrealdb-local",
             "--secrets-path",
-            secrets_path,
+            str(secrets_path),
         ]
     )
     assert exit_code == 0, f"context_importer apply failed with exit code {exit_code}"
 
 
-def _common_parameters(secrets_path: str) -> dict[str, Any]:
+def _common_parameters(secrets_path: Path) -> dict[str, Any]:
     return {
         "adapter_config_path": str(_QUERY_CONFIG_PATH),
-        "secrets_path": secrets_path,
+        "secrets_path": str(secrets_path),
         "limit": 25,
     }
 
 
-def _assert_no_secret_leak(payload: dict[str, Any], *, secrets_path: str) -> None:
+def _assert_no_secret_leak(payload: dict[str, Any], *, secrets_path: Path) -> None:
     rendered = json.dumps(payload, sort_keys=True, default=str)
-    # Do not embed any secret values or local secret paths in assertion output.
     assert "Authorization" not in rendered, "secret-like token leaked in payload"
     assert "Basic " not in rendered, "secret-like token leaked in payload"
     assert "SURREAL_PASS" not in rendered, "secret-like token leaked in payload"
     assert "SURREAL_USER" not in rendered, "secret-like token leaked in payload"
-    assert secrets_path not in rendered, "secret-like token leaked in payload"
+    assert str(secrets_path) not in rendered, "secret-like token leaked in payload"
 
 
 def _assert_ok_source(payload: dict[str, Any], tool_name: str) -> None:
@@ -230,17 +230,106 @@ def _assert_ok_source(payload: dict[str, Any], tool_name: str) -> None:
     assert payload["metadata"]["read_only"] is True, payload
 
 
+def _run_handler_smoke_checks(seeded_bundle: dict[str, Any]) -> None:
+    secrets_path = Path(seeded_bundle["secrets_path"])
+    common = _common_parameters(secrets_path)
+
+    evidence = handle_cdb_context_evidence_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                **common,
+                "mode": "by_artifact",
+                "artifact": "tools/surrealdb/evidence_lookup.py",
+            },
+        }
+    )
+    _assert_ok_source(evidence, TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE)
+    _assert_no_secret_leak(evidence, secrets_path=secrets_path)
+    assert evidence["result"]["matched_evidence"], evidence
+
+    claim = handle_cdb_context_claim_resolve(
+        {
+            "tool": TOOL_CDB_CONTEXT_CLAIM_RESOLVE,
+            "parameters": {**common, "mode": "by_scope", "scope": "wave14"},
+        }
+    )
+    _assert_ok_source(claim, TOOL_CDB_CONTEXT_CLAIM_RESOLVE)
+    _assert_no_secret_leak(claim, secrets_path=secrets_path)
+    assert claim["result"]["matched_claims"], claim
+
+    memory = handle_cdb_context_memory_get(
+        {
+            "tool": TOOL_CDB_CONTEXT_MEMORY_GET,
+            "parameters": {**common, "mode": "by_scope", "scope": "wave14"},
+        }
+    )
+    _assert_ok_source(memory, TOOL_CDB_CONTEXT_MEMORY_GET)
+    _assert_no_secret_leak(memory, secrets_path=secrets_path)
+    assert memory["result"]["matched_memory"], memory
+
+    history = handle_cdb_context_decision_history(
+        {
+            "tool": TOOL_CDB_CONTEXT_DECISION_HISTORY,
+            "parameters": {**common, "mode": "by_scope", "scope": "wave14"},
+        }
+    )
+    _assert_ok_source(history, TOOL_CDB_CONTEXT_DECISION_HISTORY)
+    _assert_no_secret_leak(history, secrets_path=secrets_path)
+    assert history["result"]["matched_decisions"], history
+
+    replay = handle_cdb_context_decision_replay(
+        {
+            "tool": TOOL_CDB_CONTEXT_DECISION_REPLAY,
+            "parameters": {**common, "mode": "replay_by_scope", "scope": "wave14"},
+        }
+    )
+    _assert_ok_source(replay, TOOL_CDB_CONTEXT_DECISION_REPLAY)
+    _assert_no_secret_leak(replay, secrets_path=secrets_path)
+    assert replay["result"]["current_decisions"], replay
+
+    trust = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                **common,
+                "scope": "wave14",
+                "artifact": "tools/surrealdb/evidence_lookup.py",
+            },
+        }
+    )
+    _assert_ok_source(trust, TOOL_CDB_CONTEXT_TRUST_SUMMARY)
+    _assert_no_secret_leak(trust, secrets_path=secrets_path)
+    assert trust["result"]["evidence_strength"] != "none", trust
+
+
 @pytest.fixture(scope="module")
-def seeded_bundle() -> dict[str, str]:
-    secrets_path = _require_local_opt_in()
-    run_id = _timestamp_run_id()
-    # Avoid relying on OS temp directories, which may be permission-restricted in
-    # some local agent runner contexts. Keep this untracked/local-only.
-    tmp_root = _REPO_ROOT / ".tmp" / "wave14-real-smoke" / run_id
+def seeded_bundle() -> dict[str, Any]:
+    secrets_dir = _require_local_opt_in()
+    run_id = resolve_smoke_run_id()
+    plan = build_record_plan(run_id)
+    tmp_root = smoke_tmp_root(run_id)
+    sql_client = Wave14SmokeSqlClient.from_secrets_dir(secrets_dir)
+
+    assert_tmp_root_absent(tmp_root)
+    assert_run_records_absent(sql_client, plan)
+
     tmp_root.mkdir(parents=True, exist_ok=True)
-    input_dir = _materialize_input_bundle(tmp_root, run_id)
-    _seed_local_surrealdb(input_dir, run_id, secrets_path)
-    return {"secrets_path": secrets_path, "run_id": run_id}
+    input_dir = _materialize_input_bundle(tmp_root, run_id=run_id, plan=plan)
+    _seed_local_surrealdb(input_dir, run_id=run_id, secrets_path=secrets_dir)
+
+    bundle = {
+        "secrets_path": str(secrets_dir),
+        "run_id": run_id,
+        "plan": plan,
+        "tmp_root": str(tmp_root),
+        "sql_client": sql_client,
+    }
+
+    yield bundle
+
+    cleanup_run_records(sql_client, plan)
+    cleanup_tmp_root(tmp_root)
 
 
 @pytest.mark.parametrize(
@@ -299,7 +388,7 @@ def seeded_bundle() -> dict[str, str]:
     ],
 )
 def test_wave14_real_surrealdb_local_handlers_ok(
-    seeded_bundle: dict[str, str],
+    seeded_bundle: dict[str, Any],
     tool_name: str,
     handler,
     parameters: dict[str, Any],
@@ -308,7 +397,7 @@ def test_wave14_real_surrealdb_local_handlers_ok(
     request = {
         "tool": tool_name,
         "parameters": {
-            **_common_parameters(seeded_bundle["secrets_path"]),
+            **_common_parameters(Path(seeded_bundle["secrets_path"])),
             **parameters,
         },
     }
@@ -316,19 +405,19 @@ def test_wave14_real_surrealdb_local_handlers_ok(
     result = handler(request)
 
     _assert_ok_source(result, tool_name)
-    _assert_no_secret_leak(result, secrets_path=seeded_bundle["secrets_path"])
+    _assert_no_secret_leak(result, secrets_path=Path(seeded_bundle["secrets_path"]))
     assert result["result"]["approval_semantics"]["no_echtgeld_go"] is True
     assert result["result"][result_key], result
 
 
 def test_wave14_real_surrealdb_local_trust_summary_ok(
-    seeded_bundle: dict[str, str],
+    seeded_bundle: dict[str, Any],
 ) -> None:
     result = handle_cdb_context_trust_summary(
         {
             "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
             "parameters": {
-                **_common_parameters(seeded_bundle["secrets_path"]),
+                **_common_parameters(Path(seeded_bundle["secrets_path"])),
                 "scope": "wave14",
                 "artifact": "tools/surrealdb/evidence_lookup.py",
             },
@@ -336,9 +425,43 @@ def test_wave14_real_surrealdb_local_trust_summary_ok(
     )
 
     _assert_ok_source(result, TOOL_CDB_CONTEXT_TRUST_SUMMARY)
-    _assert_no_secret_leak(result, secrets_path=seeded_bundle["secrets_path"])
+    _assert_no_secret_leak(result, secrets_path=Path(seeded_bundle["secrets_path"]))
     assert result["result"]["approval_semantics"]["no_echtgeld_go"] is True
     assert result["result"]["evidence_strength"] != "none", result
     assert result["result"]["claim_status_summary"].get("supported", 0) >= 1, result
     assert result["result"]["memory_trust_summary"]["total"] >= 1, result
     assert result["result"]["decision_currentness"]["total"] >= 1, result
+
+
+def test_wave14_real_smoke_cleanup_proof(seeded_bundle: dict[str, Any]) -> None:
+    """Post-cleanup assertions run in the module fixture finalizer."""
+    plan: Wave14SmokeRecordPlan = seeded_bundle["plan"]
+    sql_client: Wave14SmokeSqlClient = seeded_bundle["sql_client"]
+    for table, raw_id in plan.records_by_table:
+        assert sql_client.record_exists(table, raw_id), (
+            f"expected seeded record before cleanup: {table}:{raw_id}"
+        )
+
+
+def test_wave14_real_smoke_idempotent_cycle() -> None:
+    """Two isolated seed/query/cleanup cycles in one opt-in run."""
+    secrets_dir = _require_local_opt_in()
+
+    for _ in range(2):
+        run_id = resolve_smoke_run_id()
+        plan = build_record_plan(run_id)
+        tmp_root = smoke_tmp_root(run_id)
+        sql_client = Wave14SmokeSqlClient.from_secrets_dir(secrets_dir)
+
+        assert_tmp_root_absent(tmp_root)
+        assert_run_records_absent(sql_client, plan)
+
+        tmp_root.mkdir(parents=True, exist_ok=True)
+        input_dir = _materialize_input_bundle(tmp_root, run_id=run_id, plan=plan)
+        _seed_local_surrealdb(input_dir, run_id=run_id, secrets_path=secrets_dir)
+
+        bundle = {"secrets_path": str(secrets_dir)}
+        _run_handler_smoke_checks(bundle)
+
+        cleanup_run_records(sql_client, plan)
+        cleanup_tmp_root(tmp_root)

--- a/tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.py
+++ b/tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.py
@@ -438,9 +438,9 @@ def test_wave14_real_smoke_cleanup_proof(seeded_bundle: dict[str, Any]) -> None:
     plan: Wave14SmokeRecordPlan = seeded_bundle["plan"]
     sql_client: Wave14SmokeSqlClient = seeded_bundle["sql_client"]
     for table, raw_id in plan.records_by_table:
-        assert sql_client.record_exists(table, raw_id), (
-            f"expected seeded record before cleanup: {table}:{raw_id}"
-        )
+        assert sql_client.record_exists(
+            table, raw_id
+        ), f"expected seeded record before cleanup: {table}:{raw_id}"
 
 
 def test_wave14_real_smoke_idempotent_cycle() -> None:

--- a/tests/local/tools/mcp/wave14_smoke_helpers.py
+++ b/tests/local/tools/mcp/wave14_smoke_helpers.py
@@ -1,0 +1,311 @@
+"""Helpers for Wave-14 local real-SurrealDB smoke (#2644).
+
+Test-local only. Provides run-scoped record materialization, pre/post DB
+assertions, and targeted cleanup via the local SurrealDB /sql endpoint.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import shutil
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from tools.surrealdb.context_importer import TABLE_BY_ARTIFACT
+from tools.surrealdb.gen_run_id import _timestamp_run_id
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_FIXTURE_DIR = _REPO_ROOT / "tests" / "fixtures" / "surrealdb" / "wave14_real_smoke"
+
+LOCAL_SURR_URL = "http://127.0.0.1:8010"
+LOCAL_NS = "cdb_context_local"
+LOCAL_DB = "cdb_context_intel"
+LOCAL_ALLOWED_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+WAVE14_SMOKE_TABLES: tuple[str, ...] = tuple(
+    TABLE_BY_ARTIFACT[artifact]
+    for artifact in (
+        "evidence_refs",
+        "claims",
+        "decision_events",
+        "agent_memories",
+    )
+)
+
+_BASE_EVIDENCE_ID = "ev-wave14-real-001"
+_BASE_CLAIM_ID = "claim-wave14-real-001"
+_BASE_MEMORY_ID = "mem-wave14-real-001"
+_BASE_DECISION_IDS = ("dec-wave14-real-001", "dec-wave14-real-002")
+
+_ID_REFERENCE_FIELDS = frozenset(
+    {
+        "evidence_id",
+        "claim_id",
+        "memory_id",
+        "decision_id",
+        "validates",
+        "invalidates",
+        "evidence_refs",
+        "claim_refs",
+        "related_artifacts",
+        "related_decisions",
+        "superseded_by",
+        "invalidated_by",
+        "source_refs",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Wave14SmokeRecordPlan:
+    run_id: str
+    run_tag: str
+    evidence_ids: tuple[str, ...]
+    claim_ids: tuple[str, ...]
+    memory_ids: tuple[str, ...]
+    decision_ids: tuple[str, ...]
+
+    @property
+    def records_by_table(self) -> tuple[tuple[str, str], ...]:
+        rows: list[tuple[str, str]] = []
+        rows.extend(("evidence_ref", item) for item in self.evidence_ids)
+        rows.extend(("claim", item) for item in self.claim_ids)
+        rows.extend(("agent_memory", item) for item in self.memory_ids)
+        rows.extend(("decision_event", item) for item in self.decision_ids)
+        return tuple(rows)
+
+
+def resolve_smoke_run_id() -> str:
+    override = os.environ.get("CDB_WAVE14_SMOKE_RUN_ID", "").strip()
+    if override:
+        return override
+    return f"{_timestamp_run_id()}-{os.getpid()}"
+
+
+def smoke_run_tag(run_id: str) -> str:
+    tag = re.sub(r"[^a-zA-Z0-9]", "", run_id)
+    if not tag:
+        raise ValueError("run_id must contain at least one alphanumeric character")
+    return tag[:24]
+
+
+def build_record_plan(run_id: str) -> Wave14SmokeRecordPlan:
+    tag = smoke_run_tag(run_id)
+
+    def _scoped(base: str) -> str:
+        stem, suffix = base.rsplit("-", 1)
+        return f"{stem}-{tag}-{suffix}"
+
+    return Wave14SmokeRecordPlan(
+        run_id=run_id,
+        run_tag=tag,
+        evidence_ids=(_scoped(_BASE_EVIDENCE_ID),),
+        claim_ids=(_scoped(_BASE_CLAIM_ID),),
+        memory_ids=(_scoped(_BASE_MEMORY_ID),),
+        decision_ids=tuple(_scoped(item) for item in _BASE_DECISION_IDS),
+    )
+
+
+def _id_remap(plan: Wave14SmokeRecordPlan) -> dict[str, str]:
+    return {
+        _BASE_EVIDENCE_ID: plan.evidence_ids[0],
+        _BASE_CLAIM_ID: plan.claim_ids[0],
+        _BASE_MEMORY_ID: plan.memory_ids[0],
+        _BASE_DECISION_IDS[0]: plan.decision_ids[0],
+        _BASE_DECISION_IDS[1]: plan.decision_ids[1],
+    }
+
+
+def _replace_value(value: Any, id_map: dict[str, str]) -> Any:
+    if isinstance(value, str):
+        return id_map.get(value, value)
+    if isinstance(value, list):
+        return [_replace_value(item, id_map) for item in value]
+    return value
+
+
+def _replace_record_fields(record: dict[str, Any], id_map: dict[str, str]) -> dict[str, Any]:
+    updated: dict[str, Any] = {}
+    for key, value in record.items():
+        if key in _ID_REFERENCE_FIELDS or key.endswith("_refs") or key.endswith("_by"):
+            updated[key] = _replace_value(value, id_map)
+        else:
+            updated[key] = value
+    return updated
+
+
+def materialize_fixture_records(
+    filename: str,
+    *,
+    run_id: str,
+    plan: Wave14SmokeRecordPlan,
+) -> str:
+    path = _FIXTURE_DIR / filename
+    id_map = _id_remap(plan)
+    records: list[str] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip():
+            continue
+        record = json.loads(raw_line)
+        record["run_id"] = run_id
+        record = _replace_record_fields(record, id_map)
+        records.append(json.dumps(record, ensure_ascii=True, sort_keys=True))
+    return "\n".join(records) + ("\n" if records else "")
+
+
+def smoke_tmp_root(run_id: str) -> Path:
+    return _REPO_ROOT / ".tmp" / "wave14-real-smoke" / run_id
+
+
+def assert_tmp_root_absent(tmp_root: Path) -> None:
+    if tmp_root.exists():
+        raise AssertionError(
+            "wave14 real-smoke tmp dir already exists; "
+            "previous cleanup likely failed"
+        )
+
+
+def cleanup_tmp_root(tmp_root: Path) -> None:
+    if tmp_root.exists():
+        shutil.rmtree(tmp_root, ignore_errors=False)
+    if tmp_root.exists():
+        raise AssertionError("wave14 real-smoke tmp dir still present after cleanup")
+
+
+def _surql_record_id(table: str, raw_id: str) -> str:
+    escaped = raw_id.replace("\u27e9", "\\u27e9")
+    return f"{table}:\u27e8{escaped}\u27e9"
+
+
+class Wave14SmokeSqlClient:
+    """Minimal local-only /sql client for smoke pre/post checks."""
+
+    def __init__(
+        self,
+        *,
+        surreal_url: str,
+        namespace: str,
+        database: str,
+        user: str,
+        password: str,
+        timeout: int = 15,
+    ) -> None:
+        parsed = urllib.parse.urlparse(surreal_url)
+        host = parsed.hostname or ""
+        if host not in LOCAL_ALLOWED_HOSTS:
+            raise ValueError("wave14 smoke SQL client is local-dev only")
+        self._url = surreal_url.rstrip("/")
+        self._namespace = namespace
+        self._database = database
+        self._auth = base64.b64encode(f"{user}:{password}".encode()).decode()
+        self._timeout = timeout
+
+    @classmethod
+    def from_secrets_dir(
+        cls,
+        secrets_dir: Path,
+        *,
+        surreal_url: str = LOCAL_SURR_URL,
+        namespace: str = LOCAL_NS,
+        database: str = LOCAL_DB,
+    ) -> Wave14SmokeSqlClient:
+        env_file = secrets_dir / "SURREALDB_ENV"
+        if not env_file.is_file():
+            raise FileNotFoundError("SURREALDB_ENV missing in secrets dir")
+        user: str | None = None
+        password: str | None = None
+        for line in env_file.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("SURREAL_USER="):
+                user = stripped.split("=", 1)[1]
+            elif stripped.startswith("SURREAL_PASS="):
+                password = stripped.split("=", 1)[1]
+        if not user or not password:
+            raise ValueError("SURREALDB_ENV missing SURREAL_USER or SURREAL_PASS")
+        return cls(
+            surreal_url=surreal_url,
+            namespace=namespace,
+            database=database,
+            user=user,
+            password=password,
+        )
+
+    def execute(self, sql: str) -> list[dict[str, Any]]:
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "text/plain",
+            "Authorization": f"Basic {self._auth}",
+            "surreal-ns": self._namespace,
+            "surreal-db": self._database,
+        }
+        req = urllib.request.Request(
+            f"{self._url}/sql",
+            data=sql.encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self._timeout) as resp:
+                body = resp.read()
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"local SurrealDB /sql request failed: {exc.reason}") from exc
+
+        raw = body.decode("utf-8", errors="replace")
+        if not raw.strip():
+            raise RuntimeError("local SurrealDB /sql returned empty body")
+        parsed = json.loads(raw)
+        if not isinstance(parsed, list):
+            raise RuntimeError("local SurrealDB /sql returned unexpected payload")
+        for item in parsed:
+            if isinstance(item, dict) and item.get("status") not in (None, "OK"):
+                detail = item.get("detail") or item.get("result") or item
+                raise RuntimeError(f"local SurrealDB /sql error: {detail!s}"[:400])
+        return [item for item in parsed if isinstance(item, dict)]
+
+    def record_exists(self, table: str, raw_id: str) -> bool:
+        rid = _surql_record_id(table, raw_id)
+        results = self.execute(f"SELECT * FROM {rid};")
+        for item in results:
+            result = item.get("result")
+            if isinstance(result, list) and result:
+                return True
+        return False
+
+    def delete_record(self, table: str, raw_id: str) -> None:
+        rid = _surql_record_id(table, raw_id)
+        self.execute(f"DELETE {rid};")
+
+
+def assert_run_records_absent(client: Wave14SmokeSqlClient, plan: Wave14SmokeRecordPlan) -> None:
+    present = [
+        f"{table}:{raw_id}"
+        for table, raw_id in plan.records_by_table
+        if client.record_exists(table, raw_id)
+    ]
+    if present:
+        raise AssertionError(
+            "run-scoped Wave-14 smoke records already exist before import: "
+            + ", ".join(present)
+        )
+
+
+def cleanup_run_records(client: Wave14SmokeSqlClient, plan: Wave14SmokeRecordPlan) -> None:
+    # Delete decisions first, then dependent rows.
+    delete_order = (
+        ("decision_event", plan.decision_ids),
+        ("claim", plan.claim_ids),
+        ("agent_memory", plan.memory_ids),
+        ("evidence_ref", plan.evidence_ids),
+    )
+    for table, ids in delete_order:
+        for raw_id in ids:
+            if client.record_exists(table, raw_id):
+                client.delete_record(table, raw_id)
+    assert_run_records_absent(client, plan)

--- a/tests/local/tools/mcp/wave14_smoke_helpers.py
+++ b/tests/local/tools/mcp/wave14_smoke_helpers.py
@@ -131,7 +131,9 @@ def _replace_value(value: Any, id_map: dict[str, str]) -> Any:
     return value
 
 
-def _replace_record_fields(record: dict[str, Any], id_map: dict[str, str]) -> dict[str, Any]:
+def _replace_record_fields(
+    record: dict[str, Any], id_map: dict[str, str]
+) -> dict[str, Any]:
     updated: dict[str, Any] = {}
     for key, value in record.items():
         if key in _ID_REFERENCE_FIELDS or key.endswith("_refs") or key.endswith("_by"):
@@ -255,7 +257,9 @@ class Wave14SmokeSqlClient:
             with urllib.request.urlopen(req, timeout=self._timeout) as resp:
                 body = resp.read()
         except urllib.error.URLError as exc:
-            raise RuntimeError(f"local SurrealDB /sql request failed: {exc.reason}") from exc
+            raise RuntimeError(
+                f"local SurrealDB /sql request failed: {exc.reason}"
+            ) from exc
 
         raw = body.decode("utf-8", errors="replace")
         if not raw.strip():
@@ -283,7 +287,9 @@ class Wave14SmokeSqlClient:
         self.execute(f"DELETE {rid};")
 
 
-def assert_run_records_absent(client: Wave14SmokeSqlClient, plan: Wave14SmokeRecordPlan) -> None:
+def assert_run_records_absent(
+    client: Wave14SmokeSqlClient, plan: Wave14SmokeRecordPlan
+) -> None:
     present = [
         f"{table}:{raw_id}"
         for table, raw_id in plan.records_by_table
@@ -296,7 +302,9 @@ def assert_run_records_absent(client: Wave14SmokeSqlClient, plan: Wave14SmokeRec
         )
 
 
-def cleanup_run_records(client: Wave14SmokeSqlClient, plan: Wave14SmokeRecordPlan) -> None:
+def cleanup_run_records(
+    client: Wave14SmokeSqlClient, plan: Wave14SmokeRecordPlan
+) -> None:
     # Delete decisions first, then dependent rows.
     delete_order = (
         ("decision_event", plan.decision_ids),

--- a/tests/local/tools/mcp/wave14_smoke_helpers.py
+++ b/tests/local/tools/mcp/wave14_smoke_helpers.py
@@ -181,9 +181,23 @@ def cleanup_tmp_root(tmp_root: Path) -> None:
         raise AssertionError("wave14 real-smoke tmp dir still present after cleanup")
 
 
-def _surql_record_id(table: str, raw_id: str) -> str:
-    escaped = raw_id.replace("\u27e9", "\\u27e9")
-    return f"{table}:\u27e8{escaped}\u27e9"
+_TABLE_ID_FIELD = {
+    "evidence_ref": "evidence_id",
+    "claim": "claim_id",
+    "agent_memory": "memory_id",
+    "decision_event": "decision_id",
+}
+
+
+def _table_id_field(table: str) -> str:
+    try:
+        return _TABLE_ID_FIELD[table]
+    except KeyError as exc:
+        raise ValueError("unsupported Wave-14 smoke table") from exc
+
+
+def _surql_string(value: str) -> str:
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
 
 
 class Wave14SmokeSqlClient:
@@ -274,8 +288,9 @@ class Wave14SmokeSqlClient:
         return [item for item in parsed if isinstance(item, dict)]
 
     def record_exists(self, table: str, raw_id: str) -> bool:
-        rid = _surql_record_id(table, raw_id)
-        results = self.execute(f"SELECT * FROM {rid};")
+        id_field = _table_id_field(table)
+        literal = _surql_string(raw_id)
+        results = self.execute(f"SELECT * FROM {table} WHERE {id_field} = {literal};")
         for item in results:
             result = item.get("result")
             if isinstance(result, list) and result:
@@ -283,8 +298,9 @@ class Wave14SmokeSqlClient:
         return False
 
     def delete_record(self, table: str, raw_id: str) -> None:
-        rid = _surql_record_id(table, raw_id)
-        self.execute(f"DELETE {rid};")
+        id_field = _table_id_field(table)
+        literal = _surql_string(raw_id)
+        self.execute(f"DELETE {table} WHERE {id_field} = {literal};")
 
 
 def assert_run_records_absent(


### PR DESCRIPTION
## Summary
- Adds run-scoped Wave-14 real-smoke record IDs.
- Adds pre-test assertions for run isolation.
- Adds targeted post-test DB cleanup.
- Adds temporary fixture cleanup.
- Adds a double-cycle local smoke path for idempotency validation.
- Keeps real SurrealDB smoke opt-in and local-only.

Refs #2644.

## Scope
In scope:
- `tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.py`
- `tests/local/tools/mcp/wave14_smoke_helpers.py`
- minimal runbook update for §7.7

Out of scope:
- #2642 onboarding doctor
- #2637 epic refresh
- production SurrealDB schema changes
- MCP handler/runtime behavior changes
- Live-readiness / trading changes

## Validation
Passed:
- `pytest -q tests/unit/surrealdb/test_wave14_context_record_schemas.py tests/unit/tools/mcp/test_wave14_query_contracts.py`
- `ruff check` on touched files

Blocked/skipped:
- Real SurrealDB smoke double-run could not be proven in this environment because `infrastructure/config/surrealdb/context_query.local.yaml` is missing.
- SurrealDB `/health` returned 200.
- `SURREALDB_ENV` is present.

Required before marking ready:
```powershell
$env:CDB_RUN_REAL_SURREALDB_SMOKE = "1"
pytest -q -m local_only tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.py
pytest -q -m local_only tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.py
```

## Safety
- No secrets in output.
- No broad DB deletes.
- Cleanup is scoped to generated run IDs.
- Real-smoke remains opt-in/local-only.
- LR remains NO-GO.
