### PR TITLE
Add context onboarding doctor (#2642)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ else
   SECRETS_PATH ?= $(HOME)/Documents/.secrets/.cdb
 endif
 
-.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke context-smoke-db
+.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke context-smoke-db context-doctor
 
 help:
 	@echo "Claire de Binare - Test Commands"
@@ -100,6 +100,7 @@ help:
 	@echo "  make context-query-smoke     - Lese-Query-Smoke (graceful fail)"
 	@echo "  make context-smoke           - Komplette lokale Pipeline (smoke test)"
 	@echo "  make context-smoke-db        - Hard fail-closed DB-backed smoke (#2460)"
+	@echo "  make context-doctor          - Read-only onboarding preflight (#2642)"
 # ============================================================================
 # CI-Tests (schnell, mit Mocks)
 # ============================================================================
@@ -350,6 +351,10 @@ context-schema-apply:
 context-schema-check:
 	@echo "=== SurrealDB Schema Check: context_intelligence_v0 ==="
 	@$(PYTHON) tools/surrealdb/local_schema_check.py --secrets-path "$(SECRETS_PATH)"
+
+context-doctor:
+	@echo "=== Context Onboarding Doctor (read-only preflight) ==="
+	@$(PYTHON) -m tools.surrealdb.context_onboarding_doctor
 
 context-reset-local:
 	@echo "=== SurrealDB Local Reset (DESTRUKTIV - nur Context-Intelligence-Daten) ==="

--- a/docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md
+++ b/docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md
@@ -86,6 +86,28 @@ Exits 0 wenn OK, 1 wenn Datei fehlt oder `SECRETS_PATH` nicht gesetzt.
 
 ---
 
+## Onboarding Doctor (Preflight)
+
+```bash
+make context-doctor
+# oder:
+python -m tools.surrealdb.context_onboarding_doctor --format json
+```
+
+Read-only Preflight für neue Agents/Operatoren (#2642). Prüft:
+
+- MCP HTTP-Port `127.0.0.1:8811` (TCP, optional — stdio `cdb_context` kann trotzdem funktionieren)
+- SurrealDB `127.0.0.1:8010` (`/health`, `/version`, read-only Schema)
+- `SECRETS_PATH` / `CDB_CONTEXT_SECRETS_PATH` (nur SET/VALID/INVALID, keine Werte)
+- Canon Secret Store und `SURREALDB_ENV` (EXISTS/MISSING)
+- `context_query.local.yaml` (EXISTS/MISSING)
+
+Keine Secrets im Output. Kein Docker-Start/Stop. Kein DB-Write. LR bleibt **NO-GO**.
+
+Exit codes: `0` = nutzbar oder nur Warnings, `1` = blockierender Befund, `2` = CLI-Fehler.
+
+---
+
 ## Start
 
 ```bash

--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -150,6 +150,18 @@ Run the onboarding script to validate your setup:
 pwsh -File agents/templates/onboarding_mcp_setup.ps1
 ```
 
+**Context onboarding doctor** (#2642) — zusätzlicher read-only Preflight für Secrets,
+lokale Config, SurrealDB und optionalen MCP-HTTP-Port:
+
+```bash
+make context-doctor
+python -m tools.surrealdb.context_onboarding_doctor --format json
+```
+
+- Repo-stdio-MCP: `cdb_context` in `claire-de-binare.mcp.json` (kein TCP-Port nötig).
+- Issue #2642 prüft optional `127.0.0.1:8811` (HTTP MCP host).
+- Separater remote `cdb`-Server in OpenCode nutzt laut Runbook-Hinweis `127.0.0.1:8812/mcp` — nicht mit #2642 verwechseln.
+
 Expected output (best case — bridge + stdio both work):
 ```
 === CDB Context MCP Capability Validation ===

--- a/tests/unit/surrealdb/test_context_onboarding_doctor.py
+++ b/tests/unit/surrealdb/test_context_onboarding_doctor.py
@@ -1,0 +1,380 @@
+"""Unit tests for context onboarding doctor (#2642)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.surrealdb import context_onboarding_doctor as doctor
+
+pytestmark = pytest.mark.unit
+
+
+def test_evaluate_env_var_unset() -> None:
+    assert doctor.evaluate_env_var("SECRETS_PATH", {}) == "unset"
+
+
+def test_evaluate_env_var_set_invalid(tmp_path: Path) -> None:
+    missing = tmp_path / "missing-dir"
+    assert (
+        doctor.evaluate_env_var("SECRETS_PATH", {"SECRETS_PATH": str(missing)})
+        == "set_invalid"
+    )
+
+
+def test_evaluate_env_var_set_valid(tmp_path: Path) -> None:
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    assert (
+        doctor.evaluate_env_var("SECRETS_PATH", {"SECRETS_PATH": str(secrets)})
+        == "set_valid"
+    )
+
+
+def test_resolve_secrets_prefers_cdb_context_override(tmp_path: Path) -> None:
+    canon = tmp_path / "canon"
+    override = tmp_path / "override"
+    canon.mkdir()
+    override.mkdir()
+    (override / "SURREALDB_ENV").write_text(
+        "SURREAL_USER=root\nSURREAL_PASS=super-secret-password\n",
+        encoding="utf-8",
+    )
+    env = {
+        "SECRETS_PATH": str(canon),
+        "CDB_CONTEXT_SECRETS_PATH": str(override),
+    }
+    resolved = doctor.resolve_secrets_dir(env)
+    assert resolved.resolved_source == "CDB_CONTEXT_SECRETS_PATH"
+    assert resolved.canon_store == "exists"
+    assert resolved.surrealdb_env == "exists"
+    assert resolved.resolved_dir == override
+
+
+def test_resolve_secrets_falls_back_to_secrets_path(tmp_path: Path) -> None:
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    (secrets / "SURREALDB_ENV").write_text(
+        "SURREAL_USER=root\nSURREAL_PASS=super-secret-password\n",
+        encoding="utf-8",
+    )
+    resolved = doctor.resolve_secrets_dir({"SECRETS_PATH": str(secrets)})
+    assert resolved.resolved_source == "SECRETS_PATH"
+    assert resolved.canon_store == "exists"
+
+
+def test_resolve_secrets_missing_returns_none(tmp_path: Path) -> None:
+    with patch.object(doctor, "_canon_default_secrets_dir", return_value=tmp_path / "nope"):
+        resolved = doctor.resolve_secrets_dir({})
+    assert resolved.resolved_source == "none"
+    assert resolved.canon_store == "missing"
+
+
+def test_config_exists_missing(tmp_path: Path) -> None:
+    report = doctor.build_report(
+        tmp_path,
+        skip_mcp=True,
+        skip_schema=True,
+        tcp_checker=lambda _h, _p, _t: False,
+        environ={},
+    )
+    assert report.config_context_query_local == "missing"
+
+
+def test_config_exists_when_present(tmp_path: Path) -> None:
+    config_dir = tmp_path / "infrastructure/config/surrealdb"
+    config_dir.mkdir(parents=True)
+    (config_dir / "context_query.local.yaml").write_text(
+        "auth_mode: none\n", encoding="utf-8"
+    )
+    report = doctor.build_report(
+        tmp_path,
+        skip_mcp=True,
+        skip_schema=True,
+        tcp_checker=lambda _h, _p, _t: False,
+        environ={},
+    )
+    assert report.config_context_query_local == "exists"
+
+
+def test_mcp_reachable_and_not_reachable() -> None:
+    report_up = doctor.build_report(
+        Path("."),
+        skip_mcp=False,
+        skip_schema=True,
+        tcp_checker=lambda host, port, _t: host == "127.0.0.1" and port == 8811,
+        http_checker=lambda _u, _t: False,
+        environ={"SECRETS_PATH": "/nope"},
+    )
+    assert report_up.mcp_server_status == "reachable"
+
+    report_down = doctor.build_report(
+        Path("."),
+        skip_mcp=False,
+        skip_schema=True,
+        tcp_checker=lambda _h, _p, _t: False,
+        http_checker=lambda _u, _t: False,
+        environ={"SECRETS_PATH": "/nope"},
+    )
+    assert report_down.mcp_server_status == "not_reachable"
+
+
+def test_surrealdb_health_and_version_ok() -> None:
+    def http_ok(url: str, _timeout: float) -> int | None:
+        if url.endswith("/health") or url.endswith("/version"):
+            return 200
+        return None
+
+    report = doctor.build_report(
+        Path("."),
+        skip_mcp=True,
+        skip_schema=True,
+        tcp_checker=lambda _h, port, _t: port == 8010,
+        http_checker=http_ok,
+        environ={"SECRETS_PATH": "/nope"},
+    )
+    assert report.surrealdb_status == "reachable"
+    assert report.surrealdb_health == "ok"
+    assert report.surrealdb_version == "ok"
+
+
+def test_surrealdb_health_fail() -> None:
+    report = doctor.build_report(
+        Path("."),
+        skip_mcp=True,
+        skip_schema=True,
+        tcp_checker=lambda _h, port, _t: port == 8010,
+        http_checker=lambda _u, _t: None,
+        environ={"SECRETS_PATH": "/nope"},
+    )
+    assert report.surrealdb_health == "fail"
+    assert report.surrealdb_version == "fail"
+
+
+def test_schema_ok_and_fail(tmp_path: Path) -> None:
+    config_dir = tmp_path / "infrastructure/config/surrealdb"
+    config_dir.mkdir(parents=True)
+    (config_dir / "context_query.local.yaml").write_text(
+        "auth_mode: root\n", encoding="utf-8"
+    )
+
+    def schema_ok(_url: str, _user: str, _password: str) -> doctor.CheckStatus:
+        return "ok"
+
+    def schema_fail(_url: str, _user: str, _password: str) -> doctor.CheckStatus:
+        return "fail"
+
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    (secrets / "SURREALDB_ENV").write_text(
+        "SURREAL_USER=root\nSURREAL_PASS=super-secret-password\n",
+        encoding="utf-8",
+    )
+    env = {"SECRETS_PATH": str(secrets)}
+
+    report_ok = doctor.build_report(
+        tmp_path,
+        skip_mcp=True,
+        skip_schema=False,
+        tcp_checker=lambda _h, port, _t: port == 8010,
+        http_checker=lambda url, _t: 200 if "/health" in url or "/version" in url else None,
+        schema_checker=schema_ok,
+        environ=env,
+    )
+    report_fail = doctor.build_report(
+        tmp_path,
+        skip_mcp=True,
+        skip_schema=False,
+        tcp_checker=lambda _h, port, _t: port == 8010,
+        http_checker=lambda url, _t: 200 if "/health" in url or "/version" in url else None,
+        schema_checker=schema_fail,
+        environ=env,
+    )
+    assert report_ok.surrealdb_schema == "ok"
+    assert report_fail.surrealdb_schema == "fail"
+
+
+@pytest.mark.parametrize(
+    ("report_kwargs", "expected_action"),
+    [
+        (
+            {"secrets_canon_store": "missing"},
+            "set SECRETS_PATH or CDB_CONTEXT_SECRETS_PATH",
+        ),
+        (
+            {
+                "secrets_canon_store": "exists",
+                "secrets_surrealdb_env": "missing",
+            },
+            "create SURREALDB_ENV from infrastructure/config/surrealdb/SURREALDB_ENV.example",
+        ),
+        (
+            {
+                "secrets_canon_store": "exists",
+                "secrets_surrealdb_env": "exists",
+                "config_context_query_local": "missing",
+            },
+            "create context_query.local.yaml from context_query.local.example.yaml",
+        ),
+        (
+            {
+                "secrets_canon_store": "exists",
+                "secrets_surrealdb_env": "exists",
+                "config_context_query_local": "exists",
+                "surrealdb_status": "not_reachable",
+            },
+            "start local SurrealDB with make context-up",
+        ),
+        (
+            {
+                "secrets_canon_store": "exists",
+                "secrets_surrealdb_env": "exists",
+                "config_context_query_local": "exists",
+                "surrealdb_status": "reachable",
+                "surrealdb_health": "fail",
+            },
+            "start local SurrealDB with make context-up",
+        ),
+        (
+            {
+                "secrets_canon_store": "exists",
+                "secrets_surrealdb_env": "exists",
+                "config_context_query_local": "exists",
+                "surrealdb_status": "reachable",
+                "surrealdb_health": "ok",
+                "surrealdb_version": "ok",
+                "surrealdb_schema": "fail",
+            },
+            "run make context-schema-apply",
+        ),
+        (
+            {
+                "secrets_canon_store": "exists",
+                "secrets_surrealdb_env": "exists",
+                "config_context_query_local": "exists",
+                "surrealdb_status": "reachable",
+                "surrealdb_health": "ok",
+                "surrealdb_version": "ok",
+                "surrealdb_schema": "ok",
+                "mcp_server_status": "not_reachable",
+            },
+            "configure MCP host for 127.0.0.1:8811 or use stdio cdb_context via claire-de-binare.mcp.json",
+        ),
+        (
+            {
+                "secrets_canon_store": "exists",
+                "secrets_surrealdb_env": "exists",
+                "config_context_query_local": "exists",
+                "surrealdb_status": "reachable",
+                "surrealdb_health": "ok",
+                "surrealdb_version": "ok",
+                "surrealdb_schema": "ok",
+                "mcp_server_status": "reachable",
+            },
+            "no action required",
+        ),
+    ],
+)
+def test_prioritize_next_action(report_kwargs: dict, expected_action: str) -> None:
+    report = doctor.DoctorReport(**report_kwargs)
+    assert doctor.prioritize_next_action(report) == expected_action
+
+
+def test_json_output_contains_no_secret_values(tmp_path: Path) -> None:
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    (secrets / "SURREALDB_ENV").write_text(
+        "SURREAL_USER=root\nSURREAL_PASS=super-secret-password\n",
+        encoding="utf-8",
+    )
+    config_dir = tmp_path / "infrastructure/config/surrealdb"
+    config_dir.mkdir(parents=True)
+    (config_dir / "context_query.local.yaml").write_text(
+        "auth_mode: root\n", encoding="utf-8"
+    )
+
+    report = doctor.build_report(
+        tmp_path,
+        skip_mcp=True,
+        skip_schema=True,
+        tcp_checker=lambda _h, _p, _t: False,
+        environ={"SECRETS_PATH": str(secrets)},
+    )
+    payload = doctor.format_report(report, "json")
+    assert "super-secret-password" not in payload
+    assert "SURREAL_PASS" not in payload
+    assert "SURREAL_USER=root" not in payload
+    parsed = json.loads(payload)
+    assert parsed["lr_note"] == "NO-GO"
+    assert parsed["secrets"]["canon_store"] == "exists"
+
+
+def test_text_output_contains_no_secret_values(tmp_path: Path) -> None:
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    (secrets / "SURREALDB_ENV").write_text(
+        "SURREAL_USER=root\nSURREAL_PASS=super-secret-password\n",
+        encoding="utf-8",
+    )
+    report = doctor.build_report(
+        tmp_path,
+        skip_mcp=True,
+        skip_schema=True,
+        tcp_checker=lambda _h, _p, _t: False,
+        environ={"SECRETS_PATH": str(secrets)},
+    )
+    text = doctor.format_report(report, "text")
+    assert "super-secret-password" not in text
+    assert "SURREAL_PASS" not in text
+
+
+def test_compute_exit_code_blocking_and_ok() -> None:
+    blocked = doctor.DoctorReport(
+        secrets_canon_store="missing",
+        config_context_query_local="missing",
+        surrealdb_status="not_reachable",
+    )
+    assert doctor.compute_exit_code(blocked) == 1
+
+    ok = doctor.DoctorReport(
+        secrets_canon_store="exists",
+        secrets_surrealdb_env="exists",
+        config_context_query_local="exists",
+        surrealdb_status="reachable",
+        surrealdb_health="ok",
+        surrealdb_version="ok",
+        surrealdb_schema="ok",
+        mcp_server_status="not_reachable",
+    )
+    assert doctor.compute_exit_code(ok) == 0
+
+
+def test_main_exit_codes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        doctor,
+        "build_report",
+        lambda *_args, **_kwargs: doctor.DoctorReport(secrets_canon_store="missing"),
+    )
+    assert doctor.main(["--format", "json"]) == 1
+
+    monkeypatch.setattr(
+        doctor,
+        "build_report",
+        lambda *_args, **_kwargs: doctor.DoctorReport(
+            secrets_canon_store="exists",
+            secrets_surrealdb_env="exists",
+            config_context_query_local="exists",
+            surrealdb_status="reachable",
+            surrealdb_health="ok",
+            surrealdb_version="ok",
+            surrealdb_schema="ok",
+        ),
+    )
+    assert doctor.main(["--format", "text"]) == 0
+
+    with pytest.raises(SystemExit) as exc_info:
+        doctor.main(["--format", "xml"])
+    assert exc_info.value.code == 2

--- a/tests/unit/surrealdb/test_context_onboarding_doctor.py
+++ b/tests/unit/surrealdb/test_context_onboarding_doctor.py
@@ -67,7 +67,9 @@ def test_resolve_secrets_falls_back_to_secrets_path(tmp_path: Path) -> None:
 
 
 def test_resolve_secrets_missing_returns_none(tmp_path: Path) -> None:
-    with patch.object(doctor, "_canon_default_secrets_dir", return_value=tmp_path / "nope"):
+    with patch.object(
+        doctor, "_canon_default_secrets_dir", return_value=tmp_path / "nope"
+    ):
         resolved = doctor.resolve_secrets_dir({})
     assert resolved.resolved_source == "none"
     assert resolved.canon_store == "missing"
@@ -180,7 +182,9 @@ def test_schema_ok_and_fail(tmp_path: Path) -> None:
         skip_mcp=True,
         skip_schema=False,
         tcp_checker=lambda _h, port, _t: port == 8010,
-        http_checker=lambda url, _t: 200 if "/health" in url or "/version" in url else None,
+        http_checker=lambda url, _t: (
+            200 if "/health" in url or "/version" in url else None
+        ),
         schema_checker=schema_ok,
         environ=env,
     )
@@ -189,7 +193,9 @@ def test_schema_ok_and_fail(tmp_path: Path) -> None:
         skip_mcp=True,
         skip_schema=False,
         tcp_checker=lambda _h, port, _t: port == 8010,
-        http_checker=lambda url, _t: 200 if "/health" in url or "/version" in url else None,
+        http_checker=lambda url, _t: (
+            200 if "/health" in url or "/version" in url else None
+        ),
         schema_checker=schema_fail,
         environ=env,
     )

--- a/tools/surrealdb/context_onboarding_doctor.py
+++ b/tools/surrealdb/context_onboarding_doctor.py
@@ -1,0 +1,538 @@
+"""Read-only context onboarding doctor for local SurrealDB / MCP preflight.
+
+Validates local Context Intelligence prerequisites without dangerous actions,
+secret output, DB writes, or stack mutation.
+
+Issue: #2642
+Epic: #1976
+
+Usage:
+    python -m tools.surrealdb.context_onboarding_doctor
+    python -m tools.surrealdb.context_onboarding_doctor --format json
+    make context-doctor
+
+Exit codes:
+    0 - core checks OK or only non-blocking warnings (e.g. MCP port down)
+    1 - onboarding not usable (missing secrets/config/DB/schema)
+    2 - CLI usage error
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import socket
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Literal
+
+from tools.surrealdb.local_schema_check import (
+    DEFAULT_DB,
+    DEFAULT_NS,
+    DEFAULT_SURREAL_URL,
+    EXPECTED_TABLES,
+)
+
+MCP_HOST = "127.0.0.1"
+MCP_PORT = 8811
+SURREALDB_URL = DEFAULT_SURREAL_URL
+CONTEXT_QUERY_LOCAL_REL = Path(
+    "infrastructure/config/surrealdb/context_query.local.yaml"
+)
+CONTEXT_QUERY_EXAMPLE_REL = Path(
+    "infrastructure/config/surrealdb/context_query.local.example.yaml"
+)
+SURREALDB_ENV_FILENAME = "SURREALDB_ENV"
+SURREALDB_ENV_EXAMPLE_REL = Path(
+    "infrastructure/config/surrealdb/SURREALDB_ENV.example"
+)
+
+EnvVarStatus = Literal["set_valid", "set_invalid", "unset"]
+ResolvedSource = Literal[
+    "CDB_CONTEXT_SECRETS_PATH", "SECRETS_PATH", "canon_default", "none"
+]
+ReachableStatus = Literal["reachable", "not_reachable", "skipped"]
+CheckStatus = Literal["ok", "fail", "skipped", "unsupported"]
+StoreStatus = Literal["exists", "missing"]
+ConfigStatus = Literal["exists", "missing"]
+
+FORBIDDEN_OUTPUT_SUBSTRINGS = (
+    "SURREAL_PASS",
+    "SURREAL_USER=",
+    "super-secret-password",
+    "sentinel://fake-secrets-path",
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _canon_default_secrets_dir() -> Path:
+    if os.name == "nt":
+        userprofile = os.environ.get("USERPROFILE", "").strip()
+        if userprofile:
+            return Path(userprofile) / "Documents" / ".secrets" / ".cdb"
+    return Path.home() / "Documents" / ".secrets" / ".cdb"
+
+
+def evaluate_env_var(name: str, environ: dict[str, str] | None = None) -> EnvVarStatus:
+    """Classify an env var as unset, set_invalid, or set_valid directory."""
+    env = os.environ if environ is None else environ
+    raw = env.get(name, "").strip()
+    if not raw:
+        return "unset"
+    path = Path(raw)
+    try:
+        if path.is_dir():
+            return "set_valid"
+    except OSError:
+        pass
+    return "set_invalid"
+
+
+def _candidate_secrets_dirs(
+    environ: dict[str, str] | None = None,
+) -> list[tuple[ResolvedSource, Path]]:
+    env = os.environ if environ is None else environ
+    candidates: list[tuple[ResolvedSource, Path]] = []
+
+    for env_key, source in (
+        ("CDB_CONTEXT_SECRETS_PATH", "CDB_CONTEXT_SECRETS_PATH"),
+        ("SECRETS_PATH", "SECRETS_PATH"),
+    ):
+        raw = env.get(env_key, "").strip()
+        if raw:
+            candidates.append((source, Path(raw)))
+
+    candidates.append(("canon_default", _canon_default_secrets_dir()))
+    return candidates
+
+
+@dataclass(frozen=True)
+class SecretsResolution:
+    resolved_source: ResolvedSource
+    canon_store: StoreStatus
+    surrealdb_env: StoreStatus
+    resolved_dir: Path | None = None
+
+
+def resolve_secrets_dir(
+    environ: dict[str, str] | None = None,
+) -> SecretsResolution:
+    for source, path in _candidate_secrets_dirs(environ):
+        try:
+            if path.is_dir():
+                env_file = path / SURREALDB_ENV_FILENAME
+                return SecretsResolution(
+                    resolved_source=source,
+                    canon_store="exists",
+                    surrealdb_env="exists" if env_file.is_file() else "missing",
+                    resolved_dir=path,
+                )
+        except OSError:
+            continue
+    return SecretsResolution(
+        resolved_source="none",
+        canon_store="missing",
+        surrealdb_env="missing",
+        resolved_dir=None,
+    )
+
+
+def check_tcp_reachable(
+    host: str,
+    port: int,
+    timeout: float = 2.0,
+    connector: Callable[[str, int, float], bool] | None = None,
+) -> bool:
+    if connector is not None:
+        return connector(host, port, timeout)
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def check_http_ok(
+    url: str,
+    timeout: float = 3.0,
+    opener: Callable[[str, float], int | None] | None = None,
+) -> bool:
+    if opener is not None:
+        status = opener(url, timeout)
+        return status == 200
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            return int(response.status) == 200
+    except (urllib.error.URLError, OSError, ValueError):
+        return False
+
+
+def _load_credentials(env_file: Path) -> tuple[str, str] | None:
+    if not env_file.is_file():
+        return None
+    user: str | None = None
+    password: str | None = None
+    try:
+        with env_file.open(encoding="utf-8") as fh:
+            for line in fh:
+                stripped = line.strip()
+                if stripped.startswith("SURREAL_USER="):
+                    user = stripped[len("SURREAL_USER=") :]
+                elif stripped.startswith("SURREAL_PASS="):
+                    password = stripped[len("SURREAL_PASS=") :]
+    except OSError:
+        return None
+    if not user or not password:
+        return None
+    return user, password
+
+
+def _sql_request(
+    url: str,
+    sql: str,
+    user: str,
+    password: str,
+    ns: str,
+    db: str,
+    timeout: float = 10.0,
+) -> tuple[int, bytes]:
+    token = base64.b64encode(f"{user}:{password}".encode()).decode()
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "text/plain",
+        "Authorization": f"Basic {token}",
+        "surreal-ns": ns,
+        "surreal-db": db,
+    }
+    req = urllib.request.Request(
+        f"{url}/sql", data=sql.encode(), headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+
+
+def _read_auth_mode(config_path: Path) -> str | None:
+    if not config_path.is_file():
+        return None
+    try:
+        import yaml  # noqa: PLC0415 — optional parse for doctor only
+
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    auth_mode = data.get("auth_mode")
+    return auth_mode if isinstance(auth_mode, str) else None
+
+
+def check_schema_readonly(
+    url: str,
+    user: str,
+    password: str,
+    ns: str = DEFAULT_NS,
+    db: str = DEFAULT_DB,
+    sql_request: Callable[..., tuple[int, bytes]] | None = None,
+) -> CheckStatus:
+    request = _sql_request if sql_request is None else sql_request
+    status, body = request(url, "INFO FOR DB;", user, password, ns, db)
+    if status not in (200, 204):
+        return "fail"
+    try:
+        response = json.loads(body)
+        if not isinstance(response, list) or not response:
+            return "fail"
+        result = response[0].get("result", {})
+        if not isinstance(result, dict):
+            return "fail"
+        tables_in_db = set(result.get("tables", {}).keys())
+    except (json.JSONDecodeError, KeyError, TypeError, IndexError):
+        return "fail"
+    missing = [table for table in EXPECTED_TABLES if table not in tables_in_db]
+    return "ok" if not missing else "fail"
+
+
+@dataclass
+class DoctorReport:
+    mcp_server_status: ReachableStatus = "skipped"
+    surrealdb_status: ReachableStatus = "skipped"
+    surrealdb_health: CheckStatus = "skipped"
+    surrealdb_version: CheckStatus = "skipped"
+    surrealdb_schema: CheckStatus = "skipped"
+    secrets_path_env: EnvVarStatus = "unset"
+    cdb_context_secrets_path_env: EnvVarStatus = "unset"
+    secrets_resolved_source: ResolvedSource = "none"
+    secrets_canon_store: StoreStatus = "missing"
+    secrets_surrealdb_env: StoreStatus = "missing"
+    config_context_query_local: ConfigStatus = "missing"
+    next_action: str = "no action required"
+    lr_note: str = "NO-GO"
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mcp_server": {"status": self.mcp_server_status},
+            "surrealdb": {
+                "status": self.surrealdb_status,
+                "health": self.surrealdb_health,
+                "version": self.surrealdb_version,
+                "schema": self.surrealdb_schema,
+            },
+            "env": {
+                "SECRETS_PATH": self.secrets_path_env,
+                "CDB_CONTEXT_SECRETS_PATH": self.cdb_context_secrets_path_env,
+            },
+            "secrets": {
+                "resolved_source": self.secrets_resolved_source,
+                "canon_store": self.secrets_canon_store,
+                "surrealdb_env": self.secrets_surrealdb_env,
+            },
+            "config": {
+                "context_query_local": self.config_context_query_local,
+            },
+            "next_action": self.next_action,
+            "lr_note": self.lr_note,
+            "warnings": list(self.warnings),
+        }
+
+
+def prioritize_next_action(report: DoctorReport) -> str:
+    if report.secrets_canon_store == "missing":
+        return "set SECRETS_PATH or CDB_CONTEXT_SECRETS_PATH"
+    if report.secrets_surrealdb_env == "missing":
+        return (
+            "create SURREALDB_ENV from "
+            "infrastructure/config/surrealdb/SURREALDB_ENV.example"
+        )
+    if report.config_context_query_local == "missing":
+        return (
+            "create context_query.local.yaml from "
+            "context_query.local.example.yaml"
+        )
+    if report.surrealdb_status == "not_reachable":
+        return "start local SurrealDB with make context-up"
+    if report.surrealdb_health == "fail" or report.surrealdb_version == "fail":
+        return "start local SurrealDB with make context-up"
+    if report.surrealdb_schema == "fail":
+        return "run make context-schema-apply"
+    infra_ready = (
+        report.secrets_canon_store == "exists"
+        and report.secrets_surrealdb_env == "exists"
+        and report.config_context_query_local == "exists"
+        and report.surrealdb_status == "reachable"
+        and report.surrealdb_health == "ok"
+        and report.surrealdb_version == "ok"
+        and report.surrealdb_schema in ("ok", "unsupported", "skipped")
+    )
+    if infra_ready and report.mcp_server_status == "not_reachable":
+        return (
+            "configure MCP host for 127.0.0.1:8811 or use stdio cdb_context "
+            "via claire-de-binare.mcp.json"
+        )
+    if infra_ready:
+        return "no action required"
+    return "no action required"
+
+
+def compute_exit_code(report: DoctorReport) -> int:
+    blocking = (
+        report.secrets_canon_store == "missing"
+        or report.secrets_surrealdb_env == "missing"
+        or report.config_context_query_local == "missing"
+        or report.surrealdb_status == "not_reachable"
+        or report.surrealdb_health == "fail"
+        or report.surrealdb_version == "fail"
+        or report.surrealdb_schema == "fail"
+    )
+    return 1 if blocking else 0
+
+
+def build_report(
+    repo_root: Path | None = None,
+    *,
+    skip_mcp: bool = False,
+    skip_schema: bool = False,
+    environ: dict[str, str] | None = None,
+    tcp_checker: Callable[[str, int, float], bool] | None = None,
+    http_checker: Callable[[str, float], bool] | None = None,
+    schema_checker: Callable[..., CheckStatus] | None = None,
+) -> DoctorReport:
+    root = _repo_root() if repo_root is None else repo_root
+    report = DoctorReport()
+
+    report.secrets_path_env = evaluate_env_var("SECRETS_PATH", environ)
+    report.cdb_context_secrets_path_env = evaluate_env_var(
+        "CDB_CONTEXT_SECRETS_PATH", environ
+    )
+
+    secrets = resolve_secrets_dir(environ)
+    report.secrets_resolved_source = secrets.resolved_source
+    report.secrets_canon_store = secrets.canon_store
+    report.secrets_surrealdb_env = secrets.surrealdb_env
+
+    config_path = root / CONTEXT_QUERY_LOCAL_REL
+    report.config_context_query_local = (
+        "exists" if config_path.is_file() else "missing"
+    )
+
+    if skip_mcp:
+        report.mcp_server_status = "skipped"
+    else:
+        report.mcp_server_status = (
+            "reachable"
+            if check_tcp_reachable(MCP_HOST, MCP_PORT, connector=tcp_checker)
+            else "not_reachable"
+        )
+        if report.mcp_server_status == "not_reachable":
+            report.warnings.append(
+                "MCP HTTP port 127.0.0.1:8811 is not reachable; "
+                "stdio cdb_context may still work"
+            )
+
+    surreal_reachable = check_tcp_reachable(
+        "127.0.0.1",
+        8010,
+        connector=tcp_checker,
+    )
+    report.surrealdb_status = "reachable" if surreal_reachable else "not_reachable"
+
+    if not surreal_reachable:
+        report.surrealdb_health = "skipped"
+        report.surrealdb_version = "skipped"
+        report.surrealdb_schema = "skipped"
+    else:
+        health_url = f"{SURREALDB_URL}/health"
+        version_url = f"{SURREALDB_URL}/version"
+        report.surrealdb_health = (
+            "ok" if check_http_ok(health_url, opener=http_checker) else "fail"
+        )
+        report.surrealdb_version = (
+            "ok" if check_http_ok(version_url, opener=http_checker) else "fail"
+        )
+
+        if skip_schema:
+            report.surrealdb_schema = "skipped"
+        elif report.config_context_query_local == "exists":
+            auth_mode = _read_auth_mode(config_path)
+            if auth_mode == "none":
+                report.surrealdb_schema = "unsupported"
+            elif secrets.resolved_dir is None or secrets.surrealdb_env == "missing":
+                report.surrealdb_schema = "skipped"
+            else:
+                creds = _load_credentials(secrets.resolved_dir / SURREALDB_ENV_FILENAME)
+                if creds is None:
+                    report.surrealdb_schema = "skipped"
+                else:
+                    user, password = creds
+                    checker = check_schema_readonly if schema_checker is None else schema_checker
+                    report.surrealdb_schema = checker(
+                        SURREALDB_URL, user, password
+                    )
+        else:
+            report.surrealdb_schema = "skipped"
+
+    report.next_action = prioritize_next_action(report)
+    return report
+
+
+def format_report(report: DoctorReport, fmt: str) -> str:
+    if fmt == "json":
+        return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    if fmt != "text":
+        raise ValueError(f"unsupported format: {fmt!r}")
+
+    lines = [
+        "=== Context Onboarding Doctor ===",
+        f"lr_note: {report.lr_note}",
+        "",
+        f"mcp_server.status: {report.mcp_server_status}",
+        f"surrealdb.status: {report.surrealdb_status}",
+        f"surrealdb.health: {report.surrealdb_health}",
+        f"surrealdb.version: {report.surrealdb_version}",
+        f"surrealdb.schema: {report.surrealdb_schema}",
+        "",
+        f"env.SECRETS_PATH: {report.secrets_path_env}",
+        f"env.CDB_CONTEXT_SECRETS_PATH: {report.cdb_context_secrets_path_env}",
+        f"secrets.resolved_source: {report.secrets_resolved_source}",
+        f"secrets.canon_store: {report.secrets_canon_store}",
+        f"secrets.surrealdb_env: {report.secrets_surrealdb_env}",
+        f"config.context_query_local: {report.config_context_query_local}",
+        "",
+        f"next_action: {report.next_action}",
+    ]
+    if report.warnings:
+        lines.append("")
+        lines.append("warnings:")
+        for warning in report.warnings:
+            lines.append(f"  - {warning}")
+    return "\n".join(lines)
+
+
+def _validate_output_safe(text: str) -> None:
+    for forbidden in FORBIDDEN_OUTPUT_SUBSTRINGS:
+        if forbidden in text:
+            raise ValueError(f"output contains forbidden substring: {forbidden}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only preflight for local Context Intelligence onboarding."
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--skip-mcp",
+        action="store_true",
+        help="Skip MCP TCP reachability check",
+    )
+    parser.add_argument(
+        "--skip-schema",
+        action="store_true",
+        help="Skip read-only SurrealDB schema check",
+    )
+    args = parser.parse_args(argv)
+
+    if args.format not in ("text", "json"):
+        print("ERROR: unsupported --format", file=sys.stderr)
+        return 2
+
+    report = build_report(
+        args.repo_root,
+        skip_mcp=args.skip_mcp,
+        skip_schema=args.skip_schema,
+    )
+    output = format_report(report, args.format)
+    _validate_output_safe(output)
+    print(output)
+    return compute_exit_code(report)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc

--- a/tools/surrealdb/context_onboarding_doctor.py
+++ b/tools/surrealdb/context_onboarding_doctor.py
@@ -16,6 +16,7 @@ Exit codes:
     1 - onboarding not usable (missing secrets/config/DB/schema)
     2 - CLI usage error
 """
+
 from __future__ import annotations
 
 import argparse
@@ -317,8 +318,7 @@ def prioritize_next_action(report: DoctorReport) -> str:
         )
     if report.config_context_query_local == "missing":
         return (
-            "create context_query.local.yaml from "
-            "context_query.local.example.yaml"
+            "create context_query.local.yaml from " "context_query.local.example.yaml"
         )
     if report.surrealdb_status == "not_reachable":
         return "start local SurrealDB with make context-up"
@@ -382,9 +382,7 @@ def build_report(
     report.secrets_surrealdb_env = secrets.surrealdb_env
 
     config_path = root / CONTEXT_QUERY_LOCAL_REL
-    report.config_context_query_local = (
-        "exists" if config_path.is_file() else "missing"
-    )
+    report.config_context_query_local = "exists" if config_path.is_file() else "missing"
 
     if skip_mcp:
         report.mcp_server_status = "skipped"
@@ -435,10 +433,12 @@ def build_report(
                     report.surrealdb_schema = "skipped"
                 else:
                     user, password = creds
-                    checker = check_schema_readonly if schema_checker is None else schema_checker
-                    report.surrealdb_schema = checker(
-                        SURREALDB_URL, user, password
+                    checker = (
+                        check_schema_readonly
+                        if schema_checker is None
+                        else schema_checker
                     )
+                    report.surrealdb_schema = checker(SURREALDB_URL, user, password)
         else:
             report.surrealdb_schema = "skipped"
 


### PR DESCRIPTION
## Summary
- Adds read-only `context_onboarding_doctor` CLI for local SurrealDB/MCP/secrets/config preflight
- Adds `make context-doctor` target and runbook entries for operator onboarding
- Includes 24 unit tests; no secrets in output, no DB writes, no trading/LR changes

Closes #2642

## Test plan
- [x] `pytest -q tests/unit/surrealdb/test_context_onboarding_doctor.py` (24 passed)
- [x] `ruff check tools/surrealdb/context_onboarding_doctor.py tests/unit/surrealdb/test_context_onboarding_doctor.py`
- [x] `python -m tools.surrealdb.context_onboarding_doctor --format json` (local smoke)

Made with [Cursor](https://cursor.com)