### PR TITLE
feat(agents): add PR2 CDB governance skills for Cursor

### DIFF
--- a/.codex/cdb_skills/cdb-ci-cd-guard/SKILL.md
+++ b/.codex/cdb_skills/cdb-ci-cd-guard/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: cdb-ci-cd-guard
+description: CDB CI/CD governance audit and hardening for the working repo. Use when GitHub Actions, rulesets, required checks, secret guards, or fake-green behavior need to be verified or fixed. Derive protected refs, required checks, and enforcement behavior from current repo evidence and GitHub state instead of assuming old branch patterns or legacy docs-hub paths.
+---
+
+# CI/CD Guard
+
+## Canon first
+- Use the working repo as the only default source.
+- Start control-first:
+  1. GitHub control issue `#1445`
+  2. newest weekly comment on `#1445`
+  3. stage-ratification issue `#1492` as Board context only
+  4. `docs/runbooks/CONTROL_REGISTER.md`
+  5. `CURRENT_STATUS.md`
+  6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+  7. only then inspect rulesets, issues, PRs, and workflows
+- Read `docs/index.md` and `docs/runbooks/merge_policy_ci_gate.md` for local CI canon after the control-first chain.
+- Treat GitHub rulesets and required checks as evidence-bearing runtime state. If they are not observable, report the gap instead of inventing a result.
+- Treat `#1492` only as current Board context, not as any CI or LR override.
+
+## Use this when
+- a run is green but hidden stub, mock, skip, or fallback behavior is suspected
+- required checks, branch protection, secret guards, or delivery gates look inconsistent
+- workflow behavior changes by branch or secret availability
+
+## Hard rules
+- Do not assume protected branch patterns. Derive them from current rulesets, workflows, or explicit user input.
+- No silent stub or mock path on protected refs.
+- Missing critical secrets on protected refs must fail closed.
+- Without explicit approval, default to audit plus fix plan rather than mutation.
+
+## Workflow
+1. Inventory active workflows and identify gate-bearing jobs.
+2. Derive protected refs, required checks, and enforcement scope from repo evidence plus GitHub state.
+3. Search for fake-green vectors: stub, mock, fallback, skipped gates, soft-fail secret handling.
+4. Verify that guard decisions are visible in logs and outputs.
+5. Produce deterministic evidence per workflow: protected behavior, unprotected behavior, secret handling, merge-blocking effect.
+6. If fixes are needed, propose the smallest reversible patchset first.
+
+## Output
+- PASS or FAIL
+- concrete enforcement gaps, grouped by workflow or ruleset
+- mapping table: workflow -> trigger/ref scope -> secret behavior -> merge effect
+- minimal fix plan, or patchset if explicit approval exists

--- a/.codex/cdb_skills/cdb-contract-evidence-gatekeeper/SKILL.md
+++ b/.codex/cdb_skills/cdb-contract-evidence-gatekeeper/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: cdb-contract-evidence-gatekeeper
+description: 'Hard gatekeeper for Claire_de_Binare acceptance and evidence decisions. Use when the task is deciding `freigabefaehig`, `closure-ready`, `wirklich erledigt`, `go/no-go`, `accept/reject`, `PASS/BLOCKED`, blocker vs non-blocking gap, report artifact vs real defect, canon drift vs evidence gap, Stage-System vs LR-System vs Repo/Engineering-Status, or cross-service contract ambiguity around producer, owner, unit, metadata, persistence, or proof. Do not use for broad implementation work.'
+---
+
+# CDB Contract Evidence Gatekeeper
+
+## Purpose
+Use this skill for hard gate decisions, not for implementation.
+
+This skill exists to decide whether a claim, issue, PR, report, status change, or proposed conclusion is actually justified under the current Claire_de_Binare canon.
+
+Use it to stop:
+- fake closure
+- status inflation
+- stage/LR confusion
+- narrative replacing evidence
+- contract claims passing without producer, owner, unit, or persistence clarity
+
+## Use this skill when
+- the user asks `freigabefaehig?`
+- the user asks `closure-ready?`
+- the user asks `wirklich erledigt?`
+- the user asks for go/no-go, accept/reject, PASS/BLOCKED
+- the user asks whether something is a blocker or only a non-blocking gap
+- the user asks to separate Stage-System, LR-System, and Repo/Engineering-Status
+- the user asks whether a claim is repo-backed or only narrative
+- the user asks whether a problem is canon drift, contract drift, evidence gap, policy ambiguity, or only a reporting artifact
+- the user asks whether cross-service metadata, payload, producer, owner, unit, or persistence claims are actually proven
+
+## Do NOT use this skill when
+- the task is mainly feature implementation
+- the task is broad coding work without a gate decision
+- the task is routine documentation editing without an acceptance question
+- the task is a straightforward CI repair with no canon, evidence, or gate ambiguity
+- the task is future architecture brainstorming without a current closure or acceptance decision
+
+If the hard decision is complete and the remaining work becomes implementation, hand off to the relevant execution skill.
+
+## Mandatory canon sources
+Before making a gate decision, use this control-first order:
+
+1. `#1445`
+2. newest weekly comment in `#1445`
+3. `#1492` only when Stage-/`trade-capable`-context is involved
+4. `docs/runbooks/CONTROL_REGISTER.md`
+5. `CURRENT_STATUS.md`
+6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+7. only then directly relevant issues, PRs, files, tests, and committed evidence artifacts
+
+If the task does not touch GitHub, stage, LR, or status claims, scale this down conservatively. If it does touch those surfaces, skipping the canon is forbidden.
+
+## Hard rules
+### 1. Status-class first
+Classify every decision surface before judging it:
+- Stage-System
+- LR-System
+- Repo/Engineering-Status
+- Runtime/Operator-Reality
+- CI/Workflow-Reality
+- Data-contract/persistence-reality
+- Documentation/reporting quality
+
+If more than one class is involved, split them. Never let one system silently overwrite another.
+
+### 2. SSOT boundaries are mandatory
+- `CURRENT_STATUS.md` = repo and engineering status
+- `docs/runbooks/CONTROL_REGISTER.md` = control-board focus, stage context, cockpit memory
+- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` = LR verdict and LR phase status
+- `#1445` = operational control umbrella
+- `#1492` = ratified stage context only when `trade-capable` is relevant
+
+Never derive LR go/no-go from Board stage.
+Never read `trade-capable` as implicit live-readiness.
+Never treat issue closure by itself as proof.
+
+### 3. Evidence over narrative
+Split every claim into these buckets:
+- direct repo-backed evidence
+- indirect evidence
+- policy decision
+- assumption or interpretation
+- missing evidence
+
+Do not blend them into one soft conclusion.
+
+### 4. Fail closed on unresolved ambiguity
+Do not produce a fake PASS if any required gate depends on unresolved ambiguity such as:
+- unclear producer
+- unclear owner of truth
+- unclear units or semantics
+- unclear source of truth
+- unclear Stage-vs-LR scope
+- ambiguous evidence wording
+- memory-backed criteria with no repo anchor
+
+Use `BLOCKED` or `NON-BLOCKING GAP` instead.
+
+### 5. Separate policy from proof
+A maintainer policy decision can be valid, but it is not the same as repo-backed proof.
+If the conclusion depends on policy, say so explicitly.
+
+### 6. No fake closure
+Do not recommend full closure when the truthful result is one of these:
+- closure-ready with explicit limits
+- stage-ratified but LR-still-partial
+- fixed in code but not evidenced enough
+- report corrected, underlying system unchanged
+- non-blocking residual still needs to stay explicit
+
+### 7. Cross-service claims require contract checking
+If the task touches payload propagation, metadata, persistence, replayability, or cross-service meaning, inspect explicitly:
+- producer
+- consumer
+- owner of truth
+- units and semantics
+- propagation path
+- persisted surface
+- test coverage
+- fail-closed behavior
+
+Do not accept a cross-service claim just because one layer mentions the field.
+
+## Decision workflow
+1. Classify the decision surface.
+2. State the exact claim under review.
+3. Pull the canon and only the artifacts that can change the verdict.
+4. Build the evidence map.
+5. Classify each gap exactly once.
+6. Issue one verdict from the allowed verdict classes.
+7. Recommend exactly one next move.
+
+## Allowed verdict classes
+- `PASS`
+- `PASS WITH EXPLICIT LIMITS`
+- `NON-BLOCKING GAP`
+- `BLOCKED`
+- `OUT OF SCOPE`
+
+Use the narrowest truthful verdict.
+
+## Required output format
+1. `Decision surface`
+2. `Claim under review`
+3. `Canon anchors`
+4. `Evidence map`
+5. `Verdict`
+6. `Why`
+7. `Recommended next move`
+
+Optional:
+8. `Issue comment draft`
+
+## Special decision patterns
+### Report vs real system defect
+If the problem is only wording or reporting, say so directly.
+Use the smallest truthful label:
+- reporting artifact
+- canon drift
+- runtime defect
+- contract defect
+- evidence gap
+- policy ambiguity
+
+### Stage vs LR
+If Stage and LR diverge:
+- state both statuses explicitly
+- state which one is under review
+- forbid implicit promotion from one system into the other
+
+Typical pattern:
+- Stage: ratified or acceptable
+- LR: still partial or still NO-GO
+- conclusion: stage decision may pass with limits while LR cannot be upgraded
+
+### Code fixed, proof incomplete
+If implementation exists but proof for the claimed status is incomplete:
+- do not call it fully done
+- prefer `PASS WITH EXPLICIT LIMITS` or `NON-BLOCKING GAP`
+
+### Contract ambiguity
+If a field exists somewhere but producer, owner, unit, or meaning is unclear:
+- treat it as contract ambiguity
+- do not pass the claim as canonically clean
+
+## Repo-specific guardrails
+- `trade-capable` is a stage label, not live-capital authorization
+- `LR-050` remaining `NO-GO` is orthogonal to stage ratification
+- Grafana is not automatically a gate surface
+- Solo-maintainer reality applies; do not invent teams, reviewers, or escalation chains
+- evidence beats storytelling
+- non-blocking residuals must remain explicit instead of disappearing into comments
+- the working repo is canon
+- historical docs are not active proof unless explicitly relevant
+
+## Tooling posture
+- read-only first
+- inspect before action
+- prefer file reads, grep, issue reads, PR reads, tests, and committed artifacts
+- only propose writes, updates, or closure after the verdict is stable
+
+This skill should feel like a gate review, not like opportunistic implementation.
+
+## Anti-patterns
+Do not:
+- claim `PASS` because wording sounds convincing
+- treat issue closure as proof by itself
+- use remembered thresholds with no repo match
+- merge Stage, LR, and Repo status into one blended judgement
+- call something a blocker without naming the blocking system
+- call something done when it is really a non-blocking residual
+- accept field propagation without producer, owner, unit, and semantics clarity
+- rewrite scope just to avoid a hard verdict
+
+## References
+- Read [references/CDB_DECISION_SURFACE_MATRIX.md](references/CDB_DECISION_SURFACE_MATRIX.md) when the task spans multiple status classes.
+- Read [references/CDB_VERDICT_CLASSES.md](references/CDB_VERDICT_CLASSES.md) when the verdict boundary is tight.
+- Read [references/CDB_ISSUE_COMMENT_PATTERNS.md](references/CDB_ISSUE_COMMENT_PATTERNS.md) when the result should be posted back to GitHub.

--- a/.codex/cdb_skills/cdb-contract-evidence-gatekeeper/references/CDB_DECISION_SURFACE_MATRIX.md
+++ b/.codex/cdb_skills/cdb-contract-evidence-gatekeeper/references/CDB_DECISION_SURFACE_MATRIX.md
@@ -1,0 +1,17 @@
+# CDB Decision Surface Matrix
+
+Use this matrix before issuing a verdict.
+
+| Surface | Primary question | Canon anchor | Typical failure mode |
+|---|---|---|---|
+| Stage-System | Is a Board-stage claim or transition justified? | `#1445`, newest weekly comment, `#1492` when relevant, `docs/runbooks/CONTROL_REGISTER.md` | Stage is silently promoted into LR |
+| LR-System | Is a live-readiness claim justified? | `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` | `CURRENT_STATUS.md` is misread as LR authority |
+| Repo/Engineering-Status | Is the repo, PR, or engineering ledger claim justified? | `CURRENT_STATUS.md` | closed issue or merged code is overstated as broader proof |
+| Runtime/Operator-Reality | Is the system operable or fail-closed in practice? | current runbooks, committed artifacts, direct runtime evidence | dashboards or stories substitute for technical checks |
+| CI/Workflow-Reality | Is a workflow, gate, or ruleset claim justified? | workflows, rulesets, current GitHub state | green status hides skipped or soft-failed gates |
+| Data-contract/persistence-reality | Is a field or metadata claim proven end-to-end? | producer, consumer, tests, persisted artifacts | one layer mentions a field and the rest is assumed |
+| Documentation/reporting quality | Is the defect only phrasing or actually technical? | report text plus the canon it references | reporting artifact is inflated into system defect |
+
+Rule:
+- If more than one surface is involved, separate them.
+- Never let one verdict class overwrite another surface.

--- a/.codex/cdb_skills/cdb-contract-evidence-gatekeeper/references/CDB_ISSUE_COMMENT_PATTERNS.md
+++ b/.codex/cdb_skills/cdb-contract-evidence-gatekeeper/references/CDB_ISSUE_COMMENT_PATTERNS.md
@@ -1,0 +1,48 @@
+# CDB Issue Comment Patterns
+
+Use short issue-ready comments after the gate verdict is stable.
+
+## PASS WITH EXPLICIT LIMITS
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: PASS WITH EXPLICIT LIMITS
+
+Why:
+- Direct evidence: <artifact>
+- Limits: <explicit residual>
+- Not upgraded: <surface that remains unchanged>
+
+Next move:
+- <one concrete action>
+```
+
+## NON-BLOCKING GAP
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: NON-BLOCKING GAP
+
+Why:
+- The core claim is supportable for this surface.
+- Residual gap: <explicit gap>
+- This does not block: <named surface>
+
+Next move:
+- <one concrete action>
+```
+
+## BLOCKED
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: BLOCKED
+
+Why:
+- Missing or ambiguous proof: <artifact or contract gap>
+- Blocking system: <surface>
+- No fake PASS issued.
+
+Next move:
+- <one concrete action>
+```

--- a/.codex/cdb_skills/cdb-contract-evidence-gatekeeper/references/CDB_VERDICT_CLASSES.md
+++ b/.codex/cdb_skills/cdb-contract-evidence-gatekeeper/references/CDB_VERDICT_CLASSES.md
@@ -1,0 +1,26 @@
+# CDB Verdict Classes
+
+Use exactly one primary verdict.
+
+## PASS
+Use only when the claim is directly supported by the relevant canon and evidence.
+
+## PASS WITH EXPLICIT LIMITS
+Use when the claim is acceptable only with named boundaries that must stay visible.
+
+## NON-BLOCKING GAP
+Use when a real gap exists, but it does not block the decision surface under review.
+Keep the residual explicit.
+
+## BLOCKED
+Use when a required condition, proof basis, or source-of-truth boundary is unresolved.
+Do not soften this into narrative.
+
+## OUT OF SCOPE
+Use when the finding is real but not part of the current decision surface.
+Do not silently absorb it into the verdict.
+
+## Fast checks
+- If proof depends on memory, use `BLOCKED` or `NON-BLOCKING GAP`.
+- If Stage is acceptable but LR is still `NO-GO`, do not use `PASS` for LR.
+- If code is fixed but closure proof is incomplete, prefer `PASS WITH EXPLICIT LIMITS` or `NON-BLOCKING GAP`.

--- a/.codex/cdb_skills/cdb-drift-reconcile/SKILL.md
+++ b/.codex/cdb_skills/cdb-drift-reconcile/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: cdb-drift-reconcile
+description: >
+  Reconcile known Claire_de_Binare drift vectors against the current canon and
+  produce a conservative findings report. Use when Codex must inspect
+  documentation, runbooks, discovery surfaces, architecture maps, stack and
+  secrets references, or service catalogs for canon drift, classify each area
+  as belegt, unklar, or kein Befund, and separate documentation drift from
+  operational drift without expanding scope. Use this for bounded canon-drift
+  reconciliation, not for generic docs cleanup.
+---
+
+# CDB drift reconcile
+
+Check known drift vectors against the current canon and return a bounded reconciliation finding, not a broad cleanup campaign.
+
+## Inputs
+
+- A drift-check request, drift suspicion, or maintenance pass over canon surfaces.
+- Working repo at `D:\Dev\Workspaces\Repos\Claire_de_Binare`.
+- Access to `docs/runbooks/CONTROL_REGISTER.md` and the repo surfaces it points to.
+
+## Required Drift Areas
+
+Always check these areas unless the request explicitly narrows scope further:
+
+- Solo-Maintainer-Drift in SOPs
+- Terminologie-Drift: use `Risk Service` / `cdb_risk` consistently; avoid stale service terminology
+- Stack-Canon-Drift: `BLUE/RED` instead of legacy single-compose language
+- Secrets-Canon-Drift
+- SSOT-Grenzen between `CURRENT_STATUS.md` and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- Discovery-Surfaces / EntryPoints / Cheatsheets
+- `ARCHITECTURE_MAP` / `SERVICE_CATALOG` when service changes are implicated
+
+## Workflow
+
+1. Read `docs/runbooks/CONTROL_REGISTER.md` first.
+2. Build the search and review matrix from the drift vectors defined there:
+   - Do not invent new drift categories unless the control source itself requires them.
+   - Use the required drift areas above as the minimum matrix.
+3. Inspect only the repo surfaces needed to evaluate the active matrix:
+   - Runbooks, SOPs, status files, architecture maps, service catalogs, discovery docs, cheatsheets, and stack or secrets references.
+   - Pull service maps only when the suspected drift touches service naming, boundaries, or runtime topology.
+   - Keep historical snapshots and archive paths out of scope unless needed to confirm that something is merely historical.
+4. Classify every checked area with exactly one finding state:
+   - `belegt`
+   - `unklar`
+   - `kein Befund`
+5. For every `belegt` or `unklar` finding, separate the impact type:
+   - Documentation drift only
+   - Operational drift
+   - Blocker-relevant operational drift
+6. Reconcile conservatively:
+   - Treat historical anchors as historical unless current canon still points to them as active.
+   - Treat canon-boundary uncertainty as unresolved, not as clean.
+   - Do not convert every drift finding into a follow-up issue or workflow change.
+   - Keep Board stage separate from LR status at all times.
+
+## Classification Rules
+
+- `belegt` means the repo surface directly contradicts or lags the current canon.
+- `unklar` means the evidence is incomplete, ambiguous, or canon boundaries are not stable enough to call clean.
+- `kein Befund` means the checked surface matches the current canon closely enough for the reviewed vector.
+- Documentation drift only means wording, pointers, naming, or navigation are stale but the live operational path or enforced runtime behavior is not changed by the drift.
+- Operational drift means the stale canon can misroute execution, verification, secrets handling, stack invocation, or service understanding in current work.
+- Blocker-relevant operational drift means the drift can directly compromise safe operation, safe validation, or correct control interpretation and should be treated as a blocker until reconciled.
+
+## Fail-Closed Rules
+
+- If `CONTROL_REGISTER.md` cannot be read, stop and report reconciliation blocked.
+- If canon boundaries between active docs and historical snapshots cannot be determined confidently, classify the area as `unklar`.
+- If a surface looks stale but the active canon source is not identifiable, do not normalize it away; keep the finding conservative.
+- If service topology, secrets canon, or status-source boundaries may be affected and the relevant maps cannot be confirmed, do not downgrade below `unklar`.
+- If a finding appears historical only, but current entrypoints still route users there, classify it as active drift rather than archive noise.
+
+## Output
+
+Return the result in this structure:
+
+```md
+Drift-Befund
+- Area: belegt | unklar | kein Befund
+
+Betroffene Dateien / Artefakte
+- ...
+
+Schweregrad
+- low | medium | high
+
+Drift-Typ
+- Dokumentationsdrift | operative Drift | blocker-relevante operative Drift
+
+Empfohlene naechste Schritte
+- ...
+
+Nicht im Scope
+- ...
+```
+
+## Anti-Patterns
+
+- Do not turn every stale reference into a new issue.
+- Do not create meta-management work that is not justified by current canon.
+- Do not treat historical anchors as active tasks by default.
+- Do not expand from one drift vector into a full repo rewrite.
+- Do not read Board stage as LR-GO or use LR files to redefine Board stage.

--- a/.codex/cdb_skills/cdb-shadow-validation/SKILL.md
+++ b/.codex/cdb_skills/cdb-shadow-validation/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: cdb-shadow-validation
+description: >
+  Decide the conservative validation path for Claire_de_Binare strategy,
+  signal, execution, dataflow, contract, persistence, observability, or
+  shadow-relevant changes. Use when Codex must classify a change, assess blast
+  radius and risk against current control status, and choose exactly one
+  outcome: unit tests only, replay needed, mock exchange or emulator needed,
+  shadow evidence needed, or stop and do not release. Use after planning or
+  before session close when a concrete change needs a validation decision.
+---
+
+# CDB shadow validation
+
+Use this after planning narrows to a concrete change or before `cdb-session-close` when validation depth is still undecided. Choose the minimum safe validation path for a concrete change and fail closed when the evidence is incomplete.
+
+## Inputs
+
+- A concrete change, diff, PR, issue, commit, or scoped work description.
+- Working repo at `D:\Dev\Workspaces\Repos\Claire_de_Binare`.
+- Access to `docs/runbooks/CONTROL_REGISTER.md`, `CURRENT_STATUS.md`, and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`.
+
+## Required Outcomes
+
+Choose exactly one:
+
+- `nur Unit Tests`
+- `Replay noetig`
+- `MockExchange / Emulator noetig`
+- `Shadow-Evidence noetig`
+- `stoppen / nicht freigeben`
+
+## Workflow
+
+1. Read control status first, before looking at the change details in depth:
+   - Read `docs/runbooks/CONTROL_REGISTER.md`.
+   - Read `CURRENT_STATUS.md`.
+   - Read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`.
+   - Extract the current control boundary: Board stage may be `trade-capable`, but LR remains `NO-GO` and work stays shadow/mock only unless an explicit source proves otherwise.
+2. Determine the change class from evidence, not from intent:
+   - Strategy or signal logic.
+   - Execution, order, trade, routing, or exchange path.
+   - Interface, API, schema, or contract boundary.
+   - Data model, persistence, storage, or migration path.
+   - Observability, alerting, monitoring, or operator signal path.
+   - Purely local and isolated internal logic.
+3. Identify affected systems and contracts:
+   - Name the touched services, modules, adapters, reports, or persistence layers.
+   - Name any producer-consumer or request-response contracts affected.
+   - Name whether the change can influence orders, fills, positions, balances, signals, or operator decisions.
+4. Assess risk and blast radius conservatively:
+   - Low: isolated internal logic with no contract, execution, persistence, or control-signal effect.
+   - Medium: cross-module or contract-adjacent change without direct execution exposure.
+   - High: strategy, signal, execution, order, trade, persistence, or operator control path.
+   - Critical: ambiguous or multi-surface change, or any change where the blast radius cannot be bounded confidently.
+5. Select the validation path:
+   - `nur Unit Tests` only for low-risk isolated logic with no shadow, LR, contract, persistence, execution, or observability relevance.
+   - `Replay noetig` for strategy, signal, deterministic decision logic, contract-adjacent, or dataflow changes that can be validated offline without exchange behavior.
+   - `MockExchange / Emulator noetig` for execution, order lifecycle, adapter, fill-handling, or exchange-facing changes.
+   - `Shadow-Evidence noetig` for changes that can alter operational behavior, confidence, or release posture beyond replay or emulation alone, especially when strategy, signal, execution, observability, or cross-service interactions remain behaviorally relevant.
+   - `stoppen / nicht freigeben` if the change is ambiguous, unbounded, under-specified, conflicts with control status, or needs validation evidence that is unavailable.
+6. Escalate upward when uncertain:
+   - If two outcomes seem plausible, choose the stricter one.
+   - If the required validation environment or evidence cannot be confirmed, choose `stoppen / nicht freigeben`.
+   - If LR or shadow relevance is uncertain, treat the change as shadow-relevant.
+
+## Decision Rules
+
+- Never infer LR-GO from Board stage, repo status, or successful local tests.
+- Never allow live-capital reasoning or live-release implications.
+- Never mix unrelated scope into the validation decision.
+- Derive test depth from blast radius and risk, not from developer convenience.
+- Treat strategy and signal changes as behavior changes even when the diff looks small.
+- Treat contract, persistence, and observability changes as potentially cross-service until proven otherwise.
+- Treat missing evidence as increased risk, not as neutral.
+- Treat current `trade-capable` Board stage as orthogonal to validation strictness; it does not justify a lighter path.
+- If the selected path is anything other than `nur Unit Tests` for a truly isolated internal change, default the operational posture to shadow/mock only.
+
+## Fail-Closed Rules
+
+- If any required control file cannot be read, stop and return `stoppen / nicht freigeben`.
+- If the change scope cannot be bounded confidently, stop and return `stoppen / nicht freigeben`.
+- If execution, order, or trade paths may be touched but the boundary is unclear, require at least `MockExchange / Emulator noetig`; if even that scope is unclear, stop.
+- If cross-service contracts or persistence may be affected and offline evidence is insufficient, require at least `Replay noetig`; escalate to `Shadow-Evidence noetig` when behavior remains operationally relevant.
+- If observability or alerting changes could alter operator understanding, do not downgrade below the highest validation level justified by the affected operational path.
+- If the change has possible LR or shadow relevance and that relevance cannot be excluded, keep it shadow/mock only.
+
+## Output
+
+Return the result in this structure:
+
+```md
+Befund
+- ...
+
+Aenderungsklasse
+- ...
+
+Empfohlener Validierungspfad
+- one of: nur Unit Tests | Replay noetig | MockExchange / Emulator noetig | Shadow-Evidence noetig | stoppen / nicht freigeben
+
+Notwendige Checks
+- ...
+
+Stop-Kriterien
+- ...
+
+Restunsicherheiten
+- ...
+
+Shadow/mock only
+- yes/no + why
+```
+
+## Anti-Patterns
+
+- Do not guess the lightest validation path.
+- Do not reduce validation depth because the diff is small.
+- Do not treat passing unit tests as sufficient for strategy, signal, execution, contract, persistence, or observability changes.
+- Do not imply deployment or release approval from a validation-path decision.
+- Do not blur replay, emulation, and shadow evidence into one bucket.

--- a/.cursor/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.cursor/skills/cdb-ci-cd-guard/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: cdb-ci-cd-guard
+description: CDB CI/CD governance audit and hardening for the working repo. Use when GitHub Actions, rulesets, required checks, secret guards, or fake-green behavior need to be verified or fixed. Derive protected refs, required checks, and enforcement behavior from current repo evidence and GitHub state instead of assuming old branch patterns or legacy docs-hub paths.
+disable-model-invocation: true
+---
+
+# CI/CD Guard
+
+## Canon first
+- Use the working repo as the only default source.
+- Start control-first:
+  1. GitHub control issue `#1445`
+  2. newest weekly comment on `#1445`
+  3. stage-ratification issue `#1492` as Board context only
+  4. `docs/runbooks/CONTROL_REGISTER.md`
+  5. `CURRENT_STATUS.md`
+  6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+  7. only then inspect rulesets, issues, PRs, and workflows
+- Read `docs/index.md` and `docs/runbooks/merge_policy_ci_gate.md` for local CI canon after the control-first chain.
+- Treat GitHub rulesets and required checks as evidence-bearing runtime state. If they are not observable, report the gap instead of inventing a result.
+- Treat `#1492` only as current Board context, not as any CI or LR override.
+
+## Use this when
+- a run is green but hidden stub, mock, skip, or fallback behavior is suspected
+- required checks, branch protection, secret guards, or delivery gates look inconsistent
+- workflow behavior changes by branch or secret availability
+
+## Hard rules
+- Do not assume protected branch patterns. Derive them from current rulesets, workflows, or explicit user input.
+- No silent stub or mock path on protected refs.
+- Missing critical secrets on protected refs must fail closed.
+- Without explicit approval, default to audit plus fix plan rather than mutation.
+
+## Workflow
+1. Inventory active workflows and identify gate-bearing jobs.
+2. Derive protected refs, required checks, and enforcement scope from repo evidence plus GitHub state.
+3. Search for fake-green vectors: stub, mock, fallback, skipped gates, soft-fail secret handling.
+4. Verify that guard decisions are visible in logs and outputs.
+5. Produce deterministic evidence per workflow: protected behavior, unprotected behavior, secret handling, merge-blocking effect.
+6. If fixes are needed, propose the smallest reversible patchset first.
+
+## Output
+- PASS or FAIL
+- concrete enforcement gaps, grouped by workflow or ruleset
+- mapping table: workflow -> trigger/ref scope -> secret behavior -> merge effect
+- minimal fix plan, or patchset if explicit approval exists

--- a/.cursor/skills/cdb-contract-evidence-gatekeeper/SKILL.md
+++ b/.cursor/skills/cdb-contract-evidence-gatekeeper/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: cdb-contract-evidence-gatekeeper
+description: 'Hard gatekeeper for Claire_de_Binare acceptance and evidence decisions. Use when the task is deciding `freigabefaehig`, `closure-ready`, `wirklich erledigt`, `go/no-go`, `accept/reject`, `PASS/BLOCKED`, blocker vs non-blocking gap, report artifact vs real defect, canon drift vs evidence gap, Stage-System vs LR-System vs Repo/Engineering-Status, or cross-service contract ambiguity around producer, owner, unit, metadata, persistence, or proof. Do not use for broad implementation work.'
+disable-model-invocation: true
+---
+
+# CDB Contract Evidence Gatekeeper
+
+## Purpose
+Use this skill for hard gate decisions, not for implementation.
+
+This skill exists to decide whether a claim, issue, PR, report, status change, or proposed conclusion is actually justified under the current Claire_de_Binare canon.
+
+Use it to stop:
+- fake closure
+- status inflation
+- stage/LR confusion
+- narrative replacing evidence
+- contract claims passing without producer, owner, unit, or persistence clarity
+
+## Use this skill when
+- the user asks `freigabefaehig?`
+- the user asks `closure-ready?`
+- the user asks `wirklich erledigt?`
+- the user asks for go/no-go, accept/reject, PASS/BLOCKED
+- the user asks whether something is a blocker or only a non-blocking gap
+- the user asks to separate Stage-System, LR-System, and Repo/Engineering-Status
+- the user asks whether a claim is repo-backed or only narrative
+- the user asks whether a problem is canon drift, contract drift, evidence gap, policy ambiguity, or only a reporting artifact
+- the user asks whether cross-service metadata, payload, producer, owner, unit, or persistence claims are actually proven
+
+## Do NOT use this skill when
+- the task is mainly feature implementation
+- the task is broad coding work without a gate decision
+- the task is routine documentation editing without an acceptance question
+- the task is a straightforward CI repair with no canon, evidence, or gate ambiguity
+- the task is future architecture brainstorming without a current closure or acceptance decision
+
+If the hard decision is complete and the remaining work becomes implementation, hand off to the relevant execution skill.
+
+## Mandatory canon sources
+Before making a gate decision, use this control-first order:
+
+1. `#1445`
+2. newest weekly comment in `#1445`
+3. `#1492` only when Stage-/`trade-capable`-context is involved
+4. `docs/runbooks/CONTROL_REGISTER.md`
+5. `CURRENT_STATUS.md`
+6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+7. only then directly relevant issues, PRs, files, tests, and committed evidence artifacts
+
+If the task does not touch GitHub, stage, LR, or status claims, scale this down conservatively. If it does touch those surfaces, skipping the canon is forbidden.
+
+## Hard rules
+### 1. Status-class first
+Classify every decision surface before judging it:
+- Stage-System
+- LR-System
+- Repo/Engineering-Status
+- Runtime/Operator-Reality
+- CI/Workflow-Reality
+- Data-contract/persistence-reality
+- Documentation/reporting quality
+
+If more than one class is involved, split them. Never let one system silently overwrite another.
+
+### 2. SSOT boundaries are mandatory
+- `CURRENT_STATUS.md` = repo and engineering status
+- `docs/runbooks/CONTROL_REGISTER.md` = control-board focus, stage context, cockpit memory
+- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` = LR verdict and LR phase status
+- `#1445` = operational control umbrella
+- `#1492` = ratified stage context only when `trade-capable` is relevant
+
+Never derive LR go/no-go from Board stage.
+Never read `trade-capable` as implicit live-readiness.
+Never treat issue closure by itself as proof.
+
+### 3. Evidence over narrative
+Split every claim into these buckets:
+- direct repo-backed evidence
+- indirect evidence
+- policy decision
+- assumption or interpretation
+- missing evidence
+
+Do not blend them into one soft conclusion.
+
+### 4. Fail closed on unresolved ambiguity
+Do not produce a fake PASS if any required gate depends on unresolved ambiguity such as:
+- unclear producer
+- unclear owner of truth
+- unclear units or semantics
+- unclear source of truth
+- unclear Stage-vs-LR scope
+- ambiguous evidence wording
+- memory-backed criteria with no repo anchor
+
+Use `BLOCKED` or `NON-BLOCKING GAP` instead.
+
+### 5. Separate policy from proof
+A maintainer policy decision can be valid, but it is not the same as repo-backed proof.
+If the conclusion depends on policy, say so explicitly.
+
+### 6. No fake closure
+Do not recommend full closure when the truthful result is one of these:
+- closure-ready with explicit limits
+- stage-ratified but LR-still-partial
+- fixed in code but not evidenced enough
+- report corrected, underlying system unchanged
+- non-blocking residual still needs to stay explicit
+
+### 7. Cross-service claims require contract checking
+If the task touches payload propagation, metadata, persistence, replayability, or cross-service meaning, inspect explicitly:
+- producer
+- consumer
+- owner of truth
+- units and semantics
+- propagation path
+- persisted surface
+- test coverage
+- fail-closed behavior
+
+Do not accept a cross-service claim just because one layer mentions the field.
+
+## Decision workflow
+1. Classify the decision surface.
+2. State the exact claim under review.
+3. Pull the canon and only the artifacts that can change the verdict.
+4. Build the evidence map.
+5. Classify each gap exactly once.
+6. Issue one verdict from the allowed verdict classes.
+7. Recommend exactly one next move.
+
+## Allowed verdict classes
+- `PASS`
+- `PASS WITH EXPLICIT LIMITS`
+- `NON-BLOCKING GAP`
+- `BLOCKED`
+- `OUT OF SCOPE`
+
+Use the narrowest truthful verdict.
+
+## Required output format
+1. `Decision surface`
+2. `Claim under review`
+3. `Canon anchors`
+4. `Evidence map`
+5. `Verdict`
+6. `Why`
+7. `Recommended next move`
+
+Optional:
+8. `Issue comment draft`
+
+## Special decision patterns
+### Report vs real system defect
+If the problem is only wording or reporting, say so directly.
+Use the smallest truthful label:
+- reporting artifact
+- canon drift
+- runtime defect
+- contract defect
+- evidence gap
+- policy ambiguity
+
+### Stage vs LR
+If Stage and LR diverge:
+- state both statuses explicitly
+- state which one is under review
+- forbid implicit promotion from one system into the other
+
+Typical pattern:
+- Stage: ratified or acceptable
+- LR: still partial or still NO-GO
+- conclusion: stage decision may pass with limits while LR cannot be upgraded
+
+### Code fixed, proof incomplete
+If implementation exists but proof for the claimed status is incomplete:
+- do not call it fully done
+- prefer `PASS WITH EXPLICIT LIMITS` or `NON-BLOCKING GAP`
+
+### Contract ambiguity
+If a field exists somewhere but producer, owner, unit, or meaning is unclear:
+- treat it as contract ambiguity
+- do not pass the claim as canonically clean
+
+## Repo-specific guardrails
+- `trade-capable` is a stage label, not live-capital authorization
+- `LR-050` remaining `NO-GO` is orthogonal to stage ratification
+- Grafana is not automatically a gate surface
+- Solo-maintainer reality applies; do not invent teams, reviewers, or escalation chains
+- evidence beats storytelling
+- non-blocking residuals must remain explicit instead of disappearing into comments
+- the working repo is canon
+- historical docs are not active proof unless explicitly relevant
+
+## Tooling posture
+- read-only first
+- inspect before action
+- prefer file reads, grep, issue reads, PR reads, tests, and committed artifacts
+- only propose writes, updates, or closure after the verdict is stable
+
+This skill should feel like a gate review, not like opportunistic implementation.
+
+## Anti-patterns
+Do not:
+- claim `PASS` because wording sounds convincing
+- treat issue closure as proof by itself
+- use remembered thresholds with no repo match
+- merge Stage, LR, and Repo status into one blended judgement
+- call something a blocker without naming the blocking system
+- call something done when it is really a non-blocking residual
+- accept field propagation without producer, owner, unit, and semantics clarity
+- rewrite scope just to avoid a hard verdict
+
+## References
+- Read [references/CDB_DECISION_SURFACE_MATRIX.md](references/CDB_DECISION_SURFACE_MATRIX.md) when the task spans multiple status classes.
+- Read [references/CDB_VERDICT_CLASSES.md](references/CDB_VERDICT_CLASSES.md) when the verdict boundary is tight.
+- Read [references/CDB_ISSUE_COMMENT_PATTERNS.md](references/CDB_ISSUE_COMMENT_PATTERNS.md) when the result should be posted back to GitHub.

--- a/.cursor/skills/cdb-contract-evidence-gatekeeper/references/CDB_DECISION_SURFACE_MATRIX.md
+++ b/.cursor/skills/cdb-contract-evidence-gatekeeper/references/CDB_DECISION_SURFACE_MATRIX.md
@@ -1,0 +1,17 @@
+# CDB Decision Surface Matrix
+
+Use this matrix before issuing a verdict.
+
+| Surface | Primary question | Canon anchor | Typical failure mode |
+|---|---|---|---|
+| Stage-System | Is a Board-stage claim or transition justified? | `#1445`, newest weekly comment, `#1492` when relevant, `docs/runbooks/CONTROL_REGISTER.md` | Stage is silently promoted into LR |
+| LR-System | Is a live-readiness claim justified? | `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` | `CURRENT_STATUS.md` is misread as LR authority |
+| Repo/Engineering-Status | Is the repo, PR, or engineering ledger claim justified? | `CURRENT_STATUS.md` | closed issue or merged code is overstated as broader proof |
+| Runtime/Operator-Reality | Is the system operable or fail-closed in practice? | current runbooks, committed artifacts, direct runtime evidence | dashboards or stories substitute for technical checks |
+| CI/Workflow-Reality | Is a workflow, gate, or ruleset claim justified? | workflows, rulesets, current GitHub state | green status hides skipped or soft-failed gates |
+| Data-contract/persistence-reality | Is a field or metadata claim proven end-to-end? | producer, consumer, tests, persisted artifacts | one layer mentions a field and the rest is assumed |
+| Documentation/reporting quality | Is the defect only phrasing or actually technical? | report text plus the canon it references | reporting artifact is inflated into system defect |
+
+Rule:
+- If more than one surface is involved, separate them.
+- Never let one verdict class overwrite another surface.

--- a/.cursor/skills/cdb-contract-evidence-gatekeeper/references/CDB_ISSUE_COMMENT_PATTERNS.md
+++ b/.cursor/skills/cdb-contract-evidence-gatekeeper/references/CDB_ISSUE_COMMENT_PATTERNS.md
@@ -1,0 +1,48 @@
+# CDB Issue Comment Patterns
+
+Use short issue-ready comments after the gate verdict is stable.
+
+## PASS WITH EXPLICIT LIMITS
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: PASS WITH EXPLICIT LIMITS
+
+Why:
+- Direct evidence: <artifact>
+- Limits: <explicit residual>
+- Not upgraded: <surface that remains unchanged>
+
+Next move:
+- <one concrete action>
+```
+
+## NON-BLOCKING GAP
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: NON-BLOCKING GAP
+
+Why:
+- The core claim is supportable for this surface.
+- Residual gap: <explicit gap>
+- This does not block: <named surface>
+
+Next move:
+- <one concrete action>
+```
+
+## BLOCKED
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: BLOCKED
+
+Why:
+- Missing or ambiguous proof: <artifact or contract gap>
+- Blocking system: <surface>
+- No fake PASS issued.
+
+Next move:
+- <one concrete action>
+```

--- a/.cursor/skills/cdb-contract-evidence-gatekeeper/references/CDB_VERDICT_CLASSES.md
+++ b/.cursor/skills/cdb-contract-evidence-gatekeeper/references/CDB_VERDICT_CLASSES.md
@@ -1,0 +1,26 @@
+# CDB Verdict Classes
+
+Use exactly one primary verdict.
+
+## PASS
+Use only when the claim is directly supported by the relevant canon and evidence.
+
+## PASS WITH EXPLICIT LIMITS
+Use when the claim is acceptable only with named boundaries that must stay visible.
+
+## NON-BLOCKING GAP
+Use when a real gap exists, but it does not block the decision surface under review.
+Keep the residual explicit.
+
+## BLOCKED
+Use when a required condition, proof basis, or source-of-truth boundary is unresolved.
+Do not soften this into narrative.
+
+## OUT OF SCOPE
+Use when the finding is real but not part of the current decision surface.
+Do not silently absorb it into the verdict.
+
+## Fast checks
+- If proof depends on memory, use `BLOCKED` or `NON-BLOCKING GAP`.
+- If Stage is acceptable but LR is still `NO-GO`, do not use `PASS` for LR.
+- If code is fixed but closure proof is incomplete, prefer `PASS WITH EXPLICIT LIMITS` or `NON-BLOCKING GAP`.

--- a/.cursor/skills/cdb-drift-reconcile/SKILL.md
+++ b/.cursor/skills/cdb-drift-reconcile/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: cdb-drift-reconcile
+description: >
+  Reconcile known Claire_de_Binare drift vectors against the current canon and
+  produce a conservative findings report. Use when Codex must inspect
+  documentation, runbooks, discovery surfaces, architecture maps, stack and
+  secrets references, or service catalogs for canon drift, classify each area
+  as belegt, unklar, or kein Befund, and separate documentation drift from
+  operational drift without expanding scope. Use this for bounded canon-drift
+  reconciliation, not for generic docs cleanup.
+disable-model-invocation: true
+---
+
+# CDB drift reconcile
+
+Check known drift vectors against the current canon and return a bounded reconciliation finding, not a broad cleanup campaign.
+
+## Inputs
+
+- A drift-check request, drift suspicion, or maintenance pass over canon surfaces.
+- Working repo at `D:\Dev\Workspaces\Repos\Claire_de_Binare`.
+- Access to `docs/runbooks/CONTROL_REGISTER.md` and the repo surfaces it points to.
+
+## Required Drift Areas
+
+Always check these areas unless the request explicitly narrows scope further:
+
+- Solo-Maintainer-Drift in SOPs
+- Terminologie-Drift: use `Risk Service` / `cdb_risk` consistently; avoid stale service terminology
+- Stack-Canon-Drift: `BLUE/RED` instead of legacy single-compose language
+- Secrets-Canon-Drift
+- SSOT-Grenzen between `CURRENT_STATUS.md` and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- Discovery-Surfaces / EntryPoints / Cheatsheets
+- `ARCHITECTURE_MAP` / `SERVICE_CATALOG` when service changes are implicated
+
+## Workflow
+
+1. Read `docs/runbooks/CONTROL_REGISTER.md` first.
+2. Build the search and review matrix from the drift vectors defined there:
+   - Do not invent new drift categories unless the control source itself requires them.
+   - Use the required drift areas above as the minimum matrix.
+3. Inspect only the repo surfaces needed to evaluate the active matrix:
+   - Runbooks, SOPs, status files, architecture maps, service catalogs, discovery docs, cheatsheets, and stack or secrets references.
+   - Pull service maps only when the suspected drift touches service naming, boundaries, or runtime topology.
+   - Keep historical snapshots and archive paths out of scope unless needed to confirm that something is merely historical.
+4. Classify every checked area with exactly one finding state:
+   - `belegt`
+   - `unklar`
+   - `kein Befund`
+5. For every `belegt` or `unklar` finding, separate the impact type:
+   - Documentation drift only
+   - Operational drift
+   - Blocker-relevant operational drift
+6. Reconcile conservatively:
+   - Treat historical anchors as historical unless current canon still points to them as active.
+   - Treat canon-boundary uncertainty as unresolved, not as clean.
+   - Do not convert every drift finding into a follow-up issue or workflow change.
+   - Keep Board stage separate from LR status at all times.
+
+## Classification Rules
+
+- `belegt` means the repo surface directly contradicts or lags the current canon.
+- `unklar` means the evidence is incomplete, ambiguous, or canon boundaries are not stable enough to call clean.
+- `kein Befund` means the checked surface matches the current canon closely enough for the reviewed vector.
+- Documentation drift only means wording, pointers, naming, or navigation are stale but the live operational path or enforced runtime behavior is not changed by the drift.
+- Operational drift means the stale canon can misroute execution, verification, secrets handling, stack invocation, or service understanding in current work.
+- Blocker-relevant operational drift means the drift can directly compromise safe operation, safe validation, or correct control interpretation and should be treated as a blocker until reconciled.
+
+## Fail-Closed Rules
+
+- If `CONTROL_REGISTER.md` cannot be read, stop and report reconciliation blocked.
+- If canon boundaries between active docs and historical snapshots cannot be determined confidently, classify the area as `unklar`.
+- If a surface looks stale but the active canon source is not identifiable, do not normalize it away; keep the finding conservative.
+- If service topology, secrets canon, or status-source boundaries may be affected and the relevant maps cannot be confirmed, do not downgrade below `unklar`.
+- If a finding appears historical only, but current entrypoints still route users there, classify it as active drift rather than archive noise.
+
+## Output
+
+Return the result in this structure:
+
+```md
+Drift-Befund
+- Area: belegt | unklar | kein Befund
+
+Betroffene Dateien / Artefakte
+- ...
+
+Schweregrad
+- low | medium | high
+
+Drift-Typ
+- Dokumentationsdrift | operative Drift | blocker-relevante operative Drift
+
+Empfohlene naechste Schritte
+- ...
+
+Nicht im Scope
+- ...
+```
+
+## Anti-Patterns
+
+- Do not turn every stale reference into a new issue.
+- Do not create meta-management work that is not justified by current canon.
+- Do not treat historical anchors as active tasks by default.
+- Do not expand from one drift vector into a full repo rewrite.
+- Do not read Board stage as LR-GO or use LR files to redefine Board stage.

--- a/.cursor/skills/cdb-shadow-validation/SKILL.md
+++ b/.cursor/skills/cdb-shadow-validation/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: cdb-shadow-validation
+description: >
+  Decide the conservative validation path for Claire_de_Binare strategy,
+  signal, execution, dataflow, contract, persistence, observability, or
+  shadow-relevant changes. Use when Codex must classify a change, assess blast
+  radius and risk against current control status, and choose exactly one
+  outcome: unit tests only, replay needed, mock exchange or emulator needed,
+  shadow evidence needed, or stop and do not release. Use after planning or
+  before session close when a concrete change needs a validation decision.
+disable-model-invocation: true
+---
+
+# CDB shadow validation
+
+Use this after planning narrows to a concrete change or before `cdb-session-close` when validation depth is still undecided. Choose the minimum safe validation path for a concrete change and fail closed when the evidence is incomplete.
+
+## Inputs
+
+- A concrete change, diff, PR, issue, commit, or scoped work description.
+- Working repo at `D:\Dev\Workspaces\Repos\Claire_de_Binare`.
+- Access to `docs/runbooks/CONTROL_REGISTER.md`, `CURRENT_STATUS.md`, and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`.
+
+## Required Outcomes
+
+Choose exactly one:
+
+- `nur Unit Tests`
+- `Replay noetig`
+- `MockExchange / Emulator noetig`
+- `Shadow-Evidence noetig`
+- `stoppen / nicht freigeben`
+
+## Workflow
+
+1. Read control status first, before looking at the change details in depth:
+   - Read `docs/runbooks/CONTROL_REGISTER.md`.
+   - Read `CURRENT_STATUS.md`.
+   - Read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`.
+   - Extract the current control boundary: Board stage may be `trade-capable`, but LR remains `NO-GO` and work stays shadow/mock only unless an explicit source proves otherwise.
+2. Determine the change class from evidence, not from intent:
+   - Strategy or signal logic.
+   - Execution, order, trade, routing, or exchange path.
+   - Interface, API, schema, or contract boundary.
+   - Data model, persistence, storage, or migration path.
+   - Observability, alerting, monitoring, or operator signal path.
+   - Purely local and isolated internal logic.
+3. Identify affected systems and contracts:
+   - Name the touched services, modules, adapters, reports, or persistence layers.
+   - Name any producer-consumer or request-response contracts affected.
+   - Name whether the change can influence orders, fills, positions, balances, signals, or operator decisions.
+4. Assess risk and blast radius conservatively:
+   - Low: isolated internal logic with no contract, execution, persistence, or control-signal effect.
+   - Medium: cross-module or contract-adjacent change without direct execution exposure.
+   - High: strategy, signal, execution, order, trade, persistence, or operator control path.
+   - Critical: ambiguous or multi-surface change, or any change where the blast radius cannot be bounded confidently.
+5. Select the validation path:
+   - `nur Unit Tests` only for low-risk isolated logic with no shadow, LR, contract, persistence, execution, or observability relevance.
+   - `Replay noetig` for strategy, signal, deterministic decision logic, contract-adjacent, or dataflow changes that can be validated offline without exchange behavior.
+   - `MockExchange / Emulator noetig` for execution, order lifecycle, adapter, fill-handling, or exchange-facing changes.
+   - `Shadow-Evidence noetig` for changes that can alter operational behavior, confidence, or release posture beyond replay or emulation alone, especially when strategy, signal, execution, observability, or cross-service interactions remain behaviorally relevant.
+   - `stoppen / nicht freigeben` if the change is ambiguous, unbounded, under-specified, conflicts with control status, or needs validation evidence that is unavailable.
+6. Escalate upward when uncertain:
+   - If two outcomes seem plausible, choose the stricter one.
+   - If the required validation environment or evidence cannot be confirmed, choose `stoppen / nicht freigeben`.
+   - If LR or shadow relevance is uncertain, treat the change as shadow-relevant.
+
+## Decision Rules
+
+- Never infer LR-GO from Board stage, repo status, or successful local tests.
+- Never allow live-capital reasoning or live-release implications.
+- Never mix unrelated scope into the validation decision.
+- Derive test depth from blast radius and risk, not from developer convenience.
+- Treat strategy and signal changes as behavior changes even when the diff looks small.
+- Treat contract, persistence, and observability changes as potentially cross-service until proven otherwise.
+- Treat missing evidence as increased risk, not as neutral.
+- Treat current `trade-capable` Board stage as orthogonal to validation strictness; it does not justify a lighter path.
+- If the selected path is anything other than `nur Unit Tests` for a truly isolated internal change, default the operational posture to shadow/mock only.
+
+## Fail-Closed Rules
+
+- If any required control file cannot be read, stop and return `stoppen / nicht freigeben`.
+- If the change scope cannot be bounded confidently, stop and return `stoppen / nicht freigeben`.
+- If execution, order, or trade paths may be touched but the boundary is unclear, require at least `MockExchange / Emulator noetig`; if even that scope is unclear, stop.
+- If cross-service contracts or persistence may be affected and offline evidence is insufficient, require at least `Replay noetig`; escalate to `Shadow-Evidence noetig` when behavior remains operationally relevant.
+- If observability or alerting changes could alter operator understanding, do not downgrade below the highest validation level justified by the affected operational path.
+- If the change has possible LR or shadow relevance and that relevance cannot be excluded, keep it shadow/mock only.
+
+## Output
+
+Return the result in this structure:
+
+```md
+Befund
+- ...
+
+Aenderungsklasse
+- ...
+
+Empfohlener Validierungspfad
+- one of: nur Unit Tests | Replay noetig | MockExchange / Emulator noetig | Shadow-Evidence noetig | stoppen / nicht freigeben
+
+Notwendige Checks
+- ...
+
+Stop-Kriterien
+- ...
+
+Restunsicherheiten
+- ...
+
+Shadow/mock only
+- yes/no + why
+```
+
+## Anti-Patterns
+
+- Do not guess the lightest validation path.
+- Do not reduce validation depth because the diff is small.
+- Do not treat passing unit tests as sufficient for strategy, signal, execution, contract, persistence, or observability changes.
+- Do not imply deployment or release approval from a validation-path decision.
+- Do not blur replay, emulation, and shadow evidence into one bucket.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,7 @@ except InvalidOperation:
 
 Codex skill surface: `.codex/cdb_skills/`
 
-Cursor skill surface: `.cursor/skills/` (repo-versioniert; PR 1: Session-Foundation)
+Cursor skill surface: `.cursor/skills/` (repo-versioniert; PR 1 Session-Foundation, PR 2 Governance & Validation)
 
 OpenCode skill surface zusaetzlich: `.opencode/skills/` (gezielt laden, nicht pauschal).
 
@@ -245,11 +245,11 @@ OpenCode skill surface zusaetzlich: `.opencode/skills/` (gezielt laden, nicht pa
 | `cdb-session-close` | Disciplined session close with honest summary | `.cursor/skills/cdb-session-close/SKILL.md` |
 | `cdb-issue-to-session-plan` | Convert issue to session plan | `.cursor/skills/cdb-issue-to-session-plan/SKILL.md` |
 | `cdb-control-intake` | Control context reading | `.cursor/skills/cdb-control-intake/SKILL.md` |
-| `cdb-shadow-validation` | Shadow validation workflows |
+| `cdb-shadow-validation` | Shadow validation workflows | `.cursor/skills/cdb-shadow-validation/SKILL.md` |
 | `cdb-backtest-engine` | Backtest engine operations |
-| `cdb-ci-cd-guard` | CI/CD guardrails |
-| `cdb-contract-evidence-gatekeeper` | Contract evidence gating |
-| `cdb-drift-reconcile` | Drift reconciliation |
+| `cdb-ci-cd-guard` | CI/CD guardrails | `.cursor/skills/cdb-ci-cd-guard/SKILL.md` |
+| `cdb-contract-evidence-gatekeeper` | Contract evidence gating | `.cursor/skills/cdb-contract-evidence-gatekeeper/SKILL.md` |
+| `cdb-drift-reconcile` | Drift reconciliation | `.cursor/skills/cdb-drift-reconcile/SKILL.md` |
 | `cdb-exchange-adapters` | Exchange adapter operations |
 | `cdb-risk-governance` | Risk governance operations |
 | `cdb-trading-core` | Trading core operations |


### PR DESCRIPTION
## Summary

- Port Wave 2 governance and validation skills from .opencode/skills/ to .codex/cdb_skills/ (canon) and .cursor/skills/ (Cursor mirror).
- Skills: cdb-shadow-validation, cdb-contract-evidence-gatekeeper (+ references), cdb-drift-reconcile, cdb-ci-cd-guard.
- All four Cursor skills use disable-model-invocation: true; session-start/close unchanged from PR 1.
- Minimal AGENTS.md update: Cursor paths for Wave 2 skills and surface note (no CLAUDE.md change).

## Test plan

- [x] 15 files staged (4 Codex SKILL.md + 3 gatekeeper refs × 2 surfaces + 4 Cursor SKILL.md + AGENTS.md)
- [x] No nested junk, scripts, or __pycache__ from local skill-pack drift
- [x] context_query.local.yaml not staged
- [ ] CI + policy-gate green on PR

Made with [Cursor](https://cursor.com)