### PR TITLE
feat(agents): add PR3 CDB domain and ops skills for Cursor

### DIFF
--- a/.codex/cdb_skills/cdb-backtest-engine/SKILL.md
+++ b/.codex/cdb_skills/cdb-backtest-engine/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: cdb-backtest-engine
+description: Deterministic CDB backtesting and strategy evaluation in the working repo. Use when Codex needs to run or update offline backtests, parameter sweeps, walk-forward tests, baseline comparisons, or PR-ready evidence packs. Treat the local working repo as canon, not the retired external docs repo; never infer live readiness from Board stage; no live keys, no live or testnet execution.
+---
+
+# Backtest Engine
+
+## Canon first
+- Use local working-repo paths only.
+- Read `CURRENT_STATUS.md` for repo and engineering context.
+- Read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for Echtgeld guardrails and current `NO-GO`.
+- Read `docs/runbooks/CONTROL_REGISTER.md` for Board stage, but never treat `trade-capable` as live authorization.
+
+## Use this when you see
+- backtest, walk-forward, parameter sweep
+- baseline comparison or regression check
+- equity curve, drawdown, Sharpe, profit factor
+- evidence pack, report, or gate-supporting metrics
+
+## Hard rules
+- Evidence over assumptions: if the dataset, baseline, or configuration is ambiguous, stop and surface the missing artifact.
+- Determinism required: freeze dataset window, seed, parameters, and code reference.
+- Offline replay only. Do not call live or testnet endpoints.
+- Always print output artifact paths in the final response.
+
+## Default deliverables
+1. `results.json` for raw run output when available
+2. `metrics.json` for computed summary
+3. `report.md` for human-readable evidence
+4. `compare.md` only when a baseline is provided

--- a/.codex/cdb_skills/cdb-docs-ops/SKILL.md
+++ b/.codex/cdb_skills/cdb-docs-ops/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: cdb-docs-ops
+description: 'Create or update CDB operational documentation from the working-repo canon. Use when Codex needs to capture system state, derive a health/status digest, write a tactical runbook, or build a crisis playbook. Keep the current SSOT split explicit: `CURRENT_STATUS.md` for repo state, `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for Echtgeld Go/No-Go, and `docs/runbooks/CONTROL_REGISTER.md` for Board stage and operating focus.'
+---
+
+# CDB Ops Docs
+
+## Canon first
+- Working repo only. Do not default to retired external docs repos.
+- Start control-first:
+  1. GitHub control issue `#1445`
+  2. newest weekly comment on `#1445`
+  3. stage-ratification issue `#1492` as Board context only
+  4. `docs/runbooks/CONTROL_REGISTER.md`
+  5. `CURRENT_STATUS.md`
+  6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+  7. only then supporting issues, PRs, or repo artifacts
+- Keep status classes separate:
+  - `CURRENT_STATUS.md` = repo and engineering state
+  - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` = live-readiness verdict
+  - `docs/runbooks/CONTROL_REGISTER.md` = Board stage and operating focus
+- Never restate `trade-capable` as live authorization. LR is still `NO-GO`.
+- Treat `#1492` strictly as ratified stage context, never as LR clearance.
+
+## Modes
+1. Create a source doc from raw operational knowledge.
+2. Derive exactly one artifact from source docs or canon docs:
+   - status digest
+   - runbook
+   - playbook
+
+## Source doc rules
+- Use deterministic wording only.
+- Capture facts, constraints, dependencies, downstream impact, and invalidation triggers.
+- If the request mixes repo state, LR verdict, and Board stage, split them explicitly instead of collapsing them into one status claim.
+- If evidence is missing, stop and ask targeted questions rather than filling gaps with assumptions.
+
+## Artifact rules
+- Status digest for health or "where do we stand?"
+- Runbook for tactical recovery steps
+- Playbook for multi-step incidents or human-gated crisis handling
+- Use semantic colors only for gates, verdicts, triggers, and expected results.
+
+## Safety
+- No real trades.
+- No irreversible action without explicit human approval.
+- For any live-trading topic, treat `knowledge/operating_rules/LIVE_TRADING_RUNBOOK.md` as procedure shape only and `LR-AUDIT-STATUS` as the verdict authority.

--- a/.codex/cdb_skills/cdb-exchange-adapters/SKILL.md
+++ b/.codex/cdb_skills/cdb-exchange-adapters/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: cdb-exchange-adapters
+description: CDB exchange-adapter work in the current working repo. Use when Codex needs to implement or harden REST or websocket adapters, order or market-data normalization, rate-limit handling, reconnect logic, or idempotent exchange boundaries. Prefer current repo realities and active integrations; treat MEXC as the default exchange only when the repo context proves it, and keep all work in paper or testnet-safe scope.
+---
+
+# Exchange Adapters
+
+## Canon first
+- Use the working repo as canon. Do not reference the retired external docs repo.
+- Read `CURRENT_STATUS.md` and local adapter code before assuming the active exchange scope.
+- Stage `trade-capable` is not a license for live endpoints or live keys.
+
+## Trigger phrases
+- exchange adapter, REST client, websocket client
+- MEXC, Binance, Crypto.com, market data, order schema
+- rate limit, retry, backoff, reconnect, heartbeat
+- idempotency, auth failure, timeout taxonomy
+
+## Non-negotiables
+- No real keys in code.
+- Default-safe scope is paper/mock only.
+- Testnet is allowed only with explicit user GO and an explicit reason.
+- Live endpoints / real keys are never the default; do not derive any live-trading authorization from this skill text.
+- Normalize to the repo's current internal schema instead of inventing a new one.
+- Add tests for happy path plus failure taxonomy.
+- Include one simulated failure case that proves retry or backoff behavior.
+
+## Deliverables
+- adapter module or boundary patch
+- tests for success and failure paths
+- short evidence snippet for the user or PR

--- a/.codex/cdb_skills/cdb-operator/SKILL.md
+++ b/.codex/cdb_skills/cdb-operator/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: cdb-operator
+description: Enforces Claire de Binare operator workflow: bootloader first, live GitHub truth, dry-run planning, strict GO gates, no merge without human approval.
+compatibility: opencode
+metadata:
+  project: claire-de-binare
+  workflow: operator
+---
+
+# CDB Operator Skill
+
+## Purpose
+
+Use this skill when working on Claire_de_Binare with OpenCode.
+
+## Required workflow
+
+1. Read `AGENTS.md` in the repo root.
+2. Follow the pointer to `agents/AGENTS.md`.
+3. Read `agents/OPEN_CODE_AGENTS.md` if present.
+4. Read the complete repo read order before planning.
+5. Pull GitHub issue and PR state live.
+6. Treat `CURRENT_STATUS.md` as ledger, not live truth.
+7. Produce only Lage, Befund, Plan, Dry-Run, Validierung, Restunsicherheiten.
+8. Do not write, commit, push, comment, label, close, or merge without explicit human GO.
+
+## Stop conditions
+
+Stop immediately on missing bootloader, unclear scope, unexpected diff, red checks, pending checks before merge, scope growth, or any live-readiness/echtgeld implication.
+

--- a/.codex/cdb_skills/cdb-risk-governance/SKILL.md
+++ b/.codex/cdb_skills/cdb-risk-governance/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: cdb-risk-governance
+description: CDB risk-governance changes for the current Risk Service (`cdb_risk`). Use when Codex needs to implement or harden enforceable limits, kill-switches, drawdown or exposure caps, fail-closed gating, or human-approval semantics. Respect the current repo canon, the `Risk Service` naming, and the fact that Board stage does not clear live trading.
+---
+
+# Risk Governance
+
+## Canon first
+- Use the working repo and current `Risk Service` / `cdb_risk` terminology.
+- Read `CURRENT_STATUS.md` for recent risk and runtime changes.
+- Read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` before making any claim about live readiness.
+- Never interpret `trade-capable` as permission to resume or enable live trading.
+
+## Trigger phrases
+- risk limits, daily loss, drawdown
+- kill switch, circuit breaker, stop trading
+- exposure cap, position cap, leverage guard
+- no-trade mode, human approval, fail-closed gate
+
+## Non-negotiables
+- Critical breaches must produce a machine-checkable stop state.
+- Resume paths require explicit human approval where policy demands it.
+- Add tests for breach and non-breach paths.
+- If thresholds or policy intent are unclear, stop and surface the ambiguity instead of guessing.
+
+## Deliverables
+- guard logic and config changes
+- tests for breach and non-breach scenarios
+- concise evidence table mapping scenario to expected gate state

--- a/.codex/cdb_skills/cdb-trading-core/SKILL.md
+++ b/.codex/cdb_skills/cdb-trading-core/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: cdb-trading-core
+description: 'Trading-system development for Claire de Binare in the current working repo. Use when Codex needs cross-cutting work over strategy logic, backtesting, market-data flow, Risk Service integration, shadow or paper evidence, or performance reporting. Respect the current canon: the working repo is authoritative, `trade-capable` does not imply LR-GO, and no action may place live orders or use live credentials.'
+---
+
+# Claire de Binare Trading
+
+## Canon first
+- Use the working repo as canon; do not use the retired external docs repo.
+- Separate status classes:
+  - `CURRENT_STATUS.md` for repo and engineering state
+  - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for live-readiness verdict
+  - `docs/runbooks/CONTROL_REGISTER.md` for Board stage
+- Current reality: Board stage can be `trade-capable` while LR remains `NO-GO`.
+
+## Scope
+- strategy logic and evaluation
+- market-data and decision-flow plumbing
+- shadow or paper execution evidence
+- performance reporting
+- coordination across backtesting, exchange boundaries, and risk gates
+
+## Routing rule
+- If the task is mainly backtesting, prefer `cdb-backtest-engine`.
+- If the task is mainly exchange-boundary work, prefer `cdb-exchange-adapters`.
+- If the task is mainly gating or limits, prefer `cdb-risk-governance`.
+- Use this skill when the request spans multiple of those areas.
+
+## Working rules
+- Evidence over assumptions. If a strategy, exchange, or runtime mode is unclear, derive it from the repo or ask.
+- Prefer paper, replay, or shadow evidence.
+- Do not introduce live-order behavior.
+- Keep credentials in secret storage only and never print them.
+
+## Safety
+- No live orders.
+- No live-credential changes.
+- If the request implies enabling live trading, stop and point to `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` plus `knowledge/operating_rules/LIVE_TRADING_RUNBOOK.md` as procedure shape only.

--- a/.codex/cdb_skills/ctb-docker-stack/SKILL.md
+++ b/.codex/cdb_skills/ctb-docker-stack/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: ctb-ops-stack-skillpack
+description: Ops skillpack for the current CDB stack. Use when Codex needs command-first PowerShell guidance for Docker, compose, DR, rollback, incident response, or stack inspection in the working repo. Use canonical BLUE+RED runtime paths, respect `SECRETS_PATH`, and require explicit user approval before any mutating Docker or compose action.
+---
+
+# CDB Ops Stack Skillpack
+
+## Discovery mapping
+- Folder: ctb-docker-stack
+- Skill name: ctb-ops-stack-skillpack
+- Treat these as the same OpenCode skill surface; do not rename the folder or the skill in this patch.
+
+## Canon first
+- Working repo only.
+- Start control-first:
+  1. GitHub control issue `#1445`
+  2. newest weekly comment on `#1445`
+  3. ratified stage issue `#1492` as Board context only
+  4. `docs/runbooks/CONTROL_REGISTER.md`
+  5. `CURRENT_STATUS.md`
+  6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+  7. only then repo-level commands, issues, or PR actions
+- Use `knowledge/CDB_DOCKER_STACK_INVENTORY.md` only after the control-first chain above.
+- Treat Board stage and LR verdict separately. `trade-capable` does not authorize live operations.
+- `#1492` is ratified stage context, not LR-GO.
+
+## Approval gate
+For any command that mutates Docker Desktop, compose state, containers, networks, volumes, images, or configuration:
+
+> STOP -> present the exact command -> wait for explicit user approval -> then act
+
+This replaces older gate names. The required approver is the explicit user in the current thread.
+
+## Hard rules
+- No guessing. Missing runtime facts or target paths require a short clarifying question.
+- No secrets: never print secret values or secret file contents.
+- Use canonical compose files explicitly: `infrastructure/compose/compose.blue.yml` and `infrastructure/compose/compose.red.yml`.
+- Do not give single-compose shortcuts as default guidance; prefer `make docker-up` and explicitly reference `infrastructure/compose/compose.blue.yml` + `infrastructure/compose/compose.red.yml`.
+- Treat `SECRETS_PATH` as canonical for local secrets.
+- Never use `docker compose down -v` unless the user explicitly approves a destructive action.
+
+## Default output format
+1. Context snapshot
+2. Proposed commands, clearly marked as not executed until approved
+3. Mini-runbook
+4. Approval status: pending or approved

--- a/.codex/cdb_skills/gh-address-comments/SKILL.md
+++ b/.codex/cdb_skills/gh-address-comments/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: gh-address-comments
+description: Address GitHub PR review comments in the current repo with `gh`. Use when the user wants comment triage, replies, or code changes for review feedback on the current-branch PR or a specified PR. Verify `gh` authentication first, rebuild context control-first, and do not assume an open PR exists. This skill does not handle generic issue-comment threads unless a separate workflow is added.
+---
+
+# GitHub Comment Handler
+
+Run `gh` commands with escalated network access when needed.
+
+## Workflow
+1. Rebuild context control-first:
+   - inspect GitHub control issue `#1445`
+   - inspect the newest weekly comment on `#1445`
+   - treat issue `#1492` only as current stage context
+   - read `docs/runbooks/CONTROL_REGISTER.md`
+   - read `CURRENT_STATUS.md`
+   - read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+2. Verify `gh` authentication with `gh auth status`.
+3. Resolve the target PR:
+   - prefer the current branch PR when one exists
+   - otherwise use the explicit PR number or URL the user provided
+   - if no PR is discoverable, stop and ask for it
+4. Fetch comments and review threads with `gh` directly:
+   - `gh pr view <PR> --json reviewThreads,comments,reviews`
+   - `gh api /repos/{owner}/{repo}/pulls/<PR>/comments`
+   - optional: use a repo-provided helper script only if it exists locally
+5. Summarize actionable comments in numbered form.
+6. Stop and ask for explicit user GO, separately for:
+   - code changes (repo writes)
+   - GitHub writes (reply, review, resolve threads)
+7. Only after explicit GO: implement the selected code changes and/or draft the selected replies/resolves.
+
+## Rules
+- Do not assume there is an open PR for the current branch.
+- Do not imply support for generic issue-comment threads; this pack is PR-focused.
+- If auth or rate limits fail, ask the user to re-authenticate and retry.
+- Keep code changes scoped to the selected comments.
+- Do not read `#1492` as LR clearance.
+- Default is read-only: first read, then plan, then wait for explicit GO.
+- No code changes without explicit user GO.
+- No GitHub writes without explicit user GO (reply/review/resolve).
+- Never resolve review threads blindly; show the planned replies/resolves first and why.

--- a/.codex/cdb_skills/gh-fix-ci/SKILL.md
+++ b/.codex/cdb_skills/gh-fix-ci/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: gh-fix-ci
+description: Inspect failing GitHub PR checks in the current repo with `gh`, pull actionable GitHub Actions logs, summarize the failure context, then propose a fix plan and implement after explicit user approval. Use for GitHub Actions-based PR CI failures; for external checks, report the URL and keep them out of scope.
+---
+
+# GitHub CI Fix
+
+## Overview
+Use `gh` to locate failing PR checks, fetch GitHub Actions logs for actionable failures, summarize the failure snippet, then draft a concise plan in the current thread and implement after explicit approval.
+
+## Inputs
+- `repo`: path inside the repo, default `.`
+- `pr`: PR number or URL, optional
+- authenticated `gh`
+
+## Workflow
+1. Rebuild context control-first:
+   - inspect GitHub control issue `#1445`
+   - inspect the newest weekly comment on `#1445`
+   - treat issue `#1492` only as current stage context
+   - read `docs/runbooks/CONTROL_REGISTER.md`
+   - read `CURRENT_STATUS.md`
+   - read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+2. Verify `gh` authentication with `gh auth status`.
+3. Resolve the PR:
+   - prefer the current branch PR if present
+   - otherwise use the PR the user specified
+4. Inspect failing GitHub Actions checks:
+   - prefer `docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py`
+   - fall back to `gh pr checks`, `gh run view`, and log fetches if needed
+5. Separate GitHub Actions failures from external checks and mark external systems as out of scope.
+6. Summarize the failure with the check name, URL, and short log snippet.
+7. Draft a short fix plan in the current thread and wait for explicit user approval before implementation.
+8. After explicit approval, implement the fix, run relevant verification, and suggest rechecking PR status.
+
+## Rules
+- Do not depend on a separate `plan` skill.
+- Do not assume a fixed required-check count; use the current repo and GitHub state.
+- If logs are missing or the run is still active, say so explicitly.
+- Do not read `#1492` as LR clearance.
+
+## Bundled resource
+`docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py` fetches failing PR checks, extracts log snippets, and can emit JSON for summarization.

--- a/.cursor/skills/cdb-backtest-engine/SKILL.md
+++ b/.cursor/skills/cdb-backtest-engine/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: cdb-backtest-engine
+description: Deterministic CDB backtesting and strategy evaluation in the working repo. Use when Codex needs to run or update offline backtests, parameter sweeps, walk-forward tests, baseline comparisons, or PR-ready evidence packs. Treat the local working repo as canon, not the retired external docs repo; never infer live readiness from Board stage; no live keys, no live or testnet execution.
+disable-model-invocation: true
+---
+
+# Backtest Engine
+
+## Canon first
+- Use local working-repo paths only.
+- Read `CURRENT_STATUS.md` for repo and engineering context.
+- Read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for Echtgeld guardrails and current `NO-GO`.
+- Read `docs/runbooks/CONTROL_REGISTER.md` for Board stage, but never treat `trade-capable` as live authorization.
+
+## Use this when you see
+- backtest, walk-forward, parameter sweep
+- baseline comparison or regression check
+- equity curve, drawdown, Sharpe, profit factor
+- evidence pack, report, or gate-supporting metrics
+
+## Hard rules
+- Evidence over assumptions: if the dataset, baseline, or configuration is ambiguous, stop and surface the missing artifact.
+- Determinism required: freeze dataset window, seed, parameters, and code reference.
+- Offline replay only. Do not call live or testnet endpoints.
+- Always print output artifact paths in the final response.
+
+## Default deliverables
+1. `results.json` for raw run output when available
+2. `metrics.json` for computed summary
+3. `report.md` for human-readable evidence
+4. `compare.md` only when a baseline is provided

--- a/.cursor/skills/cdb-docs-ops/SKILL.md
+++ b/.cursor/skills/cdb-docs-ops/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: cdb-docs-ops
+description: 'Create or update CDB operational documentation from the working-repo canon. Use when Codex needs to capture system state, derive a health/status digest, write a tactical runbook, or build a crisis playbook. Keep the current SSOT split explicit: `CURRENT_STATUS.md` for repo state, `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for Echtgeld Go/No-Go, and `docs/runbooks/CONTROL_REGISTER.md` for Board stage and operating focus.'
+disable-model-invocation: true
+---
+
+# CDB Ops Docs
+
+## Canon first
+- Working repo only. Do not default to retired external docs repos.
+- Start control-first:
+  1. GitHub control issue `#1445`
+  2. newest weekly comment on `#1445`
+  3. stage-ratification issue `#1492` as Board context only
+  4. `docs/runbooks/CONTROL_REGISTER.md`
+  5. `CURRENT_STATUS.md`
+  6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+  7. only then supporting issues, PRs, or repo artifacts
+- Keep status classes separate:
+  - `CURRENT_STATUS.md` = repo and engineering state
+  - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` = live-readiness verdict
+  - `docs/runbooks/CONTROL_REGISTER.md` = Board stage and operating focus
+- Never restate `trade-capable` as live authorization. LR is still `NO-GO`.
+- Treat `#1492` strictly as ratified stage context, never as LR clearance.
+
+## Modes
+1. Create a source doc from raw operational knowledge.
+2. Derive exactly one artifact from source docs or canon docs:
+   - status digest
+   - runbook
+   - playbook
+
+## Source doc rules
+- Use deterministic wording only.
+- Capture facts, constraints, dependencies, downstream impact, and invalidation triggers.
+- If the request mixes repo state, LR verdict, and Board stage, split them explicitly instead of collapsing them into one status claim.
+- If evidence is missing, stop and ask targeted questions rather than filling gaps with assumptions.
+
+## Artifact rules
+- Status digest for health or "where do we stand?"
+- Runbook for tactical recovery steps
+- Playbook for multi-step incidents or human-gated crisis handling
+- Use semantic colors only for gates, verdicts, triggers, and expected results.
+
+## Safety
+- No real trades.
+- No irreversible action without explicit human approval.
+- For any live-trading topic, treat `knowledge/operating_rules/LIVE_TRADING_RUNBOOK.md` as procedure shape only and `LR-AUDIT-STATUS` as the verdict authority.

--- a/.cursor/skills/cdb-exchange-adapters/SKILL.md
+++ b/.cursor/skills/cdb-exchange-adapters/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: cdb-exchange-adapters
+description: CDB exchange-adapter work in the current working repo. Use when Codex needs to implement or harden REST or websocket adapters, order or market-data normalization, rate-limit handling, reconnect logic, or idempotent exchange boundaries. Prefer current repo realities and active integrations; treat MEXC as the default exchange only when the repo context proves it, and keep all work in paper or testnet-safe scope.
+disable-model-invocation: true
+---
+
+# Exchange Adapters
+
+## Canon first
+- Use the working repo as canon. Do not reference the retired external docs repo.
+- Read `CURRENT_STATUS.md` and local adapter code before assuming the active exchange scope.
+- Stage `trade-capable` is not a license for live endpoints or live keys.
+
+## Trigger phrases
+- exchange adapter, REST client, websocket client
+- MEXC, Binance, Crypto.com, market data, order schema
+- rate limit, retry, backoff, reconnect, heartbeat
+- idempotency, auth failure, timeout taxonomy
+
+## Non-negotiables
+- No real keys in code.
+- Default-safe scope is paper/mock only.
+- Testnet is allowed only with explicit user GO and an explicit reason.
+- Live endpoints / real keys are never the default; do not derive any live-trading authorization from this skill text.
+- Normalize to the repo's current internal schema instead of inventing a new one.
+- Add tests for happy path plus failure taxonomy.
+- Include one simulated failure case that proves retry or backoff behavior.
+
+## Deliverables
+- adapter module or boundary patch
+- tests for success and failure paths
+- short evidence snippet for the user or PR

--- a/.cursor/skills/cdb-operator/SKILL.md
+++ b/.cursor/skills/cdb-operator/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: cdb-operator
+description: Enforces Claire de Binare operator workflow: bootloader first, live GitHub truth, dry-run planning, strict GO gates, no merge without human approval.
+compatibility: opencode
+metadata:
+  project: claire-de-binare
+  workflow: operator
+disable-model-invocation: true
+---
+
+# CDB Operator Skill
+
+## Purpose
+
+Use this skill when working on Claire_de_Binare with OpenCode.
+
+## Required workflow
+
+1. Read `AGENTS.md` in the repo root.
+2. Follow the pointer to `agents/AGENTS.md`.
+3. Read `agents/OPEN_CODE_AGENTS.md` if present.
+4. Read the complete repo read order before planning.
+5. Pull GitHub issue and PR state live.
+6. Treat `CURRENT_STATUS.md` as ledger, not live truth.
+7. Produce only Lage, Befund, Plan, Dry-Run, Validierung, Restunsicherheiten.
+8. Do not write, commit, push, comment, label, close, or merge without explicit human GO.
+
+## Stop conditions
+
+Stop immediately on missing bootloader, unclear scope, unexpected diff, red checks, pending checks before merge, scope growth, or any live-readiness/echtgeld implication.
+

--- a/.cursor/skills/cdb-risk-governance/SKILL.md
+++ b/.cursor/skills/cdb-risk-governance/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: cdb-risk-governance
+description: CDB risk-governance changes for the current Risk Service (`cdb_risk`). Use when Codex needs to implement or harden enforceable limits, kill-switches, drawdown or exposure caps, fail-closed gating, or human-approval semantics. Respect the current repo canon, the `Risk Service` naming, and the fact that Board stage does not clear live trading.
+disable-model-invocation: true
+---
+
+# Risk Governance
+
+## Canon first
+- Use the working repo and current `Risk Service` / `cdb_risk` terminology.
+- Read `CURRENT_STATUS.md` for recent risk and runtime changes.
+- Read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` before making any claim about live readiness.
+- Never interpret `trade-capable` as permission to resume or enable live trading.
+
+## Trigger phrases
+- risk limits, daily loss, drawdown
+- kill switch, circuit breaker, stop trading
+- exposure cap, position cap, leverage guard
+- no-trade mode, human approval, fail-closed gate
+
+## Non-negotiables
+- Critical breaches must produce a machine-checkable stop state.
+- Resume paths require explicit human approval where policy demands it.
+- Add tests for breach and non-breach paths.
+- If thresholds or policy intent are unclear, stop and surface the ambiguity instead of guessing.
+
+## Deliverables
+- guard logic and config changes
+- tests for breach and non-breach scenarios
+- concise evidence table mapping scenario to expected gate state

--- a/.cursor/skills/cdb-trading-core/SKILL.md
+++ b/.cursor/skills/cdb-trading-core/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: cdb-trading-core
+description: 'Trading-system development for Claire de Binare in the current working repo. Use when Codex needs cross-cutting work over strategy logic, backtesting, market-data flow, Risk Service integration, shadow or paper evidence, or performance reporting. Respect the current canon: the working repo is authoritative, `trade-capable` does not imply LR-GO, and no action may place live orders or use live credentials.'
+disable-model-invocation: true
+---
+
+# Claire de Binare Trading
+
+## Canon first
+- Use the working repo as canon; do not use the retired external docs repo.
+- Separate status classes:
+  - `CURRENT_STATUS.md` for repo and engineering state
+  - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for live-readiness verdict
+  - `docs/runbooks/CONTROL_REGISTER.md` for Board stage
+- Current reality: Board stage can be `trade-capable` while LR remains `NO-GO`.
+
+## Scope
+- strategy logic and evaluation
+- market-data and decision-flow plumbing
+- shadow or paper execution evidence
+- performance reporting
+- coordination across backtesting, exchange boundaries, and risk gates
+
+## Routing rule
+- If the task is mainly backtesting, prefer `cdb-backtest-engine`.
+- If the task is mainly exchange-boundary work, prefer `cdb-exchange-adapters`.
+- If the task is mainly gating or limits, prefer `cdb-risk-governance`.
+- Use this skill when the request spans multiple of those areas.
+
+## Working rules
+- Evidence over assumptions. If a strategy, exchange, or runtime mode is unclear, derive it from the repo or ask.
+- Prefer paper, replay, or shadow evidence.
+- Do not introduce live-order behavior.
+- Keep credentials in secret storage only and never print them.
+
+## Safety
+- No live orders.
+- No live-credential changes.
+- If the request implies enabling live trading, stop and point to `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` plus `knowledge/operating_rules/LIVE_TRADING_RUNBOOK.md` as procedure shape only.

--- a/.cursor/skills/ctb-docker-stack/SKILL.md
+++ b/.cursor/skills/ctb-docker-stack/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: ctb-ops-stack-skillpack
+description: Ops skillpack for the current CDB stack. Use when Codex needs command-first PowerShell guidance for Docker, compose, DR, rollback, incident response, or stack inspection in the working repo. Use canonical BLUE+RED runtime paths, respect `SECRETS_PATH`, and require explicit user approval before any mutating Docker or compose action.
+disable-model-invocation: true
+---
+
+# CDB Ops Stack Skillpack
+
+## Discovery mapping
+- Folder: ctb-docker-stack
+- Skill name: ctb-ops-stack-skillpack
+- Treat these as the same OpenCode skill surface; do not rename the folder or the skill in this patch.
+
+## Canon first
+- Working repo only.
+- Start control-first:
+  1. GitHub control issue `#1445`
+  2. newest weekly comment on `#1445`
+  3. ratified stage issue `#1492` as Board context only
+  4. `docs/runbooks/CONTROL_REGISTER.md`
+  5. `CURRENT_STATUS.md`
+  6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+  7. only then repo-level commands, issues, or PR actions
+- Use `knowledge/CDB_DOCKER_STACK_INVENTORY.md` only after the control-first chain above.
+- Treat Board stage and LR verdict separately. `trade-capable` does not authorize live operations.
+- `#1492` is ratified stage context, not LR-GO.
+
+## Approval gate
+For any command that mutates Docker Desktop, compose state, containers, networks, volumes, images, or configuration:
+
+> STOP -> present the exact command -> wait for explicit user approval -> then act
+
+This replaces older gate names. The required approver is the explicit user in the current thread.
+
+## Hard rules
+- No guessing. Missing runtime facts or target paths require a short clarifying question.
+- No secrets: never print secret values or secret file contents.
+- Use canonical compose files explicitly: `infrastructure/compose/compose.blue.yml` and `infrastructure/compose/compose.red.yml`.
+- Do not give single-compose shortcuts as default guidance; prefer `make docker-up` and explicitly reference `infrastructure/compose/compose.blue.yml` + `infrastructure/compose/compose.red.yml`.
+- Treat `SECRETS_PATH` as canonical for local secrets.
+- Never use `docker compose down -v` unless the user explicitly approves a destructive action.
+
+## Default output format
+1. Context snapshot
+2. Proposed commands, clearly marked as not executed until approved
+3. Mini-runbook
+4. Approval status: pending or approved

--- a/.cursor/skills/gh-address-comments/SKILL.md
+++ b/.cursor/skills/gh-address-comments/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: gh-address-comments
+description: Address GitHub PR review comments in the current repo with `gh`. Use when the user wants comment triage, replies, or code changes for review feedback on the current-branch PR or a specified PR. Verify `gh` authentication first, rebuild context control-first, and do not assume an open PR exists. This skill does not handle generic issue-comment threads unless a separate workflow is added.
+disable-model-invocation: true
+---
+
+# GitHub Comment Handler
+
+Run `gh` commands with escalated network access when needed.
+
+## Workflow
+1. Rebuild context control-first:
+   - inspect GitHub control issue `#1445`
+   - inspect the newest weekly comment on `#1445`
+   - treat issue `#1492` only as current stage context
+   - read `docs/runbooks/CONTROL_REGISTER.md`
+   - read `CURRENT_STATUS.md`
+   - read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+2. Verify `gh` authentication with `gh auth status`.
+3. Resolve the target PR:
+   - prefer the current branch PR when one exists
+   - otherwise use the explicit PR number or URL the user provided
+   - if no PR is discoverable, stop and ask for it
+4. Fetch comments and review threads with `gh` directly:
+   - `gh pr view <PR> --json reviewThreads,comments,reviews`
+   - `gh api /repos/{owner}/{repo}/pulls/<PR>/comments`
+   - optional: use a repo-provided helper script only if it exists locally
+5. Summarize actionable comments in numbered form.
+6. Stop and ask for explicit user GO, separately for:
+   - code changes (repo writes)
+   - GitHub writes (reply, review, resolve threads)
+7. Only after explicit GO: implement the selected code changes and/or draft the selected replies/resolves.
+
+## Rules
+- Do not assume there is an open PR for the current branch.
+- Do not imply support for generic issue-comment threads; this pack is PR-focused.
+- If auth or rate limits fail, ask the user to re-authenticate and retry.
+- Keep code changes scoped to the selected comments.
+- Do not read `#1492` as LR clearance.
+- Default is read-only: first read, then plan, then wait for explicit GO.
+- No code changes without explicit user GO.
+- No GitHub writes without explicit user GO (reply/review/resolve).
+- Never resolve review threads blindly; show the planned replies/resolves first and why.

--- a/.cursor/skills/gh-fix-ci/SKILL.md
+++ b/.cursor/skills/gh-fix-ci/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: gh-fix-ci
+description: Inspect failing GitHub PR checks in the current repo with `gh`, pull actionable GitHub Actions logs, summarize the failure context, then propose a fix plan and implement after explicit user approval. Use for GitHub Actions-based PR CI failures; for external checks, report the URL and keep them out of scope.
+disable-model-invocation: true
+---
+
+# GitHub CI Fix
+
+## Overview
+Use `gh` to locate failing PR checks, fetch GitHub Actions logs for actionable failures, summarize the failure snippet, then draft a concise plan in the current thread and implement after explicit approval.
+
+## Inputs
+- `repo`: path inside the repo, default `.`
+- `pr`: PR number or URL, optional
+- authenticated `gh`
+
+## Workflow
+1. Rebuild context control-first:
+   - inspect GitHub control issue `#1445`
+   - inspect the newest weekly comment on `#1445`
+   - treat issue `#1492` only as current stage context
+   - read `docs/runbooks/CONTROL_REGISTER.md`
+   - read `CURRENT_STATUS.md`
+   - read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+2. Verify `gh` authentication with `gh auth status`.
+3. Resolve the PR:
+   - prefer the current branch PR if present
+   - otherwise use the PR the user specified
+4. Inspect failing GitHub Actions checks:
+   - prefer `docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py`
+   - fall back to `gh pr checks`, `gh run view`, and log fetches if needed
+5. Separate GitHub Actions failures from external checks and mark external systems as out of scope.
+6. Summarize the failure with the check name, URL, and short log snippet.
+7. Draft a short fix plan in the current thread and wait for explicit user approval before implementation.
+8. After explicit approval, implement the fix, run relevant verification, and suggest rechecking PR status.
+
+## Rules
+- Do not depend on a separate `plan` skill.
+- Do not assume a fixed required-check count; use the current repo and GitHub state.
+- If logs are missing or the run is still active, say so explicitly.
+- Do not read `#1492` as LR clearance.
+
+## Bundled resource
+`docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py` fetches failing PR checks, extracts log snippets, and can emit JSON for summarization.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,7 @@ except InvalidOperation:
 
 Codex skill surface: `.codex/cdb_skills/`
 
-Cursor skill surface: `.cursor/skills/` (repo-versioniert; PR 1 Session-Foundation, PR 2 Governance & Validation)
+Cursor skill surface: `.cursor/skills/` (repo-versioniert; PR 1–3: vollständige OpenCode-Migration)
 
 OpenCode skill surface zusaetzlich: `.opencode/skills/` (gezielt laden, nicht pauschal).
 
@@ -246,18 +246,19 @@ OpenCode skill surface zusaetzlich: `.opencode/skills/` (gezielt laden, nicht pa
 | `cdb-issue-to-session-plan` | Convert issue to session plan | `.cursor/skills/cdb-issue-to-session-plan/SKILL.md` |
 | `cdb-control-intake` | Control context reading | `.cursor/skills/cdb-control-intake/SKILL.md` |
 | `cdb-shadow-validation` | Shadow validation workflows | `.cursor/skills/cdb-shadow-validation/SKILL.md` |
-| `cdb-backtest-engine` | Backtest engine operations |
+| `cdb-backtest-engine` | Backtest engine operations | `.cursor/skills/cdb-backtest-engine/SKILL.md` |
 | `cdb-ci-cd-guard` | CI/CD guardrails | `.cursor/skills/cdb-ci-cd-guard/SKILL.md` |
 | `cdb-contract-evidence-gatekeeper` | Contract evidence gating | `.cursor/skills/cdb-contract-evidence-gatekeeper/SKILL.md` |
 | `cdb-drift-reconcile` | Drift reconciliation | `.cursor/skills/cdb-drift-reconcile/SKILL.md` |
-| `cdb-exchange-adapters` | Exchange adapter operations |
-| `cdb-risk-governance` | Risk governance operations |
-| `cdb-trading-core` | Trading core operations |
-| `cdb-docs-ops` | Documentation and ops-doc maintenance |
+| `cdb-exchange-adapters` | Exchange adapter operations | `.cursor/skills/cdb-exchange-adapters/SKILL.md` |
+| `cdb-risk-governance` | Risk governance operations | `.cursor/skills/cdb-risk-governance/SKILL.md` |
+| `cdb-trading-core` | Trading core operations | `.cursor/skills/cdb-trading-core/SKILL.md` |
+| `cdb-docs-ops` | Documentation and ops-doc maintenance | `.cursor/skills/cdb-docs-ops/SKILL.md` |
+| `cdb-operator` | Operator workflow (bootloader, GO gates) | `.cursor/skills/cdb-operator/SKILL.md` |
 | `codex-primary-runtime` | Core runtime operations |
-| `ctb-docker-stack` | Docker stack operations |
-| `gh-address-comments` | GitHub comment handling |
-| `gh-fix-ci` | CI fix operations |
+| `ctb-docker-stack` | Docker stack operations | `.cursor/skills/ctb-docker-stack/SKILL.md` |
+| `gh-address-comments` | GitHub comment handling | `.cursor/skills/gh-address-comments/SKILL.md` |
+| `gh-fix-ci` | CI fix operations | `.cursor/skills/gh-fix-ci/SKILL.md` |
 
 ---
 


### PR DESCRIPTION
## Summary
- Ports final Wave 3+4 CDB skills from OpenCode to .codex/cdb_skills.
- Adds Cursor versions for the same 9 domain/ops skills under .cursor/skills.
- Updates AGENTS.md Cursor path coverage.

## Scope
PR 3 only: final 9 domain/ops skills.

## Safety
- No secrets.
- No DB writes.
- No runtime or stack mutation.
- No trading/live-readiness change.
- LR remains NO-GO.
- context_query.local.yaml remains untracked/local-only.

## Validation
- 9/9 Codex skills copied from OpenCode SKILL.md only.
- 9/9 Cursor skills include disable-model-invocation: true.
- Ignored local packs stayed untracked/ignored and were not staged.
- PR 1+2+3 complete 17/17 OpenCode-CDB skill coverage for Codex + Cursor.

Made with [Cursor](https://cursor.com)