### PR TITLE
docs(session): close Cursor skills migration PR1-PR3 (#2653-2655)

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -3,14 +3,14 @@
 **Status Class**: Working Repo / Engineering Status
 **Authority**: Current repo/main/test/dependency snapshot; not the canonical live-readiness or Echtgeld Go/No-Go source.
 **Operational Canon**: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-**Last Updated**: 2026-05-15
+**Last Updated**: 2026-05-27
 **GitHub Boundary**: The live commit and PR state is tracked in GitHub (UI/API or `gh`); this file is a curated repo/engineering ledger, not a live mirror.
 
 ---
 
-## Repo / Engineering Status (2026-05-15)
+## Repo / Engineering Status (2026-05-27)
 
-- **main**: green (HEAD `87827c00`, PR #2495 gemergt; Merge-Commit `87827c00c1ecc14a472a4e51605331a0dd3f64a0`)
+- **main**: green (HEAD `87459c47`, PR #2655 gemergt; Merge-Commit `87459c47e3eff4887d5a54ca5957b116360e8a62`)
 - **Active GitHub focus (manual, non-exhaustive)**:
   - #2448 (CURRENT_STATUS focus reconcile — aktueller Hygiene-Slice)
   - #2440 (LR-030 Shadow/Soak Run — OPEN, Review-Befund `INCONCLUSIVE`, kein LR-Go)
@@ -99,6 +99,7 @@
 - **Merged (2026-05-14)**: PR #2482 (`0ac94adf`) — docs(arvp): reconcile calibration pilot status. `knowledge/governance/ARVP_PRODUCT_INTENT.md` mit repo-backed narrow pilot evidence aus `docs/evidence/arvp_calibration_pilot_1932_2026-04-26.md` reconciled. Guardrails unveraendert: #1900 bleibt OPEN als North-Star-/Control-Anchor; #1905 bleibt OPEN + `status:parked`; kein Unpark, kein Implementierungsstart, keine DB-Discovery, keine LR-/Live-/Echtgeld-Implikation.
 - **Merged (2026-05-15, Security Alert Readout #2289 — issue-automation Slice)**: PR #2495 (`87827c00`) — feat(security): add alert readout issue automation. Neues Skript `scripts/audit/security_issue_automation.py` (CLI: `--delta-json`, `--live-mode`; exit 0/1/2); 21 neue Unit-Tests (156 gesamt PASS); `_normalize_delta_keys()` in `security_alert_issue_candidates.py` ergaenzt. Workflow: neuer Job `issue-automation` nach `security-readout`; `comment-epic` jetzt `needs: [security-readout, issue-automation]` mit dynamischer Ledger-Boundary-Zeile. `TRIAGE_RUNBOOK.md` §10 ergaenzt. CONTROL_REGISTER.md Workflow-Control-Note hinzugefuegt (via #2496). Epic: #2289.
 - **Merged (Session 2026-05-27, Wave-14 Context Onboarding)**: PR #2651 (`7971437d`) — feat(surrealdb): context onboarding doctor (`make context-doctor`, read-only preflight). Closes #2642. PR #2608 (`9e16d3b5`) — build(surrealdb): Makefile OS-aware `PYTHON` default (`python` on Windows_NT, `python3` elsewhere); Makefile-only. Refs #2603 (Epic bleibt OPEN). Session-Log: `knowledge/logs/sessions/2026-05-27-context-onboarding-doctor-and-python-default.md`.
+- **Merged (Session 2026-05-27, Cursor Skills Migration PR 1–3)**: PR #2653 (`f3308489`) — Wave 0+1: `.gitignore` Codex-runtime hygiene; 4 session-foundation skills → `.codex/cdb_skills/` + `.cursor/skills/`; `CLAUDE.md`/`AGENTS.md`. PR #2654 (`d0e90efe`) — Wave 2: 4 governance skills + gatekeeper references. PR #2655 (`87459c47`) — Wave 3+4: final 9 domain/ops skills; 17/17 OpenCode CDB skills now in Codex + Cursor. Session-Log: `knowledge/logs/sessions/2026-05-27-cursor-skills-migration-pr1-pr3.md`. LR bleibt NO-GO.
 
 ---
 

--- a/knowledge/logs/sessions/2026-05-27-cursor-skills-migration-pr1-pr3.md
+++ b/knowledge/logs/sessions/2026-05-27-cursor-skills-migration-pr1-pr3.md
@@ -1,0 +1,54 @@
+# Session Log — 2026-05-27: Cursor Skills Migration (PR 1–3)
+
+## Scope
+
+OpenCode → Codex (`.codex/cdb_skills/`) → Cursor (`.cursor/skills/`) migration for all 17 CDB repo skills, delivered in three PRs. No runtime, trading, secrets, or LR changes.
+
+Status surfaces remain separated:
+
+- Repo/engineering ledger: `CURRENT_STATUS.md`
+- Board stage: `docs/runbooks/CONTROL_REGISTER.md` — `trade-capable`
+- Live-readiness: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` — **NO-GO**
+
+## Merged (repo-backed)
+
+| PR | Wave | Merge commit | Content |
+|----|------|--------------|---------|
+| #2653 | PR 1 — Session foundation | `f3308489` | `.gitignore` hygiene (`.system/`, `Anthropic-Cybersecurity-Skills/`); 4 skills: `cdb-control-intake`, `cdb-session-start`, `cdb-session-close`, `cdb-issue-to-session-plan`; `CLAUDE.md` + `AGENTS.md` |
+| #2654 | PR 2 — Governance & validation | `d0e90efe` | 4 skills + gatekeeper `references/` (3 files): `cdb-shadow-validation`, `cdb-contract-evidence-gatekeeper`, `cdb-drift-reconcile`, `cdb-ci-cd-guard`; `AGENTS.md` |
+| #2655 | PR 3 — Domain & ops | `87459c47` | Final 9 skills: `cdb-trading-core`, `cdb-risk-governance`, `cdb-exchange-adapters`, `cdb-backtest-engine`, `cdb-docs-ops`, `cdb-operator`, `ctb-docker-stack`, `gh-address-comments`, `gh-fix-ci`; `AGENTS.md` complete Cursor paths |
+
+**Coverage after #2655:** 17/17 OpenCode CDB skills in Codex + Cursor.
+
+## Hygiene / lessons
+
+- Local `.codex/cdb_skills/` contains ignored skill-pack drift (`jMerta/`, `skillforge/`, `mockexchange/`, nested `scripts/`/`assets/`/`references/`). **Never** use `Copy-Item -Recurse` from `.codex/` — source is **only** `.opencode/skills/<skill>/SKILL.md` (+ OpenCode `references/` when present).
+- Pre-commit gate: `git status --short --ignored .codex/cdb_skills .cursor/skills`
+- Codex paths need `git add -f` when local `.git/info/exclude` ignores `/.codex/`
+- Cursor frontmatter: Wave 2+3 skills use `disable-model-invocation: true`; `cdb-session-start` / `cdb-session-close` remain without it (PR 1 rule)
+
+## Validation evidence
+
+- All three PRs: CI SUCCESS, policy-gate SUCCESS, mergeState CLEAN
+- PR 3: 9/9 Codex SKILL.md byte-identical to OpenCode; 9/9 Cursor skills with `disable-model-invocation: true`
+- 19 files per PR 3 diff; no secrets, no DB/runtime/trading scope
+
+## Local-only (not committed)
+
+- `infrastructure/config/surrealdb/context_query.local.yaml` — operator local config; stays untracked
+
+## Operating rule (session outcome)
+
+Adopted for future agents: **work on concrete PR/Issue number; exhaust diagnostics first, ask only at governance gates** (merge, risky push, issue-close, scope expansion, secret/live/trading/LR risk, red CI without safe fix path).
+
+## Recommended next levers
+
+1. Optional: Cursor rule or `AGENTS.md` snippet codifying autonomy level above
+2. Optional: document local `.git/info/exclude` `/.codex/` pitfall for contributors
+3. `codex-primary-runtime` remains in skill table without OpenCode port (not in 17-skill set)
+
+## Session close metadata
+
+- **Branch at close**: `main` @ `87459c47`
+- **Working tree**: only untracked `context_query.local.yaml`
+- **Status**: erledigt (migration PR 1–3 landed on main)


### PR DESCRIPTION
## Summary
- Session log for Cursor skills migration PR 1–3 (17/17 OpenCode skills in Codex + Cursor).
- Updates CURRENT_STATUS.md ledger (main @ 87459c47 after #2655).

## Safety
- Docs-only. No secrets, DB, runtime, or trading changes.
- LR remains NO-GO.
- Does not include local \context_query.local.yaml\ (accidental checkpoint commit excluded from this branch).

## Test plan
- [x] Branch pushed from commit 2ab84501 only (not HEAD 4cc1c75f)
- [ ] CI + policy-gate green

Made with [Cursor](https://cursor.com)