### PR TITLE
docs(cli): improve context doctor help examples

### DIFF
--- a/tools/surrealdb/context_onboarding_doctor.py
+++ b/tools/surrealdb/context_onboarding_doctor.py
@@ -485,9 +485,25 @@ def _validate_output_safe(text: str) -> None:
             raise ValueError(f"output contains forbidden substring: {forbidden}")
 
 
+_HELP_EPILOG = """\
+Examples:
+  python -m tools.surrealdb.context_onboarding_doctor
+  python -m tools.surrealdb.context_onboarding_doctor --format json
+  python -m tools.surrealdb.context_onboarding_doctor --skip-mcp --skip-schema
+  make context-doctor
+
+Exit codes:
+  0  checks OK or only non-blocking warnings
+  1  onboarding not usable (missing secrets/config/DB/schema)
+  2  CLI usage error
+"""
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Read-only preflight for local Context Intelligence onboarding."
+        description="Read-only preflight for local Context Intelligence onboarding.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_HELP_EPILOG,
     )
     parser.add_argument(
         "--format",


### PR DESCRIPTION
## Summary
- Adds copy-pasteable examples to context onboarding doctor --help.
- Documents the doctor exit-code contract in CLI help.
- Keeps the doctor read-only and behavior unchanged.

## Scope
Small CLI discoverability/docs improvement for the existing context onboarding doctor.

## Validation
- python -m tools.surrealdb.context_onboarding_doctor --help
- pytest -q tests/unit/surrealdb/test_context_onboarding_doctor.py
- ruff check tools/surrealdb/context_onboarding_doctor.py tests/unit/surrealdb/test_context_onboarding_doctor.py
- black --config pyproject.toml --check tools/surrealdb/context_onboarding_doctor.py tests/unit/surrealdb/test_context_onboarding_doctor.py

## Safety
- No secrets.
- No DB writes.
- No stack mutation.
- No runtime/trading changes.
- LR remains NO-GO.

Refs #2657.
