### PR TITLE
fix(ops): stack verify logging default + Windows docker-health

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,12 +212,21 @@ docker-down:
 	docker compose -f infrastructure/compose/compose.red.yml down; \
 	docker compose -f infrastructure/compose/compose.blue.yml down
 
+ifeq ($(OS),Windows_NT)
+docker-health:
+	@echo "🏥 Prüfe Health-Status aller Container (BLUE+RED)..."
+	@echo "--- BLUE ---"
+	@pwsh -NoProfile -Command "docker compose -f infrastructure/compose/compose.blue.yml ps --format 'table {{.Name}}\t{{.Status}}' 2>$$null | Select-String 'cdb_'"
+	@echo "--- RED ---"
+	@pwsh -NoProfile -Command "docker compose -f infrastructure/compose/compose.red.yml ps --format 'table {{.Name}}\t{{.Status}}' 2>$$null | Select-String 'cdb_'"
+else
 docker-health:
 	@echo "🏥 Prüfe Health-Status aller Container (BLUE+RED)..."
 	@echo "--- BLUE ---"
 	@docker compose -f infrastructure/compose/compose.blue.yml ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null | grep cdb_ || true
 	@echo "--- RED ---"
 	@docker compose -f infrastructure/compose/compose.red.yml ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null | grep cdb_ || true
+endif
 
 # ============================================================================# Context (SurrealDB Local Runtime) — #2393 / #2394
 # Context Infrastructure only. No Trading-Runtime. No BLUE/RED touch.

--- a/infrastructure/compose/SERVICE_MAPPING.md
+++ b/infrastructure/compose/SERVICE_MAPPING.md
@@ -57,8 +57,8 @@
 
 | Service | Reason | Alternative |
 |---------|--------|-------------|
-| `cdb_loki` | Not in current compose | Removed earlier |
-| `cdb_promtail` | Not in current compose | Removed earlier |
+| `cdb_loki` | Not in current compose | Optional overlay via `logging.yml`; verify with `tools/verify_stack.ps1 -IncludeLogging:$true` |
+| `cdb_promtail` | Not in current compose | Optional overlay via `logging.yml`; verify with `tools/verify_stack.ps1 -IncludeLogging:$true` |
 | `cdb_node_exporter` | Removed from active BLUE+RED runtime canon due to Windows/WSL2 mount propagation issues | cAdvisor for container metrics; no host node-exporter metrics in current canon |
 
 ---

--- a/tools/README.md
+++ b/tools/README.md
@@ -32,7 +32,8 @@ Non-interactive form:
 
 - `infrastructure/scripts/init-secrets.ps1` - Initialize local secrets in `~/Documents/.secrets/.cdb`.
 - `infrastructure/scripts/setup_blue_red.ps1` - Canonical PowerShell runtime entrypoint for the BLUE+RED stack.
-- `tools/verify_stack.ps1` - Verify Docker stack health, expected volumes, networks, and optional endpoints.
+- `tools/verify_stack.ps1` - Verify Docker stack health, expected volumes, networks, and optional endpoints. Default expects canonical BLUE+RED only (10 services); pass `-IncludeLogging:$true` when the optional `logging.yml` overlay is running.
+- On Windows, prefer `.\tools\cdb.ps1 stack verify` for stack health; `make docker-health` is also Windows-compatible via PowerShell filtering.
 - `tools/cdb-service-logs.ps1` - Read focused service logs during runtime diagnosis.
 - `infrastructure/scripts/smoke_test.ps1` - Validate the current BLUE core flow path. This does not validate the full BLUE+RED stack end-to-end.
 

--- a/tools/verify_stack.ps1
+++ b/tools/verify_stack.ps1
@@ -12,7 +12,10 @@
 .PARAMETER StackName
     Stack name prefix (default: STACK_NAME env var or "cdb").
 .PARAMETER IncludeLogging
-    Include logging services (cdb_loki, cdb_promtail) in expected list.
+    Include logging overlay services (cdb_loki, cdb_promtail). Default is false
+    because Loki/Promtail live in infrastructure/compose/logging.yml, not the
+    canonical BLUE+RED start. Use -IncludeLogging:$true when the logging overlay
+    is running.
 .PARAMETER IncludePaperRunner
     Include paper trading runner in expected list.
 .PARAMETER ExpectedVolumes
@@ -25,12 +28,14 @@
     pwsh -File tools/verify_stack.ps1 -Verbose -Json
 .EXAMPLE
     .\tools\cdb.ps1 stack verify
+.EXAMPLE
+    pwsh -File tools/verify_stack.ps1 -IncludeLogging:$true -Verbose
 #>
 param(
     [switch]$Verbose,
     [switch]$Json,
     [string]$StackName = ($env:STACK_NAME | ForEach-Object { $_ }) ?? 'cdb',
-    [bool]$IncludeLogging = $true,
+    [bool]$IncludeLogging = $false,
     [bool]$IncludePaperRunner = $true,
     [int]$ExpectedVolumes = 6,
     [int]$ExpectedNetworks = 2
@@ -53,6 +58,10 @@ function Require-Command($name) {
 }
 
 Require-Command docker
+
+if (-not $IncludeLogging) {
+    Write-Info 'Logging overlay excluded (default). Pass -IncludeLogging:$true when logging.yml is up.'
+}
 
 $expectedServices = @(
     'cdb_redis',
@@ -156,7 +165,9 @@ if ($Verbose) {
         'cdb_paper_runner' = 'http://localhost:8004/health'
         'cdb_grafana' = 'http://localhost:3000/api/health'
         'cdb_prometheus' = 'http://localhost:19090/-/healthy'
-        'cdb_loki' = 'http://localhost:3100/ready'
+    }
+    if ($IncludeLogging) {
+        $endpoints['cdb_loki'] = 'http://localhost:3100/ready'
     }
 
     foreach ($key in $endpoints.Keys) {


### PR DESCRIPTION
## Summary
- Default `verify_stack.ps1` to canonical BLUE+RED (10 services); logging overlay opt-in via `-IncludeLogging:$true`
- Fix `make docker-health` on Windows using PowerShell `Select-String` instead of grep
- Update tools/README and SERVICE_MAPPING for optional Loki/Promtail

## Test plan
- [x] `git diff --check`
- [x] `make docker-health` (Windows)
- [x] `pwsh -NoProfile -File tools/verify_stack.ps1 -Json` (exit 0, logging excluded)

Closes #2668
Closes #2669

No LR impact; BLUE+RED canon unchanged.

Made with [Cursor](https://cursor.com)