### PR TITLE
docs: reconcile architecture catalog after stack verify update

### DIFF
--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -68,7 +68,7 @@ Hinweis: `services/signal/config.py` hat `SIGNAL_PORT`-Default `8001`; der kanon
 
 ### Logging Overlay (logging.yml) — separates Overlay, nicht Teil des Standard-BLUE/RED-Starts
 
-Aktivierung: `docker compose -f compose.blue.yml -f logging.yml up -d`
+Aktivierung: `docker compose -f infrastructure/compose/compose.blue.yml -f infrastructure/compose/logging.yml up -d`
 
 | Service | Container | Compose-Datei |
 |---------|-----------|---------------|
@@ -91,6 +91,16 @@ docker compose -f infrastructure/compose/compose.red.yml up -d
 
 # Schnellcheck
 docker ps --filter "name=cdb_" --format "table {{.Names}}\t{{.Status}}"
+
+# Kanonischer Stack-Verify (10 Services, BLUE+RED-Subset; Logging-Overlay standardmaessig aus)
+pwsh -NoProfile -File tools/verify_stack.ps1
+# Optional mit Loki/Promtail, wenn logging.yml laeuft:
+pwsh -NoProfile -File tools/verify_stack.ps1 -IncludeLogging:$true
+# Front Door:
+.\tools\cdb.ps1 stack verify
+
+# Makefile-Health (Windows-kompatibel via PowerShell-Filter statt grep)
+make docker-health
 ```
 
 ### Erwarteter Output (BLUE + RED healthy)
@@ -248,3 +258,4 @@ Legacy-Layer (base.yml, dev.yml, tls.yml, etc.) existieren noch, sind nicht mehr
 | 2026-04-23 | PR #1891 Nachzug: ARVP Operator-Facing Dataset Layer finalisiert (file\|db modes, db_dataset_window format, source-aware paths, legacy naming entfernt). CLI-Naming: run_accelerated_shadow_replay → run_arvp_replay (Issue #1892) | Codex |
 | 2026-04-24 | PRs #1914/#1916/#1918/#1920 Nachzug: ARVP validation comparisons & scorecards. shadow_compare, replay_vs_paper_compare, simulator_calibration_report, arvp_regime_scorecards, paper_reference_window_export + CLI-Runner dokumentiert. Offline-Validation, keine Runtime-Komponenten. (Issues #1915/#1917/#1919/#1921) | Codex |
 | 2026-05-13 | PR #2453/#2455 Nachzug: WS-Metrics-Delta-Logik + lazy `mexc_pb`-Client-Import sowie Postgres-Exporter-DSN/Secret-Wiring in RED-Compose dokumentiert (Issues #2454/#2456) | Codex |
+| 2026-05-29 | PR #2670/#2671 Nachzug: `verify_stack.ps1` Default ohne Logging-Overlay; `-IncludeLogging:$true` fuer Loki/Promtail; Logging-Aktivierungspfad auf `infrastructure/compose/` praezisiert; Windows-`make docker-health` ergaenzt (Issue #2671) | Codex |

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -172,10 +172,23 @@ docker compose -f infrastructure/compose/compose.red.yml up -d
 
 ---
 
+## Stack-Verification (kanonisch)
+
+| Pfad | Erwartung | Hinweis |
+|------|-----------|---------|
+| `tools/verify_stack.ps1` | 10 Services (BLUE+RED-Subset) | Default `$IncludeLogging = $false`; Loki/Promtail leben in `logging.yml`, nicht im Standard-Start |
+| `tools/verify_stack.ps1 -IncludeLogging:$true` | +2 OVERLAY-Services | Nur wenn `logging.yml`-Overlay aktiv ist |
+| `.\tools\cdb.ps1 stack verify` | Front Door zu `verify_stack.ps1` | Gleiche Semantik wie oben |
+| `make docker-health` | Container-Health via Makefile | Windows-kompatibel (PowerShell `Select-String`, kein `grep`) |
+
+Referenz: `infrastructure/compose/SERVICE_MAPPING.md`, PR #2670.
+
 ## Prüf-Checkliste (bei jedem Stack-Start)
 
 - [ ] Alle AKTIV-Services laufen (`docker ps`)
 - [ ] Alle Services "healthy" (keine "unhealthy" oder "starting")
+- [ ] `tools/verify_stack.ps1` oder `make docker-health` ohne unerwartete Missing/Unhealthy
+- [ ] OVERLAY-Services (Loki/Promtail) nur geprueft, wenn Overlay bewusst gestartet (`-IncludeLogging:$true`)
 - [ ] GAP-Services bewusst nicht gestartet (dokumentiert)
 - [ ] BEREIT-Services bewusst deaktiviert (Begründung aktuell)
 - [ ] Keine unbekannten Container im Stack
@@ -203,3 +216,4 @@ docker compose -f infrastructure/compose/compose.red.yml up -d
 | 2026-04-24 | PRs #1914/#1916/#1918/#1920 Nachzug: ARVP validation comparisons & scorecards. shadow_compare, replay_vs_paper_compare, ARVP gate, simulator_calibration_report, arvp_regime_scorecards, paper_reference_window_export + CLI-Runner dokumentiert. Offline-Validation und Audit-Komponenten, keine Runtime-Services im BLUE/RED-Stack. (Issues #1915/#1917/#1919/#1921) | Codex |
 | 2026-04-26 | PRs #1944/#1947 Nachzug: `primary_breakout_v1` nutzt zeitbasierte Lookback-Semantik (SignalEngine). `strategy_backtest_runner` implementiert opt-in Gate-Trace (JSONL); ARVP Replay CLI exponiert/forwarded `--gate-trace-path`. (Issues #1945/#1948) | Codex |
 | 2026-05-13 | PR #2453/#2455 Nachzug: WS-Service (Delta-Counter + lazy `mexc_pb`-Import) und Postgres-Exporter-DSN/Secret-Wiring im RED-Stack nachgezogen (Issues #2454/#2456) | Codex |
+| 2026-05-29 | PR #2670/#2671 Nachzug: Stack-Verification-Tabelle (`verify_stack.ps1` Default ohne Logging-Overlay, `-IncludeLogging:$true` opt-in, Windows-`make docker-health`) ergänzt (Issue #2671) | Codex |


### PR DESCRIPTION
## Summary
- Document `tools/verify_stack.ps1` default: canonical BLUE+RED subset (10 services), logging overlay excluded unless `-IncludeLogging:$true`
- Add stack-verification table and checklist items to `SERVICE_CATALOG.md`
- Align `ARCHITECTURE_MAP.md` logging overlay activation path and verification commands with PR #2670 / `SERVICE_MAPPING.md`
- Note Windows-compatible `make docker-health` (PowerShell filter, no grep)

## Context
Follow-up to merged PR #2670 (fix(ops): stack verify logging default + Windows docker-health).

Closes #2671

## Test plan
- [x] `git diff --check`
- [x] rg validation across architecture docs vs `SERVICE_MAPPING.md` / `verify_stack.ps1`
- [x] docs-only; no runtime/docker commands

No LR impact. Squash merge requested (merge commits disallowed).