### PR TITLE
fix(context): smoke-db run_id at recipe time + Windows context-down (#2603 Slice 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,11 +292,18 @@ endif
 
 context-down:
 	@echo "Stopping SurrealDB context sidecar (BLUE/RED untouched)..."
+ifeq ($(OS),Windows_NT)
+	@pwsh -NoProfile -Command "\
+	$$sp = if ($$env:SECRETS_PATH) { $$env:SECRETS_PATH } else { Join-Path $$env:USERPROFILE 'Documents\.secrets\.cdb' }; \
+	$$env:SECRETS_PATH = $$sp; \
+	docker compose -f 'infrastructure/compose/surrealdb.yml' -f 'infrastructure/compose/surrealdb-dev.yml' down 2>&1 | Out-Null"
+else
 	@SECRETS_PATH=$${SECRETS_PATH:-$$HOME/Documents/.secrets/.cdb} \
 	 docker compose \
 	  -f infrastructure/compose/surrealdb.yml \
 	  -f infrastructure/compose/surrealdb-dev.yml \
 	  down 2>/dev/null || true
+endif
 	@echo "[OK] cdb_surrealdb stopped."
 
 ifeq ($(OS),Windows_NT)
@@ -434,16 +441,21 @@ context-smoke-db: context-env-check
 	@echo "--- Schritt 2: Scan (Snapshot + JSONL erzeugen) ---"
 	$(MAKE) context-scan CONTEXT_SCOPE_CONFIG=infrastructure/config/surrealdb/context_ingestion_scope.smoke.yaml
 	@echo "--- Schritt 3: Import (echter SurrealDB-Adapter, fail-closed) ---"
-	@$(PYTHON) -m tools.surrealdb.context_importer apply \
+ifeq ($(OS),Windows_NT)
+	@pwsh -NoProfile -Command "$$rid = & '$(PYTHON)' 'tools/surrealdb/gen_run_id.py' '$(CONTEXT_SNAP_DIR)/snapshot.json'; if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE }; & '$(PYTHON)' -m tools.surrealdb.context_importer apply --input-dir '$(CONTEXT_SNAP_DIR)' --surreal-url http://127.0.0.1:8010 --namespace cdb_context_local --database cdb_context_intel --apply --apply-mode local-dev --config infrastructure/config/surrealdb/context_import.local.example.yaml --run-id $$rid --adapter surrealdb-local --secrets-path '$(SECRETS_PATH)'; if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE }"
+else
+	@RUN_ID=$$($(PYTHON) tools/surrealdb/gen_run_id.py $(CONTEXT_SNAP_DIR)/snapshot.json); \
+	$(PYTHON) -m tools.surrealdb.context_importer apply \
 		--input-dir $(CONTEXT_SNAP_DIR) \
 		--surreal-url http://127.0.0.1:8010 \
 		--namespace cdb_context_local \
 		--database cdb_context_intel \
 		--apply --apply-mode local-dev \
 		--config infrastructure/config/surrealdb/context_import.local.example.yaml \
-		--run-id $(shell $(PYTHON) tools/surrealdb/gen_run_id.py $(CONTEXT_SNAP_DIR)/snapshot.json) \
+		--run-id $$RUN_ID \
 		--adapter surrealdb-local \
 		--secrets-path "$(SECRETS_PATH)"
+endif
 	@echo "--- Schritt 4: Query-Smoke (hard, >= 1 Record, fail-closed) ---"
 	@$(PYTHON) -m tools.surrealdb.context_query \
 		--adapter surrealdb-local \

--- a/knowledge/logs/sessions/2026-05-29-2603-runtime-smoke-slice1.md
+++ b/knowledge/logs/sessions/2026-05-29-2603-runtime-smoke-slice1.md
@@ -1,0 +1,72 @@
+# Session Log: #2603 Runtime Smoke Slice 1
+
+**Date:** 2026-05-29  
+**Issue:** #2603 (Epic — SurrealDB Context Runtime)  
+**Branch:** `feat/2603-runtime-smoke-slice1`  
+**LR:** NO-GO (unchanged)  
+**Board stage:** trade-capable (orthogonal; no live capital)
+
+## Scope
+
+Local SurrealDB context runtime proof only. BLUE/RED read-only; no trading/live changes.
+
+## Preflight
+
+| Check | Result |
+|-------|--------|
+| `make context-env-check` | PASS (credentials redacted) |
+| `make context-doctor` | EXIT 1 — missing `context_query.local.yaml` (MCP onboarding; non-blocking for runtime slice) |
+| BLUE/RED baseline | 27 containers up including `cdb_surrealdb` |
+
+## Runtime
+
+| Step | Result |
+|------|--------|
+| `make context-up` | PASS (idempotent, 127.0.0.1:8010) |
+| `make context-status` | `cdb_surrealdb` healthy, volume present |
+| `make context-schema-check` (soft) | 18/18 tables, exit 0 |
+| Hard schema check | 18/18 tables, exit 0 (extra: `config_reference`, `doc_code_link`) |
+| `make context-schema-apply` | Not required |
+
+## Smoke DB
+
+### First run (pre-fix)
+
+- `make context-smoke-db` → **EXIT 2** at import
+- Root cause: Makefile used parse-time `$(shell gen_run_id.py …)` so import `--run-id` did not match post-scan snapshot → `run_id_mismatch`
+- Artifact: `artifacts/context-intelligence/2603-smoke-db-output.txt`
+
+### Fix applied
+
+- `context-smoke-db` step 3: resolve `run_id` at recipe runtime (Windows `pwsh` + Unix `RUN_ID=$$(…)`)
+- `context-down`: Windows `pwsh` branch (was bash-only)
+- Contract tests updated (`test_context_smoke_db_contracts.py`)
+
+### Second run (post-fix)
+
+- `make context-smoke-db` → **EXIT 0** (~26 min; large smoke scope)
+- Step 3: `"adapter": "surrealdb-local"`, local-dev apply OK
+- Step 4: `"source": "surrealdb-local"`, `"status": "ok"`, `repo_artifact` records returned (min-count satisfied)
+- Artifact: `artifacts/context-intelligence/2603-smoke-db-output-fixed.txt`
+
+## Teardown / isolation
+
+| Step | Result |
+|------|--------|
+| `make context-down` | PASS (Windows pwsh path) |
+| BLUE/RED diff | Only `cdb_surrealdb` removed (27→26 containers); all other `cdb_*` unchanged |
+
+## Deliverables
+
+- Code fix + unit tests on branch `feat/2603-runtime-smoke-slice1`
+- PR (Refs #2603; epic not closed)
+- GitHub comment on #2603 with PASS matrix
+
+## Follow-ups (not in Slice 1)
+
+- `context-doctor` exit 1 for missing `infrastructure/config/surrealdb/context_query.local.yaml` → #2605 / MCP onboarding scope
+- Epic body stale (claims `context-smoke-db` missing) — update in separate docs pass if desired
+
+## Status
+
+**DONE_WITH_FIX_PR** — runtime proof PASS after Makefile Windows/run_id fix.

--- a/tests/unit/surrealdb/test_context_smoke_db_contracts.py
+++ b/tests/unit/surrealdb/test_context_smoke_db_contracts.py
@@ -44,7 +44,7 @@ def _read_makefile() -> str:
 
 
 def _lines_for_target(content: str, target: str) -> list[str]:
-    """Return all indented recipe lines under a Makefile target."""
+    """Return recipe and conditional lines under a Makefile target."""
     lines = content.splitlines()
     in_target = False
     recipe: list[str] = []
@@ -55,10 +55,13 @@ def _lines_for_target(content: str, target: str) -> list[str]:
         if in_target:
             if line.startswith("\t"):
                 recipe.append(line)
+            elif line.startswith("ifeq ") or line.startswith("else") or line.startswith("endif"):
+                recipe.append(line)
             elif line.strip() == "" or line.startswith("#"):
                 continue
+            elif line and not line.startswith("\t") and ":" in line.split()[0]:
+                break
             else:
-                # New non-indented line = new target or variable; stop.
                 break
     return recipe
 
@@ -375,9 +378,24 @@ def test_makefile_context_smoke_db_run_id_uses_gen_run_id() -> None:
     assert "gen_run_id.py" in recipe_text, (
         "gen_run_id.py not found in context-smoke-db recipe — required for Windows compat"
     )
-    assert "$$($(PYTHON)" not in recipe_text, (
+    assert "$$($(PYTHON) -c" not in recipe_text, (
         "Shell command substitution '$$($(PYTHON) -c ...)' still present in "
         "context-smoke-db — breaks cmd.exe"
+    )
+
+
+@pytest.mark.unit
+def test_makefile_context_smoke_db_run_id_not_parse_time_shell() -> None:
+    """run-id must be resolved after context-scan, not via parse-time $(shell ...) (#2603)."""
+    content = _read_makefile()
+    recipe = _lines_for_target(content, "context-smoke-db")
+    recipe_text = "\n".join(recipe)
+    assert (
+        "$(shell $(PYTHON) tools/surrealdb/gen_run_id.py $(CONTEXT_SNAP_DIR)/snapshot.json)"
+        not in recipe_text
+    ), (
+        "parse-time $(shell gen_run_id.py snapshot.json) causes run_id_mismatch "
+        "after context-scan refreshes snapshot.json"
     )
 
 


### PR DESCRIPTION
## Summary

- Fix `make context-smoke-db` on Windows: resolve `run_id` from `snapshot.json` at recipe runtime (after `context-scan`), eliminating `run_id_mismatch` on import.
- Add Windows `pwsh` branch for `make context-down` (previously bash-only).
- Extend Makefile contract tests for conditional recipe blocks and parse-time guard.

Refs #2603 (Slice 1 runtime smoke). Epic **not** closed.

## Evidence (local, LR NO-GO)

- `make context-smoke-db` exit **0** after fix; step 4 query: `source=surrealdb-local`, `status=ok`
- Hard schema check 18/18; `context-down` stops only `cdb_surrealdb`; BLUE/RED otherwise unchanged
- Session log: `knowledge/logs/sessions/2026-05-29-2603-runtime-smoke-slice1.md`

## Test plan

- [x] `pytest tests/unit/surrealdb/test_context_smoke_db_contracts.py -m unit` (20 passed)
- [x] `make context-smoke-db` (local, ~26 min smoke import)
- [x] `make context-down` + BLUE/RED container diff (only surreal sidecar removed)

Made with [Cursor](https://cursor.com)