### PR TITLE
fix(context): import-local run_id + CLI chain smoke evidence (#2604 Slice 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,7 +407,21 @@ context-import-dry-run:
 context-import-local:
 	@echo "=== Context Local Import: Schreiben in lokale SurrealDB ==="
 	@$(PYTHON) tools/surrealdb/local_schema_check.py --secrets-path "$(SECRETS_PATH)"
-	@$(PYTHON) -m tools.surrealdb.context_importer apply --input-dir $(CONTEXT_SNAP_DIR) --surreal-url http://127.0.0.1:8010 --namespace cdb_context_local --database cdb_context_intel --apply --apply-mode local-dev --config infrastructure/config/surrealdb/context_import.local.example.yaml --run-id $(shell $(PYTHON) tools/surrealdb/gen_run_id.py) --adapter surrealdb-local --secrets-path "$(SECRETS_PATH)"
+ifeq ($(OS),Windows_NT)
+	@pwsh -NoProfile -Command "$$rid = & '$(PYTHON)' 'tools/surrealdb/gen_run_id.py' '$(CONTEXT_SNAP_DIR)/snapshot.json'; if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE }; & '$(PYTHON)' -m tools.surrealdb.context_importer apply --input-dir '$(CONTEXT_SNAP_DIR)' --surreal-url http://127.0.0.1:8010 --namespace cdb_context_local --database cdb_context_intel --apply --apply-mode local-dev --config infrastructure/config/surrealdb/context_import.local.example.yaml --run-id $$rid --adapter surrealdb-local --secrets-path '$(SECRETS_PATH)'; if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE }"
+else
+	@RUN_ID=$$($(PYTHON) tools/surrealdb/gen_run_id.py $(CONTEXT_SNAP_DIR)/snapshot.json); \
+	$(PYTHON) -m tools.surrealdb.context_importer apply \
+		--input-dir $(CONTEXT_SNAP_DIR) \
+		--surreal-url http://127.0.0.1:8010 \
+		--namespace cdb_context_local \
+		--database cdb_context_intel \
+		--apply --apply-mode local-dev \
+		--config infrastructure/config/surrealdb/context_import.local.example.yaml \
+		--run-id $$RUN_ID \
+		--adapter surrealdb-local \
+		--secrets-path "$(SECRETS_PATH)"
+endif
 
 context-query-smoke:
 	@echo "=== Context Query Smoke (read-only, graceful fail wenn kein Container) ==="

--- a/docs/runbooks/surrealdb_context_import.md
+++ b/docs/runbooks/surrealdb_context_import.md
@@ -91,7 +91,7 @@ Example (local/dev only):
 # example, not production
 python tools/surrealdb/context_indexer.py export-jsonl \
   --scope-config infrastructure/config/surrealdb/context_ingestion_scope.yaml \
-  --output-dir temp/context-index/run \
+  --output temp/context-index/run \
   --format json
 ```
 

--- a/knowledge/logs/sessions/2026-05-29-2604-cli-chain-smoke-slice2.md
+++ b/knowledge/logs/sessions/2026-05-29-2604-cli-chain-smoke-slice2.md
@@ -1,0 +1,95 @@
+# Session Log: #2604 CLI Chain Smoke Slice 2
+
+**Date:** 2026-05-29  
+**Issue:** #2604 (Epic — SurrealDB Context Intelligence CLI Tools)  
+**Branch:** `feat/2604-cli-chain-smoke-slice2`  
+**LR:** NO-GO (unchanged)  
+**Board stage:** trade-capable (orthogonal; no live capital)
+
+## Scope
+
+Prove the CLI chain `indexer → JSONL export → importer validate/plan/dry-run/apply → query → explain-source`
+end-to-end against the real local SurrealDB runtime from #2603. BLUE/RED read-only; no trading/live/MCP changes.
+#2604 not closed. #2603 read as runtime prerequisite; #2605/#2606 context only.
+
+## Runtime prerequisite (read-only proof of #2603)
+
+| Step | Result |
+|------|--------|
+| `make context-env-check` | PASS (credentials redacted) |
+| `make context-up` / `context-status` | `cdb_surrealdb` healthy, 127.0.0.1:8010 |
+| `make context-schema-check` | PASS, exit 0 |
+| BLUE/RED baseline | 27 containers (26 BLUE/RED + `cdb_surrealdb`) |
+
+## Indexer (smoke scope)
+
+- Scope: `infrastructure/config/surrealdb/context_ingestion_scope.smoke.yaml` (docs/knowledge/agents + README; no code).
+- `run_id = context-indexer-8d9e14a17cbb30b4`, `state_hash = 8d9e14a1…` — **reproducible** across re-scan (same git commit → same hashes).
+- Counts: included=734, skipped=62, forbidden=690; artifacts=734, pages=612, sections=8279, chunks=8295,
+  **code_symbols=0** (expected — smoke scope excludes code), config_refs=3231, doc_code_links=5823, dependency_edges=5823.
+- JSONL valid; `forbidden_files.jsonl` carries metadata only (path/reason/size/sensitivity), **no secret content**.
+- No oversized/noise/archive paths ingested.
+
+## Importer (fail-closed gating)
+
+| Step | Result |
+|------|--------|
+| `validate-jsonl` | PASS |
+| `plan` (run twice) | deterministic (identical plan) |
+| `dry-run` reconcile | PASS, 0 blocking |
+| `apply` WITHOUT `--apply --apply-mode local-dev` | **fail-closed (exit 5, WRITE_DENIED)** |
+
+## Local apply (gated, real adapter)
+
+- `make context-import-local` (after Makefile fix below) → **exit 0**, ~21 min (large smoke corpus; sequential HTTP upserts).
+- Evidence: `status=applied`, `apply_executed=true`, `real_surrealdb_adapter_available=true`,
+  `surrealdb_connection=local-http-api`, `surrealdb_writes=local-db-writes`,
+  `reconcile_status=reconciled`, `actions=32797`, `blocking=0`, `failed=0`, `skipped=0`, `creates=26974`.
+- `creates=26974` vs `actions=32797` delta = `dependency_edge=5823` reconciled as already-present no-ops from prior local-dev smoke runs (idempotent upsert). No productive DB writes.
+
+## Query + provenance (real reads, `--adapter surrealdb-local --hard-mode`)
+
+| Command | Result |
+|---------|--------|
+| `find-artifact --source-path README` | `source=surrealdb-local`, count=2; provenance: `source_path`, `normalized_sha256`, `source_commit`, `source_hash`, `raw_sha256`, `integrity_algo` |
+| `find-doc --query SurrealDB` | `source=surrealdb-local`, count=3 |
+| `find-symbol --name Manager` | `source=surrealdb-local`, count=0 (valid empty read — no code in smoke scope) |
+| `trace --source-path … --direction up/down` | `source=surrealdb-local`, status=ok (read path proven) |
+| `explain-source --artifact-id repo_artifact:…` | `source=surrealdb-local`, count=1; provenance includes `run_id`, `source_commit=67a3665d…` (matches indexer snapshot), `source_path`, `source_hash`, `chunk_id`, `edge_id`, `symbol_id` |
+
+`source=surrealdb-local` appears only on real DB reads; provenance fields present per contract.
+
+## Cross-CLI smoke
+
+- `context-smoke-db` (Makefile L449–481) already wraps schema-check → scan(smoke) → apply(surrealdb-local) → `show-snapshot --min-count 1`.
+- Its fail-closed acceptance gate executed standalone: **PASS** (exit 0, `source=surrealdb-local`, count=100, min-count=1 enforced).
+- All wrapped stages independently proven this session ⇒ **no real gap; no new target/test added** (reuse-first per clarification).
+
+## Fixes (in-scope, minimal)
+
+1. **Makefile `context-import-local`** — resolve `--run-id` at recipe runtime from `$(CONTEXT_SNAP_DIR)/snapshot.json`
+   (Windows `pwsh` + POSIX branch), mirroring the #2603 `context-smoke-db` fix. Prior parse-time `$(shell gen_run_id.py)`
+   produced a timestamp run_id → `run_id_mismatch` blocking apply.
+2. **Runbook `docs/runbooks/surrealdb_context_import.md`** — `--output-dir` → `--output` (indexer rejects `--output-dir`, would exit 2).
+3. **Test `tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py`** — Makefile-parser now skips `ifeq/else/endif`
+   conditional directives so the `--adapter surrealdb-local` assertion survives the new Windows/POSIX branch structure.
+
+## Findings (candidate follow-up)
+
+- **Query statement normalizer uppercases string literals.** `find-artifact --file-type md` → `WHERE FILE_TYPE = "MD"` (0 hits vs lowercase-stored `md`);
+  `find-symbol --name apply` → **false `WRITE_DENIED`** (search term `apply` upcased to `APPLY` collides with write-keyword denylist);
+  `trace --source-path docs/` misses lowercase paths. Read path + classification guardrail work; the literal-casing is the defect.
+  Scope-relevant to #2604 but a classifier change is non-trivial → dedup follow-up rather than in-slice fix.
+- **Apply runtime** ~21 min for the 734-doc smoke corpus (32,797 sequential HTTP upserts) — known characteristic also noted in #2603.
+
+## Teardown
+
+| Step | Result |
+|------|--------|
+| `make context-down` | `cdb_surrealdb` stopped; 27 → 26 containers |
+| BLUE/RED isolation | intact (postgres/redis/risk/execution/market + exporters untouched) |
+| `pytest -q tests/unit/surrealdb` | green after test fix (1266 passed) |
+
+## Verdict
+
+CLI chain proven end-to-end against real local SurrealDB. LR stays **NO-GO**. #2604 remains open.

--- a/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
+++ b/tests/unit/surrealdb/test_surrealdb_local_apply_adapter.py
@@ -501,6 +501,10 @@ def test_makefile_context_import_local_uses_surrealdb_local_adapter() -> None:
     makefile = Path(__file__).parents[3] / "Makefile"
     assert makefile.exists(), "Makefile not found"
     content = makefile.read_text(encoding="utf-8")
+    # Makefile conditional directives (ifeq/else/endif) sit at column 0 inside a
+    # recipe but do NOT terminate the target; they wrap the Windows/POSIX branches
+    # used to derive the deterministic run_id (mirrors context-smoke-db).
+    conditional_directives = ("ifeq", "ifneq", "ifdef", "ifndef", "else", "endif")
     in_target = False
     for line in content.splitlines():
         if line.startswith("context-import-local:"):
@@ -508,6 +512,8 @@ def test_makefile_context_import_local_uses_surrealdb_local_adapter() -> None:
         elif in_target and line.startswith("\t"):
             if "--adapter surrealdb-local" in line:
                 return
+        elif in_target and line.strip().startswith(conditional_directives):
+            continue
         elif in_target and not line.startswith("\t") and line.strip():
             break
     pytest.fail(


### PR DESCRIPTION
## Summary

Slice 2 of #2604: prove the Context Intelligence CLI chain end-to-end against the **real local SurrealDB** runtime from #2603, fix one blocking Makefile bug + confirmed doc drift, and keep a test honest.

- **`context-import-local` run_id fix** — the target resolved `--run-id` at parse time via `$(shell gen_run_id.py)` (no snapshot), producing a timestamp run_id that mismatched the indexer output and **blocked apply** (`run_id_mismatch`). Now resolved at recipe runtime from `snapshot.json` on both Windows (`pwsh`) and POSIX, mirroring the #2603 `context-smoke-db` fix.
- **Runbook fix** — `docs/runbooks/surrealdb_context_import.md` `export-jsonl` example `--output-dir` → `--output` (the indexer rejects `--output-dir`, exit 2).
- **Test fix** — `test_makefile_context_import_local_uses_surrealdb_local_adapter` now skips `ifeq/else/endif` directives so the `--adapter surrealdb-local` assertion survives the new Windows/POSIX branch structure.
- **Evidence** — session log under `knowledge/logs/sessions/`.

## CLI chain proven (real local SurrealDB, smoke scope)

| Stage | Result |
|-------|--------|
| Indexer scan + export-jsonl | reproducible `run_id=context-indexer-8d9e14a1…`; 734 files → 32,797 records; `code_symbols=0` (scope); no secrets in `forbidden_files.jsonl` |
| Importer `validate`/`plan`×2/`dry-run` | deterministic; 0 blocking |
| `apply` without explicit flags | **fail-closed (exit 5, WRITE_DENIED)** |
| `apply --adapter surrealdb-local --apply-mode local-dev` | exit 0; `surrealdb_writes=local-db-writes`; `actions=32797`, `failed=0`, `blocking=0` |
| Query (`find-artifact`/`find-doc`/`find-symbol`/`trace`/`explain-source`) | `source=surrealdb-local` on real reads; `explain-source` provenance `source_commit=67a3665d…` matches indexer snapshot |
| `context-smoke-db` acceptance gate (`show-snapshot --min-count 1`) | **PASS** (exit 0, count=100) |
| `pytest -q tests/unit/surrealdb` | 1266 passed |
| `make context-down` | `cdb_surrealdb` stopped; BLUE/RED (26) untouched |

## Safety

- LR stays **NO-GO**. BLUE/RED read-only/untouched. No MCP/memory/trading/live changes. No secrets in logs or artifacts.
- #2604 **not closed** by this PR (Slice 2 evidence only).

## Follow-up (filed separately, not in this PR)

- Query statement normalizer uppercases string literals → case-mismatch on exact filters and a false `WRITE_DENIED` when a search term (`apply`) collides with the write-keyword denylist. Read path + guardrail work; literal casing is the defect.

## Test plan

- [x] `make context-env-check` / `context-up` / `context-status` / `context-schema-check`
- [x] `make context-scan CONTEXT_SCOPE_CONFIG=…smoke.yaml`
- [x] importer validate/plan/dry-run + negative fail-closed
- [x] `make context-import-local` (real adapter, local-dev)
- [x] query subcommands + `explain-source` provenance
- [x] `context-smoke-db` fail-closed gate
- [x] `pytest -q tests/unit/surrealdb` green (1266 passed)
- [x] `make context-down` + BLUE/RED isolation
