### PR TITLE
fix(context-query): preserve string literals in statement normalizer

### DIFF
--- a/tests/unit/surrealdb/test_context_query_classifier.py
+++ b/tests/unit/surrealdb/test_context_query_classifier.py
@@ -15,8 +15,9 @@ from tools.surrealdb.context_query import (
     load_config,
 )
 
-
-EXAMPLE_CONFIG = Path("infrastructure/config/surrealdb/context_query.local.example.yaml")
+EXAMPLE_CONFIG = Path(
+    "infrastructure/config/surrealdb/context_query.local.example.yaml"
+)
 
 
 @pytest.mark.unit
@@ -133,7 +134,9 @@ def test_whitespace_and_case_variants_are_stable() -> None:
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("statement", ["APPLY something", "MIGRATION run", "TRANSACTION start"])
+@pytest.mark.parametrize(
+    "statement", ["APPLY something", "MIGRATION run", "TRANSACTION start"]
+)
 def test_transaction_migration_apply_flows_are_blocked(statement: str) -> None:
     with pytest.raises(WriteDeniedError):
         classify_statement(statement)

--- a/tests/unit/surrealdb/test_context_query_classifier.py
+++ b/tests/unit/surrealdb/test_context_query_classifier.py
@@ -6,7 +6,14 @@ from pathlib import Path
 
 import pytest
 
-from tools.surrealdb.context_query import WriteDeniedError, classify_statement, load_config
+from tools.surrealdb.context_query import (
+    WriteDeniedError,
+    build_artifact_query,
+    build_symbol_query,
+    build_trace_query,
+    classify_statement,
+    load_config,
+)
 
 
 EXAMPLE_CONFIG = Path("infrastructure/config/surrealdb/context_query.local.example.yaml")
@@ -130,3 +137,48 @@ def test_whitespace_and_case_variants_are_stable() -> None:
 def test_transaction_migration_apply_flows_are_blocked(statement: str) -> None:
     with pytest.raises(WriteDeniedError):
         classify_statement(statement)
+
+
+@pytest.mark.unit
+def test_built_artifact_query_preserves_file_type_literal_case() -> None:
+    query = build_artifact_query(file_type="md", limit=10)
+    result = classify_statement(query)
+
+    assert result.allowed is True
+    assert 'file_type = "md"' in query
+    assert 'FILE_TYPE = "md"' in result.normalized
+    assert '"MD"' not in result.normalized
+
+
+@pytest.mark.unit
+def test_built_trace_query_preserves_source_path_literal_case() -> None:
+    query = build_trace_query(source_path="docs/", limit=10)
+    result = classify_statement(query)
+
+    assert result.allowed is True
+    assert 'source_path CONTAINS "docs/"' in query
+    assert 'SOURCE_PATH CONTAINS "docs/"' in result.normalized
+    assert '"DOCS/"' not in result.normalized
+
+
+@pytest.mark.unit
+def test_built_symbol_query_name_apply_is_read_only() -> None:
+    query = build_symbol_query(name="apply", limit=10)
+    result = classify_statement(query)
+
+    assert result.allowed is True
+    assert 'name CONTAINS "apply"' in query
+    assert 'NAME CONTAINS "apply"' in result.normalized
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "literal",
+    ["update", "delete", "create", "insert"],
+)
+def test_write_keywords_inside_string_literals_are_allowed(literal: str) -> None:
+    statement = f'SELECT * FROM doc_chunk WHERE name CONTAINS "{literal}"'
+    result = classify_statement(statement)
+
+    assert result.allowed is True
+    assert f'"{literal}"' in result.normalized

--- a/tools/surrealdb/context_query.py
+++ b/tools/surrealdb/context_query.py
@@ -330,9 +330,7 @@ class SurrealDBLocalQueryAdapter(QueryAdapter):
 
     def _make_auth_header(self) -> str | None:
         if self._user and self._password:
-            token = base64.b64encode(
-                f"{self._user}:{self._password}".encode()
-            ).decode()
+            token = base64.b64encode(f"{self._user}:{self._password}".encode()).decode()
             return f"Basic {token}"
         return None
 
@@ -364,9 +362,7 @@ class SurrealDBLocalQueryAdapter(QueryAdapter):
         except urllib.error.URLError as exc:
             self.status = self._STATUS_UNAVAILABLE
             if self._hard_mode:
-                raise QueryAdapterError(
-                    f"SurrealDB unreachable: {exc.reason}"
-                ) from exc
+                raise QueryAdapterError(f"SurrealDB unreachable: {exc.reason}") from exc
             logger.warning("SurrealDB unreachable (soft mode): %s", exc.reason)
             return []
         try:
@@ -836,7 +832,9 @@ def build_symbol_query(
     if name:
         conditions.append(f"name CONTAINS {_surrealql_string(name)}")
     if qualified_name:
-        conditions.append(f"qualified_name CONTAINS {_surrealql_string(qualified_name)}")
+        conditions.append(
+            f"qualified_name CONTAINS {_surrealql_string(qualified_name)}"
+        )
     if source_path:
         conditions.append(f"source_path CONTAINS {_surrealql_string(source_path)}")
     if symbol_type:
@@ -1921,7 +1919,9 @@ def _handle(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
     adapter_name = getattr(args, "adapter", "noop")
     if adapter_name == "surrealdb-local":
         if config is None:
-            raise InputNotFoundError("--config is required for --adapter surrealdb-local")
+            raise InputNotFoundError(
+                "--config is required for --adapter surrealdb-local"
+            )
         secrets_path = getattr(args, "secrets_path", None)
         user, password = _load_query_credentials(config, secrets_path)
         hard_mode = getattr(args, "hard_mode", False)

--- a/tools/surrealdb/context_query.py
+++ b/tools/surrealdb/context_query.py
@@ -653,8 +653,29 @@ def _tombstone_meta(include_tombstoned: bool) -> dict[str, Any]:
     }
 
 
+_SURQL_STRING_LITERAL_RE = re.compile(
+    r'"(?:\\.|[^"\\])*"' + r"|" + r"'(?:\\.|[^'\\])*'"
+)
+
+
 def _normalize_statement(statement: str) -> str:
-    return re.sub(r"\s+", " ", statement.strip()).upper()
+    """Collapse whitespace and uppercase keywords for classifier guards only.
+
+    String literal contents are preserved so write-keyword checks and
+    classification metadata do not mutate user filter values.
+    """
+    collapsed = re.sub(r"\s+", " ", statement.strip())
+    if not collapsed:
+        return collapsed
+
+    parts: list[str] = []
+    last = 0
+    for match in _SURQL_STRING_LITERAL_RE.finditer(collapsed):
+        parts.append(collapsed[last : match.start()].upper())
+        parts.append(match.group(0))
+        last = match.end()
+    parts.append(collapsed[last:].upper())
+    return "".join(parts)
 
 
 def _secret_key_segments(key: str) -> set[str]:


### PR DESCRIPTION
## Summary
- Literal-safe `_normalize_statement` for the read-only Context Query classifier (fixes false `WRITE_DENIED` on benign terms like `apply`).
- String literal contents (e.g. `md`, `docs/`, `apply`) are no longer uppercased; keywords and identifiers outside literals still normalize for guards.
- Write-keyword denylist and fail-closed behavior for real writes unchanged.

## Test plan
- [x] `pytest tests/unit/surrealdb/test_context_query_classifier.py -v`
- [x] `pytest tests/unit/surrealdb/test_context_query_builders.py -v`
- [x] `ruff check` on touched files

Closes #2679
Refs #2604

Made with [Cursor](https://cursor.com)