### PR TITLE
feat(surrealdb): #2606 memory slice 2 deterministic memory_id + validation

### DIFF
--- a/docs/surrealdb/memory-reality-slice1-audit.md
+++ b/docs/surrealdb/memory-reality-slice1-audit.md
@@ -266,6 +266,88 @@ Stop and do not implement write if:
 
 ---
 
+## 16. Slice 2 addendum
+
+**Slice 2 delivered**: `2606-memory-slice2-contracts`  
+**Repo HEAD at delivery**: see PR for commit SHA  
+**Date**: 2026-05-29
+
+### 16.1 What was built
+
+| Artifact | Path |
+| --- | --- |
+| `memory_contract.py` | `tools/surrealdb/memory_contract.py` |
+| Unit tests | `tests/unit/surrealdb/test_memory_contract.py` |
+
+### 16.2 R5 finalized (memory_id spec)
+
+R5 from Slice 1 (planned, not implemented) is now implemented:
+
+| Property | Value |
+| --- | --- |
+| Algorithm | UUIDv5 (`uuid.uuid5`) |
+| Namespace constant | `MEMORY_ID_NAMESPACE = uuid.UUID("b4e1d2c3-a5f6-4780-9bcd-ef0123456789")` |
+| Name string | `{scope}\|{namespace}\|{memory_type}\|{created_by}\|{content_hash}\|{source_refs_fingerprint}` |
+| `content_hash` | SHA256 of `content.strip().encode("utf-8")` |
+| `source_refs_fingerprint` | `canonical_hash(sorted(set(source_refs)))` from `core/replay/canonical_json.py` |
+| **NOT in ID** | `created_at`, `ttl`, `confidence`, `evidence_refs` |
+
+### 16.3 Validator contract (v1)
+
+`validate_memory_record(raw, *, strict=True)`:
+
+- Required: `scope`, `namespace`, `memory_type`, `content`, `source_refs`, `evidence_refs`, `confidence`, `ttl`, `created_by`, `created_at`
+- `memory_type`: one of 6 CANONICAL_MEMORY_TYPES (lowercased)
+- `source_refs` / `evidence_refs`: non-empty list of non-empty strings
+- `confidence`: float in [0.0, 1.0]
+- `ttl`: int ≥ 0 (seconds); if ttl > 0 → `expires_at` required and must be strictly after `created_at`
+- Optional: `superseded_by` (non-empty if present), `stale_after` (int ≥ 0), `comment`
+- `strict=True`: rejects unknown fields
+- If `memory_id` present: must match computed value
+- If `memory_id` absent: computed and attached
+
+Canon names enforced: `created_by` (NOT `agent_id`), `source_refs` (NOT `source_ref`), `superseded_by` (NOT `supersedes`).
+
+### 16.4 Test coverage (Slice 2)
+
+76 unit tests in `tests/unit/surrealdb/test_memory_contract.py`:
+- ID determinism and stability (3 tests)
+- ID sensitivity to all 6 identity fields (6 parametrized)
+- ID insensitivity to `created_at`, `confidence`/`ttl`, `evidence_refs`
+- `compute_content_hash`: determinism, strip, length, sensitivity
+- `compute_source_refs_fingerprint`: order-insensitive, deduplicating, deterministic, sensitive
+- Valid record: memory_id added, memory_type normalized, fields preserved
+- Missing required fields: 10 parametrized
+- Empty `evidence_refs` / `source_refs`
+- Confidence out of range: 4 parametrized; edge values 0.0/1.0 pass
+- TTL contract: ttl=0 OK without `expires_at`; ttl>0 fails without `expires_at`, fails if `expires_at` ≤ `created_at`
+- `stale_after`: valid and negative
+- `superseded_by`: valid, empty string, whitespace
+- Unknown memory_type
+- Unknown extra field strict/non-strict
+- `memory_id` mismatch
+- `validate_memory_id_matches_record`: correct / wrong / missing
+
+### 16.5 No-changes list (Slice 2)
+
+- `memory_read.py` — unchanged
+- `core/utils/uuid_gen.py` — unchanged
+- MCP tools — unchanged
+- SurrealDB schema / Docker / infrastructure — unchanged
+- `DELIVERY_APPROVED.yaml` — unchanged
+- LR verdict remains NO-GO
+
+### 16.6 Remaining gaps after Slice 2
+
+| Gap | Slice |
+| --- | --- |
+| TTL unit drift (`ttl` seconds vs `ttl_days` in reader) | Slice 3 |
+| DB-backed memory read proof | Slice 3 |
+| Human-GO write gate design | Slice 4 |
+| Memory write implementation | Slice 5 (only after Human-GO + Slices 2–4) |
+
+---
+
 ## Provenance
 
 | Source | Role |

--- a/knowledge/logs/sessions/2026-05-29-2606-memory-slice2.md
+++ b/knowledge/logs/sessions/2026-05-29-2606-memory-slice2.md
@@ -1,0 +1,92 @@
+# Session Log: #2606 Memory Reality Slice 2 — Deterministic memory_id + Validation
+
+**Date:** 2026-05-29 (Europe/Berlin)  
+**Scope:** Plan-GO (user explicit) — Slice 2: deterministic memory_id + fail-closed validator. No memory write, no DB, no MCP changes.  
+**Issue:** [#2606](https://github.com/jannekbuengener/Claire_de_Binare/issues/2606) — OPEN  
+**Branch:** `2606-memory-slice2-contracts` from `main @ c9af79d6`  
+**Guardrail:** LR remains NO-GO. Board stage `trade-capable` ≠ live-go.
+
+---
+
+## Git-Wahrheit (session start)
+
+- Branch: `main` (clean, no uncommitted changes)
+- Commits above origin/main: none
+- HEAD: `c9af79d6` (matches approved plan baseline)
+
+---
+
+## Scope
+
+**IN:**
+- `tools/surrealdb/memory_contract.py` — new: deterministic memory_id + validator
+- `tests/unit/surrealdb/test_memory_contract.py` — new: 76 unit tests, no DB
+- `docs/surrealdb/memory-reality-slice1-audit.md` — addendum `## 16. Slice 2 addendum`
+- `knowledge/logs/sessions/2026-05-29-2606-memory-slice2.md` — this log
+
+**OUT (strict):**
+- No `memory_read.py` changes
+- No `core/utils/uuid_gen.py` changes
+- No MCP tools changes
+- No SurrealDB schema / Docker / infrastructure changes
+- No `DELIVERY_APPROVED.yaml` changes
+- No `Closes #2606` (issue remains open; Refs only)
+
+---
+
+## Delivered artifacts
+
+| Artifact | Path | Notes |
+| --- | --- | --- |
+| `memory_contract.py` | `tools/surrealdb/memory_contract.py` | New module |
+| Unit tests | `tests/unit/surrealdb/test_memory_contract.py` | 76 tests, all pass |
+| Audit addendum | `docs/surrealdb/memory-reality-slice1-audit.md` | `## 16` added |
+| Session log | `knowledge/logs/sessions/2026-05-29-2606-memory-slice2.md` | This file |
+
+---
+
+## R5 finalized
+
+Reconcile decision R5 from Slice 1 ("memory_id strategy — planned, not implemented") is now implemented:
+
+- **Algorithm**: UUIDv5 (`uuid.uuid5`) with `MEMORY_ID_NAMESPACE`
+- **Namespace**: `uuid.UUID("b4e1d2c3-a5f6-4780-9bcd-ef0123456789")` — dedicated constant, never reused
+- **Name string**: `{scope}|{namespace}|{memory_type}|{created_by}|{content_hash}|{source_refs_fingerprint}`
+- **`content_hash`**: SHA256 of `content.strip().encode("utf-8")`
+- **`source_refs_fingerprint`**: `canonical_hash(sorted(set(source_refs)))` via `core/replay/canonical_json.py`
+- **NOT in ID**: `created_at`, `ttl`, `confidence`, `evidence_refs` (mutable metadata)
+
+---
+
+## Validation results
+
+```
+pytest tests/unit/surrealdb/test_memory_contract.py -v
+  76 passed in 0.15s
+
+pytest tests/unit/surrealdb/test_memory_read_characterization.py tests/unit/surrealdb/test_wave14_services_v1.py -v
+  41 passed (no regressions)
+
+ruff check tools/surrealdb/memory_contract.py tests/unit/surrealdb/test_memory_contract.py
+  All checks passed!
+
+black --check (after auto-fix)
+  All checks passed!
+```
+
+---
+
+## Remaining gaps (Slice 2 does not close)
+
+| Gap | Owner slice |
+| --- | --- |
+| TTL unit drift (R4: `ttl` seconds vs `ttl_days`) | Slice 3 |
+| DB-backed memory read proof | Slice 3 |
+| Human-GO write gate design | Slice 4 |
+| Memory write path | Slice 5 |
+
+---
+
+## Closure semantics
+
+`Refs #2606` — Slice 2 is a scoped partial delivery. Issue #2606 remains open pending Slices 3–5.

--- a/tests/unit/surrealdb/test_memory_contract.py
+++ b/tests/unit/surrealdb/test_memory_contract.py
@@ -1,0 +1,623 @@
+"""Unit tests for memory_contract — #2606 Memory Reality Slice 2.
+
+No DB. No MCP. No side effects.
+
+Covers:
+    - ID determinism and stability
+    - ID sensitivity: changes to identity fields (scope, namespace,
+      memory_type, created_by, content, source_refs) change the ID
+    - ID insensitivity: confidence, ttl, evidence_refs do NOT affect the ID
+    - content_hash determinism and strip behavior
+    - source_refs fingerprint: order-insensitive and deduplicating
+    - Valid record passes validation and receives memory_id
+    - Missing required fields (parametrized)
+    - Empty evidence_refs / source_refs rejected
+    - Confidence out of [0.0, 1.0] rejected
+    - TTL contract: ttl=0 OK without expires_at; ttl>0 requires expires_at after created_at
+    - stale_after: valid ints pass, negatives rejected
+    - superseded_by: non-empty string passes, empty/whitespace rejected
+    - Unknown memory_type rejected
+    - Unknown extra field in strict mode rejected
+    - Unknown extra field in non-strict mode allowed
+    - memory_id mismatch in record rejected
+    - validate_memory_id_matches_record: correct passes, wrong raises, missing raises
+    - SCHEMA_VERSION and CANONICAL_MEMORY_TYPES constants
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tools.surrealdb.memory_contract import (
+    CANONICAL_MEMORY_TYPES,
+    SCHEMA_VERSION,
+    MemoryContractError,
+    compute_content_hash,
+    compute_source_refs_fingerprint,
+    generate_memory_id,
+    validate_memory_id_matches_record,
+    validate_memory_record,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _valid_record(**overrides) -> dict:
+    """Return a minimal valid memory record dict. Callers may override any field."""
+    base: dict = {
+        "scope": "agent:TEST/cursor",
+        "namespace": "session",
+        "memory_type": "working_memory",
+        "content": "Test memory content for slice 2",
+        "source_refs": ["docs/AGENTS.md@abc123"],
+        "evidence_refs": ["ev-001"],
+        "confidence": 0.9,
+        "ttl": 3600,
+        "expires_at": "2026-05-30T00:00:00+00:00",
+        "created_by": "cursor-agent-v1",
+        "created_at": "2026-05-29T04:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# ID determinism
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_generate_memory_id_deterministic() -> None:
+    """Same inputs always produce the same memory_id (idempotency)."""
+    id1 = generate_memory_id(
+        "s:A", "ns", "working_memory", "agent-1", "content", ["ref1"]
+    )
+    id2 = generate_memory_id(
+        "s:A", "ns", "working_memory", "agent-1", "content", ["ref1"]
+    )
+    assert id1 == id2
+
+
+@pytest.mark.unit
+def test_generate_memory_id_is_uuidv5() -> None:
+    """Generated memory_id is a valid UUIDv5 string."""
+    mid = generate_memory_id("s", "n", "semantic_memory", "agent", "c", ["r"])
+    parsed = uuid.UUID(mid)
+    assert parsed.version == 5
+
+
+@pytest.mark.unit
+def test_generate_memory_id_stable_across_calls() -> None:
+    """Multiple calls with identical arguments return the same ID."""
+    kwargs: dict = dict(
+        scope="stable:scope",
+        namespace="prod",
+        memory_type="risk_memory",
+        created_by="risk-agent-v2",
+        content="Important risk memory",
+        source_refs=["risk/risk_policy.md@v1"],
+    )
+    ids = [generate_memory_id(**kwargs) for _ in range(5)]
+    assert len(set(ids)) == 1, "All calls should return the same ID"
+
+
+# ---------------------------------------------------------------------------
+# ID sensitivity — any identity field change produces a different ID
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("scope", "scope:B"),
+        ("namespace", "different_ns"),
+        ("memory_type", "semantic_memory"),
+        ("created_by", "different-agent"),
+        ("content", "different content string"),
+        ("source_refs", ["ref2"]),
+    ],
+)
+def test_memory_id_sensitive_to_identity_field(field: str, value) -> None:
+    """Changing any identity field produces a different memory_id."""
+    base_kwargs: dict = dict(
+        scope="scope:A",
+        namespace="ns",
+        memory_type="working_memory",
+        created_by="agent-1",
+        content="content",
+        source_refs=["ref1"],
+    )
+    id_base = generate_memory_id(**base_kwargs)
+    changed = {**base_kwargs, field: value}
+    id_changed = generate_memory_id(**changed)
+    assert id_base != id_changed, f"ID should differ when {field!r} changes"
+
+
+# ---------------------------------------------------------------------------
+# ID insensitivity — non-identity metadata does not affect generate_memory_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_memory_id_insensitive_to_created_at_field() -> None:
+    """created_at is NOT part of the ID name string; never passed to generate_memory_id."""
+    id1 = generate_memory_id("s", "n", "working_memory", "a", "content", ["r"])
+    id2 = generate_memory_id("s", "n", "working_memory", "a", "content", ["r"])
+    assert id1 == id2
+
+
+@pytest.mark.unit
+def test_memory_id_insensitive_to_ttl_and_confidence() -> None:
+    """Confidence and ttl are not identity fields; validate_memory_record produces
+    the same memory_id for records that differ only in those fields."""
+    rec_a = _valid_record(
+        confidence=0.5, ttl=100, expires_at="2026-06-01T00:00:00+00:00"
+    )
+    rec_b = _valid_record(
+        confidence=0.99, ttl=7200, expires_at="2026-06-01T00:00:00+00:00"
+    )
+    out_a = validate_memory_record(rec_a)
+    out_b = validate_memory_record(rec_b)
+    assert out_a["memory_id"] == out_b["memory_id"]
+
+
+@pytest.mark.unit
+def test_memory_id_insensitive_to_evidence_refs() -> None:
+    """evidence_refs is not part of the ID; different evidence_refs produce the same ID."""
+    rec_a = _valid_record(evidence_refs=["ev-001"])
+    rec_b = _valid_record(evidence_refs=["ev-001", "ev-002", "ev-003"])
+    out_a = validate_memory_record(rec_a)
+    out_b = validate_memory_record(rec_b)
+    assert out_a["memory_id"] == out_b["memory_id"]
+
+
+# ---------------------------------------------------------------------------
+# compute_content_hash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_compute_content_hash_deterministic() -> None:
+    h1 = compute_content_hash("hello")
+    h2 = compute_content_hash("hello")
+    assert h1 == h2
+
+
+@pytest.mark.unit
+def test_compute_content_hash_strip_whitespace() -> None:
+    """Content is stripped before hashing so leading/trailing space is ignored."""
+    assert compute_content_hash("  hello  ") == compute_content_hash("hello")
+    assert compute_content_hash("\thello\n") == compute_content_hash("hello")
+
+
+@pytest.mark.unit
+def test_compute_content_hash_length() -> None:
+    """SHA256 hex digest is exactly 64 characters."""
+    assert len(compute_content_hash("anything")) == 64
+
+
+@pytest.mark.unit
+def test_compute_content_hash_sensitive_to_content() -> None:
+    assert compute_content_hash("content-A") != compute_content_hash("content-B")
+
+
+# ---------------------------------------------------------------------------
+# compute_source_refs_fingerprint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_source_refs_fingerprint_order_insensitive() -> None:
+    """Source refs are sorted before hashing — list order does not matter."""
+    f1 = compute_source_refs_fingerprint(["b", "a"])
+    f2 = compute_source_refs_fingerprint(["a", "b"])
+    assert f1 == f2
+
+
+@pytest.mark.unit
+def test_source_refs_fingerprint_deduplicates() -> None:
+    """Duplicate entries are collapsed before hashing."""
+    f1 = compute_source_refs_fingerprint(["a", "a", "b"])
+    f2 = compute_source_refs_fingerprint(["a", "b"])
+    assert f1 == f2
+
+
+@pytest.mark.unit
+def test_source_refs_fingerprint_deterministic() -> None:
+    f1 = compute_source_refs_fingerprint(["ref-x", "ref-y"])
+    f2 = compute_source_refs_fingerprint(["ref-x", "ref-y"])
+    assert f1 == f2
+
+
+@pytest.mark.unit
+def test_source_refs_fingerprint_sensitive_to_content() -> None:
+    f1 = compute_source_refs_fingerprint(["ref-A"])
+    f2 = compute_source_refs_fingerprint(["ref-B"])
+    assert f1 != f2
+
+
+@pytest.mark.unit
+def test_source_refs_fingerprint_length() -> None:
+    assert len(compute_source_refs_fingerprint(["x"])) == 64
+
+
+# ---------------------------------------------------------------------------
+# validate_memory_record — valid record
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_memory_record_valid_adds_memory_id() -> None:
+    """A valid record without memory_id gets one computed and attached."""
+    rec = _valid_record()
+    out = validate_memory_record(rec)
+    assert "memory_id" in out
+    mid = out["memory_id"]
+    assert len(uuid.UUID(mid).hex) == 32  # valid UUID
+
+
+@pytest.mark.unit
+def test_validate_memory_record_normalizes_memory_type_case() -> None:
+    """memory_type is lowercased in the returned record."""
+    rec = _valid_record(memory_type="Working_Memory")
+    out = validate_memory_record(rec)
+    assert out["memory_type"] == "working_memory"
+
+
+@pytest.mark.unit
+def test_validate_memory_record_valid_preserves_supplied_memory_id() -> None:
+    """A correct memory_id in the record passes validation unchanged."""
+    rec = _valid_record()
+    out_first = validate_memory_record(rec)
+    mid = out_first["memory_id"]
+    rec_with_id = _valid_record(memory_id=mid)
+    out = validate_memory_record(rec_with_id)
+    assert out["memory_id"] == mid
+
+
+@pytest.mark.unit
+def test_validate_memory_record_returns_all_input_fields() -> None:
+    """Returned record preserves all input fields plus adds memory_id."""
+    rec = _valid_record(comment="test comment")
+    out = validate_memory_record(rec)
+    assert out["comment"] == "test comment"
+    assert out["scope"] == rec["scope"]
+    assert out["evidence_refs"] == rec["evidence_refs"]
+
+
+# ---------------------------------------------------------------------------
+# Missing required fields (parametrized)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "missing_field",
+    [
+        "scope",
+        "namespace",
+        "memory_type",
+        "content",
+        "source_refs",
+        "evidence_refs",
+        "confidence",
+        "ttl",
+        "created_by",
+        "created_at",
+    ],
+)
+def test_validate_memory_record_missing_required_field(missing_field: str) -> None:
+    """Removing any required field raises MemoryContractError."""
+    rec = _valid_record()
+    del rec[missing_field]
+    with pytest.raises(MemoryContractError, match=missing_field):
+        validate_memory_record(rec)
+
+
+# ---------------------------------------------------------------------------
+# evidence_refs and source_refs validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_memory_record_empty_evidence_refs_rejected() -> None:
+    rec = _valid_record(evidence_refs=[])
+    with pytest.raises(MemoryContractError, match="evidence_refs"):
+        validate_memory_record(rec)
+
+
+@pytest.mark.unit
+def test_validate_memory_record_empty_source_refs_rejected() -> None:
+    rec = _valid_record(source_refs=[])
+    with pytest.raises(MemoryContractError, match="source_refs"):
+        validate_memory_record(rec)
+
+
+@pytest.mark.unit
+def test_validate_memory_record_evidence_refs_not_list_rejected() -> None:
+    rec = _valid_record(evidence_refs="ev-001")
+    with pytest.raises(MemoryContractError, match="evidence_refs"):
+        validate_memory_record(rec)
+
+
+# ---------------------------------------------------------------------------
+# Confidence validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad_confidence", [-0.001, 1.001, 2.0, -1.0])
+def test_validate_memory_record_bad_confidence_rejected(bad_confidence: float) -> None:
+    rec = _valid_record(confidence=bad_confidence)
+    with pytest.raises(MemoryContractError, match="confidence"):
+        validate_memory_record(rec)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("ok_confidence", [0.0, 0.5, 1.0, 0.123])
+def test_validate_memory_record_confidence_edge_values_accepted(
+    ok_confidence: float,
+) -> None:
+    rec = _valid_record(confidence=ok_confidence)
+    out = validate_memory_record(rec)
+    assert out["confidence"] == ok_confidence
+
+
+# ---------------------------------------------------------------------------
+# TTL contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_memory_record_ttl_zero_without_expires_at_ok() -> None:
+    """ttl=0 means no expiry; expires_at is not required."""
+    rec = _valid_record(ttl=0)
+    rec.pop("expires_at", None)
+    out = validate_memory_record(rec)
+    assert out["ttl"] == 0
+
+
+@pytest.mark.unit
+def test_validate_memory_record_ttl_positive_without_expires_at_rejected() -> None:
+    """ttl > 0 without expires_at violates the contract."""
+    rec = _valid_record(ttl=3600)
+    del rec["expires_at"]
+    with pytest.raises(MemoryContractError, match="expires_at"):
+        validate_memory_record(rec)
+
+
+@pytest.mark.unit
+def test_validate_memory_record_ttl_positive_expires_at_before_created_at_rejected() -> (
+    None
+):
+    """expires_at must be strictly after created_at when ttl > 0."""
+    rec = _valid_record(
+        ttl=3600,
+        created_at="2026-05-29T10:00:00+00:00",
+        expires_at="2026-05-29T09:00:00+00:00",
+    )
+    with pytest.raises(MemoryContractError, match="expires_at"):
+        validate_memory_record(rec)
+
+
+@pytest.mark.unit
+def test_validate_memory_record_ttl_positive_expires_at_equal_created_at_rejected() -> (
+    None
+):
+    """expires_at must be strictly after created_at (equal is not enough)."""
+    rec = _valid_record(
+        ttl=1,
+        created_at="2026-05-29T10:00:00+00:00",
+        expires_at="2026-05-29T10:00:00+00:00",
+    )
+    with pytest.raises(MemoryContractError, match="expires_at"):
+        validate_memory_record(rec)
+
+
+@pytest.mark.unit
+def test_validate_memory_record_ttl_negative_rejected() -> None:
+    rec = _valid_record(ttl=-1)
+    with pytest.raises(MemoryContractError, match="ttl"):
+        validate_memory_record(rec)
+
+
+@pytest.mark.unit
+def test_validate_memory_record_ttl_positive_valid() -> None:
+    """ttl > 0 with expires_at after created_at passes."""
+    rec = _valid_record(
+        ttl=7200,
+        created_at="2026-05-29T08:00:00+00:00",
+        expires_at="2026-05-29T10:00:00+00:00",
+    )
+    out = validate_memory_record(rec)
+    assert out["ttl"] == 7200
+
+
+# ---------------------------------------------------------------------------
+# stale_after
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_memory_record_stale_after_valid() -> None:
+    rec = _valid_record(stale_after=7200)
+    out = validate_memory_record(rec)
+    assert out["stale_after"] == 7200
+
+
+@pytest.mark.unit
+def test_validate_memory_record_stale_after_zero_ok() -> None:
+    rec = _valid_record(stale_after=0)
+    out = validate_memory_record(rec)
+    assert out["stale_after"] == 0
+
+
+@pytest.mark.unit
+def test_validate_memory_record_stale_after_negative_rejected() -> None:
+    rec = _valid_record(stale_after=-1)
+    with pytest.raises(MemoryContractError, match="stale_after"):
+        validate_memory_record(rec)
+
+
+# ---------------------------------------------------------------------------
+# superseded_by
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_memory_record_superseded_by_valid() -> None:
+    rec = _valid_record(superseded_by="mem-prev-id-001")
+    out = validate_memory_record(rec)
+    assert out["superseded_by"] == "mem-prev-id-001"
+
+
+@pytest.mark.unit
+def test_validate_memory_record_superseded_by_empty_string_rejected() -> None:
+    """superseded_by must be non-empty if present."""
+    rec = _valid_record(superseded_by="")
+    with pytest.raises(MemoryContractError, match="superseded_by"):
+        validate_memory_record(rec)
+
+
+@pytest.mark.unit
+def test_validate_memory_record_superseded_by_whitespace_rejected() -> None:
+    rec = _valid_record(superseded_by="   ")
+    with pytest.raises(MemoryContractError, match="superseded_by"):
+        validate_memory_record(rec)
+
+
+# ---------------------------------------------------------------------------
+# Unknown memory_type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_memory_record_unknown_memory_type_rejected() -> None:
+    rec = _valid_record(memory_type="unknown_memory")
+    with pytest.raises(MemoryContractError, match="memory_type"):
+        validate_memory_record(rec)
+
+
+@pytest.mark.unit
+def test_generate_memory_id_unknown_memory_type_rejected() -> None:
+    with pytest.raises(MemoryContractError, match="memory_type"):
+        generate_memory_id("s", "n", "bad_type", "a", "c", ["r"])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "memory_type",
+    list(CANONICAL_MEMORY_TYPES),
+)
+def test_all_canonical_memory_types_accepted(memory_type: str) -> None:
+    """All six canonical memory types pass validation."""
+    rec = _valid_record(memory_type=memory_type)
+    out = validate_memory_record(rec)
+    assert out["memory_type"] == memory_type
+
+
+# ---------------------------------------------------------------------------
+# Unknown extra fields (strict / non-strict)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_memory_record_unknown_field_strict_rejected() -> None:
+    """strict=True rejects records with fields not in the known field set."""
+    rec = _valid_record(totally_unknown_field_xyz="should_fail")
+    with pytest.raises(MemoryContractError, match="unknown fields"):
+        validate_memory_record(rec, strict=True)
+
+
+@pytest.mark.unit
+def test_validate_memory_record_unknown_field_non_strict_allowed() -> None:
+    """strict=False permits extra unknown fields."""
+    rec = _valid_record(totally_unknown_field_xyz="allowed")
+    out = validate_memory_record(rec, strict=False)
+    assert "memory_id" in out
+
+
+# ---------------------------------------------------------------------------
+# memory_id mismatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_memory_record_memory_id_mismatch_rejected() -> None:
+    """A record with an incorrect memory_id is rejected."""
+    rec = _valid_record(memory_id="00000000-0000-0000-0000-000000000000")
+    with pytest.raises(MemoryContractError, match="memory_id mismatch"):
+        validate_memory_record(rec)
+
+
+@pytest.mark.unit
+def test_validate_memory_record_wrong_memory_id_rejected() -> None:
+    """Any non-matching UUID is rejected."""
+    import uuid as _uuid
+
+    rec = _valid_record(memory_id=str(_uuid.uuid4()))
+    with pytest.raises(MemoryContractError, match="memory_id mismatch"):
+        validate_memory_record(rec)
+
+
+# ---------------------------------------------------------------------------
+# validate_memory_id_matches_record
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_memory_id_matches_record_correct() -> None:
+    """A correctly validated record passes the post-validation ID check."""
+    rec = _valid_record()
+    validated = validate_memory_record(rec)
+    validate_memory_id_matches_record(validated)  # must not raise
+
+
+@pytest.mark.unit
+def test_validate_memory_id_matches_record_wrong_id_raises() -> None:
+    rec = _valid_record()
+    validated = validate_memory_record(rec)
+    validated["memory_id"] = "00000000-0000-0000-0000-000000000000"
+    with pytest.raises(MemoryContractError, match="memory_id mismatch"):
+        validate_memory_id_matches_record(validated)
+
+
+@pytest.mark.unit
+def test_validate_memory_id_matches_record_missing_id_raises() -> None:
+    rec = _valid_record()
+    with pytest.raises(MemoryContractError, match="missing memory_id"):
+        validate_memory_id_matches_record(rec)
+
+
+# ---------------------------------------------------------------------------
+# SCHEMA_VERSION and CANONICAL_MEMORY_TYPES constants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_schema_version_constant() -> None:
+    assert SCHEMA_VERSION == "memory-contract/v1"
+
+
+@pytest.mark.unit
+def test_canonical_memory_types_count() -> None:
+    """Exactly 6 canonical memory types as per scoped-agent-memory-model-v1.md."""
+    assert len(CANONICAL_MEMORY_TYPES) == 6
+
+
+@pytest.mark.unit
+def test_canonical_memory_types_names() -> None:
+    expected = {
+        "working_memory",
+        "semantic_memory",
+        "episodic_memory",
+        "procedural_memory",
+        "preference_memory",
+        "risk_memory",
+    }
+    assert CANONICAL_MEMORY_TYPES == expected

--- a/tools/surrealdb/memory_contract.py
+++ b/tools/surrealdb/memory_contract.py
@@ -1,0 +1,447 @@
+"""Deterministic memory_id generation and fail-closed record validation.
+
+Issues:
+    #2606 — [EPIC][AGENT-MEMORY] Langzeitgedaechtnis / Persistent Agent Memory
+    Slice: Memory Reality Slice 2 — deterministic memory_id + contracts
+
+Scope:
+    Generates a stable UUIDv5 memory_id from canonical identity fields.
+    Validates agent_memory records against the v1 field contract.
+    No DB access. No MCP changes. No writes. No side effects.
+
+Guardrails:
+    - Read/compute-only. No memory write, no mutation.
+    - LR remains NO-GO. Board stage 'trade-capable' is not live-go.
+    - Deterministic: same inputs always produce the same memory_id.
+    - Fail-closed: invalid records raise MemoryContractError.
+
+Relations:
+    role: memory_id_generator_and_validator
+    domain: agent_memory
+    upstream:
+        - core/replay/canonical_json.py  (canonical_hash for source_refs fingerprint)
+    downstream:
+        - Slice 3 DB read proof
+        - Slice 4 Human-GO write gate
+    see_also:
+        - docs/surrealdb/memory-reality-slice1-audit.md  (R5 finalized here)
+        - docs/surrealdb/scoped-agent-memory-model-v1.md
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from core.replay.canonical_json import canonical_hash
+
+SCHEMA_VERSION = "memory-contract/v1"
+
+CANONICAL_MEMORY_TYPES: frozenset[str] = frozenset(
+    {
+        "working_memory",
+        "semantic_memory",
+        "episodic_memory",
+        "procedural_memory",
+        "preference_memory",
+        "risk_memory",
+    }
+)
+
+# UUIDv5 namespace dedicated exclusively to memory_id generation.
+# Must never be reused for other ID domains (decision_pk, event_pk, etc.).
+MEMORY_ID_NAMESPACE = uuid.UUID("b4e1d2c3-a5f6-4780-9bcd-ef0123456789")
+
+# All valid top-level fields in a v1 memory record.
+_KNOWN_FIELDS: frozenset[str] = frozenset(
+    {
+        "memory_id",
+        "scope",
+        "namespace",
+        "memory_type",
+        "content",
+        "source_refs",
+        "evidence_refs",
+        "confidence",
+        "ttl",
+        "expires_at",
+        "created_by",
+        "created_at",
+        "superseded_by",
+        "stale_after",
+        "comment",
+    }
+)
+
+_REQUIRED_FIELDS: tuple[str, ...] = (
+    "scope",
+    "namespace",
+    "memory_type",
+    "content",
+    "source_refs",
+    "evidence_refs",
+    "confidence",
+    "ttl",
+    "created_by",
+    "created_at",
+)
+
+
+class MemoryContractError(ValueError):
+    """Raised when a memory record or memory_id contract is violated."""
+
+
+# ---------------------------------------------------------------------------
+# Hash helpers
+# ---------------------------------------------------------------------------
+
+
+def compute_content_hash(content: str) -> str:
+    """Compute SHA256 hex digest of stripped UTF-8 content.
+
+    Args:
+        content: Raw memory content string.
+
+    Returns:
+        64-character lowercase hex SHA256 digest.
+    """
+    return hashlib.sha256(content.strip().encode("utf-8")).hexdigest()
+
+
+def compute_source_refs_fingerprint(source_refs: list[str]) -> str:
+    """Compute canonical hash of sorted unique source reference strings.
+
+    Uses canonical_hash (sorted-key JSON + SHA256) from core.replay.canonical_json
+    so the fingerprint is stable regardless of list ordering or duplicates.
+
+    Args:
+        source_refs: List of source reference strings.
+
+    Returns:
+        64-character lowercase hex SHA256 digest.
+    """
+    return canonical_hash(sorted(set(source_refs)))
+
+
+# ---------------------------------------------------------------------------
+# ID generation
+# ---------------------------------------------------------------------------
+
+
+def generate_memory_id(
+    scope: str,
+    namespace: str,
+    memory_type: str,
+    created_by: str,
+    content: str,
+    source_refs: list[str],
+) -> str:
+    """Generate a deterministic UUIDv5 memory_id.
+
+    Name string (pipe-delimited):
+        ``{scope}|{namespace}|{memory_type}|{created_by}|{content_hash}|{source_refs_fingerprint}``
+
+    Fields deliberately NOT in the ID: created_at, ttl, confidence,
+    evidence_refs.  These are mutable metadata; the ID must be stable
+    across updates to those fields.
+
+    Args:
+        scope: Memory scope identifier (required, non-empty).
+        namespace: Memory namespace (required, non-empty).
+        memory_type: Must be a member of CANONICAL_MEMORY_TYPES; lowercased.
+        created_by: Identity string of the creating agent (required, non-empty).
+        content: Memory content string.
+        source_refs: Source reference strings list.
+
+    Returns:
+        UUIDv5 string (36 characters, lowercase hyphenated).
+
+    Raises:
+        MemoryContractError: If any required input is invalid or memory_type
+            is not in CANONICAL_MEMORY_TYPES.
+    """
+    if not isinstance(scope, str) or not scope.strip():
+        raise MemoryContractError("scope is required for memory_id generation")
+    if not isinstance(namespace, str) or not namespace.strip():
+        raise MemoryContractError("namespace is required for memory_id generation")
+    if not isinstance(created_by, str) or not created_by.strip():
+        raise MemoryContractError("created_by is required for memory_id generation")
+
+    mt = memory_type.lower() if isinstance(memory_type, str) else ""
+    if mt not in CANONICAL_MEMORY_TYPES:
+        raise MemoryContractError(
+            f"unknown memory_type {memory_type!r}; must be one of {sorted(CANONICAL_MEMORY_TYPES)}"
+        )
+
+    content_hash = compute_content_hash(content)
+    source_refs_fingerprint = compute_source_refs_fingerprint(source_refs)
+
+    name = (
+        f"{scope.strip()}|{namespace.strip()}|{mt}|{created_by.strip()}"
+        f"|{content_hash}|{source_refs_fingerprint}"
+    )
+    return str(uuid.uuid5(MEMORY_ID_NAMESPACE, name))
+
+
+# ---------------------------------------------------------------------------
+# Validation internals
+# ---------------------------------------------------------------------------
+
+
+def _parse_datetime_strict(value: Any, field: str) -> datetime:
+    """Parse an ISO 8601 datetime; fail-closed on any error."""
+    if isinstance(value, datetime):
+        return (
+            value.astimezone(timezone.utc)
+            if value.tzinfo
+            else value.replace(tzinfo=timezone.utc)
+        )
+    if not isinstance(value, str) or not value.strip():
+        raise MemoryContractError(f"{field} must be a non-empty ISO datetime string")
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise MemoryContractError(
+            f"{field} is not a valid ISO datetime: {value!r}"
+        ) from exc
+    return (
+        parsed.astimezone(timezone.utc)
+        if parsed.tzinfo
+        else parsed.replace(tzinfo=timezone.utc)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public validation API
+# ---------------------------------------------------------------------------
+
+
+def validate_memory_record(raw: Any, *, strict: bool = True) -> dict[str, Any]:
+    """Validate a raw agent_memory record against the v1 contract.
+
+    Fail-closed: raises MemoryContractError for any violation.
+
+    Contract rules:
+    - Required: scope, namespace, memory_type, content, source_refs,
+      evidence_refs, confidence, ttl, created_by, created_at.
+    - memory_type must be in CANONICAL_MEMORY_TYPES.
+    - source_refs: non-empty list of non-empty strings.
+    - evidence_refs: non-empty list of non-empty strings.
+    - confidence: numeric value in [0.0, 1.0].
+    - ttl: integer >= 0 (seconds).
+    - If ttl > 0: expires_at required, and must be strictly after created_at.
+    - Optional superseded_by: non-empty string if present.
+    - Optional stale_after: integer >= 0 if present.
+    - Optional comment: any string.
+    - If memory_id is present: must equal the computed UUIDv5.
+    - If memory_id is absent: validator computes and attaches it.
+    - strict=True: rejects any fields not in _KNOWN_FIELDS.
+
+    Canon field names (not aliases):
+    - created_by (NOT agent_id)
+    - source_refs (NOT source_ref)
+    - superseded_by (NOT supersedes)
+
+    Args:
+        raw: Dict representing a raw memory record.
+        strict: If True (default), reject records with unknown fields.
+
+    Returns:
+        Validated and normalized record dict with memory_id set and
+        memory_type lowercased.
+
+    Raises:
+        MemoryContractError: On any contract violation.
+    """
+    if not isinstance(raw, dict):
+        raise MemoryContractError("memory record must be a dict")
+
+    if strict:
+        unknown = set(raw.keys()) - _KNOWN_FIELDS
+        if unknown:
+            raise MemoryContractError(
+                f"unknown fields in memory record (strict=True): {sorted(unknown)}"
+            )
+
+    # Required field presence
+    for field in _REQUIRED_FIELDS:
+        if field not in raw:
+            raise MemoryContractError(f"missing required field: {field!r}")
+
+    # scope
+    scope = raw["scope"]
+    if not isinstance(scope, str) or not scope.strip():
+        raise MemoryContractError("scope must be a non-empty string")
+
+    # namespace
+    namespace = raw["namespace"]
+    if not isinstance(namespace, str) or not namespace.strip():
+        raise MemoryContractError("namespace must be a non-empty string")
+
+    # memory_type
+    memory_type = raw["memory_type"]
+    if not isinstance(memory_type, str):
+        raise MemoryContractError("memory_type must be a string")
+    mt = memory_type.lower()
+    if mt not in CANONICAL_MEMORY_TYPES:
+        raise MemoryContractError(
+            f"unknown memory_type {memory_type!r}; must be one of {sorted(CANONICAL_MEMORY_TYPES)}"
+        )
+
+    # content
+    content = raw["content"]
+    if not isinstance(content, str) or not content.strip():
+        raise MemoryContractError("content must be a non-empty string")
+
+    # source_refs
+    source_refs = raw["source_refs"]
+    if not isinstance(source_refs, list) or not source_refs:
+        raise MemoryContractError("source_refs must be a non-empty list")
+    if not all(isinstance(r, str) and r.strip() for r in source_refs):
+        raise MemoryContractError("source_refs must be a list of non-empty strings")
+
+    # evidence_refs
+    evidence_refs = raw["evidence_refs"]
+    if not isinstance(evidence_refs, list) or not evidence_refs:
+        raise MemoryContractError("evidence_refs must be a non-empty list")
+    if not all(isinstance(r, str) and r.strip() for r in evidence_refs):
+        raise MemoryContractError("evidence_refs must be a list of non-empty strings")
+
+    # confidence
+    confidence = raw["confidence"]
+    try:
+        confidence_f = float(confidence)
+    except (TypeError, ValueError) as exc:
+        raise MemoryContractError(
+            f"confidence must be a float in [0.0, 1.0]; got {confidence!r}"
+        ) from exc
+    if not (0.0 <= confidence_f <= 1.0):
+        raise MemoryContractError(
+            f"confidence must be in [0.0, 1.0]; got {confidence_f}"
+        )
+
+    # ttl
+    ttl = raw["ttl"]
+    try:
+        ttl_int = int(ttl)
+    except (TypeError, ValueError) as exc:
+        raise MemoryContractError(
+            f"ttl must be an integer >= 0 (seconds); got {ttl!r}"
+        ) from exc
+    if ttl_int < 0:
+        raise MemoryContractError(f"ttl must be >= 0; got {ttl_int}")
+
+    # created_by
+    created_by = raw["created_by"]
+    if not isinstance(created_by, str) or not created_by.strip():
+        raise MemoryContractError("created_by must be a non-empty string")
+
+    # created_at
+    created_at_dt = _parse_datetime_strict(raw["created_at"], "created_at")
+
+    # expires_at: required when ttl > 0
+    if ttl_int > 0:
+        if "expires_at" not in raw:
+            raise MemoryContractError("expires_at is required when ttl > 0")
+        expires_at_dt = _parse_datetime_strict(raw["expires_at"], "expires_at")
+        if expires_at_dt <= created_at_dt:
+            raise MemoryContractError(
+                f"expires_at must be strictly after created_at; "
+                f"got expires_at={raw['expires_at']!r}, created_at={raw['created_at']!r}"
+            )
+
+    # superseded_by (optional, non-empty if present)
+    if "superseded_by" in raw:
+        sv = raw["superseded_by"]
+        if not isinstance(sv, str) or not sv.strip():
+            raise MemoryContractError(
+                "superseded_by must be a non-empty string if present"
+            )
+
+    # stale_after (optional, int >= 0)
+    if "stale_after" in raw:
+        sa = raw["stale_after"]
+        try:
+            sa_int = int(sa)
+        except (TypeError, ValueError) as exc:
+            raise MemoryContractError(
+                f"stale_after must be an integer >= 0; got {sa!r}"
+            ) from exc
+        if sa_int < 0:
+            raise MemoryContractError(f"stale_after must be >= 0; got {sa_int}")
+
+    # Compute canonical memory_id
+    computed_id = generate_memory_id(
+        scope=scope.strip(),
+        namespace=namespace.strip(),
+        memory_type=mt,
+        created_by=created_by.strip(),
+        content=content,
+        source_refs=source_refs,
+    )
+
+    # memory_id check: if present must match; if absent attach computed value
+    if "memory_id" in raw:
+        existing_id = raw["memory_id"]
+        if existing_id != computed_id:
+            raise MemoryContractError(
+                f"memory_id mismatch: record has {existing_id!r}, "
+                f"computed {computed_id!r}"
+            )
+
+    # Build normalized output (shallow copy, override computed fields)
+    record: dict[str, Any] = dict(raw)
+    record["memory_type"] = mt  # lowercased canonical form
+    record["memory_id"] = computed_id  # attach (or confirm)
+
+    return record
+
+
+def validate_memory_id_matches_record(record: dict[str, Any]) -> None:
+    """Verify that record['memory_id'] matches the value computed from the record.
+
+    Args:
+        record: Memory record dict. Must have memory_id and all fields
+            required for ID computation (scope, namespace, memory_type,
+            created_by, content, source_refs).
+
+    Raises:
+        MemoryContractError: If memory_id is absent or does not match the
+            computed UUIDv5.
+    """
+    if "memory_id" not in record:
+        raise MemoryContractError("record is missing memory_id field")
+
+    _required_for_id = (
+        "scope",
+        "namespace",
+        "memory_type",
+        "created_by",
+        "content",
+        "source_refs",
+    )
+    for field in _required_for_id:
+        if field not in record:
+            raise MemoryContractError(
+                f"record is missing field required for ID computation: {field!r}"
+            )
+
+    computed = generate_memory_id(
+        scope=str(record["scope"]).strip(),
+        namespace=str(record["namespace"]).strip(),
+        memory_type=str(record["memory_type"]).lower(),
+        created_by=str(record["created_by"]).strip(),
+        content=record["content"],
+        source_refs=record["source_refs"],
+    )
+
+    if record["memory_id"] != computed:
+        raise MemoryContractError(
+            f"memory_id mismatch: record has {record['memory_id']!r}, "
+            f"computed {computed!r}"
+        )


### PR DESCRIPTION
## Summary

Implements Reconcile Decision R5 from the Slice 1 audit (#2606): deterministic memory_id generation and fail-closed validation for SurrealDB memory records.

**New files:**
- 	ools/surrealdb/memory_contract.py — core contract module with:
  - SCHEMA_VERSION = 'memory-contract/v1'
  - CANONICAL_MEMORY_TYPES (6 types: working/semantic/episodic/procedural/preference/risk memory)
  - MEMORY_ID_NAMESPACE (fixed UUIDv5 namespace)
  - compute_content_hash(content) — SHA256 of stripped UTF-8
  - compute_source_refs_fingerprint(source_refs) — canonical_hash of sorted unique refs
  - generate_memory_id(scope, namespace, memory_type, created_by, content, source_refs) — UUIDv5 deterministic ID; NOT influenced by created_at/ttl/confidence/evidence_refs
  - alidate_memory_record(raw, *, strict=True) — fail-closed, adds memory_id if absent
  - alidate_memory_id_matches_record(record) — raises MemoryContractError on mismatch

- 	ests/unit/surrealdb/test_memory_contract.py — 76 unit tests covering:
  - ID determinism and field sensitivity/insensitivity
  - All 10 required fields (parametrized missing-field tests)
  - TTL contract (ttl>0 requires expires_at after created_at)
  - Confidence bounds [0.0, 1.0]
  - stale_after, superseded_by, comment optional fields
  - Unknown memory_type rejection
  - strict/non-strict unknown extra field behavior
  - memory_id mismatch detection

**Updated:**
- docs/surrealdb/memory-reality-slice1-audit.md — ## 16. Slice 2 addendum
- knowledge/logs/sessions/2026-05-29-2606-memory-slice2.md — session evidence log

## What is NOT changed
No DB write, no MCP change, no memory_read.py change, no core/utils/uuid_gen.py change, no surql/docker/infra. LR remains NO-GO.

## Test plan
`
pytest tests/unit/surrealdb/test_memory_contract.py -v          # 76 passed
pytest tests/unit/surrealdb/test_memory_read_characterization.py tests/unit/surrealdb/test_wave14_services_v1.py -v  # no regressions
ruff check tools/surrealdb/memory_contract.py tests/unit/surrealdb/test_memory_contract.py  # clean
black --check tools/surrealdb/memory_contract.py tests/unit/surrealdb/test_memory_contract.py  # clean
`

Refs #2606