### PR TITLE
feat(surrealdb): #2606 memory slice 3 TTL freshness stale proof

### DIFF
--- a/docs/surrealdb/memory-reality-slice1-audit.md
+++ b/docs/surrealdb/memory-reality-slice1-audit.md
@@ -341,10 +341,67 @@ Canon names enforced: `created_by` (NOT `agent_id`), `source_refs` (NOT `source_
 
 | Gap | Slice |
 | --- | --- |
-| TTL unit drift (`ttl` seconds vs `ttl_days` in reader) | Slice 3 |
-| DB-backed memory read proof | Slice 3 |
+| TTL unit drift (`ttl` seconds vs `ttl_days` in reader) | **Slice 3 (closed in-memory)** |
+| DB-backed memory read proof | Follow-up slice (not Slice 3 scope) |
 | Human-GO write gate design | Slice 4 |
 | Memory write implementation | Slice 5 (only after Human-GO + Slices 2–4) |
+
+---
+
+## 17. Slice 3 addendum
+
+**Slice 3 delivered:** `2606-memory-slice3-ttl-freshness`  
+**Date:** 2026-05-29
+
+### 17.1 What was built
+
+| Artifact | Path |
+| --- | --- |
+| Freshness classifier | `classify_memory_freshness()` in `tools/surrealdb/memory_contract.py` |
+| Reader TTL fix | `tools/surrealdb/memory_read.py` — uses contract helper, optional `now=` |
+| MCP normalizer fix | `tools/mcp/context_evidence_memory_tools.py` — no `ttl` → `ttl_days` copy |
+| Unit tests | `tests/unit/surrealdb/test_memory_freshness.py` (15 tests) |
+| Characterization update | `tests/unit/surrealdb/test_memory_read_characterization.py` |
+
+### 17.2 R4 closed (in-memory proof)
+
+| Before | After |
+| --- | --- |
+| Reader used `ttl_days` + wall-clock age in days | Reader uses `expires_at`, `ttl` (seconds), `stale_after`, optional legacy `ttl_days` |
+| MCP copied `ttl` → `ttl_days` 1:1 | Schema `ttl` passes through unchanged |
+| Fake-fresh records when `ttl=3600` meant 3600 days | Canonical seconds + `expires_at` classification |
+
+**Canon:** `ttl` is seconds; `expires_at` authoritative when present; `stale_after` is seconds since `created_at`. Stale/expired records are **marked**, not filtered.
+
+**Injectable time:** `read_memory_v1(..., now=)` for deterministic tests; production default `cdb_utcnow()`.
+
+**Legacy shim:** Reader fixtures with only `ttl_days` (no `ttl`/`expires_at`) still work with reason `legacy_ttl_days` (e.g. `wave14_v1.json`).
+
+### 17.3 Test coverage (Slice 3)
+
+15 unit tests in `test_memory_freshness.py` plus updated characterization tests:
+- fresh / expired / stale_after / superseded / explicit stale
+- legacy `ttl_days` only
+- derived expiry from `ttl` seconds when `expires_at` absent
+- reader marks expired without filtering
+- MCP normalizer preserves `ttl` seconds
+- guardrail: no `datetime.now()` in `memory_read.py`
+
+### 17.4 No-changes list (Slice 3)
+
+- No DB access, no SurrealDB runtime, no Docker/infra
+- No memory write, no MCP registry changes
+- `stale_knowledge_scan.py` unchanged (already uses `expires_at`)
+- `DELIVERY_APPROVED.yaml` unchanged
+- LR remains NO-GO
+
+### 17.5 Remaining gaps after Slice 3
+
+| Gap | Follow-up |
+| --- | --- |
+| DB-backed memory read proof (`surrealdb-local`) | Separate slice / local_only |
+| Human-GO write gate design | Slice 4 |
+| Memory write implementation | Slice 5 |
 
 ---
 

--- a/knowledge/logs/sessions/2026-05-29-2606-memory-slice3-ttl-freshness.md
+++ b/knowledge/logs/sessions/2026-05-29-2606-memory-slice3-ttl-freshness.md
@@ -1,0 +1,69 @@
+# Session Log: #2606 Memory Reality Slice 3 — TTL / Freshness / Stale Proof
+
+**Date:** 2026-05-29 (Europe/Berlin)  
+**Scope:** Plan-GO — Slice 3: TTL/freshness/stale contract proof (in-memory only).  
+**Issue:** [#2606](https://github.com/jannekbuengener/Claire_de_Binare/issues/2606) — OPEN  
+**Guardrail:** LR remains NO-GO. No memory write, no DB, no runtime.
+
+---
+
+## Git-Wahrheit (session start)
+
+- Branch: `main` @ `57a4cdd8` (PR #2684 merged)
+- Worktree: clean
+- Open PRs: none
+
+---
+
+## Scope
+
+**IN:**
+- `classify_memory_freshness()` + `MemoryFreshness` in `memory_contract.py`
+- `memory_read.py` — canonical TTL path, `now=` injection
+- `_normalize_memory_row` — stop `ttl` → `ttl_days` 1:1
+- `tests/unit/surrealdb/test_memory_freshness.py` (new)
+- Updated characterization tests
+- Audit §17 addendum
+
+**OUT:**
+- No DB-backed proof, no SurrealDB runtime, no Docker
+- No memory write, no MCP registry changes
+- No `Closes #2606`
+
+---
+
+## Delivered
+
+| Artifact | Path |
+| --- | --- |
+| Freshness API | `tools/surrealdb/memory_contract.py` |
+| Reader fix | `tools/surrealdb/memory_read.py` |
+| MCP normalizer | `tools/mcp/context_evidence_memory_tools.py` |
+| Tests | `tests/unit/surrealdb/test_memory_freshness.py` |
+| Audit addendum | `docs/surrealdb/memory-reality-slice1-audit.md` §17 |
+
+---
+
+## Validation
+
+```
+pytest tests/unit/surrealdb/test_memory_freshness.py tests/unit/surrealdb/test_memory_contract.py tests/unit/surrealdb/test_memory_read_characterization.py tests/unit/surrealdb/test_wave14_services_v1.py -v
+pytest tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py -v -k memory
+ruff check (changed files)
+black --check (changed files)
+```
+
+---
+
+## R4 outcome
+
+- **Closed (in-memory):** `ttl` seconds vs `ttl_days` drift in reader + MCP normalizer
+- **Open:** DB-backed memory read proof (deferred per scope override)
+
+---
+
+## Remaining gaps
+
+- DB-backed read proof (`local_only`)
+- Human-GO write gate (Slice 4)
+- Memory write (Slice 5)

--- a/tests/unit/surrealdb/test_memory_freshness.py
+++ b/tests/unit/surrealdb/test_memory_freshness.py
@@ -1,0 +1,292 @@
+"""Unit tests for memory TTL/freshness/stale classification (Slice 3).
+
+Issue #2606 — Memory Reality Slice 3: TTL / Freshness / Stale Proof.
+
+Deterministic in-memory tests only; no DB, no writes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from tools.surrealdb.memory_contract import (
+    MemoryFreshness,
+    classify_memory_freshness,
+)
+from tools.surrealdb.memory_read import MemoryReadRequest, read_memory_v1
+from tools.mcp.context_evidence_memory_tools import _normalize_memory_row
+
+_NOW = datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)
+_CREATED = datetime(2026, 5, 29, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+@pytest.mark.unit
+def test_classify_no_ttl_or_expiry_is_fresh() -> None:
+    result = classify_memory_freshness(
+        {"created_at": _iso(_CREATED), "stale": False},
+        now=_NOW,
+    )
+    assert result == MemoryFreshness(
+        is_fresh=True, is_stale=False, is_expired=False, reasons=()
+    )
+
+
+@pytest.mark.unit
+def test_classify_expires_at_in_future_is_fresh() -> None:
+    expires = _NOW + timedelta(hours=1)
+    result = classify_memory_freshness(
+        {
+            "created_at": _iso(_CREATED),
+            "ttl": 7200,
+            "expires_at": _iso(expires),
+        },
+        now=_NOW,
+    )
+    assert result.is_fresh is True
+    assert result.is_stale is False
+    assert result.is_expired is False
+
+
+@pytest.mark.unit
+def test_classify_expires_at_elapsed_is_expired_and_stale() -> None:
+    expires = _NOW - timedelta(seconds=1)
+    result = classify_memory_freshness(
+        {
+            "created_at": _iso(_CREATED),
+            "ttl": 3600,
+            "expires_at": _iso(expires),
+        },
+        now=_NOW,
+    )
+    assert result.is_fresh is False
+    assert result.is_stale is True
+    assert result.is_expired is True
+    assert "expires_at_elapsed" in result.reasons
+
+
+@pytest.mark.unit
+def test_classify_stale_after_elapsed_not_expired() -> None:
+    expires = _NOW + timedelta(hours=2)
+    result = classify_memory_freshness(
+        {
+            "created_at": _iso(_CREATED),
+            "ttl": 86400,
+            "expires_at": _iso(expires),
+            "stale_after": 3600,
+        },
+        now=_NOW,
+    )
+    assert result.is_stale is True
+    assert result.is_expired is False
+    assert "stale_after_elapsed" in result.reasons
+    assert "expires_at_elapsed" not in result.reasons
+
+
+@pytest.mark.unit
+def test_classify_ttl_zero_without_expires_at_is_fresh() -> None:
+    result = classify_memory_freshness(
+        {"created_at": _iso(_CREATED), "ttl": 0},
+        now=_NOW,
+    )
+    assert result.is_fresh is True
+    assert result.is_expired is False
+
+
+@pytest.mark.unit
+def test_classify_superseded_by_is_stale_not_expired() -> None:
+    expires = _NOW - timedelta(hours=1)
+    result = classify_memory_freshness(
+        {
+            "created_at": _iso(_CREATED),
+            "expires_at": _iso(expires),
+            "superseded_by": "mem-newer",
+        },
+        now=_NOW,
+    )
+    assert result.is_stale is True
+    assert result.is_expired is False
+    assert result.reasons == ("superseded_by",)
+
+
+@pytest.mark.unit
+def test_classify_explicit_stale_flag() -> None:
+    result = classify_memory_freshness(
+        {"created_at": _iso(_CREATED), "stale": True},
+        now=_NOW,
+    )
+    assert result.is_stale is True
+    assert result.reasons == ("explicit_stale",)
+
+
+@pytest.mark.unit
+def test_classify_legacy_ttl_days_only() -> None:
+    old_created = _NOW - timedelta(days=10)
+    result = classify_memory_freshness(
+        {"created_at": _iso(old_created), "ttl_days": 1},
+        now=_NOW,
+    )
+    assert result.is_stale is True
+    assert "legacy_ttl_days" in result.reasons
+
+
+@pytest.mark.unit
+def test_classify_derives_expiry_from_ttl_seconds() -> None:
+    created = _NOW - timedelta(seconds=7200)
+    result = classify_memory_freshness(
+        {"created_at": _iso(created), "ttl": 3600},
+        now=_NOW,
+    )
+    assert result.is_expired is True
+    assert "expires_at_elapsed" in result.reasons
+
+
+@pytest.mark.unit
+def test_read_memory_expired_record_marked_stale_not_filtered() -> None:
+    created = _NOW - timedelta(hours=2)
+    expires = _NOW - timedelta(minutes=30)
+    records = [
+        {
+            "memory_id": "mem-expired-001",
+            "scope": "wave14",
+            "memory_type": "working_memory",
+            "content": "old",
+            "created_at": _iso(created),
+            "ttl": 3600,
+            "expires_at": _iso(expires),
+            "source_refs": ["docs/AGENTS.md"],
+            "evidence_refs": ["ev-001"],
+        }
+    ]
+    result = read_memory_v1(
+        records,
+        MemoryReadRequest(mode="by_scope", scope="wave14"),
+        now=_NOW,
+    )
+    assert len(result["matched_memory"]) == 1
+    row = result["matched_memory"][0]
+    assert row["stale"] is True
+    assert row["expired"] is True
+    assert "expires_at_elapsed" in row["freshness_reasons"]
+    assert "mem-expired-001" in result["stale_memory_ids"]
+
+
+@pytest.mark.unit
+def test_read_memory_fresh_with_canonical_ttl() -> None:
+    created = _NOW - timedelta(seconds=30)
+    expires = _NOW + timedelta(hours=1)
+    records = [
+        {
+            "memory_id": "mem-fresh-001",
+            "scope": "wave14",
+            "memory_type": "working_memory",
+            "content": "current",
+            "created_at": _iso(created),
+            "ttl": 3600,
+            "expires_at": _iso(expires),
+            "source_refs": ["docs/AGENTS.md"],
+            "evidence_refs": ["ev-001"],
+        }
+    ]
+    result = read_memory_v1(
+        records,
+        MemoryReadRequest(mode="by_scope", scope="wave14"),
+        now=_NOW,
+    )
+    row = result["matched_memory"][0]
+    assert row["stale"] is False
+    assert row.get("expired") is False
+    assert row["ttl"] == 3600
+    assert "mem-fresh-001" not in result["stale_memory_ids"]
+
+
+@pytest.mark.unit
+def test_read_memory_legacy_ttl_days_fixture_still_stale() -> None:
+    old = _NOW - timedelta(days=10)
+    records = [
+        {
+            "memory_id": "mem-char-ttl-days",
+            "scope": "wave14",
+            "memory_type": "working_memory",
+            "content": "pinned",
+            "created_at": _iso(old),
+            "ttl_days": 1,
+            "source_refs": ["docs/AGENTS.md"],
+            "evidence_refs": ["ev-pin-001"],
+        }
+    ]
+    result = read_memory_v1(
+        records,
+        MemoryReadRequest(mode="by_scope", scope="wave14"),
+        now=_NOW,
+    )
+    matched = {m["memory_id"]: m for m in result["matched_memory"]}
+    assert matched["mem-char-ttl-days"]["stale"] is True
+    assert "legacy_ttl_days" in matched["mem-char-ttl-days"]["freshness_reasons"]
+
+
+@pytest.mark.unit
+def test_normalize_memory_row_preserves_ttl_seconds() -> None:
+    row = _normalize_memory_row(
+        {
+            "memory_id": "mem-schema-pin",
+            "scope": "agent:OPENCODE/copilot",
+            "namespace": "session",
+            "memory_type": "semantic_memory",
+            "content": "test",
+            "created_by": "agent-test-001",
+            "ttl": 3600,
+            "source_refs": ["docs/AGENTS.md@abc123"],
+            "evidence_refs": ["ev-001"],
+        }
+    )
+    assert row["agent"] == "agent-test-001"
+    assert row["ttl"] == 3600
+    assert "ttl_days" not in row
+
+
+@pytest.mark.unit
+def test_normalize_memory_row_one_second_ttl_not_mapped_to_days() -> None:
+    recent = _NOW - timedelta(seconds=30)
+    expires = _NOW + timedelta(seconds=30)
+    row = _normalize_memory_row(
+        {
+            "memory_id": "mem-ttl-unit-gap",
+            "scope": "wave14",
+            "namespace": "session",
+            "memory_type": "working_memory",
+            "content": "ttl gap pin",
+            "created_by": "codex",
+            "ttl": 60,
+            "source_refs": ["docs/AGENTS.md"],
+            "evidence_refs": ["ev-001"],
+            "created_at": _iso(recent),
+            "expires_at": _iso(expires),
+        }
+    )
+    assert row["ttl"] == 60
+    assert "ttl_days" not in row
+
+    result = read_memory_v1(
+        [row],
+        MemoryReadRequest(mode="by_scope", scope="wave14"),
+        now=_NOW,
+    )
+    matched = result["matched_memory"][0]
+    assert matched["memory_id"] == "mem-ttl-unit-gap"
+    assert matched["stale"] is False
+    assert "mem-ttl-unit-gap" not in result["stale_memory_ids"]
+
+
+@pytest.mark.unit
+def test_memory_read_no_datetime_now_in_source() -> None:
+    """Guardrail: memory_read must use injectable clock, not datetime.now()."""
+    source = Path("tools/surrealdb/memory_read.py").read_text(encoding="utf-8")
+    assert "datetime.now(" not in source
+    assert "datetime.utcnow(" not in source

--- a/tests/unit/surrealdb/test_memory_read_characterization.py
+++ b/tests/unit/surrealdb/test_memory_read_characterization.py
@@ -1,10 +1,8 @@
 """Characterization tests for memory read contract and schema normalizer drift.
 
-Issue #2606 — Memory Reality Slice 1 (audit only; no behavior change).
+Issue #2606 — Memory Reality Slice 3 (TTL/freshness/stale proof).
 
-These tests PIN current behavior so a future TTL-unit fix (Slice 3) must be
-an explicit, reviewed change. See docs/surrealdb/memory-reality-slice1-audit.md
-(Reconcile R4).
+See docs/surrealdb/memory-reality-slice1-audit.md (Reconcile R4, Slice 3 addendum).
 """
 
 from __future__ import annotations
@@ -16,15 +14,17 @@ import pytest
 from tools.mcp.context_evidence_memory_tools import _normalize_memory_row
 from tools.surrealdb.memory_read import MemoryReadRequest, read_memory_v1
 
+_NOW = datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)
+
 
 def _utc_iso(dt: datetime) -> str:
     return dt.astimezone(timezone.utc).isoformat()
 
 
 @pytest.mark.unit
-def test_memory_read_ttl_days_marks_old_record_stale() -> None:
-    """Reader TTL path uses ttl_days as whole days (fixture contract)."""
-    old = datetime.now(timezone.utc) - timedelta(days=10)
+def test_memory_read_legacy_ttl_days_marks_old_record_stale() -> None:
+    """Legacy reader fixtures: ttl_days (whole days) when no schema ttl/expires_at."""
+    old = _NOW - timedelta(days=10)
     records = [
         {
             "memory_id": "mem-char-ttl-days",
@@ -38,7 +38,7 @@ def test_memory_read_ttl_days_marks_old_record_stale() -> None:
         }
     ]
     result = read_memory_v1(
-        records, MemoryReadRequest(mode="by_scope", scope="wave14")
+        records, MemoryReadRequest(mode="by_scope", scope="wave14"), now=_NOW
     )
     matched = {m["memory_id"]: m for m in result["matched_memory"]}
     assert matched["mem-char-ttl-days"]["stale"] is True
@@ -62,17 +62,15 @@ def test_normalize_memory_row_maps_created_by_to_agent() -> None:
         }
     )
     assert row["agent"] == "agent-test-001"
-    assert row["ttl_days"] == 3600
+    assert row["ttl"] == 3600
+    assert "ttl_days" not in row
 
 
 @pytest.mark.unit
-def test_normalize_memory_row_ttl_copied_to_ttl_days_without_unit_conversion() -> None:
-    """KNOWN GAP (R4): schema ttl (seconds) is copied 1:1 to ttl_days.
-
-    One second of schema ttl is treated as one day of reader TTL until Slice 3.
-    This test must fail if someone 'fixes' normalization without updating reader.
-    """
-    recent = datetime.now(timezone.utc) - timedelta(seconds=30)
+def test_normalize_memory_row_ttl_seconds_not_copied_to_ttl_days() -> None:
+    """R4 fix: schema ttl (seconds) stays ttl; reader uses expires_at / ttl seconds."""
+    recent = _NOW - timedelta(seconds=30)
+    expires = _NOW + timedelta(seconds=30)
     row = _normalize_memory_row(
         {
             "memory_id": "mem-ttl-unit-gap",
@@ -81,16 +79,18 @@ def test_normalize_memory_row_ttl_copied_to_ttl_days_without_unit_conversion() -
             "memory_type": "working_memory",
             "content": "ttl gap pin",
             "created_by": "codex",
-            "ttl": 1,
+            "ttl": 60,
             "source_refs": ["docs/AGENTS.md"],
             "evidence_refs": ["ev-001"],
             "created_at": _utc_iso(recent),
+            "expires_at": _utc_iso(expires),
         }
     )
-    assert row["ttl_days"] == 1
+    assert row["ttl"] == 60
+    assert "ttl_days" not in row
 
     result = read_memory_v1(
-        [row], MemoryReadRequest(mode="by_scope", scope="wave14")
+        [row], MemoryReadRequest(mode="by_scope", scope="wave14"), now=_NOW
     )
     matched = result["matched_memory"][0]
     assert matched["memory_id"] == "mem-ttl-unit-gap"
@@ -107,15 +107,15 @@ def test_memory_read_superseded_by_sets_superseded_trust() -> None:
             "scope": "wave14",
             "memory_type": "episodic_memory",
             "content": "old fact",
-            "created_at": _utc_iso(datetime.now(timezone.utc)),
+            "created_at": _utc_iso(_NOW),
             "superseded_by": "mem-newer",
             "source_refs": ["issue:#1"],
             "evidence_refs": ["ev-001"],
         }
     ]
     result = read_memory_v1(
-        records, MemoryReadRequest(mode="by_scope", scope="wave14")
+        records, MemoryReadRequest(mode="by_scope", scope="wave14"), now=_NOW
     )
     entry = result["matched_memory"][0]
     assert entry["trust_level"] == "superseded"
-    assert "mem-superseded-pin" in result["superseded_memory_ids"]
+    assert entry["superseded"] is True

--- a/tests/unit/surrealdb/test_wave14_context_record_schemas.py
+++ b/tests/unit/surrealdb/test_wave14_context_record_schemas.py
@@ -46,7 +46,10 @@ def test_surql_declares_created_at_for_wave14_tables(
 @pytest.mark.unit
 @pytest.mark.parametrize(
     ("artifact", "table"),
-    [(artifact, TABLE_BY_ARTIFACT[artifact]) for artifact in contracts.WAVE14_JSONL_ARTIFACTS],
+    [
+        (artifact, TABLE_BY_ARTIFACT[artifact])
+        for artifact in contracts.WAVE14_JSONL_ARTIFACTS
+    ],
 )
 def test_jsonl_required_fields_map_to_surql_columns(
     surql_text: str, artifact: str, table: str
@@ -55,7 +58,9 @@ def test_jsonl_required_fields_map_to_surql_columns(
     jsonl_required = contracts.WAVE14_JSONL_REQUIRED[artifact]
     record_fields = jsonl_required - contracts.JSONL_ENVELOPE_FIELDS
     missing = record_fields - surql_fields
-    assert not missing, f"{artifact} JSONL fields missing from {table} surql: {sorted(missing)}"
+    assert (
+        not missing
+    ), f"{artifact} JSONL fields missing from {table} surql: {sorted(missing)}"
 
 
 @pytest.mark.unit
@@ -69,7 +74,10 @@ def test_evidence_ref_normalization_aliases() -> None:
     }
     normalized = _normalize_evidence_ref_row(row)
 
-    for schema_field, contract_field in contracts.EVIDENCE_SCHEMA_TO_LOOKUP_ALIASES.items():
+    for (
+        schema_field,
+        contract_field,
+    ) in contracts.EVIDENCE_SCHEMA_TO_LOOKUP_ALIASES.items():
         if schema_field == "source_path":
             assert normalized[contract_field] == [row[schema_field]]
         else:
@@ -191,9 +199,10 @@ def test_decision_event_null_and_empty_fields_do_not_crash_history_query() -> No
         events,
         DecisionHistoryQueryRequest(mode="by_scope", scope="wave14"),
     )
-    assert result["schema_version"] == contracts.SERVICE_SCHEMA_VERSIONS[
-        "cdb_context_decision_history"
-    ]
+    assert (
+        result["schema_version"]
+        == contracts.SERVICE_SCHEMA_VERSIONS["cdb_context_decision_history"]
+    )
     assert len(result["matched_decisions"]) == 1
     decision = result["matched_decisions"][0]
     assert decision["decision_id"] == "dec-empty-001"

--- a/tests/unit/surrealdb/test_wave14_context_record_schemas.py
+++ b/tests/unit/surrealdb/test_wave14_context_record_schemas.py
@@ -126,7 +126,8 @@ def test_memory_normalization_maps_schema_aliases() -> None:
     }
     normalized = _normalize_memory_row(row)
     assert normalized["agent"] == "agent-test-001"
-    assert normalized["ttl_days"] == 7
+    assert normalized["ttl"] == 7
+    assert "ttl_days" not in normalized
     for field in contracts.MEMORY_SCHEMA_DEFAULTS:
         assert field in normalized
 

--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -1014,7 +1014,7 @@ def test_memory_get_db_limit_invalid_returns_error(monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Bu_hE: _normalize_memory_row maps created_by → agent and ttl → ttl_days
+# Bu_hE: _normalize_memory_row maps created_by → agent; ttl stays seconds
 # ---------------------------------------------------------------------------
 
 

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -221,8 +221,8 @@ def _normalize_memory_row(row: Mapping[str, Any]) -> dict[str, Any]:
     SurrealDB agent_memory schema  → memory reader contract
     ─────────────────────────────────────────────────────────
     created_by (str)  → agent    (str)
-    ttl        (int)  → ttl_days (int)   [unit assumed days; only int field present]
-    scope      (str)  → agent fallback if created_by is absent
+    ttl        (int)  → ttl      (int, seconds — unchanged)
+    expires_at, stale_after       → pass-through when present
 
     Resolver-only fields absent from the schema receive empty defaults so that
     ``read_memory_v1`` can operate without KeyErrors.  Modes ``by_topic``,
@@ -232,8 +232,6 @@ def _normalize_memory_row(row: Mapping[str, Any]) -> dict[str, Any]:
     result = dict(row)
     if "agent" not in result:
         result["agent"] = result.get("created_by") or result.get("scope") or ""
-    if "ttl_days" not in result and "ttl" in result:
-        result["ttl_days"] = result["ttl"]
     if "topic" not in result:
         result["topic"] = None
     if "topics" not in result:

--- a/tools/surrealdb/memory_contract.py
+++ b/tools/surrealdb/memory_contract.py
@@ -32,8 +32,9 @@ from __future__ import annotations
 
 import hashlib
 import uuid
-from datetime import datetime, timezone
-from typing import Any
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping
 
 from core.replay.canonical_json import canonical_hash
 
@@ -91,6 +92,16 @@ _REQUIRED_FIELDS: tuple[str, ...] = (
 
 class MemoryContractError(ValueError):
     """Raised when a memory record or memory_id contract is violated."""
+
+
+@dataclass(frozen=True)
+class MemoryFreshness:
+    """TTL/freshness classification for a memory record at a fixed point in time."""
+
+    is_fresh: bool
+    is_stale: bool
+    is_expired: bool
+    reasons: tuple[str, ...]
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +199,137 @@ def generate_memory_id(
 # ---------------------------------------------------------------------------
 # Validation internals
 # ---------------------------------------------------------------------------
+
+
+def _parse_datetime_lenient(value: Any) -> datetime | None:
+    """Parse ISO datetime for freshness classification; fail-soft on error."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return (
+            value.astimezone(timezone.utc)
+            if value.tzinfo
+            else value.replace(tzinfo=timezone.utc)
+        )
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return (
+        parsed.astimezone(timezone.utc)
+        if parsed.tzinfo
+        else parsed.replace(tzinfo=timezone.utc)
+    )
+
+
+def _as_int_lenient(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def classify_memory_freshness(
+    record: Mapping[str, Any],
+    *,
+    now: datetime,
+) -> MemoryFreshness:
+    """Classify memory freshness/staleness at an explicit point in time.
+
+    Canon: ``ttl`` is seconds; ``expires_at`` is authoritative when present;
+    ``stale_after`` is seconds since ``created_at``. Records are marked stale
+    or expired, never filtered. Legacy reader fixtures may supply ``ttl_days``
+    (whole days) only when neither ``ttl`` nor ``expires_at`` is present.
+
+    Args:
+        record: Raw or partially normalized memory mapping.
+        now: Reference instant (UTC-aware or naive treated as UTC).
+
+    Returns:
+        MemoryFreshness with ``is_expired`` a subset of ``is_stale``.
+    """
+    if now.tzinfo is None:
+        ref = now.replace(tzinfo=timezone.utc)
+    else:
+        ref = now.astimezone(timezone.utc)
+
+    reasons: list[str] = []
+
+    superseded_by = record.get("superseded_by")
+    if isinstance(superseded_by, str) and superseded_by.strip():
+        reasons.append("superseded_by")
+        return MemoryFreshness(
+            is_fresh=False,
+            is_stale=True,
+            is_expired=False,
+            reasons=tuple(reasons),
+        )
+
+    if bool(record.get("stale", False)):
+        reasons.append("explicit_stale")
+        return MemoryFreshness(
+            is_fresh=False,
+            is_stale=True,
+            is_expired=False,
+            reasons=tuple(reasons),
+        )
+
+    created_at = _parse_datetime_lenient(record.get("created_at"))
+    if created_at is None and "_created_at_dt" in record:
+        created_at = _parse_datetime_lenient(record.get("_created_at_dt"))
+
+    expires_at = _parse_datetime_lenient(record.get("expires_at"))
+    ttl_int = _as_int_lenient(record.get("ttl"))
+
+    if (
+        expires_at is None
+        and ttl_int is not None
+        and ttl_int > 0
+        and created_at is not None
+    ):
+        expires_at = created_at + timedelta(seconds=ttl_int)
+
+    is_expired = False
+    if expires_at is not None and ref >= expires_at:
+        reasons.append("expires_at_elapsed")
+        is_expired = True
+
+    stale_after = _as_int_lenient(record.get("stale_after"))
+    if (
+        stale_after is not None
+        and stale_after >= 0
+        and created_at is not None
+        and (ref - created_at).total_seconds() >= stale_after
+    ):
+        reasons.append("stale_after_elapsed")
+
+    has_ttl = "ttl" in record
+    has_expires = "expires_at" in record and record.get("expires_at") is not None
+    ttl_days = _as_int_lenient(record.get("ttl_days"))
+    if (
+        not has_ttl
+        and not has_expires
+        and ttl_days is not None
+        and created_at is not None
+    ):
+        age_days = (ref - created_at).days
+        if age_days > ttl_days:
+            reasons.append("legacy_ttl_days")
+
+    is_stale = bool(reasons)
+    return MemoryFreshness(
+        is_fresh=not is_stale,
+        is_stale=is_stale,
+        is_expired=is_expired,
+        reasons=tuple(reasons),
+    )
 
 
 def _parse_datetime_strict(value: Any, field: str) -> datetime:

--- a/tools/surrealdb/memory_read.py
+++ b/tools/surrealdb/memory_read.py
@@ -23,6 +23,7 @@ from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping
 
 from core.utils.clock import utcnow as cdb_utcnow
+from tools.surrealdb.memory_contract import classify_memory_freshness
 
 SCHEMA_VERSION = "memory-read/v1"
 
@@ -62,7 +63,11 @@ def _parse_datetime(raw: Any) -> datetime | None:
     if raw is None:
         return None
     if isinstance(raw, datetime):
-        return raw.astimezone(timezone.utc) if raw.tzinfo else raw.replace(tzinfo=timezone.utc)
+        return (
+            raw.astimezone(timezone.utc)
+            if raw.tzinfo
+            else raw.replace(tzinfo=timezone.utc)
+        )
     if not isinstance(raw, str):
         return None
     text = raw.strip()
@@ -74,7 +79,11 @@ def _parse_datetime(raw: Any) -> datetime | None:
         parsed = datetime.fromisoformat(text)
     except ValueError:
         return None
-    return parsed.astimezone(timezone.utc) if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    return (
+        parsed.astimezone(timezone.utc)
+        if parsed.tzinfo
+        else parsed.replace(tzinfo=timezone.utc)
+    )
 
 
 def _as_list(value: Any) -> list[Any]:
@@ -108,7 +117,9 @@ def _as_int(value: Any) -> int | None:
 def _compute_trust(memory: Mapping[str, Any]) -> str:
     """Classify memory trust level from record fields."""
     stale = bool(memory.get("stale", False))
-    superseded = bool(memory.get("superseded", False)) or bool(memory.get("superseded_by"))
+    superseded = bool(memory.get("superseded", False)) or bool(
+        memory.get("superseded_by")
+    )
     evidence_backed = bool(memory.get("evidence_backed", False)) or bool(
         _as_list(memory.get("evidence_refs"))
     )
@@ -127,19 +138,14 @@ def _compute_trust(memory: Mapping[str, Any]) -> str:
     return "weak"
 
 
-def _is_stale_by_ttl(memory: Mapping[str, Any]) -> bool:
-    """Return True if TTL has elapsed."""
-    ttl_days = _as_int(memory.get("ttl_days"))
-    if ttl_days is None:
-        return False
-    created_at: datetime | None = memory.get("_created_at_dt")
-    if created_at is None:
-        return False
-    age_days = (cdb_utcnow().replace(tzinfo=timezone.utc) - created_at).days
-    return age_days > ttl_days
+def _resolve_now(now: datetime | None) -> datetime:
+    effective = now if now is not None else cdb_utcnow()
+    if effective.tzinfo is None:
+        return effective.replace(tzinfo=timezone.utc)
+    return effective.astimezone(timezone.utc)
 
 
-def _normalize_memory(raw: Mapping[str, Any]) -> dict[str, Any]:
+def _normalize_memory(raw: Mapping[str, Any], *, now: datetime) -> dict[str, Any]:
     memory_id = _as_str(raw.get("memory_id"))
     if not memory_id:
         raise MemoryReadError("memory record missing memory_id")
@@ -149,7 +155,9 @@ def _normalize_memory(raw: Mapping[str, Any]) -> dict[str, Any]:
     scope = _as_str(raw.get("scope")) or ""
     agent = _as_str(raw.get("agent")) or ""
     superseded_by = _as_str(raw.get("superseded_by"))
-    ttl_days = _as_int(raw.get("ttl_days"))
+    ttl = _as_int(raw.get("ttl"))
+    expires_at = _parse_datetime(raw.get("expires_at"))
+    stale_after = _as_int(raw.get("stale_after"))
 
     topics: list[str] = []
     if _as_str(raw.get("topic")):
@@ -176,7 +184,6 @@ def _normalize_memory(raw: Mapping[str, Any]) -> dict[str, Any]:
         "evidence_refs": sorted(set(evidence_refs)),
         "source_refs": sorted(set(source_refs)),
         "superseded_by": superseded_by,
-        "ttl_days": ttl_days,
         "stale": stale_flag,
         "superseded": bool(superseded_by),
         "evidence_backed": bool(evidence_refs),
@@ -184,9 +191,23 @@ def _normalize_memory(raw: Mapping[str, Any]) -> dict[str, Any]:
         "created_at": created_at.isoformat() if created_at else None,
         "_created_at_dt": created_at,
     }
-    # TTL-based stale detection
-    if not stale_flag and _is_stale_by_ttl(entry):
+    if ttl is not None:
+        entry["ttl"] = ttl
+    if expires_at is not None:
+        entry["expires_at"] = expires_at.isoformat()
+    if stale_after is not None:
+        entry["stale_after"] = stale_after
+    if _as_int(raw.get("ttl_days")) is not None:
+        entry["ttl_days"] = _as_int(raw.get("ttl_days"))
+
+    freshness = classify_memory_freshness(
+        {**raw, **entry, "_created_at_dt": created_at}, now=now
+    )
+    if freshness.is_stale:
         entry["stale"] = True
+    entry["expired"] = freshness.is_expired
+    if freshness.reasons:
+        entry["freshness_reasons"] = list(freshness.reasons)
 
     entry["trust_level"] = _compute_trust(entry)
     return entry
@@ -218,7 +239,7 @@ def _validate_request(req: MemoryReadRequest) -> None:
         raise MemoryReadError(f"{req.mode} requires {required_field}")
 
 
-def _match(memory: Mapping[str, Any], req: MemoryReadRequest) -> bool:
+def _match(memory: Mapping[str, Any], req: MemoryReadRequest, *, now: datetime) -> bool:
     if req.mode == "by_scope":
         scope = (req.scope or "").strip()
         return scope == str(memory.get("scope", "")).strip()
@@ -237,22 +258,34 @@ def _match(memory: Mapping[str, Any], req: MemoryReadRequest) -> bool:
         dt: datetime | None = memory.get("_created_at_dt")
         if dt is None:
             return False
-        age_days = (cdb_utcnow().replace(tzinfo=timezone.utc) - dt).days
+        age_days = (now - dt).days
         return age_days <= req.freshness_days
     if req.mode == "by_memory_type":
-        return str(memory.get("memory_type", "")).strip().lower() == (req.memory_type or "").strip().lower()
+        return (
+            str(memory.get("memory_type", "")).strip().lower()
+            == (req.memory_type or "").strip().lower()
+        )
     return False
 
 
 def read_memory_v1(
     memory_records: Iterable[Mapping[str, Any]],
     request: MemoryReadRequest,
+    *,
+    now: datetime | None = None,
 ) -> dict[str, Any]:
     """Read scoped agent memory over in-memory records.
 
     Deterministic and side-effect-free. No writes.
+
+    Args:
+        memory_records: In-memory agent_memory rows.
+        request: Query mode and filters.
+        now: Optional reference instant for TTL/freshness (UTC). Defaults to
+            ``cdb_utcnow()`` when omitted.
     """
     _validate_request(request)
+    ref_now = _resolve_now(now)
 
     warnings: list[str] = []
 
@@ -260,10 +293,10 @@ def read_memory_v1(
     for raw in memory_records:
         if not isinstance(raw, Mapping):
             continue
-        normalized.append(_normalize_memory(raw))
+        normalized.append(_normalize_memory(raw, now=ref_now))
 
     normalized_sorted = sorted(normalized, key=_memory_sort_key)
-    matched = [m for m in normalized_sorted if _match(m, request)]
+    matched = [m for m in normalized_sorted if _match(m, request, now=ref_now)]
 
     if not matched:
         warnings.append("no_memory_matched")
@@ -309,7 +342,9 @@ def read_memory_v1(
     }
 
     # Strip internal dt field before returning
-    clean_matched = [{k: v for k, v in m.items() if k != "_created_at_dt"} for m in matched]
+    clean_matched = [
+        {k: v for k, v in m.items() if k != "_created_at_dt"} for m in matched
+    ]
 
     approval_semantics = {
         "read_only": True,


### PR DESCRIPTION
## Summary
- Add `classify_memory_freshness()` and `MemoryFreshness` to `memory_contract.py` (canonical ttl seconds, expires_at, stale_after, legacy ttl_days shim)
- Fix `memory_read.py` to use contract helper with injectable `now`; mark stale/expired without filtering
- Fix MCP `_normalize_memory_row` to stop copying `ttl` to `ttl_days` 1:1
- Add 15 unit tests in `test_memory_freshness.py`; update characterization tests
- Audit doc section 17 addendum + session log

## Scope boundaries
- In-memory contract/reader proof only — no DB, no write, no runtime
- LR remains NO-GO

Refs #2606