### PR TITLE
fix(surrealdb): allow optional agent memory fields

### DIFF
--- a/docs/surrealdb/memory-reality-slice1-audit.md
+++ b/docs/surrealdb/memory-reality-slice1-audit.md
@@ -407,7 +407,7 @@ Canon names enforced: `created_by` (NOT `agent_id`), `source_refs` (NOT `source_
 
 ## 18. Slice 4 addendum — DB-backed memory read proof (#2606)
 
-**Delivered (PR pending):** read-only proof helper, contract-compliant fixtures, opt-in local smoke.
+**Delivered:** read-only proof helper, contract-compliant fixtures, opt-in local smoke.
 
 ### 18.1 Proof helper
 
@@ -441,13 +441,31 @@ pytest -v -m local_only tests/local/surrealdb/test_memory_db_read_proof.py
 
 Proven behaviors: DB read → `source=surrealdb-local` (helper + MCP), contract validation pass, UUIDv5 `memory_id` match, freshness fresh vs expired, forged caller `source` ignored on MCP path.
 
-### 18.4 No-changes list (Slice 4)
+### 18.4 #2691 optional-field correction
 
-- No memory write feature, no MCP write, no schema/docker changes
+The local-only DB smoke initially exposed a schemafull SurrealDB mismatch:
+missing optional `agent_memory.stale_after` values were treated as `NONE` and
+rejected by `TYPE int`. Runtime verification then exposed the same optional-field
+class for `superseded_by` (`NONE` rejected by `TYPE string`).
+
+Correction:
+
+- `stale_after` is `option<int>` in `context_intelligence_v0.surql`.
+- `superseded_by` is `option<string>` in `context_intelligence_v0.surql`.
+- `validate_memory_record()` accepts explicit `None` for both optional fields.
+- Tests cover missing and `None` values, plus schema declarations.
+
+Post-fix local-only smoke result: `CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE=1 pytest
+tests/local/surrealdb/test_memory_db_read_proof.py -q` passed (`1 passed, 1
+skipped`) against `surrealdb-local`.
+
+### 18.5 No-changes list (Slice 4)
+
+- No memory write feature, no MCP write, no Docker/runtime-stack changes
 - Wave-14 pre-contract fixture unchanged
 - LR remains NO-GO
 
-### 18.5 Remaining gaps after Slice 4
+### 18.6 Remaining gaps after Slice 4
 
 | Gap | Follow-up |
 | --- | --- |

--- a/infrastructure/surrealdb/context_intelligence_v0.surql
+++ b/infrastructure/surrealdb/context_intelligence_v0.surql
@@ -261,8 +261,8 @@ DEFINE FIELD evidence_refs ON TABLE agent_memory TYPE array;
 DEFINE FIELD confidence ON TABLE agent_memory TYPE float;
 DEFINE FIELD ttl ON TABLE agent_memory TYPE int;
 DEFINE FIELD expires_at ON TABLE agent_memory TYPE datetime;
-DEFINE FIELD stale_after ON TABLE agent_memory TYPE int;
-DEFINE FIELD superseded_by ON TABLE agent_memory TYPE string;
+DEFINE FIELD stale_after ON TABLE agent_memory TYPE option<int>;
+DEFINE FIELD superseded_by ON TABLE agent_memory TYPE option<string>;
 DEFINE FIELD created_by ON TABLE agent_memory TYPE string;
 DEFINE FIELD comment ON TABLE agent_memory TYPE string;
 DEFINE FIELD created_at ON TABLE agent_memory TYPE datetime VALUE $value OR time::now(); -- REQUIRED(v0-draft)

--- a/knowledge/logs/sessions/2026-05-29-2691-stale-after-db-memory-proof.md
+++ b/knowledge/logs/sessions/2026-05-29-2691-stale-after-db-memory-proof.md
@@ -1,0 +1,124 @@
+# 2026-05-29 — #2691 optional agent_memory fields DB proof
+
+## Scope
+
+Fix #2691 for #2606 local-only DB Memory Read Smoke after #2687/#2690 resolved
+the missing local query config blocker.
+
+Guardrails: local `surrealdb-local` only, no Memory-Write feature, no MCP write,
+no productive DB write, no BLUE/RED mutation, no Trading-/Live-/LR change.
+LR remains `NO-GO`.
+
+## Brain Evidence
+
+brain_source: repo-only
+brain_status: partial
+
+tools_or_queries:
+- `ReadFile` for bootloader/read-order files and #2691 files.
+- `gh issue view 2691/2687/2689/2606`, `gh pr view 2690/2688/2686`,
+  `gh pr list --state open`.
+- `git fetch origin main`, `git status --short`, `git branch --show-current`,
+  `git rev-parse --short HEAD`, `git rev-parse --short origin/main`.
+- Runtime debug logs in `debug-899172.log` during reproduction and verification.
+- `make context-query-config-init`, `make context-doctor`, `make context-env-check`,
+  `make context-up`, `make context-status`, `make context-schema-check`.
+- `pytest tests/local/surrealdb/test_memory_db_read_proof.py -q` with and
+  without `CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE=1`.
+
+records_or_results:
+- #2691: open at start.
+- #2606: open at start.
+- #2687: closed.
+- #2689: open and out of scope.
+- PR #2686/#2688/#2690: merged.
+- No open PRs at start.
+- `HEAD` and `origin/main`: `8500417d`.
+- Post-fix smoke: `1 passed, 1 skipped` against `surrealdb-local`.
+
+repo_crosscheck:
+- `tools/surrealdb/memory_contract.py`
+- `tools/surrealdb/memory_db_read_proof.py`
+- `tests/local/surrealdb/test_memory_db_read_proof.py`
+- `tests/local/surrealdb/memory_db_proof_helpers.py`
+- `tests/fixtures/surrealdb/memory_db_proof/agent_memories.jsonl`
+- `tests/fixtures/surrealdb/memory_db_proof/evidence_refs.jsonl`
+- `infrastructure/surrealdb/context_intelligence_v0.surql`
+- `docs/surrealdb/memory-reality-slice1-audit.md`
+
+impact_on_plan:
+- The fix stayed in the optional `agent_memory` schema/contract surface.
+- No fixture fake-freshness or write-path workaround was added.
+
+limitations:
+- MCP resources were not used; DB-backed claim is limited to the explicit
+  local smoke result.
+- The local schema apply target is not idempotent on an already-seeded volume;
+  local field updates were applied with targeted `DEFINE FIELD OVERWRITE`.
+
+## Runtime evidence
+
+Pre-fix reproduction:
+
+- Smoke command: `CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE=1 pytest tests/local/surrealdb/test_memory_db_read_proof.py -q`.
+- Result: `1 skipped, 1 error`.
+- Importer evidence: `adapter=surrealdb-local`, `real_surrealdb_adapter_available=true`,
+  `apply_executed=true`, `counts.applied=2`, `counts.failed=2`.
+- Error: `stale_after`: `Expected int but found NONE`.
+
+Debug evidence:
+
+- `agent_memory` payload logs showed `payload_has_stale_after=false`,
+  `surql_contains_stale_after=false`, `surql_contains_null=false`.
+- After fixing `stale_after`, the next optional schemafull field surfaced:
+  `superseded_by`: `Expected string but found NONE`.
+- Follow-up debug logs showed `payload_has_superseded_by=false`,
+  `surql_contains_superseded_by=false`, `surql_contains_null=false`.
+
+Conclusion:
+
+- The bug was not caused by fixture values, helper injection, or JSON `null`.
+- SurrealDB schemafull validation treats omitted optional fields as `NONE`;
+  optional `agent_memory` fields must use `option<T>`.
+
+## Fix
+
+- `agent_memory.stale_after`: `TYPE int` -> `TYPE option<int>`.
+- `agent_memory.superseded_by`: `TYPE string` -> `TYPE option<string>`.
+- `validate_memory_record()` accepts explicit `None` for both optional fields.
+- Unit coverage added for missing/`None` optional values and schema declarations.
+
+No memory write API, MCP write path, production DB write, BLUE/RED mutation, or
+LR status change was introduced.
+
+## Validation
+
+Passed:
+
+- `pytest tests/unit/surrealdb/test_memory_db_read_proof.py -q`
+- `pytest tests/unit/surrealdb/test_memory_contract.py tests/unit/surrealdb/test_memory_freshness.py tests/unit/surrealdb/test_memory_read_characterization.py tests/unit/surrealdb/test_wave14_context_record_schemas.py -q`
+- `pytest tests/local/surrealdb/test_memory_db_read_proof.py -q` without env gate:
+  `1 passed, 1 skipped`
+- `CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE=1 pytest tests/local/surrealdb/test_memory_db_read_proof.py -q`:
+  `1 passed, 1 skipped`, source path exercised via `surrealdb-local`
+- `ruff check tools/surrealdb/memory_contract.py tests/unit/surrealdb/test_memory_contract.py tests/unit/surrealdb/test_wave14_context_record_schemas.py tests/unit/surrealdb/test_memory_db_read_proof.py tests/local/surrealdb/test_memory_db_read_proof.py`
+- `black --check tools/surrealdb/memory_contract.py tests/unit/surrealdb/test_memory_contract.py tests/unit/surrealdb/test_wave14_context_record_schemas.py tests/unit/surrealdb/test_memory_db_read_proof.py tests/local/surrealdb/test_memory_db_read_proof.py`
+
+Known note:
+
+- The successful real smoke emitted an existing `datetime.utcnow()` deprecation
+  warning from `core/utils/clock.py`; it did not affect #2691.
+
+## Local runtime and cleanup
+
+- `make context-up` started only `cdb_surrealdb` on `127.0.0.1:8010`.
+- `make context-status` showed `cdb_surrealdb` running and using
+  `cdb_database_surrealdb_data`.
+- Failed run-scoped partial `evidence_ref` rows were removed with the test-local
+  cleanup helper.
+- Debug instrumentation was removed after post-fix verification, and
+  `debug-899172.log` was deleted.
+
+## Status
+
+DONE_NO_PR at log-write time; PR and issue lifecycle actions pending.

--- a/tests/unit/surrealdb/test_memory_contract.py
+++ b/tests/unit/surrealdb/test_memory_contract.py
@@ -458,6 +458,21 @@ def test_validate_memory_record_stale_after_zero_ok() -> None:
 
 
 @pytest.mark.unit
+def test_validate_memory_record_stale_after_missing_optional_ok() -> None:
+    rec = _valid_record()
+    rec.pop("stale_after", None)
+    out = validate_memory_record(rec)
+    assert "stale_after" not in out
+
+
+@pytest.mark.unit
+def test_validate_memory_record_stale_after_none_optional_ok() -> None:
+    rec = _valid_record(stale_after=None)
+    out = validate_memory_record(rec)
+    assert out["stale_after"] is None
+
+
+@pytest.mark.unit
 def test_validate_memory_record_stale_after_negative_rejected() -> None:
     rec = _valid_record(stale_after=-1)
     with pytest.raises(MemoryContractError, match="stale_after"):
@@ -474,6 +489,21 @@ def test_validate_memory_record_superseded_by_valid() -> None:
     rec = _valid_record(superseded_by="mem-prev-id-001")
     out = validate_memory_record(rec)
     assert out["superseded_by"] == "mem-prev-id-001"
+
+
+@pytest.mark.unit
+def test_validate_memory_record_superseded_by_missing_optional_ok() -> None:
+    rec = _valid_record()
+    rec.pop("superseded_by", None)
+    out = validate_memory_record(rec)
+    assert "superseded_by" not in out
+
+
+@pytest.mark.unit
+def test_validate_memory_record_superseded_by_none_optional_ok() -> None:
+    rec = _valid_record(superseded_by=None)
+    out = validate_memory_record(rec)
+    assert out["superseded_by"] is None
 
 
 @pytest.mark.unit

--- a/tests/unit/surrealdb/test_wave14_context_record_schemas.py
+++ b/tests/unit/surrealdb/test_wave14_context_record_schemas.py
@@ -141,6 +141,21 @@ def test_memory_normalization_maps_schema_aliases() -> None:
 
 
 @pytest.mark.unit
+def test_agent_memory_stale_after_schema_is_optional(surql_text: str) -> None:
+    assert (
+        "DEFINE FIELD stale_after ON TABLE agent_memory TYPE option<int>;" in surql_text
+    )
+
+
+@pytest.mark.unit
+def test_agent_memory_superseded_by_schema_is_optional(surql_text: str) -> None:
+    assert (
+        "DEFINE FIELD superseded_by ON TABLE agent_memory TYPE option<string>;"
+        in surql_text
+    )
+
+
+@pytest.mark.unit
 def test_memory_normalization_uses_scope_when_created_by_missing() -> None:
     row = {
         "memory_id": "mem-scope-fallback",

--- a/tools/surrealdb/memory_contract.py
+++ b/tools/surrealdb/memory_contract.py
@@ -377,8 +377,8 @@ def validate_memory_record(raw: Any, *, strict: bool = True) -> dict[str, Any]:
     - confidence: numeric value in [0.0, 1.0].
     - ttl: integer >= 0 (seconds).
     - If ttl > 0: expires_at required, and must be strictly after created_at.
-    - Optional superseded_by: non-empty string if present.
-    - Optional stale_after: integer >= 0 if present.
+    - Optional superseded_by: non-empty string if present and not null.
+    - Optional stale_after: integer >= 0 if present and not null.
     - Optional comment: any string.
     - If memory_id is present: must equal the computed UUIDv5.
     - If memory_id is absent: validator computes and attaches it.
@@ -500,7 +500,7 @@ def validate_memory_record(raw: Any, *, strict: bool = True) -> dict[str, Any]:
     # superseded_by (optional, non-empty if present)
     if "superseded_by" in raw:
         sv = raw["superseded_by"]
-        if not isinstance(sv, str) or not sv.strip():
+        if sv is not None and (not isinstance(sv, str) or not sv.strip()):
             raise MemoryContractError(
                 "superseded_by must be a non-empty string if present"
             )
@@ -508,14 +508,15 @@ def validate_memory_record(raw: Any, *, strict: bool = True) -> dict[str, Any]:
     # stale_after (optional, int >= 0)
     if "stale_after" in raw:
         sa = raw["stale_after"]
-        try:
-            sa_int = int(sa)
-        except (TypeError, ValueError) as exc:
-            raise MemoryContractError(
-                f"stale_after must be an integer >= 0; got {sa!r}"
-            ) from exc
-        if sa_int < 0:
-            raise MemoryContractError(f"stale_after must be >= 0; got {sa_int}")
+        if sa is not None:
+            try:
+                sa_int = int(sa)
+            except (TypeError, ValueError) as exc:
+                raise MemoryContractError(
+                    f"stale_after must be an integer >= 0; got {sa!r}"
+                ) from exc
+            if sa_int < 0:
+                raise MemoryContractError(f"stale_after must be >= 0; got {sa_int}")
 
     # Compute canonical memory_id
     computed_id = generate_memory_id(


### PR DESCRIPTION
## Summary
- Makes optional `agent_memory` schema fields nullable for schemafull SurrealDB imports (`stale_after`, `superseded_by`).
- Aligns the Python memory contract with missing/`None` optional fields and adds regression coverage.
- Records #2691 runtime evidence and the successful local-only DB memory smoke for #2606.

## Test plan
- `pytest tests/unit/surrealdb/test_memory_db_read_proof.py -q`
- `pytest tests/unit/surrealdb/test_memory_contract.py tests/unit/surrealdb/test_memory_freshness.py tests/unit/surrealdb/test_memory_read_characterization.py tests/unit/surrealdb/test_wave14_context_record_schemas.py -q`
- `pytest tests/local/surrealdb/test_memory_db_read_proof.py -q`
- `CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE=1 pytest tests/local/surrealdb/test_memory_db_read_proof.py -q`
- `ruff check tools/surrealdb/memory_contract.py tests/unit/surrealdb/test_memory_contract.py tests/unit/surrealdb/test_wave14_context_record_schemas.py tests/unit/surrealdb/test_memory_db_read_proof.py tests/local/surrealdb/test_memory_db_read_proof.py`
- `black --check tools/surrealdb/memory_contract.py tests/unit/surrealdb/test_memory_contract.py tests/unit/surrealdb/test_wave14_context_record_schemas.py tests/unit/surrealdb/test_memory_db_read_proof.py tests/local/surrealdb/test_memory_db_read_proof.py`

Refs #2691. Refs #2606.