### PR TITLE
test(surrealdb): add #2606 slice 6 local-only memory write smoke harness

### DIFF
--- a/docs/surrealdb/memory-reality-slice1-audit.md
+++ b/docs/surrealdb/memory-reality-slice1-audit.md
@@ -524,6 +524,52 @@ Proven behaviors: block without GO, block on scope mismatch, block on contract v
 
 ---
 
+## 20. Slice 6 addendum — local-only gated write smoke (#2694)
+
+**Delivered:** gated localhost UPSERT smoke executor, `local_only` integration test, unit tests with mock SQL. No MCP write. No `PERSIST_ALLOWED` flip.
+
+### 20.1 Write smoke module
+
+| Artifact | Role |
+| --- | --- |
+| `tools/surrealdb/memory_db_write_smoke.py` | `execute_gated_local_memory_write_v1()`, env + gate fail-closed |
+| `docs/surrealdb/memory-write-gate-v1.md` §8 | Operator-GO + env contract |
+
+Properties:
+
+- Requires `CDB_RUN_REAL_SURREALDB_MEMORY_WRITE=1` **and** `gate_status == approved_dry_run`
+- `persist_allowed` remains `false` in gate envelope; runtime permission is env + operator GO only
+- Writes: one `evidence_ref` + one `agent_memory` via `MemoryDbProofSqlClient.upsert_create()` (localhost)
+- Scope prefix: `memory_db_write_smoke:<run_tag>` (distinct from Slice 4 read proof scope)
+- Audit envelope: `human_go_token` never serialized; `write_status: written_local_only`
+
+### 20.2 Tests
+
+| File | Marker | CI |
+| --- | --- | --- |
+| `tests/unit/surrealdb/test_memory_db_write_smoke.py` | `unit` | yes (mock SQL) |
+| `tests/local/surrealdb/test_memory_db_write_smoke.py` | `local_only` | no (opt-in DB) |
+
+Proven (unit): gate blocked → zero `upsert_create`; env missing → no write; gate pass + env → two UPSERTs.
+
+Proven (local, opt-in): gated UPSERT → `prove_agent_memory_db_read_v1` scope match → `finally` DELETE.
+
+### 20.3 No-changes list (Slice 6)
+
+- `memory_write_gate.py` module constant unchanged (`PERSIST_ALLOWED = False`)
+- No MCP write tools, no BLUE/RED, no trading/risk/execution path
+- LR remains NO-GO
+
+### 20.4 Remaining gaps after Slice 6
+
+| Gap | Follow-up |
+| --- | --- |
+| Productive memory write / importer default path | Future slice after sustained smoke evidence |
+| MCP write surface | Explicit design slice |
+| Production `audit_observation` persistence | After write path ratified |
+
+---
+
 ## Provenance
 
 | Source | Role |

--- a/docs/surrealdb/memory-write-gate-v1.md
+++ b/docs/surrealdb/memory-write-gate-v1.md
@@ -110,6 +110,50 @@ ruff check tools/surrealdb/memory_write_gate.py tests/unit/surrealdb/test_memory
 
 ---
 
+## 8. Slice 6 — local-only write smoke (execution)
+
+**Issue**: [#2694](https://github.com/jannekbuengener/Claire_de_Binare/issues/2694)  
+**Status**: Gated executor + `local_only` test (no CI DB). LR remains NO-GO.
+
+### Preconditions (all required)
+
+| Layer | Requirement |
+| --- | --- |
+| Operator prompt | Explicit Operator-GO for Slice 6 local write smoke |
+| Gate | `evaluate_memory_write_gate()` → `approved_dry_run` |
+| Env | `CDB_RUN_REAL_SURREALDB_MEMORY_WRITE=1` (orthogonal to read flag `CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE`) |
+| Module constant | `PERSIST_ALLOWED` stays `False` in `memory_write_gate.py` |
+| Runtime | `MemoryDbProofSqlClient` → `127.0.0.1:8010` only |
+| Token env | `CDB_MEMORY_WRITE_HUMAN_GO_TOKEN` (`GO-YYYY-MM-DD[-suffix]`) — never log raw value |
+
+### Execution surface
+
+| Artifact | Path |
+| --- | --- |
+| Write smoke executor | `tools/surrealdb/memory_db_write_smoke.py` |
+| Local test | `tests/local/surrealdb/test_memory_db_write_smoke.py` |
+| Unit tests (mock SQL) | `tests/unit/surrealdb/test_memory_db_write_smoke.py` |
+| Helpers | `tests/local/surrealdb/memory_db_proof_helpers.py` (`memory_db_write_smoke:<tag>` scope) |
+
+Flow: gate pass → env check → UPSERT `evidence_ref` then `agent_memory` → read-back via `prove_agent_memory_db_read_v1` → `finally` DELETE run-scoped rows.
+
+### Validation
+
+```bash
+pytest tests/unit/surrealdb/test_memory_db_write_smoke.py -q
+ruff check tools/surrealdb/memory_db_write_smoke.py tests/local/surrealdb/test_memory_db_write_smoke.py tests/unit/surrealdb/test_memory_db_write_smoke.py
+```
+
+Local-only (after Operator-GO):
+
+```powershell
+$env:CDB_RUN_REAL_SURREALDB_MEMORY_WRITE = "1"
+$env:CDB_MEMORY_WRITE_HUMAN_GO_TOKEN = "GO-2026-05-29-slice6"
+pytest tests/local/surrealdb/test_memory_db_write_smoke.py -q
+```
+
+---
+
 ## Provenance
 
 | Source | Role |

--- a/tests/local/surrealdb/memory_db_proof_helpers.py
+++ b/tests/local/surrealdb/memory_db_proof_helpers.py
@@ -31,7 +31,10 @@ LOCAL_DB = "cdb_context_intel"
 LOCAL_ALLOWED_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 
 _BASE_SCOPE = "memory_db_proof"
+_BASE_WRITE_SCOPE = "memory_db_write_smoke"
 _BASE_EVIDENCE_IDS = ("ev-mdbproof-base-001", "ev-mdbproof-base-002")
+_BASE_WRITE_EVIDENCE_ID = "ev-mdbwrite-base-001"
+_JSONL_STRIP_FIELDS = frozenset({"schema_version", "run_id", "sensitivity"})
 
 _ID_REFERENCE_FIELDS = frozenset(
     {
@@ -333,6 +336,25 @@ class MemoryDbProofSqlClient:
         literal = _surql_string(raw_id)
         self.execute(f"DELETE {table} WHERE {id_field} = {literal};")
 
+    @staticmethod
+    def _surql_record_id(table: str, record_id: str) -> str:
+        escaped = record_id.replace("\u27e9", "\\u27e9")
+        return f"{table}:\u27e8{escaped}\u27e9"
+
+    def upsert_create(self, table: str, record_id: str, payload: dict[str, Any]) -> None:
+        """UPSERT one record on local SurrealDB (Slice 6 write smoke only)."""
+        from tools.surrealdb.context_importer import (
+            _payload_to_surql_content,
+            _remap_record_refs_for_db_payload,
+        )
+
+        rid = self._surql_record_id(table, record_id)
+        db_payload = _remap_record_refs_for_db_payload(table, dict(payload))
+        for field in _JSONL_STRIP_FIELDS:
+            db_payload.pop(field, None)
+        payload_json = _payload_to_surql_content(db_payload)
+        self.execute(f"UPSERT {rid} CONTENT {payload_json};")
+
 
 def assert_memory_proof_records_absent(
     client: MemoryDbProofSqlClient, plan: MemoryDbProofRecordPlan
@@ -362,3 +384,142 @@ def cleanup_memory_proof_records(
             if client.record_exists(table, raw_id, id_field=id_field):
                 client.delete_record(table, raw_id, id_field=id_field)
     assert_memory_proof_records_absent(client, plan)
+
+
+@dataclass(frozen=True)
+class MemoryWriteSmokeRecordPlan:
+    """Run-scoped IDs for Slice 6 local-only write smoke (single memory row)."""
+
+    run_id: str
+    run_tag: str
+    scope: str
+    evidence_id: str
+    memory_id: str
+
+    @property
+    def records_by_table(self) -> tuple[tuple[str, str], ...]:
+        return (
+            ("evidence_ref", self.evidence_id),
+            ("agent_memory", self.memory_id),
+        )
+
+
+def resolve_memory_write_smoke_run_id() -> str:
+    override = os.environ.get("CDB_MEMORY_WRITE_SMOKE_RUN_ID", "").strip()
+    if override:
+        return override
+    return f"{_timestamp_run_id()}-{os.getpid()}"
+
+
+def memory_write_smoke_tmp_root(run_id: str) -> Path:
+    return _REPO_ROOT / ".tmp" / "memory-db-write-smoke" / run_id
+
+
+def build_memory_write_smoke_plan(run_id: str) -> MemoryWriteSmokeRecordPlan:
+    tag = memory_proof_run_tag(run_id)
+    scope = f"{_BASE_WRITE_SCOPE}:{tag}"
+    stem, suffix = _BASE_WRITE_EVIDENCE_ID.rsplit("-", 1)
+    evidence_id = f"{stem}-{tag}-{suffix}"
+    memory_id = _compute_single_run_scoped_memory_id(
+        scope=scope,
+        evidence_id=evidence_id,
+    )
+    return MemoryWriteSmokeRecordPlan(
+        run_id=run_id,
+        run_tag=tag,
+        scope=scope,
+        evidence_id=evidence_id,
+        memory_id=memory_id,
+    )
+
+
+def _compute_single_run_scoped_memory_id(
+    *,
+    scope: str,
+    evidence_id: str,
+) -> str:
+    fresh_path = _FIXTURE_DIR / "agent_memories.jsonl"
+    for raw_line in fresh_path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip():
+            continue
+        record = json.loads(raw_line)
+        record["scope"] = scope
+        record["namespace"] = scope
+        record["evidence_refs"] = [evidence_id]
+        record["content"] = "Slice 6 local-only gated memory write smoke record."
+        return generate_memory_id(
+            scope=record["scope"],
+            namespace=record["namespace"],
+            memory_type=record["memory_type"],
+            created_by=record["created_by"],
+            content=record["content"],
+            source_refs=record["source_refs"],
+        )
+    raise ValueError("agent_memories.jsonl fixture has no records")
+
+
+def materialize_memory_write_smoke_evidence(
+    *,
+    run_id: str,
+    plan: MemoryWriteSmokeRecordPlan,
+) -> dict[str, Any]:
+    path = _FIXTURE_DIR / "evidence_refs.jsonl"
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip():
+            continue
+        record = json.loads(raw_line)
+        record["run_id"] = run_id
+        record["evidence_id"] = plan.evidence_id
+        record["comment"] = "Slice 6 local-only gated memory write smoke evidence"
+        return record
+    raise ValueError("evidence_refs.jsonl fixture has no records")
+
+
+def materialize_memory_write_smoke_memory_record(
+    *,
+    run_id: str,
+    plan: MemoryWriteSmokeRecordPlan,
+) -> dict[str, Any]:
+    fresh_path = _FIXTURE_DIR / "agent_memories.jsonl"
+    for raw_line in fresh_path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip():
+            continue
+        record = json.loads(raw_line)
+        record["run_id"] = run_id
+        record["scope"] = plan.scope
+        record["namespace"] = plan.scope
+        record["evidence_refs"] = [plan.evidence_id]
+        record["memory_id"] = plan.memory_id
+        record["content"] = "Slice 6 local-only gated memory write smoke record."
+        return record
+    raise ValueError("agent_memories.jsonl fixture has no records")
+
+
+def assert_memory_write_smoke_records_absent(
+    client: MemoryDbProofSqlClient, plan: MemoryWriteSmokeRecordPlan
+) -> None:
+    id_fields = {"evidence_ref": "evidence_id", "agent_memory": "memory_id"}
+    present = [
+        f"{table}:{raw_id}"
+        for table, raw_id in plan.records_by_table
+        if client.record_exists(table, raw_id, id_field=id_fields[table])
+    ]
+    if present:
+        raise AssertionError(
+            "run-scoped memory write smoke records already exist before write: "
+            + ", ".join(present)
+        )
+
+
+def cleanup_memory_write_smoke_records(
+    client: MemoryDbProofSqlClient, plan: MemoryWriteSmokeRecordPlan
+) -> None:
+    delete_order = (
+        ("agent_memory", (plan.memory_id,), "memory_id"),
+        ("evidence_ref", (plan.evidence_id,), "evidence_id"),
+    )
+    for table, ids, id_field in delete_order:
+        for raw_id in ids:
+            if client.record_exists(table, raw_id, id_field=id_field):
+                client.delete_record(table, raw_id, id_field=id_field)
+    assert_memory_write_smoke_records_absent(client, plan)

--- a/tests/local/surrealdb/test_memory_db_write_smoke.py
+++ b/tests/local/surrealdb/test_memory_db_write_smoke.py
@@ -1,0 +1,238 @@
+"""Opt-in local-only gated memory write smoke — #2606 Slice 6.
+
+Requires:
+- ``CDB_RUN_REAL_SURREALDB_MEMORY_WRITE=1``
+- Operator-supplied ``CDB_MEMORY_WRITE_HUMAN_GO_TOKEN`` (valid GO-* shape)
+- local SurrealDB @ ``127.0.0.1:8010``, secrets, ``context_query.local.yaml``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+import urllib.error
+import urllib.request
+
+import pytest
+
+from tests.local.surrealdb.memory_db_proof_helpers import (
+    MemoryDbProofSqlClient,
+    MemoryWriteSmokeRecordPlan,
+    assert_memory_write_smoke_records_absent,
+    build_memory_write_smoke_plan,
+    cleanup_memory_write_smoke_records,
+    materialize_memory_write_smoke_evidence,
+    materialize_memory_write_smoke_memory_record,
+    memory_write_smoke_tmp_root,
+    resolve_memory_write_smoke_run_id,
+)
+from tools.surrealdb.memory_contract import validate_memory_id_matches_record
+from tools.surrealdb.memory_db_read_proof import prove_agent_memory_db_read_v1
+from tools.surrealdb.memory_db_write_smoke import (
+    WRITE_SMOKE_ENV_VAR,
+    execute_gated_local_memory_write_v1,
+)
+from tools.surrealdb.memory_write_gate import MemoryWriteAuthorization
+from tools.mcp.context_evidence_memory_tools import TOOL_CDB_CONTEXT_MEMORY_GET
+from tools.mcp.surrealdb_adapter_factory import build_adapter_from_params
+
+pytestmark = pytest.mark.local_only
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_QUERY_CONFIG_PATH = (
+    _REPO_ROOT / "infrastructure" / "config" / "surrealdb" / "context_query.local.yaml"
+)
+_LOCAL_SURR_URLS = (
+    "http://127.0.0.1:8010/health",
+    "http://127.0.0.1:8010/version",
+)
+_NOW = datetime(2026, 5, 29, 14, 0, 0, tzinfo=timezone.utc)
+
+
+def _http_status(url: str) -> int | None:
+    try:
+        with urllib.request.urlopen(url, timeout=5) as response:
+            return int(response.status)
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+
+
+def _candidate_secrets_paths() -> list[Path]:
+    candidates: list[Path] = []
+    for env_key in ("CDB_CONTEXT_SECRETS_PATH", "SECRETS_PATH"):
+        raw = os.environ.get(env_key, "").strip()
+        if raw:
+            candidates.append(Path(raw))
+    if os.name == "nt":
+        userprofile = os.environ.get("USERPROFILE", "").strip()
+        if userprofile:
+            candidates.append(Path(userprofile) / "Documents" / ".secrets" / ".cdb")
+    else:
+        candidates.append(Path.home() / "Documents" / ".secrets" / ".cdb")
+    seen: set[Path] = set()
+    ordered: list[Path] = []
+    for path in candidates:
+        if path in seen:
+            continue
+        seen.add(path)
+        ordered.append(path)
+    return ordered
+
+
+def _resolve_secrets_path() -> Path | None:
+    for candidate in _candidate_secrets_paths():
+        try:
+            if candidate.is_dir():
+                return candidate
+        except OSError:
+            continue
+    return None
+
+
+def _require_write_smoke_opt_in() -> Path:
+    if os.environ.get(WRITE_SMOKE_ENV_VAR) != "1":
+        pytest.skip(
+            "real surrealdb-local memory write smoke disabled; "
+            f"set {WRITE_SMOKE_ENV_VAR}=1"
+        )
+    if not _QUERY_CONFIG_PATH.exists():
+        pytest.skip(
+            "missing local query config: "
+            "infrastructure/config/surrealdb/context_query.local.yaml"
+        )
+    secrets_dir = _resolve_secrets_path()
+    if secrets_dir is None:
+        pytest.skip(
+            "missing secrets dir for surrealdb-local auth "
+            "(set CDB_CONTEXT_SECRETS_PATH or SECRETS_PATH)"
+        )
+    if not (secrets_dir / "SURREALDB_ENV").is_file():
+        pytest.skip("missing required secrets file SURREALDB_ENV in secrets dir")
+    for url in _LOCAL_SURR_URLS:
+        status = _http_status(url)
+        if status != 200:
+            pytest.skip(f"local SurrealDB preflight failed for {url} (status={status})")
+    return secrets_dir
+
+
+def _operator_authorization(plan: MemoryWriteSmokeRecordPlan) -> MemoryWriteAuthorization:
+    token = os.environ.get("CDB_MEMORY_WRITE_HUMAN_GO_TOKEN", "").strip()
+    if not token:
+        pytest.skip(
+            "missing operator GO token; set CDB_MEMORY_WRITE_HUMAN_GO_TOKEN "
+            "(GO-YYYY-MM-DD[-suffix])"
+        )
+    return MemoryWriteAuthorization(
+        human_go_token=token,
+        authorized_by=os.environ.get("CDB_MEMORY_WRITE_AUTHORIZED_BY", "operator").strip()
+        or "operator",
+        authorized_at=os.environ.get(
+            "CDB_MEMORY_WRITE_AUTHORIZED_AT", "2026-05-29T14:00:00+00:00"
+        ).strip(),
+        scope=plan.scope,
+        target_issue=os.environ.get("CDB_MEMORY_WRITE_TARGET_ISSUE", "2694").strip()
+        or "2694",
+        evidence_refs=tuple(
+            part.strip()
+            for part in os.environ.get(
+                "CDB_MEMORY_WRITE_EVIDENCE_REFS",
+                "github:issue/2694",
+            ).split(",")
+            if part.strip()
+        )
+        or ("github:issue/2694",),
+        operation="create",
+    )
+
+
+def _assert_no_secret_leak(payload: dict[str, Any], *, secrets_path: Path) -> None:
+    rendered = json.dumps(payload, sort_keys=True, default=str)
+    assert "Authorization" not in rendered
+    assert "Basic " not in rendered
+    assert "SURREAL_PASS" not in rendered
+    assert "SURREAL_USER" not in rendered
+    assert str(secrets_path) not in rendered
+    token = os.environ.get("CDB_MEMORY_WRITE_HUMAN_GO_TOKEN", "")
+    if token:
+        assert token not in rendered
+
+
+def _build_adapter(secrets_path: Path) -> Any:
+    result = build_adapter_from_params(
+        {
+            "adapter_config_path": str(_QUERY_CONFIG_PATH),
+            "secrets_path": str(secrets_path),
+        },
+        TOOL_CDB_CONTEXT_MEMORY_GET,
+    )
+    assert not isinstance(result, dict), result
+    adapter, _config = result
+    return adapter
+
+
+@pytest.fixture
+def memory_write_smoke_context() -> (
+    tuple[MemoryWriteSmokeRecordPlan, Path, MemoryDbProofSqlClient]
+):
+    secrets_path = _require_write_smoke_opt_in()
+    run_id = resolve_memory_write_smoke_run_id()
+    plan = build_memory_write_smoke_plan(run_id)
+    tmp_root = memory_write_smoke_tmp_root(run_id)
+    sql_client = MemoryDbProofSqlClient.from_secrets_dir(secrets_path)
+    assert_memory_write_smoke_records_absent(sql_client, plan)
+    try:
+        yield plan, secrets_path, sql_client
+    finally:
+        cleanup_memory_write_smoke_records(sql_client, plan)
+        if tmp_root.exists():
+            shutil.rmtree(tmp_root, ignore_errors=False)
+
+
+def test_memory_db_write_smoke_skips_without_env_flag() -> None:
+    if os.environ.get(WRITE_SMOKE_ENV_VAR) == "1":
+        pytest.skip("env flag set; covered by gated write smoke test")
+    with pytest.raises(pytest.skip.Exception):
+        _require_write_smoke_opt_in()
+
+
+def test_memory_db_write_smoke_gated_upsert_and_read_back(
+    memory_write_smoke_context: tuple[
+        MemoryWriteSmokeRecordPlan, Path, MemoryDbProofSqlClient
+    ],
+) -> None:
+    plan, secrets_path, sql_client = memory_write_smoke_context
+    record = materialize_memory_write_smoke_memory_record(run_id=plan.run_id, plan=plan)
+    evidence = materialize_memory_write_smoke_evidence(run_id=plan.run_id, plan=plan)
+    auth = _operator_authorization(plan)
+
+    result = execute_gated_local_memory_write_v1(
+        record=record,
+        authorization=auth,
+        sql_client=sql_client,
+        evidence_record=evidence,
+        evidence_id=plan.evidence_id,
+        now=_NOW,
+    )
+    assert result["write_status"] == "written_local_only"
+    assert result["gate_status"] == "approved_dry_run"
+    assert result["persist_allowed"] is False
+    assert result["memory_id"] == plan.memory_id
+    assert result["evidence_id"] == plan.evidence_id
+
+    validate_memory_id_matches_record(record)
+
+    adapter = _build_adapter(secrets_path)
+    proof = prove_agent_memory_db_read_v1(
+        adapter=adapter,
+        scope=plan.scope,
+        limit=10,
+        now=_NOW,
+    )
+    assert proof["source"] == "surrealdb-local"
+    assert plan.memory_id in proof["memory_ids"]
+    _assert_no_secret_leak(result, secrets_path=secrets_path)
+    _assert_no_secret_leak(proof, secrets_path=secrets_path)

--- a/tests/unit/surrealdb/test_memory_db_write_smoke.py
+++ b/tests/unit/surrealdb/test_memory_db_write_smoke.py
@@ -1,0 +1,186 @@
+"""Unit tests for memory_db_write_smoke — #2606 Slice 6.
+
+No DB. Mock SQL client. Gate-blocked paths must not call upsert_create.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.surrealdb.memory_db_write_smoke import (
+    WRITE_SMOKE_ENV_VAR,
+    MemoryWriteSmokeError,
+    execute_gated_local_memory_write_v1,
+    local_write_smoke_enabled,
+    write_smoke_env_enabled,
+)
+from tools.surrealdb.memory_write_gate import MemoryWriteAuthorization
+
+FIXED_NOW = datetime(2026, 5, 29, 14, 0, 0, tzinfo=timezone.utc)
+
+
+def _valid_record(**overrides) -> dict:
+    base: dict = {
+        "scope": "memory_db_write_smoke:abc123",
+        "namespace": "memory_db_write_smoke:abc123",
+        "memory_type": "semantic_memory",
+        "content": "Slice 6 unit test memory record.",
+        "source_refs": ["docs/surrealdb/memory-write-gate-v1.md"],
+        "evidence_refs": ["ev-mdbwrite-base-001"],
+        "confidence": 0.9,
+        "ttl": 86400,
+        "expires_at": "2026-05-30T10:00:00Z",
+        "created_by": "cdb-test-001",
+        "created_at": "2026-05-29T10:00:00Z",
+    }
+    base.update(overrides)
+    from tools.surrealdb.memory_contract import generate_memory_id
+
+    base["memory_id"] = generate_memory_id(
+        scope=base["scope"],
+        namespace=base["namespace"],
+        memory_type=base["memory_type"],
+        created_by=base["created_by"],
+        content=base["content"],
+        source_refs=base["source_refs"],
+    )
+    return base
+
+
+def _valid_auth(**overrides) -> MemoryWriteAuthorization:
+    base = dict(
+        human_go_token="GO-2026-05-29-slice6",
+        authorized_by="jannekbuengener",
+        authorized_at="2026-05-29T14:00:00+00:00",
+        scope="memory_db_write_smoke:abc123",
+        target_issue="2694",
+        evidence_refs=("github:issue/2694",),
+        operation="create",
+    )
+    base.update(overrides)
+    return MemoryWriteAuthorization(**base)
+
+
+def _mock_sql() -> MagicMock:
+    client = MagicMock()
+    client.record_exists.return_value = False
+    return client
+
+
+@pytest.mark.unit
+def test_write_smoke_env_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(WRITE_SMOKE_ENV_VAR, raising=False)
+    assert write_smoke_env_enabled() is False
+
+
+@pytest.mark.unit
+def test_local_write_smoke_enabled_requires_env_and_dry_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(WRITE_SMOKE_ENV_VAR, "1")
+    assert local_write_smoke_enabled(
+        {"gate_status": "approved_dry_run", "persist_allowed": False}
+    )
+    assert not local_write_smoke_enabled(
+        {"gate_status": "blocked_no_human_go", "persist_allowed": False}
+    )
+    monkeypatch.delenv(WRITE_SMOKE_ENV_VAR, raising=False)
+    assert not local_write_smoke_enabled(
+        {"gate_status": "approved_dry_run", "persist_allowed": False}
+    )
+
+
+@pytest.mark.unit
+def test_execute_blocked_without_authorization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(WRITE_SMOKE_ENV_VAR, "1")
+    sql = _mock_sql()
+    with pytest.raises(MemoryWriteSmokeError, match="blocked"):
+        execute_gated_local_memory_write_v1(
+            record=_valid_record(),
+            authorization=None,  # type: ignore[arg-type]
+            sql_client=sql,
+            evidence_record={"evidence_id": "ev-1"},
+            evidence_id="ev-1",
+            now=FIXED_NOW,
+        )
+    sql.upsert_create.assert_not_called()
+
+
+@pytest.mark.unit
+def test_execute_blocked_invalid_go_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(WRITE_SMOKE_ENV_VAR, "1")
+    sql = _mock_sql()
+    auth = _valid_auth(human_go_token="not-a-go-token")
+    with pytest.raises(MemoryWriteSmokeError, match="blocked"):
+        execute_gated_local_memory_write_v1(
+            record=_valid_record(),
+            authorization=auth,
+            sql_client=sql,
+            evidence_record={"evidence_id": "ev-1"},
+            evidence_id="ev-1",
+            now=FIXED_NOW,
+        )
+    sql.upsert_create.assert_not_called()
+
+
+@pytest.mark.unit
+def test_execute_blocked_without_env_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(WRITE_SMOKE_ENV_VAR, raising=False)
+    sql = _mock_sql()
+    record = _valid_record()
+    auth = _valid_auth(scope=record["scope"])
+    with pytest.raises(MemoryWriteSmokeError, match=WRITE_SMOKE_ENV_VAR):
+        execute_gated_local_memory_write_v1(
+            record=record,
+            authorization=auth,
+            sql_client=sql,
+            evidence_record={"evidence_id": "ev-1", "comment": "test"},
+            evidence_id="ev-1",
+            now=FIXED_NOW,
+        )
+    sql.upsert_create.assert_not_called()
+
+
+@pytest.mark.unit
+def test_execute_writes_when_gate_and_env_pass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(WRITE_SMOKE_ENV_VAR, "1")
+    sql = _mock_sql()
+
+    def exists_side_effect(table: str, raw_id: str, *, id_field: str) -> bool:
+        if sql.upsert_create.call_count == 0:
+            return False
+        return True
+
+    sql.record_exists.side_effect = exists_side_effect
+
+    record = _valid_record()
+    auth = _valid_auth(scope=record["scope"])
+    evidence_id = "ev-mdbwrite-unit-001"
+    result = execute_gated_local_memory_write_v1(
+        record=record,
+        authorization=auth,
+        sql_client=sql,
+        evidence_record={
+            "evidence_id": evidence_id,
+            "comment": "unit test evidence",
+        },
+        evidence_id=evidence_id,
+        now=FIXED_NOW,
+    )
+    assert result["write_status"] == "written_local_only"
+    assert sql.upsert_create.call_count == 2
+    calls = [c.args[0] for c in sql.upsert_create.call_args_list]
+    assert calls == ["evidence_ref", "agent_memory"]
+    rendered = str(result)
+    assert auth.human_go_token not in rendered

--- a/tools/surrealdb/memory_db_write_smoke.py
+++ b/tools/surrealdb/memory_db_write_smoke.py
@@ -1,0 +1,172 @@
+"""Local-only gated memory write smoke — #2606 Memory Reality Slice 6.
+
+Executes a minimal SurrealDB write only after Human-GO gate pass and explicit
+env opt-in. No MCP writes. No productive memory path.
+
+Guardrails:
+    - Module-level PERSIST_ALLOWED in memory_write_gate stays False.
+    - Runtime permission requires CDB_RUN_REAL_SURREALDB_MEMORY_WRITE=1.
+    - Gate must return approved_dry_run before any SQL UPSERT.
+    - LR remains NO-GO.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Mapping, Protocol
+
+from core.utils.clock import utcnow as cdb_utcnow
+from tools.surrealdb.memory_write_gate import (
+    GATE_SCHEMA_VERSION,
+    MemoryWriteAuthorization,
+    evaluate_memory_write_gate,
+)
+
+WRITE_SMOKE_SCHEMA_VERSION = "memory-db-write-smoke/v1"
+WRITE_SMOKE_ENV_VAR = "CDB_RUN_REAL_SURREALDB_MEMORY_WRITE"
+OBSERVED_BY = "memory_db_write_smoke/v1"
+
+
+class MemoryWriteSmokeError(RuntimeError):
+    """Raised when gated local write smoke preconditions are not met."""
+
+
+class MemoryWriteSqlClient(Protocol):
+    """Minimal SQL client surface for local write smoke."""
+
+    def upsert_create(self, table: str, record_id: str, payload: dict[str, Any]) -> None: ...
+
+    def record_exists(self, table: str, raw_id: str, *, id_field: str) -> bool: ...
+
+
+def write_smoke_env_enabled() -> bool:
+    return os.environ.get(WRITE_SMOKE_ENV_VAR) == "1"
+
+
+def local_write_smoke_enabled(envelope: Mapping[str, Any]) -> bool:
+    return (
+        write_smoke_env_enabled()
+        and envelope.get("gate_status") == "approved_dry_run"
+        and envelope.get("persist_allowed") is False
+    )
+
+
+def _parse_observed_at(value: datetime | None) -> datetime:
+    effective = value if value is not None else cdb_utcnow()
+    if effective.tzinfo is None:
+        return effective.replace(tzinfo=timezone.utc)
+    return effective.astimezone(timezone.utc)
+
+
+def _audit_safe_envelope(
+    envelope: dict[str, Any],
+    *,
+    write_status: str,
+    tables_written: tuple[str, ...],
+    memory_id: str,
+    evidence_id: str,
+) -> dict[str, Any]:
+    audit = dict(envelope.get("audit") or {})
+    audit["observation_type"] = "memory_write_smoke_execution"
+    audit["observed_by"] = OBSERVED_BY
+    audit["subject_ref"] = memory_id
+    audit["gate_status"] = envelope.get("gate_status")
+    audit["write_status"] = write_status
+    audit["tables_written"] = list(tables_written)
+    audit["related_memory"] = [memory_id]
+    audit["evidence_refs"] = [evidence_id]
+    return {
+        "schema_version": WRITE_SMOKE_SCHEMA_VERSION,
+        "gate_schema_version": GATE_SCHEMA_VERSION,
+        "write_status": write_status,
+        "gate_status": envelope.get("gate_status"),
+        "persist_allowed": False,
+        "memory_id": memory_id,
+        "evidence_id": evidence_id,
+        "tables_written": list(tables_written),
+        "audit": audit,
+        "limitations": [
+            "local_only",
+            "run_scoped_cleanup_required",
+            "lr_no_go",
+            "persist_allowed_false",
+            "slice_6_smoke_only",
+        ],
+        "approval_semantics": envelope.get("approval_semantics"),
+    }
+
+
+def execute_gated_local_memory_write_v1(
+    *,
+    record: Mapping[str, Any],
+    authorization: MemoryWriteAuthorization,
+    sql_client: MemoryWriteSqlClient,
+    evidence_record: Mapping[str, Any],
+    evidence_id: str,
+    strict: bool = True,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Evaluate gate, then UPSERT evidence_ref and agent_memory on localhost only.
+
+    Fail-closed: raises MemoryWriteSmokeError when gate blocks or env is unset.
+    Never logs raw human_go_token.
+    """
+    observed_at = _parse_observed_at(now)
+    envelope = evaluate_memory_write_gate(
+        record,
+        authorization,
+        strict=strict,
+        now=observed_at,
+    )
+    gate_status = envelope.get("gate_status")
+    if gate_status != "approved_dry_run":
+        raise MemoryWriteSmokeError(
+            f"memory write smoke blocked: gate_status={gate_status!r}"
+        )
+    if not local_write_smoke_enabled(envelope):
+        raise MemoryWriteSmokeError(
+            "memory write smoke blocked: "
+            f"{WRITE_SMOKE_ENV_VAR} must be '1' and gate must approve dry-run only"
+        )
+
+    validated = envelope.get("validated_record")
+    if not isinstance(validated, dict):
+        raise MemoryWriteSmokeError(
+            "memory write smoke blocked: gate envelope missing validated_record"
+        )
+    memory_id = str(validated["memory_id"])
+    if not evidence_id.strip():
+        raise MemoryWriteSmokeError("memory write smoke blocked: evidence_id is required")
+
+    if sql_client.record_exists("agent_memory", memory_id, id_field="memory_id"):
+        raise MemoryWriteSmokeError(
+            f"memory write smoke blocked: agent_memory already exists: {memory_id}"
+        )
+    if sql_client.record_exists("evidence_ref", evidence_id, id_field="evidence_id"):
+        raise MemoryWriteSmokeError(
+            f"memory write smoke blocked: evidence_ref already exists: {evidence_id}"
+        )
+
+    evidence_payload = dict(evidence_record)
+    memory_payload = dict(validated)
+
+    sql_client.upsert_create("evidence_ref", evidence_id, evidence_payload)
+    sql_client.upsert_create("agent_memory", memory_id, memory_payload)
+
+    if not sql_client.record_exists("evidence_ref", evidence_id, id_field="evidence_id"):
+        raise MemoryWriteSmokeError(
+            f"memory write smoke failed: evidence_ref not found after write: {evidence_id}"
+        )
+    if not sql_client.record_exists("agent_memory", memory_id, id_field="memory_id"):
+        raise MemoryWriteSmokeError(
+            f"memory write smoke failed: agent_memory not found after write: {memory_id}"
+        )
+
+    return _audit_safe_envelope(
+        envelope,
+        write_status="written_local_only",
+        tables_written=("evidence_ref", "agent_memory"),
+        memory_id=memory_id,
+        evidence_id=evidence_id,
+    )


### PR DESCRIPTION
## Summary
- Add `tools/surrealdb/memory_db_write_smoke.py` with gated local-only memory write smoke helper.
- Add local-only opt-in test guarded by `CDB_RUN_REAL_SURREALDB_MEMORY_WRITE=1` and `CDB_MEMORY_WRITE_HUMAN_GO_TOKEN`.
- Add unit tests proving blocked gate / missing env performs no writes.
- Extend local proof helpers for write-smoke planning and run-scoped cleanup.
- Document Slice 6 execution contract and audit addendum.

## Test plan
- [x] `pytest tests/unit/surrealdb/test_memory_write_gate.py tests/unit/surrealdb/test_memory_db_write_smoke.py -q`
- [x] `pytest tests/local/surrealdb/test_memory_db_write_smoke.py::test_memory_db_write_smoke_skips_without_env_flag -q`
- [x] `ruff check tools/surrealdb/memory_db_write_smoke.py tests/local/surrealdb/test_memory_db_write_smoke.py tests/unit/surrealdb/test_memory_db_write_smoke.py tests/local/surrealdb/memory_db_proof_helpers.py`

## Not run
- Real local DB write smoke was not executed.
- Requires explicit Operator-GO:
  - `CDB_RUN_REAL_SURREALDB_MEMORY_WRITE=1`
  - `CDB_MEMORY_WRITE_HUMAN_GO_TOKEN=<operator token>`

## Explicitly not included
- No productive Memory Write.
- No MCP write.
- No Auto-Memory.
- No BLUE/RED runtime mutation.
- No Trading/Risk/Execution change.
- No LR/Live/Echtgeld implication.

## References
- Refs #2694
- Refs #2606
- #2606 remains OPEN (epic DoD not claimed by harness-only delivery)
- #2689 remains separate and out of scope
- LR remains NO-GO
