### PR TITLE
fix(surrealdb): strip jsonl-only fields for memory write smoke

### DIFF
--- a/tests/local/surrealdb/memory_db_proof_helpers.py
+++ b/tests/local/surrealdb/memory_db_proof_helpers.py
@@ -491,6 +491,8 @@ def materialize_memory_write_smoke_memory_record(
         record["evidence_refs"] = [plan.evidence_id]
         record["memory_id"] = plan.memory_id
         record["content"] = "Slice 6 local-only gated memory write smoke record."
+        for field in _JSONL_STRIP_FIELDS:
+            record.pop(field, None)
         return record
     raise ValueError("agent_memories.jsonl fixture has no records")
 


### PR DESCRIPTION
## Summary
- Strip JSONL-only fields from `materialize_memory_write_smoke_memory_record()`.
- Makes the Slice-6 local-only write-smoke harness reproducible on clean `main`.
- Fixes local precondition observed during #2694 Operator-GO smoke: strict gate blocked `schema_version` / `run_id` fixture fields.

## Validation
- `pytest tests/unit/surrealdb/test_memory_db_write_smoke.py -q`
- `pytest tests/local/surrealdb/test_memory_db_write_smoke.py::test_memory_db_write_smoke_skips_without_env_flag -q`
- `ruff check tests/local/surrealdb/memory_db_proof_helpers.py tests/unit/surrealdb/test_memory_db_write_smoke.py tests/local/surrealdb/test_memory_db_write_smoke.py`

## Not run
- Real local-only DB write smoke was not rerun in this PR.
- Requires separate explicit Operator-GO.

## Explicitly not included
- No DB write.
- No MCP write.
- No productive Memory Write.
- No Auto-Memory.
- No BLUE/RED runtime mutation.
- No LR/Live/Echtgeld implication.

## References
- Refs #2694
- Refs #2606
- #2694 remains OPEN for clean-main execution evidence.
- #2606 remains OPEN.
- LR remains NO-GO.
