### PR TITLE
feat(surrealdb): enforce memory agent output contract

### DIFF
--- a/tests/unit/tools/mcp/test_memory_output_contract.py
+++ b/tests/unit/tools/mcp/test_memory_output_contract.py
@@ -1,0 +1,482 @@
+"""Unit tests for memory agent output contract enforcement.
+
+Issue: #2701 — enforce agent output contract on memory MCP tools
+Parent: #2606 (Langzeitgedaechtnis / Persistent Agent Memory)
+
+Validates that:
+    - All four Wave-14 memory/evidence MCP handlers produce responses that
+      pass ``validate_memory_output_contract``.
+    - ``stamp_limitations`` injects default limitations when absent.
+    - ``enforce_memory_output_contract`` raises on violations.
+    - Per-record ``memory_id`` and ``trust_level`` are present in matched_memory.
+    - ``metadata.source`` uses guarded values from the allowed set.
+    - Error responses are not subject to contract validation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tools.mcp.memory_output_contract import (
+    ALLOWED_SOURCE_LABELS,
+    MEMORY_OUTPUT_CONTRACT_VERSION,
+    MemoryOutputContractError,
+    default_limitations,
+    enforce_memory_output_contract,
+    stamp_limitations,
+    validate_memory_output_contract,
+)
+from tools.mcp.context_evidence_memory_tools import (
+    TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+    TOOL_CDB_CONTEXT_CLAIM_RESOLVE,
+    TOOL_CDB_CONTEXT_MEMORY_GET,
+    TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+    handle_cdb_context_evidence_resolve,
+    handle_cdb_context_claim_resolve,
+    handle_cdb_context_memory_get,
+    handle_cdb_context_trust_summary,
+)
+
+pytestmark = pytest.mark.unit
+
+FIXTURE_PATH = Path("tests/fixtures/surrealdb/wave14/wave14_v1.json")
+
+
+def _load_fixture() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+# ── Contract module unit tests ───────────────────────────────────────────────
+
+
+class TestContractVersion:
+    def test_version_string_defined(self) -> None:
+        assert MEMORY_OUTPUT_CONTRACT_VERSION == "memory-output-contract/v1"
+
+
+class TestDefaultLimitations:
+    def test_returns_list(self) -> None:
+        lims = default_limitations()
+        assert isinstance(lims, list)
+        assert len(lims) >= 1
+
+    def test_returns_fresh_copy(self) -> None:
+        a = default_limitations()
+        b = default_limitations()
+        assert a == b
+        assert a is not b
+
+    def test_contains_no_go_guardrail(self) -> None:
+        text = " ".join(default_limitations())
+        assert "NO-GO" in text
+
+
+class TestStampLimitations:
+    def test_adds_limitations_when_absent(self) -> None:
+        result: dict[str, Any] = {"trust_level": "weak"}
+        stamp_limitations(result)
+        assert "limitations" in result
+        assert len(result["limitations"]) >= 1
+
+    def test_preserves_existing_limitations(self) -> None:
+        result: dict[str, Any] = {"limitations": ["custom limitation"]}
+        stamp_limitations(result)
+        assert "custom limitation" in result["limitations"]
+        assert len(result["limitations"]) > 1
+
+    def test_deduplicates(self) -> None:
+        result: dict[str, Any] = {"limitations": list(default_limitations())}
+        stamp_limitations(result)
+        assert len(result["limitations"]) == len(set(result["limitations"]))
+
+    def test_extra_appended(self) -> None:
+        result: dict[str, Any] = {}
+        stamp_limitations(result, extra=["extra item"])
+        assert "extra item" in result["limitations"]
+
+
+class TestValidateContract:
+    def test_minimal_valid_memory_response(self) -> None:
+        response = {
+            "tool": "cdb_context_memory_get",
+            "status": "ok",
+            "metadata": {"source": "in_memory", "read_only": True},
+            "result": {
+                "limitations": ["test"],
+                "matched_memory": [
+                    {"memory_id": "m-1", "trust_level": "weak"}
+                ],
+                "memory_summary": {"overall_trust": "weak"},
+            },
+        }
+        violations = validate_memory_output_contract(response)
+        assert violations == []
+
+    def test_missing_tool_field(self) -> None:
+        response = {
+            "status": "ok",
+            "metadata": {"source": "in_memory", "read_only": True},
+            "result": {"limitations": ["x"]},
+        }
+        violations = validate_memory_output_contract(response)
+        assert any("tool" in v for v in violations)
+
+    def test_missing_metadata_source(self) -> None:
+        response = {
+            "tool": "t",
+            "status": "ok",
+            "metadata": {"read_only": True},
+            "result": {"limitations": ["x"]},
+        }
+        violations = validate_memory_output_contract(response)
+        assert any("source" in v for v in violations)
+
+    def test_invalid_source_label(self) -> None:
+        response = {
+            "tool": "t",
+            "status": "ok",
+            "metadata": {"source": "spoofed-value", "read_only": True},
+            "result": {"limitations": ["x"]},
+        }
+        violations = validate_memory_output_contract(response)
+        assert any("spoofed-value" in v for v in violations)
+
+    def test_missing_limitations(self) -> None:
+        response = {
+            "tool": "t",
+            "status": "ok",
+            "metadata": {"source": "in_memory", "read_only": True},
+            "result": {},
+        }
+        violations = validate_memory_output_contract(response)
+        assert any("limitations" in v for v in violations)
+
+    def test_missing_trust_when_memory_present(self) -> None:
+        response = {
+            "tool": "t",
+            "status": "ok",
+            "metadata": {"source": "in_memory", "read_only": True},
+            "result": {
+                "limitations": ["x"],
+                "matched_memory": [{"memory_id": "m-1"}],
+            },
+        }
+        violations = validate_memory_output_contract(response)
+        assert any("trust" in v.lower() for v in violations)
+
+    def test_trust_not_required_when_confidence_summary_only(self) -> None:
+        """claim-resolve has confidence_summary with stats, not trust context."""
+        response = {
+            "tool": "cdb_context_claim_resolve",
+            "status": "ok",
+            "metadata": {"source": "in_memory", "read_only": True},
+            "result": {
+                "limitations": ["x"],
+                "matched_claims": [{"claim_id": "c-1"}],
+                "confidence_summary": {"min": 0.8, "max": 0.95, "avg": 0.9, "count": 2},
+            },
+        }
+        violations = validate_memory_output_contract(response)
+        assert violations == []
+
+    def test_trust_not_required_for_evidence_claim(self) -> None:
+        response = {
+            "tool": "cdb_context_evidence_resolve",
+            "status": "ok",
+            "metadata": {"source": "in_memory", "read_only": True},
+            "result": {
+                "limitations": ["x"],
+                "matched_evidence": [{"evidence_id": "ev-1"}],
+            },
+        }
+        violations = validate_memory_output_contract(response)
+        assert violations == []
+
+    def test_per_record_memory_id_required(self) -> None:
+        response = {
+            "tool": "t",
+            "status": "ok",
+            "metadata": {"source": "in_memory", "read_only": True},
+            "result": {
+                "limitations": ["x"],
+                "matched_memory": [
+                    {"trust_level": "weak"},
+                ],
+                "memory_summary": {"overall_trust": "weak"},
+            },
+        }
+        violations = validate_memory_output_contract(response)
+        assert any("memory_id" in v for v in violations)
+
+    def test_per_record_trust_level_required(self) -> None:
+        response = {
+            "tool": "t",
+            "status": "ok",
+            "metadata": {"source": "in_memory", "read_only": True},
+            "result": {
+                "limitations": ["x"],
+                "matched_memory": [
+                    {"memory_id": "m-1"},
+                ],
+                "memory_summary": {"overall_trust": "weak"},
+            },
+        }
+        violations = validate_memory_output_contract(response)
+        assert any("trust_level" in v for v in violations)
+
+    def test_error_responses_skip_result_checks(self) -> None:
+        response = {
+            "tool": "t",
+            "status": "error",
+            "error": {"code": "test", "message": "msg"},
+            "metadata": {"source": "in_memory", "read_only": True},
+        }
+        violations = validate_memory_output_contract(response)
+        assert violations == []
+
+    def test_allowed_source_labels_complete(self) -> None:
+        assert "in_memory" in ALLOWED_SOURCE_LABELS
+        assert "surrealdb-local" in ALLOWED_SOURCE_LABELS
+        assert "surrealdb-local-unavailable" in ALLOWED_SOURCE_LABELS
+
+
+class TestEnforceContract:
+    def test_raises_on_violation(self) -> None:
+        bad = {"status": "ok", "metadata": {}, "result": {}}
+        with pytest.raises(MemoryOutputContractError):
+            enforce_memory_output_contract(bad)
+
+    def test_passes_on_valid(self) -> None:
+        good = {
+            "tool": "t",
+            "status": "ok",
+            "metadata": {"source": "in_memory", "read_only": True},
+            "result": {"limitations": ["x"]},
+        }
+        enforce_memory_output_contract(good)
+
+
+# ── Handler integration: contract compliance ─────────────────────────────────
+
+
+class TestMemoryGetOutputContract:
+    """Verify cdb_context_memory_get output satisfies the memory output contract."""
+
+    def test_contract_compliant(self) -> None:
+        fx = _load_fixture()
+        response = handle_cdb_context_memory_get({
+            "tool": TOOL_CDB_CONTEXT_MEMORY_GET,
+            "parameters": {
+                "mode": "by_scope",
+                "scope": "wave14",
+                "memory_records": fx["memory_records"],
+            },
+        })
+        violations = validate_memory_output_contract(response)
+        assert violations == [], f"Contract violations: {violations}"
+
+    def test_has_limitations(self) -> None:
+        fx = _load_fixture()
+        response = handle_cdb_context_memory_get({
+            "tool": TOOL_CDB_CONTEXT_MEMORY_GET,
+            "parameters": {
+                "mode": "by_scope",
+                "scope": "wave14",
+                "memory_records": fx["memory_records"],
+            },
+        })
+        assert isinstance(response["result"]["limitations"], list)
+        assert len(response["result"]["limitations"]) >= 1
+
+    def test_per_record_memory_id_present(self) -> None:
+        fx = _load_fixture()
+        response = handle_cdb_context_memory_get({
+            "tool": TOOL_CDB_CONTEXT_MEMORY_GET,
+            "parameters": {
+                "mode": "by_scope",
+                "scope": "wave14",
+                "memory_records": fx["memory_records"],
+            },
+        })
+        for record in response["result"]["matched_memory"]:
+            assert "memory_id" in record, f"missing memory_id in {record}"
+            assert "trust_level" in record, f"missing trust_level in {record}"
+
+    def test_metadata_source_guarded(self) -> None:
+        fx = _load_fixture()
+        response = handle_cdb_context_memory_get({
+            "tool": TOOL_CDB_CONTEXT_MEMORY_GET,
+            "parameters": {
+                "mode": "by_scope",
+                "scope": "wave14",
+                "memory_records": fx["memory_records"],
+            },
+        })
+        assert response["metadata"]["source"] in ALLOWED_SOURCE_LABELS
+
+
+class TestTrustSummaryOutputContract:
+    """Verify cdb_context_trust_summary output satisfies the memory output contract."""
+
+    def test_contract_compliant(self) -> None:
+        response = handle_cdb_context_trust_summary({
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {"scope": "wave14"},
+        })
+        violations = validate_memory_output_contract(response)
+        assert violations == [], f"Contract violations: {violations}"
+
+    def test_has_limitations(self) -> None:
+        response = handle_cdb_context_trust_summary({
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {"scope": "wave14"},
+        })
+        assert isinstance(response["result"]["limitations"], list)
+        assert len(response["result"]["limitations"]) >= 1
+
+    def test_trust_level_present(self) -> None:
+        response = handle_cdb_context_trust_summary({
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {"scope": "wave14"},
+        })
+        assert response["result"]["trust_level"] in (
+            "blocked", "weak", "acceptable", "strong"
+        )
+
+    def test_metadata_source_guarded(self) -> None:
+        response = handle_cdb_context_trust_summary({
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {"scope": "wave14"},
+        })
+        assert response["metadata"]["source"] in ALLOWED_SOURCE_LABELS
+
+
+class TestEvidenceResolveOutputContract:
+    """Verify cdb_context_evidence_resolve satisfies source + limitations."""
+
+    def test_contract_compliant(self) -> None:
+        fx = _load_fixture()
+        response = handle_cdb_context_evidence_resolve({
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                "mode": "by_artifact",
+                "artifact": "tools/surrealdb/context_stop_resolver.py",
+                "evidence_records": fx["evidence_records"],
+            },
+        })
+        violations = validate_memory_output_contract(response)
+        assert violations == [], f"Contract violations: {violations}"
+
+    def test_has_limitations(self) -> None:
+        fx = _load_fixture()
+        response = handle_cdb_context_evidence_resolve({
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                "mode": "by_artifact",
+                "artifact": "tools/surrealdb/context_stop_resolver.py",
+                "evidence_records": fx["evidence_records"],
+            },
+        })
+        assert isinstance(response["result"]["limitations"], list)
+        assert len(response["result"]["limitations"]) >= 1
+
+    def test_metadata_source_guarded(self) -> None:
+        fx = _load_fixture()
+        response = handle_cdb_context_evidence_resolve({
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {
+                "mode": "by_artifact",
+                "artifact": "tools/surrealdb/context_stop_resolver.py",
+                "evidence_records": fx["evidence_records"],
+            },
+        })
+        assert response["metadata"]["source"] in ALLOWED_SOURCE_LABELS
+
+
+class TestClaimResolveOutputContract:
+    """Verify cdb_context_claim_resolve satisfies source + limitations."""
+
+    def test_contract_compliant(self) -> None:
+        fx = _load_fixture()
+        response = handle_cdb_context_claim_resolve({
+            "tool": TOOL_CDB_CONTEXT_CLAIM_RESOLVE,
+            "parameters": {
+                "mode": "by_topic",
+                "topic": "stop_conditions",
+                "claim_records": fx["claim_records"],
+            },
+        })
+        violations = validate_memory_output_contract(response)
+        assert violations == [], f"Contract violations: {violations}"
+
+    def test_has_limitations(self) -> None:
+        fx = _load_fixture()
+        response = handle_cdb_context_claim_resolve({
+            "tool": TOOL_CDB_CONTEXT_CLAIM_RESOLVE,
+            "parameters": {
+                "mode": "by_topic",
+                "topic": "stop_conditions",
+                "claim_records": fx["claim_records"],
+            },
+        })
+        assert isinstance(response["result"]["limitations"], list)
+        assert len(response["result"]["limitations"]) >= 1
+
+    def test_metadata_source_guarded(self) -> None:
+        fx = _load_fixture()
+        response = handle_cdb_context_claim_resolve({
+            "tool": TOOL_CDB_CONTEXT_CLAIM_RESOLVE,
+            "parameters": {
+                "mode": "by_topic",
+                "topic": "stop_conditions",
+                "claim_records": fx["claim_records"],
+            },
+        })
+        assert response["metadata"]["source"] in ALLOWED_SOURCE_LABELS
+
+
+# ── Error response exclusions ────────────────────────────────────────────────
+
+
+class TestErrorResponsesExcluded:
+    """Error responses should not be flagged for missing contract fields."""
+
+    def test_memory_get_error_passes_contract(self) -> None:
+        response = handle_cdb_context_memory_get({
+            "tool": TOOL_CDB_CONTEXT_MEMORY_GET,
+            "parameters": {"mode": "by_scope", "scope": "x"},
+        })
+        assert response["status"] == "error"
+        violations = validate_memory_output_contract(response)
+        assert violations == []
+
+    def test_trust_summary_error_passes_contract(self) -> None:
+        response = handle_cdb_context_trust_summary({
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {},
+        })
+        assert response["status"] == "error"
+        violations = validate_memory_output_contract(response)
+        assert violations == []
+
+    def test_evidence_error_passes_contract(self) -> None:
+        response = handle_cdb_context_evidence_resolve({
+            "tool": TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE,
+            "parameters": {"mode": "by_artifact", "artifact": "x"},
+        })
+        assert response["status"] == "error"
+        violations = validate_memory_output_contract(response)
+        assert violations == []
+
+    def test_claim_error_passes_contract(self) -> None:
+        response = handle_cdb_context_claim_resolve({
+            "tool": TOOL_CDB_CONTEXT_CLAIM_RESOLVE,
+            "parameters": {"mode": "by_topic", "topic": "x"},
+        })
+        assert response["status"] == "error"
+        violations = validate_memory_output_contract(response)
+        assert violations == []

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -48,6 +48,7 @@ from tools.mcp.surrealdb_adapter_factory import (
     build_adapter_from_params,
     derive_guarded_source_label,
 )
+from tools.mcp.memory_output_contract import stamp_limitations
 
 TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE = "cdb_context_evidence_resolve"
 TOOL_CDB_CONTEXT_CLAIM_RESOLVE = "cdb_context_claim_resolve"
@@ -448,6 +449,7 @@ def handle_cdb_context_evidence_resolve(request: Mapping[str, Any]) -> dict[str,
     semantics = dict(result.get("approval_semantics") or {})
     semantics["no_echtgeld_go"] = True
     result["approval_semantics"] = semantics
+    stamp_limitations(result)
 
     return _ok_response(
         TOOL_CDB_CONTEXT_EVIDENCE_RESOLVE, result=result, source=_source
@@ -547,6 +549,7 @@ def handle_cdb_context_claim_resolve(request: Mapping[str, Any]) -> dict[str, An
     semantics = dict(result.get("approval_semantics") or {})
     semantics["no_echtgeld_go"] = True
     result["approval_semantics"] = semantics
+    stamp_limitations(result)
 
     return _ok_response(TOOL_CDB_CONTEXT_CLAIM_RESOLVE, result=result, source=_source)
 
@@ -641,6 +644,7 @@ def handle_cdb_context_memory_get(request: Mapping[str, Any]) -> dict[str, Any]:
     semantics = dict(result.get("approval_semantics") or {})
     semantics["no_echtgeld_go"] = True
     result["approval_semantics"] = semantics
+    stamp_limitations(result)
 
     return _ok_response(TOOL_CDB_CONTEXT_MEMORY_GET, result=result, source=_source)
 
@@ -774,5 +778,6 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
     semantics = dict(result.get("approval_semantics") or {})
     semantics["no_echtgeld_go"] = True
     result["approval_semantics"] = semantics
+    stamp_limitations(result)
 
     return _ok_response(TOOL_CDB_CONTEXT_TRUST_SUMMARY, result=result, source=_source)

--- a/tools/mcp/memory_output_contract.py
+++ b/tools/mcp/memory_output_contract.py
@@ -1,0 +1,153 @@
+"""Agent output contract for memory/evidence MCP tools.
+
+Issue: #2701
+Parent: #2606 (Langzeitgedaechtnis / Persistent Agent Memory)
+Cross-refs: #2605 (Context MCP), agents/AGENTS.md § Brain Evidence Gate
+
+Enforces a consistent response envelope on memory/evidence MCP tools so
+agents must surface ``memory_id`` (per-record), guarded ``source``,
+``trust``/``trust_level``, and ``limitations`` when operating in
+Memory/Evidence scope.
+
+Guardrails:
+    - Read-only contract validation; no DB writes, no mutations.
+    - Caller-spoofed ``brain_source`` / ``metadata.source`` cannot upgrade
+      the source label to ``surrealdb-local`` (enforced by
+      ``derive_guarded_source_label`` — this contract validates the output).
+    - LR remains NO-GO.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+MEMORY_OUTPUT_CONTRACT_VERSION = "memory-output-contract/v1"
+
+REQUIRED_ENVELOPE_FIELDS = frozenset({"tool", "status", "metadata"})
+REQUIRED_METADATA_FIELDS = frozenset({"source", "read_only"})
+
+ALLOWED_SOURCE_LABELS = frozenset(
+    {
+        "in_memory",
+        "surrealdb-local",
+        "surrealdb-local-unavailable",
+    }
+)
+
+_DEFAULT_LIMITATIONS = [
+    "Memory is provided as context, not as authoritative truth.",
+    "stale/superseded memory is flagged but not auto-removed.",
+    "LR remains NO-GO; no live-go or Echtgeld-GO implied.",
+]
+
+
+class MemoryOutputContractError(ValueError):
+    """Raised when a memory/evidence MCP response violates the output contract."""
+
+
+def default_limitations() -> list[str]:
+    """Return the canonical limitations list for memory/evidence tools."""
+    return list(_DEFAULT_LIMITATIONS)
+
+
+def validate_memory_output_contract(response: Mapping[str, Any]) -> list[str]:
+    """Validate that *response* satisfies the memory agent output contract.
+
+    Returns a list of violation descriptions. An empty list means the
+    response is contract-compliant.
+    """
+    violations: list[str] = []
+
+    for field in REQUIRED_ENVELOPE_FIELDS:
+        if field not in response:
+            violations.append(f"missing required envelope field: {field}")
+
+    if response.get("status") == "error":
+        return violations
+
+    metadata = response.get("metadata")
+    if not isinstance(metadata, Mapping):
+        violations.append("metadata must be a mapping")
+        return violations
+
+    for field in REQUIRED_METADATA_FIELDS:
+        if field not in metadata:
+            violations.append(f"missing required metadata field: {field}")
+
+    source = metadata.get("source")
+    if source is not None and source not in ALLOWED_SOURCE_LABELS:
+        violations.append(
+            f"metadata.source '{source}' is not in allowed set: "
+            f"{sorted(ALLOWED_SOURCE_LABELS)}"
+        )
+
+    result = response.get("result")
+    if not isinstance(result, Mapping):
+        violations.append("result must be a mapping for ok responses")
+        return violations
+
+    if "limitations" not in result:
+        violations.append("missing required field: result.limitations")
+
+    # Trust check: required only when the result carries memory/trust context.
+    # Evidence-resolve and claim-resolve do not produce memory-trust fields —
+    # the contract requires only source + limitations for those tools.
+    # Note: claim-resolve has a ``confidence_summary`` with numeric stats
+    # (min/max/avg/count) which is NOT memory-trust context.
+    _has_trust_scope = (
+        "matched_memory" in result
+        or "trust_level" in result
+        or "memory_summary" in result
+    )
+    if _has_trust_scope:
+        trust_level = result.get("trust_level")
+        trust_in_summary = (result.get("memory_summary") or {}).get(
+            "overall_trust"
+        )
+        if trust_level is None and trust_in_summary is None:
+            violations.append(
+                "missing trust information: need trust_level or "
+                "memory_summary.overall_trust"
+            )
+
+    matched_memory = result.get("matched_memory")
+    if isinstance(matched_memory, list):
+        for idx, record in enumerate(matched_memory):
+            if not isinstance(record, Mapping):
+                continue
+            if "memory_id" not in record:
+                violations.append(
+                    f"matched_memory[{idx}] missing required field: memory_id"
+                )
+            if "trust_level" not in record:
+                violations.append(
+                    f"matched_memory[{idx}] missing required field: trust_level"
+                )
+
+    return violations
+
+
+def enforce_memory_output_contract(response: Mapping[str, Any]) -> None:
+    """Raise ``MemoryOutputContractError`` if *response* violates the contract."""
+    violations = validate_memory_output_contract(response)
+    if violations:
+        raise MemoryOutputContractError(
+            f"Memory output contract violations: {'; '.join(violations)}"
+        )
+
+
+def stamp_limitations(
+    result: dict[str, Any],
+    *,
+    extra: list[str] | None = None,
+) -> dict[str, Any]:
+    """Add ``limitations`` to *result* if not already present.
+
+    Merges default limitations with any *extra* entries.  Existing
+    ``limitations`` in *result* are preserved and extended.
+    """
+    existing = list(result.get("limitations") or [])
+    defaults = default_limitations()
+    merged = list(dict.fromkeys(existing + defaults + (extra or [])))
+    result["limitations"] = merged
+    return result


### PR DESCRIPTION
## Summary

Adds **memory-output-contract/v1** enforcing required fields on all Wave-14 memory/evidence MCP tool responses.

**Required fields per contract:**
- \memory_id\ — per record (in \matched_memory\, \matched_claims\, \matched_evidence\)
- \source\ — in \metadata.source\, guarded against allowed labels
- \	rust\ — \	rust_level\ or \memory_summary.overall_trust\ (conditional, only when tool provides memory/trust context)
- \limitations\ — always present in \esult\, stamped via \stamp_limitations()\

**Changes:**
- New \	ools/mcp/memory_output_contract.py\: contract definition (\MEMORY_OUTPUT_CONTRACT_VERSION = 1\), \alidate_memory_output_contract()\, \nforce_memory_output_contract()\, \stamp_limitations()\, \default_limitations()\
- \	ools/mcp/context_evidence_memory_tools.py\: all four handlers (\vidence_resolve\, \claim_resolve\, \memory_get\, \	rust_summary\) call \stamp_limitations(result)\ before returning
- New \	ests/unit/tools/mcp/test_memory_output_contract.py\: 40 unit tests covering contract module, handler compliance, per-record field checks, source guard, error exclusions, and conditional trust logic

## Validation

- \uff check\ clean on all changed files
- 898 MCP unit tests pass (0 failures, 0 regressions)
- No DB dependency, no write surface, no productive mutation

## Explicitly not included

- No DB write, no MCP write mutation, no productive memory write, no auto-memory
- No BLUE/RED stack changes
- No CURRENT_STATUS.md changes
- LR remains **NO-GO**
- \#2606 remains **OPEN**

## Test plan

- [x] \uff check tools/mcp/memory_output_contract.py tools/mcp/context_evidence_memory_tools.py tests/unit/tools/mcp/test_memory_output_contract.py\
- [x] \pytest tests/unit/tools/mcp/ -v\ — 898 passed
- [ ] CI (\ci\ + \policy-gate\) must pass

Refs #2701
Refs #2606