### PR TITLE
test(surrealdb): add DB-backed stale memory scan proof

### DIFF
--- a/docs/surrealdb/stale-knowledge-runbook.md
+++ b/docs/surrealdb/stale-knowledge-runbook.md
@@ -65,6 +65,19 @@ The following are explicitly out of scope for this system:
 - **Output**: `StaleKnowledgeScanResult` containing `findings`, `blocking_count`,
   `severity_summary`, `recommended_refresh`, and `guardrails`.
 
+### 3.1.1 DB-backed memory stale scan — `scan_agent_memory_stale_v1`
+
+- **Module**: `tools/surrealdb/memory_db_stale_scan.py`
+- **Schema version**: `memory-db-stale-scan/v1`
+- **API**: `scan_agent_memory_stale_v1(adapter, scope, limit=200, now=None) → dict`
+- **Read-only**. SELECT from `agent_memory` via a local SurrealDB adapter only;
+  classifies rows with `classify_memory_freshness`; optionally bridges expired rows
+  into Wave-16 `memory_ttl_expired` findings. No writes. No auto-fix.
+- **Scope**: complements §3.1 bundle scan (#2702); the bundle path above is unchanged.
+- **Evidence**: unit mocks in CI; opt-in local proof via
+  `CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE=1` and
+  `tests/local/surrealdb/test_memory_db_stale_scan.py`.
+
 ### 3.2 CLI — `stale_context_cli.py`
 
 - **Module**: `tools/surrealdb/stale_context_cli.py`

--- a/tests/local/surrealdb/test_memory_db_stale_scan.py
+++ b/tests/local/surrealdb/test_memory_db_stale_scan.py
@@ -1,0 +1,235 @@
+"""Opt-in local-only DB-backed stale/expired memory scan — #2702.
+
+Runs only when:
+- ``CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE=1``
+- ``infrastructure/config/surrealdb/context_query.local.yaml`` exists
+- secrets path resolves (CDB canon, overridable via env)
+- local SurrealDB answers on ``127.0.0.1:8010``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+import urllib.error
+import urllib.request
+
+import pytest
+
+from tests.local.surrealdb.memory_db_proof_helpers import (
+    MemoryDbProofRecordPlan,
+    MemoryDbProofSqlClient,
+    assert_memory_proof_records_absent,
+    assert_memory_proof_tmp_absent,
+    build_memory_proof_record_plan,
+    cleanup_memory_proof_records,
+    cleanup_memory_proof_tmp,
+    materialize_memory_proof_bundle,
+    memory_proof_tmp_root,
+    resolve_memory_proof_run_id,
+)
+from tools.mcp.surrealdb_adapter_factory import build_adapter_from_params
+from tools.mcp.context_evidence_memory_tools import TOOL_CDB_CONTEXT_MEMORY_GET
+from tools.surrealdb.context_importer import main as importer_main
+from tools.surrealdb.memory_db_stale_scan import scan_agent_memory_stale_v1
+
+pytestmark = pytest.mark.local_only
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_QUERY_CONFIG_PATH = (
+    _REPO_ROOT / "infrastructure" / "config" / "surrealdb" / "context_query.local.yaml"
+)
+_IMPORT_CONFIG_PATH = (
+    _REPO_ROOT
+    / "infrastructure"
+    / "config"
+    / "surrealdb"
+    / "context_import.local.example.yaml"
+)
+_LOCAL_SURR_URLS = (
+    "http://127.0.0.1:8010/health",
+    "http://127.0.0.1:8010/version",
+)
+_NOW = datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _http_status(url: str) -> int | None:
+    try:
+        with urllib.request.urlopen(url, timeout=5) as response:
+            return int(response.status)
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+
+
+def _candidate_secrets_paths() -> list[Path]:
+    candidates: list[Path] = []
+    for env_key in ("CDB_CONTEXT_SECRETS_PATH", "SECRETS_PATH"):
+        raw = os.environ.get(env_key, "").strip()
+        if raw:
+            candidates.append(Path(raw))
+    if os.name == "nt":
+        userprofile = os.environ.get("USERPROFILE", "").strip()
+        if userprofile:
+            candidates.append(Path(userprofile) / "Documents" / ".secrets" / ".cdb")
+    else:
+        candidates.append(Path.home() / "Documents" / ".secrets" / ".cdb")
+    seen: set[Path] = set()
+    ordered: list[Path] = []
+    for path in candidates:
+        if path in seen:
+            continue
+        seen.add(path)
+        ordered.append(path)
+    return ordered
+
+
+def _resolve_secrets_path() -> Path | None:
+    for candidate in _candidate_secrets_paths():
+        try:
+            if candidate.is_dir():
+                return candidate
+        except OSError:
+            continue
+    return None
+
+
+def _require_local_opt_in() -> Path:
+    if os.environ.get("CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE") != "1":
+        pytest.skip(
+            "real surrealdb-local memory proof disabled; "
+            "set CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE=1"
+        )
+    if not _QUERY_CONFIG_PATH.exists():
+        pytest.skip(
+            "missing local query config: "
+            "infrastructure/config/surrealdb/context_query.local.yaml"
+        )
+    secrets_dir = _resolve_secrets_path()
+    if secrets_dir is None:
+        pytest.skip(
+            "missing secrets dir for surrealdb-local auth "
+            "(set CDB_CONTEXT_SECRETS_PATH or SECRETS_PATH, or provide canon secrets store)"
+        )
+    if not (secrets_dir / "SURREALDB_ENV").is_file():
+        pytest.skip("missing required secrets file SURREALDB_ENV in secrets dir")
+    for url in _LOCAL_SURR_URLS:
+        status = _http_status(url)
+        if status != 200:
+            pytest.skip(f"local SurrealDB preflight failed for {url} (status={status})")
+    return secrets_dir
+
+
+def _seed_local_surrealdb(
+    input_dir: Path,
+    *,
+    run_id: str,
+    secrets_path: Path,
+) -> None:
+    exit_code = importer_main(
+        [
+            "apply",
+            "--input-dir",
+            str(input_dir),
+            "--surreal-url",
+            "http://127.0.0.1:8010",
+            "--namespace",
+            "cdb_context_local",
+            "--database",
+            "cdb_context_intel",
+            "--apply",
+            "--apply-mode",
+            "local-dev",
+            "--config",
+            str(_IMPORT_CONFIG_PATH),
+            "--run-id",
+            run_id,
+            "--adapter",
+            "surrealdb-local",
+            "--secrets-path",
+            str(secrets_path),
+        ]
+    )
+    assert exit_code == 0, f"context_importer apply failed with exit code {exit_code}"
+
+
+def _build_adapter(secrets_path: Path) -> Any:
+    result = build_adapter_from_params(
+        {
+            "adapter_config_path": str(_QUERY_CONFIG_PATH),
+            "secrets_path": str(secrets_path),
+        },
+        TOOL_CDB_CONTEXT_MEMORY_GET,
+    )
+    assert not isinstance(result, dict), result
+    adapter, _config = result
+    return adapter
+
+
+def _assert_no_secret_leak(payload: dict[str, Any], *, secrets_path: Path) -> None:
+    rendered = json.dumps(payload, sort_keys=True, default=str)
+    assert "Authorization" not in rendered
+    assert "Basic " not in rendered
+    assert "SURREAL_PASS" not in rendered
+    assert "SURREAL_USER" not in rendered
+    assert str(secrets_path) not in rendered
+
+
+@pytest.fixture
+def memory_db_proof_context() -> (
+    tuple[MemoryDbProofRecordPlan, Path, MemoryDbProofSqlClient]
+):
+    secrets_path = _require_local_opt_in()
+    run_id = resolve_memory_proof_run_id()
+    plan = build_memory_proof_record_plan(run_id)
+    tmp_root = memory_proof_tmp_root(run_id)
+    assert_memory_proof_tmp_absent(tmp_root)
+    sql_client = MemoryDbProofSqlClient.from_secrets_dir(secrets_path)
+    assert_memory_proof_records_absent(sql_client, plan)
+    bundle_dir = materialize_memory_proof_bundle(tmp_root, run_id=run_id, plan=plan)
+    _seed_local_surrealdb(bundle_dir, run_id=run_id, secrets_path=secrets_path)
+    try:
+        yield plan, secrets_path, sql_client
+    finally:
+        cleanup_memory_proof_records(sql_client, plan)
+        cleanup_memory_proof_tmp(tmp_root)
+
+
+def test_memory_db_stale_scan_skips_without_env_flag() -> None:
+    if os.environ.get("CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE") == "1":
+        pytest.skip("env flag set; covered by seeded stale scan test")
+    with pytest.raises(pytest.skip.Exception):
+        _require_local_opt_in()
+
+
+def test_memory_db_stale_scan_finds_fresh_and_expired(
+    memory_db_proof_context: tuple[
+        MemoryDbProofRecordPlan, Path, MemoryDbProofSqlClient
+    ],
+) -> None:
+    plan, secrets_path, _sql_client = memory_db_proof_context
+    adapter = _build_adapter(secrets_path)
+
+    result = scan_agent_memory_stale_v1(
+        adapter=adapter,
+        scope=plan.scope,
+        limit=25,
+        now=_NOW,
+    )
+
+    assert result["source"] == "surrealdb-local"
+    assert result["record_count"] == 2
+    assert result["fresh_count"] == 1
+    assert result["stale_count"] == 1
+    assert result["expired_count"] == 1
+    assert set(result["expired_memory_ids"]) == {plan.memory_ids[1]}
+    assert plan.memory_ids[0] not in result["stale_memory_ids"]
+    assert plan.memory_ids[1] in result["stale_memory_ids"]
+
+    wave16 = result["wave16_memory_ttl"]
+    assert wave16["finding_count"] == 1
+    assert wave16["stale_types"] == ["memory_ttl_expired"]
+
+    _assert_no_secret_leak(result, secrets_path=secrets_path)

--- a/tests/unit/surrealdb/test_memory_db_stale_scan.py
+++ b/tests/unit/surrealdb/test_memory_db_stale_scan.py
@@ -1,0 +1,182 @@
+"""Unit tests for DB-backed stale/expired memory scan — #2702."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.surrealdb.memory_contract import (
+    MemoryContractError,
+    generate_memory_id,
+)
+from tools.surrealdb.memory_db_stale_scan import scan_agent_memory_stale_v1
+from tools.surrealdb.stale_knowledge_scan import scan_stale_knowledge_v1
+
+_NOW = datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)
+_SCOPE = "memory_db_proof"
+
+
+def _fresh_record(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "scope": _SCOPE,
+        "namespace": _SCOPE,
+        "memory_type": "semantic_memory",
+        "content": "Fresh memory for DB stale scan proof.",
+        "source_refs": ["docs/surrealdb/memory-reality-slice1-audit.md"],
+        "evidence_refs": ["ev-mdbproof-base-001"],
+        "confidence": 0.9,
+        "ttl": 86400,
+        "created_by": "cdb-test-001",
+        "created_at": "2026-05-29T10:00:00Z",
+        "expires_at": "2026-05-30T10:00:00Z",
+        "run_id": "seed-run",
+        "schema_version": "context-indexer/v0",
+        "id": "agent_memory:seed",
+        "sensitivity": "internal",
+    }
+    base.update(overrides)
+    base["memory_id"] = generate_memory_id(
+        scope=base["scope"],
+        namespace=base["namespace"],
+        memory_type=base["memory_type"],
+        created_by=base["created_by"],
+        content=base["content"],
+        source_refs=base["source_refs"],
+    )
+    return base
+
+
+def _expired_record(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "scope": _SCOPE,
+        "namespace": _SCOPE,
+        "memory_type": "semantic_memory",
+        "content": "Expired memory for DB stale scan proof.",
+        "source_refs": ["docs/surrealdb/memory-reality-slice1-audit.md"],
+        "evidence_refs": ["ev-mdbproof-base-002"],
+        "confidence": 0.85,
+        "ttl": 3600,
+        "created_by": "cdb-test-001",
+        "created_at": "2026-05-01T10:00:00Z",
+        "expires_at": "2026-05-01T11:00:00Z",
+    }
+    base.update(overrides)
+    base["memory_id"] = generate_memory_id(
+        scope=base["scope"],
+        namespace=base["namespace"],
+        memory_type=base["memory_type"],
+        created_by=base["created_by"],
+        content=base["content"],
+        source_refs=base["source_refs"],
+    )
+    return base
+
+
+def _mock_adapter(rows: list[dict[str, Any]]) -> MagicMock:
+    adapter = MagicMock()
+    adapter.status = "surrealdb-local"
+    adapter.execute.return_value = rows
+    return adapter
+
+
+@pytest.mark.unit
+def test_scan_agent_memory_stale_v1_partitions_fresh_and_expired() -> None:
+    adapter = _mock_adapter([_fresh_record(), _expired_record()])
+    result = scan_agent_memory_stale_v1(
+        adapter=adapter, scope=_SCOPE, limit=10, now=_NOW
+    )
+
+    assert result["source"] == "surrealdb-local"
+    assert result["adapter_status"] == "surrealdb-local"
+    assert result["schema_version"] == "memory-db-stale-scan/v1"
+    assert result["record_count"] == 2
+    assert result["fresh_count"] == 1
+    assert result["stale_count"] == 1
+    assert result["expired_count"] == 1
+    assert len(result["stale_memory_ids"]) == 1
+    assert len(result["expired_memory_ids"]) == 1
+    assert result["approval_semantics"]["read_only"] is True
+    assert result["approval_semantics"]["no_write"] is True
+
+    expired_id = result["expired_memory_ids"][0]
+    assert expired_id in result["stale_memory_ids"]
+    expired_entry = result["expired_records"][0]
+    assert expired_entry["freshness"]["is_expired"] is True
+    assert expired_entry["freshness"]["is_stale"] is True
+
+    fresh_id = generate_memory_id(
+        scope=_SCOPE,
+        namespace=_SCOPE,
+        memory_type="semantic_memory",
+        created_by="cdb-test-001",
+        content="Fresh memory for DB stale scan proof.",
+        source_refs=["docs/surrealdb/memory-reality-slice1-audit.md"],
+    )
+    assert fresh_id not in result["stale_memory_ids"]
+
+
+@pytest.mark.unit
+def test_scan_agent_memory_stale_v1_wave16_bridge_for_expired() -> None:
+    adapter = _mock_adapter([_expired_record()])
+    result = scan_agent_memory_stale_v1(
+        adapter=adapter, scope=_SCOPE, limit=5, now=_NOW
+    )
+
+    wave16 = result["wave16_memory_ttl"]
+    assert wave16["finding_count"] == 1
+    assert wave16["stale_types"] == ["memory_ttl_expired"]
+    assert len(wave16["stale_ids"]) == 1
+
+
+@pytest.mark.unit
+def test_scan_agent_memory_stale_v1_strips_db_metadata() -> None:
+    adapter = _mock_adapter([_fresh_record()])
+    result = scan_agent_memory_stale_v1(
+        adapter=adapter, scope=_SCOPE, limit=5, now=_NOW
+    )
+    record = result["stale_records"]  # empty
+    assert record == []
+    # all records are fresh — check via record_count
+    assert result["record_count"] == 1
+    # No stale_records but we loaded one row — verify no metadata in query path
+    adapter.execute.assert_called_once()
+
+
+@pytest.mark.unit
+def test_scan_agent_memory_stale_v1_builds_scope_filter_query() -> None:
+    adapter = _mock_adapter([])
+    scan_agent_memory_stale_v1(adapter=adapter, scope=_SCOPE, limit=3, now=_NOW)
+    adapter.execute.assert_called_once_with(
+        f"SELECT * FROM agent_memory WHERE scope = '{_SCOPE}' LIMIT 3"
+    )
+
+
+@pytest.mark.unit
+def test_scan_agent_memory_stale_v1_unsafe_scope_rejected() -> None:
+    adapter = _mock_adapter([])
+    with pytest.raises(ValueError, match="not safe for SurrealQL"):
+        scan_agent_memory_stale_v1(
+            adapter=adapter,
+            scope="scope'; DROP TABLE agent_memory; --",
+            now=_NOW,
+        )
+
+
+@pytest.mark.unit
+def test_scan_agent_memory_stale_v1_contract_violation_fail_closed() -> None:
+    bad = _fresh_record()
+    bad["memory_id"] = "00000000-0000-0000-0000-000000000001"
+    adapter = _mock_adapter([bad])
+    with pytest.raises(MemoryContractError, match="memory_id mismatch"):
+        scan_agent_memory_stale_v1(adapter=adapter, scope=_SCOPE, now=_NOW)
+
+
+@pytest.mark.unit
+def test_wave16_bundle_path_unchanged_on_empty_bundle() -> None:
+    """Regression: Wave-16 bundle scan unchanged (no DB coupling)."""
+    result = scan_stale_knowledge_v1({}, as_of=_NOW.isoformat())
+    assert result.total_count == 0
+    assert result.blocking_count == 0

--- a/tools/surrealdb/memory_db_stale_scan.py
+++ b/tools/surrealdb/memory_db_stale_scan.py
@@ -1,0 +1,218 @@
+"""DB-backed agent_memory stale/expired scan — #2702 Wave-16 runtime gap.
+
+Read-only scan that loads ``agent_memory`` rows from a local SurrealDB adapter,
+classifies freshness via ``classify_memory_freshness``, and surfaces stale/expired
+memory IDs with optional Wave-16 ``memory_ttl_expired`` findings.
+
+No writes. No MCP registry changes. No live trading scope.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any, Mapping, Protocol
+
+from core.utils.clock import utcnow as cdb_utcnow
+from tools.mcp.surrealdb_adapter_factory import adapter_source
+from tools.surrealdb.memory_contract import (
+    MemoryContractError,
+    MemoryFreshness,
+    SCHEMA_VERSION as MEMORY_CONTRACT_SCHEMA_VERSION,
+    classify_memory_freshness,
+    validate_memory_record,
+)
+from tools.surrealdb.stale_knowledge_scan import scan_stale_knowledge_v1
+
+SCAN_SCHEMA_VERSION = "memory-db-stale-scan/v1"
+
+_SURQL_SAFE_RE = re.compile(r"^[a-zA-Z0-9/_.@:#+ \-]+$")
+
+_DB_STRIP_FIELDS = frozenset(
+    {
+        "run_id",
+        "schema_version",
+        "id",
+        "sensitivity",
+    }
+)
+
+
+class MemoryProofAdapter(Protocol):
+    """Minimal adapter surface required for DB stale scan."""
+
+    status: str
+
+    def execute(self, query: str) -> list[dict[str, Any]]: ...
+
+
+def _safe_surql_str(value: str | None) -> str | None:
+    if not value:
+        return None
+    text = value.strip()
+    return text if (text and _SURQL_SAFE_RE.match(text)) else None
+
+
+def _strip_db_metadata(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: value for key, value in dict(row).items() if key not in _DB_STRIP_FIELDS
+    }
+
+
+def _serialize_freshness(freshness: MemoryFreshness) -> dict[str, Any]:
+    return {
+        "is_fresh": freshness.is_fresh,
+        "is_stale": freshness.is_stale,
+        "is_expired": freshness.is_expired,
+        "reasons": list(freshness.reasons),
+    }
+
+
+def _resolve_now(now: datetime | None) -> datetime:
+    effective = now if now is not None else cdb_utcnow()
+    if effective.tzinfo is None:
+        return effective.replace(tzinfo=timezone.utc)
+    return effective.astimezone(timezone.utc)
+
+
+def _wave16_memory_ttl_findings(
+    *,
+    expired_records: list[dict[str, Any]],
+    as_of: str,
+) -> dict[str, Any]:
+    """Bridge expired DB rows into Wave-16 memory_ttl_expired findings (read-only)."""
+    memory_records = [
+        {
+            "memory_id": item["record"]["memory_id"],
+            "expires_at": item["record"].get("expires_at"),
+            "scope": item["record"].get("scope"),
+        }
+        for item in expired_records
+        if item["record"].get("expires_at")
+    ]
+    if not memory_records:
+        return {
+            "finding_count": 0,
+            "stale_ids": [],
+            "stale_types": [],
+        }
+
+    scan_result = scan_stale_knowledge_v1(
+        {"memory_records": memory_records},
+        as_of=as_of,
+    )
+    memory_findings = [
+        f
+        for f in scan_result.findings
+        if f.stale_type == "memory_ttl_expired"
+    ]
+    return {
+        "finding_count": len(memory_findings),
+        "stale_ids": [f.stale_id for f in memory_findings],
+        "stale_types": sorted({f.stale_type for f in memory_findings}),
+    }
+
+
+def scan_agent_memory_stale_v1(
+    *,
+    adapter: MemoryProofAdapter,
+    scope: str,
+    limit: int = 200,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Scan DB-backed agent_memory rows for stale/expired state (read-only).
+
+    Args:
+        adapter: Read-only query adapter (typically ``SurrealDBLocalQueryAdapter``).
+        scope: Exact scope filter for ``SELECT * FROM agent_memory``.
+        limit: Maximum rows to load (1..10000).
+        now: Reference instant for freshness classification (UTC).
+
+    Returns:
+        Structured scan bundle with stale/expired counts, memory IDs, and optional
+        Wave-16 ``memory_ttl_expired`` bridge findings.
+
+    Raises:
+        MemoryContractError: Invalid limit or contract violation on any row.
+        ValueError: When scope cannot be safely embedded in SurrealQL.
+    """
+    safe_scope = _safe_surql_str(scope)
+    if not safe_scope:
+        raise ValueError(f"scope is not safe for SurrealQL embedding: {scope!r}")
+
+    if limit < 1 or limit > 10_000:
+        raise MemoryContractError("limit must be within 1..10000")
+
+    ref_now = _resolve_now(now)
+    as_of = ref_now.isoformat()
+    source = adapter_source(adapter)
+
+    query = f"SELECT * FROM agent_memory WHERE scope = '{safe_scope}' LIMIT {limit}"
+    raw_rows = adapter.execute(query)
+
+    all_records: list[dict[str, Any]] = []
+    stale_records: list[dict[str, Any]] = []
+    expired_records: list[dict[str, Any]] = []
+    stale_memory_ids: list[str] = []
+    expired_memory_ids: list[str] = []
+
+    for raw_row in raw_rows:
+        if not isinstance(raw_row, Mapping):
+            continue
+        stripped = _strip_db_metadata(raw_row)
+        validated = validate_memory_record(stripped, strict=False)
+        freshness = classify_memory_freshness(validated, now=ref_now)
+        entry = {
+            "record": validated,
+            "freshness": _serialize_freshness(freshness),
+        }
+        all_records.append(entry)
+        if freshness.is_stale:
+            stale_records.append(entry)
+            stale_memory_ids.append(validated["memory_id"])
+        if freshness.is_expired:
+            expired_records.append(entry)
+            expired_memory_ids.append(validated["memory_id"])
+
+    fresh_count = len(all_records) - len(stale_records)
+    wave16 = _wave16_memory_ttl_findings(
+        expired_records=expired_records,
+        as_of=as_of,
+    )
+
+    limitations = [
+        "read_only_scan_no_writes",
+        "db_metadata_fields_stripped_before_validation",
+        "strict_false_allows_importer_only_fields_when_present",
+        "wave16_bridge_uses_memory_ttl_expired_only_for_expired_rows_with_expires_at",
+    ]
+
+    return {
+        "schema_version": SCAN_SCHEMA_VERSION,
+        "memory_contract_schema_version": MEMORY_CONTRACT_SCHEMA_VERSION,
+        "source": source,
+        "adapter_status": adapter.status,
+        "scope": safe_scope,
+        "as_of": as_of,
+        "record_count": len(all_records),
+        "fresh_count": fresh_count,
+        "stale_count": len(stale_records),
+        "expired_count": len(expired_records),
+        "stale_memory_ids": stale_memory_ids,
+        "expired_memory_ids": expired_memory_ids,
+        "stale_records": stale_records,
+        "expired_records": expired_records,
+        "wave16_memory_ttl": wave16,
+        "limitations": limitations,
+        "approval_semantics": {
+            "read_only": True,
+            "no_write": True,
+            "no_approval": True,
+            "no_live_go": True,
+            "no_echtgeld_go": True,
+            "note": (
+                "DB-backed stale/expired memory scan only. Stale detection is signal, "
+                "not authorization. No write. No Human-GO."
+            ),
+        },
+    }

--- a/tools/surrealdb/memory_db_stale_scan.py
+++ b/tools/surrealdb/memory_db_stale_scan.py
@@ -102,9 +102,7 @@ def _wave16_memory_ttl_findings(
         as_of=as_of,
     )
     memory_findings = [
-        f
-        for f in scan_result.findings
-        if f.stale_type == "memory_ttl_expired"
+        f for f in scan_result.findings if f.stale_type == "memory_ttl_expired"
     ]
     return {
         "finding_count": len(memory_findings),


### PR DESCRIPTION
## Summary

- Add read-only `scan_agent_memory_stale_v1` (`memory-db-stale-scan/v1`) that SELECTs `agent_memory` rows by scope, classifies freshness via existing contract helpers, and aggregates stale/expired IDs with optional Wave-16 `memory_ttl_expired` bridge.
- Add CI-safe unit tests (mock adapter) and opt-in `local_only` proof test reusing the Slice-4 memory DB proof harness.
- Document the DB-backed scan in the stale-knowledge runbook; Wave-16 bundle-only path unchanged.

Refs #2702
Refs #2606

## Delivered

- `tools/surrealdb/memory_db_stale_scan.py` — read-only stale/expired scan proof
- `tests/unit/surrealdb/test_memory_db_stale_scan.py` — fresh/expired partitioning, fail-closed, regression
- `tests/local/surrealdb/test_memory_db_stale_scan.py` — local smoke behind `CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE=1`
- `docs/surrealdb/stale-knowledge-runbook.md` — §3.1.1 DB-backed scan note

## Validation

- `pytest tests/unit/surrealdb/test_memory_db_stale_scan.py -v` — 7 passed
- `ruff check tools/surrealdb/memory_db_stale_scan.py tests/unit/surrealdb/test_memory_db_stale_scan.py tests/local/surrealdb/test_memory_db_stale_scan.py` — pass
- `pytest tests/unit/surrealdb/test_stale_knowledge_scan.py -v` — regression (bundle path unchanged)

## Local-only evidence

With `CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE=1`:

- `test_memory_db_stale_scan_finds_fresh_and_expired` — PASS
- `record_count=2`, `fresh_count=1`, `stale_count=1`, `expired_count=1`
- `source=surrealdb-local`
- Wave-16 bridge: `memory_ttl_expired` finding_count=1 for expired fixture row

## Explicitly not included

- MCP `cdb_context_stale` adapter mode
- DB writes / UPSERT / DELETE in scan code
- Changes to `stale_knowledge_scan.py` bundle API
- BLUE/RED, LR artifacts, #2606 closure

**LR remains NO-GO.** **#2606 remains OPEN.**

## Test plan

- [x] Unit tests pass in CI (mock adapter, no live DB)
- [x] Local smoke with seeded fresh+expired pair (operator opt-in)
- [ ] CI `ci (Unit/Integration + Lint gesammelt)` green
- [ ] `policy-gate` green
