### PR TITLE
feat(surrealdb): add memory write path v1 audit contract

### DIFF
--- a/docs/surrealdb/audit-observation-model-v1.md
+++ b/docs/surrealdb/audit-observation-model-v1.md
@@ -50,7 +50,7 @@ menschliche Review oder gesteuerte Agenten-Folgearbeit — **keine autonomen Akt
 
 ## 3. Typ-Katalog (`observation_type`)
 
-Exakt 8 kanonische Typen. Kein freier String außerhalb dieses Katalogs.
+Exakt 9 kanonische Typen. Kein freier String außerhalb dieses Katalogs.
 
 | Typ | Beschreibung | Typischer Severity |
 |---|---|---|
@@ -62,6 +62,7 @@ Exakt 8 kanonische Typen. Kein freier String außerhalb dieses Katalogs.
 | `decision_without_evidence` | `decision_event` ohne `evidence_refs` und ohne `human_go` | `warning` / `blocking` |
 | `conflicting_decision` | Zwei `decision_event`-Records mit widersprüchlichen Antworten ohne Supersession-Chain | `warning` / `blocking` |
 | `scope_risk` | Erkannte Scope-Drift oder Scope-Überschreitung ohne autorisierte Erweiterung | `warning` / `blocking` |
+| `memory_write_gate_evaluation` | Human-GO memory write gate evaluation (dry-run or blocked) | `info` / `blocking` |
 
 ---
 
@@ -111,7 +112,7 @@ Enforcement kommt in einem späteren Schema-Version (v1+).
 | A4 | Kein Runtime-Write als direkte Folge einer Observation. |
 | A5 | Kein Memory-Write als direkte Folge einer Observation. |
 | A6 | Keine automatische Issue-Erzeugung auf GitHub. |
-| A7 | `observation_type` muss aus dem 8-Typen-Katalog (§3) stammen. |
+| A7 | `observation_type` muss aus dem 9-Typen-Katalog (§3) stammen. |
 | A8 | `severity` muss aus dem 3-Werte-Katalog (§4) stammen. |
 | A9 | `status` muss aus dem 4-Werte-Katalog (§5) stammen. |
 | A10 | Observations werden nicht gelöscht — `status: superseded` oder `resolved` für Ablösung. |

--- a/docs/surrealdb/memory-reality-slice1-audit.md
+++ b/docs/surrealdb/memory-reality-slice1-audit.md
@@ -572,6 +572,37 @@ Proven (local, opt-in): gated UPSERT → `prove_agent_memory_db_read_v1` scope m
 
 ---
 
+## 21. Slice 7 addendum — Memory Write Path v1 (#2703)
+
+**Delivered:** operator orchestration, audit_observation materialization, local audit persist (env-gated), runbook. No `agent_memory` write via path v1. `PERSIST_ALLOWED` unchanged.
+
+### 21.1 Modules
+
+| Artifact | Role |
+| --- | --- |
+| `tools/surrealdb/memory_write_path_v1.py` | `run_memory_write_path_v1()` dry_run + audit_persist_local |
+| `tools/surrealdb/audit_observation_from_gate.py` | Gate audit → `audit_observation` row |
+| `docs/surrealdb/memory-write-path-v1-runbook.md` | Operator runbook + evidence template |
+
+### 21.2 Tests
+
+| File | Marker | CI |
+| --- | --- | --- |
+| `tests/unit/surrealdb/test_memory_write_path_v1.py` | `unit` | yes |
+| `tests/unit/surrealdb/test_audit_observation_from_gate.py` | `unit` | yes |
+
+Proven: dry_run zero SQL; audit persist env-gated; blocked without GO; no raw token in gate envelope; audit_observation UPSERT only.
+
+### 21.3 Remaining gaps after Slice 7
+
+| Gap | Follow-up |
+| --- | --- |
+| MCP write surface (dry-run intent tool) | #2704 |
+| Parent closure audit | #2705 |
+| Productive memory write / PERSIST_ALLOWED flip | Separate maintainer GO |
+
+---
+
 ## Provenance
 
 | Source | Role |

--- a/docs/surrealdb/memory-write-gate-v1.md
+++ b/docs/surrealdb/memory-write-gate-v1.md
@@ -154,6 +154,33 @@ pytest tests/local/surrealdb/test_memory_db_write_smoke.py -q
 
 ---
 
+## 9. Write Path v1 — operator orchestration (#2703)
+
+**Issue**: [#2703](https://github.com/jannekbuengener/Claire_de_Binare/issues/2703)  
+**Status**: Dry-run default; optional localhost `audit_observation` persist.
+
+| Artifact | Path |
+| --- | --- |
+| Write path orchestrator | `tools/surrealdb/memory_write_path_v1.py` |
+| Audit materializer | `tools/surrealdb/audit_observation_from_gate.py` |
+| Operator runbook | `docs/surrealdb/memory-write-path-v1-runbook.md` |
+| Unit tests | `tests/unit/surrealdb/test_memory_write_path_v1.py` |
+
+Properties:
+
+- Default mode `dry_run`: gate evaluation only, zero SQL
+- `audit_persist_local` requires `CDB_PERSIST_MEMORY_WRITE_GATE_AUDIT=1` plus gate pass
+- Persists **audit_observation only** — never `agent_memory`
+- `PERSIST_ALLOWED` unchanged (`False`)
+
+Validation:
+
+```bash
+pytest tests/unit/surrealdb/test_memory_write_path_v1.py tests/unit/surrealdb/test_audit_observation_from_gate.py -v
+```
+
+---
+
 ## Provenance
 
 | Source | Role |

--- a/docs/surrealdb/memory-write-path-v1-runbook.md
+++ b/docs/surrealdb/memory-write-path-v1-runbook.md
@@ -1,0 +1,114 @@
+# Memory Write Path v1 — Operator Runbook
+
+**Issue**: [#2703](https://github.com/jannekbuengener/Claire_de_Binare/issues/2703)  
+**Parent**: [#2606](https://github.com/jannekbuengener/Claire_de_Binare/issues/2606)  
+**Status**: Gated operator path (dry-run default; local audit persist opt-in)  
+**Guardrail**: No productive `agent_memory` write. LR remains NO-GO.
+
+---
+
+## 1. Purpose
+
+Provide a repeatable, audited operator surface for memory write **intent**
+evaluation. The path wraps [`memory_write_gate.py`](../../tools/surrealdb/memory_write_gate.py)
+and optionally persists gate evaluations to `audit_observation` on localhost only.
+
+This path does **not** replace Slice 6 local write smoke (`memory_db_write_smoke.py`)
+for `agent_memory` UPSERT proof.
+
+---
+
+## 2. Surface boundaries
+
+| Surface | Role | Writes |
+| --- | --- | --- |
+| `memory_write_gate.py` | Human-GO gate evaluation | None |
+| `memory_write_path_v1.py` (this runbook) | Operator orchestration | `audit_observation` only (opt-in local) |
+| `memory_db_write_smoke.py` | Slice 6 local smoke | `evidence_ref` + `agent_memory` (separate GO) |
+| `context_importer.py` | Bulk import | Out of scope; not default write path |
+
+`PERSIST_ALLOWED` in `memory_write_gate.py` remains **`False`**.
+
+---
+
+## 3. Modes
+
+| Mode | SQL | Env required |
+| --- | --- | --- |
+| `dry_run` (default) | None | None |
+| `audit_persist_local` | UPSERT one `audit_observation` | `CDB_PERSIST_MEMORY_WRITE_GATE_AUDIT=1` |
+
+Both modes require valid Human-GO authorization for gate pass. Blocked gate → no SQL.
+
+---
+
+## 4. Operator prerequisites
+
+1. Explicit maintainer Human-GO for the scoped write intent (issue-linked).
+2. Valid `MemoryWriteAuthorization` with `human_go_token` matching `GO-YYYY-MM-DD[-suffix]`.
+3. Token supplied via secure env (e.g. `CDB_MEMORY_WRITE_HUMAN_GO_TOKEN`) — **never log raw token**.
+4. Local SurrealDB at `127.0.0.1:8010` only when using `audit_persist_local`.
+5. Run-scoped cleanup for any local audit rows (DELETE by `observation_id`).
+
+---
+
+## 5. Environment variables
+
+| Variable | Required for | Notes |
+| --- | --- | --- |
+| `CDB_MEMORY_WRITE_HUMAN_GO_TOKEN` | Operator auth assembly | Never log; not serialized in audit rows |
+| `CDB_PERSIST_MEMORY_WRITE_GATE_AUDIT` | `audit_persist_local` | Must be `1`; orthogonal to Slice 6 write flag |
+| `CDB_RUN_REAL_SURREALDB_MEMORY_WRITE` | Slice 6 smoke only | Not used by write path v1 |
+
+---
+
+## 6. Evidence pack template
+
+Session evidence for a write-path operator run should include:
+
+```text
+- Date/time (UTC)
+- Git commit SHA
+- Issue ref (#2703 / #2606)
+- Mode: dry_run | audit_persist_local
+- gate_status (blocked_* | approved_dry_run)
+- path_status (evaluated_only | audit_persisted_local)
+- observation_id (if audit persist)
+- memory_id (if known)
+- pytest unit evidence (paths below)
+- Explicit: no agent_memory write via path v1
+- LR: NO-GO unchanged
+```
+
+---
+
+## 7. Validation (CI-safe)
+
+```bash
+pytest tests/unit/surrealdb/test_memory_write_path_v1.py -v
+pytest tests/unit/surrealdb/test_audit_observation_from_gate.py -v
+pytest tests/unit/surrealdb/test_memory_write_gate.py -v
+ruff check tools/surrealdb/memory_write_path_v1.py tools/surrealdb/audit_observation_from_gate.py
+```
+
+---
+
+## 8. subject_ref convention (v0-draft)
+
+When `memory_id` is known, materialized rows use:
+
+`subject_ref = agent_memory:{memory_id}`
+
+When blocked before contract validation, fallback:
+
+`subject_ref = audit_observation:unknown_subject`
+
+---
+
+## Provenance
+
+| Source | Role |
+| --- | --- |
+| `docs/surrealdb/memory-write-gate-v1.md` | Gate contract |
+| `docs/surrealdb/audit-observation-model-v1.md` | Observation type catalog |
+| `tools/surrealdb/memory_write_path_v1.py` | Implementation |

--- a/tests/unit/surrealdb/test_audit_observation_from_gate.py
+++ b/tests/unit/surrealdb/test_audit_observation_from_gate.py
@@ -1,0 +1,82 @@
+"""Unit tests for audit_observation_from_gate — #2703."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tools.surrealdb.audit_observation_from_gate import (
+    AuditObservationMaterializeError,
+    audit_observation_row_is_redacted,
+    materialize_audit_observation_from_gate,
+)
+from tools.surrealdb.memory_write_gate import (
+    MemoryWriteAuthorization,
+    evaluate_memory_write_gate,
+)
+
+FIXED_NOW = datetime(2026, 5, 29, 15, 0, 0, tzinfo=timezone.utc)
+
+
+def _valid_record(**overrides) -> dict:
+    base: dict = {
+        "scope": "agent:TEST/cursor",
+        "namespace": "session",
+        "memory_type": "working_memory",
+        "content": "Test memory content for path v1",
+        "source_refs": ["docs/AGENTS.md@abc123"],
+        "evidence_refs": ["ev-001"],
+        "confidence": 0.9,
+        "ttl": 3600,
+        "expires_at": "2026-05-30T00:00:00+00:00",
+        "created_by": "cursor-agent-v1",
+        "created_at": "2026-05-29T04:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_auth(**overrides) -> MemoryWriteAuthorization:
+    base = dict(
+        human_go_token="GO-2026-05-29-pathv1",
+        authorized_by="jannekbuengener",
+        authorized_at="2026-05-29T15:00:00+00:00",
+        scope="agent:TEST/cursor",
+        target_issue="2703",
+        evidence_refs=("github:issue/2703",),
+        operation="create",
+    )
+    base.update(overrides)
+    return MemoryWriteAuthorization(**base)
+
+
+@pytest.mark.unit
+def test_materialize_maps_required_fields() -> None:
+    envelope = evaluate_memory_write_gate(_valid_record(), _valid_auth(), now=FIXED_NOW)
+    row = materialize_audit_observation_from_gate(envelope, now=FIXED_NOW)
+    assert row["observation_type"] == "memory_write_gate_evaluation"
+    assert row["status"] == "open"
+    assert row["severity"] == "info"
+    assert row["observation_id"] == envelope["audit"]["observation_id"]
+    assert row["subject_ref"].startswith("agent_memory:")
+    assert audit_observation_row_is_redacted(row)
+
+
+@pytest.mark.unit
+def test_materialize_blocked_gate() -> None:
+    envelope = evaluate_memory_write_gate(_valid_record(), None, now=FIXED_NOW)
+    row = materialize_audit_observation_from_gate(envelope, now=FIXED_NOW)
+    assert row["severity"] == "blocking"
+    assert row["subject_ref"] == "audit_observation:unknown_subject"
+
+
+@pytest.mark.unit
+def test_materialize_rejects_forbidden_audit_key() -> None:
+    envelope = evaluate_memory_write_gate(_valid_record(), _valid_auth(), now=FIXED_NOW)
+    bad = dict(envelope)
+    audit = dict(bad["audit"])
+    audit["human_go_token"] = "GO-2026-05-29-secret"
+    bad["audit"] = audit
+    with pytest.raises(AuditObservationMaterializeError, match="forbidden"):
+        materialize_audit_observation_from_gate(bad, now=FIXED_NOW)

--- a/tests/unit/surrealdb/test_memory_write_gate.py
+++ b/tests/unit/surrealdb/test_memory_write_gate.py
@@ -5,6 +5,7 @@ No DB. No MCP. No persistence. Harness must not invoke write executors.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
@@ -173,3 +174,13 @@ def test_harness_does_not_call_write_executor_on_pass() -> None:
         now=FIXED_NOW,
     )
     executor.assert_not_called()
+
+
+@pytest.mark.unit
+def test_envelope_never_contains_raw_human_go_token() -> None:
+    token = "GO-2026-05-29-slice5-secret"
+    auth = _valid_auth(human_go_token=token)
+    result = evaluate_memory_write_gate(_valid_record(), auth, now=FIXED_NOW)
+    serialized = json.dumps(result, default=str)
+    assert token not in serialized
+    assert '"human_go_token"' not in serialized

--- a/tests/unit/surrealdb/test_memory_write_path_v1.py
+++ b/tests/unit/surrealdb/test_memory_write_path_v1.py
@@ -1,0 +1,177 @@
+"""Unit tests for memory_write_path_v1 — #2703."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.surrealdb.memory_write_gate import (
+    PERSIST_ALLOWED,
+    MemoryWriteAuthorization,
+)
+from tools.surrealdb.memory_write_path_v1 import (
+    AUDIT_PERSIST_ENV_VAR,
+    MemoryWritePathError,
+    audit_persist_env_enabled,
+    run_memory_write_path_v1,
+)
+
+FIXED_NOW = datetime(2026, 5, 29, 15, 30, 0, tzinfo=timezone.utc)
+
+
+def _valid_record(**overrides) -> dict:
+    base: dict = {
+        "scope": "memory_write_path:abc123",
+        "namespace": "memory_write_path:abc123",
+        "memory_type": "semantic_memory",
+        "content": "Path v1 unit test record.",
+        "source_refs": ["docs/surrealdb/memory-write-path-v1-runbook.md"],
+        "evidence_refs": ["ev-path-001"],
+        "confidence": 0.9,
+        "ttl": 86400,
+        "expires_at": "2026-05-30T10:00:00Z",
+        "created_by": "cdb-test-001",
+        "created_at": "2026-05-29T10:00:00Z",
+    }
+    base.update(overrides)
+    from tools.surrealdb.memory_contract import generate_memory_id
+
+    base["memory_id"] = generate_memory_id(
+        scope=base["scope"],
+        namespace=base["namespace"],
+        memory_type=base["memory_type"],
+        created_by=base["created_by"],
+        content=base["content"],
+        source_refs=base["source_refs"],
+    )
+    return base
+
+
+def _valid_auth(**overrides) -> MemoryWriteAuthorization:
+    base = dict(
+        human_go_token="GO-2026-05-29-pathv1",
+        authorized_by="jannekbuengener",
+        authorized_at="2026-05-29T15:30:00+00:00",
+        scope="memory_write_path:abc123",
+        target_issue="2703",
+        evidence_refs=("github:issue/2703",),
+        operation="create",
+    )
+    base.update(overrides)
+    return MemoryWriteAuthorization(**base)
+
+
+def _mock_sql() -> MagicMock:
+    client = MagicMock()
+    client.record_exists.return_value = False
+    return client
+
+
+@pytest.mark.unit
+def test_persist_allowed_unchanged() -> None:
+    assert PERSIST_ALLOWED is False
+
+
+@pytest.mark.unit
+def test_dry_run_no_sql_calls() -> None:
+    sql = _mock_sql()
+    result = run_memory_write_path_v1(
+        _valid_record(),
+        _valid_auth(),
+        mode="dry_run",
+        sql_client=sql,
+        now=FIXED_NOW,
+    )
+    assert result["path_status"] == "evaluated_only"
+    assert result["gate_status"] == "approved_dry_run"
+    sql.upsert_create.assert_not_called()
+
+
+@pytest.mark.unit
+def test_blocked_without_authorization() -> None:
+    sql = _mock_sql()
+    result = run_memory_write_path_v1(
+        _valid_record(),
+        None,
+        mode="dry_run",
+        sql_client=sql,
+        now=FIXED_NOW,
+    )
+    assert result["gate_status"] == "blocked_no_authorization"
+    sql.upsert_create.assert_not_called()
+
+
+@pytest.mark.unit
+def test_audit_persist_blocked_without_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(AUDIT_PERSIST_ENV_VAR, raising=False)
+    sql = _mock_sql()
+    with pytest.raises(MemoryWritePathError, match=AUDIT_PERSIST_ENV_VAR):
+        run_memory_write_path_v1(
+            _valid_record(),
+            _valid_auth(),
+            mode="audit_persist_local",
+            sql_client=sql,
+            now=FIXED_NOW,
+        )
+    sql.upsert_create.assert_not_called()
+
+
+@pytest.mark.unit
+def test_audit_persist_blocked_when_gate_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(AUDIT_PERSIST_ENV_VAR, "1")
+    sql = _mock_sql()
+    with pytest.raises(MemoryWritePathError, match="gate_status"):
+        run_memory_write_path_v1(
+            _valid_record(),
+            None,
+            mode="audit_persist_local",
+            sql_client=sql,
+            now=FIXED_NOW,
+        )
+    sql.upsert_create.assert_not_called()
+
+
+@pytest.mark.unit
+def test_audit_persist_writes_one_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(AUDIT_PERSIST_ENV_VAR, "1")
+    sql = _mock_sql()
+    seen: set[str] = set()
+
+    def record_exists(table: str, raw_id: str, *, id_field: str) -> bool:
+        return raw_id in seen
+
+    def upsert_create(table: str, record_id: str, payload: dict) -> None:
+        seen.add(record_id)
+
+    sql.record_exists.side_effect = record_exists
+    sql.upsert_create.side_effect = upsert_create
+    result = run_memory_write_path_v1(
+        _valid_record(),
+        _valid_auth(),
+        mode="audit_persist_local",
+        sql_client=sql,
+        now=FIXED_NOW,
+    )
+    assert result["path_status"] == "audit_persisted_local"
+    assert result["tables_written"] == ["audit_observation"]
+    assert result["audit_observation"]["observation_type"] == (
+        "memory_write_gate_evaluation"
+    )
+    sql.upsert_create.assert_called_once()
+    assert sql.upsert_create.call_args.args[0] == "audit_observation"
+
+
+@pytest.mark.unit
+def test_audit_persist_env_disabled_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(AUDIT_PERSIST_ENV_VAR, raising=False)
+    assert audit_persist_env_enabled() is False

--- a/tools/surrealdb/audit_observation_from_gate.py
+++ b/tools/surrealdb/audit_observation_from_gate.py
@@ -1,0 +1,144 @@
+"""Map memory write gate audit blocks to audit_observation records — #2703.
+
+Fail-closed materialization only. No persistence in this module.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+OBSERVATION_TYPE_MEMORY_WRITE_GATE = "memory_write_gate_evaluation"
+AUDIT_OBSERVATION_SCHEMA_VERSION = "audit-observation-from-gate/v1"
+
+_FORBIDDEN_KEYS = frozenset({"human_go_token", "human_go"})
+_SUBJECT_REF_RE = re.compile(r"^agent_memory:[a-zA-Z0-9/_\-.]+$")
+
+
+class AuditObservationMaterializeError(ValueError):
+    """Raised when a gate audit block cannot be materialized safely."""
+
+
+def _parse_observed_at(value: str | None, fallback: datetime | None) -> datetime:
+    if isinstance(value, str) and value.strip():
+        text = value.strip()
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(text)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    effective = fallback if fallback is not None else cdb_utcnow()
+    if effective.tzinfo is None:
+        return effective.replace(tzinfo=timezone.utc)
+    return effective.astimezone(timezone.utc)
+
+
+def _subject_ref_from_memory_id(memory_id: str | None) -> str | None:
+    if not memory_id or not str(memory_id).strip():
+        return None
+    cleaned = str(memory_id).strip()
+    subject = f"agent_memory:{cleaned}"
+    if not _SUBJECT_REF_RE.match(subject):
+        raise AuditObservationMaterializeError(
+            f"memory_id is not safe for subject_ref: {memory_id!r}"
+        )
+    return subject
+
+
+def materialize_audit_observation_from_gate(
+    gate_envelope: Mapping[str, Any],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build an audit_observation row dict from a memory write gate envelope.
+
+    Never includes raw human_go_token. Raises on forbidden keys in audit block.
+    """
+    audit = gate_envelope.get("audit")
+    if not isinstance(audit, Mapping):
+        raise AuditObservationMaterializeError("gate envelope missing audit block")
+
+    for key in _FORBIDDEN_KEYS:
+        if key in audit:
+            raise AuditObservationMaterializeError(
+                f"audit block must not contain forbidden key: {key}"
+            )
+
+    observation_id = audit.get("observation_id")
+    if not isinstance(observation_id, str) or not observation_id.strip():
+        raise AuditObservationMaterializeError("audit.observation_id is required")
+
+    observation_type = audit.get("observation_type")
+    if observation_type != OBSERVATION_TYPE_MEMORY_WRITE_GATE:
+        raise AuditObservationMaterializeError(
+            "audit.observation_type must be memory_write_gate_evaluation"
+        )
+
+    severity = audit.get("severity")
+    if severity not in {"info", "warning", "blocking"}:
+        raise AuditObservationMaterializeError(
+            f"audit.severity invalid for audit_observation: {severity!r}"
+        )
+
+    message = audit.get("message")
+    if not isinstance(message, str) or not message.strip():
+        raise AuditObservationMaterializeError("audit.message is required")
+
+    observed_by = audit.get("observed_by")
+    if not isinstance(observed_by, str) or not observed_by.strip():
+        raise AuditObservationMaterializeError("audit.observed_by is required")
+
+    observed_at = _parse_observed_at(
+        audit.get("observed_at") if isinstance(audit.get("observed_at"), str) else None,
+        now,
+    )
+
+    memory_id = gate_envelope.get("memory_id")
+    if memory_id is None:
+        subject_ref = audit.get("subject_ref")
+    else:
+        subject_ref = _subject_ref_from_memory_id(str(memory_id))
+
+    if subject_ref is None:
+        subject_ref = "audit_observation:unknown_subject"
+
+    evidence_refs = audit.get("evidence_refs")
+    if not isinstance(evidence_refs, list):
+        evidence_refs = []
+
+    related_memory = audit.get("related_memory")
+    if not isinstance(related_memory, list):
+        related_memory = []
+
+    row: dict[str, Any] = {
+        "schema_version": AUDIT_OBSERVATION_SCHEMA_VERSION,
+        "observation_id": observation_id.strip(),
+        "observation_type": OBSERVATION_TYPE_MEMORY_WRITE_GATE,
+        "subject_ref": subject_ref,
+        "severity": severity,
+        "message": message.strip(),
+        "evidence_refs": list(evidence_refs),
+        "related_memory": list(related_memory),
+        "observed_by": observed_by.strip(),
+        "observed_at": observed_at.isoformat(),
+        "status": "open",
+        "created_at": observed_at.isoformat(),
+        "gate_status": gate_envelope.get("gate_status"),
+        "human_go_token_present": bool(audit.get("human_go_token_present")),
+    }
+    return row
+
+
+def audit_observation_row_is_redacted(row: Mapping[str, Any]) -> bool:
+    """Return True when serialized row contains no raw GO token keys or values."""
+    if _FORBIDDEN_KEYS.intersection(row.keys()):
+        return False
+    serialized = json.dumps(dict(row), default=str)
+    if '"human_go_token"' in serialized:
+        return False
+    return True

--- a/tools/surrealdb/memory_write_path_v1.py
+++ b/tools/surrealdb/memory_write_path_v1.py
@@ -1,0 +1,163 @@
+"""Memory Write Path v1 — gated operator surface with audit_observation — #2703.
+
+Orchestrates Human-GO gate evaluation and optional localhost audit_observation
+persistence. Never performs productive agent_memory writes.
+
+Guardrails:
+    - PERSIST_ALLOWED in memory_write_gate remains False (not flipped here).
+    - Default mode is dry_run (zero SQL).
+    - audit_persist_local requires env CDB_PERSIST_MEMORY_WRITE_GATE_AUDIT=1.
+    - LR remains NO-GO.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Literal, Mapping, Protocol
+
+from core.utils.clock import utcnow as cdb_utcnow
+from tools.surrealdb.audit_observation_from_gate import (
+    materialize_audit_observation_from_gate,
+)
+from tools.surrealdb.memory_write_gate import (
+    GATE_SCHEMA_VERSION,
+    MemoryWriteAuthorization,
+    PERSIST_ALLOWED,
+    evaluate_memory_write_gate,
+)
+
+WRITE_PATH_SCHEMA_VERSION = "memory-write-path/v1"
+AUDIT_PERSIST_ENV_VAR = "CDB_PERSIST_MEMORY_WRITE_GATE_AUDIT"
+
+MemoryWritePathMode = Literal["dry_run", "audit_persist_local"]
+
+
+class MemoryWritePathError(RuntimeError):
+    """Raised when write path preconditions are not met."""
+
+
+class MemoryWritePathSqlClient(Protocol):
+    """Minimal SQL client for localhost audit_observation UPSERT."""
+
+    def upsert_create(
+        self, table: str, record_id: str, payload: dict[str, Any]
+    ) -> None: ...
+
+    def record_exists(self, table: str, raw_id: str, *, id_field: str) -> bool: ...
+
+
+def audit_persist_env_enabled() -> bool:
+    return os.environ.get(AUDIT_PERSIST_ENV_VAR) == "1"
+
+
+def _parse_now(value: datetime | None) -> datetime:
+    effective = value if value is not None else cdb_utcnow()
+    if effective.tzinfo is None:
+        return effective.replace(tzinfo=timezone.utc)
+    return effective.astimezone(timezone.utc)
+
+
+def _path_envelope(
+    gate_envelope: dict[str, Any],
+    *,
+    path_status: str,
+    audit_observation: dict[str, Any] | None = None,
+    tables_written: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    limitations = list(gate_envelope.get("limitations") or [])
+    limitations.extend(
+        [
+            "memory_write_path_v1",
+            "persist_allowed_false",
+            "lr_no_go",
+            "no_agent_memory_write_in_path_v1",
+        ]
+    )
+    if path_status == "evaluated_only":
+        limitations.append("path_dry_run_only")
+    if path_status == "audit_persisted_local":
+        limitations.extend(["audit_persist_local_only", "run_scoped_cleanup_required"])
+
+    return {
+        "schema_version": WRITE_PATH_SCHEMA_VERSION,
+        "gate_schema_version": GATE_SCHEMA_VERSION,
+        "path_status": path_status,
+        "gate_status": gate_envelope.get("gate_status"),
+        "persist_allowed": PERSIST_ALLOWED,
+        "dry_run_only": True,
+        "memory_id": gate_envelope.get("memory_id"),
+        "gate": gate_envelope,
+        "audit_observation": audit_observation,
+        "tables_written": list(tables_written),
+        "limitations": limitations,
+        "approval_semantics": gate_envelope.get("approval_semantics"),
+    }
+
+
+def run_memory_write_path_v1(
+    record: Mapping[str, Any],
+    authorization: MemoryWriteAuthorization | None,
+    *,
+    mode: MemoryWritePathMode = "dry_run",
+    sql_client: MemoryWritePathSqlClient | None = None,
+    strict: bool = True,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Evaluate gate and optionally persist audit_observation on localhost.
+
+    Fail-closed: blocked gate never writes. audit_persist_local never writes
+    agent_memory.
+    """
+    ref_now = _parse_now(now)
+    gate_envelope = evaluate_memory_write_gate(
+        record,
+        authorization,
+        strict=strict,
+        now=ref_now,
+    )
+
+    if mode == "dry_run":
+        return _path_envelope(gate_envelope, path_status="evaluated_only")
+
+    if mode != "audit_persist_local":
+        raise MemoryWritePathError(f"unsupported write path mode: {mode!r}")
+
+    gate_status = gate_envelope.get("gate_status")
+    if gate_status != "approved_dry_run":
+        raise MemoryWritePathError(
+            f"audit persist blocked: gate_status={gate_status!r}"
+        )
+    if not audit_persist_env_enabled():
+        raise MemoryWritePathError(
+            f"audit persist blocked: {AUDIT_PERSIST_ENV_VAR} must be '1'"
+        )
+    if sql_client is None:
+        raise MemoryWritePathError("audit persist blocked: sql_client is required")
+
+    audit_row = materialize_audit_observation_from_gate(gate_envelope, now=ref_now)
+    observation_id = str(audit_row["observation_id"])
+
+    if sql_client.record_exists(
+        "audit_observation", observation_id, id_field="observation_id"
+    ):
+        raise MemoryWritePathError(
+            f"audit persist blocked: audit_observation already exists: {observation_id}"
+        )
+
+    sql_client.upsert_create("audit_observation", observation_id, audit_row)
+
+    if not sql_client.record_exists(
+        "audit_observation", observation_id, id_field="observation_id"
+    ):
+        raise MemoryWritePathError(
+            f"audit persist failed: audit_observation not found after write: "
+            f"{observation_id}"
+        )
+
+    return _path_envelope(
+        gate_envelope,
+        path_status="audit_persisted_local",
+        audit_observation=audit_row,
+        tables_written=("audit_observation",),
+    )


### PR DESCRIPTION
## Summary
- Add \memory_write_path_v1\ orchestrator (dry_run default, audit_persist_local env-gated)
- Add \udit_observation_from_gate\ materializer for gate audit rows
- Operator runbook, audit observation type catalog extension, Slice 7 audit addendum
- Unit tests: path, materializer, token redaction on gate envelope

## Test plan
- [x] pytest tests/unit/surrealdb/test_memory_write_path_v1.py
- [x] pytest tests/unit/surrealdb/test_audit_observation_from_gate.py
- [x] pytest tests/unit/surrealdb/test_memory_write_gate.py
- [x] ruff + black on touched files

Closes #2703
Refs #2606

LR remains NO-GO. No agent_memory productive write. PERSIST_ALLOWED stays False.