### PR TITLE
feat(mcp): design gated memory write surface dry-run default

### DIFF
--- a/docs/surrealdb/context-mcp-bridge-contract.md
+++ b/docs/surrealdb/context-mcp-bridge-contract.md
@@ -55,6 +55,7 @@ Die folgenden `cdb_context_*` Namen sind die **Ziel-/Contract-Aliase** gemäß #
 | `cdb_context_evidence_resolve` | Evidence-Referenzen auflösen | (vorgesehen) `context.evidence_resolve` | target/future (handler not present on `origin/main`) |
 | `cdb_context_decision_history` | Historische Entscheidungen abrufen | (follow-up) `cdb_context_decision_history` | target/future (not in `origin/main` context bridge) |
 | `cdb_context_memory_get` | Agent Memory State abrufen | (follow-up) `context.memory_get` | target/future (handler not present on `origin/main`) |
+| `cdb_context_memory_write_intent` | Memory write intent gate (dry-run) | `cdb_context_memory_write_intent` | dry-run exposed (#2704) |
 | `cdb_context_impact` | Auswirkungen einer Entscheidung bewerten | `cdb_context_impact` | currently exposed |
 | `cdb_context_briefing` | Strukturiertes Briefing generieren | `cdb_context_briefing` (Alias für `context.briefing`) | currently exposed |
 

--- a/docs/surrealdb/mcp-memory-write-surface-v1.md
+++ b/docs/surrealdb/mcp-memory-write-surface-v1.md
@@ -1,0 +1,59 @@
+# MCP Memory Write Surface v1 — Design (#2704)
+
+Status: Phase 1 delivered (dry-run default, mutation fail-closed)  
+Parent: [#2606](https://github.com/jannekbuengener/Claire_de_Binare/issues/2606)  
+Issue: [#2704](https://github.com/jannekbuengener/Claire_de_Binare/issues/2704)
+
+LR remains **NO-GO**. Board stage `trade-capable` does not authorize live memory
+mutation or Echtgeld operations.
+
+## Purpose
+
+Expose a gated **memory write intent** MCP tool so agents can evaluate Human-GO
+authorization and memory contract validity without executing persistence.
+
+## Tool
+
+| Field | Value |
+|-------|-------|
+| Tool ID | `cdb_context_memory_write_intent` |
+| Registry | `read_only=True` |
+| Module constant | `MUTATION_ALLOWED = False` |
+| Handler | `tools/mcp/memory_write_intent_tools.py` |
+
+## Phase 1 (this delivery)
+
+- Default path: **`evaluate_memory_write_gate()`** only (implicit dry-run).
+- Response wraps gate envelope + agent output contract fields (`memory_id`,
+  `limitations`, `metadata.source=in_memory`).
+- Mutation flags (`mutation_requested`, `execute_write`, `execute`, `persist`,
+  `audit_persist_local`) → **`mutation_blocked_by_default`**.
+- Optional `query` / `sql` / `surql` / `statement` parameters with SQL keywords
+  → **`unsafe_input`** (handler-level; record body exempt from blanket scan).
+- No SQL client, no adapter import, no `agent_memory` UPSERT.
+
+## Phase 2 (future — separate Human-GO)
+
+Not implemented in this slice:
+
+- Registry `read_only=False` for a mutation-capable tool variant.
+- Permission-guard extension for audited write execution.
+- Wiring to `memory_write_path_v1` audit persist or Slice 6 smoke paths.
+
+Any future mutation surface requires explicit operator GO, contract evidence, and
+a separate issue/PR — not implied by this design doc.
+
+## Cross-refs
+
+- Gate: [`memory_write_gate.py`](../../tools/surrealdb/memory_write_gate.py)
+- Write path v1: [`memory_write_path_v1.py`](../../tools/surrealdb/memory_write_path_v1.py)
+- Operator runbook: [`memory-write-path-v1-runbook.md`](memory-write-path-v1-runbook.md)
+- Output contract: [`memory_output_contract.py`](../../tools/mcp/memory_output_contract.py) (#2701)
+- Bridge contract: [`context-mcp-bridge-contract.md`](context-mcp-bridge-contract.md)
+
+## Validation
+
+```bash
+pytest tests/unit/tools/mcp/test_memory_write_intent_tool.py -v
+ruff check tools/mcp/memory_write_intent_tools.py tests/unit/tools/mcp/test_memory_write_intent_tool.py
+```

--- a/tests/unit/tools/mcp/test_memory_write_intent_tool.py
+++ b/tests/unit/tools/mcp/test_memory_write_intent_tool.py
@@ -1,0 +1,136 @@
+"""Unit tests for cdb_context_memory_write_intent MCP tool — #2704."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools.mcp.context_bridge import ContextBridge
+from tools.mcp.memory_output_contract import validate_memory_output_contract
+from tools.mcp.memory_write_intent_tools import (
+    MUTATION_ALLOWED,
+    TOOL_CDB_CONTEXT_MEMORY_WRITE_INTENT,
+    handle_cdb_context_memory_write_intent,
+)
+from tools.mcp.registry import ContextToolRegistry
+
+pytestmark = pytest.mark.unit
+
+
+def _valid_record(**overrides) -> dict:
+    base: dict = {
+        "scope": "agent:TEST/cursor",
+        "namespace": "session",
+        "memory_type": "working_memory",
+        "content": "Test memory content for MCP write intent",
+        "source_refs": ["docs/AGENTS.md@abc123"],
+        "evidence_refs": ["ev-001"],
+        "confidence": 0.9,
+        "ttl": 3600,
+        "expires_at": "2026-05-30T00:00:00+00:00",
+        "created_by": "cursor-agent-v1",
+        "created_at": "2026-05-29T04:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_auth() -> dict:
+    return {
+        "human_go_token": "GO-2026-05-29-slice5",
+        "authorized_by": "jannekbuengener",
+        "authorized_at": "2026-05-29T11:00:00+00:00",
+        "scope": "agent:TEST/cursor",
+        "target_issue": "2606",
+        "evidence_refs": ["github:issue/2606"],
+        "operation": "create",
+    }
+
+
+def _request(**params) -> dict:
+    return {
+        "tool": TOOL_CDB_CONTEXT_MEMORY_WRITE_INTENT,
+        "parameters": params,
+    }
+
+
+@pytest.mark.unit
+def test_mutation_allowed_is_false() -> None:
+    assert MUTATION_ALLOWED is False
+
+
+@pytest.mark.unit
+def test_default_dry_run_returns_gate_envelope() -> None:
+    response = handle_cdb_context_memory_write_intent(
+        _request(record=_valid_record(), authorization=_valid_auth())
+    )
+    assert response["status"] == "ok"
+    result = response["result"]
+    assert result["gate_status"] == "approved_dry_run"
+    assert result["gate_envelope"]["persist_allowed"] is False
+    assert result["dry_run_only"] is True
+
+
+@pytest.mark.unit
+def test_blocked_without_authorization() -> None:
+    response = handle_cdb_context_memory_write_intent(_request(record=_valid_record()))
+    assert response["status"] == "ok"
+    assert response["result"]["gate_status"] == "blocked_no_authorization"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("flag", ["mutation_requested", "execute_write", "persist"])
+def test_mutation_flag_blocked(flag: str) -> None:
+    response = handle_cdb_context_memory_write_intent(
+        _request(record=_valid_record(), **{flag: True})
+    )
+    assert response["status"] == "error"
+    assert response["error"]["code"] == "mutation_blocked_by_default"
+
+
+@pytest.mark.unit
+def test_unsafe_query_field_blocked() -> None:
+    response = handle_cdb_context_memory_write_intent(
+        _request(record=_valid_record(), query="INSERT INTO agent_memory SET foo=1")
+    )
+    assert response["status"] == "error"
+    assert response["error"]["code"] == "unsafe_input"
+
+
+@pytest.mark.unit
+def test_output_passes_memory_output_contract() -> None:
+    response = handle_cdb_context_memory_write_intent(
+        _request(record=_valid_record(), authorization=_valid_auth())
+    )
+    violations = validate_memory_output_contract(response)
+    assert violations == []
+
+
+@pytest.mark.unit
+def test_response_never_contains_raw_human_go_token() -> None:
+    response = handle_cdb_context_memory_write_intent(
+        _request(record=_valid_record(), authorization=_valid_auth())
+    )
+    serialized = json.dumps(response)
+    assert "GO-2026-05-29-slice5" not in serialized
+    assert '"human_go_token"' not in serialized
+
+
+@pytest.mark.unit
+def test_registry_read_only_consistency() -> None:
+    tool = ContextToolRegistry.get_tool(TOOL_CDB_CONTEXT_MEMORY_WRITE_INTENT)
+    assert tool is not None
+    assert tool.read_only is True
+    ContextToolRegistry.assert_read_only_consistency()
+
+
+@pytest.mark.unit
+def test_bridge_execute_dry_run_only() -> None:
+    bridge = ContextBridge()
+    response = bridge.execute_tool(
+        TOOL_CDB_CONTEXT_MEMORY_WRITE_INTENT,
+        {"record": _valid_record(), "authorization": _valid_auth()},
+    )
+    assert response["status"] == "ok"
+    assert response["result"]["gate_status"] == "approved_dry_run"

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -2811,6 +2811,18 @@ def cdb_context_memory_get_handler(**kwargs) -> dict[str, Any]:
     return handle_cdb_context_memory_get(kwargs)
 
 
+def cdb_context_memory_write_intent_handler(**kwargs) -> dict[str, Any]:
+    """Read-only MCP handler for cdb_context_memory_write_intent (#2704).
+
+    Dry-run gate evaluation only. Fail-closed on mutation flags. No DB/network/write.
+    """
+    from tools.mcp.memory_write_intent_tools import (
+        handle_cdb_context_memory_write_intent,
+    )
+
+    return handle_cdb_context_memory_write_intent(kwargs)
+
+
 def cdb_context_trust_summary_handler(**kwargs) -> dict[str, Any]:
     """Read-only MCP handler for cdb_context_trust_summary.
 
@@ -3106,6 +3118,7 @@ class ContextBridge:
             "cdb_context_evidence_resolve": cdb_context_evidence_resolve_handler,
             "cdb_context_claim_resolve": cdb_context_claim_resolve_handler,
             "cdb_context_memory_get": cdb_context_memory_get_handler,
+            "cdb_context_memory_write_intent": cdb_context_memory_write_intent_handler,
             "cdb_context_trust_summary": cdb_context_trust_summary_handler,
             "cdb_context_decision_history": cdb_context_decision_history_handler,
             "cdb_context_decision_replay": cdb_context_decision_replay_handler,

--- a/tools/mcp/memory_write_intent_tools.py
+++ b/tools/mcp/memory_write_intent_tools.py
@@ -1,0 +1,217 @@
+"""MCP dry-run surface for gated memory write intents — #2704.
+
+Issue: #2704 — design gated memory write surface (dry-run default)
+Parent: #2606 (Langzeitgedaechtnis / Persistent Agent Memory)
+
+Exposes ``cdb_context_memory_write_intent`` as a read-only MCP tool that
+evaluates Human-GO memory write gates only. No DB adapter, no SQL client,
+no persistence, no mutation execution.
+
+Guardrails:
+    - MUTATION_ALLOWED is always False in this slice.
+    - Default path is dry-run gate evaluation via ``evaluate_memory_write_gate``.
+    - Mutation flags fail closed with ``mutation_blocked_by_default``.
+    - Raw human_go_token must never appear in responses or logs.
+    - LR remains NO-GO.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Mapping
+
+from tools.mcp.memory_output_contract import stamp_limitations
+from tools.surrealdb.memory_write_gate import (
+    MemoryWriteAuthorization,
+    evaluate_memory_write_gate,
+)
+
+logger = logging.getLogger(__name__)
+
+TOOL_CDB_CONTEXT_MEMORY_WRITE_INTENT = "cdb_context_memory_write_intent"
+MUTATION_ALLOWED = False
+
+_MUTATION_FLAGS = frozenset(
+    {
+        "mutation_requested",
+        "execute_write",
+        "execute",
+        "persist",
+        "audit_persist_local",
+    }
+)
+
+_FORBIDDEN_INJECTION_FIELDS = frozenset({"query", "sql", "surql", "statement"})
+_FORBIDDEN_SQL_TOKENS = frozenset(
+    {"INSERT", "UPDATE", "DELETE", "DROP", "CREATE", "ALTER", "TRUNCATE"}
+)
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        return value
+    return None
+
+
+def _error_response(
+    *,
+    code: str,
+    message: str,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "tool": TOOL_CDB_CONTEXT_MEMORY_WRITE_INTENT,
+        "status": "error",
+        "error": {"code": code, "message": message},
+        "metadata": {
+            "query_time_ms": 0,
+            "source": "in_memory",
+            "read_only": True,
+        },
+    }
+    if details:
+        payload["error"]["details"] = dict(details)
+    return payload
+
+
+def _ok_response(*, result: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "tool": TOOL_CDB_CONTEXT_MEMORY_WRITE_INTENT,
+        "status": "ok",
+        "result": dict(result),
+        "metadata": {
+            "query_time_ms": 0,
+            "source": "in_memory",
+            "read_only": True,
+        },
+    }
+
+
+def _parse_authorization(raw: Any) -> MemoryWriteAuthorization | None:
+    mapping = _as_mapping(raw)
+    if mapping is None:
+        return None
+    return MemoryWriteAuthorization(
+        human_go_token=str(mapping.get("human_go_token") or ""),
+        authorized_by=str(mapping.get("authorized_by") or ""),
+        authorized_at=str(mapping.get("authorized_at") or ""),
+        scope=str(mapping.get("scope") or ""),
+        target_issue=str(mapping.get("target_issue") or ""),
+        evidence_refs=tuple(str(r) for r in (mapping.get("evidence_refs") or [])),
+        operation=str(mapping.get("operation") or "create"),  # type: ignore[arg-type]
+    )
+
+
+def _scan_injection_fields(parameters: Mapping[str, Any]) -> str | None:
+    for key, value in parameters.items():
+        if key not in _FORBIDDEN_INJECTION_FIELDS:
+            continue
+        if not isinstance(value, str):
+            continue
+        upper = value.upper()
+        for token in _FORBIDDEN_SQL_TOKENS:
+            if token in upper:
+                return f"{key} contains forbidden SQL keyword {token}"
+    return None
+
+
+def _wrap_gate_envelope(envelope: Mapping[str, Any]) -> dict[str, Any]:
+    memory_id = envelope.get("memory_id")
+    result: dict[str, Any] = {
+        "memory_id": memory_id,
+        "gate_status": envelope.get("gate_status"),
+        "gate_envelope": dict(envelope),
+        "dry_run_only": True,
+        "persist_allowed": False,
+        "approval_semantics": dict(envelope.get("approval_semantics") or {}),
+    }
+    if memory_id:
+        result["matched_memory"] = [
+            {"memory_id": str(memory_id), "trust_level": "pending_write"}
+        ]
+        result["memory_summary"] = {"overall_trust": "pending_write"}
+    stamp_limitations(
+        result,
+        extra=[
+            "MCP memory write intent is dry-run gate evaluation only.",
+            "mutation_blocked_by_default; no DB write via MCP.",
+        ],
+    )
+    return result
+
+
+def _response_has_raw_token(payload: Mapping[str, Any]) -> bool:
+    serialized = json.dumps(payload, default=str)
+    return '"human_go_token"' in serialized
+
+
+def handle_cdb_context_memory_write_intent(
+    request: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Evaluate a memory write intent through the Human-GO gate (dry-run only).
+
+    Parameters (under ``parameters`` or top-level):
+        record: memory record dict (required)
+        authorization: optional Human-GO authorization block
+        dry_run: ignored; always dry-run in v1
+        mutation_requested / execute_write / execute / persist: fail-closed
+    """
+    if not MUTATION_ALLOWED:
+        pass
+
+    tool = request.get("tool")
+    if tool is not None and tool != TOOL_CDB_CONTEXT_MEMORY_WRITE_INTENT:
+        return _error_response(
+            code="invalid_tool",
+            message=(
+                f"expected tool {TOOL_CDB_CONTEXT_MEMORY_WRITE_INTENT!r}, "
+                f"got {tool!r}"
+            ),
+        )
+
+    parameters = _as_mapping(request.get("parameters")) or request
+
+    for flag in _MUTATION_FLAGS:
+        if parameters.get(flag):
+            return _error_response(
+                code="mutation_blocked_by_default",
+                message=(
+                    "Memory write mutation is blocked by default on the MCP "
+                    "surface. Dry-run gate evaluation only."
+                ),
+                details={"flag": flag, "mutations_allowed": MUTATION_ALLOWED},
+            )
+
+    injection_issue = _scan_injection_fields(parameters)
+    if injection_issue:
+        return _error_response(
+            code="unsafe_input",
+            message=injection_issue,
+        )
+
+    record = _as_mapping(parameters.get("record"))
+    if record is None:
+        return _error_response(
+            code="invalid_parameters",
+            message="record is required (object)",
+        )
+
+    authorization = _parse_authorization(parameters.get("authorization"))
+
+    envelope = evaluate_memory_write_gate(dict(record), authorization)
+    if _response_has_raw_token(envelope):
+        logger.error("gate envelope leaked human_go_token; blocking response")
+        return _error_response(
+            code="internal_error",
+            message="gate envelope must not contain raw human_go_token",
+        )
+
+    result = _wrap_gate_envelope(envelope)
+    response = _ok_response(result=result)
+    if _response_has_raw_token(response):
+        return _error_response(
+            code="internal_error",
+            message="response must not contain raw human_go_token",
+        )
+    return response

--- a/tools/mcp/permission_guard.py
+++ b/tools/mcp/permission_guard.py
@@ -20,6 +20,12 @@ stop_conditions, and structural field checks. Task descriptions like
 "Deploy system" or "Update config" are legitimate scope descriptions
 that the readiness/briefing handlers evaluate correctly.
 
+``cdb_context_memory_write_intent`` (#2704) is exempt from blanket input scanning
+because memory record content may contain SQL-like words; the handler still
+blocks mutation flags and optional query/sql injection fields. Registry
+``read_only=True`` is unchanged — enabling mutation would require an explicit
+future registry/permission-guard change outside this slice.
+
 This module does NOT perform any writes, runtime actions, or live assertions.
 It is a pure, stateless, deterministic guard layer.
 
@@ -142,6 +148,9 @@ INPUT_SCAN_EXEMPT_TOOLS: frozenset[str] = frozenset(
         "cdb_context_evidence_resolve",
         "cdb_context_claim_resolve",
         "cdb_context_memory_get",
+        # #2704 memory write intent: record content may contain SQL-like words;
+        # tool is dry-run gate evaluation only (MUTATION_ALLOWED=False).
+        "cdb_context_memory_write_intent",
         "cdb_context_trust_summary",
         "cdb_context_decision_history",
         "cdb_context_decision_replay",

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -992,6 +992,41 @@ TOOLS_V0 = [
         handler=create_not_implemented_handler("cdb_context_memory_get"),
     ),
     ToolDefinition(
+        name="cdb_context_memory_write_intent",
+        description=(
+            "Memory write intent gate MCP tool (dry-run default). Evaluates "
+            "Human-GO memory write authorization against the memory contract. "
+            "Read-only, fail-closed, no DB/network/write execution. "
+            "Mutation flags blocked. No Live-Go, no Echtgeld-Go."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "record": {"type": "object"},
+                        "authorization": {"type": "object"},
+                        "dry_run": {"type": "boolean", "default": True},
+                    },
+                    "required": ["record"],
+                },
+            },
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "tool": {"type": "string"},
+                "status": {"type": "string"},
+                "result": {"type": "object"},
+                "metadata": {"type": "object"},
+            },
+        },
+        read_only=True,
+        handler=create_not_implemented_handler("cdb_context_memory_write_intent"),
+    ),
+    ToolDefinition(
         name="cdb_context_trust_summary",
         description=(
             "Wave-14 trust summary MCP tool. Builds a trust assessment from "


### PR DESCRIPTION
## Summary
- Add \cdb_context_memory_write_intent\ MCP tool (dry-run gate evaluation only)
- Registry/bridge wiring with \ead_only=True\; \MUTATION_ALLOWED=False\
- Permission guard exemption + handler-level mutation/SQL injection blocks
- Design doc + unit tests (#2701 output contract compliance)

## Test plan
- [x] pytest tests/unit/tools/mcp/test_memory_write_intent_tool.py
- [x] ruff + black on touched files

Closes #2704
Refs #2606

LR remains NO-GO. No DB write via MCP.