### PR TITLE
feat(surrealdb): add knowledge refresh loop report

### DIFF
--- a/docs/surrealdb/knowledge-refresh-loop-contract-v1.md
+++ b/docs/surrealdb/knowledge-refresh-loop-contract-v1.md
@@ -1,0 +1,171 @@
+# Knowledge Refresh Loop Contract v1
+
+**Schema:** `knowledge-refresh-report/v1`  
+**Status:** MVP read-only closure slice  
+**Issue:** [#2717](https://github.com/jannekbuengener/Claire_de_Binare/issues/2717)  
+**Parent Epic:** [#1976](https://github.com/jannekbuengener/Claire_de_Binare/issues/1976)  
+**Live-Readiness:** `NO-GO` — report is signal only, no live-go implication  
+**Board Stage:** `trade-capable` — orthogonal to LR; no live capital
+
+---
+
+## Purpose
+
+The Knowledge Refresh Loop Report composes existing Wave-16–20 read-only modules
+into one deterministic operator report:
+
+- `stale_knowledge_scan.py` → stale findings
+- `stale_refresh_plan.py` → refresh plan items (`write_authorized=false`)
+- `quality_scoring.py` → quality summary
+- `architect_signals.py` → architect signal summary
+- `agent_os_readiness.py` → optional readiness summary signal
+
+The report surfaces documentation/knowledge refresh candidates. It does **not**
+delete, archive, write memory, open GitHub issues, or mutate SurrealDB.
+
+---
+
+## Producer
+
+| Component | Path |
+|---|---|
+| Orchestrator | `tools/surrealdb/knowledge_refresh_report.py` |
+| CLI | `tools/surrealdb/knowledge_refresh_cli.py` |
+| Entry point | `generate_knowledge_refresh_report_v1(bundle, as_of=None, include_readiness=True)` |
+
+**Pure-report path constraints:**
+
+- No SurrealDB SDK import
+- No network I/O
+- No GitHub API calls
+- No filesystem writes from the report generator
+
+---
+
+## Input Bundle
+
+Same in-memory bundle shape as stale/quality/architect modules. Minimum:
+
+```json
+{
+  "meta": {
+    "scope_id": "example-scope",
+    "level": "domain",
+    "as_of": "2026-05-06T12:00:00+00:00"
+  },
+  "sources": [],
+  "decisions": [],
+  "evidence_records": [],
+  "memory_records": [],
+  "dependency_edges": [],
+  "context_packages": [],
+  "briefings": []
+}
+```
+
+Optional keys reused by quality/architect/readiness:
+
+- `evidence_items`, `contradiction_findings`, `stale_findings`, `scope_drift_findings`, `memory_items`
+
+When `evidence_items` is absent but `evidence_records` is present, the orchestrator
+maps records into `evidence_items` for downstream scoring.
+
+---
+
+## Output Schema (`knowledge-refresh-report/v1`)
+
+Top-level fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema_version` | string | Always `knowledge-refresh-report/v1` |
+| `report_id` | string | Deterministic SHA256 prefix (`scope_id\|as_of\|schema`) |
+| `scope_id` | string | From `meta.scope_id` or default |
+| `as_of` | string | ISO-8601 UTC reference time |
+| `status` | string | `ok` or `error` |
+| `classification_summary` | object | Counts per classification |
+| `items` | array | Classified refresh candidates |
+| `stale_scan` | object | Scan summary |
+| `refresh_plan` | object | Plan summary; `write_authorized=false` |
+| `quality` | object | Overall grade/score summary |
+| `architect_signals` | object | Signal counts |
+| `agent_os_readiness` | object \| null | Optional summary signal |
+| `guardrails` | array | Non-empty guardrail strings |
+| `errors` | array | Non-fatal sub-evaluator errors |
+
+### Refresh report item
+
+| Field | Type | Notes |
+|---|---|---|
+| `item_id` | string | Deterministic SHA256 prefix |
+| `target_ref` | string | Path or artifact ref (source paths resolved from `source_id`) |
+| `classification` | string | See classifications below |
+| `reason` | string | Human-readable rationale |
+| `write_authorized` | bool | **Always `false`** |
+| `canon_protected` | bool | True when path matches canon prefix list |
+| `stale_type` | string \| omitted | From stale scan when applicable |
+| `severity` | string \| omitted | From stale finding |
+| `priority` | string \| omitted | From refresh plan (`P0`–`P3`) |
+| `plan_id` | string \| omitted | Refresh plan item id |
+| `recommended_action` | string \| omitted | Canonical refresh action |
+| `architect_signal_ids` | array \| omitted | Linked architect signals |
+| `issue_proposal` | string \| omitted | Text-only proposal; never auto-submitted |
+
+---
+
+## Classifications
+
+| Classification | Meaning |
+|---|---|
+| `canon_protected` | Canon path with no open stale finding requiring action |
+| `refresh_required` | Open stale finding; includes canon paths (never archive-only) |
+| `archive_candidate` | Non-canon deleted source; non-blocking delete signal |
+| `needs_issue_proposal` | Blocking delete, P0 plan item, or blocking architect signal |
+| `stale_but_accepted` | Finding status `accepted_stale` or `false_positive` |
+| `orphan_candidate` | Source without owner/coverage/references |
+| `no_action` | No refresh action indicated |
+
+**Hard invariant:** Canon-protected sources are never classified as
+`archive_candidate` or delete-only outcomes.
+
+---
+
+## Canon Protected Prefixes
+
+Paths normalized to forward slashes and matched by prefix:
+
+- `AGENTS.md`
+- `agents/AGENTS.md`
+- `agents/roles/`
+- `knowledge/governance/`
+- `docs/live-readiness/`
+- `docs/runbooks/CONTROL_REGISTER.md`
+- `CURRENT_STATUS.md`
+- `CLAUDE.md`
+
+---
+
+## Determinism
+
+- JSON output uses `core.replay.canonical_json.canonical_json_dumps` (sorted keys, compact).
+- Repeated calls with the same bundle and `as_of` produce identical JSON.
+- Timestamps default from `meta.as_of` when provided.
+
+---
+
+## Non-Goals (v1)
+
+- DB write / memory write / GitHub write
+- Auto-issue / auto-delete / auto-archive
+- CI scheduler / dashboard / MCP tool exposure
+
+---
+
+## Related Issues
+
+| Issue | Relationship |
+|---|---|
+| #1976 | Parent epic |
+| #2204, #2603–#2606 | Related context/memory epics |
+| #2689 | Out of scope (Gordon/Docker AI doc cleanup) |
+| #2606 | Not blocking while MVP stays read-only |

--- a/docs/surrealdb/knowledge-refresh-loop-runbook.md
+++ b/docs/surrealdb/knowledge-refresh-loop-runbook.md
@@ -1,0 +1,140 @@
+# Knowledge Refresh Loop Runbook
+
+**Status:** MVP read-only closure slice  
+**Authority:** Issue [#2717](https://github.com/jannekbuengener/Claire_de_Binare/issues/2717) / Epic [#1976](https://github.com/jannekbuengener/Claire_de_Binare/issues/1976)  
+**Contract:** [`knowledge-refresh-loop-contract-v1.md`](knowledge-refresh-loop-contract-v1.md)
+
+**LR-Status: NO-GO** — this runbook covers read-only reporting only.  
+**Board Stage: trade-capable** — orthogonal to LR; no live capital.
+
+---
+
+## 1. Purpose
+
+Operators and agents use the Knowledge Refresh Loop Report to see consolidated
+refresh candidates across stale scan, refresh plan, quality, architect signals,
+and optional Agent OS readiness — without triggering any write path.
+
+Detection and classification are **signal, not authorization**.
+
+---
+
+## 2. Artefacts
+
+| Artefact | Path |
+|---|---|
+| Orchestrator | `tools/surrealdb/knowledge_refresh_report.py` |
+| CLI | `tools/surrealdb/knowledge_refresh_cli.py` |
+| Fixture | `tests/fixtures/surrealdb/knowledge_refresh/sample_bundle.json` |
+| Unit tests | `tests/unit/surrealdb/test_knowledge_refresh_report.py` |
+| Contract | `docs/surrealdb/knowledge-refresh-loop-contract-v1.md` |
+
+---
+
+## 3. Operator Commands
+
+### JSON report (stdout)
+
+```bash
+python -m tools.surrealdb.knowledge_refresh_cli report-knowledge-refresh \
+  --input tests/fixtures/surrealdb/knowledge_refresh/sample_bundle.json \
+  --format json \
+  --as-of 2026-05-06T12:00:00+00:00
+```
+
+### Markdown report (stdout)
+
+```bash
+python -m tools.surrealdb.knowledge_refresh_cli report-knowledge-refresh \
+  --input tests/fixtures/surrealdb/knowledge_refresh/sample_bundle.json \
+  --format markdown \
+  --as-of 2026-05-06T12:00:00+00:00
+```
+
+### Omit optional readiness summary
+
+```bash
+python -m tools.surrealdb.knowledge_refresh_cli report-knowledge-refresh \
+  --input tests/fixtures/surrealdb/knowledge_refresh/sample_bundle.json \
+  --no-readiness
+```
+
+### Programmatic use
+
+```python
+from tools.surrealdb.knowledge_refresh_report import generate_knowledge_refresh_report_v1
+
+report = generate_knowledge_refresh_report_v1(bundle, as_of="2026-05-06T12:00:00+00:00")
+print(report.to_json())
+print(report.to_markdown())
+```
+
+---
+
+## 4. Interpreting Classifications
+
+| Classification | Operator action |
+|---|---|
+| `refresh_required` | Review and refresh content; canon paths still require human review |
+| `archive_candidate` | Non-canon delete signal — propose archive only after human review |
+| `needs_issue_proposal` | Review embedded text proposal; open GitHub issue manually if warranted |
+| `stale_but_accepted` | Known/accepted drift — no automatic action |
+| `orphan_candidate` | Investigate ownership and references |
+| `canon_protected` | Treat as governance-critical; never auto-delete/archive |
+| `no_action` | Informational only |
+
+All items carry `write_authorized=false`. The refresh plan summary also
+states `write_authorized=false`.
+
+---
+
+## 5. Issue Proposals
+
+When classification is `needs_issue_proposal`, the report includes a
+**text-only** `issue_proposal` block. The tool does **not** call GitHub.
+Operators copy/adapt the proposal and open issues manually under epic #1976.
+
+---
+
+## 6. Validation
+
+```bash
+pytest tests/unit/surrealdb/test_knowledge_refresh_report.py -q
+ruff check tools/surrealdb/knowledge_refresh_report.py tools/surrealdb/knowledge_refresh_cli.py
+```
+
+Expected: all tests pass; ruff clean; no network/DB activity in pure-report path.
+
+---
+
+## 7. Guardrails
+
+- Read-only first; Git/repo remains source of truth.
+- `CURRENT_STATUS.md` is a ledger, not live truth.
+- Board stage `trade-capable` is not a live-go.
+- Live-Readiness remains NO-GO.
+- No documentation deletion without separate Human-GO.
+- No memory writes without separate Human-GO (#2606).
+- No CI scheduler or MCP exposure in v1.
+
+---
+
+## 8. Out of Scope
+
+| Item | Notes |
+|---|---|
+| #2689 Gordon/Docker AI cleanup | Separate doc decommission track |
+| #2606 memory persistence | Not required for read-only MVP |
+| CI automation (#2202 follow-up) | Future slice |
+| DB-backed default bundle | Depends on #2603 maturity |
+
+---
+
+## 9. Failure Modes
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| CLI exit 2 | Missing/invalid JSON bundle | Fix bundle path and schema |
+| Empty `items` | Clean bundle | Expected for healthy snapshots |
+| `errors` populated | Quality/architect/readiness sub-evaluator issue | Inspect error strings; fix bundle shape |
+| Non-deterministic JSON | Missing `--as-of` / `meta.as_of` | Pass explicit reference timestamp |

--- a/tests/fixtures/surrealdb/knowledge_refresh/sample_bundle.json
+++ b/tests/fixtures/surrealdb/knowledge_refresh/sample_bundle.json
@@ -1,0 +1,105 @@
+{
+  "_comment": "Knowledge Refresh Loop sample bundle (#2717). Deterministic, no live data.",
+  "meta": {
+    "scope_id": "knowledge-refresh-sample",
+    "level": "domain",
+    "as_of": "2026-05-06T12:00:00+00:00",
+    "description": "Mixed stale, canon, orphan, and accepted-stale cases"
+  },
+  "sources": [
+    {
+      "source_id": "src-canon-stale-001",
+      "path": "AGENTS.md",
+      "current_hash": "aaa111",
+      "last_verified_hash": "bbb222",
+      "exists": true,
+      "owner": "cdb-core",
+      "has_documentation": true,
+      "has_tests": false
+    },
+    {
+      "source_id": "src-deleted-001",
+      "path": "docs/deprecated/old-runbook.md",
+      "exists": false,
+      "deleted_at": "2026-04-01T12:00:00+00:00"
+    },
+    {
+      "source_id": "src-orphan-001",
+      "path": "docs/scratch/unowned-notes.md",
+      "exists": true
+    },
+    {
+      "source_id": "src-mixed-001",
+      "path": "tools/surrealdb/stale_knowledge_scan.py",
+      "current_hash": "deadbeef",
+      "last_verified_hash": "cafebabe",
+      "exists": true,
+      "owner": "cdb-core",
+      "has_documentation": true,
+      "has_tests": true
+    },
+    {
+      "source_id": "src-accepted-001",
+      "path": "docs/architecture/legacy-note.md",
+      "current_hash": "111111",
+      "last_verified_hash": "222222",
+      "exists": true,
+      "status": "accepted_stale"
+    }
+  ],
+  "decisions": [
+    {
+      "decision_id": "D-001",
+      "title": "Use stale scan for refresh loop",
+      "status": "active",
+      "evidence_refs": ["E-001"]
+    }
+  ],
+  "evidence_records": [
+    {
+      "evidence_id": "E-001",
+      "expires_at": "2026-01-01T00:00:00+00:00",
+      "topic": "Expired canary evidence (fixture)"
+    }
+  ],
+  "memory_records": [
+    {
+      "memory_id": "MEM-001",
+      "expires_at": "2026-01-01T00:00:00+00:00",
+      "scope": "cdb"
+    }
+  ],
+  "dependency_edges": [
+    {
+      "edge_id": "EDGE-001",
+      "source": "tools/surrealdb/stale_knowledge_scan.py",
+      "target": "core/utils/clock.py",
+      "confidence": "high",
+      "observed": true
+    }
+  ],
+  "context_packages": [
+    {
+      "package_id": "PKG-001",
+      "source_snapshot_id": "snap-old",
+      "current_snapshot_id": "snap-new"
+    }
+  ],
+  "briefings": [
+    {
+      "briefing_id": "BR-001",
+      "source_snapshot_id": "snap-brief-old",
+      "current_snapshot_id": "snap-brief-new"
+    }
+  ],
+  "contradiction_findings": [
+    {
+      "contradiction_id": "C-001",
+      "contradiction_type": "doc_vs_code",
+      "severity": "watch",
+      "status": "open",
+      "affected_paths": ["tools/surrealdb/stale_knowledge_scan.py"]
+    }
+  ],
+  "scope_drift_findings": []
+}

--- a/tests/unit/surrealdb/test_knowledge_refresh_report.py
+++ b/tests/unit/surrealdb/test_knowledge_refresh_report.py
@@ -1,0 +1,314 @@
+"""Unit tests for knowledge_refresh_report.py — Knowledge Refresh Loop v1 (#2717)."""
+
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tools.surrealdb.knowledge_refresh_cli import EXIT_ERROR, EXIT_OK, main
+from tools.surrealdb.knowledge_refresh_report import (
+    CLASSIFICATIONS,
+    GUARDRAILS,
+    SCHEMA_VERSION,
+    classify_finding,
+    generate_knowledge_refresh_report_v1,
+    is_canon_protected,
+)
+
+pytestmark = pytest.mark.unit
+
+_AS_OF = "2026-05-06T12:00:00+00:00"
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "surrealdb"
+    / "knowledge_refresh"
+    / "sample_bundle.json"
+)
+
+
+def _load_fixture() -> dict[str, Any]:
+    return json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _minimal_bundle(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "meta": {"scope_id": "test-scope", "level": "domain", "as_of": _AS_OF},
+        "sources": [],
+        "decisions": [],
+        "evidence_records": [],
+        "memory_records": [],
+        "dependency_edges": [],
+        "context_packages": [],
+        "briefings": [],
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.unit
+def test_is_canon_protected_paths() -> None:
+    assert is_canon_protected("AGENTS.md")
+    assert is_canon_protected("agents/AGENTS.md")
+    assert is_canon_protected("knowledge/governance/CDB_CONSTITUTION.md")
+    assert is_canon_protected("docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md")
+    assert not is_canon_protected("docs/scratch/unowned-notes.md")
+
+
+@pytest.mark.unit
+def test_canon_protected_stale_never_archive() -> None:
+    bundle = _minimal_bundle(
+        sources=[
+            {
+                "source_id": "s1",
+                "path": "AGENTS.md",
+                "current_hash": "a",
+                "last_verified_hash": "b",
+                "exists": True,
+            }
+        ]
+    )
+    report = generate_knowledge_refresh_report_v1(bundle, as_of=_AS_OF)
+    agent_item = next(i for i in report.items if i.target_ref == "AGENTS.md")
+    assert agent_item.classification == "refresh_required"
+    assert agent_item.canon_protected is True
+    assert agent_item.write_authorized is False
+    assert agent_item.classification != "archive_candidate"
+
+
+@pytest.mark.unit
+def test_deleted_non_canon_source_archive_or_issue() -> None:
+    bundle = _minimal_bundle(
+        sources=[
+            {
+                "source_id": "s1",
+                "path": "docs/deprecated/old-runbook.md",
+                "exists": False,
+            }
+        ]
+    )
+    report = generate_knowledge_refresh_report_v1(bundle, as_of=_AS_OF)
+    item = next(i for i in report.items if "old-runbook" in i.target_ref)
+    assert item.classification in {"archive_candidate", "needs_issue_proposal"}
+    assert item.canon_protected is False
+    assert item.write_authorized is False
+
+
+@pytest.mark.unit
+def test_expired_evidence_refresh_required() -> None:
+    bundle = _minimal_bundle(
+        evidence_records=[
+            {"evidence_id": "E-1", "expires_at": "2026-01-01T00:00:00+00:00"}
+        ]
+    )
+    report = generate_knowledge_refresh_report_v1(bundle, as_of=_AS_OF)
+    item = next(i for i in report.items if i.stale_type == "evidence_expired")
+    assert item.classification == "refresh_required"
+
+
+@pytest.mark.unit
+def test_stale_memory_refresh_required() -> None:
+    bundle = _minimal_bundle(
+        memory_records=[
+            {"memory_id": "M-1", "expires_at": "2026-01-01T00:00:00+00:00"}
+        ]
+    )
+    report = generate_knowledge_refresh_report_v1(bundle, as_of=_AS_OF)
+    item = next(i for i in report.items if i.stale_type == "memory_ttl_expired")
+    assert item.classification == "refresh_required"
+
+
+@pytest.mark.unit
+def test_stale_context_package_and_briefing() -> None:
+    bundle = _minimal_bundle(
+        context_packages=[
+            {
+                "package_id": "P-1",
+                "source_snapshot_id": "old",
+                "current_snapshot_id": "new",
+            }
+        ],
+        briefings=[
+            {
+                "briefing_id": "B-1",
+                "source_snapshot_id": "old",
+                "current_snapshot_id": "new",
+            }
+        ],
+    )
+    report = generate_knowledge_refresh_report_v1(bundle, as_of=_AS_OF)
+    types = {i.stale_type for i in report.items}
+    assert "stale_context_package" in types
+    assert "stale_briefing" in types
+
+
+@pytest.mark.unit
+def test_accepted_stale_classification() -> None:
+    from tools.surrealdb.stale_knowledge_scan import scan_stale_knowledge_v1
+
+    bundle = _minimal_bundle(
+        sources=[
+            {
+                "source_id": "s1",
+                "path": "docs/architecture/legacy-note.md",
+                "current_hash": "a",
+                "last_verified_hash": "b",
+                "exists": True,
+            }
+        ]
+    )
+    scan = scan_stale_knowledge_v1(bundle, as_of=_AS_OF)
+    finding = next(f for f in scan.findings if f.stale_type == "source_hash_changed")
+    finding = finding.__class__(
+        **{**finding.__dict__, "status": "accepted_stale", "blocking": False}
+    )
+    assert classify_finding(finding, None, []) == "stale_but_accepted"
+
+
+@pytest.mark.unit
+def test_mixed_stale_quality_architect_fixture() -> None:
+    report = generate_knowledge_refresh_report_v1(_load_fixture(), as_of=_AS_OF)
+    assert report.status == "ok"
+    assert report.classification_summary["refresh_required"] >= 1
+    mixed = next(
+        (i for i in report.items if "stale_knowledge_scan.py" in i.target_ref),
+        None,
+    )
+    assert mixed is not None
+    assert mixed.classification == "refresh_required"
+    assert report.quality.get("overall_grade")
+    assert report.architect_signals.get("total_signals", 0) >= 0
+
+
+@pytest.mark.unit
+def test_orphan_candidate_detection() -> None:
+    bundle = _minimal_bundle(
+        sources=[{"source_id": "o1", "path": "docs/scratch/unowned-notes.md", "exists": True}]
+    )
+    report = generate_knowledge_refresh_report_v1(bundle, as_of=_AS_OF)
+    orphan = next(
+        (i for i in report.items if i.classification == "orphan_candidate"),
+        None,
+    )
+    assert orphan is not None
+    assert orphan.target_ref == "docs/scratch/unowned-notes.md"
+
+
+@pytest.mark.unit
+def test_all_plan_items_write_authorized_false() -> None:
+    report = generate_knowledge_refresh_report_v1(_load_fixture(), as_of=_AS_OF)
+    assert all(item.write_authorized is False for item in report.items)
+    assert report.refresh_plan["write_authorized"] is False
+
+
+@pytest.mark.unit
+def test_issue_proposal_text_only() -> None:
+    bundle = _minimal_bundle(
+        sources=[{"source_id": "s1", "path": "docs/deprecated/gone.md", "exists": False}]
+    )
+    report = generate_knowledge_refresh_report_v1(bundle, as_of=_AS_OF)
+    proposals = [i for i in report.items if i.issue_proposal]
+    assert proposals
+    assert "NOT auto-created" in proposals[0].issue_proposal
+
+
+@pytest.mark.unit
+def test_deterministic_json_output() -> None:
+    bundle = _load_fixture()
+    first = generate_knowledge_refresh_report_v1(bundle, as_of=_AS_OF).to_json()
+    second = generate_knowledge_refresh_report_v1(bundle, as_of=_AS_OF).to_json()
+    assert first == second
+
+
+@pytest.mark.unit
+def test_markdown_output_operator_friendly() -> None:
+    report = generate_knowledge_refresh_report_v1(_load_fixture(), as_of=_AS_OF)
+    md = report.to_markdown()
+    assert "# Knowledge Refresh Loop Report" in md
+    assert "## Guardrails" in md
+    for guardrail in GUARDRAILS[:2]:
+        assert guardrail in md
+
+
+@pytest.mark.unit
+def test_schema_and_classifications_present() -> None:
+    report = generate_knowledge_refresh_report_v1(_load_fixture(), as_of=_AS_OF)
+    data = report.to_dict()
+    assert data["schema_version"] == SCHEMA_VERSION
+    assert set(data["classification_summary"].keys()).issubset(CLASSIFICATIONS)
+
+
+@pytest.mark.unit
+def test_no_forbidden_imports_in_report_module() -> None:
+    import tools.surrealdb.knowledge_refresh_report as mod
+
+    source = Path(mod.__file__).read_text(encoding="utf-8")
+    for forbidden in ("surrealdb", "requests", "httpx", "subprocess"):
+        assert f"import {forbidden}" not in source
+
+
+@pytest.mark.unit
+def test_cli_report_json(tmp_path: Path, capsys) -> None:
+    bundle_path = tmp_path / "bundle.json"
+    bundle_path.write_text(json.dumps(_load_fixture()), encoding="utf-8")
+    exit_code = main(
+        [
+            "--format",
+            "json",
+            "report-knowledge-refresh",
+            "--input",
+            str(bundle_path),
+            "--as-of",
+            _AS_OF,
+        ]
+    )
+    assert exit_code == EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["status"] == "ok"
+
+
+@pytest.mark.unit
+def test_cli_report_markdown(tmp_path: Path, capsys) -> None:
+    bundle_path = tmp_path / "bundle.json"
+    bundle_path.write_text(json.dumps(_minimal_bundle()), encoding="utf-8")
+    exit_code = main(
+        [
+            "--format",
+            "markdown",
+            "report-knowledge-refresh",
+            "--input",
+            str(bundle_path),
+            "--as-of",
+            _AS_OF,
+        ]
+    )
+    assert exit_code == EXIT_OK
+    out = capsys.readouterr().out
+    assert "Knowledge Refresh Loop Report" in out
+
+
+@pytest.mark.unit
+def test_cli_missing_input_exit_2(capsys) -> None:
+    exit_code = main(
+        [
+            "report-knowledge-refresh",
+            "--input",
+            "does-not-exist-bundle.json",
+        ]
+    )
+    assert exit_code == EXIT_ERROR
+
+
+@pytest.mark.unit
+def test_pure_report_path_no_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fail(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("network call attempted")
+
+    monkeypatch.setattr(socket, "socket", _fail)
+    report = generate_knowledge_refresh_report_v1(_load_fixture(), as_of=_AS_OF)
+    assert report.report_id

--- a/tools/surrealdb/knowledge_refresh_cli.py
+++ b/tools/surrealdb/knowledge_refresh_cli.py
@@ -1,0 +1,156 @@
+"""Knowledge Refresh CLI — read-only report, no writes, no DB, no network.
+
+Issues:
+    #2717 — [SURREALDB][CONTEXT][REFRESH-LOOP] Add read-only Knowledge Refresh Loop report
+    Parent Epic: #1976
+
+Commands:
+    report-knowledge-refresh   Generate JSON or Markdown knowledge refresh report
+
+Exit codes:
+    0 = success
+    2 = CLI / input / validation error
+
+Guardrails:
+    - Read-only. Stdout only. No file output from CLI.
+    - No DB access. No SurrealDB SDK. No network. No GitHub calls.
+    - LR status remains NO-GO for live trading.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from tools.surrealdb.knowledge_refresh_report import (
+    SCHEMA_VERSION,
+    KnowledgeRefreshReportError,
+    generate_knowledge_refresh_report_v1,
+)
+
+EXIT_OK = 0
+EXIT_ERROR = 2
+
+SUPPORTED_FORMATS = frozenset({"json", "markdown"})
+
+
+class KnowledgeRefreshCLIError(Exception):
+    """CLI validation error."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+def _load_bundle(path: Path) -> dict[str, Any]:
+    try:
+        exists = path.exists()
+    except OSError as exc:
+        raise KnowledgeRefreshCLIError(f"cannot stat input file: {path}: {exc}") from exc
+    if not exists:
+        raise KnowledgeRefreshCLIError(f"input file not found: {path}")
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise KnowledgeRefreshCLIError(f"cannot read input file: {path}: {exc}") from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise KnowledgeRefreshCLIError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise KnowledgeRefreshCLIError("input bundle must be a JSON object")
+    return data
+
+
+def _error_payload(message: str) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "error",
+        "error": "CLI_ERROR",
+        "message": message,
+    }
+
+
+def handle_report_knowledge_refresh(args: argparse.Namespace) -> tuple[Any, int]:
+    bundle_path = Path(args.input)
+    bundle = _load_bundle(bundle_path)
+    report = generate_knowledge_refresh_report_v1(
+        bundle,
+        as_of=args.as_of,
+        include_readiness=not args.no_readiness,
+    )
+    if args.format == "markdown":
+        return report.to_markdown(), EXIT_OK
+    return json.loads(report.to_json()), EXIT_OK
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="knowledge_refresh_cli",
+        description=(
+            "Knowledge Refresh CLI (#2717). Read-only local report — "
+            "no DB, no network, no writes."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=sorted(SUPPORTED_FORMATS),
+        default="json",
+        help="Output format (default: json).",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    report = subparsers.add_parser(
+        "report-knowledge-refresh",
+        help="Generate knowledge refresh loop report from input bundle.",
+    )
+    report.add_argument(
+        "--input",
+        required=True,
+        metavar="PATH",
+        help="Path to JSON input bundle.",
+    )
+    report.add_argument(
+        "--as-of",
+        dest="as_of",
+        default=None,
+        metavar="ISO8601",
+        help="Optional reference timestamp for deterministic output.",
+    )
+    report.add_argument(
+        "--no-readiness",
+        action="store_true",
+        default=False,
+        help="Omit optional Agent OS readiness summary signal.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command != "report-knowledge-refresh":
+            raise KnowledgeRefreshCLIError(f"unknown command: {args.command}")
+        payload, exit_code = handle_report_knowledge_refresh(args)
+        if args.format == "markdown":
+            print(payload)
+        else:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        return exit_code
+    except KnowledgeRefreshCLIError as exc:
+        print(json.dumps(_error_payload(exc.message), indent=2, sort_keys=True))
+        return EXIT_ERROR
+    except KnowledgeRefreshReportError as exc:
+        print(json.dumps(_error_payload(str(exc)), indent=2, sort_keys=True))
+        return EXIT_ERROR
+    except Exception as exc:  # noqa: BLE001
+        print(json.dumps(_error_payload(str(exc)), indent=2, sort_keys=True))
+        return EXIT_ERROR
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/surrealdb/knowledge_refresh_report.py
+++ b/tools/surrealdb/knowledge_refresh_report.py
@@ -1,0 +1,691 @@
+"""Knowledge Refresh Loop Report v1 — read-only closure orchestrator.
+
+Issues:
+    #2717 — [SURREALDB][CONTEXT][REFRESH-LOOP] Add read-only Knowledge Refresh Loop report
+    Parent Epic: #1976
+
+Scope:
+    Composes stale scan, refresh plan, quality scoring, architect signals, and
+    optional Agent OS readiness into a single deterministic JSON/Markdown report.
+    Pure in-memory. No DB. No SurrealDB SDK. No MCP. No network. No writes.
+
+Guardrails:
+    - Read-only first; write_authorized is always False on every item.
+    - Canon-protected sources are never classified as archive-only/delete-only.
+    - Issue proposals are text blocks only — no GitHub API calls.
+    - LR status remains NO-GO for live trading.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from core.replay.canonical_json import canonical_json_dumps
+from core.utils.clock import utcnow as cdb_utcnow
+from tools.surrealdb.agent_os_readiness import (
+    AgentOsReadinessResult,
+    evaluate_agent_os_readiness_v1,
+)
+from tools.surrealdb.architect_signals import (
+    ArchitectSignal,
+    ArchitectSignalResult,
+    scan_architect_signals_v1,
+)
+from tools.surrealdb.quality_scoring import QualityScoreResult, score_knowledge_quality_v1
+from tools.surrealdb.stale_knowledge_scan import (
+    GUARDRAILS as STALE_GUARDRAILS,
+    StaleFinding,
+    StaleKnowledgeScanResult,
+    scan_stale_knowledge_v1,
+)
+from tools.surrealdb.stale_refresh_plan import (
+    RefreshPlanItem,
+    RefreshPlanResult,
+    generate_refresh_plan_v1,
+)
+
+SCHEMA_VERSION = "knowledge-refresh-report/v1"
+TOOL_NAME = "knowledge_refresh_report"
+GENERATED_BY = "knowledge-refresh-report/v1"
+
+CLASSIFICATIONS: frozenset[str] = frozenset(
+    {
+        "canon_protected",
+        "refresh_required",
+        "archive_candidate",
+        "needs_issue_proposal",
+        "stale_but_accepted",
+        "orphan_candidate",
+        "no_action",
+    }
+)
+
+CANON_PROTECTED_PREFIXES: tuple[str, ...] = (
+    "AGENTS.md",
+    "agents/AGENTS.md",
+    "agents/roles/",
+    "knowledge/governance/",
+    "docs/live-readiness/",
+    "docs/runbooks/CONTROL_REGISTER.md",
+    "CURRENT_STATUS.md",
+    "CLAUDE.md",
+)
+
+GUARDRAILS: tuple[str, ...] = (
+    "Knowledge Refresh Report is signal, not authorization.",
+    "No automatic delete.",
+    "No automatic archive.",
+    "No automatic issue creation.",
+    "No DB write. No memory write. No GitHub write.",
+    "No Live-Readiness-Go.",
+    "No Echtgeld-Go.",
+    "Git/Repo remains source of truth.",
+)
+
+_ACCEPTED_STALE_STATUSES = frozenset({"accepted_stale", "false_positive"})
+
+
+class KnowledgeRefreshReportError(ValueError):
+    """Raised when report inputs are invalid or unsafe."""
+
+
+@dataclass(frozen=True)
+class RefreshReportItem:
+    """A single classified refresh candidate in the knowledge refresh report."""
+
+    item_id: str
+    target_ref: str
+    classification: str
+    reason: str
+    write_authorized: bool
+    canon_protected: bool
+    stale_type: str | None = None
+    severity: str | None = None
+    priority: str | None = None
+    plan_id: str | None = None
+    recommended_action: str | None = None
+    architect_signal_ids: tuple[str, ...] = ()
+    issue_proposal: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "item_id": self.item_id,
+            "target_ref": self.target_ref,
+            "classification": self.classification,
+            "reason": self.reason,
+            "write_authorized": self.write_authorized,
+            "canon_protected": self.canon_protected,
+        }
+        if self.stale_type is not None:
+            payload["stale_type"] = self.stale_type
+        if self.severity is not None:
+            payload["severity"] = self.severity
+        if self.priority is not None:
+            payload["priority"] = self.priority
+        if self.plan_id is not None:
+            payload["plan_id"] = self.plan_id
+        if self.recommended_action is not None:
+            payload["recommended_action"] = self.recommended_action
+        if self.architect_signal_ids:
+            payload["architect_signal_ids"] = list(self.architect_signal_ids)
+        if self.issue_proposal is not None:
+            payload["issue_proposal"] = self.issue_proposal
+        return payload
+
+
+@dataclass(frozen=True)
+class KnowledgeRefreshReportResult:
+    """Full knowledge refresh loop report."""
+
+    report_id: str
+    scope_id: str
+    as_of: str
+    status: str
+    classification_summary: dict[str, int]
+    items: tuple[RefreshReportItem, ...]
+    stale_scan: dict[str, Any]
+    refresh_plan: dict[str, Any]
+    quality: dict[str, Any]
+    architect_signals: dict[str, Any]
+    agent_os_readiness: dict[str, Any] | None
+    guardrails: tuple[str, ...]
+    errors: tuple[str, ...]
+    schema_version: str = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "tool": TOOL_NAME,
+            "generated_by": GENERATED_BY,
+            "report_id": self.report_id,
+            "scope_id": self.scope_id,
+            "as_of": self.as_of,
+            "status": self.status,
+            "classification_summary": dict(self.classification_summary),
+            "items": [item.to_dict() for item in self.items],
+            "stale_scan": self.stale_scan,
+            "refresh_plan": self.refresh_plan,
+            "quality": self.quality,
+            "architect_signals": self.architect_signals,
+            "agent_os_readiness": self.agent_os_readiness,
+            "guardrails": list(self.guardrails),
+            "errors": list(self.errors),
+        }
+
+    def to_json(self) -> str:
+        return canonical_json_dumps(self.to_dict())
+
+    def to_markdown(self) -> str:
+        lines: list[str] = [
+            "# Knowledge Refresh Loop Report",
+            "",
+            f"**Schema:** `{self.schema_version}`  ",
+            f"**Report ID:** `{self.report_id}`  ",
+            f"**Scope:** `{self.scope_id}`  ",
+            f"**As of:** `{self.as_of}`  ",
+            f"**Status:** `{self.status}`  ",
+            "",
+            "## Classification Summary",
+            "",
+        ]
+        for cls in sorted(CLASSIFICATIONS):
+            count = self.classification_summary.get(cls, 0)
+            if count:
+                lines.append(f"- `{cls}`: {count}")
+        if not any(self.classification_summary.values()):
+            lines.append("_No classified items._")
+        lines.append("")
+
+        if self.agent_os_readiness:
+            level = self.agent_os_readiness.get("readiness_level", "unknown")
+            lines += [
+                "## Agent OS Readiness (summary signal)",
+                "",
+                f"- **Level:** `{level}`",
+                f"- **Confidence:** {self.agent_os_readiness.get('confidence', 0):.2f}",
+                "",
+            ]
+
+        quality_grade = self.quality.get("overall_grade")
+        if quality_grade:
+            lines += [
+                "## Quality Summary",
+                "",
+                f"- **Overall grade:** `{quality_grade}`",
+                f"- **Overall score:** {self.quality.get('overall_score', 0):.2f}",
+                "",
+            ]
+
+        lines += ["## Items", ""]
+        if not self.items:
+            lines.append("_No refresh candidates._")
+        else:
+            for item in self.items:
+                lines.append(f"### `{item.target_ref}` — `{item.classification}`")
+                lines.append("")
+                lines.append(f"- **Reason:** {item.reason}")
+                if item.stale_type:
+                    lines.append(f"- **Stale type:** `{item.stale_type}`")
+                if item.priority:
+                    lines.append(f"- **Priority:** `{item.priority}`")
+                if item.recommended_action:
+                    lines.append(f"- **Recommended action:** `{item.recommended_action}`")
+                lines.append(f"- **Canon protected:** `{item.canon_protected}`")
+                lines.append(f"- **Write authorized:** `{item.write_authorized}`")
+                if item.issue_proposal:
+                    lines += ["", "**Issue proposal (text only — not submitted):**", "", item.issue_proposal, ""]
+                lines.append("")
+
+        lines += ["## Guardrails", ""]
+        lines.extend(f"- {g}" for g in self.guardrails)
+        lines.append("")
+        if self.errors:
+            lines += ["## Errors", ""]
+            lines.extend(f"- {err}" for err in self.errors)
+            lines.append("")
+        return "\n".join(lines)
+
+
+def normalize_path(path: str) -> str:
+    return path.replace("\\", "/").lstrip("./")
+
+
+def is_canon_protected(path: str) -> bool:
+    normalized = normalize_path(path)
+    for prefix in CANON_PROTECTED_PREFIXES:
+        if normalized == prefix or normalized.startswith(prefix):
+            return True
+    return False
+
+
+def _item_id(target_ref: str, classification: str, stale_type: str | None) -> str:
+    raw = f"{target_ref}|{classification}|{stale_type or ''}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _report_id(scope_id: str, as_of: str) -> str:
+    raw = f"{scope_id}|{as_of}|{SCHEMA_VERSION}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _as_str(value: Any) -> str:
+    return value if isinstance(value, str) else str(value) if value is not None else ""
+
+
+def _as_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _validate_bundle(bundle: Any) -> dict[str, Any]:
+    if not isinstance(bundle, Mapping):
+        raise KnowledgeRefreshReportError("bundle must be a mapping")
+    return dict(bundle)
+
+
+def _resolve_as_of(bundle: Mapping[str, Any], as_of: str | None) -> str:
+    if isinstance(as_of, str) and as_of.strip():
+        return as_of.strip()
+    meta = bundle.get("meta")
+    if isinstance(meta, Mapping):
+        meta_as_of = meta.get("as_of")
+        if isinstance(meta_as_of, str) and meta_as_of.strip():
+            return meta_as_of.strip()
+    return cdb_utcnow().isoformat()
+
+
+def _resolve_scope_id(bundle: Mapping[str, Any]) -> str:
+    meta = bundle.get("meta")
+    if isinstance(meta, Mapping):
+        scope_id = _as_str(meta.get("scope_id", "")).strip()
+        if scope_id:
+            return scope_id
+    return "knowledge-refresh-default"
+
+
+def _finding_to_stale_dict(finding: StaleFinding) -> dict[str, Any]:
+    return {
+        "finding_id": finding.stale_id,
+        "stale_id": finding.stale_id,
+        "stale_type": finding.stale_type,
+        "target_ref": finding.target_ref,
+        "severity": finding.severity,
+        "status": finding.status,
+        "blocking": finding.blocking,
+        "confidence": finding.confidence,
+    }
+
+
+def _enrich_bundle(
+    bundle: Mapping[str, Any],
+    scan_result: StaleKnowledgeScanResult,
+) -> dict[str, Any]:
+    enriched: dict[str, Any] = dict(bundle)
+    meta = dict(enriched.get("meta") or {})
+    if not _as_str(meta.get("scope_id", "")).strip():
+        meta["scope_id"] = _resolve_scope_id(bundle)
+    if not _as_str(meta.get("level", "")).strip():
+        meta["level"] = "domain"
+    enriched["meta"] = meta
+
+    if not enriched.get("evidence_items") and enriched.get("evidence_records"):
+        evidence_items: list[dict[str, Any]] = []
+        for record in _as_list(enriched.get("evidence_records")):
+            if isinstance(record, Mapping):
+                evidence_items.append(
+                    {
+                        "evidence_id": record.get("evidence_id", record.get("id", "")),
+                        "strength": record.get("strength", "medium"),
+                        "expires_at": record.get("expires_at"),
+                        "description": record.get("topic", record.get("description", "")),
+                    }
+                )
+        enriched["evidence_items"] = evidence_items
+
+    enriched["stale_findings"] = [_finding_to_stale_dict(f) for f in scan_result.findings]
+    return enriched
+
+
+def _plan_by_stale_id(plan: RefreshPlanResult) -> dict[str, RefreshPlanItem]:
+    return {item.stale_id: item for item in plan.plan_items}
+
+
+def _signals_by_path(signals: ArchitectSignalResult) -> dict[str, list[ArchitectSignal]]:
+    by_path: dict[str, list[ArchitectSignal]] = {}
+    for signal in signals.signals:
+        for path in signal.affected_paths:
+            normalized = normalize_path(path)
+            by_path.setdefault(normalized, []).append(signal)
+    return by_path
+
+
+def _issue_proposal_text(
+    target_ref: str,
+    classification: str,
+    stale_type: str | None,
+    priority: str | None,
+    reason: str,
+) -> str:
+    title_kind = stale_type or classification
+    return (
+        f"Proposed issue (NOT auto-created):\n"
+        f"Title: [SURREALDB][CONTEXT][REFRESH] Review {title_kind} for `{target_ref}`\n"
+        f"Priority hint: {priority or 'review'}\n"
+        f"Reason: {reason}\n"
+        f"Parent: #1976 / #2717"
+    )
+
+
+def classify_finding(
+    finding: StaleFinding,
+    plan_item: RefreshPlanItem | None,
+    path_signals: list[ArchitectSignal],
+) -> str:
+    target = normalize_path(finding.target_ref)
+    canon = is_canon_protected(target)
+
+    if finding.status in _ACCEPTED_STALE_STATUSES:
+        return "stale_but_accepted"
+
+    blocking_architect = any(s.severity == "blocking" for s in path_signals)
+    priority = plan_item.priority if plan_item else None
+
+    if finding.stale_type == "source_deleted":
+        if canon:
+            return "refresh_required"
+        if finding.blocking or finding.severity == "blocking" or priority == "P0":
+            return "needs_issue_proposal"
+        return "archive_candidate"
+
+    if blocking_architect or priority == "P0" or (
+        plan_item and plan_item.requires_human_review and finding.blocking
+    ):
+        return "needs_issue_proposal"
+
+    if finding.severity in ("warning", "blocking") or finding.blocking:
+        return "refresh_required"
+
+    return "no_action"
+
+
+def _classify_orphan(path: str) -> str:
+    if is_canon_protected(path):
+        return "canon_protected"
+    return "orphan_candidate"
+
+
+def _referenced_paths(bundle: Mapping[str, Any]) -> set[str]:
+    refs: set[str] = set()
+    for decision in _as_list(bundle.get("decisions")):
+        if isinstance(decision, Mapping):
+            for key in ("path", "target_ref", "source_path"):
+                val = _as_str(decision.get(key, "")).strip()
+                if val:
+                    refs.add(normalize_path(val))
+    for edge in _as_list(bundle.get("dependency_edges")):
+        if isinstance(edge, Mapping):
+            for key in ("source", "target", "from_ref", "to_ref"):
+                val = _as_str(edge.get(key, "")).strip()
+                if val:
+                    refs.add(normalize_path(val))
+    return refs
+
+
+def _detect_orphan_sources(
+    bundle: Mapping[str, Any],
+    covered_targets: set[str],
+) -> list[RefreshReportItem]:
+    items: list[RefreshReportItem] = []
+    referenced = _referenced_paths(bundle)
+    for source in _as_list(bundle.get("sources")):
+        if not isinstance(source, Mapping):
+            continue
+        if source.get("exists") is False:
+            continue
+        path = _as_str(source.get("path", "")).strip()
+        if not path:
+            continue
+        normalized = normalize_path(path)
+        if normalized in covered_targets:
+            continue
+        owner = _as_str(source.get("owner", "")).strip()
+        has_docs = bool(source.get("has_documentation"))
+        has_tests = bool(source.get("has_tests"))
+        source_id = _as_str(source.get("source_id", "")).strip()
+        if (
+            owner
+            or has_docs
+            or has_tests
+            or normalized in referenced
+            or source_id in covered_targets
+        ):
+            if is_canon_protected(normalized) and normalized not in covered_targets:
+                classification = "canon_protected"
+                reason = "Canon-protected source; no open stale findings."
+            else:
+                continue
+        else:
+            classification = _classify_orphan(normalized)
+            reason = "Source has no owner, coverage flags, or observed references."
+        items.append(
+            RefreshReportItem(
+                item_id=_item_id(normalized, classification, None),
+                target_ref=normalized,
+                classification=classification,
+                reason=reason,
+                write_authorized=False,
+                canon_protected=is_canon_protected(normalized),
+            )
+        )
+    return items
+
+
+def _build_source_index(
+    bundle: Mapping[str, Any],
+) -> tuple[dict[str, Mapping[str, Any]], dict[str, Mapping[str, Any]]]:
+    by_id: dict[str, Mapping[str, Any]] = {}
+    by_path: dict[str, Mapping[str, Any]] = {}
+    for source in _as_list(bundle.get("sources")):
+        if not isinstance(source, Mapping):
+            continue
+        source_id = _as_str(source.get("source_id", "")).strip()
+        path = _as_str(source.get("path", "")).strip()
+        if source_id:
+            by_id[source_id] = source
+        if path:
+            by_path[normalize_path(path)] = source
+    return by_id, by_path
+
+
+def _resolve_item_ref(
+    finding: StaleFinding,
+    sources_by_id: dict[str, Mapping[str, Any]],
+) -> str:
+    if finding.stale_type in {"source_hash_changed", "source_deleted"}:
+        source = sources_by_id.get(finding.target_ref)
+        if source is not None:
+            path = _as_str(source.get("path", "")).strip()
+            if path:
+                return normalize_path(path)
+    return normalize_path(finding.target_ref)
+
+
+def _build_items_from_findings(
+    bundle: Mapping[str, Any],
+    scan_result: StaleKnowledgeScanResult,
+    plan: RefreshPlanResult,
+    signals: ArchitectSignalResult,
+) -> list[RefreshReportItem]:
+    plan_map = _plan_by_stale_id(plan)
+    signal_map = _signals_by_path(signals)
+    sources_by_id, _ = _build_source_index(bundle)
+    items: list[RefreshReportItem] = []
+
+    for finding in scan_result.findings:
+        target = _resolve_item_ref(finding, sources_by_id)
+        plan_item = plan_map.get(finding.stale_id)
+        path_signals = signal_map.get(target, [])
+        classification = classify_finding(finding, plan_item, path_signals)
+        if classification not in CLASSIFICATIONS:
+            classification = "no_action"
+
+        issue_proposal: str | None = None
+        if classification == "needs_issue_proposal":
+            issue_proposal = _issue_proposal_text(
+                target,
+                classification,
+                finding.stale_type,
+                plan_item.priority if plan_item else None,
+                finding.reason,
+            )
+
+        items.append(
+            RefreshReportItem(
+                item_id=_item_id(target, classification, finding.stale_type),
+                target_ref=target,
+                classification=classification,
+                reason=finding.reason,
+                write_authorized=False,
+                canon_protected=is_canon_protected(target),
+                stale_type=finding.stale_type,
+                severity=finding.severity,
+                priority=plan_item.priority if plan_item else None,
+                plan_id=plan_item.plan_id if plan_item else None,
+                recommended_action=plan_item.recommended_action if plan_item else None,
+                architect_signal_ids=tuple(s.signal_id for s in path_signals),
+                issue_proposal=issue_proposal,
+            )
+        )
+    return items
+
+
+def _classification_summary(items: tuple[RefreshReportItem, ...]) -> dict[str, int]:
+    summary = {cls: 0 for cls in CLASSIFICATIONS}
+    for item in items:
+        if item.classification in summary:
+            summary[item.classification] += 1
+    return summary
+
+
+def _quality_summary(result: QualityScoreResult) -> dict[str, Any]:
+    data = result.to_dict()
+    return {
+        "overall_score": data.get("overall_score"),
+        "overall_grade": data.get("overall_grade"),
+        "scope_id": data.get("scope_id"),
+    }
+
+
+def _architect_summary(result: ArchitectSignalResult) -> dict[str, Any]:
+    return {
+        "total_signals": result.total_signals,
+        "blocking_count": result.blocking_count,
+        "watch_count": result.watch_count,
+    }
+
+
+def _readiness_summary(result: AgentOsReadinessResult) -> dict[str, Any]:
+    return {
+        "readiness_level": result.readiness_level,
+        "confidence": result.confidence,
+        "blocking_findings_count": len(result.blocking_findings),
+        "weak_findings_count": len(result.weak_findings),
+    }
+
+
+def generate_knowledge_refresh_report_v1(
+    bundle: Mapping[str, Any],
+    as_of: str | None = None,
+    *,
+    include_readiness: bool = True,
+) -> KnowledgeRefreshReportResult:
+    """Generate a deterministic knowledge refresh loop report from a bundle.
+
+    Read-only. No DB/network/file writes. No GitHub calls.
+    """
+    validated = _validate_bundle(bundle)
+    resolved_as_of = _resolve_as_of(validated, as_of)
+    scope_id = _resolve_scope_id(validated)
+    errors: list[str] = []
+
+    scan_result = scan_stale_knowledge_v1(validated, as_of=resolved_as_of)
+    plan_result = generate_refresh_plan_v1(scan_result, as_of=resolved_as_of)
+    enriched = _enrich_bundle(validated, scan_result)
+
+    quality_result: QualityScoreResult | None = None
+    architect_result: ArchitectSignalResult | None = None
+    readiness_result: AgentOsReadinessResult | None = None
+
+    try:
+        quality_result = score_knowledge_quality_v1(enriched, as_of=resolved_as_of)
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"quality_scoring: {type(exc).__name__}: {exc}")
+
+    try:
+        architect_result = scan_architect_signals_v1(enriched, as_of=resolved_as_of)
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"architect_signals: {type(exc).__name__}: {exc}")
+
+    if include_readiness:
+        try:
+            readiness_result = evaluate_agent_os_readiness_v1(enriched, as_of=resolved_as_of)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"agent_os_readiness: {type(exc).__name__}: {exc}")
+
+    items: list[RefreshReportItem] = []
+    if architect_result is not None:
+        items.extend(
+            _build_items_from_findings(
+                validated, scan_result, plan_result, architect_result
+            )
+        )
+    else:
+        empty_signals = ArchitectSignalResult(
+            scope_id=scope_id,
+            total_signals=0,
+            blocking_count=0,
+            watch_count=0,
+            signals=(),
+            scanned_at=resolved_as_of,
+        )
+        items.extend(
+            _build_items_from_findings(
+                validated, scan_result, plan_result, empty_signals
+            )
+        )
+
+    covered = {item.target_ref for item in items}
+    items.extend(_detect_orphan_sources(validated, covered))
+
+    items.sort(key=lambda i: (i.classification, i.target_ref, i.item_id))
+    item_tuple = tuple(items)
+    status = "error" if errors and not item_tuple else "ok"
+    if errors and item_tuple:
+        status = "ok"
+
+    return KnowledgeRefreshReportResult(
+        report_id=_report_id(scope_id, resolved_as_of),
+        scope_id=scope_id,
+        as_of=resolved_as_of,
+        status=status,
+        classification_summary=_classification_summary(item_tuple),
+        items=item_tuple,
+        stale_scan={
+            "total_count": scan_result.total_count,
+            "blocking_count": scan_result.blocking_count,
+            "status": scan_result.status,
+            "guardrails": list(STALE_GUARDRAILS),
+        },
+        refresh_plan={
+            "plan_item_count": plan_result.plan_item_count,
+            "blocking_findings": plan_result.blocking_findings,
+            "status": plan_result.status,
+            "write_authorized": False,
+        },
+        quality=_quality_summary(quality_result) if quality_result else {},
+        architect_signals=_architect_summary(architect_result) if architect_result else {},
+        agent_os_readiness=_readiness_summary(readiness_result) if readiness_result else None,
+        guardrails=GUARDRAILS,
+        errors=tuple(errors),
+    )


### PR DESCRIPTION
## Summary

Adds a read-only Knowledge Refresh Loop report for Issue #2717.
The report consolidates existing Context Intelligence signals from stale knowledge scanning, refresh planning, quality scoring, architect signals, and optional Agent OS readiness into deterministic JSON/Markdown output.

Closes #2717.

## Scope

- Add `tools/surrealdb/knowledge_refresh_report.py`
- Add `tools/surrealdb/knowledge_refresh_cli.py`
- Add deterministic fixture under `tests/fixtures/surrealdb/knowledge_refresh/`
- Add unit tests for classification and guardrails
- Add contract and runbook docs

## Non-Goals

- No DB write
- No Memory write
- No GitHub write from tool code
- No scheduler
- No CI workflow
- No dashboard
- No MCP tool in v1
- No auto-delete
- No auto-archive
- No Live-/Echtgeld-Go

## Validation

- [x] `pytest tests/unit/surrealdb/test_knowledge_refresh_report.py -q`
- [x] `ruff check tools/surrealdb/knowledge_refresh_report.py tools/surrealdb/knowledge_refresh_cli.py`
- [x] Optional CLI smoke:
  `python -m tools.surrealdb.knowledge_refresh_cli --format markdown report-knowledge-refresh --input tests/fixtures/surrealdb/knowledge_refresh/sample_bundle.json --as-of 2026-05-06T12:00:00+00:00`

## Guardrails

- Pure report path only
- Deterministic JSON output
- `write_authorized=false` on report items
- Canon-protected sources are never classified as archive/delete-only candidates
- Issue proposals are text-only
- LR remains NO-GO
- Board-stage `trade-capable` is not a Live-Go

## Brain Evidence

brain_source: repo-only
brain_status: not-used
tools_or_queries:
  - pytest tests/unit/surrealdb/test_knowledge_refresh_report.py -q
  - ruff check tools/surrealdb/knowledge_refresh_report.py tools/surrealdb/knowledge_refresh_cli.py
  - gh issue view 2717, 1976, 2204, 2603-2606
records_or_results:
  - 19 unit tests passed
  - ruff clean on new modules
  - commit 580a6d9c on feat/2717-knowledge-refresh-loop-report from origin/main
repo_crosscheck:
  - tools/surrealdb/stale_knowledge_scan.py, stale_refresh_plan.py, quality_scoring.py, architect_signals.py reused
  - no surrealdb SDK import in knowledge_refresh_report.py
impact_on_plan:
  - Closure slice for #2717 only; no CI/DB/MCP expansion
limitations:
  - CI checks on PR not yet verified at authoring time
  - DB-backed bundle load deferred to #2603 follow-up
