### PR TITLE
test(surrealdb): add cross-session memory rediscovery proof

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ else
   SECRETS_PATH ?= $(HOME)/Documents/.secrets/.cdb
 endif
 
-.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-query-config-init context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke context-smoke-db context-memory-db-proof context-claim-evidence-proof context-doctor
+.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-query-config-init context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke context-smoke-db context-memory-db-proof context-claim-evidence-proof context-memory-rediscovery-proof context-doctor
 
 help:
 	@echo "Claire de Binare - Test Commands"
@@ -107,6 +107,7 @@ help:
 	@echo "  make context-smoke-db        - Hard fail-closed DB-backed smoke (#2460)"
 	@echo "  make context-memory-db-proof - Narrow memory read+stale proof (#2603/#2606)"
 	@echo "  make context-claim-evidence-proof - Claim evidence at rest proof (#2719/#2606)"
+	@echo "  make context-memory-rediscovery-proof - Cross-session memory rediscovery (#2720)"
 	@echo "  make context-doctor          - Read-only onboarding preflight (#2642)"
 # ============================================================================
 # CI-Tests (schnell, mit Mocks)
@@ -505,6 +506,16 @@ context-claim-evidence-proof: context-env-check
 	@echo "--- Schritt 2: Claim evidence at rest proof (run-scoped cleanup) ---"
 	@$(PYTHON) -m tools.surrealdb.claim_evidence_proof_cli run-proof --confirm
 	@echo "[OK] context-claim-evidence-proof: claim evidence at rest complete (LR: NO-GO)"
+
+context-memory-rediscovery-proof: context-env-check
+	@echo "=== Cross-session memory rediscovery proof #2720 ==="
+	@echo "NOTE: Lokaler Scope nur. LR: NO-GO. Manifest + subprocess prove; kein produktiver Write."
+	@echo "--- Schritt 1: Hard Schema-Check (cdb_surrealdb muss laufen) ---"
+	@$(PYTHON) tools/surrealdb/local_schema_check.py --hard-mode \
+		--secrets-path "$(SECRETS_PATH)"
+	@echo "--- Schritt 2: Seed + manifest + subprocess prove (run-scoped cleanup) ---"
+	@$(PYTHON) -m tools.surrealdb.memory_rediscovery_proof_cli run-proof --confirm
+	@echo "[OK] context-memory-rediscovery-proof: cross-session rediscovery complete (LR: NO-GO)"
 
 # ============================================================================# Paper Trading (14-Tage Test)
 # ============================================================================

--- a/docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md
+++ b/docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md
@@ -378,6 +378,16 @@ CLI equivalent:
 python -m tools.surrealdb.claim_evidence_proof_cli run-proof --confirm
 ```
 
+### Cross-session memory rediscovery (#2720)
+
+Two-process proof: manifest under ``.cdb_memory_rediscovery/<run_id>/`` plus DB
+lookup by ``memory_id`` and ``scope``. See
+[`docs/surrealdb/cross-session-memory-rediscovery-v1.md`](../surrealdb/cross-session-memory-rediscovery-v1.md).
+
+```bash
+make context-memory-rediscovery-proof
+```
+
 ---
 
 ## Häufige Fehler

--- a/docs/surrealdb/cross-session-memory-rediscovery-v1.md
+++ b/docs/surrealdb/cross-session-memory-rediscovery-v1.md
@@ -1,0 +1,68 @@
+# Cross-Session Memory Rediscovery v1 (#2720)
+
+**Status:** Campaign deliverable  
+**Issue:** [#2720](https://github.com/jannekbuengener/Claire_de_Binare/issues/2720)  
+**Epic:** [#2606](https://github.com/jannekbuengener/Claire_de_Binare/issues/2606) (stays OPEN)  
+**LR:** NO-GO (unchanged)
+
+---
+
+## Purpose
+
+Prove that run-scoped ``agent_memory`` rows remain discoverable by ``memory_id`` and
+``scope`` across process boundaries. Process A seeds DB rows and writes a
+non-sensitive manifest; process B (fresh Python subprocess) reads only the
+manifest and DB.
+
+**Non-goals:** productive memory write; MCP mutation; MCP ``by_memory_id`` feature;
+closing #2606.
+
+---
+
+## Flow
+
+1. Seed run-scoped fixtures (same path as #2603 / #2719).
+2. Write ``.cdb_memory_rediscovery/<run_id>/manifest.json`` (memory_id, scope, evidence_ids, run_id only).
+3. Subprocess ``prove-phase`` loads manifest + SurrealDB adapter; SELECT by memory_id AND scope.
+4. Stale scan + claim evidence at rest (#2719) on the same scope.
+5. Cleanup DB rows and manifest directory.
+
+---
+
+## Operator path
+
+```bash
+make context-memory-rediscovery-proof
+```
+
+CLI:
+
+```bash
+python -m tools.surrealdb.memory_rediscovery_proof_cli run-proof --confirm
+```
+
+---
+
+## CI boundary
+
+| Layer | Proves |
+|-------|--------|
+| `tests/unit/surrealdb/test_memory_cross_session_rediscovery_contract.py` | Manifest + prove contracts (mocks) |
+| `make context-memory-rediscovery-proof` | Local two-process proof |
+| Required `ci.yml` | **No** live SurrealDB |
+
+---
+
+## Limits
+
+- Proof is local operator / opt-in ``local_only`` only.
+- Manifest handoff is file-based; not a production rediscovery API.
+- Depends on #2719 claim evidence enforcement for linked claims in scope.
+
+---
+
+## References
+
+- [`db-runtime-ci-proof-path-v1.md`](db-runtime-ci-proof-path-v1.md)
+- [`claim-evidence-at-rest-v1.md`](claim-evidence-at-rest-v1.md)
+- Module: `tools/surrealdb/memory_cross_session_rediscovery.py`

--- a/docs/surrealdb/db-runtime-ci-proof-path-v1.md
+++ b/docs/surrealdb/db-runtime-ci-proof-path-v1.md
@@ -28,7 +28,7 @@ compose changes; closing #2606; SurrealDB in required CI (~26 min `context-smoke
 | 2 | DB stale scan proof | `memory_db_stale_scan.py`; #2708 on main | Same boundary as (1) | Same operator path | **IMPLEMENTABLE_NOW** — local PASS path; CI **PARTIAL** |
 | 3 | Productive audit trail | Gate + local `audit_observation` only | By design blocked | Document **BLOCKED** | **BLOCKED** (no activation) |
 | 4 | Claim evidence at rest | `claim_evidence_at_rest.py`; unit mocks; optional `context-claim-evidence-proof` | CI: mocks only; runtime: local operator path | `make context-claim-evidence-proof`; see [`claim-evidence-at-rest-v1.md`](claim-evidence-at-rest-v1.md) | **PASS WITH LIMITS** — local operator path; CI **PARTIAL** |
-| 5 | Cross-session rediscovery | Depends on (1); `memory_id`+`scope` in helpers | Not CI-proven across sessions | Follow-up #2720 | **NEEDS_FOLLOW_UP** (until #2720 lands) |
+| 5 | Cross-session rediscovery | `memory_cross_session_rediscovery.py`; manifest + subprocess prove | CI: mocks only; runtime: local operator | `make context-memory-rediscovery-proof`; see [`cross-session-memory-rediscovery-v1.md`](cross-session-memory-rediscovery-v1.md) | **PASS WITH LIMITS** — local two-process proof; CI **PARTIAL** |
 | 6 | CI/runtime SurrealDB service | `context-smoke-db` needs Docker + secrets; not in `ci.yml` | Self-hosted `docker` label; no SurrealDB step | Document boundary; optional non-required workflow | **NEEDS_FOLLOW_UP** |
 
 ---
@@ -43,6 +43,7 @@ compose changes; closing #2606; SurrealDB in required CI (~26 min `context-smoke
 | `make context-smoke-db` | Full context pipeline + DB write + query min-count | No (operator; ~26 min) |
 | `make context-memory-db-proof` | Narrow read + stale on run-scoped fixtures | No (operator; minutes) |
 | `make context-claim-evidence-proof` | Claim evidence at rest on run-scoped fixtures (#2719) | No (operator; minutes) |
+| `make context-memory-rediscovery-proof` | Cross-session memory_id+scope rediscovery (#2720) | No (operator; minutes) |
 | `pytest -m local_only` memory proof tests | Same as CLI cycle with env gate | No |
 
 **CI policy:** Do not add live SurrealDB to required `.github/workflows/ci.yml`.

--- a/tests/local/surrealdb/test_memory_cross_session_rediscovery_local.py
+++ b/tests/local/surrealdb/test_memory_cross_session_rediscovery_local.py
@@ -1,0 +1,33 @@
+"""Opt-in local cross-session memory rediscovery — #2720."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tools.surrealdb.memory_rediscovery_proof_runtime import (
+    run_memory_rediscovery_proof_cycle,
+)
+
+pytestmark = pytest.mark.local_only
+
+_ENV = "CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE"
+
+
+def _enabled() -> bool:
+    return os.environ.get(_ENV) == "1"
+
+
+@pytest.mark.skipif(
+    not _enabled(),
+    reason=f"set {_ENV}=1 for local SurrealDB rediscovery proof",
+)
+def test_cross_session_rediscovery_local_cycle() -> None:
+    result = run_memory_rediscovery_proof_cycle(confirm=True)
+    assert result["status"] == "ok"
+    prove = result["prove_envelope"]
+    assert prove["schema_version"] == "memory-cross-session-rediscovery/v1"
+    assert prove["seed_process"] != prove["prove_process"]
+    assert prove["memory_ids_found"]
+    assert "SURREAL_PASS" not in str(result)

--- a/tests/unit/surrealdb/test_local_runtime.py
+++ b/tests/unit/surrealdb/test_local_runtime.py
@@ -105,6 +105,23 @@ def test_makefile_context_claim_evidence_proof_invokes_cli() -> None:
 
 
 @pytest.mark.unit
+def test_makefile_context_memory_rediscovery_proof_in_phony() -> None:
+    content = _read_makefile()
+    phony_lines = [line for line in content.splitlines() if line.startswith(".PHONY:")]
+    phony_text = " ".join(phony_lines)
+    assert "context-memory-rediscovery-proof" in phony_text
+
+
+@pytest.mark.unit
+def test_makefile_context_memory_rediscovery_proof_invokes_cli() -> None:
+    content = _read_makefile()
+    recipe = _lines_for_target(content, "context-memory-rediscovery-proof")
+    recipe_text = "\n".join(recipe)
+    assert "memory_rediscovery_proof_cli" in recipe_text
+    assert "run-proof" in recipe_text
+
+
+@pytest.mark.unit
 def test_local_schema_check_hard_mode_exits_nonzero_if_offline() -> None:
     from tools.surrealdb import local_schema_check
 

--- a/tests/unit/surrealdb/test_memory_cross_session_rediscovery_contract.py
+++ b/tests/unit/surrealdb/test_memory_cross_session_rediscovery_contract.py
@@ -1,0 +1,172 @@
+"""Unit tests for cross-session memory rediscovery contracts — #2720."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.surrealdb.memory_cross_session_rediscovery import (
+    MemoryRediscoveryError,
+    build_manifest_from_plan,
+    load_rediscovery_manifest,
+    prove_cross_session_rediscovery_from_manifest,
+    write_rediscovery_manifest,
+)
+
+_SCOPE = "memory_db_proof:unittest"
+
+
+def _mock_adapter(rows_by_query: dict[str, list[dict[str, Any]]]) -> MagicMock:
+    adapter = MagicMock()
+    adapter.status = "surrealdb-local"
+
+    def _execute(query: str) -> list[dict[str, Any]]:
+        for key, rows in rows_by_query.items():
+            if key in query:
+                return rows
+        return []
+
+    adapter.execute.side_effect = _execute
+    return adapter
+
+
+def _memory_row(memory_id: str) -> dict[str, Any]:
+    return {
+        "memory_id": memory_id,
+        "scope": _SCOPE,
+        "namespace": _SCOPE,
+        "memory_type": "semantic_memory",
+        "content": "cross-session proof memory",
+        "source_refs": ["docs/surrealdb/memory-reality-slice1-audit.md"],
+        "evidence_refs": ["ev-unit-001"],
+        "confidence": 0.9,
+        "ttl": 86400,
+        "created_by": "cdb-test-001",
+        "created_at": "2026-05-29T10:00:00Z",
+        "expires_at": "2026-05-30T10:00:00Z",
+    }
+
+
+@pytest.mark.unit
+def test_manifest_round_trip(tmp_path: Path) -> None:
+    manifest = build_manifest_from_plan(
+        run_id="run-test-001",
+        scope=_SCOPE,
+        memory_ids=("mid-a", "mid-b"),
+        evidence_ids=("ev-unit-001",),
+        seed_process_id=1000,
+    )
+    path = tmp_path / "manifest.json"
+    write_rediscovery_manifest(manifest, path)
+    loaded = load_rediscovery_manifest(path)
+    assert loaded.run_id == "run-test-001"
+    assert len(loaded.entries) == 2
+    assert loaded.entries[0].memory_id == "mid-a"
+
+
+@pytest.mark.unit
+def test_prove_without_manifest_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(MemoryRediscoveryError, match="manifest missing"):
+        load_rediscovery_manifest(tmp_path / "missing.json")
+
+
+@pytest.mark.unit
+def test_scope_mismatch_in_manifest_entries_blocks_prove() -> None:
+    from tools.surrealdb.memory_cross_session_rediscovery import (
+        RediscoveryManifest,
+        RediscoveryManifestEntry,
+    )
+
+    manifest = RediscoveryManifest(
+        schema_version="memory-cross-session-rediscovery-manifest/v1",
+        run_id="r1",
+        seed_process_id=1,
+        entries=(
+            RediscoveryManifestEntry("m1", "scope-a", ("ev-1",)),
+            RediscoveryManifestEntry("m2", "scope-b", ("ev-1",)),
+        ),
+    )
+    adapter = _mock_adapter({})
+    with pytest.raises(MemoryRediscoveryError, match="single scope"):
+        prove_cross_session_rediscovery_from_manifest(
+            adapter,
+            manifest,
+            prove_process_id=2,
+        )
+
+
+@pytest.mark.unit
+def test_memory_id_and_scope_lookup_required() -> None:
+    manifest = build_manifest_from_plan(
+        run_id="r2",
+        scope=_SCOPE,
+        memory_ids=("mid-lookup",),
+        evidence_ids=("ev-unit-001",),
+        seed_process_id=10,
+    )
+    adapter = _mock_adapter({})
+    with pytest.raises(MemoryRediscoveryError, match="expected exactly one"):
+        prove_cross_session_rediscovery_from_manifest(
+            adapter,
+            manifest,
+            prove_process_id=20,
+        )
+
+
+@pytest.mark.unit
+def test_prove_envelope_has_source_trust_limitations() -> None:
+    memory_id = "988581e3-7003-5e93-a847-9dcfe2d4633f"
+    row = _memory_row(memory_id)
+    from tools.surrealdb.memory_contract import generate_memory_id
+
+    row["memory_id"] = generate_memory_id(
+        scope=row["scope"],
+        namespace=row["namespace"],
+        memory_type=row["memory_type"],
+        created_by=row["created_by"],
+        content=row["content"],
+        source_refs=row["source_refs"],
+    )
+    mid = row["memory_id"]
+    manifest = build_manifest_from_plan(
+        run_id="r3",
+        scope=_SCOPE,
+        memory_ids=(mid,),
+        evidence_ids=("ev-unit-001",),
+        seed_process_id=30,
+    )
+
+    claim_row = {
+        "claim_id": "claim-unit",
+        "scope": _SCOPE,
+        "status": "supported",
+        "evidence_refs": ["ev-unit-001"],
+    }
+    evidence_row = {"evidence_id": "ev-unit-001", "evidence_type": "test_run"}
+
+    adapter = _mock_adapter(
+        {
+            "agent_memory": [row],
+            f"memory_id = '{mid}'": [row],
+            "FROM claim": [claim_row],
+            "FROM evidence_ref": [evidence_row],
+        }
+    )
+
+    prove = prove_cross_session_rediscovery_from_manifest(
+        adapter,
+        manifest,
+        prove_process_id=40,
+    )
+    assert prove["schema_version"] == "memory-cross-session-rediscovery/v1"
+    assert prove["source"] == "surrealdb-local"
+    assert prove["trust"]["lookup_keys"] == ["memory_id", "scope"]
+    assert prove["limitations"]
+    assert prove["approval_semantics"]["no_live_go"] is True
+    assert prove["claim_evidence_at_rest"]["claim_count"] >= 1
+    rendered = json.dumps(prove)
+    assert "SURREAL_PASS" not in rendered

--- a/tools/surrealdb/memory_cross_session_rediscovery.py
+++ b/tools/surrealdb/memory_cross_session_rediscovery.py
@@ -1,0 +1,344 @@
+"""Cross-session memory rediscovery proof — #2720.
+
+Proves that run-scoped ``agent_memory`` rows remain discoverable by
+``memory_id`` + ``scope`` across process boundaries using a manifest handoff.
+
+No productive writes. No MCP mutation. LR: NO-GO.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Protocol
+
+from core.utils.clock import utcnow as cdb_utcnow
+from tools.mcp.surrealdb_adapter_factory import adapter_source
+from tools.surrealdb.claim_evidence_at_rest import prove_claim_evidence_at_rest_db_v1
+from tools.surrealdb.memory_contract import (
+    MemoryContractError,
+    validate_memory_id_matches_record,
+    validate_memory_record,
+)
+from tools.surrealdb.memory_db_stale_scan import scan_agent_memory_stale_v1
+
+SCHEMA_VERSION = "memory-cross-session-rediscovery/v1"
+MANIFEST_SCHEMA_VERSION = "memory-cross-session-rediscovery-manifest/v1"
+
+_SURQL_SAFE_RE = re.compile(r"^[a-zA-Z0-9/_.@:#+ \-]+$")
+
+_DB_STRIP_FIELDS = frozenset(
+    {
+        "run_id",
+        "schema_version",
+        "id",
+        "sensitivity",
+    }
+)
+
+_SECRET_SUBSTRINGS = frozenset(
+    {
+        "SURREAL_PASS",
+        "SURREAL_USER",
+        "Authorization",
+        "Basic ",
+    }
+)
+
+
+class MemoryRediscoveryError(ValueError):
+    """Raised when cross-session rediscovery proof fails."""
+
+
+class MemoryRediscoveryAdapter(Protocol):
+    status: str
+
+    def execute(self, query: str) -> list[dict[str, Any]]: ...
+
+
+@dataclass(frozen=True)
+class RediscoveryManifestEntry:
+    memory_id: str
+    scope: str
+    evidence_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RediscoveryManifest:
+    schema_version: str
+    run_id: str
+    seed_process_id: int
+    entries: tuple[RediscoveryManifestEntry, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id,
+            "seed_process_id": self.seed_process_id,
+            "entries": [
+                {
+                    "memory_id": entry.memory_id,
+                    "scope": entry.scope,
+                    "evidence_ids": list(entry.evidence_ids),
+                }
+                for entry in self.entries
+            ],
+        }
+
+
+def rediscovery_manifest_dir(repo_root: Path, run_id: str) -> Path:
+    return repo_root / ".cdb_memory_rediscovery" / run_id
+
+
+def manifest_path_for_run(repo_root: Path, run_id: str) -> Path:
+    return rediscovery_manifest_dir(repo_root, run_id) / "manifest.json"
+
+
+def build_manifest_from_plan(
+    *,
+    run_id: str,
+    scope: str,
+    memory_ids: tuple[str, ...],
+    evidence_ids: tuple[str, ...],
+    seed_process_id: int,
+) -> RediscoveryManifest:
+    if not memory_ids:
+        raise MemoryRediscoveryError("manifest requires at least one memory_id")
+    entries = tuple(
+        RediscoveryManifestEntry(
+            memory_id=mid,
+            scope=scope,
+            evidence_ids=evidence_ids,
+        )
+        for mid in memory_ids
+    )
+    return RediscoveryManifest(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        run_id=run_id,
+        seed_process_id=seed_process_id,
+        entries=entries,
+    )
+
+
+def write_rediscovery_manifest(manifest: RediscoveryManifest, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(manifest.to_dict(), indent=2, sort_keys=True, ensure_ascii=True)
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def load_rediscovery_manifest(path: Path) -> RediscoveryManifest:
+    if not path.is_file():
+        raise MemoryRediscoveryError(f"manifest missing: {path}")
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if raw.get("schema_version") != MANIFEST_SCHEMA_VERSION:
+        raise MemoryRediscoveryError("manifest schema_version mismatch")
+    run_id = str(raw.get("run_id") or "").strip()
+    if not run_id:
+        raise MemoryRediscoveryError("manifest missing run_id")
+    entries_raw = raw.get("entries")
+    if not isinstance(entries_raw, list) or not entries_raw:
+        raise MemoryRediscoveryError("manifest entries empty")
+    entries: list[RediscoveryManifestEntry] = []
+    for item in entries_raw:
+        if not isinstance(item, Mapping):
+            raise MemoryRediscoveryError("manifest entry must be object")
+        memory_id = str(item.get("memory_id") or "").strip()
+        scope = str(item.get("scope") or "").strip()
+        if not memory_id or not scope:
+            raise MemoryRediscoveryError("manifest entry missing memory_id or scope")
+        evidence_raw = item.get("evidence_ids") or []
+        if not isinstance(evidence_raw, list):
+            raise MemoryRediscoveryError("manifest evidence_ids must be list")
+        evidence_ids = tuple(str(x).strip() for x in evidence_raw if str(x).strip())
+        entries.append(
+            RediscoveryManifestEntry(
+                memory_id=memory_id,
+                scope=scope,
+                evidence_ids=evidence_ids,
+            )
+        )
+    return RediscoveryManifest(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        run_id=run_id,
+        seed_process_id=int(raw.get("seed_process_id") or 0),
+        entries=tuple(entries),
+    )
+
+
+def _safe_surql_str(value: str | None) -> str | None:
+    if not value:
+        return None
+    text = value.strip()
+    return text if (text and _SURQL_SAFE_RE.match(text)) else None
+
+
+def _strip_db_metadata(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: value for key, value in dict(row).items() if key not in _DB_STRIP_FIELDS
+    }
+
+
+def _fetch_memory_by_id_and_scope(
+    adapter: MemoryRediscoveryAdapter,
+    *,
+    memory_id: str,
+    scope: str,
+) -> dict[str, Any]:
+    safe_id = _safe_surql_str(memory_id)
+    safe_scope = _safe_surql_str(scope)
+    if not safe_id or not safe_scope:
+        raise MemoryRediscoveryError("memory_id or scope not safe for SurrealQL")
+    query = (
+        f"SELECT * FROM agent_memory WHERE memory_id = '{safe_id}' "
+        f"AND scope = '{safe_scope}' LIMIT 2"
+    )
+    rows = adapter.execute(query)
+    matches: list[dict[str, Any]] = []
+    for row in rows:
+        if isinstance(row, Mapping):
+            matches.append(_strip_db_metadata(row))
+    if len(matches) != 1:
+        raise MemoryRediscoveryError(
+            f"expected exactly one memory row for {memory_id!r} + {scope!r}, "
+            f"found {len(matches)}"
+        )
+    record = matches[0]
+    validate_memory_record(record)
+    validate_memory_id_matches_record(record)
+    if str(record.get("scope")) != scope:
+        raise MemoryRediscoveryError("loaded row scope mismatch")
+    return record
+
+
+def prove_cross_session_rediscovery_from_manifest(
+    adapter: MemoryRediscoveryAdapter,
+    manifest: RediscoveryManifest,
+    *,
+    prove_process_id: int,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Prove phase: manifest + DB only (intended for a fresh subprocess)."""
+    if prove_process_id == manifest.seed_process_id:
+        raise MemoryRediscoveryError(
+            "prove process must differ from seed process for cross-session proof"
+        )
+
+    ref_now = now or cdb_utcnow()
+    if ref_now.tzinfo is None:
+        ref_now = ref_now.replace(tzinfo=timezone.utc)
+
+    scopes = {entry.scope for entry in manifest.entries}
+    if len(scopes) != 1:
+        raise MemoryRediscoveryError("manifest must use single scope for proof slice")
+    scope = next(iter(scopes))
+
+    memory_ids_found: list[str] = []
+    records: list[dict[str, Any]] = []
+
+    for entry in manifest.entries:
+        if entry.scope != scope:
+            raise MemoryRediscoveryError("manifest scope mismatch across entries")
+        record = _fetch_memory_by_id_and_scope(
+            adapter,
+            memory_id=entry.memory_id,
+            scope=entry.scope,
+        )
+        memory_ids_found.append(entry.memory_id)
+        records.append(record)
+
+    stale_scan = scan_agent_memory_stale_v1(
+        adapter=adapter,
+        scope=scope,
+        limit=max(25, len(manifest.entries) * 4),
+        now=ref_now,
+    )
+
+    claim_proof = prove_claim_evidence_at_rest_db_v1(
+        adapter,
+        scope=scope,
+        limit=50,
+    )
+
+    envelope = {
+        "schema_version": SCHEMA_VERSION,
+        "source": adapter_source(adapter),
+        "adapter_status": adapter.status,
+        "seed_process": manifest.seed_process_id,
+        "prove_process": prove_process_id,
+        "run_id": manifest.run_id,
+        "scope": scope,
+        "memory_ids_found": memory_ids_found,
+        "record_count": len(records),
+        "stale_preserved": {
+            "stale_memory_ids": stale_scan.get("stale_memory_ids", []),
+            "expired_memory_ids": stale_scan.get("expired_memory_ids", []),
+            "record_count": stale_scan.get("record_count"),
+        },
+        "claim_evidence_at_rest": {
+            "schema_version": claim_proof.get("schema_version"),
+            "claim_count": claim_proof.get("claim_count"),
+            "known_evidence_ids": claim_proof.get("known_evidence_ids"),
+        },
+        "trust": {
+            "manifest_schema": MANIFEST_SCHEMA_VERSION,
+            "lookup_keys": ["memory_id", "scope"],
+            "read_only": True,
+        },
+        "limitations": _limitations(),
+        "approval_semantics": _approval_semantics(),
+    }
+    _assert_no_secrets(envelope)
+    return envelope
+
+
+def cleanup_rediscovery_manifest(path: Path) -> None:
+    directory = path.parent
+    if path.is_file():
+        path.unlink()
+    if directory.is_dir() and not any(directory.iterdir()):
+        directory.rmdir()
+    parent = directory.parent
+    if parent.is_dir() and parent.name == ".cdb_memory_rediscovery":
+        try:
+            if not any(parent.iterdir()):
+                parent.rmdir()
+        except OSError:
+            pass
+
+
+def _limitations() -> list[str]:
+    return [
+        "read_only_proof_no_writes",
+        "cross_session_via_manifest_and_subprocess",
+        "no_mcp_by_memory_id_surface",
+        "lr_no_go",
+    ]
+
+
+def _approval_semantics() -> dict[str, Any]:
+    return {
+        "read_only": True,
+        "no_write": True,
+        "no_approval": True,
+        "no_live_go": True,
+        "no_echtgeld_go": True,
+        "note": (
+            "Cross-session rediscovery proof only. Does not authorize productive "
+            "memory write or MCP mutation."
+        ),
+    }
+
+
+def _assert_no_secrets(payload: Mapping[str, Any]) -> None:
+    rendered = str(payload)
+    for needle in _SECRET_SUBSTRINGS:
+        if needle in rendered:
+            raise MemoryRediscoveryError(
+                "envelope contains forbidden secret-like substring"
+            )

--- a/tools/surrealdb/memory_rediscovery_proof_cli.py
+++ b/tools/surrealdb/memory_rediscovery_proof_cli.py
@@ -1,0 +1,84 @@
+"""CLI for #2720 cross-session memory rediscovery proof."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from tools.surrealdb.memory_rediscovery_proof_runtime import (
+    check_memory_rediscovery_proof_preconditions,
+    run_memory_rediscovery_proof_cycle,
+    run_prove_phase_only,
+)
+
+EXIT_OK = 0
+EXIT_RUNTIME = 1
+EXIT_USAGE = 2
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Cross-session memory rediscovery proof (manifest + DB). "
+            "LR: NO-GO. No productive write."
+        )
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    preflight = sub.add_parser("preflight", help="Check local SurrealDB preconditions")
+    preflight.add_argument("--confirm", action="store_true")
+
+    run = sub.add_parser(
+        "run-proof",
+        help="Seed fixtures, write manifest, prove in subprocess, cleanup",
+    )
+    run.add_argument("--confirm", action="store_true")
+
+    prove = sub.add_parser(
+        "prove-phase",
+        help="Prove phase only (subprocess); requires existing manifest + DB rows",
+    )
+    prove.add_argument(
+        "--manifest",
+        required=True,
+        help="Path to rediscovery manifest.json",
+    )
+    prove.add_argument("--confirm", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "preflight":
+            result = check_memory_rediscovery_proof_preconditions(confirm=args.confirm)
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return EXIT_OK if result["ok"] else EXIT_RUNTIME
+
+        if args.command == "run-proof":
+            result = run_memory_rediscovery_proof_cycle(confirm=args.confirm)
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return EXIT_OK
+
+        if args.command == "prove-phase":
+            result = run_prove_phase_only(
+                manifest_path=Path(args.manifest),
+                confirm=args.confirm,
+            )
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return EXIT_OK
+
+    except RuntimeError as exc:
+        print(json.dumps({"status": "error", "message": str(exc)}, indent=2))
+        return EXIT_RUNTIME
+
+    parser.print_help()
+    return EXIT_USAGE
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/surrealdb/memory_rediscovery_proof_runtime.py
+++ b/tools/surrealdb/memory_rediscovery_proof_runtime.py
@@ -1,0 +1,209 @@
+"""Operator runtime for #2720 cross-session memory rediscovery proof."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from core.utils.clock import utcnow as cdb_utcnow
+from tools.mcp.context_evidence_memory_tools import TOOL_CDB_CONTEXT_MEMORY_GET
+from tools.mcp.surrealdb_adapter_factory import build_adapter_from_params
+from tools.surrealdb.memory_cross_session_rediscovery import (
+    SCHEMA_VERSION,
+    build_manifest_from_plan,
+    cleanup_rediscovery_manifest,
+    load_rediscovery_manifest,
+    manifest_path_for_run,
+    prove_cross_session_rediscovery_from_manifest,
+    write_rediscovery_manifest,
+)
+from tools.surrealdb.memory_db_proof_local_dev import (
+    QUERY_CONFIG_REL,
+    MemoryDbProofRecordPlan,
+    MemoryDbProofSqlClient,
+    assert_memory_proof_records_absent,
+    assert_memory_proof_tmp_absent,
+    build_memory_proof_record_plan,
+    cleanup_memory_proof_records,
+    cleanup_memory_proof_tmp,
+    materialize_memory_proof_bundle,
+    memory_proof_tmp_root,
+    repo_root,
+    resolve_memory_proof_run_id,
+    resolve_secrets_path,
+    seed_memory_proof_bundle,
+)
+from tools.surrealdb.memory_db_proof_runtime import check_memory_db_proof_preconditions
+
+REDISCOVERY_RUNTIME_SCHEMA = "memory-rediscovery-proof-runtime/v1"
+_PROVE_CLI_MODULE = "tools.surrealdb.memory_rediscovery_proof_cli"
+
+
+def _redact_for_output(
+    payload: dict[str, Any], *, secrets_path: Path | None
+) -> dict[str, Any]:
+    rendered = json.dumps(payload, sort_keys=True, default=str)
+    assert "Authorization" not in rendered
+    assert "Basic " not in rendered
+    assert "SURREAL_PASS" not in rendered
+    assert "SURREAL_USER" not in rendered
+    if secrets_path is not None:
+        assert str(secrets_path) not in rendered
+    return payload
+
+
+def check_memory_rediscovery_proof_preconditions(
+    *, confirm: bool = False
+) -> dict[str, Any]:
+    base = check_memory_db_proof_preconditions(confirm=confirm)
+    return {
+        **base,
+        "schema_version": REDISCOVERY_RUNTIME_SCHEMA,
+    }
+
+
+def _build_adapter(secrets_path: Path) -> Any:
+    query_config = repo_root() / QUERY_CONFIG_REL
+    result = build_adapter_from_params(
+        {
+            "adapter_config_path": str(query_config),
+            "secrets_path": str(secrets_path),
+        },
+        TOOL_CDB_CONTEXT_MEMORY_GET,
+    )
+    if isinstance(result, dict):
+        raise RuntimeError(f"adapter build failed: {result}")
+    adapter, _config = result
+    return adapter
+
+
+def run_prove_phase_subprocess(
+    *,
+    manifest_path: Path,
+    confirm: bool,
+) -> dict[str, Any]:
+    cmd = [
+        sys.executable,
+        "-m",
+        _PROVE_CLI_MODULE,
+        "prove-phase",
+        "--manifest",
+        str(manifest_path),
+    ]
+    if confirm:
+        cmd.append("--confirm")
+    completed = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        stderr = (completed.stderr or "").strip()[:500]
+        raise RuntimeError(
+            f"prove-phase subprocess failed (exit={completed.returncode}): {stderr}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("prove-phase subprocess returned invalid JSON") from exc
+
+
+def run_memory_rediscovery_proof_cycle(*, confirm: bool = False) -> dict[str, Any]:
+    preflight = check_memory_rediscovery_proof_preconditions(confirm=confirm)
+    if not preflight["ok"]:
+        raise RuntimeError("; ".join(preflight["errors"]))
+
+    secrets_path = resolve_secrets_path()
+    if secrets_path is None:
+        raise RuntimeError("secrets path missing after preflight")
+
+    root = repo_root()
+    run_id = resolve_memory_proof_run_id()
+    plan = build_memory_proof_record_plan(run_id)
+    tmp_root = memory_proof_tmp_root(run_id)
+    manifest_path = manifest_path_for_run(root, run_id)
+
+    assert_memory_proof_tmp_absent(tmp_root)
+    sql_client = MemoryDbProofSqlClient.from_secrets_dir(secrets_path)
+    assert_memory_proof_records_absent(sql_client, plan)
+
+    try:
+        bundle_dir = materialize_memory_proof_bundle(tmp_root, run_id=run_id, plan=plan)
+        seed_memory_proof_bundle(bundle_dir, run_id=run_id, secrets_path=secrets_path)
+
+        manifest = build_manifest_from_plan(
+            run_id=run_id,
+            scope=plan.scope,
+            memory_ids=plan.memory_ids,
+            evidence_ids=plan.evidence_ids,
+            seed_process_id=os.getpid(),
+        )
+        write_rediscovery_manifest(manifest, manifest_path)
+
+        prove_envelope = run_prove_phase_subprocess(
+            manifest_path=manifest_path,
+            confirm=confirm,
+        )
+        _validate_prove_envelope(plan, prove_envelope)
+
+        envelope = {
+            "schema_version": REDISCOVERY_RUNTIME_SCHEMA,
+            "status": "ok",
+            "run_id": run_id,
+            "scope": plan.scope,
+            "manifest_path": str(manifest_path.relative_to(root)),
+            "seed_process": manifest.seed_process_id,
+            "prove_envelope": prove_envelope,
+            "approval_semantics": prove_envelope.get("approval_semantics", {}),
+            "limitations": list(
+                dict.fromkeys(
+                    (prove_envelope.get("limitations") or [])
+                    + (preflight.get("limitations") or [])
+                )
+            ),
+        }
+        return _redact_for_output(envelope, secrets_path=secrets_path)
+    finally:
+        cleanup_memory_proof_records(sql_client, plan)
+        cleanup_memory_proof_tmp(tmp_root)
+        cleanup_rediscovery_manifest(manifest_path)
+
+
+def run_prove_phase_only(
+    *,
+    manifest_path: Path,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    """Subprocess entry: load manifest + DB proof only."""
+    preflight = check_memory_rediscovery_proof_preconditions(confirm=confirm)
+    if not preflight["ok"]:
+        raise RuntimeError("; ".join(preflight["errors"]))
+
+    secrets_path = resolve_secrets_path()
+    if secrets_path is None:
+        raise RuntimeError("secrets path missing after preflight")
+
+    manifest = load_rediscovery_manifest(manifest_path)
+    adapter = _build_adapter(secrets_path)
+    return prove_cross_session_rediscovery_from_manifest(
+        adapter,
+        manifest,
+        prove_process_id=os.getpid(),
+        now=cdb_utcnow(),
+    )
+
+
+def _validate_prove_envelope(
+    plan: MemoryDbProofRecordPlan, prove: dict[str, Any]
+) -> None:
+    if prove.get("schema_version") != SCHEMA_VERSION:
+        raise RuntimeError("prove envelope schema mismatch")
+    if set(prove.get("memory_ids_found", [])) != set(plan.memory_ids):
+        raise RuntimeError("memory_ids_found mismatch")
+    if prove.get("scope") != plan.scope:
+        raise RuntimeError("prove scope mismatch")


### PR DESCRIPTION
## Summary
- Cross-session proof: seed process writes manifest; fresh subprocess proves `memory_id` + `scope` DB lookup, stale scan, and #2719 claim evidence linkage.
- Operator: `make context-memory-rediscovery-proof`; docs + proof-gap row 5 → PASS WITH LIMITS (local).

## Brain Evidence
brain_source: repo-only
brain_status: used
tools_or_queries:
  - pytest tests/unit/surrealdb/test_memory_cross_session_rediscovery_contract.py
records_or_results:
  - PR #2724 merged (d308bf6a) — #2719
  - tools/surrealdb/memory_cross_session_rediscovery.py
repo_crosscheck:
  - tools/surrealdb/memory_db_proof_local_dev.py
  - tools/surrealdb/claim_evidence_at_rest.py
impact_on_plan:
  - #2720 acceptance via unit + optional local subprocess cycle
limitations:
  - No MCP by_memory_id; no productive write; CI mock-only; LR NO-GO

## Test plan
- [x] pytest tests/unit/surrealdb/test_memory_cross_session_rediscovery_contract.py -q
- [x] ruff + black on touched files
- [ ] CI required checks

Closes #2720
Part of #2606 (parent stays OPEN)