### PR TITLE
ci(surrealdb): add optional memory proof workflow

### DIFF
--- a/.github/workflows/surrealdb-memory-proof.yml
+++ b/.github/workflows/surrealdb-memory-proof.yml
@@ -1,0 +1,247 @@
+name: Optional SurrealDB Memory Proof
+
+# Non-required, opt-in proof workflow for #2603/#2606 memory paths.
+# Does NOT gate merges. LR remains NO-GO. No productive memory write.
+
+on:
+  workflow_dispatch:
+    inputs:
+      proof_suite:
+        description: "Proof suite to attempt when preflight passes"
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - db-read-only
+          - preflight-only
+      attempt_runtime_proof:
+        description: "Run make proof targets after successful preflight"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  surrealdb-memory-proof:
+    name: Optional SurrealDB Memory Proof
+    runs-on: [self-hosted, cdb, docker]
+    timeout-minutes: 45
+    continue-on-error: true
+    env:
+      CDB_RUN_REAL_SURREALDB_MEMORY_SMOKE: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Init evidence directory
+        shell: bash
+        run: mkdir -p artifacts/surrealdb_memory_proof
+
+      - name: Ensure local query config exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          make context-query-config-init 2>&1 | tee artifacts/surrealdb_memory_proof/query_config_init.log
+
+      - name: Collect proof plan (preflight)
+        id: preflight
+        shell: bash
+        run: |
+          set +e
+          python -m tools.surrealdb.memory_db_proof_cli preflight --confirm \
+            > artifacts/surrealdb_memory_proof/preflight_db_read.json 2>&1
+          db_rc=$?
+
+          python -m tools.surrealdb.claim_evidence_proof_cli preflight --confirm \
+            > artifacts/surrealdb_memory_proof/preflight_claim_evidence.json 2>&1
+          claim_rc=$?
+
+          python -m tools.surrealdb.memory_rediscovery_proof_cli preflight --confirm \
+            > artifacts/surrealdb_memory_proof/preflight_rediscovery.json 2>&1
+          rediscovery_rc=$?
+          set -e
+
+          ok="false"
+          if [[ "$db_rc" -eq 0 && "$claim_rc" -eq 0 && "$rediscovery_rc" -eq 0 ]]; then
+            ok="true"
+          fi
+
+          echo "preflight_ok=${ok}" >> "$GITHUB_OUTPUT"
+          echo "db_preflight_rc=${db_rc}" >> "$GITHUB_OUTPUT"
+          echo "claim_preflight_rc=${claim_rc}" >> "$GITHUB_OUTPUT"
+          echo "rediscovery_preflight_rc=${rediscovery_rc}" >> "$GITHUB_OUTPUT"
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          root = Path("artifacts/surrealdb_memory_proof")
+          plan = {
+              "schema_version": "surrealdb-memory-proof-plan/v1",
+              "issue": "#2721",
+              "lr_verdict": "NO-GO",
+              "required_ci_gate": False,
+              "operator_targets": {
+                  "db_read_stale": "make context-memory-db-proof",
+                  "claim_evidence": "make context-claim-evidence-proof",
+                  "cross_session_rediscovery": "make context-memory-rediscovery-proof",
+              },
+              "manual_local_fallback": (
+                  "If this workflow preflight fails, run the same make targets on a "
+                  "workstation with Docker, SECRETS_PATH/SURREALDB_ENV, and "
+                  "make context-up. See docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md"
+              ),
+              "preflight_artifacts": [
+                  "preflight_db_read.json",
+                  "preflight_claim_evidence.json",
+                  "preflight_rediscovery.json",
+              ],
+          }
+          (root / "proof_plan.json").write_text(
+              json.dumps(plan, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Start context sidecar when preflight passed
+        if: >-
+          steps.preflight.outputs.preflight_ok == 'true'
+          && github.event.inputs.attempt_runtime_proof == 'true'
+          && github.event.inputs.proof_suite != 'preflight-only'
+        shell: bash
+        run: |
+          set -euo pipefail
+          make context-up 2>&1 | tee artifacts/surrealdb_memory_proof/context_up.log
+          make context-schema-apply 2>&1 | tee artifacts/surrealdb_memory_proof/context_schema_apply.log
+
+      - name: Run memory DB read proof
+        if: >-
+          steps.preflight.outputs.preflight_ok == 'true'
+          && github.event.inputs.attempt_runtime_proof == 'true'
+          && (github.event.inputs.proof_suite == 'all' || github.event.inputs.proof_suite == 'db-read-only')
+        shell: bash
+        run: |
+          set -euo pipefail
+          make context-memory-db-proof 2>&1 | tee artifacts/surrealdb_memory_proof/context_memory_db_proof.log
+
+      - name: Run claim evidence proof
+        if: >-
+          steps.preflight.outputs.preflight_ok == 'true'
+          && github.event.inputs.attempt_runtime_proof == 'true'
+          && github.event.inputs.proof_suite == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          make context-claim-evidence-proof 2>&1 | tee artifacts/surrealdb_memory_proof/context_claim_evidence_proof.log
+
+      - name: Run cross-session rediscovery proof
+        if: >-
+          steps.preflight.outputs.preflight_ok == 'true'
+          && github.event.inputs.attempt_runtime_proof == 'true'
+          && github.event.inputs.proof_suite == 'all'
+        shell: bash
+        run: |
+          set -euo pipefail
+          make context-memory-rediscovery-proof 2>&1 | tee artifacts/surrealdb_memory_proof/context_memory_rediscovery_proof.log
+
+      - name: Stop context sidecar
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          make context-down 2>&1 | tee artifacts/surrealdb_memory_proof/context_down.log
+
+      - name: Build proof summary
+        if: always()
+        shell: bash
+        env:
+          PREFLIGHT_OK: ${{ steps.preflight.outputs.preflight_ok }}
+          PROOF_SUITE: ${{ github.event.inputs.proof_suite }}
+          ATTEMPT_RUNTIME: ${{ github.event.inputs.attempt_runtime_proof }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path("artifacts/surrealdb_memory_proof")
+          summary = {
+              "schema_version": "surrealdb-memory-proof-summary/v1",
+              "event_name": os.environ.get("GITHUB_EVENT_NAME", "unknown"),
+              "proof_suite": os.environ.get("PROOF_SUITE", "unknown"),
+              "attempt_runtime_proof": os.environ.get("ATTEMPT_RUNTIME", "unknown"),
+              "preflight_ok": os.environ.get("PREFLIGHT_OK") == "true",
+              "required_ci_gate": False,
+              "lr_verdict": "NO-GO",
+              "limitations": [
+                  "optional_non_required_workflow",
+                  "self_hosted_runner_with_docker_label",
+                  "no_productive_memory_write",
+                  "failures_do_not_block_merge",
+              ],
+          }
+          (root / "summary.json").write_text(
+              json.dumps(summary, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+
+          md = "\n".join(
+              [
+                  "## Optional SurrealDB Memory Proof",
+                  "",
+                  "**Non-required workflow.** Failures do not block merges. LR: NO-GO.",
+                  "",
+                  f"- proof_suite: `{summary['proof_suite']}`",
+                  f"- attempt_runtime_proof: `{summary['attempt_runtime_proof']}`",
+                  f"- preflight_ok: `{summary['preflight_ok']}`",
+                  "",
+                  "### Operator fallback (manual local proof)",
+                  "",
+                  "```bash",
+                  "make context-up",
+                  "make context-memory-db-proof",
+                  "make context-claim-evidence-proof",
+                  "make context-memory-rediscovery-proof",
+                  "```",
+                  "",
+                  "Doc: `docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md`",
+              ]
+          )
+          (root / "summary.md").write_text(md + "\n", encoding="utf-8")
+          print(md)
+          PY
+          cat artifacts/surrealdb_memory_proof/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload proof artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: surrealdb-memory-proof-${{ github.run_id }}
+          path: artifacts/surrealdb_memory_proof/
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md
+++ b/docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md
@@ -388,6 +388,35 @@ lookup by ``memory_id`` and ``scope``. See
 make context-memory-rediscovery-proof
 ```
 
+### Optional GitHub Actions proof (#2721)
+
+Non-required, opt-in workflow for self-hosted runners with the `docker` label.
+Does **not** gate merges; failures are informational. LR remains **NO-GO**.
+
+| Item | Value |
+|------|-------|
+| Workflow | `.github/workflows/surrealdb-memory-proof.yml` |
+| Trigger | `workflow_dispatch` only |
+| Runner | `[self-hosted, cdb, docker]` |
+| Permissions | `contents: read` |
+| Inputs | `proof_suite` (`all` / `db-read-only` / `preflight-only`); `attempt_runtime_proof` |
+
+**Runner prerequisites:** Docker, `SECRETS_PATH` with `SURREALDB_ENV`, local query config
+(`make context-query-config-init`). The workflow runs preflight first; when preflight passes
+and `attempt_runtime_proof=true`, it may invoke the same `make` targets as the operator path
+above and uploads redacted artifacts (`proof_plan.json`, `summary.md`, logs).
+
+**Manual fallback** (canonical when GHA preflight fails or runner lacks secrets):
+
+```bash
+make context-up
+make context-memory-db-proof
+make context-claim-evidence-proof
+make context-memory-rediscovery-proof
+```
+
+Doc matrix row 6: [`docs/surrealdb/db-runtime-ci-proof-path-v1.md`](../surrealdb/db-runtime-ci-proof-path-v1.md).
+
 ---
 
 ## Häufige Fehler

--- a/docs/surrealdb/db-runtime-ci-proof-path-v1.md
+++ b/docs/surrealdb/db-runtime-ci-proof-path-v1.md
@@ -29,7 +29,7 @@ compose changes; closing #2606; SurrealDB in required CI (~26 min `context-smoke
 | 3 | Productive audit trail | Gate + local `audit_observation` only | By design blocked | Document **BLOCKED** | **BLOCKED** (no activation) |
 | 4 | Claim evidence at rest | `claim_evidence_at_rest.py`; unit mocks; optional `context-claim-evidence-proof` | CI: mocks only; runtime: local operator path | `make context-claim-evidence-proof`; see [`claim-evidence-at-rest-v1.md`](claim-evidence-at-rest-v1.md) | **PASS WITH LIMITS** — local operator path; CI **PARTIAL** |
 | 5 | Cross-session rediscovery | `memory_cross_session_rediscovery.py`; manifest + subprocess prove | CI: mocks only; runtime: local operator | `make context-memory-rediscovery-proof`; see [`cross-session-memory-rediscovery-v1.md`](cross-session-memory-rediscovery-v1.md) | **PASS WITH LIMITS** — local two-process proof; CI **PARTIAL** |
-| 6 | CI/runtime SurrealDB service | `context-smoke-db` needs Docker + secrets; not in `ci.yml` | Self-hosted `docker` label; no SurrealDB step | Document boundary; optional non-required workflow | **NEEDS_FOLLOW_UP** |
+| 6 | CI/runtime SurrealDB service | `context-smoke-db` needs Docker + secrets; not in `ci.yml` | Self-hosted `docker` label; optional workflow | `.github/workflows/surrealdb-memory-proof.yml` (`workflow_dispatch`, non-required); preflight + optional `make context-memory-db-proof` / `context-claim-evidence-proof` / `context-memory-rediscovery-proof`; manual fallback in runbook | **PASS WITH LIMITS** — opt-in GHA path; required CI stays mock-only |
 
 ---
 
@@ -45,8 +45,11 @@ compose changes; closing #2606; SurrealDB in required CI (~26 min `context-smoke
 | `make context-claim-evidence-proof` | Claim evidence at rest on run-scoped fixtures (#2719) | No (operator; minutes) |
 | `make context-memory-rediscovery-proof` | Cross-session memory_id+scope rediscovery (#2720) | No (operator; minutes) |
 | `pytest -m local_only` memory proof tests | Same as CLI cycle with env gate | No |
+| `.github/workflows/surrealdb-memory-proof.yml` | Preflight + optional operator proofs on self-hosted Docker runner | No (opt-in `workflow_dispatch` only) |
 
 **CI policy:** Do not add live SurrealDB to required `.github/workflows/ci.yml`.
+Optional proof workflow: `surrealdb-memory-proof.yml` (#2721) — `continue-on-error: true`,
+not a branch-protection required check.
 Canonical gate remains `pytest -q -k "not test_mcp_time_server_runtime"`.
 
 ---

--- a/tests/unit/scripts/test_surrealdb_memory_proof_workflow.py
+++ b/tests/unit/scripts/test_surrealdb_memory_proof_workflow.py
@@ -1,0 +1,76 @@
+"""Surface guard for optional SurrealDB memory proof workflow (#2721).
+
+Protects against drift between the workflow and canonical Makefile proof targets
+for #2603/#2606 local operator paths.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "surrealdb-memory-proof.yml"
+MAKEFILE_PATH = REPO_ROOT / "Makefile"
+
+PROOF_TARGETS = (
+    "context-memory-db-proof",
+    "context-claim-evidence-proof",
+    "context-memory-rediscovery-proof",
+)
+
+
+def _load_workflow() -> dict:
+    assert WORKFLOW_PATH.exists(), f"Workflow not found: {WORKFLOW_PATH}"
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.mark.unit
+def test_surrealdb_memory_proof_workflow_has_workflow_dispatch() -> None:
+    workflow = _load_workflow()
+    on_triggers = workflow.get("on") or workflow.get(True) or {}
+    assert "workflow_dispatch" in on_triggers, (
+        "surrealdb-memory-proof.yml must declare workflow_dispatch (#2721)."
+    )
+
+
+@pytest.mark.unit
+def test_surrealdb_memory_proof_workflow_minimal_permissions() -> None:
+    workflow = _load_workflow()
+    permissions = workflow.get("permissions") or {}
+    assert permissions.get("contents") == "read", (
+        "surrealdb-memory-proof.yml must use contents: read only (#2721)."
+    )
+
+
+@pytest.mark.unit
+def test_surrealdb_memory_proof_workflow_uses_self_hosted_docker() -> None:
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "runs-on: [self-hosted, cdb, docker]" in content
+
+
+@pytest.mark.unit
+def test_surrealdb_memory_proof_workflow_is_non_blocking() -> None:
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "continue-on-error: true" in content
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("target", PROOF_TARGETS)
+def test_makefile_has_memory_proof_target(target: str) -> None:
+    content = MAKEFILE_PATH.read_text(encoding="utf-8")
+    assert re.search(rf"^{target}:", content, re.MULTILINE), (
+        f"Makefile missing target {target!r} required by #2721 workflow."
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("target", PROOF_TARGETS)
+def test_surrealdb_memory_proof_workflow_invokes_make_target(target: str) -> None:
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert f"make {target}" in content, (
+        f"surrealdb-memory-proof.yml must invoke make {target} (#2721 coupling)."
+    )


### PR DESCRIPTION
## Summary
- Add optional non-required \.github/workflows/surrealdb-memory-proof.yml\ (\workflow_dispatch\, \contents: read\, self-hosted \docker\ runner, \continue-on-error: true\).
- Preflight all three proof CLIs; optionally run \make context-memory-db-proof\, \context-claim-evidence-proof\, and \context-memory-rediscovery-proof\ when runner preconditions pass.
- Document opt-in GHA path in runbook + proof matrix row 6; unit tests guard workflow/Makefile coupling.

Closes #2721

## Test plan
- [x] \pytest tests/unit/scripts/test_surrealdb_memory_proof_workflow.py -v\ (10 passed)
- [x] \git diff --check\
- [x] \uff check\ on touched test file
- [ ] Required CI (\ci\, \policy-gate\) green on PR
- [ ] Optional: manual \workflow_dispatch\ on self-hosted runner (informational only)

## Boundaries
- No changes to required \ci.yml\
- No productive memory write; LR NO-GO unchanged
- Does not close #2606