### PR TITLE
docs(agents): harden Cursor subagent write gates

### DIFF
--- a/.cursor/agents/README_CDB_CURSOR_SUBAGENTS.md
+++ b/.cursor/agents/README_CDB_CURSOR_SUBAGENTS.md
@@ -65,6 +65,19 @@ Canon matrix: `docs/meta/WORKING_REPO_CANON.md`.
 - `CURRENT_STATUS.md` is a ledger, not live truth.
 - Board stage `trade-capable` is not Live-Go.
 - No subagent grants merge, deploy, live trading, or Echtgeld GO.
+- **`CDB_AGENT_POLICY.md` wins** on conflict; see shared contract § Zone A vs Write-Zone.
+
+## Write gates (summary)
+
+| Gate | Rule |
+| --- | --- |
+| Parent enforcement | Parent agent enforces Jannek GO, session-start, LOCK, Brain Evidence, scope — not the subagent alone. |
+| `readonly: false` | Technical capability only; fail-closed without GO + session-start + LOCK (when issue-scoped). |
+| GitHub mutations | **`gh` CLI only** — PRs, comments, labels, reviews, merges, branch deletes, workflow dispatch. |
+| MCP / API / connectors | Read / inspect / dry-run only unless separate explicit GO names tool + action. |
+| Zone A discovery | Read-only repo/GitHub inspection allowed; mutating actions = Write-Zone. |
+
+Full rules: [`_CDB_SUBAGENT_CONTRACT.md`](_CDB_SUBAGENT_CONTRACT.md) (§ Parent agent enforcement, § Non-Negotiable Operating Rules, § Zone A vs Write-Zone).
 
 ## Reload
 

--- a/.cursor/agents/_CDB_SUBAGENT_CONTRACT.md
+++ b/.cursor/agents/_CDB_SUBAGENT_CONTRACT.md
@@ -18,6 +18,31 @@ work. They are **not** standalone authorities:
 
 ---
 
+## Parent agent enforcement
+
+The **parent agent** (Session Lead / invoking operator context) owns gates;
+subagents do not self-authorize.
+
+**Parent MUST enforce before delegating or accepting subagent output:**
+
+1. **Jannek GO** — explicit, scoped GO for any write, GitHub mutation, or
+   delivery action (subagent prompts alone are not GO).
+2. **Session-start** — `.cursor/skills/cdb-session-start/SKILL.md` completed for
+   the write scope when applicable.
+3. **Single-Writer LOCK** — per `knowledge/governance/CDB_AGENT_POLICY.md` §4
+   when issue-scoped writes apply.
+4. **Brain Evidence Gate** — when scope requires it (see below).
+5. **Scope gates** — IN/OUT scope stated; subagent must not expand scope.
+
+**`readonly: false` in frontmatter** means the subagent *can* edit files **only
+after** the parent has confirmed GO + session-start + LOCK (when required). It is
+**not** a free pass; without gates the subagent stays read-only (fail-closed).
+
+Subagents must **STOP** and return the missing gate (GO, LOCK, skill, evidence)
+instead of improvising writes or GitHub actions.
+
+---
+
 ## Cursor Subagent Contract
 
 - Work in your own clean context and return one final, consolidated result to the parent agent.
@@ -50,11 +75,40 @@ Before any analysis, implementation, review, or plan:
 - Live-readiness remains **NO-GO** unless the LR SSOT and explicit human gate say otherwise.
 - Default mode is read-only until Jannek gives a precise GO.
 - No writes, commits, pushes, labels, comments, merges, branch deletes, workflow dispatches, stack changes, or live-mode changes without explicit GO.
-- GitHub writes must use `gh` CLI only. No direct API writes unless explicitly authorized for a narrow gap.
+- **GitHub writes — `gh` CLI only (absolute):** Any repository-mutating or
+  GitHub-side action MUST go through the **`gh` CLI**, including: PR
+  create/update, issue comments, labels, review actions, merges, branch deletes,
+  and workflow dispatch. **No silent substitute** via GitHub REST/GraphQL API,
+  MCP GitHub tools, connectors, or IDE integrations when `gh` can perform the
+  action.
+- **MCP / API / connectors — read-only default for subagents:** GitHub MCP,
+  GitHub API clients, and third-party connectors may be used for **read /
+  inspect / dry-run** only (e.g. `gh pr view`, `gh issue view`, check status).
+  They MUST NOT perform mutating GitHub operations unless Jannek gives a
+  **separate, explicit GO** that names the exact tool and action — and even
+  then, prefer `gh` for the mutation. MCP config mutation is out of scope
+  unless explicitly GO-gated.
 - Direct push to `main` is not an acceptable default path. Use PR-based flow.
 - `DELIVERY_APPROVED.yaml` is human-controlled; agents must not modify it.
 - If scope grows, checks are red, evidence is missing, or assumptions are unstable: stop and report.
 - Before Docker/infra stack changes, ask Gordon for advice first. If Gordon is unavailable, report `GORDON_NOT_AVAILABLE` and hold changes unless Jannek explicitly overrides.
+
+---
+
+## Zone A vs Write-Zone (`CDB_AGENT_POLICY` precedence)
+
+`knowledge/governance/CDB_AGENT_POLICY.md` is authoritative when subagent text
+or user phrasing conflicts with policy.
+
+| Class | Zone | Subagent behavior |
+| --- | --- | --- |
+| Read-only discovery | Zone A–C (non-mutating) | Allowed without GO: repo reads, `gh` **view/list/status**, analysis, comparisons, plans marked review-only. |
+| Mutating repo/GitHub/infra | Write-Zone (§4 Write-Gates) | Requires Jannek GO + session-start + LOCK (when issue-scoped) + **`gh`-only** for GitHub mutations. |
+| Forbidden | Zone D | Never: custody/tresor, hard limits, canonical policy edits without GO, execution without risk layer, safety bypass. |
+
+**Tension rule:** Subagents must not treat Zone A autonomy as permission to
+commit, push, merge, label, comment on GitHub, dispatch workflows, or mutate
+MCP/runtime/infra. Those are Write-Zone actions. On ambiguity → **STOP** (fail-closed).
 
 ---
 
@@ -152,6 +206,8 @@ DB-backed Memory** (see `agents/OPEN_CODE_AGENTS.md`):
 4. `brain_source=unavailable` → **repo-only fallback**; mark limitations explicitly; no DB-backed claims.
 5. Wave-14 read-only tools: `metadata.source=surrealdb-local` only from real adapter evidence; caller-supplied source fields are not DB evidence (fail-closed).
 6. Do not mutate MCP configuration unless explicitly scoped and GO-gated.
+7. **No MCP GitHub mutation:** MCP tools must not create/update GitHub resources
+   (issues, PRs, comments, labels, merges) for subagents; use `gh` after GO.
 
 ---
 

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -22,8 +22,10 @@ in einem separaten externen Doku-Repo gesucht wurde.
 
 ## Cursor Subagents
 
-Cursor IDE helper roles live under `.cursor/agents/`. They are **not** standalone
-authorities; Session Lead and Human Gate retain decision power.
+`.cursor/agents/` is the **Cursor IDE subagent surface** — operational helper
+roles invoked as `/cdb-<name>`. This is **discovery and delegation only**; it
+does not create a new authority tier. Session Lead, Human Gate, and
+`knowledge/governance/CDB_AGENT_POLICY.md` remain authoritative.
 
 | Item | Path |
 | --- | --- |
@@ -31,12 +33,31 @@ authorities; Session Lead and Human Gate retain decision power.
 | Shared contract | `.cursor/agents/_CDB_SUBAGENT_CONTRACT.md` |
 | Subagent files | `.cursor/agents/cdb-*.md` |
 
+**Parent agent enforcement:** The invoking parent must enforce Jannek GO,
+session-start, Single-Writer LOCK (when issue-scoped), Brain Evidence (when
+scope requires), and scope limits before any subagent write or GitHub mutation.
+Subagents return evidence to the parent; they do not own delivery.
+
 **Readonly policy:** only `cdb-ci-debugger`, `cdb-context-intelligence-engineer`,
 `cdb-docs-canon-maintainer`, and `cdb-implementation-engineer` have
-`readonly: false` — and only after Jannek GO, session-start, and LOCK when
-issue-scoped. All other subagents are read-only.
+`readonly: false` in frontmatter — **technical capability only**, not
+autonomous write permission. Effective writes require GO + session-start + LOCK
+(when issue-scoped). All other subagents are read-only regardless of user phrasing.
+
+**GitHub writes:** Subagent-related GitHub mutations (PR create/update, issue
+comments, labels, review actions, merges, branch deletes, workflow dispatch) are
+**`gh` CLI only**. MCP/GitHub API/connectors: read/inspect/dry-run unless a
+separate explicit GO lifts a named action.
+
+**Zone A vs Write-Zone:** Read-only discovery (repo reads, `gh view/list`) is
+allowed without GO. Commits, pushes, and GitHub mutations are Write-Zone per
+`CDB_AGENT_POLICY.md` §4. On conflict, **`CDB_AGENT_POLICY.md` wins** (see
+shared contract § Zone A vs Write-Zone).
 
 Invocation: `/cdb-<name>` (e.g. `/cdb-governance-gatekeeper`).
+
+Related surfaces (not subagents): `.cursor/skills/` (session skills),
+`.opencode/skills/` (OpenCode), `.codex/cdb_skills/` (Codex).
 
 ## Canonical Domains
 

--- a/knowledge/logs/sessions/2026-05-29-cursor-subagent-gate-hardening.md
+++ b/knowledge/logs/sessions/2026-05-29-cursor-subagent-gate-hardening.md
@@ -1,0 +1,29 @@
+# Session: Cursor subagent gate hardening
+
+Date: 2026-05-29  
+Agent: cdb-docs-canon-maintainer (Cursor)  
+GO: `GO CURSOR SUBAGENT GATE HARDENING`
+
+## Scope
+
+Docs-only hardening after PR #2729 smoke test. No runtime, workflow, infra, MCP
+mutation, LR/live/trading implication. No `CURRENT_STATUS.md` update in slice.
+
+## Changes
+
+- `.cursor/agents/_CDB_SUBAGENT_CONTRACT.md` — Parent agent enforcement; absolute
+  `gh`-only GitHub writes; MCP/API read-only default; Zone A vs Write-Zone with
+  `CDB_AGENT_POLICY` precedence.
+- `.cursor/agents/README_CDB_CURSOR_SUBAGENTS.md` — Write-gates summary table.
+- `agents/AGENTS.md` — Cursor subagent operational surface / discovery; parent
+  enforcement; gh-only; Zone A clarification.
+
+## Validation
+
+- YAML frontmatter of 13 `cdb-*.md` unchanged; contract refs intact.
+- Formal frontmatter script: PASS.
+- Risk phrase grep: no autonomous merge/deploy/live-go additions.
+
+## LR / Board
+
+Unchanged. LR NO-GO. Board `trade-capable` orthogonal.


### PR DESCRIPTION
## Summary

- Harden shared Cursor subagent contract after PR #2729 smoke-test governance gaps.
- Absolute **`gh` CLI only** for GitHub mutations; MCP/API/connectors read-only by default.
- Parent-agent enforcement: GO, session-start, LOCK, Brain Evidence, scope — not subagent self-authorization.
- Zone A read-only discovery vs Write-Zone; **`CDB_AGENT_POLICY.md` wins** on conflict.
- Expand `agents/AGENTS.md` Cursor subagent operational surface (discovery only, no new authority).

## Scope

- `.cursor/agents/_CDB_SUBAGENT_CONTRACT.md`
- `.cursor/agents/README_CDB_CURSOR_SUBAGENTS.md`
- `agents/AGENTS.md`
- Session log `knowledge/logs/sessions/2026-05-29-cursor-subagent-gate-hardening.md`

## Governance fix

- `readonly: false` = technical capability after gates, not autonomous write permission.
- No subagent grants merge, deploy, live trading, or Echtgeld GO (unchanged).

## Validation

- 13 `cdb-*.md` frontmatter unchanged; contract refs intact (script PASS).
- No runtime/workflow/infra/MCP config changes.
- Risk-phrase grep: no autonomous merge/deploy/live-go additions.

## Test plan

- [ ] Review contract § Parent agent enforcement, § Zone A vs Write-Zone, gh-only rules
- [ ] Confirm registry text in `agents/AGENTS.md` matches shared contract
- [ ] Optional: reload Cursor and invoke read-only subagent without GO (must stop on writes)

## LR / live implication

None. Docs-only. LR remains NO-GO. Board `trade-capable` orthogonal.