### PR TITLE
fix(redis): reuse pooled client in risk service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,6 +310,18 @@ All services under `services/` require Redis and Postgres (provided by Docker in
 normal operation). In Cloud Agent mode without Docker, verify service logic
 through unit/integration tests rather than starting services directly.
 
+### Redis (message bus)
+
+- **Runtime services** must use `create_redis_client` from `core.utils.redis_client`
+  (shared `ConnectionPool` per host/port/db/TLS config). Do not open ad-hoc
+  `redis.Redis()` connections in long-lived service processes.
+- **One client per service** where possible: pub/sub, streams, and envelope emission
+  should reuse the same pool-backed client (see `services/risk/service.py`).
+- **Cache keys / streams**: prefer consistent prefixes (`cdb:` for streams,
+  dotted channel names for pub/sub) and TTLs on ephemeral cache data.
+- Cursor’s **Redis plugin** applies pooling, timeout, and structure rules automatically
+  when editing Redis-related code.
+
 ### Secrets
 
 Services expect secrets from a directory (default `~/Documents/.secrets/.cdb/`).

--- a/core/utils/redis_client.py
+++ b/core/utils/redis_client.py
@@ -13,6 +13,7 @@ Environment Variables:
     REDIS_CA_CERT: Path to CA certificate for TLS verification
     REDIS_CERT: Path to client certificate (optional, for mTLS)
     REDIS_KEY: Path to client private key (optional, for mTLS)
+    REDIS_SOCKET_CONNECT_TIMEOUT: TCP connect timeout in seconds (default: 2.0)
 
 Usage:
     from core.utils.redis_client import create_redis_client
@@ -30,14 +31,208 @@ Usage:
     )
 """
 
+from __future__ import annotations
+
 import logging
 import os
-import ssl
-from typing import Optional
+from typing import Any, Optional
 
 import redis
 
 logger = logging.getLogger(__name__)
+
+_POOL_CACHE: dict[tuple[Any, ...], redis.ConnectionPool] = {}
+_PINGED_POOLS: set[tuple[Any, ...]] = set()
+
+
+def _resolve_tls(
+    use_tls: Optional[bool],
+) -> bool:
+    if use_tls is not None:
+        return use_tls
+    tls_env = os.getenv("REDIS_TLS", "false").lower()
+    return tls_env in ("true", "1", "yes", "on")
+
+
+def _default_socket_connect_timeout() -> float:
+    raw = os.getenv("REDIS_SOCKET_CONNECT_TIMEOUT", "2.0")
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Invalid REDIS_SOCKET_CONNECT_TIMEOUT=%r; using 2.0", raw)
+        return 2.0
+
+
+def _pool_cache_key(
+    *,
+    host: str,
+    port: int,
+    password: Optional[str],
+    db: int,
+    use_tls: bool,
+    ssl_ca_certs: Optional[str],
+    ssl_certfile: Optional[str],
+    ssl_keyfile: Optional[str],
+    socket_timeout: float,
+    socket_connect_timeout: float,
+    decode_responses: bool,
+) -> tuple[Any, ...]:
+    return (
+        host,
+        port,
+        password,
+        db,
+        use_tls,
+        ssl_ca_certs,
+        ssl_certfile,
+        ssl_keyfile,
+        socket_timeout,
+        socket_connect_timeout,
+        decode_responses,
+    )
+
+
+def _build_pool_kwargs(
+    *,
+    host: str,
+    port: int,
+    password: Optional[str],
+    db: int,
+    use_tls: bool,
+    ssl_ca_certs: Optional[str],
+    ssl_certfile: Optional[str],
+    ssl_keyfile: Optional[str],
+    socket_timeout: float,
+    socket_connect_timeout: float,
+    decode_responses: bool,
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "host": host,
+        "port": port,
+        "password": password,
+        "db": db,
+        "socket_timeout": socket_timeout,
+        "socket_connect_timeout": socket_connect_timeout,
+        "decode_responses": decode_responses,
+    }
+
+    if use_tls:
+        if ssl_ca_certs and not os.path.exists(ssl_ca_certs):
+            raise FileNotFoundError(f"TLS CA certificate not found: {ssl_ca_certs}")
+        if ssl_certfile and not os.path.exists(ssl_certfile):
+            raise FileNotFoundError(f"TLS client cert not found: {ssl_certfile}")
+        if ssl_keyfile and not os.path.exists(ssl_keyfile):
+            raise FileNotFoundError(f"TLS client key not found: {ssl_keyfile}")
+
+        kwargs["ssl"] = True
+        kwargs["ssl_ca_certs"] = ssl_ca_certs
+        if ssl_certfile:
+            kwargs["ssl_certfile"] = ssl_certfile
+        if ssl_keyfile:
+            kwargs["ssl_keyfile"] = ssl_keyfile
+
+    return kwargs
+
+
+def get_redis_connection_pool(
+    host: Optional[str] = None,
+    port: Optional[int] = None,
+    password: Optional[str] = None,
+    db: int = 0,
+    use_tls: Optional[bool] = None,
+    ssl_ca_certs: Optional[str] = None,
+    ssl_certfile: Optional[str] = None,
+    ssl_keyfile: Optional[str] = None,
+    socket_timeout: float = 5.0,
+    socket_connect_timeout: Optional[float] = None,
+    decode_responses: bool = False,
+) -> redis.ConnectionPool:
+    """
+    Return a cached ConnectionPool for the given Redis configuration.
+
+    Pools are keyed by host, port, db, TLS settings, and timeout/decode options.
+    """
+    host = host or os.getenv("REDIS_HOST", "localhost")
+    port = port or int(os.getenv("REDIS_PORT", "6379"))
+    password = password if password is not None else os.getenv("REDIS_PASSWORD")
+    use_tls = _resolve_tls(use_tls)
+    ssl_ca_certs = ssl_ca_certs or os.getenv("REDIS_CA_CERT")
+    ssl_certfile = ssl_certfile or os.getenv("REDIS_CERT")
+    ssl_keyfile = ssl_keyfile or os.getenv("REDIS_KEY")
+    if socket_connect_timeout is None:
+        socket_connect_timeout = _default_socket_connect_timeout()
+
+    cache_key = _pool_cache_key(
+        host=host,
+        port=port,
+        password=password,
+        db=db,
+        use_tls=use_tls,
+        ssl_ca_certs=ssl_ca_certs,
+        ssl_certfile=ssl_certfile,
+        ssl_keyfile=ssl_keyfile,
+        socket_timeout=socket_timeout,
+        socket_connect_timeout=socket_connect_timeout,
+        decode_responses=decode_responses,
+    )
+
+    pool = _POOL_CACHE.get(cache_key)
+    if pool is not None:
+        return pool
+
+    pool_kwargs = _build_pool_kwargs(
+        host=host,
+        port=port,
+        password=password,
+        db=db,
+        use_tls=use_tls,
+        ssl_ca_certs=ssl_ca_certs,
+        ssl_certfile=ssl_certfile,
+        ssl_keyfile=ssl_keyfile,
+        socket_timeout=socket_timeout,
+        socket_connect_timeout=socket_connect_timeout,
+        decode_responses=decode_responses,
+    )
+
+    if use_tls:
+        logger.info("Creating Redis connection pool with TLS to %s:%s", host, port)
+    else:
+        logger.info("Creating Redis connection pool (no TLS) to %s:%s", host, port)
+
+    pool = redis.ConnectionPool(**pool_kwargs)
+    _POOL_CACHE[cache_key] = pool
+    return pool
+
+
+def _discard_cached_pool(
+    cache_key: tuple[Any, ...],
+    pool: Optional[redis.ConnectionPool],
+) -> None:
+    """Remove a pool from process caches after failed verification."""
+    _POOL_CACHE.pop(cache_key, None)
+    _PINGED_POOLS.discard(cache_key)
+    if pool is not None:
+        try:
+            pool.disconnect()
+        except Exception:
+            logger.debug("Redis pool disconnect failed during cache eviction", exc_info=True)
+
+
+def _ping_pool_once(
+    cache_key: tuple[Any, ...],
+    client: redis.Redis,
+    pool: redis.ConnectionPool,
+) -> None:
+    if cache_key in _PINGED_POOLS:
+        return
+    try:
+        client.ping()
+    except redis.ConnectionError as e:
+        logger.error("Redis connection failed: %s", e)
+        _discard_cached_pool(cache_key, pool)
+        raise
+    _PINGED_POOLS.add(cache_key)
+    logger.info("Redis connection pool verified")
 
 
 def create_redis_client(
@@ -50,10 +245,11 @@ def create_redis_client(
     ssl_certfile: Optional[str] = None,
     ssl_keyfile: Optional[str] = None,
     socket_timeout: float = 5.0,
+    socket_connect_timeout: Optional[float] = None,
     decode_responses: bool = False,
 ) -> redis.Redis:
     """
-    Create a Redis client with optional TLS support.
+    Create a Redis client backed by a shared connection pool.
 
     Args:
         host: Redis server hostname. Defaults to REDIS_HOST env var or 'localhost'.
@@ -64,88 +260,58 @@ def create_redis_client(
         ssl_ca_certs: Path to CA certificate. Defaults to REDIS_CA_CERT env var.
         ssl_certfile: Path to client certificate. Defaults to REDIS_CERT env var.
         ssl_keyfile: Path to client private key. Defaults to REDIS_KEY env var.
-        socket_timeout: Connection timeout in seconds. Defaults to 5.0.
+        socket_timeout: Command/socket timeout in seconds. Defaults to 5.0.
+        socket_connect_timeout: TCP connect timeout. Defaults to
+            REDIS_SOCKET_CONNECT_TIMEOUT or 2.0.
         decode_responses: Decode responses to strings. Defaults to False.
 
     Returns:
-        redis.Redis: Configured Redis client.
+        redis.Redis: Configured Redis client using a shared pool.
 
     Raises:
-        redis.ConnectionError: If connection fails.
-        FileNotFoundError: If TLS is enabled but certificate files not found.
+        redis.ConnectionError: If the first health check for this pool fails.
+        FileNotFoundError: If TLS is enabled but certificate files are missing.
     """
-    # Read from environment with fallbacks
-    host = host or os.getenv("REDIS_HOST", "localhost")
-    port = port or int(os.getenv("REDIS_PORT", "6379"))
-    password = password or os.getenv("REDIS_PASSWORD")
+    if socket_connect_timeout is None:
+        socket_connect_timeout = _default_socket_connect_timeout()
 
-    # TLS configuration
-    if use_tls is None:
-        tls_env = os.getenv("REDIS_TLS", "false").lower()
-        use_tls = tls_env in ("true", "1", "yes", "on")
+    resolved_host = host or os.getenv("REDIS_HOST", "localhost")
+    resolved_port = port or int(os.getenv("REDIS_PORT", "6379"))
+    resolved_password = password if password is not None else os.getenv("REDIS_PASSWORD")
+    resolved_tls = _resolve_tls(use_tls)
+    resolved_ssl_ca = ssl_ca_certs or os.getenv("REDIS_CA_CERT")
+    resolved_ssl_cert = ssl_certfile or os.getenv("REDIS_CERT")
+    resolved_ssl_key = ssl_keyfile or os.getenv("REDIS_KEY")
 
-    ssl_ca_certs = ssl_ca_certs or os.getenv("REDIS_CA_CERT")
-    ssl_certfile = ssl_certfile or os.getenv("REDIS_CERT")
-    ssl_keyfile = ssl_keyfile or os.getenv("REDIS_KEY")
+    cache_key = _pool_cache_key(
+        host=resolved_host,
+        port=resolved_port,
+        password=resolved_password,
+        db=db,
+        use_tls=resolved_tls,
+        ssl_ca_certs=resolved_ssl_ca,
+        ssl_certfile=resolved_ssl_cert,
+        ssl_keyfile=resolved_ssl_key,
+        socket_timeout=socket_timeout,
+        socket_connect_timeout=socket_connect_timeout,
+        decode_responses=decode_responses,
+    )
 
-    # Build connection kwargs
-    kwargs = {
-        "host": host,
-        "port": port,
-        "password": password,
-        "db": db,
-        "socket_timeout": socket_timeout,
-        "decode_responses": decode_responses,
-    }
-
-    if use_tls:
-        logger.info(f"Creating Redis client with TLS to {host}:{port}")
-
-        # Verify CA cert exists
-        if ssl_ca_certs and not os.path.exists(ssl_ca_certs):
-            raise FileNotFoundError(f"TLS CA certificate not found: {ssl_ca_certs}")
-
-        # Build SSL context
-        ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-
-        if ssl_ca_certs:
-            ssl_context.load_verify_locations(ssl_ca_certs)
-            logger.debug(f"Loaded CA certificate: {ssl_ca_certs}")
-
-        # Client certificate (mTLS) - optional
-        if ssl_certfile and ssl_keyfile:
-            if not os.path.exists(ssl_certfile):
-                raise FileNotFoundError(f"TLS client cert not found: {ssl_certfile}")
-            if not os.path.exists(ssl_keyfile):
-                raise FileNotFoundError(f"TLS client key not found: {ssl_keyfile}")
-
-            ssl_context.load_cert_chain(
-                certfile=ssl_certfile,
-                keyfile=ssl_keyfile,
-            )
-            logger.debug(f"Loaded client certificate: {ssl_certfile}")
-
-        kwargs["ssl"] = True
-        kwargs["ssl_ca_certs"] = ssl_ca_certs
-        if ssl_certfile:
-            kwargs["ssl_certfile"] = ssl_certfile
-        if ssl_keyfile:
-            kwargs["ssl_keyfile"] = ssl_keyfile
-
-    else:
-        logger.info(f"Creating Redis client (no TLS) to {host}:{port}")
-
-    client = redis.Redis(**kwargs)
-
-    # Test connection
-    try:
-        client.ping()
-        tls_status = "with TLS" if use_tls else "without TLS"
-        logger.info(f"Redis connection successful ({tls_status})")
-    except redis.ConnectionError as e:
-        logger.error(f"Redis connection failed: {e}")
-        raise
-
+    pool = get_redis_connection_pool(
+        host=host,
+        port=port,
+        password=password,
+        db=db,
+        use_tls=use_tls,
+        ssl_ca_certs=ssl_ca_certs,
+        ssl_certfile=ssl_certfile,
+        ssl_keyfile=ssl_keyfile,
+        socket_timeout=socket_timeout,
+        socket_connect_timeout=socket_connect_timeout,
+        decode_responses=decode_responses,
+    )
+    client = redis.Redis(connection_pool=pool)
+    _ping_pool_once(cache_key, client, pool)
     return client
 
 
@@ -171,15 +337,12 @@ def get_redis_url(
     """
     host = host or os.getenv("REDIS_HOST", "localhost")
     port = port or int(os.getenv("REDIS_PORT", "6379"))
-    password = password or os.getenv("REDIS_PASSWORD")
+    password = password if password is not None else os.getenv("REDIS_PASSWORD")
 
-    if use_tls is None:
-        tls_env = os.getenv("REDIS_TLS", "false").lower()
-        use_tls = tls_env in ("true", "1", "yes", "on")
+    use_tls = _resolve_tls(use_tls)
 
     scheme = "rediss" if use_tls else "redis"
 
     if password:
         return f"{scheme}://:{password}@{host}:{port}/{db}"
-    else:
-        return f"{scheme}://{host}:{port}/{db}"
+    return f"{scheme}://{host}:{port}/{db}"

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -775,14 +775,13 @@ class RiskManager:
     def connect_redis(self):
         """Redis-Verbindung"""
         try:
-            self.redis_client = redis.Redis(
+            self.redis_client = create_redis_client(
                 host=self.config.redis_host,
                 port=self.config.redis_port,
                 password=self.config.redis_password,
                 db=self.config.redis_db,
                 decode_responses=True,
             )
-            self.redis_client.ping()
             logger.info(
                 f"Redis verbunden: {self.config.redis_host}:{self.config.redis_port}"
             )
@@ -809,17 +808,17 @@ class RiskManager:
             self._envelope_publisher = None
             return
 
+        if self.redis_client is None:
+            logger.error("Envelope emission requires an active Redis client")
+            self._envelope_redis_client = None
+            self._envelope_publisher = None
+            return
+
         try:
             from core.replay.emitter import configure_envelope_emission
             from core.replay.publisher import EnvelopePublisher
 
-            envelope_client = create_redis_client(
-                host=self.config.redis_host,
-                port=self.config.redis_port,
-                password=self.config.redis_password,
-                db=self.config.redis_db,
-                decode_responses=True,
-            )
+            envelope_client = self.redis_client
             mode = os.getenv("CDB_ENVELOPE_REDIS_MODE", "stream").lower()
             if mode != "pubsub":
                 mode = "stream"

--- a/tests/unit/services/test_risk_service_emission.py
+++ b/tests/unit/services/test_risk_service_emission.py
@@ -30,6 +30,7 @@ def test_setup_envelope_emitter_off_does_not_create_client(monkeypatch):
     sys.modules.pop("core.replay.publisher", None)
 
     manager = RiskManager()
+    manager.redis_client = MagicMock()
     called = False
 
     def fake_create(**kwargs):
@@ -51,11 +52,11 @@ def test_setup_envelope_emitter_off_does_not_create_client(monkeypatch):
 def test_setup_envelope_emitter_on_pubsub(monkeypatch):
     manager = RiskManager()
     client = MagicMock()
+    manager.redis_client = client
     monkeypatch.setenv("CDB_ENVELOPE_EMISSION", "1")
     monkeypatch.setenv("CDB_ENVELOPE_REDIS_MODE", "PuBSub")
     monkeypatch.setenv("CDB_ENVELOPE_REDIS_STREAM", "stream.envelopes")
     monkeypatch.setenv("CDB_ENVELOPE_REDIS_CHANNEL", "channel.envelopes")
-    monkeypatch.setitem(_SVC_GLOBALS, "create_redis_client", lambda **kwargs: client)
 
     manager._setup_envelope_emitter()
 
@@ -80,9 +81,9 @@ def test_setup_envelope_emitter_on_pubsub(monkeypatch):
 def test_setup_envelope_emitter_invalid_mode_defaults_to_stream(monkeypatch):
     manager = RiskManager()
     client = MagicMock()
+    manager.redis_client = client
     monkeypatch.setenv("CDB_ENVELOPE_EMISSION", "1")
     monkeypatch.setenv("CDB_ENVELOPE_REDIS_MODE", "INVALID")
-    monkeypatch.setitem(_SVC_GLOBALS, "create_redis_client", lambda **kwargs: client)
 
     manager._setup_envelope_emitter()
 

--- a/tests/unit/utils/test_redis_client.py
+++ b/tests/unit/utils/test_redis_client.py
@@ -1,0 +1,102 @@
+"""Unit tests for core.utils.redis_client connection pooling."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import redis
+
+import core.utils.redis_client as redis_client_module
+from core.utils.redis_client import create_redis_client, get_redis_connection_pool
+
+
+@pytest.fixture(autouse=True)
+def clear_pool_cache():
+    redis_client_module._POOL_CACHE.clear()
+    redis_client_module._PINGED_POOLS.clear()
+    yield
+    redis_client_module._POOL_CACHE.clear()
+    redis_client_module._PINGED_POOLS.clear()
+
+
+def test_get_redis_connection_pool_reuses_identical_config():
+    with patch.object(redis_client_module.redis, "ConnectionPool") as pool_cls:
+        pool_cls.side_effect = [MagicMock(name="pool_a"), MagicMock(name="pool_b")]
+
+        first = get_redis_connection_pool(
+            host="redis.internal",
+            port=6379,
+            password="secret",
+            db=0,
+            decode_responses=True,
+        )
+        second = get_redis_connection_pool(
+            host="redis.internal",
+            port=6379,
+            password="secret",
+            db=0,
+            decode_responses=True,
+        )
+
+    assert first is second
+    pool_cls.assert_called_once()
+
+
+def test_get_redis_connection_pool_distinct_for_different_db():
+    with patch.object(redis_client_module.redis, "ConnectionPool") as pool_cls:
+        pool_cls.side_effect = [MagicMock(name="pool_0"), MagicMock(name="pool_1")]
+
+        pool_0 = get_redis_connection_pool(host="h", port=6379, db=0)
+        pool_1 = get_redis_connection_pool(host="h", port=6379, db=1)
+
+    assert pool_0 is not pool_1
+    assert pool_cls.call_count == 2
+
+
+def test_create_redis_client_uses_pool_and_pings_once():
+    mock_pool = MagicMock(name="pool")
+    mock_client = MagicMock(name="client")
+    mock_client.ping.return_value = True
+
+    with patch.object(redis_client_module.redis, "ConnectionPool", return_value=mock_pool):
+        with patch.object(redis_client_module.redis, "Redis", return_value=mock_client) as redis_cls:
+            first = create_redis_client(host="h", port=6379, password="p")
+            second = create_redis_client(host="h", port=6379, password="p")
+
+    redis_cls.assert_called()
+    for call in redis_cls.call_args_list:
+        assert call.kwargs.get("connection_pool") is mock_pool
+
+    assert first is mock_client
+    assert second is mock_client
+    mock_client.ping.assert_called_once()
+
+
+def test_create_redis_client_evicts_pool_on_ping_failure_and_retries():
+    mock_pool_fail = MagicMock(name="pool_fail")
+    mock_pool_ok = MagicMock(name="pool_ok")
+    mock_client_fail = MagicMock(name="client_fail")
+    mock_client_ok = MagicMock(name="client_ok")
+    mock_client_fail.ping.side_effect = redis.ConnectionError("redis unavailable")
+    mock_client_ok.ping.return_value = True
+
+    with patch.object(
+        redis_client_module.redis, "ConnectionPool", side_effect=[mock_pool_fail, mock_pool_ok]
+    ) as pool_cls:
+        with patch.object(
+            redis_client_module.redis,
+            "Redis",
+            side_effect=[mock_client_fail, mock_client_ok],
+        ):
+            with pytest.raises(redis.ConnectionError, match="redis unavailable"):
+                create_redis_client(host="h", port=6379, password="p")
+
+            assert redis_client_module._POOL_CACHE == {}
+            assert redis_client_module._PINGED_POOLS == set()
+            mock_pool_fail.disconnect.assert_called_once()
+
+            client = create_redis_client(host="h", port=6379, password="p")
+
+    assert pool_cls.call_count == 2
+    assert client is mock_client_ok
+    mock_client_ok.ping.assert_called_once()
+    assert mock_pool_ok in redis_client_module._POOL_CACHE.values()


### PR DESCRIPTION
## Summary

- Add shared `ConnectionPool` caching in `core/utils/redis_client.py` with connect/ping timeouts and eviction when the initial pool ping fails.
- Route `RiskManager.connect_redis` through `create_redis_client` and reuse the same client for pub/sub and envelope emission (no second Redis connection per instance).
- Document Redis message-bus conventions in root `AGENTS.md`.
- Add unit tests for pool reuse, cache-key separation, ping-failure eviction, and risk envelope wiring.

## Validation

- `git diff --check` — clean
- `ruff check core/utils/redis_client.py services/risk/service.py tests/unit/services/test_risk_service_emission.py tests/unit/utils/test_redis_client.py` — passed
- `pytest tests/unit/utils/test_redis_client.py tests/unit/services/test_risk_service_emission.py -q` — 7 passed

## Scope / Non-goals

**In scope:** Redis factory pooling, risk single-client connect path, scoped tests and agent note.

**Out of scope:** Migrating other services still using direct `redis.Redis()`, pub/sub vs streams changes, compose/stack changes, live Redis verification.

Redis plugin guidance applied to connection pooling and timeouts (`conn-pooling`, `conn-timeouts`).

## LR / Live impact

None. LR remains **NO-GO**. No trading gates, credentials, or live stack changes.
