### PR TITLE
[SURREALDB][MEMORY][G3a] MCP operation_mode fail-closed scaffold

### DIFF
--- a/docs/surrealdb/mcp-memory-write-surface-v1.md
+++ b/docs/surrealdb/mcp-memory-write-surface-v1.md
@@ -32,19 +32,24 @@ authorization and memory contract validity without executing persistence.
   → **`unsafe_input`** (handler-level; record body exempt from blanket scan).
 - No SQL client, no adapter import, no `agent_memory` UPSERT.
 
-## Phase 2 (G2 design — #2739)
+## Phase 2 (G2 design — #2739; G3a scaffold — #2741)
 
 Spec: [`productive-memory-audit-trail-mcp-phase2-design-v1.md`](productive-memory-audit-trail-mcp-phase2-design-v1.md)
 
-**Not implemented on `main`.** G2 defines:
+**G3a (#2741): refusal scaffold implemented on `main` (after merge).** Handler
+`memory_write_intent_tools.py` resolves `operation_mode` and refuses non-dry-run
+modes per G2 (`productive_audit_not_activated`, `local_audit_mcp_not_activated`,
+`agent_memory_write_not_activated`, `hg_p_required`, `operation_mode_invalid`).
+Dry-run path unchanged; registry remains `read_only=True`; no SQL; no
+`PERSIST_ALLOWED` flip.
 
-- `operation_mode` resolution (`dry_run`, `audit_persist_productive`, etc.)
-- MCP refusal contracts for T3 productive audit (`productive_audit_not_activated`)
-- Permission model extensions (registry / PermissionGuard — G3 code)
-- Wiring intent to G1 governed endpoint via future `memory_write_path_productive`
+G2 also defines (not yet implemented):
 
-Any future mutation or registry `read_only=False` change requires G3 maintainer GO,
-contract evidence, and a separate issue/PR — not implied by Phase 1 or G2 docs.
+- Permission model extensions (registry / PermissionGuard — G3b/G3c)
+- Wiring intent to G1 governed endpoint via `memory_write_path_productive` (G3b)
+
+Any future mutation or registry `read_only=False` change requires maintainer GO,
+contract evidence, and a separate issue/PR — not implied by Phase 1, G2, or G3a.
 
 ### Legacy Phase 2 stub (pre-G2)
 
@@ -83,6 +88,7 @@ checklist: [`productive-memory-write-readiness-runbook-v1.md`](productive-memory
 - Productive audit trail: [`productive-memory-audit-trail-v1.md`](productive-memory-audit-trail-v1.md) (#2730)
 - G1 endpoint design: [`productive-memory-audit-trail-endpoint-design-v1.md`](productive-memory-audit-trail-endpoint-design-v1.md) (#2735)
 - G2 MCP Phase 2 design: [`productive-memory-audit-trail-mcp-phase2-design-v1.md`](productive-memory-audit-trail-mcp-phase2-design-v1.md) (#2739)
+- G3a MCP operation_mode scaffold: #2741 (handler refusal codes; no persist)
 
 ## Validation
 

--- a/docs/surrealdb/memory-reality-slice1-audit.md
+++ b/docs/surrealdb/memory-reality-slice1-audit.md
@@ -678,6 +678,29 @@ updated to **DESIGN-READY (G1+G2 MCP) / NOT ACTIVATED**.
 
 Parent #2606 criterion 6 remains **PARTIAL**; G2 design does not close epic.
 
+### 22.4 G3a addendum — MCP operation_mode fail-closed scaffold (#2741)
+
+**Delivered:** Handler-level `operation_mode` resolution and G2 refusal codes in
+`tools/mcp/memory_write_intent_tools.py`. Unit tests cover refusal matrix. Registry
+schema extended; `read_only=True` unchanged. No SQL client, no productive persist,
+no `PERSIST_ALLOWED` flip.
+
+| Mode | MCP behavior (G3a) |
+| --- | --- |
+| `dry_run` (default) | Gate evaluation only (Phase 1 unchanged + phase fields) |
+| `audit_persist_productive` | `status: refused`, `productive_audit_not_activated` |
+| `audit_persist_local` | `status: refused`, `local_audit_mcp_not_activated` |
+| `agent_memory_write` | `status: refused`, `agent_memory_write_not_activated` |
+| Invalid mode | `status: refused`, `operation_mode_invalid` |
+
+| Gap | After G3a |
+| --- | --- |
+| `memory_write_path_productive` module | Not implemented (G3b) |
+| HG-P operator proof / governed endpoint | Not implemented (G3c) |
+| `PERSIST_ALLOWED` flip | Unchanged (`False`) |
+
+Parent #2606 criterion 6 remains **PARTIAL**; G3a scaffold does not close epic.
+
 ---
 
 ## Provenance

--- a/knowledge/logs/sessions/2026-05-30-g3a-mcp-operation-mode-scaffold.md
+++ b/knowledge/logs/sessions/2026-05-30-g3a-mcp-operation-mode-scaffold.md
@@ -1,0 +1,42 @@
+# Session: G3a MCP operation_mode fail-closed scaffold (#2741)
+
+**Date:** 2026-05-30  
+**Issue:** [#2741](https://github.com/jannekbuengener/Claire_de_Binare/issues/2741)  
+**Parent:** [#2606](https://github.com/jannekbuengener/Claire_de_Binare/issues/2606) (OPEN)  
+**Branch:** `feat/g3a-mcp-operation-mode-scaffold`
+
+## Goal
+
+Implement G2 refusal semantics in `cdb_context_memory_write_intent` without
+productive persist, SQL, or `PERSIST_ALLOWED` flip.
+
+## Changes
+
+| File | Change |
+| --- | --- |
+| `tools/mcp/memory_write_intent_tools.py` | `operation_mode` resolution; `_refused_response`; G2 codes |
+| `tools/mcp/memory_output_contract.py` | Skip full contract validation for `status: refused` |
+| `tools/mcp/registry.py` | Input schema: `operation_mode`, `memory_record` |
+| `tests/unit/tools/mcp/test_memory_write_intent_tool.py` | Refusal matrix (+12 tests) |
+| `docs/surrealdb/mcp-memory-write-surface-v1.md` | Phase 2 G3a status |
+| `docs/surrealdb/memory-reality-slice1-audit.md` | §22.4 G3a addendum |
+
+## Verification
+
+```bash
+pytest tests/unit/tools/mcp/test_memory_write_intent_tool.py -v  # 20 passed
+ruff check tools/mcp/memory_write_intent_tools.py tools/mcp/memory_output_contract.py tools/mcp/registry.py tests/unit/tools/mcp/test_memory_write_intent_tool.py
+```
+
+## Boundaries preserved
+
+- LR: **NO-GO**
+- `PERSIST_ALLOWED=False`
+- `MUTATION_ALLOWED=False`
+- Registry `read_only=True`
+- #2606 not closed
+
+## Next
+
+- G3b: `memory_write_path_productive` module + mock tests
+- G3c: HG-P operator proof (separate GO)

--- a/tests/unit/tools/mcp/test_memory_write_intent_tool.py
+++ b/tests/unit/tools/mcp/test_memory_write_intent_tool.py
@@ -1,4 +1,4 @@
-"""Unit tests for cdb_context_memory_write_intent MCP tool — #2704."""
+"""Unit tests for cdb_context_memory_write_intent MCP tool — #2704 / G3a #2741."""
 
 from __future__ import annotations
 
@@ -70,6 +70,94 @@ def test_default_dry_run_returns_gate_envelope() -> None:
     assert result["gate_status"] == "approved_dry_run"
     assert result["gate_envelope"]["persist_allowed"] is False
     assert result["dry_run_only"] is True
+    assert result["operation_mode_resolved"] == "dry_run"
+    assert result["productive_audit_status"] == "not_activated"
+    assert result["mcp_phase"] == "1"
+
+
+@pytest.mark.unit
+def test_memory_record_alias_accepted() -> None:
+    response = handle_cdb_context_memory_write_intent(
+        _request(memory_record=_valid_record(), authorization=_valid_auth())
+    )
+    assert response["status"] == "ok"
+    assert response["result"]["gate_status"] == "approved_dry_run"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("operation_mode", "code", "gate_status"),
+    [
+        (
+            "audit_persist_productive",
+            "productive_audit_not_activated",
+            "blocked_productive_audit_not_implemented",
+        ),
+        (
+            "audit_persist_local",
+            "local_audit_mcp_not_activated",
+            "blocked_local_audit_mcp_not_activated",
+        ),
+        (
+            "agent_memory_write",
+            "agent_memory_write_not_activated",
+            "blocked_agent_memory_write_not_activated",
+        ),
+    ],
+)
+def test_non_dry_run_operation_mode_refused(
+    operation_mode: str, code: str, gate_status: str
+) -> None:
+    response = handle_cdb_context_memory_write_intent(
+        _request(
+            record=_valid_record(),
+            authorization=_valid_auth(),
+            operation_mode=operation_mode,
+        )
+    )
+    assert response["status"] == "refused"
+    assert response["code"] == code
+    assert response["operation_mode_resolved"] == operation_mode
+    assert response["gate_status"] == gate_status
+    assert response["productive_audit_status"] == "not_activated"
+    assert response["mcp_phase"] == "1"
+
+
+@pytest.mark.unit
+def test_audit_persist_productive_hg_l_refuses_hg_p_required() -> None:
+    auth = {**_valid_auth(), "human_go_tier": "HG-L"}
+    response = handle_cdb_context_memory_write_intent(
+        _request(
+            record=_valid_record(),
+            authorization=auth,
+            operation_mode="audit_persist_productive",
+        )
+    )
+    assert response["status"] == "refused"
+    assert response["code"] == "hg_p_required"
+    assert response["gate_status"] == "blocked_hg_p_required"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("invalid_mode", ["  ", "bogus_mode", 123])
+def test_invalid_operation_mode(invalid_mode) -> None:
+    response = handle_cdb_context_memory_write_intent(
+        _request(
+            record=_valid_record(),
+            operation_mode=invalid_mode,
+        )
+    )
+    assert response["status"] == "refused"
+    assert response["code"] == "operation_mode_invalid"
+
+
+@pytest.mark.unit
+def test_audit_persist_local_boolean_flag_still_mutation_blocked() -> None:
+    response = handle_cdb_context_memory_write_intent(
+        _request(record=_valid_record(), audit_persist_local=True)
+    )
+    assert response["status"] == "error"
+    assert response["error"]["code"] == "mutation_blocked_by_default"
 
 
 @pytest.mark.unit

--- a/tools/mcp/memory_output_contract.py
+++ b/tools/mcp/memory_output_contract.py
@@ -62,7 +62,7 @@ def validate_memory_output_contract(response: Mapping[str, Any]) -> list[str]:
         if field not in response:
             violations.append(f"missing required envelope field: {field}")
 
-    if response.get("status") == "error":
+    if response.get("status") in ("error", "refused"):
         return violations
 
     metadata = response.get("metadata")

--- a/tools/mcp/memory_write_intent_tools.py
+++ b/tools/mcp/memory_write_intent_tools.py
@@ -1,6 +1,7 @@
-"""MCP dry-run surface for gated memory write intents — #2704.
+"""MCP dry-run surface for gated memory write intents — #2704 / G3a #2741.
 
 Issue: #2704 — design gated memory write surface (dry-run default)
+G3a: #2741 — operation_mode fail-closed scaffold (G2 refusal codes)
 Parent: #2606 (Langzeitgedaechtnis / Persistent Agent Memory)
 
 Exposes ``cdb_context_memory_write_intent`` as a read-only MCP tool that
@@ -10,6 +11,7 @@ no persistence, no mutation execution.
 Guardrails:
     - MUTATION_ALLOWED is always False in this slice.
     - Default path is dry-run gate evaluation via ``evaluate_memory_write_gate``.
+    - Non-dry-run ``operation_mode`` values are refused per G2 design (#2739).
     - Mutation flags fail closed with ``mutation_blocked_by_default``.
     - Raw human_go_token must never appear in responses or logs.
     - LR remains NO-GO.
@@ -31,6 +33,16 @@ logger = logging.getLogger(__name__)
 
 TOOL_CDB_CONTEXT_MEMORY_WRITE_INTENT = "cdb_context_memory_write_intent"
 MUTATION_ALLOWED = False
+MCP_PHASE = "1"
+
+_VALID_OPERATION_MODES: frozenset[str] = frozenset(
+    {
+        "dry_run",
+        "audit_persist_local",
+        "audit_persist_productive",
+        "agent_memory_write",
+    }
+)
 
 _MUTATION_FLAGS = frozenset(
     {
@@ -75,6 +87,30 @@ def _error_response(
     return payload
 
 
+def _refused_response(
+    *,
+    code: str,
+    message: str,
+    operation_mode_resolved: str,
+    gate_status: str,
+) -> dict[str, Any]:
+    return {
+        "tool": TOOL_CDB_CONTEXT_MEMORY_WRITE_INTENT,
+        "status": "refused",
+        "code": code,
+        "message": message,
+        "operation_mode_resolved": operation_mode_resolved,
+        "gate_status": gate_status,
+        "productive_audit_status": "not_activated",
+        "mcp_phase": MCP_PHASE,
+        "metadata": {
+            "query_time_ms": 0,
+            "source": "in_memory",
+            "read_only": True,
+        },
+    }
+
+
 def _ok_response(*, result: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "tool": TOOL_CDB_CONTEXT_MEMORY_WRITE_INTENT,
@@ -103,6 +139,97 @@ def _parse_authorization(raw: Any) -> MemoryWriteAuthorization | None:
     )
 
 
+def _parse_human_go_tier(raw: Any) -> str | None:
+    mapping = _as_mapping(raw)
+    if mapping is None:
+        return None
+    tier = mapping.get("human_go_tier")
+    if tier is None:
+        return None
+    text = str(tier).strip().upper()
+    return text or None
+
+
+def _resolve_operation_mode(
+    parameters: Mapping[str, Any],
+) -> tuple[str | None, dict[str, Any] | None]:
+    raw = parameters.get("operation_mode")
+    if raw is None or raw == "":
+        return "dry_run", None
+    if not isinstance(raw, str):
+        return None, _refused_response(
+            code="operation_mode_invalid",
+            message="operation_mode must be a string",
+            operation_mode_resolved=str(raw),
+            gate_status="blocked_operation_mode_invalid",
+        )
+    mode = raw.strip()
+    if mode not in _VALID_OPERATION_MODES:
+        return None, _refused_response(
+            code="operation_mode_invalid",
+            message=f"unsupported operation_mode: {mode!r}",
+            operation_mode_resolved=mode,
+            gate_status="blocked_operation_mode_invalid",
+        )
+    return mode, None
+
+
+def _refuse_non_dry_run_mode(
+    mode: str,
+    authorization_raw: Any,
+) -> dict[str, Any] | None:
+    if mode == "dry_run":
+        return None
+    if mode == "audit_persist_local":
+        return _refused_response(
+            code="local_audit_mcp_not_activated",
+            message=(
+                "MCP is not authorized for audit_persist_local; use the "
+                "operator write path (memory_write_path_v1) instead."
+            ),
+            operation_mode_resolved=mode,
+            gate_status="blocked_local_audit_mcp_not_activated",
+        )
+    if mode == "audit_persist_productive":
+        tier = _parse_human_go_tier(authorization_raw)
+        if tier == "HG-L":
+            return _refused_response(
+                code="hg_p_required",
+                message=(
+                    "audit_persist_productive requires Human-GO tier HG-P; "
+                    "HG-L is insufficient for T3 productive audit."
+                ),
+                operation_mode_resolved=mode,
+                gate_status="blocked_hg_p_required",
+            )
+        return _refused_response(
+            code="productive_audit_not_activated",
+            message=(
+                "MCP Phase 2 productive audit persist is design-only; "
+                "G3b/G3c implementation required."
+            ),
+            operation_mode_resolved=mode,
+            gate_status="blocked_productive_audit_not_implemented",
+        )
+    if mode == "agent_memory_write":
+        return _refused_response(
+            code="agent_memory_write_not_activated",
+            message=(
+                "agent_memory_write (T4) is not activated; G4 scope remains blocked."
+            ),
+            operation_mode_resolved=mode,
+            gate_status="blocked_agent_memory_write_not_activated",
+        )
+    return None
+
+
+def _resolve_record(parameters: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    record = _as_mapping(parameters.get("record"))
+    if record is not None:
+        return record
+    return _as_mapping(parameters.get("memory_record"))
+
+
 def _scan_injection_fields(parameters: Mapping[str, Any]) -> str | None:
     for key, value in parameters.items():
         if key not in _FORBIDDEN_INJECTION_FIELDS:
@@ -116,7 +243,11 @@ def _scan_injection_fields(parameters: Mapping[str, Any]) -> str | None:
     return None
 
 
-def _wrap_gate_envelope(envelope: Mapping[str, Any]) -> dict[str, Any]:
+def _wrap_gate_envelope(
+    envelope: Mapping[str, Any],
+    *,
+    operation_mode_resolved: str = "dry_run",
+) -> dict[str, Any]:
     memory_id = envelope.get("memory_id")
     result: dict[str, Any] = {
         "memory_id": memory_id,
@@ -124,6 +255,9 @@ def _wrap_gate_envelope(envelope: Mapping[str, Any]) -> dict[str, Any]:
         "gate_envelope": dict(envelope),
         "dry_run_only": True,
         "persist_allowed": False,
+        "operation_mode_resolved": operation_mode_resolved,
+        "productive_audit_status": "not_activated",
+        "mcp_phase": MCP_PHASE,
         "approval_semantics": dict(envelope.get("approval_semantics") or {}),
     }
     if memory_id:
@@ -136,6 +270,9 @@ def _wrap_gate_envelope(envelope: Mapping[str, Any]) -> dict[str, Any]:
         extra=[
             "MCP memory write intent is dry-run gate evaluation only.",
             "mutation_blocked_by_default; no DB write via MCP.",
+            "no_persistence",
+            "no_mcp_mutation",
+            "t3_productive_audit_not_activated",
         ],
     )
     return result
@@ -152,9 +289,10 @@ def handle_cdb_context_memory_write_intent(
     """Evaluate a memory write intent through the Human-GO gate (dry-run only).
 
     Parameters (under ``parameters`` or top-level):
-        record: memory record dict (required)
+        record / memory_record: memory record dict (required)
         authorization: optional Human-GO authorization block
-        dry_run: ignored; always dry-run in v1
+        operation_mode: dry_run (default) | audit_persist_* | agent_memory_write
+        dry_run: ignored; always dry-run in v1 when operation_mode is dry_run
         mutation_requested / execute_write / execute / persist: fail-closed
     """
     if not MUTATION_ALLOWED:
@@ -171,6 +309,16 @@ def handle_cdb_context_memory_write_intent(
         )
 
     parameters = _as_mapping(request.get("parameters")) or request
+
+    operation_mode, mode_error = _resolve_operation_mode(parameters)
+    if mode_error is not None:
+        return mode_error
+    assert operation_mode is not None
+
+    authorization_raw = parameters.get("authorization")
+    refusal = _refuse_non_dry_run_mode(operation_mode, authorization_raw)
+    if refusal is not None:
+        return refusal
 
     for flag in _MUTATION_FLAGS:
         if parameters.get(flag):
@@ -190,14 +338,14 @@ def handle_cdb_context_memory_write_intent(
             message=injection_issue,
         )
 
-    record = _as_mapping(parameters.get("record"))
+    record = _resolve_record(parameters)
     if record is None:
         return _error_response(
             code="invalid_parameters",
-            message="record is required (object)",
+            message="record (or memory_record) is required (object)",
         )
 
-    authorization = _parse_authorization(parameters.get("authorization"))
+    authorization = _parse_authorization(authorization_raw)
 
     envelope = evaluate_memory_write_gate(dict(record), authorization)
     if _response_has_raw_token(envelope):
@@ -207,7 +355,7 @@ def handle_cdb_context_memory_write_intent(
             message="gate envelope must not contain raw human_go_token",
         )
 
-    result = _wrap_gate_envelope(envelope)
+    result = _wrap_gate_envelope(envelope, operation_mode_resolved=operation_mode)
     response = _ok_response(result=result)
     if _response_has_raw_token(response):
         return _error_response(

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -1007,7 +1007,17 @@ TOOLS_V0 = [
                     "type": "object",
                     "properties": {
                         "record": {"type": "object"},
+                        "memory_record": {"type": "object"},
                         "authorization": {"type": "object"},
+                        "operation_mode": {
+                            "type": "string",
+                            "enum": [
+                                "dry_run",
+                                "audit_persist_local",
+                                "audit_persist_productive",
+                                "agent_memory_write",
+                            ],
+                        },
                         "dry_run": {"type": "boolean", "default": True},
                     },
                     "required": ["record"],


### PR DESCRIPTION
## Summary

- Implement G2 `operation_mode` resolution and fail-closed refusal codes in `cdb_context_memory_write_intent` (G3a / #2741).
- Dry-run path unchanged; success envelope adds `operation_mode_resolved`, `productive_audit_status`, `mcp_phase`.
- Non-dry-run modes return `status: refused` with G2 codes (`productive_audit_not_activated`, `local_audit_mcp_not_activated`, `agent_memory_write_not_activated`, `hg_p_required`, `operation_mode_invalid`).
- Registry schema extended; `read_only=True` preserved. No SQL, no `PERSIST_ALLOWED` flip.

Closes #2741
Refs #2606

## Boundaries

- LR remains NO-GO
- `PERSIST_ALLOWED=False`, `MUTATION_ALLOWED=False`
- Does **not** close #2606
- G3b/G3c out of scope

## Test plan

- [x] `pytest tests/unit/tools/mcp/test_memory_write_intent_tool.py -v` (20 passed)
- [x] `ruff check` on touched Python files
- [ ] CI + policy-gate green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Fail-closed refusals and expanded tests only; no persistence, SQL, or registry mutation flags changed.
> 
> **Overview**
> Adds **G3a fail-closed `operation_mode` handling** to `cdb_context_memory_write_intent`: default **`dry_run`** still runs the Human-GO gate only; **`audit_persist_*`**, **`agent_memory_write`**, and invalid modes return **`status: refused`** with G2 codes (including **`hg_p_required`** when productive audit is requested with **HG-L**).
> 
> Successful dry-run responses now expose **`operation_mode_resolved`**, **`productive_audit_status`**, and **`mcp_phase`**. Registry input adds **`operation_mode`** and **`memory_record`**; **`memory_output_contract`** treats **`refused`** like **`error`** for validation. Docs/session log record G3a; **no SQL, no persist, registry stays `read_only=True`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6e123a75efc0d706727dbad9a1cc02d0e35140d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->