### PR TITLE
feat(surrealdb): G3b productive memory adapter contract proof (#2744)

### DIFF
--- a/docs/surrealdb/mcp-memory-write-surface-v1.md
+++ b/docs/surrealdb/mcp-memory-write-surface-v1.md
@@ -45,11 +45,16 @@ Dry-run path unchanged; registry remains `read_only=True`; no SQL; no
 
 G2 also defines (not yet implemented):
 
-- Permission model extensions (registry / PermissionGuard — G3b/G3c)
-- Wiring intent to G1 governed endpoint via `memory_write_path_productive` (G3b)
+- Permission model extensions (registry / PermissionGuard — G3c)
+- MCP handler wiring to productive adapter execution (G3c+)
+
+**G3b (#2744): adapter contract proof (pending merge).** Module
+`memory_write_path_productive.py` provides mock-proven T3 boundary with HG-P tier
+semantics and mock sink only. MCP handler still refuses `audit_persist_productive`
+(G3a); no `PERSIST_ALLOWED` / `MUTATION_ALLOWED` flip.
 
 Any future mutation or registry `read_only=False` change requires maintainer GO,
-contract evidence, and a separate issue/PR — not implied by Phase 1, G2, or G3a.
+contract evidence, and a separate issue/PR — not implied by Phase 1, G2, G3a, or G3b.
 
 ### Legacy Phase 2 stub (pre-G2)
 
@@ -89,6 +94,7 @@ checklist: [`productive-memory-write-readiness-runbook-v1.md`](productive-memory
 - G1 endpoint design: [`productive-memory-audit-trail-endpoint-design-v1.md`](productive-memory-audit-trail-endpoint-design-v1.md) (#2735)
 - G2 MCP Phase 2 design: [`productive-memory-audit-trail-mcp-phase2-design-v1.md`](productive-memory-audit-trail-mcp-phase2-design-v1.md) (#2739)
 - G3a MCP operation_mode scaffold: #2741 (handler refusal codes; no persist)
+- G3b productive adapter contract proof: #2744 (mock sink only; no MCP enable)
 
 ## Validation
 

--- a/docs/surrealdb/memory-reality-slice1-audit.md
+++ b/docs/surrealdb/memory-reality-slice1-audit.md
@@ -701,6 +701,26 @@ no `PERSIST_ALLOWED` flip.
 
 Parent #2606 criterion 6 remains **PARTIAL**; G3a scaffold does not close epic.
 
+### 22.5 G3b addendum — productive memory adapter contract proof (#2744)
+
+**Delivered (pending merge):** Mock-proven contract boundary in
+`tools/surrealdb/memory_write_path_productive.py`. Unit tests cover 14 fail-closed
+checks. Mock sink only; no real DB/network writes; `PRODUCTIVE_ACTIVATED=False`;
+`PERSIST_ALLOWED` unchanged.
+
+| Mode | G3b behavior |
+| --- | --- |
+| `dry_run` (default) | Gate evaluation only; `path_status=evaluated_only` |
+| `audit_persist_productive` | Mock sink + HG-P + env gate; no real endpoint |
+
+| Gap | After G3b |
+| --- | --- |
+| HG-P operator proof / governed endpoint | Not implemented (G3c) |
+| MCP `audit_persist_productive` execution | Still refused (G3a handler) |
+| `PERSIST_ALLOWED` flip | Unchanged (`False`) |
+
+Parent #2606 criterion 6 remains **PARTIAL**; G3b contract proof does not close epic.
+
 ---
 
 ## Provenance

--- a/knowledge/logs/sessions/2026-05-30-2744-g3b-productive-memory-adapter-proof.md
+++ b/knowledge/logs/sessions/2026-05-30-2744-g3b-productive-memory-adapter-proof.md
@@ -1,0 +1,49 @@
+# Session: G3b productive memory adapter contract proof (#2744)
+
+**Date:** 2026-05-30  
+**Issue:** [#2744](https://github.com/jannekbuengener/Claire_de_Binare/issues/2744)  
+**Parent:** [#2606](https://github.com/jannekbuengener/Claire_de_Binare/issues/2606) (OPEN / NOT_CLOSURE_READY)  
+**Branch:** `feat/2606-g3b-productive-memory-adapter-proof`
+
+## Goal
+
+Deliver mock-proven, non-productive adapter/contract proof for future T3 productive
+audit trail path (G3b slice). No real DB writes, no guardrail flips.
+
+## Changes
+
+| File | Change |
+| --- | --- |
+| `tools/surrealdb/memory_write_path_productive.py` | New G3b contract boundary module |
+| `tests/unit/surrealdb/test_memory_write_path_productive.py` | 14 fail-closed unit checks |
+| `docs/surrealdb/memory-reality-slice1-audit.md` | §22.5 G3b addendum |
+| `docs/surrealdb/mcp-memory-write-surface-v1.md` | G3b status cross-reference |
+
+## Verification
+
+```bash
+pytest tests/unit/surrealdb/test_memory_write_path_productive.py -v  # 14 passed
+pytest tests/unit/surrealdb/test_memory_write_path_v1.py \
+  tests/unit/surrealdb/test_memory_write_gate.py \
+  tests/unit/surrealdb/test_audit_observation_from_gate.py \
+  tests/unit/tools/mcp/test_memory_write_intent_tool.py -q  # 46 passed
+ruff check tools/surrealdb/memory_write_path_productive.py \
+  tests/unit/surrealdb/test_memory_write_path_productive.py
+```
+
+## Boundaries preserved
+
+- LR: **NO-GO**
+- `PERSIST_ALLOWED=False` (unchanged in `memory_write_gate.py`)
+- `MUTATION_ALLOWED=False` (unchanged in MCP handler)
+- `PRODUCTIVE_ACTIVATED=False` (module constant)
+- Mock sink only; no real SurrealDB/HTTP writes
+- MCP `audit_persist_productive` still refused (G3a handler unchanged)
+- #2606 not closed
+
+## Non-goals (explicit)
+
+- G3c HG-P operator proof
+- Productive endpoint activation
+- `agent_memory_write`
+- Infra/workflow changes

--- a/knowledge/logs/sessions/2026-05-30-2744-g3b-productive-memory-adapter-proof.md
+++ b/knowledge/logs/sessions/2026-05-30-2744-g3b-productive-memory-adapter-proof.md
@@ -41,9 +41,15 @@ ruff check tools/surrealdb/memory_write_path_productive.py \
 - MCP `audit_persist_productive` still refused (G3a handler unchanged)
 - #2606 not closed
 
-## Non-goals (explicit)
+## Merge status
 
-- G3c HG-P operator proof
-- Productive endpoint activation
-- `agent_memory_write`
-- Infra/workflow changes
+- PR [#2745](https://github.com/jannekbuengener/Claire_de_Binare/pull/2745) open
+- CI `ci (Unit/Integration + Lint gesammelt)`: **PASS**
+- `policy-gate`: **queued** (self-hosted runner `[self-hosted, cdb, docker, merge-gate]`)
+- Merge blocked until policy-gate completes
+
+## Next (post-merge)
+
+- Close #2744
+- Comment on #2606 (do not close)
+- Update §22.5 addendum from "pending merge" to "delivered"

--- a/tests/unit/surrealdb/test_memory_write_path_productive.py
+++ b/tests/unit/surrealdb/test_memory_write_path_productive.py
@@ -1,0 +1,362 @@
+"""Unit tests for memory_write_path_productive — G3b #2744."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Mapping
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.surrealdb.memory_write_gate import PERSIST_ALLOWED
+from tools.surrealdb.memory_write_path_productive import (
+    PRODUCTIVE_ACTIVATED,
+    PRODUCTIVE_ENV_VAR,
+    ProductiveWriteAuthorization,
+    run_memory_write_path_productive,
+)
+
+FIXED_NOW = datetime(2026, 5, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _valid_record(**overrides) -> dict:
+    base: dict = {
+        "scope": "memory_write_path_productive:g3b001",
+        "namespace": "memory_write_path_productive:g3b001",
+        "memory_type": "semantic_memory",
+        "content": "G3b productive path unit test record.",
+        "source_refs": ["docs/surrealdb/productive-memory-audit-trail-endpoint-design-v1.md"],
+        "evidence_refs": ["ev-g3b-001"],
+        "confidence": 0.9,
+        "ttl": 86400,
+        "expires_at": "2026-05-31T10:00:00Z",
+        "created_by": "cdb-test-g3b",
+        "created_at": "2026-05-30T10:00:00Z",
+    }
+    base.update(overrides)
+    from tools.surrealdb.memory_contract import generate_memory_id
+
+    base["memory_id"] = generate_memory_id(
+        scope=base["scope"],
+        namespace=base["namespace"],
+        memory_type=base["memory_type"],
+        created_by=base["created_by"],
+        content=base["content"],
+        source_refs=base["source_refs"],
+    )
+    return base
+
+
+def _valid_auth(**overrides) -> ProductiveWriteAuthorization:
+    base = dict(
+        human_go_token="GO-2026-05-30-g3b",
+        human_go_tier="HG-P",
+        authorized_by="jannekbuengener",
+        authorized_at="2026-05-30T12:00:00+00:00",
+        scope="memory_write_path_productive:g3b001",
+        target_issue="2744",
+        evidence_refs=("github:issue/2744",),
+        operation="create",
+    )
+    base.update(overrides)
+    return ProductiveWriteAuthorization(**base)
+
+
+class _MockSink:
+    def __init__(self, *, mode: str = "mock") -> None:
+        self._mode = mode
+        self._rows: dict[str, dict[str, Any]] = {}
+
+    def mode(self) -> str:
+        return self._mode
+
+    def upsert_audit_observation(
+        self, observation_id: str, payload: Mapping[str, Any]
+    ) -> None:
+        self._rows[observation_id] = dict(payload)
+
+    def observation_exists(self, observation_id: str) -> bool:
+        return observation_id in self._rows
+
+
+@pytest.mark.unit
+def test_productive_defaults_fail_closed() -> None:
+    assert PRODUCTIVE_ACTIVATED is False
+    assert PERSIST_ALLOWED is False
+    sink = _MockSink()
+    result = run_memory_write_path_productive(
+        _valid_record(),
+        _valid_auth(),
+        mode="dry_run",
+        sink=sink,
+        now=FIXED_NOW,
+    )
+    assert result["path_status"] == "evaluated_only"
+    assert result["tables_written"] == []
+    assert not sink._rows
+
+
+@pytest.mark.unit
+def test_dry_run_evaluates_gate_only() -> None:
+    sink = _MockSink()
+    result = run_memory_write_path_productive(
+        _valid_record(),
+        _valid_auth(),
+        mode="dry_run",
+        sink=sink,
+        now=FIXED_NOW,
+    )
+    assert result["path_status"] == "evaluated_only"
+    assert result["gate_status"] == "approved_dry_run"
+    assert result["operation_mode_resolved"] == "dry_run"
+    assert not sink._rows
+
+
+@pytest.mark.unit
+def test_productive_mode_refused_without_authorization() -> None:
+    sink = _MockSink()
+    result = run_memory_write_path_productive(
+        _valid_record(),
+        None,
+        mode="audit_persist_productive",
+        sink=sink,
+        now=FIXED_NOW,
+    )
+    assert result["status"] == "refused"
+    assert result["code"] == "no_authorization"
+    assert not sink._rows
+
+
+@pytest.mark.unit
+def test_productive_mode_refused_hg_l() -> None:
+    sink = _MockSink()
+    result = run_memory_write_path_productive(
+        _valid_record(),
+        _valid_auth(human_go_tier="HG-L"),
+        mode="audit_persist_productive",
+        sink=sink,
+        now=FIXED_NOW,
+    )
+    assert result["status"] == "refused"
+    assert result["code"] == "hg_p_required"
+
+
+@pytest.mark.unit
+def test_productive_mode_refused_invalid_tier() -> None:
+    sink = _MockSink()
+    result = run_memory_write_path_productive(
+        _valid_record(),
+        _valid_auth(human_go_tier="HG-W"),
+        mode="audit_persist_productive",
+        sink=sink,
+        now=FIXED_NOW,
+    )
+    assert result["status"] == "refused"
+    assert result["code"] == "hg_p_required"
+
+
+@pytest.mark.unit
+def test_productive_mode_refused_when_gate_blocked() -> None:
+    sink = _MockSink()
+    result = run_memory_write_path_productive(
+        _valid_record(),
+        _valid_auth(scope="wrong-scope"),
+        mode="audit_persist_productive",
+        sink=sink,
+        now=FIXED_NOW,
+    )
+    assert result["status"] == "refused"
+    assert result["code"] == "gate_blocked"
+
+
+@pytest.mark.unit
+def test_productive_mode_refused_when_env_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(PRODUCTIVE_ENV_VAR, raising=False)
+    sink = _MockSink()
+    result = run_memory_write_path_productive(
+        _valid_record(),
+        _valid_auth(),
+        mode="audit_persist_productive",
+        sink=sink,
+        now=FIXED_NOW,
+    )
+    assert result["status"] == "refused"
+    assert result["code"] == "productive_env_missing"
+
+
+@pytest.mark.unit
+def test_productive_mode_refused_without_sink(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(PRODUCTIVE_ENV_VAR, "1")
+    result = run_memory_write_path_productive(
+        _valid_record(),
+        _valid_auth(),
+        mode="audit_persist_productive",
+        sink=None,
+        now=FIXED_NOW,
+    )
+    assert result["status"] == "refused"
+    assert result["code"] == "mock_sink_required"
+
+
+@pytest.mark.unit
+def test_productive_mode_refused_non_mock_sink(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(PRODUCTIVE_ENV_VAR, "1")
+    sink = _MockSink(mode="real")
+    result = run_memory_write_path_productive(
+        _valid_record(),
+        _valid_auth(),
+        mode="audit_persist_productive",
+        sink=sink,
+        now=FIXED_NOW,
+    )
+    assert result["status"] == "refused"
+    assert result["code"] == "mock_sink_invalid_mode"
+
+
+@pytest.mark.unit
+def test_productive_mode_mock_persist_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(PRODUCTIVE_ENV_VAR, "1")
+    sink = _MockSink()
+    result = run_memory_write_path_productive(
+        _valid_record(),
+        _valid_auth(),
+        mode="audit_persist_productive",
+        sink=sink,
+        now=FIXED_NOW,
+    )
+    assert result["status"] == "ok"
+    assert result["path_status"] == "mock_persisted_productive_audit"
+    assert result["tables_written"] == ["audit_observation"]
+    assert result["sink_mode"] == "mock"
+    assert result["productive_audit_status"] == "mock_persisted"
+    assert len(sink._rows) == 1
+    assert result["audit_observation"]["observation_type"] == (
+        "memory_write_gate_evaluation"
+    )
+
+
+@pytest.mark.unit
+def test_productive_mode_refuses_duplicate_observation_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(PRODUCTIVE_ENV_VAR, "1")
+    sink = _MockSink()
+    first = run_memory_write_path_productive(
+        _valid_record(),
+        _valid_auth(),
+        mode="audit_persist_productive",
+        sink=sink,
+        now=FIXED_NOW,
+    )
+    assert first["status"] == "ok"
+    second = run_memory_write_path_productive(
+        _valid_record(),
+        _valid_auth(),
+        mode="audit_persist_productive",
+        sink=sink,
+        now=FIXED_NOW,
+    )
+    assert second["status"] == "refused"
+    assert second["code"] == "duplicate_observation_id"
+    assert len(sink._rows) == 1
+
+
+@pytest.mark.unit
+def test_response_never_contains_raw_human_go_token() -> None:
+    token = "GO-2026-05-30-g3b-secret"
+    result = run_memory_write_path_productive(
+        _valid_record(),
+        _valid_auth(human_go_token=token),
+        mode="dry_run",
+        now=FIXED_NOW,
+    )
+    serialized = json.dumps(result)
+    assert token not in serialized
+    assert "human_go_token" not in serialized
+
+
+@pytest.mark.unit
+def test_forbidden_keys_in_audit_payload_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(PRODUCTIVE_ENV_VAR, "1")
+    sink = _MockSink()
+    record = _valid_record()
+    auth = _valid_auth()
+    from tools.surrealdb.memory_write_gate import (
+        MemoryWriteAuthorization,
+        evaluate_memory_write_gate,
+    )
+
+    gate_envelope = evaluate_memory_write_gate(
+        record,
+        MemoryWriteAuthorization(
+            human_go_token=auth.human_go_token,
+            authorized_by=auth.authorized_by,
+            authorized_at=auth.authorized_at,
+            scope=auth.scope,
+            target_issue=auth.target_issue,
+            evidence_refs=auth.evidence_refs,
+            operation=auth.operation,
+        ),
+        now=FIXED_NOW,
+    )
+    gate_envelope = dict(gate_envelope)
+    audit = dict(gate_envelope["audit"])
+    audit["human_go_token"] = "LEAK"
+    gate_envelope["audit"] = audit
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv(PRODUCTIVE_ENV_VAR, "1")
+        original_eval = evaluate_memory_write_gate
+
+        def patched_eval(*args, **kwargs):
+            if kwargs.get("now") == FIXED_NOW and args[0] is record:
+                return gate_envelope
+            return original_eval(*args, **kwargs)
+
+        mp.setattr(
+            "tools.surrealdb.memory_write_path_productive.evaluate_memory_write_gate",
+            patched_eval,
+        )
+        result = run_memory_write_path_productive(
+            record,
+            auth,
+            mode="audit_persist_productive",
+            sink=sink,
+            now=FIXED_NOW,
+        )
+    assert result["status"] == "refused"
+    assert result["code"] == "forbidden_key_present"
+
+
+@pytest.mark.unit
+def test_deterministic_envelope_for_same_inputs() -> None:
+    record = _valid_record()
+    auth = _valid_auth()
+    first = run_memory_write_path_productive(
+        record,
+        auth,
+        mode="dry_run",
+        now=FIXED_NOW,
+    )
+    second = run_memory_write_path_productive(
+        record,
+        auth,
+        mode="dry_run",
+        now=FIXED_NOW,
+    )
+    assert first["gate"]["audit"]["observation_id"] == (
+        second["gate"]["audit"]["observation_id"]
+    )
+    assert first["memory_id"] == second["memory_id"]
+    assert first["gate_status"] == second["gate_status"]

--- a/tools/surrealdb/memory_write_path_productive.py
+++ b/tools/surrealdb/memory_write_path_productive.py
@@ -319,15 +319,6 @@ def _success_envelope(
     )
 
 
-def _public_audit_observation(
-    audit_observation: Mapping[str, Any] | None,
-) -> dict[str, Any] | None:
-    if audit_observation is None:
-        return None
-    cleaned = _public_gate_envelope(audit_observation)
-    return cleaned if isinstance(cleaned, dict) else dict(audit_observation)
-
-
 def run_memory_write_path_productive(
     record: Mapping[str, Any],
     authorization: ProductiveWriteAuthorization | None,

--- a/tools/surrealdb/memory_write_path_productive.py
+++ b/tools/surrealdb/memory_write_path_productive.py
@@ -1,0 +1,495 @@
+"""Memory Write Path Productive — mock-proven contract boundary — G3b #2744.
+
+Non-productive adapter/contract proof for future T3 productive audit trail.
+Never performs real DB/network writes. PRODUCTIVE_ACTIVATED remains False.
+
+Guardrails:
+    - PERSIST_ALLOWED in memory_write_gate remains False (not flipped here).
+    - Default mode is dry_run (zero persistence).
+    - audit_persist_productive requires HG-P, env gate, and mock sink only.
+    - LR remains NO-GO.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal, Mapping, Protocol
+
+from core.utils.clock import utcnow as cdb_utcnow
+from tools.surrealdb.audit_observation_from_gate import (
+    AuditObservationMaterializeError,
+    audit_observation_row_is_redacted,
+    materialize_audit_observation_from_gate,
+)
+from tools.surrealdb.memory_write_gate import (
+    GATE_SCHEMA_VERSION,
+    MemoryWriteAuthorization,
+    PERSIST_ALLOWED,
+    evaluate_memory_write_gate,
+)
+
+WRITE_PATH_PRODUCTIVE_SCHEMA_VERSION = "memory-write-path-productive/v1"
+PRODUCTIVE_AUDIT_SCHEMA_VERSION = "productive-audit-path/v1"
+PRODUCTIVE_TIER = "T3"
+PRODUCTIVE_ACTIVATED = False
+PRODUCTIVE_ENV_VAR = "CDB_PERSIST_PRODUCTIVE_AUDIT_TRAIL"
+REQUIRED_HUMAN_GO_TIER = "HG-P"
+ALLOWED_SINK_MODE = "mock"
+
+ProductiveMode = Literal["dry_run", "audit_persist_productive"]
+ProductivePathStatus = Literal[
+    "evaluated_only",
+    "refused",
+    "mock_persisted_productive_audit",
+]
+
+_FORBIDDEN_KEYS = frozenset({"human_go_token", "human_go"})
+
+
+class MemoryWritePathProductiveError(RuntimeError):
+    """Raised when productive write path preconditions are not met."""
+
+
+@dataclass(frozen=True)
+class ProductiveWriteAuthorization:
+    """Explicit human authorization for productive audit trail mock path."""
+
+    human_go_token: str
+    human_go_tier: str
+    authorized_by: str
+    authorized_at: str
+    scope: str
+    target_issue: str
+    evidence_refs: tuple[str, ...]
+    operation: Literal["create", "supersede"] = "create"
+
+
+class ProductiveAuditSink(Protocol):
+    """Mock-only sink abstraction for contract proof."""
+
+    def mode(self) -> str: ...
+
+    def upsert_audit_observation(
+        self, observation_id: str, payload: Mapping[str, Any]
+    ) -> None: ...
+
+    def observation_exists(self, observation_id: str) -> bool: ...
+
+
+def productive_env_enabled() -> bool:
+    return os.environ.get(PRODUCTIVE_ENV_VAR) == "1"
+
+
+def _parse_now(value: datetime | None) -> datetime:
+    effective = value if value is not None else cdb_utcnow()
+    if effective.tzinfo is None:
+        return effective.replace(tzinfo=timezone.utc)
+    return effective.astimezone(timezone.utc)
+
+
+def _token_fingerprint(token: str) -> str:
+    digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    return f"sha256:{digest[:16]}"
+
+
+def _normalize_tier(tier: str | None) -> str:
+    if tier is None:
+        return ""
+    return tier.strip().upper()
+
+
+def _to_gate_authorization(
+    authorization: ProductiveWriteAuthorization,
+) -> MemoryWriteAuthorization:
+    return MemoryWriteAuthorization(
+        human_go_token=authorization.human_go_token,
+        authorized_by=authorization.authorized_by,
+        authorized_at=authorization.authorized_at,
+        scope=authorization.scope,
+        target_issue=authorization.target_issue,
+        evidence_refs=authorization.evidence_refs,
+        operation=authorization.operation,
+    )
+
+
+def _contains_forbidden_keys(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            if key in _FORBIDDEN_KEYS:
+                return True
+            if _contains_forbidden_keys(nested):
+                return True
+        return False
+    if isinstance(value, list):
+        return any(_contains_forbidden_keys(item) for item in value)
+    return False
+
+
+def _contains_raw_token(value: Any, token: str) -> bool:
+    if not token:
+        return False
+    if isinstance(value, str):
+        return token in value
+    if isinstance(value, Mapping):
+        return any(_contains_raw_token(nested, token) for nested in value.values())
+    if isinstance(value, list):
+        return any(_contains_raw_token(item, token) for item in value)
+    return False
+
+
+def _public_gate_envelope(gate_envelope: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return a response-safe gate snapshot without forbidden keys."""
+    if not gate_envelope:
+        return {}
+
+    def _clean(node: Any) -> Any:
+        if isinstance(node, Mapping):
+            cleaned: dict[str, Any] = {}
+            for key, value in node.items():
+                if key in _FORBIDDEN_KEYS:
+                    continue
+                public_key = (
+                    "go_token_present" if key == "human_go_token_present" else key
+                )
+                cleaned[public_key] = _clean(value)
+            return cleaned
+        if isinstance(node, list):
+            return [_clean(item) for item in node]
+        return node
+
+    return _clean(dict(gate_envelope))
+
+
+def _sanitize_envelope(
+    envelope: dict[str, Any],
+    *,
+    raw_token: str | None = None,
+) -> dict[str, Any]:
+    if _contains_forbidden_keys(envelope):
+        raise MemoryWritePathProductiveError("forbidden key present in envelope")
+    serialized = json.dumps(envelope, default=str)
+    if '"human_go_token"' in serialized:
+        raise MemoryWritePathProductiveError("human_go_token key leaked in envelope")
+    if raw_token and _contains_raw_token(envelope, raw_token):
+        raise MemoryWritePathProductiveError("raw human_go_token leaked in envelope")
+    return envelope
+
+
+def _refused_envelope(
+    *,
+    code: str,
+    message: str,
+    gate_envelope: dict[str, Any] | None = None,
+    operation_mode_resolved: str,
+    authorization: ProductiveWriteAuthorization | None = None,
+) -> dict[str, Any]:
+    gate = _public_gate_envelope(gate_envelope)
+    limitations = [
+        "memory_write_path_productive",
+        "persist_allowed_false",
+        "productive_not_activated",
+        "lr_no_go",
+        "no_agent_memory_write_in_productive_path",
+        "mock_sink_only_in_g3b",
+    ]
+    payload: dict[str, Any] = {
+        "schema_version": WRITE_PATH_PRODUCTIVE_SCHEMA_VERSION,
+        "path_schema_version": PRODUCTIVE_AUDIT_SCHEMA_VERSION,
+        "gate_schema_version": GATE_SCHEMA_VERSION,
+        "status": "refused",
+        "code": code,
+        "message": message,
+        "path_status": "refused",
+        "operation_mode_resolved": operation_mode_resolved,
+        "productive_tier": PRODUCTIVE_TIER,
+        "productive_activated": PRODUCTIVE_ACTIVATED,
+        "productive_audit_status": "not_activated",
+        "gate_status": gate.get("gate_status"),
+        "persist_allowed": PERSIST_ALLOWED,
+        "dry_run_only": True,
+        "memory_id": gate.get("memory_id"),
+        "gate": gate,
+        "audit_observation": None,
+        "tables_written": [],
+        "sink_mode": None,
+        "limitations": limitations,
+        "approval_semantics": gate.get(
+            "approval_semantics",
+            {
+                "read_only": True,
+                "no_write": True,
+                "dry_run_only": True,
+                "no_approval": True,
+                "no_live_go": True,
+                "no_echtgeld_go": True,
+            },
+        ),
+        "token_redaction": {
+            "go_token_present": bool(
+                authorization and authorization.human_go_token.strip()
+            ),
+            "go_token_fingerprint": (
+                _token_fingerprint(authorization.human_go_token)
+                if authorization and authorization.human_go_token.strip()
+                else None
+            ),
+        },
+    }
+    return _sanitize_envelope(
+        payload,
+        raw_token=authorization.human_go_token if authorization else None,
+    )
+
+
+def _public_audit_observation(
+    audit_observation: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    if audit_observation is None:
+        return None
+    cleaned = _public_gate_envelope(audit_observation)
+    return cleaned if isinstance(cleaned, dict) else dict(audit_observation)
+
+
+def _success_envelope(
+    gate_envelope: dict[str, Any],
+    *,
+    path_status: ProductivePathStatus,
+    operation_mode_resolved: str,
+    authorization: ProductiveWriteAuthorization | None = None,
+    audit_observation: dict[str, Any] | None = None,
+    tables_written: tuple[str, ...] = (),
+    sink_mode: str | None = None,
+    productive_audit_status: str = "not_activated",
+) -> dict[str, Any]:
+    limitations = list(gate_envelope.get("limitations") or [])
+    limitations.extend(
+        [
+            "memory_write_path_productive",
+            "persist_allowed_false",
+            "productive_not_activated",
+            "lr_no_go",
+            "no_agent_memory_write_in_productive_path",
+        ]
+    )
+    if path_status == "evaluated_only":
+        limitations.append("path_dry_run_only")
+    if path_status == "mock_persisted_productive_audit":
+        limitations.extend(["mock_sink_only_in_g3b", "no_real_db_write_in_g3b"])
+
+    payload: dict[str, Any] = {
+        "schema_version": WRITE_PATH_PRODUCTIVE_SCHEMA_VERSION,
+        "path_schema_version": PRODUCTIVE_AUDIT_SCHEMA_VERSION,
+        "gate_schema_version": GATE_SCHEMA_VERSION,
+        "status": "ok",
+        "code": None,
+        "message": None,
+        "path_status": path_status,
+        "operation_mode_resolved": operation_mode_resolved,
+        "productive_tier": PRODUCTIVE_TIER,
+        "productive_activated": PRODUCTIVE_ACTIVATED,
+        "productive_audit_status": productive_audit_status,
+        "gate_status": gate_envelope.get("gate_status"),
+        "persist_allowed": PERSIST_ALLOWED,
+        "dry_run_only": True,
+        "memory_id": gate_envelope.get("memory_id"),
+        "gate": _public_gate_envelope(gate_envelope),
+        "audit_observation": _public_audit_observation(audit_observation),
+        "tables_written": list(tables_written),
+        "sink_mode": sink_mode,
+        "limitations": limitations,
+        "approval_semantics": gate_envelope.get("approval_semantics"),
+        "token_redaction": {
+            "go_token_present": bool(
+                authorization and authorization.human_go_token.strip()
+            ),
+            "go_token_fingerprint": (
+                _token_fingerprint(authorization.human_go_token)
+                if authorization and authorization.human_go_token.strip()
+                else None
+            ),
+        },
+    }
+    return _sanitize_envelope(
+        payload,
+        raw_token=authorization.human_go_token if authorization else None,
+    )
+
+
+def _public_audit_observation(
+    audit_observation: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    if audit_observation is None:
+        return None
+    cleaned = _public_gate_envelope(audit_observation)
+    return cleaned if isinstance(cleaned, dict) else dict(audit_observation)
+
+
+def run_memory_write_path_productive(
+    record: Mapping[str, Any],
+    authorization: ProductiveWriteAuthorization | None,
+    *,
+    mode: ProductiveMode = "dry_run",
+    sink: ProductiveAuditSink | None = None,
+    strict: bool = True,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Evaluate gate and optionally mock-persist audit_observation via sink.
+
+    Fail-closed: no real DB/network writes. PRODUCTIVE_ACTIVATED remains False.
+    """
+    ref_now = _parse_now(now)
+
+    if mode not in ("dry_run", "audit_persist_productive"):
+        return _refused_envelope(
+            code="operation_mode_invalid",
+            message=f"unsupported productive write path mode: {mode!r}",
+            operation_mode_resolved=str(mode),
+            authorization=authorization,
+        )
+
+    if mode == "dry_run":
+        gate_envelope = evaluate_memory_write_gate(
+            record,
+            _to_gate_authorization(authorization) if authorization else None,
+            strict=strict,
+            now=ref_now,
+        )
+        return _success_envelope(
+            gate_envelope,
+            path_status="evaluated_only",
+            operation_mode_resolved="dry_run",
+            authorization=authorization,
+        )
+
+    if authorization is None:
+        return _refused_envelope(
+            code="no_authorization",
+            message="Productive audit persist blocked: authorization is required.",
+            operation_mode_resolved="audit_persist_productive",
+        )
+
+    tier = _normalize_tier(authorization.human_go_tier)
+    if tier != REQUIRED_HUMAN_GO_TIER:
+        return _refused_envelope(
+            code="hg_p_required",
+            message=(
+                f"Productive audit persist blocked: human_go_tier must be "
+                f"{REQUIRED_HUMAN_GO_TIER!r}."
+            ),
+            operation_mode_resolved="audit_persist_productive",
+            authorization=authorization,
+        )
+
+    gate_envelope = evaluate_memory_write_gate(
+        record,
+        _to_gate_authorization(authorization),
+        strict=strict,
+        now=ref_now,
+    )
+
+    if gate_envelope.get("gate_status") != "approved_dry_run":
+        return _refused_envelope(
+            code="gate_blocked",
+            message=(
+                "Productive audit persist blocked: gate did not approve dry-run."
+            ),
+            gate_envelope=gate_envelope,
+            operation_mode_resolved="audit_persist_productive",
+            authorization=authorization,
+        )
+
+    if not PRODUCTIVE_ACTIVATED:
+        pass  # G3b: mock path permitted while PRODUCTIVE_ACTIVATED is False
+
+    if not productive_env_enabled():
+        return _refused_envelope(
+            code="productive_env_missing",
+            message=(
+                f"Productive audit persist blocked: {PRODUCTIVE_ENV_VAR} must be '1'."
+            ),
+            gate_envelope=gate_envelope,
+            operation_mode_resolved="audit_persist_productive",
+            authorization=authorization,
+        )
+
+    if sink is None:
+        return _refused_envelope(
+            code="mock_sink_required",
+            message="Productive audit persist blocked: mock sink is required.",
+            gate_envelope=gate_envelope,
+            operation_mode_resolved="audit_persist_productive",
+            authorization=authorization,
+        )
+
+    if sink.mode() != ALLOWED_SINK_MODE:
+        return _refused_envelope(
+            code="mock_sink_invalid_mode",
+            message=(
+                f"Productive audit persist blocked: sink mode must be "
+                f"{ALLOWED_SINK_MODE!r}."
+            ),
+            gate_envelope=gate_envelope,
+            operation_mode_resolved="audit_persist_productive",
+            authorization=authorization,
+        )
+
+    try:
+        audit_row = materialize_audit_observation_from_gate(gate_envelope, now=ref_now)
+    except AuditObservationMaterializeError as exc:
+        return _refused_envelope(
+            code="forbidden_key_present",
+            message=f"Productive audit persist blocked: {exc}",
+            gate_envelope=gate_envelope,
+            operation_mode_resolved="audit_persist_productive",
+            authorization=authorization,
+        )
+
+    if not audit_observation_row_is_redacted(audit_row):
+        return _refused_envelope(
+            code="audit_row_not_redacted",
+            message="Productive audit persist blocked: audit row is not redacted.",
+            gate_envelope=gate_envelope,
+            operation_mode_resolved="audit_persist_productive",
+            authorization=authorization,
+        )
+
+    observation_id = str(audit_row["observation_id"])
+    if sink.observation_exists(observation_id):
+        return _refused_envelope(
+            code="duplicate_observation_id",
+            message=(
+                "Productive audit persist blocked: audit_observation already exists."
+            ),
+            gate_envelope=gate_envelope,
+            operation_mode_resolved="audit_persist_productive",
+            authorization=authorization,
+        )
+
+    sink.upsert_audit_observation(observation_id, audit_row)
+
+    if not sink.observation_exists(observation_id):
+        return _refused_envelope(
+            code="internal_contract_violation",
+            message=(
+                "Productive audit persist failed: observation not found after mock "
+                "upsert."
+            ),
+            gate_envelope=gate_envelope,
+            operation_mode_resolved="audit_persist_productive",
+            authorization=authorization,
+        )
+
+    return _success_envelope(
+        gate_envelope,
+        path_status="mock_persisted_productive_audit",
+        operation_mode_resolved="audit_persist_productive",
+        authorization=authorization,
+        audit_observation=audit_row,
+        tables_written=("audit_observation",),
+        sink_mode=ALLOWED_SINK_MODE,
+        productive_audit_status="mock_persisted",
+    )


### PR DESCRIPTION
## Summary

- Add `tools/surrealdb/memory_write_path_productive.py` — mock-proven T3 contract boundary with HG-P tier semantics, mock sink only, and fail-closed refusal taxonomy.
- Add 14 unit tests covering dry-run, productive-mode refusals, mock persist success, token redaction, and determinism.
- Minimal doc cross-references in memory-reality audit (§22.5) and MCP write surface docs.

## Guardrails (unchanged)

- `PERSIST_ALLOWED=False` — not flipped
- `MUTATION_ALLOWED=False` — MCP handler unchanged; `audit_persist_productive` still refused
- `PRODUCTIVE_ACTIVATED=False` — module constant
- No real DB/SurrealDB writes; mock sink only
- LR remains **NO-GO**
- **Does not close #2606** — partial G3b delivery only

## Issues

- Closes #2744
- Refs #2606 (parent epic stays OPEN / NOT_CLOSURE_READY)

## Test plan

- [x] `pytest tests/unit/surrealdb/test_memory_write_path_productive.py -v` (14 passed)
- [x] Regression: v1 path, write gate, audit_observation, MCP write intent (46 passed)
- [x] `ruff check` on new/changed Python files
- [x] Safety grep: no `PERSIST_ALLOWED=True`, no `MUTATION_ALLOWED=True`, no `PRODUCTIVE_ACTIVATED=True`

## Non-goals (explicit)

- G3c HG-P operator proof
- Productive endpoint activation
- `agent_memory_write`
- Infra/workflow changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Human-GO tier checks, env-gated audit materialization, and token redaction on a security-sensitive write path, but remain fail-closed with no guardrail flips or real persistence.
> 
> **Overview**
> Adds **G3b (#2744)** mock contract proof for the future T3 productive memory audit path via new `memory_write_path_productive.py` and **14** unit tests.
> 
> **`run_memory_write_path_productive`** supports `dry_run` (gate evaluation only, no sink writes) and `audit_persist_productive` (HG-P tier, `CDB_PERSIST_PRODUCTIVE_AUDIT_TRAIL=1`, **mock** sink only) with a fail-closed refusal taxonomy, redacted responses (no raw Human-GO tokens), and optional mock `audit_observation` upsert—**no** real DB/network writes; `PRODUCTIVE_ACTIVATED`, `PERSIST_ALLOWED`, and MCP `audit_persist_productive` refusal (G3a) stay unchanged.
> 
> Docs gain G3b cross-refs (`mcp-memory-write-surface-v1.md`, memory-reality audit §22.5) plus a session log; epic **#2606** remains partial/open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a30c837449a3482afc218dbf9432fce4c10d1e9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->