### PR TITLE
chore(cursor): adopt repo cursor rules

### DIFF
--- a/.cursor/rules/CDB-Bootloader-Rule.mdc
+++ b/.cursor/rules/CDB-Bootloader-Rule.mdc
@@ -1,0 +1,20 @@
+---
+alwaysApply: true
+---
+
+For any task in the Claire_de_Binare/CDB repository, resolve governance before implementation.
+
+Required order:
+1. Resolve the CDB agent bootloader:
+   - root pointer: AGENTS.md
+   - canonical agent registry: agents/AGENTS.md
+   - full Read Order from agents/AGENTS.md
+2. Prefer verified Context/DB/MCP evidence when available.
+3. Every Context/DB/MCP claim must include tool/query/record evidence.
+4. If Context/DB/MCP evidence is missing, stale, contradictory, or unverifiable, fail closed by reading the repo files directly.
+5. If a canonical file or Read Order entry is missing, report it exactly and do not start implementation.
+6. Only after governance is resolved, fetch live GitHub issues, PRs, checks, and diffs.
+
+Never improvise issue work before reading governance.
+GitHub live data remains authoritative for issues, PRs, checks, branches, and diffs.
+Repo-backed files remain authoritative for code, contracts, docs, and governance.

--- a/.cursor/rules/CDB-Brain-Evidence-Rule.mdc
+++ b/.cursor/rules/CDB-Brain-Evidence-Rule.mdc
@@ -1,0 +1,28 @@
+---
+alwaysApply: true
+---
+
+If the task touches strategy, runtime, modules, services, contracts, context, SurrealDB, MCP, DB-backed memory, or evidence, output a Brain Evidence block before any plan.
+
+Use this exact structure:
+
+## Brain Evidence
+brain_source: surrealdb-local | in_memory | repo-only | unavailable
+brain_status: used | partial | not-used | blocked
+tools_or_queries:
+  - <tool, command, query, or repo read>
+records_or_results:
+  - <record id, count, source, hash, commit, timestamp if available>
+repo_crosscheck:
+  - <file, path, symbol, commit, or diff evidence>
+impact_on_plan:
+  - <what changed because of the evidence>
+limitations:
+  - <what is not proven>
+
+Rules:
+- Do not make DB-backed brain claims without real tool/query/record evidence.
+- Caller-supplied source, brain_source, brain_status, or metadata.source are not DB evidence.
+- If only repo evidence was used, clearly report repo-only / brain-not-used.
+- If surrealdb-local was used, state which records, tools, or queries were used.
+- GitHub, repo, and live evidence override memory or brain claims.

--- a/.cursor/rules/CDB-Checks-and-Merge-Rule.mdc
+++ b/.cursor/rules/CDB-Checks-and-Merge-Rule.mdc
@@ -1,0 +1,37 @@
+---
+alwaysApply: true
+---
+
+Red, missing, stale, or pending required checks are not a reason to stop and ask Jannek.
+
+If required checks are red, missing, stale, or pending:
+1. Inspect live check status and logs.
+2. Identify the cause.
+3. Update the branch if needed.
+4. Rerun checks if useful.
+5. Apply small in-scope fixes if the cause is inside the approved plan.
+6. Recheck.
+7. Merge only when required checks are green.
+
+If the failure cannot be fixed within the approved scope:
+- do not expand scope silently
+- document HOLD/BLOCKED
+- dedupe existing issues
+- create a follow-up issue if needed
+- link the finding in the final report
+- continue independent approved work where possible
+
+When merge is explicitly allowed by the approved plan, merge autonomously if all criteria are true:
+1. PR belongs to approved scope.
+2. Diff matches the plan and has no unauthorized scope growth.
+3. All required checks are green.
+4. Non-required checks are green, skipped with explanation, or documented as non-blocking.
+5. No blocking reviews, unresolved blocker threads, or CHANGES_REQUESTED state.
+6. PR is not draft and not HOLD/BLOCKED.
+7. Branch is mergeable or has been updated in scope.
+8. No secrets, sensitive values, or token leaks were introduced.
+9. No safety, LR, live/echtgeld, productive DB, MCP mutation, or BLUE/RED boundary is bypassed.
+10. PR body or final report includes Delivered, Validation, Non-goals, and Remaining uncertainty.
+
+Do not ask “Should I merge?” when the merge criteria are satisfied.
+Instead: merge, then report the evidence.

--- a/.cursor/rules/CDB-Final-Report-Rule.mdc
+++ b/.cursor/rules/CDB-Final-Report-Rule.mdc
@@ -1,0 +1,33 @@
+---
+alwaysApply: true
+---
+
+For CDB work, finish with a compact evidence-based report.
+
+Use this structure:
+
+Status:
+- DONE_MERGED | DONE_NO_PR | HOLD | BLOCKED | PARTIAL
+
+Scope:
+- <what was approved>
+
+Delivered:
+- <what changed or was verified>
+
+Validation:
+- <commands, checks, tests, PR checks, or live GitHub evidence>
+
+GitHub/Repo State:
+- <issues, PRs, branch, commit, merge status>
+
+Boundaries:
+- <LR/live/echtgeld/secrets/DB/MCP/runtime impact>
+
+Follow-ups:
+- <created or existing issues, or “none”>
+
+Limitations:
+- <what remains unproven or intentionally untouched>
+
+Keep it factual. Do not pad with motivational filler.

--- a/.cursor/rules/CDB-Follow-up-Issue-Rule.mdc
+++ b/.cursor/rules/CDB-Follow-up-Issue-Rule.mdc
@@ -1,0 +1,22 @@
+---
+alwaysApply: true
+---
+
+Create a deduplicated follow-up issue without asking Jannek when an important next action is discovered but falls outside the approved plan.
+
+Process:
+1. Do not silently expand the current scope.
+2. Search existing open issues and PRs for duplicates.
+3. If no suitable issue exists, create a focused follow-up issue.
+4. Link the follow-up in the final report.
+5. Continue the approved plan where independent progress is possible.
+
+Use follow-up issues for:
+- out-of-scope fixes
+- non-blocking technical debt
+- unresolved blockers
+- CI failures outside current scope
+- missing docs/contracts discovered during validation
+- safety-relevant restgaps
+
+Do not create noisy issues for trivial observations.

--- a/.cursor/rules/CDB-Plan-GO-Autonomy-Rule.mdc
+++ b/.cursor/rules/CDB-Plan-GO-Autonomy-Rule.mdc
@@ -1,0 +1,40 @@
+---
+alwaysApply: true
+---
+
+When Jannek approves a plan, that approval covers all explicitly described steps inside that plan scope.
+
+Do not ask for separate micro-approvals such as:
+- Merge-GO
+- Review-GO
+- Resolve-GO
+- Comment-GO
+- Label-GO
+- Push-GO
+- Branch-update-GO
+- Issue-close-GO
+
+After Plan-GO:
+1. Recheck live state.
+2. Execute the approved plan.
+3. Validate the result.
+4. Report evidence and final status.
+5. Handle deviations according to the plan and safety rules.
+
+Allowed after Plan-GO, if explicitly inside scope:
+- review PRs
+- inspect diffs
+- check required checks
+- update branches
+- rerun checks
+- implement small in-scope fixes
+- commit and push
+- resolve review threads
+- post comments
+- apply or remove labels
+- close issues
+- merge PRs
+- create deduplicated follow-up issues
+- report final status
+
+This is not a blank check. Productive DB writes, MCP mutations, BLUE/RED runtime changes, LR/live/echtgeld actions, secret handling, and scope expansion still require their own explicit scope or gate.

--- a/.cursor/rules/CDB-Safety-Boundary-Rule.mdc
+++ b/.cursor/rules/CDB-Safety-Boundary-Rule.mdc
@@ -1,0 +1,21 @@
+---
+alwaysApply: true
+---
+
+Always work within these CDB boundaries:
+
+- Shadow/Paper-first.
+- LR-SSOT governs live readiness.
+- Live/echtgeld actions require explicit approval.
+- Secrets must stay protected.
+- Sensitive values must not appear in issues, PRs, comments, logs, or reports.
+- Productive DB or memory writes are gate-bound.
+- MCP mutations are gate-bound.
+- BLUE/RED runtime changes require their own explicit scope.
+- Evidence comes before planning.
+- Live GitHub/repo state overrides ledger or memory.
+- Local-to-remote is the default working direction.
+- Do not create fake DB-backed claims.
+- Repo fallback is correct fail-closed behavior, not a failure.
+
+If a requested action crosses one of these boundaries, stop that action, document the blocker, and propose the smallest safe next step.


### PR DESCRIPTION
## Ziel
Aufnahme der bisher untracked `.cursor/rules/*.mdc` Dateien in den Repo-Canon, ohne Scope-Erweiterung.

## Dateien
- `.cursor/rules/CDB-Bootloader-Rule.mdc`
- `.cursor/rules/CDB-Brain-Evidence-Rule.mdc`
- `.cursor/rules/CDB-Checks-and-Merge-Rule.mdc`
- `.cursor/rules/CDB-Final-Report-Rule.mdc`
- `.cursor/rules/CDB-Follow-up-Issue-Rule.mdc`
- `.cursor/rules/CDB-Plan-GO-Autonomy-Rule.mdc`
- `.cursor/rules/CDB-Safety-Boundary-Rule.mdc`

## Safety-Check
- Secret-Keyword-Scan ausgefuehrt (`token|password|secret|api_key|private_key|bearer|credential`)
- Keine URLs gefunden (`https?://`)
- Keine lokalen absoluten Pfade gefunden (Windows/Unix Muster)
- Governance-Check: keine Live-/Echtgeld-Freigabe, keine MCP-/DB-Mutationsfreigabe, kein Direct-Push-auf-main-Pattern

## Non-Goals
- Keine Runtime-/Docker-/BLUE-RED-Aenderung
- Keine inhaltliche Aenderung an #2747/#2748/#2606
- Keine Aufnahme anderer `.cursor/` Flaechen

## Validation
- `git fetch origin main`
- `git status -sb`
- `git rev-parse --short HEAD`
- `git rev-parse --short origin/main`
- `git diff --stat`
- `git ls-files --others --exclude-standard .cursor/rules/`
- Secret-/Leak-Scans auf `.cursor/rules/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Cursor agent rules; no runtime, auth, data, or live-trading code paths are modified.
> 
> **Overview**
> This PR **tracks seven always-on Cursor rule files** under `.cursor/rules/` that were previously local-only, so agent behavior in the CDB repo is versioned with the rest of the canon.
> 
> Together they define how Cursor agents should operate: **governance-first** boot via `AGENTS.md` / `agents/AGENTS.md`, mandatory **Brain Evidence** blocks when strategy/DB/MCP context matters, **Plan-GO** autonomy (merge, push, labels, etc. without micro-approvals when in scope), **CI triage and autonomous merge** when criteria are met, compact **final reports**, **deduplicated follow-up issues** for out-of-scope work, and **safety boundaries** (shadow/paper, LR, live/echtgeld, secrets, gated DB/MCP/BLUE-RED).
> 
> There are **no application, runtime, or infrastructure code changes**—only Cursor-facing policy text with `alwaysApply: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83fbebefe8c59d1000b49cf6beb4a95b4baa1ad5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->