### PR TITLE
docs(mcp): reconcile cdb_context stdio config

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -3,17 +3,10 @@
     "cdb_context": {
       "enabled": true,
       "command": ".venv/Scripts/python.exe",
-      "args": ["-m", "tools.mcp.server"],
-      "type": "stdio"
-    },
-    "redis": {
-      "enabled": false,
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-redis"],
-      "env": {
-        "REDIS_PORT": "6379",
-        "REDIS_HOST": "127.0.0.1"
-      },
+      "args": [
+        "-m",
+        "tools.mcp.server"
+      ],
       "type": "stdio"
     }
   }

--- a/agents/templates/codex_mcp_config.md
+++ b/agents/templates/codex_mcp_config.md
@@ -1,9 +1,31 @@
 # Codex MCP Config Reference
 
-Codex does not have a separate MCP config surface. Codex is invoked through
-**OpenCode** (for repo-native dev work) or **Claude Code** (for session-led
-architecture work). The CDB Context MCP server is available to Codex through
-the calling agent's MCP configuration.
+Codex loads MCP servers from **global** `~/.codex/config.toml` and **project**
+`.codex/config.toml` (merged per Codex precedence). The CDB Context MCP server
+(`cdb_context`) is the repo-native stdio process `python -m tools.mcp.server` and
+must run with **cwd** set to the Claire de Binare repo root so `tools.*` imports
+resolve.
+
+## Project-local Codex (recommended)
+
+**Claire de Binare** — [`.codex/config.toml`](../../.codex/config.toml) at repo root
+(relative `command`, absolute `cwd`).
+
+**sample-brain** — `.codex/config.toml` in the sample-brain checkout points
+`cdb_context` at `D:/Dev/Workspaces/Repos/Claire_de_Binare` (cross-repo).
+
+Example (sample-brain or global):
+
+```toml
+[mcp_servers.cdb_context]
+enabled = true
+command = "D:/Dev/Workspaces/Repos/Claire_de_Binare/.venv/Scripts/python.exe"
+args = ["-m", "tools.mcp.server"]
+cwd = "D:/Dev/Workspaces/Repos/Claire_de_Binare"
+```
+
+After editing, restart or reconnect MCP in the Codex app so the stdio server
+reloads.
 
 ## Via OpenCode
 
@@ -17,12 +39,20 @@ the calling agent's MCP configuration.
    `.mcp.json` (see Claude Code docs for the correct path).
 2. When Claude Code delegates to Codex, MCP tools are available.
 
+## Canonical repo config
+
+- Cursor (CDB): `.cursor/mcp.json`
+- Canon / sync source: `claire-de-binare.mcp.json` (`cdb_context` + optional `redis`)
+- OpenCode: `opencode.jsonc`
+
 ## Validation
 
 ```bash
-# From repo root, verify bridge works
+# From CDB repo root, verify bridge works
 python -c "from tools.mcp.context_bridge import create_bridge; b=create_bridge(); print(len(b.list_tools()))"
 # Expected: 26
+
+pwsh -File agents/templates/onboarding_mcp_setup.ps1
 ```
 
 ## Fallback

--- a/claire-de-binare.mcp.json
+++ b/claire-de-binare.mcp.json
@@ -1,20 +1,20 @@
 {
   "mcpServers": {
+    "cdb_context": {
+      "enabled": true,
+      "command": ".venv/Scripts/python.exe",
+      "args": ["-m", "tools.mcp.server"],
+      "type": "stdio"
+    },
     "redis": {
       "enabled": true,
       "command": "cmd",
       "args": ["npx", "-y", "@modelcontextprotocol/redis"],
       "env": {
-        "REDIS_PORT": "6379",
         "REDIS_HOST": "cdb_redis",
+        "REDIS_PORT": "6379",
         "REDIS_PASSWORD": "${REDIS_PASSWORD}"
       },
-      "type": "stdio"
-    },
-    "cdb_context": {
-      "enabled": true,
-      "command": "python",
-      "args": ["-m", "tools.mcp.server"],
       "type": "stdio"
     }
   }


### PR DESCRIPTION
## Summary
- Align \claire-de-binare.mcp.json\ and \.cursor/mcp.json\ on repo-local \.venv/Scripts/python.exe\ for \cdb_context\ stdio MCP.
- Remove disabled \edis\ stub from Cursor config (canon redis entry unchanged with \\\ placeholder).
- Expand \gents/templates/codex_mcp_config.md\ with Codex TOML stdio guidance, canonical config pointers, and onboarding validation command.

## Test plan
- [x] \python tools/validate_mcp_config.py\ — PASSED
- [x] \pwsh -File agents/templates/onboarding_mcp_setup.ps1\ — 3 passed, 1 warning (local pydantic-core stdio import; bridge OK)
- [x] JSON syntax check for \.cursor/mcp.json\ and \claire-de-binare.mcp.json\
- [x] gitleaks on changed files — no leaks

## Non-goals
- No Sample Brain changes
- No LR/live/DB/MCP mutation
- Out of scope: #2606, #2759, #2758

## Remaining uncertainty
- Local stdio import may warn on pydantic-core mismatch; config shape is validated; bridge-level MCP works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and local MCP launcher paths only; no runtime auth, data, or application logic changes.
> 
> **Overview**
> **Aligns `cdb_context` stdio MCP** across Cursor and the canonical `claire-de-binare.mcp.json`: both now use repo-local `.venv/Scripts/python.exe` with `python -m tools.mcp.server` instead of a bare `python` command on the canon file.
> 
> **Cursor** drops the disabled `redis` stub so only `cdb_context` remains; **canon** keeps `redis` (host `cdb_redis`, env ordering tweak) and lists `cdb_context` first.
> 
> **Codex docs** (`agents/templates/codex_mcp_config.md`) are rewritten for project/global `.codex/config.toml`, `cwd` at repo root, cross-repo sample-brain example, pointers to `.cursor/mcp.json` / `claire-de-binare.mcp.json` / `opencode.jsonc`, and onboarding validation via `onboarding_mcp_setup.ps1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 178d4fffa3fdc28dbc564ce1739699c77ac8dd1d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->