### PR TITLE
docs(surrealdb): document context query hard mode options

### DIFF
--- a/docs/runbooks/surrealdb_context_query.md
+++ b/docs/runbooks/surrealdb_context_query.md
@@ -187,6 +187,34 @@ python -m tools.surrealdb.context_query \
     show-audit --run-id run-123
 ```
 
+### 5.10 Global verification flags (read-only)
+
+These global flags apply to query subcommands. They support fail-closed
+verification of read results. They do **not** authorize writes, `--apply`, or
+productive SurrealDB mutations (`PERSIST_ALLOWED=False`, `MUTATION_ALLOWED=False`).
+
+| Flag | Default | Behavior |
+|------|---------|----------|
+| `--hard-mode` | off (soft mode) | When the query uses a live local DB connection, an unreachable database causes a **non-zero exit** (`QueryAdapterError`). Without this flag, unreachable DBs return empty results and a warning. |
+| `--min-count N` | `0` (no floor) | After a successful query, exit non-zero with `MIN_COUNT_NOT_MET` if `payload.count` is below `N`. |
+
+For the full operator smoke path that combines these flags with local DB setup,
+see [`SURREALDB_LOCAL_CONTEXT_RUNTIME.md`](SURREALDB_LOCAL_CONTEXT_RUNTIME.md)
+(`make context-smoke-db`).
+
+Example (read-only query with verification flags):
+
+```bash
+python -m tools.surrealdb.context_query \
+    --config infrastructure/config/surrealdb/context_query.local.yaml \
+    --hard-mode \
+    --min-count 1 \
+    find-artifact --source-path src/
+```
+
+**Note:** LR verdict remains **NO-GO**. This runbook covers read-only context
+queries only.
+
 ---
 
 ## 6. Output Formats


### PR DESCRIPTION
## Summary
- Document `--hard-mode` and `--min-count` in `docs/runbooks/surrealdb_context_query.md` (section 5.10)
- Docs-only change; no runtime, DB, MCP, or Phase-2 scope

refs #2604
refs #2774

## Delivered
- documented `--hard-mode` (fail-closed on unreachable local DB when using live connection)
- documented `--min-count` (`MIN_COUNT_NOT_MET` when result count below threshold)
- kept change docs-only; read-only / no productive writes called out explicitly

## Validation
- `rg -n "hard-mode|min-count" docs/runbooks/surrealdb_context_query.md tools/surrealdb/context_query.py`
- `pytest tests/unit/surrealdb/ -k context_query -q` → 216 passed

## Out of Scope
- no runtime changes
- no DB smoke (`make context-smoke-db` not run)
- no MCP changes
- no Phase-2 activation
- no issue closure (#2604 / #2774)
- `--adapter` / `--secrets-path` runbook gap deferred to follow-up

## LR / Safety Boundary
- LR remains NO-GO
- #2778 remains PARKED/BLOCKED
- PERSIST_ALLOWED=False
- MUTATION_ALLOWED=False
- no productive SurrealDB writes
- no trading state, secrets, orders, fills, positions or risk-state in SurrealDB

## Remaining uncertainty
- #2604 issue-body DoD checkboxes vs. belegte coverage from #2774 closeout still needs separate closure session
- `--adapter` and `--secrets-path` still undocumented in this runbook (follow-up fund)