### PR TITLE
docs(context): remove stale gordon docker ai gate claims

### DIFF
--- a/.cursor/agents/_CDB_SUBAGENT_CONTRACT.md
+++ b/.cursor/agents/_CDB_SUBAGENT_CONTRACT.md
@@ -91,7 +91,7 @@ Before any analysis, implementation, review, or plan:
 - Direct push to `main` is not an acceptable default path. Use PR-based flow.
 - `DELIVERY_APPROVED.yaml` is human-controlled; agents must not modify it.
 - If scope grows, checks are red, evidence is missing, or assumptions are unstable: stop and report.
-- Before Docker/infra stack changes, ask Gordon for advice first. If Gordon is unavailable, report `GORDON_NOT_AVAILABLE` and hold changes unless Jannek explicitly overrides.
+- Before Docker/infra stack changes, require explicit Jannek Human-GO with stated scope. There is no external Gordon/Docker-AI gate; if GO is missing, **STOP** (fail-closed). Prefer GitHub-live and repo evidence before ledger or memory claims.
 
 ---
 

--- a/.cursor/agents/cdb-stack-ops-auditor.md
+++ b/.cursor/agents/cdb-stack-ops-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: cdb-stack-ops-auditor
 description: Read-only CDB stack ops auditor. Use for Docker/Compose/runtime health,
-  secrets paths, stack drift, and Gordon-gated infra review.
+  secrets paths, stack drift, and Human-GO-gated infra review.
 model: inherit
 readonly: true
 is_background: false
@@ -27,7 +27,7 @@ Follow [`.cursor/agents/_CDB_SUBAGENT_CONTRACT.md`](_CDB_SUBAGENT_CONTRACT.md) i
 - Stack-/Health-/Smoke-Evidence read-only auswerten.
 - Infra-Drift und Windows-spezifische Stolperfallen markieren.
 - Recovery-/Rollback-Plan vorbereiten.
-- Vor Änderungen Gordon-Gate erzwingen.
+- Vor Änderungen explizites Jannek Human-GO erzwingen (kein Gordon/Docker-AI-Gate).
 
 ## Inputs
 
@@ -41,7 +41,7 @@ Follow [`.cursor/agents/_CDB_SUBAGENT_CONTRACT.md`](_CDB_SUBAGENT_CONTRACT.md) i
 - Stack-Befund
 - Risiko-/Blocker-Liste
 - sichere Prüfreihenfolge
-- Change-Plan mit Gordon-/Human-Gates
+- Change-Plan mit Human-GO und GitHub-live-before-ledger
 
 ## Grenzen
 

--- a/reports/EXECUTION_QUEUE.md
+++ b/reports/EXECUTION_QUEUE.md
@@ -1,7 +1,14 @@
 # EXECUTION_QUEUE.md
-**Generiert:** 2026-01-07
-**Repo:** Claire_de Binare
-**Ziel:** Now Queue - Produktion/CI/Security entblocken
+
+> **Historischer Snapshot (orphaned)** — generiert 2026-01-07. Nicht als aktive
+> Queue, Merge-Plan oder Deployment-Owner-SSOT verwenden. Gordon/Docker-AI
+> Erwähnungen unten sind **historisch**; operatives Gate ist Jannek Human-GO +
+> GitHub-live-before-ledger. Aktueller Repo-Stand: `CURRENT_STATUS.md`,
+> `docs/runbooks/CONTROL_REGISTER.md`.
+
+**Generiert:** 2026-01-07  
+**Repo:** Claire_de Binare  
+**Ziel:** Now Queue - Produktion/CI/Security entblocken (historisch)
 
 ---
 

--- a/reports/GORDON_P8B_BRIEF.md
+++ b/reports/GORDON_P8B_BRIEF.md
@@ -1,8 +1,13 @@
 # Gordon Brief: Phase 8B - Deterministic risk_events Persistence
 
-**Date:** 2026-02-15
-**Requester:** Claude Opus 4.5
-**Status:** AWAITING GORDON REVIEW
+> **Orphaned / historisch** — Gordon/Docker-AI/MCP_DOCKER als Review-Gate ist
+> **dekommissioniert** (#2689). Inhalt unten ist Archiv-Evidence; keine aktive
+> Freigabe oder Blocker-Warteschlange. Entscheidungen: Jannek Human-GO +
+> GitHub-live-before-ledger.
+
+**Date:** 2026-02-15  
+**Requester:** Claude Opus 4.5  
+**Status:** ORPHANED (historisch: AWAITING GORDON REVIEW)
 
 ---
 
@@ -102,11 +107,11 @@ Pitfalls: [any additional concerns]
 
 ---
 
-**Awaiting Gordon's review before implementation.**
+**Historisch:** Review wurde extern simuliert; kein aktiver Gordon-Gate mehr.
 
 ---
 
-## Gordon Response (via MCP_DOCKER)
+## Gordon Response (via MCP_DOCKER) — historisch, nicht operativ
 
 **Consultation Date:** 2026-02-15
 **Method:** Docker infrastructure inspection
@@ -173,4 +178,4 @@ Pitfalls: [any additional concerns]
 
 ---
 
-**Status:** GORDON APPROVED - Proceed with implementation
+**Status (historisch):** GORDON APPROVED — Archiv only; Implementation-GO nur via Jannek + Live-Evidence

--- a/services/execution/EXECUTION_SERVICE_STATUS.md
+++ b/services/execution/EXECUTION_SERVICE_STATUS.md
@@ -1,9 +1,15 @@
 # Execution-Service - Entwicklungsstatus
 
+> **Historischer Snapshot (orphaned)** — Stand 2025-10-23. Nicht als aktiver
+> Deployment- oder Debug-Status verwenden. Gordon als Deployment-Owner ist
+> **veraltet**; Stack-Ops und Container-Änderungen erfordern Jannek Human-GO.
+> Aktueller Service-Canon: Repo unter `services/execution/`, Ledger:
+> `CURRENT_STATUS.md`.
+
 **Erstellt**: 2025-10-23 14:30 UTC  
-**Status**: 🟡 Code fertig, Container-Deployment in Debugging  
+**Status**: 🟡 Code fertig, Container-Deployment in Debugging (historisch)  
 **Version**: 0.1.0  
-**Verantwortlich**: Claude (Code), Gordon (Deployment)
+**Verantwortlich (historisch)**: Claude (Code), solo-maintainer (Deployment via Human-GO)
 
 ---
 
@@ -121,9 +127,9 @@ CMD ["python", "-u", "service.py"]
 
 **Symptom**: Container startet und crasht sofort  
 **Impact**: 🔴 Kritisch - Service nicht deployed  
-**Status**: 🟡 Gordon debuggt aktiv
+**Status**: 🟡 Container-Debug offen (historisch; kein externer Gordon-Gate)
 
-### Diagnose-Schritte (für Gordon)
+### Diagnose-Schritte (historisch — Operator / solo-maintainer)
 
 **1. Build-Logs prüfen**
 ```powershell
@@ -230,15 +236,15 @@ Service gilt als **deployed**, wenn:
 
 ## 📝 NÄCHSTE SCHRITTE
 
-### 1. Gordon: Container stabilisieren (JETZT) 🔴
+### 1. Operator: Container stabilisieren (historisch) 🔴
 - Build-Logs analysieren
 - Runtime-Fehler identifizieren
-- Fixes anwenden
+- Fixes anwenden (nur mit Jannek Human-GO)
 - Container zum Laufen bringen
 
-### 2. Claude: Lösung dokumentieren (DANACH) 📝
-- Gordon's Fixes in Doku übernehmen
-- PROJECT_STATUS.md aktualisieren
+### 2. Doku aktualisieren (DANACH) 📝
+- Fixes in Ledger/Session-Log übernehmen
+- `CURRENT_STATUS.md` aktualisieren (nicht dieses Snapshot-Dokument)
 - Lessons Learned festhalten
 
 ### 3. Team: End-to-End Test (DANN) 🧪
@@ -254,10 +260,10 @@ Service gilt als **deployed**, wenn:
 | Rolle | Person | Aufgabe | Status |
 |-------|--------|---------|--------|
 | **IT-Chef** | Claude | Code entwickeln, Architektur | ✅ Fertig |
-| **Server-Admin** | Gordon | Container deployen, debuggen | 🟡 Aktiv |
+| **Operator / Deployment** | Jannek (solo-maintainer) | Container deployen, debuggen | Human-GO |
 | **Projektleiter** | Jannek | Koordination, Entscheidungen | ✅ Aktiv |
 
-**Kommunikation**: Gordon → Jannek → Claude
+**Kommunikation (historisch ersetzt)**: Operator Human-GO → Implementierung → Ledger
 
 ---
 
@@ -278,4 +284,4 @@ Service gilt als **deployed**, wenn:
 
 **Erstellt**: 2025-10-23 14:30 UTC  
 **Letzte Änderung**: 2025-10-23 14:30 UTC  
-**Nächstes Update**: Nach Gordon's Container-Fix
+**Nächstes Update**: Nicht geplant — Datei orphaned; siehe `CURRENT_STATUS.md`


### PR DESCRIPTION
## Summary
- Remove stale Gordon/Docker-AI infra gate from Cursor subagent contract and stack-ops-auditor agent doc; replace with Jannek Human-GO + GitHub-live-before-ledger.
- Mark `reports/EXECUTION_QUEUE.md`, `services/execution/EXECUTION_SERVICE_STATUS.md`, and `reports/GORDON_P8B_BRIEF.md` as orphaned/historical snapshots with explicit decommission banners.

refs #2689
refs #2778

## Delivered
- Active agent policy no longer requires Gordon before Docker/infra changes.
- Historical report/status files no longer present Gordon as live deployment owner or review gate.

## Validation
- `git diff` on 5 scoped files
- `rg` scan for Gordon/Docker-AI in active surfaces (remaining hits documented as historical or out-of-slice)

## Out of Scope
- SurrealDB/Context/Memory DB writes, MCP mutations, Phase-2, runtime changes
- Broader Gordon cleanup in `reports/GORDON_REVIEW_RESPONSE.md`, `reports/BLUE_RED_IMPLEMENTATION_SUMMARY.md`, knowledge archives (#2689 follow-up)

## LR/Safety Boundary
- Docs/agent-config only. LR remains NO-GO. No live/echtgeld, no stack mutations.

## Remaining uncertainty
- Issue #2689 full scope includes additional active surfaces and DB/Context entries not covered by this slice; closure requires follow-up or separate PRs.
- #2778 stays PARKED/BLOCKED; unaffected by this docs-only change.