### PR TITLE
feat(surrealdb): add context certification proof pack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ else
   SECRETS_PATH ?= $(HOME)/Documents/.secrets/.cdb
 endif
 
-.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-query-config-init context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke context-smoke-db context-memory-db-proof context-claim-evidence-proof context-memory-rediscovery-proof context-doctor audit-trail-t3-bootstrap audit-trail-t3-proof audit-trail-t3-status audit-trail-t3-down
+.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-query-config-init context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke context-smoke-db context-memory-db-proof context-claim-evidence-proof context-memory-rediscovery-proof context-doctor context-certify audit-trail-t3-bootstrap audit-trail-t3-proof audit-trail-t3-status audit-trail-t3-down
 
 help:
 	@echo "Claire de Binare - Test Commands"
@@ -109,6 +109,7 @@ help:
 	@echo "  make context-claim-evidence-proof - Claim evidence at rest proof (#2719/#2606)"
 	@echo "  make context-memory-rediscovery-proof - Cross-session memory rediscovery (#2720)"
 	@echo "  make context-doctor          - Read-only onboarding preflight (#2642)"
+	@echo "  make context-certify         - Read-only operator certification proof pack (#2776)"
 # ============================================================================
 # CI-Tests (schnell, mit Mocks)
 # ============================================================================
@@ -395,6 +396,10 @@ context-schema-check:
 context-doctor:
 	@echo "=== Context Onboarding Doctor (read-only preflight) ==="
 	@$(PYTHON) -m tools.surrealdb.context_onboarding_doctor
+
+context-certify:
+	@echo "=== Context Operator Certification (read-only proof pack, #2776) ==="
+	@$(PYTHON) -m tools.surrealdb.context_certify
 
 context-reset-local:
 	@echo "=== SurrealDB Local Reset (DESTRUKTIV - nur Context-Intelligence-Daten) ==="

--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -177,6 +177,30 @@ python -m tools.surrealdb.context_onboarding_doctor --format json
 - Issue #2642 prüft optional `127.0.0.1:8811` (HTTP MCP host).
 - Separater remote `cdb`-Server in OpenCode nutzt laut Runbook-Hinweis `127.0.0.1:8812/mcp` — nicht mit #2642 verwechseln.
 
+**Context operator certification** (#2776) — wiederholbarer read-only Proof Pack
+für Bridge/Registry/Permission-Guard (kein produktiver DB-Smoke, kein `--apply`):
+
+```bash
+make context-certify
+python -m tools.surrealdb.context_certify --format json
+python -m tools.surrealdb.context_certify --format markdown --output context-certify.md
+```
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | `final_verdict: certified` — static registry/guard gates pass |
+| `1` | Blocking failure (e.g. non-read-only tool in registry) |
+| `2` | CLI or output validation error |
+
+Default behavior:
+- Emits JSON (with `--format json`) or markdown/text summary including `gate_matrix`,
+  `skipped_checks_with_reason`, `safety_flags`, and `lr_note: NO-GO`.
+- Does **not** run `make context-smoke-db`, `make context-smoke`, or any `--apply` path.
+- Live MCP/SurrealDB probes are **skipped** unless `--include-live-checks` (non-blocking).
+
+Safety boundary: `PERSIST_ALLOWED=False`, `MUTATION_ALLOWED=False`; LR remains **NO-GO**;
+Phase-2 (#2778) is not activated by certification alone.
+
 Expected output (best case — bridge + stdio both work):
 ```
 === CDB Context MCP Capability Validation ===

--- a/tests/unit/surrealdb/test_context_certify.py
+++ b/tests/unit/surrealdb/test_context_certify.py
@@ -1,0 +1,148 @@
+"""Unit tests for context operator certification proof pack (#2776)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.mcp.registry import ContextToolRegistry, ToolDefinition
+from tools.surrealdb import context_certify as certify
+
+pytestmark = pytest.mark.unit
+
+REQUIRED_TOP_LEVEL_KEYS = {
+    "timestamp",
+    "git_sha",
+    "branch",
+    "worktree_clean",
+    "tool_count",
+    "doctor_status",
+    "bridge_status",
+    "mcp_readonly_summary",
+    "permission_guard_summary",
+    "test_results",
+    "gate_matrix",
+    "skipped_checks_with_reason",
+    "blocked_checks_with_reason",
+    "safety_flags",
+    "lr_note",
+    "final_verdict",
+}
+
+
+def test_build_report_certified_by_default(tmp_path: Path) -> None:
+    report = certify.build_report(tmp_path)
+    payload = report.to_dict()
+    assert REQUIRED_TOP_LEVEL_KEYS <= set(payload.keys())
+    assert report.final_verdict == "certified"
+    assert report.tool_count >= 1
+    assert report.safety_flags["PERSIST_ALLOWED"] is False
+    assert report.safety_flags["MUTATION_ALLOWED"] is False
+    assert report.safety_flags["includes_context_smoke_db"] is False
+    assert report.lr_note == "NO-GO"
+    assert any(
+        gate.check_id == "registry_all_read_only" and gate.status == "pass"
+        for gate in report.gate_matrix
+    )
+    assert report.skipped_checks_with_reason
+    assert not report.blocked_checks_with_reason
+
+
+def test_compute_exit_code() -> None:
+    ok = certify.CertifyReport(
+        timestamp="2026-06-01T00:00:00Z",
+        git_sha="abc",
+        branch="main",
+        worktree_clean=True,
+        tool_count=27,
+        doctor_status={},
+        bridge_status={},
+        mcp_readonly_summary={},
+        permission_guard_summary={},
+        test_results={},
+        final_verdict="certified",
+    )
+    fail = certify.CertifyReport(
+        timestamp="2026-06-01T00:00:00Z",
+        git_sha="abc",
+        branch="main",
+        worktree_clean=True,
+        tool_count=27,
+        doctor_status={},
+        bridge_status={},
+        mcp_readonly_summary={},
+        permission_guard_summary={},
+        test_results={},
+        final_verdict="fail",
+    )
+    assert certify.compute_exit_code(ok) == 0
+    assert certify.compute_exit_code(fail) == 1
+
+
+def test_format_json_roundtrip(tmp_path: Path) -> None:
+    report = certify.build_report(tmp_path)
+    text = certify.format_report(report, "json")
+    certify._validate_output_safe(text)
+    parsed = json.loads(text)
+    assert parsed["final_verdict"] == "certified"
+    assert isinstance(parsed["gate_matrix"], list)
+
+
+def test_main_exit_code_zero(tmp_path: Path) -> None:
+    code = certify.main(["--repo-root", str(tmp_path), "--format", "json"])
+    assert code == 0
+
+
+def test_registry_failure_marks_fail(tmp_path: Path) -> None:
+    bad_tool = ToolDefinition(
+        name="context.bad_write",
+        description="injected for certify test",
+        input_schema={"type": "object"},
+        output_schema={"type": "object"},
+        read_only=False,
+    )
+    bridge_status = {
+        "enforced": True,
+        "tools_count": 1,
+        "read_only_tools": [],
+        "description": "mock",
+    }
+    with patch.object(ContextToolRegistry, "list_tools", return_value=[bad_tool]):
+        with patch.object(
+            ContextToolRegistry,
+            "assert_read_only_consistency",
+            side_effect=ValueError("non-read-only tools found"),
+        ):
+            with patch(
+                "tools.surrealdb.context_certify.create_bridge"
+            ) as mock_bridge:
+                mock_bridge.return_value.get_read_only_status.return_value = (
+                    bridge_status
+                )
+                report = certify.build_report(tmp_path)
+    assert report.final_verdict == "fail"
+    assert report.blocked_checks_with_reason
+    assert certify.compute_exit_code(report) == 1
+
+
+def test_git_metadata_detects_dirty(tmp_path: Path) -> None:
+    with patch.object(certify, "_git_metadata") as mock_git:
+        mock_git.return_value = {
+            "git_sha": "deadbeef",
+            "branch": "feat/test",
+            "worktree_clean": False,
+            "git_available": True,
+        }
+        report = certify.build_report(tmp_path)
+    assert report.git_sha == "deadbeef"
+    assert report.worktree_clean is False
+
+
+def test_test_command_suggestions_present(tmp_path: Path) -> None:
+    report = certify.build_report(tmp_path)
+    suggestions = report.test_results["test_command_suggestions"]
+    assert any("test_context_certify" in cmd for cmd in suggestions)
+    assert any("test_context_onboarding_doctor" in cmd for cmd in suggestions)

--- a/tests/unit/surrealdb/test_context_certify.py
+++ b/tests/unit/surrealdb/test_context_certify.py
@@ -116,9 +116,7 @@ def test_registry_failure_marks_fail(tmp_path: Path) -> None:
             "assert_read_only_consistency",
             side_effect=ValueError("non-read-only tools found"),
         ):
-            with patch(
-                "tools.surrealdb.context_certify.create_bridge"
-            ) as mock_bridge:
+            with patch("tools.surrealdb.context_certify.create_bridge") as mock_bridge:
                 mock_bridge.return_value.get_read_only_status.return_value = (
                     bridge_status
                 )

--- a/tools/surrealdb/context_certify.py
+++ b/tools/surrealdb/context_certify.py
@@ -1,0 +1,522 @@
+"""Read-only operator certification proof pack for Context/Memory/MCP/CLI.
+
+Aggregates static registry/bridge/guard evidence and optional live doctor checks
+without productive DB writes, apply modes, or context-smoke-db.
+
+Issue: #2776
+Parent: #1976
+
+Usage:
+    python -m tools.surrealdb.context_certify
+    python -m tools.surrealdb.context_certify --format json
+    python -m tools.surrealdb.context_certify --format markdown --output report.md
+    make context-certify
+
+Exit codes:
+    0 - certified (static gates pass; no blocking failures)
+    1 - blocking failure (registry/guard inconsistency)
+    2 - CLI or output validation error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from tools.mcp.context_bridge import create_bridge
+from tools.mcp.permission_guard import (
+    FORBIDDEN_SQL_KEYWORDS,
+    INPUT_SCAN_EXEMPT_TOOLS,
+    INPUT_SCAN_TOOLS,
+)
+from tools.mcp.registry import ContextToolRegistry
+from tools.surrealdb import context_onboarding_doctor as doctor
+
+GateStatus = Literal["pass", "fail", "skipped", "blocked"]
+FinalVerdict = Literal["certified", "fail"]
+
+FORBIDDEN_OUTPUT_SUBSTRINGS = doctor.FORBIDDEN_OUTPUT_SUBSTRINGS
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _git_metadata(repo_root: Path) -> dict[str, Any]:
+    def _run(*args: str) -> tuple[bool, str]:
+        try:
+            proc = subprocess.run(
+                ["git", *args],
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False, ""
+        if proc.returncode != 0:
+            return False, (proc.stdout or proc.stderr).strip()
+        return True, (proc.stdout or "").strip()
+
+    sha_ok, sha = _run("rev-parse", "HEAD")
+    branch_ok, branch = _run("rev-parse", "--abbrev-ref", "HEAD")
+    clean_ok, porcelain = _run("status", "--porcelain")
+    worktree_clean = clean_ok and porcelain == ""
+    return {
+        "git_sha": sha if sha_ok else "unknown",
+        "branch": branch if branch_ok else "unknown",
+        "worktree_clean": worktree_clean if clean_ok else False,
+        "git_available": sha_ok and branch_ok,
+    }
+
+
+@dataclass
+class GateEntry:
+    check_id: str
+    status: GateStatus
+    blocking: bool
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "check_id": self.check_id,
+            "status": self.status,
+            "blocking": self.blocking,
+            "detail": self.detail,
+        }
+
+
+@dataclass
+class CertifyReport:
+    timestamp: str
+    git_sha: str
+    branch: str
+    worktree_clean: bool
+    tool_count: int
+    doctor_status: dict[str, Any]
+    bridge_status: dict[str, Any]
+    mcp_readonly_summary: dict[str, Any]
+    permission_guard_summary: dict[str, Any]
+    test_results: dict[str, Any]
+    gate_matrix: list[GateEntry] = field(default_factory=list)
+    skipped_checks_with_reason: list[dict[str, str]] = field(default_factory=list)
+    blocked_checks_with_reason: list[dict[str, str]] = field(default_factory=list)
+    safety_flags: dict[str, bool] = field(default_factory=dict)
+    lr_note: str = "NO-GO"
+    final_verdict: FinalVerdict = "certified"
+    issue_ref: str = "#2776"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "timestamp": self.timestamp,
+            "git_sha": self.git_sha,
+            "branch": self.branch,
+            "worktree_clean": self.worktree_clean,
+            "tool_count": self.tool_count,
+            "doctor_status": self.doctor_status,
+            "bridge_status": self.bridge_status,
+            "mcp_readonly_summary": self.mcp_readonly_summary,
+            "permission_guard_summary": self.permission_guard_summary,
+            "test_results": self.test_results,
+            "gate_matrix": [entry.to_dict() for entry in self.gate_matrix],
+            "skipped_checks_with_reason": list(self.skipped_checks_with_reason),
+            "blocked_checks_with_reason": list(self.blocked_checks_with_reason),
+            "safety_flags": dict(self.safety_flags),
+            "lr_note": self.lr_note,
+            "final_verdict": self.final_verdict,
+            "issue_ref": self.issue_ref,
+        }
+
+
+def _collect_static_gates() -> tuple[list[GateEntry], dict[str, Any], dict[str, Any]]:
+    gates: list[GateEntry] = []
+    bridge = create_bridge()
+    bridge_status = bridge.get_read_only_status()
+    tools = ContextToolRegistry.list_tools()
+    non_read_only = [tool.name for tool in tools if not tool.read_only]
+
+    registry_ok = not non_read_only
+    gates.append(
+        GateEntry(
+            check_id="registry_all_read_only",
+            status="pass" if registry_ok else "fail",
+            blocking=True,
+            detail=(
+                f"{len(tools)} tools registered; all read_only=True"
+                if registry_ok
+                else f"non-read-only tools: {non_read_only}"
+            ),
+        )
+    )
+
+    try:
+        ContextToolRegistry.assert_read_only_consistency()
+        consistency_detail = "assert_read_only_consistency OK"
+        consistency_status: GateStatus = "pass"
+    except ValueError as exc:
+        consistency_detail = str(exc)
+        consistency_status = "fail"
+
+    gates.append(
+        GateEntry(
+            check_id="permission_guard_registry_consistency",
+            status=consistency_status,
+            blocking=True,
+            detail=consistency_detail,
+        )
+    )
+
+    tool_count = len(tools)
+    expected_read_only = len(bridge_status.get("read_only_tools", []))
+    count_ok = tool_count == expected_read_only == bridge_status.get("tools_count")
+    gates.append(
+        GateEntry(
+            check_id="bridge_tool_inventory",
+            status="pass" if count_ok else "fail",
+            blocking=True,
+            detail=(
+                f"bridge tools_count={bridge_status.get('tools_count')}, "
+                f"read_only_tools={expected_read_only}, registry={tool_count}"
+            ),
+        )
+    )
+
+    mcp_summary = {
+        "enforced": bridge_status.get("enforced"),
+        "tools_count": tool_count,
+        "read_only_tools_count": expected_read_only,
+        "non_read_only_tools": non_read_only,
+    }
+    permission_summary = {
+        "registry_gate": "pass" if registry_ok and consistency_status == "pass" else "fail",
+        "input_scan_tools_count": len(INPUT_SCAN_TOOLS),
+        "input_scan_exempt_tools_count": len(INPUT_SCAN_EXEMPT_TOOLS),
+        "forbidden_sql_keywords_count": len(FORBIDDEN_SQL_KEYWORDS),
+    }
+    return gates, mcp_summary, permission_summary
+
+
+def _default_skipped_checks() -> list[dict[str, str]]:
+    return [
+        {
+            "check": "context-smoke-db",
+            "reason": "not run by certification (hard DB-backed smoke is operator-only)",
+        },
+        {
+            "check": "context-smoke-full-pipeline",
+            "reason": "make context-smoke not invoked by context-certify",
+        },
+        {
+            "check": "context-import-apply",
+            "reason": "no --apply or productive import in certification default",
+        },
+        {
+            "check": "live_mcp_http_port",
+            "reason": "skipped unless --include-live-checks",
+        },
+        {
+            "check": "live_surrealdb_schema",
+            "reason": "skipped unless --include-live-checks (requires local stack + secrets)",
+        },
+    ]
+
+
+def _run_doctor(
+    repo_root: Path,
+    *,
+    include_live: bool,
+) -> tuple[dict[str, Any], list[GateEntry]]:
+    gates: list[GateEntry] = []
+    report = doctor.build_report(
+        repo_root,
+        skip_mcp=not include_live,
+        skip_schema=not include_live,
+    )
+    doctor_dict = report.to_dict()
+    doctor_dict["mode"] = "live" if include_live else "inventory_only"
+    doctor_dict["exit_code_if_onboarding"] = doctor.compute_exit_code(report)
+
+    if include_live:
+        code = doctor.compute_exit_code(report)
+        gates.append(
+            GateEntry(
+                check_id="context_doctor_live",
+                status="pass" if code == 0 else "fail",
+                blocking=False,
+                detail=report.next_action,
+            )
+        )
+    else:
+        gates.append(
+            GateEntry(
+                check_id="context_doctor_live",
+                status="skipped",
+                blocking=False,
+                detail="inventory-only; pass --include-live-checks for TCP/MCP/schema",
+            )
+        )
+
+    doctor_status = {
+        "summary": doctor_dict,
+        "reachable": report.surrealdb_status,
+        "mcp_server": report.mcp_server_status,
+        "next_action": report.next_action,
+    }
+    return doctor_status, gates
+
+
+def _run_unit_tests(repo_root: Path) -> dict[str, Any]:
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "tests/unit/surrealdb/test_context_certify.py",
+        "-q",
+    ]
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "ran": True,
+            "passed": False,
+            "command": " ".join(cmd),
+            "detail": str(exc),
+        }
+    output = (proc.stdout or "") + (proc.stderr or "")
+    return {
+        "ran": True,
+        "passed": proc.returncode == 0,
+        "exit_code": proc.returncode,
+        "command": " ".join(cmd),
+        "tail": output.strip()[-500:] if output else "",
+    }
+
+
+def build_report(
+    repo_root: Path | None = None,
+    *,
+    include_live_checks: bool = False,
+    run_unit_tests: bool = False,
+) -> CertifyReport:
+    root = _repo_root() if repo_root is None else repo_root
+    git_info = _git_metadata(root)
+    static_gates, mcp_summary, permission_summary = _collect_static_gates()
+    doctor_status, doctor_gates = _run_doctor(
+        root, include_live=include_live_checks
+    )
+
+    gates = static_gates + doctor_gates
+    skipped = _default_skipped_checks()
+    blocked: list[dict[str, str]] = []
+
+    for gate in gates:
+        if gate.status == "fail" and gate.blocking:
+            blocked.append(
+                {"check": gate.check_id, "reason": gate.detail},
+            )
+
+    test_suggestions = [
+        "pytest tests/unit/surrealdb/test_context_onboarding_doctor.py -q",
+        "pytest tests/unit/tools/mcp/test_context_bridge.py -q",
+        "pytest tests/unit/tools/mcp/test_permission_guard.py -q",
+        "pytest tests/unit/surrealdb/test_context_certify.py -q",
+    ]
+    test_results: dict[str, Any] = {
+        "ran_in_certify": False,
+        "test_command_suggestions": test_suggestions,
+    }
+    if run_unit_tests:
+        test_results["certify_unit"] = _run_unit_tests(root)
+        test_results["ran_in_certify"] = True
+        gates.append(
+            GateEntry(
+                check_id="certify_unit_tests",
+                status="pass" if test_results["certify_unit"]["passed"] else "fail",
+                blocking=False,
+                detail=test_results["certify_unit"]["command"],
+            )
+        )
+
+    safety_flags = {
+        "PERSIST_ALLOWED": False,
+        "MUTATION_ALLOWED": False,
+        "includes_db_smoke": False,
+        "includes_apply": False,
+        "includes_context_smoke_db": False,
+        "read_only_by_default": True,
+    }
+
+    blocking_fail = any(
+        gate.status == "fail" and gate.blocking for gate in gates
+    )
+    final_verdict: FinalVerdict = "fail" if blocking_fail else "certified"
+
+    return CertifyReport(
+        timestamp=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        git_sha=git_info["git_sha"],
+        branch=git_info["branch"],
+        worktree_clean=git_info["worktree_clean"],
+        tool_count=mcp_summary["tools_count"],
+        doctor_status=doctor_status,
+        bridge_status=create_bridge().get_read_only_status(),
+        mcp_readonly_summary=mcp_summary,
+        permission_guard_summary=permission_summary,
+        test_results=test_results,
+        gate_matrix=gates,
+        skipped_checks_with_reason=skipped,
+        blocked_checks_with_reason=blocked,
+        safety_flags=safety_flags,
+        final_verdict=final_verdict,
+    )
+
+
+def compute_exit_code(report: CertifyReport) -> int:
+    if report.final_verdict == "fail":
+        return 1
+    return 0
+
+
+def format_report_markdown(report: CertifyReport) -> str:
+    lines = [
+        "# Context Operator Certification Proof Pack",
+        "",
+        f"- **timestamp:** {report.timestamp}",
+        f"- **git_sha:** {report.git_sha}",
+        f"- **branch:** {report.branch}",
+        f"- **worktree_clean:** {report.worktree_clean}",
+        f"- **tool_count:** {report.tool_count}",
+        f"- **final_verdict:** {report.final_verdict}",
+        f"- **lr_note:** {report.lr_note}",
+        "",
+        "## Safety flags",
+    ]
+    for key, value in sorted(report.safety_flags.items()):
+        lines.append(f"- {key}: {value}")
+    lines.extend(["", "## Gate matrix"])
+    for gate in report.gate_matrix:
+        lines.append(
+            f"- `{gate.check_id}`: **{gate.status}** "
+            f"(blocking={gate.blocking}) — {gate.detail}"
+        )
+    if report.skipped_checks_with_reason:
+        lines.extend(["", "## Skipped checks"])
+        for item in report.skipped_checks_with_reason:
+            lines.append(f"- **{item['check']}:** {item['reason']}")
+    if report.blocked_checks_with_reason:
+        lines.extend(["", "## Blocked checks"])
+        for item in report.blocked_checks_with_reason:
+            lines.append(f"- **{item['check']}:** {item['reason']}")
+    lines.extend(["", "## Test commands"])
+    for cmd in report.test_results.get("test_command_suggestions", []):
+        lines.append(f"- `{cmd}`")
+    return "\n".join(lines)
+
+
+def format_report(report: CertifyReport, fmt: str) -> str:
+    if fmt == "json":
+        return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    if fmt == "markdown":
+        return format_report_markdown(report)
+    if fmt == "text":
+        return format_report_markdown(report)
+    raise ValueError(f"unsupported format: {fmt!r}")
+
+
+def _validate_output_safe(text: str) -> None:
+    for forbidden in FORBIDDEN_OUTPUT_SUBSTRINGS:
+        if forbidden in text:
+            raise ValueError(f"output contains forbidden substring: {forbidden}")
+
+
+_HELP_EPILOG = """\
+Examples:
+  python -m tools.surrealdb.context_certify
+  python -m tools.surrealdb.context_certify --format json
+  python -m tools.surrealdb.context_certify --format markdown --output certify.md
+  make context-certify
+
+Notes:
+  - Read-only by default; does not run context-smoke-db or --apply.
+  - Live MCP/SurrealDB checks require --include-live-checks (non-blocking).
+  - LR remains NO-GO; no Phase-2 activation.
+
+Exit codes:
+  0  certified (static gates pass)
+  1  blocking registry/guard failure
+  2  CLI or output validation error
+"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only Context/Memory/MCP operator certification proof pack.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_HELP_EPILOG,
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json", "markdown"),
+        default="text",
+        help="Output format (default: text)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write report to file (optional)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--include-live-checks",
+        action="store_true",
+        help="Run context-doctor live MCP/SurrealDB probes (non-blocking)",
+    )
+    parser.add_argument(
+        "--run-unit-tests",
+        action="store_true",
+        help="Run certify unit tests as part of the proof pack (non-blocking)",
+    )
+    args = parser.parse_args(argv)
+
+    report = build_report(
+        args.repo_root,
+        include_live_checks=args.include_live_checks,
+        run_unit_tests=args.run_unit_tests,
+    )
+    output = format_report(report, args.format)
+    _validate_output_safe(output)
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(output, encoding="utf-8")
+    print(output)
+    return compute_exit_code(report)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc

--- a/tools/surrealdb/context_certify.py
+++ b/tools/surrealdb/context_certify.py
@@ -25,10 +25,10 @@ import json
 import subprocess
 import sys
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 
+from core.utils.clock import utcnow
 from tools.mcp.context_bridge import create_bridge
 from tools.mcp.permission_guard import (
     FORBIDDEN_SQL_KEYWORDS,
@@ -366,7 +366,7 @@ def build_report(
     final_verdict: FinalVerdict = "fail" if blocking_fail else "certified"
 
     return CertifyReport(
-        timestamp=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        timestamp=utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
         git_sha=git_info["git_sha"],
         branch=git_info["branch"],
         worktree_clean=git_info["worktree_clean"],

--- a/tools/surrealdb/context_certify.py
+++ b/tools/surrealdb/context_certify.py
@@ -195,7 +195,9 @@ def _collect_static_gates() -> tuple[list[GateEntry], dict[str, Any], dict[str, 
         "non_read_only_tools": non_read_only,
     }
     permission_summary = {
-        "registry_gate": "pass" if registry_ok and consistency_status == "pass" else "fail",
+        "registry_gate": (
+            "pass" if registry_ok and consistency_status == "pass" else "fail"
+        ),
         "input_scan_tools_count": len(INPUT_SCAN_TOOLS),
         "input_scan_exempt_tools_count": len(INPUT_SCAN_EXEMPT_TOOLS),
         "forbidden_sql_keywords_count": len(FORBIDDEN_SQL_KEYWORDS),
@@ -315,9 +317,7 @@ def build_report(
     root = _repo_root() if repo_root is None else repo_root
     git_info = _git_metadata(root)
     static_gates, mcp_summary, permission_summary = _collect_static_gates()
-    doctor_status, doctor_gates = _run_doctor(
-        root, include_live=include_live_checks
-    )
+    doctor_status, doctor_gates = _run_doctor(root, include_live=include_live_checks)
 
     gates = static_gates + doctor_gates
     skipped = _default_skipped_checks()
@@ -360,9 +360,7 @@ def build_report(
         "read_only_by_default": True,
     }
 
-    blocking_fail = any(
-        gate.status == "fail" and gate.blocking for gate in gates
-    )
+    blocking_fail = any(gate.status == "fail" and gate.blocking for gate in gates)
     final_verdict: FinalVerdict = "fail" if blocking_fail else "certified"
 
     return CertifyReport(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a read-only-by-default operator certification proof pack for Context/Memory/MCP/CLI (`make context-certify`).

Refs: #2776, #1976

## Delivered

- `tools/surrealdb/context_certify.py` — proof-pack JSON/markdown/text, gate matrix, skipped/blocked semantics, exit codes 0/1/2
- `make context-certify` — no `context-smoke-db`, no `--apply`, live checks optional via `--include-live-checks`
- `tests/unit/surrealdb/test_context_certify.py` — report schema, exit codes, registry failure path
- Runbook section in `docs/runbooks/surrealdb_context_mcp_access.md`

## Validation

- `pytest tests/unit/surrealdb/test_context_certify.py -q` — 7 passed
- `pytest tests/unit/surrealdb/test_context_onboarding_doctor.py -q` — 24 passed
- `make context-certify` — exit 0, `final_verdict: certified`, 27 tools
- `ruff check` on touched Python files

## Out of Scope

- No productive DB writes or `make context-smoke-db` by default
- No MCP implementation changes beyond read-only inventory use
- No Phase-2 activation (#2778)
- No LR/live trading change

## LR / Safety

- LR remains **NO-GO**
- `PERSIST_ALLOWED=False`, `MUTATION_ALLOWED=False`
- #2778 remains PARKED/BLOCKED

## Remaining uncertainty

- Live MCP/SurrealDB certification requires operator `--include-live-checks` (non-blocking)
- Issue closeout comments require maintainer token (Cloud integration cannot write issues)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41d7c527-7bf8-479a-a593-c8e0d7bc1601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41d7c527-7bf8-479a-a593-c8e0d7bc1601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

