### PR TITLE
chore(ci): park stale Control Board label-dispatch workflow (#2805)

### DIFF
--- a/.github/workflows/control-board-routing-label-dispatch.yml
+++ b/.github/workflows/control-board-routing-label-dispatch.yml
@@ -1,57 +1,41 @@
+# ⚠️ PARKED fail-closed in #2805 (2026-06-02).
+# Auto-dispatched `control_board_route_issue_label` events to the Control Board
+# Auto Routing workflow on routing-relevant issue label changes (`stage:`,
+# `prio:`, `p0`–`p3` labels). The live trigger is removed because the
+# repository_dispatch listener (`control_board_route_issue_label`) was removed
+# in #2772 / #2796 and has no active consumer:
+# - `issues` (type: labeled) fired on every routing-relevant label change.
+# - `control_board_upsert.yml` (`workflow_dispatch` + Monday `02:30 UTC`
+#   schedule) remains the active board reconciliation path, gated by
+#   `CDB_CONTROL_BOARD_AUTOMATION_ENABLED`.
+# No automatic label dispatch remains. The workflow is retained as a
+# `workflow_dispatch` stub only; it does NOT call createDispatchEvent because
+# the consumer listener was intentionally withdrawn.
+# Re-enable per-label dispatch requires a separate scoped issue.
+# See .github/README.md for current control-plane documentation.
+
 name: Control Board Routing Label Dispatch
 
 on:
-  issues:
-    types: [labeled]
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  dispatch-control-board-routing:
-    if: >-
-      ${{
-        vars.CDB_CONTROL_BOARD_AUTOMATION_ENABLED == 'true' &&
-        (
-          startsWith(github.event.label.name || '', 'stage:') ||
-          startsWith(github.event.label.name || '', 'label:stage:') ||
-          startsWith(github.event.label.name || '', 'prio:') ||
-          startsWith(github.event.label.name || '', 'priority:') ||
-          github.event.label.name == 'p0' ||
-          github.event.label.name == 'p1' ||
-          github.event.label.name == 'p2' ||
-          github.event.label.name == 'p3' ||
-          github.event.label.name == 'P0' ||
-          github.event.label.name == 'P1' ||
-          github.event.label.name == 'P2' ||
-          github.event.label.name == 'P3'
-        )
-      }}
+  parked-notice:
     runs-on: ubuntu-latest
     steps:
-      - name: Dispatch routing-relevant label event
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const issueNumber = context.payload.issue?.number;
-            const labelName = String(context.payload.label?.name || "").trim();
-
-            if (!issueNumber) {
-              core.warning("Could not determine the issue number for this event.");
-              return;
-            }
-
-            await github.rest.repos.createDispatchEvent({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              event_type: "control_board_route_issue_label",
-              client_payload: {
-                issue_number: issueNumber,
-                action: context.payload.action || "",
-                label: labelName,
-              },
-            });
-
-            core.info(
-              `Dispatched control_board_route_issue_label for issue #${issueNumber} (${labelName || "<none>"}).`
-            );
+      - name: Parking notice
+        run: |
+          echo "⚠️  Control Board Routing Label Dispatch is parked fail-closed."
+          echo "Auto-trigger removed in #2805 (2026-06-02):"
+          echo "  - on: issues (labeled)"
+          echo "  - createDispatchEvent (event_type: control_board_route_issue_label)"
+          echo "The repository_dispatch listener was removed in #2772 / #2796."
+          echo "Active board reconciliation runs through control_board_upsert.yml"
+          echo "(workflow_dispatch + Mon 02:30 UTC schedule, gated by"
+          echo "vars.CDB_CONTROL_BOARD_AUTOMATION_ENABLED)."
+          echo "This dispatch stub prints the diagnostic only; no Dispatch API"
+          echo "calls are performed."
+          echo "See .github/README.md for current control-plane documentation."

--- a/docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md
+++ b/docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md
@@ -190,7 +190,7 @@ graph TD
     SL -.->|reads| labels_json[labels.json]
 ```
 
-> **Parking note (#2772):** `control_board_auto_routing.yml` is parked; its previous edges to `O5` (Project board items) and `O6` (Labels on issues/PRs) are intentionally removed. The dispatch stub does not call the routing script.
+> **Parking note (#2772, #2805):** `control_board_auto_routing.yml` (#2772) and `control-board-routing-label-dispatch.yml` (#2805) are parked. Their previous edges to `O5` (Project board items), `O6` (Labels on issues/PRs) and the dispatch chain between them are intentionally removed. The dispatch stubs do not call the routing script or `createDispatchEvent`.
 
 ---
 
@@ -226,7 +226,7 @@ Full mapping across all support surfaces.
 | Hygiene issues | `cdb-weekly-control-hygiene-classifier.yml` |
 | Follow-up issues/comments | `cdb-post-merge-followup-scanner.yml`, `cdb-control-followup-classifier.yml`, `triage_guard.yml` |
 | Project board items | `control_board_upsert.yml`, `project_reconcile_daily.yml`, `add_to_project.yml` (`control_board_auto_routing.yml` was parked in #2772 and no longer writes to the project board) |
-| Issue labels | `sync-labels.yml`, `auto-milestone.yml`, `auto-milestone-label-dispatch.yml`, `control-board-routing-label-dispatch.yml`, `project_status_label_map.yml`, `milestone_stage_label_sync.yml`, `stale.yml`, `gemini-triage.yml` (`control_board_auto_routing.yml` was parked in #2772 and no longer labels issues) |
+| Issue labels | `sync-labels.yml`, `auto-milestone.yml`, `auto-milestone-label-dispatch.yml`, `project_status_label_map.yml`, `milestone_stage_label_sync.yml`, `stale.yml`, `gemini-triage.yml` (`control_board_auto_routing.yml` was parked in #2772 and no longer labels issues; `control-board-routing-label-dispatch.yml` was parked in #2805 and no longer dispatches label events) |
 | PR check status | `ci.yml`, `policy-gate.yml`, `docs-hub-guard.yml`, `gitleaks.yml` |
 
 ---
@@ -249,7 +249,7 @@ These workflows are self-contained (no `.github/scripts/` or `.github/prompts/` 
 | `add_to_project.yml` | Reconcile |
 | `milestone_stage_label_sync.yml` | Reconcile |
 | `control_board_auto_routing.yml` | Reconcile (PARKED #2772; dispatch stub only) |
-| `control-board-routing-label-dispatch.yml` | Reconcile |
+| `control-board-routing-label-dispatch.yml` | Reconcile (PARKED #2805; dispatch stub only) |
 | `ci.yml` | CI |
 | `contracts.yml` | CI |
 | `lr021_replay_smoke.yml` | CI |

--- a/docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md
+++ b/docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md
@@ -177,7 +177,7 @@ Check issue labels for `control-delta`, `hygiene`, `triage` prefixes.
 Cross-reference with `docs/runbooks/CONTROL_REGISTER.md` § Active Infra Workflows.
 
 ### 4.3 A label operation cascaded into many workflows
-Label events (`issues: labeled`) trigger: `auto-milestone.yml`, `auto-milestone-label-dispatch.yml`, `control-board-routing-label-dispatch.yml`, `project_status_label_map.yml`, `project_status_sync.yml`. Any unexpected label on an issue can trigger all of these. Check the labeling source first.
+Label events (`issues: labeled`) trigger: `auto-milestone.yml`, `auto-milestone-label-dispatch.yml`, `project_status_label_map.yml`, `project_status_sync.yml`. Any unexpected label on an issue can trigger all of these. Check the labeling source first. (`control-board-routing-label-dispatch.yml` was removed from the cascade in #2805.)
 
 ### 4.4 `ci.yml` is failing
 `ci.yml` is the canonical required check. Before diagnosing the failure, confirm it's `ci.yml` (not `ci.yaml` — the legacy frozen copy). Check:
@@ -209,6 +209,7 @@ Workflows that **mutate repo state** outside their own run:
 | `auto-label.yml` | Labels issues | Historisch/unklar |
 | `auto-milestone.yml` | Assigns milestones | Fires on issue labeled events |
 | `auto-milestone-label-dispatch.yml` | Dispatches milestone label assignment | Issues trigger |
+| `control-board-routing-label-dispatch.yml` | **PARKED fail-closed (#2805)** — auto-dispatch to `control_board_route_issue_label` listener removed; dispatch stub only | Dispatch (issues trigger removed) |
 | `auto-milestone-pr-apply.yml` | Assigns milestone to PR | workflow_run downstream |
 | `control_board_upsert.yml` | Creates/updates GitHub Project board items | Schedule + dispatch |
 | `project_reconcile_daily.yml` | Reconciles project board state | Daily schedule |
@@ -251,6 +252,7 @@ Workflows that **mutate repo state** outside their own run:
 - `gemini-invoke.yml`, `gemini-review.yml`, `gemini-triage.yml` — reusable only, no standalone trigger.
 - `gemini-scheduled-triage.yml` — parked fail-closed (schedule removed deliberately).
 - `control_board_auto_routing.yml` — **PARKED fail-closed in #2772**: auto `issues`/`pull_request`/`repository_dispatch` triggers removed; dispatch stub only prints parking notice. Re-enabling per-event routing requires a separate scoped issue.
+- `control-board-routing-label-dispatch.yml` — **PARKED fail-closed in #2805**: auto `issues` trigger removed; `createDispatchEvent` to `control_board_route_issue_label` removed (listener was withdrawn in #2772/#2796). Dispatch stub only prints parking notice. Re-enabling per-label dispatch requires a separate scoped issue.
 - `auto-label.yml`, `bulk-issue-labeling.yml`, `comprehensive-issue-labeling.yml`, `issue-governance.yml`, `milestone-assignment.yml` — historisch/unklar; do not enable without scoped review.
 
 ---

--- a/docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
+++ b/docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
@@ -107,7 +107,7 @@ Only entries that differ materially from their group baseline are listed.
 | `auto-milestone-label-dispatch.yml` | `perm:w-contents` | — |
 | `auto-milestone-pr-apply.yml` | `perm:w-issues` | `in:wrun` |
 | `control_board_auto_routing.yml` | (parked #2772; `perm:r` only) | — |
-| `control-board-routing-label-dispatch.yml` | `perm:w-contents` | — |
+| `control-board-routing-label-dispatch.yml` | (parked #2805; `perm:r` only) | — |
 | `cdb-backlog-curation.yml` | `perm:w-issues` | `in:script:backlog_curation.py` |
 | `cdb-backlog-anomaly-escalation.yml` | `perm:w-issues`, `perm:actions-read` | `in:wrun`, `in:script:backlog_anomaly_escalation.py` |
 | `cdb-daily-delta-triage.yml` | `perm:w-issues` | `in:script:daily_delta_triage.py`, `in:control-register` |
@@ -159,7 +159,7 @@ Label, milestone, and project board management.
 | `milestone_stage_label_sync.yml` | aktiv | issues | Sync milestone stage to labels | — | Issue labels updated | O | None (automatic) |
 | `control_board_upsert.yml` | aktiv | dispatch, sched (Mon 02:30 UTC) | Create/upsert GitHub Project board items | — | Project board items | O | Weekly review in #1445 |
 | `control_board_auto_routing.yml` | **parked** | dispatch (issues, PR, repository_dispatch triggers removed in #2772) | **PARKED fail-closed**: per-event routing for project board was removed in #2772; dispatch stub only prints parking notice | — | (Disabled) | — | Re-enable requires explicit scoped decision |
-| `control-board-routing-label-dispatch.yml` | aktiv | issues | Dispatch routing label for board | — | Label on issue | O | None (automatic) |
+| `control-board-routing-label-dispatch.yml` | **parked** | dispatch (issues trigger removed in #2805) | **PARKED fail-closed**: auto-dispatch to `control_board_route_issue_label` listener removed in #2772 / #2796; dispatch stub only prints parking notice | — | (Disabled) | — | Re-enable requires explicit scoped decision |
 | `project_reconcile_daily.yml` | aktiv | sched, dispatch | Daily project board reconciliation | — | Project board state reconciled | O | Daily check in #1445 |
 | `project_status_label_map.yml` | aktiv | issues | Map project status column to labels | — | Labels on issue | O | None (automatic) |
 | `project_status_sync.yml` | aktiv | issues | Sync issue labels back to project status | — | Project status field updated | O | None (automatic) |
@@ -331,30 +331,31 @@ Legacy label and milestone automation. Not actively maintained; do not enable wi
 ## Status summary
 
 | Status | Count |
-|---|---|
-| aktiv | 54 |
+|---|---|---|
+| aktiv | 53 |
 | manual-only | 4 (`label-bootstrap`, `required-checks-audit`, `governance-audit`, `cdb-control-followup-classifier`) |
-| parked | 5 (`gemini-scheduled-triage`, `issue-governance`, `auto-label`, `comprehensive-issue-labeling`, `control_board_auto_routing`) |
+| parked | 6 (`gemini-scheduled-triage`, `issue-governance`, `auto-label`, `comprehensive-issue-labeling`, `control_board_auto_routing`, `control-board-routing-label-dispatch`) |
 | historisch | 2 |
 | frozen legacy | 1 (`ci.yaml`) |
-| **Total** | **66** (aktiv 54 + manual 4 + parked 5 + historisch 2 + frozen 1 = 66... see note below) |
+| **Total** | **66** (aktiv 53 + manual 4 + parked 6 + historisch 2 + frozen 1 = 66... see note below) |
 
 > **Count note:** `ci.yaml` is tracked separately as `frozen legacy`, not folded into the `historisch` bucket.
 > Of the 53 active workflows, 3 (`gemini-invoke.yml`, `gemini-review.yml`, `gemini-triage.yml`) are `workflow_call` reusable units and are not independently triggerable.
 > `parked` updated from 1→4 in #1642: `issue-governance.yml` (PR #1658), `auto-label.yml` and `comprehensive-issue-labeling.yml` (PR #1702).
 > `parked` updated from 4→5 in #2772: `control_board_auto_routing.yml` (auto `issues`/`pull_request`/`repository_dispatch` triggers removed; dispatch stub only).
+> `parked` updated from 5→6 in #2805: `control-board-routing-label-dispatch.yml` (auto `issues` trigger removed; dispatch stub only; `createDispatchEvent` removed).
 
 | Status | Count |
-|---|---|
-| aktiv (independently triggered) | 51 |
+|---|---|---|
+| aktiv (independently triggered) | 50 |
 | reusable (workflow_call only) | 3 (`gemini-invoke`, `gemini-review`, `gemini-triage`) |
 | manual-only (dispatch-only) | 4 |
-| parked | 5 |
+| parked | 6 |
 | historisch / unklar | 2 |
 | frozen legacy | 1 (`ci.yaml`) |
 | **Total** | **66** |
 
-> **Methodology note:** The current repo has 66 tracked workflow YAML files. `ci.yaml` is split out as `frozen legacy`; the three Gemini `workflow_call` units are active but non-standalone reusable workflows. `control_board_auto_routing.yml` (#2772) is parked but retained as a `workflow_dispatch` diagnostic stub.
+> **Methodology note:** The current repo has 66 tracked workflow YAML files. `ci.yaml` is split out as `frozen legacy`; the three Gemini `workflow_call` units are active but non-standalone reusable workflows. `control_board_auto_routing.yml` (#2772) and `control-board-routing-label-dispatch.yml` (#2805) are parked but retained as `workflow_dispatch` diagnostic stubs.
 
 ---
 

--- a/docs/runbooks/control_board_board_as_code.md
+++ b/docs/runbooks/control_board_board_as_code.md
@@ -13,6 +13,7 @@ ist kein Live-Kapital-GO und keine Strategie-Validierung.
 - Routing-Script: `scripts/project/route_control_board.py`
 - Workflow Upsert: `.github/workflows/control_board_upsert.yml`
 - Workflow Routing: `.github/workflows/control_board_auto_routing.yml` (**PARKED in #2772** — nur noch `workflow_dispatch`-Stub)
+- Label Dispatch: `.github/workflows/control-board-routing-label-dispatch.yml` (**PARKED in #2805** — nur noch `workflow_dispatch`-Stub)
 
 ## Feature Toggle (default OFF)
 

--- a/tests/unit/scripts/test_control_board_routing_label_dispatch_workflow_contract.py
+++ b/tests/unit/scripts/test_control_board_routing_label_dispatch_workflow_contract.py
@@ -1,0 +1,107 @@
+"""Workflow contract guards for the parked Control Board Routing Label Dispatch workflow (#2805)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = (
+    REPO_ROOT / ".github" / "workflows" / "control-board-routing-label-dispatch.yml"
+)
+PARKING_HEADER = "PARKED fail-closed in #2805"
+PARKING_REF_ISSUE = "#2805"
+REMOVED_LISTENER_ISSUE = "#2772"
+DISPATCH_EVENT_TYPE = "control_board_route_issue_label"
+
+
+def _load_workflow() -> dict:
+    assert WORKFLOW_PATH.exists(), f"Workflow not found: {WORKFLOW_PATH}"
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _on_triggers(workflow: dict) -> dict:
+    return workflow.get("on") or workflow.get(True) or {}
+
+
+@pytest.mark.unit
+def test_workflow_file_is_parked_with_header_comment() -> None:
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert PARKING_HEADER in content
+    assert PARKING_REF_ISSUE in content
+
+
+@pytest.mark.unit
+def test_parked_workflow_exposes_only_workflow_dispatch_trigger() -> None:
+    workflow = _load_workflow()
+    on_triggers = _on_triggers(workflow)
+
+    assert "issues" not in on_triggers, (
+        f"Parked workflow must not declare `issues` trigger "
+        f"(removed in {PARKING_REF_ISSUE})."
+    )
+    assert "repository_dispatch" not in on_triggers, (
+        f"Parked workflow must not declare `repository_dispatch` trigger "
+        f"(listener was removed in {REMOVED_LISTENER_ISSUE})."
+    )
+
+    assert "workflow_dispatch" in on_triggers, (
+        "Parked workflow must still expose `workflow_dispatch` as the only trigger "
+        "so operators can run the diagnostic stub manually."
+    )
+
+
+@pytest.mark.unit
+def test_parked_workflow_does_not_use_github_script_action() -> None:
+    workflow = _load_workflow()
+    jobs = workflow.get("jobs", {})
+    for job_name, job_def in jobs.items():
+        steps = job_def.get("steps", [])
+        for step in steps:
+            uses_action = step.get("uses", "")
+            assert "actions/github-script" not in uses_action, (
+                f"Parked workflow job `{job_name}` must not use "
+                f"`actions/github-script` step in `{step.get('name', '')}`; "
+                f"the `createDispatchEvent` call was removed in {PARKING_REF_ISSUE}."
+            )
+
+
+@pytest.mark.unit
+def test_parked_workflow_does_not_reference_dispatch_event_type_in_on_block() -> (
+    None
+):
+    workflow = _load_workflow()
+    on_triggers = _on_triggers(workflow)
+    assert "repository_dispatch" not in on_triggers, (
+        f"Parked workflow must not declare `repository_dispatch` trigger in `on:` block; "
+        f"the `{DISPATCH_EVENT_TYPE}` listener was removed in "
+        f"{REMOVED_LISTENER_ISSUE}."
+    )
+
+
+@pytest.mark.unit
+def test_parked_workflow_permissions_reduced_to_contents_read() -> None:
+    workflow = _load_workflow()
+    permissions = workflow.get("permissions") or {}
+
+    assert permissions == {"contents": "read"}, (
+        "Parked workflow should only request `contents: read`; "
+        f"`contents: write` for `createDispatchEvent` was removed in {PARKING_REF_ISSUE}."
+    )
+
+
+@pytest.mark.unit
+def test_parked_workflow_has_no_label_event_references() -> None:
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    forbidden_label_refs = (
+        "startsWith(github.event.label.name",
+        "github.event.label.name",
+        "context.payload.label?.name",
+    )
+    for ref in forbidden_label_refs:
+        assert ref not in content, (
+            f"Parked workflow must not reference label event payload `{ref}`; "
+            f"the `issues: labeled` trigger was removed in {PARKING_REF_ISSUE}."
+        )

--- a/tests/unit/scripts/test_control_board_routing_label_dispatch_workflow_contract.py
+++ b/tests/unit/scripts/test_control_board_routing_label_dispatch_workflow_contract.py
@@ -69,9 +69,7 @@ def test_parked_workflow_does_not_use_github_script_action() -> None:
 
 
 @pytest.mark.unit
-def test_parked_workflow_does_not_reference_dispatch_event_type_in_on_block() -> (
-    None
-):
+def test_parked_workflow_does_not_reference_dispatch_event_type_in_on_block() -> None:
     workflow = _load_workflow()
     on_triggers = _on_triggers(workflow)
     assert "repository_dispatch" not in on_triggers, (


### PR DESCRIPTION
## Summary

Parks the stale `control-board-routing-label-dispatch.yml` workflow fail-closed (#2805).

## Context

- #2772 / PR #2796 removed the `repository_dispatch` listener `control_board_route_issue_label` from `control_board_auto_routing.yml`.
- `control-board-routing-label-dispatch.yml` continued to fire on `issues: labeled` and emit `createDispatchEvent` calls - a dead dispatch path.
- This PR removes the auto-trigger (`issues: labeled`) and the `createDispatchEvent` call. The workflow is retained as a `workflow_dispatch` diagnostic stub.

## Changes (6 files)

| File | Change |
|---|---|
| `.github/workflows/control-board-routing-label-dispatch.yml` | **Parked fail-closed**: `issues: labeled` trigger removed, `contents: write` to `contents: read`, `actions/github-script` + `createDispatchEvent` replaced by parking notice |
| `docs/runbooks/GITHUB_WORKFLOW_REGISTER.md` | Status: aktiv to parked; permission override: perm:w-contents to perm:r; counts: aktiv 54 to 53, parked 5 to 6 |
| `docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md` | Section 4.3 removed from cascade list; Section 5 added to Side Effects Catalog as parked; Section 6 added to frozen/parked assets |
| `docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md` | Section 6 Issue labels updated; Section 7 marked PARKED; parking note extended |
| `docs/runbooks/control_board_board_as_code.md` | Added label dispatch entry as PARKED in #2805 |
| `tests/unit/scripts/test_control_board_routing_label_dispatch_workflow_contract.py` | **New**: 6 contract tests |

Closes #2805

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes a no-op dispatch path and tightens workflow permissions; behavior change is fewer automated runs on label events, with upsert still documented as the active path.
> 
> **Overview**
> **Parks** `control-board-routing-label-dispatch.yml` **fail-closed** (#2805) after the `control_board_route_issue_label` listener was removed (#2772/#2796). The workflow no longer runs on **`issues: labeled`** or calls **`createDispatchEvent`** via `actions/github-script`; it is a **`workflow_dispatch`** stub that prints a parking notice, with **`contents: read`** only.
> 
> Control-plane docs and the board-as-code runbook now treat this workflow as **parked**, drop it from the **label-event cascade**, and note that **`control_board_upsert.yml`** remains the active reconciliation path. **Six new unit contract tests** lock in the parked shape (triggers, permissions, no dispatch/label payload refs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c51ab7b0e4b256b422b91262480911aeac69103. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->