### PR TITLE
feat(surrealdb): add evidence-aware decision replay v2

### DIFF
--- a/docs/surrealdb/decision_replay_query_contract.md
+++ b/docs/surrealdb/decision_replay_query_contract.md
@@ -194,11 +194,47 @@ Minimalfall:
 - Für Konsistenz mit #2118 soll bei Änderungen immer die #2118 Unit-Suite grün bleiben:
   - `pytest -v tests/unit/surrealdb/test_decision_history_query_v1.py`
 
+## Agent-readable JSON Schema (v2, additive — #2800)
+
+`schema_version`: `decision-replay-query/v2`
+
+v2 **behält alle v1-Felder** und ergänzt read-only Evidence-Enrichment:
+
+```json
+{
+  "schema_version": "decision-replay-query/v2",
+  "evidence_links": [{ "id": "ev-002", "link_status": "summary_resolved|record_resolved|unresolved" }],
+  "resolved_evidence": [{ "id": "ev-002", "resolution_source": "summary|record", "authorization_implied": false }],
+  "unresolved_evidence_refs": ["ev-missing-001"],
+  "evidence_resolution_status": "none|refs_only|partial|full",
+  "evidence_warnings": ["unresolved_evidence_refs_present"],
+  "decision_chain_hash": "sha256-hex (deterministic, no wall-clock)",
+  "replay_explainability": {
+    "mode": "replay_by_decision_id",
+    "primary_decision_id": "dec-002",
+    "evidence_resolution_status": "partial",
+    "limitations": ["..."],
+    "authorization_note": "Replay explains only..."
+  }
+}
+```
+
+### v2 Semantics (fail-closed)
+
+- **Optional inputs**: `evidence_summaries` (wie v1) und/oder in-memory `evidence_records` (MCP/builder).
+- **Nie implizit verifizieren**: `known_evidence_ids` allein reicht **nicht** für `resolved_evidence`; fehlende Records/Summaries bleiben in `unresolved_evidence_refs`.
+- **`decision_chain_hash`**: Hash über `decision_chain`, `supersession_chain`, sortierte evidence/claim refs und unresolved-Listen — **ohne** `current_status.as_of`.
+- **Redaction**: token/secret/password/api_key-artige Felder in resolved payloads → `[REDACTED]`.
+- **LR / Live**: `approval_semantics` und `replay_explainability.history_only` bleiben non-authorizing; kein Live-Go, kein Echtgeld-Go.
+
+### v2 Validation (CI)
+
+- `pytest -q tests/unit/surrealdb/test_decision_replay_builder_v1.py` (v1 unverändert)
+- `pytest -q tests/unit/surrealdb/test_decision_replay_builder_v2.py`
+- `pytest -q tests/unit/tools/mcp/test_wave14_query_contracts.py -k decision_replay`
+
 ## Non-Goals (explizit)
 
-- Kein Replay Builder (#2119)
-- Kein MCP Tool (#2124)
-- Kein Evidence Lookup (#2116)
-- Kein Claim Resolution (#2117)
 - Keine produktive SurrealDB-Queries, keine DB-Writes, keine Runtime-/Docker-Änderungen
 - Keine Live-/LR-/Echtgeld-Autorisierung
+- Keine automatische Freigabe aus Replay- oder Evidence-Output

--- a/docs/surrealdb/decision_replay_query_contract.md
+++ b/docs/surrealdb/decision_replay_query_contract.md
@@ -223,7 +223,7 @@ v2 **behält alle v1-Felder** und ergänzt read-only Evidence-Enrichment:
 
 - **Optional inputs**: `evidence_summaries` (wie v1) und/oder in-memory `evidence_records` (MCP/builder).
 - **Nie implizit verifizieren**: `known_evidence_ids` allein reicht **nicht** für `resolved_evidence`; fehlende Records/Summaries bleiben in `unresolved_evidence_refs`.
-- **`decision_chain_hash`**: Hash über `decision_chain`, `supersession_chain`, sortierte evidence/claim refs und unresolved-Listen — **ohne** `current_status.as_of`.
+- **`decision_chain_hash`**: Hash über `decision_chain`, `supersession_chain`, sortierte evidence/claim refs, **v2-angereicherte** `unresolved_evidence_refs`, `resolved_evidence_ids`, `evidence_resolution_status` — **ohne** `current_status.as_of`.
 - **Redaction**: token/secret/password/api_key-artige Felder in resolved payloads → `[REDACTED]`.
 - **LR / Live**: `approval_semantics` und `replay_explainability.history_only` bleiben non-authorizing; kein Live-Go, kein Echtgeld-Go.
 

--- a/tests/unit/surrealdb/test_decision_mcp_tools_v1.py
+++ b/tests/unit/surrealdb/test_decision_mcp_tools_v1.py
@@ -55,7 +55,7 @@ def test_cdb_context_decision_replay_returns_replay_output() -> None:
     assert result["tool"] == TOOL_CDB_CONTEXT_DECISION_REPLAY
     assert result["status"] == "ok"
     assert result["metadata"]["read_only"] is True
-    assert result["result"]["schema_version"] == "decision-replay-query/v1"
+    assert result["result"]["schema_version"] == "decision-replay-query/v2"
     assert result["result"]["decision_summary"]["decision_id"] == "dec-002"
 
 

--- a/tests/unit/surrealdb/test_decision_replay_builder_v2.py
+++ b/tests/unit/surrealdb/test_decision_replay_builder_v2.py
@@ -151,6 +151,27 @@ def test_v2_human_go_visible_but_non_authorizing() -> None:
 
 
 @pytest.mark.unit
+def test_v2_hash_reflects_enriched_evidence_resolution_state() -> None:
+    fixture = _load_fixture()
+    req = DecisionReplayRequest(mode="replay_by_decision_id", decision_id="dec-002", limit=50)
+    refs_only = build_decision_replay_v2(fixture["decisions"], req)
+    with_record = build_decision_replay_v2(
+        fixture["decisions"],
+        req,
+        evidence_records=[
+            {
+                "evidence_id": "ev-002",
+                "title": "Resolved via record",
+                "created_at": "2026-05-02T10:00:00+00:00",
+            }
+        ],
+    )
+    assert refs_only["decision_chain_hash"] != with_record["decision_chain_hash"]
+    assert refs_only["evidence_resolution_status"] == "refs_only"
+    assert with_record["evidence_resolution_status"] == "partial"
+
+
+@pytest.mark.unit
 def test_v2_refs_only_status_when_no_resolution_inputs() -> None:
     fixture = _load_fixture()
     req = DecisionReplayRequest(mode="replay_by_decision_id", decision_id="dec-002", limit=50)

--- a/tests/unit/surrealdb/test_decision_replay_builder_v2.py
+++ b/tests/unit/surrealdb/test_decision_replay_builder_v2.py
@@ -1,0 +1,159 @@
+"""Unit tests for Decision Replay Builder v2 (#2800)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.surrealdb.decision_replay_builder import (
+    DecisionReplayRequest,
+    SCHEMA_VERSION_V2,
+    build_decision_replay_v1,
+    build_decision_replay_v2,
+)
+
+
+FIXTURE_PATH = Path("tests/fixtures/surrealdb/decision_replay/replay_v1.json")
+
+
+def _load_fixture() -> dict:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.mark.unit
+def test_v2_preserves_v1_core_fields_without_evidence_inputs() -> None:
+    fixture = _load_fixture()
+    req = DecisionReplayRequest(mode="replay_by_decision_id", decision_id="dec-002", limit=50)
+    v1 = build_decision_replay_v1(
+        fixture["decisions"],
+        req,
+        known_evidence_ids=set(fixture["known_evidence_ids"]),
+        known_claim_ids=set(fixture["known_claim_ids"]),
+        evidence_summaries=fixture["evidence_summaries"],
+        claim_summaries=fixture["claim_summaries"],
+        stop_conditions=fixture["stop_conditions"],
+    )
+    v2 = build_decision_replay_v2(
+        fixture["decisions"],
+        req,
+        known_evidence_ids=set(fixture["known_evidence_ids"]),
+        known_claim_ids=set(fixture["known_claim_ids"]),
+        evidence_summaries=fixture["evidence_summaries"],
+        claim_summaries=fixture["claim_summaries"],
+        stop_conditions=fixture["stop_conditions"],
+    )
+    assert v2["schema_version"] == SCHEMA_VERSION_V2
+    for key in (
+        "query",
+        "decision_summary",
+        "decision_chain",
+        "evidence_chain",
+        "claim_chain",
+        "approval_semantics",
+    ):
+        assert v2[key] == v1[key]
+    assert v2["evidence_resolution_status"] == "partial"
+    assert "ev-missing-001" in v2["unresolved_evidence_refs"]
+
+
+@pytest.mark.unit
+def test_v2_resolves_evidence_from_records() -> None:
+    fixture = _load_fixture()
+    req = DecisionReplayRequest(mode="replay_by_decision_id", decision_id="dec-002", limit=50)
+    records = [
+        {
+            "evidence_id": "ev-002",
+            "title": "Replay evidence",
+            "evidence_type": "log",
+            "confidence": 0.9,
+            "created_at": "2026-05-02T10:00:00+00:00",
+        }
+    ]
+    result = build_decision_replay_v2(
+        fixture["decisions"],
+        req,
+        known_evidence_ids=set(fixture["known_evidence_ids"]),
+        evidence_records=records,
+    )
+    resolved_ids = {entry.get("id") for entry in result["resolved_evidence"]}
+    assert "ev-002" in resolved_ids
+    assert "ev-missing-001" in result["unresolved_evidence_refs"]
+    assert result["evidence_resolution_status"] == "partial"
+    assert "unresolved_evidence_refs_present" in result["evidence_warnings"]
+
+
+@pytest.mark.unit
+def test_v2_never_verifies_missing_evidence_implicitly() -> None:
+    fixture = _load_fixture()
+    req = DecisionReplayRequest(mode="replay_by_decision_id", decision_id="dec-002", limit=50)
+    result = build_decision_replay_v2(
+        fixture["decisions"],
+        req,
+        known_evidence_ids={"ev-missing-001", "ev-002", "ev-003"},
+    )
+    assert "ev-missing-001" in result["unresolved_evidence_refs"]
+    resolved_ids = {entry.get("id") for entry in result["resolved_evidence"]}
+    assert "ev-missing-001" not in resolved_ids
+
+
+@pytest.mark.unit
+def test_v2_decision_chain_hash_is_deterministic_and_excludes_as_of() -> None:
+    fixture = _load_fixture()
+    req = DecisionReplayRequest(mode="replay_by_decision_id", decision_id="dec-002", limit=50)
+    first = build_decision_replay_v2(fixture["decisions"], req)
+    second = build_decision_replay_v2(fixture["decisions"], req)
+    assert first["decision_chain_hash"] == second["decision_chain_hash"]
+    assert first["current_status"]["as_of"] != second["current_status"]["as_of"]
+
+
+@pytest.mark.unit
+def test_v2_redacts_sensitive_fields_in_resolved_evidence() -> None:
+    fixture = _load_fixture()
+    req = DecisionReplayRequest(mode="replay_by_decision_id", decision_id="dec-002", limit=50)
+    records = [
+        {
+            "evidence_id": "ev-002",
+            "title": "Sensitive evidence",
+            "api_key": "should-not-leak",
+            "password": "should-not-leak",
+            "nested": {"client_secret": "nested-secret"},
+            "created_at": "2026-05-02T10:00:00+00:00",
+        }
+    ]
+    result = build_decision_replay_v2(
+        fixture["decisions"],
+        req,
+        evidence_records=records,
+    )
+    record_entry = next(
+        item for item in result["resolved_evidence"] if item.get("id") == "ev-002"
+    )
+    evidence = record_entry["evidence"]
+    assert evidence["api_key"] == "[REDACTED]"
+    assert evidence["password"] == "[REDACTED]"
+    assert evidence["nested"]["client_secret"] == "[REDACTED]"
+
+
+@pytest.mark.unit
+def test_v2_human_go_visible_but_non_authorizing() -> None:
+    fixture = _load_fixture()
+    req = DecisionReplayRequest(mode="replay_by_decision_id", decision_id="dec-002", limit=50)
+    result = build_decision_replay_v2(fixture["decisions"], req)
+    assert result["decision_summary"]["human_go"]["present"] is True
+    semantics = result["approval_semantics"]
+    assert semantics["no_live_go"] is True
+    assert semantics["no_echtgeld_go"] is True
+    explain = result["replay_explainability"]
+    assert explain["history_only"] is True
+    assert explain["limitations"]
+
+
+@pytest.mark.unit
+def test_v2_refs_only_status_when_no_resolution_inputs() -> None:
+    fixture = _load_fixture()
+    req = DecisionReplayRequest(mode="replay_by_decision_id", decision_id="dec-002", limit=50)
+    result = build_decision_replay_v2(fixture["decisions"], req)
+    assert result["evidence_resolution_status"] == "refs_only"
+    assert "evidence_resolution_inputs_not_provided" in result["evidence_warnings"]

--- a/tests/unit/surrealdb/wave14_contract_constants.py
+++ b/tests/unit/surrealdb/wave14_contract_constants.py
@@ -105,7 +105,7 @@ SERVICE_SCHEMA_VERSIONS: dict[str, str] = {
     "cdb_context_memory_get": "memory-read/v1",
     "cdb_context_trust_summary": "trust-summary/v1",
     "cdb_context_decision_history": "decision-history-query/v1",
-    "cdb_context_decision_replay": "decision-replay-query/v1",
+    "cdb_context_decision_replay": "decision-replay-query/v2",
 }
 
 WAVE14_QUERY_RESULT_KEYS: dict[str, frozenset[str]] = {
@@ -220,6 +220,13 @@ WAVE14_QUERY_RESULT_KEYS: dict[str, frozenset[str]] = {
             "human_go",
             "warnings",
             "approval_semantics",
+            "evidence_links",
+            "resolved_evidence",
+            "unresolved_evidence_refs",
+            "evidence_resolution_status",
+            "evidence_warnings",
+            "decision_chain_hash",
+            "replay_explainability",
         }
     ),
 }

--- a/tools/mcp/context_decision_tools.py
+++ b/tools/mcp/context_decision_tools.py
@@ -12,7 +12,7 @@ from tools.surrealdb.decision_history_query import (
 from tools.surrealdb.decision_replay_builder import (
     DecisionReplayError,
     DecisionReplayRequest,
-    build_decision_replay_v1,
+    build_decision_replay_v2,
 )
 from tools.surrealdb.context_query import ContextQueryError
 from tools.mcp.surrealdb_adapter_factory import (
@@ -390,6 +390,8 @@ def handle_cdb_context_decision_replay(request: Mapping[str, Any]) -> dict[str, 
 
     evidence_summaries = _as_mapping(params.get("evidence_summaries"))
     claim_summaries = _as_mapping(params.get("claim_summaries"))
+    evidence_records = _as_list_of_mappings(params.get("evidence_records"))
+    claim_records = _as_list_of_mappings(params.get("claim_records"))
 
     stop_conditions_raw = params.get("stop_conditions")
     stop_conditions: list[dict[str, Any]] | None = None
@@ -399,13 +401,15 @@ def handle_cdb_context_decision_replay(request: Mapping[str, Any]) -> dict[str, 
         stop_conditions = [dict(x) for x in stop_conditions_raw]
 
     try:
-        result = build_decision_replay_v1(
+        result = build_decision_replay_v2(
             decision_events,
             replay_request,
             known_evidence_ids=known_evidence_ids,
             known_claim_ids=known_claim_ids,
             evidence_summaries=evidence_summaries,
             claim_summaries=claim_summaries,
+            evidence_records=evidence_records,
+            claim_records=claim_records,
             stop_conditions=stop_conditions,
         )
     except DecisionReplayError as exc:

--- a/tools/surrealdb/decision_replay_builder.py
+++ b/tools/surrealdb/decision_replay_builder.py
@@ -687,7 +687,30 @@ def _build_evidence_enrichment_v2(
     return evidence_links, resolved_evidence, unresolved, status, evidence_warnings
 
 
-def _decision_chain_hash_payload(base: Mapping[str, Any]) -> dict[str, Any]:
+def _resolved_evidence_ids(resolved_evidence: Iterable[Mapping[str, Any]]) -> list[str]:
+    ids: list[str] = []
+    for item in resolved_evidence:
+        if not isinstance(item, Mapping):
+            continue
+        ref = item.get("id")
+        if isinstance(ref, str) and ref.strip():
+            ids.append(ref.strip())
+            continue
+        evidence = item.get("evidence")
+        if isinstance(evidence, Mapping):
+            evidence_id = evidence.get("evidence_id")
+            if isinstance(evidence_id, str) and evidence_id.strip():
+                ids.append(evidence_id.strip())
+    return sorted(set(ids))
+
+
+def _decision_chain_hash_payload(
+    base: Mapping[str, Any],
+    *,
+    unresolved_evidence_refs: list[str],
+    resolved_evidence_ids: list[str],
+    evidence_resolution_status: str,
+) -> dict[str, Any]:
     evidence_chain = base.get("evidence_chain") or {}
     claim_chain = base.get("claim_chain") or {}
     return {
@@ -703,11 +726,9 @@ def _decision_chain_hash_payload(base: Mapping[str, Any]) -> dict[str, Any]:
             for ref in claim_chain.get("refs", [])
             if isinstance(ref, str) and ref.strip()
         ),
-        "unresolved_evidence_refs": sorted(
-            str(ref).strip()
-            for ref in evidence_chain.get("unresolved", [])
-            if isinstance(ref, str) and ref.strip()
-        ),
+        "unresolved_evidence_refs": sorted(unresolved_evidence_refs),
+        "resolved_evidence_ids": sorted(resolved_evidence_ids),
+        "evidence_resolution_status": evidence_resolution_status,
         "unresolved_claim_refs": sorted(
             str(ref).strip()
             for ref in claim_chain.get("unresolved", [])
@@ -796,7 +817,14 @@ def build_decision_replay_v2(
     enriched["unresolved_evidence_refs"] = unresolved_evidence_refs
     enriched["evidence_resolution_status"] = evidence_resolution_status
     enriched["evidence_warnings"] = sorted(set(evidence_warnings))
-    enriched["decision_chain_hash"] = canonical_hash(_decision_chain_hash_payload(base))
+    enriched["decision_chain_hash"] = canonical_hash(
+        _decision_chain_hash_payload(
+            base,
+            unresolved_evidence_refs=unresolved_evidence_refs,
+            resolved_evidence_ids=_resolved_evidence_ids(resolved_evidence),
+            evidence_resolution_status=evidence_resolution_status,
+        )
+    )
     enriched["replay_explainability"] = _build_replay_explainability_v2(
         base,
         evidence_resolution_status=evidence_resolution_status,

--- a/tools/surrealdb/decision_replay_builder.py
+++ b/tools/surrealdb/decision_replay_builder.py
@@ -1,7 +1,8 @@
-"""Decision Replay Builder v1 — side-effect-free domain component.
+"""Decision Replay Builder v1/v2 — side-effect-free domain component.
 
 Issue:
     #2119 — [SURREALDB][CONTEXT][REPLAY] Implement decision replay v1
+    #2800 — [PHASE-2][SURREALDB][SLICE-4] Evidence-aware decision replay v2
     Parent: #2115 (Wave-14)
     Epic: #1976
 
@@ -26,6 +27,9 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping
 
+import re
+
+from core.replay.canonical_json import canonical_hash
 from core.utils.clock import utcnow
 from tools.surrealdb.decision_history_query import (
     DecisionHistoryQueryRequest,
@@ -33,6 +37,12 @@ from tools.surrealdb.decision_history_query import (
 )
 
 SCHEMA_VERSION = "decision-replay-query/v1"
+SCHEMA_VERSION_V2 = "decision-replay-query/v2"
+
+_SENSITIVE_KEY_RE = re.compile(
+    r"(token|secret|password|api[_-]?key|credential|private[_-]?key)",
+    re.IGNORECASE,
+)
 
 SUPPORTED_MODES = frozenset(
     {
@@ -523,3 +533,277 @@ def build_decision_replay_v1(
         "warnings": sorted(set(warnings + list(history_result.get("warnings", [])))),
         "approval_semantics": approval_semantics,
     }
+
+
+def _is_sensitive_key(key: str) -> bool:
+    return bool(_SENSITIVE_KEY_RE.search(key))
+
+
+def _redact_value(key: str, value: Any) -> Any:
+    if _is_sensitive_key(key):
+        return "[REDACTED]"
+    if isinstance(value, dict):
+        return _redact_mapping(value)
+    if isinstance(value, list):
+        return [_redact_value(key, item) for item in value]
+    return value
+
+
+def _redact_mapping(raw: Mapping[str, Any]) -> dict[str, Any]:
+    redacted: dict[str, Any] = {}
+    for key, value in raw.items():
+        if str(key).startswith("_"):
+            continue
+        redacted[str(key)] = _redact_value(str(key), value)
+    return redacted
+
+
+def _index_evidence_records(
+    evidence_records: Iterable[Mapping[str, Any]] | None,
+) -> dict[str, dict[str, Any]]:
+    if evidence_records is None:
+        return {}
+    index: dict[str, dict[str, Any]] = {}
+    for raw in evidence_records:
+        if not isinstance(raw, Mapping):
+            continue
+        evidence_id = raw.get("evidence_id")
+        if not isinstance(evidence_id, str) or not evidence_id.strip():
+            continue
+        sanitized = _redact_mapping(_sanitize_decision(raw))
+        sanitized.pop("_created_at_dt", None)
+        index[evidence_id.strip()] = sanitized
+    return index
+
+
+def _resolved_from_v1_chain(evidence_chain: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    resolved_by_id: dict[str, dict[str, Any]] = {}
+    for item in evidence_chain.get("resolved", []):
+        if not isinstance(item, Mapping):
+            continue
+        ref = item.get("id")
+        if isinstance(ref, str) and ref.strip():
+            resolved_by_id[ref.strip()] = dict(item)
+    return resolved_by_id
+
+
+def _evidence_resolution_status(
+    refs: list[str],
+    unresolved: list[str],
+    resolved_count: int,
+    *,
+    inputs_provided: bool,
+) -> str:
+    if not refs:
+        return "none"
+    if not inputs_provided:
+        return "refs_only"
+    if unresolved:
+        return "partial" if resolved_count else "refs_only"
+    if resolved_count >= len(refs):
+        return "full"
+    return "partial"
+
+
+def _build_evidence_enrichment_v2(
+    base: Mapping[str, Any],
+    *,
+    evidence_records: Iterable[Mapping[str, Any]] | None = None,
+    evidence_summaries: Mapping[str, Any] | None = None,
+) -> tuple[
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[str],
+    str,
+    list[str],
+]:
+    evidence_chain = base.get("evidence_chain") or {}
+    refs = sorted(
+        {
+            str(ref).strip()
+            for ref in evidence_chain.get("refs", [])
+            if isinstance(ref, str) and ref.strip()
+        }
+    )
+    v1_unresolved = {
+        str(ref).strip()
+        for ref in evidence_chain.get("unresolved", [])
+        if isinstance(ref, str) and ref.strip()
+    }
+    v1_resolved = _resolved_from_v1_chain(evidence_chain)
+    record_index = _index_evidence_records(evidence_records)
+
+    inputs_provided = evidence_summaries is not None or bool(record_index)
+    evidence_links: list[dict[str, Any]] = []
+    resolved_evidence: list[dict[str, Any]] = []
+    unresolved: list[str] = []
+    evidence_warnings: list[str] = []
+
+    if refs and not inputs_provided:
+        evidence_warnings.append("evidence_resolution_inputs_not_provided")
+
+    for ref in refs:
+        link_status = "unresolved"
+        if ref in v1_resolved:
+            entry = _redact_mapping(v1_resolved[ref])
+            entry["resolution_source"] = "summary"
+            entry["authorization_implied"] = False
+            resolved_evidence.append(entry)
+            link_status = "summary_resolved"
+        elif ref in record_index:
+            resolved_evidence.append(
+                {
+                    "id": ref,
+                    "resolution_source": "record",
+                    "authorization_implied": False,
+                    "evidence": record_index[ref],
+                }
+            )
+            link_status = "record_resolved"
+        else:
+            unresolved.append(ref)
+            link_status = "unresolved"
+        evidence_links.append({"id": ref, "link_status": link_status})
+
+    unresolved = sorted(set(unresolved) | v1_unresolved)
+    resolved_ids = {
+        item.get("id")
+        for item in resolved_evidence
+        if isinstance(item.get("id"), str) and item.get("id")
+    }
+    unresolved = sorted(ref for ref in unresolved if ref not in resolved_ids)
+
+    if unresolved:
+        evidence_warnings.append("unresolved_evidence_refs_present")
+    if refs and unresolved and inputs_provided:
+        evidence_warnings.append("evidence_resolution_partial")
+
+    status = _evidence_resolution_status(
+        refs,
+        unresolved,
+        len(resolved_evidence),
+        inputs_provided=inputs_provided,
+    )
+    return evidence_links, resolved_evidence, unresolved, status, evidence_warnings
+
+
+def _decision_chain_hash_payload(base: Mapping[str, Any]) -> dict[str, Any]:
+    evidence_chain = base.get("evidence_chain") or {}
+    claim_chain = base.get("claim_chain") or {}
+    return {
+        "decision_chain": list(base.get("decision_chain") or []),
+        "supersession_chain": list(base.get("supersession_chain") or []),
+        "evidence_refs": sorted(
+            str(ref).strip()
+            for ref in evidence_chain.get("refs", [])
+            if isinstance(ref, str) and ref.strip()
+        ),
+        "claim_refs": sorted(
+            str(ref).strip()
+            for ref in claim_chain.get("refs", [])
+            if isinstance(ref, str) and ref.strip()
+        ),
+        "unresolved_evidence_refs": sorted(
+            str(ref).strip()
+            for ref in evidence_chain.get("unresolved", [])
+            if isinstance(ref, str) and ref.strip()
+        ),
+        "unresolved_claim_refs": sorted(
+            str(ref).strip()
+            for ref in claim_chain.get("unresolved", [])
+            if isinstance(ref, str) and ref.strip()
+        ),
+    }
+
+
+def _build_replay_explainability_v2(
+    base: Mapping[str, Any],
+    *,
+    evidence_resolution_status: str,
+    unresolved_evidence_refs: list[str],
+    evidence_warnings: list[str],
+) -> dict[str, Any]:
+    query = base.get("query") or {}
+    decision_summary = base.get("decision_summary") or {}
+    evidence_chain = base.get("evidence_chain") or {}
+    refs = evidence_chain.get("refs", [])
+    limitations: list[str] = []
+    if evidence_resolution_status in {"refs_only", "partial"}:
+        limitations.append(
+            "Evidence refs are visible; full resolution requires optional "
+            "evidence_summaries or in-memory evidence_records."
+        )
+    if unresolved_evidence_refs:
+        limitations.append(
+            "Unresolved evidence refs remain unverified and do not imply approval."
+        )
+    if evidence_warnings:
+        limitations.append("See evidence_warnings and warnings for operator detail.")
+
+    approval = base.get("approval_semantics") or {}
+    return {
+        "mode": query.get("mode"),
+        "primary_decision_id": decision_summary.get("decision_id"),
+        "evidence_resolution_status": evidence_resolution_status,
+        "evidence_ref_count": len(refs) if isinstance(refs, list) else 0,
+        "unresolved_evidence_count": len(unresolved_evidence_refs),
+        "decision_chain_length": len(base.get("decision_chain") or []),
+        "limitations": limitations,
+        "authorization_note": approval.get("note"),
+        "history_only": approval.get("history_only", True),
+    }
+
+
+def build_decision_replay_v2(
+    decision_events: Iterable[Mapping[str, Any]],
+    request: DecisionReplayRequest,
+    *,
+    known_evidence_ids: set[str] | None = None,
+    known_claim_ids: set[str] | None = None,
+    evidence_summaries: Mapping[str, Any] | None = None,
+    claim_summaries: Mapping[str, Any] | None = None,
+    evidence_records: Iterable[Mapping[str, Any]] | None = None,
+    claim_records: Iterable[Mapping[str, Any]] | None = None,
+    stop_conditions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build Decision Replay v2: v1 semantics plus evidence enrichment and chain hash."""
+    _ = claim_records  # reserved for future claim-record enrichment; v1 claim_chain unchanged
+    base = build_decision_replay_v1(
+        decision_events,
+        request,
+        known_evidence_ids=known_evidence_ids,
+        known_claim_ids=known_claim_ids,
+        evidence_summaries=evidence_summaries,
+        claim_summaries=claim_summaries,
+        stop_conditions=stop_conditions,
+    )
+    (
+        evidence_links,
+        resolved_evidence,
+        unresolved_evidence_refs,
+        evidence_resolution_status,
+        evidence_warnings,
+    ) = _build_evidence_enrichment_v2(
+        base,
+        evidence_records=evidence_records,
+        evidence_summaries=evidence_summaries,
+    )
+
+    enriched = dict(base)
+    enriched["schema_version"] = SCHEMA_VERSION_V2
+    enriched["evidence_links"] = evidence_links
+    enriched["resolved_evidence"] = resolved_evidence
+    enriched["unresolved_evidence_refs"] = unresolved_evidence_refs
+    enriched["evidence_resolution_status"] = evidence_resolution_status
+    enriched["evidence_warnings"] = sorted(set(evidence_warnings))
+    enriched["decision_chain_hash"] = canonical_hash(_decision_chain_hash_payload(base))
+    enriched["replay_explainability"] = _build_replay_explainability_v2(
+        base,
+        evidence_resolution_status=evidence_resolution_status,
+        unresolved_evidence_refs=unresolved_evidence_refs,
+        evidence_warnings=enriched["evidence_warnings"],
+    )
+    enriched["warnings"] = sorted(
+        set(enriched.get("warnings", [])) | set(enriched["evidence_warnings"])
+    )
+    return enriched


### PR DESCRIPTION
## Summary

- Add `build_decision_replay_v2` as an additive layer on unchanged `build_decision_replay_v1`
- Optional read-only evidence enrichment via `evidence_summaries` and in-memory `evidence_records`
- Deterministic `decision_chain_hash` (excludes `current_status.as_of`), redaction, and `replay_explainability`
- MCP `cdb_context_decision_replay` and Wave14 contract updated to `decision-replay-query/v2`

Closes #2800
Refs #2778
Refs #1976

## Brain Evidence

brain_source: repo-only
brain_status: used
tools_or_queries:
- `gh issue view 2800`
- `git rev-parse origin/main`
- Repo reads: `decision_replay_builder.py`, `context_decision_tools.py`, `wave14_contract_constants.py`
records_or_results:
- #2800 OPEN; `origin/main` @ `95458eb1`
repo_crosscheck:
- V1 builder + MCP replay path; no v2 hash/evidence fields before this PR
impact_on_plan:
- Evidence integration slice implemented as additive v2 without v1 semantic drift
limitations:
- No productive SurrealDB query in CI; fixture/in-memory only

## Delivered

- `build_decision_replay_v2` with evidence_links, resolved_evidence, unresolved_evidence_refs, evidence_resolution_status, evidence_warnings, decision_chain_hash, replay_explainability
- MCP passes optional `evidence_records` / `claim_records` (claim_records reserved; claim_chain unchanged)
- Unit tests for v2 determinism, redaction, non-implicit verification, Wave14/MCP schema v2
- Contract doc v2 section

## Validation

- `pytest -q tests/unit/surrealdb/test_decision_replay_builder_v1.py`
- `pytest -q tests/unit/surrealdb/test_decision_replay_builder_v2.py`
- `pytest -q tests/unit/surrealdb/test_decision_mcp_tools_v1.py`
- `pytest -q tests/unit/tools/mcp/test_wave14_query_contracts.py -k decision_replay`
- `ruff check` on touched modules

## Non-goals

- No LR/Live/Echtgeld implication
- No productive SurrealDB writes; no MCP mutations
- #2798 / #2802 / #2803 / #2804 untouched
- #1976 remains open

## Safety Boundaries

- Read-only replay; `approval_semantics` unchanged (no_live_go, no_echtgeld_go)
- Unresolved evidence never upgraded to verified without summary/record input
- PERSIST_ALLOWED / MUTATION_ALLOWED not in scope

## Restunsicherheiten

- Real DB-backed replay enrichment not exercised in CI (by design)
- `claim_records` parameter accepted but not yet used for claim-record enrichment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches decision-replay MCP output and explainability semantics (non-authorizing, but consumers must handle v2 fields and stricter evidence resolution); sensitive-field redaction reduces leak risk in resolved evidence.
> 
> **Overview**
> Introduces **evidence-aware decision replay v2** as an additive layer on unchanged `build_decision_replay_v1`, then wires **MCP** `cdb_context_decision_replay` and Wave14 contracts to schema `decision-replay-query/v2`.
> 
> v2 adds optional read-only enrichment from `evidence_summaries` and in-memory `evidence_records` (`evidence_links`, `resolved_evidence`, `unresolved_evidence_refs`, `evidence_resolution_status`, `evidence_warnings`, `replay_explainability`). **`known_evidence_ids` alone never counts as resolved**; missing summaries/records stay unresolved. Resolved record payloads are **redacted** for sensitive keys; a **deterministic `decision_chain_hash`** tracks chain + evidence resolution state and excludes `current_status.as_of`. MCP accepts optional `evidence_records` / `claim_records` (claim records reserved). Contract doc, v2 unit tests, and MCP schema expectations are updated; v1 builder and tests remain for direct callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c545acf3742c43ea5bad7dcdd13537b4eab434. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->