### PR TITLE
feat(surrealdb): add context package v2 envelope

### DIFF
--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -1060,6 +1060,8 @@ Even when `status: ready_for_human_go`, the agent MUST stop and wait for explici
 | Bridge Tests | `tests/unit/tools/mcp/test_context_bridge.py` |
 | Permission Guard Tests | `tests/unit/tools/mcp/test_permission_guard.py` |
 | Package Handler Tests | `tests/unit/tools/mcp/test_context_package_handler.py` |
+| Context Package v2 Model | `docs/surrealdb/context-package-model-v2.md` |
+| Context Package v2 Builder Tests | `tests/unit/surrealdb/test_context_package_v2.py` |
 | Output Contract Tests | `tests/unit/tools/mcp/test_output_contracts.py` |
 | Control Register | `docs/runbooks/CONTROL_REGISTER.md` |
 

--- a/docs/surrealdb/context-agent-briefing-schema-v1.md
+++ b/docs/surrealdb/context-agent-briefing-schema-v1.md
@@ -185,7 +185,7 @@ This document (#2104) delivers the **concrete schema slice** of #2018: the norma
     },
     "context_package_ref": {
       "type": ["string", "null"],
-      "description": "Reference to the assembled Context Package (#2016), or null if no package was produced."
+      "description": "Reference (package_id) to the assembled Context Package (#2016 v1 doc, #2798 v2 envelope), or null if no package was produced. v2 schema: docs/surrealdb/context-package-model-v2.md."
     },
     "required_reads": {
       "type": "array",
@@ -338,7 +338,7 @@ This document (#2104) delivers the **concrete schema slice** of #2018: the norma
 |-------|:--------:|------|-----------|
 | `briefing_id` | Yes | `string` | Deterministic briefing identifier, derived as a hash of request fields. Enables idempotent retrieval and replay-verifiability. |
 | `scope_summary` | Yes | `string` | Human-readable paragraph summarising what the task is about, what context was found, and what constraints apply. |
-| `context_package_ref` | No | `string \| null` | Reference (package_id) to the Context Package (#2016) assembled for this briefing. `null` if no package was produced (e.g. for quick depth). |
+| `context_package_ref` | No | `string \| null` | Reference (package_id) to the Context Package assembled for this briefing (#2016 v1 model, #2798 v2 envelope — see `docs/surrealdb/context-package-model-v2.md`). `null` if no package was produced (e.g. for quick depth). |
 | `required_reads` | No | `string[]` | Ordered list of canonical files the agent must read. Minimum baseline per #2021 §6.3: AGENTS.md, agents/AGENTS.md, agents/OPEN_CODE_AGENTS.md, CONTROL_REGISTER.md, CURRENT_STATUS.md, LR-AUDIT-STATUS. |
 | `relevant_artifacts` | No | `object[]` | Key context artefacts matching the task scope. Each artefact carries a source_ref and confidence score. |
 | `relevant_symbols` | No | `object[]` | Code symbols (functions, classes, modules) in scope, with file paths and dependency lists. |

--- a/docs/surrealdb/context-package-model-v2.md
+++ b/docs/surrealdb/context-package-model-v2.md
@@ -1,0 +1,250 @@
+# Context Package Model v2
+
+**Issue**: #2798
+**Status**: Contract Defined
+**Date**: 2026-06-02
+**Parent**: #2778 (Phase-2 epic)
+**Epic**: #1976
+
+## Overview
+
+Context Package v2 is the governed agent handoff envelope for the read-only Context
+Intelligence layer. It packages retrieval ingredients, required reads, ranked context,
+evidence links, and decision replay links into a bounded, redacted, deterministic output.
+
+Implementation: [`tools/surrealdb/context_package_v2.py`](../../tools/surrealdb/context_package_v2.py)
+
+## Purpose
+
+- Standardized agent handoff schema with explicit guardrails
+- Deterministic multi-artifact hashing for replay and audit
+- Granular redaction with attributable `redaction_summary`
+- Integration hooks for hybrid ranking (#2799) and decision replay (#2800)
+- Fail-closed limitations when upstream inputs are missing or unverified
+
+## Non-Goals
+
+- No authorization, Live-Go, or Echtgeld-Go derivation
+- No productive SurrealDB writes; `PERSIST_ALLOWED=False`, `MUTATION_ALLOWED=False`
+- No trading/risk/execution/strategy effects
+- No automatic code or issue actions from package output
+- No replacement of MCP `context.package` v0 handler in this slice
+
+## Relationship to v1
+
+| Surface | Role |
+|---------|------|
+| [`context-package-model-v1.md`](context-package-model-v1.md) | Rich retrieval lifecycle model (#2016) — unchanged |
+| MCP `context.package` handler | Repo/registry packaging v0 — unchanged |
+| **Context Package v2** | Pure builder envelope for governed handoffs (#2798) |
+
+Briefings reference packages via `context_package_ref` (package_id). v2 uses
+`schema_version: "context-package/v2"`.
+
+---
+
+## Envelope Schema
+
+All packages **must** include these top-level fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `schema_version` | string | Yes | Always `"context-package/v2"` |
+| `package_id` | string | Yes | Deterministic ID (`pkg_<12 hex chars>`) |
+| `generated_at_or_as_of` | string | Yes | ISO8601 timestamp or as-of marker |
+| `target_scope` | string | Yes | Task/issue/scope identifier |
+| `source_priority` | string[] | Yes | Truth-order for downstream consumers |
+| `required_reads` | object[] | Yes | Structured required read entries |
+| `artifacts` | object[] | Yes | Redacted artifact payloads |
+| `ranked_context` | object \| null | Yes | Hybrid ranking output (#2799) or null |
+| `evidence_links` | object[] | Yes | Evidence references (may be empty) |
+| `decision_replay_links` | object[] | Yes | Replay references (#2800) |
+| `redaction_summary` | object[] | Yes | What was redacted (path/field/type only) |
+| `limitations` | string[] | Yes | Missing/unverified upstream signals |
+| `guardrails` | string[] | Yes | Non-authorizing boundary statements |
+| `determinism` | object | Yes | Hash metadata block |
+
+### Example
+
+```json
+{
+  "schema_version": "context-package/v2",
+  "package_id": "pkg_a1b2c3d4e5f6",
+  "generated_at_or_as_of": "2026-06-02T12:00:00+00:00",
+  "target_scope": "issue:2798",
+  "source_priority": [
+    "github_live",
+    "repo_live",
+    "verified_context_db_mcp_evidence",
+    "canonical_governance_files",
+    "ledger_files",
+    "memory"
+  ],
+  "required_reads": [
+    {
+      "path": "AGENTS.md",
+      "priority": "required",
+      "reason": "Root pointer"
+    }
+  ],
+  "artifacts": [
+    {
+      "artifact_id": "docs/surrealdb/context-package-model-v1.md",
+      "artifact_type": "doc",
+      "summary": "Baseline package model"
+    }
+  ],
+  "ranked_context": null,
+  "evidence_links": [],
+  "decision_replay_links": [],
+  "redaction_summary": [],
+  "limitations": [
+    "ranked_context_not_provided",
+    "decision_replay_links_not_provided",
+    "evidence_links_not_provided"
+  ],
+  "guardrails": [
+    "Context Package is orientation, not authorization.",
+    "LR remains NO-GO; no Live-Go.",
+    "No Echtgeld-Go.",
+    "No automatic code or issue action from package output.",
+    "No DB-backed claim without tool/query/record evidence."
+  ],
+  "determinism": {
+    "hash_algorithm": "canonical_sha256",
+    "wall_clock_excluded": true,
+    "artifact_count": 1,
+    "content_hash": "<64-char hex>"
+  }
+}
+```
+
+---
+
+## Artifact Input Contract
+
+Each artifact ingredient must include:
+
+- `artifact_id` (or `id`)
+- `artifact_type` (or `type`)
+
+Optional nested fields (metadata, source_refs, summaries) are redacted in place.
+Transient fields (`generated_at`, `created_at`, `updated_at`, `as_of`) are excluded
+from per-artifact hash input.
+
+---
+
+## Redaction Rules
+
+1. **Sensitive keys** matching `(token|secret|password|api_key|credential|private_key|auth)`
+   (case-insensitive) → value replaced with `"[REDACTED]"`.
+2. **Secret value patterns** in string values (Bearer tokens, `sk-…`, JWT `eyJ…`) → redacted.
+3. **Raw secret values must never appear** in package output.
+4. **`redaction_summary`** records `{ "path", "field", "redaction_type" }` only — never
+   the original value.
+5. Unresolved or unsafe inputs produce `limitations` entries, not fake verification.
+
+### redaction_type Values
+
+| Type | Meaning |
+|------|---------|
+| `sensitive_key` | Field name matched sensitive key pattern |
+| `secret_value_pattern` | String value matched secret pattern |
+
+---
+
+## Multi-Artifact Hash Algorithm
+
+Uses [`core/replay/canonical_json.py`](../../core/replay/canonical_json.py) (`canonical_hash`).
+
+1. **Redact** all artifact payloads and nested link maps.
+2. **Sort artifacts** by `(artifact_id, artifact_type, canonical_json(payload))`.
+3. **Per-artifact hash:** `canonical_hash(redacted_payload_without_transient_fields)`.
+4. **Build hash input** (wall-clock excluded):
+
+```json
+{
+  "schema_version": "context-package/v2",
+  "target_scope": "...",
+  "source_priority": ["..."],
+  "required_reads": [],
+  "artifact_hashes": ["..."],
+  "ranked_context_fingerprint": null,
+  "evidence_links_fingerprint": null,
+  "decision_replay_links_fingerprint": null
+}
+```
+
+5. **`content_hash`** = `canonical_hash(hash_input)` (full 64-char hex).
+6. **`package_id`** = `"pkg_" + content_hash[:12]`.
+7. **`generated_at_or_as_of`** is in the envelope but **excluded** from hash input.
+
+---
+
+## Source Priority / Truth Order
+
+Default `source_priority`:
+
+1. `github_live`
+2. `repo_live`
+3. `verified_context_db_mcp_evidence`
+4. `canonical_governance_files`
+5. `ledger_files`
+6. `memory`
+
+Consumers must treat higher-priority sources as authoritative over lower tiers.
+Package output itself is orientation — not authorization.
+
+---
+
+## Upstream Integration
+
+| Upstream | Field | Missing behaviour |
+|----------|-------|-----------------|
+| #2799 `rank_retrieval_ranking` | `ranked_context` | `limitations: ranked_context_not_provided` |
+| #2800 `decision_replay_builder` | `decision_replay_links` | `limitations: decision_replay_links_not_provided` |
+| `context_required_reads` | `required_reads` | Empty list allowed |
+| Evidence resolver (future) | `evidence_links` | `limitations: evidence_links_unverified` when refs-only |
+
+No live DB is required. All integration is via in-memory dict inputs.
+
+---
+
+## Operator / Agent Consumption
+
+- Use the package for **orientation** before planning or handoff.
+- Read `limitations` before trusting ranked/evidence/replay sections.
+- Check `guardrails` and `redaction_summary` before citing package content.
+- **`context_package_ref` in briefings** should reference `package_id` from this envelope.
+- **LR remains NO-GO** — package output does not authorize live trading or Echtgeld.
+
+---
+
+## Guardrails
+
+Non-negotiable statements included in every package:
+
+- Context Package is orientation, not authorization.
+- LR remains NO-GO; no Live-Go.
+- No Echtgeld-Go.
+- No automatic code or issue action from package output.
+- No DB-backed claim without tool/query/record evidence.
+
+---
+
+## Validation
+
+Contract tests: [`tests/unit/surrealdb/test_context_package_v2.py`](../../tests/unit/surrealdb/test_context_package_v2.py)
+
+---
+
+## References
+
+| Item | Link |
+|------|------|
+| v1 model | [`context-package-model-v1.md`](context-package-model-v1.md) |
+| Hybrid ranking | [`context-hybrid-retrieval-strategy-v1.md`](context-hybrid-retrieval-strategy-v1.md) |
+| Decision replay | [`decision_replay_query_contract.md`](decision_replay_query_contract.md) |
+| Briefing schema | [`context-agent-briefing-schema-v1.md`](context-agent-briefing-schema-v1.md) |
+| Issue #2798 | Context Package v2 implementation |
+| Issue #2778 | Phase-2 parent epic |

--- a/tests/fixtures/surrealdb/context_package_v2/minimal_ingredients.json
+++ b/tests/fixtures/surrealdb/context_package_v2/minimal_ingredients.json
@@ -1,0 +1,23 @@
+{
+  "target_scope": "issue:2798",
+  "artifacts": [
+    {
+      "artifact_id": "docs/surrealdb/context-package-model-v1.md",
+      "artifact_type": "doc",
+      "summary": "Context package baseline model"
+    },
+    {
+      "artifact_id": "tools/surrealdb/hybrid_retrieval_ranking.py",
+      "artifact_type": "code",
+      "summary": "Hybrid ranking integration point"
+    }
+  ],
+  "required_reads": [
+    {
+      "path": "AGENTS.md",
+      "priority": "required",
+      "reason": "Root pointer"
+    }
+  ],
+  "generated_at_or_as_of": "2026-06-02T12:00:00+00:00"
+}

--- a/tests/unit/surrealdb/test_context_package_v2.py
+++ b/tests/unit/surrealdb/test_context_package_v2.py
@@ -207,6 +207,15 @@ def test_empty_artifacts_fail_closed() -> None:
 
 
 @pytest.mark.unit
+def test_secret_only_differences_do_not_change_package_id_for_same_artifact() -> None:
+    artifact_a = _sample_artifact("shared-artifact", metadata={"api_key": "sk-one"})
+    artifact_b = _sample_artifact("shared-artifact", metadata={"api_key": "sk-two"})
+    package_a = build_context_package_v2(_base_request(artifacts=[artifact_a]))
+    package_b = build_context_package_v2(_base_request(artifacts=[artifact_b]))
+    assert package_a["package_id"] == package_b["package_id"]
+
+
+@pytest.mark.unit
 def test_required_reads_are_redacted() -> None:
     secret = "sk-required-read-secret"
     package = build_context_package_v2(

--- a/tests/unit/surrealdb/test_context_package_v2.py
+++ b/tests/unit/surrealdb/test_context_package_v2.py
@@ -207,6 +207,18 @@ def test_empty_artifacts_fail_closed() -> None:
 
 
 @pytest.mark.unit
+def test_required_reads_are_redacted() -> None:
+    secret = "sk-required-read-secret"
+    package = build_context_package_v2(
+        _base_request(
+            required_reads=[{"path": "AGENTS.md", "api_key": secret}],
+        )
+    )
+    assert secret not in json.dumps(package)
+    assert package["required_reads"][0]["api_key"] == "[REDACTED]"
+
+
+@pytest.mark.unit
 def test_evidence_and_replay_links_are_redacted() -> None:
     secret = "Bearer abc.def.ghi"
     package = build_context_package_v2(

--- a/tests/unit/surrealdb/test_context_package_v2.py
+++ b/tests/unit/surrealdb/test_context_package_v2.py
@@ -207,6 +207,46 @@ def test_empty_artifacts_fail_closed() -> None:
 
 
 @pytest.mark.unit
+def test_tokenized_url_values_are_redacted() -> None:
+    secret_url = "https://example.com/context?token=super-secret-value"
+    package = build_context_package_v2(
+        _base_request(
+            artifacts=[_sample_artifact(source_url=secret_url)],
+            evidence_links=[{"ref": secret_url}],
+        )
+    )
+    serialized = json.dumps(package)
+    assert "super-secret-value" not in serialized
+    assert package["artifacts"][0]["source_url"] == "[REDACTED]"
+    assert package["evidence_links"][0]["ref"] == "[REDACTED]"
+    assert all(
+        "super-secret-value" not in entry.get("path", "")
+        for entry in package["redaction_summary"]
+    )
+
+
+@pytest.mark.unit
+def test_link_secret_only_differences_do_not_change_package_id() -> None:
+    package_a = build_context_package_v2(
+        _base_request(
+            evidence_links=[
+                {"ref": "evidence:shared", "api_key": "sk-one"},
+                {"ref": "evidence:other", "content_hash": "abc"},
+            ],
+        )
+    )
+    package_b = build_context_package_v2(
+        _base_request(
+            evidence_links=[
+                {"ref": "evidence:shared", "api_key": "sk-two"},
+                {"ref": "evidence:other", "content_hash": "abc"},
+            ],
+        )
+    )
+    assert package_a["package_id"] == package_b["package_id"]
+
+
+@pytest.mark.unit
 def test_private_rank_field_does_not_change_package_id() -> None:
     artifact_a = _sample_artifact("shared-artifact", _rank=1)
     artifact_b = _sample_artifact("shared-artifact", _rank=99)
@@ -221,6 +261,21 @@ def test_secret_only_differences_do_not_change_package_id_for_same_artifact() ->
     artifact_b = _sample_artifact("shared-artifact", metadata={"api_key": "sk-two"})
     package_a = build_context_package_v2(_base_request(artifacts=[artifact_a]))
     package_b = build_context_package_v2(_base_request(artifacts=[artifact_b]))
+    assert package_a["package_id"] == package_b["package_id"]
+
+
+@pytest.mark.unit
+def test_required_read_secret_only_differences_do_not_change_package_id() -> None:
+    package_a = build_context_package_v2(
+        _base_request(
+            required_reads=[{"path": "AGENTS.md", "api_key": "sk-one"}],
+        )
+    )
+    package_b = build_context_package_v2(
+        _base_request(
+            required_reads=[{"path": "AGENTS.md", "api_key": "sk-two"}],
+        )
+    )
     assert package_a["package_id"] == package_b["package_id"]
 
 

--- a/tests/unit/surrealdb/test_context_package_v2.py
+++ b/tests/unit/surrealdb/test_context_package_v2.py
@@ -1,0 +1,214 @@
+"""Unit tests for context_package_v2.py — Context Package v2.
+
+Issues:
+    #2798 — [PHASE-2][SURREALDB][SLICE-2] Context Package v2
+    Parent: #2778
+
+Scope:
+    Fixture-based unit tests. No DB. No MCP. No networking. No writes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tools.surrealdb.context_package_v2 import (
+    GUARDRAILS,
+    SCHEMA_VERSION,
+    ContextPackageV2Error,
+    ContextPackageV2Request,
+    build_context_package_v2,
+)
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "surrealdb"
+    / "context_package_v2"
+    / "minimal_ingredients.json"
+)
+
+REQUIRED_FIELDS = (
+    "schema_version",
+    "package_id",
+    "generated_at_or_as_of",
+    "target_scope",
+    "source_priority",
+    "required_reads",
+    "artifacts",
+    "ranked_context",
+    "evidence_links",
+    "decision_replay_links",
+    "redaction_summary",
+    "limitations",
+    "guardrails",
+    "determinism",
+)
+
+
+def _sample_artifact(
+    artifact_id: str = "docs/surrealdb/context-package-model-v1.md",
+    artifact_type: str = "doc",
+    **extra: Any,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "artifact_id": artifact_id,
+        "artifact_type": artifact_type,
+        "summary": "Baseline package model",
+    }
+    payload.update(extra)
+    return payload
+
+
+def _base_request(**overrides: Any) -> ContextPackageV2Request:
+    defaults: dict[str, Any] = {
+        "target_scope": "issue:2798",
+        "artifacts": [_sample_artifact()],
+        "generated_at_or_as_of": "2026-06-02T12:00:00+00:00",
+    }
+    defaults.update(overrides)
+    return ContextPackageV2Request(**defaults)
+
+
+@pytest.mark.unit
+def test_v2_package_has_required_schema_fields() -> None:
+    package = build_context_package_v2(_base_request())
+    for field in REQUIRED_FIELDS:
+        assert field in package, f"missing required field: {field}"
+    assert package["schema_version"] == SCHEMA_VERSION
+
+
+@pytest.mark.unit
+def test_package_id_is_deterministic_for_equivalent_inputs() -> None:
+    request = _base_request()
+    first = build_context_package_v2(request)
+    second = build_context_package_v2(request)
+    assert first["package_id"] == second["package_id"]
+    assert first["determinism"]["content_hash"] == second["determinism"]["content_hash"]
+
+
+@pytest.mark.unit
+def test_generated_at_or_as_of_does_not_change_package_id() -> None:
+    base = _base_request(generated_at_or_as_of="2026-06-02T12:00:00+00:00")
+    other = _base_request(generated_at_or_as_of="2026-06-03T08:15:00+00:00")
+    assert build_context_package_v2(base)["package_id"] == build_context_package_v2(other)[
+        "package_id"
+    ]
+
+
+@pytest.mark.unit
+def test_artifact_ordering_is_stable() -> None:
+    artifacts = [
+        _sample_artifact("b-artifact", "doc"),
+        _sample_artifact("a-artifact", "doc"),
+    ]
+    forward = build_context_package_v2(_base_request(artifacts=artifacts))
+    reverse = build_context_package_v2(_base_request(artifacts=list(reversed(artifacts))))
+    assert forward["package_id"] == reverse["package_id"]
+    assert [item["artifact_id"] for item in forward["artifacts"]] == [
+        "a-artifact",
+        "b-artifact",
+    ]
+
+
+@pytest.mark.unit
+def test_sensitive_fields_are_redacted_in_artifacts() -> None:
+    package = build_context_package_v2(
+        _base_request(
+            artifacts=[
+                _sample_artifact(
+                    metadata={
+                        "api_key": "sk-live-secret-value",
+                        "password": "hunter2",
+                        "token": "Bearer abc.def.ghi",
+                    }
+                )
+            ]
+        )
+    )
+    metadata = package["artifacts"][0]["metadata"]
+    assert metadata["api_key"] == "[REDACTED]"
+    assert metadata["password"] == "[REDACTED]"
+    assert metadata["token"] == "[REDACTED]"
+
+
+@pytest.mark.unit
+def test_redaction_summary_contains_no_raw_secret_values() -> None:
+    secret = "sk-live-secret-value"
+    package = build_context_package_v2(
+        _base_request(
+            artifacts=[_sample_artifact(metadata={"api_key": secret})]
+        )
+    )
+    serialized = json.dumps(package["redaction_summary"])
+    assert secret not in serialized
+    assert package["redaction_summary"]
+    for entry in package["redaction_summary"]:
+        assert "path" in entry
+        assert "field" in entry
+        assert "redaction_type" in entry
+
+
+@pytest.mark.unit
+def test_missing_ranked_and_replay_inputs_produce_limitations() -> None:
+    package = build_context_package_v2(_base_request())
+    assert "ranked_context_not_provided" in package["limitations"]
+    assert "decision_replay_links_not_provided" in package["limitations"]
+    assert "evidence_links_not_provided" in package["limitations"]
+    assert package["ranked_context"] is None
+
+
+@pytest.mark.unit
+def test_refs_only_replay_links_add_limitation_not_fake_verification() -> None:
+    package = build_context_package_v2(
+        _base_request(
+            decision_replay_links=[{"ref": "decision:123", "mode": "replay_by_decision_id"}]
+        )
+    )
+    assert "decision_replay_links_refs_only" in package["limitations"]
+
+
+@pytest.mark.unit
+def test_guardrails_include_no_live_go_and_no_authorization() -> None:
+    package = build_context_package_v2(_base_request())
+    assert list(package["guardrails"]) == list(GUARDRAILS)
+    joined = " ".join(package["guardrails"]).lower()
+    assert "no-go" in joined
+    assert "orientation" in joined
+    assert "authorization" in joined
+
+
+@pytest.mark.unit
+def test_ranked_context_and_replay_links_integrate_when_provided() -> None:
+    package = build_context_package_v2(
+        _base_request(
+            ranked_context={"schema_version": "hybrid-retrieval-ranking/v1", "results": []},
+            evidence_links=[{"ref": "evidence:1", "content_hash": "abc123", "verified": True}],
+            decision_replay_links=[
+                {"replay_id": "replay:1", "content_hash": "def456", "mode": "replay_by_decision_id"}
+            ],
+        )
+    )
+    assert package["ranked_context"] is not None
+    assert package["evidence_links"]
+    assert package["decision_replay_links"]
+    assert "ranked_context_not_provided" not in package["limitations"]
+    assert "decision_replay_links_not_provided" not in package["limitations"]
+
+
+@pytest.mark.unit
+def test_empty_artifacts_fail_closed() -> None:
+    with pytest.raises(ContextPackageV2Error, match="non-empty"):
+        build_context_package_v2(_base_request(artifacts=[]))
+
+
+@pytest.mark.unit
+def test_fixture_minimal_ingredients_builds_package() -> None:
+    payload = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+    package = build_context_package_v2(ContextPackageV2Request(**payload))
+    assert package["package_id"].startswith("pkg_")
+    assert package["determinism"]["artifact_count"] == len(payload["artifacts"])

--- a/tests/unit/surrealdb/test_context_package_v2.py
+++ b/tests/unit/surrealdb/test_context_package_v2.py
@@ -207,6 +207,15 @@ def test_empty_artifacts_fail_closed() -> None:
 
 
 @pytest.mark.unit
+def test_private_rank_field_does_not_change_package_id() -> None:
+    artifact_a = _sample_artifact("shared-artifact", _rank=1)
+    artifact_b = _sample_artifact("shared-artifact", _rank=99)
+    package_a = build_context_package_v2(_base_request(artifacts=[artifact_a]))
+    package_b = build_context_package_v2(_base_request(artifacts=[artifact_b]))
+    assert package_a["package_id"] == package_b["package_id"]
+
+
+@pytest.mark.unit
 def test_secret_only_differences_do_not_change_package_id_for_same_artifact() -> None:
     artifact_a = _sample_artifact("shared-artifact", metadata={"api_key": "sk-one"})
     artifact_b = _sample_artifact("shared-artifact", metadata={"api_key": "sk-two"})

--- a/tests/unit/surrealdb/test_context_package_v2.py
+++ b/tests/unit/surrealdb/test_context_package_v2.py
@@ -207,6 +207,24 @@ def test_empty_artifacts_fail_closed() -> None:
 
 
 @pytest.mark.unit
+def test_evidence_and_replay_links_are_redacted() -> None:
+    secret = "Bearer abc.def.ghi"
+    package = build_context_package_v2(
+        _base_request(
+            evidence_links=[{"ref": "evidence:1", "api_key": secret}],
+            decision_replay_links=[
+                {"ref": "decision:1", "token": "sk-live-secret-value"}
+            ],
+        )
+    )
+    serialized = json.dumps(package)
+    assert secret not in serialized
+    assert "sk-live-secret-value" not in serialized
+    assert package["evidence_links"][0]["api_key"] == "[REDACTED]"
+    assert package["decision_replay_links"][0]["token"] == "[REDACTED]"
+
+
+@pytest.mark.unit
 def test_fixture_minimal_ingredients_builds_package() -> None:
     payload = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
     package = build_context_package_v2(ContextPackageV2Request(**payload))

--- a/tools/surrealdb/context_package_v2.py
+++ b/tools/surrealdb/context_package_v2.py
@@ -277,7 +277,11 @@ def build_context_package_v2(request: ContextPackageV2Request) -> dict[str, Any]
         redacted_artifacts.append(redacted)
         artifact_hashes.append(canonical_hash(_artifact_hash_payload(redacted)))
 
-    required_reads = _stable_required_reads(request.required_reads)
+    required_reads_stable = _stable_required_reads(request.required_reads)
+    required_reads = [
+        _redact_mapping(item, f"required_reads[{index}]", redaction_summary)
+        for index, item in enumerate(required_reads_stable)
+    ]
     evidence_links = _stable_redacted_links(
         request.evidence_links,
         "evidence_links",

--- a/tools/surrealdb/context_package_v2.py
+++ b/tools/surrealdb/context_package_v2.py
@@ -1,0 +1,331 @@
+"""Context Package v2 — side-effect-free domain component.
+
+Issues:
+    #2798 — [PHASE-2][SURREALDB][SLICE-2] Context Package v2
+    Parent: #2778 (Phase-2 epic)
+    Epic: #1976
+
+Scope:
+    Build a governed agent handoff envelope from in-memory package ingredients.
+    Deterministic multi-artifact hashing, redaction, and guardrails.
+    No DB access. No SurrealDB SDK. No MCP. No networking. No file writes.
+
+Guardrails:
+    - Context Package is orientation, not authorization.
+    - LR remains NO-GO; no Live-Go; no Echtgeld-Go.
+    - No automatic code or issue action from package output.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from core.replay.canonical_json import canonical_hash, canonical_json_dumps
+from core.utils.clock import utcnow
+
+SCHEMA_VERSION = "context-package/v2"
+
+DEFAULT_SOURCE_PRIORITY: tuple[str, ...] = (
+    "github_live",
+    "repo_live",
+    "verified_context_db_mcp_evidence",
+    "canonical_governance_files",
+    "ledger_files",
+    "memory",
+)
+
+GUARDRAILS: tuple[str, ...] = (
+    "Context Package is orientation, not authorization.",
+    "LR remains NO-GO; no Live-Go.",
+    "No Echtgeld-Go.",
+    "No automatic code or issue action from package output.",
+    "No DB-backed claim without tool/query/record evidence.",
+)
+
+_SENSITIVE_KEY_RE = re.compile(
+    r"(token|secret|password|api[_-]?key|credential|private[_-]?key|auth)",
+    re.IGNORECASE,
+)
+
+_SECRET_VALUE_RE = re.compile(
+    r"(Bearer\s+\S+|sk-[A-Za-z0-9_-]{8,}|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)",
+    re.IGNORECASE,
+)
+
+_TRANSIENT_ARTIFACT_FIELDS = frozenset(
+    {
+        "generated_at",
+        "created_at",
+        "updated_at",
+        "as_of",
+    }
+)
+
+
+class ContextPackageV2Error(ValueError):
+    """Raised when package inputs are invalid or unsafe."""
+
+
+@dataclass(frozen=True)
+class ContextPackageV2Request:
+    target_scope: str
+    artifacts: Sequence[Mapping[str, Any]]
+    required_reads: Sequence[Mapping[str, Any]] | None = None
+    ranked_context: Mapping[str, Any] | None = None
+    evidence_links: Sequence[Mapping[str, Any]] | None = None
+    decision_replay_links: Sequence[Mapping[str, Any]] | None = None
+    source_priority: Sequence[str] | None = None
+    generated_at_or_as_of: str | None = None
+
+
+def _utc_now_iso() -> str:
+    return utcnow().isoformat()
+
+
+def _as_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    return str(value).strip() or None
+
+
+def _is_sensitive_key(key: str) -> bool:
+    return bool(_SENSITIVE_KEY_RE.search(key))
+
+
+def _looks_like_secret_value(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    return bool(_SECRET_VALUE_RE.search(value.strip()))
+
+
+def _redact_value(
+    key: str,
+    value: Any,
+    path: str,
+    summary: list[dict[str, str]],
+) -> Any:
+    if _is_sensitive_key(key) or _looks_like_secret_value(value):
+        summary.append(
+            {
+                "path": path,
+                "field": key,
+                "redaction_type": "sensitive_key"
+                if _is_sensitive_key(key)
+                else "secret_value_pattern",
+            }
+        )
+        return "[REDACTED]"
+    if isinstance(value, dict):
+        return _redact_mapping(value, path, summary)
+    if isinstance(value, list):
+        return [
+            _redact_value(key, item, f"{path}[{index}]", summary)
+            for index, item in enumerate(value)
+        ]
+    return value
+
+
+def _redact_mapping(
+    raw: Mapping[str, Any],
+    path: str,
+    summary: list[dict[str, str]],
+) -> dict[str, Any]:
+    redacted: dict[str, Any] = {}
+    for key, value in raw.items():
+        key_text = str(key)
+        if key_text.startswith("_"):
+            continue
+        child_path = f"{path}.{key_text}" if path else key_text
+        redacted[key_text] = _redact_value(key_text, value, child_path, summary)
+    return redacted
+
+
+def _artifact_sort_key(artifact: Mapping[str, Any]) -> tuple[str, str, str]:
+    artifact_id = _as_str(artifact.get("artifact_id")) or _as_str(artifact.get("id")) or ""
+    artifact_type = _as_str(artifact.get("artifact_type")) or _as_str(artifact.get("type")) or ""
+    payload = dict(artifact)
+    for transient in _TRANSIENT_ARTIFACT_FIELDS:
+        payload.pop(transient, None)
+    return (artifact_id, artifact_type, canonical_json_dumps(payload))
+
+
+def _normalize_artifact(artifact: Mapping[str, Any]) -> dict[str, Any]:
+    artifact_id = _as_str(artifact.get("artifact_id")) or _as_str(artifact.get("id"))
+    artifact_type = _as_str(artifact.get("artifact_type")) or _as_str(artifact.get("type"))
+    if not artifact_id:
+        raise ContextPackageV2Error("each artifact must include artifact_id or id")
+    if not artifact_type:
+        raise ContextPackageV2Error(
+            f"artifact '{artifact_id}' must include artifact_type or type"
+        )
+    normalized = dict(artifact)
+    normalized["artifact_id"] = artifact_id
+    normalized["artifact_type"] = artifact_type
+    return normalized
+
+
+def _artifact_hash_payload(redacted_artifact: Mapping[str, Any]) -> dict[str, Any]:
+    payload = dict(redacted_artifact)
+    for transient in _TRANSIENT_ARTIFACT_FIELDS:
+        payload.pop(transient, None)
+    for key in list(payload):
+        if str(key).startswith("_"):
+            payload.pop(key, None)
+    return payload
+
+
+def _stable_required_reads(
+    required_reads: Sequence[Mapping[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    if not required_reads:
+        return []
+    normalized = [dict(item) for item in required_reads]
+    return sorted(
+        normalized,
+        key=lambda item: (
+            _as_str(item.get("path")) or "",
+            _as_str(item.get("priority")) or "",
+            canonical_json_dumps(item),
+        ),
+    )
+
+
+def _stable_links(links: Sequence[Mapping[str, Any]] | None) -> list[dict[str, Any]]:
+    if not links:
+        return []
+    normalized = [dict(item) for item in links]
+    return sorted(
+        normalized,
+        key=lambda item: (
+            _as_str(item.get("ref")) or _as_str(item.get("id")) or "",
+            canonical_json_dumps(item),
+        ),
+    )
+
+
+def _fingerprint(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        if not value:
+            return None
+        return canonical_hash(value)
+    if isinstance(value, dict):
+        if not value:
+            return None
+        return canonical_hash(value)
+    return canonical_hash(value)
+
+
+def _dedupe_redaction_summary(
+    summary: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    seen: set[tuple[str, str, str]] = set()
+    deduped: list[dict[str, str]] = []
+    for entry in summary:
+        key = (
+            entry.get("path", ""),
+            entry.get("field", ""),
+            entry.get("redaction_type", ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(entry)
+    return sorted(deduped, key=lambda item: (item.get("path", ""), item.get("field", "")))
+
+
+def build_context_package_v2(request: ContextPackageV2Request) -> dict[str, Any]:
+    """Build a Context Package v2 envelope from in-memory ingredients."""
+    target_scope = _as_str(request.target_scope)
+    if not target_scope:
+        raise ContextPackageV2Error("target_scope is required")
+
+    if not request.artifacts:
+        raise ContextPackageV2Error("artifacts must be a non-empty sequence")
+
+    source_priority = list(request.source_priority or DEFAULT_SOURCE_PRIORITY)
+    generated_at_or_as_of = request.generated_at_or_as_of or _utc_now_iso()
+
+    redaction_summary: list[dict[str, str]] = []
+    limitations: list[str] = []
+
+    normalized_artifacts = [_normalize_artifact(item) for item in request.artifacts]
+    sorted_artifacts = sorted(normalized_artifacts, key=_artifact_sort_key)
+
+    redacted_artifacts: list[dict[str, Any]] = []
+    artifact_hashes: list[str] = []
+    for index, artifact in enumerate(sorted_artifacts):
+        redacted = _redact_mapping(artifact, f"artifacts[{index}]", redaction_summary)
+        redacted_artifacts.append(redacted)
+        artifact_hashes.append(canonical_hash(_artifact_hash_payload(redacted)))
+
+    required_reads = _stable_required_reads(request.required_reads)
+    evidence_links = _stable_links(request.evidence_links)
+    decision_replay_links = _stable_links(request.decision_replay_links)
+
+    ranked_context: dict[str, Any] | None = None
+    if request.ranked_context is not None:
+        ranked_context = _redact_mapping(
+            request.ranked_context,
+            "ranked_context",
+            redaction_summary,
+        )
+    else:
+        limitations.append("ranked_context_not_provided")
+
+    if not decision_replay_links:
+        limitations.append("decision_replay_links_not_provided")
+    elif all(
+        not _as_str(item.get("replay_id")) and not _as_str(item.get("content_hash"))
+        for item in decision_replay_links
+    ):
+        limitations.append("decision_replay_links_refs_only")
+
+    if not evidence_links:
+        limitations.append("evidence_links_not_provided")
+    elif all(
+        item.get("verified") is not True and not _as_str(item.get("content_hash"))
+        for item in evidence_links
+    ):
+        limitations.append("evidence_links_unverified")
+
+    hash_input = {
+        "schema_version": SCHEMA_VERSION,
+        "target_scope": target_scope,
+        "source_priority": source_priority,
+        "required_reads": required_reads,
+        "artifact_hashes": artifact_hashes,
+        "ranked_context_fingerprint": _fingerprint(ranked_context),
+        "evidence_links_fingerprint": _fingerprint(evidence_links),
+        "decision_replay_links_fingerprint": _fingerprint(decision_replay_links),
+    }
+    content_hash = canonical_hash(hash_input)
+    package_id = f"pkg_{content_hash[:12]}"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "package_id": package_id,
+        "generated_at_or_as_of": generated_at_or_as_of,
+        "target_scope": target_scope,
+        "source_priority": source_priority,
+        "required_reads": required_reads,
+        "artifacts": redacted_artifacts,
+        "ranked_context": ranked_context,
+        "evidence_links": evidence_links,
+        "decision_replay_links": decision_replay_links,
+        "redaction_summary": _dedupe_redaction_summary(redaction_summary),
+        "limitations": sorted(set(limitations)),
+        "guardrails": list(GUARDRAILS),
+        "determinism": {
+            "hash_algorithm": "canonical_sha256",
+            "wall_clock_excluded": True,
+            "artifact_count": len(redacted_artifacts),
+            "content_hash": content_hash,
+        },
+    }

--- a/tools/surrealdb/context_package_v2.py
+++ b/tools/surrealdb/context_package_v2.py
@@ -54,6 +54,11 @@ _SECRET_VALUE_RE = re.compile(
     re.IGNORECASE,
 )
 
+_URL_QUERY_SECRET_RE = re.compile(
+    r"[?&](?:token|api[_-]?key|secret|password|credential|auth)=[^&\s#\"']+",
+    re.IGNORECASE,
+)
+
 _TRANSIENT_ARTIFACT_FIELDS = frozenset(
     {
         "generated_at",
@@ -100,7 +105,19 @@ def _is_sensitive_key(key: str) -> bool:
 def _looks_like_secret_value(value: Any) -> bool:
     if not isinstance(value, str):
         return False
-    return bool(_SECRET_VALUE_RE.search(value.strip()))
+    text = value.strip()
+    if not text:
+        return False
+    return bool(_SECRET_VALUE_RE.search(text) or _URL_QUERY_SECRET_RE.search(text))
+
+
+def _safe_summary_path_segment(value: Any, *, fallback: str) -> str:
+    text = _as_str(value)
+    if not text:
+        return fallback
+    if _looks_like_secret_value(text):
+        return fallback
+    return text
 
 
 def _redact_value(
@@ -198,33 +215,52 @@ def _artifact_hash_payload(redacted_artifact: Mapping[str, Any]) -> dict[str, An
     return payload
 
 
-def _stable_required_reads(
+def _redacted_link_sort_key(redacted_link: Mapping[str, Any]) -> tuple[str, str]:
+    ref = _as_str(redacted_link.get("ref")) or _as_str(redacted_link.get("id")) or ""
+    return ref, canonical_json_dumps(dict(redacted_link))
+
+
+def _stable_redacted_links(
+    links: Sequence[Mapping[str, Any]] | None,
+    path_prefix: str,
+    summary: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    if not links:
+        return []
+    redacted_candidates = [
+        _redact_mapping(
+            dict(item),
+            f"{path_prefix}[{_safe_summary_path_segment(_as_str(item.get('ref')) or _as_str(item.get('id')), fallback=str(index))}]",
+            summary,
+        )
+        for index, item in enumerate(links)
+    ]
+    return sorted(redacted_candidates, key=_redacted_link_sort_key)
+
+
+def _redacted_required_read_sort_key(redacted_read: Mapping[str, Any]) -> tuple[str, str, str]:
+    return (
+        _as_str(redacted_read.get("path")) or "",
+        _as_str(redacted_read.get("priority")) or "",
+        canonical_json_dumps(dict(redacted_read)),
+    )
+
+
+def _stable_redacted_required_reads(
     required_reads: Sequence[Mapping[str, Any]] | None,
+    summary: list[dict[str, str]],
 ) -> list[dict[str, Any]]:
     if not required_reads:
         return []
-    normalized = [dict(item) for item in required_reads]
-    return sorted(
-        normalized,
-        key=lambda item: (
-            _as_str(item.get("path")) or "",
-            _as_str(item.get("priority")) or "",
-            canonical_json_dumps(item),
-        ),
-    )
-
-
-def _stable_links(links: Sequence[Mapping[str, Any]] | None) -> list[dict[str, Any]]:
-    if not links:
-        return []
-    normalized = [dict(item) for item in links]
-    return sorted(
-        normalized,
-        key=lambda item: (
-            _as_str(item.get("ref")) or _as_str(item.get("id")) or "",
-            canonical_json_dumps(item),
-        ),
-    )
+    redacted_candidates = [
+        _redact_mapping(
+            dict(item),
+            f"required_reads[{_as_str(item.get('path')) or index}]",
+            summary,
+        )
+        for index, item in enumerate(required_reads)
+    ]
+    return sorted(redacted_candidates, key=_redacted_required_read_sort_key)
 
 
 def _fingerprint(value: Any) -> str | None:
@@ -239,18 +275,6 @@ def _fingerprint(value: Any) -> str | None:
             return None
         return canonical_hash(value)
     return canonical_hash(value)
-
-
-def _stable_redacted_links(
-    links: Sequence[Mapping[str, Any]] | None,
-    path_prefix: str,
-    summary: list[dict[str, str]],
-) -> list[dict[str, Any]]:
-    stable = _stable_links(links)
-    return [
-        _redact_mapping(item, f"{path_prefix}[{index}]", summary)
-        for index, item in enumerate(stable)
-    ]
 
 
 def build_context_package_v2(request: ContextPackageV2Request) -> dict[str, Any]:
@@ -286,11 +310,10 @@ def build_context_package_v2(request: ContextPackageV2Request) -> dict[str, Any]
         redacted_artifacts.append(redacted)
         artifact_hashes.append(canonical_hash(_artifact_hash_payload(redacted)))
 
-    required_reads_stable = _stable_required_reads(request.required_reads)
-    required_reads = [
-        _redact_mapping(item, f"required_reads[{index}]", redaction_summary)
-        for index, item in enumerate(required_reads_stable)
-    ]
+    required_reads = _stable_redacted_required_reads(
+        request.required_reads,
+        redaction_summary,
+    )
     evidence_links = _stable_redacted_links(
         request.evidence_links,
         "evidence_links",

--- a/tools/surrealdb/context_package_v2.py
+++ b/tools/surrealdb/context_package_v2.py
@@ -222,6 +222,18 @@ def _fingerprint(value: Any) -> str | None:
     return canonical_hash(value)
 
 
+def _stable_redacted_links(
+    links: Sequence[Mapping[str, Any]] | None,
+    path_prefix: str,
+    summary: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    stable = _stable_links(links)
+    return [
+        _redact_mapping(item, f"{path_prefix}[{index}]", summary)
+        for index, item in enumerate(stable)
+    ]
+
+
 def _dedupe_redaction_summary(
     summary: list[dict[str, str]],
 ) -> list[dict[str, str]]:
@@ -266,8 +278,16 @@ def build_context_package_v2(request: ContextPackageV2Request) -> dict[str, Any]
         artifact_hashes.append(canonical_hash(_artifact_hash_payload(redacted)))
 
     required_reads = _stable_required_reads(request.required_reads)
-    evidence_links = _stable_links(request.evidence_links)
-    decision_replay_links = _stable_links(request.decision_replay_links)
+    evidence_links = _stable_redacted_links(
+        request.evidence_links,
+        "evidence_links",
+        redaction_summary,
+    )
+    decision_replay_links = _stable_redacted_links(
+        request.decision_replay_links,
+        "decision_replay_links",
+        redaction_summary,
+    )
 
     ranked_context: dict[str, Any] | None = None
     if request.ranked_context is not None:

--- a/tools/surrealdb/context_package_v2.py
+++ b/tools/surrealdb/context_package_v2.py
@@ -145,13 +145,32 @@ def _redact_mapping(
     return redacted
 
 
-def _artifact_sort_key(artifact: Mapping[str, Any]) -> tuple[str, str, str]:
-    artifact_id = _as_str(artifact.get("artifact_id")) or _as_str(artifact.get("id")) or ""
-    artifact_type = _as_str(artifact.get("artifact_type")) or _as_str(artifact.get("type")) or ""
-    payload = dict(artifact)
-    for transient in _TRANSIENT_ARTIFACT_FIELDS:
-        payload.pop(transient, None)
-    return (artifact_id, artifact_type, canonical_json_dumps(payload))
+def _redacted_artifact_sort_key(redacted_artifact: Mapping[str, Any]) -> tuple[str, str, str]:
+    artifact_id = _as_str(redacted_artifact.get("artifact_id")) or ""
+    artifact_type = _as_str(redacted_artifact.get("artifact_type")) or ""
+    return (
+        artifact_id,
+        artifact_type,
+        canonical_json_dumps(_artifact_hash_payload(redacted_artifact)),
+    )
+
+
+def _dedupe_redaction_summary(
+    summary: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    seen: set[tuple[str, str, str]] = set()
+    deduped: list[dict[str, str]] = []
+    for entry in summary:
+        key = (
+            entry.get("path", ""),
+            entry.get("field", ""),
+            entry.get("redaction_type", ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(entry)
+    return sorted(deduped, key=lambda item: (item.get("path", ""), item.get("field", "")))
 
 
 def _normalize_artifact(artifact: Mapping[str, Any]) -> dict[str, Any]:
@@ -234,24 +253,6 @@ def _stable_redacted_links(
     ]
 
 
-def _dedupe_redaction_summary(
-    summary: list[dict[str, str]],
-) -> list[dict[str, str]]:
-    seen: set[tuple[str, str, str]] = set()
-    deduped: list[dict[str, str]] = []
-    for entry in summary:
-        key = (
-            entry.get("path", ""),
-            entry.get("field", ""),
-            entry.get("redaction_type", ""),
-        )
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(entry)
-    return sorted(deduped, key=lambda item: (item.get("path", ""), item.get("field", "")))
-
-
 def build_context_package_v2(request: ContextPackageV2Request) -> dict[str, Any]:
     """Build a Context Package v2 envelope from in-memory ingredients."""
     target_scope = _as_str(request.target_scope)
@@ -268,12 +269,20 @@ def build_context_package_v2(request: ContextPackageV2Request) -> dict[str, Any]
     limitations: list[str] = []
 
     normalized_artifacts = [_normalize_artifact(item) for item in request.artifacts]
-    sorted_artifacts = sorted(normalized_artifacts, key=_artifact_sort_key)
+    redacted_candidates: list[dict[str, Any]] = []
+    for artifact in normalized_artifacts:
+        artifact_id = artifact["artifact_id"]
+        redacted_candidates.append(
+            _redact_mapping(artifact, f"artifacts[{artifact_id}]", redaction_summary)
+        )
+    sorted_redacted_artifacts = sorted(
+        redacted_candidates,
+        key=_redacted_artifact_sort_key,
+    )
 
     redacted_artifacts: list[dict[str, Any]] = []
     artifact_hashes: list[str] = []
-    for index, artifact in enumerate(sorted_artifacts):
-        redacted = _redact_mapping(artifact, f"artifacts[{index}]", redaction_summary)
+    for redacted in sorted_redacted_artifacts:
         redacted_artifacts.append(redacted)
         artifact_hashes.append(canonical_hash(_artifact_hash_payload(redacted)))
 


### PR DESCRIPTION
Closes #2798
Refs #2778
Refs #1976
Refs #2797
Refs #2799
Refs #2800
Refs #2801

## Delivered
- Add `tools/surrealdb/context_package_v2.py`: governed v2 envelope builder with redaction, deterministic multi-artifact hashing, guardrails, and limitations for missing upstream inputs
- Add contract doc `docs/surrealdb/context-package-model-v2.md`
- Add unit tests and minimal fixture for v2 contract coverage
- Minimal briefing/runbook pointers to v2 schema (no MCP handler rewrite)

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- Repo crosscheck: v1 doc + MCP handler unchanged; canonical_hash from `core/replay/canonical_json.py`; redaction aligned with `decision_replay_builder` patterns

## Validation
- `git diff --check`
- `pytest -q tests/unit/surrealdb/test_context_package_v2.py` (12 passed)
- `pytest -q tests/unit/tools/mcp/test_context_package_handler.py tests/unit/tools/mcp/test_context_bridge.py -k "context_package or package"` (35 passed)
- `ruff check tools/surrealdb/context_package_v2.py tests/unit/surrealdb/test_context_package_v2.py`

## Non-goals
- No MCP `context.package` handler rewrite
- No productive SurrealDB writes; no scope to #2802/#2803/#2804
- No Visual Control Room / managed runtime decision work

## Safety Boundaries
- LR remains NO-GO
- PERSIST_ALLOWED=False / MUTATION_ALLOWED=False
- Package output is orientation, not authorization
- No secrets in outputs (`redaction_summary` records paths/types only)

## Restunsicherheiten
- Thin MCP adapter calling v2 builder deferred to follow-up outside #2798

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New handoff envelope and secret-redaction logic affect how agents consume context, but the slice is read-only with no MCP rewrite, DB writes, or authorization changes.
> 
> **Overview**
> Introduces **Context Package v2** (`context-package/v2`): a side-effect-free, in-memory envelope builder for governed agent handoffs, alongside a normative contract doc, fixture, and unit tests.
> 
> `build_context_package_v2` assembles required reads, redacted artifacts, optional ranked context / evidence / decision-replay links, default **source priority**, fixed **guardrails**, and **limitations** when upstream inputs are missing or only refs. **Deterministic** `package_id` and `content_hash` use canonical JSON hashing with stable artifact ordering; timestamps do not affect the id. **Redaction** masks sensitive keys and secret-like string patterns and records paths in `redaction_summary` without leaking values.
> 
> Docs only clarify that briefing `context_package_ref` may point at v2 `package_id`; the MCP runbook gains v2 references. **MCP `context.package` and v1 model are unchanged** (thin adapter deferred).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c32b494004fb9c7fd157b59189767c6822ac682a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->