### PR TITLE
fix(context): handle scope drift minimal bundles

### DIFF
--- a/tests/unit/surrealdb/test_scope_drift_firewall.py
+++ b/tests/unit/surrealdb/test_scope_drift_firewall.py
@@ -188,6 +188,25 @@ def test_invalid_bundle_list_raises() -> None:
         scan_scope_drift_v1([])  # type: ignore[arg-type]
 
 
+@pytest.mark.unit
+def test_declared_scope_string_label_no_attribute_error() -> None:
+    """#2844: plain-string declared_scope must not break rule evaluation."""
+    bundle = {
+        "declared_scope": "benchmark",
+        "touched_artifacts": [],
+        "issue_refs": [],
+    }
+    result = scan_scope_drift_v1(bundle, as_of=_AS_OF)
+    assert result.status == "ok"
+    assert len(result.findings) == 0
+
+
+@pytest.mark.unit
+def test_declared_scope_invalid_type_raises() -> None:
+    with pytest.raises(ScopeDriftFirewallError, match="declared_scope"):
+        scan_scope_drift_v1({"declared_scope": 42}, as_of=_AS_OF)
+
+
 # ── Deterministic IDs ─────────────────────────────────────────────────────────
 
 

--- a/tests/unit/tools/mcp/test_scope_drift_tools.py
+++ b/tests/unit/tools/mcp/test_scope_drift_tools.py
@@ -507,3 +507,93 @@ def test_no_db_no_network_no_write_bundle_write_keywords() -> None:
     # Must return a valid dict response (error or ok — no exception)
     assert isinstance(result, dict)
     assert "status" in result
+
+
+# ── 15. Benchmark #2 minimal bundles (#2844) ─────────────────────────────────
+
+
+def _bundle_benchmark_minimal() -> dict[str, Any]:
+    """Operator-style minimal bundle from Benchmark #2 live invocation."""
+    return {
+        "meta": {"scope_id": "bench", "level": "system"},
+        "declared_scope": "benchmark",
+        "touched_artifacts": [],
+        "issue_refs": [],
+        "generated_findings": [],
+        "forbidden_surfaces": [],
+    }
+
+
+def _bundle_valid_minimal_structured() -> dict[str, Any]:
+    """Structured declared_scope with explicit empty constraint lists."""
+    return {
+        "meta": {"scope_id": "bench", "as_of": _AS_OF},
+        "declared_scope": {
+            "target_paths": [],
+            "allowed_domains": [],
+        },
+        "touched_artifacts": [],
+        "issue_refs": [],
+        "generated_findings": [],
+        "forbidden_surfaces": [],
+    }
+
+
+@pytest.mark.unit
+def test_benchmark_minimal_bundle_no_scan_error() -> None:
+    """#2844: string declared_scope must not raise scan_error / AttributeError."""
+    result = handle_cdb_context_scope_drift(_request(_bundle_benchmark_minimal()))
+    assert result["status"] == "ok"
+    assert result.get("error") is None
+    assert result["scan_status"] == "ok"
+    assert result["summary"]["total_count"] == 0
+
+
+@pytest.mark.unit
+def test_benchmark_minimal_bundle_via_bridge() -> None:
+    """Bridge path matches direct handler for minimal benchmark bundle."""
+    bridge = ContextBridge()
+    result = bridge.execute_tool(
+        TOOL_CDB_CONTEXT_SCOPE_DRIFT,
+        {"bundle": _bundle_benchmark_minimal(), "as_of": _AS_OF},
+    )
+    assert result["status"] == "ok"
+    assert "scan_error" not in str(result.get("error", {}))
+
+
+@pytest.mark.unit
+def test_empty_bundle_lists_ok() -> None:
+    """Empty artifact lists with empty declared_scope object → ok, zero findings."""
+    result = handle_cdb_context_scope_drift(
+        _request(
+            {
+                "declared_scope": {},
+                "touched_artifacts": [],
+                "issue_refs": [],
+                "generated_findings": [],
+                "forbidden_surfaces": [],
+            }
+        )
+    )
+    assert result["status"] == "ok"
+    assert result["summary"]["total_count"] == 0
+
+
+@pytest.mark.unit
+def test_malformed_declared_scope_type_returns_invalid_bundle() -> None:
+    """Non-string/non-mapping declared_scope → invalid_bundle, not scan_error."""
+    result = handle_cdb_context_scope_drift(
+        _request({"declared_scope": ["not", "a", "mapping"]})
+    )
+    assert result["status"] == "error"
+    assert result["error"]["code"] == "invalid_bundle"
+    assert "declared_scope" in result["error"]["message"]
+
+
+@pytest.mark.unit
+def test_valid_minimal_structured_bundle_deterministic() -> None:
+    """Structured minimal bundle returns stable ok response with explicit as_of."""
+    result = handle_cdb_context_scope_drift(_request(_bundle_valid_minimal_structured()))
+    assert result["status"] == "ok"
+    assert result["scanned_at"] == _AS_OF
+    assert result["summary"]["total_count"] == 0

--- a/tools/surrealdb/scope_drift_firewall.py
+++ b/tools/surrealdb/scope_drift_firewall.py
@@ -240,6 +240,36 @@ def _as_list(value: Any) -> list[Any]:
     return [value]
 
 
+def _declared_scope_mapping(bundle: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Normalize declared_scope for rule evaluation (fail-closed, no AttributeError).
+
+    Operator/benchmark bundles may pass a plain scope label string instead of a
+    structured object. A non-empty string means "label only" with no path/issue
+    constraints — rules that require target_paths or allowed_domains stay inactive.
+    """
+    raw = bundle.get("declared_scope")
+    if raw is None:
+        return {}
+    if isinstance(raw, Mapping):
+        return raw
+    if isinstance(raw, str):
+        return {}
+    raise ScopeDriftFirewallError(
+        "declared_scope must be a mapping/object or scope label string, "
+        f"got {type(raw).__name__}"
+    )
+
+
+def _meta_mapping(bundle: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Normalize meta to a mapping; ignore non-mapping values (no path constraints)."""
+    raw = bundle.get("meta")
+    if raw is None:
+        return {}
+    if isinstance(raw, Mapping):
+        return raw
+    return {}
+
+
 def _make_finding(
     *,
     drift_type: str,
@@ -314,7 +344,7 @@ def _rule_path_out_of_scope(
         touched_artifacts[].path: str
     """
     findings: list[ScopeDriftFinding] = []
-    declared_scope = bundle.get("declared_scope") or {}
+    declared_scope = _declared_scope_mapping(bundle)
     target_paths = _as_list(declared_scope.get("target_paths"))
     touched = _as_list(bundle.get("touched_artifacts"))
 
@@ -363,7 +393,7 @@ def _rule_domain_out_of_scope(
         touched_artifacts[].surface_type: str
     """
     findings: list[ScopeDriftFinding] = []
-    declared_scope = bundle.get("declared_scope") or {}
+    declared_scope = _declared_scope_mapping(bundle)
     allowed_domains = _as_list(declared_scope.get("allowed_domains"))
     touched = _as_list(bundle.get("touched_artifacts"))
 
@@ -412,7 +442,7 @@ def _rule_issue_out_of_scope(
         issue_refs[].label: str  — optional
     """
     findings: list[ScopeDriftFinding] = []
-    declared_scope = bundle.get("declared_scope") or {}
+    declared_scope = _declared_scope_mapping(bundle)
     target_issue = _as_str(declared_scope.get("target_issue"))
     allowed_issues_raw = _as_list(declared_scope.get("allowed_issues"))
     issue_refs = _as_list(bundle.get("issue_refs"))
@@ -659,7 +689,7 @@ def _rule_unexpected_dependency_expansion(
         touched_artifacts: list[dict]
     """
     findings: list[ScopeDriftFinding] = []
-    declared_scope = bundle.get("declared_scope") or {}
+    declared_scope = _declared_scope_mapping(bundle)
     touched = _as_list(bundle.get("touched_artifacts"))
     target_paths = _as_list(declared_scope.get("target_paths"))
 
@@ -775,7 +805,7 @@ def _rule_missing_human_go(
         meta.human_go_token: str | None  — explicit GO token
     """
     findings: list[ScopeDriftFinding] = []
-    meta = bundle.get("meta") or {}
+    meta = _meta_mapping(bundle)
     operation_mode = _as_str(meta.get("operation_mode")) or ""
     human_go_token = _as_str(meta.get("human_go_token"))
 


### PR DESCRIPTION
## Summary

Closes #2844. Refs #2847. Refs #2845.

Fixes the only Benchmark #2 **FAIL**: `cdb_context_scope_drift` no longer returns `scan_error` / `AttributeError` when `declared_scope` is a plain scope label string (minimal operator bundle).

## Repro

```python
from tools.mcp.context_bridge import create_bridge
b = create_bridge()
r = b.execute_tool(
    "cdb_context_scope_drift",
    {
        "bundle": {
            "meta": {"scope_id": "bench", "level": "system"},
            "declared_scope": "benchmark",
            "touched_artifacts": [],
            "issue_refs": [],
            "generated_findings": [],
            "forbidden_surfaces": [],
        }
    },
)
# Before: status=error, error.code=scan_error, AttributeError
# After: status=ok, scan_status=ok, zero findings
```

## Root Cause

`bundle.get("declared_scope") or {}` kept a non-empty **string** (truthy), so rules called `.get()` on a `str` → `AttributeError`, surfaced as `scan_error` by the MCP adapter.

## Delivered

- `_declared_scope_mapping()` / `_meta_mapping()` in `scope_drift_firewall.py`
- String scope labels → empty constraint mapping (no path rules fire → ok, zero findings)
- Invalid `declared_scope` types → `ScopeDriftFirewallError` → MCP `invalid_bundle`
- Unit tests for minimal/empty/malformed/structured bundles (#2844)

## Validation

- `pytest -q tests/unit/tools/mcp/test_scope_drift_tools.py -m unit` — 37 passed
- `pytest -q tests/unit/surrealdb/test_scope_drift_firewall.py -m unit` — 63 passed
- `pytest -q tests/unit/tools/mcp/ -m unit` — 862 passed
- Live repro via `ContextBridge.execute_tool` → `status=ok`
- `git diff --check` — clean

## Safety Boundaries

- Read-only tool path unchanged; no DB/MCP mutations
- `PERSIST_ALLOWED` / `MUTATION_ALLOWED` unchanged
- LR remains NO-GO; no live-go semantics added

## Non-goals

- #2848 cwd semantics, #2849 regression harness, #2852 PASS_WITH_LIMITS ratification
- Full Benchmark #2 re-run
- Registry handler still stub (bridge path is canonical)

## Restunsicherheiten

- String `declared_scope` is treated as label-only (no drift rules); structured object still required for path/issue constraints
