### PR TITLE
fix(context): normalize readiness root cwd semantics

### DIFF
--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -962,29 +962,36 @@ class TestContextReadinessHandler:
             for m in result["readiness"]["missing_context"]
         )
 
-    def test_missing_required_reads_returns_blocked_missing_context(self) -> None:
-        """Missing minimum required reads blocks."""
+    def test_missing_canon_on_effective_scan_root_blocks(self, tmp_path) -> None:
+        """Missing minimum canon files at effective_scan_root blocks (#2848)."""
+        (tmp_path / "AGENTS.md").write_text("pointer\n", encoding="utf-8")
         bridge = create_bridge()
         result = bridge.execute_tool(
             "context.readiness",
             {
                 "task_scope": "Inspect the risk engine.",
                 "operation_mode": "read_only",
+                "stop_conditions": ["S1: unit test"],
+                "repo_root": str(tmp_path),
                 "required_reads": ["AGENTS.md"],
             },
         )
         assert result["readiness"]["status"] == "blocked_missing_context"
         missing = result["readiness"]["missing_context"]
-        assert any("minimum required reads missing" in m for m in missing)
+        assert any("effective_scan_root" in m for m in missing)
 
-    def test_no_context_package_and_no_reads_blocks(self) -> None:
-        """No context package and no required reads blocks."""
+    def test_no_context_package_and_no_reads_blocks_without_canon_on_disk(
+        self, tmp_path
+    ) -> None:
+        """No package, empty required_reads, and no canon on scan root blocks."""
         bridge = create_bridge()
         result = bridge.execute_tool(
             "context.readiness",
             {
                 "task_scope": "Refactor something.",
                 "operation_mode": "read_only",
+                "stop_conditions": ["S1: unit test"],
+                "repo_root": str(tmp_path),
             },
         )
         assert result["readiness"]["status"] == "blocked_missing_context"

--- a/tests/unit/tools/mcp/test_context_readiness_root.py
+++ b/tests/unit/tools/mcp/test_context_readiness_root.py
@@ -133,7 +133,9 @@ def test_missing_canon_on_scan_root_blocks_fail_closed(
 
 def test_invalid_repo_root_parameter_blocks() -> None:
     readiness = _readiness(
-        context_readiness_handler(**_base_kwargs(repo_root="/nonexistent/cdb/repo/root"))
+        context_readiness_handler(
+            **_base_kwargs(repo_root="/nonexistent/cdb/repo/root")
+        )
     )
     assert readiness["status"] == "blocked_missing_context"
     assert readiness["drift_severity"] == "blocked"

--- a/tests/unit/tools/mcp/test_context_readiness_root.py
+++ b/tests/unit/tools/mcp/test_context_readiness_root.py
@@ -1,0 +1,156 @@
+"""Unit tests for context.readiness host cwd vs repo root semantics (#2848)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.unit.tools.mcp.fixtures.context_fixtures import MINIMUM_REQUIRED_READS
+from tools.mcp.context_bridge import (
+    READINESS_MINIMUM_READS,
+    context_readiness_handler,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _base_kwargs(**overrides) -> dict:
+    payload = {
+        "task_scope": "normalize readiness root cwd semantics",
+        "operation_mode": "read_only",
+        "stop_conditions": ["S1: unit test scope"],
+        "required_reads": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _readiness(result: dict) -> dict:
+    assert result.get("tool") == "context.readiness"
+    assert result.get("status") == "ok"
+    readiness = result.get("readiness")
+    assert isinstance(readiness, dict)
+    return readiness
+
+
+def _assert_root_fields(readiness: dict) -> None:
+    for key in (
+        "host_cwd",
+        "resolved_repo_root",
+        "effective_scan_root",
+        "root_source",
+        "cwd_matches_repo_root",
+        "root_drift_detected",
+        "drift_severity",
+        "limitations",
+        "evidence",
+    ):
+        assert key in readiness, f"missing root field: {key}"
+
+
+@pytest.fixture
+def mini_repo(tmp_path: Path) -> Path:
+    for rel in READINESS_MINIMUM_READS:
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(f"fixture for {rel}\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_matching_cwd_and_repo_root_passes_without_required_reads_param(
+    mini_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(mini_repo)
+    readiness = _readiness(
+        context_readiness_handler(**_base_kwargs(repo_root=str(mini_repo)))
+    )
+    _assert_root_fields(readiness)
+    assert readiness["cwd_matches_repo_root"] is True
+    assert readiness["root_drift_detected"] is False
+    assert readiness["drift_severity"] == "none"
+    assert readiness["status"] == "ready_for_read_only"
+    assert readiness["effective_scan_root"] == str(mini_repo.resolve())
+
+
+def test_host_cwd_drift_with_explicit_repo_root_scans_repo(
+    mini_repo: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    other_cwd = tmp_path / "host_cwd"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+    readiness = _readiness(
+        context_readiness_handler(
+            **_base_kwargs(repo_root=str(mini_repo)),
+        )
+    )
+    _assert_root_fields(readiness)
+    assert readiness["root_drift_detected"] is True
+    assert readiness["drift_severity"] == "warning"
+    assert readiness["cwd_matches_repo_root"] is False
+    assert readiness["effective_scan_root"] == str(mini_repo.resolve())
+    assert readiness["status"] == "ready_for_read_only"
+
+
+def test_host_cwd_drift_without_repo_root_uses_bridge_module_root(
+    repo_root: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    other_cwd = tmp_path / "outside_repo"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+    readiness = _readiness(context_readiness_handler(**_base_kwargs()))
+    _assert_root_fields(readiness)
+    assert readiness["resolved_repo_root"] == str(repo_root.resolve())
+    assert readiness["effective_scan_root"] == str(repo_root.resolve())
+    if readiness["root_drift_detected"]:
+        assert readiness["drift_severity"] == "warning"
+    assert readiness["status"] == "ready_for_read_only"
+
+
+@pytest.fixture
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def test_missing_canon_on_scan_root_blocks_fail_closed(
+    mini_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    missing = READINESS_MINIMUM_READS[0]
+    (mini_repo / missing).unlink()
+    monkeypatch.chdir(mini_repo)
+    readiness = _readiness(
+        context_readiness_handler(
+            **_base_kwargs(
+                repo_root=str(mini_repo),
+                required_reads=list(MINIMUM_REQUIRED_READS),
+            ),
+        )
+    )
+    assert readiness["status"] == "blocked_missing_context"
+    assert any("effective_scan_root" in item for item in readiness["missing_context"])
+
+
+def test_invalid_repo_root_parameter_blocks() -> None:
+    readiness = _readiness(
+        context_readiness_handler(**_base_kwargs(repo_root="/nonexistent/cdb/repo/root"))
+    )
+    assert readiness["status"] == "blocked_missing_context"
+    assert readiness["drift_severity"] == "blocked"
+    assert readiness["effective_scan_root"] is None
+
+
+def test_benchmark_repro_empty_reads_ok_when_canon_on_module_root(
+    repo_root: Path,
+) -> None:
+    """MCP-style empty required_reads must not block when canon exists at repo root."""
+    if not all((repo_root / rel).is_file() for rel in READINESS_MINIMUM_READS):
+        pytest.skip("full working repo canon not present in this checkout")
+    original = os.getcwd()
+    try:
+        os.chdir(repo_root)
+        readiness = _readiness(context_readiness_handler(**_base_kwargs()))
+    finally:
+        os.chdir(original)
+    assert readiness["status"] == "ready_for_read_only"
+    assert readiness["root_drift_detected"] is False

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -93,7 +93,9 @@ def _canon_file_exists_at_root(scan_root: Path, repo_relative_path: str) -> bool
 def _missing_canon_reads_on_disk(
     scan_root: Path, minimum_reads: tuple[str, ...] = READINESS_MINIMUM_READS
 ) -> list[str]:
-    return [rel for rel in minimum_reads if not _canon_file_exists_at_root(scan_root, rel)]
+    return [
+        rel for rel in minimum_reads if not _canon_file_exists_at_root(scan_root, rel)
+    ]
 
 
 def _resolve_readiness_root_context(
@@ -139,7 +141,9 @@ def _resolve_readiness_root_context(
                     "cwd_matches_repo_root": False,
                     "root_drift_detected": True,
                     "drift_severity": "blocked",
-                    "limitations": [f"repo_root path resolution failed: {explicit_root!r}"],
+                    "limitations": [
+                        f"repo_root path resolution failed: {explicit_root!r}"
+                    ],
                     "evidence": [],
                     "resolution_error": "repo_root path resolution failed",
                 },
@@ -155,9 +159,7 @@ def _resolve_readiness_root_context(
                     "cwd_matches_repo_root": False,
                     "root_drift_detected": True,
                     "drift_severity": "blocked",
-                    "limitations": [
-                        f"repo_root is not a directory: {candidate}"
-                    ],
+                    "limitations": [f"repo_root is not a directory: {candidate}"],
                     "evidence": [],
                     "resolution_error": "repo_root is not a directory",
                 },
@@ -1523,9 +1525,10 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
             output_stop_conditions.append(
                 f"S3: minimum read unavailable at effective_scan_root: {r}"
             )
-    if root_context.get("root_drift_detected") and root_context.get(
-        "drift_severity"
-    ) == "warning":
+    if (
+        root_context.get("root_drift_detected")
+        and root_context.get("drift_severity") == "warning"
+    ):
         output_stop_conditions.append(
             "S3: host_cwd differs from resolved_repo_root — use effective_scan_root for canon reads"
         )
@@ -2049,8 +2052,7 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
         for rc in resolved:
             sc_type = rc.get("type", "")
             sc_text = (
-                f"{rc.get('severity', 'warning')}: {sc_type} — "
-                f"{rc.get('reason', '')}"
+                f"{rc.get('severity', 'warning')}: {sc_type} — {rc.get('reason', '')}"
             )
             if sc_text not in stop_conditions:
                 stop_conditions.append(sc_text)
@@ -2177,12 +2179,11 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
     known_risks.append("v0 briefing builder uses synthetic/mock package inputs")
     if readiness_status.startswith("blocked"):
         known_risks.append(
-            f"Readiness check blocked: {readiness_status}; "
-            f"briefing may be incomplete"
+            f"Readiness check blocked: {readiness_status}; briefing may be incomplete"
         )
     if not target_paths and not target_symbols:
         known_risks.append(
-            "no target_paths or target_symbols specified; " "context may be minimal"
+            "no target_paths or target_symbols specified; context may be minimal"
         )
 
     # --- Surface resolver failure ---

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -13,6 +13,7 @@ Reference:
 import logging
 import json
 import hashlib
+import os
 from copy import deepcopy
 from pathlib import Path, PurePosixPath
 import re
@@ -63,6 +64,144 @@ def _normalize_repo_relative_path(path_value: str) -> str | None:
 
 def _repo_relative_file_exists(repo_relative_path: str) -> bool:
     return (REPO_ROOT / repo_relative_path).is_file()
+
+
+READINESS_MINIMUM_READS: tuple[str, ...] = (
+    "AGENTS.md",
+    "agents/AGENTS.md",
+    "agents/OPEN_CODE_AGENTS.md",
+    "docs/runbooks/CONTROL_REGISTER.md",
+    "CURRENT_STATUS.md",
+    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+)
+
+
+def _paths_same_dir(left: Path, right: Path) -> bool:
+    try:
+        return os.path.samefile(left, right)
+    except OSError:
+        return left.resolve() == right.resolve()
+
+
+def _canon_file_exists_at_root(scan_root: Path, repo_relative_path: str) -> bool:
+    normalized = _normalize_repo_relative_path(repo_relative_path)
+    if normalized is None:
+        return False
+    return (scan_root / normalized).is_file()
+
+
+def _missing_canon_reads_on_disk(
+    scan_root: Path, minimum_reads: tuple[str, ...] = READINESS_MINIMUM_READS
+) -> list[str]:
+    return [rel for rel in minimum_reads if not _canon_file_exists_at_root(scan_root, rel)]
+
+
+def _resolve_readiness_root_context(
+    kwargs: dict[str, Any],
+) -> tuple[dict[str, Any], Path | None]:
+    """Resolve host cwd vs repo root for readiness; fail-closed on invalid explicit root."""
+    host_cwd = Path.cwd().resolve()
+    limitations: list[str] = []
+    evidence: list[str] = []
+
+    root_source = "bridge_module"
+    resolved_repo_root = REPO_ROOT.resolve()
+
+    explicit_root = kwargs.get("repo_root")
+    if explicit_root is not None:
+        if not isinstance(explicit_root, str) or not explicit_root.strip():
+            return (
+                {
+                    "host_cwd": str(host_cwd),
+                    "resolved_repo_root": None,
+                    "effective_scan_root": None,
+                    "root_source": "parameter_invalid",
+                    "cwd_matches_repo_root": False,
+                    "root_drift_detected": True,
+                    "drift_severity": "blocked",
+                    "limitations": [
+                        "repo_root parameter must be a non-empty string path to a directory"
+                    ],
+                    "evidence": [],
+                    "resolution_error": "invalid repo_root parameter",
+                },
+                None,
+            )
+        try:
+            candidate = Path(explicit_root.strip()).resolve()
+        except OSError:
+            return (
+                {
+                    "host_cwd": str(host_cwd),
+                    "resolved_repo_root": None,
+                    "effective_scan_root": None,
+                    "root_source": "parameter_invalid",
+                    "cwd_matches_repo_root": False,
+                    "root_drift_detected": True,
+                    "drift_severity": "blocked",
+                    "limitations": [f"repo_root path resolution failed: {explicit_root!r}"],
+                    "evidence": [],
+                    "resolution_error": "repo_root path resolution failed",
+                },
+                None,
+            )
+        if not candidate.is_dir():
+            return (
+                {
+                    "host_cwd": str(host_cwd),
+                    "resolved_repo_root": str(candidate),
+                    "effective_scan_root": None,
+                    "root_source": "parameter_invalid",
+                    "cwd_matches_repo_root": False,
+                    "root_drift_detected": True,
+                    "drift_severity": "blocked",
+                    "limitations": [
+                        f"repo_root is not a directory: {candidate}"
+                    ],
+                    "evidence": [],
+                    "resolution_error": "repo_root is not a directory",
+                },
+                None,
+            )
+        resolved_repo_root = candidate
+        root_source = "parameter"
+        evidence.append("repo_root parameter applied")
+
+    effective_scan_root = resolved_repo_root
+    cwd_matches_repo_root = _paths_same_dir(host_cwd, resolved_repo_root)
+    root_drift_detected = not cwd_matches_repo_root
+    drift_severity = "none"
+    if root_drift_detected:
+        drift_severity = "warning"
+        limitations.append(
+            "host_cwd differs from resolved_repo_root; canon file checks use "
+            f"effective_scan_root={effective_scan_root}"
+        )
+        evidence.append(f"host_cwd={host_cwd}")
+        evidence.append(f"resolved_repo_root={resolved_repo_root}")
+
+    return (
+        {
+            "host_cwd": str(host_cwd),
+            "resolved_repo_root": str(resolved_repo_root),
+            "effective_scan_root": str(effective_scan_root),
+            "root_source": root_source,
+            "cwd_matches_repo_root": cwd_matches_repo_root,
+            "root_drift_detected": root_drift_detected,
+            "drift_severity": drift_severity,
+            "limitations": limitations,
+            "evidence": evidence,
+        },
+        effective_scan_root,
+    )
+
+
+def _readiness_payload_with_root(
+    readiness: dict[str, Any], root_context: dict[str, Any]
+) -> dict[str, Any]:
+    merged = dict(readiness)
+    merged.update(root_context)
+    return merged
 
 
 def _infer_handler_status(tool_def: ToolDefinition) -> str:
@@ -1176,7 +1315,35 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
     docs/surrealdb/context-action-readiness-contract.md
 
     Pure in-process evaluation. No DB/network. Fail-closed.
+    Canon minimum reads are verified on effective_scan_root (resolved repo root),
+    not on host_cwd alone. Host/repo drift is surfaced explicitly (#2848).
     """
+    root_context, effective_scan_root = _resolve_readiness_root_context(kwargs)
+    if effective_scan_root is None:
+        resolution_error = root_context.get("resolution_error", "repo root unresolved")
+        return {
+            "tool": "context.readiness",
+            "status": "ok",
+            "readiness": _readiness_payload_with_root(
+                {
+                    "status": "blocked_missing_context",
+                    "reasons": ["Repo root could not be resolved for readiness"],
+                    "required_next_reads": list(READINESS_MINIMUM_READS),
+                    "human_go_required": False,
+                    "stop_conditions": [f"S3: {resolution_error}"],
+                    "missing_context": [resolution_error],
+                    "missing_evidence": [],
+                    "scope_drift_findings": [],
+                    "uncertainties": [],
+                    "guardrails": [
+                        "Do not proceed. Resolve repo root before claiming repo-backed context.",
+                        "Readiness is not authorization. LR remains NO-GO. Board stage (trade-capable) is orthogonal.",
+                    ],
+                },
+                root_context,
+            ),
+        }
+
     # --- Input extraction ---
     task_scope = kwargs.get("task_scope")
     target_paths = kwargs.get("target_paths", [])
@@ -1236,28 +1403,24 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
         return {
             "tool": "context.readiness",
             "status": "ok",
-            "readiness": {
-                "status": "blocked_missing_context",
-                "reasons": ["Invalid or missing operation_mode"],
-                "required_next_reads": [
-                    "AGENTS.md",
-                    "agents/AGENTS.md",
-                    "agents/OPEN_CODE_AGENTS.md",
-                    "docs/runbooks/CONTROL_REGISTER.md",
-                    "CURRENT_STATUS.md",
-                    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
-                ],
-                "human_go_required": False,
-                "stop_conditions": [invalid_mode_stop],
-                "missing_context": [invalid_mode_context],
-                "missing_evidence": [],
-                "scope_drift_findings": [],
-                "uncertainties": [],
-                "guardrails": [
-                    "Do not proceed. Resolve missing context first.",
-                    "Readiness is not authorization. LR remains NO-GO. Board stage (trade-capable) is orthogonal.",
-                ],
-            },
+            "readiness": _readiness_payload_with_root(
+                {
+                    "status": "blocked_missing_context",
+                    "reasons": ["Invalid or missing operation_mode"],
+                    "required_next_reads": list(READINESS_MINIMUM_READS),
+                    "human_go_required": False,
+                    "stop_conditions": [invalid_mode_stop],
+                    "missing_context": [invalid_mode_context],
+                    "missing_evidence": [],
+                    "scope_drift_findings": [],
+                    "uncertainties": [],
+                    "guardrails": [
+                        "Do not proceed. Resolve missing context first.",
+                        "Readiness is not authorization. LR remains NO-GO. Board stage (trade-capable) is orthogonal.",
+                    ],
+                },
+                root_context,
+            ),
         }
 
     # --- Accumulators ---
@@ -1269,14 +1432,7 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
     guardrails: list[str] = []
     output_stop_conditions: list[str] = []
 
-    MINIMUM_READS = [
-        "AGENTS.md",
-        "agents/AGENTS.md",
-        "agents/OPEN_CODE_AGENTS.md",
-        "docs/runbooks/CONTROL_REGISTER.md",
-        "CURRENT_STATUS.md",
-        "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
-    ]
+    MINIMUM_READS = list(READINESS_MINIMUM_READS)
 
     # --- Derive characteristics ---
     is_write = isinstance(operation_mode, str) and operation_mode.startswith("write")
@@ -1301,16 +1457,34 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
     if not task_scope or not isinstance(task_scope, str) or not task_scope.strip():
         blocked_context.append("scope not defined")
 
-    # --- Check 3: Required Reads (minimum baseline) ---
-    missing_reads = [r for r in MINIMUM_READS if r not in required_reads]
-    if missing_reads:
+    # --- Check 3: Canon reads on effective_scan_root (repo-backed, not host cwd) ---
+    missing_reads_on_disk = _missing_canon_reads_on_disk(
+        effective_scan_root, READINESS_MINIMUM_READS
+    )
+    if missing_reads_on_disk:
         blocked_context.append(
-            f"minimum required reads missing: {', '.join(missing_reads)}"
+            "minimum canon reads unavailable at effective_scan_root: "
+            + ", ".join(missing_reads_on_disk)
         )
 
+    missing_reads_declared = [r for r in MINIMUM_READS if r not in required_reads]
+    canon_available_on_disk = not missing_reads_on_disk
+
     # --- Check 2: Context Package or Required Reads ---
-    if not context_package_ref and not required_reads:
+    if not context_package_ref and not required_reads and not canon_available_on_disk:
         blocked_context.append("no context package and no required reads")
+    elif (
+        not context_package_ref
+        and not required_reads
+        and canon_available_on_disk
+        and missing_reads_declared
+    ):
+        root_context["limitations"].append(
+            "required_reads parameter empty but canon files exist at effective_scan_root"
+        )
+        root_context["evidence"].append(
+            "repo-backed canon availability satisfied without required_reads parameter"
+        )
 
     # --- Check 5: Impact Report for write operations ---
     if is_write and not impact_refs:
@@ -1344,10 +1518,18 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
         )
 
     # --- Build output stop conditions from detected issues ---
-    if missing_reads:
-        for r in missing_reads:
-            output_stop_conditions.append(f"S3: minimum read unavailable: {r}")
-    if not context_package_ref and not required_reads:
+    if missing_reads_on_disk:
+        for r in missing_reads_on_disk:
+            output_stop_conditions.append(
+                f"S3: minimum read unavailable at effective_scan_root: {r}"
+            )
+    if root_context.get("root_drift_detected") and root_context.get(
+        "drift_severity"
+    ) == "warning":
+        output_stop_conditions.append(
+            "S3: host_cwd differs from resolved_repo_root — use effective_scan_root for canon reads"
+        )
+    if not context_package_ref and not required_reads and not canon_available_on_disk:
         output_stop_conditions.append("S2: no context package and no required reads")
     if is_write and not impact_refs:
         output_stop_conditions.append("S6: write without impact report")
@@ -1403,18 +1585,21 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
     return {
         "tool": "context.readiness",
         "status": "ok",
-        "readiness": {
-            "status": status,
-            "reasons": reasons,
-            "required_next_reads": required_next_reads,
-            "human_go_required": human_go_required,
-            "stop_conditions": output_stop_conditions,
-            "missing_context": blocked_context if blocked_context else [],
-            "missing_evidence": blocked_evidence if blocked_evidence else [],
-            "scope_drift_findings": scope_drift_findings,
-            "uncertainties": uncertainties,
-            "guardrails": guardrails,
-        },
+        "readiness": _readiness_payload_with_root(
+            {
+                "status": status,
+                "reasons": reasons,
+                "required_next_reads": required_next_reads,
+                "human_go_required": human_go_required,
+                "stop_conditions": output_stop_conditions,
+                "missing_context": blocked_context if blocked_context else [],
+                "missing_evidence": blocked_evidence if blocked_evidence else [],
+                "scope_drift_findings": scope_drift_findings,
+                "uncertainties": uncertainties,
+                "guardrails": guardrails,
+            },
+            root_context,
+        ),
     }
 
 

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -289,6 +289,10 @@ TOOLS_V0 = [
                     "items": {"type": "string"},
                     "description": "Canonical files the agent must read before acting.",
                 },
+                "repo_root": {
+                    "type": "string",
+                    "description": "Optional absolute path to the working repo root. Canon file checks use this (or bridge module root), not host cwd alone.",
+                },
                 "evidence_refs": {
                     "type": "array",
                     "items": {"type": "string"},


### PR DESCRIPTION
## Summary
- `context.readiness` exposes `host_cwd`, `resolved_repo_root`, `effective_scan_root`, drift fields, `limitations`, and `evidence`.
- Minimum canon is verified on `effective_scan_root` (repo root), not host cwd alone; empty `required_reads` no longer false-blocks when canon exists on disk.
- Optional `repo_root` parameter with fail-closed handling for invalid paths.

Closes #2848
Refs #2847
Refs #2845
Refs #2857

## Repro
Benchmark #2: MCP `context.readiness` with empty `required_reads` returned `blocked_missing_context` while bridge with full `required_reads` returned `ok`, even though canon files exist at module `REPO_ROOT`.

## Root Cause
Readiness treated membership in the `required_reads` parameter as canon availability and ignored host cwd vs repo root semantics.

## Validation
- `pytest -q tests/unit/tools/mcp/test_context_readiness_root.py -m unit` (6 passed)
- `pytest -q tests/unit/tools/mcp/test_context_bridge.py::TestContextReadinessHandler -m unit` (20 passed)
- Manual: empty `required_reads` from repo cwd and from `%TEMP%` → `ready_for_read_only` with explicit drift warning when cwd differs

## Safety Boundaries
- Read-only MCP surface unchanged; no DB writes, no mutations, no runtime changes.

## Non-goals
- Full cross-repo root inventory (#2849/#2852), MCP server cwd configuration, output_schema field enumeration.

## Restunsicherheiten
- Stdio MCP subprocess with cwd=repo root not re-benchmarked in CI; behavior follows `effective_scan_root` resolution.