### PR TITLE
[CONTEXT] Ratify PASS_WITH_LIMITS tools and full harness profile (#2852)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ else
   SECRETS_PATH ?= $(HOME)/Documents/.secrets/.cdb
 endif
 
-.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-query-config-init context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke context-smoke-db context-memory-db-proof context-claim-evidence-proof context-memory-rediscovery-proof context-doctor context-certify context-live-invoke audit-trail-t3-bootstrap audit-trail-t3-proof audit-trail-t3-status audit-trail-t3-down
+.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-query-config-init context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke context-smoke-db context-memory-db-proof context-claim-evidence-proof context-memory-rediscovery-proof context-doctor context-certify context-live-invoke context-live-invoke-full audit-trail-t3-bootstrap audit-trail-t3-proof audit-trail-t3-status audit-trail-t3-down
 
 help:
 	@echo "Claire de Binare - Test Commands"
@@ -110,7 +110,8 @@ help:
 	@echo "  make context-memory-rediscovery-proof - Cross-session memory rediscovery (#2720)"
 	@echo "  make context-doctor          - Read-only onboarding preflight (#2642)"
 	@echo "  make context-certify         - Read-only operator certification proof pack (#2776)"
-	@echo "  make context-live-invoke     - All-tools live bridge invocation matrix (#2849)"
+	@echo "  make context-live-invoke     - All-tools live bridge matrix, minimal profile (#2849)"
+	@echo "  make context-live-invoke-full - Same harness with inline records, 27 PASS (#2852)"
 # ============================================================================
 # CI-Tests (schnell, mit Mocks)
 # ============================================================================
@@ -405,6 +406,10 @@ context-certify:
 context-live-invoke:
 	@echo "=== Context live invocation regression harness (bridge, #2849) ==="
 	@$(PYTHON) -m tools.surrealdb.context_live_invocation_harness
+
+context-live-invoke-full:
+	@echo "=== Context live invocation harness, full inline-record profile (#2852) ==="
+	@$(PYTHON) -m tools.surrealdb.context_live_invocation_harness --profile full
 
 context-reset-local:
 	@echo "=== SurrealDB Local Reset (DESTRUKTIV - nur Context-Intelligence-Daten) ==="

--- a/docs/evidence/context_tooling/CDB_PASS_WITH_LIMITS_RATIFICATION_2026-06-03.md
+++ b/docs/evidence/context_tooling/CDB_PASS_WITH_LIMITS_RATIFICATION_2026-06-03.md
@@ -1,0 +1,85 @@
+# CDB PASS_WITH_LIMITS ratification — Benchmark #2 / harness minimal profile
+
+Status: Ratification record (closes [#2852](https://github.com/jannekbuengener/Claire_de_Binare/issues/2852))  
+Parent meta: [#2847](https://github.com/jannekbuengener/Claire_de_Binare/issues/2847)  
+Harness: `tools/surrealdb/context_live_invocation_harness.py` (`--profile minimal` default, `--profile full` optional)  
+Benchmark source: [`CDB_ALL_TOOLS_LIVE_INVOCATION_PROOF_2026-06-03.md`](CDB_ALL_TOOLS_LIVE_INVOCATION_PROOF_2026-06-03.md)
+
+Boundaries: No live-go, no persist activation, no MCP mutations. LR **NO-GO** unchanged.
+
+---
+
+## Summary vs matrix count (6 vs 8)
+
+| Count | What it measured |
+|-------|------------------|
+| **6** | Executive summary in Benchmark #2: distinct **limitation classes** still open after that session (host cwd, five `missing_*` record paths, bundle gap). |
+| **8** | Per-tool matrix rows marked **PASS_WITH_LIMITS** (or equivalent) including `context.readiness` (MCP-only) and `cdb_context_stale` (call without bundle). |
+
+**Reconciliation after #2844 / #2848 / #2849 (bridge harness on `main`):**
+
+- `cdb_context_scope_drift`: **FAIL → PASS** ([#2844](https://github.com/jannekbuengener/Claire_de_Binare/issues/2844), PR #2857).
+- `context.readiness`: **PASS_WITH_LIMITS (MCP cwd) → PASS** on bridge when canon + stop_conditions satisfied ([#2848](https://github.com/jannekbuengener/Claire_de_Binare/issues/2848), PR #2859).
+- `cdb_context_stale`: **PASS_WITH_LIMITS (no bundle) → PASS** when harness supplies `bundle` + `scope` (manifest fix in #2849).
+- **Remaining 6** on `--profile minimal`: Wave-14 record tools invoked **without** inline `*_records` / `records` — intentional fail-closed proof, not handler defects.
+
+`cdb_context_memory_write_intent` is **PASS** (refused) on bridge; MCP-only **BLOCKED_SAFETY** remains an accepted Smart Mode boundary, not a PASS_WITH_LIMITS row.
+
+---
+
+## Per-tool decisions
+
+| tool_name | Root cause | Decision | Safety impact | Recheck trigger |
+|-----------|------------|----------|---------------|-----------------|
+| `context.readiness` | MCP host `cwd` ≠ repo root; empty `required_reads` without canon check (pre-#2848) | **FIXED (bridge)** + **ACCEPTED_LIMITATION (MCP cwd)** | Readiness is not authorization; LR NO-GO | Re-run MCP from repo root; harness `--profile minimal` |
+| `cdb_context_evidence_resolve` | No `evidence_records[]` in minimal call | **ACCEPTED_LIMITATION** | Lookup-only; no writes | `make context-live-invoke` or `--profile full` |
+| `cdb_context_claim_resolve` | No `claim_records[]` | **ACCEPTED_LIMITATION** | Resolver fail-closed; no approval | Harness full profile / supply records in integration |
+| `cdb_context_memory_get` | No `memory_records[]` | **ACCEPTED_LIMITATION** | Read-only memory surface | Harness full profile |
+| `cdb_context_decision_history` | No `decision_events[]` | **ACCEPTED_LIMITATION** | History query only | Harness full profile |
+| `cdb_context_decision_replay` | No `decision_events[]` | **ACCEPTED_LIMITATION** | Replay builder only | Harness full profile |
+| `cdb_context_contradictions` | No `records` object (bundle alone insufficient) | **ACCEPTED_LIMITATION** | Scan-only; no mutation | Harness full profile with `records` dict |
+| `cdb_context_stale` | Benchmark called without `bundle` | **FIXED (harness)** | Stale scan read-only | `make context-live-invoke` |
+| `cdb_context_scope_drift` | `AttributeError` on minimal bundle (pre-#2844) | **FIXED** ([#2844](https://github.com/jannekbuengener/Claire_de_Binare/issues/2844)) | No scope mutation | Harness must stay PASS |
+
+---
+
+## ACCEPTED_LIMITATION rationale (Wave-14 minimal profile)
+
+The six remaining **PASS_WITH_LIMITS** results on `--profile minimal` prove that handlers:
+
+1. Are **callable** (real JSON, not inventory-only).
+2. **Fail closed** when inline adapter inputs are omitted (no silent empty success).
+3. Do **not** require productive SurrealDB or MCP writes for regression signal.
+
+Supplying inline benchmark records is validated separately via `--profile full` (all 27 **PASS**, 0 **PASS_WITH_LIMITS** on bridge).
+
+---
+
+## Validation commands
+
+```bash
+# Minimal profile (fail-closed record paths — 6 PASS_WITH_LIMITS expected)
+make context-live-invoke
+
+# Full inline-record profile (27 PASS expected)
+make context-live-invoke-full
+
+pytest tests/unit/surrealdb/test_context_live_invocation_harness.py -q
+```
+
+---
+
+## Brain Evidence
+
+```text
+brain_source: repo-only
+brain_status: used
+tools_or_queries:
+  - python -m tools.surrealdb.context_live_invocation_harness --profile minimal
+  - python -m tools.surrealdb.context_live_invocation_harness --profile full
+records_or_results:
+  - minimal: 21 PASS, 6 PASS_WITH_LIMITS, 0 FAIL (main post-#2849)
+  - full: 27 PASS, 0 PASS_WITH_LIMITS, 0 FAIL (expected after #2852)
+limitations:
+  - MCP stdio path and Smart Mode write-intent block not re-proven each run
+```

--- a/tests/unit/surrealdb/test_context_live_invocation_harness.py
+++ b/tests/unit/surrealdb/test_context_live_invocation_harness.py
@@ -13,6 +13,18 @@ pytestmark = pytest.mark.unit
 
 def test_benchmark_manifest_covers_expected_tool_count() -> None:
     assert len(harness.BENCHMARK_SAFE_INVOCATIONS) == harness.EXPECTED_TOOL_COUNT
+    assert (
+        len(harness.invocations_for_profile("minimal")) == harness.EXPECTED_TOOL_COUNT
+    )
+    assert len(harness.invocations_for_profile("full")) == harness.EXPECTED_TOOL_COUNT
+
+
+def test_full_profile_overrides_six_wave14_tools() -> None:
+    assert len(harness.BENCHMARK_FULL_RECORD_OVERRIDES) == 6
+    minimal = harness.invocations_for_profile("minimal")
+    full = harness.invocations_for_profile("full")
+    for tool in harness.BENCHMARK_FULL_RECORD_OVERRIDES:
+        assert minimal[tool] != full[tool]
 
 
 def test_classify_ok_and_limits() -> None:
@@ -122,12 +134,43 @@ def test_run_matrix_live_mock_all_pass(monkeypatch: pytest.MonkeyPatch) -> None:
         },
     )
 
-    report = harness.run_matrix(live=True)
+    report = harness.run_matrix(live=True, profile="minimal")
     assert report.final_verdict == "pass"
     assert report.tool_count == 27
     assert report.summary.get("FAIL", 0) == 0
+    assert report.profile == "minimal"
     assert report.safety_flags["PERSIST_ALLOWED"] is False
     assert report.safety_flags["MUTATION_ALLOWED"] is False
+
+
+def test_run_matrix_full_profile_mock_all_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry_names = sorted(harness.invocations_for_profile("full").keys())
+    bridge = MagicMock()
+    bridge.list_tools.return_value = [{"name": n} for n in registry_names]
+
+    def _execute(tool_name: str, parameters: dict) -> dict:
+        if tool_name == "cdb_context_memory_write_intent":
+            return {
+                "status": "refused",
+                "code": "agent_memory_write_not_activated",
+            }
+        return {"status": "ok", "tool": tool_name}
+
+    bridge.execute_tool.side_effect = _execute
+    monkeypatch.setattr(harness, "create_bridge", lambda: bridge)
+    monkeypatch.setattr(
+        harness,
+        "_git_metadata",
+        lambda _root: {
+            "git_sha": "deadbeef",
+            "branch": "test",
+            "worktree_clean": True,
+            "git_available": True,
+        },
+    )
+    report = harness.run_matrix(live=True, profile="full", fail_on_limits=True)
+    assert report.final_verdict == "pass"
+    assert report.summary.get("PASS_WITH_LIMITS", 0) == 0
 
 
 def test_run_matrix_fails_when_registry_missing_manifest_entry(
@@ -150,7 +193,7 @@ def test_run_matrix_fails_when_registry_missing_manifest_entry(
             "git_available": True,
         },
     )
-    report = harness.run_matrix(live=True)
+    report = harness.run_matrix(live=True, profile="minimal")
     assert report.final_verdict == "fail"
     assert report.missing_from_manifest == ["context.unlisted_tool"]
 

--- a/tools/surrealdb/context_live_invocation_harness.py
+++ b/tools/surrealdb/context_live_invocation_harness.py
@@ -3,14 +3,15 @@
 Invokes every registered tool via ContextBridge (same handler path as MCP server)
 with benchmark-safe parameters. Produces a per-tool matrix for regression detection.
 
-Issue: #2849
+Issue: #2849, #2852 (profiles + ratification)
 Parent: #2847
 
 Usage:
     python -m tools.surrealdb.context_live_invocation_harness
+    python -m tools.surrealdb.context_live_invocation_harness --profile full
     python -m tools.surrealdb.context_live_invocation_harness --format json
-    python -m tools.surrealdb.context_live_invocation_harness --format markdown --output report.md
     make context-live-invoke
+    make context-live-invoke-full
 
 Exit codes:
     0 - all tools callable; no FAIL rows
@@ -39,6 +40,37 @@ OutputFormat = Literal["text", "json", "markdown"]
 
 EXPECTED_TOOL_COUNT = 27
 ISSUE_REF = "#2849"
+RATIFICATION_DOC = (
+    "docs/evidence/context_tooling/CDB_PASS_WITH_LIMITS_RATIFICATION_2026-06-03.md"
+)
+InvocationProfile = Literal["minimal", "full"]
+
+_BENCH_SCOPE = "bench-2852"
+_BENCH_EVIDENCE: list[dict[str, Any]] = [
+    {
+        "evidence_id": "ev1",
+        "evidence_type": "doc",
+        "scope": _BENCH_SCOPE,
+    }
+]
+_BENCH_CLAIM: list[dict[str, Any]] = [
+    {
+        "claim_id": "c1",
+        "status": "open",
+        "scope": _BENCH_SCOPE,
+        "evidence_refs": ["ev1"],
+    }
+]
+_BENCH_MEMORY: list[dict[str, Any]] = [
+    {"memory_id": "m1", "scope": _BENCH_SCOPE, "summary": "bench inline record"}
+]
+_BENCH_DECISION_EVENTS: list[dict[str, Any]] = [
+    {"decision_id": "d1", "scope": _BENCH_SCOPE, "status": "recorded"}
+]
+_BENCH_CONTRADICTION_RECORDS: dict[str, Any] = {
+    "evidence_records": _BENCH_EVIDENCE,
+    "claims": _BENCH_CLAIM,
+}
 
 _BENCH_BUNDLE: dict[str, Any] = {
     "meta": {
@@ -108,6 +140,53 @@ BENCHMARK_SAFE_INVOCATIONS: dict[str, dict[str, Any]] = {
     "cdb_agent_os_readiness": {"bundle": _BENCH_BUNDLE},
     "cdb_context_briefing": dict(_BRIEFING_PAYLOAD),
 }
+
+# Inline-record overrides for --profile full (#2852 operational completeness check).
+BENCHMARK_FULL_RECORD_OVERRIDES: dict[str, dict[str, Any]] = {
+    "cdb_context_evidence_resolve": {
+        "evidence_records": _BENCH_EVIDENCE,
+        "mode": "by_artifact",
+        "artifact": "AGENTS.md",
+        "limit": 10,
+    },
+    "cdb_context_claim_resolve": {
+        "claim_records": _BENCH_CLAIM,
+        "mode": "by_claim_id",
+        "claim_id": "c1",
+    },
+    "cdb_context_memory_get": {
+        "memory_records": _BENCH_MEMORY,
+        "mode": "by_scope",
+        "scope": _BENCH_SCOPE,
+    },
+    "cdb_context_decision_history": {
+        "decision_events": _BENCH_DECISION_EVENTS,
+        "mode": "by_scope",
+        "scope": _BENCH_SCOPE,
+        "limit": 3,
+    },
+    "cdb_context_decision_replay": {
+        "decision_events": _BENCH_DECISION_EVENTS,
+        "mode": "replay_by_decision_id",
+        "decision_id": "d1",
+    },
+    "cdb_context_contradictions": {
+        "bundle": _BENCH_BUNDLE,
+        "records": _BENCH_CONTRADICTION_RECORDS,
+    },
+}
+
+
+def invocations_for_profile(profile: InvocationProfile) -> dict[str, dict[str, Any]]:
+    """Return per-tool invocation payloads for minimal or full inline-record profile."""
+    merged = {name: dict(params) for name, params in BENCHMARK_SAFE_INVOCATIONS.items()}
+    if profile == "full":
+        for tool_name, overrides in BENCHMARK_FULL_RECORD_OVERRIDES.items():
+            call = dict(merged.get(tool_name, {}))
+            call.update(overrides)
+            merged[tool_name] = call
+    return merged
+
 
 # Fail-closed error codes that indicate the handler ran but lacks inline records (expected).
 PASS_WITH_LIMITS_ERROR_CODES = frozenset(
@@ -197,19 +276,14 @@ def _summarize_actual(result: dict[str, Any]) -> str:
     return f"status={status}"
 
 
-def _expected_summary(tool_name: str) -> str:
+def _expected_summary(tool_name: str, *, profile: InvocationProfile) -> str:
     if tool_name == "context.readiness":
         return "status=ok, readiness.status=ready_for_read_only"
     if tool_name == "cdb_context_memory_write_intent":
         return "status=refused (negative control; no persist)"
-    if tool_name in {
-        "cdb_context_evidence_resolve",
-        "cdb_context_claim_resolve",
-        "cdb_context_memory_get",
-        "cdb_context_decision_history",
-        "cdb_context_decision_replay",
-        "cdb_context_contradictions",
-    }:
+    if profile == "full" and tool_name in BENCHMARK_FULL_RECORD_OVERRIDES:
+        return "status=ok with inline adapter records"
+    if tool_name in BENCHMARK_FULL_RECORD_OVERRIDES:
         return "fail-closed missing_* records (no inline bundle)"
     return "status=ok (handler JSON)"
 
@@ -316,6 +390,8 @@ class HarnessReport:
     lr_note: str = "NO-GO"
     final_verdict: FinalVerdict = "pass"
     issue_ref: str = ISSUE_REF
+    profile: InvocationProfile = "minimal"
+    ratification_doc: str = RATIFICATION_DOC
     manifest_tool_names: list[str] = field(default_factory=list)
     registry_tool_names: list[str] = field(default_factory=list)
     missing_from_manifest: list[str] = field(default_factory=list)
@@ -335,6 +411,8 @@ class HarnessReport:
             "lr_note": self.lr_note,
             "final_verdict": self.final_verdict,
             "issue_ref": self.issue_ref,
+            "profile": self.profile,
+            "ratification_doc": self.ratification_doc,
             "manifest_tool_names": self.manifest_tool_names,
             "registry_tool_names": self.registry_tool_names,
             "missing_from_manifest": self.missing_from_manifest,
@@ -364,24 +442,28 @@ def _registry_tool_names(bridge: Any) -> list[str]:
     return sorted(names)
 
 
-def run_matrix(*, live: bool = True) -> HarnessReport:
+def run_matrix(
+    *,
+    live: bool = True,
+    profile: InvocationProfile = "minimal",
+    fail_on_limits: bool = False,
+) -> HarnessReport:
     """Build the invocation matrix. When live=False, only validate manifest/registry."""
     repo_root = _repo_root()
     git = _git_metadata(repo_root)
     bridge = create_bridge() if live else None
+    invocations = invocations_for_profile(profile)
     registry_names = (
-        _registry_tool_names(bridge)
-        if bridge
-        else sorted(BENCHMARK_SAFE_INVOCATIONS.keys())
+        _registry_tool_names(bridge) if bridge else sorted(invocations.keys())
     )
-    manifest_names = sorted(BENCHMARK_SAFE_INVOCATIONS.keys())
+    manifest_names = sorted(invocations.keys())
     missing = sorted(set(registry_names) - set(manifest_names))
     extra = sorted(set(manifest_names) - set(registry_names))
 
     rows: list[MatrixRow] = []
     if live and bridge is not None:
         for tool_name in registry_names:
-            params = BENCHMARK_SAFE_INVOCATIONS.get(tool_name)
+            params = invocations.get(tool_name)
             if params is None:
                 rows.append(
                     MatrixRow(
@@ -390,7 +472,7 @@ def run_matrix(*, live: bool = True) -> HarnessReport:
                         expected="callable via bridge",
                         actual="no manifest entry",
                         status="FAIL",
-                        limitation="missing BENCHMARK_SAFE_INVOCATIONS entry",
+                        limitation=f"missing invocation entry for profile={profile}",
                     )
                 )
                 continue
@@ -411,7 +493,7 @@ def run_matrix(*, live: bool = True) -> HarnessReport:
                 MatrixRow(
                     tool_name=tool_name,
                     call=params,
-                    expected=_expected_summary(tool_name),
+                    expected=_expected_summary(tool_name, profile=profile),
                     actual=_summarize_actual(result),
                     status=matrix_status,
                     handler_status=(
@@ -449,6 +531,10 @@ def run_matrix(*, live: bool = True) -> HarnessReport:
         fail_reasons.append("safety gates must remain default-off")
     if summary.get("FAIL", 0) > 0:
         fail_reasons.append(f"{summary['FAIL']} FAIL row(s)")
+    if fail_on_limits and summary.get("PASS_WITH_LIMITS", 0) > 0:
+        fail_reasons.append(
+            f"{summary['PASS_WITH_LIMITS']} PASS_WITH_LIMITS row(s) not allowed"
+        )
 
     final: FinalVerdict = "fail" if fail_reasons else "pass"
 
@@ -463,6 +549,7 @@ def run_matrix(*, live: bool = True) -> HarnessReport:
         summary=summary,
         safety_flags=safety,
         final_verdict=final,
+        profile=profile,
         manifest_tool_names=manifest_names,
         registry_tool_names=registry_names,
         missing_from_manifest=missing,
@@ -470,8 +557,10 @@ def run_matrix(*, live: bool = True) -> HarnessReport:
     )
 
 
-def compute_exit_code(report: HarnessReport) -> int:
+def compute_exit_code(report: HarnessReport, *, fail_on_limits: bool = False) -> int:
     if report.final_verdict == "fail":
+        return 1
+    if fail_on_limits and report.summary.get("PASS_WITH_LIMITS", 0) > 0:
         return 1
     return 0
 
@@ -487,6 +576,8 @@ def format_report_markdown(report: HarnessReport) -> str:
         f"- **tool_count:** {report.tool_count} (expected {report.expected_tool_count})",
         f"- **final_verdict:** {report.final_verdict}",
         f"- **issue_ref:** {report.issue_ref}",
+        f"- **profile:** {report.profile}",
+        f"- **ratification_doc:** {report.ratification_doc}",
         f"- **lr_note:** {report.lr_note}",
         "",
         "## Summary",
@@ -531,6 +622,7 @@ Examples:
   python -m tools.surrealdb.context_live_invocation_harness
   python -m tools.surrealdb.context_live_invocation_harness --format json
   make context-live-invoke
+  make context-live-invoke-full
 
 Notes:
   - Bridge-only live path (same handlers as MCP server); no productive DB writes.
@@ -567,16 +659,36 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Validate manifest vs registry only (no live handler calls)",
     )
+    parser.add_argument(
+        "--profile",
+        choices=("minimal", "full"),
+        default="minimal",
+        help=(
+            "minimal: fail-closed record paths (6 PASS_WITH_LIMITS expected). "
+            "full: inline records for Wave-14 tools (27 PASS expected)."
+        ),
+    )
+    parser.add_argument(
+        "--fail-on-limits",
+        action="store_true",
+        help="Exit 1 when any PASS_WITH_LIMITS row is present",
+    )
     args = parser.parse_args(argv)
 
-    report = run_matrix(live=not args.manifest_only)
+    profile: InvocationProfile = args.profile
+    fail_on_limits = args.fail_on_limits or profile == "full"
+    report = run_matrix(
+        live=not args.manifest_only,
+        profile=profile,
+        fail_on_limits=fail_on_limits,
+    )
     output = format_report(report, args.format)
 
     if args.output is not None:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(output, encoding="utf-8")
     print(output)
-    return compute_exit_code(report)
+    return compute_exit_code(report, fail_on_limits=fail_on_limits)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds ratification record `docs/evidence/context_tooling/CDB_PASS_WITH_LIMITS_RATIFICATION_2026-06-03.md` with per-tool decisions (ACCEPTED_LIMITATION vs FIXED) and 6 vs 8 count reconciliation.
- Extends live invocation harness with `--profile full` (inline Wave-14 records → 27 PASS) and `make context-live-invoke-full`.
- Default `--profile minimal` keeps six fail-closed PASS_WITH_LIMITS rows for regression signal (#2849).

## Evidence (local)
- `make context-live-invoke` → pass, 6 PASS_WITH_LIMITS, 0 FAIL
- `make context-live-invoke-full` → pass, 27 PASS, 0 PASS_WITH_LIMITS
- `pytest tests/unit/surrealdb/test_context_live_invocation_harness.py -q` → 8 passed

Closes #2852