### PR TITLE
docs(context): define db-record evidence contract

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -155,7 +155,9 @@ Higher wins; fail-closed when lower layers conflict:
 ### Rules
 
 - No plan may claim Memory/Evidence/Decision consideration without
-  record/tool/query evidence.
+  record/tool/query evidence. Structured claim envelope:
+  [`docs/contracts/context_tooling/DB_RECORD_EVIDENCE_CONTRACT.md`](../docs/contracts/context_tooling/DB_RECORD_EVIDENCE_CONTRACT.md)
+  (validator: `tools/surrealdb/db_record_evidence_contract.py`, Issue #2851).
 - Strategy/Runtime/Module work MUST distinguish `repo-only` from brain-backed.
 - `context.briefing` / `briefing.session_context` is read-only working/session
   memory (`session_only=true`); not persistent DB memory; see

--- a/docs/contracts/context_tooling/DB_RECORD_EVIDENCE_CONTRACT.md
+++ b/docs/contracts/context_tooling/DB_RECORD_EVIDENCE_CONTRACT.md
@@ -1,0 +1,148 @@
+# DB-record evidence contract (context / tooling claims)
+
+| Field | Value |
+| --- | --- |
+| Status | **active** |
+| Version | `db-record-evidence-contract/v1` |
+| Issue | [#2851](https://github.com/jannekbuengener/Claire_de_Binare/issues/2851) |
+| Parent meta | [#2847](https://github.com/jannekbuengener/Claire_de_Binare/issues/2847) |
+| Validator | [`tools/surrealdb/db_record_evidence_contract.py`](../../../tools/surrealdb/db_record_evidence_contract.py) |
+| JSON Schema | [`docs/contracts/db_record_evidence_claim.v1.schema.json`](../db_record_evidence_claim.v1.schema.json) |
+
+## Purpose
+
+Agents and harnesses need a single SSOT for when a **context/tooling claim** may be cited as **DB-backed** (`surrealdb-local`) versus **repo-only**, **in-memory fixture**, or **accepted limitation** (fail-closed `missing_*` paths).
+
+This contract complements (does not replace):
+
+- [`agents/AGENTS.md`](../../../agents/AGENTS.md) § Brain Evidence Gate
+- [`knowledge/decisions/CDB_CONTEXT_BRAIN_DEFAULT_POSTURE.md`](../../../knowledge/decisions/CDB_CONTEXT_BRAIN_DEFAULT_POSTURE.md)
+- [`tools/mcp/memory_output_contract.py`](../../../tools/mcp/memory_output_contract.py) (MCP response envelope)
+- [`tools/surrealdb/claim_evidence_at_rest.py`](../../../tools/surrealdb/claim_evidence_at_rest.py) (DB row integrity)
+- Live invocation harness: [`tools/surrealdb/context_live_invocation_harness.py`](../../../tools/surrealdb/context_live_invocation_harness.py)
+
+## Safety boundaries
+
+- LR remains **NO-GO** ([`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../live-readiness/LR-AUDIT-STATUS-2026-03-05.md)).
+- Board stage `trade-capable` is **not** live-go.
+- `PERSIST_ALLOWED=False` and `MUTATION_ALLOWED=False` on agent surfaces (default).
+- No productive SurrealDB writes from this contract.
+- Caller-supplied `brain_source`, `brain_status`, or `metadata.source` is **not** DB evidence ([#2638](https://github.com/jannekbuengener/Claire_de_Binare/issues/2638); `derive_guarded_source_label()`).
+
+## Required claim fields (v1)
+
+| Field | Role |
+| --- | --- |
+| `claim_id` | Stable identifier for the claim instance |
+| `claim_type` | e.g. `context_tooling_benchmark`, `brain_evidence_block`, `wave14_read` |
+| `claim_text_or_summary` | Human-readable summary (no secrets) |
+| `producer_tool` | MCP/bridge/CLI tool that produced evidence |
+| `tool_invocation_id_or_hash` | Invocation correlation (hash or stable id) |
+| `query_or_lookup_fingerprint` | Query/command fingerprint (SurrealQL, adapter op, or bridge path) |
+| `record_source` | `surrealdb-local`, `surrealdb-local-unavailable`, `in_memory`, `repo-only` |
+| `record_ids` | List of record IDs (may be empty when not DB-backed) |
+| `record_hashes_or_content_fingerprints` | Content fingerprints when IDs omitted |
+| `record_timestamps_or_freshness_signal` | Freshness hint (excluded from `determinism_hash`) |
+| `repo_crosscheck` | Path/symbol/commit or narrative crosscheck |
+| `source_priority` | Which layer won: `live_github`, `repo_files`, `surrealdb_context`, `ledger_snapshots`, `fallback` |
+| `trust_classification` | Outcome class (see below) |
+| `limitations` | Explicit non-proof statements |
+| `redaction_summary` | What was redacted (no raw secrets) |
+| `determinism_hash` | `canonical_hash` over stable claim subset |
+
+Optional: `schema_version` = `db-record-evidence-contract/v1`.
+
+## Source priority (authoritative order)
+
+Higher wins; fail-closed on conflict:
+
+1. **live_github** — issues, PRs, checks, branches
+2. **repo_files** — governance, code, contracts, runbooks
+3. **surrealdb_context** — guarded adapter + record evidence only
+4. **ledger_snapshots** — e.g. `CURRENT_STATUS.md` (not live truth)
+5. **fallback** — explicit limitations only
+
+## Trust classifications
+
+| `trust_classification` | Meaning | DB-backed claim allowed? |
+| --- | --- | --- |
+| `valid_db_backed` | Tool/query + record ID or hash from guarded adapter | **Yes** (still not live-go) |
+| `partial` | Degraded/unavailable adapter or incomplete proof | No |
+| `repo_only` | Repo/GitHub evidence only | No |
+| `in_memory_fixture` | Inline/harness/fixture records | No |
+| `accepted_limitation` | Fail-closed `missing_*` (harness PASS_WITH_LIMITS) | No |
+| `invalid_fake_db` | Caller-forged source without adapter proof | No |
+
+### Valid DB-backed (all required)
+
+- `record_source` = `surrealdb-local`
+- Non-empty `producer_tool` and (`query_or_lookup_fingerprint` or `tool_invocation_id_or_hash`)
+- Non-empty `record_ids` **or** `record_hashes_or_content_fingerprints`
+- No reliance on caller-only keys (`brain_source`, `metadata.source`, etc.) as sole evidence
+- `trust_classification` = `valid_db_backed` and consistent `determinism_hash`
+
+### Repo-only
+
+- `record_source` = `repo-only`
+- `repo_crosscheck` present (path/symbol/commit or explicit limitation text)
+- `trust_classification` = `repo_only`
+- No assertion of verified SurrealDB record proof
+
+### Accepted limitation (PASS_WITH_LIMITS)
+
+Maps to harness fail-closed codes (must match harness):
+
+- `missing_evidence_records`
+- `missing_claim_records`
+- `missing_memory_records`
+- `missing_decision_events`
+- `missing_records`
+- `missing_bundle`
+
+Ratification: [`docs/evidence/context_tooling/CDB_PASS_WITH_LIMITS_RATIFICATION_2026-06-03.md`](../../evidence/context_tooling/CDB_PASS_WITH_LIMITS_RATIFICATION_2026-06-03.md).
+
+- `trust_classification` = `accepted_limitation`
+- `limitations` must reference at least one code above
+- **Not** a verified DB-backed claim
+
+## Determinism
+
+`determinism_hash` = SHA-256 of canonical JSON ([`core/replay/canonical_json.py`](../../../core/replay/canonical_json.py)) over the claim **excluding**:
+
+- `determinism_hash`
+- `record_timestamps_or_freshness_signal`
+
+Wall-clock values must not affect the hash.
+
+## Redaction
+
+Forbidden raw substrings in claim body and `redaction_summary` (case-insensitive), including:
+
+`SURREAL_PASS`, `SURREAL_USER`, `Authorization`, `Basic `, `Bearer `, and assignment forms such as `password=`, `api_key=`, `secret=`, `token=`.
+
+Use `redact_for_summary()` in the validator for safe logging.
+
+## JSON export compatibility (#2850 — not implemented here)
+
+Issue [#2850](https://github.com/jannekbuengener/Claire_de_Binare/issues/2850) may emit benchmark JSON using this schema:
+
+- File: `docs/contracts/db_record_evidence_claim.v1.schema.json`
+- Examples: `docs/contracts/examples/db_record_evidence_*.json`
+- Stable field names in this document are the export contract; no generator in #2851.
+
+## Validation
+
+```bash
+python -m pytest tests/unit/surrealdb/test_db_record_evidence_contract.py -q
+```
+
+Harness regression (unchanged):
+
+```bash
+make context-live-invoke
+make context-live-invoke-full
+```
+
+## Related Wave-14 tables
+
+Evidence/claim/memory/decision record shapes: `tests/unit/surrealdb/wave14_contract_constants.py` and `infrastructure/surrealdb/context_intelligence_v0.surql`.

--- a/docs/contracts/db_record_evidence_claim.v1.schema.json
+++ b/docs/contracts/db_record_evidence_claim.v1.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DB Record Evidence Claim",
+  "$comment": "Issue #2851 — agent-facing context/tooling claim envelope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "claim_id",
+    "claim_type",
+    "claim_text_or_summary",
+    "producer_tool",
+    "tool_invocation_id_or_hash",
+    "query_or_lookup_fingerprint",
+    "record_source",
+    "record_ids",
+    "record_hashes_or_content_fingerprints",
+    "record_timestamps_or_freshness_signal",
+    "repo_crosscheck",
+    "source_priority",
+    "trust_classification",
+    "limitations",
+    "redaction_summary",
+    "determinism_hash"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "db-record-evidence-contract/v1",
+      "type": "string"
+    },
+    "claim_id": { "type": "string", "minLength": 1 },
+    "claim_type": { "type": "string", "minLength": 1 },
+    "claim_text_or_summary": { "type": "string", "minLength": 1 },
+    "producer_tool": { "type": "string", "minLength": 1 },
+    "tool_invocation_id_or_hash": { "type": "string", "minLength": 1 },
+    "query_or_lookup_fingerprint": { "type": "string", "minLength": 1 },
+    "record_source": {
+      "type": "string",
+      "enum": [
+        "surrealdb-local",
+        "surrealdb-local-unavailable",
+        "in_memory",
+        "repo-only"
+      ]
+    },
+    "record_ids": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "record_hashes_or_content_fingerprints": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "record_timestamps_or_freshness_signal": { "type": "string" },
+    "repo_crosscheck": {
+      "oneOf": [
+        { "type": "string", "minLength": 1 },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "path": { "type": "string" },
+            "file": { "type": "string" },
+            "symbol": { "type": "string" },
+            "commit": { "type": "string" },
+            "sha": { "type": "string" }
+          }
+        },
+        {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      ]
+    },
+    "source_priority": {
+      "type": "string",
+      "enum": [
+        "live_github",
+        "repo_files",
+        "surrealdb_context",
+        "ledger_snapshots",
+        "fallback"
+      ]
+    },
+    "trust_classification": {
+      "type": "string",
+      "enum": [
+        "valid_db_backed",
+        "partial",
+        "repo_only",
+        "in_memory_fixture",
+        "accepted_limitation",
+        "invalid_fake_db"
+      ]
+    },
+    "limitations": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "redaction_summary": { "type": "string" },
+    "determinism_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "caller_evidence": {
+      "type": "object",
+      "description": "Optional audit trail of ignored caller fields; must not be sole DB proof",
+      "additionalProperties": true
+    }
+  }
+}

--- a/docs/contracts/examples/db_record_evidence_accepted_limitation.json
+++ b/docs/contracts/examples/db_record_evidence_accepted_limitation.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "db-record-evidence-contract/v1",
+  "claim_id": "claim-harness-minimal-missing-evidence",
+  "claim_type": "context_tooling_benchmark",
+  "claim_text_or_summary": "Minimal harness invocation omitted inline evidence_records; handler fail-closed.",
+  "producer_tool": "cdb_context_evidence_resolve",
+  "tool_invocation_id_or_hash": "inv-minimal-cdb_context_evidence_resolve",
+  "query_or_lookup_fingerprint": "bridge:cdb_context_evidence_resolve:minimal:no_inline_records",
+  "record_source": "in_memory",
+  "record_ids": [],
+  "record_hashes_or_content_fingerprints": [],
+  "record_timestamps_or_freshness_signal": "not_applicable",
+  "repo_crosscheck": {
+    "path": "tools/surrealdb/context_live_invocation_harness.py",
+    "symbol": "PASS_WITH_LIMITS_ERROR_CODES",
+    "commit": "71a02158"
+  },
+  "source_priority": "repo_files",
+  "trust_classification": "accepted_limitation",
+  "limitations": [
+    "status=error code=missing_evidence_records — ACCEPTED_LIMITATION per #2852 ratification"
+  ],
+  "redaction_summary": "no sensitive values present",
+  "determinism_hash": "724d54f6a4c28f30f459280ad2510371f004f3ed4b3cefa4de459e709e6e96c1"
+}

--- a/docs/contracts/examples/db_record_evidence_invalid_fake_db.json
+++ b/docs/contracts/examples/db_record_evidence_invalid_fake_db.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "db-record-evidence-contract/v1",
+  "claim_id": "claim-forged-001",
+  "claim_type": "brain_evidence_block",
+  "claim_text_or_summary": "Caller asserted surrealdb-local without adapter record proof.",
+  "producer_tool": "context.briefing",
+  "tool_invocation_id_or_hash": "forged-invocation-001",
+  "query_or_lookup_fingerprint": "none",
+  "record_source": "surrealdb-local",
+  "record_ids": [],
+  "record_hashes_or_content_fingerprints": [],
+  "record_timestamps_or_freshness_signal": "not_applicable",
+  "repo_crosscheck": {
+    "path": "agents/AGENTS.md",
+    "commit": "71a02158"
+  },
+  "source_priority": "fallback",
+  "trust_classification": "invalid_fake_db",
+  "limitations": [
+    "caller brain_source ignored per derive_guarded_source_label"
+  ],
+  "redaction_summary": "no sensitive values present",
+  "caller_evidence": {
+    "brain_source": "surrealdb-local",
+    "metadata_source": "surrealdb-local"
+  },
+  "determinism_hash": "1b4491ac5c2536a7cc9e515b4b7838489fbd2177b00fa45e62ce21085fb167ad"
+}

--- a/docs/contracts/examples/db_record_evidence_valid.json
+++ b/docs/contracts/examples/db_record_evidence_valid.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "db-record-evidence-contract/v1",
+  "claim_id": "claim-wave14-evidence-001",
+  "claim_type": "wave14_read",
+  "claim_text_or_summary": "Evidence resolve returned one evidence_ref row from guarded local adapter.",
+  "producer_tool": "cdb_context_evidence_resolve",
+  "tool_invocation_id_or_hash": "a3f2c8e91b004d2f9e7a6c5b4d3e2f1a0b9c8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3",
+  "query_or_lookup_fingerprint": "SELECT * FROM evidence_ref WHERE evidence_id = $id LIMIT 1",
+  "record_source": "surrealdb-local",
+  "record_ids": ["evidence_ref:bench001"],
+  "record_hashes_or_content_fingerprints": [],
+  "record_timestamps_or_freshness_signal": "adapter_reported_created_at=2026-06-01T12:00:00Z",
+  "repo_crosscheck": {
+    "path": "tools/mcp/context_evidence_memory_tools.py",
+    "symbol": "cdb_context_evidence_resolve_handler",
+    "commit": "71a02158"
+  },
+  "source_priority": "surrealdb_context",
+  "trust_classification": "valid_db_backed",
+  "limitations": [
+    "LR NO-GO; record proof does not authorize live trading or persistence activation"
+  ],
+  "redaction_summary": "no sensitive values present",
+  "determinism_hash": "74d88a673992203aa732f65844ca895e7350772b3ea26c46e753dd2702967fd6"
+}

--- a/docs/evidence/context_tooling/CDB_PASS_WITH_LIMITS_RATIFICATION_2026-06-03.md
+++ b/docs/evidence/context_tooling/CDB_PASS_WITH_LIMITS_RATIFICATION_2026-06-03.md
@@ -65,6 +65,9 @@ make context-live-invoke
 make context-live-invoke-full
 
 pytest tests/unit/surrealdb/test_context_live_invocation_harness.py -q
+
+# DB-record evidence contract (agent claims; Issue #2851)
+pytest tests/unit/surrealdb/test_db_record_evidence_contract.py -q
 ```
 
 ---

--- a/tests/unit/surrealdb/test_db_record_evidence_contract.py
+++ b/tests/unit/surrealdb/test_db_record_evidence_contract.py
@@ -1,0 +1,140 @@
+"""Unit tests for DB-record evidence contract (#2851)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.surrealdb.db_record_evidence_contract import (
+    ACCEPTED_LIMITATION_CODES,
+    SCHEMA_VERSION,
+    build_example_claim,
+    classify_trust,
+    compute_determinism_hash,
+    redact_for_summary,
+    validate_db_record_evidence_claim,
+)
+
+EXAMPLES_DIR = Path("docs/contracts/examples")
+
+
+def _load_example(name: str) -> dict:
+    data = json.loads((EXAMPLES_DIR / name).read_text(encoding="utf-8"))
+    data["determinism_hash"] = compute_determinism_hash(data)
+    return data
+
+
+@pytest.mark.unit
+def test_valid_db_backed_example_passes_validator() -> None:
+    claim = _load_example("db_record_evidence_valid.json")
+    assert classify_trust(claim) == "valid_db_backed"
+    assert validate_db_record_evidence_claim(claim) == []
+
+
+@pytest.mark.unit
+def test_invalid_fake_db_example_classifies_but_has_no_valid_db_proof() -> None:
+    claim = _load_example("db_record_evidence_invalid_fake_db.json")
+    assert classify_trust(claim) == "invalid_fake_db"
+    assert validate_db_record_evidence_claim(claim) == []
+
+
+@pytest.mark.unit
+def test_accepted_limitation_example_passes() -> None:
+    claim = _load_example("db_record_evidence_accepted_limitation.json")
+    assert classify_trust(claim) == "accepted_limitation"
+    assert validate_db_record_evidence_claim(claim) == []
+
+
+@pytest.mark.unit
+def test_repo_only_baseline_from_builder() -> None:
+    claim = build_example_claim()
+    assert classify_trust(claim) == "repo_only"
+    assert validate_db_record_evidence_claim(claim) == []
+
+
+@pytest.mark.unit
+def test_caller_brain_source_without_records_is_invalid_fake_db() -> None:
+    claim = build_example_claim(
+        record_source="surrealdb-local",
+        trust_classification="invalid_fake_db",
+        record_ids=[],
+        record_hashes_or_content_fingerprints=[],
+        caller_evidence={"brain_source": "surrealdb-local"},
+        limitations=["caller brain_source ignored"],
+    )
+    claim["determinism_hash"] = compute_determinism_hash(claim)
+    assert classify_trust(claim) == "invalid_fake_db"
+    assert validate_db_record_evidence_claim(claim) == []
+
+
+@pytest.mark.unit
+def test_secret_substring_rejected() -> None:
+    claim = build_example_claim(
+        claim_text_or_summary="api_key=super-secret-value",
+    )
+    claim["determinism_hash"] = compute_determinism_hash(claim)
+    violations = validate_db_record_evidence_claim(claim)
+    assert any("secret" in v.lower() for v in violations)
+
+
+@pytest.mark.unit
+def test_redact_for_summary_masks_secrets() -> None:
+    claim = build_example_claim(
+        claim_text_or_summary="SURREAL_PASS=must-not-appear",
+    )
+    redacted = redact_for_summary(claim)
+    assert "[REDACTED]" in redacted["claim_text_or_summary"]
+
+
+@pytest.mark.unit
+def test_determinism_hash_stable_and_excludes_freshness() -> None:
+    claim = build_example_claim(
+        record_timestamps_or_freshness_signal="2026-06-03T18:00:00Z",
+    )
+    h1 = compute_determinism_hash(claim)
+    claim2 = dict(claim)
+    claim2["record_timestamps_or_freshness_signal"] = "2026-06-04T19:00:00Z"
+    h2 = compute_determinism_hash(claim2)
+    assert h1 == h2
+    claim["determinism_hash"] = h1
+    assert validate_db_record_evidence_claim(claim) == []
+
+
+@pytest.mark.unit
+def test_determinism_hash_mismatch_reported() -> None:
+    claim = build_example_claim()
+    claim["determinism_hash"] = "0" * 64
+    violations = validate_db_record_evidence_claim(claim)
+    assert any("determinism_hash mismatch" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_valid_db_backed_requires_record_proof() -> None:
+    claim = build_example_claim(
+        record_source="surrealdb-local",
+        trust_classification="valid_db_backed",
+        source_priority="surrealdb_context",
+        producer_tool="cdb_context_evidence_resolve",
+        query_or_lookup_fingerprint="SELECT 1",
+        record_ids=["evidence_ref:test"],
+        limitations=["LR NO-GO"],
+    )
+    claim["determinism_hash"] = compute_determinism_hash(claim)
+    assert validate_db_record_evidence_claim(claim) == []
+
+
+@pytest.mark.unit
+def test_accepted_limitation_codes_align_with_harness() -> None:
+    from tools.surrealdb.context_live_invocation_harness import (
+        PASS_WITH_LIMITS_ERROR_CODES,
+    )
+
+    assert ACCEPTED_LIMITATION_CODES == PASS_WITH_LIMITS_ERROR_CODES
+
+
+@pytest.mark.unit
+def test_schema_version_constant() -> None:
+    claim = build_example_claim()
+    assert claim["schema_version"] == SCHEMA_VERSION

--- a/tools/surrealdb/db_record_evidence_contract.py
+++ b/tools/surrealdb/db_record_evidence_contract.py
@@ -326,9 +326,7 @@ def validate_db_record_evidence_claim(claim: Mapping[str, Any]) -> list[str]:
 
     if classified == "valid_db_backed":
         if record_source != "surrealdb-local":
-            violations.append(
-                "valid_db_backed requires record_source=surrealdb-local"
-            )
+            violations.append("valid_db_backed requires record_source=surrealdb-local")
         if not _has_tool_query_proof(claim):
             violations.append(
                 "valid_db_backed requires producer_tool and "

--- a/tools/surrealdb/db_record_evidence_contract.py
+++ b/tools/surrealdb/db_record_evidence_contract.py
@@ -1,0 +1,410 @@
+"""DB-record evidence contract for context/tooling agent claims (Issue #2851).
+
+Read-only validation helpers. No DB access, no MCP mutations, no writes.
+LR remains NO-GO. Caller-supplied brain_source/metadata.source is not evidence.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any, Mapping
+
+from core.replay.canonical_json import canonical_hash
+
+SCHEMA_VERSION = "db-record-evidence-contract/v1"
+
+# Must stay aligned with tools.surrealdb.context_live_invocation_harness.PASS_WITH_LIMITS_ERROR_CODES
+ACCEPTED_LIMITATION_CODES = frozenset(
+    {
+        "missing_evidence_records",
+        "missing_claim_records",
+        "missing_memory_records",
+        "missing_decision_events",
+        "missing_records",
+        "missing_bundle",
+    }
+)
+
+CALLER_ONLY_EVIDENCE_KEYS = frozenset(
+    {
+        "brain_source",
+        "brain_status",
+        "metadata_source",
+        "metadata.source",
+        "adapter_status",
+        "caller_brain_source",
+        "caller_metadata_source",
+    }
+)
+
+SECRET_SUBSTRINGS = frozenset(
+    {
+        "SURREAL_PASS",
+        "SURREAL_USER",
+        "Authorization:",
+        "Authorization ",
+        "Basic ",
+        "password=",
+        "api_key=",
+        "api-key=",
+        "secret=",
+        "token=",
+        "Bearer ",
+    }
+)
+
+REQUIRED_CLAIM_FIELDS = (
+    "claim_id",
+    "claim_type",
+    "claim_text_or_summary",
+    "producer_tool",
+    "tool_invocation_id_or_hash",
+    "query_or_lookup_fingerprint",
+    "record_source",
+    "record_ids",
+    "record_hashes_or_content_fingerprints",
+    "record_timestamps_or_freshness_signal",
+    "repo_crosscheck",
+    "source_priority",
+    "trust_classification",
+    "limitations",
+    "redaction_summary",
+    "determinism_hash",
+)
+
+ALLOWED_RECORD_SOURCES = frozenset(
+    {
+        "surrealdb-local",
+        "surrealdb-local-unavailable",
+        "in_memory",
+        "repo-only",
+    }
+)
+
+ALLOWED_TRUST_CLASSIFICATIONS = frozenset(
+    {
+        "valid_db_backed",
+        "partial",
+        "repo_only",
+        "in_memory_fixture",
+        "accepted_limitation",
+        "invalid_fake_db",
+    }
+)
+
+ALLOWED_SOURCE_PRIORITIES = frozenset(
+    {
+        "live_github",
+        "repo_files",
+        "surrealdb_context",
+        "ledger_snapshots",
+        "fallback",
+    }
+)
+
+HASH_EXCLUDED_FIELDS = frozenset(
+    {
+        "determinism_hash",
+        "record_timestamps_or_freshness_signal",
+    }
+)
+
+_SECRET_RE = re.compile(
+    "|".join(re.escape(s) for s in sorted(SECRET_SUBSTRINGS, key=len, reverse=True)),
+    re.IGNORECASE,
+)
+
+
+class DbRecordEvidenceContractError(ValueError):
+    """Raised when a claim object cannot be interpreted."""
+
+
+def _as_str_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if isinstance(value, (list, tuple)):
+        out: list[str] = []
+        for item in value:
+            if item is None:
+                continue
+            text = str(item).strip()
+            if text:
+                out.append(text)
+        return out
+    text = str(value).strip()
+    return [text] if text else []
+
+
+def _claim_has_secret_leak(text: str) -> bool:
+    return bool(_SECRET_RE.search(text))
+
+
+def _serialize_claim_fragment(obj: Any) -> str:
+    if isinstance(obj, Mapping):
+        parts = []
+        for key in sorted(obj.keys()):
+            parts.append(f"{key}={_serialize_claim_fragment(obj[key])}")
+        return "{" + ",".join(parts) + "}"
+    if isinstance(obj, (list, tuple)):
+        return "[" + ",".join(_serialize_claim_fragment(v) for v in obj) + "]"
+    return str(obj)
+
+
+def _has_nonempty_record_proof(claim: Mapping[str, Any]) -> bool:
+    return bool(_as_str_list(claim.get("record_ids"))) or bool(
+        _as_str_list(claim.get("record_hashes_or_content_fingerprints"))
+    )
+
+
+def _has_tool_query_proof(claim: Mapping[str, Any]) -> bool:
+    tool = str(claim.get("producer_tool") or "").strip()
+    query = str(claim.get("query_or_lookup_fingerprint") or "").strip()
+    invocation = str(claim.get("tool_invocation_id_or_hash") or "").strip()
+    return bool(tool and (query or invocation))
+
+
+def _repo_crosscheck_present(claim: Mapping[str, Any]) -> bool:
+    crosscheck = claim.get("repo_crosscheck")
+    if isinstance(crosscheck, str) and crosscheck.strip():
+        return True
+    if isinstance(crosscheck, Mapping):
+        path = str(crosscheck.get("path") or crosscheck.get("file") or "").strip()
+        symbol = str(crosscheck.get("symbol") or "").strip()
+        commit = str(crosscheck.get("commit") or crosscheck.get("sha") or "").strip()
+        return bool(path or symbol or commit)
+    if isinstance(crosscheck, list) and crosscheck:
+        return True
+    return False
+
+
+def _caller_only_evidence_present(claim: Mapping[str, Any]) -> bool:
+    for key in CALLER_ONLY_EVIDENCE_KEYS:
+        if key in claim and claim.get(key) not in (None, "", [], {}):
+            return True
+    nested = claim.get("caller_evidence")
+    if isinstance(nested, Mapping) and nested:
+        return True
+    return False
+
+
+def hash_payload_for_determinism(claim: Mapping[str, Any]) -> dict[str, Any]:
+    """Build the stable subset used for determinism_hash (wall-clock excluded)."""
+    payload = {k: v for k, v in claim.items() if k not in HASH_EXCLUDED_FIELDS}
+    version = claim.get("schema_version")
+    if version is None:
+        payload["schema_version"] = SCHEMA_VERSION
+    return payload
+
+
+def compute_determinism_hash(claim: Mapping[str, Any]) -> str:
+    """Deterministic SHA-256 over canonical JSON of the stable claim subset."""
+    return canonical_hash(hash_payload_for_determinism(claim))
+
+
+def redact_for_summary(claim: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a redacted copy safe for logs and redaction_summary derivation."""
+
+    def _redact_value(value: Any) -> Any:
+        if isinstance(value, str):
+            if _claim_has_secret_leak(value):
+                return "[REDACTED]"
+            return value
+        if isinstance(value, Mapping):
+            return {k: _redact_value(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [_redact_value(v) for v in value]
+        return value
+
+    return _redact_value(dict(claim))
+
+
+def classify_trust(claim: Mapping[str, Any]) -> str:
+    """Classify trust outcome for a claim mapping (best-effort, after field checks)."""
+    declared = str(claim.get("trust_classification") or "").strip()
+    if declared in ALLOWED_TRUST_CLASSIFICATIONS:
+        # Honor explicit invalid/limitation classifications when consistent.
+        if declared == "invalid_fake_db":
+            return declared
+        if declared == "accepted_limitation":
+            return declared
+
+    record_source = str(claim.get("record_source") or "").strip()
+    limitations = _as_str_list(claim.get("limitations"))
+
+    for item in limitations:
+        for code in ACCEPTED_LIMITATION_CODES:
+            if code in item:
+                return "accepted_limitation"
+
+    if _caller_only_evidence_present(claim) and not _has_nonempty_record_proof(claim):
+        if record_source == "surrealdb-local":
+            return "invalid_fake_db"
+
+    if record_source == "surrealdb-local-unavailable":
+        return "partial"
+
+    if record_source == "repo-only":
+        return "repo_only"
+
+    if record_source == "in_memory":
+        return "in_memory_fixture"
+
+    if record_source == "surrealdb-local":
+        if (
+            _has_tool_query_proof(claim)
+            and _has_nonempty_record_proof(claim)
+            and not _caller_only_evidence_present(claim)
+        ):
+            return "valid_db_backed"
+        if _caller_only_evidence_present(claim):
+            return "invalid_fake_db"
+        return "partial"
+
+    if declared in ALLOWED_TRUST_CLASSIFICATIONS:
+        return declared
+    return "partial"
+
+
+def validate_db_record_evidence_claim(claim: Mapping[str, Any]) -> list[str]:
+    """Return violation messages; empty list means contract-compliant."""
+    violations: list[str] = []
+
+    if not isinstance(claim, Mapping):
+        return ["claim must be a mapping"]
+
+    for field in REQUIRED_CLAIM_FIELDS:
+        if field not in claim:
+            violations.append(f"missing required field: {field}")
+
+    version = claim.get("schema_version")
+    if version is not None and version != SCHEMA_VERSION:
+        violations.append(
+            f"schema_version must be {SCHEMA_VERSION!r} or omitted, got {version!r}"
+        )
+
+    serialized = _serialize_claim_fragment(claim)
+    if _claim_has_secret_leak(serialized):
+        violations.append("claim contains forbidden secret-like substrings")
+
+    record_source = str(claim.get("record_source") or "").strip()
+    if record_source and record_source not in ALLOWED_RECORD_SOURCES:
+        violations.append(
+            f"record_source {record_source!r} not in {sorted(ALLOWED_RECORD_SOURCES)}"
+        )
+
+    trust = str(claim.get("trust_classification") or "").strip()
+    if trust and trust not in ALLOWED_TRUST_CLASSIFICATIONS:
+        violations.append(
+            f"trust_classification {trust!r} not in "
+            f"{sorted(ALLOWED_TRUST_CLASSIFICATIONS)}"
+        )
+
+    priority = str(claim.get("source_priority") or "").strip()
+    if priority and priority not in ALLOWED_SOURCE_PRIORITIES:
+        violations.append(
+            f"source_priority {priority!r} not in {sorted(ALLOWED_SOURCE_PRIORITIES)}"
+        )
+
+    expected_hash = str(claim.get("determinism_hash") or "").strip()
+    if expected_hash:
+        actual = compute_determinism_hash(claim)
+        if expected_hash != actual:
+            violations.append(
+                "determinism_hash mismatch: expected stable canonical hash "
+                f"(got {expected_hash[:12]}..., expected {actual[:12]}...)"
+            )
+
+    classified = classify_trust(claim)
+    if trust and classified != trust:
+        violations.append(
+            f"trust_classification {trust!r} inconsistent with derived {classified!r}"
+        )
+
+    if classified == "valid_db_backed":
+        if record_source != "surrealdb-local":
+            violations.append(
+                "valid_db_backed requires record_source=surrealdb-local"
+            )
+        if not _has_tool_query_proof(claim):
+            violations.append(
+                "valid_db_backed requires producer_tool and "
+                "query_or_lookup_fingerprint or tool_invocation_id_or_hash"
+            )
+        if not _has_nonempty_record_proof(claim):
+            violations.append(
+                "valid_db_backed requires non-empty record_ids or "
+                "record_hashes_or_content_fingerprints"
+            )
+        if _caller_only_evidence_present(claim):
+            violations.append(
+                "valid_db_backed cannot rely on caller-only evidence keys"
+            )
+
+    if classified == "repo_only":
+        if not _repo_crosscheck_present(claim):
+            violations.append(
+                "repo_only requires repo_crosscheck path/symbol/commit or text"
+            )
+        if _has_nonempty_record_proof(claim) and record_source == "surrealdb-local":
+            violations.append("repo_only cannot assert surrealdb-local record proof")
+
+    if classified == "accepted_limitation":
+        if record_source == "surrealdb-local" and _has_nonempty_record_proof(claim):
+            violations.append(
+                "accepted_limitation cannot present as verified DB-backed"
+            )
+        has_limit_code = any(
+            any(code in lim for code in ACCEPTED_LIMITATION_CODES)
+            for lim in _as_str_list(claim.get("limitations"))
+        )
+        if not has_limit_code:
+            violations.append(
+                "accepted_limitation requires a limitation referencing "
+                f"one of {sorted(ACCEPTED_LIMITATION_CODES)}"
+            )
+
+    if classified == "invalid_fake_db":
+        if not _caller_only_evidence_present(claim):
+            violations.append(
+                "invalid_fake_db should document caller-only evidence in claim"
+            )
+
+    redaction = str(claim.get("redaction_summary") or "")
+    if redaction and _claim_has_secret_leak(redaction):
+        violations.append("redaction_summary must not contain raw secret-like values")
+
+    return violations
+
+
+def build_example_claim(**overrides: Any) -> dict[str, Any]:
+    """Helper for tests: minimal valid repo-only claim with deterministic hash."""
+    base: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "claim_id": "claim-example-001",
+        "claim_type": "context_tooling_benchmark",
+        "claim_text_or_summary": "Harness minimal profile documents fail-closed record paths.",
+        "producer_tool": "context_live_invocation_harness",
+        "tool_invocation_id_or_hash": "inv-minimal-cdb_context_evidence_resolve",
+        "query_or_lookup_fingerprint": "bridge:cdb_context_evidence_resolve:minimal",
+        "record_source": "repo-only",
+        "record_ids": [],
+        "record_hashes_or_content_fingerprints": [],
+        "record_timestamps_or_freshness_signal": "not_applicable",
+        "repo_crosscheck": {
+            "path": "docs/evidence/context_tooling/CDB_PASS_WITH_LIMITS_RATIFICATION_2026-06-03.md",
+            "commit": "71a02158",
+        },
+        "source_priority": "repo_files",
+        "trust_classification": "repo_only",
+        "limitations": [
+            "brain_source=repo-only; no surrealdb-local record IDs in this benchmark slice",
+        ],
+        "redaction_summary": "no sensitive values present",
+    }
+    base.update(overrides)
+    base["determinism_hash"] = compute_determinism_hash(base)
+    return base


### PR DESCRIPTION
## Summary

Defines the canonical **DB-record evidence contract** for context/tooling agent claims (Issue #2851): documentation, JSON Schema, examples, and a read-only Python validator with unit tests.

Closes #2851

Refs #2847

Refs #2850 (schema field stability only; no JSON benchmark export in this PR)

## Delivered

- Contract doc: `docs/contracts/context_tooling/DB_RECORD_EVIDENCE_CONTRACT.md`
- JSON Schema: `docs/contracts/db_record_evidence_claim.v1.schema.json`
- Examples: `docs/contracts/examples/db_record_evidence_*.json`
- Validator: `tools/surrealdb/db_record_evidence_contract.py`
- Tests: `tests/unit/surrealdb/test_db_record_evidence_contract.py` (12 tests)
- Nav: link in `agents/AGENTS.md` § Brain Evidence; pytest line in PASS_WITH_LIMITS ratification doc

## Brain Evidence

```text
brain_source: repo-only
brain_status: used
tools_or_queries:
  - gh issue view 2851
  - python -m pytest tests/unit/surrealdb/test_db_record_evidence_contract.py -q
records_or_results:
  - 12 passed unit tests; no surrealdb-local record IDs queried
repo_crosscheck:
  - agents/AGENTS.md § Brain Evidence Gate
  - tools/mcp/surrealdb_adapter_factory.py derive_guarded_source_label
  - context_live_invocation_harness PASS_WITH_LIMITS_ERROR_CODES alignment test
impact_on_plan:
  - SSOT for when claims may be cited as DB-backed vs repo-only / accepted_limitation
limitations:
  - No MCP/bridge wiring; no productive DB writes; LR NO-GO unchanged
```

## Validation

- `python -m pytest tests/unit/surrealdb/test_db_record_evidence_contract.py -q` → 12 passed
- `git diff --check` → clean

## Non-goals

- #2850 JSON benchmark artifact generator
- #2853 root inventory
- #2854 negative controls regression
- Runtime BLUE/RED or MCP behavior changes

## Safety Boundaries

- LR **NO-GO**; `PERSIST_ALLOWED=False`; `MUTATION_ALLOWED=False`
- Caller-supplied `brain_source` / `metadata.source` is not DB evidence
- Board `trade-capable` is not live-go

## Test plan

- [x] Unit tests for validator (valid DB-backed, repo-only, accepted_limitation, fake DB, redaction, determinism)
- [x] `ACCEPTED_LIMITATION_CODES` matches harness `PASS_WITH_LIMITS_ERROR_CODES`
