### PR TITLE
feat(context): emit machine-readable invocation evidence

### DIFF
--- a/docs/contracts/context_tooling/DB_RECORD_EVIDENCE_CONTRACT.md
+++ b/docs/contracts/context_tooling/DB_RECORD_EVIDENCE_CONTRACT.md
@@ -8,6 +8,7 @@
 | Parent meta | [#2847](https://github.com/jannekbuengener/Claire_de_Binare/issues/2847) |
 | Validator | [`tools/surrealdb/db_record_evidence_contract.py`](../../../tools/surrealdb/db_record_evidence_contract.py) |
 | JSON Schema | [`docs/contracts/db_record_evidence_claim.v1.schema.json`](../db_record_evidence_claim.v1.schema.json) |
+| Invocation bundle (#2850) | [`TOOL_INVOCATION_JSON_EVIDENCE.md`](TOOL_INVOCATION_JSON_EVIDENCE.md) |
 
 ## Purpose
 

--- a/docs/contracts/context_tooling/TOOL_INVOCATION_JSON_EVIDENCE.md
+++ b/docs/contracts/context_tooling/TOOL_INVOCATION_JSON_EVIDENCE.md
@@ -1,0 +1,38 @@
+# Tool invocation JSON evidence (#2850)
+
+Machine-readable evidence for the context live invocation regression harness. Complements human-readable markdown/text output and embeds **db-record-evidence claims** from [#2851](../context_tooling/DB_RECORD_EVIDENCE_CONTRACT.md).
+
+| Artifact | Path |
+|----------|------|
+| Aggregate JSON Schema | [`docs/contracts/tool_invocation_evidence.v1.schema.json`](../tool_invocation_evidence.v1.schema.json) |
+| Per-claim JSON Schema | [`docs/contracts/db_record_evidence_claim.v1.schema.json`](../db_record_evidence_claim.v1.schema.json) |
+| Builder | [`tools/surrealdb/context_invocation_evidence_json.py`](../../../tools/surrealdb/context_invocation_evidence_json.py) |
+| Harness | [`tools/surrealdb/context_live_invocation_harness.py`](../../../tools/surrealdb/context_live_invocation_harness.py) |
+
+## Generate JSON evidence
+
+```bash
+# Minimal profile (expect final_verdict PASS_WITH_LIMITS, six accepted limitations)
+python -m tools.surrealdb.context_live_invocation_harness --format json
+
+# Full profile (expect final_verdict PASS, zero accepted limitations)
+python -m tools.surrealdb.context_live_invocation_harness --profile full --format json
+
+# Write to file (optional)
+python -m tools.surrealdb.context_live_invocation_harness --format json \
+  --output docs/evidence/context_tooling/latest_invocation_evidence.json
+```
+
+Makefile targets `context-live-invoke` and `context-live-invoke-full` remain unchanged (text/markdown default). Use `--format json` when you need the evidence bundle.
+
+## Interpretation
+
+- **`final_verdict`**: `PASS_WITH_LIMITS` when the minimal profile documents six fail-closed Wave-14 record paths; `PASS` when the full inline-record profile has no `PASS_WITH_LIMITS` rows.
+- **`evidence_claims`**: One claim per `PASS_WITH_LIMITS` matrix row, `trust_classification=accepted_limitation`, aligned with `PASS_WITH_LIMITS_ERROR_CODES` / #2852 ratification.
+- **`determinism_hash`**: Stable across runs with the same matrix and git SHA; excludes `started_at_or_observed_at` and the hash field itself.
+- **No fake DB-backed claims**: Accepted-limitation claims use `in_memory` / empty record proof, not `surrealdb-local` with record IDs.
+
+## Scope boundaries
+
+- **#2853** (root inventory), **#2854** (negative controls), **#2855** (operator senses docs), **#2856** (trust thresholds) are out of scope for this slice.
+- **LR remains NO-GO**; JSON evidence does not authorize live capital or productive DB writes.

--- a/docs/contracts/tool_invocation_evidence.v1.schema.json
+++ b/docs/contracts/tool_invocation_evidence.v1.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare.local/contracts/tool_invocation_evidence.v1.schema.json",
+  "title": "Tool invocation benchmark evidence (aggregate)",
+  "description": "Machine-readable evidence bundle for context live invocation harness (#2850). evidence_claims entries MUST comply with db_record_evidence_claim.v1.schema.json.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "run_id_or_invocation_id",
+    "profile",
+    "final_verdict",
+    "started_at_or_observed_at",
+    "tool_invocations",
+    "evidence_claims",
+    "limits",
+    "accepted_limitations",
+    "missing_evidence_codes",
+    "summary_counts",
+    "determinism_hash",
+    "redaction_summary",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "tool-invocation-evidence/v1"
+    },
+    "run_id_or_invocation_id": { "type": "string", "minLength": 1 },
+    "profile": { "enum": ["minimal", "full"] },
+    "final_verdict": { "enum": ["PASS", "PASS_WITH_LIMITS", "FAIL"] },
+    "started_at_or_observed_at": { "type": "string" },
+    "tool_invocations": { "type": "array" },
+    "evidence_claims": {
+      "type": "array",
+      "description": "Each item is a db-record-evidence claim per #2851"
+    },
+    "limits": { "type": "array" },
+    "accepted_limitations": { "type": "array" },
+    "missing_evidence_codes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "summary_counts": { "type": "object" },
+    "determinism_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "redaction_summary": { "type": "string" },
+    "limitations": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/tests/unit/surrealdb/test_context_invocation_evidence_json.py
+++ b/tests/unit/surrealdb/test_context_invocation_evidence_json.py
@@ -158,9 +158,9 @@ def test_determinism_hash_stable_for_equivalent_report() -> None:
     )
     doc_b = evidence_json.build_invocation_evidence(other)
     assert doc_a["determinism_hash"] == doc_b["determinism_hash"]
-    assert doc_a["determinism_hash"] == evidence_json.compute_aggregate_determinism_hash(
-        doc_a
-    )
+    assert doc_a[
+        "determinism_hash"
+    ] == evidence_json.compute_aggregate_determinism_hash(doc_a)
 
 
 def test_json_output_has_no_secret_substrings() -> None:

--- a/tests/unit/surrealdb/test_context_invocation_evidence_json.py
+++ b/tests/unit/surrealdb/test_context_invocation_evidence_json.py
@@ -1,0 +1,212 @@
+"""Unit tests for machine-readable invocation JSON evidence (#2850)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.surrealdb import context_invocation_evidence_json as evidence_json
+from tools.surrealdb import context_live_invocation_harness as harness
+from tools.surrealdb.db_record_evidence_contract import (
+    ACCEPTED_LIMITATION_CODES,
+    validate_db_record_evidence_claim,
+)
+
+pytestmark = pytest.mark.unit
+
+_REQUIRED_TOP_LEVEL = frozenset(
+    {
+        "schema_version",
+        "run_id_or_invocation_id",
+        "profile",
+        "final_verdict",
+        "started_at_or_observed_at",
+        "tool_invocations",
+        "evidence_claims",
+        "limits",
+        "accepted_limitations",
+        "missing_evidence_codes",
+        "summary_counts",
+        "determinism_hash",
+        "redaction_summary",
+        "limitations",
+    }
+)
+
+
+def _mock_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    profile: harness.InvocationProfile,
+    execute_fn,
+) -> harness.HarnessReport:
+    registry_names = sorted(harness.invocations_for_profile(profile).keys())
+    bridge = MagicMock()
+    bridge.list_tools.return_value = [{"name": n} for n in registry_names]
+    bridge.execute_tool.side_effect = execute_fn
+    monkeypatch.setattr(harness, "create_bridge", lambda: bridge)
+    monkeypatch.setattr(
+        harness,
+        "_git_metadata",
+        lambda _root: {
+            "git_sha": "deadbeefdeadbeef",
+            "branch": "test",
+            "worktree_clean": True,
+            "git_available": True,
+        },
+    )
+    return harness.run_matrix(
+        live=True,
+        profile=profile,
+        fail_on_limits=profile == "full",
+    )
+
+
+def test_minimal_json_pass_with_limits_and_six_accepted_limitations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _execute(tool_name: str, parameters: dict) -> dict:
+        if tool_name == "cdb_context_memory_write_intent":
+            return {"status": "refused", "code": "agent_memory_write_not_activated"}
+        if tool_name in harness.BENCHMARK_FULL_RECORD_OVERRIDES:
+            code = "missing_records"
+            if tool_name == "cdb_context_evidence_resolve":
+                code = "missing_evidence_records"
+            elif tool_name == "cdb_context_claim_resolve":
+                code = "missing_claim_records"
+            elif tool_name == "cdb_context_memory_get":
+                code = "missing_memory_records"
+            elif tool_name.startswith("cdb_context_decision"):
+                code = "missing_decision_events"
+            return {"status": "error", "error": {"code": code}}
+        return {"status": "ok", "tool": tool_name}
+
+    report = _mock_matrix(monkeypatch, profile="minimal", execute_fn=_execute)
+    doc = evidence_json.build_invocation_evidence(report)
+
+    assert doc["schema_version"] == evidence_json.SCHEMA_VERSION
+    assert doc["profile"] == "minimal"
+    assert doc["final_verdict"] == "PASS_WITH_LIMITS"
+    assert set(_REQUIRED_TOP_LEVEL) <= set(doc.keys())
+    assert len(doc["accepted_limitations"]) == 6
+    assert len(doc["evidence_claims"]) == 6
+    assert set(doc["missing_evidence_codes"]) <= set(ACCEPTED_LIMITATION_CODES)
+    for claim in doc["evidence_claims"]:
+        assert not validate_db_record_evidence_claim(claim)
+        assert claim["trust_classification"] == "accepted_limitation"
+        assert claim["record_source"] in ("in_memory", "repo-only")
+        assert not claim.get("record_ids")
+
+
+def test_full_json_pass_zero_accepted_limitations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _execute(tool_name: str, parameters: dict) -> dict:
+        if tool_name == "cdb_context_memory_write_intent":
+            return {
+                "status": "refused",
+                "code": "agent_memory_write_not_activated",
+            }
+        return {"status": "ok", "tool": tool_name}
+
+    report = _mock_matrix(monkeypatch, profile="full", execute_fn=_execute)
+    doc = evidence_json.build_invocation_evidence(report)
+
+    assert doc["final_verdict"] == "PASS"
+    assert doc["accepted_limitations"] == []
+    assert doc["evidence_claims"] == []
+    assert doc["missing_evidence_codes"] == []
+    assert report.summary.get("PASS_WITH_LIMITS", 0) == 0
+
+
+def test_determinism_hash_stable_for_equivalent_report() -> None:
+    base = harness.HarnessReport(
+        timestamp="2026-06-03T12:00:00Z",
+        git_sha="abc123",
+        branch="main",
+        worktree_clean=True,
+        tool_count=27,
+        expected_tool_count=27,
+        profile="minimal",
+        matrix=[
+            harness.MatrixRow(
+                tool_name="cdb_context_evidence_resolve",
+                call={"evidence_id": "ev1"},
+                expected="fail-closed",
+                actual="missing_evidence_records",
+                status="PASS_WITH_LIMITS",
+                error_code="missing_evidence_records",
+            )
+        ],
+        summary={"PASS": 21, "PASS_WITH_LIMITS": 6, "FAIL": 0, "BLOCKED_SAFETY": 0},
+        final_verdict="pass",
+    )
+    doc_a = evidence_json.build_invocation_evidence(base)
+    other = harness.HarnessReport(
+        timestamp="2026-06-04T99:99:99Z",
+        git_sha=base.git_sha,
+        branch=base.branch,
+        worktree_clean=base.worktree_clean,
+        tool_count=base.tool_count,
+        expected_tool_count=base.expected_tool_count,
+        profile=base.profile,
+        matrix=base.matrix,
+        summary=base.summary,
+        final_verdict=base.final_verdict,
+    )
+    doc_b = evidence_json.build_invocation_evidence(other)
+    assert doc_a["determinism_hash"] == doc_b["determinism_hash"]
+    assert doc_a["determinism_hash"] == evidence_json.compute_aggregate_determinism_hash(
+        doc_a
+    )
+
+
+def test_json_output_has_no_secret_substrings() -> None:
+    report = harness.HarnessReport(
+        timestamp="2026-06-03T00:00:00Z",
+        git_sha="abc",
+        branch="main",
+        worktree_clean=True,
+        tool_count=1,
+        expected_tool_count=27,
+        matrix=[
+            harness.MatrixRow(
+                tool_name="context.search",
+                call={"query": "benchmark"},
+                expected="ok",
+                actual="status=ok",
+                status="PASS",
+            )
+        ],
+    )
+    payload = evidence_json.serialize_invocation_evidence(report)
+    lowered = payload.lower()
+    assert "password=" not in lowered
+    assert "api_key=" not in lowered
+    assert "bearer " not in lowered
+
+
+def test_format_report_json_emits_evidence_schema() -> None:
+    report = harness.HarnessReport(
+        timestamp="2026-06-03T00:00:00Z",
+        git_sha="abc",
+        branch="main",
+        worktree_clean=True,
+        tool_count=1,
+        expected_tool_count=27,
+        matrix=[
+            harness.MatrixRow(
+                tool_name="context.search",
+                call={"query": "x"},
+                expected="ok",
+                actual="status=ok",
+                status="PASS",
+            )
+        ],
+    )
+    payload = harness.format_report(report, "json")
+    doc = json.loads(payload)
+    assert doc["schema_version"] == evidence_json.SCHEMA_VERSION
+    assert "determinism_hash" in doc

--- a/tests/unit/surrealdb/test_context_live_invocation_harness.py
+++ b/tests/unit/surrealdb/test_context_live_invocation_harness.py
@@ -198,7 +198,7 @@ def test_run_matrix_fails_when_registry_missing_manifest_entry(
     assert report.missing_from_manifest == ["context.unlisted_tool"]
 
 
-def test_format_report_json_contains_matrix() -> None:
+def test_format_report_json_emits_machine_readable_evidence() -> None:
     report = harness.HarnessReport(
         timestamp="2026-06-03T00:00:00Z",
         git_sha="abc",
@@ -217,5 +217,6 @@ def test_format_report_json_contains_matrix() -> None:
         ],
     )
     payload = harness.format_report(report, "json")
+    assert "tool-invocation-evidence/v1" in payload
     assert '"context.search"' in payload
-    assert '"PASS"' in payload
+    assert "determinism_hash" in payload

--- a/tools/surrealdb/context_invocation_evidence_json.py
+++ b/tools/surrealdb/context_invocation_evidence_json.py
@@ -37,7 +37,9 @@ GLOBAL_LIMITATIONS = (
 )
 
 
-def _invocation_fingerprint(tool_name: str, call: Mapping[str, Any], profile: str) -> str:
+def _invocation_fingerprint(
+    tool_name: str, call: Mapping[str, Any], profile: str
+) -> str:
     payload = {"profile": profile, "tool": tool_name, "call": dict(call)}
     return canonical_hash(payload)[:16]
 
@@ -168,11 +170,7 @@ def _limits_block(report: harness.HarnessReport) -> list[dict[str, str]]:
 
 def hash_payload_for_determinism(document: Mapping[str, Any]) -> dict[str, Any]:
     """Stable subset for aggregate determinism_hash (wall-clock excluded)."""
-    return {
-        k: v
-        for k, v in document.items()
-        if k not in HASH_EXCLUDED_TOP_LEVEL
-    }
+    return {k: v for k, v in document.items() if k not in HASH_EXCLUDED_TOP_LEVEL}
 
 
 def compute_aggregate_determinism_hash(document: Mapping[str, Any]) -> str:

--- a/tools/surrealdb/context_invocation_evidence_json.py
+++ b/tools/surrealdb/context_invocation_evidence_json.py
@@ -1,0 +1,236 @@
+"""Machine-readable JSON evidence for context live invocation benchmarks (#2850).
+
+Aggregates harness matrix output with db-record-evidence claims (#2851).
+Read-only: no DB access, no MCP mutations, no writes except optional file export.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+from core.replay.canonical_json import canonical_hash, canonical_json_dumps
+from tools.surrealdb import context_live_invocation_harness as harness
+from tools.surrealdb.db_record_evidence_contract import (
+    ACCEPTED_LIMITATION_CODES,
+    SCHEMA_VERSION as CLAIM_SCHEMA_VERSION,
+    build_example_claim,
+    compute_determinism_hash,
+    validate_db_record_evidence_claim,
+)
+
+SCHEMA_VERSION = "tool-invocation-evidence/v1"
+ISSUE_REF = "2850"
+
+HASH_EXCLUDED_TOP_LEVEL = frozenset(
+    {
+        "determinism_hash",
+        "started_at_or_observed_at",
+    }
+)
+
+GLOBAL_LIMITATIONS = (
+    "bridge_only: MCP stdio path not exercised; handlers invoked via in-process bridge",
+    "PERSIST_ALLOWED=false and MUTATION_ALLOWED=false for benchmark runs",
+    "no productive SurrealDB writes in this harness slice",
+    "LR remains NO-GO; benchmark evidence is not live-capital or LR-GO proof",
+)
+
+
+def _invocation_fingerprint(tool_name: str, call: Mapping[str, Any], profile: str) -> str:
+    payload = {"profile": profile, "tool": tool_name, "call": dict(call)}
+    return canonical_hash(payload)[:16]
+
+
+def _stable_run_id(profile: str, git_sha: str) -> str:
+    sha = (git_sha or "unknown")[:12]
+    return f"context-live-invoke-{profile}-{sha}"
+
+
+def derive_evidence_final_verdict(report: harness.HarnessReport) -> str:
+    """Map harness outcome to machine-readable final_verdict for JSON evidence."""
+    if report.final_verdict == "fail":
+        return "FAIL"
+    limits_count = report.summary.get("PASS_WITH_LIMITS", 0)
+    if limits_count > 0 and report.profile == "minimal":
+        return "PASS_WITH_LIMITS"
+    return "PASS"
+
+
+def _build_accepted_limitation_claim(
+    row: harness.MatrixRow,
+    *,
+    profile: str,
+    git_sha: str,
+) -> dict[str, Any]:
+    code = row.error_code or "missing_records"
+    if code not in ACCEPTED_LIMITATION_CODES:
+        code = "missing_records"
+    inv_hash = _invocation_fingerprint(row.tool_name, row.call, profile)
+    claim = build_example_claim(
+        claim_id=f"claim-{profile}-{row.tool_name}",
+        claim_type="context_tooling_benchmark",
+        claim_text_or_summary=(
+            f"Harness {profile} profile: {row.tool_name} returned fail-closed "
+            f"{code} without inline records."
+        ),
+        producer_tool=row.tool_name,
+        tool_invocation_id_or_hash=f"inv-{profile}-{row.tool_name}-{inv_hash}",
+        query_or_lookup_fingerprint=(
+            f"bridge:{row.tool_name}:{profile}:no_inline_records"
+        ),
+        record_source="in_memory",
+        record_ids=[],
+        record_hashes_or_content_fingerprints=[],
+        record_timestamps_or_freshness_signal="not_applicable",
+        repo_crosscheck={
+            "path": harness.RATIFICATION_DOC,
+            "symbol": "PASS_WITH_LIMITS_ERROR_CODES",
+            "commit": (git_sha or "unknown")[:8],
+        },
+        source_priority="repo_files",
+        trust_classification="accepted_limitation",
+        limitations=[
+            f"status=error code={code} — ACCEPTED_LIMITATION per #2852 ratification",
+        ],
+        redaction_summary="no sensitive values present",
+    )
+    violations = validate_db_record_evidence_claim(claim)
+    if violations:
+        raise ValueError(
+            f"accepted_limitation claim for {row.tool_name} invalid: {violations}"
+        )
+    return claim
+
+
+def _tool_invocation_row(row: harness.MatrixRow, *, profile: str) -> dict[str, Any]:
+    return {
+        "tool_name": row.tool_name,
+        "invocation_id": _invocation_fingerprint(row.tool_name, row.call, profile),
+        "call": row.call,
+        "matrix_status": row.status,
+        "handler_status": row.handler_status,
+        "error_code": row.error_code,
+        "limitation_note": row.limitation,
+        "invocation_path": row.invocation_path,
+        "expected_summary": row.expected,
+        "actual_summary": row.actual,
+    }
+
+
+def _accepted_limitations_list(
+    rows: list[harness.MatrixRow],
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        if row.status != "PASS_WITH_LIMITS":
+            continue
+        code = row.error_code or "missing_records"
+        out.append(
+            {
+                "tool_name": row.tool_name,
+                "error_code": code,
+                "matrix_status": row.status,
+                "accepted": True,
+                "rationale": "PASS_WITH_LIMITS_ERROR_CODES and #2852 ratification",
+            }
+        )
+    return sorted(out, key=lambda item: item["tool_name"])
+
+
+def _missing_evidence_codes(rows: list[harness.MatrixRow]) -> list[str]:
+    codes: set[str] = set()
+    for row in rows:
+        if row.status == "PASS_WITH_LIMITS" and row.error_code:
+            codes.add(row.error_code)
+    return sorted(codes)
+
+
+def _limits_block(report: harness.HarnessReport) -> list[dict[str, str]]:
+    items = [
+        {"code": "bridge_only", "description": GLOBAL_LIMITATIONS[0]},
+        {"code": "safety_gates_default_off", "description": GLOBAL_LIMITATIONS[1]},
+        {"code": "no_productive_db_writes", "description": GLOBAL_LIMITATIONS[2]},
+        {"code": "lr_no_go", "description": GLOBAL_LIMITATIONS[3]},
+    ]
+    if report.profile == "minimal":
+        items.append(
+            {
+                "code": "inline_records_absent",
+                "description": (
+                    "Six Wave-14 tools use minimal fail-closed payloads; "
+                    "full profile supplies inline records (#2852)."
+                ),
+            }
+        )
+    return items
+
+
+def hash_payload_for_determinism(document: Mapping[str, Any]) -> dict[str, Any]:
+    """Stable subset for aggregate determinism_hash (wall-clock excluded)."""
+    return {
+        k: v
+        for k, v in document.items()
+        if k not in HASH_EXCLUDED_TOP_LEVEL
+    }
+
+
+def compute_aggregate_determinism_hash(document: Mapping[str, Any]) -> str:
+    return canonical_hash(hash_payload_for_determinism(document))
+
+
+def build_invocation_evidence(report: harness.HarnessReport) -> dict[str, Any]:
+    """Build the #2850 machine-readable evidence document from a harness report."""
+    limit_rows = [r for r in report.matrix if r.status == "PASS_WITH_LIMITS"]
+    evidence_claims = [
+        _build_accepted_limitation_claim(
+            row, profile=report.profile, git_sha=report.git_sha
+        )
+        for row in sorted(limit_rows, key=lambda r: r.tool_name)
+    ]
+    tool_invocations = [
+        _tool_invocation_row(row, profile=report.profile)
+        for row in sorted(report.matrix, key=lambda r: r.tool_name)
+    ]
+    accepted = _accepted_limitations_list(report.matrix)
+    missing_codes = _missing_evidence_codes(report.matrix)
+    final_verdict = derive_evidence_final_verdict(report)
+
+    document: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id_or_invocation_id": _stable_run_id(report.profile, report.git_sha),
+        "profile": report.profile,
+        "final_verdict": final_verdict,
+        "started_at_or_observed_at": report.timestamp,
+        "tool_invocations": tool_invocations,
+        "evidence_claims": evidence_claims,
+        "limits": _limits_block(report),
+        "accepted_limitations": accepted,
+        "missing_evidence_codes": missing_codes,
+        "summary_counts": dict(report.summary),
+        "redaction_summary": "no sensitive values present; bridge benchmark payloads only",
+        "limitations": list(GLOBAL_LIMITATIONS),
+        "issue_ref": ISSUE_REF,
+        "parent_issue_ref": harness.ISSUE_REF,
+        "ratification_doc": report.ratification_doc,
+        "claim_schema_version": CLAIM_SCHEMA_VERSION,
+        "git_sha": report.git_sha,
+        "branch": report.branch,
+        "worktree_clean": report.worktree_clean,
+        "lr_note": report.lr_note,
+        "safety_flags": dict(report.safety_flags),
+    }
+    document["determinism_hash"] = compute_aggregate_determinism_hash(document)
+    return document
+
+
+def serialize_invocation_evidence(
+    report: harness.HarnessReport,
+    *,
+    indent: int | None = 2,
+) -> str:
+    """Canonical JSON string for CLI and file export."""
+    document = build_invocation_evidence(report)
+    if indent is None:
+        return canonical_json_dumps(document)
+    return json.dumps(document, indent=indent, sort_keys=True, ensure_ascii=False)

--- a/tools/surrealdb/context_live_invocation_harness.py
+++ b/tools/surrealdb/context_live_invocation_harness.py
@@ -3,13 +3,14 @@
 Invokes every registered tool via ContextBridge (same handler path as MCP server)
 with benchmark-safe parameters. Produces a per-tool matrix for regression detection.
 
-Issue: #2849, #2852 (profiles + ratification)
+Issue: #2849, #2852 (profiles + ratification), #2850 (JSON evidence)
 Parent: #2847
 
 Usage:
     python -m tools.surrealdb.context_live_invocation_harness
     python -m tools.surrealdb.context_live_invocation_harness --profile full
     python -m tools.surrealdb.context_live_invocation_harness --format json
+    python -m tools.surrealdb.context_live_invocation_harness --format json --output docs/evidence/context_tooling/latest_invocation_evidence.json
     make context-live-invoke
     make context-live-invoke-full
 
@@ -611,7 +612,11 @@ def format_report_markdown(report: HarnessReport) -> str:
 
 def format_report(report: HarnessReport, fmt: OutputFormat) -> str:
     if fmt == "json":
-        return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+        from tools.surrealdb.context_invocation_evidence_json import (
+            serialize_invocation_evidence,
+        )
+
+        return serialize_invocation_evidence(report)
     if fmt in ("text", "markdown"):
         return format_report_markdown(report)
     raise ValueError(f"unsupported format: {fmt!r}")
@@ -621,6 +626,7 @@ _HELP_EPILOG = """\
 Examples:
   python -m tools.surrealdb.context_live_invocation_harness
   python -m tools.surrealdb.context_live_invocation_harness --format json
+  python -m tools.surrealdb.context_live_invocation_harness --format json --output docs/evidence/context_tooling/latest_invocation_evidence.json
   make context-live-invoke
   make context-live-invoke-full
 
@@ -646,7 +652,10 @@ def main(argv: list[str] | None = None) -> int:
         "--format",
         choices=("text", "json", "markdown"),
         default="text",
-        help="Output format (default: text)",
+        help=(
+            "Output format (default: text). json emits #2850 machine-readable "
+            "invocation evidence (compatible with db-record-evidence claims)."
+        ),
     )
     parser.add_argument(
         "--output",


### PR DESCRIPTION
## Summary
- Emit deterministic \	ool-invocation-evidence/v1\ JSON from the live invocation harness (\--format json\).
- Embed #2851 \db-record-evidence\ claims for each \PASS_WITH_LIMITS\ row (minimal profile: six accepted \missing_*\ limitations).
- Add aggregate schema, operator doc, and unit tests (minimal/full/determinism/no secrets).

Closes #2850
Refs #2851
Refs #2852
Refs #2847

## Delivered
- \	ools/surrealdb/context_invocation_evidence_json.py\ builder + stable \determinism_hash\
- Harness \--format json\ wired to aggregate evidence (text/markdown unchanged)
- \docs/contracts/tool_invocation_evidence.v1.schema.json\ + \TOOL_INVOCATION_JSON_EVIDENCE.md\

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- No SurrealDB/MCP queries in this slice; claims use \in_memory\ / accepted_limitation semantics per #2851.

## Validation
- \pytest -q tests/unit/surrealdb/test_db_record_evidence_contract.py tests/unit/surrealdb/test_context_invocation_evidence_json.py tests/unit/surrealdb/test_context_live_invocation_harness.py\ (25 passed)
- \make context-live-invoke\ (27 tools, 6 PASS_WITH_LIMITS)
- Live \--format json\ → \inal_verdict=PASS_WITH_LIMITS\, six accepted limitations

## Non-goals
- #2853 root inventory, #2854 negative controls, #2855 operator senses docs, #2856 trust thresholds

## Safety Boundaries
- LR NO-GO; no productive DB writes; PERSIST_ALLOWED/MUTATION_ALLOWED remain false; no runtime BLUE/RED changes.

## Restunsicherheiten
- Aggregate schema is separate from per-claim schema; \vidence_claims[]\ validated in tests via #2851 validator, not JSON Schema ref yet.

Made with [Cursor](https://cursor.com)