### PR TITLE
fix(mcp): reconcile root target inventory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ help:
 	@echo "  make context-certify         - Read-only operator certification proof pack (#2776)"
 	@echo "  make context-live-invoke     - All-tools live bridge matrix, minimal profile (#2849)"
 	@echo "  make context-live-invoke-full - Same harness with inline records, 27 PASS (#2852)"
+	@echo "  make context-root-inventory  - Cross-repo root + GitHub target inventory (#2853)"
 # ============================================================================
 # CI-Tests (schnell, mit Mocks)
 # ============================================================================
@@ -410,6 +411,10 @@ context-live-invoke:
 context-live-invoke-full:
 	@echo "=== Context live invocation harness, full inline-record profile (#2852) ==="
 	@$(PYTHON) -m tools.surrealdb.context_live_invocation_harness --profile full
+
+context-root-inventory:
+	@echo "=== Cross-repo root and GitHub target inventory (#2853) ==="
+	@$(PYTHON) -m tools.mcp.cross_repo_root_inventory --format markdown
 
 context-reset-local:
 	@echo "=== SurrealDB Local Reset (DESTRUKTIV - nur Context-Intelligence-Daten) ==="

--- a/docs/evidence/context_tooling/CDB_CROSS_REPO_ROOT_INVENTORY_2026-06-03.md
+++ b/docs/evidence/context_tooling/CDB_CROSS_REPO_ROOT_INVENTORY_2026-06-03.md
@@ -1,0 +1,78 @@
+# Cross-repo root and GitHub target inventory — 2026-06-03
+
+Status: Evidence artifact (Issue **#2853**, parent **#2847**)  
+Boundaries: Read-only discovery; no repo cloning; no productive DB/MCP writes; LR **NO-GO**
+
+---
+
+## Canonical source
+
+| Item | Path |
+|------|------|
+| Inventory config (SSOT) | `infrastructure/config/mcp/cross_repo_root_inventory.json` |
+| Builder + CLI | `tools/mcp/cross_repo_root_inventory.py` |
+| Harness attachment | `tools/surrealdb/context_live_invocation_harness.py` |
+| Certification gate | `tools/surrealdb/context_certify.py` (`cross_repo_root_inventory`) |
+
+Regenerate operator table:
+
+```bash
+python -m tools.mcp.cross_repo_root_inventory --format markdown
+make context-root-inventory
+```
+
+Optional GitHub reachability (read-only `gh repo view`, no clone):
+
+```bash
+python -m tools.mcp.cross_repo_root_inventory --format json
+```
+
+---
+
+## Operator machine snapshot (2026-06-03)
+
+Working repo: `D:/Dev/Workspaces/Repos/Claire_de_Binare` @ `origin/main`  
+Workspaces sibling dir: `D:/Dev/Workspaces/Repos`
+
+| key | local_status | local_path | github_slug | github_target_status | required |
+|-----|--------------|------------|-------------|----------------------|----------|
+| working | OK | `.` | jannekbuengener/Claire_de_Binare | OK (when gh available) | yes |
+| db | OK | `tools/surrealdb` | same as working | same as working | yes |
+| mcp | OK | `tools/mcp` | same as working | same as working | yes |
+| config | OK | `claire-de-binare.mcp.json`, `pyproject.toml` | same as working | same as working | yes |
+| traumtaenzer | OK | sibling `TraumTaenzer` | jannekbuengener/TraumTaenzer | OK (when gh available) | no |
+| sample_brain | MISSING | — | jannekbuengener/sample_brain | not cloned locally | no |
+| gpt_mcp_server | MISSING | — | jannekbuengener/gpt-mcp-server | not cloned locally | no |
+
+**roots_verdict:** `pass_with_limits` when optional external repos are absent locally.  
+**Fail-closed:** required roots (`working`, `db`, `mcp`, `config`) with `local_status != OK` → `roots_verdict=fail` and harness/certify blocking.
+
+---
+
+## Reconciliation with benchmark / preflight
+
+| Surface | Before #2853 | After #2853 |
+|---------|----------------|---------------|
+| `CDB_ALL_TOOLS_LIVE_INVOCATION_PROOF_2026-06-03.md` | Ad-hoc markdown table | Same facts; machine table from inventory command |
+| `context_live_invocation_harness` | Tool matrix only | Adds `root_inventory` block; fails if required root missing |
+| `context_certify` | MCP/registry gates only | Adds `cross_repo_root_inventory` gate |
+| Nav `REPO.map.json` | In-repo roots only | Unchanged; cross-repo SSOT is `cross_repo_root_inventory.json` |
+
+---
+
+## Limitations and recheck trigger
+
+- No cloning or private-repo fetch without operator GO.
+- `github_target_status` for MISSING local paths does **not** imply local PASS.
+- Re-run inventory after: cloning `sample_brain` / `gpt-mcp-server`, moving working repo, or changing `CDB_WORKSPACES_REPOS`.
+- Security alert scope (#2860–#2869) and epic #2289/#2513 explicitly out of scope.
+
+---
+
+## Validation (implementation slice)
+
+- `pytest -q tests/unit/tools/mcp/test_cross_repo_root_inventory.py`
+- `pytest -q tests/unit/tools/mcp/ -m unit`
+- Targeted harness/certify unit tests as needed
+
+Refs **#2853**, **#2847**.

--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -207,6 +207,19 @@ python -m tools.surrealdb.context_onboarding_doctor --format json
 - Issue #2642 prüft optional `127.0.0.1:8811` (HTTP MCP host).
 - Separater remote `cdb`-Server in OpenCode nutzt laut Runbook-Hinweis `127.0.0.1:8812/mcp` — nicht mit #2642 verwechseln.
 
+**Cross-repo root inventory** (#2853) — deterministische Tabelle für Working-Repo und
+konfigurierte Sibling-/Extern-Roots (lokal vs. GitHub getrennt; kein Clone):
+
+```bash
+make context-root-inventory
+python -m tools.mcp.cross_repo_root_inventory --format markdown
+python -m tools.mcp.cross_repo_root_inventory --format json --no-github-check
+```
+
+- SSOT: `infrastructure/config/mcp/cross_repo_root_inventory.json`
+- Evidence: `docs/evidence/context_tooling/CDB_CROSS_REPO_ROOT_INVENTORY_2026-06-03.md`
+- Harness/certify binden dieselbe Inventory-Quelle ein (`context-live-invoke`, `context-certify`).
+
 **Context operator certification** (#2776) — wiederholbarer read-only Proof Pack
 für Bridge/Registry/Permission-Guard (kein produktiver DB-Smoke, kein `--apply`):
 

--- a/infrastructure/config/mcp/cross_repo_root_inventory.json
+++ b/infrastructure/config/mcp/cross_repo_root_inventory.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "1.0",
+  "issue_refs": ["#2853", "#2847"],
+  "discovery_notes": [
+    "Read-only filesystem discovery; no git clone or private-repo fetch.",
+    "Local status and GitHub target status are evaluated independently.",
+    "GitHub reachability uses gh repo view when a slug is configured (optional)."
+  ],
+  "defaults": {
+    "workspaces_repos_dir_env": "CDB_WORKSPACES_REPOS"
+  },
+  "entries": [
+    {
+      "key": "working",
+      "display_name": "Claire de Binare (working repo)",
+      "required": true,
+      "local": { "kind": "repo_root" },
+      "github": {
+        "owner": "jannekbuengener",
+        "repo": "Claire_de_Binare"
+      }
+    },
+    {
+      "key": "db",
+      "display_name": "SurrealDB / context tooling",
+      "required": true,
+      "local": { "relative_path": "tools/surrealdb" },
+      "github": { "kind": "same_as_working" }
+    },
+    {
+      "key": "mcp",
+      "display_name": "MCP bridge and registry",
+      "required": true,
+      "local": { "relative_path": "tools/mcp" },
+      "github": { "kind": "same_as_working" }
+    },
+    {
+      "key": "config",
+      "display_name": "MCP and Python project config",
+      "required": true,
+      "local": {
+        "relative_paths": ["claire-de-binare.mcp.json", "pyproject.toml"]
+      },
+      "github": { "kind": "same_as_working" }
+    },
+    {
+      "key": "traumtaenzer",
+      "display_name": "TraumTaenzer (sibling repo)",
+      "required": false,
+      "local": { "sibling_dir": "TraumTaenzer" },
+      "github": {
+        "owner": "jannekbuengener",
+        "repo": "TraumTaenzer"
+      }
+    },
+    {
+      "key": "sample_brain",
+      "display_name": "sample_brain (external brain repo)",
+      "required": false,
+      "local": { "sibling_dir": "sample_brain" },
+      "github": {
+        "owner": "jannekbuengener",
+        "repo": "sample_brain"
+      }
+    },
+    {
+      "key": "gpt_mcp_server",
+      "display_name": "gpt-mcp-server (external MCP repo)",
+      "required": false,
+      "local": { "sibling_dir": "gpt-mcp-server" },
+      "github": {
+        "owner": "jannekbuengener",
+        "repo": "gpt-mcp-server"
+      }
+    }
+  ]
+}

--- a/tests/unit/surrealdb/test_context_certify.py
+++ b/tests/unit/surrealdb/test_context_certify.py
@@ -13,6 +13,13 @@ from tools.surrealdb import context_certify as certify
 
 pytestmark = pytest.mark.unit
 
+
+@pytest.fixture
+def certify_repo_root() -> Path:
+    """Working-repo root with cross-repo inventory config (#2853)."""
+    return certify._repo_root()
+
+
 REQUIRED_TOP_LEVEL_KEYS = {
     "timestamp",
     "git_sha",
@@ -33,8 +40,8 @@ REQUIRED_TOP_LEVEL_KEYS = {
 }
 
 
-def test_build_report_certified_by_default(tmp_path: Path) -> None:
-    report = certify.build_report(tmp_path)
+def test_build_report_certified_by_default(certify_repo_root: Path) -> None:
+    report = certify.build_report(certify_repo_root)
     payload = report.to_dict()
     assert REQUIRED_TOP_LEVEL_KEYS <= set(payload.keys())
     assert report.final_verdict == "certified"
@@ -45,6 +52,10 @@ def test_build_report_certified_by_default(tmp_path: Path) -> None:
     assert report.lr_note == "NO-GO"
     assert any(
         gate.check_id == "registry_all_read_only" and gate.status == "pass"
+        for gate in report.gate_matrix
+    )
+    assert any(
+        gate.check_id == "cross_repo_root_inventory" and gate.status == "pass"
         for gate in report.gate_matrix
     )
     assert report.skipped_checks_with_reason
@@ -82,8 +93,8 @@ def test_compute_exit_code() -> None:
     assert certify.compute_exit_code(fail) == 1
 
 
-def test_format_json_roundtrip(tmp_path: Path) -> None:
-    report = certify.build_report(tmp_path)
+def test_format_json_roundtrip(certify_repo_root: Path) -> None:
+    report = certify.build_report(certify_repo_root)
     text = certify.format_report(report, "json")
     certify._validate_output_safe(text)
     parsed = json.loads(text)
@@ -91,12 +102,12 @@ def test_format_json_roundtrip(tmp_path: Path) -> None:
     assert isinstance(parsed["gate_matrix"], list)
 
 
-def test_main_exit_code_zero(tmp_path: Path) -> None:
-    code = certify.main(["--repo-root", str(tmp_path), "--format", "json"])
+def test_main_exit_code_zero(certify_repo_root: Path) -> None:
+    code = certify.main(["--repo-root", str(certify_repo_root), "--format", "json"])
     assert code == 0
 
 
-def test_registry_failure_marks_fail(tmp_path: Path) -> None:
+def test_registry_failure_marks_fail(certify_repo_root: Path) -> None:
     bad_tool = ToolDefinition(
         name="context.bad_write",
         description="injected for certify test",
@@ -120,13 +131,13 @@ def test_registry_failure_marks_fail(tmp_path: Path) -> None:
                 mock_bridge.return_value.get_read_only_status.return_value = (
                     bridge_status
                 )
-                report = certify.build_report(tmp_path)
+                report = certify.build_report(certify_repo_root)
     assert report.final_verdict == "fail"
     assert report.blocked_checks_with_reason
     assert certify.compute_exit_code(report) == 1
 
 
-def test_git_metadata_detects_dirty(tmp_path: Path) -> None:
+def test_git_metadata_detects_dirty(certify_repo_root: Path) -> None:
     with patch.object(certify, "_git_metadata") as mock_git:
         mock_git.return_value = {
             "git_sha": "deadbeef",
@@ -134,13 +145,13 @@ def test_git_metadata_detects_dirty(tmp_path: Path) -> None:
             "worktree_clean": False,
             "git_available": True,
         }
-        report = certify.build_report(tmp_path)
+        report = certify.build_report(certify_repo_root)
     assert report.git_sha == "deadbeef"
     assert report.worktree_clean is False
 
 
-def test_test_command_suggestions_present(tmp_path: Path) -> None:
-    report = certify.build_report(tmp_path)
+def test_test_command_suggestions_present(certify_repo_root: Path) -> None:
+    report = certify.build_report(certify_repo_root)
     suggestions = report.test_results["test_command_suggestions"]
     assert any("test_context_certify" in cmd for cmd in suggestions)
     assert any("test_context_onboarding_doctor" in cmd for cmd in suggestions)

--- a/tests/unit/tools/mcp/test_cross_repo_root_inventory.py
+++ b/tests/unit/tools/mcp/test_cross_repo_root_inventory.py
@@ -1,0 +1,205 @@
+"""Unit tests for cross-repo root inventory (#2853)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.mcp import cross_repo_root_inventory as inventory
+
+pytestmark = pytest.mark.unit
+
+
+def _mini_config(
+    *,
+    sibling_name: str = "missing-sibling",
+    include_config_files: bool = True,
+) -> dict:
+    config_paths = (
+        ["claire-de-binare.mcp.json", "pyproject.toml"]
+        if include_config_files
+        else ["claire-de-binare.mcp.json"]
+    )
+    return {
+        "schema_version": "1.0",
+        "issue_refs": ["#2853"],
+        "defaults": {"workspaces_repos_dir_env": "CDB_WORKSPACES_REPOS_TEST"},
+        "entries": [
+            {
+                "key": "working",
+                "display_name": "working",
+                "required": True,
+                "local": {"kind": "repo_root"},
+                "github": {
+                    "owner": "jannekbuengener",
+                    "repo": "Claire_de_Binare",
+                },
+            },
+            {
+                "key": "db",
+                "display_name": "db",
+                "required": True,
+                "local": {"relative_path": "tools/surrealdb"},
+                "github": {"kind": "same_as_working"},
+            },
+            {
+                "key": "mcp",
+                "display_name": "mcp",
+                "required": True,
+                "local": {"relative_path": "tools/mcp"},
+                "github": {"kind": "same_as_working"},
+            },
+            {
+                "key": "config",
+                "display_name": "config",
+                "required": True,
+                "local": {"relative_paths": config_paths},
+                "github": {"kind": "same_as_working"},
+            },
+            {
+                "key": "optional_external",
+                "display_name": "optional",
+                "required": False,
+                "local": {"sibling_dir": sibling_name},
+                "github": {
+                    "owner": "jannekbuengener",
+                    "repo": "sample_brain",
+                },
+            },
+        ],
+    }
+
+
+def _bootstrap_mini_repo(tmp_path: Path) -> Path:
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "AGENTS.md").write_text("# agents\n", encoding="utf-8")
+    (tmp_path / "tools" / "surrealdb").mkdir(parents=True)
+    (tmp_path / "tools" / "mcp").mkdir(parents=True)
+    (tmp_path / "claire-de-binare.mcp.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_build_inventory_all_required_ok(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _bootstrap_mini_repo(tmp_path)
+    workspaces = tmp_path / "workspaces"
+    workspaces.mkdir()
+    monkeypatch.setenv("CDB_WORKSPACES_REPOS_TEST", str(workspaces))
+
+    report = inventory.build_inventory(
+        repo,
+        config=_mini_config(),
+        check_github=False,
+    )
+
+    assert len(report.rows) == 5
+    keys = {row.key for row in report.rows}
+    assert keys == {"working", "db", "mcp", "config", "optional_external"}
+    for row in report.rows:
+        if row.required:
+            assert row.local_status == "OK"
+    optional = next(r for r in report.rows if r.key == "optional_external")
+    assert optional.local_status == "MISSING"
+    assert optional.github_target_status == "SKIPPED"
+    assert report.roots_verdict == "pass_with_limits"
+
+
+def test_missing_required_root_fails_closed(tmp_path: Path) -> None:
+    repo = _bootstrap_mini_repo(tmp_path)
+    (repo / "tools" / "mcp").rmdir()
+
+    report = inventory.build_inventory(
+        repo,
+        config=_mini_config(),
+        check_github=False,
+    )
+
+    mcp_row = next(r for r in report.rows if r.key == "mcp")
+    assert mcp_row.local_status == "MISSING"
+    assert report.roots_verdict == "fail"
+    assert any("mcp" in reason for reason in report.fail_reasons)
+
+
+def test_config_partial_missing_is_limited_not_ok(tmp_path: Path) -> None:
+    repo = _bootstrap_mini_repo(tmp_path)
+    (repo / "pyproject.toml").unlink()
+
+    report = inventory.build_inventory(
+        repo,
+        config=_mini_config(include_config_files=True),
+        check_github=False,
+    )
+
+    config_row = next(r for r in report.rows if r.key == "config")
+    assert config_row.local_status == "LIMITED"
+    assert report.roots_verdict == "fail"
+
+
+def test_local_and_github_fields_are_separate(tmp_path: Path) -> None:
+    repo = _bootstrap_mini_repo(tmp_path)
+
+    report = inventory.build_inventory(
+        repo,
+        config=_mini_config(),
+        check_github=False,
+    )
+
+    optional = next(r for r in report.rows if r.key == "optional_external")
+    assert optional.local_status == "MISSING"
+    assert optional.github_slug == "jannekbuengener/sample_brain"
+    assert optional.github_target_status == "SKIPPED"
+
+
+def test_rendered_inventory_has_no_secret_patterns(tmp_path: Path) -> None:
+    repo = _bootstrap_mini_repo(tmp_path)
+    report = inventory.build_inventory(
+        repo,
+        config=_mini_config(),
+        check_github=False,
+    )
+    rendered = inventory.format_report(report, "json")
+    lowered = rendered.lower()
+    assert "password" not in lowered
+    assert "api_key" not in lowered
+    assert "token" not in lowered or "no secret" in lowered
+
+
+def test_canonical_config_loads_from_repo() -> None:
+    cfg = inventory.load_inventory_config()
+    keys = [entry["key"] for entry in cfg["entries"]]
+    assert keys == [
+        "working",
+        "db",
+        "mcp",
+        "config",
+        "traumtaenzer",
+        "sample_brain",
+        "gpt_mcp_server",
+    ]
+
+
+def test_compute_exit_code() -> None:
+    ok = inventory.RootInventoryReport(
+        schema_version="1.0",
+        timestamp="t",
+        issue_refs=[],
+        working_repo_root="/w",
+        workspaces_repos_dir="/p",
+        config_path="/c",
+        roots_verdict="pass",
+    )
+    assert inventory.compute_exit_code(ok) == 0
+    fail = inventory.RootInventoryReport(
+        schema_version="1.0",
+        timestamp="t",
+        issue_refs=[],
+        working_repo_root="/w",
+        workspaces_repos_dir="/p",
+        config_path="/c",
+        roots_verdict="fail",
+    )
+    assert inventory.compute_exit_code(fail) == 1

--- a/tools/mcp/cross_repo_root_inventory.py
+++ b/tools/mcp/cross_repo_root_inventory.py
@@ -1,0 +1,545 @@
+"""Deterministic cross-repo root and GitHub target inventory (#2853).
+
+Read-only discovery: local filesystem checks and optional ``gh repo view``.
+Never clones repositories or reports MISSING local roots as PASS.
+
+Issue: #2853
+Parent: #2847
+
+Usage:
+    python -m tools.mcp.cross_repo_root_inventory
+    python -m tools.mcp.cross_repo_root_inventory --format json
+    python -m tools.mcp.cross_repo_root_inventory --format markdown
+    make context-root-inventory
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from core.utils.clock import utcnow
+
+LocalStatus = Literal["OK", "MISSING", "LIMITED"]
+GithubTargetStatus = Literal[
+    "OK", "MISSING", "LIMITED", "NOT_CONFIGURED", "SKIPPED"
+]
+RootsVerdict = Literal["pass", "fail", "pass_with_limits"]
+OutputFormat = Literal["text", "json", "markdown"]
+
+CONFIG_REL = Path("infrastructure/config/mcp/cross_repo_root_inventory.json")
+ISSUE_REF = "#2853"
+PARENT_ISSUE_REF = "#2847"
+
+_GITHUB_SLUG_RE = re.compile(
+    r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/.\s]+)",
+    re.IGNORECASE,
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def load_inventory_config(
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    root = _repo_root() if repo_root is None else repo_root
+    config_path = root / CONFIG_REL
+    if not config_path.is_file():
+        raise FileNotFoundError(f"missing inventory config: {config_path}")
+    with config_path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("inventory config must be a JSON object")
+    return payload
+
+
+def resolve_workspaces_repos_dir(
+    working_repo_root: Path,
+    config: dict[str, Any],
+) -> Path:
+    defaults = config.get("defaults") or {}
+    env_name = defaults.get("workspaces_repos_dir_env")
+    if isinstance(env_name, str) and env_name.strip():
+        override = os.environ.get(env_name.strip())
+        if override and override.strip():
+            candidate = Path(override.strip()).expanduser()
+            if candidate.is_dir():
+                return candidate.resolve()
+    return working_repo_root.resolve().parent
+
+
+def _display_path(path: Path, working_repo_root: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(working_repo_root.resolve()))
+    except ValueError:
+        return str(resolved)
+
+
+def _git_remote_slug(path: Path) -> tuple[str | None, str | None, list[str]]:
+    limitations: list[str] = []
+    git_dir = path / ".git"
+    if not git_dir.exists():
+        return None, None, ["no .git directory; github slug not inferred from local"]
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(path), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return None, None, [f"git remote lookup failed: {type(exc).__name__}"]
+    if proc.returncode != 0:
+        return None, None, ["origin remote not configured"]
+    url = (proc.stdout or "").strip()
+    match = _GITHUB_SLUG_RE.search(url)
+    if not match:
+        return None, None, [f"origin URL not parsed as GitHub slug: {url!r}"]
+    return match.group("owner"), match.group("repo"), limitations
+
+
+def _gh_repo_visible(owner: str, repo: str) -> tuple[GithubTargetStatus, list[str]]:
+    slug = f"{owner}/{repo}"
+    limitations: list[str] = []
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "repo",
+                "view",
+                slug,
+                "--json",
+                "nameWithOwner",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return "LIMITED", [f"gh unavailable: {type(exc).__name__}"]
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip()
+        snippet = err[:200] if err else "gh repo view failed"
+        return "MISSING", [f"github target not reachable: {snippet}"]
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError:
+        return "LIMITED", ["gh returned non-JSON response"]
+    name = payload.get("nameWithOwner")
+    if isinstance(name, str) and name.lower() == slug.lower():
+        return "OK", limitations
+    return "LIMITED", [f"gh nameWithOwner mismatch: {name!r}"]
+
+
+def _resolve_github_slug(
+    entry: dict[str, Any],
+    *,
+    working_slug: tuple[str | None, str | None],
+) -> tuple[str | None, str | None, list[str]]:
+    github = entry.get("github")
+    if not isinstance(github, dict):
+        return None, None, []
+    kind = github.get("kind")
+    if kind == "same_as_working":
+        owner, repo = working_slug
+        return owner, repo, ["github target inherits working repo slug"]
+    owner = github.get("owner")
+    repo = github.get("repo")
+    if isinstance(owner, str) and isinstance(repo, str) and owner and repo:
+        return owner, repo, []
+    return None, None, ["github owner/repo not configured"]
+
+
+def _evaluate_local(
+    entry: dict[str, Any],
+    *,
+    working_repo_root: Path,
+    workspaces_repos_dir: Path,
+) -> tuple[Path | None, LocalStatus, list[str]]:
+    limitations: list[str] = []
+    local = entry.get("local")
+    if not isinstance(local, dict):
+        return None, "MISSING", ["local spec missing"]
+
+    kind = local.get("kind")
+    if kind == "repo_root":
+        path = working_repo_root.resolve()
+        markers = [path / ".git", path / "AGENTS.md"]
+        if all(marker.exists() for marker in markers):
+            return path, "OK", limitations
+        missing = [m.name for m in markers if not m.exists()]
+        return path, "LIMITED", [f"missing working repo markers: {missing}"]
+
+    rel = local.get("relative_path")
+    if isinstance(rel, str) and rel.strip():
+        path = (working_repo_root / rel.strip()).resolve()
+        if path.is_dir():
+            return path, "OK", limitations
+        return path, "MISSING", [f"directory not found: {rel.strip()}"]
+
+    rel_paths = local.get("relative_paths")
+    if isinstance(rel_paths, list) and rel_paths:
+        missing_files: list[str] = []
+        first: Path | None = None
+        for item in rel_paths:
+            if not isinstance(item, str) or not item.strip():
+                continue
+            candidate = (working_repo_root / item.strip()).resolve()
+            if first is None:
+                first = candidate
+            if not candidate.is_file():
+                missing_files.append(item.strip())
+        if not missing_files:
+            return first, "OK", limitations
+        if len(missing_files) == len(rel_paths):
+            return first, "MISSING", [f"config files missing: {missing_files}"]
+        return first, "LIMITED", [f"partial config missing: {missing_files}"]
+
+    sibling = local.get("sibling_dir")
+    if isinstance(sibling, str) and sibling.strip():
+        path = (workspaces_repos_dir / sibling.strip()).resolve()
+        if path.is_dir():
+            return path, "OK", limitations
+        return path, "MISSING", [f"sibling repo directory not present: {sibling.strip()}"]
+
+    return None, "MISSING", ["unsupported or empty local spec"]
+
+
+def _evaluate_github_target(
+    entry: dict[str, Any],
+    *,
+    local_status: LocalStatus,
+    local_path: Path | None,
+    owner: str | None,
+    repo: str | None,
+    check_github: bool,
+) -> tuple[GithubTargetStatus, list[str]]:
+    limitations: list[str] = []
+    if owner is None or repo is None:
+        return "NOT_CONFIGURED", limitations
+
+    if local_path is not None and local_path.is_dir():
+        inferred_owner, inferred_repo, infer_notes = _git_remote_slug(local_path)
+        limitations.extend(infer_notes)
+        if inferred_owner and inferred_repo:
+            if inferred_owner.lower() != owner.lower() or inferred_repo.lower() != (
+                repo.lower()
+            ):
+                limitations.append(
+                    "configured github slug differs from local origin remote"
+                )
+
+    if not check_github:
+        return "SKIPPED", limitations + ["github reachability check disabled"]
+
+    if local_status == "MISSING":
+        gh_status, gh_notes = _gh_repo_visible(owner, repo)
+        limitations.extend(gh_notes)
+        limitations.append(
+            "local path missing; github status does not imply local PASS"
+        )
+        return gh_status, limitations
+
+    return _gh_repo_visible(owner, repo) if check_github else ("SKIPPED", limitations)
+
+
+@dataclass
+class RootInventoryRow:
+    key: str
+    display_name: str
+    local_path: str | None
+    local_status: LocalStatus
+    github_owner: str | None
+    github_repo: str | None
+    github_slug: str | None
+    github_target_status: GithubTargetStatus
+    limitations: list[str] = field(default_factory=list)
+    required: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "display_name": self.display_name,
+            "local_path": self.local_path,
+            "local_status": self.local_status,
+            "github_owner": self.github_owner,
+            "github_repo": self.github_repo,
+            "github_slug": self.github_slug,
+            "github_target_status": self.github_target_status,
+            "limitations": list(self.limitations),
+            "required": self.required,
+        }
+
+
+@dataclass
+class RootInventoryReport:
+    schema_version: str
+    timestamp: str
+    issue_refs: list[str]
+    working_repo_root: str
+    workspaces_repos_dir: str
+    config_path: str
+    rows: list[RootInventoryRow] = field(default_factory=list)
+    summary: dict[str, int] = field(default_factory=dict)
+    roots_verdict: RootsVerdict = "pass"
+    fail_reasons: list[str] = field(default_factory=list)
+    discovery_notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "timestamp": self.timestamp,
+            "issue_refs": list(self.issue_refs),
+            "working_repo_root": self.working_repo_root,
+            "workspaces_repos_dir": self.workspaces_repos_dir,
+            "config_path": self.config_path,
+            "rows": [row.to_dict() for row in self.rows],
+            "summary": dict(self.summary),
+            "roots_verdict": self.roots_verdict,
+            "fail_reasons": list(self.fail_reasons),
+            "discovery_notes": list(self.discovery_notes),
+            "issue_ref": ISSUE_REF,
+            "parent_issue_ref": PARENT_ISSUE_REF,
+        }
+
+
+def build_inventory(
+    working_repo_root: Path | None = None,
+    *,
+    check_github: bool = True,
+    config: dict[str, Any] | None = None,
+) -> RootInventoryReport:
+    """Build the cross-repo root inventory from canonical config."""
+    root = _repo_root() if working_repo_root is None else working_repo_root.resolve()
+    cfg = load_inventory_config(root) if config is None else config
+    workspaces_dir = resolve_workspaces_repos_dir(root, cfg)
+    entries = cfg.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("inventory config entries must be a list")
+
+    working_owner, working_repo, _ = _git_remote_slug(root)
+    working_slug = (working_owner, working_repo)
+
+    rows: list[RootInventoryRow] = []
+    summary: dict[str, int] = {"OK": 0, "MISSING": 0, "LIMITED": 0}
+    fail_reasons: list[str] = []
+
+    for raw in entries:
+        if not isinstance(raw, dict):
+            continue
+        key = raw.get("key")
+        if not isinstance(key, str) or not key.strip():
+            continue
+        display = raw.get("display_name")
+        display_name = display if isinstance(display, str) else key
+        required = bool(raw.get("required"))
+
+        local_path, local_status, local_notes = _evaluate_local(
+            raw,
+            working_repo_root=root,
+            workspaces_repos_dir=workspaces_dir,
+        )
+        owner, repo, slug_notes = _resolve_github_slug(
+            raw, working_slug=working_slug
+        )
+        gh_status, gh_notes = _evaluate_github_target(
+            raw,
+            local_status=local_status,
+            local_path=local_path,
+            owner=owner,
+            repo=repo,
+            check_github=check_github,
+        )
+        limitations = list(local_notes) + list(slug_notes) + list(gh_notes)
+        if local_status in summary:
+            summary[local_status] += 1
+
+        path_display = (
+            _display_path(local_path, root) if local_path is not None else None
+        )
+        slug = f"{owner}/{repo}" if owner and repo else None
+
+        if required and local_status != "OK":
+            fail_reasons.append(
+                f"required root {key!r} local_status={local_status}"
+            )
+
+        rows.append(
+            RootInventoryRow(
+                key=key,
+                display_name=display_name,
+                local_path=path_display,
+                local_status=local_status,
+                github_owner=owner,
+                github_repo=repo,
+                github_slug=slug,
+                github_target_status=gh_status,
+                limitations=limitations,
+                required=required,
+            )
+        )
+
+    optional_missing = [
+        r.key
+        for r in rows
+        if not r.required and r.local_status == "MISSING"
+    ]
+    roots_verdict: RootsVerdict
+    if fail_reasons:
+        roots_verdict = "fail"
+    elif optional_missing:
+        roots_verdict = "pass_with_limits"
+    else:
+        roots_verdict = "pass"
+
+    notes = cfg.get("discovery_notes")
+    discovery_notes = (
+        [str(item) for item in notes if isinstance(item, str)]
+        if isinstance(notes, list)
+        else []
+    )
+
+    return RootInventoryReport(
+        schema_version=str(cfg.get("schema_version") or "1.0"),
+        timestamp=utcnow().isoformat(),
+        issue_refs=[
+            str(item)
+            for item in (cfg.get("issue_refs") or [ISSUE_REF, PARENT_ISSUE_REF])
+            if isinstance(item, str)
+        ],
+        working_repo_root=str(root),
+        workspaces_repos_dir=str(workspaces_dir),
+        config_path=str((root / CONFIG_REL).as_posix()),
+        rows=rows,
+        summary=summary,
+        roots_verdict=roots_verdict,
+        fail_reasons=fail_reasons,
+        discovery_notes=discovery_notes,
+    )
+
+
+def compute_exit_code(report: RootInventoryReport) -> int:
+    return 1 if report.roots_verdict == "fail" else 0
+
+
+def format_report_markdown(report: RootInventoryReport) -> str:
+    lines = [
+        "# Cross-repo root and GitHub target inventory",
+        "",
+        f"- **timestamp:** {report.timestamp}",
+        f"- **roots_verdict:** {report.roots_verdict}",
+        f"- **working_repo_root:** `{report.working_repo_root}`",
+        f"- **workspaces_repos_dir:** `{report.workspaces_repos_dir}`",
+        f"- **config:** `{report.config_path}`",
+        "",
+        "## Summary (local status)",
+    ]
+    for key in ("OK", "MISSING", "LIMITED"):
+        lines.append(f"- **{key}:** {report.summary.get(key, 0)}")
+    if report.fail_reasons:
+        lines.extend(["", "## Fail reasons"])
+        for reason in report.fail_reasons:
+            lines.append(f"- {reason}")
+    lines.extend(
+        [
+            "",
+            "## Inventory",
+            "",
+            "| key | local_status | local_path | github_slug | github_target_status | required |",
+            "|-----|--------------|------------|-------------|----------------------|----------|",
+        ]
+    )
+    for row in report.rows:
+        lines.append(
+            f"| `{row.key}` | **{row.local_status}** | "
+            f"{row.local_path or '—'} | {row.github_slug or '—'} | "
+            f"**{row.github_target_status}** | {row.required} |"
+        )
+        if row.limitations:
+            lines.append(f"| | | _{'; '.join(row.limitations)}_ | | | |")
+    if report.discovery_notes:
+        lines.extend(["", "## Discovery notes"])
+        for note in report.discovery_notes:
+            lines.append(f"- {note}")
+    return "\n".join(lines)
+
+
+def format_report(report: RootInventoryReport, fmt: OutputFormat) -> str:
+    if fmt == "json":
+        return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    if fmt == "markdown":
+        return format_report_markdown(report)
+    lines = [
+        f"roots_verdict={report.roots_verdict}",
+        f"working_repo_root={report.working_repo_root}",
+        f"workspaces_repos_dir={report.workspaces_repos_dir}",
+        "",
+    ]
+    for row in report.rows:
+        lines.append(
+            f"{row.key}: local={row.local_status} path={row.local_path or '—'} "
+            f"github={row.github_target_status} slug={row.github_slug or '—'}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Cross-repo root and GitHub target inventory (#2853)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json", "markdown"),
+        default="text",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Override working repo root (default: package parent)",
+    )
+    parser.add_argument(
+        "--no-github-check",
+        action="store_true",
+        help="Skip gh repo view reachability checks",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to write report (json or markdown by --format)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = build_inventory(
+            args.repo_root,
+            check_github=not args.no_github_check,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"inventory error: {exc}", file=sys.stderr)
+        return 2
+
+    fmt: OutputFormat = args.format
+    rendered = format_report(report, fmt)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+    return compute_exit_code(report)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/surrealdb/context_certify.py
+++ b/tools/surrealdb/context_certify.py
@@ -205,6 +205,50 @@ def _collect_static_gates() -> tuple[list[GateEntry], dict[str, Any], dict[str, 
     return gates, mcp_summary, permission_summary
 
 
+def _collect_root_inventory_gates(repo_root: Path) -> list[GateEntry]:
+    from tools.mcp.cross_repo_root_inventory import build_inventory
+
+    try:
+        inv = build_inventory(repo_root, check_github=False)
+    except (FileNotFoundError, ValueError) as exc:
+        return [
+            GateEntry(
+                check_id="cross_repo_root_inventory",
+                status="fail",
+                blocking=True,
+                detail=f"inventory build failed: {exc}",
+            )
+        ]
+
+    missing_optional = [
+        row.key for row in inv.rows if row.local_status == "MISSING" and not row.required
+    ]
+    if inv.roots_verdict == "fail":
+        status: GateStatus = "fail"
+        detail = "; ".join(inv.fail_reasons) or "required local root missing"
+        blocking = True
+    elif missing_optional:
+        status = "pass"
+        detail = (
+            f"roots_verdict={inv.roots_verdict}; optional missing: "
+            f"{', '.join(missing_optional)}"
+        )
+        blocking = False
+    else:
+        status = "pass"
+        detail = f"roots_verdict={inv.roots_verdict}; all configured roots present"
+        blocking = False
+
+    return [
+        GateEntry(
+            check_id="cross_repo_root_inventory",
+            status=status,
+            blocking=blocking,
+            detail=detail,
+        )
+    ]
+
+
 def _default_skipped_checks() -> list[dict[str, str]]:
     return [
         {
@@ -318,8 +362,9 @@ def build_report(
     git_info = _git_metadata(root)
     static_gates, mcp_summary, permission_summary = _collect_static_gates()
     doctor_status, doctor_gates = _run_doctor(root, include_live=include_live_checks)
+    root_gates = _collect_root_inventory_gates(root)
 
-    gates = static_gates + doctor_gates
+    gates = static_gates + doctor_gates + root_gates
     skipped = _default_skipped_checks()
     blocked: list[dict[str, str]] = []
 

--- a/tools/surrealdb/context_invocation_evidence_json.py
+++ b/tools/surrealdb/context_invocation_evidence_json.py
@@ -217,6 +217,7 @@ def build_invocation_evidence(report: harness.HarnessReport) -> dict[str, Any]:
         "worktree_clean": report.worktree_clean,
         "lr_note": report.lr_note,
         "safety_flags": dict(report.safety_flags),
+        "root_inventory": dict(report.root_inventory),
     }
     document["determinism_hash"] = compute_aggregate_determinism_hash(document)
     return document

--- a/tools/surrealdb/context_live_invocation_harness.py
+++ b/tools/surrealdb/context_live_invocation_harness.py
@@ -3,7 +3,7 @@
 Invokes every registered tool via ContextBridge (same handler path as MCP server)
 with benchmark-safe parameters. Produces a per-tool matrix for regression detection.
 
-Issue: #2849, #2852 (profiles + ratification), #2850 (JSON evidence)
+Issue: #2849, #2852 (profiles + ratification), #2850 (JSON evidence), #2853 (root inventory)
 Parent: #2847
 
 Usage:
@@ -397,6 +397,7 @@ class HarnessReport:
     registry_tool_names: list[str] = field(default_factory=list)
     missing_from_manifest: list[str] = field(default_factory=list)
     extra_in_manifest: list[str] = field(default_factory=list)
+    root_inventory: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -418,6 +419,7 @@ class HarnessReport:
             "registry_tool_names": self.registry_tool_names,
             "missing_from_manifest": self.missing_from_manifest,
             "extra_in_manifest": self.extra_in_manifest,
+            "root_inventory": self.root_inventory,
         }
 
 
@@ -443,14 +445,29 @@ def _registry_tool_names(bridge: Any) -> list[str]:
     return sorted(names)
 
 
+def _attach_root_inventory(
+    repo_root: Path,
+    *,
+    check_github: bool = True,
+) -> dict[str, Any]:
+    from tools.mcp.cross_repo_root_inventory import build_inventory
+
+    report = build_inventory(repo_root, check_github=check_github)
+    return report.to_dict()
+
+
 def run_matrix(
     *,
     live: bool = True,
     profile: InvocationProfile = "minimal",
     fail_on_limits: bool = False,
+    check_github_roots: bool = True,
 ) -> HarnessReport:
     """Build the invocation matrix. When live=False, only validate manifest/registry."""
     repo_root = _repo_root()
+    root_inventory = _attach_root_inventory(
+        repo_root, check_github=check_github_roots
+    )
     git = _git_metadata(repo_root)
     bridge = create_bridge() if live else None
     invocations = invocations_for_profile(profile)
@@ -536,6 +553,11 @@ def run_matrix(
         fail_reasons.append(
             f"{summary['PASS_WITH_LIMITS']} PASS_WITH_LIMITS row(s) not allowed"
         )
+    if root_inventory.get("roots_verdict") == "fail":
+        fail_reasons.append("cross-repo root inventory: required local root missing")
+        for reason in root_inventory.get("fail_reasons") or []:
+            if isinstance(reason, str):
+                fail_reasons.append(f"root_inventory: {reason}")
 
     final: FinalVerdict = "fail" if fail_reasons else "pass"
 
@@ -555,6 +577,7 @@ def run_matrix(
         registry_tool_names=registry_names,
         missing_from_manifest=missing,
         extra_in_manifest=extra,
+        root_inventory=root_inventory,
     )
 
 
@@ -594,6 +617,23 @@ def format_report_markdown(report: HarnessReport) -> str:
             lines.append(f"- missing_from_manifest: {report.missing_from_manifest}")
         if report.extra_in_manifest:
             lines.append(f"- extra_in_manifest: {report.extra_in_manifest}")
+    if report.root_inventory:
+        inv = report.root_inventory
+        lines.extend(
+            [
+                "",
+                "## Cross-repo root inventory (#2853)",
+                f"- **roots_verdict:** {inv.get('roots_verdict')}",
+            ]
+        )
+        for row in inv.get("rows") or []:
+            if not isinstance(row, dict):
+                continue
+            lines.append(
+                f"- `{row.get('key')}`: local={row.get('local_status')} "
+                f"github={row.get('github_target_status')} "
+                f"path={row.get('local_path') or '—'}"
+            )
     lines.extend(
         [
             "",


### PR DESCRIPTION
## Summary
- Single SSOT inventory (`infrastructure/config/mcp/cross_repo_root_inventory.json`) with builder CLI and `make context-root-inventory`.
- `context-live-invoke`, evidence JSON, and `context-certify` consume the same rows; local vs GitHub status separated; required roots fail-closed.
- Evidence doc and runbook pointer for operator machine (#2853 / #2847).

Closes #2853
Refs #2847

## Delivered
- Deterministic inventory for keys: working, db, mcp, config, traumtaenzer, sample_brain, gpt_mcp_server.
- Harness markdown section + roots_verdict fail when required root missing.
- Certify gate `cross_repo_root_inventory` (blocking on required missing only).
- Unit tests + operator evidence artifact.

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- tools_or_queries: repo reads, `python -m tools.mcp.cross_repo_root_inventory`, `make context-live-invoke`
- repo_crosscheck: `tools/mcp/cross_repo_root_inventory.py`, harness/certify wiring, `docs/evidence/context_tooling/CDB_CROSS_REPO_ROOT_INVENTORY_2026-06-03.md`

## Validation
- `git diff --check` — clean
- `pytest -q tests/unit/tools/mcp/test_cross_repo_root_inventory.py` — pass
- `pytest -q tests/unit/tools/mcp/ -m unit` — 875 passed
- `pytest -q tests/unit/surrealdb/test_context_certify.py -m unit` — pass
- `make context-live-invoke` — final_verdict pass, roots_verdict pass_with_limits

## Non-goals
- No clone of missing sibling repos (sample_brain, gpt-mcp-server).
- Security alert scope (#2860–#2869), LR/live, BLUE/RED runtime, DB/MCP mutations.

## Safety Boundaries
- LR NO-GO unchanged; read-only discovery; no secrets in rendered output.

## Restunsicherheiten
- GitHub `LIMITED` on TraumTaenzer may reflect gh visibility; optional roots remain MISSING locally until operator clones.

Made with [Cursor](https://cursor.com)