### PR TITLE
test(context): standardize mutation negative controls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ help:
 	@echo "  make context-certify         - Read-only operator certification proof pack (#2776)"
 	@echo "  make context-live-invoke     - All-tools live bridge matrix, minimal profile (#2849)"
 	@echo "  make context-live-invoke-full - Same harness with inline records, 27 PASS (#2852)"
+	@echo "  make context-negative-controls - Write-intent/mutation negative-control regression (#2854)"
 	@echo "  make context-root-inventory  - Cross-repo root + GitHub target inventory (#2853)"
 # ============================================================================
 # CI-Tests (schnell, mit Mocks)
@@ -411,6 +412,10 @@ context-live-invoke:
 context-live-invoke-full:
 	@echo "=== Context live invocation harness, full inline-record profile (#2852) ==="
 	@$(PYTHON) -m tools.surrealdb.context_live_invocation_harness --profile full
+
+context-negative-controls:
+	@echo "=== Context write-intent / mutation negative-control regression (#2854) ==="
+	@$(PYTHON) -m pytest -q tests/unit/surrealdb/test_negative_controls_regression.py tests/unit/tools/mcp/test_memory_write_intent_tool.py tests/unit/surrealdb/test_memory_write_gate.py -m unit
 
 context-root-inventory:
 	@echo "=== Cross-repo root and GitHub target inventory (#2853) ==="

--- a/docs/evidence/context_tooling/CDB_NEGATIVE_CONTROLS_MATRIX_2026-06-03.md
+++ b/docs/evidence/context_tooling/CDB_NEGATIVE_CONTROLS_MATRIX_2026-06-03.md
@@ -1,0 +1,73 @@
+# Negative-control matrix — write-intent and mutation blockades
+
+**Issue:** [#2854](https://github.com/jannekbuengener/Claire_de_Binare/issues/2854)  
+**Parent:** [#2847](https://github.com/jannekbuengener/Claire_de_Binare/issues/2847)  
+**Date:** 2026-06-03
+
+## Scope
+
+Regression-only. No productive SurrealDB writes, no MCP mutations, no runtime BLUE/RED
+changes, no Security-alert scope (#2860–#2869).
+
+## Safety defaults (must stay off in CI)
+
+| Flag | Expected | Module |
+|------|----------|--------|
+| `PERSIST_ALLOWED` | `False` | `tools/surrealdb/memory_write_gate.py` |
+| `MUTATION_ALLOWED` | `False` | `tools/mcp/memory_write_intent_tools.py` |
+
+## Matrix categories
+
+| Category | Intent |
+|----------|--------|
+| `safety_defaults` | Module constants remain default-off |
+| `write_intent` | `cdb_context_memory_write_intent` dry-run vs refused modes |
+| `mutation_gate` | Mutation flags / SQL injection blocked |
+| `productive_persist` | `approved_for_persist` false without `CDB_PERSIST_ALLOWED=1` |
+| `fake_db_evidence` | Caller `brain_source` without records → `invalid_fake_db` |
+| `scope_drift` | `unauthorized_write_intent` without `human_go_token` |
+| `harness_classification` | Bridge **PASS** vs MCP **BLOCKED_SAFETY** |
+
+## Harness verdict semantics
+
+| Verdict | Meaning |
+|---------|---------|
+| **PASS** | Expected fail-closed refusal or dry-run gate (bridge write-intent) |
+| **BLOCKED_SAFETY** | MCP Smart Mode / policy blocked the call (not a handler FAIL) |
+| **FAIL** | Unexpected activation or missing block |
+
+Bridge `cdb_context_memory_write_intent` with `operation_mode=agent_memory_write`
+must classify as **PASS** (`status=refused`, `agent_memory_write_not_activated`).
+
+MCP-only Smart Mode blocks classify as **BLOCKED_SAFETY** (accepted boundary per
+benchmark #2849 evidence).
+
+## Rerun focused tests
+
+```bash
+make context-negative-controls
+```
+
+Or:
+
+```bash
+pytest -q tests/unit/surrealdb/test_negative_controls_regression.py -m unit
+pytest -q tests/unit/tools/mcp/test_memory_write_intent_tool.py -m unit
+pytest -q tests/unit/surrealdb/test_memory_write_gate.py -m unit
+```
+
+Include in broader context regression:
+
+```bash
+make context-live-invoke
+```
+
+Machine-readable matrix index is embedded in harness JSON evidence under
+`negative_controls` (`tools/surrealdb/negative_controls.py`).
+
+## Non-goals
+
+- Enabling `PERSIST_ALLOWED` / `MUTATION_ALLOWED` in CI
+- Live MCP stdio mutation proofs
+- Security workflow changes
+- Operator trust scoring (#2856) or senses docs (#2855)

--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -272,6 +272,32 @@ Agent OS Readiness is a **signal**, not an authorization. Certification is an
 **adoption gate**, not LR-Go. Missing certification must not block unrelated PR
 work or general readiness checks that do not claim operator adoption.
 
+### Negative-control regression matrix (#2854)
+
+Write-intent and mutation-adjacent surfaces must stay **fail-closed** in CI:
+
+- Canonical matrix: `tools/surrealdb/negative_controls_matrix.py`
+- Classifiers: `tools/surrealdb/negative_controls.py` (`PASS` vs `BLOCKED_SAFETY` vs `FAIL`)
+- Regression tests: `tests/unit/surrealdb/test_negative_controls_regression.py`
+- Evidence doc: `docs/evidence/context_tooling/CDB_NEGATIVE_CONTROLS_MATRIX_2026-06-03.md`
+
+| Path | `cdb_context_memory_write_intent` expected classification |
+|------|-----------------------------------------------------------|
+| Bridge (in-process handlers) | **PASS** when `status=refused` / dry-run `approved_dry_run` |
+| MCP stdio (Smart Mode policy) | **BLOCKED_SAFETY** when policy blocks the call (not FAIL) |
+
+**Never** set `PERSIST_ALLOWED=True` or `MUTATION_ALLOWED=True` in CI. Caller-supplied
+`brain_source` / `metadata.source` is not DB evidence ([#2638](https://github.com/jannekbuengener/Claire_de_Binare/issues/2638)).
+
+Rerun:
+
+```bash
+make context-negative-controls
+```
+
+Harness JSON evidence (`make context-live-invoke --format json`) includes a
+`negative_controls` summary block for machine-readable proof. Refs parent epic [#2847](https://github.com/jannekbuengener/Claire_de_Binare/issues/2847).
+
 Expected output (best case — bridge + stdio both work):
 ```
 === CDB Context MCP Capability Validation ===

--- a/tests/fixtures/surrealdb/negative_controls_matrix.py
+++ b/tests/fixtures/surrealdb/negative_controls_matrix.py
@@ -1,0 +1,15 @@
+"""Test re-export of production negative-control matrix (#2854)."""
+
+from tools.surrealdb.negative_controls_matrix import (
+    NEGATIVE_CONTROL_MATRIX,
+    NegativeControlCase,
+    case_by_id,
+    matrix_case_ids,
+)
+
+__all__ = [
+    "NEGATIVE_CONTROL_MATRIX",
+    "NegativeControlCase",
+    "case_by_id",
+    "matrix_case_ids",
+]

--- a/tests/unit/surrealdb/test_context_invocation_evidence_json.py
+++ b/tests/unit/surrealdb/test_context_invocation_evidence_json.py
@@ -119,6 +119,10 @@ def test_full_json_pass_zero_accepted_limitations(
     assert doc["evidence_claims"] == []
     assert doc["missing_evidence_codes"] == []
     assert report.summary.get("PASS_WITH_LIMITS", 0) == 0
+    nc = doc.get("negative_controls") or {}
+    assert nc.get("schema") == "negative-controls-matrix/v1"
+    assert nc.get("issue_ref") == "2854"
+    assert nc["safety_flags"]["PERSIST_ALLOWED"] is False
 
 
 def test_determinism_hash_stable_for_equivalent_report() -> None:

--- a/tests/unit/surrealdb/test_negative_controls_regression.py
+++ b/tests/unit/surrealdb/test_negative_controls_regression.py
@@ -1,0 +1,261 @@
+"""Regression suite for write-intent and mutation negative controls (#2854)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.fixtures.surrealdb.negative_controls_matrix import (
+    NEGATIVE_CONTROL_MATRIX,
+    NegativeControlCase,
+)
+from tools.mcp.context_bridge import ContextBridge
+from tools.mcp.memory_write_intent_tools import (
+    MUTATION_ALLOWED,
+    handle_cdb_context_memory_write_intent,
+)
+from tools.surrealdb import negative_controls as nc
+from tools.surrealdb.db_record_evidence_contract import (
+    build_example_claim,
+    classify_trust,
+    compute_determinism_hash,
+)
+from tools.surrealdb.memory_write_gate import (
+    PERSIST_ALLOWED,
+    PERSIST_ENV_VAR,
+    approved_for_persist,
+)
+from tools.surrealdb.memory_write_gate import (
+    MemoryWriteAuthorization,
+    PROOF_SCOPE_HGW_2759,
+)
+from tools.surrealdb.scope_drift_firewall import scan_scope_drift_v1
+from tools.surrealdb.negative_controls_matrix import case_by_id
+
+pytestmark = pytest.mark.unit
+
+
+def _valid_record(**overrides) -> dict:
+    base: dict = {
+        "scope": "agent:TEST/cursor",
+        "namespace": "session",
+        "memory_type": "working_memory",
+        "content": "Negative control regression record",
+        "source_refs": ["docs/AGENTS.md@abc123"],
+        "evidence_refs": ["ev-2854"],
+        "confidence": 0.9,
+        "ttl": 3600,
+        "expires_at": "2026-05-30T00:00:00+00:00",
+        "created_by": "cursor-agent-v1",
+        "created_at": "2026-05-29T04:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_auth() -> dict:
+    return {
+        "human_go_token": "GO-2026-05-29-slice5",
+        "authorized_by": "jannekbuengener",
+        "authorized_at": "2026-05-29T11:00:00+00:00",
+        "scope": "agent:TEST/cursor",
+        "target_issue": "2854",
+        "evidence_refs": ["github:issue/2854"],
+        "operation": "create",
+    }
+
+
+def _hgw_auth(**overrides) -> MemoryWriteAuthorization:
+    base = dict(
+        human_go_token="GO-2026-05-31-hgw",
+        authorized_by="jannekbuengener",
+        authorized_at="2026-05-31T12:00:00+00:00",
+        scope=f"memory_write_path_t4:{PROOF_SCOPE_HGW_2759}",
+        target_issue="2759",
+        evidence_refs=("github:issue/2759",),
+        operation="create",
+    )
+    base.update(overrides)
+    return MemoryWriteAuthorization(**base)
+
+
+def _invoke_write_intent(case: NegativeControlCase) -> dict:
+    params: dict = {"record": _valid_record()}
+    if case.include_authorization:
+        params["authorization"] = _valid_auth()
+    if case.operation_mode:
+        params["operation_mode"] = case.operation_mode
+    if case.mutation_flag:
+        params[case.mutation_flag] = True
+    if case.parameters:
+        params.update(case.parameters)
+    return handle_cdb_context_memory_write_intent(
+        {"tool": "cdb_context_memory_write_intent", "parameters": params}
+    )
+
+
+@pytest.mark.unit
+def test_safety_defaults_off() -> None:
+    assert nc.assert_safety_defaults_off() == []
+    assert PERSIST_ALLOWED is False
+    assert MUTATION_ALLOWED is False
+
+
+@pytest.mark.unit
+def test_negative_control_matrix_summary_machine_readable() -> None:
+    summary = nc.negative_control_matrix_summary()
+    assert summary["schema"] == "negative-controls-matrix/v1"
+    assert summary["issue_ref"] == "2854"
+    assert len(summary["cases"]) == len(NEGATIVE_CONTROL_MATRIX)
+    assert summary["safety_flags"]["PERSIST_ALLOWED"] is False
+    assert summary["safety_flags"]["MUTATION_ALLOWED"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "case_id",
+    [c.case_id for c in NEGATIVE_CONTROL_MATRIX if c.category == "write_intent"],
+)
+def test_write_intent_matrix_cases(case_id: str) -> None:
+    case = case_by_id(case_id)
+    response = _invoke_write_intent(case)
+    if case.operation_mode == "dry_run" and case.include_authorization:
+        assert response["status"] == "ok"
+        assert response["result"]["gate_status"] == "approved_dry_run"
+        assert response["result"]["persist_allowed"] is False
+    elif not case.include_authorization:
+        assert response["status"] == "ok"
+        assert response["result"]["gate_status"] == "blocked_no_authorization"
+    else:
+        assert response["status"] == "refused"
+    safe, issues = nc.refusal_output_is_safe(response)
+    assert safe, issues
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "case_id",
+    [c.case_id for c in NEGATIVE_CONTROL_MATRIX if c.category == "mutation_gate"],
+)
+def test_mutation_gate_matrix_cases(case_id: str) -> None:
+    case = case_by_id(case_id)
+    response = _invoke_write_intent(case)
+    if case.parameters and "query" in case.parameters:
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "unsafe_input"
+    else:
+        assert response["status"] == "error"
+        assert response["error"]["code"] == "mutation_blocked_by_default"
+    safe, _ = nc.refusal_output_is_safe(response)
+    assert safe
+
+
+@pytest.mark.unit
+def test_productive_persist_blocked_without_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(PERSIST_ENV_VAR, raising=False)
+    assert approved_for_persist(_hgw_auth(), human_go_tier="HG-W") is False
+    assert PERSIST_ALLOWED is False
+
+
+@pytest.mark.unit
+def test_fake_brain_source_classified_invalid_fake_db() -> None:
+    claim = build_example_claim(
+        record_source="surrealdb-local",
+        trust_classification="invalid_fake_db",
+        record_ids=[],
+        record_hashes_or_content_fingerprints=[],
+        caller_evidence={"brain_source": "surrealdb-local"},
+        limitations=["caller brain_source ignored"],
+    )
+    claim["determinism_hash"] = compute_determinism_hash(claim)
+    assert classify_trust(claim) == "invalid_fake_db"
+
+
+@pytest.mark.unit
+def test_scope_drift_blocks_write_intent_without_go() -> None:
+    bundle = {
+        "human_go_token": "",
+        "generated_findings": [
+            {
+                "write_intent": True,
+                "content": "persist this finding to agent_memory",
+            }
+        ],
+    }
+    result = scan_scope_drift_v1(bundle)
+    types = {f.drift_type for f in result.findings}
+    assert "unauthorized_write_intent" in types
+
+
+@pytest.mark.unit
+def test_harness_classify_bridge_refused_is_pass() -> None:
+    from tools.surrealdb import context_live_invocation_harness as harness
+
+    result = {
+        "status": "refused",
+        "code": "agent_memory_write_not_activated",
+    }
+    assert (
+        harness.classify_tool_result("cdb_context_memory_write_intent", result)
+        == "PASS"
+    )
+    assert (
+        nc.classify_memory_write_intent_negative_control(
+            result, invocation_path="bridge"
+        )
+        == "PASS"
+    )
+
+
+@pytest.mark.unit
+def test_harness_classify_mcp_blocked_safety_not_fail() -> None:
+    result = {
+        "status": "error",
+        "error": {
+            "code": "blocked_safety",
+            "message": "Smart Mode blocked write-intent MCP call",
+        },
+    }
+    assert (
+        nc.classify_memory_write_intent_negative_control(
+            result, invocation_path="mcp"
+        )
+        == "BLOCKED_SAFETY"
+    )
+
+
+@pytest.mark.unit
+def test_bridge_execute_write_intent_refusal_no_secrets() -> None:
+    bridge = ContextBridge()
+    response = bridge.execute_tool(
+        "cdb_context_memory_write_intent",
+        {
+            "record": _valid_record(),
+            "authorization": _valid_auth(),
+            "operation_mode": "agent_memory_write",
+        },
+    )
+    assert response["status"] == "refused"
+    assert response["code"] == "agent_memory_write_not_activated"
+    serialized = json.dumps(response)
+    assert "GO-2026-05-29-slice5" not in serialized
+    assert '"human_go_token"' not in serialized
+
+
+@pytest.mark.unit
+def test_matrix_case_mcp_smart_mode_blocked_safety_entry() -> None:
+    case = case_by_id("mcp_smart_mode_blocked_safety")
+    assert case.expected_verdict == "BLOCKED_SAFETY"
+    simulated = {
+        "status": "error",
+        "error": {"code": case.mcp_simulated_code, "message": "Smart Mode policy"},
+    }
+    assert (
+        nc.classify_memory_write_intent_negative_control(
+            simulated, invocation_path="mcp"
+        )
+        == case.expected_verdict
+    )

--- a/tests/unit/surrealdb/test_negative_controls_regression.py
+++ b/tests/unit/surrealdb/test_negative_controls_regression.py
@@ -220,9 +220,7 @@ def test_harness_classify_mcp_blocked_safety_not_fail() -> None:
         },
     }
     assert (
-        nc.classify_memory_write_intent_negative_control(
-            result, invocation_path="mcp"
-        )
+        nc.classify_memory_write_intent_negative_control(result, invocation_path="mcp")
         == "BLOCKED_SAFETY"
     )
 

--- a/tools/surrealdb/context_invocation_evidence_json.py
+++ b/tools/surrealdb/context_invocation_evidence_json.py
@@ -11,6 +11,7 @@ from typing import Any, Mapping
 
 from core.replay.canonical_json import canonical_hash, canonical_json_dumps
 from tools.surrealdb import context_live_invocation_harness as harness
+from tools.surrealdb.negative_controls import negative_control_matrix_summary
 from tools.surrealdb.db_record_evidence_contract import (
     ACCEPTED_LIMITATION_CODES,
     SCHEMA_VERSION as CLAIM_SCHEMA_VERSION,
@@ -218,6 +219,7 @@ def build_invocation_evidence(report: harness.HarnessReport) -> dict[str, Any]:
         "lr_note": report.lr_note,
         "safety_flags": dict(report.safety_flags),
         "root_inventory": dict(report.root_inventory),
+        "negative_controls": negative_control_matrix_summary(),
     }
     document["determinism_hash"] = compute_aggregate_determinism_hash(document)
     return document

--- a/tools/surrealdb/context_live_invocation_harness.py
+++ b/tools/surrealdb/context_live_invocation_harness.py
@@ -303,13 +303,17 @@ def classify_tool_result(
     code = _extract_error_code(result)
 
     if tool_name == "cdb_context_memory_write_intent":
-        if status == "refused":
+        from tools.surrealdb.negative_controls import (
+            classify_memory_write_intent_negative_control,
+        )
+
+        verdict = classify_memory_write_intent_negative_control(
+            result, invocation_path="bridge"
+        )
+        if verdict == "PASS":
             return "PASS"
-        if code == "agent_memory_write_not_activated" and status in (
-            "refused",
-            "error",
-        ):
-            return "PASS"
+        if verdict == "BLOCKED_SAFETY":
+            return "BLOCKED_SAFETY"
         return "FAIL"
 
     if status == "ok":

--- a/tools/surrealdb/context_live_invocation_harness.py
+++ b/tools/surrealdb/context_live_invocation_harness.py
@@ -469,9 +469,7 @@ def run_matrix(
 ) -> HarnessReport:
     """Build the invocation matrix. When live=False, only validate manifest/registry."""
     repo_root = _repo_root()
-    root_inventory = _attach_root_inventory(
-        repo_root, check_github=check_github_roots
-    )
+    root_inventory = _attach_root_inventory(repo_root, check_github=check_github_roots)
     git = _git_metadata(repo_root)
     bridge = create_bridge() if live else None
     invocations = invocations_for_profile(profile)

--- a/tools/surrealdb/negative_controls.py
+++ b/tools/surrealdb/negative_controls.py
@@ -53,9 +53,7 @@ SECRET_SUBSTRINGS_IN_OUTPUT = (
     "secret=",
 )
 
-_HUMAN_GO_TOKEN_PATTERN = re.compile(
-    r"GO-\d{4}-\d{2}-\d{2}(?:-[A-Za-z0-9._-]+)?"
-)
+_HUMAN_GO_TOKEN_PATTERN = re.compile(r"GO-\d{4}-\d{2}-\d{2}(?:-[A-Za-z0-9._-]+)?")
 
 
 def default_safety_flags() -> dict[str, bool]:

--- a/tools/surrealdb/negative_controls.py
+++ b/tools/surrealdb/negative_controls.py
@@ -1,0 +1,182 @@
+"""Shared negative-control classification for Context/MCP/SurrealDB (#2854).
+
+Read-only helpers: no DB access, no MCP mutations, no persistence.
+LR remains NO-GO. Defaults: PERSIST_ALLOWED=False, MUTATION_ALLOWED=False.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Literal, Mapping
+
+from tools.mcp.memory_write_intent_tools import MUTATION_ALLOWED
+from tools.surrealdb.memory_write_gate import PERSIST_ALLOWED
+
+NegativeControlVerdict = Literal["PASS", "BLOCKED_SAFETY", "FAIL"]
+InvocationPath = Literal["bridge", "mcp"]
+
+WRITE_INTENT_PASS_CODES = frozenset(
+    {
+        "agent_memory_write_not_activated",
+        "productive_audit_not_activated",
+        "local_audit_mcp_not_activated",
+        "hg_p_required",
+        "operation_mode_invalid",
+        "mutation_blocked_by_default",
+    }
+)
+
+MCP_BLOCKED_SAFETY_CODES = frozenset(
+    {
+        "blocked_safety",
+        "smart_mode_blocked",
+        "mcp_mutation_blocked",
+        "policy_blocked",
+    }
+)
+
+MCP_BLOCKED_SAFETY_MESSAGE_MARKERS = (
+    "smart mode",
+    "blocked_safety",
+    "mutation not allowed",
+    "write intent blocked",
+)
+
+SECRET_SUBSTRINGS_IN_OUTPUT = (
+    "SURREAL_PASS",
+    "SURREAL_USER",
+    "Authorization:",
+    "Bearer ",
+    "password=",
+    "api_key=",
+    "secret=",
+)
+
+_HUMAN_GO_TOKEN_PATTERN = re.compile(
+    r"GO-\d{4}-\d{2}-\d{2}(?:-[A-Za-z0-9._-]+)?"
+)
+
+
+def default_safety_flags() -> dict[str, bool]:
+    """Module-level safety defaults for harness and regression matrix."""
+    return {
+        "PERSIST_ALLOWED": bool(PERSIST_ALLOWED),
+        "MUTATION_ALLOWED": bool(MUTATION_ALLOWED),
+    }
+
+
+def assert_safety_defaults_off() -> list[str]:
+    """Return violation messages when default-off gates are not enforced."""
+    violations: list[str] = []
+    flags = default_safety_flags()
+    if flags["PERSIST_ALLOWED"]:
+        violations.append("PERSIST_ALLOWED must remain False in CI/regression")
+    if flags["MUTATION_ALLOWED"]:
+        violations.append("MUTATION_ALLOWED must remain False in CI/regression")
+    return violations
+
+
+def _extract_code(result: Mapping[str, Any]) -> str | None:
+    err = result.get("error")
+    if isinstance(err, dict):
+        code = err.get("code")
+        if isinstance(code, str) and code.strip():
+            return code.strip()
+    code_top = result.get("code")
+    if isinstance(code_top, str) and code_top.strip():
+        return code_top.strip()
+    return None
+
+
+def _extract_message(result: Mapping[str, Any]) -> str:
+    err = result.get("error")
+    if isinstance(err, dict):
+        msg = err.get("message")
+        if isinstance(msg, str):
+            return msg
+    msg_top = result.get("message")
+    return str(msg_top) if msg_top is not None else ""
+
+
+def classify_memory_write_intent_negative_control(
+    result: Mapping[str, Any],
+    *,
+    invocation_path: InvocationPath = "bridge",
+) -> NegativeControlVerdict:
+    """Classify write-intent negative-control outcomes (bridge vs MCP policy path)."""
+    status = result.get("status")
+    code = _extract_code(result)
+    message = _extract_message(result).lower()
+
+    if status == "ok":
+        gate = result.get("result")
+        if isinstance(gate, dict):
+            gate_status = gate.get("gate_status")
+            if gate_status == "approved_dry_run":
+                return "PASS"
+        return "FAIL"
+
+    if invocation_path == "mcp":
+        if code in MCP_BLOCKED_SAFETY_CODES:
+            return "BLOCKED_SAFETY"
+        if any(marker in message for marker in MCP_BLOCKED_SAFETY_MESSAGE_MARKERS):
+            return "BLOCKED_SAFETY"
+        if status == "error" and code not in WRITE_INTENT_PASS_CODES:
+            return "BLOCKED_SAFETY"
+
+    if status == "refused":
+        if code in WRITE_INTENT_PASS_CODES or code is None:
+            return "PASS"
+        return "PASS"
+
+    if code in WRITE_INTENT_PASS_CODES:
+        return "PASS"
+
+    if code == "mutation_blocked_by_default":
+        return "PASS"
+
+    if status in ("refused", "error") and code:
+        return "PASS"
+
+    return "FAIL"
+
+
+def refusal_output_is_safe(payload: Mapping[str, Any]) -> tuple[bool, list[str]]:
+    """Ensure refusal/error payloads do not leak secrets or raw GO tokens."""
+    serialized = json.dumps(payload, default=str)
+    issues: list[str] = []
+    if '"human_go_token"' in serialized:
+        issues.append("raw human_go_token field in output")
+    for match in _HUMAN_GO_TOKEN_PATTERN.findall(serialized):
+        if match.startswith("GO-"):
+            issues.append("raw GO token pattern in output")
+            break
+    upper = serialized.upper()
+    for marker in SECRET_SUBSTRINGS_IN_OUTPUT:
+        if marker.upper() in upper:
+            issues.append(f"forbidden substring {marker!r} in output")
+    return (len(issues) == 0, issues)
+
+
+def negative_control_matrix_summary() -> dict[str, Any]:
+    """Machine-readable matrix index for harness evidence exports."""
+    from tools.surrealdb.negative_controls_matrix import NEGATIVE_CONTROL_MATRIX
+
+    rows = [
+        {
+            "case_id": case.case_id,
+            "category": case.category,
+            "expected_verdict": case.expected_verdict,
+            "invocation_path": case.invocation_path,
+            "issue_ref": "2854",
+        }
+        for case in NEGATIVE_CONTROL_MATRIX
+    ]
+    return {
+        "schema": "negative-controls-matrix/v1",
+        "issue_ref": "2854",
+        "parent_issue_ref": "2847",
+        "safety_flags": default_safety_flags(),
+        "cases": rows,
+    }

--- a/tools/surrealdb/negative_controls_matrix.py
+++ b/tools/surrealdb/negative_controls_matrix.py
@@ -1,0 +1,172 @@
+"""Central negative-control matrix for write-intent and mutation blockades (#2854).
+
+Read-only catalog for regression tests and harness evidence. No live DB/MCP mutations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+NegativeControlCategory = Literal[
+    "safety_defaults",
+    "write_intent",
+    "mutation_gate",
+    "productive_persist",
+    "fake_db_evidence",
+    "scope_drift",
+    "harness_classification",
+]
+
+InvocationPath = Literal["bridge", "mcp", "n/a"]
+ExpectedVerdict = Literal["PASS", "BLOCKED_SAFETY", "FAIL", "blocked"]
+
+
+@dataclass(frozen=True)
+class NegativeControlCase:
+    case_id: str
+    category: NegativeControlCategory
+    description: str
+    expected_verdict: ExpectedVerdict
+    invocation_path: InvocationPath = "bridge"
+    parameters: dict[str, Any] | None = None
+    operation_mode: str | None = None
+    mutation_flag: str | None = None
+    mcp_simulated_code: str | None = None
+    include_authorization: bool = True
+
+
+NEGATIVE_CONTROL_MATRIX: tuple[NegativeControlCase, ...] = (
+    NegativeControlCase(
+        case_id="defaults_persist_allowed_false",
+        category="safety_defaults",
+        description="PERSIST_ALLOWED module constant remains False",
+        expected_verdict="PASS",
+        invocation_path="n/a",
+    ),
+    NegativeControlCase(
+        case_id="defaults_mutation_allowed_false",
+        category="safety_defaults",
+        description="MUTATION_ALLOWED module constant remains False",
+        expected_verdict="PASS",
+        invocation_path="n/a",
+    ),
+    NegativeControlCase(
+        case_id="write_intent_dry_run_allowed",
+        category="write_intent",
+        description="dry_run gate evaluation returns approved_dry_run",
+        expected_verdict="PASS",
+        invocation_path="bridge",
+        operation_mode="dry_run",
+        include_authorization=True,
+    ),
+    NegativeControlCase(
+        case_id="write_intent_agent_memory_refused",
+        category="write_intent",
+        description="agent_memory_write operation_mode refused on bridge",
+        expected_verdict="PASS",
+        invocation_path="bridge",
+        operation_mode="agent_memory_write",
+        include_authorization=True,
+    ),
+    NegativeControlCase(
+        case_id="write_intent_productive_audit_refused",
+        category="write_intent",
+        description="audit_persist_productive refused without G3b activation",
+        expected_verdict="PASS",
+        invocation_path="bridge",
+        operation_mode="audit_persist_productive",
+        include_authorization=True,
+    ),
+    NegativeControlCase(
+        case_id="write_intent_local_audit_refused",
+        category="write_intent",
+        description="audit_persist_local refused on MCP surface",
+        expected_verdict="PASS",
+        invocation_path="bridge",
+        operation_mode="audit_persist_local",
+        include_authorization=True,
+    ),
+    NegativeControlCase(
+        case_id="mutation_flag_persist_blocked",
+        category="mutation_gate",
+        description="persist=true blocked with mutation_blocked_by_default",
+        expected_verdict="PASS",
+        invocation_path="bridge",
+        mutation_flag="persist",
+    ),
+    NegativeControlCase(
+        case_id="mutation_flag_execute_write_blocked",
+        category="mutation_gate",
+        description="execute_write=true blocked with mutation_blocked_by_default",
+        expected_verdict="PASS",
+        invocation_path="bridge",
+        mutation_flag="execute_write",
+    ),
+    NegativeControlCase(
+        case_id="productive_persist_without_env",
+        category="productive_persist",
+        description="approved_for_persist false without CDB_PERSIST_ALLOWED=1",
+        expected_verdict="PASS",
+        invocation_path="n/a",
+    ),
+    NegativeControlCase(
+        case_id="write_intent_no_authorization",
+        category="write_intent",
+        description="missing authorization yields blocked_no_authorization",
+        expected_verdict="PASS",
+        invocation_path="bridge",
+        operation_mode="dry_run",
+        include_authorization=False,
+    ),
+    NegativeControlCase(
+        case_id="unsafe_sql_injection_blocked",
+        category="mutation_gate",
+        description="query field with INSERT blocked as unsafe_input",
+        expected_verdict="PASS",
+        invocation_path="bridge",
+        parameters={"query": "INSERT INTO agent_memory SET x=1"},
+    ),
+    NegativeControlCase(
+        case_id="mcp_smart_mode_blocked_safety",
+        category="harness_classification",
+        description="MCP Smart Mode policy block is BLOCKED_SAFETY not FAIL",
+        expected_verdict="BLOCKED_SAFETY",
+        invocation_path="mcp",
+        mcp_simulated_code="blocked_safety",
+    ),
+    NegativeControlCase(
+        case_id="mcp_bridge_refused_still_pass",
+        category="harness_classification",
+        description="bridge refused write-intent remains PASS regression row",
+        expected_verdict="PASS",
+        invocation_path="bridge",
+        operation_mode="agent_memory_write",
+        include_authorization=True,
+    ),
+    NegativeControlCase(
+        case_id="fake_brain_source_not_db_evidence",
+        category="fake_db_evidence",
+        description="caller brain_source without records is invalid_fake_db",
+        expected_verdict="PASS",
+        invocation_path="n/a",
+    ),
+    NegativeControlCase(
+        case_id="scope_drift_write_without_go",
+        category="scope_drift",
+        description="scope drift firewall blocks write-intent without human_go_token",
+        expected_verdict="blocked",
+        invocation_path="n/a",
+    ),
+)
+
+
+def matrix_case_ids() -> list[str]:
+    return [c.case_id for c in NEGATIVE_CONTROL_MATRIX]
+
+
+def case_by_id(case_id: str) -> NegativeControlCase:
+    for case in NEGATIVE_CONTROL_MATRIX:
+        if case.case_id == case_id:
+            return case
+    raise KeyError(case_id)


### PR DESCRIPTION
## Summary
Standardize write-intent and mutation negative-control regression tests with a shared matrix, classifiers, and harness evidence block.

Closes #2854
Refs #2847

## Delivered
- `tools/surrealdb/negative_controls_matrix.py` — canonical case catalog
- `tools/surrealdb/negative_controls.py` — PASS / BLOCKED_SAFETY / FAIL classification helpers
- `tests/unit/surrealdb/test_negative_controls_regression.py` — parametrized regression suite
- Harness + JSON evidence: shared write-intent classifier; `negative_controls` summary field
- `make context-negative-controls`; runbook + evidence doc updates

## Validation
- Local: `python -m pytest -q tests/unit/surrealdb/test_negative_controls_regression.py tests/unit/tools/mcp/test_memory_write_intent_tool.py tests/unit/surrealdb/test_memory_write_gate.py tests/unit/surrealdb/test_context_live_invocation_harness.py tests/unit/surrealdb/test_context_invocation_evidence_json.py -m unit`
- Local: `ruff check` on touched Python modules
- CI required checks pending on PR

## Non-goals
Security alert scope; productive DB/MCP mutations; runtime BLUE/RED; trust scoring (#2856).

## Safety Boundaries
PERSIST_ALLOWED and MUTATION_ALLOWED remain False; LR NO-GO.

## Restunsicherheiten
Live MCP Smart Mode BLOCKED_SAFETY is unit-simulated; bridge path covered in CI tests.