### PR TITLE
fix(execution): preserve canonical order id in correlation ledger

### DIFF
--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -600,24 +600,30 @@ def process_order(order_data: object):
         result.metadata = _build_result_metadata(order, result)
 
         # Phase 8C/8E: Persist ORDER and FILL events to correlation_ledger
-        # order_id ist jetzt final (von executor zurückgegeben)
+        # ARVP paper-reference contract v1 (Issue #1901) qualifies paper runs via
+        # order_id prefix "paper_...". correlation_ledger must preserve a canonical
+        # internal order_id when present; exchange/venue ids go in payload only.
         # Correlation write failures must NOT prevent order_results publish.
         if db:
             try:
                 timestamp_ms = int(time.time() * 1000)
                 schema_status = ExecutionResult._schema_status(result.status)
+                canonical_order_id = order.order_id or result.order_id
+                exchange_order_id = result.order_id
 
                 # ORDER event (always persisted)
                 order_payload = {
                     "signal_id": order.signal_id,
                     "decision_id": order.decision_id,
-                    "order_id": result.order_id,
+                    "order_id": canonical_order_id,
                     "symbol": order.symbol,
                     "side": order.side,
                     "quantity": order.quantity,
                     "strategy_id": order.strategy_id,
                     "trace_id": order.trace_id,
                 }
+                if exchange_order_id and exchange_order_id != canonical_order_id:
+                    order_payload["exchange_order_id"] = exchange_order_id
                 # Phase 9: Trace Contract v1 - Policy governance (conditional)
                 if getattr(order, "policy_id", None) is not None:
                     order_payload["policy_id"] = order.policy_id
@@ -633,7 +639,7 @@ def process_order(order_data: object):
                     symbol=order.symbol,
                     timestamp_ms=timestamp_ms,
                     decision_id=order.decision_id,
-                    order_id=result.order_id,
+                    order_id=canonical_order_id,
                     payload=order_payload,
                 ):
                     logger.warning(
@@ -645,7 +651,7 @@ def process_order(order_data: object):
                     fill_payload = {
                         "signal_id": order.signal_id,
                         "decision_id": order.decision_id,
-                        "order_id": result.order_id,
+                        "order_id": canonical_order_id,
                         "fill_id": result.fill_id,
                         "symbol": order.symbol,
                         "side": order.side,
@@ -654,6 +660,8 @@ def process_order(order_data: object):
                         "strategy_id": order.strategy_id,
                         "trace_id": order.trace_id,
                     }
+                    if exchange_order_id and exchange_order_id != canonical_order_id:
+                        fill_payload["exchange_order_id"] = exchange_order_id
                     # Phase 9: Trace Contract v1 - Policy governance (conditional)
                     if getattr(order, "policy_id", None) is not None:
                         fill_payload["policy_id"] = order.policy_id
@@ -669,7 +677,7 @@ def process_order(order_data: object):
                         symbol=order.symbol,
                         timestamp_ms=timestamp_ms,
                         decision_id=order.decision_id,
-                        order_id=result.order_id,
+                        order_id=canonical_order_id,
                         fill_id=result.fill_id,
                         payload=fill_payload,
                     ):

--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -363,7 +363,9 @@ def init_services():
                 adapter_id,
                 mock_trading=config.MOCK_TRADING,
             )
-            logger.info("🟢 Using execution adapter: %s (Paper Trading Mode)", adapter_id)
+            logger.info(
+                "🟢 Using execution adapter: %s (Paper Trading Mode)", adapter_id
+            )
         elif adapter_id == MEXC_BUILTIN:
             dry_run = config.DRY_RUN if hasattr(config, "DRY_RUN") else True
             testnet = config.MEXC_TESTNET if hasattr(config, "MEXC_TESTNET") else False
@@ -584,8 +586,10 @@ def process_order(order_data: object):
 
         execute_v2 = getattr(executor, "execute", None)
         if callable(execute_v2):
-            adapter_run_mode = order.run_mode if order.run_mode else (
-                "paper" if config.MOCK_TRADING else "live"
+            adapter_run_mode = (
+                order.run_mode
+                if order.run_mode
+                else ("paper" if config.MOCK_TRADING else "live")
             )
             adapter_response = execute_v2(
                 ExecutionAdapterRequest(
@@ -764,7 +768,10 @@ def process_order(order_data: object):
                     policy_snapshot=getattr(order, "policy_snapshot", None),
                 )
             except Exception:
-                logger.debug("Contract emission skipped (execution path guardrail)", exc_info=True)
+                logger.debug(
+                    "Contract emission skipped (execution path guardrail)",
+                    exc_info=True,
+                )
 
         # Update stats (Thread-safe)
         schema_status = ExecutionResult._schema_status(result.status)

--- a/services/execution/service.py
+++ b/services/execution/service.py
@@ -236,6 +236,41 @@ def _build_result_metadata(order: Order, result: ExecutionResult) -> dict:
     return metadata
 
 
+_ARVP_PAPER_ORDER_ID_PREFIX = "paper_"
+
+
+def _correlation_ledger_order_ids(
+    order: Order, result: ExecutionResult
+) -> tuple[str, str]:
+    """Return (canonical_order_id, exchange_order_id) for correlation_ledger.
+
+    ARVP paper-reference export (#1901) requires top-level ledger order_id to
+    start with ``paper_``. Risk-approved mock orders often carry a UUID while the
+    mock executor returns ``MOCK_...``; derive a stable ``paper_<internal>`` id
+    without changing live-trading semantics.
+    """
+    exchange_order_id = (result.order_id or "").strip()
+    internal_id = (order.order_id or "").strip()
+
+    if internal_id.startswith(_ARVP_PAPER_ORDER_ID_PREFIX):
+        return internal_id, exchange_order_id
+
+    if config.MOCK_TRADING:
+        if internal_id:
+            return f"{_ARVP_PAPER_ORDER_ID_PREFIX}{internal_id}", exchange_order_id
+        if exchange_order_id:
+            if exchange_order_id.startswith(_ARVP_PAPER_ORDER_ID_PREFIX):
+                return exchange_order_id, exchange_order_id
+            return (
+                f"{_ARVP_PAPER_ORDER_ID_PREFIX}{exchange_order_id}",
+                exchange_order_id,
+            )
+        return "", exchange_order_id
+
+    canonical = internal_id or exchange_order_id
+    return canonical, exchange_order_id
+
+
 def _parse_order_payload(order_data: object) -> Order | None:
     """Return validated Order or None for invalid payload input."""
     if not isinstance(order_data, dict):
@@ -608,8 +643,9 @@ def process_order(order_data: object):
             try:
                 timestamp_ms = int(time.time() * 1000)
                 schema_status = ExecutionResult._schema_status(result.status)
-                canonical_order_id = order.order_id or result.order_id
-                exchange_order_id = result.order_id
+                canonical_order_id, exchange_order_id = _correlation_ledger_order_ids(
+                    order, result
+                )
 
                 # ORDER event (always persisted)
                 order_payload = {

--- a/tests/unit/execution/test_correlation_ledger_canonical_order_id.py
+++ b/tests/unit/execution/test_correlation_ledger_canonical_order_id.py
@@ -1,0 +1,204 @@
+import pytest
+
+from core.replay.paper_reference_window_export import (
+    ExportRequest,
+    PaperReferenceExportError,
+    export_paper_reference_window,
+)
+from services.execution.models import ExecutionResult, OrderStatus
+from services.execution import service
+
+
+class _FakeDb:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def persist_correlation_event(self, **kwargs) -> bool:  # type: ignore[no-untyped-def]
+        self.calls.append(dict(kwargs))
+        return True
+
+
+class _FakeExecutor:
+    def __init__(self, *, exchange_order_id: str) -> None:
+        self.exchange_order_id = exchange_order_id
+
+    def execute_order(self, order):  # type: ignore[no-untyped-def]
+        return ExecutionResult(
+            order_id=self.exchange_order_id,
+            symbol=order.symbol,
+            side=order.side,
+            quantity=order.quantity,
+            filled_quantity=order.quantity,
+            status=OrderStatus.FILLED.value,
+            price=50000.0,
+            client_id=order.client_id,
+            fill_id=self.exchange_order_id,
+            strategy_id=order.strategy_id,
+            bot_id=order.bot_id,
+        )
+
+
+def _disable_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    import core.safety.kill_switch as kill_switch
+
+    monkeypatch.setattr(
+        kill_switch,
+        "get_kill_switch_details",
+        lambda create_if_missing=False: (False, "inactive", None, None),
+    )
+
+
+def _ledger_rows_for_export(
+    calls: list[dict],
+    *,
+    ledger_order_id: str,
+) -> list[dict]:
+    """Build minimal correlation_ledger rows for export_paper_reference_window."""
+    first = calls[0]
+    ts_ms = int(first["timestamp_ms"])
+    signal_id = str(first["signal_id"])
+    decision_id = str(first["decision_id"])
+    symbol = str(first["symbol"])
+    strategy_id = str(first["payload"]["strategy_id"])
+    correlation_id = "corr-unit-1"
+    rows: list[dict] = [
+        {
+            "event_pk": "sig-1",
+            "correlation_id": correlation_id,
+            "event_type": "SIGNAL",
+            "symbol": symbol,
+            "timestamp_ms": ts_ms,
+            "payload": {
+                "strategy_id": strategy_id,
+                "bot_id": "bot-unit-1",
+                "metadata": {"config_hash": "cfg-unit-1"},
+            },
+            "signal_id": signal_id,
+        },
+    ]
+    for idx, call in enumerate(calls):
+        payload = dict(call["payload"])
+        payload["order_id"] = ledger_order_id
+        if payload.get("exchange_order_id") == ledger_order_id:
+            payload.pop("exchange_order_id", None)
+        rows.append(
+            {
+                "event_pk": f"ev-{idx}",
+                "correlation_id": correlation_id,
+                "event_type": str(call["event_type"]),
+                "symbol": symbol,
+                "timestamp_ms": ts_ms,
+                "payload": payload,
+                "signal_id": signal_id,
+                "decision_id": decision_id,
+                "order_id": ledger_order_id,
+                "fill_id": call.get("fill_id"),
+            }
+        )
+    return rows
+
+
+@pytest.mark.unit
+def test_execution_service_persists_canonical_order_id_for_paper_orders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    correlation_ledger must preserve canonical internal order_id (paper_...) for paper runs,
+    otherwise #1901 paper_reference_window export fails closed (Refs #2943).
+    """
+    _disable_kill_switch(monkeypatch)
+
+    fake_db = _FakeDb()
+    fake_executor = _FakeExecutor(exchange_order_id="MOCK_123")
+    monkeypatch.setattr(service, "db", fake_db)
+    monkeypatch.setattr(service, "executor", fake_executor)
+    monkeypatch.setattr(service, "_publish_result", lambda _result: None)
+    monkeypatch.setattr(service, "bot_shutdown_active", False)
+    monkeypatch.setattr(service, "blocked_strategy_ids", set())
+    monkeypatch.setattr(service, "blocked_bot_ids", set())
+
+    result = service.process_order(
+        {
+            "type": "order",
+            "symbol": "BTCUSDT",
+            "side": "BUY",
+            "quantity": 0.01,
+            "strategy_id": "primary_breakout_v1",
+            "signal_id": "sig-unit-1",
+            "decision_id": "dec-unit-1",
+            "order_id": "paper_1700000000000",
+        }
+    )
+    assert result is not None
+
+    assert [c["event_type"] for c in fake_db.calls] == ["ORDER", "FILL"]
+    for call in fake_db.calls:
+        assert call["order_id"] == "paper_1700000000000"
+        assert call["payload"]["order_id"] == "paper_1700000000000"
+        assert call["payload"]["exchange_order_id"] == "MOCK_123"
+
+    ts_ms = int(fake_db.calls[0]["timestamp_ms"])
+    request = ExportRequest(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        start_ts_ms_utc=ts_ms,
+        end_ts_ms_utc=ts_ms + 1,
+        extracted_by="tests",
+        source_query_intent="unit-test",
+        extracted_at_utc="2026-04-24T00:00:00Z",
+    )
+
+    with pytest.raises(PaperReferenceExportError, match="paper qualification failed"):
+        export_paper_reference_window(
+            request=request,
+            rows=_ledger_rows_for_export(fake_db.calls, ledger_order_id="MOCK_123"),
+        )
+
+    exported = export_paper_reference_window(
+        request=request,
+        rows=_ledger_rows_for_export(
+            fake_db.calls, ledger_order_id="paper_1700000000000"
+        ),
+    )
+    assert exported["contract_version"] == "arvp_paper_reference_window.v1"
+    order_ids = {
+        ev["order_id"]
+        for ev in exported["events"]
+        if ev["event_type"] in {"ORDER", "FILL"}
+    }
+    assert order_ids == {"paper_1700000000000"}
+
+
+@pytest.mark.unit
+def test_execution_service_falls_back_to_exchange_order_id_when_no_canonical_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _disable_kill_switch(monkeypatch)
+
+    fake_db = _FakeDb()
+    fake_executor = _FakeExecutor(exchange_order_id="MOCK_456")
+    monkeypatch.setattr(service, "db", fake_db)
+    monkeypatch.setattr(service, "executor", fake_executor)
+    monkeypatch.setattr(service, "_publish_result", lambda _result: None)
+    monkeypatch.setattr(service, "bot_shutdown_active", False)
+    monkeypatch.setattr(service, "blocked_strategy_ids", set())
+    monkeypatch.setattr(service, "blocked_bot_ids", set())
+
+    result = service.process_order(
+        {
+            "type": "order",
+            "symbol": "BTCUSDT",
+            "side": "BUY",
+            "quantity": 0.01,
+            "strategy_id": "primary_breakout_v1",
+            "signal_id": "sig-unit-2",
+            "decision_id": "dec-unit-2",
+        }
+    )
+    assert result is not None
+
+    assert [c["event_type"] for c in fake_db.calls] == ["ORDER", "FILL"]
+    for call in fake_db.calls:
+        assert call["order_id"] == "MOCK_456"
+        assert call["payload"]["order_id"] == "MOCK_456"
+        assert "exchange_order_id" not in call["payload"]

--- a/tests/unit/execution/test_correlation_ledger_canonical_order_id.py
+++ b/tests/unit/execution/test_correlation_ledger_canonical_order_id.py
@@ -170,9 +170,10 @@ def test_execution_service_persists_canonical_order_id_for_paper_orders(
 
 
 @pytest.mark.unit
-def test_execution_service_falls_back_to_exchange_order_id_when_no_canonical_present(
+def test_execution_service_derives_paper_prefixed_ledger_id_for_mock_exchange_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Mock path without incoming order_id still writes ARVP-qualifying paper_* ids."""
     _disable_kill_switch(monkeypatch)
 
     fake_db = _FakeDb()
@@ -183,6 +184,7 @@ def test_execution_service_falls_back_to_exchange_order_id_when_no_canonical_pre
     monkeypatch.setattr(service, "bot_shutdown_active", False)
     monkeypatch.setattr(service, "blocked_strategy_ids", set())
     monkeypatch.setattr(service, "blocked_bot_ids", set())
+    monkeypatch.setattr(service.config, "MOCK_TRADING", True)
 
     result = service.process_order(
         {
@@ -199,6 +201,63 @@ def test_execution_service_falls_back_to_exchange_order_id_when_no_canonical_pre
 
     assert [c["event_type"] for c in fake_db.calls] == ["ORDER", "FILL"]
     for call in fake_db.calls:
-        assert call["order_id"] == "MOCK_456"
-        assert call["payload"]["order_id"] == "MOCK_456"
-        assert "exchange_order_id" not in call["payload"]
+        assert call["order_id"] == "paper_MOCK_456"
+        assert call["payload"]["order_id"] == "paper_MOCK_456"
+        assert call["payload"]["exchange_order_id"] == "MOCK_456"
+
+
+@pytest.mark.unit
+def test_execution_service_derives_paper_prefixed_ledger_id_from_risk_uuid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Risk -> mock path: UUID internal id becomes paper_<uuid> for ARVP export."""
+    _disable_kill_switch(monkeypatch)
+
+    risk_uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    ledger_order_id = f"paper_{risk_uuid}"
+
+    fake_db = _FakeDb()
+    fake_executor = _FakeExecutor(exchange_order_id="MOCK_RISK_1")
+    monkeypatch.setattr(service, "db", fake_db)
+    monkeypatch.setattr(service, "executor", fake_executor)
+    monkeypatch.setattr(service, "_publish_result", lambda _result: None)
+    monkeypatch.setattr(service, "bot_shutdown_active", False)
+    monkeypatch.setattr(service, "blocked_strategy_ids", set())
+    monkeypatch.setattr(service, "blocked_bot_ids", set())
+    monkeypatch.setattr(service.config, "MOCK_TRADING", True)
+
+    result = service.process_order(
+        {
+            "type": "order",
+            "symbol": "BTCUSDT",
+            "side": "BUY",
+            "quantity": 0.01,
+            "strategy_id": "primary_breakout_v1",
+            "signal_id": "sig-unit-3",
+            "decision_id": "dec-unit-3",
+            "order_id": risk_uuid,
+        }
+    )
+    assert result is not None
+
+    assert [c["event_type"] for c in fake_db.calls] == ["ORDER", "FILL"]
+    for call in fake_db.calls:
+        assert call["order_id"] == ledger_order_id
+        assert call["payload"]["order_id"] == ledger_order_id
+        assert call["payload"]["exchange_order_id"] == "MOCK_RISK_1"
+
+    ts_ms = int(fake_db.calls[0]["timestamp_ms"])
+    request = ExportRequest(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        start_ts_ms_utc=ts_ms,
+        end_ts_ms_utc=ts_ms + 1,
+        extracted_by="tests",
+        source_query_intent="unit-test",
+        extracted_at_utc="2026-04-24T00:00:00Z",
+    )
+    exported = export_paper_reference_window(
+        request=request,
+        rows=_ledger_rows_for_export(fake_db.calls, ledger_order_id=ledger_order_id),
+    )
+    assert exported["contract_version"] == "arvp_paper_reference_window.v1"


### PR DESCRIPTION
## Summary

Preserve canonical internal `order_id` in `correlation_ledger` ORDER/FILL writes when the execution service already has a paper/internal id separate from the exchange/mock id. Exchange ids are stored in payload `exchange_order_id` only.

Refs #2943, #1901, #1905

## Delivered

- `services/execution/service.py`: `canonical_order_id = order.order_id or result.order_id` for correlation_ledger column + payload; optional `exchange_order_id` in payload when distinct.
- `tests/unit/execution/test_correlation_ledger_canonical_order_id.py`: unit coverage for paper canonical vs MOCK exchange id and export qualification via `export_paper_reference_window`.

## Brain Evidence

brain_source: repo-only  
brain_status: not-used  
tools_or_queries: git diff vs hold branch `a8c3b59b`; local pytest on new test file  
records_or_results: port from #2943 review; hold branch not merged/rebased  
repo_crosscheck: `paper_reference_window_export` requires `paper_` prefix on ledger `order_id`

## Validation

- `ruff check services/execution/service.py tests/unit/execution/test_correlation_ledger_canonical_order_id.py`
- `pytest -q tests/unit/execution/test_correlation_ledger_canonical_order_id.py` (2 passed)
- `pytest -q tests/unit/execution/test_database_security.py` (5 passed)

## Non-goals

- Does not unpark or close #1905 (remains parked).
- No broad execution realism / ARVP calibration implementation.
- Old hold branch `codex/1905-correlation-ledger-canonical-order-id` was **not** merged; logic re-ported onto current `main`.

## Safety Boundaries

- Shadow/Paper path only; no LR/live/echtgeld implication.
- No Docker/runtime/BLUE/RED changes.
- No DB schema or MCP/SurrealDB writes.

## Restunsicherheiten

- No Postgres E2E proof that live paper runs unblock export after deploy.
- Other correlation_ledger writers outside `process_order` not audited in this slice.
