### PR TITLE
docs(lr050):add-runtime-dry-run-evidence-pack

### DIFF
--- a/reports/lr050/runtime_dry_run/2026-06-04/blocker_matrix.md
+++ b/reports/lr050/runtime_dry_run/2026-06-04/blocker_matrix.md
@@ -1,0 +1,26 @@
+# Blocker Matrix
+
+Status vocabulary:
+- `proven`
+- `partial`
+- `blocker_before_live`
+- `not_tested`
+
+| Checkpoint | Status | Evidence | Note |
+| --- | --- | --- | --- |
+| Effective safe flags before execution-path command | proven | `effective_config_redacted.json` | current shell overrides absent; repo defaults stay safe |
+| `MOCK_TRADING=true` default resolves `mock_builtin` | proven | repo reads in `external_adapter_registry.py`, `compose.blue.yml`, `services/execution/config.py` | default adapter selection is repo-backed |
+| `DRY_RUN=true` direct executor branch | proven | `execution_dry_run_evidence.md` | direct `LiveExecutor(dry_run=True)` harness returned `DRY_RUN_*` result with `client_is_none=true` |
+| `TRADING_MODE=staged` is not accepted as dry-run proof | proven | repo reads in `core/config/trading_mode.py`, `services/execution/service.py`, `LR-050-VENUE-AUDIT.md` | active execution path does not wire `TRADING_MODE` |
+| `MEXC_TESTNET=true` is not accepted as non-send proof | proven | `LR-050-DRY-RUN-PROOF.md`, `LR-050-VENUE-AUDIT.md`, `core/clients/mexc.py` | testnet path is still exchange-capable when dry-run/mock are off |
+| Execution-service shadow gate | proven | targeted pytest | `SHADOW_BLOCKED` path exercised in unit set |
+| Execution-service kill-switch gate | proven | targeted pytest | `KILL_SWITCH_BLOCKED` and fail-closed error path exercised |
+| Risk-service kill-switch HTTP endpoints | proven | targeted pytest | activate / deactivate / status all green with repo-local basetemp |
+| Risk-side contract enforcement | proven | targeted pytest | strict contract identity and kill-switch block behavior green |
+| Order-builder full runtime path | partial | `order_builder_dry_run_evidence.md` | adjacent contract and gate logic exercised; full runtime builder path not run |
+| Running BLUE stack effective env with unknown overrides | not_tested | intentionally withheld | no Docker / service boot in `#2951` slice |
+| Venue / testnet / WS endpoint semantics external verification | blocker_before_live | `LR-050-VENUE-AUDIT.md` | repo-only inventory; external semantics unproven |
+| Canary numeric caps and symbols | blocker_before_live | `LR-050-RISK-LIMITS.md`, `LR-050-CANARY-PLAN.md` | remain `TBD_BLOCKER_BEFORE_LIVE` |
+| Receiver proof / operator receipt | blocker_before_live | `LR-050-OBSERVABILITY-GATES.md`, `LR-050-CANARY-PLAN.md` | no runtime receipt artifact on `main` |
+| Exact Human Approval for live capital | blocker_before_live | `LR-050-HUMAN-APPROVAL.md` | still absent |
+| LR global verdict uplift | blocker_before_live | `LR-AUDIT-STATUS-2026-03-05.md`, `LR-050-FINAL-RECONCILE.md` | LR remains `NO-GO` |

--- a/reports/lr050/runtime_dry_run/2026-06-04/command_manifest.md
+++ b/reports/lr050/runtime_dry_run/2026-06-04/command_manifest.md
@@ -1,0 +1,53 @@
+# Command Manifest
+
+Scope: `#2951` only.
+
+No command in this pack was allowed to:
+- place a real order
+- touch a live or testnet venue
+- mutate exchange, broker, account, DB, or MCP state
+- print secret values
+
+## GitHub live reads
+
+| Command / surface | Purpose | Outcome |
+| --- | --- | --- |
+| `git fetch origin --prune` | refresh `origin/main` before branching | success |
+| `gh issue view 2951 --json ...` | confirm issue truth and scope | `#2951 OPEN`; no prior runtime evidence delivered |
+| `gh pr list --state open --json ...` | detect existing PR / lock collision | `[]`; no open PR to continue |
+| `gh issue view 1445 --json ...` | control-first live anchor | confirms `#1445` as cockpit anchor and `NO-GO` posture |
+| `gh issue view 1492 --json ...` | separate Stage from LR | confirms historical stage ratification only; not live-go |
+| `gh issue view 2689 --json ...` | dedupe Gordon cleanup follow-up | `#2689 CLOSED`; active Gordon remnants remain outside `#2951` scope |
+
+## Repo / config inspection
+
+| Command / surface | Purpose | Outcome |
+| --- | --- | --- |
+| `git status -sb` | verify clean start surface | clean branch surface |
+| `git rev-parse HEAD` | anchor repo state | `4d332b0ffe6cb32bd02505c9fff38326d75e4c04` |
+| `git rev-parse origin/main` | anchor live base | `4d332b0ffe6cb32bd02505c9fff38326d75e4c04` |
+| `git worktree list` | verify no extra writer surface | single worktree only |
+| `set DRY_RUN` and peers | inspect current shell overrides | all relevant flags unset |
+| `type services/execution/config.py` | read runtime defaults | `MOCK_TRADING=true`, `DRY_RUN=true`, `MEXC_TESTNET=true` defaults |
+| `rg -n ... services/execution/service.py` | inspect active execution path | `TRADING_MODE` logged only; `_require_live_confirmation()` gates unsafe mainnet tuple |
+| `rg -n ... services/execution/live_executor.py core/clients/mexc.py` | inspect send vs dry-run branch | `dry_run=True` keeps `client=None`; send path calls `place_market_order` / `place_limit_order` only when not dry-run |
+| `rg -n ... core/config/trading_mode.py` | inspect legacy staged map | `STAGED -> MOCK_TRADING=false, DRY_RUN=false, MEXC_TESTNET=true`; not acceptable as dry-run proof on active path |
+| `rg -n ... infrastructure/compose/compose.blue.yml .env.example` | inspect repo defaults | compose default `MOCK_TRADING: "true"`; `.env.example` keeps `MEXC_TESTNET=true`, `MOCK_TRADING=true`, `DRY_RUN=true` |
+
+## Dry-run / guard validation commands
+
+| Command / surface | Purpose | Outcome |
+| --- | --- | --- |
+| `pytest -q tests/...` with default temp | initial targeted validation | 31 passed / 35 environment errors due temp ACL; not a product regression |
+| `pytest -q --basetemp .tmp\\pytest-lr050-runtime-dry-run tests\\unit\\services\\test_execution_shadow_gate.py tests\\unit\\risk\\test_kill_switch_endpoints.py tests\\unit\\risk\\test_contract_enforcement.py tests\\unit\\safety\\test_kill_switch.py` | repo-local deterministic evidence run | `66 passed, 104 warnings, 0 failures` |
+| interactive `python` harness for `LiveExecutor(dry_run=True, testnet=True)` | direct non-send executor proof without stack start | `client_is_none=true`, `order_id=DRY_RUN_lr050-cli-1`, `status=FILLED` simulated |
+
+## Commands intentionally not executed
+
+| Withheld command class | Why withheld |
+| --- | --- |
+| `docker compose up`, service starts, stack restarts | broader than `#2951`, runtime mutation surface too wide |
+| balance / account / auth checks against MEXC | would require real secrets or exchange touch |
+| any `place_*` or `DRY_RUN=false` executor call | violates non-send boundary |
+| receiver proof / Alertmanager delivery drills | separate blocker and separate runtime scope |
+| live or testnet venue probes | `MEXC_TESTNET` is not non-send proof |

--- a/reports/lr050/runtime_dry_run/2026-06-04/effective_config_redacted.json
+++ b/reports/lr050/runtime_dry_run/2026-06-04/effective_config_redacted.json
@@ -1,0 +1,70 @@
+{
+  "scope": "#2951 non-destructive runtime evidence only",
+  "source_order": [
+    "github_live",
+    "repo_live",
+    "runtime_effective_config_evidence",
+    "local_command_output",
+    "canonical_governance_files"
+  ],
+  "shell_env_flags": {
+    "DRY_RUN": "unset",
+    "MOCK_TRADING": "unset",
+    "MEXC_TESTNET": "unset",
+    "CONFIRM_LIVE_TRADING": "unset",
+    "TRADING_MODE": "unset",
+    "EXECUTION_ADAPTER_ID": "unset"
+  },
+  "services_execution_defaults": {
+    "MEXC_BASE_URL": "https://contract.mexc.com",
+    "MEXC_TESTNET": true,
+    "MOCK_TRADING": true,
+    "DRY_RUN": true
+  },
+  "compose_blue_defaults": {
+    "MOCK_TRADING": "true",
+    "USE_REAL_BALANCE": "false",
+    "TRACE_CONTRACT_V1_ENABLED": "1"
+  },
+  "adapter_resolution": {
+    "default_execution_adapter_when_mock_trading_true": "mock_builtin",
+    "default_execution_adapter_when_mock_trading_false": "mexc_builtin",
+    "explicit_execution_adapter_id_in_shell": "unset"
+  },
+  "legacy_trading_mode_reference_only": {
+    "paper": {
+      "MOCK_TRADING": true,
+      "DRY_RUN": true,
+      "MEXC_TESTNET": true
+    },
+    "staged": {
+      "MOCK_TRADING": false,
+      "DRY_RUN": false,
+      "MEXC_TESTNET": true
+    },
+    "live": {
+      "MOCK_TRADING": false,
+      "DRY_RUN": false,
+      "MEXC_TESTNET": false
+    }
+  },
+  "active_execution_path_notes": [
+    "On cdb_execution, TRADING_MODE is logged but not wired to set effective execution flags.",
+    "MEXC_TESTNET alone is not accepted as non-send proof.",
+    "CONFIRM_LIVE_TRADING is a startup gate only when MOCK_TRADING=false, DRY_RUN=false, and MEXC_TESTNET=false."
+  ],
+  "session_non_send_conclusion": {
+    "repo_backed_preconditions_met": true,
+    "basis": [
+      "no shell overrides were set for safe/live flags",
+      "execution config defaults keep DRY_RUN and MOCK_TRADING enabled",
+      "compose.blue default keeps MOCK_TRADING enabled",
+      "direct LiveExecutor dry-run harness instantiated no client and returned DRY_RUN_* result"
+    ]
+  },
+  "redaction": {
+    "secret_values_read": false,
+    "secret_values_printed": false,
+    "safe_flags_only": true
+  }
+}

--- a/reports/lr050/runtime_dry_run/2026-06-04/execution_dry_run_evidence.md
+++ b/reports/lr050/runtime_dry_run/2026-06-04/execution_dry_run_evidence.md
@@ -1,0 +1,60 @@
+# Execution Dry-Run Evidence
+
+## Scope
+
+Dry-run evidence for the execution path only. No Docker start, no service boot, no venue call, no credentials, no secret reads.
+
+## Direct runtime harness
+
+Method:
+- interactive `python` session
+- imported `LiveExecutor`
+- instantiated `LiveExecutor(dry_run=True, testnet=True, api_key=None, api_secret=None)`
+- created a synthetic `Order`
+- called `execute_order(order)`
+
+Observed transcript (trimmed to the relevant lines):
+
+```text
+DRY RUN MODE - Orders will be logged but NOT executed!
+DRY RUN: Would execute BTCUSDT BUY 0.001
+{"dry_run":true,"client_is_none":true,"order_id":"DRY_RUN_lr050-cli-1","status":"FILLED","filled_quantity":0.001,"price":null,"error_message":null}
+```
+
+Interpretation:
+- the executor entered dry-run mode immediately
+- the executor kept `client=None`
+- the synthetic order produced a deterministic `DRY_RUN_*` result
+- no exchange client was needed
+
+## Supporting unit evidence
+
+Command:
+
+```text
+pytest -q --basetemp .tmp\pytest-lr050-runtime-dry-run tests\unit\services\test_execution_shadow_gate.py tests\unit\risk\test_kill_switch_endpoints.py tests\unit\risk\test_contract_enforcement.py tests\unit\safety\test_kill_switch.py
+```
+
+Result:
+
+```text
+66 passed, 104 warnings in 0.87s
+```
+
+Execution-path-relevant coverage inside that set:
+- `tests/unit/services/test_execution_shadow_gate.py`
+  - shadow mode blocks before execution
+  - kill-switch active blocks execution
+  - kill-switch evaluation errors fail closed
+  - unknown execution adapter ids fail closed at init
+
+## What this file does not claim
+
+- no claim about a running BLUE stack
+- no claim about testnet or mainnet endpoint correctness
+- no receiver proof
+- no proof of live auth or account reachability
+
+## Verdict
+
+`proven` for a direct non-destructive executor dry-run branch in this session.

--- a/reports/lr050/runtime_dry_run/2026-06-04/manifest.json
+++ b/reports/lr050/runtime_dry_run/2026-06-04/manifest.json
@@ -1,0 +1,60 @@
+{
+  "issue": 2951,
+  "title": "[LR-050][RUNTIME-DRY-RUN] Produce non-destructive runtime evidence pack",
+  "date": "2026-06-04",
+  "generated_at_local": "04.06.2026 12:42:13,01 Europe/Berlin",
+  "branch": "lr050-runtime-dry-run-evidence-pack",
+  "base_ref": "origin/main",
+  "repo_head_at_capture": "4d332b0ffe6cb32bd02505c9fff38326d75e4c04",
+  "runtime_go_scope": {
+    "issue": 2951,
+    "non_destructive_only": true,
+    "evidence_pack_only": true,
+    "no_live_capital": true,
+    "no_exchange_mutation": true,
+    "source": "prompt_contract runtime_gate"
+  },
+  "brain_source": "repo-only",
+  "brain_status": "not-used",
+  "gordon_gate_used": false,
+  "lr_status": "NO-GO",
+  "overall_verdict": "repo-backed non-destructive evidence pack assembled; live blockers remain open",
+  "artifact_files": [
+    "manifest.json",
+    "command_manifest.md",
+    "effective_config_redacted.json",
+    "non_send_guard_proof.md",
+    "execution_dry_run_evidence.md",
+    "risk_gate_dry_run_evidence.md",
+    "order_builder_dry_run_evidence.md",
+    "redaction_report.md",
+    "blocker_matrix.md",
+    "summary.md"
+  ],
+  "executed_commands_summary": [
+    {
+      "name": "github_live_issue_2951",
+      "result": "OPEN"
+    },
+    {
+      "name": "github_live_open_prs",
+      "result": "none"
+    },
+    {
+      "name": "env_safe_flag_presence",
+      "result": "DRY_RUN, MOCK_TRADING, MEXC_TESTNET, CONFIRM_LIVE_TRADING, TRADING_MODE, EXECUTION_ADAPTER_ID all unset in current shell"
+    },
+    {
+      "name": "pytest_targeted_runtime_guard_set",
+      "result": "66 passed, 104 warnings, 0 failures with repo-local basetemp"
+    },
+    {
+      "name": "interactive_live_executor_dry_run",
+      "result": "dry_run=true, client_is_none=true, order_id=DRY_RUN_lr050-cli-1"
+    }
+  ],
+  "known_environment_limitations": [
+    "PowerShell exec path fails locally with CreateProcessAsUserW failed: 1312; cmd.exe fallback used.",
+    "pytest default temp roots under C:\\Users\\janne\\AppData\\Local\\Temp and D:\\tmp were not writable in this session; repo-local --basetemp succeeded."
+  ]
+}

--- a/reports/lr050/runtime_dry_run/2026-06-04/non_send_guard_proof.md
+++ b/reports/lr050/runtime_dry_run/2026-06-04/non_send_guard_proof.md
@@ -1,0 +1,66 @@
+# Non-Send Guard Proof
+
+## Claim
+
+The commands executed for this evidence pack did not send a real or testnet order, did not mutate exchange or broker state, and did not require secret values.
+
+## Proof chain
+
+1. Current shell flags that could override safe defaults were all unset:
+   - `DRY_RUN`
+   - `MOCK_TRADING`
+   - `MEXC_TESTNET`
+   - `CONFIRM_LIVE_TRADING`
+   - `TRADING_MODE`
+   - `EXECUTION_ADAPTER_ID`
+
+2. Active execution defaults are safe by default:
+   - [`services/execution/config.py`](../../../services/execution/config.py) defaults `MOCK_TRADING=true`
+   - [`services/execution/config.py`](../../../services/execution/config.py) defaults `DRY_RUN=true`
+   - [`services/execution/config.py`](../../../services/execution/config.py) defaults `MEXC_TESTNET=true`
+
+3. The canonical BLUE stack default keeps `MOCK_TRADING` enabled:
+   - [`infrastructure/compose/compose.blue.yml`](../../../infrastructure/compose/compose.blue.yml) sets `MOCK_TRADING: "true"` for `cdb_execution`
+
+4. Default execution adapter resolution is safe when `MOCK_TRADING=true`:
+   - [`core/contracts/external_adapter_registry.py`](../../../core/contracts/external_adapter_registry.py) resolves `mock_builtin`
+
+5. `TRADING_MODE=staged` is explicitly rejected as dry-run proof:
+   - legacy reference only: [`core/config/trading_mode.py`](../../../core/config/trading_mode.py) maps `STAGED` to `MOCK_TRADING=false`, `DRY_RUN=false`, `MEXC_TESTNET=true`
+   - active execution path: [`services/execution/service.py`](../../../services/execution/service.py) only logs `TRADING_MODE`
+
+6. `MEXC_TESTNET=true` is explicitly rejected as non-send proof:
+   - [`docs/live-readiness/LR-050-DRY-RUN-PROOF.md`](../../../docs/live-readiness/LR-050-DRY-RUN-PROOF.md)
+   - [`docs/live-readiness/LR-050-VENUE-AUDIT.md`](../../../docs/live-readiness/LR-050-VENUE-AUDIT.md)
+
+7. Direct executor dry-run harness showed no client construction and no live submission:
+
+```json
+{"dry_run":true,"client_is_none":true,"order_id":"DRY_RUN_lr050-cli-1","status":"FILLED","filled_quantity":0.001,"price":null,"error_message":null}
+```
+
+Interpretation:
+- `dry_run=true` means the executor used the dry-run branch.
+- `client_is_none=true` means no `MexcClient` was instantiated.
+- `order_id` starts with `DRY_RUN_`, matching the dry-run result path.
+- `status=FILLED` here is a simulated dry-run fill, not a venue submission.
+
+8. Direct send functions remain behind the unsafe branch only:
+   - [`services/execution/live_executor.py`](../../../services/execution/live_executor.py) calls `place_market_order` / `place_limit_order` only when `self.dry_run` is false
+   - [`core/clients/mexc.py`](../../../core/clients/mexc.py) owns the real REST post path
+
+## Negative space
+
+The following were intentionally not executed:
+- Docker / compose start
+- `DRY_RUN=false` executor path
+- `MOCK_TRADING=false` plus venue credentials
+- account or balance calls
+- receiver or webhook delivery drills
+- any exchange or broker HTTP / WS mutation path
+
+## Verdict
+
+`proven` for this session's command surface.
+
+This proof is intentionally narrower than a live BLUE runtime proof. It proves the non-send boundary for the commands actually executed here, not for an already running external stack with unknown overrides.

--- a/reports/lr050/runtime_dry_run/2026-06-04/order_builder_dry_run_evidence.md
+++ b/reports/lr050/runtime_dry_run/2026-06-04/order_builder_dry_run_evidence.md
@@ -1,0 +1,45 @@
+# Order Builder Dry-Run Evidence
+
+## Scope decision
+
+A full runtime order-builder drill was not executed in this session.
+
+Reason:
+- a realistic order-builder path would widen the surface into live `RiskManager` state, Redis streams, and additional runtime wiring
+- that would exceed the smallest safe slice for `#2951`
+- the prompt contract explicitly prefers a hard non-send proof before any broader execution-path command
+
+## What was exercised instead
+
+### Adjacent evidence that is repo-backed and executed
+
+1. `tests/unit/risk/test_contract_enforcement.py`
+   - validates decision-contract identity binding
+   - validates hash provenance overwrite
+   - validates risk-side kill-switch fail-closed behavior
+
+2. `tests/unit/services/test_execution_shadow_gate.py`
+   - validates downstream handling of order payloads at execution-service ingress
+   - proves shadow and kill-switch reject behavior before executor use
+
+### Repo-backed code reads
+
+- [`services/risk/service.py`](../../../services/risk/service.py)
+  - `_kill_switch_gate()`
+  - `check_exposure_limit()`
+  - allocation gating via `allocation_pct <= 0`
+  - `emit_bot_shutdown()`
+- [`docs/live-readiness/LR-050-RISK-LIMITS.md`](../../../docs/live-readiness/LR-050-RISK-LIMITS.md)
+  - canary values remain `TBD_BLOCKER_BEFORE_LIVE`
+
+## What remains unproven here
+
+- full `process_signal()` runtime path with real market state inputs
+- order publication to Redis under a controlled dry-run harness
+- end-to-end evidence that a risk-approved order payload reaches execution while still remaining non-destructive
+
+## Conservative verdict
+
+`partial`
+
+This file is intentionally conservative. It records that order-builder-adjacent contract and gate logic were exercised, but the full runtime order-builder path remains a separate live blocker or follow-up slice before any live-capital reconsideration.

--- a/reports/lr050/runtime_dry_run/2026-06-04/redaction_report.md
+++ b/reports/lr050/runtime_dry_run/2026-06-04/redaction_report.md
@@ -1,0 +1,56 @@
+# Redaction Report
+
+## Redaction posture
+
+Only safe, non-secret surfaces were read or printed:
+- boolean / string presence of safe runtime flags
+- repo source code and docs
+- pytest summaries
+- synthetic dry-run harness output for a fake order
+
+## Secret handling
+
+What was not done:
+- no secret file content was printed
+- no API key, token, password, or account identifier was printed
+- no `read_secret(...)` result was emitted
+- no GitHub secret or local secret store mutation was attempted
+- no venue auth or balance call was attempted
+
+## Outputs reviewed for this pack
+
+Reviewed outputs:
+- GitHub live issue / PR JSON
+- `set DRY_RUN`, `set MOCK_TRADING`, `set MEXC_TESTNET`, `set CONFIRM_LIVE_TRADING`, `set TRADING_MODE`, `set EXECUTION_ADAPTER_ID`
+- targeted `pytest` summaries
+- interactive `LiveExecutor(dry_run=True)` harness transcript
+- generated artifact files under this directory
+
+## Expected false positives elsewhere in repo
+
+Repo files legitimately contain literal secret names and gate names such as:
+- `MEXC_API_KEY`
+- `MEXC_API_SECRET`
+- `CONFIRM_LIVE_TRADING`
+- `LIVE_TRADING_CONFIRMED`
+
+Those are names or policy literals, not leaked values.
+
+## Direct findings for this pack
+
+- no secret-like values found in generated artifact text
+- no PEM blocks
+- no token prefixes
+- no raw key material
+- no private account data
+
+## Environment findings
+
+- initial default `pytest` temp roots were not writable in this session
+- switching to repo-local `--basetemp` produced the needed evidence without widening scope
+
+## Verdict
+
+`pass`
+
+Redaction for this evidence pack is acceptable. Residual repo-wide literal secret names remain canonical documentation or code identifiers, not evidence-pack leaks.

--- a/reports/lr050/runtime_dry_run/2026-06-04/risk_gate_dry_run_evidence.md
+++ b/reports/lr050/runtime_dry_run/2026-06-04/risk_gate_dry_run_evidence.md
@@ -1,0 +1,75 @@
+# Risk Gate Dry-Run Evidence
+
+## Executed evidence
+
+Primary command:
+
+```text
+pytest -q --basetemp .tmp\pytest-lr050-runtime-dry-run tests\unit\services\test_execution_shadow_gate.py tests\unit\risk\test_kill_switch_endpoints.py tests\unit\risk\test_contract_enforcement.py tests\unit\safety\test_kill_switch.py
+```
+
+Result:
+
+```text
+66 passed, 104 warnings in 0.87s
+```
+
+Focused kill-switch rerun:
+
+```text
+pytest -q --basetemp .tmp\pytest-lr050-runtime-dry-run tests\unit\risk\test_kill_switch_endpoints.py tests\unit\safety\test_kill_switch.py
+```
+
+Result:
+
+```text
+36 passed, 89 warnings in 0.34s
+```
+
+## What was proven
+
+### 1. Execution-service reject gates
+
+Repo-backed by `tests/unit/services/test_execution_shadow_gate.py`:
+- `run_mode="shadow"` is rejected before executor use
+- execution-service kill-switch blocks orders
+- execution-service kill-switch evaluation errors fail closed
+- bot-shutdown related gate state remains explicit
+
+### 2. Risk-service kill-switch HTTP surface
+
+Repo-backed by `tests/unit/risk/test_kill_switch_endpoints.py`:
+- `GET /kill-switch`
+- `POST /kill-switch/activate`
+- `POST /kill-switch/deactivate`
+- same state-file binding across those endpoints
+
+### 3. Kill-switch persistence core
+
+Repo-backed by `tests/unit/safety/test_kill_switch.py`:
+- persistent state survives restart
+- corrupted state defaults active fail-closed
+- deactivate requires operator and justification
+- log sanitization stays intact
+
+### 4. Risk-side contract / gate hardening
+
+Repo-backed by `tests/unit/risk/test_contract_enforcement.py`:
+- strict order identity binding
+- contract evidence overwrites stale hashes
+- risk-side kill-switch gate blocks signals when active or unevaluable
+
+## Important interpretation boundary
+
+These runs prove gate behavior and fail-closed logic, not a full live runtime:
+- no Redis or Postgres live drill was started
+- no `process_signal -> publish -> execution -> result` stack run was started
+- no receiver / abort routing was exercised
+
+## Environment note
+
+The initial `pytest` run against the default temp root failed with Windows ACL errors outside repo scope. Re-running with repo-local `--basetemp .tmp\pytest-lr050-runtime-dry-run` produced clean green results. This is a local session environment issue, not a product regression in the validated gate logic.
+
+## Verdict
+
+`proven` for targeted risk and kill-switch gate logic in non-destructive local test execution.

--- a/reports/lr050/runtime_dry_run/2026-06-04/summary.md
+++ b/reports/lr050/runtime_dry_run/2026-06-04/summary.md
@@ -1,0 +1,58 @@
+# LR-050 Runtime Dry-Run Evidence Pack
+
+Status: non-destructive evidence pack assembled for `#2951`; LR remains `NO-GO`.
+
+## Scope
+
+- issue: `#2951`
+- runtime-go scope: non-destructive only
+- no real orders
+- no exchange or broker mutation
+- no productive DB writes
+- no secret reads or outputs
+- no Gordon gate used
+
+## Live / control truth
+
+- `#2951` is `OPEN`
+- there was no open PR to continue
+- `#1445` remains the control-first cockpit anchor
+- `#1492` remains historical stage ratification only
+- LR stays `NO-GO`
+
+## Main findings
+
+1. Current shell overrides for the relevant execution flags were all unset.
+2. Repo defaults keep `MOCK_TRADING=true` and `DRY_RUN=true`.
+3. `TRADING_MODE=staged` is not valid dry-run proof on the active execution path.
+4. `MEXC_TESTNET=true` is not valid non-send proof.
+5. A direct `LiveExecutor(dry_run=True)` harness produced a `DRY_RUN_*` result with no client instantiation.
+6. Targeted non-destructive guard tests passed cleanly once `pytest` used a repo-local temp root:
+   - `66 passed, 104 warnings`
+
+## Main blockers that remain open
+
+- venue / endpoint semantics external verification
+- canary numeric caps and symbols
+- full order-builder runtime path
+- receiver proof / operator receipt
+- exact human live-capital approval
+
+## Gordon decommission handling
+
+- No Gordon gate was used.
+- `#2689` already exists and is closed.
+- Active Gordon remnants remain in some non-`#2951` docs and decision records.
+- Those remnants do not block this evidence pack, but they still warrant a narrow deduped follow-up because active docs still mention Gordon for Docker / compose changes.
+
+## Environment limitations encountered
+
+- PowerShell-based local exec was unusable in this session due `CreateProcessAsUserW failed: 1312`.
+- `pytest` default temp roots outside the repo were not writable.
+- Both limitations were worked around without widening runtime scope:
+  - `cmd.exe` fallback
+  - repo-local `--basetemp .tmp\pytest-lr050-runtime-dry-run`
+
+## Conservative conclusion
+
+This pack proves a narrow non-send command surface for `#2951` and upgrades the runtime discussion from docs-only to repo-backed local evidence. It does not clear the live blockers and does not move LR beyond `NO-GO`.


### PR DESCRIPTION
Closes #2951

## Delivered

- added a repo-backed runtime dry-run evidence pack under `reports/lr050/runtime_dry_run/2026-06-04/`
- documented command surface, effective redacted config, non-send proof, execution evidence, risk-gate evidence, blocker matrix, redaction posture, and summary
- kept scope docs/evidence only; no code, compose, or runtime activation changes

## Runtime-GO Scope

- issue: `#2951`
- non-destructive only
- evidence-pack only
- no live capital
- no exchange mutation

## No Gordon gate used

- Gordon stayed decommissioned throughout this slice
- `#2957` was opened as a separate narrow follow-up for active Gordon-gate remnants outside `#2951`

## Non-Send Proof

- current shell had no explicit overrides for `DRY_RUN`, `MOCK_TRADING`, `MEXC_TESTNET`, `CONFIRM_LIVE_TRADING`, `TRADING_MODE`, or `EXECUTION_ADAPTER_ID`
- `services/execution/config.py` defaults keep `MOCK_TRADING=true`, `DRY_RUN=true`, `MEXC_TESTNET=true`
- `compose.blue.yml` keeps `MOCK_TRADING: "true"` by default
- direct `LiveExecutor(dry_run=True)` harness produced `client_is_none=true` and `order_id=DRY_RUN_lr050-cli-1`
- `TRADING_MODE=staged` and `MEXC_TESTNET=true` were explicitly treated as insufficient non-send proof

## Brain Evidence

```text
brain_source: repo-only
brain_status: not-used
tools_or_queries:
  - gh issue/pr reads for #2951, #1445, #1492, #2689
  - repo reads for LR-050 SSOTs and execution/risk code paths
  - targeted pytest and direct dry-run harness
records_or_results:
  - #2951 OPEN; no open PR existed
  - 66 passed targeted tests with repo-local basetemp
  - direct dry-run harness returned DRY_RUN_* result with no client init
repo_crosscheck:
  - services/execution/config.py
  - services/execution/service.py
  - services/execution/live_executor.py
  - core/config/trading_mode.py
  - core/clients/mexc.py
  - services/risk/service.py
impact_on_plan:
  - keep runtime proof narrow and non-destructive
limitations:
  - no running BLUE stack proof
  - no receiver proof
  - no venue semantics verification
```

## Validation

- `git diff --check`
- `pytest -q --basetemp .tmp\pytest-lr050-runtime-dry-run tests\unit\services\test_execution_shadow_gate.py tests\unit\risk\test_kill_switch_endpoints.py tests\unit\risk\test_contract_enforcement.py tests\unit\safety\test_kill_switch.py`
  - result: `66 passed, 104 warnings`
- `rg -n "SECRET|TOKEN|API_KEY|PRIVATE|PASSWORD|BEGIN|MEXC.*KEY|CONFIRM_LIVE_TRADING=yes|LIVE_TRADING_CONFIRMED=yes" reports/lr050/runtime_dry_run/2026-06-04 docs services core`
  - reviewed as name/policy false positives only; no secret values in generated pack

## Safety Boundaries

- LR remains `NO-GO`
- no live-go
- no real-money-go
- no real orders
- no exchange or broker mutation
- no productive DB writes
- no MCP mutations
- no secret values in outputs

## Remaining Blockers

- venue / testnet / WS semantics external verification
- canary numeric caps and symbol set
- full runtime order-builder path
- receiver proof / operator receipt
- exact human live-capital approval

## LR remains NO-GO

This PR upgrades `#2951` from docs-only planning context to repo-backed local evidence, but it does not clear live blockers and does not move LR beyond `NO-GO`.
