### PR TITLE
docs(governance): remove active Gordon gate references

### DIFF
--- a/docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_2886-2892-2909_2026-06-03.md
+++ b/docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_2886-2892-2909_2026-06-03.md
@@ -67,12 +67,12 @@ Filtered Trivy alerts for CVE-2026-34040, CVE-2026-41567, CVE-2026-42306, CVE-20
 
 ---
 
-## Ask-Gordon gate
+## Ask-Gordon gate (historical / decommissioned)
 
 | Item | Status |
 |------|--------|
 | Infra / compose / digest diff in this slice | **None** (docs-only) |
-| Ask-Gordon integration in repo | Not found |
+| Ask-Gordon integration in repo | Not found; historical reference only |
 | Gate outcome | **N/A** — no infra mutation; documented as repo-only triage |
 
 ---

--- a/knowledge/decisions/CDB_CONTEXT_MANAGED_NONLOCAL_RUNTIME_DECISION.md
+++ b/knowledge/decisions/CDB_CONTEXT_MANAGED_NONLOCAL_RUNTIME_DECISION.md
@@ -99,7 +99,7 @@ labels until a future contract extends the factory with inverse allowlist guards
 | G0-6 | Adapter contract extension (**read-only**, non-local allowlist, localhost denylist for productive-read path) | Implementation PR + unit tests |
 | G0-7 | Operator proof pack: read queries succeed; write/admin SQL fail-closed | Session log + redacted proof |
 | G0-8 | LR-SSOT review: managed path docs do not imply LR-Go or Echtgeld | Human review vs `LR-AUDIT-STATUS` |
-| G0-9 | **Gordon gate** before any Docker/BLUE/RED/compose change | Explicit Gordon-GO (forbidden in #2803) |
+| G0-9 | Docker/BLUE/RED/compose change requires explicit Jannek Human-GO (Gordon gate decommissioned) | Explicit Human-GO (forbidden in #2803) |
 
 Gate 0 is **documentation and evidence** in this slice. Satisfying G0-4 through G0-9
 requires **follow-up issues**; none are activated here.
@@ -178,7 +178,7 @@ For this decision slice (#2803), evidence is **repo-only**:
 | **3** | Operator proof | Operator | Redacted session log; read PASS; write/admin FAIL |
 | **4** | Jannek-GO | Human | Per-option enablement (`managed_readonly` vs `nonlocal_readonly_mcp`) |
 | **5** | LR-SSOT review | Human | If docs touch live-readiness narrative |
-| **Gordon** | Infra/runtime | Human | **Only** for Docker/BLUE/RED/compose — **forbidden in #2803** |
+| **Jannek Human-GO** | Infra/runtime | Human | **Only** for Docker/BLUE/RED/compose; Gordon gate decommissioned — **forbidden in #2803** |
 
 Certification (`make context-certify`, #2801) supports readiness evaluation but
 **does not** authorize managed/non-local activation alone.
@@ -216,7 +216,7 @@ at decision time (2026-06-02); consider filing if implementation slice starts.
 | FU-1 | Managed-read-only pilot design (network + adapter allowlist) | `[PHASE-2] managed read-only context pilot design` |
 | FU-2 | Secret policy for managed/non-local postures | `[PHASE-2] context managed runtime secret policy` |
 | FU-3 | Non-local MCP/tunnel verification harness | `[PHASE-2] non-local read-only MCP verification` |
-| FU-4 | Runtime activation / compose (Gordon-GO) | `[PHASE-2] context runtime activation` (infra explicit) |
+| FU-4 | Runtime activation / compose (Jannek Human-GO; Gordon gate decommissioned) | `[PHASE-2] context runtime activation` (infra explicit) |
 
 Issue #2804 remains the **write-strategy design** slice; do not expand #2803 into write
 implementation.
@@ -241,7 +241,7 @@ implementation.
 | Enable `managed_readonly` | **Yes** — per follow-up issue | **Yes** if docs imply operational readiness |
 | Enable `nonlocal_readonly_mcp` | **Yes** — per follow-up issue | **Yes** if exposure changes trust model |
 | Flip persist/mutation defaults | **Yes** — explicit; out of #2803 | **Yes** |
-| Docker/BLUE/RED changes | **Gordon-GO** | No unless LR narrative changes |
+| Docker/BLUE/RED changes | **Jannek Human-GO** | No unless LR narrative changes |
 | Live/Echtgeld trading | **Yes** + LR human gate | **Required** |
 
 ## Safety and LR boundaries

--- a/knowledge/decisions/CDB_CONTEXT_MANAGED_RUNTIME_SECRET_POLICY_GATES_0_4.md
+++ b/knowledge/decisions/CDB_CONTEXT_MANAGED_RUNTIME_SECRET_POLICY_GATES_0_4.md
@@ -216,7 +216,7 @@ issues + evidence + Jannek-GO:
 | G0-6 Adapter contract extension (read-only non-local allowlist) | Implementation PR |
 | G0-7 Operator proof pack (read OK / write fail-closed) | Session log |
 | G0-8 LR-SSOT human review | LR audit files |
-| G0-9 Gordon gate for Docker/compose | Explicit GO |
+| G0-9 Docker/compose change requires explicit Jannek Human-GO (Gordon gate decommissioned) | Explicit GO |
 | Write ladder L0–L4 | #2804 |
 | MCP/tunnel/compose changes | Scoped issues only |
 

--- a/services/execution/EXECUTION_SERVICE_STATUS.md
+++ b/services/execution/EXECUTION_SERVICE_STATUS.md
@@ -2,7 +2,7 @@
 
 > **Historischer Snapshot (orphaned)** — Stand 2025-10-23. Nicht als aktiver
 > Deployment- oder Debug-Status verwenden. Gordon als Deployment-Owner ist
-> **veraltet**; Stack-Ops und Container-Änderungen erfordern Jannek Human-GO.
+> historisch/decommissioned; Stack-Ops und Container-Änderungen erfordern Jannek Human-GO.
 > Aktueller Service-Canon: Repo unter `services/execution/`, Ledger:
 > `CURRENT_STATUS.md`.
 
@@ -127,7 +127,7 @@ CMD ["python", "-u", "service.py"]
 
 **Symptom**: Container startet und crasht sofort  
 **Impact**: 🔴 Kritisch - Service nicht deployed  
-**Status**: 🟡 Container-Debug offen (historisch; kein externer Gordon-Gate)
+**Status**: 🟡 Container-Debug offen (historisch; kein externer Gordon-Gate, nicht operativ)
 
 ### Diagnose-Schritte (historisch — Operator / solo-maintainer)
 


### PR DESCRIPTION
Closes #2957

Delivered
- Active Gordon references removed/decommissioned in the current canon.
- Historical references preserved where appropriate.

Validation
- `git diff --check`
- `rg -n` Gordon/Ask-Gordon scan over active canon surfaces

Safety Boundaries
- Docs-only slice; no runtime, Docker, DB, or MCP mutations.
- LR remains NO-GO.