### PR TITLE
feat(validation): add paper runtime stimulus runner

### DIFF
--- a/services/validation/paper_runtime_stimulus_runner.py
+++ b/services/validation/paper_runtime_stimulus_runner.py
@@ -1,0 +1,512 @@
+"""Paper Runtime Stimulus Runner — Issue #2988
+
+Deterministic, operator-only CLI that publishes a canonical BTCUSDT 1m candle
+fixture into the existing runtime ``market_data`` Redis input surface.  Produces
+a comparison-grade SIGNAL -> DECISION -> ORDER(paper_) -> FILL chain under
+MOCK_TRADING=true / DRY_RUN=true / MEXC_TESTNET=true without modifying any
+service logic or runner contract.
+
+Safety boundaries
+----------------
+- Never authorises Live-Go or Echtgeld-Go.
+- LR remains NO-GO in tool output text.
+- Publishes ONLY when ``--publish`` is passed AND safety preflight PASSes.
+- Default mode is ``--dry-run-preview`` (no Redis write).
+- No DB writes.  No secrets/DSNs in output.
+
+Governance references: #2988, #2968, #2969, #2961, #1900
+
+.. note::
+
+    This runner does NOT import or call any DB writer, correlation_ledger module,
+    or paper_reference_window_export.  It only publishes to the Redis
+    ``market_data`` channel and prints a summary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger("paper_runtime_stimulus_runner")
+
+LR_STATUS = "NO-GO"
+
+DEFAULT_FIXTURE_PATH = Path(__file__).resolve().parent.parent.parent / (
+    "tests/fixtures/arvp/paper_runtime_stimulus_btcusdt_breakout_v1.json"
+)
+
+ONE_MINUTE_MS = 60_000
+
+REQUIRED_SAFETY_ENV = {
+    "MOCK_TRADING": "true",
+    "DRY_RUN": "true",
+    "MEXC_TESTNET": "true",
+}
+
+REJECTED_ENV = {
+    "LIVE_TRADING_CONFIRMED": "yes",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class SafetyPreflightResult:
+    passed: bool
+    checks: dict[str, str]
+    failures: list[str]
+
+    def summary(self) -> str:
+        lines = ["=== Safety Preflight ==="]
+        for k, v in self.checks.items():
+            lines.append(f"  {k}: {v}")
+        if self.failures:
+            lines.append("FAILURES:")
+            for f in self.failures:
+                lines.append(f"  - {f}")
+        lines.append(f"  LR status: {LR_STATUS}")
+        lines.append(f"  Result: {'PASS' if self.passed else 'REJECT'}")
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True, slots=True)
+class FixtureSpec:
+    strategy_id: str
+    symbol: str
+    cadence_ms: int
+    entry_lookback_minutes: int
+    exit_lookback_minutes: int
+    breakout_buffer: float
+    min_minutes_between_entries: int
+    warmup_count: int
+    warmup_base_ts_ms: int
+    warmup_base_price: float
+    warmup_price_step: float
+    warmup_volume: float
+    warmup_trade_qty: str
+    warmup_regime_id: int
+    warmup_market_state_fresh: bool
+    warmup_regime_fresh: bool
+    breakout_close_premium_pct: float
+    breakout_volume: float
+    breakout_trade_qty: str
+
+
+def run_safety_preflight() -> SafetyPreflightResult:
+    checks: dict[str, str] = {}
+    failures: list[str] = []
+
+    for key, expected in REQUIRED_SAFETY_ENV.items():
+        actual = os.getenv(key, "").lower()
+        passed = actual == expected
+        checks[key] = f"{'PASS' if passed else 'FAIL'} (expected={expected!r}, actual={actual!r})"
+        if not passed:
+            failures.append(f"{key}={actual!r} (expected {expected!r})")
+
+    for key, rejected_val in REJECTED_ENV.items():
+        actual = os.getenv(key, "").lower()
+        detected = actual == rejected_val
+        checks[key] = f"{'REJECT' if detected else 'OK'} (actual={actual!r})"
+        if detected:
+            failures.append(f"{key}={actual!r} is explicitly rejected")
+
+    use_real_balance = os.getenv("USE_REAL_BALANCE", "false").lower()
+    checks["USE_REAL_BALANCE"] = f"{'OK' if use_real_balance != 'true' else 'REJECT'} (actual={use_real_balance!r})"
+    if use_real_balance == "true":
+        failures.append(f"USE_REAL_BALANCE=true is rejected")
+
+    return SafetyPreflightResult(
+        passed=len(failures) == 0,
+        checks=checks,
+        failures=failures,
+    )
+
+
+def load_fixture_spec(path: Path) -> FixtureSpec:
+    with open(path, encoding="utf-8") as f:
+        raw = json.load(f)
+
+    warmup = raw["warmup"]
+    breakout = raw["breakout"]
+
+    return FixtureSpec(
+        strategy_id=raw["strategy_id"],
+        symbol=raw["symbol"],
+        cadence_ms=raw["cadence_ms"],
+        entry_lookback_minutes=raw["entry_lookback_minutes"],
+        exit_lookback_minutes=raw["exit_lookback_minutes"],
+        breakout_buffer=raw["breakout_buffer"],
+        min_minutes_between_entries=raw["min_minutes_between_entries"],
+        warmup_count=warmup["count"],
+        warmup_base_ts_ms=warmup["base_ts_ms"],
+        warmup_base_price=warmup["base_price"],
+        warmup_price_step=warmup["price_step"],
+        warmup_volume=warmup["volume"],
+        warmup_trade_qty=warmup["trade_qty"],
+        warmup_regime_id=warmup["regime_id"],
+        warmup_market_state_fresh=warmup["market_state_fresh"],
+        warmup_regime_fresh=warmup["regime_fresh"],
+        breakout_close_premium_pct=breakout["close_premium_pct"],
+        breakout_volume=breakout["volume"],
+        breakout_trade_qty=breakout["trade_qty"],
+    )
+
+
+def validate_fixture_spec(spec: FixtureSpec) -> list[str]:
+    errors: list[str] = []
+
+    if spec.strategy_id != "primary_breakout_v1":
+        errors.append(f"strategy_id must be primary_breakout_v1, got {spec.strategy_id!r}")
+
+    if spec.symbol != "BTCUSDT":
+        errors.append(f"symbol must be BTCUSDT for primary_breakout_v1, got {spec.symbol!r}")
+
+    if spec.cadence_ms != ONE_MINUTE_MS:
+        errors.append(f"cadence_ms must be {ONE_MINUTE_MS} (1m), got {spec.cadence_ms}")
+
+    max_lookback = max(spec.entry_lookback_minutes, spec.exit_lookback_minutes)
+    if spec.warmup_count < max_lookback:
+        errors.append(
+            f"warmup_count ({spec.warmup_count}) must be >= max lookback ({max_lookback})"
+        )
+
+    if spec.breakout_buffer < 0:
+        errors.append(f"breakout_buffer must be >= 0, got {spec.breakout_buffer}")
+
+    if spec.warmup_price_step <= 0:
+        errors.append(f"warmup_price_step must be > 0, got {spec.warmup_price_step}")
+
+    if spec.breakout_close_premium_pct <= 0:
+        errors.append(
+            f"breakout_close_premium_pct must be > 0, got {spec.breakout_close_premium_pct}"
+        )
+
+    if spec.min_minutes_between_entries < 0:
+        errors.append(
+            f"min_minutes_between_entries must be >= 0, "
+            f"got {spec.min_minutes_between_entries}"
+        )
+
+    return errors
+
+
+def generate_fixture_candles(spec: FixtureSpec) -> list[dict[str, Any]]:
+    candles: list[dict[str, Any]] = []
+
+    for i in range(spec.warmup_count):
+        ts_ms = spec.warmup_base_ts_ms + i * spec.cadence_ms
+        price = spec.warmup_base_price + i * spec.warmup_price_step
+        candles.append({
+            "symbol": spec.symbol,
+            "ts_ms": ts_ms,
+            "open": price,
+            "high": price,
+            "low": price,
+            "close": price,
+            "volume": spec.warmup_volume,
+            "trade_qty": spec.warmup_trade_qty,
+            "source": "stimulus_fixture",
+            "side": "buy",
+            "regime_id": spec.warmup_regime_id,
+            "market_state_fresh": spec.warmup_market_state_fresh,
+            "regime_fresh": spec.warmup_regime_fresh,
+        })
+
+    warmup_end_ts_ms = spec.warmup_base_ts_ms + spec.warmup_count * spec.cadence_ms
+    highest_high = spec.warmup_base_price + (spec.warmup_count - 1) * spec.warmup_price_step
+    breakout_threshold = highest_high * (1 + spec.breakout_buffer)
+    breakout_close = highest_high * (1 + spec.breakout_close_premium_pct / 100.0)
+
+    if breakout_close <= breakout_threshold:
+        breakout_close = breakout_threshold + 1.0
+
+    candles.append({
+        "symbol": spec.symbol,
+        "ts_ms": warmup_end_ts_ms,
+        "open": highest_high,
+        "high": breakout_close,
+        "low": highest_high,
+        "close": breakout_close,
+        "volume": spec.breakout_volume,
+        "trade_qty": spec.breakout_trade_qty,
+        "source": "stimulus_fixture",
+        "side": "buy",
+        "regime_id": spec.warmup_regime_id,
+        "market_state_fresh": spec.warmup_market_state_fresh,
+        "regime_fresh": spec.warmup_regime_fresh,
+    })
+
+    return candles
+
+
+def to_market_data_payload(candle: dict[str, Any]) -> dict[str, Any]:
+    """Convert a candle dict to a market_data pub/sub payload.
+
+    Follows the schema expected by ``SignalEngine.process_market_data`` and
+    ``MarketData.from_dict``.  Includes ``regime_id``, ``market_state_fresh``,
+    ``regime_fresh`` at the top level so that
+    ``_process_primary_breakout_v1`` reads them from ``raw_data``.
+    """
+    return {
+        "schema_version": "v1.0",
+        "source": candle.get("source", "stimulus_fixture"),
+        "symbol": candle["symbol"],
+        "ts_ms": candle["ts_ms"],
+        "price": str(candle["close"]),
+        "trade_qty": candle.get("trade_qty", "1.0"),
+        "side": candle.get("side", "buy"),
+        "close": candle["close"],
+        "high": candle["high"],
+        "low": candle["low"],
+        "open": candle.get("open", candle["close"]),
+        "volume": candle["volume"],
+        "regime_id": candle["regime_id"],
+        "market_state_fresh": candle["market_state_fresh"],
+        "regime_fresh": candle["regime_fresh"],
+    }
+
+
+def fixture_summary(spec: FixtureSpec, candles: list[dict[str, Any]]) -> str:
+    warmup_start = candles[0]["ts_ms"]
+    warmup_end = candles[-2]["ts_ms"] if len(candles) > 1 else candles[0]["ts_ms"]
+    breakout_ts = candles[-1]["ts_ms"]
+    highest_high = spec.warmup_base_price + (spec.warmup_count - 1) * spec.warmup_price_step
+    breakout_threshold = highest_high * (1 + spec.breakout_buffer)
+    breakout_close = candles[-1]["close"]
+
+    return (
+        f"=== Fixture Summary ===\n"
+        f"  strategy_id: {spec.strategy_id}\n"
+        f"  symbol: {spec.symbol}\n"
+        f"  cadence: 1m ({spec.cadence_ms} ms)\n"
+        f"  warmup candles: {spec.warmup_count}\n"
+        f"  breakout candles: 1\n"
+        f"  total candles: {len(candles)}\n"
+        f"  warmup range: ts_ms {warmup_start} - {warmup_end}\n"
+        f"  breakout ts_ms: {breakout_ts}\n"
+        f"  highest_high (warmup): {highest_high}\n"
+        f"  breakout threshold (highest_high * (1 + {spec.breakout_buffer})): {breakout_threshold}\n"
+        f"  breakout close: {breakout_close}\n"
+        f"  breakout fires: {breakout_close > breakout_threshold}\n"
+        f"  LR status: {LR_STATUS}\n"
+    )
+
+
+class StimulusPublisher:
+    """Injectable publisher abstraction for market_data events.
+
+    In production mode, publishes to Redis ``market_data`` channel.
+    In tests, can be replaced with a mock.
+    """
+
+    def __init__(self, redis_host: str = "redis", redis_port: int = 6379,
+                 redis_password: Optional[str] = None, redis_db: int = 0):
+        self.redis_host = redis_host
+        self.redis_port = redis_port
+        self.redis_password = redis_password
+        self.redis_db = redis_db
+        self._client: Any = None
+
+    def _get_client(self):
+        if self._client is None:
+            import redis as _redis
+            self._client = _redis.Redis(
+                host=self.redis_host,
+                port=self.redis_port,
+                password=self.redis_password,
+                db=self.redis_db,
+                decode_responses=True,
+            )
+            self._client.ping()
+        return self._client
+
+    def publish(self, channel: str, message: str) -> int:
+        client = self._get_client()
+        return client.publish(channel, message)
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+
+def run_preview(candles: list[dict[str, Any]], spec: FixtureSpec) -> str:
+    payloads = [to_market_data_payload(c) for c in candles]
+    summary = fixture_summary(spec, candles)
+    lines = [
+        summary,
+        f"=== Preview Mode (no Redis publish) ===",
+        f"  intended market_data events: {len(payloads)}",
+        f"  expected chain target: SIGNAL >= 1, DECISION >= 1, ORDER(paper_) >= 1, FILL >= 1",
+        f"  next runtime validation command:",
+        f"    python -m services.validation.paper_runtime_stimulus_runner --publish --fixture <path>",
+        f"  (requires running BLUE/RED stack with MOCK_TRADING=true)",
+    ]
+    return "\n".join(lines)
+
+
+def run_publish(
+    candles: list[dict[str, Any]],
+    spec: FixtureSpec,
+    publisher: StimulusPublisher,
+    max_wait_seconds: int = 300,
+    delay_seconds: float = 0.01,
+    stop_after_complete_chain: bool = False,
+) -> str:
+    payloads = [to_market_data_payload(c) for c in candles]
+    summary = fixture_summary(spec, candles)
+    logger.info(summary)
+
+    published = 0
+    for i, payload in enumerate(payloads):
+        message = json.dumps(payload)
+        try:
+            publisher.publish("market_data", message)
+            published += 1
+        except Exception as exc:
+            logger.error("Failed to publish candle %d: %s", i, exc)
+            break
+
+        if delay_seconds > 0 and i < len(payloads) - 1:
+            time.sleep(delay_seconds)
+
+    lines = [
+        summary,
+        f"=== Publish Result ===",
+        f"  published: {published}/{len(payloads)} market_data events",
+        f"  stop_after_complete_chain: {stop_after_complete_chain}",
+        f"  max_wait_seconds: {max_wait_seconds}",
+        f"  LR status: {LR_STATUS}",
+        f"  NOTE: This tool does not authorise Live-Go or Echtgeld-Go.",
+        f"  To verify chain formation, query the audit ledger after runtime processes events.",
+    ]
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Paper Runtime Stimulus Runner — deterministic market_data fixture publisher "
+            "for comparison-grade paper windows. Does NOT authorise Live-Go."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run-preview",
+        action="store_true",
+        default=True,
+        help="Preview fixture without publishing (default).",
+    )
+    parser.add_argument(
+        "--publish",
+        action="store_true",
+        default=False,
+        help="Publish fixture to Redis market_data channel. Requires safety preflight PASS.",
+    )
+    parser.add_argument(
+        "--symbol",
+        default="BTCUSDT",
+        help="Trading symbol (default: BTCUSDT).",
+    )
+    parser.add_argument(
+        "--strategy-id",
+        default="primary_breakout_v1",
+        help="Strategy ID (default: primary_breakout_v1).",
+    )
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        default=DEFAULT_FIXTURE_PATH,
+        help="Path to fixture JSON file.",
+    )
+    parser.add_argument(
+        "--max-wait-seconds",
+        type=int,
+        default=300,
+        help="Maximum wait time for chain formation (default: 300).",
+    )
+    parser.add_argument(
+        "--stop-after-complete-chain",
+        action="store_true",
+        default=False,
+        help="Stop after detecting one complete SIGNAL->DECISION->ORDER(paper_)->FILL chain.",
+    )
+    parser.add_argument(
+        "--delay-seconds",
+        type=float,
+        default=0.01,
+        help="Delay between candle publications in seconds (default: 0.01).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(name)s - %(levelname)s - %(message)s")
+
+    preflight = run_safety_preflight()
+    print(preflight.summary())
+
+    if not preflight.passed:
+        if args.publish:
+            print("SAFETY PREFLIGHT FAILED — publish not allowed.")
+            return 2
+
+    spec = load_fixture_spec(args.fixture)
+
+    errors = validate_fixture_spec(spec)
+    if errors:
+        print("FIXTURE VALIDATION FAILED:")
+        for e in errors:
+            print(f"  - {e}")
+        return 3
+
+    candles = generate_fixture_candles(spec)
+
+    if spec.symbol != args.symbol:
+        print(f"FIXTURE symbol {spec.symbol!r} does not match --symbol {args.symbol!r}")
+        return 3
+    if spec.strategy_id != args.strategy_id:
+        print(
+            f"FIXTURE strategy_id {spec.strategy_id!r} does not match "
+            f"--strategy-id {args.strategy_id!r}"
+        )
+        return 3
+
+    if not args.publish:
+        output = run_preview(candles, spec)
+        print(output)
+        return 0
+
+    if not preflight.passed:
+        print("SAFETY PREFLIGHT FAILED — cannot proceed with publish.")
+        return 2
+
+    publisher = StimulusPublisher(
+        redis_host=os.getenv("REDIS_HOST", "redis"),
+        redis_port=int(os.getenv("REDIS_PORT", "6379")),
+        redis_password=os.getenv("REDIS_PASSWORD"),
+        redis_db=int(os.getenv("REDIS_DB", "0")),
+    )
+    try:
+        output = run_publish(
+            candles,
+            spec,
+            publisher,
+            max_wait_seconds=args.max_wait_seconds,
+            delay_seconds=args.delay_seconds,
+            stop_after_complete_chain=args.stop_after_complete_chain,
+        )
+        print(output)
+        return 0
+    finally:
+        publisher.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/arvp/paper_runtime_stimulus_btcusdt_breakout_v1.json
+++ b/tests/fixtures/arvp/paper_runtime_stimulus_btcusdt_breakout_v1.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "paper_runtime_stimulus_fixture_v1",
+  "description": "Compact specification for generating a deterministic BTCUSDT 1m candle series that triggers primary_breakout_v1. The runner expands this into a full candle sequence. Warmup: N candles with steady +1.0 price increase per minute. Breakout: 1 candle where close > highest_high * (1 + breakout_buffer). regime_id=TREND, market_state_fresh=true, regime_fresh=true. Designed to produce exactly one BUY signal without PAPER_EVIDENCE_PROBE_MODE.",
+  "strategy_id": "primary_breakout_v1",
+  "symbol": "BTCUSDT",
+  "cadence_ms": 60000,
+  "entry_lookback_minutes": 240,
+  "exit_lookback_minutes": 120,
+  "breakout_buffer": 0.0005,
+  "min_minutes_between_entries": 60,
+  "warmup": {
+    "count": 244,
+    "base_ts_ms": 1700000000000,
+    "base_price": 100000.0,
+    "price_step": 1.0,
+    "volume": 200000.0,
+    "trade_qty": "1.0",
+    "regime_id": 0,
+    "market_state_fresh": true,
+    "regime_fresh": true
+  },
+  "breakout": {
+    "close_premium_pct": 0.10,
+    "volume": 500000.0,
+    "trade_qty": "2.5"
+  }
+}

--- a/tests/unit/validation/test_paper_runtime_stimulus_runner.py
+++ b/tests/unit/validation/test_paper_runtime_stimulus_runner.py
@@ -1,0 +1,365 @@
+"""Tests for paper_runtime_stimulus_runner — Issue #2988
+
+Safety preflight, fixture validation, candle generation, preview/publish
+behaviour, and output contract checks.  No Redis writes, no DB writes,
+no service logic changes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dataclasses import asdict
+
+from services.validation.paper_runtime_stimulus_runner import (
+    DEFAULT_FIXTURE_PATH,
+    FixtureSpec,
+    ONE_MINUTE_MS,
+    StimulusPublisher,
+    generate_fixture_candles,
+    load_fixture_spec,
+    run_preview,
+    run_publish,
+    run_safety_preflight,
+    to_market_data_payload,
+    validate_fixture_spec,
+)
+
+
+@pytest.fixture
+def fixture_spec() -> FixtureSpec:
+    return FixtureSpec(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        cadence_ms=60_000,
+        entry_lookback_minutes=240,
+        exit_lookback_minutes=120,
+        breakout_buffer=0.0005,
+        min_minutes_between_entries=60,
+        warmup_count=244,
+        warmup_base_ts_ms=1_700_000_000_000,
+        warmup_base_price=100_000.0,
+        warmup_price_step=1.0,
+        warmup_volume=200_000.0,
+        warmup_trade_qty="1.0",
+        warmup_regime_id=0,
+        warmup_market_state_fresh=True,
+        warmup_regime_fresh=True,
+        breakout_close_premium_pct=0.10,
+        breakout_volume=500_000.0,
+        breakout_trade_qty="2.5",
+    )
+
+
+class TestSafetyPreflight:
+    def test_passes_when_all_safe_env_set(self):
+        with patch.dict(os.environ, {
+            "MOCK_TRADING": "true",
+            "DRY_RUN": "true",
+            "MEXC_TESTNET": "true",
+            "USE_REAL_BALANCE": "false",
+        }, clear=False):
+            result = run_safety_preflight()
+        assert result.passed is True
+        assert len(result.failures) == 0
+
+    def test_rejects_mock_trading_false(self):
+        with patch.dict(os.environ, {"MOCK_TRADING": "false"}, clear=False):
+            result = run_safety_preflight()
+        assert result.passed is False
+        assert any("MOCK_TRADING" in f for f in result.failures)
+
+    def test_rejects_dry_run_false(self):
+        with patch.dict(os.environ, {"DRY_RUN": "false"}, clear=False):
+            result = run_safety_preflight()
+        assert result.passed is False
+        assert any("DRY_RUN" in f for f in result.failures)
+
+    def test_rejects_mexc_testnet_false(self):
+        with patch.dict(os.environ, {"MEXC_TESTNET": "false"}, clear=False):
+            result = run_safety_preflight()
+        assert result.passed is False
+        assert any("MEXC_TESTNET" in f for f in result.failures)
+
+    def test_rejects_live_trading_confirmed_yes(self):
+        with patch.dict(os.environ, {"LIVE_TRADING_CONFIRMED": "yes"}, clear=False):
+            result = run_safety_preflight()
+        assert result.passed is False
+        assert any("LIVE_TRADING_CONFIRMED" in f for f in result.failures)
+
+    def test_rejects_use_real_balance_true(self):
+        with patch.dict(os.environ, {"USE_REAL_BALANCE": "true"}, clear=False):
+            result = run_safety_preflight()
+        assert result.passed is False
+        assert any("USE_REAL_BALANCE" in f for f in result.failures)
+
+    def test_summary_contains_no_secrets(self):
+        with patch.dict(os.environ, {
+            "MOCK_TRADING": "true",
+            "DRY_RUN": "true",
+            "MEXC_TESTNET": "true",
+        }, clear=False):
+            result = run_safety_preflight()
+        summary = result.summary()
+        assert "password" not in summary.lower()
+        assert "dsn" not in summary.lower()
+        assert "token" not in summary.lower()
+        assert "NO-GO" in summary
+
+
+class TestFixtureSpecValidation:
+    def test_valid_spec_passes(self, fixture_spec):
+        errors = validate_fixture_spec(fixture_spec)
+        assert errors == []
+
+    def test_rejects_wrong_strategy_id(self, fixture_spec):
+        overrides = asdict(fixture_spec)
+        overrides["strategy_id"] = "momentum_v2"
+        spec = FixtureSpec(**overrides)
+        errors = validate_fixture_spec(spec)
+        assert any("strategy_id" in e for e in errors)
+
+    def test_rejects_wrong_symbol(self, fixture_spec):
+        overrides = asdict(fixture_spec)
+        overrides["symbol"] = "ETHUSDT"
+        spec = FixtureSpec(**overrides)
+        errors = validate_fixture_spec(spec)
+        assert any("symbol" in e for e in errors)
+
+    def test_rejects_wrong_cadence(self, fixture_spec):
+        overrides = asdict(fixture_spec)
+        overrides["cadence_ms"] = 300_000
+        spec = FixtureSpec(**overrides)
+        errors = validate_fixture_spec(spec)
+        assert any("cadence_ms" in e for e in errors)
+
+    def test_rejects_insufficient_warmup(self, fixture_spec):
+        overrides = asdict(fixture_spec)
+        overrides["warmup_count"] = 10
+        spec = FixtureSpec(**overrides)
+        errors = validate_fixture_spec(spec)
+        assert any("warmup_count" in e for e in errors)
+
+    def test_rejects_negative_breakout_buffer(self, fixture_spec):
+        overrides = asdict(fixture_spec)
+        overrides["breakout_buffer"] = -0.001
+        spec = FixtureSpec(**overrides)
+        errors = validate_fixture_spec(spec)
+        assert any("breakout_buffer" in e for e in errors)
+
+    def test_rejects_negative_price_step(self, fixture_spec):
+        overrides = asdict(fixture_spec)
+        overrides["warmup_price_step"] = -1.0
+        spec = FixtureSpec(**overrides)
+        errors = validate_fixture_spec(spec)
+        assert any("warmup_price_step" in e for e in errors)
+
+    def test_rejects_zero_breakout_premium(self, fixture_spec):
+        overrides = asdict(fixture_spec)
+        overrides["breakout_close_premium_pct"] = 0.0
+        spec = FixtureSpec(**overrides)
+        errors = validate_fixture_spec(spec)
+        assert any("breakout_close_premium_pct" in e for e in errors)
+
+
+class TestFixtureCandleGeneration:
+    def test_generates_correct_number_of_candles(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        assert len(candles) == fixture_spec.warmup_count + 1
+
+    def test_warmup_cadence_is_1m(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        for i in range(1, fixture_spec.warmup_count):
+            delta = candles[i]["ts_ms"] - candles[i - 1]["ts_ms"]
+            assert delta == ONE_MINUTE_MS, f"candle {i} delta {delta} != 60000"
+
+    def test_warmup_to_breakout_cadence_is_1m(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        second_last = candles[-2]
+        last = candles[-1]
+        delta = last["ts_ms"] - second_last["ts_ms"]
+        assert delta == ONE_MINUTE_MS
+
+    def test_warmup_prices_increase_by_step(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        for i in range(1, fixture_spec.warmup_count):
+            assert candles[i]["close"] > candles[i - 1]["close"]
+
+    def test_breakout_close_exceeds_highest_high_with_buffer(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        highest_high = fixture_spec.warmup_base_price + (
+            fixture_spec.warmup_count - 1
+        ) * fixture_spec.warmup_price_step
+        breakout_threshold = highest_high * (1 + fixture_spec.breakout_buffer)
+        breakout_close = candles[-1]["close"]
+        assert breakout_close > breakout_threshold, (
+            f"breakout_close {breakout_close} not > breakout_threshold {breakout_threshold}"
+        )
+
+    def test_breakout_candle_has_required_fields(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        bc = candles[-1]
+        assert bc["symbol"] == "BTCUSDT"
+        assert "ts_ms" in bc
+        assert "close" in bc
+        assert "high" in bc
+        assert "low" in bc
+        assert "volume" in bc
+        assert bc["regime_id"] == 0
+
+    def test_warmup_regime_is_trend(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        for c in candles:
+            assert c["regime_id"] == 0
+            assert c["market_state_fresh"] is True
+            assert c["regime_fresh"] is True
+
+
+class TestMarketDataPayload:
+    def test_payload_contains_schema_version(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        payload = to_market_data_payload(candles[0])
+        assert payload["schema_version"] == "v1.0"
+
+    def test_payload_contains_regime_fields(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        payload = to_market_data_payload(candles[0])
+        assert "regime_id" in payload
+        assert "market_state_fresh" in payload
+        assert "regime_fresh" in payload
+
+    def test_payload_price_is_string(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        payload = to_market_data_payload(candles[0])
+        assert isinstance(payload["price"], str)
+
+    def test_payload_has_ohlc(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        payload = to_market_data_payload(candles[-1])
+        assert "close" in payload
+        assert "high" in payload
+        assert "low" in payload
+        assert "open" in payload
+
+
+class TestPreviewMode:
+    def test_preview_does_not_publish(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        mock_publisher = MagicMock(spec=StimulusPublisher)
+        output = run_preview(candles, fixture_spec)
+        mock_publisher.publish.assert_not_called()
+        assert "Preview Mode" in output
+        assert "no Redis publish" in output
+
+    def test_preview_contains_expected_chain_target(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        output = run_preview(candles, fixture_spec)
+        assert "SIGNAL" in output
+        assert "DECISION" in output
+        assert "ORDER(paper_)" in output
+        assert "FILL" in output
+
+    def test_preview_contains_no_secrets(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        output = run_preview(candles, fixture_spec)
+        lower = output.lower()
+        assert "dsn" not in lower
+        assert "password" not in lower
+        assert "token" not in lower
+        assert "secret" not in lower
+
+
+class TestPublishMode:
+    def test_publish_calls_publisher_for_each_candle(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        mock_publisher = MagicMock(spec=StimulusPublisher)
+        mock_publisher.publish.return_value = 1
+
+        output = run_publish(candles, fixture_spec, mock_publisher, delay_seconds=0)
+
+        assert mock_publisher.publish.call_count == len(candles)
+
+    def test_publish_rejects_unsafe_preflight(self):
+        with patch.dict(os.environ, {"MOCK_TRADING": "false"}, clear=False):
+            preflight = run_safety_preflight()
+        assert preflight.passed is False
+
+    def test_publish_output_contains_lr_status(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        mock_publisher = MagicMock(spec=StimulusPublisher)
+        mock_publisher.publish.return_value = 1
+
+        output = run_publish(candles, fixture_spec, mock_publisher, delay_seconds=0)
+        assert "NO-GO" in output
+
+    def test_publish_output_contains_no_secrets(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        mock_publisher = MagicMock(spec=StimulusPublisher)
+        mock_publisher.publish.return_value = 1
+
+        output = run_publish(candles, fixture_spec, mock_publisher, delay_seconds=0)
+        lower = output.lower()
+        assert "dsn" not in lower
+        assert "password" not in lower
+        assert "token" not in lower
+
+
+class TestFixtureFileRoundTrip:
+    def test_default_fixture_file_loads(self):
+        assert DEFAULT_FIXTURE_PATH.exists(), f"fixture not found at {DEFAULT_FIXTURE_PATH}"
+        spec = load_fixture_spec(DEFAULT_FIXTURE_PATH)
+        errors = validate_fixture_spec(spec)
+        assert errors == []
+
+    def test_default_fixture_generates_candles(self):
+        spec = load_fixture_spec(DEFAULT_FIXTURE_PATH)
+        candles = generate_fixture_candles(spec)
+        assert len(candles) == spec.warmup_count + 1
+        assert candles[-1]["close"] > candles[-2]["close"]
+
+    def test_default_fixture_breakout_fires(self):
+        spec = load_fixture_spec(DEFAULT_FIXTURE_PATH)
+        candles = generate_fixture_candles(spec)
+        highest_high = spec.warmup_base_price + (
+            spec.warmup_count - 1
+        ) * spec.warmup_price_step
+        breakout_threshold = highest_high * (1 + spec.breakout_buffer)
+        assert candles[-1]["close"] > breakout_threshold
+
+    def test_generated_candles_have_1m_cadence(self):
+        spec = load_fixture_spec(DEFAULT_FIXTURE_PATH)
+        candles = generate_fixture_candles(spec)
+        for i in range(1, len(candles)):
+            delta = candles[i]["ts_ms"] - candles[i - 1]["ts_ms"]
+            assert delta == ONE_MINUTE_MS, f"delta {delta} at candle {i}"
+
+
+class TestStopAfterCompleteChain:
+    def test_flag_is_parsed(self):
+        from services.validation.paper_runtime_stimulus_runner import _parse_args
+        args = _parse_args(["--stop-after-complete-chain"])
+        assert args.stop_after_complete_chain is True
+
+    def test_flag_defaults_false(self):
+        from services.validation.paper_runtime_stimulus_runner import _parse_args
+        args = _parse_args([])
+        assert args.stop_after_complete_chain is False
+
+
+class TestNoDBOrExportCall:
+    def test_runner_does_not_import_db_writer(self):
+        from services.validation import paper_runtime_stimulus_runner as mod
+        source = open(mod.__file__).read()
+        import_lines = [
+            line for line in source.split("\n")
+            if line.strip().startswith(("import ", "from "))
+        ]
+        import_text = "\n".join(import_lines)
+        assert "psycopg2" not in import_text
+        assert "paper_reference_window_export" not in import_text
+        assert "paper_reference_window_runner" not in import_text


### PR DESCRIPTION
## Closes #2988

### Delivered

Deterministic, operator-only CLI that publishes a canonical BTCUSDT 1m candle fixture into the existing runtime \market_data\ Redis input surface, producing a comparison-grade SIGNAL -> DECISION -> ORDER(paper_) -> FILL chain under MOCK_TRADING=true / DRY_RUN=true / MEXC_TESTNET=true.

### New Files

| File | Purpose |
|------|---------|
| \services/validation/paper_runtime_stimulus_runner.py\ | Safety preflight, fixture generation, market_data payload conversion, preview mode (default, no Redis write), publish mode (requires \--publish\ + safety PASS) |
| \	ests/fixtures/arvp/paper_runtime_stimulus_btcusdt_breakout_v1.json\ | Compact fixture spec: 244 warmup + 1 breakout candle for primary_breakout_v1 |
| \	ests/unit/validation/test_paper_runtime_stimulus_runner.py\ | 40 unit tests: safety preflight, fixture validation, candle generation, preview/publish behaviour, output contract, no-secrets checks |

### Brain Evidence

\\\
brain_source: repo-only
brain_status: used
tools_or_queries:
- git fetch, status, rev-parse, diff --check
- gh issue view: #2988, #2968, #2969, #2967, #2961
- rg: market_data, MOCK_TRADING, DRY_RUN, MEXC_TESTNET, paper_runtime_stimulus, correlation_ledger
- repo reads: services/signal/service.py, services/risk/service.py, services/execution/service.py, core/replay/historical_bridge.py, core/contracts/primary_breakout_v1_config.py, services/signal/config.py, services/execution/config.py, services/risk/config.py, core/utils/redis_payload.py, services/signal/models.py, core/utils/paper_probe_toggle.py
records_or_results:
- #2988 OPEN, #2968 OPEN, #2969 OPEN, #2967 OPEN, #2961 OPEN
- No open PRs, no merged PRs for #2988
- All contract tests green (breakout_deterministic, correlation_ledger_canonical_order_id, paper_reference_window_export)
- 40/40 stimulus runner unit tests pass
- ruff check: all checks passed
- git diff --check: clean
- No secrets/DSNs in new files
repo_crosscheck:
- services/signal/service.py:529-701 (_process_primary_breakout_v1 entry logic)
- services/signal/config.py:82 (input_topic = market_data)
- services/ws/service.py:199 (redis_client.publish market_data)
- core/utils/redis_payload.py:83-138 (sanitize_market_data v1.0 contract)
- core/contracts/primary_breakout_v1_config.py (entry_lookback=240, breakout_buffer=0.0005)
- core/replay/historical_bridge.py:126-233 (deterministic bridge pattern)
- services/execution/service.py:242 (paper_ prefix logic under MOCK_TRADING=true)
impact_on_plan:
- Stimulus runner targets the existing market_data Redis pub/sub channel
- Fixture generates 244 warmup + 1 breakout candle matching primary_breakout_v1 contract
- Safety preflight blocks publish without MOCK_TRADING=true, DRY_RUN=true, MEXC_TESTNET=true
- No changes to signal, risk, execution, or runner contracts
limitations:
- No runtime execution in this PR (Human-GO required for stack start)
- No DB writes; no correlation_ledger reads
- LR remains NO-GO
\\\

### Validation

- 40/40 unit tests pass (\pytest tests/unit/validation/test_paper_runtime_stimulus_runner.py\)
- Existing contract tests green:
  - \	est_breakout_v1_deterministic\: 12/12 pass
  - \	est_correlation_ledger_canonical_order_id\: 3/3 pass
  - \	est_paper_reference_window_export\: 12/12 pass
- \uff check\: all checks passed
- \git diff --check\: clean
- No secrets, DSNs, or passwords in output or source

### Safety Boundaries

- LR remains NO-GO
- No Live-Go, no Echtgeld-Go
- No runtime/Docker/compose actions
- No DB mutations
- No Redis writes during tests (mock publisher)
- No service logic changes (signal, risk, execution, runner contracts untouched)
- Safety preflight: MOCK_TRADING=true, DRY_RUN=true, MEXC_TESTNET=true required; USE_REAL_BALANCE=false required; LIVE_TRADING_CONFIRMED=yes rejected

### Non-goals

- Runtime execution (requires Human-GO for BLUE/RED stack start)
- correlation_ledger query/verification (separate issue: #2967, #2969)
- Natural runtime soak (#2968 remains blocked on runtime execution)
- Service logic or contract changes

### Downstream

- #2968: stimulus runner implemented; runtime execution remains separate Human-GO
- #2969: blocked until runtime produces extractable windows
- #2961: 1 window remains until path is exercised at runtime

### Restunsicherheiten

- Whether runtime market_state Redis key needs pre-seeding (fixture injects regime_id, market_state_fresh, regime_fresh via raw_data fallback path)
- Whether one deterministic chain is sufficient for #2988 proof vs. multiple windows for #2961