### PR TITLE
feat(validation): add runtime-relative paper stimulus timestamps

### DIFF
--- a/services/validation/paper_runtime_stimulus_runner.py
+++ b/services/validation/paper_runtime_stimulus_runner.py
@@ -26,6 +26,7 @@ Governance references: #2988, #2968, #2969, #2961, #1900
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import logging
 import os
@@ -44,6 +45,23 @@ DEFAULT_FIXTURE_PATH = Path(__file__).resolve().parent.parent.parent / (
 )
 
 ONE_MINUTE_MS = 60_000
+
+
+def compute_stimulus_run_id(
+    base_ts_ms: int, fixture_path: Path, runtime_relative: bool
+) -> str:
+    """Deterministic, non-secret run identifier for attribution.
+
+    Combines base timestamp, fixture path stem, and mode flag into a short
+    hex hash.  Visible in payloads and summary output for traceability.
+    """
+    raw = f"{base_ts_ms}|{fixture_path.stem}|{runtime_relative}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def align_to_minute(ts_ms: int) -> int:
+    """Round down to the nearest 1-minute boundary."""
+    return (ts_ms // ONE_MINUTE_MS) * ONE_MINUTE_MS
 
 REQUIRED_SAFETY_ENV = {
     "MOCK_TRADING": "true",
@@ -196,13 +214,19 @@ def validate_fixture_spec(spec: FixtureSpec) -> list[str]:
     return errors
 
 
-def generate_fixture_candles(spec: FixtureSpec) -> list[dict[str, Any]]:
+def generate_fixture_candles(
+    spec: FixtureSpec,
+    *,
+    base_ts_ms_override: int | None = None,
+    stimulus_run_id: str | None = None,
+) -> list[dict[str, Any]]:
     candles: list[dict[str, Any]] = []
+    base_ts = base_ts_ms_override if base_ts_ms_override is not None else spec.warmup_base_ts_ms
 
     for i in range(spec.warmup_count):
-        ts_ms = spec.warmup_base_ts_ms + i * spec.cadence_ms
+        ts_ms = base_ts + i * spec.cadence_ms
         price = spec.warmup_base_price + i * spec.warmup_price_step
-        candles.append({
+        candle = {
             "symbol": spec.symbol,
             "ts_ms": ts_ms,
             "open": price,
@@ -216,9 +240,12 @@ def generate_fixture_candles(spec: FixtureSpec) -> list[dict[str, Any]]:
             "regime_id": spec.warmup_regime_id,
             "market_state_fresh": spec.warmup_market_state_fresh,
             "regime_fresh": spec.warmup_regime_fresh,
-        })
+        }
+        if stimulus_run_id is not None:
+            candle["stimulus_run_id"] = stimulus_run_id
+        candles.append(candle)
 
-    warmup_end_ts_ms = spec.warmup_base_ts_ms + spec.warmup_count * spec.cadence_ms
+    warmup_end_ts_ms = base_ts + spec.warmup_count * spec.cadence_ms
     highest_high = spec.warmup_base_price + (spec.warmup_count - 1) * spec.warmup_price_step
     breakout_threshold = highest_high * (1 + spec.breakout_buffer)
     breakout_close = highest_high * (1 + spec.breakout_close_premium_pct / 100.0)
@@ -226,7 +253,7 @@ def generate_fixture_candles(spec: FixtureSpec) -> list[dict[str, Any]]:
     if breakout_close <= breakout_threshold:
         breakout_close = breakout_threshold + 1.0
 
-    candles.append({
+    breakout_candle = {
         "symbol": spec.symbol,
         "ts_ms": warmup_end_ts_ms,
         "open": highest_high,
@@ -240,7 +267,10 @@ def generate_fixture_candles(spec: FixtureSpec) -> list[dict[str, Any]]:
         "regime_id": spec.warmup_regime_id,
         "market_state_fresh": spec.warmup_market_state_fresh,
         "regime_fresh": spec.warmup_regime_fresh,
-    })
+    }
+    if stimulus_run_id is not None:
+        breakout_candle["stimulus_run_id"] = stimulus_run_id
+    candles.append(breakout_candle)
 
     return candles
 
@@ -253,7 +283,7 @@ def to_market_data_payload(candle: dict[str, Any]) -> dict[str, Any]:
     ``regime_fresh`` at the top level so that
     ``_process_primary_breakout_v1`` reads them from ``raw_data``.
     """
-    return {
+    payload = {
         "schema_version": "v1.0",
         "source": candle.get("source", "stimulus_fixture"),
         "symbol": candle["symbol"],
@@ -270,32 +300,47 @@ def to_market_data_payload(candle: dict[str, Any]) -> dict[str, Any]:
         "market_state_fresh": candle["market_state_fresh"],
         "regime_fresh": candle["regime_fresh"],
     }
+    run_id = candle.get("stimulus_run_id")
+    if run_id is not None:
+        payload["stimulus_run_id"] = run_id
+    return payload
 
 
-def fixture_summary(spec: FixtureSpec, candles: list[dict[str, Any]]) -> str:
+def fixture_summary(
+    spec: FixtureSpec,
+    candles: list[dict[str, Any]],
+    *,
+    stimulus_run_id: str | None = None,
+    runtime_relative: bool = False,
+) -> str:
     warmup_start = candles[0]["ts_ms"]
     warmup_end = candles[-2]["ts_ms"] if len(candles) > 1 else candles[0]["ts_ms"]
     breakout_ts = candles[-1]["ts_ms"]
     highest_high = spec.warmup_base_price + (spec.warmup_count - 1) * spec.warmup_price_step
     breakout_threshold = highest_high * (1 + spec.breakout_buffer)
     breakout_close = candles[-1]["close"]
+    mode = "runtime-relative" if runtime_relative else "static-historical"
 
-    return (
-        f"=== Fixture Summary ===\n"
-        f"  strategy_id: {spec.strategy_id}\n"
-        f"  symbol: {spec.symbol}\n"
-        f"  cadence: 1m ({spec.cadence_ms} ms)\n"
-        f"  warmup candles: {spec.warmup_count}\n"
-        f"  breakout candles: 1\n"
-        f"  total candles: {len(candles)}\n"
-        f"  warmup range: ts_ms {warmup_start} - {warmup_end}\n"
-        f"  breakout ts_ms: {breakout_ts}\n"
-        f"  highest_high (warmup): {highest_high}\n"
-        f"  breakout threshold (highest_high * (1 + {spec.breakout_buffer})): {breakout_threshold}\n"
-        f"  breakout close: {breakout_close}\n"
-        f"  breakout fires: {breakout_close > breakout_threshold}\n"
-        f"  LR status: {LR_STATUS}\n"
-    )
+    lines = [
+        f"=== Fixture Summary ===",
+        f"  mode: {mode}",
+        f"  strategy_id: {spec.strategy_id}",
+        f"  symbol: {spec.symbol}",
+        f"  cadence: 1m ({spec.cadence_ms} ms)",
+        f"  warmup candles: {spec.warmup_count}",
+        f"  breakout candles: 1",
+        f"  total candles: {len(candles)}",
+        f"  warmup range: ts_ms {warmup_start} - {warmup_end}",
+        f"  breakout ts_ms: {breakout_ts}",
+        f"  highest_high (warmup): {highest_high}",
+        f"  breakout threshold (highest_high * (1 + {spec.breakout_buffer})): {breakout_threshold}",
+        f"  breakout close: {breakout_close}",
+        f"  breakout fires: {breakout_close > breakout_threshold}",
+        f"  LR status: {LR_STATUS}",
+    ]
+    if stimulus_run_id is not None:
+        lines.append(f"  stimulus_run_id: {stimulus_run_id}")
+    return "\n".join(lines)
 
 
 class StimulusPublisher:
@@ -336,9 +381,17 @@ class StimulusPublisher:
             self._client = None
 
 
-def run_preview(candles: list[dict[str, Any]], spec: FixtureSpec) -> str:
+def run_preview(
+    candles: list[dict[str, Any]],
+    spec: FixtureSpec,
+    *,
+    stimulus_run_id: str | None = None,
+    runtime_relative: bool = False,
+) -> str:
     payloads = [to_market_data_payload(c) for c in candles]
-    summary = fixture_summary(spec, candles)
+    summary = fixture_summary(
+        spec, candles, stimulus_run_id=stimulus_run_id, runtime_relative=runtime_relative
+    )
     lines = [
         summary,
         f"=== Preview Mode (no Redis publish) ===",
@@ -358,9 +411,14 @@ def run_publish(
     max_wait_seconds: int = 300,
     delay_seconds: float = 0.01,
     stop_after_complete_chain: bool = False,
+    *,
+    stimulus_run_id: str | None = None,
+    runtime_relative: bool = False,
 ) -> str:
     payloads = [to_market_data_payload(c) for c in candles]
-    summary = fixture_summary(spec, candles)
+    summary = fixture_summary(
+        spec, candles, stimulus_run_id=stimulus_run_id, runtime_relative=runtime_relative
+    )
     logger.info(summary)
 
     published = 0
@@ -442,6 +500,33 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=0.01,
         help="Delay between candle publications in seconds (default: 0.01).",
     )
+    parser.add_argument(
+        "--runtime-relative",
+        action="store_true",
+        default=False,
+        help=(
+            "Shift fixture timestamps to current wall-clock (or --base-ts-ms) "
+            "aligned to 1m cadence. Preserves candle shape and breakout condition."
+        ),
+    )
+    parser.add_argument(
+        "--base-ts-ms",
+        type=int,
+        default=None,
+        help=(
+            "Explicit base timestamp in ms for --runtime-relative mode. "
+            "Defaults to current wall-clock aligned to 1m boundary."
+        ),
+    )
+    parser.add_argument(
+        "--start-offset-minutes",
+        type=int,
+        default=0,
+        help=(
+            "Shift the runtime-relative base backward by this many minutes "
+            "(default: 0, meaning warmup starts at base_ts_ms)."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -466,7 +551,27 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  - {e}")
         return 3
 
-    candles = generate_fixture_candles(spec)
+    base_ts_ms_override: int | None = None
+    runtime_relative = args.runtime_relative
+    if runtime_relative:
+        if args.base_ts_ms is not None:
+            base_ts_ms_override = align_to_minute(args.base_ts_ms)
+        else:
+            base_ts_ms_override = align_to_minute(int(time.time() * 1000))
+        if args.start_offset_minutes > 0:
+            base_ts_ms_override -= args.start_offset_minutes * ONE_MINUTE_MS
+
+    run_id = compute_stimulus_run_id(
+        base_ts_ms_override if base_ts_ms_override is not None else spec.warmup_base_ts_ms,
+        args.fixture,
+        runtime_relative,
+    )
+
+    candles = generate_fixture_candles(
+        spec,
+        base_ts_ms_override=base_ts_ms_override,
+        stimulus_run_id=run_id,
+    )
 
     if spec.symbol != args.symbol:
         print(f"FIXTURE symbol {spec.symbol!r} does not match --symbol {args.symbol!r}")
@@ -479,7 +584,12 @@ def main(argv: list[str] | None = None) -> int:
         return 3
 
     if not args.publish:
-        output = run_preview(candles, spec)
+        output = run_preview(
+            candles,
+            spec,
+            stimulus_run_id=run_id,
+            runtime_relative=runtime_relative,
+        )
         print(output)
         return 0
 
@@ -501,6 +611,8 @@ def main(argv: list[str] | None = None) -> int:
             max_wait_seconds=args.max_wait_seconds,
             delay_seconds=args.delay_seconds,
             stop_after_complete_chain=args.stop_after_complete_chain,
+            stimulus_run_id=run_id,
+            runtime_relative=runtime_relative,
         )
         print(output)
         return 0

--- a/services/validation/paper_runtime_stimulus_runner.py
+++ b/services/validation/paper_runtime_stimulus_runner.py
@@ -63,6 +63,7 @@ def align_to_minute(ts_ms: int) -> int:
     """Round down to the nearest 1-minute boundary."""
     return (ts_ms // ONE_MINUTE_MS) * ONE_MINUTE_MS
 
+
 REQUIRED_SAFETY_ENV = {
     "MOCK_TRADING": "true",
     "DRY_RUN": "true",
@@ -123,7 +124,9 @@ def run_safety_preflight() -> SafetyPreflightResult:
     for key, expected in REQUIRED_SAFETY_ENV.items():
         actual = os.getenv(key, "").lower()
         passed = actual == expected
-        checks[key] = f"{'PASS' if passed else 'FAIL'} (expected={expected!r}, actual={actual!r})"
+        checks[key] = (
+            f"{'PASS' if passed else 'FAIL'} (expected={expected!r}, actual={actual!r})"
+        )
         if not passed:
             failures.append(f"{key}={actual!r} (expected {expected!r})")
 
@@ -135,7 +138,9 @@ def run_safety_preflight() -> SafetyPreflightResult:
             failures.append(f"{key}={actual!r} is explicitly rejected")
 
     use_real_balance = os.getenv("USE_REAL_BALANCE", "false").lower()
-    checks["USE_REAL_BALANCE"] = f"{'OK' if use_real_balance != 'true' else 'REJECT'} (actual={use_real_balance!r})"
+    checks["USE_REAL_BALANCE"] = (
+        f"{'OK' if use_real_balance != 'true' else 'REJECT'} (actual={use_real_balance!r})"
+    )
     if use_real_balance == "true":
         failures.append(f"USE_REAL_BALANCE=true is rejected")
 
@@ -180,10 +185,14 @@ def validate_fixture_spec(spec: FixtureSpec) -> list[str]:
     errors: list[str] = []
 
     if spec.strategy_id != "primary_breakout_v1":
-        errors.append(f"strategy_id must be primary_breakout_v1, got {spec.strategy_id!r}")
+        errors.append(
+            f"strategy_id must be primary_breakout_v1, got {spec.strategy_id!r}"
+        )
 
     if spec.symbol != "BTCUSDT":
-        errors.append(f"symbol must be BTCUSDT for primary_breakout_v1, got {spec.symbol!r}")
+        errors.append(
+            f"symbol must be BTCUSDT for primary_breakout_v1, got {spec.symbol!r}"
+        )
 
     if spec.cadence_ms != ONE_MINUTE_MS:
         errors.append(f"cadence_ms must be {ONE_MINUTE_MS} (1m), got {spec.cadence_ms}")
@@ -221,7 +230,11 @@ def generate_fixture_candles(
     stimulus_run_id: str | None = None,
 ) -> list[dict[str, Any]]:
     candles: list[dict[str, Any]] = []
-    base_ts = base_ts_ms_override if base_ts_ms_override is not None else spec.warmup_base_ts_ms
+    base_ts = (
+        base_ts_ms_override
+        if base_ts_ms_override is not None
+        else spec.warmup_base_ts_ms
+    )
 
     for i in range(spec.warmup_count):
         ts_ms = base_ts + i * spec.cadence_ms
@@ -246,7 +259,9 @@ def generate_fixture_candles(
         candles.append(candle)
 
     warmup_end_ts_ms = base_ts + spec.warmup_count * spec.cadence_ms
-    highest_high = spec.warmup_base_price + (spec.warmup_count - 1) * spec.warmup_price_step
+    highest_high = (
+        spec.warmup_base_price + (spec.warmup_count - 1) * spec.warmup_price_step
+    )
     breakout_threshold = highest_high * (1 + spec.breakout_buffer)
     breakout_close = highest_high * (1 + spec.breakout_close_premium_pct / 100.0)
 
@@ -316,7 +331,9 @@ def fixture_summary(
     warmup_start = candles[0]["ts_ms"]
     warmup_end = candles[-2]["ts_ms"] if len(candles) > 1 else candles[0]["ts_ms"]
     breakout_ts = candles[-1]["ts_ms"]
-    highest_high = spec.warmup_base_price + (spec.warmup_count - 1) * spec.warmup_price_step
+    highest_high = (
+        spec.warmup_base_price + (spec.warmup_count - 1) * spec.warmup_price_step
+    )
     breakout_threshold = highest_high * (1 + spec.breakout_buffer)
     breakout_close = candles[-1]["close"]
     mode = "runtime-relative" if runtime_relative else "static-historical"
@@ -350,8 +367,13 @@ class StimulusPublisher:
     In tests, can be replaced with a mock.
     """
 
-    def __init__(self, redis_host: str = "redis", redis_port: int = 6379,
-                 redis_password: Optional[str] = None, redis_db: int = 0):
+    def __init__(
+        self,
+        redis_host: str = "redis",
+        redis_port: int = 6379,
+        redis_password: Optional[str] = None,
+        redis_db: int = 0,
+    ):
         self.redis_host = redis_host
         self.redis_port = redis_port
         self.redis_password = redis_password
@@ -361,6 +383,7 @@ class StimulusPublisher:
     def _get_client(self):
         if self._client is None:
             import redis as _redis
+
             self._client = _redis.Redis(
                 host=self.redis_host,
                 port=self.redis_port,
@@ -390,7 +413,10 @@ def run_preview(
 ) -> str:
     payloads = [to_market_data_payload(c) for c in candles]
     summary = fixture_summary(
-        spec, candles, stimulus_run_id=stimulus_run_id, runtime_relative=runtime_relative
+        spec,
+        candles,
+        stimulus_run_id=stimulus_run_id,
+        runtime_relative=runtime_relative,
     )
     lines = [
         summary,
@@ -417,7 +443,10 @@ def run_publish(
 ) -> str:
     payloads = [to_market_data_payload(c) for c in candles]
     summary = fixture_summary(
-        spec, candles, stimulus_run_id=stimulus_run_id, runtime_relative=runtime_relative
+        spec,
+        candles,
+        stimulus_run_id=stimulus_run_id,
+        runtime_relative=runtime_relative,
     )
     logger.info(summary)
 
@@ -532,7 +561,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
-    logging.basicConfig(level=logging.INFO, format="%(name)s - %(levelname)s - %(message)s")
+    logging.basicConfig(
+        level=logging.INFO, format="%(name)s - %(levelname)s - %(message)s"
+    )
 
     preflight = run_safety_preflight()
     print(preflight.summary())
@@ -562,7 +593,11 @@ def main(argv: list[str] | None = None) -> int:
             base_ts_ms_override -= args.start_offset_minutes * ONE_MINUTE_MS
 
     run_id = compute_stimulus_run_id(
-        base_ts_ms_override if base_ts_ms_override is not None else spec.warmup_base_ts_ms,
+        (
+            base_ts_ms_override
+            if base_ts_ms_override is not None
+            else spec.warmup_base_ts_ms
+        ),
         args.fixture,
         runtime_relative,
     )

--- a/tests/unit/validation/test_paper_runtime_stimulus_runner.py
+++ b/tests/unit/validation/test_paper_runtime_stimulus_runner.py
@@ -21,6 +21,9 @@ from services.validation.paper_runtime_stimulus_runner import (
     FixtureSpec,
     ONE_MINUTE_MS,
     StimulusPublisher,
+    align_to_minute,
+    compute_stimulus_run_id,
+    fixture_summary,
     generate_fixture_candles,
     load_fixture_spec,
     run_preview,
@@ -363,3 +366,160 @@ class TestNoDBOrExportCall:
         assert "psycopg2" not in import_text
         assert "paper_reference_window_export" not in import_text
         assert "paper_reference_window_runner" not in import_text
+
+
+class TestRuntimeRelativeMode:
+    def test_default_timestamps_unchanged_without_flag(self, fixture_spec):
+        candles_default = generate_fixture_candles(fixture_spec)
+        assert candles_default[0]["ts_ms"] == fixture_spec.warmup_base_ts_ms
+
+    def test_runtime_relative_shifts_to_supplied_base(self, fixture_spec):
+        custom_base = 1_800_000_000_000
+        candles = generate_fixture_candles(
+            fixture_spec, base_ts_ms_override=custom_base
+        )
+        assert candles[0]["ts_ms"] == custom_base
+
+    def test_runtime_relative_preserves_1m_cadence(self, fixture_spec):
+        custom_base = 1_800_000_000_000
+        candles = generate_fixture_candles(
+            fixture_spec, base_ts_ms_override=custom_base
+        )
+        for i in range(1, len(candles)):
+            delta = candles[i]["ts_ms"] - candles[i - 1]["ts_ms"]
+            assert delta == ONE_MINUTE_MS, f"candle {i} delta {delta} != 60000"
+
+    def test_runtime_relative_preserves_warmup_count(self, fixture_spec):
+        custom_base = 1_800_000_000_000
+        candles = generate_fixture_candles(
+            fixture_spec, base_ts_ms_override=custom_base
+        )
+        assert len(candles) == fixture_spec.warmup_count + 1
+
+    def test_runtime_relative_preserves_breakout_condition(self, fixture_spec):
+        custom_base = 1_800_000_000_000
+        candles = generate_fixture_candles(
+            fixture_spec, base_ts_ms_override=custom_base
+        )
+        highest_high = fixture_spec.warmup_base_price + (
+            fixture_spec.warmup_count - 1
+        ) * fixture_spec.warmup_price_step
+        breakout_threshold = highest_high * (1 + fixture_spec.breakout_buffer)
+        assert candles[-1]["close"] > breakout_threshold
+
+    def test_stimulus_run_id_in_candles_when_supplied(self, fixture_spec):
+        run_id = "abc123def456"
+        candles = generate_fixture_candles(
+            fixture_spec, stimulus_run_id=run_id
+        )
+        for c in candles:
+            assert c["stimulus_run_id"] == run_id
+
+    def test_stimulus_run_id_absent_when_not_supplied(self, fixture_spec):
+        candles = generate_fixture_candles(fixture_spec)
+        for c in candles:
+            assert "stimulus_run_id" not in c
+
+    def test_stimulus_run_id_in_payload(self, fixture_spec):
+        run_id = "abc123def456"
+        candles = generate_fixture_candles(
+            fixture_spec, stimulus_run_id=run_id
+        )
+        payload = to_market_data_payload(candles[0])
+        assert payload["stimulus_run_id"] == run_id
+
+    def test_stimulus_run_id_in_summary(self, fixture_spec):
+        run_id = "abc123def456"
+        candles = generate_fixture_candles(
+            fixture_spec, stimulus_run_id=run_id
+        )
+        summary = fixture_summary(
+            fixture_spec, candles, stimulus_run_id=run_id, runtime_relative=True
+        )
+        assert run_id in summary
+        assert "runtime-relative" in summary
+
+    def test_compute_stimulus_run_id_deterministic(self):
+        r1 = compute_stimulus_run_id(1_700_000_000_000, Path("fixture.json"), False)
+        r2 = compute_stimulus_run_id(1_700_000_000_000, Path("fixture.json"), False)
+        assert r1 == r2
+        assert len(r1) == 16
+
+    def test_compute_stimulus_run_id_differs_by_base(self):
+        r1 = compute_stimulus_run_id(1_700_000_000_000, Path("fixture.json"), False)
+        r2 = compute_stimulus_run_id(1_800_000_000_000, Path("fixture.json"), False)
+        assert r1 != r2
+
+    def test_compute_stimulus_run_id_differs_by_mode(self):
+        r1 = compute_stimulus_run_id(1_700_000_000_000, Path("fixture.json"), False)
+        r2 = compute_stimulus_run_id(1_700_000_000_000, Path("fixture.json"), True)
+        assert r1 != r2
+
+    def test_align_to_minute(self):
+        assert align_to_minute(60_000) == 60_000
+        assert align_to_minute(60_001) == 60_000
+        assert align_to_minute(119_999) == 60_000
+        assert align_to_minute(120_000) == 120_000
+        assert align_to_minute(120_001) == 120_000
+        assert align_to_minute(0) == 0
+
+    def test_preview_with_runtime_relative_shows_mode(self, fixture_spec):
+        run_id = "test_run_id_1234"
+        candles = generate_fixture_candles(
+            fixture_spec, base_ts_ms_override=1_800_000_000_000, stimulus_run_id=run_id
+        )
+        output = run_preview(
+            candles, fixture_spec, stimulus_run_id=run_id, runtime_relative=True
+        )
+        assert "runtime-relative" in output
+        assert run_id in output
+        assert "Preview Mode" in output
+
+    def test_publish_with_runtime_relative_shows_mode(self, fixture_spec):
+        run_id = "test_run_id_5678"
+        candles = generate_fixture_candles(
+            fixture_spec, base_ts_ms_override=1_800_000_000_000, stimulus_run_id=run_id
+        )
+        mock_publisher = MagicMock(spec=StimulusPublisher)
+        mock_publisher.publish.return_value = 1
+        output = run_publish(
+            candles, fixture_spec, mock_publisher, delay_seconds=0,
+            stimulus_run_id=run_id, runtime_relative=True,
+        )
+        assert "runtime-relative" in output
+        assert run_id in output
+        assert "NO-GO" in output
+
+    def test_runtime_relative_flag_parsed(self):
+        from services.validation.paper_runtime_stimulus_runner import _parse_args
+        args = _parse_args(["--runtime-relative"])
+        assert args.runtime_relative is True
+
+    def test_runtime_relative_flag_defaults_false(self):
+        from services.validation.paper_runtime_stimulus_runner import _parse_args
+        args = _parse_args([])
+        assert args.runtime_relative is False
+
+    def test_base_ts_ms_flag_parsed(self):
+        from services.validation.paper_runtime_stimulus_runner import _parse_args
+        args = _parse_args(["--base-ts-ms", "1800000000000"])
+        assert args.base_ts_ms == 1_800_000_000_000
+
+    def test_start_offset_minutes_flag_parsed(self):
+        from services.validation.paper_runtime_stimulus_runner import _parse_args
+        args = _parse_args(["--start-offset-minutes", "5"])
+        assert args.start_offset_minutes == 5
+
+    def test_no_secrets_in_runtime_relative_summary(self, fixture_spec):
+        run_id = "safe_run_id_0000"
+        candles = generate_fixture_candles(
+            fixture_spec, base_ts_ms_override=1_800_000_000_000, stimulus_run_id=run_id
+        )
+        summary = fixture_summary(
+            fixture_spec, candles, stimulus_run_id=run_id, runtime_relative=True
+        )
+        lower = summary.lower()
+        assert "dsn" not in lower
+        assert "password" not in lower
+        assert "token" not in lower
+        assert "secret" not in lower

--- a/tests/unit/validation/test_paper_runtime_stimulus_runner.py
+++ b/tests/unit/validation/test_paper_runtime_stimulus_runner.py
@@ -61,12 +61,16 @@ def fixture_spec() -> FixtureSpec:
 
 class TestSafetyPreflight:
     def test_passes_when_all_safe_env_set(self):
-        with patch.dict(os.environ, {
-            "MOCK_TRADING": "true",
-            "DRY_RUN": "true",
-            "MEXC_TESTNET": "true",
-            "USE_REAL_BALANCE": "false",
-        }, clear=False):
+        with patch.dict(
+            os.environ,
+            {
+                "MOCK_TRADING": "true",
+                "DRY_RUN": "true",
+                "MEXC_TESTNET": "true",
+                "USE_REAL_BALANCE": "false",
+            },
+            clear=False,
+        ):
             result = run_safety_preflight()
         assert result.passed is True
         assert len(result.failures) == 0
@@ -102,11 +106,15 @@ class TestSafetyPreflight:
         assert any("USE_REAL_BALANCE" in f for f in result.failures)
 
     def test_summary_contains_no_secrets(self):
-        with patch.dict(os.environ, {
-            "MOCK_TRADING": "true",
-            "DRY_RUN": "true",
-            "MEXC_TESTNET": "true",
-        }, clear=False):
+        with patch.dict(
+            os.environ,
+            {
+                "MOCK_TRADING": "true",
+                "DRY_RUN": "true",
+                "MEXC_TESTNET": "true",
+            },
+            clear=False,
+        ):
             result = run_safety_preflight()
         summary = result.summary()
         assert "password" not in summary.lower()
@@ -195,14 +203,15 @@ class TestFixtureCandleGeneration:
 
     def test_breakout_close_exceeds_highest_high_with_buffer(self, fixture_spec):
         candles = generate_fixture_candles(fixture_spec)
-        highest_high = fixture_spec.warmup_base_price + (
-            fixture_spec.warmup_count - 1
-        ) * fixture_spec.warmup_price_step
+        highest_high = (
+            fixture_spec.warmup_base_price
+            + (fixture_spec.warmup_count - 1) * fixture_spec.warmup_price_step
+        )
         breakout_threshold = highest_high * (1 + fixture_spec.breakout_buffer)
         breakout_close = candles[-1]["close"]
-        assert breakout_close > breakout_threshold, (
-            f"breakout_close {breakout_close} not > breakout_threshold {breakout_threshold}"
-        )
+        assert (
+            breakout_close > breakout_threshold
+        ), f"breakout_close {breakout_close} not > breakout_threshold {breakout_threshold}"
 
     def test_breakout_candle_has_required_fields(self, fixture_spec):
         candles = generate_fixture_candles(fixture_spec)
@@ -314,7 +323,9 @@ class TestPublishMode:
 
 class TestFixtureFileRoundTrip:
     def test_default_fixture_file_loads(self):
-        assert DEFAULT_FIXTURE_PATH.exists(), f"fixture not found at {DEFAULT_FIXTURE_PATH}"
+        assert (
+            DEFAULT_FIXTURE_PATH.exists()
+        ), f"fixture not found at {DEFAULT_FIXTURE_PATH}"
         spec = load_fixture_spec(DEFAULT_FIXTURE_PATH)
         errors = validate_fixture_spec(spec)
         assert errors == []
@@ -328,9 +339,9 @@ class TestFixtureFileRoundTrip:
     def test_default_fixture_breakout_fires(self):
         spec = load_fixture_spec(DEFAULT_FIXTURE_PATH)
         candles = generate_fixture_candles(spec)
-        highest_high = spec.warmup_base_price + (
-            spec.warmup_count - 1
-        ) * spec.warmup_price_step
+        highest_high = (
+            spec.warmup_base_price + (spec.warmup_count - 1) * spec.warmup_price_step
+        )
         breakout_threshold = highest_high * (1 + spec.breakout_buffer)
         assert candles[-1]["close"] > breakout_threshold
 
@@ -345,11 +356,13 @@ class TestFixtureFileRoundTrip:
 class TestStopAfterCompleteChain:
     def test_flag_is_parsed(self):
         from services.validation.paper_runtime_stimulus_runner import _parse_args
+
         args = _parse_args(["--stop-after-complete-chain"])
         assert args.stop_after_complete_chain is True
 
     def test_flag_defaults_false(self):
         from services.validation.paper_runtime_stimulus_runner import _parse_args
+
         args = _parse_args([])
         assert args.stop_after_complete_chain is False
 
@@ -357,9 +370,11 @@ class TestStopAfterCompleteChain:
 class TestNoDBOrExportCall:
     def test_runner_does_not_import_db_writer(self):
         from services.validation import paper_runtime_stimulus_runner as mod
+
         source = open(mod.__file__).read()
         import_lines = [
-            line for line in source.split("\n")
+            line
+            for line in source.split("\n")
             if line.strip().startswith(("import ", "from "))
         ]
         import_text = "\n".join(import_lines)
@@ -401,17 +416,16 @@ class TestRuntimeRelativeMode:
         candles = generate_fixture_candles(
             fixture_spec, base_ts_ms_override=custom_base
         )
-        highest_high = fixture_spec.warmup_base_price + (
-            fixture_spec.warmup_count - 1
-        ) * fixture_spec.warmup_price_step
+        highest_high = (
+            fixture_spec.warmup_base_price
+            + (fixture_spec.warmup_count - 1) * fixture_spec.warmup_price_step
+        )
         breakout_threshold = highest_high * (1 + fixture_spec.breakout_buffer)
         assert candles[-1]["close"] > breakout_threshold
 
     def test_stimulus_run_id_in_candles_when_supplied(self, fixture_spec):
         run_id = "abc123def456"
-        candles = generate_fixture_candles(
-            fixture_spec, stimulus_run_id=run_id
-        )
+        candles = generate_fixture_candles(fixture_spec, stimulus_run_id=run_id)
         for c in candles:
             assert c["stimulus_run_id"] == run_id
 
@@ -422,17 +436,13 @@ class TestRuntimeRelativeMode:
 
     def test_stimulus_run_id_in_payload(self, fixture_spec):
         run_id = "abc123def456"
-        candles = generate_fixture_candles(
-            fixture_spec, stimulus_run_id=run_id
-        )
+        candles = generate_fixture_candles(fixture_spec, stimulus_run_id=run_id)
         payload = to_market_data_payload(candles[0])
         assert payload["stimulus_run_id"] == run_id
 
     def test_stimulus_run_id_in_summary(self, fixture_spec):
         run_id = "abc123def456"
-        candles = generate_fixture_candles(
-            fixture_spec, stimulus_run_id=run_id
-        )
+        candles = generate_fixture_candles(fixture_spec, stimulus_run_id=run_id)
         summary = fixture_summary(
             fixture_spec, candles, stimulus_run_id=run_id, runtime_relative=True
         )
@@ -483,8 +493,12 @@ class TestRuntimeRelativeMode:
         mock_publisher = MagicMock(spec=StimulusPublisher)
         mock_publisher.publish.return_value = 1
         output = run_publish(
-            candles, fixture_spec, mock_publisher, delay_seconds=0,
-            stimulus_run_id=run_id, runtime_relative=True,
+            candles,
+            fixture_spec,
+            mock_publisher,
+            delay_seconds=0,
+            stimulus_run_id=run_id,
+            runtime_relative=True,
         )
         assert "runtime-relative" in output
         assert run_id in output
@@ -492,21 +506,25 @@ class TestRuntimeRelativeMode:
 
     def test_runtime_relative_flag_parsed(self):
         from services.validation.paper_runtime_stimulus_runner import _parse_args
+
         args = _parse_args(["--runtime-relative"])
         assert args.runtime_relative is True
 
     def test_runtime_relative_flag_defaults_false(self):
         from services.validation.paper_runtime_stimulus_runner import _parse_args
+
         args = _parse_args([])
         assert args.runtime_relative is False
 
     def test_base_ts_ms_flag_parsed(self):
         from services.validation.paper_runtime_stimulus_runner import _parse_args
+
         args = _parse_args(["--base-ts-ms", "1800000000000"])
         assert args.base_ts_ms == 1_800_000_000_000
 
     def test_start_offset_minutes_flag_parsed(self):
         from services.validation.paper_runtime_stimulus_runner import _parse_args
+
         args = _parse_args(["--start-offset-minutes", "5"])
         assert args.start_offset_minutes == 5
 


### PR DESCRIPTION
## Closes #2991

### Refs #2968, #2988, #2969, #2961

### Delivered

Add \--runtime-relative\ mode to \paper_runtime_stimulus_runner.py\ that shifts fixture timestamps to current wall-clock (or explicit \--base-ts-ms\) aligned to 1m cadence. This addresses the \HOLD_STIMULUS_NO_CHAIN\ finding from #2968 where static historical timestamps (\ase_ts_ms=1700000000000\) did not form a fixture-attributable chain on the running signal service.

### Changes

| File | Change |
|------|--------|
| \services/validation/paper_runtime_stimulus_runner.py\ | Add \--runtime-relative\, \--base-ts-ms\, \--start-offset-minutes\ flags; \compute_stimulus_run_id()\; \lign_to_minute()\; \stimulus_run_id\ in payloads/summary |
| \	ests/unit/validation/test_paper_runtime_stimulus_runner.py\ | 20 new unit tests (60 total) |

### Brain Evidence

\\\
brain_source: repo-only
brain_status: used
tools_or_queries:
- git fetch, status, rev-parse, diff --check
- gh issue view: #2968, #2988, #2969, #2961
- gh issue create: #2991
- rg: runtime-relative, stimulus, HOLD_STIMULUS_NO_CHAIN
- repo reads: paper_runtime_stimulus_runner.py, test_paper_runtime_stimulus_runner.py, signal/service.py
records_or_results:
- #2991 created (follow-up for runtime-relative timestamps)
- #2988 CLOSED via PR #2989
- 60/60 stimulus runner tests pass
- 27/27 contract regression tests pass
- ruff: all checks passed
repo_crosscheck:
- services/signal/service.py:529-701 (warmup/cooldown uses ts_ms directly)
- services/validation/paper_runtime_stimulus_runner.py (new flags + functions)
impact_on_plan:
- Runtime-relative mode allows fixture to integrate with running signal service
- No service logic changes
limitations:
- No runtime execution in this PR
- LR remains NO-GO
\\\

### Validation

- 60/60 unit tests pass (\pytest tests/unit/validation/test_paper_runtime_stimulus_runner.py\)
- Contract regression tests green:
  - \	est_breakout_v1_deterministic\: 12/12
  - \	est_correlation_ledger_canonical_order_id\: 3/3
  - \	est_paper_reference_window_export\: 12/12
- \uff check\: all checks passed
- \git diff --check\: clean

### Safety Boundaries

- LR remains NO-GO
- No Live-Go, no Echtgeld-Go
- No runtime/Docker/compose actions
- No DB mutations
- No Redis writes during tests (mock publisher)
- No service logic changes (signal, risk, execution, runner contracts untouched)
- Safety preflight unchanged: MOCK_TRADING=true, DRY_RUN=true, MEXC_TESTNET=true required for publish

### Runtime not executed

This PR does not execute the stimulus against a running stack. Runtime validation with \--runtime-relative --publish\ remains a separate Human-GO action.

### Restunsicherheiten

- Whether runtime-relative timestamps alone are sufficient for chain formation (market_state freshness, regime state, and cooldown tracking may still need investigation at runtime)
- Whether the signal service's in-memory price buffer interacts correctly with the fixture's price progression when timestamps are current