### PR TITLE
docs(readme): add recommended navigation READMEs (services, runbooks, surrealdb, MCP)

### DIFF
--- a/.cursor/skills/README.md
+++ b/.cursor/skills/README.md
@@ -1,0 +1,50 @@
+# Cursor Skills (`/.cursor/skills/`)
+
+Repo-versionierte Session-Skills für Cursor Agents. Jeder Skill lebt in `<name>/SKILL.md`.
+
+## Session boundary (Pflicht)
+
+| Skill | Wann |
+|---|---|
+| [`cdb-session-start`](cdb-session-start/SKILL.md) | Vor Repo-/GitHub-/Implementierungsarbeit |
+| [`cdb-session-close`](cdb-session-close/SKILL.md) | Nach Implementierung/Validierung, vor Abschluss |
+
+## Control / planning
+
+| Skill | Zweck |
+|---|---|
+| [`cdb-control-intake`](cdb-control-intake/SKILL.md) | Control context (Register, LR, status) |
+| [`cdb-issue-to-session-plan`](cdb-issue-to-session-plan/SKILL.md) | Issue → Session-Plan |
+| [`cdb-operator`](cdb-operator/SKILL.md) | Bootloader, GO gates |
+
+## Domain
+
+| Skill | Zweck |
+|---|---|
+| [`cdb-trading-core`](cdb-trading-core/SKILL.md) | Trading core |
+| [`cdb-risk-governance`](cdb-risk-governance/SKILL.md) | Risk governance |
+| [`cdb-exchange-adapters`](cdb-exchange-adapters/SKILL.md) | Exchange adapters |
+| [`cdb-backtest-engine`](cdb-backtest-engine/SKILL.md) | Backtest |
+| [`cdb-shadow-validation`](cdb-shadow-validation/SKILL.md) | Shadow validation |
+| [`cdb-contract-evidence-gatekeeper`](cdb-contract-evidence-gatekeeper/SKILL.md) | Contract evidence |
+| [`cdb-drift-reconcile`](cdb-drift-reconcile/SKILL.md) | Drift reconcile |
+| [`cdb-docs-ops`](cdb-docs-ops/SKILL.md) | Docs maintenance |
+| [`ctb-docker-stack`](ctb-docker-stack/SKILL.md) | Docker BLUE+RED |
+
+## GitHub helpers
+
+| Skill | Zweck |
+|---|---|
+| [`gh-fix-ci`](gh-fix-ci/SKILL.md) | CI failures |
+| [`gh-address-comments`](gh-address-comments/SKILL.md) | PR review comments |
+
+## Related surfaces
+
+- Codex: `.codex/cdb_skills/` (gleiche Skill-Namen, wo migriert)
+- OpenCode: `.opencode/skills/`
+- Subagents (delegation only): `.cursor/agents/README_CDB_CURSOR_SUBAGENTS.md`
+- Registry: `agents/AGENTS.md`
+
+## Rule
+
+Skills strukturieren Arbeit; sie ersetzen keine Human-GO, LR-SSOT oder Write-Gates in `knowledge/governance/CDB_AGENT_POLICY.md`.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,65 @@
+# Operative Runbooks (`docs/runbooks/`)
+
+Index für operator- und agent-nahe Runbooks im Working Repo. **Kein** Live-Readiness-SSOT.
+
+## Cockpit (zuerst lesen)
+
+| Dokument | Zweck |
+|---|---|
+| [`CONTROL_REGISTER.md`](CONTROL_REGISTER.md) | Board-Stage, Workflow-Notizen, operativer Fokus |
+| [`control-cockpit/CONTROL_COCKPIT_1445_REBASELINE_2026-05-13.md`](control-cockpit/CONTROL_COCKPIT_1445_REBASELINE_2026-05-13.md) | Cockpit #1445 Rebaseline |
+| GitHub Issue **#1445** | Operatives Cockpit (Live-Wahrheit: neuester Kommentar) |
+| [`../live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../live-readiness/LR-AUDIT-STATUS-2026-03-05.md) | Echtgeld Go/No-Go (**NO-GO**) |
+
+Stage `trade-capable` autorisiert kein Live-Trading.
+
+## Control / GitHub / CI
+
+| Runbook | Thema |
+|---|---|
+| [`GITHUB_CONTROL_PLANE_RUNBOOK.md`](GITHUB_CONTROL_PLANE_RUNBOOK.md) | Control-plane Betrieb |
+| [`GITHUB_CONTROL_PLANE_GRAPH.md`](GITHUB_CONTROL_PLANE_GRAPH.md) | Workflow-Graph |
+| [`GITHUB_WORKFLOW_REGISTER.md`](GITHUB_WORKFLOW_REGISTER.md) | Workflow-Register |
+| [`merge_policy_ci_gate.md`](merge_policy_ci_gate.md) | PR-Gates, required checks |
+| [`merge_strategy_squash_vs_merge.md`](merge_strategy_squash_vs_merge.md) | Merge-Strategie |
+| [`ci_hygiene_drift_checks.md`](ci_hygiene_drift_checks.md) | CI-Drift |
+| [`resolve_review_threads_via_graphql.md`](resolve_review_threads_via_graphql.md) | Review-Threads |
+| [`project_board_automation.md`](project_board_automation.md) | Project v2 / Board |
+| [`control_board_board_as_code.md`](control_board_board_as_code.md) | Board-as-Code |
+
+## CDB Automation (Issue #1445-Nachzug)
+
+| Runbook | Thema |
+|---|---|
+| [`CDB_WEEKLY_CONTROL_HYGIENE_CLASSIFIER.md`](CDB_WEEKLY_CONTROL_HYGIENE_CLASSIFIER.md) | Weekly hygiene |
+| [`CDB_DAILY_DELTA_TRIAGE.md`](CDB_DAILY_DELTA_TRIAGE.md) | Daily delta |
+| [`CDB_POST_MERGE_FOLLOWUP_SCANNER.md`](CDB_POST_MERGE_FOLLOWUP_SCANNER.md) | Post-merge scan |
+| [`CDB_BACKLOG_ANOMALY_ESCALATION.md`](CDB_BACKLOG_ANOMALY_ESCALATION.md) | Backlog escalation |
+| [`CDB_CONTROL_FOLLOWUP_CLASSIFIER.md`](CDB_CONTROL_FOLLOWUP_CLASSIFIER.md) | HITL classifier |
+| [`CDB_AGENT_SENSES_OPERATOR.md`](CDB_AGENT_SENSES_OPERATOR.md) | Context/MCP operator senses |
+
+## Daten / Infra / Secrets
+
+| Runbook | Thema |
+|---|---|
+| [`SURREALDB_LOCAL_CONTEXT_RUNTIME.md`](SURREALDB_LOCAL_CONTEXT_RUNTIME.md) | Lokaler Context-Runtime |
+| [`surrealdb_context_mcp_access.md`](surrealdb_context_mcp_access.md) | MCP capability matrix |
+| [`surrealdb_context_import.md`](surrealdb_context_import.md) | Context import |
+| [`surrealdb_context_query.md`](surrealdb_context_query.md) | Context query |
+| [`surrealdb_append_only_enforcement.md`](surrealdb_append_only_enforcement.md) | Append-only |
+| [`postgres_least_privilege_rls.md`](postgres_least_privilege_rls.md) | Postgres RLS |
+| [`redis_aof_corruption_recovery.md`](redis_aof_corruption_recovery.md) | Redis AOF recovery |
+| [`cdb_secrets_ssot.md`](cdb_secrets_ssot.md) | Secrets SSOT |
+| [`BACKUP_AUTOMATION.md`](BACKUP_AUTOMATION.md) | Backup automation |
+| [`local_ops_artifacts.md`](local_ops_artifacts.md) | Lokale Ops-Artefakte |
+| [`mcp_worktree_hygiene.md`](mcp_worktree_hygiene.md) | Worktree hygiene |
+
+## Evidence
+
+- [`evidence/`](evidence/) — Run-scoped Evidence (z. B. SurrealDB restore drill); kein Status-SSOT.
+
+## Related
+
+- [`../index.md`](../index.md) — Docs-Hub
+- [`../../knowledge/runbooks/`](../../knowledge/runbooks/) — Knowledge-Runbooks (operating rules)
+- [`../../.github/README.md`](../../.github/README.md) — Control plane entry

--- a/docs/surrealdb/README.md
+++ b/docs/surrealdb/README.md
@@ -1,0 +1,46 @@
+# SurrealDB / Context Intelligence Docs
+
+Dokumentation für Context Brain, MCP-Tools, Memory-Gates und SurrealDB-Mirror — **read-only / gate-bound** auf `main`.
+
+## Operator entry (read first)
+
+| Doc | Zweck |
+|---|---|
+| [`../runbooks/surrealdb_context_mcp_access.md`](../runbooks/surrealdb_context_mcp_access.md) | MCP capability resolution, tool matrix |
+| [`../runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md`](../runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md) | Lokaler Runtime-Pfad |
+| [`db-runtime-ci-proof-path-v1.md`](db-runtime-ci-proof-path-v1.md) | CI proof matrix |
+| [`../evidence/context_tooling/README.md`](../evidence/context_tooling/README.md) | Benchmark #2 evidence index |
+
+## Grandparent / Phase-2 closeout (#1976)
+
+| Doc | Zweck |
+|---|---|
+| [`SURREALDB_1976_GRANDPARENT_DOD_AND_REAL_TASK_PROOF.md`](SURREALDB_1976_GRANDPARENT_DOD_AND_REAL_TASK_PROOF.md) | DoD + RTP SSOT |
+| [`SURREALDB_1976_WAVE_MATRIX_RECERTIFICATION_2026-06-03.md`](SURREALDB_1976_WAVE_MATRIX_RECERTIFICATION_2026-06-03.md) | Wave recert |
+| [`SURREALDB_PHASE2_FINAL_CLOSEOUT_REVIEW.md`](SURREALDB_PHASE2_FINAL_CLOSEOUT_REVIEW.md) | Phase-2 closeout |
+| [`SURREALDB_PRE_PHASE2_DOCS_CANON_AUDIT.md`](SURREALDB_PRE_PHASE2_DOCS_CANON_AUDIT.md) | Pre-Phase-2 audit |
+
+## Core contracts (Auswahl)
+
+- [`context-mcp-bridge-contract.md`](context-mcp-bridge-contract.md)
+- [`context-package-model-v2.md`](context-package-model-v2.md)
+- [`memory-write-gate-v1.md`](memory-write-gate-v1.md)
+- [`productive-memory-audit-trail-v1.md`](productive-memory-audit-trail-v1.md)
+- [`scoped-agent-memory-model-v1.md`](scoped-agent-memory-model-v1.md)
+
+## Wave completion gates
+
+Wellen-Dokumente: `context-wave7-completion-gates.md` … `context-wave21-completion-gates.md`, `wave16-completion-gates.md` — jeweils Wellen-Abschlusskriterien.
+
+## Code / infra pointers
+
+- MCP server: `tools/mcp/server.py` — `python -m tools.mcp.server`
+- Tooling: `tools/surrealdb/`
+- Schema bootstrap: `infrastructure/surrealdb/setup.surql`
+- Mirror overview: `infrastructure/surrealdb/README.md`
+
+## SSOT boundary
+
+- Produktive Writes / managed runtime: **NOT ACTIVATED** ohne expliziten Human-GO.
+- LR **NO-GO** — `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- Repo/engineering ledger: `CURRENT_STATUS.md`

--- a/mcp_navpack_working_repo/README.md
+++ b/mcp_navpack_working_repo/README.md
@@ -1,0 +1,28 @@
+# MCP Navpack (Working Repo)
+
+Kompakte Navigations- und Evidence-Hilfe für Agents/MCP — ergänzt, ersetzt nicht `README.md` oder `agents/AGENTS.md`.
+
+## Files
+
+| File | Zweck |
+|---|---|
+| [`ENTRYPOINTS.yaml`](ENTRYPOINTS.yaml) | Maschinenlesbare Read-Order (15 Steps) |
+| [`CHEATSHEET.md`](CHEATSHEET.md) | Menschliche Kurzreferenz, Top-Commands |
+| [`REPO.map.json`](REPO.map.json) | Repo-Map / discovery hints |
+
+## Recommended read order (summary)
+
+1. `README.md` — Projekt-Front-Door, LR NO-GO framing  
+2. `docs/index.md` — kurzer Docs-Index  
+3. `DEVELOPER_ONBOARDING.md` — lokales Setup  
+4. `Makefile` + `.github/workflows/ci.yml` — Test/Lint-Gates  
+5. `infrastructure/compose/README.md` — BLUE+RED  
+6. MCP: `claire-de-binare.mcp.json`, `tools/validate_mcp_config.py`  
+7. Safety: `core/config/trading_mode.py`  
+8. `services/README.md`, `tests/README.md`, `agents/AGENTS.md`
+
+## SSOT boundary
+
+- Live GitHub > Repo files > Ledger (`CURRENT_STATUS.md`).
+- Board stage `trade-capable` ≠ Live-Go.
+- Navpack listet Pfade; Verdikt steht in kanonischen SSOT-Dateien.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,53 @@
+# Repo Scripts (`scripts/`)
+
+Automation, Guards und Evidence-Helfer auf Repo-Root-Ebene. Für Stack/Backup/Secrets siehe `infrastructure/scripts/` und `tools/`.
+
+## Governance / LR guards
+
+| Script | Zweck |
+|---|---|
+| `lr003_contract_drift_guard.py` | Contract drift |
+| `lr004_completion_guard.py` | LR completion guard |
+| `dual_write_evidence_gate.py` | Dual-write evidence |
+| `validate_write_zones.sh` | Write-zone validation |
+| `pre_close_sweep.sh` | Pre-close untracked sweep |
+
+## Smoke / validation
+
+| Script | Zweck |
+|---|---|
+| `smoke_core_flow.py` | Core flow smoke (allocation → signal path) |
+| `validate_paper_market_data_provenance.py` | Paper market_data provenance |
+| `smart_health_check.py` | Health aggregation |
+| `smart_startup.py` | Startup helper |
+
+## Ops / reporting
+
+| Script | Zweck |
+|---|---|
+| `lr_reporter.py` | LR reporting helper |
+| `lr020_tier2_evidence_capture.py` | Tier-2 evidence |
+| `run_72h_test.py` | Long-run test driver |
+| `generate_test_report.py` | Test reports |
+| `check_core_duplicates.py` | Duplicate detection |
+
+## GitHub / project (PowerShell)
+
+| Script | Zweck |
+|---|---|
+| `setup_testnet.ps1` | Testnet setup |
+| `manage_secrets.ps1` | Secrets compat (prefer `infrastructure/scripts/manage_secrets.ps1`) |
+| `bulk-issue-labeling.ps1` | Issue labeling |
+| `milestone-assignment.ps1` | Milestones |
+
+## Related (canonical paths)
+
+| Pfad | Zweck |
+|---|---|
+| [`infrastructure/scripts/`](../infrastructure/scripts/) | `setup_blue_red.ps1`, `smoke_test.ps1`, backup/DR |
+| [`tools/`](../tools/README.md) | `cdb.ps1`, MCP validate, secrets rotator |
+| [`.github/scripts/`](../.github/scripts/) | Workflow-backed Python |
+
+## Boundary
+
+Scripts hier ersetzen keine Live-Readiness-Freigabe. LR **NO-GO** — `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`.

--- a/services/README.md
+++ b/services/README.md
@@ -8,18 +8,19 @@ Stateless runtime services for the BLUE+RED stack. Persistent state lives in Pos
 
 ## Service index
 
-| Service | Stack | Notes |
+| Service | Stack | README |
 |---|---|---|
-| [allocation/](allocation/) | BLUE | Regime → allocation_pct |
-| [candles/](candles/) | BLUE | 1m candle aggregation |
-| [db_writer/](db_writer/) | BLUE | Redis streams → Postgres |
-| [execution/](execution/) | BLUE | Order submission (`MOCK_TRADING` default) |
-| [market/](market/) | BLUE | `market_state:{symbol}` owner |
-| [paper_runner/](paper_runner/) | BLUE | Paper trading runner |
-| [regime/](regime/) | BLUE | ADX/ATR regime classification |
-| [risk/](risk/) | BLUE | Central order gate + kill-switch |
-| [signal/](signal/) | RED | Strategy signals → `stream.signals` |
-| [ws/](ws/) | RED | MEXC WebSocket feed |
+| [allocation/](allocation/) | BLUE | [README](allocation/README.md) |
+| [candles/](candles/) | BLUE | [README](candles/README.md) |
+| [db_writer/](db_writer/) | BLUE | [README](db_writer/README.md) |
+| [execution/](execution/) | BLUE | [README](execution/README.md) |
+| [market/](market/) | BLUE | [README](market/README.md) |
+| [paper_runner/](paper_runner/) | BLUE | (see compose + `knowledge/operating_rules/`) |
+| [regime/](regime/) | BLUE | [README](regime/README.md) |
+| [risk/](risk/) | BLUE | [README](risk/README.md) |
+| [signal/](signal/) | RED | [README](signal/README.md) |
+| [validation/](validation/) | offline lib | [README](validation/README.md) |
+| [ws/](ws/) | RED | [README](ws/README.md) |
 
 ## Redis transport
 

--- a/services/candles/README.md
+++ b/services/candles/README.md
@@ -1,0 +1,37 @@
+# Candles Service (`cdb_candles`)
+
+Aggregiert `market_data` zu 1-Minuten-Candles und schreibt `stream.candles_1m`.
+
+## Current-main Scope
+
+- Konsumiert Redis Pub/Sub `market_data`.
+- Emittiert deterministische 1m-Candles auf `stream.candles_1m`.
+- Optional Regime-Staleness-Checks gegen `stream.regime_signals`.
+
+## Topics / Streams
+
+- Input: `market_data` (Pub/Sub, `CANDLE_INPUT_CHANNEL`)
+- Output Stream: `stream.candles_1m` (`CANDLE_OUTPUT_STREAM`)
+
+## Runtime Surface
+
+- Endpoint-Port: `CANDLE_PORT` (Default `8007`)
+- HTTP: `/health`, `/metrics`
+
+Start im BLUE-Stack:
+
+```powershell
+docker compose -f infrastructure/compose/compose.blue.yml up -d cdb_candles
+```
+
+## Key Config
+
+- `CANDLE_OUTPUT_STREAM`, `CANDLE_INPUT_CHANNEL`
+- `CANDLE_WRITE_MARKET_STATE`, `CANDLE_REGIME_STREAM`
+- `CANDLE_REGIME_STALENESS_SECONDS`
+
+## Canonical References
+
+- `services/candles/service.py`
+- `services/candles/config.py`
+- `services/market/README.md`

--- a/services/db_writer/README.md
+++ b/services/db_writer/README.md
@@ -1,0 +1,36 @@
+# DB Writer (`cdb_db_writer`)
+
+Persistiert Redis-Stream-Events nach Postgres (kanonischer Insert-Pfad für Streams).
+
+## Current-main Scope
+
+- Konsumiert Trading-/Lifecycle-Streams und schreibt idempotent nach Postgres.
+- Kanonische Candle-Persistenz aus `stream.candles_1m`.
+- Kein zweiter unkontrollierter Writer für dieselben Tabellen (siehe Dual-Writer-Reconcile-Historie in `CURRENT_STATUS.md`).
+
+## Streams (typisch)
+
+- `stream.candles_1m` (dedizierter Candle-Writer-Thread)
+- Weitere Stream-Consumer gemäß `services/db_writer/db_writer.py`
+
+## Runtime Surface
+
+- Metrics-Port: `DB_WRITER_METRICS_PORT` (Default `8010`)
+- Kein öffentlicher Trading-HTTP-API-Pfad — Beobachtung über Metrics/Logs
+
+Start im BLUE-Stack:
+
+```powershell
+docker compose -f infrastructure/compose/compose.blue.yml up -d cdb_db_writer
+```
+
+## Key Config
+
+- `REDIS_*`, `POSTGRES_*` / `DATABASE_URL`
+- Stream-Namen in `db_writer.py` (z. B. `_CANDLE_STREAM_KEY`)
+
+## Canonical References
+
+- `services/db_writer/db_writer.py`
+- `infrastructure/database/`
+- `services/execution/README.md` (fills → stream)

--- a/services/execution/README.md
+++ b/services/execution/README.md
@@ -1,0 +1,41 @@
+# Execution Service (`cdb_execution`)
+
+Order-Execution-Service: konsumiert freigegebene Orders vom Risk Service und publiziert Fills/Results.
+
+## Current-main Scope
+
+- Subscribes `orders` (Pub/Sub) nur nach Risk-`ALLOW`.
+- Default: `MOCK_TRADING=true`, `DRY_RUN=true` — kein unkontrolliertes Live-Trading.
+- Publiziert `order_results` und schreibt in `stream.fills` (kanonisch für Persistenz via `cdb_db_writer`).
+- Kill-Switch-Volume geteilt mit `cdb_risk` (`CDB_KILL_SWITCH_STATE_FILE`).
+
+## Topics / Streams
+
+- Input Topic: `orders`
+- Output Topic: `order_results`
+- Output Stream: `stream.fills` (`STREAM_ORDER_RESULTS`)
+- Shutdown Stream: `stream.bot_shutdown`
+
+## Runtime Surface
+
+- Endpoint-Port: `8003` (`SERVICE_PORT`)
+- HTTP: `/health`, `/status`, `/metrics`
+
+Start im BLUE-Stack:
+
+```powershell
+docker compose -f infrastructure/compose/compose.blue.yml up -d cdb_execution
+```
+
+## Key Config
+
+- `MOCK_TRADING`, `DRY_RUN`, `MEXC_TESTNET`
+- `MEXC_API_KEY` / `MEXC_API_SECRET` (Secrets)
+- `STREAM_ORDER_RESULTS`, `STREAM_BOT_SHUTDOWN`
+
+## Canonical References
+
+- `services/execution/service.py`
+- `services/execution/config.py`
+- `services/risk/README.md`
+- `core/contracts/decision_contract_v1.py`

--- a/services/market/README.md
+++ b/services/market/README.md
@@ -1,0 +1,37 @@
+# Market Service (`cdb_market`)
+
+Eigentümer von `market_state:{symbol}` in Redis — aggregiert Candles/Regime-Kontext für downstream BLUE-Services.
+
+## Current-main Scope
+
+- Post-cutover Market-State-Owner (Issue #1201).
+- Liest `stream.candles_1m` und `stream.regime_signals` für State-Aufbau.
+- Fail-closed wenn erforderliche Felder fehlen (siehe `docs/governance/MARKET_STATE_CONTRACT_V1.md`).
+
+## Topics / Streams
+
+- Input: `market_data` (Pub/Sub), `stream.candles_1m`, `stream.regime_signals`
+- Redis keys: `market_state:{symbol}` (TTL-konfigurierbar)
+
+## Runtime Surface
+
+- Endpoint-Port: `MARKET_PORT` (Default `8009`)
+- HTTP: `/health`, `/status`, `/metrics`
+
+Start im BLUE-Stack:
+
+```powershell
+docker compose -f infrastructure/compose/compose.blue.yml up -d cdb_market
+```
+
+## Key Config
+
+- `MARKET_CANDLES_STREAM`, `MARKET_REGIME_STREAM`
+- `MARKET_STATE_KEY_PREFIX`, TTL-Settings in `services/market/service.py`
+
+## Canonical References
+
+- `services/market/service.py`
+- `docs/governance/MARKET_STATE_CONTRACT_V1.md`
+- `services/candles/README.md`
+- `services/regime/README.md`

--- a/services/validation/README.md
+++ b/services/validation/README.md
@@ -1,0 +1,34 @@
+# Validation Package (`services/validation`)
+
+Offline-/Batch-Validierung: Replay, Backtest, Paper-Runtime-Stimulus, ARVP-Scorecards und Gate-Evaluatoren.
+
+## Current-main Scope
+
+- **Kein** kanonischer always-on BLUE/RED-Container wie `cdb_risk` — Library + Runner-Skripte.
+- Wird von CI, Makefile-Targets und Evidence-Workflows aufgerufen.
+- Shadow/Paper-first; erzeugt keine Live-Kapital-Freigabe.
+
+## Module (Auswahl)
+
+| Module | Zweck |
+|---|---|
+| `pipeline.py` | Collect + aggregate Fenster |
+| `strategy_replay_runner.py` | Strategie-Replay |
+| `strategy_backtest_runner.py` | Backtest |
+| `paper_runtime_stimulus_runner.py` | Paper-Stimulus |
+| `gate_evaluator.py` | Gate-Auswertung |
+| `arvp_regime_scorecard_runner.py` | ARVP-Scorecard |
+
+## Usage
+
+```bash
+# Typisch über pytest oder dedizierte Scripts/Make-Targets
+pytest -q tests/unit/validation/
+```
+
+## Canonical References
+
+- `services/validation/pipeline.py`
+- `tests/unit/validation/`
+- `knowledge/contracts/PRIMARY_BREAKOUT_V1_VALIDATION.md`
+- `docs/evidence/SHADOW_SOAK_RUN_INDEX.md` (via `docs/index.md`)

--- a/services/ws/README.md
+++ b/services/ws/README.md
@@ -1,0 +1,35 @@
+# WebSocket Service (`cdb_ws`)
+
+MEXC WebSocket Feed (Protobuf v3) — publiziert normalisierte `market_data` auf Redis Pub/Sub.
+
+## Current-main Scope
+
+- RED-Stack-Service; Restart von RED darf BLUE-Core nicht invalidieren.
+- Protobuf unter `services/ws/mexc_proto_gen/` (generiert, nicht manuell editieren).
+- Health/Metrics auf Port `8000` auch ohne aktive WS-Verbindung importierbar.
+
+## Topics / Streams
+
+- Output Topic: `market_data` (Pub/Sub)
+
+## Runtime Surface
+
+- Endpoint-Port: `8000`
+- HTTP: `/health`, `/metrics`
+
+Start im RED-Stack:
+
+```powershell
+docker compose -f infrastructure/compose/compose.red.yml up -d cdb_ws
+```
+
+## Key Config
+
+- MEXC credentials via Docker secrets / env (siehe `core/secrets`)
+- Redis host/port/db wie übrige Services
+
+## Canonical References
+
+- `services/ws/service.py`
+- `services/ws/mexc_v3_client.py`
+- `services/candles/README.md`

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -1,0 +1,47 @@
+# CDB Context MCP Server (`tools/mcp/`)
+
+Stdio-MCP-Server für read-only Context Intelligence Tools (ContextBridge + PermissionGuard).
+
+## Start
+
+```bash
+python -m tools.mcp.server
+```
+
+Kanonische Config: `claire-de-binare.mcp.json` (Repo-Root); Cursor: `.cursor/mcp.json`.
+
+Validierung:
+
+```bash
+make mcp-config-validate
+# oder
+python tools/validate_mcp_config.py tests/fixtures/mcp_smoke_config.json
+```
+
+## Guardrails
+
+- Default: in-memory/noop adapter — kein SurrealDB/Docker nötig zum Start.
+- DB-backed mode: explizit per `adapter_config_path` pro Tool-Call.
+- Keine Writes, kein Schema-Apply, keine Remote-DB-URLs durch Agenten.
+- LR **NO-GO** — Tool-Output autorisiert keine Live-Orders.
+
+## Layout
+
+| File | Rolle |
+|---|---|
+| `server.py` | MCP stdio entry |
+| `context_bridge.py` | Bridge + tool dispatch |
+| `registry.py` | Tool registry |
+| `permission_guard.py` | Fail-closed permissions |
+| `*_tools.py` | Tool implementations |
+
+## Tests
+
+- `tests/unit/tools/mcp/` — contract/unit
+- `tests/smoke/test_mcp_runtime.py` — runtime smoke (CI slice may exclude)
+
+## Canonical References
+
+- [`docs/runbooks/surrealdb_context_mcp_access.md`](../../docs/runbooks/surrealdb_context_mcp_access.md)
+- [`agents/templates/README.md`](../../agents/templates/README.md)
+- [`docs/surrealdb/README.md`](../../docs/surrealdb/README.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Delivered

Follow-up to merged #2999 — implements the recommended README sequence:

1. **Service READMEs (6):** `execution`, `market`, `candles`, `ws`, `db_writer`, `validation`
2. **`docs/runbooks/README.md`** — cockpit + categorized index
3. **`docs/surrealdb/README.md`** — operator entry, #1976 SSOTs, wave pointers
4. **`tools/mcp/README.md`** + **`scripts/README.md`**
5. **`mcp_navpack_working_repo/README.md`**
6. **`.cursor/skills/README.md`**
7. **`services/README.md`** — links all service READMEs

## Validation

- Docs-only; no runtime/code changes.

## Non-goals

- Archiv paths, `tests/unit/**` indexes, `knowledge/decisions/` (optional follow-up).

## Remaining uncertainty

- `paper_runner` has no dedicated README yet (compose/operating_rules only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c8cee29-83c7-4960-971d-7e4f54d187cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c8cee29-83c7-4960-971d-7e4f54d187cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

