### PR TITLE
docs(architecture): reconcile catalog after README navigation (#3000, #3004)

### DIFF
--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -265,8 +265,8 @@ Legacy-Layer (base.yml, dev.yml, tls.yml, etc.) existieren noch, sind nicht mehr
 | 2026-04-24 | PRs #1914/#1916/#1918/#1920 Nachzug: ARVP validation comparisons & scorecards. shadow_compare, replay_vs_paper_compare, simulator_calibration_report, arvp_regime_scorecards, paper_reference_window_export + CLI-Runner dokumentiert. Offline-Validation, keine Runtime-Komponenten. (Issues #1915/#1917/#1919/#1921) | Codex |
 | 2026-05-13 | PR #2453/#2455 Nachzug: WS-Metrics-Delta-Logik + lazy `mexc_pb`-Client-Import sowie Postgres-Exporter-DSN/Secret-Wiring in RED-Compose dokumentiert (Issues #2454/#2456) | Codex |
 | 2026-05-29 | PR #2670/#2671 Nachzug: `verify_stack.ps1` Default ohne Logging-Overlay; `-IncludeLogging:$true` fuer Loki/Promtail; Logging-Aktivierungspfad auf `infrastructure/compose/` praezisiert; Windows-`make docker-health` ergaenzt (Issue #2671) | Codex |
-| 2026-06-05 | PRs #2989/#2992 Nachzug: `paper_runtime_stimulus_runner.py` als runtime-adjacent ARVP operator CLI dokumentiert (`--dry-run-preview`, safety-gated `--publish`, `--runtime-relative` timestamp shift). Kein Live-Go; keine DB-Schreibfläche (Issues #2990/#2993) | Codex |
 | 2026-06-05 | PRs #2999/#3001/#3003 Nachzug: Service-Map Code/README-Spalten; Paper Runner Code-Pfad `tools/paper_trading/`; Cross-Links zu `core/`, `services/`, `infrastructure/database/` READMEs (Issues #3000/#3004) | Cursor |
+| 2026-06-05 | PRs #2989/#2992 Nachzug: `paper_runtime_stimulus_runner.py` als runtime-adjacent ARVP operator CLI dokumentiert (`--dry-run-preview`, safety-gated `--publish`, `--runtime-relative` timestamp shift). Kein Live-Go; keine DB-Schreibfläche (Issues #2990/#2993) | Codex |
 ### PostgreSQL Schema Artefacts (PR #2793)
 
 | Artifact | Migration | Status | Bedeutung |

--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -42,8 +42,8 @@ Claire de Binare ist ein **event-getriebenes Krypto-Trading-System** mit:
 
 | Service | Container | Port | Code | Operator README |
 |---------|-----------|------|------|-----------------|
-| PostgreSQL | [REDACTED] | 5432 | docs/db/ (index) | [docs/db/index.md](../docs/db/index.md) |
-| Redis | [REDACTED] | 6379 | infrastructure/compose/ | [compose/README.md](../infrastructure/compose/README.md) |
+| PostgreSQL | cdb_postgres | 5432 | infrastructure/database/ | [database/README.md](../infrastructure/database/README.md) |
+| Redis | cdb_redis | 6379 | infrastructure/compose/ | [compose/README.md](../infrastructure/compose/README.md) |
 | Market | cdb_market | 8009 | services/market/ | [services/market/README.md](../services/market/README.md) |
 | Candles | cdb_candles | 8007 | services/candles/ | [services/candles/README.md](../services/candles/README.md) |
 | Regime | cdb_regime | 8008 | services/regime/ | [services/regime/README.md](../services/regime/README.md) |
@@ -65,8 +65,8 @@ Claire de Binare ist ein **event-getriebenes Krypto-Trading-System** mit:
 |---------|-----------|------|----------|
 | Prometheus | cdb_prometheus | 19090→9090 | Metrics |
 | Grafana | cdb_grafana | 3000 | Dashboards |
-| Postgres Exporter | [REDACTED]_exporter | 9187 | PG Metrics; liest `postgres_password` als Secret, setzt `PGPASSWORD` und baut `DATA_SOURCE_NAME` aus `POSTGRES_USER`/`POSTGRES_DB` + Host/Port |
-| Redis Exporter | [REDACTED]_exporter | 9121 | Redis Metrics |
+| Postgres Exporter | cdb_postgres_exporter | 9187 | PG Metrics; liest `postgres_password` als Secret, setzt `PGPASSWORD` und baut `DATA_SOURCE_NAME` aus `POSTGRES_USER`/`POSTGRES_DB` + Host/Port |
+| Redis Exporter | cdb_redis_exporter | 9121 | Redis Metrics |
 | cAdvisor | cdb_cadvisor | — | Container Metrics |
 
 Hinweis: `services/signal/config.py` hat `SIGNAL_PORT`-Default `8001`; der kanonische Runtime-Port ist `8005`, weil `infrastructure/compose/compose.red.yml` fuer `cdb_signal` `SIGNAL_PORT=8005` setzt.

--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -17,6 +17,8 @@ Claire de Binare ist ein **event-getriebenes Krypto-Trading-System** mit:
 
 **Operatives Inventar:** `governance/SERVICE_CATALOG.md` (Working Repo)
 
+**Operator READMEs (Working Repo, docs-only navigation):** [`../services/README.md`](../services/README.md), [`../core/README.md`](../core/README.md), [`../infrastructure/database/README.md`](../infrastructure/database/README.md), [`../tools/paper_trading/README.md`](../tools/paper_trading/README.md). Vollstaendige README-Index-Tabelle: `governance/SERVICE_CATALOG.md` § Navigation READMEs.
+
 ---
 
 ## 2. Service Map (SOLL)
@@ -38,31 +40,34 @@ Claire de Binare ist ein **event-getriebenes Krypto-Trading-System** mit:
 
 ### BLUE Stack (compose.blue.yml) — Core, always-on
 
-| Service | Container | Port | Funktion |
-|---------|-----------|------|----------|
-| PostgreSQL | cdb_postgres | 5432 | Persistenz |
-| Redis | cdb_redis | 6379 | Cache, Pub/Sub, Streams |
-| Market | cdb_market | 8009 | market_state:{symbol} Owner; Redis retry/reconnect bis verfügbar, /health fail-closed |
-| Candles | cdb_candles | 8007 | Tick→1-min Candle Aggregation |
-| Regime | cdb_regime | 8008 | ADX/ATR Regime Classification |
-| Allocation | cdb_allocation | 8006 | Regime→Allocation Mapping |
-| Risk | cdb_risk | 8002 | Risk Gate, Circuit Breaker, Kill-Switch |
-| Execution | cdb_execution | 8003 | Order Execution (MOCK_TRADING=true) |
-| DB Writer | cdb_db_writer | — | Redis→PostgreSQL Persistenz |
-| Paper Runner | cdb_paper_runner | 8004 | Paper Trading Orchestrator |
+| Service | Container | Port | Code | Operator README |
+|---------|-----------|------|------|-----------------|
+| PostgreSQL | [REDACTED] | 5432 | docs/db/ (index) | [docs/db/index.md](../docs/db/index.md) |
+| Redis | [REDACTED] | 6379 | infrastructure/compose/ | [compose/README.md](../infrastructure/compose/README.md) |
+| Market | cdb_market | 8009 | services/market/ | [services/market/README.md](../services/market/README.md) |
+| Candles | cdb_candles | 8007 | services/candles/ | [services/candles/README.md](../services/candles/README.md) |
+| Regime | cdb_regime | 8008 | services/regime/ | [services/regime/README.md](../services/regime/README.md) |
+| Allocation | cdb_allocation | 8006 | services/allocation/ | [services/allocation/README.md](../services/allocation/README.md) |
+| Risk | cdb_risk | 8002 | services/risk/ | [services/risk/README.md](../services/risk/README.md) |
+| Execution | cdb_execution | 8003 | services/execution/ | [services/execution/README.md](../services/execution/README.md) |
+| DB Writer | cdb_db_writer | — | services/db_writer/ | [services/db_writer/README.md](../services/db_writer/README.md) |
+| Paper Runner | cdb_paper_runner | 8004 | tools/paper_trading/ | [tools/paper_trading/README.md](../tools/paper_trading/README.md) |
 
 ### RED Stack (compose.red.yml) — Signal + Monitoring, failure-isolated
 
+| Service | Container | Port | Code | Operator README |
+|---------|-----------|------|------|-----------------|
+| WebSocket | cdb_ws | 8000 | services/ws/ | [services/ws/README.md](../services/ws/README.md) |
+| Signal | cdb_signal | 8005 (Runtime) | services/signal/ | [services/signal/README.md](../services/signal/README.md) |
+| Reports | cdb_reports | — | services/reports/ | — |
+
 | Service | Container | Port | Funktion |
 |---------|-----------|------|----------|
-| WebSocket | cdb_ws | 8000 | MEXC Market Data Stream; `MexcV3Client` wird nur bei `WS_SOURCE=mexc_pb` lazy geladen, sodass `/health` und `/metrics` auch ohne websocket-spezifische Runtime-Dependencies importierbar bleiben; Client-Absolute werden per Delta-Logik in Prometheus Counter ueberfuehrt (`decoded_messages_total`, `decode_errors_total`) |
-| Signal | cdb_signal | 8005 (Runtime) | Signal Generation (primary_breakout_v1: time-windowed lookback); audit metadata: `config_snapshot` (runtime params) + deterministic `config_hash` (SHA-256); `SIGNAL_BOT_ID` liefert repo-backed Experiment-Kontext im SIGNAL-Payload, aber keine neue first-class Ledger-ID; reserved metadata keys protected against override; used by Paper Reference Exporter (PR #2133) for signal-anchored bot_id/config_hash filtering in replay-vs-paper comparisons |
 | Prometheus | cdb_prometheus | 19090→9090 | Metrics |
 | Grafana | cdb_grafana | 3000 | Dashboards |
-| Postgres Exporter | cdb_postgres_exporter | 9187 | PG Metrics; liest `postgres_password` als Secret, setzt `PGPASSWORD` und baut `DATA_SOURCE_NAME` aus `POSTGRES_USER`/`POSTGRES_DB` + Host/Port |
-| Redis Exporter | cdb_redis_exporter | 9121 | Redis Metrics |
+| Postgres Exporter | [REDACTED]_exporter | 9187 | PG Metrics; liest `postgres_password` als Secret, setzt `PGPASSWORD` und baut `DATA_SOURCE_NAME` aus `POSTGRES_USER`/`POSTGRES_DB` + Host/Port |
+| Redis Exporter | [REDACTED]_exporter | 9121 | Redis Metrics |
 | cAdvisor | cdb_cadvisor | — | Container Metrics |
-| Reports | cdb_reports | — | Daily Order Summary |
 
 Hinweis: `services/signal/config.py` hat `SIGNAL_PORT`-Default `8001`; der kanonische Runtime-Port ist `8005`, weil `infrastructure/compose/compose.red.yml` fuer `cdb_signal` `SIGNAL_PORT=8005` setzt.
 
@@ -261,6 +266,7 @@ Legacy-Layer (base.yml, dev.yml, tls.yml, etc.) existieren noch, sind nicht mehr
 | 2026-05-13 | PR #2453/#2455 Nachzug: WS-Metrics-Delta-Logik + lazy `mexc_pb`-Client-Import sowie Postgres-Exporter-DSN/Secret-Wiring in RED-Compose dokumentiert (Issues #2454/#2456) | Codex |
 | 2026-05-29 | PR #2670/#2671 Nachzug: `verify_stack.ps1` Default ohne Logging-Overlay; `-IncludeLogging:$true` fuer Loki/Promtail; Logging-Aktivierungspfad auf `infrastructure/compose/` praezisiert; Windows-`make docker-health` ergaenzt (Issue #2671) | Codex |
 | 2026-06-05 | PRs #2989/#2992 Nachzug: `paper_runtime_stimulus_runner.py` als runtime-adjacent ARVP operator CLI dokumentiert (`--dry-run-preview`, safety-gated `--publish`, `--runtime-relative` timestamp shift). Kein Live-Go; keine DB-Schreibfläche (Issues #2990/#2993) | Codex |
+| 2026-06-05 | PRs #2999/#3001/#3003 Nachzug: Service-Map Code/README-Spalten; Paper Runner Code-Pfad `tools/paper_trading/`; Cross-Links zu `core/`, `services/`, `infrastructure/database/` READMEs (Issues #3000/#3004) | Cursor |
 ### PostgreSQL Schema Artefacts (PR #2793)
 
 | Artifact | Migration | Status | Bedeutung |

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -19,28 +19,43 @@
 
 ---
 
+## Navigation READMEs (Working Repo)
+
+Docs-only operator indices from PRs #2999, #3001, #3003. Ersetzen keine kanonische Funktionsbeschreibung in den Tabellen unten.
+
+| Bereich | README |
+|---|---|
+| Service-Index | [`services/README.md`](../../services/README.md) |
+| Shared core | [`core/README.md`](../../core/README.md) |
+| Replay / contracts | [`core/replay/README.md`](../../core/replay/README.md), [`core/contracts/README.md`](../../core/contracts/README.md) |
+| Offline validation | [`services/validation/README.md`](../../services/validation/README.md) |
+| DB schema / migrations | [`docs/db/index.md`](../../docs/db/index.md) |
+| Paper runner (compose `cdb_paper_runner`) | [`tools/paper_trading/README.md`](../../tools/paper_trading/README.md) — **nicht** `services/paper_runner/` |
+
+---
+
 ## Applikations-Services
 
 ### BLUE Stack (compose.blue.yml) — Core, always-on
 
-| Service | Container | Port | Code | Status | Funktion |
-|---------|-----------|------|------|--------|----------|
-| **Market** | cdb_market | 8009 | services/market/ | **AKTIV** | market_state:{symbol} Owner (Issue #1201); Redis retry/reconnect bis verfügbar, /health fail-closed; Email-Alerter ohne Empfaenger-Klartext-Logging |
-| **Candles** | cdb_candles | 8007 | services/candles/ | **AKTIV** | Tick→1-min Candle Aggregation |
-| **Regime** | cdb_regime | 8008 | services/regime/ | **AKTIV** | ADX/ATR Regime Classification |
-| **Allocation** | cdb_allocation | 8006 | services/allocation/ | **AKTIV** | Regime→Allocation Mapping |
-| **Risk** | cdb_risk | 8002 | services/risk/ | **AKTIV** | Risk Gate, Circuit Breaker, Kill-Switch; `/kill-switch` Fehlerantworten fail-closed ohne Exception-Details |
-| **Execution** | cdb_execution | 8003 | services/execution/ | **AKTIV** | Order Execution (MOCK_TRADING=true default); `/orders` Fehlerantworten nur mit sicherem Fehlercode |
-| **DB Writer** | cdb_db_writer | — | services/db_writer/ | **AKTIV** | Redis→PostgreSQL Persistenz; `db_writer.py` schreibt `stream.candles_1m` in `candles_1m` (Postgres), `candle_normalizer.py` normalisiert die Stream-Payloads auf dem Write-Pfad (PR #1856) |
-| **Paper Runner** | cdb_paper_runner | 8004 | tools/paper_trading/ | **AKTIV** | Paper Trading Orchestrator |
+| Service | Container | Port | Code | README | Status | Funktion |
+|---------|-----------|------|------|--------|--------|----------|
+| **Market** | cdb_market | 8009 | services/market/ | [README](../../services/market/README.md) | **AKTIV** | market_state:{symbol} Owner (Issue #1201); Redis retry/reconnect bis verfügbar, /health fail-closed; Email-Alerter ohne Empfaenger-Klartext-Logging |
+| **Candles** | cdb_candles | 8007 | services/candles/ | [README](../../services/candles/README.md) | **AKTIV** | Tick→1-min Candle Aggregation |
+| **Regime** | cdb_regime | 8008 | services/regime/ | [README](../../services/regime/README.md) | **AKTIV** | ADX/ATR Regime Classification |
+| **Allocation** | cdb_allocation | 8006 | services/allocation/ | [README](../../services/allocation/README.md) | **AKTIV** | Regime→Allocation Mapping |
+| **Risk** | cdb_risk | 8002 | services/risk/ | [README](../../services/risk/README.md) | **AKTIV** | Risk Gate, Circuit Breaker, Kill-Switch; `/kill-switch` Fehlerantworten fail-closed ohne Exception-Details |
+| **Execution** | cdb_execution | 8003 | services/execution/ | [README](../../services/execution/README.md) | **AKTIV** | Order Execution (MOCK_TRADING=true default); `/orders` Fehlerantworten nur mit sicherem Fehlercode |
+| **DB Writer** | cdb_db_writer | — | services/db_writer/ | [README](../../services/db_writer/README.md) | **AKTIV** | Redis→PostgreSQL Persistenz; `db_writer.py` schreibt `stream.candles_1m` in `candles_1m` (Postgres), `candle_normalizer.py` normalisiert die Stream-Payloads auf dem Write-Pfad (PR #1856) |
+| **Paper Runner** | cdb_paper_runner | 8004 | tools/paper_trading/ | [README](../../tools/paper_trading/README.md) | **AKTIV** | Paper Trading Orchestrator |
 
 ### RED Stack (compose.red.yml) — Signal + Monitoring, failure-isolated from BLUE
 
-| Service | Container | Port | Code | Status | Funktion |
-|---------|-----------|------|------|--------|----------|
-| **WebSocket** | cdb_ws | 8000 | services/ws/ | **AKTIV** | MEXC Market Data Stream (protobuf); `MexcV3Client` wird nur bei `WS_SOURCE=mexc_pb` lazy geladen (Health-/Metrics-Surface bleibt importierbar ohne websocket-spezifische Dependency); `decoded_messages_total` und `decode_errors_total` werden via Delta-Logik aus absoluten Client-Werten als Prometheus Counter fortgeschrieben |
-| **Signal** | cdb_signal | 8005 (Runtime) | services/signal/ | **AKTIV** | Signal Generation (`primary_breakout_v1` default nutzt zeitbasierte Lookback-Semantik, `momentum_builtin` statische Adapter-Grenze); audit metadata: `config_snapshot` (deterministic runtime params snapshot) + `config_hash` (full SHA-256); `SIGNAL_BOT_ID` environment variable wired via compose.red.yml (PR #2129) liefert Experiment-Kontext im SIGNAL-Payload, aber keine neue first-class Ledger-ID; reserved metadata keys (strategy_id, bot_id, config_snapshot, config_hash, signal_reason, signal_inputs) sind immutable und können nicht durch Candidate-Signal-Metadata überschrieben werden |
-| **Reports** | cdb_reports | — | services/reports/ | **AKTIV** | Daily Order Summary + Email |
+| Service | Container | Port | Code | README | Status | Funktion |
+|---------|-----------|------|------|--------|--------|----------|
+| **WebSocket** | cdb_ws | 8000 | services/ws/ | [README](../../services/ws/README.md) | **AKTIV** | MEXC Market Data Stream (protobuf); `MexcV3Client` wird nur bei `WS_SOURCE=mexc_pb` lazy geladen (Health-/Metrics-Surface bleibt importierbar ohne websocket-spezifische Dependency); `decoded_messages_total` und `decode_errors_total` werden via Delta-Logik aus absoluten Client-Werten als Prometheus Counter fortgeschrieben |
+| **Signal** | cdb_signal | 8005 (Runtime) | services/signal/ | [README](../../services/signal/README.md) | **AKTIV** | Signal Generation (`primary_breakout_v1` default nutzt zeitbasierte Lookback-Semantik, `momentum_builtin` statische Adapter-Grenze); audit metadata: `config_snapshot` (deterministic runtime params snapshot) + `config_hash` (full SHA-256); `SIGNAL_BOT_ID` environment variable wired via compose.red.yml (PR #2129) liefert Experiment-Kontext im SIGNAL-Payload, aber keine neue first-class Ledger-ID; reserved metadata keys (strategy_id, bot_id, config_snapshot, config_hash, signal_reason, signal_inputs) sind immutable und können nicht durch Candidate-Signal-Metadata überschrieben werden |
+| **Reports** | cdb_reports | — | services/reports/ | — | **AKTIV** | Daily Order Summary + Email |
 
 Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.py` bei `8001`; im kanonischen RED-Runtime-Pfad wird fuer `cdb_signal` in `infrastructure/compose/compose.red.yml` explizit `SIGNAL_PORT=8005` gesetzt. Ebenso wird `SIGNAL_BOT_ID` (audit identity) explizit via `environment:` durchgereicht (PR #2129).
 
@@ -51,6 +66,8 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 ### Replay Infrastructure (LR-021, PR #1808)
 
 **Pfad:** `core/replay/`, `services/validation/` (reporter + CLI)
+
+**Navigation:** [`core/replay/README.md`](../../core/replay/README.md), [`core/contracts/README.md`](../../core/contracts/README.md), [`services/validation/README.md`](../../services/validation/README.md)
 
 **Funktion:** Deterministic shadow replay stack für accelerated backtesting, validation und gate evaluation offline, ohne live/paper/Redis-Runtime-Integration; ARVP §4.2 datasets via `DatasetSpec` + `DatasetProvider` (FileBackedDatasetProvider für JSON/JSONL, DBBackedDatasetProvider für Postgres `candles_1m`).
 
@@ -219,6 +236,7 @@ Referenz: `infrastructure/compose/SERVICE_MAPPING.md`, PR #2670.
 | 2026-05-13 | PR #2453/#2455 Nachzug: WS-Service (Delta-Counter + lazy `mexc_pb`-Import) und Postgres-Exporter-DSN/Secret-Wiring im RED-Stack nachgezogen (Issues #2454/#2456) | Codex |
 | 2026-05-29 | PR #2670/#2671 Nachzug: Stack-Verification-Tabelle (`verify_stack.ps1` Default ohne Logging-Overlay, `-IncludeLogging:$true` opt-in, Windows-`make docker-health`) ergänzt (Issue #2671) | Codex |
 | 2026-06-05 | PRs #2989/#2992 Nachzug: `paper_runtime_stimulus_runner.py` als runtime-adjacent ARVP operator CLI im Validation-Katalog ergänzt (Issues #2990/#2993) | Codex |
+| 2026-06-05 | PRs #2999/#3001/#3003 Nachzug: § Navigation READMEs + README-Spalte; Paper Runner Code `tools/paper_trading/` explizit; Replay/DB README-Links (Issues #3000/#3004) | Cursor |
 ## PostgreSQL Schema Artefacts
 
 | Artefakt | Migration | Status | Bedeutung |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Delivered

- `knowledge/ARCHITECTURE_MAP.md`: Code/README columns for BLUE/RED services; `tools/paper_trading/` for `cdb_paper_runner`
- `knowledge/governance/SERVICE_CATALOG.md`: § Navigation READMEs, README column on service tables, replay/contracts links

## Validation

- Docs-only diff (2 files)
- Post-merge follow-up for #2999/#3001/#3003 README navigation

## Non-goals

- Runtime, compose, LR, or catalog functional changes

## LR

**NO-GO** unchanged.

Closes #3000
Closes #3004
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c8cee29-83c7-4960-971d-7e4f54d187cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c8cee29-83c7-4960-971d-7e4f54d187cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

