### PR TITLE
docs(arvp): clarify regime scorecard trace input

### DIFF
--- a/docs/runbooks/ARVP_OPERATOR_RUNBOOK.md
+++ b/docs/runbooks/ARVP_OPERATOR_RUNBOOK.md
@@ -184,10 +184,16 @@ Command template:
 ```bash
 python -m services.validation.arvp_regime_scorecard_runner \
   --run-id <RUN_ID> \
-  --replay-trace artifacts/replay_reports/<RUN_ID>/report.json \
+  --replay-trace <PATH_TO_REPLAY_TRACE_JSON> \
   --comparison artifacts/replay_vs_paper_compare/<RUN_ID>/shadow_comparison.json \
   --output-dir artifacts/arvp_regime_scorecards
 ```
+
+Operator notes:
+
+- Point `--replay-trace` at the replay trace JSON emitted by the replay pipeline.
+- Do not pass `report.json`; that schema is not accepted by the scorecard runner.
+- `--comparison` is optional and only suitable when the JSON already contains regime segments.
 
 Interpretation:
 


### PR DESCRIPTION
Addresses review comment https://github.com/jannekbuengener/Claire_de_Binare/pull/3010#discussion_r3364209925

Delivered
- `Stage 6` now points `--replay-trace` at a trace placeholder instead of `report.json`.
- Added an operator note that `report.json` is not accepted by `arvp_regime_scorecard_runner`.
- Clarified that `--comparison` is optional and only valid when the JSON already contains regime segments.

Validation
- `git diff --check`
- `rg -n "replay-trace|report.json|regime scorecard runner|regime segments" docs/runbooks/ARVP_OPERATOR_RUNBOOK.md`

Safety Boundaries
- Docs-only
- No runtime, DB, Docker, or secret changes
- LR remains NO-GO
