### PR TITLE
fix(mcp): make show_audit schema opencode-compatible

### DIFF
--- a/tests/unit/tools/mcp/test_show_handlers.py
+++ b/tests/unit/tools/mcp/test_show_handlers.py
@@ -131,15 +131,11 @@ class TestShowAuditHandler:
         tool = ContextToolRegistry.get_tool("context.show_audit")
         schema = tool.input_schema
         props = schema.get("properties", {})
+        forbidden_top_level_keys = {"oneOf", "anyOf", "allOf", "enum", "not"}
         assert "target_tool" in props
         assert "entity_id" in props
-        any_of = schema.get("anyOf", [])
-        assert any(
-            isinstance(o, dict) and o.get("required") == ["target_tool"] for o in any_of
-        )
-        assert any(
-            isinstance(o, dict) and o.get("required") == ["entity_id"] for o in any_of
-        )
+        assert schema.get("type") == "object"
+        assert forbidden_top_level_keys.isdisjoint(schema)
         assert "tool" in tool.output_schema.get("properties", {})
         assert "status" in tool.output_schema.get("properties", {})
 

--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -209,7 +209,6 @@ TOOLS_V0 = [
                 "audit_type": {"type": "string", "default": "all"},
                 "limit": {"type": "integer", "default": 50},
             },
-            "anyOf": [{"required": ["target_tool"]}, {"required": ["entity_id"]}],
         },
         output_schema={
             "type": "object",


### PR DESCRIPTION
## Summary

Root cause: OpenCode/OpenCore rejects top-level `anyOf` in `cdb_context_context_show_audit` schema.

Delivered:
- removed top-level `anyOf` from `context.show_audit` `input_schema`
- kept top-level `type: object`
- kept `target_tool`, `entity_id`, `audit_type`, and `limit`
- updated the regression test to assert OpenCode-compatible top-level schema keys

Safety:
- handler still fail-closed validates `target_tool` / `entity_id` at runtime
- empty input still returns `invalid_entity_id`

Validation:
- `git diff --check`
- `pytest -q tests/unit/tools/mcp/test_show_handlers.py` -> passed
- `pytest -q tests/unit/tools/mcp/test_permission_guard.py` -> 151 passed
- `pytest -q tests/unit/tools/mcp/test_context_bridge.py` -> 252 passed, 2 environment errors unrelated to this diff
- `pytest -q tests/unit/tools/mcp/ -m unit` -> 865 passed, 11 environment errors unrelated to this diff
- `ruff check tools/mcp tests/unit/tools/mcp` -> passed
- `rg -n "\"anyOf\"|\"oneOf\"|\"allOf\"|\"not\"" tools/mcp/registry.py` -> no matches

Non-goals:
- no runtime changes
- no DB changes
- no Docker changes
- no Live-Go or trading changes
