### PR TITLE
fix(risk): ignore invalid regime context for rc001 lookup

### DIFF
--- a/services/candles/service.py
+++ b/services/candles/service.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 import redis
 import importlib.util
+
 try:
     _FLASK_AVAILABLE = importlib.util.find_spec("flask") is not None
 except ModuleNotFoundError as e:
@@ -203,7 +204,9 @@ class CandleService:
             elif regime_str == "CRISIS":
                 return 3
             else:
-                logger.debug("regime_id skip: %s unknown regime '%s'", symbol, regime_str)
+                logger.debug(
+                    "regime_id skip: %s unknown regime '%s'", symbol, regime_str
+                )
                 return None
 
         except Exception as e:
@@ -402,6 +405,7 @@ if _FLASK_AVAILABLE:
             f"candle_candles_emitted_total {stats['candles_emitted']}\n"
         )
         return Response(body, mimetype="text/plain")
+
 else:
     app = None
 

--- a/services/candles/service.py
+++ b/services/candles/service.py
@@ -105,9 +105,17 @@ class CandleService:
         # Skipped when CANDLE_WRITE_MARKET_STATE=false (kill-switch for cutover).
         symbol = candle.get("symbol")
         if symbol and self.config.write_market_state:
-            self._update_market_state(symbol)
+            candle_ts_s = None
+            if candle.get("ts") is not None:
+                try:
+                    candle_ts_s = int(candle.get("ts"))
+                except (TypeError, ValueError):
+                    candle_ts_s = None
+            self._update_market_state(symbol, candle_ts_s)
 
-    def _lookup_regime_id(self, symbol: str) -> int | None:
+    def _lookup_regime_id(
+        self, symbol: str, as_of_ts_s: int | None = None
+    ) -> int | None:
         """
         Lookup regime_id from stream.regime_signals (deterministic mapping).
 
@@ -117,6 +125,12 @@ class CandleService:
         - HIGH_VOL_* (startswith) → 2
         - CRISIS → 3
         - UNKNOWN, missing, stale → None (fail-closed)
+
+        Selection rule:
+        - Prefer the newest valid regime entry at or before ``as_of_ts_s`` when
+          provided (the candle timestamp that is being enriched).
+        - Future, out-of-range, and stale entries are skipped so they cannot mask
+          a valid current-window regime.
 
         Fail-closed:
         - No regime signal found → None → RC_001 blocks
@@ -130,47 +144,51 @@ class CandleService:
                 self.config.regime_stream, "+", "-", count=50
             )
 
-            # Find latest entry for this symbol
+            lookup_ts_s = int(time.time()) if as_of_ts_s is None else int(as_of_ts_s)
+
+            # Find latest valid entry for this symbol at or before the lookup anchor.
             regime_entry = None
             for entry_id, payload in raw_entries:
-                if payload.get("symbol") == symbol:
-                    regime_entry = payload
-                    break
+                if payload.get("symbol") != symbol:
+                    continue
+
+                # Parse and validate ts (must be seconds, not ms)
+                ts_raw = payload.get("ts")
+                if ts_raw is None:
+                    logger.debug("regime_id skip: %s ts missing", symbol)
+                    continue
+                try:
+                    regime_ts = int(ts_raw)
+                except (ValueError, TypeError):
+                    logger.debug("regime_id skip: %s ts not parseable", symbol)
+                    continue
+
+                # Plausibility: must be seconds (not ms), not too old, not in future
+                if regime_ts < 1_000_000_000 or regime_ts > 4_000_000_000:
+                    logger.debug(
+                        "regime_id skip: %s ts out of range %d", symbol, regime_ts
+                    )
+                    continue
+
+                age = lookup_ts_s - regime_ts
+                if age < 0:
+                    logger.debug("regime_id skip: %s ts in future", symbol)
+                    continue
+
+                if age > self.config.regime_staleness_seconds:
+                    logger.debug(
+                        "regime_id skip: %s signal stale (%ds old, max %ds)",
+                        symbol,
+                        age,
+                        self.config.regime_staleness_seconds,
+                    )
+                    continue
+
+                regime_entry = payload
+                break
 
             if regime_entry is None:
                 logger.debug("regime_id skip: %s no signal found", symbol)
-                return None
-
-            # Parse and validate ts (must be seconds, not ms)
-            ts_raw = regime_entry.get("ts")
-            if ts_raw is None:
-                logger.debug("regime_id skip: %s ts missing", symbol)
-                return None
-            try:
-                regime_ts = int(ts_raw)
-            except (ValueError, TypeError):
-                logger.debug("regime_id skip: %s ts not parseable", symbol)
-                return None
-
-            # Plausibility: must be seconds (not ms), not too old, not in future
-            if regime_ts < 1_000_000_000 or regime_ts > 4_000_000_000:
-                logger.debug("regime_id skip: %s ts out of range %d", symbol, regime_ts)
-                return None
-
-            now_s = int(time.time())
-            age = now_s - regime_ts
-            if age < 0:
-                logger.debug("regime_id skip: %s ts in future", symbol)
-                return None
-
-            # Check staleness
-            if age > self.config.regime_staleness_seconds:
-                logger.debug(
-                    "regime_id skip: %s signal stale (%ds old, max %ds)",
-                    symbol,
-                    age,
-                    self.config.regime_staleness_seconds,
-                )
                 return None
 
             # Deterministic mapping: regime string → regime_id
@@ -192,7 +210,7 @@ class CandleService:
             logger.warning("regime_id error for %s: %s", symbol, e)
             return None
 
-    def _update_market_state(self, symbol: str) -> None:
+    def _update_market_state(self, symbol: str, candle_ts_s: int | None = None) -> None:
         """
         Compute market_state V1 returns from candle history and persist to Redis.
 
@@ -256,7 +274,9 @@ class CandleService:
             price_change_5m = abs(return_5m)
 
             # Lookup regime_id from stream.regime_signals (fail-closed)
-            regime_id = self._lookup_regime_id(symbol)
+            # Anchor to the candle timestamp so a later future/stale regime entry
+            # cannot override the regime that was valid for this candle.
+            regime_id = self._lookup_regime_id(symbol, candle_ts_s)
 
             # Build market_state payload
             ts_ms = int(time.time() * 1000)

--- a/tests/unit/candles/test_market_state_kill_switch.py
+++ b/tests/unit/candles/test_market_state_kill_switch.py
@@ -62,7 +62,7 @@ def test_kill_switch_true_calls_market_state_write():
     service = _make_service(write_market_state=True)
     with patch.object(service, "_update_market_state") as mock_update:
         service._emit_candle(_CANDLE.copy())
-    mock_update.assert_called_once_with("BTCUSDT")
+    mock_update.assert_called_once_with("BTCUSDT", 1700000000)
 
 
 @pytest.mark.unit

--- a/tests/unit/candles/test_market_state_kill_switch.py
+++ b/tests/unit/candles/test_market_state_kill_switch.py
@@ -6,6 +6,7 @@ Verifies that:
 - garbage env value → treated as true (fail-safe)
 - candle emission itself is unaffected by the kill-switch in either case
 """
+
 import copy
 import os
 from unittest.mock import MagicMock, patch
@@ -24,7 +25,7 @@ def _make_service(write_market_state: bool) -> CandleService:
     Uses a copy of the config to avoid mutating the module-level singleton.
     """
     service = CandleService()
-    service.config = copy.copy(service.config)   # isolate from global singleton
+    service.config = copy.copy(service.config)  # isolate from global singleton
     service.config.write_market_state = write_market_state
     service.redis_client = MagicMock()
     service.redis_client.xadd.return_value = None
@@ -104,6 +105,7 @@ def test_config_false_string_disables_write():
         # Re-parse env vars by re-importing config directly
         import importlib
         import services.candles.config as cfg_mod
+
         importlib.reload(cfg_mod)
         assert cfg_mod.config.write_market_state is False
     finally:
@@ -122,6 +124,7 @@ def test_config_false_case_insensitive():
         os.environ["CANDLE_WRITE_MARKET_STATE"] = "FALSE"
         import importlib
         import services.candles.config as cfg_mod
+
         importlib.reload(cfg_mod)
         assert cfg_mod.config.write_market_state is False
     finally:
@@ -140,6 +143,7 @@ def test_config_garbage_value_defaults_to_true():
         os.environ["CANDLE_WRITE_MARKET_STATE"] = "yes"
         import importlib
         import services.candles.config as cfg_mod
+
         importlib.reload(cfg_mod)
         assert cfg_mod.config.write_market_state is True
     finally:

--- a/tests/unit/candles/test_regime_lookup.py
+++ b/tests/unit/candles/test_regime_lookup.py
@@ -4,6 +4,7 @@ import os
 import time
 import pytest
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 # Set required env var before importing service
 os.environ.setdefault("CANDLE_INTERVAL_SECONDS", "60")
@@ -144,6 +145,59 @@ def test_regime_ts_in_future_returns_none():
     entries = [("1-0", {"symbol": "BTCUSDT", "regime": "TREND", "ts": str(future_s)})]
     service = _make_service_with_mock_redis(entries)
     assert service._lookup_regime_id("BTCUSDT") is None
+
+
+@pytest.mark.unit
+def test_regime_skips_future_entry_and_uses_current_valid_entry():
+    """Future regime entry must not mask a valid current-window TREND entry."""
+    now_s = int(time.time())
+    entries = [
+        ("2-0", {"symbol": "BTCUSDT", "regime": "HIGH_VOL_CHAOTIC", "ts": str(now_s + 100)}),
+        ("1-0", {"symbol": "BTCUSDT", "regime": "TREND", "ts": str(now_s - 10)}),
+    ]
+    service = _make_service_with_mock_redis(entries)
+
+    assert service._lookup_regime_id("BTCUSDT", as_of_ts_s=now_s) == 0
+
+
+@pytest.mark.unit
+def test_regime_skips_stale_entry_and_uses_current_valid_entry():
+    """Stale regime entry must not mask a valid current-window TREND entry."""
+    now_s = int(time.time())
+    entries = [
+        ("2-0", {"symbol": "BTCUSDT", "regime": "HIGH_VOL_CHAOTIC", "ts": str(now_s - 120)}),
+        ("1-0", {"symbol": "BTCUSDT", "regime": "TREND", "ts": str(now_s - 10)}),
+    ]
+    service = _make_service_with_mock_redis(entries)
+    original_staleness = service.config.regime_staleness_seconds
+    try:
+        service.config.regime_staleness_seconds = 30
+        assert service._lookup_regime_id("BTCUSDT", as_of_ts_s=now_s) == 0
+    finally:
+        service.config.regime_staleness_seconds = original_staleness
+
+
+@pytest.mark.unit
+def test_update_market_state_anchors_regime_lookup_to_candle_timestamp():
+    """Market-state enrichment must pass the candle timestamp into regime lookup."""
+    now_s = int(time.time())
+    candle_entries = [
+        ("6-0", {"symbol": "BTCUSDT", "close": "105.0", "ts": str(now_s - 60)}),
+        ("5-0", {"symbol": "BTCUSDT", "close": "104.0", "ts": str(now_s - 120)}),
+        ("4-0", {"symbol": "BTCUSDT", "close": "103.0", "ts": str(now_s - 180)}),
+        ("3-0", {"symbol": "BTCUSDT", "close": "102.0", "ts": str(now_s - 240)}),
+        ("2-0", {"symbol": "BTCUSDT", "close": "101.0", "ts": str(now_s - 300)}),
+        ("1-0", {"symbol": "BTCUSDT", "close": "100.0", "ts": str(now_s - 360)}),
+    ]
+    service = _make_service_with_mock_redis(candle_entries)
+    service.redis_client.setex = MagicMock()
+    service.aggregator.last_tick_ts_ms["BTCUSDT"] = now_s * 1000
+
+    with patch.object(service, "_lookup_regime_id", return_value=0) as lookup:
+        service._update_market_state("BTCUSDT", candle_ts_s=now_s)
+
+    lookup.assert_called_once_with("BTCUSDT", now_s)
+    service.redis_client.setex.assert_called_once()
 
 
 @pytest.mark.unit

--- a/tests/unit/candles/test_regime_lookup.py
+++ b/tests/unit/candles/test_regime_lookup.py
@@ -42,7 +42,12 @@ def test_regime_mapping_range():
 def test_regime_mapping_high_vol_chaotic():
     """HIGH_VOL_CHAOTIC → regime_id=2"""
     now_s = int(time.time())
-    entries = [("1-0", {"symbol": "BTCUSDT", "regime": "HIGH_VOL_CHAOTIC", "ts": str(now_s - 10)})]
+    entries = [
+        (
+            "1-0",
+            {"symbol": "BTCUSDT", "regime": "HIGH_VOL_CHAOTIC", "ts": str(now_s - 10)},
+        )
+    ]
     service = _make_service_with_mock_redis(entries)
     assert service._lookup_regime_id("BTCUSDT") == 2
 
@@ -51,7 +56,12 @@ def test_regime_mapping_high_vol_chaotic():
 def test_regime_mapping_high_vol_any_suffix():
     """HIGH_VOL_* (any suffix via startswith) → regime_id=2"""
     now_s = int(time.time())
-    entries = [("1-0", {"symbol": "BTCUSDT", "regime": "HIGH_VOL_WHATEVER", "ts": str(now_s - 10)})]
+    entries = [
+        (
+            "1-0",
+            {"symbol": "BTCUSDT", "regime": "HIGH_VOL_WHATEVER", "ts": str(now_s - 10)},
+        )
+    ]
     service = _make_service_with_mock_redis(entries)
     assert service._lookup_regime_id("BTCUSDT") == 2
 
@@ -60,7 +70,9 @@ def test_regime_mapping_high_vol_any_suffix():
 def test_regime_mapping_crisis():
     """CRISIS → regime_id=3"""
     now_s = int(time.time())
-    entries = [("1-0", {"symbol": "BTCUSDT", "regime": "CRISIS", "ts": str(now_s - 10)})]
+    entries = [
+        ("1-0", {"symbol": "BTCUSDT", "regime": "CRISIS", "ts": str(now_s - 10)})
+    ]
     service = _make_service_with_mock_redis(entries)
     assert service._lookup_regime_id("BTCUSDT") == 3
 
@@ -69,7 +81,9 @@ def test_regime_mapping_crisis():
 def test_regime_unknown_returns_none():
     """UNKNOWN regime string → None (fail-closed)"""
     now_s = int(time.time())
-    entries = [("1-0", {"symbol": "BTCUSDT", "regime": "UNKNOWN", "ts": str(now_s - 10)})]
+    entries = [
+        ("1-0", {"symbol": "BTCUSDT", "regime": "UNKNOWN", "ts": str(now_s - 10)})
+    ]
     service = _make_service_with_mock_redis(entries)
     assert service._lookup_regime_id("BTCUSDT") is None
 
@@ -152,7 +166,10 @@ def test_regime_skips_future_entry_and_uses_current_valid_entry():
     """Future regime entry must not mask a valid current-window TREND entry."""
     now_s = int(time.time())
     entries = [
-        ("2-0", {"symbol": "BTCUSDT", "regime": "HIGH_VOL_CHAOTIC", "ts": str(now_s + 100)}),
+        (
+            "2-0",
+            {"symbol": "BTCUSDT", "regime": "HIGH_VOL_CHAOTIC", "ts": str(now_s + 100)},
+        ),
         ("1-0", {"symbol": "BTCUSDT", "regime": "TREND", "ts": str(now_s - 10)}),
     ]
     service = _make_service_with_mock_redis(entries)
@@ -165,7 +182,10 @@ def test_regime_skips_stale_entry_and_uses_current_valid_entry():
     """Stale regime entry must not mask a valid current-window TREND entry."""
     now_s = int(time.time())
     entries = [
-        ("2-0", {"symbol": "BTCUSDT", "regime": "HIGH_VOL_CHAOTIC", "ts": str(now_s - 120)}),
+        (
+            "2-0",
+            {"symbol": "BTCUSDT", "regime": "HIGH_VOL_CHAOTIC", "ts": str(now_s - 120)},
+        ),
         ("1-0", {"symbol": "BTCUSDT", "regime": "TREND", "ts": str(now_s - 10)}),
     ]
     service = _make_service_with_mock_redis(entries)


### PR DESCRIPTION
## Summary
Minimal fail-closed fix for the RC_001 / regime lookup blocker observed in #2968.

## Delivered
- `CandleService._lookup_regime_id()` now skips future, out-of-range, and stale regime rows instead of letting them mask a valid current-window regime.
- `CandleService._update_market_state()` anchors regime lookup to the candle timestamp.
- Added targeted tests for future/stale masking and lookup anchoring.

## Evidence
- `tests/unit/candles/test_regime_lookup.py`
- `tests/unit/signal/test_breakout_v1_deterministic.py`

## Brain Evidence
- `brain_source: repo-only`
- `brain_status: not-used`
- `tools_or_queries`: repo reads, `git fetch/status`, `gh issue view`, targeted `pytest`
- `records_or_results`: 32 targeted tests green
- `repo_crosscheck`: `services/candles/service.py`, `tests/unit/candles/test_regime_lookup.py`
- `impact_on_plan`: no global RC_001 weakening; only invalid regime context is skipped
- `limitations`: no runtime execution, no DB mutation

## Validation
- `git diff --check`
- `pytest -q tests/unit/candles/test_regime_lookup.py tests/unit/signal/test_breakout_v1_deterministic.py`

## Non-goals
- No Live-Go
- No Echtgeld-Go
- No DB migration
- No exporter contract weakening
- No global RC_001 relaxation

## Safety Boundaries
- LR remains NO-GO
- No secrets emitted
- No runtime execution
- No DB mutation

Refs #2968
Refs #2969
Closes #3013
