### PR TITLE
fix(arvp): make runtime stimulus signal path deterministic

### DIFF
--- a/services/validation/paper_runtime_stimulus_runner.py
+++ b/services/validation/paper_runtime_stimulus_runner.py
@@ -64,6 +64,76 @@ def align_to_minute(ts_ms: int) -> int:
     return (ts_ms // ONE_MINUTE_MS) * ONE_MINUTE_MS
 
 
+def resolve_runtime_base_ts_ms(
+    spec: FixtureSpec,
+    *,
+    wall_clock_ms: int | None = None,
+    explicit_base_ms: int | None = None,
+    extra_offset_minutes: int = 0,
+) -> int:
+    """Anchor a runtime-relative series so the breakout candle lands on the current minute.
+
+    Without this offset, ``--runtime-relative`` would place warmup at wall-clock *now*
+    and push the breakout ~warmup_count minutes into the future, which breaks regime
+    lookup anchoring and mixes poorly with live ``market_data``.
+    """
+    if explicit_base_ms is not None:
+        base = align_to_minute(explicit_base_ms)
+    else:
+        now_ms = wall_clock_ms if wall_clock_ms is not None else int(time.time() * 1000)
+        base = align_to_minute(now_ms) - spec.warmup_count * spec.cadence_ms
+    if extra_offset_minutes > 0:
+        base -= extra_offset_minutes * ONE_MINUTE_MS
+    return base
+
+
+def _fetch_market_close_from_redis(symbol: str) -> float | None:
+    """Best-effort read of ``close_now`` from market_state for price anchoring."""
+    try:
+        import redis as _redis
+
+        client = _redis.Redis(
+            host=os.getenv("REDIS_HOST", "redis"),
+            port=int(os.getenv("REDIS_PORT", "6379")),
+            password=os.getenv("REDIS_PASSWORD"),
+            db=int(os.getenv("REDIS_DB", "0")),
+            decode_responses=True,
+            socket_connect_timeout=2,
+        )
+        client.ping()
+        for prefix in ("market_state", "market_state_shadow"):
+            raw = client.get(f"{prefix}:{symbol}")
+            if not raw:
+                continue
+            parsed = json.loads(raw)
+            if not isinstance(parsed, dict):
+                continue
+            for key in ("close_now", "close"):
+                value = parsed.get(key)
+                if value is None or value == "":
+                    continue
+                close = float(value)
+                if close > 0:
+                    return close
+    except Exception:
+        return None
+    return None
+
+
+def resolve_runtime_warmup_base_price(
+    spec: FixtureSpec,
+    *,
+    explicit_base_price: float | None = None,
+    market_close: float | None = None,
+) -> float:
+    """Choose a warmup start price that ends near the live market close when possible."""
+    if explicit_base_price is not None and explicit_base_price > 0:
+        return explicit_base_price
+    if market_close is not None and market_close > 0:
+        return market_close - (spec.warmup_count - 1) * spec.warmup_price_step
+    return spec.warmup_base_price
+
+
 REQUIRED_SAFETY_ENV = {
     "MOCK_TRADING": "true",
     "DRY_RUN": "true",
@@ -227,6 +297,7 @@ def generate_fixture_candles(
     spec: FixtureSpec,
     *,
     base_ts_ms_override: int | None = None,
+    warmup_base_price_override: float | None = None,
     stimulus_run_id: str | None = None,
 ) -> list[dict[str, Any]]:
     candles: list[dict[str, Any]] = []
@@ -235,10 +306,15 @@ def generate_fixture_candles(
         if base_ts_ms_override is not None
         else spec.warmup_base_ts_ms
     )
+    warmup_base_price = (
+        warmup_base_price_override
+        if warmup_base_price_override is not None
+        else spec.warmup_base_price
+    )
 
     for i in range(spec.warmup_count):
         ts_ms = base_ts + i * spec.cadence_ms
-        price = spec.warmup_base_price + i * spec.warmup_price_step
+        price = warmup_base_price + i * spec.warmup_price_step
         candle = {
             "symbol": spec.symbol,
             "ts_ms": ts_ms,
@@ -259,14 +335,11 @@ def generate_fixture_candles(
         candles.append(candle)
 
     warmup_end_ts_ms = base_ts + spec.warmup_count * spec.cadence_ms
-    highest_high = (
-        spec.warmup_base_price + (spec.warmup_count - 1) * spec.warmup_price_step
-    )
+    highest_high = warmup_base_price + (spec.warmup_count - 1) * spec.warmup_price_step
     breakout_threshold = highest_high * (1 + spec.breakout_buffer)
-    breakout_close = highest_high * (1 + spec.breakout_close_premium_pct / 100.0)
-
-    if breakout_close <= breakout_threshold:
-        breakout_close = breakout_threshold + 1.0
+    # Minimal lift above threshold: preserves breakout fires=true while keeping ATR
+    # near the warmup cadence (large premium spikes classify HIGH_VOL_CHAOTIC).
+    breakout_close = breakout_threshold + spec.warmup_price_step
 
     breakout_candle = {
         "symbol": spec.symbol,
@@ -331,9 +404,8 @@ def fixture_summary(
     warmup_start = candles[0]["ts_ms"]
     warmup_end = candles[-2]["ts_ms"] if len(candles) > 1 else candles[0]["ts_ms"]
     breakout_ts = candles[-1]["ts_ms"]
-    highest_high = (
-        spec.warmup_base_price + (spec.warmup_count - 1) * spec.warmup_price_step
-    )
+    warmup_base = candles[0]["close"]
+    highest_high = warmup_base + (spec.warmup_count - 1) * spec.warmup_price_step
     breakout_threshold = highest_high * (1 + spec.breakout_buffer)
     breakout_close = candles[-1]["close"]
     mode = "runtime-relative" if runtime_relative else "static-historical"
@@ -552,8 +624,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=int,
         default=0,
         help=(
-            "Shift the runtime-relative base backward by this many minutes "
-            "(default: 0, meaning warmup starts at base_ts_ms)."
+            "Additional backward shift (minutes) applied after the runtime-relative "
+            "warmup anchor. Default 0: breakout candle aligns to the current minute."
+        ),
+    )
+    parser.add_argument(
+        "--base-price",
+        type=float,
+        default=None,
+        help=(
+            "Override warmup start price. When omitted in --runtime-relative mode, "
+            "the runner tries market_state close_now before falling back to the fixture."
         ),
     )
     return parser.parse_args(argv)
@@ -583,14 +664,20 @@ def main(argv: list[str] | None = None) -> int:
         return 3
 
     base_ts_ms_override: int | None = None
+    warmup_base_price_override: float | None = None
     runtime_relative = args.runtime_relative
     if runtime_relative:
-        if args.base_ts_ms is not None:
-            base_ts_ms_override = align_to_minute(args.base_ts_ms)
-        else:
-            base_ts_ms_override = align_to_minute(int(time.time() * 1000))
-        if args.start_offset_minutes > 0:
-            base_ts_ms_override -= args.start_offset_minutes * ONE_MINUTE_MS
+        base_ts_ms_override = resolve_runtime_base_ts_ms(
+            spec,
+            explicit_base_ms=args.base_ts_ms,
+            extra_offset_minutes=args.start_offset_minutes,
+        )
+        market_close = _fetch_market_close_from_redis(spec.symbol)
+        warmup_base_price_override = resolve_runtime_warmup_base_price(
+            spec,
+            explicit_base_price=args.base_price,
+            market_close=market_close,
+        )
 
     run_id = compute_stimulus_run_id(
         (
@@ -605,6 +692,7 @@ def main(argv: list[str] | None = None) -> int:
     candles = generate_fixture_candles(
         spec,
         base_ts_ms_override=base_ts_ms_override,
+        warmup_base_price_override=warmup_base_price_override,
         stimulus_run_id=run_id,
     )
 

--- a/tests/fixtures/arvp/paper_runtime_stimulus_btcusdt_breakout_v1.json
+++ b/tests/fixtures/arvp/paper_runtime_stimulus_btcusdt_breakout_v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "paper_runtime_stimulus_fixture_v1",
-  "description": "Compact specification for generating a deterministic BTCUSDT 1m candle series that triggers primary_breakout_v1. The runner expands this into a full candle sequence. Warmup: N candles with steady +1.0 price increase per minute. Breakout: 1 candle where close > highest_high * (1 + breakout_buffer). regime_id=TREND, market_state_fresh=true, regime_fresh=true. Designed to produce exactly one BUY signal without PAPER_EVIDENCE_PROBE_MODE.",
+  "description": "Compact specification for generating a deterministic BTCUSDT 1m candle series that triggers primary_breakout_v1. The runner expands this into a full candle sequence. Warmup: N candles with steady +1.0 price increase per minute. Breakout: 1 candle where close clears highest_high * (1 + breakout_buffer) by one warmup_price_step (minimal ATR spike). In --runtime-relative mode the runner anchors warmup to market_state close_now when available. regime_id=TREND, market_state_fresh=true, regime_fresh=true. Designed to produce exactly one BUY signal without PAPER_EVIDENCE_PROBE_MODE.",
   "strategy_id": "primary_breakout_v1",
   "symbol": "BTCUSDT",
   "cadence_ms": 60000,

--- a/tests/unit/validation/test_paper_runtime_stimulus_runner.py
+++ b/tests/unit/validation/test_paper_runtime_stimulus_runner.py
@@ -26,6 +26,7 @@ from services.validation.paper_runtime_stimulus_runner import (
     fixture_summary,
     generate_fixture_candles,
     load_fixture_spec,
+    resolve_runtime_base_ts_ms,
     run_preview,
     run_publish,
     run_safety_preflight,
@@ -394,6 +395,13 @@ class TestRuntimeRelativeMode:
             fixture_spec, base_ts_ms_override=custom_base
         )
         assert candles[0]["ts_ms"] == custom_base
+
+    def test_runtime_relative_anchor_places_breakout_on_wall_clock(self, fixture_spec):
+        wall = align_to_minute(1_800_000_000_000)
+        base = resolve_runtime_base_ts_ms(fixture_spec, wall_clock_ms=wall)
+        candles = generate_fixture_candles(fixture_spec, base_ts_ms_override=base)
+        assert candles[-1]["ts_ms"] == wall
+        assert candles[0]["ts_ms"] == wall - fixture_spec.warmup_count * ONE_MINUTE_MS
 
     def test_runtime_relative_preserves_1m_cadence(self, fixture_spec):
         custom_base = 1_800_000_000_000

--- a/tests/unit/validation/test_stimulus_regime_signal_contract.py
+++ b/tests/unit/validation/test_stimulus_regime_signal_contract.py
@@ -149,9 +149,9 @@ def test_fixture_breakout_keeps_regime_trend_not_high_vol():
         warmup_base_price_override=start,
     )
     current, last_raw, atr = _simulate_regime_state_machine(candles)
-    assert current == "TREND", (
-        f"confirmed regime must stay TREND (current={current}, last_raw={last_raw}, atr={atr})"
-    )
+    assert (
+        current == "TREND"
+    ), f"confirmed regime must stay TREND (current={current}, last_raw={last_raw}, atr={atr})"
 
 
 @pytest.mark.unit

--- a/tests/unit/validation/test_stimulus_regime_signal_contract.py
+++ b/tests/unit/validation/test_stimulus_regime_signal_contract.py
@@ -1,0 +1,195 @@
+"""ARVP stimulus fixture contract: regime TREND + breakout signal path (#3015)."""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from services.regime.models import Candle, compute_adx, compute_atr
+from services.validation.paper_runtime_stimulus_runner import (
+    DEFAULT_FIXTURE_PATH,
+    ONE_MINUTE_MS,
+    align_to_minute,
+    generate_fixture_candles,
+    load_fixture_spec,
+    resolve_runtime_base_ts_ms,
+    resolve_runtime_warmup_base_price,
+    to_market_data_payload,
+)
+
+_services_signal = Path(__file__).resolve().parents[3] / "services" / "signal"
+if str(_services_signal) not in sys.path:
+    sys.path.insert(0, str(_services_signal))
+
+from config import SignalConfig  # noqa: E402
+from service import SignalEngine  # noqa: E402
+
+
+def _simulate_regime_state_machine(
+    candles: list[dict],
+    *,
+    atr_high_vol_threshold: float = 2.0,
+    adx_trend_threshold: float = 25.0,
+    adx_range_threshold: float = 20.0,
+    confirmation_bars: int = 3,
+    period: int = 14,
+) -> tuple[str, str, float]:
+    """Mirror ``RegimeService._derive_regime`` confirmation semantics."""
+    bucket: list[Candle] = []
+    current = "UNKNOWN"
+    candidate: str | None = None
+    candidate_count = 0
+    last_raw = "UNKNOWN"
+    last_atr = 0.0
+    for candle in candles:
+        bucket.append(
+            Candle(
+                ts=int(candle["ts_ms"] // 1000),
+                symbol=candle["symbol"],
+                timeframe="60s",
+                open=float(candle["open"]),
+                high=float(candle["high"]),
+                low=float(candle["low"]),
+                close=float(candle["close"]),
+                volume=float(candle["volume"]),
+            )
+        )
+        adx = compute_adx(bucket, period)
+        atr = compute_atr(bucket, period)
+        if adx is None or atr is None:
+            continue
+        last_atr = atr
+        if atr >= atr_high_vol_threshold:
+            raw_regime = "HIGH_VOL_CHAOTIC"
+        elif adx >= adx_trend_threshold:
+            raw_regime = "TREND"
+        elif adx <= adx_range_threshold:
+            raw_regime = "RANGE"
+        else:
+            raw_regime = current
+        last_raw = raw_regime
+        if raw_regime == current:
+            candidate = None
+            candidate_count = 0
+            continue
+        if candidate != raw_regime:
+            candidate = raw_regime
+            candidate_count = 1
+        else:
+            candidate_count += 1
+        if candidate_count >= confirmation_bars:
+            current = raw_regime
+            candidate = None
+            candidate_count = 0
+    return current, last_raw, last_atr
+
+
+def _make_breakout_engine() -> SignalEngine:
+    config = SignalConfig(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        entry_lookback_minutes=240,
+        exit_lookback_minutes=120,
+        breakout_buffer=0.0005,
+        min_minutes_between_entries=60,
+        trade_side_mode="long_only",
+        market_state_staleness_s=300,
+    )
+    engine = SignalEngine.__new__(SignalEngine)
+    engine.config = config
+    engine.redis_client = None
+    engine._high_history = __import__("collections").defaultdict(list)
+    engine._low_history = __import__("collections").defaultdict(list)
+    engine._last_entry_ts_ms = {}
+    engine._position_open_by_symbol = __import__("collections").defaultdict(bool)
+    engine.price_buffer = __import__(
+        "services.signal.price_buffer", fromlist=["PriceBuffer"]
+    ).PriceBuffer()
+    from core.contracts.external_adapter_registry import build_strategy_adapter
+
+    engine.strategy_adapter = build_strategy_adapter(
+        None, evaluate_fn=engine._evaluate_builtin_strategy
+    )
+    return engine
+
+
+@pytest.mark.unit
+def test_runtime_relative_anchors_breakout_to_current_minute():
+    spec = load_fixture_spec(DEFAULT_FIXTURE_PATH)
+    now_ms = align_to_minute(int(time.time() * 1000))
+    base_ts = resolve_runtime_base_ts_ms(spec, wall_clock_ms=now_ms)
+    candles = generate_fixture_candles(spec, base_ts_ms_override=base_ts)
+    assert candles[-1]["ts_ms"] == now_ms
+    assert candles[0]["ts_ms"] == now_ms - spec.warmup_count * ONE_MINUTE_MS
+
+
+@pytest.mark.unit
+def test_runtime_warmup_base_price_anchors_to_market_close():
+    spec = load_fixture_spec(DEFAULT_FIXTURE_PATH)
+    market_close = 60_123.45
+    start = resolve_runtime_warmup_base_price(spec, market_close=market_close)
+    candles = generate_fixture_candles(spec, warmup_base_price_override=start)
+    highest = candles[-2]["close"]
+    assert highest == pytest.approx(market_close, rel=0, abs=spec.warmup_price_step)
+
+
+@pytest.mark.unit
+def test_fixture_breakout_keeps_regime_trend_not_high_vol():
+    spec = load_fixture_spec(DEFAULT_FIXTURE_PATH)
+    market_close = 60_000.0
+    start = resolve_runtime_warmup_base_price(spec, market_close=market_close)
+    now_ms = align_to_minute(int(time.time() * 1000))
+    base_ts = resolve_runtime_base_ts_ms(spec, wall_clock_ms=now_ms)
+    candles = generate_fixture_candles(
+        spec,
+        base_ts_ms_override=base_ts,
+        warmup_base_price_override=start,
+    )
+    current, last_raw, atr = _simulate_regime_state_machine(candles)
+    assert current == "TREND", (
+        f"confirmed regime must stay TREND (current={current}, last_raw={last_raw}, atr={atr})"
+    )
+
+
+@pytest.mark.unit
+def test_legacy_premium_spike_would_classify_high_vol():
+    """Documents the pre-#3015 failure mode: large breakout premium spikes ATR."""
+    spec = load_fixture_spec(DEFAULT_FIXTURE_PATH)
+    candles = generate_fixture_candles(spec)
+    highest = candles[-2]["close"]
+    threshold = highest * (1 + spec.breakout_buffer)
+    spike_close = highest * (1 + spec.breakout_close_premium_pct / 100.0)
+    for idx in range(-3, 0):
+        candles[idx]["close"] = spike_close
+        candles[idx]["high"] = spike_close
+    current, last_raw, atr = _simulate_regime_state_machine(candles)
+    assert last_raw == "HIGH_VOL_CHAOTIC"
+    assert current == "HIGH_VOL_CHAOTIC"
+    assert atr >= 2.0
+    assert spike_close > threshold
+
+
+@pytest.mark.unit
+def test_stimulus_fixture_sequence_emits_breakout_buy_signal():
+    spec = load_fixture_spec(DEFAULT_FIXTURE_PATH)
+    market_close = 60_000.0
+    start = resolve_runtime_warmup_base_price(spec, market_close=market_close)
+    now_ms = align_to_minute(int(time.time() * 1000))
+    base_ts = resolve_runtime_base_ts_ms(spec, wall_clock_ms=now_ms)
+    candles = generate_fixture_candles(
+        spec,
+        base_ts_ms_override=base_ts,
+        warmup_base_price_override=start,
+        stimulus_run_id="contract-test",
+    )
+    engine = _make_breakout_engine()
+    signal = None
+    for candle in candles:
+        payload = to_market_data_payload(candle)
+        signal = engine.process_market_data(payload)
+    assert signal is not None
+    assert signal.side == "BUY"
+    assert signal.reason == "breakout_entry"


### PR DESCRIPTION
## Summary
- Anchors `--runtime-relative` stimulus so the breakout candle lands on the current minute (warmup in the past), not ~244 minutes in the future.
- Optionally anchors warmup prices to `market_state` `close_now` (or `--base-price`) to avoid fixture/live price mixing that sustained `HIGH_VOL_CHAOTIC`.
- Uses minimal breakout close lift (threshold + one warmup step) instead of `close_premium_pct` spike; adds contract tests for regime confirmation + BUY signal.

Closes #3015
Refs #2968
Refs #2969
Refs #3013

## Root Cause
- **FIXTURE_SHAPE_RISK_OFF_BY_DESIGN** (partial): large `breakout_close_premium_pct` spike + price mismatch vs live WS sustained `HIGH_VOL_CHAOTIC` after confirmation.
- **REGIME_RECLASSIFICATION_TIMING_GAP**: `--runtime-relative` previously anchored warmup at *now*, pushing breakout into the future.
- **MARKET_STATE_PROPAGATION_GAP** (secondary): fixture ~100k vs live ~60k mixed in `stream.candles_1m`.

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- Evidence: unit contract tests + regime state-machine simulation mirroring `confirmation_bars=3`.

## Delivered
- `resolve_runtime_base_ts_ms` / `resolve_runtime_warmup_base_price` helpers
- `--base-price` CLI flag; Redis `market_state` close anchor in runtime-relative mode
- `test_stimulus_regime_signal_contract.py` (5 tests)

## Validation
- `pytest -q tests/unit/candles tests/unit/regime tests/unit/signal tests/unit/validation -k "stimulus or regime or market_state or high_vol or candle or runtime_relative"` → 107 passed

## Test plan
- [x] Unit contract tests for runtime anchor, market close anchor, regime confirmation, legacy spike reproducer, BUY signal
- [x] Existing stimulus runner tests still pass

## Non-goals
- No global weakening of `HIGH_VOL_CHAOTIC` / risk_off
- No Docker/runtime execution in this PR
- No strategy logic changes

## Safety Boundaries
- LR remains NO-GO; shadow/paper only
- No DB/MCP/runtime mutations

## Restunsicherheiten
- Full SIGNAL→DECISION→ORDER→FILL chain on live stack requires #2968 human-gated runtime retry after merge.
