### PR TITLE
fix(arvp): trigger signal path after runtime stimulus breakout

### DIFF
--- a/services/market/service.py
+++ b/services/market/service.py
@@ -122,6 +122,8 @@ def _process_message(raw: str) -> None:
         MESSAGES_INVALID.inc()
         return
 
+    tick_source = data.get("source")
+
     try:
         sanitized = sanitize_market_data(data)
     except ValueError as exc:
@@ -156,7 +158,12 @@ def _process_message(raw: str) -> None:
             )
         except redis.RedisError as exc:
             logger.warning("Redis write failed for %s: %s", key, exc)
-        _update_market_state(key, entry["ts_ms"], _redis_client)
+        _update_market_state(
+            key,
+            entry["ts_ms"],
+            _redis_client,
+            tick_source=tick_source,
+        )
 
 
 # ─── Market State V1 ─────────────────────────────────────────────────────────
@@ -165,54 +172,77 @@ def _process_message(raw: str) -> None:
 # No creative reinterpretation — any behavior change here is a bug.
 
 
-def _lookup_regime_id(symbol: str, redis_client: redis.Redis) -> "int | None":
+def _lookup_regime_id(
+    symbol: str,
+    redis_client: redis.Redis,
+    as_of_ts_s: int | None = None,
+) -> "int | None":
     """Lookup regime_id from stream.regime_signals (deterministic mapping).
 
     Mapping (identical to cdb_candles):
     - TREND → 0, RANGE → 1, HIGH_VOL_* → 2, CRISIS → 3
     - missing / stale / invalid → None (fail-closed: RC_001 blocks)
+
+    Selection rule (Issue #3014 parity):
+    - Prefer the newest valid regime entry at or before ``as_of_ts_s`` when
+      provided (the candle timestamp being enriched).
+    - Future, out-of-range, and stale entries are skipped.
     """
     try:
         raw_entries = redis_client.xrevrange(MARKET_REGIME_STREAM, "+", "-", count=50)
 
+        lookup_ts_s = int(time.time()) if as_of_ts_s is None else int(as_of_ts_s)
+
         regime_entry = None
         for _entry_id, payload in raw_entries:
-            if payload.get("symbol") == symbol:
-                regime_entry = payload
-                break
+            if payload.get("symbol") != symbol:
+                continue
+
+            ts_raw = payload.get("ts")
+            if ts_raw is None:
+                logger.debug("regime_id skip: %s ts missing", symbol)
+                continue
+            try:
+                regime_ts = int(ts_raw)
+            except (ValueError, TypeError):
+                logger.debug("regime_id skip: %s ts not parseable", symbol)
+                continue
+
+            if regime_ts < 1_000_000_000 or regime_ts > 4_000_000_000:
+                logger.debug("regime_id skip: %s ts out of range %d", symbol, regime_ts)
+                continue
+
+            age = lookup_ts_s - regime_ts
+            if age < 0:
+                logger.debug("regime_id skip: %s ts in future", symbol)
+                continue
+            if age > MARKET_REGIME_STALENESS_SECONDS:
+                logger.debug(
+                    "regime_id skip: %s signal stale (%ds old, max %ds)",
+                    symbol,
+                    age,
+                    MARKET_REGIME_STALENESS_SECONDS,
+                )
+                continue
+
+            regime_entry = payload
+            break
 
         if regime_entry is None:
-            return None
-
-        ts_raw = regime_entry.get("ts")
-        if ts_raw is None:
-            return None
-        try:
-            regime_ts = int(ts_raw)
-        except (ValueError, TypeError):
-            return None
-
-        if regime_ts < 1_000_000_000 or regime_ts > 4_000_000_000:
-            return None
-
-        now_s = int(time.time())
-        age = now_s - regime_ts
-        if age < 0:
-            return None
-        if age > MARKET_REGIME_STALENESS_SECONDS:
+            logger.debug("regime_id skip: %s no signal found", symbol)
             return None
 
         regime_str = (regime_entry.get("regime") or "").upper()
         if regime_str == "TREND":
             return 0
-        elif regime_str == "RANGE":
+        if regime_str == "RANGE":
             return 1
-        elif regime_str.startswith("HIGH_VOL"):
+        if regime_str.startswith("HIGH_VOL"):
             return 2
-        elif regime_str == "CRISIS":
+        if regime_str == "CRISIS":
             return 3
-        else:
-            return None
+        logger.debug("regime_id skip: %s unknown regime '%s'", symbol, regime_str)
+        return None
 
     except Exception as exc:
         logger.warning("regime_id error for %s: %s", symbol, exc)
@@ -220,7 +250,11 @@ def _lookup_regime_id(symbol: str, redis_client: redis.Redis) -> "int | None":
 
 
 def _update_market_state(
-    symbol: str, last_tick_ts_ms: "int | None", redis_client: redis.Redis
+    symbol: str,
+    last_tick_ts_ms: "int | None",
+    redis_client: redis.Redis,
+    *,
+    tick_source: str | None = None,
 ) -> None:
     """Compute market_state V1 from candle history and persist to Redis.
 
@@ -270,9 +304,22 @@ def _update_market_state(
         return_5m = ((close_now - close_5m_ago) / close_5m_ago) * 100.0
         price_change_5m = abs(return_5m)
 
-        regime_id = _lookup_regime_id(symbol, redis_client)
+        candle_ts_s: int | None = None
+        ts_raw = candles[0].get("ts")
+        if ts_raw is not None:
+            try:
+                candle_ts_s = int(ts_raw)
+            except (TypeError, ValueError):
+                candle_ts_s = None
+
+        regime_id = _lookup_regime_id(symbol, redis_client, as_of_ts_s=candle_ts_s)
 
         ts_ms = int(time.time() * 1000)
+        effective_last_tick_ts_ms = last_tick_ts_ms
+        if tick_source == "stimulus_fixture":
+            # Runtime-relative fixture ticks carry historical ts_ms; RC_004 uses wall now.
+            effective_last_tick_ts_ms = ts_ms
+
         market_state = {
             "symbol": symbol,
             "return_1m": return_1m,
@@ -282,7 +329,7 @@ def _update_market_state(
             "close_now": close_now,
             "close_1m_ago": close_1m_ago,
             "close_5m_ago": close_5m_ago,
-            "last_tick_ts_ms": last_tick_ts_ms,
+            "last_tick_ts_ms": effective_last_tick_ts_ms,
         }
         if regime_id is not None:
             market_state["regime_id"] = regime_id

--- a/services/validation/paper_runtime_stimulus_runner.py
+++ b/services/validation/paper_runtime_stimulus_runner.py
@@ -47,6 +47,19 @@ DEFAULT_FIXTURE_PATH = Path(__file__).resolve().parent.parent.parent / (
 ONE_MINUTE_MS = 60_000
 
 
+def _wait_for_breakout_candle_sweep(
+    breakout_ts_s: int,
+    *,
+    interval_s: int = 60,
+    pad_s: float = 2.0,
+) -> float:
+    """Block until cdb_candles sweep can emit the breakout OHLCV window."""
+    wait_s = max(0.0, breakout_ts_s + interval_s - time.time()) + pad_s
+    if wait_s > 0:
+        time.sleep(wait_s)
+    return wait_s
+
+
 def compute_stimulus_run_id(
     base_ts_ms: int, fixture_path: Path, runtime_relative: bool
 ) -> str:
@@ -523,6 +536,12 @@ def run_publish(
     logger.info(summary)
 
     published = 0
+    expected_events = len(payloads) + (1 if runtime_relative else 0)
+    follow_up_tick_published = False
+    follow_up_tick_ts_ms: int | None = None
+    follow_up_tick_price: float | None = None
+    sweep_wait_s = 0.0
+
     for i, payload in enumerate(payloads):
         message = json.dumps(payload)
         try:
@@ -535,10 +554,33 @@ def run_publish(
         if delay_seconds > 0 and i < len(payloads) - 1:
             time.sleep(delay_seconds)
 
+    if runtime_relative and published == len(payloads):
+        breakout_ts_s = int(candles[-1]["ts_ms"] // 1000)
+        sweep_wait_s = _wait_for_breakout_candle_sweep(
+            breakout_ts_s, interval_s=spec.cadence_ms // 1000
+        )
+        follow_up_payload = to_market_data_payload(candles[-1])
+        follow_up_tick_ts_ms = int(time.time() * 1000)
+        follow_up_payload["ts_ms"] = follow_up_tick_ts_ms
+        if stimulus_run_id is not None:
+            follow_up_payload["stimulus_run_id"] = stimulus_run_id
+        try:
+            publisher.publish("market_data", json.dumps(follow_up_payload))
+            published += 1
+            follow_up_tick_published = True
+            follow_up_tick_price = float(candles[-1]["close"])
+        except Exception as exc:
+            logger.error("Failed to publish follow-up tick: %s", exc)
+
     lines = [
         summary,
         f"=== Publish Result ===",
-        f"  published: {published}/{len(payloads)} market_data events",
+        f"  published: {published}/{expected_events} market_data events",
+        f"  burst_published: {published - (1 if follow_up_tick_published else 0)}/{len(payloads)}",
+        f"  follow_up_tick_published: {follow_up_tick_published}",
+        f"  follow_up_tick_ts_ms: {follow_up_tick_ts_ms}",
+        f"  follow_up_tick_price: {follow_up_tick_price}",
+        f"  sweep_wait_s: {sweep_wait_s:.1f}",
         f"  stop_after_complete_chain: {stop_after_complete_chain}",
         f"  max_wait_seconds: {max_wait_seconds}",
         f"  LR status: {LR_STATUS}",

--- a/tests/unit/market/test_market_state.py
+++ b/tests/unit/market/test_market_state.py
@@ -245,6 +245,56 @@ def test_regime_id_absent_when_no_regime_signal():
     assert "regime_id" not in payload
 
 
+@pytest.mark.unit
+def test_regime_lookup_skips_future_entry_with_candle_anchor():
+    """Future regime entry must not mask a valid entry at candle timestamp."""
+    now_s = int(time.time())
+    regime_entries = [
+        (
+            "2-0",
+            {"symbol": "BTCUSDT", "regime": "HIGH_VOL_CHAOTIC", "ts": str(now_s + 100)},
+        ),
+        ("1-0", {"symbol": "BTCUSDT", "regime": "TREND", "ts": str(now_s - 10)}),
+    ]
+    mock_redis = _make_mock_redis([], regime_entries)
+    assert svc._lookup_regime_id("BTCUSDT", mock_redis, as_of_ts_s=now_s) == 0
+
+
+@pytest.mark.unit
+def test_stimulus_fixture_last_tick_always_wall_clock():
+    """stimulus_fixture ticks always map last_tick_ts_ms to wall clock for RC_004."""
+    closes = [110.0, 100.0, 99.0, 98.0, 97.0, 50.0]
+    mock_redis = _make_mock_redis(_candle_entries("BTCUSDT", closes), [])
+    historical_ts = int(time.time() * 1000) - 300_000
+
+    before_ms = int(time.time() * 1000)
+    svc._update_market_state(
+        "BTCUSDT",
+        historical_ts,
+        mock_redis,
+        tick_source="stimulus_fixture",
+    )
+    after_ms = int(time.time() * 1000)
+
+    payload = json.loads(mock_redis.setex.call_args[0][2])
+    assert before_ms <= payload["last_tick_ts_ms"] <= after_ms
+
+
+@pytest.mark.unit
+def test_regime_lookup_skips_stale_entry_with_candle_anchor():
+    """Stale regime entry must not mask a fresher valid entry at candle timestamp."""
+    now_s = int(time.time())
+    regime_entries = [
+        (
+            "2-0",
+            {"symbol": "BTCUSDT", "regime": "HIGH_VOL_CHAOTIC", "ts": str(now_s - 400)},
+        ),
+        ("1-0", {"symbol": "BTCUSDT", "regime": "TREND", "ts": str(now_s - 10)}),
+    ]
+    mock_redis = _make_mock_redis([], regime_entries)
+    assert svc._lookup_regime_id("BTCUSDT", mock_redis, as_of_ts_s=now_s) == 0
+
+
 # ─── TTL and key format ───────────────────────────────────────────────────────
 
 

--- a/tests/unit/validation/test_paper_runtime_stimulus_runner.py
+++ b/tests/unit/validation/test_paper_runtime_stimulus_runner.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -321,6 +322,40 @@ class TestPublishMode:
         assert "password" not in lower
         assert "token" not in lower
 
+    def test_runtime_relative_burst_keeps_native_ts_then_follow_up_tick(
+        self, fixture_spec, monkeypatch
+    ):
+        """Burst keeps fixture ts_ms; follow-up tick uses wall clock after sweep."""
+        sleeps: list[float] = []
+        monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
+        base_ts = align_to_minute(int(time.time() * 1000)) - (
+            fixture_spec.warmup_count * ONE_MINUTE_MS
+        )
+        candles = generate_fixture_candles(fixture_spec, base_ts_ms_override=base_ts)
+        mock_publisher = MagicMock(spec=StimulusPublisher)
+        mock_publisher.publish.return_value = 1
+        before_ms = int(time.time() * 1000)
+
+        output = run_publish(
+            candles,
+            fixture_spec,
+            mock_publisher,
+            delay_seconds=0,
+            runtime_relative=True,
+        )
+
+        after_ms = int(time.time() * 1000)
+        assert mock_publisher.publish.call_count == len(candles) + 1
+        burst_last = json.loads(mock_publisher.publish.call_args_list[-2][0][1])
+        follow_up = json.loads(mock_publisher.publish.call_args_list[-1][0][1])
+        assert burst_last["ts_ms"] == candles[-1]["ts_ms"]
+        assert before_ms <= follow_up["ts_ms"] <= after_ms + 5000
+        assert follow_up["price"] == str(candles[-1]["close"])
+        assert follow_up["close"] == candles[-1]["close"]
+        assert "published: 246/246 market_data events" in output
+        assert "follow_up_tick_published: True" in output
+        assert sleeps  # sweep wait invoked
+
 
 class TestFixtureFileRoundTrip:
     def test_default_fixture_file_loads(self):
@@ -493,7 +528,8 @@ class TestRuntimeRelativeMode:
         assert run_id in output
         assert "Preview Mode" in output
 
-    def test_publish_with_runtime_relative_shows_mode(self, fixture_spec):
+    def test_publish_with_runtime_relative_shows_mode(self, fixture_spec, monkeypatch):
+        monkeypatch.setattr(time, "sleep", lambda _s: None)
         run_id = "test_run_id_5678"
         candles = generate_fixture_candles(
             fixture_spec, base_ts_ms_override=1_800_000_000_000, stimulus_run_id=run_id


### PR DESCRIPTION
Closes #3018
Refs #2968
Refs #2969

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- tools_or_queries: git/gh live checks, canonical read order, targeted pytest, diff checks
- records_or_results: HEAD/origin main c17106c6 at session start; issues #3018/#2968/#2969 OPEN; no open PRs before this PR
- repo_crosscheck: AGENTS.md, agents/AGENTS.md, CONTROL_REGISTER.md, LR-AUDIT-STATUS-2026-03-05.md, services/market/service.py, services/validation/paper_runtime_stimulus_runner.py
- impact_on_plan: kept fix repo-only; no DB-backed memory claims; runtime evidence to be collected only after merge/redeploy
- limitations: no SurrealDB/DB-backed Context Brain used; runtime retry still required after required checks/merge

## RCA
Previous #2968 retry produced a BUY path but no comparison-grade DB chain. Runtime evidence showed cdb_market owned market_state and lacked #3014-style candle-timestamp regime lookup, while runtime-relative fixture ticks could leave last_tick_ts_ms stale for RC_004. After the burst, the signal/risk/db chain also needed a deterministic post-breakout tick after candle finalization.

## Changes
- Port #3014-style regime lookup semantics to cdb_market: select newest valid regime at or before the candle timestamp; skip future, stale, malformed, and out-of-range entries.
- Keep normal market tick timestamp semantics unchanged; only stimulus_fixture market_state writes align last_tick_ts_ms to wall clock for RC_004 freshness.
- Add a runtime-relative follow-up market_data tick after the breakout burst and candle sweep wait.
- Keep follow-up tick price at breakout close to avoid artificial volatility.

## Validation
- pytest -q tests/unit/validation/test_paper_runtime_stimulus_runner.py -> 62 passed
- pytest -q tests/unit/validation/test_stimulus_regime_signal_contract.py -> 5 passed
- pytest -q tests/unit/candles/test_regime_lookup.py -> 20 passed
- pytest -q tests/unit/market/test_market_state.py -> 16 passed
- git diff --check -> pass
- black --check scoped files -> pass

## Safety Boundaries
- LR remains NO-GO.
- No Live-Go / Echtgeld-Go.
- No real exchange orders.
- No DB/schema/exporter contract changes.
- No risk/regime policy weakening; no regime heartbeat injection or payload-regime fallback retained.
- No secrets or DSNs in output.