### PR TITLE
fix(candles): preserve stimulus freshness for rc004

### DIFF
--- a/services/candles/models.py
+++ b/services/candles/models.py
@@ -74,6 +74,8 @@ class CandleAggregator:
         self.windows: dict[str, CandleWindow] = {}
         # Track last tick timestamp per symbol (monotonic, ms)
         self.last_tick_ts_ms: dict[str, int] = {}
+        # Track source of the last tick per symbol (for stimulus freshness)
+        self.last_tick_source: dict[str, str] = {}
 
     def _align_timestamp(self, ts: int) -> int:
         """Align timestamp to interval boundary (floor)"""
@@ -131,6 +133,7 @@ class CandleAggregator:
             prev_ts = self.last_tick_ts_ms.get(symbol, 0)
             if ts_ms_int > prev_ts:
                 self.last_tick_ts_ms[symbol] = ts_ms_int
+                self.last_tick_source[symbol] = str(trade.get("source", ""))
 
             return completed
 

--- a/services/candles/service.py
+++ b/services/candles/service.py
@@ -285,6 +285,13 @@ class CandleService:
             ts_ms = int(time.time() * 1000)
             # Get last_tick_ts_ms from aggregator (updated on each trade)
             last_tick_ts_ms = self.aggregator.last_tick_ts_ms.get(symbol)
+            # When the last tick source is a stimulus fixture, the aggregator's
+            # ts_ms is a historical fixture timestamp.  Use wall-clock to preserve
+            # freshness so cdb_risk RC_004 (data_silence) does not block the
+            # shadow-validation path (#3021).  Without this, cdb_candles overwrites
+            # the wall-clock value that cdb_market already wrote (#3019).
+            if self.aggregator.last_tick_source.get(symbol) == "stimulus_fixture":
+                last_tick_ts_ms = ts_ms
             market_state = {
                 "symbol": symbol,
                 "return_1m": return_1m,

--- a/tests/unit/candles/test_aggregator.py
+++ b/tests/unit/candles/test_aggregator.py
@@ -44,7 +44,9 @@ def test_last_tick_ts_ms_monotonic_guard():
         "trade_qty": "0.2",
     }
     aggregator.process_trade(trade2)
-    assert aggregator.last_tick_ts_ms.get("BTCUSDT") == 1700000002000  # Still older value
+    assert (
+        aggregator.last_tick_ts_ms.get("BTCUSDT") == 1700000002000
+    )  # Still older value
 
     # Newer trade - should update
     trade3 = {

--- a/tests/unit/candles/test_aggregator.py
+++ b/tests/unit/candles/test_aggregator.py
@@ -1,4 +1,4 @@
-"""Unit tests for CandleAggregator - last_tick_ts_ms tracking."""
+"""Unit tests for CandleAggregator - last_tick_ts_ms and last_tick_source tracking."""
 
 import pytest
 from services.candles.models import CandleAggregator
@@ -97,3 +97,76 @@ def test_last_tick_ts_ms_not_set_on_invalid_trade():
     aggregator.process_trade(invalid_trade)
 
     assert aggregator.last_tick_ts_ms.get("BTCUSDT") is None
+
+
+@pytest.mark.unit
+def test_last_tick_source_tracked_on_trade():
+    """last_tick_source should track the source field of each trade."""
+    aggregator = CandleAggregator(interval_seconds=60)
+
+    trade = {
+        "ts_ms": 1700000000000,
+        "symbol": "BTCUSDT",
+        "price": "50000.0",
+        "trade_qty": "0.1",
+        "source": "stimulus_fixture",
+    }
+
+    aggregator.process_trade(trade)
+
+    assert aggregator.last_tick_source.get("BTCUSDT") == "stimulus_fixture"
+
+
+@pytest.mark.unit
+def test_last_tick_source_default_empty_on_missing_source():
+    """last_tick_source should default to empty string when source is missing."""
+    aggregator = CandleAggregator(interval_seconds=60)
+
+    trade = {
+        "ts_ms": 1700000000000,
+        "symbol": "BTCUSDT",
+        "price": "50000.0",
+        "trade_qty": "0.1",
+    }
+
+    aggregator.process_trade(trade)
+
+    assert aggregator.last_tick_source.get("BTCUSDT") == ""
+
+
+@pytest.mark.unit
+def test_last_tick_source_monotonic_guard():
+    """last_tick_source should only update when ts_ms is newer (same guard as ts)."""
+    aggregator = CandleAggregator(interval_seconds=60)
+
+    trade1 = {
+        "ts_ms": 1700000002000,
+        "symbol": "BTCUSDT",
+        "price": "50000.0",
+        "trade_qty": "0.1",
+        "source": "live_exchange",
+    }
+    aggregator.process_trade(trade1)
+    assert aggregator.last_tick_source.get("BTCUSDT") == "live_exchange"
+
+    # Out-of-order trade (older) — source should NOT update
+    trade2 = {
+        "ts_ms": 1700000001000,
+        "symbol": "BTCUSDT",
+        "price": "50001.0",
+        "trade_qty": "0.2",
+        "source": "other",
+    }
+    aggregator.process_trade(trade2)
+    assert aggregator.last_tick_source.get("BTCUSDT") == "live_exchange"
+
+    # Newer trade — source SHOULD update
+    trade3 = {
+        "ts_ms": 1700000003000,
+        "symbol": "BTCUSDT",
+        "price": "50002.0",
+        "trade_qty": "0.3",
+        "source": "stimulus_fixture",
+    }
+    aggregator.process_trade(trade3)
+    assert aggregator.last_tick_source.get("BTCUSDT") == "stimulus_fixture"

--- a/tests/unit/candles/test_market_state_kill_switch.py
+++ b/tests/unit/candles/test_market_state_kill_switch.py
@@ -152,3 +152,118 @@ def test_config_garbage_value_defaults_to_true():
         else:
             os.environ["CANDLE_WRITE_MARKET_STATE"] = original
         importlib.reload(cfg_mod)
+
+
+# ─── Stimulus fixture freshness (#3021) ─────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_stimulus_fixture_uses_wall_clock_last_tick():
+    """When last_tick_source=stimulus_fixture, _update_market_state must use
+    wall-clock last_tick_ts_ms to preserve freshness for cdb_risk RC_004."""
+    service = _make_service(write_market_state=True)
+    service.aggregator.last_tick_ts_ms["BTCUSDT"] = 1700000000000  # historical
+    service.aggregator.last_tick_source["BTCUSDT"] = "stimulus_fixture"
+
+    from unittest.mock import patch
+    import time
+
+    wall_clock = 1780702600000
+
+    # Simulate 6 candles in the stream so market_state is not skipped
+    candles = [
+        {"symbol": "BTCUSDT", "close": "50000", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50001", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50002", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50003", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50004", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50005", "ts": str(wall_clock // 1000)},
+    ]
+    xrevrange_result = [(f"{wall_clock}-{i}", c) for i, c in enumerate(candles)]
+    service.redis_client.xrevrange.return_value = xrevrange_result
+
+    # Mock regime lookup to avoid Redis regime stream dependency
+    with patch.object(service, "_lookup_regime_id", return_value=0):
+        with patch.object(time, "time", return_value=wall_clock / 1000.0):
+            service._update_market_state("BTCUSDT", 1700000000000)
+
+    # Extract the payload that was setex'd into Redis
+    # setex(key, ttl, value) → args[0]=key, args[1]=ttl, args[2]=json_string
+    args, _kwargs = service.redis_client.setex.call_args
+    payload = __import__("json").loads(args[2])
+
+    # last_tick_ts_ms must be wall-clock, not the historical aggregator value
+    assert payload["last_tick_ts_ms"] == wall_clock
+
+
+@pytest.mark.unit
+def test_non_stimulus_source_preserves_aggregator_last_tick():
+    """When last_tick_source is not stimulus_fixture, _update_market_state must use
+    the aggregator's historical last_tick_ts_ms (existing behaviour, no regression)."""
+    service = _make_service(write_market_state=True)
+    service.aggregator.last_tick_ts_ms["BTCUSDT"] = 1700000000000  # historical
+    service.aggregator.last_tick_source["BTCUSDT"] = "live_exchange"
+
+    from unittest.mock import patch
+    import time
+
+    wall_clock = 1780702600000
+
+    candles = [
+        {"symbol": "BTCUSDT", "close": "50000", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50001", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50002", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50003", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50004", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50005", "ts": str(wall_clock // 1000)},
+    ]
+    xrevrange_result = [(f"{wall_clock}-{i}", c) for i, c in enumerate(candles)]
+    service.redis_client.xrevrange.return_value = xrevrange_result
+
+    with patch.object(service, "_lookup_regime_id", return_value=0):
+        with patch.object(time, "time", return_value=wall_clock / 1000.0):
+            service._update_market_state("BTCUSDT", 1700000000000)
+
+    args, _kwargs = service.redis_client.setex.call_args
+    payload = __import__("json").loads(args[2])
+
+    # last_tick_ts_ms must still be the aggregator's historical value
+    assert payload["last_tick_ts_ms"] == 1700000000000
+
+
+@pytest.mark.unit
+def test_stimulus_fixture_preserves_other_market_state_fields():
+    """The wall-clock override for last_tick_ts_ms must not change other fields."""
+    service = _make_service(write_market_state=True)
+    service.aggregator.last_tick_ts_ms["BTCUSDT"] = 1700000000000
+    service.aggregator.last_tick_source["BTCUSDT"] = "stimulus_fixture"
+
+    from unittest.mock import patch
+    import time
+
+    wall_clock = 1780702600000
+
+    candles = [
+        {"symbol": "BTCUSDT", "close": "50000", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50001", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50002", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50003", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50004", "ts": str(wall_clock // 1000)},
+        {"symbol": "BTCUSDT", "close": "50005", "ts": str(wall_clock // 1000)},
+    ]
+    xrevrange_result = [(f"{wall_clock}-{i}", c) for i, c in enumerate(candles)]
+    service.redis_client.xrevrange.return_value = xrevrange_result
+
+    with patch.object(service, "_lookup_regime_id", return_value=0):
+        with patch.object(time, "time", return_value=wall_clock / 1000.0):
+            service._update_market_state("BTCUSDT", 1700000000000)
+
+    args, _kwargs = service.redis_client.setex.call_args
+    payload = __import__("json").loads(args[2])
+
+    assert payload["symbol"] == "BTCUSDT"
+    assert payload["ts_ms"] == wall_clock
+    assert payload["close_now"] == 50000.0
+    assert payload["close_1m_ago"] == 50001.0
+    assert payload["close_5m_ago"] == 50005.0
+    assert payload["regime_id"] == 0


### PR DESCRIPTION
## Root Cause

`cdb_candles._update_market_state` overwrites `market_state:BTCUSDT` with a stale `last_tick_ts_ms` after `cdb_market` has already written the correct wall-clock value.

**Race:**
1. Runner publishes burst candle with `source="stimulus_fixture"` to `market_data`
2. `cdb_market` receives → `_update_market_state` sets `last_tick_ts_ms = wall_clock` (#3019 `tick_source` guard) → writes `market_state:BTCUSDT`
3. `cdb_candles` also receives → aggregator tracks `last_tick_ts_ms = historical` → emits candle → calls `_update_market_state` → writes `market_state:BTCUSDT` with historical `last_tick_ts_ms`
4. `cdb_candles`'s write OVERWRITES the wall-clock value
5. `cdb_risk` reads `market_state:BTCUSDT` → `last_tick_ts_ms = historical` → `data_silence_s = 38.833` → RC_004 BLOCK

**Evidence from #2968 runtime:**
- `market_state_ts_ms = 1780702598778` (wall clock — from `cdb_market`)
- `last_tick_ts_ms = 1780702560000` (historical — overwritten by `cdb_candles`)
- `last_tick_ts_ms` matches breakout candle `ts_ms` exactly

## Delivered

- `services/candles/models.py`: Added `last_tick_source` dict to `CandleAggregator`, tracked in `process_trade` with the same monotonic guard as `last_tick_ts_ms`
- `services/candles/service.py`: In `_update_market_state`, when `last_tick_source[symbol] == "stimulus_fixture"`, use wall-clock `ts_ms` for `last_tick_ts_ms` instead of the aggregator's historical value
- Added 3 aggregator unit tests (`last_tick_source` tracking, monotonic guard, missing source default)
- Added 3 `_update_market_state` unit tests (stimulus wall-clock override, non-stimulus regression, other field preservation)

## Brain Evidence

brain_source: repo-only
brain_status: not-used
tools_or_queries: `git fetch origin --prune`, `git status -sb`, `git rev-parse`, `gh pr list`, `gh issue view 3021`, `rg` for data_silence/last_tick/candles market_state write, `pytest -q tests/unit/candles/ -v`, `ruff check`
records_or_results: `HEAD == origin/main == 906d866d`, 38/38 candle tests green, 100/100 filtered tests green, lint clean, `data_silence_s=38.833` from #2968 evidence
repo_crosscheck: `services/candles/models.py:76,131-133`, `services/candles/service.py:285-298`, `services/market/service.py:317-321`, `services/risk/service.py:292-346`
impact_on_plan: Fix targets the exact overwrite race; no other changes needed
limitations: No runtime rerun in this slice; verification requires future #2968 retry

## Validation

```bash
git diff --check                          # clean
ruff check services/candles/ tests/unit/candles/  # all passed
pytest -q tests/unit/candles/ -v          # 38 passed
pytest -q tests/unit/risk tests/unit/market tests/unit/signal tests/unit/validation tests/unit/candles -k "rc004 or data_silence or freshness or stimulus or market_state" -v  # 100 passed
```

## Non-goals

- No RC_004 threshold change (`data_silence_s_max` stays at 30.0)
- No `cdb_risk` change
- No `cdb_market` change
- No `cdb_candles` config change (`write_market_state` stays true)
- No DB mutation, no runtime execution, no exporter contract change

## Safety Boundaries

- LR remains NO-GO
- No Live-Go / Echtgeld-Go
- RC_004 fail-closed semantics preserved for genuinely stale data (non-stimulus sources continue to use aggregator timestamp)
- No secrets

## Restunsicherheiten

- Runtime verification needs #2968 retry (not in this slice)
- If `cdb_candles` processes `market_data` before `cdb_market`, the _first_ write will have wall-clock `last_tick_ts_ms` and `cdb_market`'s subsequent write will also have wall-clock — no regression either way

Closes #3021
Refs #2968
Refs #2969
Refs #3018
Refs #3019