### PR TITLE
docs: fix github control plane mermaid graph rendering

### DIFF
--- a/docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md
+++ b/docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md
@@ -147,7 +147,7 @@ graph TD
         SL[sync-labels.yml]
         CBU[control_board_upsert.yml]
         PRD[project_reconcile_daily.yml]
-        CAR[control_board_auto_routing.yml<br/>(PARKED #2772)]
+        CAR["control_board_auto_routing.yml<br/>(PARKED #2772)"]
     end
 
     %% Script connections


### PR DESCRIPTION
## Summary

Fix Mermaid graph rendering in `docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md` Section 5 — quote the `CAR` node label so GitHub's Mermaid parser correctly handles the `#2772` reference inside the label text.

## Change

- `docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md`: `CAR[...]` -> `CAR["..."]` (1 line, 1 insertion/1 deletion)

## Validation

- git diff --stat: only `docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md` changed (other files were pre-existing worktree dirt)
- Mermaid block: valid structure — heading, blank line, mermaid fence, graph TD, 9 subgraphs, all edges, closing fence
- No semantic change to graph nodes, subgraphs, or edges
- No runtime/Docker/DB/secrets/MCP/workflow changes

## Safety / Scope

- Docs-only. No governance, code, config, or workflow changes.
- LR status unchanged (NO-GO). No live/Echtgeld actions.
- No secrets read or written. No DB/memory writes. No MCP mutations.

## Restunsicherheiten

- None. Single-line quote fix, verified via diff and manual block inspection.
