### PR TITLE
fix(arvp): resolve strategy id at paper window chain level

### DIFF
--- a/core/replay/paper_reference_window_export.py
+++ b/core/replay/paper_reference_window_export.py
@@ -6,7 +6,11 @@ This module is intentionally narrow:
 
 Design rules:
   - Fail-closed: missing/invalid required fields -> PaperReferenceExportError.
-  - Explicit: strategy_id is taken from payload.strategy_id (not inferred).
+  - Chain-level strategy resolution: strategy_id is required in the export output
+    for every event (contract B2). When payload.strategy_id is present, it must
+    match the window's strategy_id. When absent (e.g. DECISION rows that do not
+    carry strategy_id in their evidence payload), it is resolved from the SIGNAL
+    anchor of the same correlation chain. Mixed-strategy chains are rejected.
   - Paper qualification: requires at least one ORDER and one FILL whose order_id
     is prefixed with "paper_".
   - Deterministic ordering: events are sorted by (timestamp_ms, event_pk).
@@ -215,13 +219,23 @@ def export_paper_reference_window(
 
         payload = row.get("payload")
         payload = {} if payload is None else _require_mapping(payload, "payload")
-        payload_strategy = _require_non_empty_string(
-            payload.get("strategy_id"), "payload.strategy_id"
-        )
-        if payload_strategy != request.strategy_id:
-            raise PaperReferenceExportError(
-                f"payload.strategy_id mismatch: expected {request.strategy_id!r}, got {payload_strategy!r}"
-            )
+
+        # strategy_id resolution (chain-level, #3025):
+        # If payload.strategy_id is present and non-empty, it must match
+        # request.strategy_id (strict per-row contract check).
+        # If absent or empty, it will be resolved from the SIGNAL anchor of the
+        # same correlation chain after all rows are processed.
+        raw_strategy = payload.get("strategy_id")
+        if raw_strategy is not None and isinstance(raw_strategy, str) and raw_strategy.strip():
+            resolved_strategy = raw_strategy.strip()
+            if resolved_strategy != request.strategy_id:
+                raise PaperReferenceExportError(
+                    f"payload.strategy_id mismatch: expected {request.strategy_id!r}, got {resolved_strategy!r}"
+                )
+            needs_chain_resolution = False
+        else:
+            needs_chain_resolution = True
+            resolved_strategy = None
 
         ev: dict[str, Any] = {
             "event_pk": event_pk,
@@ -230,6 +244,7 @@ def export_paper_reference_window(
             "symbol": symbol,
             "timestamp_ms": timestamp_ms,
             "payload": dict(payload),
+            "_needs_strategy_resolution": needs_chain_resolution,
         }
         # Optional chain fields (contract requires presence for certain event types, but
         # correlation_ledger allows nulls; we fail-closed when missing for those types).
@@ -298,6 +313,24 @@ def export_paper_reference_window(
                 "chain-integrity failed: event signal_id does not match SIGNAL anchor "
                 f"for correlation_id {correlation_id!r}"
             )
+
+    # Chain-level strategy_id resolution (#3025):
+    # Events that lack payload.strategy_id inherit it from their SIGNAL anchor.
+    # This allows DECISION rows (which do not carry strategy_id in their evidence
+    # payload) to be exported as part of a valid single-strategy chain.
+    for ev in all_events:
+        if not ev.pop("_needs_strategy_resolution"):
+            continue
+        correlation_id = str(ev["correlation_id"])
+        anchor = signal_anchors.get(correlation_id)
+        if anchor is None:
+            raise PaperReferenceExportError(
+                f"chain-strategy resolution failed: no SIGNAL anchor for "
+                f"correlation_id {correlation_id!r} to resolve payload.strategy_id"
+            )
+        # SIGNAL payload.strategy_id was already validated against request.strategy_id
+        # during the per-row loop, so request.strategy_id is the canonical value.
+        ev["payload"]["strategy_id"] = request.strategy_id
 
     selected_correlation_ids: set[str] = set()
     for correlation_id, anchor in signal_anchors.items():

--- a/tests/unit/replay/test_paper_reference_window_export.py
+++ b/tests/unit/replay/test_paper_reference_window_export.py
@@ -176,6 +176,237 @@ def test_fails_closed_when_no_paper_fill() -> None:
         export_paper_reference_window(request=request, rows=rows)
 
 
+def _decision_row(
+    *,
+    event_pk: str,
+    correlation_id: str,
+    signal_id: str,
+    decision_id: str,
+    timestamp_ms: int,
+    strategy_id: str | None = "SENTINEL_NO_STRATEGY",
+) -> dict:
+    payload: dict = {
+        "decision_id": decision_id,
+        "signal_id": signal_id,
+        "regime_id": "HIGH_VOL_CHAOTIC",
+        "contract_version": "1.0",
+    }
+    if strategy_id != "SENTINEL_NO_STRATEGY":
+        payload["strategy_id"] = strategy_id
+    return {
+        "event_pk": event_pk,
+        "correlation_id": correlation_id,
+        "signal_id": signal_id,
+        "decision_id": decision_id,
+        "order_id": None,
+        "fill_id": None,
+        "event_type": "DECISION",
+        "symbol": "BTCUSDT",
+        "timestamp_ms": timestamp_ms,
+        "payload": payload,
+    }
+
+
+def test_decision_without_payload_strategy_id_resolves_from_signal_anchor() -> None:
+    request = _req()
+    rows = [
+        _signal_row(
+            event_pk="sig-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1100,
+        ),
+        _decision_row(
+            event_pk="dec-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            timestamp_ms=1200,
+        ),
+        _order_row(
+            event_pk="ord-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1300,
+        ),
+        _fill_row(
+            event_pk="fill-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1400,
+        ),
+    ]
+    payload = export_paper_reference_window(request=request, rows=rows)
+    assert payload["strategy_id"] == "primary_breakout_v1"
+    events_by_type = {e["event_type"]: e for e in payload["events"]}
+    assert events_by_type["DECISION"]["payload"]["strategy_id"] == "primary_breakout_v1"
+
+
+def test_decision_rows_all_missing_strategy_id_resolved_from_signal() -> None:
+    request = _req()
+    rows = [
+        _signal_row(
+            event_pk="sig-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1100,
+        ),
+        _decision_row(
+            event_pk="dec-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            timestamp_ms=1200,
+        ),
+        _decision_row(
+            event_pk="dec-1b",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1b",
+            timestamp_ms=1250,
+        ),
+        _order_row(
+            event_pk="ord-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1300,
+        ),
+        _fill_row(
+            event_pk="fill-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1400,
+        ),
+    ]
+    payload = export_paper_reference_window(request=request, rows=rows)
+    assert payload["strategy_id"] == "primary_breakout_v1"
+    for ev in payload["events"]:
+        if ev["event_type"] == "DECISION":
+            assert ev["payload"]["strategy_id"] == "primary_breakout_v1"
+
+
+def test_mixed_strategy_chain_rejected_even_when_signal_anchor_resolves() -> None:
+    request = _req()
+    rows = [
+        _signal_row(
+            event_pk="sig-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1100,
+        ),
+        _decision_row(
+            event_pk="dec-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            timestamp_ms=1200,
+        ),
+        _order_row(
+            event_pk="ord-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1300,
+            strategy_id="other_strategy",
+        ),
+        _fill_row(
+            event_pk="fill-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1400,
+        ),
+    ]
+    with pytest.raises(
+        PaperReferenceExportError, match="payload\\.strategy_id mismatch"
+    ):
+        export_paper_reference_window(request=request, rows=rows)
+
+
+def test_chain_no_signal_anchor_cannot_resolve_strategy() -> None:
+    request = _req()
+    rows = [
+        _decision_row(
+            event_pk="dec-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            timestamp_ms=1200,
+        ),
+        _order_row(
+            event_pk="ord-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1300,
+        ),
+        _fill_row(
+            event_pk="fill-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1400,
+        ),
+    ]
+    with pytest.raises(PaperReferenceExportError, match="no SIGNAL anchors"):
+        export_paper_reference_window(request=request, rows=rows)
+
+
+def test_decision_with_explicit_strategy_id_matching_request_accepted() -> None:
+    request = _req()
+    rows = [
+        _signal_row(
+            event_pk="sig-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            timestamp_ms=1100,
+        ),
+        _decision_row(
+            event_pk="dec-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            timestamp_ms=1200,
+            strategy_id="primary_breakout_v1",
+        ),
+        _order_row(
+            event_pk="ord-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            timestamp_ms=1300,
+        ),
+        _fill_row(
+            event_pk="fill-1",
+            correlation_id="c1",
+            signal_id="sig1",
+            decision_id="dec1",
+            order_id="paper_001",
+            fill_id="fill1",
+            timestamp_ms=1400,
+        ),
+    ]
+    payload = export_paper_reference_window(request=request, rows=rows)
+    assert payload["strategy_id"] == "primary_breakout_v1"
+
+
 def test_fails_closed_on_strategy_mismatch() -> None:
     request = _req()
     rows = [


### PR DESCRIPTION
## Closes #3025
## Refs #2968, #2969

### Root Cause

`export_paper_reference_window` validated `payload.strategy_id` as a non-empty string on every row (lines 218-224). DECISION events in `correlation_ledger` do not include `strategy_id` in their payload — the `evidence` dict produced by `risk/service.py:decide_trade()` (lines 296-326) contains `signal_id`, `decision_id`, `regime_id`, etc., but NOT `strategy_id`. SIGNAL, ORDER, and FILL events all carry `strategy_id` in their payloads.

This caused a valid single-strategy chain (SIGNAL -> DECISION -> ORDER(paper_) -> FILL with shared lineage) to be rejected with exit code 2: `payload.strategy_id must be a non-empty string`.

### Delivered

**`core/replay/paper_reference_window_export.py`:**
- Replaced per-row `payload.strategy_id` requirement with chain-level resolution
- If `payload.strategy_id` is present and non-empty: validated against `request.strategy_id` (strict, unchanged)
- If `payload.strategy_id` is absent or empty: resolved from the SIGNAL anchor of the same `correlation_id` chain
- Resolved `strategy_id` is injected into the event payload so the export artifact satisfies contract B2
- Mixed-strategy chains (where a row carries a different `strategy_id`) are still rejected via per-row mismatch check
- Chains without SIGNAL anchors cannot resolve and fail closed as before

**`tests/unit/replay/test_paper_reference_window_export.py`:**
- Added `_decision_row()` helper (with sentinel for missing `strategy_id`)
- `test_decision_without_payload_strategy_id_resolves_from_signal_anchor` — reproduces #3025: DECISION without `payload.strategy_id` in valid single-strategy chain now exports successfully
- `test_decision_rows_all_missing_strategy_id_resolved_from_signal` — multiple DECISION rows all missing `strategy_id`, resolved from SIGNAL anchor
- `test_mixed_strategy_chain_rejected_even_when_signal_anchor_resolves` — ORDER with different `strategy_id` still rejected (strictness preserved)
- `test_chain_no_signal_anchor_cannot_resolve_strategy` — no SIGNAL anchor still fails closed
- `test_decision_with_explicit_strategy_id_matching_request_accepted` — DECISION with explicit matching `strategy_id` still works

### Brain Evidence

```
brain_source: repo-only
brain_status: not-used
tools_or_queries:
  - rg/git/code search for paper_reference_window, strategy_id, DECISION
records_or_results:
  - core/replay/paper_reference_window_export.py (exporter, lines 218-224 root cause)
  - services/risk/service.py (DECISION evidence dict, lines 296-326, no strategy_id)
  - services/signal/service.py (SIGNAL payload includes strategy_id)
  - services/execution/service.py (ORDER/FILL payloads include strategy_id)
  - tests/unit/replay/test_paper_reference_window_export.py (17 tests, all pass)
repo_crosscheck:
  - docs/governance/arvp_paper_reference_contract.md (contract B2: payload must carry strategy_id)
  - core/replay/replay_vs_paper_compare.py (consumer validates payload.strategy_id per event)
impact_on_plan:
  - Chain-level resolution preserves contract B2 (output payload always contains strategy_id)
  - No DB schema or writer changes required
  - No contract weakening — mixed-strategy and ambiguous chains still rejected
limitations:
  - Not tested with live DB export (unit tests only)
  - Race condition with concurrent DECISION writes adding strategy_id in future producer changes is a non-issue (present strategy_id is validated; absent is resolved)
```

### Validation

- `ruff check` — All checks passed
- `pytest tests/unit/replay/test_paper_reference_window_export.py` — 17 passed
- `pytest tests/unit/validation/ -k "paper_reference_window"` — 6 passed
- `pytest tests/unit/replay/` — 951 passed
- Module import verification — OK

### Non-goals

- No runtime retry of #2968 (export-only fix)
- No Docker changes
- No DB mutation or backfill
- No contract weakening for ambiguous/mixed-strategy chains
- No LR/Live/Echtgeld scope touched

### Safety Boundaries

| Rule | Status |
|------|--------|
| LR remains NO-GO | Enforced |
| No real-money path | Enforced |
| No secrets in output | Enforced |
| No DB mutation | Enforced |
| No exporter contract weakening | Enforced (mixed/ambiguous still rejected) |

### Restunsicherheiten

- Future DECISION payload changes to include `strategy_id` at write time would be compatible with this fix (explicit `strategy_id` in payload is validated; absent is resolved)
- Downstream consumer `replay_vs_paper_compare.py` validates `payload.strategy_id` per event in its input — our export now injects `strategy_id` into DECISION payloads, so consumption succeeds