### PR TITLE
docs(strategy): define profitability candidate contract v1

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -10,6 +10,7 @@ Repo-backed JSON/YAML schemas und Contract-Dokumente für Messages, Replay und C
 | Context tooling | [`context_tooling/`](context_tooling/) | MCP evidence contracts |
 | Examples | [`examples/`](examples/) | Valid/invalid fixtures |
 | Replay | [`REPLAY_CONTRACTS_AND_DETERMINISM.md`](REPLAY_CONTRACTS_AND_DETERMINISM.md) | Determinism rules |
+| Profitability | `profitability_candidate_contract.v1.schema.json`, `profitability_evidence_packet.v1.schema.json` | Strategy candidate and evidence packet research contracts |
 
 ## Related canon (not duplicated here)
 

--- a/docs/contracts/examples/profitability_candidate_contract_valid.json
+++ b/docs/contracts/examples/profitability_candidate_contract_valid.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "profitability_candidate_contract.v1",
+  "candidate_id": "cand-primary-breakout-v1-btcusdt-trend",
+  "strategy_family": "primary_breakout",
+  "symbol_universe": [
+    "BTCUSDT"
+  ],
+  "timeframe": "1m",
+  "direction": "long_only",
+  "regime_scope": {
+    "allowed_regimes": [
+      "TREND"
+    ],
+    "blocked_regimes": [
+      "RANGE",
+      "PANIC",
+      "UNKNOWN"
+    ],
+    "freshness_required": true
+  },
+  "parameter_set": {
+    "entry_lookback_minutes": 240,
+    "exit_lookback_minutes": 120,
+    "breakout_buffer": 0.0005,
+    "min_minutes_between_entries": 60
+  },
+  "hypothesis": "BTCUSDT trend breakouts can produce positive net expectancy when regime freshness, execution friction, and replay-vs-paper drift remain inside explicit research limits.",
+  "risk_assumptions": [
+    "Core Risk Service, kill-switch, and LR gates remain authoritative.",
+    "Candidate evidence cannot override runtime risk blocks."
+  ],
+  "execution_assumptions": [
+    "Fees, spread, and slippage must be accounted for before ranking.",
+    "Backtest, ARVP, and paper evidence do not imply live execution readiness."
+  ],
+  "status": "SPECIFIED",
+  "allowed_next_gate": "BACKTESTED",
+  "reject_reason": null,
+  "unsafe_zones": [
+    {
+      "zone": "live-capital",
+      "reason": "LR remains NO-GO and this contract is research-only."
+    }
+  ],
+  "limitations": [
+    "Single-symbol v1 example.",
+    "No productive DB registry is created by this fixture."
+  ]
+}

--- a/docs/contracts/examples/profitability_evidence_packet_valid.json
+++ b/docs/contracts/examples/profitability_evidence_packet_valid.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "profitability_evidence_packet.v1",
+  "evidence_packet_id": "pep-primary-breakout-v1-btcusdt-trend-001",
+  "candidate_id": "cand-primary-breakout-v1-btcusdt-trend",
+  "generated_at": "2026-06-06T00:00:00Z",
+  "dataset_id": "dataset-primary-breakout-v1-reference-20260418",
+  "dataset_fingerprint": "sha256:01f30b10fb3e7712a2c0e8b8122ce1789ee9e669ff04d6cfbb9fc7034edcdb12",
+  "source_run_refs": [
+    "artifacts/backtests/primary_breakout_v1/20260418-212643/metrics.json",
+    "docs/evidence/arvp_calibration_pilot_1932_2026-04-26.md"
+  ],
+  "gross_return": 0.018,
+  "net_return": 0.011,
+  "fees": 0.002,
+  "spread_cost": 0.0015,
+  "slippage_cost": 0.0035,
+  "profit_factor": 1.12,
+  "expectancy": 0.02,
+  "win_rate": 0.51,
+  "avg_win": 0.042,
+  "avg_loss": 0.038,
+  "max_drawdown": 0.08,
+  "loss_streak": 4,
+  "trade_count": 24,
+  "regime_scorecard": {
+    "status": "unavailable",
+    "artifact_ref": null,
+    "summary": "No regime scorecard artifact is attached to this example packet."
+  },
+  "scenario_results": [
+    {
+      "scenario_id": "base_case",
+      "status": "WARNING",
+      "net_return": 0.011,
+      "max_drawdown": 0.08,
+      "notes": "Example values only; not a pass claim."
+    }
+  ],
+  "replay_vs_paper_status": "pessimistic_drift",
+  "simulator_drift": "pessimistic",
+  "risk_blocks": 0,
+  "kill_switch_events": 0,
+  "recommendation": "PARK",
+  "limitations": [
+    "Example packet only; does not claim strategy readiness.",
+    "Dataset quality gate result is not embedded in this v1 fixture."
+  ],
+  "safety_boundaries": [
+    "LR remains NO-GO.",
+    "Backtest, ARVP, and paper evidence are not live approval.",
+    "No automatic promotion or capital scaling is authorized."
+  ]
+}

--- a/docs/contracts/profitability_candidate_contract.v1.schema.json
+++ b/docs/contracts/profitability_candidate_contract.v1.schema.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Profitability Candidate Contract v1",
+  "description": "Machine-readable research contract for CDB Profitability Engine strategy candidates. This is not a trade approval, runtime contract, DB schema, or live-readiness signal.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "candidate_id",
+    "strategy_family",
+    "symbol_universe",
+    "timeframe",
+    "direction",
+    "regime_scope",
+    "parameter_set",
+    "hypothesis",
+    "risk_assumptions",
+    "execution_assumptions",
+    "status",
+    "allowed_next_gate",
+    "reject_reason",
+    "unsafe_zones",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_candidate_contract.v1"
+    },
+    "candidate_id": {
+      "type": "string",
+      "pattern": "^cand-[a-z0-9][a-z0-9-]{2,80}$"
+    },
+    "strategy_family": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "symbol_universe": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z0-9_:-]{3,40}$"
+      }
+    },
+    "timeframe": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 20
+    },
+    "direction": {
+      "type": "string",
+      "enum": [
+        "long_only",
+        "short_only",
+        "long_short",
+        "flat_research_only"
+      ]
+    },
+    "regime_scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "allowed_regimes",
+        "blocked_regimes",
+        "freshness_required"
+      ],
+      "properties": {
+        "allowed_regimes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "blocked_regimes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "freshness_required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "parameter_set": {
+      "type": "object",
+      "description": "Candidate-local parameter snapshot. Values must remain research metadata and must not override runtime risk, execution, kill-switch, or LR gates.",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "hypothesis": {
+      "type": "string",
+      "minLength": 20,
+      "maxLength": 2000
+    },
+    "risk_assumptions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 500
+      }
+    },
+    "execution_assumptions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 500
+      }
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "IDEA",
+        "SPECIFIED",
+        "BACKTESTED",
+        "ARVP_VALIDATED",
+        "STRESS_TESTED",
+        "PAPER_CANDIDATE",
+        "PAPER_VALIDATED",
+        "MICRO_LIVE_CANDIDATE",
+        "CAPITAL_SCALING_CANDIDATE",
+        "REJECTED",
+        "PARKED",
+        "UNSAFE",
+        "SUPERSEDED",
+        "STALE"
+      ]
+    },
+    "allowed_next_gate": {
+      "type": "string",
+      "enum": [
+        "SPECIFIED",
+        "BACKTESTED",
+        "ARVP_VALIDATED",
+        "STRESS_TESTED",
+        "PAPER_CANDIDATE",
+        "PAPER_VALIDATED",
+        "MICRO_LIVE_CANDIDATE",
+        "CAPITAL_SCALING_CANDIDATE",
+        "NONE"
+      ]
+    },
+    "reject_reason": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        }
+      ]
+    },
+    "unsafe_zones": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "zone",
+          "reason"
+        ],
+        "properties": {
+          "zone": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          }
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 500
+      }
+    }
+  }
+}

--- a/docs/contracts/profitability_evidence_packet.v1.schema.json
+++ b/docs/contracts/profitability_evidence_packet.v1.schema.json
@@ -1,0 +1,273 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Profitability Evidence Packet v1",
+  "description": "Machine-readable research evidence packet for CDB Profitability Engine candidates. Evidence packets support comparison and review only; they do not authorize paper, micro-live, live capital, runtime changes, or capital scaling.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "evidence_packet_id",
+    "candidate_id",
+    "generated_at",
+    "dataset_id",
+    "dataset_fingerprint",
+    "source_run_refs",
+    "gross_return",
+    "net_return",
+    "fees",
+    "spread_cost",
+    "slippage_cost",
+    "profit_factor",
+    "expectancy",
+    "win_rate",
+    "avg_win",
+    "avg_loss",
+    "max_drawdown",
+    "loss_streak",
+    "trade_count",
+    "regime_scorecard",
+    "scenario_results",
+    "replay_vs_paper_status",
+    "simulator_drift",
+    "risk_blocks",
+    "kill_switch_events",
+    "recommendation",
+    "limitations",
+    "safety_boundaries"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_evidence_packet.v1"
+    },
+    "evidence_packet_id": {
+      "type": "string",
+      "pattern": "^pep-[a-z0-9][a-z0-9-]{2,80}$"
+    },
+    "candidate_id": {
+      "type": "string",
+      "pattern": "^cand-[a-z0-9][a-z0-9-]{2,80}$"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "dataset_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160
+    },
+    "dataset_fingerprint": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "source_run_refs": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 300
+      }
+    },
+    "gross_return": {
+      "type": "number"
+    },
+    "net_return": {
+      "type": "number"
+    },
+    "fees": {
+      "type": "number",
+      "minimum": 0.0
+    },
+    "spread_cost": {
+      "type": "number",
+      "minimum": 0.0
+    },
+    "slippage_cost": {
+      "type": "number",
+      "minimum": 0.0
+    },
+    "profit_factor": {
+      "type": "number",
+      "minimum": 0.0
+    },
+    "expectancy": {
+      "type": "number"
+    },
+    "win_rate": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
+    "avg_win": {
+      "type": "number",
+      "minimum": 0.0
+    },
+    "avg_loss": {
+      "type": "number",
+      "minimum": 0.0
+    },
+    "max_drawdown": {
+      "type": "number",
+      "minimum": 0.0
+    },
+    "loss_streak": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "trade_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "regime_scorecard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "artifact_ref",
+        "summary"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "ok",
+            "unavailable",
+            "insufficient_data"
+          ]
+        },
+        "artifact_ref": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 300
+            }
+          ]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        }
+      }
+    },
+    "scenario_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "scenario_id",
+          "status",
+          "net_return",
+          "max_drawdown",
+          "notes"
+        ],
+        "properties": {
+          "scenario_id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PASS",
+              "WARNING",
+              "FAIL",
+              "BLOCKED",
+              "NOT_RUN"
+            ]
+          },
+          "net_return": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "max_drawdown": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number",
+                "minimum": 0.0
+              }
+            ]
+          },
+          "notes": {
+            "type": "string",
+            "maxLength": 1000
+          }
+        }
+      }
+    },
+    "replay_vs_paper_status": {
+      "type": "string",
+      "enum": [
+        "aligned",
+        "pessimistic_drift",
+        "optimistic_drift",
+        "ambiguous_drift",
+        "missing_reference",
+        "not_run"
+      ]
+    },
+    "simulator_drift": {
+      "type": "string",
+      "enum": [
+        "none",
+        "pessimistic",
+        "optimistic",
+        "ambiguous",
+        "unusable",
+        "not_assessed"
+      ]
+    },
+    "risk_blocks": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "kill_switch_events": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "recommendation": {
+      "type": "string",
+      "enum": [
+        "REJECT",
+        "PARK",
+        "PROMOTE_TO_NEXT_RESEARCH_GATE",
+        "UNSAFE",
+        "NO_RECOMMENDATION"
+      ]
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 500
+      }
+    },
+    "safety_boundaries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 500
+      }
+    }
+  }
+}

--- a/docs/strategy/CDB_PROFITABILITY_CANDIDATE_CONTRACT_V1.md
+++ b/docs/strategy/CDB_PROFITABILITY_CANDIDATE_CONTRACT_V1.md
@@ -1,0 +1,118 @@
+# CDB Profitability Candidate Contract v1
+
+**Status:** Draft contract surface for #3034  
+**Mode:** Docs / schema / example fixtures only  
+**Parent:** #3032  
+**Live-Readiness:** NO-GO  
+**Runtime Impact:** none  
+
+## Purpose
+
+This document defines the first machine-readable contract surface for Profitability
+Engine strategy candidates and their evidence packets.
+
+It makes candidate comparison repeatable without changing the trading core:
+
+- `profitability_candidate_contract.v1` defines what a strategy candidate is.
+- `profitability_evidence_packet.v1` defines how validation evidence is reported.
+- Example fixtures show valid shapes for documentation and later tooling.
+
+## Contract Artifacts
+
+| Artifact | Path | Role |
+|---|---|---|
+| Candidate schema | `docs/contracts/profitability_candidate_contract.v1.schema.json` | Candidate identity, scope, assumptions, lifecycle state, next gate |
+| Evidence schema | `docs/contracts/profitability_evidence_packet.v1.schema.json` | Dataset fingerprint, gross/net metrics, friction costs, ARVP/Paper status, recommendation |
+| Candidate example | `docs/contracts/examples/profitability_candidate_contract_valid.json` | Valid research-only candidate fixture |
+| Evidence example | `docs/contracts/examples/profitability_evidence_packet_valid.json` | Valid research-only evidence fixture |
+
+## Candidate Contract v1
+
+The candidate contract captures the minimum comparable strategy definition:
+
+- `candidate_id`
+- `strategy_family`
+- `symbol_universe`
+- `timeframe`
+- `direction`
+- `regime_scope`
+- `parameter_set`
+- `hypothesis`
+- `risk_assumptions`
+- `execution_assumptions`
+- `status`
+- `allowed_next_gate`
+- `reject_reason`
+- `unsafe_zones`
+- `limitations`
+
+The canonical lifecycle statuses match the Profitability Engine Canon:
+
+- `IDEA`
+- `SPECIFIED`
+- `BACKTESTED`
+- `ARVP_VALIDATED`
+- `STRESS_TESTED`
+- `PAPER_CANDIDATE`
+- `PAPER_VALIDATED`
+- `MICRO_LIVE_CANDIDATE`
+- `CAPITAL_SCALING_CANDIDATE`
+- `REJECTED`
+- `PARKED`
+- `UNSAFE`
+- `SUPERSEDED`
+- `STALE`
+
+## Evidence Packet v1
+
+The evidence packet makes validation results comparable before ranking:
+
+- dataset identity and fingerprint
+- gross and net return
+- fees, spread cost, and slippage cost
+- profit factor, expectancy, win rate, average win/loss, drawdown, loss streak,
+  and trade count
+- regime scorecard status
+- scenario results
+- replay-vs-paper status
+- simulator drift status
+- risk block and kill-switch event counts
+- recommendation and limitations
+
+The `recommendation` field is advisory only. It cannot promote a candidate into
+paper, live, micro-live, or capital scaling by itself.
+
+## Safety Boundaries
+
+- LR remains NO-GO.
+- `trade-capable` is not Live-Go.
+- No Echtgeld-Go.
+- No runtime change.
+- No productive DB write.
+- No MCP mutation.
+- No Risk, Execution, Allocation, kill-switch, or LR gate change.
+- ARVP, backtest, and paper are evidence, not approval.
+- AI, dashboard, and docs are not authority.
+- No automatic promotion.
+- No capital scaling without separate gates.
+
+## Non-Goals
+
+- no productive candidate registry
+- no DB migration
+- no runtime implementation
+- no dependency introduction
+- no strategy logic change
+- no live-readiness uplift
+
+## Validation
+
+For this docs-only slice, validation means:
+
+1. JSON syntax for both schemas and both fixtures parses cleanly.
+2. Each example fixture validates against its matching schema.
+3. The contract surfaces include the #3034 required fields.
+4. The safety boundaries remain explicit.
+
+This validation does not prove strategy profitability, paper readiness, or live
+readiness.


### PR DESCRIPTION
## Kurzbefund
- #3034 bekommt eine docs/schema-only Contract-Fläche für Profitability Candidate Contract v1 und Evidence Packet v1. Der Slice definiert maschinenlesbare JSON-Schemas, validierende Beispiel-Fixtures und eine kurze Strategiedoku. Keine Runtime-, DB-, MCP-, Risk-, Execution-, Allocation-, Live-Go- oder Echtgeld-Go-Änderung.

## Warum jetzt
- #3034 ist der erste aktive Child-Slice nach dem Profitability Canon #3033. Ohne stabilen Candidate-/Evidence-Contract bleiben ARVP Batch Runner, Scenario Packs, Execution Economics und Strategy League Table nicht sauber vergleichbar.

## Scope
- in: Candidate Contract v1 Schema, Evidence Packet v1 Schema, valid example fixtures, Contract-Index, docs-only Strategy Contract Note.
- out: produktive Candidate Registry, DB-Migration, Runtime-Implementierung, Dependency-Einführung, Strategy-Logic-Änderung, Risk-/Execution-/Allocation-Anpassung, Live-Readiness-Uplift.

## Betroffene Dateien / Artefakte
- `docs/contracts/profitability_candidate_contract.v1.schema.json`
- `docs/contracts/profitability_evidence_packet.v1.schema.json`
- `docs/contracts/examples/profitability_candidate_contract_valid.json`
- `docs/contracts/examples/profitability_evidence_packet_valid.json`
- `docs/strategy/CDB_PROFITABILITY_CANDIDATE_CONTRACT_V1.md`
- `docs/contracts/README.md`

## Validierung / Checks
- PASS: `jsonschema` validation for both example fixtures against their matching schemas.
- PASS: `git diff --check` (only CRLF warning for touched docs files, no whitespace errors).
- PASS: staged diff reviewed: exactly the six #3034 files.

## Risiken / Guardrails
- LR bleibt NO-GO.
- `trade-capable` ist kein Live-Go.
- ARVP, Backtest und Paper bleiben Evidence, keine Freigabe.
- `recommendation` im Evidence Packet ist advisory-only und autorisiert keine automatische Promotion.
- Die Schemas sind Research-/Docs-Contracts, keine Runtime- oder DB-Contracts.

## Restunsicherheiten
- Keine breite Test-Suite gelaufen; dieser Slice ist docs/schema-only und wurde gezielt per JSON Schema geprüft.
- #3035 Dataset Quality Gate ist bewusst Folgearbeit und noch nicht geliefert.

## Issue-Bezug
- Refs #3034
- Refs #3032
