### PR TITLE
[PROFITABILITY][DATA] Define dataset quality gate v1

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -11,6 +11,7 @@ Repo-backed JSON/YAML schemas und Contract-Dokumente für Messages, Replay und C
 | Examples | [`examples/`](examples/) | Valid/invalid fixtures |
 | Replay | [`REPLAY_CONTRACTS_AND_DETERMINISM.md`](REPLAY_CONTRACTS_AND_DETERMINISM.md) | Determinism rules |
 | Profitability | `profitability_candidate_contract.v1.schema.json`, `profitability_evidence_packet.v1.schema.json` | Strategy candidate and evidence packet research contracts |
+| Profitability data quality | `profitability_dataset_quality_report.v1.schema.json` | Dataset quality gate report for candidate validation |
 
 ## Related canon (not duplicated here)
 

--- a/docs/contracts/examples/profitability_dataset_quality_report_valid.json
+++ b/docs/contracts/examples/profitability_dataset_quality_report_valid.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "profitability_dataset_quality_report.v1",
+  "report_id": "dq-primary-breakout-v1-btcusdt-001",
+  "dataset_id": "dataset-primary-breakout-v1-reference-20260418",
+  "dataset_fingerprint": "sha256:01f30b10fb3e7712a2c0e8b8122ce1789ee9e669ff04d6cfbb9fc7034edcdb12",
+  "generated_at": "2026-06-06T00:00:00Z",
+  "symbol": "BTCUSDT",
+  "timeframe": "1m",
+  "requested_window": {
+    "start_ts_ms": 1775001600000,
+    "end_ts_ms": 1776211140000
+  },
+  "observed_window": {
+    "start_ts_ms": 1775001600000,
+    "end_ts_ms": 1776211140000,
+    "candles_expected": 20160,
+    "candles_observed": 20158
+  },
+  "coverage_summary": {
+    "coverage_ratio": 0.9999,
+    "missing_candle_count": 2,
+    "duplicate_timestamp_count": 0,
+    "out_of_order_count": 0,
+    "timeframe_mismatch_count": 0
+  },
+  "checks": {
+    "coverage_check": {
+      "status": "WARNING",
+      "summary": "Coverage is below strict perfect completeness because two candles are missing."
+    },
+    "missing_candle_check": {
+      "status": "WARNING",
+      "summary": "Two missing 1m candles were detected inside the requested window.",
+      "details": [
+        "Concrete backfill remains a separate data issue such as #3031."
+      ]
+    },
+    "duplicate_check": {
+      "status": "PASS",
+      "summary": "No duplicate timestamps detected."
+    },
+    "ordering_check": {
+      "status": "PASS",
+      "summary": "Observed candles remain strictly increasing by ts_ms."
+    },
+    "timeframe_consistency_check": {
+      "status": "PASS",
+      "summary": "Observed cadence stays on a strict 1m canvas for present candles."
+    },
+    "symbol_window_metadata_check": {
+      "status": "PASS",
+      "summary": "Symbol and requested/observed window metadata are internally consistent."
+    },
+    "dataset_fingerprint_check": {
+      "status": "PASS",
+      "summary": "Content fingerprint is present and stable for downstream evidence joins."
+    }
+  },
+  "quality_verdict": "WARNING",
+  "blocking_reasons": [],
+  "limitations": [
+    "Example report only; not a claim that the referenced dataset is production-ready.",
+    "A WARNING verdict still requires downstream policy to decide whether the dataset is acceptable for the intended research slice."
+  ]
+}

--- a/docs/contracts/profitability_dataset_quality_report.v1.schema.json
+++ b/docs/contracts/profitability_dataset_quality_report.v1.schema.json
@@ -1,0 +1,229 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Profitability Dataset Quality Report v1",
+  "description": "Machine-readable dataset quality report for CDB Profitability Engine candidate validation. This report evaluates dataset readiness for research and evidence only; it does not authorize backtest validity by itself, paper promotion, runtime changes, or live-readiness progress.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "report_id",
+    "dataset_id",
+    "dataset_fingerprint",
+    "generated_at",
+    "symbol",
+    "timeframe",
+    "requested_window",
+    "observed_window",
+    "coverage_summary",
+    "checks",
+    "quality_verdict",
+    "blocking_reasons",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_dataset_quality_report.v1"
+    },
+    "report_id": {
+      "type": "string",
+      "pattern": "^dq-[a-z0-9][a-z0-9-]{2,80}$"
+    },
+    "dataset_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160
+    },
+    "dataset_fingerprint": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "symbol": {
+      "type": "string",
+      "pattern": "^[A-Z0-9_:-]{3,40}$"
+    },
+    "timeframe": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 20
+    },
+    "requested_window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "start_ts_ms",
+        "end_ts_ms"
+      ],
+      "properties": {
+        "start_ts_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "end_ts_ms": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "observed_window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "start_ts_ms",
+        "end_ts_ms",
+        "candles_expected",
+        "candles_observed"
+      ],
+      "properties": {
+        "start_ts_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "end_ts_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "candles_expected": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "candles_observed": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "coverage_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coverage_ratio",
+        "missing_candle_count",
+        "duplicate_timestamp_count",
+        "out_of_order_count",
+        "timeframe_mismatch_count"
+      ],
+      "properties": {
+        "coverage_ratio": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "missing_candle_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "duplicate_timestamp_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "out_of_order_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "timeframe_mismatch_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coverage_check",
+        "missing_candle_check",
+        "duplicate_check",
+        "ordering_check",
+        "timeframe_consistency_check",
+        "symbol_window_metadata_check",
+        "dataset_fingerprint_check"
+      ],
+      "properties": {
+        "coverage_check": {
+          "$ref": "#/definitions/checkResult"
+        },
+        "missing_candle_check": {
+          "$ref": "#/definitions/checkResult"
+        },
+        "duplicate_check": {
+          "$ref": "#/definitions/checkResult"
+        },
+        "ordering_check": {
+          "$ref": "#/definitions/checkResult"
+        },
+        "timeframe_consistency_check": {
+          "$ref": "#/definitions/checkResult"
+        },
+        "symbol_window_metadata_check": {
+          "$ref": "#/definitions/checkResult"
+        },
+        "dataset_fingerprint_check": {
+          "$ref": "#/definitions/checkResult"
+        }
+      }
+    },
+    "quality_verdict": {
+      "type": "string",
+      "enum": [
+        "PASS",
+        "WARNING",
+        "FAIL",
+        "BLOCKED"
+      ]
+    },
+    "blocking_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 500
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 500
+      }
+    }
+  },
+  "definitions": {
+    "checkResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "summary"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "PASS",
+            "WARNING",
+            "FAIL",
+            "BLOCKED"
+          ]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/strategy/CDB_PROFITABILITY_DATASET_QUALITY_GATE_V1.md
+++ b/docs/strategy/CDB_PROFITABILITY_DATASET_QUALITY_GATE_V1.md
@@ -1,0 +1,115 @@
+# CDB Profitability Dataset Quality Gate v1
+
+**Status:** Draft contract surface for #3035  
+**Mode:** Docs / schema / example fixture only  
+**Parent:** #3032  
+**Live-Readiness:** NO-GO  
+**Runtime Impact:** none  
+
+## Purpose
+
+This document defines the first dataset quality gate surface for Profitability
+Engine candidate validation.
+
+The gate exists because poor market data creates false profitability evidence.
+It formalizes the dataset checks that must be explicit before a candidate is
+trusted in backtest or ARVP-style comparison work.
+
+## Contract Artifacts
+
+| Artifact | Path | Role |
+|---|---|---|
+| Dataset quality schema | `docs/contracts/profitability_dataset_quality_report.v1.schema.json` | Machine-readable quality report |
+| Valid example | `docs/contracts/examples/profitability_dataset_quality_report_valid.json` | Example report fixture |
+
+## Required Checks
+
+The quality gate v1 defines these checks:
+
+- coverage check
+- missing candle check
+- duplicate check
+- ordering check
+- timeframe consistency check
+- symbol/window metadata check
+- dataset fingerprint check
+
+The report also carries:
+
+- requested window
+- observed window
+- expected and observed candle counts
+- coverage ratio
+- missing, duplicate, out-of-order, and timeframe mismatch counts
+- overall verdict
+- blocking reasons
+- limitations
+
+## Verdict Semantics
+
+- `PASS`: dataset quality is clean enough for the scoped research use.
+- `WARNING`: dataset is usable only with explicit caution and documented limits.
+- `FAIL`: dataset quality is insufficient for the intended research step.
+- `BLOCKED`: the dataset cannot be assessed honestly because a prerequisite is
+  missing or the underlying data issue stays unresolved.
+
+The quality gate is fail-closed:
+
+- missing data can force `WARNING`, `FAIL`, or `BLOCKED`
+- duplicate or out-of-order data cannot be silently normalized away
+- timeframe inconsistency cannot be downgraded into a cosmetic note
+
+## Relationship To Existing Replay Surfaces
+
+This gate does not replace the existing replay dataset layer:
+
+- `core/replay/dataset_spec.py` already defines request identity for symbol,
+  timeframe, window, and source.
+- `core/replay/dataset_provider.py` already validates transport/data-shape
+  invariants such as strict ordering and 1m cadence.
+- `services/validation/strategy_replay_runner.py` already carries dataset
+  fingerprints through replay artifacts.
+
+Dataset Quality Gate v1 sits before or beside those surfaces as a reusable
+reporting/evidence layer. It standardizes how quality is expressed, not how
+datasets are loaded.
+
+## Relationship To #3031
+
+Issue #3031 remains the concrete active data blocker for replayable 1m candles.
+This slice does not backfill data and does not implement a recovery path. It
+defines the reusable quality standard that future backfill or data repair work
+must satisfy.
+
+## Safety Boundaries
+
+- LR remains NO-GO.
+- `trade-capable` is not Live-Go.
+- No Echtgeld-Go.
+- No runtime change.
+- No productive DB write.
+- No MCP mutation.
+- No Risk, Execution, Allocation, kill-switch, or LR gate change.
+- ARVP, backtest, and paper are evidence, not approval.
+- AI, dashboard, and docs are not authority.
+- No automatic promotion.
+
+## Non-Goals
+
+- no direct backfill implementation
+- no DB migration
+- no runtime implementation
+- no strategy logic change
+- no live-readiness uplift
+
+## Validation
+
+For this docs-only slice, validation means:
+
+1. the JSON schema parses and passes `jsonschema` schema checks
+2. the valid example fixture validates against the schema
+3. the report fields cover the #3035 issue requirements
+4. the fail-closed verdict semantics remain explicit
+
+This does not prove any concrete dataset is ready for paper, live, or capital
+use.


### PR DESCRIPTION
## Kurzbefund
- fuehrt einen docs-only Slice fuer #3035 ein: Dataset-Quality-Gate v1 als Strategie-Text, JSON-Schema und validiertes Beispielartefakt
- ergaenzt die Contract-Uebersicht um den neuen Profitability-Dataset-Quality-Report

## Warum jetzt
- #3035 ist der naechste Canon-Baustein nach #3034 und definiert die Datenqualitaetsgrenzen, bevor Kandidaten wirtschaftlich verglichen werden
- der Slice dokumentiert die Gate-Kriterien auf vorhandenen Replay-/Dataset-Flaechen, ohne Runtime, Risk oder Allocation anzufassen

## Scope
- in: Doku, Contract-Schema, Beispielartefakt fuer den Dataset Quality Report
- out: Runtime-Implementierung, produktive Gates, DB/MCP-Mutationen, Live-Go-Aussagen

## Betroffene Dateien / Artefakte
- docs/strategy/CDB_PROFITABILITY_DATASET_QUALITY_GATE_V1.md
- docs/contracts/profitability_dataset_quality_report.v1.schema.json
- docs/contracts/examples/profitability_dataset_quality_report_valid.json
- docs/contracts/README.md

## Validierung / Checks
- JSON Schema validation des Beispielartefakts: PASS
- git diff --check: keine Patch-/Whitespace-Fehler; nur erwartete LF/CRLF-Warnung in docs/contracts/README.md

## Risiken / Guardrails
- LR bleibt NO-GO; trade-capable ist kein Live-Go
- keine Runtime-, Risk-, Execution-, Allocation- oder DB-Aenderung
- #3031 bleibt expliziter Datenblocker fuer die spaetere Umsetzung

## Restunsicherheiten
- der Slice definiert den Contract und die Gate-Logik nur dokumentarisch; die spaetere technische Durchsetzung bleibt Folgearbeit

## Issue-Bezug
- Refs #3035
- Refs #3032
