### PR TITLE
[PROFITABILITY][ARVP] Define ARVP batch runner v1

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -12,6 +12,7 @@ Repo-backed JSON/YAML schemas und Contract-Dokumente für Messages, Replay und C
 | Replay | [`REPLAY_CONTRACTS_AND_DETERMINISM.md`](REPLAY_CONTRACTS_AND_DETERMINISM.md) | Determinism rules |
 | Profitability | `profitability_candidate_contract.v1.schema.json`, `profitability_evidence_packet.v1.schema.json` | Strategy candidate and evidence packet research contracts |
 | Profitability data quality | `profitability_dataset_quality_report.v1.schema.json` | Dataset quality gate report for candidate validation |
+| Profitability ARVP batch | `profitability_arvp_batch_manifest.v1.schema.json`, `profitability_arvp_batch_summary.v1.schema.json` | Multi-candidate ARVP batch runner design contracts |
 
 ## Related canon (not duplicated here)
 

--- a/docs/contracts/examples/profitability_arvp_batch_manifest_valid.json
+++ b/docs/contracts/examples/profitability_arvp_batch_manifest_valid.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "profitability_arvp_batch_manifest.v1",
+  "batch_id": "profit-batch-btc-breakout-q2",
+  "created_at": "2026-06-06T15:30:00+00:00",
+  "parent_issue": "#3032",
+  "dataset_selection": {
+    "dataset_quality_report_ref": "docs/contracts/examples/profitability_dataset_quality_report_valid.json",
+    "dataset_fingerprint": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "symbol": "BTCUSDT",
+    "timeframe": "1m",
+    "window_start_utc": "2026-04-18T00:00:00+00:00",
+    "window_end_utc": "2026-04-18T12:00:00+00:00",
+    "quality_verdict": "PASS"
+  },
+  "candidate_inputs": [
+    {
+      "candidate_id": "cand-primary-breakout-a1",
+      "candidate_contract_ref": "docs/contracts/examples/profitability_candidate_contract_valid.json",
+      "candidate_status": "BACKTESTED",
+      "adapter_id": "primary_breakout_v1.replay_adapter",
+      "expected_next_gate": "ARVP_VALIDATION",
+      "baseline_evidence_ref": "artifacts/backtests/primary_breakout_v1/summary.json"
+    }
+  ],
+  "adapter_boundary": {
+    "candidate_contract_required": true,
+    "dataset_selector_required": true,
+    "pure_research_only": true,
+    "core_rewrite_allowed": false
+  },
+  "runner_surfaces": {
+    "scenario_harness_surface": "core.replay.scenario_harness.run_scenario_group",
+    "run_registry_surface": "core.replay.run_registry.ReplayRunRecord",
+    "gate_surface": "core.replay.arvp_gate.ARVPEvidenceBundle",
+    "replay_compare_surface": "core.replay.replay_vs_paper_compare",
+    "scenario_pack_ref": "core.replay.scenario_packs.BUILTIN_SCENARIO_IDS"
+  },
+  "evidence_hooks": {
+    "evidence_packet_schema_ref": "docs/contracts/profitability_evidence_packet.v1.schema.json",
+    "batch_summary_schema_ref": "docs/contracts/profitability_arvp_batch_summary.v1.schema.json",
+    "gate_verdict_required": true,
+    "compare_ref_required": true
+  },
+  "failure_policy": {
+    "candidate_failure_mode": "CONTINUE_AND_RECORD",
+    "blocked_conditions": [
+      "dataset_quality_verdict=BLOCKED",
+      "candidate_contract_missing",
+      "adapter_boundary_missing"
+    ],
+    "parked_conditions": [
+      "scenario_group_failed_partial",
+      "replay_compare_missing",
+      "evidence_packet_incomplete"
+    ],
+    "summary_required": true
+  },
+  "limitations": [
+    "Research-only manifest; no runtime orchestration is implied.",
+    "Scenario Pack Library remains a separate issue (#3038)."
+  ]
+}

--- a/docs/contracts/examples/profitability_arvp_batch_summary_valid.json
+++ b/docs/contracts/examples/profitability_arvp_batch_summary_valid.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "profitability_arvp_batch_summary.v1",
+  "batch_id": "profit-batch-btc-breakout-q2",
+  "started_at": "2026-06-06T15:35:00+00:00",
+  "finished_at": "2026-06-06T16:10:00+00:00",
+  "batch_status": "PARTIAL",
+  "total_candidates": 2,
+  "completed_candidates": 1,
+  "parked_candidates": 1,
+  "blocked_candidates": 0,
+  "failed_candidates": 0,
+  "candidate_results": [
+    {
+      "candidate_id": "cand-primary-breakout-a1",
+      "candidate_contract_ref": "docs/contracts/examples/profitability_candidate_contract_valid.json",
+      "batch_outcome": "COMPLETED",
+      "dataset_quality_verdict": "PASS",
+      "scenario_group_id": "profit_batch_group_01",
+      "scenario_group_manifest_ref": "artifacts/replay_reports/profit_batch_group_01/scenario_group_manifest.json",
+      "scenario_group_fingerprint": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "run_record_refs": [
+        "artifacts/replay_reports/profit_batch_group_01/run_registry.jsonl#replay-ae0be21cc75e-0001"
+      ],
+      "gate_verdict_ref": "artifacts/replay_reports/profit_batch_group_01/arvp_gate_verdict.json",
+      "replay_compare_ref": "artifacts/replay_reports/profit_batch_group_01/replay_vs_paper_compare.json",
+      "evidence_packet_ref": "artifacts/replay_reports/profit_batch_group_01/profitability_evidence_packet.json",
+      "blocking_reasons": [],
+      "advisory_findings": [
+        "scenario_group: total=5 succeeded=5 failed=0"
+      ],
+      "next_action": "EXECUTION_ECONOMICS"
+    },
+    {
+      "candidate_id": "cand-secondary-breakout-b2",
+      "candidate_contract_ref": "docs/contracts/examples/profitability_candidate_contract_valid.json",
+      "batch_outcome": "PARKED",
+      "dataset_quality_verdict": "WARNING",
+      "scenario_group_id": "profit_batch_group_02",
+      "scenario_group_manifest_ref": "artifacts/replay_reports/profit_batch_group_02/scenario_group_manifest.json",
+      "scenario_group_fingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "run_record_refs": [
+        "artifacts/replay_reports/profit_batch_group_02/run_registry.jsonl#replay-bf1ce21cc75e-0001"
+      ],
+      "gate_verdict_ref": "artifacts/replay_reports/profit_batch_group_02/arvp_gate_verdict.json",
+      "evidence_packet_ref": "artifacts/replay_reports/profit_batch_group_02/profitability_evidence_packet.json",
+      "blocking_reasons": [],
+      "advisory_findings": [
+        "dataset_quality_warning: missing_candles=2",
+        "scenario_group: total=5 succeeded=4 failed=1"
+      ],
+      "next_action": "SCENARIO_PACK_REVIEW"
+    }
+  ],
+  "limitations": [
+    "Batch summary is advisory evidence only.",
+    "No ranking or capital decision is implied."
+  ]
+}

--- a/docs/contracts/profitability_arvp_batch_manifest.v1.schema.json
+++ b/docs/contracts/profitability_arvp_batch_manifest.v1.schema.json
@@ -1,0 +1,260 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/profitability_arvp_batch_manifest.v1.schema.json",
+  "title": "Profitability ARVP Batch Manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "batch_id",
+    "created_at",
+    "parent_issue",
+    "dataset_selection",
+    "candidate_inputs",
+    "adapter_boundary",
+    "runner_surfaces",
+    "evidence_hooks",
+    "failure_policy",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_arvp_batch_manifest.v1"
+    },
+    "batch_id": {
+      "type": "string",
+      "pattern": "^profit-batch-[a-z0-9_-]{8,64}$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "parent_issue": {
+      "type": "string",
+      "pattern": "^#3032$"
+    },
+    "dataset_selection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dataset_quality_report_ref",
+        "dataset_fingerprint",
+        "symbol",
+        "timeframe",
+        "window_start_utc",
+        "window_end_utc",
+        "quality_verdict"
+      ],
+      "properties": {
+        "dataset_quality_report_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "dataset_fingerprint": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "symbol": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timeframe": {
+          "type": "string",
+          "minLength": 1
+        },
+        "window_start_utc": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "window_end_utc": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "quality_verdict": {
+          "type": "string",
+          "enum": ["PASS", "WARNING", "FAIL", "BLOCKED"]
+        }
+      }
+    },
+    "candidate_inputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "candidate_id",
+          "candidate_contract_ref",
+          "candidate_status",
+          "adapter_id",
+          "expected_next_gate"
+        ],
+        "properties": {
+          "candidate_id": {
+            "type": "string",
+            "pattern": "^cand-[a-z0-9_-]{4,64}$"
+          },
+          "candidate_contract_ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "candidate_status": {
+            "type": "string",
+            "enum": [
+              "SPECIFIED",
+              "BACKTESTED",
+              "ARVP_VALIDATED",
+              "STRESS_TESTED",
+              "PARKED",
+              "UNSAFE"
+            ]
+          },
+          "adapter_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9_.-]{3,64}$"
+          },
+          "expected_next_gate": {
+            "type": "string",
+            "enum": [
+              "ARVP_VALIDATION",
+              "STRESS_TEST",
+              "EXECUTION_ECONOMICS",
+              "PARK",
+              "REJECT"
+            ]
+          },
+          "baseline_evidence_ref": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "adapter_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_contract_required",
+        "dataset_selector_required",
+        "pure_research_only",
+        "core_rewrite_allowed"
+      ],
+      "properties": {
+        "candidate_contract_required": {
+          "type": "boolean"
+        },
+        "dataset_selector_required": {
+          "type": "boolean"
+        },
+        "pure_research_only": {
+          "type": "boolean"
+        },
+        "core_rewrite_allowed": {
+          "type": "boolean"
+        }
+      }
+    },
+    "runner_surfaces": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scenario_harness_surface",
+        "run_registry_surface",
+        "gate_surface",
+        "replay_compare_surface",
+        "scenario_pack_ref"
+      ],
+      "properties": {
+        "scenario_harness_surface": {
+          "type": "string",
+          "const": "core.replay.scenario_harness.run_scenario_group"
+        },
+        "run_registry_surface": {
+          "type": "string",
+          "const": "core.replay.run_registry.ReplayRunRecord"
+        },
+        "gate_surface": {
+          "type": "string",
+          "const": "core.replay.arvp_gate.ARVPEvidenceBundle"
+        },
+        "replay_compare_surface": {
+          "type": "string",
+          "const": "core.replay.replay_vs_paper_compare"
+        },
+        "scenario_pack_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidence_hooks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evidence_packet_schema_ref",
+        "batch_summary_schema_ref",
+        "gate_verdict_required",
+        "compare_ref_required"
+      ],
+      "properties": {
+        "evidence_packet_schema_ref": {
+          "type": "string",
+          "const": "docs/contracts/profitability_evidence_packet.v1.schema.json"
+        },
+        "batch_summary_schema_ref": {
+          "type": "string",
+          "const": "docs/contracts/profitability_arvp_batch_summary.v1.schema.json"
+        },
+        "gate_verdict_required": {
+          "type": "boolean"
+        },
+        "compare_ref_required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "failure_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_failure_mode",
+        "blocked_conditions",
+        "parked_conditions",
+        "summary_required"
+      ],
+      "properties": {
+        "candidate_failure_mode": {
+          "type": "string",
+          "enum": ["CONTINUE_AND_RECORD", "STOP_BATCH"]
+        },
+        "blocked_conditions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "parked_conditions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "summary_required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/contracts/profitability_arvp_batch_summary.v1.schema.json
+++ b/docs/contracts/profitability_arvp_batch_summary.v1.schema.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/profitability_arvp_batch_summary.v1.schema.json",
+  "title": "Profitability ARVP Batch Summary v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "batch_id",
+    "started_at",
+    "finished_at",
+    "batch_status",
+    "total_candidates",
+    "completed_candidates",
+    "parked_candidates",
+    "blocked_candidates",
+    "failed_candidates",
+    "candidate_results",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_arvp_batch_summary.v1"
+    },
+    "batch_id": {
+      "type": "string",
+      "pattern": "^profit-batch-[a-z0-9_-]{8,64}$"
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "finished_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "batch_status": {
+      "type": "string",
+      "enum": ["COMPLETED", "PARTIAL", "BLOCKED", "FAILED"]
+    },
+    "total_candidates": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "completed_candidates": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "parked_candidates": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "blocked_candidates": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "failed_candidates": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "candidate_results": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "candidate_id",
+          "candidate_contract_ref",
+          "batch_outcome",
+          "dataset_quality_verdict",
+          "scenario_group_id",
+          "scenario_group_manifest_ref",
+          "scenario_group_fingerprint",
+          "run_record_refs",
+          "gate_verdict_ref",
+          "evidence_packet_ref",
+          "blocking_reasons",
+          "advisory_findings",
+          "next_action"
+        ],
+        "properties": {
+          "candidate_id": {
+            "type": "string",
+            "pattern": "^cand-[a-z0-9_-]{4,64}$"
+          },
+          "candidate_contract_ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "batch_outcome": {
+            "type": "string",
+            "enum": [
+              "COMPLETED",
+              "PARKED",
+              "BLOCKED",
+              "FAILED"
+            ]
+          },
+          "dataset_quality_verdict": {
+            "type": "string",
+            "enum": ["PASS", "WARNING", "FAIL", "BLOCKED"]
+          },
+          "scenario_group_id": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_-]{1,64}$"
+          },
+          "scenario_group_manifest_ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "scenario_group_fingerprint": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          },
+          "run_record_refs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "gate_verdict_ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "replay_compare_ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_packet_ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "blocking_reasons": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "advisory_findings": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "next_action": {
+            "type": "string",
+            "enum": [
+              "EXECUTION_ECONOMICS",
+              "SCENARIO_PACK_REVIEW",
+              "DATA_REPAIR",
+              "PARK",
+              "REJECT"
+            ]
+          }
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/strategy/CDB_PROFITABILITY_ARVP_BATCH_RUNNER_V1.md
+++ b/docs/strategy/CDB_PROFITABILITY_ARVP_BATCH_RUNNER_V1.md
@@ -1,0 +1,149 @@
+# CDB Profitability ARVP Batch Runner v1
+
+**Status:** Draft contract surface for #3037  
+**Mode:** Docs / schema / example fixtures only  
+**Parent:** #3032  
+**Live-Readiness:** NO-GO  
+**Runtime Impact:** none  
+
+## Purpose
+
+This document defines the first design contract for a multi-candidate ARVP batch
+runner inside the Profitability Engine program.
+
+The goal is not a new runtime. The goal is a repeatable batch shape that can:
+
+- take multiple candidate contracts as input
+- bind them to one explicit dataset selection
+- route them through existing replay and ARVP evidence surfaces
+- emit a comparable batch summary with explicit `COMPLETED`, `PARKED`,
+  `BLOCKED`, or `FAILED` outcomes
+
+## Contract Artifacts
+
+| Artifact | Path | Role |
+|---|---|---|
+| Batch manifest schema | `docs/contracts/profitability_arvp_batch_manifest.v1.schema.json` | Input contract for candidates, dataset selection, evidence hooks, and failure policy |
+| Batch summary schema | `docs/contracts/profitability_arvp_batch_summary.v1.schema.json` | Output contract for per-candidate outcomes and batch-level status |
+| Manifest example | `docs/contracts/examples/profitability_arvp_batch_manifest_valid.json` | Valid research-only manifest fixture |
+| Summary example | `docs/contracts/examples/profitability_arvp_batch_summary_valid.json` | Valid research-only batch summary fixture |
+
+## Relationship To Existing ARVP Surfaces
+
+Batch Runner v1 is deliberately a thin orchestration layer over existing repo
+surfaces. It does not replace them:
+
+- `core.replay.scenario_harness.run_scenario_group` remains the scenario group
+  orchestration anchor and emits `ScenarioGroupManifest`.
+- `core.replay.run_registry.ReplayRunRecord` remains the run identity and
+  lifecycle anchor.
+- `core.replay.arvp_gate.ARVPEvidenceBundle` and `ARVPGateVerdict` remain the
+  gate/evidence verdict anchor.
+- `core.replay.replay_vs_paper_compare` remains the replay-vs-paper comparison
+  anchor.
+- `core.replay.scenario_packs` is a current technical scenario source, but the
+  profitability-specific Scenario Pack Library remains separate work in `#3038`.
+
+This means Batch Runner v1 defines how existing evidence is grouped, not how the
+underlying ARVP components behave internally.
+
+## Manifest Design
+
+The manifest is the controlled batch input. It requires:
+
+- one explicit dataset selection with fingerprint and quality verdict
+- one or more candidate inputs with contract references and adapter IDs
+- a clear adapter boundary that stays research-only
+- explicit runner surface references
+- explicit evidence hooks into the Profitability Evidence Packet and batch
+  summary
+- a failure policy that distinguishes `BLOCKED` from `PARKED`
+
+The manifest is fail-closed:
+
+- missing candidate contracts are not silently tolerated
+- missing dataset quality reports are not silently tolerated
+- adapter boundary ambiguity is a `BLOCKED` condition
+- scenario pack usage is by reference only in this issue; pack definitions are
+  not duplicated here
+
+## Output Bundle Design
+
+The summary is the controlled batch output. It records:
+
+- batch-level status
+- counts for completed, parked, blocked, and failed candidates
+- per-candidate dataset quality verdict
+- per-candidate `ScenarioGroupManifest` reference and fingerprint
+- one or more run record references
+- gate verdict reference
+- optional replay-vs-paper compare reference
+- evidence packet reference
+- blocking reasons, advisory findings, and next action
+
+This design keeps a candidate comparable even when the batch is only partial.
+One weak candidate must not erase the evidence of the others.
+
+## Failure Semantics
+
+Batch Runner v1 separates outcomes deliberately:
+
+- `COMPLETED`: evidence bundle is complete enough to move into the next
+  profitability step
+- `PARKED`: evidence exists, but scenario or comparison quality still requires
+  review
+- `BLOCKED`: a prerequisite such as dataset quality or adapter boundary is
+  missing, so honest execution is not possible
+- `FAILED`: execution attempt or evidence generation failed in a way that still
+  needs explicit triage
+
+`PARKED` is not a soft success, and `BLOCKED` is not a cosmetic label. Both
+must remain explicit in the batch summary.
+
+## Relationship To Neighbor Issues
+
+- `#3034` defines the candidate and evidence packet contracts consumed here.
+- `#3035` defines the dataset quality report referenced by the batch manifest.
+- `#3038` stays separate and will define profitability-specific scenario pack
+  contents; this slice only defines the consumption hook.
+- `#3039` stays separate and will define net-economics interpretation after
+  batch evidence exists.
+- `#3031` remains the active data blocker for replayable 1m candles and can
+  still block honest batch execution.
+
+## Safety Boundaries
+
+- LR remains NO-GO.
+- `trade-capable` is not Live-Go.
+- No Echtgeld-Go.
+- No runtime change.
+- No productive DB write.
+- No MCP mutation.
+- No Risk, Execution, Allocation, kill-switch, or LR gate change.
+- ARVP, backtest, and paper are evidence, not approval.
+- AI, dashboard, and docs are not authority.
+- No automatic promotion.
+- No capital scaling without separate gates.
+
+## Non-Goals
+
+- no new batch runtime implementation
+- no core rewrite
+- no DB migration
+- no scenario pack catalog definition
+- no execution economics model
+- no strategy ranking
+- no live-readiness uplift
+
+## Validation
+
+For this docs-only slice, validation means:
+
+1. both JSON schemas parse and pass schema validation
+2. both example fixtures validate against their matching schemas
+3. the batch contracts reference the existing ARVP surfaces instead of replacing
+   them
+4. `BLOCKED` and `PARKED` remain explicit and fail-closed
+
+This does not prove batch profitability, paper readiness, live readiness, or
+capital readiness.


### PR DESCRIPTION
## Kurzbefund
- fuehrt einen docs-only Slice fuer #3037 ein: ARVP Batch Runner v1 als Strategiedokument plus Input-/Output-Contracts mit validierten Beispielartefakten
- haengt den Profitability-Batch-Runner explizit an bestehende ARVP-Surfaces wie ScenarioGroupManifest, ReplayRunRecord und ARVPEvidenceBundle statt neue Runtime zu erfinden
- gestapelte PR auf dem offenen #3035-Branch, weil der Batch-Manifest-Contract die Dataset-Quality-Gate-Ref aus #3035 konsumiert

## Warum jetzt
- nach #3034 und #3035 ist der naechste belastbare Profitability-Schritt die kontrollierte Multi-Candidate-Orchestrierung ueber vorhandene ARVP-Flaechen
- der Slice macht Inputs, Evidence-Hooks und BLOCKED/PARKED-Semantik vergleichbar, ohne Core, Risk oder Live-Gates anzutasten

## Scope
- in: Strategiedoku, Batch-Manifest-Schema, Batch-Summary-Schema, zwei Beispielartefakte, README-Eintrag
- out: Runtime-Implementierung, Scenario-Pack-Katalog (#3038), Execution Economics (#3039), Ranking, DB/MCP-Mutationen, Live-Go-Aussagen

## Betroffene Dateien / Artefakte
- docs/strategy/CDB_PROFITABILITY_ARVP_BATCH_RUNNER_V1.md
- docs/contracts/profitability_arvp_batch_manifest.v1.schema.json
- docs/contracts/profitability_arvp_batch_summary.v1.schema.json
- docs/contracts/examples/profitability_arvp_batch_manifest_valid.json
- docs/contracts/examples/profitability_arvp_batch_summary_valid.json
- docs/contracts/README.md

## Validierung / Checks
- JSON Schema validation beider Beispielartefakte: PASS
- git diff --check: keine Patch-/Whitespace-Fehler; nur erwartete LF/CRLF-Warnung in docs/contracts/README.md
- Doku-Quercheck auf #3034/#3035/#3038/#3039/#3031 und die Profitability-Guardrails

## Risiken / Guardrails
- LR bleibt NO-GO; trade-capable ist kein Live-Go
- keine Runtime-, Risk-, Execution-, Allocation- oder DB-Aenderung
- Scenario Pack Library und Execution Economics bleiben absichtlich in getrennten Issues
- #3031 bleibt expliziter Datenblocker fuer ehrliche Batch-Ausfuehrung

## Restunsicherheiten
- diese PR definiert nur die Batch-Contract-Flaeche und keine technische Runner-Durchsetzung
- weil #3044 noch offen ist, ist diese PR bewusst gestapelt und erst sauber landbar, wenn der #3035-Branch in main aufgegangen ist

## Issue-Bezug
- Refs #3037
- Refs #3032
