### PR TITLE
[PROFITABILITY][VALIDATION] Define scenario pack library v1

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -13,6 +13,7 @@ Repo-backed JSON/YAML schemas und Contract-Dokumente für Messages, Replay und C
 | Profitability | `profitability_candidate_contract.v1.schema.json`, `profitability_evidence_packet.v1.schema.json` | Strategy candidate and evidence packet research contracts |
 | Profitability data quality | `profitability_dataset_quality_report.v1.schema.json` | Dataset quality gate report for candidate validation |
 | Profitability ARVP batch | `profitability_arvp_batch_manifest.v1.schema.json`, `profitability_arvp_batch_summary.v1.schema.json` | Multi-candidate ARVP batch runner design contracts |
+| Profitability scenario packs | `profitability_scenario_pack_catalog.v1.schema.json`, `profitability_scenario_stress_summary.v1.schema.json` | Stress-scenario catalog and candidate stress summary contracts |
 
 ## Related canon (not duplicated here)
 

--- a/docs/contracts/examples/profitability_scenario_pack_catalog_valid.json
+++ b/docs/contracts/examples/profitability_scenario_pack_catalog_valid.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": "profitability_scenario_pack_catalog.v1",
+  "catalog_id": "psc-profitability-v1",
+  "created_at": "2026-06-06T17:20:00+00:00",
+  "parent_issue": "#3032",
+  "pack_version": "v1",
+  "stress_domains": [
+    "SLIPPAGE",
+    "SPREAD",
+    "PARTIAL_FILL",
+    "REJECTION",
+    "LATENCY",
+    "FEED_GAP",
+    "VOLATILITY",
+    "LIQUIDITY"
+  ],
+  "scenario_packs": [
+    {
+      "scenario_id": "baseline_reference",
+      "domain": "SPREAD",
+      "severity": "BASELINE",
+      "description": "Reference baseline with no extra friction beyond the scoped research assumptions.",
+      "deterministic": true,
+      "config_overrides": {},
+      "expected_research_use": "BASELINE_REFERENCE"
+    },
+    {
+      "scenario_id": "slippage_high",
+      "domain": "SLIPPAGE",
+      "severity": "HIGH",
+      "description": "Adverse slippage shock for thin fills or unfavorable price improvement.",
+      "deterministic": true,
+      "config_overrides": {
+        "execution_slippage_bps": 40
+      },
+      "expected_research_use": "REJECT_IF_FRAGILE"
+    },
+    {
+      "scenario_id": "rejection_medium",
+      "domain": "REJECTION",
+      "severity": "MEDIUM",
+      "description": "Deterministic rejection injection on a subset of entry attempts.",
+      "deterministic": true,
+      "config_overrides": {
+        "entry_rejection_rate": 0.15
+      },
+      "expected_research_use": "PARK_IF_FRAGILE"
+    },
+    {
+      "scenario_id": "feed_gap_high",
+      "domain": "FEED_GAP",
+      "severity": "HIGH",
+      "description": "Stale or gapped feed segment to expose brittle timing assumptions.",
+      "deterministic": true,
+      "config_overrides": {
+        "feed_gap_bars": 3
+      },
+      "expected_research_use": "STRESS_SCREEN"
+    }
+  ],
+  "evidence_integration": {
+    "batch_manifest_ref": "docs/contracts/profitability_arvp_batch_manifest.v1.schema.json",
+    "evidence_packet_ref": "docs/contracts/profitability_evidence_packet.v1.schema.json",
+    "stress_summary_ref": "docs/contracts/profitability_scenario_stress_summary.v1.schema.json",
+    "scenario_results_required": true
+  },
+  "limitations": [
+    "Catalog is research-only and does not imply runtime implementation.",
+    "Execution Economics remains a separate issue (#3039)."
+  ]
+}

--- a/docs/contracts/examples/profitability_scenario_stress_summary_valid.json
+++ b/docs/contracts/examples/profitability_scenario_stress_summary_valid.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "profitability_scenario_stress_summary.v1",
+  "stress_summary_id": "pss-primary-breakout-v1",
+  "candidate_id": "cand-primary-breakout-a1",
+  "catalog_id": "psc-profitability-v1",
+  "generated_at": "2026-06-06T17:45:00+00:00",
+  "overall_stress_outcome": "WARNING",
+  "scenario_results": [
+    {
+      "scenario_id": "baseline_reference",
+      "domain": "SPREAD",
+      "severity": "BASELINE",
+      "status": "PASS",
+      "net_return_delta": 0.0,
+      "max_drawdown_delta": 0.0,
+      "impact_summary": "Reference baseline remains within expected drawdown and return bounds.",
+      "requires_followup_issue": false
+    },
+    {
+      "scenario_id": "slippage_high",
+      "domain": "SLIPPAGE",
+      "severity": "HIGH",
+      "status": "FAIL",
+      "net_return_delta": -0.086,
+      "max_drawdown_delta": 0.041,
+      "impact_summary": "Candidate loses too much net return under adverse slippage shock.",
+      "requires_followup_issue": false
+    },
+    {
+      "scenario_id": "rejection_medium",
+      "domain": "REJECTION",
+      "severity": "MEDIUM",
+      "status": "WARNING",
+      "net_return_delta": -0.019,
+      "max_drawdown_delta": 0.008,
+      "impact_summary": "Candidate remains viable but should be parked pending order-path review.",
+      "requires_followup_issue": false
+    },
+    {
+      "scenario_id": "feed_gap_high",
+      "domain": "FEED_GAP",
+      "severity": "HIGH",
+      "status": "WARNING",
+      "net_return_delta": -0.026,
+      "max_drawdown_delta": 0.012,
+      "impact_summary": "Signal timing degrades under stale-feed windows but does not fully break.",
+      "requires_followup_issue": false
+    }
+  ],
+  "recommendation_impact": {
+    "promote_allowed": false,
+    "park_required": true,
+    "reject_required": false,
+    "notes": "Stress outcome stays advisory evidence only and blocks automatic promotion."
+  },
+  "limitations": [
+    "Stress summary is advisory evidence and not a paper or live approval.",
+    "Ranking and net-economics interpretation remain downstream work."
+  ]
+}

--- a/docs/contracts/profitability_scenario_pack_catalog.v1.schema.json
+++ b/docs/contracts/profitability_scenario_pack_catalog.v1.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/profitability_scenario_pack_catalog.v1.schema.json",
+  "title": "Profitability Scenario Pack Catalog v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "catalog_id",
+    "created_at",
+    "parent_issue",
+    "pack_version",
+    "stress_domains",
+    "scenario_packs",
+    "evidence_integration",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_scenario_pack_catalog.v1"
+    },
+    "catalog_id": {
+      "type": "string",
+      "pattern": "^psc-[a-z0-9_-]{6,64}$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "parent_issue": {
+      "type": "string",
+      "pattern": "^#3032$"
+    },
+    "pack_version": {
+      "type": "string",
+      "pattern": "^v[0-9]+$"
+    },
+    "stress_domains": {
+      "type": "array",
+      "minItems": 4,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "SLIPPAGE",
+          "SPREAD",
+          "PARTIAL_FILL",
+          "REJECTION",
+          "LATENCY",
+          "FEED_GAP",
+          "VOLATILITY",
+          "LIQUIDITY"
+        ]
+      }
+    },
+    "scenario_packs": {
+      "type": "array",
+      "minItems": 4,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "scenario_id",
+          "domain",
+          "severity",
+          "description",
+          "deterministic",
+          "config_overrides",
+          "expected_research_use"
+        ],
+        "properties": {
+          "scenario_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9_]{3,64}$"
+          },
+          "domain": {
+            "type": "string",
+            "enum": [
+              "SLIPPAGE",
+              "SPREAD",
+              "PARTIAL_FILL",
+              "REJECTION",
+              "LATENCY",
+              "FEED_GAP",
+              "VOLATILITY",
+              "LIQUIDITY"
+            ]
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["BASELINE", "LOW", "MEDIUM", "HIGH"]
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "deterministic": {
+            "type": "boolean"
+          },
+          "config_overrides": {
+            "type": "object"
+          },
+          "expected_research_use": {
+            "type": "string",
+            "enum": [
+              "BASELINE_REFERENCE",
+              "STRESS_SCREEN",
+              "PARK_IF_FRAGILE",
+              "REJECT_IF_FRAGILE"
+            ]
+          },
+          "notes": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "evidence_integration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "batch_manifest_ref",
+        "evidence_packet_ref",
+        "stress_summary_ref",
+        "scenario_results_required"
+      ],
+      "properties": {
+        "batch_manifest_ref": {
+          "type": "string",
+          "const": "docs/contracts/profitability_arvp_batch_manifest.v1.schema.json"
+        },
+        "evidence_packet_ref": {
+          "type": "string",
+          "const": "docs/contracts/profitability_evidence_packet.v1.schema.json"
+        },
+        "stress_summary_ref": {
+          "type": "string",
+          "const": "docs/contracts/profitability_scenario_stress_summary.v1.schema.json"
+        },
+        "scenario_results_required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/contracts/profitability_scenario_stress_summary.v1.schema.json
+++ b/docs/contracts/profitability_scenario_stress_summary.v1.schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/profitability_scenario_stress_summary.v1.schema.json",
+  "title": "Profitability Scenario Stress Summary v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "stress_summary_id",
+    "candidate_id",
+    "catalog_id",
+    "generated_at",
+    "overall_stress_outcome",
+    "scenario_results",
+    "recommendation_impact",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_scenario_stress_summary.v1"
+    },
+    "stress_summary_id": {
+      "type": "string",
+      "pattern": "^pss-[a-z0-9_-]{6,64}$"
+    },
+    "candidate_id": {
+      "type": "string",
+      "pattern": "^cand-[a-z0-9_-]{4,64}$"
+    },
+    "catalog_id": {
+      "type": "string",
+      "pattern": "^psc-[a-z0-9_-]{6,64}$"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "overall_stress_outcome": {
+      "type": "string",
+      "enum": ["PASS", "WARNING", "FAIL", "BLOCKED"]
+    },
+    "scenario_results": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "scenario_id",
+          "domain",
+          "severity",
+          "status",
+          "net_return_delta",
+          "max_drawdown_delta",
+          "impact_summary"
+        ],
+        "properties": {
+          "scenario_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9_]{3,64}$"
+          },
+          "domain": {
+            "type": "string",
+            "enum": [
+              "SLIPPAGE",
+              "SPREAD",
+              "PARTIAL_FILL",
+              "REJECTION",
+              "LATENCY",
+              "FEED_GAP",
+              "VOLATILITY",
+              "LIQUIDITY"
+            ]
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["BASELINE", "LOW", "MEDIUM", "HIGH"]
+          },
+          "status": {
+            "type": "string",
+            "enum": ["PASS", "WARNING", "FAIL", "BLOCKED", "NOT_RUN"]
+          },
+          "net_return_delta": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "max_drawdown_delta": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "impact_summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "requires_followup_issue": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "recommendation_impact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "promote_allowed",
+        "park_required",
+        "reject_required",
+        "notes"
+      ],
+      "properties": {
+        "promote_allowed": {
+          "type": "boolean"
+        },
+        "park_required": {
+          "type": "boolean"
+        },
+        "reject_required": {
+          "type": "boolean"
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/strategy/CDB_PROFITABILITY_SCENARIO_PACK_LIBRARY_V1.md
+++ b/docs/strategy/CDB_PROFITABILITY_SCENARIO_PACK_LIBRARY_V1.md
@@ -1,0 +1,145 @@
+# CDB Profitability Scenario Pack Library v1
+
+**Status:** Draft contract surface for #3038  
+**Mode:** Docs / schema / example fixtures only  
+**Parent:** #3032  
+**Live-Readiness:** NO-GO  
+**Runtime Impact:** none  
+
+## Purpose
+
+This document defines the first profitability-specific Scenario Pack Library for
+stress-testing strategy candidates before they move toward ranking or paper
+candidate status.
+
+The goal is not a new simulator. The goal is a controlled, versioned catalog of
+stress scenarios that can be consumed by the ARVP Batch Runner and reported
+through existing Profitability evidence surfaces.
+
+## Contract Artifacts
+
+| Artifact | Path | Role |
+|---|---|---|
+| Scenario pack catalog schema | `docs/contracts/profitability_scenario_pack_catalog.v1.schema.json` | Versioned catalog of profitability stress scenarios |
+| Stress summary schema | `docs/contracts/profitability_scenario_stress_summary.v1.schema.json` | Candidate-level stress outcome summary |
+| Catalog example | `docs/contracts/examples/profitability_scenario_pack_catalog_valid.json` | Valid research-only catalog fixture |
+| Stress summary example | `docs/contracts/examples/profitability_scenario_stress_summary_valid.json` | Valid research-only stress summary fixture |
+
+## Relationship To Existing Repo Surfaces
+
+Profitability Scenario Pack Library v1 does not replace the existing technical
+scenario surfaces:
+
+- `core.replay.scenario_packs.py` remains the current technical built-in pack
+  surface and already defines deterministic packs such as `baseline`,
+  `pessimistic_execution`, `delayed_execution`, `low_liquidity`, and
+  `feed_gap`.
+- `#3037` defines how a batch runner consumes scenario references and groups
+  them into comparable evidence.
+- `profitability_evidence_packet.v1` already contains `scenario_results` and is
+  the downstream evidence hook for this slice.
+
+This means `#3038` defines the profitability research catalog and stress
+semantics, not a new runtime runner.
+
+## Scenario Domains
+
+Scenario Pack Library v1 must cover at least these domains:
+
+- slippage shock
+- spread expansion
+- partial fills
+- rejections
+- latency
+- feed gaps
+- volatility stress
+- liquidity stress
+
+Each scenario in the catalog carries:
+
+- a stable `scenario_id`
+- a domain
+- a severity
+- deterministic config overrides
+- an expected research use
+
+The deterministic requirement is deliberate. Random stress without reproducible
+shape would weaken candidate comparison and break auditability.
+
+## Catalog Design
+
+The catalog is the reusable scenario definition layer. It records:
+
+- catalog identity and pack version
+- covered stress domains
+- one or more scenario packs with deterministic overrides
+- explicit evidence integration references
+- limitations
+
+Versioning matters because later scenario additions must not silently rewrite
+the meaning of older stress evidence.
+
+## Stress Summary Design
+
+The stress summary is the candidate-level outcome layer. It records:
+
+- overall stress outcome
+- per-scenario status
+- per-scenario net return delta
+- per-scenario drawdown delta
+- impact summary
+- recommendation impact without authority
+
+Stress evidence remains advisory only:
+
+- `PASS` does not authorize paper, micro-live, live, or capital scaling
+- `WARNING` means the candidate may need to be parked or reviewed
+- `FAIL` means the candidate is stress-fragile for the scoped research purpose
+- `BLOCKED` means the stress result cannot be assessed honestly
+
+## Relationship To Neighbor Issues
+
+- `#3034` defines the evidence packet surface that receives scenario results.
+- `#3035` defines dataset quality prerequisites before stress evidence is
+  trusted.
+- `#3037` defines the batch-runner consumption hook for scenario references.
+- `#3039` remains separate and will convert gross results plus friction into
+  net-economics interpretation.
+- If later runtime or simulation work is needed beyond this contract surface,
+  that implementation stays out of scope for this slice and belongs in a
+  separate issue.
+
+## Safety Boundaries
+
+- LR remains NO-GO.
+- `trade-capable` is not Live-Go.
+- No Echtgeld-Go.
+- No runtime change.
+- No productive DB write.
+- No MCP mutation.
+- No Risk, Execution, Allocation, kill-switch, or LR gate change.
+- ARVP, backtest, and paper are evidence, not approval.
+- AI, dashboard, and docs are not authority.
+- No automatic promotion.
+- No capital scaling without separate gates.
+
+## Non-Goals
+
+- no scenario runner implementation
+- no execution-service rewrite
+- no new execution simulation in core
+- no DB migration
+- no ranking logic
+- no live-readiness uplift
+
+## Validation
+
+For this docs-only slice, validation means:
+
+1. both JSON schemas parse and pass schema validation
+2. both example fixtures validate against their matching schemas
+3. the catalog covers the required `#3038` stress domains
+4. the evidence path from scenario catalog to batch runner to evidence packet
+   stays explicit
+
+This does not prove a candidate is profitable, paper-ready, or live-ready.


### PR DESCRIPTION
## Kurzbefund
- fuehrt einen docs-only Slice fuer #3038 ein: profitability-spezifische Scenario Pack Library v1 als Strategiedokument plus Katalog-/Stress-Summary-Contracts mit validierten Beispielartefakten
- trennt den Profitability-Stresskatalog bewusst von der bestehenden technischen `core/replay/scenario_packs.py`-Flaeche und haengt ihn stattdessen an #3037 und das bestehende Evidence Packet an
- gestapelte PR auf dem offenen #3037-Branch, weil die Scenario-Pack-Refs vom frischen ARVP-Batch-Runner-Contract konsumiert werden

## Warum jetzt
- nach Candidate Contract, Dataset Quality Gate und ARVP Batch Runner fehlt der wiederverwendbare Stresskatalog, bevor Kandidaten Richtung Ranking oder Paper verglichen werden
- der Slice macht Stress-Domaenen, Versionierung und Evidence-Integration explizit, ohne Core, Risk oder Live-Gates anzutasten

## Scope
- in: Strategiedoku, Scenario-Pack-Katalog-Schema, Stress-Summary-Schema, zwei Beispielartefakte, README-Eintrag
- out: Runtime-Implementierung, neue Execution-Simulation im Core, Execution Economics (#3039), Ranking, DB/MCP-Mutationen, Live-Go-Aussagen

## Betroffene Dateien / Artefakte
- docs/strategy/CDB_PROFITABILITY_SCENARIO_PACK_LIBRARY_V1.md
- docs/contracts/profitability_scenario_pack_catalog.v1.schema.json
- docs/contracts/profitability_scenario_stress_summary.v1.schema.json
- docs/contracts/examples/profitability_scenario_pack_catalog_valid.json
- docs/contracts/examples/profitability_scenario_stress_summary_valid.json
- docs/contracts/README.md

## Validierung / Checks
- JSON Schema validation beider Beispielartefakte: PASS
- git diff --check: keine Patch-/Whitespace-Fehler; nur erwartete LF/CRLF-Warnung in docs/contracts/README.md
- Doku-Quercheck auf #3034/#3035/#3037/#3039 sowie NO-GO-Guardrails und separate-issue-Grenze fuer spaetere Runtime-Arbeit

## Risiken / Guardrails
- LR bleibt NO-GO; trade-capable ist kein Live-Go
- keine Runtime-, Risk-, Execution-, Allocation- oder DB-Aenderung
- spaetere technische Umsetzung jenseits der Contract-Flaeche bleibt out of scope und braucht ein separates Issue
- #3039 bleibt absichtlich getrennt fuer Netto-Wirtschaftlichkeit und Cost-Interpretation

## Restunsicherheiten
- diese PR definiert nur den Stresskatalog und keine technische Durchsetzung im Runner
- weil #3045 noch offen ist, ist diese PR bewusst gestapelt und erst sauber landbar, wenn #3037 in main aufgegangen ist

## Issue-Bezug
- Refs #3038
- Refs #3032
