### PR TITLE
[PROFITABILITY][EXECUTION] Define execution economics v1

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -14,6 +14,7 @@ Repo-backed JSON/YAML schemas und Contract-Dokumente für Messages, Replay und C
 | Profitability data quality | `profitability_dataset_quality_report.v1.schema.json` | Dataset quality gate report for candidate validation |
 | Profitability ARVP batch | `profitability_arvp_batch_manifest.v1.schema.json`, `profitability_arvp_batch_summary.v1.schema.json` | Multi-candidate ARVP batch runner design contracts |
 | Profitability scenario packs | `profitability_scenario_pack_catalog.v1.schema.json`, `profitability_scenario_stress_summary.v1.schema.json` | Stress-scenario catalog and candidate stress summary contracts |
+| Profitability execution economics | `profitability_execution_economics_model.v1.schema.json`, `profitability_execution_economics_assessment.v1.schema.json` | Net-economics model and candidate cost-attribution contracts |
 
 ## Related canon (not duplicated here)
 

--- a/docs/contracts/examples/profitability_execution_economics_assessment_valid.json
+++ b/docs/contracts/examples/profitability_execution_economics_assessment_valid.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "profitability_execution_economics_assessment.v1",
+  "assessment_id": "peea-primary-breakout-v1",
+  "candidate_id": "cand-primary-breakout-a1",
+  "model_id": "peem-profitability-v1",
+  "generated_at": "2026-06-06T18:45:00+00:00",
+  "gross_return": 0.143,
+  "net_return": 0.098,
+  "cost_breakdown": {
+    "fees": 0.012,
+    "spread_cost": 0.009,
+    "slippage_cost": 0.017,
+    "other_friction_cost": 0.007,
+    "total_cost": 0.045
+  },
+  "assessment_status": "WARNING",
+  "ranking_ready": false,
+  "assumption_findings": [
+    {
+      "category": "FEE",
+      "severity": "INFO",
+      "summary": "Fee basis is a bounded research assumption and not a live venue feed."
+    },
+    {
+      "category": "SLIPPAGE",
+      "severity": "WARNING",
+      "summary": "Candidate remains materially sensitive to slippage stress and should not rank as net-ready yet."
+    }
+  ],
+  "limitations": [
+    "Assessment is advisory evidence only and cannot authorize promotion.",
+    "Final ranking remains blocked until #3040 consumes the net-economics surface."
+  ]
+}

--- a/docs/contracts/examples/profitability_execution_economics_model_valid.json
+++ b/docs/contracts/examples/profitability_execution_economics_model_valid.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "profitability_execution_economics_model.v1",
+  "model_id": "peem-profitability-v1",
+  "created_at": "2026-06-06T18:30:00+00:00",
+  "parent_issue": "#3032",
+  "fee_model": {
+    "basis": "STATIC_RESEARCH_ASSUMPTION",
+    "maker_bps": 2.0,
+    "taker_bps": 4.0,
+    "status_if_unknown": "WARNING"
+  },
+  "spread_model": {
+    "basis": "OBSERVED_REPLAY_PROXY",
+    "measurement_unit": "BPS",
+    "applies_to_entry_and_exit": true,
+    "status_if_unknown": "FAIL"
+  },
+  "slippage_model": {
+    "basis": "ARVP_SCENARIO_PROXY",
+    "input_sources": [
+      "SCENARIO_RESULTS",
+      "REPLAY_COMPARE"
+    ],
+    "quantity_sensitive": true,
+    "status_if_unknown": "FAIL"
+  },
+  "cost_attribution": {
+    "gross_return_required": true,
+    "net_return_required": true,
+    "cost_fields": [
+      "fees",
+      "spread_cost",
+      "slippage_cost",
+      "other_friction_cost"
+    ],
+    "ranking_dependency": "#3040"
+  },
+  "evidence_integration": {
+    "evidence_packet_ref": "docs/contracts/profitability_evidence_packet.v1.schema.json",
+    "assessment_ref": "docs/contracts/profitability_execution_economics_assessment.v1.schema.json",
+    "net_fields_required_before_ranking": true
+  },
+  "incomplete_assumption_policy": {
+    "warning_conditions": [
+      "fee source estimated but bounded",
+      "spread proxy available only for subset of runs"
+    ],
+    "fail_conditions": [
+      "net return cannot be reconstructed from gross return and cost fields",
+      "slippage assumption missing for candidate comparison"
+    ],
+    "blocked_conditions": [
+      "gross return missing",
+      "dataset quality blocked",
+      "candidate evidence packet missing"
+    ]
+  },
+  "limitations": [
+    "Research-only economics model; no runtime fee routing is implied.",
+    "League Table stays downstream in #3040."
+  ]
+}

--- a/docs/contracts/profitability_execution_economics_assessment.v1.schema.json
+++ b/docs/contracts/profitability_execution_economics_assessment.v1.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/profitability_execution_economics_assessment.v1.schema.json",
+  "title": "Profitability Execution Economics Assessment v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "assessment_id",
+    "candidate_id",
+    "model_id",
+    "generated_at",
+    "gross_return",
+    "net_return",
+    "cost_breakdown",
+    "assessment_status",
+    "ranking_ready",
+    "assumption_findings",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_execution_economics_assessment.v1"
+    },
+    "assessment_id": {
+      "type": "string",
+      "pattern": "^peea-[a-z0-9_-]{6,64}$"
+    },
+    "candidate_id": {
+      "type": "string",
+      "pattern": "^cand-[a-z0-9_-]{4,64}$"
+    },
+    "model_id": {
+      "type": "string",
+      "pattern": "^peem-[a-z0-9_-]{6,64}$"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "gross_return": {
+      "type": "number"
+    },
+    "net_return": {
+      "type": "number"
+    },
+    "cost_breakdown": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fees",
+        "spread_cost",
+        "slippage_cost",
+        "other_friction_cost",
+        "total_cost"
+      ],
+      "properties": {
+        "fees": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "spread_cost": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "slippage_cost": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "other_friction_cost": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "total_cost": {
+          "type": "number",
+          "minimum": 0.0
+        }
+      }
+    },
+    "assessment_status": {
+      "type": "string",
+      "enum": ["PASS", "WARNING", "FAIL", "BLOCKED"]
+    },
+    "ranking_ready": {
+      "type": "boolean"
+    },
+    "assumption_findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "category",
+          "severity",
+          "summary"
+        ],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": ["FEE", "SPREAD", "SLIPPAGE", "ATTRIBUTION", "DATA_GAP"]
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["INFO", "WARNING", "FAIL", "BLOCKED"]
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/contracts/profitability_execution_economics_model.v1.schema.json
+++ b/docs/contracts/profitability_execution_economics_model.v1.schema.json
@@ -1,0 +1,218 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/profitability_execution_economics_model.v1.schema.json",
+  "title": "Profitability Execution Economics Model v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "model_id",
+    "created_at",
+    "parent_issue",
+    "fee_model",
+    "spread_model",
+    "slippage_model",
+    "cost_attribution",
+    "evidence_integration",
+    "incomplete_assumption_policy",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_execution_economics_model.v1"
+    },
+    "model_id": {
+      "type": "string",
+      "pattern": "^peem-[a-z0-9_-]{6,64}$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "parent_issue": {
+      "type": "string",
+      "pattern": "^#3032$"
+    },
+    "fee_model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "basis",
+        "maker_bps",
+        "taker_bps",
+        "status_if_unknown"
+      ],
+      "properties": {
+        "basis": {
+          "type": "string",
+          "enum": ["STATIC_RESEARCH_ASSUMPTION", "VENUE_PROFILE_REFERENCE"]
+        },
+        "maker_bps": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "taker_bps": {
+          "type": "number",
+          "minimum": 0.0
+        },
+        "status_if_unknown": {
+          "type": "string",
+          "enum": ["WARNING", "FAIL", "BLOCKED"]
+        }
+      }
+    },
+    "spread_model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "basis",
+        "measurement_unit",
+        "applies_to_entry_and_exit",
+        "status_if_unknown"
+      ],
+      "properties": {
+        "basis": {
+          "type": "string",
+          "enum": ["OBSERVED_REPLAY_PROXY", "STATIC_RESEARCH_ASSUMPTION"]
+        },
+        "measurement_unit": {
+          "type": "string",
+          "enum": ["BPS", "PRICE_DISTANCE"]
+        },
+        "applies_to_entry_and_exit": {
+          "type": "boolean"
+        },
+        "status_if_unknown": {
+          "type": "string",
+          "enum": ["WARNING", "FAIL", "BLOCKED"]
+        }
+      }
+    },
+    "slippage_model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "basis",
+        "input_sources",
+        "quantity_sensitive",
+        "status_if_unknown"
+      ],
+      "properties": {
+        "basis": {
+          "type": "string",
+          "enum": ["ARVP_SCENARIO_PROXY", "RESEARCH_ASSUMPTION"]
+        },
+        "input_sources": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["SCENARIO_RESULTS", "REPLAY_COMPARE", "STATIC_BPS"]
+          }
+        },
+        "quantity_sensitive": {
+          "type": "boolean"
+        },
+        "status_if_unknown": {
+          "type": "string",
+          "enum": ["WARNING", "FAIL", "BLOCKED"]
+        }
+      }
+    },
+    "cost_attribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "gross_return_required",
+        "net_return_required",
+        "cost_fields",
+        "ranking_dependency"
+      ],
+      "properties": {
+        "gross_return_required": {
+          "type": "boolean"
+        },
+        "net_return_required": {
+          "type": "boolean"
+        },
+        "cost_fields": {
+          "type": "array",
+          "minItems": 3,
+          "items": {
+            "type": "string",
+            "enum": ["fees", "spread_cost", "slippage_cost", "other_friction_cost"]
+          }
+        },
+        "ranking_dependency": {
+          "type": "string",
+          "const": "#3040"
+        }
+      }
+    },
+    "evidence_integration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evidence_packet_ref",
+        "assessment_ref",
+        "net_fields_required_before_ranking"
+      ],
+      "properties": {
+        "evidence_packet_ref": {
+          "type": "string",
+          "const": "docs/contracts/profitability_evidence_packet.v1.schema.json"
+        },
+        "assessment_ref": {
+          "type": "string",
+          "const": "docs/contracts/profitability_execution_economics_assessment.v1.schema.json"
+        },
+        "net_fields_required_before_ranking": {
+          "type": "boolean"
+        }
+      }
+    },
+    "incomplete_assumption_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "warning_conditions",
+        "fail_conditions",
+        "blocked_conditions"
+      ],
+      "properties": {
+        "warning_conditions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "fail_conditions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "blocked_conditions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/strategy/CDB_PROFITABILITY_EXECUTION_ECONOMICS_V1.md
+++ b/docs/strategy/CDB_PROFITABILITY_EXECUTION_ECONOMICS_V1.md
@@ -1,0 +1,130 @@
+# CDB Profitability Execution Economics v1
+
+**Status:** Draft contract surface for #3039  
+**Mode:** Docs / schema / example fixtures only  
+**Parent:** #3032  
+**Live-Readiness:** NO-GO  
+**Runtime Impact:** none  
+
+## Purpose
+
+This document defines the first Execution Economics v1 surface for the
+Profitability Engine.
+
+The goal is not to change the execution service. The goal is to make candidate
+economics auditable before any ranking step by forcing gross return, cost
+attribution, and net return into one repeatable research contract.
+
+## Contract Artifacts
+
+| Artifact | Path | Role |
+|---|---|---|
+| Economics model schema | `docs/contracts/profitability_execution_economics_model.v1.schema.json` | Research fee/spread/slippage model and fail-closed assumption policy |
+| Economics assessment schema | `docs/contracts/profitability_execution_economics_assessment.v1.schema.json` | Candidate-level gross-to-net assessment output |
+| Model example | `docs/contracts/examples/profitability_execution_economics_model_valid.json` | Valid research-only economics model fixture |
+| Assessment example | `docs/contracts/examples/profitability_execution_economics_assessment_valid.json` | Valid research-only assessment fixture |
+
+## Relationship To Existing Repo Surfaces
+
+Execution Economics v1 does not replace execution runtime code:
+
+- `profitability_evidence_packet.v1` already contains `gross_return`,
+  `net_return`, `fees`, `spread_cost`, and `slippage_cost`.
+- `#3037` defines how batch evidence is grouped across candidates.
+- `#3038` defines the stress scenarios that inform slippage and friction
+  understanding.
+
+This slice adds the missing contract layer that says when those fields are good
+enough to support a comparison and when they remain too weak for ranking.
+
+## Model Design
+
+Execution Economics Model v1 records:
+
+- fee model basis and bounded assumptions
+- spread model basis and measurement unit
+- slippage model basis and input sources
+- explicit cost-attribution requirements
+- evidence integration references
+- explicit warning/fail/blocked rules when assumptions are incomplete
+
+The model is fail-closed:
+
+- missing gross return is `BLOCKED`
+- missing slippage assumptions for candidate comparison is `FAIL`
+- weak or estimated fee assumptions may downgrade to `WARNING`
+
+This keeps net performance honest instead of pretending gross return is enough.
+
+## Assessment Design
+
+Execution Economics Assessment v1 records:
+
+- candidate and model identity
+- gross return
+- net return
+- cost breakdown
+- assessment status
+- ranking readiness
+- assumption findings
+
+`ranking_ready=false` is meaningful. A candidate may have positive gross return
+and still remain not rankable because cost assumptions are incomplete or stress
+signals show fragile economics.
+
+## Relationship To Neighbor Issues
+
+- `#3034` defines the candidate and evidence packet surfaces consumed here.
+- `#3035` defines dataset quality prerequisites before economics should be
+  trusted.
+- `#3037` defines the multi-candidate batch evidence hook.
+- `#3038` defines profitability scenario stress packs that inform economics
+  assumptions.
+- `#3040` remains separate and may only rank candidates after this net
+  economics surface exists.
+- If later runtime integration or live fee sourcing is required, that work
+  stays out of scope for this slice and belongs in a separate issue.
+
+## Ranking Dependency
+
+Strategy League Table work must treat Execution Economics as a hard dependency:
+
+- no gross-only ranking
+- no candidate promotion based on raw replay return alone
+- no hidden fee, spread, or slippage assumptions
+
+Without Execution Economics v1, any league table is incomplete.
+
+## Safety Boundaries
+
+- LR remains NO-GO.
+- `trade-capable` is not Live-Go.
+- No Echtgeld-Go.
+- No runtime change.
+- No productive DB write.
+- No MCP mutation.
+- No Risk, Execution, Allocation, kill-switch, or LR gate change.
+- ARVP, backtest, and paper are evidence, not approval.
+- AI, dashboard, and docs are not authority.
+- No automatic promotion.
+- No capital scaling without separate gates.
+
+## Non-Goals
+
+- no execution-service change
+- no live fee or exchange integration
+- no risk-code change
+- no DB migration
+- no league table implementation
+- no live-readiness uplift
+
+## Validation
+
+For this docs-only slice, validation means:
+
+1. both JSON schemas parse and pass schema validation
+2. both example fixtures validate against their matching schemas
+3. fee, spread, slippage, and cost attribution are explicit
+4. ranking dependency on net economics remains explicit and fail-closed
+
+This does not prove a candidate is profitable, paper-ready, or live-ready.


### PR DESCRIPTION
## Kurzbefund
- fuehrt einen docs-only Slice fuer #3039 ein: Execution Economics v1 als Strategiedokument plus Model-/Assessment-Contracts mit validierten Beispielartefakten
- schliesst die Profitability-Luecke zwischen Evidence Packet und spaeterer League Table, indem Brutto-, Kosten- und Netto-Sicht als fail-closed Research-Contract formalisiert werden
- gestapelte PR auf dem offenen #3038-Branch, weil Economics die vorigen Candidate-, Dataset-, Batch- und Scenario-Pack-Surfaces konsumiert

## Warum jetzt
- nach #3034 bis #3038 fehlt der belastbare Netto-Wirtschaftlichkeits-Standard, bevor Kandidaten in eine League Table ueberhaupt eingehen duerfen
- der Slice macht Fee-, Spread-, Slippage- und Cost-Attribution-Annahmen explizit, ohne Core, Risk oder Live-Gates anzutasten

## Scope
- in: Strategiedoku, Economics-Model-Schema, Economics-Assessment-Schema, zwei Beispielartefakte, README-Eintrag
- out: Runtime-Implementierung, Live-Fee-/Exchange-Anbindung, Ranking/League Table (#3040), DB/MCP-Mutationen, Live-Go-Aussagen

## Betroffene Dateien / Artefakte
- docs/strategy/CDB_PROFITABILITY_EXECUTION_ECONOMICS_V1.md
- docs/contracts/profitability_execution_economics_model.v1.schema.json
- docs/contracts/profitability_execution_economics_assessment.v1.schema.json
- docs/contracts/examples/profitability_execution_economics_model_valid.json
- docs/contracts/examples/profitability_execution_economics_assessment_valid.json
- docs/contracts/README.md

## Validierung / Checks
- JSON Schema validation beider Beispielartefakte: PASS
- git diff --check: keine Patch-/Whitespace-Fehler; nur erwartete LF/CRLF-Warnung in docs/contracts/README.md
- Doku-Quercheck auf #3034/#3035/#3037/#3038/#3040 sowie Ranking-Abhaengigkeit und NO-GO-Guardrails

## Risiken / Guardrails
- LR bleibt NO-GO; trade-capable ist kein Live-Go
- keine Runtime-, Risk-, Execution-, Allocation- oder DB-Aenderung
- spaetere Runtime- oder Live-Fee-Integration bleibt out of scope und braucht ein separates Issue
- #3040 darf Rankings erst nach dieser Netto-Economics-Flaeche aufsetzen

## Restunsicherheiten
- diese PR definiert nur den Net-Economics-Contract und keine technische Durchsetzung im Runtime-Pfad
- weil #3046 noch offen ist, ist diese PR bewusst gestapelt und erst sauber landbar, wenn #3038 in main aufgegangen ist

## Issue-Bezug
- Refs #3039
- Refs #3032
