### PR TITLE
[PROFITABILITY][RANKING] Define strategy league table v1

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -15,6 +15,7 @@ Repo-backed JSON/YAML schemas und Contract-Dokumente für Messages, Replay und C
 | Profitability ARVP batch | `profitability_arvp_batch_manifest.v1.schema.json`, `profitability_arvp_batch_summary.v1.schema.json` | Multi-candidate ARVP batch runner design contracts |
 | Profitability scenario packs | `profitability_scenario_pack_catalog.v1.schema.json`, `profitability_scenario_stress_summary.v1.schema.json` | Stress-scenario catalog and candidate stress summary contracts |
 | Profitability execution economics | `profitability_execution_economics_model.v1.schema.json`, `profitability_execution_economics_assessment.v1.schema.json` | Net-economics model and candidate cost-attribution contracts |
+| Profitability league table | `profitability_league_table_model.v1.schema.json`, `profitability_league_table_report.v1.schema.json` | Ranking model and recommendation report contracts |
 
 ## Related canon (not duplicated here)
 

--- a/docs/contracts/examples/profitability_league_table_model_valid.json
+++ b/docs/contracts/examples/profitability_league_table_model_valid.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "profitability_league_table_model.v1",
+  "model_id": "pltm-profitability-v1",
+  "created_at": "2026-06-06T19:20:00+00:00",
+  "parent_issue": "#3032",
+  "scoring_dimensions": [
+    {
+      "dimension": "NET_RETURN",
+      "weight_pct": 30.0,
+      "requires_net_economics": true,
+      "description": "Candidate must rank on net and not gross-only return."
+    },
+    {
+      "dimension": "ROBUSTNESS",
+      "weight_pct": 20.0,
+      "requires_net_economics": true,
+      "description": "Candidate should remain stable across replay, compare, and stress evidence."
+    },
+    {
+      "dimension": "EVIDENCE_COMPLETENESS",
+      "weight_pct": 20.0,
+      "requires_net_economics": false,
+      "description": "Missing evidence lowers confidence and score."
+    },
+    {
+      "dimension": "SAFETY_STATUS",
+      "weight_pct": 15.0,
+      "requires_net_economics": false,
+      "description": "Unsafe or blocked candidates cannot float upward via score alone."
+    },
+    {
+      "dimension": "STRESS_RESILIENCE",
+      "weight_pct": 15.0,
+      "requires_net_economics": false,
+      "description": "Scenario-pack results must visibly affect ranking confidence."
+    }
+  ],
+  "ranking_rules": {
+    "gross_only_ranking_allowed": false,
+    "ranking_ready_required": true,
+    "tie_breakers": [
+      "BETTER_STRESS_OUTCOME",
+      "LOWER_DRAWDOWN",
+      "HIGHER_EVIDENCE_COMPLETENESS"
+    ],
+    "blocked_conditions": [
+      "execution_economics_assessment.ranking_ready=false",
+      "candidate status is UNSAFE",
+      "dataset quality verdict is BLOCKED"
+    ]
+  },
+  "recommendation_semantics": {
+    "allowed_recommendations": [
+      "REJECT",
+      "PARK",
+      "PROMOTE_TO_NEXT_RESEARCH_GATE",
+      "UNSAFE",
+      "NO_RECOMMENDATION"
+    ],
+    "automatic_promotion_allowed": false,
+    "capital_authority": "NONE",
+    "notes": "League table output is advisory only and cannot authorize promotion or allocation."
+  },
+  "report_contract": {
+    "report_ref": "docs/contracts/profitability_league_table_report.v1.schema.json",
+    "candidate_minimum_fields": [
+      "candidate_id",
+      "rank",
+      "total_score",
+      "net_return",
+      "recommendation",
+      "ranking_ready",
+      "evidence_completeness",
+      "limitations_summary"
+    ],
+    "score_range": "0_to_100"
+  },
+  "limitations": [
+    "League Table remains research-only and not an execution or allocation authority.",
+    "Capital scaling anchors #205 and #211 stay future-only."
+  ]
+}

--- a/docs/contracts/examples/profitability_league_table_report_valid.json
+++ b/docs/contracts/examples/profitability_league_table_report_valid.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "profitability_league_table_report.v1",
+  "report_id": "pltr-profitability-v1-run01",
+  "model_id": "pltm-profitability-v1",
+  "generated_at": "2026-06-06T19:35:00+00:00",
+  "table_status": "PARTIAL",
+  "candidate_rankings": [
+    {
+      "candidate_id": "cand-primary-breakout-a1",
+      "rank": 1,
+      "total_score": 78.4,
+      "ranking_ready": true,
+      "net_return": 0.098,
+      "dimension_scores": [
+        {
+          "dimension": "NET_RETURN",
+          "score": 82.0
+        },
+        {
+          "dimension": "ROBUSTNESS",
+          "score": 74.0
+        },
+        {
+          "dimension": "EVIDENCE_COMPLETENESS",
+          "score": 90.0
+        },
+        {
+          "dimension": "SAFETY_STATUS",
+          "score": 80.0
+        },
+        {
+          "dimension": "STRESS_RESILIENCE",
+          "score": 66.0
+        }
+      ],
+      "recommendation": "PARK",
+      "limitations_summary": [
+        "Slippage sensitivity still degrades ranking confidence.",
+        "Promotion remains advisory only."
+      ]
+    },
+    {
+      "candidate_id": "cand-secondary-breakout-b2",
+      "rank": 2,
+      "total_score": 51.2,
+      "ranking_ready": false,
+      "net_return": null,
+      "dimension_scores": [
+        {
+          "dimension": "NET_RETURN",
+          "score": 0.0
+        },
+        {
+          "dimension": "ROBUSTNESS",
+          "score": 58.0
+        },
+        {
+          "dimension": "EVIDENCE_COMPLETENESS",
+          "score": 49.0
+        },
+        {
+          "dimension": "SAFETY_STATUS",
+          "score": 62.0
+        },
+        {
+          "dimension": "STRESS_RESILIENCE",
+          "score": 55.0
+        }
+      ],
+      "recommendation": "NO_RECOMMENDATION",
+      "limitations_summary": [
+        "Execution economics not rank-ready.",
+        "Stress evidence is incomplete."
+      ]
+    }
+  ],
+  "limitations": [
+    "League Table report is advisory only and cannot trigger promotion.",
+    "Future capital or portfolio actions remain separate work."
+  ]
+}

--- a/docs/contracts/profitability_league_table_model.v1.schema.json
+++ b/docs/contracts/profitability_league_table_model.v1.schema.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/profitability_league_table_model.v1.schema.json",
+  "title": "Profitability League Table Model v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "model_id",
+    "created_at",
+    "parent_issue",
+    "scoring_dimensions",
+    "ranking_rules",
+    "recommendation_semantics",
+    "report_contract",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_league_table_model.v1"
+    },
+    "model_id": {
+      "type": "string",
+      "pattern": "^pltm-[a-z0-9_-]{6,64}$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "parent_issue": {
+      "type": "string",
+      "pattern": "^#3032$"
+    },
+    "scoring_dimensions": {
+      "type": "array",
+      "minItems": 4,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "dimension",
+          "weight_pct",
+          "requires_net_economics",
+          "description"
+        ],
+        "properties": {
+          "dimension": {
+            "type": "string",
+            "enum": [
+              "NET_RETURN",
+              "ROBUSTNESS",
+              "EVIDENCE_COMPLETENESS",
+              "SAFETY_STATUS",
+              "DRAWDOWN_DISCIPLINE",
+              "STRESS_RESILIENCE"
+            ]
+          },
+          "weight_pct": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 100.0
+          },
+          "requires_net_economics": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "ranking_rules": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "gross_only_ranking_allowed",
+        "ranking_ready_required",
+        "tie_breakers",
+        "blocked_conditions"
+      ],
+      "properties": {
+        "gross_only_ranking_allowed": {
+          "type": "boolean"
+        },
+        "ranking_ready_required": {
+          "type": "boolean"
+        },
+        "tie_breakers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "LOWER_DRAWDOWN",
+              "BETTER_STRESS_OUTCOME",
+              "HIGHER_EVIDENCE_COMPLETENESS",
+              "FEWER_LIMITATIONS"
+            ]
+          }
+        },
+        "blocked_conditions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "recommendation_semantics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "allowed_recommendations",
+        "automatic_promotion_allowed",
+        "capital_authority",
+        "notes"
+      ],
+      "properties": {
+        "allowed_recommendations": {
+          "type": "array",
+          "minItems": 3,
+          "items": {
+            "type": "string",
+            "enum": [
+              "REJECT",
+              "PARK",
+              "PROMOTE_TO_NEXT_RESEARCH_GATE",
+              "UNSAFE",
+              "NO_RECOMMENDATION"
+            ]
+          }
+        },
+        "automatic_promotion_allowed": {
+          "type": "boolean"
+        },
+        "capital_authority": {
+          "type": "string",
+          "enum": ["NONE"]
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "report_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "report_ref",
+        "candidate_minimum_fields",
+        "score_range"
+      ],
+      "properties": {
+        "report_ref": {
+          "type": "string",
+          "const": "docs/contracts/profitability_league_table_report.v1.schema.json"
+        },
+        "candidate_minimum_fields": {
+          "type": "array",
+          "minItems": 5,
+          "items": {
+            "type": "string",
+            "enum": [
+              "candidate_id",
+              "rank",
+              "total_score",
+              "net_return",
+              "recommendation",
+              "ranking_ready",
+              "evidence_completeness",
+              "limitations_summary"
+            ]
+          }
+        },
+        "score_range": {
+          "type": "string",
+          "const": "0_to_100"
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/contracts/profitability_league_table_report.v1.schema.json
+++ b/docs/contracts/profitability_league_table_report.v1.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/profitability_league_table_report.v1.schema.json",
+  "title": "Profitability League Table Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "report_id",
+    "model_id",
+    "generated_at",
+    "table_status",
+    "candidate_rankings",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_league_table_report.v1"
+    },
+    "report_id": {
+      "type": "string",
+      "pattern": "^pltr-[a-z0-9_-]{6,64}$"
+    },
+    "model_id": {
+      "type": "string",
+      "pattern": "^pltm-[a-z0-9_-]{6,64}$"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "table_status": {
+      "type": "string",
+      "enum": ["COMPLETE", "PARTIAL", "BLOCKED"]
+    },
+    "candidate_rankings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "candidate_id",
+          "rank",
+          "total_score",
+          "ranking_ready",
+          "net_return",
+          "dimension_scores",
+          "recommendation",
+          "limitations_summary"
+        ],
+        "properties": {
+          "candidate_id": {
+            "type": "string",
+            "pattern": "^cand-[a-z0-9_-]{4,64}$"
+          },
+          "rank": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "total_score": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 100.0
+          },
+          "ranking_ready": {
+            "type": "boolean"
+          },
+          "net_return": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "dimension_scores": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "dimension",
+                "score"
+              ],
+              "properties": {
+                "dimension": {
+                  "type": "string",
+                  "enum": [
+                    "NET_RETURN",
+                    "ROBUSTNESS",
+                    "EVIDENCE_COMPLETENESS",
+                    "SAFETY_STATUS",
+                    "DRAWDOWN_DISCIPLINE",
+                    "STRESS_RESILIENCE"
+                  ]
+                },
+                "score": {
+                  "type": "number",
+                  "minimum": 0.0,
+                  "maximum": 100.0
+                }
+              }
+            }
+          },
+          "recommendation": {
+            "type": "string",
+            "enum": [
+              "REJECT",
+              "PARK",
+              "PROMOTE_TO_NEXT_RESEARCH_GATE",
+              "UNSAFE",
+              "NO_RECOMMENDATION"
+            ]
+          },
+          "limitations_summary": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/strategy/CDB_PROFITABILITY_LEAGUE_TABLE_V1.md
+++ b/docs/strategy/CDB_PROFITABILITY_LEAGUE_TABLE_V1.md
@@ -1,0 +1,136 @@
+# CDB Profitability League Table v1
+
+**Status:** Draft contract surface for #3040  
+**Mode:** Docs / schema / example fixtures only  
+**Parent:** #3032  
+**Live-Readiness:** NO-GO  
+**Runtime Impact:** none  
+
+## Purpose
+
+This document defines the first Strategy League Table v1 surface for the
+Profitability Engine.
+
+The goal is not automatic promotion. The goal is a repeatable, evidence-backed
+ranking view that compares candidates on net economics, robustness, evidence
+completeness, and safety status before any next research gate is considered.
+
+## Contract Artifacts
+
+| Artifact | Path | Role |
+|---|---|---|
+| League table model schema | `docs/contracts/profitability_league_table_model.v1.schema.json` | Ranking dimensions, rules, recommendation semantics |
+| League table report schema | `docs/contracts/profitability_league_table_report.v1.schema.json` | Candidate ranking output and report shape |
+| Model example | `docs/contracts/examples/profitability_league_table_model_valid.json` | Valid research-only ranking model fixture |
+| Report example | `docs/contracts/examples/profitability_league_table_report_valid.json` | Valid research-only ranking report fixture |
+
+## Relationship To Existing Repo Surfaces
+
+League Table v1 depends on already defined Profitability contracts:
+
+- `#3034` defines the candidate and evidence packet surfaces.
+- `#3035` defines dataset-quality preconditions.
+- `#3037` defines multi-candidate batch evidence grouping.
+- `#3038` defines stress signals used for robustness and stress resilience.
+- `#3039` defines the execution-economics surface and `ranking_ready`.
+
+This means League Table v1 is a ranking contract over existing evidence, not a
+new runtime evaluator.
+
+## Scoring Design
+
+League Table v1 records weighted scoring dimensions such as:
+
+- net return
+- robustness
+- evidence completeness
+- safety status
+- stress resilience
+
+Weights are explicit, and gross-only ranking is forbidden. A candidate without
+net-economics readiness may still appear in the report, but it must not be
+treated as fully rankable.
+
+## Ranking Rules
+
+The ranking rules are fail-closed:
+
+- no gross-only ranking
+- `ranking_ready=true` is required for honest full ranking
+- blocked conditions remain explicit
+- tie-breakers must prefer safer and better evidenced candidates, not just
+  raw returns
+
+This keeps the table from hiding weak assumptions behind a single score.
+
+## Recommendation Semantics
+
+League Table recommendations remain advisory only:
+
+- `REJECT`
+- `PARK`
+- `PROMOTE_TO_NEXT_RESEARCH_GATE`
+- `UNSAFE`
+- `NO_RECOMMENDATION`
+
+These are not executable actions. They do not authorize paper, micro-live,
+capital allocation, or reactivation of `#205` / `#211`.
+
+## Report Design
+
+The report output records:
+
+- table status
+- candidate rank
+- total score
+- ranking readiness
+- net return
+- dimension scores
+- recommendation
+- limitations summary
+
+This allows partial tables where some candidates are present for visibility but
+still clearly marked as not rank-ready.
+
+## Relationship To Neighbor Issues
+
+- `#3040` must stay downstream of `#3039`; ranking without net economics is
+  incomplete.
+- `#205` and `#211` remain future scaling anchors only and are not reactivated
+  here.
+- If later portfolio allocation or capital-sleeve logic is needed, that work
+  stays out of scope for this slice and belongs in a separate issue.
+
+## Safety Boundaries
+
+- LR remains NO-GO.
+- `trade-capable` is not Live-Go.
+- No Echtgeld-Go.
+- No runtime change.
+- No productive DB write.
+- No MCP mutation.
+- No Risk, Execution, Allocation, kill-switch, or LR gate change.
+- ARVP, backtest, and paper are evidence, not approval.
+- AI, dashboard, and docs are not authority.
+- No automatic promotion.
+- No capital scaling without separate gates.
+
+## Non-Goals
+
+- no automatic promotion
+- no capital allocation
+- no #205/#211 reactivation
+- no runtime implementation
+- no DB migration
+- no live-readiness uplift
+
+## Validation
+
+For this docs-only slice, validation means:
+
+1. both JSON schemas parse and pass schema validation
+2. both example fixtures validate against their matching schemas
+3. ranking remains net-first and fail-closed
+4. recommendation semantics remain advisory and non-executing
+
+This does not prove a candidate is profitable, paper-ready, or live-ready.


### PR DESCRIPTION
## Kurzbefund
- fuehrt einen docs-only Slice fuer #3040 ein: Strategy League Table v1 als Strategiedokument plus Ranking-Model-/Report-Contracts mit validierten Beispielartefakten
- bindet Ranking explizit an Net-Economics, Stress-Resilience, Evidence-Completeness und Safety statt an Brutto-Rendite allein
- gestapelte PR auf dem offenen #3039-Branch, weil League Table die vorigen Candidate-, Dataset-, Batch-, Scenario-Pack- und Economics-Surfaces konsumiert

## Warum jetzt
- nach #3034 bis #3039 fehlt der explizite Ranking- und Recommendation-Standard, um Kandidaten vergleichbar zu ordnen ohne brutto-naive oder automatisch ausfuehrende Logik
- der Slice macht Score-Dimensionen, blocked conditions und advisory-only Recommendations explizit, ohne Core, Risk oder Live-Gates anzutasten

## Scope
- in: Strategiedoku, League-Table-Model-Schema, League-Table-Report-Schema, zwei Beispielartefakte, README-Eintrag
- out: Runtime-Implementierung, automatische Promotion, Capital Allocation, #205/#211-Reaktivierung, DB/MCP-Mutationen, Live-Go-Aussagen

## Betroffene Dateien / Artefakte
- docs/strategy/CDB_PROFITABILITY_LEAGUE_TABLE_V1.md
- docs/contracts/profitability_league_table_model.v1.schema.json
- docs/contracts/profitability_league_table_report.v1.schema.json
- docs/contracts/examples/profitability_league_table_model_valid.json
- docs/contracts/examples/profitability_league_table_report_valid.json
- docs/contracts/README.md

## Validierung / Checks
- JSON Schema validation beider Beispielartefakte: PASS
- git diff --check: keine Patch-/Whitespace-Fehler; nur erwartete LF/CRLF-Warnung in docs/contracts/README.md
- Doku-Quercheck auf #3034/#3035/#3037/#3038/#3039/#205/#211 sowie NO-GO-Guardrails und separate-issue-Grenze fuer spaetere Allocation-/Runtime-Arbeit

## Risiken / Guardrails
- LR bleibt NO-GO; trade-capable ist kein Live-Go
- keine Runtime-, Risk-, Execution-, Allocation- oder DB-Aenderung
- spaetere Portfolio-/Capital-Logik bleibt out of scope und braucht ein separates Issue
- League Table Recommendations bleiben advisory only und nicht ausfuehrend

## Restunsicherheiten
- diese PR definiert nur den Ranking-Contract und keine technische Durchsetzung im Runtime-Pfad
- weil #3047 noch offen ist, ist diese PR bewusst gestapelt und erst sauber landbar, wenn #3039 in main aufgegangen ist

## Issue-Bezug
- Refs #3040
- Refs #3032
