### PR TITLE
[PROFITABILITY][CAPITAL] Define capital sleeve model and paper accounting v1

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -16,6 +16,7 @@ Repo-backed JSON/YAML schemas und Contract-Dokumente für Messages, Replay und C
 | Profitability scenario packs | `profitability_scenario_pack_catalog.v1.schema.json`, `profitability_scenario_stress_summary.v1.schema.json` | Stress-scenario catalog and candidate stress summary contracts |
 | Profitability execution economics | `profitability_execution_economics_model.v1.schema.json`, `profitability_execution_economics_assessment.v1.schema.json` | Net-economics model and candidate cost-attribution contracts |
 | Profitability league table | `profitability_league_table_model.v1.schema.json`, `profitability_league_table_report.v1.schema.json` | Ranking model and recommendation report contracts |
+| Profitability capital sleeves | `profitability_capital_sleeve_model.v1.schema.json`, `profitability_paper_accounting_report.v1.schema.json` | Sleeve-governance model and paper-accounting report contracts |
 
 ## Related canon (not duplicated here)
 

--- a/docs/contracts/examples/profitability_capital_sleeve_model_valid.json
+++ b/docs/contracts/examples/profitability_capital_sleeve_model_valid.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "profitability_capital_sleeve_model.v1",
+  "model_id": "pcsm-profitability-v1",
+  "created_at": "2026-06-06T20:05:00+00:00",
+  "parent_issue": "#3032",
+  "paper_context_ref": "#1784",
+  "sleeves": [
+    {
+      "sleeve_id": "CORE",
+      "label": "Core",
+      "purpose": "Paper sleeve for the most repeatable and evidence-complete candidates.",
+      "paper_only": true,
+      "candidate_profile": "HIGH_CONFIDENCE",
+      "admission_basis": [
+        "LEAGUE_TABLE",
+        "EXECUTION_ECONOMICS",
+        "STRESS_SUMMARY"
+      ]
+    },
+    {
+      "sleeve_id": "GROWTH",
+      "label": "Growth",
+      "purpose": "Paper sleeve for net-positive candidates that still need comparative learning.",
+      "paper_only": true,
+      "candidate_profile": "NET_POSITIVE_BUT_GROWING",
+      "admission_basis": [
+        "LEAGUE_TABLE",
+        "EXECUTION_ECONOMICS"
+      ]
+    },
+    {
+      "sleeve_id": "OPPORTUNISTIC",
+      "label": "Opportunistic",
+      "purpose": "Paper sleeve for tactical or regime-bound candidates with narrower use windows.",
+      "paper_only": true,
+      "candidate_profile": "TACTICAL_OR_REGIME_BOUND",
+      "admission_basis": [
+        "LEAGUE_TABLE",
+        "PAPER_OBSERVATION"
+      ]
+    },
+    {
+      "sleeve_id": "EXPERIMENTAL",
+      "label": "Experimental",
+      "purpose": "Paper sleeve for early research candidates kept visible without capital authority.",
+      "paper_only": true,
+      "candidate_profile": "EARLY_RESEARCH",
+      "admission_basis": [
+        "PAPER_OBSERVATION"
+      ]
+    }
+  ],
+  "allocation_simulation_rules": {
+    "real_capital_authority": false,
+    "simulation_only": true,
+    "drawdown_tracking_required": true,
+    "pnl_reporting_required": true
+  },
+  "integration_boundaries": {
+    "risk_code_change_allowed": false,
+    "allocation_service_change_allowed": false,
+    "future_anchors": [
+      "#205",
+      "#211"
+    ],
+    "live_roadmap_ref": "#2985"
+  },
+  "limitations": [
+    "Sleeve model is governance-only and does not authorize real capital.",
+    "Risk and allocation integration remain separate future gates."
+  ]
+}

--- a/docs/contracts/examples/profitability_paper_accounting_report_valid.json
+++ b/docs/contracts/examples/profitability_paper_accounting_report_valid.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "profitability_paper_accounting_report.v1",
+  "report_id": "ppar-profitability-v1-run01",
+  "model_id": "pcsm-profitability-v1",
+  "generated_at": "2026-06-06T20:20:00+00:00",
+  "report_scope": "PAPER_ONLY",
+  "sleeve_reports": [
+    {
+      "sleeve_id": "CORE",
+      "candidate_count": 2,
+      "paper_pnl": 0.124,
+      "drawdown": 0.041,
+      "allocation_simulation_status": "SIMULATED",
+      "notes": [
+        "Core sleeve remains paper-only despite positive pnl.",
+        "No real allocation authority is implied."
+      ]
+    },
+    {
+      "sleeve_id": "GROWTH",
+      "candidate_count": 3,
+      "paper_pnl": 0.083,
+      "drawdown": 0.067,
+      "allocation_simulation_status": "SIMULATED",
+      "notes": [
+        "Growth sleeve still needs more evidence before any future gate discussion."
+      ]
+    },
+    {
+      "sleeve_id": "OPPORTUNISTIC",
+      "candidate_count": 1,
+      "paper_pnl": 0.019,
+      "drawdown": 0.054,
+      "allocation_simulation_status": "NOT_STARTED",
+      "notes": [
+        "Tactical candidate remains too narrow for allocation simulation."
+      ]
+    },
+    {
+      "sleeve_id": "EXPERIMENTAL",
+      "candidate_count": 4,
+      "paper_pnl": -0.012,
+      "drawdown": 0.092,
+      "allocation_simulation_status": "BLOCKED",
+      "notes": [
+        "Experimental sleeve is observation-only and blocked from allocation simulation."
+      ]
+    }
+  ],
+  "limitations": [
+    "Paper accounting report is advisory only and cannot authorize capital.",
+    "Portfolio and live-roadmap work remain separate."
+  ]
+}

--- a/docs/contracts/profitability_capital_sleeve_model.v1.schema.json
+++ b/docs/contracts/profitability_capital_sleeve_model.v1.schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/profitability_capital_sleeve_model.v1.schema.json",
+  "title": "Profitability Capital Sleeve Model v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "model_id",
+    "created_at",
+    "parent_issue",
+    "paper_context_ref",
+    "sleeves",
+    "allocation_simulation_rules",
+    "integration_boundaries",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_capital_sleeve_model.v1"
+    },
+    "model_id": {
+      "type": "string",
+      "pattern": "^pcsm-[a-z0-9_-]{6,64}$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "parent_issue": {
+      "type": "string",
+      "pattern": "^#3032$"
+    },
+    "paper_context_ref": {
+      "type": "string",
+      "const": "#1784"
+    },
+    "sleeves": {
+      "type": "array",
+      "minItems": 4,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "sleeve_id",
+          "label",
+          "purpose",
+          "paper_only",
+          "candidate_profile",
+          "admission_basis"
+        ],
+        "properties": {
+          "sleeve_id": {
+            "type": "string",
+            "enum": [
+              "CORE",
+              "GROWTH",
+              "OPPORTUNISTIC",
+              "EXPERIMENTAL"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "purpose": {
+            "type": "string",
+            "minLength": 1
+          },
+          "paper_only": {
+            "type": "boolean"
+          },
+          "candidate_profile": {
+            "type": "string",
+            "enum": [
+              "HIGH_CONFIDENCE",
+              "NET_POSITIVE_BUT_GROWING",
+              "TACTICAL_OR_REGIME_BOUND",
+              "EARLY_RESEARCH"
+            ]
+          },
+          "admission_basis": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": [
+                "LEAGUE_TABLE",
+                "EXECUTION_ECONOMICS",
+                "STRESS_SUMMARY",
+                "PAPER_OBSERVATION"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "allocation_simulation_rules": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "real_capital_authority",
+        "simulation_only",
+        "drawdown_tracking_required",
+        "pnl_reporting_required"
+      ],
+      "properties": {
+        "real_capital_authority": {
+          "type": "boolean"
+        },
+        "simulation_only": {
+          "type": "boolean"
+        },
+        "drawdown_tracking_required": {
+          "type": "boolean"
+        },
+        "pnl_reporting_required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "integration_boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "risk_code_change_allowed",
+        "allocation_service_change_allowed",
+        "future_anchors",
+        "live_roadmap_ref"
+      ],
+      "properties": {
+        "risk_code_change_allowed": {
+          "type": "boolean"
+        },
+        "allocation_service_change_allowed": {
+          "type": "boolean"
+        },
+        "future_anchors": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "string",
+            "enum": ["#205", "#211"]
+          }
+        },
+        "live_roadmap_ref": {
+          "type": "string",
+          "const": "#2985"
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/contracts/profitability_paper_accounting_report.v1.schema.json
+++ b/docs/contracts/profitability_paper_accounting_report.v1.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/profitability_paper_accounting_report.v1.schema.json",
+  "title": "Profitability Paper Accounting Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "report_id",
+    "model_id",
+    "generated_at",
+    "report_scope",
+    "sleeve_reports",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_paper_accounting_report.v1"
+    },
+    "report_id": {
+      "type": "string",
+      "pattern": "^ppar-[a-z0-9_-]{6,64}$"
+    },
+    "model_id": {
+      "type": "string",
+      "pattern": "^pcsm-[a-z0-9_-]{6,64}$"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "report_scope": {
+      "type": "string",
+      "enum": ["PAPER_ONLY", "SIMULATION_ONLY"]
+    },
+    "sleeve_reports": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "sleeve_id",
+          "candidate_count",
+          "paper_pnl",
+          "drawdown",
+          "allocation_simulation_status",
+          "notes"
+        ],
+        "properties": {
+          "sleeve_id": {
+            "type": "string",
+            "enum": [
+              "CORE",
+              "GROWTH",
+              "OPPORTUNISTIC",
+              "EXPERIMENTAL"
+            ]
+          },
+          "candidate_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "paper_pnl": {
+            "type": "number"
+          },
+          "drawdown": {
+            "type": "number",
+            "minimum": 0.0
+          },
+          "allocation_simulation_status": {
+            "type": "string",
+            "enum": ["NOT_STARTED", "SIMULATED", "BLOCKED"]
+          },
+          "notes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/strategy/CDB_PROFITABILITY_CAPITAL_SLEEVES_V1.md
+++ b/docs/strategy/CDB_PROFITABILITY_CAPITAL_SLEEVES_V1.md
@@ -1,0 +1,126 @@
+# CDB Profitability Capital Sleeves v1
+
+**Status:** Draft contract surface for #3041  
+**Mode:** Docs / schema / example fixtures only  
+**Parent:** #3032  
+**Live-Readiness:** NO-GO  
+**Runtime Impact:** none  
+
+## Purpose
+
+This document defines the first Capital Sleeve Model and Paper Accounting v1
+surface for the Profitability Engine.
+
+The goal is not real capital allocation. The goal is a repeatable paper-only
+governance and reporting model that groups candidates into sleeves and tracks
+paper pnl, drawdown, and simulation state without touching risk or allocation
+runtime code.
+
+## Contract Artifacts
+
+| Artifact | Path | Role |
+|---|---|---|
+| Capital sleeve model schema | `docs/contracts/profitability_capital_sleeve_model.v1.schema.json` | Sleeve definitions, paper context, and integration boundaries |
+| Paper accounting report schema | `docs/contracts/profitability_paper_accounting_report.v1.schema.json` | Sleeve-level paper pnl and drawdown reporting |
+| Model example | `docs/contracts/examples/profitability_capital_sleeve_model_valid.json` | Valid research-only sleeve model fixture |
+| Report example | `docs/contracts/examples/profitability_paper_accounting_report_valid.json` | Valid research-only paper accounting report fixture |
+
+## Relationship To Existing Repo Surfaces
+
+Capital Sleeves v1 depends on already defined Profitability and paper surfaces:
+
+- `#3040` defines how candidates are comparatively ranked before sleeve
+  grouping.
+- `#1784` remains the paper-betriebsfaden and operational context anchor.
+- `#205` and `#211` remain future scaling anchors only.
+- `#2985` remains the separate live roadmap and must not be collapsed into this
+  slice.
+
+This means Capital Sleeves v1 is a paper-governance contract over existing
+evidence, not an allocation engine.
+
+## Sleeve Design
+
+The sleeve model records four paper-only sleeves:
+
+- `CORE`
+- `GROWTH`
+- `OPPORTUNISTIC`
+- `EXPERIMENTAL`
+
+Each sleeve carries:
+
+- purpose
+- candidate profile
+- admission basis
+- explicit paper-only semantics
+
+This keeps sleeve usage explicit instead of drifting into informal capital
+language.
+
+## Paper Accounting Design
+
+The paper accounting report records:
+
+- sleeve-level candidate counts
+- sleeve-level paper pnl
+- sleeve-level drawdown
+- allocation simulation status
+- notes and limitations
+
+This provides visibility into paper behavior without creating real allocation
+authority.
+
+## Integration Boundaries
+
+The integration boundaries are fail-closed:
+
+- no risk-code changes
+- no allocation-service changes
+- no real capital authority
+- future anchors `#205` and `#211` remain future-only
+- live roadmap `#2985` remains separate
+
+If later portfolio or allocation-runtime work is needed, that work stays out of
+scope for this slice and belongs in a separate issue.
+
+## Relationship To Neighbor Issues
+
+- `#3041` must stay downstream of ranking and net economics.
+- sleeve grouping is not a promotion engine
+- paper accounting is not a live-go signal
+- future risk/allocation integration remains a separate gate
+
+## Safety Boundaries
+
+- LR remains NO-GO.
+- `trade-capable` is not Live-Go.
+- No Echtgeld-Go.
+- No runtime change.
+- No productive DB write.
+- No MCP mutation.
+- No Risk, Execution, Allocation, kill-switch, or LR gate change.
+- ARVP, backtest, and paper are evidence, not approval.
+- AI, dashboard, and docs are not authority.
+- No automatic promotion.
+- No capital scaling without separate gates.
+
+## Non-Goals
+
+- no risk-code change
+- no allocation-service change
+- no capital authorization
+- no #205/#211 reactivation
+- no runtime implementation
+- no live-readiness uplift
+
+## Validation
+
+For this docs-only slice, validation means:
+
+1. both JSON schemas parse and pass schema validation
+2. both example fixtures validate against their matching schemas
+3. sleeve governance remains paper-only and non-activating
+4. future allocation and live-roadmap boundaries remain explicit
+
+This does not prove a candidate is profitable, paper-ready, or live-ready.


### PR DESCRIPTION
## Kurzbefund
- fuehrt einen docs-only Slice fuer #3041 ein: Capital Sleeve Model und Paper Accounting v1 als Strategiedokument plus Sleeve-/Report-Contracts mit validierten Beispielartefakten
- bindet Sleeve-Governance explizit an Ranking, Paper-Betriebsfaden #1784 und separate Future-Anker statt an reale Allocation- oder Risk-Logik
- gestapelte PR auf dem offenen #3040-Branch, weil Capital Sleeves die vorigen Ranking- und Evidence-Surfaces konsumieren

## Warum jetzt
- nach #3034 bis #3040 fehlt der explizite Paper-Governance- und Accounting-Rahmen, um Kandidaten spaeter geordnet in Core/Growth/Opportunistic/Experimental einzuhaengen, ohne in Kapitalfreigabe abzurutschen
- der Slice macht Sleeve-Semantik, Paper-PnL, Drawdown-Sicht und Future-Boundaries explizit, ohne Core, Risk oder Live-Gates anzutasten

## Scope
- in: Strategiedoku, Capital-Sleeve-Model-Schema, Paper-Accounting-Report-Schema, zwei Beispielartefakte, README-Eintrag
- out: Runtime-Implementierung, reale Capital Allocation, Risk-/Allocation-Service-Aenderungen, #205/#211-Reaktivierung, DB/MCP-Mutationen, Live-Go-Aussagen

## Betroffene Dateien / Artefakte
- docs/strategy/CDB_PROFITABILITY_CAPITAL_SLEEVES_V1.md
- docs/contracts/profitability_capital_sleeve_model.v1.schema.json
- docs/contracts/profitability_paper_accounting_report.v1.schema.json
- docs/contracts/examples/profitability_capital_sleeve_model_valid.json
- docs/contracts/examples/profitability_paper_accounting_report_valid.json
- docs/contracts/README.md

## Validierung / Checks
- JSON Schema validation beider Beispielartefakte: PASS
- git diff --check: keine Patch-/Whitespace-Fehler; nur erwartete LF/CRLF-Warnung in docs/contracts/README.md
- Doku-Quercheck auf #1784/#205/#211/#2985 sowie NO-GO-Guardrails und separate-issue-Grenze fuer spaetere Allocation-/Runtime-Arbeit

## Risiken / Guardrails
- LR bleibt NO-GO; trade-capable ist kein Live-Go
- keine Runtime-, Risk-, Execution-, Allocation- oder DB-Aenderung
- spaetere Portfolio-/Allocation-Integration bleibt out of scope und braucht ein separates Issue
- Sleeve-Modell und Paper-Accounting bleiben governance-/paper-only und nicht aktivierend

## Restunsicherheiten
- diese PR definiert nur den Capital-/Paper-Contract und keine technische Durchsetzung im Runtime-Pfad
- weil #3048 noch offen ist, ist diese PR bewusst gestapelt und erst sauber landbar, wenn #3040 in main aufgegangen ist

## Issue-Bezug
- Refs #3041
- Refs #3032
