### PR TITLE
[PROFITABILITY][CONTROL] Define profitability control room v1

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -17,6 +17,7 @@ Repo-backed JSON/YAML schemas und Contract-Dokumente für Messages, Replay und C
 | Profitability execution economics | `profitability_execution_economics_model.v1.schema.json`, `profitability_execution_economics_assessment.v1.schema.json` | Net-economics model and candidate cost-attribution contracts |
 | Profitability league table | `profitability_league_table_model.v1.schema.json`, `profitability_league_table_report.v1.schema.json` | Ranking model and recommendation report contracts |
 | Profitability capital sleeves | `profitability_capital_sleeve_model.v1.schema.json`, `profitability_paper_accounting_report.v1.schema.json` | Sleeve-governance model and paper-accounting report contracts |
+| Profitability control room | `profitability_control_room_requirements.v1.schema.json`, `profitability_control_room_snapshot.v1.schema.json` | Control-room requirements and read-only snapshot contracts |
 
 ## Related canon (not duplicated here)
 

--- a/docs/contracts/examples/profitability_control_room_requirements_valid.json
+++ b/docs/contracts/examples/profitability_control_room_requirements_valid.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "profitability_control_room_requirements.v1",
+  "requirements_id": "pcrr-profitability-v1",
+  "created_at": "2026-06-07T08:45:00+00:00",
+  "parent_issue": "#3032",
+  "cockpit_anchor_ref": "#1445",
+  "panels": [
+    {
+      "panel_id": "CANDIDATE_STATUS",
+      "title": "Candidate Status",
+      "required_inputs": [
+        "profitability_candidate_contract.v1",
+        "profitability_evidence_packet.v1"
+      ],
+      "operator_view": true,
+      "management_view": true
+    },
+    {
+      "panel_id": "LEAGUE_TABLE",
+      "title": "Strategy League Table",
+      "required_inputs": [
+        "profitability_league_table_report.v1"
+      ],
+      "operator_view": true,
+      "management_view": true
+    },
+    {
+      "panel_id": "COST_RISK_REGIME",
+      "title": "Cost / Risk / Regime",
+      "required_inputs": [
+        "profitability_execution_economics_assessment.v1",
+        "profitability_scenario_stress_summary.v1"
+      ],
+      "operator_view": true,
+      "management_view": true
+    },
+    {
+      "panel_id": "EVIDENCE_COMPLETENESS",
+      "title": "Evidence Completeness",
+      "required_inputs": [
+        "profitability_dataset_quality_report.v1",
+        "profitability_arvp_batch_summary.v1"
+      ],
+      "operator_view": true,
+      "management_view": false
+    },
+    {
+      "panel_id": "SLEEVE_PNL",
+      "title": "Sleeve PnL",
+      "required_inputs": [
+        "profitability_paper_accounting_report.v1"
+      ],
+      "operator_view": true,
+      "management_view": true
+    }
+  ],
+  "operator_questions": [
+    "Welche Kandidaten sind aktuell blockiert oder geparkt und warum?",
+    "Welche Evidence-Luecken verhindern ehrliche Vergleiche?",
+    "Welche Sleeves zeigen im Paper-Modell auffaellige Drawdown- oder PnL-Muster?"
+  ],
+  "management_questions": [
+    "Welche Kandidaten sind netto und evidenzseitig am belastbarsten?",
+    "Wo konzentrieren sich die groessten Profitability-Risiken?",
+    "Welche Sleeve-Sicht bleibt rein paper-only und nicht aktivierend?"
+  ],
+  "authority_boundaries": {
+    "dashboard_is_approval": false,
+    "ai_is_authority": false,
+    "docs_are_authority": false,
+    "grafana_gate_semantics_allowed": false
+  },
+  "limitations": [
+    "Control Room requirements are read-only and not an approval surface.",
+    "Operational cockpit #1445 remains the existing anchor and is not replaced here."
+  ]
+}

--- a/docs/contracts/examples/profitability_control_room_snapshot_valid.json
+++ b/docs/contracts/examples/profitability_control_room_snapshot_valid.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "profitability_control_room_snapshot.v1",
+  "snapshot_id": "pcrs-profitability-v1-run01",
+  "requirements_id": "pcrr-profitability-v1",
+  "generated_at": "2026-06-07T09:05:00+00:00",
+  "candidate_status_panel": {
+    "candidate_count": 6,
+    "status_summary": [
+      "2 candidates ranking-ready",
+      "3 candidates parked",
+      "1 candidate blocked by dataset quality"
+    ]
+  },
+  "league_table_panel": {
+    "table_status": "PARTIAL",
+    "top_candidates": [
+      "cand-primary-breakout-a1",
+      "cand-secondary-breakout-b2"
+    ]
+  },
+  "cost_risk_regime_panel": {
+    "cost_status": "WARNING",
+    "risk_status": "OK",
+    "regime_status": "WARNING"
+  },
+  "evidence_panel": {
+    "completeness_status": "WARNING",
+    "missing_artifact_count": 2
+  },
+  "sleeve_pnl_panel": {
+    "tracked_sleeves": [
+      "CORE",
+      "GROWTH",
+      "OPPORTUNISTIC",
+      "EXPERIMENTAL"
+    ],
+    "paper_only": true
+  },
+  "limitations": [
+    "Snapshot is advisory visibility only and cannot authorize promotion.",
+    "Cockpit and dashboard outputs remain non-authoritative."
+  ]
+}

--- a/docs/contracts/profitability_control_room_requirements.v1.schema.json
+++ b/docs/contracts/profitability_control_room_requirements.v1.schema.json
@@ -38,7 +38,8 @@
     },
     "panels": {
       "type": "array",
-      "minItems": 4,
+      "minItems": 5,
+      "maxItems": 5,
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -79,7 +80,84 @@
             "type": "boolean"
           }
         }
-      }
+      },
+      "allOf": [
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "panel_id": {
+                "const": "CANDIDATE_STATUS"
+              }
+            },
+            "required": [
+              "panel_id"
+            ]
+          },
+          "minContains": 1,
+          "maxContains": 1
+        },
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "panel_id": {
+                "const": "LEAGUE_TABLE"
+              }
+            },
+            "required": [
+              "panel_id"
+            ]
+          },
+          "minContains": 1,
+          "maxContains": 1
+        },
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "panel_id": {
+                "const": "COST_RISK_REGIME"
+              }
+            },
+            "required": [
+              "panel_id"
+            ]
+          },
+          "minContains": 1,
+          "maxContains": 1
+        },
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "panel_id": {
+                "const": "EVIDENCE_COMPLETENESS"
+              }
+            },
+            "required": [
+              "panel_id"
+            ]
+          },
+          "minContains": 1,
+          "maxContains": 1
+        },
+        {
+          "contains": {
+            "type": "object",
+            "properties": {
+              "panel_id": {
+                "const": "SLEEVE_PNL"
+              }
+            },
+            "required": [
+              "panel_id"
+            ]
+          },
+          "minContains": 1,
+          "maxContains": 1
+        }
+      ]
     },
     "operator_questions": {
       "type": "array",
@@ -108,16 +186,16 @@
       ],
       "properties": {
         "dashboard_is_approval": {
-          "type": "boolean"
+          "const": false
         },
         "ai_is_authority": {
-          "type": "boolean"
+          "const": false
         },
         "docs_are_authority": {
-          "type": "boolean"
+          "const": false
         },
         "grafana_gate_semantics_allowed": {
-          "type": "boolean"
+          "const": false
         }
       }
     },

--- a/docs/contracts/profitability_control_room_requirements.v1.schema.json
+++ b/docs/contracts/profitability_control_room_requirements.v1.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/profitability_control_room_requirements.v1.schema.json",
+  "title": "Profitability Control Room Requirements v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "requirements_id",
+    "created_at",
+    "parent_issue",
+    "cockpit_anchor_ref",
+    "panels",
+    "operator_questions",
+    "management_questions",
+    "authority_boundaries",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_control_room_requirements.v1"
+    },
+    "requirements_id": {
+      "type": "string",
+      "pattern": "^pcrr-[a-z0-9_-]{6,64}$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "parent_issue": {
+      "type": "string",
+      "pattern": "^#3032$"
+    },
+    "cockpit_anchor_ref": {
+      "type": "string",
+      "const": "#1445"
+    },
+    "panels": {
+      "type": "array",
+      "minItems": 4,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "panel_id",
+          "title",
+          "required_inputs",
+          "operator_view",
+          "management_view"
+        ],
+        "properties": {
+          "panel_id": {
+            "type": "string",
+            "enum": [
+              "CANDIDATE_STATUS",
+              "LEAGUE_TABLE",
+              "COST_RISK_REGIME",
+              "EVIDENCE_COMPLETENESS",
+              "SLEEVE_PNL"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "required_inputs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "operator_view": {
+            "type": "boolean"
+          },
+          "management_view": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "operator_questions": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "management_questions": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "authority_boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dashboard_is_approval",
+        "ai_is_authority",
+        "docs_are_authority",
+        "grafana_gate_semantics_allowed"
+      ],
+      "properties": {
+        "dashboard_is_approval": {
+          "type": "boolean"
+        },
+        "ai_is_authority": {
+          "type": "boolean"
+        },
+        "docs_are_authority": {
+          "type": "boolean"
+        },
+        "grafana_gate_semantics_allowed": {
+          "type": "boolean"
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/contracts/profitability_control_room_snapshot.v1.schema.json
+++ b/docs/contracts/profitability_control_room_snapshot.v1.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/profitability_control_room_snapshot.v1.schema.json",
+  "title": "Profitability Control Room Snapshot v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "snapshot_id",
+    "requirements_id",
+    "generated_at",
+    "candidate_status_panel",
+    "league_table_panel",
+    "cost_risk_regime_panel",
+    "evidence_panel",
+    "sleeve_pnl_panel",
+    "limitations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_control_room_snapshot.v1"
+    },
+    "snapshot_id": {
+      "type": "string",
+      "pattern": "^pcrs-[a-z0-9_-]{6,64}$"
+    },
+    "requirements_id": {
+      "type": "string",
+      "pattern": "^pcrr-[a-z0-9_-]{6,64}$"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "candidate_status_panel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_count",
+        "status_summary"
+      ],
+      "properties": {
+        "candidate_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "status_summary": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "league_table_panel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "table_status",
+        "top_candidates"
+      ],
+      "properties": {
+        "table_status": {
+          "type": "string",
+          "enum": ["COMPLETE", "PARTIAL", "BLOCKED"]
+        },
+        "top_candidates": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "cost_risk_regime_panel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "cost_status",
+        "risk_status",
+        "regime_status"
+      ],
+      "properties": {
+        "cost_status": {
+          "type": "string",
+          "enum": ["OK", "WARNING", "FAIL", "BLOCKED"]
+        },
+        "risk_status": {
+          "type": "string",
+          "enum": ["OK", "WARNING", "FAIL", "BLOCKED"]
+        },
+        "regime_status": {
+          "type": "string",
+          "enum": ["OK", "WARNING", "FAIL", "BLOCKED"]
+        }
+      }
+    },
+    "evidence_panel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "completeness_status",
+        "missing_artifact_count"
+      ],
+      "properties": {
+        "completeness_status": {
+          "type": "string",
+          "enum": ["OK", "WARNING", "FAIL", "BLOCKED"]
+        },
+        "missing_artifact_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "sleeve_pnl_panel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tracked_sleeves",
+        "paper_only"
+      ],
+      "properties": {
+        "tracked_sleeves": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "CORE",
+              "GROWTH",
+              "OPPORTUNISTIC",
+              "EXPERIMENTAL"
+            ]
+          }
+        },
+        "paper_only": {
+          "type": "boolean"
+        }
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/strategy/CDB_PROFITABILITY_CONTROL_ROOM_V1.md
+++ b/docs/strategy/CDB_PROFITABILITY_CONTROL_ROOM_V1.md
@@ -1,0 +1,117 @@
+# CDB Profitability Control Room v1
+
+**Status:** Draft contract surface for #3042  
+**Mode:** Docs / schema / example fixtures only  
+**Parent:** #3032  
+**Live-Readiness:** NO-GO  
+**Runtime Impact:** none  
+
+## Purpose
+
+This document defines the first Profitability Control Room v1 requirements for
+operator and management visibility.
+
+The goal is not a gate or approval engine. The goal is a read-only visibility
+surface that makes candidate status, ranking, economics, evidence completeness,
+and sleeve paper behavior visible without claiming operational authority.
+
+## Contract Artifacts
+
+| Artifact | Path | Role |
+|---|---|---|
+| Control room requirements schema | `docs/contracts/profitability_control_room_requirements.v1.schema.json` | Required panels, questions, and authority boundaries |
+| Control room snapshot schema | `docs/contracts/profitability_control_room_snapshot.v1.schema.json` | Read-only snapshot shape for visibility outputs |
+| Requirements example | `docs/contracts/examples/profitability_control_room_requirements_valid.json` | Valid research-only requirements fixture |
+| Snapshot example | `docs/contracts/examples/profitability_control_room_snapshot_valid.json` | Valid research-only snapshot fixture |
+
+## Relationship To Existing Repo Surfaces
+
+Control Room v1 depends on already defined Profitability and cockpit surfaces:
+
+- `#1445` remains the existing operative cockpit anchor.
+- `#3034` and `#3035` define candidate and dataset evidence foundations.
+- `#3040` defines the league table view consumed here.
+- `#3041` defines sleeve paper-pnl visibility consumed here.
+
+This means Control Room v1 is a visibility contract over existing evidence, not
+an approval path.
+
+## Panel Design
+
+Control Room v1 requires at least these panels:
+
+- Candidate Status
+- Strategy League Table
+- Cost / Risk / Regime
+- Evidence Completeness
+- Sleeve PnL
+
+Each panel must declare its required inputs and whether it is intended for
+operator view, management view, or both.
+
+## Operator And Management Questions
+
+The requirements layer must make concrete questions answerable, such as:
+
+- which candidates are blocked or parked and why
+- where evidence is incomplete
+- where sleeve-level paper pnl or drawdown needs attention
+- which candidates are net-credible but still not rank-ready
+
+This keeps the control room anchored in decision support rather than pretty
+status surfaces.
+
+## Authority Boundaries
+
+The authority boundaries are fail-closed:
+
+- dashboard is not approval
+- AI is not authority
+- docs are not authority
+- no Grafana-gate semantics
+
+The control room may summarize evidence, but it cannot authorize promotion,
+paper go, live go, capital allocation, or risk overrides.
+
+## Relationship To Neighbor Issues
+
+- `#3042` stays downstream of candidate, economics, ranking, and sleeve
+  contracts.
+- `#1445` remains the operational cockpit anchor and is not mutated here.
+- If later dashboard or implementation work is needed beyond this requirements
+  surface, that work stays out of scope for this slice and belongs in a
+  separate issue.
+
+## Safety Boundaries
+
+- LR remains NO-GO.
+- `trade-capable` is not Live-Go.
+- No Echtgeld-Go.
+- No runtime change.
+- No productive DB write.
+- No MCP mutation.
+- No Risk, Execution, Allocation, kill-switch, or LR gate change.
+- ARVP, backtest, and paper are evidence, not approval.
+- AI, dashboard, and docs are not authority.
+- No automatic promotion.
+- No capital scaling without separate gates.
+
+## Non-Goals
+
+- no dashboard implementation
+- no Grafana-gate semantics
+- no runtime implementation
+- no DB migration
+- no automatic promotion
+- no live-readiness uplift
+
+## Validation
+
+For this docs-only slice, validation means:
+
+1. both JSON schemas parse and pass schema validation
+2. both example fixtures validate against their matching schemas
+3. candidate, ranking, economics, evidence, and sleeve visibility stay explicit
+4. dashboard / AI / docs remain non-authoritative
+
+This does not prove a candidate is profitable, paper-ready, or live-ready.


### PR DESCRIPTION
## Kurzbefund
- fuehrt einen docs-only Slice fuer #3042 ein: Profitability Control Room v1 als Strategiedokument plus Requirements-/Snapshot-Contracts mit validierten Beispielartefakten
- bindet die Sichtflaechen explizit an bestehende Profitability-Evidence, League Table, Sleeve-PnL und den operativen Cockpit-Anker #1445
- gestapelte PR auf dem offenen #3041-Branch; keine Runtime-, DB-, MCP- oder Live-Semantik

## Warum jetzt
- nach Candidate, Dataset, Batch, Stress, Economics, League Table und Capital Sleeves fehlt die kontrollierte Sicht auf Candidate-Status, Kosten-/Risk-/Regime-Kontext, Evidence Completeness und Sleeve-PnL
- der Slice macht diese Sicht explizit, ohne daraus Approval- oder Gate-Autoritaet abzuleiten

## Scope
- in: Strategiedoku, Control-Room-Requirements-Schema, Control-Room-Snapshot-Schema, zwei Beispielartefakte, README-Eintrag
- out: Dashboard-Implementierung, Grafana-Gate-Semantik, Runtime-Implementierung, DB/MCP-Mutationen, Live-Go-Aussagen

## Betroffene Dateien / Artefakte
- docs/strategy/CDB_PROFITABILITY_CONTROL_ROOM_V1.md
- docs/contracts/profitability_control_room_requirements.v1.schema.json
- docs/contracts/profitability_control_room_snapshot.v1.schema.json
- docs/contracts/examples/profitability_control_room_requirements_valid.json
- docs/contracts/examples/profitability_control_room_snapshot_valid.json
- docs/contracts/README.md

## Validierung / Checks
- JSON Schema validation beider Beispielartefakte: PASS
- git diff --check: keine Patch-/Whitespace-Fehler; nur erwartete LF/CRLF-Warnung in docs/contracts/README.md
- Doku-Quercheck auf #1445 sowie dashboard-is-not-approval, AI-/Docs-nicht-Autoritaet und separate-issue-Grenze

## Risiken / Guardrails
- LR bleibt NO-GO; trade-capable ist kein Live-Go
- keine Runtime-, Risk-, Execution-, Allocation- oder DB-Aenderung
- keine Dashboard-/AI-/Docs-Autoritaet
- spaetere Implementierung jenseits der Requirements bleibt out of scope und braucht ein separates Issue

## Restunsicherheiten
- diese PR definiert nur Requirements- und Snapshot-Contracts, keine technische Dashboard-Durchsetzung
- weil #3049 noch offen ist, ist diese PR bewusst gestapelt und erst sauber landbar, wenn #3041 in main aufgegangen ist

## Issue-Bezug
- Closes #3042
- Refs #3032
- Refs #3041
