### PR TITLE
fix(security): resolve plugin creator uninitialized local variable

### DIFF
--- a/.codex/cdb_skills/.system/plugin-creator/scripts/create_basic_plugin.py
+++ b/.codex/cdb_skills/.system/plugin-creator/scripts/create_basic_plugin.py
@@ -280,6 +280,7 @@ def main() -> None:
             args.force,
         )
 
+    marketplace_path = None
     if args.with_marketplace:
         marketplace_path = Path(args.marketplace_path).expanduser().resolve()
         update_marketplace_json(

--- a/tests/unit/test_plugin_creator.py
+++ b/tests/unit/test_plugin_creator.py
@@ -1,0 +1,83 @@
+"""Tests for create_basic_plugin.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_help_exits_zero() -> None:
+    """Script --help should exit 0."""
+    script = (
+        Path(__file__).resolve().parents[2]
+        / ".codex"
+        / "cdb_skills"
+        / ".system"
+        / "plugin-creator"
+        / "scripts"
+        / "create_basic_plugin.py"
+    )
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "usage:" in result.stdout
+
+
+def test_marketplace_variable_initialized(tmp_path: Path) -> None:
+    """Script with --with-marketplace must not raise UnboundLocalError."""
+    script = (
+        Path(__file__).resolve().parents[2]
+        / ".codex"
+        / "cdb_skills"
+        / ".system"
+        / "plugin-creator"
+        / "scripts"
+        / "create_basic_plugin.py"
+    )
+    plugin_dir = tmp_path / "my_plugin"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "test-plugin",
+            "--path",
+            str(tmp_path),
+            "--with-marketplace",
+            "--marketplace-path",
+            str(tmp_path / "marketplace.json"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    assert "Created plugin scaffold" in result.stdout
+
+
+def test_no_marketplace_no_crash(tmp_path: Path) -> None:
+    """Script without --with-marketplace must not crash."""
+    script = (
+        Path(__file__).resolve().parents[2]
+        / ".codex"
+        / "cdb_skills"
+        / ".system"
+        / "plugin-creator"
+        / "scripts"
+        / "create_basic_plugin.py"
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "bare-plugin",
+            "--path",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    assert "Created plugin scaffold" in result.stdout


### PR DESCRIPTION
Closes #3071
Refs #2289

## Delivered

Minimal fix for CodeQL Alert #4625 (`py/uninitialized-local-variable`) in `.codex/cdb_skills/.system/plugin-creator/scripts/create_basic_plugin.py`.

## Brain Evidence

```
brain_source: repo-only
brain_status: not-used
tools_or_queries:
  - gh issue view 3071
  - gh api /repos/.../code-scanning/alerts/4625
  - rg -n "create_basic_plugin" tests/ .codex/
  - python -m py_compile
  - task (explore) for test search
records_or_results:
  - CodeQL Alert #4625: line 297, col 40-56, variable marketplace_path
  - No existing tests for plugin-creator
  - File compiles clean
repo_crosscheck:
  - create_basic_plugin.py:284,297
impact_on_plan:
  - Minimal one-line fix plus targeted unit tests
limitations:
  - No SurrealDB/MCP evidence needed
```

## Root cause

`marketplace_path` was defined inside an `if args.with_marketplace:` block (line 284) but referenced in a separate `if args.with_marketplace:` block (line 297). CodeQL cannot path-sensitively correlate the two identical conditions.

## Fix

Added explicit `marketplace_path = None` initialization before the first conditional block — one-line change.

## Validation

- `python -m py_compile` — OK
- `ruff check` — all checks passed
- `pytest -q tests/unit/test_plugin_creator.py` — 3/3 passed
- `git diff --check` — no whitespace errors

## Non-goals

- No broad plugin-creator refactor
- No unrelated skill changes
- No runtime/BLUE+RED changes
- No Docker/infra changes
- No productive DB writes
- No MCP mutations
- No secret handling changes
- No CodeQL alert dismissal (alert resolves on next scan)

## Safety boundaries

- LR status remains NO-GO
- `trade-capable` Board stage untouched
- No live/real money paths touched

## Restunsicherheiten

CodeQL may need a new scan run to mark alert #4625 as fixed — this is a CodeQL timing artifact, not a code issue.
