### PR TITLE
fix(security): triage cve-2026-42504 monitoring image alerts

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -378,7 +378,7 @@ jobs:
           echo "### Known Issues (Documented as Accepted Risk)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**gosu Binary CVEs in Redis/Postgres base images:**" >> $GITHUB_STEP_SUMMARY
-          echo "- 4 CRITICAL + 40 HIGH CVEs from Go stdlib 1.18.2" >> $GITHUB_STEP_SUMMARY
+          echo "- 4 CRITICAL + 40 HIGH CVEs from Go stdlib 1.18.2 (incl. CVE-2026-42504 Go mime)" >> $GITHUB_STEP_SUMMARY
           echo "- Risk: LOW (startup-only, no network exposure)" >> $GITHUB_STEP_SUMMARY
           echo "- Documented in: [docs/security/TRIAGE_RUNBOOK.md](docs/security/TRIAGE_RUNBOOK.md)" >> $GITHUB_STEP_SUMMARY
           echo "- Upstream tracking: docker-library/redis, docker-library/postgres" >> $GITHUB_STEP_SUMMARY

--- a/docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3065-3070-CVE-42504_2026-06-08.md
+++ b/docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3065-3070-CVE-42504_2026-06-08.md
@@ -1,0 +1,112 @@
+# Security Batch Matrix — Issues #3065–#3070
+
+**Stand:** 2026-06-08 (UTC)
+**Readout run:** 2026-06-08T08:05:55Z (GitHub Code Scanning)
+**Scope guard:** Triage/evidence only. Kein LR-Go, keine Alert-Dismissals, keine Runtime-/Stack-Mutation.
+
+---
+
+## Executive summary
+
+| Gruppe | Issues | CVE | Layer | Verdict |
+|--------|--------|-----|-------|---------|
+| Prometheus (bin/prometheus) | #3065 | CVE-2026-42504 | `prom/prometheus:v3.11.3` Go stdlib mime | **UPSTREAM_BLOCKED** |
+| Promtool (bin/promtool) | #3066 | CVE-2026-42504 | `prom/prometheus:v3.11.3` Go stdlib mime | **UPSTREAM_BLOCKED** |
+| gosu (usr/local/bin/gosu) | #3067 | CVE-2026-42504 | embedded in `redis:7.4.9-alpine` / `postgres:15.18-alpine` | **UPSTREAM_BLOCKED** (accepted risk) |
+| Grafana (usr/share/grafana/bin/grafana) | #3068 | CVE-2026-42504 | `grafana/grafana:12.4.3-security-02-ubuntu` Go stdlib mime | **UPSTREAM_BLOCKED** |
+| Grafana-cli | #3069 | CVE-2026-42504 | `grafana/grafana:12.4.3-security-02-ubuntu` Go stdlib mime | **UPSTREAM_BLOCKED** |
+| Grafana-server | #3070 | CVE-2026-42504 | `grafana/grafana:12.4.3-security-02-ubuntu` Go stdlib mime | **UPSTREAM_BLOCKED** |
+
+**Cluster parent:** [#2933](https://github.com/jannekbuengener/Claire_de_Binare/issues/2933) (Grafana/Prometheus/Postgres upstream-blocked image CVEs)
+**Parent residual tracker:** [#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513)
+
+---
+
+## CVE-2026-42504 Details
+
+- **Published:** 2026-06-02
+- **CVSS 7.5 (High)** — Network, Low complexity, No privileges, No user interaction, Availability only
+- **Affected:** Go standard library `mime` package — `WordDecoder.DecodeHeader` quadratic complexity algorithmic DoS
+- **Fixed in:** Go 1.25.11 / 1.26.4
+- **GitHub Advisory:** [`GHSA-h524-452v-82p9`](https://github.com/advisories/GHSA-h524-452v-82p9)
+- **Go issue:** [`go.dev/issue/79217`](https://go.dev/issue/79217)
+
+All Go binaries built with earlier versions are vulnerable. The fix requires rebuilding with Go >=1.25.11 or >=1.26.4.
+
+---
+
+## Fixability evidence
+
+### Prometheus / Grafana binaries (embedded Go stdlib)
+
+Both `prom/prometheus:v3.11.3` and `grafana/grafana:12.4.3-security-02-ubuntu` ship statically-linked Go binaries. CDB does not build these images — they are consumed directly from upstream. Fixing requires:
+
+1. Upstream (Prometheus/Grafana) rebuilds binaries with Go >=1.25.11/>=1.26.4
+2. Publishes new Docker images with new digests
+3. CDB can then bump the digest pin
+
+As of 2026-06-08 (6 days post-disclosure), **no scan-verified upstream rebuild is available** for either image that clears CVE-2026-42504. The current pinned digests (`e4254400…` for prometheus, `089f9dbb…` for grafana) are unchanged from the vulnerable build.
+
+**Conclusion:** `UPSTREAM_BLOCKED` — same fixability pattern as the existing #2933 cluster (CVE-2026-34040, CVE-2026-41567, CVE-2026-42306).
+
+### gosu binary (embedded in Redis/Postgres)
+
+gosu is a Go binary embedded at `/usr/local/bin/gosu` inside `redis:7.4.9-alpine` and `postgres:15.18-alpine`. The existing Trivy scan summary in `security-scan.yml` already documents:
+
+- 4 CRITICAL + 40 HIGH Go stdlib 1.18.2 CVEs (startup-only, no network exposure)
+- Risk: LOW — gosu runs at container startup to drop privileges, then exits
+
+CVE-2026-42504 is **another Go stdlib CVE** in the same binary. The existing accepted-risk documentation covers this class of findings. No separate mitigation is warranted for this additional Go stdlib CVE.
+
+---
+
+## Docker image pins (current repo state)
+
+| Image | Tag / Digest | Compose file |
+|-------|-------------|-------------|
+| `prom/prometheus` | `v3.11.3@sha256:e4254400b85610324913f0dc4acf92603d9984e7519414c5a12811aa6146acc3` | `base.yml:59` |
+| `grafana/grafana` | `12.4.3-security-02-ubuntu@sha256:089f9dbbfa3c21e6989aab20f14f1a78cef54c04819af5e9deb2bd9c37966bc5` | `base.yml:78` |
+| `redis` | `7.4.9-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99` | `base.yml:16` |
+| `postgres` | `15.18-alpine@sha256:df7bca0066e6f60cc3dd32faa70caddec20e2c22b58932f79498e5704b23854a` | `base.yml:34` |
+
+Source: `infrastructure/compose/base.yml`, confirmed in `.github/workflows/security-scan.yml`.
+
+---
+
+## Re-triage triggers
+
+| Component | Trigger |
+|-----------|---------|
+| Prometheus | New `prom/prometheus` release rebuilt with Go >=1.25.11/>=1.26.4, scan-verified clear for CVE-2026-42504 |
+| Grafana | New `grafana/grafana` security build rebuilt with Go >=1.25.11/>=1.26.4, scan-verified clear for CVE-2026-42504 |
+| gosu | docker-library/redis or docker-library/postgres publishes base image with gosu rebuilt with Go >=1.25.11/>=1.26.4 |
+
+---
+
+## References
+
+- Cluster tracker: [#2933](https://github.com/jannekbuengener/Claire_de_Binare/issues/2933)
+- Parent residual program: [#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513)
+- Prior batch matrix (moby/docker CVEs): `docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_2886-2892-2909_2026-06-03.md`
+- Security Epic: [#2289](https://github.com/jannekbuengener/Claire_de_Binare/issues/2289)
+- Runbook: `docs/security/TRIAGE_RUNBOOK.md`
+- gosu accepted-risk documentation: `.github/workflows/security-scan.yml` lines 380-384, 392-405
+
+---
+
+## Blast radius
+
+- **Images:** 3 base scan targets (prometheus, grafana, redis/postgres via gosu) in `security-scan.yml`; compose pins unchanged.
+- **Runtime:** No change in this slice.
+- **LR / live / echtgeld:** No impact.
+
+---
+
+## Validation performed for this document
+
+- `gh issue view` #3065–#3070, #2933, #2513
+- `rg -n` for CVE-2026-42504 in repo — zero existing references (fresh alerts)
+- `rg -n` for prometheus/grafana/gosu image references in `infrastructure/`, `.github/`
+- Web evidence: CVE-2026-42504 upstream fix in Go 1.25.11/1.26.4
+
+No alert dismissals. No issue closes without cluster documentation.


### PR DESCRIPTION
## Description

Triage and consolidate 6 new CVE-2026-42504 code-scanning alerts (#3065–#3070) into the existing monitoring image CVE cluster #2933.

### Closes / Refs

- Closes #3065
- Closes #3066
- Closes #3067
- Closes #3068
- Closes #3069
- Closes #3070
- Refs #2933
- Refs #2513

### Delivered

- Evidence doc: \docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3065-3070-CVE-42504_2026-06-08.md\
- \.github/workflows/security-scan.yml\ gosu accepted-risk documentation updated (CVE-2026-42504 added)
- #2933 cluster body updated with CVE-2026-42504 sub-cluster
- Issues #3065–#3070 closed with upstream-blocked triage comments

### Brain Evidence

\\\
brain_source: repo-only
brain_status: not-used
tools_or_queries:
  - gh issue view #3065–#3070, #2933, #2513
  - rg -n prometheus|grafana|gosu|42504 in infrastructure/ .github/ docs/
  - Read: base.yml, security-scan.yml, SERVICE_CATALOG.md, CURRENT_STATUS.md
  - Web search: CVE-2026-42504
records_or_results: none (repo-only)
repo_crosscheck:
  - infrastructure/compose/base.yml — current image pins verified
  - .github/workflows/security-scan.yml — gosu accepted risk
impact_on_plan: upstream-blocked confirmed; existing cluster #2933 covers same images
limitations: kein docker pull möglich (plan mode); kein Container-Zugriff
\\\

### Triage result

**CVE-2026-42504** — Go stdlib \mime\ package vulnerability (CVSS 7.5 HIGH). Fixed in Go 1.25.11/1.26.4. Affects all Go binaries in upstream Docker images:

| Issue | Binary | Image |
|-------|--------|-------|
| #3065 | bin/prometheus | prom/prometheus:v3.11.3 |
| #3066 | bin/promtool | prom/prometheus:v3.11.3 |
| #3067 | usr/local/bin/gosu | embedded in redis/postgres |
| #3068 | usr/share/grafana/bin/grafana | grafana/grafana:12.4.3-security-02-ubuntu |
| #3069 | usr/share/grafana/bin/grafana-cli | grafana/grafana:12.4.3-security-02-ubuntu |
| #3070 | usr/share/grafana/bin/grafana-server | grafana/grafana:12.4.3-security-02-ubuntu |

### Fixability decision

**HOLD_UPSTREAM_BLOCKED** — All affected binaries are statically-linked Go binaries in upstream images. CDB does not build these images. Fix requires upstream rebuild with Go >=1.25.11/>=1.26.4. No scan-verified upstream rebuild available as of 2026-06-08.

### Validation

- \git diff --check\: clean
- \g -n\ for CVE-2026-42504 in repo: documented in evidence doc and security-scan.yml
- All 6 issues closed with triage comments

### Non-goals

- No Compose/image-tag changes (no fix candidate available)
- No code-scanning alert dismissals (alerts remain OPEN on GitHub)
- No runtime/stack/Docker mutation
- No LR-Go or Echtgeld implication

### Safety boundaries

- LR status remains NO-GO
- No runtime BLUE/RED changes
- No productive DB writes
- No secrets exposed

### Restunsicherheiten

- Docker-library redis/postgres may have newer digests with Go >=1.25.11 — not verifiable without \docker pull\ in this session
- CVE-2026-42504 could be cleared by Alpine packaging Go 1.25.11/1.26.4