### PR TITLE
fix(#3079): add price_policy config to historical bridge + evaluation evidence (HOLD)

### DIFF
--- a/core/replay/historical_bridge.py
+++ b/core/replay/historical_bridge.py
@@ -18,9 +18,34 @@ PRIMARY_BREAKOUT_STRATEGY_ID = "primary_breakout_v1"
 PRIMARY_BREAKOUT_SYMBOL = "BTCUSDT"
 ONE_MINUTE_MS = 60_000
 
+VALID_PRICE_POLICIES = frozenset({"close", "high", "hlc3", "ohlc4"})
+
 
 class HistoricalBridgeError(ValueError):
     """Raised when historical input is not bridge-safe."""
+
+
+def _apply_price_policy(row: Mapping[str, Any], policy: str) -> float:
+    """Compute the effective close_now price for a candle row under a given policy.
+
+    Policies:
+    - ``close`` — settled candle close (current default, deterministic)
+    - ``high`` — candle high (optimistic intrabar proxy)
+    - ``hlc3`` — typical price (high + low + close) / 3 (conservative proxy)
+    - ``ohlc4`` — average price (open + high + low + close) / 4 (conservative proxy)
+    """
+    close = _required_number(row, "close")
+    if policy == "close":
+        return close
+    high = _required_number(row, "high")
+    if policy == "high":
+        return high
+    low = _required_number(row, "low")
+    if policy == "hlc3":
+        return (high + low + close) / 3.0
+    # ohlc4
+    open_val = _required_number(row, "open")
+    return (open_val + high + low + close) / 4.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -32,6 +57,7 @@ class PrimaryBreakoutBridgeConfig:
     breakout_buffer: float = 0.0005
     min_minutes_between_entries: int = 60
     trade_side_mode: str = "long_only"
+    price_policy: str = "close"
 
     def validate(self) -> None:
         if self.entry_lookback_minutes <= 0:
@@ -44,6 +70,11 @@ class PrimaryBreakoutBridgeConfig:
             raise HistoricalBridgeError("min_minutes_between_entries must be >= 0")
         if self.trade_side_mode != "long_only":
             raise HistoricalBridgeError("trade_side_mode must be long_only")
+        if self.price_policy not in VALID_PRICE_POLICIES:
+            raise HistoricalBridgeError(
+                f"price_policy must be one of {sorted(VALID_PRICE_POLICIES)}, "
+                f"got {self.price_policy!r}"
+            )
 
 
 def _required_number(row: Mapping[str, Any], key: str) -> float:
@@ -110,7 +141,9 @@ def _validate_candle_series(
         ts_ms = _required_int(row, "ts_ms")
         if previous_ts_ms is not None:
             if ts_ms <= previous_ts_ms:
-                raise HistoricalBridgeError("candles must be strictly increasing by ts_ms")
+                raise HistoricalBridgeError(
+                    "candles must be strictly increasing by ts_ms"
+                )
             if ts_ms - previous_ts_ms != ONE_MINUTE_MS:
                 raise HistoricalBridgeError(
                     "candles must have strict 1m cadence (delta 60000 ms)"
@@ -158,13 +191,11 @@ def build_primary_breakout_historical_bridge(
     requests: list[StrategyAdapterRequest] = []
     for index in range(max_lookback, len(candles)):
         row = candles[index]
-        close_now = _required_number(row, "close")
+        close_now = _apply_price_policy(row, active_config.price_policy)
         ts_ms = _required_int(row, "ts_ms")
         data_gap_active = _optional_bool(row, "data_gap_active", default=False)
 
-        entry_window = candles[
-            index - active_config.entry_lookback_minutes : index
-        ]
+        entry_window = candles[index - active_config.entry_lookback_minutes : index]
         exit_window = candles[index - active_config.exit_lookback_minutes : index]
         highest_high = max(_required_number(item, "high") for item in entry_window)
         lowest_low = min(_required_number(item, "low") for item in exit_window)
@@ -209,7 +240,9 @@ def build_primary_breakout_historical_bridge(
         }
         if data_gap_active:
             market_snapshot["volume"] = (
-                _required_number(row, "volume") if row.get("volume") is not None else 0.0
+                _required_number(row, "volume")
+                if row.get("volume") is not None
+                else 0.0
             )
         else:
             market_event["price"] = close_now
@@ -219,7 +252,9 @@ def build_primary_breakout_historical_bridge(
             market_snapshot["high"] = _required_number(row, "high")
             market_snapshot["low"] = _required_number(row, "low")
             market_snapshot["volume"] = (
-                _required_number(row, "volume") if row.get("volume") is not None else 0.0
+                _required_number(row, "volume")
+                if row.get("volume") is not None
+                else 0.0
             )
         requests.append(
             StrategyAdapterRequest(

--- a/docs/evidence/arvp_price_policy_evaluation_3079.md
+++ b/docs/evidence/arvp_price_policy_evaluation_3079.md
@@ -1,0 +1,52 @@
+# ARVP Price Policy Evaluation — #3079
+
+**Status:** HOLD — close remains default; no policy closes the signal gap
+
+**Verdict:** The LIVE_VS_REPLAY_SIGNAL_SEMANTICS_GAP is **not caused by intra-candle price selection**. No measurable price policy can close it. The gap is driven by venue-level market structure mismatch (MEXC tick vs Binance candles per #3028).
+
+---
+
+## Summary
+
+| Policy | Pilot Sig Δ | 3028 Sig Δ | Verdict |
+|--------|------------:|-----------:|---------|
+| `close` (default) | +0 | -1 | status quo, zero regression |
+| `high` | +2 | -1 | overly optimistic — false positives |
+| `hlc3` | +0 | -1 | equivalent to close on this data |
+| `ohlc4` | +0 | -1 | equivalent to close on this data |
+
+**Recommendation:** Leave default as `close`. Do not switch to `high` (over-generates). `hlc3`/`ohlc4` introduce no regression but also no benefit over `close`.
+
+---
+
+## Method
+
+- **Tool:** `tools/replay/evaluate_price_policies.py` — offline, deterministic, no DB/MCP/runtime
+- **Engine:** `SignalEngine.process_market_data()` with each candle's policy-adjusted price fed as `price` + `close`
+- **Windows:** pilot (MEXC same-venue, ~240 candles) + #3028 (Binance, ~240 candles)
+- **Reference:** paper_reference_window.json per window (signal/order/fill counts incl. causal_context)
+- **Metrics:** signal_count, order_count, fill_count, deltas against paper reference
+
+## Results per Window
+
+### Pilot Window (MEXC same-venue)
+- Expected paper signal = 0 signals + 1 causal-context signal (total 1)
+- `close`: 0 signals (ctx_delta=-1) — matches PR #3080 baseline
+- `high`: 2 signals (ctx_delta=+1) — over-generates; would produce false positives
+- `hlc3`: 0 signals (ctx_delta=-1) — identical to close for this dataset
+- `ohlc4`: 0 signals (ctx_delta=-1) — identical to close for this dataset
+
+### #3028 Window (Binance venue_mismatch)
+- Expected paper signal = 1 signal (no causal signals in this window)
+- All policies produce 0 signals (delta=-1) — the gap persists regardless of price selection
+- Confirms the gap is venue-level, not candle-level
+
+## Conclusion
+
+The *LIVE_VS_REPLAY_SIGNAL_SEMANTICS_GAP* (#3079) is a **venue mismatch / market-microstructure gap**, not a price-policy gap. The pre-switch signal decision (tick price) versus replay signal decision (candle close) produces identical breakout outcomes on this dataset. The remaining gap originates from different market structure (MEXC tick domain vs Binance 1m candle domain).
+
+Closing this gap requires either:
+1. A venue-matched replay source (MEXC 1m candles instead of Binance — blocked by data availability per #3058)
+2. A different evaluation framework that does not rely on replay-parity with a different venue
+
+No action needed on the `price_policy` dimension. Close #3079 as **HOLD** with this evidence.

--- a/tests/unit/replay/test_historical_bridge.py
+++ b/tests/unit/replay/test_historical_bridge.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import json
+import pathlib
 from unittest.mock import patch
 
 import pytest
 
 from core.replay.historical_bridge import (
     HistoricalBridgeError,
+    VALID_PRICE_POLICIES,
     PrimaryBreakoutBridgeConfig,
     build_primary_breakout_historical_bridge,
 )
@@ -140,7 +143,9 @@ def test_bridge_rejects_invalid_trade_side_mode_in_config() -> None:
     candles = _candles()
     config = PrimaryBreakoutBridgeConfig(trade_side_mode="both")
 
-    with pytest.raises(HistoricalBridgeError, match="trade_side_mode must be long_only"):
+    with pytest.raises(
+        HistoricalBridgeError, match="trade_side_mode must be long_only"
+    ):
         build_primary_breakout_historical_bridge(candles, config=config)
 
 
@@ -210,10 +215,156 @@ def test_runtime_and_historical_bridge_align_on_first_evaluable_breakout() -> No
     assert runtime_signal.reason == "breakout_entry"
 
     first_request = requests[0]
-    assert int(first_request.market_event["ts_ms"]) == candles[runtime_signal_index]["ts_ms"]
-    assert first_request.market_event["market_state"]["close_now"] == runtime_signal.price
+    assert (
+        int(first_request.market_event["ts_ms"])
+        == candles[runtime_signal_index]["ts_ms"]
+    )
+    assert (
+        first_request.market_event["market_state"]["close_now"] == runtime_signal.price
+    )
     assert (
         first_request.market_event["market_state"]["highest_high"]
         == runtime_signal.metadata["highest_high"]
         == 102.0
     )
+
+
+@pytest.mark.unit
+def test_price_policy_default_is_close() -> None:
+    config = PrimaryBreakoutBridgeConfig()
+    assert config.price_policy == "close"
+
+
+@pytest.mark.unit
+def test_price_policy_accepts_valid_values() -> None:
+    for policy in ("close", "high", "hlc3", "ohlc4"):
+        config = PrimaryBreakoutBridgeConfig(price_policy=policy)
+        assert config.price_policy == policy
+
+
+@pytest.mark.unit
+def test_price_policy_rejects_invalid_value() -> None:
+    with pytest.raises(HistoricalBridgeError, match="price_policy must be one of"):
+        PrimaryBreakoutBridgeConfig(price_policy="midpoint").validate()
+
+
+def _policy_candle_series(count: int = 245) -> list[dict]:
+    """Monotonically increasing candle series for price policy tests."""
+    return [
+        {
+            "symbol": "BTCUSDT",
+            "ts_ms": 1_700_000_000_000 + i * 60_000,
+            "open": 100.0 + i * 0.1,
+            "high": 101.0 + i * 0.1,
+            "low": 99.0 + i * 0.1,
+            "close": 100.0 + i * 0.1,
+            "volume": 10000.0 + i,
+            "regime_id": 0,
+            "market_state_fresh": True,
+            "regime_fresh": True,
+        }
+        for i in range(count)
+    ]
+
+
+@pytest.mark.unit
+def test_price_policy_high_produces_at_least_as_many_breakouts() -> None:
+    """high policy should produce >= breakouts vs close on monotonically rising data."""
+    candles = _candles(count=250)
+    close_requests = build_primary_breakout_historical_bridge(
+        candles,
+        config=PrimaryBreakoutBridgeConfig(price_policy="close"),
+    )
+    high_requests = build_primary_breakout_historical_bridge(
+        candles,
+        config=PrimaryBreakoutBridgeConfig(price_policy="high"),
+    )
+    assert len(high_requests) >= len(close_requests)
+
+
+@pytest.mark.unit
+def test_price_policy_hlc3_computes_typical_price() -> None:
+    candles = _policy_candle_series(250)
+    close_req = build_primary_breakout_historical_bridge(
+        candles,
+        config=PrimaryBreakoutBridgeConfig(price_policy="close"),
+    )
+    hlc3_req = build_primary_breakout_historical_bridge(
+        candles,
+        config=PrimaryBreakoutBridgeConfig(price_policy="hlc3"),
+    )
+    if close_req:
+        close_now_close = close_req[0].market_event["market_state"]["close_now"]
+        close_now_hlc3 = hlc3_req[0].market_event["market_state"]["close_now"]
+        candle_240 = candles[240]
+        expected_hlc3 = round(
+            (candle_240["high"] + candle_240["low"] + candle_240["close"]) / 3.0, 2
+        )
+        assert close_now_hlc3 == expected_hlc3
+        assert close_now_close == candle_240["close"]
+
+
+@pytest.mark.unit
+def test_price_policy_ohlc4_computes_average_price() -> None:
+    candles = _policy_candle_series(250)
+    ohlc4_req = build_primary_breakout_historical_bridge(
+        candles,
+        config=PrimaryBreakoutBridgeConfig(price_policy="ohlc4"),
+    )
+    if ohlc4_req:
+        candle_240 = candles[240]
+        expected = round(
+            (
+                candle_240["open"]
+                + candle_240["high"]
+                + candle_240["low"]
+                + candle_240["close"]
+            )
+            / 4.0,
+            2,
+        )
+        assert ohlc4_req[0].market_event["market_state"]["close_now"] == expected
+
+
+@pytest.mark.unit
+def test_price_policy_all_policies_produce_valid_close_now() -> None:
+    candles = _policy_candle_series(250)
+    for policy in sorted(VALID_PRICE_POLICIES):
+        requests = build_primary_breakout_historical_bridge(
+            candles,
+            config=PrimaryBreakoutBridgeConfig(price_policy=policy),
+        )
+        assert len(requests) > 0
+        for req in requests:
+            close_now = req.market_event["market_state"]["close_now"]
+            assert isinstance(close_now, float)
+            assert close_now > 0
+
+
+@pytest.mark.unit
+def test_price_policy_pilot_evaluation_differs() -> None:
+    """Smoke check: at least one non-close policy must produce different close_now
+    values on the real pilot candle dataset."""
+
+    pilot = json.loads(
+        pathlib.Path("artifacts/calibration/2961/pilot_candles.json").read_text("utf-8")
+    )
+    close_reqs = build_primary_breakout_historical_bridge(
+        pilot,
+        config=PrimaryBreakoutBridgeConfig(price_policy="close"),
+    )
+    high_reqs = build_primary_breakout_historical_bridge(
+        pilot,
+        config=PrimaryBreakoutBridgeConfig(price_policy="high"),
+    )
+    ohlc4_reqs = build_primary_breakout_historical_bridge(
+        pilot,
+        config=PrimaryBreakoutBridgeConfig(price_policy="ohlc4"),
+    )
+    # At least one of high or ohlc4 must produce different close_now values
+    close_prices = {req.market_event["market_state"]["close_now"] for req in close_reqs}
+    high_prices = {req.market_event["market_state"]["close_now"] for req in high_reqs}
+    ohlc4_prices = {req.market_event["market_state"]["close_now"] for req in ohlc4_reqs}
+    assert (
+        close_prices != high_prices or close_prices != ohlc4_prices
+    ), f"All policies produced identical close_now values: {close_prices}"

--- a/tools/replay/evaluate_price_policies.py
+++ b/tools/replay/evaluate_price_policies.py
@@ -1,0 +1,255 @@
+"""Deterministic ARVP price-policy evaluation for replay signal semantics.
+
+Evaluates each price policy (close, high, hlc3, ohlc4) against the existing
+window bank and produces a comparison matrix.
+
+Usage:
+    python -m tools.replay.evaluate_price_policies
+
+Output:
+    - stdout: comparison matrix (markdown)
+    - artifacts/price_policy_evaluation_3079/ — JSON + MD artifacts
+
+Scope (#3079): deterministic, offline, no DB/Redis/MCP/runtime dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+import sys
+from typing import Any
+
+from core.replay.historical_bridge import VALID_PRICE_POLICIES
+from services.signal.config import SignalConfig
+from services.signal.service import SignalEngine
+
+logging.disable(logging.CRITICAL)
+
+_ARTIFACT_DIR = pathlib.Path("artifacts/price_policy_evaluation_3079")
+_PILOT_CANDLES_PATH = pathlib.Path("artifacts/calibration/2961/pilot_candles.json")
+_PILOT_PAPER_PATH = pathlib.Path(
+    "artifacts/recheck_2980/pilot_window_causal/paper_reference_window.json"
+)
+_W3028_CANDLES_PATH = pathlib.Path("artifacts/candles/3028_window/candles.json")
+_W3028_PAPER_PATH = pathlib.Path(
+    "artifacts/paper_reference_windows/paper_reference_window.json"
+)
+
+
+def _load_json(path: pathlib.Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _create_signal_engine() -> SignalEngine:
+    """Create a deterministic SignalEngine for policy evaluation."""
+    from unittest.mock import patch
+
+    config = SignalConfig(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        min_volume=0.0,
+        entry_lookback_minutes=240,
+        exit_lookback_minutes=120,
+        breakout_buffer=0.0005,
+        min_minutes_between_entries=60,
+        trade_side_mode="long_only",
+    )
+    with patch("services.signal.service.config", config):
+        return SignalEngine()
+
+
+def _count_signals_by_policy(
+    candles: list[dict[str, Any]], policy: str
+) -> dict[str, int]:
+    """Run the signal engine over candle data using a given price policy.
+
+    Feeds each candle's OHLC values to the engine, using the policy price as
+    ``price`` and ``close`` to simulate what the historical bridge would emit.
+    Returns signal/order/fill counts.
+    """
+    engine = _create_signal_engine()
+
+    signal_count = 0
+    order_count = 0
+    fill_count = 0
+
+    for candle in candles:
+        policy_price = None
+        close = float(candle["close"])
+        high = float(candle["high"])
+        low = float(candle["low"])
+        open_val = float(candle.get("open", close))
+        if policy == "close":
+            policy_price = close
+        elif policy == "high":
+            policy_price = high
+        elif policy == "hlc3":
+            policy_price = (high + low + close) / 3.0
+        elif policy == "ohlc4":
+            policy_price = (open_val + high + low + close) / 4.0
+
+        signal = engine.process_market_data(
+            {
+                "symbol": candle["symbol"],
+                "timestamp": candle["ts_ms"] // 1000,
+                "price": policy_price,
+                "close": policy_price,
+                "high": high,
+                "low": low,
+                "volume": float(candle.get("volume", 0)),
+                "regime_id": candle.get("regime_id", 0),
+                "market_state_fresh": candle.get("market_state_fresh", True),
+                "regime_fresh": candle.get("regime_fresh", True),
+            }
+        )
+        if signal is not None:
+            signal_count += 1
+            if signal.side == "BUY":
+                order_count += 1
+                fill_count += 1
+            elif signal.side == "SELL":
+                pass
+
+    return {
+        "policy": policy,
+        "signal_count": signal_count,
+        "order_count": order_count,
+        "fill_count": fill_count,
+    }
+
+
+def _paper_stats(paper_ref: dict[str, Any], window_label: str) -> dict[str, int]:
+    """Extract paper reference signal/order/fill counts."""
+    events = paper_ref.get("events", [])
+    signal_count = 0
+    order_count = 0
+    fill_count = 0
+    for ev in events:
+        ev_type = ev.get("event_type")
+        if ev_type == "SIGNAL":
+            signal_count += 1
+        elif ev_type == "ORDER":
+            order_id = ev.get("order_id", "")
+            if isinstance(order_id, str) and order_id.startswith("paper_"):
+                order_count += 1
+        elif ev_type == "FILL":
+            order_id = ev.get("order_id", "")
+            if isinstance(order_id, str) and order_id.startswith("paper_"):
+                fill_count += 1
+    causal = paper_ref.get("causal_context_events", [])
+    causal_signal_count = sum(1 for cev in causal if cev.get("event_type") == "SIGNAL")
+    return {
+        "window": window_label,
+        "paper_signal_count": signal_count,
+        "paper_causal_signal_count": causal_signal_count,
+        "paper_order_count": order_count,
+        "paper_fill_count": fill_count,
+    }
+
+
+def evaluate_window(
+    candles: list[dict[str, Any]],
+    paper_ref: dict[str, Any],
+    window_label: str,
+) -> list[dict[str, Any]]:
+    """Evaluate all price policies for one window, produce row per policy."""
+    paper = _paper_stats(paper_ref, window_label)
+    rows = []
+    for policy in sorted(VALID_PRICE_POLICIES):
+        result = _count_signals_by_policy(candles, policy)
+        rows.append(
+            {
+                "window": window_label,
+                "policy": policy,
+                **result,
+                "paper_signal_count": paper["paper_signal_count"],
+                "paper_causal_signal_count": paper["paper_causal_signal_count"],
+                "paper_order_count": paper["paper_order_count"],
+                "paper_fill_count": paper["paper_fill_count"],
+                "signal_count_delta": result["signal_count"]
+                - paper["paper_signal_count"],
+                "signal_context_delta": result["signal_count"]
+                - (paper["paper_signal_count"] + paper["paper_causal_signal_count"]),
+                "order_count_delta": result["order_count"] - paper["paper_order_count"],
+                "fill_count_delta": result["fill_count"] - paper["paper_fill_count"],
+            }
+        )
+    return rows
+
+
+def build_matrix_md(rows: list[dict[str, Any]]) -> str:
+    lines = [
+        "# ARVP Price Policy Evaluation Matrix",
+        "",
+        "**Scope:** #3079 — deterministic comparison of replay price policies",
+        "**Generated:** offline, no DB/MCP/runtime dependencies",
+        "",
+        "## Per-Policy Comparison",
+        "",
+        "| Window | Policy | Signal | Order | Fill | Paper Sig | Paper Causal | Paper Ord | Paper Fill | Sig Δ | Ctx Δ | Ord Δ | Fill Δ |",
+        "|--------|--------|-------:|------:|-----:|----------:|-------------:|----------:|-----------:|------:|------:|------:|-------:|",
+    ]
+    for r in rows:
+        lines.append(
+            f"| {r['window']} | {r['policy']} "
+            f"| {r['signal_count']} | {r['order_count']} | {r['fill_count']} "
+            f"| {r['paper_signal_count']} | {r['paper_causal_signal_count']} "
+            f"| {r['paper_order_count']} | {r['paper_fill_count']} "
+            f"| {r['signal_count_delta']:+d} | {r['signal_context_delta']:+d} "
+            f"| {r['order_count_delta']:+d} | {r['fill_count_delta']:+d} |"
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    pilot_candles = _load_json(_PILOT_CANDLES_PATH)
+    pilot_paper = _load_json(_PILOT_PAPER_PATH)
+    w3028_candles = _load_json(_W3028_CANDLES_PATH)
+    w3028_paper = _load_json(_W3028_PAPER_PATH)
+
+    results: list[dict[str, Any]] = []
+
+    print("### Pilot Window (MEXC same-venue)")
+    pilot_rows = evaluate_window(pilot_candles, pilot_paper, "pilot")
+    results.extend(pilot_rows)
+    for r in pilot_rows:
+        print(
+            f"  {r['policy']:8s} → signals={r['signal_count']}, "
+            f"delta={r['signal_count_delta']:+d}, "
+            f"ctx_delta={r['signal_context_delta']:+d}, "
+            f"orders={r['order_count']}, fills={r['fill_count']}"
+        )
+
+    print()
+    print("### #3028 Window (Binance venue_mismatch)")
+    w3028_rows = evaluate_window(w3028_candles, w3028_paper, "3028")
+    results.extend(w3028_rows)
+    for r in w3028_rows:
+        print(
+            f"  {r['policy']:8s} → signals={r['signal_count']}, "
+            f"delta={r['signal_count_delta']:+d}, "
+            f"ctx_delta={r['signal_context_delta']:+d}, "
+            f"orders={r['order_count']}, fills={r['fill_count']}"
+        )
+
+    matrix_md = build_matrix_md(results)
+    print()
+    print(matrix_md)
+
+    _ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    json_path = _ARTIFACT_DIR / "policy_evaluation.json"
+    json_path.write_text(
+        json.dumps(results, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    md_path = _ARTIFACT_DIR / "policy_evaluation_matrix.md"
+    md_path.write_text(matrix_md, encoding="utf-8")
+
+    print(f"\nArtifacts written to {_ARTIFACT_DIR}/")
+    print(f"  JSON: {json_path}")
+    print(f"  MD:   {md_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

## Summary

Adds a configurable price_policy field to the PrimaryBreakoutBridgeConfig with four deterministic options (close, high, hlc3, ohlc4). The default remains close — zero regression.

## Changes

- **core/replay/historical_bridge.py**: Added VALID_PRICE_POLICIES, _apply_price_policy() helper, price_policy field with validation; changed close_now resolution from hardcoded \close\ to policy-based
- **tests/unit/replay/test_historical_bridge.py**: 8 new tests
- **tools/replay/evaluate_price_policies.py**: Standalone offline evaluation tool
- **docs/evidence/arvp_price_policy_evaluation_3079.md**: Evidence doc with full matrix

## Evaluation Results

| Policy | Pilot Sig Δ | 3028 Sig Δ | Verdict |
|--------|:----------:|:----------:|---------|
| close | +0 | -1 | status quo |
| high | +2 | -1 | overly optimistic |
| hlc3 | +0 | -1 | = close on this data |
| ohlc4 | +0 | -1 | = close on this data |

## Verdict

**HOLD.** No price policy closes the LIVE_VS_REPLAY_SIGNAL_SEMANTICS_GAP. The gap is driven by venue-level market microstructure mismatch (MEXC tick vs Binance candle), not intra-candle price selection. Default remains \close\. Closing this gap requires venue-matched replay source (per #3058) or a different evaluation framework.

## Verification

- 977/977 replay unit tests pass
- ruff: clean
- black: formatted
- git diff --check: clean
