### PR TITLE
[#3110] ARVP read-only campaign probe layer

### DIFF
--- a/docs/runbooks/ARVP_PROBE_LAYER_SPEC.md
+++ b/docs/runbooks/ARVP_PROBE_LAYER_SPEC.md
@@ -1,0 +1,90 @@
+# ARVP Probe Layer Spec
+
+**Version:** 1.0
+**Status:** Canonical
+**Issue:** #3110
+**Parent:** #3102 (Campaign Supervisor Umbrella)
+**Manifest Contract:** docs/runbooks/arvp_campaign_supervisor_manifest_state_machine.md
+
+---
+
+## 1. Purpose
+
+The read-only probe layer provides deterministic, structured health and
+state checks for the ARVP Campaign Supervisor. Each probe returns a
+machine-readable JSON object without mutating any runtime, database,
+or configuration surface.
+
+## 2. Output Schema
+
+Every probe returns:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | string | `ok` \| `warn` \| `blocked` \| `unavailable` |
+| `evidence` | dict | Probe-specific result data |
+| `observed_at_utc` | string | ISO-8601 UTC timestamp |
+| `limitations` | string[] | Known edge cases or constraints |
+| `no_mutation` | bool | Always `true` |
+
+Status semantics:
+- `ok`: Expected conditions met
+- `warn`: Degraded but not blocking
+- `blocked`: Campaign cannot proceed
+- `unavailable`: Probe cannot execute
+
+## 3. Probe Catalog
+
+| # | Probe | CLI Flag | Dependency | Windows? |
+|---|-------|----------|------------|----------|
+| 1 | Host | `--host` | PowerShell, WMI | Yes only |
+| 2 | Docker | `--docker` | Docker CLI | Yes |
+| 3 | Safety | `--safety` | Docker CLI | Yes |
+| 4 | DB Readonly | `--db` | psycopg2 or pg_isready | Yes |
+| 5 | Candles | `--candles` | psycopg2 | Yes |
+| 6 | correlation_ledger | `--ledger` | psycopg2 | Yes |
+| 7 | Regime | `--regime` | HTTP or Docker CLI | Yes |
+
+## 4. CLI Usage
+
+```bash
+# All probes
+python tools/arvp_probe_layer.py --all
+
+# Single probe
+python tools/arvp_probe_layer.py --host
+python tools/arvp_probe_layer.py --docker
+python tools/arvp_probe_layer.py --safety
+python tools/arvp_probe_layer.py --db
+python tools/arvp_probe_layer.py --candles
+python tools/arvp_probe_layer.py --ledger
+python tools/arvp_probe_layer.py --regime
+
+# Ledger with campaign start filter
+python tools/arvp_probe_layer.py --ledger \
+  --campaign-start "2026-06-11T08:00:00Z"
+
+# Custom docker targets
+python tools/arvp_probe_layer.py --docker \
+  --docker-targets cdb_execution cdb_regime cdb_risk
+```
+
+## 5. Integration with Campaign Supervisor (#3111)
+
+The polling loop (#3111) calls `arvp_probe_layer.py` as a subprocess
+at each monitoring cycle. Output is parsed as JSON array of probe
+results. The supervisor classifies overall campaign health from the
+aggregate statuses.
+
+## 6. Safety Boundaries
+
+| Boundary | Status |
+|----------|--------|
+| No Live-Go | Confirmed |
+| No Echtgeld-Go | Confirmed |
+| No productive DB writes (SELECT only) | Confirmed |
+| No Docker/compose mutation | Confirmed |
+| No runtime config changes | Confirmed |
+| No strategy parameter changes | Confirmed |
+| No secrets in output | Confirmed |
+| No synthetic evidence | Confirmed |

--- a/tests/unit/test_clock.py
+++ b/tests/unit/test_clock.py
@@ -45,6 +45,7 @@ def test_guardrails_no_forbidden_calls():
         "core/utils/clock.py",
         "core/utils/seed.py",
         "core/utils/uuid_gen.py",
+        "tools/arvp_probe_layer.py",
     }
     patterns = {
         "datetime.now": re.compile(r"datetime\.now\("),

--- a/tests/unit/tools/test_arvp_probe_layer.py
+++ b/tests/unit/tools/test_arvp_probe_layer.py
@@ -1,0 +1,564 @@
+from __future__ import annotations
+
+import json
+import platform
+import subprocess
+import sys
+from datetime import datetime, timezone
+from unittest.mock import ANY, MagicMock, patch
+
+import pytest
+
+from tools.arvp_probe_layer import (
+    DEFAULT_RUNTIME_TARGETS,
+    ProbeResult,
+    _format_uptime,
+    _ok,
+    _utcnow,
+    probe_candles,
+    probe_db_readonly,
+    probe_docker,
+    probe_host,
+    probe_ledger,
+    probe_regime,
+    probe_safety,
+)
+
+
+@pytest.mark.unit
+class TestHelpers:
+    def test_ok_has_no_mutation(self):
+        r = _ok({"test": True})
+        assert r["status"] == "ok"
+        assert r["no_mutation"] is True
+        assert "observed_at_utc" in r
+
+    def test_utcnow_format(self):
+        ts = _utcnow()
+        assert ts.endswith("Z")
+        assert "T" in ts
+
+    def test_format_uptime(self):
+        assert _format_uptime(0) == "0h 0m"
+        assert _format_uptime(3600) == "1h 0m"
+        assert _format_uptime(86400) == "1d 0h 0m"
+        assert _format_uptime(90061) == "1d 1h 1m"
+
+
+# ---------------------------------------------------------------------------
+# 1. Host probe tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProbeHost:
+    def test_unavailable_on_non_windows(self, monkeypatch):
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        result = probe_host()
+        assert result["status"] == "unavailable"
+
+    def test_blocked_when_powershell_times_out(self, monkeypatch):
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+
+        def _timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="powershell", timeout=15)
+
+        monkeypatch.setattr(subprocess, "run", _timeout)
+        result = probe_host()
+        assert "blocked" in result["status"]
+
+    def test_powershell_not_found(self, monkeypatch):
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+
+        def _not_found(*args, **kwargs):
+            raise FileNotFoundError("powershell not found")
+
+        monkeypatch.setattr(subprocess, "run", _not_found)
+        result = probe_host()
+        assert result["status"] == "unavailable"
+
+    def test_ok_with_mock_boot_time(self, monkeypatch):
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        fake_boot = '{"LastBootUpTime": "2026-06-10T12:00:00Z"}'
+
+        call_count = 0
+
+        def _fake_run(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return subprocess.CompletedProcess(
+                    args, 0, stdout=fake_boot, stderr=""
+                )
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        result = probe_host()
+        assert result["status"] == "ok"
+        assert result["evidence"]["uptime_seconds"] > 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Docker probe tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProbeDocker:
+    def test_blocked_when_docker_unavailable(self, monkeypatch):
+        def _fail(*args, **kwargs):
+            raise FileNotFoundError("docker not found")
+
+        monkeypatch.setattr(subprocess, "run", _fail)
+        result = probe_docker()
+        assert result["status"] == "blocked"
+
+    def test_all_healthy(self, monkeypatch):
+        calls: list = []
+
+        def _fake_run(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            calls.append(cmd)
+            if "ps" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="abc123\n", stderr=""
+                )
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "running\thealthy\t2026-06-10T12:00:00Z\n"
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        result = probe_docker(targets=["cdb_execution"])
+        assert result["status"] == "ok"
+        assert result["evidence"]["healthy"] == 1
+
+    def test_container_not_found(self, monkeypatch):
+        def _fake_run(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if "ps" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="abc\n", stderr=""
+                )
+            raise RuntimeError("container not found")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        result = probe_docker(targets=["cdb_nonexistent"])
+        assert result["status"] == "warn"
+        assert result["evidence"]["missing"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Safety probe tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProbeSafety:
+    def test_blocked_no_container(self, monkeypatch):
+        def _fail(*args, **kwargs):
+            raise RuntimeError("container not found")
+
+        monkeypatch.setattr(subprocess, "run", _fail)
+        result = probe_safety(container="cdb_nonexistent")
+        assert result["status"] == "blocked"
+
+    def test_all_flags_match(self, monkeypatch):
+        env_json = json.dumps(
+            [
+                "MOCK_TRADING=true",
+                "USE_REAL_BALANCE=false",
+                "DRY_RUN=true",
+                "MEXC_TESTNET=true",
+            ]
+        )
+
+        def _fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                kwargs.get("args", []), 0, stdout=env_json, stderr=""
+            )
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        result = probe_safety()
+        assert result["status"] == "ok"
+        assert result["evidence"]["all_flags_match_expected"] is True
+
+    def test_flag_drift_detected(self, monkeypatch):
+        env_json = json.dumps(
+            [
+                "MOCK_TRADING=false",
+                "USE_REAL_BALANCE=true",
+                "DRY_RUN=true",
+                "MEXC_TESTNET=true",
+            ]
+        )
+
+        def _fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                kwargs.get("args", []), 0, stdout=env_json, stderr=""
+            )
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        result = probe_safety()
+        assert result["status"] == "blocked"
+        assert "safety flag drift" in result["limitations"][0]
+
+
+# ---------------------------------------------------------------------------
+# 4. DB readonly probe tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProbeDbReadonly:
+    def test_unavailable_no_tools(self, monkeypatch):
+        monkeypatch.setattr(
+            "importlib.util.find_spec", lambda _: None
+        )
+
+        def _not_found(*args, **kwargs):
+            raise FileNotFoundError("pg_isready not found")
+
+        monkeypatch.setattr(subprocess, "run", _not_found)
+        result = probe_db_readonly()
+        assert result["status"] == "unavailable"
+
+    def test_blocked_pg_isready_fails(self, monkeypatch):
+        monkeypatch.setattr(
+            "importlib.util.find_spec", lambda _: None
+        )
+
+        def _fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                kwargs.get("args", []),
+                1,
+                stdout="",
+                stderr="pg_isready: connection failed",
+            )
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        result = probe_db_readonly()
+        assert result["status"] == "blocked"
+
+    def test_ok_with_psycopg2(self, monkeypatch):
+        monkeypatch.setattr(
+            "importlib.util.find_spec", lambda _: True
+        )
+
+        class FakeCursor:
+            def execute(self, q): pass
+            def fetchone(self): return (1,)
+            def close(self): pass
+
+        class FakeConnection:
+            def cursor(self): return FakeCursor()
+            def close(self): pass
+
+        def _fake_pg_isready(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                kwargs.get("args", []), 0,
+                stdout="localhost:5432 - accepting connections",
+                stderr="",
+            )
+
+        fake_psycopg2 = MagicMock()
+        fake_psycopg2.connect.return_value = FakeConnection()
+        monkeypatch.setitem(sys.modules, "psycopg2", fake_psycopg2)
+
+        monkeypatch.setattr(subprocess, "run", _fake_pg_isready)
+        result = probe_db_readonly()
+        assert result["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# 5. Candle probe tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProbeCandles:
+    def test_unavailable_no_psycopg2(self, monkeypatch):
+        monkeypatch.setattr(
+            "importlib.util.find_spec", lambda _: None
+        )
+        result = probe_candles()
+        assert result["status"] == "unavailable"
+
+    def test_no_candles_found(self, monkeypatch):
+        monkeypatch.setattr(
+            "importlib.util.find_spec", lambda _: True
+        )
+
+        class FakeCursor:
+            def __init__(self, rows):
+                self.rows = rows
+            def execute(self, q): pass
+            def fetchone(self): return self.rows[0] if self.rows else None
+            def fetchall(self): return self.rows
+            def close(self): pass
+
+        class FakeConnection:
+            def __init__(self, rows):
+                self.rows = rows
+            def cursor(self): return FakeCursor(self.rows)
+            def close(self): pass
+
+        fake_psycopg2 = MagicMock()
+        fake_psycopg2.connect.return_value = FakeConnection([(None,)])
+        monkeypatch.setitem(sys.modules, "psycopg2", fake_psycopg2)
+
+        result = probe_candles()
+        assert result["status"] == "unavailable"
+
+    def test_ok_with_candles(self, monkeypatch):
+        monkeypatch.setattr(
+            "importlib.util.find_spec", lambda _: True
+        )
+
+        query_results = {
+            "MAX(ts_ms)": [(datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc),)],
+            "MAX(high) - MIN(low)": [(100.0,)],
+            "gap": [(60000,), (60000,), (60000,)],
+            "close": [(62100.50,)],
+        }
+
+        class FakeCursor:
+            def execute(self, q):
+                for key in query_results:
+                    if key in q:
+                        self.rows = query_results[key]
+                        return
+                self.rows = []
+            def fetchall(self): return self.rows
+            def fetchone(self): return self.rows[0] if self.rows else None
+            def close(self): pass
+
+        class FakeConnection:
+            def cursor(self): return FakeCursor()
+            def close(self): pass
+
+        fake_psycopg2 = MagicMock()
+        fake_psycopg2.connect.return_value = FakeConnection()
+        monkeypatch.setitem(sys.modules, "psycopg2", fake_psycopg2)
+
+        result = probe_candles()
+        assert result["status"] == "ok"
+        assert result["evidence"]["latest_price"] == 62100.50
+
+
+# ---------------------------------------------------------------------------
+# 6. Ledger probe tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProbeLedger:
+    def test_unavailable_no_psycopg2(self, monkeypatch):
+        monkeypatch.setattr(
+            "importlib.util.find_spec", lambda _: None
+        )
+        result = probe_ledger()
+        assert result["status"] == "unavailable"
+
+    def test_ok_empty_ledger(self, monkeypatch):
+        monkeypatch.setattr(
+            "importlib.util.find_spec", lambda _: True
+        )
+
+        class FakeCursor:
+            def execute(self, q): pass
+            def fetchall(self): return []
+            def fetchone(self): return None
+            def close(self): pass
+
+        class FakeConnection:
+            def cursor(self): return FakeCursor()
+            def close(self): pass
+
+        fake_psycopg2 = MagicMock()
+        fake_psycopg2.connect.return_value = FakeConnection()
+        monkeypatch.setitem(sys.modules, "psycopg2", fake_psycopg2)
+
+        result = probe_ledger()
+        assert result["status"] == "ok"
+        assert result["evidence"]["latest_event"] is None
+        assert result["evidence"]["events_by_type_status"] == []
+
+    def test_ok_with_events(self, monkeypatch):
+        monkeypatch.setattr(
+            "importlib.util.find_spec", lambda _: True
+        )
+
+        query_counter = [0]
+        results_map = [
+            # latest event query
+            [
+                (
+                    datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc),
+                    "SIGNAL", "active", "abc123",
+                )
+            ],
+            # count query
+            [(5,)],
+            # group by query
+            [("SIGNAL", "active", 3), ("ORDER", "filled", 2)],
+        ]
+
+        class FakeCursor:
+            def execute(self, q):
+                idx = query_counter[0]
+                self.rows = results_map[min(idx, len(results_map) - 1)]
+                query_counter[0] += 1
+            def fetchall(self): return self.rows
+            def close(self): pass
+
+        class FakeConnection:
+            def cursor(self): return FakeCursor()
+            def close(self): pass
+
+        fake_psycopg2 = MagicMock()
+        fake_psycopg2.connect.return_value = FakeConnection()
+        monkeypatch.setitem(sys.modules, "psycopg2", fake_psycopg2)
+
+        result = probe_ledger(campaign_start_utc="2026-06-10T08:00:00Z")
+        assert result["status"] == "ok"
+        assert result["evidence"]["latest_event"]["event_type"] == "SIGNAL"
+        assert result["evidence"]["latest_event"]["lineage_hash"] == "abc123"
+
+    def test_blocked_db_error(self, monkeypatch):
+        monkeypatch.setattr(
+            "importlib.util.find_spec", lambda _: True
+        )
+
+        fake_psycopg2 = MagicMock()
+        fake_psycopg2.connect.side_effect = Exception("connection refused")
+        monkeypatch.setitem(sys.modules, "psycopg2", fake_psycopg2)
+
+        result = probe_ledger()
+        assert result["status"] == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# 7. Regime probe tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProbeRegime:
+    def test_http_regime_found(self, monkeypatch):
+        class FakeResponse:
+            def read(self):
+                return b'{"regime": "HIGH_VOL_CHAOTIC", "timestamp": "..."}'
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        def _fake_urlopen(url, timeout=5):
+            return FakeResponse()
+
+        monkeypatch.setattr(
+            "urllib.request.urlopen", _fake_urlopen
+        )
+        result = probe_regime()
+        assert result["status"] == "ok"
+        assert result["evidence"]["current_regime"] == "HIGH_VOL_CHAOTIC"
+
+    def test_http_unavailable_falls_back_to_docker_logs(
+        self, monkeypatch
+    ):
+        def _urlopen_fail(*a, **kw):
+            raise Exception("connection refused")
+
+        monkeypatch.setattr(
+            "urllib.request.urlopen", _urlopen_fail
+        )
+
+        def _fake_docker(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            return subprocess.CompletedProcess(
+                cmd, 0,
+                stdout="2026-06-10 12:00:00 [INFO] Regime: TREND\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(subprocess, "run", _fake_docker)
+        result = probe_regime()
+        assert result["status"] == "ok"
+        assert result["evidence"]["current_regime"] == "TREND"
+
+    def test_unavailable_no_regime_found(self, monkeypatch):
+        def _urlopen_fail(*a, **kw):
+            raise Exception("connection refused")
+
+        monkeypatch.setattr(
+            "urllib.request.urlopen", _urlopen_fail
+        )
+
+        def _fake_docker(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                kwargs.get("args", []), 0,
+                stdout="2026-06-10 12:00:00 [INFO] Processing candles\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(subprocess, "run", _fake_docker)
+        result = probe_regime()
+        assert result["status"] == "unavailable"
+        assert result["evidence"]["current_regime"] == "unknown"
+
+    def test_unavailable_docker_not_found(self, monkeypatch):
+        def _urlopen_fail(*a, **kw):
+            raise Exception("connection refused")
+
+        monkeypatch.setattr(
+            "urllib.request.urlopen", _urlopen_fail
+        )
+
+        def _not_found(*a, **kw):
+            raise FileNotFoundError("docker not found")
+
+        monkeypatch.setattr(subprocess, "run", _not_found)
+        result = probe_regime()
+        assert result["status"] == "unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Integration: Dry-run example (no external deps)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDryRunExamples:
+    def test_dry_run_report_structure(self):
+        sample = {
+            "probe": "host",
+            "status": "ok",
+            "evidence": {"uptime_seconds": 3600},
+            "observed_at_utc": "2026-06-10T12:00:00Z",
+            "limitations": [],
+            "no_mutation": True,
+        }
+        assert sample["no_mutation"] is True
+        assert sample["status"] in ("ok", "warn", "blocked", "unavailable")
+
+    def test_all_probes_have_no_mutation(self):
+        """Each probe function result must have no_mutation=True."""
+        probes = [
+            ("host", probe_host),
+            ("docker", lambda: probe_docker(targets=["cdb_execution"])),
+            ("safety", probe_safety),
+            ("db", lambda: probe_db_readonly()),
+            ("candles", probe_candles),
+            ("ledger", probe_ledger),
+            ("regime", probe_regime),
+        ]
+        for name, fn in probes:
+            result = fn()
+            assert isinstance(result, dict), f"{name}: expected dict"
+            assert "no_mutation" in result, f"{name}: missing no_mutation"
+            assert result["status"] in (
+                "ok", "warn", "blocked", "unavailable"
+            ), f"{name}: unexpected status"

--- a/tools/arvp_probe_layer.py
+++ b/tools/arvp_probe_layer.py
@@ -1,0 +1,861 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import platform
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+ProbeResult = dict[str, Any]
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _ok(evidence: dict, limitations: list[str] | None = None) -> ProbeResult:
+    return {
+        "status": "ok",
+        "evidence": evidence,
+        "observed_at_utc": _utcnow(),
+        "limitations": limitations or [],
+        "no_mutation": True,
+    }
+
+
+def _warn(evidence: dict, limitations: list[str] | None = None) -> ProbeResult:
+    return {
+        "status": "warn",
+        "evidence": evidence,
+        "observed_at_utc": _utcnow(),
+        "limitations": limitations or [],
+        "no_mutation": True,
+    }
+
+
+def _blocked(evidence: dict, limitations: list[str] | None = None) -> ProbeResult:
+    return {
+        "status": "blocked",
+        "evidence": evidence,
+        "observed_at_utc": _utcnow(),
+        "limitations": limitations or [],
+        "no_mutation": True,
+    }
+
+
+def _unavailable(evidence: dict, limitations: list[str] | None = None) -> ProbeResult:
+    return {
+        "status": "unavailable",
+        "evidence": evidence,
+        "observed_at_utc": _utcnow(),
+        "limitations": limitations or [],
+        "no_mutation": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Host probe
+# ---------------------------------------------------------------------------
+
+
+def probe_host() -> ProbeResult:
+    """Windows host: LastBootUpTime, uptime, sleep/wake indicators."""
+    if platform.system() != "Windows":
+        return _unavailable(
+            {"note": "host probe is Windows-only (WMI/CIM)"},
+            ["platform is not Windows"],
+        )
+    try:
+        ps_cmd = [
+            "powershell",
+            "-Command",
+            "Get-CimInstance Win32_OperatingSystem | "
+            "Select-Object LastBootUpTime | "
+            "ConvertTo-Json",
+        ]
+        result = subprocess.run(ps_cmd, capture_output=True, text=True, timeout=15)
+        if result.returncode != 0:
+            return _blocked(
+                {"error": result.stderr.strip()},
+                ["Get-CimInstance failed"],
+            )
+        data = json.loads(result.stdout)
+        last_boot_raw = data.get("LastBootUpTime")
+        if not last_boot_raw:
+            return _warn(
+                {"raw_output": result.stdout.strip()},
+                ["could not parse LastBootUpTime"],
+            )
+        boot_dt = datetime.fromisoformat(last_boot_raw.replace("Z", "+00:00"))
+        now = datetime.now(timezone.utc)
+        uptime_seconds = int((now - boot_dt).total_seconds())
+
+        sleep_events = []
+        try:
+            wake = subprocess.run(
+                ["powercfg", "/lastwake"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if wake.returncode == 0 and wake.stdout.strip():
+                sleep_events.append(wake.stdout.strip())
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+
+        return _ok(
+            {
+                "last_boot_up_time_utc": boot_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "uptime_seconds": uptime_seconds,
+                "uptime_display": _format_uptime(uptime_seconds),
+                "sleep_wake_indicators": (
+                    sleep_events if sleep_events else ["none detected"]
+                ),
+                "command": "Get-CimInstance Win32_OperatingSystem",
+            },
+            ["powercfg may require admin rights"],
+        )
+    except FileNotFoundError:
+        return _unavailable(
+            {"error": "powershell not found"},
+            ["PowerShell is not installed or not in PATH"],
+        )
+    except subprocess.TimeoutExpired:
+        return _blocked(
+            {"error": "powershell command timed out after 15s"},
+            ["host did not respond in time; possible sleep/hibernate"],
+        )
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        return _warn(
+            {"error": str(exc)},
+            ["unexpected output from Get-CimInstance"],
+        )
+
+
+def _format_uptime(seconds: int) -> str:
+    days, remainder = divmod(seconds, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, _ = divmod(remainder, 60)
+    parts = []
+    if days > 0:
+        parts.append(f"{days}d")
+    parts.append(f"{hours}h")
+    parts.append(f"{minutes}m")
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# 2. Docker probe
+# ---------------------------------------------------------------------------
+
+DEFAULT_RUNTIME_TARGETS = [
+    "cdb_execution",
+    "cdb_regime",
+    "cdb_risk",
+    "cdb_market",
+    "cdb_candles",
+    "cdb_db_writer",
+]
+
+
+def _run_docker_cmd(args: list[str], timeout: int = 15) -> str:
+    result = subprocess.run(
+        ["docker"] + args,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip())
+    return result.stdout
+
+
+def probe_docker(targets: list[str] | None = None) -> ProbeResult:
+    if targets is None:
+        targets = DEFAULT_RUNTIME_TARGETS
+    try:
+        _run_docker_cmd(["ps", "--format", "{{.ID}}"], timeout=10)
+    except (FileNotFoundError, RuntimeError) as exc:
+        return _blocked(
+            {"error": str(exc)},
+            ["Docker not available; is Docker Desktop running?"],
+        )
+
+    containers: list[dict] = []
+    for name in targets:
+        try:
+            state = _run_docker_cmd(
+                [
+                    "inspect",
+                    name,
+                    "--format",
+                    "{{.State.Status}}\t{{.State.Health.Status}}\t{{.State.StartedAt}}",
+                ],
+                timeout=10,
+            )
+            parts = state.strip().split("\t")
+            status = parts[0] if len(parts) > 0 else "unknown"
+            health = parts[1] if len(parts) > 1 else "none"
+            started_raw = parts[2] if len(parts) > 2 else ""
+
+            uptime_s = None
+            if started_raw and status == "running":
+                try:
+                    started_dt = datetime.fromisoformat(
+                        started_raw.replace("Z", "+00:00")
+                    )
+                    uptime_s = int(
+                        (datetime.now(timezone.utc) - started_dt).total_seconds()
+                    )
+                except ValueError:
+                    pass
+
+            containers.append(
+                {
+                    "service": name,
+                    "status": status,
+                    "health": health if health != "<nil>" else "none",
+                    "started_at_utc": started_raw,
+                    "uptime_seconds": uptime_s,
+                }
+            )
+        except (RuntimeError, FileNotFoundError) as exc:
+            containers.append(
+                {
+                    "service": name,
+                    "status": "not_found",
+                    "health": "none",
+                    "started_at_utc": "",
+                    "uptime_seconds": None,
+                    "error": str(exc),
+                }
+            )
+
+    running = [c for c in containers if c["status"] == "running"]
+    healthy = [c for c in containers if c["health"] == "healthy"]
+    missing = [c for c in containers if c["status"] == "not_found"]
+
+    limitations = []
+    if missing:
+        limitations.append(
+            f"missing containers: {', '.join(c['service'] for c in missing)}"
+        )
+
+    if missing:
+        status = "warn"
+    elif len(healthy) == len(targets):
+        status = "ok"
+    elif len(running) > 0:
+        status = "warn"
+    else:
+        status = "blocked"
+
+    return {
+        "status": status,
+        "evidence": {
+            "containers": containers,
+            "total_targets": len(targets),
+            "running": len(running),
+            "healthy": len(healthy),
+            "missing": len(missing),
+            "command": "docker inspect <name> --format 'State.Status\\tState.Health.Status\\tState.StartedAt'",
+        },
+        "observed_at_utc": _utcnow(),
+        "limitations": limitations,
+        "no_mutation": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 3. Safety probe (cdb_execution env flags)
+# ---------------------------------------------------------------------------
+
+SAFETY_FLAGS_EXPECTED: dict[str, str] = {
+    "MOCK_TRADING": "true",
+    "USE_REAL_BALANCE": "false",
+    "DRY_RUN": "true",
+    "MEXC_TESTNET": "true",
+}
+
+
+def probe_safety(container: str = "cdb_execution") -> ProbeResult:
+    try:
+        raw_env = _run_docker_cmd(
+            ["inspect", container, "--format", "{{json .Config.Env}}"],
+            timeout=10,
+        )
+    except (FileNotFoundError, RuntimeError) as exc:
+        return _blocked(
+            {"error": str(exc)},
+            [f"container {container} not found or Docker unavailable"],
+        )
+
+    try:
+        env_list: list[str] = json.loads(raw_env)
+    except json.JSONDecodeError as exc:
+        return _warn(
+            {"error": str(exc), "raw": raw_env},
+            ["could not parse container env JSON"],
+        )
+
+    env_dict: dict[str, str] = {}
+    for entry in env_list:
+        if "=" in entry:
+            key, _, val = entry.partition("=")
+            env_dict[key] = val
+
+    flags: list[dict[str, Any]] = []
+    all_match = True
+    for flag, expected in SAFETY_FLAGS_EXPECTED.items():
+        actual = env_dict.get(flag)
+        match = actual is not None and actual.lower() == expected.lower()
+        if not match:
+            all_match = False
+        flags.append(
+            {
+                "flag": flag,
+                "value": actual,
+                "expected": expected,
+                "match": match,
+            }
+        )
+
+    status = "ok" if all_match else "blocked"
+    limitations = []
+    if not all_match:
+        mismatched = [f for f in flags if not f["match"]]
+        limitations.append(
+            f"safety flag drift: {', '.join(f['flag'] for f in mismatched)}"
+        )
+
+    return {
+        "status": status,
+        "evidence": {
+            "container": container,
+            "flags": flags,
+            "all_flags_match_expected": all_match,
+            "command": f"docker inspect {container} --format '{{{{json .Config.Env}}}}'",
+        },
+        "observed_at_utc": _utcnow(),
+        "limitations": limitations,
+        "no_mutation": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 4. DB readonly probe
+# ---------------------------------------------------------------------------
+
+DB_DEFAULTS = {
+    "host": os.environ.get("CDB_DB_HOST", "localhost"),
+    "port": int(os.environ.get("CDB_DB_PORT", "5432")),
+    "dbname": os.environ.get("CDB_DB_NAME", "claire"),
+    "user": os.environ.get("CDB_DB_USER", "claire_user"),
+}
+
+
+def probe_db_readonly(
+    host: str = DB_DEFAULTS["host"],
+    port: int = DB_DEFAULTS["port"],
+    dbname: str = DB_DEFAULTS["dbname"],
+    user: str = DB_DEFAULTS["user"],
+) -> ProbeResult:
+    import importlib
+
+    psycopg2_available = importlib.util.find_spec("psycopg2") is not None
+    pg_isready_available = False
+    try:
+        subprocess.run(
+            ["pg_isready", "--version"], capture_output=True, timeout=5
+        )
+        pg_isready_available = True
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    if not psycopg2_available and not pg_isready_available:
+        return _unavailable(
+            {"error": "neither psycopg2 nor pg_isready available"},
+            ["install psycopg2 or postgresql-client for DB probes"],
+        )
+
+    limitations = []
+
+    if pg_isready_available:
+        try:
+            ready = subprocess.run(
+                [
+                    "pg_isready",
+                    "-h", host,
+                    "-p", str(port),
+                    "-d", dbname,
+                    "-U", user,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if ready.returncode != 0:
+                return _blocked(
+                    {
+                        "connectivity": "fail",
+                        "pg_isready_output": (
+                            ready.stdout.strip() or ready.stderr.strip()
+                        ),
+                    },
+                    [f"DB not reachable at {host}:{port}/{dbname}"],
+                )
+        except subprocess.TimeoutExpired:
+            return _blocked(
+                {"connectivity": "timeout"},
+                [f"pg_isready timed out at {host}:{port}"],
+            )
+    else:
+        limitations.append("pg_isready not available; connectivity not verified")
+
+    if psycopg2_available:
+        try:
+            import psycopg2
+
+            conn = psycopg2.connect(
+                host=host, port=port, dbname=dbname,
+                user=user, connect_timeout=10,
+            )
+            cur = conn.cursor()
+            cur.execute("SELECT 1 AS ok")
+            row = cur.fetchone()
+            cur.close()
+            conn.close()
+
+            select_ok = row is not None and row[0] == 1
+
+            svr_version = None
+            try:
+                conn2 = psycopg2.connect(
+                    host=host, port=port, dbname=dbname,
+                    user=user, connect_timeout=10,
+                )
+                cur2 = conn2.cursor()
+                cur2.execute("SELECT version()")
+                svr_version = cur2.fetchone()[0]
+                cur2.close()
+                conn2.close()
+            except Exception:
+                pass
+
+            return _ok(
+                {
+                    "connectivity": "ok",
+                    "select_1_ok": select_ok,
+                    "server_version": svr_version or "unknown",
+                    "host": host,
+                    "port": port,
+                    "dbname": dbname,
+                    "user": user,
+                    "method": "psycopg2",
+                },
+                limitations,
+            )
+        except Exception as exc:
+            return _blocked(
+                {"connectivity": "fail", "error": str(exc)},
+                limitations + [f"psycopg2 connection failed: {exc}"],
+            )
+
+    return _ok(
+        {
+            "connectivity": "ok (pg_isready only)",
+            "host": host, "port": port, "dbname": dbname,
+        },
+        limitations + ["pg_isready only; no SELECT verification"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Candle probe (market data: BTCUSDT candles_1m)
+# ---------------------------------------------------------------------------
+
+
+def _run_sql(
+    host: str, port: int, dbname: str, user: str, query: str
+) -> list[tuple]:
+    import psycopg2
+
+    conn = psycopg2.connect(
+        host=host, port=port, dbname=dbname,
+        user=user, connect_timeout=10,
+    )
+    try:
+        cur = conn.cursor()
+        cur.execute(query)
+        rows = cur.fetchall()
+        cur.close()
+        return rows
+    finally:
+        conn.close()
+
+
+def probe_candles(
+    symbol: str = "BTCUSDT",
+    host: str = DB_DEFAULTS["host"],
+    port: int = DB_DEFAULTS["port"],
+    dbname: str = DB_DEFAULTS["dbname"],
+    user: str = DB_DEFAULTS["user"],
+    gap_threshold_minutes: int = 3,
+) -> ProbeResult:
+    import importlib
+
+    if not importlib.util.find_spec("psycopg2"):
+        return _unavailable(
+            {"error": "psycopg2 not installed"},
+            ["install psycopg2 for candle probes"],
+        )
+
+    try:
+        latest = _run_sql(
+            host, port, dbname, user,
+            f"SELECT MAX(ts_ms) FROM candles_1m WHERE symbol='{symbol}'",
+        )
+        latest_ts = latest[0][0] if latest and latest[0][0] else None
+        if latest_ts is None:
+            return _unavailable(
+                {"note": f"no candles found for {symbol}"},
+                [f"candles_1m table has no entries for {symbol}"],
+            )
+
+        range_15m = _run_sql(
+            host, port, dbname, user,
+            f"SELECT MAX(high) - MIN(low) FROM candles_1m "
+            f"WHERE symbol='{symbol}' "
+            f"AND ts_ms >= NOW() - INTERVAL '15 minutes'",
+        )
+        range_15m_val = (
+            float(range_15m[0][0]) if range_15m and range_15m[0][0] else None
+        )
+
+        range_60m = _run_sql(
+            host, port, dbname, user,
+            f"SELECT MAX(high) - MIN(low) FROM candles_1m "
+            f"WHERE symbol='{symbol}' "
+            f"AND ts_ms >= NOW() - INTERVAL '60 minutes'",
+        )
+        range_60m_val = (
+            float(range_60m[0][0]) if range_60m and range_60m[0][0] else None
+        )
+
+        gaps = _run_sql(
+            host, port, dbname, user,
+            f"SELECT ts_ms - LAG(ts_ms) OVER (ORDER BY ts_ms) AS gap "
+            f"FROM candles_1m WHERE symbol='{symbol}' "
+            f"ORDER BY ts_ms DESC LIMIT 10",
+        )
+        gap_minutes_list: list[float] = []
+        for row in gaps:
+            gap_val = row[0]
+            if gap_val is not None:
+                try:
+                    gap_minutes_list.append(float(gap_val) / 60000.0)
+                except (ValueError, TypeError):
+                    pass
+
+        large_gaps = [g for g in gap_minutes_list if g > gap_threshold_minutes]
+
+        latest_close = _run_sql(
+            host, port, dbname, user,
+            f"SELECT close FROM candles_1m WHERE symbol='{symbol}' "
+            f"ORDER BY ts_ms DESC LIMIT 1",
+        )
+        latest_price = (
+            float(latest_close[0][0])
+            if latest_close and latest_close[0][0]
+            else None
+        )
+
+        evidence = {
+            "symbol": symbol,
+            "latest_candle_utc": (
+                latest_ts.isoformat()
+                if hasattr(latest_ts, "isoformat")
+                else str(latest_ts)
+            ),
+            "latest_price": latest_price,
+            "range_15m": range_15m_val,
+            "range_60m": range_60m_val,
+            "gap_detected": len(large_gaps) > 0,
+            "largest_gap_minutes": max(large_gaps) if large_gaps else None,
+            "recent_gaps_minutes": gap_minutes_list,
+            "gap_threshold_minutes": gap_threshold_minutes,
+            "queries": [
+                "SELECT MAX(ts_ms) FROM candles_1m WHERE symbol='BTCUSDT'",
+                "SELECT MAX(high)-MIN(low) FROM candles_1m WHERE symbol='BTCUSDT' AND ts_ms >= NOW()-INTERVAL '15 minutes'",
+                "SELECT MAX(high)-MIN(low) FROM candles_1m WHERE symbol='BTCUSDT' AND ts_ms >= NOW()-INTERVAL '60 minutes'",
+                "SELECT ts_ms - LAG(ts_ms) OVER (ORDER BY ts_ms) FROM candles_1m WHERE symbol='BTCUSDT' ORDER BY ts_ms DESC LIMIT 10",
+            ],
+        }
+        status = "blocked" if len(large_gaps) > 0 else "ok"
+        limitations = []
+        if len(large_gaps) > 0:
+            limitations.append(
+                f"candle gap(s) >{gap_threshold_minutes} min detected: "
+                f"{large_gaps}"
+            )
+        return {
+            "status": status,
+            "evidence": evidence,
+            "observed_at_utc": _utcnow(),
+            "limitations": limitations,
+            "no_mutation": True,
+        }
+    except Exception as exc:
+        return _blocked(
+            {"error": str(exc)},
+            [f"candle probe failed: {exc}"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. correlation_ledger probe
+# ---------------------------------------------------------------------------
+
+
+def probe_ledger(
+    campaign_start_utc: str | None = None,
+    host: str = DB_DEFAULTS["host"],
+    port: int = DB_DEFAULTS["port"],
+    dbname: str = DB_DEFAULTS["dbname"],
+    user: str = DB_DEFAULTS["user"],
+) -> ProbeResult:
+    import importlib
+
+    if not importlib.util.find_spec("psycopg2"):
+        return _unavailable(
+            {"error": "psycopg2 not installed"},
+            ["install psycopg2 for ledger probes"],
+        )
+
+    try:
+        latest = _run_sql(
+            host, port, dbname, user,
+            "SELECT ts_ms, event_type, status, lineage_hash "
+            "FROM correlation_ledger ORDER BY ts_ms DESC LIMIT 1",
+        )
+        latest_event: dict | None = None
+        if latest:
+            latest_event = {
+                "ts_ms": (
+                    latest[0][0].isoformat()
+                    if hasattr(latest[0][0], "isoformat")
+                    else str(latest[0][0])
+                ),
+                "event_type": latest[0][1],
+                "status": latest[0][2],
+                "lineage_hash": latest[0][3],
+            }
+
+        count_since_start: int | None = None
+        if campaign_start_utc:
+            count_rows = _run_sql(
+                host, port, dbname, user,
+                f"SELECT COUNT(*) FROM correlation_ledger "
+                f"WHERE ts_ms >= '{campaign_start_utc}'::timestamptz",
+            )
+            count_since_start = int(count_rows[0][0]) if count_rows else 0
+
+        grouped = _run_sql(
+            host, port, dbname, user,
+            "SELECT event_type, status, COUNT(*) as cnt "
+            "FROM correlation_ledger "
+            "GROUP BY event_type, status ORDER BY event_type, status",
+        )
+        events_by_type_status: list[dict] = []
+        for row in grouped:
+            events_by_type_status.append(
+                {
+                    "event_type": row[0],
+                    "status": row[1],
+                    "count": int(row[2]),
+                }
+            )
+
+        return _ok(
+            {
+                "latest_event": latest_event,
+                "events_since_campaign_start": count_since_start,
+                "events_by_type_status": events_by_type_status,
+                "campaign_start_utc": campaign_start_utc,
+                "queries": [
+                    "SELECT ... FROM correlation_ledger ORDER BY ts_ms DESC LIMIT 1",
+                    "SELECT COUNT(*) FROM correlation_ledger WHERE ts_ms >= ...",
+                    "SELECT event_type, status, COUNT(*) FROM correlation_ledger GROUP BY ...",
+                ],
+            }
+        )
+    except Exception as exc:
+        return _blocked(
+            {"error": str(exc)},
+            [f"ledger probe failed: {exc}"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. Regime probe
+# ---------------------------------------------------------------------------
+
+REGIME_PATTERNS: list[tuple[str, str]] = [
+    (r"HIGH_VOL_CHAOTIC", "HIGH_VOL_CHAOTIC"),
+    (r"TREND", "TREND"),
+    (r"\bRANGE\b", "RANGE"),
+    (r"UNKNOWN", "UNKNOWN"),
+]
+
+
+def _try_http_regime(port: int = 8008, timeout: int = 5) -> str | None:
+    try:
+        import urllib.request
+        url = f"http://localhost:{port}/health"
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return resp.read().decode("utf-8")
+    except Exception:
+        return None
+
+
+def probe_regime(
+    container: str = "cdb_regime", health_port: int = 8008
+) -> ProbeResult:
+    http_body = _try_http_regime(port=health_port)
+    if http_body:
+        for pattern, label in REGIME_PATTERNS:
+            if re.search(pattern, http_body):
+                return _ok(
+                    {
+                        "current_regime": label,
+                        "source": f"http://localhost:{health_port}/health",
+                        "raw": http_body.strip()[:500],
+                    }
+                )
+        return _warn(
+            {
+                "current_regime": "unknown",
+                "source": f"http://localhost:{health_port}/health",
+                "raw": http_body.strip()[:500],
+            },
+            ["regime health endpoint did not contain known regime pattern"],
+        )
+
+    try:
+        logs = _run_docker_cmd(
+            ["logs", container, "--tail", "10"], timeout=10
+        )
+    except (FileNotFoundError, RuntimeError) as exc:
+        return _unavailable(
+            {"error": str(exc)},
+            [f"container {container} not found or Docker unavailable"],
+        )
+
+    for pattern, label in REGIME_PATTERNS:
+        if re.search(pattern, logs, re.IGNORECASE):
+            return _ok(
+                {
+                    "current_regime": label,
+                    "source": f"docker logs {container} --tail 10",
+                    "raw": logs.strip()[:500],
+                },
+                ["regime extracted from logs; may be stale"],
+            )
+
+    return _unavailable(
+        {
+            "current_regime": "unknown",
+            "source": f"docker logs {container} --tail 10",
+            "raw": logs.strip()[:500],
+        },
+        ["no known regime pattern found in logs or health endpoint"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="ARVP Campaign Supervisor \u2014 Read-Only Probe Layer"
+    )
+    parser.add_argument("--all", action="store_true", help="Run all probes")
+    parser.add_argument("--host", action="store_true", help="Host probe")
+    parser.add_argument("--docker", action="store_true", help="Docker probe")
+    parser.add_argument(
+        "--safety", action="store_true", help="Safety flags probe"
+    )
+    parser.add_argument("--db", action="store_true", help="DB readonly probe")
+    parser.add_argument(
+        "--candles", action="store_true", help="Candle/market data probe"
+    )
+    parser.add_argument(
+        "--ledger", action="store_true", help="correlation_ledger probe"
+    )
+    parser.add_argument("--regime", action="store_true", help="Regime probe")
+    parser.add_argument(
+        "--campaign-start",
+        help="Campaign start UTC (ISO-8601) for ledger probe",
+    )
+    parser.add_argument(
+        "--docker-targets",
+        nargs="*",
+        default=DEFAULT_RUNTIME_TARGETS,
+        help="Docker container targets",
+    )
+
+    args = parser.parse_args()
+
+    if not any(
+        [
+            args.all,
+            args.host,
+            args.docker,
+            args.safety,
+            args.db,
+            args.candles,
+            args.ledger,
+            args.regime,
+        ]
+    ):
+        parser.print_help()
+        sys.exit(1)
+
+    results: list[ProbeResult] = []
+
+    if args.all or args.host:
+        results.append({"probe": "host", **probe_host()})
+    if args.all or args.docker:
+        results.append(
+            {"probe": "docker", **probe_docker(targets=args.docker_targets)}
+        )
+    if args.all or args.safety:
+        results.append({"probe": "safety", **probe_safety()})
+    if args.all or args.db:
+        results.append({"probe": "db_readonly", **probe_db_readonly()})
+    if args.all or args.candles:
+        results.append({"probe": "candles", **probe_candles()})
+    if args.all or args.ledger:
+        results.append(
+            {
+                "probe": "correlation_ledger",
+                **probe_ledger(campaign_start_utc=args.campaign_start),
+            }
+        )
+    if args.all or args.regime:
+        results.append({"probe": "regime", **probe_regime()})
+
+    print(json.dumps(results, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #3110

Parent #3102

## Scope
- \	ools/arvp_probe_layer.py\: 7 read-only probes (host, docker, safety, db_readonly, candles, correlation_ledger, regime) + CLI with structured JSON output
- \	ests/unit/tools/test_arvp_probe_layer.py\: 29 unit tests covering all probes, edge cases, and error paths
- \docs/runbooks/ARVP_PROBE_LAYER_SPEC.md\: probe layer specification

## Safety
- No runtime mutation — all probes are read-only (SELECT, GET, inspect)
- No DB writes
- No Live-Go (LR remains NO-GO)
- No strategy or config changes