### PR TITLE
[#3111] ARVP campaign supervisor CLI polling loop

### DIFF
--- a/tests/unit/test_clock.py
+++ b/tests/unit/test_clock.py
@@ -1,4 +1,5 @@
 import pytest
+
 """Unit tests for core.utils.clock module."""
 
 import re
@@ -46,6 +47,7 @@ def test_guardrails_no_forbidden_calls():
         "core/utils/seed.py",
         "core/utils/uuid_gen.py",
         "tools/arvp_probe_layer.py",
+        "tools/arvp_campaign_supervisor.py",
     }
     patterns = {
         "datetime.now": re.compile(r"datetime\.now\("),
@@ -71,4 +73,6 @@ def test_guardrails_no_forbidden_calls():
         for label, pattern in patterns.items():
             if pattern.search(content):
                 violations.append(f"{rel}:{label}")
-    assert not violations, "Forbidden calls detected:\\n" + "\\n".join(sorted(violations))
+    assert not violations, "Forbidden calls detected:\\n" + "\\n".join(
+        sorted(violations)
+    )

--- a/tests/unit/tools/test_arvp_campaign_supervisor.py
+++ b/tests/unit/tools/test_arvp_campaign_supervisor.py
@@ -1,0 +1,627 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from tools.arvp_campaign_supervisor import (
+    EXIT_BLOCKED_DB_READONLY,
+    EXIT_BLOCKED_GOVERNANCE,
+    EXIT_BLOCKED_RUNTIME,
+    EXIT_CHAIN_FOUND,
+    EXIT_INTERRUPTED,
+    EXIT_INVALID_USAGE,
+    EXIT_OK,
+    EXIT_TIMEOUT_NO_CHAIN,
+    STATE_BLOCKED_DB_READONLY,
+    STATE_BLOCKED_GOVERNANCE,
+    STATE_BLOCKED_RUNTIME,
+    STATE_CHAIN_FOUND,
+    STATE_INTERRUPTED,
+    STATE_RUNNING,
+    STATE_TIMEOUT_NO_CHAIN,
+    detect_chain,
+    detect_interruption,
+    evaluate_state,
+    load_manifest,
+    run_all_probes,
+    write_jsonl_entry,
+    write_status_md,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok(probe: str, evidence: dict | None = None) -> dict:
+    return {
+        "probe": probe,
+        "status": "ok",
+        "evidence": evidence or {},
+        "observed_at_utc": "2026-06-10T12:00:00Z",
+        "limitations": [],
+        "no_mutation": True,
+    }
+
+
+def _blocked(probe: str, evidence: dict | None = None) -> dict:
+    return {
+        "probe": probe,
+        "status": "blocked",
+        "evidence": evidence or {"error": "mock blocked"},
+        "observed_at_utc": "2026-06-10T12:00:00Z",
+        "limitations": ["mock blocked"],
+        "no_mutation": True,
+    }
+
+
+def _minimal_manifest(**overrides) -> dict:
+    m = {
+        "schema_version": "1.0",
+        "campaign_id": "test_campaign_1",
+        "parent_issue": 3095,
+        "related_issues": [3087, 3102],
+        "symbol": "BTCUSDT",
+        "strategy_id": "primary_breakout_v1",
+        "evidence_class": "natural_paper_evidence",
+        "start_utc": "2026-06-10T08:00:00Z",
+        "timeout_utc": "2026-06-10T16:00:00Z",
+        "max_duration_hours": 8.0,
+        "start_criteria": {"pre_documented": True},
+        "safety_flags": {
+            "mock_trading": True,
+            "use_real_balance": False,
+            "dry_run": True,
+            "mexc_testnet": True,
+        },
+        "runtime_targets": ["cdb_execution", "cdb_regime"],
+        "db_readonly_targets": ["public.correlation_ledger"],
+        "evidence_doc": "docs/evidence/test.md",
+        "evidence_log_jsonl": "artifacts/test/evidence.jsonl",
+        "github_reporting": {"post_on_issue_3095": True},
+        "allowed_statuses": ["running", "chain_found"],
+        "terminal_statuses": ["chain_found"],
+    }
+    m.update(overrides)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# 1. Manifest loading
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLoadManifest:
+    def test_invalid_path(self):
+        with pytest.raises(ValueError, match="not found"):
+            load_manifest("/nonexistent/path.yaml")
+
+    def test_missing_required_field(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as f:
+            json.dump({"schema_version": "1.0"}, f)
+            path = f.name
+        try:
+            with pytest.raises(ValueError, match="missing required fields"):
+                load_manifest(path)
+        finally:
+            os.unlink(path)
+
+    def test_unsupported_schema_version(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+        ) as f:
+            yaml.dump({**_minimal_manifest(), "schema_version": "2.0"}, f)
+            path = f.name
+        try:
+            with pytest.raises(ValueError, match="unsupported schema_version"):
+                load_manifest(path)
+        finally:
+            os.unlink(path)
+
+    def test_valid_yaml_manifest(self):
+        m = _minimal_manifest()
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+        ) as f:
+            yaml.dump(m, f)
+            path = f.name
+        try:
+            result = load_manifest(path)
+            assert result["campaign_id"] == "test_campaign_1"
+            assert result["schema_version"] == "1.0"
+        finally:
+            os.unlink(path)
+
+    def test_valid_json_manifest(self):
+        m = _minimal_manifest()
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as f:
+            json.dump(m, f)
+            path = f.name
+        try:
+            result = load_manifest(path)
+            assert result["campaign_id"] == "test_campaign_1"
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# 2. State evaluation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEvaluateState:
+    def test_running_before_timeout_no_chain(self):
+        probes = [
+            _ok(
+                "host",
+                {"uptime_seconds": 86400, "sleep_wake_indicators": ["none detected"]},
+            ),
+            _ok("docker"),
+            _ok("safety"),
+            _ok("db_readonly"),
+            _ok("candles", {"latest_price": 62100}),
+            _ok(
+                "correlation_ledger",
+                {
+                    "latest_event": None,
+                    "events_since_campaign_start": 0,
+                    "events_by_type_status": [],
+                },
+            ),
+            _ok("regime", {"current_regime": "RANGE"}),
+        ]
+        manifest = _minimal_manifest(timeout_utc="2099-01-01T00:00:00Z")
+        state = evaluate_state(probes, manifest, 1)
+        assert state == STATE_RUNNING
+
+    def test_timeout_no_chain(self):
+        probes = [
+            _ok(
+                "host",
+                {"uptime_seconds": 86400, "sleep_wake_indicators": ["none detected"]},
+            ),
+            _ok("docker"),
+            _ok("safety"),
+            _ok("db_readonly"),
+            _ok("candles", {"latest_price": 62100}),
+            _ok(
+                "correlation_ledger",
+                {
+                    "latest_event": None,
+                    "events_since_campaign_start": 0,
+                    "events_by_type_status": [],
+                },
+            ),
+            _ok("regime", {"current_regime": "RANGE"}),
+        ]
+        manifest = _minimal_manifest(timeout_utc="2020-01-01T00:00:00Z")
+        state = evaluate_state(probes, manifest, 5)
+        assert state == STATE_TIMEOUT_NO_CHAIN
+
+    def test_chain_found(self):
+        probes = [
+            _ok(
+                "host",
+                {"uptime_seconds": 86400, "sleep_wake_indicators": ["none detected"]},
+            ),
+            _ok("docker"),
+            _ok("safety"),
+            _ok("db_readonly"),
+            _ok("candles", {"latest_price": 62100}),
+            _ok(
+                "correlation_ledger",
+                {
+                    "latest_event": {"event_type": "FILL", "status": "filled"},
+                    "events_since_campaign_start": 4,
+                    "events_by_type_status": [
+                        {"event_type": "SIGNAL", "status": "active", "count": 1},
+                        {"event_type": "DECISION", "status": "executed", "count": 1},
+                        {"event_type": "ORDER", "status": "filled", "count": 1},
+                        {"event_type": "FILL", "status": "confirmed", "count": 1},
+                    ],
+                },
+            ),
+            _ok("regime", {"current_regime": "TREND"}),
+        ]
+        manifest = _minimal_manifest()
+        state = evaluate_state(probes, manifest, 3)
+        assert state == STATE_CHAIN_FOUND
+
+    def test_chain_found_with_order_paper_prefix(self):
+        probes = [
+            _ok(
+                "host",
+                {"uptime_seconds": 86400, "sleep_wake_indicators": ["none detected"]},
+            ),
+            _ok("docker"),
+            _ok("safety"),
+            _ok("db_readonly"),
+            _ok("candles", {"latest_price": 62100}),
+            _ok(
+                "correlation_ledger",
+                {
+                    "events_since_campaign_start": 4,
+                    "events_by_type_status": [
+                        {"event_type": "SIGNAL", "status": "active", "count": 1},
+                        {"event_type": "DECISION", "status": "executed", "count": 1},
+                        {"event_type": "ORDER(paper_)", "status": "filled", "count": 1},
+                        {"event_type": "FILL", "status": "confirmed", "count": 1},
+                    ],
+                },
+            ),
+            _ok("regime"),
+        ]
+        manifest = _minimal_manifest()
+        state = evaluate_state(probes, manifest, 1)
+        assert state == STATE_CHAIN_FOUND
+
+    def test_interrupted_host_sleep_events(self):
+        probes = [
+            _ok(
+                "host",
+                {
+                    "uptime_seconds": 3600,
+                    "sleep_wake_indicators": ["Wake history count: 1"],
+                },
+            ),
+            _ok("docker"),
+            _ok("safety"),
+            _ok("db_readonly"),
+            _ok("candles", {"latest_price": 62100}),
+            _ok("correlation_ledger", {"events_by_type_status": []}),
+            _ok("regime"),
+        ]
+        manifest = _minimal_manifest(timeout_utc="2099-01-01T00:00:00Z")
+        state = evaluate_state(probes, manifest, 2)
+        assert state == STATE_INTERRUPTED
+
+    def test_interrupted_low_uptime(self):
+        probes = [
+            _ok(
+                "host",
+                {
+                    "uptime_seconds": 120,
+                    "sleep_wake_indicators": ["none detected"],
+                },
+            ),
+            _ok("docker"),
+            _ok("safety"),
+            _ok("db_readonly"),
+            _ok("candles"),
+            _ok("correlation_ledger", {"events_by_type_status": []}),
+            _ok("regime"),
+        ]
+        manifest = _minimal_manifest(timeout_utc="2099-01-01T00:00:00Z")
+        state = evaluate_state(probes, manifest, 1)
+        assert state == STATE_INTERRUPTED
+
+    def test_blocked_runtime_docker(self):
+        probes = [
+            _ok(
+                "host",
+                {"uptime_seconds": 86400, "sleep_wake_indicators": ["none detected"]},
+            ),
+            _blocked("docker"),
+            _ok("safety"),
+            _ok("db_readonly"),
+            _ok("candles"),
+            _ok("correlation_ledger", {"events_by_type_status": []}),
+            _ok("regime"),
+        ]
+        manifest = _minimal_manifest()
+        state = evaluate_state(probes, manifest, 1)
+        assert state == STATE_BLOCKED_RUNTIME
+
+    def test_blocked_runtime_safety(self):
+        probes = [
+            _ok("host"),
+            _ok("docker"),
+            _blocked("safety"),
+            _ok("db_readonly"),
+            _ok("candles"),
+            _ok("correlation_ledger", {"events_by_type_status": []}),
+            _ok("regime"),
+        ]
+        manifest = _minimal_manifest()
+        state = evaluate_state(probes, manifest, 1)
+        assert state == STATE_BLOCKED_RUNTIME
+
+    def test_blocked_db_readonly(self):
+        probes = [
+            _ok(
+                "host",
+                {"uptime_seconds": 86400, "sleep_wake_indicators": ["none detected"]},
+            ),
+            _ok("docker"),
+            _ok("safety"),
+            _blocked("db_readonly"),
+            _ok("candles"),
+            _ok("correlation_ledger", {"events_by_type_status": []}),
+            _ok("regime"),
+        ]
+        manifest = _minimal_manifest()
+        state = evaluate_state(probes, manifest, 1)
+        assert state == STATE_BLOCKED_DB_READONLY
+
+    def test_blocked_governance_via_safety_drift(self):
+        probes = [
+            _ok(
+                "host",
+                {"uptime_seconds": 86400, "sleep_wake_indicators": ["none detected"]},
+            ),
+            _ok("docker"),
+            {
+                "probe": "safety",
+                "status": "blocked",
+                "evidence": {
+                    "all_flags_match_expected": False,
+                    "flags": [
+                        {
+                            "flag": "MOCK_TRADING",
+                            "value": "false",
+                            "expected": "true",
+                            "match": False,
+                        }
+                    ],
+                },
+                "observed_at_utc": "2026-06-10T12:00:00Z",
+                "limitations": ["safety flag drift: MOCK_TRADING"],
+                "no_mutation": True,
+            },
+            _ok("db_readonly"),
+            _ok("candles"),
+            _ok("correlation_ledger", {"events_by_type_status": []}),
+            _ok("regime"),
+        ]
+        manifest = _minimal_manifest()
+        state = evaluate_state(probes, manifest, 1)
+        assert state == STATE_BLOCKED_RUNTIME
+
+
+# ---------------------------------------------------------------------------
+# 3. Chain detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDetectChain:
+    def test_no_ledger_probe(self):
+        assert detect_chain([]) is False
+
+    def test_ledger_not_ok(self):
+        probes = [_blocked("correlation_ledger")]
+        assert detect_chain(probes) is False
+
+    def test_empty_events(self):
+        probes = [_ok("correlation_ledger", {"events_by_type_status": []})]
+        assert detect_chain(probes) is False
+
+    def test_partial_chain(self):
+        probes = [
+            _ok(
+                "correlation_ledger",
+                {
+                    "events_by_type_status": [
+                        {"event_type": "SIGNAL", "status": "active", "count": 1}
+                    ]
+                },
+            )
+        ]
+        assert detect_chain(probes) is False
+
+    def test_full_chain(self):
+        probes = [
+            _ok(
+                "correlation_ledger",
+                {
+                    "events_by_type_status": [
+                        {"event_type": "SIGNAL", "status": "active", "count": 1},
+                        {"event_type": "DECISION", "status": "executed", "count": 1},
+                        {"event_type": "ORDER(paper_)", "status": "filled", "count": 1},
+                        {"event_type": "FILL", "status": "confirmed", "count": 1},
+                    ]
+                },
+            )
+        ]
+        assert detect_chain(probes) is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Interruption detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDetectInterruption:
+    def test_no_host_probe(self):
+        assert detect_interruption([]) is False
+
+    def test_no_sleep_events_high_uptime(self):
+        probes = [
+            _ok(
+                "host",
+                {
+                    "uptime_seconds": 86400,
+                    "sleep_wake_indicators": ["none detected"],
+                },
+            )
+        ]
+        assert detect_interruption(probes) is False
+
+    def test_sleep_events_detected(self):
+        probes = [
+            _ok(
+                "host",
+                {
+                    "uptime_seconds": 86400,
+                    "sleep_wake_indicators": ["Wake history count: 1"],
+                },
+            )
+        ]
+        assert detect_interruption(probes) is True
+
+    def test_low_uptime_triggers_interruption(self):
+        probes = [
+            _ok(
+                "host",
+                {
+                    "uptime_seconds": 300,
+                    "sleep_wake_indicators": ["none detected"],
+                },
+            )
+        ]
+        assert detect_interruption(probes) is True
+
+
+# ---------------------------------------------------------------------------
+# 5. Evidence writers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestWriteJsonl:
+    def test_append_only_jsonl(self):
+        entry = {"cycle": 1, "state": "CAMPAIGN_RUNNING", "no_mutation": True}
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+        ) as f:
+            path = f.name
+        try:
+            write_jsonl_entry(path, entry)
+            write_jsonl_entry(
+                path, {"cycle": 2, "state": "CHAIN_FOUND", "no_mutation": True}
+            )
+            with open(path, encoding="utf-8") as f:
+                lines = f.readlines()
+            assert len(lines) == 2
+            assert json.loads(lines[0])["cycle"] == 1
+            assert json.loads(lines[1])["cycle"] == 2
+        finally:
+            os.unlink(path)
+
+    def test_creates_parent_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "subdir", "test.jsonl")
+            write_jsonl_entry(path, {"cycle": 1, "no_mutation": True})
+            assert os.path.isfile(path)
+
+
+@pytest.mark.unit
+class TestWriteStatusMd:
+    def test_writes_markdown(self):
+        manifest = _minimal_manifest()
+        entry = {
+            "observed_at_utc": "2026-06-10T12:00:00Z",
+            "cycle": 1,
+            "campaign_id": "test_campaign_1",
+            "state": "CAMPAIGN_RUNNING",
+            "probe_statuses": {"host": "ok", "docker": "ok"},
+            "event_count_since_start": 0,
+            "chain_detected": False,
+            "no_mutation": True,
+            "limitations": [],
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", delete=False, encoding="utf-8"
+        ) as f:
+            path = f.name
+        try:
+            write_status_md(path, entry, manifest)
+            with open(path, encoding="utf-8") as f:
+                content = f.read()
+            assert "CAMPAIGN_RUNNING" in content
+            assert "test_campaign_1" in content
+            assert "no_mutation: True" in content
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# 6. Integration: run_all_probes (mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunAllProbes:
+    def test_all_probes_in_result(self, monkeypatch):
+        for fn_name in [
+            "probe_host",
+            "probe_docker",
+            "probe_safety",
+            "probe_db_readonly",
+            "probe_candles",
+            "probe_ledger",
+            "probe_regime",
+        ]:
+            monkeypatch.setattr(
+                f"tools.arvp_campaign_supervisor.{fn_name}",
+                lambda: _ok("mocked"),
+            )
+        monkeypatch.setattr(
+            "tools.arvp_campaign_supervisor.probe_docker",
+            lambda targets=None: _ok("docker"),
+        )
+        monkeypatch.setattr(
+            "tools.arvp_campaign_supervisor.probe_ledger",
+            lambda campaign_start_utc=None: _ok("correlation_ledger"),
+        )
+
+        manifest = _minimal_manifest()
+        results = run_all_probes(manifest)
+        assert len(results) == 7
+        assert all(r["status"] == "ok" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# 7. Exit code mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExitCodes:
+    def test_exit_codes_are_distinct(self):
+        codes = {
+            STATE_RUNNING: EXIT_OK,
+            STATE_CHAIN_FOUND: EXIT_CHAIN_FOUND,
+            STATE_TIMEOUT_NO_CHAIN: EXIT_TIMEOUT_NO_CHAIN,
+            STATE_INTERRUPTED: EXIT_INTERRUPTED,
+            STATE_BLOCKED_RUNTIME: EXIT_BLOCKED_RUNTIME,
+            STATE_BLOCKED_DB_READONLY: EXIT_BLOCKED_DB_READONLY,
+            STATE_BLOCKED_GOVERNANCE: EXIT_BLOCKED_GOVERNANCE,
+        }
+        vals = list(codes.values())
+        assert len(vals) == len(set(vals)), "exit codes must be distinct"
+        assert EXIT_INVALID_USAGE == 2
+        assert EXIT_OK == 0
+
+
+# ---------------------------------------------------------------------------
+# 8. No secrets in output
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNoSecrets:
+    def test_no_secret_keywords_in_source(self):
+        with open("tools/arvp_campaign_supervisor.py", encoding="utf-8") as f:
+            source = f.read()
+        for keyword in [
+            "Live-Go",
+            "Echtgeld-Go",
+            "auto-merge",
+            "gh issue comment",
+            "gh pr merge",
+        ]:
+            assert keyword not in source, f"forbidden keyword found: {keyword}"

--- a/tools/arvp_campaign_supervisor.py
+++ b/tools/arvp_campaign_supervisor.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+from tools.arvp_probe_layer import (
+    probe_candles,
+    probe_db_readonly,
+    probe_docker,
+    probe_host,
+    probe_ledger,
+    probe_regime,
+    probe_safety,
+)
+
+logger = logging.getLogger(__name__)
+
+EXIT_INVALID_USAGE = 2
+EXIT_OK = 0
+EXIT_CHAIN_FOUND = 10
+EXIT_TIMEOUT_NO_CHAIN = 20
+EXIT_INTERRUPTED = 30
+EXIT_BLOCKED_RUNTIME = 40
+EXIT_BLOCKED_DB_READONLY = 41
+EXIT_BLOCKED_GOVERNANCE = 42
+
+STATE_RUNNING = "CAMPAIGN_RUNNING"
+STATE_CHAIN_FOUND = "CHAIN_FOUND"
+STATE_TIMEOUT_NO_CHAIN = "TIMEOUT_NO_CHAIN"
+STATE_INTERRUPTED = "INTERRUPTED"
+STATE_BLOCKED_RUNTIME = "BLOCKED_RUNTIME"
+STATE_BLOCKED_DB_READONLY = "BLOCKED_DB_READONLY"
+STATE_BLOCKED_GOVERNANCE = "BLOCKED_GOVERNANCE"
+
+EXIT_CODE_MAP: dict[str, int] = {
+    STATE_RUNNING: EXIT_OK,
+    STATE_CHAIN_FOUND: EXIT_CHAIN_FOUND,
+    STATE_TIMEOUT_NO_CHAIN: EXIT_TIMEOUT_NO_CHAIN,
+    STATE_INTERRUPTED: EXIT_INTERRUPTED,
+    STATE_BLOCKED_RUNTIME: EXIT_BLOCKED_RUNTIME,
+    STATE_BLOCKED_DB_READONLY: EXIT_BLOCKED_DB_READONLY,
+    STATE_BLOCKED_GOVERNANCE: EXIT_BLOCKED_GOVERNANCE,
+}
+
+REQUIRED_MANIFEST_FIELDS = [
+    "schema_version",
+    "campaign_id",
+    "parent_issue",
+    "related_issues",
+    "symbol",
+    "strategy_id",
+    "evidence_class",
+    "start_utc",
+    "timeout_utc",
+    "max_duration_hours",
+    "start_criteria",
+    "safety_flags",
+    "runtime_targets",
+    "db_readonly_targets",
+    "evidence_doc",
+    "evidence_log_jsonl",
+    "github_reporting",
+    "allowed_statuses",
+    "terminal_statuses",
+]
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_utc(ts: str) -> datetime:
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def load_manifest(path: str) -> dict[str, Any]:
+    if not os.path.isfile(path):
+        raise ValueError(f"manifest file not found: {path}")
+
+    raw: dict[str, Any] | None = None
+
+    if path.endswith((".yaml", ".yml")):
+        import yaml
+
+        with open(path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+    else:
+        with open(path, encoding="utf-8") as f:
+            raw = json.load(f)
+
+    if not isinstance(raw, dict):
+        raise ValueError("manifest must be a JSON/YAML object")
+
+    missing = [f for f in REQUIRED_MANIFEST_FIELDS if f not in raw]
+    if missing:
+        raise ValueError(f"manifest missing required fields: {', '.join(missing)}")
+
+    if raw["schema_version"] != "1.0":
+        raise ValueError(f"unsupported schema_version: {raw['schema_version']}")
+
+    return raw
+
+
+def run_all_probes(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    start_utc = manifest.get("start_utc")
+    results: list[dict[str, Any]] = []
+
+    results.append({"probe": "host", **probe_host()})
+    results.append(
+        {
+            "probe": "docker",
+            **probe_docker(targets=manifest.get("runtime_targets")),
+        }
+    )
+    results.append({"probe": "safety", **probe_safety()})
+    results.append({"probe": "db_readonly", **probe_db_readonly()})
+    results.append({"probe": "candles", **probe_candles()})
+    results.append(
+        {
+            "probe": "correlation_ledger",
+            **probe_ledger(campaign_start_utc=start_utc),
+        }
+    )
+    results.append({"probe": "regime", **probe_regime()})
+
+    return results
+
+
+def _find_probe(probes: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    for p in probes:
+        if p.get("probe") == name:
+            return p
+    return None
+
+
+def _check_blocked(probes: list[dict[str, Any]], name: str) -> bool:
+    p = _find_probe(probes, name)
+    return p is not None and p.get("status") in ("blocked",)
+
+
+def detect_chain(probes: list[dict[str, Any]]) -> bool:
+    ledger = _find_probe(probes, "correlation_ledger")
+    if ledger is None or ledger.get("status") != "ok":
+        return False
+
+    evidence = ledger.get("evidence", {})
+    events_by_type = evidence.get("events_by_type_status", [])
+
+    found_types: set[str] = set()
+    for entry in events_by_type:
+        etype = str(entry.get("event_type", "")).upper()
+        if etype == "ORDER" or etype.startswith("ORDER("):
+            found_types.add("ORDER")
+        else:
+            found_types.add(etype)
+
+    required = {"SIGNAL", "DECISION", "ORDER", "FILL"}
+    return required.issubset(found_types)
+
+
+def detect_interruption(probes: list[dict[str, Any]]) -> bool:
+    host = _find_probe(probes, "host")
+    if host is None or host.get("status") != "ok":
+        return False
+
+    evidence = host.get("evidence", {})
+    indicators = evidence.get("sleep_wake_indicators", [])
+    if indicators and not all(i == "none detected" for i in indicators):
+        return True
+
+    uptime = evidence.get("uptime_seconds")
+    if uptime is not None and uptime < 3600:
+        return True
+
+    return False
+
+
+def evaluate_state(
+    probes: list[dict[str, Any]],
+    manifest: dict[str, Any],
+    cycle_count: int,
+) -> str:
+    docker_blocked = _check_blocked(probes, "docker")
+    safety_blocked = _check_blocked(probes, "safety")
+
+    if docker_blocked or safety_blocked:
+        return STATE_BLOCKED_RUNTIME
+
+    db_blocked = _check_blocked(probes, "db_readonly")
+    candles_blocked = _check_blocked(probes, "candles")
+    ledger_blocked = _check_blocked(probes, "correlation_ledger")
+
+    if db_blocked or candles_blocked or ledger_blocked:
+        return STATE_BLOCKED_DB_READONLY
+
+    safety = _find_probe(probes, "safety")
+    if safety is not None and safety.get("status") == "blocked":
+        return STATE_BLOCKED_GOVERNANCE
+
+    if detect_chain(probes):
+        return STATE_CHAIN_FOUND
+
+    if detect_interruption(probes):
+        return STATE_INTERRUPTED
+
+    timeout_utc = manifest.get("timeout_utc")
+    if timeout_utc:
+        try:
+            timeout_dt = _parse_utc(timeout_utc)
+            now = datetime.now(timezone.utc)
+            if now >= timeout_dt:
+                return STATE_TIMEOUT_NO_CHAIN
+        except (ValueError, TypeError):
+            pass
+
+    return STATE_RUNNING
+
+
+def _build_cycle_entry(
+    cycle: int,
+    probes: list[dict[str, Any]],
+    state: str,
+    manifest: dict[str, Any],
+) -> dict[str, Any]:
+    ledger = _find_probe(probes, "correlation_ledger")
+    event_count = None
+    if ledger is not None:
+        ev = ledger.get("evidence", {})
+        event_count = ev.get("events_since_campaign_start")
+
+    probe_statuses = {p["probe"]: p.get("status") for p in probes}
+
+    return {
+        "observed_at_utc": _utcnow(),
+        "cycle": cycle,
+        "campaign_id": manifest.get("campaign_id"),
+        "state": state,
+        "probe_statuses": probe_statuses,
+        "event_count_since_start": event_count,
+        "chain_detected": state == STATE_CHAIN_FOUND,
+        "no_mutation": True,
+        "limitations": [],
+    }
+
+
+def write_jsonl_entry(path: str, entry: dict[str, Any]) -> None:
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, default=str) + "\n")
+
+
+def write_status_md(path: str, entry: dict[str, Any], manifest: dict[str, Any]) -> None:
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+    safety = manifest.get("safety_flags", {})
+    lines = [
+        f"# Campaign Status: {manifest.get('campaign_id', 'unknown')}",
+        "",
+        f"**Observed at (UTC):** {entry['observed_at_utc']}",
+        f"**Cycle:** {entry['cycle']}",
+        f"**State:** {entry['state']}",
+        "",
+        "## Probe Statuses",
+    ]
+    for probe_name, status in entry.get("probe_statuses", {}).items():
+        lines.append(f"- **{probe_name}:** {status}")
+    lines += [
+        "",
+        "## Campaign Info",
+        f"- **Symbol:** {manifest.get('symbol', '-')}",
+        f"- **Strategy:** {manifest.get('strategy_id', '-')}",
+        f"- **Start (UTC):** {manifest.get('start_utc', '-')}",
+        f"- **Timeout (UTC):** {manifest.get('timeout_utc', '-')}",
+        f"- **Event count since start:** {entry.get('event_count_since_start', '-')}",
+        f"- **Chain detected:** {entry.get('chain_detected', False)}",
+        "",
+        "## Safety Flags",
+    ]
+    for flag, val in safety.items():
+        lines.append(f"- **{flag}:** {val}")
+    lines += [
+        "",
+        "---",
+        f"*no_mutation: {entry.get('no_mutation', True)}*",
+        "",
+    ]
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def run_loop(
+    manifest: dict[str, Any],
+    poll_seconds: int,
+    max_cycles: int | None,
+    once: bool,
+    dry_run: bool,
+    output_jsonl: str | None,
+    status_md: str | None,
+) -> int:
+    cycle = 0
+
+    while True:
+        cycle += 1
+        if max_cycles is not None and cycle > max_cycles:
+            break
+
+        probes = run_all_probes(manifest)
+        state = evaluate_state(probes, manifest, cycle)
+
+        entry = _build_cycle_entry(cycle, probes, state, manifest)
+
+        if not dry_run:
+            if output_jsonl:
+                write_jsonl_entry(output_jsonl, entry)
+            if status_md:
+                write_status_md(status_md, entry, manifest)
+
+        if state != STATE_RUNNING:
+            exit_code = EXIT_CODE_MAP.get(state, EXIT_OK)
+            print(json.dumps(entry, default=str))
+            return exit_code
+
+        if once:
+            print(json.dumps(entry, default=str))
+            return EXIT_OK
+
+        time.sleep(poll_seconds)
+
+    return EXIT_OK
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="ARVP Campaign Supervisor \u2014 CLI Polling Loop"
+    )
+    parser.add_argument(
+        "--manifest",
+        required=True,
+        help="Path to campaign manifest (YAML or JSON)",
+    )
+    parser.add_argument(
+        "--poll-seconds",
+        type=int,
+        default=900,
+        help="Polling interval in seconds (default: 900)",
+    )
+    parser.add_argument(
+        "--max-cycles",
+        type=int,
+        default=None,
+        help="Maximum number of cycles (for tests)",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Run a single cycle and exit",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run probes and evaluate state without writing output files",
+    )
+    parser.add_argument(
+        "--output-jsonl",
+        default=None,
+        help="Path to append-only JSONL evidence log",
+    )
+    parser.add_argument(
+        "--status-md",
+        default=None,
+        help="Path to Markdown status snapshot file",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        manifest = load_manifest(args.manifest)
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"ERROR: invalid manifest: {exc}", file=sys.stderr)
+        sys.exit(EXIT_INVALID_USAGE)
+
+    exit_code = run_loop(
+        manifest=manifest,
+        poll_seconds=args.poll_seconds,
+        max_cycles=args.max_cycles,
+        once=args.once,
+        dry_run=args.dry_run,
+        output_jsonl=args.output_jsonl,
+        status_md=args.status_md,
+    )
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #3111

Parent: #3102
Depends on: #3109 (manifest/state machine), #3110 (read-only probe layer)

## Scope
- **tools/arvp_campaign_supervisor.py**: CLI polling loop with:
  - YAML/JSON manifest loading with full field validation per #3109 contract
  - Direct import of all 7 probes from \	ools.arvp_probe_layer\
  - Deterministic state evaluation: CAMPAIGN_RUNNING, CHAIN_FOUND, TIMEOUT_NO_CHAIN, INTERRUPTED, BLOCKED_RUNTIME, BLOCKED_DB_READONLY, BLOCKED_GOVERNANCE
  - Lightweight chain detection via correlation_ledger event types (full detector deferred to #3112)
  - Append-only JSONL evidence output per cycle
  - Markdown status snapshot (atomically rewritten)
  - CLI flags: \--manifest\, \--poll-seconds\, \--max-cycles\, \--once\, \--dry-run\, \--output-jsonl\, \--status-md\
  - Exit codes: 0 running, 10 chain, 20 timeout, 30 interrupted, 40 runtime, 41 db, 42 governance, 2 invalid manifest
- **tests/unit/tools/test_arvp_campaign_supervisor.py**: 30 unit tests covering all state classifications, manifest validation, evidence writers, safety verification

## Explicitly Out of Scope
- GitHub reporter (→ #3113)
- Chain detector + evidence export (→ #3112)
- Windows background runner (→ #3114)
- Test/failure-simulation pack (→ #3115)

## Safety
- No Live-Go, no Echtgeld-Go
- No GitHub writes (no gh issue comment, no gh pr merge)
- No DB writes (SELECT only via probe layer)
- No runtime/Docker config mutation
- LR remains NO-GO