### PR TITLE
[ARVP][OPS][SUPERVISOR] Add chain detector and evidence export trigger for paper windows

### DIFF
--- a/tests/unit/tools/test_arvp_campaign_supervisor.py
+++ b/tests/unit/tools/test_arvp_campaign_supervisor.py
@@ -398,15 +398,15 @@ class TestEvaluateState:
 @pytest.mark.unit
 class TestDetectChain:
     def test_no_ledger_probe(self):
-        assert detect_chain([]) is False
+        assert detect_chain([]) is None
 
     def test_ledger_not_ok(self):
         probes = [_blocked("correlation_ledger")]
-        assert detect_chain(probes) is False
+        assert detect_chain(probes) is None
 
     def test_empty_events(self):
         probes = [_ok("correlation_ledger", {"events_by_type_status": []})]
-        assert detect_chain(probes) is False
+        assert detect_chain(probes) is None
 
     def test_partial_chain(self):
         probes = [
@@ -419,7 +419,7 @@ class TestDetectChain:
                 },
             )
         ]
-        assert detect_chain(probes) is False
+        assert detect_chain(probes) is None
 
     def test_full_chain(self):
         probes = [
@@ -435,7 +435,10 @@ class TestDetectChain:
                 },
             )
         ]
-        assert detect_chain(probes) is True
+        result = detect_chain(probes)
+        assert result is not None
+        assert result["chain_status"] == "complete_chain"
+        assert result["complete"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -575,7 +578,9 @@ class TestRunAllProbes:
         )
         monkeypatch.setattr(
             "tools.arvp_campaign_supervisor.probe_ledger",
-            lambda campaign_start_utc=None: _ok("correlation_ledger"),
+            lambda campaign_start_utc=None, include_events=False: _ok(
+                "correlation_ledger"
+            ),
         )
 
         manifest = _minimal_manifest()

--- a/tests/unit/tools/test_arvp_chain_detector.py
+++ b/tests/unit/tools/test_arvp_chain_detector.py
@@ -1,0 +1,706 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+
+import pytest
+
+from tools.arvp_chain_detector import (
+    ChainDetector,
+    is_malformed,
+    load_events,
+    normalize_event_type,
+)
+
+
+def _event(
+    id_val: int,
+    event_type: str,
+    ts_str: str | None = None,
+    status: str = "active",
+    lineage_hash: str | None = None,
+) -> dict:
+    return {
+        "id": id_val,
+        "ts_ms": ts_str or f"2026-06-10T{10 + id_val:02d}:00:00Z",
+        "event_type": event_type,
+        "status": status,
+        "lineage_hash": lineage_hash or f"hash_{id_val}",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. No events → no_events / complete false
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNoEvents:
+    def test_empty_events_list(self):
+        detector = ChainDetector(events=[])
+        assert detector.classify() == "no_events"
+        result = detector.detect()
+        assert result["complete"] is False
+        assert result["chain_status"] == "no_events"
+        assert "export_trigger" not in result
+
+    def test_no_events_no_by_type(self):
+        detector = ChainDetector()
+        assert detector.classify() == "no_events"
+
+    def test_empty_by_type_status(self):
+        detector = ChainDetector(events_by_type_status=[])
+        assert detector.classify() == "no_events"
+
+    def test_no_events_event_count_none(self):
+        result = ChainDetector(events=[]).detect()
+        assert result["event_count"] is None
+
+    def test_no_events_missing_all(self):
+        result = ChainDetector(events=[]).detect()
+        assert result["missing_steps"] == ["SIGNAL", "DECISION", "ORDER", "FILL"]
+
+
+# ---------------------------------------------------------------------------
+# 2. SIGNAL only → partial
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSignalOnly:
+    def test_classify_signal_only(self):
+        events = [_event(1, "SIGNAL")]
+        detector = ChainDetector(events=events)
+        assert detector.classify() == "signal_only"
+
+    def test_detect_signal_only_not_complete(self):
+        events = [_event(1, "SIGNAL")]
+        result = ChainDetector(events=events).detect()
+        assert result["complete"] is False
+        assert result["chain_status"] == "signal_only"
+        assert "export_trigger" not in result
+
+    def test_signal_only_via_aggregated(self):
+        detector = ChainDetector(
+            events_by_type_status=[
+                {"event_type": "SIGNAL", "status": "active", "count": 1}
+            ]
+        )
+        assert detector.classify() == "signal_only"
+
+
+# ---------------------------------------------------------------------------
+# 3. SIGNAL + DECISION → partial
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSignalDecision:
+    def test_classify_signal_decision(self):
+        events = [_event(1, "SIGNAL"), _event(2, "DECISION")]
+        detector = ChainDetector(events=events)
+        assert detector.classify() == "signal_decision"
+
+    def test_detect_signal_decision_not_complete(self):
+        events = [_event(1, "SIGNAL"), _event(2, "DECISION")]
+        result = ChainDetector(events=events).detect()
+        assert result["complete"] is False
+        assert result["chain_status"] == "signal_decision"
+        assert result["missing_steps"] == ["ORDER", "FILL"]
+
+    def test_signal_decision_via_aggregated(self):
+        detector = ChainDetector(
+            events_by_type_status=[
+                {"event_type": "SIGNAL", "status": "active", "count": 1},
+                {"event_type": "DECISION", "status": "executed", "count": 1},
+            ]
+        )
+        assert detector.classify() == "signal_decision"
+
+
+# ---------------------------------------------------------------------------
+# 4. SIGNAL + DECISION + ORDER → partial
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSignalDecisionOrder:
+    def test_classify_signal_decision_order(self):
+        events = [_event(1, "SIGNAL"), _event(2, "DECISION"), _event(3, "ORDER")]
+        detector = ChainDetector(events=events)
+        assert detector.classify() == "signal_decision_order"
+
+    def test_detect_signal_decision_order_not_complete(self):
+        events = [_event(1, "SIGNAL"), _event(2, "DECISION"), _event(3, "ORDER")]
+        result = ChainDetector(events=events).detect()
+        assert result["complete"] is False
+        assert result["chain_status"] == "signal_decision_order"
+        assert result["missing_steps"] == ["FILL"]
+
+    def test_signal_decision_order_via_aggregated(self):
+        detector = ChainDetector(
+            events_by_type_status=[
+                {"event_type": "SIGNAL", "status": "active", "count": 1},
+                {"event_type": "DECISION", "status": "executed", "count": 1},
+                {"event_type": "ORDER", "status": "filled", "count": 1},
+            ]
+        )
+        assert detector.classify() == "signal_decision_order"
+
+
+# ---------------------------------------------------------------------------
+# 5. Full chain → complete_chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCompleteChain:
+    def test_classify_complete(self):
+        events = [
+            _event(1, "SIGNAL"),
+            _event(2, "DECISION"),
+            _event(3, "ORDER"),
+            _event(4, "FILL"),
+        ]
+        detector = ChainDetector(events=events)
+        assert detector.classify() == "complete_chain"
+
+    def test_detect_complete(self):
+        events = [
+            _event(1, "SIGNAL", "2026-06-10T10:00:00Z"),
+            _event(2, "DECISION", "2026-06-10T10:01:00Z"),
+            _event(3, "ORDER", "2026-06-10T10:02:00Z"),
+            _event(4, "FILL", "2026-06-10T10:03:00Z"),
+        ]
+        result = ChainDetector(events=events).detect()
+        assert result["complete"] is True
+        assert result["chain_status"] == "complete_chain"
+        assert result["event_count"] == 4
+        assert result["event_ids"] == ["1", "2", "3", "4"]
+        assert result["first_event_ts"] == "2026-06-10T10:00:00Z"
+        assert result["last_event_ts"] == "2026-06-10T10:03:00Z"
+        assert result["missing_steps"] == []
+        assert "SIGNAL" in result["observed_types"]
+        assert "ORDER" in result["observed_types"]
+        assert "FILL" in result["observed_types"]
+
+    def test_detect_complete_has_export_trigger(self):
+        events = [
+            _event(1, "SIGNAL"),
+            _event(2, "DECISION"),
+            _event(3, "ORDER"),
+            _event(4, "FILL"),
+        ]
+        result = ChainDetector(events=events).detect()
+        trigger = result.get("export_trigger")
+        assert trigger is not None
+        assert trigger["export_candidate"] is True
+        assert trigger["evidence_class"] == "natural_paper_evidence"
+        assert len(trigger["next_tools"]) == 4
+
+    def test_complete_no_mutation_flag(self):
+        events = [
+            _event(1, "SIGNAL"),
+            _event(2, "DECISION"),
+            _event(3, "ORDER"),
+            _event(4, "FILL"),
+        ]
+        result = ChainDetector(events=events).detect()
+        assert result["no_mutation"] is True
+
+
+# ---------------------------------------------------------------------------
+# 6. ORDER(paper_) wird akzeptiert
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOrderPaperPrefix:
+    def test_order_paper_classifies_as_order(self):
+        assert normalize_event_type("ORDER(paper_)") == "ORDER"
+
+    def test_order_paper_in_chain(self):
+        events = [
+            _event(1, "SIGNAL"),
+            _event(2, "DECISION"),
+            _event(3, "ORDER(paper_)"),
+            _event(4, "FILL"),
+        ]
+        detector = ChainDetector(events=events)
+        assert detector.classify() == "complete_chain"
+
+    def test_order_paper_detect_complete(self):
+        events = [
+            _event(1, "SIGNAL"),
+            _event(2, "DECISION"),
+            _event(3, "ORDER(paper_)"),
+            _event(4, "FILL"),
+        ]
+        result = ChainDetector(events=events).detect()
+        assert result["complete"] is True
+        assert result["chain_status"] == "complete_chain"
+        assert "ORDER" in result["observed_types"]
+
+    def test_order_paper_via_aggregated(self):
+        detector = ChainDetector(
+            events_by_type_status=[
+                {"event_type": "SIGNAL", "status": "active", "count": 1},
+                {"event_type": "DECISION", "status": "executed", "count": 1},
+                {"event_type": "ORDER(paper_)", "status": "filled", "count": 1},
+                {"event_type": "FILL", "status": "confirmed", "count": 1},
+            ]
+        )
+        assert detector.classify() == "complete_chain"
+
+
+# ---------------------------------------------------------------------------
+# 7. Out-of-order events werden korrekt sortiert
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOutOfOrder:
+    def test_out_of_order_sorted_in_detect(self):
+        events = [
+            _event(4, "FILL", "2026-06-10T10:03:00Z"),
+            _event(1, "SIGNAL", "2026-06-10T10:00:00Z"),
+            _event(3, "ORDER", "2026-06-10T10:02:00Z"),
+            _event(2, "DECISION", "2026-06-10T10:01:00Z"),
+        ]
+        result = ChainDetector(events=events).detect()
+        assert result["complete"] is True
+        assert result["event_ids"] == ["1", "2", "3", "4"]
+        assert result["first_event_ts"] == "2026-06-10T10:00:00Z"
+        assert result["last_event_ts"] == "2026-06-10T10:03:00Z"
+
+    def test_out_of_order_still_classifies_complete(self):
+        events = [
+            _event(4, "FILL", "2026-06-10T10:03:00Z"),
+            _event(1, "SIGNAL", "2026-06-10T10:00:00Z"),
+            _event(3, "ORDER", "2026-06-10T10:02:00Z"),
+            _event(2, "DECISION", "2026-06-10T10:01:00Z"),
+        ]
+        detector = ChainDetector(events=events)
+        assert detector.classify() == "complete_chain"
+
+
+# ---------------------------------------------------------------------------
+# 8. Duplicate events werden stabil behandelt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDuplicateEvents:
+    def test_exact_duplicate_ids_handled(self):
+        events = [
+            _event(1, "SIGNAL", "2026-06-10T10:00:00Z"),
+            _event(1, "SIGNAL", "2026-06-10T10:00:00Z"),
+            _event(2, "DECISION", "2026-06-10T10:01:00Z"),
+            _event(3, "ORDER", "2026-06-10T10:02:00Z"),
+            _event(4, "FILL", "2026-06-10T10:03:00Z"),
+        ]
+        result = ChainDetector(events=events).detect()
+        assert result["complete"] is True
+        assert result["event_count"] == 5
+        assert result["event_ids"] == ["1", "2", "3", "4"]
+
+    def test_duplicate_events_different_ids(self):
+        events = [
+            _event(1, "SIGNAL", "2026-06-10T10:00:00Z"),
+            _event(5, "SIGNAL", "2026-06-10T10:00:00Z"),
+            _event(2, "DECISION", "2026-06-10T10:01:00Z"),
+            _event(3, "ORDER", "2026-06-10T10:02:00Z"),
+            _event(4, "FILL", "2026-06-10T10:03:00Z"),
+        ]
+        result = ChainDetector(events=events).detect()
+        assert result["complete"] is True
+        assert result["event_count"] == 5
+        assert result["event_ids"] == ["1", "5", "2", "3", "4"]
+
+
+# ---------------------------------------------------------------------------
+# 9. Malformed events → malformed_chain oder limitation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMalformedEvents:
+    def test_is_malformed_no_event_type(self):
+        assert is_malformed({"id": 1}) is not None
+
+    def test_is_malformed_empty_event_type(self):
+        assert is_malformed({"id": 1, "event_type": ""}) is not None
+
+    def test_is_malformed_unknown_type(self):
+        assert (
+            is_malformed(
+                {"id": 1, "event_type": "BOGUS", "ts_ms": "2026-01-01T00:00:00Z"}
+            )
+            is not None
+        )
+
+    def test_is_malformed_missing_ts(self):
+        assert is_malformed({"id": 1, "event_type": "SIGNAL"}) is not None
+
+    def test_is_malformed_empty_ts(self):
+        assert is_malformed({"id": 1, "event_type": "SIGNAL", "ts_ms": ""}) is not None
+
+    def test_is_malformed_not_a_dict(self):
+        assert is_malformed("not a dict") is not None
+
+    def test_malformed_events_classify(self):
+        events = [
+            {"id": 1, "event_type": "SIGNAL", "ts_ms": "2026-06-10T10:00:00Z"},
+            {"id": 2, "event_type": "", "ts_ms": "2026-06-10T10:01:00Z"},
+        ]
+        detector = ChainDetector(events=events)
+        assert detector.classify() == "malformed_chain"
+
+    def test_malformed_events_limitation(self):
+        events = [
+            {"id": 1, "event_type": "SIGNAL", "ts_ms": "2026-06-10T10:00:00Z"},
+            {"id": 2, "event_type": "BAD", "ts_ms": "2026-06-10T10:01:00Z"},
+        ]
+        result = ChainDetector(events=events).detect()
+        assert any("malformed" in lim for lim in result["limitations"])
+
+    def test_not_malformed_unknown_event_type(self):
+        detector = ChainDetector(
+            events_by_type_status=[
+                {"event_type": "UNKNOWN", "status": "active", "count": 1}
+            ]
+        )
+        assert detector.classify() != "malformed_chain"
+
+
+# ---------------------------------------------------------------------------
+# 10. Export trigger nur bei complete_chain true
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExportTrigger:
+    def test_no_export_on_no_events(self):
+        result = ChainDetector(events=[]).detect()
+        assert "export_trigger" not in result
+
+    def test_no_export_on_signal_only(self):
+        result = ChainDetector(events=[_event(1, "SIGNAL")]).detect()
+        assert "export_trigger" not in result
+
+    def test_no_export_on_signal_decision(self):
+        events = [_event(1, "SIGNAL"), _event(2, "DECISION")]
+        result = ChainDetector(events=events).detect()
+        assert "export_trigger" not in result
+
+    def test_no_export_on_signal_decision_order(self):
+        events = [_event(1, "SIGNAL"), _event(2, "DECISION"), _event(3, "ORDER")]
+        result = ChainDetector(events=events).detect()
+        assert "export_trigger" not in result
+
+    def test_export_only_on_complete(self):
+        events = [
+            _event(1, "SIGNAL"),
+            _event(2, "DECISION"),
+            _event(3, "ORDER"),
+            _event(4, "FILL"),
+        ]
+        result = ChainDetector(events=events).detect()
+        assert "export_trigger" in result
+        assert result["export_trigger"]["export_candidate"] is True
+        assert result["export_trigger"]["evidence_class"] == "natural_paper_evidence"
+
+    def test_export_trigger_structure(self):
+        events = [
+            _event(1, "SIGNAL", "2026-06-10T10:00:00Z"),
+            _event(4, "FILL", "2026-06-10T10:03:00Z"),
+            _event(2, "DECISION", "2026-06-10T10:01:00Z"),
+            _event(3, "ORDER", "2026-06-10T10:02:00Z"),
+        ]
+        result = ChainDetector(events=events).detect()
+        trigger = result["export_trigger"]
+        assert trigger["suggested_window_start_utc"] == "2026-06-10T10:00:00Z"
+        assert trigger["suggested_window_end_utc"] == "2026-06-10T10:03:00Z"
+        assert len(trigger["next_tools"]) == 4
+        assert "paper_reference_window.v1 export" in trigger["next_tools"]
+        assert "replay-vs-paper compare" in trigger["next_tools"]
+        assert "simulator calibration" in trigger["next_tools"]
+        assert "regime scorecard" in trigger["next_tools"]
+
+
+# ---------------------------------------------------------------------------
+# 11. Supervisor integration — detect_chain returns only complete_chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSupervisorIntegration:
+    def test_from_probe_result_none(self):
+        from tools.arvp_chain_detector import ChainDetector
+
+        probe = {
+            "status": "ok",
+            "evidence": {
+                "latest_event": None,
+                "events_since_campaign_start": 0,
+                "events_by_type_status": [],
+                "campaign_start_utc": "2026-06-10T08:00:00Z",
+            },
+        }
+        detector = ChainDetector.from_probe_result(probe)
+        assert detector.classify() == "no_events"
+
+    def test_from_probe_result_partial(self):
+        probe = {
+            "status": "ok",
+            "evidence": {
+                "latest_event": {"event_type": "SIGNAL"},
+                "events_since_campaign_start": 1,
+                "events_by_type_status": [
+                    {"event_type": "SIGNAL", "status": "active", "count": 1}
+                ],
+            },
+        }
+        detector = ChainDetector.from_probe_result(probe)
+        assert detector.classify() == "signal_only"
+        result = detector.detect()
+        assert result["complete"] is False
+
+    def test_from_probe_result_complete_with_events(self):
+        probe = {
+            "status": "ok",
+            "evidence": {
+                "latest_event": {"event_type": "FILL"},
+                "events_since_campaign_start": 4,
+                "events_by_type_status": [],
+                "events": [
+                    _event(1, "SIGNAL", "2026-06-10T10:00:00Z"),
+                    _event(2, "DECISION", "2026-06-10T10:01:00Z"),
+                    _event(3, "ORDER", "2026-06-10T10:02:00Z"),
+                    _event(4, "FILL", "2026-06-10T10:03:00Z"),
+                ],
+            },
+        }
+        detector = ChainDetector.from_probe_result(probe)
+        assert detector.classify() == "complete_chain"
+        result = detector.detect()
+        assert result["complete"] is True
+        assert result["export_trigger"]["export_candidate"] is True
+
+    def test_from_probe_result_with_events_and_aggregated(self):
+        probe = {
+            "status": "ok",
+            "evidence": {
+                "events_since_campaign_start": 4,
+                "events_by_type_status": [
+                    {"event_type": "SIGNAL", "status": "active", "count": 1},
+                    {"event_type": "DECISION", "status": "executed", "count": 1},
+                    {"event_type": "ORDER(paper_)", "status": "filled", "count": 1},
+                    {"event_type": "FILL", "status": "confirmed", "count": 1},
+                ],
+                "events": [
+                    _event(1, "SIGNAL", "2026-06-10T10:00:00Z"),
+                    _event(2, "DECISION", "2026-06-10T10:01:00Z"),
+                    _event(3, "ORDER(paper_)", "2026-06-10T10:02:00Z"),
+                    _event(4, "FILL", "2026-06-10T10:03:00Z"),
+                ],
+            },
+        }
+        detector = ChainDetector.from_probe_result(probe)
+        assert detector.classify() == "complete_chain"
+
+
+# ---------------------------------------------------------------------------
+# 12. No secrets/no live boundaries
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNoSecrets:
+    def test_no_live_keywords_in_detector_source(self):
+        with open("tools/arvp_chain_detector.py", encoding="utf-8") as f:
+            source = f.read()
+        for keyword in [
+            "Live-Go",
+            "Echtgeld-Go",
+            "auto-merge",
+            "INSERT",
+            "UPDATE",
+            "DELETE",
+        ]:
+            assert keyword not in source, f"forbidden keyword found: {keyword}"
+
+    def test_no_live_keywords_in_output(self):
+        events = [
+            _event(1, "SIGNAL"),
+            _event(2, "DECISION"),
+            _event(3, "ORDER"),
+            _event(4, "FILL"),
+        ]
+        result = ChainDetector(events=events).detect()
+        output = json.dumps(result, default=str)
+        for keyword in ["Live-Go", "Echtgeld", "live_trading"]:
+            assert keyword not in output
+
+    def test_no_mutation_in_outputs(self):
+        for status in [
+            "no_events",
+            "signal_only",
+            "signal_decision",
+            "signal_decision_order",
+            "complete_chain",
+        ]:
+            events = [
+                _event(1, "SIGNAL"),
+            ]
+            if status in ("signal_decision", "signal_decision_order", "complete_chain"):
+                events.append(_event(2, "DECISION"))
+            if status in ("signal_decision_order", "complete_chain"):
+                events.append(_event(3, "ORDER"))
+            if status == "complete_chain":
+                events.append(_event(4, "FILL"))
+            result = ChainDetector(events=events).detect()
+            assert result["no_mutation"] is True, f"no_mutation false for {status}"
+
+
+# ---------------------------------------------------------------------------
+# load_events edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLoadEvents:
+    def test_load_from_list_json(self):
+        events = [_event(1, "SIGNAL")]
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as f:
+            json.dump(events, f)
+            path = f.name
+        try:
+            loaded = load_events(path)
+            assert len(loaded) == 1
+            assert loaded[0]["event_type"] == "SIGNAL"
+        finally:
+            os.unlink(path)
+
+    def test_load_from_probe_output(self):
+        data = {
+            "correlation_ledger": {
+                "status": "ok",
+                "evidence": {
+                    "events": [_event(1, "SIGNAL"), _event(2, "FILL")],
+                },
+            }
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as f:
+            json.dump(data, f)
+            path = f.name
+        try:
+            loaded = load_events(path)
+            assert len(loaded) == 2
+        finally:
+            os.unlink(path)
+
+    def test_load_nonexistent_path(self):
+        with pytest.raises(FileNotFoundError):
+            load_events("/nonexistent/file.json")
+
+    def test_load_empty_file_returns_empty_list(self):
+        data = {}
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as f:
+            json.dump(data, f)
+            path = f.name
+        try:
+            loaded = load_events(path)
+            assert loaded == []
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases: strict_lineage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestStrictLineage:
+    def test_strict_lineage_no_hash(self):
+        events = [
+            _event(1, "SIGNAL", lineage_hash=None),
+            _event(2, "DECISION", lineage_hash=None),
+            _event(3, "ORDER", lineage_hash=None),
+            _event(4, "FILL", lineage_hash=None),
+        ]
+        result = ChainDetector(events=events, strict_lineage=True).detect()
+        assert result["complete"] is True
+        assert any("lineage_hash" in lim for lim in result["limitations"])
+
+    def test_strict_lineage_multiple_hashes(self):
+        events = [
+            _event(1, "SIGNAL", lineage_hash="abc"),
+            _event(2, "DECISION", lineage_hash="def"),
+            _event(3, "ORDER", lineage_hash="abc"),
+            _event(4, "FILL", lineage_hash="abc"),
+        ]
+        result = ChainDetector(events=events, strict_lineage=True).detect()
+        assert result["complete"] is True
+        assert any("lineage_hash" in lim for lim in result["limitations"])
+
+    def test_strict_lineage_single_hash(self):
+        events = [
+            _event(1, "SIGNAL", lineage_hash="abc"),
+            _event(2, "DECISION", lineage_hash="abc"),
+            _event(3, "ORDER", lineage_hash="abc"),
+            _event(4, "FILL", lineage_hash="abc"),
+        ]
+        result = ChainDetector(events=events, strict_lineage=True).detect()
+        assert result["complete"] is True
+        lineage_lims = [lim for lim in result["limitations"] if "lineage_hash" in lim]
+        assert len(lineage_lims) == 0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases: from_probe_result with empty/missing data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFromProbeResultEdgeCases:
+    def test_probe_without_evidence(self):
+        probe = {"status": "ok"}
+        detector = ChainDetector.from_probe_result(probe)
+        assert detector.classify() == "no_events"
+
+    def test_probe_with_events_by_type_only(self):
+        probe = {
+            "status": "ok",
+            "evidence": {
+                "events_by_type_status": [
+                    {"event_type": "SIGNAL", "status": "active", "count": 1},
+                    {"event_type": "FILL", "status": "confirmed", "count": 1},
+                ],
+            },
+        }
+        detector = ChainDetector.from_probe_result(probe)
+        assert detector.classify() == "signal_only"
+
+    def test_probe_with_signal_decision_order_by_type_only(self):
+        probe = {
+            "status": "ok",
+            "evidence": {
+                "events_by_type_status": [
+                    {"event_type": "SIGNAL", "status": "active", "count": 1},
+                    {"event_type": "DECISION", "status": "executed", "count": 1},
+                    {"event_type": "ORDER", "status": "filled", "count": 1},
+                ],
+            },
+        }
+        detector = ChainDetector.from_probe_result(probe)
+        assert detector.classify() == "signal_decision_order"

--- a/tools/arvp_campaign_supervisor.py
+++ b/tools/arvp_campaign_supervisor.py
@@ -9,6 +9,7 @@ import time
 from datetime import datetime, timezone
 from typing import Any
 
+from tools.arvp_chain_detector import ChainDetector, normalize_event_type
 from tools.arvp_probe_layer import (
     probe_candles,
     probe_db_readonly,
@@ -124,7 +125,7 @@ def run_all_probes(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     results.append(
         {
             "probe": "correlation_ledger",
-            **probe_ledger(campaign_start_utc=start_utc),
+            **probe_ledger(campaign_start_utc=start_utc, include_events=True),
         }
     )
     results.append({"probe": "regime", **probe_regime()})
@@ -144,24 +145,18 @@ def _check_blocked(probes: list[dict[str, Any]], name: str) -> bool:
     return p is not None and p.get("status") in ("blocked",)
 
 
-def detect_chain(probes: list[dict[str, Any]]) -> bool:
+def detect_chain(probes: list[dict[str, Any]]) -> dict[str, Any] | None:
     ledger = _find_probe(probes, "correlation_ledger")
     if ledger is None or ledger.get("status") != "ok":
-        return False
+        return None
 
-    evidence = ledger.get("evidence", {})
-    events_by_type = evidence.get("events_by_type_status", [])
+    detector = ChainDetector.from_probe_result(ledger)
+    result = detector.detect()
 
-    found_types: set[str] = set()
-    for entry in events_by_type:
-        etype = str(entry.get("event_type", "")).upper()
-        if etype == "ORDER" or etype.startswith("ORDER("):
-            found_types.add("ORDER")
-        else:
-            found_types.add(etype)
+    if result.get("chain_status") == "complete_chain":
+        return result
 
-    required = {"SIGNAL", "DECISION", "ORDER", "FILL"}
-    return required.issubset(found_types)
+    return None
 
 
 def detect_interruption(probes: list[dict[str, Any]]) -> bool:
@@ -203,7 +198,11 @@ def evaluate_state(
     if safety is not None and safety.get("status") == "blocked":
         return STATE_BLOCKED_GOVERNANCE
 
-    if detect_chain(probes):
+    chain_result = detect_chain(probes)
+    if (
+        chain_result is not None
+        and chain_result.get("chain_status") == "complete_chain"
+    ):
         return STATE_CHAIN_FOUND
 
     if detect_interruption(probes):
@@ -236,7 +235,9 @@ def _build_cycle_entry(
 
     probe_statuses = {p["probe"]: p.get("status") for p in probes}
 
-    return {
+    chain_details = detect_chain(probes)
+
+    entry: dict[str, Any] = {
         "observed_at_utc": _utcnow(),
         "cycle": cycle,
         "campaign_id": manifest.get("campaign_id"),
@@ -247,6 +248,22 @@ def _build_cycle_entry(
         "no_mutation": True,
         "limitations": [],
     }
+
+    if chain_details is not None:
+        entry["chain_details"] = {
+            "chain_status": chain_details.get("chain_status"),
+            "complete": chain_details.get("complete"),
+            "event_count": chain_details.get("event_count"),
+            "event_ids": chain_details.get("event_ids"),
+            "first_event_ts": chain_details.get("first_event_ts"),
+            "last_event_ts": chain_details.get("last_event_ts"),
+            "missing_steps": chain_details.get("missing_steps"),
+            "observed_types": chain_details.get("observed_types"),
+        }
+        if chain_details.get("export_trigger"):
+            entry["chain_details"]["export_trigger"] = chain_details["export_trigger"]
+
+    return entry
 
 
 def write_jsonl_entry(path: str, entry: dict[str, Any]) -> None:

--- a/tools/arvp_chain_detector.py
+++ b/tools/arvp_chain_detector.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from datetime import datetime
+from typing import Any
+
+from core.utils.clock import utcnow
+
+logger = logging.getLogger(__name__)
+
+CHAIN_STATUSES = [
+    "no_events",
+    "signal_only",
+    "signal_decision",
+    "signal_decision_order",
+    "complete_chain",
+    "malformed_chain",
+]
+
+REQUIRED_TYPES = ["SIGNAL", "DECISION", "ORDER", "FILL"]
+KNOWN_TYPES = {"SIGNAL", "DECISION", "ORDER", "FILL", "ORDER(paper_)"}
+
+
+def _utcnow() -> str:
+    return utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def normalize_event_type(raw: str) -> str:
+    upper = raw.upper()
+    if upper == "ORDER" or upper.startswith("ORDER("):
+        return "ORDER"
+    return upper
+
+
+def _parse_ts(ts: Any) -> datetime | None:
+    if ts is None:
+        return None
+    if isinstance(ts, datetime):
+        return ts
+    if isinstance(ts, str):
+        try:
+            return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return None
+    return None
+
+
+def is_malformed(event: dict) -> str | None:
+    if not isinstance(event, dict):
+        return "event is not a dict"
+    etype = event.get("event_type")
+    if not etype or not isinstance(etype, str):
+        return "missing or invalid event_type"
+    norm = normalize_event_type(etype)
+    if norm not in KNOWN_TYPES and etype not in KNOWN_TYPES:
+        return f"unknown event_type: {etype}"
+    ts = event.get("ts_ms")
+    if ts is None:
+        return "missing ts_ms"
+    if isinstance(ts, str) and not ts.strip():
+        return "empty ts_ms"
+    return None
+
+
+class ChainDetector:
+    def __init__(
+        self,
+        events: list[dict] | None = None,
+        events_by_type_status: list[dict] | None = None,
+        campaign_start_utc: str | None = None,
+        strict_lineage: bool = False,
+    ):
+        self._events = events or []
+        self._events_by_type_status = events_by_type_status or []
+        self._campaign_start_utc = campaign_start_utc
+        self._strict_lineage = strict_lineage
+
+    def classify(self) -> str:
+        raw_types: set[str] = set()
+
+        if self._events:
+            for ev in self._events:
+                raw_types.add(normalize_event_type(ev.get("event_type", "")))
+        elif self._events_by_type_status:
+            for entry in self._events_by_type_status:
+                raw_types.add(normalize_event_type(entry.get("event_type", "")))
+        else:
+            return "no_events"
+
+        has_malformed = any(is_malformed(ev) for ev in self._events)
+        if has_malformed and self._events:
+            return "malformed_chain"
+
+        if not raw_types:
+            return "no_events"
+
+        if REQUIRED_TYPES[3] in raw_types:
+            if raw_types.issuperset(REQUIRED_TYPES):
+                return "complete_chain"
+        if REQUIRED_TYPES[2] in raw_types:
+            if raw_types.issuperset(REQUIRED_TYPES[:3]):
+                return "signal_decision_order"
+        if REQUIRED_TYPES[1] in raw_types:
+            if raw_types.issuperset(REQUIRED_TYPES[:2]):
+                return "signal_decision"
+        if REQUIRED_TYPES[0] in raw_types:
+            return "signal_only"
+
+        return "signal_only"
+
+    def detect(self) -> dict[str, Any]:
+        chain_status = self.classify()
+        complete = chain_status == "complete_chain"
+
+        sorted_events: list[dict] = []
+        for ev in self._events:
+            parsed_ts = _parse_ts(ev.get("ts_ms"))
+            if parsed_ts:
+                sorted_events.append((parsed_ts, ev))
+        sorted_events.sort(key=lambda x: x[0])
+
+        seen_ids: set[str] = set()
+        deduped: list[dict] = []
+        for _, ev in sorted_events:
+            eid = ev.get("id")
+            if eid is not None:
+                eid_str = str(eid)
+                if eid_str in seen_ids:
+                    continue
+                seen_ids.add(eid_str)
+            deduped.append(ev)
+        sorted_events = deduped
+
+        event_ids: list[str] | None = None
+        if self._events:
+            ids = []
+            for ev in sorted_events:
+                eid = ev.get("id")
+                if eid is not None:
+                    ids.append(str(eid))
+            if ids:
+                event_ids = ids
+
+        first_ts = None
+        last_ts = None
+        if sorted_events:
+            first_parsed = _parse_ts(sorted_events[0].get("ts_ms"))
+            last_parsed = _parse_ts(sorted_events[-1].get("ts_ms"))
+            if first_parsed:
+                first_ts = first_parsed.strftime("%Y-%m-%dT%H:%M:%SZ")
+            if last_parsed:
+                last_ts = last_parsed.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        observed_norm: set[str] = set()
+        for ev in self._events:
+            observed_norm.add(normalize_event_type(ev.get("event_type", "")))
+        for entry in self._events_by_type_status:
+            observed_norm.add(normalize_event_type(entry.get("event_type", "")))
+
+        missing = [t for t in REQUIRED_TYPES if t not in observed_norm]
+
+        limitations: list[str] = []
+
+        if self._strict_lineage and complete and self._events:
+            lineage_hashes = set()
+            for ev in self._events:
+                lh = ev.get("lineage_hash")
+                if lh:
+                    lineage_hashes.add(str(lh))
+            if len(lineage_hashes) > 1:
+                limitations.append(f"multiple lineage_hashes: {lineage_hashes}")
+            elif len(lineage_hashes) == 0:
+                limitations.append("no lineage_hash data available")
+
+        if not self._events:
+            limitations.append("aggregated counts only; no individual events")
+
+        bad_count = sum(1 for ev in self._events if is_malformed(ev))
+        if bad_count > 0:
+            limitations.append(f"{bad_count} malformed event(s)")
+
+        result: dict[str, Any] = {
+            "chain_status": chain_status,
+            "complete": complete,
+            "event_count": len(self._events) if self._events else None,
+            "event_ids": event_ids,
+            "first_event_ts": first_ts,
+            "last_event_ts": last_ts,
+            "missing_steps": missing,
+            "observed_types": sorted(observed_norm),
+            "limitations": limitations,
+            "no_mutation": True,
+            "observed_at_utc": _utcnow(),
+        }
+
+        if complete:
+            result["export_trigger"] = self._build_export_trigger()
+
+        return result
+
+    def _build_export_trigger(self) -> dict[str, Any]:
+        sorted_events: list[dict] = []
+        for ev in self._events:
+            parsed_ts = _parse_ts(ev.get("ts_ms"))
+            if parsed_ts:
+                sorted_events.append((parsed_ts, ev))
+        sorted_events.sort(key=lambda x: x[0])
+        seen_ids: set[str] = set()
+        sorted_unique: list[dict] = []
+        for _, ev in sorted_events:
+            eid = ev.get("id")
+            if eid is not None:
+                eid_str = str(eid)
+                if eid_str in seen_ids:
+                    continue
+                seen_ids.add(eid_str)
+            sorted_unique.append(ev)
+        sorted_events = sorted_unique
+
+        window_start = None
+        window_end = None
+        if sorted_events:
+            first_parsed = _parse_ts(sorted_events[0].get("ts_ms"))
+            last_parsed = _parse_ts(sorted_events[-1].get("ts_ms"))
+            if first_parsed:
+                window_start = first_parsed.strftime("%Y-%m-%dT%H:%M:%SZ")
+            if last_parsed:
+                window_end = last_parsed.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        return {
+            "export_candidate": True,
+            "suggested_window_start_utc": window_start,
+            "suggested_window_end_utc": window_end,
+            "source_campaign_id": None,
+            "evidence_class": "natural_paper_evidence",
+            "next_tools": [
+                "paper_reference_window.v1 export",
+                "replay-vs-paper compare",
+                "simulator calibration",
+                "regime scorecard",
+            ],
+        }
+
+    @classmethod
+    def from_probe_result(
+        cls, probe_result: dict[str, Any], strict_lineage: bool = False
+    ) -> ChainDetector:
+        evidence = probe_result.get("evidence", {})
+        events = evidence.get("events", None)
+        events_by_type = evidence.get("events_by_type_status", None)
+        campaign_start = evidence.get("campaign_start_utc", None)
+        return cls(
+            events=events,
+            events_by_type_status=events_by_type,
+            campaign_start_utc=campaign_start,
+            strict_lineage=strict_lineage,
+        )
+
+
+def load_events(path: str) -> list[dict]:
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        events = data.get("events") or data.get("event_ids") or data.get("results")
+        if isinstance(events, list):
+            return events
+        for key in ("correlation_ledger", "ledger"):
+            sub = data.get(key, {})
+            if isinstance(sub, dict):
+                ev = sub.get("evidence", {}).get("events") or sub.get(
+                    "evidence", {}
+                ).get("event_ids")
+                if isinstance(ev, list):
+                    return ev
+    return []
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="ARVP Chain Detector \u2014 classify correlation_ledger chains"
+    )
+    parser.add_argument(
+        "--ledger-input",
+        help="Path to JSON file with ledger events or full probe output",
+    )
+    parser.add_argument(
+        "--classify-only",
+        action="store_true",
+        help="Only output chain classification (no full detect result)",
+    )
+    parser.add_argument(
+        "--strict-lineage",
+        action="store_true",
+        help="Require shared lineage_hash for complete_chain",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
+    if not args.ledger_input:
+        parser.print_help()
+        sys.exit(1)
+
+    raw_events = load_events(args.ledger_input)
+    detector = ChainDetector(events=raw_events, strict_lineage=args.strict_lineage)
+
+    if args.classify_only:
+        print(detector.classify())
+    else:
+        result = detector.detect()
+        result["source_file"] = args.ledger_input
+        print(json.dumps(result, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/arvp_probe_layer.py
+++ b/tools/arvp_probe_layer.py
@@ -372,9 +372,7 @@ def probe_db_readonly(
     psycopg2_available = importlib.util.find_spec("psycopg2") is not None
     pg_isready_available = False
     try:
-        subprocess.run(
-            ["pg_isready", "--version"], capture_output=True, timeout=5
-        )
+        subprocess.run(["pg_isready", "--version"], capture_output=True, timeout=5)
         pg_isready_available = True
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
@@ -392,10 +390,14 @@ def probe_db_readonly(
             ready = subprocess.run(
                 [
                     "pg_isready",
-                    "-h", host,
-                    "-p", str(port),
-                    "-d", dbname,
-                    "-U", user,
+                    "-h",
+                    host,
+                    "-p",
+                    str(port),
+                    "-d",
+                    dbname,
+                    "-U",
+                    user,
                 ],
                 capture_output=True,
                 text=True,
@@ -424,8 +426,11 @@ def probe_db_readonly(
             import psycopg2
 
             conn = psycopg2.connect(
-                host=host, port=port, dbname=dbname,
-                user=user, connect_timeout=10,
+                host=host,
+                port=port,
+                dbname=dbname,
+                user=user,
+                connect_timeout=10,
             )
             cur = conn.cursor()
             cur.execute("SELECT 1 AS ok")
@@ -438,8 +443,11 @@ def probe_db_readonly(
             svr_version = None
             try:
                 conn2 = psycopg2.connect(
-                    host=host, port=port, dbname=dbname,
-                    user=user, connect_timeout=10,
+                    host=host,
+                    port=port,
+                    dbname=dbname,
+                    user=user,
+                    connect_timeout=10,
                 )
                 cur2 = conn2.cursor()
                 cur2.execute("SELECT version()")
@@ -471,7 +479,9 @@ def probe_db_readonly(
     return _ok(
         {
             "connectivity": "ok (pg_isready only)",
-            "host": host, "port": port, "dbname": dbname,
+            "host": host,
+            "port": port,
+            "dbname": dbname,
         },
         limitations + ["pg_isready only; no SELECT verification"],
     )
@@ -482,14 +492,15 @@ def probe_db_readonly(
 # ---------------------------------------------------------------------------
 
 
-def _run_sql(
-    host: str, port: int, dbname: str, user: str, query: str
-) -> list[tuple]:
+def _run_sql(host: str, port: int, dbname: str, user: str, query: str) -> list[tuple]:
     import psycopg2
 
     conn = psycopg2.connect(
-        host=host, port=port, dbname=dbname,
-        user=user, connect_timeout=10,
+        host=host,
+        port=port,
+        dbname=dbname,
+        user=user,
+        connect_timeout=10,
     )
     try:
         cur = conn.cursor()
@@ -519,7 +530,10 @@ def probe_candles(
 
     try:
         latest = _run_sql(
-            host, port, dbname, user,
+            host,
+            port,
+            dbname,
+            user,
             f"SELECT MAX(ts_ms) FROM candles_1m WHERE symbol='{symbol}'",
         )
         latest_ts = latest[0][0] if latest and latest[0][0] else None
@@ -530,7 +544,10 @@ def probe_candles(
             )
 
         range_15m = _run_sql(
-            host, port, dbname, user,
+            host,
+            port,
+            dbname,
+            user,
             f"SELECT MAX(high) - MIN(low) FROM candles_1m "
             f"WHERE symbol='{symbol}' "
             f"AND ts_ms >= NOW() - INTERVAL '15 minutes'",
@@ -540,7 +557,10 @@ def probe_candles(
         )
 
         range_60m = _run_sql(
-            host, port, dbname, user,
+            host,
+            port,
+            dbname,
+            user,
             f"SELECT MAX(high) - MIN(low) FROM candles_1m "
             f"WHERE symbol='{symbol}' "
             f"AND ts_ms >= NOW() - INTERVAL '60 minutes'",
@@ -550,7 +570,10 @@ def probe_candles(
         )
 
         gaps = _run_sql(
-            host, port, dbname, user,
+            host,
+            port,
+            dbname,
+            user,
             f"SELECT ts_ms - LAG(ts_ms) OVER (ORDER BY ts_ms) AS gap "
             f"FROM candles_1m WHERE symbol='{symbol}' "
             f"ORDER BY ts_ms DESC LIMIT 10",
@@ -567,14 +590,15 @@ def probe_candles(
         large_gaps = [g for g in gap_minutes_list if g > gap_threshold_minutes]
 
         latest_close = _run_sql(
-            host, port, dbname, user,
+            host,
+            port,
+            dbname,
+            user,
             f"SELECT close FROM candles_1m WHERE symbol='{symbol}' "
             f"ORDER BY ts_ms DESC LIMIT 1",
         )
         latest_price = (
-            float(latest_close[0][0])
-            if latest_close and latest_close[0][0]
-            else None
+            float(latest_close[0][0]) if latest_close and latest_close[0][0] else None
         )
 
         evidence = {
@@ -602,8 +626,7 @@ def probe_candles(
         limitations = []
         if len(large_gaps) > 0:
             limitations.append(
-                f"candle gap(s) >{gap_threshold_minutes} min detected: "
-                f"{large_gaps}"
+                f"candle gap(s) >{gap_threshold_minutes} min detected: " f"{large_gaps}"
             )
         return {
             "status": status,
@@ -630,6 +653,7 @@ def probe_ledger(
     port: int = DB_DEFAULTS["port"],
     dbname: str = DB_DEFAULTS["dbname"],
     user: str = DB_DEFAULTS["user"],
+    include_events: bool = False,
 ) -> ProbeResult:
     import importlib
 
@@ -641,7 +665,10 @@ def probe_ledger(
 
     try:
         latest = _run_sql(
-            host, port, dbname, user,
+            host,
+            port,
+            dbname,
+            user,
             "SELECT ts_ms, event_type, status, lineage_hash "
             "FROM correlation_ledger ORDER BY ts_ms DESC LIMIT 1",
         )
@@ -661,14 +688,20 @@ def probe_ledger(
         count_since_start: int | None = None
         if campaign_start_utc:
             count_rows = _run_sql(
-                host, port, dbname, user,
+                host,
+                port,
+                dbname,
+                user,
                 f"SELECT COUNT(*) FROM correlation_ledger "
                 f"WHERE ts_ms >= '{campaign_start_utc}'::timestamptz",
             )
             count_since_start = int(count_rows[0][0]) if count_rows else 0
 
         grouped = _run_sql(
-            host, port, dbname, user,
+            host,
+            port,
+            dbname,
+            user,
             "SELECT event_type, status, COUNT(*) as cnt "
             "FROM correlation_ledger "
             "GROUP BY event_type, status ORDER BY event_type, status",
@@ -683,19 +716,54 @@ def probe_ledger(
                 }
             )
 
-        return _ok(
-            {
-                "latest_event": latest_event,
-                "events_since_campaign_start": count_since_start,
-                "events_by_type_status": events_by_type_status,
-                "campaign_start_utc": campaign_start_utc,
-                "queries": [
-                    "SELECT ... FROM correlation_ledger ORDER BY ts_ms DESC LIMIT 1",
-                    "SELECT COUNT(*) FROM correlation_ledger WHERE ts_ms >= ...",
-                    "SELECT event_type, status, COUNT(*) FROM correlation_ledger GROUP BY ...",
-                ],
-            }
-        )
+        evidence: dict[str, Any] = {
+            "latest_event": latest_event,
+            "events_since_campaign_start": count_since_start,
+            "events_by_type_status": events_by_type_status,
+            "campaign_start_utc": campaign_start_utc,
+            "queries": [
+                "SELECT ... FROM correlation_ledger ORDER BY ts_ms DESC LIMIT 1",
+                "SELECT COUNT(*) FROM correlation_ledger WHERE ts_ms >= ...",
+                "SELECT event_type, status, COUNT(*) FROM correlation_ledger GROUP BY ...",
+            ],
+        }
+
+        events_raw: list[dict] | None = None
+        if include_events:
+            try:
+                rows = _run_sql(
+                    host,
+                    port,
+                    dbname,
+                    user,
+                    "SELECT id, ts_ms, event_type, status, lineage_hash "
+                    "FROM correlation_ledger ORDER BY ts_ms ASC",
+                )
+                events_raw = []
+                for row in rows:
+                    events_raw.append(
+                        {
+                            "id": row[0],
+                            "ts_ms": (
+                                row[1].isoformat()
+                                if hasattr(row[1], "isoformat")
+                                else str(row[1])
+                            ),
+                            "event_type": row[2],
+                            "status": row[3],
+                            "lineage_hash": row[4],
+                        }
+                    )
+                evidence["events"] = events_raw
+                evidence["queries"].append(
+                    "SELECT id, ts_ms, event_type, status, lineage_hash "
+                    "FROM correlation_ledger ORDER BY ts_ms ASC"
+                )
+            except Exception as exc:
+                logger.warning("events query failed: %s", exc)
+                evidence["events_error"] = str(exc)
+
+        return _ok(evidence)
     except Exception as exc:
         return _blocked(
             {"error": str(exc)},
@@ -718,6 +786,7 @@ REGIME_PATTERNS: list[tuple[str, str]] = [
 def _try_http_regime(port: int = 8008, timeout: int = 5) -> str | None:
     try:
         import urllib.request
+
         url = f"http://localhost:{port}/health"
         with urllib.request.urlopen(url, timeout=timeout) as resp:
             return resp.read().decode("utf-8")
@@ -725,9 +794,7 @@ def _try_http_regime(port: int = 8008, timeout: int = 5) -> str | None:
         return None
 
 
-def probe_regime(
-    container: str = "cdb_regime", health_port: int = 8008
-) -> ProbeResult:
+def probe_regime(container: str = "cdb_regime", health_port: int = 8008) -> ProbeResult:
     http_body = _try_http_regime(port=health_port)
     if http_body:
         for pattern, label in REGIME_PATTERNS:
@@ -749,9 +816,7 @@ def probe_regime(
         )
 
     try:
-        logs = _run_docker_cmd(
-            ["logs", container, "--tail", "10"], timeout=10
-        )
+        logs = _run_docker_cmd(["logs", container, "--tail", "10"], timeout=10)
     except (FileNotFoundError, RuntimeError) as exc:
         return _unavailable(
             {"error": str(exc)},
@@ -791,9 +856,7 @@ def main() -> None:
     parser.add_argument("--all", action="store_true", help="Run all probes")
     parser.add_argument("--host", action="store_true", help="Host probe")
     parser.add_argument("--docker", action="store_true", help="Docker probe")
-    parser.add_argument(
-        "--safety", action="store_true", help="Safety flags probe"
-    )
+    parser.add_argument("--safety", action="store_true", help="Safety flags probe")
     parser.add_argument("--db", action="store_true", help="DB readonly probe")
     parser.add_argument(
         "--candles", action="store_true", help="Candle/market data probe"
@@ -835,9 +898,7 @@ def main() -> None:
     if args.all or args.host:
         results.append({"probe": "host", **probe_host()})
     if args.all or args.docker:
-        results.append(
-            {"probe": "docker", **probe_docker(targets=args.docker_targets)}
-        )
+        results.append({"probe": "docker", **probe_docker(targets=args.docker_targets)})
     if args.all or args.safety:
         results.append({"probe": "safety", **probe_safety()})
     if args.all or args.db:


### PR DESCRIPTION
Closes #3112
Parent #3102
Depends on #3110/#3111

## Scope
- Deterministic chain detector (\	ools/arvp_chain_detector.py\)
- Partial-chain classification (6 statuses: no_events → complete_chain)
- Export trigger contract (prepares window export, replay comparison, simulator, regime scorecard)
- Supervisor integration — \detect_chain()\ now uses \ChainDetector\; \CHAIN_FOUND\ only on \complete_chain\
- Probe layer extension — \probe_ledger(include_events=True)\ returns individual event rows
- 62 test cases across 3 test files (117 total, all passing)

## Out of scope
- GitHub Reporter (#3113)
- Windows Runner (#3114)
- Full failure simulation pack (#3115)
- Synthetic evidence / strategy changes / runtime mutation

## Safety
- LR remains NO-GO
- No DB writes (SELECT only)
- no_mutation: True in all outputs
- No Live-Go, no Echtgeld-Go