### PR TITLE
[ARVP][OPS][SUPERVISOR] Add GitHub reporter for campaign comments and evidence PRs (#3113)

### DIFF
--- a/tests/unit/tools/test_arvp_github_reporter.py
+++ b/tests/unit/tools/test_arvp_github_reporter.py
@@ -30,7 +30,6 @@ from tools.arvp_github_reporter import (
     ISSUE_REFERENCE_WINDOW,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -183,11 +182,14 @@ class TestRenderInterrupted:
 
 @pytest.mark.unit
 class TestRenderBlocked:
-    @pytest.mark.parametrize("state", [
-        STATE_BLOCKED_RUNTIME,
-        STATE_BLOCKED_DB_READONLY,
-        STATE_BLOCKED_GOVERNANCE,
-    ])
+    @pytest.mark.parametrize(
+        "state",
+        [
+            STATE_BLOCKED_RUNTIME,
+            STATE_BLOCKED_DB_READONLY,
+            STATE_BLOCKED_GOVERNANCE,
+        ],
+    )
     def test_contains_blocked_info(self, state: str):
         entry = _entry(state)
         body = render_blocked(entry, _manifest())
@@ -283,15 +285,18 @@ class TestSafetyNoForbiddenPatterns:
         "MEXC_TESTNET=false",
     ]
 
-    @pytest.mark.parametrize("state", [
-        STATE_CHAIN_FOUND,
-        STATE_TIMEOUT_NO_CHAIN,
-        STATE_INTERRUPTED,
-        STATE_BLOCKED_RUNTIME,
-        STATE_BLOCKED_DB_READONLY,
-        STATE_BLOCKED_GOVERNANCE,
-        STATE_EVIDENCE_MERGED,
-    ])
+    @pytest.mark.parametrize(
+        "state",
+        [
+            STATE_CHAIN_FOUND,
+            STATE_TIMEOUT_NO_CHAIN,
+            STATE_INTERRUPTED,
+            STATE_BLOCKED_RUNTIME,
+            STATE_BLOCKED_DB_READONLY,
+            STATE_BLOCKED_GOVERNANCE,
+            STATE_EVIDENCE_MERGED,
+        ],
+    )
     def test_no_forbidden_in_template(self, state: str):
         body = render_body(state, _entry(state), _manifest())
         for pat in self.FORBIDDEN:
@@ -433,42 +438,62 @@ class TestGitHubReporterInit:
 @pytest.mark.unit
 class TestResolveTargets:
     def test_chain_found_includes_3087(self):
-        reporter = GitHubReporter(_manifest(github_reporting={
-            "post_on_issue_3095": True,
-            "post_on_issue_3087": True,
-        }))
+        reporter = GitHubReporter(
+            _manifest(
+                github_reporting={
+                    "post_on_issue_3095": True,
+                    "post_on_issue_3087": True,
+                }
+            )
+        )
         targets = reporter._resolve_targets(STATE_CHAIN_FOUND, 0)
         assert ISSUE_CAMPAIGN in targets
         assert ISSUE_REFERENCE_WINDOW in targets
 
     def test_timeout_no_chain_excludes_3087_below_3(self):
-        reporter = GitHubReporter(_manifest(github_reporting={
-            "post_on_issue_3095": True,
-            "post_on_issue_3087": True,
-        }))
+        reporter = GitHubReporter(
+            _manifest(
+                github_reporting={
+                    "post_on_issue_3095": True,
+                    "post_on_issue_3087": True,
+                }
+            )
+        )
         targets = reporter._resolve_targets(STATE_TIMEOUT_NO_CHAIN, 2)
         assert ISSUE_CAMPAIGN in targets
         assert ISSUE_REFERENCE_WINDOW not in targets
 
     def test_timeout_no_chain_includes_3087_at_3(self):
-        reporter = GitHubReporter(_manifest(github_reporting={
-            "post_on_issue_3095": True,
-            "post_on_issue_3087": True,
-        }))
+        reporter = GitHubReporter(
+            _manifest(
+                github_reporting={
+                    "post_on_issue_3095": True,
+                    "post_on_issue_3087": True,
+                }
+            )
+        )
         targets = reporter._resolve_targets(STATE_TIMEOUT_NO_CHAIN, 3)
         assert ISSUE_REFERENCE_WINDOW in targets
 
     def test_3095_disabled_via_manifest(self):
-        reporter = GitHubReporter(_manifest(github_reporting={
-            "post_on_issue_3095": False,
-        }))
+        reporter = GitHubReporter(
+            _manifest(
+                github_reporting={
+                    "post_on_issue_3095": False,
+                }
+            )
+        )
         targets = reporter._resolve_targets(STATE_CHAIN_FOUND, 0)
         assert ISSUE_CAMPAIGN not in targets
 
     def test_3087_disabled_via_manifest(self):
-        reporter = GitHubReporter(_manifest(github_reporting={
-            "post_on_issue_3087": False,
-        }))
+        reporter = GitHubReporter(
+            _manifest(
+                github_reporting={
+                    "post_on_issue_3087": False,
+                }
+            )
+        )
         targets = reporter._resolve_targets(STATE_CHAIN_FOUND, 0)
         assert ISSUE_REFERENCE_WINDOW not in targets
 
@@ -544,12 +569,12 @@ class TestReportTerminal:
             # commit, push, gh pr create, checkout main
             mock_run.side_effect = [
                 mock_comment,  # gh issue comment (to #3095)
-                mock_fail,     # git rev-parse --verify (branch doesn't exist)
-                mock_ok,       # git checkout -b
-                mock_ok,       # git commit
-                mock_ok,       # git push
-                mock_ok,       # gh pr create
-                mock_ok,       # git checkout main
+                mock_fail,  # git rev-parse --verify (branch doesn't exist)
+                mock_ok,  # git checkout -b
+                mock_ok,  # git commit
+                mock_ok,  # git push
+                mock_ok,  # gh pr create
+                mock_ok,  # git checkout main
             ]
 
             results = reporter.report_terminal(_entry(STATE_CHAIN_FOUND))
@@ -597,12 +622,12 @@ class TestReportTerminal:
             #           push(rc=1), gh pr create(rc=1), checkout main
             mock_run.side_effect = [
                 mock_comment,  # gh issue comment (to #3095)
-                mock_fail,     # git rev-parse (branch doesn't exist)
-                mock_ok,       # git checkout -b
-                mock_ok,       # git commit
-                mock_fail,     # git push (rc=1, but check=True not enforced by mock)
-                mock_fail,     # gh pr create (rc=1)
-                mock_ok,       # git checkout main (cleanup after pr_create fails)
+                mock_fail,  # git rev-parse (branch doesn't exist)
+                mock_ok,  # git checkout -b
+                mock_ok,  # git commit
+                mock_fail,  # git push (rc=1, but check=True not enforced by mock)
+                mock_fail,  # gh pr create (rc=1)
+                mock_ok,  # git checkout main (cleanup after pr_create fails)
             ]
 
             results = reporter.report_terminal(_entry(STATE_CHAIN_FOUND))
@@ -634,11 +659,15 @@ class TestReportTerminal:
                 assert "TIMEOUT_NO_CHAIN" in r["body"]
 
     def test_reports_to_multiple_issues(self):
-        reporter = GitHubReporter(_manifest(github_reporting={
-            "post_on_issue_3095": True,
-            "post_on_issue_3087": True,
-            "post_on_issue_3102": True,
-        }))
+        reporter = GitHubReporter(
+            _manifest(
+                github_reporting={
+                    "post_on_issue_3095": True,
+                    "post_on_issue_3087": True,
+                    "post_on_issue_3102": True,
+                }
+            )
+        )
         results = reporter.report_terminal(_entry(STATE_CHAIN_FOUND), 0)
         comment_actions = [r for r in results if "comment" in r.get("action", "")]
         issues_reported = {r["issue"] for r in comment_actions}
@@ -673,7 +702,9 @@ class TestPostComment:
             assert result["action"] == "comment_posted"
             mock_run.assert_called_once_with(
                 ["gh", "issue", "comment", "3095", "--body", "test body"],
-                capture_output=True, text=True, timeout=30,
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
 
     def test_gh_not_found_returns_error(self):
@@ -745,13 +776,12 @@ class TestLoadEntry:
     def test_from_file(self):
         from tools.arvp_github_reporter import load_entry
 
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump({"state": "TIMEOUT_NO_CHAIN"}, f)
             fname = f.name
 
         try:
+
             class FakeArgs:
                 cycle_entry = None
                 cycle_entry_file = fname

--- a/tests/unit/tools/test_arvp_github_reporter.py
+++ b/tests/unit/tools/test_arvp_github_reporter.py
@@ -1,0 +1,785 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from tools.arvp_github_reporter import (
+    GitHubReporter,
+    _format_probe_table,
+    _git_branch_name,
+    _should_comment_3087,
+    pr_body,
+    render_body,
+    render_chain_found,
+    render_timeout_no_chain,
+    render_interrupted,
+    render_blocked,
+    render_merged,
+    STATE_CHAIN_FOUND,
+    STATE_TIMEOUT_NO_CHAIN,
+    STATE_INTERRUPTED,
+    STATE_BLOCKED_RUNTIME,
+    STATE_BLOCKED_DB_READONLY,
+    STATE_BLOCKED_GOVERNANCE,
+    STATE_EVIDENCE_MERGED,
+    ISSUE_CAMPAIGN,
+    ISSUE_REFERENCE_WINDOW,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _manifest(**overrides: object) -> dict:
+    base = {
+        "schema_version": "1.0",
+        "campaign_id": "arvp_3095_vol_window_3_20260611_0800",
+        "parent_issue": 3095,
+        "symbol": "BTCUSDT",
+        "strategy_id": "primary_breakout_v1",
+        "evidence_class": "natural_paper_evidence",
+        "evidence_doc": "docs/evidence/arvp_test.md",
+        "evidence_log_jsonl": "artifacts/campaigns/test/evidence_log.jsonl",
+        "github_reporting": {
+            "post_on_issue_3095": True,
+            "post_on_issue_3087": False,
+            "post_on_issue_3102": False,
+            "pr_create_on_chain_found": True,
+            "issue_close_after_acceptance": False,
+        },
+        "start_utc": "2026-06-11T08:00:00Z",
+        "timeout_utc": "2026-06-11T16:00:00Z",
+        "max_duration_hours": 8.0,
+        "start_criteria": {"pre_documented": True},
+        "safety_flags": {
+            "mock_trading": True,
+            "use_real_balance": False,
+            "dry_run": True,
+            "mexc_testnet": True,
+        },
+        "runtime_targets": ["cdb_execution"],
+        "db_readonly_targets": ["public.correlation_ledger"],
+        "allowed_statuses": ["running", "chain_found"],
+        "terminal_statuses": ["chain_found"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _entry(state: str, **overrides: object) -> dict:
+    base = {
+        "observed_at_utc": "2026-06-11T12:00:00Z",
+        "cycle": 12,
+        "campaign_id": "arvp_3095_vol_window_3_20260611_0800",
+        "state": state,
+        "probe_statuses": {
+            "host": "ok",
+            "docker": "ok",
+            "safety": "ok",
+            "db_readonly": "ok",
+            "candles": "ok",
+            "correlation_ledger": "ok",
+            "regime": "ok",
+        },
+        "event_count_since_start": 4,
+        "chain_detected": state == STATE_CHAIN_FOUND,
+        "no_mutation": True,
+        "limitations": [],
+    }
+    if state == STATE_CHAIN_FOUND:
+        base["chain_details"] = {
+            "chain_status": "complete_chain",
+            "complete": True,
+            "event_count": 4,
+            "event_ids": [101, 102, 103, 104],
+            "first_event_ts": "2026-06-11T11:45:00Z",
+            "last_event_ts": "2026-06-11T11:46:30Z",
+            "missing_steps": [],
+            "observed_types": ["SIGNAL", "DECISION", "ORDER", "FILL"],
+            "export_trigger": {"export_candidate": True},
+        }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# 1. Template rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRenderChainFound:
+    def test_contains_key_fields(self):
+        entry = _entry(STATE_CHAIN_FOUND)
+        body = render_chain_found(entry, _manifest())
+        assert "CHAIN_FOUND" in body
+        assert "101, 102, 103, 104" in body
+        assert "2026-06-11T11:45:00Z" in body
+        assert "LR remains NO-GO" in body
+
+    def test_contains_evidence_paths(self):
+        entry = _entry(STATE_CHAIN_FOUND)
+        manifest = _manifest(
+            evidence_doc="docs/evidence/arvp_test.md",
+            evidence_log_jsonl="artifacts/campaigns/test/log.jsonl",
+        )
+        body = render_chain_found(entry, manifest)
+        assert "docs/evidence/arvp_test.md" in body
+        assert "artifacts/campaigns/test/log.jsonl" in body
+
+    def test_no_issue_closure_in_body(self):
+        entry = _entry(STATE_CHAIN_FOUND)
+        body = render_chain_found(entry, _manifest())
+        assert "Closes #" not in body
+        assert "closes #" not in body
+
+    def test_no_event_ids_graceful(self):
+        entry = _entry(STATE_CHAIN_FOUND, chain_details={"event_ids": []})
+        body = render_chain_found(entry, _manifest())
+        assert "none" in body or "event_ids" not in body
+
+
+@pytest.mark.unit
+class TestRenderTimeoutNoChain:
+    def test_contains_classification(self):
+        entry = _entry(STATE_TIMEOUT_NO_CHAIN)
+        body = render_timeout_no_chain(entry, _manifest())
+        assert "TIMEOUT_NO_CHAIN" in body
+        assert "campaign_timeout_record" in body
+        assert "counts as failure" in body
+        assert "LR remains NO-GO" in body
+
+    def test_probe_table_rendered(self):
+        entry = _entry(STATE_TIMEOUT_NO_CHAIN)
+        body = render_timeout_no_chain(entry, _manifest())
+        assert "| Probe | Status |" in body
+        assert "| host | ok |" in body
+
+    def test_no_issue_closure(self):
+        body = render_timeout_no_chain(_entry(STATE_TIMEOUT_NO_CHAIN), _manifest())
+        assert "Closes #" not in body
+
+
+@pytest.mark.unit
+class TestRenderInterrupted:
+    def test_contains_classification(self):
+        entry = _entry(STATE_INTERRUPTED)
+        body = render_interrupted(entry, _manifest())
+        assert "INTERRUPTED" in body
+        assert "interruption_record" in body
+        assert "does NOT count as failure" in body
+        assert "LR remains NO-GO" in body
+
+    def test_no_issue_closure(self):
+        body = render_interrupted(_entry(STATE_INTERRUPTED), _manifest())
+        assert "Closes #" not in body
+
+
+@pytest.mark.unit
+class TestRenderBlocked:
+    @pytest.mark.parametrize("state", [
+        STATE_BLOCKED_RUNTIME,
+        STATE_BLOCKED_DB_READONLY,
+        STATE_BLOCKED_GOVERNANCE,
+    ])
+    def test_contains_blocked_info(self, state: str):
+        entry = _entry(state)
+        body = render_blocked(entry, _manifest())
+        assert state in body
+        assert "LR remains NO-GO" in body
+
+    def test_blocking_probe_listed(self):
+        entry = _entry(
+            STATE_BLOCKED_RUNTIME,
+            probe_statuses={"docker": "blocked", "host": "ok"},
+        )
+        body = render_blocked(entry, _manifest())
+        assert "docker" in body
+
+    def test_no_issue_closure(self):
+        body = render_blocked(_entry(STATE_BLOCKED_RUNTIME), _manifest())
+        assert "Closes #" not in body
+
+
+@pytest.mark.unit
+class TestRenderMerged:
+    def test_contains_merge_info(self):
+        entry = _entry(
+            STATE_EVIDENCE_MERGED,
+            pr_url="https://github.com/example/repo/pull/42",
+            merge_sha="abc123def456",
+        )
+        body = render_merged(entry, _manifest())
+        assert "EVIDENCE_MERGED" not in body
+        assert "Merged" in body
+        assert "abc123def456" in body
+        assert "LR remains NO-GO" in body
+        assert "No Echtgeld claim" in body
+
+    def test_no_issue_closure(self):
+        entry = _entry(STATE_EVIDENCE_MERGED, pr_url="?", merge_sha="?")
+        body = render_merged(entry, _manifest())
+        assert "Closes #" not in body
+
+
+@pytest.mark.unit
+class TestRenderBody:
+    def test_unknown_state_raises(self):
+        with pytest.raises(ValueError, match="unknown state"):
+            render_body("BOGUS_STATE", _entry("BOGUS_STATE"), _manifest())
+
+    def test_dispatches_correctly(self):
+        for state in [
+            STATE_CHAIN_FOUND,
+            STATE_TIMEOUT_NO_CHAIN,
+            STATE_INTERRUPTED,
+            STATE_BLOCKED_RUNTIME,
+            STATE_BLOCKED_DB_READONLY,
+            STATE_BLOCKED_GOVERNANCE,
+            STATE_EVIDENCE_MERGED,
+        ]:
+            body = render_body(state, _entry(state), _manifest())
+            assert isinstance(body, str)
+            assert len(body) > 20
+
+    def test_all_templates_have_lr_no_go(self):
+        for state in [
+            STATE_CHAIN_FOUND,
+            STATE_TIMEOUT_NO_CHAIN,
+            STATE_INTERRUPTED,
+            STATE_BLOCKED_RUNTIME,
+            STATE_BLOCKED_DB_READONLY,
+            STATE_BLOCKED_GOVERNANCE,
+            STATE_EVIDENCE_MERGED,
+        ]:
+            body = render_body(state, _entry(state), _manifest())
+            assert "LR remains NO-GO" in body, f"missing LR NO-GO in {state}"
+
+
+# ---------------------------------------------------------------------------
+# 2. Safety: forbidden patterns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSafetyNoForbiddenPatterns:
+    FORBIDDEN = [
+        "gh issue close",
+        "gh pr merge",
+        "Closes #3095",
+        "Closes #3087",
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "USE_REAL_BALANCE=true",
+        "MOCK_TRADING=false",
+        "DRY_RUN=false",
+        "MEXC_TESTNET=false",
+    ]
+
+    @pytest.mark.parametrize("state", [
+        STATE_CHAIN_FOUND,
+        STATE_TIMEOUT_NO_CHAIN,
+        STATE_INTERRUPTED,
+        STATE_BLOCKED_RUNTIME,
+        STATE_BLOCKED_DB_READONLY,
+        STATE_BLOCKED_GOVERNANCE,
+        STATE_EVIDENCE_MERGED,
+    ])
+    def test_no_forbidden_in_template(self, state: str):
+        body = render_body(state, _entry(state), _manifest())
+        for pat in self.FORBIDDEN:
+            assert pat not in body, f"found '{pat}' in {state} template"
+
+    def test_no_forbidden_in_pr_body(self):
+        entry = _entry(STATE_CHAIN_FOUND)
+        body = pr_body("test_campaign", "CHAIN_FOUND", entry, "doc.md", "log.jsonl")
+        for pat in self.FORBIDDEN:
+            assert pat not in body, f"found '{pat}' in PR body"
+
+
+# ---------------------------------------------------------------------------
+# 3. Utilities
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFormatProbeTable:
+    def test_empty_dict(self):
+        assert _format_probe_table({}) == "*No probe data*"
+
+    def test_renders_table(self):
+        result = _format_probe_table({"host": "ok", "docker": "ok"})
+        assert "| Probe | Status |" in result
+        assert "| host | ok |" in result
+        assert "| docker | ok |" in result
+
+
+@pytest.mark.unit
+class TestShouldComment3087:
+    def test_chain_found_returns_true(self):
+        assert _should_comment_3087(STATE_CHAIN_FOUND, 0) is True
+
+    def test_timeout_with_3_failures_returns_true(self):
+        assert _should_comment_3087(STATE_TIMEOUT_NO_CHAIN, 3) is True
+
+    def test_timeout_with_2_failures_returns_false(self):
+        assert _should_comment_3087(STATE_TIMEOUT_NO_CHAIN, 2) is False
+
+    def test_timeout_with_0_failures_returns_false(self):
+        assert _should_comment_3087(STATE_TIMEOUT_NO_CHAIN, 0) is False
+
+    def test_interrupted_returns_false(self):
+        assert _should_comment_3087(STATE_INTERRUPTED, 0) is False
+
+    def test_blocked_returns_false(self):
+        assert _should_comment_3087(STATE_BLOCKED_RUNTIME, 0) is False
+
+
+@pytest.mark.unit
+class TestGitBranchName:
+    def test_chain_found(self):
+        name = _git_branch_name(
+            "arvp_3095_vol_window_3_20260611_0800", STATE_CHAIN_FOUND
+        )
+        assert name == "evidence/arvp-arvp_3095_vol_window_3_20260611_0800-chain_found"
+
+    def test_sanitizes_slashes(self):
+        name = _git_branch_name("campaign/id/1", STATE_CHAIN_FOUND)
+        assert "/" not in name.replace("evidence/", "", 1)
+
+    def test_lowercases_state(self):
+        name = _git_branch_name("test", STATE_BLOCKED_RUNTIME)
+        assert "BLOCKED" not in name
+        assert "blocked_runtime" in name
+
+
+# ---------------------------------------------------------------------------
+# 4. PR body
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPrBody:
+    def test_contains_campaign_info(self):
+        entry = _entry(STATE_CHAIN_FOUND)
+        body = pr_body("test_campaign", "CHAIN_FOUND", entry, "doc.md", "log.jsonl")
+        assert "test_campaign" in body
+        assert "CHAIN_FOUND" in body
+        assert "doc.md" in body
+        assert "log.jsonl" in body
+        assert "#3102" in body
+
+    def test_no_issue_closure_in_pr_body(self):
+        entry = _entry(STATE_CHAIN_FOUND)
+        body = pr_body("test_campaign", "CHAIN_FOUND", entry, "doc.md", "log.jsonl")
+        assert "Closes #" not in body
+
+    def test_lr_no_go_present(self):
+        entry = _entry(STATE_CHAIN_FOUND)
+        body = pr_body("test_campaign", "CHAIN_FOUND", entry, "doc.md", "log.jsonl")
+        assert "LR remains NO-GO" in body
+        assert "No Echtgeld claim" in body
+
+
+# ---------------------------------------------------------------------------
+# 5. GitHubReporter: construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGitHubReporterInit:
+    def test_create_pr_requires_github_write(self):
+        with pytest.raises(ValueError, match="--create-pr requires --github-write"):
+            GitHubReporter(_manifest(), github_write=False, create_pr=True)
+
+    def test_create_pr_with_github_write_ok(self):
+        reporter = GitHubReporter(_manifest(), github_write=True, create_pr=True)
+        assert reporter._create_pr is True
+        assert reporter._github_write is True
+
+    def test_default_dry_run(self):
+        reporter = GitHubReporter(_manifest())
+        assert reporter._github_write is False
+        assert reporter._create_pr is False
+
+    def test_reads_github_reporting_from_manifest(self):
+        manifest = _manifest(
+            github_reporting={
+                "post_on_issue_3095": False,
+                "post_on_issue_3087": True,
+                "post_on_issue_3102": True,
+                "pr_create_on_chain_found": False,
+            }
+        )
+        reporter = GitHubReporter(manifest)
+        assert reporter._post_3095 is False
+        assert reporter._post_3087 is True
+        assert reporter._post_3102 is True
+        assert reporter._pr_on_chain is False
+
+
+# ---------------------------------------------------------------------------
+# 6. GitHubReporter: issue target resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResolveTargets:
+    def test_chain_found_includes_3087(self):
+        reporter = GitHubReporter(_manifest(github_reporting={
+            "post_on_issue_3095": True,
+            "post_on_issue_3087": True,
+        }))
+        targets = reporter._resolve_targets(STATE_CHAIN_FOUND, 0)
+        assert ISSUE_CAMPAIGN in targets
+        assert ISSUE_REFERENCE_WINDOW in targets
+
+    def test_timeout_no_chain_excludes_3087_below_3(self):
+        reporter = GitHubReporter(_manifest(github_reporting={
+            "post_on_issue_3095": True,
+            "post_on_issue_3087": True,
+        }))
+        targets = reporter._resolve_targets(STATE_TIMEOUT_NO_CHAIN, 2)
+        assert ISSUE_CAMPAIGN in targets
+        assert ISSUE_REFERENCE_WINDOW not in targets
+
+    def test_timeout_no_chain_includes_3087_at_3(self):
+        reporter = GitHubReporter(_manifest(github_reporting={
+            "post_on_issue_3095": True,
+            "post_on_issue_3087": True,
+        }))
+        targets = reporter._resolve_targets(STATE_TIMEOUT_NO_CHAIN, 3)
+        assert ISSUE_REFERENCE_WINDOW in targets
+
+    def test_3095_disabled_via_manifest(self):
+        reporter = GitHubReporter(_manifest(github_reporting={
+            "post_on_issue_3095": False,
+        }))
+        targets = reporter._resolve_targets(STATE_CHAIN_FOUND, 0)
+        assert ISSUE_CAMPAIGN not in targets
+
+    def test_3087_disabled_via_manifest(self):
+        reporter = GitHubReporter(_manifest(github_reporting={
+            "post_on_issue_3087": False,
+        }))
+        targets = reporter._resolve_targets(STATE_CHAIN_FOUND, 0)
+        assert ISSUE_REFERENCE_WINDOW not in targets
+
+
+# ---------------------------------------------------------------------------
+# 7. GitHubReporter: report_terminal behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestReportTerminal:
+    def test_non_terminal_state_raises(self):
+        reporter = GitHubReporter(_manifest())
+        with pytest.raises(ValueError, match="non-terminal state"):
+            reporter.report_terminal({"state": "RUNNING"})
+
+    def test_dry_run_returns_dry_run_actions(self):
+        reporter = GitHubReporter(_manifest())
+        results = reporter.report_terminal(_entry(STATE_TIMEOUT_NO_CHAIN))
+        assert len(results) >= 1
+        for r in results:
+            assert r["action"].startswith("dry_run_")
+
+    def test_dry_run_does_not_call_subprocess(self):
+        reporter = GitHubReporter(_manifest())
+        with patch("subprocess.run") as mock_run:
+            reporter.report_terminal(_entry(STATE_TIMEOUT_NO_CHAIN))
+            mock_run.assert_not_called()
+
+    def test_github_write_calls_subprocess(self):
+        reporter = GitHubReporter(_manifest(), github_write=True)
+        with patch("subprocess.run") as mock_run:
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = "https://github.com/comment/1"
+            mock_run.return_value = mock_result
+
+            results = reporter.report_terminal(_entry(STATE_TIMEOUT_NO_CHAIN))
+
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            assert args[0] == "gh"
+            assert args[1] == "issue"
+            assert args[2] == "comment"
+            assert args[3] == str(ISSUE_CAMPAIGN)
+
+    def test_chain_found_includes_pr_dry_run(self):
+        reporter = GitHubReporter(_manifest())
+        results = reporter.report_terminal(_entry(STATE_CHAIN_FOUND))
+        pr_results = [r for r in results if "pr" in r.get("action", "")]
+        assert len(pr_results) >= 1
+        assert pr_results[0]["action"] == "dry_run_pr"
+
+    def test_chain_found_with_create_pr_calls_subprocess(self):
+        reporter = GitHubReporter(_manifest(), github_write=True, create_pr=True)
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("os.path.isfile", return_value=False),
+        ):
+            mock_comment = MagicMock()
+            mock_comment.returncode = 0
+            mock_comment.stdout = "https://github.com/comment/1"
+
+            mock_ok = MagicMock()
+            mock_ok.returncode = 0
+            mock_ok.stdout = ""
+
+            mock_fail = MagicMock()
+            mock_fail.returncode = 1
+            mock_fail.stdout = ""
+
+            # subprocess calls: gh comment, git rev-parse, checkout -b,
+            # commit, push, gh pr create, checkout main
+            mock_run.side_effect = [
+                mock_comment,  # gh issue comment (to #3095)
+                mock_fail,     # git rev-parse --verify (branch doesn't exist)
+                mock_ok,       # git checkout -b
+                mock_ok,       # git commit
+                mock_ok,       # git push
+                mock_ok,       # gh pr create
+                mock_ok,       # git checkout main
+            ]
+
+            results = reporter.report_terminal(_entry(STATE_CHAIN_FOUND))
+
+            pr_results = [r for r in results if r.get("action") == "pr_created"]
+            assert len(pr_results) == 1
+
+    def test_chain_found_pr_skipped_if_branch_exists(self):
+        reporter = GitHubReporter(_manifest(), github_write=True, create_pr=True)
+        with patch("subprocess.run") as mock_run:
+            mock_ok = MagicMock()
+            mock_ok.returncode = 0
+            mock_ok.stdout = "abc123"
+
+            mock_run.return_value = mock_ok
+
+            results = reporter.report_terminal(_entry(STATE_CHAIN_FOUND))
+
+            pr_results = [r for r in results if "pr" in r.get("action", "")]
+            assert len(pr_results) == 1
+            assert pr_results[0]["action"] == "pr_skipped"
+
+    def test_chain_found_pr_create_failure_returns_error(self):
+        reporter = GitHubReporter(_manifest(), github_write=True, create_pr=True)
+        with (
+            patch("subprocess.run") as mock_run,
+            patch("os.path.isfile", return_value=False),
+        ):
+            mock_comment = MagicMock()
+            mock_comment.returncode = 0
+            mock_comment.stdout = "https://github.com/comment/1"
+
+            mock_fail = MagicMock()
+            mock_fail.returncode = 1
+            mock_fail.stdout = ""
+            mock_fail.stderr = "push rejected"
+
+            mock_ok = MagicMock()
+            mock_ok.returncode = 0
+            mock_ok.stdout = ""
+
+            # mock subprocess does not enforce check=True,
+            # so git push failure does not raise CalledProcessError
+            # Sequence: gh comment, rev-parse, checkout, commit,
+            #           push(rc=1), gh pr create(rc=1), checkout main
+            mock_run.side_effect = [
+                mock_comment,  # gh issue comment (to #3095)
+                mock_fail,     # git rev-parse (branch doesn't exist)
+                mock_ok,       # git checkout -b
+                mock_ok,       # git commit
+                mock_fail,     # git push (rc=1, but check=True not enforced by mock)
+                mock_fail,     # gh pr create (rc=1)
+                mock_ok,       # git checkout main (cleanup after pr_create fails)
+            ]
+
+            results = reporter.report_terminal(_entry(STATE_CHAIN_FOUND))
+
+            pr_results = [r for r in results if "pr" in r.get("action", "")]
+            assert len(pr_results) == 1
+            assert pr_results[0]["action"] == "pr_create_failed"
+
+    def test_github_write_comment_failure_returns_error(self):
+        reporter = GitHubReporter(_manifest(), github_write=True)
+        with patch("subprocess.run") as mock_run:
+            mock_result = MagicMock()
+            mock_result.returncode = 1
+            mock_result.stderr = "auth error"
+            mock_run.return_value = mock_result
+
+            results = reporter.report_terminal(_entry(STATE_TIMEOUT_NO_CHAIN))
+
+            comments = [r for r in results if r.get("action") == "comment_failed"]
+            assert len(comments) >= 1
+            assert "auth error" in comments[0]["error"]
+
+    def test_result_includes_comment_body(self):
+        reporter = GitHubReporter(_manifest())
+        results = reporter.report_terminal(_entry(STATE_TIMEOUT_NO_CHAIN))
+        for r in results:
+            if r.get("action") == "dry_run_comment":
+                assert "body" in r
+                assert "TIMEOUT_NO_CHAIN" in r["body"]
+
+    def test_reports_to_multiple_issues(self):
+        reporter = GitHubReporter(_manifest(github_reporting={
+            "post_on_issue_3095": True,
+            "post_on_issue_3087": True,
+            "post_on_issue_3102": True,
+        }))
+        results = reporter.report_terminal(_entry(STATE_CHAIN_FOUND), 0)
+        comment_actions = [r for r in results if "comment" in r.get("action", "")]
+        issues_reported = {r["issue"] for r in comment_actions}
+        assert ISSUE_CAMPAIGN in issues_reported
+        assert ISSUE_REFERENCE_WINDOW in issues_reported
+
+
+# ---------------------------------------------------------------------------
+# 8. GitHubReporter: _post_comment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPostComment:
+    def test_without_github_write_returns_dry_run(self):
+        reporter = GitHubReporter(_manifest())
+        result = reporter._post_comment(3095, "test body")
+        assert result["action"] == "dry_run_comment"
+        assert result["issue"] == 3095
+        assert result["body"] == "test body"
+
+    def test_with_github_write_calls_gh(self):
+        reporter = GitHubReporter(_manifest(), github_write=True)
+        with patch("subprocess.run") as mock_run:
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = "https://github.com/comment/1"
+            mock_run.return_value = mock_result
+
+            result = reporter._post_comment(3095, "test body")
+
+            assert result["action"] == "comment_posted"
+            mock_run.assert_called_once_with(
+                ["gh", "issue", "comment", "3095", "--body", "test body"],
+                capture_output=True, text=True, timeout=30,
+            )
+
+    def test_gh_not_found_returns_error(self):
+        reporter = GitHubReporter(_manifest(), github_write=True)
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("gh not found")
+            result = reporter._post_comment(3095, "body")
+            assert result["action"] == "comment_failed"
+            assert "gh not found" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# 9. CLI
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCLI:
+    def test_help_smoke(self):
+        from tools.arvp_github_reporter import parse_args
+
+        with pytest.raises(SystemExit):
+            parse_args(["--help"])
+
+    def test_manifest_required(self):
+        from tools.arvp_github_reporter import parse_args
+
+        with pytest.raises(SystemExit):
+            parse_args([])
+
+    def test_requires_state_or_entry(self):
+        from tools.arvp_github_reporter import parse_args
+
+        args = parse_args(["--manifest", "test.yaml"])
+        assert args.manifest == "test.yaml"
+
+    def test_github_write_flag(self):
+        from tools.arvp_github_reporter import parse_args
+
+        args = parse_args(["--manifest", "test.yaml", "--github-write"])
+        assert args.github_write is True
+
+    def test_create_pr_flag(self):
+        from tools.arvp_github_reporter import parse_args
+
+        args = parse_args(["--manifest", "test.yaml", "--create-pr"])
+        assert args.create_pr is True
+
+    def test_verbose_flag(self):
+        from tools.arvp_github_reporter import parse_args
+
+        args = parse_args(["--manifest", "test.yaml", "--verbose"])
+        assert args.verbose is True
+
+
+@pytest.mark.unit
+class TestLoadEntry:
+    def test_from_json_string(self):
+        from tools.arvp_github_reporter import load_entry
+
+        class FakeArgs:
+            cycle_entry = '{"state": "CHAIN_FOUND"}'
+            cycle_entry_file = None
+            state = None
+
+        entry = load_entry(FakeArgs())
+        assert entry["state"] == "CHAIN_FOUND"
+
+    def test_from_file(self):
+        from tools.arvp_github_reporter import load_entry
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump({"state": "TIMEOUT_NO_CHAIN"}, f)
+            fname = f.name
+
+        try:
+            class FakeArgs:
+                cycle_entry = None
+                cycle_entry_file = fname
+                state = None
+
+            entry = load_entry(FakeArgs())
+            assert entry["state"] == "TIMEOUT_NO_CHAIN"
+        finally:
+            os.unlink(fname)
+
+    def test_from_state_override(self):
+        from tools.arvp_github_reporter import load_entry
+
+        class FakeArgs:
+            cycle_entry = None
+            cycle_entry_file = None
+            state = "CHAIN_FOUND"
+
+        entry = load_entry(FakeArgs())
+        assert entry["state"] == "CHAIN_FOUND"
+
+    def test_no_input_raises(self):
+        from tools.arvp_github_reporter import load_entry
+
+        class FakeArgs:
+            cycle_entry = None
+            cycle_entry_file = None
+            state = None
+
+        with pytest.raises(ValueError):
+            load_entry(FakeArgs())

--- a/tools/arvp_github_reporter.py
+++ b/tools/arvp_github_reporter.py
@@ -256,9 +256,7 @@ class GitHubReporter:
 
         return results
 
-    def _resolve_targets(
-        self, state: str, campaign_failure_count: int
-    ) -> list[int]:
+    def _resolve_targets(self, state: str, campaign_failure_count: int) -> list[int]:
         targets: list[int] = []
         if self._post_3095:
             targets.append(ISSUE_CAMPAIGN)
@@ -278,9 +276,7 @@ class GitHubReporter:
 
         cmd = [self._gh, "issue", "comment", str(issue_number), "--body", body]
         try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=30
-            )
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
             if result.returncode != 0:
                 return {
                     "action": "comment_failed",
@@ -331,7 +327,9 @@ class GitHubReporter:
         try:
             exists = subprocess.run(
                 ["git", "rev-parse", "--verify", branch],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
             if exists.returncode == 0:
                 return {
@@ -342,42 +340,71 @@ class GitHubReporter:
 
             subprocess.run(
                 ["git", "checkout", "-b", branch],
-                capture_output=True, text=True, timeout=10, check=True,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=True,
             )
 
             paths = [p for p in [evidence_doc, evidence_log] if p and os.path.isfile(p)]
             for p in paths:
                 subprocess.run(
                     ["git", "add", p],
-                    capture_output=True, text=True, timeout=10, check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    check=True,
                 )
 
             subprocess.run(
-                ["git", "commit", "-m", f"docs/evidence: add {campaign_id} {state} evidence"],
-                capture_output=True, text=True, timeout=10, check=True,
+                [
+                    "git",
+                    "commit",
+                    "-m",
+                    f"docs/evidence: add {campaign_id} {state} evidence",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=True,
             )
 
             subprocess.run(
                 ["git", "push", "-u", "origin", branch],
-                capture_output=True, text=True, timeout=30, check=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=True,
             )
 
             pr_cmd = [
-                self._gh, "pr", "create",
-                "--title", pr_title,
-                "--body", pr_body_content,
-                "--base", "main",
-                "--head", branch,
+                self._gh,
+                "pr",
+                "create",
+                "--title",
+                pr_title,
+                "--body",
+                pr_body_content,
+                "--base",
+                "main",
+                "--head",
+                branch,
                 "--draft",
-                "--label", "ARVP,evidence",
+                "--label",
+                "ARVP,evidence",
             ]
             pr_result = subprocess.run(
-                pr_cmd, capture_output=True, text=True, timeout=30,
+                pr_cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             if pr_result.returncode != 0:
                 subprocess.run(
                     ["git", "checkout", "main"],
-                    capture_output=True, text=True, timeout=10,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
                 )
                 return {
                     "action": "pr_create_failed",
@@ -387,7 +414,9 @@ class GitHubReporter:
 
             subprocess.run(
                 ["git", "checkout", "main"],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
 
             return {
@@ -396,11 +425,16 @@ class GitHubReporter:
                 "url": pr_result.stdout.strip(),
             }
 
-        except (FileNotFoundError, subprocess.TimeoutExpired,
-                subprocess.CalledProcessError) as exc:
+        except (
+            FileNotFoundError,
+            subprocess.TimeoutExpired,
+            subprocess.CalledProcessError,
+        ) as exc:
             subprocess.run(
                 ["git", "checkout", "main"],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
             return {
                 "action": "pr_create_failed",
@@ -422,39 +456,49 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         )
     )
     parser.add_argument(
-        "--manifest", required=True,
+        "--manifest",
+        required=True,
         help="Path to campaign manifest (YAML or JSON)",
     )
     parser.add_argument(
-        "--cycle-entry", default=None,
+        "--cycle-entry",
+        default=None,
         help="JSON string of the supervisor cycle entry",
     )
     parser.add_argument(
-        "--cycle-entry-file", default=None,
+        "--cycle-entry-file",
+        default=None,
         help="Path to JSON file containing the cycle entry",
     )
     parser.add_argument(
-        "--state", default=None,
+        "--state",
+        default=None,
         help="Override terminal state (used without cycle entry for simple reports)",
     )
     parser.add_argument(
-        "--campaign-failure-count", type=int, default=0,
+        "--campaign-failure-count",
+        type=int,
+        default=0,
         help="Number of consecutive campaign failures (for #3087 escalation)",
     )
     parser.add_argument(
-        "--github-write", action="store_true",
+        "--github-write",
+        action="store_true",
         help="Enable live GitHub issue comments via gh CLI",
     )
     parser.add_argument(
-        "--create-pr", action="store_true",
+        "--create-pr",
+        action="store_true",
         help="Create evidence PR (implies --github-write)",
     )
     parser.add_argument(
-        "--gh-executable", default="gh",
+        "--gh-executable",
+        default="gh",
         help="Path to gh executable (default: gh)",
     )
     parser.add_argument(
-        "--verbose", action="store_true",
+        "--verbose",
+        action="store_true",
         help="Enable debug logging",
     )
     return parser.parse_args(argv)
@@ -468,9 +512,7 @@ def load_entry(args: argparse.Namespace) -> dict[str, Any]:
             return json.load(f)
     if args.state:
         return {"state": args.state, "observed_at_utc": "unknown"}
-    raise ValueError(
-        "one of --cycle-entry, --cycle-entry-file, or --state is required"
-    )
+    raise ValueError("one of --cycle-entry, --cycle-entry-file, or --state is required")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tools/arvp_github_reporter.py
+++ b/tools/arvp_github_reporter.py
@@ -1,0 +1,505 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+ISSUE_CAMPAIGN = 3095
+ISSUE_REFERENCE_WINDOW = 3087
+ISSUE_UMBRELLA = 3102
+
+STATE_CHAIN_FOUND = "CHAIN_FOUND"
+STATE_TIMEOUT_NO_CHAIN = "TIMEOUT_NO_CHAIN"
+STATE_INTERRUPTED = "INTERRUPTED"
+STATE_BLOCKED_RUNTIME = "BLOCKED_RUNTIME"
+STATE_BLOCKED_DB_READONLY = "BLOCKED_DB_READONLY"
+STATE_BLOCKED_GOVERNANCE = "BLOCKED_GOVERNANCE"
+STATE_EVIDENCE_MERGED = "EVIDENCE_MERGED"
+
+TERMINAL_STATES = {
+    STATE_CHAIN_FOUND,
+    STATE_TIMEOUT_NO_CHAIN,
+    STATE_INTERRUPTED,
+    STATE_BLOCKED_RUNTIME,
+    STATE_BLOCKED_DB_READONLY,
+    STATE_BLOCKED_GOVERNANCE,
+    STATE_EVIDENCE_MERGED,
+}
+
+
+def _format_probe_table(probe_statuses: dict[str, str]) -> str:
+    if not probe_statuses:
+        return "*No probe data*"
+    lines = ["| Probe | Status |", "|-------|--------|"]
+    for name in sorted(probe_statuses):
+        lines.append(f"| {name} | {probe_statuses[name]} |")
+    return "\n".join(lines)
+
+
+def _should_comment_3087(state: str, campaign_failure_count: int) -> bool:
+    if state == STATE_CHAIN_FOUND:
+        return True
+    if state == STATE_TIMEOUT_NO_CHAIN and campaign_failure_count >= 3:
+        return True
+    return False
+
+
+def _git_branch_name(campaign_id: str, state: str) -> str:
+    safe_id = campaign_id.replace(" ", "_").replace("/", "_")
+    safe_state = state.lower().replace(" ", "_").replace("/", "_")
+    return f"evidence/arvp-{safe_id}-{safe_state}"
+
+
+# ---------------------------------------------------------------------------
+# Template renderers (pure functions, no side effects)
+# ---------------------------------------------------------------------------
+
+
+def render_chain_found(entry: dict[str, Any], manifest: dict[str, Any]) -> str:
+    details = entry.get("chain_details", {})
+    campaign_id = entry.get("campaign_id", "unknown")
+    observed = entry.get("observed_at_utc", "unknown")
+    event_count = details.get("event_count", "?")
+    first_ts = details.get("first_event_ts", "?")
+    last_ts = details.get("last_event_ts", "?")
+    event_ids = details.get("event_ids", [])
+    ids_str = ", ".join(str(i) for i in (event_ids or [])) if event_ids else "none"
+    evidence_doc = manifest.get("evidence_doc", "?")
+    evidence_log = manifest.get("evidence_log_jsonl", "?")
+
+    return (
+        f"## Chain Found — Campaign {campaign_id}\n\n"
+        f"**State:** CHAIN_FOUND\n"
+        f"**Observed:** {observed}\n"
+        f"**Event count:** {event_count}\n"
+        f"**First event:** {first_ts}\n"
+        f"**Last event:** {last_ts}\n"
+        f"**Event IDs:** {ids_str}\n\n"
+        f"**Evidence doc:** {evidence_doc}\n"
+        f"**Evidence log:** {evidence_log}\n\n"
+        f"---\n"
+        f"*This is paper-only evidence (MOCK_TRADING=true). LR remains NO-GO.*"
+    )
+
+
+def render_timeout_no_chain(entry: dict[str, Any], manifest: dict[str, Any]) -> str:
+    campaign_id = entry.get("campaign_id", "unknown")
+    observed = entry.get("observed_at_utc", "unknown")
+    event_count = entry.get("event_count_since_start", "?")
+    probe_statuses = entry.get("probe_statuses", {})
+
+    return (
+        f"## Timeout — No Chain Detected\n\n"
+        f"**Campaign:** {campaign_id}\n"
+        f"**State:** TIMEOUT_NO_CHAIN\n"
+        f"**Observed:** {observed}\n"
+        f"**Event count:** {event_count}\n\n"
+        f"**Probe Statuses:**\n"
+        f"{_format_probe_table(probe_statuses)}\n\n"
+        f"**Classification:** campaign_timeout_record (counts as failure)\n\n"
+        f"---\n"
+        f"*LR remains NO-GO.*"
+    )
+
+
+def render_interrupted(entry: dict[str, Any], manifest: dict[str, Any]) -> str:
+    campaign_id = entry.get("campaign_id", "unknown")
+    observed = entry.get("observed_at_utc", "unknown")
+    event_count = entry.get("event_count_since_start", "?")
+    probe_statuses = entry.get("probe_statuses", {})
+
+    return (
+        f"## Campaign Interrupted\n\n"
+        f"**Campaign:** {campaign_id}\n"
+        f"**State:** INTERRUPTED\n"
+        f"**Observed:** {observed}\n"
+        f"**Event count:** {event_count}\n\n"
+        f"**Probe Statuses:**\n"
+        f"{_format_probe_table(probe_statuses)}\n\n"
+        f"**Classification:** interruption_record (does NOT count as failure)\n\n"
+        f"---\n"
+        f"*LR remains NO-GO.*"
+    )
+
+
+def render_blocked(entry: dict[str, Any], manifest: dict[str, Any]) -> str:
+    campaign_id = entry.get("campaign_id", "unknown")
+    state = entry.get("state", "BLOCKED_UNKNOWN")
+    observed = entry.get("observed_at_utc", "unknown")
+    probe_statuses = entry.get("probe_statuses", {})
+
+    blocked_probes = [k for k, v in probe_statuses.items() if v == "blocked"]
+    label = state.replace("BLOCKED_", "").replace("_", " ").title()
+
+    return (
+        f"## Campaign Blocked — {label}\n\n"
+        f"**Campaign:** {campaign_id}\n"
+        f"**State:** {state}\n"
+        f"**Observed:** {observed}\n"
+        f"**Blocking probe(s):** "
+        f"{', '.join(blocked_probes) if blocked_probes else '?'}\n\n"
+        f"**Probe Statuses:**\n"
+        f"{_format_probe_table(probe_statuses)}\n\n"
+        f"---\n"
+        f"*LR remains NO-GO.*"
+    )
+
+
+def render_merged(entry: dict[str, Any], manifest: dict[str, Any]) -> str:
+    campaign_id = entry.get("campaign_id", "unknown")
+    pr_url = entry.get("pr_url", "?")
+    merge_sha = entry.get("merge_sha", "?")
+    evidence_doc = manifest.get("evidence_doc", "?")
+
+    return (
+        f"## Evidence PR Merged — {campaign_id}\n\n"
+        f"**PR:** {pr_url}\n"
+        f"**Merge SHA:** {merge_sha}\n"
+        f"**Evidence doc:** {evidence_doc}\n\n"
+        f"---\n"
+        f"*LR remains NO-GO. No Echtgeld claim.*"
+    )
+
+
+_RENDERERS: dict[str, Any] = {
+    STATE_CHAIN_FOUND: render_chain_found,
+    STATE_TIMEOUT_NO_CHAIN: render_timeout_no_chain,
+    STATE_INTERRUPTED: render_interrupted,
+    STATE_BLOCKED_RUNTIME: render_blocked,
+    STATE_BLOCKED_DB_READONLY: render_blocked,
+    STATE_BLOCKED_GOVERNANCE: render_blocked,
+    STATE_EVIDENCE_MERGED: render_merged,
+}
+
+
+def render_body(state: str, entry: dict[str, Any], manifest: dict[str, Any]) -> str:
+    renderer = _RENDERERS.get(state)
+    if renderer is None:
+        raise ValueError(f"unknown state for template: {state}")
+    return renderer(entry, manifest)
+
+
+def pr_body(
+    campaign_id: str,
+    state: str,
+    entry: dict[str, Any],
+    evidence_doc: str,
+    evidence_log: str,
+) -> str:
+    observed = entry.get("observed_at_utc", "?")
+    chain_details = entry.get("chain_details", {})
+    event_count = chain_details.get("event_count", "?") if chain_details else "?"
+
+    return (
+        f"## {campaign_id} — {state}\n\n"
+        f"**Observed:** {observed}\n"
+        f"**Event count:** {event_count}\n\n"
+        f"**Evidence doc:** `{evidence_doc}`\n"
+        f"**Evidence log:** `{evidence_log}`\n\n"
+        f"**Parent:** #3102\n"
+        f"**Related:** #3095 #3087\n\n"
+        f"---\n"
+        f"*This is paper-only evidence (MOCK_TRADING=true). LR remains NO-GO.*\n"
+        f"*No Echtgeld claim. No live trading authorization.*"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GitHubReporter
+# ---------------------------------------------------------------------------
+
+
+class GitHubReporter:
+    def __init__(
+        self,
+        manifest: dict[str, Any],
+        github_write: bool = False,
+        create_pr: bool = False,
+        gh_executable: str = "gh",
+    ):
+        if create_pr and not github_write:
+            raise ValueError("--create-pr requires --github-write")
+
+        self._manifest = manifest
+        self._github_write = github_write
+        self._create_pr = create_pr
+        self._gh = gh_executable
+
+        reporting = manifest.get("github_reporting", {})
+        self._post_3095 = reporting.get("post_on_issue_3095", True)
+        self._post_3087 = reporting.get("post_on_issue_3087", False)
+        self._post_3102 = reporting.get("post_on_issue_3102", False)
+        self._pr_on_chain = reporting.get("pr_create_on_chain_found", True)
+
+    def report_terminal(
+        self, entry: dict[str, Any], campaign_failure_count: int = 0
+    ) -> list[dict[str, Any]]:
+        state = entry.get("state", "")
+        if state not in TERMINAL_STATES:
+            raise ValueError(f"non-terminal state: {state}")
+
+        body = render_body(state, entry, self._manifest)
+        results: list[dict[str, Any]] = []
+
+        targets = self._resolve_targets(state, campaign_failure_count)
+        for issue in targets:
+            results.append(self._post_comment(issue, body))
+
+        if state == STATE_CHAIN_FOUND and self._pr_on_chain:
+            results.append(self._maybe_create_pr(entry))
+
+        return results
+
+    def _resolve_targets(
+        self, state: str, campaign_failure_count: int
+    ) -> list[int]:
+        targets: list[int] = []
+        if self._post_3095:
+            targets.append(ISSUE_CAMPAIGN)
+        if self._post_3087 and _should_comment_3087(state, campaign_failure_count):
+            targets.append(ISSUE_REFERENCE_WINDOW)
+        if self._post_3102:
+            targets.append(ISSUE_UMBRELLA)
+        return targets
+
+    def _post_comment(self, issue_number: int, body: str) -> dict[str, Any]:
+        if not self._github_write:
+            return {
+                "action": "dry_run_comment",
+                "issue": issue_number,
+                "body": body,
+            }
+
+        cmd = [self._gh, "issue", "comment", str(issue_number), "--body", body]
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=30
+            )
+            if result.returncode != 0:
+                return {
+                    "action": "comment_failed",
+                    "issue": issue_number,
+                    "error": result.stderr.strip(),
+                }
+            return {
+                "action": "comment_posted",
+                "issue": issue_number,
+                "url": result.stdout.strip(),
+            }
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            return {
+                "action": "comment_failed",
+                "issue": issue_number,
+                "error": str(exc),
+            }
+
+    def _maybe_create_pr(self, entry: dict[str, Any]) -> dict[str, Any]:
+        campaign_id = entry.get("campaign_id", "unknown")
+        state = entry.get("state", "unknown")
+        branch = _git_branch_name(campaign_id, state)
+
+        if not self._create_pr:
+            return {
+                "action": "dry_run_pr",
+                "branch": branch,
+                "body": self._build_pr_body(entry),
+            }
+
+        return self._execute_create_pr(entry, campaign_id, state, branch)
+
+    def _build_pr_body(self, entry: dict[str, Any]) -> str:
+        campaign_id = entry.get("campaign_id", "unknown")
+        state = entry.get("state", "unknown")
+        evidence_doc = self._manifest.get("evidence_doc", "?")
+        evidence_log = self._manifest.get("evidence_log_jsonl", "?")
+        return pr_body(campaign_id, state, entry, evidence_doc, evidence_log)
+
+    def _execute_create_pr(
+        self, entry: dict[str, Any], campaign_id: str, state: str, branch: str
+    ) -> dict[str, Any]:
+        evidence_doc = self._manifest.get("evidence_doc", "")
+        evidence_log = self._manifest.get("evidence_log_jsonl", "")
+        pr_title = f"[ARVP][EVIDENCE] {campaign_id} — {state}"
+        pr_body_content = self._build_pr_body(entry)
+
+        try:
+            exists = subprocess.run(
+                ["git", "rev-parse", "--verify", branch],
+                capture_output=True, text=True, timeout=10,
+            )
+            if exists.returncode == 0:
+                return {
+                    "action": "pr_skipped",
+                    "branch": branch,
+                    "error": f"branch already exists: {branch}",
+                }
+
+            subprocess.run(
+                ["git", "checkout", "-b", branch],
+                capture_output=True, text=True, timeout=10, check=True,
+            )
+
+            paths = [p for p in [evidence_doc, evidence_log] if p and os.path.isfile(p)]
+            for p in paths:
+                subprocess.run(
+                    ["git", "add", p],
+                    capture_output=True, text=True, timeout=10, check=True,
+                )
+
+            subprocess.run(
+                ["git", "commit", "-m", f"docs/evidence: add {campaign_id} {state} evidence"],
+                capture_output=True, text=True, timeout=10, check=True,
+            )
+
+            subprocess.run(
+                ["git", "push", "-u", "origin", branch],
+                capture_output=True, text=True, timeout=30, check=True,
+            )
+
+            pr_cmd = [
+                self._gh, "pr", "create",
+                "--title", pr_title,
+                "--body", pr_body_content,
+                "--base", "main",
+                "--head", branch,
+                "--draft",
+                "--label", "ARVP,evidence",
+            ]
+            pr_result = subprocess.run(
+                pr_cmd, capture_output=True, text=True, timeout=30,
+            )
+            if pr_result.returncode != 0:
+                subprocess.run(
+                    ["git", "checkout", "main"],
+                    capture_output=True, text=True, timeout=10,
+                )
+                return {
+                    "action": "pr_create_failed",
+                    "branch": branch,
+                    "error": pr_result.stderr.strip(),
+                }
+
+            subprocess.run(
+                ["git", "checkout", "main"],
+                capture_output=True, text=True, timeout=10,
+            )
+
+            return {
+                "action": "pr_created",
+                "branch": branch,
+                "url": pr_result.stdout.strip(),
+            }
+
+        except (FileNotFoundError, subprocess.TimeoutExpired,
+                subprocess.CalledProcessError) as exc:
+            subprocess.run(
+                ["git", "checkout", "main"],
+                capture_output=True, text=True, timeout=10,
+            )
+            return {
+                "action": "pr_create_failed",
+                "branch": branch,
+                "error": str(exc),
+            }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "ARVP GitHub Reporter — controlled GitHub reporting "
+            "for campaign supervisor results"
+        )
+    )
+    parser.add_argument(
+        "--manifest", required=True,
+        help="Path to campaign manifest (YAML or JSON)",
+    )
+    parser.add_argument(
+        "--cycle-entry", default=None,
+        help="JSON string of the supervisor cycle entry",
+    )
+    parser.add_argument(
+        "--cycle-entry-file", default=None,
+        help="Path to JSON file containing the cycle entry",
+    )
+    parser.add_argument(
+        "--state", default=None,
+        help="Override terminal state (used without cycle entry for simple reports)",
+    )
+    parser.add_argument(
+        "--campaign-failure-count", type=int, default=0,
+        help="Number of consecutive campaign failures (for #3087 escalation)",
+    )
+    parser.add_argument(
+        "--github-write", action="store_true",
+        help="Enable live GitHub issue comments via gh CLI",
+    )
+    parser.add_argument(
+        "--create-pr", action="store_true",
+        help="Create evidence PR (implies --github-write)",
+    )
+    parser.add_argument(
+        "--gh-executable", default="gh",
+        help="Path to gh executable (default: gh)",
+    )
+    parser.add_argument(
+        "--verbose", action="store_true",
+        help="Enable debug logging",
+    )
+    return parser.parse_args(argv)
+
+
+def load_entry(args: argparse.Namespace) -> dict[str, Any]:
+    if args.cycle_entry:
+        return json.loads(args.cycle_entry)
+    if args.cycle_entry_file:
+        with open(args.cycle_entry_file, encoding="utf-8") as f:
+            return json.load(f)
+    if args.state:
+        return {"state": args.state, "observed_at_utc": "unknown"}
+    raise ValueError(
+        "one of --cycle-entry, --cycle-entry-file, or --state is required"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+
+    from tools.arvp_campaign_supervisor import load_manifest
+
+    manifest = load_manifest(args.manifest)
+    entry = load_entry(args)
+
+    reporter = GitHubReporter(
+        manifest=manifest,
+        github_write=args.github_write,
+        create_pr=args.create_pr,
+        gh_executable=args.gh_executable,
+    )
+
+    results = reporter.report_terminal(
+        entry, campaign_failure_count=args.campaign_failure_count
+    )
+
+    for result in results:
+        print(json.dumps(result, default=str))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #3113

Parent #3102
Depends on #3111/#3112

## Scope
- \	ools/arvp_github_reporter.py\ — GitHub Reporter component
- \	ests/unit/tools/test_arvp_github_reporter.py\ — 74 unit tests
- Template renderers for all 7 terminal states (CHAIN_FOUND, TIMEOUT_NO_CHAIN, INTERRUPTED, BLOCKED_*, EVIDENCE_MERGED)
- Explicit write gates: \--github-write\ for live comments, \--create-pr\ for evidence PRs
- Default dry-run: no \gh\/\git\ calls without flags
- \--create-pr\ requires \--github-write\
- Draft evidence PR creation (branch: \vidence/arvp-{campaign_id}-{state}\)
- Issue target resolution: #3095 (always), #3087 (chain_found or 3+ failures)
- Safety enforced: no \gh issue close\, no \gh pr merge\, no \Closes #\ in PR bodies, LR NO-GO in all templates

## Out of Scope (v1)
- Auto-merge (requires human review)
- Issue closure (handled by human/umbrella)
- Running cycle comments (terminal state only)
- Windows background runner (#3114)
- Full evidence export pipeline (contract from #3112)

## Validation
- \pytest tests/unit/tools/test_arvp_github_reporter.py\ — 74/74 passed
- \pytest tests/unit/tools/test_arvp_campaign_supervisor.py\ — 30/30 passed (no regression)
- \pytest tests/unit/tools/test_arvp_chain_detector.py\ — 58/58 passed (no regression)
- \pytest tests/unit/tools/test_arvp_probe_layer.py\ — 29/29 passed (no regression)
- \uff check tools/arvp_github_reporter.py tests/unit/tools/test_arvp_github_reporter.py\ — clean
- Safety grep: no forbidden patterns in source