### PR TITLE
[ARVP][PROBE] Fix Campaign #3 probe-layer runtime assumptions

### DIFF
--- a/manifests/campaign_3.yaml
+++ b/manifests/campaign_3.yaml
@@ -1,0 +1,67 @@
+schema_version: "1.0"
+campaign_id: arvp_3095_vol_window_3_20260611_1301
+parent_issue: 3095
+related_issues:
+  - 3087
+symbol: BTCUSDT
+strategy_id: primary_breakout_v1
+evidence_class: natural_paper_evidence
+start_utc: "2026-06-11T13:03:00Z"
+timeout_utc: "2026-06-11T21:03:00Z"
+max_duration_hours: 8.0
+start_criteria:
+  pre_documented: true
+  description: "P2 fulfilled (60m range 1.103% >= 0.75%) + HIGH_VOL_CHAOTIC regime per #3103 policy"
+  start_policy_ref: docs/evidence/arvp_volatility_window_start_policy_3103.md
+  primary_p1_threshold_pct: 0.35
+  primary_p2_threshold_pct: 0.75
+  primary_p3_regimes:
+    - TREND
+  actual_p1_pct: 0.281
+  actual_p2_pct: 1.103
+  actual_p3: HIGH_VOL_CHAOTIC
+  criteria_met: true
+  criteria_met_reason: "P2 (1.103% >= 0.75%) + HIGH_VOL_CHAOTIC allowed per #3103 because P2 is met and no blockers active"
+safety_flags:
+  mock_trading: true
+  use_real_balance: false
+  dry_run: true
+  mexc_testnet: true
+runtime_targets:
+  - cdb_execution
+  - cdb_regime
+  - cdb_risk
+  - cdb_market
+  - cdb_candles
+  - cdb_db_writer
+db_readonly_targets:
+  - public.correlation_ledger
+  - public.candles_1m
+evidence_doc: docs/evidence/arvp_volatility_window_campaign_3095_3.md
+evidence_log_jsonl: artifacts/campaigns/arvp_3095_vol_window_3_20260611_1301/evidence_log.jsonl
+github_reporting:
+  post_on_issue_3095: true
+  post_on_issue_3087: false
+  post_on_issue_3102: true
+  pr_create_on_chain_found: true
+  issue_close_after_acceptance: false
+allowed_statuses:
+  - planned
+  - preflight_failed
+  - running
+  - chain_found
+  - timeout_no_chain
+  - interrupted
+  - blocked_runtime
+  - blocked_db_readonly
+  - blocked_governance
+  - evidence_pr_open
+  - evidence_merged
+terminal_statuses:
+  - chain_found
+  - timeout_no_chain
+  - interrupted
+  - blocked_runtime
+  - blocked_db_readonly
+  - blocked_governance
+  - evidence_merged

--- a/tests/unit/tools/test_arvp_probe_layer.py
+++ b/tests/unit/tools/test_arvp_probe_layer.py
@@ -395,17 +395,17 @@ class TestProbeLedger:
 
         query_counter = [0]
         results_map = [
-            # latest event query
+            # latest event query (timestamp_ms, event_type, correlation_id)
             [
                 (
                     datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc),
-                    "SIGNAL", "active", "abc123",
+                    "SIGNAL", "abc123",
                 )
             ],
             # count query
             [(5,)],
-            # group by query
-            [("SIGNAL", "active", 3), ("ORDER", "filled", 2)],
+            # group by query (event_type, count)
+            [("SIGNAL", 3), ("ORDER", 2)],
         ]
 
         class FakeCursor:
@@ -427,7 +427,7 @@ class TestProbeLedger:
         result = probe_ledger(campaign_start_utc="2026-06-10T08:00:00Z")
         assert result["status"] == "ok"
         assert result["evidence"]["latest_event"]["event_type"] == "SIGNAL"
-        assert result["evidence"]["latest_event"]["lineage_hash"] == "abc123"
+        assert result["evidence"]["latest_event"]["correlation_id"] == "abc123"
 
     def test_blocked_db_error(self, monkeypatch):
         monkeypatch.setattr(
@@ -437,6 +437,11 @@ class TestProbeLedger:
         fake_psycopg2 = MagicMock()
         fake_psycopg2.connect.side_effect = Exception("connection refused")
         monkeypatch.setitem(sys.modules, "psycopg2", fake_psycopg2)
+
+        monkeypatch.setattr(
+            "tools.arvp_probe_layer._run_sql_docker_exec",
+            lambda _q, _c: None,
+        )
 
         result = probe_ledger()
         assert result["status"] == "blocked"

--- a/tools/arvp_probe_layer.py
+++ b/tools/arvp_probe_layer.py
@@ -284,6 +284,11 @@ SAFETY_FLAGS_EXPECTED: dict[str, str] = {
     "MEXC_TESTNET": "true",
 }
 
+# Flags that are code defaults (not required in Docker env).
+# Per arvp_campaign_supervisor_manifest_state_machine.md §9.1:
+# DRY_RUN and MEXC_TESTNET are "Verified at start (code defaults)".
+CODE_DEFAULT_FLAGS: set[str] = {"DRY_RUN", "MEXC_TESTNET"}
+
 
 def probe_safety(container: str = "cdb_execution") -> ProbeResult:
     try:
@@ -315,7 +320,10 @@ def probe_safety(container: str = "cdb_execution") -> ProbeResult:
     all_match = True
     for flag, expected in SAFETY_FLAGS_EXPECTED.items():
         actual = env_dict.get(flag)
-        match = actual is not None and actual.lower() == expected.lower()
+        if flag in CODE_DEFAULT_FLAGS and actual is None:
+            match = True
+        else:
+            match = actual is not None and actual.lower() == expected.lower()
         if not match:
             all_match = False
         flags.append(
@@ -356,9 +364,12 @@ def probe_safety(container: str = "cdb_execution") -> ProbeResult:
 DB_DEFAULTS = {
     "host": os.environ.get("CDB_DB_HOST", "localhost"),
     "port": int(os.environ.get("CDB_DB_PORT", "5432")),
-    "dbname": os.environ.get("CDB_DB_NAME", "claire"),
+    "dbname": os.environ.get("CDB_DB_NAME", "claire_de_binare"),
     "user": os.environ.get("CDB_DB_USER", "claire_user"),
+    "container": "cdb_postgres",
 }
+
+LEDGER_TIMESTAMP_COL = "timestamp_ms"
 
 
 def probe_db_readonly(
@@ -471,19 +482,40 @@ def probe_db_readonly(
                 limitations,
             )
         except Exception as exc:
-            return _blocked(
-                {"connectivity": "fail", "error": str(exc)},
-                limitations + [f"psycopg2 connection failed: {exc}"],
-            )
+            limitations.append(f"psycopg2 connection failed: {exc}")
 
-    return _ok(
-        {
-            "connectivity": "ok (pg_isready only)",
-            "host": host,
-            "port": port,
-            "dbname": dbname,
-        },
-        limitations + ["pg_isready only; no SELECT verification"],
+    fallback_rows = _run_sql_docker_exec("SELECT 1 AS ok", DB_DEFAULTS["container"])
+    if fallback_rows:
+        svr_version = None
+        version_rows = _run_sql_docker_exec(
+            "SELECT version()", DB_DEFAULTS["container"]
+        )
+        if version_rows and version_rows[0]:
+            svr_version = version_rows[0][0]
+        return _ok(
+            {
+                "connectivity": "ok",
+                "select_1_ok": True,
+                "server_version": svr_version or "unknown",
+                "host": "docker exec",
+                "port": "container",
+                "dbname": dbname,
+                "user": user,
+                "method": "docker_exec",
+                "container": DB_DEFAULTS["container"],
+            },
+            limitations + ["connected via docker exec; host port auth not verified"],
+        )
+
+    if not psycopg2_available and not fallback_rows:
+        return _unavailable(
+            {"error": "no DB connectivity method available"},
+            ["install psycopg2 or ensure Docker container is running"],
+        )
+
+    return _blocked(
+        {"connectivity": "fail"},
+        limitations + ["all connectivity methods failed"],
     )
 
 
@@ -492,24 +524,74 @@ def probe_db_readonly(
 # ---------------------------------------------------------------------------
 
 
-def _run_sql(host: str, port: int, dbname: str, user: str, query: str) -> list[tuple]:
-    import psycopg2
+def _run_sql(
+    host: str,
+    port: int,
+    dbname: str,
+    user: str,
+    query: str,
+    container: str = DB_DEFAULTS["container"],
+) -> list[tuple]:
+    import importlib
 
-    conn = psycopg2.connect(
-        host=host,
-        port=port,
-        dbname=dbname,
-        user=user,
-        connect_timeout=10,
+    if importlib.util.find_spec("psycopg2"):
+        try:
+            import psycopg2
+
+            conn = psycopg2.connect(
+                host=host,
+                port=port,
+                dbname=dbname,
+                user=user,
+                connect_timeout=10,
+            )
+            try:
+                cur = conn.cursor()
+                cur.execute(query)
+                rows = cur.fetchall()
+                cur.close()
+                return rows
+            finally:
+                conn.close()
+        except Exception:
+            pass
+
+    fallback = _run_sql_docker_exec(query, container)
+    if fallback:
+        return fallback
+    raise RuntimeError(
+        f"DB unreachable via psycopg2 ({host}:{port}/{dbname}) and docker exec"
     )
+
+
+def _run_sql_docker_exec(query: str, container: str) -> list[tuple] | None:
     try:
-        cur = conn.cursor()
-        cur.execute(query)
-        rows = cur.fetchall()
-        cur.close()
-        return rows
-    finally:
-        conn.close()
+        out = _run_docker_cmd(
+            [
+                "exec",
+                container,
+                "psql",
+                "-U",
+                "claire_user",
+                "-d",
+                "claire_de_binare",
+                "-At",
+                "-c",
+                query,
+            ],
+            timeout=15,
+        )
+        rows: list[tuple] = []
+        for line in out.strip().split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split("|")
+            row: tuple = tuple(parts)
+            rows.append(row)
+        return rows if rows else None
+    except Exception:
+        return None
 
 
 def probe_candles(
@@ -550,7 +632,7 @@ def probe_candles(
             user,
             f"SELECT MAX(high) - MIN(low) FROM candles_1m "
             f"WHERE symbol='{symbol}' "
-            f"AND ts_ms >= NOW() - INTERVAL '15 minutes'",
+            f"AND ts_ms >= EXTRACT(EPOCH FROM NOW() - INTERVAL '15 minutes')::bigint * 1000",
         )
         range_15m_val = (
             float(range_15m[0][0]) if range_15m and range_15m[0][0] else None
@@ -563,7 +645,7 @@ def probe_candles(
             user,
             f"SELECT MAX(high) - MIN(low) FROM candles_1m "
             f"WHERE symbol='{symbol}' "
-            f"AND ts_ms >= NOW() - INTERVAL '60 minutes'",
+            f"AND ts_ms >= EXTRACT(EPOCH FROM NOW() - INTERVAL '60 minutes')::bigint * 1000",
         )
         range_60m_val = (
             float(range_60m[0][0]) if range_60m and range_60m[0][0] else None
@@ -617,9 +699,9 @@ def probe_candles(
             "gap_threshold_minutes": gap_threshold_minutes,
             "queries": [
                 "SELECT MAX(ts_ms) FROM candles_1m WHERE symbol='BTCUSDT'",
-                "SELECT MAX(high)-MIN(low) FROM candles_1m WHERE symbol='BTCUSDT' AND ts_ms >= NOW()-INTERVAL '15 minutes'",
-                "SELECT MAX(high)-MIN(low) FROM candles_1m WHERE symbol='BTCUSDT' AND ts_ms >= NOW()-INTERVAL '60 minutes'",
-                "SELECT ts_ms - LAG(ts_ms) OVER (ORDER BY ts_ms) FROM candles_1m WHERE symbol='BTCUSDT' ORDER BY ts_ms DESC LIMIT 10",
+                "SELECT MAX(high)-MIN(low) FROM candles_1m WHERE symbol='BTCUSDT' AND ts_ms >= ...15min_epoch_ms",
+                "SELECT MAX(high)-MIN(low) FROM candles_1m WHERE symbol='BTCUSDT' AND ts_ms >= ...60min_epoch_ms",
+                "SELECT ts_ms - LAG(ts_ms) OVER ... FROM candles_1m ORDER BY ts_ms DESC LIMIT 10",
             ],
         }
         status = "blocked" if len(large_gaps) > 0 else "ok"
@@ -669,8 +751,8 @@ def probe_ledger(
             port,
             dbname,
             user,
-            "SELECT ts_ms, event_type, status, lineage_hash "
-            "FROM correlation_ledger ORDER BY ts_ms DESC LIMIT 1",
+            "SELECT timestamp_ms, event_type, correlation_id "
+            "FROM correlation_ledger ORDER BY timestamp_ms DESC LIMIT 1",
         )
         latest_event: dict | None = None
         if latest:
@@ -681,8 +763,7 @@ def probe_ledger(
                     else str(latest[0][0])
                 ),
                 "event_type": latest[0][1],
-                "status": latest[0][2],
-                "lineage_hash": latest[0][3],
+                "correlation_id": latest[0][2],
             }
 
         count_since_start: int | None = None
@@ -693,7 +774,8 @@ def probe_ledger(
                 dbname,
                 user,
                 f"SELECT COUNT(*) FROM correlation_ledger "
-                f"WHERE ts_ms >= '{campaign_start_utc}'::timestamptz",
+                f"WHERE timestamp_ms >= "
+                f"EXTRACT(EPOCH FROM '{campaign_start_utc}'::timestamptz)::bigint * 1000",
             )
             count_since_start = int(count_rows[0][0]) if count_rows else 0
 
@@ -702,29 +784,28 @@ def probe_ledger(
             port,
             dbname,
             user,
-            "SELECT event_type, status, COUNT(*) as cnt "
+            "SELECT event_type, COUNT(*) as cnt "
             "FROM correlation_ledger "
-            "GROUP BY event_type, status ORDER BY event_type, status",
+            "GROUP BY event_type ORDER BY event_type",
         )
-        events_by_type_status: list[dict] = []
+        events_by_type: list[dict] = []
         for row in grouped:
-            events_by_type_status.append(
+            events_by_type.append(
                 {
                     "event_type": row[0],
-                    "status": row[1],
-                    "count": int(row[2]),
+                    "count": int(row[1]),
                 }
             )
 
         evidence: dict[str, Any] = {
             "latest_event": latest_event,
             "events_since_campaign_start": count_since_start,
-            "events_by_type_status": events_by_type_status,
+            "events_by_type_status": events_by_type,
             "campaign_start_utc": campaign_start_utc,
             "queries": [
-                "SELECT ... FROM correlation_ledger ORDER BY ts_ms DESC LIMIT 1",
-                "SELECT COUNT(*) FROM correlation_ledger WHERE ts_ms >= ...",
-                "SELECT event_type, status, COUNT(*) FROM correlation_ledger GROUP BY ...",
+                "SELECT ... FROM correlation_ledger ORDER BY timestamp_ms DESC LIMIT 1",
+                "SELECT COUNT(*) FROM correlation_ledger WHERE timestamp_ms >= ...",
+                "SELECT event_type, COUNT(*) FROM correlation_ledger GROUP BY ...",
             ],
         }
 
@@ -736,8 +817,8 @@ def probe_ledger(
                     port,
                     dbname,
                     user,
-                    "SELECT id, ts_ms, event_type, status, lineage_hash "
-                    "FROM correlation_ledger ORDER BY ts_ms ASC",
+                    "SELECT id, timestamp_ms, event_type, correlation_id "
+                    "FROM correlation_ledger ORDER BY timestamp_ms ASC",
                 )
                 events_raw = []
                 for row in rows:
@@ -750,14 +831,13 @@ def probe_ledger(
                                 else str(row[1])
                             ),
                             "event_type": row[2],
-                            "status": row[3],
-                            "lineage_hash": row[4],
+                            "correlation_id": row[3],
                         }
                     )
                 evidence["events"] = events_raw
                 evidence["queries"].append(
-                    "SELECT id, ts_ms, event_type, status, lineage_hash "
-                    "FROM correlation_ledger ORDER BY ts_ms ASC"
+                    "SELECT id, timestamp_ms, event_type, correlation_id "
+                    "FROM correlation_ledger ORDER BY timestamp_ms ASC"
                 )
             except Exception as exc:
                 logger.warning("events query failed: %s", exc)


### PR DESCRIPTION
## Summary

Read-only probe/runtime observation assumption fixes discovered at Campaign #3 startup (arvp_3095_vol_window_3_20260611_1301). No strategy changes, no runtime/config mutation, no DB writes, no Live/Echtgeld-Go.

## Changes

### Safety probe
- `CODE_DEFAULT_FLAGS`: Accept null (code default) for `DRY_RUN` and `MEXC_TESTNET` per arvp_campaign_supervisor_manifest_state_machine.md section 9.1

### DB defaults
- `DB_DEFAULTS.dbname`: claire -> claire_de_binare (actual Postgres database name)
- Added `DB_DEFAULTS.container: cdb_postgres`
- Added `LEDGER_TIMESTAMP_COL = "timestamp_ms"`

### DB connectivity -- docker exec fallback
- `probe_db_readonly`: when psycopg2 TCP to localhost fails, falls back to `docker exec cdb_postgres psql`
- `_run_sql`: same psycopg2-first, docker exec fallback
- `_run_sql_docker_exec`: new helper that runs SQL via docker exec

### Candle probe -- type mismatch
- `candles_1m.ts_ms` is `bigint` (epoch ms), not `timestamptz`
- Fixed comparison to use `EXTRACT(EPOCH FROM NOW() - INTERVAL)...::bigint * 1000`

### correlation_ledger probe -- column mismatch
- No `status` column; removed from queries
- No `lineage_hash` column; uses `correlation_id` instead
- GROUP BY: removed status, now event_type only

### Tests updated
- test_ok_with_events: 3-column query shape, assertion key lineage_hash -> correlation_id
- test_blocked_db_error: mock _run_sql_docker_exec to avoid live Docker interference

## Validation
- 29/29 probe layer tests pass
- 222/222 supervisor/chain/reporter/failure tests pass
- Ruff: all checks passed
- Safety grep: no dangerous patterns
- git diff --check: clean
- Campaign #3 still running (PID 8140)

## References
- Refs #3095
- Refs #3087
- Refs #3103

## No-Go assertions
- No strategy changes
- No runtime/config mutation
- No DB writes
- No Live-Go / no Echtgeld-Go
- LR remains NO-GO
