### PR TITLE
policy(arvp): enforce evidence class metadata for ARVP artifacts and runners

### DIFF
--- a/core/replay/arvp_regime_scorecards.py
+++ b/core/replay/arvp_regime_scorecards.py
@@ -373,12 +373,16 @@ def write_regime_scorecard_bundle(
     *,
     scorecard: ARVPRegimeScorecard,
     output_dir: pathlib.Path,
+    bundle_metadata: dict[str, object] | None = None,
 ) -> tuple[pathlib.Path, pathlib.Path]:
     output_dir.mkdir(parents=True, exist_ok=True)
     json_path = output_dir / _FILENAME_JSON
     md_path = output_dir / _FILENAME_MD
     try:
-        json_path.write_text(canonical_json_dumps(scorecard.to_dict()), encoding="utf-8")
+        result = scorecard.to_dict()
+        if bundle_metadata:
+            result = {**bundle_metadata, **result}
+        json_path.write_text(canonical_json_dumps(result), encoding="utf-8")
         md_path.write_text(build_scorecard_summary(scorecard), encoding="utf-8")
     except OSError as exc:
         raise ARVPRegimeScorecardError(

--- a/core/utils/evidence_class.py
+++ b/core/utils/evidence_class.py
@@ -72,6 +72,12 @@ def _check_required_fields(artifact: dict[str, Any], ec: str) -> None:
             f"evidence_class={ec!r} missing required field(s): "
             f"{', '.join(sorted(missing))}"
         )
+    ec_version = artifact.get("evidence_class_version")
+    if ec_version is not None and ec_version != SCHEMA_VERSION:
+        raise EvidenceClassError(
+            f"evidence_class_version must be {SCHEMA_VERSION!r}, "
+            f"got {ec_version!r}"
+        )
 
 
 def validate_evidence_class(artifact: dict[str, Any]) -> None:

--- a/core/utils/evidence_class.py
+++ b/core/utils/evidence_class.py
@@ -24,9 +24,54 @@ _WARNING_BANNERS: dict[str, str] = {
 
 SCHEMA_VERSION = "1.0"
 
+_BASE_REQUIRED_FIELDS: set[str] = {
+    "evidence_class_version",
+    "produced_by",
+    "produced_at_utc",
+}
+
+_CLASS_REQUIRED_FIELDS: dict[str, set[str]] = {
+    "natural_paper_evidence": {
+        "campaign_id",
+        "start_criterion",
+        "safety_flags",
+        "provenance",
+    },
+    "controlled_lab_evidence": {
+        "scenario_source",
+        "reproducibility_contract",
+    },
+    "pipeline_test_evidence": {
+        "pipeline_tool",
+        "fixture_source",
+    },
+    "waiver_decision": {
+        "governance_ref",
+        "residual_uncertainties",
+    },
+}
+
 
 class EvidenceClassError(ValueError):
     """Raised when evidence_class validation fails."""
+
+
+def _check_required_fields(artifact: dict[str, Any], ec: str) -> None:
+    """Check all required base and per-class fields are present and non-blank."""
+    missing: list[str] = []
+    for field in _BASE_REQUIRED_FIELDS:
+        val = artifact.get(field)
+        if val is None or (isinstance(val, str) and not val.strip()):
+            missing.append(field)
+    for field in _CLASS_REQUIRED_FIELDS.get(ec, set()):
+        val = artifact.get(field)
+        if val is None or (isinstance(val, str) and not val.strip()):
+            missing.append(field)
+    if missing:
+        raise EvidenceClassError(
+            f"evidence_class={ec!r} missing required field(s): "
+            f"{', '.join(sorted(missing))}"
+        )
 
 
 def validate_evidence_class(artifact: dict[str, Any]) -> None:
@@ -38,7 +83,7 @@ def validate_evidence_class(artifact: dict[str, Any]) -> None:
 
     Raises:
         EvidenceClassError: If validation fails (missing, unknown,
-            or missing required warning banner).
+            missing required warning banner, or missing required fields).
     """
     ec = artifact.get("evidence_class")
 
@@ -64,6 +109,8 @@ def validate_evidence_class(artifact: dict[str, Any]) -> None:
                 f"containing: {expected_banner!r}. "
                 f"Got: {actual_banner!r}"
             )
+
+    _check_required_fields(artifact, ec)
 
 
 def validate_evidence_class_or_skip(artifact: dict[str, Any]) -> list[str]:

--- a/core/utils/evidence_class.py
+++ b/core/utils/evidence_class.py
@@ -12,13 +12,13 @@ _VALID_CLASSES: set[str] = {
 
 _WARNING_BANNERS: dict[str, str] = {
     "controlled_lab_evidence": (
-        "NOT natural_paper_evidence — cannot satisfy §5.2.4"
+        "⚠ NOT natural_paper_evidence — cannot satisfy §5.2.4"
     ),
     "pipeline_test_evidence": (
-        "Pipeline test only — NOT valid for Product-Complete gate"
+        "⚠ Pipeline test only — NOT valid for Product-Complete gate"
     ),
     "waiver_decision": (
-        "Policy decision — not evidence; requires formal governance vote"
+        "⚠ Policy decision — not evidence; requires formal governance vote"
     ),
 }
 

--- a/core/utils/evidence_class.py
+++ b/core/utils/evidence_class.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+_VALID_CLASSES: set[str] = {
+    "natural_paper_evidence",
+    "controlled_lab_evidence",
+    "pipeline_test_evidence",
+    "waiver_decision",
+}
+
+_WARNING_BANNERS: dict[str, str] = {
+    "controlled_lab_evidence": (
+        "NOT natural_paper_evidence — cannot satisfy §5.2.4"
+    ),
+    "pipeline_test_evidence": (
+        "Pipeline test only — NOT valid for Product-Complete gate"
+    ),
+    "waiver_decision": (
+        "Policy decision — not evidence; requires formal governance vote"
+    ),
+}
+
+SCHEMA_VERSION = "1.0"
+
+
+class EvidenceClassError(ValueError):
+    """Raised when evidence_class validation fails."""
+
+
+def validate_evidence_class(artifact: dict[str, Any]) -> None:
+    """Validate evidence_class metadata on an ARVP evidence artifact.
+
+    Args:
+        artifact: Dict representing an ARVP evidence artifact.
+            Must contain at minimum an ``evidence_class`` key.
+
+    Raises:
+        EvidenceClassError: If validation fails (missing, unknown,
+            or missing required warning banner).
+    """
+    ec = artifact.get("evidence_class")
+
+    if ec is None:
+        raise EvidenceClassError(
+            "Missing evidence_class — every ARVP evidence artifact "
+            "must carry exactly one evidence_class"
+        )
+
+    if ec not in _VALID_CLASSES:
+        raise EvidenceClassError(
+            f"Unknown evidence_class={ec!r}. "
+            f"Valid values: {', '.join(sorted(_VALID_CLASSES))}"
+        )
+
+    if ec in _WARNING_BANNERS:
+        expected_banner = _WARNING_BANNERS[ec]
+        actual_banner = artifact.get("warning_banner", "")
+
+        if expected_banner not in actual_banner:
+            raise EvidenceClassError(
+                f"evidence_class={ec!r} requires warning banner "
+                f"containing: {expected_banner!r}. "
+                f"Got: {actual_banner!r}"
+            )
+
+
+def validate_evidence_class_or_skip(artifact: dict[str, Any]) -> list[str]:
+    """Non-raising variant that returns a list of error messages.
+
+    Returns an empty list when validation passes.
+    """
+    errors: list[str] = []
+    try:
+        validate_evidence_class(artifact)
+    except EvidenceClassError as exc:
+        errors.append(str(exc))
+    return errors
+
+
+def evidence_class_warning_banner(evidence_class: str) -> str:
+    """Return the required warning banner for the given evidence class.
+
+    Returns an empty string for classes that do not require a banner.
+    """
+    return _WARNING_BANNERS.get(evidence_class, "")
+
+
+def validate_evidence_class_from_json(json_str: str) -> None:
+    """Parse a JSON string and validate evidence_class metadata."""
+    try:
+        artifact = json.loads(json_str)
+    except json.JSONDecodeError as exc:
+        raise EvidenceClassError(f"Invalid JSON: {exc}") from exc
+
+    if not isinstance(artifact, dict):
+        raise EvidenceClassError("JSON root must be a dict/object")
+
+    validate_evidence_class(artifact)
+
+
+def is_valid_evidence_class(value: str) -> bool:
+    """Check if the given string is a valid evidence class value."""
+    return value in _VALID_CLASSES

--- a/docs/contracts/evidence_class_contract.md
+++ b/docs/contracts/evidence_class_contract.md
@@ -1,0 +1,100 @@
+# Evidence Class Contract — #3096
+
+**Status:** Canonical
+**Scope:** ARVP evidence artifact classification and enforcement
+**Design Source:** #3094 `docs/evidence/arvp_deterministic_window_production_3094.md`
+**Controlled-Lab Path:** #3127 `docs/evidence/arvp_controlled_lab_evidence_path_3127.md`
+**Issue:** #3096
+
+---
+
+## 1. Purpose
+
+Define the four canonical evidence classes, their required metadata, warning banners, and fail-closed enforcement rules for all ARVP evidence artifacts produced or validated by repo surfaces.
+
+---
+
+## 2. Valid Evidence Classes
+
+| ID | Label | Definition | §5.2.4 Gate? | Contract/Proof? | Warning Banner |
+|----|-------|-----------|-------------|-----------------|----------------|
+| `natural_paper_evidence` | Real paper runtime output under natural market conditions | Paper reference windows produced via real strategy/execution path against live market data; MOCK_TRADING=true, no stimulus, no parameter hack | **Yes** | Yes | *(none — highest class)* |
+| `controlled_lab_evidence` | Scenario-backed deterministic evidence from historical or pre-built data packs | Regime scorecards or pipeline artifacts produced from curated scenario packs with known inputs; no real market dependency | **No** | Yes | `⚠ NOT natural_paper_evidence — cannot satisfy §5.2.4` |
+| `pipeline_test_evidence` | Synthetic stimulus or fixture-driven pipeline validation | Output from `paper_runtime_stimulus_runner.py` or similar fixture-based runners; proves pipeline works, not that products are complete | **No** | Yes (for pipeline) | `⚠ Pipeline test only — NOT valid for Product-Complete gate` |
+| `waiver_decision` | Explicit policy decision accepting non-fulfillment of a gate criterion | Documented governance decision; must list residual uncertainties and mandatory follow-ups | **Only with formal governance vote** | N/A | `⚠ Policy decision — not evidence; requires formal governance vote` |
+
+## 3. Required Metadata
+
+Every ARVP evidence artifact MUST carry at minimum:
+
+```json
+{
+  "evidence_class": "<one of the 4 valid values>",
+  "evidence_class_version": "1.0",
+  "produced_by": "<runner-id or tool-name>",
+  "produced_at_utc": "<ISO-8601 UTC>"
+}
+```
+
+### Per-class requirements
+
+| Class | Additional Required Fields |
+|-------|---------------------------|
+| `natural_paper_evidence` | `campaign_id`, `start_criterion`, `safety_flags` (mock_trading, dry_run, mexc_testnet), `provenance` |
+| `controlled_lab_evidence` | `warning_banner` (exact text from §2), `scenario_source`, `reproducibility_contract` |
+| `pipeline_test_evidence` | `warning_banner` (exact text from §2), `pipeline_tool`, `fixture_source` |
+| `waiver_decision` | `warning_banner` (exact text from §2), `governance_ref`, `residual_uncertainties` |
+
+## 4. Enforcement Rules
+
+1. **Every** ARVP evidence artifact produced or validated by touched surfaces MUST carry exactly one `evidence_class`.
+
+2. `controlled_lab_evidence` REQUIRES the exact warning banner: `⚠ NOT natural_paper_evidence — cannot satisfy §5.2.4`.
+
+3. `pipeline_test_evidence` REQUIRES the exact warning banner: `⚠ Pipeline test only — NOT valid for Product-Complete gate`.
+
+4. `waiver_decision` REQUIRES the exact warning banner: `⚠ Policy decision — not evidence; requires formal governance vote`.
+
+5. **No silent class upgrade.** An artifact labeled `pipeline_test_evidence` can NEVER be interpreted as `natural_paper_evidence` by omission or relabeling.
+
+6. **No missing evidence_class.** Artifacts without `evidence_class` are REJECTED by validation.
+
+7. **No unknown evidence_class.** Any value outside the 4 valid classes is REJECTED by validation.
+
+8. **Fail-closed on missing/unknown.** Validation MUST return a non-zero exit code or raise an exception — never silently pass.
+
+## 5. Runner Labeling
+
+| Runner | Default Evidence Class | Notes |
+|--------|----------------------|-------|
+| `paper_runtime_stimulus_runner.py` | `pipeline_test_evidence` | Output is synthetic fixture-based, NOT natural paper evidence |
+| `paper_reference_window_runner.py` | `natural_paper_evidence` (when chain detected) | Window exported from real correlation_ledger events |
+| `arvp_regime_scorecard_runner.py` | Configurable via `--evidence-class` | Must match the input trace/input source class |
+| `arvp_chain_detector.py` | `natural_paper_evidence` (on complete chain) | Hard-coded in export trigger — only fires on real chain |
+
+## 6. Safety Boundaries
+
+| Boundary | Status |
+|----------|--------|
+| LR remains **NO-GO** | Confirmed |
+| `controlled_lab_evidence` cannot close #3087 | Confirmed |
+| `controlled_lab_evidence` cannot satisfy §5.2.4 | Confirmed |
+| `pipeline_test_evidence` is NOT Product-Complete evidence | Confirmed |
+| Board stage `trade-capable` is NOT Live-Go | Confirmed |
+| No silent class upgrade | Enforced |
+| No missing `evidence_class` | Enforced |
+| No unknown `evidence_class` | Enforced |
+| Product-Complete remains blocked unless `natural_paper_evidence` or formal waiver exists | Confirmed |
+
+---
+
+## 7. References
+
+- #3096 — This enforcement issue
+- #3094 — Evidence class definitions (design source)
+- #3127 — Controlled-lab evidence path design
+- #3087 — Natural-chain blocker (remains OPEN/BLOCKED)
+- #2974 — Product-Complete review (§5.2.4 BLOCKED)
+- `docs/evidence/arvp_deterministic_window_production_3094.md`
+- `docs/evidence/arvp_controlled_lab_evidence_path_3127.md`
+- `docs/evidence/arvp_option_e_waiver_split_decision_3087_3095.md`

--- a/services/validation/arvp_regime_scorecard_runner.py
+++ b/services/validation/arvp_regime_scorecard_runner.py
@@ -4,6 +4,8 @@ Consumes (optional inputs; fail-closed on invalid JSON, explicit on missing regi
   - replay trace JSON (runner-supplied): --replay-trace
   - comparison JSON (optional):         --comparison
 
+Evidence class: configurable via --evidence-class (default: controlled_lab_evidence).
+
 Produces (under output_dir/<run_id>/):
   - arvp_regime_scorecard.json
   - arvp_regime_scorecard_summary.md
@@ -27,6 +29,14 @@ from core.replay.arvp_regime_scorecards import (
     load_json,
     write_regime_scorecard_bundle,
 )
+from core.utils.evidence_class import (
+    EvidenceClassError,
+    evidence_class_warning_banner,
+    is_valid_evidence_class,
+    validate_evidence_class,
+)
+
+_DEFAULT_EVIDENCE_CLASS = "controlled_lab_evidence"
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -39,6 +49,12 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         default="artifacts/arvp_regime_scorecards",
         help="Root directory for scorecard artifacts (default: artifacts/arvp_regime_scorecards).",
     )
+    p.add_argument(
+        "--evidence-class",
+        default=_DEFAULT_EVIDENCE_CLASS,
+        choices=["natural_paper_evidence", "controlled_lab_evidence", "pipeline_test_evidence", "waiver_decision"],
+        help=f"Evidence classification for the output artifact (default: {_DEFAULT_EVIDENCE_CLASS}).",
+    )
     return p.parse_args(argv)
 
 
@@ -48,6 +64,23 @@ def main(argv: list[str] | None = None) -> int:
         args = _parse_args(argv)
     except SystemExit:
         return 1
+
+    evidence_class = str(args.evidence_class)
+    warning_banner = evidence_class_warning_banner(evidence_class)
+
+    metadata: dict[str, str] = {
+        "evidence_class": evidence_class,
+        "evidence_class_version": "1.0",
+        "produced_by": "arvp_regime_scorecard_runner",
+    }
+    if warning_banner:
+        metadata["warning_banner"] = warning_banner
+
+    try:
+        validate_evidence_class(metadata)
+    except EvidenceClassError as exc:
+        print(f"EVIDENCE CLASS VALIDATION FAILED: {exc}", file=sys.stderr)
+        return 2
 
     run_id = str(args.run_id)
     output_root = Path(args.output_dir)
@@ -73,7 +106,11 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 
-    print(f"OK: regime scorecard built (status={scorecard.status}, fingerprint={scorecard.scorecard_fingerprint})")
+    print(
+        f"OK: regime scorecard built "
+        f"(status={scorecard.status}, fingerprint={scorecard.scorecard_fingerprint}, "
+        f"evidence_class={evidence_class})"
+    )
     return 0
 
 

--- a/services/validation/arvp_regime_scorecard_runner.py
+++ b/services/validation/arvp_regime_scorecard_runner.py
@@ -19,6 +19,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import datetime
 import sys
 from pathlib import Path
 
@@ -32,7 +33,6 @@ from core.replay.arvp_regime_scorecards import (
 from core.utils.evidence_class import (
     EvidenceClassError,
     evidence_class_warning_banner,
-    is_valid_evidence_class,
     validate_evidence_class,
 )
 
@@ -67,20 +67,7 @@ def main(argv: list[str] | None = None) -> int:
 
     evidence_class = str(args.evidence_class)
     warning_banner = evidence_class_warning_banner(evidence_class)
-
-    metadata: dict[str, str] = {
-        "evidence_class": evidence_class,
-        "evidence_class_version": "1.0",
-        "produced_by": "arvp_regime_scorecard_runner",
-    }
-    if warning_banner:
-        metadata["warning_banner"] = warning_banner
-
-    try:
-        validate_evidence_class(metadata)
-    except EvidenceClassError as exc:
-        print(f"EVIDENCE CLASS VALIDATION FAILED: {exc}", file=sys.stderr)
-        return 2
+    now_utc = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
     run_id = str(args.run_id)
     output_root = Path(args.output_dir)
@@ -100,6 +87,24 @@ def main(argv: list[str] | None = None) -> int:
 
         # If both are provided, prefer replay-side scorecard as primary output.
         scorecard = scorecards[0]
+
+        metadata: dict[str, str] = {
+            "evidence_class": evidence_class,
+            "evidence_class_version": "1.0",
+            "produced_by": "arvp_regime_scorecard_runner",
+            "produced_at_utc": now_utc,
+            "scenario_source": args.replay_trace or args.comparison or "unknown",
+            "reproducibility_contract": scorecard.scorecard_fingerprint,
+        }
+        if warning_banner:
+            metadata["warning_banner"] = warning_banner
+
+        try:
+            validate_evidence_class(metadata)
+        except EvidenceClassError as exc:
+            print(f"EVIDENCE CLASS VALIDATION FAILED: {exc}", file=sys.stderr)
+            return 2
+
         out_dir = output_root / run_id
         write_regime_scorecard_bundle(
             scorecard=scorecard, output_dir=out_dir, bundle_metadata=metadata

--- a/services/validation/arvp_regime_scorecard_runner.py
+++ b/services/validation/arvp_regime_scorecard_runner.py
@@ -19,7 +19,6 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
-import datetime
 import sys
 from pathlib import Path
 
@@ -30,6 +29,7 @@ from core.replay.arvp_regime_scorecards import (
     load_json,
     write_regime_scorecard_bundle,
 )
+from core.utils.clock import utcnow
 from core.utils.evidence_class import (
     EvidenceClassError,
     evidence_class_warning_banner,
@@ -67,7 +67,7 @@ def main(argv: list[str] | None = None) -> int:
 
     evidence_class = str(args.evidence_class)
     warning_banner = evidence_class_warning_banner(evidence_class)
-    now_utc = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    now_utc = utcnow().isoformat()
 
     run_id = str(args.run_id)
     output_root = Path(args.output_dir)

--- a/services/validation/arvp_regime_scorecard_runner.py
+++ b/services/validation/arvp_regime_scorecard_runner.py
@@ -52,7 +52,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     p.add_argument(
         "--evidence-class",
         default=_DEFAULT_EVIDENCE_CLASS,
-        choices=["natural_paper_evidence", "controlled_lab_evidence", "pipeline_test_evidence", "waiver_decision"],
+        choices=["controlled_lab_evidence"],
         help=f"Evidence classification for the output artifact (default: {_DEFAULT_EVIDENCE_CLASS}).",
     )
     return p.parse_args(argv)

--- a/services/validation/arvp_regime_scorecard_runner.py
+++ b/services/validation/arvp_regime_scorecard_runner.py
@@ -101,7 +101,9 @@ def main(argv: list[str] | None = None) -> int:
         # If both are provided, prefer replay-side scorecard as primary output.
         scorecard = scorecards[0]
         out_dir = output_root / run_id
-        write_regime_scorecard_bundle(scorecard=scorecard, output_dir=out_dir)
+        write_regime_scorecard_bundle(
+            scorecard=scorecard, output_dir=out_dir, bundle_metadata=metadata
+        )
     except ARVPRegimeScorecardError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2

--- a/services/validation/paper_reference_window_runner.py
+++ b/services/validation/paper_reference_window_runner.py
@@ -283,22 +283,45 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: paper_reference_window export failed: {exc}", file=sys.stderr)
         return 2
 
-    evidence_class = "natural_paper_evidence"
-    warning_banner = evidence_class_warning_banner(evidence_class)
     now_utc = utcnow().isoformat()
     extracted_by = getattr(request, "extracted_by", "paper_reference_window_runner")
+
+    # Detect stimulus-derived chains: any event payload containing
+    # stimulus_run_id means the window comes from the stimulus runner,
+    # not from natural market conditions (#3129 review).
+    has_stimulus = False
+    for ev in payload.get("events", []):
+        ev_payload = ev.get("payload", {})
+        if isinstance(ev_payload, dict) and ev_payload.get("stimulus_run_id"):
+            has_stimulus = True
+            break
+    if not has_stimulus:
+        for ev in payload.get("causal_context_events", []):
+            ev_payload = ev.get("payload", {})
+            if isinstance(ev_payload, dict) and ev_payload.get("stimulus_run_id"):
+                has_stimulus = True
+                break
+
+    if has_stimulus:
+        evidence_class = "pipeline_test_evidence"
+        payload["pipeline_tool"] = "paper_runtime_stimulus_runner"
+        payload["fixture_source"] = f"extracted_by={extracted_by}"
+    else:
+        evidence_class = "natural_paper_evidence"
+        payload["campaign_id"] = request.strategy_id
+        payload["start_criterion"] = "ledger_export"
+        payload["safety_flags"] = {
+            "mock_trading": True,
+            "dry_run": True,
+            "mexc_testnet": True,
+        }
+        payload["provenance"] = f"extracted_by={extracted_by}@{now_utc}"
+
+    warning_banner = evidence_class_warning_banner(evidence_class)
     payload["evidence_class"] = evidence_class
     payload["evidence_class_version"] = "1.0"
     payload["produced_by"] = "paper_reference_window_runner"
     payload["produced_at_utc"] = now_utc
-    payload["campaign_id"] = request.strategy_id
-    payload["start_criterion"] = "ledger_export"
-    payload["safety_flags"] = {
-        "mock_trading": True,
-        "dry_run": True,
-        "mexc_testnet": True,
-    }
-    payload["provenance"] = f"extracted_by={extracted_by}@{now_utc}"
     if warning_banner:
         payload["warning_banner"] = warning_banner
 

--- a/services/validation/paper_reference_window_runner.py
+++ b/services/validation/paper_reference_window_runner.py
@@ -15,6 +15,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import datetime
 import os
 import sys
 from pathlib import Path
@@ -284,9 +285,19 @@ def main(argv: list[str] | None = None) -> int:
 
     evidence_class = "natural_paper_evidence"
     warning_banner = evidence_class_warning_banner(evidence_class)
+    now_utc = datetime.datetime.now(datetime.timezone.utc).isoformat()
     payload["evidence_class"] = evidence_class
     payload["evidence_class_version"] = "1.0"
     payload["produced_by"] = "paper_reference_window_runner"
+    payload["produced_at_utc"] = now_utc
+    payload["campaign_id"] = request.strategy_id
+    payload["start_criterion"] = "ledger_export"
+    payload["safety_flags"] = {
+        "mock_trading": True,
+        "dry_run": True,
+        "mexc_testnet": True,
+    }
+    payload["provenance"] = f"extracted_by={request.extracted_by}@{now_utc}"
     if warning_banner:
         payload["warning_banner"] = warning_banner
 

--- a/services/validation/paper_reference_window_runner.py
+++ b/services/validation/paper_reference_window_runner.py
@@ -15,7 +15,6 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
-import datetime
 import os
 import sys
 from pathlib import Path
@@ -29,6 +28,7 @@ from core.replay.paper_reference_window_export import (
     build_export_request,
     export_paper_reference_window,
 )
+from core.utils.clock import utcnow
 from core.utils.evidence_class import (
     EvidenceClassError,
     evidence_class_warning_banner,
@@ -285,7 +285,8 @@ def main(argv: list[str] | None = None) -> int:
 
     evidence_class = "natural_paper_evidence"
     warning_banner = evidence_class_warning_banner(evidence_class)
-    now_utc = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    now_utc = utcnow().isoformat()
+    extracted_by = getattr(request, "extracted_by", "paper_reference_window_runner")
     payload["evidence_class"] = evidence_class
     payload["evidence_class_version"] = "1.0"
     payload["produced_by"] = "paper_reference_window_runner"
@@ -297,7 +298,7 @@ def main(argv: list[str] | None = None) -> int:
         "dry_run": True,
         "mexc_testnet": True,
     }
-    payload["provenance"] = f"extracted_by={request.extracted_by}@{now_utc}"
+    payload["provenance"] = f"extracted_by={extracted_by}@{now_utc}"
     if warning_banner:
         payload["warning_banner"] = warning_banner
 

--- a/services/validation/paper_reference_window_runner.py
+++ b/services/validation/paper_reference_window_runner.py
@@ -81,6 +81,13 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         type=int,
         help="Optional later bound for causal post-window SIGNAL lookup (#3058).",
     )
+    p.add_argument(
+        "--chain-source",
+        default="live",
+        choices=["live", "stimulus"],
+        help="Source of the chain: 'live' (natural market, default) or 'stimulus' (synthetic fixture). "
+        "Stimulus chains are classified as pipeline_test_evidence.",
+    )
     return p.parse_args(argv)
 
 
@@ -96,6 +103,7 @@ def _build_source_query_intent(args: argparse.Namespace) -> str:
         qualifiers.append(f"filter bot_id={args.bot_id}")
     if args.config_hash:
         qualifiers.append(f"filter config_hash={args.config_hash}")
+    qualifiers.append(f"chain_source={getattr(args, 'chain_source', 'live')}")
     return "; ".join(qualifiers)
 
 
@@ -286,23 +294,12 @@ def main(argv: list[str] | None = None) -> int:
     now_utc = utcnow().isoformat()
     extracted_by = getattr(request, "extracted_by", "paper_reference_window_runner")
 
-    # Detect stimulus-derived chains: any event payload containing
-    # stimulus_run_id means the window comes from the stimulus runner,
-    # not from natural market conditions (#3129 review).
-    has_stimulus = False
-    for ev in payload.get("events", []):
-        ev_payload = ev.get("payload", {})
-        if isinstance(ev_payload, dict) and ev_payload.get("stimulus_run_id"):
-            has_stimulus = True
-            break
-    if not has_stimulus:
-        for ev in payload.get("causal_context_events", []):
-            ev_payload = ev.get("payload", {})
-            if isinstance(ev_payload, dict) and ev_payload.get("stimulus_run_id"):
-                has_stimulus = True
-                break
-
-    if has_stimulus:
+    # Evidence class is determined by --chain-source CLI arg. Stimulus-runner
+    # chains cannot be detected from persisted ledger fields (stimulus_run_id
+    # is used for UUIDv5 signal-id seeding but never stored), so the operator
+    # must explicitly declare the chain source (#3129 review).
+    chain_source = getattr(args, "chain_source", "live")
+    if chain_source == "stimulus":
         evidence_class = "pipeline_test_evidence"
         payload["pipeline_tool"] = "paper_runtime_stimulus_runner"
         payload["fixture_source"] = f"extracted_by={extracted_by}"
@@ -340,6 +337,7 @@ def main(argv: list[str] | None = None) -> int:
         f"window=[{request.start_ts_ms_utc},{request.end_ts_ms_utc}], "
         f"bot_id={request.bot_id or '*'}, config_hash={request.config_hash or '*'}, "
         f"evidence_class={evidence_class}, "
+        f"chain_source={chain_source}, "
         f"database={readonly_database}, current_user={readonly_current_user}, "
         f"session_user={readonly_session_user})"
     )

--- a/services/validation/paper_reference_window_runner.py
+++ b/services/validation/paper_reference_window_runner.py
@@ -28,6 +28,11 @@ from core.replay.paper_reference_window_export import (
     build_export_request,
     export_paper_reference_window,
 )
+from core.utils.evidence_class import (
+    EvidenceClassError,
+    evidence_class_warning_banner,
+    validate_evidence_class,
+)
 
 _READONLY_DSN_ENV = "POSTGRES_READONLY_PASSWORD_DSN"
 _EXPECTED_READONLY_LOGIN = "cdb_readonly"
@@ -270,7 +275,6 @@ def main(argv: list[str] | None = None) -> int:
         payload = export_paper_reference_window(
             request=request, rows=rows, causal_context_rows=causal_context_rows
         )
-        out_path.write_text(canonical_json_dumps(payload), encoding="utf-8")
     except PaperReferenceExportError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
@@ -278,12 +282,37 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: paper_reference_window export failed: {exc}", file=sys.stderr)
         return 2
 
+    evidence_class = "natural_paper_evidence"
+    warning_banner = evidence_class_warning_banner(evidence_class)
+    evidence_envelope: dict[str, Any] = {
+        "contract_version": payload.get("contract_version"),
+        "strategy_id": payload.get("strategy_id"),
+        "symbol": payload.get("symbol"),
+        "start_ts_ms_utc": payload.get("start_ts_ms_utc"),
+        "end_ts_ms_utc": payload.get("end_ts_ms_utc"),
+        "evidence_class": evidence_class,
+        "evidence_class_version": "1.0",
+        "produced_by": "paper_reference_window_runner",
+    }
+    if warning_banner:
+        evidence_envelope["warning_banner"] = warning_banner
+    evidence_envelope["window"] = payload
+
+    try:
+        validate_evidence_class(evidence_envelope)
+    except EvidenceClassError as exc:
+        print(f"EVIDENCE CLASS VALIDATION FAILED: {exc}", file=sys.stderr)
+        return 2
+
+    out_path.write_text(canonical_json_dumps(evidence_envelope), encoding="utf-8")
+
     readonly_database, readonly_current_user, readonly_session_user = readonly_identity
     print(
         "OK: paper_reference_window exported "
         f"(strategy_id={request.strategy_id}, symbol={request.symbol}, "
         f"window=[{request.start_ts_ms_utc},{request.end_ts_ms_utc}], "
         f"bot_id={request.bot_id or '*'}, config_hash={request.config_hash or '*'}, "
+        f"evidence_class={evidence_class}, "
         f"database={readonly_database}, current_user={readonly_current_user}, "
         f"session_user={readonly_session_user})"
     )

--- a/services/validation/paper_reference_window_runner.py
+++ b/services/validation/paper_reference_window_runner.py
@@ -284,27 +284,19 @@ def main(argv: list[str] | None = None) -> int:
 
     evidence_class = "natural_paper_evidence"
     warning_banner = evidence_class_warning_banner(evidence_class)
-    evidence_envelope: dict[str, Any] = {
-        "contract_version": payload.get("contract_version"),
-        "strategy_id": payload.get("strategy_id"),
-        "symbol": payload.get("symbol"),
-        "start_ts_ms_utc": payload.get("start_ts_ms_utc"),
-        "end_ts_ms_utc": payload.get("end_ts_ms_utc"),
-        "evidence_class": evidence_class,
-        "evidence_class_version": "1.0",
-        "produced_by": "paper_reference_window_runner",
-    }
+    payload["evidence_class"] = evidence_class
+    payload["evidence_class_version"] = "1.0"
+    payload["produced_by"] = "paper_reference_window_runner"
     if warning_banner:
-        evidence_envelope["warning_banner"] = warning_banner
-    evidence_envelope["window"] = payload
+        payload["warning_banner"] = warning_banner
 
     try:
-        validate_evidence_class(evidence_envelope)
+        validate_evidence_class(payload)
     except EvidenceClassError as exc:
         print(f"EVIDENCE CLASS VALIDATION FAILED: {exc}", file=sys.stderr)
         return 2
 
-    out_path.write_text(canonical_json_dumps(evidence_envelope), encoding="utf-8")
+    out_path.write_text(canonical_json_dumps(payload), encoding="utf-8")
 
     readonly_database, readonly_current_user, readonly_session_user = readonly_identity
     print(

--- a/services/validation/paper_runtime_stimulus_runner.py
+++ b/services/validation/paper_runtime_stimulus_runner.py
@@ -6,6 +6,9 @@ a comparison-grade SIGNAL -> DECISION -> ORDER(paper_) -> FILL chain under
 MOCK_TRADING=true / DRY_RUN=true / MEXC_TESTNET=true without modifying any
 service logic or runner contract.
 
+Evidence class: pipeline_test_evidence
+WARNING: Pipeline test only — NOT valid for Product-Complete gate (§5.2.4).
+
 Safety boundaries
 ----------------
 - Never authorises Live-Go or Echtgeld-Go.
@@ -36,9 +39,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
+from core.utils.evidence_class import evidence_class_warning_banner
+
 logger = logging.getLogger("paper_runtime_stimulus_runner")
 
 LR_STATUS = "NO-GO"
+
+EVIDENCE_CLASS = "pipeline_test_evidence"
+EVIDENCE_CLASS_BANNER = evidence_class_warning_banner(EVIDENCE_CLASS)
 
 DEFAULT_FIXTURE_PATH = Path(__file__).resolve().parent.parent.parent / (
     "tests/fixtures/arvp/paper_runtime_stimulus_btcusdt_breakout_v1.json"
@@ -425,6 +433,8 @@ def fixture_summary(
 
     lines = [
         f"=== Fixture Summary ===",
+        f"  evidence_class: {EVIDENCE_CLASS}",
+        f"  warning_banner: {EVIDENCE_CLASS_BANNER}",
         f"  mode: {mode}",
         f"  strategy_id: {spec.strategy_id}",
         f"  symbol: {spec.symbol}",
@@ -507,6 +517,8 @@ def run_preview(
         summary,
         f"=== Preview Mode (no Redis publish) ===",
         f"  intended market_data events: {len(payloads)}",
+        f"  evidence_class: {EVIDENCE_CLASS}",
+        f"  warning_banner: {EVIDENCE_CLASS_BANNER}",
         f"  expected chain target: SIGNAL >= 1, DECISION >= 1, ORDER(paper_) >= 1, FILL >= 1",
         f"  next runtime validation command:",
         f"    python -m services.validation.paper_runtime_stimulus_runner --publish --fixture <path>",
@@ -575,6 +587,8 @@ def run_publish(
     lines = [
         summary,
         f"=== Publish Result ===",
+        f"  evidence_class: {EVIDENCE_CLASS}",
+        f"  warning_banner: {EVIDENCE_CLASS_BANNER}",
         f"  published: {published}/{expected_events} market_data events",
         f"  burst_published: {published - (1 if follow_up_tick_published else 0)}/{len(payloads)}",
         f"  follow_up_tick_published: {follow_up_tick_published}",
@@ -584,6 +598,7 @@ def run_publish(
         f"  stop_after_complete_chain: {stop_after_complete_chain}",
         f"  max_wait_seconds: {max_wait_seconds}",
         f"  LR status: {LR_STATUS}",
+        f"  WARNING: {EVIDENCE_CLASS_BANNER}",
         f"  NOTE: This tool does not authorise Live-Go or Echtgeld-Go.",
         f"  To verify chain formation, query the audit ledger after runtime processes events.",
     ]

--- a/tests/unit/core/test_evidence_class.py
+++ b/tests/unit/core/test_evidence_class.py
@@ -33,7 +33,7 @@ def _minimal_controlled_lab() -> dict:
         "evidence_class_version": "1.0",
         "produced_by": "test_runner",
         "produced_at_utc": "2026-06-12T00:00:00+00:00",
-        "warning_banner": "NOT natural_paper_evidence — cannot satisfy §5.2.4",
+        "warning_banner": "⚠ NOT natural_paper_evidence — cannot satisfy §5.2.4",
         "scenario_source": "test_scenario",
         "reproducibility_contract": "test_fingerprint",
     }
@@ -45,7 +45,7 @@ def _minimal_pipeline_test() -> dict:
         "evidence_class_version": "1.0",
         "produced_by": "test_runner",
         "produced_at_utc": "2026-06-12T00:00:00+00:00",
-        "warning_banner": "Pipeline test only — NOT valid for Product-Complete gate",
+        "warning_banner": "⚠ Pipeline test only — NOT valid for Product-Complete gate",
         "pipeline_tool": "test_tool",
         "fixture_source": "test_fixture",
     }
@@ -57,7 +57,7 @@ def _minimal_waiver() -> dict:
         "evidence_class_version": "1.0",
         "produced_by": "test_runner",
         "produced_at_utc": "2026-06-12T00:00:00+00:00",
-        "warning_banner": "Policy decision — not evidence; requires formal governance vote",
+        "warning_banner": "⚠ Policy decision — not evidence; requires formal governance vote",
         "governance_ref": "test_ref",
         "residual_uncertainties": "test_risk",
     }

--- a/tests/unit/core/test_evidence_class.py
+++ b/tests/unit/core/test_evidence_class.py
@@ -14,31 +14,67 @@ from core.utils.evidence_class import (
 )
 
 
+def _minimal_natural_paper() -> dict:
+    return {
+        "evidence_class": "natural_paper_evidence",
+        "evidence_class_version": "1.0",
+        "produced_by": "test_runner",
+        "produced_at_utc": "2026-06-12T00:00:00+00:00",
+        "campaign_id": "test_campaign",
+        "start_criterion": "manual",
+        "safety_flags": {"mock_trading": True, "dry_run": True, "mexc_testnet": True},
+        "provenance": "test_provenance",
+    }
+
+
+def _minimal_controlled_lab() -> dict:
+    return {
+        "evidence_class": "controlled_lab_evidence",
+        "evidence_class_version": "1.0",
+        "produced_by": "test_runner",
+        "produced_at_utc": "2026-06-12T00:00:00+00:00",
+        "warning_banner": "NOT natural_paper_evidence — cannot satisfy §5.2.4",
+        "scenario_source": "test_scenario",
+        "reproducibility_contract": "test_fingerprint",
+    }
+
+
+def _minimal_pipeline_test() -> dict:
+    return {
+        "evidence_class": "pipeline_test_evidence",
+        "evidence_class_version": "1.0",
+        "produced_by": "test_runner",
+        "produced_at_utc": "2026-06-12T00:00:00+00:00",
+        "warning_banner": "Pipeline test only — NOT valid for Product-Complete gate",
+        "pipeline_tool": "test_tool",
+        "fixture_source": "test_fixture",
+    }
+
+
+def _minimal_waiver() -> dict:
+    return {
+        "evidence_class": "waiver_decision",
+        "evidence_class_version": "1.0",
+        "produced_by": "test_runner",
+        "produced_at_utc": "2026-06-12T00:00:00+00:00",
+        "warning_banner": "Policy decision — not evidence; requires formal governance vote",
+        "governance_ref": "test_ref",
+        "residual_uncertainties": "test_risk",
+    }
+
+
 class TestValidateEvidenceClass:
     def test_natural_paper_evidence_valid(self):
-        artifact = {"evidence_class": "natural_paper_evidence"}
-        validate_evidence_class(artifact)
+        validate_evidence_class(_minimal_natural_paper())
 
     def test_controlled_lab_evidence_with_banner(self):
-        artifact = {
-            "evidence_class": "controlled_lab_evidence",
-            "warning_banner": "NOT natural_paper_evidence — cannot satisfy §5.2.4",
-        }
-        validate_evidence_class(artifact)
+        validate_evidence_class(_minimal_controlled_lab())
 
     def test_pipeline_test_evidence_with_banner(self):
-        artifact = {
-            "evidence_class": "pipeline_test_evidence",
-            "warning_banner": "Pipeline test only — NOT valid for Product-Complete gate",
-        }
-        validate_evidence_class(artifact)
+        validate_evidence_class(_minimal_pipeline_test())
 
     def test_waiver_decision_with_banner(self):
-        artifact = {
-            "evidence_class": "waiver_decision",
-            "warning_banner": "Policy decision — not evidence; requires formal governance vote",
-        }
-        validate_evidence_class(artifact)
+        validate_evidence_class(_minimal_waiver())
 
     def test_missing_evidence_class_fails(self):
         with pytest.raises(EvidenceClassError, match="Missing evidence_class"):
@@ -53,56 +89,93 @@ class TestValidateEvidenceClass:
             validate_evidence_class({"evidence_class": "invalid_class"})
 
     def test_controlled_lab_missing_banner_fails(self):
+        art = _minimal_controlled_lab()
+        art.pop("warning_banner")
         with pytest.raises(EvidenceClassError, match="requires warning banner"):
-            validate_evidence_class(
-                {
-                    "evidence_class": "controlled_lab_evidence",
-                    "warning_banner": "",
-                }
-            )
+            validate_evidence_class(art)
 
     def test_controlled_lab_wrong_banner_fails(self):
+        art = _minimal_controlled_lab()
+        art["warning_banner"] = "some random text"
         with pytest.raises(EvidenceClassError, match="requires warning banner"):
-            validate_evidence_class(
-                {
-                    "evidence_class": "controlled_lab_evidence",
-                    "warning_banner": "some random text",
-                }
-            )
+            validate_evidence_class(art)
 
     def test_pipeline_test_missing_banner_fails(self):
+        art = _minimal_pipeline_test()
+        art.pop("warning_banner")
         with pytest.raises(EvidenceClassError, match="requires warning banner"):
-            validate_evidence_class(
-                {
-                    "evidence_class": "pipeline_test_evidence",
-                    "warning_banner": "",
-                }
-            )
+            validate_evidence_class(art)
 
     def test_waiver_decision_missing_banner_fails(self):
+        art = _minimal_waiver()
+        art.pop("warning_banner")
         with pytest.raises(EvidenceClassError, match="requires warning banner"):
-            validate_evidence_class(
-                {
-                    "evidence_class": "waiver_decision",
-                }
-            )
+            validate_evidence_class(art)
 
     def test_extra_fields_ok(self):
-        validate_evidence_class(
-            {
-                "evidence_class": "natural_paper_evidence",
-                "produced_by": "test",
-                "run_id": "abc123",
-                "some_other_field": "value",
-            }
-        )
+        art = _minimal_natural_paper()
+        art["run_id"] = "abc123"
+        art["some_other_field"] = "value"
+        validate_evidence_class(art)
+
+    def test_missing_evidence_class_version_fails(self):
+        art = _minimal_natural_paper()
+        art.pop("evidence_class_version")
+        with pytest.raises(EvidenceClassError, match="evidence_class_version"):
+            validate_evidence_class(art)
+
+    def test_missing_produced_by_fails(self):
+        art = _minimal_natural_paper()
+        art.pop("produced_by")
+        with pytest.raises(EvidenceClassError, match="produced_by"):
+            validate_evidence_class(art)
+
+    def test_missing_produced_at_utc_fails(self):
+        art = _minimal_natural_paper()
+        art.pop("produced_at_utc")
+        with pytest.raises(EvidenceClassError, match="produced_at_utc"):
+            validate_evidence_class(art)
+
+    def test_missing_natural_paper_per_class_field_fails(self):
+        art = _minimal_natural_paper()
+        art.pop("campaign_id")
+        with pytest.raises(EvidenceClassError, match="campaign_id"):
+            validate_evidence_class(art)
+
+    def test_missing_controlled_lab_per_class_field_fails(self):
+        art = _minimal_controlled_lab()
+        art.pop("scenario_source")
+        with pytest.raises(EvidenceClassError, match="scenario_source"):
+            validate_evidence_class(art)
+
+    def test_missing_pipeline_test_per_class_field_fails(self):
+        art = _minimal_pipeline_test()
+        art.pop("pipeline_tool")
+        with pytest.raises(EvidenceClassError, match="pipeline_tool"):
+            validate_evidence_class(art)
+
+    def test_missing_waiver_per_class_field_fails(self):
+        art = _minimal_waiver()
+        art.pop("governance_ref")
+        with pytest.raises(EvidenceClassError, match="governance_ref"):
+            validate_evidence_class(art)
+
+    def test_blank_produced_by_fails(self):
+        art = _minimal_natural_paper()
+        art["produced_by"] = ""
+        with pytest.raises(EvidenceClassError, match="produced_by"):
+            validate_evidence_class(art)
+
+    def test_blank_produced_at_utc_fails(self):
+        art = _minimal_natural_paper()
+        art["produced_at_utc"] = "   "
+        with pytest.raises(EvidenceClassError, match="produced_at_utc"):
+            validate_evidence_class(art)
 
 
 class TestValidateEvidenceClassOrSkip:
     def test_valid_returns_empty_list(self):
-        errors = validate_evidence_class_or_skip(
-            {"evidence_class": "natural_paper_evidence"}
-        )
+        errors = validate_evidence_class_or_skip(_minimal_natural_paper())
         assert errors == []
 
     def test_invalid_returns_error_list(self):
@@ -119,7 +192,7 @@ class TestValidateEvidenceClassOrSkip:
 
 class TestValidateEvidenceClassFromJson:
     def test_valid_json(self):
-        json_str = json.dumps({"evidence_class": "natural_paper_evidence"})
+        json_str = json.dumps(_minimal_natural_paper())
         validate_evidence_class_from_json(json_str)
 
     def test_invalid_json(self):
@@ -179,13 +252,10 @@ class TestPipelineTestEvidenceCannotBeNaturalPaper:
         assert "pipeline_test_evidence" != "natural_paper_evidence"
 
     def test_pipeline_test_rejected_as_unknown_when_used_as_natural(self):
+        art = _minimal_pipeline_test()
+        art["warning_banner"] = ""
         with pytest.raises(EvidenceClassError, match="requires warning banner"):
-            validate_evidence_class(
-                {
-                    "evidence_class": "pipeline_test_evidence",
-                    "warning_banner": "",
-                }
-            )
+            validate_evidence_class(art)
 
     def test_warning_banner_distinct(self):
         pipeline_banner = evidence_class_warning_banner("pipeline_test_evidence")
@@ -194,9 +264,7 @@ class TestPipelineTestEvidenceCannotBeNaturalPaper:
         assert "Pipeline test only" in pipeline_banner
 
     def test_validate_blocks_silent_upgrade(self):
-        """An artifact labeled pipeline_test_evidence cannot pass as natural_paper_evidence."""
-        artifact = {
-            "evidence_class": "pipeline_test_evidence",
-        }
+        art = _minimal_pipeline_test()
+        art.pop("warning_banner")
         with pytest.raises(EvidenceClassError, match="requires warning banner"):
-            validate_evidence_class(artifact)
+            validate_evidence_class(artifact=art)

--- a/tests/unit/core/test_evidence_class.py
+++ b/tests/unit/core/test_evidence_class.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from core.utils.evidence_class import (
+    EvidenceClassError,
+    evidence_class_warning_banner,
+    is_valid_evidence_class,
+    validate_evidence_class,
+    validate_evidence_class_from_json,
+    validate_evidence_class_or_skip,
+)
+
+
+class TestValidateEvidenceClass:
+    def test_natural_paper_evidence_valid(self):
+        artifact = {"evidence_class": "natural_paper_evidence"}
+        validate_evidence_class(artifact)
+
+    def test_controlled_lab_evidence_with_banner(self):
+        artifact = {
+            "evidence_class": "controlled_lab_evidence",
+            "warning_banner": "NOT natural_paper_evidence — cannot satisfy §5.2.4",
+        }
+        validate_evidence_class(artifact)
+
+    def test_pipeline_test_evidence_with_banner(self):
+        artifact = {
+            "evidence_class": "pipeline_test_evidence",
+            "warning_banner": "Pipeline test only — NOT valid for Product-Complete gate",
+        }
+        validate_evidence_class(artifact)
+
+    def test_waiver_decision_with_banner(self):
+        artifact = {
+            "evidence_class": "waiver_decision",
+            "warning_banner": "Policy decision — not evidence; requires formal governance vote",
+        }
+        validate_evidence_class(artifact)
+
+    def test_missing_evidence_class_fails(self):
+        with pytest.raises(EvidenceClassError, match="Missing evidence_class"):
+            validate_evidence_class({})
+
+    def test_none_evidence_class_fails(self):
+        with pytest.raises(EvidenceClassError, match="Missing evidence_class"):
+            validate_evidence_class({"evidence_class": None})
+
+    def test_unknown_evidence_class_fails(self):
+        with pytest.raises(EvidenceClassError, match="Unknown evidence_class"):
+            validate_evidence_class({"evidence_class": "invalid_class"})
+
+    def test_controlled_lab_missing_banner_fails(self):
+        with pytest.raises(EvidenceClassError, match="requires warning banner"):
+            validate_evidence_class(
+                {
+                    "evidence_class": "controlled_lab_evidence",
+                    "warning_banner": "",
+                }
+            )
+
+    def test_controlled_lab_wrong_banner_fails(self):
+        with pytest.raises(EvidenceClassError, match="requires warning banner"):
+            validate_evidence_class(
+                {
+                    "evidence_class": "controlled_lab_evidence",
+                    "warning_banner": "some random text",
+                }
+            )
+
+    def test_pipeline_test_missing_banner_fails(self):
+        with pytest.raises(EvidenceClassError, match="requires warning banner"):
+            validate_evidence_class(
+                {
+                    "evidence_class": "pipeline_test_evidence",
+                    "warning_banner": "",
+                }
+            )
+
+    def test_waiver_decision_missing_banner_fails(self):
+        with pytest.raises(EvidenceClassError, match="requires warning banner"):
+            validate_evidence_class(
+                {
+                    "evidence_class": "waiver_decision",
+                }
+            )
+
+    def test_extra_fields_ok(self):
+        validate_evidence_class(
+            {
+                "evidence_class": "natural_paper_evidence",
+                "produced_by": "test",
+                "run_id": "abc123",
+                "some_other_field": "value",
+            }
+        )
+
+
+class TestValidateEvidenceClassOrSkip:
+    def test_valid_returns_empty_list(self):
+        errors = validate_evidence_class_or_skip(
+            {"evidence_class": "natural_paper_evidence"}
+        )
+        assert errors == []
+
+    def test_invalid_returns_error_list(self):
+        errors = validate_evidence_class_or_skip({})
+        assert len(errors) == 1
+        assert "Missing evidence_class" in errors[0]
+
+    def test_unknown_returns_error(self):
+        errors = validate_evidence_class_or_skip(
+            {"evidence_class": "invalid_class"}
+        )
+        assert len(errors) == 1
+
+
+class TestValidateEvidenceClassFromJson:
+    def test_valid_json(self):
+        json_str = json.dumps({"evidence_class": "natural_paper_evidence"})
+        validate_evidence_class_from_json(json_str)
+
+    def test_invalid_json(self):
+        with pytest.raises(EvidenceClassError, match="Invalid JSON"):
+            validate_evidence_class_from_json("not json")
+
+    def test_non_dict_json(self):
+        with pytest.raises(EvidenceClassError, match="JSON root must be a dict"):
+            validate_evidence_class_from_json(json.dumps([1, 2, 3]))
+
+    def test_missing_class_in_json(self):
+        with pytest.raises(EvidenceClassError, match="Missing evidence_class"):
+            validate_evidence_class_from_json(json.dumps({"foo": "bar"}))
+
+
+class TestWarningBanner:
+    def test_natural_paper_no_banner(self):
+        assert evidence_class_warning_banner("natural_paper_evidence") == ""
+
+    def test_controlled_lab_banner(self):
+        banner = evidence_class_warning_banner("controlled_lab_evidence")
+        assert "NOT natural_paper_evidence" in banner
+        assert "§5.2.4" in banner
+
+    def test_pipeline_test_banner(self):
+        banner = evidence_class_warning_banner("pipeline_test_evidence")
+        assert "Pipeline test only" in banner
+        assert "Product-Complete" in banner
+
+    def test_waiver_decision_banner(self):
+        banner = evidence_class_warning_banner("waiver_decision")
+        assert "Policy decision" in banner
+        assert "governance vote" in banner
+
+    def test_unknown_class_empty_banner(self):
+        assert evidence_class_warning_banner("unknown_class") == ""
+
+
+class TestIsValidEvidenceClass:
+    def test_valid_classes(self):
+        assert is_valid_evidence_class("natural_paper_evidence")
+        assert is_valid_evidence_class("controlled_lab_evidence")
+        assert is_valid_evidence_class("pipeline_test_evidence")
+        assert is_valid_evidence_class("waiver_decision")
+
+    def test_invalid_classes(self):
+        assert not is_valid_evidence_class("invalid_class")
+        assert not is_valid_evidence_class("")
+        assert not is_valid_evidence_class(None)
+        assert not is_valid_evidence_class("natural-paper-evidence")
+
+
+class TestPipelineTestEvidenceCannotBeNaturalPaper:
+    """Prove pipeline_test_evidence cannot be interpreted as natural_paper_evidence."""
+
+    def test_different_classes(self):
+        assert "pipeline_test_evidence" != "natural_paper_evidence"
+
+    def test_pipeline_test_rejected_as_unknown_when_used_as_natural(self):
+        with pytest.raises(EvidenceClassError, match="requires warning banner"):
+            validate_evidence_class(
+                {
+                    "evidence_class": "pipeline_test_evidence",
+                    "warning_banner": "",
+                }
+            )
+
+    def test_warning_banner_distinct(self):
+        pipeline_banner = evidence_class_warning_banner("pipeline_test_evidence")
+        natural_banner = evidence_class_warning_banner("natural_paper_evidence")
+        assert pipeline_banner != natural_banner
+        assert "Pipeline test only" in pipeline_banner
+
+    def test_validate_blocks_silent_upgrade(self):
+        """An artifact labeled pipeline_test_evidence cannot pass as natural_paper_evidence."""
+        artifact = {
+            "evidence_class": "pipeline_test_evidence",
+        }
+        with pytest.raises(EvidenceClassError, match="requires warning banner"):
+            validate_evidence_class(artifact)

--- a/tools/validate_evidence_class.py
+++ b/tools/validate_evidence_class.py
@@ -76,7 +76,7 @@ def main(argv: list[str] | None = None) -> int:
 
     for path in files:
         if not path.is_file():
-            warnings.append(f"{path}: not a file, skipped")
+            failures.append(f"{path}: not a file")
             continue
 
         try:

--- a/tools/validate_evidence_class.py
+++ b/tools/validate_evidence_class.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""CLI gate for evidence_class metadata validation.
+
+Scans JSON artifact files for valid evidence_class metadata.
+Exit code 0 = all passed, 1 = failures found.
+
+Usage:
+    python tools/validate_evidence_class.py <path> [<path> ...]
+    python tools/validate_evidence_class.py --dir <directory> [--recursive]
+
+Forward-only: does not require historical artifacts to have evidence_class.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from core.utils.evidence_class import (
+    EvidenceClassError,
+    validate_evidence_class,
+)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Validate evidence_class metadata on ARVP evidence artifacts."
+    )
+    p.add_argument("paths", nargs="*", type=Path, help="JSON artifact file paths.")
+    p.add_argument(
+        "--dir",
+        type=Path,
+        help="Scan a directory for JSON artifacts.",
+    )
+    p.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Recursively scan --dir.",
+    )
+    p.add_argument(
+        "--forward-only",
+        action="store_true",
+        default=True,
+        help="Forward-only mode: missing evidence_class is a warning, not a failure (default).",
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        default=False,
+        help="Strict mode: missing evidence_class is a failure.",
+    )
+    return p.parse_args(argv)
+
+
+def _scan_dir(directory: Path, recursive: bool) -> list[Path]:
+    pattern = "**/*.json" if recursive else "*.json"
+    return sorted(directory.glob(pattern))
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    files: list[Path] = list(args.paths)
+    if args.dir:
+        files.extend(_scan_dir(args.dir, args.recursive))
+
+    if not files:
+        print("No files to validate.", file=sys.stderr)
+        return 0
+
+    failures: list[str] = []
+    warnings: list[str] = []
+    passed = 0
+
+    for path in files:
+        if not path.is_file():
+            warnings.append(f"{path}: not a file, skipped")
+            continue
+
+        try:
+            raw = path.read_text(encoding="utf-8")
+            artifact = json.loads(raw)
+        except (json.JSONDecodeError, OSError) as exc:
+            warnings.append(f"{path}: cannot read/parse: {exc}")
+            continue
+
+        if not isinstance(artifact, dict):
+            warnings.append(f"{path}: JSON root is not a dict, skipped")
+            continue
+
+        if "evidence_class" not in artifact:
+            if args.strict:
+                failures.append(f"{path}: missing evidence_class")
+            else:
+                warnings.append(f"{path}: missing evidence_class (forward-only, skipped)")
+            continue
+
+        try:
+            validate_evidence_class(artifact)
+            passed += 1
+        except EvidenceClassError as exc:
+            failures.append(f"{path}: {exc}")
+
+    print(f"Validated: {passed} passed, {len(failures)} failed, {len(warnings)} warnings")
+
+    for w in warnings:
+        print(f"  WARNING: {w}")
+
+    if failures:
+        for f in failures:
+            print(f"  FAIL: {f}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate_evidence_class.py
+++ b/tools/validate_evidence_class.py
@@ -83,11 +83,11 @@ def main(argv: list[str] | None = None) -> int:
             raw = path.read_text(encoding="utf-8")
             artifact = json.loads(raw)
         except (json.JSONDecodeError, OSError) as exc:
-            warnings.append(f"{path}: cannot read/parse: {exc}")
+            failures.append(f"{path}: cannot read/parse: {exc}")
             continue
 
         if not isinstance(artifact, dict):
-            warnings.append(f"{path}: JSON root is not a dict, skipped")
+            failures.append(f"{path}: JSON root is not a dict")
             continue
 
         if "evidence_class" not in artifact:


### PR DESCRIPTION
## Closes #3096

Implements the evidence-class system from #3094/#3127 across all three ARVP runners and adds a pure offline validator, canonical contract doc, CI gate script, and 30 unit tests.

## Refs
- #3094 — Evidence class design source (4 classes defined)
- #3127 — Controlled-lab evidence path design
- #3087 — ARVP Option-E waiver split (remains OPEN/blocked for §5.2.4)

## Delivered
- **core/utils/evidence_class.py**: Pure offline validator (validate, banner lookup, is_valid, JSON parse helpers). No DB/network/runtime dependency.
- **docs/contracts/evidence_class_contract.md**: Canonical contract defining the 4 evidence classes, banner requirements, and enforcement rules.
- **services/validation/paper_runtime_stimulus_runner.py**: Labeled as \pipeline_test_evidence\ with banner in summary/preview/publish output. Synthetic fixture output never qualifies as natural paper.
- **services/validation/paper_reference_window_runner.py**: Wraps exported payload with \
atural_paper_evidence\ envelope; validates before write.
- **services/validation/arvp_regime_scorecard_runner.py**: \--evidence-class\ CLI arg (default \controlled_lab_evidence\); validates and emits metadata.
- **tools/validate_evidence_class.py**: CI gate script (forward-only default, \--strict\ for fail-closed).
- **tests/unit/core/test_evidence_class.py**: 30 unit tests (valid classes, missing/unknown, banner enforcement, JSON parse, silent-upgrade blocking).

## Validation
- All 30 new tests pass (pytest -v tests/unit/core/test_evidence_class.py)
- All 88 existing ARVP tool tests pass (test_arvp_campaign_supervisor + test_arvp_chain_detector)
- ruff lint passes
- No forbidden patterns in new code

## Non-goals
- Does NOT modify arvp_chain_detector.py or arvp_campaign_supervisor.py (those already have evidence_class support; chain detector already emits \vidence_class: natural_paper_evidence\)
- Does NOT close #3087 (ARVP §5.2.4 remains blocked — controlled-lab evidence cannot satisfy natural-paper requirement)
- Does NOT modify campaign state machine, ledger, or DB schema
- Does NOT change existing test fixture structure

## Safety Boundaries
- All new code is pure/offline: no DB, no network, no runtime dependency
- CI gate is forward-only by default to avoid breaking historical artifacts
- LR remains NO-GO; no Live-Go/Echtgeld-Go claims
- Board stage \	rade-capable\ does not authorize live trading

## Restunsicherheiten
- Existing historical artifacts without evidence_class metadata pass the forward-only gate but would fail under \--strict\. No remediation planned — forward-only default is intentional.
- The \--evidence-class\ CLI arg on scorecard runner is not yet backed by a governance audit; enforcement is syntactic, not semantic.