### PR TITLE
docs(governance): prevent Gordon gate regression in MEXC evidence policy

### DIFF
--- a/docs/evidence/mexc_same_venue_data_quality_policy_3091.md
+++ b/docs/evidence/mexc_same_venue_data_quality_policy_3091.md
@@ -204,16 +204,18 @@ insufficient condition for natural_paper_evidence.
 
 ---
 
-## 9. Gordon Checkpoint
+## 9. Active Gate
 
-```
-ASK GORDON BEFORE ANY FUTURE STACK/INFRA EXECUTION:
-- Stack start/stop/restart
-- Docker rebuild after db_writer cursor-persistence patch
-- Redis stream configuration changes
-- DB schema migrations
-- Any action that could disrupt the active capture pipeline
-```
+Gordon/Docker-AI is historical/decommissioned and is not an active operational gate.
+
+For future Docker/Infra/Runtime actions, the active gate is:
+- explicit Jannek Human-GO
+- GitHub-live evidence
+- repo-backed evidence
+- required checks where applicable
+
+No Gordon-based checks apply.
+LR remains NO-GO.
 
 ---
 


### PR DESCRIPTION
## Delivered
- Replace the active `Gordon Checkpoint` section in `docs/evidence/mexc_same_venue_data_quality_policy_3091.md` with the current active gate language.
- Classify Gordon/Docker-AI as historical/decommissioned, not an active operational gate.
- Keep the active gate aligned to explicit Jannek Human-GO, GitHub-live evidence, repo-backed evidence, and required checks where applicable.
- Keep `LR remains NO-GO` explicit.

## Validation
- `git diff --check`
- `rg -n "Gordon Checkpoint|ASK GORDON|Gordon HOLD|Gordon GO" docs/evidence/mexc_same_venue_data_quality_policy_3091.md` (no matches)
- Scope check: diff is limited to `docs/evidence/mexc_same_venue_data_quality_policy_3091.md`

## Safety Boundaries
- Docs-only change; no code, test, DB, Docker, runtime, or MCP mutation.
- LR remains `NO-GO`.
- No Live-Go and no Echtgeld-Go.

## Non-goals
- No broader Gordon re-audit.
- No reopen of #2689 or #2793.
- No changes outside the target evidence document.

## Restunsicherheiten
- Required GitHub checks still need to run on this PR.
- This slice does not change runtime readiness or live-trading posture.

Closes #3135
Refs #3091
Refs #2689
Refs #2793