### PR TITLE
db(governance): allow readonly candle exports for #3091

### DIFF
--- a/docs/runbooks/postgres_least_privilege_rls.md
+++ b/docs/runbooks/postgres_least_privilege_rls.md
@@ -31,6 +31,8 @@ against Issue #741 which scopes both topics.
 | `risk_events` | SELECT | SELECT, INSERT | ALL | Append-only risk decisions |
 | `correlation_ledger` | SELECT | SELECT, INSERT | ALL | Append-only correlation audit trail |
 | `blocked_decisions` | SELECT | SELECT, INSERT | ALL | Append-only blocked decision log |
+| `candles_1m` | SELECT | — | ALL | Persistent 1m OHLCV candle data (#1855); readonly export for #3091 |
+| `candle_backfill_imports` | SELECT | — | ALL | Candle backfill provenance (#1906); readonly audit |
 | `core_secrets_metadata` | SELECT | — | ALL | Governance mirror (no runtime writes) |
 | `audit_trail` | SELECT | — | ALL | Governance mirror (no runtime writes) |
 | `governance_events` | SELECT | — | ALL | Governance mirror (no runtime writes) |
@@ -209,7 +211,9 @@ Check output sections 1-8. The readonly verification must confirm:
 - membership in `cdb_reader`
 - no membership in `cdb_writer` or `cdb_admin`
 - effective `SELECT` on `public.correlation_ledger`
+- effective `SELECT` on `public.candles_1m` (#3091: MEXC same-venue candle export)
 - no effective `INSERT`, `UPDATE`, or `DELETE` on `public.correlation_ledger`
+- no effective `INSERT`, `UPDATE`, or `DELETE` on `public.candles_1m`
 
 ### Step 4: Enforce (deliberate operator step)
 

--- a/infrastructure/database/operator_create_readonly_login.sql
+++ b/infrastructure/database/operator_create_readonly_login.sql
@@ -108,6 +108,21 @@ BEGIN
         RAISE EXCEPTION 'cdb_readonly must not have write privileges on public.correlation_ledger';
     END IF;
 
+    -- #3091: readonly candle export surface must also be accessible.
+    IF to_regclass('public.candles_1m') IS NULL THEN
+        RAISE NOTICE 'public.candles_1m does not exist — candle export surface not verified in this run.';
+    ELSE
+        IF NOT has_table_privilege('cdb_readonly', 'public.candles_1m', 'SELECT') THEN
+            RAISE EXCEPTION 'cdb_readonly must have SELECT on public.candles_1m via cdb_reader';
+        END IF;
+
+        IF has_table_privilege('cdb_readonly', 'public.candles_1m', 'INSERT')
+           OR has_table_privilege('cdb_readonly', 'public.candles_1m', 'UPDATE')
+           OR has_table_privilege('cdb_readonly', 'public.candles_1m', 'DELETE') THEN
+            RAISE EXCEPTION 'cdb_readonly must not have write privileges on public.candles_1m';
+        END IF;
+    END IF;
+
     RAISE NOTICE '---------------------------------------------';
     RAISE NOTICE 'operator_create_readonly_login.sql applied';
     RAISE NOTICE 'cdb_readonly remains operator-managed';

--- a/infrastructure/database/roles_and_grants.sql
+++ b/infrastructure/database/roles_and_grants.sql
@@ -56,6 +56,7 @@ DECLARE
     reader_tables TEXT[] := ARRAY[
         'signals', 'orders', 'trades', 'positions', 'portfolio_snapshots',
         'risk_events', 'correlation_ledger', 'blocked_decisions',
+        'candles_1m', 'candle_backfill_imports',
         'core_secrets_metadata', 'audit_trail', 'governance_events',
         'deployment_approvals_mirror', 'system_config', 'security_policy_refs',
         'schema_version'

--- a/infrastructure/database/verify_privileges.sql
+++ b/infrastructure/database/verify_privileges.sql
@@ -128,6 +128,20 @@ SELECT
 -- GRANT cdb_reader TO cdb_readonly are not reliably visible via
 -- information_schema.table_privileges WHERE grantee = 'cdb_readonly'.
 
+\echo '=== 7b. Effective privileges (cdb_readonly -> public.candles_1m) ==='
+-- #3091: readonly candle export for MEXC same-venue datasets.
+WITH readonly_role AS (
+    SELECT oid
+    FROM pg_roles
+    WHERE rolname = 'cdb_readonly'
+)
+SELECT
+    EXISTS (SELECT 1 FROM readonly_role) AS cdb_readonly_exists,
+    COALESCE((SELECT has_table_privilege(oid, 'public.candles_1m', 'SELECT') FROM readonly_role), false) AS cdb_can_select,
+    COALESCE((SELECT has_table_privilege(oid, 'public.candles_1m', 'INSERT') FROM readonly_role), false) AS cdb_can_insert,
+    COALESCE((SELECT has_table_privilege(oid, 'public.candles_1m', 'UPDATE') FROM readonly_role), false) AS cdb_can_update,
+    COALESCE((SELECT has_table_privilege(oid, 'public.candles_1m', 'DELETE') FROM readonly_role), false) AS cdb_can_delete;
+
 \echo '=== 8. Table privileges (claire_user direct) ==='
 SELECT table_name, privilege_type
 FROM information_schema.table_privileges


### PR DESCRIPTION
Refs #3091
Refs #3086

## Delivered

Extend the existing least-privilege grant and verification contracts so that cdb_readonly inherits SELECT-only access to public.candles_1m (and candle_backfill_imports) via cdb_reader.

## Files changed

| File | Change |
|------|--------|
| roles_and_grants.sql | Added candles_1m and candle_backfill_imports to cdb_reader SELECT-only table list |
| verify_privileges.sql | New section 7b: effective cdb_readonly privileges on public.candles_1m |
| operator_create_readonly_login.sql | Fail-closed check: cdb_readonly has SELECT (and no writes) on public.candles_1m when the table exists |
| postgres_least_privilege_rls.md | Access matrix and verification checklist updated to include candles_1m |

## Why

The current readonly surface covers correlation_ledger but not candles_1m. The MEXC same-venue strict window for #3091 is already DB-qualified (PR #3133), but cdb_readonly cannot SELECT from candles_1m today, blocking the read-only file export step.

## Validation

- git diff --check: PASS
- candles_1m references: 16 across 4 target files
- secret scan: only expected variable-name/table-name references, no real secrets

## Non-goals

- No direct DB apply in this slice.
- No grants directly to cdb_readonly -- all access is via role inheritance.
- No writer/admin membership changes.
- No secrets, no DSNs, no runtime actions.
- No export, no capture.

## Safety Boundaries

- LR remains NO-GO
- No DB apply (contract surfaces only)
- No secrets in diff
- No runtime/Docker actions
- No Live-Go / Echtgeld-Go

## Operator apply still required

After merge, an operator must run roles_and_grants.sql (idempotent) and then verify with verify_privileges.sql so that cdb_readonly actually has SELECT on candles_1m. That step is not automated by this PR.

## Restunsicherheiten

- candle_backfill_imports is also added to the reader list for audit completeness, but the primary need for #3091 is candles_1m.