### PR TITLE
docs(profitability): expand MEXC sample-size evidence for #3032

### DIFF
--- a/docs/evidence/profitability_evidence_packet_primary_breakout_v1_mexc_sample_expansion_3032.json
+++ b/docs/evidence/profitability_evidence_packet_primary_breakout_v1_mexc_sample_expansion_3032.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "profitability_evidence_packet.v1",
+  "evidence_packet_id": "pep-primary-breakout-v1-btcusdt-mexc-sample-expansion-3032",
+  "candidate_id": "cand-primary-breakout-v1-btcusdt-mexc-3032",
+  "generated_at": "2026-06-12T20:00:00Z",
+  "dataset_id": "mexc_sample_expansion_3032_1m_cadence",
+  "dataset_fingerprint": "sha256:b13e24af15539d54e2d7e870121587c56197b3c6505c383e33b748e626490e99",
+  "source_run_refs": [
+    "artifacts/candles/mexc_sample_expansion_3032/dataset_spec.json",
+    "artifacts/candles/mexc_sample_expansion_3032/provenance_manifest.json",
+    "artifacts/candles/mexc_sample_expansion_3032_1m_cadence/dataset_spec.json",
+    "artifacts/candles/mexc_sample_expansion_3032_1m_cadence_regime_calibrated/dataset_spec.json",
+    "artifacts/candles/mexc_sample_expansion_3032_1m_cadence_regime_calibrated/regime_assignment_manifest.json",
+    "artifacts/replay_reports/mexc_sample_expansion_3032/replay-b1472f81e943-0001/report.json",
+    "scripts/profitability/assign_regime_calibrate_3032_expansion.py",
+    "docs/evidence/profitability_execution_economics_primary_breakout_v1_mexc_sample_expansion_3032.json"
+  ],
+  "gross_return": -0.0108940532,
+  "net_return": -0.0168875231,
+  "fees": 562.497528,
+  "spread_cost": 0.0,
+  "slippage_cost": 0.0,
+  "profit_factor": 0.0,
+  "expectancy": -0.0021788106,
+  "win_rate": 0.0,
+  "avg_win": null,
+  "avg_loss": -0.0021788106,
+  "max_drawdown": 0.0168875231,
+  "loss_streak": 5,
+  "trade_count": 5,
+  "regime_scorecard": {
+    "status": "ok",
+    "artifact_ref": "artifacts/candles/mexc_sample_expansion_3032_1m_cadence_regime_calibrated/regime_assignment_manifest.json",
+    "summary": "Regime labels assigned via offline ADX/ATR heuristic with calibrated ATR threshold=52.59 (p75 of this dataset). Distribution: TREND=2676 (35.3%), RANGE=3366 (44.4%), HIGH_VOL_CHAOTIC=1533 (20.2%). Labels are estimated, not runtime-derived."
+  },
+  "scenario_results": [
+    {
+      "scenario_id": "replay_calibrated_atr_p75_52_59",
+      "status": "PASS",
+      "net_return": -0.0168875231,
+      "max_drawdown": 0.0168875231,
+      "notes": "Full replay completed with calibrated ATR=52.59 (p75 of this Jan-2026 BTCUSDT dataset). run_id=replay-b1472f81e943-0001. 10 signals (5 buy + 5 sell), 10 orders, 5 fills, 5 closed trades. deterministic_replay_ok=True. Gate=FAIL (min_closed_trades_total, min_profit_factor, min_expectancy_r). All 5 trades were losses. BTC price dropped from ~$96k to ~$90k during the window."
+    }
+  ],
+  "replay_vs_paper_status": "not_run",
+  "simulator_drift": "not_assessed",
+  "risk_blocks": 0,
+  "kill_switch_events": 0,
+  "recommendation": "PARK",
+  "limitations": [
+    "Only 5 closed trades over 126h (7575 1m candles). While a 25% increase over the prior 4-trade evidence, N=5 remains statistically insufficient for economic assessment.",
+    "Profit factor 0.0 with 0 wins and 5 losses. While directionally negative, 5 trades cannot distinguish strategy failure from an unlucky draw in a bearish window.",
+    "All 5 trades were losses. Average loss was -0.0022R (0.22% per trade). Fees consumed 562.50 USDT (0.06% taker rate on ~$90k BTC).",
+    "Regime labels are estimated via offline ADX/ATR heuristic (calibrated p75 threshold), not runtime-derived. They are controlled_lab_evidence.",
+    "ATR p75 threshold (52.59) is derived from this specific Jan-2026 BTCUSDT MEXC window where BTC was at ~$92k. The prior calibration on Jun-2026 data at ~$60k gave p75=61.82. Threshold is not generalizable without further evidence.",
+    "Dataset window: 2026-01-16T09:39Z to 2026-01-22T22:13Z. BTC price dropped from $95,672 to $89,627 over this week. Strong bearish trend likely contributed to all-loss outcome.",
+    "This is a controlled_lab_evidence artifact only. No production config change, no strategy change, no Live-Go, no Echtgeld-Go."
+  ],
+  "evidence_class": "controlled_lab_evidence",
+  "lr_status": "NO-GO",
+  "board_stage": "trade-capable",
+  "board_stage_note": "Board stage is orthogonal to LR. Does not authorize live trading.",
+  "sample_size_verdict": "insufficient",
+  "sample_size_note": "N=5 trades over 126h is an improvement from N=4 over 58h but remains far below the recommended threshold of >20 trades for economic assessment. Per #3145 recommendation: acquire >10k candles for statistically meaningful trade count.",
+  "parent_issue": "#3032",
+  "child_issue": "#3150"
+}

--- a/docs/evidence/profitability_execution_economics_primary_breakout_v1_mexc_sample_expansion_3032.json
+++ b/docs/evidence/profitability_execution_economics_primary_breakout_v1_mexc_sample_expansion_3032.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "execution_economics_summary.v1",
+  "summary_id": "econ-primary-breakout-v1-btcusdt-mexc-sample-expansion-3032",
+  "evidence_packet_ref": "docs/evidence/profitability_evidence_packet_primary_breakout_v1_mexc_sample_expansion_3032.json",
+  "candidate_id": "cand-primary-breakout-v1-btcusdt-mexc-3032",
+  "generated_at": "2026-06-12T20:00:00Z",
+  "replay_run_id": "replay-b1472f81e943-0001",
+  "dataset_id": "mexc_sample_expansion_3032_1m_cadence",
+  "calibration_variant": {
+    "slug": "atr_p75_52_59",
+    "atr_threshold": 52.59,
+    "selection_rule": "ATR at p75 (75th percentile of this Jan-2026 BTCUSDT ATR distribution). Distribution-based, non-profit-selected. Same methodology as #3145/#3147: p75 rule applied to the new dataset's independent ATR percentile."
+  },
+  "trade_metrics": {
+    "signals_total": 10,
+    "buy_signals_total": 5,
+    "sell_signals_total": 5,
+    "closed_trades_total": 5,
+    "trades_win_count": 0,
+    "trades_loss_count": 5,
+    "win_rate": 0.0
+  },
+  "return_metrics_r": {
+    "gross_return_r": -0.0108940532,
+    "expectancy_r": -0.0021788106,
+    "fee_adjusted_expectancy_r": -0.0033775046,
+    "profit_factor": 0.0,
+    "fee_adjusted_profit_factor": 0.0,
+    "max_drawdown_r": 0.0168875231,
+    "fee_adjusted_max_drawdown_r": 0.0168875231,
+    "avg_win_r": null,
+    "avg_loss_r": -0.0021788106,
+    "largest_win_r": null,
+    "largest_loss_r": -0.0040200316,
+    "fee_adjustment_note": "Pre-fee metrics use r_return from trade dict. Fee-adjusted metrics subtract entry_fee + exit_fee divided by (entry_price * order_size) from each r_return. With 0 wins, all win-related R metrics are null."
+  },
+  "return_metrics_quote": {
+    "gross_pnl_quote": -1029.9821084595,
+    "net_pnl_quote": -1592.4796364595,
+    "fees_total_quote": 562.497528,
+    "order_size": 1.0,
+    "quote_note": "Absolute PnL in USDT quote currency. Fees from execution simulator at taker rate 0.06% per fill (2 fills per round-trip trade x 5 trades = 10 fills)."
+  },
+  "risk_metrics": {
+    "max_drawdown_quote": null,
+    "max_drawdown_quote_available": false,
+    "max_drawdown_quote_note": "Available as r-multiple only. Absolute quote drawdown requires equity curve with per-bar NAV."
+  },
+  "unavailable_metrics": {
+    "sharpe_ratio": null,
+    "sharpe_ratio_note": "Requires return time series.",
+    "sortino_ratio": null,
+    "sortino_ratio_note": "Requires return time series.",
+    "equity_curve": null,
+    "equity_curve_note": "Per-bar equity snapshots not available.",
+    "avg_holding_period_minutes": null,
+    "avg_holding_period_note": "Not summarized by replay runner."
+  },
+  "execution_quality": {
+    "deterministic_replay_ok": true,
+    "data_integrity_ok": true,
+    "risk_blocks": 0,
+    "kill_switch_events": 0
+  },
+  "sample_size_gate": {
+    "verdict": "insufficient",
+    "closed_trades_total": 5,
+    "recommended_threshold": 20,
+    "note": "5 trades over 126h (7575 1m candles) vs prior 4 trades over 58h. 25% trade count increase, 2.2x time extension. Still insufficient for economic assessment. Per #3145: target >10k candles for statistically meaningful trade count (>20 expected). Directional evidence (0 wins, 5 losses) is consistent with a bearish window (BTC -6.3%) but does not constitute strategy validation."
+  },
+  "evidence_gate": {
+    "gate_result": "FAIL",
+    "gate_failed_criteria": [
+      "min_closed_trades_total",
+      "min_profit_factor",
+      "min_expectancy_r"
+    ],
+    "gate_note": "Gate thresholds calibrated for multi-week backtest windows. Expected failure for a 1-week dataset with 5 trades."
+  },
+  "verdict": {
+    "overall": "PARK",
+    "economic_assessment": "Not interpretable at N=5",
+    "improvement_over_prior": "25% more trades (5 vs 4), 2.2x longer window (126h vs 58h), fee data now available. Pipeline improvement confirmed but sample threshold not reached.",
+    "next_recommended_step": "Acquire longer contiguous dataset. Existing 123k BTCUSDT rows span 121 days but are fragmented into segments separated by hours-to-weeks gaps. Largest contiguous 1m-cadenced segment is 7575 rows (126h). A longer runtime capture or gap-tolerant replay mode would be needed for multi-week evidence."
+  },
+  "evidence_class": "controlled_lab_evidence",
+  "lr_status": "NO-GO",
+  "parent_issue": "#3032",
+  "child_issue": "#3150"
+}

--- a/docs/evidence/profitability_mexc_sample_size_expansion_3032.md
+++ b/docs/evidence/profitability_mexc_sample_size_expansion_3032.md
@@ -1,0 +1,210 @@
+# CDB Profitability -- MEXC Sample-Size Expansion Evidence #3032
+
+**Date:** 2026-06-12
+**Parent:** #3032
+**Issue:** #3150
+**Refs:** #3147, #3149, #3145, #3142
+**Status:** Complete -- longer MEXC dataset exported, calibrated, replayed, and evidenced
+
+## Brain Evidence
+
+| Field | Value |
+|-------|-------|
+| `brain_source` | `repo-only` |
+| `brain_status` | `not-used` |
+| `tools_or_queries` | `git fetch`, `git switch`, `gh issue view/create/comment`, `psycopg2` via `POSTGRES_READONLY_PASSWORD_DSN` (readonly SELECT only), `make replay-shadow-run`, `python json.tool` |
+| `records_or_results` | DB inventory: 123,923 BTCUSDT rows, 3718h span, 121 days, 30 gaps >5min. Longest contiguous segment: 9,567 rows (159.5h). Longest 1m-cadenced: 7,575 rows (126.2h). Calibrated ATR p75=52.59. Replay: 10 signals, 5 trades, 0 wins, profit_factor=0.0. |
+| `repo_crosscheck` | `artifacts/candles/mexc_sample_expansion_3032/`, `artifacts/replay_reports/mexc_sample_expansion_3032/replay-b1472f81e943-0001/report.json` |
+| `impact_on_plan` | Sample expanded from 4 to 5 trades (25%), window from 58h to 126h (2.2x). Economics fields now available (#3149). Sample still insufficient; recommendation PARK. |
+| `limitations` | No SurrealDB/Context Brain. All regime labels estimated. N=5 trades insufficient for economic significance. Data fragmented: longest 1m-cadenced window only 7.6k of 123k available rows. |
+
+## Scope and Non-goals
+
+### In scope
+- Inventory readonly `public.candles_1m` for MEXC BTCUSDT 1m coverage.
+- Export longest contiguous strictly 1m-cadenced file-backed dataset.
+- Apply distribution-based regime calibration (ATR p75, same methodology as #3145).
+- Run file-backed replay with #3149 economics output.
+- Produce evidence packet and execution economics JSON.
+- Report sample-size verdict honestly.
+
+### Non-goals
+- No runtime capture.
+- No Docker / compose.
+- No DB writes.
+- No Live-Go, no Echtgeld-Go.
+- No strategy/core/schema changes.
+- No threshold selection by profit.
+- No production config changes.
+
+## DB Inventory
+
+### Coverage
+
+| Metric | Value |
+|--------|-------|
+| Total BTCUSDT rows | 123,923 |
+| Time span | 2026-01-08 to 2026-06-12 (3718h / ~155 days) |
+| Distinct days | 121 |
+| Export principal | `cdb_readonly` |
+| regime_id status | All null (123,923/123,923) |
+
+### Gap Profile
+
+The data has 30 gaps larger than 5 minutes. The two largest:
+- 2026-02-20 → 2026-03-11: 18.8 days (27,003 minutes)
+- 2026-01-29 → 2026-02-14: 15.8 days (22,743 minutes)
+
+Other gaps are 12-48h (likely weekends or capture-service restarts).
+
+### Constraints
+
+- The replay runner requires exact 1m cadence (gap=60,000ms). Sporadic 2-3 minute gaps within segments block replay.
+- Only the longest strictly 1m-cadenced sub-segment is usable for file-backed replay.
+
+## Selected Window
+
+### Selection Rule
+Longest strictly 1m-cadenced contiguous sub-segment of the longest >5min-gap segment (#6).
+
+### Window Metrics
+
+| Metric | Existing (3091) | Expansion | Delta |
+|--------|----------------|-----------|-------|
+| Rows | 3,496 | 7,575 | +117% |
+| Hours | 58.3 | 126.2 | 2.2x |
+| Start UTC | 2026-06-06 13:43 | 2026-01-16 09:39 | -- |
+| End UTC | 2026-06-08 23:58 | 2026-01-22 22:13 | -- |
+| BTC price range | ~$60k | $95,672 → $89,627 | -6.3% |
+| Cadence | 1m strict | 1m strict | same |
+| Venue | MEXC | MEXC | same |
+
+**Note:** Original DB segment #6 had 9,567 rows (159.5h). 1,992 rows (20.8%) were trimmed to achieve strict 1m cadence. The replay runner's cadence validator is stricter than the gap threshold used for segment extraction.
+
+## Calibration
+
+### ATR Threshold Determination
+
+Following the predeclared distribution-based rule from #3145/#3147:
+
+| Statistic | Jan 2026 (BTC ~$92k) | Jun 2026 (BTC ~$60k) |
+|-----------|----------------------|----------------------|
+| ATR p50 | 31.95 USD | 48.01 USD |
+| **ATR p75** | **52.59 USD** | 61.82 USD |
+| ATR p90 | 92.87 USD | 76.84 USD |
+| ATR_pct p50 | 0.0346% | -- |
+| ATR_pct p75 | 0.0578% | -- |
+
+**Selected:** ATR p75 = 52.59 USD (this dataset's 75th percentile). Not profit-optimized. Same methodology as #3145/#3147: distribution-based, not selected by replay outcome.
+
+### Regime Distribution (ATR=52.59)
+
+| Regime | Candles | Percentage |
+|--------|---------|------------|
+| TREND (0) | 2,676 | 35.3% |
+| RANGE (1) | 3,366 | 44.4% |
+| HIGH_VOL_CHAOTIC (2) | 1,533 | 20.2% |
+| CRISIS (3) | 0 | 0.0% |
+
+This is a dramatic improvement over the committed ATR=2.0 which produced 99.5% HVC. 35.3% TREND enables the primary_breakout_v1 strategy to generate entry signals.
+
+## Replay Result
+
+| Metric | Value |
+|--------|-------|
+| Run ID | `replay-b1472f81e943-0001` |
+| Candles processed | 7,575 |
+| Buy signals | 5 |
+| Sell signals | 5 |
+| Orders placed | 10 |
+| Fills recorded | 5 |
+| Closed trades | **5** |
+| Trades won | 0 |
+| Trades lost | 5 |
+| Win rate | 0.0 |
+| Profit factor | 0.0 |
+| Deterministic replay | True |
+| Data integrity | True |
+| Gate result | FAIL |
+
+### Return & PnL
+
+| Metric | Value |
+|--------|-------|
+| Gross return (R) | -0.0109 |
+| Expectancy (R) | -0.0022 |
+| Fee-adj expectancy (R) | -0.0034 |
+| Fee-adj profit factor | 0.0 |
+| Gross PnL (USDT) | -1,029.98 |
+| Net PnL (USDT) | -1,592.48 |
+| Fees paid (USDT) | 562.50 |
+
+### Sample-Size Verdict
+
+**INSUFFICIENT.** N=5 trades over 126h. Per the replay runner's own sample_size_verdict: `weak`. This is a 25% improvement over the prior N=4 (58h) evidence, but remains 4x below the recommended threshold of >20 trades for economic assessment.
+
+## Comparison: 3091 vs Expansion
+
+| Metric | 3091 (#3147) | Expansion (#3150) | Delta |
+|--------|-------------|-------------------|-------|
+| Candles | 3,496 | 7,575 | +117% |
+| Hours | 58.3 | 126.2 | +116% |
+| ATR p75 | 61.82 | 52.59 | -15% |
+| Trades | 4 | 5 | +25% |
+| Wins | 1 | 0 | n/a |
+| Profit factor | 0.517 | 0.0 | n/a |
+| Fee-adj PF | 0.425 | 0.0 | n/a |
+| Net PnL (USDT) | -1,217.31 | -1,592.48 | -31% |
+| Fees (USDT) | 299.28 | 562.50 | +88% |
+
+**Interpretation:** The expansion increased data volume by 2.2x but only produced 25% more trades. The BTC price context shifted from $60k (Jun) to $92k (Jan) — the Jan window was strongly bearish (-6.3% drop), which likely contributed to the all-loss outcome. The sample size remains too small to distinguish strategy weakness from market regime.
+
+## Recommendation
+
+**PARK.** Do not promote. The sample-size expansion succeeded as a pipeline exercise (readonly DB export, calibration, replay, evidence artifacts all work) but failed to reach the sample-size threshold needed for economic assessment.
+
+### What was gained
+
+1. **Pipeline proven at larger scale:** DB inventory, export, cadence filtering, calibration, replay, and evidence production all work end-to-end on a 7.6k-candle dataset.
+2. **Fee economics confirmed:** The #3149 economics fields produce correct fee-adjusted returns. Fees at 0.06% taker rate are significant (562 USDT on 5 trades).
+3. **Data fragmentation understood:** 123k candles exist but are fragmented into 30+ segments. The longest useful segment is 7.6k rows after cadence filtering. This is a **data architecture constraint**, not a strategy or calibration constraint.
+4. **BTCUSDT price context matters:** ATR p75 changes with price level (52.59 at $92k vs 61.82 at $60k). The p75 rule is scale-adapting but produces different absolute thresholds per dataset window.
+
+### What is still needed
+
+1. **Longer contiguous data:** With 123k rows available but fragmented, a gap-tolerant replay mode or continuous capture beyond 1 week would be the fastest path to >20 trades.
+2. **ATR_pct as first-class parameter:** The #3145 recommendation to use ATR_pct (scale-invariant) for regime classification would simplify calibration across BTC price levels. This requires implementation (separate issue).
+3. **Multiple non-overlapping evidence runs:** A single 126h window is insufficient regardless of trade count. Multiple independent windows are needed for any claim of robustness.
+
+## Safety Boundaries
+
+| Boundary | Status |
+|----------|--------|
+| LR status | **NO-GO** |
+| Live-Go | false |
+| Echtgeld-Go | false |
+| DB writes | none |
+| Runtime/Docker | none |
+| Strategy changes | none |
+| Config changes | none |
+| Evidence class | controlled_lab_evidence |
+
+## Produced Artifacts
+
+| Path | Type | Description |
+|------|------|-------------|
+| `artifacts/candles/mexc_sample_expansion_3032/` | Dataset | Raw export (9,567 rows, longest segment #6) |
+| `artifacts/candles/mexc_sample_expansion_3032_1m_cadence/` | Dataset | 1m-cadenced subset (7,575 rows) |
+| `artifacts/candles/mexc_sample_expansion_3032_1m_cadence_regime_calibrated/` | Dataset | Calibrated derived dataset (ATR=52.59) |
+| `artifacts/replay_reports/mexc_sample_expansion_3032/replay-b1472f81e943-0001/` | Replay | Full replay bundle with report.json |
+| `scripts/profitability/assign_regime_calibrate_3032_expansion.py` | Script | Regime assignment for expansion datasets |
+| `docs/evidence/profitability_mexc_sample_size_expansion_3032.md` | Doc | This file |
+| `docs/evidence/profitability_evidence_packet_primary_breakout_v1_mexc_sample_expansion_3032.json` | Evidence | Evidence packet |
+| `docs/evidence/profitability_execution_economics_primary_breakout_v1_mexc_sample_expansion_3032.json` | Evidence | Execution economics |
+
+## Restunsicherheiten
+
+- ATR p75 varies with BTC price level. The Jan window ($92k) and Jun window ($60k) produce different thresholds. Without scale-invariant calibration (ATR_pct), each window requires independent calibration.
+- The all-loss outcome (0/5 wins) in a bearish window says more about market direction than strategy quality. Long-only strategies will struggle in 1-week bearish windows regardless of signal quality.
+- Data fragmentation prevents multi-week contiguous evidence. The root cause (capture-service pauses) is outside this slice's scope.
+- No claim of generalizability across time periods, price levels, or market regimes is made from this single-window evidence.

--- a/scripts/profitability/assign_regime_calibrate_3032_expansion.py
+++ b/scripts/profitability/assign_regime_calibrate_3032_expansion.py
@@ -1,0 +1,359 @@
+"""Generate regime-assigned calibrated dataset for the MEXC sample expansion 3032 dataset.
+
+Uses the predeclared distribution-based calibration rule from #3145/#3147:
+ATR p75 of this specific dataset's ATR distribution.
+
+Usage:
+    python scripts/profitability/assign_regime_calibrate_3032_expansion.py
+    python scripts/profitability/assign_regime_calibrate_3032_expansion.py --verify-only
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+RAW_PATH = Path("artifacts/candles/mexc_sample_expansion_3032/candles.jsonl")
+DERIVED_DIR = Path("artifacts/candles/mexc_sample_expansion_3032_regime_calibrated")
+
+EXPECTED_RAW_SHA256 = "888cfd6bc1b96c53e47ae7be984e7d8a3924207750478f0d1cb4896899b9bd0a"
+
+ADX_PERIOD = 14
+ATR_PERIOD = 14
+ADX_TREND_THRESHOLD = 25.0
+ADX_RANGE_THRESHOLD = 20.0
+CONFIRMATION_BARS = 3
+BUFFER_MAXLEN = max(ADX_PERIOD, ATR_PERIOD) * 5
+
+# ATR p75 on this specific dataset (computed 2026-06-12 via analyze_seg6.py)
+# BTCUSDT at ~$92k in Jan 2026
+ATR_HIGH_VOL_THRESHOLD = 52.59
+
+REGIME_NAME_TO_ID = {
+    "TREND": 0,
+    "RANGE": 1,
+    "HIGH_VOL_CHAOTIC": 2,
+    "CRISIS": 3,
+}
+REGIME_ID_TO_NAME = {v: k for k, v in REGIME_NAME_TO_ID.items()}
+
+
+def compute_atr(candles: list[dict], period: int) -> float | None:
+    if len(candles) < period + 1:
+        return None
+    trs: list[float] = []
+    for i in range(1, len(candles)):
+        cur = candles[i]
+        prev = candles[i - 1]
+        cur_high = float(cur["high"])
+        cur_low = float(cur["low"])
+        prev_close = float(prev["close"])
+        tr = max(
+            cur_high - cur_low,
+            abs(cur_high - prev_close),
+            abs(cur_low - prev_close),
+        )
+        trs.append(tr)
+    atr_val = sum(trs[:period]) / period
+    for tr in trs[period:]:
+        atr_val = (atr_val * (period - 1) + tr) / period
+    return atr_val
+
+
+def compute_adx(candles: list[dict], period: int) -> float | None:
+    if len(candles) < period + 1:
+        return None
+    trs: list[float] = []
+    pdm: list[float] = []
+    ndm: list[float] = []
+    for i in range(1, len(candles)):
+        cur = candles[i]
+        prev = candles[i - 1]
+        cur_high = float(cur["high"])
+        cur_low = float(cur["low"])
+        prev_high = float(prev["high"])
+        prev_low = float(prev["low"])
+        prev_close = float(prev["close"])
+        tr = max(
+            cur_high - cur_low,
+            abs(cur_high - prev_close),
+            abs(cur_low - prev_close),
+        )
+        up_move = cur_high - prev_high
+        down_move = prev_low - cur_low
+        trs.append(tr)
+        pdm.append(up_move if up_move > down_move and up_move > 0 else 0.0)
+        ndm.append(down_move if down_move > up_move and down_move > 0 else 0.0)
+
+    atr_val = sum(trs[:period]) / period
+    pdm_smooth = sum(pdm[:period])
+    ndm_smooth = sum(ndm[:period])
+
+    def _dx(pdm_v: float, ndm_v: float, atr_v: float) -> float:
+        if atr_v == 0:
+            return 0.0
+        pdi = 100.0 * (pdm_v / atr_v)
+        ndi = 100.0 * (ndm_v / atr_v)
+        denom = pdi + ndi
+        if denom == 0:
+            return 0.0
+        return 100.0 * abs(pdi - ndi) / denom
+
+    dxs: list[float] = []
+    for i in range(period):
+        dxs.append(_dx(pdm_smooth, ndm_smooth, atr_val))
+        if i + 1 < period:
+            atr_val = (atr_val * (period - 1) + trs[i + 1]) / period
+            pdm_smooth = (pdm_smooth * (period - 1) + pdm[i + 1]) / period
+            ndm_smooth = (ndm_smooth * (period - 1) + ndm[i + 1]) / period
+
+    adx_val = sum(dxs) / period
+    for i in range(period, len(trs)):
+        atr_val = (atr_val * (period - 1) + trs[i]) / period
+        pdm_smooth = (pdm_smooth * (period - 1) + pdm[i]) / period
+        ndm_smooth = (ndm_smooth * (period - 1) + ndm[i]) / period
+        dx = _dx(pdm_smooth, ndm_smooth, atr_val)
+        adx_val = (adx_val * (period - 1) + dx) / period
+
+    return adx_val
+
+
+def build_derived_candles(
+    raw_candles: list[dict], atr_threshold: float
+) -> tuple[list[dict], Counter[int]]:
+    current_regime = "UNKNOWN"
+    candidate_regime: str | None = None
+    candidate_count = 0
+    assigned_regime_id = 0
+
+    buffer: list[dict] = []
+    derived: list[dict] = []
+
+    for candle in raw_candles:
+        buffer.append(candle)
+        if len(buffer) > BUFFER_MAXLEN:
+            buffer.pop(0)
+
+        adx = compute_adx(buffer, ADX_PERIOD)
+        atr = compute_atr(buffer, ATR_PERIOD)
+
+        if adx is not None and atr is not None:
+            if atr >= atr_threshold:
+                raw_regime = "HIGH_VOL_CHAOTIC"
+            elif adx >= ADX_TREND_THRESHOLD:
+                raw_regime = "TREND"
+            elif adx <= ADX_RANGE_THRESHOLD:
+                raw_regime = "RANGE"
+            else:
+                raw_regime = current_regime
+
+            if raw_regime == current_regime:
+                candidate_count = 0
+            elif candidate_regime != raw_regime:
+                candidate_regime = raw_regime
+                candidate_count = 1
+            else:
+                candidate_count += 1
+
+            if candidate_regime is not None and candidate_count >= CONFIRMATION_BARS:
+                current_regime = candidate_regime
+                candidate_regime = None
+                candidate_count = 0
+
+            assigned_regime_id = REGIME_NAME_TO_ID.get(current_regime, 0)
+        else:
+            assigned_regime_id = 0
+
+        row = dict(candle)
+        row["regime_id"] = assigned_regime_id
+        derived.append(row)
+
+    distribution = Counter(r["regime_id"] for r in derived)
+    return derived, distribution
+
+
+def main() -> int:
+    verify_only = "--verify-only" in sys.argv
+
+    if not RAW_PATH.exists():
+        print(f"ERROR: Raw dataset not found: {RAW_PATH}", file=sys.stderr)
+        return 2
+
+    raw_hasher = hashlib.sha256()
+    raw_candles: list[dict] = []
+    for line in RAW_PATH.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        raw_hasher.update((stripped + "\n").encode("utf-8"))
+        raw_candles.append(json.loads(stripped))
+
+    raw_hash = raw_hasher.hexdigest()
+    if raw_hash != EXPECTED_RAW_SHA256:
+        print(
+            f"ERROR: Raw SHA-256 mismatch.\n"
+            f"Expected: {EXPECTED_RAW_SHA256}\n"
+            f"Got:      {raw_hash}",
+            file=sys.stderr,
+        )
+        return 2
+
+    n_raw = len(raw_candles)
+    print(f"Raw dataset OK: SHA-256={raw_hash}, rows={n_raw}")
+
+    print(f"ATR threshold: {ATR_HIGH_VOL_THRESHOLD} (p75 of this dataset)")
+    print(f"Calibration rule: distribution-based p75 per #3145/#3147")
+
+    if verify_only:
+        print("VERIFY-ONLY: Would generate derived dataset at", DERIVED_DIR)
+        return 0
+
+    derived, distribution = build_derived_candles(raw_candles, ATR_HIGH_VOL_THRESHOLD)
+
+    # Integrity checks
+    null_count = sum(1 for r in derived if r["regime_id"] is None)
+    if null_count > 0:
+        print(f"ERROR: {null_count} rows have null regime_id", file=sys.stderr)
+        return 2
+
+    invalid = [i for i, r in enumerate(derived) if r["regime_id"] not in {0, 1, 2, 3}]
+    if invalid:
+        print(f"ERROR: {len(invalid)} rows have invalid regime_id", file=sys.stderr)
+        return 2
+
+    DERIVED_DIR.mkdir(parents=True, exist_ok=True)
+
+    candles_path = DERIVED_DIR / "candles.jsonl"
+    derived_bytes = 0
+    derived_hasher = hashlib.sha256()
+    with candles_path.open("w") as f:
+        for row in derived:
+            line = json.dumps(row) + "\n"
+            derived_hasher.update(line.encode("utf-8"))
+            f.write(line)
+            derived_bytes += len(line)
+
+    derived_sha256 = derived_hasher.hexdigest()
+
+    print()
+    print("Regime distribution:")
+    total = sum(distribution.values())
+    for rid in sorted(distribution):
+        name = REGIME_ID_TO_NAME.get(rid, "???")
+        count = distribution[rid]
+        pct = count / total * 100
+        print(f"  {name:<20} {count:>6} ({pct:5.1f}%)")
+
+    # Write regime_assignment_manifest.json
+    manifest = {
+        "schema_version": "regime_assignment_manifest.v1",
+        "issue": "#3150",
+        "parent": "#3032",
+        "refs": ["#3142", "#3144", "#3145", "#3147"],
+        "derived_from": {
+            "source_directory": str(RAW_PATH.parent),
+            "source_candles": str(RAW_PATH),
+            "source_sha256": EXPECTED_RAW_SHA256,
+            "source_rows": n_raw,
+        },
+        "method": "offline_heuristic_adx_atr",
+        "method_detail": (
+            "Deterministic offline ADX/ATR regime classification with "
+            f"calibrated ATR threshold={ATR_HIGH_VOL_THRESHOLD} (p75 of this dataset). "
+            "ADX thresholds kept at committed values (trend=25.0, range=20.0). "
+            "Confirmation bars applied per RegimeService logic."
+        ),
+        "calibration_rule": "distribution_based_p75",
+        "calibration_rule_refs": ["#3145", "#3147"],
+        "calibration_note": (
+            "Threshold NOT selected by profit. p75 of this dataset's independent "
+            "ATR(14) distribution, computed on raw candles before any replay. "
+            "Same methodology as #3145/#3147: distribution-based, not profit-optimized."
+        ),
+        "parameters": {
+            "adx_period": ADX_PERIOD,
+            "atr_period": ATR_PERIOD,
+            "adx_trend_threshold": ADX_TREND_THRESHOLD,
+            "adx_range_threshold": ADX_RANGE_THRESHOLD,
+            "atr_high_vol_threshold": ATR_HIGH_VOL_THRESHOLD,
+            "confirmation_bars": CONFIRMATION_BARS,
+            "buffer_maxlen": BUFFER_MAXLEN,
+        },
+        "estimation": True,
+        "estimation_note": (
+            "All regime_id values are estimated via offline ADX/ATR heuristic. "
+            "They are NOT runtime-derived. Evidence class remains "
+            "controlled_lab_evidence."
+        ),
+        "evidence_class": "controlled_lab_evidence",
+        "regime_mapping": {
+            "0": "TREND",
+            "1": "RANGE",
+            "2": "HIGH_VOL_CHAOTIC",
+            "3": "CRISIS",
+        },
+        "regime_distribution": {
+            str(rid): {
+                "regime_name": REGIME_ID_TO_NAME.get(rid, "UNKNOWN"),
+                "count": count,
+            }
+            for rid, count in sorted(distribution.items())
+        },
+        "output_rows": len(derived),
+        "input_output_row_count_match": n_raw == len(derived),
+        "output_sha256": derived_sha256,
+        "deterministic": True,
+        "no_randomness": True,
+        "no_raw_dataset_overwrite": True,
+        "raw_dataset_sha256_unchanged": EXPECTED_RAW_SHA256,
+        "generated_by": "scripts/profitability/assign_regime_calibrate_3032_expansion.py",
+        "generated_for": "Issue #3150 -- Expand MEXC same-venue sample size",
+        "lr_status": "NO-GO",
+        "board_stage": "trade-capable",
+        "board_stage_note": (
+            "Board stage is orthogonal to LR. Does not authorize live trading."
+        ),
+    }
+    manifest_path = DERIVED_DIR / "regime_assignment_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
+
+    # Also write dataset_spec.json for the derived dataset
+    spec = {
+        "spec_version": "1.0",
+        "dataset_id": "mexc_sample_expansion_3032_regime_calibrated",
+        "derived_from": "mexc_sample_expansion_3032",
+        "source": "file",
+        "venue": "mexc",
+        "venue_match": True,
+        "symbol": "BTCUSDT",
+        "interval": "1m",
+        "regime_assigned": True,
+        "regime_calibrated": True,
+        "calibration_rule": "distribution_based_p75",
+        "atr_threshold": ATR_HIGH_VOL_THRESHOLD,
+        "quality": {
+            "total_rows": len(derived),
+            "regime_id_available": True,
+            "all_regime_ids_valid": True,
+        },
+        "sha256": derived_sha256,
+        "evidence_class": "controlled_lab_evidence",
+    }
+    spec_path = DERIVED_DIR / "dataset_spec.json"
+    spec_path.write_text(json.dumps(spec, indent=2, ensure_ascii=False) + "\n")
+
+    print()
+    print(f"Derived dataset: {candles_path}")
+    print(f"  SHA-256: {derived_sha256}")
+    print(f"  Rows: {len(derived)}")
+    print(f"  Files: {DERIVED_DIR.name}/")
+    print("ALL REGIME LABELS ARE ESTIMATED. CONTROLLED_LAB_EVIDENCE ONLY.")
+    print("NO PRODUCTION CONFIG CHANGE. NO THRESHOLD SELECTION BY PROFIT.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #3032, #3150, #3147, #3149

## Delivered
- **DB inventory:** 123,923 BTCUSDT rows (3718h) in public.candles_1m via cdb_readonly
- **Longest 1m-cadenced window:** 7,575 rows (126.2h) exported
- **Calibration:** ATR p75=52.59 (distribution-based rule per #3145/#3147)
- **File-backed replay:** 5 trades, 0 wins, profit_factor=0.0, gate=FAIL
- **Economics (#3149):** fees 562.50 USDT, net PnL -1,592.48 USDT
- **Evidence:** packet + economics + markdown doc produced

## Dataset Coverage
| Metric | Prior (#3147) | Expansion (#3150) | Delta |
|--------|-------------|-------------------|-------|
| Rows | 3,496 | 7,575 | +117% |
| Hours | 58.3 | 126.2 | +116% |
| Trades | 4 | 5 | +25% |
| ATR p75 | 61.82 | 52.59 | BTC price-dependent |

## Replay/Economics Result
- 5 closed trades, 0 winners — all-loss outcome in bearish window (BTC -6.3%)
- Profit factor 0.0, fee-adjusted PF 0.0
- **Sample-size verdict: INSUFFICIENT** — N=5 vs recommended >20

## Safety Boundaries
- No DB writes, no runtime, no Docker
- No strategy/core/config/schema changes
- LR remains NO-GO, no Live-Go, no Echtgeld-Go
- All regime labels: controlled_lab_evidence
- Threshold selected by ATR p75 distribution, not profit

## Non-goals
- No runtime capture, no Docker/compose
- No DB writes, no schema changes
- No strategy behavior change
- No production config change
- No Live-Go, no Echtgeld-Go, no LR status change

## Restunsicherheiten
- Data fragmented into 30+ segments; longest 1m-cadenced block is 7.6k of 123k available rows
- ATR p75 varies with BTC price level; ATR_pct recommended for scale-invariant calibration
- Single-window evidence; no claim of generalizability