### PR TITLE
profitability(#3162): league-table PARK seed for range_mean_reversion_v1

### DIFF
--- a/docs/evidence/profitability_league_table_report_seed_3162.json
+++ b/docs/evidence/profitability_league_table_report_seed_3162.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": "profitability_league_table_report.v1",
+  "report_id": "pltr-range-mr-v1-park-seed-3162",
+  "model_id": "pltm-profitability-v1",
+  "generated_at": "2026-06-13T16:30:00Z",
+  "table_status": "PARTIAL",
+  "candidate_rankings": [
+    {
+      "candidate_id": "cand-primary-breakout-v1-btcusdt-mexc-3032",
+      "rank": 1,
+      "total_score": 0.0,
+      "ranking_ready": false,
+      "net_return": -0.1221562421,
+      "dimension_scores": [
+        {
+          "dimension": "NET_RETURN",
+          "score": 0.0
+        },
+        {
+          "dimension": "ROBUSTNESS",
+          "score": 0.0
+        },
+        {
+          "dimension": "EVIDENCE_COMPLETENESS",
+          "score": 0.0
+        },
+        {
+          "dimension": "SAFETY_STATUS",
+          "score": 0.0
+        },
+        {
+          "dimension": "STRESS_RESILIENCE",
+          "score": 0.0
+        }
+      ],
+      "recommendation": "PARK",
+      "limitations_summary": [
+        "Aggregate economics are materially negative: net_pnl_quote=-9258.98 and fee_adjusted_return_r=-0.122156.",
+        "Evidence class remains controlled_lab_evidence only; no natural-paper evidence exists.",
+        "ranking_ready=false because the repo has no numeric scoring formula for an honest full ranking; zero scores are a fail-closed sentinel, not a comparative metric.",
+        "No promotion, no paper-ready implication, no live-ready implication."
+      ]
+    },
+    {
+      "candidate_id": "cand-range-mean-reversion-v1-btcusdt-mexc",
+      "rank": 2,
+      "total_score": 0.0,
+      "ranking_ready": false,
+      "net_return": -0.8788407991798681,
+      "dimension_scores": [
+        {
+          "dimension": "NET_RETURN",
+          "score": 0.0
+        },
+        {
+          "dimension": "ROBUSTNESS",
+          "score": 0.0
+        },
+        {
+          "dimension": "EVIDENCE_COMPLETENESS",
+          "score": 0.0
+        },
+        {
+          "dimension": "SAFETY_STATUS",
+          "score": 0.0
+        },
+        {
+          "dimension": "STRESS_RESILIENCE",
+          "score": 0.0
+        }
+      ],
+      "recommendation": "PARK",
+      "limitations_summary": [
+        "Aggregate economics are severely negative: net_pnl_quote=-67189.13 and fee_adjusted_return_r=-0.8788.",
+        "Evidence class remains controlled_lab_evidence only; no natural-paper evidence exists.",
+        "ranking_ready=false because the repo has no numeric scoring formula for an honest full ranking; zero scores are a fail-closed sentinel, not a comparative metric.",
+        "No promotion, no paper-ready implication, no live-ready implication.",
+        "Long-only first pass only; short-side blocked (HOLD_SHORT_SIDE_BLOCKER).",
+        "Operational HOLD: parameter set is initial research estimate requiring calibration.",
+        "Single-symbol candidate (BTCUSDT only).",
+        "Win_rate comparison corrected: primary_breakout_v1 actual win_rate is 15.38% (not 51.3% as stated in issue #3162 body)."
+      ]
+    }
+  ],
+  "limitations": [
+    "This is a seed report for two candidates and is intentionally PARTIAL (table_status=PARTIAL).",
+    "The league-table schema requires numeric scores, but the repo does not define a numeric scoring formula; zero scores here are a fail-closed sentinel only.",
+    "The candidates are visible for ranking governance, but not honestly full-rankable yet.",
+    "League-table output is advisory only and cannot authorize promotion, paper deployment, or live capital.",
+    "Both candidates are PARK with ranking_ready=false; no comparative ranking exists despite shown rank positions.",
+    "Range_mean_reversion_v1 is long-only first pass only; short-side blocked.",
+    "Rank positions are static (1=primary_breakout_v1, 2=range_mean_reversion_v1) based solely on net_return_r (less negative is rank 1); this is not a scored ranking.",
+    "A third candidate is recommended for meaningful multi-candidate comparison before a scoring formula can be developed."
+  ]
+}

--- a/docs/evidence/profitability_league_table_seed_range_mean_reversion_v1_3162.json
+++ b/docs/evidence/profitability_league_table_seed_range_mean_reversion_v1_3162.json
@@ -1,0 +1,94 @@
+{
+  "schema_version": "profitability_league_table_seed.v1",
+  "seed_id": "plts-range-mean-revision-v1-3162-park-seed",
+  "generated_at": "2026-06-13T16:30:00Z",
+  "parent_issue": "#3157",
+  "issue": "#3162",
+  "candidate_id": "cand-range-mean-reversion-v1-btcusdt-mexc",
+  "candidate_name": "range_mean_reversion_v1",
+  "source_evidence_refs": [
+    "docs/evidence/profitability_execution_economics_range_mean_reversion_v1_mexc_multi_window_3157.json",
+    "docs/evidence/profitability_evidence_packet_range_mean_reversion_v1_mexc_multi_window_3157.json",
+    "docs/evidence/profitability_candidate_range_mean_reversion_v1_3157.json"
+  ],
+  "contract_refs": [
+    "docs/contracts/profitability_league_table_model.v1.schema.json",
+    "docs/contracts/profitability_league_table_report.v1.schema.json",
+    "docs/strategy/CDB_PROFITABILITY_LEAGUE_TABLE_V1.md",
+    "docs/strategy/CDB_PROFITABILITY_EXECUTION_ECONOMICS_V1.md",
+    "docs/strategy/CDB_PROFITABILITY_ENGINE_CANON.md"
+  ],
+  "evidence_snapshot": {
+    "total_windows": 20,
+    "successful_windows": 20,
+    "windows_with_trades": 20,
+    "closed_trades_total": 443,
+    "trades_win_count": 65,
+    "trades_loss_count": 378,
+    "gross_pnl_quote": -26646.0177176257,
+    "net_pnl_quote": -67189.13382430622,
+    "fees_total_quote": 40543.11610668052,
+    "gross_return_r": -0.3474486865701576,
+    "fee_adjusted_return_r": -0.8788407991798681,
+    "win_rate": 0.14672686230248308,
+    "sample_size_verdict": "PASS",
+    "evidence_class": "controlled_lab_evidence"
+  },
+  "ranking_contract_interpretation": {
+    "allowed_recommendations": [
+      "REJECT",
+      "PARK",
+      "PROMOTE_TO_NEXT_RESEARCH_GATE",
+      "UNSAFE",
+      "NO_RECOMMENDATION"
+    ],
+    "gross_only_ranking_allowed": false,
+    "ranking_ready_required": true,
+    "seed_report_table_status": "PARTIAL",
+    "ranking_ready": false,
+    "reason": "The merged evidence supports an explicit PARK decision, but not an honest full ranking. The report schema requires numeric scores while the repo does not define a numeric scoring formula. This seed therefore uses a fail-closed zero-score sentinel and marks ranking_ready=false."
+  },
+  "classification": {
+    "decision": "PARK",
+    "reject_considered": true,
+    "reject_not_taken_reason": "The candidate remains useful as a second entry in the league table (multi-candidate comparison is a prerequisite for honest ranking). Aggregate economics are severely negative but do not create risk of reputational or capital damage because the candidate is ring-fenced as PARK/controlled_lab_evidence only.",
+    "decision_basis": [
+      "sample-size PASS was reached in controlled-lab evidence (443 closed trades across 20 windows)",
+      "aggregate economics are severely negative: fee_adjusted_return_r=-0.8788, net_pnl=-67189.13",
+      "win_rate (14.67%) is structurally worse than primary_breakout_v1 baseline (15.38%)",
+      "no promotion is allowed",
+      "no natural-paper evidence exists",
+      "the candidate serves as the second league-table entry, enabling cross-candidate comparison"
+    ]
+  },
+  "report_seed_policy": {
+    "total_score_sentinel": 0.0,
+    "dimension_score_sentinel": 0.0,
+    "score_is_comparative": false,
+    "score_note": "Zero scores in the seed report are a fail-closed sentinel for a not-ranking-ready candidate, not a comparative quantitative ranking method."
+  },
+  "safety_boundaries": {
+    "promotion_allowed": false,
+    "live_go": false,
+    "real_money_go": false,
+    "lr_status": "NO-GO",
+    "new_replay_run": false,
+    "db_access": false,
+    "runtime_actions": false,
+    "docker_actions": false,
+    "strategy_change": false,
+    "production_config_change": false
+  },
+  "limitations": [
+    "controlled_lab_evidence only",
+    "windows are independent fragments, not one continuous market history",
+    "public.candles_1m has no source or venue column; MEXC attribution is inherited from prior same-venue evidence",
+    "the league-table report schema requires numeric scores, but the repo does not define a numeric scoring formula",
+    "the report seed therefore uses a fail-closed zero-score sentinel with ranking_ready=false",
+    "range_mean_reversion_v1 is long-only first pass only; short-side blocked (HOLD_SHORT_SIDE_BLOCKER)",
+    "operational HOLD: parameter set is initial research estimate requiring calibration from replay evidence",
+    "operational HOLD: mean reversion in low-volume regime transitions may produce extended losses if regime shifts to TREND mid-trade",
+    "operational HOLD: single-symbol candidate (BTCUSDT only)",
+    "win_rate comparison in issue #3162 body incorrectly states primary_breakout_v1 win_rate as 51.3%; actual committed value is 15.38%"
+  ]
+}

--- a/docs/evidence/profitability_range_mean_reversion_v1_hold_park_decision_3162.md
+++ b/docs/evidence/profitability_range_mean_reversion_v1_hold_park_decision_3162.md
@@ -1,0 +1,78 @@
+# Range Mean Reversion v1: HOLD/PARK Decision
+
+**Issue:** #3162
+**Candidate:** range_mean_reversion_v1 (long-only first pass)
+**Decision:** PARK (with operational HOLD status)
+**Date:** 2026-06-13
+
+---
+
+## Evidence Summary
+
+| Metric | range_mean_reversion_v1 | primary_breakout_v1 (baseline) |
+|---|---|---|
+| Closed trades | 443 | 39 |
+| Win rate | 14.67% | 15.38% |
+| Gross return_r | -0.3474 | -0.0754 |
+| Fee-adjusted return_r | -0.8788 | -0.1222 |
+| Net PnL (quote) | -67,189.13 | -9,258.98 |
+| Windows with trades | 20/20 | 17/20 |
+| Evidence class | controlled_lab_evidence | controlled_lab_evidence |
+
+**Source:** Committed execution economics and evidence packet JSON artifacts (see seed artifact for full refs).
+
+---
+
+## Why PARK (Not REJECT)
+
+1. **useful as a second league-table entry** — a multi-candidate table is prerequisite for future honest ranking.
+2. **no capital risk** — candidate is ring-fenced at controlled_lab_evidence only; LR remains NO-GO.
+3. **short-side is blocked, not rejected** — if the simulator learns short execution, the full long_short hypothesis may produce different results.
+
+---
+
+## Operational HOLD Status
+
+"PARK" is the allowed league-table recommendation enum. "HOLD" is an operational status describing the candidate's development state:
+
+| Aspect | Status | Rationale |
+|---|---|---|
+| Direction | long-only first pass | Short-side blocked (HOLD_SHORT_BLOCKER) |
+| Parameters | initial research estimate | Requires calibration from replay evidence |
+| Symbol universe | BTCUSDT only | Single-symbol v1 |
+| Regime risk | unmitigated | Mean reversion held during TREND/HIGH_VOL_CHAOTIC regime shifts may produce extended adverse moves |
+| Scoring | not rankable | No repo-defined numeric scoring formula |
+
+A HOLD means the candidate is not promoted, not rejected, not live — it is retained for structural comparison and deferred for future scope.
+
+---
+
+## Key Clarification
+
+The issue #3162 body states: *"Primary breakout v1 achieved a 51.3% win rate."* This is incorrect. The committed evidence JSON (`profitability_execution_economics_primary_breakout_v1_mexc_multi_window_3032.json`) shows win_rate = 0.153846 (15.38%). The 51.3% value does not appear in any committed artifact and is not used in this decision.
+
+---
+
+## Regulatory Notes
+
+| Gate | Status |
+|---|---|
+| Live-Go | NO-GO |
+| Echtgeld-Go | NO-GO |
+| Promotion allowed | No |
+| Paper deployment | Not recommended |
+| New replay run | Not required for this decision |
+
+---
+
+## Recommendation
+
+**PARK** range_mean_reversion_v1 in the league table as a second PARK candidate. Create a follow-up issue to select or develop a third league-table candidate before defining a numeric scoring formula.
+
+---
+
+## Artifacts Created
+
+- `docs/evidence/profitability_league_table_seed_range_mean_reversion_v1_3162.json` — seed entry
+- `docs/evidence/profitability_league_table_report_seed_3162.json` — successor multi-candidate report
+- This decision document


### PR DESCRIPTION
## Summary
League-table PARK entry for range_mean_reversion_v1 (long-only first pass), closing #3162.

## Artifacts
- \docs/evidence/profitability_league_table_seed_range_mean_reversion_v1_3162.json\ — seed entry (PARK, ranking_ready=false)
- \docs/evidence/profitability_league_table_report_seed_3162.json\ — successor report with both candidates (PARTIAL, PARK+PARK)
- \docs/evidence/profitability_range_mean_reversion_v1_hold_park_decision_3162.md\ — decision doc

## Safety
- No replay, DB, runtime, Docker, code/config/schema changes
- LR remains NO-GO
- All three artifacts are docs/evidence-only
- Ranking_ready=false (no numeric scoring formula exists)
- Both candidates PARK, neither promotable

## Correction in this PR
Issue #3162 body stated primary_breakout_v1 win_rate as 51.3%. Committed evidence shows 15.38%. The decision doc flags this.

## Predecessor
Seed supersedes \#3153\ seed; evidence chain: #3157 → #3156 → #3032
