### PR TITLE
[ONBOARDING][README] Restore root README as GitHub landing page (#3228)

### DIFF
--- a/.github/CONTROL_PLANE.md
+++ b/.github/CONTROL_PLANE.md
@@ -1,4 +1,6 @@
-# .github — Control Plane Entrypoint
+# .github - Control Plane Entrypoint
+
+This document moved off the `.github` README entrypoint so the root `README.md` remains the public GitHub landing page for the repository.
 
 **Repo:** Claire de Binare (`jannekbuengener/Claire_de_Binare`)
 **Default branch:** `main`

--- a/.github/control-plane/README.md
+++ b/.github/control-plane/README.md
@@ -112,7 +112,7 @@ The validator's `--generate` flag produces `generated/workflow-register.json` �
 
 Future consumers (#1640):
 - `docs/runbooks/GITHUB_WORKFLOW_REGISTER.md` generated from this register
-- `.github/README.md` navigation sections
+- `.github/CONTROL_PLANE.md` navigation sections
 - `GITHUB_CONTROL_PLANE_GRAPH.md` relationship map
 
 Generation must flow through a PR — no silent direct mutation to `main`.
@@ -143,7 +143,7 @@ Full automation as a scheduled GitHub Actions workflow is **#1642 scope**.
 - Initial `workflow-register.json` generation
 
 **Out of scope (linked issues):**
-- `.github/README.md` entrypoint → #1640
+- `.github/CONTROL_PLANE.md` entrypoint -> #1640
 - Human-readable register/graph docs → #1640
 - Path-filter-based changed-surface CI workflow → #1642
 - Anti-drift scheduled scan workflow → #1642

--- a/.github/scripts/backlog_curation.py
+++ b/.github/scripts/backlog_curation.py
@@ -63,14 +63,14 @@ SENSITIVE_TEXT_PATTERNS = (
 WORKFLOW_DOC_SURFACES = {
     "docs/runbooks/CONTROL_REGISTER.md",
     "docs/runbooks/GITHUB_WORKFLOW_REGISTER.md",
-    ".github/README.md",
+    ".github/CONTROL_PLANE.md",
 }
 ARCHITECTURE_SURFACES = {
     "knowledge/ARCHITECTURE_MAP.md",
     "knowledge/governance/SERVICE_CATALOG.md",
 }
 GENERIC_FALLBACK_SURFACES = {
-    ".github/README.md",
+    ".github/CONTROL_PLANE.md",
     "CURRENT_STATUS.md",
     "docs/runbooks/CONTROL_REGISTER.md",
     "docs/runbooks/GITHUB_WORKFLOW_REGISTER.md",
@@ -276,7 +276,7 @@ SURFACE_SPECS = (
         change_hint="Use this to verify workflow-run wiring and artifact handoff compatibility.",
     ),
     SurfaceSpec(
-        path=".github/README.md",
+        path=".github/CONTROL_PLANE.md",
         default_role="background",
         reason="Control-plane entrypoint documenting workflow inventory and where backlog curation fits in the GitHub layer.",
         section_hint="workflow inventory / reporting control signals",
@@ -339,7 +339,7 @@ NEIGHBOR_MAP = {
     ".github/workflows/cdb-backlog-curation.yml": [
         ".github/scripts/backlog_curation.py",
         ".github/workflows/cdb-backlog-anomaly-escalation.yml",
-        ".github/README.md",
+        ".github/CONTROL_PLANE.md",
     ],
     ".github/scripts/backlog_anomaly_escalation.py": [
         ".github/workflows/cdb-backlog-anomaly-escalation.yml",

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -4,7 +4,7 @@
 # is no longer aligned with the current governance label ontology, and the workflow
 # generated noise and occasional ontology drift on current issues.
 # Auto-trigger removed. Retained as workflow_dispatch dispatch stub only.
-# See .github/README.md for current control-plane documentation.
+# See .github/CONTROL_PLANE.md for current control-plane documentation.
 
 name: 'Auto Label Issues'
 
@@ -24,4 +24,4 @@ jobs:
           echo "The live issues: [opened, edited] trigger was removed in #1642."
           echo "Keyword-matching label logic is no longer aligned with the current governance label ontology."
           echo "Auto-trigger removed — dispatch stub only."
-          echo "See .github/README.md for current control-plane documentation."
+          echo "See .github/CONTROL_PLANE.md for current control-plane documentation."

--- a/.github/workflows/comprehensive-issue-labeling.yml
+++ b/.github/workflows/comprehensive-issue-labeling.yml
@@ -6,7 +6,7 @@
 # - Duplicate functionality with auto-label.yml; both fired on every issue event.
 # - No operative benefit for current issues (all outside the hardcoded ranges).
 # Auto-trigger removed. Retained as workflow_dispatch dispatch stub only.
-# See .github/README.md for current control-plane documentation.
+# See .github/CONTROL_PLANE.md for current control-plane documentation.
 
 name: 'Comprehensive Issue Auto-Labeling'
 
@@ -26,4 +26,4 @@ jobs:
           echo "The live issues: [opened, edited] trigger was removed in #1642."
           echo "Hardcoded issue ranges (91-106, 156-200 etc.) are fully obsolete."
           echo "Auto-trigger removed — dispatch stub only."
-          echo "See .github/README.md for current control-plane documentation."
+          echo "See .github/CONTROL_PLANE.md for current control-plane documentation."

--- a/.github/workflows/control-board-routing-label-dispatch.yml
+++ b/.github/workflows/control-board-routing-label-dispatch.yml
@@ -12,7 +12,7 @@
 # `workflow_dispatch` stub only; it does NOT call createDispatchEvent because
 # the consumer listener was intentionally withdrawn.
 # Re-enable per-label dispatch requires a separate scoped issue.
-# See .github/README.md for current control-plane documentation.
+# See .github/CONTROL_PLANE.md for current control-plane documentation.
 
 name: Control Board Routing Label Dispatch
 
@@ -38,4 +38,4 @@ jobs:
           echo "vars.CDB_CONTROL_BOARD_AUTOMATION_ENABLED)."
           echo "This dispatch stub prints the diagnostic only; no Dispatch API"
           echo "calls are performed."
-          echo "See .github/README.md for current control-plane documentation."
+          echo "See .github/CONTROL_PLANE.md for current control-plane documentation."

--- a/.github/workflows/control_board_auto_routing.yml
+++ b/.github/workflows/control_board_auto_routing.yml
@@ -17,7 +17,7 @@
 # `route_control_board.py` requires a GitHub event payload (`issues`,
 # `pull_request`, or `repository_dispatch`) which `workflow_dispatch` does not
 # provide. Re-enable per-event routing requires a separate scoped issue.
-# See .github/README.md for current control-plane documentation.
+# See .github/CONTROL_PLANE.md for current control-plane documentation.
 
 name: Control Board Auto Routing
 
@@ -43,4 +43,4 @@ jobs:
           echo "vars.CDB_CONTROL_BOARD_AUTOMATION_ENABLED)."
           echo "This dispatch stub prints the diagnostic only; no Project API"
           echo "mutations are performed."
-          echo "See .github/README.md for current control-plane documentation."
+          echo "See .github/CONTROL_PLANE.md for current control-plane documentation."

--- a/.github/workflows/issue-governance.yml
+++ b/.github/workflows/issue-governance.yml
@@ -6,7 +6,7 @@
 # runs logged "No phase detected (or unmapped). Skipping." — pure runner noise.
 # Auto-trigger removed. Retained as workflow_dispatch with a deprecation notice
 # job only; the stale github-script logic is removed to avoid a broken manual path.
-# See .github/README.md for current control-plane documentation.
+# See .github/CONTROL_PLANE.md for current control-plane documentation.
 
 name: Issue Governance (Milestones)
 
@@ -25,4 +25,4 @@ jobs:
           echo "⚠️  Issue Governance (Milestones) is deprecated."
           echo "The M1-M9 milestone mapping was retired during milestone consolidation."
           echo "Auto-trigger was removed in #1642 — this job exists only as a safe dispatch stub."
-          echo "See .github/README.md for current control-plane documentation."
+          echo "See .github/CONTROL_PLANE.md for current control-plane documentation."

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # Claire de Binare
 
-Deterministisches, governance-first Trading-System im Working Repo Canon.
-Der aktive Pfad bleibt Shadow/Paper-first; Live-Kapital ist nicht freigegeben.
+Claire de Binare (CDB) ist ein deterministisches, governance-first Trading-System im Working Repo Canon.
+Diese Root-README ist die GitHub-Haupt-Landingpage. Der aktive Pfad bleibt Shadow/Paper-first; Live-Kapital ist nicht freigegeben.
 
-## Current Operating Reality (current main)
+## Start Here
+
+- Neue Entwickler: [`DEVELOPER_ONBOARDING.md`](DEVELOPER_ONBOARDING.md)
+- Kurzer Docs-Index: [`docs/index.md`](docs/index.md)
+- Agenten-Bootloader: [`AGENTS.md`](AGENTS.md) -> [`agents/AGENTS.md`](agents/AGENTS.md)
+- Repo Brain / Context Intelligence: [`docs/surrealdb/README.md`](docs/surrealdb/README.md)
+- GitHub-Control-Plane-Unterdokument: [`.github/CONTROL_PLANE.md`](.github/CONTROL_PLANE.md)
+- Repo-/Engineering-Ledger: [`CURRENT_STATUS.md`](CURRENT_STATUS.md)
+
+## Safety / LR Status
 
 - **Control-Board Stage:** `trade-capable` (Board-Kontext, nicht LR-Freigabe)
 - **Live-Readiness Verdict:** **NO-GO** (SSOT: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`)
@@ -20,7 +29,27 @@ Der aktive Pfad bleibt Shadow/Paper-first; Live-Kapital ist nicht freigegeben.
 
 Stage und LR sind orthogonale Systeme: `trade-capable` autorisiert kein Live-Trading.
 
-## Current-main Landing Snapshot
+## New Developer Entry
+
+- [`DEVELOPER_ONBOARDING.md`](DEVELOPER_ONBOARDING.md) - lokales Setup, Secrets, Stack-Bootstrap
+- [`docs/index.md`](docs/index.md) - kuerzester aktiver Docs-Einstieg
+- [`services/README.md`](services/README.md) - Service-Grenzen und Topologie
+- [`tests/README.md`](tests/README.md) - Test-Taxonomie und Einstiege
+- [`tools/README.md`](tools/README.md) - lokale Helfer, PowerShell Front Door, Diagnosepfade
+
+## Agent Entry
+
+- Bootloader-Reihenfolge: [`AGENTS.md`](AGENTS.md) -> [`agents/AGENTS.md`](agents/AGENTS.md) -> [`agents/OPEN_CODE_AGENTS.md`](agents/OPEN_CODE_AGENTS.md)
+- Status-Surfaces zuerst getrennt lesen: [`docs/runbooks/CONTROL_REGISTER.md`](docs/runbooks/CONTROL_REGISTER.md), [`CURRENT_STATUS.md`](CURRENT_STATUS.md), [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)
+
+## Repo Brain / Context Intelligence
+
+- Context-/MCP-Docs-Index: [`docs/surrealdb/README.md`](docs/surrealdb/README.md)
+- Read-only Preflight fuer lokale Context-Tooling-Pruefung: `make context-doctor`
+- Default posture auf `main`: `PERSIST_ALLOWED=False`, `MUTATION_ALLOWED=False`
+- GitHub-/Repo-Live-Wahrheit gewinnt gegen Brain-/Ledger-Claims; LR bleibt `NO-GO`
+
+## Current-main Snapshot
 
 Auf `origin/main` sind die juengsten Kern-Cluster gelandet, u. a.:
 
@@ -33,7 +62,7 @@ Operatives Cockpit: GitHub Issue `#1445`. Aktiver Engineering-Fokus (nicht exhau
 
 Details und Session-Ledger: `CURRENT_STATUS.md`.
 
-## Canonical Entrypoints
+## Docs / Canonical Entrypoints
 
 1. `docs/runbooks/CONTROL_REGISTER.md`
 2. GitHub Issue `#1445` (inkl. neuestem Wochenkommentar)
@@ -41,17 +70,23 @@ Details und Session-Ledger: `CURRENT_STATUS.md`.
 4. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
 5. `docs/meta/WORKING_REPO_CANON.md`
 6. `agents/AGENTS.md`
+7. `docs/index.md`
+8. `DEVELOPER_ONBOARDING.md`
 
-## Active Main Paths
+## Tooling / Tests / Services
 
-- `core/` — gemeinsame Domain-/Contract-Logik
-- `services/` — laufende Runtime-Services (Signal/Risk/Execution/etc.)
-- `infrastructure/compose/` — Compose-Canon (`compose.blue.yml` + `compose.red.yml`)
-- `docs/runbooks/` — operative Runbooks inkl. Control Register
-- `docs/live-readiness/` — LR-Audit- und Gate-Artefakte
-- `knowledge/` — aktive Knowledge-/Governance-Flaeche
-- `tools/` — PowerShell Front Doors und Ops-Helfer
-- `tests/` — Unit/Integration/E2E/Replay/Chaos
+- Tooling: [`tools/README.md`](tools/README.md)
+- Services: [`services/README.md`](services/README.md)
+- Tests: [`tests/README.md`](tests/README.md)
+
+- `core/` - gemeinsame Domain-/Contract-Logik
+- `services/` - laufende Runtime-Services (Signal/Risk/Execution/etc.)
+- `infrastructure/compose/` - Compose-Canon (`compose.blue.yml` + `compose.red.yml`)
+- `docs/runbooks/` - operative Runbooks inkl. Control Register
+- `docs/live-readiness/` - LR-Audit- und Gate-Artefakte
+- `knowledge/` - aktive Knowledge-/Governance-Flaeche
+- `tools/` - PowerShell Front Doors und Ops-Helfer
+- `tests/` - Unit/Integration/E2E/Replay/Chaos
 
 ## Dev / Test (CI mode, no containers)
 
@@ -86,6 +121,12 @@ Docker CI Lab Baseline:
 ```bash
 docker compose -f infrastructure/compose/base.yml -f infrastructure/compose/test.yml up --abort-on-container-exit
 ```
+
+## .github Control Plane
+
+- Landing-page-Regel: diese Root-README bleibt die Repo-Front-Door.
+- Preserved control-plane doc: [`.github/CONTROL_PLANE.md`](.github/CONTROL_PLANE.md)
+- Deep-dive runbooks: [`docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md`](docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md) and [`docs/runbooks/GITHUB_WORKFLOW_REGISTER.md`](docs/runbooks/GITHUB_WORKFLOW_REGISTER.md)
 
 ## Navigation
 

--- a/docs/governance/GITHUB_CONTROL_PLANE_SEAL.md
+++ b/docs/governance/GITHUB_CONTROL_PLANE_SEAL.md
@@ -3,7 +3,7 @@
 **Authority:** Canonical governance policy for `.github/` changes.
 **Owner:** `@jannekbuengener` (CODEOWNERS)
 **Introduced:** #1643
-**Linked to:** `.github/README.md`, `docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md`
+**Linked to:** `.github/CONTROL_PLANE.md`, `docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md`
 
 ---
 
@@ -48,7 +48,7 @@ Every `.github/` change belongs to exactly one class:
 
 | Class | What it covers | Examples |
 |---|---|---|
-| `doc-only` | Comment, annotation, README update. No workflow/script logic change. | Add `# PARKED` comment; fix typo in `.github/README.md` |
+| `doc-only` | Comment, annotation, README update. No workflow/script logic change. | Add `# PARKED` comment; fix typo in `.github/CONTROL_PLANE.md` |
 | `behavior-neutral` | Rename, reformat, pin action SHA. Triggers, permissions, and outputs unchanged. | Pin action to SHA; normalize YAML indentation |
 | `behavior-change` | Workflow trigger, permission, script logic, or job step change. Runtime output may differ. | Change `schedule:` cron; add `issues: write` permission; modify script logic |
 | `new-surface` | Add a new workflow, script, prompt, command, template, or root file. | New `*.yml` workflow; new script under `scripts/` |
@@ -68,7 +68,7 @@ Sync surfaces that **must** be updated:
 | `doc-only` | None unless the change affects a documented register field |
 | `behavior-neutral` | If rename/move: update register references + graph if coupling changed |
 | `behavior-change` | `GITHUB_WORKFLOW_REGISTER.md` row (trigger/permission/output fields); side effects declared in PR |
-| `new-surface` | New `GITHUB_WORKFLOW_REGISTER.md` entry; `GITHUB_CONTROL_PLANE_GRAPH.md` if new coupling; `.github/README.md` folder layout if new category added |
+| `new-surface` | New `GITHUB_WORKFLOW_REGISTER.md` entry; `GITHUB_CONTROL_PLANE_GRAPH.md` if new coupling; `.github/CONTROL_PLANE.md` folder layout if new category added |
 | `removal/deprecation` | Register status updated; graph coupling removed; `CONTROL_REGISTER.md` if was an active infra workflow |
 | `governance-only` | This seal doc if policy changed; Runbook linked-docs section if reference added |
 
@@ -167,7 +167,7 @@ What keeps this seal working over time:
 
 | Document | Role |
 |---|---|
-| `.github/README.md` | Canonical entrypoint; folder layout; navigation guide |
+| `.github/CONTROL_PLANE.md` | Canonical entrypoint; folder layout; navigation guide |
 | `docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md` | Technical operator guide; pre-edit checklist |
 | `docs/runbooks/GITHUB_WORKFLOW_REGISTER.md` | Full 65-workflow register |
 | `docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md` | Relationship matrix + Mermaid graph |

--- a/docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md
+++ b/docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md
@@ -324,7 +324,7 @@ Legacy copy of `ci.yml`. Coexists silently. Risk of accidental activation. Shoul
 
 ## 10. Cross-links
 
-- `.github/README.md` — canonical entrypoint
+- `.github/CONTROL_PLANE.md` — canonical entrypoint
 - `docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md` — how to read and debug workflows
 - `docs/runbooks/GITHUB_WORKFLOW_REGISTER.md` — full 65-workflow register
 - `docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md` § "Issue templates as control-plane surface" — intake/policy depth

--- a/docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md
+++ b/docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md
@@ -3,7 +3,7 @@
 **Repo:** Claire de Binare
 **Scope:** `.github/` — workflows, scripts, prompts, commands, templates, collection layer
 **SSOT for stage/LR:** `docs/runbooks/CONTROL_REGISTER.md` + `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-**Canonical entrypoint:** `.github/README.md`
+**Canonical entrypoint:** `.github/CONTROL_PLANE.md`
 
 ---
 
@@ -30,7 +30,7 @@ Layer 3: Collection manifest (introduced #1644)
   .github/control-plane/generated/workflow-register.json
 
 Layer 4: Documentation (introduced #1640)
-  .github/README.md            Canonical entrypoint
+  .github/CONTROL_PLANE.md     Canonical entrypoint
   docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md  (this file)
   docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
   docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md
@@ -62,7 +62,7 @@ Issue templates under `.github/ISSUE_TEMPLATE/` are in-scope control-plane asset
 
 Cross-reference:
 - `docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md` (`Workflow -> Issue Template Relationships`)
-- `.github/README.md` (`Issue templates as control-plane surface (in scope)`)
+- `.github/CONTROL_PLANE.md` (`Issue templates as control-plane surface (in scope)`)
 - `docs/runbooks/GITHUB_WORKFLOW_REGISTER.md` (`#1640 minimum-field coverage model`)
 
 ## 1b. Merge and closure guardrail (Option A / #1661)
@@ -324,7 +324,7 @@ pytest tests/test_control_plane.py -v
 
 ## 9. Linked documentation
 
-- `.github/README.md` — canonical entrypoint with folder layout
+- `.github/CONTROL_PLANE.md` — canonical entrypoint with folder layout
 - `docs/runbooks/GITHUB_WORKFLOW_REGISTER.md` — full 66-workflow register
 - `docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md` — relationship matrix + Mermaid graph
 - `.github/control-plane/README.md` — collection layer usage

--- a/docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
+++ b/docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
@@ -6,7 +6,7 @@
 **Non-workflow file in `/workflows/`:** `labels.json` (label spec — consumed by `sync-labels.yml`)
 
 **Related docs:**
-- `.github/README.md` — folder layout and navigation
+- `.github/CONTROL_PLANE.md` — folder layout and navigation
 - `docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md` — how to read and edit workflows
 - `docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md` — relationship matrix + Mermaid graph
 - `docs/runbooks/CONTROL_REGISTER.md` — Board stage, LR verdict, active infra workflows
@@ -53,7 +53,7 @@ If a field cannot be resolved from row + profile + override, treat it as **not s
 ### Register-wide defaults (all workflow entries)
 
 - **Owner:** `@jannekbuengener` via `.github/CODEOWNERS`
-- **Canonical doc set:** `.github/README.md`, this register, `docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md`, `docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md`
+- **Canonical doc set:** `.github/CONTROL_PLANE.md`, this register, `docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md`, `docs/runbooks/GITHUB_CONTROL_PLANE_GRAPH.md`
 - **Human review rule:** merge/closure decisions are human-gated; no automatic acceptance inference from this document alone
 
 ### Permission and primary-input profiles

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -68,4 +68,4 @@ Stage `trade-capable` autorisiert kein Live-Trading.
 
 - [`../index.md`](../index.md) — Docs-Hub
 - [`../../knowledge/runbooks/README.md`](../../knowledge/runbooks/README.md) — Knowledge-Runbooks (operating rules)
-- [`../../.github/README.md`](../../.github/README.md) — Control plane entry
+- [`../../.github/CONTROL_PLANE.md`](../../.github/CONTROL_PLANE.md) — Control plane entry


### PR DESCRIPTION
## Summary
- restore root `README.md` as the repo landing page by removing the `.github/README.md` entrypoint
- preserve the `.github` control-plane documentation under `.github/CONTROL_PLANE.md`
- update active internal control-plane references to the new path and sharpen the root README entry chain for developers and agents

## Changed files
- `README.md`
- `.github/CONTROL_PLANE.md` (renamed from `.github/README.md`)
- active control-plane references: `.github/control-plane/README.md`, `.github/scripts/backlog_curation.py`, selected `.github/workflows/*.yml`, `docs/runbooks/*.md`, `docs/governance/GITHUB_CONTROL_PLANE_SEAL.md`

## GitHub README priority before/after
- Before: `gh api repos/jannekbuengener/Claire_de_Binare/readme` returned `path: .github/README.md`
- After this PR: `.github/README.md` no longer exists; expected post-merge repo landing path is `README.md`

## Validation
- `git diff --check`
- `rg -n "\.github/README\.md" README.md docs .github mcp_navpack_working_repo`
- `ruff check .` -> blocked only by pre-existing untracked `.opencode/plans/validate_comments.py:1` (`E401`, scope-fremd)
- `gh api repos/jannekbuengener/Claire_de_Binare/readme` executed pre-change to prove the current landing-page override

## Scope boundaries
- docs/control-plane path and landing-page navigation only
- no runtime, Docker, trading, live, LR, secrets, or DB/memory write changes
- no full repair of `DEVELOPER_ONBOARDING.md`, `docs/index.md`, navpack, or repo-brain onboarding beyond direct root-entry visibility
- historical audit evidence in `docs/evidence/onboarding_readme_navigation_audit_3227.md` intentionally remains unchanged where it records the pre-fix state

## LR / Safety statement
- LR remains `NO-GO`
- Board stage `trade-capable` remains orthogonal to LR and is not Live-Go
- no Echtgeld-Go, no runtime activation

Refs #3228
