### PR TITLE
[ONBOARDING][DX] Add visual developer start examples and templates (#3238)

### DIFF
--- a/docs/onboarding/DEVELOPER_VISUAL_START_HERE.md
+++ b/docs/onboarding/DEVELOPER_VISUAL_START_HERE.md
@@ -1,0 +1,119 @@
+# CDB Developer Visual Start Here
+
+Status: Orientation
+Issue: #3238
+Scope: Developer onboarding, examples, templates, and visual docs only
+
+## What Is CDB?
+
+Claire de Binare (CDB) is a deterministic, governance-first trading-system repo.
+The working repo is the active canon for code, docs, governance, agent bootloader,
+and Context Intelligence navigation. The active development posture stays
+shadow/paper-first: `trade-capable` is Board context, not Live-Go.
+
+Docs/UI sind Orientierung, keine Autoritaet. The canonical sources remain the
+repo files and GitHub live state named by the bootloader, governance docs, and
+status surfaces.
+
+## Start Path For New Developers
+
+Use this path when you have a fresh checkout and need a human-friendly overview
+before touching implementation work.
+
+1. Read the root landing page: [`../../README.md`](../../README.md).
+2. Read the shortest docs index: [`../index.md`](../index.md).
+3. Read the developer setup guide: [`../../DEVELOPER_ONBOARDING.md`](../../DEVELOPER_ONBOARDING.md).
+4. Read service, test, and tool indexes when they match your task:
+   [`../../services/README.md`](../../services/README.md),
+   [`../../tests/README.md`](../../tests/README.md),
+   [`../../tools/README.md`](../../tools/README.md).
+5. Use the examples in [`examples/README.md`](examples/README.md) before drafting
+   your first issue-to-PR workflow.
+6. Use the templates in [`templates/`](templates/) for prompts, evidence docs,
+   and docs/onboarding PR bodies.
+
+## Start Path For Agents
+
+Use this path when the actor is an AI coding agent or a human preparing an
+agent prompt.
+
+1. Resolve the bootloader: [`../../AGENTS.md`](../../AGENTS.md) ->
+   [`../../agents/AGENTS.md`](../../agents/AGENTS.md) ->
+   [`../../agents/OPEN_CODE_AGENTS.md`](../../agents/OPEN_CODE_AGENTS.md).
+2. Read the full Read Order from `agents/AGENTS.md` before planning.
+3. If scope includes Context, SurrealDB, MCP, DB-backed memory, or evidence,
+   output the Brain Evidence block before the plan.
+4. Prefer verified Context/MCP evidence when available; otherwise declare
+   `brain_source=repo-only` and use repo/GitHub live cross-checks.
+5. For issue work, verify GitHub live state before writing.
+6. Respect the single-writer lock and issue/PR comments required by
+   `CDB_AGENT_POLICY.md` section 4.
+
+## Safety And LR Boundaries
+
+- LR bleibt NO-GO.
+- Board stage `trade-capable` is not Live-Go.
+- No Echtgeld-Go.
+- No real GUI, web app, Streamlit, Grafana, React, Vite, screenshots, or runtime
+  surface is created by this pack.
+- No Docker, runtime, service, strategy, risk, execution, trading, LR, productive
+  DB, or memory-write change is included.
+- `CURRENT_STATUS.md` is a repo/engineering ledger, not GitHub live truth.
+- GitHub live and repo live evidence win over Brain, memory, or ledger claims.
+
+## Developer Onboarding Flow
+
+Mermaid source: [`diagrams/cdb_developer_flow.mmd`](diagrams/cdb_developer_flow.mmd).
+
+```mermaid
+flowchart TD
+    A[Root README] --> B[Visual Start]
+    B --> C[Developer Onboarding]
+    B --> D[Docs Index]
+    C --> E[Choose Small Issue]
+    D --> E
+    E --> F[Create Branch]
+    F --> G[Make Scoped Docs Change]
+    G --> H[Run Validation]
+    H --> I[Open PR]
+    I --> J[Required Checks Green]
+    J --> K[Merge After Scope Review]
+    K --> L[Comment And Close Issue]
+```
+
+## Repo Brain / Context Intelligence Flow
+
+Mermaid source: [`diagrams/cdb_repo_brain_flow.mmd`](diagrams/cdb_repo_brain_flow.mmd).
+
+```mermaid
+flowchart TD
+    A[Task Scope] --> B[Bootloader Read Order]
+    B --> C[Brain Evidence Gate]
+    C --> D{Verified Context or DB records?}
+    D -- Yes --> E[Use Record-Backed Orientation]
+    D -- No --> F[Declare repo-only fallback]
+    E --> G[Cross-check Repo Files]
+    F --> G
+    G --> H[Cross-check GitHub Live]
+    H --> I[Plan Within Scope]
+    I --> J[No Live-Go / No Echtgeld-Go]
+```
+
+## Examples And Templates
+
+- Examples index: [`examples/README.md`](examples/README.md)
+- First issue-to-PR flow: [`examples/first_issue_to_pr_flow.md`](examples/first_issue_to_pr_flow.md)
+- First Repo Brain / Context use: [`examples/repo_brain_first_use.md`](examples/repo_brain_first_use.md)
+- Agent prompt template: [`templates/agent_prompt_template.md`](templates/agent_prompt_template.md)
+- Evidence doc template: [`templates/evidence_doc_template.md`](templates/evidence_doc_template.md)
+- PR body template: [`templates/pr_body_template.md`](templates/pr_body_template.md)
+
+## Authority Boundary
+
+This pack is a developer-facing start surface. It does not replace:
+
+- Governance canon under `knowledge/governance/`
+- The agent bootloader in `AGENTS.md` and `agents/AGENTS.md`
+- GitHub live issue/PR state
+- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for Echtgeld Go/No-Go
+- `docs/runbooks/CONTROL_REGISTER.md` for Board stage and operating focus

--- a/docs/onboarding/diagrams/cdb_developer_flow.mmd
+++ b/docs/onboarding/diagrams/cdb_developer_flow.mmd
@@ -1,0 +1,13 @@
+flowchart TD
+    A[Root README] --> B[Visual Start]
+    B --> C[Developer Onboarding]
+    B --> D[Docs Index]
+    C --> E[Choose Small Issue]
+    D --> E
+    E --> F[Create Branch]
+    F --> G[Make Scoped Docs Change]
+    G --> H[Run Validation]
+    H --> I[Open PR]
+    I --> J[Required Checks Green]
+    J --> K[Merge After Scope Review]
+    K --> L[Comment And Close Issue]

--- a/docs/onboarding/diagrams/cdb_repo_brain_flow.mmd
+++ b/docs/onboarding/diagrams/cdb_repo_brain_flow.mmd
@@ -1,0 +1,11 @@
+flowchart TD
+    A[Task Scope] --> B[Bootloader Read Order]
+    B --> C[Brain Evidence Gate]
+    C --> D{Verified Context or DB records?}
+    D -- Yes --> E[Use Record-Backed Orientation]
+    D -- No --> F[Declare repo-only fallback]
+    E --> G[Cross-check Repo Files]
+    F --> G
+    G --> H[Cross-check GitHub Live]
+    H --> I[Plan Within Scope]
+    I --> J[No Live-Go / No Echtgeld-Go]

--- a/docs/onboarding/examples/README.md
+++ b/docs/onboarding/examples/README.md
@@ -1,0 +1,38 @@
+# Onboarding Examples
+
+Status: Orientation
+Issue: #3238
+
+These examples show the smallest useful CDB developer workflows. They are
+written for docs/onboarding and do not authorize runtime, Docker, trading,
+productive DB, memory-write, or LR changes.
+
+Docs/UI sind Orientierung, keine Autoritaet. LR bleibt NO-GO. No Live-Go. No
+Echtgeld-Go.
+
+## Available Examples
+
+| Example | Use it when | File |
+|---|---|---|
+| First issue flow | You need to read one scoped issue, verify live state, set LOCK/START, branch, and make a bounded change | [`first_issue_to_pr_flow.md`](first_issue_to_pr_flow.md) |
+| First PR flow | You need to validate, commit, push, open a PR, wait for checks, merge, and comment the issue | [`first_issue_to_pr_flow.md`](first_issue_to_pr_flow.md) |
+| Repo Brain first use | You need to use Context Intelligence or Repo Brain as read-only orientation without DB-backed claims | [`repo_brain_first_use.md`](repo_brain_first_use.md) |
+
+## Which Example Should I Use?
+
+Use the first issue-to-PR flow when the task is already approved, bounded, and
+issue-driven.
+
+Use the Repo Brain first-use example when the task mentions Context,
+SurrealDB, MCP, evidence, memory, or agent onboarding and you must decide
+whether verified records exist or whether to fall back to repo-only evidence.
+
+## What Is Deliberately Not Included?
+
+- No real GUI or web app buildout.
+- No screenshots or visual asset generation.
+- No Docker or runtime startup path.
+- No service, trading, risk, execution, strategy, or LR implementation path.
+- No productive DB or memory-write path.
+- No credential values or environment-specific private material.
+- No replacement for governance, bootloader, or GitHub live truth.

--- a/docs/onboarding/examples/first_issue_to_pr_flow.md
+++ b/docs/onboarding/examples/first_issue_to_pr_flow.md
@@ -1,0 +1,119 @@
+# Example: First Issue To PR Flow
+
+Status: Orientation
+Issue: #3238
+
+This example shows a conservative CDB docs-slice delivery path. Adjust paths,
+issue numbers, validation, and closure wording to the actual task.
+
+Docs/UI sind Orientierung, keine Autoritaet. LR bleibt NO-GO. No Live-Go. No
+Echtgeld-Go.
+
+## 1. Read The Issue And Canon First
+
+Start with the issue, but do not trust issue prose alone.
+
+Required shape:
+
+1. Resolve the bootloader: `AGENTS.md` -> `agents/AGENTS.md` -> full Read Order.
+2. Read `CDB_AGENT_POLICY.md` section 4 before write-zone work.
+3. Read `docs/runbooks/CONTROL_REGISTER.md`, `CURRENT_STATUS.md`, and
+   `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` as separate status
+   surfaces.
+4. Pull GitHub live state for the target issue, related issues, and open PRs.
+
+Governance reminders:
+
+- GitHub live comes before ledger state.
+- `CURRENT_STATUS.md` is a ledger, not live truth.
+- Board stage `trade-capable` is not Live-Go.
+- LR bleibt NO-GO.
+
+## 2. Verify The Clean Start Surface
+
+Example command shape:
+
+```bash
+git fetch origin --prune
+git status -sb
+git rev-parse HEAD
+git rev-parse origin/main
+git branch --show-current
+gh issue view <issue> --json number,title,state,labels,body,comments
+gh pr list --state open --limit 20
+```
+
+Stop if the repo is not on `main`, local `main` differs from `origin/main`, the
+issue is closed, a matching open PR already exists, or scope drifts into GUI,
+runtime, Docker, trading, live, DB write, memory write, or LR changes.
+
+## 3. Lock, Branch, And Change
+
+Post the single-writer lock before becoming the issue writer:
+
+```text
+LOCK: agent=<agent-id> issue=#<issue> ts=<ISO8601> mode=single-writer
+
+START: <one-sentence scoped task and safety boundary>
+```
+
+Create a branch from current `main`:
+
+```bash
+git switch -c docs/<short-scope>-<issue>
+```
+
+Make the smallest docs change that satisfies the issue. Avoid opportunistic
+cleanup in adjacent docs unless the issue explicitly asks for it.
+
+## 4. Validate Locally
+
+Use the validation required by the issue. For docs-only slices this often means:
+
+```bash
+git diff --check
+rg -n "Live-Go|Echtgeld-Go|LR bleibt NO-GO|Docs/UI sind Orientierung" docs/<scope>
+ruff check .
+```
+
+Run the repo's agreed sensitive-term scan for the changed docs path as a
+separate validation step, and investigate any hit before publishing.
+
+If a validation failure is caused by known unrelated untracked files, document it
+as scope-fremd and do not fix it inside the issue unless explicitly instructed.
+
+## 5. Commit, Push, And Open PR
+
+Use a narrow commit message:
+
+```bash
+git add docs/<scope>
+git commit -m "docs(onboarding): add visual developer start pack"
+git push -u origin docs/<short-scope>-<issue>
+```
+
+PR body should include summary, changed files, validation, scope boundaries,
+Safety/LR statement, and issue links. Use
+[`../templates/pr_body_template.md`](../templates/pr_body_template.md) as the
+starting point.
+
+## 6. Wait For Checks And Merge Only If Safe
+
+Before merge:
+
+1. Required checks are green.
+2. Diff remains in scope.
+3. No new stop condition appeared in comments or checks.
+4. No live, runtime, Docker, trading, DB write, memory write, or LR change was
+   introduced.
+
+Use squash merge only when the repo rules and required checks allow it.
+
+## 7. Comment And Close
+
+After merge, comment on the target issue with the PR link, commit, validation,
+and scope boundary. Close the issue only when the merged PR satisfies the issue
+acceptance.
+
+If the issue is part of a parent chain, add a short parent status comment with
+the next recommended slice.

--- a/docs/onboarding/examples/repo_brain_first_use.md
+++ b/docs/onboarding/examples/repo_brain_first_use.md
@@ -1,0 +1,99 @@
+# Example: Repo Brain First Use
+
+Status: Orientation
+Issue: #3238
+
+This example shows how a new developer or agent uses Repo Brain / Context
+Intelligence as read-only orientation. It does not authorize writes, merges,
+runtime actions, trading actions, Live-Go, or Echtgeld-Go.
+
+Docs/UI sind Orientierung, keine Autoritaet. LR bleibt NO-GO.
+
+## Scenario
+
+You receive a task that mentions Context Intelligence, Repo Brain, MCP tools,
+Evidence, SurrealDB, or memory. You need orientation, but you must not invent
+DB-backed claims.
+
+## Step 1: Resolve The Bootloader
+
+Read:
+
+1. `AGENTS.md`
+2. `agents/AGENTS.md`
+3. the full Read Order from `agents/AGENTS.md`
+4. `agents/OPEN_CODE_AGENTS.md`
+
+The Brain Evidence Gate applies before any plan when Context, SurrealDB, MCP,
+DB-backed memory, or evidence is in scope.
+
+## Step 2: Ask What Evidence You Actually Have
+
+Use read-only Context tooling only when it is available in the active agent
+surface and returns a real handler response.
+
+Valid examples of orientation tooling:
+
+```text
+context.required_reads
+context.briefing
+context.search
+context.readiness
+```
+
+If the tool returns synthetic, mocked, empty, or repo-only results, say so. Do
+not claim `surrealdb-local` or DB-backed evidence without adapter/query/record
+evidence.
+
+## Step 3: Use Repo-Backed Context Paths
+
+Repo-backed references for Context onboarding are:
+
+- [`../../surrealdb/README.md`](../../surrealdb/README.md)
+- [`../../runbooks/surrealdb_context_mcp_access.md`](../../runbooks/surrealdb_context_mcp_access.md)
+- `make context-doctor` as the read-only local Context onboarding preflight
+- `python -m tools.surrealdb.context_onboarding_doctor --format json`
+
+The context-doctor path is read-only orientation. It may report missing local
+config or unavailable local services; that is evidence, not permission to start
+runtime or write productive memory.
+
+## Step 4: Fill The Brain Evidence Block Honestly
+
+Example fallback when no verified DB records are available:
+
+```text
+## Brain Evidence
+brain_source: repo-only
+brain_status: not-used
+tools_or_queries:
+  - context.required_reads for the task scope
+  - context.briefing for the task scope
+  - repo reads from the bootloader Read Order
+records_or_results:
+  - No SurrealDB-local record evidence returned
+  - Context briefing used as orientation only
+repo_crosscheck:
+  - AGENTS.md -> agents/AGENTS.md
+  - docs/runbooks/surrealdb_context_mcp_access.md
+impact_on_plan:
+  - Use repo and GitHub live evidence as authority
+  - Do not make DB-backed Brain claims
+limitations:
+  - No productive DB or memory-write evidence
+  - No Live-Go / Echtgeld-Go authority
+```
+
+## Step 5: Cross-Check Against Authority
+
+Use this priority order:
+
+1. GitHub live issue and PR state
+2. Repo files and canonical docs
+3. Verified SurrealDB context package with record evidence, if actually present
+4. Ledger/status snapshots such as `CURRENT_STATUS.md`
+5. Explicit fallback with limitations
+
+Repo Brain helps with evidence and orientation, but it is not a live, trading,
+merge, or LR authority. Context/MCP output does not override GitHub live state,
+repo canon, Human-GO, `PERSIST_ALLOWED=False`, or `MUTATION_ALLOWED=False`.

--- a/docs/onboarding/templates/agent_prompt_template.md
+++ b/docs/onboarding/templates/agent_prompt_template.md
@@ -1,0 +1,153 @@
+# CDB Agent Prompt Template
+
+Status: Template
+Issue: #3238
+
+Use this as a reusable prompt skeleton for CDB agent work. Replace placeholders
+with task-specific values. Do not include credential values, private material,
+or references to hidden ChatGPT/internal documents.
+
+Docs/UI sind Orientierung, keine Autoritaet. LR bleibt NO-GO. No Live-Go. No
+Echtgeld-Go.
+
+## Aufgabe
+
+Bearbeite CDB Issue `<issue-number>`:
+`<issue-title-or-url>`
+
+## Ziel
+
+`<one concise target outcome>`
+
+## Scope
+
+In scope:
+
+- `<paths, docs, or code areas explicitly allowed>`
+
+Out of scope:
+
+- No real GUI or web app unless explicitly approved.
+- No runtime, Docker, trading, live, LR, productive DB, or memory-write changes
+  unless explicitly approved for this issue.
+- No credential values or private operator material.
+
+## Bootloader
+
+Resolve before planning or writing:
+
+1. `AGENTS.md`
+2. `agents/AGENTS.md`
+3. Full Read Order from `agents/AGENTS.md`
+4. `agents/OPEN_CODE_AGENTS.md`
+5. Task-specific canon and evidence docs
+
+If a canonical file or Read Order entry is missing, stop and report it exactly.
+
+## Brain Evidence
+
+If scope touches Context, SurrealDB, MCP, DB-backed memory, evidence, service,
+contract, module, runtime, or strategy, output this block before any plan:
+
+```text
+## Brain Evidence
+brain_source: surrealdb-local | in_memory | repo-only | unavailable
+brain_status: used | partial | not-used | blocked
+tools_or_queries:
+  - <tool, command, query, or repo read>
+records_or_results:
+  - <record id, count, source, hash, or explicit none>
+repo_crosscheck:
+  - <file, path, symbol, commit, or issue>
+impact_on_plan:
+  - <what changed because of the evidence>
+limitations:
+  - <what is not proven>
+```
+
+No DB-backed Brain claim is allowed without real tool/query/record evidence.
+GitHub live and repo evidence win over Brain or memory claims.
+
+## Live-Checks
+
+Run before changes:
+
+```bash
+git fetch origin --prune
+git status -sb
+git rev-parse HEAD
+git rev-parse origin/main
+git branch --show-current
+gh issue view <issue-number> --json number,title,state,labels,body,comments
+gh pr list --state open --limit 20
+```
+
+Add related issue/PR reads when the issue body or parent issue requires them.
+
+Stop if:
+
+- Repo is not on `main`.
+- `main` does not equal `origin/main`.
+- Target issue is closed.
+- A matching open PR already exists.
+- Required governance files are missing.
+- Scope grows into a forbidden area.
+
+## Arbeitsplan
+
+1. `<small step 1>`
+2. `<small step 2>`
+3. `<small step 3>`
+
+Keep the plan to the smallest correct slice. Do not add backward compatibility,
+new tooling, or navigation wiring unless the issue explicitly asks for it.
+
+## Validierung
+
+Run the commands required by the issue, for example:
+
+```bash
+git diff --check
+ruff check .
+```
+
+For docs/onboarding safety text, also run:
+
+```bash
+rg -n "Live-Go|Echtgeld-Go|LR bleibt NO-GO|Docs/UI sind Orientierung" <target-path>
+```
+
+## Issue-/PR-Regeln
+
+- Set a single-writer LOCK before becoming the writer for the issue.
+- Create a branch from current `main`.
+- Commit only intended files.
+- Open a PR with summary, changed files, validation, scope boundary,
+  Safety/LR statement, and issue links.
+- Do not merge while required checks are red or scope is unclear.
+- Comment the target issue with the PR link after PR creation.
+- After merge, comment and close only if the merged diff satisfies acceptance.
+
+## Safety
+
+- LR bleibt NO-GO.
+- Board stage `trade-capable` is not Live-Go.
+- No Echtgeld-Go.
+- No productive DB or memory writes without explicit separate approval.
+- No credential values in logs, docs, issues, PRs, examples, or templates.
+- `CURRENT_STATUS.md` is a ledger, not live truth.
+
+## Output-Format
+
+Return:
+
+1. Brain Evidence Block
+2. Bootloader-/Read-Order-Evidence
+3. Live-Lage
+4. Befund
+5. Umgesetzte Schritte
+6. Validierung
+7. PR-/Issue-Links
+8. Holds / Follow-up-Issues
+9. Restunsicherheiten
+10. Status

--- a/docs/onboarding/templates/evidence_doc_template.md
+++ b/docs/onboarding/templates/evidence_doc_template.md
@@ -1,0 +1,87 @@
+# Evidence Document Template
+
+Status: Template
+Issue: `<issue-number>`
+Date: `<YYYY-MM-DD>`
+Scope: `<bounded scope>`
+
+Docs/UI sind Orientierung, keine Autoritaet. LR bleibt NO-GO. No Live-Go. No
+Echtgeld-Go.
+
+## Summary
+
+- `<one-sentence result>`
+- `<what this evidence proves>`
+- `<what this evidence does not prove>`
+
+## Scope
+
+In scope:
+
+- `<path or artifact>`
+
+Out of scope:
+
+- `<explicit exclusions>`
+
+## Brain Evidence
+
+```text
+## Brain Evidence
+brain_source: `<surrealdb-local | in_memory | repo-only | unavailable>`
+brain_status: `<used | partial | not-used | blocked>`
+tools_or_queries:
+  - `<tool, command, query, or repo read>`
+records_or_results:
+  - `<record id, count, source, hash, or explicit none>`
+repo_crosscheck:
+  - `<file/path/commit/issue>`
+impact_on_plan:
+  - `<evidence-driven effect>`
+limitations:
+  - `<unproven area>`
+```
+
+## Bootloader Evidence
+
+| Surface | Evidence |
+|---|---|
+| `AGENTS.md` | `<root pointer resolved>` |
+| `agents/AGENTS.md` | `<Read Order resolved>` |
+| `CDB_AGENT_POLICY.md` section 4 | `<write-gate read>` |
+| Status surfaces | `<CONTROL_REGISTER / CURRENT_STATUS / LR audit read>` |
+
+## Live Evidence
+
+| Check | Result |
+|---|---|
+| `git fetch origin --prune` | `<result>` |
+| `git status -sb` | `<result>` |
+| `git rev-parse HEAD` | `<sha>` |
+| `git rev-parse origin/main` | `<sha>` |
+| `gh issue view <issue>` | `<open/closed plus relevant facts>` |
+| `gh pr list ...` | `<matching PR state>` |
+
+## Findings
+
+| Finding | Evidence | Impact | Classification |
+|---|---|---|---|
+| `<finding>` | `<file/line/issue/run>` | `<effect>` | `<pass/warn/block>` |
+
+## Validation
+
+| Command | Result | Notes |
+|---|---|---|
+| `<command>` | `<exit/result>` | `<scope note>` |
+
+## Follow-ups
+
+- `<follow-up issue or none>`
+
+## Restunsicherheiten
+
+- `<known uncertainty or none>`
+
+## Status
+
+`<PASS | PASS_WITH_LIMITS | BLOCKED | HOLD_<reason>>`

--- a/docs/onboarding/templates/pr_body_template.md
+++ b/docs/onboarding/templates/pr_body_template.md
@@ -1,0 +1,40 @@
+# PR Body Template: CDB Docs / Onboarding Slice
+
+## Summary
+
+- `<what changed>`
+- `<why it is scoped to this issue>`
+- `<what remains out of scope>`
+
+## Changed Files
+
+- `<path>` - `<purpose>`
+- `<path>` - `<purpose>`
+
+## Validation
+
+- [ ] `git diff --check`
+- [ ] `ruff check .`
+- [ ] `<issue-specific docs/link/safety checks>`
+
+## Scope Boundary
+
+- Docs/onboarding only.
+- No real GUI or web app.
+- No runtime, Docker, service, strategy, risk, execution, trading, LR, productive
+  DB, or memory-write changes.
+- No credential values or private operator material.
+
+## Safety/LR
+
+- LR bleibt NO-GO.
+- Board stage `trade-capable` is not Live-Go.
+- No Echtgeld-Go.
+- Docs/UI sind Orientierung, keine Autoritaet.
+- `CURRENT_STATUS.md` is a ledger, not GitHub live truth.
+
+## Issue Links
+
+Refs #`<issue-number>`
+
+Related: `<parent or sibling issues>`


### PR DESCRIPTION
## Summary
- Adds a docs-only visual developer onboarding start surface under docs/onboarding.
- Adds two Mermaid diagrams, onboarding examples, and reusable templates for agent prompts, evidence docs, and PR bodies.
- Keeps navigation graph wiring out of scope for #3230.

## Created files
- docs/onboarding/DEVELOPER_VISUAL_START_HERE.md
- docs/onboarding/diagrams/cdb_developer_flow.mmd
- docs/onboarding/diagrams/cdb_repo_brain_flow.mmd
- docs/onboarding/examples/README.md
- docs/onboarding/examples/first_issue_to_pr_flow.md
- docs/onboarding/examples/repo_brain_first_use.md
- docs/onboarding/templates/agent_prompt_template.md
- docs/onboarding/templates/evidence_doc_template.md
- docs/onboarding/templates/pr_body_template.md

## Validation
- PASS: git diff --check
- PASS: git diff --cached --check
- PASS: rg -n "Live-Go|Echtgeld-Go|LR bleibt NO-GO|Docs/UI sind Orientierung" docs/onboarding
- PASS: sensitive-term scan over docs/onboarding returned no hits with PowerShell-compatible exit handling
- BLOCKED local-only: ruff check . fails on pre-existing untracked scope-fremd .opencode/plans/validate_comments.py E401; not part of this PR and not modified

## Scope boundaries
- Docs/onboarding only.
- No root README or docs/index wiring; #3230 remains the navigation graph slice.
- No real GUI/Web-App, Streamlit, Grafana, React/Vite, screenshots, runtime, Docker, trading, LR, productive DB, or memory-write changes.
- Untracked .opencode/plans/ and docs/decisions/ remain untouched.

## Safety/LR statement
- LR bleibt NO-GO.
- Board stage trade-capable is not Live-Go.
- No Echtgeld-Go.
- Docs/UI sind Orientierung, keine Autoritaet.
- CURRENT_STATUS.md is a ledger, not GitHub live truth.

Refs #3238