### PR TITLE
[ONBOARDING][TOOLS] Add one-command developer onboarding doctor (#3232)

### DIFF
--- a/DEVELOPER_ONBOARDING.md
+++ b/DEVELOPER_ONBOARDING.md
@@ -254,7 +254,36 @@ ruff check .
 pytest -q -k "not test_mcp_time_server_runtime" --no-header
 ```
 
-### 4. Repo Brain / Context Preflight
+### 4. Onboarding Doctor (One-Command Preflight)
+
+```bash
+# Cross-platform Python doctor (recommended)
+python -m tools.onboarding_doctor
+
+# JSON output
+python -m tools.onboarding_doctor --format json
+
+# PowerShell v1 front door (Windows)
+.\tools\cdb.ps1 onboarding doctor
+
+# Make target (all platforms)
+make onboarding-doctor
+```
+
+This read-only tool validates your entire local developer setup without
+requiring a running stack, Docker mutation, or secret exposure. It checks:
+- Git installed and branch state
+- Python version (3.11+ required)
+- Docker and Docker Compose presence (optional)
+- gh CLI and authentication (optional)
+- `.env` file presence
+- SECRETS_PATH existence (not contents)
+- All key onboarding files exist
+- `make context-doctor` reachability
+
+It does **not** output secret values. Exit codes: 0 = all good, 1 = blocking.
+
+### 5. Repo Brain / Context Preflight
 
 ```bash
 make context-doctor
@@ -580,6 +609,7 @@ Read [`CONTRIBUTING.md`](CONTRIBUTING.md) for:
 | **Lint** | `ruff check .` |
 | **Format** | `black .` |
 | **Type check** | `mypy core/ services/` |
+| **Onboarding doctor** | `python -m tools.onboarding_doctor` or `.\tools\cdb.ps1 onboarding doctor` or `make onboarding-doctor` |
 | **Context preflight** | `make context-doctor` |
 | **Core smoke test** | `.\tools\cdb.ps1 runtime smoke` |
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ else
   SECRETS_PATH ?= $(HOME)/Documents/.secrets/.cdb
 endif
 
-.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close context-env-check context-query-config-init context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke context-smoke-db context-memory-db-proof context-claim-evidence-proof context-memory-rediscovery-proof context-doctor context-certify context-live-invoke context-live-invoke-full audit-trail-t3-bootstrap audit-trail-t3-proof audit-trail-t3-status audit-trail-t3-down
+.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close onboarding-doctor context-env-check context-query-config-init context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke context-smoke-db context-memory-db-proof context-claim-evidence-proof context-memory-rediscovery-proof context-doctor context-certify context-live-invoke context-live-invoke-full audit-trail-t3-bootstrap audit-trail-t3-proof audit-trail-t3-status audit-trail-t3-down
 
 help:
 	@echo "Claire de Binare - Test Commands"
@@ -108,7 +108,8 @@ help:
 	@echo "  make context-memory-db-proof - Narrow memory read+stale proof (#2603/#2606)"
 	@echo "  make context-claim-evidence-proof - Claim evidence at rest proof (#2719/#2606)"
 	@echo "  make context-memory-rediscovery-proof - Cross-session memory rediscovery (#2720)"
-	@echo "  make context-doctor          - Read-only onboarding preflight (#2642)"
+	@echo "  make onboarding-doctor       - Read-only developer setup preflight (#3232)"
+	@echo "  make context-doctor          - Read-only context/CI onboarding preflight (#2642)"
 	@echo "  make context-certify         - Read-only operator certification proof pack (#2776)"
 	@echo "  make context-live-invoke     - All-tools live bridge matrix, minimal profile (#2849)"
 	@echo "  make context-live-invoke-full - Same harness with inline records, 27 PASS (#2852)"
@@ -396,6 +397,10 @@ context-schema-apply:
 context-schema-check:
 	@echo "=== SurrealDB Schema Check: context_intelligence_v0 ==="
 	@$(PYTHON) tools/surrealdb/local_schema_check.py --secrets-path "$(SECRETS_PATH)"
+
+onboarding-doctor:
+	@echo "=== CDB Onboarding Doctor (developer setup preflight) ==="
+	@$(PYTHON) -m tools.onboarding_doctor
 
 context-doctor:
 	@echo "=== Context Onboarding Doctor (read-only preflight) ==="

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,7 @@ sondern ein Pointer auf die bestehenden Docs, Runbooks und Source Trees.
 |-------|-------|-------|
 | Einen visuellen Developer-Start mit Mermaid-Flow brauchst | [`DEVELOPER_VISUAL_START_HERE.md`](onboarding/DEVELOPER_VISUAL_START_HERE.md) | Mermaid-Flussdiagramme, Beispiele, Vorlagen — erstellt in #3238 |
 | Das vollständige lokale Setup brauchst | [`DEVELOPER_ONBOARDING.md`](../DEVELOPER_ONBOARDING.md) | Secrets, Stack-Bootstrap, erste PR-Schritte |
+| Einen One-Command-Setup-Check brauchst | `python -m tools.onboarding_doctor` or `make onboarding-doctor` | Read-only Developer-Onboarding Preflight |
 | Ein Issue-to-PR-Beispiel durchspielen willst | [`first_issue_to_pr_flow.md`](onboarding/examples/first_issue_to_pr_flow.md) | Kleinster Issue-to-PR-Workflow |
 | Den Repo-Brain-Erstkontakt brauchst | [`repo_brain_first_use.md`](onboarding/examples/repo_brain_first_use.md) | Context Intelligence / Repo Brain als read-only Orientation |
 | Das vollständige Repo-Brain-Onboarding brauchst | [`repo_brain_context_intelligence.md`](onboarding/repo_brain_context_intelligence.md) | Brain Evidence Block, Safety Boundaries, First-Use-Flow |
@@ -62,6 +63,7 @@ sondern ein Pointer auf die bestehenden Docs, Runbooks und Source Trees.
 ## Repo Brain / Context Intelligence
 
 - [`docs/surrealdb/README.md`](surrealdb/README.md) — Context-/MCP-Docs-Index und lokaler Context-Runtime-Einstieg
+- `make onboarding-doctor` — Read-only Preflight für Developer-Onboarding-Prüfung
 - `make context-doctor` — Read-only Preflight für lokale Context-Tooling-Prüfung
 - [`mcp_navpack_working_repo/ENTRYPOINTS.yaml`](../mcp_navpack_working_repo/ENTRYPOINTS.yaml) — maschinenlesbare Read-Order (navpack)
 - [`mcp_navpack_working_repo/CHEATSHEET.md`](../mcp_navpack_working_repo/CHEATSHEET.md) — schnelle menschliche Nav-Quickref

--- a/docs/onboarding/DEVELOPER_VISUAL_START_HERE.md
+++ b/docs/onboarding/DEVELOPER_VISUAL_START_HERE.md
@@ -27,9 +27,11 @@ before touching implementation work.
    [`../../services/README.md`](../../services/README.md),
    [`../../tests/README.md`](../../tests/README.md),
    [`../../tools/README.md`](../../tools/README.md).
-5. Use the examples in [`examples/README.md`](examples/README.md) before drafting
+5. Run the onboarding doctor to verify your local setup:
+   `python -m tools.onboarding_doctor` or `make onboarding-doctor`.
+6. Use the examples in [`examples/README.md`](examples/README.md) before drafting
    your first issue-to-PR workflow.
-6. Use the templates in [`templates/`](templates/) for prompts, evidence docs,
+7. Use the templates in [`templates/`](templates/) for prompts, evidence docs,
    and docs/onboarding PR bodies.
 
 ## Start Path For Agents

--- a/docs/onboarding/repo_brain_context_intelligence.md
+++ b/docs/onboarding/repo_brain_context_intelligence.md
@@ -164,6 +164,24 @@ When you start working with Repo Brain / Context Intelligence for the first time
 
 ## Local Readiness Check
 
+Start with the **developer onboarding doctor** for a general setup check:
+
+```bash
+# Cross-platform Python doctor
+python -m tools.onboarding_doctor
+
+# JSON output
+python -m tools.onboarding_doctor --format json
+
+# PowerShell v1 front door (Windows)
+.\tools\cdb.ps1 onboarding doctor
+
+# Make target (all platforms)
+make onboarding-doctor
+```
+
+Then run the **context doctor** for Context Intelligence preflight:
+
 ```bash
 # One-command preflight
 make context-doctor
@@ -172,17 +190,23 @@ make context-doctor
 python -m tools.surrealdb.context_onboarding_doctor --format json
 ```
 
-The command is **read-only**. It does not modify any files, does not start any
-service, and does not require a running Docker stack. It validates:
+Both commands are **read-only**. They do not modify any files, do not start any
+service, and do not require a running Docker stack. Together they validate:
 
+- Git installed and branch state
+- Python version (3.11+)
+- Docker and Docker Compose presence (optional)
+- gh CLI and authentication (optional)
+- `.env` file presence
+- SECRETS_PATH existence (not contents)
+- All key onboarding files exist
 - Python venv and dependencies
 - Secret directory presence (not contents)
-- Key repo file references
-- No live-key or LR violations
 - Local MCP config accessibility
+- Context Intelligence prerequisites
 
-**Security:** The doctor never outputs secret values. Do not modify the doctor to
-display secret values.
+**Security:** Neither doctor ever outputs secret values. Do not modify either
+doctor to display secret values.
 
 ## MCP / Agent Templates
 

--- a/mcp_navpack_working_repo/CHEATSHEET.md
+++ b/mcp_navpack_working_repo/CHEATSHEET.md
@@ -10,6 +10,7 @@
   - Full onboarding: `docs/onboarding/repo_brain_context_intelligence.md`
   - Context/MCP index: `docs/surrealdb/README.md`
   - Local preflight: `make context-doctor`
+- **Developer onboarding doctor:** `python -m tools.onboarding_doctor` or `make onboarding-doctor` or `.\tools\cdb.ps1 onboarding doctor` (Windows).
 - **First Repo Brain use:** `docs/onboarding/examples/repo_brain_first_use.md`.
 - Check `.github/workflows/ci.yml` and `Makefile` together to understand what CI enforces and what you can run locally.
 - Read `AGENTS.md` before assuming docs ownership; it resolves to the local canonical registry at `agents/AGENTS.md`.

--- a/mcp_navpack_working_repo/ENTRYPOINTS.yaml
+++ b/mcp_navpack_working_repo/ENTRYPOINTS.yaml
@@ -80,6 +80,13 @@ read_order:
     path: "AGENTS.md"
     intent: "Clarify agent-doc ownership boundaries"
     expected_signal: "Root pointer resolves to local agents/AGENTS.md in this working repo"
+  - id: "16"
+    path: "tools/onboarding_doctor.py"
+    intent: "Run one-command developer onboarding preflight"
+    expected_signal: "PASS/WARN/FAIL for git, python, docker, .env, SECRETS_PATH, key docs"
+    commands:
+      - "python -m tools.onboarding_doctor"
+      - "python -m tools.onboarding_doctor --format json"
 minimal_context_bundle:
   - "README.md"
   - "docs/index.md"

--- a/tests/unit/test_onboarding_doctor.py
+++ b/tests/unit/test_onboarding_doctor.py
@@ -1,0 +1,307 @@
+"""Unit tests for onboarding doctor (#3232)."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from subprocess import CompletedProcess
+
+import pytest
+
+from tools import onboarding_doctor as doctor
+
+pytestmark = pytest.mark.unit
+
+
+def test_parse_python_version_good() -> None:
+    assert doctor._parse_python_version("Python 3.12.0") == (3, 12, 0)
+    assert doctor._parse_python_version("Python 3.11.5") == (3, 11, 5)
+
+
+def test_parse_python_version_edge() -> None:
+    assert doctor._parse_python_version("Python 3.10.0") == (3, 10, 0)
+    assert doctor._parse_python_version("") is None
+    assert doctor._parse_python_version("not a version") is None
+
+
+def test_version_ok() -> None:
+    assert doctor._version_ok((3, 12, 0)) is True
+    assert doctor._version_ok((3, 11, 0)) is True
+    assert doctor._version_ok((3, 10, 0)) is False
+    assert doctor._version_ok(None) is False
+    assert doctor._version_ok((4, 0, 0)) is True
+
+
+def test_check_python_version() -> None:
+    status, ver_str, ok = doctor.check_python_version("Python 3.12.0")
+    assert status == "PASS"
+    assert ver_str == "3.12.0"
+    assert ok == "PASS"
+
+    status, ver_str, ok = doctor.check_python_version("Python 3.10.0")
+    assert status == "WARN"
+    assert ok == "FAIL"
+
+    status, ver_str, ok = doctor.check_python_version("garbage")
+    assert status == "WARN"
+    assert ok == "FAIL"
+
+
+def test_onboarding_files_all_exist(tmp_path: Path) -> None:
+    for rel in doctor.ONBOARDING_FILE_CHECKS:
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("test")
+    status, missing = doctor._onboarding_files_exist(tmp_path)
+    assert status == "PASS"
+    assert not missing
+
+
+def test_onboarding_files_missing(tmp_path: Path) -> None:
+    status, missing = doctor._onboarding_files_exist(tmp_path)
+    assert status == "FAIL"
+    assert len(missing) > 2
+
+
+def test_check_env_file_exists(tmp_path: Path) -> None:
+    orig = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        (tmp_path / ".env").write_text("test")
+        status, detail = doctor._check_env_file()
+        assert status == "PASS"
+        assert "found" in detail
+    finally:
+        os.chdir(orig)
+
+
+def test_check_env_file_missing_but_example(tmp_path: Path) -> None:
+    orig = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        (tmp_path / ".env.example").write_text("test")
+        status, detail = doctor._check_env_file()
+        assert status == "WARN"
+        assert ".env.example" in detail
+    finally:
+        os.chdir(orig)
+
+
+def test_check_env_file_missing(tmp_path: Path) -> None:
+    orig = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        status, _ = doctor._check_env_file()
+        assert status == "FAIL"
+    finally:
+        os.chdir(orig)
+
+
+def test_check_secrets_path_env_set_valid(tmp_path: Path) -> None:
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    os.environ["SECRETS_PATH"] = str(secrets)
+    try:
+        status, detail = doctor._check_secrets_path()
+        assert status == "PASS"
+        assert str(secrets) in detail
+    finally:
+        os.environ.pop("SECRETS_PATH", None)
+
+
+def test_check_secrets_path_env_set_invalid() -> None:
+    os.environ["SECRETS_PATH"] = "/nonexistent/path"
+    try:
+        status, _ = doctor._check_secrets_path()
+        assert status == "FAIL"
+    finally:
+        os.environ.pop("SECRETS_PATH", None)
+
+
+def test_check_secrets_path_unset(tmp_path: Path) -> None:
+    status, _ = doctor._check_secrets_path()
+    assert status in ("PASS", "WARN")
+
+
+def test_build_report_repo_root(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("test")
+    (tmp_path / ".git").mkdir()
+
+    def mock_runner(cmd, **kwargs):
+        return CompletedProcess(cmd, 0, "output", "")
+
+    report = doctor.build_report(
+        tmp_path,
+        git_runner=mock_runner,
+        python_runner=mock_runner,
+        gh_runner=mock_runner,
+        docker_runner=mock_runner,
+        compose_runner=mock_runner,
+        context_doctor_runner=mock_runner,
+    )
+    assert report.repo_root_found == "PASS"
+
+
+def test_build_report_python_not_found(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("test")
+
+    def fail_runner(cmd, **kwargs):
+        return CompletedProcess(cmd, 1, "", "")
+
+    def git_ok(cmd, **kwargs):
+        return CompletedProcess(cmd, 0, "git version 2.40.0", "")
+
+    def git_porcelain(cmd, **kwargs):
+        return CompletedProcess(cmd, 0, "", "")
+
+    report = doctor.build_report(
+        tmp_path,
+        git_runner=git_porcelain,
+        python_runner=fail_runner,
+        gh_runner=fail_runner,
+        docker_runner=fail_runner,
+        compose_runner=fail_runner,
+        context_doctor_runner=fail_runner,
+    )
+    assert report.python_found == "FAIL"
+    assert report.repo_root_found == "PASS"
+
+
+def test_json_output_no_secret_leak(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("test")
+
+    def mock_runner(cmd, **kwargs):
+        return CompletedProcess(cmd, 0, "python 3.12.0", "")
+
+    report = doctor.build_report(
+        tmp_path,
+        git_runner=mock_runner,
+        python_runner=mock_runner,
+        gh_runner=mock_runner,
+        docker_runner=mock_runner,
+        compose_runner=mock_runner,
+        context_doctor_runner=mock_runner,
+    )
+    payload = doctor.format_report(report, "json")
+    for pattern in doctor.FORBIDDEN_OUTPUT_PATTERNS:
+        assert not pattern.search(payload), f"forbidden pattern found in JSON output: {pattern.pattern}"
+
+
+def test_text_output_no_secret_leak(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("test")
+
+    def mock_runner(cmd, **kwargs):
+        return CompletedProcess(cmd, 0, "python 3.12.0", "")
+
+    report = doctor.build_report(
+        tmp_path,
+        git_runner=mock_runner,
+        python_runner=mock_runner,
+        gh_runner=mock_runner,
+        docker_runner=mock_runner,
+        compose_runner=mock_runner,
+        context_doctor_runner=mock_runner,
+    )
+    text = doctor.format_report(report, "text")
+    assert "super-secret" not in text.lower()
+
+
+def test_compute_exit_code() -> None:
+    ok = doctor.DoctorOutput()
+    ok.checks = [doctor.CheckItem(name="x", status="PASS")]
+    assert doctor.compute_exit_code(ok) == 0
+
+    fail = doctor.DoctorOutput()
+    fail.checks = [doctor.CheckItem(name="x", status="FAIL")]
+    assert doctor.compute_exit_code(fail) == 1
+
+    warn = doctor.DoctorOutput()
+    warn.checks = [doctor.CheckItem(name="x", status="WARN")]
+    assert doctor.compute_exit_code(warn) == 0
+
+
+def test_main_exit_codes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def mock_report(*args, **kwargs):
+        r = doctor.DoctorOutput()
+        r.repo_root_found = "PASS"
+        r.checks = [doctor.CheckItem(name="test", status="FAIL")]
+        return r
+
+    monkeypatch.setattr(doctor, "build_report", mock_report)
+    assert doctor.main(["--format", "json"]) == 1
+
+    def mock_report_ok(*args, **kwargs):
+        r = doctor.DoctorOutput()
+        r.repo_root_found = "PASS"
+        r.checks = [doctor.CheckItem(name="test", status="PASS")]
+        return r
+
+    monkeypatch.setattr(doctor, "build_report", mock_report_ok)
+    assert doctor.main(["--format", "text"]) == 0
+
+    with pytest.raises(SystemExit) as exc_info:
+        doctor.main(["--format", "xml"])
+    assert exc_info.value.code == 2
+
+
+def test_forbidden_output_patterns_detect_secret() -> None:
+    vulnerabilities = [
+        "api_key=abc123def456",
+        "secret=my-secret-value",
+        "password=supersecret",
+        "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "https://github.com/user/repo",
+    ]
+    for sample in vulnerabilities:
+        assert any(
+            p.search(sample) for p in doctor.FORBIDDEN_OUTPUT_PATTERNS
+        ), f"pattern should detect: {sample}"
+
+    safe_samples = [
+        "SECRETS_PATH=C:/Users/user/Documents/.secrets/.cdb",
+        "gh auth status: not logged in",
+    ]
+    for sample in safe_samples:
+        for p in doctor.FORBIDDEN_OUTPUT_PATTERNS:
+            if p.search(sample):
+                break
+        else:
+            continue
+        # Some may match, some may not; that's OK for safe samples
+
+
+def test_onboarding_files_warn_few_missing(tmp_path: Path) -> None:
+    for rel in doctor.ONBOARDING_FILE_CHECKS[:7]:
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("test")
+    status, missing = doctor._onboarding_files_exist(tmp_path)
+    # 7 present, 2 missing (tests/README.md, services/README.md) = WARN
+    assert status == "WARN"
+    assert 2 <= len(missing) <= 2
+
+
+
+def test_doctor_output_to_dict(tmp_path: Path) -> None:
+    r = doctor.DoctorOutput(
+        repo_root_found="PASS",
+        git_found="PASS",
+        git_branch="main",
+        git_dirty="PASS",
+        python_found="PASS",
+        python_version="3.12.0",
+        python_version_ok="PASS",
+        env_file="PASS",
+        secrets_path="PASS",
+        onboarding_files="PASS",
+        context_doctor_reachable="PASS",
+    )
+    d = r.to_dict()
+    assert d["repo_root"] == "PASS"
+    assert d["git"]["branch"] == "main"
+    assert d["lr_note"] == "NO-GO"
+    assert "checks" in d

--- a/tools/README.md
+++ b/tools/README.md
@@ -24,6 +24,7 @@ Important:
 | `.\tools\cdb.ps1 stack verify` | `tools/verify_stack.ps1` |
 | `.\tools\cdb.ps1 service logs -ServiceName cdb_risk -Lines 100` | `tools/cdb-service-logs.ps1` |
 | `.\tools\cdb.ps1 runtime smoke` | `infrastructure/scripts/smoke_test.ps1` |
+| `.\tools\cdb.ps1 onboarding doctor` | `tools/onboarding_doctor.py` |
 
 Non-interactive form:
 - `pwsh -ExecutionPolicy Bypass -File .\tools\cdb.ps1 runtime up`

--- a/tools/cdb.ps1
+++ b/tools/cdb.ps1
@@ -24,6 +24,7 @@ Usage:
   .\tools\cdb.ps1 runtime smoke [args]
   .\tools\cdb.ps1 stack verify [args]
   .\tools\cdb.ps1 service logs [args]
+  .\tools\cdb.ps1 onboarding doctor [--format json]
 
 Examples:
   .\tools\cdb.ps1 secrets init
@@ -65,6 +66,7 @@ $targetRelativePath = switch ($commandKey) {
     'runtime smoke' { 'infrastructure\scripts\smoke_test.ps1' }
     'stack verify' { 'tools\verify_stack.ps1' }
     'service logs' { 'tools\cdb-service-logs.ps1' }
+    'onboarding doctor' { 'tools\onboarding_doctor.py' }
     default { $null }
 }
 
@@ -79,32 +81,48 @@ if (-not (Test-Path -LiteralPath $targetPath)) {
     exit 1
 }
 
-$shellCommand = if ($PSVersionTable.PSEdition -eq 'Core') {
-    Get-Command pwsh -ErrorAction SilentlyContinue
+if ($targetRelativePath -like '*.py') {
+    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+    if (-not $pythonCmd) {
+        Write-Error "Missing required Python interpreter (expected python in PATH)."
+        exit 1
+    }
+    $invokeArgs = @($targetPath) + $RemainingArgs
+    Push-Location -LiteralPath $repoRoot
+    try {
+        & $pythonCmd.Source @invokeArgs
+        exit $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
 } else {
-    Get-Command powershell.exe -ErrorAction SilentlyContinue
-}
-if (-not $shellCommand) {
-    $shellCommand = Get-Command pwsh -ErrorAction SilentlyContinue
-}
-if (-not $shellCommand) {
-    $shellCommand = Get-Command powershell.exe -ErrorAction SilentlyContinue
-}
-if (-not $shellCommand) {
-    Write-Error "Missing required PowerShell host (expected pwsh or powershell.exe)."
-    exit 1
-}
+    $shellCommand = if ($PSVersionTable.PSEdition -eq 'Core') {
+        Get-Command pwsh -ErrorAction SilentlyContinue
+    } else {
+        Get-Command powershell.exe -ErrorAction SilentlyContinue
+    }
+    if (-not $shellCommand) {
+        $shellCommand = Get-Command pwsh -ErrorAction SilentlyContinue
+    }
+    if (-not $shellCommand) {
+        $shellCommand = Get-Command powershell.exe -ErrorAction SilentlyContinue
+    }
+    if (-not $shellCommand) {
+        Write-Error "Missing required PowerShell host (expected pwsh or powershell.exe)."
+        exit 1
+    }
 
-$invokeArgs = @(
-    '-NoProfile',
-    '-ExecutionPolicy', 'Bypass',
-    '-File', $targetPath
-) + $RemainingArgs
+    $invokeArgs = @(
+        '-NoProfile',
+        '-ExecutionPolicy', 'Bypass',
+        '-File', $targetPath
+    ) + $RemainingArgs
 
-Push-Location -LiteralPath $repoRoot
-try {
-    & $shellCommand.Source @invokeArgs
-    exit $LASTEXITCODE
-} finally {
-    Pop-Location
+    Push-Location -LiteralPath $repoRoot
+    try {
+        & $shellCommand.Source @invokeArgs
+        exit $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
 }

--- a/tools/onboarding_doctor.py
+++ b/tools/onboarding_doctor.py
@@ -1,0 +1,459 @@
+"""Read-only developer onboarding doctor for CDB.
+
+Validates local developer setup without dangerous actions,
+secret output, stack mutation, DB writes, or MCP mutations.
+
+Usage:
+    python -m tools.onboarding_doctor
+    python -m tools.onboarding_doctor --format json
+    ./tools/cdb.ps1 onboarding doctor
+    make onboarding-doctor
+
+Exit codes:
+    0 - all checks PASS or only non-blocking WARN
+    1 - one or more FAIL checks (onboarding not usable)
+    2 - CLI usage error
+
+Issue: #3232
+Parent: #3226
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+
+CheckResult = str  # "PASS" | "WARN" | "FAIL" | "SKIP"
+EnvVarCheck = str  # "set" | "unset" | "invalid"
+
+
+ONBOARDING_FILE_CHECKS: list[str] = [
+    "README.md",
+    "docs/index.md",
+    "DEVELOPER_ONBOARDING.md",
+    "docs/onboarding/DEVELOPER_VISUAL_START_HERE.md",
+    "docs/onboarding/repo_brain_context_intelligence.md",
+    "docs/surrealdb/README.md",
+    "tools/README.md",
+    "tests/README.md",
+    "services/README.md",
+]
+
+SECRET_PATH_DEFAULTS: list[str] = [
+    str(Path.home() / "Documents" / ".secrets" / ".cdb"),
+]
+
+FORBIDDEN_OUTPUT_PATTERNS: list[re.Pattern] = [
+    re.compile(r"(?i)\b(token|secret|password|passwd|api[_-]?key)\s*[:=]\s*\S+"),
+    re.compile(r"(?i)SURREAL_(?:PASS|USER)\s*=\s*\S+"),
+    re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"),
+    re.compile(r"https?://[^\s\"']+"),
+    re.compile(r"(?i)(?:api|private|secret)_key[=:]\s*\S+"),
+]
+
+
+def _run_cmd(
+    cmd: str,
+    timeout: float = 15.0,
+    runner: Callable[..., subprocess.CompletedProcess] | None = None,
+) -> tuple[int, str, str]:
+    kwargs: dict[str, Any] = {
+        "capture_output": True,
+        "text": True,
+        "timeout": timeout,
+        "errors": "replace",
+    }
+    if os.name == "nt":
+        kwargs["shell"] = True
+    else:
+        kwargs["shell"] = False
+    try:
+        if runner is not None:
+            proc = runner(cmd, **kwargs)
+        else:
+            proc = subprocess.run(cmd, **kwargs)  # noqa: S603
+        out = (proc.stdout or "").strip()
+        err = (proc.stderr or "").strip()
+        return proc.returncode, out, err
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired, UnicodeDecodeError) as exc:
+        return -1, "", str(exc)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+@dataclass
+class CheckItem:
+    name: str
+    status: CheckResult
+    detail: str = ""
+    action: str = ""
+
+
+@dataclass
+class DoctorOutput:
+    repo_root_found: CheckResult = "FAIL"
+    git_found: CheckResult = "FAIL"
+    git_branch: str = ""
+    git_dirty: CheckResult = "SKIP"
+    python_found: CheckResult = "FAIL"
+    python_version: str = ""
+    python_version_ok: CheckResult = "FAIL"
+    gh_found: CheckResult = "SKIP"
+    gh_auth: CheckResult = "SKIP"
+    docker_found: CheckResult = "SKIP"
+    compose_found: CheckResult = "SKIP"
+    env_file: CheckResult = "FAIL"
+    secrets_path: CheckResult = "FAIL"
+    secrets_resolved_dir: str = ""
+    onboarding_files: CheckResult = "FAIL"
+    context_doctor_reachable: CheckResult = "SKIP"
+    lr_note: str = "NO-GO"
+    warnings: list[str] = field(default_factory=list)
+    checks: list[CheckItem] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "repo_root": self.repo_root_found,
+            "git": {
+                "found": self.git_found,
+                "branch": self.git_branch,
+                "dirty": self.git_dirty,
+            },
+            "python": {
+                "found": self.python_found,
+                "version": self.python_version,
+                "version_ok": self.python_version_ok,
+            },
+            "gh": {
+                "found": self.gh_found,
+                "auth": self.gh_auth,
+            },
+            "docker": {
+                "found": self.docker_found,
+                "compose": self.compose_found,
+            },
+            "env_file": self.env_file,
+            "secrets_path": self.secrets_path,
+            "secrets_resolved_dir": self.secrets_resolved_dir,
+            "onboarding_files": self.onboarding_files,
+            "context_doctor_reachable": self.context_doctor_reachable,
+            "lr_note": self.lr_note,
+            "warnings": self.warnings,
+            "checks": [
+                {"name": c.name, "status": c.status, "detail": c.detail, "action": c.action}
+                for c in self.checks
+            ],
+        }
+
+
+def _parse_python_version(version_str: str) -> tuple[int, int, int] | None:
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", version_str.strip())
+    if match:
+        return int(match.group(1)), int(match.group(2)), int(match.group(3))
+    return None
+
+
+def _version_ok(ver: tuple[int, int, int] | None) -> bool:
+    if ver is None:
+        return False
+    major, minor, _ = ver
+    return (major == 3 and minor >= 11) or major >= 4
+
+
+def _check_secrets_path() -> tuple[CheckResult, str]:
+    env_path = os.environ.get("SECRETS_PATH", "").strip()
+    if env_path:
+        p = Path(env_path)
+        if p.is_dir():
+            return "PASS", str(p)
+        return "FAIL", f"SECRETS_PATH set but directory not found: {env_path}"
+    for default in SECRET_PATH_DEFAULTS:
+        p = Path(default)
+        if p.is_dir():
+            return "PASS", str(p)
+    return "WARN", "SECRETS_PATH unset and no canonical secrets directory found"
+
+
+def _check_env_file() -> tuple[CheckResult, str]:
+    env_path = Path.cwd() / ".env"
+    if env_path.is_file():
+        return "PASS", ".env found"
+    example = Path.cwd() / ".env.example"
+    if example.is_file():
+        return "WARN", ".env missing, but .env.example exists (run: cp .env.example .env)"
+    return "FAIL", ".env missing and no .env.example found"
+
+
+def _onboarding_files_exist(root: Path) -> tuple[CheckResult, list[str]]:
+    missing: list[str] = []
+    for rel_path in ONBOARDING_FILE_CHECKS:
+        if not (root / rel_path).is_file():
+            missing.append(rel_path)
+    if not missing:
+        return "PASS", []
+    if len(missing) <= 2:
+        return "WARN", missing
+    return "FAIL", missing
+
+
+def _check_context_doctor_reachable(
+    runner: Callable[..., subprocess.CompletedProcess] | None = None,
+) -> CheckResult:
+    cmd = "python -m tools.surrealdb.context_onboarding_doctor --skip-mcp --skip-schema"
+    rc, _, _ = _run_cmd(cmd, timeout=10.0, runner=runner)
+    return "PASS" if rc == 0 else "WARN"
+
+
+def _validate_output_safe(text: str) -> None:
+    for pattern in FORBIDDEN_OUTPUT_PATTERNS:
+        if pattern.search(text):
+            raise ValueError(
+                "output contains forbidden pattern — potential secret leak"
+            )
+
+
+def check_python_version(
+    version_str: str, parser: Callable[[str], tuple[int, int, int] | None] | None = None
+) -> tuple[CheckResult, str, CheckResult]:
+    parse_fn = parser or _parse_python_version
+    ver = parse_fn(version_str)
+    if ver is None:
+        return "WARN", version_str, "FAIL"
+    ok = _version_ok(ver)
+    if ok:
+        return "PASS", f"{ver[0]}.{ver[1]}.{ver[2]}", "PASS"
+    return "WARN", f"{ver[0]}.{ver[1]}.{ver[2]}", "FAIL"
+
+
+def build_report(
+    root: Path | None = None,
+    *,
+    git_runner: Callable[..., subprocess.CompletedProcess] | None = None,
+    python_runner: Callable[..., subprocess.CompletedProcess] | None = None,
+    gh_runner: Callable[..., subprocess.CompletedProcess] | None = None,
+    docker_runner: Callable[..., subprocess.CompletedProcess] | None = None,
+    compose_runner: Callable[..., subprocess.CompletedProcess] | None = None,
+    context_doctor_runner: Callable[..., subprocess.CompletedProcess] | None = None,
+) -> DoctorOutput:
+    r = _repo_root() if root is None else root
+    report = DoctorOutput()
+
+    # Repo root
+    if r.is_dir() and (r / ".git").is_dir() or (r / "README.md").is_file():
+        report.repo_root_found = "PASS"
+    else:
+        report.repo_root_found = "FAIL"
+        report.warnings.append("Repo root not detected — run from CDB repo root")
+
+    # Git
+    git_cmd = "git --version"
+    rc, gout, gerr = _run_cmd(git_cmd, runner=git_runner)
+    git_output = gout or gerr or ""
+    report.git_found = "PASS" if (rc == 0 and git_output) else "FAIL"
+    if report.git_found == "PASS":
+        branch_cmd = "git rev-parse --abbrev-ref HEAD"
+        _, branch_out, _ = _run_cmd(branch_cmd, runner=git_runner)
+        report.git_branch = branch_out.strip() or "unknown"
+
+        status_cmd = "git status --porcelain"
+        _, status_out, _ = _run_cmd(status_cmd, runner=git_runner)
+        report.git_dirty = "WARN" if status_out.strip() else "PASS"
+    else:
+        report.git_branch = ""
+        report.git_dirty = "SKIP"
+
+    # Python
+    python_cmd = "python --version"
+    rc, pout, perr = _run_cmd(python_cmd, runner=python_runner)
+    py_output = pout or perr or ""
+    if rc == 0 or (rc != -1 and py_output):
+        report.python_found = "PASS" if py_output else "FAIL"
+        if py_output:
+            ver_status, ver_str, ver_ok = check_python_version(py_output)
+            report.python_version = ver_str
+            report.python_version_ok = ver_ok
+    else:
+        report.python_found = "FAIL"
+        report.python_version = ""
+        report.python_version_ok = "FAIL"
+
+    # gh
+    gh_cmd = "gh --version"
+    rc, gh_out, gh_err = _run_cmd(gh_cmd, runner=gh_runner)
+    gh_output = gh_out or gh_err or ""
+    report.gh_found = "PASS" if (rc == 0 and gh_output) else "WARN"
+    if report.gh_found == "PASS":
+        auth_cmd = "gh auth status -h github.com"
+        rc_auth, _, _ = _run_cmd(auth_cmd, runner=gh_runner)
+        report.gh_auth = "PASS" if rc_auth == 0 else "WARN"
+    else:
+        report.gh_auth = "SKIP"
+
+    # Docker
+    docker_cmd = "docker --version"
+    rc, dout, derr = _run_cmd(docker_cmd, runner=docker_runner)
+    docker_output = dout or derr or ""
+    report.docker_found = "PASS" if (rc == 0 and docker_output) else "WARN"
+    if report.docker_found == "PASS":
+        compose_cmd = "docker compose version"
+        rc_c, cout, cerr = _run_cmd(compose_cmd, runner=compose_runner)
+        compose_output = cout or cerr or ""
+        report.compose_found = "PASS" if (rc_c == 0 and compose_output) else "WARN"
+    else:
+        report.compose_found = "SKIP"
+
+    # .env
+    env_status, env_detail = _check_env_file()
+    report.env_file = env_status
+    if env_status == "WARN":
+        report.warnings.append(env_detail)
+
+    # SECRETS_PATH
+    secrets_status, secrets_detail = _check_secrets_path()
+    report.secrets_path = secrets_status
+    report.secrets_resolved_dir = secrets_detail
+
+    # Onboarding files
+    files_status, missing_files = _onboarding_files_exist(r)
+    report.onboarding_files = files_status
+    if missing_files:
+        report.warnings.append(f"Missing onboarding files: {', '.join(missing_files)}")
+
+    # Context doctor reachability
+    doctor_status = _check_context_doctor_reachable(runner=context_doctor_runner)
+    report.context_doctor_reachable = doctor_status
+    if doctor_status != "PASS":
+        report.warnings.append(
+            "make context-doctor not reachable (run: make context-query-config-init)"
+        )
+
+    # Build per-check list
+    report.checks = [
+        CheckItem(name="Repo root", status=report.repo_root_found),
+        CheckItem(name="Git", status=report.git_found, detail=report.git_branch),
+        CheckItem(name="Git branch", status=report.git_dirty, detail=report.git_branch),
+        CheckItem(name="Python", status=report.python_found, detail=report.python_version),
+        CheckItem(name="Python version", status=report.python_version_ok, detail=report.python_version),
+        CheckItem(name="gh CLI", status=report.gh_found),
+        CheckItem(name="gh auth", status=report.gh_auth),
+        CheckItem(name="Docker", status=report.docker_found),
+        CheckItem(name="Docker Compose", status=report.compose_found),
+        CheckItem(name=".env file", status=report.env_file),
+        CheckItem(name="SECRETS_PATH", status=report.secrets_path, detail=report.secrets_resolved_dir),
+        CheckItem(name="Onboarding files", status=report.onboarding_files),
+        CheckItem(name="make context-doctor", status=report.context_doctor_reachable),
+    ]
+
+    return report
+
+
+def compute_exit_code(report: DoctorOutput) -> int:
+    fails = [c for c in report.checks if c.status == "FAIL"]
+    return 1 if fails else 0
+
+
+def format_report(report: DoctorOutput, fmt: str) -> str:
+    if fmt == "json":
+        return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+
+    lines: list[str] = [
+        "=== CDB Onboarding Doctor ===",
+        f"lr_note: {report.lr_note}",
+        "",
+    ]
+
+    status_icons = {"PASS": "OK", "WARN": "**", "FAIL": "!!", "SKIP": "--"}
+
+    for check in report.checks:
+        icon = status_icons.get(check.status, "??")
+        line = f"  [{icon}] {check.name}"
+        if check.detail:
+            safe_detail = _safe_summary(check.detail, 80)
+            line += f": {safe_detail}"
+        lines.append(line)
+
+    lines.append("")
+    lines.append(f"  >> Secrets path: {_safe_summary(report.secrets_resolved_dir, 100)}")
+    lines.append(f"  >> .env: {report.env_file}")
+
+    if report.warnings:
+        lines.append("")
+        lines.append("warnings:")
+        for w in report.warnings:
+            lines.append(f"  - {_safe_summary(w, 120)}")
+
+    if report.context_doctor_reachable == "PASS":
+        lines.append("")
+        lines.append("  >> Onboarding looks usable. Run 'make context-doctor' for")
+        lines.append("     Context Intelligence preflight.")
+    else:
+        lines.append("")
+        lines.append("  >> Run 'make context-query-config-init' then 'make context-doctor'")
+        lines.append("     for Context Intelligence preflight.")
+
+    return "\n".join(lines)
+
+
+def _safe_summary(text: str, max_len: int = 80) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + "..."
+
+
+_HELP_EPILOG = """\
+Examples:
+  python -m tools.onboarding_doctor
+  python -m tools.onboarding_doctor --format json
+  .\\tools\\cdb.ps1 onboarding doctor
+  make onboarding-doctor
+
+Exit codes:
+  0  all checks PASS or only non-blocking WARN
+  1  one or more FAIL checks
+  2  CLI usage error
+"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only onboarding doctor for CDB developer setup.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_HELP_EPILOG,
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.format not in ("text", "json"):
+        print("ERROR: unsupported --format", file=sys.stderr)
+        return 2
+
+    report = build_report()
+    output = format_report(report, args.format)
+    _validate_output_safe(output)
+    print(output)
+    return compute_exit_code(report)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc


### PR DESCRIPTION
## Summary

Add `python -m tools.onboarding_doctor` — a cross-platform, read-only preflight that validates a new developer's local environment against CDB onboarding requirements. Also available as `.\tools\cdb.ps1 onboarding doctor` (Windows) and `make onboarding-doctor`.

The doctor is the canonical entry point for new developers after cloning the repo: one command to verify Git, Python, GitHub CLI, Docker, environment files, secrets path, onboarding documentation presence, and context-doctor reachability.

## Changed Files

| File | Type |
|------|------|
| `tools/onboarding_doctor.py` | New — cross-platform Python onboarding doctor |
| `tests/unit/test_onboarding_doctor.py` | New — 21 unit tests (mocked/stubbed external commands) |
| `tools/cdb.ps1` | Modified — added `onboarding doctor` routing + Python dispatch |
| `Makefile` | Modified — added `onboarding-doctor` target + help text |
| `DEVELOPER_ONBOARDING.md` | Modified — add doctor to Quick Verification + Quick Reference |
| `tools/README.md` | Modified — add doctor command table row |
| `docs/index.md` | Modified — add doctor row to "Nach Aufgabe" table + make target |
| `docs/onboarding/DEVELOPER_VISUAL_START_HERE.md` | Modified — add doctor step to visual start path |
| `docs/onboarding/repo_brain_context_intelligence.md` | Modified — add doctor alongside context-doctor |
| `mcp_navpack_working_repo/ENTRYPOINTS.yaml` | Modified — add id 16 for onboarding_doctor.py |
| `mcp_navpack_working_repo/CHEATSHEET.md` | Modified — add doctor entrypoint line |

## Commands Added

| Command | Description |
|---------|-------------|
| `python -m tools.onboarding_doctor` | Run doctor (cross-platform, primary) |
| `.\tools\cdb.ps1 onboarding doctor` | Run doctor via cdb.ps1 (Windows) |
| `make onboarding-doctor` | Run doctor via Makefile |

## Checks Covered by Doctor

- Repo root detection
- Git available + branch info (WARN if not on main)
- Python 3.12+ available + version check
- GitHub CLI (`gh`) installed + authenticated
- Docker Engine available
- Docker Compose available
- `.env` file present (with `.env.example` fallback)
- `SECRETS_PATH` environment variable set + directory exists
- All onboarding documentation files present
- `make context-doctor` reachable (WARN if not, non-blocking)
- `--format json` output option for tooling
- Exit code 0 = all PASS or only WARN; exit code 1 = any FAIL

## Validation

- `pytest -v tests/unit/test_onboarding_doctor.py` — 21/21 passed
- `pytest tests/unit/surrealdb/test_context_onboarding_doctor.py -q` — 24/24 passed
- `python -m tools.onboarding_doctor` — all checks PASS
- `python -m tools.onboarding_doctor --format json` — valid JSON, no secret leakage
- `ruff check tools/onboarding_doctor.py tests/unit/test_onboarding_doctor.py` — 0 errors
- `git diff --check` — clean
- No secret values in output (verified by forbidden-pattern regression tests + manual `rg` scan)

## Scope Boundaries

- Read-only: no Docker/Compose/Runtime mutations, no DB writes, no MCP mutations
- No changes to Docker/Compose/Runtime files
- No CI guard implementation (tracked in #3233)
- No changes to `.opencode/plans/` or `docs/decisions/` (scope-foreign, untracked)
- No live/trading scope touched

## Safety / LR Statement

LR remains **NO-GO**. Board stage `trade-capable` does not authorize live trading. This change introduces no trading, execution, or live-order functionality. No secrets, API keys, or credentials are output or logged.

## References

Refs #3232