### PR TITLE
[ONBOARDING][V3] Add core system eventflow visual docs

### DIFF
--- a/docs/onboarding/DEVELOPER_VISUAL_START_HERE.md
+++ b/docs/onboarding/DEVELOPER_VISUAL_START_HERE.md
@@ -114,6 +114,19 @@ flowchart TD
 - Evidence doc template: [`templates/evidence_doc_template.md`](templates/evidence_doc_template.md)
 - PR body template: [`templates/pr_body_template.md`](templates/pr_body_template.md)
 
+## Core System Eventflows
+
+The [Core System Eventflows](core-eventflows/README.md) pack visualizes CDB's primary
+runtime dataflows: Eventbus, BLUE/RED Topology, Signal Decision, Risk Gate,
+Execution/Paper Feedback, Persistence/Audit Chain, ARVP Replay Validation, and
+the Profitability Candidate Lifecycle.
+
+These visuals are **orientation, not authority**. They help new developers and
+agents understand the system flow before touching runtime code. The canonical
+sources remain the files named in the bootloader read order.
+
+> **LR remains NO-GO.** Board stage `trade-capable` is not Live-Go. No Echtgeld-Go.
+
 ## Authority Boundary
 
 This pack is a developer-facing start surface. It does not replace:

--- a/docs/onboarding/core-eventflows/README.md
+++ b/docs/onboarding/core-eventflows/README.md
@@ -1,0 +1,93 @@
+# Core System Eventflows — Onboarding Pack
+
+## Status
+
+Docs-only onboarding artifact. Visual orientation — not authoritative.
+
+Status: docs-only, LR remains NO-GO, kein Live-Go, kein Echtgeld-Go.
+
+## Parent / Issue Refs
+
+- Parent: [#3253 Core-System Eventflow Map Pack](https://github.com/jannekbuengener/Claire_de_Binare/issues/3253)
+- Child Issues: #3254, #3255, #3256, #3257, #3258, #3259, #3260, #3261
+- Glossary Issue: [#3262 Extend CDB Glossary](https://github.com/jannekbuengener/Claire_de_Binare/issues/3262)
+- Glossary Dependency: [#3247 V2 Glossary](https://github.com/jannekbuengener/Claire_de_Binare/issues/3247)
+
+## Ziel des Packs
+
+Dieses Pack visualisiert die Kernsystem-Flüsse von Claire de Binare: Runtime Eventbus,
+BLUE/RED Topology, Signal Decision, Risk Gate, Execution/Paper Feedback, Persistence/Audit,
+ARVP Replay Validation und den Profitability Candidate Lifecycle.
+
+Neue Developer und Agents sollen den echten Systemfluss verstehen, bevor sie an
+Runtime-, Strategy-, Risk- oder Execution-Code arbeiten.
+
+## Wann dieses Pack lesen
+
+- Du bist neu im Repo und hast die Start-Pfade in
+  [`DEVELOPER_VISUAL_START_HERE.md`](../DEVELOPER_VISUAL_START_HERE.md) gelesen.
+- Du planst Arbeiten an einem Runtime-Service, der Strategie, Risk oder Execution betrifft.
+- Du möchtest den Datenfluss zwischen den CDB-Komponenten verstehen.
+- Du bereitest einen Agenten-Prompt für systemnahe Arbeiten vor.
+
+## Reihenfolge der Flow-Dokumente
+
+Die Dokumente bauen inhaltlich aufeinander auf. Lies sie in dieser Reihenfolge:
+
+| # | Flow | Kernfrage |
+|---|------|-----------|
+| 1 | [Core Runtime Eventflow](core_runtime_eventflow.md) | Wie fliessen Daten durch das System? |
+| 2 | [BLUE/RED Runtime Topology](blue_red_runtime_topology.md) | Welche Services gehören zu welchem Stack? |
+| 3 | [Signal Decision Flow](signal_decision_flow.md) | Wie entsteht ein Signal? |
+| 4 | [Risk Gate Flow](risk_gate_flow.md) | Wie wird ein Signal zur Order? |
+| 5 | [Execution, Paper/Mock and Order Result Feedback](execution_paper_order_result_flow.md) | Wie wird eine Order ausgeführt? |
+| 6 | [Persistence and Audit Chain](persistence_audit_chain_flow.md) | Wie werden Events persistiert? |
+| 7 | [ARVP Replay Validation Flow](arvp_replay_validation_flow.md) | Wie wird offline validiert? |
+| 8 | [Profitability Candidate Lifecycle](profitability_candidate_lifecycle_flow.md) | Wie wird aus einer Idee ein Kandidat? |
+
+## Flow-Übersicht
+
+| Flow | Issue | Datei | Kernfrage |
+|------|-------|-------|-----------|
+| Core Runtime Eventflow | [#3254](https://github.com/jannekbuengener/Claire_de_Binare/issues/3254) | [`core_runtime_eventflow.md`](core_runtime_eventflow.md) | Wie fliessen Daten durch das System? |
+| BLUE/RED Topology | [#3255](https://github.com/jannekbuengener/Claire_de_Binare/issues/3255) | [`blue_red_runtime_topology.md`](blue_red_runtime_topology.md) | Welche Services gehören zu welchem Stack? |
+| Signal Decision | [#3256](https://github.com/jannekbuengener/Claire_de_Binare/issues/3256) | [`signal_decision_flow.md`](signal_decision_flow.md) | Wie entsteht ein Signal? |
+| Risk Gate | [#3257](https://github.com/jannekbuengener/Claire_de_Binare/issues/3257) | [`risk_gate_flow.md`](risk_gate_flow.md) | Wie wird ein Signal zur Order? |
+| Execution/Paper | [#3258](https://github.com/jannekbuengener/Claire_de_Binare/issues/3258) | [`execution_paper_order_result_flow.md`](execution_paper_order_result_flow.md) | Wie wird eine Order ausgeführt? |
+| Persistence/Audit | [#3259](https://github.com/jannekbuengener/Claire_de_Binare/issues/3259) | [`persistence_audit_chain_flow.md`](persistence_audit_chain_flow.md) | Wie werden Events persistiert? |
+| ARVP Replay | [#3260](https://github.com/jannekbuengener/Claire_de_Binare/issues/3260) | [`arvp_replay_validation_flow.md`](arvp_replay_validation_flow.md) | Wie wird offline validiert? |
+| Candidate Lifecycle | [#3261](https://github.com/jannekbuengener/Claire_de_Binare/issues/3261) | [`profitability_candidate_lifecycle_flow.md`](profitability_candidate_lifecycle_flow.md) | Wie wird aus einer Idee ein Kandidat? |
+
+## Safety Summary
+
+- **Docs-only.** Keine Runtime-, Service-, DB-, Risk-, Execution-, Allocation- oder LR-Änderung.
+- **LR bleibt NO-GO.** Board stage `trade-capable` ist kein Live-Go. Kein Echtgeld-Go.
+- **Kein Code.** Diese Dokumente sind reine Markdown/Mermaid-Visualisierungen.
+- **Orientierung, nicht Authority.** Die kanonischen Quellen bleiben die im Bootloader
+  genannten Dateien und der GitHub Live State.
+- **Keine automatische Promotion.** Keine Ableitung von Live-Berechtigung aus Visuals.
+
+## Quellenliste
+
+- [`knowledge/ARCHITECTURE_MAP.md`](../../knowledge/ARCHITECTURE_MAP.md)
+- [`services/README.md`](../../services/README.md)
+- [`docs/strategy/CDB_PROFITABILITY_ENGINE_CANON.md`](../../docs/strategy/CDB_PROFITABILITY_ENGINE_CANON.md)
+- [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)
+- [`docs/runbooks/CONTROL_REGISTER.md`](../../docs/runbooks/CONTROL_REGISTER.md)
+- [`docs/onboarding/DEVELOPER_VISUAL_START_HERE.md`](../DEVELOPER_VISUAL_START_HERE.md)
+
+## Glossary Dependency
+
+Die Begriffe in diesen Flow-Dokumenten setzen ein gemeinsames Verständnis von
+CDB-Terminologie voraus. Ein kanonisches Glossary wird in
+[#3247](https://github.com/jannekbuengener/Claire_de_Binare/issues/3247) geplant
+und in [#3262](https://github.com/jannekbuengener/Claire_de_Binare/issues/3262) um
+Core-System-Flow-Begriffe erweitert. Zum Zeitpunkt der Erstellung dieses Packs
+existiert die Glossar-Datei noch nicht (`HOLD_PARTIAL_GLOSSARY`).
+
+## Hinweis: Board trade-capable ist kein Live-Go
+
+Board stage `trade-capable` ([`docs/runbooks/CONTROL_REGISTER.md`](../../docs/runbooks/CONTROL_REGISTER.md))
+ist ein betrieblicher Fokus, keine Live-Freigabe. Das LR-System
+([`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md))
+bleibt die alleinige SSOT für Echtgeld Go/No-Go.

--- a/docs/onboarding/core-eventflows/arvp_replay_validation_flow.md
+++ b/docs/onboarding/core-eventflows/arvp_replay_validation_flow.md
@@ -1,0 +1,96 @@
+# ARVP Replay and Replay-vs-Paper Validation Flow
+
+## Status
+
+Docs-only onboarding artifact. Visual orientation — not authoritative.
+
+## Parent / Issue Refs
+
+- Parent: [#3253 Core-System Eventflow Map Pack](https://github.com/jannekbuengener/Claire_de_Binare/issues/3253)
+- Issue: [#3260 Map ARVP Replay and Replay-vs-Paper Validation Flow](https://github.com/jannekbuengener/Claire_de_Binare/issues/3260)
+
+## Purpose
+
+Show the ARVP (Automated Replay Validation Pipeline) flow: from dataset acquisition through deterministic replay, replay-vs-paper comparison, calibration reports, regime scorecards, and finally the ARVP Gate verdict. ARVP is CDB's primary validation mechanism — it produces evidence, not approvals.
+
+## Mermaid Diagram
+
+See [`diagrams/arvp_replay_validation_flow.mmd`](diagrams/arvp_replay_validation_flow.mmd) for the source file.
+
+```mermaid
+flowchart TD
+    subgraph Dataset["Dataset Layer"]
+        DS[Dataset Source<br/>file | db]
+        DP[DatasetProvider<br/>FileBacked | DBBacked]
+        DQ[DatasetSpec<br/>fingerprint, window]
+    end
+    subgraph Replay["Replay Execution"]
+        HB[Historical Bridge<br/>file-backed historical input]
+        SR[Strategy Replay Runner<br/>strategy_backtest_runner.py]
+        SC[Scheduler<br/>event-time, speed profiles]
+        RR[Replay Reporter<br/>report.json, manifest, audit.log]
+    end
+    subgraph Compare["Replay-vs-Paper Compare"]
+        RC[Replay vs Paper Compare<br/>replay_vs_paper_compare.py]
+        SCMP[Shadow Comparison<br/>shadow_comparison.json]
+        CR[Calibration Report<br/>simulator_calibration_report.json]
+    end
+    subgraph Evidence["Evidence / Gate"]
+        RS[Regime Scorecards<br/>arvp_regime_scorecard.json]
+        AG[ARVP Gate Verdict<br/>pass / fail / blocked]
+    end
+    DS --> DP
+    DP --> DQ
+    DQ --> HB
+    HB --> SR
+    SC --> SR
+    SR --> RR
+    RR --> RC
+    RC --> SCMP
+    SCMP --> CR
+    RC --> RS
+    RS --> AG
+    SCMP --> AG
+    CR --> AG
+```
+
+## What New Developers Must Understand
+
+1. **ARVP is evidence, not release authorization.** A passing ARVP gate means the replay evidence is consistent. It does not authorize paper promotion, live trading, or any operational change.
+2. **Replay is offline/validation, not runtime.** Replay runs use historical data and deterministic schedulers. They do not touch Redis, live services, or any runtime component.
+3. **Dataset quality is a precondition.** Garbage in, garbage out. The DatasetSpec and DatasetProvider layers validate ordering, tick cadence, and required fields before any replay starts.
+4. **Drift must be visible.** Replay-vs-Paper Compare, Calibration Reports, and Regime Scorecards are designed to surface drift between simulated and paper execution. If drift exceeds thresholds, the ARVP gate blocks.
+5. **Two dataset sources exist.** File-based (JSON/JSONL) for local validation and DB-based (Postgres `candles_1m`) for production replay. They are mutually exclusive per run.
+
+## Source of Truth / Primary Repo Sources
+
+- [`knowledge/ARCHITECTURE_MAP.md`](../../knowledge/ARCHITECTURE_MAP.md) — Core replay infrastructure, DatasetSpec, DatasetProvider, ARVP gate, comparison tools
+- [`core/replay/`](../../core/replay/) — Replay contracts, deterministic loop, envelopes, scheduler, comparison, calibration
+- [`services/validation/`](../../services/validation/) — CLI runners for replay, comparison, calibration, scorecards
+
+## Safety Boundaries
+
+- Replay is fully offline. It has no network, Redis, or PostgreSQL access during execution.
+- ARVP Gate verdicts are machine-readable but require human interpretation for any promotion decision.
+- All replay artifacts are deterministic and fingerprintable.
+- Replay never creates or modifies trading state.
+
+## Non-Goals
+
+- Not a strategy validation methodology document
+- Not a dataset curation guide
+- Not a replacement for operator review of replay results
+
+## Common Failure Modes / Onboarding Traps
+
+| Trap | Reality |
+|------|---------|
+| Expecting replay to match paper exactly | Replay and paper have different execution contexts. Drift is expected; the question is whether drift is within acceptable thresholds. |
+| Assuming dataset file = dataset db equivalence | File-backed and DB-backed datasets may have different timestamps, ordering, or completeness. Always verify source alignment before comparison. |
+| Treating ARVP pass as paper promotion approval | ARVP validates replay consistency. Paper promotion requires additional gates, evidence, and human approval. |
+
+## LR NO-GO / Kein Live-Go / Kein Echtgeld-Go
+
+LR remains NO-GO ([`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)).
+Board stage `trade-capable` is not Live-Go.
+No Echtgeld-Go.

--- a/docs/onboarding/core-eventflows/blue_red_runtime_topology.md
+++ b/docs/onboarding/core-eventflows/blue_red_runtime_topology.md
@@ -1,0 +1,98 @@
+# BLUE/RED Runtime Topology
+
+## Status
+
+Docs-only onboarding artifact. Visual orientation — not authoritative.
+
+## Parent / Issue Refs
+
+- Parent: [#3253 Core-System Eventflow Map Pack](https://github.com/jannekbuengener/Claire_de_Binare/issues/3253)
+- Issue: [#3255 Map BLUE/RED Runtime Topology](https://github.com/jannekbuengener/Claire_de_Binare/issues/3255)
+
+## Purpose
+
+Show the BLUE/RED stack split that structures CDB's Docker Compose deployment. BLUE is the always-on core trading layer; RED is the signal-generation and monitoring layer. Understanding this topology is essential for operators, developers, and anyone touching the runtime environment.
+
+## Mermaid Diagram
+
+See [`diagrams/blue_red_runtime_topology.mmd`](diagrams/blue_red_runtime_topology.mmd) for the source file.
+
+```mermaid
+flowchart TD
+    subgraph BLUE["BLUE Stack (compose.blue.yml) — Core, Always-On"]
+        PG[PostgreSQL<br/>cdb_postgres :5432]
+        RD[Redis<br/>cdb_redis :6379]
+        MK[Market<br/>cdb_market :8009]
+        CA[Candles<br/>cdb_candles :8007]
+        RE[Regime<br/>cdb_regime :8008]
+        AL[Allocation<br/>cdb_allocation :8006]
+        RK[Risk<br/>cdb_risk :8002]
+        EX[Execution<br/>cdb_execution :8003]
+        DW[DB Writer<br/>cdb_db_writer]
+        PR[Paper Runner<br/>cdb_paper_runner :8004]
+    end
+    subgraph RED["RED Stack (compose.red.yml) — Signal + Monitoring"]
+        WS[WebSocket<br/>cdb_ws :8000]
+        SG[Signal<br/>cdb_signal :8005]
+        RP[Reports<br/>cdb_reports]
+        PM[Prometheus<br/>cdb_prometheus :19090→9090]
+        GF[Grafana<br/>cdb_grafana :3000]
+        PX[Postgres Exporter<br/>cdb_postgres_exporter :9187]
+        RX[Redis Exporter<br/>cdb_redis_exporter :9121]
+        CAV[cAdvisor<br/>cdb_cadvisor]
+    end
+    subgraph LOG["Logging Overlay (logging.yml) — Optional"]
+        LK[Loki<br/>cdb_loki]
+        PT[Promtail<br/>cdb_promtail]
+        AM[Alertmanager<br/>cdb_alertmanager]
+    end
+    WS -->|market_data Pub/Sub| MK
+    WS -->|market_data Pub/Sub| CA
+    WS -->|market_data Pub/Sub| SG
+    WS -->|market_data Pub/Sub| PR
+    SG -->|signals Stream| RK
+    RK -->|orders Stream| EX
+    EX -->|order_results Stream| RK
+    EX -->|order_results Stream| DW
+    PR -->|portfolio_snapshots Stream| DW
+    DW --> PG
+```
+
+## What New Developers Must Understand
+
+1. **BLUE is the core.** It contains all trading-critical services: Market, Candles, Regime, Allocation, Risk, Execution, DB Writer, and Paper Runner. If BLUE is down, the system cannot function.
+2. **RED is signal + observability.** WebSocket feeds market data in; Signal produces trading signals. Monitoring (Prometheus, Grafana, exporters) lives here. RED can fail without taking down BLUE's core pipeline.
+3. **The Logging Overlay is optional.** Loki, Promtail, and Alertmanager are not part of the standard BLUE/RED start sequence. Activate them explicitly via `-f logging.yml`.
+4. **`compose.blue.yml` and `compose.red.yml` are the canonical compose files.** Legacy files (`base.yml`, `dev.yml`, `tls.yml`) exist but are non-canonical.
+5. **Healthy stack != Live-readiness.** The stack can be fully up and healthy while the system remains in LR NO-GO status.
+
+## Source of Truth / Primary Repo Sources
+
+- [`knowledge/ARCHITECTURE_MAP.md`](../../knowledge/ARCHITECTURE_MAP.md) — Full service map with ports and compose references
+- [`infrastructure/compose/README.md`](../../infrastructure/compose/README.md) — Compose file documentation
+
+## Safety Boundaries
+
+- This diagram describes the **current deployment topology**, not a target architecture.
+- The stack can be started and verified without any live-trading risk.
+- No service in this topology can independently place a real trade.
+
+## Non-Goals
+
+- Not a Docker/docker-compose tutorial
+- Not a capacity planning document
+- Not a high-availability or disaster-recovery runbook
+
+## Common Failure Modes / Onboarding Traps
+
+| Trap | Reality |
+|------|---------|
+| Assuming RED must be up for BLUE to function | BLUE containers start without RED. Market data will not flow without cdb_ws, but core services remain available. |
+| Confusing Logging Overlay as part of standard startup | Logging is optional. Start with `make docker-up` (BLUE+RED), add logging explicitly. |
+| Reading healthy stack as readiness | All containers green does not mean the system is cleared for live trading. |
+
+## LR NO-GO / Kein Live-Go / Kein Echtgeld-Go
+
+LR remains NO-GO ([`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)).
+Board stage `trade-capable` is not Live-Go.
+No Echtgeld-Go.

--- a/docs/onboarding/core-eventflows/core_runtime_eventflow.md
+++ b/docs/onboarding/core-eventflows/core_runtime_eventflow.md
@@ -1,0 +1,102 @@
+# Core Runtime Eventflow
+
+## Status
+
+Docs-only onboarding artifact. Visual orientation — not authoritative.
+
+## Parent / Issue Refs
+
+- Parent: [#3253 Core-System Eventflow Map Pack](https://github.com/jannekbuengener/Claire_de_Binare/issues/3253)
+- Issue: [#3254 Map Core Runtime Eventflow](https://github.com/jannekbuengener/Claire_de_Binare/issues/3254)
+
+## Purpose
+
+Show the primary dataflow through CDB's runtime: from WebSocket market data ingestion through market, candles, signal, risk, execution, and finally persistence. This is the frame every developer needs before touching any runtime service.
+
+## Mermaid Diagram
+
+See [`diagrams/core_runtime_eventflow.mmd`](diagrams/core_runtime_eventflow.mmd) for the source file.
+
+```mermaid
+flowchart LR
+    subgraph External["External"]
+        WS[cdb_ws<br/>WebSocket Service]
+    end
+    subgraph Redis["Redis Layer"]
+        MD[market_data<br/>Pub/Sub channel]
+        SIG[signals<br/>Redis Stream]
+        ORD[orders<br/>Redis Stream]
+        FR[stream.fills<br/>Redis Stream]
+        OR[order_results<br/>Redis Stream]
+    end
+    subgraph BLUE["BLUE Core Services"]
+        MK[cdb_market<br/>Market Service]
+        CA[cdb_candles<br/>Candles Service]
+        RG[cdb_regime<br/>Regime Service]
+        AL[cdb_allocation<br/>Allocation Service]
+        RK[cdb_risk<br/>Risk Service]
+        EX[cdb_execution<br/>Execution Service]
+        DW[cdb_db_writer<br/>DB Writer]
+    end
+    subgraph RED["RED Signal Services"]
+        SG[cdb_signal<br/>Signal Service]
+        PR[cdb_paper_runner<br/>Paper Runner]
+    end
+    subgraph Storage["Persistent Storage"]
+        PG[(PostgreSQL)]
+    end
+    WS --> MD
+    MD --> MK
+    MD --> CA
+    MD --> SG
+    MD --> PR
+    SG --> SIG
+    SIG --> RK
+    SIG --> DW
+    RK --> ORD
+    ORD --> EX
+    EX --> FR
+    EX --> OR
+    OR --> RK
+    OR --> DW
+    DW --> PG
+```
+
+## What New Developers Must Understand
+
+1. `market_data` is **Redis Pub/Sub** (not a Stream). It is a fire-and-forget broadcast channel. Services that miss a message will not replay it from this channel.
+2. `signals`, `orders`, `allocation_decisions`, `stream.fills` are **Redis Streams** — durable, replayable logs. Consumers can read from any point.
+3. `order_results` is feedback flow: execution results go back to Risk (for position/exposure tracking) and to DB Writer (for persistence).
+4. The DB Writer is a **persistence consumer**, not a decision maker. It writes what it receives; it does not validate or block.
+5. Allocation and Regime are supporting services — they provide context (position targets, market regime) to Risk but are not on the hot path.
+
+## Source of Truth / Primary Repo Sources
+
+- [`knowledge/ARCHITECTURE_MAP.md`](../../knowledge/ARCHITECTURE_MAP.md) — Service map, Redis channels, dataflows
+- [`services/README.md`](../../services/README.md) — Redis transport semantics, service index
+
+## Safety Boundaries
+
+- This flow doc describes the **runtime as it exists today**. It does not propose changes.
+- The system runs in **paper/mock mode by default**. Live exchange integration is gated.
+- No service on this map can independently authorize a real trade. Every order passes through Risk.
+
+## Non-Goals
+
+- Not a deployment guide (see [`infrastructure/compose/README.md`](../../infrastructure/compose/README.md))
+- Not a service implementation reference (see individual service READMEs under [`services/`](../../services/))
+- Not a governance document (see [`knowledge/governance/`](../../knowledge/governance/))
+
+## Common Failure Modes / Onboarding Traps
+
+| Trap | Reality |
+|------|---------|
+| Treating `market_data` as a durable Stream | It is Pub/Sub — no replay. Subscribers must handle missed messages gracefully. |
+| Expecting DB Writer to validate | It persists what it receives. Validation happens upstream in Risk/Signal. |
+| Expecting direct service-to-service calls | All inter-service communication goes through Redis. Services are stateless and event-driven. |
+
+## LR NO-GO / Kein Live-Go / Kein Echtgeld-Go
+
+LR remains NO-GO ([`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)).
+Board stage `trade-capable` is not Live-Go.
+No Echtgeld-Go.

--- a/docs/onboarding/core-eventflows/diagrams/arvp_replay_validation_flow.mmd
+++ b/docs/onboarding/core-eventflows/diagrams/arvp_replay_validation_flow.mmd
@@ -1,0 +1,42 @@
+---
+title: ARVP Replay and Replay-vs-Paper Validation Flow
+---
+
+flowchart TD
+    subgraph Dataset["Dataset Layer"]
+        DS[Dataset Source<br/>file | db]
+        DP[DatasetProvider<br/>FileBacked | DBBacked]
+        DQ[DatasetSpec<br/>fingerprint, window]
+    end
+
+    subgraph Replay["Replay Execution"]
+        HB[Historical Bridge<br/>file-backed historical input]
+        SR[Strategy Replay Runner<br/>strategy_backtest_runner.py]
+        SC[Scheduler<br/>event-time, speed profiles]
+        RR[Replay Reporter<br/>report.json, manifest, audit.log]
+    end
+
+    subgraph Compare["Replay-vs-Paper Compare"]
+        RC[Replay vs Paper Compare<br/>replay_vs_paper_compare.py]
+        SCMP[Shadow Comparison<br/>shadow_comparison.json]
+        CR[Calibration Report<br/>simulator_calibration_report.json]
+    end
+
+    subgraph Evidence["Evidence / Gate"]
+        RS[Regime Scorecards<br/>arvp_regime_scorecard.json]
+        AG[ARVP Gate Verdict<br/>pass / fail / blocked]
+    end
+
+    DS --> DP
+    DP --> DQ
+    DQ --> HB
+    HB --> SR
+    SC --> SR
+    SR --> RR
+    RR --> RC
+    RC --> SCMP
+    SCMP --> CR
+    RC --> RS
+    RS --> AG
+    SCMP --> AG
+    CR --> AG

--- a/docs/onboarding/core-eventflows/diagrams/blue_red_runtime_topology.mmd
+++ b/docs/onboarding/core-eventflows/diagrams/blue_red_runtime_topology.mmd
@@ -1,0 +1,46 @@
+---
+title: BLUE/RED Runtime Topology
+---
+
+flowchart TD
+    subgraph BLUE["BLUE Stack (compose.blue.yml) — Core, Always-On"]
+        PG[PostgreSQL<br/>cdb_postgres :5432]
+        RD[Redis<br/>cdb_redis :6379]
+        MK[Market<br/>cdb_market :8009]
+        CA[Candles<br/>cdb_candles :8007]
+        RE[Regime<br/>cdb_regime :8008]
+        AL[Allocation<br/>cdb_allocation :8006]
+        RK[Risk<br/>cdb_risk :8002]
+        EX[Execution<br/>cdb_execution :8003]
+        DW[DB Writer<br/>cdb_db_writer]
+        PR[Paper Runner<br/>cdb_paper_runner :8004]
+    end
+
+    subgraph RED["RED Stack (compose.red.yml) — Signal + Monitoring"]
+        WS[WebSocket<br/>cdb_ws :8000]
+        SG[Signal<br/>cdb_signal :8005]
+        RP[Reports<br/>cdb_reports]
+        PM[Prometheus<br/>cdb_prometheus :19090→9090]
+        GF[Grafana<br/>cdb_grafana :3000]
+        PX[Postgres Exporter<br/>cdb_postgres_exporter :9187]
+        RX[Redis Exporter<br/>cdb_redis_exporter :9121]
+        CAV[cAdvisor<br/>cdb_cadvisor]
+    end
+
+    subgraph LOG["Logging Overlay (logging.yml) — Optional"]
+        LK[Loki<br/>cdb_loki]
+        PT[Promtail<br/>cdb_promtail]
+        AM[Alertmanager<br/>cdb_alertmanager]
+    end
+
+    WS -->|market_data Pub/Sub| MK
+    WS -->|market_data Pub/Sub| CA
+    WS -->|market_data Pub/Sub| SG
+    WS -->|market_data Pub/Sub| PR
+
+    SG -->|signals Stream| RK
+    RK -->|orders Stream| EX
+    EX -->|order_results Stream| RK
+    EX -->|order_results Stream| DW
+    PR -->|portfolio_snapshots Stream| DW
+    DW --> PG

--- a/docs/onboarding/core-eventflows/diagrams/core_runtime_eventflow.mmd
+++ b/docs/onboarding/core-eventflows/diagrams/core_runtime_eventflow.mmd
@@ -1,0 +1,58 @@
+---
+title: Core Runtime Eventflow
+---
+
+flowchart LR
+    subgraph External["External"]
+        WS[cdb_ws<br/>WebSocket Service]
+    end
+
+    subgraph Redis["Redis Layer"]
+        MD[market_data<br/>Pub/Sub channel]
+        SIG[signals<br/>Redis Stream]
+        ORD[orders<br/>Redis Stream]
+        FR[stream.fills<br/>Redis Stream]
+        OR[order_results<br/>Redis Stream]
+    end
+
+    subgraph BLUE["BLUE Core Services"]
+        MK[cdb_market<br/>Market Service]
+        CA[cdb_candles<br/>Candles Service]
+        RG[cdb_regime<br/>Regime Service]
+        AL[cdb_allocation<br/>Allocation Service]
+        RK[cdb_risk<br/>Risk Service]
+        EX[cdb_execution<br/>Execution Service]
+        DW[cdb_db_writer<br/>DB Writer]
+    end
+
+    subgraph RED["RED Signal Services"]
+        SG[cdb_signal<br/>Signal Service]
+        PR[cdb_paper_runner<br/>Paper Runner]
+    end
+
+    subgraph Storage["Persistent Storage"]
+        PG[(PostgreSQL)]
+    end
+
+    WS --> MD
+    MD --> MK
+    MD --> CA
+    MD --> SG
+    MD --> PR
+
+    SG --> SIG
+
+    SIG --> RK
+    SIG --> DW
+
+    RK --> ORD
+
+    ORD --> EX
+
+    EX --> FR
+    EX --> OR
+
+    OR --> RK
+    OR --> DW
+
+    DW --> PG

--- a/docs/onboarding/core-eventflows/diagrams/execution_paper_order_result_flow.mmd
+++ b/docs/onboarding/core-eventflows/diagrams/execution_paper_order_result_flow.mmd
@@ -1,0 +1,43 @@
+---
+title: Execution, Paper/Mock and Order Result Feedback
+---
+
+flowchart LR
+    subgraph Input["Input"]
+        ORD[orders Stream]
+    end
+
+    subgraph Exec["Execution Service (cdb_execution)"]
+        EP[Execution Processor]
+        MOCK{Mock/Paper Boundary<br/>default mode}
+        DPL[Deployment Logic<br/>paper vs live]
+    end
+
+    subgraph Exchange["Exchange Boundary"]
+        EX_LIVE[Live Exchange<br/>GATED FUTURE<br/>requires explicit LR gate]
+    end
+
+    subgraph Feedback["Order Result Feedback"]
+        FR[stream.fills Redis Stream]
+        ORI[order_results Redis Stream]
+    end
+
+    subgraph Consumers["Consumers"]
+        RK[cdb_risk<br/>position/exposure update]
+        DW[cdb_db_writer<br/>persistence]
+    end
+
+    ORD --> EP
+    EP --> MOCK
+    MOCK -->|Paper/Mock mode (default)| DPL
+    MOCK -->|Live mode| EX_LIVE
+    DPL --> FR
+    DPL --> ORI
+    EX_LIVE -->|fills + results| FR
+    EX_LIVE -->|fills + results| ORI
+    ORI --> RK
+    ORI --> DW
+    FR --> RK
+    FR --> DW
+
+    style EX_LIVE fill:#f99,stroke:#c33,stroke-dasharray: 5 5

--- a/docs/onboarding/core-eventflows/diagrams/persistence_audit_chain_flow.mmd
+++ b/docs/onboarding/core-eventflows/diagrams/persistence_audit_chain_flow.mmd
@@ -1,0 +1,46 @@
+---
+title: Persistence and Correlation/Audit Event Chain
+---
+
+flowchart LR
+    subgraph Streams["Redis Streams"]
+        SIG[signals]
+        ORD[orders]
+        ORI[order_results]
+        PS[portfolio_snapshots]
+    end
+
+    subgraph RiskEvents["Risk Events (DB)"]
+        RE[risk_events]
+        BD[blocked_decisions]
+    end
+
+    subgraph Writer["DB Writer (cdb_db_writer)"]
+        DW[Stream Consumer<br/>fan-out persistence]
+        CL[correlation_ledger<br/>SIGNAL→DECISION→ORDER→FILL]
+    end
+
+    subgraph DB["PostgreSQL"]
+        PG[(Persistent Store)]
+    end
+
+    subgraph Audit["Audit / Evidence Chain"]
+        EC[Event Chain<br/>fully traceable]
+        PW[Paper Reference Windows<br/>for replay-vs-paper compare]
+    end
+
+    SIG --> DW
+    ORD --> DW
+    ORI --> DW
+    PS --> DW
+    RE --> DW
+    BD --> DW
+
+    DW --> CL
+    CL --> PG
+
+    PG --> EC
+    PG --> PW
+
+    EC -.->|audit reference| Audit
+    PW -.->|comparison reference| Audit

--- a/docs/onboarding/core-eventflows/diagrams/profitability_candidate_lifecycle_flow.mmd
+++ b/docs/onboarding/core-eventflows/diagrams/profitability_candidate_lifecycle_flow.mmd
@@ -1,0 +1,65 @@
+---
+title: Profitability Candidate Lifecycle and Evidence Gate Flow
+---
+
+flowchart LR
+    subgraph Active["Active States"]
+        IDEA[IDEA]
+        SPEC[SPECIFIED]
+        BT[BACKTESTED]
+        ARV[ARVP_VALIDATED]
+        ST[STRESS_TESTED]
+        PC[PAPER_CANDIDATE]
+        PV[PAPER_VALIDATED]
+        MLC[MICRO_LIVE_CANDIDATE]
+    end
+
+    subgraph Terminal["Terminal States"]
+        REJ[REJECTED]
+        PRK[PARKED]
+        UNS[UNSAFE]
+        SUP[SUPERSEDED]
+        STL[STALE]
+    end
+
+    IDEA --> SPEC
+    SPEC --> BT
+    BT --> ARV
+    ARV --> ST
+    ST --> PC
+    PC --> PV
+    PV --> MLC
+
+    IDEA --> REJ
+    SPEC --> REJ
+    BT --> REJ
+    ARV --> REJ
+    ST --> REJ
+
+    SPEC --> PRK
+    BT --> PRK
+    ARV --> PRK
+    ST --> PRK
+    PV --> PRK
+
+    SPEC --> UNS
+    BT --> UNS
+    ARV --> UNS
+    ST --> UNS
+    PC --> UNS
+    PV --> UNS
+
+    SPEC --> SUP
+    BT --> SUP
+    ARV --> SUP
+    ST --> SUP
+
+    PC --> STL
+    PV --> STL
+
+    style MLC fill:#9cf,stroke:#069
+    style REJ fill:#f99,stroke:#c33
+    style PRK fill:#ff9,stroke:#c90
+    style UNS fill:#f66,stroke:#c00
+    style SUP fill:#ddd,stroke:#999
+    style STL fill:#ddd,stroke:#999

--- a/docs/onboarding/core-eventflows/diagrams/risk_gate_flow.mmd
+++ b/docs/onboarding/core-eventflows/diagrams/risk_gate_flow.mmd
@@ -1,0 +1,47 @@
+---
+title: Risk Gate, Circuit Breaker and KillSwitch Flow
+---
+
+flowchart TD
+    subgraph Input["Input"]
+        SIG[Signal<br/>from signals Stream]
+    end
+
+    subgraph RiskGate["Risk Service (cdb_risk)"]
+        MSC[Market State Contract<br/>freshness, validity]
+        EXP[Exposure Check<br/>current vs limit]
+        DD[Drawdown Check<br/>max drawdown guard]
+        LIM[Additional Limits<br/>position size, rate]
+        CB{Circuit Breaker<br/>auto-trip on threshold}
+        KS{KillSwitch<br/>manual/admin override}
+    end
+
+    subgraph Decision["Decision Path"]
+        AP[Approved Order]
+        BL[Blocked Decision]
+        EV[risk_events<br/>and blocked_decisions]
+    end
+
+    subgraph Output["Output"]
+        ORD[orders Stream]
+        ALRT[alerts channel]
+    end
+
+    SIG --> MSC
+    MSC --> EXP
+    EXP --> DD
+    DD --> LIM
+    LIM --> CB
+    CB -->|Breaker Tripped| BL
+    CB -->|OK| KS
+    KS -->|KillSwitch Active| BL
+    KS -->|KillSwitch Inactive| AP
+
+    AP --> ORD
+    BL --> EV
+    AP --> EV
+    EV --> ALRT
+
+    style BL fill:#f99,stroke:#c33
+    style CB fill:#ff9,stroke:#c90
+    style KS fill:#ff9,stroke:#c90

--- a/docs/onboarding/core-eventflows/diagrams/signal_decision_flow.mmd
+++ b/docs/onboarding/core-eventflows/diagrams/signal_decision_flow.mmd
@@ -1,0 +1,37 @@
+---
+title: Strategy Signal Decision Flow
+---
+
+flowchart TD
+    subgraph Input["Input Layer"]
+        MC[Market Data<br/>from cdb_ws]
+        CD[Candles 1m]
+        RM[Regime Context]
+    end
+
+    subgraph Strategy["Strategy Context (primary_breakout_v1)"]
+        WH[Time-Window History<br/>High/Low with ts_ms]
+        LO[Time-Window Lookback<br/>entry/exit in minutes]
+        WU[Warmup Check<br/>full window span required]
+        DEC[Decision Logic<br/>evaluate BEFORE append]
+        APP[Append tick/candle<br/>to history AFTER decision]
+    end
+
+    subgraph Output["Output Layer"]
+        SP[Signal Payload<br/>direction, price, confidence]
+        CH[signals channel<br/>Redis Stream]
+    end
+
+    MC --> WH
+    CD --> WH
+    RM --> DEC
+    WH --> LO
+    LO --> WU
+    WU -->|pass| DEC
+    WU -->|fail: warmup| NO[No Signal<br/>warmup not met]
+    DEC -->|evaluate| APP
+    APP --> WH
+    DEC --> SP
+    SP --> CH
+
+    style NO fill:#f99,stroke:#c33

--- a/docs/onboarding/core-eventflows/execution_paper_order_result_flow.md
+++ b/docs/onboarding/core-eventflows/execution_paper_order_result_flow.md
@@ -1,0 +1,95 @@
+# Execution, Paper/Mock and Order Result Feedback
+
+## Status
+
+Docs-only onboarding artifact. Visual orientation — not authoritative.
+
+## Parent / Issue Refs
+
+- Parent: [#3253 Core-System Eventflow Map Pack](https://github.com/jannekbuengener/Claire_de_Binare/issues/3253)
+- Issue: [#3258 Map Execution, Paper/Mock and Order Result Feedback](https://github.com/jannekbuengener/Claire_de_Binare/issues/3258)
+
+## Purpose
+
+Show how orders from Risk are processed by Execution, how the paper/mock boundary works, and how order results flow back to Risk and persistence. This is the path between a risk-approved order and a recorded fill.
+
+## Mermaid Diagram
+
+See [`diagrams/execution_paper_order_result_flow.mmd`](diagrams/execution_paper_order_result_flow.mmd) for the source file.
+
+```mermaid
+flowchart LR
+    subgraph Input["Input"]
+        ORD[orders Stream]
+    end
+    subgraph Exec["Execution Service (cdb_execution)"]
+        EP[Execution Processor]
+        MOCK{Mock/Paper Boundary<br/>default mode}
+        DPL[Deployment Logic<br/>paper vs live}
+    end
+    subgraph Exchange["Exchange Boundary"]
+        EX_LIVE[Live Exchange<br/>GATED FUTURE<br/>requires explicit LR gate]
+    end
+    subgraph Feedback["Order Result Feedback"]
+        FR[stream.fills Redis Stream]
+        ORI[order_results Redis Stream]
+    end
+    subgraph Consumers["Consumers"]
+        RK[cdb_risk<br/>position/exposure update]
+        DW[cdb_db_writer<br/>persistence]
+    end
+    ORD --> EP
+    EP --> MOCK
+    MOCK -->|Paper/Mock mode (default)| DPL
+    MOCK -->|Live mode| EX_LIVE
+    DPL --> FR
+    DPL --> ORI
+    EX_LIVE --> FR
+    EX_LIVE --> ORI
+    ORI --> RK
+    ORI --> DW
+    FR --> RK
+    FR --> DW
+    style EX_LIVE fill:#f99,stroke:#c33,stroke-dasharray: 5 5
+```
+
+## What New Developers Must Understand
+
+1. **Paper/Mock is the default mode.** Every order runs through paper/mock execution unless explicitly gated for live. This is not a config flag — it is a safety invariant.
+2. **Execution does not authorize trades.** It receives risk-approved orders and processes them. It does not decide what to trade, how much, or whether to trade at all.
+3. **Live/Exchange is a gated future boundary.** The live exchange adapter exists in code but requires explicit LR gate clearance and human approval. It is never the default path.
+4. **Order results flow bidirectionally.** `order_results` and `stream.fills` update Risk (position tracking, exposure) and DB Writer (persistence) simultaneously.
+5. **No order is final until it appears in `order_results`.** Execution may reject an order (e.g. invalid parameters, rate limits). Consumers must handle both fill and reject paths.
+
+## Source of Truth / Primary Repo Sources
+
+- [`services/execution/README.md`](../../services/execution/README.md) — Execution service documentation
+- [`tools/paper_trading/README.md`](../../tools/paper_trading/README.md) — Paper runner documentation
+- [`knowledge/ARCHITECTURE_MAP.md`](../../knowledge/ARCHITECTURE_MAP.md) — Channel map, invariants
+
+## Safety Boundaries
+
+- Execution is strictly a processor. It has no authority to generate orders or modify risk parameters.
+- Paper/mock execution produces realistic fills but never touches a real exchange.
+- Live exchange integration is gated by the LR process and requires explicit human GO.
+- All order results are recorded in Redis Streams and PostgreSQL for full auditability.
+
+## Non-Goals
+
+- Not an order type reference
+- Not an exchange adapter implementation guide
+- Not a paper simulation accuracy analysis
+
+## Common Failure Modes / Onboarding Traps
+
+| Trap | Reality |
+|------|---------|
+| Assuming paper execution equals live execution | Paper fills have no slippage, latency, or liquidity constraints. Replay-vs-paper comparison exists precisely to quantify these gaps. |
+| Expecting Execution to validate risk | Execution trusts that Risk has already validated the order. It processes what it receives. |
+| Confusing paper runner with execution paper mode | Paper Runner (`tools/paper_trading/`) is a separate portfolio simulator. Execution's built-in paper mode is the default order processing path. |
+
+## LR NO-GO / Kein Live-Go / Kein Echtgeld-Go
+
+LR remains NO-GO ([`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)).
+Board stage `trade-capable` is not Live-Go.
+No Echtgeld-Go.

--- a/docs/onboarding/core-eventflows/persistence_audit_chain_flow.md
+++ b/docs/onboarding/core-eventflows/persistence_audit_chain_flow.md
@@ -1,0 +1,95 @@
+# Persistence and Correlation/Audit Event Chain
+
+## Status
+
+Docs-only onboarding artifact. Visual orientation — not authoritative.
+
+## Parent / Issue Refs
+
+- Parent: [#3253 Core-System Eventflow Map Pack](https://github.com/jannekbuengener/Claire_de_Binare/issues/3253)
+- Issue: [#3259 Map Persistence and Correlation/Audit Event Chain](https://github.com/jannekbuengener/Claire_de_Binare/issues/3259)
+
+## Purpose
+
+Show how CDB persists all trading events and maintains a fully traceable audit chain. The `correlation_ledger` links every SIGNAL -> DECISION -> ORDER -> FILL into an append-only chain. This is the foundation for audit, replay-vs-paper comparison, and evidence-based validation.
+
+## Mermaid Diagram
+
+See [`diagrams/persistence_audit_chain_flow.mmd`](diagrams/persistence_audit_chain_flow.mmd) for the source file.
+
+```mermaid
+flowchart LR
+    subgraph Streams["Redis Streams"]
+        SIG[signals]
+        ORD[orders]
+        ORI[order_results]
+        PS[portfolio_snapshots]
+    end
+    subgraph RiskEvents["Risk Events (DB)"]
+        RE[risk_events]
+        BD[blocked_decisions]
+    end
+    subgraph Writer["DB Writer (cdb_db_writer)"]
+        DW[Stream Consumer<br/>fan-out persistence]
+        CL[correlation_ledger<br/>SIGNAL→DECISION→ORDER→FILL]
+    end
+    subgraph DB["PostgreSQL"]
+        PG[(Persistent Store)]
+    end
+    subgraph Audit["Audit / Evidence Chain"]
+        EC[Event Chain<br/>fully traceable]
+        PW[Paper Reference Windows<br/>for replay-vs-paper compare]
+    end
+    SIG --> DW
+    ORD --> DW
+    ORI --> DW
+    PS --> DW
+    RE --> DW
+    BD --> DW
+    DW --> CL
+    CL --> PG
+    PG --> EC
+    PG --> PW
+    EC -.->|audit reference| Audit
+    PW -.->|comparison reference| Audit
+```
+
+## What New Developers Must Understand
+
+1. **Persistence is evidence, not approval.** Writing to PostgreSQL does not mean any action is approved. It means the event was recorded for audit, replay, or evidence purposes.
+2. **The correlation_ledger is the audit spine.** Every trading-relevant event links back through the chain: a FILL references its ORDER, which references its DECISION, which references its SIGNAL. This chain is the foundation for all audit and comparison workflows.
+3. **Paper Reference Windows enable replay-vs-paper comparison.** A `paper_reference_window` is a time-bound extract from the correlation_ledger that captures a paper trading session. Replay runs can be compared against these windows to quantify drift.
+4. **risk_events and blocked_decisions are also persisted.** These are not just real-time signals — they are written to PostgreSQL for retrospective analysis and audit.
+5. **The DB Writer is a passive consumer.** It writes what it receives from Redis Streams. It does not validate, filter, or enrich.
+
+## Source of Truth / Primary Repo Sources
+
+- [`knowledge/ARCHITECTURE_MAP.md`](../../knowledge/ARCHITECTURE_MAP.md) — PostgreSQL schema artefacts, correlation_ledger, blocked_decisions
+- [`services/db_writer/README.md`](../../services/db_writer/README.md) — DB Writer service documentation
+- [`infrastructure/database/migrations/`](../../infrastructure/database/migrations/) — Migration files for correlation_ledger (006_correlation_phase8c.sql) and risk_events (005_risk_events_idempotent.sql)
+
+## Safety Boundaries
+
+- The DB Writer has no write path to Redis Streams. It cannot inject events.
+- The correlation_ledger is append-only. No deletion or modification of historical events.
+- All persistence is in service of audit, replay, and evidence — never for trade authorization.
+
+## Non-Goals
+
+- Not a database schema reference
+- Not a migration guide
+- Not an audit compliance document
+
+## Common Failure Modes / Onboarding Traps
+
+| Trap | Reality |
+|------|---------|
+| Treating PostgreSQL as the system of decision | PostgreSQL stores what happened. It does not decide what should happen. |
+| Expecting the correlation_ledger to be complete in real-time | There is a processing delay between a Stream event and its ledger entry. Query with appropriate time buffers. |
+| Assuming paper_reference_window export includes all events | The export requires at least one ORDER with one FILL in the window. Empty windows are valid but produce no export. |
+
+## LR NO-GO / Kein Live-Go / Kein Echtgeld-Go
+
+LR remains NO-GO ([`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)).
+Board stage `trade-capable` is not Live-Go.
+No Echtgeld-Go.

--- a/docs/onboarding/core-eventflows/profitability_candidate_lifecycle_flow.md
+++ b/docs/onboarding/core-eventflows/profitability_candidate_lifecycle_flow.md
@@ -1,0 +1,115 @@
+# Profitability Candidate Lifecycle and Evidence Gate Flow
+
+## Status
+
+Docs-only onboarding artifact. Visual orientation — not authoritative.
+
+## Parent / Issue Refs
+
+- Parent: [#3253 Core-System Eventflow Map Pack](https://github.com/jannekbuengener/Claire_de_Binare/issues/3253)
+- Issue: [#3261 Map Profitability Candidate Lifecycle](https://github.com/jannekbuengener/Claire_de_Binare/issues/3261)
+- Canon: [`CDB_PROFITABILITY_ENGINE_CANON.md`](../../docs/strategy/CDB_PROFITABILITY_ENGINE_CANON.md)
+
+## Purpose
+
+Show the full lifecycle of a profitability candidate through CDB's strategy pipeline: from raw IDEA through specification, backtesting, ARVP validation, stress testing, paper validation, and ultimately to micro-live candidate status. This is the path a strategy idea follows to become a candidate for real trading — with explicit gates, evidence requirements, and terminal states.
+
+## Mermaid Diagram
+
+See [`diagrams/profitability_candidate_lifecycle_flow.mmd`](diagrams/profitability_candidate_lifecycle_flow.mmd) for the source file.
+
+```mermaid
+flowchart LR
+    subgraph Active["Active States"]
+        IDEA[IDEA]
+        SPEC[SPECIFIED]
+        BT[BACKTESTED]
+        ARV[ARVP_VALIDATED]
+        ST[STRESS_TESTED]
+        PC[PAPER_CANDIDATE]
+        PV[PAPER_VALIDATED]
+        MLC[MICRO_LIVE_CANDIDATE]
+    end
+    subgraph Terminal["Terminal States"]
+        REJ[REJECTED]
+        PRK[PARKED]
+        UNS[UNSAFE]
+        SUP[SUPERSEDED]
+        STL[STALE]
+    end
+    IDEA --> SPEC
+    SPEC --> BT
+    BT --> ARV
+    ARV --> ST
+    ST --> PC
+    PC --> PV
+    PV --> MLC
+    IDEA --> REJ
+    SPEC --> REJ
+    BT --> REJ
+    ARV --> REJ
+    ST --> REJ
+    SPEC --> PRK
+    BT --> PRK
+    ARV --> PRK
+    ST --> PRK
+    PV --> PRK
+    SPEC --> UNS
+    BT --> UNS
+    ARV --> UNS
+    ST --> UNS
+    PC --> UNS
+    PV --> UNS
+    SPEC --> SUP
+    BT --> SUP
+    ARV --> SUP
+    ST --> SUP
+    PC --> STL
+    PV --> STL
+    style MLC fill:#9cf,stroke:#069
+    style REJ fill:#f99,stroke:#c33
+    style PRK fill:#ff9,stroke:#c90
+    style UNS fill:#f66,stroke:#c00
+    style SUP fill:#ddd,stroke:#999
+    style STL fill:#ddd,stroke:#999
+```
+
+## What New Developers Must Understand
+
+1. **Candidate Factory creates candidates, not trades.** The lifecycle tracks strategy candidates through validation stages. It does not authorize trading. A candidate in any active state is still just a candidate.
+2. **Net profitability matters.** Gross returns are not sufficient. Evidence must account for fees, spread, slippage, rejections, and latency before any promotion decision.
+3. **The Strategy League Table recommends but does not authorize.** Ranking candidates by performance helps prioritize validation effort. It does not give any candidate the right to trade.
+4. **Micro-Live requires separate LR gates.** Even PAPER_VALIDATED does not imply live readiness. MICRO_LIVE_CANDIDATE requires explicit LR gate clearance, human approval, and a cleared LR-SSOT.
+5. **Terminal states are final.** REJECTED, PARKED, UNSAFE, SUPERSEDED, and STALE are endpoints. A candidate in these states is not on the active pipeline.
+
+## Source of Truth / Primary Repo Sources
+
+- [`docs/strategy/CDB_PROFITABILITY_ENGINE_CANON.md`](../../docs/strategy/CDB_PROFITABILITY_ENGINE_CANON.md) — Full lifecycle definition, gate matrix, evidence requirements
+- [`knowledge/ARCHITECTURE_MAP.md`](../../knowledge/ARCHITECTURE_MAP.md) — Replay infrastructure underlying ARVP validation
+
+## Safety Boundaries
+
+- The Candidate Lifecycle is a governance framework, not a runtime system.
+- No candidate lifecycle state change creates a financial instrument trade.
+- MICRO_LIVE_CANDIDATE is the furthest state from raw IDEA — it requires passing through every validation gate.
+- Terminal states (UNSAFE, REJECTED) are not reversible without a full re-evaluation.
+
+## Non-Goals
+
+- Not a template for candidate specification
+- Not an evidence packet format reference
+- Not a replacement for the Profitability Engine Canon
+
+## Common Failure Modes / Onboarding Traps
+
+| Trap | Reality |
+|------|---------|
+| Treating PAPER_VALIDATED as near-live | PAPER_VALIDATED is evidence-heavy but still requires Micro-Live gates. Paper success is not a predictor of live success. |
+| Ignoring net economics | A candidate may look profitable on gross returns but fail after fees, spread, and slippage. Net calculation is mandatory at ARVP_VALIDATED and above. |
+| Assuming promotion is automatic | Every state transition requires explicit evidence and gate review. No candidate promotes itself. |
+
+## LR NO-GO / Kein Live-Go / Kein Echtgeld-Go
+
+LR remains NO-GO ([`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)).
+Board stage `trade-capable` is not Live-Go.
+No Echtgeld-Go.

--- a/docs/onboarding/core-eventflows/risk_gate_flow.md
+++ b/docs/onboarding/core-eventflows/risk_gate_flow.md
@@ -1,0 +1,98 @@
+# Risk Gate, Circuit Breaker and KillSwitch Flow
+
+## Status
+
+Docs-only onboarding artifact. Visual orientation — not authoritative.
+
+## Parent / Issue Refs
+
+- Parent: [#3253 Core-System Eventflow Map Pack](https://github.com/jannekbuengener/Claire_de_Binare/issues/3253)
+- Issue: [#3257 Map Risk Gate, Circuit Breaker and KillSwitch Flow](https://github.com/jannekbuengener/Claire_de_Binare/issues/3257)
+
+## Purpose
+
+Show how the Risk Service gates every signal before it becomes an order. This is the system's primary safety layer — it enforces exposure limits, drawdown caps, circuit breakers, and a manual kill switch. No trade happens without passing through Risk.
+
+## Mermaid Diagram
+
+See [`diagrams/risk_gate_flow.mmd`](diagrams/risk_gate_flow.mmd) for the source file.
+
+```mermaid
+flowchart TD
+    subgraph Input["Input"]
+        SIG[Signal<br/>from signals Stream]
+    end
+    subgraph RiskGate["Risk Service (cdb_risk)"]
+        MSC[Market State Contract<br/>freshness, validity]
+        EXP[Exposure Check<br/>current vs limit]
+        DD[Drawdown Check<br/>max drawdown guard]
+        LIM[Additional Limits<br/>position size, rate]
+        CB{Circuit Breaker<br/>auto-trip on threshold}
+        KS{KillSwitch<br/>manual/admin override}
+    end
+    subgraph Decision["Decision Path"]
+        AP[Approved Order]
+        BL[Blocked Decision]
+        EV[risk_events<br/>and blocked_decisions]
+    end
+    subgraph Output["Output"]
+        ORD[orders Stream]
+        ALRT[alerts channel]
+    end
+    SIG --> MSC
+    MSC --> EXP
+    EXP --> DD
+    DD --> LIM
+    LIM --> CB
+    CB -->|Breaker Tripped| BL
+    CB -->|OK| KS
+    KS -->|KillSwitch Active| BL
+    KS -->|KillSwitch Inactive| AP
+    AP --> ORD
+    BL --> EV
+    AP --> EV
+    EV --> ALRT
+    style BL fill:#f99,stroke:#c33
+    style CB fill:#ff9,stroke:#c90
+    style KS fill:#ff9,stroke:#c90
+```
+
+## What New Developers Must Understand
+
+1. **Risk gates every execution.** No signal bypasses Risk. A blocked decision is system protection, not a failure.
+2. **Circuit Breaker is automatic.** It trips when configurable thresholds (e.g. consecutive losses, volatility spikes) are exceeded. Reset requires explicit intervention.
+3. **KillSwitch is manual/admin.** An operator or automated admin can engage the KillSwitch to instantly block all order flow. It overrides all other checks.
+4. **Blocked decisions are recorded.** Every blocked decision produces a `blocked_decisions` event and a `risk_events` entry. These are persisted for audit.
+5. **No bypass possible.** Risk, KillSwitch, and LR gates cannot be circumvented by any service, agent, or operator shortcut.
+
+## Source of Truth / Primary Repo Sources
+
+- [`services/risk/README.md`](../../services/risk/README.md) — Risk service documentation
+- [`knowledge/governance/CDB_AGENT_POLICY.md`](../../knowledge/governance/CDB_AGENT_POLICY.md) — Agent policy on risk gate compliance
+- [`knowledge/ARCHITECTURE_MAP.md`](../../knowledge/ARCHITECTURE_MAP.md) — Risk events, blocked_decisions persistence
+
+## Safety Boundaries
+
+- Risk gating is fail-closed: if Risk cannot evaluate a signal, the signal is blocked.
+- No order reaches Execution without an explicit `orders` Stream entry produced by Risk.
+- Circuit Breaker and KillSwitch states are persisted and observable.
+
+## Non-Goals
+
+- Not a risk parameter tuning guide
+- Not a specification for new risk checks
+- Not an incident response runbook
+
+## Common Failure Modes / Onboarding Traps
+
+| Trap | Reality |
+|------|---------|
+| Assuming a passed risk check guarantees execution | Risk approval is necessary but not sufficient. Execution may reject or the KillSwitch may engage between check and order. |
+| Treating blocked decisions as bugs | A blocked decision is the system working correctly. Investigate the reason before overriding. |
+| Expecting to bypass Risk for testing | Risk gates are non-negotiable. All testing must respect the same gate path as production. |
+
+## LR NO-GO / Kein Live-Go / Kein Echtgeld-Go
+
+LR remains NO-GO ([`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)).
+Board stage `trade-capable` is not Live-Go.
+No Echtgeld-Go.

--- a/docs/onboarding/core-eventflows/signal_decision_flow.md
+++ b/docs/onboarding/core-eventflows/signal_decision_flow.md
@@ -1,0 +1,89 @@
+# Strategy Signal Decision Flow
+
+## Status
+
+Docs-only onboarding artifact. Visual orientation — not authoritative.
+
+## Parent / Issue Refs
+
+- Parent: [#3253 Core-System Eventflow Map Pack](https://github.com/jannekbuengener/Claire_de_Binare/issues/3253)
+- Issue: [#3256 Map Strategy Signal Decision Flow](https://github.com/jannekbuengener/Claire_de_Binare/issues/3256)
+
+## Purpose
+
+Show how CDB's strategy engine (`primary_breakout_v1`) evaluates market data and produces signals. The signal decision flow is the boundary between raw market data and actionable trading decisions — but a signal is not a trade authorization.
+
+## Mermaid Diagram
+
+See [`diagrams/signal_decision_flow.mmd`](diagrams/signal_decision_flow.mmd) for the source file.
+
+```mermaid
+flowchart TD
+    subgraph Input["Input Layer"]
+        MC[Market Data<br/>from cdb_ws]
+        CD[Candles 1m]
+        RM[Regime Context]
+    end
+    subgraph Strategy["Strategy Context (primary_breakout_v1)"]
+        WH[Time-Window History<br/>High/Low with ts_ms]
+        LO[Time-Window Lookback<br/>entry/exit in minutes]
+        WU[Warmup Check<br/>full window span required]
+        DEC[Decision Logic<br/>evaluate BEFORE append]
+        APP[Append tick/candle<br/>to history AFTER decision]
+    end
+    subgraph Output["Output Layer"]
+        SP[Signal Payload<br/>direction, price, confidence]
+        CH[signals channel<br/>Redis Stream]
+    end
+    MC --> WH
+    CD --> WH
+    RM --> DEC
+    WH --> LO
+    LO --> WU
+    WU -->|pass| DEC
+    WU -->|fail: warmup| NO[No Signal<br/>warmup not met]
+    DEC -->|evaluate| APP
+    APP --> WH
+    DEC --> SP
+    SP --> CH
+    style NO fill:#f99,stroke:#c33
+```
+
+## What New Developers Must Understand
+
+1. **Signal is not a trade authorization.** A signal on the `signals` channel must pass through Risk before any order is placed. A signal alone never produces a trade.
+2. **Decision-before-append.** The strategy evaluates the signal **before** appending the current candle/tick to the time-window history. This prevents lookahead bias.
+3. **Warmup semantics.** A signal is only generated when the time-window history covers the full lookback span. During warmup, no signals are produced. This is a common source of confusion when comparing replay vs paper results.
+4. **Time-window lookback.** Entry and exit lookbacks are measured as time windows (minutes), not as event counts. This ensures deterministic behavior regardless of tick frequency.
+
+## Source of Truth / Primary Repo Sources
+
+- [`knowledge/ARCHITECTURE_MAP.md`](../../knowledge/ARCHITECTURE_MAP.md) — Signal lookback semantics, warmup validation
+- [`services/signal/README.md`](../../services/signal/README.md) — Signal service implementation
+- [`core/strategy/`](../../core/strategy/) — Strategy implementations
+
+## Safety Boundaries
+
+- Signal generation is pure computation over market data. It does not interact with Risk, Execution, or any trade path.
+- No signal causes any financial instrument to be bought or sold.
+- The `signals` channel is a durable Redis Stream — consumers can replay or catch up.
+
+## Non-Goals
+
+- Not a strategy design guide
+- Not a specification for new strategy implementations
+- Not a risk or trading document
+
+## Common Failure Modes / Onboarding Traps
+
+| Trap | Reality |
+|------|---------|
+| Assuming a signal means a trade will happen | Every signal passes through Risk, which can block it. Signal = proposal, not order. |
+| Confusing lookback window semantics | Lookback is time-based (minutes), not count-based. A sparse-tick market may have fewer candles than expected. |
+| Forgetting warmup in comparisons | Replay runs with full history may produce signals where paper-with-warmup did not. Always align warmup windows. |
+
+## LR NO-GO / Kein Live-Go / Kein Echtgeld-Go
+
+LR remains NO-GO ([`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)).
+Board stage `trade-capable` is not Live-Go.
+No Echtgeld-Go.


### PR DESCRIPTION
# Summary

Implement the Core-System Eventflow Visual Onboarding Pack (#3253) as a docs-only PR. Adds 9 flow documents with embedded Mermaid diagrams, 9 standalone Mermaid diagram files, an index README, a new section in DEVELOPER_VISUAL_START_HERE.md, and notes a glossary dependency.

# Files Changed

## New files (18)
- docs/onboarding/core-eventflows/README.md — Index with flow table, safety summary, glossary dependency
- docs/onboarding/core-eventflows/core_runtime_eventflow.md + .mmd — Issue #3254
- docs/onboarding/core-eventflows/blue_red_runtime_topology.md + .mmd — Issue #3255
- docs/onboarding/core-eventflows/signal_decision_flow.md + .mmd — Issue #3256
- docs/onboarding/core-eventflows/risk_gate_flow.md + .mmd — Issue #3257
- docs/onboarding/core-eventflows/execution_paper_order_result_flow.md + .mmd — Issue #3258
- docs/onboarding/core-eventflows/persistence_audit_chain_flow.md + .mmd — Issue #3259
- docs/onboarding/core-eventflows/arvp_replay_validation_flow.md + .mmd — Issue #3260
- docs/onboarding/core-eventflows/profitability_candidate_lifecycle_flow.md + .mmd — Issue #3261

## Updated files (1)
- docs/onboarding/DEVELOPER_VISUAL_START_HERE.md — Added Core System Eventflows section linking to the pack

# Validation
- \git diff --check\: no whitespace errors
- All 18 files present (9 docs + 9 diagrams)
- Every flow doc includes: status, issue refs, purpose, Mermaid diagram, developer takeaways, source references, safety boundaries, non-goals, failure modes, LR NO-GO notice
- Safety markers confirmed in all files via \g\
- No forbidden paths touched (no services/, core/, infra/, migrations/, scripts/, .env*)
- Worktree clean: only intended docs files staged

# Safety
- **Docs-only**: no runtime, service, DB, risk, execution, allocation, or LR change
- **LR remains NO-GO**: no Live-Go, no Echtgeld-Go
- Board stage trade-capable is not Live-Go
- No code changes, no Docker changes, no infrastructure changes
- Glossary: HOLD_PARTIAL_GLOSSARY — existing glossary (#3247) not yet implemented; glossary dependency noted in README

# Refs
- Refs #3253
- Closes #3254
- Closes #3255
- Closes #3256
- Closes #3257
- Closes #3258
- Closes #3259
- Closes #3260
- Closes #3261
- Refs #3262 (glossary not yet implemented — HOLD_PARTIAL_GLOSSARY)