### PR TITLE
[ONBOARDING][V2] Add fresh-clone onboarding rehearsal

### DIFF
--- a/DEVELOPER_ONBOARDING.md
+++ b/DEVELOPER_ONBOARDING.md
@@ -36,6 +36,7 @@ Bevor du Code auscheckst, lies die aktuelle Projektlage:
 | [`README.md`](README.md) | GitHub-Landingpage; aktueller Status und Navigation |
 | [`docs/index.md`](docs/index.md) | Kuerzester aktiver Docs-Einstieg |
 | [`docs/onboarding/DEVELOPER_VISUAL_START_HERE.md`](docs/onboarding/DEVELOPER_VISUAL_START_HERE.md) | Visueller Developer-Start (Mermaid-Flow, Beispiele, Vorlagen) |
+| [`docs/onboarding/fresh_clone_rehearsal.md`](docs/onboarding/fresh_clone_rehearsal.md) | Read-only-by-default Fresh-Clone-Pfad bis zur ersten Grundsicherheit |
 | [`AGENTS.md`](AGENTS.md) | Root-Pointer -> [`agents/AGENTS.md`](agents/AGENTS.md) (Agenten-Read-Order) |
 | [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md) | SSOT fuer Echtgeld Go/No-Go (**NO-GO**) |
 | [`docs/runbooks/CONTROL_REGISTER.md`](docs/runbooks/CONTROL_REGISTER.md) | Board-Stage und operativer Fokus |

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,7 @@ sondern ein Pointer auf die bestehenden Docs, Runbooks und Source Trees.
 
 | Wenn du ... | Geh hierhin | Warum |
 |-------|-------|-------|
+| Einen frischen Clone sicher bis zur ersten Grundsicherheit durchlaufen willst | [`fresh_clone_rehearsal.md`](onboarding/fresh_clone_rehearsal.md) | Read-only-by-default Rehearsal von README uber Docs-Navigation bis zum ersten sicheren Issue/PR-Flow |
 | Einen visuellen Developer-Start mit Mermaid-Flow brauchst | [`DEVELOPER_VISUAL_START_HERE.md`](onboarding/DEVELOPER_VISUAL_START_HERE.md) | Mermaid-Flussdiagramme, Beispiele, Vorlagen — erstellt in #3238 |
 | Das vollständige lokale Setup brauchst | [`DEVELOPER_ONBOARDING.md`](../DEVELOPER_ONBOARDING.md) | Secrets, Stack-Bootstrap, erste PR-Schritte |
 | Einen One-Command-Setup-Check brauchst | `python -m tools.onboarding_doctor` or `make onboarding-doctor` | Read-only Developer-Onboarding Preflight |

--- a/docs/onboarding/DEVELOPER_VISUAL_START_HERE.md
+++ b/docs/onboarding/DEVELOPER_VISUAL_START_HERE.md
@@ -22,16 +22,17 @@ before touching implementation work.
 
 1. Read the root landing page: [`../../README.md`](../../README.md).
 2. Read the shortest docs index: [`../index.md`](../index.md).
-3. Read the developer setup guide: [`../../DEVELOPER_ONBOARDING.md`](../../DEVELOPER_ONBOARDING.md).
-4. Read service, test, and tool indexes when they match your task:
+3. Rehearse the fresh-clone path: [`fresh_clone_rehearsal.md`](fresh_clone_rehearsal.md).
+4. Read the developer setup guide: [`../../DEVELOPER_ONBOARDING.md`](../../DEVELOPER_ONBOARDING.md).
+5. Read service, test, and tool indexes when they match your task:
    [`../../services/README.md`](../../services/README.md),
    [`../../tests/README.md`](../../tests/README.md),
    [`../../tools/README.md`](../../tools/README.md).
-5. Run the onboarding doctor to verify your local setup:
+6. Run the onboarding doctor to verify your local setup:
    `python -m tools.onboarding_doctor` or `make onboarding-doctor`.
-6. Use the examples in [`examples/README.md`](examples/README.md) before drafting
+7. Use the examples in [`examples/README.md`](examples/README.md) before drafting
    your first issue-to-PR workflow.
-7. Use the templates in [`templates/`](templates/) for prompts, evidence docs,
+8. Use the templates in [`templates/`](templates/) for prompts, evidence docs,
    and docs/onboarding PR bodies.
 
 ## Start Path For Agents
@@ -107,6 +108,7 @@ flowchart TD
 ## Examples And Templates
 
 - Examples index: [`examples/README.md`](examples/README.md)
+- Fresh-clone rehearsal: [`fresh_clone_rehearsal.md`](fresh_clone_rehearsal.md)
 - First issue-to-PR flow: [`examples/first_issue_to_pr_flow.md`](examples/first_issue_to_pr_flow.md)
 - Repo Brain / Context Intelligence onboarding: [`repo_brain_context_intelligence.md`](repo_brain_context_intelligence.md)
 - First Repo Brain / Context use: [`examples/repo_brain_first_use.md`](examples/repo_brain_first_use.md)

--- a/docs/onboarding/fresh_clone_rehearsal.md
+++ b/docs/onboarding/fresh_clone_rehearsal.md
@@ -1,0 +1,293 @@
+# Fresh-Clone Onboarding Rehearsal
+
+## Status / Scope
+
+- Status: docs-only onboarding rehearsal.
+- Scope: fresh clone -> active onboarding surfaces -> optional local-confidence checks -> first safe issue/PR rehearsal.
+- Authority boundary: docs/UI are orientation, not authority. GitHub live state, repo canon, governance docs, and LR-SSOT remain authoritative.
+- Baseline mode: read-only by default. No Docker stack start is required.
+- Safety reminder: LR remains NO-GO. Board stage `trade-capable` is not Live-Go. No Echtgeld-Go.
+
+## Purpose
+
+Use this rehearsal to prove that a zero-context developer can move from a fresh
+clone to basic confidence without guessing the canon, printing secrets, starting
+the stack, or touching runtime/trading scope.
+
+Basic confidence means:
+
+- you can find the active onboarding surfaces,
+- you can explain the difference between Board stage and LR verdict,
+- you can run the read-only onboarding doctor if needed,
+- and you can describe the first safe issue/PR flow for a docs-only slice.
+
+## Who should use this rehearsal
+
+- A new developer entering CDB for the first time.
+- A maintainer validating that onboarding links still form a usable path.
+- An agent or prompt author who must point a contributor to the safest first path.
+
+## Preconditions
+
+- Mandatory baseline:
+  - Git installed.
+  - Access to clone the repo.
+  - A text editor or browser for reading the onboarding surfaces.
+- Optional local-confidence:
+  - Python available for `python -m tools.onboarding_doctor`.
+  - A local virtual environment and dev dependencies if you want lint/test smoke.
+  - `gh` CLI if you want to rehearse the issue/PR workflow locally.
+- Explicitly not required for the baseline:
+  - Docker stack start.
+  - Real secrets.
+  - Runtime access.
+  - DB writes.
+  - MCP mutations.
+
+## Step 1 — Fresh clone
+
+Mode: Mandatory baseline.
+
+Clone the repo and confirm that the checkout is sane before reading deeper docs.
+
+```bash
+git clone https://github.com/jannekbuengener/Claire_de_Binare.git
+cd Claire_de_Binare
+git status -sb
+git branch --show-current
+```
+
+What good looks like:
+
+- the repo clones without side steps,
+- the working tree is clean after clone,
+- and you know which branch you started from.
+
+Record the branch and the current HEAD SHA in your notes or evidence doc.
+
+## Step 2 — Start from README.md
+
+Mode: Mandatory baseline.
+
+Read [`../../README.md`](../../README.md) first.
+
+Confirm that you can identify:
+
+- the main new-developer entry points,
+- the active safety boundary (`LR` remains `NO-GO`),
+- the difference between repo/engineering status and live-readiness status,
+- and the direct links into onboarding, tools, tests, and services.
+
+Do not treat the README as the authority for runtime or go/no-go decisions. It is
+the front door, not the final source of truth.
+
+## Step 3 — Navigate docs/index.md
+
+Mode: Mandatory baseline.
+
+Read [`../index.md`](../index.md).
+
+Use it as the shortest docs landing page and verify that you can find:
+
+- the onboarding surfaces,
+- the glossary,
+- the visual start page,
+- the developer onboarding guide,
+- and the Repo Brain / Context Intelligence entry.
+
+Important: `docs/index.md` is a pointer page. It helps you navigate the canon but
+does not replace the source docs it links to.
+
+## Step 4 — Read CDB glossary
+
+Mode: Mandatory baseline.
+
+Read [`cdb_glossary.md`](cdb_glossary.md) before interpreting unfamiliar terms.
+
+At minimum, make sure you understand these terms in CDB context:
+
+- `LR`
+- `SSOT`
+- `Board-Stage`
+- `trade-capable`
+- `Live-Go`
+- `Echtgeld-Go`
+- `BLUE`
+- `RED`
+
+If a later onboarding page uses a term you do not know, come back to the glossary
+instead of inferring meaning from context.
+
+## Step 5 — Use Developer Visual Start Here
+
+Mode: Mandatory baseline.
+
+Read [`DEVELOPER_VISUAL_START_HERE.md`](DEVELOPER_VISUAL_START_HERE.md).
+
+Use it to build a mental map of:
+
+- the human start path,
+- the agent bootloader path,
+- the authority boundary for docs/UI,
+- and the example/template surfaces for a first contribution.
+
+This page is especially useful when the repo feels large. It is still orientation,
+not authority.
+
+## Step 6 — Follow DEVELOPER_ONBOARDING.md
+
+Mode: Mandatory baseline.
+
+Read [`../../DEVELOPER_ONBOARDING.md`](../../DEVELOPER_ONBOARDING.md) with a narrow
+goal: understand the safe baseline first, then the optional local setup path.
+
+Prioritize these sections:
+
+1. `Orientierung`
+2. `Prerequisites`
+3. `Initial Setup`
+4. `Quick Verification`
+5. `Development Workflow`
+
+Do not treat `Running the Stack (Optional)` as part of the baseline. Only continue
+there if your real task explicitly requires runtime work and the task scope allows it.
+
+## Step 7 — Run onboarding doctor if available
+
+Mode: Optional local-confidence.
+
+If you want command-level confidence, run the read-only onboarding doctor.
+
+```bash
+python -m tools.onboarding_doctor
+python -m tools.onboarding_doctor --format json
+make onboarding-doctor
+```
+
+Windows PowerShell front door:
+
+```powershell
+.\tools\cdb.ps1 onboarding doctor
+```
+
+Expected behavior:
+
+- no secret values are printed,
+- no stack start is required,
+- no DB write or MCP mutation occurs,
+- and failures point to local setup gaps rather than runtime fixes.
+
+If the doctor reports missing `.env` or `SECRETS_PATH`, follow
+`DEVELOPER_ONBOARDING.md` for the safe local setup path. Do not paste secret values
+into notes, issues, PRs, or terminal captures.
+
+## Step 8 — Minimal safe local validation
+
+Mode: Optional local-confidence.
+
+Only run this step if you want extra confidence beyond the read-only baseline.
+
+Suggested path:
+
+1. Create and activate `.venv`.
+2. Install the dev dependencies from `DEVELOPER_ONBOARDING.md`.
+3. Run a small lint/test smoke without starting the stack.
+
+```bash
+ruff check .
+pytest -q -k "not test_mcp_time_server_runtime"
+```
+
+Use this step to confirm that your clone is locally usable, not to prove runtime
+readiness. Keep the scope local and safe.
+
+## Step 9 — First safe issue/PR workflow rehearsal
+
+Mode: Mandatory reading, optional execution.
+
+Read the example flow:
+
+- [`examples/first_issue_to_pr_flow.md`](examples/first_issue_to_pr_flow.md)
+
+Rehearse the workflow for a tiny docs-only slice:
+
+1. Verify the issue state on GitHub live.
+2. Branch from current `main`.
+3. Make the smallest scoped docs change.
+4. Run the scoped validation for that slice.
+5. Push and create the PR.
+6. Set the required PR lock before any follow-up push or PR mutation:
+
+```text
+LOCK: agent=<agent-id> issue=#<issue> ts=<ISO8601> mode=single-writer
+```
+
+7. Wait for the repo-required checks to go green.
+8. Squash-merge only if the diff stays inside the approved scope.
+9. Comment the issue and close it only after the merged PR satisfies acceptance.
+
+Stay out of runtime, Docker, trading, DB-write, memory-write, LR, or live-capital
+scope for this first rehearsal.
+
+## Evidence/report template
+
+Suggested evidence path:
+
+- `docs/evidence/onboarding_fresh_clone_rehearsal_<YYYY-MM-DD>.md`
+
+Recommended starting point:
+
+- [`templates/evidence_doc_template.md`](templates/evidence_doc_template.md)
+
+Minimum content for the rehearsal report:
+
+- clone date, branch, and HEAD SHA
+- which mandatory steps were completed
+- whether the onboarding doctor was run and what it reported
+- whether optional lint/test smoke was run
+- the first issue/PR flow you rehearsed or inspected
+- open questions, limitations, and final confidence level
+
+## Limitations
+
+- This rehearsal does not prove runtime health.
+- It does not prove Docker, exchange, replay, or full-stack readiness.
+- It does not authorize Live-Go or Echtgeld-Go.
+- It does not replace governance canon, GitHub live truth, or LR-SSOT.
+- It does not create productive DB writes, memory writes, or MCP mutations.
+
+## Safety boundaries
+
+- Read-only by default.
+- No Docker stack start as a mandatory step.
+- No secret values displayed.
+- No Live-Go.
+- No Echtgeld-Go.
+- No productive DB writes.
+- No MCP mutations.
+- Docs/UI are orientation, not authority.
+
+## Troubleshooting
+
+- If you cannot tell which status source wins, return to `AGENTS.md` ->
+  `agents/AGENTS.md` and re-check the status-surface split.
+- If `trade-capable` sounds like live permission, stop and re-read
+  `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` plus
+  `docs/runbooks/CONTROL_REGISTER.md`.
+- If onboarding terms are unclear, use [`cdb_glossary.md`](cdb_glossary.md) first.
+- If the onboarding doctor fails, classify the failure as a local setup gap until
+  proven otherwise.
+- If a step requires runtime, Docker, DB, or live behavior to continue, treat that
+  as out of baseline scope and stop the rehearsal there.
+
+## Sources
+
+- [`../../README.md`](../../README.md)
+- [`../index.md`](../index.md)
+- [`cdb_glossary.md`](cdb_glossary.md)
+- [`DEVELOPER_VISUAL_START_HERE.md`](DEVELOPER_VISUAL_START_HERE.md)
+- [`../../DEVELOPER_ONBOARDING.md`](../../DEVELOPER_ONBOARDING.md)
+- [`examples/first_issue_to_pr_flow.md`](examples/first_issue_to_pr_flow.md)
+- [`templates/evidence_doc_template.md`](templates/evidence_doc_template.md)
+- [`../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)
+- [`../../docs/runbooks/CONTROL_REGISTER.md`](../../docs/runbooks/CONTROL_REGISTER.md)

--- a/tools/validate_onboarding_docs.py
+++ b/tools/validate_onboarding_docs.py
@@ -39,6 +39,7 @@ ACTIVE_ONBOARDING_SURFACES: list[str] = [
     "tools/README.md",
     "docs/surrealdb/README.md",
     "docs/onboarding/DEVELOPER_VISUAL_START_HERE.md",
+    "docs/onboarding/fresh_clone_rehearsal.md",
     "docs/onboarding/repo_brain_context_intelligence.md",
     "docs/onboarding/examples/README.md",
     "docs/onboarding/examples/first_issue_to_pr_flow.md",


### PR DESCRIPTION
## Summary
Add a docs-only fresh-clone onboarding rehearsal that guides a zero-context developer from README and docs navigation to optional local-confidence checks and a first safe issue/PR rehearsal.

## Delivered
- Added docs/onboarding/fresh_clone_rehearsal.md
- Linked the rehearsal from docs/onboarding/DEVELOPER_VISUAL_START_HERE.md, docs/index.md, and DEVELOPER_ONBOARDING.md
- Added the new active onboarding surface to tools/validate_onboarding_docs.py

## Validation
- git diff --check
- rg -n "fresh_clone_rehearsal|Fresh-Clone|fresh clone|cdb_glossary|DEVELOPER_VISUAL_START_HERE|onboarding doctor|No Live-Go|No Echtgeld-Go|LR" docs/onboarding docs/index.md DEVELOPER_ONBOARDING.md README.md
- rg -n "docker compose|runtime up|stack verify" docs/onboarding/fresh_clone_rehearsal.md
- python -m tools.validate_onboarding_docs
- pytest -q tests/unit/tools/test_validate_onboarding_docs.py --no-header

## Safety boundaries
- Docs-only scope
- No mandatory Docker stack start
- No secret output
- No Live-Go / No Echtgeld-Go
- No productive DB writes or MCP mutations

Closes #3248
Refs #3246
Refs #3226
Refs #1445