### PR TITLE
[ONBOARDING][V2][TOUR] Add guided onboarding tour command

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ sondern ein Pointer auf die bestehenden Docs, Runbooks und Source Trees.
 |-------|-------|-------|
 | Einen frischen Clone sicher bis zur ersten Grundsicherheit durchlaufen willst | [`fresh_clone_rehearsal.md`](onboarding/fresh_clone_rehearsal.md) | Read-only-by-default Rehearsal von README uber Docs-Navigation bis zum ersten sicheren Issue/PR-Flow |
 | Einen visuellen Developer-Start mit Mermaid-Flow brauchst | [`DEVELOPER_VISUAL_START_HERE.md`](onboarding/DEVELOPER_VISUAL_START_HERE.md) | Mermaid-Flussdiagramme, Beispiele, Vorlagen — erstellt in #3238 |
+| Einen kurzen guided onboarding tour command brauchst | `python -m tools.onboarding_tour` oder `.\tools\cdb.ps1 onboarding tour` | Read-only Rollenpfad fuer Developer, Agent, Docs Maintainer und Validation/Evidence |
 | Das vollständige lokale Setup brauchst | [`DEVELOPER_ONBOARDING.md`](../DEVELOPER_ONBOARDING.md) | Secrets, Stack-Bootstrap, erste PR-Schritte |
 | Einen One-Command-Setup-Check brauchst | `python -m tools.onboarding_doctor` or `make onboarding-doctor` | Read-only Developer-Onboarding Preflight |
 | Ein Issue-to-PR-Beispiel durchspielen willst | [`first_issue_to_pr_flow.md`](onboarding/examples/first_issue_to_pr_flow.md) | Kleinster Issue-to-PR-Workflow |

--- a/tests/unit/test_onboarding_tour.py
+++ b/tests/unit/test_onboarding_tour.py
@@ -1,0 +1,100 @@
+"""Unit tests for onboarding tour (#3249)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from tools import onboarding_doctor
+from tools import onboarding_tour
+
+pytestmark = pytest.mark.unit
+
+
+def test_render_tour_default_contains_core_surfaces() -> None:
+    output = onboarding_tour.render_tour()
+
+    assert "Role: General" in output
+    assert "LR remains NO-GO." in output
+    assert "Board stage trade-capable is not Live-Go." in output
+    assert "No Echtgeld-Go." in output
+    assert "docs/onboarding/cdb_glossary.md" in output
+    assert "docs/onboarding/fresh_clone_rehearsal.md" in output
+    assert ".\\tools\\cdb.ps1 onboarding doctor" in output
+    assert "#3251 planned next surface" in output
+    assert "docs/onboarding/examples/first_issue_to_pr_flow.md" in output
+
+
+@pytest.mark.parametrize(
+    ("role", "expected_title", "expected_surface"),
+    [
+        ("developer", "Role: Developer", "DEVELOPER_ONBOARDING.md"),
+        ("agent", "Role: Agent", "agents/OPEN_CODE_AGENTS.md"),
+        ("docs", "Role: Docs Maintainer", "tools/README.md"),
+        (
+            "validation",
+            "Role: Validation / Evidence",
+            "docs/onboarding/templates/evidence_doc_template.md",
+        ),
+        (
+            "evidence",
+            "Role: Validation / Evidence",
+            "docs/onboarding/templates/evidence_doc_template.md",
+        ),
+    ],
+)
+def test_render_tour_role_paths(
+    role: str, expected_title: str, expected_surface: str
+) -> None:
+    output = onboarding_tour.render_tour(role)
+
+    assert expected_title in output
+    assert expected_surface in output
+
+
+def test_render_tour_output_has_no_forbidden_patterns() -> None:
+    for role in (None, "developer", "agent", "docs", "validation", "evidence"):
+        output = onboarding_tour.render_tour(role)
+        for pattern in onboarding_doctor.FORBIDDEN_OUTPUT_PATTERNS:
+            assert not pattern.search(output), pattern.pattern
+
+
+def test_main_rejects_unknown_role() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        onboarding_tour.main(["--role", "runtime"])
+
+    assert exc_info.value.code == 2
+
+
+def test_main_prints_agent_tour(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = onboarding_tour.main(["--role", "agent"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Role: Agent" in captured.out
+    assert "AGENTS.md" in captured.out
+
+
+def test_cdb_front_door_includes_onboarding_tour() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    content = (repo_root / "tools" / "cdb.ps1").read_text(encoding="utf-8")
+
+    assert ".\\tools\\cdb.ps1 onboarding tour" in content
+    assert "'onboarding tour' { 'tools\\onboarding_tour.py' }" in content
+
+
+def test_direct_script_execution_works() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "tools/onboarding_tour.py", "--role", "docs"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Role: Docs Maintainer" in result.stdout

--- a/tools/README.md
+++ b/tools/README.md
@@ -25,6 +25,7 @@ Important:
 | `.\tools\cdb.ps1 service logs -ServiceName cdb_risk -Lines 100` | `tools/cdb-service-logs.ps1` |
 | `.\tools\cdb.ps1 runtime smoke` | `infrastructure/scripts/smoke_test.ps1` |
 | `.\tools\cdb.ps1 onboarding doctor` | `tools/onboarding_doctor.py` |
+| `.\tools\cdb.ps1 onboarding tour` | `tools/onboarding_tour.py` |
 | `make onboarding-docs-guard` | `tools/validate_onboarding_docs.py` — validiert aktive Onboarding-Dokumente: Links, Einstiegspunkte, Secret-Leaks (#3233) |
 
 Non-interactive form:

--- a/tools/cdb.ps1
+++ b/tools/cdb.ps1
@@ -25,6 +25,7 @@ Usage:
   .\tools\cdb.ps1 stack verify [args]
   .\tools\cdb.ps1 service logs [args]
   .\tools\cdb.ps1 onboarding doctor [--format json]
+  .\tools\cdb.ps1 onboarding tour [--role developer|agent|docs|validation|evidence]
 
 Examples:
   .\tools\cdb.ps1 secrets init
@@ -34,6 +35,7 @@ Examples:
   .\tools\cdb.ps1 stack verify -Verbose
   .\tools\cdb.ps1 service logs -ServiceName cdb_risk -Lines 100
   .\tools\cdb.ps1 runtime smoke -Verbose
+  .\tools\cdb.ps1 onboarding tour --role developer
 
 Non-interactive:
   pwsh -ExecutionPolicy Bypass -File .\tools\cdb.ps1 runtime up
@@ -67,6 +69,7 @@ $targetRelativePath = switch ($commandKey) {
     'stack verify' { 'tools\verify_stack.ps1' }
     'service logs' { 'tools\cdb-service-logs.ps1' }
     'onboarding doctor' { 'tools\onboarding_doctor.py' }
+    'onboarding tour' { 'tools\onboarding_tour.py' }
     default { $null }
 }
 

--- a/tools/onboarding_tour.py
+++ b/tools/onboarding_tour.py
@@ -1,0 +1,266 @@
+"""Read-only guided onboarding tour for CDB.
+
+Usage:
+    python -m tools.onboarding_tour
+    python -m tools.onboarding_tour --role developer
+    .\\tools\\cdb.ps1 onboarding tour
+
+Issue: #3249
+Parent: #3246
+"""
+
+from __future__ import annotations
+
+import argparse
+
+try:
+    from tools.onboarding_doctor import FORBIDDEN_OUTPUT_PATTERNS
+except ModuleNotFoundError:  # direct script execution via tools/cdb.ps1
+    from onboarding_doctor import FORBIDDEN_OUTPUT_PATTERNS
+
+
+ROLE_ALIASES: dict[str, str] = {
+    "developer": "developer",
+    "dev": "developer",
+    "agent": "agent",
+    "docs": "docs",
+    "docs maintainer": "docs",
+    "docs-maintainer": "docs",
+    "docs_maintainer": "docs",
+    "validation": "validation",
+    "validation/evidence": "validation",
+    "validation-evidence": "validation",
+    "evidence": "validation",
+}
+
+ROLE_LABELS: dict[str | None, str] = {
+    None: "General",
+    "developer": "Developer",
+    "agent": "Agent",
+    "docs": "Docs Maintainer",
+    "validation": "Validation / Evidence",
+}
+
+PURPOSE = (
+    "Claire de Binare is a deterministic, governance-first trading-system repo. "
+    "The working repo is the active canon for code, docs, governance, and "
+    "onboarding navigation."
+)
+
+SAFETY_LINES: list[str] = [
+    "LR remains NO-GO.",
+    "Board stage trade-capable is not Live-Go.",
+    "No Echtgeld-Go.",
+    "Docs/UI are orientation, not authority.",
+    "This tour is read-only: no file writes, no Docker/runtime calls, and no DB or MCP mutation.",
+]
+
+DEFAULT_PATH: list[tuple[str, str]] = [
+    ("README.md", "Repo landing page and safety boundary."),
+    ("docs/index.md", "Shortest docs landing page for active surfaces."),
+    (
+        "docs/onboarding/DEVELOPER_VISUAL_START_HERE.md",
+        "Visual onboarding map for developers and agents.",
+    ),
+    (
+        "docs/onboarding/cdb_glossary.md",
+        "Terminology anchor before you infer CDB-specific terms.",
+    ),
+    (
+        "docs/onboarding/fresh_clone_rehearsal.md",
+        "Read-only fresh-clone path to first safe confidence.",
+    ),
+]
+
+ROLE_PATHS: dict[str, list[tuple[str, str]]] = {
+    "developer": [
+        ("README.md", "Repo landing page and safety boundary."),
+        ("docs/index.md", "Fastest way into the active docs surfaces."),
+        (
+            "docs/onboarding/DEVELOPER_VISUAL_START_HERE.md",
+            "Human-friendly visual start path.",
+        ),
+        (
+            "docs/onboarding/fresh_clone_rehearsal.md",
+            "Fresh-clone rehearsal before you touch implementation.",
+        ),
+        (
+            "DEVELOPER_ONBOARDING.md",
+            "Local setup, quick verification, and first PR workflow.",
+        ),
+    ],
+    "agent": [
+        ("AGENTS.md", "Resolve the repo root pointer first."),
+        (
+            "agents/AGENTS.md",
+            "Read the canonical read order and status-surface rules.",
+        ),
+        (
+            "agents/OPEN_CODE_AGENTS.md",
+            "OpenCode shared contract, Brain Evidence rules, and gh-only GitHub writes.",
+        ),
+        (
+            "docs/runbooks/CONTROL_REGISTER.md",
+            "Board stage and current operating focus.",
+        ),
+        (
+            "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+            "LR SSOT for Echtgeld Go/No-Go.",
+        ),
+    ],
+    "docs": [
+        ("README.md", "Repo landing page and onboarding boundary."),
+        ("docs/index.md", "Primary docs navigation into onboarding surfaces."),
+        (
+            "docs/onboarding/DEVELOPER_VISUAL_START_HERE.md",
+            "Visual pack and authority boundary wording.",
+        ),
+        (
+            "docs/onboarding/cdb_glossary.md",
+            "Terminology consistency surface.",
+        ),
+        (
+            "tools/README.md",
+            "Canonical tool discovery, including onboarding front doors.",
+        ),
+    ],
+    "validation": [
+        ("README.md", "Repo landing page and safety boundary."),
+        (
+            "docs/index.md",
+            "Fast jump table into onboarding, evidence, tests, and runbooks.",
+        ),
+        (
+            "docs/onboarding/fresh_clone_rehearsal.md",
+            "Read-only baseline path for first safe validation steps.",
+        ),
+        (
+            "tools/README.md",
+            "Read-only onboarding doctor and docs guard entrypoints.",
+        ),
+        (
+            "docs/onboarding/templates/evidence_doc_template.md",
+            "Evidence template for scoped onboarding follow-ups.",
+        ),
+    ],
+}
+
+COMMON_SURFACES: list[tuple[str, str]] = [
+    (
+        "docs/onboarding/cdb_glossary.md",
+        "Glossary for CDB-specific terms across all onboarding docs.",
+    ),
+    (
+        "docs/onboarding/fresh_clone_rehearsal.md",
+        "Fresh-clone rehearsal for first safe orientation.",
+    ),
+    (
+        "python -m tools.onboarding_doctor | .\\tools\\cdb.ps1 onboarding doctor",
+        "Read-only local onboarding doctor.",
+    ),
+    (
+        "docs/onboarding/templates/",
+        "Prompt, evidence, and PR-body templates.",
+    ),
+    (
+        "#3251 planned next surface; use docs/onboarding/examples/first_issue_to_pr_flow.md until it lands.",
+        "First-issue sandbox is not live yet, so the tour keeps it as a planned surface only.",
+    ),
+]
+
+ROLE_HINTS: dict[str | None, str] = {
+    None: "Use --role developer|agent|docs|validation|evidence for a narrower tour.",
+    "developer": "Next safe command: python -m tools.onboarding_doctor",
+    "agent": "If scope reaches module/service/contract/context/evidence surfaces, emit the Brain Evidence block before planning.",
+    "docs": "After docs-only changes, run: python -m tools.validate_onboarding_docs",
+    "validation": "For onboarding evidence slices, start from the evidence template and keep LR/Live claims out of scope.",
+}
+
+
+def _normalize_role(role: str | None) -> str | None:
+    if role is None:
+        return None
+
+    normalized = ROLE_ALIASES.get(role.strip().lower())
+    if normalized is None:
+        allowed = "developer, agent, docs, validation, evidence"
+        raise ValueError(f"unsupported role '{role}'. Allowed roles: {allowed}")
+    return normalized
+
+
+def _validate_output_safe(text: str) -> None:
+    for pattern in FORBIDDEN_OUTPUT_PATTERNS:
+        if pattern.search(text):
+            raise ValueError("output contains forbidden pattern - potential secret leak")
+
+
+def _format_steps(title: str, steps: list[tuple[str, str]]) -> list[str]:
+    lines = [title]
+    for index, (target, note) in enumerate(steps, start=1):
+        lines.append(f"{index}. {target} - {note}")
+    return lines
+
+
+def render_tour(role: str | None = None) -> str:
+    resolved_role = _normalize_role(role)
+    path_steps = ROLE_PATHS.get(resolved_role, DEFAULT_PATH)
+
+    lines: list[str] = [
+        "=== CDB Onboarding Tour ===",
+        "Mode: read-only orientation",
+        f"Role: {ROLE_LABELS[resolved_role]}",
+        "",
+        "Purpose:",
+        PURPOSE,
+        "",
+        "Safety boundaries:",
+    ]
+    lines.extend(f"- {line}" for line in SAFETY_LINES)
+    lines.append("")
+    lines.extend(_format_steps("First 5 active reads:", path_steps))
+    lines.append("")
+    lines.append("Active onboarding surfaces:")
+    for target, note in COMMON_SURFACES:
+        lines.append(f"- {target} - {note}")
+    lines.append("")
+    lines.append("Role hint:")
+    lines.append(f"- {ROLE_HINTS[resolved_role]}")
+    lines.append("- Guided tour command: python -m tools.onboarding_tour")
+    lines.append("- PowerShell front door: .\\tools\\cdb.ps1 onboarding tour")
+    return "\n".join(lines)
+
+
+_HELP_EPILOG = """\
+Examples:
+  python -m tools.onboarding_tour
+  python -m tools.onboarding_tour --role developer
+  python -m tools.onboarding_tour --role agent
+  .\\tools\\cdb.ps1 onboarding tour
+  .\\tools\\cdb.ps1 onboarding tour --role docs
+"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only guided onboarding tour for CDB.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_HELP_EPILOG,
+    )
+    parser.add_argument(
+        "--role",
+        help="Optional role path: developer, agent, docs, validation, evidence",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        output = render_tour(args.role)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    _validate_output_safe(output)
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #3249
Refs #3246

## Delivered
- add read-only `tools/onboarding_tour.py` with default and role-based onboarding paths
- wire `./tools/cdb.ps1 onboarding tour` into help output and dispatcher mapping
- add narrow onboarding discovery updates in `tools/README.md` and `docs/index.md`
- add targeted unit tests for default output, role routing, secret-safe output, direct script execution, and PowerShell front-door mapping
- mark the First-Issue Sandbox as a planned next surface (`#3251`) and route to `docs/onboarding/examples/first_issue_to_pr_flow.md` until that surface lands

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- tools_or_queries: git/gh live checks, canonical repo reads, `context.briefing`, `context.required_reads`, `cdb_context_impact`, `rg`
- records_or_results: `HEAD=origin/main=d036e016`, #3249 open, #3246 open, #3247/#3248 closed, only Dependabot PRs open, context tools returned no DB-backed evidence
- repo_crosscheck: bootloader chain, governance docs, `tools/cdb.ps1`, onboarding doctor/validator, onboarding docs, `tools/README.md`, `docs/index.md`
- impact_on_plan: no existing tour surface found; keep implementation deterministic, read-only, and scoped; treat First-Issue Sandbox as planned-only because no file exists yet
- limitations: no SurrealDB/DB-backed records used; context tool output is advisory only and not operational truth

## Validation
- `git diff --check`
- `pytest -q tests/unit/test_onboarding_tour.py`
- `pytest -q tests/unit/test_onboarding_doctor.py`
- `python -m tools.validate_onboarding_docs`
- `python -m tools.onboarding_tour`
- `./tools/cdb.ps1 onboarding tour --role docs`

## Safety Boundaries
- LR remains NO-GO
- Board stage `trade-capable` is not Live-Go
- No Echtgeld-Go
- read-only output only; no file writes, Docker/runtime calls, or DB/MCP mutation
- no runtime, trading, strategy, or LR-status changes

## Non-goals
- no First-Issue Sandbox implementation; `#3251` remains separate
- no onboarding doctor markdown-report work; `#3250` remains separate
- no runtime, Docker, trading, or live-readiness changes

## Restunsicherheiten
- the First-Issue Sandbox does not exist as a live doc surface yet, so the tour can only mark it as planned and point to the existing first-issue example
- required GitHub checks are still pending at PR creation time and must pass before merge
