### PR TITLE
feat(onboarding): add Markdown report output for onboarding doctor (#3250)

### DIFF
--- a/DEVELOPER_ONBOARDING.md
+++ b/DEVELOPER_ONBOARDING.md
@@ -268,6 +268,9 @@ python -m tools.onboarding_doctor --format json
 # PowerShell v1 front door (Windows)
 .\tools\cdb.ps1 onboarding doctor
 
+# Write a Markdown evidence report
+python -m tools.onboarding_doctor --report docs/evidence/local_onboarding_check.md
+
 # Make target (all platforms)
 make onboarding-doctor
 ```
@@ -284,6 +287,11 @@ requiring a running stack, Docker mutation, or secret exposure. It checks:
 - `make context-doctor` reachability
 
 It does **not** output secret values. Exit codes: 0 = all good, 1 = blocking.
+
+The `--report PATH` option writes a Markdown evidence report including the
+repo HEAD, branch, a check summary, active onboarding surfaces, and safety
+boundaries. The report is only written when `--report` is explicitly set;
+the default doctor run remains read-only and writes no files.
 
 ### 5. Repo Brain / Context Preflight
 

--- a/tests/unit/test_onboarding_doctor.py
+++ b/tests/unit/test_onboarding_doctor.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import re
+import sys
 from pathlib import Path
 from subprocess import CompletedProcess
 
@@ -292,6 +294,7 @@ def test_doctor_output_to_dict(tmp_path: Path) -> None:
         git_found="PASS",
         git_branch="main",
         git_dirty="PASS",
+        repo_head="abcd1234",
         python_found="PASS",
         python_version="3.12.0",
         python_version_ok="PASS",
@@ -302,6 +305,222 @@ def test_doctor_output_to_dict(tmp_path: Path) -> None:
     )
     d = r.to_dict()
     assert d["repo_root"] == "PASS"
+    assert d["repo_head"] == "abcd1234"
     assert d["git"]["branch"] == "main"
+    assert d["git"]["head"] == "abcd1234"
     assert d["lr_note"] == "NO-GO"
     assert "checks" in d
+
+
+class TestFormatMarkdownReport:
+    def _build_sample_report(self) -> doctor.DoctorOutput:
+        r = doctor.DoctorOutput(
+            repo_root_found="PASS",
+            git_found="PASS",
+            git_branch="feat/test",
+            git_dirty="PASS",
+            repo_head="deadbeef1234",
+            python_found="PASS",
+            python_version="3.12.0",
+            python_version_ok="PASS",
+            docker_found="WARN",
+            compose_found="SKIP",
+            env_file="PASS",
+            secrets_path="PASS",
+            secrets_resolved_dir="/home/user/.secrets/.cdb",
+            onboarding_files="PASS",
+            context_doctor_reachable="PASS",
+        )
+        r.checks = [
+            doctor.CheckItem(name="Repo root", status="PASS"),
+            doctor.CheckItem(name="Git", status="PASS", detail="feat/test"),
+            doctor.CheckItem(name="Docker", status="WARN"),
+            doctor.CheckItem(name="gh CLI", status="SKIP"),
+        ]
+        return r
+
+    def test_contains_safety_statement(self) -> None:
+        r = self._build_sample_report()
+        md = doctor.format_markdown_report(r, "2026-06-16T12:00:00+00:00")
+        assert "LR remains **NO-GO**" in md
+        assert "Board stage `trade-capable` is **not** a Live-Go" in md
+        assert "No Echtgeld-Go" in md
+
+    def test_contains_repo_head(self) -> None:
+        r = self._build_sample_report()
+        md = doctor.format_markdown_report(r, "2026-06-16T12:00:00+00:00")
+        assert "deadbeef1234" in md
+
+    def test_contains_generated_timestamp(self) -> None:
+        r = self._build_sample_report()
+        ts = "2026-06-16T12:00:00+00:00"
+        md = doctor.format_markdown_report(r, ts)
+        assert ts in md
+
+    def test_contains_summary_counts(self) -> None:
+        r = self._build_sample_report()
+        md = doctor.format_markdown_report(r, "2026-06-16T12:00:00+00:00")
+        assert "**PASS**: 2" in md
+        assert "**WARN**: 1" in md
+        assert "**FAIL**: 0" in md
+        assert "**Overall**: WARN" in md
+
+    def test_contains_onboarding_surfaces(self) -> None:
+        r = self._build_sample_report()
+        md = doctor.format_markdown_report(r, "2026-06-16T12:00:00+00:00")
+        assert "## Active Onboarding Surfaces" in md
+        assert "README.md" in md
+        assert "DEVELOPER_ONBOARDING.md" in md
+
+    def test_contains_limitations(self) -> None:
+        r = self._build_sample_report()
+        md = doctor.format_markdown_report(r, "2026-06-16T12:00:00+00:00")
+        assert "## Limitations" in md
+        assert "Local checks only" in md
+
+    def test_no_secret_leak(self) -> None:
+        r = self._build_sample_report()
+        md = doctor.format_markdown_report(r, "2026-06-16T12:00:00+00:00")
+        for pattern in doctor.FORBIDDEN_OUTPUT_PATTERNS:
+            assert not pattern.search(md), f"forbidden pattern found: {pattern.pattern}"
+
+    def test_with_warnings(self) -> None:
+        r = self._build_sample_report()
+        r.warnings = ["Missing onboarding files: tests/README.md"]
+        md = doctor.format_markdown_report(r, "2026-06-16T12:00:00+00:00")
+        assert "## Warnings" in md
+        assert "tests/README.md" in md
+
+    def test_without_warnings_section_omitted(self) -> None:
+        r = self._build_sample_report()
+        r.warnings = []
+        md = doctor.format_markdown_report(r, "2026-06-16T12:00:00+00:00")
+        assert "## Warnings" not in md
+
+    def test_overall_fail(self) -> None:
+        r = self._build_sample_report()
+        r.checks.append(doctor.CheckItem(name="Fail check", status="FAIL"))
+        md = doctor.format_markdown_report(r, "2026-06-16T12:00:00+00:00")
+        assert "**Overall**: FAIL" in md
+
+    def test_overall_pass(self) -> None:
+        r = doctor.DoctorOutput(
+            repo_root_found="PASS",
+            git_found="PASS",
+            git_branch="main",
+            git_dirty="PASS",
+            repo_head="abc123",
+        )
+        r.checks = [doctor.CheckItem(name="x", status="PASS")]
+        md = doctor.format_markdown_report(r, "2026-06-16T12:00:00+00:00")
+        assert "**Overall**: PASS" in md
+
+    def test_generated_at_defaults_to_utc(self) -> None:
+        r = self._build_sample_report()
+        md = doctor.format_markdown_report(r)
+        assert "**Generated**:" in md
+
+    def test_pipe_character_escaped_in_detail(self) -> None:
+        r = self._build_sample_report()
+        r.checks = [doctor.CheckItem(name="Test", status="PASS", detail="a|b")]
+        md = doctor.format_markdown_report(r, "2026-06-16T12:00:00+00:00")
+        assert "a\\|b" in md
+
+
+class TestCLIReportArg:
+    def _mock_build_report(self, monkeypatch: pytest.MonkeyPatch) -> doctor.DoctorOutput:
+        r = doctor.DoctorOutput(
+            repo_root_found="PASS",
+            git_found="PASS",
+            git_branch="main",
+            git_dirty="PASS",
+            repo_head="testsha123",
+            python_found="PASS",
+            python_version="3.12.0",
+            python_version_ok="PASS",
+            env_file="PASS",
+            secrets_path="PASS",
+            onboarding_files="PASS",
+            context_doctor_reachable="PASS",
+        )
+        r.checks = [doctor.CheckItem(name="test", status="PASS")]
+        monkeypatch.setattr(doctor, "build_report", lambda **kw: r)
+        return r
+
+    def test_report_writes_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._mock_build_report(monkeypatch)
+        report_file = tmp_path / "report.md"
+        exit_code = doctor.main(["--report", str(report_file)])
+        assert exit_code == 0
+        assert report_file.is_file()
+        content = report_file.read_text(encoding="utf-8")
+        assert "# CDB Onboarding Doctor Report" in content
+        assert "testsha123" in content
+
+    def test_report_creates_parent_dirs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._mock_build_report(monkeypatch)
+        report_file = tmp_path / "nested" / "dir" / "report.md"
+        exit_code = doctor.main(["--report", str(report_file)])
+        assert exit_code == 0
+        assert report_file.is_file()
+
+    def test_default_no_file_write(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._mock_build_report(monkeypatch)
+        initial_files = set(p.name for p in tmp_path.iterdir())
+        exit_code = doctor.main([])
+        assert exit_code == 0
+        final_files = set(p.name for p in tmp_path.iterdir())
+        assert final_files == initial_files
+
+    def test_report_invalid_path_returns_2(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._mock_build_report(monkeypatch)
+        exit_code = doctor.main(["--report", "Z:\\INVALID\\PATH\\report.md"])
+        assert exit_code == 2
+
+    def test_json_output_remains_parseable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        r = self._mock_build_report(monkeypatch)
+        r.repo_head = "abcd1234"
+        monkeypatch.setattr(doctor, "build_report", lambda **kw: r)
+
+        import io
+        out = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+        exit_code = doctor.main(["--format", "json"])
+        assert exit_code == 0
+        data = json.loads(out.getvalue())
+        assert data["repo_root"] == "PASS"
+        assert data["repo_head"] == "abcd1234"
+        assert data["git"]["branch"] == "main"
+        assert data["git"]["head"] == "abcd1234"
+        assert data["lr_note"] == "NO-GO"
+        assert "checks" in data
+
+    def test_report_contains_secret_validation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        r = self._mock_build_report(monkeypatch)
+        r.secrets_resolved_dir = "C:\\Users\\user\\Documents\\.secrets\\.cdb"
+        monkeypatch.setattr(doctor, "build_report", lambda **kw: r)
+        report_file = tmp_path / "report.md"
+        exit_code = doctor.main(["--report", str(report_file)])
+        assert exit_code == 0
+        content = report_file.read_text(encoding="utf-8")
+        for pattern in doctor.FORBIDDEN_OUTPUT_PATTERNS:
+            assert not pattern.search(content), f"forbidden pattern found: {pattern.pattern}"
+
+    def test_report_and_text_output_coexist(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._mock_build_report(monkeypatch)
+        report_file = tmp_path / "report.md"
+        exit_code = doctor.main(["--format", "text", "--report", str(report_file)])
+        assert exit_code == 0
+        assert report_file.is_file()
+        captured = capsys.readouterr()
+        assert "=== CDB Onboarding Doctor ===" in captured.out

--- a/tests/unit/test_onboarding_doctor.py
+++ b/tests/unit/test_onboarding_doctor.py
@@ -188,7 +188,9 @@ def test_json_output_no_secret_leak(tmp_path: Path) -> None:
     )
     payload = doctor.format_report(report, "json")
     for pattern in doctor.FORBIDDEN_OUTPUT_PATTERNS:
-        assert not pattern.search(payload), f"forbidden pattern found in JSON output: {pattern.pattern}"
+        assert not pattern.search(
+            payload
+        ), f"forbidden pattern found in JSON output: {pattern.pattern}"
 
 
 def test_text_output_no_secret_leak(tmp_path: Path) -> None:
@@ -224,9 +226,7 @@ def test_compute_exit_code() -> None:
     assert doctor.compute_exit_code(warn) == 0
 
 
-def test_main_exit_codes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_main_exit_codes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     def mock_report(*args, **kwargs):
         r = doctor.DoctorOutput()
         r.repo_root_found = "PASS"
@@ -285,7 +285,6 @@ def test_onboarding_files_warn_few_missing(tmp_path: Path) -> None:
     # 7 present, 2 missing (tests/README.md, services/README.md) = WARN
     assert status == "WARN"
     assert 2 <= len(missing) <= 2
-
 
 
 def test_doctor_output_to_dict(tmp_path: Path) -> None:
@@ -428,7 +427,9 @@ class TestFormatMarkdownReport:
 
 
 class TestCLIReportArg:
-    def _mock_build_report(self, monkeypatch: pytest.MonkeyPatch) -> doctor.DoctorOutput:
+    def _mock_build_report(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> doctor.DoctorOutput:
         r = doctor.DoctorOutput(
             repo_root_found="PASS",
             git_found="PASS",
@@ -447,7 +448,9 @@ class TestCLIReportArg:
         monkeypatch.setattr(doctor, "build_report", lambda **kw: r)
         return r
 
-    def test_report_writes_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_report_writes_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         self._mock_build_report(monkeypatch)
         report_file = tmp_path / "report.md"
         exit_code = doctor.main(["--report", str(report_file)])
@@ -457,7 +460,9 @@ class TestCLIReportArg:
         assert "# CDB Onboarding Doctor Report" in content
         assert "testsha123" in content
 
-    def test_report_creates_parent_dirs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_report_creates_parent_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         self._mock_build_report(monkeypatch)
         report_file = tmp_path / "nested" / "dir" / "report.md"
         exit_code = doctor.main(["--report", str(report_file)])
@@ -489,6 +494,7 @@ class TestCLIReportArg:
         monkeypatch.setattr(doctor, "build_report", lambda **kw: r)
 
         import io
+
         out = io.StringIO()
         monkeypatch.setattr(sys, "stdout", out)
         exit_code = doctor.main(["--format", "json"])
@@ -512,10 +518,15 @@ class TestCLIReportArg:
         assert exit_code == 0
         content = report_file.read_text(encoding="utf-8")
         for pattern in doctor.FORBIDDEN_OUTPUT_PATTERNS:
-            assert not pattern.search(content), f"forbidden pattern found: {pattern.pattern}"
+            assert not pattern.search(
+                content
+            ), f"forbidden pattern found: {pattern.pattern}"
 
     def test_report_and_text_output_coexist(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
     ) -> None:
         self._mock_build_report(monkeypatch)
         report_file = tmp_path / "report.md"

--- a/tests/unit/test_onboarding_doctor.py
+++ b/tests/unit/test_onboarding_doctor.py
@@ -483,7 +483,10 @@ class TestCLIReportArg:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         self._mock_build_report(monkeypatch)
-        exit_code = doctor.main(["--report", "Z:\\INVALID\\PATH\\report.md"])
+        blocker = tmp_path / "blocker"
+        blocker.write_text("block")
+        report_file = blocker / "subdir" / "report.md"
+        exit_code = doctor.main(["--report", str(report_file)])
         assert exit_code == 2
 
     def test_json_output_remains_parseable(

--- a/tools/README.md
+++ b/tools/README.md
@@ -24,7 +24,7 @@ Important:
 | `.\tools\cdb.ps1 stack verify` | `tools/verify_stack.ps1` |
 | `.\tools\cdb.ps1 service logs -ServiceName cdb_risk -Lines 100` | `tools/cdb-service-logs.ps1` |
 | `.\tools\cdb.ps1 runtime smoke` | `infrastructure/scripts/smoke_test.ps1` |
-| `.\tools\cdb.ps1 onboarding doctor` | `tools/onboarding_doctor.py` |
+| `.\tools\cdb.ps1 onboarding doctor` | `tools/onboarding_doctor.py` — read-only developer setup preflight; `--format json` and `--report PATH` supported |
 | `.\tools\cdb.ps1 onboarding tour` | `tools/onboarding_tour.py` |
 | `make onboarding-docs-guard` | `tools/validate_onboarding_docs.py` — validiert aktive Onboarding-Dokumente: Links, Einstiegspunkte, Secret-Leaks (#3233) |
 

--- a/tools/cdb.ps1
+++ b/tools/cdb.ps1
@@ -24,7 +24,7 @@ Usage:
   .\tools\cdb.ps1 runtime smoke [args]
   .\tools\cdb.ps1 stack verify [args]
   .\tools\cdb.ps1 service logs [args]
-  .\tools\cdb.ps1 onboarding doctor [--format json]
+  .\tools\cdb.ps1 onboarding doctor [--format json] [--report PATH]
   .\tools\cdb.ps1 onboarding tour [--role developer|agent|docs|validation|evidence]
 
 Examples:

--- a/tools/onboarding_doctor.py
+++ b/tools/onboarding_doctor.py
@@ -32,7 +32,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
-from core.utils.clock import utcnow as cdb_utcnow
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from core.utils.clock import utcnow as cdb_utcnow  # noqa: E402
 
 CheckResult = str  # "PASS" | "WARN" | "FAIL" | "SKIP"
 EnvVarCheck = str  # "set" | "unset" | "invalid"

--- a/tools/onboarding_doctor.py
+++ b/tools/onboarding_doctor.py
@@ -23,7 +23,6 @@ Parent: #3226
 from __future__ import annotations
 
 import argparse
-from datetime import datetime, timezone
 import json
 import os
 import re
@@ -32,6 +31,8 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
+
+from core.utils.clock import utcnow as cdb_utcnow
 
 CheckResult = str  # "PASS" | "WARN" | "FAIL" | "SKIP"
 EnvVarCheck = str  # "set" | "unset" | "invalid"
@@ -446,7 +447,7 @@ def format_markdown_report(
     generated_at: str | None = None,
 ) -> str:
     if generated_at is None:
-        generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        generated_at = cdb_utcnow().isoformat(timespec="seconds")
 
     fail_count = sum(1 for c in report.checks if c.status == "FAIL")
     warn_count = sum(1 for c in report.checks if c.status == "WARN")
@@ -593,7 +594,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.report:
         try:
-            generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            generated_at = cdb_utcnow().isoformat(timespec="seconds")
             md = format_markdown_report(report, generated_at)
             _validate_output_safe(md)
             report_path = Path(args.report)

--- a/tools/onboarding_doctor.py
+++ b/tools/onboarding_doctor.py
@@ -33,7 +33,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
-
 CheckResult = str  # "PASS" | "WARN" | "FAIL" | "SKIP"
 EnvVarCheck = str  # "set" | "unset" | "invalid"
 
@@ -86,7 +85,12 @@ def _run_cmd(
         out = (proc.stdout or "").strip()
         err = (proc.stderr or "").strip()
         return proc.returncode, out, err
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired, UnicodeDecodeError) as exc:
+    except (
+        FileNotFoundError,
+        OSError,
+        subprocess.TimeoutExpired,
+        UnicodeDecodeError,
+    ) as exc:
         return -1, "", str(exc)
 
 
@@ -156,7 +160,12 @@ class DoctorOutput:
             "lr_note": self.lr_note,
             "warnings": self.warnings,
             "checks": [
-                {"name": c.name, "status": c.status, "detail": c.detail, "action": c.action}
+                {
+                    "name": c.name,
+                    "status": c.status,
+                    "detail": c.detail,
+                    "action": c.action,
+                }
                 for c in self.checks
             ],
         }
@@ -196,7 +205,10 @@ def _check_env_file() -> tuple[CheckResult, str]:
         return "PASS", ".env found"
     example = Path.cwd() / ".env.example"
     if example.is_file():
-        return "WARN", ".env missing, but .env.example exists (run: cp .env.example .env)"
+        return (
+            "WARN",
+            ".env missing, but .env.example exists (run: cp .env.example .env)",
+        )
     return "FAIL", ".env missing and no .env.example found"
 
 
@@ -353,14 +365,24 @@ def build_report(
         CheckItem(name="Repo root", status=report.repo_root_found),
         CheckItem(name="Git", status=report.git_found, detail=report.git_branch),
         CheckItem(name="Git branch", status=report.git_dirty, detail=report.git_branch),
-        CheckItem(name="Python", status=report.python_found, detail=report.python_version),
-        CheckItem(name="Python version", status=report.python_version_ok, detail=report.python_version),
+        CheckItem(
+            name="Python", status=report.python_found, detail=report.python_version
+        ),
+        CheckItem(
+            name="Python version",
+            status=report.python_version_ok,
+            detail=report.python_version,
+        ),
         CheckItem(name="gh CLI", status=report.gh_found),
         CheckItem(name="gh auth", status=report.gh_auth),
         CheckItem(name="Docker", status=report.docker_found),
         CheckItem(name="Docker Compose", status=report.compose_found),
         CheckItem(name=".env file", status=report.env_file),
-        CheckItem(name="SECRETS_PATH", status=report.secrets_path, detail=report.secrets_resolved_dir),
+        CheckItem(
+            name="SECRETS_PATH",
+            status=report.secrets_path,
+            detail=report.secrets_resolved_dir,
+        ),
         CheckItem(name="Onboarding files", status=report.onboarding_files),
         CheckItem(name="make context-doctor", status=report.context_doctor_reachable),
     ]
@@ -394,7 +416,9 @@ def format_report(report: DoctorOutput, fmt: str) -> str:
         lines.append(line)
 
     lines.append("")
-    lines.append(f"  >> Secrets path: {_safe_summary(report.secrets_resolved_dir, 100)}")
+    lines.append(
+        f"  >> Secrets path: {_safe_summary(report.secrets_resolved_dir, 100)}"
+    )
     lines.append(f"  >> .env: {report.env_file}")
 
     if report.warnings:
@@ -409,7 +433,9 @@ def format_report(report: DoctorOutput, fmt: str) -> str:
         lines.append("     Context Intelligence preflight.")
     else:
         lines.append("")
-        lines.append("  >> Run 'make context-query-config-init' then 'make context-doctor'")
+        lines.append(
+            "  >> Run 'make context-query-config-init' then 'make context-doctor'"
+        )
         lines.append("     for Context Intelligence preflight.")
 
     return "\n".join(lines)
@@ -475,36 +501,42 @@ def format_markdown_report(
         detail = check.detail.replace("|", "\\|") if check.detail else ""
         lines.append(f"| {check.name} | {check.status} | {detail} |")
 
-    lines.extend([
-        "",
-        "## Active Onboarding Surfaces",
-        "",
-    ])
+    lines.extend(
+        [
+            "",
+            "## Active Onboarding Surfaces",
+            "",
+        ]
+    )
     for rel_path in ONBOARDING_FILE_CHECKS:
         lines.append(f"- `{rel_path}`")
 
     if report.warnings:
-        lines.extend([
-            "",
-            "## Warnings",
-            "",
-        ])
+        lines.extend(
+            [
+                "",
+                "## Warnings",
+                "",
+            ]
+        )
         for w in report.warnings:
             lines.append(f"- {_safe_summary(w, 200)}")
 
-    lines.extend([
-        "",
-        "## Limitations",
-        "",
-        "- Local checks only; no runtime, Docker, DB, or MCP mutation.",
-        "- Context Doctor reachability is a check only, not a full preflight.",
-        "- No container, network, or stack validation.",
-        "- No external-API or exchange-connectivity validation.",
-        "",
-        "---",
-        "",
-        f"*Report generated by `tools/onboarding_doctor.py` ({overall})*",
-    ])
+    lines.extend(
+        [
+            "",
+            "## Limitations",
+            "",
+            "- Local checks only; no runtime, Docker, DB, or MCP mutation.",
+            "- Context Doctor reachability is a check only, not a full preflight.",
+            "- No container, network, or stack validation.",
+            "- No external-API or exchange-connectivity validation.",
+            "",
+            "---",
+            "",
+            f"*Report generated by `tools/onboarding_doctor.py` ({overall})*",
+        ]
+    )
 
     return "\n".join(lines) + "\n"
 

--- a/tools/onboarding_doctor.py
+++ b/tools/onboarding_doctor.py
@@ -6,7 +6,9 @@ secret output, stack mutation, DB writes, or MCP mutations.
 Usage:
     python -m tools.onboarding_doctor
     python -m tools.onboarding_doctor --format json
+    python -m tools.onboarding_doctor --report docs/evidence/local_onboarding_check.md
     ./tools/cdb.ps1 onboarding doctor
+    ./tools/cdb.ps1 onboarding doctor --report docs/evidence/local_onboarding_check.md
     make onboarding-doctor
 
 Exit codes:
@@ -21,6 +23,7 @@ Parent: #3226
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
 import json
 import os
 import re
@@ -105,6 +108,7 @@ class DoctorOutput:
     git_found: CheckResult = "FAIL"
     git_branch: str = ""
     git_dirty: CheckResult = "SKIP"
+    repo_head: str = ""
     python_found: CheckResult = "FAIL"
     python_version: str = ""
     python_version_ok: CheckResult = "FAIL"
@@ -124,10 +128,12 @@ class DoctorOutput:
     def to_dict(self) -> dict[str, Any]:
         return {
             "repo_root": self.repo_root_found,
+            "repo_head": self.repo_head,
             "git": {
                 "found": self.git_found,
                 "branch": self.git_branch,
                 "dirty": self.git_dirty,
+                "head": self.repo_head,
             },
             "python": {
                 "found": self.python_found,
@@ -265,12 +271,17 @@ def build_report(
         _, branch_out, _ = _run_cmd(branch_cmd, runner=git_runner)
         report.git_branch = branch_out.strip() or "unknown"
 
+        head_cmd = "git rev-parse HEAD"
+        _, head_out, _ = _run_cmd(head_cmd, runner=git_runner)
+        report.repo_head = head_out.strip() or ""
+
         status_cmd = "git status --porcelain"
         _, status_out, _ = _run_cmd(status_cmd, runner=git_runner)
         report.git_dirty = "WARN" if status_out.strip() else "PASS"
     else:
         report.git_branch = ""
         report.git_dirty = "SKIP"
+        report.repo_head = ""
 
     # Python
     python_cmd = "python --version"
@@ -404,6 +415,100 @@ def format_report(report: DoctorOutput, fmt: str) -> str:
     return "\n".join(lines)
 
 
+def format_markdown_report(
+    report: DoctorOutput,
+    generated_at: str | None = None,
+) -> str:
+    if generated_at is None:
+        generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    fail_count = sum(1 for c in report.checks if c.status == "FAIL")
+    warn_count = sum(1 for c in report.checks if c.status == "WARN")
+    pass_count = sum(1 for c in report.checks if c.status == "PASS")
+
+    if fail_count > 0:
+        overall = "FAIL"
+    elif warn_count > 0:
+        overall = "WARN"
+    else:
+        overall = "PASS"
+
+    lines: list[str] = [
+        "# CDB Onboarding Doctor Report",
+        "",
+        f"**Generated**: {generated_at}",
+        f"**Repo HEAD**: {report.repo_head or 'unknown'}",
+        f"**Branch**: {report.git_branch or 'unknown'}",
+        "",
+        "## Summary",
+        "",
+        f"- **PASS**: {pass_count}",
+        f"- **WARN**: {warn_count}",
+        f"- **FAIL**: {fail_count}",
+        f"- **Overall**: {overall}",
+        "",
+        "## Safety Boundaries",
+        "",
+        "- LR remains **NO-GO**.",
+        "- Board stage `trade-capable` is **not** a Live-Go.",
+        "- No Echtgeld-Go.",
+        "- This report is read-only evidence; no runtime, Docker, DB, or MCP actions performed.",
+        "- No secret values are included in this report.",
+        "",
+        "## Repo State",
+        "",
+        "| Field | Value |",
+        "|-------|-------|",
+        f"| HEAD | `{report.repo_head or 'unknown'}` |",
+        f"| Branch | `{report.git_branch or 'unknown'}` |",
+        f"| Working tree | {report.git_dirty} |",
+        f"| Secrets path | {_safe_summary(report.secrets_resolved_dir, 120)} |",
+        f"| .env | {report.env_file} |",
+        "",
+        "## Checks",
+        "",
+        "| Check | Status | Detail |",
+        "|-------|--------|--------|",
+    ]
+
+    for check in report.checks:
+        detail = check.detail.replace("|", "\\|") if check.detail else ""
+        lines.append(f"| {check.name} | {check.status} | {detail} |")
+
+    lines.extend([
+        "",
+        "## Active Onboarding Surfaces",
+        "",
+    ])
+    for rel_path in ONBOARDING_FILE_CHECKS:
+        lines.append(f"- `{rel_path}`")
+
+    if report.warnings:
+        lines.extend([
+            "",
+            "## Warnings",
+            "",
+        ])
+        for w in report.warnings:
+            lines.append(f"- {_safe_summary(w, 200)}")
+
+    lines.extend([
+        "",
+        "## Limitations",
+        "",
+        "- Local checks only; no runtime, Docker, DB, or MCP mutation.",
+        "- Context Doctor reachability is a check only, not a full preflight.",
+        "- No container, network, or stack validation.",
+        "- No external-API or exchange-connectivity validation.",
+        "",
+        "---",
+        "",
+        f"*Report generated by `tools/onboarding_doctor.py` ({overall})*",
+    ])
+
+    return "\n".join(lines) + "\n"
+
+
 def _safe_summary(text: str, max_len: int = 80) -> str:
     if len(text) <= max_len:
         return text
@@ -414,7 +519,9 @@ _HELP_EPILOG = """\
 Examples:
   python -m tools.onboarding_doctor
   python -m tools.onboarding_doctor --format json
+  python -m tools.onboarding_doctor --report docs/evidence/local_onboarding_check.md
   .\\tools\\cdb.ps1 onboarding doctor
+  .\\tools\\cdb.ps1 onboarding doctor --report docs/evidence/local_onboarding_check.md
   make onboarding-doctor
 
 Exit codes:
@@ -436,6 +543,11 @@ def main(argv: list[str] | None = None) -> int:
         default="text",
         help="Output format (default: text)",
     )
+    parser.add_argument(
+        "--report",
+        metavar="PATH",
+        help="Write a Markdown report to PATH (opt-in; default: no file written)",
+    )
     args = parser.parse_args(argv)
 
     if args.format not in ("text", "json"):
@@ -446,6 +558,23 @@ def main(argv: list[str] | None = None) -> int:
     output = format_report(report, args.format)
     _validate_output_safe(output)
     print(output)
+
+    if args.report:
+        try:
+            generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            md = format_markdown_report(report, generated_at)
+            _validate_output_safe(md)
+            report_path = Path(args.report)
+            report_path.parent.mkdir(parents=True, exist_ok=True)
+            report_path.write_text(md, encoding="utf-8")
+            print(
+                f"Markdown report written to: {report_path.resolve()}",
+                file=sys.stderr,
+            )
+        except (OSError, ValueError) as exc:
+            print(f"ERROR: cannot write report: {exc}", file=sys.stderr)
+            return 2
+
     return compute_exit_code(report)
 
 


### PR DESCRIPTION
Closes #3250
Refs #3246

## Delivered

- \--report PATH\ opt-in CLI argument for \	ools/onboarding_doctor.py\
- \ormat_markdown_report()\ function producing a structured evidence report
- Report includes: timestamp, repo HEAD, branch, PASS/WARN/FAIL summary, individual checks table, active onboarding surfaces, warnings, limitations, LR safety boundaries
- \DoctorOutput\ extended with \epo_head\ (additive; no existing keys changed)
- \	o_dict()\ extended with \epo_head\ and \git.head\ (additive only)
- Existing text/JSON output unchanged
- Default doctor remains read-only, no file write
- \_validate_output_safe()\ applied to markdown report output
- PowerShell front door (\cdb.ps1\) argument passthrough unchanged; help text updated
- Docs: \DEVELOPER_ONBOARDING.md\, \	ools/README.md\ mention \--report\

## Brain Evidence

\\\
brain_source: repo-only
brain_status: not-used
tools_or_queries: []
records_or_results: []
repo_crosscheck:
  - tools/onboarding_doctor.py (full file)
  - tests/unit/test_onboarding_doctor.py (full file)
  - tools/cdb.ps1 (:93 RemainingArgs forwarding)
  - Makefile:402-404 (onboarding-doctor target)
  - grep for existing --report/markdown report support: 0 hits in onboarding_doctor
impact_on_plan:
  - Clean add; no existing report support to merge with
  - cdb.ps1 already passes RemainingArgs through — no PS changes needed
limitations:
  - No SurrealDB/Context-MCP evidence available
  - Repo-only evidence; no brain-backed claims
\\\

## Validation

- \pytest -q tests/unit/test_onboarding_doctor.py\ — 41/41 PASSED
- \pytest -q tests/unit/test_onboarding_tour.py\ — 11/11 PASSED
- \pytest -q tests/unit/tools/test_validate_onboarding_docs.py\ — 31/31 PASSED
- \uff check tools/onboarding_doctor.py tests/unit/test_onboarding_doctor.py\ — PASSED
- \python -m tools.validate_onboarding_docs\ — PASSED
- \python -m tools.onboarding_doctor\ — text output stable
- \python -m tools.onboarding_doctor --format json\ — JSON parseable, additive fields present
- \python -m tools.onboarding_doctor --report ...\ — Markdown file written, safety-validated
- \git diff --check\ — clean

## Safety Boundaries

- LR remains NO-GO
- Board stage trade-capable is not Live-Go
- No Echtgeld-Go
- No runtime/Docker/DB/MCP mutation
- No secret output
- Default doctor remains read-only, no file writes without explicit --report
- Report output validated via FORBIDDEN_OUTPUT_PATTERNS before write

## Non-goals

- No Makefile target change (--report usage is explicit via python/cdb.ps1)
- No default report writing (opt-in only via --report)
- No docker/runtime/strategy changes
- No docs restructuring beyond minimal updates

## Restunsicherheiten

- PowerShell stderr color codes are terminal artifacts, not a code-level issue
- Smoke report file cleaned up after validation; not committed