### PR TITLE
docs(governance): enforce Context Brain first bootloader with evidenced repo fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,7 @@ OpenCode skill surface zusaetzlich: `.opencode/skills/` (gezielt laden, nicht pa
 
 ## Agent Operating Rules
 
+- **Context Brain first.** Jeder Agenten-Prompt MUSS vor Repo-Reads einen Context Brain Preflight versuchen. Repo-Fallback ist nur nach belegtem Fehlversuch erlaubt. Siehe `agents/AGENTS.md` § Context Brain Preflight Gate.
 - Read `knowledge/governance/CDB_AGENT_POLICY.md` section 4 before any write.
 - Respect single-writer locks, explicit stop signals, and write gates.
 - `DELIVERY_APPROVED.yaml` is human-controlled; agents must not modify it.

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -100,6 +100,36 @@ Related surfaces (not subagents): `.cursor/skills/` (session skills),
 - Das lokale Archiv `docs/archive/docs_hub_snapshot/` ist nur noch ein optionaler historischer Rueckgriff.
 - Externe Docs-Repo-Pfade sind kein produktiver Default mehr.
 
+## Context Brain Preflight Gate
+
+Jeder Agenten-Prompt MUSS vor Repo-Reads einen **Context Brain Preflight** versuchen.
+Repo-Fallback ist nur nach belegtem Fehlversuch erlaubt.
+
+### Evidence-Felder (Pflicht)
+
+```text
+context_brain_attempted: true
+context_brain_used: true | false
+repo_fallback_used: true | false
+repo_fallback_reason: none | unavailable | stale | contradictory | insufficient_evidence | missing_record | tool_blocked
+```
+
+### Regeln
+
+1. **Context Brain / Context-DB / MCP-Context ist der verpflichtende erste
+   Aufloesungsversuch** fuer Bootloader-, Read-Order-, Governance- und Kontext-Briefing.
+2. Repo ist nur Fallback, wenn Context Brain:
+   - nicht verfuegbar ist (`unavailable`),
+   - stale wirkt (`stale`),
+   - widerspruechlich ist (`contradictory`),
+   - keine belegbare Tool-/Query-/Record-Evidence liefert (`insufficient_evidence`),
+   - die benoetigte Information dort nicht belastbar aufloesbar ist (`missing_record`),
+   - oder die MCP-Tools blockiert sind (`tool_blocked`).
+3. Bei `repo_fallback_used=true` MUSS der Agent den konkreten Grund dokumentieren.
+4. Keine DB-backed Claims ohne Tool-/Query-/Record-Evidence.
+5. Context Brain / MCP-Ergebnisse autorisieren **keine** automatischen Code-,
+   Issue- oder Write-Aktionen; Human-GO erforderlich.
+
 ## Brain Evidence Gate
 
 For sessions whose scope includes **Strategy, Runtime, Module, Service, Contract,
@@ -120,6 +150,10 @@ impact_on_plan:
   - <Was dadurch anders geplant wurde>
 limitations:
   - <Was nicht bewiesen ist>
+context_brain_attempted: true
+context_brain_used: true | false
+repo_fallback_used: true | false
+repo_fallback_reason: none | unavailable | stale | contradictory | insufficient_evidence | missing_record | tool_blocked
 ```
 
 ### Field Logic
@@ -130,6 +164,10 @@ limitations:
   Brain-Claims.
 - `brain_source=repo-only`: Klar `brain-not-used` melden.
 - `brain_source=unavailable`: Klar `blocked` oder `repo-only fallback` melden.
+- `context_brain_attempted`: IMMER `true` — der Preflight-Versuch ist Pflicht.
+- `context_brain_used`: `true` nur wenn echte Tool-/Query-/Record-Evidence vorliegt.
+- `repo_fallback_used`: `true` wenn nach Preflight auf Repo-Reads zurueckgefallen wurde.
+- `repo_fallback_reason`: Exakter Grund fuer Repo-Fallback (Enum).
 
 ### Default posture (SSOT)
 

--- a/agents/OPEN_CODE_AGENTS.md
+++ b/agents/OPEN_CODE_AGENTS.md
@@ -28,11 +28,12 @@ Gilt für **alle** OpenCode Agents (egal welcher Provider).
 ## OpenCode Skill Routing
 
 - Bootloader immer zuerst: `AGENTS.md` -> `agents/AGENTS.md` -> `agents/OPEN_CODE_AGENTS.md`
+- **Context Brain Preflight immer vor Repo-Reads:** Pflichtfeld `context_brain_attempted=true`; MCP-Tool-Check vor Planung. Bei `tool_blocked` oder anderem validem Grund: `repo_fallback_used=true` mit exaktem `repo_fallback_reason`. Siehe `agents/AGENTS.md` § Context Brain Preflight Gate.
 - Für CDB-Repo-Arbeit danach `cdb-session-start`
 - Danach `cdb-control-intake`
 - Bei Issue-Arbeit danach `cdb-issue-to-session-plan`
 - Bei Context-, SurrealDB-, MCP-Tool-, ContextBridge- oder DB-backed-Memory-Scope: MCP Capability Resolution Gate ausführen vor Implementierung oder toolabhängiger Planung — Repo-Präsenz ist nicht gleich MCP-Verfügbarkeit. Referenz: `docs/runbooks/surrealdb_context_mcp_access.md` § 1.5.
-- Bei Strategy-, Runtime-, Module-, Service-, Contract-, Context-, SurrealDB-, MCP-, Memory- oder Evidence-Scope: **Brain Evidence Gate** aus `agents/AGENTS.md` § Brain Evidence Gate ausführen **vor jeder Planung** — der Agent MUSS den vollständigen Brain-Evidence-Block mit `brain_source`, `brain_status`, `tools_or_queries`, `records_or_results`, `repo_crosscheck`, `impact_on_plan` und `limitations` ausgeben.
+- Bei Strategy-, Runtime-, Module-, Service-, Contract-, Context-, SurrealDB-, MCP-, Memory- oder Evidence-Scope: **Brain Evidence Gate** aus `agents/AGENTS.md` § Brain Evidence Gate ausführen **vor jeder Planung** — der Agent MUSS den vollständigen Brain-Evidence-Block mit `brain_source`, `brain_status`, `tools_or_queries`, `records_or_results`, `repo_crosscheck`, `impact_on_plan` und `limitations` sowie `context_brain_attempted`, `context_brain_used`, `repo_fallback_used`, `repo_fallback_reason` ausgeben.
 - **Source priority** (SSOT: `knowledge/decisions/CDB_CONTEXT_BRAIN_DEFAULT_POSTURE.md`): live GitHub → repo files → SurrealDB context package (guarded) → ledger → fallback. `CURRENT_STATUS.md` ist Ledger, nicht Live-Wahrheit.
 - Context-/MCP-/Briefing-Ergebnisse erzeugen **keine** automatische Code-, Issue- oder Write-Aktion; `PERSIST_ALLOWED=False` und `MUTATION_ALLOWED=False` bleiben Default auf `main`.
 - Für `context.briefing`-basierte Handoffs ist `briefing.session_context` die bevorzugte Kurzzeit-/Session-Handoff-Fläche für Context-, MCP-, Memory- und Evidence-Scope. Diese Fläche ist immer `working_memory` mit `session_only=true`, ist nicht als persistente DB-Memory zu behandeln und erlaubt DB-backed Brain-Claims nur bei `brain_source=surrealdb-local` und nutzbarem `brain_status` (`used` oder `partial`). `blocked` und `not-used` bleiben fail-closed.


### PR DESCRIPTION
## Delivered
- agents/AGENTS.md: New § Context Brain Preflight Gate with mandatory evidence fields (context_brain_attempted, context_brain_used, repo_fallback_used, repo_fallback_reason)
- agents/AGENTS.md: Updated Brain Evidence Gate to include the four new fields with field logic
- agents/OPEN_CODE_AGENTS.md: Context Brain first routing before repo reads
- AGENTS.md (root pointer): Context Brain first operating rule

## Validation
- git diff --check: PASS
- All key terms present across 3 files confirmed via rg

## Non-Goals
- No runtime/Docker/trading/LR/DB/MCP changes
- No productive SurrealDB writes
- No MCP mutations
- No Live-Go / Echtgeld-Go

## Safety Boundaries
- LR: NO-GO
- Board stage trade-capable is not Live-Go
- Docs/governance change only

## Restunsicherheiten
- Context Brain MCP tool availability verified as unknown_tool in current session; rule is enforced but MCP availability varies per environment