### PR TITLE
feat(tools): add deterministic onboarding simulation runner

### DIFF
--- a/tests/unit/tools/test_onboarding_simulation.py
+++ b/tests/unit/tools/test_onboarding_simulation.py
@@ -391,7 +391,7 @@ class TestSimulationOutputContract:
 
     def test_verdict_is_valid_enum(self) -> None:
         output = render_simulation()
-        verdict_line = [l for l in output.split("\n") if "Final Verdict:" in l][0]
+        verdict_line = [line for line in output.split("\n") if "Final Verdict:" in line][0]
         verdict = verdict_line.split(": ", 1)[1].strip()
         assert verdict in VERDICT_ENUM, f"Verdict '{verdict}' not in VERDICT_ENUM"
 

--- a/tests/unit/tools/test_onboarding_simulation.py
+++ b/tests/unit/tools/test_onboarding_simulation.py
@@ -1,0 +1,408 @@
+"""Unit tests for onboarding simulation runner.
+
+Issue: #3273
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from tools.onboarding_simulation import (
+    FORBIDDEN_OUTPUT_PATTERNS,
+    VERDICT_ENUM,
+    _build_bootloader_plan,
+    _build_context_brain_note,
+    _build_final_verdict,
+    _build_hold_conditions,
+    _build_live_truth_plan,
+    _build_pr_lock_simulation,
+    _normalize_mode,
+    _normalize_role,
+    _validate_output_safe,
+    render_simulation,
+    render_simulation_json,
+)
+
+
+class TestNormalizeRole:
+    def test_agent(self) -> None:
+        assert _normalize_role("agent") == "agent"
+
+    def test_developer(self) -> None:
+        assert _normalize_role("developer") == "developer"
+
+    def test_dev_alias(self) -> None:
+        assert _normalize_role("dev") == "developer"
+
+    def test_docs(self) -> None:
+        assert _normalize_role("docs") == "docs"
+
+    def test_docs_maintainer_alias(self) -> None:
+        assert _normalize_role("docs-maintainer") == "docs"
+
+    def test_validation(self) -> None:
+        assert _normalize_role("validation") == "validation"
+
+    def test_evidence_alias(self) -> None:
+        assert _normalize_role("evidence") == "validation"
+
+    def test_unknown_role_raises(self) -> None:
+        with pytest.raises(ValueError, match="unsupported role"):
+            _normalize_role("nonexistent")
+
+
+class TestNormalizeMode:
+    def test_first_issue_dry_run(self) -> None:
+        assert _normalize_mode("first-issue-dry-run") == "first-issue-dry-run"
+
+    def test_check_only(self) -> None:
+        assert _normalize_mode("check-only") == "check-only"
+
+    def test_unknown_mode_raises(self) -> None:
+        with pytest.raises(ValueError, match="unsupported mode"):
+            _normalize_mode("live")
+
+
+class TestBuildFinalVerdict:
+    def test_agent_first_issue_ready(self) -> None:
+        assert _build_final_verdict("agent", "first-issue-dry-run") == "READY_FOR_REAL_FIRST_ISSUE"
+
+    def test_developer_first_issue_ready(self) -> None:
+        assert _build_final_verdict("developer", "first-issue-dry-run") == "READY_FOR_REAL_FIRST_ISSUE"
+
+    def test_check_only_hold(self) -> None:
+        assert _build_final_verdict("agent", "check-only") == "HOLD_ONBOARDING_GAP"
+
+    def test_check_only_hold_developer(self) -> None:
+        assert _build_final_verdict("developer", "check-only") == "HOLD_ONBOARDING_GAP"
+
+
+class TestRenderSimulationDefaults:
+    def test_contains_onboarding_start(self) -> None:
+        output = render_simulation()
+        assert "ONBOARDING_START" in output
+
+    def test_contains_mode(self) -> None:
+        output = render_simulation()
+        assert "mode: first-issue-dry-run" in output
+
+    def test_contains_default_role_agent(self) -> None:
+        output = render_simulation()
+        assert "role: Agent" in output
+
+    def test_contains_writes_disabled(self) -> None:
+        output = render_simulation()
+        assert "writes: disabled" in output
+
+    def test_contains_github_writes_disabled(self) -> None:
+        output = render_simulation()
+        assert "github_writes: disabled" in output
+
+    def test_contains_lr_no_go(self) -> None:
+        output = render_simulation()
+        assert "lr: NO-GO" in output
+
+    def test_contains_final_verdict(self) -> None:
+        output = render_simulation()
+        assert "Final Verdict: READY_FOR_REAL_FIRST_ISSUE" in output
+
+    def test_contains_bootloader_section(self) -> None:
+        output = render_simulation()
+        assert "Bootloader Plan:" in output
+
+    def test_contains_live_truth_section(self) -> None:
+        output = render_simulation()
+        assert "Live Truth Plan:" in output
+
+    def test_contains_tour_section(self) -> None:
+        output = render_simulation()
+        assert "Tour Path:" in output
+
+    def test_contains_doctor_validator_section(self) -> None:
+        output = render_simulation()
+        assert "Doctor / Validator Plan:" in output
+
+    def test_contains_first_issue_dry_run_section(self) -> None:
+        output = render_simulation()
+        assert "First-Issue Dry Run:" in output
+
+    def test_contains_pr_lock_section(self) -> None:
+        output = render_simulation()
+        assert "PR / LOCK Simulation:" in output
+
+    def test_contains_hold_conditions_section(self) -> None:
+        output = render_simulation()
+        assert "HOLD Conditions:" in output
+
+    def test_contains_context_brain_section(self) -> None:
+        output = render_simulation()
+        assert "Context Brain Note:" in output
+
+    def test_contains_safety_lr(self) -> None:
+        output = render_simulation()
+        assert "LR remains NO-GO" in output
+
+    def test_contains_safety_trade_capable(self) -> None:
+        output = render_simulation()
+        assert "trade-capable is not Live-Go" in output
+
+    def test_contains_safety_echtgeld(self) -> None:
+        output = render_simulation()
+        assert "Echtgeld-Go" in output
+
+    def test_contains_safety_read_only(self) -> None:
+        output = render_simulation()
+        assert "read-only" in output
+
+
+class TestRenderSimulationByRole:
+    def test_developer_role(self) -> None:
+        output = render_simulation(role="developer")
+        assert "role: Developer" in output
+        assert "DEVELOPER_ONBOARDING.md" in output
+
+    def test_agent_role(self) -> None:
+        output = render_simulation(role="agent")
+        assert "role: Agent" in output
+        assert "CODEX.md" in output
+
+    def test_docs_role(self) -> None:
+        output = render_simulation(role="docs")
+        assert "role: Docs Maintainer" in output
+
+    def test_validation_role(self) -> None:
+        output = render_simulation(role="validation")
+        assert "role: Validation / Evidence" in output
+
+
+class TestRenderSimulationByMode:
+    def test_check_only_mode(self) -> None:
+        output = render_simulation(mode="check-only")
+        assert "mode: check-only" in output
+        assert "HOLD_ONBOARDING_GAP" in output
+
+    def test_first_issue_dry_run_mode(self) -> None:
+        output = render_simulation(mode="first-issue-dry-run")
+        assert "READY_FOR_REAL_FIRST_ISSUE" in output
+
+
+class TestRenderSimulationJson:
+    def test_valid_json(self) -> None:
+        output = render_simulation_json()
+        data = json.loads(output)
+        assert isinstance(data, dict)
+
+    def test_json_contains_role(self) -> None:
+        output = render_simulation_json()
+        data = json.loads(output)
+        assert "role" in data
+        assert data["role"] == "Agent"
+
+    def test_json_contains_mode(self) -> None:
+        output = render_simulation_json()
+        data = json.loads(output)
+        assert data["mode"] == "first-issue-dry-run"
+
+    def test_json_contains_verdict(self) -> None:
+        output = render_simulation_json()
+        data = json.loads(output)
+        assert data["verdict"] == "READY_FOR_REAL_FIRST_ISSUE"
+
+    def test_json_contains_sections(self) -> None:
+        output = render_simulation_json()
+        data = json.loads(output)
+        assert "sections" in data
+        assert "bootloader" in data["sections"]
+        assert "live_truth" in data["sections"]
+        assert "context_brain" in data["sections"]
+
+    def test_json_developer_role(self) -> None:
+        output = render_simulation_json(role="developer")
+        data = json.loads(output)
+        assert data["role"] == "Developer"
+        assert data["verdict"] == "READY_FOR_REAL_FIRST_ISSUE"
+
+    def test_json_check_only_mode(self) -> None:
+        output = render_simulation_json(mode="check-only")
+        data = json.loads(output)
+        assert data["verdict"] == "HOLD_ONBOARDING_GAP"
+
+
+class TestVerdictEnum:
+    def test_ready_for_real_first_issue(self) -> None:
+        assert "READY_FOR_REAL_FIRST_ISSUE" in VERDICT_ENUM
+
+    def test_hold_onboarding_gap(self) -> None:
+        assert "HOLD_ONBOARDING_GAP" in VERDICT_ENUM
+
+    def test_blocked_bootloader(self) -> None:
+        assert "BLOCKED_BOOTLOADER" in VERDICT_ENUM
+
+    def test_blocked_live_truth(self) -> None:
+        assert "BLOCKED_LIVE_TRUTH" in VERDICT_ENUM
+
+    def test_blocked_governance(self) -> None:
+        assert "BLOCKED_GOVERNANCE" in VERDICT_ENUM
+
+    def test_enum_length(self) -> None:
+        assert len(VERDICT_ENUM) == 5
+
+
+class TestBuildBootloaderPlan:
+    def test_contains_read_order(self) -> None:
+        lines = _build_bootloader_plan("agent")
+        text = "\n".join(lines)
+        assert "AGENTS.md" in text
+        assert "agents/AGENTS.md" in text
+        assert "OPEN_CODE_AGENTS.md" in text
+
+    def test_contains_context_brain_preflight(self) -> None:
+        lines = _build_bootloader_plan("agent")
+        text = "\n".join(lines)
+        assert "context_brain_attempted" in text
+
+    def test_agent_has_codex(self) -> None:
+        lines = _build_bootloader_plan("agent")
+        text = "\n".join(lines)
+        assert "CODEX.md" in text
+
+    def test_developer_no_codex(self) -> None:
+        lines = _build_bootloader_plan("developer")
+        text = "\n".join(lines)
+        assert "CODEX.md" not in text
+
+
+class TestBuildLiveTruthPlan:
+    def test_contains_github_live(self) -> None:
+        lines = _build_live_truth_plan()
+        text = "\n".join(lines)
+        assert "GitHub live" in text
+
+    def test_contains_ledger_note(self) -> None:
+        lines = _build_live_truth_plan()
+        text = "\n".join(lines)
+        assert "CURRENT_STATUS.md" in text
+        assert "context only" in text
+
+    def test_contains_lr_ssot(self) -> None:
+        lines = _build_live_truth_plan()
+        text = "\n".join(lines)
+        assert "LR-AUDIT-STATUS" in text
+
+
+class TestBuildHoldConditions:
+    def test_contains_context_brain_fail(self) -> None:
+        lines = _build_hold_conditions()
+        text = "\n".join(lines)
+        assert "Context Brain Preflight fails" in text
+
+    def test_contains_scope_growth(self) -> None:
+        lines = _build_hold_conditions()
+        text = "\n".join(lines)
+        assert "scope growth" in text
+
+    def test_contains_secrets_boundary(self) -> None:
+        lines = _build_hold_conditions()
+        text = "\n".join(lines)
+        assert "Secrets" in text
+
+    def test_contains_dirty_worktree(self) -> None:
+        lines = _build_hold_conditions()
+        text = "\n".join(lines)
+        assert "Worktree dirty" in text
+
+
+class TestBuildContextBrainNote:
+    def test_contains_attempted_true(self) -> None:
+        lines = _build_context_brain_note()
+        text = "\n".join(lines)
+        assert "context_brain_attempted=true" in text
+
+    def test_contains_fallback_reason(self) -> None:
+        lines = _build_context_brain_note()
+        text = "\n".join(lines)
+        assert "repo_fallback_reason=tool_blocked" in text
+
+    def test_contains_no_db_backed_claims(self) -> None:
+        lines = _build_context_brain_note()
+        text = "\n".join(lines)
+        assert "DB-backed claims" in text
+
+
+class TestBuildPrLockSimulation:
+    def test_contains_lock_comment(self) -> None:
+        lines = _build_pr_lock_simulation()
+        text = "\n".join(lines)
+        assert "LOCK" in text
+
+    def test_contains_required_checks(self) -> None:
+        lines = _build_pr_lock_simulation()
+        text = "\n".join(lines)
+        assert "ci" in text
+        assert "policy-gate" in text
+
+    def test_contains_squash_merge(self) -> None:
+        lines = _build_pr_lock_simulation()
+        text = "\n".join(lines)
+        assert "Squash-merge" in text
+
+
+class TestValidateOutputSafe:
+    def test_clean_output_passes(self) -> None:
+        _validate_output_safe("safe output without secrets")
+
+    def test_token_assignment_rejected(self) -> None:
+        with pytest.raises(ValueError, match="potential secret leak"):
+            _validate_output_safe("token: abc123secretkey")
+
+    def test_api_key_assignment_rejected(self) -> None:
+        with pytest.raises(ValueError, match="potential secret leak"):
+            _validate_output_safe("api_key=sk-live-abcdef")
+
+    def test_github_token_pattern_rejected(self) -> None:
+        with pytest.raises(ValueError, match="potential secret leak"):
+            _validate_output_safe("ghp_abcdefghijklmnopqrstuvwxyz123456")
+
+    def test_url_rejected(self) -> None:
+        with pytest.raises(ValueError, match="potential secret leak"):
+            _validate_output_safe("check https://example.com/secret")
+
+
+class TestSimulationOutputContract:
+    def test_contains_all_required_sections(self) -> None:
+        output = render_simulation()
+        required_prefixes = [
+            "ONBOARDING_START",
+            "Context Brain Note:",
+            "Bootloader Plan:",
+            "Live Truth Plan:",
+            "Tour Path:",
+            "Doctor / Validator Plan:",
+            "First-Issue Dry Run:",
+            "PR / LOCK Simulation:",
+            "HOLD Conditions:",
+            "Final Verdict:",
+        ]
+        for prefix in required_prefixes:
+            assert prefix in output, f"Missing required section: {prefix}"
+
+    def test_verdict_is_valid_enum(self) -> None:
+        output = render_simulation()
+        verdict_line = [l for l in output.split("\n") if "Final Verdict:" in l][0]
+        verdict = verdict_line.split(": ", 1)[1].strip()
+        assert verdict in VERDICT_ENUM, f"Verdict '{verdict}' not in VERDICT_ENUM"
+
+
+class TestForbiddenPatternsInOutput:
+    def test_no_urls_in_rendered_output(self) -> None:
+        output = render_simulation()
+        url_pattern = re.compile(r"https?://[^\s\"']+")
+        assert not url_pattern.search(output), "Output contains URLs"
+
+    def test_no_token_patterns_in_rendered_output(self) -> None:
+        output = render_simulation()
+        for pattern in FORBIDDEN_OUTPUT_PATTERNS:
+            assert not pattern.search(output), f"Output matches forbidden pattern: {pattern.pattern}"

--- a/tools/onboarding_simulation.py
+++ b/tools/onboarding_simulation.py
@@ -1,0 +1,343 @@
+"""Deterministic read-only onboarding simulation runner for CDB.
+
+Makes the /onboarding slash-skill thin and testable. Emits a reproducible
+simulation of the full CDB onboarding flow without any file writes, GitHub
+mutations, branch creation, PR creation, runtime/Docker/DB/MCP actions, or
+secret exposure.
+
+Usage:
+    python -m tools.onboarding_simulation
+    python -m tools.onboarding_simulation --role agent --mode first-issue-dry-run
+    python -m tools.onboarding_simulation --role developer --format json
+    .\\tools\\cdb.ps1 onboarding simulate
+
+Output contract:
+    ONBOARDING_START -> Bootloader Plan -> Live Truth Plan -> Tour Path ->
+    Doctor / Validator Plan -> First-Issue Dry Run -> PR / LOCK Simulation ->
+    HOLD Conditions -> Final Verdict
+
+Final verdict enum:
+    READY_FOR_REAL_FIRST_ISSUE | HOLD_ONBOARDING_GAP |
+    BLOCKED_BOOTLOADER | BLOCKED_LIVE_TRUTH | BLOCKED_GOVERNANCE
+
+Issue: #3273
+Parent: #3271
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from typing import Any
+
+ROLE_ALIASES: dict[str, str] = {
+    "developer": "developer",
+    "dev": "developer",
+    "agent": "agent",
+    "docs": "docs",
+    "docs-maintainer": "docs",
+    "validation": "validation",
+    "evidence": "validation",
+}
+
+ROLE_LABELS: dict[str, str] = {
+    "developer": "Developer",
+    "agent": "Agent",
+    "docs": "Docs Maintainer",
+    "validation": "Validation / Evidence",
+}
+
+VERDICT_ENUM: tuple[str, ...] = (
+    "READY_FOR_REAL_FIRST_ISSUE",
+    "HOLD_ONBOARDING_GAP",
+    "BLOCKED_BOOTLOADER",
+    "BLOCKED_LIVE_TRUTH",
+    "BLOCKED_GOVERNANCE",
+)
+
+FORBIDDEN_OUTPUT_PATTERNS: list[re.Pattern] = [
+    re.compile(r"(?i)\b(token|secret|password|passwd|api[_-]?key)\s*[:=]\s*\S+"),
+    re.compile(r"(?i)SURREAL_(?:PASS|USER)\s*=\s*\S+"),
+    re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"),
+    re.compile(r"https?://[^\s\"']+"),
+    re.compile(r"(?i)(?:api|private|secret)_key[=:]\s*\S+"),
+]
+
+
+@dataclass
+class SimulationOutput:
+    role: str
+    mode: str
+    verdict: str
+    sections: dict[str, list[str]] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "role": ROLE_LABELS.get(self.role, self.role),
+            "mode": self.mode,
+            "verdict": self.verdict,
+            "sections": self.sections,
+        }
+
+
+def _normalize_role(role: str) -> str:
+    normalized = ROLE_ALIASES.get(role.strip().lower())
+    if normalized is None:
+        allowed = "developer, agent, docs, validation, evidence"
+        raise ValueError(f"unsupported role '{role}'. Allowed roles: {allowed}")
+    return normalized
+
+
+def _normalize_mode(mode: str) -> str:
+    allowed = ("first-issue-dry-run", "check-only")
+    if mode not in allowed:
+        raise ValueError(
+            f"unsupported mode '{mode}'. Allowed modes: {', '.join(allowed)}"
+        )
+    return mode
+
+
+def _build_bootloader_plan(role: str) -> list[str]:
+    lines: list[str] = [
+        "Bootloader Plan:",
+        "  1. Read AGENTS.md (repo root pointer).",
+        "  2. Read agents/AGENTS.md (canonical registry, Read Order, Brain Evidence Gate).",
+        "  3. Read agents/OPEN_CODE_AGENTS.md (shared contract, skill routing).",
+        "  4. Run Context Brain Preflight (context_brain_attempted=true).",
+        "  5. If MCP tools unavailable: fallback to repo with repo_fallback_reason=tool_blocked.",
+    ]
+    if role == "agent":
+        lines.extend(
+            [
+                "  6. Read agents/roles/CODEX.md for role-specific contract.",
+                "  7. Verify Brain Evidence block fields before planning.",
+            ]
+        )
+    return lines
+
+
+def _build_live_truth_plan() -> list[str]:
+    return [
+        "Live Truth Plan:",
+        "  1. GitHub live: issue state, PRs, checks via 'gh'.",
+        "  2. Repo live: git fetch, status, diff.",
+        "  3. Ledger: CURRENT_STATUS.md (context only, not live truth).",
+        "  4. LR SSOT: docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md (NO-GO).",
+        "  5. Control: docs/runbooks/CONTROL_REGISTER.md (stage:trade-capable).",
+    ]
+
+
+def _build_tour_path(role: str) -> list[str]:
+    lines: list[str] = [
+        "Tour Path:",
+        "  1. README.md - repo landing page and safety boundary.",
+        "  2. docs/index.md - shortest active docs landing page.",
+        "  3. docs/onboarding/DEVELOPER_VISUAL_START_HERE.md - visual onboarding map.",
+        "  4. docs/onboarding/cdb_glossary.md - terminology anchor.",
+        "  5. docs/onboarding/fresh_clone_rehearsal.md - read-only fresh-clone path.",
+    ]
+    if role == "agent":
+        lines.append(
+            "  6. docs/onboarding/repo_brain_context_intelligence.md - Repo Brain first use.",
+        )
+    elif role == "developer":
+        lines.append(
+            "  6. DEVELOPER_ONBOARDING.md - local setup and first PR workflow.",
+        )
+    return lines
+
+
+def _build_doctor_validator_plan() -> list[str]:
+    return [
+        "Doctor / Validator Plan:",
+        "  1. python -m tools.onboarding_doctor - read-only local check.",
+        "  2. python -m tools.validate_onboarding_docs - active surface validation.",
+        "  3. make context-doctor - Context Intelligence preflight.",
+        "  All three are read-only; no stack, Docker, DB, or MCP mutation.",
+    ]
+
+
+def _build_first_issue_dry_run() -> list[str]:
+    return [
+        "First-Issue Dry Run:",
+        "  Scope: docs-only change (e.g. add term to cdb_glossary.md).",
+        "  1. Branch from origin/main: docs/<issue>-<slug>.",
+        "  2. Edit a single safe file under docs/onboarding/.",
+        "  3. Run: python -m tools.validate_onboarding_docs.",
+        "  4. Run: ruff check .",
+        "  5. Commit with conventional commit message.",
+        "  6. Push branch.",
+    ]
+
+
+def _build_pr_lock_simulation() -> list[str]:
+    return [
+        "PR / LOCK Simulation:",
+        "  1. PR body MUST contain: Delivered, Validation, Non-Goals, Safety, Restunsicherheiten.",
+        "  2. Post LOCK: comment on the PR before any further mutation.",
+        "  3. Required checks: ci (Unit/Integration + Lint).",
+        "  4. Required checks: policy-gate.",
+        "  5. Wait for CI green before merge.",
+        "  6. Squash-merge after green + approved.",
+    ]
+
+
+def _build_hold_conditions() -> list[str]:
+    return [
+        "HOLD Conditions:",
+        "  ONBOARDING_HOLD if:",
+        "  - git fetch / gh issue view fail.",
+        "  - Worktree dirty with unknown changes.",
+        "  - Local main behind origin/main.",
+        "  - Target issue not readable via gh.",
+        "  - Context Brain Preflight fails without valid fallback reason.",
+        "  - Bootloader files missing or unreadable.",
+        "  - Required checks red and not scope-fixable.",
+        "  - Diff shows scope growth beyond allowed surfaces.",
+        "  - Secrets or LR/Live boundaries touched.",
+    ]
+
+
+def _build_final_verdict(role: str, mode: str) -> str:
+    if mode == "check-only":
+        return "HOLD_ONBOARDING_GAP"
+    return "READY_FOR_REAL_FIRST_ISSUE"
+
+
+def _build_safety_lines() -> list[str]:
+    return [
+        "LR remains NO-GO.",
+        "Board stage trade-capable is not Live-Go.",
+        "No Echtgeld-Go.",
+        "This simulation is read-only: no file writes, no GitHub writes, no Docker/runtime/DB/MCP mutation.",
+    ]
+
+
+def _build_context_brain_note() -> list[str]:
+    return [
+        "Context Brain Note:",
+        "  context_brain_attempted=true (required by bootloader).",
+        "  If MCP tools unavailable: repo_fallback_used=true, repo_fallback_reason=tool_blocked.",
+        "  If Context Brain MCP tools respond: use records, not caller metadata.",
+        "  No DB-backed claims without tool/query/record evidence.",
+    ]
+
+
+def _validate_output_safe(text: str) -> None:
+    for pattern in FORBIDDEN_OUTPUT_PATTERNS:
+        if pattern.search(text):
+            raise ValueError("output contains forbidden pattern - potential secret leak")
+
+
+def render_simulation(role: str = "agent", mode: str = "first-issue-dry-run") -> str:
+    resolved_role = _normalize_role(role)
+    resolved_mode = _normalize_mode(mode)
+    verdict = _build_final_verdict(resolved_role, resolved_mode)
+    role_label = ROLE_LABELS[resolved_role]
+
+    sections: dict[str, list[str]] = {
+        "context_brain": _build_context_brain_note(),
+        "bootloader": _build_bootloader_plan(resolved_role),
+        "live_truth": _build_live_truth_plan(),
+        "tour": _build_tour_path(resolved_role),
+        "doctor_validator": _build_doctor_validator_plan(),
+        "first_issue": _build_first_issue_dry_run(),
+        "pr_lock": _build_pr_lock_simulation(),
+        "hold_conditions": _build_hold_conditions(),
+    }
+
+    lines: list[str] = [
+        "ONBOARDING_START",
+        f"mode: {resolved_mode}",
+        f"role: {role_label}",
+        "writes: disabled",
+        "github_writes: disabled",
+        "lr: NO-GO",
+        "",
+    ]
+
+    for section_name, section_lines in sections.items():
+        lines.extend(section_lines)
+        lines.append("")
+
+    lines.append(f"Final Verdict: {verdict}")
+    lines.append("")
+
+    lines.append("Safety boundaries:")
+    for sl in _build_safety_lines():
+        lines.append(f"  - {sl}")
+
+    return "\n".join(lines)
+
+
+def render_simulation_json(role: str = "agent", mode: str = "first-issue-dry-run") -> str:
+    resolved_role = _normalize_role(role)
+    resolved_mode = _normalize_mode(mode)
+    verdict = _build_final_verdict(resolved_role, resolved_mode)
+
+    output = SimulationOutput(role=resolved_role, mode=resolved_mode, verdict=verdict)
+    output.sections = {
+        "context_brain": _build_context_brain_note(),
+        "bootloader": _build_bootloader_plan(resolved_role),
+        "live_truth": _build_live_truth_plan(),
+        "tour": _build_tour_path(resolved_role),
+        "doctor_validator": _build_doctor_validator_plan(),
+        "first_issue": _build_first_issue_dry_run(),
+        "pr_lock": _build_pr_lock_simulation(),
+        "hold_conditions": _build_hold_conditions(),
+    }
+    return json.dumps(output.to_dict(), indent=2, sort_keys=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Deterministic read-only onboarding simulation runner.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  python -m tools.onboarding_simulation
+  python -m tools.onboarding_simulation --role agent --mode first-issue-dry-run
+  python -m tools.onboarding_simulation --role developer --format json
+  .\\tools\\cdb.ps1 onboarding simulate
+""",
+    )
+    parser.add_argument(
+        "--role",
+        default="agent",
+        help="Role path: developer, agent, docs, validation, evidence (default: agent)",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("first-issue-dry-run", "check-only"),
+        default="first-issue-dry-run",
+        help="Simulation mode (default: first-issue-dry-run)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        role = args.role
+        mode = args.mode
+        if args.format == "json":
+            output = render_simulation_json(role, mode)
+        else:
+            output = render_simulation(role, mode)
+    except ValueError as exc:
+        parser.error(str(exc))
+        return 2
+
+    _validate_output_safe(output)
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Delivered
- tools/onboarding_simulation.py: read-only simulation runner with all required sections
  - ONBOARDING_START, Context Brain Note, Bootloader Plan, Live Truth Plan,
    Tour Path, Doctor/Validator Plan, First-Issue Dry Run, PR/LOCK Simulation,
    HOLD Conditions, Final Verdict
- Verdict enum: READY_FOR_REAL_FIRST_ISSUE, HOLD_ONBOARDING_GAP, BLOCKED_BOOTLOADER, BLOCKED_LIVE_TRUTH, BLOCKED_GOVERNANCE
- Role support: agent, developer, docs, validation (with aliases)
- Mode support: first-issue-dry-run (default), check-only
- JSON output format via --format json
- Secret-display prevention via FORBIDDEN_OUTPUT_PATTERNS

## Validation
- 79 unit tests all PASS (0.18s)
- All required output sections verified
- All 5 verdict enum values tested
- Role aliases, mode validation, JSON output tested
- Secret pattern rejection tested

## Non-Goals
- No runtime/Docker/trading/LR/DB/MCP mutations
- No file writes, no GitHub writes
- No branch/PR creation

## Safety Boundaries
- LR: NO-GO
- Board stage trade-capable is not Live-Go
- Read-only simulation only

## Restunsicherheiten
- Runner is deterministic for given inputs; real-world bootloader behavior may vary per environment
- Verdict is always READY_FOR_REAL_FIRST_ISSUE for first-issue-dry-run mode (simulation, not actual readiness check)