### PR TITLE
docs(onboarding): redesign core eventflow diagrams

### DIFF
--- a/docs/onboarding/core-eventflows/arvp_replay_validation_flow.md
+++ b/docs/onboarding/core-eventflows/arvp_replay_validation_flow.md
@@ -18,40 +18,50 @@ Show the ARVP (Automated Replay Validation Pipeline) flow: from dataset acquisit
 See [`diagrams/arvp_replay_validation_flow.mmd`](diagrams/arvp_replay_validation_flow.mmd) for the source file.
 
 ```mermaid
-flowchart TD
-    subgraph Dataset["Dataset Layer"]
-        DS[Dataset Source<br/>file | db]
-        DP[DatasetProvider<br/>FileBacked | DBBacked]
-        DQ[DatasetSpec<br/>fingerprint, window]
+flowchart TB
+    subgraph DATA["DATA LAYER"]
+        DS["Dataset Source<br/>file | db"] --> DP["DatasetProvider<br/>FileBacked | DBBacked"]
+        DP --> DQ["DatasetSpec<br/>fingerprint · window · checks"]
+        DQ --> CHK{"Data<br/>Sufficient?"}
+        CHK -->|"yes"| HB["Historical Bridge<br/>file-backed input"]
+        CHK -->|"HOLD"| H1["HOLD<br/>insufficient data"]
     end
-    subgraph Replay["Replay Execution"]
-        HB[Historical Bridge<br/>file-backed historical input]
-        SR[Strategy Replay Runner<br/>strategy_backtest_runner.py]
-        SC[Scheduler<br/>event-time, speed profiles]
-        RR[Replay Reporter<br/>report.json, manifest, audit.log]
+
+    subgraph ENGINE["REPLAY ENGINE (deterministic · event-time · offline)"]
+        HB --> SCH["Scheduler<br/>event-time · speed profiles"]
+        SCH --> SR["Strategy Replay Runner<br/>strategy_backtest_runner.py"]
+        SR --> RR["Replay Reporter<br/>report.json · manifest · audit.log"]
     end
-    subgraph Compare["Replay-vs-Paper Compare"]
-        RC[Replay vs Paper Compare<br/>replay_vs_paper_compare.py]
-        SCMP[Shadow Comparison<br/>shadow_comparison.json]
-        CR[Calibration Report<br/>simulator_calibration_report.json]
+
+    subgraph COMPARE["COMPARISON & CALIBRATION"]
+        RR --> RC["Replay vs Paper Compare<br/>replay_vs_paper_compare.py"]
+        RC --> PAPER{"Paper<br/>Reference?"}
+        PAPER -->|"yes"| SCMP["Shadow Comparison<br/>shadow_comparison.json"]
+        PAPER -->|"HOLD"| H2["HOLD<br/>missing paper reference"]
+        SCMP --> CR["Calibration Report<br/>simulator_calibration_report.json"]
+        CR --> DRIFT{"Simulator Drift<br/>within threshold?"}
+        DRIFT -->|"yes"| RS["Regime Scorecards<br/>arvp_regime_scorecard.json"]
+        DRIFT -->|"HOLD"| H3["HOLD<br/>simulator drift"]
     end
-    subgraph Evidence["Evidence / Gate"]
-        RS[Regime Scorecards<br/>arvp_regime_scorecard.json]
-        AG[ARVP Gate Verdict<br/>pass / fail / blocked]
+
+    subgraph GATE["ARVP GATE (validation evidence only · NOT LIVE-GO)"]
+        RS --> AG{"ARVP Gate<br/>Verdict"}
+        AG -->|"PASS"| PASS["VALIDATION_PASS<br/>replay evidence consistent<br/>does not authorize Live-Go"]
+        AG -->|"BLOCKED"| BLOCK["BLOCKED<br/>gate not met"]
+        AG -->|"HOLD"| HOLD["HOLD<br/>needs human review"]
     end
-    DS --> DP
-    DP --> DQ
-    DQ --> HB
-    HB --> SR
-    SC --> SR
-    SR --> RR
-    RR --> RC
-    RC --> SCMP
-    SCMP --> CR
-    RC --> RS
-    RS --> AG
-    SCMP --> AG
-    CR --> AG
+
+    DATA --> ENGINE
+    ENGINE --> COMPARE
+    COMPARE --> GATE
+
+    style H1 fill:#f99,stroke:#c33
+    style H2 fill:#f99,stroke:#c33
+    style H3 fill:#f99,stroke:#c33
+    style BLOCK fill:#f99,stroke:#c33
+    style HOLD fill:#fc3,stroke:#c93
+    style PASS fill:#9f9,stroke:#393
+    style AG fill:#ff9,stroke:#c93
 ```
 
 ## What New Developers Must Understand

--- a/docs/onboarding/core-eventflows/diagrams/arvp_replay_validation_flow.mmd
+++ b/docs/onboarding/core-eventflows/diagrams/arvp_replay_validation_flow.mmd
@@ -2,41 +2,47 @@
 title: ARVP Replay and Replay-vs-Paper Validation Flow
 ---
 
-flowchart TD
-    subgraph Dataset["Dataset Layer"]
-        DS[Dataset Source<br/>file | db]
-        DP[DatasetProvider<br/>FileBacked | DBBacked]
-        DQ[DatasetSpec<br/>fingerprint, window]
+flowchart TB
+    subgraph DATA["DATA LAYER"]
+        DS["Dataset Source<br/>file | db"] --> DP["DatasetProvider<br/>FileBacked | DBBacked"]
+        DP --> DQ["DatasetSpec<br/>fingerprint · window · checks"]
+        DQ --> CHK{"Data<br/>Sufficient?"}
+        CHK -->|"yes"| HB["Historical Bridge<br/>file-backed input"]
+        CHK -->|"HOLD"| H1["HOLD<br/>insufficient data"]
     end
 
-    subgraph Replay["Replay Execution"]
-        HB[Historical Bridge<br/>file-backed historical input]
-        SR[Strategy Replay Runner<br/>strategy_backtest_runner.py]
-        SC[Scheduler<br/>event-time, speed profiles]
-        RR[Replay Reporter<br/>report.json, manifest, audit.log]
+    subgraph ENGINE["REPLAY ENGINE (deterministic · event-time · offline)"]
+        HB --> SCH["Scheduler<br/>event-time · speed profiles"]
+        SCH --> SR["Strategy Replay Runner<br/>strategy_backtest_runner.py"]
+        SR --> RR["Replay Reporter<br/>report.json · manifest · audit.log"]
     end
 
-    subgraph Compare["Replay-vs-Paper Compare"]
-        RC[Replay vs Paper Compare<br/>replay_vs_paper_compare.py]
-        SCMP[Shadow Comparison<br/>shadow_comparison.json]
-        CR[Calibration Report<br/>simulator_calibration_report.json]
+    subgraph COMPARE["COMPARISON & CALIBRATION"]
+        RR --> RC["Replay vs Paper Compare<br/>replay_vs_paper_compare.py"]
+        RC --> PAPER{"Paper<br/>Reference?"}
+        PAPER -->|"yes"| SCMP["Shadow Comparison<br/>shadow_comparison.json"]
+        PAPER -->|"HOLD"| H2["HOLD<br/>missing paper reference"]
+        SCMP --> CR["Calibration Report<br/>simulator_calibration_report.json"]
+        CR --> DRIFT{"Simulator Drift<br/>within threshold?"}
+        DRIFT -->|"yes"| RS["Regime Scorecards<br/>arvp_regime_scorecard.json"]
+        DRIFT -->|"HOLD"| H3["HOLD<br/>simulator drift"]
     end
 
-    subgraph Evidence["Evidence / Gate"]
-        RS[Regime Scorecards<br/>arvp_regime_scorecard.json]
-        AG[ARVP Gate Verdict<br/>pass / fail / blocked]
+    subgraph GATE["ARVP GATE (validation evidence only · NOT LIVE-GO)"]
+        RS --> AG{"ARVP Gate<br/>Verdict"}
+        AG -->|"PASS"| PASS["VALIDATION_PASS<br/>replay evidence consistent<br/>does not authorize Live-Go"]
+        AG -->|"BLOCKED"| BLOCK["BLOCKED<br/>gate not met"]
+        AG -->|"HOLD"| HOLD["HOLD<br/>needs human review"]
     end
 
-    DS --> DP
-    DP --> DQ
-    DQ --> HB
-    HB --> SR
-    SC --> SR
-    SR --> RR
-    RR --> RC
-    RC --> SCMP
-    SCMP --> CR
-    RC --> RS
-    RS --> AG
-    SCMP --> AG
-    CR --> AG
+    DATA --> ENGINE
+    ENGINE --> COMPARE
+    COMPARE --> GATE
+
+    style H1 fill:#f99,stroke:#c33
+    style H2 fill:#f99,stroke:#c33
+    style H3 fill:#f99,stroke:#c33
+    style BLOCK fill:#f99,stroke:#c33
+    style HOLD fill:#fc3,stroke:#c93
+    style PASS fill:#9f9,stroke:#393
+    style AG fill:#ff9,stroke:#c93

--- a/docs/onboarding/core-eventflows/diagrams/execution_paper_order_result_flow.mmd
+++ b/docs/onboarding/core-eventflows/diagrams/execution_paper_order_result_flow.mmd
@@ -2,42 +2,47 @@
 title: Execution, Paper/Mock and Order Result Feedback
 ---
 
-flowchart LR
-    subgraph Input["Input"]
-        ORD[orders Stream]
+flowchart TB
+    subgraph INPUT["INPUT: Orders Stream"]
+        RISK["cdb_risk<br/>risk-approved orders"] --> ORD["orders Redis Stream"]
     end
 
-    subgraph Exec["Execution Service (cdb_execution)"]
-        EP[Execution Processor]
-        MOCK{Mock/Paper Boundary<br/>default mode}
-        DPL[Deployment Logic<br/>paper vs live]
+    subgraph EXEC["EXECUTION SERVICE (cdb_execution)"]
+        EP["Execution Processor"]
+        BOUNDARY{"Execution<br/>Boundary"}
     end
 
-    subgraph Exchange["Exchange Boundary"]
-        EX_LIVE[Live Exchange<br/>GATED FUTURE<br/>requires explicit LR gate]
+    subgraph PAPER["PAPER / MOCK — default path · active"]
+        SIM["Paper Engine<br/>simulated fills · results"]
+        SIM --> FR["stream.fills"]
+        SIM --> ORI["order_results"]
     end
 
-    subgraph Feedback["Order Result Feedback"]
-        FR[stream.fills Redis Stream]
-        ORI[order_results Redis Stream]
+    subgraph LIVE["LIVE EXCHANGE — gated · blocked"]
+        EXL["Exchange Adapter"]
+        LR_BLOCK["LR NO-GO · future only<br/>requires explicit human gate"]
     end
 
-    subgraph Consumers["Consumers"]
-        RK[cdb_risk<br/>position/exposure update]
-        DW[cdb_db_writer<br/>persistence]
+    subgraph FEEDBACK["FEEDBACK LOOP"]
+        RISK2["cdb_risk<br/>position · exposure update"]
+        DW["cdb_db_writer<br/>persistence"]
     end
 
     ORD --> EP
-    EP --> MOCK
-    MOCK -->|Paper/Mock mode (default)| DPL
-    MOCK -->|Live mode| EX_LIVE
-    DPL --> FR
-    DPL --> ORI
-    EX_LIVE -->|fills + results| FR
-    EX_LIVE -->|fills + results| ORI
-    ORI --> RK
-    ORI --> DW
-    FR --> RK
-    FR --> DW
+    EP --> BOUNDARY
+    BOUNDARY -->|"default"| SIM
+    BOUNDARY -.->|"gated · blocked"| EXL
+    EXL -.->|"blocked"| LR_BLOCK
 
-    style EX_LIVE fill:#f99,stroke:#c33,stroke-dasharray: 5 5
+    FR --> RISK2
+    ORI --> RISK2
+    FR --> DW
+    ORI --> DW
+
+    RISK2 -.->|"exposure feedback"| RISK
+
+    style EXL fill:#f99,stroke:#c33,stroke-dasharray:5 5
+    style LR_BLOCK fill:#fcc,stroke:#c33
+    style BOUNDARY fill:#ff9,stroke:#c93
+    style PAPER fill:#efe,stroke:#6a6
+    style LIVE fill:#fee,stroke:#c66

--- a/docs/onboarding/core-eventflows/execution_paper_order_result_flow.md
+++ b/docs/onboarding/core-eventflows/execution_paper_order_result_flow.md
@@ -18,39 +18,50 @@ Show how orders from Risk are processed by Execution, how the paper/mock boundar
 See [`diagrams/execution_paper_order_result_flow.mmd`](diagrams/execution_paper_order_result_flow.mmd) for the source file.
 
 ```mermaid
-flowchart LR
-    subgraph Input["Input"]
-        ORD[orders Stream]
+flowchart TB
+    subgraph INPUT["INPUT: Orders Stream"]
+        RISK["cdb_risk<br/>risk-approved orders"] --> ORD["orders Redis Stream"]
     end
-    subgraph Exec["Execution Service (cdb_execution)"]
-        EP[Execution Processor]
-        MOCK{Mock/Paper Boundary<br/>default mode}
-        DPL[Deployment Logic<br/>paper vs live}
+
+    subgraph EXEC["EXECUTION SERVICE (cdb_execution)"]
+        EP["Execution Processor"]
+        BOUNDARY{"Execution<br/>Boundary"}
     end
-    subgraph Exchange["Exchange Boundary"]
-        EX_LIVE[Live Exchange<br/>GATED FUTURE<br/>requires explicit LR gate]
+
+    subgraph PAPER["PAPER / MOCK — default path · active"]
+        SIM["Paper Engine<br/>simulated fills · results"]
+        SIM --> FR["stream.fills"]
+        SIM --> ORI["order_results"]
     end
-    subgraph Feedback["Order Result Feedback"]
-        FR[stream.fills Redis Stream]
-        ORI[order_results Redis Stream]
+
+    subgraph LIVE["LIVE EXCHANGE — gated · blocked"]
+        EXL["Exchange Adapter"]
+        LR_BLOCK["LR NO-GO · future only<br/>requires explicit human gate"]
     end
-    subgraph Consumers["Consumers"]
-        RK[cdb_risk<br/>position/exposure update]
-        DW[cdb_db_writer<br/>persistence]
+
+    subgraph FEEDBACK["FEEDBACK LOOP"]
+        RISK2["cdb_risk<br/>position · exposure update"]
+        DW["cdb_db_writer<br/>persistence"]
     end
+
     ORD --> EP
-    EP --> MOCK
-    MOCK -->|Paper/Mock mode (default)| DPL
-    MOCK -->|Live mode| EX_LIVE
-    DPL --> FR
-    DPL --> ORI
-    EX_LIVE --> FR
-    EX_LIVE --> ORI
-    ORI --> RK
-    ORI --> DW
-    FR --> RK
+    EP --> BOUNDARY
+    BOUNDARY -->|"default"| SIM
+    BOUNDARY -.->|"gated · blocked"| EXL
+    EXL -.->|"blocked"| LR_BLOCK
+
+    FR --> RISK2
+    ORI --> RISK2
     FR --> DW
-    style EX_LIVE fill:#f99,stroke:#c33,stroke-dasharray: 5 5
+    ORI --> DW
+
+    RISK2 -.->|"exposure feedback"| RISK
+
+    style EXL fill:#f99,stroke:#c33,stroke-dasharray:5 5
+    style LR_BLOCK fill:#fcc,stroke:#c33
+    style BOUNDARY fill:#ff9,stroke:#c93
+    style PAPER fill:#efe,stroke:#6a6
+    style LIVE fill:#fee,stroke:#c66
 ```
 
 ## What New Developers Must Understand


### PR DESCRIPTION
Closes #3281

## Brain Evidence

\\\
brain_source: repo-only
brain_status: not-used
tools_or_queries: [gh issue view 3281, git fetch/status, rg search, 4 file reads]
records_or_results: []
repo_crosscheck: [docs/onboarding/core-eventflows/diagrams/*.mmd, wrapper .md files]
impact_on_plan: [Kein DB-Brain verfügbar; alle Entscheidungen aus Live GitHub + Repo-Reads]
limitations: [Keine Mermaid-Automation-Validator im Repo; manuelle Syntax-Prüfung]
\\\

## Delivered

### arvp_replay_validation_flow.mmd
- Klare Layer-Trennung: DATA → REPLAY ENGINE → COMPARISON → ARVP GATE
- Diamond-Entscheidungsknoten für HOLD-Pfade (insufficient data, missing paper reference, simulator drift)
- Deterministic event-time replay explizit im Subgraph-Titel
- ARVP GATE als &quot;validation evidence only · NOT LIVE-GO&quot; markiert
- Gate-Verdict: PASS / BLOCKED / HOLD mit Farbcodierung
- VALIDATION_PASS explizit: &quot;does not authorize Live-Go&quot;

### execution_paper_order_result_flow.mmd
- Layout von LR auf TB geändert für bessere Lesbarkeit
- Paper/Mock Default Path (aktiv) vs Live Exchange Path (gated · blocked) visuell getrennt
- Live Exchange Subgraph rot gestylt mit &quot;LR NO-GO · future only&quot;
- Paper Engine produziert simulated fills/results
- Feedback-Loop von cdb_risk zurück zu exposure (gestrichelt)
- Subgraph-Farben: PAPER grün (aktiv), LIVE rot (blockiert)

## Validation

- \git diff --check\ — clean (nur LF/CRLF warnings)
- \python -m tools.validate_onboarding_docs --verbose\ — all OK
- \g\ search confirms: HOLD paths, simulator drift, missing paper reference, gated · blocked, NOT LIVE-GO, VALIDATION_PASS, exposure feedback — all present in diagrams and wrappers
- Mermaid syntax: manuell geprüft (kein Mermaid-Automation-Validator im Repo)

## Safety Boundaries

- LR remains NO-GO
- Board stage trade-capable is not Live-Go
- Nur .mmd und wrapper .md geändert; kein Code, Runtime, Docker, DB, MCP
- Keine untracked/unrelated files committed

## Restunsicherheiten

- Keine Mermaid-Automation-Validator im Repo — syntax manuell geprüft
- GitHub Mermaid-Rendering kann von lokaler Vorschau abweichen

## Untracked pre-existing files classification

- \.cursor/skills/.system/\ — pre-existing (vorherige Session)
- \.cursor/skills/onboarding/\ — pre-existing (vorherige Session)
- \.opencode/plans/\ — pre-existing
- \docs/decisions/\ — pre-existing
- Keine dieser Dateien in #3281 committed