### PR TITLE
feat(context): add fail-closed context package validator

### DIFF
--- a/docs/runbooks/CDB_CONTEXT_REFRESH.md
+++ b/docs/runbooks/CDB_CONTEXT_REFRESH.md
@@ -1,0 +1,185 @@
+# CDB Context Refresh Runbook
+
+**Zweck:** Zweimal woechentlich den aktuellen CDB-Repo-Kontext aus GitHub/Repo-Live-Wahrheit
+in ein evidence-faehiges Context-/Brain-Paket ueberfuehren.
+
+**Parent Epic:** [#3286](https://github.com/jannekbuengener/Claire_de_Binare/issues/3286)
+**Erster operativer Slice:** [#3288](https://github.com/jannekbuengener/Claire_de_Binare/issues/3288)
+**Naechster Slice (Brain Apply):** [#3289](https://github.com/jannekbuengener/Claire_de_Binare/issues/3289) — benoetigt validiertes Package aus #3288
+
+**LR-Status:** `NO-GO`
+**Board-Stage:** `trade-capable` — orthogonal zum LR-System, keine Live-Implikation
+
+---
+
+## 1. Context Package Schema
+
+Das maschinenlesbare Schema definiert die Struktur und Sicherheitsgrenzen eines
+Context Packages, bevor ein Brain-Apply (#3289) moeglich wird.
+
+**Schema-Datei:** `tools/context/schemas/context_package.schema.json`
+**Validator:** `tools/context/validate_context_package.py`
+
+### Package-Struktur
+
+```json
+{
+  "package": {
+    "package_id": "cdb-context-package-<YYYY-MM-DD>-<seq>",
+    "package_type": "context_package",
+    "created_at": "<ISO-8601 UTC>",
+    "source_commit": "<SHA>",
+    "source_repo": "Claire_de_Binare",
+    "records": []
+  },
+  "meta": {
+    "version": "1.0",
+    "validator_ref": "tools/context/validate_context_package.py",
+    "schema_ref": "tools/context/schemas/context_package.schema.json",
+    "safety_boundaries": {
+      "lr_status": "NO-GO",
+      "board_stage_is_live_go": false,
+      "real_money_go": false,
+      "productive_db_writes_allowed": false,
+      "secrets_in_outputs_allowed": false,
+      "trading_state_ingestion_allowed": false
+    }
+  }
+}
+```
+
+### Mindestfelder je Record
+
+Jeder Record im Package MUSS alle folgenden Felder enthalten
+(Validierung erfolgt fail-closed durch das Schema):
+
+| Feld | Typ | Beschreibung |
+|------|-----|-------------|
+| `record_id` | string | Eindeutige ID innerhalb des Packages |
+| `record_type` | string (enum) | Einer der erlaubten Record-Typen (s.u.) |
+| `repo` | string | Repo-Identifier |
+| `source_path` | string | Relativer Dateipfad im Quell-Repo |
+| `source_commit` | string | Git-Commit-SHA |
+| `source_hash` | string | Content-Hash (z.B. SHA-256 hex) |
+| `observed_at` | string (date-time) | ISO-8601 UTC-Beobachtungszeitpunkt |
+| `confidence` | string (enum) | high, medium, low, unverified |
+| `supersedes` | string or null | Referenz auf supersedierten Record |
+| `tags` | string[] | Kategorisierungs-Tags |
+| `summary` | string | Menschlesbare Zusammenfassung |
+| `evidence_refs` | object[] | Evidence-Referenzen (ref + source) |
+
+### Erlaubte Record-Typen
+
+- `doc_record` — Dokumentationseintrag
+- `code_snapshot` — Code-Snapshot
+- `decision_record` — Entscheidungsrecord
+- `evidence_record` — Evidence-Record
+- `claim_record` — Claim-Record (benoetigt canon_read_evidence)
+- `memory_record` — Memory-Record
+- `dependency_edge` — Dependency-Edge
+- `context_package_ref` — Referenz auf anderes Context Package
+
+### Safety Boundaries (im Meta-Objekt verankert)
+
+- `lr_status` ist fix `NO-GO` — nur LR-SSOT kann das aendern
+- `board_stage_is_live_go` ist fix `false`
+- `real_money_go` ist fix `false`
+- `productive_db_writes_allowed` ist fix `false`
+- `secrets_in_outputs_allowed` ist fix `false`
+- `trading_state_ingestion_allowed` ist fix `false`
+
+---
+
+## 2. Fail-Closed Validator
+
+Der Validator prueft ein Context Package auf zwei Ebenen:
+
+### Ebene 1: Schema-Validierung (JSON Schema)
+
+- Struktur, erforderliche Felder, erlaubte Record-Typen, Typkorrektheit
+- Auch zusaetzliche unbekannte Felder werden blockiert (`additionalProperties: false`)
+
+### Ebene 2: Stop Rules (zusaezlich zur Schema-Validierung)
+
+| Regel | Ausloeser | Ergebnis |
+|-------|-----------|----------|
+| Secret-Indikator | `api_key`, `secret`, `password`, `token` u.a. in `summary` oder `source_path` | BLOCKED |
+| Orders/Fills/Positions | `order data`, `fill status`, `position update`, `live-risk-state` in `summary` | BLOCKED |
+| Live/Echtgeld-Claim | `live_or_echtgeld_claim` ohne gueltige LR-SSOT-Referenz | BLOCKED |
+| Fehlende Canon-Read-Evidence | `claim_record` ohne `canon_read_evidence` | BLOCKED |
+| Fehlende Evidence-Refs | Record mit leerem `evidence_refs` | BLOCKED |
+
+### Validierungsergebnis
+
+- **PASS:** Exit-Code 0, keine Fehler
+- **BLOCKED:** Exit-Code 1, agentenlesbare + maschinenlesbare Fehlerausgabe
+- **FAIL:** Exit-Code 2, unerwarteter Fehler (Datei nicht gefunden, JSON-Parse-Fehler)
+
+### CLI-Usage
+
+```bash
+# Package validieren (Datei)
+python tools/context/validate_context_package.py pfad/zum/package.json
+
+# Package validieren (stdin)
+python tools/context/validate_context_package.py --stdin < package.json
+
+# Maschinenlesbare JSON-Report-Ausgabe
+python tools/context/validate_context_package.py package.json --json
+
+# Hilfe
+python tools/context/validate_context_package.py --help
+```
+
+---
+
+## 3. Workflow (Uebersicht)
+
+```
+Repo live lesen (#3287)
+    |
+    v
+Delta-Paket bauen (Context Package)
+    |
+    v
+Package validieren (#3288) ← dieses Schema/Validator
+    |
+    v (nur bei PASS)
+Lokaler append-only Brain Apply (#3289)
+    |
+    v
+Agent Briefing (#3290) / Drift Report (#3291)
+```
+
+---
+
+## 4. Safety-Grenzen (Nicht-Ziele)
+
+- **Report/Validation only:** Dieses Schema und der Validator fuehren keinen
+  Brain Apply durch. Das ist Scope von #3289.
+- **Keine produktiven DB-Writes:** Context Packages sind read-only Artefakte.
+  Sie schreiben nicht in SurrealDB, PostgreSQL oder Redis.
+- **Keine Secrets-Ingestion:** Secret-Patterns werden blockiert. Keine
+  Secret-Werte erscheinen in Fehlerausgaben oder Reports.
+- **Keine Trading-State-Ingestion:** Orders, Fills, Positions, Live-Risk-State
+  sind blockiert.
+- **LR bleibt NO-GO:** Weder Board-Stage `trade-capable` noch ein validiertes
+  Context Package autorisieren Live-Kapital oder Echtgeld-Trading.
+- **Keine Runtime-Aenderung:** Kein Docker-, Compose-, Runtime- oder
+  BLUE/RED-Stack-Eingriff.
+- **Kein MCP-Mutation:** Context Packages werden nicht automatisch in MCP-Tools
+  oder SurrealDB-Verbindungen eingespielt.
+
+---
+
+## 5. Verwandte Issues
+
+| Issue | Beschreibung | Status |
+|-------|-------------|--------|
+| #3286 | Parent Epic: Context Refresh Workflow | OFFEN |
+| #3287 | Report-only GitHub Actions Workflow | OFFEN |
+| #3288 | Context Package Schema + Validator | DIESES |
+| #3289 | Lokaler append-only Brain Apply | OFFEN |
+| #3290 | Agent Briefing Resolver | OFFEN |
+| #3291 | Stale Documentation / Impact Radar | OFFEN |
+| #3292 | Onboarding Scenario (bewusst zuletzt) | OFFEN |

--- a/tests/unit/tools/context/test_validate_context_package.py
+++ b/tests/unit/tools/context/test_validate_context_package.py
@@ -1,0 +1,280 @@
+"""Unit tests for CDB Context Package fail-closed validator.
+
+Covers: PASS, BLOCKED for schema/stop-rule violations,
+deterministic report shape, secret value hiding.
+#3288
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.context.validate_context_package import (
+    validate_package,
+    check_secret_indicators,
+    check_forbidden_trading_state,
+    check_live_echtgeld_claims,
+    check_canon_read_evidence,
+    check_evidence_refs,
+    build_report,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCHEMA_PATH = REPO_ROOT / "tools" / "context" / "schemas" / "context_package.schema.json"
+VALID_RECORD = {
+    "record_id": "rec_001",
+    "record_type": "doc_record",
+    "repo": "Claire_de_Binare",
+    "source_path": "docs/example.md",
+    "source_commit": "8131849f2ab2cc3bc7cd761668bb9e0e83574492",
+    "source_hash": "abc123def456",
+    "observed_at": "2026-06-17T12:00:00Z",
+    "confidence": "high",
+    "supersedes": None,
+    "tags": ["example", "test"],
+    "summary": "Example test record",
+    "evidence_refs": [
+        {"ref": "docs/example.md", "source": "repo"}
+    ],
+}
+
+VALID_PACKAGE = {
+    "package": {
+        "package_id": "cdb-context-package-2026-06-17-001",
+        "package_type": "context_package",
+        "created_at": "2026-06-17T12:00:00Z",
+        "source_commit": "8131849f2ab2cc3bc7cd761668bb9e0e83574492",
+        "source_repo": "Claire_de_Binare",
+        "records": [VALID_RECORD],
+    },
+    "meta": {
+        "version": "1.0",
+        "validator_ref": "tools/context/validate_context_package.py",
+        "schema_ref": "tools/context/schemas/context_package.schema.json",
+        "safety_boundaries": {
+            "lr_status": "NO-GO",
+            "board_stage_is_live_go": False,
+            "real_money_go": False,
+            "productive_db_writes_allowed": False,
+            "secrets_in_outputs_allowed": False,
+            "trading_state_ingestion_allowed": False,
+        },
+    },
+}
+
+
+def test_valid_minimal_package_pass() -> None:
+    report = validate_package(VALID_PACKAGE)
+    assert report["status"] == "PASS"
+    assert report["exit_code"] == 0
+    assert report["error_count"] == 0
+
+
+def test_missing_source_hash_blocked() -> None:
+    pkg = json.loads(json.dumps(VALID_PACKAGE))
+    pkg["package"]["records"][0]["source_hash"] = ""
+    report = validate_package(pkg)
+    assert report["status"] == "BLOCKED"
+    assert report["exit_code"] == 1
+    codes = [e["code"] for e in report["errors"]]
+    assert "min_length" in codes
+
+
+def test_unknown_record_type_blocked() -> None:
+    pkg = json.loads(json.dumps(VALID_PACKAGE))
+    pkg["package"]["records"][0]["record_type"] = "unknown_type"
+    report = validate_package(pkg)
+    assert report["status"] == "BLOCKED"
+    assert report["exit_code"] == 1
+    codes = [e["code"] for e in report["errors"]]
+    assert "invalid_enum" in codes
+
+
+def test_secret_indicator_in_summary_blocked() -> None:
+    errors: list = []
+    record = {
+        **VALID_RECORD,
+        "summary": "Contains api_key=sk-test and some other text",
+    }
+    check_secret_indicators(
+        {"package": {"records": [record]}}, errors
+    )
+    assert len(errors) >= 1
+    assert errors[0]["code"] == "secret_indicator"
+    assert "No secret values" in errors[0]["message"]
+
+
+def test_secret_indicator_in_source_path_blocked() -> None:
+    errors: list = []
+    record = {
+        **VALID_RECORD,
+        "source_path": "secrets/REDIS_PASSWORD.txt",
+    }
+    check_secret_indicators(
+        {"package": {"records": [record]}}, errors
+    )
+    assert len(errors) >= 1
+    assert errors[0]["code"] == "secret_indicator"
+    assert errors[0]["path"].endswith(".source_path")
+
+
+def test_secret_value_not_in_output() -> None:
+    pkg = json.loads(json.dumps(VALID_PACKAGE))
+    pkg["package"]["records"][0]["summary"] = "Contains api_key=sk-test-secret-key"
+    report = validate_package(pkg)
+    assert report["status"] == "BLOCKED"
+    report_str = json.dumps(report)
+    assert "sk-test-secret-key" not in report_str
+    assert "secret_key" not in report_str
+
+
+def test_orders_fills_positions_blocked() -> None:
+    errors: list = []
+    for keyword in ["order data", "fill status", "position update", "live-risk-state"]:
+        record = {**VALID_RECORD, "summary": f"Contains {keyword}"}
+        errs: list = []
+        check_forbidden_trading_state(
+            {"package": {"records": [record]}}, errs
+        )
+        assert len(errs) >= 1, f"Should block on '{keyword}'"
+        assert "BLOCKED" in errs[0]["message"]
+
+
+def test_live_claim_without_lr_ssot_blocked() -> None:
+    errors: list = []
+    record = {
+        **VALID_RECORD,
+        "live_or_echtgeld_claim": {
+            "lr_ssot_ref": "some/other/path.md",
+            "claim_type": "lr_status",
+        },
+    }
+    check_live_echtgeld_claims(
+        {"package": {"records": [record]}}, errors
+    )
+    assert len(errors) >= 1
+    assert errors[0]["code"] == "live_claim_without_lr_ssot"
+
+
+def test_live_claim_with_valid_lr_ssot_allowed() -> None:
+    errors: list = []
+    record = {
+        **VALID_RECORD,
+        "live_or_echtgeld_claim": {
+            "lr_ssot_ref": "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+            "claim_type": "lr_status",
+        },
+    }
+    check_live_echtgeld_claims(
+        {"package": {"records": [record]}}, errors
+    )
+    assert len(errors) == 0
+
+
+def test_missing_canon_evidence_for_claim_blocked() -> None:
+    errors: list = []
+    record = {
+        **VALID_RECORD,
+        "record_type": "claim_record",
+    }
+    check_canon_read_evidence(
+        {"package": {"records": [record]}}, errors
+    )
+    assert len(errors) >= 1
+    assert errors[0]["code"] == "missing_canon_evidence"
+
+
+def test_claim_with_canon_evidence_allowed() -> None:
+    errors: list = []
+    record = {
+        **VALID_RECORD,
+        "record_type": "claim_record",
+        "canon_read_evidence": [
+            {"path": "AGENTS.md", "commit": "8131849f2ab2cc3bc7cd761668bb9e0e83574492"}
+        ],
+    }
+    check_canon_read_evidence(
+        {"package": {"records": [record]}}, errors
+    )
+    assert len(errors) == 0
+
+
+def test_non_claim_record_no_canon_evidence_required() -> None:
+    errors: list = []
+    record = {
+        **VALID_RECORD,
+        "record_type": "doc_record",
+    }
+    check_canon_read_evidence(
+        {"package": {"records": [record]}}, errors
+    )
+    assert len(errors) == 0
+
+
+def test_missing_evidence_refs_blocked() -> None:
+    errors: list = []
+    record = {
+        **VALID_RECORD,
+        "evidence_refs": [],
+    }
+    check_evidence_refs(
+        {"package": {"records": [record]}}, errors
+    )
+    assert len(errors) >= 1
+    assert errors[0]["code"] == "missing_evidence_refs"
+
+
+def test_deterministic_report_shape() -> None:
+    report_success = build_report([], [], True)
+    assert set(report_success.keys()) == {"status", "exit_code", "error_count", "schema_errors", "stop_rule_errors", "errors"}
+    assert report_success["status"] == "PASS"
+    assert report_success["exit_code"] == 0
+
+    report_fail = build_report(
+        [{"path": "$.test", "code": "test_error", "message": "test"}],
+        [],
+        False,
+    )
+    assert report_fail["status"] == "BLOCKED"
+    assert report_fail["exit_code"] == 1
+    assert report_fail["error_count"] == 1
+
+
+def test_empty_records_allowed() -> None:
+    pkg = json.loads(json.dumps(VALID_PACKAGE))
+    pkg["package"]["records"] = []
+    report = validate_package(pkg)
+    assert report["status"] == "PASS"
+
+
+def test_multiple_valid_records_pass() -> None:
+    pkg = json.loads(json.dumps(VALID_PACKAGE))
+    record_types = [
+        "doc_record", "code_snapshot", "decision_record",
+        "evidence_record", "memory_record", "dependency_edge",
+        "context_package_ref",
+    ]
+    pkg["package"]["records"] = []
+    for i, rt in enumerate(record_types):
+        rec = json.loads(json.dumps(VALID_RECORD))
+        rec["record_id"] = f"rec_{i:03d}"
+        rec["record_type"] = rt
+        pkg["package"]["records"].append(rec)
+    report = validate_package(pkg)
+    assert report["status"] == "PASS"
+
+
+@pytest.mark.parametrize("forbidden_type", [
+    "order_record", "fill_record", "position_record",
+    "risk_state", "live_trade", "echtgeld_order",
+])
+def test_nonexistent_record_types_blocked_by_schema(forbidden_type: str) -> None:
+    pkg = json.loads(json.dumps(VALID_PACKAGE))
+    pkg["package"]["records"][0]["record_type"] = forbidden_type
+    report = validate_package(pkg)
+    assert report["status"] == "BLOCKED"
+    codes = [e["code"] for e in report["errors"]]
+    assert "invalid_enum" in codes

--- a/tools/context/schemas/context_package.schema.json
+++ b/tools/context/schemas/context_package.schema.json
@@ -1,0 +1,243 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "tools/context/schemas/context_package.schema.json",
+  "title": "CDB Context Package Schema",
+  "description": "Fail-closed JSON Schema for CDB repo context refresh packages. This schema validates the structure and safety boundaries of context packages before any brain-apply step (#3289). Live-/Echtgeld-claims require explicit LR-SSOT reference. Orders/Fills/Positions/Risk-State records are forbidden. LR remains NO-GO. No productive DB writes. No secrets ingestion.",
+  "type": "object",
+  "required": ["package", "meta"],
+  "additionalProperties": false,
+  "properties": {
+    "package": {
+      "type": "object",
+      "required": ["package_id", "package_type", "created_at", "source_commit", "source_repo", "records"],
+      "additionalProperties": false,
+      "properties": {
+        "package_id": {
+          "type": "string",
+          "description": "Unique package identifier. Convention: cdb-context-package-<YYYY-MM-DD>-<seq>"
+        },
+        "package_type": {
+          "type": "string",
+          "enum": ["context_package"],
+          "description": "Fixed value 'context_package' for this schema version."
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO-8601 UTC timestamp of package creation."
+        },
+        "source_commit": {
+          "type": "string",
+          "description": "Git commit SHA at time of package assembly."
+        },
+        "source_repo": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9_/-]+$",
+          "description": "Repository identifier (e.g. 'Claire_de_Binare')."
+        },
+        "records": {
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "$ref": "#/definitions/record"
+          }
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "required": ["version", "validator_ref", "schema_ref", "safety_boundaries"],
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "type": "string",
+          "enum": ["1.0"],
+          "description": "Schema version identifier."
+        },
+        "validator_ref": {
+          "type": "string",
+          "description": "Path to the canonical validator script."
+        },
+        "schema_ref": {
+          "type": "string",
+          "description": "Path to this schema file."
+        },
+        "safety_boundaries": {
+          "type": "object",
+          "required": ["lr_status", "board_stage_is_live_go", "real_money_go", "productive_db_writes_allowed", "secrets_in_outputs_allowed", "trading_state_ingestion_allowed"],
+          "additionalProperties": false,
+          "properties": {
+            "lr_status": {
+              "type": "string",
+              "enum": ["NO-GO"],
+              "description": "Live readiness status. Fixed NO-GO. Only LR-SSOT can change this."
+            },
+            "board_stage_is_live_go": {
+              "type": "boolean",
+              "enum": [false],
+              "description": "Board stage must never be interpreted as live-go."
+            },
+            "real_money_go": {
+              "type": "boolean",
+              "enum": [false],
+              "description": "No real-money trading authorized."
+            },
+            "productive_db_writes_allowed": {
+              "type": "boolean",
+              "enum": [false],
+              "description": "No productive DB writes from context packages."
+            },
+            "secrets_in_outputs_allowed": {
+              "type": "boolean",
+              "enum": [false],
+              "description": "No secrets may appear in validation outputs."
+            },
+            "trading_state_ingestion_allowed": {
+              "type": "boolean",
+              "enum": [false],
+              "description": "No orders, fills, positions, or live risk state ingestion."
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "record": {
+      "type": "object",
+      "required": [
+        "record_id",
+        "record_type",
+        "repo",
+        "source_path",
+        "source_commit",
+        "source_hash",
+        "observed_at",
+        "confidence",
+        "supersedes",
+        "tags",
+        "summary",
+        "evidence_refs"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "record_id": {
+          "type": "string",
+          "description": "Unique record identifier within the package."
+        },
+        "record_type": {
+          "type": "string",
+          "enum": [
+            "doc_record",
+            "code_snapshot",
+            "decision_record",
+            "evidence_record",
+            "claim_record",
+            "memory_record",
+            "dependency_edge",
+            "context_package_ref"
+          ],
+          "description": "Canonical record type. Unknown or unspecified types are blocked."
+        },
+        "repo": {
+          "type": "string",
+          "description": "Repository identifier where the source artifact lives."
+        },
+        "source_path": {
+          "type": "string",
+          "description": "Relative file path in the source repo."
+        },
+        "source_commit": {
+          "type": "string",
+          "description": "Git commit SHA of the source artifact."
+        },
+        "source_hash": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Content hash of the source artifact (e.g. SHA-256 hex). Must be non-empty."
+        },
+        "observed_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO-8601 UTC timestamp when the observation was made."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": ["high", "medium", "low", "unverified"],
+          "description": "Confidence level of the record content."
+        },
+        "supersedes": {
+          "oneOf": [
+            { "type": "null" },
+            { "type": "string", "description": "record_id of the superseded record, if any." }
+          ],
+          "description": "Optional reference to a previously superseded record."
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Arbitrary string tags for categorization."
+        },
+        "summary": {
+          "type": "string",
+          "description": "Human-readable summary of the record content."
+        },
+        "evidence_refs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["ref", "source"],
+            "additionalProperties": false,
+            "properties": {
+              "ref": {
+                "type": "string",
+                "description": "Reference identifier (e.g. file path, URL, record_id)."
+              },
+              "source": {
+                "type": "string",
+                "description": "Source type (e.g. 'repo', 'github_issue', 'github_pr', 'run_artifact', 'mcp_tool')."
+              }
+            }
+          },
+          "description": "Evidence references supporting the record content."
+        },
+        "canon_read_evidence": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["path", "commit"],
+            "additionalProperties": false,
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Canonical file path that was read."
+              },
+              "commit": {
+                "type": "string",
+                "description": "Commit SHA at time of read."
+              }
+            }
+          },
+          "description": "Optional evidence of canon file reads supporting this record."
+        },
+        "live_or_echtgeld_claim": {
+          "type": "object",
+          "description": "If present, the record makes a live- or echtgeld-related claim. Requires explicit LR-SSOT reference. Absent by default.",
+          "required": ["lr_ssot_ref", "claim_type"],
+          "additionalProperties": false,
+          "properties": {
+            "lr_ssot_ref": {
+              "type": "string",
+              "description": "Explicit reference to the LR SSOT document (e.g. 'docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md')."
+            },
+            "claim_type": {
+              "type": "string",
+              "enum": ["lr_status", "live_gate", "echtgeld_gate", "canary_status"],
+              "description": "Type of live/echtgeld claim."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/context/validate_context_package.py
+++ b/tools/context/validate_context_package.py
@@ -1,0 +1,376 @@
+"""Fail-closed validator for CDB Context Packages.
+
+Validates a context package JSON file against:
+- JSON Schema (structure, required fields, allowed record types)
+- Stop rules (secrets, forbidden trading state, live/echtgeld claims, canon evidence)
+
+Usage:
+    python tools/context/validate_context_package.py <package.json>
+    python tools/context/validate_context_package.py --stdin < package.json
+    python tools/context/validate_context_package.py --help
+
+Exit codes:
+    0 - PASS (all checks pass)
+    1 - BLOCKED (validation failures)
+    2 - FAIL (unexpected error)
+
+Issue: #3288
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_PATH = Path(__file__).resolve().parent / "schemas" / "context_package.schema.json"
+
+SECRET_PATTERNS: list[re.Pattern] = [
+    re.compile(r"(?i)(api[_-]?key|api[_-]?secret|secret|password|token|credential|private[_-]?key)"),
+    re.compile(r"(?i)(?:REDIS_PASSWORD|POSTGRES_PASSWORD|GRAFANA_PASSWORD|MEXC_API_KEY|MEXC_API_SECRET|SECRETS_PATH|SMTP_PASSWORD)"),
+]
+
+FORBIDDEN_RECORD_SUBSTRINGS: list[re.Pattern] = [
+    re.compile(r"(?i)(order|fill|position)\s*(id|data|status|event|record|update)"),
+    re.compile(r"(?i)live[_-]risk[_-]state"),
+    re.compile(r"(?i)trading[_-]state"),
+]
+
+FORBIDDEN_ALLOWED_LR_KEYS: set[str] = {"lr_status", "live_gate", "echtgeld_gate", "canary_status"}
+
+LR_SSOT_PATH = "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md"
+
+VALID_REPOS: set[str] = {"Claire_de_Binare"}
+
+CANON_PATHS: set[str] = {
+    "AGENTS.md",
+    "agents/AGENTS.md",
+    "agents/OPEN_CODE_AGENTS.md",
+    "docs/runbooks/CONTROL_REGISTER.md",
+    "CURRENT_STATUS.md",
+    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+    "knowledge/governance/CDB_CONSTITUTION.md",
+    "knowledge/governance/CDB_GOVERNANCE.md",
+    "knowledge/governance/CDB_AGENT_POLICY.md",
+    "knowledge/governance/SYSTEM_INVARIANTS.md",
+    "knowledge/CDB_KNOWLEDGE_HUB.md",
+    "docs/meta/WORKING_REPO_CANON.md",
+}
+
+
+def load_schema() -> dict[str, Any]:
+    with open(SCHEMA_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def resolve_ref(ref: str, schema: dict[str, Any]) -> dict[str, Any]:
+    if ref.startswith("#/definitions/"):
+        key = ref[len("#/definitions/"):]
+        return schema["definitions"][key]
+    msg = f"Cannot resolve $ref: {ref}"
+    raise ValueError(msg)
+
+
+def validate_against_schema(
+    package: dict[str, Any], schema: dict[str, Any]
+) -> list[dict[str, Any]]:
+    errors: list[dict[str, Any]] = []
+    _validate_object(package, schema, "$", errors, schema)
+    return errors
+
+
+def _validate_object(
+    obj: Any, schema_node: dict[str, Any], path: str, errors: list[dict[str, Any]],
+    root_schema: dict[str, Any],
+) -> None:
+    if not isinstance(obj, dict):
+        _report_error(errors, path, "expected_object", f"Expected object, got {type(obj).__name__}")
+        return
+
+    if "$ref" in schema_node:
+        resolved = resolve_ref(schema_node["$ref"], root_schema)
+        _validate_object(obj, resolved, path, errors, root_schema)
+        return
+
+    required = schema_node.get("required", [])
+    for field in required:
+        if field not in obj:
+            _report_error(errors, f"{path}.{field}", "missing_required", f"Missing required field: {field}")
+
+    properties = schema_node.get("properties", {})
+    for key, value in obj.items():
+        prop_path = f"{path}.{key}"
+        if key not in properties:
+            if schema_node.get("additionalProperties", True) is False:
+                _report_error(errors, prop_path, "unknown_field", f"Unknown field: {key}")
+            continue
+        prop_schema = properties[key]
+        _validate_value(value, prop_schema, prop_path, errors, root_schema)
+
+
+def _validate_value(
+    value: Any, schema_node: dict[str, Any], path: str, errors: list[dict[str, Any]],
+    root_schema: dict[str, Any],
+) -> None:
+    if "$ref" in schema_node:
+        resolved_schema = resolve_ref(schema_node["$ref"], root_schema)
+        type_schema = resolved_schema
+    else:
+        type_schema = schema_node
+
+    if "type" in type_schema and type_schema["type"] == "object" and isinstance(value, dict):
+        _validate_object(value, type_schema, path, errors, root_schema)
+        return
+
+    if type_schema.get("type") == "array" and isinstance(value, list):
+        items_schema = type_schema.get("items", {})
+        min_items = type_schema.get("minItems")
+        if min_items is not None and len(value) < min_items:
+            _report_error(errors, path, "min_items", f"Minimum {min_items} items required, got {len(value)}")
+        for i, item in enumerate(value):
+            _validate_value(item, items_schema, f"{path}[{i}]", errors, root_schema)
+        return
+
+    if "type" in type_schema:
+        expected = type_schema["type"]
+        if expected == "string" and not isinstance(value, str):
+            _report_error(errors, path, "type_mismatch", f"Expected string, got {type(value).__name__}")
+        elif expected == "boolean" and not isinstance(value, bool):
+            _report_error(errors, path, "type_mismatch", f"Expected boolean, got {type(value).__name__}")
+
+    if isinstance(value, str):
+        if "enum" in type_schema and value not in type_schema["enum"]:
+            _report_error(
+                errors, path, "invalid_enum",
+                f"Invalid value '{value}'. Allowed: {type_schema['enum']}",
+            )
+        if "minLength" in type_schema and len(value) < type_schema["minLength"]:
+            _report_error(errors, path, "min_length", f"Minimum length {type_schema['minLength']} required")
+        if "pattern" in type_schema and not re.match(type_schema["pattern"], value):
+            _report_error(errors, path, "pattern_mismatch", f"Value '{value}' does not match pattern {type_schema['pattern']}")
+
+    if "oneOf" in type_schema:
+        matched = False
+        for option in type_schema["oneOf"]:
+            if option.get("type") == "null" and value is None:
+                matched = True
+                break
+            if isinstance(value, dict) and option.get("type") == "object":
+                matched = True
+                break
+            if isinstance(value, str) and option.get("type") == "string":
+                matched = True
+                break
+        if not matched:
+            _report_error(errors, path, "oneof_mismatch", f"Value does not match any oneOf schema: {type(value).__name__}")
+
+
+def check_secret_indicators(
+    package: dict[str, Any], errors: list[dict[str, Any]]
+) -> None:
+    records = package.get("package", {}).get("records", [])
+    for i, record in enumerate(records):
+        summary = record.get("summary", "")
+        if isinstance(summary, str) and any(p.search(summary) for p in SECRET_PATTERNS):
+            _report_error(
+                errors, f"$.package.records[{i}].summary",
+                "secret_indicator",
+                "Secret indicator detected in summary field. No secret values will be displayed.",
+            )
+        source_path = record.get("source_path", "")
+        if isinstance(source_path, str) and any(p.search(source_path) for p in SECRET_PATTERNS):
+            _report_error(
+                errors, f"$.package.records[{i}].source_path",
+                "secret_indicator",
+                "Secret indicator detected in source_path. BLOCKED.",
+            )
+
+
+def check_forbidden_trading_state(
+    package: dict[str, Any], errors: list[dict[str, Any]]
+) -> None:
+    records = package.get("package", {}).get("records", [])
+    for i, record in enumerate(records):
+        summary = record.get("summary", "")
+        if isinstance(summary, str):
+            for pattern in FORBIDDEN_RECORD_SUBSTRINGS:
+                if pattern.search(summary):
+                    _report_error(
+                        errors, f"$.package.records[{i}].summary",
+                        "forbidden_trading_state",
+                        f"Orders/Fills/Positions/Live-Risk-State content detected. BLOCKED: matched '{pattern.pattern}'",
+                    )
+
+
+def check_live_echtgeld_claims(
+    package: dict[str, Any], errors: list[dict[str, Any]]
+) -> None:
+    records = package.get("package", {}).get("records", [])
+    for i, record in enumerate(records):
+        claim = record.get("live_or_echtgeld_claim")
+        if claim is not None:
+            lr_ref = claim.get("lr_ssot_ref", "")
+            if not lr_ref or LR_SSOT_PATH not in lr_ref:
+                _report_error(
+                    errors, f"$.package.records[{i}].live_or_echtgeld_claim.lr_ssot_ref",
+                    "live_claim_without_lr_ssot",
+                    f"Live/Echtgeld claim without valid LR-SSOT reference. Expected ref containing '{LR_SSOT_PATH}'.",
+                )
+
+
+def check_canon_read_evidence(
+    package: dict[str, Any], errors: list[dict[str, Any]]
+) -> None:
+    records = package.get("package", {}).get("records", [])
+    for i, record in enumerate(records):
+        record_type = record.get("record_type", "")
+        if record_type == "claim_record":
+            canon_evidence = record.get("canon_read_evidence", [])
+            if not canon_evidence:
+                _report_error(
+                    errors, f"$.package.records[{i}].canon_read_evidence",
+                    "missing_canon_evidence",
+                    "Claim record missing canon_read_evidence. BLOCKED.",
+                )
+
+
+def check_evidence_refs(
+    package: dict[str, Any], errors: list[dict[str, Any]]
+) -> None:
+    records = package.get("package", {}).get("records", [])
+    for i, record in enumerate(records):
+        evidence_refs = record.get("evidence_refs", [])
+        if not evidence_refs:
+            _report_error(
+                errors, f"$.package.records[{i}].evidence_refs",
+                "missing_evidence_refs",
+                "Record has no evidence_refs. BLOCKED.",
+            )
+
+
+def _report_error(
+    errors: list[dict[str, Any]], path: str, code: str, message: str
+) -> None:
+    errors.append({
+        "path": path,
+        "code": code,
+        "message": message,
+    })
+
+
+def build_report(
+    schema_errors: list[dict[str, Any]],
+    stop_rule_errors: list[dict[str, Any]],
+    passed: bool,
+) -> dict[str, Any]:
+    all_errors = schema_errors + stop_rule_errors
+    return {
+        "status": "PASS" if passed else "BLOCKED",
+        "exit_code": 0 if passed else 1,
+        "error_count": len(all_errors),
+        "schema_errors": schema_errors,
+        "stop_rule_errors": stop_rule_errors,
+        "errors": all_errors,
+    }
+
+
+def validate_package(
+    package: dict[str, Any],
+) -> dict[str, Any]:
+    schema = load_schema()
+    schema_errors = validate_against_schema(package, schema)
+
+    stop_rule_errors: list[dict[str, Any]] = []
+    if not schema_errors:
+        check_secret_indicators(package, stop_rule_errors)
+        check_forbidden_trading_state(package, stop_rule_errors)
+        check_live_echtgeld_claims(package, stop_rule_errors)
+        check_canon_read_evidence(package, stop_rule_errors)
+        check_evidence_refs(package, stop_rule_errors)
+
+    passed = len(schema_errors) == 0 and len(stop_rule_errors) == 0
+    return build_report(schema_errors, stop_rule_errors, passed)
+
+
+def format_agent_report(report: dict[str, Any]) -> str:
+    lines: list[str] = []
+    if report["status"] == "PASS":
+        lines.append(f"[PASS] Context package validation passed. 0 errors.")
+    else:
+        lines.append(f"[BLOCKED] Context package validation FAILED — {report['error_count']} error(s).")
+        lines.append("")
+        lines.append("=== Schema Errors ===")
+        for err in report["schema_errors"]:
+            lines.append(f"  [{err['code']}] {err['path']}: {err['message']}")
+        lines.append("")
+        lines.append("=== Stop Rule Errors ===")
+        for err in report["stop_rule_errors"]:
+            lines.append(f"  [{err['code']}] {err['path']}: {err['message']}")
+        lines.append("")
+        lines.append("=== No secret values included in this report ===")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail-closed validator for CDB Context Packages (#3288)",
+    )
+    parser.add_argument(
+        "file",
+        nargs="?",
+        type=str,
+        help="Path to context package JSON file. Reads from stdin if omitted and --stdin is set.",
+    )
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read JSON from stdin instead of a file.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output machine-readable JSON report instead of agent-readable text.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress agent-readable output. JSON report still available.",
+    )
+    args = parser.parse_args()
+
+    if args.file:
+        pkg_path = Path(args.file)
+        try:
+            with open(pkg_path, encoding="utf-8") as f:
+                package = json.load(f)
+        except FileNotFoundError:
+            print(f"[FAIL] File not found: {args.file}", file=sys.stderr)
+            return 2
+        except json.JSONDecodeError as e:
+            print(f"[FAIL] Invalid JSON in {args.file}: {e}", file=sys.stderr)
+            return 2
+    elif args.stdin:
+        try:
+            package = json.load(sys.stdin)
+        except json.JSONDecodeError as e:
+            print(f"[FAIL] Invalid JSON from stdin: {e}", file=sys.stderr)
+            return 2
+    else:
+        parser.print_help()
+        return 0
+
+    report = validate_package(package)
+
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    elif not args.quiet:
+        print(format_agent_report(report))
+
+    return report["exit_code"]
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #3288
Refs #3286

## Delivered

- **Schema:** \	ools/context/schemas/context_package.schema.json\ — maschinenlesbares JSON Schema fuer Context Packages mit 12 Pflichtfeldern, 8 allowlisteten Record-Types und Safety Boundaries im Meta-Objekt.
- **Validator:** \	ools/context/validate_context_package.py\ — fail-closed CLI Validator mit Schema-Validierung + Stop Rules (Secrets, Trading-State, Live/Echtgeld-Claims, Canon-Evidence, Evidence-Refs).
- **Tests:** \	ests/unit/tools/context/test_validate_context_package.py\ — 22 Unit-Tests (PASS/BLOCKED/Fixtures, Secret-Wert-Redaktion, deterministischer Report).
- **Docs:** \docs/runbooks/CDB_CONTEXT_REFRESH.md\ — Runbook-Kapitel für Schema/Validator, Safety-Grenzen und Workflow-Uebersicht.

## Brain Evidence

\\\	ext
brain_source: repo-only
brain_status: not-used
tools_or_queries:
  - git fetch origin main
  - gh issue view 3288, 3286
  - gh pr list
  - rg (dedupe check)
  - pytest (validation)
  - ruff check (lint)
records_or_results:
  - Keine DB/MCP Records — repo-only session
repo_crosscheck:
  - agents/AGENTS.md (Read Order, Brain Evidence Gate)
  - docs/runbooks/CONTROL_REGISTER.md (Board stage trade-capable, LR NO-GO)
  - docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md (LR bleibt NO-GO)
  - CURRENT_STATUS.md (Repo Ledger)
impact_on_plan:
  - Kein Brain-Apply — Schema/Validator sind read-only Artefakte
limitations:
  - Keine SurrealDB/MCP-Evidence verfuegbar — repo-only session
  - Context Brain Preflight: kein MCP-Tool mit DB-Evidence verfuegbar
  - Repo-Fallback-Grund: kein SurrealDB/MCP-Context-Tool im aktiven MCP-Surface
\\\

## Bootloader Evidence

- Read Order aus \gents/AGENTS.md\ vollstaendig abgearbeitet.
- \CDB_CONSTITUTION.md\, \CDB_GOVERNANCE.md\, \CDB_AGENT_POLICY.md\ (Auszuege) gelesen.
- Control Register: Stage \	rade-capable\, LR \NO-GO\.
- Git Truth: HEAD auf \origin/main\ (8131849f), working tree clean (nur unsere neuen Dateien + bekannte untracked areas).
- Issue #3288: OPEN, kein merged PR gefunden — gueltige Startbasis.
- Keine Context-/DB-/MCP-Evidence verfuegbar — repo-only.

## Validation

- \pytest tests/unit/tools/context/test_validate_context_package.py\: 22/22 PASS
- \uff check tools/context/validate_context_package.py tests/unit/tools/context/test_validate_context_package.py\: All checks passed
- \git diff --check\: keine Whitespace-Fehler
- \python tools/context/validate_context_package.py --help\: CLI funktioniert
- E2E-Smoke: Valid Package -> PASS (Exit 0)

## Safety Boundaries

- LR-Status: \NO-GO\ (hart codiert im Schema und Validator)
- Board-Stage \	rade-capable\ ist nicht Live-Go
- \eal_money_go: false\
- \productive_db_writes_allowed: false\
- \secrets_in_outputs_allowed: false\
- \	rading_state_ingestion_allowed: false\
- Secret-Indikatoren werden blockiert, ohne Secret-Werte auszugeben
- Orders/Fills/Positions/Live-Risk-State werden auf Summary-Ebene blockiert
- Live/Echtgeld-Claims nur mit explizitem LR-SSOT-Ref erlaubt

## Non-goals

- Kein Brain Apply (#3289)
- Kein GitHub Actions Workflow (#3287)
- Kein Agent Briefing (#3290)
- Kein Drift Report (#3291)
- Kein Onboarding Scenario (#3292)
- Keine produktiven DB/MCP/Runtime-Writes
- Keine Live-/Echtgeld-Autorisierung

## Restunsicherheiten

- Der Validator verwendet einen eigenen einfachen JSON-Schema-Interpreter (keine externe Lib wie \jsonschema\). Das ist bewusst gewaehlt fuer minimale Dependencies und fail-closed Kontrolle, deckt aber nicht 100% der JSON-Schema-Draft-07-Edge-Cases ab. Ausreichend fuer unsere strukturierten Context-Packages.
- \vidence_refs\ muss mindestens einen Eintrag haben — das koennte fuer leere Packages zu restriktiv sein. Aktuell passend fuer den fail-closed Anspruch.
- \live_or_echtgeld_claim\ wird nur per String-Contains auf den LR-SSOT-Pfad geprueft. Bei SSOT-Refaktor braucht der Validator ein Update.
