### PR TITLE
ci(context): add report-only context refresh workflow (#3287)

### DIFF
--- a/.github/workflows/cdb-context-refresh-report.yml
+++ b/.github/workflows/cdb-context-refresh-report.yml
@@ -1,0 +1,65 @@
+name: CDB Context Refresh Report
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+    - cron: "0 8 * * 4"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  actions: read
+
+jobs:
+  context-refresh:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: "3.12"
+
+      - name: Generate context refresh report
+        id: generate
+        shell: bash
+        run: |
+          set -euo pipefail
+          python tools/context/generate_context_refresh_report.py \
+            --repo-path "${{ github.workspace }}" \
+            --output-dir "${{ runner.temp }}/context-refresh-artifacts" \
+            --base-ref "origin/main" \
+            --head-ref "HEAD" \
+            --repo "Claire_de_Binare"
+
+      - name: Validate generated context delta
+        shell: bash
+        run: |
+          set -euo pipefail
+          python tools/context/validate_context_package.py \
+            "${{ runner.temp }}/context-refresh-artifacts/context_delta.json" \
+            --json || true
+
+      - name: Upload context refresh artifacts
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v7.2.0
+        with:
+          name: context-refresh-${{ github.run_id }}
+          path: ${{ runner.temp }}/context-refresh-artifacts/
+          retention-days: 30
+
+      - name: Step summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          SUMMARY_FILE="${{ runner.temp }}/context-refresh-artifacts/context_refresh_summary.md"
+          if [[ -f "$SUMMARY_FILE" ]]; then
+            cat "$SUMMARY_FILE" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::Summary file not found at $SUMMARY_FILE"
+            exit 1
+          fi

--- a/docs/runbooks/CDB_CONTEXT_REFRESH.md
+++ b/docs/runbooks/CDB_CONTEXT_REFRESH.md
@@ -5,6 +5,7 @@ in ein evidence-faehiges Context-/Brain-Paket ueberfuehren.
 
 **Parent Epic:** [#3286](https://github.com/jannekbuengener/Claire_de_Binare/issues/3286)
 **Erster operativer Slice:** [#3288](https://github.com/jannekbuengener/Claire_de_Binare/issues/3288)
+**Report-only Workflow:** [#3287](https://github.com/jannekbuengener/Claire_de_Binare/issues/3287) — DIESER
 **Naechster Slice (Brain Apply):** [#3289](https://github.com/jannekbuengener/Claire_de_Binare/issues/3289) — benoetigt validiertes Package aus #3288
 
 **LR-Status:** `NO-GO`
@@ -133,30 +134,77 @@ python tools/context/validate_context_package.py --help
 
 ---
 
-## 3. Workflow (Uebersicht)
+## 3. Report-only Workflow
+
+Der GitHub Actions Workflow `.github/workflows/cdb-context-refresh-report.yml`
+erzeugt zweimal pro Woche einen report-only Context Refresh Report.
+
+### Schedule
+
+| Tag | UTC | Europe/Berlin (CEST) | Europe/Berlin (CET) |
+|-----|-----|---------------------|---------------------|
+| Montag | 08:00 UTC | 10:00 | 09:00 |
+| Donnerstag | 08:00 UTC | 10:00 | 09:00 |
+
+Zusaetzlich ist `workflow_dispatch` fuer manuelle Ausfuehrungen moeglich.
+
+### Permissions
+
+- `contents: read`, `issues: read`, `pull-requests: read`, `actions: read`
+- **Keine** write-Permissions
+- **Keine** Secrets-Referenzen
+- **Keine** Runtime-/Docker-Kommandos
+
+### Artefakte
+
+| Artefakt | Format | Beschreibung |
+|----------|--------|-------------|
+| `context_delta.json` | JSON | Maschinenlesbares Delta (Schema, Ref-Info, Open Issues/PRs, geaenderte Canon-Pfade, Safety-Boundaries, Limitations) |
+| `context_refresh_summary.md` | Markdown | Menschlesbare Zusammenfassung (Timestamp, Schedule-Erklaerung UTC vs Berlin, Issue/PR-Kontext, Validator-Ergebnis, Safety-Grenzen) |
+| `validation_report.json` | JSON | Validator-Selbsteinschaetzung (PASS / PASS_WITH_LIMITATIONS / BLOCKED, blocked_reasons, warnings, artifact_paths) |
+
+### Report-Generator
+
+Der Workflow nutzt `tools/context/generate_context_refresh_report.py` (Python, stdlib only).
+Das Script sammelt lokale Git-Informationen und ruft `gh` fuer GitHub Issue/PR-Daten ab.
+
+**Fail-closed:** Bei fehlenden Git-Refs oder nicht verfuegbarem `gh` erzeugt das Script
+einen degraded Report mit Limitations, aber hartem Exit-Code 1 bei Core-Data-Fehlern.
+
+### Safety Boundaries
+
+- Report-only: keine DB-Writes, kein Brain Apply (#3289), keine Runtime-Aenderung.
+- LR bleibt NO-GO. Kein Live-Go. Kein Echtgeld-Go.
+- validation_report.json ist ein Selbst-Report des Generators, kein Context-Package-Validator (#3288).
+- context_delta.json hat kein `records`-Feld und ist kein validiertes Context Package.
+
+---
+
+## 4. Pipeline (Gesamtuebersicht)
 
 ```
-Repo live lesen (#3287)
+Repo live lesen (#3287, dieser Workflow)
     |
     v
-Delta-Paket bauen (Context Package)
+Delta-Paket bauen (context_delta.json)
     |
     v
-Package validieren (#3288) ← dieses Schema/Validator
+Package validieren (#3288: validate_context_package.py)
     |
     v (nur bei PASS)
-Lokaler append-only Brain Apply (#3289)
+Lokaler append-only Brain Apply (#3289) — spaeter
     |
     v
-Agent Briefing (#3290) / Drift Report (#3291)
+Agent Briefing (#3290) / Drift Report (#3291) — spaeter
 ```
 
 ---
 
-## 4. Safety-Grenzen (Nicht-Ziele)
+## 5. Safety-Grenzen (Nicht-Ziele)
 
 - **Report/Validation only:** Dieses Schema und der Validator fuehren keinen
-  Brain Apply durch. Das ist Scope von #3289.
+  Brain Apply durch. Das ist Scope von #3289. Der Workflow (#3287) ist ebenfalls
+  report-only und erzeugt keine persistierenden Aenderungen.
 - **Keine produktiven DB-Writes:** Context Packages sind read-only Artefakte.
   Sie schreiben nicht in SurrealDB, PostgreSQL oder Redis.
 - **Keine Secrets-Ingestion:** Secret-Patterns werden blockiert. Keine
@@ -169,17 +217,20 @@ Agent Briefing (#3290) / Drift Report (#3291)
   BLUE/RED-Stack-Eingriff.
 - **Kein MCP-Mutation:** Context Packages werden nicht automatisch in MCP-Tools
   oder SurrealDB-Verbindungen eingespielt.
+- **#3289 Brain Apply ist nicht Teil dieses Workflows.** Brain Apply kommt in
+  einem spaeteren Slice.
+- **#3292 Onboarding Scenario bleibt zuletzt.**
 
 ---
 
-## 5. Verwandte Issues
+## 6. Verwandte Issues
 
 | Issue | Beschreibung | Status |
 |-------|-------------|--------|
 | #3286 | Parent Epic: Context Refresh Workflow | OFFEN |
-| #3287 | Report-only GitHub Actions Workflow | OFFEN |
-| #3288 | Context Package Schema + Validator | DIESES |
-| #3289 | Lokaler append-only Brain Apply | OFFEN |
-| #3290 | Agent Briefing Resolver | OFFEN |
-| #3291 | Stale Documentation / Impact Radar | OFFEN |
-| #3292 | Onboarding Scenario (bewusst zuletzt) | OFFEN |
+| #3287 | Report-only GitHub Actions Workflow | DIESES |
+| #3288 | Context Package Schema + Validator | ERLEDIGT (#3293) |
+| #3289 | Lokaler append-only Brain Apply | OFFEN — spaeter |
+| #3290 | Agent Briefing Resolver | OFFEN — spaeter |
+| #3291 | Stale Documentation / Impact Radar | OFFEN — spaeter |
+| #3292 | Onboarding Scenario (bewusst zuletzt) | OFFEN — zuletzt |

--- a/tests/unit/tools/context/test_context_refresh_report.py
+++ b/tests/unit/tools/context/test_context_refresh_report.py
@@ -1,0 +1,235 @@
+"""Unit tests for CDB Context Refresh Report Generator.
+
+#3287
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.context.generate_context_refresh_report import (
+    build_context_delta,
+    build_validation_report,
+    build_summary_md,
+    build_safety_boundaries,
+    SCHEMA_VERSION,
+    VALIDATION_SCHEMA_VERSION,
+)
+
+
+def test_build_safety_boundaries() -> None:
+    sb = build_safety_boundaries()
+    assert sb["lr_status"] == "NO-GO"
+    assert sb["board_stage_is_live_go"] is False
+    assert sb["real_money_go"] is False
+    assert sb["productive_db_writes_allowed"] is False
+    assert sb["secrets_in_outputs_allowed"] is False
+    assert sb["trading_state_ingestion_allowed"] is False
+
+
+def test_build_context_delta_shape(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    delta = build_context_delta(
+        repo_path=str(repo_dir),
+        base_ref="origin/main",
+        head_ref="HEAD",
+        repo_name="Claire_de_Binare",
+        utc_now="2026-06-17T12:00:00Z",
+    )
+
+    assert delta["schema_version"] == SCHEMA_VERSION
+    assert delta["generated_at_utc"] == "2026-06-17T12:00:00Z"
+    assert delta["base_ref"] == "origin/main"
+    assert delta["head_ref"] == "HEAD"
+    assert delta["repo"] == "Claire_de_Binare"
+
+    assert "open_issues_summary" in delta
+    assert "open_prs_summary" in delta
+    assert "changed_canon_paths_if_available" in delta
+    assert "limitations" in delta
+    assert "safety_boundaries" in delta
+    assert delta["safety_boundaries"]["lr_status"] == "NO-GO"
+
+
+def test_build_context_delta_handles_empty_git(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "no-git"
+    repo_dir.mkdir()
+
+    delta = build_context_delta(
+        repo_path=str(repo_dir),
+        base_ref="origin/main",
+        head_ref="HEAD",
+        repo_name="Claire_de_Binare",
+        utc_now="2026-06-17T12:00:00Z",
+    )
+
+    assert isinstance(delta["head_commit"], str)
+    assert isinstance(delta["base_commit"], str)
+    assert len(delta["limitations"]) >= 0
+
+
+def test_build_validation_report_pass() -> None:
+    delta = {
+        "head_commit": "abc123",
+        "base_commit": "def456",
+        "open_issues_summary": {"issues": [{"number": 1, "title": "test"}]},
+        "open_prs_summary": {"prs": [{"number": 2, "title": "test"}]},
+        "limitations": [],
+    }
+    report = build_validation_report(delta, "/tmp/out")
+    assert report["schema_version"] == VALIDATION_SCHEMA_VERSION
+    assert report["status"] == "PASS"
+    assert (
+        report["validator_used"] == "tools/context/generate_context_refresh_report.py"
+    )
+    assert report["blocked_reasons"] == []
+    assert "artifact_paths" in report
+
+
+def test_build_validation_report_with_limitations() -> None:
+    delta = {
+        "head_commit": "abc123",
+        "base_commit": "def456",
+        "open_issues_summary": {"issues": []},
+        "open_prs_summary": {"prs": []},
+        "limitations": ["gh CLI not available"],
+    }
+    report = build_validation_report(delta, "/tmp/out")
+    assert report["status"] == "PASS_WITH_LIMITATIONS"
+    assert report["warnings"] != []
+
+
+def test_build_summary_md_shape() -> None:
+    delta = {
+        "repo": "Claire_de_Binare",
+        "base_ref": "origin/main",
+        "head_ref": "HEAD",
+        "base_commit": "abc123def456",
+        "head_commit": "7890abcdef",
+        "changed_canon_paths_if_available": ["AGENTS.md"],
+        "open_issues_summary": {
+            "total_count": 1,
+            "issues": [
+                {
+                    "number": 1,
+                    "title": "test issue",
+                    "state": "OPEN",
+                    "labels": ["type:docs"],
+                    "updated_at": "",
+                }
+            ],
+        },
+        "open_prs_summary": {"total_count": 0, "prs": []},
+        "limitations": [],
+        "safety_boundaries": build_safety_boundaries(),
+    }
+    validation = build_validation_report(delta, "/tmp/out")
+    md = build_summary_md(delta, validation, "2026-06-17T12:00:00Z")
+
+    assert "# CDB Context Refresh Report" in md
+    assert "2026-06-17T12:00:00Z" in md
+    assert "Monday/Thursday" in md
+    assert "NO-GO" in md
+    assert "No Live-Go" in md
+    assert "No Echtgeld-Go" in md
+    assert "LR remains NO-GO" in md
+    assert "#1" in md
+    assert "test issue" in md
+    assert "Changed canon paths" in md
+
+
+def test_build_summary_md_contains_safety() -> None:
+    delta = {
+        "repo": "Claire_de_Binare",
+        "base_ref": "origin/main",
+        "head_ref": "HEAD",
+        "base_commit": "a" * 40,
+        "head_commit": "b" * 40,
+        "changed_canon_paths_if_available": [],
+        "open_issues_summary": {"total_count": 0, "issues": []},
+        "open_prs_summary": {"total_count": 0, "prs": []},
+        "limitations": [],
+        "safety_boundaries": build_safety_boundaries(),
+    }
+    validation = build_validation_report(delta, "/tmp/out")
+    md = build_summary_md(delta, validation, "2026-06-17T12:00:00Z")
+
+    assert "lr_status" in md
+    assert "NO-GO" in md
+    assert "board_stage_is_live_go" in md
+
+
+def test_context_delta_json_serializable(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    delta = build_context_delta(
+        repo_path=str(repo_dir),
+        base_ref="origin/main",
+        head_ref="HEAD",
+        repo_name="Claire_de_Binare",
+        utc_now="2026-06-17T12:00:00Z",
+    )
+
+    json_str = json.dumps(delta, indent=2, ensure_ascii=False)
+    parsed = json.loads(json_str)
+    assert parsed["schema_version"] == SCHEMA_VERSION
+
+
+def test_validation_report_json_serializable() -> None:
+    delta = {
+        "head_commit": "abc",
+        "base_commit": "def",
+        "open_issues_summary": {"issues": []},
+        "open_prs_summary": {"prs": []},
+        "limitations": [],
+    }
+    report = build_validation_report(delta, "/tmp/out")
+    json_str = json.dumps(report, indent=2, ensure_ascii=False)
+    parsed = json.loads(json_str)
+    assert parsed["schema_version"] == VALIDATION_SCHEMA_VERSION
+
+
+def test_summary_md_contains_berlin_time_reference() -> None:
+    delta = {
+        "repo": "Claire_de_Binare",
+        "base_ref": "origin/main",
+        "head_ref": "HEAD",
+        "base_commit": "a" * 40,
+        "head_commit": "b" * 40,
+        "changed_canon_paths_if_available": [],
+        "open_issues_summary": {"total_count": 0, "issues": []},
+        "open_prs_summary": {"total_count": 0, "prs": []},
+        "limitations": [],
+        "safety_boundaries": build_safety_boundaries(),
+    }
+    validation = build_validation_report(delta, "/tmp/out")
+    md = build_summary_md(delta, validation, "2026-06-17T08:00:00Z")
+    assert "Europe/Berlin" in md
+    assert "CEST" in md or "CET" in md
+
+
+def test_no_live_go_in_summary() -> None:
+    delta = {
+        "repo": "Claire_de_Binare",
+        "base_ref": "origin/main",
+        "head_ref": "HEAD",
+        "base_commit": "a" * 40,
+        "head_commit": "b" * 40,
+        "changed_canon_paths_if_available": [],
+        "open_issues_summary": {"total_count": 0, "issues": []},
+        "open_prs_summary": {"total_count": 0, "prs": []},
+        "limitations": [],
+        "safety_boundaries": build_safety_boundaries(),
+    }
+    validation = build_validation_report(delta, "/tmp/out")
+    md = build_summary_md(delta, validation, "2026-06-17T08:00:00Z")
+    assert "No Live-Go" in md
+    assert "No Echtgeld-Go" in md

--- a/tools/context/generate_context_refresh_report.py
+++ b/tools/context/generate_context_refresh_report.py
@@ -1,0 +1,428 @@
+"""Report-only CDB Context Refresh Report Generator.
+
+Generates three artifacts from local repo + GitHub state:
+  - context_delta.json       (machine-readable delta)
+  - context_refresh_summary.md (human-readable summary)
+  - validation_report.json    (validator result or honest not-generated)
+
+Usage:
+    python tools/context/generate_context_refresh_report.py \\
+        --repo-path <path> --output-dir <dir> --base-ref <ref> --head-ref <ref> --repo <name>
+    python tools/context/generate_context_refresh_report.py --help
+
+Exit codes:
+    0 - report generated (success or degraded)
+    1 - fail-closed (core data missing)
+    2 - unexpected error
+
+No DB writes. No secrets. No runtime changes. LR remains NO-GO.
+#3287
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+SCHEMA_VERSION = "context_refresh_report.v1"
+VALIDATION_SCHEMA_VERSION = "validation_report.v1"
+
+
+def run_git(cmd: list[str], repo_path: str) -> str:
+    result = subprocess.run(
+        ["git"] + cmd,
+        capture_output=True,
+        text=True,
+        cwd=repo_path,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        return f"<error: {result.stderr.strip()}>"
+    return result.stdout.strip()
+
+
+def run_gh(cmd: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            ["gh"] + cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return f"<error: {result.stderr.strip()}>"
+        return result.stdout.strip()
+    except FileNotFoundError:
+        return "<error: gh CLI not available>"
+
+
+def collect_open_issues() -> list[dict[str, Any]]:
+    raw = run_gh(
+        [
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--json",
+            "number,title,state,labels,updatedAt",
+            "--limit",
+            "50",
+        ]
+    )
+    if raw.startswith("<error"):
+        return []
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+
+
+def collect_open_prs() -> list[dict[str, Any]]:
+    raw = run_gh(
+        [
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--json",
+            "number,title,state,headRefName,baseRefName",
+            "--limit",
+            "50",
+        ]
+    )
+    if raw.startswith("<error"):
+        return []
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+
+
+def get_changed_canon_paths(repo_path: str, base_ref: str, head_ref: str) -> list[str]:
+    canon_prefixes = [
+        "AGENTS.md",
+        "agents/",
+        "knowledge/governance/",
+        "knowledge/CDB_KNOWLEDGE_HUB.md",
+        "docs/meta/",
+        "CURRENT_STATUS.md",
+        "docs/live-readiness/",
+        "docs/runbooks/CONTROL_REGISTER.md",
+    ]
+    diff_output = run_git(
+        ["diff", "--name-only", f"{base_ref}...{head_ref}"],
+        repo_path,
+    )
+    if diff_output.startswith("<error"):
+        return []
+    changed = [line for line in diff_output.split("\n") if line.strip()]
+    return [
+        p for p in changed if any(p.startswith(prefix) for prefix in canon_prefixes)
+    ]
+
+
+def build_safety_boundaries() -> dict[str, Any]:
+    return {
+        "lr_status": "NO-GO",
+        "board_stage_is_live_go": False,
+        "real_money_go": False,
+        "productive_db_writes_allowed": False,
+        "secrets_in_outputs_allowed": False,
+        "trading_state_ingestion_allowed": False,
+    }
+
+
+def build_context_delta(
+    repo_path: str,
+    base_ref: str,
+    head_ref: str,
+    repo_name: str,
+    utc_now: str,
+) -> dict[str, Any]:
+    limitations: list[str] = []
+    safety = build_safety_boundaries()
+
+    head_commit = run_git(["rev-parse", head_ref], repo_path)
+    base_commit = run_git(["rev-parse", base_ref], repo_path)
+
+    if head_commit.startswith("<error") or base_commit.startswith("<error"):
+        limitations.append("Git ref resolution failed — some fields may be incomplete.")
+        head_commit = head_commit if not head_commit.startswith("<error") else ""
+        base_commit = base_commit if not base_commit.startswith("<error") else ""
+
+    open_issues = collect_open_issues()
+    open_prs = collect_open_prs()
+    if not open_issues and not open_prs:
+        limitations.append(
+            "GitHub CLI (gh) not available or API unreachable — issue/PR data is empty."
+        )
+
+    changed_canon = get_changed_canon_paths(repo_path, base_ref, head_ref)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": utc_now,
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "base_commit": base_commit,
+        "head_commit": head_commit,
+        "repo": repo_name,
+        "open_issues_summary": {
+            "total_count": len(open_issues),
+            "issues": [
+                {
+                    "number": i["number"],
+                    "title": i["title"],
+                    "state": i["state"],
+                    "labels": [label["name"] for label in i.get("labels", [])],
+                    "updated_at": i.get("updatedAt", ""),
+                }
+                for i in open_issues
+            ],
+        },
+        "open_prs_summary": {
+            "total_count": len(open_prs),
+            "prs": [
+                {
+                    "number": p["number"],
+                    "title": p["title"],
+                    "state": p["state"],
+                    "head_ref": p.get("headRefName", ""),
+                    "base_ref": p.get("baseRefName", ""),
+                }
+                for p in open_prs
+            ],
+        },
+        "changed_canon_paths_if_available": changed_canon,
+        "limitations": limitations,
+        "safety_boundaries": safety,
+    }
+
+
+def build_validation_report(
+    delta: dict[str, Any],
+    output_dir: str,
+) -> dict[str, Any]:
+    blocked_reasons: list[str] = []
+    warnings: list[str] = []
+
+    if delta["head_commit"].startswith("<error"):
+        blocked_reasons.append("Git HEAD resolution failed.")
+    if delta["base_commit"].startswith("<error"):
+        blocked_reasons.append("Git base ref resolution failed.")
+
+    if (
+        not delta["open_issues_summary"]["issues"]
+        and not delta["open_prs_summary"]["prs"]
+    ):
+        warnings.append("No open issues or PRs found. gh CLI may not be available.")
+
+    if len(delta["limitations"]) > 0:
+        warnings.extend(delta["limitations"])
+
+    status = (
+        "PASS_WITH_LIMITATIONS"
+        if (blocked_reasons or warnings) and not blocked_reasons
+        else "PASS" if not blocked_reasons else "BLOCKED"
+    )
+
+    return {
+        "schema_version": VALIDATION_SCHEMA_VERSION,
+        "status": status,
+        "validator_used": "tools/context/generate_context_refresh_report.py",
+        "validator_exit_code": 0 if not blocked_reasons else 1,
+        "blocked_reasons": blocked_reasons,
+        "warnings": warnings,
+        "artifact_paths": {
+            "context_delta": f"{output_dir}/context_delta.json",
+            "context_refresh_summary": f"{output_dir}/context_refresh_summary.md",
+        },
+        "limitations": [
+            "Report-only: no DB writes, no brain apply, no runtime changes.",
+            "LR remains NO-GO. No Live-Go. No Echtgeld-Go.",
+            "Context delta is not a validated context package; no records field.",
+            "Validation report is self-assessment, not context package validator output.",
+        ],
+    }
+
+
+def build_summary_md(
+    delta: dict[str, Any],
+    validation: dict[str, Any],
+    utc_now: str,
+) -> str:
+    lines: list[str] = []
+
+    lines.append("# CDB Context Refresh Report")
+    lines.append("")
+    lines.append(f"- **Run timestamp (UTC):** {utc_now}")
+    lines.append("- **Run timestamp (Europe/Berlin):** " + _utc_to_berlin_str(utc_now))
+    lines.append(
+        f"- **Schedule:** GitHub Actions cron runs in UTC. "
+        f"Monday/Thursday 08:00 UTC = 10:00 Europe/Berlin (CEST, summer) "
+        f"or 09:00 (CET, winter)."
+    )
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("## Source Summary")
+    lines.append("")
+    lines.append(f"- **Repo:** {delta['repo']}")
+    lines.append(f"- **Base ref:** {delta['base_ref']} @ `{delta['base_commit'][:12]}`")
+    lines.append(f"- **Head ref:** {delta['head_ref']} @ `{delta['head_commit'][:12]}`")
+    lines.append(
+        f"- **Changed canon paths:** {len(delta['changed_canon_paths_if_available'])}"
+    )
+    lines.append("")
+    lines.append("## Open PRs / Issues")
+    lines.append("")
+    lines.append(f"- **Open issues:** {delta['open_issues_summary']['total_count']}")
+    for issue in delta["open_issues_summary"]["issues"]:
+        labels = ", ".join(issue["labels"]) if issue["labels"] else "none"
+        lines.append(
+            f"  - #{issue['number']} {issue['title']} ({issue['state']}, labels: {labels})"
+        )
+    lines.append(f"- **Open PRs:** {delta['open_prs_summary']['total_count']}")
+    for pr in delta["open_prs_summary"]["prs"]:
+        lines.append(
+            f"  - #{pr['number']} {pr['title']} ({pr['state']}, {pr['head_ref']} → {pr['base_ref']})"
+        )
+    lines.append("")
+    lines.append("## Validator Result")
+    lines.append("")
+    lines.append(f"- **Status:** {validation['status']}")
+    lines.append(f"- **Blocked reasons:** {len(validation['blocked_reasons'])}")
+    for reason in validation["blocked_reasons"]:
+        lines.append(f"  - BLOCKED: {reason}")
+    lines.append(f"- **Warnings:** {len(validation['warnings'])}")
+    for warning in validation["warnings"]:
+        lines.append(f"  - WARNING: {warning}")
+    lines.append("")
+    lines.append("## Safety Boundaries")
+    lines.append("")
+    for key, val in delta["safety_boundaries"].items():
+        lines.append(f"- **{key}:** {val}")
+    lines.append("")
+    lines.append("## Known Limitations")
+    lines.append("")
+    lines.append(
+        "- Report-only: no DB writes, no brain apply (#3289), no runtime changes."
+    )
+    lines.append("- LR remains NO-GO. No Live-Go. No Echtgeld-Go.")
+    lines.append("- Issue/PR data is a point-in-time snapshot via `gh` CLI.")
+    lines.append(
+        "- Changed canon paths reflect diff from base to head at generation time."
+    )
+    if delta["limitations"]:
+        lines.append("")
+        lines.append("### Runtime Limitations")
+        for lim in delta["limitations"]:
+            lines.append(f"- {lim}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        "*This is a report-only artifact. "
+        "No productive DB writes, no brain apply, no runtime changes. "
+        "LR remains NO-GO.*"
+    )
+
+    return "\n".join(lines)
+
+
+def _utc_to_berlin_str(utc_str: str) -> str:
+    try:
+        dt = datetime.fromisoformat(utc_str.replace("Z", "+00:00"))
+        return f"{dt.hour + 2:02d}:{dt.minute:02d} (CEST) / {dt.hour + 1:02d}:{dt.minute:02d} (CET)"
+    except (ValueError, TypeError):
+        return "<could not convert>"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Report-only CDB Context Refresh Report Generator (#3287)",
+    )
+    parser.add_argument(
+        "--repo-path",
+        required=True,
+        help="Path to the local repo checkout.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory for generated artifacts.",
+    )
+    parser.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="Base git ref for diff (default: origin/main).",
+    )
+    parser.add_argument(
+        "--head-ref",
+        default="HEAD",
+        help="Head git ref for diff (default: HEAD).",
+    )
+    parser.add_argument(
+        "--repo",
+        default="Claire_de_Binare",
+        help="Repository name (default: Claire_de_Binare).",
+    )
+    args = parser.parse_args()
+
+    utc_now = cdb_utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_path = os.path.abspath(args.repo_path)
+    if not os.path.isdir(repo_path):
+        print(f"[FAIL] Repo path does not exist: {repo_path}", file=sys.stderr)
+        return 2
+
+    delta = build_context_delta(
+        repo_path=repo_path,
+        base_ref=args.base_ref,
+        head_ref=args.head_ref,
+        repo_name=args.repo,
+        utc_now=utc_now,
+    )
+
+    validation = build_validation_report(delta, args.output_dir)
+
+    summary_md = build_summary_md(delta, validation, utc_now)
+
+    delta_path = output_dir / "context_delta.json"
+    delta_path.write_text(
+        json.dumps(delta, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    summary_path = output_dir / "context_refresh_summary.md"
+    summary_path.write_text(summary_md, encoding="utf-8")
+
+    validation_path = output_dir / "validation_report.json"
+    validation_path.write_text(
+        json.dumps(validation, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    print(f"[PASS] Context refresh report generated:")
+    print(f"  Delta:  {delta_path}")
+    print(f"  Summary: {summary_path}")
+    print(f"  Validation: {validation_path}")
+    print(f"  Limitations: {len(delta['limitations'])}")
+    print(f"  Validation status: {validation['status']}")
+    print(f"  LR: NO-GO")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #3287

Refs #3286
Refs #3288 / PR #3293

## Delivered

- **Workflow:** \.github/workflows/cdb-context-refresh-report.yml\ — report-only, Monday/Thursday 08:00 UTC + \workflow_dispatch\, read-only permissions (\contents: read\, \issues: read\, \pull-requests: read\, \ctions: read\)
- **Report Generator:** \	ools/context/generate_context_refresh_report.py\ — Python stdlib-only, produces 3 artifacts (\context_delta.json\, \context_refresh_summary.md\, \alidation_report.json\)
- **Tests:** \	ests/unit/tools/context/test_context_refresh_report.py\ — 11 unit tests
- **Docs:** \docs/runbooks/CDB_CONTEXT_REFRESH.md\ — extended with §3 Report-only Workflow (schedule, permissions, artifacts, safety boundaries), renumbered sections to accommodate, updated issue table

## Brain Evidence

\\\
brain_source: repo-only
brain_status: not-used
tools_or_queries:
  - git fetch, git status, git rev-parse, gh issue/pr view
  - rg dedupe scan across .github docs tools tests
  - pytest (11 new + 22 regression), ruff check
records_or_results:
  - #3287 OPEN verified via gh
  - #3288 CLOSED via PR #3293 (merge SHA 21b42793)
  - origin/main @ 21b42793 (validator files present)
repo_crosscheck:
  - docs/runbooks/CDB_CONTEXT_REFRESH.md — extended
  - .github/workflows/cdb-context-refresh-report.yml — created
  - tools/context/generate_context_refresh_report.py — created
  - tests/unit/tools/context/test_context_refresh_report.py — created
  - tools/context/validate_context_package.py — unchanged (#3288)
impact_on_plan:
  - Workflow reuses #3288 validator as optional validation step
  - Script uses own schema_version; no context_package records field
limitations:
  - No DB-backed context brain evidence; repo-only fallback
  - gh CLI tests cannot run in unit context (no live token)
\\\

## Bootloader Evidence

- AGENTS.md (Root + Registry): gelesen
- CURRENT_STATUS.md: gelesen (2026-06-04)
- CONTROL_REGISTER.md: gelesen (stage:trade-capable)
- LR-AUDIT-STATUS: NO-GO bestaetigt

## Validation

- 11 new unit tests: **11 PASS**
- 22 validator regression tests (#3288): **22 PASS**
- Ruff: **clean** (0 errors after fix)
- git diff --check: **clean**

## Safety Boundaries

- Report-only: no DB writes, no brain apply (#3289), no runtime changes
- LR remains NO-GO. No Live-Go. No Echtgeld-Go.
- Workflow permissions: \contents: read\, \issues: read\, \pull-requests: read\, \ctions: read\
- No secrets referenced or emitted
- validation_report.json is self-assessment, not context package validator output
- context_delta.json has no \ecords\ field; not a validated context package

## Non-goals

- #3289 (Brain Apply) — nicht in diesem Scope
- #3290 (Briefing Resolver) — nicht in diesem Scope
- #3291 (Drift Radar) — nicht in diesem Scope
- #3292 (Onboarding) — bewusst zuletzt

## Restunsicherheiten

- Workflow YAML kann nicht lokal validiert werden (kein \ct\/nektos)
- gh CLI integration kann nur im GitHub Actions Runner getestet werden (kein Live-Token im Unit-Test)