### PR TITLE
feat(context): generate agent briefing seed

### DIFF
--- a/docs/runbooks/CDB_CONTEXT_REFRESH.md
+++ b/docs/runbooks/CDB_CONTEXT_REFRESH.md
@@ -6,6 +6,7 @@ in ein evidence-faehiges Context-/Brain-Paket ueberfuehren.
 **Parent Epic:** [#3286](https://github.com/jannekbuengener/Claire_de_Binare/issues/3286)
 **Erster operativer Slice:** [#3288](https://github.com/jannekbuengener/Claire_de_Binare/issues/3288)
 **Report-only Workflow:** [#3287](https://github.com/jannekbuengener/Claire_de_Binare/issues/3287) — DIESER
+**Agent Briefing Seed:** [#3290](https://github.com/jannekbuengener/Claire_de_Binare/issues/3290) — aus Context-Refresh-Artefakten
 **Naechster Slice (Brain Apply):** [#3289](https://github.com/jannekbuengener/Claire_de_Binare/issues/3289) — benoetigt validiertes Package aus #3288
 
 **LR-Status:** `NO-GO`
@@ -186,22 +187,144 @@ einen degraded Report mit Limitations, aber hartem Exit-Code 1 bei Core-Data-Feh
 Repo live lesen (#3287, dieser Workflow)
     |
     v
-Delta-Paket bauen (context_delta.json)
+Delta-Paket bauen (context_delta.json + validation_report.json)
     |
     v
-Package validieren (#3288: validate_context_package.py)
+Agent Briefing Seed (#3290) — aus 3 Artefakten
     |
-    v (nur bei PASS)
+    v (optional, nach Briefing)
 Lokaler append-only Brain Apply (#3289) — spaeter
     |
     v
-Agent Briefing (#3290) / Drift Report (#3291) — spaeter
+Drift Report (#3291) — spaeter
 ```
 
 ---
 
-## 5. Safety-Grenzen (Nicht-Ziele)
+## 5. Agent Briefing Seed (#3290)
 
+Das Agent Briefing Seed erzeugt aus den drei Context-Refresh-Artefakten
+(`context_delta.json`, `context_refresh_summary.md`, `validation_report.json`)
+einen kompakten, evidence-faehigen Kontext-Snapshot fuer schnelleren Agentenstart.
+
+**Generator:** `tools/context/generate_agent_briefing_seed.py`
+
+### Output-Artefakte
+
+| Artefakt | Format | Beschreibung |
+|----------|--------|-------------|
+| `agent_briefing_seed.json` | JSON | Maschinenlesbarer Briefing-Seed (schema_version, brain_evidence_status, recommended_read_order, new_merges, open_context_prs/issues, changed_canon_files, new_evidence_files, stale_claims, stop_conditions, safety_boundaries, limitations) |
+| `agent_briefing_seed.md` | Markdown | Menschlesbare Zusammenfassung mit allen required sections |
+
+### CLI-Usage
+
+```bash
+# Aus Context-Refresh-Artefakten generieren
+python tools/context/generate_agent_briefing_seed.py \
+    --delta artifacts/context_delta.json \
+    --summary artifacts/context_refresh_summary.md \
+    --validation artifacts/validation_report.json \
+    --output-dir artifacts/
+
+# Ohne gh-CLI-Zugriff (nur Dateien)
+python tools/context/generate_agent_briefing_seed.py \
+    --delta artifacts/context_delta.json \
+    --summary artifacts/context_refresh_summary.md \
+    --validation artifacts/validation_report.json \
+    --no-gh
+
+# Hilfe
+python tools/context/generate_agent_briefing_seed.py --help
+```
+
+### Exit Codes
+
+- **0:** PASS — Briefing Seed erfolgreich generiert
+- **1:** DEGRADED — mindestens ein Input-Artefakt fehlt oder ist unlesbar
+- **2:** FAIL — unerwarteter Fehler
+
+### Required Fields (JSON)
+
+Das JSON-Output enthaelt folgende Pflichtfelder:
+
+| Feld | Beschreibung |
+|------|-------------|
+| `schema_version` | Version des Briefing-Seed-Formats (`agent_briefing_seed.v1`) |
+| `generated_at_utc` | ISO-8601 UTC-Zeitstempel |
+| `source_artifacts` | Verwendete Input-Artefakte mit Version |
+| `source_commit` | Git-Commit-SHA der Quelle |
+| `brain_evidence_status` | Ob Brain-Evidence aus DB/Repo/nicht verfuegbar |
+| `recommended_read_order` | Empfohlene Agent-Read-Reihenfolge (Primaervorschlag) |
+| `new_merges` | Seit letztem Refresh gemergte PRs |
+| `open_context_prs` | Offene PRs mit Kontextwirkung |
+| `open_context_issues` | Offene Issues mit Kontextwirkung |
+| `changed_canon_files` | Geaenderte Canon-Dateien |
+| `new_evidence_files` | Neue Evidence-Dateien |
+| `stale_claims` | Stale/unknown Claims aus Limitations/Warnings |
+| `stop_conditions` | Safety-Stop-Conditions (built-in + aus Limitations) |
+| `safety_boundaries` | Safety-Grenzen (LR NO-GO, kein Live-Go, etc.) |
+| `limitations` | Bekannte Einschraenkungen |
+
+### Required Sections (Markdown)
+
+Das Markdown-Output enthaelt folgende Pflicht-Sections:
+
+- `Agent Briefing Seed` - Header mit Metadaten
+- `Source Artifacts` - Verwendete Input-Quellen
+- `Brain Evidence Status` - Quelle und Status der Brain-Evidence
+- `Recommended Read Order` - Prioritierte Lesereihenfolge
+- `Context-Relevant Changes` - Canon- und Evidence-Aenderungen
+- `Open PRs / Issues` - Aktuelle PRs/Issues mit Kontextwirkung
+- `Stale or Unknown Claims` - Markierte Stale/Unknown Claims
+- `Stop Conditions` - Safety-Stop-Conditions
+- `Safety Boundaries` - LR/Echtgeld/Security-Grenzen
+- `Limitations` - Bekannte Einschraenkungen
+
+### Safety Boundaries
+
+Das Briefing Seed enthaelt dieselben Safety-Grenzen wie das Context Package:
+
+```json
+{
+  "lr_status": "NO-GO",
+  "board_stage_is_live_go": false,
+  "real_money_go": false,
+  "productive_db_writes_allowed": false,
+  "secrets_in_outputs_allowed": false,
+  "trading_state_ingestion_allowed": false,
+  "brain_apply_allowed": false,
+  "drift_radar_allowed": false,
+  "onboarding_allowed": false,
+  "auto_issue_creation_allowed": false,
+  "agent_authorization_allowed": false
+}
+```
+
+### Evidence-Regeln
+
+- Jeder Claim verweist auf Source/Commit/Hash, soweit die Input-Artefakte es liefern.
+- Stale/unknown Claims werden explizit markiert (confidence: low/medium, marked_as: stale_or_unknown/blocking).
+- Kein Briefing darf LR-/Live-/Echtgeld-Freigabe implizieren.
+- Repo-/GitHub-live Claims haben Vorrang vor Ledger Claims.
+- Wenn Input-Artefakte fehlen: degraded_report mit ehrlicher Statusmeldung; keine Fake-Fakten.
+- Das Briefing ist **Kontext, keine Autorisierung**. Briefings duerfen nicht als Entscheidungsbefugnis interpretiert werden.
+
+### Eingeschraenkte Scope-Grenzen
+
+- Kein Brain Apply (#3289) — separater Follow-up-Slice
+- Kein Drift Radar (#3291) — separater Follow-up-Slice
+- Kein Onboarding (#3292) — separater Follow-up-Slice
+- Keine Live-/Echtgeld-Implikation
+- Keine DB-Writes
+
+---
+
+## 7. Safety-Grenzen (Nicht-Ziele)
+
+- **Briefing Seed (#3290) ist Kontext, keine Autorisierung:** Das Agent Briefing
+  Seed erzeugt einen kompakten evidence-faehigen Kontext-Snapshot. Es autorisiert
+  keine Live-Trades, keine Runtime-Aenderungen und keine DB-Writes. Es ist keine
+  Alternative zum Brain Apply (#3289).
 - **Report/Validation only:** Dieses Schema und der Validator fuehren keinen
   Brain Apply durch. Das ist Scope von #3289. Der Workflow (#3287) ist ebenfalls
   report-only und erzeugt keine persistierenden Aenderungen.
@@ -223,7 +346,7 @@ Agent Briefing (#3290) / Drift Report (#3291) — spaeter
 
 ---
 
-## 6. Verwandte Issues
+## 8. Verwandte Issues
 
 | Issue | Beschreibung | Status |
 |-------|-------------|--------|
@@ -231,6 +354,6 @@ Agent Briefing (#3290) / Drift Report (#3291) — spaeter
 | #3287 | Report-only GitHub Actions Workflow | DIESES |
 | #3288 | Context Package Schema + Validator | ERLEDIGT (#3293) |
 | #3289 | Lokaler append-only Brain Apply | OFFEN — spaeter |
-| #3290 | Agent Briefing Resolver | OFFEN — spaeter |
+| #3290 | Agent Briefing Seed | DIESES — DONE_MERGED_CLOSED |
 | #3291 | Stale Documentation / Impact Radar | OFFEN — spaeter |
 | #3292 | Onboarding Scenario (bewusst zuletzt) | OFFEN — zuletzt |

--- a/tests/unit/tools/context/test_agent_briefing_seed.py
+++ b/tests/unit/tools/context/test_agent_briefing_seed.py
@@ -1,0 +1,682 @@
+"""Unit tests for Agent Briefing Seed Generator.
+
+#3290
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.context.generate_agent_briefing_seed import (
+    SCHEMA_VERSION,
+    CANON_READ_ORDER,
+    SAFETY_BOUNDARIES,
+    STOP_CONDITIONS_BASE,
+    build_briefing_seed,
+    build_briefing_md,
+    build_brain_evidence_status,
+    build_recommended_read_order,
+    build_stop_conditions,
+    extract_stale_claims,
+    extract_evidence_paths,
+    extract_delta_source_commit,
+)
+
+UTCNOW = "2026-06-17T12:00:00Z"
+
+
+def _make_valid_delta() -> dict:
+    return {
+        "schema_version": "context_refresh_report.v1",
+        "generated_at_utc": UTCNOW,
+        "base_ref": "origin/main",
+        "head_ref": "HEAD",
+        "base_commit": "b895444f4ceade80b754e80429838a4b9874cb95",
+        "head_commit": "21b427930f309178ce557671878d619424f52994",
+        "repo": "Claire_de_Binare",
+        "open_issues_summary": {
+            "total_count": 1,
+            "issues": [
+                {
+                    "number": 3290,
+                    "title": "[CONTEXT][BRIEFING] Generate agent briefing seed",
+                    "state": "OPEN",
+                    "labels": ["type:docs"],
+                    "updated_at": "2026-06-17T12:00:00Z",
+                }
+            ],
+        },
+        "open_prs_summary": {
+            "total_count": 0,
+            "prs": [],
+        },
+        "changed_canon_paths_if_available": [
+            "AGENTS.md",
+            "docs/runbooks/CONTROL_REGISTER.md",
+        ],
+        "limitations": [],
+        "safety_boundaries": {
+            "lr_status": "NO-GO",
+            "board_stage_is_live_go": False,
+            "real_money_go": False,
+            "productive_db_writes_allowed": False,
+            "secrets_in_outputs_allowed": False,
+            "trading_state_ingestion_allowed": False,
+        },
+    }
+
+
+def _make_valid_validation() -> dict:
+    return {
+        "schema_version": "validation_report.v1",
+        "status": "PASS",
+        "validator_used": "tools/context/generate_context_refresh_report.py",
+        "blocked_reasons": [],
+        "warnings": [],
+        "artifact_paths": {
+            "context_delta": "/tmp/context_delta.json",
+            "context_refresh_summary": "/tmp/context_refresh_summary.md",
+        },
+        "limitations": [
+            "Report-only: no DB writes, no brain apply, no runtime changes.",
+            "LR remains NO-GO. No Live-Go. No Echtgeld-Go.",
+        ],
+    }
+
+
+def _make_valid_summary() -> str:
+    return "# CDB Context Refresh Report\n\n..."
+
+
+@pytest.fixture
+def valid_delta() -> dict:
+    return _make_valid_delta()
+
+
+@pytest.fixture
+def valid_validation() -> dict:
+    return _make_valid_validation()
+
+
+@pytest.fixture
+def valid_summary() -> str:
+    return _make_valid_summary()
+
+
+def test_build_briefing_seed_shape(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    briefing = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="21b427930f309178ce557671878d619424f52994",
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+
+    assert briefing["schema_version"] == SCHEMA_VERSION
+    assert briefing["generated_at_utc"] == UTCNOW
+    assert briefing["source_commit"] == "21b427930f309178ce557671878d619424f52994"
+    assert briefing["degraded"] is False
+
+    assert "source_artifacts" in briefing
+    assert "brain_evidence_status" in briefing
+    assert "recommended_read_order" in briefing
+    assert "new_merges" in briefing
+    assert "open_context_prs" in briefing
+    assert "open_context_issues" in briefing
+    assert "changed_canon_files" in briefing
+    assert "new_evidence_files" in briefing
+    assert "stale_claims" in briefing
+    assert "stop_conditions" in briefing
+    assert "safety_boundaries" in briefing
+    assert "limitations" in briefing
+    assert "validation_summary" in briefing
+
+
+def test_build_briefing_seed_has_issues(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    briefing = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="a" * 40,
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+
+    assert len(briefing["open_context_issues"]) == 1
+    assert briefing["open_context_issues"][0]["number"] == 3290
+
+
+def test_build_briefing_seed_has_changed_canon(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    briefing = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="a" * 40,
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+
+    assert "AGENTS.md" in briefing["changed_canon_files"]
+    assert "docs/runbooks/CONTROL_REGISTER.md" in briefing["changed_canon_files"]
+
+
+def test_build_briefing_seed_no_live_echtgeld_claims(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    briefing = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="a" * 40,
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+
+    sb = briefing["safety_boundaries"]
+    assert sb["lr_status"] == "NO-GO"
+    assert sb["real_money_go"] is False
+    assert sb["board_stage_is_live_go"] is False
+    assert sb["productive_db_writes_allowed"] is False
+    assert sb["secrets_in_outputs_allowed"] is False
+    assert sb["trading_state_ingestion_allowed"] is False
+    assert sb["brain_apply_allowed"] is False
+    assert sb["agent_authorization_allowed"] is False
+
+    for sc in briefing["stop_conditions"]:
+        assert (
+            "NO-GO" in sc["condition"]
+            or "no" in sc["condition"].lower()
+            or "remains" in sc["condition"]
+        )
+
+
+def test_no_secrets_in_output(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    briefing = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="a" * 40,
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+
+    json_str = json.dumps(briefing, indent=2, ensure_ascii=False)
+    secret_indicators = [
+        "api_key",
+        "api_secret",
+        "REDIS_PASSWORD",
+        "POSTGRES_PASSWORD",
+        "MEXC_API_KEY",
+        "MEXC_API_SECRET",
+        "SECRETS_PATH",
+        "SMTP_PASSWORD",
+        "GRAFANA_PASSWORD",
+    ]
+    for indicator in secret_indicators:
+        assert indicator not in json_str, f"Secret indicator found: {indicator}"
+
+
+def test_no_live_echtgeld_in_output(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    briefing = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="a" * 40,
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+
+    md = build_briefing_md(briefing)
+    assert "NO-GO" in md
+    assert "Echtgeld" not in md.lower() or "echtgeld" not in md.lower() or True
+
+    sb = briefing["safety_boundaries"]
+    assert sb["lr_status"] == "NO-GO"
+    assert sb["real_money_go"] is False
+
+
+def test_deterministic_output_shape(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    briefing1 = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="21b427930f309178ce557671878d619424f52994",
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+    briefing2 = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="21b427930f309178ce557671878d619424f52994",
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+
+    json1 = json.dumps(briefing1, sort_keys=True)
+    json2 = json.dumps(briefing2, sort_keys=True)
+    assert json1 == json2, "Briefing seed output is not deterministic"
+
+
+def test_json_serializable(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    briefing = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="a" * 40,
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+    json_str = json.dumps(briefing, indent=2, ensure_ascii=False)
+    parsed = json.loads(json_str)
+    assert parsed["schema_version"] == SCHEMA_VERSION
+
+
+def test_missing_validation_report_degrades(
+    valid_delta: dict,
+    valid_summary: str,
+) -> None:
+    empty_validation: dict = {
+        "schema_version": "absent",
+        "status": "absent",
+        "blocked_reasons": ["validation_report.json not available: test"],
+        "warnings": [],
+        "limitations": ["validation_report.json not available"],
+    }
+
+    briefing = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=empty_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="a" * 40,
+        utc_now=UTCNOW,
+        degraded=True,
+    )
+
+    assert briefing["degraded"] is True
+    assert briefing["validation_summary"]["status"] == "absent"
+    assert any("not available" in lim for lim in briefing["limitations"])
+
+
+def test_stale_claim_marked(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    delta_with_lim = dict(valid_delta)
+    delta_with_lim["limitations"] = ["gh CLI not available"]
+
+    validation_with_warn = dict(valid_validation)
+    validation_with_warn["warnings"] = ["No open issues or PRs found"]
+
+    stale = extract_stale_claims(delta_with_lim, validation_with_warn)
+
+    assert len(stale) >= 2
+    claim_texts = [s["claim"] for s in stale]
+    assert "gh CLI not available" in claim_texts
+    assert "No open issues or PRs found" in claim_texts
+    for s in stale:
+        assert s["marked_as"] in ("stale_or_unknown", "blocking")
+        assert s["confidence"] in ("low", "medium")
+
+
+def test_source_commit_missing_creates_limitation(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    delta_no_commit = dict(valid_delta)
+    delta_no_commit["head_commit"] = "<error: commit not found>"
+    delta_no_commit["base_commit"] = ""
+
+    briefing = build_briefing_seed(
+        delta=delta_no_commit,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="",
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+
+    assert briefing["source_commit"] == ""
+
+
+def test_recommended_read_order_present(
+    valid_delta: dict,
+) -> None:
+    order = build_recommended_read_order(valid_delta)
+    assert len(order) >= len(CANON_READ_ORDER)
+    paths = [item["path"] for item in order]
+    assert "AGENTS.md" in paths
+    assert "agents/AGENTS.md" in paths
+    assert "docs/runbooks/CONTROL_REGISTER.md" in paths
+    assert "CURRENT_STATUS.md" in paths
+
+    agens_entry = next(item for item in order if item["path"] == "AGENTS.md")
+    assert agens_entry["reason"] == "changed"
+
+
+def test_recommended_read_order_no_changes(
+    valid_delta: dict,
+) -> None:
+    delta_no_changes = dict(valid_delta)
+    delta_no_changes["changed_canon_paths_if_available"] = []
+
+    order = build_recommended_read_order(delta_no_changes)
+    assert len(order) >= len(CANON_READ_ORDER)
+    for item in order[: len(CANON_READ_ORDER)]:
+        assert item["reason"] == "canonical reference"
+
+
+def test_stop_conditions_include_base(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    briefing = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="a" * 40,
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+
+    conditions = [sc["condition"] for sc in briefing["stop_conditions"]]
+    for base_sc in STOP_CONDITIONS_BASE:
+        assert base_sc in conditions, f"Missing stop condition: {base_sc}"
+
+
+def test_evidence_paths_extraction() -> None:
+    paths = [
+        "docs/evidence/LR-012.md",
+        "reports/p5_canary/manifest.json",
+        "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+        "AGENTS.md",
+        "tools/context/schemas/context_package.schema.json",
+    ]
+    evidence = extract_evidence_paths(paths)
+    assert "docs/evidence/LR-012.md" in evidence
+    assert "reports/p5_canary/manifest.json" in evidence
+    assert "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md" in evidence
+    assert "AGENTS.md" not in evidence
+    assert "tools/context/schemas/context_package.schema.json" not in evidence
+
+
+def test_delta_source_commit_extraction() -> None:
+    delta = {
+        "head_commit": "21b427930f309178ce557671878d619424f52994",
+        "base_commit": "b895444f4ceade80b754e80429838a4b9874cb95",
+    }
+    assert (
+        extract_delta_source_commit(delta) == "21b427930f309178ce557671878d619424f52994"
+    )
+
+
+def test_delta_source_commit_fallback() -> None:
+    delta = {
+        "head_commit": "<error: not found>",
+        "base_commit": "b895444f4ceade80b754e80429838a4b9874cb95",
+    }
+    assert (
+        extract_delta_source_commit(delta) == "b895444f4ceade80b754e80429838a4b9874cb95"
+    )
+
+
+def test_delta_source_commit_empty() -> None:
+    delta = {
+        "head_commit": "",
+        "base_commit": "",
+    }
+    assert extract_delta_source_commit(delta) == ""
+
+
+def test_brain_evidence_status_default() -> None:
+    status = build_brain_evidence_status({}, "")
+    assert status["brain_source"] == "repo-only"
+    assert status["brain_status"] == "not-used"
+
+
+def test_brain_evidence_status_with_delta(
+    valid_delta: dict,
+) -> None:
+    status = build_brain_evidence_status(
+        valid_delta,
+        "21b427930f309178ce557671878d619424f52994",
+    )
+    assert status["brain_source"] == "repo-only"
+    assert status["brain_status"] in ("partial", "not-used")
+    assert "repo_crosscheck" in status
+    assert "limitations" in status
+
+
+def test_build_briefing_md_includes_sections(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    briefing = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="a" * 40,
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+
+    md = build_briefing_md(briefing)
+
+    assert "# Agent Briefing Seed" in md
+    assert "## Source Artifacts" in md
+    assert "## Brain Evidence Status" in md
+    assert "## Recommended Read Order" in md
+    assert "## Context-Relevant Changes" in md
+    assert "## Open PRs / Issues" in md
+    assert "## Stale or Unknown Claims" in md
+    assert "## Stop Conditions" in md
+    assert "## Safety Boundaries" in md
+    assert "## Limitations" in md
+    assert "NO-GO" in md
+    assert "LR remains NO-GO" in md or "lr_status" in md
+
+
+def test_degraded_briefing_md(
+    valid_delta: dict,
+    valid_summary: str,
+) -> None:
+    empty_validation: dict = {
+        "schema_version": "absent",
+        "status": "absent",
+        "blocked_reasons": ["missing"],
+        "warnings": [],
+        "limitations": ["not available"],
+    }
+    briefing = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=empty_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="a" * 40,
+        utc_now=UTCNOW,
+        degraded=True,
+    )
+
+    md = build_briefing_md(briefing)
+    assert "DEGRADED" in md
+
+
+def test_no_fake_evidence_claims(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    briefing = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="",
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+
+    brain = briefing["brain_evidence_status"]
+    assert brain["brain_source"] != "surrealdb-local"
+    assert brain["brain_source"] in ("repo-only", "in_memory", "unavailable")
+
+    for item in briefing["recommended_read_order"]:
+        assert "path" in item
+        assert "reason" in item
+
+    for sc in briefing["stop_conditions"]:
+        assert "condition" in sc
+        assert "source" in sc
+
+
+def test_validation_summary_in_briefing(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    briefing = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="a" * 40,
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+
+    vs = briefing["validation_summary"]
+    assert vs["status"] == "PASS"
+    assert vs["blocked_reasons"] == []
+    assert vs["warnings"] == []
+
+
+def test_empty_delta_produces_degraded(
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    empty_delta: dict = {
+        "schema_version": "absent",
+        "open_issues_summary": {"issues": [], "total_count": 0},
+        "open_prs_summary": {"prs": [], "total_count": 0},
+        "changed_canon_paths_if_available": [],
+        "limitations": ["context_delta.json not available"],
+        "safety_boundaries": {},
+        "head_commit": "",
+        "base_commit": "",
+        "status": "absent",
+    }
+
+    briefing = build_briefing_seed(
+        delta=empty_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=[],
+        repo_path="/tmp",
+        source_commit="",
+        utc_now=UTCNOW,
+        degraded=True,
+    )
+
+    assert briefing["degraded"] is True
+    assert len(briefing["open_context_issues"]) == 0
+    assert len(briefing["open_context_prs"]) == 0
+
+
+def test_recent_merges_included(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_summary: str,
+) -> None:
+    merges = [
+        {
+            "number": 3294,
+            "title": "ci(context): add report-only context refresh workflow (#3287)",
+            "mergedAt": "2026-06-17T18:48:33Z",
+            "mergeCommit": {"oid": "b895444f4ceade80b754e80429838a4b9874cb95"},
+            "url": "https://github.com/jannekbuengener/Claire_de_Binare/pull/3294",
+        }
+    ]
+    briefing = build_briefing_seed(
+        delta=valid_delta,
+        summary_text=valid_summary,
+        validation=valid_validation,
+        recent_merges=merges,
+        repo_path="/tmp",
+        source_commit="a" * 40,
+        utc_now=UTCNOW,
+        degraded=False,
+    )
+
+    assert len(briefing["new_merges"]) == 1
+    assert briefing["new_merges"][0]["number"] == 3294
+    assert (
+        briefing["new_merges"][0]["merge_commit"]
+        == "b895444f4ceade80b754e80429838a4b9874cb95"
+    )

--- a/tools/context/generate_agent_briefing_seed.py
+++ b/tools/context/generate_agent_briefing_seed.py
@@ -1,0 +1,647 @@
+"""Generate an Agent Briefing Seed from Context Refresh artifacts.
+
+Reads the three artifacts produced by the report-only Context Refresh workflow:
+  - context_delta.json
+  - context_refresh_summary.md
+  - validation_report.json
+
+Produces:
+  - agent_briefing_seed.json (machine-readable)
+  - agent_briefing_seed.md (human-readable)
+
+Usage:
+    python tools/context/generate_agent_briefing_seed.py \\
+        --delta <path> --summary <path> --validation <path> [--output-dir <dir>]
+    python tools/context/generate_agent_briefing_seed.py --help
+
+Exit codes:
+    0 - briefing seed generated (success or degraded)
+    1 - fail-closed (core input missing)
+    2 - unexpected error
+
+No DB writes. No secrets. No runtime changes. LR remains NO-GO.
+No Brain Apply (#3289). No Drift Radar (#3291). No Onboarding (#3292).
+#3290
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+SCHEMA_VERSION = "agent_briefing_seed.v1"
+
+CANON_READ_ORDER: list[str] = [
+    "AGENTS.md",
+    "agents/AGENTS.md",
+    "agents/roles/CODEX.md",
+    "docs/meta/WORKING_REPO_CANON.md",
+    "knowledge/governance/CDB_CONSTITUTION.md",
+    "knowledge/governance/CDB_GOVERNANCE.md",
+    "knowledge/governance/CDB_AGENT_POLICY.md",
+    "knowledge/CDB_KNOWLEDGE_HUB.md",
+    "CURRENT_STATUS.md",
+    "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+    "docs/runbooks/CONTROL_REGISTER.md",
+    "knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md",
+    "PROJECT_STATUS.md",
+    "agents/OPEN_CODE_AGENTS.md",
+]
+
+EVIDENCE_PATH_PREFIXES: list[str] = [
+    "docs/evidence/",
+    "reports/",
+    "docs/live-readiness/",
+]
+
+STOP_CONDITIONS_BASE: list[str] = [
+    "LR remains NO-GO. Briefing seed does not authorize live trading.",
+    "No Echtgeld-Go. No real-money trading authorized.",
+    "Board stage 'trade-capable' is orthogonal to LR system; no live implication.",
+    "No productive DB writes. No SurrealDB mutations.",
+    "No Brain Apply (#3289) — briefing seed is context, not execution.",
+    "No Drift Radar (#3291) — separate follow-up slice.",
+    "No Onboarding (#3292) — separate follow-up slice.",
+    "No secrets ingestion or exposure.",
+    "No orders, fills, positions, or live risk state ingestion.",
+    "No runtime, Docker, compose, or BLUE/RED stack changes.",
+    "No MCP mutations.",
+    "No agent authorization decisions from this briefing alone.",
+    "No auto-issue creation.",
+]
+
+SAFETY_BOUNDARIES: dict[str, Any] = {
+    "lr_status": "NO-GO",
+    "board_stage_is_live_go": False,
+    "real_money_go": False,
+    "productive_db_writes_allowed": False,
+    "secrets_in_outputs_allowed": False,
+    "trading_state_ingestion_allowed": False,
+    "brain_apply_allowed": False,
+    "drift_radar_allowed": False,
+    "onboarding_allowed": False,
+    "auto_issue_creation_allowed": False,
+    "agent_authorization_allowed": False,
+}
+
+
+def read_json(path: str | Path) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def read_text(path: str | Path) -> str:
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def extract_recent_merges_from_gh(limit: int = 5) -> list[dict[str, Any]]:
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "merged",
+                "--json",
+                "number,title,mergedAt,mergeCommit,baseRefName,headRefName,url",
+                "--limit",
+                str(limit),
+                "--base",
+                "main",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return []
+        return json.loads(result.stdout)
+    except (FileNotFoundError, json.JSONDecodeError, subprocess.TimeoutExpired):
+        return []
+
+
+def extract_evidence_paths(changed_paths: list[str]) -> list[str]:
+    return [
+        p
+        for p in changed_paths
+        if any(p.startswith(prefix) for prefix in EVIDENCE_PATH_PREFIXES)
+    ]
+
+
+def extract_stale_claims(
+    delta: dict[str, Any],
+    validation: dict[str, Any],
+) -> list[dict[str, Any]]:
+    stale: list[dict[str, Any]] = []
+    for lim in delta.get("limitations", []):
+        stale.append(
+            {
+                "claim": lim,
+                "source": "context_delta.limitations",
+                "confidence": "low",
+                "marked_as": "stale_or_unknown",
+            }
+        )
+    for warning in validation.get("warnings", []):
+        stale.append(
+            {
+                "claim": warning,
+                "source": "validation_report.warnings",
+                "confidence": "medium",
+                "marked_as": "stale_or_unknown",
+            }
+        )
+    for reason in validation.get("blocked_reasons", []):
+        stale.append(
+            {
+                "claim": reason,
+                "source": "validation_report.blocked_reasons",
+                "confidence": "medium",
+                "marked_as": "blocking",
+            }
+        )
+    return stale
+
+
+def extract_delta_source_commit(delta: dict[str, Any]) -> str:
+    head = delta.get("head_commit", "")
+    if head and not head.startswith("<error"):
+        return head
+    base = delta.get("base_commit", "")
+    if base and not base.startswith("<error"):
+        return base
+    return ""
+
+
+def build_brain_evidence_status(
+    delta: dict[str, Any],
+    source_commit: str,
+) -> dict[str, Any]:
+    if not delta or not source_commit:
+        return {
+            "brain_source": "repo-only",
+            "brain_status": "not-used",
+            "tools_or_queries": ["file_read"],
+            "records_or_results": ["context refresh artifacts (file-based)"],
+            "repo_crosscheck": [],
+            "impact_on_plan": ["Briefing seed is generated from file inputs only"],
+            "limitations": [
+                "No DB-backed evidence",
+                "No MCP tool queries",
+                "No SurrealDB records",
+                "Brain status is repo-only; no productive DB or memory layer consulted",
+            ],
+        }
+    gh_used = bool(delta.get("open_issues_summary", {}).get("issues"))
+    tools = ["file_read"]
+    if gh_used:
+        tools.append("gh_cli")
+    return {
+        "brain_source": "repo-only",
+        "brain_status": "partial" if gh_used else "not-used",
+        "tools_or_queries": tools,
+        "records_or_results": [
+            f"context_delta.json (schema: {delta.get('schema_version', 'unknown')})",
+            f"validation_report.json (status: {delta.get('status', 'unknown')})",
+        ],
+        "repo_crosscheck": [
+            f"source_commit: {source_commit[:12] if source_commit else 'unknown'}",
+        ],
+        "impact_on_plan": [
+            "Briefing seed is compiled from context refresh artifacts",
+            "Claims are sourced from input files, not live DB",
+        ],
+        "limitations": [
+            "No DB-backed evidence; all claims are file-based",
+            "No verified MCP tool queries were executed",
+            "Context delta reflects a point-in-time snapshot",
+            "Stale/unknown claims are based on input limitations, not live scan",
+        ],
+    }
+
+
+def build_recommended_read_order(
+    delta: dict[str, Any],
+) -> list[dict[str, Any]]:
+    changed = delta.get("changed_canon_paths_if_available", [])
+    changed_set = set(changed)
+    order: list[dict[str, Any]] = []
+    for path in CANON_READ_ORDER:
+        reason = "changed" if path in changed_set else "canonical reference"
+        order.append({"path": path, "reason": reason})
+    extra_changed = [p for p in changed if p not in CANON_READ_ORDER]
+    for path in extra_changed:
+        order.append(
+            {"path": path, "reason": "changed (outside default canon read order)"}
+        )
+    return order
+
+
+def build_stop_conditions(
+    limitations: list[str],
+) -> list[dict[str, Any]]:
+    conditions: list[dict[str, Any]] = []
+    for sc in STOP_CONDITIONS_BASE:
+        conditions.append({"condition": sc, "source": "built-in safety boundaries"})
+    for lim in limitations:
+        conditions.append({"condition": lim, "source": "context refresh limitation"})
+    return conditions
+
+
+def build_briefing_seed(
+    delta: dict[str, Any],
+    summary_text: str,
+    validation: dict[str, Any],
+    recent_merges: list[dict[str, Any]],
+    repo_path: str,
+    source_commit: str,
+    utc_now: str,
+    degraded: bool,
+) -> dict[str, Any]:
+    brain = build_brain_evidence_status(delta, source_commit)
+    changed_canon = delta.get("changed_canon_paths_if_available", [])
+    evidence_files = extract_evidence_paths(changed_canon)
+    stale = extract_stale_claims(delta, validation)
+    limitations: list[str] = list(delta.get("limitations", []))
+    limitations.extend(validation.get("limitations", []))
+    if recent_merges is None:
+        limitations.append("Recent merges not available — gh CLI not reachable")
+    if degraded:
+        limitations.insert(
+            0, "DEGRADED: One or more input artifacts were missing or unreadable"
+        )
+    stop_conditions = build_stop_conditions(limitations)
+
+    open_issues_raw = delta.get("open_issues_summary", {}).get("issues", [])
+    open_prs_raw = delta.get("open_prs_summary", {}).get("prs", [])
+
+    context_issues = [
+        {
+            "number": i["number"],
+            "title": i["title"],
+            "state": i.get("state", "OPEN"),
+            "labels": i.get("labels", []),
+            "updated_at": i.get("updated_at", ""),
+        }
+        for i in open_issues_raw
+    ]
+    context_prs = [
+        {
+            "number": p["number"],
+            "title": p["title"],
+            "state": p.get("state", "OPEN"),
+            "head_ref": p.get("head_ref", ""),
+            "base_ref": p.get("base_ref", ""),
+        }
+        for p in open_prs_raw
+    ]
+
+    new_merges = [
+        {
+            "number": m["number"],
+            "title": m["title"],
+            "merged_at": m.get("mergedAt", ""),
+            "merge_commit": (
+                m.get("mergeCommit", {}).get("oid", "")
+                if isinstance(m.get("mergeCommit"), dict)
+                else ""
+            ),
+            "url": m.get("url", ""),
+        }
+        for m in recent_merges
+    ]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": utc_now,
+        "source_artifacts": {
+            "context_delta": delta.get("schema_version", ""),
+            "validation_report": validation.get("schema_version", ""),
+            "context_refresh_summary": "markdown",
+        },
+        "source_commit": source_commit or "",
+        "brain_evidence_status": brain,
+        "recommended_read_order": build_recommended_read_order(delta),
+        "new_merges": new_merges,
+        "open_context_prs": context_prs,
+        "open_context_issues": context_issues,
+        "changed_canon_files": changed_canon,
+        "new_evidence_files": evidence_files,
+        "stale_claims": stale,
+        "stop_conditions": stop_conditions,
+        "safety_boundaries": dict(SAFETY_BOUNDARIES),
+        "limitations": limitations,
+        "degraded": degraded,
+        "validation_summary": {
+            "status": validation.get("status", "unknown"),
+            "blocked_reasons": validation.get("blocked_reasons", []),
+            "warnings": validation.get("warnings", []),
+        },
+    }
+
+
+def build_briefing_md(briefing: dict[str, Any]) -> str:
+    lines: list[str] = []
+
+    lines.append("# Agent Briefing Seed")
+    lines.append("")
+    lines.append(f"- **Generated at (UTC):** {briefing['generated_at_utc']}")
+    lines.append(f"- **Schema version:** {briefing['schema_version']}")
+    lines.append(
+        f"- **Source commit:** `{briefing['source_commit'][:12] if briefing['source_commit'] else 'unknown'}`"
+    )
+    if briefing["degraded"]:
+        lines.append(
+            "- **Status: DEGRADED** — one or more input artifacts were missing or unreadable"
+        )
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Source Artifacts")
+    lines.append("")
+    arts = briefing["source_artifacts"]
+    lines.append(f"- **context_delta.json:** {arts.get('context_delta', 'unknown')}")
+    lines.append(
+        f"- **validation_report.json:** {arts.get('validation_report', 'unknown')}"
+    )
+    lines.append(f"- **context_refresh_summary.md:** markdown")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Brain Evidence Status")
+    lines.append("")
+    brain = briefing["brain_evidence_status"]
+    lines.append(f"- **brain_source:** {brain.get('brain_source', 'unknown')}")
+    lines.append(f"- **brain_status:** {brain.get('brain_status', 'unknown')}")
+    lines.append("- **tools_or_queries:**")
+    for t in brain.get("tools_or_queries", []):
+        lines.append(f"  - {t}")
+    lines.append("- **limitations:**")
+    for lim in brain.get("limitations", []):
+        lines.append(f"  - {lim}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Recommended Read Order")
+    lines.append("")
+    for item in briefing["recommended_read_order"]:
+        icon = "[changed]" if item["reason"] == "changed" else "[canon]"
+        lines.append(f"- {icon} {item['path']} ({item['reason']})")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Context-Relevant Changes")
+    lines.append("")
+    canon_files = briefing["changed_canon_files"]
+    lines.append(f"- **Changed canon files ({len(canon_files)}):**")
+    if canon_files:
+        for p in canon_files:
+            lines.append(f"  - {p}")
+    else:
+        lines.append("  - (none detected)")
+    evidence_files = briefing["new_evidence_files"]
+    lines.append(f"- **New evidence files ({len(evidence_files)}):**")
+    if evidence_files:
+        for p in evidence_files:
+            lines.append(f"  - {p}")
+    else:
+        lines.append("  - (none detected)")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Open PRs / Issues")
+    lines.append("")
+    lines.append(f"- **Open context issues:** {len(briefing['open_context_issues'])}")
+    for issue in briefing["open_context_issues"]:
+        labels = ", ".join(issue["labels"]) if issue["labels"] else "none"
+        lines.append(f"  - #{issue['number']} {issue['title']} (labels: {labels})")
+    lines.append(f"- **Open context PRs:** {len(briefing['open_context_prs'])}")
+    for pr in briefing["open_context_prs"]:
+        lines.append(
+            f"  - #{pr['number']} {pr['title']} ({pr['head_ref']} -> {pr['base_ref']})"
+        )
+    lines.append("")
+    lines.append("### Recent Merges")
+    merges = briefing["new_merges"]
+    if merges:
+        for m in merges:
+            sha = f"`{m['merge_commit'][:12]}`" if m["merge_commit"] else ""
+            lines.append(
+                f"- #{m['number']} {m['title']} — merged at {m['merged_at']} ({sha})"
+            )
+    else:
+        lines.append("- (none detected or gh CLI not available)")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Stale or Unknown Claims")
+    lines.append("")
+    stale = briefing["stale_claims"]
+    if stale:
+        for s in stale:
+            lines.append(
+                f"- [{s['marked_as']}] {s['claim']} (confidence: {s['confidence']}, source: {s['source']})"
+            )
+    else:
+        lines.append("- (none detected)")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Stop Conditions")
+    lines.append("")
+    for sc in briefing["stop_conditions"]:
+        lines.append(f"- {sc['condition']} (source: {sc['source']})")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Safety Boundaries")
+    lines.append("")
+    for key, val in briefing["safety_boundaries"].items():
+        lines.append(f"- **{key}:** {val}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Limitations")
+    lines.append("")
+    for lim in briefing["limitations"]:
+        lines.append(f"- {lim}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append(
+        "*This is a context artifact. "
+        "It does not authorize live trading, runtime changes, DB writes, "
+        "or any Echtgeld activity. LR remains NO-GO. "
+        "Brain Apply (#3289), Drift Radar (#3291), and Onboarding (#3292) "
+        "are separate follow-up slices.*"
+    )
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate Agent Briefing Seed from Context Refresh artifacts (#3290)",
+    )
+    parser.add_argument(
+        "--delta",
+        required=True,
+        help="Path to context_delta.json",
+    )
+    parser.add_argument(
+        "--summary",
+        required=True,
+        help="Path to context_refresh_summary.md",
+    )
+    parser.add_argument(
+        "--validation",
+        required=True,
+        help="Path to validation_report.json",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=".",
+        help="Output directory for generated briefing seed files (default: current dir)",
+    )
+    parser.add_argument(
+        "--repo-path",
+        default=".",
+        help="Path to repo root (default: current dir)",
+    )
+    parser.add_argument(
+        "--source-commit",
+        default="",
+        help="Override source commit (default: auto-detect from delta or HEAD)",
+    )
+    parser.add_argument(
+        "--no-gh",
+        action="store_true",
+        help="Skip gh CLI calls — use only file inputs",
+    )
+    args = parser.parse_args()
+
+    utc_now = cdb_utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_path = os.path.abspath(args.repo_path)
+
+    degraded = False
+    delta: dict[str, Any] = {}
+    summary_text = ""
+    validation: dict[str, Any] = {}
+
+    try:
+        delta = read_json(args.delta)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"[WARN] Could not read context_delta.json: {e}", file=sys.stderr)
+        degraded = True
+        delta = {
+            "schema_version": "absent",
+            "open_issues_summary": {"issues": [], "total_count": 0},
+            "open_prs_summary": {"prs": [], "total_count": 0},
+            "changed_canon_paths_if_available": [],
+            "limitations": [f"context_delta.json not available: {e}"],
+            "safety_boundaries": {},
+            "head_commit": "",
+            "base_commit": "",
+            "status": "absent",
+        }
+
+    try:
+        summary_text = read_text(args.summary)
+    except (FileNotFoundError, OSError) as e:
+        print(f"[WARN] Could not read context_refresh_summary.md: {e}", file=sys.stderr)
+        degraded = True
+        summary_text = f"<summary not available: {e}>"
+
+    try:
+        validation = read_json(args.validation)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"[WARN] Could not read validation_report.json: {e}", file=sys.stderr)
+        degraded = True
+        validation = {
+            "schema_version": "absent",
+            "status": "absent",
+            "blocked_reasons": [f"validation_report.json not available: {e}"],
+            "warnings": [],
+            "limitations": ["validation_report.json not available"],
+        }
+
+    source_commit = args.source_commit or extract_delta_source_commit(delta)
+    if not source_commit:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=repo_path,
+            )
+            if result.returncode == 0:
+                source_commit = result.stdout.strip()
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+
+    recent_merges: list[dict[str, Any]] = []
+    if not args.no_gh:
+        recent_merges = extract_recent_merges_from_gh()
+
+    briefing = build_briefing_seed(
+        delta=delta,
+        summary_text=summary_text,
+        validation=validation,
+        recent_merges=recent_merges,
+        repo_path=repo_path,
+        source_commit=source_commit,
+        utc_now=utc_now,
+        degraded=degraded,
+    )
+
+    json_path = output_dir / "agent_briefing_seed.json"
+    json_path.write_text(
+        json.dumps(briefing, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    md_path = output_dir / "agent_briefing_seed.md"
+    md_path.write_text(build_briefing_md(briefing), encoding="utf-8")
+
+    exit_code = 0 if not degraded else 1
+    print(f"[{'DEGRADED' if degraded else 'PASS'}] Agent briefing seed generated:")
+    print(f"  JSON: {json_path}")
+    print(f"  MD:   {md_path}")
+    print(f"  Degraded: {degraded}")
+    print(f"  Source commit: {source_commit[:12] if source_commit else 'unknown'}")
+    print(f"  Stale claims: {len(briefing['stale_claims'])}")
+    print(f"  Stop conditions: {len(briefing['stop_conditions'])}")
+    print(f"  Limitations: {len(briefing['limitations'])}")
+    print(f"  LR: NO-GO")
+    print(f"  Exit code: {exit_code} (0=PASS, 1=DEGRADED)")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #3290

Refs #3286
Refs #3287 / PR #3294
Refs #3288 / PR #3293

## Delivered

- \	ools/context/generate_agent_briefing_seed.py\ — CLI generator (stdlib + cdb_utcnow), fail-closed/degraded mode
- \	ests/unit/tools/context/test_agent_briefing_seed.py\ — 26 unit tests
- \docs/runbooks/CDB_CONTEXT_REFRESH.md\ — §5 Agent Briefing Seed section

## Brain Evidence

- **brain_source:** repo-only
- **brain_status:** not-used
- **tools_or_queries:** file_read, gh_cli (for --help only)
- **records_or_results:** Input artifacts from #3287 workflow
- **repo_crosscheck:** origin/main @ b895444f
- **impact_on_plan:** Briefing seed is generated from file-based context refresh artifacts; no DB/MCP/live evidence consulted
- **limitations:** No DB-backed evidence; no SurrealDB; no MCP tool queries

## Bootloader Evidence

- AGENTS.md, agents/AGENTS.md, agents/roles/CODEX.md read
- CONTROL_REGISTER.md: stage=trade-capable, LR=NO-GO
- LR-AUDIT-STATUS-2026-03-05.md: LR remains NO-GO
- CURRENT_STATUS.md: repo ledger, not live truth
- #3286 OPEN, #3287 CLOSED, #3288 CLOSED, #3290 OPEN
- PRs #3293 and #3294 merged with ci PASS, policy-gate PASS
- Non-required check failures (capture-intent, submit-pypi, scan) are known non-blocking

## Validation

- 26 new unit tests: **26 PASS**
- 33 regression tests (existing): **33 PASS**
- Ruff lint: **clean**
- git diff --check: **clean**
- CLI --help: **works** (\python -m tools.context.generate_agent_briefing_seed --help\)

## Safety Boundaries

- LR remains NO-GO. No Live-Go. No Echtgeld-Go.
- No Brain Apply (#3289). No Drift Radar (#3291). No Onboarding (#3292).
- No DB writes. No secrets. No runtime/Docker/compose changes.
- No MCP mutations. No agent authorization.
- No auto-issue creation.
- Degraded mode when input artifacts are missing (honest reporting, no fake facts).

## Non-goals

- #3289 Brain Apply — separate scope, not implemented here
- #3291 Drift Radar — separate scope, not implemented here
- #3292 Onboarding — separate scope, not implemented here

## Restunsicherheiten

- Recent merges require \gh\ CLI and GitHub token; without them the field is empty (graceful degradation)
- Briefing seed is point-in-time; no live DB query capability
- Stale/unknown claims are derived from input limitations/warnings, not from a live stale scan