### PR TITLE
feat(context): add drift impact radar (#3291)

### DIFF
--- a/docs/runbooks/CDB_CONTEXT_REFRESH.md
+++ b/docs/runbooks/CDB_CONTEXT_REFRESH.md
@@ -7,6 +7,7 @@ in ein evidence-faehiges Context-/Brain-Paket ueberfuehren.
 **Erster operativer Slice:** [#3288](https://github.com/jannekbuengener/Claire_de_Binare/issues/3288)
 **Report-only Workflow:** [#3287](https://github.com/jannekbuengener/Claire_de_Binare/issues/3287) — DIESER
 **Agent Briefing Seed:** [#3290](https://github.com/jannekbuengener/Claire_de_Binare/issues/3290) — aus Context-Refresh-Artefakten
+**Drift Radar:** [#3291](https://github.com/jannekbuengener/Claire_de_Binare/issues/3291) — DIESER SLICE — siehe §6
 **Naechster Slice (Brain Apply):** [#3289](https://github.com/jannekbuengener/Claire_de_Binare/issues/3289) — benoetigt validiertes Package aus #3288
 
 **LR-Status:** `NO-GO`
@@ -192,11 +193,11 @@ Delta-Paket bauen (context_delta.json + validation_report.json)
     v
 Agent Briefing Seed (#3290) — aus 3 Artefakten
     |
-    v (optional, nach Briefing)
-Lokaler append-only Brain Apply (#3289) — spaeter
-    |
     v
-Drift Report (#3291) — spaeter
+Drift Radar (#3291, DIESER SLICE) — aus Delta + Validation + optional Briefing
+    |
+    v (optional, nach Drift Radar)
+Lokaler append-only Brain Apply (#3289) — spaeter
 ```
 
 ---
@@ -312,10 +313,136 @@ Das Briefing Seed enthaelt dieselben Safety-Grenzen wie das Context Package:
 ### Eingeschraenkte Scope-Grenzen
 
 - Kein Brain Apply (#3289) — separater Follow-up-Slice
-- Kein Drift Radar (#3291) — separater Follow-up-Slice
+- Drift Radar (#3291) — DIESER SLICE — siehe §6
 - Kein Onboarding (#3292) — separater Follow-up-Slice
 - Keine Live-/Echtgeld-Implikation
 - Keine DB-Writes
+
+---
+
+## 6. Drift Radar (#3291)
+
+Der Drift Radar ist ein read-only Scanner, der stale Dokumentation und
+widerspruechliche Canon-/Ledger-/GitHub-Signale sichtbar macht.
+
+**Generator:** `tools/context/generate_context_drift_radar.py`
+
+### Input-Artefakte
+
+| Artefakt | Pflicht | Beschreibung |
+|----------|---------|-------------|
+| `context_delta.json` | Ja | Aus dem Report-Workflow (#3287) |
+| `validation_report.json` | Ja | Aus dem Report-Workflow (#3287) |
+| `agent_briefing_seed.json` | Optional | Aus dem Briefing-Generator (#3290) |
+
+### Drift-Kategorien
+
+| Kategorie | Beschreibung | Default Severity |
+|-----------|-------------|-----------------|
+| `canon_pointer_drift` | Canon-Pointer-Dateien (AGENTS.md, WORKING_REPO_CANON) geaendert | medium |
+| `ledger_vs_github_drift` | Offene Context-/Drift-Issues im Widerspruch zum Ledger | medium |
+| `lr_status_ambiguity` | LR-Status weicht von NO-GO ab | high |
+| `stale_architecture_docs` | Architecture-/Knowledge-Hub-Dateien geaendert | medium |
+| `stale_onboarding_docs` | Onboarding-bezogene Dateien geaendert | medium |
+| `stale_agent_bootloader_instructions` | Bootloader-/Agent-Surfaces geaendert | medium |
+| `workflow_check_drift` | Validation-Report blockiert/warnt | high/medium |
+| `unknown_high_risk_delta` | Limitations mit Live-/Echtgeld-/Secret-Indikatoren | high |
+
+### Output-Artefakte
+
+| Artefakt | Format | Beschreibung |
+|----------|--------|-------------|
+| `stale_claims.json` | JSON | Maschinenlesbare Claims (schema_version, generated_at_utc, source_artifacts, claims, summary, degraded, limitations) |
+| `impact_radar.md` | Markdown | Menschlesbarer Impact-Bericht mit allen required sections |
+
+Optional (via `--json`):
+| `impact_radar.json` | JSON | Maschinenlesbare Impact-Radar-Struktur |
+
+### Required Fields (stale_claims.json)
+
+| Feld | Beschreibung |
+|------|-------------|
+| `schema_version` | Version des Claim-Formats (`stale_claims.v1`) |
+| `generated_at_utc` | ISO-8601 UTC-Zeitstempel |
+| `source_artifacts` | Verwendete Input-Artefakte mit Version |
+| `claims[]` | Liste der Drift-Claims |
+| `claims[].claim` | Beschreibung des Drifts |
+| `claims[].drift_category` | Eine der 8 Drift-Kategorien |
+| `claims[].severity` | high / medium / low |
+| `claims[].source_ref` | Quelle des Claims im Input |
+| `claims[].current_truth_ref` | Referenz auf aktuelle Wahrheit |
+| `claims[].status` | blocking / changed / open / needs_review / stale_or_unknown / warning |
+| `claims[].recommended_action` | Empfohlene Massnahme |
+| `claims[].blocks_brain_apply` | true/false — blockiert dieser Claim Brain Apply? |
+| `summary` | Zusammenfassung (total_claims, blocking, high/medium/low severity, blocks_brain_apply) |
+| `degraded` | Ob das Radar degraded lief |
+| `limitations` | Bekannte Einschraenkungen |
+
+### Required Sections (impact_radar.md)
+
+- `Context Drift / Impact Radar` — Header mit Metadaten
+- `Source Artifacts` — Verwendete Input-Quellen
+- `High-Risk Drift` — Claims mit severity=high
+- `Brain Apply Blockers` — Claims mit blocks_brain_apply=true
+- `Stale Claims` — Alle erkannten Drift-Claims
+- `Canon / Ledger / GitHub Conflicts` — Kategorisierte Konflikte
+- `Workflow / Check Drift` — Validierungs-Warnungen/Blockierungen
+- `Recommended Follow-up Issues` — Report-only Issue-Empfehlungen (keine Auto-Anlage)
+- `Safety Boundaries` — LR/Echtgeld/Security-Grenzen
+- `Limitations` — Bekannte Einschraenkungen
+
+### Brain-Apply-Blocking Policy
+
+High-risk Drift blockiert Brain Apply (#3289) unter folgenden Bedingungen:
+
+| Bedingung | Grund |
+|-----------|-------|
+| `severity == high` | Jeder high-severity Claim blockiert vorsorglich |
+| `category == lr_status_ambiguity` | LR-Status-Abweichung ist immer blocking |
+| `category == unknown_high_risk_delta` | Unbekannte high-risk Deltas blockieren |
+| Claim impliziert Live-Go/Echtgeld-Go | Nur LR-SSOT darf Live-Status setzen |
+| Claim involviert Secrets/Orders/Fills/Positions/Risk-State | Safety-Grenze |
+| Erforderliche Canon-Quelle fehlt | Unvollstaendige Basis |
+| GitHub/Repo-live widerspricht Briefing/Ledger-Claim | Live-Wahrheit gewinnt |
+
+**Verdikt:** Der Radar bewertet Brain Apply als `blocked` oder `recommended_hold`.
+Brain Apply (#3289) wird hier nicht implementiert — nur der Blocker-Report.
+
+### Exit Codes
+
+- **0:** PASS — Radar erfolgreich generiert, keine blocking Claims
+- **1:** BLOCKED — High-risk Drift erkannt, Brain Apply blockiert
+- **2:** FAIL — Unerwarteter Fehler (beide Pflicht-Inputs fehlen)
+
+### CLI-Usage
+
+```bash
+# Aus Context-Refresh-Artefakten generieren
+python tools/context/generate_context_drift_radar.py \
+    --delta artifacts/context_delta.json \
+    --validation artifacts/validation_report.json \
+    --briefing artifacts/agent_briefing_seed.json \
+    --output-dir artifacts/
+
+# Mit optionalem JSON-Output
+python tools/context/generate_context_drift_radar.py \
+    --delta artifacts/context_delta.json \
+    --validation artifacts/validation_report.json \
+    --json \
+    --output-dir artifacts/
+
+# Hilfe
+python tools/context/generate_context_drift_radar.py --help
+```
+
+### Safety Boundaries
+
+- Drift Radar ist read-only: keine DB-Writes, kein Brain Apply (#3289), kein Onboarding (#3292).
+- LR bleibt NO-GO. Kein Live-Go. Kein Echtgeld-Go.
+- Reports empfehlen Folge-Issues, legen sie aber nicht automatisch an.
+- High-risk Drift blockiert Brain Apply, aber der Radar fuehrt keinen Apply aus.
+- Keine Secrets in Outputs (Secret-Indikatoren in Inputs werden als Limitation gemeldet).
+- Keine Runtime-/Docker-/Trading-Aenderungen.
 
 ---
 
@@ -342,6 +469,8 @@ Das Briefing Seed enthaelt dieselben Safety-Grenzen wie das Context Package:
   oder SurrealDB-Verbindungen eingespielt.
 - **#3289 Brain Apply ist nicht Teil dieses Workflows.** Brain Apply kommt in
   einem spaeteren Slice.
+- **#3291 Drift Radar (§6) ist read-only.** Es erzeugt Reports und blockiert
+  ggf. Brain Apply, fuehrt aber keinen Apply aus.
 - **#3292 Onboarding Scenario bleibt zuletzt.**
 
 ---
@@ -351,9 +480,9 @@ Das Briefing Seed enthaelt dieselben Safety-Grenzen wie das Context Package:
 | Issue | Beschreibung | Status |
 |-------|-------------|--------|
 | #3286 | Parent Epic: Context Refresh Workflow | OFFEN |
-| #3287 | Report-only GitHub Actions Workflow | DIESES |
+| #3287 | Report-only GitHub Actions Workflow | ERLEDIGT (#3294) |
 | #3288 | Context Package Schema + Validator | ERLEDIGT (#3293) |
 | #3289 | Lokaler append-only Brain Apply | OFFEN — spaeter |
-| #3290 | Agent Briefing Seed | DIESES — DONE_MERGED_CLOSED |
-| #3291 | Stale Documentation / Impact Radar | OFFEN — spaeter |
+| #3290 | Agent Briefing Seed | ERLEDIGT (#3295) |
+| #3291 | Stale Documentation / Impact Radar | DIESES — SIEHE §6 |
 | #3292 | Onboarding Scenario (bewusst zuletzt) | OFFEN — zuletzt |

--- a/tests/unit/tools/context/test_context_drift_radar.py
+++ b/tests/unit/tools/context/test_context_drift_radar.py
@@ -1,0 +1,731 @@
+"""Unit tests for CDB Context Drift Radar.
+
+#3291
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.context.generate_context_drift_radar import (
+    SCHEMA_VERSION,
+    RADAR_SCHEMA_VERSION,
+    DRIFT_CATEGORIES,
+    scan_all,
+    scan_canon_pointer_drift,
+    scan_ledger_vs_github_drift,
+    scan_lr_status_ambiguity,
+    scan_stale_architecture_docs,
+    scan_stale_onboarding_docs,
+    scan_stale_agent_bootloader_instructions,
+    scan_workflow_check_drift,
+    scan_unknown_high_risk_delta,
+    build_stale_claims,
+    build_impact_radar,
+    build_impact_radar_md,
+    _severity_for_category,
+    _blocks_brain_apply,
+    _find_secret_indicators,
+)
+
+UTCNOW = "2026-06-17T12:00:00Z"
+
+
+def _make_valid_delta() -> dict:
+    return {
+        "schema_version": "context_refresh_report.v1",
+        "generated_at_utc": UTCNOW,
+        "base_ref": "origin/main",
+        "head_ref": "HEAD",
+        "base_commit": "b895444f4ceade80b754e80429838a4b9874cb95",
+        "head_commit": "072b740a28586dfd885d80c7bcbc8e82822e2dab",
+        "repo": "Claire_de_Binare",
+        "open_issues_summary": {
+            "total_count": 1,
+            "issues": [
+                {
+                    "number": 3291,
+                    "title": "[CONTEXT][DRIFT] Add stale documentation and impact radar",
+                    "state": "OPEN",
+                    "labels": ["type:docs"],
+                    "updated_at": UTCNOW,
+                }
+            ],
+        },
+        "open_prs_summary": {
+            "total_count": 0,
+            "prs": [],
+        },
+        "changed_canon_paths_if_available": [
+            "AGENTS.md",
+            "docs/runbooks/CONTROL_REGISTER.md",
+        ],
+        "limitations": [],
+        "safety_boundaries": {
+            "lr_status": "NO-GO",
+            "board_stage_is_live_go": False,
+            "real_money_go": False,
+            "productive_db_writes_allowed": False,
+            "secrets_in_outputs_allowed": False,
+            "trading_state_ingestion_allowed": False,
+        },
+    }
+
+
+def _make_valid_validation() -> dict:
+    return {
+        "schema_version": "validation_report.v1",
+        "status": "PASS",
+        "validator_used": "tools/context/generate_context_refresh_report.py",
+        "blocked_reasons": [],
+        "warnings": [],
+        "artifact_paths": {
+            "context_delta": "/tmp/context_delta.json",
+            "context_refresh_summary": "/tmp/context_refresh_summary.md",
+        },
+        "limitations": [
+            "Report-only: no DB writes, no brain apply, no runtime changes.",
+            "LR remains NO-GO. No Live-Go. No Echtgeld-Go.",
+        ],
+    }
+
+
+def _make_valid_briefing() -> dict:
+    return {
+        "schema_version": "agent_briefing_seed.v1",
+        "generated_at_utc": UTCNOW,
+        "source_commit": "072b740a28586dfd885d80c7bcbc8e82822e2dab",
+        "stale_claims": [],
+        "safety_boundaries": {
+            "lr_status": "NO-GO",
+            "board_stage_is_live_go": False,
+            "real_money_go": False,
+            "productive_db_writes_allowed": False,
+            "secrets_in_outputs_allowed": False,
+            "trading_state_ingestion_allowed": False,
+            "brain_apply_allowed": False,
+        },
+    }
+
+
+@pytest.fixture
+def valid_delta() -> dict:
+    return _make_valid_delta()
+
+
+@pytest.fixture
+def valid_validation() -> dict:
+    return _make_valid_validation()
+
+
+@pytest.fixture
+def valid_briefing() -> dict:
+    return _make_valid_briefing()
+
+
+def test_valid_input_no_drift_produces_empty_or_pass(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    claims = scan_all(valid_delta, valid_validation, valid_briefing)
+    stale = build_stale_claims(
+        claims=claims,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+    assert isinstance(claims, list)
+    assert "claims" in stale
+    assert "summary" in stale
+    assert stale["summary"]["blocking_claims"] == 0
+
+
+def test_ledger_vs_github_drift_detected(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    claims = scan_ledger_vs_github_drift(valid_delta, valid_briefing)
+    assert len(claims) >= 1
+    assert claims[0]["drift_category"] == "ledger_vs_github_drift"
+    assert claims[0]["severity"] == "medium"
+
+
+def test_lr_status_ambiguity_blocks_brain_apply(
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    bad_delta = dict(_make_valid_delta())
+    bad_delta["safety_boundaries"]["lr_status"] = "GO"
+
+    claims = scan_lr_status_ambiguity(bad_delta, valid_validation, valid_briefing)
+    assert len(claims) >= 1
+    for c in claims:
+        assert c["blocks_brain_apply"] is True
+        assert c["severity"] == "high"
+
+
+def test_unknown_high_risk_delta_blocks_brain_apply(
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    bad_delta = dict(_make_valid_delta())
+    bad_delta["limitations"] = ["ECHTGELD-GO detected in upstream"]
+
+    claims = scan_unknown_high_risk_delta(bad_delta, valid_briefing)
+    assert len(claims) >= 1
+    for c in claims:
+        assert c["blocks_brain_apply"] is True
+        assert c["severity"] == "high"
+        assert c["drift_category"] == "unknown_high_risk_delta"
+
+
+def test_stale_onboarding_docs_classified(
+    valid_delta: dict,
+    valid_briefing: dict,
+) -> None:
+    delta_with_onboarding = dict(_make_valid_delta())
+    delta_with_onboarding["changed_canon_paths_if_available"] = [
+        "agents/roles/CODEX.md",
+    ]
+
+    claims = scan_stale_onboarding_docs(delta_with_onboarding, valid_briefing)
+    assert len(claims) >= 1
+    for c in claims:
+        assert c["drift_category"] == "stale_onboarding_docs"
+
+
+def test_stale_agent_bootloader_instructions_classified(
+    valid_delta: dict,
+    valid_briefing: dict,
+) -> None:
+    delta_with_boot = dict(_make_valid_delta())
+    delta_with_boot["changed_canon_paths_if_available"] = [
+        "AGENTS.md",
+        "agents/AGENTS.md",
+    ]
+
+    claims = scan_stale_agent_bootloader_instructions(delta_with_boot, valid_briefing)
+    assert len(claims) >= 1
+    for c in claims:
+        assert c["drift_category"] == "stale_agent_bootloader_instructions"
+
+
+def test_workflow_check_drift_classified(
+    valid_delta: dict,
+    valid_briefing: dict,
+) -> None:
+    bad_validation = dict(_make_valid_validation())
+    bad_validation["status"] = "BLOCKED"
+    bad_validation["blocked_reasons"] = ["Git HEAD resolution failed"]
+
+    claims = scan_workflow_check_drift(bad_validation)
+    assert len(claims) >= 1
+    for c in claims:
+        assert c["drift_category"] == "workflow_check_drift"
+
+
+def test_recommended_follow_up_issues_report_only(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    claims = scan_all(valid_delta, valid_validation, valid_briefing)
+    stale = build_stale_claims(
+        claims=claims,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+    radar = build_impact_radar(
+        stale_claims=stale,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+
+    issues = radar["recommended_follow_up_issues"]
+    assert isinstance(issues, list)
+    for issue in issues:
+        assert "title" in issue
+        assert "reasoning" in issue
+        assert "dedupe_hint" in issue
+        assert "safety_boundary" in issue
+
+
+def test_no_auto_github_writes(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    claims = scan_all(valid_delta, valid_validation, valid_briefing)
+    stale = build_stale_claims(
+        claims=claims,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+    radar = build_impact_radar(
+        stale_claims=stale,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+
+    sb = radar["safety_boundaries"]
+    assert sb["auto_issue_creation_allowed"] is False
+
+
+def test_no_secrets_in_output(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    claims = scan_all(valid_delta, valid_validation, valid_briefing)
+    stale = build_stale_claims(
+        claims=claims,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+
+    json_str = json.dumps(stale, indent=2, ensure_ascii=False)
+    secret_indicators = [
+        "api_key",
+        "api_secret",
+        "REDIS_PASSWORD",
+        "POSTGRES_PASSWORD",
+        "MEXC_API_KEY",
+        "MEXC_API_SECRET",
+        "SECRETS_PATH",
+        "SMTP_PASSWORD",
+        "GRAFANA_PASSWORD",
+    ]
+    for indicator in secret_indicators:
+        assert indicator not in json_str, f"Secret indicator found: {indicator}"
+
+    radar = build_impact_radar(
+        stale_claims=stale,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+    radar_json = json.dumps(radar, indent=2, ensure_ascii=False)
+    for indicator in secret_indicators:
+        assert (
+            indicator not in radar_json
+        ), f"Secret indicator found in radar: {indicator}"
+
+
+def test_no_live_echtgeld_claims_in_output(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    claims = scan_all(valid_delta, valid_validation, valid_briefing)
+    stale = build_stale_claims(
+        claims=claims,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+    radar = build_impact_radar(
+        stale_claims=stale,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+
+    sb = radar["safety_boundaries"]
+    assert sb["lr_status"] == "NO-GO"
+    assert sb["real_money_go"] is False
+    assert sb["board_stage_is_live_go"] is False
+
+    md = build_impact_radar_md(radar)
+    assert "NO-GO" in md
+    assert "Echtgeld" not in md or "LR remains NO-GO" in md
+
+
+def test_deterministic_output_shape(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    claims1 = scan_all(valid_delta, valid_validation, valid_briefing)
+    stale1 = build_stale_claims(
+        claims=claims1,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+    radar1 = build_impact_radar(
+        stale_claims=stale1,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+
+    claims2 = scan_all(valid_delta, valid_validation, valid_briefing)
+    stale2 = build_stale_claims(
+        claims=claims2,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+    radar2 = build_impact_radar(
+        stale_claims=stale2,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+
+    json1 = json.dumps(radar1, sort_keys=True)
+    json2 = json.dumps(radar2, sort_keys=True)
+    assert json1 == json2, "Drift radar output is not deterministic"
+
+
+def test_json_serializable(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    claims = scan_all(valid_delta, valid_validation, valid_briefing)
+    stale = build_stale_claims(
+        claims=claims,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+    radar = build_impact_radar(
+        stale_claims=stale,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+
+    for obj, name in [(stale, "stale_claims"), (radar, "impact_radar")]:
+        json_str = json.dumps(obj, indent=2, ensure_ascii=False)
+        parsed = json.loads(json_str)
+        assert isinstance(parsed, dict), f"{name} is not serializable"
+
+
+def test_missing_inputs_degrades() -> None:
+    claims = scan_all(None, None, None)
+    stale = build_stale_claims(
+        claims=claims,
+        source_artifacts={},
+        utc_now=UTCNOW,
+        degraded=True,
+        limitations=["Both inputs missing"],
+    )
+    assert stale["degraded"] is True
+    assert stale["summary"]["total_claims"] == 0
+
+
+def test_stale_claims_json_has_required_fields(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    claims = scan_all(valid_delta, valid_validation, valid_briefing)
+    stale = build_stale_claims(
+        claims=claims,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+
+    assert "schema_version" in stale
+    assert "generated_at_utc" in stale
+    assert "source_artifacts" in stale
+    assert "claims" in stale
+    assert "summary" in stale
+    assert "degraded" in stale
+    assert "limitations" in stale
+
+    assert stale["schema_version"] == SCHEMA_VERSION
+
+    if stale["claims"]:
+        sample = stale["claims"][0]
+        assert "claim" in sample
+        assert "drift_category" in sample
+        assert "severity" in sample
+        assert "source_ref" in sample
+        assert "current_truth_ref" in sample
+        assert "status" in sample
+        assert "recommended_action" in sample
+        assert "blocks_brain_apply" in sample
+
+
+def test_impact_radar_md_has_required_sections(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    claims = scan_all(valid_delta, valid_validation, valid_briefing)
+    stale = build_stale_claims(
+        claims=claims,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+    radar = build_impact_radar(
+        stale_claims=stale,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+    md = build_impact_radar_md(radar)
+
+    sections = [
+        "# Context Drift / Impact Radar",
+        "## Source Artifacts",
+        "## High-Risk Drift",
+        "## Brain Apply Blockers",
+        "## Stale Claims",
+        "## Canon / Ledger / GitHub Conflicts",
+        "## Workflow / Check Drift",
+        "## Recommended Follow-up Issues",
+        "## Safety Boundaries",
+        "## Limitations",
+    ]
+    for section in sections:
+        assert section in md, f"Missing section: {section}"
+
+    assert "NO-GO" in md
+    assert "LR remains NO-GO" in md or "lr_status" in md
+
+
+def test_scan_canon_pointer_drift(
+    valid_delta: dict,
+    valid_briefing: dict,
+) -> None:
+    claims = scan_canon_pointer_drift(valid_delta, valid_briefing)
+    assert isinstance(claims, list)
+    for c in claims:
+        assert c["drift_category"] == "canon_pointer_drift"
+
+
+def test_scan_stale_architecture_docs(
+    valid_delta: dict,
+    valid_briefing: dict,
+) -> None:
+    delta_with_arch = dict(_make_valid_delta())
+    delta_with_arch["changed_canon_paths_if_available"] = [
+        "knowledge/CDB_KNOWLEDGE_HUB.md",
+    ]
+
+    claims = scan_stale_architecture_docs(delta_with_arch, valid_briefing)
+    assert len(claims) >= 1
+    for c in claims:
+        assert c["drift_category"] == "stale_architecture_docs"
+
+
+def test_severity_mapping() -> None:
+    assert _severity_for_category("lr_status_ambiguity") == "high"
+    assert _severity_for_category("unknown_high_risk_delta") == "high"
+    assert _severity_for_category("canon_pointer_drift") == "medium"
+    assert _severity_for_category("stale_onboarding_docs") == "medium"
+
+
+def test_blocks_brain_apply_logic() -> None:
+    assert _blocks_brain_apply("high", "canon_pointer_drift", "something") is True
+    assert _blocks_brain_apply("medium", "lr_status_ambiguity", "something") is True
+    assert _blocks_brain_apply("medium", "unknown_high_risk_delta", "something") is True
+    assert _blocks_brain_apply("medium", "stale_onboarding_docs", "live-go") is True
+    assert (
+        _blocks_brain_apply("medium", "stale_onboarding_docs", "documentation change")
+        is False
+    )
+
+
+def test_secret_indicator_detection() -> None:
+    text = "some text with api_key=123 and password=secret"
+    found = _find_secret_indicators(text)
+    assert "api_key" in found
+    assert "password=" in found
+
+    clean = "no secrets here"
+    assert _find_secret_indicators(clean) == []
+
+
+def test_degraded_mode_no_delta(
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    claims = scan_all(None, valid_validation, valid_briefing)
+    stale = build_stale_claims(
+        claims=claims,
+        source_artifacts={"validation": "v1"},
+        utc_now=UTCNOW,
+        degraded=True,
+        limitations=["delta not available"],
+    )
+    assert stale["degraded"] is True
+    assert "delta not available" in stale["limitations"]
+
+
+def test_degraded_mode_no_validation(
+    valid_delta: dict,
+    valid_briefing: dict,
+) -> None:
+    claims = scan_all(valid_delta, None, valid_briefing)
+    stale = build_stale_claims(
+        claims=claims,
+        source_artifacts={"delta": "v1"},
+        utc_now=UTCNOW,
+        degraded=True,
+        limitations=["validation not available"],
+    )
+    assert stale["degraded"] is True
+
+
+def test_blocks_brain_apply_summary(
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    bad_delta = dict(_make_valid_delta())
+    bad_delta["safety_boundaries"]["lr_status"] = "GO"
+
+    claims = scan_all(bad_delta, valid_validation, valid_briefing)
+    stale = build_stale_claims(
+        claims=claims,
+        source_artifacts={"delta": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+
+    assert stale["summary"]["blocks_brain_apply"] is True
+    assert stale["summary"]["blocking_claims"] >= 1
+
+
+def test_follow_up_not_auto_created(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    claims = scan_all(valid_delta, valid_validation, valid_briefing)
+    stale = build_stale_claims(
+        claims=claims,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+    radar = build_impact_radar(
+        stale_claims=stale,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+
+    issues = radar["recommended_follow_up_issues"]
+    assert isinstance(issues, list)
+    for issue in issues:
+        assert "dedupe_hint" in issue
+        assert "Do not auto-create" not in json.dumps(issue)
+    assert radar["safety_boundaries"]["auto_issue_creation_allowed"] is False
+
+
+def test_drift_categories_enum() -> None:
+    expected = [
+        "canon_pointer_drift",
+        "ledger_vs_github_drift",
+        "lr_status_ambiguity",
+        "stale_architecture_docs",
+        "stale_onboarding_docs",
+        "stale_agent_bootloader_instructions",
+        "workflow_check_drift",
+        "unknown_high_risk_delta",
+    ]
+    assert DRIFT_CATEGORIES == expected
+
+
+def test_impact_radar_json_schema(
+    valid_delta: dict,
+    valid_validation: dict,
+    valid_briefing: dict,
+) -> None:
+    claims = scan_all(valid_delta, valid_validation, valid_briefing)
+    stale = build_stale_claims(
+        claims=claims,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+    radar = build_impact_radar(
+        stale_claims=stale,
+        source_artifacts={"test": "v1"},
+        utc_now=UTCNOW,
+        degraded=False,
+        limitations=[],
+    )
+
+    assert radar["schema_version"] == RADAR_SCHEMA_VERSION
+    assert "title" in radar
+    assert "high_risk_drift" in radar
+    assert "brain_apply_blockers" in radar
+    assert "brain_apply_blocked" in radar
+    assert "stale_claims" in radar
+    assert "by_category" in radar
+    assert "canon_ledger_github_conflicts" in radar
+    assert "workflow_check_drift" in radar
+    assert "recommended_follow_up_issues" in radar
+    assert "safety_boundaries" in radar
+    assert "degraded" in radar
+    assert "limitations" in radar
+
+
+def test_workflow_check_blocked_blocks_brain(
+    valid_delta: dict,
+    valid_briefing: dict,
+) -> None:
+    bad_validation = dict(_make_valid_validation())
+    bad_validation["status"] = "BLOCKED"
+    bad_validation["blocked_reasons"] = ["Git HEAD resolution failed"]
+
+    claims = scan_workflow_check_drift(bad_validation)
+    assert len(claims) >= 1
+    for c in claims:
+        assert c["blocks_brain_apply"] is True
+        assert c["severity"] == "high"
+
+
+def test_workflow_check_warning_does_not_block(
+    valid_delta: dict,
+    valid_briefing: dict,
+) -> None:
+    warn_validation = dict(_make_valid_validation())
+    warn_validation["warnings"] = ["No open issues or PRs found"]
+
+    claims = scan_workflow_check_drift(warn_validation)
+    assert len(claims) >= 1
+    for c in claims:
+        assert c["drift_category"] == "workflow_check_drift"
+        if c["severity"] == "medium":
+            assert c["blocks_brain_apply"] is False

--- a/tools/context/generate_context_drift_radar.py
+++ b/tools/context/generate_context_drift_radar.py
@@ -1,0 +1,908 @@
+"""Read-only CDB Context Drift Radar.
+
+Scans context refresh artifacts for stale documentation, contradictions between
+canon/ledger/GitHub signals, and high-risk drift that blocks Brain Apply (#3289).
+
+Inputs (from context refresh pipeline):
+  - context_delta.json          (#3287)
+  - validation_report.json      (#3287)
+  - agent_briefing_seed.json    (#3290, optional)
+
+Outputs:
+  - stale_claims.json  (machine-readable)
+  - impact_radar.md    (human-readable)
+  - impact_radar.json  (machine-readable, optional via --json)
+
+Usage:
+    python tools/context/generate_context_drift_radar.py \\
+        --delta <path> --validation <path> [--briefing <path>] [--output-dir <dir>]
+    python tools/context/generate_context_drift_radar.py --help
+
+Exit codes:
+    0 - radar generated (success or degraded)
+    1 - blocked (high-risk drift detected, Brain Apply blocked)
+    2 - unexpected error
+
+No DB writes. No secrets. No runtime changes. LR remains NO-GO.
+No Brain Apply (#3289). No Onboarding (#3292).
+#3291
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+SCHEMA_VERSION = "stale_claims.v1"
+RADAR_SCHEMA_VERSION = "impact_radar.v1"
+
+DRIFT_CATEGORIES = [
+    "canon_pointer_drift",
+    "ledger_vs_github_drift",
+    "lr_status_ambiguity",
+    "stale_architecture_docs",
+    "stale_onboarding_docs",
+    "stale_agent_bootloader_instructions",
+    "workflow_check_drift",
+    "unknown_high_risk_delta",
+]
+
+HIGH_SEVERITY_CATEGORIES: set[str] = {
+    "lr_status_ambiguity",
+    "unknown_high_risk_delta",
+}
+
+BRAIN_APPLY_BLOCKING_CLAIM_PATTERNS: list[str] = [
+    "live readiness",
+    "live-go",
+    "echtgeld-go",
+    "real money",
+    "trade-capable",
+    "orders",
+    "fills",
+    "positions",
+    "live-risk-state",
+    "api_key",
+    "api_secret",
+    "password",
+    "token",
+    "secret",
+]
+
+CANON_POINTER_PATHS: list[str] = [
+    "docs/meta/WORKING_REPO_CANON.md",
+    "AGENTS.md",
+    "agents/AGENTS.md",
+]
+
+ONBOARDING_PATHS: list[str] = [
+    "agents/roles/CODEX.md",
+    "knowledge/SYSTEM.CONTEXT.md",
+]
+
+ARCHITECTURE_PATHS: list[str] = [
+    "docs/architecture/",
+    "knowledge/CDB_KNOWLEDGE_HUB.md",
+]
+
+BOOTLOADER_PATTERNS: list[str] = [
+    "bootloader",
+    "Read Order",
+    "read order",
+    "Context Brain Preflight",
+    "Brain Evidence Gate",
+    "session-start",
+]
+
+
+def read_json(path: str | Path) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _severity_for_category(category: str) -> str:
+    if category in HIGH_SEVERITY_CATEGORIES:
+        return "high"
+    return "medium"
+
+
+def _blocks_brain_apply(severity: str, category: str, claim_text: str) -> bool:
+    if severity == "high":
+        return True
+    if category in ("lr_status_ambiguity", "unknown_high_risk_delta"):
+        return True
+    lower = claim_text.lower()
+    for pattern in BRAIN_APPLY_BLOCKING_CLAIM_PATTERNS:
+        if pattern in lower:
+            return True
+    return False
+
+
+def _find_secret_indicators(text: str) -> list[str]:
+    found: list[str] = []
+    indicators = [
+        "api_key",
+        "api_secret",
+        "REDIS_PASSWORD",
+        "POSTGRES_PASSWORD",
+        "MEXC_API_KEY",
+        "MEXC_API_SECRET",
+        "SECRETS_PATH",
+        "SMTP_PASSWORD",
+        "GRAFANA_PASSWORD",
+        "secret=",
+        "password=",
+        "token=",
+    ]
+    for ind in indicators:
+        if ind in text:
+            found.append(ind)
+    return found
+
+
+def _collect_source_artifacts(
+    delta: dict[str, Any] | None,
+    validation: dict[str, Any] | None,
+    briefing: dict[str, Any] | None,
+) -> dict[str, Any]:
+    artifacts: dict[str, Any] = {}
+    if delta:
+        artifacts["context_delta"] = delta.get("schema_version", "unknown")
+    if validation:
+        artifacts["validation_report"] = validation.get("schema_version", "unknown")
+    if briefing:
+        artifacts["agent_briefing_seed"] = briefing.get("schema_version", "unknown")
+    return artifacts
+
+
+def scan_canon_pointer_drift(
+    delta: dict[str, Any] | None,
+    briefing: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    claims: list[dict[str, Any]] = []
+    changed = set(delta.get("changed_canon_paths_if_available", []) if delta else [])
+    for canon_path in CANON_POINTER_PATHS:
+        if canon_path in changed:
+            claims.append(
+                {
+                    "claim": f"Canon pointer file changed: {canon_path}",
+                    "drift_category": "canon_pointer_drift",
+                    "severity": "medium",
+                    "source_ref": f"context_delta.changed_canon_paths_if_available",
+                    "current_truth_ref": canon_path,
+                    "status": "changed",
+                    "recommended_action": f"Review {canon_path} for pointer consistency",
+                    "blocks_brain_apply": False,
+                }
+            )
+    return claims
+
+
+def scan_ledger_vs_github_drift(
+    delta: dict[str, Any] | None,
+    briefing: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    claims: list[dict[str, Any]] = []
+    if not delta:
+        return claims
+
+    issues = delta.get("open_issues_summary", {}).get("issues", [])
+    for issue in issues:
+        title = issue.get("title", "")
+        if "CONTEXT" in title or "DRIFT" in title:
+            claims.append(
+                {
+                    "claim": f"Open context/drift issue: #{issue['number']} {title}",
+                    "drift_category": "ledger_vs_github_drift",
+                    "severity": "medium",
+                    "source_ref": f"context_delta.open_issues_summary.issues[#{issue['number']}]",
+                    "current_truth_ref": f"https://github.com/jannekbuengener/Claire_de_Binare/issues/{issue['number']}",
+                    "status": "open",
+                    "recommended_action": f"Resolve #{issue['number']} before asserting ledger/GitHub alignment",
+                    "blocks_brain_apply": False,
+                }
+            )
+
+    return claims
+
+
+def scan_lr_status_ambiguity(
+    delta: dict[str, Any] | None,
+    validation: dict[str, Any] | None,
+    briefing: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    claims: list[dict[str, Any]] = []
+    if not delta:
+        return claims
+    safety = delta.get("safety_boundaries", {})
+    if safety.get("lr_status") != "NO-GO":
+        claims.append(
+            {
+                "claim": f"LR status in context_delta is not NO-GO: {safety.get('lr_status')}",
+                "drift_category": "lr_status_ambiguity",
+                "severity": "high",
+                "source_ref": "context_delta.safety_boundaries.lr_status",
+                "current_truth_ref": "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                "status": "blocking",
+                "recommended_action": "Revert lr_status to NO-GO; only LR-SSOT can change this.",
+                "blocks_brain_apply": True,
+            }
+        )
+
+    if briefing:
+        briefing_safety = briefing.get("safety_boundaries", {})
+        if briefing_safety.get("lr_status") != "NO-GO":
+            claims.append(
+                {
+                    "claim": f"LR status in agent_briefing_seed is not NO-GO: {briefing_safety.get('lr_status')}",
+                    "drift_category": "lr_status_ambiguity",
+                    "severity": "high",
+                    "source_ref": "agent_briefing_seed.safety_boundaries.lr_status",
+                    "current_truth_ref": "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md",
+                    "status": "blocking",
+                    "recommended_action": "Revert briefing lr_status to NO-GO.",
+                    "blocks_brain_apply": True,
+                }
+            )
+
+    return claims
+
+
+def scan_stale_architecture_docs(
+    delta: dict[str, Any] | None,
+    briefing: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    claims: list[dict[str, Any]] = []
+    changed = set(delta.get("changed_canon_paths_if_available", []) if delta else [])
+    for arch_path in ARCHITECTURE_PATHS:
+        if arch_path in changed:
+            claims.append(
+                {
+                    "claim": f"Architecture or knowledge hub file changed: {arch_path}. Review for stale references.",
+                    "drift_category": "stale_architecture_docs",
+                    "severity": "medium",
+                    "source_ref": f"context_delta.changed_canon_paths_if_available",
+                    "current_truth_ref": arch_path,
+                    "status": "needs_review",
+                    "recommended_action": f"Audit {arch_path} for outdated architecture claims",
+                    "blocks_brain_apply": False,
+                }
+            )
+    return claims
+
+
+def scan_stale_onboarding_docs(
+    delta: dict[str, Any] | None,
+    briefing: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    claims: list[dict[str, Any]] = []
+    changed = set(delta.get("changed_canon_paths_if_available", []) if delta else [])
+    for ob_path in ONBOARDING_PATHS:
+        if ob_path in changed:
+            claims.append(
+                {
+                    "claim": f"Onboarding-related file changed: {ob_path}. Onboarding docs may be stale.",
+                    "drift_category": "stale_onboarding_docs",
+                    "severity": "medium",
+                    "source_ref": f"context_delta.changed_canon_paths_if_available",
+                    "current_truth_ref": ob_path,
+                    "status": "needs_review",
+                    "recommended_action": f"Review {ob_path} for onboarding accuracy",
+                    "blocks_brain_apply": False,
+                }
+            )
+    return claims
+
+
+def scan_stale_agent_bootloader_instructions(
+    delta: dict[str, Any] | None,
+    briefing: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    claims: list[dict[str, Any]] = []
+    changed = set(delta.get("changed_canon_paths_if_available", []) if delta else [])
+
+    for boot_path in set(changed):
+        if any(
+            boot_path.startswith(p)
+            for p in ["AGENTS.md", "agents/", ".cursor/", ".opencode/", ".claude/"]
+        ):
+            claims.append(
+                {
+                    "claim": f"Agent or bootloader surface changed: {boot_path}. Bootloader instructions may be stale.",
+                    "drift_category": "stale_agent_bootloader_instructions",
+                    "severity": "medium",
+                    "source_ref": f"context_delta.changed_canon_paths_if_available",
+                    "current_truth_ref": boot_path,
+                    "status": "needs_review",
+                    "recommended_action": f"Audit {boot_path} for bootloader instruction drift",
+                    "blocks_brain_apply": False,
+                }
+            )
+
+    if briefing:
+        stale = briefing.get("stale_claims", [])
+        for s in stale:
+            text = s.get("claim", "")
+            for pattern in BOOTLOADER_PATTERNS:
+                if pattern in text:
+                    claims.append(
+                        {
+                            "claim": text,
+                            "drift_category": "stale_agent_bootloader_instructions",
+                            "severity": "medium",
+                            "source_ref": "agent_briefing_seed.stale_claims",
+                            "current_truth_ref": s.get("source", ""),
+                            "status": "stale_or_unknown",
+                            "recommended_action": "Resolve bootloader/read-order claim before Brain Apply",
+                            "blocks_brain_apply": False,
+                        }
+                    )
+                    break
+
+    return claims
+
+
+def scan_workflow_check_drift(
+    validation: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    claims: list[dict[str, Any]] = []
+    if not validation:
+        return claims
+
+    status = validation.get("status", "unknown")
+    blocked = validation.get("blocked_reasons", [])
+    warnings = validation.get("warnings", [])
+
+    if status == "BLOCKED":
+        claims.append(
+            {
+                "claim": f"Validation report status is BLOCKED: {'; '.join(blocked)}",
+                "drift_category": "workflow_check_drift",
+                "severity": "high",
+                "source_ref": "validation_report.status",
+                "current_truth_ref": "validation_report.blocked_reasons",
+                "status": "blocking",
+                "recommended_action": "Resolve validation blockages before proceeding",
+                "blocks_brain_apply": True,
+            }
+        )
+
+    for warning in warnings:
+        claims.append(
+            {
+                "claim": f"Validation warning: {warning}",
+                "drift_category": "workflow_check_drift",
+                "severity": "medium",
+                "source_ref": "validation_report.warnings",
+                "current_truth_ref": "",
+                "status": "warning",
+                "recommended_action": f"Review: {warning}",
+                "blocks_brain_apply": False,
+            }
+        )
+
+    return claims
+
+
+def scan_unknown_high_risk_delta(
+    delta: dict[str, Any] | None,
+    briefing: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    claims: list[dict[str, Any]] = []
+    if not delta:
+        return claims
+
+    limitations = delta.get("limitations", [])
+    for lim in limitations:
+        lower = lim.lower()
+        for pattern in BRAIN_APPLY_BLOCKING_CLAIM_PATTERNS:
+            if pattern in lower:
+                claims.append(
+                    {
+                        "claim": f"High-risk limitation: {lim}",
+                        "drift_category": "unknown_high_risk_delta",
+                        "severity": "high",
+                        "source_ref": "context_delta.limitations",
+                        "current_truth_ref": "",
+                        "status": "blocking",
+                        "recommended_action": "Resolve limitation before proceeding with Brain Apply",
+                        "blocks_brain_apply": True,
+                    }
+                )
+                break
+
+    return claims
+
+
+def scan_all(
+    delta: dict[str, Any] | None,
+    validation: dict[str, Any] | None,
+    briefing: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    all_claims: list[dict[str, Any]] = []
+    all_claims.extend(scan_canon_pointer_drift(delta, briefing))
+    all_claims.extend(scan_ledger_vs_github_drift(delta, briefing))
+    all_claims.extend(scan_lr_status_ambiguity(delta, validation, briefing))
+    all_claims.extend(scan_stale_architecture_docs(delta, briefing))
+    all_claims.extend(scan_stale_onboarding_docs(delta, briefing))
+    all_claims.extend(scan_stale_agent_bootloader_instructions(delta, briefing))
+    all_claims.extend(scan_workflow_check_drift(validation))
+    all_claims.extend(scan_unknown_high_risk_delta(delta, briefing))
+    return all_claims
+
+
+def build_stale_claims(
+    claims: list[dict[str, Any]],
+    source_artifacts: dict[str, Any],
+    utc_now: str,
+    degraded: bool,
+    limitations: list[str],
+) -> dict[str, Any]:
+    blocks_brain = any(c.get("blocks_brain_apply", False) for c in claims)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": utc_now,
+        "source_artifacts": source_artifacts,
+        "claims": claims,
+        "summary": {
+            "total_claims": len(claims),
+            "blocking_claims": sum(1 for c in claims if c.get("blocks_brain_apply")),
+            "high_severity": sum(1 for c in claims if c.get("severity") == "high"),
+            "medium_severity": sum(1 for c in claims if c.get("severity") == "medium"),
+            "low_severity": sum(1 for c in claims if c.get("severity") == "low"),
+            "blocks_brain_apply": blocks_brain,
+        },
+        "degraded": degraded,
+        "limitations": limitations,
+    }
+
+
+def build_impact_radar(
+    stale_claims: dict[str, Any],
+    source_artifacts: dict[str, Any],
+    utc_now: str,
+    degraded: bool,
+    limitations: list[str],
+) -> dict[str, Any]:
+    claims = stale_claims.get("claims", [])
+    summary = stale_claims.get("summary", {})
+    blocks_brain = summary.get("blocks_brain_apply", False)
+
+    by_category: dict[str, list[dict[str, Any]]] = {}
+    for c in claims:
+        cat = c.get("drift_category", "unknown")
+        by_category.setdefault(cat, []).append(c)
+
+    blocking = [c for c in claims if c.get("blocks_brain_apply")]
+    high_risk = [c for c in claims if c.get("severity") == "high"]
+
+    follow_up_recommendations: list[dict[str, Any]] = []
+    if blocks_brain:
+        follow_up_recommendations.append(
+            {
+                "title": "Resolve Brain Apply blockers from drift radar",
+                "reasoning": f"{summary.get('blocking_claims', 0)} claims block Brain Apply (#3289)",
+                "priority": "high",
+                "safety_boundary": "Brain Apply must not proceed while blocks_brain_apply claims exist",
+                "dedupe_hint": "Check if #3289 already tracks these blockers",
+            }
+        )
+    if high_risk:
+        follow_up_recommendations.append(
+            {
+                "title": "Investigate high-risk drift signals",
+                "reasoning": f"{len(high_risk)} high-severity claims detected",
+                "priority": "high",
+                "safety_boundary": "High-risk claims must be resolved before any live-adjacent work",
+                "dedupe_hint": "Do not auto-create; use this report to triage",
+            }
+        )
+    if any(c.get("drift_category") == "stale_architecture_docs" for c in claims):
+        follow_up_recommendations.append(
+            {
+                "title": "Update stale architecture documentation",
+                "reasoning": "Architecture or knowledge hub files changed",
+                "priority": "medium",
+                "safety_boundary": "Stale architecture docs may mislead agents",
+                "dedupe_hint": "Verify no existing docs-maintenance issue is open",
+            }
+        )
+    if any(c.get("drift_category") == "stale_onboarding_docs" for c in claims):
+        follow_up_recommendations.append(
+            {
+                "title": "Refresh onboarding documentation",
+                "reasoning": "Onboarding-related files changed",
+                "priority": "medium",
+                "safety_boundary": "Onboarding docs drift affects agent session quality",
+                "dedupe_hint": "Onboarding scenario (#3292) is the planned slot for this",
+            }
+        )
+    if any(
+        c.get("drift_category") == "stale_agent_bootloader_instructions" for c in claims
+    ):
+        follow_up_recommendations.append(
+            {
+                "title": "Audit agent bootloader instructions for drift",
+                "reasoning": "Bootloader surfaces changed since last refresh",
+                "priority": "medium",
+                "safety_boundary": "Bootloader drift can cause agent confusion",
+                "dedupe_hint": "Check AGENTS.md and agent role files for consistency",
+            }
+        )
+    if any(c.get("drift_category") == "workflow_check_drift" for c in claims):
+        follow_up_recommendations.append(
+            {
+                "title": "Resolve workflow/check drift",
+                "reasoning": "Validation report contains blockages or warnings",
+                "priority": (
+                    "high"
+                    if any(
+                        c.get("severity") == "high"
+                        and c.get("drift_category") == "workflow_check_drift"
+                        for c in claims
+                    )
+                    else "medium"
+                ),
+                "safety_boundary": "Workflow check drift may indicate CI/reporting failures",
+                "dedupe_hint": "Check CI status before creating new issue",
+            }
+        )
+
+    return {
+        "schema_version": RADAR_SCHEMA_VERSION,
+        "generated_at_utc": utc_now,
+        "title": "CDB Context Drift / Impact Radar",
+        "source_artifacts": source_artifacts,
+        "high_risk_drift": high_risk,
+        "brain_apply_blockers": blocking,
+        "brain_apply_blocked": blocks_brain,
+        "stale_claims": claims,
+        "by_category": by_category,
+        "canon_ledger_github_conflicts": {
+            "ledger_vs_github": [
+                c for c in claims if c.get("drift_category") == "ledger_vs_github_drift"
+            ],
+            "canon_pointer": [
+                c for c in claims if c.get("drift_category") == "canon_pointer_drift"
+            ],
+            "lr_ambiguity": [
+                c for c in claims if c.get("drift_category") == "lr_status_ambiguity"
+            ],
+        },
+        "workflow_check_drift": [
+            c for c in claims if c.get("drift_category") == "workflow_check_drift"
+        ],
+        "recommended_follow_up_issues": follow_up_recommendations,
+        "safety_boundaries": {
+            "lr_status": "NO-GO",
+            "board_stage_is_live_go": False,
+            "real_money_go": False,
+            "productive_db_writes_allowed": False,
+            "secrets_in_outputs_allowed": False,
+            "trading_state_ingestion_allowed": False,
+            "brain_apply_blocked": blocks_brain,
+            "auto_issue_creation_allowed": False,
+        },
+        "degraded": degraded,
+        "limitations": limitations,
+    }
+
+
+def build_impact_radar_md(radar: dict[str, Any]) -> str:
+    lines: list[str] = []
+
+    lines.append("# Context Drift / Impact Radar")
+    lines.append("")
+    lines.append(f"- **Generated at (UTC):** {radar['generated_at_utc']}")
+    lines.append(f"- **Schema version:** {radar['schema_version']}")
+    if radar["degraded"]:
+        lines.append(
+            "- **Status: DEGRADED** — one or more input artifacts were missing or unreadable"
+        )
+    if radar["brain_apply_blocked"]:
+        lines.append("- **Brain Apply: BLOCKED** — high-risk drift prevents #3289")
+    else:
+        lines.append("- **Brain Apply: NOT BLOCKED** — no high-risk drift detected")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Source Artifacts")
+    lines.append("")
+    for name, version in radar["source_artifacts"].items():
+        lines.append(f"- **{name}:** {version}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## High-Risk Drift")
+    lines.append("")
+    high = radar["high_risk_drift"]
+    if high:
+        for c in high:
+            lines.append(
+                f"- [{c['drift_category']}] {c['claim']} "
+                f"(severity: {c['severity']}, blocks_brain_apply: {c['blocks_brain_apply']})"
+            )
+    else:
+        lines.append("- (none detected)")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Brain Apply Blockers")
+    lines.append("")
+    blockers = radar["brain_apply_blockers"]
+    if blockers:
+        for c in blockers:
+            lines.append(
+                f"- [{c['drift_category']}] {c['claim']} " f"(status: {c['status']})"
+            )
+        lines.append("")
+        lines.append(
+            "**Verdict:** Brain Apply (#3289) is BLOCKED until these claims are resolved."
+        )
+    else:
+        lines.append("- (none detected)")
+        lines.append("")
+        lines.append("**Verdict:** Brain Apply (#3289) is NOT BLOCKED by drift radar.")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Stale Claims")
+    lines.append("")
+    stale = radar["stale_claims"]
+    if stale:
+        for c in stale:
+            lines.append(
+                f"- [{c['drift_category']}] {c['claim']} "
+                f"(severity: {c['severity']}, recommended: {c.get('recommended_action', 'review')})"
+            )
+    else:
+        lines.append("- (none detected)")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Canon / Ledger / GitHub Conflicts")
+    lines.append("")
+    conflicts = radar["canon_ledger_github_conflicts"]
+    ledger = conflicts["ledger_vs_github"]
+    canon = conflicts["canon_pointer"]
+    lr = conflicts["lr_ambiguity"]
+    lines.append(f"- **Ledger vs GitHub:** {len(ledger)} claim(s)")
+    for c in ledger:
+        lines.append(f"  - {c['claim']}")
+    lines.append(f"- **Canon pointer drift:** {len(canon)} claim(s)")
+    for c in canon:
+        lines.append(f"  - {c['claim']}")
+    lines.append(f"- **LR status ambiguity:** {len(lr)} claim(s)")
+    for c in lr:
+        lines.append(f"  - {c['claim']}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Workflow / Check Drift")
+    lines.append("")
+    wf = radar["workflow_check_drift"]
+    if wf:
+        for c in wf:
+            lines.append(f"- [{c['status']}] {c['claim']}")
+    else:
+        lines.append("- (none detected)")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Recommended Follow-up Issues")
+    lines.append("")
+    issues = radar["recommended_follow_up_issues"]
+    if issues:
+        for rec in issues:
+            lines.append(f"- **{rec['title']}**")
+            lines.append(f"  - Reasoning: {rec['reasoning']}")
+            lines.append(f"  - Priority: {rec['priority']}")
+            lines.append(f"  - Safety boundary: {rec['safety_boundary']}")
+            lines.append(f"  - Dedupe hint: {rec['dedupe_hint']}")
+    else:
+        lines.append("- (none recommended)")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Safety Boundaries")
+    lines.append("")
+    for key, val in radar["safety_boundaries"].items():
+        lines.append(f"- **{key}:** {val}")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append("## Limitations")
+    lines.append("")
+    for lim in radar["limitations"]:
+        lines.append(f"- {lim}")
+    if not radar["limitations"]:
+        lines.append("- (none)")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    lines.append(
+        "*This is a read-only drift detection artifact. "
+        "It does not authorize live trading, runtime changes, DB writes, "
+        "or any Echtgeld activity. LR remains NO-GO. "
+        "Brain Apply (#3289) and Onboarding (#3292) are separate follow-up slices. "
+        "Follow-up issues are recommendations only — not auto-created.*"
+    )
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only CDB Context Drift Radar (#3291)",
+    )
+    parser.add_argument(
+        "--delta",
+        required=True,
+        help="Path to context_delta.json",
+    )
+    parser.add_argument(
+        "--validation",
+        required=True,
+        help="Path to validation_report.json",
+    )
+    parser.add_argument(
+        "--briefing",
+        default=None,
+        help="Path to agent_briefing_seed.json (optional)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=".",
+        help="Output directory for generated files (default: current dir)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="emit_json",
+        help="Also emit impact_radar.json (machine-readable)",
+    )
+    args = parser.parse_args()
+
+    utc_now = cdb_utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    degraded = False
+    limitations: list[str] = []
+
+    delta: dict[str, Any] | None = None
+    validation: dict[str, Any] | None = None
+    briefing: dict[str, Any] | None = None
+
+    try:
+        delta = read_json(args.delta)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"[WARN] Could not read context_delta.json: {e}", file=sys.stderr)
+        degraded = True
+        limitations.append(f"context_delta.json not available: {e}")
+
+    try:
+        validation = read_json(args.validation)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"[WARN] Could not read validation_report.json: {e}", file=sys.stderr)
+        degraded = True
+        limitations.append(f"validation_report.json not available: {e}")
+
+    if args.briefing:
+        try:
+            briefing = read_json(args.briefing)
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            print(
+                f"[WARN] Could not read agent_briefing_seed.json: {e}", file=sys.stderr
+            )
+            degraded = True
+            limitations.append(f"agent_briefing_seed.json not available: {e}")
+
+    source_artifacts = _collect_source_artifacts(delta, validation, briefing)
+
+    if delta is None and validation is None:
+        print(
+            "[FAIL] Both context_delta.json and validation_report.json are required. Aborting.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if delta is None:
+        limitations.append("context_delta.json missing — some drift categories skipped")
+    if validation is None:
+        limitations.append(
+            "validation_report.json missing — some drift categories skipped"
+        )
+
+    secret_warnings: list[str] = []
+    for artifact_name, artifact in [
+        ("context_delta", delta),
+        ("validation_report", validation),
+        ("agent_briefing_seed", briefing),
+    ]:
+        if artifact:
+            text = json.dumps(artifact)
+            found = _find_secret_indicators(text)
+            if found:
+                secret_warnings.append(
+                    f"Secret indicators found in {artifact_name}: {found}"
+                )
+
+    if secret_warnings:
+        for sw in secret_warnings:
+            print(f"[SECRET WARNING] {sw}", file=sys.stderr)
+            limitations.append(sw)
+
+    claims = scan_all(delta, validation, briefing)
+    stale_claims = build_stale_claims(
+        claims=claims,
+        source_artifacts=source_artifacts,
+        utc_now=utc_now,
+        degraded=degraded,
+        limitations=list(limitations),
+    )
+
+    radar = build_impact_radar(
+        stale_claims=stale_claims,
+        source_artifacts=source_artifacts,
+        utc_now=utc_now,
+        degraded=degraded,
+        limitations=list(limitations),
+    )
+
+    claims_path = output_dir / "stale_claims.json"
+    claims_path.write_text(
+        json.dumps(stale_claims, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    md_path = output_dir / "impact_radar.md"
+    md_path.write_text(build_impact_radar_md(radar), encoding="utf-8")
+
+    json_path: Path | None = None
+    if args.emit_json:
+        json_path = output_dir / "impact_radar.json"
+        json_path.write_text(
+            json.dumps(radar, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+    blocks_brain = stale_claims["summary"]["blocks_brain_apply"]
+    exit_code = 1 if blocks_brain else (1 if degraded else 0)
+
+    print(
+        f"[{'BLOCKED' if blocks_brain else 'DEGRADED' if degraded else 'PASS'}] Drift radar generated:"
+    )
+    print(f"  Claims:  {claims_path}")
+    print(f"  MD:      {md_path}")
+    if json_path:
+        print(f"  JSON:    {json_path}")
+    print(f"  Degraded: {degraded}")
+    print(f"  Total claims: {len(claims)}")
+    print(f"  Blocking: {stale_claims['summary']['blocking_claims']}")
+    print(f"  Brain Apply blocked: {blocks_brain}")
+    print(f"  LR: NO-GO")
+    print(f"  Exit code: {exit_code} (0=PASS, 1=BLOCKED/DEGRADED)")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Closes #3291

## Refs #3286

### Delivered
- **tools/context/generate_context_drift_radar.py** — read-only CLI drift radar (stdlib + cdb_utcnow), 8 drift categories, stale_claims.json + impact_radar.md output, Brain Apply blocking policy
- **tests/unit/tools/context/test_context_drift_radar.py** — 29 unit tests (valid input, all 8 categories, blocking policy, deterministic shape, no secrets, no auto-GitHub-writes, degraded mode)
- **docs/runbooks/CDB_CONTEXT_REFRESH.md** — §6 Drift Radar, pipeline updated, issue table updated

### Dependencies on Prior Slices
- #3290 / PR #3295 (merge sha 072b740a) — Agent Briefing Seed (optional input)
- #3287 / PR #3294 (merge sha b895444f) — Report Generator (required inputs: context_delta.json, validation_report.json)
- #3288 / PR #3293 (merge sha 21b4279) — Context Package Schema (used in Stale Claims model)

### Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- tools_or_queries: git fetch/status/rev-parse, gh issue/pr view, file reads
- repo_crosscheck: AGENTS.md (root/agents/), agents/roles/CODEX.md, tools/context/ existing surfaces
- impact_on_plan: implemented per #3291 spec from prompt_contract verbatim

### Bootloader Evidence
- AGENTS.md (root + agents/) read and verified
- Read Order followed from agents/AGENTS.md
- Context Brain Preflight: attempted, unavailable (repo-only fallback)
- No DB-backed claims

### Validation
- 29 new unit tests: **29 PASS**
- 59 regression tests: **59 PASS** (total 88)
- Ruff lint: **clean**
- Black format: **clean**
- Required Checks: pending

### Safety Boundaries
- LR remains NO-GO. No Live-Go. No Echtgeld-Go.
- No Brain Apply (#3289) — drift radar is read-only report only
- No Onboarding (#3292) — separate follow-up slice
- No DB writes, no secrets, no runtime/Docker/Compose changes
- Follow-up issues are recommendations only — not auto-created
- High-risk drift blocks Brain Apply (blocks_brain_apply=true)
- board_stage trade-capable is orthogonal to LR system

### Non-goals
- #3289 (Brain Apply) — not in this scope
- #3292 (Onboarding) — not in this scope
- Auto-issue creation — report only
- Runtime/Docker/Trading changes

### Restunsicherheiten
- Drift radar requires at least one input artifact (context_delta.json or validation_report.json) to produce meaningful output; degraded mode reports honestly when both are missing.
- Optional agent_briefing_seed.json input enriches bootloader instruction scan.
- Secret indicator detection is substring-based; may produce false positives on non-secret field names.