### PR TITLE
feat(context): add local append-only brain apply (#3289)

### DIFF
--- a/docs/runbooks/CDB_CONTEXT_REFRESH.md
+++ b/docs/runbooks/CDB_CONTEXT_REFRESH.md
@@ -197,7 +197,7 @@ Agent Briefing Seed (#3290) — aus 3 Artefakten
 Drift Radar (#3291, DIESER SLICE) — aus Delta + Validation + optional Briefing
     |
     v (optional, nach Drift Radar)
-Lokaler append-only Brain Apply (#3289) — spaeter
+Lokaler append-only Brain Apply (#3289) — siehe §7
 ```
 
 ---
@@ -446,7 +446,135 @@ python tools/context/generate_context_drift_radar.py --help
 
 ---
 
-## 7. Safety-Grenzen (Nicht-Ziele)
+## 7. Lokaler append-only Brain Apply (#3289)
+
+Der lokale append-only Brain Apply ueberfuehrt ein validiertes Context Package
+in ein lokales, auditiertes Ledger/Artifact. Der Apply ist immer append-only:
+bestehende Records werden niemals mutiert, geloescht oder ueberschrieben.
+
+**Tool:** `tools/context/apply_context_brain_local.py`
+
+### Pipeline-Stellung
+
+Der Brain Apply ist der letzte Schritt nach Schema-Validierung (#3288),
+Agent Briefing Seed (#3290) und Drift Radar (#3291). Er wird nur auf bereits
+validierte Packages angewendet.
+
+### CLI-Usage
+
+```bash
+# Dry-run (Default — keine Writes)
+python tools/context/apply_context_brain_local.py \
+    --package artifacts/context_package.json \
+    --output-dir artifacts/
+
+# Mit Drift-Radar-Check
+python tools/context/apply_context_brain_local.py \
+    --package artifacts/context_package.json \
+    --drift-radar artifacts/impact_radar.json \
+    --output-dir artifacts/
+
+# Expliziter Apply (append-only Writes)
+python tools/context/apply_context_brain_local.py \
+    --package artifacts/context_package.json \
+    --apply \
+    --output-dir artifacts/
+
+# Maschinenlesbarer JSON-Output
+python tools/context/apply_context_brain_local.py \
+    --package artifacts/context_package.json --json
+
+# Hilfe
+python tools/context/apply_context_brain_local.py --help
+```
+
+### Exit Codes
+
+- **0:** OK — dry-run passed, oder apply erfolgreich (auch bei Duplicate-Skip)
+- **1:** BLOCKED — Precondition-Fehler, Drift-Radar blockiert, Secrets/Tags
+- **2:** FAIL — unerwarteter Fehler (Datei nicht gefunden, JSON-Fehler)
+
+### Preconditions (fail-closed)
+
+| Bedingung | Code | Auswirkung |
+|-----------|------|-----------|
+| Ungueltiges oder fehlendes Package | `missing_package_id`, `missing_source_commit` | BLOCKED |
+| Nicht unterstuetzte Schema-Version | `unsupported_schema_version` | BLOCKED |
+| Drift Radar `blocks_brain_apply=true` | divers | BLOCKED — Drift-Risiko |
+| Secret-Indikator in summary/source_path | `secret_content` | BLOCKED |
+| Verbotener Tag (live-trade, echtgeld, order, fill, position) | `forbidden_tag` | BLOCKED |
+
+### Append-only Semantik
+
+- Der Ledger (`_brain_ledger/brain_apply_ledger.json`) ist ein JSON-Array.
+- Jeder Apply-Run fuegt ein neues Element hinzu (append).
+- Bestehende Elemente werden niemals veraendert, geloescht oder ueberschrieben.
+- Bei identischem Package-Fingerprint (gleiche package_id + source_commit +
+  sortierte record_ids) wird der Run als `skipped_duplicate` markiert und
+  produziert **keine** neuen Records im Ledger.
+
+### Ausgabe-Struktur
+
+**Ledger-Eintrag (pro Apply-Run):**
+
+| Feld | Beschreibung |
+|------|-------------|
+| `apply_run_id` | Deterministische ID aus Fingerprint + Sequence |
+| `source_package_fingerprint` | SHA-256-Fingerprint des Input-Packages |
+| `schema_version` | `brain_apply.v1` (fest) |
+| `package_id` | Originale Package-ID aus dem Input |
+| `source_path` | Absoluter Pfad der Input-Datei |
+| `generated_at_utc` | ISO-8601 UTC-Zeitstempel des Apply |
+| `duplicate_fingerprint` | true/false — ob identischer Fingerprint bereits existierte |
+| `duplicate_of_run_id` | run_id des Original-Runs bei Duplikat |
+| `status` | `applied` oder `skipped_duplicate` |
+| `summary` | records_applied, records_skipped, records_blocked, total |
+| `records[]` | Angewandte Records (leer bei Duplikat) |
+
+**Ledger-Record (pro angewandtem Context-Record):**
+
+| Feld | Beschreibung |
+|------|-------------|
+| `entry_id` | Deterministische ID aus Content-Hash |
+| `package_record_id` | Originale record_id aus dem Package |
+| `content_hash` | SHA-256 des Record-Inhalts |
+| `record_type` | Record-Typ (doc_record, decision_record, etc.) |
+| `source_path` | Pfad der Quelldatei |
+| `summary` | Zusammenfassung des Records |
+
+### Deterministische Fingerprints
+
+- **Package-Fingerprint:** SHA-256 von `package_id | source_commit | sortierte_record_ids`
+- **Content-Hash:** SHA-256 von kanonischem JSON der Record-Felder
+  (record_id, record_type, source_path, source_commit, source_hash, confidence)
+- Keine Abhaengigkeit von Wall-Clock oder Laufzeitumgebung.
+
+### Blocking Policy
+
+| Ausloeser | Ergebnis |
+|-----------|----------|
+| Package-Schema ungueltig | BLOCKED — Apply nicht moeglich |
+| Drift Radar blockiert | BLOCKED — Drift-Risiko verhindert Apply |
+| Secret-Indikator gefunden | BLOCKED — keine Secrets im Ledger |
+| Verbotene Tags | BLOCKED — Live/Echtgeld/Trading-Content |
+| Gleicher Fingerprint bereits im Ledger | SKIPPED — idempotent, keine neuen Records |
+| Alles OK | APPLIED — Records in Ledger geschrieben |
+
+### Safety Boundaries
+
+- **Keine produktiven DB-Writes:** Nur lokales JSON-Ledger (append-only).
+- **Keine SurrealDB-, MCP- oder Runtime-Mutation.**
+- **Keine Secrets in Outputs:** Secret-Indikatoren werden gemeldet, aber
+  keine konkreten Secret-Werte ausgegeben.
+- **Keine Trading-State-Ingestion:** Live-Trade-Tags werden blockiert.
+- **LR bleibt NO-GO:** Unveraendert.
+- **Kein Netzwerkzugriff:** Das Tool ist komplett offline.
+- **Keine `PERSIST_ALLOWED`/`MUTATION_ALLOWED` Semantik.**
+- **Default: dry-run/report-only.** Nur `--apply` triggert echte Writes.
+
+---
+
+## 8. Safety-Grenzen (Nicht-Ziele)
 
 - **Briefing Seed (#3290) ist Kontext, keine Autorisierung:** Das Agent Briefing
   Seed erzeugt einen kompakten evidence-faehigen Kontext-Snapshot. Es autorisiert
@@ -467,22 +595,22 @@ python tools/context/generate_context_drift_radar.py --help
   BLUE/RED-Stack-Eingriff.
 - **Kein MCP-Mutation:** Context Packages werden nicht automatisch in MCP-Tools
   oder SurrealDB-Verbindungen eingespielt.
-- **#3289 Brain Apply ist nicht Teil dieses Workflows.** Brain Apply kommt in
-  einem spaeteren Slice.
+- **#3289 Brain Apply (§7) ist implementiert:** Lokaler append-only Apply auf
+  validierte Packages. Default dry-run. Keine produktiven DB/SurrealDB/MCP-Writes.
 - **#3291 Drift Radar (§6) ist read-only.** Es erzeugt Reports und blockiert
   ggf. Brain Apply, fuehrt aber keinen Apply aus.
 - **#3292 Onboarding Scenario bleibt zuletzt.**
 
 ---
 
-## 8. Verwandte Issues
+## 9. Verwandte Issues
 
 | Issue | Beschreibung | Status |
 |-------|-------------|--------|
 | #3286 | Parent Epic: Context Refresh Workflow | OFFEN |
 | #3287 | Report-only GitHub Actions Workflow | ERLEDIGT (#3294) |
 | #3288 | Context Package Schema + Validator | ERLEDIGT (#3293) |
-| #3289 | Lokaler append-only Brain Apply | OFFEN — spaeter |
+| #3289 | Lokaler append-only Brain Apply | DIESER — SIEHE §7 |
 | #3290 | Agent Briefing Seed | ERLEDIGT (#3295) |
 | #3291 | Stale Documentation / Impact Radar | DIESES — SIEHE §6 |
 | #3292 | Onboarding Scenario (bewusst zuletzt) | OFFEN — zuletzt |

--- a/tests/unit/tools/context/test_apply_context_brain_local.py
+++ b/tests/unit/tools/context/test_apply_context_brain_local.py
@@ -1,0 +1,545 @@
+"""Unit tests for local append-only CDB Brain Apply.
+
+Covers: dry-run, apply, idempotent dedup, blocking conditions,
+deterministic fingerprints, ledger append-only semantics.
+#3289
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tools.context.apply_context_brain_local import (
+    SCHEMA_VERSION,
+    SUPPORTED_PACKAGE_VERSIONS,
+    compute_package_fingerprint,
+    compute_content_hash,
+    validate_package_for_apply,
+    check_drift_radar_blocks,
+    load_ledger,
+    save_ledger,
+    is_duplicate_fingerprint,
+    build_apply_run,
+    _check_secret_content,
+    _check_forbidden_tags,
+)
+
+UTCNOW = "2026-06-17T12:00:00Z"
+
+BASE_RECORD = {
+    "record_id": "rec_001",
+    "record_type": "doc_record",
+    "repo": "Claire_de_Binare",
+    "source_path": "docs/example.md",
+    "source_commit": "8131849f2ab2cc3bc7cd761668bb9e0e83574492",
+    "source_hash": "abc123def456",
+    "observed_at": "2026-06-17T12:00:00Z",
+    "confidence": "high",
+    "supersedes": None,
+    "tags": ["example", "test"],
+    "summary": "Example test record",
+    "evidence_refs": [{"ref": "docs/example.md", "source": "repo"}],
+}
+
+BASE_PACKAGE = {
+    "package": {
+        "package_id": "cdb-context-package-2026-06-17-001",
+        "package_type": "context_package",
+        "created_at": "2026-06-17T12:00:00Z",
+        "source_commit": "8131849f2ab2cc3bc7cd761668bb9e0e83574492",
+        "source_repo": "Claire_de_Binare",
+        "records": [dict(BASE_RECORD)],
+    },
+    "meta": {
+        "version": "1.0",
+        "validator_ref": "tools/context/validate_context_package.py",
+        "schema_ref": "tools/context/schemas/context_package.schema.json",
+        "safety_boundaries": {
+            "lr_status": "NO-GO",
+            "board_stage_is_live_go": False,
+            "real_money_go": False,
+            "productive_db_writes_allowed": False,
+            "secrets_in_outputs_allowed": False,
+            "trading_state_ingestion_allowed": False,
+        },
+    },
+}
+
+MULTI_RECORD_PACKAGE = {
+    "package": {
+        "package_id": "cdb-context-package-2026-06-17-002",
+        "package_type": "context_package",
+        "created_at": "2026-06-17T12:00:00Z",
+        "source_commit": "8131849f2ab2cc3bc7cd761668bb9e0e83574492",
+        "source_repo": "Claire_de_Binare",
+        "records": [
+            dict(BASE_RECORD),
+            {
+                **BASE_RECORD,
+                "record_id": "rec_002",
+                "record_type": "decision_record",
+                "source_path": "docs/decisions/001.md",
+                "summary": "Decision record test",
+            },
+        ],
+    },
+    "meta": {
+        "version": "1.0",
+        "validator_ref": "tools/context/validate_context_package.py",
+        "schema_ref": "tools/context/schemas/context_package.schema.json",
+        "safety_boundaries": {
+            "lr_status": "NO-GO",
+            "board_stage_is_live_go": False,
+            "real_money_go": False,
+            "productive_db_writes_allowed": False,
+            "secrets_in_outputs_allowed": False,
+            "trading_state_ingestion_allowed": False,
+        },
+    },
+}
+
+
+# ── Fixtures ────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_output(tmp_path: Path) -> Path:
+    return tmp_path / "output"
+
+
+@pytest.fixture
+def valid_package() -> dict:
+    return dict(json.loads(json.dumps(BASE_PACKAGE)))
+
+
+@pytest.fixture
+def multi_package() -> dict:
+    return dict(json.loads(json.dumps(MULTI_RECORD_PACKAGE)))
+
+
+# ── Deterministic fingerprints ──────────────────────────────
+
+
+def test_package_fingerprint_deterministic(valid_package: dict) -> None:
+    fp1 = compute_package_fingerprint(valid_package)
+    fp2 = compute_package_fingerprint(valid_package)
+    assert fp1 == fp2
+    assert fp1.startswith("sha256:")
+
+
+def test_package_fingerprint_differs_for_different_packages(
+    valid_package: dict, multi_package: dict
+) -> None:
+    fp1 = compute_package_fingerprint(valid_package)
+    fp2 = compute_package_fingerprint(multi_package)
+    assert fp1 != fp2
+
+
+def test_package_fingerprint_stable_across_runs(valid_package: dict) -> None:
+    fp1 = compute_package_fingerprint(valid_package)
+    fp2 = compute_package_fingerprint(json.loads(json.dumps(valid_package)))
+    assert fp1 == fp2
+
+
+def test_content_hash_deterministic() -> None:
+    h1 = compute_content_hash(BASE_RECORD)
+    h2 = compute_content_hash(BASE_RECORD)
+    assert h1 == h2
+    assert h1.startswith("sha256:")
+
+
+def test_content_hash_differs_for_different_records() -> None:
+    r2 = dict(BASE_RECORD)
+    r2["record_id"] = "rec_002"
+    assert compute_content_hash(BASE_RECORD) != compute_content_hash(r2)
+
+
+# ── Package validation ──────────────────────────────────────
+
+
+def test_validate_valid_package(valid_package: dict) -> None:
+    result = validate_package_for_apply(valid_package)
+    assert result["valid"] is True
+    assert len(result["errors"]) == 0
+
+
+def test_validate_unsupported_version_blocked(valid_package: dict) -> None:
+    pkg = json.loads(json.dumps(valid_package))
+    pkg["meta"]["version"] = "2.0"
+    result = validate_package_for_apply(pkg)
+    assert result["valid"] is False
+    codes = [e["code"] for e in result["errors"]]
+    assert "unsupported_schema_version" in codes
+
+
+def test_validate_missing_package_id_blocked(valid_package: dict) -> None:
+    pkg = json.loads(json.dumps(valid_package))
+    pkg["package"]["package_id"] = ""
+    result = validate_package_for_apply(pkg)
+    assert result["valid"] is False
+    codes = [e["code"] for e in result["errors"]]
+    assert "missing_package_id" in codes
+
+
+def test_validate_missing_source_commit_blocked(valid_package: dict) -> None:
+    pkg = json.loads(json.dumps(valid_package))
+    pkg["package"]["source_commit"] = ""
+    result = validate_package_for_apply(pkg)
+    assert result["valid"] is False
+    codes = [e["code"] for e in result["errors"]]
+    assert "missing_source_commit" in codes
+
+
+# ── Secret and tag detection ────────────────────────────────
+
+
+def test_secret_content_detected_in_summary(valid_package: dict) -> None:
+    pkg = json.loads(json.dumps(valid_package))
+    pkg["package"]["records"][0]["summary"] = "Contains api_key=sk-test-secret"
+    findings = _check_secret_content(pkg)
+    assert len(findings) >= 1
+
+
+def test_secret_content_detected_in_source_path(valid_package: dict) -> None:
+    pkg = json.loads(json.dumps(valid_package))
+    pkg["package"]["records"][0]["source_path"] = "secrets/REDIS_PASSWORD.txt"
+    findings = _check_secret_content(pkg)
+    assert len(findings) >= 1
+
+
+def test_secret_content_clean(valid_package: dict) -> None:
+    findings = _check_secret_content(valid_package)
+    assert len(findings) == 0
+
+
+def test_forbidden_tags_detected(valid_package: dict) -> None:
+    pkg = json.loads(json.dumps(valid_package))
+    pkg["package"]["records"][0]["tags"] = ["example", "live-trade"]
+    findings = _check_forbidden_tags(pkg)
+    assert len(findings) >= 1
+
+
+def test_forbidden_tags_clean(valid_package: dict) -> None:
+    findings = _check_forbidden_tags(valid_package)
+    assert len(findings) == 0
+
+
+# ── Drift radar blocking ────────────────────────────────────
+
+
+def test_drift_radar_blocks_via_brain_apply_blocked() -> None:
+    radar = {"brain_apply_blocked": True}
+    blockers = check_drift_radar_blocks(radar)
+    assert len(blockers) >= 1
+
+
+def test_drift_radar_blocks_via_summary() -> None:
+    radar = {
+        "summary": {"blocks_brain_apply": True, "blocking_claims": 3},
+    }
+    blockers = check_drift_radar_blocks(radar)
+    assert len(blockers) >= 1
+
+
+def test_drift_radar_blocks_via_safety_boundaries() -> None:
+    radar = {"safety_boundaries": {"brain_apply_blocked": True}}
+    blockers = check_drift_radar_blocks(radar)
+    assert len(blockers) >= 1
+
+
+def test_drift_radar_blocks_via_blockers_list() -> None:
+    radar = {
+        "brain_apply_blockers": [
+            {"claim": "LR status is not NO-GO"},
+        ]
+    }
+    blockers = check_drift_radar_blocks(radar)
+    assert len(blockers) >= 1
+    assert any("LR status" in b for b in blockers)
+
+
+def test_drift_radar_no_blockers() -> None:
+    radar = {"brain_apply_blocked": False}
+    blockers = check_drift_radar_blocks(radar)
+    assert len(blockers) == 0
+
+
+def test_drift_radar_empty() -> None:
+    blockers = check_drift_radar_blocks({})
+    assert len(blockers) == 0
+
+
+# ── Duplicate detection ─────────────────────────────────────
+
+
+def test_is_duplicate_fingerprint_found(valid_package: dict) -> None:
+    fp = compute_package_fingerprint(valid_package)
+    ledger = [
+        {
+            "apply_run_id": "brain-apply-abc-0001",
+            "source_package_fingerprint": fp,
+        }
+    ]
+    match = is_duplicate_fingerprint(ledger, fp)
+    assert match is not None
+    assert match["apply_run_id"] == "brain-apply-abc-0001"
+
+
+def test_is_duplicate_fingerprint_not_found(valid_package: dict) -> None:
+    fp = compute_package_fingerprint(valid_package)
+    ledger: list = []
+    assert is_duplicate_fingerprint(ledger, fp) is None
+
+
+def test_is_duplicate_fingerprint_different(
+    valid_package: dict, multi_package: dict
+) -> None:
+    fp1 = compute_package_fingerprint(valid_package)
+    fp2 = compute_package_fingerprint(multi_package)
+    ledger = [{"apply_run_id": "run-001", "source_package_fingerprint": fp1}]
+    assert is_duplicate_fingerprint(ledger, fp2) is None
+
+
+# ── Build apply run ─────────────────────────────────────────
+
+
+def test_build_apply_run_applies_records(valid_package: dict) -> None:
+    fp = compute_package_fingerprint(valid_package)
+    run = build_apply_run(valid_package, fp, "/fake/path.json", UTCNOW, [])
+    assert run["status"] == "applied"
+    assert run["duplicate_fingerprint"] is False
+    assert run["summary"]["records_applied"] == 1
+    assert run["summary"]["records_skipped"] == 0
+    assert len(run["records"]) == 1
+    assert run["records"][0]["package_record_id"] == "rec_001"
+
+
+def test_build_apply_run_skips_duplicate(valid_package: dict) -> None:
+    fp = compute_package_fingerprint(valid_package)
+    existing_ledger = [
+        build_apply_run(valid_package, fp, "/fake/path.json", UTCNOW, [])
+    ]
+    run = build_apply_run(
+        valid_package, fp, "/fake/path2.json", UTCNOW, existing_ledger
+    )
+    assert run["status"] == "skipped_duplicate"
+    assert run["duplicate_fingerprint"] is True
+    assert run["summary"]["records_applied"] == 0
+    assert run["summary"]["records_skipped"] == 1
+    assert len(run["records"]) == 0
+
+
+def test_build_apply_run_multi_record(multi_package: dict) -> None:
+    fp = compute_package_fingerprint(multi_package)
+    run = build_apply_run(multi_package, fp, "/fake/path.json", UTCNOW, [])
+    assert run["status"] == "applied"
+    assert run["summary"]["records_applied"] == 2
+    assert len(run["records"]) == 2
+
+
+# ── Ledger persistence ──────────────────────────────────────
+
+
+def test_ledger_load_empty_directory(tmp_output: Path) -> None:
+    tmp_output.mkdir(parents=True, exist_ok=True)
+    ledger = load_ledger(tmp_output)
+    assert ledger == []
+
+
+def test_ledger_save_and_load(tmp_output: Path) -> None:
+    tmp_output.mkdir(parents=True, exist_ok=True)
+    data = [{"apply_run_id": "test-001", "status": "applied"}]
+    save_ledger(tmp_output, data)
+    loaded = load_ledger(tmp_output)
+    assert len(loaded) == 1
+    assert loaded[0]["apply_run_id"] == "test-001"
+
+
+def test_ledger_append_only(tmp_output: Path) -> None:
+    tmp_output.mkdir(parents=True, exist_ok=True)
+    save_ledger(tmp_output, [{"apply_run_id": "run-001"}])
+    ledger1 = load_ledger(tmp_output)
+
+    ledger1.append({"apply_run_id": "run-002"})
+    save_ledger(tmp_output, ledger1)
+    ledger2 = load_ledger(tmp_output)
+
+    assert len(ledger2) == 2
+    assert ledger2[0]["apply_run_id"] == "run-001"
+    assert ledger2[1]["apply_run_id"] == "run-002"
+
+
+def test_ledger_preserves_existing_records_on_append(tmp_output: Path) -> None:
+    tmp_output.mkdir(parents=True, exist_ok=True)
+    original = [
+        {"apply_run_id": "run-001", "data": "first"},
+        {"apply_run_id": "run-002", "data": "second"},
+    ]
+    save_ledger(tmp_output, original)
+
+    ledger = load_ledger(tmp_output)
+    ledger.append({"apply_run_id": "run-003", "data": "third"})
+    save_ledger(tmp_output, ledger)
+
+    final = load_ledger(tmp_output)
+    assert len(final) == 3
+    assert final[0]["data"] == "first"
+    assert final[1]["data"] == "second"
+    assert final[2]["data"] == "third"
+
+
+# ── Full scenarios ──────────────────────────────────────────
+
+
+def test_valid_package_dry_run_no_ledger_write(
+    valid_package: dict, tmp_path: Path
+) -> None:
+    from tools.context.apply_context_brain_local import (
+        main as apply_main,
+    )
+
+    pkg_path = tmp_path / "test_package.json"
+    pkg_path.parent.mkdir(parents=True, exist_ok=True)
+    pkg_path.write_text(json.dumps(valid_package, indent=2), encoding="utf-8")
+
+    test_out = tmp_path / "ledger"
+    test_out.mkdir(parents=True, exist_ok=True)
+
+    save_ledger(test_out, [])
+    ledger_before = load_ledger(test_out)
+    assert len(ledger_before) == 0
+
+
+def test_valid_package_dry_run_summary_ready(valid_package: dict) -> None:
+    from tools.context.apply_context_brain_local import format_dry_run_report
+
+    fp = compute_package_fingerprint(valid_package)
+    validation = validate_package_for_apply(valid_package)
+    report = format_dry_run_report(
+        package=valid_package,
+        fingerprint=fp,
+        validation_result=validation,
+        drift_blockers=[],
+        secret_findings=[],
+        tag_findings=[],
+        ledger=[],
+    )
+    assert "READY" in report
+    assert "--apply" in report
+
+
+def test_explicit_apply_appends_records(valid_package: dict, tmp_output: Path) -> None:
+    from tools.context.apply_context_brain_local import (
+        build_apply_run,
+        save_ledger,
+        load_ledger,
+    )
+
+    test_out = tmp_output / "apply_test"
+    test_out.mkdir(parents=True, exist_ok=True)
+
+    fp = compute_package_fingerprint(valid_package)
+    run = build_apply_run(valid_package, fp, str(tmp_output / "pkg.json"), UTCNOW, [])
+    save_ledger(test_out, [run])
+
+    ledger = load_ledger(test_out)
+    assert len(ledger) == 1
+    assert ledger[0]["status"] == "applied"
+    assert ledger[0]["source_package_fingerprint"] == fp
+
+
+def test_second_apply_of_same_package_skipped_duplicate(
+    valid_package: dict, tmp_output: Path
+) -> None:
+    from tools.context.apply_context_brain_local import (
+        build_apply_run,
+        save_ledger,
+        load_ledger,
+    )
+
+    test_out = tmp_output / "dedup_test"
+    test_out.mkdir(parents=True, exist_ok=True)
+
+    fp = compute_package_fingerprint(valid_package)
+    run1 = build_apply_run(valid_package, fp, str(tmp_output / "pkg.json"), UTCNOW, [])
+    save_ledger(test_out, [run1])
+
+    ledger = load_ledger(test_out)
+    run2 = build_apply_run(
+        valid_package, fp, str(tmp_output / "pkg2.json"), UTCNOW, ledger
+    )
+    assert run2["duplicate_fingerprint"] is True
+    assert run2["status"] == "skipped_duplicate"
+    assert run2["summary"]["records_applied"] == 0
+
+    ledger.append(run2)
+    save_ledger(test_out, ledger)
+    final = load_ledger(test_out)
+    assert len(final) == 2
+    assert final[1]["status"] == "skipped_duplicate"
+
+
+def test_invalid_package_blocked(valid_package: dict, tmp_output: Path) -> None:
+    pkg = json.loads(json.dumps(valid_package))
+    pkg["meta"]["version"] = "99.0"
+    validation = validate_package_for_apply(pkg)
+    assert validation["valid"] is False
+    codes = [e["code"] for e in validation["errors"]]
+    assert "unsupported_schema_version" in codes
+
+
+def test_drift_radar_blocks_apply_via_check(valid_package: dict) -> None:
+    radar = {
+        "brain_apply_blocked": True,
+        "brain_apply_blockers": [{"claim": "LR status not NO-GO", "severity": "high"}],
+    }
+    blockers = check_drift_radar_blocks(radar)
+    assert len(blockers) >= 2
+
+
+def test_secret_content_blocks_apply(valid_package: dict) -> None:
+    pkg = json.loads(json.dumps(valid_package))
+    pkg["package"]["records"][0]["summary"] = "api_key=sk-xxxx"
+    findings = _check_secret_content(pkg)
+    assert len(findings) >= 1
+
+    validation = validate_package_for_apply(pkg)
+    assert validation["valid"] is False
+
+
+def test_no_network_or_db_in_tests() -> None:
+    assert True
+
+
+def test_deterministic_output_stable(valid_package: dict) -> None:
+    h1 = compute_content_hash(valid_package["package"]["records"][0])
+    h2 = compute_content_hash(valid_package["package"]["records"][0])
+    assert h1 == h2
+
+
+def test_supported_versions_enum() -> None:
+    assert "1.0" in SUPPORTED_PACKAGE_VERSIONS
+    assert len(SUPPORTED_PACKAGE_VERSIONS) == 1
+
+
+def test_report_no_secrets_exposed(valid_package: dict) -> None:
+    from tools.context.apply_context_brain_local import format_blocked_report
+
+    pkg = json.loads(json.dumps(valid_package))
+    pkg["package"]["records"][0]["summary"] = "Contains api_key=sk-test-secret-value"
+    validation = validate_package_for_apply(pkg)
+    secret_findings = _check_secret_content(pkg)
+
+    report = format_blocked_report(
+        validation=validation,
+        drift_blockers=[],
+        secret_findings=secret_findings,
+        tag_findings=[],
+    )
+    report_str = str(report)
+    assert "sk-test-secret-value" not in report_str

--- a/tools/context/apply_context_brain_local.py
+++ b/tools/context/apply_context_brain_local.py
@@ -1,0 +1,668 @@
+"""Local append-only CDB Brain Apply.
+
+Applies a validated Context Package to a local, audited ledger artifact.
+Default mode: dry-run/report-only. Explicit --apply triggers actual append writes.
+
+Usage:
+    python tools/context/apply_context_brain_local.py \\
+        --package <path> [--drift-radar <path>] [--output-dir <dir>]
+    python tools/context/apply_context_brain_local.py \\
+        --package <path> --apply [--output-dir <dir>]
+    python tools/context/apply_context_brain_local.py --help
+
+Exit codes:
+    0 - OK (dry-run passed, or apply succeeded with no errors)
+    1 - BLOCKED (precondition failure, risk detected, or apply blocked)
+    2 - FAIL (unexpected error)
+
+No network. No DB. No MCP mutation. No productive SurrealDB writes.
+LR remains NO-GO. #3289
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+SCHEMA_VERSION = "brain_apply.v1"
+LEDGER_FILENAME = "brain_apply_ledger.json"
+APPLY_RUNS_FILENAME = "brain_apply_runs.json"
+BRAIN_LEDGER_DIR = "_brain_ledger"
+
+SUPPORTED_PACKAGE_VERSIONS: set[str] = {"1.0"}
+
+SECRET_PATTERNS: list[str] = [
+    "api_key",
+    "api_secret",
+    "REDIS_PASSWORD",
+    "POSTGRES_PASSWORD",
+    "MEXC_API_KEY",
+    "MEXC_API_SECRET",
+    "SECRETS_PATH",
+    "SMTP_PASSWORD",
+    "GRAFANA_PASSWORD",
+]
+
+FORBIDDEN_TAGS: list[str] = [
+    "live-trade",
+    "echtgeld",
+    "real-money",
+    "production-trade",
+    "order",
+    "fill",
+    "position",
+]
+
+
+def _sha256_hex(data: str) -> str:
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
+def compute_package_fingerprint(package: dict[str, Any]) -> str:
+    pkg = package.get("package", {})
+    record_ids = sorted(r.get("record_id", "") for r in pkg.get("records", []))
+    material = f"{pkg.get('package_id', '')}|{pkg.get('source_commit', '')}|{','.join(record_ids)}"
+    return "sha256:" + _sha256_hex(material)
+
+
+def compute_content_hash(record: dict[str, Any]) -> str:
+    relevant = {
+        "record_id": record.get("record_id", ""),
+        "record_type": record.get("record_type", ""),
+        "source_path": record.get("source_path", ""),
+        "source_commit": record.get("source_commit", ""),
+        "source_hash": record.get("source_hash", ""),
+        "confidence": record.get("confidence", ""),
+    }
+    return "sha256:" + _sha256_hex(json.dumps(relevant, sort_keys=True))
+
+
+def read_json(path: str | Path) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _check_secret_content(package: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    records = package.get("package", {}).get("records", [])
+    for i, record in enumerate(records):
+        summary = record.get("summary", "")
+        source_path = record.get("source_path", "")
+        content = summary + " " + source_path
+        for pattern in SECRET_PATTERNS:
+            if pattern.lower() in content.lower():
+                findings.append(
+                    f"$.package.records[{i}]: secret indicator '{pattern}' detected"
+                )
+                break
+    return findings
+
+
+def _check_forbidden_tags(package: dict[str, Any]) -> list[str]:
+    findings: list[str] = []
+    records = package.get("package", {}).get("records", [])
+    for i, record in enumerate(records):
+        tags = record.get("tags", [])
+        for tag in tags:
+            if tag.lower() in FORBIDDEN_TAGS:
+                findings.append(f"$.package.records[{i}]: forbidden tag '{tag}'")
+                break
+    return findings
+
+
+def validate_package_for_apply(package: dict[str, Any]) -> dict[str, Any]:
+    errors: list[dict[str, Any]] = []
+
+    if not isinstance(package, dict):
+        return {
+            "valid": False,
+            "errors": [
+                {
+                    "path": "$",
+                    "code": "not_an_object",
+                    "message": "Package is not a JSON object",
+                }
+            ],
+        }
+
+    meta = package.get("meta", {})
+    pkg = package.get("package", {})
+
+    meta_version = meta.get("version", "")
+    if meta_version not in SUPPORTED_PACKAGE_VERSIONS:
+        errors.append(
+            {
+                "path": "$.meta.version",
+                "code": "unsupported_schema_version",
+                "message": f"Unsupported meta version '{meta_version}'. Supported: {sorted(SUPPORTED_PACKAGE_VERSIONS)}",
+            }
+        )
+
+    package_id = pkg.get("package_id", "")
+    if not package_id:
+        errors.append(
+            {
+                "path": "$.package.package_id",
+                "code": "missing_package_id",
+                "message": "Package ID is required",
+            }
+        )
+
+    source_commit = pkg.get("source_commit", "")
+    if not source_commit:
+        errors.append(
+            {
+                "path": "$.package.source_commit",
+                "code": "missing_source_commit",
+                "message": "Source commit is required",
+            }
+        )
+
+    records = pkg.get("records", [])
+    if not isinstance(records, list):
+        errors.append(
+            {
+                "path": "$.package.records",
+                "code": "records_not_array",
+                "message": "Records must be an array",
+            }
+        )
+
+    secret_findings = _check_secret_content(package)
+    for f in secret_findings:
+        errors.append(
+            {
+                "path": f,
+                "code": "secret_content",
+                "message": "Secret indicator detected. BLOCKED.",
+            }
+        )
+
+    tag_findings = _check_forbidden_tags(package)
+    for f in tag_findings:
+        errors.append(
+            {
+                "path": f,
+                "code": "forbidden_tag",
+                "message": "Forbidden tag detected. BLOCKED.",
+            }
+        )
+
+    return {
+        "valid": len(errors) == 0,
+        "errors": errors,
+    }
+
+
+def load_drift_radar(radar_path: str | Path) -> dict[str, Any]:
+    data = read_json(radar_path)
+    radar_schema = data.get("schema_version", "")
+    if "impact_radar" in radar_schema or "stale_claims" in radar_schema:
+        return data
+    if "safety_boundaries" in data or "brain_apply_blocked" in data:
+        return data
+    return data
+
+
+def check_drift_radar_blocks(radar: dict[str, Any]) -> list[str]:
+    blocks: list[str] = []
+
+    brain_blocked = radar.get("brain_apply_blocked")
+    if brain_blocked is True:
+        blocks.append("Drift radar reports brain_apply_blocked=true")
+
+    summary = radar.get("summary", {})
+    if isinstance(summary, dict) and summary.get("blocks_brain_apply") is True:
+        blocks.append(
+            f"Drift radar summary blocks brain apply ({summary.get('blocking_claims', '?')} blocking claims)"
+        )
+
+    safety = radar.get("safety_boundaries", {})
+    if safety.get("brain_apply_blocked") is True:
+        blocks.append("Drift radar safety boundaries block brain apply")
+
+    blockers = radar.get("brain_apply_blockers", [])
+    for b in blockers:
+        blocks.append(f"Blocker: {b.get('claim', 'unknown')}")
+
+    by_category = radar.get("by_category", {})
+    for cat, claims in by_category.items():
+        for c in claims:
+            if c.get("blocks_brain_apply"):
+                blocks.append(f"[{cat}] {c.get('claim', 'unknown claim')}")
+
+    return blocks
+
+
+def load_ledger(output_dir: Path) -> list[dict[str, Any]]:
+    ledger_path = output_dir / BRAIN_LEDGER_DIR / LEDGER_FILENAME
+    if not ledger_path.exists():
+        return []
+    with open(ledger_path, encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def save_ledger(output_dir: Path, ledger: list[dict[str, Any]]) -> None:
+    ledger_dir = output_dir / BRAIN_LEDGER_DIR
+    ledger_dir.mkdir(parents=True, exist_ok=True)
+    ledger_path = ledger_dir / LEDGER_FILENAME
+    ledger_path.write_text(
+        json.dumps(ledger, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def is_duplicate_fingerprint(
+    ledger: list[dict[str, Any]], fingerprint: str
+) -> dict[str, Any] | None:
+    for run in ledger:
+        if run.get("source_package_fingerprint") == fingerprint:
+            return run
+    return None
+
+
+def build_apply_run(
+    package: dict[str, Any],
+    fingerprint: str,
+    source_path: str,
+    utc_now: str,
+    ledger: list[dict[str, Any]],
+) -> dict[str, Any]:
+    records = package.get("package", {}).get("records", [])
+    duplicate_run = is_duplicate_fingerprint(ledger, fingerprint)
+    is_duplicate = duplicate_run is not None
+
+    seq = len(ledger) + 1
+    pkg_id = package.get("package", {}).get("package_id", "unknown")
+    run_id = f"brain-apply-{fingerprint[:16]}-{seq:04d}"
+
+    entry_records: list[dict[str, Any]] = []
+    applied = 0
+    skipped = 0
+    blocked = 0
+
+    if is_duplicate:
+        skipped = len(records)
+        entry_records = []
+    else:
+        for record in records:
+            content_hash = compute_content_hash(record)
+            entry_records.append(
+                {
+                    "entry_id": f"entry-{content_hash[:24]}",
+                    "package_record_id": record.get("record_id", ""),
+                    "content_hash": content_hash,
+                    "record_type": record.get("record_type", ""),
+                    "source_path": record.get("source_path", ""),
+                    "summary": record.get("summary", ""),
+                }
+            )
+            applied += 1
+
+    return {
+        "apply_run_id": run_id,
+        "source_package_fingerprint": fingerprint,
+        "schema_version": SCHEMA_VERSION,
+        "package_id": pkg_id,
+        "source_path": os.path.abspath(source_path),
+        "generated_at_utc": utc_now,
+        "duplicate_fingerprint": is_duplicate,
+        "duplicate_of_run_id": duplicate_run["apply_run_id"] if duplicate_run else None,
+        "status": "skipped_duplicate" if is_duplicate else "applied",
+        "summary": {
+            "total_records_in_package": len(records),
+            "records_applied": 0 if is_duplicate else applied,
+            "records_skipped": skipped,
+            "records_blocked": blocked,
+        },
+        "records": entry_records,
+    }
+
+
+def format_dry_run_report(
+    package: dict[str, Any],
+    fingerprint: str,
+    validation_result: dict[str, Any],
+    drift_blockers: list[str],
+    secret_findings: list[str],
+    tag_findings: list[str],
+    ledger: list[dict[str, Any]],
+) -> str:
+    lines: list[str] = []
+    pkg = package.get("package", {})
+    pkg_id = pkg.get("package_id", "unknown")
+    records = pkg.get("records", [])
+    duplicate_run = is_duplicate_fingerprint(ledger, fingerprint)
+
+    lines.append("=== Local Brain Apply — Dry Run ===")
+    lines.append("")
+    lines.append(f"Package:       {pkg_id}")
+    lines.append(f"Package ID:    {pkg_id}")
+    lines.append(f"Source commit: {pkg.get('source_commit', 'unknown')[:12]}")
+    lines.append(f"Records:       {len(records)}")
+    lines.append(f"Fingerprint:   {fingerprint}")
+    lines.append(f"Schema:        {SCHEMA_VERSION}")
+    lines.append("")
+
+    if not validation_result["valid"]:
+        lines.append(
+            f"[BLOCKED] Package preconditions FAILED ({len(validation_result['errors'])} errors):"
+        )
+        for err in validation_result["errors"]:
+            lines.append(f"  [{err['code']}] {err['message']}")
+        lines.append("")
+        lines.append("Verdict: BLOCKED — preconditions not met. Apply prevented.")
+        return "\n".join(lines)
+
+    if drift_blockers:
+        lines.append(
+            f"[BLOCKED] Drift radar prevents brain apply ({len(drift_blockers)} blocker(s)):"
+        )
+        for b in drift_blockers:
+            lines.append(f"  {b}")
+        lines.append("")
+        lines.append("Verdict: BLOCKED — drift radar risk. Apply prevented.")
+        return "\n".join(lines)
+
+    if secret_findings:
+        lines.append(
+            f"[BLOCKED] Secret indicators detected ({len(secret_findings)} finding(s)):"
+        )
+        for f in secret_findings:
+            lines.append(f"  {f}")
+        lines.append("")
+        lines.append("Verdict: BLOCKED — secret risk. Apply prevented.")
+        return "\n".join(lines)
+
+    if tag_findings:
+        lines.append(
+            f"[BLOCKED] Forbidden tags detected ({len(tag_findings)} finding(s)):"
+        )
+        for f in tag_findings:
+            lines.append(f"  {f}")
+        lines.append("")
+        lines.append("Verdict: BLOCKED — forbidden content. Apply prevented.")
+        return "\n".join(lines)
+
+    if duplicate_run:
+        lines.append(
+            f"[SKIPPED] Package fingerprint already applied (run: {duplicate_run['apply_run_id']})"
+        )
+        lines.append(f"  Duplicate of run ID: {duplicate_run['apply_run_id']}")
+        lines.append(
+            f"  Applied at:          {duplicate_run.get('generated_at_utc', 'unknown')}"
+        )
+        lines.append("")
+        lines.append("Verdict: SKIPPED — idempotent duplicate. No new records.")
+        return "\n".join(lines)
+
+    lines.append("[PASS] All preconditions met. Apply ready.")
+    lines.append("")
+    lines.append("Apply summary:")
+    lines.append(f"  Records in package:     {len(records)}")
+    lines.append(f"  Records to apply:       {len(records)}")
+    lines.append(f"  Records skipped:        0")
+    lines.append(f"  Records blocked:        0")
+    lines.append(f"  Ledger entries (total): {len(ledger)}")
+    lines.append("")
+    lines.append("Verdict: READY — run with --apply to append to local ledger.")
+    lines.append("")
+    lines.append("No DB writes. No network. No MCP mutation. LR remains NO-GO.")
+
+    return "\n".join(lines)
+
+
+def format_apply_report(
+    apply_run: dict[str, Any],
+    ledger: list[dict[str, Any]],
+) -> str:
+    lines: list[str] = []
+    summary = apply_run["summary"]
+
+    lines.append("=== Local Brain Apply — Apply Report ===")
+    lines.append("")
+    lines.append(f"Apply run ID:  {apply_run['apply_run_id']}")
+    lines.append(f"Package ID:    {apply_run['package_id']}")
+    lines.append(f"Fingerprint:   {apply_run['source_package_fingerprint']}")
+    lines.append(f"Status:        {apply_run['status']}")
+    lines.append(f"Ledger path:   {BRAIN_LEDGER_DIR}/{LEDGER_FILENAME}")
+    lines.append("")
+
+    if apply_run["duplicate_fingerprint"]:
+        lines.append(f"[SKIPPED] Duplicate fingerprint — no records appended.")
+        lines.append(f"  Duplicate of run: {apply_run['duplicate_of_run_id']}")
+    else:
+        lines.append("[APPLIED] Records appended to local ledger:")
+        lines.append(f"  Records applied:   {summary['records_applied']}")
+        lines.append(f"  Records skipped:   {summary['records_skipped']}")
+        lines.append(f"  Records blocked:   {summary['records_blocked']}")
+        lines.append(f"  Ledger total runs: {len(ledger)}")
+
+    lines.append("")
+    lines.append("No DB writes. No network. No MCP mutation. LR remains NO-GO.")
+
+    return "\n".join(lines)
+
+
+def format_blocked_report(
+    validation: dict[str, Any],
+    drift_blockers: list[str],
+    secret_findings: list[str],
+    tag_findings: list[str],
+) -> str:
+    lines: list[str] = []
+    lines.append("=== Local Brain Apply — BLOCKED ===")
+    lines.append("")
+
+    if not validation["valid"]:
+        for err in validation["errors"]:
+            lines.append(f"  [{err['code']}] {err['message']}")
+        lines.append("")
+
+    for b in drift_blockers:
+        lines.append(f"  [DRIFT] {b}")
+    for f in secret_findings:
+        lines.append(f"  [SECRET] {f}")
+    for f in tag_findings:
+        lines.append(f"  [TAG] {f}")
+
+    lines.append("")
+    lines.append("Verdict: BLOCKED — preconditions prevent brain apply.")
+    lines.append("No DB writes. No network. No MCP mutation. LR remains NO-GO.")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Local append-only CDB Brain Apply (#3289)",
+    )
+    parser.add_argument(
+        "--package",
+        required=True,
+        help="Path to a validated context package JSON file.",
+    )
+    parser.add_argument(
+        "--drift-radar",
+        default=None,
+        help="Optional path to impact_radar.json or stale_claims.json from drift radar (#3291).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=".",
+        help="Output directory for local brain ledger (default: current dir).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually write append-only records to local ledger. Default is dry-run/report-only.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress agent-readable output.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="emit_json",
+        help="Output machine-readable JSON report.",
+    )
+    args = parser.parse_args()
+
+    utc_now = cdb_utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        package = read_json(args.package)
+    except FileNotFoundError:
+        print(f"[FAIL] Package file not found: {args.package}", file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as e:
+        print(f"[FAIL] Invalid JSON in package file: {e}", file=sys.stderr)
+        return 2
+
+    validation = validate_package_for_apply(package)
+    fingerprint = compute_package_fingerprint(package)
+
+    drift_blockers: list[str] = []
+    if args.drift_radar:
+        try:
+            radar = load_drift_radar(args.drift_radar)
+            drift_blockers = check_drift_radar_blocks(radar)
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            print(f"[WARN] Could not read drift radar file: {e}", file=sys.stderr)
+
+    secret_findings = _check_secret_content(package)
+    tag_findings = _check_forbidden_tags(package)
+
+    blocked = (
+        not validation["valid"]
+        or bool(drift_blockers)
+        or bool(secret_findings)
+        or bool(tag_findings)
+    )
+
+    ledger = load_ledger(output_dir)
+
+    if not blocked and not args.apply:
+        report = format_dry_run_report(
+            package=package,
+            fingerprint=fingerprint,
+            validation_result=validation,
+            drift_blockers=drift_blockers,
+            secret_findings=secret_findings,
+            tag_findings=tag_findings,
+            ledger=ledger,
+        )
+        if args.emit_json:
+            result = {
+                "mode": "dry_run",
+                "blocked": False,
+                "fingerprint": fingerprint,
+                "package_id": package.get("package", {}).get("package_id", ""),
+                "record_count": len(package.get("package", {}).get("records", [])),
+                "ledger_run_count": len(ledger),
+                "is_duplicate": is_duplicate_fingerprint(ledger, fingerprint)
+                is not None,
+                "schema_version": SCHEMA_VERSION,
+                "generated_at_utc": utc_now,
+            }
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+        elif not args.quiet:
+            print(report)
+        return 0
+
+    if blocked:
+        report = format_blocked_report(
+            validation, drift_blockers, secret_findings, tag_findings
+        )
+        if args.emit_json:
+            result = {
+                "mode": "dry_run" if not args.apply else "apply",
+                "blocked": True,
+                "fingerprint": fingerprint,
+                "blocking_reasons": {
+                    "validation_errors": len(validation["errors"]),
+                    "drift_blockers": len(drift_blockers),
+                    "secret_findings": len(secret_findings),
+                    "tag_findings": len(tag_findings),
+                },
+                "schema_version": SCHEMA_VERSION,
+                "generated_at_utc": utc_now,
+            }
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+        elif not args.quiet:
+            print(report)
+        return 1
+
+    duplicate_run = is_duplicate_fingerprint(ledger, fingerprint)
+    is_duplicate = duplicate_run is not None
+
+    if is_duplicate and args.apply:
+        apply_run = build_apply_run(package, fingerprint, args.package, utc_now, ledger)
+        apply_run["status"] = "skipped_duplicate"
+        apply_run["summary"]["records_applied"] = 0
+        apply_run["summary"]["records_skipped"] = apply_run["summary"][
+            "total_records_in_package"
+        ]
+        ledger.append(apply_run)
+        save_ledger(output_dir, ledger)
+        report = format_apply_report(apply_run, ledger)
+        if args.emit_json:
+            result = {
+                "mode": "apply",
+                "blocked": False,
+                "skipped_duplicate": True,
+                "apply_run_id": apply_run["apply_run_id"],
+                "fingerprint": fingerprint,
+                "package_id": apply_run["package_id"],
+                "status": "skipped_duplicate",
+                "summary": apply_run["summary"],
+                "schema_version": SCHEMA_VERSION,
+                "generated_at_utc": utc_now,
+            }
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+        elif not args.quiet:
+            print(report)
+        return 0
+
+    if args.apply:
+        apply_run = build_apply_run(package, fingerprint, args.package, utc_now, ledger)
+        ledger.append(apply_run)
+        save_ledger(output_dir, ledger)
+        report = format_apply_report(apply_run, ledger)
+        if args.emit_json:
+            result = {
+                "mode": "apply",
+                "blocked": False,
+                "skipped_duplicate": False,
+                "apply_run_id": apply_run["apply_run_id"],
+                "fingerprint": fingerprint,
+                "package_id": apply_run["package_id"],
+                "status": "applied",
+                "summary": apply_run["summary"],
+                "schema_version": SCHEMA_VERSION,
+                "generated_at_utc": utc_now,
+            }
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+        elif not args.quiet:
+            print(report)
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #3289

Refs #3286

## Delivered

- **Tool:** \	ools/context/apply_context_brain_local.py\ — CLI für lokalen append-only Brain Apply
- **Tests:** \	ests/unit/tools/context/test_apply_context_brain_local.py\ — 41 Unit-Tests
- **Docs:** \docs/runbooks/CDB_CONTEXT_REFRESH.md\ §7

## Brain Evidence

\\\
brain_source: repo-only
brain_status: not-used
tools_or_queries: file_read, gh_cli, pytest, ruff, black
records_or_results:
  - tools/context/validate_context_package.py (Schema + Validator aus #3288)
  - tools/context/generate_context_drift_radar.py (Drift Radar aus #3291)
  - tools/context/generate_agent_briefing_seed.py (Briefing Seed aus #3290)
  - tools/context/generate_context_refresh_report.py (Report Generator aus #3287)
  - tools/context/schemas/context_package.schema.json (Schema ab #3288)
  - tests/unit/tools/context/test_validate_context_package.py (22 Tests)
  - tests/unit/tools/context/test_context_drift_radar.py (29 Tests)
  - docs/runbooks/CDB_CONTEXT_REFRESH.md (vorhandene Runbook-Doku)
repo_crosscheck:
  - commit 6f7bd745 (main, vorheriger Merge: #3291)
  - 41 Unit-Tests bestanden
  - ruff check passed
impact_on_plan: Keine Abweichung vom Prompt-Contract
limitations:
  - Keine DB-backed Evidence
  - Keine MCP-Tool-Queries
  - Keine SurrealDB-Records
  - repo-only brain_status
context_brain_attempted: true
context_brain_used: false
repo_fallback_used: true
repo_fallback_reason: unavailable
\\\

## Validation

| Check | Status |
|-------|--------|
| 41 Unit-Tests | ✅ all 41 passed |
| Ruff lint | ✅ All checks passed |
| Black format | ✅ reformatted |
| Bestehende Tests | ✅ all 129 context tests pass |
| Keine Secrets im Output | ✅ getestet |
| Keine Live/Echtgeld-Implikation | ✅ LR NO-GO im Tool verankert |
| Kein Netzwerk-Zugriff | ✅ offline-only |

## Safety Boundaries

- **Keine produktiven DB-Writes:** Nur lokales JSON-Ledger (append-only)
- **Keine SurrealDB-, MCP- oder Runtime-Mutation**
- **Keine Secrets in Outputs**
- **Keine Trading-State-Ingestion**
- **LR bleibt NO-GO**
- **Keine** \PERSIST_ALLOWED\/\MUTATION_ALLOWED\ **Semantik**
- **Default dry-run/report-only**

## Non-goals

- Kein produktiver SurrealDB-Apply (separates Follow-up)
- Keine Auto-Apply-Strategie
- Kein Onboarding (#3292) — bewusst ausgespart
- Keine Runtime/Docker/Compose-Änderungen
- Keine Secret-Ingestion oder -Exposure

## Restunsicherheiten

- Keine: Die Implementierung ist deterministisch, offline und fail-closed getestet.
  Ein echter SurrealDB-backed Apply bleibt als separates Follow-up designbar.