### PR TITLE
docs(agents): harden context brain fallback classification (#3298)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,11 +267,12 @@ OpenCode skill surface zusaetzlich: `.opencode/skills/` (gezielt laden, nicht pa
 
 ## Agent Operating Rules
 
-- **Context Brain first.** Jeder Agenten-Prompt MUSS vor Repo-Reads einen Context Brain Preflight versuchen. Repo-Fallback ist nur nach belegtem Fehlversuch erlaubt. Siehe `agents/AGENTS.md` § Context Brain Preflight Gate.
+- **Context Brain first.** Jeder Agenten-Prompt MUSS vor Repo-Reads einen Context Brain Preflight versuchen. Repo-Fallback ist nur nach belegtem Fehlversuch erlaubt. Siehe `agents/AGENTS.md` § Context Brain Preflight Gate (inkl. Fallback-Klassifikationsmatrix).
+- **Fallback-Klassifikation hart:** `repo_fallback_reason=unavailable` ist NUR erlaubt, wenn Context Tools wirklich nicht verfuegbar sind. Bei verfuegbarem Tool + LOW/no Records ist `insufficient_evidence` oder `missing_record` korrekt. Falsche Klassifikation blockiert den Workflow (`HOLD_BOOTLOADER_EVIDENCE_MISCLASSIFIED`).
 - Read `knowledge/governance/CDB_AGENT_POLICY.md` section 4 before any write.
 - Respect single-writer locks, explicit stop signals, and write gates.
 - `DELIVERY_APPROVED.yaml` is human-controlled; agents must not modify it.
-- Before planning for strategy/runtime/module/service/contract/context scope, output a `Brain Evidence` block (see `agents/AGENTS.md` § Brain Evidence Gate).
+- Before planning for strategy/runtime/module/service/contract/context scope, output a `Brain Evidence` block (see `agents/AGENTS.md` § Brain Evidence Gate). Der Block MUSS die Felder `context_tool_status`, `context_trust_level` und `records_found` enthalten.
 - LR status remains NO-GO for live trading unless explicitly changed by canon/human approval.
 
 ---

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -112,7 +112,30 @@ context_brain_attempted: true
 context_brain_used: true | false
 repo_fallback_used: true | false
 repo_fallback_reason: none | unavailable | stale | contradictory | insufficient_evidence | missing_record | tool_blocked
+context_tool_status: available | partial | blocked | absent
+context_trust_level: high | medium | low | none
+records_found: <count> | none
 ```
+
+### Fallback-Klassifikationsmatrix
+
+Welcher `repo_fallback_reason` bei welchem tatsächlichen Tool-Zustand korrekt ist:
+
+| Tool-Status | Trust-Level | Records Found | Korrekter `repo_fallback_reason` |
+|---|---|---|---|
+| `available` | `high` | >=1 | `none` (kein Fallback nötig) |
+| `available` | `low` | 0 | `insufficient_evidence` |
+| `available` | `medium` | 0 | `missing_record` |
+| `available` | `low` | >=1 (stale) | `stale` |
+| `available` | `any` | widersprüchlich | `contradictory` |
+| `partial` | `low` | 0 | `insufficient_evidence` |
+| `blocked` | `none` | 0 | `tool_blocked` |
+| `absent` | `none` | 0 | `unavailable` |
+
+**Härteregel:** `repo_fallback_reason=unavailable` ist NUR erlaubt, wenn der
+Context-Brain-Tool-Zugang wirklich fehlt (Tool nicht importierbar, nicht aufrufbar,
+nicht im aktiven MCP-Surface). Ein verfügbares Tool, das LOW Trust oder keine
+Records liefert, ist **nicht** `unavailable`.
 
 ### Regeln
 
@@ -129,6 +152,15 @@ repo_fallback_reason: none | unavailable | stale | contradictory | insufficient_
 4. Keine DB-backed Claims ohne Tool-/Query-/Record-Evidence.
 5. Context Brain / MCP-Ergebnisse autorisieren **keine** automatischen Code-,
    Issue- oder Write-Aktionen; Human-GO erforderlich.
+6. `context_brain_used=true` nur mit echter Tool-/Query-/Record-Evidence.
+   Context Briefing, session memory oder caller-supplied metadata allein
+   sind keine DB-backed Evidence.
+7. Falsche Fallback-Klassifikation (z. B. `unavailable` bei verfügbarem Tool mit
+   LOW/no Records) löst `HOLD_BOOTLOADER_EVIDENCE_MISCLASSIFIED` aus und blockiert
+   den weiteren Workflow bis zur Korrektur.
+8. Lokale Context-Refresh-/Brain-Apply-Artefakte aus #3287-#3291 sind als
+   repo-backed Brain-Evidence-Kandidaten zu prüfen, wenn Context Tools keine
+   Records liefern.
 
 ## Brain Evidence Gate
 
@@ -154,6 +186,9 @@ context_brain_attempted: true
 context_brain_used: true | false
 repo_fallback_used: true | false
 repo_fallback_reason: none | unavailable | stale | contradictory | insufficient_evidence | missing_record | tool_blocked
+context_tool_status: available | partial | blocked | absent
+context_trust_level: high | medium | low | none
+records_found: <count> | none
 ```
 
 ### Field Logic
@@ -166,8 +201,17 @@ repo_fallback_reason: none | unavailable | stale | contradictory | insufficient_
 - `brain_source=unavailable`: Klar `blocked` oder `repo-only fallback` melden.
 - `context_brain_attempted`: IMMER `true` — der Preflight-Versuch ist Pflicht.
 - `context_brain_used`: `true` nur wenn echte Tool-/Query-/Record-Evidence vorliegt.
+  Context Briefing, session memory oder caller-supplied metadata allein sind
+  keine DB-backed Evidence.
 - `repo_fallback_used`: `true` wenn nach Preflight auf Repo-Reads zurueckgefallen wurde.
-- `repo_fallback_reason`: Exakter Grund fuer Repo-Fallback (Enum).
+- `repo_fallback_reason`: Exakter Grund fuer Repo-Fallback (Enum). Siehe
+  Fallback-Klassifikationsmatrix oben: `unavailable` ist NUR bei echt fehlendem
+  Tool-Zugang erlaubt, nicht bei LOW/no Records.
+- `context_tool_status`: Tatsaechlicher Status des Context-Brain-Tools nach
+  Preflight-Versuch.
+- `context_trust_level`: Vertrauensniveau der gelieferten Evidence (kann auf
+  Tool-Metadaten oder Bundle-Signalen basieren).
+- `records_found`: Anzahl der gefundenen Records (0 bei `none`).
 
 ### Default posture (SSOT)
 
@@ -208,6 +252,9 @@ Higher wins; fail-closed when lower layers conflict:
 - GitHub/Repo/Live evidence wins over Brain/CIS claims.
 - Board-Stage `trade-capable` is not Live-Go.
 - LR remains NO-GO.
+- Falsche Fallback-Klassifikation (z. B. `unavailable` bei verfügbarem Tool mit
+  LOW/no Records) löst `HOLD_BOOTLOADER_EVIDENCE_MISCLASSIFIED` aus. Der Workflow
+  muss bis zur Korrektur blockiert bleiben.
 
 ## Legacy Note
 

--- a/tests/unit/agents/test_context_brain_bootloader_contract.py
+++ b/tests/unit/agents/test_context_brain_bootloader_contract.py
@@ -57,6 +57,4 @@ def test_context_brain_bootloader_contract_anchors(
     assert path.is_file(), f"missing canonical file: {relative_path}"
     text = path.read_text(encoding="utf-8")
     for needle in needles:
-        assert needle in text, (
-            f"{relative_path} missing contract anchor: {needle!r}"
-        )
+        assert needle in text, f"{relative_path} missing contract anchor: {needle!r}"

--- a/tests/unit/agents/test_context_brain_bootloader_contract.py
+++ b/tests/unit/agents/test_context_brain_bootloader_contract.py
@@ -1,0 +1,62 @@
+"""Contract anchors for Context Brain Bootloader enforcement (#3298).
+
+Static checks that agents/AGENTS.md and AGENTS.md contain the hardened
+fallback classification rules from #3298.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CANONICAL_FILES: dict[str, tuple[str, ...]] = {
+    "agents/AGENTS.md": (
+        "Context Brain Preflight Gate",
+        "Fallback-Klassifikationsmatrix",
+        "context_brain_attempted",
+        "context_brain_used",
+        "repo_fallback_reason",
+        "context_tool_status",
+        "context_trust_level",
+        "records_found",
+        "insufficient_evidence",
+        "missing_record",
+        "tool_blocked",
+        "unavailable",
+        "HOLD_BOOTLOADER_EVIDENCE_MISCLASSIFIED",
+        "repo_fallback_reason=unavailable",
+        "is a ledger, not live truth",
+        "GitHub/Repo/Live evidence wins",
+        "LR remains NO-GO",
+    ),
+    "AGENTS.md": (
+        "Context Brain first",
+        "Fallback-Klassifikation hart",
+        "repo_fallback_reason=unavailable",
+        "HOLD_BOOTLOADER_EVIDENCE_MISCLASSIFIED",
+        "insufficient_evidence",
+        "missing_record",
+        "context_tool_status",
+        "context_trust_level",
+        "records_found",
+        "LR status remains NO-GO",
+    ),
+}
+
+
+@pytest.mark.parametrize("relative_path,needles", list(CANONICAL_FILES.items()))
+def test_context_brain_bootloader_contract_anchors(
+    relative_path: str, needles: tuple[str, ...]
+) -> None:
+    path = REPO_ROOT / relative_path
+    assert path.is_file(), f"missing canonical file: {relative_path}"
+    text = path.read_text(encoding="utf-8")
+    for needle in needles:
+        assert needle in text, (
+            f"{relative_path} missing contract anchor: {needle!r}"
+        )


### PR DESCRIPTION
Closes #3298

## Delivered

- **agents/AGENTS.md**: Added explicit Fallback-Klassifikationsmatrix with 8 rows mapping Tool-Status + Trust-Level + Records-Found to the correct `repo_fallback_reason`.
- **agents/AGENTS.md**: Added three new required Brain Evidence fields: `context_tool_status`, `context_trust_level`, `records_found`.
- **agents/AGENTS.md**: Hardened Field Logic section to clarify that `unavailable` is only valid when tool access truly fails, not for LOW/no records.
- **agents/AGENTS.md**: Added Rule #6 (`context_brain_used=true` requires real tool/query/record evidence; briefing/session memory alone is insufficient).
- **agents/AGENTS.md**: Added Rule #7 (false classification triggers `HOLD_BOOTLOADER_EVIDENCE_MISCLASSIFIED`).
- **agents/AGENTS.md**: Added Rule #8 (local context-refresh/brain-apply artifacts from #3287-#3291 must be checked as repo-backed brain candidates).
- **agents/AGENTS.md**: Added `HOLD_BOOTLOADER_EVIDENCE_MISCLASSIFIED` to Brain Evidence Gate Rules.
- **AGENTS.md**: Hardened Agent Operating Rules: added explicit Fallback-Klassifikation entry and reference to classification matrix.
- **tests/unit/agents/test_context_brain_bootloader_contract.py**: New static contract test verifying that both AGENTS.md files contain the required contract anchors.

## Brain Evidence

- brain_source: repo-only
- brain_status: not-used
- tools_or_queries: gh issue search, gh label list, rg anchor search, pytest contract test
- records_or_results: No duplicate open issue found; 4 labels verified; 2 contract tests added (2/2 PASS)
- repo_crosscheck: AGENTS.md, agents/AGENTS.md, tests/unit/agents/test_context_brain_bootloader_contract.py
- impact_on_plan: Scope confirmed as docs/governance only; no Runtime/DB/MCP/LR changes needed
- limitations: No Context Brain MCP records available in this session; repo-only evidence used

## Context Brain classification fix

The real observed weakness was: `repo_fallback_reason=unavailable` was used when Context Tools are available but produce LOW/no-record evidence. The fix:

1. Adds a classification matrix that maps tool status + trust level + records to the correct reason.
2. Explicitly states: `unavailable` = tool truly missing/blocked. Available tool + LOW/no records = `insufficient_evidence` or `missing_record`.
3. Adds `HOLD_BOOTLOADER_EVIDENCE_MISCLASSIFIED` as a stop condition for wrong classification.
4. Adds `context_tool_status`, `context_trust_level`, and `records_found` fields so agents can report the exact tool state.

## Validation

```bash
rg -n "Context Brain Preflight Gate|repo_fallback_reason|insufficient_evidence|missing_record|tool_blocked|context_tool_status|trust_level|records_found|HOLD_BOOTLOADER_EVIDENCE_MISCLASSIFIED" AGENTS.md agents/AGENTS.md
# -> All anchors confirmed present in both files.

pytest -q tests/unit/agents/test_context_brain_bootloader_contract.py
# -> 2 passed in 0.05s

pytest -q tests/unit/agents/test_agent_brain_adoption_contract.py
# -> 4 passed in 0.08s (existing contract still passes)

git diff --check
# -> No whitespace errors
```

## Safety Boundaries

- LR: NO-GO
- Board: trade-capable (not Live-Go)
- No Runtime/Docker/DB/MCP/SurrealDB changes
- No secrets in output
- No productive writes

## Non-goals

- No onboarding #3292 implementation
- No productive Brain Apply
- No SurrealDB integration
- No MCP mutation
- No Live/Echtgeld changes

## Restunsicherheiten

- The classification matrix cannot be enforced at runtime; it serves as a governance contract that agent harnesses and reviews must check.
- The static test checks for string anchors, not semantic correctness of an agent's actual Brain Evidence block.
- #3292 onboarding scenario remains a separate deferred item that should eventually validate this contract end-to-end.
