### PR TITLE
docs(onboarding): add root README slash command discovery (#3300)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Stage und LR sind orthogonale Systeme: `trade-capable` autorisiert kein Live-Tra
 
 ## Agent Entry
 
+- `/onboarding` — schnellster Discovery-Einstieg fuer frische Agenten (Skill: `.opencode/skills/onboarding/`)
 - Bootloader-Reihenfolge: [`AGENTS.md`](AGENTS.md) -> [`agents/AGENTS.md`](agents/AGENTS.md) -> [`agents/OPEN_CODE_AGENTS.md`](agents/OPEN_CODE_AGENTS.md)
 - Status-Surfaces zuerst getrennt lesen: [`docs/runbooks/CONTROL_REGISTER.md`](docs/runbooks/CONTROL_REGISTER.md), [`CURRENT_STATUS.md`](CURRENT_STATUS.md), [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)
 


### PR DESCRIPTION
Closes #3300
Refs #3292

## Delivered

- Added `/onboarding` as first entry in `## Agent Entry` section of root README.md
- References canonical onboarding skill at `.opencode/skills/onboarding/`
- Describes it as "schnellster Discovery-Einstieg fuer frische Agenten"
- No runtime/Docker/DB/MCP/Live changes

## Brain Evidence

- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_tool_status: available
- context_trust_level: low (no DB-backed records in session)
- records_found: 0
- context_brain_used: false
- repo_fallback_used: true
- repo_fallback_reason: insufficient_evidence
- tools_or_queries: rg surface discovery, gh issue views
- records_or_results: Canonical onboarding skill found at `.opencode/skills/onboarding/SKILL.md`
- repo_crosscheck: README.md, .opencode/skills/onboarding/SKILL.md
- impact_on_plan: Docs-only; no test added (no existing README test surface)
- limitations: No DB-backed records; repo-only evidence

## Validation

```bash
git diff --check                    # no whitespace errors
rg -n "/onboarding" README.md      # line 44: `/onboarding` present
rg -n "NO-GO|trade-capable" README.md  # safety framing preserved
```

## Safety Boundaries

- LR: NO-GO | Board: trade-capable (not Live-Go)
- No Runtime/Docker/DB/MCP/SurrealDB changes
- No secrets
- No #3292 implementation

## Non-goals

- No onboarding scenario #3292 implementation
- No new skill creation
- No README restructuring
- No test added (docs-only change, no existing README test surface)

## Restunsicherheiten

- /onboarding exists as skill, but #3292 onboarding scenario test is not yet defined
- No automated test validates this README entry; rely on rg-based validation
