### PR TITLE
docs(audit): clarify cdb_node_exporter legacy runtime status

### DIFF
--- a/docs/runbooks/legacy_service_drift.md
+++ b/docs/runbooks/legacy_service_drift.md
@@ -1,0 +1,56 @@
+# Legacy Service Drift — Operator-Prüfpfad
+
+**Erstellt:** 2026-06-18 (Audit #3302)
+**Scope:** Erkennung und Klassifikation unerwarteter Legacy-Container im BLUE+RED-Stack
+**Referenz:** `knowledge/governance/SERVICE_CATALOG.md` § Entfernte Services (Legacy)
+
+---
+
+## Betroffener Service
+
+| Service | Status | Erwarteter Runtime-Zustand |
+|---------|--------|---------------------------|
+| `cdb_node_exporter` | LEGACY (entfernt 2026-04-09, #1528/PR #1535) | `absent` — kein Container im BLUE/RED-Stack |
+
+---
+
+## Read-Only-Prüfung
+
+```powershell
+# Prüfen, ob ein cdb_node_exporter-Container läuft
+docker ps --filter "name=cdb_node_exporter" --format "table {{.Names}}\t{{.Status}}\t{{.Image}}"
+
+# Prüfen, ob der Container aus einem bestimmten Compose-Projekt stammt
+docker inspect cdb_node_exporter --format "{{index .Config.Labels `com.docker.compose.project`}}" 2>$null
+```
+
+---
+
+## Klassifikation
+
+| Befund | Klassifikation | Aktion |
+|--------|---------------|--------|
+| Kein Container | **OK** — erwarteter Zustand | Keine Aktion |
+| Container läuft, Compose-Projekt = `claire_de_binare` oder `cdb_*` | **Unerwarteter Runtime-Drift** — Container aus historischem Compose-Projekt (vor #1528-Bereinigung) | Gordon-Gate einholen; keine selbstständige Container-Mutation |
+| Container läuft, kein Compose-Projekt-Label | **Unerwarteter Runtime-Drift** — Container manuell oder extern gestartet | Gordon-Gate einholen; keine selbstständige Container-Mutation |
+
+---
+
+## Bereinigung (nur mit Gordon-Gate)
+
+```powershell
+# Container stoppen und entfernen (nur nach explizitem Gordon-Go)
+docker stop cdb_node_exporter
+docker rm cdb_node_exporter
+```
+
+---
+
+## Referenzen
+
+- `knowledge/governance/SERVICE_CATALOG.md` — Entfernte Services (Legacy)
+- `infrastructure/compose/SERVICE_MAPPING.md` — Removed Services
+- `infrastructure/docs/BLUE_RED_SPLIT.md` — Removed Services
+- `infrastructure/monitoring/METRICS_MATRIX.md` — Canon- und Dokudrift (§4)
+- Issue #1528 — ursprüngliche Bereinigung (CLOSED, PR #1535)
+- Issue #3302 — aktuelles Audit (dieses Runbook)

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -150,6 +150,20 @@ Aktivierung: `docker compose -f infrastructure/compose/compose.blue.yml -f infra
 
 ---
 
+## Entfernte Services (Legacy)
+
+Services, die aus dem aktiven BLUE+RED-Runtime-Canon entfernt wurden. Kein Container im BLUE/RED-Stack erwartet.
+
+| Service | Entfernt | Grund | Alternative |
+|---------|----------|-------|-------------|
+| `cdb_node_exporter` | 2026-04-09 (#1528, PR #1535) | Windows/WSL2-Mount-Propagation-Probleme; kein unterstuetztes Host-Node-Exporter-Surface im aktuellen Stack | cAdvisor fuer Container-Metriken; keine Host-Node-Metriken im aktuellen Canon |
+
+Erwarteter Runtime-Zustand: `absent` — kein `cdb_node_exporter`-Container im BLUE/RED-Stack. Ein laufender Container ist unerwarteter Runtime-Drift (Pruefpfad: `docs/runbooks/legacy_service_drift.md`).
+
+Referenz: `infrastructure/compose/SERVICE_MAPPING.md`, `infrastructure/docs/BLUE_RED_SPLIT.md`, `infrastructure/monitoring/METRICS_MATRIX.md`.
+
+---
+
 ## GAP-Analyse
 
 ### Aktuell keine kritischen GAPs
@@ -212,6 +226,7 @@ Referenz: `infrastructure/compose/SERVICE_MAPPING.md`, PR #2670.
 - [ ] GAP-Services bewusst nicht gestartet (dokumentiert)
 - [ ] BEREIT-Services bewusst deaktiviert (Begründung aktuell)
 - [ ] Keine unbekannten Container im Stack
+- [ ] Legacy-Services (cdb_node_exporter) nicht im Stack (Pruefpfad: `docs/runbooks/legacy_service_drift.md`)
 
 ---
 
@@ -241,6 +256,7 @@ Referenz: `infrastructure/compose/SERVICE_MAPPING.md`, PR #2670.
 | 2026-06-05 | PRs #2999/#3001/#3003 Nachzug: § Navigation READMEs + README-Spalte; Paper Runner Code `tools/paper_trading/` explizit; Replay/DB README-Links (Issues #3000/#3004) | Cursor |
 | 2026-06-06 | PRs #3016/#3019/#3022 Nachzug: Stimulus-Determinismus und Wall-Clock-Override für Freshness (RC_004) in Market & Candles dokumentiert (Issues #3017/#3020/#3023) | Codex |
 | 2026-06-08 | PR #3081 Nachzug: `historical_bridge.py` + `evaluate_price_policies.py` als Replay-Infrastruktur-Komponenten im Core-Libraries-Katalog ergänzt; `price_policy`-Support vermerkt (Issue #3082) | Codex |
+| 2026-06-18 | Audit #3302: Entfernte-Services-Sektion ergänzt; cdb_node_exporter als LEGACY mit Decommission-Datum, Grund, Alternative, erwartetem Runtime-Zustand und Runbook-Prüfpfad dokumentiert; Prüf-Checkliste um Legacy-Check ergänzt | Codex |
 ## PostgreSQL Schema Artefacts
 
 | Artefakt | Migration | Status | Bedeutung |


### PR DESCRIPTION
Closes #3302
Refs #1528

## Brain Evidence

brain_source: repo-only
brain_status: not-used
context_brain_attempted: true
context_brain_used: false
repo_fallback_used: true
repo_fallback_reason: insufficient_evidence
context_tool_status: available
context_trust_level: low
records_found: 0

## Bootloader Evidence

- AGENTS.md (Root-Pointer): gelesen
- agents/AGENTS.md (Kanonische Agenten-Registry): gelesen
- Read Order §7 CURRENT_STATUS.md: gelesen
- Read Order §8 LR-AUDIT-STATUS: gelesen (NO-GO bestätigt)
- Read Order §9 CONTROL_REGISTER.md: gelesen
- GitHub Live: gh issue view 3302 + 1528

## Delivered

1. **SERVICE_CATALOG.md**: Neue Sektion Entfernte Services (Legacy) mit cdb_node_exporter-Eintrag: Decommission-Datum (2026-04-09), Grund (Windows/WSL2-Mount-Propagation), Alternative (cAdvisor), erwarteter Runtime-Zustand (absent), Runbook-Prüfpfad. Prüf-Checkliste um Legacy-Check ergänzt. Änderungshistorie ergänzt.

2. **docs/runbooks/legacy_service_drift.md**: Neues Operator-Runbook mit Read-Only-Prüfpfad (docker ps --filter, docker inspect Compose-Projekt-Label), Klassifikationsmatrix (OK / Unerwarteter Runtime-Drift), Bereinigungsanleitung (nur mit Gordon-Gate), und vollständigen Referenzen.

## Validation

- git diff --check: clean (nur Windows LF→CRLF warning)
- rg node_exporter: alle 5 kanonischen Quellen konsistent (SERVICE_CATALOG, METRICS_MATRIX, BLUE_RED_SPLIT, SERVICE_MAPPING, legacy_service_drift.md)
- Keine compose-/prometheus-/alert-Änderung (bereits durch #1528 bereinigt)
- Keine scope-Ausweitung auf #3303/#3304/#3305

## Safety Boundaries

- LR: NO-GO (unverändert)
- Keine Docker-/Runtime-Mutation
- Keine Container-Mutation (Gordon-Gate nicht eingeholt, da nicht erforderlich für Docs-Only-Change)
- Keine Secrets
- Keine Echtgeld-/Live-Trading-Änderung

## Gordon Gate

Nicht erforderlich: Dieser PR enthält ausschließlich Docs-Änderungen (SERVICE_CATALOG.md + neues Runbook). Keine Docker-/Compose-/Runtime-Mutation. Falls ein laufender cdb_node_exporter-Container tatsächlich existiert, ist dies als unerwarteter Runtime-Drift dokumentiert; die Bereinigung erfordert ein separates Gordon-Gate + Follow-up-Issue.

## Restunsicherheiten

- Container-Laufstatus nicht live verifiziert (Plan-Mode → Docs-Only-Audit). Falls cdb_node_exporter tatsächlich läuft: Follow-up-Issue für Gordon-basierte Host-Bereinigung nötig.
- Kein zweiter Legacy-Service (cdb_loki, cdb_promtail) in dieser Sektion — die sind im Logging Overlay weiterhin als OVERLAY definiert.