### PR TITLE
docs(audit): record cdb_market_eth legacy runtime drift

### DIFF
--- a/docs/runbooks/legacy_service_drift.md
+++ b/docs/runbooks/legacy_service_drift.md
@@ -6,22 +6,29 @@
 
 ---
 
-## Betroffener Service
+## Betroffene Services
 
 | Service | Status | Erwarteter Runtime-Zustand |
 |---------|--------|---------------------------|
 | `cdb_node_exporter` | LEGACY (entfernt 2026-04-09, #1528/PR #1535) | `absent` — kein Container im BLUE/RED-Stack |
+| `cdb_market_eth` | LEGACY (entfernt 2026-06-18, #3303) | `absent` — kein Container im BLUE/RED-Stack |
 
 ---
 
 ## Read-Only-Prüfung
 
 ```powershell
-# Prüfen, ob ein cdb_node_exporter-Container läuft
+# cdb_node_exporter — Prüfen, ob ein Container läuft
 docker ps --filter "name=cdb_node_exporter" --format "table {{.Names}}\t{{.Status}}\t{{.Image}}"
 
-# Prüfen, ob der Container aus einem bestimmten Compose-Projekt stammt
+# cdb_node_exporter — Compose-Projekt-Herkunft prüfen
 docker inspect cdb_node_exporter --format "{{index .Config.Labels `com.docker.compose.project`}}" 2>$null
+
+# cdb_market_eth — Prüfen, ob ein Container läuft (Port 8011, Image claire_de_binare-cdb_market_eth)
+docker ps --filter "name=cdb_market_eth" --format "table {{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Ports}}"
+
+# cdb_market_eth — V3-Env redacted prüfen (MARKET_V3_SYMBOL, MARKET_V3_CLIENT_ENABLED, MARKET_V3_LIVE_WRITE)
+docker inspect cdb_market_eth --format "{{range .Config.Env}}{{println .}}{{end}}" 2>$null | Select-String "MARKET_V3|MARKET_PORT"
 ```
 
 ---
@@ -39,9 +46,15 @@ docker inspect cdb_node_exporter --format "{{index .Config.Labels `com.docker.co
 ## Bereinigung (nur mit Gordon-Gate)
 
 ```powershell
-# Container stoppen und entfernen (nur nach explizitem Gordon-Go)
+# cdb_node_exporter — Container stoppen und entfernen (nur nach explizitem Gordon-Go)
 docker stop cdb_node_exporter
 docker rm cdb_node_exporter
+
+# cdb_market_eth — Container stoppen und entfernen (nur nach explizitem Gordon-Go)
+# Image-Remove erfordert separates Gordon-Go (forensische Nachvollziehbarkeit).
+# Keine Reaktivierung ohne eigenes Design-/Evidence-Issue.
+docker stop cdb_market_eth
+docker rm cdb_market_eth
 ```
 
 ---
@@ -52,5 +65,8 @@ docker rm cdb_node_exporter
 - `infrastructure/compose/SERVICE_MAPPING.md` — Removed Services
 - `infrastructure/docs/BLUE_RED_SPLIT.md` — Removed Services
 - `infrastructure/monitoring/METRICS_MATRIX.md` — Canon- und Dokudrift (§4)
-- Issue #1528 — ursprüngliche Bereinigung (CLOSED, PR #1535)
-- Issue #3302 — aktuelles Audit (dieses Runbook)
+- Issue #1528 — ursprüngliche Bereinigung `cdb_node_exporter` (CLOSED, PR #1535)
+- Issue #3302 — Audit `cdb_node_exporter` (dieses Runbook)
+- Issue #3303 — Audit + Decommission `cdb_market_eth`
+- Issue #1596 — 503-Bug cdb_market/cdb_market_eth (CLOSED)
+- Issue #1206 — ursprünglicher V3-Market-Branch (nicht auf main)

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -157,8 +157,9 @@ Services, die aus dem aktiven BLUE+RED-Runtime-Canon entfernt wurden. Kein Conta
 | Service | Entfernt | Grund | Alternative |
 |---------|----------|-------|-------------|
 | `cdb_node_exporter` | 2026-04-09 (#1528, PR #1535) | Windows/WSL2-Mount-Propagation-Probleme; kein unterstuetztes Host-Node-Exporter-Surface im aktuellen Stack | cAdvisor fuer Container-Metriken; keine Host-Node-Metriken im aktuellen Canon |
+| `cdb_market_eth` | 2026-06-18 (#3303) | Branch/#1206-V3 Runtime-Artefakt, nie main-backed. Container schrieb mit MARKET_V3_LIVE_WRITE=true auf market_state:ETHUSDT — Race Condition mit cdb_market. Kein Code (mexc_v3_client.py) und keine Compose-Definition auf main. | cdb_market (Port 8009) ist der einzige kanonische Market-Service |
 
-Erwarteter Runtime-Zustand: `absent` — kein `cdb_node_exporter`-Container im BLUE/RED-Stack. Ein laufender Container ist unerwarteter Runtime-Drift (Pruefpfad: `docs/runbooks/legacy_service_drift.md`).
+Erwarteter Runtime-Zustand: `absent` — kein `cdb_node_exporter`- oder `cdb_market_eth`-Container im BLUE/RED-Stack. Ein laufender Container ist unerwarteter Runtime-Drift (Pruefpfad: `docs/runbooks/legacy_service_drift.md`).
 
 Referenz: `infrastructure/compose/SERVICE_MAPPING.md`, `infrastructure/docs/BLUE_RED_SPLIT.md`, `infrastructure/monitoring/METRICS_MATRIX.md`.
 


### PR DESCRIPTION
Closes #3303

## Gordon Gate
- Gordon-Gate-Anfrage gestellt und GO erhalten.
- Container-Mutation (stop + rm) durchgefuehrt.

## Docker Evidence

### Pre-Mutation
| Feld | Wert |
|------|------|
| Container | cdb_market_eth, Up 14h (healthy), Port 8011 |
| Image | claire_de_binare-cdb_market_eth:latest |
| Image ID | sha256:9dd63dc4569015158136eef1b300f5b1bb5f56ac5ad348c34ebaedce9df55c78 |
| Created | 2026-03-18T18:56:06 UTC |
| Env | MARKET_V3_SYMBOL=ETHUSDT, MARKET_V3_CLIENT_ENABLED=true, MARKET_V3_LIVE_WRITE=true, MARKET_PORT=8011, MARKET_STATE_KEY_PREFIX=market_state |
| Herkunft | Branch/#1206-V3 (nie auf main) |
| Repo-Code | 0 Referenzen auf MARKET_V3_* oder mexc_v3_client.py auf main |
| Repo-Compose | 0 Compose-Dateien definieren cdb_market_eth |

### Post-Mutation
- Container gestoppt + entfernt
- Image behalten (Image-ID dokumentiert, kein docker rmi ohne separates Gordon-Go)
- cdb_market Hauptservice unverändert healthy auf Port 8009

## Decommission Result
\\\
docker stop cdb_market_eth  # ok
docker rm cdb_market_eth    # ok
docker ps --filter name=cdb_market_eth   # empty
docker ps -a --filter name=cdb_market_eth # empty
\\\

## Docs Delivered
- \knowledge/governance/SERVICE_CATALOG.md\: cdb_market_eth als LEGACY in Entfernte Services
- \docs/runbooks/legacy_service_drift.md\: Erkennung, Gordon-Stop/Remove, Keine-Reaktivierung-Policy

## Validation
- git diff --check: clean
- rg cdb_market_eth|MARKET_V3|mexc_v3_client in infrastructure/compose services/market: 0 Treffer
- cdb_market Hauptservice: Up 14h (healthy)

## Safety Boundaries
- LR: NO-GO (unverändert)
- Keine V3-Code-Reaktivierung
- Keine Compose-Erweiterung
- Kein Live-Trading-Go
- Keine Secrets im Output

## Restunsicherheiten
- Image-ID dokumentiert, Image noch auf Host (docker rmi erst nach separatem Gordon-Go)
- Consumer von market_state:ETHUSDT (falls es welche gab) erhalten jetzt nur noch cdb_market-Daten — keine Race Condition mehr

Refs #1596, #3307