### PR TITLE
docs(audit): #3304 decommission lr030/lr040 soak monitors, add Scheduler cleanup

### DIFF
--- a/docs/operations/72H_SOAK_TEST_RUNBOOK.md
+++ b/docs/operations/72H_SOAK_TEST_RUNBOOK.md
@@ -158,7 +158,7 @@ grep -B2 "soak_test: abort" infrastructure/monitoring/alerts.yml
 ## Stop / Abort Procedure
 
 ```bash
-# 1. Remove cron
+# 1. Remove cron (Linux)
 crontab -l | grep -v soak_monitor | crontab -
 
 # 2. Capture final state
@@ -168,6 +168,11 @@ docker stats --no-stream > artifacts/final_resources.txt
 
 # 3. Stop stack (optional — may keep running for investigation)
 docker compose -f infrastructure/compose/compose.blue.yml down
+```
+
+```powershell
+# Windows: Scheduler-Tasks deaktivieren statt Cron (nicht loeschen, #3304)
+Get-ScheduledTask -TaskName "CDB_LR040_SoakMonitor", "CDB_Soak_Sidecar" -ErrorAction SilentlyContinue | Disable-ScheduledTask
 ```
 
 ## Post-run

--- a/docs/operations/SOAK_MONITOR_RUNBOOK.md
+++ b/docs/operations/SOAK_MONITOR_RUNBOOK.md
@@ -210,11 +210,21 @@ python infrastructure/scripts/lr030_soak_supervisor.py \
 ## Disable / Rollback
 
 ```bash
-# Remove cron entry
+# Remove cron entry (Linux)
 crontab -e   # delete the soak_monitor line
 
 # Or comment out temporarily
 # 0 * * * * cd /path/to/repo && ./infrastructure/scripts/soak_monitor.sh ...
+```
+
+```powershell
+# Windows Task Scheduler — Soak-Tasks deaktivieren (nach Phasenabschluss, #3304)
+Get-ScheduledTask -TaskName "CDB_LR040_SoakMonitor", "CDB_Soak_Sidecar" -ErrorAction SilentlyContinue | Disable-ScheduledTask
+
+# Tasks nicht loeschen (forensische Nachvollziehbarkeit).
+# Container nach Scheduler-Deaktivierung stoppen + entfernen:
+#   docker stop lr030_soak_monitor lr040_soak_monitor
+#   docker rm lr030_soak_monitor lr040_soak_monitor
 ```
 
 No rollback needed for the script itself; it is read-only against the stack.

--- a/docs/runbooks/legacy_service_drift.md
+++ b/docs/runbooks/legacy_service_drift.md
@@ -1,7 +1,7 @@
 # Legacy Service Drift — Operator-Prüfpfad
 
-**Erstellt:** 2026-06-18 (Audit #3302)
-**Scope:** Erkennung und Klassifikation unerwarteter Legacy-Container im BLUE+RED-Stack
+**Erstellt:** 2026-06-18 (Audit #3302, #3304)
+**Scope:** Erkennung und Klassifikation unerwarteter Legacy-Container im BLUE+RED-Stack inkl. Soak-Monitore und Scheduler-Tasks
 **Referenz:** `knowledge/governance/SERVICE_CATALOG.md` § Entfernte Services (Legacy)
 
 ---
@@ -12,6 +12,8 @@
 |---------|--------|---------------------------|
 | `cdb_node_exporter` | LEGACY (entfernt 2026-04-09, #1528/PR #1535) | `absent` — kein Container im BLUE/RED-Stack |
 | `cdb_market_eth` | LEGACY (entfernt 2026-06-18, #3303) | `absent` — kein Container im BLUE/RED-Stack |
+| `lr030_soak_monitor` | LEGACY (decommissioned 2026-06-18, #3304) | `absent` — kein Container; Windows-Task `CDB_Soak_Sidecar` deaktiviert |
+| `lr040_soak_monitor` | LEGACY (decommissioned 2026-06-18, #3304) | `absent` — kein Container; Windows-Task `CDB_LR040_SoakMonitor` deaktiviert |
 
 ---
 
@@ -29,6 +31,15 @@ docker ps --filter "name=cdb_market_eth" --format "table {{.Names}}\t{{.Status}}
 
 # cdb_market_eth — V3-Env redacted prüfen (MARKET_V3_SYMBOL, MARKET_V3_CLIENT_ENABLED, MARKET_V3_LIVE_WRITE)
 docker inspect cdb_market_eth --format "{{range .Config.Env}}{{println .}}{{end}}" 2>$null | Select-String "MARKET_V3|MARKET_PORT"
+
+# lr030_soak_monitor — Prüfen, ob ein Container läuft (Image ubuntu:22.04, kein Compose)
+docker ps --filter "name=lr030_soak_monitor" --format "table {{.Names}}\t{{.Status}}\t{{.Image}}"
+
+# lr040_soak_monitor — Prüfen, ob ein Container läuft (Image ubuntu:22.04, kein Compose)
+docker ps --filter "name=lr040_soak_monitor" --format "table {{.Names}}\t{{.Status}}\t{{.Image}}"
+
+# Soak Scheduler-Tasks — Prüfen, ob Windows-Tasks noch aktiv sind
+Get-ScheduledTask -TaskName "CDB_LR040_SoakMonitor", "CDB_Soak_Sidecar" -ErrorAction SilentlyContinue | Format-Table TaskName, State
 ```
 
 ---
@@ -70,3 +81,4 @@ docker rm cdb_market_eth
 - Issue #3303 — Audit + Decommission `cdb_market_eth`
 - Issue #1596 — 503-Bug cdb_market/cdb_market_eth (CLOSED)
 - Issue #1206 — ursprünglicher V3-Market-Branch (nicht auf main)
+- Issue #3304 — Audit + Decommission `lr030_soak_monitor` / `lr040_soak_monitor` + Scheduler `CDB_LR040_SoakMonitor` / `CDB_Soak_Sidecar`

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -158,8 +158,10 @@ Services, die aus dem aktiven BLUE+RED-Runtime-Canon entfernt wurden. Kein Conta
 |---------|----------|-------|-------------|
 | `cdb_node_exporter` | 2026-04-09 (#1528, PR #1535) | Windows/WSL2-Mount-Propagation-Probleme; kein unterstuetztes Host-Node-Exporter-Surface im aktuellen Stack | cAdvisor fuer Container-Metriken; keine Host-Node-Metriken im aktuellen Canon |
 | `cdb_market_eth` | 2026-06-18 (#3303) | Branch/#1206-V3 Runtime-Artefakt, nie main-backed. Container schrieb mit MARKET_V3_LIVE_WRITE=true auf market_state:ETHUSDT — Race Condition mit cdb_market. Kein Code (mexc_v3_client.py) und keine Compose-Definition auf main. | cdb_market (Port 8009) ist der einzige kanonische Market-Service |
+| `lr030_soak_monitor` | 2026-06-18 (#3304) | LR-030 Soak-Phase (#2440) abgeschlossen (PASS 2026-05-17). Container lief standalone ausserhalb Compose mit `ubuntu:22.04` + `soak_entrypoint.sh`. Windows-Task `CDB_Soak_Sidecar` ebenfalls deaktiviert. | `cdb_prometheus` + `cdb_cadvisor` für Runtime-Monitoring |
+| `lr040_soak_monitor` | 2026-06-18 (#3304) | LR-040 Soak-Phase (#1420/#786) abgeschlossen (PASS 2026-04-04). Container lief standalone ausserhalb Compose mit `ubuntu:22.04` + `soak_entrypoint.sh`. Windows-Task `CDB_LR040_SoakMonitor` ebenfalls deaktiviert. | `cdb_prometheus` + `cdb_cadvisor` für Runtime-Monitoring |
 
-Erwarteter Runtime-Zustand: `absent` — kein `cdb_node_exporter`- oder `cdb_market_eth`-Container im BLUE/RED-Stack. Ein laufender Container ist unerwarteter Runtime-Drift (Pruefpfad: `docs/runbooks/legacy_service_drift.md`).
+Erwarteter Runtime-Zustand: `absent` — kein `cdb_node_exporter`-, `cdb_market_eth`-, `lr030_soak_monitor`- oder `lr040_soak_monitor`-Container im BLUE/RED-Stack. Ein laufender Container ist unerwarteter Runtime-Drift (Pruefpfad: `docs/runbooks/legacy_service_drift.md`).
 
 Referenz: `infrastructure/compose/SERVICE_MAPPING.md`, `infrastructure/docs/BLUE_RED_SPLIT.md`, `infrastructure/monitoring/METRICS_MATRIX.md`.
 
@@ -258,6 +260,7 @@ Referenz: `infrastructure/compose/SERVICE_MAPPING.md`, PR #2670.
 | 2026-06-06 | PRs #3016/#3019/#3022 Nachzug: Stimulus-Determinismus und Wall-Clock-Override für Freshness (RC_004) in Market & Candles dokumentiert (Issues #3017/#3020/#3023) | Codex |
 | 2026-06-08 | PR #3081 Nachzug: `historical_bridge.py` + `evaluate_price_policies.py` als Replay-Infrastruktur-Komponenten im Core-Libraries-Katalog ergänzt; `price_policy`-Support vermerkt (Issue #3082) | Codex |
 | 2026-06-18 | Audit #3302: Entfernte-Services-Sektion ergänzt; cdb_node_exporter als LEGACY mit Decommission-Datum, Grund, Alternative, erwartetem Runtime-Zustand und Runbook-Prüfpfad dokumentiert; Prüf-Checkliste um Legacy-Check ergänzt | Codex |
+| 2026-06-18 | Audit #3304: `lr030_soak_monitor` + `lr040_soak_monitor` als LEGACY dokumentiert; Container decommissioned, Windows-Tasks `CDB_LR040_SoakMonitor` + `CDB_Soak_Sidecar` deaktiviert; Runbooks um Windows-Scheduler-Cleanup ergänzt | OpenCode |
 ## PostgreSQL Schema Artefacts
 
 | Artefakt | Migration | Status | Bedeutung |


### PR DESCRIPTION
## Audit #3304 — Decommission lr030/lr040 soak monitors

### Befund
- \lr030_soak_monitor\ + \lr040_soak_monitor\ liefen als Standalone-Container (ubuntu:22.04, kein Compose)
- Soak-Phasen längst abgeschlossen: #2440 CLOSED PASS (2026-05-17), #1420 CLOSED PASS (2026-04-04)
- Windows Task Scheduler \CDB_LR040_SoakMonitor\ + \CDB_Soak_Sidecar\ weiterhin \Ready\
- Kein Eintrag im SERVICE_CATALOG

### Durchgeführte Decommission (Jannek-Ops-GO)
- Container \lr030_soak_monitor\ + \lr040_soak_monitor\ gestoppt + entfernt
- Scheduler-Tasks \CDB_LR040_SoakMonitor\ + \CDB_Soak_Sidecar\ deaktiviert
- Docker Images behalten, Tasks nicht gelöscht

### Docs (dieser PR)
- \SERVICE_CATALOG.md\ — Soak-Monitore in Entfernte Services (Legacy)
- \legacy_service_drift.md\ — Read-Only-Prüfpfade für Soak-Container + Scheduler
- \SOAK_MONITOR_RUNBOOK.md\ — Windows Scheduler Disable-Befehle
- \72H_SOAK_TEST_RUNBOOK.md\ — Windows Scheduler Cleanup-Hinweise

### Guardrails
- Kein LR-Status-Upgrade
- Kein Live-/Echtgeld-Go
- Kein Scope auf #3305 mockx-valkey
- LR bleibt NO-GO