### PR TITLE
docs(audit): clarify mockx valkey lifecycle

### DIFF
--- a/docs/runbooks/legacy_service_drift.md
+++ b/docs/runbooks/legacy_service_drift.md
@@ -1,8 +1,8 @@
 # Legacy Service Drift — Operator-Prüfpfad
 
-**Erstellt:** 2026-06-18 (Audit #3302, #3304)
-**Scope:** Erkennung und Klassifikation unerwarteter Legacy-Container im BLUE+RED-Stack inkl. Soak-Monitore und Scheduler-Tasks
-**Referenz:** `knowledge/governance/SERVICE_CATALOG.md` § Entfernte Services (Legacy)
+**Erstellt:** 2026-06-18 (Audit #3302, #3304, #3305)
+**Scope:** Erkennung und Klassifikation unerwarteter Legacy-/Referenz-Container im BLUE+RED-Stack inkl. Soak-Monitore, Scheduler-Tasks und MockX Valkey
+**Referenz:** `knowledge/governance/SERVICE_CATALOG.md` § Entfernte Services (Legacy) und § Referenz-/Dev-Test-Infrastruktur
 
 ---
 
@@ -14,6 +14,7 @@
 | `cdb_market_eth` | LEGACY (entfernt 2026-06-18, #3303) | `absent` — kein Container im BLUE/RED-Stack |
 | `lr030_soak_monitor` | LEGACY (decommissioned 2026-06-18, #3304) | `absent` — kein Container; Windows-Task `CDB_Soak_Sidecar` deaktiviert |
 | `lr040_soak_monitor` | LEGACY (decommissioned 2026-06-18, #3304) | `absent` — kein Container; Windows-Task `CDB_LR040_SoakMonitor` deaktiviert |
+| `mockx-valkey` | Non-canonical dev/test reference infra (#3305, #1648) | `absent by default` — nur waehrend expliziter MockX test-pack Session |
 
 ---
 
@@ -40,6 +41,13 @@ docker ps --filter "name=lr040_soak_monitor" --format "table {{.Names}}\t{{.Stat
 
 # Soak Scheduler-Tasks — Prüfen, ob Windows-Tasks noch aktiv sind
 Get-ScheduledTask -TaskName "CDB_LR040_SoakMonitor", "CDB_Soak_Sidecar" -ErrorAction SilentlyContinue | Format-Table TaskName, State
+
+# mockx-valkey — Pruefen, ob ein Container laeuft (MockX reference/dev-test only)
+docker ps --filter "name=mockx-valkey" --format "table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}"
+docker ps -a --filter "name=mockx-valkey" --format "table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}"
+
+# mockx-valkey — Herkunft redacted pruefen (keine Env-/Passwort-Ausgabe)
+docker inspect mockx-valkey --format "Name={{.Name}}{{println}}Image={{.Config.Image}}{{println}}Status={{.State.Status}}{{println}}RestartPolicy={{.HostConfig.RestartPolicy.Name}}{{println}}Ports={{json .NetworkSettings.Ports}}{{println}}Mounts={{range .Mounts}}{{.Name}}:{{.Destination}}:{{.Type}};{{end}}{{println}}ComposeProject={{index .Config.Labels `"com.docker.compose.project"`}}{{println}}ComposeService={{index .Config.Labels `"com.docker.compose.service"`}}{{println}}ComposeWorkingDir={{index .Config.Labels `"com.docker.compose.project.working_dir"`}}{{println}}ComposeConfigFiles={{index .Config.Labels `"com.docker.compose.project.config_files"`}}" 2>$null
 ```
 
 ---
@@ -49,23 +57,29 @@ Get-ScheduledTask -TaskName "CDB_LR040_SoakMonitor", "CDB_Soak_Sidecar" -ErrorAc
 | Befund | Klassifikation | Aktion |
 |--------|---------------|--------|
 | Kein Container | **OK** — erwarteter Zustand | Keine Aktion |
-| Container läuft, Compose-Projekt = `claire_de_binare` oder `cdb_*` | **Unerwarteter Runtime-Drift** — Container aus historischem Compose-Projekt (vor #1528-Bereinigung) | Gordon-Gate einholen; keine selbstständige Container-Mutation |
-| Container läuft, kein Compose-Projekt-Label | **Unerwarteter Runtime-Drift** — Container manuell oder extern gestartet | Gordon-Gate einholen; keine selbstständige Container-Mutation |
+| Container läuft, Compose-Projekt = `claire_de_binare` oder `cdb_*` | **Unerwarteter Runtime-Drift** — Container aus historischem Compose-Projekt (vor #1528-Bereinigung) | Jannek-Ops-GO einholen; keine selbstständige Container-Mutation |
+| Container läuft, kein Compose-Projekt-Label | **Unerwarteter Runtime-Drift** — Container manuell oder extern gestartet | Jannek-Ops-GO einholen; keine selbstständige Container-Mutation |
+| `mockx-valkey` läuft ausserhalb einer expliziten MockX test-pack Session | **Unerwarteter Reference-Infra-Drift** — non-canonical MockX Valkey ist nicht `cdb_redis` | Jannek-Ops-GO einholen; keine selbststaendige Container-Mutation; Volume/Image separat gate-pflichtig |
 
 ---
 
-## Bereinigung (nur mit Gordon-Gate)
+## Bereinigung (nur mit Jannek-Ops-GO)
 
 ```powershell
-# cdb_node_exporter — Container stoppen und entfernen (nur nach explizitem Gordon-Go)
+# cdb_node_exporter — Container stoppen und entfernen (nur nach explizitem Jannek-Ops-GO)
 docker stop cdb_node_exporter
 docker rm cdb_node_exporter
 
-# cdb_market_eth — Container stoppen und entfernen (nur nach explizitem Gordon-Go)
-# Image-Remove erfordert separates Gordon-Go (forensische Nachvollziehbarkeit).
+# cdb_market_eth — Container stoppen und entfernen (nur nach explizitem Jannek-Ops-GO)
+# Image-Remove erfordert separates Jannek-Ops-GO (forensische Nachvollziehbarkeit).
 # Keine Reaktivierung ohne eigenes Design-/Evidence-Issue.
 docker stop cdb_market_eth
 docker rm cdb_market_eth
+
+# mockx-valkey — Container stoppen und entfernen (nur nach explizitem Jannek-Ops-GO)
+# Volume/Image bleiben erhalten, ausser ein separates Jannek-Ops-GO erlaubt deren Cleanup.
+docker stop mockx-valkey
+docker rm mockx-valkey
 ```
 
 ---
@@ -82,3 +96,5 @@ docker rm cdb_market_eth
 - Issue #1596 — 503-Bug cdb_market/cdb_market_eth (CLOSED)
 - Issue #1206 — ursprünglicher V3-Market-Branch (nicht auf main)
 - Issue #3304 — Audit + Decommission `lr030_soak_monitor` / `lr040_soak_monitor` + Scheduler `CDB_LR040_SoakMonitor` / `CDB_Soak_Sidecar`
+- Issue #3305 — Audit + Cleanup `mockx-valkey` reference-infra drift
+- Issue #1648 — Formalized `tools/test_pack/mock_exchange/` as local reference copy, not active CDB integration

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -150,6 +150,18 @@ Aktivierung: `docker compose -f infrastructure/compose/compose.blue.yml -f infra
 
 ---
 
+## Referenz-/Dev-Test-Infrastruktur (nicht BLUE/RED-kanonisch)
+
+Diese Artefakte sind keine aktiven CDB-Services und gehoeren nicht zum Standard-BLUE/RED-Runtime-Canon.
+
+| Artefakt | Container | Status | Expected-State | Purpose | Lifecycle / Boundary |
+|---|---|---|---|---|---|
+| MockX Valkey (`tools/test_pack/mock_exchange/`, `.codex/cdb_skills/mockexchange/` quarantine/reference copies) | `mockx-valkey` | Non-canonical dev/test reference infra (#3305, #1648) | `absent by default` | Optional Redis-compatible persistence layer for explicit MockX test-pack/reference sessions only | Present only during an explicit MockX test-pack session; stop/remove container after the session. `mockx-valkey` is not CDB-canonical Redis and must never replace `cdb_redis`. Volume/image cleanup is separate Jannek-Ops-GO scope. |
+
+Read-only drift path: `docs/runbooks/legacy_service_drift.md`.
+
+---
+
 ## Entfernte Services (Legacy)
 
 Services, die aus dem aktiven BLUE+RED-Runtime-Canon entfernt wurden. Kein Container im BLUE/RED-Stack erwartet.
@@ -230,6 +242,7 @@ Referenz: `infrastructure/compose/SERVICE_MAPPING.md`, PR #2670.
 - [ ] BEREIT-Services bewusst deaktiviert (Begründung aktuell)
 - [ ] Keine unbekannten Container im Stack
 - [ ] Legacy-Services (cdb_node_exporter) nicht im Stack (Pruefpfad: `docs/runbooks/legacy_service_drift.md`)
+- [ ] `mockx-valkey` ist `absent by default` und nur waehrend expliziter MockX test-pack Sessions zulaessig (Pruefpfad: `docs/runbooks/legacy_service_drift.md`)
 
 ---
 
@@ -261,6 +274,7 @@ Referenz: `infrastructure/compose/SERVICE_MAPPING.md`, PR #2670.
 | 2026-06-08 | PR #3081 Nachzug: `historical_bridge.py` + `evaluate_price_policies.py` als Replay-Infrastruktur-Komponenten im Core-Libraries-Katalog ergänzt; `price_policy`-Support vermerkt (Issue #3082) | Codex |
 | 2026-06-18 | Audit #3302: Entfernte-Services-Sektion ergänzt; cdb_node_exporter als LEGACY mit Decommission-Datum, Grund, Alternative, erwartetem Runtime-Zustand und Runbook-Prüfpfad dokumentiert; Prüf-Checkliste um Legacy-Check ergänzt | Codex |
 | 2026-06-18 | Audit #3304: `lr030_soak_monitor` + `lr040_soak_monitor` als LEGACY dokumentiert; Container decommissioned, Windows-Tasks `CDB_LR040_SoakMonitor` + `CDB_Soak_Sidecar` deaktiviert; Runbooks um Windows-Scheduler-Cleanup ergänzt | OpenCode |
+| 2026-06-18 | Audit #3305: MockX Valkey als non-canonical dev/test reference infra dokumentiert; Expected-State `absent by default`; Boundary `mockx-valkey` ist nicht CDB-canonical Redis und darf `cdb_redis` nie ersetzen; Refs #1648 | OpenCode |
 ## PostgreSQL Schema Artefacts
 
 | Artefakt | Migration | Status | Bedeutung |

--- a/tools/test_pack/README.md
+++ b/tools/test_pack/README.md
@@ -100,6 +100,20 @@ Rationale:
   that is not justified without a specific integration target.
 - The path is browsable locally as a reference without any Git or build risk.
 
+### Runtime lifecycle
+
+MockX Valkey (`mockx-valkey`) is optional, session-local, reference/dev-test-only
+infrastructure. It is not part of the CDB BLUE/RED runtime and is `absent by default`.
+
+Expected use:
+- Start it only for an explicit MockX test-pack or reference session.
+- Stop/remove the `mockx-valkey` container after that session.
+- Do not leave it running as persistent background runtime.
+
+Boundary: `mockx-valkey` is not CDB-canonical Redis, is not a failover target, and
+must never replace `cdb_redis`. See `docs/runbooks/redis_aof_corruption_recovery.md`
+and `docs/runbooks/legacy_service_drift.md`.
+
 ### Future integration path (when a concrete use case emerges)
 
 If CDB needs the Engine package for adapter or backtest testing, install directly from the


### PR DESCRIPTION
Closes #3305
Refs #1648
Refs #3307
Refs #3308
Refs #3309

## Summary
- Document MockX Valkey as non-canonical dev/test reference infra with expected state absent by default.
- Add read-only drift checks and Jannek-Ops-GO cleanup path.
- Clarify test-pack lifecycle: session-local only, no persistent background runtime.

## Runtime cleanup evidence
- Pre-cleanup: mockx-valkey was running as valkey/valkey:7-alpine, no host port published, restart policy unless-stopped.
- Redacted inspect: ComposeProject=claire_de_binare, ComposeService=valkey, source labels pointed at .codex/cdb_skills/tools/mockexchange/docker-compose.yml.
- Logs tail: Valkey startup/RDB messages only; no credentials reported.
- Executed with Jannek-Ops-GO: docker stop mockx-valkey; docker rm mockx-valkey.
- Post-cleanup: docker ps and docker ps -a filters for mockx-valkey empty.
- Preserved: claire_de_binare_valkey_data volume and valkey/valkey:7-alpine image.

## Validation
- git diff --check (line-ending warnings only).
- rg -n "mockx-valkey|not CDB-canonical Redis|absent by default|#3305|#1648" knowledge docs tools/test_pack.
- Old Gordon gate terminology absent from touched docs.

## Guardrails
- No volume remove, no image remove.
- No cdb_redis changes.
- No compose/runtime topology change.
- No LR/live/Echtgeld scope.