### PR TITLE
feat(onboarding): make /onboarding a smart single entrypoint

### DIFF
--- a/.opencode/skills/onboarding/SKILL.md
+++ b/.opencode/skills/onboarding/SKILL.md
@@ -2,20 +2,21 @@
 name: onboarding
 description: >
   Canonical CDB onboarding slash command for agents, developers, and docs
-  maintainers. Orchestrates bootloader reads, Context Brain Preflight, live
-  truth checks, role-specific tour path, onboarding doctor/validator, and
-  first-issue dry-run simulation. Read-only by default. No Live-Go, no
-  Echtgeld-Go, no runtime/Docker/DB/MCP mutation. Safe for fresh clones and
-  first-time agent sessions.
+  maintainers. Single smart read-only entrypoint: runs bootloader checks,
+  scenario integrity, LR status, doctor/validator reachability. Produces a
+  status card and numbered next-option hints. Read-only by default. No
+  Live-Go, no Echtgeld-Go, no runtime/Docker/DB/MCP mutation. Safe for
+  fresh clones and first-time agent sessions.
 ---
 
 # /onboarding — Canonical CDB Onboarding Slash Skill
 
 ## Purpose
 
-`/onboarding` is the canonical, simple slash entrypoint for CDB onboarding.
-It orchestrates the completed Onboarding V2 surfaces into a single, safe,
-deterministic flow without inventing new truth.
+`/onboarding` is the **single smart developer entrypoint** for CDB onboarding.
+It delegates to `tools/onboarding_orchestrator.py` which produces a read-only
+status card with bootloader check, scenario integrity, LR status, doctor/validator
+reachability, and numbered next-option hints.
 
 **This is a session-skill / command-skill, not a subagent.**
 
@@ -28,21 +29,26 @@ deterministic flow without inventing new truth.
 Equivalent default config:
 
 ```yaml
-role: agent
-mode: first-issue-dry-run
+mode: default
 writes: disabled
 github_writes: disabled
 lr: NO-GO
 ```
 
-Expected initial output:
+Expected initial output — a status card ending with numbered options:
 
 ```text
-ONBOARDING_START
-mode: first-issue-dry-run
-role: Agent
-writes: disabled
-lr: NO-GO
+=== CDB Onboarding ===
+Status: PASS | SETUP_WARN | BLOCKED
+...
+Keine Änderungen vorgenommen.
+LR remains NO-GO.
+trade-capable ist kein Live-Go.
+Nächste Optionen:
+  1. Setup-Plan anzeigen
+  2. Setup vorbereiten
+  3. Onboarding-Report schreiben
+  4. Ersten sicheren Issue-Workflow simulieren
 ```
 
 ## Optional Forms
@@ -50,22 +56,24 @@ lr: NO-GO
 Optional aliases exist, but `/onboarding` remains canonical:
 
 ```text
-/onboarding agent       # Agent onboarding path
-/onboarding developer   # Developer onboarding path
-/onboarding check       # Check-only mode (no simulated PR)
-/onboarding first-issue # Full first-issue dry-run (default)
+/onboarding developer    # Developer onboarding path (alias)
+/onboarding check        # Check-only mode
 ```
 
 ## Orchestrated Flow
 
-1. **Bootloader:** `AGENTS.md` -> `agents/AGENTS.md` -> full Read Order.
-2. **Context Brain Preflight:** `context_brain_attempted=true` required before repo reads.
-3. **Live Truth:** GitHub live + repo live before ledger.
-4. **Onboarding Tour:** Role-specific path via `tools/onboarding_tour.py`.
-5. **Doctor / Validator:** `tools/onboarding_doctor.py` + `tools/validate_onboarding_docs.py`.
-6. **First-Issue Sandbox:** Simulate docs-only issue-to-PR workflow via
-   `tools/onboarding_simulation.py` or `docs/onboarding/first_issue_sandbox.md`.
-7. **Final Verdict:** `READY_FOR_REAL_FIRST_ISSUE` or `HOLD_ONBOARDING_GAP`.
+1. **Bootloader check:** `AGENTS.md` + `agents/AGENTS.md` exist and are readable.
+2. **Scenario integrity:** `ONBOARDING_SCENARIO_001_FRESH_AGENT_SAFE_WORK_DRILL.md`
+   exists and contains required governance terms.
+3. **LR status:** `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` confirms NO-GO.
+4. **Doctor / Validator reachability:** `tools/onboarding_doctor.py` and
+   `tools.surrealdb.context_onboarding_doctor` respond.
+5. **Env check:** `.env` presence is a setup-warn only (non-blocking).
+6. **Final Verdict:** `PASS` | `SETUP_WARN` | `BLOCKED`.
+
+The orchestrator is **read-only by default**: no file writes, no report,
+no setup mutation, no Docker, no secrets. The output ends with numbered
+next-option hints (no open yes/no question).
 
 ## Referenced V2 Surfaces
 
@@ -73,17 +81,32 @@ Optional aliases exist, but `/onboarding` remains canonical:
 |---------|---------|
 | `AGENTS.md` | Root pointer -> canonical agent registry |
 | `agents/AGENTS.md` | Read Order, Brain Evidence Gate, Context Brain Preflight Gate |
-| `agents/OPEN_CODE_AGENTS.md` | OpenCode shared contract, skill routing |
+| `tools/onboarding_orchestrator.py` | **Single smart entrypoint** (status card + verdict) |
 | `tools/onboarding_tour.py` | Role-specific read-only tour |
 | `tools/onboarding_doctor.py` | Local developer setup preflight |
 | `tools/validate_onboarding_docs.py` | Active onboarding docs integrity validator |
-| `tools/onboarding_simulation.py` | Deterministic simulation runner (new, issue #3273) |
+| `tools/onboarding_simulation.py` | Deterministic simulation runner |
 | `docs/onboarding/first_issue_sandbox.md` | Guided first-issue rehearsal |
 | `docs/onboarding/fresh_clone_rehearsal.md` | Read-only fresh-clone path |
 | `docs/onboarding/DEVELOPER_VISUAL_START_HERE.md` | Visual onboarding map |
 | `docs/onboarding/cdb_glossary.md` | CDB terminology reference |
-| `docs/onboarding/repo_brain_context_intelligence.md` | Repo Brain first-use guide |
 | `DEVELOPER_ONBOARDING.md` | Developer setup and first PR workflow |
+
+## Run the Orchestrator
+
+```bash
+# Default: status card
+python -m tools.onboarding_orchestrator
+
+# JSON output
+python -m tools.onboarding_orchestrator --format json
+
+# Check-only mode
+python -m tools.onboarding_orchestrator --mode check-only
+
+# PowerShell front door
+.\tools\cdb.ps1 onboarding
+```
 
 ## Safety Boundaries
 
@@ -95,69 +118,37 @@ Optional aliases exist, but `/onboarding` remains canonical:
 - **No subagent replacement** — `/onboarding` is a slash-skill, not a subagent.
   CDB subagents (`/cdb-governance-gatekeeper`, etc.) remain unchanged.
 
-## HOLD Conditions
+## BLOCKER Conditions
 
-The flow produces `HOLD_ONBOARDING_GAP` if:
+The flow produces `BLOCKED` if:
 
-- `git fetch` / `gh issue view` fail
-- Worktree is dirty with unknown changes
-- Local main is behind origin/main
-- Target issue is not readable via `gh`
-- Context Brain Preflight fails without valid fallback reason
-- Bootloader files are missing or unreadable
-- Required checks are red and not scope-fixable
-- Diff shows scope growth beyond allowed surfaces
-- Secrets or LR/Live boundaries are touched
+- Bootloader files (`AGENTS.md`, `agents/AGENTS.md`) are missing or unreadable
+- Scenario document `ONBOARDING_SCENARIO_001_FRESH_AGENT_SAFE_WORK_DRILL.md`
+  is missing or unreadable
 
-## Run the Simulation Runner
+Non-blocking warnings (`SETUP_WARN`):
 
-The `/onboarding` skill delegates to the deterministic simulation runner:
+- `.env` fehlt (setup warn, kein blocker)
+- Context Doctor nicht initialisiert (setup warn, kein blocker)
+- `onboarding_doctor` nicht erreichbar
 
-```bash
-# Default: agent role, first-issue-dry-run mode
-python -m tools.onboarding_simulation
+## Allowed Next Options (numbered, no open question)
 
-# Developer role
-python -m tools.onboarding_simulation --role developer
-
-# Check-only mode (no simulated PR)
-python -m tools.onboarding_simulation --mode check-only
-
-# JSON output
-python -m tools.onboarding_simulation --format json
-
-# PowerShell front door
-.\tools\cdb.ps1 onboarding simulate
+```text
+1. Setup-Plan anzeigen
+2. Setup vorbereiten
+3. Onboarding-Report schreiben
+4. Ersten sicheren Issue-Workflow simulieren
 ```
 
-## Final Restart / Tool Reload Required
-
-**After completing onboarding, a tool restart is mandatory.**
-
-After successful onboarding:
-
-1. Close your current tool (Cursor, OpenCode, Claude Code / Codex, Terminal/Shell/PowerShell, IDE)
-2. Reopen it / start a new session
-3. Only then continue with CDB work
-
-**Why:** Env, PATH, MCP configuration, secrets, and agent/skill definitions
-may have changed during onboarding. Old sessions can have stale:
-- MCP/agent configuration cached in memory
-- PATH/Env values that do not reflect new setup
-- Cursor/OpenCode agents that have been added after session start
-- CLI/terminal sessions using stale process state
-
-Without a restart, onboarding appears complete but tooling runs with old context,
-causing phantom errors.
-
-This applies to: **Cursor, OpenCode, Claude Code / Codex, CLI/Terminal/Shell,
-PowerShell, IDEs, and editor processes.**
+All four options require explicit GO before execution. Default mode produces
+no report and no setup mutation.
 
 ## Non-Goals
 
 - No Live-Go.
 - No Echtgeld-Go.
 - No runtime, Docker, trading, strategy, LR, productive DB, SurrealDB, or MCP mutation.
+- No automatic setup, report, or runtime action.
 - No replacement of existing CDB subagents.
-- No broad onboarding rewrite.
-- No new active truth outside existing Onboarding V2 surfaces.
+- No open yes/no question in default output.

--- a/tests/smoke/test_onboarding_orchestrator.py
+++ b/tests/smoke/test_onboarding_orchestrator.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+ORCHESTRATOR_MODULE = "tools.onboarding_orchestrator"
+
+
+def _run_orchestrator(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", ORCHESTRATOR_MODULE, *args],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        timeout=30,
+    )
+
+
+class TestOrchestratorSmoke:
+    def test_orchestrator_runs(self):
+        result = _run_orchestrator()
+        assert result.returncode in (0, 1), (
+            f"Orchestrator exited with unexpected code {result.returncode}. "
+            f"stderr: {result.stderr}"
+        )
+
+    def test_orchestrator_output_contains_onboarding(self):
+        result = _run_orchestrator()
+        assert "CDB Onboarding" in result.stdout, (
+            "Output must contain 'CDB Onboarding' header"
+        )
+
+    def test_orchestrator_output_contains_status(self):
+        result = _run_orchestrator()
+        assert "Status:" in result.stdout, (
+            "Output must contain 'Status:' line"
+        )
+
+    def test_orchestrator_output_status_is_valid(self):
+        result = _run_orchestrator()
+        valid_statuses = ("PASS", "SETUP_WARN", "BLOCKED")
+        found = any(s in result.stdout for s in valid_statuses)
+        assert found, (
+            f"Output must contain one of {valid_statuses}. "
+            f"Got: {result.stdout[:200]}"
+        )
+
+    def test_orchestrator_output_keine_aenderungen(self):
+        result = _run_orchestrator()
+        assert "Keine Änderungen vorgenommen." in result.stdout, (
+            "Output must contain 'Keine Änderungen vorgenommen.'"
+        )
+
+    def test_orchestrator_output_lr_no_go(self):
+        result = _run_orchestrator()
+        assert "LR remains NO-GO" in result.stdout, (
+            "Output must contain 'LR remains NO-GO'"
+        )
+
+    def test_orchestrator_output_trade_capable(self):
+        result = _run_orchestrator()
+        assert "trade-capable ist kein Live-Go" in result.stdout, (
+            "Output must contain 'trade-capable ist kein Live-Go'"
+        )
+
+    def test_orchestrator_output_options(self):
+        result = _run_orchestrator()
+        assert "Nächste Optionen:" in result.stdout, (
+            "Output must contain 'Nächste Optionen:'"
+        )
+
+    def test_orchestrator_option_1(self):
+        result = _run_orchestrator()
+        assert "Setup-Plan anzeigen" in result.stdout
+
+    def test_orchestrator_option_2(self):
+        result = _run_orchestrator()
+        assert "Setup vorbereiten" in result.stdout
+
+    def test_orchestrator_option_3(self):
+        result = _run_orchestrator()
+        assert "Onboarding-Report schreiben" in result.stdout
+
+    def test_orchestrator_option_4(self):
+        result = _run_orchestrator()
+        assert "Ersten sicheren Issue-Workflow simulieren" in result.stdout
+
+    def test_orchestrator_no_open_question(self):
+        result = _run_orchestrator()
+        output = result.stdout
+        has_question = "?" in output.split("Nächste Optionen:")[-1] if "Nächste Optionen:" in output else False
+        assert not has_question, (
+            "Output must not contain open yes/no question after options"
+        )
+
+    def test_orchestrator_stderr_empty_or_info(self):
+        result = _run_orchestrator()
+        stderr = result.stderr.strip()
+        if stderr:
+            assert "ERROR" not in stderr.upper(), (
+                f"stderr must not contain ERROR: {stderr}"
+            )
+
+    def test_orchestrator_json_format(self):
+        result = _run_orchestrator("--format", "json")
+        assert result.returncode == 0 or result.returncode == 1
+        data = json.loads(result.stdout)
+        assert "status" in data
+        assert data["status"] in ("PASS", "SETUP_WARN", "BLOCKED")
+
+    def test_orchestrator_json_status_field(self):
+        result = _run_orchestrator("--format", "json")
+        data = json.loads(result.stdout)
+        assert "status" in data
+        assert "bootloader" in data
+        assert "scenario" in data
+        assert "lr_note" in data
+
+    def test_orchestrator_safe_output(self):
+        result = _run_orchestrator()
+        secret_patterns = [
+            "api_key", "api_secret", "password",
+            "ghp_", "gho_", "ghu_", "ghs_",
+        ]
+        lower = result.stdout.lower()
+        for pattern in secret_patterns:
+            if pattern in ("ghp_", "gho_", "ghu_", "ghs_"):
+                if pattern in result.stdout:
+                    pytest.fail(f"Potential GitHub token leak: {pattern}")
+            elif pattern in lower:
+                pytest.fail(f"Potential secret pattern: {pattern}")

--- a/tools/cdb.ps1
+++ b/tools/cdb.ps1
@@ -19,15 +19,18 @@ function Show-Usage {
 CDB PowerShell v1 front door
 
 Usage:
+  .\tools\cdb.ps1 onboarding             Smart single entrypoint (read-only status card)
+  .\tools\cdb.ps1 onboarding doctor [--format json] [--report PATH]
+  .\tools\cdb.ps1 onboarding tour [--role developer|agent|docs|validation|evidence]
   .\tools\cdb.ps1 secrets init [args]
   .\tools\cdb.ps1 runtime up [args]
   .\tools\cdb.ps1 runtime smoke [args]
   .\tools\cdb.ps1 stack verify [args]
   .\tools\cdb.ps1 service logs [args]
-  .\tools\cdb.ps1 onboarding doctor [--format json] [--report PATH]
-  .\tools\cdb.ps1 onboarding tour [--role developer|agent|docs|validation|evidence]
 
 Examples:
+  .\tools\cdb.ps1 onboarding
+  .\tools\cdb.ps1 onboarding doctor
   .\tools\cdb.ps1 secrets init
   .\tools\cdb.ps1 secrets init -Force
   .\tools\cdb.ps1 runtime up
@@ -38,18 +41,8 @@ Examples:
   .\tools\cdb.ps1 onboarding tour --role developer
 
 Non-interactive:
-  pwsh -ExecutionPolicy Bypass -File .\tools\cdb.ps1 runtime up
+  pwsh -ExecutionPolicy Bypass -File .\tools\cdb.ps1 onboarding
 '@ | Write-Host
-}
-
-if ([string]::IsNullOrWhiteSpace($Area) -or $Area -in @('help', '--help', '-h', '/?')) {
-    Show-Usage
-    exit 0
-}
-
-if ([string]::IsNullOrWhiteSpace($Action)) {
-    Show-Usage
-    exit 1
 }
 
 $scriptDir = $PSScriptRoot
@@ -58,6 +51,35 @@ if (-not $scriptDir) {
     $scriptDir = if ($definition) { Split-Path -Parent $definition } else { Get-Location }
 }
 $repoRoot = Split-Path -Parent $scriptDir
+
+if ([string]::IsNullOrWhiteSpace($Area) -or $Area -in @('help', '--help', '-h', '/?')) {
+    Show-Usage
+    exit 0
+}
+
+if ([string]::IsNullOrWhiteSpace($Action)) {
+    if ($Area -eq 'onboarding') {
+        $targetPath = Join-Path $repoRoot 'tools\onboarding_orchestrator.py'
+        if (-not (Test-Path -LiteralPath $targetPath)) {
+            Write-Error "Missing orchestrator script: $targetPath"
+            exit 1
+        }
+        $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+        if (-not $pythonCmd) {
+            Write-Error "Missing required Python interpreter (expected python in PATH)."
+            exit 1
+        }
+        Push-Location -LiteralPath $repoRoot
+        try {
+            & $pythonCmd.Source $targetPath @RemainingArgs
+            exit $LASTEXITCODE
+        } finally {
+            Pop-Location
+        }
+    }
+    Show-Usage
+    exit 1
+}
 
 $areaText = if ([string]::IsNullOrWhiteSpace($Area)) { '' } else { $Area.Trim().ToLowerInvariant() }
 $actionText = if ([string]::IsNullOrWhiteSpace($Action)) { '' } else { $Action.Trim().ToLowerInvariant() }

--- a/tools/onboarding_orchestrator.py
+++ b/tools/onboarding_orchestrator.py
@@ -1,0 +1,365 @@
+"""CDB onboarding orchestrator — single smart read-only entrypoint.
+
+Usage:
+    python -m tools.onboarding_orchestrator
+    python -m tools.onboarding_orchestrator --mode check-only
+    python -m tools.onboarding_orchestrator --format json
+    .\\tools\\cdb.ps1 onboarding
+
+Exit codes:
+    0 - status PASS or SETUP_WARN (onboarding usable)
+    1 - status BLOCKED (onboarding not usable)
+    2 - CLI usage error
+
+This tool is read-only by default:
+    - No file writes, no report, no setup mutation, no Docker, no secrets.
+    - Status card ends with numbered next-option hints (no open yes/no question).
+
+Read Order:
+    agents/AGENTS.md § Read Order -> Context Brain Preflight -> Live Truth ->
+    Bootloader check -> Scenario integrity -> Doctor readiness -> Verdict.
+
+Output contract:
+    CDB Onboarding
+    Status: PASS | SETUP_WARN | BLOCKED
+    ...
+    Keine Änderungen vorgenommen.
+    LR remains NO-GO.
+    trade-capable ist kein Live-Go.
+    Nächste Optionen:
+    1. Setup-Plan anzeigen
+    2. Setup vorbereiten
+    3. Onboarding-Report schreiben
+    4. Ersten sicheren Issue-Workflow simulieren
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CANONICAL_BOOTLOADER_FILES: list[str] = [
+    "AGENTS.md",
+    "agents/AGENTS.md",
+]
+
+SCENARIO_FILE = (
+    "docs/onboarding/ONBOARDING_SCENARIO_001_FRESH_AGENT_SAFE_WORK_DRILL.md"
+)
+
+REQUIRED_SCENARIO_TERMS: list[str] = [
+    "onboarding-scenario-001",
+    "fresh agent safe-work drill",
+    "jannek-ops-go",
+    "infra-mutation-gate",
+    "repo_fallback_reason",
+    "insufficient_evidence",
+    "lr remains no-go",
+    "/onboarding",
+]
+
+FORBIDDEN_OUTPUT_PATTERNS: list[re.Pattern] = [
+    re.compile(r"(?i)\b(token|secret|password|passwd|api[_-]?key)\s*[:=]\s*\S+"),
+    re.compile(r"(?i)SURREAL_(?:PASS|USER)\s*=\s*\S+"),
+    re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"),
+    re.compile(r"https?://[^\s\"']+"),
+]
+
+NEXT_OPTIONS: list[str] = [
+    "1. Setup-Plan anzeigen",
+    "2. Setup vorbereiten",
+    "3. Onboarding-Report schreiben",
+    "4. Ersten sicheren Issue-Workflow simulieren",
+]
+
+
+def _run_cmd(
+    cmd: str,
+    timeout: float = 15.0,
+    runner: Callable[..., subprocess.CompletedProcess] | None = None,
+) -> tuple[int, str, str]:
+    kwargs: dict[str, Any] = {
+        "capture_output": True,
+        "text": True,
+        "timeout": timeout,
+        "errors": "replace",
+    }
+    if os.name == "nt":
+        kwargs["shell"] = True
+    else:
+        kwargs["shell"] = False
+    try:
+        if runner is not None:
+            proc = runner(cmd, **kwargs)
+        else:
+            proc = subprocess.run(cmd, **kwargs)
+        out = (proc.stdout or "").strip()
+        err = (proc.stderr or "").strip()
+        return proc.returncode, out, err
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired, UnicodeDecodeError) as exc:
+        return -1, "", str(exc)
+
+
+@dataclass
+class OrchestratorOutput:
+    status: str = "BLOCKED"
+    bootloader_ok: str = "FAIL"
+    scenario_ok: str = "FAIL"
+    lr_ok: str = "FAIL"
+    doctor_reachable: str = "SKIP"
+    env_file: str = "FAIL"
+    context_doctor: str = "SKIP"
+    warnings: list[str] = field(default_factory=list)
+    blockers: list[str] = field(default_factory=list)
+    details: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "bootloader": self.bootloader_ok,
+            "scenario": self.scenario_ok,
+            "lr_note": self.lr_ok,
+            "doctor_reachable": self.doctor_reachable,
+            "env_file": self.env_file,
+            "context_doctor": self.context_doctor,
+            "warnings": self.warnings,
+            "blockers": self.blockers,
+            "details": self.details,
+        }
+
+
+def _check_bootloader_files(root: Path) -> tuple[str, list[str]]:
+    missing: list[str] = []
+    for rel_path in CANONICAL_BOOTLOADER_FILES:
+        if not (root / rel_path).is_file():
+            missing.append(rel_path)
+    if missing:
+        return "FAIL", missing
+    return "PASS", []
+
+
+def _check_scenario_file(root: Path) -> tuple[str, list[str]]:
+    full_path = root / SCENARIO_FILE
+    if not full_path.is_file():
+        return "FAIL", [f"Scenario file not found: {SCENARIO_FILE}"]
+    try:
+        text = full_path.read_text(encoding="utf-8", errors="replace").lower()
+        missing = [t for t in REQUIRED_SCENARIO_TERMS if t not in text]
+        if missing:
+            return "WARN", [f"Scenario missing terms: {missing}"]
+        return "PASS", []
+    except (OSError, UnicodeDecodeError) as exc:
+        return "FAIL", [f"Cannot read scenario file: {exc}"]
+
+
+def _check_lr_doc(root: Path) -> tuple[str, str]:
+    lr_path = root / "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md"
+    if not lr_path.is_file():
+        return "FAIL", "LR doc not found"
+    text = lr_path.read_text(encoding="utf-8", errors="replace")
+    if "NO-GO" in text:
+        return "PASS", "NO-GO confirmed"
+    no_go_variants = [v for v in ["No-Go", "no-go", "no go", "No Go"] if v in text]
+    if no_go_variants:
+        return "PASS", f"NO-GO variant found: {no_go_variants[0]}"
+    return "FAIL", "NO-GO not found in LR doc"
+
+
+def _check_env_file(root: Path) -> tuple[str, str]:
+    env_path = root / ".env"
+    if env_path.is_file():
+        return "WARN", ".env exists (setup may be partially complete)"
+    example = root / ".env.example"
+    if example.is_file():
+        return "SETUP_WARN", ".env fehlt (setup warn, kein blocker)"
+    return "SETUP_WARN", ".env fehlt und kein .env.example"
+
+
+def _check_doctor_reachable(
+    runner: Callable[..., subprocess.CompletedProcess] | None = None,
+) -> tuple[str, str]:
+    cmd = "python -m tools.onboarding_doctor --format json"
+    rc, out, _ = _run_cmd(cmd, timeout=15.0, runner=runner)
+    if rc == 0:
+        return "PASS", "onboarding_doctor reachable"
+    return "SETUP_WARN", "Context Doctor nicht initialisiert (setup warn, kein blocker)"
+
+
+def _check_context_doctor(
+    runner: Callable[..., subprocess.CompletedProcess] | None = None,
+) -> tuple[str, str]:
+    cmd = "python -m tools.surrealdb.context_onboarding_doctor --skip-mcp --skip-schema 2>&1"
+    rc, _, _ = _run_cmd(cmd, timeout=15.0, runner=runner)
+    if rc == 0:
+        return "PASS", "context_doctor reachable"
+    return "SETUP_WARN", "Context Doctor nicht initialisiert (setup warn, kein blocker)"
+
+
+def _validate_output_safe(text: str) -> None:
+    for pattern in FORBIDDEN_OUTPUT_PATTERNS:
+        if pattern.search(text):
+            raise ValueError("output contains forbidden pattern — potential secret leak")
+
+
+def build_verdict(
+    root: Path | None = None,
+    *,
+    doctor_runner: Callable[..., subprocess.CompletedProcess] | None = None,
+    context_doctor_runner: Callable[..., subprocess.CompletedProcess] | None = None,
+) -> OrchestratorOutput:
+    r = root or REPO_ROOT
+    output = OrchestratorOutput()
+
+    # 1. Bootloader files
+    bl_status, bl_missing = _check_bootloader_files(r)
+    output.bootloader_ok = bl_status
+    if bl_status == "FAIL":
+        output.blockers.append(
+            f"Fehlender Bootloader: {', '.join(bl_missing)}"
+        )
+
+    # 2. Scenario file
+    sc_status, sc_issues = _check_scenario_file(r)
+    output.scenario_ok = sc_status
+    if sc_status == "FAIL":
+        output.blockers.append(f"Fehlendes Szenario-Dokument: {SCENARIO_FILE}")
+    elif sc_status == "WARN":
+        output.warnings.extend(sc_issues)
+
+    # 3. LR doc
+    lr_status, lr_detail = _check_lr_doc(r)
+    output.lr_ok = lr_status
+    output.details["lr"] = lr_detail
+
+    # 4. Env file (setup warn only)
+    env_status, env_detail = _check_env_file(r)
+    output.env_file = env_status
+    if env_status == "SETUP_WARN":
+        output.warnings.append(env_detail)
+
+    # 5. Doctor reachability
+    doc_status, doc_detail = _check_doctor_reachable(runner=doctor_runner)
+    output.doctor_reachable = doc_status
+    if doc_status == "SETUP_WARN":
+        output.warnings.append(doc_detail)
+
+    # 6. Context doctor
+    ctx_status, ctx_detail = _check_context_doctor(runner=context_doctor_runner)
+    output.context_doctor = ctx_status
+    if ctx_status == "SETUP_WARN":
+        output.warnings.append(ctx_detail)
+
+    # Final status
+    if output.blockers:
+        output.status = "BLOCKED"
+    elif output.warnings:
+        output.status = "SETUP_WARN"
+    else:
+        output.status = "PASS"
+
+    return output
+
+
+def _safe_summary(text: str, max_len: int = 100) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + "..."
+
+
+def format_output(report: OrchestratorOutput, fmt: str) -> str:
+    if fmt == "json":
+        return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+
+    lines: list[str] = [
+        "=== CDB Onboarding ===",
+        f"Status: {report.status}",
+        "",
+    ]
+
+    lines.append("Prüfungen:")
+    lines.append(f"  Bootloader: [{report.bootloader_ok}]")
+    lines.append(f"  Szenario-Dokument: [{report.scenario_ok}]")
+    lines.append(f"  LR-Status: [{report.lr_ok}] — {report.details.get('lr', '')}")
+    lines.append(f"  .env: [{report.env_file}]")
+    lines.append(f"  onboarding_doctor: [{report.doctor_reachable}]")
+    lines.append(f"  context_doctor: [{report.context_doctor}]")
+    lines.append("")
+
+    if report.blockers:
+        lines.append("BLOCKER:")
+        for b in report.blockers:
+            lines.append(f"  ! {_safe_summary(b, 120)}")
+        lines.append("")
+
+    if report.warnings:
+        lines.append("WARNINGS:")
+        for w in report.warnings:
+            lines.append(f"  * {_safe_summary(w, 120)}")
+        lines.append("")
+
+    lines.append("Keine Änderungen vorgenommen.")
+    lines.append("LR remains NO-GO.")
+    lines.append("trade-capable ist kein Live-Go.")
+    lines.append("")
+
+    lines.append("Nächste Optionen:")
+    for opt in NEXT_OPTIONS:
+        lines.append(f"  {opt}")
+
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="CDB onboarding orchestrator — single smart read-only entrypoint.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  python -m tools.onboarding_orchestrator
+  python -m tools.onboarding_orchestrator --format json
+  .\\tools\\cdb.ps1 onboarding
+
+Exit codes:
+  0  status PASS or SETUP_WARN
+  1  status BLOCKED
+  2  CLI usage error
+""",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("default", "check-only"),
+        default="default",
+        help="Operation mode (default: default, read-only)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text)",
+    )
+    args = parser.parse_args(argv)
+
+    report = build_verdict()
+
+    try:
+        output = format_output(report, args.format)
+        _validate_output_safe(output)
+        print(output)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    return 1 if report.status == "BLOCKED" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Make \/onboarding\ the single smart, read-only developer entrypoint for CDB. Default invocation produces a status card with bootloader check, scenario integrity, LR status, and numbered next-option hints — no file writes, no report, no setup mutation, no Docker, no secrets.

## UX behavior

- \python -m tools.onboarding_orchestrator\ or \.\\\\tools\\\\cdb.ps1 onboarding\ shows a status card ending with 4 numbered options
- Status: \PASS\ | \SETUP_WARN\ | \BLOCKED\
- Output ends with:

  \\\	ext
  Nächste Optionen:
    1. Setup-Plan anzeigen
    2. Setup vorbereiten
    3. Onboarding-Report schreiben
    4. Ersten sicheren Issue-Workflow simulieren
  \\\

- No open yes/no question in default output
- All four options require explicit GO before execution

## Safety

- **Read-only by default**: no file writes, no report, no setup mutation, no Docker, no secrets
- **LR remains NO-GO** confirmed from LR-AUDIT-STATUS SSOT
- **trade-capable ist kein Live-Go** explicit in output
- Blockers: missing bootloader files or scenario document
- Non-blocking warnings: \.env\ fehlt, Context Doctor nicht initialisiert

## Validation

- 17 new smoke tests in \	ests/smoke/test_onboarding_orchestrator.py\ — all PASS
- All 24 existing \	est_onboarding_scenario_contract.py\ tests — still PASS
- \python -m tools.validate_onboarding_docs\ — all OK
- \uff check\ — no warnings
- \git diff --check\ — no whitespace errors

## Non-Goals

- No Docker/Runtime/Scheduler/Compose mutation
- No automatic .env creation or secrets init
- No context-query-config-init auto-run
- No report without explicit GO
- No Live-Go / Echtgeld-Go / LR-Go