### PR TITLE
fix(onboarding): route onboarding intent across agent surfaces

### DIFF
--- a/.claude/skills/cdb-session-start/SKILL.md
+++ b/.claude/skills/cdb-session-start/SKILL.md
@@ -23,6 +23,18 @@ Establish a verified, fail-closed starting state before any repo work begins.
 
 ## Workflow
 
+0. Route onboarding intent before session-start takes over:
+
+   - If the user says `/onboarding`, `onboarding`, `onboarding durchführen`,
+     `mach onboarding`, `fresh agent onboarding`, or equivalent, run:
+     `python -m tools.onboarding_orchestrator`
+   - Do not start `cdb-session-start` or `onboarding_doctor` as the primary path
+     for onboarding intent.
+   - Default output is the CDB Onboarding status card.
+   - Do not create `.env`, initialize secrets, initialize context, write
+     reports, create issues, or run Docker unless the user explicitly selects a
+     next option after the status card.
+
 1. Verify Git truth before reading anything else:
 
    ```bash

--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -14,8 +14,8 @@ description: >
 ## Purpose
 
 `/onboarding` is the canonical, simple slash entrypoint for CDB onboarding.
-It orchestrates the completed Onboarding V2 surfaces into a single, safe,
-deterministic flow without inventing new truth.
+It routes first to `tools/onboarding_orchestrator.py`, which produces the
+read-only CDB Onboarding status card before any optional next step.
 
 **This is a session-skill / command-skill, not a subagent.**
 
@@ -58,14 +58,13 @@ Optional aliases exist, but `/onboarding` remains canonical:
 
 ## Orchestrated Flow
 
-1. **Bootloader:** `AGENTS.md` -> `agents/AGENTS.md` -> full Read Order.
-2. **Context Brain Preflight:** `context_brain_attempted=true` required before repo reads.
-3. **Live Truth:** GitHub live + repo live before ledger.
-4. **Onboarding Tour:** Role-specific path via `tools/onboarding_tour.py`.
-5. **Doctor / Validator:** `tools/onboarding_doctor.py` + `tools/validate_onboarding_docs.py`.
-6. **First-Issue Sandbox:** Simulate docs-only issue-to-PR workflow via
-   `tools/onboarding_simulation.py` or `docs/onboarding/first_issue_sandbox.md`.
-7. **Final Verdict:** `READY_FOR_REAL_FIRST_ISSUE` or `HOLD_ONBOARDING_GAP`.
+1. **Primary route:** `python -m tools.onboarding_orchestrator`
+2. **Bootloader:** `AGENTS.md` -> `agents/AGENTS.md` -> full Read Order.
+3. **Context Brain Preflight:** `context_brain_attempted=true` required before repo reads.
+4. **Live Truth:** GitHub live + repo live before ledger.
+5. **Optional next steps only after the status card:** role-specific tour,
+   doctor/validator, or first-issue sandbox.
+6. **Final Verdict:** CDB Onboarding status card with numbered next options.
 
 ## Referenced V2 Surfaces
 
@@ -74,6 +73,7 @@ Optional aliases exist, but `/onboarding` remains canonical:
 | `AGENTS.md` | Root pointer -> canonical agent registry |
 | `agents/AGENTS.md` | Read Order, Brain Evidence Gate, Context Brain Preflight Gate |
 | `agents/OPEN_CODE_AGENTS.md` | OpenCode shared contract, skill routing |
+| `tools/onboarding_orchestrator.py` | **Single smart entrypoint** (status card + verdict) |
 | `tools/onboarding_tour.py` | Role-specific read-only tour |
 | `tools/onboarding_doctor.py` | Local developer setup preflight |
 | `tools/validate_onboarding_docs.py` | Active onboarding docs integrity validator |
@@ -92,6 +92,7 @@ Optional aliases exist, but `/onboarding` remains canonical:
 - **No Echtgeld-Go**
 - **Read-only by default** — no file writes, no GitHub writes, no branch creation,
   no PR creation, no runtime/Docker/DB/MCP mutation, no secrets.
+- **Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.**
 - **No subagent replacement** — `/onboarding` is a slash-skill, not a subagent.
   CDB subagents (`/cdb-governance-gatekeeper`, etc.) remain unchanged.
 
@@ -109,12 +110,31 @@ The flow produces `HOLD_ONBOARDING_GAP` if:
 - Diff shows scope growth beyond allowed surfaces
 - Secrets or LR/Live boundaries are touched
 
-## Run the Simulation Runner
+## Run the Orchestrator
 
-The `/onboarding` skill delegates to the deterministic simulation runner:
+If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`,
+`fresh agent onboarding`, or equivalent, run:
 
 ```bash
-# Default: agent role, first-issue-dry-run mode
+# Default: status card
+python -m tools.onboarding_orchestrator
+
+# JSON output
+python -m tools.onboarding_orchestrator --format json
+
+# Check-only mode
+python -m tools.onboarding_orchestrator --mode check-only
+
+# PowerShell front door
+.\tools\cdb.ps1 onboarding
+```
+
+Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
+
+Optional next steps after explicit user selection:
+
+```bash
+# Agent role, first-issue dry-run
 python -m tools.onboarding_simulation
 
 # Developer role
@@ -126,8 +146,6 @@ python -m tools.onboarding_simulation --mode check-only
 # JSON output
 python -m tools.onboarding_simulation --format json
 
-# PowerShell front door
-.\tools\cdb.ps1 onboarding simulate
 ```
 
 ## Final Restart / Tool Reload Required

--- a/.codex/cdb_skills/README.md
+++ b/.codex/cdb_skills/README.md
@@ -8,6 +8,7 @@ Spiegelt die Cursor-Skill-Oberfläche unter [`.cursor/skills/README.md`](../../.
 
 | Skill | Wann |
 |---|---|
+| [`onboarding`](onboarding/SKILL.md) | Bei `/onboarding` oder natuerlichem Onboarding-Intent |
 | [`cdb-session-start`](cdb-session-start/SKILL.md) | Vor Repo-/GitHub-/Implementierungsarbeit |
 | [`cdb-session-close`](cdb-session-close/SKILL.md) | Nach Implementierung/Validierung |
 

--- a/.codex/cdb_skills/cdb-onboarding/SKILL.md
+++ b/.codex/cdb_skills/cdb-onboarding/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: cdb-onboarding
+description: Thin alias to the canonical Codex onboarding skill.
+---
+
+# CDB onboarding alias
+
+Use `../onboarding/SKILL.md` as the canonical instruction surface.
+
+Primary route: `python -m tools.onboarding_orchestrator`

--- a/.codex/cdb_skills/cdb-session-start/SKILL.md
+++ b/.codex/cdb_skills/cdb-session-start/SKILL.md
@@ -23,6 +23,18 @@ Establish a verified, fail-closed starting state before any repo work begins.
 
 ## Workflow
 
+0. Route onboarding intent before session-start takes over:
+
+   - If the user says `/onboarding`, `onboarding`, `onboarding durchführen`,
+     `mach onboarding`, `fresh agent onboarding`, or equivalent, run:
+     `python -m tools.onboarding_orchestrator`
+   - Do not start `cdb-session-start` or `onboarding_doctor` as the primary path
+     for onboarding intent.
+   - Default output is the CDB Onboarding status card.
+   - Do not create `.env`, initialize secrets, initialize context, write
+     reports, create issues, or run Docker unless the user explicitly selects a
+     next option after the status card.
+
 1. Verify Git truth before reading anything else:
 
    ```bash

--- a/.codex/cdb_skills/onboarding/SKILL.md
+++ b/.codex/cdb_skills/onboarding/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: onboarding
+description: >
+  Canonical CDB onboarding entrypoint for Codex. Route slash and natural-language
+  onboarding intent to the single smart read-only status-card path. Read-only by
+  default. No Live-Go, no Echtgeld-Go, no runtime/Docker/DB/MCP mutation.
+---
+
+# CDB onboarding
+
+If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`,
+`fresh agent onboarding`, or equivalent, run: `python -m tools.onboarding_orchestrator`
+
+Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
+
+Default output is the CDB Onboarding status card.
+
+Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
+
+## Run
+
+```bash
+python -m tools.onboarding_orchestrator
+python -m tools.onboarding_orchestrator --format json
+python -m tools.onboarding_orchestrator --mode check-only
+```
+
+## Guardrails
+
+- Read-only by default.
+- LR remains NO-GO.
+- Board stage `trade-capable` is not Live-Go.
+- No Echtgeld-Go.
+- No file writes, no GitHub writes, no branch creation, no PR creation, no runtime/Docker/DB/MCP mutation, no secrets.

--- a/.cursor/skills/cdb-session-start/SKILL.md
+++ b/.cursor/skills/cdb-session-start/SKILL.md
@@ -23,6 +23,18 @@ Establish a verified, fail-closed starting state before any repo work begins.
 
 ## Workflow
 
+0. Route onboarding intent before session-start takes over:
+
+   - If the user says `/onboarding`, `onboarding`, `onboarding durchführen`,
+     `mach onboarding`, `fresh agent onboarding`, or equivalent, run:
+     `python -m tools.onboarding_orchestrator`
+   - Do not start `cdb-session-start` or `onboarding_doctor` as the primary path
+     for onboarding intent.
+   - Default output is the CDB Onboarding status card.
+   - Do not create `.env`, initialize secrets, initialize context, write
+     reports, create issues, or run Docker unless the user explicitly selects a
+     next option after the status card.
+
 1. Verify Git truth before reading anything else:
 
    ```bash

--- a/.cursor/skills/onboarding/SKILL.md
+++ b/.cursor/skills/onboarding/SKILL.md
@@ -14,8 +14,8 @@ description: >
 ## Purpose
 
 `/onboarding` is the canonical, simple slash entrypoint for CDB onboarding.
-It orchestrates the completed Onboarding V2 surfaces into a single, safe,
-deterministic flow without inventing new truth.
+It routes first to `tools/onboarding_orchestrator.py`, which produces the
+read-only CDB Onboarding status card before any optional next step.
 
 **This is a session-skill / command-skill, not a subagent.**
 
@@ -58,14 +58,13 @@ Optional aliases exist, but `/onboarding` remains canonical:
 
 ## Orchestrated Flow
 
-1. **Bootloader:** `AGENTS.md` -> `agents/AGENTS.md` -> full Read Order.
-2. **Context Brain Preflight:** `context_brain_attempted=true` required before repo reads.
-3. **Live Truth:** GitHub live + repo live before ledger.
-4. **Onboarding Tour:** Role-specific path via `tools/onboarding_tour.py`.
-5. **Doctor / Validator:** `tools/onboarding_doctor.py` + `tools/validate_onboarding_docs.py`.
-6. **First-Issue Sandbox:** Simulate docs-only issue-to-PR workflow via
-   `tools/onboarding_simulation.py` or `docs/onboarding/first_issue_sandbox.md`.
-7. **Final Verdict:** `READY_FOR_REAL_FIRST_ISSUE` or `HOLD_ONBOARDING_GAP`.
+1. **Primary route:** `python -m tools.onboarding_orchestrator`
+2. **Bootloader:** `AGENTS.md` -> `agents/AGENTS.md` -> full Read Order.
+3. **Context Brain Preflight:** `context_brain_attempted=true` required before repo reads.
+4. **Live Truth:** GitHub live + repo live before ledger.
+5. **Optional next steps only after the status card:** role-specific tour,
+   doctor/validator, or first-issue sandbox.
+6. **Final Verdict:** CDB Onboarding status card with numbered next options.
 
 ## Referenced V2 Surfaces
 
@@ -74,6 +73,7 @@ Optional aliases exist, but `/onboarding` remains canonical:
 | `AGENTS.md` | Root pointer -> canonical agent registry |
 | `agents/AGENTS.md` | Read Order, Brain Evidence Gate, Context Brain Preflight Gate |
 | `agents/OPEN_CODE_AGENTS.md` | OpenCode shared contract, skill routing |
+| `tools/onboarding_orchestrator.py` | **Single smart entrypoint** (status card + verdict) |
 | `tools/onboarding_tour.py` | Role-specific read-only tour |
 | `tools/onboarding_doctor.py` | Local developer setup preflight |
 | `tools/validate_onboarding_docs.py` | Active onboarding docs integrity validator |
@@ -92,6 +92,7 @@ Optional aliases exist, but `/onboarding` remains canonical:
 - **No Echtgeld-Go**
 - **Read-only by default** — no file writes, no GitHub writes, no branch creation,
   no PR creation, no runtime/Docker/DB/MCP mutation, no secrets.
+- **Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.**
 - **No subagent replacement** — `/onboarding` is a slash-skill, not a subagent.
   CDB subagents (`/cdb-governance-gatekeeper`, etc.) remain unchanged.
 
@@ -109,12 +110,31 @@ The flow produces `HOLD_ONBOARDING_GAP` if:
 - Diff shows scope growth beyond allowed surfaces
 - Secrets or LR/Live boundaries are touched
 
-## Run the Simulation Runner
+## Run the Orchestrator
 
-The `/onboarding` skill delegates to the deterministic simulation runner:
+If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`,
+`fresh agent onboarding`, or equivalent, run:
 
 ```bash
-# Default: agent role, first-issue-dry-run mode
+# Default: status card
+python -m tools.onboarding_orchestrator
+
+# JSON output
+python -m tools.onboarding_orchestrator --format json
+
+# Check-only mode
+python -m tools.onboarding_orchestrator --mode check-only
+
+# PowerShell front door
+.\tools\cdb.ps1 onboarding
+```
+
+Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
+
+Optional next steps after explicit user selection:
+
+```bash
+# Agent role, first-issue dry-run
 python -m tools.onboarding_simulation
 
 # Developer role
@@ -126,8 +146,6 @@ python -m tools.onboarding_simulation --mode check-only
 # JSON output
 python -m tools.onboarding_simulation --format json
 
-# PowerShell front door
-.\tools\cdb.ps1 onboarding simulate
 ```
 
 ## Final Restart / Tool Reload Required

--- a/.opencode/skills/cdb-session-start/SKILL.md
+++ b/.opencode/skills/cdb-session-start/SKILL.md
@@ -23,6 +23,18 @@ Establish a verified, fail-closed starting state before any repo work begins.
 
 ## Workflow
 
+0. Route onboarding intent before session-start takes over:
+
+   - If the user says `/onboarding`, `onboarding`, `onboarding durchführen`,
+     `mach onboarding`, `fresh agent onboarding`, or equivalent, run:
+     `python -m tools.onboarding_orchestrator`
+   - Do not start `cdb-session-start` or `onboarding_doctor` as the primary path
+     for onboarding intent.
+   - Default output is the CDB Onboarding status card.
+   - Do not create `.env`, initialize secrets, initialize context, write
+     reports, create issues, or run Docker unless the user explicitly selects a
+     next option after the status card.
+
 1. Verify Git truth before reading anything else:
 
    ```bash

--- a/.opencode/skills/onboarding/SKILL.md
+++ b/.opencode/skills/onboarding/SKILL.md
@@ -18,6 +18,11 @@ It delegates to `tools/onboarding_orchestrator.py` which produces a read-only
 status card with bootloader check, scenario integrity, LR status, doctor/validator
 reachability, and numbered next-option hints.
 
+If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`,
+`fresh agent onboarding`, or equivalent, run: `python -m tools.onboarding_orchestrator`
+
+Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
+
 **This is a session-skill / command-skill, not a subagent.**
 
 ## Default Invocation
@@ -74,6 +79,8 @@ Optional aliases exist, but `/onboarding` remains canonical:
 The orchestrator is **read-only by default**: no file writes, no report,
 no setup mutation, no Docker, no secrets. The output ends with numbered
 next-option hints (no open yes/no question).
+
+Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
 
 ## Referenced V2 Surfaces
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,12 @@ Hinweis:
 - Das Working Repo ist der produktive Standardpfad fuer Agenten-, Governance- und Navigationsdoku.
 - Das lokale Archiv unter `docs/archive/docs_hub_snapshot/` ist nur noch historischer Rueckgriff und nicht mehr Canon.
 
+Quick Intent Router:
+- If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`, `fresh agent onboarding`, or equivalent, run: `python -m tools.onboarding_orchestrator`
+- Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
+- Default output is the CDB Onboarding status card.
+- Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
+
 ---
 
 ## Quick Reference

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -41,11 +41,17 @@
    - Dann stoppen statt Plan-Dateien schreiben.
 
 5. **Antwort-Standard**
-   Jede CDB-Antwort beginnt mit:
-   - Tool-/Skill-/Agent-/MCP-/Extensions-Check
-   - Gelesene Canon-Dateien
-   - Live-Wahrheit geprüft: ja/nein
-   - Stop-Grund, falls nein
+    Jede CDB-Antwort beginnt mit:
+    - Tool-/Skill-/Agent-/MCP-/Extensions-Check
+    - Gelesene Canon-Dateien
+    - Live-Wahrheit geprüft: ja/nein
+    - Stop-Grund, falls nein
+
+6. **Onboarding-Intent-Router**
+   - If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`, `fresh agent onboarding`, or equivalent, run: `python -m tools.onboarding_orchestrator`
+   - Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
+   - Default output is the CDB Onboarding status card.
+   - Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
 
 ---
 

--- a/agents/roles/CODEX.md
+++ b/agents/roles/CODEX.md
@@ -31,6 +31,10 @@ MUST READ FIRST:
 - [`../../PROJECT_STATUS.md`](../../PROJECT_STATUS.md) und `../../knowledge/CURRENT_STATUS.md` sind historische Snapshots und duerfen nicht als aktueller SSOT gelesen werden.
 - Eine Board-Stage darf nie als Live-Kapital-Freigabe oder Strategie-Validierung interpretiert werden.
 - Bei Statuskonflikten gilt die SSOT-Regel aus [`../../docs/meta/WORKING_REPO_CANON.md`](../../docs/meta/WORKING_REPO_CANON.md).
+- If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`, `fresh agent onboarding`, or equivalent, run: `python -m tools.onboarding_orchestrator`
+- Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
+- Default output is the CDB Onboarding status card.
+- Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
 
 ---
 

--- a/tests/smoke/test_onboarding_cross_agent_surfaces.py
+++ b/tests/smoke/test_onboarding_cross_agent_surfaces.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+CANONICAL_ROUTER_TEXT = (
+    "If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, "
+    "`mach onboarding`, `fresh agent onboarding`, or equivalent, run: "
+    "`python -m tools.onboarding_orchestrator`"
+)
+
+PRIMARY_ROUTE = "python -m tools.onboarding_orchestrator"
+READ_ONLY_DEFAULT = "Read-only by default"
+NO_ENV_DEFAULT = (
+    "Do not create `.env`, initialize secrets, initialize context, write "
+    "reports, create issues, or run Docker unless the user explicitly selects "
+    "a next option after the status card."
+)
+
+
+def read_text(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def assert_route_contract(relative_path: str) -> None:
+    text = read_text(relative_path)
+    assert CANONICAL_ROUTER_TEXT in text
+    assert PRIMARY_ROUTE in text
+    assert "Default output is the CDB Onboarding status card." in text
+    assert NO_ENV_DEFAULT in text
+
+
+class TestCodexOnboardingSurface:
+    def test_codex_onboarding_skill_exists(self):
+        assert (REPO_ROOT / ".codex/cdb_skills/onboarding/SKILL.md").exists()
+
+    def test_codex_onboarding_skill_routes_to_orchestrator(self):
+        text = read_text(".codex/cdb_skills/onboarding/SKILL.md")
+        assert PRIMARY_ROUTE in text
+        assert "tools/onboarding_orchestrator.py" in text or PRIMARY_ROUTE in text
+
+    def test_codex_onboarding_skill_is_read_only_default(self):
+        text = read_text(".codex/cdb_skills/onboarding/SKILL.md")
+        assert READ_ONLY_DEFAULT in text
+        assert "LR remains NO-GO" in text
+        assert "trade-capable` is not Live-Go" in text
+
+    def test_codex_alias_is_thin(self):
+        text = read_text(".codex/cdb_skills/cdb-onboarding/SKILL.md")
+        assert "../onboarding/SKILL.md" in text
+        assert PRIMARY_ROUTE in text
+
+
+class TestRootAndRoleRouters:
+    def test_root_agents_contains_onboarding_router(self):
+        assert_route_contract("AGENTS.md")
+
+    def test_codex_role_contains_onboarding_router(self):
+        assert_route_contract("agents/roles/CODEX.md")
+
+    def test_gemini_contains_onboarding_router(self):
+        assert_route_contract("GEMINI.md")
+
+
+class TestSharedOnboardingSkills:
+    def test_opencode_onboarding_remains_canonical(self):
+        text = read_text(".opencode/skills/onboarding/SKILL.md")
+        assert PRIMARY_ROUTE in text
+        assert "tools/onboarding_orchestrator.py" in text
+        assert "Read-only by default" in text
+
+    def test_claude_onboarding_present_and_routed(self):
+        text = read_text(".claude/skills/onboarding/SKILL.md")
+        assert PRIMARY_ROUTE in text
+        assert "tools/onboarding_orchestrator.py" in text
+
+    def test_cursor_onboarding_present_and_routed(self):
+        text = read_text(".cursor/skills/onboarding/SKILL.md")
+        assert PRIMARY_ROUTE in text
+        assert "tools/onboarding_orchestrator.py" in text
+
+
+class TestSessionStartDelegation:
+    def test_codex_session_start_delegates_onboarding_intent(self):
+        text = read_text(".codex/cdb_skills/cdb-session-start/SKILL.md")
+        assert PRIMARY_ROUTE in text
+        assert "Do not start `cdb-session-start` or `onboarding_doctor`" in text
+
+    def test_claude_session_start_delegates_onboarding_intent(self):
+        text = read_text(".claude/skills/cdb-session-start/SKILL.md")
+        assert PRIMARY_ROUTE in text
+
+    def test_cursor_session_start_delegates_onboarding_intent(self):
+        text = read_text(".cursor/skills/cdb-session-start/SKILL.md")
+        assert PRIMARY_ROUTE in text
+
+    def test_opencode_session_start_delegates_onboarding_intent(self):
+        text = read_text(".opencode/skills/cdb-session-start/SKILL.md")
+        assert PRIMARY_ROUTE in text
+
+
+class TestSafetyGuardrails:
+    def test_no_default_surface_tells_users_to_create_env(self):
+        surfaces = [
+            "AGENTS.md",
+            "agents/roles/CODEX.md",
+            "GEMINI.md",
+            ".codex/cdb_skills/onboarding/SKILL.md",
+            ".claude/skills/onboarding/SKILL.md",
+            ".cursor/skills/onboarding/SKILL.md",
+            ".opencode/skills/onboarding/SKILL.md",
+        ]
+        for relative_path in surfaces:
+            text = read_text(relative_path)
+            assert NO_ENV_DEFAULT in text
+            assert "context-query-config-init" not in text
+
+    def test_all_surfaces_preserve_lr_no_go_boundary(self):
+        surfaces = [
+            ".codex/cdb_skills/onboarding/SKILL.md",
+            ".claude/skills/onboarding/SKILL.md",
+            ".cursor/skills/onboarding/SKILL.md",
+            ".opencode/skills/onboarding/SKILL.md",
+        ]
+        for relative_path in surfaces:
+            text = read_text(relative_path)
+            assert "NO-GO" in text
+            assert "trade-capable" in text
+            assert "Live-Go" in text

--- a/tests/smoke/test_onboarding_cross_agent_surfaces.py
+++ b/tests/smoke/test_onboarding_cross_agent_surfaces.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 CANONICAL_ROUTER_TEXT = (


### PR DESCRIPTION
Closes #3318

Delivered
- Added a repo-backed Codex onboarding skill.
- Added a thin Codex cdb-onboarding alias.
- Routed AGENTS, CODEX, GEMINI, Claude, Cursor, OpenCode, and session-start surfaces to python -m tools.onboarding_orchestrator.
- Added cross-agent smoke coverage.

Bug reproduced
- OpenCode already routed correctly.
- Claude and Cursor onboarding skills still routed to python -m tools.onboarding_simulation.
- Codex had no repo-backed onboarding skill surface.
- cdb-session-start surfaces had no explicit onboarding delegation rule.

Cross-agent surfaces
- AGENTS.md
- agents/roles/CODEX.md
- GEMINI.md
- .codex/cdb_skills
- .claude/skills/onboarding/SKILL.md
- .cursor/skills/onboarding/SKILL.md
- .opencode/skills/onboarding/SKILL.md
- cdb-session-start skills for Codex, Claude, Cursor, OpenCode

Validation
- git diff --check
- pytest -q tests/smoke/test_onboarding_orchestrator.py
- pytest -q tests/smoke/test_onboarding_scenario_contract.py
- pytest -q tests/smoke/test_onboarding_cross_agent_surfaces.py
- python tools/validate_onboarding_docs.py
- python -m tools.onboarding_orchestrator
- rg -n onboarding_orchestrator|onboarding durchführen|fresh agent onboarding|cdb-session-start AGENTS.md agents .codex .claude .cursor .gemini .opencode .vscode docs tests tools

Safety boundaries
- LR remains NO-GO.
- trade-capable remains explicitly separated from Live-Go.
- No runtime, Docker, DB, MCP mutation, trading, LR, or Echtgeld scope touched.
- .vscode left unchanged because no repo-canonical onboarding instruction surface exists there.

Non-goals
- No runtime BLUE/RED changes.
- No Docker boundary changes.
- No secrets or env setup changes.
- No context-init execution.
- No new VS Code onboarding surface invented.

Restunsicherheiten
- .claude helper .skill launcher wrappers were not edited because the repo-backed instruction surface is the SKILL.md content they point to.
- Local untracked .opencode/plans and docs/decisions remain untouched and out of scope.