### PR TITLE
fix(onboarding): version full agent root surfaces

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,32 @@
+# Claude Root Surface (`/.claude/`)
+
+Repo-versionierte Claude-Code-Konfigurationsfläche. Teil des CDB-Agent-Root-Surface-Systems.
+
+## Struktur
+
+| Pfad | Zweck |
+|------|-------|
+| `README.md` | Diese Datei — Surface-Beschreibung |
+| `CLAUDE_BOOTLOADER.md` | Claude-Bootloader (Read-Order, Write-Permissions) |
+| `skills/` | Repo-versionierte Session-Skills für Claude Code |
+
+## Einstiegspunkte
+
+- **Bootloader**: `CLAUDE_BOOTLOADER.md` (Read-Order, Write-Permissions, Agent-Memory-Pfade)
+- **Skills**: `skills/` — Vollständige Listung in `.cursor/skills/README.md`
+- **Onboarding-Intent**: `python -m tools.onboarding_orchestrator`
+- **Skill Registry**: `.claude/skills/` — siehe auch `.cursor/skills/README.md` für Skill-Katalog
+
+## Onboarding-Route
+
+Bei `/onboarding`-Intent: `python -m tools.onboarding_orchestrator`
+
+Default: Read-only Status Card. Kein `.env`, keine Secrets, kein Docker, kein Issue/PR ohne explizite Auswahl.
+
+## Safety Boundaries
+
+- LR remains **NO-GO**
+- `trade-capable` ist nicht `Live-Go`
+- Keine Echtgeld-Transaktionen
+- Keine Runtime-/Docker-/DB-/MCP-Mutationen
+- Lokale State-Dateien (`settings.json`, `settings.local.json`) bleiben unversioniert

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,30 @@
+# Codex Root Surface (`/.codex/`)
+
+Repo-versionierte Codex-Konfigurationsfläche. Teil des CDB-Agent-Root-Surface-Systems.
+
+## Struktur
+
+| Pfad | Zweck |
+|------|-------|
+| `README.md` | Diese Datei — Surface-Beschreibung |
+| `cdb_skills/` | Repo-versionierte Session-Skills für Codex (siehe `cdb_skills/README.md`) |
+
+## Einstiegspunkte
+
+- **Skills**: `cdb_skills/` — Vollständiger Skill-Katalog in `cdb_skills/README.md`
+- **Onboarding-Intent**: `python -m tools.onboarding_orchestrator`
+- **Skill Registry**: `.codex/cdb_skills/` — siehe auch `.cursor/skills/README.md` für Skill-Katalog
+
+## Onboarding-Route
+
+Bei `/onboarding`-Intent: `python -m tools.onboarding_orchestrator`
+
+Default: Read-only Status Card. Kein `.env`, keine Secrets, kein Docker, kein Issue/PR ohne explizite Auswahl.
+
+## Safety Boundaries
+
+- LR remains **NO-GO**
+- `trade-capable` ist nicht `Live-Go`
+- Keine Echtgeld-Transaktionen
+- Keine Runtime-/Docker-/DB-/MCP-Mutationen
+- Lokale Konfiguration (`config.toml`) bleibt unversioniert (maschinenspezifische Pfade)

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -1,0 +1,34 @@
+# Cursor Root Surface (`/.cursor/`)
+
+Repo-versionierte Cursor-IDE-Konfigurationsfläche. Teil des CDB-Agent-Root-Surface-Systems.
+
+## Struktur
+
+| Pfad | Zweck |
+|------|-------|
+| `README.md` | Diese Datei — Surface-Beschreibung |
+| `agents/` | Cursor-Subagent-Definitionen (Helper-Rollen; Delegation only) |
+| `rules/` | Cursor-Regeln (Bootloader, Brain Evidence, Safety Boundaries) |
+| `skills/` | Repo-versionierte Session-Skills für Cursor |
+| `mcp.json` | MCP-Server-Konfiguration (Beispiel; lokale Secrets ggf. anpassen) |
+
+## Einstiegspunkte
+
+- **Subagent Registry**: `agents/README_CDB_CURSOR_SUBAGENTS.md`
+- **Skills**: `skills/README.md` — Vollständiger Skill-Katalog
+- **Rules**: `rules/` — Fail-closed session rules
+- **Onboarding-Intent**: `python -m tools.onboarding_orchestrator`
+
+## Onboarding-Route
+
+Bei `/onboarding`-Intent: `python -m tools.onboarding_orchestrator`
+
+Default: Read-only Status Card. Kein `.env`, keine Secrets, kein Docker, kein Issue/PR ohne explizite Auswahl.
+
+## Safety Boundaries
+
+- LR remains **NO-GO**
+- `trade-capable` ist nicht `Live-Go`
+- Keine Echtgeld-Transaktionen
+- Keine Runtime-/Docker-/DB-/MCP-Mutationen
+- Lokale Workspace-State-Dateien bleiben unversioniert

--- a/.gemini/README.md
+++ b/.gemini/README.md
@@ -1,0 +1,30 @@
+# Gemini Root Surface (`/.gemini/`)
+
+Repo-versionierte Gemini-Konfigurationsfläche. Teil des CDB-Agent-Root-Surface-Systems.
+
+## Wichtige Dateien
+
+| Datei | Zweck |
+|-------|-------|
+| `README.md` | Diese Datei — Surface-Beschreibung |
+| `settings.json` | Gemini-IDE-Einstellungen (lokale Pfade ggf. anpassen) |
+| `onboarding.md` | Onboarding-Router für Gemini-Agenten (siehe auch `GEMINI.md` im Repo-Root) |
+
+## Einstiegspunkte
+
+- **Gemini-Bootloader**: [`GEMINI.md`](GEMINI.md) (Repo-Root) — primärer Einstiegspunkt mit Read-Order, Tool-First-Pflicht und Onboarding-Intent-Router.
+- **Onboarding-Intent**: Siehe `onboarding.md` in diesem Verzeichnis oder `GEMINI.md` §6.
+- **Canonical Registry**: [`agents/AGENTS.md`](agents/AGENTS.md)
+
+## Onboarding-Route
+
+Bei `/onboarding`-Intent: `python -m tools.onboarding_orchestrator`
+
+Default: Read-only Status Card. Kein `.env`, keine Secrets, kein Docker, kein Issue/PR ohne explizite Auswahl.
+
+## Safety Boundaries
+
+- LR remains **NO-GO**
+- `trade-capable` ist nicht `Live-Go`
+- Keine Live-Kapital-Autorisierung
+- Keine Runtime-/Docker-/DB-/MCP-Mutationen

--- a/.gemini/onboarding.md
+++ b/.gemini/onboarding.md
@@ -1,0 +1,17 @@
+# Gemini Onboarding Router
+
+Wenn ein Gemini-Agent einen `/onboarding`-, `onboarding`-, `onboarding durchführen`-, `mach onboarding`-, `fresh agent onboarding`-Intent oder equivalent erkennt:
+
+1. **Führe aus**: `python -m tools.onboarding_orchestrator`
+2. **Starte nicht** `cdb-session-start` oder `onboarding_doctor` als primären Pfad.
+3. **Default output is the CDB Onboarding status card.**
+4. **Read-only by default.** Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
+5. **Routing-Hierarchie**: Dieser Router ist der kanonische Gemini-Onboarding-Pfad. Der Gemini-Bootloader in `GEMINI.md` (Repo-Root) verweist ergänzend auf diesen Router.
+
+## Safety Boundaries
+
+- LR remains **NO-GO**
+- `trade-capable` ist nicht `Live-Go`
+- Keine Echtgeld-Transaktionen
+- Keine Runtime-Änderungen
+- Keine Secrets in Outputs

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,83 @@
+{
+  "ui": {
+    "footer": {
+      "hideSandboxStatus": false,
+      "hideModelInfo": true,
+      "hideContextPercentage": true
+    },
+    "showStatusInTitle": true,
+    "hideContextSummary": false,
+    "showMemoryUsage": false,
+    "showCitations": true,
+    "accessibility": {
+      "screenReader": false
+    },
+    "terminalBuffer": false,
+    "useAlternateBuffer": false,
+    "showModelInfoInChat": false,
+    "inlineThinkingMode": "off",
+    "hideWindowTitle": false,
+    "terminalBackgroundPollingInterval": 60,
+    "dynamicWindowTitle": false,
+    "incrementalRendering": true,
+    "renderProcess": true
+  },
+  "output": {
+    "format": "text"
+  },
+  "general": {
+    "sessionRetention": {
+      "enabled": true
+    },
+    "previewFeatures": true,
+    "debugKeystrokeLogging": true,
+    "defaultApprovalMode": "plan",
+    "enableNotifications": true
+  },
+  "context": {
+    "loadMemoryFromIncludeDirectories": true,
+    "discoveryMaxDirs": 400,
+    "fileFiltering": {
+      "enableFuzzySearch": false
+    }
+  },
+  "tools": {
+    "shell": {
+      "showColor": true
+    },
+    "sandboxAllowedPaths": [],
+    "sandboxNetworkAccess": false
+  },
+  "security": {
+    "folderTrust": {
+      "enabled": true
+    },
+    "environmentVariableRedaction": {
+      "enabled": true
+    },
+    "enablePermanentToolApproval": true,
+    "disableYoloMode": false
+  },
+  "experimental": {
+    "generalistProfile": true,
+    "memoryManager": true
+  },
+  "mcpServers": {
+    "cdb_context": {
+      "command": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare\\.venv\\Scripts\\python.exe",
+      "args": [
+        "-m",
+        "tools.mcp.server"
+      ],
+      "type": "stdio",
+      "cwd": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare"
+    }
+  },
+  "model": {
+    "name": "",
+    "disableLoopDetection": true
+  },
+  "hooksConfig": {
+    "enabled": false
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,11 @@ wheels/
 *.egg
 MANIFEST
 
-# IDE
-.vscode/
+# IDE — repo-safe files tracked via allowlist
+.vscode/*
+!.vscode/README.md
+!.vscode/extensions.json
+!.vscode/settings.json
 .idea/
 *.swp
 *.swo
@@ -155,7 +158,11 @@ Claire_de_Binare_Docs/
 /.claude/scheduled_tasks.lock
 /.claude/settings.json
 
-.gemini/
+# Gemini — curated surfaces versioned, local state ignored
+.gemini/*
+!.gemini/README.md
+!.gemini/settings.json
+!.gemini/onboarding.md
 .agent_briefings/
 gha-creds-*.json
 .codex-worktree-*/

--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -1,0 +1,29 @@
+# OpenCode Root Surface (`/.opencode/`)
+
+Repo-versionierte OpenCode-Konfigurationsfläche. Teil des CDB-Agent-Root-Surface-Systems.
+
+## Struktur
+
+| Pfad | Zweck |
+|------|-------|
+| `README.md` | Diese Datei — Surface-Beschreibung |
+| `skills/` | Repo-versionierte Session-Skills für OpenCode (siehe `skills/README.md`) |
+
+## Einstiegspunkte
+
+- **Skills**: `skills/README.md` — Vollständiger Skill-Katalog
+- **Onboarding-Intent**: `python -m tools.onboarding_orchestrator`
+
+## Onboarding-Route
+
+Bei `/onboarding`-Intent: `python -m tools.onboarding_orchestrator`
+
+Default: Read-only Status Card. Kein `.env`, keine Secrets, kein Docker, kein Issue/PR ohne explizite Auswahl.
+
+## Safety Boundaries
+
+- LR remains **NO-GO**
+- `trade-capable` ist nicht `Live-Go`
+- Keine Echtgeld-Transaktionen
+- Keine Runtime-/Docker-/DB-/MCP-Mutationen
+- Lokale Skills in Quarantäne (`skills/.system/`, `skills/skillforge/`, `skills/mockexchange/`) bleiben unversioniert

--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -1,0 +1,34 @@
+# VS Code Root Surface (`/.vscode/`)
+
+Repo-versionierte VS-Code-Konfigurationsfläche. VS Code ist ein repo-backed Helper-Surface, keine Autorität.
+
+## Wichtige Dateien
+
+| Datei | Zweck |
+|-------|-------|
+| `README.md` | Diese Datei — Surface-Beschreibung |
+| `extensions.json` | Empfohlene Extensions für das Repo |
+| `settings.json` | Workspace-Einstellungen (CI/CD-Helfer, Formatierung, Suche) |
+
+## Role
+
+VS Code dient als **repo-backed Helper-Surface** für:
+- Standard-Formatierung (Black, Ruff)
+- CI/CD-Hilfs-Tasks (Emoji-Check, Auto-Fix)
+- Extension-Empfehlungen
+- Search/File-Watcher-Excludes
+
+Keine Autorität für Governance-, Stage- oder LR-Entscheidungen.
+
+## Onboarding-Route
+
+Bei `/onboarding`-Intent: `python -m tools.onboarding_orchestrator`
+
+Siehe auch: [`AGENTS.md`](AGENTS.md), [`docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md`](docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md)
+
+## Safety Boundaries
+
+- LR remains **NO-GO**
+- `trade-capable` ist nicht `Live-Go`
+- Keine Echtgeld-Transaktionen
+- Keine Runtime-/Docker-/DB-/MCP-Mutationen

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Wichtige kanonische Dateien:
 - [`knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md`](knowledge/runbooks/CDB_CONTROL_BOARD_RUNBOOK.md)
 - [`PROJECT_STATUS.md`](PROJECT_STATUS.md)
 - [`agents/OPEN_CODE_AGENTS.md`](agents/OPEN_CODE_AGENTS.md)
+- [`docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md`](docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md)
 
 Aktueller Projektstand:
 - Working Repo ist der produktive Canon fuer Agenten-, Governance-, Knowledge- und Navigationsdoku.
@@ -236,6 +237,20 @@ except InvalidOperation:
 - No blackbox decisions; all logic must be traceable.
 
 ---
+
+## Agent Root Surfaces
+
+Alle sechs repo-kanonischen Agent-Root-Flächen sind versioniert und onboarding-fähig.
+Siehe [`docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md`](docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md).
+
+| Surface | Purpose |
+|---------|---------|
+| `.claude/` | Claude Code — Bootloader, Session-Skills |
+| `.codex/` | Codex CLI — Session-Skills |
+| `.cursor/` | Cursor IDE — Subagents, Regeln, Session-Skills |
+| `.gemini/` | Gemini — IDE-Konfiguration, Onboarding-Router |
+| `.opencode/` | OpenCode CLI — Session-Skills |
+| `.vscode/` | VS Code — Helper-Surface (keine Autorität) |
 
 ## Selected repo skills (not exhaustive)
 

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -59,6 +59,9 @@ Invocation: `/cdb-<name>` (e.g. `/cdb-governance-gatekeeper`).
 Related surfaces (not subagents): `.cursor/skills/` (session skills),
 `.opencode/skills/` (OpenCode), `.claude/skills/` (Claude Code), `.codex/cdb_skills/` (Codex).
 
+Root surface matrix: [`docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md`](../docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md) —
+versionierte Root-Flächen für `.claude/`, `.codex/`, `.cursor/`, `.gemini/`, `.opencode/`, `.vscode/`.
+
 ## Canonical Domains
 
 - `agents/`

--- a/docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md
+++ b/docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md
@@ -1,0 +1,53 @@
+# Agent Root Surface Matrix
+
+Versionierte Repo-Root-Flächen für Cross-Agent-Onboarding.
+
+## Surfaces
+
+| Surface | Tracked Safe Files | Ignored Private/Generated | Onboarding Route | Owner/Role |
+|---------|-------------------|--------------------------|-----------------|------------|
+| `.claude/` | `README.md`, `CLAUDE_BOOTLOADER.md`, `skills/` | `settings.json`, `settings.local.json`, `scheduled_tasks.lock` | `python -m tools.onboarding_orchestrator` via `AGENTS.md` | Claude Code — Bootloader, Session-Skills |
+| `.codex/` | `README.md`, `cdb_skills/` | `config.toml`, `config.agents.snippet.toml`, `.system/` (extern), `skillforge/`, `mockexchange/` | `python -m tools.onboarding_orchestrator` via `AGENTS.md` | Codex CLI — Session-Skills (repo-versioniert) |
+| `.cursor/` | `README.md`, `agents/`, `rules/`, `skills/`, `mcp.json` | `settings.json` (local workspace state), `.system/`, `skillforge/`, `mockexchange/` | `python -m tools.onboarding_orchestrator` via `AGENTS.md` | Cursor IDE — Subagents, Regeln, Session-Skills |
+| `.gemini/` | `README.md`, `settings.json`, `onboarding.md` | `github_issue_body.txt`, lokale Session-State-Dateien | `python -m tools.onboarding_orchestrator` via `onboarding.md` und `GEMINI.md` | Gemini — IDE-Konfiguration, Onboarding-Router |
+| `.opencode/` | `README.md`, `skills/` | `.system/` (extern), `skillforge/`, `mockexchange/` | `python -m tools.onboarding_orchestrator` via `AGENTS.md` und `skills/` | OpenCode CLI — Session-Skills (repo-versioniert) |
+| `.vscode/` | `README.md`, `extensions.json`, `settings.json` | Keine (nur repo-sichere Dateien versioniert) | `python -m tools.onboarding_orchestrator` via `AGENTS.md` | VS Code — Helper-Surface (keine Autorität) |
+
+## Kanonische Onboarding-Route
+
+```
+user: "/onboarding", "onboarding", "onboarding durchführen", "mach onboarding", "fresh agent onboarding"
+→ agent: python -m tools.onboarding_orchestrator
+→ result: Read-only CDB Onboarding Status Card
+→ next: User wählt nächsten Schritt (explizit)
+```
+
+## Safety Boundaries (alle Surfaces)
+
+| Regel | Status |
+|-------|--------|
+| LR Live-Go | **NO-GO** |
+| `trade-capable` = Live-Go | **false** |
+| Echtgeld-Autorisierung | **Keine** |
+| Runtime-/Docker-/DB-/MCP-Mutation | **Keine ohne expliziten Human-GO** |
+| Secrets in Outputs | **Verboten** |
+| Blanket-Tracking lokaler State | **Verboten** |
+
+## Gitignore-Strategie
+
+```
+# Allowlist-Ansatz (pro Surface):
+<surface>/*
+!<surface>/README.md
+!<surface>/<spezifische-safe-dateien>
+```
+
+Nicht aufgeführte Dateien in jedem Surface bleiben ignoriert (private/generated/lokal).
+
+## Referenzen
+
+- Agent Registry: `agents/AGENTS.md`
+- Root Pointer: `AGENTS.md`
+- LR-Status: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- Board-Stage: `docs/runbooks/CONTROL_REGISTER.md`
+- Onboarding Orchestrator: `tools/onboarding_orchestrator.py`

--- a/tests/smoke/test_agent_root_surfaces.py
+++ b/tests/smoke/test_agent_root_surfaces.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+SHARED_ONBOARDING_TEXT = (
+    "If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, "
+    "`mach onboarding`, `fresh agent onboarding`, or equivalent, run: "
+    "`python -m tools.onboarding_orchestrator`"
+)
+PRIMARY_ROUTE = "python -m tools.onboarding_orchestrator"
+READ_ONLY_DEFAULT = "Read-only by default"
+NO_ENV_DEFAULT = (
+    "Do not create `.env`, initialize secrets, initialize context, write "
+    "reports, create issues, or run Docker unless the user explicitly selects "
+    "a next option after the status card."
+)
+FORBIDDEN_PATTERNS = [
+    "token",
+    "auth",
+    "secret",
+    "transcript",
+    "cache",
+    "github_issue_body",
+]
+
+
+def read_text(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def git_ls_files() -> set[str]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=True,
+    )
+    return set(result.stdout.strip().splitlines())
+
+
+def gitignore_text() -> str:
+    return (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
+
+
+class TestGeminiNotBlanketIgnored:
+    def test_gemini_not_blanket_ignored(self):
+        gi = gitignore_text()
+        assert (
+            ".gemini/*" in gi
+        ), ".gemini/ blanket ignore must be replaced with .gemini/*"
+        assert "!.gemini/README.md" in gi, "README.md must be allowlisted"
+        assert "!.gemini/settings.json" in gi, "settings.json must be allowlisted"
+        assert "!.gemini/onboarding.md" in gi, "onboarding.md must be allowlisted"
+
+
+class TestVscodeNotBlanketIgnored:
+    def test_vscode_not_blanket_ignored(self):
+        gi = gitignore_text()
+        assert (
+            ".vscode/*" in gi
+        ), ".vscode/ blanket ignore must be replaced with .vscode/*"
+        assert "!.vscode/README.md" in gi, "README.md must be allowlisted"
+        assert "!.vscode/extensions.json" in gi, "extensions.json must be allowlisted"
+        assert "!.vscode/settings.json" in gi, "settings.json must be allowlisted"
+
+
+class TestGeminiSurface:
+    def test_gemini_readme_exists_and_tracked(self):
+        path = ".gemini/README.md"
+        assert (REPO_ROOT / path).exists()
+        tracked = git_ls_files()
+        assert path in tracked, f"{path} must be tracked"
+
+    def test_gemini_onboarding_md_exists_and_tracked(self):
+        path = ".gemini/onboarding.md"
+        assert (REPO_ROOT / path).exists()
+        tracked = git_ls_files()
+        assert path in tracked, f"{path} must be tracked"
+
+    def test_gemini_settings_json_tracked(self):
+        path = ".gemini/settings.json"
+        tracked = git_ls_files()
+        assert path in tracked, f"{path} must be tracked"
+
+    def test_gemini_onboarding_md_routes_correctly(self):
+        text = read_text(".gemini/onboarding.md")
+        assert PRIMARY_ROUTE in text
+        assert READ_ONLY_DEFAULT in text
+        assert NO_ENV_DEFAULT in text
+
+
+class TestVscodeSurface:
+    def test_vscode_readme_exists_and_tracked(self):
+        path = ".vscode/README.md"
+        assert (REPO_ROOT / path).exists()
+        tracked = git_ls_files()
+        assert path in tracked, f"{path} must be tracked"
+
+
+class TestAllSixRootSurfacesExist:
+    def test_all_surfaces_exist(self):
+        for surface in [
+            ".claude",
+            ".codex",
+            ".cursor",
+            ".gemini",
+            ".opencode",
+            ".vscode",
+        ]:
+            assert (REPO_ROOT / surface).is_dir(), f"{surface}/ must exist"
+
+
+class TestAllSurfacesHaveDocumentation:
+    def test_claude_has_documentation(self):
+        paths = [".claude/README.md", ".claude/CLAUDE_BOOTLOADER.md"]
+        assert any(
+            (REPO_ROOT / p).exists() for p in paths
+        ), ".claude must have README.md or CLAUDE_BOOTLOADER.md"
+
+    def test_codex_has_documentation(self):
+        paths = [".codex/README.md", ".codex/cdb_skills/README.md"]
+        assert any(
+            (REPO_ROOT / p).exists() for p in paths
+        ), ".codex must have root README.md or cdb_skills/README.md"
+
+    def test_cursor_has_documentation(self):
+        paths = [
+            ".cursor/README.md",
+            ".cursor/skills/README.md",
+            ".cursor/agents/README_CDB_CURSOR_SUBAGENTS.md",
+        ]
+        assert any(
+            (REPO_ROOT / p).exists() for p in paths
+        ), ".cursor must have README.md or equivalent documentation"
+
+    def test_gemini_has_documentation(self):
+        paths = [".gemini/README.md", "GEMINI.md"]
+        assert any(
+            (REPO_ROOT / p).exists() for p in paths
+        ), ".gemini must have README.md or GEMINI.md"
+
+    def test_opencode_has_documentation(self):
+        paths = [".opencode/README.md", ".opencode/skills/README.md"]
+        assert any(
+            (REPO_ROOT / p).exists() for p in paths
+        ), ".opencode must have root README.md or skills/README.md"
+
+    def test_vscode_has_documentation(self):
+        assert (REPO_ROOT / ".vscode/README.md").exists(), ".vscode must have README.md"
+
+
+class TestOnboardingRoutes:
+    def test_agents_md_routes_to_orchestrator(self):
+        text = read_text("AGENTS.md")
+        assert PRIMARY_ROUTE in text
+        assert SHARED_ONBOARDING_TEXT in text
+
+    def test_gemini_root_routes_to_orchestrator(self):
+        text = read_text("GEMINI.md")
+        assert PRIMARY_ROUTE in text
+
+    def test_opencode_skills_onboarding_routes(self):
+        text = read_text(".opencode/skills/onboarding/SKILL.md")
+        assert PRIMARY_ROUTE in text
+
+    def test_cursor_skills_onboarding_routes(self):
+        text = read_text(".cursor/skills/onboarding/SKILL.md")
+        assert PRIMARY_ROUTE in text
+
+    def test_codex_skills_onboarding_routes(self):
+        text = read_text(".codex/cdb_skills/onboarding/SKILL.md")
+        assert PRIMARY_ROUTE in text
+
+    def test_claude_skills_onboarding_routes(self):
+        text = read_text(".claude/skills/onboarding/SKILL.md")
+        assert PRIMARY_ROUTE in text
+
+
+class TestSurfaceMatrixDoc:
+    def test_surface_matrix_exists(self):
+        path = "docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md"
+        assert (REPO_ROOT / path).exists(), f"{path} must exist"
+
+    def test_surface_matrix_lists_all_surfaces(self):
+        text = read_text("docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md")
+        for surface in [
+            ".claude",
+            ".codex",
+            ".cursor",
+            ".gemini",
+            ".opencode",
+            ".vscode",
+        ]:
+            assert surface in text, f"Matrix must mention {surface}"
+
+    def test_surface_matrix_lists_onboarding_route(self):
+        text = read_text("docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md")
+        assert PRIMARY_ROUTE in text
+
+
+class TestForbiddenPrivatePatterns:
+    def test_no_tracked_surface_file_has_forbidden_patterns(self):
+        tracked = git_ls_files()
+        surfaces = [
+            ".claude/",
+            ".codex/",
+            ".cursor/",
+            ".gemini/",
+            ".opencode/",
+            ".vscode/",
+        ]
+        surface_files = [f for f in tracked if any(f.startswith(s) for s in surfaces)]
+        forbidden = []
+        for pattern in FORBIDDEN_PATTERNS:
+            for f in surface_files:
+                if pattern in f.lower():
+                    forbidden.append(f)
+        assert len(forbidden) == 0, (
+            f"No tracked file in agent root surfaces should match forbidden patterns "
+            f"{FORBIDDEN_PATTERNS}. Found: {forbidden}"
+        )
+
+    def test_gemini_issue_body_remains_untracked(self):
+        tracked = git_ls_files()
+        issue_files = [f for f in tracked if "github_issue_body" in f.lower()]
+        assert (
+            len(issue_files) == 0
+        ), f"github_issue_body.txt must NOT be tracked, found: {issue_files}"
+
+
+class TestSafetyBoundaries:
+    def test_gemini_surface_preserves_lr_no_go(self):
+        text = read_text(".gemini/README.md")
+        assert "NO-GO" in text
+        assert "trade-capable" in text
+        assert "Live-Go" in text
+
+    def test_gemini_onboarding_preserves_lr_no_go(self):
+        text = read_text(".gemini/onboarding.md")
+        assert "NO-GO" in text
+        assert "trade-capable" in text
+
+    def test_vscode_surface_preserves_lr_no_go(self):
+        text = read_text(".vscode/README.md")
+        assert "NO-GO" in text
+        assert "trade-capable" in text
+        assert "Live-Go" in text
+
+    def test_claude_surface_preserves_lr_no_go(self):
+        text = read_text(".claude/README.md")
+        assert "NO-GO" in text
+        assert "trade-capable" in text
+        assert "Live-Go" in text
+
+    def test_codex_surface_preserves_lr_no_go(self):
+        text = read_text(".codex/README.md")
+        assert "NO-GO" in text
+        assert "trade-capable" in text
+        assert "Live-Go" in text
+
+    def test_cursor_surface_preserves_lr_no_go(self):
+        text = read_text(".cursor/README.md")
+        assert "NO-GO" in text
+        assert "trade-capable" in text
+        assert "Live-Go" in text
+
+    def test_opencode_surface_preserves_lr_no_go(self):
+        text = read_text(".opencode/README.md")
+        assert "NO-GO" in text
+        assert "trade-capable" in text
+        assert "Live-Go" in text
+
+    def test_surface_matrix_preserves_lr_no_go(self):
+        text = read_text("docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md")
+        assert "NO-GO" in text
+        assert "trade-capable" in text
+        assert "Live-Go" in text


### PR DESCRIPTION
Closes #3320

## Delivered

- Bug reproduced: .gemini blanket-ignored (line 161), .vscode blanket-ignored (line 54) with grandfathered files
- Root surface matrix: docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md
- Gitignore precision: replace blanket ignores with allowlist patterns for .gemini/ and .vscode/
- Tracked vs ignored files documented per surface

## Root surface matrix

| Surface | Purpose |
|---------|---------|
| .claude/ | Claude Code — Bootloader, Session-Skills |
| .codex/ | Codex CLI — Session-Skills |
| .cursor/ | Cursor IDE — Subagents, Regeln, Session-Skills |
| .gemini/ | Gemini — IDE-Konfiguration, Onboarding-Router |
| .opencode/ | OpenCode CLI — Session-Skills |
| .vscode/ | VS Code — Helper-Surface (keine Autorität) |

## Changed files

| File | Change |
|------|--------|
| .gitignore | Replace blanket .vscode/ and .gemini/ with allowlist patterns |
| .claude/README.md | New root README with surface description, onboarding route, safety boundaries |
| .codex/README.md | New root README with surface description, onboarding route, safety boundaries |
| .cursor/README.md | New root README with surface description, onboarding route, safety boundaries |
| .gemini/README.md | New root README with surface description, onboarding route, safety boundaries |
| .gemini/onboarding.md | New Gemini onboarding router with canonical route contract |
| .gemini/settings.json | Tracked (safe IDE settings; local paths may need adjustment) |
| .opencode/README.md | New root README with surface description, onboarding route, safety boundaries |
| .vscode/README.md | New root README documenting VS Code as helper surface |
| AGENTS.md | Added root surface section and pointer to AGENT_ROOT_SURFACE_MATRIX |
| agents/AGENTS.md | Added reference to root surface matrix |
| docs/onboarding/AGENT_ROOT_SURFACE_MATRIX.md | New comprehensive matrix documenting all 6 surfaces |
| tests/smoke/test_agent_root_surfaces.py | New 33-test smoke suite covering surface parity |

## Validation

- 33/33 new root surface tests pass
- 16/16 existing cross-agent surface tests pass
- 17/17 onboarding orchestrator tests pass
- ruff check clean
- git diff --check clean
- rg forbidden pattern check — no forbidden patterns in tracked surface files

## Safety boundaries

- LR remains NO-GO
- trade-capable is not Live-Go
- No runtime/Docker/DB/MCP/trading changes
- No secrets or private local state tracked
- .gemini/github_issue_body.txt remains untracked

## Non-goals

- No local-only settings files modified
- No runtime/Docker/DB/MCP/trading/LR changes
- No secrets read or written
- No scope growth outside agent root surfaces

## Restunsicherheiten

- .gemini/settings.json contains absolute local paths (e.g., Python venv path). Tracked as-is since no secrets.
- .codex/README.md required git add -f due to .git/info/exclude local rule for /.codex/.
- .vscode/extensions.json and settings.json were already grandfathered (tracked pre-ignore).
