### PR TITLE
[ONBOARDING][UX] Replace 4 numbered next options with 2 clear next paths

### DIFF
--- a/.opencode/skills/onboarding/SKILL.md
+++ b/.opencode/skills/onboarding/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Canonical CDB onboarding slash command for agents, developers, and docs
   maintainers. Single smart read-only entrypoint: runs bootloader checks,
   scenario integrity, LR status, doctor/validator reachability. Produces a
-  status card and numbered next-option hints. Read-only by default. No
+  status card with two clear next paths. Read-only by default. No
   Live-Go, no Echtgeld-Go, no runtime/Docker/DB/MCP mutation. Safe for
   fresh clones and first-time agent sessions.
 ---
@@ -16,7 +16,7 @@ description: >
 `/onboarding` is the **single smart developer entrypoint** for CDB onboarding.
 It delegates to `tools/onboarding_orchestrator.py` which produces a read-only
 status card with bootloader check, scenario integrity, LR status, doctor/validator
-reachability, and numbered next-option hints.
+reachability, and two clear next paths.
 
 If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`,
 `fresh agent onboarding`, or equivalent, run: `python -m tools.onboarding_orchestrator`
@@ -40,7 +40,7 @@ github_writes: disabled
 lr: NO-GO
 ```
 
-Expected initial output — a status card ending with numbered options:
+Expected initial output — a status card ending with two clear next paths:
 
 ```text
 === CDB Onboarding ===
@@ -49,11 +49,9 @@ Status: PASS | SETUP_WARN | BLOCKED
 Keine Änderungen vorgenommen.
 LR remains NO-GO.
 trade-capable ist kein Live-Go.
-Nächste Optionen:
-  1. Setup-Plan anzeigen
-  2. Setup vorbereiten
-  3. Onboarding-Report schreiben
-  4. Ersten sicheren Issue-Workflow simulieren
+
+Soll ich jetzt den sicheren Onboarding-Workflow starten? (ja/nein)
+Oder möchtest du vorher den Setup-Plan ansehen?
 ```
 
 ## Optional Forms
@@ -77,8 +75,8 @@ Optional aliases exist, but `/onboarding` remains canonical:
 6. **Final Verdict:** `PASS` | `SETUP_WARN` | `BLOCKED`.
 
 The orchestrator is **read-only by default**: no file writes, no report,
-no setup mutation, no Docker, no secrets. The output ends with numbered
-next-option hints (no open yes/no question).
+no setup mutation, no Docker, no secrets. The output ends with two clear
+next paths (a yes/no question and a setup-plan hint).
 
 Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
 
@@ -139,16 +137,18 @@ Non-blocking warnings (`SETUP_WARN`):
 - Context Doctor nicht initialisiert (setup warn, kein blocker)
 - `onboarding_doctor` nicht erreichbar
 
-## Allowed Next Options (numbered, no open question)
+## Allowed Next Paths
 
-```text
-1. Setup-Plan anzeigen
-2. Setup vorbereiten
-3. Onboarding-Report schreiben
-4. Ersten sicheren Issue-Workflow simulieren
-```
+Default output shows exactly two paths:
 
-All four options require explicit GO before execution. Default mode produces
+1. **Primär:** `Soll ich jetzt den sicheren Onboarding-Workflow starten? (ja/nein)`
+2. **Alternative:** `Oder möchtest du vorher den Setup-Plan ansehen?`
+
+The old specialized paths (Setup vorbereiten, Onboarding-Report schreiben,
+Ersten sicheren Issue-Workflow simulieren) are removed from the default
+output but remain available as explicit CLI/docs details.
+
+All paths require explicit GO before execution. Default mode produces
 no report and no setup mutation.
 
 ## Non-Goals
@@ -158,4 +158,3 @@ no report and no setup mutation.
 - No runtime, Docker, trading, strategy, LR, productive DB, SurrealDB, or MCP mutation.
 - No automatic setup, report, or runtime action.
 - No replacement of existing CDB subagents.
-- No open yes/no question in default output.

--- a/tests/smoke/test_onboarding_orchestrator.py
+++ b/tests/smoke/test_onboarding_orchestrator.py
@@ -32,15 +32,13 @@ class TestOrchestratorSmoke:
 
     def test_orchestrator_output_contains_onboarding(self):
         result = _run_orchestrator()
-        assert "CDB Onboarding" in result.stdout, (
-            "Output must contain 'CDB Onboarding' header"
-        )
+        assert (
+            "CDB Onboarding" in result.stdout
+        ), "Output must contain 'CDB Onboarding' header"
 
     def test_orchestrator_output_contains_status(self):
         result = _run_orchestrator()
-        assert "Status:" in result.stdout, (
-            "Output must contain 'Status:' line"
-        )
+        assert "Status:" in result.stdout, "Output must contain 'Status:' line"
 
     def test_orchestrator_output_status_is_valid(self):
         result = _run_orchestrator()
@@ -53,59 +51,61 @@ class TestOrchestratorSmoke:
 
     def test_orchestrator_output_keine_aenderungen(self):
         result = _run_orchestrator()
-        assert "Keine Änderungen vorgenommen." in result.stdout, (
-            "Output must contain 'Keine Änderungen vorgenommen.'"
-        )
+        assert (
+            "Keine Änderungen vorgenommen." in result.stdout
+        ), "Output must contain 'Keine Änderungen vorgenommen.'"
 
     def test_orchestrator_output_lr_no_go(self):
         result = _run_orchestrator()
-        assert "LR remains NO-GO" in result.stdout, (
-            "Output must contain 'LR remains NO-GO'"
-        )
+        assert (
+            "LR remains NO-GO" in result.stdout
+        ), "Output must contain 'LR remains NO-GO'"
 
     def test_orchestrator_output_trade_capable(self):
         result = _run_orchestrator()
-        assert "trade-capable ist kein Live-Go" in result.stdout, (
-            "Output must contain 'trade-capable ist kein Live-Go'"
-        )
+        assert (
+            "trade-capable ist kein Live-Go" in result.stdout
+        ), "Output must contain 'trade-capable ist kein Live-Go'"
 
-    def test_orchestrator_output_options(self):
+    def test_orchestrator_output_next_paths_contains_yes_no(self):
         result = _run_orchestrator()
-        assert "Nächste Optionen:" in result.stdout, (
-            "Output must contain 'Nächste Optionen:'"
-        )
+        assert (
+            "Soll ich jetzt den sicheren Onboarding-Workflow starten? (ja/nein)"
+            in result.stdout
+        ), "Output must contain the yes/no onboarding question"
 
-    def test_orchestrator_option_1(self):
+    def test_orchestrator_output_next_paths_contains_setup_plan(self):
         result = _run_orchestrator()
-        assert "Setup-Plan anzeigen" in result.stdout
+        assert (
+            "Oder möchtest du vorher den Setup-Plan ansehen?" in result.stdout
+        ), "Output must contain the setup-plan alternative"
 
-    def test_orchestrator_option_2(self):
+    def test_orchestrator_does_not_contain_old_options(self):
         result = _run_orchestrator()
-        assert "Setup vorbereiten" in result.stdout
+        old_patterns = [
+            "1. Setup-Plan anzeigen",
+            "2. Setup vorbereiten",
+            "3. Onboarding-Report schreiben",
+            "4. Ersten sicheren Issue-Workflow simulieren",
+        ]
+        for pattern in old_patterns:
+            assert (
+                pattern not in result.stdout
+            ), f"Output must not contain old numbered option: {pattern}"
 
-    def test_orchestrator_option_3(self):
+    def test_orchestrator_does_not_contain_naechste_optionen_header(self):
         result = _run_orchestrator()
-        assert "Onboarding-Report schreiben" in result.stdout
-
-    def test_orchestrator_option_4(self):
-        result = _run_orchestrator()
-        assert "Ersten sicheren Issue-Workflow simulieren" in result.stdout
-
-    def test_orchestrator_no_open_question(self):
-        result = _run_orchestrator()
-        output = result.stdout
-        has_question = "?" in output.split("Nächste Optionen:")[-1] if "Nächste Optionen:" in output else False
-        assert not has_question, (
-            "Output must not contain open yes/no question after options"
-        )
+        assert (
+            "Nächste Optionen:" not in result.stdout
+        ), "Output must not contain 'Nächste Optionen:' header"
 
     def test_orchestrator_stderr_empty_or_info(self):
         result = _run_orchestrator()
         stderr = result.stderr.strip()
         if stderr:
-            assert "ERROR" not in stderr.upper(), (
-                f"stderr must not contain ERROR: {stderr}"
-            )
+            assert (
+                "ERROR" not in stderr.upper()
+            ), f"stderr must not contain ERROR: {stderr}"
 
     def test_orchestrator_json_format(self):
         result = _run_orchestrator("--format", "json")
@@ -125,8 +125,13 @@ class TestOrchestratorSmoke:
     def test_orchestrator_safe_output(self):
         result = _run_orchestrator()
         secret_patterns = [
-            "api_key", "api_secret", "password",
-            "ghp_", "gho_", "ghu_", "ghs_",
+            "api_key",
+            "api_secret",
+            "password",
+            "ghp_",
+            "gho_",
+            "ghu_",
+            "ghs_",
         ]
         lower = result.stdout.lower()
         for pattern in secret_patterns:

--- a/tools/onboarding_orchestrator.py
+++ b/tools/onboarding_orchestrator.py
@@ -13,7 +13,7 @@ Exit codes:
 
 This tool is read-only by default:
     - No file writes, no report, no setup mutation, no Docker, no secrets.
-    - Status card ends with numbered next-option hints (no open yes/no question).
+    - Status card ends with two clear next paths (yes/no question + setup-plan hint).
 
 Read Order:
     agents/AGENTS.md § Read Order -> Context Brain Preflight -> Live Truth ->
@@ -26,11 +26,9 @@ Output contract:
     Keine Änderungen vorgenommen.
     LR remains NO-GO.
     trade-capable ist kein Live-Go.
-    Nächste Optionen:
-    1. Setup-Plan anzeigen
-    2. Setup vorbereiten
-    3. Onboarding-Report schreiben
-    4. Ersten sicheren Issue-Workflow simulieren
+
+    Soll ich jetzt den sicheren Onboarding-Workflow starten? (ja/nein)
+    Oder möchtest du vorher den Setup-Plan ansehen?
 """
 
 from __future__ import annotations
@@ -52,9 +50,7 @@ CANONICAL_BOOTLOADER_FILES: list[str] = [
     "agents/AGENTS.md",
 ]
 
-SCENARIO_FILE = (
-    "docs/onboarding/ONBOARDING_SCENARIO_001_FRESH_AGENT_SAFE_WORK_DRILL.md"
-)
+SCENARIO_FILE = "docs/onboarding/ONBOARDING_SCENARIO_001_FRESH_AGENT_SAFE_WORK_DRILL.md"
 
 REQUIRED_SCENARIO_TERMS: list[str] = [
     "onboarding-scenario-001",
@@ -74,11 +70,9 @@ FORBIDDEN_OUTPUT_PATTERNS: list[re.Pattern] = [
     re.compile(r"https?://[^\s\"']+"),
 ]
 
-NEXT_OPTIONS: list[str] = [
-    "1. Setup-Plan anzeigen",
-    "2. Setup vorbereiten",
-    "3. Onboarding-Report schreiben",
-    "4. Ersten sicheren Issue-Workflow simulieren",
+NEXT_PATHS: list[str] = [
+    "Soll ich jetzt den sicheren Onboarding-Workflow starten? (ja/nein)",
+    "Oder möchtest du vorher den Setup-Plan ansehen?",
 ]
 
 
@@ -105,7 +99,12 @@ def _run_cmd(
         out = (proc.stdout or "").strip()
         err = (proc.stderr or "").strip()
         return proc.returncode, out, err
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired, UnicodeDecodeError) as exc:
+    except (
+        FileNotFoundError,
+        OSError,
+        subprocess.TimeoutExpired,
+        UnicodeDecodeError,
+    ) as exc:
         return -1, "", str(exc)
 
 
@@ -207,7 +206,9 @@ def _check_context_doctor(
 def _validate_output_safe(text: str) -> None:
     for pattern in FORBIDDEN_OUTPUT_PATTERNS:
         if pattern.search(text):
-            raise ValueError("output contains forbidden pattern — potential secret leak")
+            raise ValueError(
+                "output contains forbidden pattern — potential secret leak"
+            )
 
 
 def build_verdict(
@@ -223,9 +224,7 @@ def build_verdict(
     bl_status, bl_missing = _check_bootloader_files(r)
     output.bootloader_ok = bl_status
     if bl_status == "FAIL":
-        output.blockers.append(
-            f"Fehlender Bootloader: {', '.join(bl_missing)}"
-        )
+        output.blockers.append(f"Fehlender Bootloader: {', '.join(bl_missing)}")
 
     # 2. Scenario file
     sc_status, sc_issues = _check_scenario_file(r)
@@ -311,9 +310,7 @@ def format_output(report: OrchestratorOutput, fmt: str) -> str:
     lines.append("trade-capable ist kein Live-Go.")
     lines.append("")
 
-    lines.append("Nächste Optionen:")
-    for opt in NEXT_OPTIONS:
-        lines.append(f"  {opt}")
+    lines.extend(NEXT_PATHS)
 
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary

Remove the four numbered next-option hints from the onboarding orchestrator
output and replace them with two clear next paths.

## Changes

### tools/onboarding_orchestrator.py
- Replace \NEXT_OPTIONS\ (4 numbered items) with \NEXT_PATHS\ (2 clear paths)
- Update docstring and output contract
- Remove "Nächste Optionen:" header from default output

### tests/smoke/test_onboarding_orchestrator.py
- Replace option tests (1-4) with new path tests
- Add: Default output contains yes/no question and setup-plan hint
- Add: Default output no longer contains old numbered options
- Add: Default output no longer contains "Nächste Optionen:" header

### .opencode/skills/onboarding/SKILL.md
- Update description, expected output, and allowed-next-paths section

## Validation
- \pytest -q tests/smoke/test_onboarding_orchestrator.py\ — 15 passed
- \pytest -q tests/smoke/test_onboarding_cross_agent_surfaces.py\ — 16 passed
- \pytest -q tests/smoke/test_agent_root_surfaces.py\ — 33 passed
- \python -m tools.onboarding_orchestrator\ — output shows new paths
- \git diff --check\ — clean

Closes #3322