### PR TITLE
fix(onboarding): replace setup-plan prompt

### DIFF
--- a/.opencode/skills/onboarding/SKILL.md
+++ b/.opencode/skills/onboarding/SKILL.md
@@ -40,7 +40,7 @@ github_writes: disabled
 lr: NO-GO
 ```
 
-Expected initial output — a status card ending with two clear next paths:
+Expected initial output — a status card ending with the strict two-option setup prompt:
 
 ```text
 === CDB Onboarding ===
@@ -50,8 +50,10 @@ Keine Änderungen vorgenommen.
 LR remains NO-GO.
 trade-capable ist kein Live-Go.
 
-Soll ich jetzt den sicheren Onboarding-Workflow starten? (ja/nein)
-Oder möchtest du vorher den Setup-Plan ansehen?
+Möchtest du das Onboarding-Setup jetzt ausführen?
+
+1. Ja
+2. Abbruch
 ```
 
 ## Optional Forms
@@ -75,8 +77,8 @@ Optional aliases exist, but `/onboarding` remains canonical:
 6. **Final Verdict:** `PASS` | `SETUP_WARN` | `BLOCKED`.
 
 The orchestrator is **read-only by default**: no file writes, no report,
-no setup mutation, no Docker, no secrets. The output ends with two clear
-next paths (a yes/no question and a setup-plan hint).
+no setup mutation, no Docker, no secrets. The output ends with a strict
+two-option setup confirmation prompt.
 
 Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
 
@@ -139,14 +141,13 @@ Non-blocking warnings (`SETUP_WARN`):
 
 ## Allowed Next Paths
 
-Default output shows exactly two paths:
+Default output shows exactly one two-option prompt:
 
-1. **Primär:** `Soll ich jetzt den sicheren Onboarding-Workflow starten? (ja/nein)`
-2. **Alternative:** `Oder möchtest du vorher den Setup-Plan ansehen?`
+1. `Möchtest du das Onboarding-Setup jetzt ausführen?`
+2. `1. Ja` / `2. Abbruch`
 
-The old specialized paths (Setup vorbereiten, Onboarding-Report schreiben,
-Ersten sicheren Issue-Workflow simulieren) are removed from the default
-output but remain available as explicit CLI/docs details.
+`1. Ja` maps only to setup approval / an allowed next action boundary in this
+slice. It does not create `.env` or perform any local setup mutation.
 
 All paths require explicit GO before execution. Default mode produces
 no report and no setup mutation.

--- a/tests/smoke/test_onboarding_orchestrator.py
+++ b/tests/smoke/test_onboarding_orchestrator.py
@@ -70,8 +70,7 @@ class TestOrchestratorSmoke:
     def test_orchestrator_output_contains_setup_prompt(self):
         result = _run_orchestrator()
         assert (
-            "Möchtest du das Onboarding-Setup jetzt ausführen?"
-            in result.stdout
+            "Möchtest du das Onboarding-Setup jetzt ausführen?" in result.stdout
         ), "Output must contain the setup confirmation prompt"
 
     def test_orchestrator_output_contains_only_two_setup_options(self):

--- a/tests/smoke/test_onboarding_orchestrator.py
+++ b/tests/smoke/test_onboarding_orchestrator.py
@@ -67,18 +67,28 @@ class TestOrchestratorSmoke:
             "trade-capable ist kein Live-Go" in result.stdout
         ), "Output must contain 'trade-capable ist kein Live-Go'"
 
-    def test_orchestrator_output_next_paths_contains_yes_no(self):
+    def test_orchestrator_output_contains_setup_prompt(self):
         result = _run_orchestrator()
         assert (
-            "Soll ich jetzt den sicheren Onboarding-Workflow starten? (ja/nein)"
+            "Möchtest du das Onboarding-Setup jetzt ausführen?"
             in result.stdout
-        ), "Output must contain the yes/no onboarding question"
+        ), "Output must contain the setup confirmation prompt"
 
-    def test_orchestrator_output_next_paths_contains_setup_plan(self):
+    def test_orchestrator_output_contains_only_two_setup_options(self):
         result = _run_orchestrator()
-        assert (
-            "Oder möchtest du vorher den Setup-Plan ansehen?" in result.stdout
-        ), "Output must contain the setup-plan alternative"
+        assert "1. Ja" in result.stdout
+        assert "2. Abbruch" in result.stdout
+
+    def test_orchestrator_does_not_contain_removed_setup_prompt_variants(self):
+        result = _run_orchestrator()
+        removed_patterns = [
+            "Soll ich jetzt den sicheren Onboarding-Workflow starten? (ja/nein)",
+            "Oder möchtest du vorher den Setup-Plan ansehen?",
+        ]
+        for pattern in removed_patterns:
+            assert (
+                pattern not in result.stdout
+            ), f"Output must not contain removed prompt variant: {pattern}"
 
     def test_orchestrator_does_not_contain_old_options(self):
         result = _run_orchestrator()

--- a/tests/unit/tools/test_onboarding_orchestrator_helpers.py
+++ b/tests/unit/tools/test_onboarding_orchestrator_helpers.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from tools import onboarding_orchestrator
+
+pytestmark = pytest.mark.unit
+
+
+def _iter_input(values: list[str]) -> Iterator[str]:
+    return iter(values)
+
+
+def test_get_setup_prompt_text_is_exact() -> None:
+    assert onboarding_orchestrator.get_setup_prompt_text() == (
+        "Möchtest du das Onboarding-Setup jetzt ausführen?\n\n"
+        "1. Ja\n"
+        "2. Abbruch"
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [
+        ("1", onboarding_orchestrator.SETUP_APPROVED),
+        ("ja", onboarding_orchestrator.SETUP_APPROVED),
+        (" yes ", onboarding_orchestrator.SETUP_APPROVED),
+        ("2", onboarding_orchestrator.SETUP_ABORTED),
+        ("nein", onboarding_orchestrator.SETUP_ABORTED),
+        ("NO", onboarding_orchestrator.SETUP_ABORTED),
+        ("abbruch", onboarding_orchestrator.SETUP_ABORTED),
+        ("cancel", onboarding_orchestrator.SETUP_ABORTED),
+    ],
+)
+def test_normalize_setup_prompt_input_maps_expected_values(
+    raw_value: str, expected: str
+) -> None:
+    assert onboarding_orchestrator.normalize_setup_prompt_input(raw_value) == expected
+
+
+@pytest.mark.parametrize("raw_value", ["", "0", "maybe", "setup-plan"])
+def test_normalize_setup_prompt_input_rejects_invalid_values(raw_value: str) -> None:
+    assert onboarding_orchestrator.normalize_setup_prompt_input(raw_value) is None
+
+
+def test_prompt_for_setup_confirmation_repeats_after_invalid_input() -> None:
+    responses = _iter_input(["vielleicht", "yes"])
+    prompts: list[str] = []
+
+    result = onboarding_orchestrator.prompt_for_setup_confirmation(
+        input_fn=lambda _prompt: next(responses),
+        output_fn=prompts.append,
+    )
+
+    assert result == onboarding_orchestrator.SETUP_APPROVED
+    assert prompts == [
+        onboarding_orchestrator.get_setup_prompt_text(),
+        onboarding_orchestrator.get_setup_prompt_text(),
+    ]
+
+
+def test_prompt_for_setup_confirmation_accepts_abort_synonym() -> None:
+    prompts: list[str] = []
+
+    result = onboarding_orchestrator.prompt_for_setup_confirmation(
+        input_fn=lambda _prompt: "abbruch",
+        output_fn=prompts.append,
+    )
+
+    assert result == onboarding_orchestrator.SETUP_ABORTED
+    assert prompts == [onboarding_orchestrator.get_setup_prompt_text()]

--- a/tests/unit/tools/test_onboarding_orchestrator_helpers.py
+++ b/tests/unit/tools/test_onboarding_orchestrator_helpers.py
@@ -15,9 +15,7 @@ def _iter_input(values: list[str]) -> Iterator[str]:
 
 def test_get_setup_prompt_text_is_exact() -> None:
     assert onboarding_orchestrator.get_setup_prompt_text() == (
-        "Möchtest du das Onboarding-Setup jetzt ausführen?\n\n"
-        "1. Ja\n"
-        "2. Abbruch"
+        "Möchtest du das Onboarding-Setup jetzt ausführen?\n\n" "1. Ja\n" "2. Abbruch"
     )
 
 

--- a/tools/onboarding_orchestrator.py
+++ b/tools/onboarding_orchestrator.py
@@ -13,7 +13,7 @@ Exit codes:
 
 This tool is read-only by default:
     - No file writes, no report, no setup mutation, no Docker, no secrets.
-    - Status card ends with two clear next paths (yes/no question + setup-plan hint).
+    - Status card ends with a strict two-option setup confirmation prompt.
 
 Read Order:
     agents/AGENTS.md § Read Order -> Context Brain Preflight -> Live Truth ->
@@ -27,8 +27,10 @@ Output contract:
     LR remains NO-GO.
     trade-capable ist kein Live-Go.
 
-    Soll ich jetzt den sicheren Onboarding-Workflow starten? (ja/nein)
-    Oder möchtest du vorher den Setup-Plan ansehen?
+    Möchtest du das Onboarding-Setup jetzt ausführen?
+
+    1. Ja
+    2. Abbruch
 """
 
 from __future__ import annotations
@@ -70,10 +72,18 @@ FORBIDDEN_OUTPUT_PATTERNS: list[re.Pattern] = [
     re.compile(r"https?://[^\s\"']+"),
 ]
 
-NEXT_PATHS: list[str] = [
-    "Soll ich jetzt den sicheren Onboarding-Workflow starten? (ja/nein)",
-    "Oder möchtest du vorher den Setup-Plan ansehen?",
+SETUP_PROMPT_LINES: list[str] = [
+    "Möchtest du das Onboarding-Setup jetzt ausführen?",
+    "",
+    "1. Ja",
+    "2. Abbruch",
 ]
+
+SETUP_APPROVED = "setup-approved"
+SETUP_ABORTED = "setup-aborted"
+
+SETUP_APPROVAL_INPUTS = {"1", "ja", "yes"}
+SETUP_ABORT_INPUTS = {"2", "nein", "no", "abbruch", "cancel"}
 
 
 def _run_cmd(
@@ -134,6 +144,35 @@ class OrchestratorOutput:
             "blockers": self.blockers,
             "details": self.details,
         }
+
+
+def get_setup_prompt_text() -> str:
+    return "\n".join(SETUP_PROMPT_LINES)
+
+
+def normalize_setup_prompt_input(value: str) -> str | None:
+    normalized = value.strip().lower()
+    if normalized in SETUP_APPROVAL_INPUTS:
+        return SETUP_APPROVED
+    if normalized in SETUP_ABORT_INPUTS:
+        return SETUP_ABORTED
+    return None
+
+
+def prompt_for_setup_confirmation(
+    input_fn: Callable[[str], str] = input,
+    output_fn: Callable[[str], None] | None = None,
+) -> str:
+    prompt_text = get_setup_prompt_text()
+    while True:
+        if output_fn is not None:
+            output_fn(prompt_text)
+            raw_value = input_fn("")
+        else:
+            raw_value = input_fn(f"{prompt_text}\n")
+        decision = normalize_setup_prompt_input(raw_value)
+        if decision is not None:
+            return decision
 
 
 def _check_bootloader_files(root: Path) -> tuple[str, list[str]]:
@@ -310,7 +349,7 @@ def format_output(report: OrchestratorOutput, fmt: str) -> str:
     lines.append("trade-capable ist kein Live-Go.")
     lines.append("")
 
-    lines.extend(NEXT_PATHS)
+    lines.extend(SETUP_PROMPT_LINES)
 
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- remove the setup-plan branch from the onboarding orchestrator output
- add strict two-option setup confirmation helpers without blocking the default CLI path
- update onboarding tests and the active OpenCode onboarding skill reference

## Validation
- git diff --check
- pytest -q tests -k onboarding
- python -m tools.onboarding_orchestrator
- python -m tools.validate_onboarding_docs
- rg -n "setup-plan|Setup-Plan|vorher.*Setup" tools tests docs agents README.md .codex .claude .gemini .opencode

Closes #3327
Refs #3326