### PR TITLE
fix(onboarding): harden batch state and doctor contracts

### DIFF
--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -28,8 +28,7 @@ read-only CDB Onboarding status card before any optional next step.
 Equivalent default config:
 
 ```yaml
-role: agent
-mode: first-issue-dry-run
+mode: default
 writes: disabled
 github_writes: disabled
 lr: NO-GO
@@ -38,11 +37,11 @@ lr: NO-GO
 Expected initial output:
 
 ```text
-ONBOARDING_START
-mode: first-issue-dry-run
-role: Agent
-writes: disabled
-lr: NO-GO
+=== CDB Onboarding ===
+Status: PASS | SETUP_WARN | BLOCKED
+State: STATUS_ONLY | SETUP_CONFIRMATION_PENDING | SETUP_REQUIRED | DRY_RUN_COMPLETE | BLOCKED
+check_scope: onboarding_status_default | onboarding_status_check_only
+allowed_next_actions: <machine-readable list>
 ```
 
 ## Optional Forms
@@ -64,7 +63,15 @@ Optional aliases exist, but `/onboarding` remains canonical:
 4. **Live Truth:** GitHub live + repo live before ledger.
 5. **Optional next steps only after the status card:** role-specific tour,
    doctor/validator, or first-issue sandbox.
-6. **Final Verdict:** CDB Onboarding status card with numbered next options.
+6. **Final Verdict:** CDB Onboarding status card with explicit state and allowed next actions.
+   The two-option setup prompt appears only when `State: SETUP_CONFIRMATION_PENDING`.
+
+## Agent Response Guardrails
+
+- Report only `Status`, `State`, warnings, `allowed_next_actions`, `check_scope`, and `skipped_checks`.
+- Do not invent or renumber options.
+- Do not offer setup execution after `--mode check-only`.
+- If a doctor output is partial, say that it is a partial check.
 
 ## Referenced V2 Surfaces
 

--- a/.codex/cdb_skills/onboarding/SKILL.md
+++ b/.codex/cdb_skills/onboarding/SKILL.md
@@ -32,3 +32,7 @@ python -m tools.onboarding_orchestrator --mode check-only
 - Board stage `trade-capable` is not Live-Go.
 - No Echtgeld-Go.
 - No file writes, no GitHub writes, no branch creation, no PR creation, no runtime/Docker/DB/MCP mutation, no secrets.
+- Report only the orchestrator `Status`, `State`, warnings, and `allowed_next_actions`.
+- Do not invent extra onboarding options or reintroduce the removed legacy setup branch.
+- `--mode check-only` is dry-run only and must not imply setup execution.
+- The `1. Ja / 2. Abbruch` prompt is only valid when the orchestrator reports `State: SETUP_CONFIRMATION_PENDING`.

--- a/.cursor/skills/onboarding/SKILL.md
+++ b/.cursor/skills/onboarding/SKILL.md
@@ -28,8 +28,7 @@ read-only CDB Onboarding status card before any optional next step.
 Equivalent default config:
 
 ```yaml
-role: agent
-mode: first-issue-dry-run
+mode: default
 writes: disabled
 github_writes: disabled
 lr: NO-GO
@@ -38,11 +37,11 @@ lr: NO-GO
 Expected initial output:
 
 ```text
-ONBOARDING_START
-mode: first-issue-dry-run
-role: Agent
-writes: disabled
-lr: NO-GO
+=== CDB Onboarding ===
+Status: PASS | SETUP_WARN | BLOCKED
+State: STATUS_ONLY | SETUP_CONFIRMATION_PENDING | SETUP_REQUIRED | DRY_RUN_COMPLETE | BLOCKED
+check_scope: onboarding_status_default | onboarding_status_check_only
+allowed_next_actions: <machine-readable list>
 ```
 
 ## Optional Forms
@@ -64,7 +63,15 @@ Optional aliases exist, but `/onboarding` remains canonical:
 4. **Live Truth:** GitHub live + repo live before ledger.
 5. **Optional next steps only after the status card:** role-specific tour,
    doctor/validator, or first-issue sandbox.
-6. **Final Verdict:** CDB Onboarding status card with numbered next options.
+6. **Final Verdict:** CDB Onboarding status card with explicit state and allowed next actions.
+   The two-option setup prompt appears only when `State: SETUP_CONFIRMATION_PENDING`.
+
+## Agent Response Guardrails
+
+- Report only `Status`, `State`, warnings, `allowed_next_actions`, `check_scope`, and `skipped_checks`.
+- Do not invent or renumber options.
+- Do not offer setup execution after `--mode check-only`.
+- If a doctor output is partial, say that it is a partial check.
 
 ## Referenced V2 Surfaces
 

--- a/.gemini/onboarding.md
+++ b/.gemini/onboarding.md
@@ -7,6 +7,8 @@ Wenn ein Gemini-Agent einen `/onboarding`-, `onboarding`-, `onboarding durchfüh
 3. **Default output is the CDB Onboarding status card.**
 4. **Read-only by default.** Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
 5. **Routing-Hierarchie**: Dieser Router ist der kanonische Gemini-Onboarding-Pfad. Der Gemini-Bootloader in `GEMINI.md` (Repo-Root) verweist ergänzend auf diesen Router.
+6. **Antwortvertrag**: Berichte nur `Status`, `State`, warnings, `allowed_next_actions`, `check_scope` und `skipped_checks`.
+7. **Keine erfundenen Optionen**: kein Legacy-Setup-Ast, keine Umnummerierung, keine direkte Setup-Ausfuehrung nach `check-only`.
 
 ## Safety Boundaries
 

--- a/.opencode/skills/onboarding/SKILL.md
+++ b/.opencode/skills/onboarding/SKILL.md
@@ -40,17 +40,22 @@ github_writes: disabled
 lr: NO-GO
 ```
 
-Expected initial output — a status card ending with the strict two-option setup prompt:
+Expected initial output - a status card with explicit state and allowed next actions:
 
 ```text
 === CDB Onboarding ===
 Status: PASS | SETUP_WARN | BLOCKED
+State: STATUS_ONLY | SETUP_CONFIRMATION_PENDING | SETUP_REQUIRED | DRY_RUN_COMPLETE | BLOCKED
+check_scope: onboarding_status_default | onboarding_status_check_only
+allowed_next_actions: <machine-readable list>
 ...
-Keine Änderungen vorgenommen.
+No changes made.
 LR remains NO-GO.
-trade-capable ist kein Live-Go.
+trade-capable is not Live-Go.
 
-Möchtest du das Onboarding-Setup jetzt ausführen?
+Only when `State: SETUP_CONFIRMATION_PENDING`:
+
+Moechtest du das Onboarding-Setup jetzt ausfuehren?
 
 1. Ja
 2. Abbruch
@@ -77,8 +82,8 @@ Optional aliases exist, but `/onboarding` remains canonical:
 6. **Final Verdict:** `PASS` | `SETUP_WARN` | `BLOCKED`.
 
 The orchestrator is **read-only by default**: no file writes, no report,
-no setup mutation, no Docker, no secrets. The output ends with a strict
-two-option setup confirmation prompt.
+no setup mutation, no Docker, no secrets. Check-only is a dry-run only and
+must not show or imply setup execution.
 
 Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
 
@@ -141,13 +146,24 @@ Non-blocking warnings (`SETUP_WARN`):
 
 ## Allowed Next Paths
 
-Default output shows exactly one two-option prompt:
+Default output may expose these machine-readable next actions only:
 
-1. `Möchtest du das Onboarding-Setup jetzt ausführen?`
-2. `1. Ja` / `2. Abbruch`
+- `status_only`
+- `approve_setup`
+- `request_setup_go`
+- `abort`
 
+The two-option prompt appears only when `State: SETUP_CONFIRMATION_PENDING`.
 `1. Ja` maps only to setup approval / an allowed next action boundary in this
 slice. It does not create `.env` or perform any local setup mutation.
+
+## Agent Response Guardrails
+
+- Report the orchestrator `Status`, `State`, warnings, and `allowed_next_actions`.
+- Do not invent, renumber, or expand options beyond the orchestrator contract.
+- Do not offer direct setup execution after `--mode check-only` / dry-run.
+- Treat `check_scope` and `skipped_checks` as part of the report contract.
+- If doctor output is partial, say so explicitly instead of presenting it as a full check.
 
 All paths require explicit GO before execution. Default mode produces
 no report and no setup mutation.

--- a/tests/smoke/test_onboarding_cross_agent_surfaces.py
+++ b/tests/smoke/test_onboarding_cross_agent_surfaces.py
@@ -12,6 +12,8 @@ CANONICAL_ROUTER_TEXT = (
 
 PRIMARY_ROUTE = "python -m tools.onboarding_orchestrator"
 READ_ONLY_DEFAULT = "Read-only by default"
+STATE_CONTRACT = "allowed_next_actions"
+CHECK_ONLY_GUARDRAIL = "check-only"
 NO_ENV_DEFAULT = (
     "Do not create `.env`, initialize secrets, initialize context, write "
     "reports, create issues, or run Docker unless the user explicitly selects "
@@ -69,16 +71,19 @@ class TestSharedOnboardingSkills:
         assert PRIMARY_ROUTE in text
         assert "tools/onboarding_orchestrator.py" in text
         assert "Read-only by default" in text
+        assert STATE_CONTRACT in text
 
     def test_claude_onboarding_present_and_routed(self):
         text = read_text(".claude/skills/onboarding/SKILL.md")
         assert PRIMARY_ROUTE in text
         assert "tools/onboarding_orchestrator.py" in text
+        assert STATE_CONTRACT in text
 
     def test_cursor_onboarding_present_and_routed(self):
         text = read_text(".cursor/skills/onboarding/SKILL.md")
         assert PRIMARY_ROUTE in text
         assert "tools/onboarding_orchestrator.py" in text
+        assert STATE_CONTRACT in text
 
 
 class TestSessionStartDelegation:
@@ -115,6 +120,19 @@ class TestSafetyGuardrails:
             text = read_text(relative_path)
             assert NO_ENV_DEFAULT in text
             assert "context-query-config-init" not in text
+
+    def test_main_surfaces_document_check_only_guardrail(self):
+        surfaces = [
+            ".codex/cdb_skills/onboarding/SKILL.md",
+            ".claude/skills/onboarding/SKILL.md",
+            ".cursor/skills/onboarding/SKILL.md",
+            ".opencode/skills/onboarding/SKILL.md",
+            ".gemini/onboarding.md",
+        ]
+        for relative_path in surfaces:
+            text = read_text(relative_path)
+            assert CHECK_ONLY_GUARDRAIL in text
+            assert "setup-plan" not in text
 
     def test_all_surfaces_preserve_lr_no_go_boundary(self):
         surfaces = [

--- a/tests/smoke/test_onboarding_orchestrator.py
+++ b/tests/smoke/test_onboarding_orchestrator.py
@@ -40,6 +40,11 @@ class TestOrchestratorSmoke:
         result = _run_orchestrator()
         assert "Status:" in result.stdout, "Output must contain 'Status:' line"
 
+    def test_orchestrator_output_contains_state_and_actions(self):
+        result = _run_orchestrator()
+        assert "State:" in result.stdout
+        assert "allowed_next_actions:" in result.stdout
+
     def test_orchestrator_output_status_is_valid(self):
         result = _run_orchestrator()
         valid_statuses = ("PASS", "SETUP_WARN", "BLOCKED")
@@ -52,8 +57,8 @@ class TestOrchestratorSmoke:
     def test_orchestrator_output_keine_aenderungen(self):
         result = _run_orchestrator()
         assert (
-            "Keine Änderungen vorgenommen." in result.stdout
-        ), "Output must contain 'Keine Änderungen vorgenommen.'"
+            "No changes made." in result.stdout
+        ), "Output must contain 'No changes made.'"
 
     def test_orchestrator_output_lr_no_go(self):
         result = _run_orchestrator()
@@ -64,19 +69,26 @@ class TestOrchestratorSmoke:
     def test_orchestrator_output_trade_capable(self):
         result = _run_orchestrator()
         assert (
-            "trade-capable ist kein Live-Go" in result.stdout
-        ), "Output must contain 'trade-capable ist kein Live-Go'"
+            "trade-capable is not Live-Go" in result.stdout
+        ), "Output must contain 'trade-capable is not Live-Go'"
 
     def test_orchestrator_output_contains_setup_prompt(self):
         result = _run_orchestrator()
-        assert (
-            "Möchtest du das Onboarding-Setup jetzt ausführen?" in result.stdout
-        ), "Output must contain the setup confirmation prompt"
+        if "State: SETUP_CONFIRMATION_PENDING" in result.stdout:
+            assert (
+                "Moechtest du das Onboarding-Setup jetzt ausfuehren?" in result.stdout
+            ), "Pending setup state must contain the setup confirmation prompt"
+        else:
+            assert (
+                "Moechtest du das Onboarding-Setup jetzt ausfuehren?"
+                not in result.stdout
+            ), "Non-pending states must not contain the setup confirmation prompt"
 
     def test_orchestrator_output_contains_only_two_setup_options(self):
         result = _run_orchestrator()
-        assert "1. Ja" in result.stdout
-        assert "2. Abbruch" in result.stdout
+        if "State: SETUP_CONFIRMATION_PENDING" in result.stdout:
+            assert "1. Ja" in result.stdout
+            assert "2. Abbruch" in result.stdout
 
     def test_orchestrator_does_not_contain_removed_setup_prompt_variants(self):
         result = _run_orchestrator()
@@ -127,9 +139,29 @@ class TestOrchestratorSmoke:
         result = _run_orchestrator("--format", "json")
         data = json.loads(result.stdout)
         assert "status" in data
+        assert "state" in data
+        assert "check_scope" in data
+        assert "allowed_next_actions" in data
+        assert "requires_explicit_setup_go" in data
+        assert "setup_prompt_visible" in data
         assert "bootloader" in data
         assert "scenario" in data
         assert "lr_note" in data
+
+    def test_orchestrator_check_only_has_no_setup_prompt(self):
+        result = _run_orchestrator("--mode", "check-only")
+        assert result.returncode in (0, 1)
+        assert "State: SETUP_CONFIRMATION_PENDING" not in result.stdout
+        assert (
+            "Moechtest du das Onboarding-Setup jetzt ausfuehren?" not in result.stdout
+        )
+        assert "check-only mode is dry-run only." in result.stdout
+
+    def test_orchestrator_check_only_json_uses_check_only_scope(self):
+        result = _run_orchestrator("--mode", "check-only", "--format", "json")
+        data = json.loads(result.stdout)
+        assert data["check_scope"] == "onboarding_status_check_only"
+        assert data["state"] in ("DRY_RUN_COMPLETE", "SETUP_REQUIRED", "BLOCKED")
 
     def test_orchestrator_safe_output(self):
         result = _run_orchestrator()

--- a/tests/unit/surrealdb/test_context_onboarding_doctor.py
+++ b/tests/unit/surrealdb/test_context_onboarding_doctor.py
@@ -84,6 +84,10 @@ def test_config_exists_missing(tmp_path: Path) -> None:
         environ={},
     )
     assert report.config_context_query_local == "missing"
+    assert report.check_scope == "partial_context_onboarding"
+    assert report.skipped_checks == ["mcp_server", "surrealdb_schema"]
+    assert report.blocking is True
+    assert "context_query_local missing" in report.blocking_findings
 
 
 def test_config_exists_when_present(tmp_path: Path) -> None:
@@ -100,6 +104,8 @@ def test_config_exists_when_present(tmp_path: Path) -> None:
         environ={},
     )
     assert report.config_context_query_local == "exists"
+    assert report.check_scope == "partial_context_onboarding"
+    assert report.skipped_checks == ["mcp_server", "surrealdb_schema"]
 
 
 def test_mcp_reachable_and_not_reachable() -> None:
@@ -314,8 +320,27 @@ def test_json_output_contains_no_secret_values(tmp_path: Path) -> None:
     assert "SURREAL_PASS" not in payload
     assert "SURREAL_USER=root" not in payload
     parsed = json.loads(payload)
+    assert parsed["check_scope"] == "partial_context_onboarding"
+    assert parsed["skipped_checks"] == ["mcp_server", "surrealdb_schema"]
     assert parsed["lr_note"] == "NO-GO"
     assert parsed["secrets"]["canon_store"] == "exists"
+
+
+def test_text_output_includes_scope_skip_and_blocking(tmp_path: Path) -> None:
+    report = doctor.build_report(
+        tmp_path,
+        skip_mcp=True,
+        skip_schema=True,
+        tcp_checker=lambda _h, _p, _t: False,
+        environ={},
+    )
+
+    text = doctor.format_report(report, "text")
+    assert "check_scope: partial_context_onboarding" in text
+    assert "skipped_checks: mcp_server, surrealdb_schema" in text
+    assert "blocking: yes" in text
+    assert "warning semantics:" in text
+    assert "blocking_findings:" in text
 
 
 def test_text_output_contains_no_secret_values(tmp_path: Path) -> None:

--- a/tests/unit/test_onboarding_doctor.py
+++ b/tests/unit/test_onboarding_doctor.py
@@ -144,6 +144,8 @@ def test_build_report_repo_root(tmp_path: Path) -> None:
         context_doctor_runner=mock_runner,
     )
     assert report.repo_root_found == "PASS"
+    assert report.check_scope == "full_local_onboarding"
+    assert report.skipped_checks == []
 
 
 def test_build_report_python_not_found(tmp_path: Path) -> None:
@@ -187,6 +189,10 @@ def test_json_output_no_secret_leak(tmp_path: Path) -> None:
         context_doctor_runner=mock_runner,
     )
     payload = doctor.format_report(report, "json")
+    parsed = json.loads(payload)
+    assert parsed["check_scope"] == "full_local_onboarding"
+    assert parsed["skipped_checks"] == []
+    assert "blocking" in parsed
     for pattern in doctor.FORBIDDEN_OUTPUT_PATTERNS:
         assert not pattern.search(
             payload
@@ -209,6 +215,8 @@ def test_text_output_no_secret_leak(tmp_path: Path) -> None:
         context_doctor_runner=mock_runner,
     )
     text = doctor.format_report(report, "text")
+    assert "check_scope: full_local_onboarding" in text
+    assert "skipped_checks: none" in text
     assert "super-secret" not in text.lower()
 
 

--- a/tests/unit/tools/test_onboarding_orchestrator_helpers.py
+++ b/tests/unit/tools/test_onboarding_orchestrator_helpers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from pathlib import Path
+from subprocess import CompletedProcess
 
 import pytest
 
@@ -15,7 +17,7 @@ def _iter_input(values: list[str]) -> Iterator[str]:
 
 def test_get_setup_prompt_text_is_exact() -> None:
     assert onboarding_orchestrator.get_setup_prompt_text() == (
-        "Möchtest du das Onboarding-Setup jetzt ausführen?\n\n" "1. Ja\n" "2. Abbruch"
+        "Moechtest du das Onboarding-Setup jetzt ausfuehren?\n\n" "1. Ja\n" "2. Abbruch"
     )
 
 
@@ -69,3 +71,86 @@ def test_prompt_for_setup_confirmation_accepts_abort_synonym() -> None:
 
     assert result == onboarding_orchestrator.SETUP_ABORTED
     assert prompts == [onboarding_orchestrator.get_setup_prompt_text()]
+
+
+def _prepare_root(tmp_path: Path) -> Path:
+    for rel_path in onboarding_orchestrator.CANONICAL_BOOTLOADER_FILES:
+        path = tmp_path / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("ok", encoding="utf-8")
+
+    scenario_path = tmp_path / onboarding_orchestrator.SCENARIO_FILE
+    scenario_path.parent.mkdir(parents=True, exist_ok=True)
+    scenario_path.write_text(
+        "\n".join(onboarding_orchestrator.REQUIRED_SCENARIO_TERMS),
+        encoding="utf-8",
+    )
+
+    lr_path = tmp_path / "docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md"
+    lr_path.parent.mkdir(parents=True, exist_ok=True)
+    lr_path.write_text("NO-GO", encoding="utf-8")
+
+    (tmp_path / ".env.example").write_text("EXAMPLE=1\n", encoding="utf-8")
+    return tmp_path
+
+
+def _runner_ok(*_args, **_kwargs) -> CompletedProcess:
+    return CompletedProcess(
+        [],
+        0,
+        '{"warnings": [], "check_scope": "partial_context_onboarding", "skipped_checks": ["mcp_server", "surrealdb_schema"]}',
+        "",
+    )
+
+
+def test_build_verdict_default_mode_enters_confirmation_pending(tmp_path: Path) -> None:
+    root = _prepare_root(tmp_path)
+    report = onboarding_orchestrator.build_verdict(
+        root,
+        mode="default",
+        doctor_runner=_runner_ok,
+        context_doctor_runner=_runner_ok,
+    )
+
+    assert report.status == "SETUP_WARN"
+    assert report.state == onboarding_orchestrator.SETUP_CONFIRMATION_PENDING
+    assert report.requires_explicit_setup_go is True
+    assert report.setup_prompt_visible is True
+    assert report.allowed_next_actions == [
+        onboarding_orchestrator.ACTION_APPROVE_SETUP,
+        onboarding_orchestrator.ACTION_ABORT,
+    ]
+
+
+def test_build_verdict_check_only_mode_hides_prompt(tmp_path: Path) -> None:
+    root = _prepare_root(tmp_path)
+    report = onboarding_orchestrator.build_verdict(
+        root,
+        mode="check-only",
+        doctor_runner=_runner_ok,
+        context_doctor_runner=_runner_ok,
+    )
+
+    assert report.status == "SETUP_WARN"
+    assert report.state == onboarding_orchestrator.SETUP_REQUIRED
+    assert report.requires_explicit_setup_go is True
+    assert report.setup_prompt_visible is False
+    assert report.allowed_next_actions == [
+        onboarding_orchestrator.ACTION_REQUEST_SETUP_GO,
+        onboarding_orchestrator.ACTION_ABORT,
+    ]
+
+
+def test_format_output_check_only_does_not_show_setup_prompt(tmp_path: Path) -> None:
+    root = _prepare_root(tmp_path)
+    report = onboarding_orchestrator.build_verdict(
+        root,
+        mode="check-only",
+        doctor_runner=_runner_ok,
+        context_doctor_runner=_runner_ok,
+    )
+
+    output = onboarding_orchestrator.format_output(report, "text")
+    assert "Moechtest du das Onboarding-Setup jetzt ausfuehren?" not in output
+    assert "check-only mode is dry-run only." in output
+    assert "Would only run setup after explicit setup GO." in output

--- a/tests/unit/tools/test_onboarding_simulation.py
+++ b/tests/unit/tools/test_onboarding_simulation.py
@@ -68,10 +68,16 @@ class TestNormalizeMode:
 
 class TestBuildFinalVerdict:
     def test_agent_first_issue_ready(self) -> None:
-        assert _build_final_verdict("agent", "first-issue-dry-run") == "READY_FOR_REAL_FIRST_ISSUE"
+        assert (
+            _build_final_verdict("agent", "first-issue-dry-run")
+            == "READY_FOR_REAL_FIRST_ISSUE"
+        )
 
     def test_developer_first_issue_ready(self) -> None:
-        assert _build_final_verdict("developer", "first-issue-dry-run") == "READY_FOR_REAL_FIRST_ISSUE"
+        assert (
+            _build_final_verdict("developer", "first-issue-dry-run")
+            == "READY_FOR_REAL_FIRST_ISSUE"
+        )
 
     def test_check_only_hold(self) -> None:
         assert _build_final_verdict("agent", "check-only") == "HOLD_ONBOARDING_GAP"
@@ -391,7 +397,9 @@ class TestSimulationOutputContract:
 
     def test_verdict_is_valid_enum(self) -> None:
         output = render_simulation()
-        verdict_line = [line for line in output.split("\n") if "Final Verdict:" in line][0]
+        verdict_line = [
+            line for line in output.split("\n") if "Final Verdict:" in line
+        ][0]
         verdict = verdict_line.split(": ", 1)[1].strip()
         assert verdict in VERDICT_ENUM, f"Verdict '{verdict}' not in VERDICT_ENUM"
 
@@ -405,4 +413,6 @@ class TestForbiddenPatternsInOutput:
     def test_no_token_patterns_in_rendered_output(self) -> None:
         output = render_simulation()
         for pattern in FORBIDDEN_OUTPUT_PATTERNS:
-            assert not pattern.search(output), f"Output matches forbidden pattern: {pattern.pattern}"
+            assert not pattern.search(
+                output
+            ), f"Output matches forbidden pattern: {pattern.pattern}"

--- a/tests/unit/tools/test_onboarding_simulation.py
+++ b/tests/unit/tools/test_onboarding_simulation.py
@@ -81,9 +81,9 @@ class TestBuildFinalVerdict:
 
 
 class TestRenderSimulationDefaults:
-    def test_contains_onboarding_start(self) -> None:
+    def test_contains_simulation_start(self) -> None:
         output = render_simulation()
-        assert "ONBOARDING_START" in output
+        assert "SIMULATION_START" in output
 
     def test_contains_mode(self) -> None:
         output = render_simulation()
@@ -375,7 +375,7 @@ class TestSimulationOutputContract:
     def test_contains_all_required_sections(self) -> None:
         output = render_simulation()
         required_prefixes = [
-            "ONBOARDING_START",
+            "SIMULATION_START",
             "Context Brain Note:",
             "Bootloader Plan:",
             "Live Truth Plan:",

--- a/tools/onboarding_doctor.py
+++ b/tools/onboarding_doctor.py
@@ -26,6 +26,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 from dataclasses import dataclass, field
@@ -68,7 +69,7 @@ FORBIDDEN_OUTPUT_PATTERNS: list[re.Pattern] = [
 
 
 def _run_cmd(
-    cmd: str,
+    cmd: str | list[str],
     timeout: float = 15.0,
     runner: Callable[..., subprocess.CompletedProcess] | None = None,
 ) -> tuple[int, str, str]:
@@ -78,15 +79,22 @@ def _run_cmd(
         "timeout": timeout,
         "errors": "replace",
     }
-    if os.name == "nt":
-        kwargs["shell"] = True
+    if isinstance(cmd, str):
+        run_cmd: str | list[str]
+        if os.name == "nt":
+            run_cmd = cmd
+            kwargs["shell"] = True
+        else:
+            run_cmd = shlex.split(cmd)
+            kwargs["shell"] = False
     else:
+        run_cmd = list(cmd)
         kwargs["shell"] = False
     try:
         if runner is not None:
-            proc = runner(cmd, **kwargs)
+            proc = runner(run_cmd, **kwargs)
         else:
-            proc = subprocess.run(cmd, **kwargs)  # noqa: S603
+            proc = subprocess.run(run_cmd, **kwargs)  # noqa: S603
         out = (proc.stdout or "").strip()
         err = (proc.stderr or "").strip()
         return proc.returncode, out, err
@@ -103,6 +111,10 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+def _module_cmd(module: str, *args: str) -> list[str]:
+    return [sys.executable, "-m", module, *args]
+
+
 @dataclass
 class CheckItem:
     name: str
@@ -113,6 +125,8 @@ class CheckItem:
 
 @dataclass
 class DoctorOutput:
+    check_scope: str = "full_local_onboarding"
+    skipped_checks: list[str] = field(default_factory=list)
     repo_root_found: CheckResult = "FAIL"
     git_found: CheckResult = "FAIL"
     git_branch: str = ""
@@ -131,11 +145,17 @@ class DoctorOutput:
     onboarding_files: CheckResult = "FAIL"
     context_doctor_reachable: CheckResult = "SKIP"
     lr_note: str = "NO-GO"
+    blocking: bool = True
+    warning_semantics: str = (
+        "WARN means a non-blocking gap or follow-up is present, but the onboarding surface remains usable."
+    )
     warnings: list[str] = field(default_factory=list)
     checks: list[CheckItem] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "check_scope": self.check_scope,
+            "skipped_checks": self.skipped_checks,
             "repo_root": self.repo_root_found,
             "repo_head": self.repo_head,
             "git": {
@@ -163,6 +183,8 @@ class DoctorOutput:
             "onboarding_files": self.onboarding_files,
             "context_doctor_reachable": self.context_doctor_reachable,
             "lr_note": self.lr_note,
+            "blocking": self.blocking,
+            "warning_semantics": self.warning_semantics,
             "warnings": self.warnings,
             "checks": [
                 {
@@ -232,7 +254,13 @@ def _onboarding_files_exist(root: Path) -> tuple[CheckResult, list[str]]:
 def _check_context_doctor_reachable(
     runner: Callable[..., subprocess.CompletedProcess] | None = None,
 ) -> CheckResult:
-    cmd = "python -m tools.surrealdb.context_onboarding_doctor --skip-mcp --skip-schema"
+    cmd = _module_cmd(
+        "tools.surrealdb.context_onboarding_doctor",
+        "--skip-mcp",
+        "--skip-schema",
+        "--format",
+        "json",
+    )
     rc, _, _ = _run_cmd(cmd, timeout=10.0, runner=runner)
     return "PASS" if rc == 0 else "WARN"
 
@@ -301,7 +329,7 @@ def build_report(
         report.repo_head = ""
 
     # Python
-    python_cmd = "python --version"
+    python_cmd = [sys.executable, "--version"]
     rc, pout, perr = _run_cmd(python_cmd, runner=python_runner)
     py_output = pout or perr or ""
     if rc == 0 or (rc != -1 and py_output):
@@ -391,6 +419,7 @@ def build_report(
         CheckItem(name="Onboarding files", status=report.onboarding_files),
         CheckItem(name="make context-doctor", status=report.context_doctor_reachable),
     ]
+    report.blocking = compute_exit_code(report) == 1
 
     return report
 
@@ -406,6 +435,9 @@ def format_report(report: DoctorOutput, fmt: str) -> str:
 
     lines: list[str] = [
         "=== CDB Onboarding Doctor ===",
+        f"check_scope: {report.check_scope}",
+        f"skipped_checks: {', '.join(report.skipped_checks) if report.skipped_checks else 'none'}",
+        f"blocking: {'yes' if report.blocking else 'no'}",
         f"lr_note: {report.lr_note}",
         "",
     ]
@@ -431,6 +463,7 @@ def format_report(report: DoctorOutput, fmt: str) -> str:
         lines.append("warnings:")
         for w in report.warnings:
             lines.append(f"  - {_safe_summary(w, 120)}")
+        lines.append(f"  - warning semantics: {report.warning_semantics}")
 
     if report.context_doctor_reachable == "PASS":
         lines.append("")

--- a/tools/onboarding_orchestrator.py
+++ b/tools/onboarding_orchestrator.py
@@ -1,4 +1,4 @@
-"""CDB onboarding orchestrator — single smart read-only entrypoint.
+"""CDB onboarding orchestrator - single smart read-only entrypoint.
 
 Usage:
     python -m tools.onboarding_orchestrator
@@ -13,7 +13,7 @@ Exit codes:
 
 This tool is read-only by default:
     - No file writes, no report, no setup mutation, no Docker, no secrets.
-    - Status card ends with a strict two-option setup confirmation prompt.
+    - The two-option setup confirmation prompt appears only in setup-confirmation state.
 
 Read Order:
     agents/AGENTS.md § Read Order -> Context Brain Preflight -> Live Truth ->
@@ -23,11 +23,11 @@ Output contract:
     CDB Onboarding
     Status: PASS | SETUP_WARN | BLOCKED
     ...
-    Keine Änderungen vorgenommen.
+    No changes made.
     LR remains NO-GO.
-    trade-capable ist kein Live-Go.
+    trade-capable is not Live-Go.
 
-    Möchtest du das Onboarding-Setup jetzt ausführen?
+    Moechtest du das Onboarding-Setup jetzt ausfuehren?
 
     1. Ja
     2. Abbruch
@@ -39,6 +39,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 from dataclasses import dataclass, field
@@ -73,7 +74,7 @@ FORBIDDEN_OUTPUT_PATTERNS: list[re.Pattern] = [
 ]
 
 SETUP_PROMPT_LINES: list[str] = [
-    "Möchtest du das Onboarding-Setup jetzt ausführen?",
+    "Moechtest du das Onboarding-Setup jetzt ausfuehren?",
     "",
     "1. Ja",
     "2. Abbruch",
@@ -82,12 +83,23 @@ SETUP_PROMPT_LINES: list[str] = [
 SETUP_APPROVED = "setup-approved"
 SETUP_ABORTED = "setup-aborted"
 
+STATUS_ONLY = "STATUS_ONLY"
+SETUP_REQUIRED = "SETUP_REQUIRED"
+SETUP_CONFIRMATION_PENDING = "SETUP_CONFIRMATION_PENDING"
+DRY_RUN_COMPLETE = "DRY_RUN_COMPLETE"
+BLOCKED_STATE = "BLOCKED"
+
+ACTION_STATUS_ONLY = "status_only"
+ACTION_APPROVE_SETUP = "approve_setup"
+ACTION_REQUEST_SETUP_GO = "request_setup_go"
+ACTION_ABORT = "abort"
+
 SETUP_APPROVAL_INPUTS = {"1", "ja", "yes"}
 SETUP_ABORT_INPUTS = {"2", "nein", "no", "abbruch", "cancel"}
 
 
 def _run_cmd(
-    cmd: str,
+    cmd: str | list[str],
     timeout: float = 15.0,
     runner: Callable[..., subprocess.CompletedProcess] | None = None,
 ) -> tuple[int, str, str]:
@@ -97,15 +109,22 @@ def _run_cmd(
         "timeout": timeout,
         "errors": "replace",
     }
-    if os.name == "nt":
-        kwargs["shell"] = True
+    if isinstance(cmd, str):
+        run_cmd: str | list[str]
+        if os.name == "nt":
+            run_cmd = cmd
+            kwargs["shell"] = True
+        else:
+            run_cmd = shlex.split(cmd)
+            kwargs["shell"] = False
     else:
+        run_cmd = list(cmd)
         kwargs["shell"] = False
     try:
         if runner is not None:
-            proc = runner(cmd, **kwargs)
+            proc = runner(run_cmd, **kwargs)
         else:
-            proc = subprocess.run(cmd, **kwargs)
+            proc = subprocess.run(run_cmd, **kwargs)
         out = (proc.stdout or "").strip()
         err = (proc.stderr or "").strip()
         return proc.returncode, out, err
@@ -120,26 +139,46 @@ def _run_cmd(
 
 @dataclass
 class OrchestratorOutput:
+    mode: str = "default"
     status: str = "BLOCKED"
+    state: str = BLOCKED_STATE
+    check_scope: str = "onboarding_status_default"
+    skipped_checks: list[str] = field(default_factory=list)
     bootloader_ok: str = "FAIL"
     scenario_ok: str = "FAIL"
     lr_ok: str = "FAIL"
     doctor_reachable: str = "SKIP"
     env_file: str = "FAIL"
     context_doctor: str = "SKIP"
+    blocking: bool = True
+    requires_explicit_setup_go: bool = False
+    setup_prompt_visible: bool = False
+    allowed_next_actions: list[str] = field(default_factory=list)
+    warning_semantics: str = (
+        "WARN means onboarding remains read-only usable, but setup or follow-up is still required."
+    )
     warnings: list[str] = field(default_factory=list)
     blockers: list[str] = field(default_factory=list)
     details: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "mode": self.mode,
             "status": self.status,
+            "state": self.state,
+            "check_scope": self.check_scope,
+            "skipped_checks": self.skipped_checks,
             "bootloader": self.bootloader_ok,
             "scenario": self.scenario_ok,
             "lr_note": self.lr_ok,
             "doctor_reachable": self.doctor_reachable,
             "env_file": self.env_file,
             "context_doctor": self.context_doctor,
+            "blocking": self.blocking,
+            "requires_explicit_setup_go": self.requires_explicit_setup_go,
+            "setup_prompt_visible": self.setup_prompt_visible,
+            "allowed_next_actions": self.allowed_next_actions,
+            "warning_semantics": self.warning_semantics,
             "warnings": self.warnings,
             "blockers": self.blockers,
             "details": self.details,
@@ -173,6 +212,10 @@ def prompt_for_setup_confirmation(
         decision = normalize_setup_prompt_input(raw_value)
         if decision is not None:
             return decision
+
+
+def _module_cmd(module: str, *args: str) -> list[str]:
+    return [sys.executable, "-m", module, *args]
 
 
 def _check_bootloader_files(root: Path) -> tuple[str, list[str]]:
@@ -215,31 +258,61 @@ def _check_lr_doc(root: Path) -> tuple[str, str]:
 def _check_env_file(root: Path) -> tuple[str, str]:
     env_path = root / ".env"
     if env_path.is_file():
-        return "WARN", ".env exists (setup may be partially complete)"
+        return "PASS", ".env found"
     example = root / ".env.example"
     if example.is_file():
-        return "SETUP_WARN", ".env fehlt (setup warn, kein blocker)"
-    return "SETUP_WARN", ".env fehlt und kein .env.example"
+        return "WARN", ".env missing (setup required, non-blocking)"
+    return "WARN", ".env missing and no .env.example found"
 
 
 def _check_doctor_reachable(
     runner: Callable[..., subprocess.CompletedProcess] | None = None,
 ) -> tuple[str, str]:
-    cmd = "python -m tools.onboarding_doctor --format json"
+    cmd = _module_cmd("tools.onboarding_doctor", "--format", "json")
     rc, out, _ = _run_cmd(cmd, timeout=15.0, runner=runner)
     if rc == 0:
+        try:
+            payload = json.loads(out) if out else {}
+        except json.JSONDecodeError:
+            payload = {}
+        warnings = payload.get("warnings") if isinstance(payload, dict) else None
+        if isinstance(warnings, list) and warnings:
+            return "WARN", f"onboarding_doctor warning: {warnings[0]}"
         return "PASS", "onboarding_doctor reachable"
-    return "SETUP_WARN", "Context Doctor nicht initialisiert (setup warn, kein blocker)"
+    return "WARN", "onboarding_doctor requires setup follow-up"
 
 
 def _check_context_doctor(
     runner: Callable[..., subprocess.CompletedProcess] | None = None,
 ) -> tuple[str, str]:
-    cmd = "python -m tools.surrealdb.context_onboarding_doctor --skip-mcp --skip-schema 2>&1"
-    rc, _, _ = _run_cmd(cmd, timeout=15.0, runner=runner)
+    cmd = _module_cmd(
+        "tools.surrealdb.context_onboarding_doctor",
+        "--skip-mcp",
+        "--skip-schema",
+        "--format",
+        "json",
+    )
+    rc, out, _ = _run_cmd(cmd, timeout=15.0, runner=runner)
     if rc == 0:
+        try:
+            payload = json.loads(out) if out else {}
+        except json.JSONDecodeError:
+            payload = {}
+        warnings = payload.get("warnings") if isinstance(payload, dict) else None
+        scope = payload.get("check_scope") if isinstance(payload, dict) else None
+        skipped = payload.get("skipped_checks") if isinstance(payload, dict) else None
+        if isinstance(warnings, list) and warnings:
+            return "WARN", f"context_doctor warning: {warnings[0]}"
+        if scope or skipped:
+            skipped_text = (
+                ", ".join(skipped) if isinstance(skipped, list) and skipped else "none"
+            )
+            return (
+                "PASS",
+                f"context_doctor {scope or 'partial check'} (skipped: {skipped_text})",
+            )
         return "PASS", "context_doctor reachable"
-    return "SETUP_WARN", "Context Doctor nicht initialisiert (setup warn, kein blocker)"
+    return "WARN", "context_doctor requires setup follow-up"
 
 
 def _validate_output_safe(text: str) -> None:
@@ -253,11 +326,17 @@ def _validate_output_safe(text: str) -> None:
 def build_verdict(
     root: Path | None = None,
     *,
+    mode: str = "default",
     doctor_runner: Callable[..., subprocess.CompletedProcess] | None = None,
     context_doctor_runner: Callable[..., subprocess.CompletedProcess] | None = None,
 ) -> OrchestratorOutput:
     r = root or REPO_ROOT
-    output = OrchestratorOutput()
+    output = OrchestratorOutput(mode=mode)
+    output.check_scope = (
+        "onboarding_status_check_only"
+        if mode == "check-only"
+        else "onboarding_status_default"
+    )
 
     # 1. Bootloader files
     bl_status, bl_missing = _check_bootloader_files(r)
@@ -281,28 +360,47 @@ def build_verdict(
     # 4. Env file (setup warn only)
     env_status, env_detail = _check_env_file(r)
     output.env_file = env_status
-    if env_status == "SETUP_WARN":
+    output.details["env_file"] = env_detail
+    if env_status == "WARN":
         output.warnings.append(env_detail)
 
     # 5. Doctor reachability
     doc_status, doc_detail = _check_doctor_reachable(runner=doctor_runner)
     output.doctor_reachable = doc_status
-    if doc_status == "SETUP_WARN":
+    output.details["doctor"] = doc_detail
+    if doc_status == "WARN":
         output.warnings.append(doc_detail)
 
     # 6. Context doctor
     ctx_status, ctx_detail = _check_context_doctor(runner=context_doctor_runner)
     output.context_doctor = ctx_status
-    if ctx_status == "SETUP_WARN":
+    output.details["context_doctor"] = ctx_detail
+    if ctx_status == "WARN":
         output.warnings.append(ctx_detail)
 
     # Final status
     if output.blockers:
         output.status = "BLOCKED"
+        output.state = BLOCKED_STATE
+        output.blocking = True
+        output.allowed_next_actions = [ACTION_ABORT]
     elif output.warnings:
         output.status = "SETUP_WARN"
+        output.blocking = False
+        if mode == "check-only":
+            output.state = SETUP_REQUIRED
+            output.allowed_next_actions = [ACTION_REQUEST_SETUP_GO, ACTION_ABORT]
+            output.setup_prompt_visible = False
+        else:
+            output.state = SETUP_CONFIRMATION_PENDING
+            output.allowed_next_actions = [ACTION_APPROVE_SETUP, ACTION_ABORT]
+            output.setup_prompt_visible = True
+        output.requires_explicit_setup_go = True
     else:
         output.status = "PASS"
+        output.blocking = False
+        output.state = DRY_RUN_COMPLETE if mode == "check-only" else STATUS_ONLY
+        output.allowed_next_actions = [ACTION_STATUS_ONLY, ACTION_ABORT]
 
     return output
 
@@ -320,16 +418,25 @@ def format_output(report: OrchestratorOutput, fmt: str) -> str:
     lines: list[str] = [
         "=== CDB Onboarding ===",
         f"Status: {report.status}",
+        f"State: {report.state}",
+        f"check_scope: {report.check_scope}",
+        f"requires_explicit_setup_go: {'yes' if report.requires_explicit_setup_go else 'no'}",
+        f"allowed_next_actions: {', '.join(report.allowed_next_actions) if report.allowed_next_actions else 'none'}",
+        f"skipped_checks: {', '.join(report.skipped_checks) if report.skipped_checks else 'none'}",
         "",
     ]
 
-    lines.append("Prüfungen:")
+    lines.append("Checks:")
     lines.append(f"  Bootloader: [{report.bootloader_ok}]")
-    lines.append(f"  Szenario-Dokument: [{report.scenario_ok}]")
-    lines.append(f"  LR-Status: [{report.lr_ok}] — {report.details.get('lr', '')}")
-    lines.append(f"  .env: [{report.env_file}]")
-    lines.append(f"  onboarding_doctor: [{report.doctor_reachable}]")
-    lines.append(f"  context_doctor: [{report.context_doctor}]")
+    lines.append(f"  Scenario document: [{report.scenario_ok}]")
+    lines.append(f"  LR-Status: [{report.lr_ok}] - {report.details.get('lr', '')}")
+    lines.append(f"  .env: [{report.env_file}] - {report.details.get('env_file', '')}")
+    lines.append(
+        f"  onboarding_doctor: [{report.doctor_reachable}] - {report.details.get('doctor', '')}"
+    )
+    lines.append(
+        f"  context_doctor: [{report.context_doctor}] - {report.details.get('context_doctor', '')}"
+    )
     lines.append("")
 
     if report.blockers:
@@ -339,17 +446,25 @@ def format_output(report: OrchestratorOutput, fmt: str) -> str:
         lines.append("")
 
     if report.warnings:
-        lines.append("WARNINGS:")
+        lines.append("Warnings:")
         for w in report.warnings:
             lines.append(f"  * {_safe_summary(w, 120)}")
         lines.append("")
+        lines.append(f"Warning semantics: {report.warning_semantics}")
+        lines.append("")
 
-    lines.append("Keine Änderungen vorgenommen.")
+    if report.mode == "check-only":
+        lines.append("check-only mode is dry-run only.")
+        lines.append("No setup mutation is allowed from this run.")
+    if report.requires_explicit_setup_go:
+        lines.append("Would only run setup after explicit setup GO.")
+    lines.append("No changes made.")
     lines.append("LR remains NO-GO.")
-    lines.append("trade-capable ist kein Live-Go.")
+    lines.append("trade-capable is not Live-Go.")
     lines.append("")
 
-    lines.extend(SETUP_PROMPT_LINES)
+    if report.setup_prompt_visible:
+        lines.extend(SETUP_PROMPT_LINES)
 
     return "\n".join(lines)
 
@@ -384,7 +499,7 @@ Exit codes:
     )
     args = parser.parse_args(argv)
 
-    report = build_verdict()
+    report = build_verdict(mode=args.mode)
 
     try:
         output = format_output(report, args.format)

--- a/tools/onboarding_simulation.py
+++ b/tools/onboarding_simulation.py
@@ -229,7 +229,9 @@ def _build_context_brain_note() -> list[str]:
 def _validate_output_safe(text: str) -> None:
     for pattern in FORBIDDEN_OUTPUT_PATTERNS:
         if pattern.search(text):
-            raise ValueError("output contains forbidden pattern - potential secret leak")
+            raise ValueError(
+                "output contains forbidden pattern - potential secret leak"
+            )
 
 
 def render_simulation(role: str = "agent", mode: str = "first-issue-dry-run") -> str:
@@ -273,7 +275,9 @@ def render_simulation(role: str = "agent", mode: str = "first-issue-dry-run") ->
     return "\n".join(lines)
 
 
-def render_simulation_json(role: str = "agent", mode: str = "first-issue-dry-run") -> str:
+def render_simulation_json(
+    role: str = "agent", mode: str = "first-issue-dry-run"
+) -> str:
     resolved_role = _normalize_role(role)
     resolved_mode = _normalize_mode(mode)
     verdict = _build_final_verdict(resolved_role, resolved_mode)

--- a/tools/onboarding_simulation.py
+++ b/tools/onboarding_simulation.py
@@ -12,7 +12,7 @@ Usage:
     .\\tools\\cdb.ps1 onboarding simulate
 
 Output contract:
-    ONBOARDING_START -> Bootloader Plan -> Live Truth Plan -> Tour Path ->
+    SIMULATION_START -> Bootloader Plan -> Live Truth Plan -> Tour Path ->
     Doctor / Validator Plan -> First-Issue Dry Run -> PR / LOCK Simulation ->
     HOLD Conditions -> Final Verdict
 
@@ -250,7 +250,7 @@ def render_simulation(role: str = "agent", mode: str = "first-issue-dry-run") ->
     }
 
     lines: list[str] = [
-        "ONBOARDING_START",
+        "SIMULATION_START",
         f"mode: {resolved_mode}",
         f"role: {role_label}",
         "writes: disabled",

--- a/tools/surrealdb/context_onboarding_doctor.py
+++ b/tools/surrealdb/context_onboarding_doctor.py
@@ -267,6 +267,8 @@ def check_schema_readonly(
 
 @dataclass
 class DoctorReport:
+    check_scope: str = "full_context_onboarding"
+    skipped_checks: list[str] = field(default_factory=list)
     mcp_server_status: ReachableStatus = "skipped"
     surrealdb_status: ReachableStatus = "skipped"
     surrealdb_health: CheckStatus = "skipped"
@@ -280,10 +282,17 @@ class DoctorReport:
     config_context_query_local: ConfigStatus = "missing"
     next_action: str = "no action required"
     lr_note: str = "NO-GO"
+    blocking: bool = True
+    warning_semantics: str = (
+        "Warnings indicate partial validation or non-blocking follow-up; blocking findings explain why setup is not yet usable."
+    )
+    blocking_findings: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "check_scope": self.check_scope,
+            "skipped_checks": list(self.skipped_checks),
             "mcp_server": {"status": self.mcp_server_status},
             "surrealdb": {
                 "status": self.surrealdb_status,
@@ -305,8 +314,30 @@ class DoctorReport:
             },
             "next_action": self.next_action,
             "lr_note": self.lr_note,
+            "blocking": self.blocking,
+            "warning_semantics": self.warning_semantics,
+            "blocking_findings": list(self.blocking_findings),
             "warnings": list(self.warnings),
         }
+
+
+def collect_blocking_findings(report: DoctorReport) -> list[str]:
+    findings: list[str] = []
+    if report.secrets_canon_store == "missing":
+        findings.append("canonical secrets directory missing")
+    if report.secrets_surrealdb_env == "missing":
+        findings.append("SURREALDB_ENV missing")
+    if report.config_context_query_local == "missing":
+        findings.append("context_query_local missing")
+    if report.surrealdb_status == "not_reachable":
+        findings.append("local SurrealDB not reachable")
+    if report.surrealdb_health == "fail":
+        findings.append("SurrealDB health endpoint failed")
+    if report.surrealdb_version == "fail":
+        findings.append("SurrealDB version endpoint failed")
+    if report.surrealdb_schema == "fail":
+        findings.append("SurrealDB schema check failed")
+    return findings
 
 
 def prioritize_next_action(report: DoctorReport) -> str:
@@ -345,16 +376,7 @@ def prioritize_next_action(report: DoctorReport) -> str:
 
 
 def compute_exit_code(report: DoctorReport) -> int:
-    blocking = (
-        report.secrets_canon_store == "missing"
-        or report.secrets_surrealdb_env == "missing"
-        or report.config_context_query_local == "missing"
-        or report.surrealdb_status == "not_reachable"
-        or report.surrealdb_health == "fail"
-        or report.surrealdb_version == "fail"
-        or report.surrealdb_schema == "fail"
-    )
-    return 1 if blocking else 0
+    return 1 if collect_blocking_findings(report) else 0
 
 
 def build_report(
@@ -369,6 +391,18 @@ def build_report(
 ) -> DoctorReport:
     root = _repo_root() if repo_root is None else repo_root
     report = DoctorReport()
+    if skip_mcp or skip_schema:
+        report.check_scope = "partial_context_onboarding"
+    if skip_mcp:
+        report.skipped_checks.append("mcp_server")
+        report.warnings.append(
+            "Partial validation: MCP reachability skipped via --skip-mcp"
+        )
+    if skip_schema:
+        report.skipped_checks.append("surrealdb_schema")
+        report.warnings.append(
+            "Partial validation: schema check skipped via --skip-schema"
+        )
 
     report.secrets_path_env = evaluate_env_var("SECRETS_PATH", environ)
     report.cdb_context_secrets_path_env = evaluate_env_var(
@@ -442,6 +476,8 @@ def build_report(
             report.surrealdb_schema = "skipped"
 
     report.next_action = prioritize_next_action(report)
+    report.blocking_findings = collect_blocking_findings(report)
+    report.blocking = bool(report.blocking_findings)
     return report
 
 
@@ -453,6 +489,9 @@ def format_report(report: DoctorReport, fmt: str) -> str:
 
     lines = [
         "=== Context Onboarding Doctor ===",
+        f"check_scope: {report.check_scope}",
+        f"skipped_checks: {', '.join(report.skipped_checks) if report.skipped_checks else 'none'}",
+        f"blocking: {'yes' if report.blocking else 'no'}",
         f"lr_note: {report.lr_note}",
         "",
         f"mcp_server.status: {report.mcp_server_status}",
@@ -475,6 +514,12 @@ def format_report(report: DoctorReport, fmt: str) -> str:
         lines.append("warnings:")
         for warning in report.warnings:
             lines.append(f"  - {warning}")
+        lines.append(f"  - warning semantics: {report.warning_semantics}")
+    if report.blocking_findings:
+        lines.append("")
+        lines.append("blocking_findings:")
+        for finding in report.blocking_findings:
+            lines.append(f"  - {finding}")
     return "\n".join(lines)
 
 


### PR DESCRIPTION
Refs #3326

Closes #3328
Closes #3329
Closes #3330
Closes #3331
Closes #3332

## Delivered
- #3328: make dry-run/check-only explicitly non-mutating and visible in the orchestrator contract
- #3329: add explicit onboarding state/action contract and gate the setup prompt to the confirmation state only
- #3330: harden Windows-facing onboarding CLI output and interpreter command paths
- #3331: align cross-agent onboarding surfaces to the same response guardrails
- #3332: extend onboarding doctor/context doctor JSON and text outputs with additive scope/skip/warning semantics

## Validation
- git diff --check
- pytest -v tests/unit/tools/test_onboarding_orchestrator_helpers.py
- pytest -v tests/unit/test_onboarding_doctor.py
- pytest -v tests/unit/surrealdb/test_context_onboarding_doctor.py
- pytest -v tests/smoke/test_onboarding_orchestrator.py
- pytest -v tests/smoke/test_onboarding_cross_agent_surfaces.py
- pytest -v tests/unit/tools/test_onboarding_simulation.py
- pytest -q tests -k onboarding
- python -m tools.onboarding_orchestrator
- python -m tools.onboarding_orchestrator --format json
- python -m tools.onboarding_orchestrator --mode check-only
- python -m tools.onboarding_doctor --format json
- python -m tools.surrealdb.context_onboarding_doctor --skip-mcp --skip-schema --format json
- python -m tools.validate_onboarding_docs
- rg -n "setup-plan|Setup-Plan|vorher.*Setup|ONBOARDING_START|Nächste Optionen:|numbered next options" tools tests docs agents README.md .codex .claude .gemini .opencode
- ruff check tools/onboarding_orchestrator.py tools/onboarding_doctor.py tools/surrealdb/context_onboarding_doctor.py tests/unit/tools/test_onboarding_orchestrator_helpers.py tests/unit/test_onboarding_doctor.py tests/unit/surrealdb/test_context_onboarding_doctor.py tests/smoke/test_onboarding_orchestrator.py tests/smoke/test_onboarding_cross_agent_surfaces.py
- black --check tools/onboarding_orchestrator.py tools/onboarding_doctor.py tools/surrealdb/context_onboarding_doctor.py tests/unit/tools/test_onboarding_orchestrator_helpers.py tests/unit/test_onboarding_doctor.py tests/unit/surrealdb/test_context_onboarding_doctor.py tests/smoke/test_onboarding_orchestrator.py tests/smoke/test_onboarding_cross_agent_surfaces.py

## Non-Goals
- no runtime, Docker, DB, MCP live, SurrealDB write, trading, secrets, or LR changes
- no hidden scope growth beyond onboarding hardening surfaces

## Safety
- LR remains NO-GO
- trade-capable is not Live-Go
- setup remains explicit-GO only