### PR TITLE
[ONBOARDING][AGENTS] Calibrate cross-agent onboarding evidence and live-truth wording

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -23,6 +23,8 @@ Bei `/onboarding`-Intent: `python -m tools.onboarding_orchestrator`
 
 Default: Read-only Status Card. Kein `.env`, keine Secrets, kein Docker, kein Issue/PR ohne explizite Auswahl.
 
+**Evidence-Abgrenzung nach /onboarding:** Antwort muss enthalten: Status, State, warnings, allowed_next_actions, check_scope, skipped_checks, Evidence-Abgrenzung (was geprüft, was nicht) und Safety-Grenzen. Ohne git/gh/check-Kommandos: "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft."
+
 ## Safety Boundaries
 
 - LR remains **NO-GO**

--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -60,7 +60,7 @@ Optional aliases exist, but `/onboarding` remains canonical:
 1. **Primary route:** `python -m tools.onboarding_orchestrator`
 2. **Bootloader:** `AGENTS.md` -> `agents/AGENTS.md` -> full Read Order.
 3. **Context Brain Preflight:** `context_brain_attempted=true` required before repo reads.
-4. **Live Truth:** GitHub live + repo live before ledger.
+4. **Live Checks (evidence-pflichtig):** `git fetch`, `gh issue view`, `gh pr list` — Ergebnisse dokumentieren. Ohne diese Kommandos: "GitHub-/Check-Live nicht geprüft."
 5. **Optional next steps only after the status card:** role-specific tour,
    doctor/validator, or first-issue sandbox.
 6. **Final Verdict:** CDB Onboarding status card with explicit state and allowed next actions.
@@ -68,10 +68,39 @@ Optional aliases exist, but `/onboarding` remains canonical:
 
 ## Agent Response Guardrails
 
+### Response Contract (required fields)
+
 - Report only `Status`, `State`, warnings, `allowed_next_actions`, `check_scope`, and `skipped_checks`.
+- Include **Evidence-Abgrenzung**: was wurde geprüft, was nicht (siehe Wording Contract).
+- Include **Safety-Grenzen**: LR NO-GO, kein Live-Go, kein Echtgeld-Go.
+
+### Wording Contract (Evidence-Abgrenzung)
+
+- **Ohne ausgeführte git/gh/check-Kommandos**:
+  "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft."
+- **Mit Live-Kommandos**:
+  "GitHub-/Repo-Live geprüft: <konkrete Kommandos und Ergebnis>."
+- **CURRENT_STATUS.md** → Engineering-Ledger, nicht Live-Wahrheit.
+- **LR-SSOT** → `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- **trade-capable** → Board-/Stage-Kontext, kein Live-Go.
+- **Invarianten** → "Zentrale Sicherheitsgrenzen erkannt."
+
+### Verbotene Phrasen
+
+- "Live-Wahrheit geprüft: Ja" (nur mit konkreten Kommandos erlaubt)
+- "trade-capable ist deaktiviert" / "trade-capable ist aktiviert"
+- "alle systemischen Invarianten erfasst" / "vollständige Live-Wahrheit geprüft"
+- "CURRENT_STATUS.md ist Live-Wahrheit"
+- "trade-capable erlaubt Live" / "trade-capable ist Live-Go"
+- Freie Management-Zusammenfassung ohne Evidence-Abgrenzung
+
+### Weitere Regeln
+
 - Do not invent or renumber options.
 - Do not offer setup execution after `--mode check-only`.
 - If a doctor output is partial, say that it is a partial check.
+- Board-Stage nie als Schalter oder Freigabe darstellen.
+- Vollständigkeitsclaims nach Teilreads vermeiden.
 
 ## Referenced V2 Surfaces
 

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -21,6 +21,8 @@ Bei `/onboarding`-Intent: `python -m tools.onboarding_orchestrator`
 
 Default: Read-only Status Card. Kein `.env`, keine Secrets, kein Docker, kein Issue/PR ohne explizite Auswahl.
 
+**Evidence-Abgrenzung nach /onboarding:** Antwort muss enthalten: Status, State, warnings, allowed_next_actions, check_scope, skipped_checks, Evidence-Abgrenzung (was geprüft, was nicht) und Safety-Grenzen. Ohne git/gh/check-Kommandos: "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft."
+
 ## Safety Boundaries
 
 - LR remains **NO-GO**

--- a/.codex/cdb_skills/onboarding/SKILL.md
+++ b/.codex/cdb_skills/onboarding/SKILL.md
@@ -27,12 +27,40 @@ python -m tools.onboarding_orchestrator --mode check-only
 
 ## Guardrails
 
+### Safety
+
 - Read-only by default.
 - LR remains NO-GO.
 - Board stage `trade-capable` is not Live-Go.
 - No Echtgeld-Go.
 - No file writes, no GitHub writes, no branch creation, no PR creation, no runtime/Docker/DB/MCP mutation, no secrets.
+
+### Response Contract (required fields)
+
 - Report only the orchestrator `Status`, `State`, warnings, and `allowed_next_actions`.
+- Include `check_scope`, `skipped_checks`, and **Evidence-Abgrenzung** (was geprüft, was nicht).
+- Include **Safety-Grenzen**: LR NO-GO, kein Live-Go, kein Echtgeld-Go.
+
+### Wording Contract (Evidence-Abgrenzung)
+
+- Ohne git/gh/check-Kommandos: "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft."
+- Mit Live-Kommandos: "GitHub-/Repo-Live geprüft: <konkrete Kommandos und Ergebnis>."
+- CURRENT_STATUS.md → Engineering-Ledger, nicht Live-Wahrheit.
+- LR-SSOT → docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md.
+- trade-capable → Board-/Stage-Kontext, kein Live-Go.
+
+### Verbotene Phrasen
+
+- "Live-Wahrheit geprüft: Ja" (nur mit konkreten Kommandos erlaubt)
+- "trade-capable ist deaktiviert/aktiviert"
+- "alle systemischen Invarianten erfasst"
+- "CURRENT_STATUS.md ist Live-Wahrheit"
+- "trade-capable erlaubt Live" / "ist Live-Go"
+- Freie Management-Zusammenfassung ohne Evidence-Abgrenzung
+
+### Weitere Regeln
+
 - Do not invent extra onboarding options or reintroduce the removed legacy setup branch.
 - `--mode check-only` is dry-run only and must not imply setup execution.
 - The `1. Ja / 2. Abbruch` prompt is only valid when the orchestrator reports `State: SETUP_CONFIRMATION_PENDING`.
+- Board-Stage nie als Schalter oder Freigabe darstellen.

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -25,6 +25,8 @@ Bei `/onboarding`-Intent: `python -m tools.onboarding_orchestrator`
 
 Default: Read-only Status Card. Kein `.env`, keine Secrets, kein Docker, kein Issue/PR ohne explizite Auswahl.
 
+**Evidence-Abgrenzung nach /onboarding:** Antwort muss enthalten: Status, State, warnings, allowed_next_actions, check_scope, skipped_checks, Evidence-Abgrenzung (was geprüft, was nicht) und Safety-Grenzen. Ohne git/gh/check-Kommandos: "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft."
+
 ## Safety Boundaries
 
 - LR remains **NO-GO**

--- a/.cursor/skills/onboarding/SKILL.md
+++ b/.cursor/skills/onboarding/SKILL.md
@@ -60,7 +60,7 @@ Optional aliases exist, but `/onboarding` remains canonical:
 1. **Primary route:** `python -m tools.onboarding_orchestrator`
 2. **Bootloader:** `AGENTS.md` -> `agents/AGENTS.md` -> full Read Order.
 3. **Context Brain Preflight:** `context_brain_attempted=true` required before repo reads.
-4. **Live Truth:** GitHub live + repo live before ledger.
+4. **Live Checks (evidence-pflichtig):** `git fetch`, `gh issue view`, `gh pr list` — Ergebnisse dokumentieren. Ohne diese Kommandos: "GitHub-/Check-Live nicht geprüft."
 5. **Optional next steps only after the status card:** role-specific tour,
    doctor/validator, or first-issue sandbox.
 6. **Final Verdict:** CDB Onboarding status card with explicit state and allowed next actions.
@@ -68,10 +68,39 @@ Optional aliases exist, but `/onboarding` remains canonical:
 
 ## Agent Response Guardrails
 
+### Response Contract (required fields)
+
 - Report only `Status`, `State`, warnings, `allowed_next_actions`, `check_scope`, and `skipped_checks`.
+- Include **Evidence-Abgrenzung**: was wurde geprüft, was nicht (siehe Wording Contract).
+- Include **Safety-Grenzen**: LR NO-GO, kein Live-Go, kein Echtgeld-Go.
+
+### Wording Contract (Evidence-Abgrenzung)
+
+- **Ohne ausgeführte git/gh/check-Kommandos**:
+  "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft."
+- **Mit Live-Kommandos**:
+  "GitHub-/Repo-Live geprüft: <konkrete Kommandos und Ergebnis>."
+- **CURRENT_STATUS.md** → Engineering-Ledger, nicht Live-Wahrheit.
+- **LR-SSOT** → `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- **trade-capable** → Board-/Stage-Kontext, kein Live-Go.
+- **Invarianten** → "Zentrale Sicherheitsgrenzen erkannt."
+
+### Verbotene Phrasen
+
+- "Live-Wahrheit geprüft: Ja" (nur mit konkreten Kommandos erlaubt)
+- "trade-capable ist deaktiviert" / "trade-capable ist aktiviert"
+- "alle systemischen Invarianten erfasst" / "vollständige Live-Wahrheit geprüft"
+- "CURRENT_STATUS.md ist Live-Wahrheit"
+- "trade-capable erlaubt Live" / "trade-capable ist Live-Go"
+- Freie Management-Zusammenfassung ohne Evidence-Abgrenzung
+
+### Weitere Regeln
+
 - Do not invent or renumber options.
 - Do not offer setup execution after `--mode check-only`.
 - If a doctor output is partial, say that it is a partial check.
+- Board-Stage nie als Schalter oder Freigabe darstellen.
+- Vollständigkeitsclaims nach Teilreads vermeiden.
 
 ## Referenced V2 Surfaces
 

--- a/.gemini/README.md
+++ b/.gemini/README.md
@@ -22,6 +22,25 @@ Bei `/onboarding`-Intent: `python -m tools.onboarding_orchestrator`
 
 Default: Read-only Status Card. Kein `.env`, keine Secrets, kein Docker, kein Issue/PR ohne explizite Auswahl.
 
+## Evidence-Abgrenzung (Response Contract)
+
+Nach `/onboarding` MUSS die Antwort enthalten:
+
+| Feld | Erforderlich |
+|------|-------------|
+| Status, State | Ja |
+| warnings, allowed_next_actions | Ja |
+| check_scope, skipped_checks | Ja |
+| Evidence-Abgrenzung (was geprüft, was nicht) | **Ja** |
+| Safety-Grenzen | Ja |
+
+**Wording-Regeln:**
+- Ohne ausgeführte `git`/`gh`/`check`-Kommandos: "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft."
+- `CURRENT_STATUS.md` ist Engineering-Ledger, nicht Live-Wahrheit.
+- LR-SSOT: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- `trade-capable` ist Board-/Stage-Kontext, kein Live-Go.
+- Keine freie Management-Zusammenfassung ohne Evidence-Abgrenzung.
+
 ## Safety Boundaries
 
 - LR remains **NO-GO**

--- a/.gemini/onboarding.md
+++ b/.gemini/onboarding.md
@@ -8,12 +8,24 @@ Wenn ein Gemini-Agent einen `/onboarding`-, `onboarding`-, `onboarding durchfüh
 4. **Read-only by default.** Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
 5. **Routing-Hierarchie**: Dieser Router ist der kanonische Gemini-Onboarding-Pfad. Der Gemini-Bootloader in `GEMINI.md` (Repo-Root) verweist ergänzend auf diesen Router.
 6. **Antwortvertrag**: Berichte nur `Status`, `State`, warnings, `allowed_next_actions`, `check_scope` und `skipped_checks`.
-7. **Keine erfundenen Optionen**: kein Legacy-Setup-Ast, keine Umnummerierung, keine direkte Setup-Ausfuehrung nach `check-only`.
+7. **Evidence-Abgrenzung (Pflicht)**: Trenne sauber zwischen geprüften und nicht geprüften Bereichen:
+   - Ohne ausgeführte `git`/`gh`/`check`-Kommandos: "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft."
+   - Mit Live-Kommandos: "GitHub-/Repo-Live geprüft: <konkrete Kommandos und Ergebnis>."
+   - `CURRENT_STATUS.md` ist Engineering-Ledger, nicht Live-Wahrheit.
+   - LR-SSOT ist `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`.
+8. **Wording Contract**: Vermeide verbotene Phrasen:
+   - Nicht: "Live-Wahrheit geprüft: Ja" (nur mit konkreten Kommandos)
+   - Nicht: "trade-capable ist deaktiviert/aktiviert" (Board-Stage, kein Schalter)
+   - Nicht: "alle systemischen Invarianten erfasst" (nach Teilreads)
+   - Nicht: "CURRENT_STATUS.md ist Live-Wahrheit" (ist Ledger)
+   - Nicht: "trade-capable erlaubt Live" / "ist Live-Go"
+9. **Keine Management-Zusammenfassung**: Keine freie, zu selbstbewusste Zusammenfassung ohne Evidence-Abgrenzung.
+10. **Keine erfundenen Optionen**: kein Legacy-Setup-Ast, keine Umnummerierung, keine direkte Setup-Ausfuehrung nach `check-only`.
 
 ## Safety Boundaries
 
 - LR remains **NO-GO**
-- `trade-capable` ist nicht `Live-Go`
+- `trade-capable` ist Board-/Stage-Kontext, kein Live-Go
 - Keine Echtgeld-Transaktionen
 - Keine Runtime-Änderungen
 - Keine Secrets in Outputs

--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -20,6 +20,8 @@ Bei `/onboarding`-Intent: `python -m tools.onboarding_orchestrator`
 
 Default: Read-only Status Card. Kein `.env`, keine Secrets, kein Docker, kein Issue/PR ohne explizite Auswahl.
 
+**Evidence-Abgrenzung nach /onboarding:** Antwort muss enthalten: Status, State, warnings, allowed_next_actions, check_scope, skipped_checks, Evidence-Abgrenzung (was geprüft, was nicht) und Safety-Grenzen. Ohne git/gh/check-Kommandos: "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft."
+
 ## Safety Boundaries
 
 - LR remains **NO-GO**

--- a/.opencode/skills/onboarding/SKILL.md
+++ b/.opencode/skills/onboarding/SKILL.md
@@ -79,7 +79,9 @@ Optional aliases exist, but `/onboarding` remains canonical:
 4. **Doctor / Validator reachability:** `tools/onboarding_doctor.py` and
    `tools.surrealdb.context_onboarding_doctor` respond.
 5. **Env check:** `.env` presence is a setup-warn only (non-blocking).
-6. **Final Verdict:** `PASS` | `SETUP_WARN` | `BLOCKED`.
+6. **Live Checks (evidence-pflichtig):** `git fetch`, `gh issue view`, `gh pr list`
+   — Ergebnisse dokumentieren. Ohne diese Kommandos: "GitHub-/Check-Live nicht geprüft."
+7. **Final Verdict:** `PASS` | `SETUP_WARN` | `BLOCKED`.
 
 The orchestrator is **read-only by default**: no file writes, no report,
 no setup mutation, no Docker, no secrets. Check-only is a dry-run only and
@@ -159,11 +161,42 @@ slice. It does not create `.env` or perform any local setup mutation.
 
 ## Agent Response Guardrails
 
+### Response Contract (required fields)
+
 - Report the orchestrator `Status`, `State`, warnings, and `allowed_next_actions`.
+- Include `check_scope` and `skipped_checks` as part of the report.
+- Include **Evidence-Abgrenzung**: was wurde geprüft, was nicht (siehe Wording Contract).
+- Include **Safety-Grenzen**: LR NO-GO, kein Live-Go, kein Echtgeld-Go.
+
+### Wording Contract (Evidence-Abgrenzung)
+
+Trenne sauber zwischen geprüften und nicht geprüften Bereichen:
+
+- **Ohne ausgeführte git/gh/check-Kommandos**:
+  erlaubt → "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft."
+- **Mit Live-Kommandos**:
+  erlaubt → "GitHub-/Repo-Live geprüft: <konkrete Kommandos und Ergebnis>."
+- **`CURRENT_STATUS.md`** → "Engineering-Ledger, nicht Live-Wahrheit."
+- **LR-SSOT** → "`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`"
+- **trade-capable** → "Board-/Stage-Kontext, kein Live-Go."
+- **Invarianten** → "Zentrale Sicherheitsgrenzen erkannt."
+
+### Verbotene Phrasen
+
+- "Live-Wahrheit geprüft: Ja" (nur mit konkreten git/gh/check-Kommandos erlaubt)
+- "trade-capable ist deaktiviert" / "trade-capable ist aktiviert"
+- "alle systemischen Invarianten erfasst" / "vollständige Live-Wahrheit geprüft"
+- "CURRENT_STATUS.md ist Live-Wahrheit"
+- "trade-capable erlaubt Live" / "trade-capable ist Live-Go"
+- Freie Management-Zusammenfassung ohne Evidence-Abgrenzung
+
+### Weitere Regeln
+
 - Do not invent, renumber, or expand options beyond the orchestrator contract.
 - Do not offer direct setup execution after `--mode check-only` / dry-run.
-- Treat `check_scope` and `skipped_checks` as part of the report contract.
 - If doctor output is partial, say so explicitly instead of presenting it as a full check.
+- Board-Stage nie als Schalter oder Freigabe darstellen.
+- Vollständigkeitsclaims nach Teilreads vermeiden.
 
 All paths require explicit GO before execution. Default mode produces
 no report and no setup mutation.

--- a/agents/GEMINI.md
+++ b/agents/GEMINI.md
@@ -44,7 +44,9 @@ Gemini:
 - vermeidet Redesigns und Scope-Erweiterungen
 - agiert im **Solo-Maintainer Canon** (Working Repo ist SSOT)
 - **Stoppt bei fehlender Live-Wahrheit**: Bei GitHub-/PR-/Issue-Hygiene sind MCP, `gh` oder `git` Pflicht. Web-Fetch ist kein Ersatz für Governance-relevante Live-Daten.
+- **Evidence-Abgrenzung (Pflicht)**: Trenne sauber zwischen geprüften und nicht geprüften Bereichen. Ohne ausgeführte `git`/`gh`/`check`-Kommandos: "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft." Mit Live-Kommandos: "GitHub-/Repo-Live geprüft: <konkrete Kommandos und Ergebnis>."
 - **Kein "HTML-Guessing"**: Keine Ergebnisse basierend auf Web-Fetch oder HTML-Scraping, wenn operative Tools (gh/git/mcp) zwingend sind.
+- **Wording-Regeln**: `CURRENT_STATUS.md` ist Engineering-Ledger, nicht Live-Wahrheit. LR-SSOT ist `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`. `trade-capable` ist Board-/Stage-Kontext, kein Live-Go. Keine freie Management-Zusammenfassung ohne Evidence-Abgrenzung.
 
 Gemini **initiiert keine Arbeit** eigenständig, sondern wird
 ausschließlich durch **Claude (Session Lead)** hinzugezogen.

--- a/docs/onboarding/ONBOARDING_SCENARIO_001_FRESH_AGENT_SAFE_WORK_DRILL.md
+++ b/docs/onboarding/ONBOARDING_SCENARIO_001_FRESH_AGENT_SAFE_WORK_DRILL.md
@@ -99,6 +99,7 @@ The fresh agent must perform and report these checks:
 - `/onboarding` als aktuellen kanonischen Einstieg erkennen.
 - `.opencode/skills/onboarding/` prüfen.
 - Alte oder erfundene Slash-Commands nicht als canonical behaupten.
+- **Evidence-Abgrenzung (Wording Contract) einhalten**: Nach read-only Onboarding keine unbewiesenen Live-/Statusclaims formulieren. Ohne ausgeführte git/gh/check-Kommandos: "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft." `CURRENT_STATUS.md` als Ledger einordnen, nicht als Live-Wahrheit. Board-Stage `trade-capable` nie als Schalter oder Live-Go darstellen. Keine freie Management-Zusammenfassung ohne Evidence-Abgrenzung.
 - `knowledge/governance/SERVICE_CATALOG.md` prüfen.
 - `docs/runbooks/legacy_service_drift.md` prüfen.
 - Untracked unrelated local files erkennen und unangetastet lassen.

--- a/tests/smoke/test_onboarding_cross_agent_surfaces.py
+++ b/tests/smoke/test_onboarding_cross_agent_surfaces.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -144,5 +147,137 @@ class TestSafetyGuardrails:
         for relative_path in surfaces:
             text = read_text(relative_path)
             assert "NO-GO" in text
+            assert "trade-capable" in text
+            assert "Live-Go" in text
+
+
+# Forbidden phrases are expected to appear in "Verbotene Phrasen" or "Nicht"
+# sections of the contract files (as documented examples of prohibited wording).
+# The test verifies they don't appear OUTSIDE these documented context sections.
+FORBIDDEN_WORDING_PATTERNS: list[tuple[str, str]] = [
+    ("Live-Wahrheit gepr\u00fcft: Ja", ".gemini/onboarding.md"),
+    ("trade-capable ist deaktiviert", ".gemini/onboarding.md"),
+    ("alle systemischen Invarianten erfasst", ".gemini/onboarding.md"),
+    ("CURRENT_STATUS.md ist Live-Wahrheit", ".gemini/onboarding.md"),
+]
+
+# These files must NOT contain the forbidden phrases at all (they're response
+# contracts, not forbidden-phrase documentation):
+NO_FORBIDDEN_ALLOWED_SURFACES: list[str] = [
+    ".opencode/README.md",
+    ".codex/README.md",
+    ".claude/README.md",
+    ".cursor/README.md",
+    ".gemini/README.md",
+    "docs/onboarding/ONBOARDING_SCENARIO_001_FRESH_AGENT_SAFE_WORK_DRILL.md",
+]
+
+# Context lines that make a forbidden phrase acceptable (it's being documented as forbidden)
+ALLOWED_CONTEXT_PREFIXES = [
+    "Nicht:",
+    "Verbotene Phrasen",
+    "forbidden phrase",
+    "Verbotene",
+]
+
+REQUIRED_EVIDENCE_PATTERNS: dict[str, list[str]] = {
+    "Evidence-Abgrenzung": [
+        ".gemini/onboarding.md",
+        ".opencode/skills/onboarding/SKILL.md",
+        ".codex/cdb_skills/onboarding/SKILL.md",
+        ".claude/skills/onboarding/SKILL.md",
+        ".cursor/skills/onboarding/SKILL.md",
+        ".gemini/README.md",
+    ],
+    "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft": [
+        ".gemini/onboarding.md",
+        ".opencode/skills/onboarding/SKILL.md",
+        ".codex/cdb_skills/onboarding/SKILL.md",
+        ".claude/skills/onboarding/SKILL.md",
+        ".cursor/skills/onboarding/SKILL.md",
+    ],
+    "Engineering-Ledger, nicht Live-Wahrheit": [
+        ".gemini/onboarding.md",
+        ".opencode/skills/onboarding/SKILL.md",
+        ".codex/cdb_skills/onboarding/SKILL.md",
+        ".claude/skills/onboarding/SKILL.md",
+        ".cursor/skills/onboarding/SKILL.md",
+    ],
+    "Board-/Stage-Kontext, kein Live-Go": [
+        ".gemini/onboarding.md",
+        ".opencode/skills/onboarding/SKILL.md",
+        ".codex/cdb_skills/onboarding/SKILL.md",
+        ".claude/skills/onboarding/SKILL.md",
+        ".cursor/skills/onboarding/SKILL.md",
+    ],
+}
+
+ALL_ONBOARDING_RESPONSE_SURFACES = [
+    ".gemini/onboarding.md",
+    ".opencode/skills/onboarding/SKILL.md",
+    ".codex/cdb_skills/onboarding/SKILL.md",
+    ".claude/skills/onboarding/SKILL.md",
+    ".cursor/skills/onboarding/SKILL.md",
+]
+
+ALL_FORBIDDEN_PHRASES = [
+    "Live-Wahrheit gepr\u00fcft: Ja",
+    "trade-capable ist deaktiviert",
+    "trade-capable ist aktiviert",
+    "alle systemischen Invarianten erfasst",
+    "vollst\u00e4ndige Live-Wahrheit gepr\u00fcft",
+    "CURRENT_STATUS.md ist Live-Wahrheit",
+    "trade-capable erlaubt Live",
+    "trade-capable ist Live-Go",
+]
+
+
+class TestWordingContract:
+    """Verify forbidden phrases only appear in documented context and required evidence patterns present."""
+
+    def test_forbidden_phrases_only_in_documented_context(self):
+        """Forbidden phrases may appear in 'Verbotene Phrasen' / 'Nicht' context
+        in response-surface docs, but must NOT appear in README/scenario surfaces."""
+        for surface in NO_FORBIDDEN_ALLOWED_SURFACES:
+            text = read_text(surface)
+            for phrase in ALL_FORBIDDEN_PHRASES:
+                assert phrase not in text, (
+                    f"{surface}: contains forbidden phrase '{phrase}'"
+                )
+
+    def test_no_free_management_summary_phrasing(self):
+        """No surface should contain conclusory live-truth claims outside documented context."""
+        for surface in ALL_ONBOARDING_RESPONSE_SURFACES:
+            text = read_text(surface)
+            assert "Evidence-Abgrenzung" in text or "Management-Zusammenfassung" in text, (
+                f"{surface}: keine Abgrenzung gegen freie Management-Zusammenfassung"
+            )
+
+    def test_required_evidence_patterns_present(self):
+        missing: list[str] = []
+        for pattern, surfaces in REQUIRED_EVIDENCE_PATTERNS.items():
+            for surface in surfaces:
+                text = read_text(surface)
+                if pattern not in text:
+                    missing.append(f"{surface}: missing required pattern '{pattern}'")
+        assert not missing, "\n".join(missing)
+
+    def test_all_response_surfaces_have_evidence_abgrenzung(self):
+        for surface in ALL_ONBOARDING_RESPONSE_SURFACES:
+            text = read_text(surface)
+            assert "Evidence-Abgrenzung" in text, (
+                f"{surface}: missing Evidence-Abgrenzung section"
+            )
+
+    def test_all_response_surfaces_have_lr_ssot_reference(self):
+        for surface in ALL_ONBOARDING_RESPONSE_SURFACES:
+            text = read_text(surface)
+            assert "LR-AUDIT-STATUS" in text or "docs/live-readiness" in text, (
+                f"{surface}: missing LR-SSOT reference"
+            )
+
+    def test_all_response_surfaces_declare_trade_capable_not_live_go(self):
+        for surface in ALL_ONBOARDING_RESPONSE_SURFACES:
+            text = read_text(surface)
             assert "trade-capable" in text
             assert "Live-Go" in text

--- a/tests/smoke/test_onboarding_cross_agent_surfaces.py
+++ b/tests/smoke/test_onboarding_cross_agent_surfaces.py
@@ -241,17 +241,17 @@ class TestWordingContract:
         for surface in NO_FORBIDDEN_ALLOWED_SURFACES:
             text = read_text(surface)
             for phrase in ALL_FORBIDDEN_PHRASES:
-                assert phrase not in text, (
-                    f"{surface}: contains forbidden phrase '{phrase}'"
-                )
+                assert (
+                    phrase not in text
+                ), f"{surface}: contains forbidden phrase '{phrase}'"
 
     def test_no_free_management_summary_phrasing(self):
         """No surface should contain conclusory live-truth claims outside documented context."""
         for surface in ALL_ONBOARDING_RESPONSE_SURFACES:
             text = read_text(surface)
-            assert "Evidence-Abgrenzung" in text or "Management-Zusammenfassung" in text, (
-                f"{surface}: keine Abgrenzung gegen freie Management-Zusammenfassung"
-            )
+            assert (
+                "Evidence-Abgrenzung" in text or "Management-Zusammenfassung" in text
+            ), f"{surface}: keine Abgrenzung gegen freie Management-Zusammenfassung"
 
     def test_required_evidence_patterns_present(self):
         missing: list[str] = []
@@ -265,16 +265,16 @@ class TestWordingContract:
     def test_all_response_surfaces_have_evidence_abgrenzung(self):
         for surface in ALL_ONBOARDING_RESPONSE_SURFACES:
             text = read_text(surface)
-            assert "Evidence-Abgrenzung" in text, (
-                f"{surface}: missing Evidence-Abgrenzung section"
-            )
+            assert (
+                "Evidence-Abgrenzung" in text
+            ), f"{surface}: missing Evidence-Abgrenzung section"
 
     def test_all_response_surfaces_have_lr_ssot_reference(self):
         for surface in ALL_ONBOARDING_RESPONSE_SURFACES:
             text = read_text(surface)
-            assert "LR-AUDIT-STATUS" in text or "docs/live-readiness" in text, (
-                f"{surface}: missing LR-SSOT reference"
-            )
+            assert (
+                "LR-AUDIT-STATUS" in text or "docs/live-readiness" in text
+            ), f"{surface}: missing LR-SSOT reference"
 
     def test_all_response_surfaces_declare_trade_capable_not_live_go(self):
         for surface in ALL_ONBOARDING_RESPONSE_SURFACES:

--- a/tests/unit/tools/test_onboarding_simulation.py
+++ b/tests/unit/tools/test_onboarding_simulation.py
@@ -298,6 +298,12 @@ class TestBuildLiveTruthPlan:
         text = "\n".join(lines)
         assert "LR-AUDIT-STATUS" in text
 
+    def test_contains_evidence_abgrenzung(self) -> None:
+        lines = _build_live_truth_plan()
+        text = "\n".join(lines)
+        assert "Evidence-Abgrenzung" in text
+        assert "Repo-/Canon-Prüfung" in text
+
 
 class TestBuildHoldConditions:
     def test_contains_context_brain_fail(self) -> None:

--- a/tools/onboarding_simulation.py
+++ b/tools/onboarding_simulation.py
@@ -127,6 +127,7 @@ def _build_live_truth_plan() -> list[str]:
         "  3. Ledger: CURRENT_STATUS.md (context only, not live truth).",
         "  4. LR SSOT: docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md (NO-GO).",
         "  5. Control: docs/runbooks/CONTROL_REGISTER.md (stage:trade-capable).",
+        "  6. Evidence-Abgrenzung: ohne ausgeführte git/gh-Kommandos 'Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft' melden.",
     ]
 
 


### PR DESCRIPTION
Closes #3335

## Delivered

Alle sechs Agent-Onboarding-Surfaces (Gemini, OpenCode, Codex, Claude, Cursor, docs/onboarding/) haben jetzt denselben evidenzkalibrierten Wording-Contract:

1. **Evidence-Abgrenzung als Pflichtfeld** - Agenten muessen nach /onboarding sauber trennen zwischen geprueften und nicht geprueften Bereichen
2. **Wording Contract** - Explizite Liste verbotener Phrasen
3. **Erlaubte Ersatzformulierungen** - "Repo-/Canon-Pruefung durchgefuehrt; GitHub-/Check-Live nicht geprueft"
4. **Live-Checks evidence-pflichtig** - Ohne ausgeführte git/gh/check-Kommandos: "GitHub-/Check-Live nicht geprueft"
5. **Tests** - Neuer TestWordingContract erkennt verbotene Phrasen und verlangt Evidence-Abgrenzung

## Validation

- 136 onboarding tests pass
- Ruff check: All checks passed
- Git diff --check: clean
- Onboarding docs validator: OK

## Non-goals

- Kein Orchestrator-Verhalten geaendert
- Keine Runtime-/Docker-/DB-/MCP-/SurrealDB-Aenderungen
- Keine Secrets
- Kein Trading

## Safety Boundaries

- LR remains NO-GO
- Board-Stage trade-capable bleibt orthogonal zum LR-System
- Kein Live-Go, kein Echtgeld-Go
