### PR TITLE
[ONBOARDING][GEMINI] Remove root GEMINI legacy live-truth wording

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -40,14 +40,23 @@
    - Wenn Plan Mode keine Live-Kommandos oder Dateiänderungen erlaubt, darf Gemini keine operative Repo-/PR-Hygiene, keine GitHub-Writes und keine Docs-Änderungen simulieren.
    - Dann stoppen statt Plan-Dateien schreiben.
 
-5. **Antwort-Standard**
+5. **Antwort-Standard (Evidence-Abgrenzung)**
     Jede CDB-Antwort beginnt mit:
     - Tool-/Skill-/Agent-/MCP-/Extensions-Check
     - Gelesene Canon-Dateien
-    - Live-Wahrheit geprüft: ja/nein
-    - Stop-Grund, falls nein
+    - Evidence-Abgrenzung: Repo-/Canon-/Onboarding-Status geprüft; GitHub-/Check-Live nicht geprüft, sofern keine konkreten git/gh/check-Kommandos ausgeführt wurden.
+    - GitHub-/Repo-Live geprüft nur mit konkreten git/gh/check-Kommandos und Ergebnissen.
+    - Stop-Grund, falls kein Live-Check möglich
 
-6. **Onboarding-Intent-Router**
+6. **Wording Contract**
+    - `tools.onboarding_orchestrator` zählt als Onboarding-Statusprüfung, nicht als GitHub-/Check-Live-Wahrheit.
+    - `trade-capable` ist Board-/Stage-Kontext, kein Live-Go.
+    - `CURRENT_STATUS.md` ist Engineering-Ledger, nicht Live-Wahrheit.
+    - LR-SSOT ist `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`.
+    - Setup nur nach explizitem Setup-GO; kann lokale Dateien erzeugen.
+    - Ohne Setup-GO: read-only bleiben. Kein "Führt cp .env.example .env aus" als UI-Erklärung.
+
+7. **Onboarding-Intent-Router**
    - If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`, `fresh agent onboarding`, or equivalent, run: `python -m tools.onboarding_orchestrator`
    - Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
    - Default output is the CDB Onboarding status card.

--- a/tests/smoke/test_onboarding_cross_agent_surfaces.py
+++ b/tests/smoke/test_onboarding_cross_agent_surfaces.py
@@ -182,6 +182,7 @@ ALLOWED_CONTEXT_PREFIXES = [
 
 REQUIRED_EVIDENCE_PATTERNS: dict[str, list[str]] = {
     "Evidence-Abgrenzung": [
+        "GEMINI.md",
         ".gemini/onboarding.md",
         ".opencode/skills/onboarding/SKILL.md",
         ".codex/cdb_skills/onboarding/SKILL.md",
@@ -189,7 +190,19 @@ REQUIRED_EVIDENCE_PATTERNS: dict[str, list[str]] = {
         ".cursor/skills/onboarding/SKILL.md",
         ".gemini/README.md",
     ],
-    "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft": [
+    "Repo-/Canon-/Onboarding-Status gepr\u00fcft; GitHub-/Check-Live nicht gepr\u00fcft": [
+        "GEMINI.md",
+    ],
+    "`tools.onboarding_orchestrator` z\u00e4hlt als Onboarding-Statuspr\u00fcfung": [
+        "GEMINI.md",
+    ],
+    "`CURRENT_STATUS.md` ist Engineering-Ledger, nicht Live-Wahrheit": [
+        "GEMINI.md",
+    ],
+    "`trade-capable` ist Board-/Stage-Kontext, kein Live-Go": [
+        "GEMINI.md",
+    ],
+    "Repo-/Canon-Pr\u00fcfung durchgef\u00fchrt; GitHub-/Check-Live nicht gepr\u00fcft": [
         ".gemini/onboarding.md",
         ".opencode/skills/onboarding/SKILL.md",
         ".codex/cdb_skills/onboarding/SKILL.md",
@@ -222,6 +235,10 @@ ALL_ONBOARDING_RESPONSE_SURFACES = [
 
 ALL_FORBIDDEN_PHRASES = [
     "Live-Wahrheit gepr\u00fcft: Ja",
+    "Live-Wahrheit gepr\u00fcft: ja",
+    "Live-Wahrheit gepr\u00fcft: ja/nein",
+    "via tools.onboarding_orchestrator",
+    "F\u00fchrt cp .env.example .env aus",
     "trade-capable ist deaktiviert",
     "trade-capable ist aktiviert",
     "alle systemischen Invarianten erfasst",


### PR DESCRIPTION
Closes #3337

## Summary

Root GEMINI.md enthielt nach PR #3336 weiterhin Legacy-Wording in Sektion 5 ("Live-Wahrheit geprueft: ja/nein").

## Changes

### GEMINI.md (Root)
- Section 5 neu: Antwort-Standard (Evidence-Abgrenzung) — Ersetzt "Live-Wahrheit geprueft: ja/nein" durch evidenzkalibrierten Antwortvertrag
- Neue Section 6: Wording Contract — Explizite Klarstellungen
- Section 7: Onboarding-Intent-Router (unveraendert, nur nummeriert)

### Tests (test_onboarding_cross_agent_surfaces.py)
- Neue forbidden phrases: "Live-Wahrheit geprueft: ja", "ja/nein", "via tools.onboarding_orchestrator", "Fuehrt cp .env.example .env aus"
- Required evidence patterns fuer GEMINI.md hinzugefuegt

## Validation
- 283 onboarding tests pass
- 33 agent root surface tests pass
- ruff check: All checks passed
- git diff --check: clean
- tools.validate_onboarding_docs: OK

## Non-goals
- Kein Orchestrator-Verhalten geaendert
- Keine Runtime-/Docker-/DB-/MCP-/SurrealDB-Aenderungen
- Keine Secrets
- Kein Trading
- LR bleibt NO-GO
