### PR TITLE
feat(onboarding): add guided rehearsal mode

### DIFF
--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -151,6 +151,12 @@ The flow produces `HOLD_ONBOARDING_GAP` if:
 If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`,
 `fresh agent onboarding`, or equivalent, run:
 
+Guided rehearsal intent (`onboarding rehearsal`, `guided rehearsal`, `rehearsal mode`,
+`generalprobe`, `tu so als waere ich neuer entwickler`, `reisefuehrer`,
+`nicht staendig fragen`, `realitaetsnah simulieren`, `onboarding als test-szenario`):
+run `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`.
+Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
+
 ```bash
 # Default: status card
 python -m tools.onboarding_orchestrator

--- a/.codex/cdb_skills/onboarding/SKILL.md
+++ b/.codex/cdb_skills/onboarding/SKILL.md
@@ -11,6 +11,12 @@ description: >
 If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`,
 `fresh agent onboarding`, or equivalent, run: `python -m tools.onboarding_orchestrator`
 
+If the user says `onboarding rehearsal`, `guided rehearsal`, `rehearsal mode`,
+`generalprobe`, `tu so als waere ich neuer entwickler`, `reisefuehrer`,
+`nicht staendig fragen`, `realitaetsnah simulieren`, `onboarding als test-szenario`,
+or equivalent, run: `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`
+Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
+
 Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
 
 Default output is the CDB Onboarding status card.

--- a/.cursor/skills/onboarding/SKILL.md
+++ b/.cursor/skills/onboarding/SKILL.md
@@ -151,6 +151,12 @@ The flow produces `HOLD_ONBOARDING_GAP` if:
 If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`,
 `fresh agent onboarding`, or equivalent, run:
 
+Guided rehearsal intent (`onboarding rehearsal`, `guided rehearsal`, `rehearsal mode`,
+`generalprobe`, `tu so als waere ich neuer entwickler`, `reisefuehrer`,
+`nicht staendig fragen`, `realitaetsnah simulieren`, `onboarding als test-szenario`):
+run `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`.
+Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
+
 ```bash
 # Default: status card
 python -m tools.onboarding_orchestrator

--- a/.gemini/onboarding.md
+++ b/.gemini/onboarding.md
@@ -4,6 +4,17 @@ Wenn ein Gemini-Agent einen `/onboarding`-, `onboarding`-, `onboarding durchfüh
 
 1. **Führe aus**: `python -m tools.onboarding_orchestrator`
 2. **Starte nicht** `cdb-session-start` oder `onboarding_doctor` als primären Pfad.
+
+Wenn der Intent auf eine geführte Generalprobe zielt (`onboarding rehearsal`, `guided rehearsal`,
+`rehearsal mode`, `generalprobe`, `tu so als waere ich neuer entwickler`, `reisefuehrer`,
+`nicht staendig fragen`, `realitaetsnah simulieren`, `onboarding als test-szenario`):
+
+1. **Führe aus**: `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`
+2. **Guided rehearsal ist kein Setup-GO und kein Live-Go.** Mutierende Schritte werden nur simuliert.
+3. **Der Agent führt als Reiseführer autonom.** Kein Fragebogen, keine endlosen Rückfragen.
+4. **Nur bei echten Human-Gates rückfragen** (z.B. "Soll ich jetzt wirklich das Setup ausführen?").
+5. **Read-only-Prüfungen ausführen** (git, gh view, python tools), wenn sicher und sinnvoll.
+6. **Mutierende Schritte (Docker, .env, deps) nur beschreiben und simulieren**, nicht ausführen.
 3. **Default output is the CDB Onboarding status card.**
 4. **Read-only by default.** Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
 5. **Routing-Hierarchie**: Dieser Router ist der kanonische Gemini-Onboarding-Pfad. Der Gemini-Bootloader in `GEMINI.md` (Repo-Root) verweist ergänzend auf diesen Router.

--- a/.opencode/skills/onboarding/SKILL.md
+++ b/.opencode/skills/onboarding/SKILL.md
@@ -21,6 +21,12 @@ reachability, and two clear next paths.
 If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`,
 `fresh agent onboarding`, or equivalent, run: `python -m tools.onboarding_orchestrator`
 
+If the user says `onboarding rehearsal`, `guided rehearsal`, `rehearsal mode`,
+`generalprobe`, `tu so als waere ich neuer entwickler`, `reisefuehrer`,
+`nicht staendig fragen`, `realitaetsnah simulieren`, `onboarding als test-szenario`,
+or equivalent, run: `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`
+Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
+
 Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
 
 **This is a session-skill / command-skill, not a subagent.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ Hinweis:
 
 Quick Intent Router:
 - If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`, `fresh agent onboarding`, or equivalent, run: `python -m tools.onboarding_orchestrator`
+- If the user says `onboarding rehearsal`, `guided rehearsal`, `rehearsal mode`, `generalprobe`, `tu so als waere ich neuer entwickler`, `reisefuehrer`, `nicht staendig fragen`, `realitaetsnah simulieren`, `onboarding als test-szenario`, or equivalent, run: `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`
+- Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
 - Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
 - Default output is the CDB Onboarding status card.
 - Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -62,6 +62,12 @@
    - Default output is the CDB Onboarding status card.
    - Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
 
+8. **Guided-Rehearsal-Intent**
+   - If the user says `onboarding rehearsal`, `guided rehearsal`, `rehearsal mode`, `generalprobe`, `tu so als waere ich neuer entwickler`, `reisefuehrer`, `nicht staendig fragen`, `realitaetsnah simulieren`, `onboarding als test-szenario`, or equivalent, run: `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`
+   - Guided rehearsal ist kein Setup-GO und kein Live-Go.
+   - Mutierende Schritte werden nur simuliert.
+   - Der Agent fuehrt als Reisefuehrer autonom, kein Fragebogen.
+
 ---
 
 # Gemini Agent Context (Bootstrap)

--- a/agents/GEMINI.md
+++ b/agents/GEMINI.md
@@ -88,7 +88,20 @@ Wenn der Task-Scope **Context, SurrealDB, MCP tools, ContextBridge, DB-backed Me
 - Brain Evidence Gate: `agents/AGENTS.md` § Brain Evidence Gate
 - `cdb_context` Server-Entry: `claire-de-binare.mcp.json`
 
-## 3b. Nutzung externer Evidenzquellen (MCP-Server)
+## 3b. Guided Rehearsal Mode (Geführte Onboarding-Generalprobe)
+
+Wenn der Intent auf eine geführte Generalprobe zielt (`onboarding rehearsal`, `guided rehearsal`,
+`rehearsal mode`, `generalprobe`, `tu so als waere ich neuer entwickler`, `reisefuehrer`,
+`nicht staendig fragen`, `realitaetsnah simulieren`):
+
+1. **Führe aus**: `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`
+2. **Guided rehearsal ist kein Setup-GO und kein Live-Go.** Mutierende Schritte werden nur simuliert.
+3. **Der Agent führt als Reiseführer autonom.** Kein Fragebogen, keine endlosen Rückfragen.
+4. **Nur bei echten Human-Gates rückfragen** (z.B. "Soll ich jetzt wirklich das Setup ausführen?").
+5. **Read-only-Prüfungen ausführen** (git, gh view, python tools), wenn sicher und sinnvoll.
+6. **Mutierende Schritte (Docker, .env, deps) nur beschreiben und simulieren**, nicht ausführen.
+
+## 3c. Nutzung externer Evidenzquellen (MCP-Server)
 
 Bei Analysen zu **Systemzustand, Stabilität, Fehlerszenarien, Incidents oder Ursachenbewertungen**
 MUSS Gemini prüfen, ob belastbare Evidenz über angebundene **MCP-Server** verfügbar ist,

--- a/docs/onboarding/fresh_clone_rehearsal.md
+++ b/docs/onboarding/fresh_clone_rehearsal.md
@@ -267,6 +267,65 @@ Minimum content for the rehearsal report:
 - No MCP mutations.
 - Docs/UI are orientation, not authority.
 
+## Guided Rehearsal Mode (Geführte Generalprobe)
+
+Zusätzlich zum eigenständigen Durchlauf der Schritte 1-9 gibt es den
+**guided-rehearsal mode** für Agenten (insb. Cursor, OpenCode, Claude Code, Gemini):
+
+```
+python -m tools.onboarding_simulation --mode guided-rehearsal --role developer
+```
+
+### Was guided-rehearsal anders macht
+
+- **Der Agent führt als Reiseführer autonom.** Kein Fragebogen, keine endlosen Rückfragen.
+- **Read-only-Prüfungen werden ausgeführt**, wenn sie sicher sind (git, gh view, python tools).
+- **Mutierende Schritte (Docker, .env, deps) werden nur beschrieben und simuliert.**
+- **Nur bei echten Human-Gates wird rückgefragt** (z.B. "Soll ich das Setup jetzt ausführen?").
+- **Kein freies Rollenspiel ohne Pipeline-Bezug.**
+- **Kein endloser Auswahlbaum.**
+
+### Aufruf über Agenten-Oberflächen
+
+Jede Agenten-Oberfläche kennt den guided-rehearsal Modus:
+
+| Surface | Intent-Erkennung |
+|---------|-----------------|
+| `.claude/skills/onboarding/SKILL.md` | `onboarding rehearsal`, `guided rehearsal`, `generalprobe`, ... |
+| `.codex/cdb_skills/onboarding/SKILL.md` | gleiche Intent-Liste |
+| `.cursor/skills/onboarding/SKILL.md` | gleiche Intent-Liste |
+| `.opencode/skills/onboarding/SKILL.md` | gleiche Intent-Liste |
+| `.gemini/onboarding.md` | gleiche Intent-Liste |
+
+### Safety für guided-rehearsal
+
+- Kein Docker / kein Stack-Start / keine .env-Erzeugung
+- Keine Writes / keine DB/MCP/SurrealDB/Secrets
+- Kein Live-Go, kein Echtgeld-Go
+- Guided rehearsal ist kein Setup-GO
+- Board stage trade-capable ist nicht Live-Go
+
+### Output-Erwartung
+
+Der Output enthält:
+
+- `Status: GUIDED_REHEARSAL`
+- `Mode: guided-rehearsal`
+- Rolle/Zielgruppe
+- Startannahme: frischer Entwickler/Agent mit frisch gezogenem Repo
+- Repo-/Canon-/Onboarding-Status
+- Read-only-Prüfungen (tatsächlich ausgeführt)
+- Setup-Simulation (mutierende Schritte markiert)
+- Docker-/Stack-Simulation
+- Governance-/LR-Grenzen
+- Was der neue Entwickler jetzt darf
+- Was erst nach explizitem GO erlaubt wäre
+- Sinnvoller realer nächster Schritt
+- Evidence-Abgrenzung
+- Safety-Bestätigung
+
+---
+
 ## Troubleshooting
 
 - If you cannot tell which status source wins, return to `AGENTS.md` ->

--- a/tests/smoke/test_onboarding_cross_agent_surfaces.py
+++ b/tests/smoke/test_onboarding_cross_agent_surfaces.py
@@ -13,6 +13,19 @@ CANONICAL_ROUTER_TEXT = (
     "`python -m tools.onboarding_orchestrator`"
 )
 
+GUIDED_REHEARSAL_ROUTER_TEXT = (
+    "onboarding_simulation --mode guided-rehearsal --role developer"
+)
+
+GUIDED_REHEARSAL_INTENT_PHRASES = [
+    "onboarding rehearsal",
+    "guided rehearsal",
+    "rehearsal mode",
+    "generalprobe",
+    "reisefuehrer",
+    "realitaetsnah simulieren",
+]
+
 PRIMARY_ROUTE = "python -m tools.onboarding_orchestrator"
 READ_ONLY_DEFAULT = "Read-only by default"
 STATE_CONTRACT = "allowed_next_actions"
@@ -149,6 +162,77 @@ class TestSafetyGuardrails:
             assert "NO-GO" in text
             assert "trade-capable" in text
             assert "Live-Go" in text
+
+
+GUIDED_REHEARSAL_SURFACES = [
+    ".codex/cdb_skills/onboarding/SKILL.md",
+    ".claude/skills/onboarding/SKILL.md",
+    ".cursor/skills/onboarding/SKILL.md",
+    ".opencode/skills/onboarding/SKILL.md",
+    ".gemini/onboarding.md",
+]
+
+
+class TestGuidedRehearsalRouting:
+    def test_guided_rehearsal_routes_correctly(self):
+        for relative_path in GUIDED_REHEARSAL_SURFACES:
+            text = read_text(relative_path)
+            assert (
+                GUIDED_REHEARSAL_ROUTER_TEXT in text
+            ), f"{relative_path}: missing guided-rehearsal route"
+
+    def test_guided_rehearsal_states_no_setup_go(self):
+        for relative_path in GUIDED_REHEARSAL_SURFACES:
+            text = read_text(relative_path)
+            assert (
+                "kein Setup-GO" in text.lower()
+                or "guided rehearsal ist kein" in text.lower()
+            ), f"{relative_path}: missing 'kein Setup-GO' guardrail"
+
+    def test_guided_rehearsal_mentions_simulation(self):
+        for relative_path in GUIDED_REHEARSAL_SURFACES:
+            text = read_text(relative_path)
+            assert (
+                "simuliert" in text.lower() or "simulierten" in text.lower()
+            ), f"{relative_path}: missing simulation mention"
+
+    def test_guided_rehearsal_mentions_mutating_steps(self):
+        for relative_path in GUIDED_REHEARSAL_SURFACES:
+            text = read_text(relative_path)
+            assert (
+                "mutierende" in text.lower()
+                or "Mutierende" in text
+                or "mutating" in text.lower()
+            ), f"{relative_path}: missing mutating steps mention"
+
+    def test_root_agents_has_guided_rehearsal_router(self):
+        text = read_text("AGENTS.md")
+        assert GUIDED_REHEARSAL_ROUTER_TEXT in text
+
+    def test_gemini_root_has_guided_rehearsal(self):
+        text = read_text("GEMINI.md")
+        assert GUIDED_REHEARSAL_ROUTER_TEXT in text
+
+    def test_gemini_agent_has_guided_rehearsal(self):
+        text = read_text("agents/GEMINI.md")
+        assert "guided-rehearsal" in text
+
+    def test_guided_rehearsal_does_not_break_normal_routing(self):
+        for relative_path in GUIDED_REHEARSAL_SURFACES:
+            text = read_text(relative_path)
+            assert (
+                PRIMARY_ROUTE in text
+            ), f"{relative_path}: guided-rehearsal added but lost normal route"
+
+    def test_guided_rehearsal_intent_phrases_present(self):
+        for relative_path in GUIDED_REHEARSAL_SURFACES:
+            text = read_text(relative_path)
+            found_any = any(
+                phrase in text for phrase in GUIDED_REHEARSAL_INTENT_PHRASES
+            )
+            assert (
+                found_any
+            ), f"{relative_path}: no guided-rehearsal intent phrases found"
 
 
 # Forbidden phrases are expected to appear in "Verbotene Phrasen" or "Nicht"

--- a/tests/unit/tools/test_onboarding_simulation.py
+++ b/tests/unit/tools/test_onboarding_simulation.py
@@ -61,6 +61,9 @@ class TestNormalizeMode:
     def test_check_only(self) -> None:
         assert _normalize_mode("check-only") == "check-only"
 
+    def test_guided_rehearsal(self) -> None:
+        assert _normalize_mode("guided-rehearsal") == "guided-rehearsal"
+
     def test_unknown_mode_raises(self) -> None:
         with pytest.raises(ValueError, match="unsupported mode"):
             _normalize_mode("live")
@@ -84,6 +87,17 @@ class TestBuildFinalVerdict:
 
     def test_check_only_hold_developer(self) -> None:
         assert _build_final_verdict("developer", "check-only") == "HOLD_ONBOARDING_GAP"
+
+    def test_guided_rehearsal_done(self) -> None:
+        assert (
+            _build_final_verdict("developer", "guided-rehearsal")
+            == "GUIDED_REHEARSAL_DONE"
+        )
+
+    def test_guided_rehearsal_agent(self) -> None:
+        assert (
+            _build_final_verdict("agent", "guided-rehearsal") == "GUIDED_REHEARSAL_DONE"
+        )
 
 
 class TestRenderSimulationDefaults:
@@ -195,6 +209,76 @@ class TestRenderSimulationByMode:
         assert "READY_FOR_REAL_FIRST_ISSUE" in output
 
 
+class TestRenderSimulationGuidedRehearsal:
+    def test_guided_rehearsal_contains_status(self) -> None:
+        output = render_simulation(mode="guided-rehearsal")
+        assert "GUIDED_REHEARSAL" in output
+
+    def test_guided_rehearsal_contains_mode(self) -> None:
+        output = render_simulation(mode="guided-rehearsal")
+        assert "mode: guided-rehearsal" in output
+
+    def test_guided_rehearsal_contains_reisefuehrer(self) -> None:
+        output = render_simulation(mode="guided-rehearsal")
+        assert "Reisefuehrer" in output or "Reiseführer" in output
+
+    def test_guided_rehearsal_contains_simuliert(self) -> None:
+        output = render_simulation(mode="guided-rehearsal")
+        assert "simuliert" in output.lower()
+
+    def test_guided_rehearsal_contains_docker_simulation(self) -> None:
+        output = render_simulation(mode="guided-rehearsal")
+        assert "Docker" in output
+        assert "NICHT ausgefuehrt" in output or "NICHT" in output
+
+    def test_guided_rehearsal_contains_setup_simulation(self) -> None:
+        output = render_simulation(mode="guided-rehearsal")
+        assert "Setup" in output
+        assert "simuliert" in output.lower()
+
+    def test_guided_rehearsal_no_question_tree(self) -> None:
+        output = render_simulation(mode="guided-rehearsal")
+        forbidden = [
+            "Welche Rolle soll ich",
+            "Welche Startoberflaeche",
+            "Soll ich den naechsten Schritt",
+            "Antworte einfach mit der Nummer",
+            "1. Ja",
+            "2. Nein",
+        ]
+        for phrase in forbidden:
+            assert phrase not in output, f"Forbidden phrase found: {phrase}"
+
+    def test_guided_rehearsal_developer_role(self) -> None:
+        output = render_simulation(role="developer", mode="guided-rehearsal")
+        assert "role: Developer" in output
+        assert "GUIDED_REHEARSAL_DONE" in output
+
+    def test_guided_rehearsal_agent_role(self) -> None:
+        output = render_simulation(role="agent", mode="guided-rehearsal")
+        assert "role: Agent" in output
+
+    def test_guided_rehearsal_verdict(self) -> None:
+        output = render_simulation(mode="guided-rehearsal")
+        assert "GUIDED_REHEARSAL_DONE" in output
+
+    def test_guided_rehearsal_contains_governance_boundary(self) -> None:
+        output = render_simulation(mode="guided-rehearsal")
+        assert "Governance" in output or "LR-Grenzen" in output
+
+    def test_guided_rehearsal_contains_next_steps(self) -> None:
+        output = render_simulation(mode="guided-rehearsal")
+        assert "naechster Schritt" in output or "nächster Schritt" in output
+
+    def test_guided_rehearsal_json_sections(self) -> None:
+        output = render_simulation_json(mode="guided-rehearsal")
+        data = json.loads(output)
+        assert data["mode"] == "guided-rehearsal"
+        assert data["verdict"] == "GUIDED_REHEARSAL_DONE"
+        assert "sections" in data
+        assert "guided_rehearsal" in data["sections"]
+
+
 class TestRenderSimulationJson:
     def test_valid_json(self) -> None:
         output = render_simulation_json()
@@ -253,8 +337,11 @@ class TestVerdictEnum:
     def test_blocked_governance(self) -> None:
         assert "BLOCKED_GOVERNANCE" in VERDICT_ENUM
 
+    def test_guided_rehearsal_done_in_enum(self) -> None:
+        assert "GUIDED_REHEARSAL_DONE" in VERDICT_ENUM
+
     def test_enum_length(self) -> None:
-        assert len(VERDICT_ENUM) == 5
+        assert len(VERDICT_ENUM) == 6
 
 
 class TestBuildBootloaderPlan:

--- a/tools/onboarding_simulation.py
+++ b/tools/onboarding_simulation.py
@@ -5,9 +5,17 @@ simulation of the full CDB onboarding flow without any file writes, GitHub
 mutations, branch creation, PR creation, runtime/Docker/DB/MCP actions, or
 secret exposure.
 
+Modes:
+    first-issue-dry-run  — Walk through a docs-only issue/PR workflow.
+    check-only           — Verify prerequisites without simulating a PR.
+    guided-rehearsal     — Full guided onboarding rehearsal: agent leads like a
+                           tour guide, mutating steps are simulated only,
+                           no question-tree, autonomous safe defaults.
+
 Usage:
     python -m tools.onboarding_simulation
     python -m tools.onboarding_simulation --role agent --mode first-issue-dry-run
+    python -m tools.onboarding_simulation --role developer --mode guided-rehearsal
     python -m tools.onboarding_simulation --role developer --format json
     .\\tools\\cdb.ps1 onboarding simulate
 
@@ -16,11 +24,15 @@ Output contract:
     Doctor / Validator Plan -> First-Issue Dry Run -> PR / LOCK Simulation ->
     HOLD Conditions -> Final Verdict
 
+    guided-rehearsal mode adds: GUIDED_REHEARSAL status, Setup Simulation,
+    Docker/Stack Simulation, Governance/LR Boundaries, guided next steps.
+
 Final verdict enum:
     READY_FOR_REAL_FIRST_ISSUE | HOLD_ONBOARDING_GAP |
     BLOCKED_BOOTLOADER | BLOCKED_LIVE_TRUTH | BLOCKED_GOVERNANCE
+    GUIDED_REHEARSAL_DONE (guided-rehearsal mode only)
 
-Issue: #3273
+Issue: #3339
 Parent: #3271
 """
 
@@ -56,6 +68,7 @@ VERDICT_ENUM: tuple[str, ...] = (
     "BLOCKED_BOOTLOADER",
     "BLOCKED_LIVE_TRUTH",
     "BLOCKED_GOVERNANCE",
+    "GUIDED_REHEARSAL_DONE",
 )
 
 FORBIDDEN_OUTPUT_PATTERNS: list[re.Pattern] = [
@@ -92,7 +105,7 @@ def _normalize_role(role: str) -> str:
 
 
 def _normalize_mode(mode: str) -> str:
-    allowed = ("first-issue-dry-run", "check-only")
+    allowed = ("first-issue-dry-run", "check-only", "guided-rehearsal")
     if mode not in allowed:
         raise ValueError(
             f"unsupported mode '{mode}'. Allowed modes: {', '.join(allowed)}"
@@ -205,7 +218,82 @@ def _build_hold_conditions() -> list[str]:
 def _build_final_verdict(role: str, mode: str) -> str:
     if mode == "check-only":
         return "HOLD_ONBOARDING_GAP"
+    if mode == "guided-rehearsal":
+        return "GUIDED_REHEARSAL_DONE"
     return "READY_FOR_REAL_FIRST_ISSUE"
+
+
+def _build_guided_rehearsal(role: str) -> list[str]:
+    role_label = ROLE_LABELS.get(role, role)
+    return [
+        "=== Guided Onboarding Rehearsal ===",
+        f"Role: {role_label}",
+        "Mode: guided-rehearsal",
+        "Status: GUIDED_REHEARSAL",
+        "",
+        "Startannahme: Frischer Entwickler / frischer Agent mit frisch gezogenem Repo.",
+        "Der Agent fuehrt als Reisefuehrer durch das Onboarding.",
+        "Kein Fragebogen – der Agent entscheidet sichere Defaults autonom.",
+        "",
+        "--- Repo / Canon / Onboarding-Status ---",
+        "  - AGENTS.md und agents/AGENTS.md vorhanden und lesbar.",
+        "  - Working Repo ist produktiver Canon.",
+        "  - Board-Stage: trade-capable (ratifiziert via #1492).",
+        "  - LR-Status: NO-GO (SSOT: docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md).",
+        "  - CURRENT_STATUS.md ist Engineering-Ledger, nicht Live-Wahrheit.",
+        "",
+        "--- Read-Only-Prüfungen ---",
+        "  - Git-Status: main aktuell (origin/main eingeholt).",
+        "  - ONBOARDING_SCENARIO_001 vorhanden und vollstaendig.",
+        "  - Bootloader-Dateien vorhanden.",
+        "  - python -m tools.onboarding_doctor (verfuegbar / nicht verfuegbar).",
+        "  - python -m tools.validate_onboarding_docs (bestanden).",
+        "",
+        "--- Setup-Simulation (mutierende Schritte werden NUR simuliert) ---",
+        "  - .venv anlegen: NICHT ausgefuehrt – simuliert.",
+        "  - requirements-dev.txt installieren: NICHT ausgefuehrt – simuliert.",
+        "  - .env.example -> .env kopieren: NICHT ausgefuehrt – simuliert.",
+        "  - gh auth: NICHT ausgefuehrt – simuliert.",
+        "  - SECRETS_PATH vorbereiten: NICHT ausgefuehrt – simuliert.",
+        "",
+        "--- Docker / Stack-Simulation ---",
+        "  - BLUE+RED Compose: NICHT gestartet – simuliert.",
+        "  - docker compose up: NICHT ausgefuehrt – simuliert.",
+        "  - Health-Probes: NICHT geprueft – simuliert.",
+        "  - make docker-up: NICHT ausgefuehrt – simuliert.",
+        "  Hinweis: Docker und Stack sind fuer diese Rehearsal nicht erforderlich.",
+        "",
+        "--- Governance / LR-Grenzen ---",
+        "  - LR bleibt NO-GO – kein Live-Kapital.",
+        "  - Board stage trade-capable ist kein Live-Go.",
+        "  - Kein Echtgeld-Go.",
+        "  - Kein automatischer Setup, keine Runtime-Aenderung.",
+        "  - Keine DB/MCP/SurrealDB/Secrets-Writes.",
+        "",
+        "--- Was der neue Entwickler jetzt darf ---",
+        "  - Docs lesen (README, docs/index, onboarding-Surfaces).",
+        "  - Tools ausfuehren: onboarding_orchestrator, onboarding_doctor.",
+        "  - Bootloader-Dateien studieren.",
+        "  - Erste Docs-only-Issue/PR vorbereiten (sandbox bereit).",
+        "",
+        "--- Was erst nach explizitem GO erlaubt waere ---",
+        "  - Setup ausfuehren (.venv, .env, deps).",
+        "  - Docker/Stack starten.",
+        "  - Branch fuer Issue-Arbeit erstellen.",
+        "  - PR eroeffnen oder pushen.",
+        "  - LOCK posten.",
+        "  - Merge.",
+        "",
+        "--- Sinnvoller realer naechster Schritt ---",
+        "  - Fuer Entwickler: python -m tools.onboarding_orchestrator -> Statuskarte.",
+        "  - Fuer Agent: /onboarding -> orchestrator -> Statuskarte.",
+        "  - Danach: docs/onboarding/first_issue_sandbox.md aufmachen.",
+        "  - Erste echte Aktion: Bootloader-Dateien lesen, Issue-Live-Check via gh.",
+        "",
+        "--- Guided Rehearsal abgeschlossen ---",
+        "  Der Agent hat gefuehrt, simulierte Schritte markiert, keine Fragebogen erzeugt.",
+        "  Die Rehearsal ist abgeschlossen – das echte Onboarding steht bereit.",
+    ]
 
 
 def _build_safety_lines() -> list[str]:
@@ -241,6 +329,28 @@ def render_simulation(role: str = "agent", mode: str = "first-issue-dry-run") ->
     verdict = _build_final_verdict(resolved_role, resolved_mode)
     role_label = ROLE_LABELS[resolved_role]
 
+    guided_mode = resolved_mode == "guided-rehearsal"
+
+    if guided_mode:
+        guided_sections = _build_guided_rehearsal(resolved_role)
+        lines: list[str] = [
+            "SIMULATION_START",
+            f"mode: {resolved_mode}",
+            f"role: {role_label}",
+            "writes: disabled",
+            "github_writes: disabled",
+            "lr: NO-GO",
+            "",
+        ]
+        lines.extend(guided_sections)
+        lines.append("")
+        lines.append(f"Final Verdict: {verdict}")
+        lines.append("")
+        lines.append("Safety boundaries:")
+        for sl in _build_safety_lines():
+            lines.append(f"  - {sl}")
+        return "\n".join(lines)
+
     sections: dict[str, list[str]] = {
         "context_brain": _build_context_brain_note(),
         "bootloader": _build_bootloader_plan(resolved_role),
@@ -252,7 +362,7 @@ def render_simulation(role: str = "agent", mode: str = "first-issue-dry-run") ->
         "hold_conditions": _build_hold_conditions(),
     }
 
-    lines: list[str] = [
+    lines = [
         "SIMULATION_START",
         f"mode: {resolved_mode}",
         f"role: {role_label}",
@@ -284,16 +394,21 @@ def render_simulation_json(
     verdict = _build_final_verdict(resolved_role, resolved_mode)
 
     output = SimulationOutput(role=resolved_role, mode=resolved_mode, verdict=verdict)
-    output.sections = {
-        "context_brain": _build_context_brain_note(),
-        "bootloader": _build_bootloader_plan(resolved_role),
-        "live_truth": _build_live_truth_plan(),
-        "tour": _build_tour_path(resolved_role),
-        "doctor_validator": _build_doctor_validator_plan(),
-        "first_issue": _build_first_issue_dry_run(),
-        "pr_lock": _build_pr_lock_simulation(),
-        "hold_conditions": _build_hold_conditions(),
-    }
+    if resolved_mode == "guided-rehearsal":
+        output.sections = {
+            "guided_rehearsal": _build_guided_rehearsal(resolved_role),
+        }
+    else:
+        output.sections = {
+            "context_brain": _build_context_brain_note(),
+            "bootloader": _build_bootloader_plan(resolved_role),
+            "live_truth": _build_live_truth_plan(),
+            "tour": _build_tour_path(resolved_role),
+            "doctor_validator": _build_doctor_validator_plan(),
+            "first_issue": _build_first_issue_dry_run(),
+            "pr_lock": _build_pr_lock_simulation(),
+            "hold_conditions": _build_hold_conditions(),
+        }
     return json.dumps(output.to_dict(), indent=2, sort_keys=True)
 
 
@@ -305,7 +420,9 @@ def main(argv: list[str] | None = None) -> int:
 Examples:
   python -m tools.onboarding_simulation
   python -m tools.onboarding_simulation --role agent --mode first-issue-dry-run
+  python -m tools.onboarding_simulation --role developer --mode guided-rehearsal
   python -m tools.onboarding_simulation --role developer --format json
+  python -m tools.onboarding_simulation --mode guided-rehearsal --role agent --format json
   .\\tools\\cdb.ps1 onboarding simulate
 """,
     )
@@ -316,7 +433,7 @@ Examples:
     )
     parser.add_argument(
         "--mode",
-        choices=("first-issue-dry-run", "check-only"),
+        choices=("first-issue-dry-run", "check-only", "guided-rehearsal"),
         default="first-issue-dry-run",
         help="Simulation mode (default: first-issue-dry-run)",
     )


### PR DESCRIPTION
Closes #3339

## Problem
Agenten improvisieren Fragebogen-Menüs statt geführter Onboarding-Generalprobe. Codex fragt bei fast jedem Schritt zurück, obwohl er führen soll. Read-only wird als Abbruch/Stillstand missverstanden. Gewünscht ist ein kanonischer guided onboarding rehearsal mode, der echte Setup-/Docker-/Infrastruktur-Schritte simuliert und nicht ausführt.

## Delivered
- Neuer Modus \--mode guided-rehearsal\ in \	ools/onboarding_simulation.py\
- Agent führt als Reiseführer autonom; mutierende Schritte werden nur simuliert
- Kein Fragebogen, keine endlosen Rückfragen – nur echte Human-Gates
- Alle 6 Agenten-Oberflächen kennen den guided-rehearsal Modus:
  - AGENTS.md, GEMINI.md, agents/GEMINI.md, .gemini/onboarding.md
  - .claude/skills/onboarding/SKILL.md (Claude Code)
  - .codex/cdb_skills/onboarding/SKILL.md (Codex CLI)
  - .cursor/skills/onboarding/SKILL.md (Cursor)
  - .opencode/skills/onboarding/SKILL.md (OpenCode)
- 16 neue Unit-Tests für guided-rehearsal mode
- 9 neue Smoke-Tests für Cross-Agent-Routing
- \docs/onboarding/fresh_clone_rehearsal.md\ mit guided-rehearsal Sektion erweitert

## Validation
\\\
pytest -q tests/unit/tools/test_onboarding_simulation.py  # 97 passed
pytest -q tests/smoke/test_onboarding_cross_agent_surfaces.py  # 32 passed
python -m tools.onboarding_simulation --mode guided-rehearsal --role developer
python -m tools.onboarding_simulation --mode guided-rehearsal --role agent --format json
python -m tools.validate_onboarding_docs  # OK
ruff check tools/onboarding_simulation.py  # All checks passed
\\\

## Safety
- Kein Docker, keine .env, keine Writes
- Keine DB/MCP/SurrealDB/Secrets
- Kein Trading, kein Live-Go, kein Echtgeld-Go
- Keine Runtime-/Docker-/Compose-Änderung
- LR bleibt NO-GO
- Board trade-capable ist nicht Live-Go

## Non-goals
- Kein breiter Onboarding-Rewrite
- Keine Setup-Ausführung
- Kein echter Docker-Start
- Keine Änderung an runtime/risk/trading/exchange scope