### PR TITLE
fix(onboarding): prohibit post-run numbered menus after guided-rehearsal

### DIFF
--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -156,6 +156,9 @@ Guided rehearsal intent (`onboarding rehearsal`, `guided rehearsal`, `rehearsal 
 `nicht staendig fragen`, `realitaetsnah simulieren`, `onboarding als test-szenario`):
 run `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`.
 Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
+**Nach guided-rehearsal-Lauf:** NICHT nummerierte Nachfolgemenues anhaengen.
+Kein "Wenn du willst..." mit 1/2/3 Optionen.
+Nur Ergebnis zusammenfassen, Safety-Grenzen nennen, genau einen naechsten Schritt empfehlen. STOP.
 
 ```bash
 # Default: status card

--- a/.codex/cdb_skills/onboarding/SKILL.md
+++ b/.codex/cdb_skills/onboarding/SKILL.md
@@ -17,6 +17,10 @@ If the user says `onboarding rehearsal`, `guided rehearsal`, `rehearsal mode`,
 or equivalent, run: `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`
 Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
 
+**Nach guided-rehearsal-Lauf:** NICHT nummerierte Nachfolgemenues anhaengen.
+Kein "Wenn du willst..." mit 1/2/3 Optionen.
+Nur Ergebnis zusammenfassen, Safety-Grenzen nennen, genau einen naechsten Schritt empfehlen. STOP.
+
 Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
 
 Default output is the CDB Onboarding status card.

--- a/.cursor/skills/onboarding/SKILL.md
+++ b/.cursor/skills/onboarding/SKILL.md
@@ -156,6 +156,9 @@ Guided rehearsal intent (`onboarding rehearsal`, `guided rehearsal`, `rehearsal 
 `nicht staendig fragen`, `realitaetsnah simulieren`, `onboarding als test-szenario`):
 run `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`.
 Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
+**Nach guided-rehearsal-Lauf:** NICHT nummerierte Nachfolgemenues anhaengen.
+Kein "Wenn du willst..." mit 1/2/3 Optionen.
+Nur Ergebnis zusammenfassen, Safety-Grenzen nennen, genau einen naechsten Schritt empfehlen. STOP.
 
 ```bash
 # Default: status card

--- a/.gemini/onboarding.md
+++ b/.gemini/onboarding.md
@@ -15,6 +15,10 @@ Wenn der Intent auf eine geführte Generalprobe zielt (`onboarding rehearsal`, `
 4. **Nur bei echten Human-Gates rückfragen** (z.B. "Soll ich jetzt wirklich das Setup ausführen?").
 5. **Read-only-Prüfungen ausführen** (git, gh view, python tools), wenn sicher und sinnvoll.
 6. **Mutierende Schritte (Docker, .env, deps) nur beschreiben und simulieren**, nicht ausführen.
+7. **Nach dem guided-rehearsal-Lauf:** NICHT nummerierte Nachfolgemenues anhaengen.
+   Kein "Wenn du willst..." mit 1/2/3 Optionen.
+   Nur Ergebnis zusammenfassen, Safety-Grenzen nennen, genau einen naechsten Schritt empfehlen. STOP.
+
 3. **Default output is the CDB Onboarding status card.**
 4. **Read-only by default.** Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
 5. **Routing-Hierarchie**: Dieser Router ist der kanonische Gemini-Onboarding-Pfad. Der Gemini-Bootloader in `GEMINI.md` (Repo-Root) verweist ergänzend auf diesen Router.

--- a/.opencode/skills/onboarding/SKILL.md
+++ b/.opencode/skills/onboarding/SKILL.md
@@ -27,6 +27,10 @@ If the user says `onboarding rehearsal`, `guided rehearsal`, `rehearsal mode`,
 or equivalent, run: `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`
 Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
 
+**Nach guided-rehearsal-Lauf:** NICHT nummerierte Nachfolgemenues anhaengen.
+Kein "Wenn du willst..." mit 1/2/3 Optionen.
+Nur Ergebnis zusammenfassen, Safety-Grenzen nennen, genau einen naechsten Schritt empfehlen. STOP.
+
 Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
 
 **This is a session-skill / command-skill, not a subagent.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Quick Intent Router:
 - If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`, `fresh agent onboarding`, or equivalent, run: `python -m tools.onboarding_orchestrator`
 - If the user says `onboarding rehearsal`, `guided rehearsal`, `rehearsal mode`, `generalprobe`, `tu so als waere ich neuer entwickler`, `reisefuehrer`, `nicht staendig fragen`, `realitaetsnah simulieren`, `onboarding als test-szenario`, or equivalent, run: `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`
 - Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
+- After guided-rehearsal run: do NOT append numbered follow-up menus. No "Wenn du willst..." with 1/2/3 options. Summarize result, state safety boundaries, recommend exactly one next step. STOP.
 - Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
 - Default output is the CDB Onboarding status card.
 - Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -67,6 +67,7 @@
    - Guided rehearsal ist kein Setup-GO und kein Live-Go.
    - Mutierende Schritte werden nur simuliert.
    - Der Agent fuehrt als Reisefuehrer autonom, kein Fragebogen.
+   - **Nach dem Lauf:** NICHT nummerierte Nachfolgemenues anhaengen. Kein "Wenn du willst..." mit Optionen. Ergebnis zusammenfassen, Safety nennen, einen naechsten Schritt empfehlen. STOP.
 
 ---
 

--- a/agents/GEMINI.md
+++ b/agents/GEMINI.md
@@ -100,6 +100,9 @@ Wenn der Intent auf eine geführte Generalprobe zielt (`onboarding rehearsal`, `
 4. **Nur bei echten Human-Gates rückfragen** (z.B. "Soll ich jetzt wirklich das Setup ausführen?").
 5. **Read-only-Prüfungen ausführen** (git, gh view, python tools), wenn sicher und sinnvoll.
 6. **Mutierende Schritte (Docker, .env, deps) nur beschreiben und simulieren**, nicht ausführen.
+7. **Nach dem guided-rehearsal-Lauf:** NICHT nummerierte Nachfolgemenues anhaengen.
+   Kein "Wenn du willst..." mit 1/2/3 Optionen.
+   Nur Ergebnis zusammenfassen, Safety-Grenzen nennen, genau einen naechsten Schritt empfehlen. STOP.
 
 ## 3c. Nutzung externer Evidenzquellen (MCP-Server)
 

--- a/tests/smoke/test_onboarding_cross_agent_surfaces.py
+++ b/tests/smoke/test_onboarding_cross_agent_surfaces.py
@@ -235,6 +235,49 @@ class TestGuidedRehearsalRouting:
             ), f"{relative_path}: no guided-rehearsal intent phrases found"
 
 
+GUIDED_REHEARSAL_ALL_ROUTER_SURFACES = GUIDED_REHEARSAL_SURFACES + [
+    "AGENTS.md",
+    "GEMINI.md",
+    "agents/GEMINI.md",
+]
+
+ANTI_MENU_KEYWORDS = [
+    "NICHT nummerierte Nachfolgemenues",
+    'Kein "Wenn du willst..."',
+    "genau einen naechsten Schritt",
+    "Nach dem guided-rehearsal-Lauf",
+    "After guided-rehearsal run",
+]
+
+
+class TestGuidedRehearsalAntiMenuPostRun:
+    def test_all_surfaces_have_anti_menu_rule(self):
+        for relative_path in GUIDED_REHEARSAL_ALL_ROUTER_SURFACES:
+            text = read_text(relative_path)
+            found_any = any(kw in text for kw in ANTI_MENU_KEYWORDS)
+            assert found_any, f"{relative_path}: missing anti-menu post-run rule"
+
+    def test_no_surface_has_followup_menu_template(self):
+        forbidden_phrases = [
+            "1. Bootloader",
+            "2. Statuskarte",
+            "3. echtes read-only Repo-Onboarding",
+        ]
+        for relative_path in GUIDED_REHEARSAL_SURFACES:
+            text = read_text(relative_path)
+            for phrase in forbidden_phrases:
+                assert phrase not in text, (
+                    f"{relative_path}: contains forbidden post-run menu "
+                    f"phrase '{phrase}'"
+                )
+
+    def test_guided_rehearsal_tool_output_has_anti_menu(self):
+        text = read_text("tools/onboarding_simulation.py")
+        assert "DO NOT append" in text
+        assert "Agent Instructions" in text
+        assert "DO NOT generate" in text
+
+
 # Forbidden phrases are expected to appear in "Verbotene Phrasen" or "Nicht"
 # sections of the contract files (as documented examples of prohibited wording).
 # The test verifies they don't appear OUTSIDE these documented context sections.

--- a/tests/unit/tools/test_onboarding_simulation.py
+++ b/tests/unit/tools/test_onboarding_simulation.py
@@ -268,7 +268,25 @@ class TestRenderSimulationGuidedRehearsal:
 
     def test_guided_rehearsal_contains_next_steps(self) -> None:
         output = render_simulation(mode="guided-rehearsal")
-        assert "naechster Schritt" in output or "nächster Schritt" in output
+        assert "naechster Schritt" in output or "n\u00e4chster Schritt" in output
+
+    def test_guided_rehearsal_next_steps_is_one_line(self) -> None:
+        output = render_simulation(mode="guided-rehearsal")
+        lines = output.split("\n")
+        in_next_steps = False
+        bullets_in_section = 0
+        for line in lines:
+            if "Sinnvoller realer naechster Schritt" in line:
+                in_next_steps = True
+                continue
+            if in_next_steps:
+                if line.strip().startswith("---") and "Schritt" not in line:
+                    break
+                if line.strip().startswith("-"):
+                    bullets_in_section += 1
+        assert (
+            bullets_in_section <= 1
+        ), f"Expected <=1 bullet in next-steps section, found {bullets_in_section}"
 
     def test_guided_rehearsal_json_sections(self) -> None:
         output = render_simulation_json(mode="guided-rehearsal")
@@ -277,6 +295,20 @@ class TestRenderSimulationGuidedRehearsal:
         assert data["verdict"] == "GUIDED_REHEARSAL_DONE"
         assert "sections" in data
         assert "guided_rehearsal" in data["sections"]
+
+    def test_guided_rehearsal_contains_anti_menu_instructions(self) -> None:
+        output = render_simulation(mode="guided-rehearsal")
+        assert "DO NOT append" in output
+        assert "Agent Instructions" in output
+        assert "DO NOT generate" in output
+
+    def test_guided_rehearsal_contains_post_run_stop(self) -> None:
+        output = render_simulation(mode="guided-rehearsal")
+        assert "STOP." in output
+
+    def test_guided_rehearsal_recommends_exactly_one_next_step(self) -> None:
+        output = render_simulation(mode="guided-rehearsal")
+        assert "exactly ONE" in output or "exactly one" in output.lower()
 
 
 class TestRenderSimulationJson:

--- a/tools/onboarding_simulation.py
+++ b/tools/onboarding_simulation.py
@@ -223,6 +223,15 @@ def _build_final_verdict(role: str, mode: str) -> str:
     return "READY_FOR_REAL_FIRST_ISSUE"
 
 
+def _single_next_step(role: str, role_label: str) -> str:
+    if role in ("developer", "docs", "validation"):
+        return (
+            f"Fuer {role_label}: python -m tools.onboarding_orchestrator aufrufen"
+            " und die Onboarding-Statuskarte lesen."
+        )
+    return f"Fuer {role_label}: /onboarding aufrufen und die Statuskarte lesen."
+
+
 def _build_guided_rehearsal(role: str) -> list[str]:
     role_label = ROLE_LABELS.get(role, role)
     return [
@@ -285,14 +294,20 @@ def _build_guided_rehearsal(role: str) -> list[str]:
         "  - Merge.",
         "",
         "--- Sinnvoller realer naechster Schritt ---",
-        "  - Fuer Entwickler: python -m tools.onboarding_orchestrator -> Statuskarte.",
-        "  - Fuer Agent: /onboarding -> orchestrator -> Statuskarte.",
-        "  - Danach: docs/onboarding/first_issue_sandbox.md aufmachen.",
-        "  - Erste echte Aktion: Bootloader-Dateien lesen, Issue-Live-Check via gh.",
+        f"  {_single_next_step(role, role_label)}",
         "",
         "--- Guided Rehearsal abgeschlossen ---",
         "  Der Agent hat gefuehrt, simulierte Schritte markiert, keine Fragebogen erzeugt.",
         "  Die Rehearsal ist abgeschlossen – das echte Onboarding steht bereit.",
+        "",
+        "--- Agent Instructions (Post-Run) ---",
+        "  THIS OUTPUT IS SELF-CONTAINED. DO NOT append a numbered follow-up menu.",
+        '  DO NOT ask "Wenn du willst..." with 1/2/3 options.',
+        "  DO NOT generate a numbered follow-up menu.",
+        "  Summarize the guided-rehearsal result.",
+        "  State safety boundaries.",
+        "  Recommend exactly ONE next step.",
+        "  STOP.",
     ]
 
 


### PR DESCRIPTION
Closes #3339

## Problem
After guided-rehearsal completes, Codex appends a new numbered follow-up menu (e.g. 'Wenn du willst...' with 1/2/3 options). This reintroduces the exact question-tree behavior guided-rehearsal was designed to prevent.

## Root Cause
The onboarding SKILL.md files route to guided-rehearsal correctly, but lack explicit instructions that agents must NOT append numbered follow-up menus after the rehearsal completes. The agent's response pipeline reads 'Optional next steps' sections and generates menus.

## Delivered
- **Anti-menu rules** in all 8 routing surfaces:
  AGENTS.md, GEMINI.md, agents/GEMINI.md, .gemini/onboarding.md,
  .claude/skills/onboarding/SKILL.md (Claude Code),
  .codex/cdb_skills/onboarding/SKILL.md (Codex CLI),
  .cursor/skills/onboarding/SKILL.md (Cursor),
  .opencode/skills/onboarding/SKILL.md (OpenCode)
- **Agent Instructions (Post-Run)** section in guided-rehearsal tool output:
  'THIS OUTPUT IS SELF-CONTAINED. DO NOT append a numbered follow-up menu.'
- 3 new unit tests + 3 new smoke tests for anti-menu behavior
- Existing 100 unit tests + 35 smoke tests all pass

## Validation
\\\
pytest tests/unit/tools/test_onboarding_simulation.py -q  # 100 passed
pytest tests/smoke/test_onboarding_cross_agent_surfaces.py -q  # 35 passed
ruff check tools/onboarding_simulation.py tests/  # All checks passed
python -m tools.onboarding_simulation --mode guided-rehearsal --role developer  # output clean
\\\

## Safety
- No Docker, no .env, no writes, no DB/MCP/SurrealDB
- No secrets, no trading, no LR changes
- Diff is onboarding-only (tools, tests, agent surfaces)
- LR remains NO-GO