### PR TITLE
fix(onboarding): harden anti-menu post-run contract

### DIFF
--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -156,9 +156,9 @@ Guided rehearsal intent (`onboarding rehearsal`, `guided rehearsal`, `rehearsal 
 `nicht staendig fragen`, `realitaetsnah simulieren`, `onboarding als test-szenario`):
 run `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`.
 Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
-**Nach guided-rehearsal-Lauf:** NICHT nummerierte Nachfolgemenues anhaengen.
-Kein "Wenn du willst..." mit 1/2/3 Optionen.
-Nur Ergebnis zusammenfassen, Safety-Grenzen nennen, genau einen naechsten Schritt empfehlen. STOP.
+**Nach guided-rehearsal-Lauf:** KEINE Anschlussfrage, keine Einladung, kein "Wenn du willst...".
+Keine nummerierten Nachfolgemenues (1/2/3).
+Der letzte Ausgabe-Absatz MUSS ein Abschluss sein: Status, ein naechster empfohlener Schritt, STOP.
 
 ```bash
 # Default: status card

--- a/.codex/cdb_skills/onboarding/SKILL.md
+++ b/.codex/cdb_skills/onboarding/SKILL.md
@@ -17,9 +17,9 @@ If the user says `onboarding rehearsal`, `guided rehearsal`, `rehearsal mode`,
 or equivalent, run: `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`
 Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
 
-**Nach guided-rehearsal-Lauf:** NICHT nummerierte Nachfolgemenues anhaengen.
-Kein "Wenn du willst..." mit 1/2/3 Optionen.
-Nur Ergebnis zusammenfassen, Safety-Grenzen nennen, genau einen naechsten Schritt empfehlen. STOP.
+**Nach guided-rehearsal-Lauf:** KEINE Anschlussfrage, keine Einladung, kein "Wenn du willst...".
+Keine nummerierten Nachfolgemenues (1/2/3).
+Der letzte Ausgabe-Absatz MUSS ein Abschluss sein: Status, ein naechster empfohlener Schritt, STOP.
 
 Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
 

--- a/.cursor/skills/onboarding/SKILL.md
+++ b/.cursor/skills/onboarding/SKILL.md
@@ -156,9 +156,9 @@ Guided rehearsal intent (`onboarding rehearsal`, `guided rehearsal`, `rehearsal 
 `nicht staendig fragen`, `realitaetsnah simulieren`, `onboarding als test-szenario`):
 run `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`.
 Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
-**Nach guided-rehearsal-Lauf:** NICHT nummerierte Nachfolgemenues anhaengen.
-Kein "Wenn du willst..." mit 1/2/3 Optionen.
-Nur Ergebnis zusammenfassen, Safety-Grenzen nennen, genau einen naechsten Schritt empfehlen. STOP.
+**Nach guided-rehearsal-Lauf:** KEINE Anschlussfrage, keine Einladung, kein "Wenn du willst...".
+Keine nummerierten Nachfolgemenues (1/2/3).
+Der letzte Ausgabe-Absatz MUSS ein Abschluss sein: Status, ein naechster empfohlener Schritt, STOP.
 
 ```bash
 # Default: status card

--- a/.gemini/onboarding.md
+++ b/.gemini/onboarding.md
@@ -15,9 +15,9 @@ Wenn der Intent auf eine geführte Generalprobe zielt (`onboarding rehearsal`, `
 4. **Nur bei echten Human-Gates rückfragen** (z.B. "Soll ich jetzt wirklich das Setup ausführen?").
 5. **Read-only-Prüfungen ausführen** (git, gh view, python tools), wenn sicher und sinnvoll.
 6. **Mutierende Schritte (Docker, .env, deps) nur beschreiben und simulieren**, nicht ausführen.
-7. **Nach dem guided-rehearsal-Lauf:** NICHT nummerierte Nachfolgemenues anhaengen.
-   Kein "Wenn du willst..." mit 1/2/3 Optionen.
-   Nur Ergebnis zusammenfassen, Safety-Grenzen nennen, genau einen naechsten Schritt empfehlen. STOP.
+7. **Nach dem guided-rehearsal-Lauf:** KEINE Anschlussfrage, keine Einladung,
+   kein "Wenn du willst..." mit Optionen.
+   Der letzte Ausgabe-Absatz MUSS ein Abschluss sein: Status, ein naechster Schritt, STOP.
 
 3. **Default output is the CDB Onboarding status card.**
 4. **Read-only by default.** Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.

--- a/.opencode/skills/onboarding/SKILL.md
+++ b/.opencode/skills/onboarding/SKILL.md
@@ -27,9 +27,9 @@ If the user says `onboarding rehearsal`, `guided rehearsal`, `rehearsal mode`,
 or equivalent, run: `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`
 Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
 
-**Nach guided-rehearsal-Lauf:** NICHT nummerierte Nachfolgemenues anhaengen.
-Kein "Wenn du willst..." mit 1/2/3 Optionen.
-Nur Ergebnis zusammenfassen, Safety-Grenzen nennen, genau einen naechsten Schritt empfehlen. STOP.
+**Nach guided-rehearsal-Lauf:** KEINE Anschlussfrage, keine Einladung, kein "Wenn du willst...".
+Keine nummerierten Nachfolgemenues (1/2/3).
+Der letzte Ausgabe-Absatz MUSS ein Abschluss sein: Status, ein naechster empfohlener Schritt, STOP.
 
 Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Quick Intent Router:
 - If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`, `fresh agent onboarding`, or equivalent, run: `python -m tools.onboarding_orchestrator`
 - If the user says `onboarding rehearsal`, `guided rehearsal`, `rehearsal mode`, `generalprobe`, `tu so als waere ich neuer entwickler`, `reisefuehrer`, `nicht staendig fragen`, `realitaetsnah simulieren`, `onboarding als test-szenario`, or equivalent, run: `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`
 - Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
-- After guided-rehearsal run: do NOT append numbered follow-up menus. No "Wenn du willst..." with 1/2/3 options. Summarize result, state safety boundaries, recommend exactly one next step. STOP.
+- After guided-rehearsal run: NO follow-up question, no invitation, no "Wenn du willst..." with options. Do NOT append numbered follow-up menus. The last output paragraph MUST be a closing: status, one recommended next step, STOP.
 - Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
 - Default output is the CDB Onboarding status card.
 - Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -67,7 +67,7 @@
    - Guided rehearsal ist kein Setup-GO und kein Live-Go.
    - Mutierende Schritte werden nur simuliert.
    - Der Agent fuehrt als Reisefuehrer autonom, kein Fragebogen.
-   - **Nach dem Lauf:** NICHT nummerierte Nachfolgemenues anhaengen. Kein "Wenn du willst..." mit Optionen. Ergebnis zusammenfassen, Safety nennen, einen naechsten Schritt empfehlen. STOP.
+   - **Nach dem Lauf:** KEINE Anschlussfrage, keine Einladung, kein "Wenn du willst..." mit Optionen. Der letzte Absatz MUSS Abschluss sein: Status, ein naechster Schritt, STOP.
 
 ---
 

--- a/agents/GEMINI.md
+++ b/agents/GEMINI.md
@@ -100,9 +100,9 @@ Wenn der Intent auf eine geführte Generalprobe zielt (`onboarding rehearsal`, `
 4. **Nur bei echten Human-Gates rückfragen** (z.B. "Soll ich jetzt wirklich das Setup ausführen?").
 5. **Read-only-Prüfungen ausführen** (git, gh view, python tools), wenn sicher und sinnvoll.
 6. **Mutierende Schritte (Docker, .env, deps) nur beschreiben und simulieren**, nicht ausführen.
-7. **Nach dem guided-rehearsal-Lauf:** NICHT nummerierte Nachfolgemenues anhaengen.
-   Kein "Wenn du willst..." mit 1/2/3 Optionen.
-   Nur Ergebnis zusammenfassen, Safety-Grenzen nennen, genau einen naechsten Schritt empfehlen. STOP.
+7. **Nach dem guided-rehearsal-Lauf:** KEINE Anschlussfrage, keine Einladung,
+   kein "Wenn du willst..." mit Optionen.
+   Der letzte Ausgabe-Absatz MUSS ein Abschluss sein: Status, ein naechster Schritt, STOP.
 
 ## 3c. Nutzung externer Evidenzquellen (MCP-Server)
 

--- a/tests/smoke/test_onboarding_cross_agent_surfaces.py
+++ b/tests/smoke/test_onboarding_cross_agent_surfaces.py
@@ -242,9 +242,11 @@ GUIDED_REHEARSAL_ALL_ROUTER_SURFACES = GUIDED_REHEARSAL_SURFACES + [
 ]
 
 ANTI_MENU_KEYWORDS = [
-    "NICHT nummerierte Nachfolgemenues",
+    "KEINE Anschlussfrage",
+    "keine Einladung",
     'Kein "Wenn du willst..."',
     "genau einen naechsten Schritt",
+    "ein naechster empfohlener Schritt",
     "Nach dem guided-rehearsal-Lauf",
     "After guided-rehearsal run",
 ]
@@ -273,9 +275,9 @@ class TestGuidedRehearsalAntiMenuPostRun:
 
     def test_guided_rehearsal_tool_output_has_anti_menu(self):
         text = read_text("tools/onboarding_simulation.py")
-        assert "DO NOT append" in text
+        assert "NO follow-up question" in text
         assert "Agent Instructions" in text
-        assert "DO NOT generate" in text
+        assert "SELF-CONTAINED" in text
 
 
 # Forbidden phrases are expected to appear in "Verbotene Phrasen" or "Nicht"

--- a/tests/unit/tools/test_onboarding_simulation.py
+++ b/tests/unit/tools/test_onboarding_simulation.py
@@ -298,9 +298,9 @@ class TestRenderSimulationGuidedRehearsal:
 
     def test_guided_rehearsal_contains_anti_menu_instructions(self) -> None:
         output = render_simulation(mode="guided-rehearsal")
-        assert "DO NOT append" in output
+        assert "NO follow-up question" in output
         assert "Agent Instructions" in output
-        assert "DO NOT generate" in output
+        assert "NO invite" in output or "no invitation" in output.lower()
 
     def test_guided_rehearsal_contains_post_run_stop(self) -> None:
         output = render_simulation(mode="guided-rehearsal")
@@ -308,7 +308,8 @@ class TestRenderSimulationGuidedRehearsal:
 
     def test_guided_rehearsal_recommends_exactly_one_next_step(self) -> None:
         output = render_simulation(mode="guided-rehearsal")
-        assert "exactly ONE" in output or "exactly one" in output.lower()
+        assert "one recommended next step" in output.lower()
+        assert "STOP" in output
 
 
 class TestRenderSimulationJson:

--- a/tools/onboarding_simulation.py
+++ b/tools/onboarding_simulation.py
@@ -301,13 +301,11 @@ def _build_guided_rehearsal(role: str) -> list[str]:
         "  Die Rehearsal ist abgeschlossen – das echte Onboarding steht bereit.",
         "",
         "--- Agent Instructions (Post-Run) ---",
-        "  THIS OUTPUT IS SELF-CONTAINED. DO NOT append a numbered follow-up menu.",
-        '  DO NOT ask "Wenn du willst..." with 1/2/3 options.',
-        "  DO NOT generate a numbered follow-up menu.",
-        "  Summarize the guided-rehearsal result.",
-        "  State safety boundaries.",
-        "  Recommend exactly ONE next step.",
-        "  STOP.",
+        "  THIS OUTPUT IS SELF-CONTAINED. NO follow-up question, no invitation.",
+        '  DO NOT ask "Wenn du willst..." with options.',
+        "  DO NOT generate a numbered follow-up menu (1/2/3).",
+        "  The last output paragraph MUST be a closing:",
+        "  status + one recommended next step + STOP.",
     ]
 
 


### PR DESCRIPTION
Closes #3339

## Change
Harden the post-guided-rehearsal contract across all 8 routing surfaces and the tool output:
- KEINE Anschlussfrage, keine Einladung, kein "Wenn du willst..."
- Der letzte Ausgabe-Absatz MUSS ein Abschluss sein: Status, ein naechster Schritt, STOP

## Validation
pytest tests/unit/tools/test_onboarding_simulation.py -q  # 101 passed
pytest tests/smoke/test_onboarding_cross_agent_surfaces.py -q  # 35 passed
ruff check tools/onboarding_simulation.py  # All checks passed

## Safety
- No Docker, no .env, no writes, no DB/MCP/SurrealDB
- No secrets, no trading, no LR changes
- Diff is onboarding-only (tools, tests, agent surfaces)
