### PR TITLE
[ARVP][WINDOW-BANK] Expand longer natural-paper windows for regime_segments

### DIFF
--- a/docs/evidence/arvp_window_bank_expansion_regime_segments_3343.md
+++ b/docs/evidence/arvp_window_bank_expansion_regime_segments_3343.md
@@ -1,0 +1,265 @@
+# ARVP Window-Bank Expansion — #3343
+
+Status Class: Scoped evidence / negative finding (HOLD)
+Issue: #3343
+Parent: #1900
+Control Refs: #2985, #2977, #3212, #3217, #3219, #3221
+Live-Readiness: NO-GO
+Echtgeld: not authorized
+
+---
+
+## 1. Brain Evidence Block
+
+```
+brain_source: repo-only, validated via readonly DB extract
+brain_status: used
+tools_or_queries:
+  - read: canonical read-order per agents/AGENTS.md
+  - read: AGENTS.md, agents/AGENTS.md
+  - read: docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md
+  - read: docs/runbooks/CONTROL_REGISTER.md
+  - read: CURRENT_STATUS.md
+  - read: docs/evidence/arvp_window_bank_inventory_3212.md
+  - read: docs/evidence/arvp_guarded_natural_paper_window_execution_3217.md
+  - read: docs/evidence/arvp_three_window_replay_vs_paper_calibration_3219.md
+  - read: docs/roadmaps/ARVP_TO_LIVE_GO_ROADMAP_2026-06.md (§5–§6)
+  - read: services/validation/paper_reference_window_runner.py
+  - read: core/replay/paper_reference_window_export.py
+  - bash: git fetch origin --prune; git status -sb; git rev-parse HEAD; git rev-parse origin/main
+  - gh: issue view 3343/1900/2977/2985; pr list
+  - execute: scripts/_3343_verify_pb1_clusters.py (readonly DB, cdb_readonly, SELECT-only)
+  - execute: scripts/_3343_inventory_windows.py (readonly DB, cdb_readonly, SELECT-only)
+records_or_results:
+  - HEAD == origin/main == b7198371 (clean, 0 open PRs)
+  - #3343 OPEN (body fresh), #1900 OPEN (reconciled 2026-06-19)
+  - #2977 OPEN/BLOCKED, #2985 OPEN (14 comments)
+  - POSTGRES_READONLY_PASSWORD_DSN confirmed set
+  - Readonly identity verified: cdb_readonly/cdb_readonly on claire_de_binare
+  - Privileges: SELECT=true, INSERT=false, UPDATE=false, DELETE=false
+  - Total correlation_ledger rows: 34256
+  - primary_breakout_v1/BTCUSDT rows: 783
+  - Paper strategy/BTCUSDT rows: 16345
+  - DB date range: 2026-02-15 to 2026-06-06
+repo_crosscheck:
+  - AGENTS.md, agents/AGENTS.md, CURRENT_STATUS.md, CONTROL_REGISTER.md
+  - paper_reference_window_runner.py, paper_reference_window_export.py
+  - arvp_window_bank_inventory_3212.md (prior bank state: 3 windows, none >2h)
+  - arvp_guarded_natural_paper_window_execution_3217.md (1h window extracted)
+  - arvp_three_window_replay_vs_paper_calibration_3219.md (A4=FAIL, regime_segments unavailable)
+impact_on_plan:
+  - PB1 window-bank path cannot proceed from existing correlation_ledger data
+  - No extraction target exists — no valid >2h PB1 cluster found
+  - A4 remains FAIL; regime_segments cannot be populated from PB1 window-bank alone
+  - Broader paper-strategy clusters exist (23h+, 25h+) but are NOT PB1 evidence
+limitations:
+  - Readonly DB session only; no Docker/runtime/backfill/replay executed
+  - No secrets printed, committed, or inspected
+  - No DB mutations performed
+```
+
+---
+
+## 2. Bootloader / Read-Order
+
+Canonical read-order executed per `agents/AGENTS.md`:
+
+1. `knowledge/governance/CDB_CONSTITUTION.md`
+2. `knowledge/governance/CDB_GOVERNANCE.md`
+3. `knowledge/governance/CDB_AGENT_POLICY.md`
+4. `knowledge/governance/SYSTEM_INVARIANTS.md`
+5. `knowledge/CDB_KNOWLEDGE_HUB.md`
+6. `docs/meta/WORKING_REPO_CANON.md`
+7. `CURRENT_STATUS.md`
+8. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+9. `docs/runbooks/CONTROL_REGISTER.md`
+10. `agents/OPEN_CODE_AGENTS.md`
+
+Verified boundaries:
+
+- `CURRENT_STATUS.md` treated as ledger, not live truth.
+- LR SSOT remains `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` (NO-GO).
+- Board stage `trade-capable` is not Live-Go.
+- No secret values printed, committed, or inspected.
+
+---
+
+## 3. Live-Lage
+
+| Item | Status |
+|------|--------|
+| HEAD / origin/main | `b7198371` / equal |
+| Working tree | clean (+2 untracked dirs `.opencode/plans/`, `docs/decisions/`) |
+| Open PRs | **0** |
+| #3343 | OPEN (body fresh) |
+| #1900 | OPEN (reconciled 2026-06-19) |
+| #2985 | OPEN (comment posted 2026-06-19) |
+| #2977 | OPEN/BLOCKED (correct) |
+| LR | **NO-GO** |
+| Board | `trade-capable` ≠ Live-Go |
+
+No live-truth conflict found.
+
+---
+
+## 4. Database Access Verification
+
+| Check | Result |
+|-------|--------|
+| DSN available | `POSTGRES_READONLY_PASSWORD_DSN` set |
+| Identity | `cdb_readonly` / `cdb_readonly` |
+| Database | `claire_de_binare` |
+| SELECT on `correlation_ledger` | true |
+| INSERT on `correlation_ledger` | false |
+| UPDATE on `correlation_ledger` | false |
+| DELETE on `correlation_ledger` | false |
+| Total rows | 34,256 |
+| primary_breakout_v1/BTCUSDT rows | 783 |
+| Paper strategy/BTCUSDT rows | 16,345 |
+| Date range | 2026-02-15 to 2026-06-06 |
+
+Readonly session confirmed. No mutations performed.
+
+---
+
+## 5. primary_breakout_v1 — Cluster Verification
+
+### 5.1 Cluster Detection Method
+
+- **Source:** `public.correlation_ledger` filtered by `payload->>strategy_id='primary_breakout_v1'` and `symbol='BTCUSDT'`
+- **Gap threshold:** 1 hour without events = new cluster
+- **Script:** `scripts/_3343_verify_pb1_clusters.py` (committed, deterministic, readonly)
+
+### 5.2 Every PB1 Cluster
+
+| # | Start UTC | End UTC | Duration | Events | Chains | SIG | DEC | ORD | FILL | Has Trade? | Verdict |
+|---|-----------|---------|----------|--------|--------|-----|-----|-----|------|------------|---------|
+| 1 | 2026-04-23T14:58:55 | 2026-04-23T16:47:41 | 1.813h (108.8min) | 767 | 767 | 767 | 0 | 0 | 0 | **No** | EXCLUDE — <2h, no DECISION, no trades |
+| 2 | 2026-04-24T00:42:34 | 2026-04-24T00:42:34 | 0.000h (0s) | 2 | 1 | 0 | 0 | 1 | 1 | Yes | EXCLUDE — instant, no DECISION |
+| 3 | 2026-06-05T14:57:55 | 2026-06-05T14:57:55 | 0.000h (0s) | 2 | 1 | 0 | 0 | 1 | 1 | Yes | EXCLUDE — instant, no DECISION |
+| 4 | 2026-06-05T23:17:03 | 2026-06-06T00:29:12 | **1.203h (72.2min)** | 10 | 5 | 5 | 0 | 3 | 2 | Yes | EXCLUDE — <2h, no DECISION |
+| 5 | 2026-06-06T03:31:54 | 2026-06-06T03:31:54 | 0.000h (0s) | 2 | 1 | 0 | 0 | 1 | 1 | Yes | EXCLUDE — instant, no DECISION |
+
+### 5.3 Key Observations
+
+1. **Max PB1 cluster (with trades):** 72.2min (Cluster 4) — the existing 3-window bank.
+2. **Max PB1 cluster (overall):** 108.8min (Cluster 1) — SIGNAL-only, zero paper trades.
+3. **No cluster exceeds 2h.** The closest is Cluster 1 at 1.813h, still 11min short.
+4. **No DECISION events** are directly stored with `strategy_id=primary_breakout_v1`. All 17,126 DECISION events have `strategy_id=NULL`. They are linked via correlation_id but stored under the generic paper framework.
+5. **Cluster 1** (767 SIGNALs) represents signals generated during the 14-day paper phase (#1784) that never resulted in paper trades. These signals lack DECISION/ORDER/FILL chains and are not comparison-grade window material.
+
+### 5.4 Comparison with Existing Window Bank
+
+| Window | Source Cluster | Duration | Chains | Part of PB1 Bank? |
+|--------|---------------|----------|--------|-------------------|
+| Pilot 1m | Cluster 2 | ~0s (instant ORDER+FILL) | 1 | Yes (docs-backed) |
+| #3028 2m | Cluster 4 | 2min (within 72min span) | 1 | Yes (artifact) |
+| June 6 1h | Cluster 4 | 52.6min data span | 4 | Yes (artifact) |
+| Any >2h window | **none** | — | — | **No candidate exists** |
+
+---
+
+## 6. Broader Paper-Strategy Clusters (NOT PB1 Evidence)
+
+The correlation_ledger also contains events with `payload->>strategy_id='paper'`. These are listed separately because:
+
+- Strategy ID is `paper`, not `primary_breakout_v1`
+- Cannot be used for PB1 strategy replay (replay engine expects PB1 strategy_id)
+- Not comparable to existing PB1 window bank
+- **Not admissible as PB1 window-bank evidence per #3343 scope**
+
+| # | Start UTC | End UTC | Duration | Events | Chains | SIG | ORD | FILL | Note |
+|---|-----------|---------|----------|--------|--------|-----|-----|------|------|
+| 1 | 2026-02-15T20:57:39 | 2026-02-16T20:21:16 | **23.4h** | 6609 | 6608 | 6607 | 1 | 1 | Only 1 trade across 23h |
+| 2 | 2026-03-06T19:35:35 | 2026-03-06T19:37:10 | 0.0h | 6 | 3 | 0 | 3 | 3 | 3 isolated ORDER+FILL pairs |
+| 3 | 2026-03-12T14:28:43 | 2026-03-12T22:43:06 | 8.2h | 2650 | 2650 | 2650 | 0 | 0 | SIGNAL-only, no trades |
+| 4 | 2026-03-23T15:49:14 | 2026-03-24T17:18:11 | **25.5h** | 7080 | 7080 | 7080 | 0 | 0 | SIGNAL-only, no trades |
+
+**Key observation:** Even the paper strategy has only **4 ORDER + 4 FILL events total** across the entire DB (Feb-Jun 2026). The 23h+ clusters exist only as SIGNAL-density blocks, not trade-dense windows. The paper strategy fires signals at ~5-10/min during active hours, but very rarely produces paper orders/fills.
+
+---
+
+## 7. Selection Contract Review
+
+| Rule | Status |
+|------|--------|
+| Minimum >2h window duration | **No candidate meets this** |
+| `strategy_id=primary_breakout_v1` | All verified clusters use this |
+| `symbol=BTCUSDT` | All verified clusters use this |
+| Non-overlapping with existing bank | Irrelevant — no candidate exists |
+| SIGNAL anchor present | Clusters 1 and 4 have SIGNALs; 2, 3, 5 are ORDER+FILL only |
+| Paper-qualified ORDER (`paper_` prefix) | Clusters 2, 3, 4, 5 have paper-prefixed ORDERs |
+| Data density: ≥2 chains per window | Clusters 1 (767), 4 (5) meet this |
+| No cherry-picking | **Guaranteed**: all clusters listed above exhaustively |
+
+---
+
+## 8. Impact on A2/A3/A4 Readiness
+
+| Workstream | Previous Status | Current Status | Change |
+|------------|----------------|----------------|--------|
+| A2 Batch Compare | PASS | PASS | Unchanged |
+| A3 Calibration + Drift | WARN | WARN | Unchanged |
+| A4 Regime Interpretation | FAIL | FAIL | **Unchanged — no new evidence** |
+
+This slice does not change any ARVP readiness assessment. The window bank remains at 3 windows (all <2h, none with `regime_segments`). A4 remains FAIL because no longer natural-paper window exists to produce continuous price data for regime segmentation.
+
+---
+
+## 9. Final Verdict
+
+**`HOLD_NO_VALID_PRIMARY_BREAKOUT_WINDOWS`**
+
+The correlation_ledger does **not** contain a `primary_breakout_v1`/BTCUSDT cluster meeting the >2h minimum duration requirement with full SIGNAL→DECISION→ORDER→FILL chain integrity.
+
+- **Max PB1 cluster with trade chain:** 72.2min (Cluster 4, June 5-6)
+- **Max PB1 cluster overall:** 108.8min (Cluster 1, April 23 — signal-only, no trades)
+- **PB1 window-bank extraction path:** exhausted from existing data
+
+Broader paper-strategy clusters (23h+, 25h+) exist in the DB but:
+- Have strategy_id=`paper`, not `primary_breakout_v1`
+- Contain only 4 ORDER/FILL events across the entire dataset
+- Are not admissible as PB1 evidence
+- Would require scope change and new strategy replay adapter to be usable
+
+**No promotable candidate exists. No Product-Complete claim. LR remains NO-GO.**
+
+---
+
+## 10. Next Options (for Jannek/Control)
+
+| Option | Scope | GO Required? |
+|--------|-------|-------------|
+| Accept 3-window bank as "best available", close #3343 HOLD | None | No |
+| Plan new primary_breakout_v1 paper trading run for longer windows | Docker + Runtime + Paper mode | Yes (separate GO) |
+| Expand scope to broader paper-strategy windows (sid=paper) | Scope change + adapter work | Yes (separate GO) |
+| Deprecate primary_breakout_v1 ARVP path entirely | Strategic decision | Yes (Control-level) |
+
+---
+
+## 11. Boundaries
+
+- LR remains **NO-GO**
+- Board stage `trade-capable` is not Live-Go
+- No Live-Go, No Echtgeld-Go
+- No Candidate #4 initiated or implied
+- No PB1/RMR/Momentum rescue
+- No Product-Complete claim
+- No runtime/Docker/backfill/replay executed
+- No DB mutations performed
+- No secrets in output
+
+---
+
+## 12. Restunsicherheiten
+
+1. The 14-day paper phase (#1784) ran with `primary_breakout_v1` strategy, but its events are stored under `sid=paper`, not `sid=primary_breakout_v1`. Whether those events could be retroactively linked to PB1 window-bank evidence is a DB schema question outside this slice.
+2. All DECISION events (17,126) have `strategy_id=NULL`. The paper framework DECISION events are linked to SIGNAL events via correlation_id, not via explicit strategy_id in the payload. Building PB1 evidence from these would require JOIN-based reconstruction.
+3. Even if paper-strategy windows were admitted, their trade density is extremely low (4 trades across 3 months). A 23h window with 1 trade is not meaningfully "comparison-grade" for replay.
+4. The inventory `scripts/_3343_inventory_windows.py` uses a 1h gap threshold. A different gap threshold might produce different cluster boundaries, but no threshold change would create >2h clusters with trades — the data simply isn't there.
+
+---
+
+## 13. Status
+
+**`DONE_MERGED_CLOSED_HOLD_NO_VALID_PRIMARY_BREAKOUT_WINDOWS`**

--- a/scripts/_3343_inventory_windows.py
+++ b/scripts/_3343_inventory_windows.py
@@ -1,0 +1,457 @@
+"""Readonly correlation_ledger inventory for #3343 window-bank expansion.
+
+Safe usage:
+  SET POSTGRES_READONLY_PASSWORD_DSN=postgresql://...
+  python scripts/_3343_inventory_windows.py
+
+Output: aggregated window candidates; no DSN/secret values printed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import psycopg2
+
+_READONLY_DSN_ENV = "POSTGRES_READONLY_PASSWORD_DSN"
+_EXPECTED_READONLY_LOGIN = "cdb_readonly"
+
+_MIN_WINDOW_MS = 7_200_000  # 2 hours
+_STRATEGY_ID = "primary_breakout_v1"
+_SYMBOL = "BTCUSDT"
+
+
+def _get_readonly_dsn() -> str:
+    dsn = os.getenv(_READONLY_DSN_ENV)
+    if not dsn or not dsn.strip():
+        raise RuntimeError(f"{_READONLY_DSN_ENV} is required")
+    return dsn.strip()
+
+
+def _verify_identity(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute("SELECT current_user, session_user")
+        row = cur.fetchone()
+    if (
+        not row
+        or row[0] != _EXPECTED_READONLY_LOGIN
+        or row[1] != _EXPECTED_READONLY_LOGIN
+    ):
+        raise RuntimeError(
+            f"Identity mismatch: {row}, expected {_EXPECTED_READONLY_LOGIN}"
+        )
+
+
+def _verify_readonly(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT has_table_privilege(current_user, 'public.correlation_ledger', 'SELECT'),"
+            " has_table_privilege(current_user, 'public.correlation_ledger', 'INSERT'),"
+            " has_table_privilege(current_user, 'public.correlation_ledger', 'UPDATE'),"
+            " has_table_privilege(current_user, 'public.correlation_ledger', 'DELETE')"
+        )
+        row = cur.fetchone()
+    if not row or not row[0]:
+        raise RuntimeError("Missing SELECT on correlation_ledger")
+    if row[1] or row[2] or row[3]:
+        raise RuntimeError("Write privileges detected on correlation_ledger")
+
+
+def _inventory_hourly(conn) -> list[dict]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+              date_trunc('hour', to_timestamp(timestamp_ms::double precision / 1000)) AS hour_bucket,
+              event_type,
+              COUNT(*) AS cnt,
+              COUNT(DISTINCT correlation_id) AS distinct_chains,
+              MIN(timestamp_ms) AS first_ts_ms,
+              MAX(timestamp_ms) AS last_ts_ms
+            FROM public.correlation_ledger
+            WHERE payload->>'strategy_id' = %s
+              AND symbol = %s
+            GROUP BY hour_bucket, event_type
+            ORDER BY hour_bucket, event_type
+            """,
+            (_STRATEGY_ID, _SYMBOL),
+        )
+        colnames = [d.name for d in cur.description]
+        cols_lower = [c.lower() for c in colnames]
+        rows = [dict(zip(cols_lower, r, strict=True)) for r in cur.fetchall()]
+    return rows
+
+
+def _inventory_candidate_windows(conn) -> list[dict]:
+    """Find contiguous event clusters (>2h) via gap detection (>1h gap = new cluster).
+
+    This avoids aggregating the entire dataset into one pseudo-window.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            WITH numbered AS (
+              SELECT
+                timestamp_ms,
+                event_type,
+                correlation_id,
+                LAG(timestamp_ms) OVER (ORDER BY timestamp_ms) AS prev_ts_ms
+              FROM public.correlation_ledger
+              WHERE payload->>'strategy_id' = %s
+                AND symbol = %s
+            ),
+            gaps AS (
+              SELECT
+                timestamp_ms,
+                CASE WHEN prev_ts_ms IS NULL
+                      OR timestamp_ms - prev_ts_ms > 3600000  -- 1h gap = new cluster
+                     THEN 1 ELSE 0 END AS new_cluster
+              FROM numbered
+            ),
+            clustered AS (
+              SELECT
+                timestamp_ms,
+                SUM(new_cluster) OVER (ORDER BY timestamp_ms) AS cluster_id
+              FROM gaps
+            ),
+            cluster_stats AS (
+              SELECT
+                cluster_id,
+                MIN(timestamp_ms) AS min_ts_ms,
+                MAX(timestamp_ms) AS max_ts_ms,
+                MAX(timestamp_ms) - MIN(timestamp_ms) AS span_ms,
+                COUNT(*) AS total_events,
+                COUNT(DISTINCT n.correlation_id) AS total_chains,
+                COUNT(*) FILTER (WHERE n.event_type = 'SIGNAL') AS signal_count,
+                COUNT(*) FILTER (WHERE n.event_type = 'DECISION') AS decision_count,
+                COUNT(*) FILTER (WHERE n.event_type = 'ORDER') AS order_count,
+                COUNT(*) FILTER (WHERE n.event_type = 'FILL') AS fill_count
+              FROM clustered c
+              JOIN numbered n ON n.timestamp_ms = c.timestamp_ms
+              GROUP BY cluster_id
+            )
+            SELECT
+              min_ts_ms,
+              max_ts_ms,
+              span_ms,
+              total_events,
+              total_chains,
+              signal_count,
+              decision_count,
+              order_count,
+              fill_count
+            FROM cluster_stats
+            WHERE span_ms >= %s
+            ORDER BY min_ts_ms ASC
+            """,
+            (_STRATEGY_ID, _SYMBOL, _MIN_WINDOW_MS),
+        )
+        colnames = [d.name for d in cur.description]
+        cols_lower = [c.lower() for c in colnames]
+        rows = [dict(zip(cols_lower, r, strict=True)) for r in cur.fetchall()]
+    return rows
+
+
+def _inventory_all_clusters(conn) -> tuple[list[dict], list[dict]]:
+    """Find ALL contiguous event clusters regardless of duration.
+
+    Returns (over_2h, under_2h) lists.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            WITH numbered AS (
+              SELECT
+                timestamp_ms,
+                event_type,
+                correlation_id,
+                LAG(timestamp_ms) OVER (ORDER BY timestamp_ms) AS prev_ts_ms
+              FROM public.correlation_ledger
+              WHERE payload->>'strategy_id' = %s
+                AND symbol = %s
+            ),
+            gaps AS (
+              SELECT
+                timestamp_ms,
+                event_type,
+                correlation_id,
+                CASE WHEN prev_ts_ms IS NULL
+                      OR timestamp_ms - prev_ts_ms > 3600000
+                     THEN 1 ELSE 0 END AS new_cluster
+              FROM numbered
+            ),
+            clustered AS (
+              SELECT
+                timestamp_ms,
+                event_type,
+                correlation_id,
+                SUM(new_cluster) OVER (ORDER BY timestamp_ms) AS cluster_id
+              FROM gaps
+            ),
+            cluster_stats AS (
+              SELECT
+                cluster_id,
+                MIN(timestamp_ms) AS min_ts_ms,
+                MAX(timestamp_ms) AS max_ts_ms,
+                MAX(timestamp_ms) - MIN(timestamp_ms) AS span_ms,
+                COUNT(*) AS total_events,
+                COUNT(DISTINCT correlation_id) AS total_chains,
+                COUNT(*) FILTER (WHERE event_type = 'SIGNAL') AS signal_count,
+                COUNT(*) FILTER (WHERE event_type = 'DECISION') AS decision_count,
+                COUNT(*) FILTER (WHERE event_type = 'ORDER') AS order_count,
+                COUNT(*) FILTER (WHERE event_type = 'FILL') AS fill_count
+              FROM clustered
+              GROUP BY cluster_id
+            )
+            SELECT
+              cluster_id,
+              min_ts_ms,
+              max_ts_ms,
+              span_ms,
+              total_events,
+              total_chains,
+              signal_count,
+              decision_count,
+              order_count,
+              fill_count
+            FROM cluster_stats
+            WHERE span_ms >= %s
+            ORDER BY min_ts_ms ASC
+            """,
+            (_STRATEGY_ID, _SYMBOL, _MIN_WINDOW_MS),
+        )
+        colnames = [d.name for d in cur.description]
+        cols_lower = [c.lower() for c in colnames]
+        over_2h = [dict(zip(cols_lower, r, strict=True)) for r in cur.fetchall()]
+
+        cur.execute(
+            """
+            WITH numbered AS (
+              SELECT
+                timestamp_ms,
+                event_type,
+                correlation_id,
+                LAG(timestamp_ms) OVER (ORDER BY timestamp_ms) AS prev_ts_ms
+              FROM public.correlation_ledger
+              WHERE payload->>'strategy_id' = %s
+                AND symbol = %s
+            ),
+            gaps AS (
+              SELECT
+                timestamp_ms,
+                event_type,
+                correlation_id,
+                CASE WHEN prev_ts_ms IS NULL
+                      OR timestamp_ms - prev_ts_ms > 3600000
+                     THEN 1 ELSE 0 END AS new_cluster
+              FROM numbered
+            ),
+            clustered AS (
+              SELECT
+                timestamp_ms,
+                event_type,
+                correlation_id,
+                SUM(new_cluster) OVER (ORDER BY timestamp_ms) AS cluster_id
+              FROM gaps
+            ),
+            cluster_stats AS (
+              SELECT
+                cluster_id,
+                MIN(timestamp_ms) AS min_ts_ms,
+                MAX(timestamp_ms) AS max_ts_ms,
+                MAX(timestamp_ms) - MIN(timestamp_ms) AS span_ms,
+                COUNT(*) AS total_events,
+                COUNT(DISTINCT correlation_id) AS total_chains,
+                COUNT(*) FILTER (WHERE event_type = 'SIGNAL') AS signal_count,
+                COUNT(*) FILTER (WHERE event_type = 'DECISION') AS decision_count,
+                COUNT(*) FILTER (WHERE event_type = 'ORDER') AS order_count,
+                COUNT(*) FILTER (WHERE event_type = 'FILL') AS fill_count
+              FROM clustered
+              GROUP BY cluster_id
+            )
+            SELECT
+              cluster_id,
+              min_ts_ms,
+              max_ts_ms,
+              span_ms,
+              total_events,
+              total_chains,
+              signal_count,
+              decision_count,
+              order_count,
+              fill_count
+            FROM cluster_stats
+            WHERE span_ms < %s
+            ORDER BY min_ts_ms ASC
+            """,
+            (_STRATEGY_ID, _SYMBOL, _MIN_WINDOW_MS),
+        )
+        cols_lower = [c.lower() for c in colnames]
+        under_2h = [dict(zip(cols_lower, r, strict=True)) for r in cur.fetchall()]
+
+    return over_2h, under_2h
+
+
+def _inventory_by_day(conn) -> list[dict]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+              date_trunc('day', to_timestamp(timestamp_ms::double precision / 1000)) AS day_bucket,
+              COUNT(*) AS total_events,
+              COUNT(DISTINCT correlation_id) AS total_chains,
+              COUNT(*) FILTER (WHERE event_type = 'SIGNAL') AS signal_count,
+              COUNT(*) FILTER (WHERE event_type = 'FILL') AS fill_count,
+              MIN(timestamp_ms) AS first_ts_ms,
+              MAX(timestamp_ms) AS last_ts_ms,
+              MAX(timestamp_ms) - MIN(timestamp_ms) AS span_ms
+            FROM public.correlation_ledger
+            WHERE payload->>'strategy_id' = %s
+              AND symbol = %s
+            GROUP BY day_bucket
+            ORDER BY day_bucket
+            """,
+            (_STRATEGY_ID, _SYMBOL),
+        )
+        colnames = [d.name for d in cur.description]
+        cols_lower = [c.lower() for c in colnames]
+        rows = [dict(zip(cols_lower, r, strict=True)) for r in cur.fetchall()]
+    return rows
+
+
+def _existing_windows_ms() -> list[tuple[int, int, str]]:
+    """Define existing windows to avoid overlap."""
+    return [
+        # Pilot 1m: 2026-04-24T00:42:00Z to 2026-04-24T00:43:00Z
+        (1713919320000, 1713919380000, "pilot_1m"),
+        # #3028 2m: 2026-06-06T00:28:12.551Z to 2026-06-06T00:30:12.814Z
+        (1780705692551, 1780705812814, "3028_2m"),
+        # June6 1h: 2026-06-05T23:30:00Z to 2026-06-06T00:30:00Z
+        (1780702200000, 1780705800000, "june6_1h"),
+    ]
+
+
+def _format_ts(ts_ms: int) -> str:
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).isoformat()
+
+
+def main() -> int:
+    dsn = _get_readonly_dsn()
+    conn = psycopg2.connect(dsn, connect_timeout=10)
+    try:
+        db_name = None
+        with conn.cursor() as cur:
+            cur.execute("SELECT current_database()")
+            db_name = cur.fetchone()[0]
+
+        _verify_identity(conn)
+        _verify_readonly(conn)
+
+        print(f"=== #3343 Window-Bank Inventory ===")
+        print(f"Database: {db_name}")
+        print(f"Strategy: {_STRATEGY_ID}, Symbol: {_SYMBOL}")
+        print(f"Min window: {_MIN_WINDOW_MS}ms ({_MIN_WINDOW_MS/3600000:.1f}h)")
+        print()
+
+        # 1. Hourly distribution
+        hourly = _inventory_hourly(conn)
+        print("--- Hourly Event Distribution ---")
+        print(
+            f"{'Hour (UTC)':<22} {'Event Type':<12} {'Count':<8} {'Chains':<8} {'Span':<10}"
+        )
+        print("-" * 60)
+        current_hour = None
+        for row in hourly:
+            hb = str(row["hour_bucket"])
+            if hb != current_hour:
+                if current_hour is not None:
+                    print()
+                current_hour = hb
+            span_ms = (
+                int(row["last_ts_ms"]) - int(row["first_ts_ms"])
+                if row["last_ts_ms"] and row["first_ts_ms"]
+                else 0
+            )
+            print(
+                f"{hb:<22} {str(row['event_type']):<12} {int(row['cnt']):<8} {int(row['distinct_chains']):<8} {span_ms/1000:.1f}s"
+            )
+        print()
+
+        # 2. By-day overview
+        daily = _inventory_by_day(conn)
+        print("--- Daily Overview ---")
+        print(
+            f"{'Day (UTC)':<22} {'Events':<8} {'Chains':<8} {'SIGNAL':<8} {'FILL':<8} {'Span':<12}"
+        )
+        print("-" * 66)
+        for row in daily:
+            span_h = int(row["span_ms"]) / 3600000 if row["span_ms"] else 0
+            print(
+                f"{str(row['day_bucket']):<22} {int(row['total_events']):<8} {int(row['total_chains']):<8} {int(row['signal_count']):<8} {int(row['fill_count']):<8} {span_h:.1f}h"
+            )
+        print()
+
+        # 3. All clusters
+        over_2h, under_2h = _inventory_all_clusters(conn)
+        existing = _existing_windows_ms()
+
+        print(f"--- All Event Clusters (>{_MIN_WINDOW_MS/3600000:.0f}h) ---")
+        print(
+            f"{'#':<4} {'Start (UTC)':<26} {'End (UTC)':<26} {'Span(h)':<9} {'Events':<8} {'Chains':<8} {'SIG':<6} {'DEC':<6} {'ORD':<6} {'FILL':<6}"
+        )
+        print("-" * 115)
+        if not over_2h:
+            print("  NO CLUSTERS >2h found.")
+        for c in over_2h:
+            start_ts = _format_ts(c["min_ts_ms"])
+            end_ts = _format_ts(c["max_ts_ms"])
+            span_h = c["span_ms"] / 3600000
+            print(
+                f"{int(c['cluster_id']):<4} {start_ts:<26} {end_ts:<26} {span_h:<9.1f} {int(c['total_events']):<8} {int(c['total_chains']):<8} {int(c['signal_count']):<6} {int(c['decision_count']):<6} {int(c['order_count']):<6} {int(c['fill_count']):<6}"
+            )
+        print()
+
+        print("--- Sub-2h Clusters ---")
+        print(
+            f"{'#':<4} {'Start (UTC)':<26} {'End (UTC)':<26} {'Span(min)':<11} {'Events':<8} {'Chains':<8} {'SIG':<6} {'DEC':<6} {'ORD':<6} {'FILL':<6} {'Overlap':<12}"
+        )
+        print("-" * 128)
+        if not under_2h:
+            print("  NO sub-2h clusters found.")
+        for c in under_2h:
+            start_ts = _format_ts(c["min_ts_ms"])
+            end_ts = _format_ts(c["max_ts_ms"])
+            span_min = c["span_ms"] / 60000
+            overlap_str = "none"
+            for es, ee, en in existing:
+                if c["min_ts_ms"] < ee and c["max_ts_ms"] > es:
+                    overlap_str = f"overlaps {en}"
+                    break
+            print(
+                f"{int(c['cluster_id']):<4} {start_ts:<26} {end_ts:<26} {span_min:<11.1f} {int(c['total_events']):<8} {int(c['total_chains']):<8} {int(c['signal_count']):<6} {int(c['decision_count']):<6} {int(c['order_count']):<6} {int(c['fill_count']):<6} {overlap_str:<12}"
+            )
+        print()
+
+        # 4. Existing windows for reference
+        print("--- Existing Window Bank ---")
+        print(f"{'Name':<12} {'Start (UTC)':<28} {'End (UTC)':<28} {'Span'}")
+        print("-" * 80)
+        for es, ee, en in existing:
+            print(
+                f"{en:<12} {_format_ts(es):<28} {_format_ts(ee):<28} {(ee-es)/3600000:.2f}h"
+            )
+
+        print()
+        print("--- Inventory Complete ---")
+        print("No secrets printed. No DB mutations. Readonly session closed.")
+    finally:
+        conn.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/_3343_verify_pb1_clusters.py
+++ b/scripts/_3343_verify_pb1_clusters.py
@@ -1,0 +1,259 @@
+"""Readonly PB1 cluster verification for #3343.
+
+Safe: reads POSTGRES_READONLY_PASSWORD_DSN from env, never prints it.
+"""
+
+from __future__ import annotations
+import os
+import sys
+from datetime import datetime, timezone
+
+import psycopg2
+
+_READONLY_DSN_ENV = "POSTGRES_READONLY_PASSWORD_DSN"
+_EXPECTED_READONLY_LOGIN = "cdb_readonly"
+
+
+def fmt(ts_ms: int) -> str:
+    return datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc).isoformat()
+
+
+def main() -> int:
+    dsn = os.getenv(_READONLY_DSN_ENV)
+    if not dsn or not dsn.strip():
+        print("FATAL: POSTGRES_READONLY_PASSWORD_DSN not set")
+        return 1
+
+    conn = psycopg2.connect(dsn.strip(), connect_timeout=10)
+    cur = conn.cursor()
+
+    # identity
+    cur.execute("SELECT current_database(), current_user, session_user")
+    row = cur.fetchone()
+    db_name, cu, su = row
+    print(f"Connected: db={db_name}, user={cu}, session={su}")
+    assert (
+        cu == _EXPECTED_READONLY_LOGIN and su == _EXPECTED_READONLY_LOGIN
+    ), "Identity fail"
+
+    # readonly
+    cur.execute(
+        """SELECT has_table_privilege(current_user, 'public.correlation_ledger', 'SELECT'),
+                          has_table_privilege(current_user, 'public.correlation_ledger', 'INSERT')"""
+    )
+    sel, ins = cur.fetchone()
+    assert sel, "SELECT not granted"
+    assert not ins, "INSERT should be false"
+    print("Privileges: SELECT=OK, INSERT=BLOCKED")
+    print()
+
+    # ========================================================================
+    # 1) EVERY primary_breakout_v1 event sorted by timestamp
+    # ========================================================================
+    cur.execute("""
+        SELECT event_pk, timestamp_ms, event_type, correlation_id, signal_id, order_id, fill_id
+        FROM public.correlation_ledger
+        WHERE payload->>'strategy_id' = 'primary_breakout_v1'
+          AND symbol = 'BTCUSDT'
+        ORDER BY timestamp_ms ASC, event_pk ASC
+    """)
+    colnames = [d.name for d in cur.description]
+    all_rows = [dict(zip(colnames, r)) for r in cur.fetchall()]
+    print(f"Total primary_breakout_v1/BTCUSDT rows: {len(all_rows)}")
+    print()
+
+    # ========================================================================
+    # 2) Cluster detection (gap > 1h = new cluster)
+    # ========================================================================
+    clusters = []
+    current_cluster = None
+    for r in all_rows:
+        ts = r["timestamp_ms"]
+        if current_cluster is None:
+            current_cluster = {
+                "min_ts": ts,
+                "max_ts": ts,
+                "events": [],
+                "signal_ids": set(),
+                "correlation_ids": set(),
+                "order_ids": set(),
+                "fill_ids": set(),
+                "has_trade": False,
+            }
+        else:
+            if ts - current_cluster["max_ts"] > 3_600_000:
+                clusters.append(current_cluster)
+                current_cluster = {
+                    "min_ts": ts,
+                    "max_ts": ts,
+                    "events": [],
+                    "signal_ids": set(),
+                    "correlation_ids": set(),
+                    "order_ids": set(),
+                    "fill_ids": set(),
+                    "has_trade": False,
+                }
+            else:
+                if ts > current_cluster["max_ts"]:
+                    current_cluster["max_ts"] = ts
+
+        current_cluster["events"].append(r)
+        current_cluster["correlation_ids"].add(r["correlation_id"])
+        if r["event_type"] == "SIGNAL" and r["signal_id"]:
+            current_cluster["signal_ids"].add(r["signal_id"])
+        if r["event_type"] == "ORDER" and r["order_id"]:
+            current_cluster["order_ids"].add(r["order_id"])
+            current_cluster["has_trade"] = True
+        if r["event_type"] == "FILL" and r["fill_id"]:
+            current_cluster["fill_ids"].add(r["fill_id"])
+            current_cluster["has_trade"] = True
+
+    if current_cluster is not None:
+        clusters.append(current_cluster)
+
+    # ========================================================================
+    # 3) Report each cluster
+    # ========================================================================
+    print("=" * 120)
+    print("PRIMARY_BREAKOUT_V1 — ALL CLUSTERS (gap threshold = 1h)")
+    print("=" * 120)
+    print()
+
+    for idx, c in enumerate(clusters, 1):
+        span_s = (c["max_ts"] - c["min_ts"]) / 1000
+        span_h = span_s / 3600
+        min_ts_dt = fmt(c["min_ts"])
+        max_ts_dt = fmt(c["max_ts"])
+
+        # Count event types
+        type_counts = {}
+        for e in c["events"]:
+            et = e["event_type"]
+            type_counts[et] = type_counts.get(et, 0) + 1
+
+        sig_cnt = type_counts.get("SIGNAL", 0)
+        dec_cnt = type_counts.get("DECISION", 0)
+        ord_cnt = type_counts.get("ORDER", 0)
+        fill_cnt = type_counts.get("FILL", 0)
+        total_ev = len(c["events"])
+        total_corr = len(c["correlation_ids"])
+
+        # Check if cluster contains DECISION events (they have sid=NULL)
+        has_decision = dec_cnt > 0
+        has_trade = c["has_trade"]
+
+        # Inclusion/exclusion verdict
+        reasons = []
+        if span_h < 2:
+            reasons.append(f"duration={span_h:.1f}h < 2h minimum")
+        if not has_decision:
+            reasons.append("no DECISION events")
+        if not has_trade:
+            reasons.append("no ORDER/FILL chain")
+        if total_corr < 1:
+            reasons.append("zero correlation_ids")
+        verdict = "EXCLUDE" if reasons else "INCLUDE"
+        print(f"--- Cluster {idx} ---")
+        print(f"  Start UTC:       {min_ts_dt}")
+        print(f"  End UTC:         {max_ts_dt}")
+        print(f"  Duration:        {span_h:.3f}h ({span_s:.1f}s)")
+        print(
+            f"  Source:          public.correlation_ledger (payload->>strategy_id=primary_breakout_v1, symbol=BTCUSDT)"
+        )
+        print(f"  Total events:    {total_ev}")
+        print(f"  Total chains:    {total_corr} (unique correlation_ids)")
+        print(
+            f"  Event breakdown: SIGNAL={sig_cnt} DECISION={dec_cnt} ORDER={ord_cnt} FILL={fill_cnt}"
+        )
+        print(f"  Has trade chain: {has_trade}")
+        print(f"  Verdict:         {verdict}")
+        if reasons:
+            print(f"  Exclusion due to: {'; '.join(reasons)}")
+        print()
+
+    # ========================================================================
+    # 4) Summary verdict for entire PB1 path
+    # ========================================================================
+    max_cluster = max(clusters, key=lambda c: c["max_ts"] - c["min_ts"])
+    max_span_h = (max_cluster["max_ts"] - max_cluster["min_ts"]) / 3_600_000
+    print("=" * 60)
+    print("PB1 WINDOW-BANK PATH VERDICT")
+    print("=" * 60)
+    print(f"  Max PB1 cluster duration: {max_span_h:.3f}h ({max_span_h*60:.1f}min)")
+    print(f"  Target minimum:           2.000h")
+    print(f"  Gap to target:            {2.0 - max_span_h:.3f}h")
+    print()
+    if max_span_h < 2.0:
+        print("  RESULT: HOLD_NO_VALID_PRIMARY_BREAKOUT_WINDOWS")
+        print(
+            "  Reason: No primary_breakout_v1 cluster > 2h found in correlation_ledger."
+        )
+    else:
+        print("  RESULT: CANDIDATE_FOUND — see cluster table above.")
+    print()
+
+    # ========================================================================
+    # 5) Separate: broader paper-strategy clusters (NOT PB1 evidence)
+    # ========================================================================
+    print("=" * 120)
+    print("PAPER STRATEGY — SEPARATE REFERENCE (NOT PB1 evidence)")
+    print("=" * 120)
+    print()
+
+    cur.execute("""
+        WITH numbered AS (
+          SELECT timestamp_ms, event_type, correlation_id,
+            LAG(timestamp_ms) OVER (ORDER BY timestamp_ms) AS prev_ts_ms
+          FROM public.correlation_ledger
+          WHERE payload->>'strategy_id' = 'paper'
+            AND symbol = 'BTCUSDT'
+        ),
+        gaps AS (
+          SELECT timestamp_ms, event_type, correlation_id,
+            CASE WHEN prev_ts_ms IS NULL OR timestamp_ms - prev_ts_ms > 3600000 THEN 1 ELSE 0 END AS new_cluster
+          FROM numbered
+        ),
+        clustered AS (
+          SELECT timestamp_ms, event_type, correlation_id,
+            SUM(new_cluster) OVER (ORDER BY timestamp_ms) AS cluster_id
+          FROM gaps
+        )
+        SELECT
+          cluster_id,
+          MIN(timestamp_ms) AS min_ts_ms,
+          MAX(timestamp_ms) AS max_ts_ms,
+          MAX(timestamp_ms) - MIN(timestamp_ms) AS span_ms,
+          COUNT(*) AS total_events,
+          COUNT(DISTINCT correlation_id) AS total_chains,
+          COUNT(*) FILTER (WHERE event_type = 'SIGNAL') AS signal_count,
+          COUNT(*) FILTER (WHERE event_type = 'ORDER') AS order_count,
+          COUNT(*) FILTER (WHERE event_type = 'FILL') AS fill_count
+        FROM clustered
+        GROUP BY cluster_id
+        ORDER BY cluster_id
+    """)
+    colnames_p = [d.name for d in cur.description]
+    for r in cur.fetchall():
+        row = dict(zip(colnames_p, r))
+        span_h = row["span_ms"] / 3_600_000
+        print(
+            f"  Cluster {row['cluster_id']}: "
+            f"{fmt(row['min_ts_ms'])} -> {fmt(row['max_ts_ms'])}, "
+            f"{span_h:.1f}h, "
+            f"SIGNAL={row['signal_count']} ORDER={row['order_count']} FILL={row['fill_count']}, "
+            f"chains={row['total_chains']}"
+        )
+    print()
+    print("  NOTE: Paper strategy events have sid='paper', NOT primary_breakout_v1.")
+    print(
+        "  NOTE: These are NOT admissible as PB1 window-bank evidence per #3343 scope."
+    )
+    print("  NOTE: Paper strategy ORDER/FILL count is 4 across entire DB.")
+    print()
+
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Readonly DB inventory and cluster verification for #3343. 

**Finding:** public.correlation_ledger contains **no** primary_breakout_v1/BTCUSDT cluster meeting the >2h minimum duration for a valid natural-paper reference window.

### Verification Result

| # | Duration | Events | Has Trade? | Verdict |
|---|----------|--------|------------|---------|
| 1 | 1.813h (108.8min) | 767 (all SIGNAL) | No | EXCLUDE — <2h, signal-only, no trades |
| 2 | 0.000h (0s) | 2 (ORDER+FILL) | Yes | EXCLUDE — instant, no DECISION |
| 3 | 0.000h (0s) | 2 (ORDER+FILL) | Yes | EXCLUDE — instant, no DECISION |
| 4 | **1.203h (72.2min)** | 10 (existing bank) | Yes | EXCLUDE — <2h |
| 5 | 0.000h (0s) | 2 (ORDER+FILL) | Yes | EXCLUDE — instant, no DECISION |

### Final Verdict

**HOLD_NO_VALID_PRIMARY_BREAKOUT_WINDOWS**

- Max PB1 cluster with trade chain: **72.2min** (existing 3-window bank)
- Max PB1 cluster overall: **108.8min** (signal-only, no trades)
- Broader paper-strategy clusters (23h+, 25h+) exist but have sid=paper, not primary_breakout_v1
- A4 remains FAIL. No promotable candidate. No Product-Complete claim.

### Assets

- docs/evidence/arvp_window_bank_expansion_regime_segments_3343.md — full evidence artifact
- scripts/_3343_inventory_windows.py — readonly DB inventory (deterministic, secret-safe)
- scripts/_3343_verify_pb1_clusters.py — definitive cluster verification (deterministic, secret-safe)

### Boundaries

- LR remains NO-GO
- No Live-Go / Echtgeld-Go
- No Candidate #4
- No PB1/RMR/Momentum rescue
- No Product-Complete claim
- No runtime/Docker/backfill/replay executed
- No DB mutations
- No secrets exposed

Closes #3343