### PR TITLE
[EVIDENCE][HARVESTER] Add local background scheduler wrapper

### DIFF
--- a/scripts/evidence_harvester_task.ps1
+++ b/scripts/evidence_harvester_task.ps1
@@ -1,0 +1,43 @@
+param(
+    [ValidateSet('plan', 'status', 'run-once-fixture', 'install', 'uninstall')]
+    [string]$Action = 'plan',
+    [string]$TaskName = 'CDB Evidence Harvester',
+    [string]$Fixture,
+    [string]$OutputDir,
+    [string]$PythonExecutable = 'python',
+    [string]$GeneratedAtUtc,
+    [string]$StartTime = '04:00',
+    [switch]$Explicit,
+    [switch]$Pretty
+)
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$moduleArgs = @('-m', 'tools.evidence_harvester.scheduler', $Action, '--task-name', $TaskName)
+
+if ($OutputDir) {
+    $moduleArgs += @('--output-dir', $OutputDir)
+}
+if ($Fixture) {
+    $moduleArgs += @('--fixture', $Fixture)
+}
+if ($GeneratedAtUtc) {
+    $moduleArgs += @('--generated-at-utc', $GeneratedAtUtc)
+}
+if ($Action -in @('plan', 'install') -and $StartTime) {
+    $moduleArgs += @('--start-time', $StartTime)
+}
+if ($Pretty) {
+    $moduleArgs += '--pretty'
+}
+if ($Action -in @('install', 'uninstall')) {
+    if (-not $Explicit) {
+        throw "$Action requires -Explicit. Default mode remains dry-run/plan-only."
+    }
+    $moduleArgs += '--explicit'
+}
+if ($Action -in @('plan', 'install')) {
+    $moduleArgs += @('--python-executable', $PythonExecutable)
+}
+
+& $PythonExecutable @moduleArgs
+exit $LASTEXITCODE

--- a/tests/unit/tools/evidence_harvester/test_scheduler.py
+++ b/tests/unit/tools/evidence_harvester/test_scheduler.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tools.evidence_harvester.scheduler import SchedulerValidationError, main
+
+
+def _fixture_payload() -> dict[str, object]:
+    return {
+        "evidence_class": "pipeline_test_evidence",
+        "evidence_class_version": "1.0",
+        "produced_by": "pytest",
+        "produced_at_utc": "2026-06-19T12:00:00Z",
+        "source_mode": "fixture",
+        "allowed_provenance_sources": ["mexc", "paper_runner"],
+        "stale_after_minutes": 60,
+        "candle_coverages": [
+            {
+                "symbol": "BTCUSDT",
+                "venue": "mexc",
+                "timeframe": "1m",
+                "first_ts_utc": "2026-06-19T10:00:00Z",
+                "last_ts_utc": "2026-06-19T10:19:00Z",
+                "observed_count": 18,
+                "expected_count": 20,
+            }
+        ],
+        "regime_coverages": [
+            {
+                "symbol": "BTCUSDT",
+                "venue": "regime_service",
+                "timeframe": "1m",
+                "first_ts_utc": "2026-06-19T10:00:00Z",
+                "last_ts_utc": "2026-06-19T10:19:00Z",
+                "observed_count": 0,
+                "expected_count": 20,
+                "regime_distribution": {},
+            }
+        ],
+        "paper_chain_coverages": [
+            {
+                "symbol": "BTCUSDT",
+                "venue": "paper_runner",
+                "timeframe": "1m",
+                "observation_window_hours": 2.0,
+                "signal_count": 0,
+                "decision_count": 0,
+                "order_count": 0,
+                "fill_count": 0,
+                "complete_chain_count": 0,
+                "partial_chain_count": 0,
+            }
+        ],
+        "provenance_observations": [
+            {"source": "mexc", "observed_count": 18, "contaminated": False},
+            {"source": "replay_runner", "observed_count": 2, "contaminated": True},
+        ],
+    }
+
+
+def _write_fixture(tmp_path: Path) -> Path:
+    fixture_path = tmp_path / "collector_input.json"
+    fixture_path.write_text(json.dumps(_fixture_payload()), encoding="utf-8")
+    return fixture_path
+
+
+@pytest.mark.unit
+def test_scheduler_defaults_to_safe_plan(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main([])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "plan"
+    assert payload["default_mode"] == "dry-run"
+    assert payload["scheduled_action"] == "run-once-fixture"
+
+
+@pytest.mark.unit
+def test_run_once_fixture_writes_snapshot_artifacts(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture_path = _write_fixture(tmp_path)
+    output_dir = tmp_path / "artifacts"
+
+    exit_code = main(
+        [
+            "run-once-fixture",
+            "--fixture",
+            str(fixture_path),
+            "--output-dir",
+            str(output_dir),
+            "--generated-at-utc",
+            "2026-06-19T16:00:00Z",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert Path(payload["artifacts"]["collector_report"]).exists()
+    assert Path(payload["artifacts"]["snapshot_json"]).exists()
+    assert Path(payload["artifacts"]["snapshot_markdown"]).exists()
+    assert payload["latest_snapshot"]["generated_at_utc"] == "2026-06-19T16:00:00Z"
+    assert payload["latest_snapshot"]["overall_status"] == "blocked"
+
+
+@pytest.mark.unit
+def test_status_reads_latest_snapshot_from_local_artifacts(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture_path = _write_fixture(tmp_path)
+    output_dir = tmp_path / "artifacts"
+
+    main(
+        [
+            "run-once-fixture",
+            "--fixture",
+            str(fixture_path),
+            "--output-dir",
+            str(output_dir),
+            "--generated-at-utc",
+            "2026-06-19T16:00:00Z",
+        ]
+    )
+    capsys.readouterr()
+
+    exit_code = main(["status", "--output-dir", str(output_dir)])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["artifacts_present"] is True
+    assert payload["latest_snapshot"]["collector_report_id"].startswith("harv-")
+    assert payload["latest_snapshot"]["overall_status"] == "blocked"
+
+
+@pytest.mark.unit
+def test_install_requires_explicit_flag(tmp_path: Path) -> None:
+    fixture_path = _write_fixture(tmp_path)
+
+    with pytest.raises(SchedulerValidationError, match="install requires --explicit"):
+        main(["install", "--fixture", str(fixture_path)])
+
+
+@pytest.mark.unit
+def test_install_path_is_patchable_and_does_not_run_real_task_install_in_tests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fixture_path = _write_fixture(tmp_path)
+    calls: list[list[str]] = []
+
+    def _fake_run(command: list[str], check: bool) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        assert check is True
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("tools.evidence_harvester.scheduler.subprocess.run", _fake_run)
+
+    exit_code = main(
+        [
+            "install",
+            "--fixture",
+            str(fixture_path),
+            "--explicit",
+            "--start-time",
+            "04:30",
+        ]
+    )
+
+    assert exit_code == 0
+    assert calls
+    assert calls[0][0] == "schtasks.exe"
+    assert "/Create" in calls[0]
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["installed"] is True
+    assert payload["start_time"] == "04:30"

--- a/tools/evidence_harvester/README.md
+++ b/tools/evidence_harvester/README.md
@@ -1,6 +1,7 @@
-# Evidence Harvester Collector
+# Evidence Harvester
 
-Passive, fixture-driven collector for ARVP/profitability evidence coverage.
+Passive, fixture-driven collector, snapshot, and local scheduler wrapper for
+ARVP/profitability evidence coverage.
 
 ## Scope
 
@@ -8,6 +9,7 @@ Passive, fixture-driven collector for ARVP/profitability evidence coverage.
 - stays read-only and secret-safe
 - does not launch services, background jobs, storage writes, or replay paths
 - keeps snapshots paper/research only; no LR-Go, no Live-Go, no Echtgeld-Go
+- keeps scheduler installation default-off and explicitly gated
 
 ## Usage
 
@@ -27,6 +29,49 @@ Daily snapshot artifacts from a collector-report fixture:
 
 ```powershell
 python -m tools.evidence_harvester.snapshot --fixture path\to\collector_report.json --json-output out\snapshot.json --markdown-output out\snapshot.md --generated-at-utc 2026-06-19T16:00:00Z --pretty
+```
+
+Default-off scheduler plan:
+
+```powershell
+python -m tools.evidence_harvester.scheduler
+```
+
+Explicit plan with fixture/output paths:
+
+```powershell
+python -m tools.evidence_harvester.scheduler plan --fixture path\to\collector_input.json --output-dir artifacts\evidence_harvester\scheduled --pretty
+```
+
+One fixture-backed run that writes collector report + snapshot JSON + Markdown:
+
+```powershell
+python -m tools.evidence_harvester.scheduler run-once-fixture --fixture path\to\collector_input.json --output-dir artifacts\evidence_harvester\scheduled --generated-at-utc 2026-06-19T16:00:00Z --pretty
+```
+
+Artifact-only local status:
+
+```powershell
+python -m tools.evidence_harvester.scheduler status --output-dir artifacts\evidence_harvester\scheduled --pretty
+```
+
+Explicit Windows Task install/uninstall wrappers:
+
+```powershell
+python -m tools.evidence_harvester.scheduler install --fixture path\to\collector_input.json --explicit
+python -m tools.evidence_harvester.scheduler uninstall --explicit
+```
+
+PowerShell wrapper defaults to plan-only:
+
+```powershell
+pwsh -NoProfile -File .\scripts\evidence_harvester_task.ps1
+```
+
+Actual task installation remains explicit:
+
+```powershell
+pwsh -NoProfile -File .\scripts\evidence_harvester_task.ps1 -Action install -Fixture path\to\collector_input.json -Explicit
 ```
 
 ## Fixture shape
@@ -67,6 +112,28 @@ Snapshot Markdown sections:
 - `Safety Boundaries`
 - `Next Action Hints`
 
+## Scheduler contract
+
+Allowed commands:
+
+- `plan`
+- `status`
+- `run-once-fixture`
+- `install --explicit`
+- `uninstall --explicit`
+
+Default behavior:
+
+- no invocation installs a task unless `--explicit` is present
+- bare `python -m tools.evidence_harvester.scheduler` resolves to safe `plan`
+- `status` reads local artifacts only; it does not query Docker, DB, Redis, or runtime services
+- scheduled action is limited to the safe fixture-backed snapshot path
+
+Recommended cadence:
+
+- collector status review every 15 minutes (manual/read-only recommendation)
+- scheduled snapshot once daily via the safe fixture path
+
 Safety boundaries:
 
 - paper/research evidence only
@@ -78,6 +145,7 @@ Safety boundaries:
 - no Redis live read/write
 - no replay or backfill execution
 - no LR-Go, no Live-Go, no Echtgeld-Go
+- no autostart by default
 
 ## Future-gated live reads
 

--- a/tools/evidence_harvester/scheduler.py
+++ b/tools/evidence_harvester/scheduler.py
@@ -1,0 +1,486 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+from .collector import EvidenceHarvesterCollector
+from .models import CollectorInput
+from .snapshot import build_snapshot, snapshot_to_markdown
+
+TASK_NAME = "CDB Evidence Harvester"
+DEFAULT_START_TIME = "04:00"
+
+
+class SchedulerValidationError(ValueError):
+    pass
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _default_output_dir() -> Path:
+    return _repo_root() / "artifacts" / "evidence_harvester" / "scheduled"
+
+
+def _format_json(payload: Mapping[str, Any], pretty: bool) -> str:
+    return json.dumps(
+        payload,
+        indent=2 if pretty else None,
+        sort_keys=True,
+        ensure_ascii=True,
+    )
+
+
+def _emit(payload: Mapping[str, Any], pretty: bool) -> None:
+    print(_format_json(payload, pretty))
+
+
+def _resolve_fixture(path: Path | None, *, required: bool) -> Path | None:
+    if path is None:
+        if required:
+            raise SchedulerValidationError("--fixture is required for this command")
+        return None
+    resolved = path.resolve()
+    if not resolved.exists():
+        raise SchedulerValidationError(f"fixture path does not exist: {resolved}")
+    return resolved
+
+
+def _resolve_output_dir(path: Path | None) -> Path:
+    return (path or _default_output_dir()).resolve()
+
+
+def _run_stamp(generated_at_utc: str) -> str:
+    return generated_at_utc.replace("-", "").replace(":", "")
+
+
+def _wrapper_command(
+    fixture: Path | None,
+    output_dir: Path,
+    python_executable: str,
+    generated_at_utc: str | None,
+    pretty: bool,
+) -> list[str]:
+    script_path = _repo_root() / "scripts" / "evidence_harvester_task.ps1"
+    command = [
+        "pwsh.exe",
+        "-NoProfile",
+        "-File",
+        str(script_path),
+        "-Action",
+        "run-once-fixture",
+        "-OutputDir",
+        str(output_dir),
+        "-PythonExecutable",
+        python_executable,
+    ]
+    if fixture is not None:
+        command.extend(["-Fixture", str(fixture)])
+    if generated_at_utc is not None:
+        command.extend(["-GeneratedAtUtc", generated_at_utc])
+    if pretty:
+        command.append("-Pretty")
+    return command
+
+
+def _planned_surface(
+    fixture: Path | None,
+    output_dir: Path,
+    python_executable: str,
+    generated_at_utc: str | None,
+    pretty: bool,
+    start_time: str,
+    task_name: str,
+) -> dict[str, Any]:
+    wrapper_command = _wrapper_command(
+        fixture,
+        output_dir,
+        python_executable,
+        generated_at_utc,
+        pretty,
+    )
+    return {
+        "mode": "plan",
+        "task_name": task_name,
+        "default_mode": "dry-run",
+        "scheduled_action": "run-once-fixture",
+        "explicit_required_for_install": True,
+        "fixture": str(fixture) if fixture is not None else None,
+        "output_dir": str(output_dir),
+        "artifacts": {
+            "collector_report_pattern": "collector_report_<YYYYMMDDTHHMMSSZ>.json",
+            "snapshot_json_pattern": "snapshot_<YYYYMMDDTHHMMSSZ>.json",
+            "snapshot_markdown_pattern": "snapshot_<YYYYMMDDTHHMMSSZ>.md",
+        },
+        "recommended_cadence": {
+            "collector_status": "every 15 minutes (manual/read-only recommendation)",
+            "snapshot_task": f"daily {start_time} local time (safe fixture snapshot only)",
+        },
+        "task_scheduler": {
+            "schedule": "DAILY",
+            "start_time": start_time,
+            "wrapper_command": subprocess.list2cmdline(wrapper_command),
+        },
+        "install_command_preview": subprocess.list2cmdline(
+            [
+                "schtasks.exe",
+                "/Create",
+                "/TN",
+                task_name,
+                "/SC",
+                "DAILY",
+                "/ST",
+                start_time,
+                "/TR",
+                subprocess.list2cmdline(wrapper_command),
+                "/F",
+            ]
+        ),
+        "uninstall_command_preview": subprocess.list2cmdline(
+            ["schtasks.exe", "/Delete", "/TN", task_name, "/F"]
+        ),
+        "safety": [
+            "default-off / dry-run by default",
+            "no Docker or runtime start",
+            "no DB execution or mutation",
+            "no secrets",
+            "no Redis live read/write",
+            "no LR-Go / no Live-Go / no Echtgeld-Go",
+        ],
+    }
+
+
+def _latest_snapshot_path(output_dir: Path) -> Path | None:
+    candidates = sorted(output_dir.glob("snapshot_*.json"))
+    if not candidates:
+        return None
+    return candidates[-1]
+
+
+def _snapshot_summary(snapshot_path: Path) -> dict[str, Any]:
+    payload = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    metadata = payload.get("metadata", {})
+    status = payload.get("status", {})
+    gap_counts = status.get("gap_counts", {})
+    return {
+        "path": str(snapshot_path),
+        "generated_at_utc": metadata.get("generated_at_utc"),
+        "collector_report_id": metadata.get("collector_report_id"),
+        "source_mode": metadata.get("source_mode"),
+        "overall_status": status.get("overall_status"),
+        "gap_counts": {
+            "blocking": gap_counts.get("blocking", 0),
+            "warning": gap_counts.get("warning", 0),
+            "info": gap_counts.get("info", 0),
+        },
+    }
+
+
+def plan_command(args: argparse.Namespace) -> int:
+    fixture = _resolve_fixture(args.fixture, required=False)
+    output_dir = _resolve_output_dir(args.output_dir)
+    payload = _planned_surface(
+        fixture,
+        output_dir,
+        args.python_executable,
+        args.generated_at_utc,
+        args.pretty,
+        args.start_time,
+        args.task_name,
+    )
+    _emit(payload, args.pretty)
+    return 0
+
+
+def status_command(args: argparse.Namespace) -> int:
+    output_dir = _resolve_output_dir(args.output_dir)
+    latest_snapshot = None
+    if output_dir.exists():
+        latest_snapshot_path = _latest_snapshot_path(output_dir)
+        if latest_snapshot_path is not None:
+            latest_snapshot = _snapshot_summary(latest_snapshot_path)
+
+    payload = {
+        "mode": "status",
+        "task_name": args.task_name,
+        "default_mode": "dry-run",
+        "output_dir": str(output_dir),
+        "artifact_dir_exists": output_dir.exists(),
+        "artifacts_present": latest_snapshot is not None,
+        "latest_snapshot": latest_snapshot,
+        "safety": [
+            "status is derived from local artifacts only",
+            "no scheduler installation check performed",
+            "no Docker/runtime/DB/Redis/secrets access",
+        ],
+    }
+    _emit(payload, args.pretty)
+    return 0
+
+
+def run_once_fixture_command(args: argparse.Namespace) -> int:
+    fixture = _resolve_fixture(args.fixture, required=True)
+    output_dir = _resolve_output_dir(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    raw_input = json.loads(fixture.read_text(encoding="utf-8"))
+    if not isinstance(raw_input, dict):
+        raise SchedulerValidationError("fixture JSON root must be an object")
+
+    collector_input = CollectorInput.from_mapping(raw_input)
+    report = EvidenceHarvesterCollector(
+        stale_after_minutes=collector_input.stale_after_minutes,
+    ).collect(collector_input)
+    snapshot = build_snapshot(
+        report.to_dict(),
+        generated_at_utc=args.generated_at_utc,
+    )
+    snapshot_payload = snapshot.to_dict()
+    stamp = _run_stamp(snapshot_payload["metadata"]["generated_at_utc"])
+
+    collector_report_path = output_dir / f"collector_report_{stamp}.json"
+    snapshot_json_path = output_dir / f"snapshot_{stamp}.json"
+    snapshot_markdown_path = output_dir / f"snapshot_{stamp}.md"
+
+    collector_report_path.write_text(
+        _format_json(report.to_dict(), args.pretty) + "\n",
+        encoding="utf-8",
+    )
+    snapshot_json_path.write_text(
+        _format_json(snapshot_payload, args.pretty) + "\n",
+        encoding="utf-8",
+    )
+    snapshot_markdown_path.write_text(
+        snapshot_to_markdown(snapshot),
+        encoding="utf-8",
+    )
+
+    payload = {
+        "mode": "run-once-fixture",
+        "task_name": args.task_name,
+        "output_dir": str(output_dir),
+        "artifacts": {
+            "collector_report": str(collector_report_path),
+            "snapshot_json": str(snapshot_json_path),
+            "snapshot_markdown": str(snapshot_markdown_path),
+        },
+        "latest_snapshot": _snapshot_summary(snapshot_json_path),
+        "safety": [
+            "fixture-only run",
+            "no scheduler autostart",
+            "no Docker/runtime/DB/Redis/secrets access",
+        ],
+    }
+    _emit(payload, args.pretty)
+    return 0
+
+
+def _require_explicit(explicit: bool, action: str) -> None:
+    if not explicit:
+        raise SchedulerValidationError(f"{action} requires --explicit")
+
+
+def install_command(args: argparse.Namespace) -> int:
+    _require_explicit(args.explicit, "install")
+    fixture = _resolve_fixture(args.fixture, required=True)
+    output_dir = _resolve_output_dir(args.output_dir)
+    payload = _planned_surface(
+        fixture,
+        output_dir,
+        args.python_executable,
+        args.generated_at_utc,
+        args.pretty,
+        args.start_time,
+        args.task_name,
+    )
+    task_command = payload["task_scheduler"]["wrapper_command"]
+    subprocess.run(
+        [
+            "schtasks.exe",
+            "/Create",
+            "/TN",
+            args.task_name,
+            "/SC",
+            "DAILY",
+            "/ST",
+            args.start_time,
+            "/TR",
+            task_command,
+            "/F",
+        ],
+        check=True,
+    )
+    _emit(
+        {
+            "mode": "install",
+            "task_name": args.task_name,
+            "installed": True,
+            "fixture": str(fixture),
+            "output_dir": str(output_dir),
+            "start_time": args.start_time,
+            "command": task_command,
+            "safety": [
+                "explicit flag required",
+                "scheduled action remains fixture-only",
+                "no Docker/runtime/DB/Redis/secrets access implied",
+            ],
+        },
+        args.pretty,
+    )
+    return 0
+
+
+def uninstall_command(args: argparse.Namespace) -> int:
+    _require_explicit(args.explicit, "uninstall")
+    subprocess.run(
+        ["schtasks.exe", "/Delete", "/TN", args.task_name, "/F"],
+        check=True,
+    )
+    _emit(
+        {
+            "mode": "uninstall",
+            "task_name": args.task_name,
+            "uninstalled": True,
+            "safety": ["explicit flag required", "no runtime or evidence run triggered"],
+        },
+        args.pretty,
+    )
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    argv = list(argv or [])
+    if not argv:
+        argv = ["plan"]
+
+    parser = argparse.ArgumentParser(
+        description="Default-off local scheduler wrapper for the evidence harvester."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    def add_common(parser_obj: argparse.ArgumentParser) -> None:
+        parser_obj.add_argument(
+            "--task-name",
+            default=TASK_NAME,
+            help="Windows Task Scheduler task name.",
+        )
+        parser_obj.add_argument(
+            "--output-dir",
+            type=Path,
+            help="Directory for scheduled collector/snapshot artifacts.",
+        )
+        parser_obj.add_argument(
+            "--pretty",
+            action="store_true",
+            help="Pretty-print JSON output.",
+        )
+
+    plan_parser = subparsers.add_parser(
+        "plan",
+        help="Print the safe dry-run plan without installing anything.",
+    )
+    add_common(plan_parser)
+    plan_parser.add_argument(
+        "--fixture",
+        type=Path,
+        help="Collector-input fixture path for the scheduled run command.",
+    )
+    plan_parser.add_argument(
+        "--python-executable",
+        default=sys.executable,
+        help="Python executable used by the PowerShell wrapper.",
+    )
+    plan_parser.add_argument(
+        "--generated-at-utc",
+        help="Optional deterministic timestamp for the planned run command.",
+    )
+    plan_parser.add_argument(
+        "--start-time",
+        default=DEFAULT_START_TIME,
+        help="Daily local start time for the Windows Task plan (HH:MM).",
+    )
+    plan_parser.set_defaults(handler=plan_command)
+
+    status_parser = subparsers.add_parser(
+        "status",
+        help="Report local artifact-based scheduler status.",
+    )
+    add_common(status_parser)
+    status_parser.set_defaults(handler=status_command)
+
+    run_parser = subparsers.add_parser(
+        "run-once-fixture",
+        help="Run the collector and snapshot once from a local fixture.",
+    )
+    add_common(run_parser)
+    run_parser.add_argument(
+        "--fixture",
+        type=Path,
+        required=True,
+        help="Collector-input fixture path.",
+    )
+    run_parser.add_argument(
+        "--generated-at-utc",
+        help="Optional deterministic timestamp for artifact generation.",
+    )
+    run_parser.set_defaults(handler=run_once_fixture_command)
+
+    install_parser = subparsers.add_parser(
+        "install",
+        help="Install the Windows Task Scheduler task (explicitly gated).",
+    )
+    add_common(install_parser)
+    install_parser.add_argument(
+        "--fixture",
+        type=Path,
+        required=True,
+        help="Collector-input fixture path for the scheduled run command.",
+    )
+    install_parser.add_argument(
+        "--python-executable",
+        default=sys.executable,
+        help="Python executable used by the PowerShell wrapper.",
+    )
+    install_parser.add_argument(
+        "--generated-at-utc",
+        help="Optional deterministic timestamp for the scheduled run command.",
+    )
+    install_parser.add_argument(
+        "--start-time",
+        default=DEFAULT_START_TIME,
+        help="Daily local start time for the Windows Task (HH:MM).",
+    )
+    install_parser.add_argument(
+        "--explicit",
+        action="store_true",
+        help="Required flag for actual task installation.",
+    )
+    install_parser.set_defaults(handler=install_command)
+
+    uninstall_parser = subparsers.add_parser(
+        "uninstall",
+        help="Remove the Windows Task Scheduler task (explicitly gated).",
+    )
+    add_common(uninstall_parser)
+    uninstall_parser.add_argument(
+        "--explicit",
+        action="store_true",
+        help="Required flag for actual task removal.",
+    )
+    uninstall_parser.set_defaults(handler=uninstall_command)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/evidence_harvester/scheduler.py
+++ b/tools/evidence_harvester/scheduler.py
@@ -346,7 +346,10 @@ def uninstall_command(args: argparse.Namespace) -> int:
             "mode": "uninstall",
             "task_name": args.task_name,
             "uninstalled": True,
-            "safety": ["explicit flag required", "no runtime or evidence run triggered"],
+            "safety": [
+                "explicit flag required",
+                "no runtime or evidence run triggered",
+            ],
         },
         args.pretty,
     )


### PR DESCRIPTION
## Brain Evidence Block
~~~text
brain_source: repo-only
brain_status: not-used
tools_or_queries:
  - cdb_context_briefing (briefing_id 4ec45ef7c3669f45)
  - cdb_context_impact (impact_id 24eae2d2a73e4829)
  - context.readiness (status ready_for_human_go)
  - git fetch origin --prune
  - gh live checks for #1445, #3345, #3348, #3349, PR #3353, PR #3354
records_or_results:
  - Context tools available with LOW trust and no evidence_records or decision_events
  - Live GitHub confirms #3348 OPEN, #3349 CLOSED, PR #3353/#3354 MERGED
repo_crosscheck:
  - docs/strategy/CDB_ALWAYS_ON_EVIDENCE_HARVESTER_V1.md
  - tools/evidence_harvester/collector.py
  - tools/evidence_harvester/snapshot.py
  - tools/evidence_harvester/README.md
  - tests/unit/tools/evidence_harvester/test_collector.py
  - tests/unit/tools/evidence_harvester/test_snapshot.py
impact_on_plan:
  - Implemented a repo-only wrapper over the existing fixture collector and snapshot surfaces
  - Kept scheduling limited to local Task Scheduler wrappers and artifact-based status
limitations:
  - No DB-backed context records were available
  - Validation intentionally excluded actual Windows Task installation
context_brain_attempted: true
context_brain_used: false
repo_fallback_used: true
repo_fallback_reason: insufficient_evidence
context_tool_status: available
context_trust_level: low
records_found: none
~~~

## Scheduler summary
- Adds tools.evidence_harvester.scheduler with plan, status, run-once-fixture, install --explicit, and uninstall --explicit.
- Adds default-off scripts/evidence_harvester_task.ps1 wrapper for Windows Task Scheduler.
- run-once-fixture writes collector report plus snapshot JSON and Markdown from a local fixture; status stays artifact-based only.

## Default-off / dry-run safety
- Bare scheduler invocation resolves to safe plan.
- Install and uninstall require explicit flags.
- No runtime start, no Docker, no DB execution or mutation, no secrets, and no Redis live I/O.
- No LR-Go / No Live-Go / No Echtgeld-Go.

## Tests
- python -m pytest tests/unit/tools/evidence_harvester -q
- ruff check tools/evidence_harvester tests/unit/tools/evidence_harvester
- git diff --check
- rg -n "docker compose|docker start|Start-Service|DATABASE_URL|SECRET|TOKEN|Redis" tools/evidence_harvester scripts tests/unit/tools/evidence_harvester
  - Reviewed: touched-file matches are documentation/safety strings only; broad scripts/ also contains unrelated pre-existing files.

## No runtime / no DB execution / no Docker / no secrets
- This slice does not start Docker, runtime services, paper runner, replay, backfill, DB, Redis, or any trading/risk/execution path.

Closes #3348