### PR TITLE
[EVIDENCE][HARVESTER] Add evidence gap alerting

### DIFF
--- a/tests/unit/tools/evidence_harvester/test_alerts.py
+++ b/tests/unit/tools/evidence_harvester/test_alerts.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.evidence_harvester.alerts import (
+    ALERT_REPORT_SCHEMA_VERSION,
+    AlertValidationError,
+    alert_report_to_markdown,
+    build_alert_report,
+    build_issue_draft,
+    load_snapshot_fixture,
+    main,
+)
+from tools.evidence_harvester.collector import EvidenceHarvesterCollector
+from tools.evidence_harvester.models import CollectorInput
+from tools.evidence_harvester.snapshot import build_snapshot
+
+
+def _fixture_payload() -> dict[str, object]:
+    return {
+        "evidence_class": "pipeline_test_evidence",
+        "evidence_class_version": "1.0",
+        "produced_by": "pytest",
+        "produced_at_utc": "2026-06-19T12:00:00Z",
+        "source_mode": "fixture",
+        "allowed_provenance_sources": ["mexc", "paper_runner"],
+        "stale_after_minutes": 60,
+        "candle_coverages": [
+            {
+                "symbol": "BTCUSDT",
+                "venue": "mexc",
+                "timeframe": "1m",
+                "first_ts_utc": "2026-06-19T10:00:00Z",
+                "last_ts_utc": "2026-06-19T10:19:00Z",
+                "observed_count": 18,
+                "expected_count": 20,
+            }
+        ],
+        "regime_coverages": [
+            {
+                "symbol": "BTCUSDT",
+                "venue": "regime_service",
+                "timeframe": "1m",
+                "first_ts_utc": "2026-06-19T10:00:00Z",
+                "last_ts_utc": "2026-06-19T10:19:00Z",
+                "observed_count": 0,
+                "expected_count": 20,
+                "regime_distribution": {},
+            }
+        ],
+        "paper_chain_coverages": [
+            {
+                "symbol": "BTCUSDT",
+                "venue": "paper_runner",
+                "timeframe": "1m",
+                "observation_window_hours": 2.0,
+                "signal_count": 0,
+                "decision_count": 0,
+                "order_count": 0,
+                "fill_count": 0,
+                "complete_chain_count": 0,
+                "partial_chain_count": 0,
+            }
+        ],
+        "provenance_observations": [
+            {"source": "mexc", "observed_count": 18, "contaminated": False},
+            {"source": "replay_runner", "observed_count": 2, "contaminated": True},
+        ],
+    }
+
+
+def _snapshot_payload() -> dict[str, object]:
+    collector_input = CollectorInput.from_mapping(_fixture_payload())
+    report = EvidenceHarvesterCollector(stale_after_minutes=60).collect(collector_input)
+    snapshot = build_snapshot(report.to_dict(), generated_at_utc="2026-06-19T16:00:00Z")
+    return snapshot.to_dict()
+
+
+@pytest.mark.unit
+def test_alert_report_is_deterministic_for_same_snapshot_and_time() -> None:
+    snapshot = _snapshot_payload()
+
+    report_a = build_alert_report(
+        snapshot,
+        evaluated_at_utc="2026-06-19T16:00:00Z",
+    ).to_dict()
+    report_b = build_alert_report(
+        snapshot,
+        evaluated_at_utc="2026-06-19T16:00:00Z",
+    ).to_dict()
+
+    assert report_a == report_b
+    assert report_a["schema_version"] == ALERT_REPORT_SCHEMA_VERSION
+    assert report_a["summary"]["highest_severity"] == "critical"
+
+
+@pytest.mark.unit
+def test_alert_report_classifies_required_gaps_and_deduplicates_by_finding_id() -> None:
+    snapshot = _snapshot_payload()
+    duplicate = dict(snapshot["gap_findings"]["items"][0])
+    duplicate["gap_id"] = "gap-999"
+    snapshot["gap_findings"]["items"] = tuple(snapshot["gap_findings"]["items"]) + (
+        duplicate,
+    )
+
+    report = build_alert_report(
+        snapshot,
+        evaluated_at_utc="2026-06-19T16:00:00Z",
+    ).to_dict()
+    finding_types = {item["finding_type"] for item in report["findings"]}
+
+    assert report["summary"]["critical_count"] >= 4
+    assert "stale_feed" in finding_types
+    assert "missing_candles" in finding_types
+    assert "missing_regime" in finding_types
+    assert "zero_paper_chains" in finding_types
+    assert "provenance_contamination" in finding_types
+    stale_feed_findings = [
+        item for item in report["findings"] if item["finding_type"] == "stale_feed"
+    ]
+    assert len(stale_feed_findings) == 1
+    assert stale_feed_findings[0]["finding_id"].startswith("alert-")
+
+
+@pytest.mark.unit
+def test_alert_report_adds_stale_snapshot_finding_from_evaluation_time() -> None:
+    report = build_alert_report(
+        _snapshot_payload(),
+        evaluated_at_utc="2026-06-19T22:30:00Z",
+        stale_snapshot_after_minutes=180,
+        critical_snapshot_after_minutes=360,
+    ).to_dict()
+
+    stale_snapshot = [
+        item for item in report["findings"] if item["finding_type"] == "stale_snapshot"
+    ]
+    assert report["snapshot_age_minutes"] == 390
+    assert stale_snapshot
+    assert stale_snapshot[0]["severity"] == "critical"
+
+
+@pytest.mark.unit
+def test_alert_report_rejects_malformed_snapshot() -> None:
+    snapshot = _snapshot_payload()
+    del snapshot["metadata"]["collector_report_id"]
+
+    with pytest.raises(AlertValidationError, match="metadata malformed"):
+        build_alert_report(snapshot)
+
+
+@pytest.mark.unit
+def test_issue_draft_and_markdown_are_plain_text_outputs_only() -> None:
+    report = build_alert_report(
+        _snapshot_payload(),
+        evaluated_at_utc="2026-06-19T16:00:00Z",
+    )
+
+    markdown = alert_report_to_markdown(report)
+    issue_draft = build_issue_draft(report, issue_number=3350, parent_issue=3345)
+
+    assert markdown.startswith("# Evidence Alert Report\n")
+    assert "manual only; no automatic GitHub writes" in markdown
+    assert "Manual escalation draft only." in issue_draft
+    assert "#3350" in issue_draft
+    assert "#3345" in issue_draft
+
+
+@pytest.mark.unit
+def test_cli_writes_alert_report_and_issue_draft(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "snapshot.json"
+    json_output = tmp_path / "alerts.json"
+    markdown_output = tmp_path / "alerts.md"
+    issue_output = tmp_path / "issue_draft.md"
+    fixture_path.write_text(json.dumps(_snapshot_payload()), encoding="utf-8")
+
+    exit_code = main(
+        [
+            "--fixture",
+            str(fixture_path),
+            "--json-output",
+            str(json_output),
+            "--markdown-output",
+            str(markdown_output),
+            "--issue-draft-output",
+            str(issue_output),
+            "--evaluated-at-utc",
+            "2026-06-19T16:00:00Z",
+            "--issue-number",
+            "3350",
+            "--parent-issue",
+            "3345",
+            "--pretty",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(json_output.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == ALERT_REPORT_SCHEMA_VERSION
+    assert "# Evidence Alert Report\n" in markdown_output.read_text(encoding="utf-8")
+    assert "Manual escalation draft only." in issue_output.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+def test_load_snapshot_fixture_rejects_non_object_json(tmp_path: Path) -> None:
+    fixture_path = tmp_path / "snapshot.json"
+    fixture_path.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(AlertValidationError, match="Snapshot fixture JSON root"):
+        load_snapshot_fixture(fixture_path)

--- a/tests/unit/tools/evidence_harvester/test_collector.py
+++ b/tests/unit/tools/evidence_harvester/test_collector.py
@@ -110,7 +110,9 @@ def test_collector_rejects_unknown_evidence_class() -> None:
         ("last_ts_utc", "not-a-time", "ISO-8601 UTC timestamp"),
     ],
 )
-def test_collector_rejects_invalid_counts_and_timestamps(field: str, value: object, match: str) -> None:
+def test_collector_rejects_invalid_counts_and_timestamps(
+    field: str, value: object, match: str
+) -> None:
     payload = _fixture_payload()
     payload["candle_coverages"][0][field] = value
 
@@ -119,18 +121,22 @@ def test_collector_rejects_invalid_counts_and_timestamps(field: str, value: obje
 
 
 @pytest.mark.unit
-def test_cli_fixture_mode_writes_json_report(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_cli_fixture_mode_writes_json_report(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     fixture_path = tmp_path / "collector_input.json"
     output_path = tmp_path / "collector_report.json"
     fixture_path.write_text(json.dumps(_fixture_payload()), encoding="utf-8")
 
-    exit_code = main([
-        "--fixture",
-        str(fixture_path),
-        "--output",
-        str(output_path),
-        "--pretty",
-    ])
+    exit_code = main(
+        [
+            "--fixture",
+            str(fixture_path),
+            "--output",
+            str(output_path),
+            "--pretty",
+        ]
+    )
 
     assert exit_code == 0
     assert output_path.exists()

--- a/tools/evidence_harvester/README.md
+++ b/tools/evidence_harvester/README.md
@@ -55,6 +55,18 @@ Artifact-only local status:
 python -m tools.evidence_harvester.scheduler status --output-dir artifacts\evidence_harvester\scheduled --pretty
 ```
 
+Deterministic alert report from a snapshot fixture:
+
+```powershell
+python -m tools.evidence_harvester.alerts --fixture path\to\snapshot.json --json-output out\alerts.json --markdown-output out\alerts.md --evaluated-at-utc 2026-06-19T18:00:00Z --pretty
+```
+
+Optional issue-draft text only:
+
+```powershell
+python -m tools.evidence_harvester.alerts --fixture path\to\snapshot.json --issue-draft-output out\issue_draft.md --issue-number 3350 --parent-issue 3345
+```
+
 Explicit Windows Task install/uninstall wrappers:
 
 ```powershell
@@ -112,6 +124,24 @@ Snapshot Markdown sections:
 - `Safety Boundaries`
 - `Next Action Hints`
 
+Alert report JSON sections:
+
+- `schema_version`
+- `evaluated_at_utc`
+- `snapshot_generated_at_utc`
+- `collector_report_id`
+- `collector_report_hash`
+- `snapshot_age_minutes`
+- `summary`
+- `findings`
+
+Alert issue-draft contract:
+
+- plain text/Markdown only
+- local file output only
+- no automatic GitHub issue creation, comments, or API writes
+- manual escalation remains a human review step
+
 ## Scheduler contract
 
 Allowed commands:
@@ -146,6 +176,18 @@ Safety boundaries:
 - no replay or backfill execution
 - no LR-Go, no Live-Go, no Echtgeld-Go
 - no autostart by default
+
+## Alerting contract
+
+Alerting reads normalized snapshot fixtures only and fails closed on malformed
+input. It classifies evidence gaps into deterministic `info`, `warn`, and
+`critical` findings, deduplicates repeated findings by stable `finding_id`, and
+can optionally render a manual issue draft.
+
+Use the alert report when you want a local, deterministic status artifact.
+Use the issue draft when a human has decided the findings should be escalated to
+GitHub manually. The module never creates issues, never posts comments, and does
+not perform any runtime, Docker, DB, secrets, or network write behavior.
 
 ## Future-gated live reads
 

--- a/tools/evidence_harvester/__init__.py
+++ b/tools/evidence_harvester/__init__.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+from .alerts import AlertReport, AlertValidationError, build_alert_report
 from .collector import EvidenceHarvesterCollector, main, load_collector_input
 from .models import CollectorInput, CollectorReport, CollectorValidationError
 
 __all__ = [
+    "AlertReport",
+    "AlertValidationError",
     "CollectorInput",
     "CollectorReport",
     "CollectorValidationError",
     "EvidenceHarvesterCollector",
+    "build_alert_report",
     "load_collector_input",
     "main",
 ]

--- a/tools/evidence_harvester/alerts.py
+++ b/tools/evidence_harvester/alerts.py
@@ -1,0 +1,902 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .snapshot import EvidenceSnapshot, SNAPSHOT_SCHEMA_VERSION
+
+ALERT_REPORT_SCHEMA_VERSION = "cdb.evidence_harvester.alert_report.v1"
+DEFAULT_STALE_SNAPSHOT_AFTER_MINUTES = 180
+DEFAULT_CRITICAL_STALE_SNAPSHOT_AFTER_MINUTES = 360
+ALLOWED_SOURCE_MODES = {"fixture", "future_readonly"}
+ALLOWED_GAP_SEVERITIES = {"blocking", "warning", "info"}
+ALLOWED_OVERALL_STATUSES = {"ok", "warning", "blocked"}
+ALLOWED_ALERT_SEVERITIES = {"info", "warn", "critical"}
+
+
+class AlertValidationError(ValueError):
+    pass
+
+
+def _parse_ts(value: Any, field_name: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise AlertValidationError(f"{field_name} must not be blank")
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError as exc:
+            raise AlertValidationError(
+                f"{field_name} must be an ISO-8601 UTC timestamp"
+            ) from exc
+    else:
+        raise AlertValidationError(f"{field_name} must be an ISO-8601 UTC timestamp")
+
+    if parsed.tzinfo is None:
+        raise AlertValidationError(f"{field_name} must be timezone-aware UTC")
+    return parsed.astimezone(UTC)
+
+
+def _format_ts(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _require_mapping(value: Any, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise AlertValidationError(f"{field_name} must be an object")
+    return value
+
+
+def _require_sequence(value: Any, field_name: str) -> Sequence[Any]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise AlertValidationError(f"{field_name} must be an array")
+    return value
+
+
+def _require_string(value: Any, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise AlertValidationError(f"{field_name} must be a string")
+    text = value.strip()
+    if not text:
+        raise AlertValidationError(f"{field_name} must not be blank")
+    return text
+
+
+def _require_non_negative_int(value: Any, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise AlertValidationError(f"{field_name} must be a non-negative integer")
+    if value < 0:
+        raise AlertValidationError(f"{field_name} must be a non-negative integer")
+    return value
+
+
+def _require_bool(value: Any, field_name: str) -> bool:
+    if not isinstance(value, bool):
+        raise AlertValidationError(f"{field_name} must be a boolean")
+    return value
+
+
+def _require_exact_keys(
+    mapping: Mapping[str, Any],
+    field_name: str,
+    expected: Sequence[str],
+) -> None:
+    actual = set(mapping.keys())
+    required = set(expected)
+    missing = sorted(required - actual)
+    extra = sorted(actual - required)
+    if missing or extra:
+        problems: list[str] = []
+        if missing:
+            problems.append(f"missing keys: {', '.join(missing)}")
+        if extra:
+            problems.append(f"unexpected keys: {', '.join(extra)}")
+        raise AlertValidationError(f"{field_name} malformed ({'; '.join(problems)})")
+
+
+def _severity_rank(value: str) -> int:
+    return {"critical": 0, "warn": 1, "info": 2}.get(value, 99)
+
+
+def _gap_severity_to_alert(value: str) -> str:
+    if value == "blocking":
+        return "critical"
+    if value == "warning":
+        return "warn"
+    return "info"
+
+
+def _finding_title(finding_type: str) -> str:
+    titles = {
+        "missing_candles": "Missing candle coverage detected",
+        "missing_regime": "Regime coverage gap detected",
+        "missing_signal_density": "Zero signal density detected",
+        "partial_paper_chains": "Partial paper chains detected",
+        "provenance_contamination": "Provenance contamination detected",
+        "stale_feed": "Stale candle feed detected",
+        "stale_regime": "Stale regime feed detected",
+        "stale_snapshot": "Snapshot is stale",
+        "zero_paper_chains": "Zero complete paper chains detected",
+    }
+    return titles.get(finding_type, finding_type.replace("_", " ").title())
+
+
+def _hash_payload(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _build_finding_id(
+    finding_type: str,
+    severity: str,
+    scope: str,
+    source_refs: Sequence[str],
+    summary: str,
+) -> str:
+    digest = _hash_payload(
+        {
+            "finding_type": finding_type,
+            "severity": severity,
+            "scope": scope,
+            "source_refs": sorted(source_refs),
+            "summary": summary,
+        }
+    )
+    return f"alert-{digest[:12]}"
+
+
+def _validate_gap_item(index: int, payload: Any) -> dict[str, Any]:
+    mapping = _require_mapping(payload, f"gap_findings.items[{index}]")
+    _require_exact_keys(
+        mapping,
+        f"gap_findings.items[{index}]",
+        ["gap_id", "gap_type", "severity", "message", "scope", "source_refs"],
+    )
+    severity = _require_string(
+        mapping["severity"], f"gap_findings.items[{index}].severity"
+    )
+    if severity not in ALLOWED_GAP_SEVERITIES:
+        raise AlertValidationError(
+            f"gap_findings.items[{index}].severity must be one of blocking|warning|info"
+        )
+    source_refs = tuple(
+        sorted(
+            _require_string(
+                item,
+                f"gap_findings.items[{index}].source_refs[{ref_index}]",
+            )
+            for ref_index, item in enumerate(
+                _require_sequence(
+                    mapping["source_refs"],
+                    f"gap_findings.items[{index}].source_refs",
+                )
+            )
+        )
+    )
+    return {
+        "gap_id": _require_string(
+            mapping["gap_id"], f"gap_findings.items[{index}].gap_id"
+        ),
+        "gap_type": _require_string(
+            mapping["gap_type"], f"gap_findings.items[{index}].gap_type"
+        ),
+        "severity": severity,
+        "message": _require_string(
+            mapping["message"], f"gap_findings.items[{index}].message"
+        ),
+        "scope": _require_string(
+            mapping["scope"], f"gap_findings.items[{index}].scope"
+        ),
+        "source_refs": source_refs,
+    }
+
+
+def _normalize_snapshot(
+    snapshot_payload: Mapping[str, Any] | EvidenceSnapshot,
+) -> dict[str, Any]:
+    payload = (
+        snapshot_payload.to_dict()
+        if isinstance(snapshot_payload, EvidenceSnapshot)
+        else dict(snapshot_payload)
+    )
+    _require_exact_keys(
+        payload,
+        "snapshot",
+        [
+            "metadata",
+            "status",
+            "coverage",
+            "provenance",
+            "paper_chains",
+            "gap_findings",
+            "safety",
+            "next_action_hints",
+        ],
+    )
+
+    metadata = _require_mapping(payload["metadata"], "metadata")
+    _require_exact_keys(
+        metadata,
+        "metadata",
+        [
+            "schema_version",
+            "generated_at_utc",
+            "collector_report_hash",
+            "collector_report_id",
+            "collector_report_schema_version",
+            "source_mode",
+            "evidence_class",
+            "evidence_class_version",
+            "produced_by",
+            "collector_report_produced_at_utc",
+        ],
+    )
+    schema_version = _require_string(
+        metadata["schema_version"], "metadata.schema_version"
+    )
+    if schema_version != SNAPSHOT_SCHEMA_VERSION:
+        raise AlertValidationError(
+            f"metadata.schema_version must be {SNAPSHOT_SCHEMA_VERSION}"
+        )
+    source_mode = _require_string(metadata["source_mode"], "metadata.source_mode")
+    if source_mode not in ALLOWED_SOURCE_MODES:
+        raise AlertValidationError(
+            "metadata.source_mode must be one of fixture|future_readonly"
+        )
+
+    status = _require_mapping(payload["status"], "status")
+    _require_exact_keys(
+        status,
+        "status",
+        ["overall_status", "gap_counts", "has_zero_paper_chains", "raw_evidence"],
+    )
+    overall_status = _require_string(status["overall_status"], "status.overall_status")
+    if overall_status not in ALLOWED_OVERALL_STATUSES:
+        raise AlertValidationError(
+            "status.overall_status must be one of ok|warning|blocked"
+        )
+    gap_counts = _require_mapping(status["gap_counts"], "status.gap_counts")
+    _require_exact_keys(
+        gap_counts,
+        "status.gap_counts",
+        ["blocking", "warning", "info"],
+    )
+    raw_evidence = _require_mapping(status["raw_evidence"], "status.raw_evidence")
+    _require_exact_keys(
+        raw_evidence,
+        "status.raw_evidence",
+        [
+            "candle_input_count",
+            "regime_input_count",
+            "paper_chain_input_count",
+            "provenance_input_count",
+            "observed_input_count",
+        ],
+    )
+
+    coverage = _require_mapping(payload["coverage"], "coverage")
+    _require_exact_keys(coverage, "coverage", ["candles", "regimes"])
+    candles = _require_mapping(coverage["candles"], "coverage.candles")
+    _require_exact_keys(
+        candles,
+        "coverage.candles",
+        [
+            "status",
+            "total_streams",
+            "observed_count_total",
+            "expected_count_total",
+            "coverage_pct",
+            "stale_stream_count",
+            "status_counts",
+            "items",
+        ],
+    )
+    regimes = _require_mapping(coverage["regimes"], "coverage.regimes")
+    _require_exact_keys(
+        regimes,
+        "coverage.regimes",
+        [
+            "status",
+            "total_streams",
+            "observed_count_total",
+            "expected_count_total",
+            "coverage_pct",
+            "zero_coverage_stream_count",
+            "status_counts",
+            "items",
+        ],
+    )
+
+    provenance = _require_mapping(payload["provenance"], "provenance")
+    _require_exact_keys(
+        provenance,
+        "provenance",
+        [
+            "status",
+            "allowed_sources",
+            "unknown_source_count",
+            "contaminated_source_count",
+            "source_findings",
+        ],
+    )
+
+    paper_chains = _require_mapping(payload["paper_chains"], "paper_chains")
+    _require_exact_keys(
+        paper_chains,
+        "paper_chains",
+        [
+            "status",
+            "total_streams",
+            "signal_count_total",
+            "decision_count_total",
+            "order_count_total",
+            "fill_count_total",
+            "complete_chain_count_total",
+            "partial_chain_count_total",
+            "zero_complete_stream_count",
+            "zero_signal_stream_count",
+            "average_signal_density_per_hour",
+            "status_counts",
+            "items",
+        ],
+    )
+
+    gap_findings = _require_mapping(payload["gap_findings"], "gap_findings")
+    _require_exact_keys(gap_findings, "gap_findings", ["summary", "items"])
+    gap_summary = _require_mapping(gap_findings["summary"], "gap_findings.summary")
+    _require_exact_keys(
+        gap_summary,
+        "gap_findings.summary",
+        ["total_count", "blocking_count", "warning_count", "info_count", "by_type"],
+    )
+    gap_by_type = _require_mapping(
+        gap_summary["by_type"], "gap_findings.summary.by_type"
+    )
+    normalized_gap_items = [
+        _validate_gap_item(index, item)
+        for index, item in enumerate(
+            _require_sequence(gap_findings["items"], "gap_findings.items")
+        )
+    ]
+
+    safety = _require_mapping(payload["safety"], "safety")
+    _require_exact_keys(
+        safety,
+        "safety",
+        [
+            "banner",
+            "lr_status",
+            "live_status",
+            "echtgeld_status",
+            "runtime_actions",
+            "db_execution",
+            "background_job_orchestration",
+            "allowed_scope",
+        ],
+    )
+    next_action_hints = tuple(
+        _require_string(item, f"next_action_hints[{index}]")
+        for index, item in enumerate(
+            _require_sequence(payload["next_action_hints"], "next_action_hints")
+        )
+    )
+
+    normalized = {
+        "metadata": {
+            "schema_version": schema_version,
+            "generated_at_utc": _format_ts(
+                _parse_ts(metadata["generated_at_utc"], "metadata.generated_at_utc")
+            ),
+            "collector_report_hash": _require_string(
+                metadata["collector_report_hash"], "metadata.collector_report_hash"
+            ),
+            "collector_report_id": _require_string(
+                metadata["collector_report_id"], "metadata.collector_report_id"
+            ),
+            "collector_report_schema_version": _require_string(
+                metadata["collector_report_schema_version"],
+                "metadata.collector_report_schema_version",
+            ),
+            "source_mode": source_mode,
+            "evidence_class": _require_string(
+                metadata["evidence_class"], "metadata.evidence_class"
+            ),
+            "evidence_class_version": _require_string(
+                metadata["evidence_class_version"],
+                "metadata.evidence_class_version",
+            ),
+            "produced_by": _require_string(
+                metadata["produced_by"], "metadata.produced_by"
+            ),
+            "collector_report_produced_at_utc": _format_ts(
+                _parse_ts(
+                    metadata["collector_report_produced_at_utc"],
+                    "metadata.collector_report_produced_at_utc",
+                )
+            ),
+        },
+        "status": {
+            "overall_status": overall_status,
+            "gap_counts": {
+                "blocking": _require_non_negative_int(
+                    gap_counts["blocking"], "status.gap_counts.blocking"
+                ),
+                "warning": _require_non_negative_int(
+                    gap_counts["warning"], "status.gap_counts.warning"
+                ),
+                "info": _require_non_negative_int(
+                    gap_counts["info"], "status.gap_counts.info"
+                ),
+            },
+            "has_zero_paper_chains": _require_bool(
+                status["has_zero_paper_chains"], "status.has_zero_paper_chains"
+            ),
+            "raw_evidence": {
+                key: _require_non_negative_int(
+                    raw_evidence[key], f"status.raw_evidence.{key}"
+                )
+                for key in raw_evidence
+            },
+        },
+        "gap_findings": {
+            "summary": {
+                "total_count": _require_non_negative_int(
+                    gap_summary["total_count"], "gap_findings.summary.total_count"
+                ),
+                "blocking_count": _require_non_negative_int(
+                    gap_summary["blocking_count"],
+                    "gap_findings.summary.blocking_count",
+                ),
+                "warning_count": _require_non_negative_int(
+                    gap_summary["warning_count"],
+                    "gap_findings.summary.warning_count",
+                ),
+                "info_count": _require_non_negative_int(
+                    gap_summary["info_count"], "gap_findings.summary.info_count"
+                ),
+                "by_type": {
+                    _require_string(
+                        key, f"gap_findings.summary.by_type[{index}].key"
+                    ): _require_non_negative_int(
+                        value,
+                        f"gap_findings.summary.by_type[{index}].value",
+                    )
+                    for index, (key, value) in enumerate(sorted(gap_by_type.items()))
+                },
+            },
+            "items": tuple(
+                sorted(
+                    normalized_gap_items,
+                    key=lambda item: (
+                        item["severity"],
+                        item["gap_type"],
+                        item["scope"],
+                        item["gap_id"],
+                    ),
+                )
+            ),
+        },
+        "next_action_hints": next_action_hints,
+    }
+    return normalized
+
+
+def load_snapshot_fixture(path: str | Path) -> dict[str, Any]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise AlertValidationError("Snapshot fixture JSON root must be an object")
+    return dict(payload)
+
+
+@dataclass(frozen=True, slots=True)
+class AlertFinding:
+    finding_id: str
+    finding_type: str
+    severity: str
+    title: str
+    summary: str
+    scope: str
+    source_refs: tuple[str, ...] = field(default_factory=tuple)
+    related_gap_ids: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True, slots=True)
+class AlertSummary:
+    highest_severity: str
+    total_count: int
+    critical_count: int
+    warn_count: int
+    info_count: int
+    manual_escalation_recommended: bool
+
+
+@dataclass(frozen=True, slots=True)
+class AlertReport:
+    schema_version: str
+    evaluated_at_utc: str
+    snapshot_generated_at_utc: str
+    collector_report_id: str
+    collector_report_hash: str
+    snapshot_age_minutes: int
+    summary: AlertSummary
+    findings: tuple[AlertFinding, ...]
+    manual_escalation_only: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _merge_finding(existing: AlertFinding, candidate: AlertFinding) -> AlertFinding:
+    return AlertFinding(
+        finding_id=existing.finding_id,
+        finding_type=existing.finding_type,
+        severity=existing.severity,
+        title=existing.title,
+        summary=existing.summary,
+        scope=existing.scope,
+        source_refs=tuple(sorted({*existing.source_refs, *candidate.source_refs})),
+        related_gap_ids=tuple(
+            sorted({*existing.related_gap_ids, *candidate.related_gap_ids})
+        ),
+    )
+
+
+def _make_gap_finding(gap_item: Mapping[str, Any]) -> AlertFinding | None:
+    finding_type = str(gap_item["gap_type"])
+    severity = _gap_severity_to_alert(str(gap_item["severity"]))
+    if finding_type in {"stale_feed", "zero_paper_chains", "provenance_contamination"}:
+        severity = "critical"
+    elif finding_type == "missing_signal_density":
+        severity = "critical"
+    elif finding_type == "partial_paper_chains":
+        severity = "warn"
+    elif finding_type == "stale_regime":
+        severity = "critical"
+    elif finding_type not in {
+        "missing_candles",
+        "missing_regime",
+        "stale_feed",
+        "stale_regime",
+        "zero_paper_chains",
+        "partial_paper_chains",
+        "missing_signal_density",
+        "provenance_contamination",
+    }:
+        return None
+
+    source_refs = tuple(sorted(str(item) for item in gap_item["source_refs"]))
+    summary = str(gap_item["message"])
+    finding_id = _build_finding_id(
+        finding_type=finding_type,
+        severity=severity,
+        scope=str(gap_item["scope"]),
+        source_refs=source_refs,
+        summary=summary,
+    )
+    return AlertFinding(
+        finding_id=finding_id,
+        finding_type=finding_type,
+        severity=severity,
+        title=_finding_title(finding_type),
+        summary=summary,
+        scope=str(gap_item["scope"]),
+        source_refs=source_refs,
+        related_gap_ids=(str(gap_item["gap_id"]),),
+    )
+
+
+def _make_stale_snapshot_finding(
+    *,
+    snapshot_age_minutes: int,
+    stale_after_minutes: int,
+    critical_after_minutes: int,
+    collector_report_id: str,
+) -> AlertFinding | None:
+    if snapshot_age_minutes <= stale_after_minutes:
+        return None
+    severity = "critical" if snapshot_age_minutes > critical_after_minutes else "warn"
+    summary = (
+        f"Snapshot {collector_report_id} is {snapshot_age_minutes} minutes old; "
+        f"thresholds warn>{stale_after_minutes} critical>{critical_after_minutes}"
+    )
+    return AlertFinding(
+        finding_id=_build_finding_id(
+            finding_type="stale_snapshot",
+            severity=severity,
+            scope="snapshot",
+            source_refs=(collector_report_id,),
+            summary=summary,
+        ),
+        finding_type="stale_snapshot",
+        severity=severity,
+        title=_finding_title("stale_snapshot"),
+        summary=summary,
+        scope="snapshot",
+        source_refs=(collector_report_id,),
+        related_gap_ids=tuple(),
+    )
+
+
+def build_alert_report(
+    snapshot_payload: Mapping[str, Any] | EvidenceSnapshot,
+    *,
+    evaluated_at_utc: datetime | str | None = None,
+    stale_snapshot_after_minutes: int = DEFAULT_STALE_SNAPSHOT_AFTER_MINUTES,
+    critical_snapshot_after_minutes: int = DEFAULT_CRITICAL_STALE_SNAPSHOT_AFTER_MINUTES,
+) -> AlertReport:
+    if stale_snapshot_after_minutes <= 0:
+        raise AlertValidationError("stale_snapshot_after_minutes must be > 0")
+    if critical_snapshot_after_minutes < stale_snapshot_after_minutes:
+        raise AlertValidationError(
+            "critical_snapshot_after_minutes must be >= stale_snapshot_after_minutes"
+        )
+
+    snapshot = _normalize_snapshot(snapshot_payload)
+    snapshot_generated_at = _parse_ts(
+        snapshot["metadata"]["generated_at_utc"],
+        "metadata.generated_at_utc",
+    )
+    evaluated_at = (
+        _parse_ts(evaluated_at_utc, "evaluated_at_utc")
+        if evaluated_at_utc is not None
+        else snapshot_generated_at
+    )
+    snapshot_age_minutes = int(
+        (evaluated_at - snapshot_generated_at).total_seconds() // 60
+    )
+    if snapshot_age_minutes < 0:
+        raise AlertValidationError(
+            "evaluated_at_utc must be >= metadata.generated_at_utc"
+        )
+
+    findings_by_id: dict[str, AlertFinding] = {}
+    for gap_item in snapshot["gap_findings"]["items"]:
+        finding = _make_gap_finding(gap_item)
+        if finding is None:
+            continue
+        existing = findings_by_id.get(finding.finding_id)
+        findings_by_id[finding.finding_id] = (
+            _merge_finding(existing, finding) if existing else finding
+        )
+
+    stale_snapshot_finding = _make_stale_snapshot_finding(
+        snapshot_age_minutes=snapshot_age_minutes,
+        stale_after_minutes=stale_snapshot_after_minutes,
+        critical_after_minutes=critical_snapshot_after_minutes,
+        collector_report_id=snapshot["metadata"]["collector_report_id"],
+    )
+    if stale_snapshot_finding is not None:
+        findings_by_id[stale_snapshot_finding.finding_id] = stale_snapshot_finding
+
+    findings = tuple(
+        sorted(
+            findings_by_id.values(),
+            key=lambda item: (
+                _severity_rank(item.severity),
+                item.finding_type,
+                item.scope,
+                item.finding_id,
+            ),
+        )
+    )
+    critical_count = sum(1 for item in findings if item.severity == "critical")
+    warn_count = sum(1 for item in findings if item.severity == "warn")
+    info_count = sum(1 for item in findings if item.severity == "info")
+    if critical_count:
+        highest_severity = "critical"
+    elif warn_count:
+        highest_severity = "warn"
+    else:
+        highest_severity = "info"
+    summary = AlertSummary(
+        highest_severity=highest_severity,
+        total_count=len(findings),
+        critical_count=critical_count,
+        warn_count=warn_count,
+        info_count=info_count,
+        manual_escalation_recommended=bool(findings),
+    )
+    return AlertReport(
+        schema_version=ALERT_REPORT_SCHEMA_VERSION,
+        evaluated_at_utc=_format_ts(evaluated_at),
+        snapshot_generated_at_utc=_format_ts(snapshot_generated_at),
+        collector_report_id=snapshot["metadata"]["collector_report_id"],
+        collector_report_hash=snapshot["metadata"]["collector_report_hash"],
+        snapshot_age_minutes=snapshot_age_minutes,
+        summary=summary,
+        findings=findings,
+    )
+
+
+def alert_report_to_markdown(report: AlertReport) -> str:
+    payload = report.to_dict()
+    lines = [
+        "# Evidence Alert Report",
+        "",
+        "## Summary",
+        f"- Highest severity: {payload['summary']['highest_severity']}",
+        f"- Evaluated at (UTC): {payload['evaluated_at_utc']}",
+        f"- Snapshot generated at (UTC): {payload['snapshot_generated_at_utc']}",
+        f"- Snapshot age (minutes): {payload['snapshot_age_minutes']}",
+        f"- Collector report: {payload['collector_report_id']}",
+        f"- Findings: total={payload['summary']['total_count']}, critical={payload['summary']['critical_count']}, warn={payload['summary']['warn_count']}, info={payload['summary']['info_count']}",
+        "- Escalation mode: manual only; no automatic GitHub writes.",
+        "",
+        "## Findings",
+    ]
+    if payload["findings"]:
+        for item in payload["findings"]:
+            lines.append(
+                f"- [{item['severity']}] {item['finding_type']} @ {item['scope']}: {item['summary']}"
+            )
+    else:
+        lines.append("- No alert-worthy evidence gaps detected.")
+    lines.extend(
+        [
+            "",
+            "## Manual Escalation",
+            "- Report and issue draft generation are local text outputs only.",
+            "- Review findings before creating or updating any GitHub issue manually.",
+            "- No LR-Go, no Live-Go, no Echtgeld-Go.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def build_issue_draft(
+    report: AlertReport,
+    *,
+    issue_number: str | int | None = None,
+    parent_issue: str | int | None = None,
+) -> str:
+    payload = report.to_dict()
+    title = f"[EVIDENCE][HARVESTER][ALERTS] Manual escalation for {payload['collector_report_id']}"
+    lines = [
+        title,
+        "",
+        "Manual escalation draft only. No automatic GitHub writes were performed.",
+        "",
+        "## Alerting summary",
+        f"- Collector report: `{payload['collector_report_id']}`",
+        f"- Highest severity: `{payload['summary']['highest_severity']}`",
+        f"- Evaluated at (UTC): `{payload['evaluated_at_utc']}`",
+        f"- Snapshot age (minutes): `{payload['snapshot_age_minutes']}`",
+        f"- Findings: total={payload['summary']['total_count']}, critical={payload['summary']['critical_count']}, warn={payload['summary']['warn_count']}, info={payload['summary']['info_count']}",
+    ]
+    if issue_number is not None:
+        lines.append(f"- Target issue context: `#{issue_number}`")
+    if parent_issue is not None:
+        lines.append(f"- Parent issue context: `#{parent_issue}`")
+    lines.extend(["", "## Findings"])
+    if payload["findings"]:
+        for item in payload["findings"]:
+            lines.append(
+                f"- [{item['severity']}] `{item['finding_type']}` at `{item['scope']}`: {item['summary']}"
+            )
+    else:
+        lines.append("- No findings.")
+    lines.extend(
+        [
+            "",
+            "## Safety",
+            "- Manual review required before any GitHub action.",
+            "- No runtime / no DB execution / no Docker / no secrets.",
+            "- No LR-Go / No Live-Go / No Echtgeld-Go.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate deterministic evidence-gap alerts from snapshot fixtures."
+    )
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        required=True,
+        help="Path to a normalized snapshot JSON fixture.",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        help="Optional path for the JSON alert report.",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        type=Path,
+        help="Optional path for the Markdown alert report.",
+    )
+    parser.add_argument(
+        "--issue-draft-output",
+        type=Path,
+        help="Optional path for a plain-text/Markdown issue draft.",
+    )
+    parser.add_argument(
+        "--evaluated-at-utc",
+        help="Optional explicit evaluation timestamp for deterministic stale-snapshot checks.",
+    )
+    parser.add_argument(
+        "--stale-snapshot-after-minutes",
+        type=int,
+        default=DEFAULT_STALE_SNAPSHOT_AFTER_MINUTES,
+        help="Warn threshold for snapshot staleness.",
+    )
+    parser.add_argument(
+        "--critical-snapshot-after-minutes",
+        type=int,
+        default=DEFAULT_CRITICAL_STALE_SNAPSHOT_AFTER_MINUTES,
+        help="Critical threshold for snapshot staleness.",
+    )
+    parser.add_argument(
+        "--issue-number",
+        help="Optional issue number to include in the issue draft text.",
+    )
+    parser.add_argument(
+        "--parent-issue",
+        help="Optional parent issue number to include in the issue draft text.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output instead of compact JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.write_text(text + ("" if text.endswith("\n") else "\n"), encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    snapshot_payload = load_snapshot_fixture(args.fixture)
+    report = build_alert_report(
+        snapshot_payload,
+        evaluated_at_utc=args.evaluated_at_utc,
+        stale_snapshot_after_minutes=args.stale_snapshot_after_minutes,
+        critical_snapshot_after_minutes=args.critical_snapshot_after_minutes,
+    )
+    report_payload = report.to_dict()
+    json_text = json.dumps(
+        report_payload,
+        indent=2 if args.pretty else None,
+        sort_keys=True,
+        ensure_ascii=True,
+    )
+    markdown_text = alert_report_to_markdown(report)
+    issue_draft_text = build_issue_draft(
+        report,
+        issue_number=args.issue_number,
+        parent_issue=args.parent_issue,
+    )
+
+    if args.json_output:
+        _write_text(args.json_output, json_text)
+    if args.markdown_output:
+        _write_text(args.markdown_output, markdown_text)
+    if args.issue_draft_output:
+        _write_text(args.issue_draft_output, issue_draft_text)
+    if (
+        not args.json_output
+        and not args.markdown_output
+        and not args.issue_draft_output
+    ):
+        print(json_text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/evidence_harvester/collector.py
+++ b/tools/evidence_harvester/collector.py
@@ -34,7 +34,9 @@ def _severity_rank(value: str) -> int:
     return {"blocking": 0, "warning": 1, "info": 2}.get(value, 99)
 
 
-def _status_for_missing(observed_count: int, expected_count: int, stale_minutes: int | None = None) -> str:
+def _status_for_missing(
+    observed_count: int, expected_count: int, stale_minutes: int | None = None
+) -> str:
     if stale_minutes is not None and stale_minutes >= 0:
         return "blocking" if stale_minutes > 0 else "warning"
     if observed_count == 0:
@@ -49,7 +51,9 @@ def _format_gap_type(symbol: str, venue: str, timeframe: str) -> str:
 
 
 def _hash_payload(payload: Mapping[str, Any]) -> str:
-    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    canonical = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
@@ -78,19 +82,38 @@ class EvidenceHarvesterCollector:
 
         candle_coverages = tuple(
             sorted(
-                (self._build_candle_coverage(item, collector_input.produced_at_utc) for item in collector_input.candle_coverages),
-                key=lambda item: (item.symbol, item.venue, item.timeframe, item.first_ts_utc),
+                (
+                    self._build_candle_coverage(item, collector_input.produced_at_utc)
+                    for item in collector_input.candle_coverages
+                ),
+                key=lambda item: (
+                    item.symbol,
+                    item.venue,
+                    item.timeframe,
+                    item.first_ts_utc,
+                ),
             )
         )
         regime_coverages = tuple(
             sorted(
-                (self._build_regime_coverage(item, collector_input.produced_at_utc) for item in collector_input.regime_coverages),
-                key=lambda item: (item.symbol, item.venue, item.timeframe, item.first_ts_utc),
+                (
+                    self._build_regime_coverage(item, collector_input.produced_at_utc)
+                    for item in collector_input.regime_coverages
+                ),
+                key=lambda item: (
+                    item.symbol,
+                    item.venue,
+                    item.timeframe,
+                    item.first_ts_utc,
+                ),
             )
         )
         paper_chain_coverages = tuple(
             sorted(
-                (self._build_paper_chain_finding(item) for item in collector_input.paper_chain_coverages),
+                (
+                    self._build_paper_chain_finding(item)
+                    for item in collector_input.paper_chain_coverages
+                ),
                 key=lambda item: (item.symbol, item.venue, item.timeframe),
             )
         )
@@ -132,12 +155,16 @@ class EvidenceHarvesterCollector:
             summary=summary,
         )
 
-    def _build_candle_coverage(self, item: CandleCoverageInput, captured_at_utc: datetime) -> CoverageFinding:
+    def _build_candle_coverage(
+        self, item: CandleCoverageInput, captured_at_utc: datetime
+    ) -> CoverageFinding:
         missing = item.expected_count - item.observed_count
         coverage = round(item.observed_count / item.expected_count, 6)
         stale_minutes = int((captured_at_utc - item.last_ts_utc).total_seconds() // 60)
         if stale_minutes < 0:
-            raise CollectorValidationError("last_ts_utc cannot be in the future relative to produced_at_utc")
+            raise CollectorValidationError(
+                "last_ts_utc cannot be in the future relative to produced_at_utc"
+            )
         status = "info"
         if stale_minutes > self.stale_after_minutes:
             status = "blocking"
@@ -164,7 +191,9 @@ class EvidenceHarvesterCollector:
         coverage = round(item.observed_count / item.expected_count, 6)
         stale_minutes = int((captured_at_utc - item.last_ts_utc).total_seconds() // 60)
         if stale_minutes < 0:
-            raise CollectorValidationError("last_ts_utc cannot be in the future relative to produced_at_utc")
+            raise CollectorValidationError(
+                "last_ts_utc cannot be in the future relative to produced_at_utc"
+            )
         status = "info"
         if item.observed_count == 0:
             status = "blocking"
@@ -265,7 +294,10 @@ class EvidenceHarvesterCollector:
         gap_index = 1
 
         for item in candle_coverages:
-            if item.stale_minutes is not None and item.stale_minutes > self.stale_after_minutes:
+            if (
+                item.stale_minutes is not None
+                and item.stale_minutes > self.stale_after_minutes
+            ):
                 findings.append(
                     GapFinding(
                         gap_id=f"gap-{gap_index:03d}",
@@ -296,7 +328,10 @@ class EvidenceHarvesterCollector:
                 gap_index += 1
 
         for item in regime_coverages:
-            if item.stale_minutes is not None and item.stale_minutes > self.stale_after_minutes:
+            if (
+                item.stale_minutes is not None
+                and item.stale_minutes > self.stale_after_minutes
+            ):
                 findings.append(
                     GapFinding(
                         gap_id=f"gap-{gap_index:03d}",
@@ -391,7 +426,11 @@ class EvidenceHarvesterCollector:
                     severity="blocking",
                     message=f"{provenance.unknown_source_count} observations came from unknown sources",
                     scope="provenance",
-                    source_refs=tuple(source.source for source in provenance.source_findings if source.status == "unknown"),
+                    source_refs=tuple(
+                        source.source
+                        for source in provenance.source_findings
+                        if source.status == "unknown"
+                    ),
                 )
             )
             gap_index += 1
@@ -404,12 +443,25 @@ class EvidenceHarvesterCollector:
                     severity="blocking",
                     message=f"{provenance.contaminated_source_count} observations were marked contaminated",
                     scope="provenance",
-                    source_refs=tuple(source.source for source in provenance.source_findings if source.status == "contaminated"),
+                    source_refs=tuple(
+                        source.source
+                        for source in provenance.source_findings
+                        if source.status == "contaminated"
+                    ),
                 )
             )
             gap_index += 1
 
-        return tuple(sorted(findings, key=lambda item: (_severity_rank(item.severity), item.gap_type, item.scope)))
+        return tuple(
+            sorted(
+                findings,
+                key=lambda item: (
+                    _severity_rank(item.severity),
+                    item.gap_type,
+                    item.scope,
+                ),
+            )
+        )
 
     def _build_summary(self, gap_findings: tuple[GapFinding, ...]) -> CollectorSummary:
         blocking = sum(1 for gap in gap_findings if gap.severity == "blocking")
@@ -421,7 +473,9 @@ class EvidenceHarvesterCollector:
             status = "warning"
         else:
             status = "ok"
-        has_zero_paper_chains = any(gap.gap_type == "zero_paper_chains" for gap in gap_findings)
+        has_zero_paper_chains = any(
+            gap.gap_type == "zero_paper_chains" for gap in gap_findings
+        )
         return CollectorSummary(
             overall_status=status,
             blocking_count=blocking,
@@ -481,7 +535,9 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     if args.output:
-        args.output.write_text(json_text + ("\n" if not json_text.endswith("\n") else ""), encoding="utf-8")
+        args.output.write_text(
+            json_text + ("\n" if not json_text.endswith("\n") else ""), encoding="utf-8"
+        )
     else:
         print(json_text)
     return 0

--- a/tools/evidence_harvester/models.py
+++ b/tools/evidence_harvester/models.py
@@ -56,9 +56,13 @@ def _parse_ts(value: Any, field_name: str) -> datetime:
         try:
             parsed = datetime.fromisoformat(text)
         except ValueError as exc:
-            raise CollectorValidationError(f"{field_name} must be an ISO-8601 UTC timestamp") from exc
+            raise CollectorValidationError(
+                f"{field_name} must be an ISO-8601 UTC timestamp"
+            ) from exc
     else:
-        raise CollectorValidationError(f"{field_name} must be an ISO-8601 UTC timestamp")
+        raise CollectorValidationError(
+            f"{field_name} must be an ISO-8601 UTC timestamp"
+        )
 
     if parsed.tzinfo is None:
         raise CollectorValidationError(f"{field_name} must be timezone-aware UTC")
@@ -95,17 +99,29 @@ class CandleCoverageInput:
         if not timeframe:
             raise CollectorValidationError("candle timeframe must not be blank")
 
-        first_ts_utc = _parse_ts(_coalesce(mapping, "first_ts_utc", "first_ts", "start_ts_utc", "start_ts"), "first_ts_utc")
-        last_ts_utc = _parse_ts(_coalesce(mapping, "last_ts_utc", "last_ts", "end_ts_utc", "end_ts"), "last_ts_utc")
+        first_ts_utc = _parse_ts(
+            _coalesce(mapping, "first_ts_utc", "first_ts", "start_ts_utc", "start_ts"),
+            "first_ts_utc",
+        )
+        last_ts_utc = _parse_ts(
+            _coalesce(mapping, "last_ts_utc", "last_ts", "end_ts_utc", "end_ts"),
+            "last_ts_utc",
+        )
         if last_ts_utc < first_ts_utc:
             raise CollectorValidationError("candle last_ts_utc must be >= first_ts_utc")
 
-        observed_count = _parse_int(_coalesce(mapping, "observed_count", "count"), "observed_count")
-        expected_count = _parse_int(_coalesce(mapping, "expected_count", "expected"), "expected_count")
+        observed_count = _parse_int(
+            _coalesce(mapping, "observed_count", "count"), "observed_count"
+        )
+        expected_count = _parse_int(
+            _coalesce(mapping, "expected_count", "expected"), "expected_count"
+        )
         if expected_count == 0:
             raise CollectorValidationError("expected_count must be > 0")
         if observed_count > expected_count:
-            raise CollectorValidationError("observed_count cannot exceed expected_count")
+            raise CollectorValidationError(
+                "observed_count cannot exceed expected_count"
+            )
 
         return cls(
             symbol=symbol,
@@ -141,19 +157,33 @@ class RegimeCoverageInput:
         if not timeframe:
             raise CollectorValidationError("regime timeframe must not be blank")
 
-        first_ts_utc = _parse_ts(_coalesce(mapping, "first_ts_utc", "first_ts", "start_ts_utc", "start_ts"), "first_ts_utc")
-        last_ts_utc = _parse_ts(_coalesce(mapping, "last_ts_utc", "last_ts", "end_ts_utc", "end_ts"), "last_ts_utc")
+        first_ts_utc = _parse_ts(
+            _coalesce(mapping, "first_ts_utc", "first_ts", "start_ts_utc", "start_ts"),
+            "first_ts_utc",
+        )
+        last_ts_utc = _parse_ts(
+            _coalesce(mapping, "last_ts_utc", "last_ts", "end_ts_utc", "end_ts"),
+            "last_ts_utc",
+        )
         if last_ts_utc < first_ts_utc:
             raise CollectorValidationError("regime last_ts_utc must be >= first_ts_utc")
 
-        observed_count = _parse_int(_coalesce(mapping, "observed_count", "count"), "observed_count")
-        expected_count = _parse_int(_coalesce(mapping, "expected_count", "expected"), "expected_count")
+        observed_count = _parse_int(
+            _coalesce(mapping, "observed_count", "count"), "observed_count"
+        )
+        expected_count = _parse_int(
+            _coalesce(mapping, "expected_count", "expected"), "expected_count"
+        )
         if expected_count == 0:
             raise CollectorValidationError("expected_count must be > 0")
         if observed_count > expected_count:
-            raise CollectorValidationError("observed_count cannot exceed expected_count")
+            raise CollectorValidationError(
+                "observed_count cannot exceed expected_count"
+            )
 
-        dist_raw = _coalesce(mapping, "regime_distribution", "distribution", "regimes") or {}
+        dist_raw = (
+            _coalesce(mapping, "regime_distribution", "distribution", "regimes") or {}
+        )
         if not isinstance(dist_raw, Mapping):
             raise CollectorValidationError("regime_distribution must be a mapping")
         distribution: list[tuple[str, int]] = []
@@ -213,9 +243,15 @@ class PaperChainCoverageInput:
         if observation_window_hours <= 0:
             raise CollectorValidationError("observation_window_hours must be > 0")
 
-        signal_count = _parse_int(_coalesce(mapping, "signal_count", "signals"), "signal_count")
-        decision_count = _parse_int(_coalesce(mapping, "decision_count", "decisions"), "decision_count")
-        order_count = _parse_int(_coalesce(mapping, "order_count", "orders"), "order_count")
+        signal_count = _parse_int(
+            _coalesce(mapping, "signal_count", "signals"), "signal_count"
+        )
+        decision_count = _parse_int(
+            _coalesce(mapping, "decision_count", "decisions"), "decision_count"
+        )
+        order_count = _parse_int(
+            _coalesce(mapping, "order_count", "orders"), "order_count"
+        )
         fill_count = _parse_int(_coalesce(mapping, "fill_count", "fills"), "fill_count")
         complete_chain_count = _parse_int(
             _coalesce(mapping, "complete_chain_count", "complete_chains"),
@@ -251,9 +287,15 @@ class ProvenanceObservationInput:
         source = str(_coalesce(mapping, "source", "source_ref", "venue")).strip()
         if not source:
             raise CollectorValidationError("provenance source must not be blank")
-        observed_count = _parse_int(_coalesce(mapping, "observed_count", "count"), "observed_count")
-        contaminated = bool(_coalesce(mapping, "contaminated", "is_contaminated") or False)
-        return cls(source=source, observed_count=observed_count, contaminated=contaminated)
+        observed_count = _parse_int(
+            _coalesce(mapping, "observed_count", "count"), "observed_count"
+        )
+        contaminated = bool(
+            _coalesce(mapping, "contaminated", "is_contaminated") or False
+        )
+        return cls(
+            source=source, observed_count=observed_count, contaminated=contaminated
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -267,8 +309,12 @@ class CollectorInput:
     stale_after_minutes: int = 120
     candle_coverages: tuple[CandleCoverageInput, ...] = field(default_factory=tuple)
     regime_coverages: tuple[RegimeCoverageInput, ...] = field(default_factory=tuple)
-    paper_chain_coverages: tuple[PaperChainCoverageInput, ...] = field(default_factory=tuple)
-    provenance_observations: tuple[ProvenanceObservationInput, ...] = field(default_factory=tuple)
+    paper_chain_coverages: tuple[PaperChainCoverageInput, ...] = field(
+        default_factory=tuple
+    )
+    provenance_observations: tuple[ProvenanceObservationInput, ...] = field(
+        default_factory=tuple
+    )
 
     @classmethod
     def from_mapping(cls, mapping: Mapping[str, Any]) -> "CollectorInput":
@@ -279,18 +325,30 @@ class CollectorInput:
         if not is_valid_evidence_class(evidence_class):
             raise CollectorValidationError(f"unknown evidence_class={evidence_class!r}")
 
-        produced_by = str(_coalesce(mapping, "produced_by", "runner", "collector_id")).strip()
+        produced_by = str(
+            _coalesce(mapping, "produced_by", "runner", "collector_id")
+        ).strip()
         if not produced_by:
             raise CollectorValidationError("produced_by must not be blank")
         produced_at_utc = _parse_ts(
             _coalesce(mapping, "produced_at_utc", "captured_at_utc", "generated_at"),
             "produced_at_utc",
         )
-        source_mode = str(_coalesce(mapping, "source_mode", "mode") or "fixture").strip()
-        allowed_sources_raw = _coalesce(mapping, "allowed_provenance_sources", "allowed_sources") or []
-        if not isinstance(allowed_sources_raw, Sequence) or isinstance(allowed_sources_raw, (str, bytes)):
-            raise CollectorValidationError("allowed_provenance_sources must be a sequence")
-        allowed_provenance_sources = _sorted_source_tuple([str(item) for item in allowed_sources_raw])
+        source_mode = str(
+            _coalesce(mapping, "source_mode", "mode") or "fixture"
+        ).strip()
+        allowed_sources_raw = (
+            _coalesce(mapping, "allowed_provenance_sources", "allowed_sources") or []
+        )
+        if not isinstance(allowed_sources_raw, Sequence) or isinstance(
+            allowed_sources_raw, (str, bytes)
+        ):
+            raise CollectorValidationError(
+                "allowed_provenance_sources must be a sequence"
+            )
+        allowed_provenance_sources = _sorted_source_tuple(
+            [str(item) for item in allowed_sources_raw]
+        )
 
         stale_after_minutes = _parse_int(
             _coalesce(mapping, "stale_after_minutes", "max_age_minutes") or 120,
@@ -309,14 +367,20 @@ class CollectorInput:
             produced_by=produced_by,
             produced_at_utc=produced_at_utc,
             evidence_class=evidence_class,
-            evidence_class_version=str(_coalesce(mapping, "evidence_class_version") or "1.0"),
+            evidence_class_version=str(
+                _coalesce(mapping, "evidence_class_version") or "1.0"
+            ),
             source_mode=source_mode,
             allowed_provenance_sources=allowed_provenance_sources,
             stale_after_minutes=stale_after_minutes,
             candle_coverages=_load_rows("candle_coverages", CandleCoverageInput),
             regime_coverages=_load_rows("regime_coverages", RegimeCoverageInput),
-            paper_chain_coverages=_load_rows("paper_chain_coverages", PaperChainCoverageInput),
-            provenance_observations=_load_rows("provenance_observations", ProvenanceObservationInput),
+            paper_chain_coverages=_load_rows(
+                "paper_chain_coverages", PaperChainCoverageInput
+            ),
+            provenance_observations=_load_rows(
+                "provenance_observations", ProvenanceObservationInput
+            ),
         )
 
     def canonical_payload(self) -> dict[str, Any]:


### PR DESCRIPTION
## Brain Evidence Block
- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_brain_used: false
- repo_fallback_used: true
- repo_fallback_reason: insufficient_evidence
- context_tool_status: available
- context_trust_level: low
- records_found: none

## Alerting summary
- add deterministic evidence-gap alerting in 	ools/evidence_harvester/alerts.py`n- read normalized snapshot objects or snapshot JSON fixtures fail-closed
- classify and deduplicate alert findings with stable inding_id`n- render local Markdown/JSON reports and manual issue-draft text only
- update README and add unit coverage for alerting behavior

## Severity contract
- info: low-severity pass-through findings only
- warn: non-blocking coverage gaps or stale snapshot beyond warn threshold
- critical: stale feeds, blocking coverage gaps, zero paper chains, provenance contamination, or stale snapshot beyond critical threshold

## Tests
- python -m pytest tests/unit/tools/evidence_harvester -q`n- uff check tools/evidence_harvester tests/unit/tools/evidence_harvester`n- lack --check tools/evidence_harvester tests/unit/tools/evidence_harvester`n- git diff --check`n- forbidden-pattern scan reviewed: matches are safety/documentation strings in README.md and existing scheduler.py, not executable write/runtime behavior

## No automatic GitHub writes
- module generates text outputs only and does not create issues or comments

## No runtime / no DB execution / no Docker / no secrets
- confirmed in code, tests, and docs scope

## No LR-Go / No Live-Go / No Echtgeld-Go
- confirmed; safety messaging remains explicit

Closes #3350