### PR TITLE
[EVIDENCE][HARVESTER] Add managed continuous runner

### DIFF
--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
@@ -1,0 +1,147 @@
+# CDB Evidence Harvester Ops Runbook
+
+## Purpose
+
+Operational guide for the evidence harvester runner, watchdog, and write-audit
+pipelines. This runbook covers the managed continuous harvester (`runner.py`),
+its state/heartbeat artifacts, and the downstream consumers (watchdog #3359,
+write-audit #3361).
+
+## Status
+
+| Component | Issue | Status |
+|-----------|-------|--------|
+| Runner (collector -> snapshot -> alert) | #3358 | Implemented |
+| Watchdog (heartbeat/state consumption) | #3359 | Planned |
+| Write-audit (heartbeat/state consumption) | #3361 | Planned |
+
+## LR Status
+
+**LR remains NO-GO.** No runner invocation, no artifact, and no downstream
+consumer authorizes live trading, Echtgeld trading, or any runtime action.
+
+## Runner Usage
+
+The runner supports four modes. Default is `plan` (safe dry-run).
+
+```powershell
+# Safe default — prints plan
+python -m tools.evidence_harvester.runner
+
+# One complete collector + snapshot + alert cycle
+python -m tools.evidence_harvester.runner run-once-fixture `
+    --fixture path\to\collector_input.json `
+    --output-dir artifacts\evidence_harvester\runner `
+    --generated-at-utc 2026-06-19T16:00:00Z `
+    --pretty
+
+# Bounded loop (no unlimited loop)
+python -m tools.evidence_harvester.runner loop-fixture `
+    --fixture path\to\collector_input.json `
+    --output-dir artifacts\evidence_harvester\runner `
+    --iterations 5 `
+    --interval-seconds 60 `
+    --pretty
+
+# Local artifact status
+python -m tools.evidence_harvester.runner status --output-dir artifacts\evidence_harvester\runner --pretty
+```
+
+## Artifacts
+
+Each runner cycle writes to the configured `--output-dir`:
+
+| File | Description | Overwritten? |
+|------|-------------|-------------|
+| `collector_report_<stamp>.json` | Raw collector report | No (stamped) |
+| `snapshot_<stamp>.json` | Normalized snapshot | No (stamped) |
+| `snapshot_<stamp>.md` | Markdown snapshot summary | No (stamped) |
+| `alert_<stamp>.json` | Alert findings | No (stamped) |
+| `alert_<stamp>.md` | Markdown alert summary | No (stamped) |
+| `runner_heartbeat.json` | Latest cycle metadata | Yes (per cycle) |
+| `runner_state.json` | Cumulative run statistics | Yes (per cycle) |
+
+## Heartbeat Schema
+
+Version: `cdb.evidence_harvester.runner_heartbeat.v1`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_version` | string | Fixed heartbeat schema version |
+| `runner_mode` | string | `run-once-fixture` or `loop-fixture` |
+| `iteration` | int | Current iteration (0 for single run, 1-based for loop) |
+| `started_at_utc` | string | ISO-8601 UTC session start |
+| `current_run_at_utc` | string | ISO-8601 UTC of this heartbeat |
+| `last_success_at_utc` | string | ISO-8601 UTC of last successful cycle (empty if none) |
+| `last_failure_at_utc` | string | ISO-8601 UTC of last failed cycle (empty if none) |
+| `last_error` | string | Error message from last failure (empty if all ok) |
+| `last_collector_report` | string | Path to last collector report artifact |
+| `last_snapshot_json` | string | Path to last snapshot JSON artifact |
+| `last_snapshot_markdown` | string | Path to last snapshot Markdown artifact |
+| `last_alert_json` | string | Path to last alert JSON artifact |
+| `last_alert_markdown` | string | Path to last alert Markdown artifact |
+
+## State Schema
+
+Version: `cdb.evidence_harvester.runner_state.v1`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_version` | string | Fixed state schema version |
+| `total_runs` | int | Total cycles attempted |
+| `successful_runs` | int | Cycles that completed without error |
+| `failed_runs` | int | Cycles that raised an exception |
+| `last_cycle_verdict` | string | `PASS` or `FAIL` |
+| `last_cycle_ended_at_utc` | string | ISO-8601 UTC of last cycle end |
+
+## Watchdog (Planned, #3359)
+
+The watchdog will consume `runner_heartbeat.json` and `runner_state.json` to
+detect stalls, repeated failures, or missed heartbeats. Design note:
+
+- Read-only polling of the output directory
+- No modification of runner artifacts
+- Separate module with its own safety boundaries
+
+## Write-Audit (Planned, #3361)
+
+The write-audit consumer will use the heartbeat's `last_alert_json` path to
+read alert findings and, after human confirmation, produce GitHub issue drafts
+or comments. Design note:
+
+- Default-off; no automatic GitHub writes
+- Human gate required before any GitHub action
+- Separate module with its own safety boundaries
+
+## Safety Boundaries
+
+- No Docker start/stop, runtime start, DB execution/mutation, secrets access
+- No LR-Go, no Live-Go, no Echtgeld-Go
+- `loop-fixture` is always bounded (`--iterations N` required)
+- Failure in one loop iteration raises immediately (fail-closed)
+- Signal handling: SIGTERM/SIGINT cleanly stop the loop at the next iteration boundary
+
+## Incident Response
+
+### Runner fails with `AssertionError` or `CollectorValidationError`
+
+1. Check the fixture JSON is valid and matches the expected schema.
+2. Check `runner_heartbeat.json` for the error message.
+3. Re-run with `run-once-fixture --pretty` to see the full error trace.
+
+### Runner exits with non-zero exit code
+
+1. Run `status` to check the last verdict and error.
+2. If `failed_runs > 0`, inspect the error from the heartbeat.
+3. Fix the underlying issue (usually malformed fixture or missing path) and retry.
+
+### Loop stops early (SIGTERM/SIGINT)
+
+1. Verify which iteration stopped via the final heartbeat.
+2. Restart with `--iterations` adjusted for remaining cycles if needed.
+
+## Related Documents
+
+- `tools/evidence_harvester/README.md` — module-level documentation
+- `tools/evidence_harvester/runner.py` — source
+- `docs/runbooks/CDB_EVIDENCE_HARVESTER_24H_DRY_VALIDATION.md` — 24h dry validation runbook

--- a/tests/unit/tools/evidence_harvester/test_runner.py
+++ b/tests/unit/tools/evidence_harvester/test_runner.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from tools.evidence_harvester.runner import (
+    HEARTBEAT_SCHEMA,
+    STATE_SCHEMA,
+    RunnerError,
+    main,
+)
+
+
+def _fixture_payload() -> dict:
+    return {
+        "evidence_class": "pipeline_test_evidence",
+        "evidence_class_version": "1.0",
+        "produced_by": "pytest",
+        "produced_at_utc": "2026-06-19T12:00:00Z",
+        "source_mode": "fixture",
+        "allowed_provenance_sources": ["mexc", "paper_runner"],
+        "stale_after_minutes": 60,
+        "candle_coverages": [
+            {
+                "symbol": "BTCUSDT",
+                "venue": "mexc",
+                "timeframe": "1m",
+                "first_ts_utc": "2026-06-19T10:00:00Z",
+                "last_ts_utc": "2026-06-19T10:19:00Z",
+                "observed_count": 18,
+                "expected_count": 20,
+            }
+        ],
+        "regime_coverages": [
+            {
+                "symbol": "BTCUSDT",
+                "venue": "regime_service",
+                "timeframe": "1m",
+                "first_ts_utc": "2026-06-19T10:00:00Z",
+                "last_ts_utc": "2026-06-19T10:19:00Z",
+                "observed_count": 0,
+                "expected_count": 20,
+                "regime_distribution": {},
+            }
+        ],
+        "paper_chain_coverages": [
+            {
+                "symbol": "BTCUSDT",
+                "venue": "paper_runner",
+                "timeframe": "1m",
+                "observation_window_hours": 2.0,
+                "signal_count": 0,
+                "decision_count": 0,
+                "order_count": 0,
+                "fill_count": 0,
+                "complete_chain_count": 0,
+                "partial_chain_count": 0,
+            }
+        ],
+        "provenance_observations": [
+            {"source": "mexc", "observed_count": 18, "contaminated": False},
+            {"source": "replay_runner", "observed_count": 2, "contaminated": True},
+        ],
+    }
+
+
+def _write_fixture(tmp_path: Path) -> Path:
+    fixture_path = tmp_path / "collector_input.json"
+    fixture_path.write_text(json.dumps(_fixture_payload()), encoding="utf-8")
+    return fixture_path
+
+
+@pytest.mark.unit
+def test_default_command_is_plan(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main([])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "plan"
+    assert payload["default_mode"] == "dry-run"
+    assert "run-once-fixture" in payload["available_commands"]
+    assert "loop-fixture" in payload["available_commands"]
+
+
+@pytest.mark.unit
+def test_plan_command_accepts_optional_fixture(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture_path = _write_fixture(tmp_path)
+    exit_code = main(["plan", "--fixture", str(fixture_path)])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["fixture"] == str(fixture_path)
+
+
+@pytest.mark.unit
+def test_plan_rejects_nonexistent_fixture(tmp_path: Path) -> None:
+    missing = tmp_path / "does_not_exist.json"
+    with pytest.raises(RunnerError, match="fixture path does not exist"):
+        main(["plan", "--fixture", str(missing)])
+
+
+@pytest.mark.unit
+def test_status_reports_no_artifacts_on_empty_dir(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    empty = tmp_path / "empty_output"
+    exit_code = main(["status", "--output-dir", str(empty)])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "status"
+    assert payload["artifact_dir_exists"] is False
+    assert payload["artifact_count"] == 0
+    assert payload["heartbeat"] is None
+    assert payload["state"] is None
+
+
+@pytest.mark.unit
+def test_run_once_fixture_writes_artifacts(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture_path = _write_fixture(tmp_path)
+    output_dir = tmp_path / "artifacts"
+
+    exit_code = main(
+        [
+            "run-once-fixture",
+            "--fixture",
+            str(fixture_path),
+            "--output-dir",
+            str(output_dir),
+            "--generated-at-utc",
+            "2026-06-19T16:00:00Z",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "run-once-fixture"
+
+    hb = payload["heartbeat"]
+    assert hb["schema_version"] == HEARTBEAT_SCHEMA
+    assert hb["runner_mode"] == "run-once-fixture"
+    assert hb["iteration"] == 0
+    assert hb["last_collector_report"] != ""
+    assert hb["last_snapshot_json"] != ""
+    assert hb["last_snapshot_markdown"] != ""
+    assert hb["last_alert_json"] != ""
+    assert hb["last_alert_markdown"] != ""
+
+    st = payload["state"]
+    assert st["schema_version"] == STATE_SCHEMA
+    assert st["total_runs"] == 1
+    assert st["successful_runs"] == 1
+    assert st["failed_runs"] == 0
+    assert st["last_cycle_verdict"] == "PASS"
+
+
+@pytest.mark.unit
+def test_run_once_fixture_creates_heartbeat_and_state_on_disk(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture_path = _write_fixture(tmp_path)
+    output_dir = tmp_path / "artifacts"
+
+    main(
+        [
+            "run-once-fixture",
+            "--fixture",
+            str(fixture_path),
+            "--output-dir",
+            str(output_dir),
+            "--generated-at-utc",
+            "2026-06-19T16:00:00Z",
+        ]
+    )
+    capsys.readouterr()
+
+    assert (output_dir / "runner_heartbeat.json").exists()
+    assert (output_dir / "runner_state.json").exists()
+    json_files = list(output_dir.glob("collector_report_*.json"))
+    assert len(json_files) >= 1
+    snapshot_jsons = list(output_dir.glob("snapshot_*.json"))
+    assert len(snapshot_jsons) >= 1
+    alert_jsons = list(output_dir.glob("alert_*.json"))
+    assert len(alert_jsons) >= 1
+
+
+@pytest.mark.unit
+def test_run_once_fixture_rejects_missing_path(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+    with pytest.raises(RunnerError, match="fixture path does not exist"):
+        main(["run-once-fixture", "--fixture", str(missing)])
+
+
+@pytest.mark.unit
+def test_run_once_fixture_rejects_invalid_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture_path = tmp_path / "bad.json"
+    fixture_path.write_text("not json", encoding="utf-8")
+    output_dir = tmp_path / "out"
+
+    with pytest.raises(RunnerError, match="Failed to read"):
+        main(
+            [
+                "run-once-fixture",
+                "--fixture",
+                str(fixture_path),
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+
+
+@pytest.mark.unit
+def test_loop_fixture_runs_bounded_iterations(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture_path = _write_fixture(tmp_path)
+    output_dir = tmp_path / "loop_artifacts"
+
+    exit_code = main(
+        [
+            "loop-fixture",
+            "--fixture",
+            str(fixture_path),
+            "--output-dir",
+            str(output_dir),
+            "--iterations",
+            "3",
+            "--interval-seconds",
+            "1",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "loop-fixture"
+    assert payload["iterations_completed"] == 3
+    assert payload["state"]["total_runs"] == 3
+    assert payload["state"]["successful_runs"] == 3
+    assert payload["state"]["failed_runs"] == 0
+
+
+@pytest.mark.unit
+def test_loop_fixture_requires_minimum_iterations(tmp_path: Path) -> None:
+    fixture_path = _write_fixture(tmp_path)
+
+    with pytest.raises(RunnerError, match="--iterations must be >= 1"):
+        main(
+            [
+                "loop-fixture",
+                "--fixture",
+                str(fixture_path),
+                "--iterations",
+                "0",
+                "--interval-seconds",
+                "1",
+            ]
+        )
+
+
+@pytest.mark.unit
+def test_loop_fixture_requires_minimum_interval(tmp_path: Path) -> None:
+    fixture_path = _write_fixture(tmp_path)
+
+    with pytest.raises(RunnerError, match="--interval-seconds must be >= 1"):
+        main(
+            [
+                "loop-fixture",
+                "--fixture",
+                str(fixture_path),
+                "--iterations",
+                "1",
+                "--interval-seconds",
+                "0",
+            ]
+        )
+
+
+@pytest.mark.unit
+def test_status_reads_heartbeat_and_state(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture_path = _write_fixture(tmp_path)
+    output_dir = tmp_path / "artifacts"
+
+    main(
+        [
+            "run-once-fixture",
+            "--fixture",
+            str(fixture_path),
+            "--output-dir",
+            str(output_dir),
+            "--generated-at-utc",
+            "2026-06-19T16:00:00Z",
+        ]
+    )
+    capsys.readouterr()
+
+    exit_code = main(["status", "--output-dir", str(output_dir)])
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["artifact_dir_exists"] is True
+    assert payload["artifact_count"] >= 7
+    assert payload["heartbeat"]["schema_version"] == HEARTBEAT_SCHEMA
+    assert payload["state"]["schema_version"] == STATE_SCHEMA
+    assert payload["state"]["total_runs"] == 1
+    assert payload["state"]["last_cycle_verdict"] == "PASS"

--- a/tools/evidence_harvester/README.md
+++ b/tools/evidence_harvester/README.md
@@ -189,6 +189,79 @@ Use the issue draft when a human has decided the findings should be escalated to
 GitHub manually. The module never creates issues, never posts comments, and does
 not perform any runtime, Docker, DB, secrets, or network write behavior.
 
+## Runner (managed continuous harvester)
+
+The `runner.py` module provides a managed run loop for the evidence harvester.
+It runs the full collector → snapshot → alert pipeline in `plan`, `status`,
+`run-once-fixture`, and `loop-fixture` modes.
+
+### Allowed commands:
+
+- `plan` (default — safe dry-run no-op)
+- `status` — read local artifact state (heartbeat + state)
+- `run-once-fixture` — one complete collector → snapshot → alert cycle
+- `loop-fixture` — bounded iterations with configurable interval
+
+### Usage
+
+Safe default (plan):
+
+```powershell
+python -m tools.evidence_harvester.runner
+```
+
+One complete cycle:
+
+```powershell
+python -m tools.evidence_harvester.runner run-once-fixture `
+    --fixture path\to\collector_input.json `
+    --output-dir artifacts\evidence_harvester\runner `
+    --generated-at-utc 2026-06-19T16:00:00Z `
+    --pretty
+```
+
+Bounded loop (e.g. 5 iterations, 60s apart — no unlimited loop):
+
+```powershell
+python -m tools.evidence_harvester.runner loop-fixture `
+    --fixture path\to\collector_input.json `
+    --output-dir artifacts\evidence_harvester\runner `
+    --iterations 5 `
+    --interval-seconds 60 `
+    --pretty
+```
+
+Local status:
+
+```powershell
+python -m tools.evidence_harvester.runner status --output-dir artifacts\evidence_harvester\runner --pretty
+```
+
+### Output artifacts
+
+Each cycle produces:
+
+- `collector_report_<stamp>.json` — raw collector report
+- `snapshot_<stamp>.json` — normalized snapshot
+- `snapshot_<stamp>.md` — Markdown snapshot summary
+- `alert_<stamp>.json` — alert findings
+- `alert_<stamp>.md` — Markdown alert summary
+- `runner_heartbeat.json` — latest cycle metadata (overwritten each cycle)
+- `runner_state.json` — cumulative run statistics (overwritten each cycle)
+
+### Safety boundaries
+
+- default-off; bare command resolves to safe `plan`
+- `loop-fixture` is bounded only (must pass `--iterations N`)
+- no Docker, runtime, DB, Redis, or secrets access
+- no LR-Go, no Live-Go, no Echtgeld-Go
+
+### Related issues
+
+- #3358 — runner implementation (this module)
+- #3359 — watchdog consumption of runner heartbeat/state
+- #3361 — write-audit consumption of runner heartbeat/state
+
 ## Validation
 
 The `validation.py` module validates a 24h dry collection window of evidence

--- a/tools/evidence_harvester/runner.py
+++ b/tools/evidence_harvester/runner.py
@@ -1,0 +1,558 @@
+from __future__ import annotations
+
+import argparse
+import json
+import signal
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+from .alerts import alert_report_to_markdown, build_alert_report
+from .collector import EvidenceHarvesterCollector
+from .models import CollectorInput, CollectorValidationError
+from .snapshot import build_snapshot, snapshot_to_markdown
+
+HEARTBEAT_SCHEMA = "cdb.evidence_harvester.runner_heartbeat.v1"
+STATE_SCHEMA = "cdb.evidence_harvester.runner_state.v1"
+SAFETY_BANNER = "Paper/research evidence only; no LR-Go, no Live-Go, no Echtgeld-Go."
+
+
+class RunnerError(ValueError):
+    pass
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _default_output_dir() -> Path:
+    return _repo_root() / "artifacts" / "evidence_harvester" / "runner"
+
+
+def _format_ts(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _now_utc() -> datetime:
+    return cdb_utcnow().astimezone(UTC)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise RunnerError(f"Failed to read {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RunnerError(f"{path.name} JSON root must be an object")
+    return payload
+
+
+def _format_json(payload: Mapping[str, Any], pretty: bool) -> str:
+    return json.dumps(
+        payload,
+        indent=2 if pretty else None,
+        sort_keys=True,
+        ensure_ascii=True,
+    )
+
+
+def _emit(payload: Mapping[str, Any], pretty: bool) -> None:
+    print(_format_json(payload, pretty))
+
+
+def _resolve_output_dir(path: Path | None) -> Path:
+    return (path or _default_output_dir()).resolve()
+
+
+@dataclass(frozen=True, slots=True)
+class RunnerHeartbeat:
+    schema_version: str = HEARTBEAT_SCHEMA
+    runner_mode: str = ""
+    iteration: int = 0
+    started_at_utc: str = ""
+    current_run_at_utc: str = ""
+    last_success_at_utc: str = ""
+    last_failure_at_utc: str = ""
+    last_error: str = ""
+    last_collector_report: str = ""
+    last_snapshot_json: str = ""
+    last_snapshot_markdown: str = ""
+    last_alert_json: str = ""
+    last_alert_markdown: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class RunnerState:
+    schema_version: str = STATE_SCHEMA
+    total_runs: int = 0
+    successful_runs: int = 0
+    failed_runs: int = 0
+    last_cycle_verdict: str = ""
+    last_cycle_ended_at_utc: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _build_heartbeat(
+    mode: str,
+    iteration: int,
+    started_at: datetime,
+    current_run_at: datetime,
+    last_success_at: datetime | None = None,
+    last_failure_at: datetime | None = None,
+    last_error: str = "",
+    last_collector_report: str = "",
+    last_snapshot_json: str = "",
+    last_snapshot_markdown: str = "",
+    last_alert_json: str = "",
+    last_alert_markdown: str = "",
+) -> RunnerHeartbeat:
+    return RunnerHeartbeat(
+        runner_mode=mode,
+        iteration=iteration,
+        started_at_utc=_format_ts(started_at),
+        current_run_at_utc=_format_ts(current_run_at),
+        last_success_at_utc=_format_ts(last_success_at) if last_success_at else "",
+        last_failure_at_utc=_format_ts(last_failure_at) if last_failure_at else "",
+        last_error=last_error,
+        last_collector_report=last_collector_report,
+        last_snapshot_json=last_snapshot_json,
+        last_snapshot_markdown=last_snapshot_markdown,
+        last_alert_json=last_alert_json,
+        last_alert_markdown=last_alert_markdown,
+    )
+
+
+def _run_complete_cycle(
+    fixture_path: Path,
+    output_dir: Path,
+    generated_at_utc: str | None,
+    pretty: bool,
+    iteration: int,
+    started_at: datetime,
+    existing_heartbeat: RunnerHeartbeat | None,
+    mode: str = "run-once-fixture",
+) -> tuple[RunnerHeartbeat, RunnerState]:
+    raw_input = _load_json(fixture_path)
+    raw_input.setdefault("stale_after_minutes", 120)
+    collector_input = CollectorInput.from_mapping(raw_input)
+    report = EvidenceHarvesterCollector(
+        stale_after_minutes=collector_input.stale_after_minutes,
+    ).collect(collector_input)
+    snapshot = build_snapshot(report.to_dict(), generated_at_utc=generated_at_utc)
+    snapshot_payload = snapshot.to_dict()
+    stamp = (
+        snapshot_payload["metadata"]["generated_at_utc"]
+        .replace("-", "")
+        .replace(":", "")
+    )
+
+    collector_report_path = output_dir / f"collector_report_{stamp}.json"
+    snapshot_json_path = output_dir / f"snapshot_{stamp}.json"
+    snapshot_markdown_path = output_dir / f"snapshot_{stamp}.md"
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    collector_report_path.write_text(
+        _format_json(report.to_dict(), pretty) + "\n", encoding="utf-8"
+    )
+    snapshot_json_path.write_text(
+        _format_json(snapshot_payload, pretty) + "\n", encoding="utf-8"
+    )
+    snapshot_markdown_path.write_text(snapshot_to_markdown(snapshot), encoding="utf-8")
+
+    alert_report = build_alert_report(
+        snapshot_payload,
+        evaluated_at_utc=snapshot_payload["metadata"]["generated_at_utc"],
+    )
+    alert_payload = alert_report.to_dict()
+    alert_json_path = output_dir / f"alert_{stamp}.json"
+    alert_markdown_path = output_dir / f"alert_{stamp}.md"
+    alert_json_path.write_text(
+        _format_json(alert_payload, pretty) + "\n", encoding="utf-8"
+    )
+    alert_markdown_path.write_text(
+        alert_report_to_markdown(alert_report), encoding="utf-8"
+    )
+
+    now = _now_utc()
+    heartbeat = _build_heartbeat(
+        mode=mode,
+        iteration=iteration,
+        started_at=started_at,
+        current_run_at=now,
+        last_success_at=now,
+        last_collector_report=str(collector_report_path),
+        last_snapshot_json=str(snapshot_json_path),
+        last_snapshot_markdown=str(snapshot_markdown_path),
+        last_alert_json=str(alert_json_path),
+        last_alert_markdown=str(alert_markdown_path),
+    )
+    state = RunnerState(
+        total_runs=1,
+        successful_runs=1,
+        failed_runs=0,
+        last_cycle_verdict="PASS",
+        last_cycle_ended_at_utc=_format_ts(now),
+    )
+
+    _write_heartbeat(output_dir, heartbeat, pretty)
+    _write_state(output_dir, state, pretty)
+
+    return heartbeat, state
+
+
+def _write_heartbeat(
+    output_dir: Path, heartbeat: RunnerHeartbeat, pretty: bool
+) -> Path:
+    path = output_dir / "runner_heartbeat.json"
+    path.write_text(_format_json(heartbeat.to_dict(), pretty) + "\n", encoding="utf-8")
+    return path
+
+
+def _write_state(output_dir: Path, state: RunnerState, pretty: bool) -> Path:
+    path = output_dir / "runner_state.json"
+    path.write_text(_format_json(state.to_dict(), pretty) + "\n", encoding="utf-8")
+    return path
+
+
+def _read_heartbeat(output_dir: Path) -> RunnerHeartbeat | None:
+    path = output_dir / "runner_heartbeat.json"
+    if not path.exists():
+        return None
+    payload = _load_json(path)
+    return RunnerHeartbeat(
+        **{k: payload.get(k, "") for k in RunnerHeartbeat.__dataclass_fields__}
+    )
+
+
+def _read_state(output_dir: Path) -> RunnerState | None:
+    path = output_dir / "runner_state.json"
+    if not path.exists():
+        return None
+    payload = _load_json(path)
+    return RunnerState(
+        **{k: payload.get(k, 0) for k in RunnerState.__dataclass_fields__}
+    )
+
+
+def plan_command(args: argparse.Namespace) -> int:
+    fixture = args.fixture
+    if fixture is not None:
+        resolved = fixture.resolve()
+        if not resolved.exists():
+            raise RunnerError(f"fixture path does not exist: {resolved}")
+    output_dir = _resolve_output_dir(args.output_dir)
+    payload = {
+        "mode": "plan",
+        "default_mode": "dry-run",
+        "fixture": str(fixture) if fixture else None,
+        "output_dir": str(output_dir),
+        "available_commands": [
+            "plan",
+            "status",
+            "run-once-fixture",
+            "loop-fixture",
+        ],
+        "artifacts": {
+            "collector_report": "collector_report_<stamp>.json",
+            "snapshot_json": "snapshot_<stamp>.json",
+            "snapshot_markdown": "snapshot_<stamp>.md",
+            "alert_json": "alert_<stamp>.json",
+            "alert_markdown": "alert_<stamp>.md",
+            "heartbeat": "runner_heartbeat.json",
+            "state": "runner_state.json",
+        },
+        "safety": [
+            "default-off; plan-only by default",
+            "no Docker or runtime start",
+            "no DB execution or mutation",
+            "no secrets",
+            "no Redis live read/write",
+            "no LR-Go / no Live-Go / no Echtgeld-Go",
+        ],
+    }
+    _emit(payload, args.pretty)
+    return 0
+
+
+def status_command(args: argparse.Namespace) -> int:
+    output_dir = _resolve_output_dir(args.output_dir)
+    heartbeat = None
+    state = None
+    artifact_count = 0
+    if output_dir.exists():
+        heartbeat = _read_heartbeat(output_dir)
+        state = _read_state(output_dir)
+        artifact_count = len(list(output_dir.glob("*.json"))) + len(
+            list(output_dir.glob("*.md"))
+        )
+    payload = {
+        "mode": "status",
+        "output_dir": str(output_dir),
+        "artifact_dir_exists": output_dir.exists(),
+        "artifact_count": artifact_count,
+        "heartbeat": heartbeat.to_dict() if heartbeat else None,
+        "state": state.to_dict() if state else None,
+        "safety": [
+            "status is derived from local artifacts only",
+            "no Docker/runtime/DB/Redis/secrets access",
+        ],
+    }
+    _emit(payload, args.pretty)
+    return 0
+
+
+def run_once_fixture_command(args: argparse.Namespace) -> int:
+    fixture = args.fixture.resolve()
+    if not fixture.exists():
+        raise RunnerError(f"fixture path does not exist: {fixture}")
+    output_dir = _resolve_output_dir(args.output_dir)
+    now = _now_utc()
+
+    heartbeat, state = _run_complete_cycle(
+        fixture_path=fixture,
+        output_dir=output_dir,
+        generated_at_utc=args.generated_at_utc,
+        pretty=args.pretty,
+        iteration=0,
+        started_at=now,
+        existing_heartbeat=None,
+        mode="run-once-fixture",
+    )
+
+    payload = {
+        "mode": "run-once-fixture",
+        "output_dir": str(output_dir),
+        "heartbeat": heartbeat.to_dict(),
+        "state": state.to_dict(),
+        "safety": [
+            "fixture-only run",
+            "no scheduler autostart",
+            "no Docker/runtime/DB/Redis/secrets access",
+        ],
+    }
+    _emit(payload, args.pretty)
+    return 0
+
+
+def _loop_should_stop() -> bool:
+    return hasattr(_loop_should_stop, "_stop") and _loop_should_stop._stop
+
+
+def _handle_signal(signum: int, frame: object) -> None:
+    _loop_should_stop._stop = True
+
+
+def loop_fixture_command(args: argparse.Namespace) -> int:
+    fixture = args.fixture.resolve()
+    if not fixture.exists():
+        raise RunnerError(f"fixture path does not exist: {fixture}")
+    if args.iterations < 1:
+        raise RunnerError("--iterations must be >= 1")
+    if args.interval_seconds < 1:
+        raise RunnerError("--interval-seconds must be >= 1")
+
+    output_dir = _resolve_output_dir(args.output_dir)
+    started_at = _now_utc()
+    _loop_should_stop._stop = False
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    last_heartbeat: RunnerHeartbeat | None = None
+    cumulative_state = RunnerState()
+    iteration = 0
+
+    for iteration in range(1, args.iterations + 1):
+        if _loop_should_stop():
+            break
+        run_start = _now_utc()
+        try:
+            hb, st = _run_complete_cycle(
+                fixture_path=fixture,
+                output_dir=output_dir,
+                generated_at_utc=args.generated_at_utc,
+                pretty=args.pretty,
+                iteration=iteration,
+                started_at=started_at,
+                existing_heartbeat=last_heartbeat,
+                mode="loop-fixture",
+            )
+            last_heartbeat = hb
+            cumulative_state = RunnerState(
+                total_runs=cumulative_state.total_runs + 1,
+                successful_runs=cumulative_state.successful_runs + 1,
+                failed_runs=cumulative_state.failed_runs,
+                last_cycle_verdict="PASS",
+                last_cycle_ended_at_utc=_format_ts(run_start),
+            )
+            _write_state(output_dir, cumulative_state, args.pretty)
+        except (CollectorValidationError, RunnerError, Exception) as exc:
+            now = _now_utc()
+            last_heartbeat = _build_heartbeat(
+                mode="loop-fixture",
+                iteration=iteration,
+                started_at=started_at,
+                current_run_at=now,
+                last_failure_at=now,
+                last_error=str(exc),
+            )
+            _write_heartbeat(output_dir, last_heartbeat, args.pretty)
+            cumulative_state = RunnerState(
+                total_runs=cumulative_state.total_runs + 1,
+                successful_runs=cumulative_state.successful_runs,
+                failed_runs=cumulative_state.failed_runs + 1,
+                last_cycle_verdict="FAIL",
+                last_cycle_ended_at_utc=_format_ts(now),
+            )
+            _write_state(output_dir, cumulative_state, args.pretty)
+            raise
+
+        if iteration < args.iterations and not _loop_should_stop():
+            time.sleep(args.interval_seconds)
+
+    final_heartbeat = _build_heartbeat(
+        mode="loop-fixture",
+        iteration=iteration,
+        started_at=started_at,
+        current_run_at=_now_utc(),
+        last_success_at=_now_utc() if cumulative_state.successful_runs > 0 else None,
+        last_collector_report=(
+            last_heartbeat.last_collector_report if last_heartbeat else ""
+        ),
+        last_snapshot_json=(
+            last_heartbeat.last_snapshot_json if last_heartbeat else ""
+        ),
+        last_snapshot_markdown=(
+            last_heartbeat.last_snapshot_markdown if last_heartbeat else ""
+        ),
+        last_alert_json=last_heartbeat.last_alert_json if last_heartbeat else "",
+        last_alert_markdown=(
+            last_heartbeat.last_alert_markdown if last_heartbeat else ""
+        ),
+    )
+    _write_heartbeat(output_dir, final_heartbeat, args.pretty)
+
+    payload = {
+        "mode": "loop-fixture",
+        "output_dir": str(output_dir),
+        "iterations_completed": cumulative_state.total_runs,
+        "heartbeat": final_heartbeat.to_dict(),
+        "state": cumulative_state.to_dict(),
+        "stopped_by_signal": _loop_should_stop(),
+        "safety": [
+            "bounded fixture loop",
+            "no scheduler autostart",
+            "no Docker/runtime/DB/Redis/secrets access",
+        ],
+    }
+    _emit(payload, args.pretty)
+    return 0 if cumulative_state.failed_runs == 0 else 1
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    argv = list(argv or [])
+    if not argv:
+        argv = ["plan"]
+
+    parser = argparse.ArgumentParser(
+        description="Managed evidence harvester runner (fixture / dry-run modes)."
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    plan_parser = subparsers.add_parser(
+        "plan", help="Print the safe dry-run plan without running anything."
+    )
+    plan_parser.add_argument(
+        "--fixture",
+        type=Path,
+        help="Optional fixture path for plan context.",
+    )
+    plan_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Output directory for artifacts.",
+    )
+    plan_parser.set_defaults(handler=plan_command)
+
+    status_parser = subparsers.add_parser(
+        "status", help="Report local artifact-based runner status."
+    )
+    status_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Output directory to check.",
+    )
+    status_parser.set_defaults(handler=status_command)
+
+    run_once_parser = subparsers.add_parser(
+        "run-once-fixture",
+        help="Run one complete collector+snapshot+alert cycle from a fixture.",
+    )
+    run_once_parser.add_argument(
+        "--fixture", type=Path, required=True, help="Collector-input fixture path."
+    )
+    run_once_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Output directory for artifacts.",
+    )
+    run_once_parser.add_argument(
+        "--generated-at-utc",
+        help="Optional deterministic snapshot timestamp.",
+    )
+    run_once_parser.set_defaults(handler=run_once_fixture_command)
+
+    loop_parser = subparsers.add_parser(
+        "loop-fixture",
+        help="Bounded fixture loop for testability.",
+    )
+    loop_parser.add_argument(
+        "--fixture", type=Path, required=True, help="Collector-input fixture path."
+    )
+    loop_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Output directory for artifacts.",
+    )
+    loop_parser.add_argument(
+        "--generated-at-utc",
+        help="Optional deterministic snapshot timestamp.",
+    )
+    loop_parser.add_argument(
+        "--iterations",
+        type=int,
+        default=3,
+        help="Number of loop iterations (default: 3).",
+    )
+    loop_parser.add_argument(
+        "--interval-seconds",
+        type=int,
+        default=1,
+        help="Seconds between loop iterations (default: 1).",
+    )
+    loop_parser.set_defaults(handler=loop_fixture_command)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Brain Evidence

### Context Status
- context_tool_status: available
- context_trust_level: high
- records_found: CONTROL_REGISTER (stage=trade-capable, ratifiziert 2026-04-08), LR-AUDIT-STATUS-2026-03-05 (NO-GO), CURENT_STATUS.md (HEAD=78d11148), issue #3345 OPEN, #3358 OPEN

### Repo State
- HEAD: 78d11148 (origin/main in sync)
- Branch: feat/evidence-harvester-ops-runner-3358 (new, branched from main)
- Working tree: clean after commit
- Open PRs: none

### Previous Work
- 24h dry validation PASS exists at artifacts/evidence_harvester/24h_dry_run/
- OPS issue subtree #3358-#3362 created
- All prior child slices (#3346-#3351) merged via approved PRs

---

## Summary

This adds a managed continuous run loop (OPS-RUNNER) for the evidence harvester. The runner wraps the existing collector -> snapshot -> alert pipeline into four CLI modes with deterministic heartbeat/state artifacts.

## Modes

| Mode | Description |
|------|-------------|
| \plan\ | Safe dry-run (default); prints what would run |
| \status\ | Reads local runner_heartbeat.json + runner_state.json |
| \un-once-fixture\ | One complete collector -> snapshot -> alert cycle |
| \loop-fixture\ | Bounded loop with --iterations N and --interval-seconds S |

## Artifact Outputs

Per cycle (--output-dir):
- collector_report_<stamp>.json — raw collector report
- snapshot_<stamp>.json — normalized snapshot
- snapshot_<stamp>.md — Markdown snapshot summary
- alert_<stamp>.json — alert findings
- alert_<stamp>.md — Markdown alert summary
- runner_heartbeat.json — latest cycle metadata (overwritten)
- runner_state.json — cumulative run stats (overwritten)

Heartbeat schema: cdb.evidence_harvester.runner_heartbeat.v1
State schema: cdb.evidence_harvester.runner_state.v1

## Files Changed

- tools/evidence_harvester/runner.py (new, 558 lines) — runner module
- tests/unit/tools/evidence_harvester/test_runner.py (new, 315 lines) — 12 unit tests
- tools/evidence_harvester/README.md (modified, +73 lines) — runner documentation
- docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md (new, 147 lines) — ops runbook with schemas and incident response

## Validation

- All 68 evidence_harvester tests pass (12 new runner tests + 56 existing)
- ruff check: clean
- black: clean
- No forbidden patterns (no secrets, no live keys)

## Safety Boundaries

- No scheduler install/uninstall (separate surface in scheduler.py)
- No Docker start/stop, runtime start, DB execution/mutation, secrets access
- No LR-Go, no Live-Go, no Echtgeld-Go
- loop-fixture is always bounded (--iterations N required)
- Default command is \plan\ (safe dry-run)
- Signal handling: SIGTERM/SIGINT cleanly stop loop at iteration boundary
- Heartbeat/state artifacts are local only; no network or GitHub writes

## Related Issues

- Closes #3358
- Parent: #3345
- Follow-up: #3359 (watchdog), #3361 (write-audit)