### PR TITLE
[EVIDENCE][HARVESTER] Add stall and staleness watchdog

### DIFF
--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
@@ -12,7 +12,7 @@ write-audit #3361).
 | Component | Issue | Status |
 |-----------|-------|--------|
 | Runner (collector -> snapshot -> alert) | #3358 | Implemented |
-| Watchdog (heartbeat/state consumption) | #3359 | Planned |
+| Watchdog (heartbeat/state consumption) | #3359 | Implemented |
 | Write-audit (heartbeat/state consumption) | #3361 | Planned |
 
 ## LR Status
@@ -94,14 +94,81 @@ Version: `cdb.evidence_harvester.runner_state.v1`
 | `last_cycle_verdict` | string | `PASS` or `FAIL` |
 | `last_cycle_ended_at_utc` | string | ISO-8601 UTC of last cycle end |
 
-## Watchdog (Planned, #3359)
+## Watchdog (#3359)
 
-The watchdog will consume `runner_heartbeat.json` and `runner_state.json` to
-detect stalls, repeated failures, or missed heartbeats. Design note:
+The watchdog (`watchdog.py`) consumes `runner_heartbeat.json` and
+`runner_state.json` plus all stamped artifacts to detect stalls, repeated
+failures, missed heartbeats, or stale evidence.
 
-- Read-only polling of the output directory
-- No modification of runner artifacts
-- Separate module with its own safety boundaries
+### Modes
+
+- `status` — full read-only inspection: heartbeat freshness, runner state,
+  required artifact presence, JSON integrity, safety flags, and snapshot cadence
+- `check-artifacts` — artifact presence and integrity only (skip heartbeat/state)
+- `render-escalation-draft` — render a manual escalation draft from a saved report JSON
+
+### Verdicts
+
+| Verdict | Meaning |
+|---------|---------|
+| PASS    | All checks clean: heartbeat fresh, state PASS, required artifacts present, no malformed JSON, safety flags correct |
+| WARN    | Some non-critical thresholds exceeded: artifact age near limit, runner has historical failures, snapshot cadence slightly exceeded |
+| FAIL    | Critical issue: stale heartbeat, missing heartbeat/state, missing required artifact, malformed JSON, runner FAIL verdict, or wrong safety flag |
+
+### Usage
+
+```powershell
+# Full status check (default)
+python -m tools.evidence_harvester.watchdog status ^
+    --artifact-dir artifacts\evidence_harvester\runner ^
+    --pretty
+
+# Save outputs
+python -m tools.evidence_harvester.watchdog status ^
+    --artifact-dir artifacts\evidence_harvester\runner ^
+    --json-output artifacts\evidence_harvester\watchdog_report.json ^
+    --markdown-output artifacts\evidence_harvester\watchdog_report.md ^
+    --escalation-draft-output artifacts\evidence_harvester\manual_escalation_draft.md
+
+# Deterministic evaluation
+python -m tools.evidence_harvester.watchdog status ^
+    --artifact-dir artifacts\evidence_harvester\runner ^
+    --evaluated-at-utc "2026-06-19T16:00:00Z"
+```
+
+### Safety boundaries
+
+- Read-only; never modifies heartbeat, state, or artifact files
+- No automatic restart, GitHub write, Docker, runtime, DB, Redis, or secrets action
+- Escalation draft is local text output only; human review required
+- Feeds #3361 (write-audit) and #3362 (OPS validation)
+
+### Incident Response for Watchdog
+
+#### Watchdog reports FAIL
+
+1. Run `python -m tools.evidence_harvester.watchdog status --pretty` to see which check failed.
+2. Check `runner_heartbeat.json` exists and has recent `current_run_at_utc`.
+3. Check `runner_state.json` exists and `last_cycle_verdict` is `PASS`.
+4. Verify required artifact files exist in the artifact directory.
+5. If heartbeat is stale, check whether the runner is still running.
+6. If artifacts are missing, check the runner output directory permissions and paths.
+7. If JSON is malformed, inspect the file manually.
+8. Fix the root cause and re-run the watchdog to verify PASS.
+
+#### Watchdog reports WARN
+
+1. Review the warn-level findings.
+2. If heartbeat age is near threshold, the runner may be running slower than expected.
+3. If failed_runs > 0, inspect the runner error log or heartbeat `last_error`.
+4. If snapshot cadence is exceeded, check whether the snapshot interval needs adjustment.
+5. Take corrective action within the next operational window.
+
+#### Watchdog escalation draft
+
+1. Use `render-escalation-draft` after a FAIL to produce human-readable escalation text.
+2. Review the draft before creating any GitHub issue manually.
+3. No automatic GitHub writes are performed by the watchdog.
 
 ## Write-Audit (Planned, #3361)
 

--- a/tests/unit/tools/evidence_harvester/test_watchdog.py
+++ b/tests/unit/tools/evidence_harvester/test_watchdog.py
@@ -1,0 +1,852 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from tools.evidence_harvester.watchdog import (
+    WATCHDOG_REPORT_SCHEMA,
+    WatchdogError,
+    WatchdogReport,
+    main,
+    render_escalation_draft,
+    report_to_markdown,
+    run_check_artifacts,
+    run_status,
+)
+
+
+def _ts(offset_minutes: int = 0) -> str:
+    now = datetime.now(UTC)
+    target = now - timedelta(minutes=offset_minutes)
+    return target.isoformat().replace("+00:00", "Z")
+
+
+def _now_iso() -> str:
+    return _ts(0)
+
+
+def _write_heartbeat(
+    artifact_dir: Path,
+    *,
+    age_minutes: int = 1,
+    mode: str = "loop-fixture",
+    iteration: int = 5,
+    last_error: str = "",
+) -> Path:
+    payload = {
+        "schema_version": "cdb.evidence_harvester.runner_heartbeat.v1",
+        "runner_mode": mode,
+        "iteration": iteration,
+        "started_at_utc": _ts(age_minutes + 10),
+        "current_run_at_utc": _ts(age_minutes),
+        "last_success_at_utc": _ts(age_minutes),
+        "last_failure_at_utc": "",
+        "last_error": last_error,
+        "last_collector_report": str(artifact_dir / "collector_report_20260619.json"),
+        "last_snapshot_json": str(artifact_dir / "snapshot_20260619.json"),
+        "last_snapshot_markdown": str(artifact_dir / "snapshot_20260619.md"),
+        "last_alert_json": str(artifact_dir / "alert_20260619.json"),
+        "last_alert_markdown": str(artifact_dir / "alert_20260619.md"),
+    }
+    path = artifact_dir / "runner_heartbeat.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _write_state(
+    artifact_dir: Path,
+    *,
+    total_runs: int = 5,
+    successful_runs: int = 5,
+    failed_runs: int = 0,
+    last_verdict: str = "PASS",
+) -> Path:
+    payload = {
+        "schema_version": "cdb.evidence_harvester.runner_state.v1",
+        "total_runs": total_runs,
+        "successful_runs": successful_runs,
+        "failed_runs": failed_runs,
+        "last_cycle_verdict": last_verdict,
+        "last_cycle_ended_at_utc": _ts(1),
+    }
+    path = artifact_dir / "runner_state.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _write_collector_report(artifact_dir: Path, stamp: str = "20260619") -> Path:
+    payload = {
+        "schema_version": "evidence_harvester.collector_report.v1",
+        "report_id": f"report_{stamp}",
+        "evidence_class": "pipeline_test_evidence",
+        "evidence_class_version": "1.0",
+        "produced_by": "pytest",
+        "produced_at_utc": _ts(15),
+        "source_mode": "fixture",
+        "raw_evidence": {
+            "candle_input_count": 10,
+            "regime_input_count": 5,
+            "paper_chain_input_count": 3,
+            "provenance_input_count": 2,
+            "observed_input_count": 20,
+        },
+        "candle_coverages": [],
+        "regime_coverages": [],
+        "paper_chain_coverages": [],
+        "provenance": {
+            "allowed_sources": ["mexc"],
+            "source_findings": [],
+            "unknown_source_count": 0,
+            "contaminated_source_count": 0,
+        },
+        "gap_findings": [],
+        "summary": {
+            "overall_status": "ok",
+            "blocking_count": 0,
+            "warning_count": 0,
+            "info_count": 0,
+            "has_zero_paper_chains": False,
+        },
+    }
+    path = artifact_dir / f"collector_report_{stamp}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _write_snapshot(
+    artifact_dir: Path,
+    stamp: str = "20260619",
+    *,
+    age_minutes: int = 10,
+    schema_version: str = "cdb.evidence_harvester.snapshot.v1",
+    lr_status: str = "NO-GO",
+    live_status: str = "NO-GO",
+    echtgeld_status: str = "NO-GO",
+) -> Path:
+    payload = {
+        "metadata": {
+            "schema_version": schema_version,
+            "generated_at_utc": _ts(age_minutes),
+            "collector_report_hash": "sha256:abc123",
+            "collector_report_id": f"report_{stamp}",
+            "collector_report_schema_version": "evidence_harvester.collector_report.v1",
+            "source_mode": "fixture",
+            "evidence_class": "pipeline_test_evidence",
+            "evidence_class_version": "1.0",
+            "produced_by": "pytest",
+            "collector_report_produced_at_utc": _ts(age_minutes + 1),
+        },
+        "safety": {
+            "banner": "Paper/research evidence only; no LR-Go, no Live-Go, no Echtgeld-Go.",
+            "lr_status": lr_status,
+            "live_status": live_status,
+            "echtgeld_status": echtgeld_status,
+            "runtime_actions": "not_allowed",
+            "db_execution": "not_allowed",
+            "background_job_orchestration": "not_in_scope",
+            "allowed_scope": "fixture-based snapshot generation only",
+        },
+        "status": {
+            "overall_status": "ok",
+            "gap_counts": {"blocking": 0, "warning": 0, "info": 0},
+            "has_zero_paper_chains": False,
+            "raw_evidence": {
+                "candle_input_count": 10,
+                "regime_input_count": 5,
+                "paper_chain_input_count": 3,
+                "provenance_input_count": 2,
+                "observed_input_count": 20,
+            },
+        },
+        "coverage": {
+            "candles": {
+                "status": "ok",
+                "total_streams": 1,
+                "observed_count_total": 18,
+                "expected_count_total": 20,
+                "coverage_pct": 0.9,
+                "stale_stream_count": 0,
+                "status_counts": {"blocking": 0, "warning": 0, "info": 1},
+                "items": [],
+            },
+            "regimes": {
+                "status": "ok",
+                "total_streams": 1,
+                "observed_count_total": 10,
+                "expected_count_total": 20,
+                "coverage_pct": 0.5,
+                "zero_coverage_stream_count": 0,
+                "status_counts": {"blocking": 0, "warning": 0, "info": 1},
+                "items": [],
+            },
+        },
+        "provenance": {
+            "status": "ok",
+            "allowed_sources": ["mexc"],
+            "unknown_source_count": 0,
+            "contaminated_source_count": 0,
+            "source_findings": [],
+        },
+        "paper_chains": {
+            "status": "ok",
+            "total_streams": 0,
+            "signal_count_total": 0,
+            "decision_count_total": 0,
+            "order_count_total": 0,
+            "fill_count_total": 0,
+            "complete_chain_count_total": 0,
+            "partial_chain_count_total": 0,
+            "zero_complete_stream_count": 0,
+            "zero_signal_stream_count": 0,
+            "average_signal_density_per_hour": 0.0,
+            "status_counts": {"blocking": 0, "warning": 0, "info": 0},
+            "items": [],
+        },
+        "gap_findings": {
+            "summary": {
+                "total_count": 0,
+                "blocking_count": 0,
+                "warning_count": 0,
+                "info_count": 0,
+                "by_type": {},
+            },
+            "items": [],
+        },
+        "next_action_hints": ["No immediate gap-driven action."],
+    }
+    path = artifact_dir / f"snapshot_{stamp}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _write_alert(
+    artifact_dir: Path,
+    stamp: str = "20260619",
+    *,
+    schema_version: str = "cdb.evidence_harvester.alert_report.v1",
+    manual_escalation_only: bool = True,
+) -> Path:
+    payload = {
+        "schema_version": schema_version,
+        "evaluated_at_utc": _ts(5),
+        "snapshot_generated_at_utc": _ts(10),
+        "collector_report_id": f"report_{stamp}",
+        "collector_report_hash": "sha256:abc123",
+        "snapshot_age_minutes": 10,
+        "summary": {
+            "highest_severity": "info",
+            "total_count": 0,
+            "critical_count": 0,
+            "warn_count": 0,
+            "info_count": 0,
+            "manual_escalation_recommended": False,
+        },
+        "findings": [],
+        "manual_escalation_only": manual_escalation_only,
+    }
+    path = artifact_dir / f"alert_{stamp}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _write_artifact_dir(
+    tmp_path: Path,
+    *,
+    heartbeat_age_minutes: int = 1,
+    snapshot_age_minutes: int = 10,
+    state_failed_runs: int = 0,
+    state_verdict: str = "PASS",
+    include_heartbeat: bool = True,
+    include_state: bool = True,
+    include_snapshot: bool = True,
+    include_alert: bool = True,
+    include_snapshot_md: bool = True,
+    include_alert_md: bool = True,
+) -> Path:
+    d = tmp_path / "runner_artifacts"
+    d.mkdir(parents=True, exist_ok=True)
+
+    if include_heartbeat:
+        _write_heartbeat(d, age_minutes=heartbeat_age_minutes)
+    if include_state:
+        _write_state(
+            d,
+            failed_runs=state_failed_runs,
+            last_verdict=state_verdict,
+        )
+    if include_snapshot:
+        _write_snapshot(d, age_minutes=snapshot_age_minutes)
+    if include_alert:
+        _write_alert(d)
+    _write_collector_report(d)
+    if include_snapshot_md:
+        (d / "snapshot_20260619.md").write_text("# Snapshot", encoding="utf-8")
+    if include_alert_md:
+        (d / "alert_20260619.md").write_text("# Alert", encoding="utf-8")
+
+    return d
+
+
+# ============================================================
+# run_status — PASS
+# ============================================================
+
+
+@pytest.mark.unit
+def test_status_pass_with_fresh_artifacts(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.schema_version == WATCHDOG_REPORT_SCHEMA
+    assert report.mode == "status"
+    assert report.verdict.verdict == "PASS"
+    assert report.heartbeat_fresh is True
+    assert report.runner_state_ok is True
+    assert report.required_artifacts_present is True
+    assert report.verdict.fail_count == 0
+
+
+@pytest.mark.unit
+def test_status_pass_default_dir_resolves(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "PASS"
+
+
+# ============================================================
+# run_status — WARN
+# ============================================================
+
+
+@pytest.mark.unit
+def test_status_warn_on_approaching_stale_heartbeat(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path, heartbeat_age_minutes=100)
+    now = datetime.now(UTC)
+
+    report = run_status(d, max_age_seconds=7200, warn_age_seconds=1800, now=now)
+
+    assert report.verdict.verdict == "WARN"
+    assert report.heartbeat_fresh is True
+
+
+@pytest.mark.unit
+def test_status_warn_on_failed_runs(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path, state_failed_runs=2)
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "WARN"
+    assert report.runner_state_ok is True
+
+
+# ============================================================
+# run_status — FAIL
+# ============================================================
+
+
+@pytest.mark.unit
+def test_status_fail_on_stale_heartbeat(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path, heartbeat_age_minutes=200)
+    now = datetime.now(UTC)
+
+    report = run_status(d, max_age_seconds=60, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+    assert report.heartbeat_fresh is False
+
+
+@pytest.mark.unit
+def test_status_fail_on_missing_heartbeat(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path, include_heartbeat=False)
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+
+
+@pytest.mark.unit
+def test_status_fail_on_missing_state(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path, include_state=False)
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+
+
+@pytest.mark.unit
+def test_status_fail_on_runner_failure_verdict(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path, state_verdict="FAIL")
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+    assert report.runner_state_ok is False
+
+
+@pytest.mark.unit
+def test_status_fail_on_missing_required_artifact(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path, include_snapshot=False)
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+    assert report.required_artifacts_present is False
+
+
+@pytest.mark.unit
+def test_status_fail_on_stale_snapshot(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path, snapshot_age_minutes=200)
+    now = datetime.now(UTC)
+
+    report = run_status(d, max_age_seconds=60, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+
+
+@pytest.mark.unit
+def test_status_fail_on_empty_dir(tmp_path: Path) -> None:
+    d = tmp_path / "empty"
+    d.mkdir()
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+
+
+# ============================================================
+# run_status — malformed JSON
+# ============================================================
+
+
+@pytest.mark.unit
+def test_status_fail_on_malformed_heartbeat_json(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    (d / "runner_heartbeat.json").write_text("not json", encoding="utf-8")
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+
+
+@pytest.mark.unit
+def test_status_fail_on_malformed_state_json(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    (d / "runner_state.json").write_text("not json", encoding="utf-8")
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+
+
+@pytest.mark.unit
+def test_status_fail_on_malformed_snapshot_json(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    (d / "snapshot_20260619.json").write_text("not json", encoding="utf-8")
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+
+
+@pytest.mark.unit
+def test_status_fail_on_malformed_alert_json(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    (d / "alert_20260619.json").write_text("not json", encoding="utf-8")
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+
+
+# ============================================================
+# run_status — safety flags
+# ============================================================
+
+
+@pytest.mark.unit
+def test_status_fail_on_wrong_safety_flag(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    _write_snapshot(d, lr_status="GO")
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+
+
+# ============================================================
+# run_check_artifacts
+# ============================================================
+
+
+@pytest.mark.unit
+def test_check_artifacts_pass(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    now = datetime.now(UTC)
+
+    report = run_check_artifacts(d, now=now)
+
+    assert report.schema_version == WATCHDOG_REPORT_SCHEMA
+    assert report.mode == "check-artifacts"
+    assert report.verdict.verdict == "PASS"
+    assert report.required_artifacts_present is True
+
+
+@pytest.mark.unit
+def test_check_artifacts_fail_on_missing_snapshot(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path, include_snapshot=False)
+    now = datetime.now(UTC)
+
+    report = run_check_artifacts(d, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+    assert report.required_artifacts_present is False
+
+
+@pytest.mark.unit
+def test_check_artifacts_fail_on_malformed_snapshot(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    (d / "snapshot_20260619.json").write_text("bad json", encoding="utf-8")
+    now = datetime.now(UTC)
+
+    report = run_check_artifacts(d, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+
+
+# ============================================================
+# run_status — cadence
+# ============================================================
+
+
+@pytest.mark.unit
+def test_status_warn_on_cadence_exceeded(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path, snapshot_age_minutes=90)
+    now = datetime.now(UTC)
+
+    report = run_status(d, cadence_seconds=3600, now=now)
+
+    assert report.verdict.verdict == "WARN"
+
+
+@pytest.mark.unit
+def test_status_fail_on_double_cadence_exceeded(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path, snapshot_age_minutes=5000)
+    now = datetime.now(UTC)
+
+    report = run_status(d, cadence_seconds=3600, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+
+
+# ============================================================
+# report_to_markdown
+# ============================================================
+
+
+@pytest.mark.unit
+def test_report_to_markdown_contains_verdict(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    now = datetime.now(UTC)
+    report = run_status(d, now=now)
+
+    md = report_to_markdown(report)
+
+    assert "PASS" in md or "WARN" in md or "FAIL" in md
+    assert "Watchdog Report" in md
+    assert "No LR-Go" in md
+
+
+# ============================================================
+# render_escalation_draft
+# ============================================================
+
+
+@pytest.mark.unit
+def test_escalation_draft_contains_verdict_and_safety(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    now = datetime.now(UTC)
+    report = run_status(d, now=now)
+
+    draft = render_escalation_draft(report)
+
+    assert "Manual Escalation Draft" in draft
+    assert "No LR-Go" in draft
+    assert report.verdict.verdict in draft
+
+
+@pytest.mark.unit
+def test_escalation_draft_accepts_parent_issue(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    now = datetime.now(UTC)
+    report = run_status(d, now=now)
+
+    draft = render_escalation_draft(report, parent_issue="3345")
+
+    assert "#3345" in draft
+
+
+# ============================================================
+# CLI — main()
+# ============================================================
+
+
+@pytest.mark.unit
+def test_cli_status_returns_zero_on_pass(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    d = _write_artifact_dir(tmp_path)
+    evaluated_at = _now_iso()
+
+    exit_code = main(
+        [
+            "status",
+            "--artifact-dir",
+            str(d),
+            "--evaluated-at-utc",
+            evaluated_at,
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "status"
+    assert payload["verdict"]["verdict"] == "PASS"
+
+
+@pytest.mark.unit
+def test_cli_status_returns_one_on_fail(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    d = tmp_path / "empty"
+    d.mkdir()
+    evaluated_at = _now_iso()
+
+    exit_code = main(
+        [
+            "status",
+            "--artifact-dir",
+            str(d),
+            "--evaluated-at-utc",
+            evaluated_at,
+        ]
+    )
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["verdict"]["verdict"] == "FAIL"
+
+
+@pytest.mark.unit
+def test_cli_check_artifacts_returns_zero_on_pass(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    d = _write_artifact_dir(tmp_path)
+    evaluated_at = _now_iso()
+
+    exit_code = main(
+        [
+            "check-artifacts",
+            "--artifact-dir",
+            str(d),
+            "--evaluated-at-utc",
+            evaluated_at,
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "check-artifacts"
+    assert payload["verdict"]["verdict"] == "PASS"
+
+
+@pytest.mark.unit
+def test_cli_render_escalation_draft_from_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    d = _write_artifact_dir(tmp_path)
+    evaluated_at = _now_iso()
+    json_out = tmp_path / "watchdog_report.json"
+
+    main(
+        [
+            "status",
+            "--artifact-dir",
+            str(d),
+            "--evaluated-at-utc",
+            evaluated_at,
+            "--json-output",
+            str(json_out),
+        ]
+    )
+    capsys.readouterr()
+
+    exit_code = main(
+        [
+            "render-escalation-draft",
+            "--report-json",
+            str(json_out),
+            "--parent-issue",
+            "3345",
+        ]
+    )
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "Manual Escalation Draft" in output
+
+
+@pytest.mark.unit
+def test_cli_default_command_is_status(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main([])
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "status"
+
+
+# ============================================================
+# File outputs
+# ============================================================
+
+
+@pytest.mark.unit
+def test_cli_writes_json_and_markdown_outputs(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    evaluated_at = _now_iso()
+    json_out = tmp_path / "report.json"
+    md_out = tmp_path / "report.md"
+
+    exit_code = main(
+        [
+            "status",
+            "--artifact-dir",
+            str(d),
+            "--evaluated-at-utc",
+            evaluated_at,
+            "--json-output",
+            str(json_out),
+            "--markdown-output",
+            str(md_out),
+        ]
+    )
+    assert exit_code == 0
+    assert json_out.exists()
+    assert md_out.exists()
+
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert payload["verdict"]["verdict"] == "PASS"
+
+    md = md_out.read_text(encoding="utf-8")
+    assert "Watchdog Report" in md
+
+
+@pytest.mark.unit
+def test_cli_writes_escalation_draft_output(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    evaluated_at = _now_iso()
+    draft_out = tmp_path / "escalation.md"
+
+    exit_code = main(
+        [
+            "status",
+            "--artifact-dir",
+            str(d),
+            "--evaluated-at-utc",
+            evaluated_at,
+            "--escalation-draft-output",
+            str(draft_out),
+        ]
+    )
+    assert exit_code == 0
+    assert draft_out.exists()
+    draft = draft_out.read_text(encoding="utf-8")
+    assert "Manual Escalation Draft" in draft
+
+
+# ============================================================
+# Determinism
+# ============================================================
+
+
+@pytest.mark.unit
+def test_status_is_deterministic_with_fixed_timestamp(tmp_path: Path) -> None:
+    d1 = _write_artifact_dir(tmp_path / "run1")
+    d2 = _write_artifact_dir(tmp_path / "run2")
+    fixed_ts = "2026-06-19T16:00:00Z"
+
+    report1 = run_status(
+        d1, now=datetime.fromisoformat(fixed_ts.replace("Z", "+00:00"))
+    )
+    report2 = run_status(
+        d2, now=datetime.fromisoformat(fixed_ts.replace("Z", "+00:00"))
+    )
+
+    assert report1.verdict.verdict == report2.verdict.verdict
+    assert report1.verdict.fail_count == report2.verdict.fail_count
+    assert report1.verdict.warn_count == report2.verdict.warn_count
+    assert report1.verdict.pass_count == report2.verdict.pass_count
+
+
+# ============================================================
+# Error handling
+# ============================================================
+
+
+@pytest.mark.unit
+def test_watchdog_error_on_missing_dir(tmp_path: Path) -> None:
+    d = tmp_path / "nonexistent"
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+
+
+@pytest.mark.unit
+def test_payload_without_safety_flags_still_handled(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    (d / "snapshot_20260619.json").write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "schema_version": "cdb.evidence_harvester.snapshot.v1",
+                    "generated_at_utc": _ts(10),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "FAIL" or report.verdict.verdict == "WARN"
+
+
+@pytest.mark.unit
+def test_cli_rejects_nonexistent_report_json(tmp_path: Path) -> None:
+    missing = tmp_path / "no_such_report.json"
+    exit_code = main(
+        [
+            "render-escalation-draft",
+            "--report-json",
+            str(missing),
+        ]
+    )
+    assert exit_code == 1

--- a/tools/evidence_harvester/README.md
+++ b/tools/evidence_harvester/README.md
@@ -261,6 +261,58 @@ Each cycle produces:
 - #3358 — runner implementation (this module)
 - #3359 — watchdog consumption of runner heartbeat/state
 - #3361 — write-audit consumption of runner heartbeat/state
+- #3362 — OPS validation
+
+## Watchdog
+
+The `watchdog.py` module detects stalled collection and stale evidence by
+inspecting runner heartbeat, state, and artifact files. It produces
+deterministic PASS/WARN/FAIL verdicts.
+
+### Allowed commands
+
+- `status` (default) — full heartbeat, state, artifact integrity, and cadence checks
+- `check-artifacts` — artifact presence and integrity only (skip heartbeat/state)
+- `render-escalation-draft` — render a manual escalation draft from a saved report JSON
+
+### Usage
+
+```powershell
+# Full status check
+python -m tools.evidence_harvester.watchdog status `
+    --artifact-dir artifacts\evidence_harvester\runner `
+    --pretty
+
+# Artifact-only check
+python -m tools.evidence_harvester.watchdog check-artifacts `
+    --artifact-dir artifacts\evidence_harvester\runner `
+    --pretty
+
+# Render escalation draft from saved report
+python -m tools.evidence_harvester.watchdog render-escalation-draft `
+    --report-jango artifacts\evidence_harvester\watchdog_report.json
+```
+
+### Output artifacts
+
+- `watchdog_report.json` — machine-readable report with verdict + findings
+- `watchdog_report.md` — human-readable Markdown summary
+- `manual_escalation_draft.md` — manual escalation text (no automatic GitHub writes)
+
+### Verdict contract
+
+| Verdict | Conditions |
+|---------|-----------|
+| PASS    | Heartbeat fresh, state reports PASS, required artifacts exist, all JSON parses, safety flags correct |
+| WARN    | Artifact age near threshold, last run had failures, optional artifact missing |
+| FAIL    | Heartbeat stale, state missing, required artifact missing, malformed JSON, runner FAIL verdict, wrong safety flags |
+
+### Safety boundaries
+
+- Read-only; never modifies artifacts
+- No automatic restart, GitHub write, Docker, runtime, DB, Redis, or secrets action
+- Escalation draft is local text output only; human review required before any GitHub action
+- Feeds #3361 (write-audit) and #3362 (OPS validation) with structured evidence
 
 ## Validation
 

--- a/tools/evidence_harvester/__init__.py
+++ b/tools/evidence_harvester/__init__.py
@@ -9,6 +9,16 @@ from .validation import (
     validate_24h_window,
     validate_24h_window_from_dir,
 )
+from .watchdog import (
+    WatchdogError,
+    WatchdogFinding,
+    WatchdogReport,
+    WatchdogVerdict,
+    run_status,
+    run_check_artifacts,
+    render_escalation_draft,
+    report_to_markdown as watchdog_report_to_markdown,
+)
 
 __all__ = [
     "AlertReport",
@@ -19,9 +29,17 @@ __all__ = [
     "EvidenceHarvesterCollector",
     "ValidationError",
     "ValidationReport",
+    "WatchdogError",
+    "WatchdogFinding",
+    "WatchdogReport",
+    "WatchdogVerdict",
     "build_alert_report",
     "load_collector_input",
     "main",
+    "run_check_artifacts",
+    "run_status",
+    "render_escalation_draft",
     "validate_24h_window",
     "validate_24h_window_from_dir",
+    "watchdog_report_to_markdown",
 ]

--- a/tools/evidence_harvester/watchdog.py
+++ b/tools/evidence_harvester/watchdog.py
@@ -1,0 +1,1123 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+from .alerts import ALERT_REPORT_SCHEMA_VERSION
+from .runner import HEARTBEAT_SCHEMA, STATE_SCHEMA
+from .snapshot import SNAPSHOT_SCHEMA_VERSION
+
+HEARTBEAT_SCHEMA_EXPECTED = HEARTBEAT_SCHEMA
+STATE_SCHEMA_EXPECTED = STATE_SCHEMA
+SNAPSHOT_SCHEMA_EXPECTED = SNAPSHOT_SCHEMA_VERSION
+ALERT_SCHEMA_EXPECTED = ALERT_REPORT_SCHEMA_VERSION
+
+WATCHDOG_REPORT_SCHEMA = "cdb.evidence_harvester.watchdog_report.v1"
+DEFAULT_MAX_AGE_SECONDS = 7200
+DEFAULT_WARN_AGE_SECONDS = 5400
+DEFAULT_CADENCE_SECONDS = 86400
+
+
+class WatchdogError(ValueError):
+    pass
+
+
+def _parse_ts(value: Any, field_name: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise WatchdogError(f"{field_name} must not be blank")
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError as exc:
+            raise WatchdogError(
+                f"{field_name} must be an ISO-8601 UTC timestamp"
+            ) from exc
+    else:
+        raise WatchdogError(f"{field_name} must be an ISO-8601 UTC timestamp")
+    if parsed.tzinfo is None:
+        raise WatchdogError(f"{field_name} must be timezone-aware UTC")
+    return parsed.astimezone(UTC)
+
+
+def _format_ts(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _now_utc() -> datetime:
+    return cdb_utcnow().astimezone(UTC)
+
+
+def _require_mapping(value: Any, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise WatchdogError(f"{field_name} must be an object")
+    return value
+
+
+def _require_string(value: Any, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise WatchdogError(f"{field_name} must be a string")
+    text = value.strip()
+    if not text:
+        raise WatchdogError(f"{field_name} must not be blank")
+    return text
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise WatchdogError(f"Malformed JSON in {path.name}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise WatchdogError(f"{path.name} JSON root must be an object")
+    return payload
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _default_artifact_dir() -> Path:
+    return _repo_root() / "artifacts" / "evidence_harvester" / "runner"
+
+
+def _resolve_artifact_dir(path: Path | None) -> Path:
+    return (path or _default_artifact_dir()).resolve()
+
+
+@dataclass(frozen=True, slots=True)
+class WatchdogFinding:
+    check_id: str
+    check_name: str
+    severity: str
+    message: str
+    artifact: str = ""
+    field_name: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class WatchdogVerdict:
+    verdict: str
+    total_checks: int
+    pass_count: int
+    warn_count: int
+    fail_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class WatchdogReport:
+    schema_version: str
+    evaluated_at_utc: str
+    artifact_dir: str
+    mode: str
+    heartbeat_fresh: bool
+    runner_state_ok: bool
+    required_artifacts_present: bool
+    verdict: WatchdogVerdict
+    findings: tuple[WatchdogFinding, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _check_heartbeat(
+    heartbeat_payload: dict[str, Any] | None,
+    artifact_dir_label: str,
+    *,
+    max_age_seconds: int,
+    warn_age_seconds: int,
+    now: datetime,
+) -> list[WatchdogFinding]:
+    findings: list[WatchdogFinding] = []
+    if heartbeat_payload is None:
+        findings.append(
+            WatchdogFinding(
+                check_id="W001",
+                check_name="Heartbeat file exists",
+                severity="fail",
+                message="runner_heartbeat.json is missing or unreadable",
+                artifact=artifact_dir_label,
+            )
+        )
+        return findings
+
+    if heartbeat_payload.get("schema_version") != HEARTBEAT_SCHEMA_EXPECTED:
+        findings.append(
+            WatchdogFinding(
+                check_id="W002",
+                check_name="Heartbeat schema version",
+                severity="fail",
+                message=(
+                    f"Expected schema_version={HEARTBEAT_SCHEMA_EXPECTED!r}, "
+                    f"got {heartbeat_payload.get('schema_version')!r}"
+                ),
+                artifact=artifact_dir_label,
+                field_name="schema_version",
+            )
+        )
+
+    current_run_raw = heartbeat_payload.get("current_run_at_utc", "")
+    if current_run_raw:
+        try:
+            current_run_ts = _parse_ts(current_run_raw, "current_run_at_utc")
+            age_seconds = (now - current_run_ts).total_seconds()
+            if age_seconds > max_age_seconds:
+                findings.append(
+                    WatchdogFinding(
+                        check_id="W003",
+                        check_name="Heartbeat freshness",
+                        severity="fail",
+                        message=(
+                            f"Heartbeat is {age_seconds:.0f}s old "
+                            f"(max_age={max_age_seconds}s)"
+                        ),
+                        artifact=artifact_dir_label,
+                        field_name="current_run_at_utc",
+                    )
+                )
+            elif age_seconds > warn_age_seconds:
+                findings.append(
+                    WatchdogFinding(
+                        check_id="W003",
+                        check_name="Heartbeat freshness",
+                        severity="warn",
+                        message=(
+                            f"Heartbeat is {age_seconds:.0f}s old "
+                            f"(warn_age={warn_age_seconds}s)"
+                        ),
+                        artifact=artifact_dir_label,
+                        field_name="current_run_at_utc",
+                    )
+                )
+            else:
+                findings.append(
+                    WatchdogFinding(
+                        check_id="W003",
+                        check_name="Heartbeat freshness",
+                        severity="pass",
+                        message=f"Heartbeat is {age_seconds:.0f}s old (within limit)",
+                        artifact=artifact_dir_label,
+                        field_name="current_run_at_utc",
+                    )
+                )
+        except WatchdogError:
+            findings.append(
+                WatchdogFinding(
+                    check_id="W003",
+                    check_name="Heartbeat freshness",
+                    severity="fail",
+                    message=(
+                        f"current_run_at_utc={current_run_raw!r} is not valid ISO-8601"
+                    ),
+                    artifact=artifact_dir_label,
+                    field_name="current_run_at_utc",
+                )
+            )
+    else:
+        findings.append(
+            WatchdogFinding(
+                check_id="W003",
+                check_name="Heartbeat freshness",
+                severity="fail",
+                message="current_run_at_utc is missing or empty",
+                artifact=artifact_dir_label,
+                field_name="current_run_at_utc",
+            )
+        )
+
+    return findings
+
+
+def _check_runner_state(
+    state_payload: dict[str, Any] | None,
+    artifact_dir_label: str,
+) -> list[WatchdogFinding]:
+    findings: list[WatchdogFinding] = []
+    if state_payload is None:
+        findings.append(
+            WatchdogFinding(
+                check_id="W004",
+                check_name="Runner state file exists",
+                severity="fail",
+                message="runner_state.json is missing or unreadable",
+                artifact=artifact_dir_label,
+            )
+        )
+        return findings
+
+    if state_payload.get("schema_version") != STATE_SCHEMA_EXPECTED:
+        findings.append(
+            WatchdogFinding(
+                check_id="W005",
+                check_name="State schema version",
+                severity="fail",
+                message=(
+                    f"Expected schema_version={STATE_SCHEMA_EXPECTED!r}, "
+                    f"got {state_payload.get('schema_version')!r}"
+                ),
+                artifact=artifact_dir_label,
+                field_name="schema_version",
+            )
+        )
+
+    last_verdict = state_payload.get("last_cycle_verdict", "")
+    if last_verdict == "FAIL":
+        findings.append(
+            WatchdogFinding(
+                check_id="W006",
+                check_name="Runner last cycle verdict",
+                severity="fail",
+                message="Last cycle ended with FAIL verdict",
+                artifact=artifact_dir_label,
+                field_name="last_cycle_verdict",
+            )
+        )
+    elif last_verdict == "PASS":
+        findings.append(
+            WatchdogFinding(
+                check_id="W006",
+                check_name="Runner last cycle verdict",
+                severity="pass",
+                message="Last cycle ended with PASS verdict",
+                artifact=artifact_dir_label,
+                field_name="last_cycle_verdict",
+            )
+        )
+    else:
+        findings.append(
+            WatchdogFinding(
+                check_id="W006",
+                check_name="Runner last cycle verdict",
+                severity="warn",
+                message=f"Last cycle verdict is {last_verdict!r} (expected PASS or FAIL)",
+                artifact=artifact_dir_label,
+                field_name="last_cycle_verdict",
+            )
+        )
+
+    failed_runs = state_payload.get("failed_runs", 0)
+    if isinstance(failed_runs, int) and failed_runs > 0:
+        total = state_payload.get("total_runs", 0)
+        findings.append(
+            WatchdogFinding(
+                check_id="W007",
+                check_name="Runner failure count",
+                severity="warn",
+                message=(
+                    f"Runner has {failed_runs} failed run(s) out of {total} total"
+                ),
+                artifact=artifact_dir_label,
+                field_name="failed_runs",
+            )
+        )
+    else:
+        findings.append(
+            WatchdogFinding(
+                check_id="W007",
+                check_name="Runner failure count",
+                severity="pass",
+                message="No failed runs recorded",
+                artifact=artifact_dir_label,
+                field_name="failed_runs",
+            )
+        )
+
+    return findings
+
+
+def _collect_artifact_paths(artifact_dir: Path) -> dict[str, list[Path]]:
+    return {
+        "collector_reports": sorted(artifact_dir.glob("collector_report_*.json")),
+        "snapshots_json": sorted(artifact_dir.glob("snapshot_*.json")),
+        "alerts_json": sorted(artifact_dir.glob("alert_*.json")),
+    }
+
+
+REQUIRED_ARTIFACT_KEYS: dict[str, str] = {
+    "collector_reports": "collector_report_*.json",
+    "snapshots_json": "snapshot_*.json",
+    "alerts_json": "alert_*.json",
+}
+
+
+def _check_required_artifacts(
+    artifact_dir: Path,
+    artifact_dir_label: str,
+    artifact_paths: dict[str, list[Path]] | None = None,
+) -> list[WatchdogFinding]:
+    findings: list[WatchdogFinding] = []
+    if artifact_paths is None:
+        artifact_paths = _collect_artifact_paths(artifact_dir)
+
+    for key, pattern in REQUIRED_ARTIFACT_KEYS.items():
+        paths = artifact_paths.get(key, [])
+        if not paths:
+            findings.append(
+                WatchdogFinding(
+                    check_id="W008",
+                    check_name=f"Required artifact: {pattern}",
+                    severity="fail",
+                    message=f"No files matching {pattern} found in {artifact_dir_label}",
+                    artifact=artifact_dir_label,
+                )
+            )
+        else:
+            most_recent = max(paths, key=lambda p: p.stat().st_mtime)
+            findings.append(
+                WatchdogFinding(
+                    check_id="W008",
+                    check_name=f"Required artifact: {pattern}",
+                    severity="pass",
+                    message=(
+                        f"Found {len(paths)} file(s) matching {pattern}, "
+                        f"most recent: {most_recent.name}"
+                    ),
+                    artifact=artifact_dir_label,
+                )
+            )
+
+    return findings
+
+
+def _check_artifact_integrity(
+    artifact_paths: dict[str, list[Path]],
+    artifact_dir_label: str,
+    *,
+    max_age_seconds: int,
+    warn_age_seconds: int,
+    now: datetime,
+) -> list[WatchdogFinding]:
+    findings: list[WatchdogFinding] = []
+    json_keys = {"collector_reports", "snapshots_json", "alerts_json"}
+
+    for label, paths in artifact_paths.items():
+        is_json_artifact = label in json_keys
+        for path in paths:
+            artifact_label = f"{artifact_dir_label}/{path.name}"
+            if not is_json_artifact:
+                continue
+
+            try:
+                payload = _load_json(path)
+            except WatchdogError as exc:
+                findings.append(
+                    WatchdogFinding(
+                        check_id="W009",
+                        check_name=f"Artifact parses as JSON: {path.name}",
+                        severity="fail",
+                        message=str(exc),
+                        artifact=artifact_label,
+                    )
+                )
+                continue
+
+            if label == "snapshots_json":
+                schema_ver = payload.get("metadata", {}).get("schema_version", "")
+                if schema_ver and schema_ver != SNAPSHOT_SCHEMA_EXPECTED:
+                    findings.append(
+                        WatchdogFinding(
+                            check_id="W010",
+                            check_name=f"Snapshot schema: {path.name}",
+                            severity="fail",
+                            message=(
+                                f"Expected {SNAPSHOT_SCHEMA_EXPECTED!r}, "
+                                f"got {schema_ver!r}"
+                            ),
+                            artifact=artifact_label,
+                            field_name="metadata.schema_version",
+                        )
+                    )
+                generated_at = payload.get("metadata", {}).get("generated_at_utc", "")
+                if generated_at:
+                    try:
+                        ts = _parse_ts(generated_at, "generated_at_utc")
+                        age_seconds = (now - ts).total_seconds()
+                        if age_seconds > max_age_seconds:
+                            findings.append(
+                                WatchdogFinding(
+                                    check_id="W011",
+                                    check_name=f"Snapshot freshness: {path.name}",
+                                    severity="fail",
+                                    message=(
+                                        f"Snapshot is {age_seconds:.0f}s old "
+                                        f"(max_age={max_age_seconds}s)"
+                                    ),
+                                    artifact=artifact_label,
+                                    field_name="metadata.generated_at_utc",
+                                )
+                            )
+                        elif age_seconds > warn_age_seconds:
+                            findings.append(
+                                WatchdogFinding(
+                                    check_id="W011",
+                                    check_name=f"Snapshot freshness: {path.name}",
+                                    severity="warn",
+                                    message=(
+                                        f"Snapshot is {age_seconds:.0f}s old "
+                                        f"(warn_age={warn_age_seconds}s)"
+                                    ),
+                                    artifact=artifact_label,
+                                    field_name="metadata.generated_at_utc",
+                                )
+                            )
+                        else:
+                            findings.append(
+                                WatchdogFinding(
+                                    check_id="W011",
+                                    check_name=f"Snapshot freshness: {path.name}",
+                                    severity="pass",
+                                    message=(
+                                        f"Snapshot is {age_seconds:.0f}s old "
+                                        "(within limit)"
+                                    ),
+                                    artifact=artifact_label,
+                                    field_name="metadata.generated_at_utc",
+                                )
+                            )
+                    except WatchdogError:
+                        findings.append(
+                            WatchdogFinding(
+                                check_id="W011",
+                                check_name=f"Snapshot freshness: {path.name}",
+                                severity="fail",
+                                message=(
+                                    f"generated_at_utc={generated_at!r} "
+                                    "is not valid ISO-8601"
+                                ),
+                                artifact=artifact_label,
+                                field_name="metadata.generated_at_utc",
+                            )
+                        )
+
+                safety = payload.get("safety", {})
+                for sf_key, expected in [
+                    ("lr_status", "NO-GO"),
+                    ("live_status", "NO-GO"),
+                    ("echtgeld_status", "NO-GO"),
+                ]:
+                    actual = safety.get(sf_key)
+                    if actual != expected:
+                        findings.append(
+                            WatchdogFinding(
+                                check_id="W012",
+                                check_name=f"Safety flag: {sf_key} in {path.name}",
+                                severity="fail",
+                                message=(
+                                    f"Expected {sf_key}={expected!r}, got {actual!r}"
+                                ),
+                                artifact=artifact_label,
+                                field_name=f"safety.{sf_key}",
+                            )
+                        )
+
+            if label == "alerts_json":
+                schema_ver = payload.get("schema_version", "")
+                if schema_ver and schema_ver != ALERT_SCHEMA_EXPECTED:
+                    findings.append(
+                        WatchdogFinding(
+                            check_id="W013",
+                            check_name=f"Alert schema: {path.name}",
+                            severity="fail",
+                            message=(
+                                f"Expected {ALERT_SCHEMA_EXPECTED!r}, "
+                                f"got {schema_ver!r}"
+                            ),
+                            artifact=artifact_label,
+                            field_name="schema_version",
+                        )
+                    )
+                manual_only = payload.get("manual_escalation_only", True)
+                if isinstance(manual_only, bool) and not manual_only:
+                    findings.append(
+                        WatchdogFinding(
+                            check_id="W014",
+                            check_name=f"Alert manual escalation: {path.name}",
+                            severity="fail",
+                            message="manual_escalation_only is false",
+                            artifact=artifact_label,
+                            field_name="manual_escalation_only",
+                        )
+                    )
+
+    return findings
+
+
+def _check_cadence(
+    artifact_paths: dict[str, list[Path]],
+    artifact_dir_label: str,
+    *,
+    cadence_seconds: int,
+    now: datetime,
+) -> list[WatchdogFinding]:
+    findings: list[WatchdogFinding] = []
+    timestamps: list[datetime] = []
+    for path in artifact_paths.get("snapshots_json", []):
+        try:
+            payload = _load_json(path)
+            ts_raw = payload.get("metadata", {}).get("generated_at_utc", "")
+            if ts_raw:
+                timestamps.append(_parse_ts(ts_raw, "generated_at_utc"))
+        except (WatchdogError, json.JSONDecodeError):
+            continue
+
+    if not timestamps:
+        if artifact_paths.get("snapshots_json"):
+            findings.append(
+                WatchdogFinding(
+                    check_id="W015",
+                    check_name="Snapshot cadence check",
+                    severity="fail",
+                    message="No valid timestamps found in snapshot metadata",
+                    artifact=artifact_dir_label,
+                )
+            )
+        return findings
+
+    latest_ts = max(timestamps)
+    gap = (now - latest_ts).total_seconds()
+    if gap > cadence_seconds * 2:
+        findings.append(
+            WatchdogFinding(
+                check_id="W015",
+                check_name="Snapshot cadence check",
+                severity="fail",
+                message=(
+                    f"Last snapshot was {gap:.0f}s ago "
+                    f"(more than 2x cadence of {cadence_seconds}s)"
+                ),
+                artifact=artifact_dir_label,
+            )
+        )
+    elif gap > cadence_seconds:
+        findings.append(
+            WatchdogFinding(
+                check_id="W015",
+                check_name="Snapshot cadence check",
+                severity="warn",
+                message=(
+                    f"Last snapshot was {gap:.0f}s ago "
+                    f"(exceeds cadence of {cadence_seconds}s)"
+                ),
+                artifact=artifact_dir_label,
+            )
+        )
+    else:
+        findings.append(
+            WatchdogFinding(
+                check_id="W015",
+                check_name="Snapshot cadence check",
+                severity="pass",
+                message=(
+                    f"Last snapshot was {gap:.0f}s ago "
+                    f"(within cadence of {cadence_seconds}s)"
+                ),
+                artifact=artifact_dir_label,
+            )
+        )
+
+    return findings
+
+
+def run_status(
+    artifact_dir: Path,
+    *,
+    max_age_seconds: int = DEFAULT_MAX_AGE_SECONDS,
+    warn_age_seconds: int = DEFAULT_WARN_AGE_SECONDS,
+    cadence_seconds: int = DEFAULT_CADENCE_SECONDS,
+    now: datetime | None = None,
+) -> WatchdogReport:
+    eval_now = now or _now_utc()
+    artifact_dir_label = str(artifact_dir)
+    artifact_paths = _collect_artifact_paths(artifact_dir)
+
+    all_findings: list[WatchdogFinding] = []
+
+    heartbeat_payload = None
+    state_payload = None
+    hb_path = artifact_dir / "runner_heartbeat.json"
+    state_path = artifact_dir / "runner_state.json"
+
+    if hb_path.exists():
+        try:
+            heartbeat_payload = _load_json(hb_path)
+        except WatchdogError:
+            pass
+    if state_path.exists():
+        try:
+            state_payload = _load_json(state_path)
+        except WatchdogError:
+            pass
+
+    hb_findings = _check_heartbeat(
+        heartbeat_payload,
+        artifact_dir_label,
+        max_age_seconds=max_age_seconds,
+        warn_age_seconds=warn_age_seconds,
+        now=eval_now,
+    )
+    all_findings.extend(hb_findings)
+
+    state_findings = _check_runner_state(state_payload, artifact_dir_label)
+    all_findings.extend(state_findings)
+
+    artifact_findings = _check_required_artifacts(
+        artifact_dir, artifact_dir_label, artifact_paths
+    )
+    all_findings.extend(artifact_findings)
+
+    integrity_findings = _check_artifact_integrity(
+        artifact_paths,
+        artifact_dir_label,
+        max_age_seconds=max_age_seconds,
+        warn_age_seconds=warn_age_seconds,
+        now=eval_now,
+    )
+    all_findings.extend(integrity_findings)
+
+    cadence_findings = _check_cadence(
+        artifact_paths,
+        artifact_dir_label,
+        cadence_seconds=cadence_seconds,
+        now=eval_now,
+    )
+    all_findings.extend(cadence_findings)
+
+    fail_count = sum(1 for f in all_findings if f.severity == "fail")
+    warn_count = sum(1 for f in all_findings if f.severity == "warn")
+    pass_count = sum(1 for f in all_findings if f.severity == "pass")
+
+    if fail_count:
+        verdict = "FAIL"
+    elif warn_count:
+        verdict = "WARN"
+    else:
+        verdict = "PASS"
+
+    heartbeat_fresh = not any(
+        f.check_id == "W003" and f.severity == "fail" for f in all_findings
+    )
+    runner_state_ok = not any(
+        f.check_id == "W006" and f.severity == "fail" for f in all_findings
+    )
+    required_artifacts_present = not any(
+        f.check_id == "W008" and f.severity == "fail" for f in all_findings
+    )
+
+    sorted_findings = tuple(
+        sorted(
+            all_findings,
+            key=lambda f: (
+                {"fail": 0, "warn": 1, "pass": 2}.get(f.severity, 9),
+                f.check_id,
+            ),
+        )
+    )
+
+    return WatchdogReport(
+        schema_version=WATCHDOG_REPORT_SCHEMA,
+        evaluated_at_utc=_format_ts(eval_now),
+        artifact_dir=str(artifact_dir),
+        mode="status",
+        heartbeat_fresh=heartbeat_fresh,
+        runner_state_ok=runner_state_ok,
+        required_artifacts_present=required_artifacts_present,
+        verdict=WatchdogVerdict(
+            verdict=verdict,
+            total_checks=len(sorted_findings),
+            pass_count=pass_count,
+            warn_count=warn_count,
+            fail_count=fail_count,
+        ),
+        findings=sorted_findings,
+    )
+
+
+def run_check_artifacts(
+    artifact_dir: Path,
+    *,
+    max_age_seconds: int = DEFAULT_MAX_AGE_SECONDS,
+    warn_age_seconds: int = DEFAULT_WARN_AGE_SECONDS,
+    now: datetime | None = None,
+) -> WatchdogReport:
+    eval_now = now or _now_utc()
+    artifact_dir_label = str(artifact_dir)
+    artifact_paths = _collect_artifact_paths(artifact_dir)
+
+    all_findings: list[WatchdogFinding] = []
+
+    artifact_findings = _check_required_artifacts(
+        artifact_dir, artifact_dir_label, artifact_paths
+    )
+    all_findings.extend(artifact_findings)
+
+    integrity_findings = _check_artifact_integrity(
+        artifact_paths,
+        artifact_dir_label,
+        max_age_seconds=max_age_seconds,
+        warn_age_seconds=warn_age_seconds,
+        now=eval_now,
+    )
+    all_findings.extend(integrity_findings)
+
+    fail_count = sum(1 for f in all_findings if f.severity == "fail")
+    warn_count = sum(1 for f in all_findings if f.severity == "warn")
+    pass_count = sum(1 for f in all_findings if f.severity == "pass")
+
+    if fail_count:
+        verdict = "FAIL"
+    elif warn_count:
+        verdict = "WARN"
+    else:
+        verdict = "PASS"
+
+    required_artifacts_present = not any(
+        f.check_id == "W008" and f.severity == "fail" for f in all_findings
+    )
+
+    sorted_findings = tuple(
+        sorted(
+            all_findings,
+            key=lambda f: (
+                {"fail": 0, "warn": 1, "pass": 2}.get(f.severity, 9),
+                f.check_id,
+            ),
+        )
+    )
+
+    return WatchdogReport(
+        schema_version=WATCHDOG_REPORT_SCHEMA,
+        evaluated_at_utc=_format_ts(eval_now),
+        artifact_dir=str(artifact_dir),
+        mode="check-artifacts",
+        heartbeat_fresh=False,
+        runner_state_ok=False,
+        required_artifacts_present=required_artifacts_present,
+        verdict=WatchdogVerdict(
+            verdict=verdict,
+            total_checks=len(sorted_findings),
+            pass_count=pass_count,
+            warn_count=warn_count,
+            fail_count=fail_count,
+        ),
+        findings=sorted_findings,
+    )
+
+
+def render_escalation_draft(
+    report: WatchdogReport, *, parent_issue: str = "3345"
+) -> str:
+    payload = report.to_dict()
+    lines = [
+        "# Evidence Harvester Watchdog — Manual Escalation Draft",
+        "",
+        "**This is a manual escalation draft only. No automatic GitHub writes were performed.**",
+        "",
+        "## Watchdog Summary",
+        f"- Verdict: `{payload['verdict']['verdict']}`",
+        f"- Evaluated at (UTC): `{payload['evaluated_at_utc']}`",
+        f"- Artifact directory: `{payload['artifact_dir']}`",
+        f"- Mode: `{payload['mode']}`",
+        f"- Heartbeat fresh: `{payload['heartbeat_fresh']}`",
+        f"- Runner state OK: `{payload['runner_state_ok']}`",
+        f"- Required artifacts present: `{payload['required_artifacts_present']}`",
+        f"- Checks: total={payload['verdict']['total_checks']}, "
+        f"pass={payload['verdict']['pass_count']}, "
+        f"warn={payload['verdict']['warn_count']}, "
+        f"fail={payload['verdict']['fail_count']}",
+        "",
+        "## Findings",
+    ]
+
+    findings = payload.get("findings", [])
+    if findings:
+        for item in findings:
+            artifact_part = f" [{item['artifact']}]" if item.get("artifact") else ""
+            field_part = f" ({item['field_name']})" if item.get("field_name") else ""
+            lines.append(
+                f"- [{item['severity'].upper()}] {item['check_name']}"
+                f"{artifact_part}{field_part}: {item['message']}"
+            )
+    else:
+        lines.append("- No findings.")
+
+    lines.extend(
+        [
+            "",
+            "## Escalation Guidance",
+            "- Review findings above before creating any GitHub issue.",
+            "- If verdict is FAIL, restart or repair the harvester runner before continuing.",
+            "- If verdict is WARN, triage within the next operational window.",
+            "- If verdict is PASS, no escalation needed.",
+            "",
+            "## Safety",
+            "- Manual review required before any GitHub action.",
+            "- No runtime / no DB execution / no Docker / no secrets.",
+            f"- Parent issue: #{parent_issue}",
+            "- No LR-Go / No Live-Go / No Echtgeld-Go.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def report_to_markdown(report: WatchdogReport) -> str:
+    payload = report.to_dict()
+    lines = [
+        "# Evidence Harvester Watchdog Report",
+        "",
+        "## Metadata",
+        f"- Schema version: `{payload['schema_version']}`",
+        f"- Evaluated at (UTC): `{payload['evaluated_at_utc']}`",
+        f"- Artifact directory: `{payload['artifact_dir']}`",
+        f"- Mode: `{payload['mode']}`",
+        "",
+        "## Status Flags",
+        f"- Heartbeat fresh: `{payload['heartbeat_fresh']}`",
+        f"- Runner state OK: `{payload['runner_state_ok']}`",
+        f"- Required artifacts present: `{payload['required_artifacts_present']}`",
+        "",
+        "## Summary",
+        f"- Verdict: **{payload['verdict']['verdict']}**",
+        f"- Total checks: {payload['verdict']['total_checks']}",
+        f"- Pass: {payload['verdict']['pass_count']}",
+        f"- Warn: {payload['verdict']['warn_count']}",
+        f"- Fail: {payload['verdict']['fail_count']}",
+        "",
+        "## Findings",
+    ]
+    for item in payload["findings"]:
+        icon = {"fail": "FAIL", "warn": "WARN", "pass": "PASS"}.get(
+            item["severity"], "????"
+        )
+        artifact_part = f" [{item['artifact']}]" if item.get("artifact") else ""
+        field_part = f" ({item['field_name']})" if item.get("field_name") else ""
+        lines.append(
+            f"  [{icon}] {item['check_name']}{artifact_part}{field_part}: {item['message']}"
+        )
+    lines.extend(
+        [
+            "",
+            "## Safety",
+            "- No LR-Go / No Live-Go / No Echtgeld-Go.",
+            "- No runtime / no DB execution / no Docker / no secrets.",
+            "- Watchdog is read-only and does not modify artifacts.",
+            "- No automatic restart, GitHub write, or scheduler install.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _add_shared_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        help="Runner artifact directory to watch.",
+    )
+    parser.add_argument(
+        "--max-age-seconds",
+        type=int,
+        default=DEFAULT_MAX_AGE_SECONDS,
+        help="Max heartbeat/snapshot age before FAIL (default: 7200).",
+    )
+    parser.add_argument(
+        "--warn-age-seconds",
+        type=int,
+        default=DEFAULT_WARN_AGE_SECONDS,
+        help="Heartbeat/snapshot age for WARN (default: 5400).",
+    )
+    parser.add_argument(
+        "--cadence-seconds",
+        type=int,
+        default=DEFAULT_CADENCE_SECONDS,
+        help="Expected snapshot cadence in seconds (default: 86400).",
+    )
+    parser.add_argument(
+        "--evaluated-at-utc",
+        help="Optional explicit evaluation timestamp for deterministic tests.",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        help="Optional path for JSON watchdog report.",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        type=Path,
+        help="Optional path for Markdown watchdog report.",
+    )
+    parser.add_argument(
+        "--escalation-draft-output",
+        type=Path,
+        help="Optional path for manual escalation draft.",
+    )
+    parser.add_argument(
+        "--parent-issue",
+        default="3345",
+        help="Parent issue number for escalation draft (default: 3345).",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output.",
+    )
+
+
+def _handle_status(args: argparse.Namespace) -> int:
+    artifact_dir = _resolve_artifact_dir(args.artifact_dir)
+    now = _resolve_now(args)
+    report = run_status(
+        artifact_dir,
+        max_age_seconds=args.max_age_seconds,
+        warn_age_seconds=args.warn_age_seconds,
+        cadence_seconds=args.cadence_seconds,
+        now=now,
+    )
+    _emit_report(args, report)
+    return 0 if report.verdict.verdict != "FAIL" else 1
+
+
+def _handle_check_artifacts(args: argparse.Namespace) -> int:
+    artifact_dir = _resolve_artifact_dir(args.artifact_dir)
+    now = _resolve_now(args)
+    report = run_check_artifacts(
+        artifact_dir,
+        max_age_seconds=args.max_age_seconds,
+        warn_age_seconds=args.warn_age_seconds,
+        now=now,
+    )
+    _emit_report(args, report)
+    return 0 if report.verdict.verdict != "FAIL" else 1
+
+
+def _handle_render_escalation_draft(args: argparse.Namespace) -> int:
+    report_json_path = args.report_json.resolve()
+    if not report_json_path.exists():
+        print(f"Report JSON not found: {report_json_path}", file=sys.stderr)
+        return 1
+    payload = _load_json(report_json_path)
+    report = WatchdogReport(
+        schema_version=payload.get("schema_version", WATCHDOG_REPORT_SCHEMA),
+        evaluated_at_utc=payload.get("evaluated_at_utc", ""),
+        artifact_dir=payload.get("artifact_dir", ""),
+        mode=payload.get("mode", "unknown"),
+        heartbeat_fresh=bool(payload.get("heartbeat_fresh", False)),
+        runner_state_ok=bool(payload.get("runner_state_ok", False)),
+        required_artifacts_present=bool(
+            payload.get("required_artifacts_present", False)
+        ),
+        verdict=WatchdogVerdict(
+            verdict=payload.get("verdict", {}).get("verdict", "FAIL"),
+            total_checks=payload.get("verdict", {}).get("total_checks", 0),
+            pass_count=payload.get("verdict", {}).get("pass_count", 0),
+            warn_count=payload.get("verdict", {}).get("warn_count", 0),
+            fail_count=payload.get("verdict", {}).get("fail_count", 0),
+        ),
+        findings=tuple(
+            WatchdogFinding(
+                check_id=item.get("check_id", ""),
+                check_name=item.get("check_name", ""),
+                severity=item.get("severity", "fail"),
+                message=item.get("message", ""),
+                artifact=item.get("artifact", ""),
+                field_name=item.get("field_name", ""),
+            )
+            for item in payload.get("findings", [])
+        ),
+    )
+    draft = render_escalation_draft(report, parent_issue=args.parent_issue)
+    if args.escalation_draft_output:
+        _write_text(args.escalation_draft_output, draft)
+    else:
+        print(draft)
+    return 0
+
+
+def _resolve_now(args: argparse.Namespace) -> datetime:
+    if args.evaluated_at_utc:
+        return _parse_ts(args.evaluated_at_utc, "--evaluated-at-utc")
+    return _now_utc()
+
+
+def _emit_report(args: argparse.Namespace, report: WatchdogReport) -> None:
+    payload = report.to_dict()
+    json_text = json.dumps(
+        payload,
+        indent=2 if args.pretty else None,
+        sort_keys=True,
+        ensure_ascii=True,
+    )
+    print(json_text)
+
+    if args.json_output:
+        _write_text(args.json_output, json_text)
+    if args.markdown_output:
+        _write_text(args.markdown_output, report_to_markdown(report))
+    if args.escalation_draft_output:
+        _write_text(
+            args.escalation_draft_output,
+            render_escalation_draft(report, parent_issue=args.parent_issue),
+        )
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.write_text(text + ("" if text.endswith("\n") else "\n"), encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    argv = list(argv or [])
+    if not argv:
+        argv = ["status"]
+
+    parser = argparse.ArgumentParser(
+        description="Evidence harvester watchdog — detect stalls and stale evidence."
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    status_parser = subparsers.add_parser(
+        "status",
+        help="Full watchdog status: heartbeat, state, artifacts, cadence.",
+    )
+    _add_shared_args(status_parser)
+    status_parser.set_defaults(handler=_handle_status)
+
+    check_parser = subparsers.add_parser(
+        "check-artifacts",
+        help="Check artifact presence and integrity only.",
+    )
+    _add_shared_args(check_parser)
+    check_parser.set_defaults(handler=_handle_check_artifacts)
+
+    draft_parser = subparsers.add_parser(
+        "render-escalation-draft",
+        help="Render a manual escalation draft from a watchdog-report JSON.",
+    )
+    _add_shared_args(draft_parser)
+    draft_parser.add_argument(
+        "--report-json",
+        type=Path,
+        required=True,
+        help="Path to an existing watchdog_report.json.",
+    )
+    draft_parser.set_defaults(handler=_handle_render_escalation_draft)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Brain Evidence Block

- **context_tool_status**: contextual_cores MCP tools available (cdb_context_*)
- **context_trust_level**: medium — repo-read + GitHub live checks confirm issue #3359 is OPEN, #3358 is MERGED/CLOSED (PR #3363, merge commit 1fcab1c6), #3345 is OPEN as parent tracker. No open PRs exist.
- **records_found**: AGENTS.md (root pointer), agents/AGENTS.md (canonical registry), docs/runbooks/CONTROL_REGISTER.md (stage:trade-capable), docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md (NO-GO), CURRENT_STATUS.md (engineering ledger), tools/evidence_harvester/*.py (full source read), tests/unit/tools/evidence_harvester/*.py (test patterns), docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md (runbook)

## Watchdog Summary

Adds `tools/evidence_harvester/watchdog.py` — a read-only module that inspects runner heartbeat, state, and evidence artifacts to detect stalled collection and stale evidence.

### Three modes:
- **`status`** (default) — full inspection: heartbeat freshness, runner state verdict, required artifact presence, JSON integrity, safety flags, snapshot cadence
- **`check-artifacts`** — artifact presence and integrity only (skips heartbeat/state)
- **`render-escalation-draft`** — renders a manual escalation draft from a saved watchdog_report.json

## PASS/WARN/FAIL Contract

| Verdict | Conditions |
|---------|-----------|
| **PASS** | Heartbeat fresh, state reports PASS, all required artifacts present, all JSON parses, safety flags correct, snapshot within cadence |
| **WARN** | Artifact age near threshold, runner has historical failures, snapshot cadence slightly exceeded |
| **FAIL** | Heartbeat stale/missing, state missing, required artifact missing, malformed JSON, runner FAIL verdict, wrong safety flags, cadence >2x exceeded |

## Outputs

Produces three local-only outputs (no automatic external writes):
- `watchdog_report.json` — machine-readable
- `watchdog_report.md` — human-readable Markdown
- `manual_escalation_draft.md` — escalation text for manual GitHub use

## Tests

35 unit tests in `tests/unit/tools/evidence_harvester/test_watchdog.py` covering:
- PASS with fresh artifacts
- WARN on approaching-stale heartbeat and historical failures
- FAIL on stale/missing heartbeat, missing state, missing artifacts, malformed JSON, runner FAIL verdict, empty dir, wrong safety flags
- check-artifacts PASS/FAIL
- Cadence within/exceeded/double-exceeded
- CLI: exit codes, JSON/MD/escalation-draft file outputs
- Determinism with fixed timestamps
- Escalation draft rendering
- Malformed JSON edge cases

## Safety Confirmation

- **No automatic restart** — escalation draft contains "restart" as documentation-only text, not implementation
- **No automatic GitHub writes** — escalation is local text output only
- **No scheduler install** — not in scope
- **No runtime / no Docker / no DB / no Redis / no secrets action**
- **No LR-Go / No Live-Go / No Echtgeld-Go**
- Read-only; never modifies artifacts

## Changed Files

| File | Change |
|------|--------|
| `tools/evidence_harvester/watchdog.py` | NEW — watchdog module |
| `tools/evidence_harvester/__init__.py` | Exports watchdog symbols |
| `tools/evidence_harvester/README.md` | Watchdog usage section with verdict contract |
| `docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md` | Full watchdog ops section with incident response |
| `tests/unit/tools/evidence_harvester/test_watchdog.py` | NEW — 35 unit tests |

## Validation

- `python -m pytest tests/unit/tools/evidence_harvester -q` — 103/103 passed
- `ruff check tools/evidence_harvester tests/unit/tools/evidence_harvester` — all checks passed
- `black --check tools/evidence_harvester tests/unit/tools/evidence_harvester` — 16 files left unchanged
- `git diff --check` — no whitespace errors
- Forbidden pattern grep — only documentation safety strings (acceptable per review rules)

## Feeds

- #3361 (WRITE-AUDIT) — watchdog report findings provide structured stall/staleness input
- #3362 (OPS-VALIDATION) — watchdog verdict provides continuous supervision evidence

Closes #3359
