### PR TITLE
[EVIDENCE][HARVESTER] Add write artifact audit

### DIFF
--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
@@ -13,7 +13,7 @@ write-audit #3361).
 |-----------|-------|--------|
 | Runner (collector -> snapshot -> alert) | #3358 | Implemented |
 | Watchdog (heartbeat/state consumption) | #3359 | Implemented |
-| Write-audit (heartbeat/state consumption) | #3361 | Planned |
+| Write-audit (artifact completeness/consistency) | #3361 | Implemented |
 
 ## LR Status
 
@@ -170,15 +170,50 @@ python -m tools.evidence_harvester.watchdog status ^
 2. Review the draft before creating any GitHub issue manually.
 3. No automatic GitHub writes are performed by the watchdog.
 
-## Write-Audit (Planned, #3361)
+## Write-Audit (#3361)
 
-The write-audit consumer will use the heartbeat's `last_alert_json` path to
-read alert findings and, after human confirmation, produce GitHub issue drafts
-or comments. Design note:
+The write-audit (`write_audit.py`) verifies that the evidence harvester actually
+produces complete, readable, temporally consistent, and usable artifact sets. It
+is a downstream consumer of the runner output directory.
 
-- Default-off; no automatic GitHub writes
-- Human gate required before any GitHub action
-- Separate module with its own safety boundaries
+### Supported checks (10 check groups, A001–A010)
+
+| ID   | Check                            | Failure Condition                        |
+|------|----------------------------------|------------------------------------------|
+| A001 | Required artifacts present       | Missing collector/snapshot/alert/heartbeat/state/watchdog |
+| A002 | JSON artifacts parse             | Malformed or non-dict JSON               |
+| A003 | Schema versions match            | Unexpected schema_version in any artifact |
+| A004 | Hash linkage                     | Snapshot collector_report_hash mismatches no collector report |
+| A005 | Safety flags                     | lr_status/live_status/echtgeld_status not NO-GO |
+| A006 | Timestamp coherence              | Stale heartbeat/snapshot or invalid timestamps |
+| A007 | Source modes valid               | source_mode not in fixture/future_readonly |
+| A008 | Artifact sizes sane              | Zero-byte or oversized artifacts         |
+| A009 | Markdown companions              | Snapshot/alert/watchdog JSON without MD companion |
+| A010 | Metadata fields present          | Missing or empty schema_version/generated_at_utc/source_mode |
+
+### Usage
+
+```powershell
+# Default audit
+python -m tools.evidence_harvester.write_audit
+
+# Save outputs
+python -m tools.evidence_harvester.write_audit ^
+    --artifact-dir artifacts\evidence_harvester\runner ^
+    --json-output artifacts\evidence_harvester\write_audit_report.json ^
+    --markdown-output artifacts\evidence_harvester\write_audit_report.md
+```
+
+### Safety boundaries
+
+- Read-only; never modifies artifacts
+- No automatic restart, GitHub write, Docker, runtime, DB, Redis, or secrets action
+- Feeds #3362 (OPS validation) with structured artifact completeness evidence
+
+### Outputs
+
+- `write_audit_report.json` — machine-readable report with per-check findings + verdict
+- `write_audit_report.md` — human-readable Markdown summary
 
 ## Safety Boundaries
 

--- a/tests/unit/tools/evidence_harvester/test_write_audit.py
+++ b/tests/unit/tools/evidence_harvester/test_write_audit.py
@@ -1,0 +1,740 @@
+from __future__ import annotations
+
+import json
+import hashlib
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from tools.evidence_harvester.write_audit import (
+    WRITE_AUDIT_REPORT_SCHEMA,
+    WriteAuditError,
+    WriteAuditReport,
+    main,
+    report_to_markdown,
+    run_write_audit,
+)
+
+_FIXED_TS = datetime(2026, 6, 19, 16, 0, 0, tzinfo=UTC)
+
+
+def _ts(offset_minutes: int = 0) -> str:
+    target = _FIXED_TS - timedelta(minutes=offset_minutes)
+    return target.isoformat().replace("+00:00", "Z")
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _collector_payload(stamp: str = "20260619", source_mode: str = "fixture") -> dict:
+    return {
+        "schema_version": "evidence_harvester.collector_report.v1",
+        "report_id": f"report_{stamp}",
+        "evidence_class": "pipeline_test_evidence",
+        "evidence_class_version": "1.0",
+        "produced_by": "pytest",
+        "produced_at_utc": _ts(15),
+        "source_mode": source_mode,
+        "raw_evidence": {
+            "candle_input_count": 10,
+            "regime_input_count": 5,
+            "paper_chain_input_count": 3,
+            "provenance_input_count": 2,
+            "observed_input_count": 20,
+        },
+        "candle_coverages": [],
+        "regime_coverages": [],
+        "paper_chain_coverages": [],
+        "provenance": {
+            "allowed_sources": ["mexc"],
+            "source_findings": [],
+            "unknown_source_count": 0,
+            "contaminated_source_count": 0,
+        },
+        "gap_findings": [],
+        "summary": {
+            "overall_status": "ok",
+            "blocking_count": 0,
+            "warning_count": 0,
+            "info_count": 0,
+            "has_zero_paper_chains": False,
+        },
+    }
+
+
+def _collector_hash(payload: dict) -> str:
+    canonical = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
+    return f"sha256:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"
+
+
+def _snapshot_payload(
+    stamp: str = "20260619",
+    age_minutes: int = 10,
+    schema_version: str = "cdb.evidence_harvester.snapshot.v1",
+    collector_hash: str = "sha256:abc123",
+    collector_id: str = "report_20260619",
+    source_mode: str = "fixture",
+) -> dict:
+    return {
+        "metadata": {
+            "schema_version": schema_version,
+            "generated_at_utc": _ts(age_minutes),
+            "collector_report_hash": collector_hash,
+            "collector_report_id": collector_id,
+            "collector_report_schema_version": "evidence_harvester.collector_report.v1",
+            "source_mode": source_mode,
+            "evidence_class": "pipeline_test_evidence",
+            "evidence_class_version": "1.0",
+            "produced_by": "pytest",
+            "collector_report_produced_at_utc": _ts(age_minutes + 1),
+        },
+        "safety": {
+            "banner": "Paper/research evidence only; no LR-Go, no Live-Go, no Echtgeld-Go.",
+            "lr_status": "NO-GO",
+            "live_status": "NO-GO",
+            "echtgeld_status": "NO-GO",
+            "runtime_actions": "not_allowed",
+            "db_execution": "not_allowed",
+            "background_job_orchestration": "not_in_scope",
+            "allowed_scope": "fixture-based snapshot generation only",
+        },
+        "status": {
+            "overall_status": "ok",
+            "gap_counts": {"blocking": 0, "warning": 0, "info": 0},
+            "has_zero_paper_chains": False,
+            "raw_evidence": {
+                "candle_input_count": 10,
+                "regime_input_count": 5,
+                "paper_chain_input_count": 3,
+                "provenance_input_count": 2,
+                "observed_input_count": 20,
+            },
+        },
+        "coverage": {
+            "candles": {
+                "status": "ok",
+                "total_streams": 1,
+                "observed_count_total": 18,
+                "expected_count_total": 20,
+                "coverage_pct": 0.9,
+                "stale_stream_count": 0,
+                "status_counts": {"blocking": 0, "warning": 0, "info": 1},
+                "items": [],
+            },
+            "regimes": {
+                "status": "ok",
+                "total_streams": 1,
+                "observed_count_total": 10,
+                "expected_count_total": 20,
+                "coverage_pct": 0.5,
+                "stale_stream_count": 0,
+                "status_counts": {"blocking": 0, "warning": 0, "info": 1},
+                "items": [],
+            },
+        },
+        "provenance": {
+            "allowed_sources": ["mexc"],
+            "source_findings": [],
+            "unknown_source_count": 0,
+            "contaminated_source_count": 0,
+        },
+        "paper_chains": {
+            "total_streams": 1,
+            "items": [],
+            "status_counts": {"blocking": 0, "warning": 0, "info": 1},
+        },
+        "gap_findings": {"items": [], "by_severity": {}},
+        "next_action_hints": [],
+    }
+
+
+def _alert_payload(
+    age_minutes: int = 8,
+    manual_escalation_only: bool = True,
+    schema_version: str = "cdb.evidence_harvester.alert_report.v1",
+) -> dict:
+    return {
+        "schema_version": schema_version,
+        "snapshot_generated_at_utc": _ts(age_minutes),
+        "snapshot_schema_version": "cdb.evidence_harvester.snapshot.v1",
+        "collector_report_hash": "sha256:abc123",
+        "collector_report_schema_version": "evidence_harvester.collector_report.v1",
+        "snapshot_source_mode": "fixture",
+        "evaluated_at_utc": _ts(age_minutes),
+        "overall_status": "ok",
+        "items": [],
+        "report_type": "evidence_harvester_alert",
+        "has_warning": False,
+        "has_blocking": False,
+        "manual_escalation_only": manual_escalation_only,
+    }
+
+
+def _heartbeat_payload(age_minutes: int = 1) -> dict:
+    return {
+        "schema_version": "cdb.evidence_harvester.runner_heartbeat.v1",
+        "runner_mode": "loop-fixture",
+        "iteration": 5,
+        "started_at_utc": _ts(age_minutes + 10),
+        "current_run_at_utc": _ts(age_minutes),
+        "last_success_at_utc": _ts(age_minutes),
+        "last_failure_at_utc": "",
+        "last_error": "",
+        "last_collector_report": "",
+        "last_snapshot_json": "",
+        "last_snapshot_markdown": "",
+        "last_alert_json": "",
+        "last_alert_markdown": "",
+    }
+
+
+def _state_payload(verdict: str = "PASS") -> dict:
+    return {
+        "schema_version": "cdb.evidence_harvester.runner_state.v1",
+        "total_runs": 5,
+        "successful_runs": 5,
+        "failed_runs": 0,
+        "last_cycle_verdict": verdict,
+        "last_cycle_ended_at_utc": _ts(1),
+    }
+
+
+def _watchdog_payload(verdict: str = "PASS") -> dict:
+    return {
+        "schema_version": "cdb.evidence_harvester.watchdog_report.v1",
+        "evaluated_at_utc": _ts(1),
+        "artifact_dir": "",
+        "mode": "status",
+        "heartbeat_fresh": True,
+        "runner_state_ok": True,
+        "required_artifacts_present": True,
+        "verdict": {
+            "verdict": verdict,
+            "total_checks": 5,
+            "pass_count": 5,
+            "warn_count": 0,
+            "fail_count": 0,
+        },
+        "findings": [],
+    }
+
+
+def _setup_complete_artifacts(
+    tmp_path: Path,
+    stamp: str = "20260619",
+) -> Path:
+    cr = _collector_payload(stamp)
+    cr_hash = _collector_hash(cr)
+    _write_json(tmp_path / f"collector_report_{stamp}.json", cr)
+    _write_json(
+        tmp_path / f"snapshot_{stamp}.json",
+        _snapshot_payload(
+            stamp, collector_hash=cr_hash, collector_id=f"report_{stamp}"
+        ),
+    )
+    _write_json(tmp_path / f"snapshot_{stamp}.md", {})
+    _write_json(tmp_path / f"alert_{stamp}.json", _alert_payload())
+    _write_json(tmp_path / f"alert_{stamp}.md", {})
+    _write_json(tmp_path / "runner_heartbeat.json", _heartbeat_payload())
+    _write_json(tmp_path / "runner_state.json", _state_payload())
+    _write_json(tmp_path / "watchdog_report.json", _watchdog_payload())
+    _write_json(tmp_path / "watchdog_report.md", {})
+    return tmp_path
+
+
+# --- A001: Required artifacts ---
+
+
+def test_rwa_a001_pass(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "PASS"
+    a001 = [f for f in report.findings if f.check_id == "A001"]
+    assert any(f.severity == "pass" for f in a001)
+    assert not any(f.severity == "fail" for f in a001)
+
+
+def test_rwa_a001_fail_missing_snapshot_json(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    (d / "snapshot_20260619.json").unlink()
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    a001 = [f for f in report.findings if f.check_id == "A001"]
+    assert any("snapshot_*.json" in f.message for f in a001)
+
+
+def test_rwa_a001_fail_missing_heartbeat(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    (d / "runner_heartbeat.json").unlink()
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    a001 = [f for f in report.findings if f.check_id == "A001"]
+    assert any("runner_heartbeat.json" in f.message for f in a001)
+
+
+def test_rwa_a001_fail_missing_state(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    (d / "runner_state.json").unlink()
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    a001 = [f for f in report.findings if f.check_id == "A001"]
+    assert any("runner_state.json" in f.message for f in a001)
+
+
+def test_rwa_a001_fail_missing_watchdog_report(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    (d / "watchdog_report.json").unlink()
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    a001 = [f for f in report.findings if f.check_id == "A001"]
+    assert any("watchdog_report.json" in f.message for f in a001)
+
+
+def test_rwa_a001_warn_missing_watchdog_md(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    (d / "watchdog_report.md").unlink()
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "WARN"
+    a001 = [f for f in report.findings if f.check_id == "A001"]
+    assert any("watchdog_report.md" in f.message for f in a001)
+
+
+# --- A002: JSON integrity ---
+
+
+def test_rwa_a002_pass(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "PASS"
+    assert report.all_json_parse is True
+    a002 = [f for f in report.findings if f.check_id == "A002"]
+    assert any(f.severity == "pass" for f in a002)
+
+
+def test_rwa_a002_fail_malformed_json(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    (d / "snapshot_20260619.json").write_text("{bad json", encoding="utf-8")
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    assert report.all_json_parse is False
+    a002 = [f for f in report.findings if f.check_id == "A002"]
+    assert any(f.severity == "fail" for f in a002)
+
+
+# --- A003: Schema versions ---
+
+
+def test_rwa_a003_pass(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "PASS"
+    assert report.schema_versions_match is True
+    a003 = [f for f in report.findings if f.check_id == "A003"]
+    assert any(f.severity == "pass" for f in a003)
+
+
+def test_rwa_a003_fail_bad_snapshot_schema(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    _write_json(
+        d / "snapshot_20260619.json",
+        _snapshot_payload(schema_version="wrong.v2"),
+    )
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    assert report.schema_versions_match is False
+    a003 = [f for f in report.findings if f.check_id == "A003"]
+    assert any("wrong.v2" in f.message for f in a003)
+
+
+def test_rwa_a003_fail_bad_heartbeat_schema(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    hb = _heartbeat_payload()
+    hb["schema_version"] = "wrong.v2"
+    _write_json(d / "runner_heartbeat.json", hb)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    a003 = [f for f in report.findings if f.check_id == "A003"]
+    assert any("wrong.v2" in f.message for f in a003)
+
+
+def test_rwa_a003_fail_bad_alert_schema(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    _write_json(
+        d / "alert_20260619.json",
+        _alert_payload(schema_version="wrong.v2"),
+    )
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    a003 = [f for f in report.findings if f.check_id == "A003"]
+    assert any("wrong.v2" in f.message for f in a003)
+
+
+def test_rwa_a003_fail_bad_watchdog_schema(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    wd = _watchdog_payload()
+    wd["schema_version"] = "wrong.v2"
+    _write_json(d / "watchdog_report.json", wd)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    a003 = [f for f in report.findings if f.check_id == "A003"]
+    assert any("wrong.v2" in f.message for f in a003)
+
+
+# --- A004: Hash linkage ---
+
+
+def test_rwa_a004_pass(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "PASS"
+    assert report.hash_linkage_valid is True
+    a004 = [f for f in report.findings if f.check_id == "A004"]
+    assert any(f.severity == "pass" for f in a004)
+
+
+def test_rwa_a004_fail_hash_mismatch(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    _write_json(
+        d / "snapshot_20260619.json",
+        _snapshot_payload(
+            collector_hash="sha256:doesnotmatch",
+            collector_id="nonexistent_report",
+        ),
+    )
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    assert report.hash_linkage_valid is False
+    a004 = [f for f in report.findings if f.check_id == "A004"]
+    assert any(f.severity == "fail" for f in a004)
+
+
+def test_rwa_a004_fail_no_collector_report(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    (d / "collector_report_20260619.json").unlink()
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    assert report.hash_linkage_valid is False
+
+
+# --- A005: Safety flags ---
+
+
+def test_rwa_a005_pass(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "PASS"
+    assert report.safety_flags_correct is True
+    a005 = [f for f in report.findings if f.check_id == "A005"]
+    assert any(f.severity == "pass" for f in a005)
+
+
+def test_rwa_a005_fail_lr_status_wrong(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    snap = _snapshot_payload(
+        collector_hash=_collector_hash(_collector_payload()),
+        collector_id="report_20260619",
+    )
+    snap["safety"]["lr_status"] = "GO"
+    _write_json(d / "snapshot_20260619.json", snap)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    assert report.safety_flags_correct is False
+    a005 = [f for f in report.findings if f.check_id == "A005"]
+    assert any(f.severity == "fail" for f in a005)
+
+
+def test_rwa_a005_fail_manual_escalation_false(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    _write_json(
+        d / "alert_20260619.json",
+        _alert_payload(manual_escalation_only=False),
+    )
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    a005 = [f for f in report.findings if f.check_id == "A005"]
+    assert any("manual_escalation_only" in f.message for f in a005)
+
+
+# --- A006: Timestamps ---
+
+
+def test_rwa_a006_pass(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "PASS"
+    assert report.timestamps_coherent is True
+    a006 = [f for f in report.findings if f.check_id == "A006"]
+    assert any(f.severity == "pass" for f in a006)
+
+
+def test_rwa_a006_fail_stale_heartbeat(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    hb = _heartbeat_payload(age_minutes=9999)
+    _write_json(d / "runner_heartbeat.json", hb)
+    report = run_write_audit(d, stale_threshold=7200, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    assert report.timestamps_coherent is False
+    a006 = [f for f in report.findings if f.check_id == "A006"]
+    assert any(f.severity == "fail" for f in a006)
+
+
+def test_rwa_a006_warn_stale_heartbeat(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    hb = _heartbeat_payload(age_minutes=100)
+    _write_json(d / "runner_heartbeat.json", hb)
+    report = run_write_audit(d, stale_threshold=99999, warn_stale=60, now=_FIXED_TS)
+    assert report.verdict.verdict == "WARN"
+    a006 = [f for f in report.findings if f.check_id == "A006"]
+    assert any(f.severity == "warn" for f in a006)
+
+
+def test_rwa_a006_fail_stale_snapshot(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    snap = _snapshot_payload(
+        age_minutes=9999,
+        collector_hash=_collector_hash(_collector_payload()),
+        collector_id="report_20260619",
+    )
+    _write_json(d / "snapshot_20260619.json", snap)
+    report = run_write_audit(d, stale_threshold=7200, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    a006 = [f for f in report.findings if f.check_id == "A006"]
+    assert any(f.severity == "fail" for f in a006)
+
+
+# --- A007: Source modes ---
+
+
+def test_rwa_a007_pass(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "PASS"
+    assert report.source_modes_valid is True
+    a007 = [f for f in report.findings if f.check_id == "A007"]
+    assert any(f.severity == "pass" for f in a007)
+
+
+def test_rwa_a007_pass_future_readonly(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    _write_json(
+        d / "collector_report_20260619.json",
+        _collector_payload(source_mode="future_readonly"),
+    )
+    cr = _collector_payload(source_mode="future_readonly")
+    _write_json(
+        d / "snapshot_20260619.json",
+        _snapshot_payload(
+            collector_hash=_collector_hash(cr),
+            collector_id="report_20260619",
+            source_mode="future_readonly",
+        ),
+    )
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "PASS"
+
+
+def test_rwa_a007_fail_bad_source_mode(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    _write_json(
+        d / "collector_report_20260619.json",
+        _collector_payload(source_mode="production"),
+    )
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    assert report.source_modes_valid is False
+    a007 = [f for f in report.findings if f.check_id == "A007"]
+    assert any("production" in f.message for f in a007)
+
+
+# --- A008: Artifact sizes ---
+
+
+def test_rwa_a008_pass(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "PASS"
+    assert report.sizes_sane is True
+    a008 = [f for f in report.findings if f.check_id == "A008"]
+    assert any(f.severity == "pass" for f in a008)
+
+
+def test_rwa_a008_fail_zero_byte(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    (d / "snapshot_20260619.json").write_text("", encoding="utf-8")
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    assert report.sizes_sane is False
+    a008 = [f for f in report.findings if f.check_id == "A008"]
+    assert any("zero bytes" in f.message for f in a008)
+
+
+# --- A009: Markdown companions ---
+
+
+def test_rwa_a009_pass(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "PASS"
+    a009 = [f for f in report.findings if f.check_id == "A009"]
+    assert any(f.severity == "pass" for f in a009)
+
+
+def test_rwa_a009_warn_missing_snapshot_md(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    (d / "snapshot_20260619.md").unlink()
+    report = run_write_audit(d, now=_FIXED_TS)
+    a009 = [f for f in report.findings if f.check_id == "A009"]
+    assert any(f.severity == "warn" for f in a009)
+
+
+# --- A010: Metadata fields ---
+
+
+def test_rwa_a010_pass(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "PASS"
+    a010 = [f for f in report.findings if f.check_id == "A010"]
+    assert any(f.severity == "pass" for f in a010)
+
+
+def test_rwa_a010_fail_empty_schema_version(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    hb = _heartbeat_payload()
+    hb["schema_version"] = ""
+    _write_json(d / "runner_heartbeat.json", hb)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    a010 = [f for f in report.findings if f.check_id == "A010"]
+    assert any("schema_version" in f.message for f in a010)
+
+
+def test_rwa_a010_fail_missing_verdict(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    wd = _watchdog_payload()
+    wd.pop("verdict")
+    _write_json(d / "watchdog_report.json", wd)
+    report = run_write_audit(d, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    a010 = [f for f in report.findings if f.check_id == "A010"]
+    assert any("verdict" in f.message for f in a010)
+
+
+# --- Determinism ---
+
+
+def test_rwa_deterministic(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path, stamp="20260619")
+    report_a = run_write_audit(d, now=_FIXED_TS)
+    report_b = run_write_audit(d, now=_FIXED_TS)
+    assert report_a.to_dict() == report_b.to_dict()
+
+
+# --- Edge cases ---
+
+
+def test_rwa_empty_directory(tmp_path: Path) -> None:
+    report = run_write_audit(tmp_path, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    assert report.required_artifacts_present is False
+
+
+def test_rwa_no_json_artifacts(tmp_path: Path) -> None:
+    _write_json(tmp_path / "some_other_file.txt", {"key": "val"})
+    report = run_write_audit(tmp_path, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+
+
+def test_rwa_non_dict_json(tmp_path: Path) -> None:
+    (tmp_path / "snapshot_20260619.json").write_text(
+        json.dumps(["list", "not", "dict"]), encoding="utf-8"
+    )
+    report = run_write_audit(tmp_path, now=_FIXED_TS)
+    assert report.verdict.verdict == "FAIL"
+    assert report.all_json_parse is False
+
+
+# --- CLI ---
+
+
+def test_rwa_cli_default(tmp_path: Path) -> None:
+    exit_code = main(["--artifact-dir", str(tmp_path)])
+    assert exit_code == 1
+
+
+def test_rwa_cli_pass(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    exit_code = main(
+        [
+            "--artifact-dir",
+            str(d),
+            "--evaluated-at-utc",
+            "2026-06-19T16:00:00Z",
+        ]
+    )
+    assert exit_code == 0
+
+
+def test_rwa_cli_json_output(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    json_out = tmp_path / "report.json"
+    exit_code = main(
+        [
+            "--artifact-dir",
+            str(d),
+            "--json-output",
+            str(json_out),
+            "--evaluated-at-utc",
+            "2026-06-19T16:00:00Z",
+        ]
+    )
+    assert exit_code == 0
+    assert json_out.exists()
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == WRITE_AUDIT_REPORT_SCHEMA
+
+
+def test_rwa_cli_md_output(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    md_out = tmp_path / "report.md"
+    exit_code = main(
+        [
+            "--artifact-dir",
+            str(d),
+            "--markdown-output",
+            str(md_out),
+            "--evaluated-at-utc",
+            "2026-06-19T16:00:00Z",
+        ]
+    )
+    assert exit_code == 0
+    assert md_out.exists()
+    text = md_out.read_text(encoding="utf-8")
+    assert "Write-Audit Report" in text
+
+
+# --- Markdown report ---
+
+
+def test_rwa_markdown_output(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    report = run_write_audit(d, now=_FIXED_TS)
+    md = report_to_markdown(report)
+    assert "Write-Audit Report" in md
+    assert "PASS" in md
+    assert "No LR-Go" in md
+    assert "No runtime" in md
+
+
+# --- WriteAuditError ---
+
+
+def test_rwa_error_base() -> None:
+    err = WriteAuditError("test error")
+    assert isinstance(err, ValueError)
+    assert "test error" in str(err)

--- a/tools/evidence_harvester/README.md
+++ b/tools/evidence_harvester/README.md
@@ -314,6 +314,70 @@ python -m tools.evidence_harvester.watchdog render-escalation-draft `
 - Escalation draft is local text output only; human review required before any GitHub action
 - Feeds #3361 (write-audit) and #3362 (OPS validation) with structured evidence
 
+## Write-Audit
+
+The `write_audit.py` module verifies that the evidence harvester produces complete,
+readable, temporally consistent, and usable artifact sets. It is a downstream
+consumer of the runner output directory and performs cross-artifact integrity
+checks.
+
+### Checks
+
+| ID   | Check                            | Failure Condition                        |
+|------|----------------------------------|------------------------------------------|
+| A001 | Required artifacts present       | Missing collector/snapshot/alert/heartbeat/state/watchdog |
+| A002 | JSON artifacts parse             | Malformed or non-dict JSON               |
+| A003 | Schema versions match            | Unexpected schema_version in any artifact |
+| A004 | Hash linkage                     | Snapshot collector_report_hash mismatches no collector report |
+| A005 | Safety flags                     | lr_status/live_status/echtgeld_status not NO-GO |
+| A006 | Timestamp coherence              | Stale heartbeat/snapshot or invalid timestamps |
+| A007 | Source modes valid               | source_mode not in fixture/future_readonly |
+| A008 | Artifact sizes sane              | Zero-byte or oversized artifacts         |
+| A009 | Markdown companions              | Snapshot/alert/watchdog JSON without MD companion |
+| A010 | Metadata fields present          | Missing or empty schema_version/generated_at_utc/source_mode |
+
+### Verdict contract
+
+| Verdict | Conditions |
+|---------|-----------|
+| PASS    | All 10 check groups pass; all required artifacts present, all JSON parse, schema versions match, hash linkage valid, safety flags correct, timestamps coherent, source modes valid, sizes sane, MD companions present, metadata fields present |
+| WARN    | Optional companion missing (e.g. watchdog_report.md), artifact age near threshold, non-critical metadata gap |
+| FAIL    | Required artifact missing, malformed JSON, hash mismatch, missing safety flags, zero-byte artifact, timestamp contradiction, invalid source mode, missing metadata fields |
+
+### Usage
+
+```powershell
+# Default audit of the runner output directory
+python -m tools.evidence_harvester.write_audit
+
+# Explicit artifact directory
+python -m tools.evidence_harvester.write_audit ^
+    --artifact-dir artifacts\evidence_harvester\runner ^
+    --pretty
+
+# Save outputs
+python -m tools.evidence_harvester.write_audit ^
+    --artifact-dir artifacts\evidence_harvester\runner ^
+    --json-output artifacts\evidence_harvester\write_audit_report.json ^
+    --markdown-output artifacts\evidence_harvester\write_audit_report.md
+
+# Deterministic evaluation with fixed timestamps
+python -m tools.evidence_harvester.write_audit ^
+    --artifact-dir artifacts\evidence_harvester\runner ^
+    --evaluated-at-utc "2026-06-19T16:00:00Z"
+```
+
+### Output artifacts
+
+- `write_audit_report.json` — machine-readable report with 10 check groups + verdict
+- `write_audit_report.md` — human-readable Markdown summary
+
+### Safety boundaries
+
+- Read-only; never modifies artifacts
+- No automatic restart, GitHub write, Docker, runtime, DB, Redis, or secrets action
+- Feeds #3362 (OPS validation) with structured artifact completeness evidence
+
 ## Validation
 
 The `validation.py` module validates a 24h dry collection window of evidence

--- a/tools/evidence_harvester/__init__.py
+++ b/tools/evidence_harvester/__init__.py
@@ -19,6 +19,14 @@ from .watchdog import (
     render_escalation_draft,
     report_to_markdown as watchdog_report_to_markdown,
 )
+from .write_audit import (
+    WriteAuditError,
+    WriteAuditFinding,
+    WriteAuditReport,
+    WriteAuditVerdict,
+    run_write_audit,
+    report_to_markdown as write_audit_report_to_markdown,
+)
 
 __all__ = [
     "AlertReport",
@@ -33,13 +41,19 @@ __all__ = [
     "WatchdogFinding",
     "WatchdogReport",
     "WatchdogVerdict",
+    "WriteAuditError",
+    "WriteAuditFinding",
+    "WriteAuditReport",
+    "WriteAuditVerdict",
     "build_alert_report",
     "load_collector_input",
     "main",
     "run_check_artifacts",
     "run_status",
     "render_escalation_draft",
+    "run_write_audit",
     "validate_24h_window",
     "validate_24h_window_from_dir",
     "watchdog_report_to_markdown",
+    "write_audit_report_to_markdown",
 ]

--- a/tools/evidence_harvester/write_audit.py
+++ b/tools/evidence_harvester/write_audit.py
@@ -1,0 +1,1172 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+from .alerts import ALERT_REPORT_SCHEMA_VERSION
+from .runner import HEARTBEAT_SCHEMA, STATE_SCHEMA
+from .snapshot import SNAPSHOT_SCHEMA_VERSION
+from .watchdog import WATCHDOG_REPORT_SCHEMA
+
+COLLECTOR_REPORT_SCHEMA = "evidence_harvester.collector_report.v1"
+
+WRITE_AUDIT_REPORT_SCHEMA = "cdb.evidence_harvester.write_audit_report.v1"
+DEFAULT_STALE_THRESHOLD_SECONDS = 7200
+DEFAULT_WARN_STALE_SECONDS = 5400
+MIN_SANE_ARTIFACT_SIZE = 1
+MAX_SANE_ARTIFACT_SIZE = 10 * 1024 * 1024
+
+
+class WriteAuditError(ValueError):
+    pass
+
+
+def _parse_ts(value: Any, field_name: str) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise WriteAuditError(f"{field_name} must not be blank")
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError as exc:
+            raise WriteAuditError(
+                f"{field_name} must be an ISO-8601 UTC timestamp"
+            ) from exc
+    else:
+        raise WriteAuditError(f"{field_name} must be an ISO-8601 UTC timestamp")
+    if parsed.tzinfo is None:
+        raise WriteAuditError(f"{field_name} must be timezone-aware UTC")
+    return parsed.astimezone(UTC)
+
+
+def _format_ts(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _now_utc() -> datetime:
+    return cdb_utcnow().astimezone(UTC)
+
+
+def _require_mapping(value: Any, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise WriteAuditError(f"{field_name} must be an object")
+    return value
+
+
+def _require_string(value: Any, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise WriteAuditError(f"{field_name} must be a string")
+    text = value.strip()
+    if not text:
+        raise WriteAuditError(f"{field_name} must not be blank")
+    return text
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise WriteAuditError(f"Malformed JSON in {path.name}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise WriteAuditError(f"{path.name} JSON root must be an object")
+    return payload
+
+
+def _hash_collector_report(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
+    return f"sha256:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _default_artifact_dir() -> Path:
+    return _repo_root() / "artifacts" / "evidence_harvester" / "runner"
+
+
+def _resolve_artifact_dir(path: Path | None) -> Path:
+    return (path or _default_artifact_dir()).resolve()
+
+
+@dataclass(frozen=True, slots=True)
+class WriteAuditFinding:
+    check_id: str
+    check_name: str
+    severity: str
+    message: str
+    artifact: str = ""
+    field_name: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class WriteAuditVerdict:
+    verdict: str
+    total_checks: int
+    pass_count: int
+    warn_count: int
+    fail_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class WriteAuditReport:
+    schema_version: str
+    evaluated_at_utc: str
+    artifact_dir: str
+    required_artifacts_present: bool
+    all_json_parse: bool
+    schema_versions_match: bool
+    hash_linkage_valid: bool
+    safety_flags_correct: bool
+    timestamps_coherent: bool
+    source_modes_valid: bool
+    sizes_sane: bool
+    verdict: WriteAuditVerdict
+    findings: tuple[WriteAuditFinding, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _collect_artifact_paths(artifact_dir: Path) -> dict[str, list[Path]]:
+    return {
+        "collector_reports": sorted(artifact_dir.glob("collector_report_*.json")),
+        "snapshots_json": sorted(artifact_dir.glob("snapshot_*.json")),
+        "snapshots_md": sorted(artifact_dir.glob("snapshot_*.md")),
+        "alerts_json": sorted(artifact_dir.glob("alert_*.json")),
+        "alerts_md": sorted(artifact_dir.glob("alert_*.md")),
+        "heartbeat": (
+            [artifact_dir / "runner_heartbeat.json"]
+            if (artifact_dir / "runner_heartbeat.json").exists()
+            else []
+        ),
+        "state": (
+            [artifact_dir / "runner_state.json"]
+            if (artifact_dir / "runner_state.json").exists()
+            else []
+        ),
+        "watchdog_json": sorted(artifact_dir.glob("watchdog_report.json")),
+        "watchdog_md": sorted(artifact_dir.glob("watchdog_report.md")),
+    }
+
+
+REQUIRED_ARTIFACT_GLOBS: dict[str, str] = {
+    "collector_reports": "collector_report_*.json",
+    "snapshots_json": "snapshot_*.json",
+    "snapshots_md": "snapshot_*.md",
+    "alerts_json": "alert_*.json",
+    "alerts_md": "alert_*.md",
+    "heartbeat": "runner_heartbeat.json",
+    "state": "runner_state.json",
+    "watchdog_json": "watchdog_report.json",
+}
+
+OPTIONAL_ARTIFACT_GLOBS: dict[str, str] = {
+    "watchdog_md": "watchdog_report.md",
+}
+
+
+def _check_required_artifacts(
+    artifact_paths: dict[str, list[Path]],
+    artifact_dir_label: str,
+) -> list[WriteAuditFinding]:
+    findings: list[WriteAuditFinding] = []
+    all_present = True
+    for key, pattern in REQUIRED_ARTIFACT_GLOBS.items():
+        paths = artifact_paths.get(key, [])
+        if not paths:
+            all_present = False
+            findings.append(
+                WriteAuditFinding(
+                    check_id="A001",
+                    check_name="Required artifact present",
+                    severity="fail",
+                    message=f"Missing required artifact matching {pattern}",
+                    artifact=artifact_dir_label,
+                )
+            )
+    for key, pattern in OPTIONAL_ARTIFACT_GLOBS.items():
+        paths = artifact_paths.get(key, [])
+        if not paths:
+            findings.append(
+                WriteAuditFinding(
+                    check_id="A001",
+                    check_name="Optional companion present",
+                    severity="warn",
+                    message=f"Missing optional companion {pattern}",
+                    artifact=artifact_dir_label,
+                )
+            )
+    if all_present:
+        findings.append(
+            WriteAuditFinding(
+                check_id="A001",
+                check_name="Required artifacts present",
+                severity="pass",
+                message="All required artifacts found",
+                artifact=artifact_dir_label,
+            )
+        )
+    return findings
+
+
+def _get_json_paths(
+    artifact_paths: dict[str, list[Path]],
+) -> dict[str, list[Path]]:
+    return {
+        k: v
+        for k, v in artifact_paths.items()
+        if k
+        in {
+            "collector_reports",
+            "snapshots_json",
+            "alerts_json",
+            "heartbeat",
+            "state",
+            "watchdog_json",
+        }
+    }
+
+
+def _check_json_integrity(
+    artifact_paths: dict[str, list[Path]],
+    artifact_dir_label: str,
+) -> list[WriteAuditFinding]:
+    findings: list[WriteAuditFinding] = []
+    json_paths = _get_json_paths(artifact_paths)
+    all_parse = True
+    for label, paths in json_paths.items():
+        for path in paths:
+            try:
+                _load_json(path)
+            except WriteAuditError as exc:
+                all_parse = False
+                findings.append(
+                    WriteAuditFinding(
+                        check_id="A002",
+                        check_name="JSON artifact parses",
+                        severity="fail",
+                        message=str(exc),
+                        artifact=f"{artifact_dir_label}/{path.name}",
+                    )
+                )
+    if all_parse:
+        findings.append(
+            WriteAuditFinding(
+                check_id="A002",
+                check_name="JSON artifacts parse",
+                severity="pass",
+                message="All found JSON artifacts parse successfully",
+                artifact=artifact_dir_label,
+            )
+        )
+    return findings
+
+
+def _check_schema_versions(
+    artifact_paths: dict[str, list[Path]],
+    artifact_dir_label: str,
+) -> list[WriteAuditFinding]:
+    findings: list[WriteAuditFinding] = []
+    expected: dict[str, dict[str, str | tuple[str, ...]]] = {
+        "collector_reports": {
+            "schema_version": COLLECTOR_REPORT_SCHEMA,
+        },
+        "snapshots_json": {
+            "metadata.schema_version": SNAPSHOT_SCHEMA_VERSION,
+        },
+        "alerts_json": {
+            "schema_version": ALERT_REPORT_SCHEMA_VERSION,
+        },
+        "heartbeat": {
+            "schema_version": HEARTBEAT_SCHEMA,
+        },
+        "state": {
+            "schema_version": STATE_SCHEMA,
+        },
+        "watchdog_json": {
+            "schema_version": WATCHDOG_REPORT_SCHEMA,
+        },
+    }
+    all_match = True
+    for label, expected_map in expected.items():
+        paths = artifact_paths.get(label, [])
+        for path in paths:
+            try:
+                payload = _load_json(path)
+            except WriteAuditError:
+                continue
+            for field, expected_ver in expected_map.items():
+                if isinstance(expected_ver, tuple):
+                    actual = _nested_get(payload, field)
+                    if actual not in expected_ver:
+                        all_match = False
+                        findings.append(
+                            WriteAuditFinding(
+                                check_id="A003",
+                                check_name="Schema version",
+                                severity="fail",
+                                message=(
+                                    f"{path.name}[{field}] = {actual!r}, "
+                                    f"expected one of {expected_ver}"
+                                ),
+                                artifact=f"{artifact_dir_label}/{path.name}",
+                                field_name=field,
+                            )
+                        )
+                else:
+                    actual = _nested_get(payload, field)
+                    if actual != expected_ver:
+                        all_match = False
+                        findings.append(
+                            WriteAuditFinding(
+                                check_id="A003",
+                                check_name="Schema version",
+                                severity="fail",
+                                message=(
+                                    f"{path.name}[{field}] = {actual!r}, "
+                                    f"expected {expected_ver!r}"
+                                ),
+                                artifact=f"{artifact_dir_label}/{path.name}",
+                                field_name=field,
+                            )
+                        )
+    if all_match:
+        findings.append(
+            WriteAuditFinding(
+                check_id="A003",
+                check_name="Schema versions match",
+                severity="pass",
+                message="All schema versions match expected values",
+                artifact=artifact_dir_label,
+            )
+        )
+    return findings
+
+
+def _nested_get(payload: dict[str, Any], dotted: str) -> Any:
+    parts = dotted.split(".")
+    current: Any = payload
+    for part in parts:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _check_hash_linkage(
+    artifact_paths: dict[str, list[Path]],
+    artifact_dir_label: str,
+) -> list[WriteAuditFinding]:
+    findings: list[WriteAuditFinding] = []
+    collector_reports = artifact_paths.get("collector_reports", [])
+    snapshots = artifact_paths.get("snapshots_json", [])
+    if not collector_reports or not snapshots:
+        findings.append(
+            WriteAuditFinding(
+                check_id="A004",
+                check_name="Hash linkage",
+                severity="fail",
+                message="Cannot verify hash linkage: collector report or snapshot missing",
+                artifact=artifact_dir_label,
+            )
+        )
+        return findings
+
+    all_valid = True
+    for snapshot_path in snapshots:
+        try:
+            snapshot_payload = _load_json(snapshot_path)
+        except WriteAuditError:
+            all_valid = False
+            continue
+        expected_hash = snapshot_payload.get("metadata", {}).get(
+            "collector_report_hash", ""
+        )
+        if not expected_hash:
+            all_valid = False
+            findings.append(
+                WriteAuditFinding(
+                    check_id="A004",
+                    check_name="Hash linkage",
+                    severity="fail",
+                    message=(f"{snapshot_path.name} has no collector_report_hash"),
+                    artifact=f"{artifact_dir_label}/{snapshot_path.name}",
+                    field_name="metadata.collector_report_hash",
+                )
+            )
+            continue
+        expected_collector_id = snapshot_payload.get("metadata", {}).get(
+            "collector_report_id", ""
+        )
+        matched = False
+        for cr_path in collector_reports:
+            try:
+                cr_payload = _load_json(cr_path)
+            except WriteAuditError:
+                continue
+            actual_hash = _hash_collector_report(cr_payload)
+            if actual_hash == expected_hash:
+                matched = True
+                break
+            cr_id = cr_payload.get("report_id", "")
+            if cr_id and cr_id == expected_collector_id:
+                matched = True
+                break
+        if matched:
+            findings.append(
+                WriteAuditFinding(
+                    check_id="A004",
+                    check_name="Hash linkage",
+                    severity="pass",
+                    message=(
+                        f"{snapshot_path.name} collector_report_hash matches "
+                        "a collector report"
+                    ),
+                    artifact=f"{artifact_dir_label}/{snapshot_path.name}",
+                    field_name="metadata.collector_report_hash",
+                )
+            )
+        else:
+            all_valid = False
+            findings.append(
+                WriteAuditFinding(
+                    check_id="A004",
+                    check_name="Hash linkage",
+                    severity="fail",
+                    message=(
+                        f"{snapshot_path.name} collector_report_hash="
+                        f"{expected_hash} does not match any collector report"
+                    ),
+                    artifact=f"{artifact_dir_label}/{snapshot_path.name}",
+                    field_name="metadata.collector_report_hash",
+                )
+            )
+    if all_valid and len(snapshots) > 0:
+        pass
+    elif not all_valid:
+        pass
+    return findings
+
+
+def _check_safety_flags(
+    artifact_paths: dict[str, list[Path]],
+    artifact_dir_label: str,
+) -> list[WriteAuditFinding]:
+    findings: list[WriteAuditFinding] = []
+    snapshots = artifact_paths.get("snapshots_json", [])
+    all_correct = True
+    for path in snapshots:
+        try:
+            payload = _load_json(path)
+        except WriteAuditError:
+            continue
+        safety = payload.get("safety", {})
+        for sf_key, expected in [
+            ("lr_status", "NO-GO"),
+            ("live_status", "NO-GO"),
+            ("echtgeld_status", "NO-GO"),
+        ]:
+            actual = safety.get(sf_key)
+            if actual != expected:
+                all_correct = False
+                findings.append(
+                    WriteAuditFinding(
+                        check_id="A005",
+                        check_name="Safety flag",
+                        severity="fail",
+                        message=(
+                            f"{path.name}[safety.{sf_key}] = {actual!r}, "
+                            f"expected {expected!r}"
+                        ),
+                        artifact=f"{artifact_dir_label}/{path.name}",
+                        field_name=f"safety.{sf_key}",
+                    )
+                )
+    alert_reports = artifact_paths.get("alerts_json", [])
+    for path in alert_reports:
+        try:
+            payload = _load_json(path)
+        except WriteAuditError:
+            continue
+        manual_only = payload.get("manual_escalation_only", True)
+        if isinstance(manual_only, bool) and not manual_only:
+            all_correct = False
+            findings.append(
+                WriteAuditFinding(
+                    check_id="A005",
+                    check_name="Safety flag",
+                    severity="fail",
+                    message=(f"{path.name}[manual_escalation_only] is false"),
+                    artifact=f"{artifact_dir_label}/{path.name}",
+                    field_name="manual_escalation_only",
+                )
+            )
+    if all_correct:
+        findings.append(
+            WriteAuditFinding(
+                check_id="A005",
+                check_name="Safety flags correct",
+                severity="pass",
+                message="All safety flags are correctly set to NO-GO",
+                artifact=artifact_dir_label,
+            )
+        )
+    else:
+        pass
+    return findings
+
+
+def _check_timestamp_coherence(
+    artifact_paths: dict[str, list[Path]],
+    artifact_dir_label: str,
+    *,
+    stale_threshold: int,
+    warn_stale: int,
+    now: datetime,
+) -> list[WriteAuditFinding]:
+    findings: list[WriteAuditFinding] = []
+    all_coherent = True
+
+    heartbeat_paths = artifact_paths.get("heartbeat", [])
+    for hb_path in heartbeat_paths:
+        try:
+            hb = _load_json(hb_path)
+        except WriteAuditError:
+            continue
+        current_run = hb.get("current_run_at_utc", "")
+        if current_run:
+            try:
+                ts = _parse_ts(current_run, "current_run_at_utc")
+                age = (now - ts).total_seconds()
+                if age > stale_threshold:
+                    all_coherent = False
+                    findings.append(
+                        WriteAuditFinding(
+                            check_id="A006",
+                            check_name="Timestamp coherence",
+                            severity="fail",
+                            message=(
+                                f"heartbeat current_run_at_utc is {age:.0f}s old "
+                                f"(threshold {stale_threshold}s)"
+                            ),
+                            artifact=f"{artifact_dir_label}/{hb_path.name}",
+                            field_name="current_run_at_utc",
+                        )
+                    )
+                elif age > warn_stale:
+                    findings.append(
+                        WriteAuditFinding(
+                            check_id="A006",
+                            check_name="Timestamp coherence",
+                            severity="warn",
+                            message=(
+                                f"heartbeat current_run_at_utc is {age:.0f}s old "
+                                f"(warn threshold {warn_stale}s)"
+                            ),
+                            artifact=f"{artifact_dir_label}/{hb_path.name}",
+                            field_name="current_run_at_utc",
+                        )
+                    )
+            except WriteAuditError:
+                all_coherent = False
+                findings.append(
+                    WriteAuditFinding(
+                        check_id="A006",
+                        check_name="Timestamp coherence",
+                        severity="fail",
+                        message=(
+                            f"heartbeat has invalid current_run_at_utc={current_run!r}"
+                        ),
+                        artifact=f"{artifact_dir_label}/{hb_path.name}",
+                        field_name="current_run_at_utc",
+                    )
+                )
+
+    collector_reports = artifact_paths.get("collector_reports", [])
+    for cr_path in collector_reports:
+        try:
+            cr = _load_json(cr_path)
+        except WriteAuditError:
+            continue
+        produced_at = cr.get("produced_at_utc", "")
+        if produced_at:
+            try:
+                _parse_ts(produced_at, "produced_at_utc")
+            except WriteAuditError:
+                all_coherent = False
+                findings.append(
+                    WriteAuditFinding(
+                        check_id="A006",
+                        check_name="Timestamp coherence",
+                        severity="fail",
+                        message=(
+                            f"{cr_path.name} has invalid "
+                            f"produced_at_utc={produced_at!r}"
+                        ),
+                        artifact=f"{artifact_dir_label}/{cr_path.name}",
+                        field_name="produced_at_utc",
+                    )
+                )
+
+    snapshots = artifact_paths.get("snapshots_json", [])
+    for snap_path in snapshots:
+        try:
+            snap = _load_json(snap_path)
+        except WriteAuditError:
+            continue
+        gen_at = snap.get("metadata", {}).get("generated_at_utc", "")
+        if gen_at:
+            try:
+                ts = _parse_ts(gen_at, "generated_at_utc")
+                age = (now - ts).total_seconds()
+                if age > stale_threshold:
+                    all_coherent = False
+                    findings.append(
+                        WriteAuditFinding(
+                            check_id="A006",
+                            check_name="Timestamp coherence",
+                            severity="fail",
+                            message=(
+                                f"{snap_path.name} generated_at_utc is {age:.0f}s "
+                                f"old (threshold {stale_threshold}s)"
+                            ),
+                            artifact=f"{artifact_dir_label}/{snap_path.name}",
+                            field_name="metadata.generated_at_utc",
+                        )
+                    )
+                elif age > warn_stale:
+                    findings.append(
+                        WriteAuditFinding(
+                            check_id="A006",
+                            check_name="Timestamp coherence",
+                            severity="warn",
+                            message=(
+                                f"{snap_path.name} generated_at_utc is {age:.0f}s "
+                                f"old (warn threshold {warn_stale}s)"
+                            ),
+                            artifact=f"{artifact_dir_label}/{snap_path.name}",
+                            field_name="metadata.generated_at_utc",
+                        )
+                    )
+            except WriteAuditError:
+                all_coherent = False
+                findings.append(
+                    WriteAuditFinding(
+                        check_id="A006",
+                        check_name="Timestamp coherence",
+                        severity="fail",
+                        message=(
+                            f"{snap_path.name} has invalid "
+                            f"generated_at_utc={gen_at!r}"
+                        ),
+                        artifact=f"{artifact_dir_label}/{snap_path.name}",
+                        field_name="metadata.generated_at_utc",
+                    )
+                )
+    if all_coherent:
+        findings.append(
+            WriteAuditFinding(
+                check_id="A006",
+                check_name="Timestamps coherent",
+                severity="pass",
+                message="All timestamps are valid and within threshold",
+                artifact=artifact_dir_label,
+            )
+        )
+    return findings
+
+
+def _check_source_modes(
+    artifact_paths: dict[str, list[Path]],
+    artifact_dir_label: str,
+) -> list[WriteAuditFinding]:
+    findings: list[WriteAuditFinding] = []
+    allowed_sources = {"fixture", "future_readonly"}
+    all_valid = True
+
+    collector_reports = artifact_paths.get("collector_reports", [])
+    for cr_path in collector_reports:
+        try:
+            cr = _load_json(cr_path)
+        except WriteAuditError:
+            continue
+        sm = cr.get("source_mode", "")
+        if sm not in allowed_sources:
+            all_valid = False
+            findings.append(
+                WriteAuditFinding(
+                    check_id="A007",
+                    check_name="Source mode",
+                    severity="fail",
+                    message=(
+                        f"{cr_path.name} source_mode={sm!r}, "
+                        f"expected one of {allowed_sources}"
+                    ),
+                    artifact=f"{artifact_dir_label}/{cr_path.name}",
+                    field_name="source_mode",
+                )
+            )
+
+    snapshots = artifact_paths.get("snapshots_json", [])
+    for snap_path in snapshots:
+        try:
+            snap = _load_json(snap_path)
+        except WriteAuditError:
+            continue
+        sm = snap.get("metadata", {}).get("source_mode", "")
+        if sm not in allowed_sources:
+            all_valid = False
+            findings.append(
+                WriteAuditFinding(
+                    check_id="A007",
+                    check_name="Source mode",
+                    severity="fail",
+                    message=(
+                        f"{snap_path.name} metadata.source_mode={sm!r}, "
+                        f"expected one of {allowed_sources}"
+                    ),
+                    artifact=f"{artifact_dir_label}/{snap_path.name}",
+                    field_name="metadata.source_mode",
+                )
+            )
+
+    if all_valid:
+        findings.append(
+            WriteAuditFinding(
+                check_id="A007",
+                check_name="Source modes valid",
+                severity="pass",
+                message="All source_mode values are valid",
+                artifact=artifact_dir_label,
+            )
+        )
+    return findings
+
+
+def _check_artifact_sizes(
+    artifact_paths: dict[str, list[Path]],
+    artifact_dir_label: str,
+) -> list[WriteAuditFinding]:
+    findings: list[WriteAuditFinding] = []
+    all_sane = True
+    for label, paths in artifact_paths.items():
+        for path in paths:
+            if not path.exists():
+                continue
+            size = path.stat().st_size
+            if size == 0:
+                all_sane = False
+                findings.append(
+                    WriteAuditFinding(
+                        check_id="A008",
+                        check_name="Artifact size",
+                        severity="fail",
+                        message=f"{path.name} is zero bytes",
+                        artifact=f"{artifact_dir_label}/{path.name}",
+                    )
+                )
+            elif size > MAX_SANE_ARTIFACT_SIZE:
+                all_sane = False
+                findings.append(
+                    WriteAuditFinding(
+                        check_id="A008",
+                        check_name="Artifact size",
+                        severity="fail",
+                        message=(
+                            f"{path.name} is {size} bytes "
+                            f"(max sane {MAX_SANE_ARTIFACT_SIZE})"
+                        ),
+                        artifact=f"{artifact_dir_label}/{path.name}",
+                    )
+                )
+    if all_sane:
+        findings.append(
+            WriteAuditFinding(
+                check_id="A008",
+                check_name="Artifact sizes sane",
+                severity="pass",
+                message="All artifact sizes are within bounds",
+                artifact=artifact_dir_label,
+            )
+        )
+    return findings
+
+
+def _check_markdown_companions(
+    artifact_paths: dict[str, list[Path]],
+    artifact_dir_label: str,
+) -> list[WriteAuditFinding]:
+    findings: list[WriteAuditFinding] = []
+    companion_pairs = [
+        ("snapshots_json", "snapshots_md", "snapshot"),
+        ("alerts_json", "alerts_md", "alert"),
+        ("watchdog_json", "watchdog_md", "watchdog"),
+    ]
+    all_present = True
+    for json_key, md_key, name in companion_pairs:
+        json_paths = artifact_paths.get(json_key, [])
+        md_paths = artifact_paths.get(md_key, [])
+        has_companions = len(md_paths) >= len(json_paths)
+        if json_paths and not has_companions:
+            all_present = False
+            findings.append(
+                WriteAuditFinding(
+                    check_id="A009",
+                    check_name="Markdown companion",
+                    severity="warn",
+                    message=(
+                        f"{name} JSON present but fewer Markdown companions: "
+                        f"{len(json_paths)} JSON, {len(md_paths)} MD"
+                    ),
+                    artifact=artifact_dir_label,
+                )
+            )
+    if all_present:
+        findings.append(
+            WriteAuditFinding(
+                check_id="A009",
+                check_name="Markdown companions present",
+                severity="pass",
+                message="All Markdown companions present where JSON exists",
+                artifact=artifact_dir_label,
+            )
+        )
+    return findings
+
+
+def _check_metadata_fields(
+    artifact_paths: dict[str, list[Path]],
+    artifact_dir_label: str,
+) -> list[WriteAuditFinding]:
+    findings: list[WriteAuditFinding] = []
+    all_ok = True
+
+    json_checks: dict[str, list[tuple[str, str]]] = {
+        "collector_reports": [
+            ("schema_version", "schema_version"),
+            ("source_mode", "source_mode"),
+            ("report_id", "report_id"),
+            ("produced_at_utc", "produced_at_utc"),
+        ],
+        "snapshots_json": [
+            ("schema_version", "metadata.schema_version"),
+            ("generated_at_utc", "metadata.generated_at_utc"),
+            ("source_mode", "metadata.source_mode"),
+            ("collector_report_hash", "metadata.collector_report_hash"),
+            (
+                "collector_report_schema_version",
+                "metadata.collector_report_schema_version",
+            ),
+        ],
+        "alerts_json": [
+            ("schema_version", "schema_version"),
+        ],
+        "heartbeat": [
+            ("schema_version", "schema_version"),
+            ("current_run_at_utc", "current_run_at_utc"),
+        ],
+        "state": [
+            ("schema_version", "schema_version"),
+            ("last_cycle_verdict", "last_cycle_verdict"),
+        ],
+        "watchdog_json": [
+            ("schema_version", "schema_version"),
+            ("evaluated_at_utc", "evaluated_at_utc"),
+            ("verdict", "verdict.verdict"),
+        ],
+    }
+
+    for label, field_checks in json_checks.items():
+        paths = artifact_paths.get(label, [])
+        for path in paths:
+            try:
+                payload = _load_json(path)
+            except WriteAuditError:
+                continue
+            for field_name, dotted_path in field_checks:
+                val = _nested_get(payload, dotted_path)
+                if not val or (isinstance(val, str) and not val.strip()):
+                    all_ok = False
+                    findings.append(
+                        WriteAuditFinding(
+                            check_id="A010",
+                            check_name="Artifact metadata field",
+                            severity="fail",
+                            message=(f"{path.name} missing or empty {field_name}"),
+                            artifact=f"{artifact_dir_label}/{path.name}",
+                            field_name=dotted_path,
+                        )
+                    )
+    if all_ok:
+        findings.append(
+            WriteAuditFinding(
+                check_id="A010",
+                check_name="Artifact metadata fields present",
+                severity="pass",
+                message="All expected metadata fields present and non-empty",
+                artifact=artifact_dir_label,
+            )
+        )
+    return findings
+
+
+def run_write_audit(
+    artifact_dir: Path,
+    *,
+    stale_threshold: int = DEFAULT_STALE_THRESHOLD_SECONDS,
+    warn_stale: int = DEFAULT_WARN_STALE_SECONDS,
+    now: datetime | None = None,
+) -> WriteAuditReport:
+    eval_now = now or _now_utc()
+    artifact_dir_label = str(artifact_dir)
+    artifact_paths = _collect_artifact_paths(artifact_dir)
+
+    all_findings: list[WriteAuditFinding] = []
+
+    required_findings = _check_required_artifacts(artifact_paths, artifact_dir_label)
+    all_findings.extend(required_findings)
+
+    integrity_findings = _check_json_integrity(artifact_paths, artifact_dir_label)
+    all_findings.extend(integrity_findings)
+
+    schema_findings = _check_schema_versions(artifact_paths, artifact_dir_label)
+    all_findings.extend(schema_findings)
+
+    hash_findings = _check_hash_linkage(artifact_paths, artifact_dir_label)
+    all_findings.extend(hash_findings)
+
+    safety_findings = _check_safety_flags(artifact_paths, artifact_dir_label)
+    all_findings.extend(safety_findings)
+
+    ts_findings = _check_timestamp_coherence(
+        artifact_paths,
+        artifact_dir_label,
+        stale_threshold=stale_threshold,
+        warn_stale=warn_stale,
+        now=eval_now,
+    )
+    all_findings.extend(ts_findings)
+
+    source_findings = _check_source_modes(artifact_paths, artifact_dir_label)
+    all_findings.extend(source_findings)
+
+    size_findings = _check_artifact_sizes(artifact_paths, artifact_dir_label)
+    all_findings.extend(size_findings)
+
+    md_findings = _check_markdown_companions(artifact_paths, artifact_dir_label)
+    all_findings.extend(md_findings)
+
+    meta_findings = _check_metadata_fields(artifact_paths, artifact_dir_label)
+    all_findings.extend(meta_findings)
+
+    fail_count = sum(1 for f in all_findings if f.severity == "fail")
+    warn_count = sum(1 for f in all_findings if f.severity == "warn")
+    pass_count = sum(1 for f in all_findings if f.severity == "pass")
+
+    if fail_count:
+        verdict = "FAIL"
+    elif warn_count:
+        verdict = "WARN"
+    else:
+        verdict = "PASS"
+
+    required_artifacts_present = not any(
+        f.check_id == "A001" and f.severity == "fail" for f in all_findings
+    )
+    all_json_parse = not any(
+        f.check_id == "A002" and f.severity == "fail" for f in all_findings
+    )
+    schema_versions_match = not any(
+        f.check_id == "A003" and f.severity == "fail" for f in all_findings
+    )
+    hash_linkage_valid = not any(
+        f.check_id == "A004" and f.severity == "fail" for f in all_findings
+    )
+    safety_flags_correct = not any(
+        f.check_id == "A005" and f.severity == "fail" for f in all_findings
+    )
+    timestamps_coherent = not any(
+        f.check_id == "A006" and f.severity == "fail" for f in all_findings
+    )
+    source_modes_valid = not any(
+        f.check_id == "A007" and f.severity == "fail" for f in all_findings
+    )
+    sizes_sane = not any(
+        f.check_id == "A008" and f.severity == "fail" for f in all_findings
+    )
+
+    sorted_findings = tuple(
+        sorted(
+            all_findings,
+            key=lambda f: (
+                {"fail": 0, "warn": 1, "pass": 2}.get(f.severity, 9),
+                f.check_id,
+            ),
+        )
+    )
+
+    return WriteAuditReport(
+        schema_version=WRITE_AUDIT_REPORT_SCHEMA,
+        evaluated_at_utc=_format_ts(eval_now),
+        artifact_dir=str(artifact_dir),
+        required_artifacts_present=required_artifacts_present,
+        all_json_parse=all_json_parse,
+        schema_versions_match=schema_versions_match,
+        hash_linkage_valid=hash_linkage_valid,
+        safety_flags_correct=safety_flags_correct,
+        timestamps_coherent=timestamps_coherent,
+        source_modes_valid=source_modes_valid,
+        sizes_sane=sizes_sane,
+        verdict=WriteAuditVerdict(
+            verdict=verdict,
+            total_checks=len(sorted_findings),
+            pass_count=pass_count,
+            warn_count=warn_count,
+            fail_count=fail_count,
+        ),
+        findings=sorted_findings,
+    )
+
+
+def report_to_markdown(report: WriteAuditReport) -> str:
+    payload = report.to_dict()
+    lines = [
+        "# Evidence Harvester Write-Audit Report",
+        "",
+        "## Metadata",
+        f"- Schema version: `{payload['schema_version']}`",
+        f"- Evaluated at (UTC): `{payload['evaluated_at_utc']}`",
+        f"- Artifact directory: `{payload['artifact_dir']}`",
+        "",
+        "## Status Flags",
+        f"- Required artifacts present: `{payload['required_artifacts_present']}`",
+        f"- All JSON parse: `{payload['all_json_parse']}`",
+        f"- Schema versions match: `{payload['schema_versions_match']}`",
+        f"- Hash linkage valid: `{payload['hash_linkage_valid']}`",
+        f"- Safety flags correct: `{payload['safety_flags_correct']}`",
+        f"- Timestamps coherent: `{payload['timestamps_coherent']}`",
+        f"- Source modes valid: `{payload['source_modes_valid']}`",
+        f"- Sizes sane: `{payload['sizes_sane']}`",
+        "",
+        "## Summary",
+        f"- Verdict: **{payload['verdict']['verdict']}**",
+        f"- Total checks: {payload['verdict']['total_checks']}",
+        f"- Pass: {payload['verdict']['pass_count']}",
+        f"- Warn: {payload['verdict']['warn_count']}",
+        f"- Fail: {payload['verdict']['fail_count']}",
+        "",
+        "## Findings",
+    ]
+    for item in payload["findings"]:
+        icon = {"fail": "FAIL", "warn": "WARN", "pass": "PASS"}.get(
+            item["severity"], "????"
+        )
+        artifact_part = f" [{item['artifact']}]" if item.get("artifact") else ""
+        field_part = f" ({item['field_name']})" if item.get("field_name") else ""
+        lines.append(
+            f"  [{icon}] {item['check_name']}{artifact_part}{field_part}: {item['message']}"
+        )
+    lines.extend(
+        [
+            "",
+            "## Safety",
+            "- No LR-Go / No Live-Go / No Echtgeld-Go.",
+            "- No runtime / no DB execution / no Docker / no secrets.",
+            "- Write-Audit is read-only and does not modify artifacts.",
+            "- No automatic restart, GitHub write, or scheduler install.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evidence harvester write-audit — verify artifacts are actually written."
+    )
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        help="Runner artifact directory to audit.",
+    )
+    parser.add_argument(
+        "--stale-threshold",
+        type=int,
+        default=DEFAULT_STALE_THRESHOLD_SECONDS,
+        help="Max artifact age before FAIL (default: 7200).",
+    )
+    parser.add_argument(
+        "--warn-stale",
+        type=int,
+        default=DEFAULT_WARN_STALE_SECONDS,
+        help="Artifact age for WARN (default: 5400).",
+    )
+    parser.add_argument(
+        "--evaluated-at-utc",
+        help="Optional explicit evaluation timestamp for deterministic tests.",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        help="Optional path for write-audit report JSON.",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        type=Path,
+        help="Optional path for write-audit report Markdown.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    artifact_dir = _resolve_artifact_dir(args.artifact_dir)
+    now = _now_utc()
+    if args.evaluated_at_utc:
+        now = _parse_ts(args.evaluated_at_utc, "--evaluated-at-utc")
+    report = run_write_audit(
+        artifact_dir,
+        stale_threshold=args.stale_threshold,
+        warn_stale=args.warn_stale,
+        now=now,
+    )
+    payload = report.to_dict()
+    json_text = json.dumps(
+        payload,
+        indent=2 if args.pretty else None,
+        sort_keys=True,
+        ensure_ascii=True,
+    )
+    print(json_text)
+
+    if args.json_output:
+        args.json_output.write_text(
+            json_text + ("" if json_text.endswith("\n") else "\n"),
+            encoding="utf-8",
+        )
+    if args.markdown_output:
+        args.markdown_output.write_text(report_to_markdown(report), encoding="utf-8")
+    return 0 if report.verdict.verdict != "FAIL" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Brain Evidence Block

- **context_tool_status**: contextual_cores MCP tools available (cdb_context_*)
- **context_trust_level**: medium — repo-read + GitHub live checks confirm issue #3361 is OPEN, deps #3358/#3359 are both CLOSED/MERGED, #3345 is OPEN as parent tracker. No open PRs exist.
- **records_found**: CONTROL_REGISTER (stage:trade-capable), LR-AUDIT-STATUS (NO-GO), CURRENT_STATUS.md (ledger), full harvester source read (runner/collector/snapshot/alerts/watchdog/models), test patterns from test_watchdog.py

## Write-Audit Summary

Adds `tools/evidence_harvester/write_audit.py` — a read-only module that verifies the evidence harvester produces complete, readable, temporally consistent, and usable artifact sets.

### 10 Check Groups (A001–A010)

| ID | Check | Failure Condition |
|----|-------|-------------------|
| A001 | Required artifacts present | Missing collector/snapshot/alert/heartbeat/state/watchdog |
| A002 | JSON artifacts parse | Malformed or non-dict JSON |
| A003 | Schema versions match | Unexpected schema_version in any artifact |
| A004 | Hash linkage | Snapshot collector_report_hash mismatches no collector report |
| A005 | Safety flags | lr_status/live_status/echtgeld_status not NO-GO |
| A006 | Timestamp coherence | Stale heartbeat/snapshot or invalid timestamps |
| A007 | Source modes valid | source_mode not in fixture/future_readonly |
| A008 | Artifact sizes sane | Zero-byte or oversized artifacts |
| A009 | Markdown companions | Snapshot/alert/watchdog JSON without MD companion |
| A010 | Metadata fields present | Missing/empty schema_version/generated_at_utc/source_mode |

## PASS/WARN/FAIL Contract

| Verdict | Conditions |
|---------|-----------|
| PASS | All 10 check groups pass; no fail or warn findings |
| WARN | Optional companion missing (e.g. watchdog_report.md), artifact age near threshold |
| FAIL | Required artifact missing, malformed JSON, hash mismatch, missing safety flags, zero-byte artifact, timestamp contradiction, invalid source mode, missing metadata fields |

## Outputs

Produces two local-only outputs (no automatic external writes):
- `write_audit_report.json` — machine-readable
- `write_audit_report.md` — human-readable Markdown

## Tests

43 unit tests in `tests/unit/tools/evidence_harvester/test_write_audit.py` covering:
- A001–A010: each check PASS/FAIL/WARN
- Hash linkage: correct hash pass, mismatch fail, missing collector report fail
- Schema versions: each artifact type, wrong version fail
- Safety flags: lr_status, live_status, echtgeld_status wrong; manual_escalation_only false
- Timestamps: stale/warn heartbeat and snapshot
- Source modes: valid fixture/future_readonly, invalid production fail
- Sizes: zero-byte fail
- Markdown companions: missing snapshot/alert/watchdog MD warn
- Metadata fields: empty/deleted fields fail
- Determinism: identical timestamps produce identical reports
- Edge cases: empty directory, non-dict JSON
- CLI: exit codes, JSON/MD file outputs
- Markdown report rendering

## Safety Confirmation

- **No automatic restart** — only documentation strings contain "restart"
- **No automatic GitHub writes** — escalation is local text output only
- **No scheduler install** — not in scope
- **No runtime / no Docker / no DB / no Redis / no secrets action**
- **No LR-Go / No Live-Go / No Echtgeld-Go**
- Read-only; never modifies artifacts

## Changed Files

| File | Change |
|------|--------|
| `tools/evidence_harvester/write_audit.py` | NEW — write-audit module |
| `tools/evidence_harvester/__init__.py` | Exports write-audit symbols |
| `tools/evidence_harvester/README.md` | Write-audit usage section with check table and verdict contract |
| `docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md` | Status table updated (Planned → Implemented); full write-audit ops section |
| `tests/unit/tools/evidence_harvester/test_write_audit.py` | NEW — 43 unit tests |

## Validation

- `python -m pytest tests/unit/tools/evidence_harvester -q` — 146/146 passed
- `ruff check tools/evidence_harvester tests/unit/tools/evidence_harvester` — all checks passed
- `black --check tools/evidence_harvester tests/unit/tools/evidence_harvester` — 18 files left unchanged
- `git diff --check` — no whitespace errors
- Forbidden pattern grep — only documentation safety strings (acceptable per review rules)

## Feeds

- #3362 (OPS-VALIDATION) — write-audit provides structured artifact completeness evidence

Closes #3361
