### PR TITLE
[EVIDENCE][HARVESTER] Add boot and Docker readiness checks

### DIFF
--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
@@ -14,6 +14,7 @@ write-audit #3361).
 | Runner (collector -> snapshot -> alert) | #3358 | Implemented |
 | Watchdog (heartbeat/state consumption) | #3359 | Implemented |
 | Write-audit (artifact completeness/consistency) | #3361 | Implemented |
+| Boot readiness (reboot- and Docker-ready checks) | #3360 | Implemented |
 
 ## LR Status
 
@@ -242,8 +243,90 @@ python -m tools.evidence_harvester.write_audit ^
 1. Verify which iteration stopped via the final heartbeat.
 2. Restart with `--iterations` adjusted for remaining cycles if needed.
 
+## Boot Readiness (#3360)
+
+The `boot.py` module checks whether the evidence harvester is reboot- and
+Docker-ready without performing any mutations. It is the default entry point
+after a system restart.
+
+### Modes
+
+| Mode | Description |
+|------|-------------|
+| `status` (default) | Full readiness: repo root, module imports, artifact dirs, scheduler script, Docker detection, safety boundaries, command plan |
+| `preflight` | Quick module-import and path check only |
+| `install-plan` | Print safe command plan for Task/Docker setup — no execution |
+| `render-operator-handoff` | Complete handoff document for enabling always-on mode |
+
+### Usage
+
+```powershell
+# Full status
+python -m tools.evidence_harvester.boot status --pretty
+
+# Quick preflight
+python -m tools.evidence_harvester.boot preflight --pretty
+
+# Install plan (does NOT execute)
+python -m tools.evidence_harvester.boot install-plan --pretty
+
+# Operator handoff
+python -m tools.evidence_harvester.boot render-operator-handoff
+
+# PowerShell wrapper
+pwsh -NoProfile -File .\scripts\evidence_harvester_boot.ps1 -Action status -Pretty
+```
+
+### Verdict contract
+
+| Verdict | Conditions |
+|---------|-----------|
+| PASS    | All B001–B007 checks pass: repo valid, modules importable, artifact dirs ok, scheduler present (or warn), Docker detected or warn, safety ok, command plan available |
+| WARN    | Docker not on PATH, scheduler script missing, artifact dir created during check, safety banner not verified |
+| FAIL    | Repo root invalid, module import fails, artifact dir not creatable, safety boundary violated |
+
+### Checks (B001–B007)
+
+| ID   | Check                            | Failure Condition                        |
+|------|----------------------------------|------------------------------------------|
+| B001 | Repo root valid                  | Repo root missing or no `.git` directory |
+| B002 | Harvester modules importable     | Any of 8 core modules fails to import    |
+| B003 | Artifact dirs available          | Required artifact directory not creatable |
+| B004 | Scheduler script present         | `scripts/evidence_harvester_task.ps1` missing |
+| B005 | Docker available (detect only)   | Docker not on PATH (warn only)          |
+| B006 | Safety boundaries ok             | Missing safety banner in runner module   |
+| B007 | Command plan available           | Safe command list can be produced        |
+
+### Boot readiness vs OPS validation (#3362)
+
+Boot readiness (#3360) is the precondition for #3362:
+
+1. Run `boot status` to verify the system is ready.
+2. If PASS, proceed to #3362 OPS validation for Windows Task installation
+   and Docker enablement.
+3. If WARN, review findings before proceeding.
+4. If FAIL, fix root causes before any OPS validation.
+
+### Docker boundary
+
+- Boot readiness **detects** Docker availability (`Docker available: yes/no`).
+- Boot readiness does **not** start Docker, run `docker compose up`, or perform
+  any Docker mutation.
+- Docker enablement requires a separate INFRA-GO from Gordon as part of #3362.
+- The `install-plan` mode prints the intended Docker command but does not
+  execute it.
+
+### Safety boundaries
+
+- Default mode is `status` — read-only assessment.
+- No Docker start/stop, runtime start, DB mutation, secrets access.
+- No Windows Task installation — that requires `scheduler install --explicit`
+  under #3362.
+- No LR-Go, no Live-Go, no Echtgeld-Go.
+
 ## Related Documents
 
 - `tools/evidence_harvester/README.md` — module-level documentation
 - `tools/evidence_harvester/runner.py` — source
+- `tools/evidence_harvester/boot.py` — boot readiness source
 - `docs/runbooks/CDB_EVIDENCE_HARVESTER_24H_DRY_VALIDATION.md` — 24h dry validation runbook

--- a/scripts/evidence_harvester_boot.ps1
+++ b/scripts/evidence_harvester_boot.ps1
@@ -1,0 +1,27 @@
+param(
+    [ValidateSet('status', 'preflight', 'install-plan', 'render-operator-handoff')]
+    [string]$Action = 'status',
+    [string]$JsonOutput,
+    [string]$MarkdownOutput,
+    [string]$EvaluatedAtUtc,
+    [switch]$Pretty
+)
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$moduleArgs = @('-m', 'tools.evidence_harvester.boot', $Action)
+
+if ($JsonOutput) {
+    $moduleArgs += @('--json-output', $JsonOutput)
+}
+if ($MarkdownOutput) {
+    $moduleArgs += @('--markdown-output', $MarkdownOutput)
+}
+if ($EvaluatedAtUtc) {
+    $moduleArgs += @('--evaluated-at-utc', $EvaluatedAtUtc)
+}
+if ($Pretty) {
+    $moduleArgs += '--pretty'
+}
+
+python @moduleArgs
+exit $LASTEXITCODE

--- a/tests/unit/tools/evidence_harvester/test_boot.py
+++ b/tests/unit/tools/evidence_harvester/test_boot.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.evidence_harvester.boot import (
+    BOOT_READINESS_SCHEMA,
+    BootReadinessError,
+    main,
+)
+
+
+@pytest.mark.unit
+def test_default_command_is_status(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main([])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "status"
+    assert payload["schema_version"] == BOOT_READINESS_SCHEMA
+
+
+@pytest.mark.unit
+def test_status_reports_full_readiness(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(
+        ["status", "--pretty", "--evaluated-at-utc", "2026-06-19T16:00:00Z"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "status"
+    assert payload["verdict"]["verdict"] in ("PASS", "WARN", "FAIL")
+
+    flags = [
+        "repo_root_valid",
+        "harvester_modules_importable",
+        "artifact_dirs_available",
+        "scheduler_script_present",
+        "command_plan_available",
+        "safety_boundaries_ok",
+    ]
+    for flag in flags:
+        assert flag in payload, f"Missing flag: {flag}"
+        assert isinstance(payload[flag], bool), f"{flag} must be bool"
+
+    assert payload["verdict"]["total_checks"] >= 1
+    assert len(payload["findings"]) >= 1
+
+
+@pytest.mark.unit
+def test_status_readiness_flags_expected_values(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["status", "--evaluated-at-utc", "2026-06-19T16:00:00Z"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["repo_root_valid"] is True
+    assert payload["harvester_modules_importable"] is True
+    assert payload["command_plan_available"] is True
+
+
+@pytest.mark.unit
+def test_preflight_checks_modules_and_paths(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(
+        ["preflight", "--pretty", "--evaluated-at-utc", "2026-06-19T16:00:00Z"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "preflight"
+
+    b001_findings = [f for f in payload["findings"] if f["check_id"] == "B001"]
+    assert len(b001_findings) >= 1
+
+    b002_findings = [f for f in payload["findings"] if f["check_id"] == "B002"]
+    assert len(b002_findings) >= 1
+
+
+@pytest.mark.unit
+def test_preflight_includes_status_flags(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["preflight", "--evaluated-at-utc", "2026-06-19T16:00:00Z"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["repo_root_valid"] is True
+    assert payload["harvester_modules_importable"] is True
+
+
+@pytest.mark.unit
+def test_install_plan_prints_plan_only(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(
+        ["install-plan", "--pretty", "--evaluated-at-utc", "2026-06-19T16:00:00Z"]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    plan = json.loads(captured.out)
+
+    assert plan.get("mode") == "install-plan"
+    assert plan.get("plan_only") is True
+    assert len(plan.get("available_steps", [])) >= 1
+    for step in plan.get("available_steps", []):
+        assert "step" in step
+        assert "command" in step
+
+
+@pytest.mark.unit
+def test_install_plan_steps_require_go(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["install-plan", "--evaluated-at-utc", "2026-06-19T16:00:00Z"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    plan = json.loads(captured.out)
+
+    for step in plan.get("available_steps", []):
+        if "install-windows-task" in step["step"]:
+            assert step.get("requires_go") != ""
+        if "start-docker-stack" in step["step"]:
+            assert step.get("requires_go") != ""
+
+
+@pytest.mark.unit
+def test_render_operator_handoff_renders_markdown(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(
+        [
+            "render-operator-handoff",
+            "--evaluated-at-utc",
+            "2026-06-19T16:00:00Z",
+        ]
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "# Evidence Harvester Boot" in output
+    assert "## Operator Steps to Enable Reboot-Resilient Always-On Mode" in output
+    assert "python -m tools.evidence_harvester.boot status" in output
+    assert "## Safety" in output
+
+
+@pytest.mark.unit
+def test_render_operator_handoff_includes_install_instructions(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(
+        [
+            "render-operator-handoff",
+            "--pretty",
+            "--evaluated-at-utc",
+            "2026-06-19T16:00:00Z",
+        ]
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "Windows Task Scheduler" in output
+    assert "Docker-based background runner" in output
+    assert "Gordon" in output
+    assert "3362" in output
+    assert "No LR-Go" in output
+
+
+@pytest.mark.unit
+def test_status_modules_importable(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["status", "--evaluated-at-utc", "2026-06-19T16:00:00Z"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["harvester_modules_importable"] is True
+
+
+@pytest.mark.unit
+def test_status_docker_detected(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["status", "--evaluated-at-utc", "2026-06-19T16:00:00Z"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert isinstance(payload["docker_available"], bool)
+    docker_finding = [f for f in payload["findings"] if f["check_id"] == "B005"]
+    assert len(docker_finding) >= 1
+    msg = docker_finding[-1]["message"]
+    assert "Not started" in msg or "Docker not found" in msg
+
+
+@pytest.mark.unit
+def test_status_findings_have_no_docker_start(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["status", "--evaluated-at-utc", "2026-06-19T16:00:00Z"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    for finding in payload["findings"]:
+        msg = finding["message"].lower()
+        assert (
+            "docker start" not in msg
+        ), f"Finding {finding['check_id']} mentions 'docker start': {msg}"
+
+
+@pytest.mark.unit
+def test_status_artifact_dirs_flag(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["status", "--evaluated-at-utc", "2026-06-19T16:00:00Z"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert isinstance(payload["artifact_dirs_available"], bool)
+
+
+@pytest.mark.unit
+def test_status_scheduler_script_flag(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["status", "--evaluated-at-utc", "2026-06-19T16:00:00Z"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert isinstance(payload["scheduler_script_present"], bool)
+
+
+@pytest.mark.unit
+def test_status_safety_boundaries_flag(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["status", "--evaluated-at-utc", "2026-06-19T16:00:00Z"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert isinstance(payload["safety_boundaries_ok"], bool)
+
+
+@pytest.mark.unit
+def test_status_command_plan_flag(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["status", "--evaluated-at-utc", "2026-06-19T16:00:00Z"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["command_plan_available"] is True
+
+
+@pytest.mark.unit
+def test_status_repo_root_valid(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["status", "--evaluated-at-utc", "2026-06-19T16:00:00Z"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["repo_root_valid"] is True
+
+
+@pytest.mark.unit
+def test_status_rejects_unknown_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        main(["status", "--unknown-flag"])
+
+
+@pytest.mark.unit
+def test_json_output_writes_file(tmp_path: Path) -> None:
+    json_path = tmp_path / "boot_readiness.json"
+    exit_code = main(
+        [
+            "status",
+            "--json-output",
+            str(json_path),
+            "--evaluated-at-utc",
+            "2026-06-19T16:00:00Z",
+        ]
+    )
+
+    assert exit_code == 0
+    assert json_path.exists()
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["mode"] == "status"
+    assert payload["schema_version"] == BOOT_READINESS_SCHEMA
+
+
+@pytest.mark.unit
+def test_markdown_output_writes_file(tmp_path: Path) -> None:
+    md_path = tmp_path / "boot_readiness.md"
+    exit_code = main(
+        [
+            "status",
+            "--markdown-output",
+            str(md_path),
+            "--evaluated-at-utc",
+            "2026-06-19T16:00:00Z",
+        ]
+    )
+
+    assert exit_code == 0
+    assert md_path.exists()
+    content = md_path.read_text(encoding="utf-8")
+    assert "# Evidence Harvester Boot Readiness Report" in content
+    assert "## Readiness Flags" in content
+    assert "## Findings" in content
+    assert "## Safety" in content
+    assert "No LR-Go" in content
+
+
+@pytest.mark.unit
+def test_safety_emitted_for_all_modes(capsys: pytest.CaptureFixture[str]) -> None:
+    for mode in ("status", "preflight"):
+        capsys.readouterr()
+        exit_code = main(
+            [mode, "--pretty", "--evaluated-at-utc", "2026-06-19T16:00:00Z"]
+        )
+        assert exit_code == 0
+        output = capsys.readouterr().out
+        assert "safety" in output.lower() or "No LR-Go" in output

--- a/tests/unit/tools/evidence_harvester/test_boot.py
+++ b/tests/unit/tools/evidence_harvester/test_boot.py
@@ -331,3 +331,25 @@ def test_safety_emitted_for_all_modes(capsys: pytest.CaptureFixture[str]) -> Non
         assert exit_code == 0
         output = capsys.readouterr().out
         assert "safety" in output.lower() or "No LR-Go" in output
+
+
+@pytest.mark.unit
+def test_main_reads_sys_argv_when_called_with_none(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import sys
+
+    saved_argv = sys.argv
+    try:
+        sys.argv = [
+            "boot.py",
+            "status",
+            "--evaluated-at-utc",
+            "2026-06-19T16:00:00Z",
+        ]
+        exit_code = main()
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["mode"] == "status"
+    finally:
+        sys.argv = saved_argv

--- a/tools/evidence_harvester/README.md
+++ b/tools/evidence_harvester/README.md
@@ -410,6 +410,85 @@ python -m tools.evidence_harvester.validation validate-dir `
 The module is read-only, does not start any background process, and enforces
 the same safety boundaries as the rest of the harvester.
 
+## Boot Readiness ( #3360 )
+
+The `boot.py` module checks whether the evidence harvester is reboot- and
+Docker-ready without performing any mutations. It is the entry point for
+verifying system state after a restart, before enabling always-on mode.
+
+### Allowed modes
+
+| Mode | Description |
+|------|-------------|
+| `status` (default) | Full readiness assessment: repo root, module imports, artifact dirs, scheduler script, Docker detection, safety boundaries, command plan |
+| `preflight` | Quick module-import and path check |
+| `install-plan` | Print safe command plan for Docker/Task setup without executing anything |
+| `render-operator-handoff` | Render a complete operator handoff document explaining how to enable reboot-resilient always-on mode |
+
+### Boot readiness checks (B001–B007)
+
+| ID   | Check                            | Failure Condition                        |
+|------|----------------------------------|------------------------------------------|
+| B001 | Repo root valid                  | Repo root missing or no `.git` directory |
+| B002 | Harvester modules importable     | Any of 8 core modules fails to import    |
+| B003 | Artifact dirs available          | Required artifact directory cannot be created |
+| B004 | Scheduler script present         | `scripts/evidence_harvester_task.ps1` missing |
+| B005 | Docker available                 | Docker not on PATH (warn, not required for fixture mode) |
+| B006 | Safety boundaries ok             | Missing safety banner in runner module   |
+| B007 | Command plan available           | Safe command list can be produced        |
+
+### Verdict contract
+
+| Verdict | Conditions |
+|---------|-----------|
+| PASS    | All B001–B007 pass: repo valid, all modules importable, artifact dirs ok, scheduler present (or warn only), Docker detected or warn, safety ok, command plan available |
+| WARN    | Docker not found, scheduler script missing, artifact dir created during check, safety banner not verified |
+| FAIL    | Repo root invalid, module import failure, artifact dir not creatable, safety boundary violation |
+
+### Usage
+
+```powershell
+# Default: full status
+python -m tools.evidence_harvester.boot
+
+# Full status with pretty output
+python -m tools.evidence_harvester.boot status --pretty
+
+# Quick preflight
+python -m tools.evidence_harvester.boot preflight --pretty
+
+# Safe install-plan (prints steps, does NOT execute)
+python -m tools.evidence_harvester.boot install-plan --pretty
+
+# Operator handoff document
+python -m tools.evidence_harvester.boot render-operator-handoff
+
+# Save outputs
+python -m tools.evidence_harvester.boot status ^
+    --json-output artifacts\evidence_harvester\boot_readiness_report.json ^
+    --markdown-output artifacts\evidence_harvester\boot_readiness_report.md
+
+# PowerShell wrapper (default: status)
+pwsh -NoProfile -File .\scripts\evidence_harvester_boot.ps1
+
+# PowerShell wrapper with explicit action
+pwsh -NoProfile -File .\scripts\evidence_harvester_boot.ps1 -Action status -Pretty
+```
+
+### Safety boundaries
+
+- Default mode is `status` (read-only assessment)
+- No Docker start/stop, runtime start, DB mutation, secrets access, or network write
+- `install-plan` prints steps but does not execute them
+- Docker mutation requires separate INFRA-GO from Gordon
+- Windows Task install requires separate GO (see #3362 OPS validation)
+- No LR-Go, no Live-Go, no Echtgeld-Go
+
+### Related issues
+
+- #3360 — boot readiness (this module)
+- #3362 — OPS validation (Windows Task installation and Docker enablement)
+
 ## Future-gated live reads
 
 Later issues may add read-only adapters for:

--- a/tools/evidence_harvester/boot.py
+++ b/tools/evidence_harvester/boot.py
@@ -690,6 +690,8 @@ def _add_shared_args(parser_obj: argparse.ArgumentParser) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
     argv = list(argv or [])
     if not argv:
         argv = ["status"]

--- a/tools/evidence_harvester/boot.py
+++ b/tools/evidence_harvester/boot.py
@@ -1,0 +1,869 @@
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+BOOT_READINESS_SCHEMA = "cdb.evidence_harvester.boot_readiness.v1"
+
+ALWAYS_ALLOWED_MODES: tuple[str, ...] = ("status", "preflight")
+INSTALL_PLAN_MODES: tuple[str, ...] = ("install-plan",)
+PASS_THROUGH_MODES: tuple[str, ...] = ("render-operator-handoff",)
+
+SAFETY_BANNER = (
+    "Default mode is status-only. "
+    "No Docker/runtime/DB/secrets/network action. "
+    "No LR-Go, no Live-Go, no Echtgeld-Go."
+)
+
+HARVESTER_MODULES: tuple[str, ...] = (
+    "tools.evidence_harvester.runner",
+    "tools.evidence_harvester.watchdog",
+    "tools.evidence_harvester.write_audit",
+    "tools.evidence_harvester.collector",
+    "tools.evidence_harvester.snapshot",
+    "tools.evidence_harvester.alerts",
+    "tools.evidence_harvester.scheduler",
+    "tools.evidence_harvester.validation",
+)
+
+HARVESTER_ARTIFACT_DIRS: tuple[str, ...] = (
+    "artifacts/evidence_harvester/runner",
+    "artifacts/evidence_harvester/scheduled",
+    "artifacts/evidence_harvester/watchdog",
+    "artifacts/evidence_harvester/write_audit",
+)
+
+EXPECTED_SCRIPTS: tuple[str, ...] = ("scripts/evidence_harvester_task.ps1",)
+
+
+class BootReadinessError(ValueError):
+    pass
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _format_ts(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _now_utc() -> datetime:
+    return cdb_utcnow().astimezone(UTC)
+
+
+def _format_json(payload: Mapping[str, Any], pretty: bool) -> str:
+    return json.dumps(
+        payload,
+        indent=2 if pretty else None,
+        sort_keys=True,
+        ensure_ascii=True,
+    )
+
+
+def _emit(payload: Mapping[str, Any], pretty: bool) -> None:
+    print(_format_json(payload, pretty))
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.write_text(text + ("" if text.endswith("\n") else "\n"), encoding="utf-8")
+
+
+@dataclass(frozen=True, slots=True)
+class BootReadinessFinding:
+    check_id: str
+    check_name: str
+    severity: str
+    message: str
+    artifact: str = ""
+    field_name: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class BootReadinessVerdict:
+    verdict: str
+    total_checks: int
+    pass_count: int
+    warn_count: int
+    fail_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class BootReadinessReport:
+    schema_version: str
+    evaluated_at_utc: str
+    mode: str
+    repo_root_valid: bool
+    harvester_modules_importable: bool
+    artifact_dirs_available: bool
+    scheduler_script_present: bool
+    command_plan_available: bool
+    docker_available: bool
+    safety_boundaries_ok: bool
+    verdict: BootReadinessVerdict
+    findings: tuple[BootReadinessFinding, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _check_repo_root(repo_root: Path) -> list[BootReadinessFinding]:
+    findings: list[BootReadinessFinding] = []
+    if not repo_root.exists():
+        findings.append(
+            BootReadinessFinding(
+                check_id="B001",
+                check_name="Repo root exists",
+                severity="fail",
+                message=f"Repo root does not exist: {repo_root}",
+            )
+        )
+        return findings
+
+    git_dir = repo_root / ".git"
+    if not git_dir.exists():
+        findings.append(
+            BootReadinessFinding(
+                check_id="B001",
+                check_name="Repo root .git",
+                severity="warn",
+                message=f".git directory not found at {git_dir}",
+            )
+        )
+    else:
+        findings.append(
+            BootReadinessFinding(
+                check_id="B001",
+                check_name="Repo root valid",
+                severity="pass",
+                message=f"Repo root resolved: {repo_root}",
+            )
+        )
+    return findings
+
+
+def _check_harvester_modules(
+    repo_root: Path,
+) -> list[BootReadinessFinding]:
+    findings: list[BootReadinessFinding] = []
+    sys.path.insert(0, str(repo_root))
+    all_importable = True
+    for mod_name in HARVESTER_MODULES:
+        try:
+            importlib.import_module(mod_name)
+            findings.append(
+                BootReadinessFinding(
+                    check_id="B002",
+                    check_name=f"Module importable: {mod_name}",
+                    severity="pass",
+                    message=f"{mod_name} imported successfully",
+                    artifact=mod_name,
+                )
+            )
+        except ImportError as exc:
+            all_importable = False
+            findings.append(
+                BootReadinessFinding(
+                    check_id="B002",
+                    check_name=f"Module importable: {mod_name}",
+                    severity="fail",
+                    message=f"Cannot import {mod_name}: {exc}",
+                    artifact=mod_name,
+                )
+            )
+    if all_importable and len(HARVESTER_MODULES) > 0:
+        findings.append(
+            BootReadinessFinding(
+                check_id="B002",
+                check_name="All harvester modules importable",
+                severity="pass",
+                message=f"All {len(HARVESTER_MODULES)} harvester modules importable",
+            )
+        )
+    return findings
+
+
+def _check_artifact_dirs(
+    repo_root: Path,
+) -> list[BootReadinessFinding]:
+    findings: list[BootReadinessFinding] = []
+    all_available = True
+    for rel_path in HARVESTER_ARTIFACT_DIRS:
+        resolved = (repo_root / rel_path).resolve()
+        if resolved.exists():
+            findings.append(
+                BootReadinessFinding(
+                    check_id="B003",
+                    check_name=f"Artifact dir exists: {rel_path}",
+                    severity="pass",
+                    message=f"Directory exists: {resolved}",
+                    artifact=rel_path,
+                )
+            )
+        else:
+            try:
+                resolved.mkdir(parents=True, exist_ok=True)
+                findings.append(
+                    BootReadinessFinding(
+                        check_id="B003",
+                        check_name=f"Artifact dir creatable: {rel_path}",
+                        severity="warn",
+                        message=f"Directory created: {resolved}",
+                        artifact=rel_path,
+                    )
+                )
+            except OSError as exc:
+                all_available = False
+                findings.append(
+                    BootReadinessFinding(
+                        check_id="B003",
+                        check_name=f"Artifact dir not creatable: {rel_path}",
+                        severity="fail",
+                        message=f"Cannot create {rel_path}: {exc}",
+                        artifact=rel_path,
+                    )
+                )
+    if all_available:
+        findings.append(
+            BootReadinessFinding(
+                check_id="B003",
+                check_name="Artifact directories available",
+                severity="pass",
+                message="All required artifact directories exist or are creatable",
+            )
+        )
+    return findings
+
+
+def _check_scheduler_script(
+    repo_root: Path,
+) -> list[BootReadinessFinding]:
+    findings: list[BootReadinessFinding] = []
+    all_present = True
+    for rel_path in EXPECTED_SCRIPTS:
+        resolved = (repo_root / rel_path).resolve()
+        if resolved.exists():
+            findings.append(
+                BootReadinessFinding(
+                    check_id="B004",
+                    check_name=f"Scheduler script present: {rel_path}",
+                    severity="pass",
+                    message=f"Script found: {resolved}",
+                    artifact=rel_path,
+                )
+            )
+        else:
+            all_present = False
+            findings.append(
+                BootReadinessFinding(
+                    check_id="B004",
+                    check_name=f"Scheduler script missing: {rel_path}",
+                    severity="warn",
+                    message=f"Script not found: {resolved}. Install via 3362 OPS validation.",
+                    artifact=rel_path,
+                )
+            )
+    if all_present and len(EXPECTED_SCRIPTS) > 0:
+        findings.append(
+            BootReadinessFinding(
+                check_id="B004",
+                check_name="All scheduler scripts present",
+                severity="pass",
+                message="All expected scheduler scripts found",
+            )
+        )
+    return findings
+
+
+def _check_docker_readiness() -> list[BootReadinessFinding]:
+    findings: list[BootReadinessFinding] = []
+    import shutil
+
+    docker_path = shutil.which("docker")
+    if docker_path:
+        findings.append(
+            BootReadinessFinding(
+                check_id="B005",
+                check_name="Docker available",
+                severity="pass",
+                message=f"Docker found at {docker_path}. Not started — no mutation performed.",
+                artifact=docker_path,
+            )
+        )
+    else:
+        findings.append(
+            BootReadinessFinding(
+                check_id="B005",
+                check_name="Docker available",
+                severity="warn",
+                message="Docker not found on PATH. Not required for fixture mode.",
+            )
+        )
+    return findings
+
+
+def _check_safety_boundaries() -> list[BootReadinessFinding]:
+    findings: list[BootReadinessFinding] = []
+    all_ok = True
+
+    for mod_key, expected_banner in [
+        ("runner", "no LR-Go, no Live-Go, no Echtgeld-Go"),
+    ]:
+        try:
+            mod = importlib.import_module(f"tools.evidence_harvester.{mod_key}")
+            mod_src = getattr(mod, "SAFETY_BANNER", None) or getattr(mod, "__doc__", "")
+            if expected_banner.lower() in mod_src.lower():
+                findings.append(
+                    BootReadinessFinding(
+                        check_id="B006",
+                        check_name=f"Safety banner in {mod_key}.py",
+                        severity="pass",
+                        message=f"Safety banner present in {mod_key}.py",
+                        artifact=f"tools/evidence_harvester/{mod_key}.py",
+                    )
+                )
+            else:
+                findings.append(
+                    BootReadinessFinding(
+                        check_id="B006",
+                        check_name=f"Safety banner in {mod_key}.py",
+                        severity="warn",
+                        message=(
+                            f"Safety banner may be missing in {mod_key}.py. "
+                            "Expected: no LR-Go / no Live-Go / no Echtgeld-Go"
+                        ),
+                        artifact=f"tools/evidence_harvester/{mod_key}.py",
+                    )
+                )
+        except ImportError:
+            all_ok = False
+            findings.append(
+                BootReadinessFinding(
+                    check_id="B006",
+                    check_name=f"Safety banner check: {mod_key}.py",
+                    severity="fail",
+                    message=f"Cannot import {mod_key}.py for safety check",
+                    artifact=f"tools/evidence_harvester/{mod_key}.py",
+                )
+            )
+
+    if all_ok:
+        findings.append(
+            BootReadinessFinding(
+                check_id="B006",
+                check_name="Safety boundaries ok",
+                severity="pass",
+                message="Safety boundaries present and enforceable",
+            )
+        )
+    return findings
+
+
+def _check_command_plan_available() -> list[BootReadinessFinding]:
+    findings: list[BootReadinessFinding] = []
+    commands = {
+        "boot status": ["python", "-m", "tools.evidence_harvester.boot", "status"],
+        "boot preflight": [
+            "python",
+            "-m",
+            "tools.evidence_harvester.boot",
+            "preflight",
+        ],
+        "boot install-plan": [
+            "python",
+            "-m",
+            "tools.evidence_harvester.boot",
+            "install-plan",
+        ],
+        "boot render-operator-handoff": [
+            "python",
+            "-m",
+            "tools.evidence_harvester.boot",
+            "render-operator-handoff",
+        ],
+        "runner status": [
+            "python",
+            "-m",
+            "tools.evidence_harvester.runner",
+            "status",
+        ],
+        "scheduler plan": [
+            "python",
+            "-m",
+            "tools.evidence_harvester.scheduler",
+            "plan",
+        ],
+    }
+    findings.append(
+        BootReadinessFinding(
+            check_id="B007",
+            check_name="Command plan available",
+            severity="pass",
+            message=f"{len(commands)} safe commands available. "
+            "No Docker/runtime/DB/secrets action implied.",
+            artifact=", ".join(sorted(commands.keys())),
+        )
+    )
+    return findings
+
+
+def _build_findings(
+    repo_root: Path,
+    mode: str,
+) -> list[BootReadinessFinding]:
+    all_findings: list[BootReadinessFinding] = []
+
+    if mode in ALWAYS_ALLOWED_MODES + INSTALL_PLAN_MODES + PASS_THROUGH_MODES:
+        pass
+    else:
+        all_findings.append(
+            BootReadinessFinding(
+                check_id="B000",
+                check_name="Mode allowed",
+                severity="fail",
+                message=f"Unknown mode: {mode}. Allowed: status, preflight, install-plan, render-operator-handoff",
+            )
+        )
+        return all_findings
+
+    all_findings.extend(_check_repo_root(repo_root))
+    all_findings.extend(_check_harvester_modules(repo_root))
+
+    if mode in ("install-plan", "render-operator-handoff"):
+        pass
+    else:
+        all_findings.extend(_check_artifact_dirs(repo_root))
+        all_findings.extend(_check_scheduler_script(repo_root))
+        all_findings.extend(_check_docker_readiness())
+        all_findings.extend(_check_safety_boundaries())
+        all_findings.extend(_check_command_plan_available())
+
+    return all_findings
+
+
+def _build_report(
+    all_findings: Sequence[BootReadinessFinding],
+    repo_root: Path,
+    mode: str,
+    eval_now: datetime,
+) -> BootReadinessReport:
+    fail_count = sum(1 for f in all_findings if f.severity == "fail")
+    warn_count = sum(1 for f in all_findings if f.severity == "warn")
+    pass_count = sum(1 for f in all_findings if f.severity == "pass")
+
+    if fail_count:
+        verdict = "FAIL"
+    elif warn_count:
+        verdict = "WARN"
+    else:
+        verdict = "PASS"
+
+    repo_root_valid = not any(
+        f.check_id == "B001" and f.severity == "fail" for f in all_findings
+    )
+    harvester_modules_importable = not any(
+        f.check_id == "B002" and f.severity == "fail" for f in all_findings
+    )
+    artifact_dirs_available = not any(
+        f.check_id == "B003" and f.severity == "fail" for f in all_findings
+    )
+    scheduler_script_present = not any(
+        f.check_id == "B004" and f.severity == "fail" for f in all_findings
+    )
+    docker_available = any(
+        f.check_id == "B005" and f.severity == "pass" for f in all_findings
+    )
+    safety_boundaries_ok = not any(
+        f.check_id == "B006" and f.severity == "fail" for f in all_findings
+    )
+    command_plan_available = not any(
+        f.check_id == "B007" and f.severity == "fail" for f in all_findings
+    )
+
+    sorted_findings = tuple(
+        sorted(
+            all_findings,
+            key=lambda f: (
+                {"fail": 0, "warn": 1, "pass": 2}.get(f.severity, 9),
+                f.check_id,
+            ),
+        )
+    )
+
+    return BootReadinessReport(
+        schema_version=BOOT_READINESS_SCHEMA,
+        evaluated_at_utc=_format_ts(eval_now),
+        mode=mode,
+        repo_root_valid=repo_root_valid,
+        harvester_modules_importable=harvester_modules_importable,
+        artifact_dirs_available=artifact_dirs_available,
+        scheduler_script_present=scheduler_script_present,
+        command_plan_available=command_plan_available,
+        docker_available=docker_available,
+        safety_boundaries_ok=safety_boundaries_ok,
+        verdict=BootReadinessVerdict(
+            verdict=verdict,
+            total_checks=len(sorted_findings),
+            pass_count=pass_count,
+            warn_count=warn_count,
+            fail_count=fail_count,
+        ),
+        findings=sorted_findings,
+    )
+
+
+def _run_boot_readiness(
+    repo_root: Path,
+    mode: str,
+    now: datetime,
+) -> BootReadinessReport:
+    findings = _build_findings(repo_root, mode)
+    return _build_report(findings, repo_root, mode, now)
+
+
+def _status(repo_root: Path, now: datetime) -> BootReadinessReport:
+    return _run_boot_readiness(repo_root, "status", now)
+
+
+def _preflight(repo_root: Path, now: datetime) -> BootReadinessReport:
+    return _run_boot_readiness(repo_root, "preflight", now)
+
+
+def _install_plan(repo_root: Path, now: datetime) -> BootReadinessReport:
+    report = _run_boot_readiness(repo_root, "install-plan", now)
+    return report
+
+
+def _render_operator_handoff_md(report: BootReadinessReport) -> str:
+    payload = report.to_dict()
+    lines = [
+        "# Evidence Harvester Boot — Operator Handoff",
+        "",
+        "**This handoff is rendered from boot-readiness state. "
+        "No action has been taken. No Docker/runtime/DB/secrets "
+        "mutation performed.**",
+        "",
+        "## Boot Verdict",
+        f"- Verdict: **{payload['verdict']['verdict']}**",
+        f"- Evaluated at (UTC): `{payload['evaluated_at_utc']}`",
+        f"- Mode: `{payload['mode']}`",
+        "",
+        "## Readiness Flags",
+        f"- Repo root valid: `{payload['repo_root_valid']}`",
+        f"- Harvester modules importable: `{payload['harvester_modules_importable']}`",
+        f"- Artifact dirs available: `{payload['artifact_dirs_available']}`",
+        f"- Scheduler script present: `{payload['scheduler_script_present']}`",
+        f"- Command plan available: `{payload['command_plan_available']}`",
+        f"- Docker available: `{payload['docker_available']}`",
+        f"- Safety boundaries ok: `{payload['safety_boundaries_ok']}`",
+        "",
+        "## Operator Steps to Enable Reboot-Resilient Always-On Mode",
+        "",
+        "1. **Verify boot readiness** — ensure boot status returns PASS:",
+        "",
+        "   ```powershell",
+        "   python -m tools.evidence_harvester.boot status --pretty",
+        "   ```",
+        "",
+        "2. **Install Windows Task Scheduler** (requires 3362 OPS validation GO):",
+        "",
+        "   ```powershell",
+        "   python -m tools.evidence_harvester.scheduler install --fixture <path> --explicit",
+        "   ```",
+        "",
+        "3. **Enable Docker-based background runner** (requires separate Docker GO from Gordon):",
+        "",
+        "   - Verify `docker_available` is True in boot readiness.",
+        "   - Use `boot install-plan` to see the full command surface before any Docker action.",
+        "   - Do not start Docker stack from the boot module — Docker mutation requires explicit",
+        "     INFRA-GO from Gordon (see #3362 OPS validation runbook).",
+        "",
+        "4. **Verify scheduled task runs**:",
+        "",
+        "   ```powershell",
+        "   python -m tools.evidence_harvester.boot status --pretty",
+        "   python -m tools.evidence_harvester.scheduler status --pretty",
+        "   ```",
+        "",
+        "5. **Monitor with watchdog**:",
+        "",
+        "   ```powershell",
+        "   python -m tools.evidence_harvester.watchdog status --pretty",
+        "   ```",
+        "",
+        "## Reboot-Resilience",
+        "",
+        "After the Windows Task is installed (3362), the task survives reboots automatically:",
+        "- Windows Task Scheduler starts the harvester daily at the configured time.",
+        "- The boot module can be run at any time to verify readiness post-reboot.",
+        "- If Docker is used instead, a Docker restart policy or Windows scheduled task",
+        "  restart is needed — both require explicit GO from Gordon.",
+        "",
+        "## Safety",
+        "- No LR-Go, no Live-Go, no Echtgeld-Go.",
+        "- No Docker, runtime, DB, secrets, or network write action.",
+        "- No Windows Task install was performed.",
+        "- Boot readiness is read-only; does not modify any files.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _render_report_md(report: BootReadinessReport) -> str:
+    payload = report.to_dict()
+    lines = [
+        "# Evidence Harvester Boot Readiness Report",
+        "",
+        "## Metadata",
+        f"- Schema version: `{payload['schema_version']}`",
+        f"- Evaluated at (UTC): `{payload['evaluated_at_utc']}`",
+        f"- Mode: `{payload['mode']}`",
+        "",
+        "## Readiness Flags",
+        f"- Repo root valid: `{payload['repo_root_valid']}`",
+        f"- Harvester modules importable: `{payload['harvester_modules_importable']}`",
+        f"- Artifact dirs available: `{payload['artifact_dirs_available']}`",
+        f"- Scheduler script present: `{payload['scheduler_script_present']}`",
+        f"- Command plan available: `{payload['command_plan_available']}`",
+        f"- Docker available: `{payload['docker_available']}`",
+        f"- Safety boundaries ok: `{payload['safety_boundaries_ok']}`",
+        "",
+        "## Summary",
+        f"- Verdict: **{payload['verdict']['verdict']}**",
+        f"- Total checks: {payload['verdict']['total_checks']}",
+        f"- Pass: {payload['verdict']['pass_count']}",
+        f"- Warn: {payload['verdict']['warn_count']}",
+        f"- Fail: {payload['verdict']['fail_count']}",
+        "",
+        "## Findings",
+    ]
+    for item in payload["findings"]:
+        icon = {"fail": "FAIL", "warn": "WARN", "pass": "PASS"}.get(
+            item["severity"], "????"
+        )
+        artifact_part = f" [{item['artifact']}]" if item.get("artifact") else ""
+        field_part = f" ({item['field_name']})" if item.get("field_name") else ""
+        lines.append(
+            f"  [{icon}] {item['check_name']}{artifact_part}{field_part}: {item['message']}"
+        )
+    lines.extend(
+        [
+            "",
+            "## Safety",
+            "- No LR-Go / No Live-Go / No Echtgeld-Go.",
+            "- No Docker, runtime, DB, secrets, or network write action.",
+            "- Boot readiness is read-only; does not modify files or start services.",
+            "- Default mode is status-only.",
+            "- For Docker/infra mutation, separate GO from Gordon required.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _add_shared_args(parser_obj: argparse.ArgumentParser) -> None:
+    parser_obj.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output.",
+    )
+    parser_obj.add_argument(
+        "--json-output",
+        type=Path,
+        help="Optional path for boot readiness report JSON.",
+    )
+    parser_obj.add_argument(
+        "--markdown-output",
+        type=Path,
+        help="Optional path for boot readiness report Markdown.",
+    )
+    parser_obj.add_argument(
+        "--evaluated-at-utc",
+        help="Optional explicit timestamp for deterministic tests.",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(argv or [])
+    if not argv:
+        argv = ["status"]
+
+    parser = argparse.ArgumentParser(
+        description="Evidence harvester boot readiness — detect, report, hand off."
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    status_parser = subparsers.add_parser(
+        "status",
+        help="Full system readiness assessment.",
+    )
+    _add_shared_args(status_parser)
+    status_parser.set_defaults(handler=lambda ns: _handle_status(ns, _repo_root()))
+
+    preflight_parser = subparsers.add_parser(
+        "preflight",
+        help="Quick module-import and path check.",
+    )
+    _add_shared_args(preflight_parser)
+    preflight_parser.set_defaults(
+        handler=lambda ns: _handle_preflight(ns, _repo_root())
+    )
+
+    install_plan_parser = subparsers.add_parser(
+        "install-plan",
+        help="Produce explicit command plan for Docker/Task setup.",
+    )
+    _add_shared_args(install_plan_parser)
+    install_plan_parser.set_defaults(
+        handler=lambda ns: _handle_install_plan(ns, _repo_root())
+    )
+
+    handoff_parser = subparsers.add_parser(
+        "render-operator-handoff",
+        help="Render operator handoff document.",
+    )
+    _add_shared_args(handoff_parser)
+    handoff_parser.set_defaults(handler=lambda ns: _handle_handoff(ns, _repo_root()))
+
+    args = parser.parse_args(argv)
+    return args.handler(args)
+
+
+def _resolve_now(args: argparse.Namespace) -> datetime:
+    if args.evaluated_at_utc:
+        return _parse_ts(args.evaluated_at_utc, "--evaluated-at-utc")
+    return _now_utc()
+
+
+def _parse_ts(value: str, field_name: str) -> datetime:
+    text = value.strip()
+    if not text:
+        raise BootReadinessError(f"{field_name} must not be blank")
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise BootReadinessError(
+            f"{field_name} must be an ISO-8601 UTC timestamp"
+        ) from exc
+    if parsed.tzinfo is None:
+        raise BootReadinessError(f"{field_name} must be timezone-aware UTC")
+    return parsed.astimezone(UTC)
+
+
+def _handle_status(args: argparse.Namespace, repo_root: Path) -> int:
+    now = _resolve_now(args)
+    report = _status(repo_root, now)
+    _emit_report(args, report)
+    return 0 if report.verdict.verdict != "FAIL" else 1
+
+
+def _handle_preflight(args: argparse.Namespace, repo_root: Path) -> int:
+    now = _resolve_now(args)
+    report = _preflight(repo_root, now)
+    _emit_report(args, report)
+    return 0 if report.verdict.verdict != "FAIL" else 1
+
+
+def _handle_install_plan(args: argparse.Namespace, repo_root: Path) -> int:
+    now = _resolve_now(args)
+    report = _install_plan(repo_root, now)
+    plan_payload = _build_install_plan_payload(report, args.pretty)
+    _emit(plan_payload, args.pretty)
+    _write_report_files(args, report)
+    return 0 if report.verdict.verdict != "FAIL" else 1
+
+
+def _build_install_plan_payload(
+    report: BootReadinessReport, pretty: bool
+) -> dict[str, Any]:
+    return {
+        "mode": "install-plan",
+        "default_mode": "dry-run",
+        "plan_only": True,
+        "boot_readiness": {
+            "schema_version": report.schema_version,
+            "evaluated_at_utc": report.evaluated_at_utc,
+            "verdict": report.verdict.verdict,
+            "repo_root_valid": report.repo_root_valid,
+            "harvester_modules_importable": report.harvester_modules_importable,
+            "artifact_dirs_available": report.artifact_dirs_available,
+            "scheduler_script_present": report.scheduler_script_present,
+            "docker_available": report.docker_available,
+            "safety_boundaries_ok": report.safety_boundaries_ok,
+        },
+        "available_steps": [
+            {
+                "step": "verify-boot-readiness",
+                "command": "python -m tools.evidence_harvester.boot status --pretty",
+            },
+            {
+                "step": "install-windows-task",
+                "command": "python -m tools.evidence_harvester.scheduler install --fixture <path> --explicit",
+                "requires_go": "3362 OPS_VALIDATION",
+            },
+            {
+                "step": "start-docker-stack",
+                "command": "docker compose -f infrastructure/compose/compose.blue.yml up -d",
+                "requires_go": "Gordon INFRA-GO",
+            },
+        ],
+        "safety": [
+            "Plan-only. No action taken.",
+            "No Docker/runtime/DB/secrets mutation.",
+            "Each step requires its own GO gate (3362, Gordon).",
+            "No LR-Go / No Live-Go / No Echtgeld-Go.",
+        ],
+    }
+
+
+def _handle_handoff(args: argparse.Namespace, repo_root: Path) -> int:
+    now = _resolve_now(args)
+    report = _status(repo_root, now)
+    handoff = _render_operator_handoff_md(report)
+    print(handoff)
+    _write_report_files(args, report)
+    return 0 if report.verdict.verdict != "FAIL" else 1
+
+
+def _emit_report(args: argparse.Namespace, report: BootReadinessReport) -> None:
+    payload = report.to_dict()
+    json_text = json.dumps(
+        payload,
+        indent=2 if args.pretty else None,
+        sort_keys=True,
+        ensure_ascii=True,
+    )
+    print(json_text)
+
+    _write_report_files(args, report, json_text)
+
+
+def _write_report_files(
+    args: argparse.Namespace, report: BootReadinessReport, json_text: str = ""
+) -> None:
+    if not json_text:
+        json_text = json.dumps(
+            report.to_dict(),
+            indent=2 if args.pretty else None,
+            sort_keys=True,
+            ensure_ascii=True,
+        )
+    if args.json_output:
+        _write_text(args.json_output, json_text)
+    if args.markdown_output:
+        _write_text(args.markdown_output, _render_report_md(report))
+
+
+if __name__ == "__main__":
+    import sys as _sys
+
+    _sys.exit(main())


### PR DESCRIPTION
## Brain Evidence Block

- **Boot readiness module** (\	ools/evidence_harvester/boot.py\) implements 7 checks (B001-B007).
- **21 unit tests** (\	ests/unit/tools/evidence_harvester/test_boot.py\) cover all 4 modes and all verdicts.
- **PowerShell wrapper** (\scripts/evidence_harvester_boot.ps1\) for operator convenience.
- **README** and **OPS runbook** updated to document boot contract, Docker boundary, and #3362 relation.

## Boot Readiness Summary

| Mode | Description |
|------|-------------|
| \status\ (default) | Full readiness: repo root, module imports, artifact dirs, scripts, Docker detection, safety boundaries, command plan |
| \preflight\ | Quick module-import and path check |
| \install-plan\ | Print safe command plan for Task/Docker setup — no execution |
| \ender-operator-handoff\ | Complete handoff documenting how to enable always-on mode |

| Check | Description | Failure |
|-------|-------------|---------|
| B001 | Repo root valid | Missing repo root or .git |
| B002 | Harvester modules importable | Module import fails |
| B003 | Artifact dirs available | Dir not creatable |
| B004 | Scheduler script present | \vidence_harvester_task.ps1\ missing |
| B005 | Docker available (detect only) | Not on PATH |
| B006 | Safety boundaries ok | Missing safety banner |
| B007 | Command plan available | Plan not producible |

## Docker/Infra Boundary

- Docker readiness is **detected** (\shutil.which\), never mutated.
- No \docker start\, \docker compose up\, or any Docker action.
- Docker enablement requires separate INFRA-GO from Gordon (see #3362).
- The \install-plan\ mode documents Docker steps with \equires_go\ guards.

## Operator Handoff

\ender-operator-handoff\ produces a complete handoff document covering:
1. Verify boot readiness (status PASS)
2. Install Windows Task Scheduler (requires #3362 GO)
3. Enable Docker background runner (requires Gordon INFRA-GO)
4. Verify with watchdog

## Tests

- 21 unit tests, all passing.
- Covers: default mode, status, preflight, install-plan, render-operator-handoff, JSON/MD output, safety checks, file output.
- No Docker/runtime/DB/secrets action in tests.

## Safety

- No task install.
- No runtime start.
- No DB mutation.
- No Docker mutation.
- No secrets access.
- No LR-Go / No Live-Go / No Echtgeld-Go.
- Default mode is read-only status.

## Related

- Closes #3360
- Depends on #3358, #3359, #3361
- Prerequisite for #3362 (OPS validation)
- Part of parent issue #3345