### PR TITLE
[EVIDENCE][HARVESTER] Add always-on ops validation tooling

### DIFF
--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_72H_OPS_VALIDATION.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_72H_OPS_VALIDATION.md
@@ -1,0 +1,171 @@
+# CDB Evidence Harvester - 72h Ops Validation Runbook
+
+## Purpose
+
+Validate the real always-on `>=72h` dry operation for the Evidence Harvester
+without granting any live, Echtgeld, trading, runtime, or infrastructure GO.
+
+This runbook defines the final validation tooling for Issue
+[#3362](https://github.com/jannekbuengener/Claire_de_Binare/issues/3362). The
+tooling is implemented in `tools/evidence_harvester/ops_validation.py` and is
+used only after the real dry run finishes.
+
+## Preconditions
+
+- Child slices [#3358](https://github.com/jannekbuengener/Claire_de_Binare/issues/3358), [#3359](https://github.com/jannekbuengener/Claire_de_Binare/issues/3359), [#3360](https://github.com/jannekbuengener/Claire_de_Binare/issues/3360), and [#3361](https://github.com/jannekbuengener/Claire_de_Binare/issues/3361) are merged.
+- `tools/evidence_harvester/ops_validation.py` is on `main`.
+- The real run has already written artifacts to one dedicated runtime directory.
+- LR remains `NO-GO`.
+
+## Safety State
+
+| Check | Expected |
+|---|---|
+| LR status | `NO-GO` |
+| Live status | `NO-GO` |
+| Echtgeld status | `NO-GO` |
+| Runtime actions | `not_allowed` |
+| DB execution | `not_allowed` |
+| Source mode | `fixture` or `future_readonly` |
+| GitHub writes from module code | forbidden |
+
+## Phase-2 Runtime Contract
+
+- Seed fixture: `artifacts/evidence_harvester/24h_dry_run/collector_input.json`
+- Artifact dir: `artifacts/evidence_harvester/72h_ops_validation/<run_id>/`
+- Runner cadence: every `900` seconds / `15` minutes
+- Watchdog: after each runner cycle
+- Write-audit: after each runner cycle
+- Final validation: after `>=72h` over the whole artifact directory
+
+## Required Artifacts
+
+- `collector_report_<stamp>.json`
+- `snapshot_<stamp>.json`
+- `snapshot_<stamp>.md`
+- `alert_<stamp>.json`
+- `alert_<stamp>.md`
+- `runner_heartbeat.json`
+- `runner_state.json`
+- `watchdog_report_<stamp>.json`
+- `watchdog_report_<stamp>.md`
+- `write_audit_report_<stamp>.json`
+- `write_audit_report_<stamp>.md`
+- `boot_readiness_report.json`
+- `boot_readiness_report.md`
+- `ops_validation_report.json`
+- `ops_validation_report.md`
+
+## Validation Contract
+
+### PASS
+
+- `>=72h` window covered
+- runner continuity evidenced by heartbeat/state counters and stamped cadence history
+- watchdog history PASS or justified WARN
+- write-audit history PASS with no FAIL findings
+- boot-readiness PASS or justified WARN
+- no side effects
+
+### WARN
+
+- minor cadence drift
+- documented non-critical boot warning
+- documented non-critical watchdog warning
+
+### FAIL
+
+- window shorter than required
+- missing or malformed required artifacts
+- write-audit FAIL
+- watchdog FAIL
+- boot-readiness FAIL
+- safety-flag violation
+- forbidden live/echtgeld/trading content
+
+## Validation Command
+
+```powershell
+python -m tools.evidence_harvester.ops_validation validate-dir ^
+    --artifact-dir artifacts\evidence_harvester\72h_ops_validation\<run_id> ^
+    --json-output artifacts\evidence_harvester\72h_ops_validation\<run_id>\ops_validation_report.json ^
+    --markdown-output artifacts\evidence_harvester\72h_ops_validation\<run_id>\ops_validation_report.md ^
+    --pretty
+```
+
+## Runtime Handoff
+
+### Boot preflight
+
+```powershell
+python -m tools.evidence_harvester.boot status --pretty
+python -m tools.evidence_harvester.boot status ^
+    --json-output artifacts\evidence_harvester\72h_ops_validation\<run_id>\boot_readiness_report.json ^
+    --markdown-output artifacts\evidence_harvester\72h_ops_validation\<run_id>\boot_readiness_report.md ^
+    --pretty
+```
+
+### Optional scheduler enablement
+
+Only under a separate Runtime-GO:
+
+```powershell
+python -m tools.evidence_harvester.scheduler install --fixture artifacts\evidence_harvester\24h_dry_run\collector_input.json --explicit
+```
+
+### 72h dry operation start
+
+```powershell
+python -m tools.evidence_harvester.runner loop-fixture ^
+    --fixture artifacts\evidence_harvester\24h_dry_run\collector_input.json ^
+    --output-dir artifacts\evidence_harvester\72h_ops_validation\<run_id> ^
+    --iterations 289 ^
+    --interval-seconds 900 ^
+    --pretty
+```
+
+Operational note:
+
+- After each runner cycle, write the latest `watchdog_report.json/.md` for
+  `write_audit.py` compatibility and archive stamped copies as
+  `watchdog_report_<stamp>.json/.md`.
+- After each runner cycle, archive stamped write-audit outputs as
+  `write_audit_report_<stamp>.json/.md`.
+
+### Stop / disable
+
+```powershell
+python -m tools.evidence_harvester.ops_validation validate-dir --artifact-dir artifacts\evidence_harvester\72h_ops_validation\<run_id> --pretty
+python -m tools.evidence_harvester.scheduler uninstall --explicit
+```
+
+## Side-Effect Checklist
+
+- [ ] No Docker mutation unless Gordon gives a separate documented GO
+- [ ] No runtime start beyond the dry runner loop itself
+- [ ] No DB mutation
+- [ ] No secrets output
+- [ ] No GitHub writes from module code
+- [ ] No LR-Go / Live-Go / Echtgeld-Go
+- [ ] No trading / order / risk / execution mutation
+
+## Gordon Consultation Checkpoint
+
+Before any Docker or infrastructure mutation, stop and obtain a separate,
+documented Gordon operator GO.
+
+## Status Boundary
+
+This runbook validates a dry/paper/research-only evidence run.
+It does not change LR status.
+LR remains `NO-GO`.
+
+## References
+
+- Parent issue: [#3345](https://github.com/jannekbuengener/Claire_de_Binare/issues/3345)
+- Validation issue: [#3362](https://github.com/jannekbuengener/Claire_de_Binare/issues/3362)
+- Runner: `tools/evidence_harvester/runner.py`
+- Watchdog: `tools/evidence_harvester/watchdog.py`
+- Write-audit: `tools/evidence_harvester/write_audit.py`
+- Boot readiness: `tools/evidence_harvester/boot.py`
+- Final validator: `tools/evidence_harvester/ops_validation.py`

--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
@@ -15,6 +15,7 @@ write-audit #3361).
 | Watchdog (heartbeat/state consumption) | #3359 | Implemented |
 | Write-audit (artifact completeness/consistency) | #3361 | Implemented |
 | Boot readiness (reboot- and Docker-ready checks) | #3360 | Implemented |
+| 72h ops validation (final composition validator) | #3362 | Implemented |
 
 ## LR Status
 
@@ -324,9 +325,61 @@ Boot readiness (#3360) is the precondition for #3362:
   under #3362.
 - No LR-Go, no Live-Go, no Echtgeld-Go.
 
+## 72h Ops Validation (#3362)
+
+The `ops_validation.py` module is the final read-only validation surface for the
+real `>=72h` always-on dry run. It validates one finished artifact directory and
+composes runner continuity, snapshot/alert coverage, watchdog history,
+write-audit history, boot readiness, and safety boundaries into a final
+PASS/WARN/FAIL verdict.
+
+### Phase-2 artifact contract
+
+- `artifacts/evidence_harvester/72h_ops_validation/<run_id>/`
+- `collector_report_<stamp>.json`
+- `snapshot_<stamp>.json`
+- `snapshot_<stamp>.md`
+- `alert_<stamp>.json`
+- `alert_<stamp>.md`
+- `runner_heartbeat.json`
+- `runner_state.json`
+- `watchdog_report_<stamp>.json`
+- `watchdog_report_<stamp>.md`
+- `write_audit_report_<stamp>.json`
+- `write_audit_report_<stamp>.md`
+- `boot_readiness_report.json`
+- `boot_readiness_report.md`
+- `ops_validation_report.json`
+- `ops_validation_report.md`
+
+### Phase-2 runtime contract
+
+- Seed fixture: `artifacts/evidence_harvester/24h_dry_run/collector_input.json`
+- Cadence: every `900` seconds / `15` minutes
+- Watchdog: after each runner cycle
+- Write-audit: after each runner cycle
+- Final validation: after `>=72h` over the whole artifact directory
+
+### Usage
+
+```powershell
+python -m tools.evidence_harvester.ops_validation validate-dir ^
+    --artifact-dir artifacts\evidence_harvester\72h_ops_validation\<run_id> ^
+    --json-output artifacts\evidence_harvester\72h_ops_validation\<run_id>\ops_validation_report.json ^
+    --markdown-output artifacts\evidence_harvester\72h_ops_validation\<run_id>\ops_validation_report.md ^
+    --pretty
+```
+
+### Safety boundaries
+
+- Read-only validation only; does not start the 72h run
+- No Windows Task install, Docker/runtime/DB/secrets mutation, or GitHub writes
+- No LR-Go, no Live-Go, no Echtgeld-Go
+
 ## Related Documents
 
 - `tools/evidence_harvester/README.md` — module-level documentation
 - `tools/evidence_harvester/runner.py` — source
 - `tools/evidence_harvester/boot.py` — boot readiness source
 - `docs/runbooks/CDB_EVIDENCE_HARVESTER_24H_DRY_VALIDATION.md` — 24h dry validation runbook
+- `docs/runbooks/CDB_EVIDENCE_HARVESTER_72H_OPS_VALIDATION.md` — final >=72h validation runbook

--- a/tests/unit/tools/evidence_harvester/test_ops_validation.py
+++ b/tests/unit/tools/evidence_harvester/test_ops_validation.py
@@ -1,0 +1,578 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from tools.evidence_harvester.ops_validation import (
+    BOOT_READINESS_SCHEMA,
+    DEFAULT_REQUIRED_WINDOW_HOURS,
+    OPS_VALIDATION_SCHEMA_VERSION,
+    OpsValidationError,
+    RuntimeHandoff,
+    report_to_markdown,
+    validate_72h_window_from_dir,
+)
+from tools.evidence_harvester.snapshot import SAFETY_BANNER, SNAPSHOT_SCHEMA_VERSION
+from tools.evidence_harvester.validation import EXPECTED_ALERT_SCHEMA
+from tools.evidence_harvester.write_audit import (
+    COLLECTOR_REPORT_SCHEMA,
+    WRITE_AUDIT_REPORT_SCHEMA,
+)
+from tools.evidence_harvester.watchdog import WATCHDOG_REPORT_SCHEMA
+
+HEARTBEAT_SCHEMA = "cdb.evidence_harvester.runner_heartbeat.v1"
+STATE_SCHEMA = "cdb.evidence_harvester.runner_state.v1"
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def _write_text(path: Path, text: str = "ok\n") -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def _deep_merge(target: dict, source: dict) -> None:
+    for key, value in source.items():
+        if key in target and isinstance(target[key], dict) and isinstance(value, dict):
+            _deep_merge(target[key], value)
+        else:
+            target[key] = value
+
+
+def _snapshot_payload(ts: str, overrides: dict | None = None) -> dict:
+    payload = {
+        "metadata": {
+            "schema_version": SNAPSHOT_SCHEMA_VERSION,
+            "generated_at_utc": ts,
+            "collector_report_hash": (
+                "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+            ),
+            "collector_report_id": "harv-test123",
+            "collector_report_schema_version": COLLECTOR_REPORT_SCHEMA,
+            "source_mode": "fixture",
+            "evidence_class": "pipeline_test_evidence",
+            "evidence_class_version": "1.0",
+            "produced_by": "test",
+            "collector_report_produced_at_utc": ts,
+        },
+        "status": {
+            "overall_status": "ok",
+            "gap_counts": {"blocking": 0, "warning": 0, "info": 0},
+            "has_zero_paper_chains": False,
+            "raw_evidence": {
+                "candle_input_count": 1,
+                "regime_input_count": 1,
+                "paper_chain_input_count": 1,
+                "provenance_input_count": 1,
+                "observed_input_count": 4,
+            },
+        },
+        "coverage": {
+            "candles": {
+                "status": "ok",
+                "total_streams": 1,
+                "observed_count_total": 100,
+                "expected_count_total": 100,
+                "coverage_pct": 1.0,
+                "stale_stream_count": 0,
+                "status_counts": {"blocking": 0, "warning": 0, "info": 1},
+                "items": [],
+            },
+            "regimes": {
+                "status": "ok",
+                "total_streams": 1,
+                "observed_count_total": 100,
+                "expected_count_total": 100,
+                "coverage_pct": 1.0,
+                "zero_coverage_stream_count": 0,
+                "status_counts": {"blocking": 0, "warning": 0, "info": 1},
+                "items": [],
+            },
+        },
+        "provenance": {
+            "status": "ok",
+            "allowed_sources": ["mexc"],
+            "unknown_source_count": 0,
+            "contaminated_source_count": 0,
+            "source_findings": [],
+        },
+        "paper_chains": {
+            "status": "ok",
+            "total_streams": 1,
+            "signal_count_total": 10,
+            "decision_count_total": 5,
+            "order_count_total": 3,
+            "fill_count_total": 3,
+            "complete_chain_count_total": 3,
+            "partial_chain_count_total": 0,
+            "zero_complete_stream_count": 0,
+            "zero_signal_stream_count": 0,
+            "average_signal_density_per_hour": 0.5,
+            "status_counts": {"blocking": 0, "warning": 0, "info": 1},
+            "items": [],
+        },
+        "gap_findings": {
+            "summary": {
+                "total_count": 0,
+                "blocking_count": 0,
+                "warning_count": 0,
+                "info_count": 0,
+                "by_type": {},
+            },
+            "items": [],
+        },
+        "safety": {
+            "banner": SAFETY_BANNER,
+            "lr_status": "NO-GO",
+            "live_status": "NO-GO",
+            "echtgeld_status": "NO-GO",
+            "runtime_actions": "not_allowed",
+            "db_execution": "not_allowed",
+            "background_job_orchestration": "not_in_scope",
+            "allowed_scope": "fixture/mock-based collector report snapshot generation only",
+        },
+        "next_action_hints": [],
+    }
+    if overrides:
+        _deep_merge(payload, overrides)
+    return payload
+
+
+def _alert_payload(ts: str, overrides: dict | None = None) -> dict:
+    payload = {
+        "schema_version": EXPECTED_ALERT_SCHEMA,
+        "evaluated_at_utc": ts,
+        "snapshot_generated_at_utc": ts,
+        "collector_report_id": "harv-test123",
+        "collector_report_hash": (
+            "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+        ),
+        "snapshot_age_minutes": 1,
+        "summary": {
+            "highest_severity": "info",
+            "total_count": 0,
+            "critical_count": 0,
+            "warn_count": 0,
+            "info_count": 0,
+            "manual_escalation_recommended": False,
+        },
+        "findings": [],
+        "manual_escalation_only": True,
+    }
+    if overrides:
+        _deep_merge(payload, overrides)
+    return payload
+
+
+def _collector_payload(ts: str) -> dict:
+    return {
+        "schema_version": COLLECTOR_REPORT_SCHEMA,
+        "collector_report_id": "harv-test123",
+        "generated_at_utc": ts,
+        "source_mode": "fixture",
+    }
+
+
+def _watchdog_payload(ts: str, verdict: str = "PASS") -> dict:
+    return {
+        "schema_version": WATCHDOG_REPORT_SCHEMA,
+        "evaluated_at_utc": ts,
+        "artifact_dir": "test",
+        "mode": "status",
+        "heartbeat_fresh": verdict != "FAIL",
+        "runner_state_ok": verdict != "FAIL",
+        "required_artifacts_present": True,
+        "verdict": {
+            "verdict": verdict,
+            "total_checks": 10,
+            "pass_count": 10 if verdict == "PASS" else 8,
+            "warn_count": 0 if verdict == "PASS" else 2,
+            "fail_count": 1 if verdict == "FAIL" else 0,
+        },
+        "findings": [],
+    }
+
+
+def _write_audit_payload(ts: str, verdict: str = "PASS") -> dict:
+    return {
+        "schema_version": WRITE_AUDIT_REPORT_SCHEMA,
+        "evaluated_at_utc": ts,
+        "artifact_dir": "test",
+        "required_artifacts_present": True,
+        "all_json_parse": True,
+        "schema_versions_match": True,
+        "hash_linkage_valid": True,
+        "safety_flags_correct": True,
+        "timestamps_coherent": True,
+        "source_modes_valid": True,
+        "sizes_sane": True,
+        "verdict": {
+            "verdict": verdict,
+            "total_checks": 10,
+            "pass_count": 10 if verdict == "PASS" else 8,
+            "warn_count": 0 if verdict == "PASS" else 2,
+            "fail_count": 1 if verdict == "FAIL" else 0,
+        },
+        "findings": [],
+    }
+
+
+def _boot_payload(ts: str, verdict: str = "PASS") -> dict:
+    return {
+        "schema_version": BOOT_READINESS_SCHEMA,
+        "evaluated_at_utc": ts,
+        "mode": "status",
+        "repo_root_valid": True,
+        "harvester_modules_importable": True,
+        "artifact_dirs_available": True,
+        "scheduler_script_present": True,
+        "command_plan_available": True,
+        "docker_available": False,
+        "safety_boundaries_ok": True,
+        "verdict": {
+            "verdict": verdict,
+            "total_checks": 8,
+            "pass_count": 8 if verdict == "PASS" else 7,
+            "warn_count": 0 if verdict == "PASS" else 1,
+            "fail_count": 1 if verdict == "FAIL" else 0,
+        },
+        "findings": [],
+    }
+
+
+def _heartbeat_payload(started_at: str, current_ts: str, iteration: int) -> dict:
+    return {
+        "schema_version": HEARTBEAT_SCHEMA,
+        "runner_mode": "loop-fixture",
+        "iteration": iteration,
+        "started_at_utc": started_at,
+        "current_run_at_utc": current_ts,
+        "last_success_at_utc": current_ts,
+        "last_failure_at_utc": "",
+        "last_error": "",
+        "last_collector_report": "collector_report_test.json",
+        "last_snapshot_json": "snapshot_test.json",
+        "last_snapshot_markdown": "snapshot_test.md",
+        "last_alert_json": "alert_test.json",
+        "last_alert_markdown": "alert_test.md",
+    }
+
+
+def _state_payload(current_ts: str, runs: int, verdict: str = "PASS") -> dict:
+    return {
+        "schema_version": STATE_SCHEMA,
+        "total_runs": runs,
+        "successful_runs": runs if verdict == "PASS" else max(0, runs - 1),
+        "failed_runs": 0 if verdict == "PASS" else 1,
+        "last_cycle_verdict": verdict,
+        "last_cycle_ended_at_utc": current_ts,
+    }
+
+
+def _stamp(ts: datetime) -> str:
+    return ts.strftime("%Y%m%dT%H%M%SZ")
+
+
+def _ts(ts: datetime) -> str:
+    return ts.isoformat().replace("+00:00", "Z")
+
+
+def _write_valid_run(
+    artifact_dir: Path,
+    *,
+    start: datetime,
+    hours: int,
+    cadence_seconds: int,
+    boot_verdict: str = "PASS",
+    watchdog_verdict: str = "PASS",
+    write_audit_verdict: str = "PASS",
+    snapshot_overrides: dict | None = None,
+) -> None:
+    times: list[datetime] = []
+    current = start
+    end = start + timedelta(hours=hours)
+    while current <= end:
+        times.append(current)
+        current += timedelta(seconds=cadence_seconds)
+    for ts in times:
+        stamp = _stamp(ts)
+        iso = _ts(ts)
+        _write_json(
+            artifact_dir / f"collector_report_{stamp}.json", _collector_payload(iso)
+        )
+        _write_json(
+            artifact_dir / f"snapshot_{stamp}.json",
+            _snapshot_payload(iso, snapshot_overrides),
+        )
+        _write_text(artifact_dir / f"snapshot_{stamp}.md")
+        _write_json(artifact_dir / f"alert_{stamp}.json", _alert_payload(iso))
+        _write_text(artifact_dir / f"alert_{stamp}.md")
+        _write_json(
+            artifact_dir / f"watchdog_report_{stamp}.json",
+            _watchdog_payload(iso, watchdog_verdict),
+        )
+        _write_text(artifact_dir / f"watchdog_report_{stamp}.md")
+        _write_json(
+            artifact_dir / f"write_audit_report_{stamp}.json",
+            _write_audit_payload(iso, write_audit_verdict),
+        )
+        _write_text(artifact_dir / f"write_audit_report_{stamp}.md")
+
+    final_ts = _ts(times[-1])
+    _write_json(
+        artifact_dir / "runner_heartbeat.json",
+        _heartbeat_payload(_ts(times[0]), final_ts, len(times)),
+    )
+    _write_json(
+        artifact_dir / "runner_state.json",
+        _state_payload(final_ts, len(times), "PASS"),
+    )
+    _write_json(
+        artifact_dir / "boot_readiness_report.json",
+        _boot_payload(final_ts, boot_verdict),
+    )
+    _write_text(artifact_dir / "boot_readiness_report.md")
+
+
+class TestValidate72hWindowFromDir:
+    @pytest.mark.unit
+    def test_pass_with_valid_artifacts(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert report.summary.verdict == "PASS"
+        assert report.required_window_hours == 2
+        assert report.observed_counts["watchdog_json"] == 3
+
+    @pytest.mark.unit
+    def test_fail_on_short_window(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=1, cadence_seconds=3600)
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert report.summary.verdict == "FAIL"
+        assert any("shorter than required 2h" in f.message for f in report.findings)
+
+    @pytest.mark.unit
+    def test_fail_on_missing_heartbeat(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        (tmp_path / "runner_heartbeat.json").unlink()
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert report.summary.verdict == "FAIL"
+        assert any("runner_heartbeat.json" in f.message for f in report.findings)
+
+    @pytest.mark.unit
+    def test_fail_on_watchdog_fail(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(
+            tmp_path,
+            start=start,
+            hours=2,
+            cadence_seconds=3600,
+            watchdog_verdict="FAIL",
+        )
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert report.summary.verdict == "FAIL"
+        assert any("Watchdog report is FAIL" in f.message for f in report.findings)
+
+    @pytest.mark.unit
+    def test_fail_on_write_audit_fail(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(
+            tmp_path,
+            start=start,
+            hours=2,
+            cadence_seconds=3600,
+            write_audit_verdict="FAIL",
+        )
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert report.summary.verdict == "FAIL"
+        assert any("Write-audit report is FAIL" in f.message for f in report.findings)
+
+    @pytest.mark.unit
+    def test_warn_on_boot_warn(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(
+            tmp_path,
+            start=start,
+            hours=2,
+            cadence_seconds=3600,
+            boot_verdict="WARN",
+        )
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert report.summary.verdict == "WARN"
+        assert any(
+            "Boot readiness report is WARN" in f.message for f in report.findings
+        )
+
+    @pytest.mark.unit
+    def test_fail_on_forbidden_content(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(
+            tmp_path,
+            start=start,
+            hours=2,
+            cadence_seconds=3600,
+            snapshot_overrides={
+                "metadata": {"collector_report_id": "trade_executed_ref"}
+            },
+        )
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert report.summary.verdict == "FAIL"
+        assert any("trade_executed" in f.message for f in report.findings)
+
+    @pytest.mark.unit
+    def test_warn_on_minor_cadence_drift(self, tmp_path: Path) -> None:
+        t0 = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        times = [t0, t0 + timedelta(minutes=70), t0 + timedelta(hours=2)]
+        for ts in times:
+            stamp = _stamp(ts)
+            iso = _ts(ts)
+            _write_json(
+                tmp_path / f"collector_report_{stamp}.json", _collector_payload(iso)
+            )
+            _write_json(tmp_path / f"snapshot_{stamp}.json", _snapshot_payload(iso))
+            _write_text(tmp_path / f"snapshot_{stamp}.md")
+            _write_json(tmp_path / f"alert_{stamp}.json", _alert_payload(iso))
+            _write_text(tmp_path / f"alert_{stamp}.md")
+            _write_json(
+                tmp_path / f"watchdog_report_{stamp}.json", _watchdog_payload(iso)
+            )
+            _write_text(tmp_path / f"watchdog_report_{stamp}.md")
+            _write_json(
+                tmp_path / f"write_audit_report_{stamp}.json", _write_audit_payload(iso)
+            )
+            _write_text(tmp_path / f"write_audit_report_{stamp}.md")
+        final_ts = _ts(times[-1])
+        _write_json(
+            tmp_path / "runner_heartbeat.json",
+            _heartbeat_payload(_ts(times[0]), final_ts, len(times)),
+        )
+        _write_json(
+            tmp_path / "runner_state.json", _state_payload(final_ts, len(times))
+        )
+        _write_json(tmp_path / "boot_readiness_report.json", _boot_payload(final_ts))
+        _write_text(tmp_path / "boot_readiness_report.md")
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert report.summary.verdict == "WARN"
+        assert any("warn threshold" in f.message for f in report.findings)
+
+    @pytest.mark.unit
+    def test_fail_on_large_cadence_gap(self, tmp_path: Path) -> None:
+        t0 = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        times = [t0, t0 + timedelta(hours=2, minutes=10), t0 + timedelta(hours=4)]
+        for ts in times:
+            stamp = _stamp(ts)
+            iso = _ts(ts)
+            _write_json(
+                tmp_path / f"collector_report_{stamp}.json", _collector_payload(iso)
+            )
+            _write_json(tmp_path / f"snapshot_{stamp}.json", _snapshot_payload(iso))
+            _write_text(tmp_path / f"snapshot_{stamp}.md")
+            _write_json(tmp_path / f"alert_{stamp}.json", _alert_payload(iso))
+            _write_text(tmp_path / f"alert_{stamp}.md")
+            _write_json(
+                tmp_path / f"watchdog_report_{stamp}.json", _watchdog_payload(iso)
+            )
+            _write_text(tmp_path / f"watchdog_report_{stamp}.md")
+            _write_json(
+                tmp_path / f"write_audit_report_{stamp}.json", _write_audit_payload(iso)
+            )
+            _write_text(tmp_path / f"write_audit_report_{stamp}.md")
+        final_ts = _ts(times[-1])
+        _write_json(
+            tmp_path / "runner_heartbeat.json",
+            _heartbeat_payload(_ts(times[0]), final_ts, len(times)),
+        )
+        _write_json(
+            tmp_path / "runner_state.json", _state_payload(final_ts, len(times))
+        )
+        _write_json(tmp_path / "boot_readiness_report.json", _boot_payload(final_ts))
+        _write_text(tmp_path / "boot_readiness_report.md")
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=4,
+            runner_cadence_seconds=3600,
+        )
+        assert report.summary.verdict == "FAIL"
+        assert any("fail threshold" in f.message for f in report.findings)
+
+    @pytest.mark.unit
+    def test_fail_on_nonexistent_dir(self, tmp_path: Path) -> None:
+        with pytest.raises(OpsValidationError, match="does not exist"):
+            validate_72h_window_from_dir(tmp_path / "missing")
+
+
+class TestMarkdownAndCli:
+    @pytest.mark.unit
+    def test_report_to_markdown_includes_runtime_handoff(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        markdown = report_to_markdown(report)
+        assert "72h Ops Validation Report" in markdown
+        assert "Runtime Handoff" in markdown
+        assert "boot_readiness_report.json" in markdown
+        assert "No LR-Go" in markdown
+
+    @pytest.mark.unit
+    def test_schema_version_constant(self) -> None:
+        assert (
+            OPS_VALIDATION_SCHEMA_VERSION == "cdb.evidence_harvester.ops_validation.v1"
+        )
+        assert DEFAULT_REQUIRED_WINDOW_HOURS == 72
+        assert isinstance(RuntimeHandoff, type)
+
+    @pytest.mark.unit
+    def test_parse_args_help(self) -> None:
+        from tools.evidence_harvester.ops_validation import parse_args
+
+        with pytest.raises(SystemExit):
+            parse_args(["--help"])
+
+    @pytest.mark.unit
+    def test_parse_args_missing_artifact_dir(self) -> None:
+        from tools.evidence_harvester.ops_validation import parse_args
+
+        with pytest.raises(SystemExit):
+            parse_args(["validate-dir"])

--- a/tests/unit/tools/evidence_harvester/test_runner.py
+++ b/tests/unit/tools/evidence_harvester/test_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import time
 from pathlib import Path
 
@@ -95,6 +96,36 @@ def test_plan_command_accepts_optional_fixture(
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["fixture"] == str(fixture_path)
+
+
+@pytest.mark.unit
+def test_main_uses_sys_argv_when_none(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = _write_fixture(tmp_path)
+    output_dir = tmp_path / "artifacts"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "runner",
+            "run-once-fixture",
+            "--fixture",
+            str(fixture_path),
+            "--output-dir",
+            str(output_dir),
+            "--generated-at-utc",
+            "2026-06-19T16:00:00Z",
+        ],
+    )
+
+    exit_code = main()
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "run-once-fixture"
 
 
 @pytest.mark.unit

--- a/tests/unit/tools/evidence_harvester/test_scheduler.py
+++ b/tests/unit/tools/evidence_harvester/test_scheduler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -77,6 +78,27 @@ def test_scheduler_defaults_to_safe_plan(capsys: pytest.CaptureFixture[str]) -> 
     assert payload["mode"] == "plan"
     assert payload["default_mode"] == "dry-run"
     assert payload["scheduled_action"] == "run-once-fixture"
+
+
+@pytest.mark.unit
+def test_scheduler_main_uses_sys_argv_when_none(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = _write_fixture(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["scheduler", "plan", "--fixture", str(fixture_path)],
+    )
+
+    exit_code = main()
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "plan"
+    assert payload["fixture"] == str(fixture_path)
 
 
 @pytest.mark.unit

--- a/tests/unit/tools/evidence_harvester/test_watchdog.py
+++ b/tests/unit/tools/evidence_harvester/test_watchdog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -309,6 +310,26 @@ def test_status_pass_with_fresh_artifacts(tmp_path: Path) -> None:
     assert report.runner_state_ok is True
     assert report.required_artifacts_present is True
     assert report.verdict.fail_count == 0
+
+
+@pytest.mark.unit
+def test_watchdog_main_uses_sys_argv_when_none(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact_dir = _write_artifact_dir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["watchdog", "check-artifacts", "--artifact-dir", str(artifact_dir)],
+    )
+
+    exit_code = main()
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "check-artifacts"
 
 
 @pytest.mark.unit

--- a/tools/evidence_harvester/README.md
+++ b/tools/evidence_harvester/README.md
@@ -410,6 +410,59 @@ python -m tools.evidence_harvester.validation validate-dir `
 The module is read-only, does not start any background process, and enforces
 the same safety boundaries as the rest of the harvester.
 
+## 72h Ops Validation (#3362)
+
+The `ops_validation.py` module is the final validation surface for the real
+always-on `>=72h` dry run. It does not start the run. It validates one finished
+artifact directory and composes runner continuity, watchdog history,
+write-audit history, boot-readiness evidence, and safety boundaries into one
+deterministic PASS/WARN/FAIL verdict.
+
+### Usage
+
+```powershell
+python -m tools.evidence_harvester.ops_validation validate-dir `
+    --artifact-dir artifacts\evidence_harvester\72h_ops_validation\<run_id> `
+    --json-output artifacts\evidence_harvester\72h_ops_validation\<run_id>\ops_validation_report.json `
+    --markdown-output artifacts\evidence_harvester\72h_ops_validation\<run_id>\ops_validation_report.md `
+    --pretty
+```
+
+### Phase-2 runtime contract
+
+- seed fixture: `artifacts/evidence_harvester/24h_dry_run/collector_input.json`
+- artifact dir: `artifacts/evidence_harvester/72h_ops_validation/<run_id>/`
+- cadence: every `900` seconds
+- watchdog: after each runner cycle
+- write-audit: after each runner cycle
+- final validation: after `>=72h` over the whole artifact directory
+
+### Required phase-2 artifacts
+
+- `collector_report_<stamp>.json`
+- `snapshot_<stamp>.json`
+- `snapshot_<stamp>.md`
+- `alert_<stamp>.json`
+- `alert_<stamp>.md`
+- `runner_heartbeat.json`
+- `runner_state.json`
+- `watchdog_report_<stamp>.json`
+- `watchdog_report_<stamp>.md`
+- `write_audit_report_<stamp>.json`
+- `write_audit_report_<stamp>.md`
+- `boot_readiness_report.json`
+- `boot_readiness_report.md`
+- `ops_validation_report.json`
+- `ops_validation_report.md`
+
+### Safety boundaries
+
+- no actual 72h run in this PR
+- no Windows Task install in this PR
+- no Docker/runtime/DB/secrets mutation
+- no GitHub writes from module code
+- no LR-Go, no Live-Go, no Echtgeld-Go
+
 ## Boot Readiness ( #3360 )
 
 The `boot.py` module checks whether the evidence harvester is reboot- and

--- a/tools/evidence_harvester/__init__.py
+++ b/tools/evidence_harvester/__init__.py
@@ -9,6 +9,13 @@ from .validation import (
     validate_24h_window,
     validate_24h_window_from_dir,
 )
+from .ops_validation import (
+    OpsValidationError,
+    OpsValidationReport,
+    report_to_markdown as ops_validation_report_to_markdown,
+    validate_72h_window,
+    validate_72h_window_from_dir,
+)
 from .watchdog import (
     WatchdogError,
     WatchdogFinding,
@@ -35,6 +42,8 @@ __all__ = [
     "CollectorReport",
     "CollectorValidationError",
     "EvidenceHarvesterCollector",
+    "OpsValidationError",
+    "OpsValidationReport",
     "ValidationError",
     "ValidationReport",
     "WatchdogError",
@@ -48,12 +57,15 @@ __all__ = [
     "build_alert_report",
     "load_collector_input",
     "main",
+    "ops_validation_report_to_markdown",
     "run_check_artifacts",
     "run_status",
     "render_escalation_draft",
     "run_write_audit",
     "validate_24h_window",
     "validate_24h_window_from_dir",
+    "validate_72h_window",
+    "validate_72h_window_from_dir",
     "watchdog_report_to_markdown",
     "write_audit_report_to_markdown",
 ]

--- a/tools/evidence_harvester/ops_validation.py
+++ b/tools/evidence_harvester/ops_validation.py
@@ -1,0 +1,1389 @@
+from __future__ import annotations
+
+import json
+import math
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+from .alerts import ALERT_REPORT_SCHEMA_VERSION
+from .boot import BOOT_READINESS_SCHEMA
+from .runner import HEARTBEAT_SCHEMA, STATE_SCHEMA
+from .snapshot import SAFETY_BANNER, SNAPSHOT_SCHEMA_VERSION
+from .write_audit import COLLECTOR_REPORT_SCHEMA, WRITE_AUDIT_REPORT_SCHEMA
+from .watchdog import WATCHDOG_REPORT_SCHEMA
+
+OPS_VALIDATION_SCHEMA_VERSION = "cdb.evidence_harvester.ops_validation.v1"
+ALLOWED_SOURCE_MODES = {"fixture", "future_readonly"}
+
+DEFAULT_REQUIRED_WINDOW_HOURS = 72
+DEFAULT_RUNNER_CADENCE_SECONDS = 900
+DEFAULT_WARN_GRACE_SECONDS = 300
+DEFAULT_FAIL_MULTIPLIER = 2.0
+
+RUNTIME_ARTIFACT_DIR_TEMPLATE = (
+    "artifacts/evidence_harvester/72h_ops_validation/<run_id>/"
+)
+RUNTIME_SEED_FIXTURE = "artifacts/evidence_harvester/24h_dry_run/collector_input.json"
+
+REQUIRED_ARTIFACT_RULES: dict[str, str] = {
+    "collector_reports": "collector_report_*.json",
+    "snapshots_json": "snapshot_*.json",
+    "snapshots_md": "snapshot_*.md",
+    "alerts_json": "alert_*.json",
+    "alerts_md": "alert_*.md",
+    "heartbeat": "runner_heartbeat.json",
+    "state": "runner_state.json",
+    "watchdog_json": "watchdog_report_*.json",
+    "watchdog_md": "watchdog_report_*.md",
+    "write_audit_json": "write_audit_report_*.json",
+    "write_audit_md": "write_audit_report_*.md",
+    "boot_json": "boot_readiness_report*.json",
+    "boot_md": "boot_readiness_report*.md",
+}
+
+REQUIRED_RUNTIME_ARTIFACTS: tuple[str, ...] = (
+    "collector_report_<stamp>.json",
+    "snapshot_<stamp>.json",
+    "snapshot_<stamp>.md",
+    "alert_<stamp>.json",
+    "alert_<stamp>.md",
+    "runner_heartbeat.json",
+    "runner_state.json",
+    "watchdog_report_<stamp>.json",
+    "watchdog_report_<stamp>.md",
+    "write_audit_report_<stamp>.json",
+    "write_audit_report_<stamp>.md",
+    "boot_readiness_report.json",
+    "boot_readiness_report.md",
+    "ops_validation_report.json",
+    "ops_validation_report.md",
+)
+
+FORBIDDEN_PATTERNS: tuple[str, ...] = (
+    "LR-Go",
+    "Live-Go",
+    "Echtgeld-Go",
+    "trade_executed",
+    "order_submitted",
+    "position_opened",
+)
+
+
+class OpsValidationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class OpsValidationFinding:
+    check_id: str
+    check_name: str
+    severity: str
+    message: str
+    artifact: str = ""
+    field_name: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class OpsValidationSummary:
+    verdict: str
+    total_checks: int
+    pass_count: int
+    warn_count: int
+    fail_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeHandoff:
+    artifact_dir_template: str
+    seed_fixture: str
+    runner_cadence_seconds: int
+    required_window_hours: int
+    expected_min_cycles: int
+    watchdog_after_each_runner_cycle: bool
+    write_audit_after_each_runner_cycle: bool
+    required_artifacts: tuple[str, ...]
+    boot_preflight_commands: tuple[str, ...]
+    enable_commands: tuple[str, ...]
+    start_commands: tuple[str, ...]
+    stop_commands: tuple[str, ...]
+    side_effect_checklist: tuple[str, ...]
+    gordon_consultation_checkpoint: str
+    safety_statement: str
+    notes: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class OpsValidationReport:
+    schema_version: str
+    validated_at_utc: str
+    artifact_dir: str
+    window_start_utc: str
+    window_end_utc: str
+    observed_window_hours: float
+    required_window_hours: int
+    cadence_seconds: int
+    expected_min_cycles: int
+    observed_counts: dict[str, int]
+    findings: tuple[OpsValidationFinding, ...]
+    summary: OpsValidationSummary
+    runtime_handoff: RuntimeHandoff
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _now_utc() -> datetime:
+    return cdb_utcnow().astimezone(UTC)
+
+
+def _format_ts(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _parse_ts(value: Any, field_name: str) -> datetime:
+    if not isinstance(value, str):
+        raise OpsValidationError(f"{field_name} must be a string")
+    text = value.strip()
+    if not text:
+        raise OpsValidationError(f"{field_name} must not be blank")
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise OpsValidationError(
+            f"{field_name} must be an ISO-8601 UTC timestamp"
+        ) from exc
+    if parsed.tzinfo is None:
+        raise OpsValidationError(f"{field_name} must be timezone-aware UTC")
+    return parsed.astimezone(UTC)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise OpsValidationError(f"Malformed JSON in {path.name}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise OpsValidationError(f"{path.name} JSON root must be an object")
+    return payload
+
+
+def _collect_artifact_paths(artifact_dir: Path) -> dict[str, list[Path]]:
+    return {
+        "collector_reports": sorted(artifact_dir.glob("collector_report_*.json")),
+        "snapshots_json": sorted(artifact_dir.glob("snapshot_*.json")),
+        "snapshots_md": sorted(artifact_dir.glob("snapshot_*.md")),
+        "alerts_json": sorted(artifact_dir.glob("alert_*.json")),
+        "alerts_md": sorted(artifact_dir.glob("alert_*.md")),
+        "heartbeat": (
+            [artifact_dir / "runner_heartbeat.json"]
+            if (artifact_dir / "runner_heartbeat.json").exists()
+            else []
+        ),
+        "state": (
+            [artifact_dir / "runner_state.json"]
+            if (artifact_dir / "runner_state.json").exists()
+            else []
+        ),
+        "watchdog_json": sorted(artifact_dir.glob("watchdog_report_*.json")),
+        "watchdog_md": sorted(artifact_dir.glob("watchdog_report_*.md")),
+        "write_audit_json": sorted(artifact_dir.glob("write_audit_report_*.json")),
+        "write_audit_md": sorted(artifact_dir.glob("write_audit_report_*.md")),
+        "boot_json": sorted(artifact_dir.glob("boot_readiness_report*.json")),
+        "boot_md": sorted(artifact_dir.glob("boot_readiness_report*.md")),
+    }
+
+
+def _expected_min_cycles(required_window_hours: int, cadence_seconds: int) -> int:
+    return max(1, math.floor((required_window_hours * 3600) / cadence_seconds))
+
+
+def _build_runtime_handoff(
+    *, required_window_hours: int, cadence_seconds: int
+) -> RuntimeHandoff:
+    expected_cycles = _expected_min_cycles(required_window_hours, cadence_seconds)
+    bounded_iterations = expected_cycles + 1
+    run_dir = RUNTIME_ARTIFACT_DIR_TEMPLATE.rstrip("/")
+    return RuntimeHandoff(
+        artifact_dir_template=RUNTIME_ARTIFACT_DIR_TEMPLATE,
+        seed_fixture=RUNTIME_SEED_FIXTURE,
+        runner_cadence_seconds=cadence_seconds,
+        required_window_hours=required_window_hours,
+        expected_min_cycles=expected_cycles,
+        watchdog_after_each_runner_cycle=True,
+        write_audit_after_each_runner_cycle=True,
+        required_artifacts=REQUIRED_RUNTIME_ARTIFACTS,
+        boot_preflight_commands=(
+            "python -m tools.evidence_harvester.boot status --pretty",
+            (
+                "python -m tools.evidence_harvester.boot status "
+                f"--json-output {run_dir}\\boot_readiness_report.json "
+                f"--markdown-output {run_dir}\\boot_readiness_report.md --pretty"
+            ),
+        ),
+        enable_commands=(
+            "No Windows Task install in Phase 1.",
+            (
+                "Runtime-GO only if scheduling is required: "
+                "python -m tools.evidence_harvester.scheduler install --fixture "
+                f"{RUNTIME_SEED_FIXTURE} --explicit"
+            ),
+        ),
+        start_commands=(
+            (
+                "python -m tools.evidence_harvester.runner loop-fixture "
+                f"--fixture {RUNTIME_SEED_FIXTURE} "
+                f"--output-dir {run_dir} "
+                f"--iterations {bounded_iterations} "
+                f"--interval-seconds {cadence_seconds} --pretty"
+            ),
+            (
+                "After each runner cycle, write the latest watchdog report for "
+                "write-audit compatibility and archive a stamped copy: "
+                f"watchdog_report.json plus watchdog_report_<stamp>.json in {run_dir}"
+            ),
+            (
+                "After each runner cycle, archive write-audit outputs as "
+                f"write_audit_report_<stamp>.json/.md in {run_dir}"
+            ),
+        ),
+        stop_commands=(
+            "Stop the runner process after the bounded loop completes.",
+            (
+                "If scheduling was enabled under a separate Runtime-GO: "
+                "python -m tools.evidence_harvester.scheduler uninstall --explicit"
+            ),
+            (
+                "Run final validation: "
+                f"python -m tools.evidence_harvester.ops_validation validate-dir --artifact-dir {run_dir} --pretty"
+            ),
+        ),
+        side_effect_checklist=(
+            "No Docker start/stop or compose mutation unless Gordon explicitly approves it.",
+            "No runtime, DB, Redis, secrets, or GitHub write action from module code.",
+            "No LR-Go, no Live-Go, no Echtgeld-Go.",
+            "No trading, order, risk, or execution mutation.",
+        ),
+        gordon_consultation_checkpoint=(
+            "Before any Docker or infrastructure mutation, stop and obtain a separate "
+            "documented Gordon operator GO."
+        ),
+        safety_statement=(
+            "Dry/paper/research only. LR remains NO-GO. No Live-Go. No Echtgeld-Go."
+        ),
+        notes=(
+            "The 72h validation depends on per-cycle stamped watchdog and write-audit archives.",
+            "Keep latest watchdog_report.json/.md current as a compatibility surface for write_audit.py.",
+        ),
+    )
+
+
+def _check_required_artifacts(
+    artifact_paths: Mapping[str, Sequence[Path]],
+    add_finding: Any,
+) -> None:
+    for key, pattern in REQUIRED_ARTIFACT_RULES.items():
+        paths = list(artifact_paths.get(key, []))
+        if not paths:
+            add_finding(
+                "Required artifact present",
+                "fail",
+                f"Missing required artifact matching {pattern}",
+                artifact=pattern,
+            )
+        else:
+            add_finding(
+                "Required artifact present",
+                "pass",
+                f"Found {len(paths)} artifact(s) matching {pattern}",
+                artifact=pattern,
+            )
+
+
+def _check_matching_counts(
+    label: str,
+    left_paths: Sequence[Path],
+    right_paths: Sequence[Path],
+    add_finding: Any,
+) -> None:
+    if len(left_paths) != len(right_paths):
+        add_finding(
+            f"{label} companion counts",
+            "fail",
+            f"Expected matching counts, got {len(left_paths)} and {len(right_paths)}",
+        )
+    else:
+        add_finding(
+            f"{label} companion counts",
+            "pass",
+            f"Matching counts: {len(left_paths)} and {len(right_paths)}",
+        )
+
+
+def _load_payloads(
+    paths: Sequence[Path],
+    add_finding: Any,
+    *,
+    expected_schema: str | None = None,
+    schema_field: str = "schema_version",
+) -> list[tuple[Path, dict[str, Any]]]:
+    results: list[tuple[Path, dict[str, Any]]] = []
+    for path in paths:
+        try:
+            payload = _load_json(path)
+            results.append((path, payload))
+            add_finding(
+                f"{path.name} parses as JSON",
+                "pass",
+                f"Valid JSON ({len(json.dumps(payload, ensure_ascii=True))} bytes)",
+                artifact=path.name,
+            )
+            if expected_schema is not None:
+                actual = payload
+                for part in schema_field.split("."):
+                    actual = actual.get(part) if isinstance(actual, dict) else None
+                if actual != expected_schema:
+                    add_finding(
+                        f"{path.name} schema version",
+                        "fail",
+                        f"Expected {schema_field}={expected_schema!r}, got {actual!r}",
+                        artifact=path.name,
+                        field_name=schema_field,
+                    )
+                else:
+                    add_finding(
+                        f"{path.name} schema version",
+                        "pass",
+                        f"{schema_field} matches {expected_schema}",
+                        artifact=path.name,
+                        field_name=schema_field,
+                    )
+        except OpsValidationError as exc:
+            add_finding(
+                f"{path.name} parses as JSON",
+                "fail",
+                str(exc),
+                artifact=path.name,
+            )
+    return results
+
+
+def _check_snapshot_payload(
+    path: Path,
+    payload: Mapping[str, Any],
+    add_finding: Any,
+) -> datetime | None:
+    metadata = payload.get("metadata", {})
+    if not isinstance(metadata, dict):
+        add_finding(
+            f"{path.name} metadata present",
+            "fail",
+            "metadata must be an object",
+            artifact=path.name,
+            field_name="metadata",
+        )
+        return None
+    source_mode = metadata.get("source_mode", "")
+    if source_mode not in ALLOWED_SOURCE_MODES:
+        add_finding(
+            f"{path.name} safe source_mode",
+            "fail",
+            f"metadata.source_mode={source_mode!r} not in allowed set",
+            artifact=path.name,
+            field_name="metadata.source_mode",
+        )
+    else:
+        add_finding(
+            f"{path.name} safe source_mode",
+            "pass",
+            f"metadata.source_mode={source_mode!r} is allowed",
+            artifact=path.name,
+            field_name="metadata.source_mode",
+        )
+    safety = payload.get("safety", {})
+    if not isinstance(safety, dict):
+        add_finding(
+            f"{path.name} safety present",
+            "fail",
+            "safety must be an object",
+            artifact=path.name,
+            field_name="safety",
+        )
+        return None
+    expected_flags = {
+        "lr_status": "NO-GO",
+        "live_status": "NO-GO",
+        "echtgeld_status": "NO-GO",
+        "runtime_actions": "not_allowed",
+        "db_execution": "not_allowed",
+    }
+    for field_name, expected in expected_flags.items():
+        actual = safety.get(field_name)
+        if actual != expected:
+            add_finding(
+                f"{path.name} safety flag {field_name}",
+                "fail",
+                f"Expected {field_name}={expected!r}, got {actual!r}",
+                artifact=path.name,
+                field_name=f"safety.{field_name}",
+            )
+        else:
+            add_finding(
+                f"{path.name} safety flag {field_name}",
+                "pass",
+                f"{field_name} is {expected!r}",
+                artifact=path.name,
+                field_name=f"safety.{field_name}",
+            )
+    banner = str(safety.get("banner", ""))
+    if SAFETY_BANNER not in banner:
+        add_finding(
+            f"{path.name} safety banner",
+            "fail",
+            "Safety banner does not match expected text",
+            artifact=path.name,
+            field_name="safety.banner",
+        )
+    else:
+        add_finding(
+            f"{path.name} safety banner",
+            "pass",
+            "Safety banner matches expected text",
+            artifact=path.name,
+            field_name="safety.banner",
+        )
+    try:
+        return _parse_ts(
+            metadata.get("generated_at_utc", ""), "metadata.generated_at_utc"
+        )
+    except OpsValidationError as exc:
+        add_finding(
+            f"{path.name} generated_at_utc",
+            "fail",
+            str(exc),
+            artifact=path.name,
+            field_name="metadata.generated_at_utc",
+        )
+        return None
+
+
+def _check_alert_payload(
+    path: Path,
+    payload: Mapping[str, Any],
+    add_finding: Any,
+) -> datetime | None:
+    manual_only = payload.get("manual_escalation_only", True)
+    if manual_only is not True:
+        add_finding(
+            f"{path.name} manual escalation only",
+            "fail",
+            "manual_escalation_only must remain true",
+            artifact=path.name,
+            field_name="manual_escalation_only",
+        )
+    else:
+        add_finding(
+            f"{path.name} manual escalation only",
+            "pass",
+            "manual_escalation_only is true",
+            artifact=path.name,
+            field_name="manual_escalation_only",
+        )
+    try:
+        return _parse_ts(payload.get("evaluated_at_utc", ""), "evaluated_at_utc")
+    except OpsValidationError as exc:
+        add_finding(
+            f"{path.name} evaluated_at_utc",
+            "fail",
+            str(exc),
+            artifact=path.name,
+            field_name="evaluated_at_utc",
+        )
+        return None
+
+
+def _check_boot_payload(
+    path: Path,
+    payload: Mapping[str, Any],
+    add_finding: Any,
+) -> datetime | None:
+    try:
+        ts = _parse_ts(payload.get("evaluated_at_utc", ""), "evaluated_at_utc")
+    except OpsValidationError as exc:
+        add_finding(
+            f"{path.name} evaluated_at_utc",
+            "fail",
+            str(exc),
+            artifact=path.name,
+            field_name="evaluated_at_utc",
+        )
+        return None
+    verdict = payload.get("verdict", {})
+    verdict_value = verdict.get("verdict") if isinstance(verdict, dict) else None
+    if verdict_value == "FAIL":
+        add_finding(
+            f"{path.name} boot readiness verdict",
+            "fail",
+            "Boot readiness report is FAIL",
+            artifact=path.name,
+            field_name="verdict.verdict",
+        )
+    elif verdict_value == "WARN":
+        add_finding(
+            f"{path.name} boot readiness verdict",
+            "warn",
+            "Boot readiness report is WARN; runtime handoff must justify it",
+            artifact=path.name,
+            field_name="verdict.verdict",
+        )
+    elif verdict_value == "PASS":
+        add_finding(
+            f"{path.name} boot readiness verdict",
+            "pass",
+            "Boot readiness report is PASS",
+            artifact=path.name,
+            field_name="verdict.verdict",
+        )
+    else:
+        add_finding(
+            f"{path.name} boot readiness verdict",
+            "fail",
+            f"Unexpected boot readiness verdict {verdict_value!r}",
+            artifact=path.name,
+            field_name="verdict.verdict",
+        )
+    return ts
+
+
+def _check_verdict_series(
+    label: str,
+    payloads: Sequence[tuple[Path, Mapping[str, Any]]],
+    add_finding: Any,
+) -> list[datetime]:
+    timestamps: list[datetime] = []
+    worst: str = "PASS"
+    for path, payload in payloads:
+        try:
+            ts = _parse_ts(payload.get("evaluated_at_utc", ""), "evaluated_at_utc")
+            timestamps.append(ts)
+        except OpsValidationError as exc:
+            add_finding(
+                f"{path.name} evaluated_at_utc",
+                "fail",
+                str(exc),
+                artifact=path.name,
+                field_name="evaluated_at_utc",
+            )
+        verdict = payload.get("verdict", {})
+        verdict_value = verdict.get("verdict") if isinstance(verdict, dict) else None
+        if verdict_value == "FAIL":
+            worst = "FAIL"
+            add_finding(
+                f"{path.name} {label} verdict",
+                "fail",
+                f"{label} report is FAIL",
+                artifact=path.name,
+                field_name="verdict.verdict",
+            )
+        elif verdict_value == "WARN":
+            if worst != "FAIL":
+                worst = "WARN"
+            add_finding(
+                f"{path.name} {label} verdict",
+                "warn",
+                f"{label} report is WARN",
+                artifact=path.name,
+                field_name="verdict.verdict",
+            )
+        elif verdict_value == "PASS":
+            add_finding(
+                f"{path.name} {label} verdict",
+                "pass",
+                f"{label} report is PASS",
+                artifact=path.name,
+                field_name="verdict.verdict",
+            )
+        else:
+            worst = "FAIL"
+            add_finding(
+                f"{path.name} {label} verdict",
+                "fail",
+                f"Unexpected {label} verdict {verdict_value!r}",
+                artifact=path.name,
+                field_name="verdict.verdict",
+            )
+    if payloads:
+        if worst == "PASS":
+            add_finding(
+                f"{label} verdict history",
+                "pass",
+                f"All {label.lower()} reports are PASS",
+            )
+        elif worst == "WARN":
+            add_finding(
+                f"{label} verdict history",
+                "warn",
+                f"At least one {label.lower()} report is WARN, none are FAIL",
+            )
+        else:
+            add_finding(
+                f"{label} verdict history",
+                "fail",
+                f"At least one {label.lower()} report is FAIL",
+            )
+    return timestamps
+
+
+def _check_runner_state(
+    heartbeat_payload: Mapping[str, Any] | None,
+    state_payload: Mapping[str, Any] | None,
+    latest_snapshot_ts: datetime | None,
+    *,
+    expected_min_cycles: int,
+    cadence_seconds: int,
+    add_finding: Any,
+) -> None:
+    if heartbeat_payload is None or state_payload is None:
+        return
+    iteration = heartbeat_payload.get("iteration")
+    if not isinstance(iteration, int) or iteration < expected_min_cycles:
+        add_finding(
+            "Runner heartbeat iteration count",
+            "fail",
+            f"Expected iteration >= {expected_min_cycles}, got {iteration!r}",
+            artifact="runner_heartbeat.json",
+            field_name="iteration",
+        )
+    else:
+        add_finding(
+            "Runner heartbeat iteration count",
+            "pass",
+            f"iteration={iteration} covers the expected minimum cycles",
+            artifact="runner_heartbeat.json",
+            field_name="iteration",
+        )
+    total_runs = state_payload.get("total_runs")
+    successful_runs = state_payload.get("successful_runs")
+    failed_runs = state_payload.get("failed_runs")
+    if not isinstance(total_runs, int) or total_runs < expected_min_cycles:
+        add_finding(
+            "Runner total runs",
+            "fail",
+            f"Expected total_runs >= {expected_min_cycles}, got {total_runs!r}",
+            artifact="runner_state.json",
+            field_name="total_runs",
+        )
+    else:
+        add_finding(
+            "Runner total runs",
+            "pass",
+            f"total_runs={total_runs} covers the expected minimum cycles",
+            artifact="runner_state.json",
+            field_name="total_runs",
+        )
+    if not isinstance(successful_runs, int) or successful_runs < expected_min_cycles:
+        add_finding(
+            "Runner successful runs",
+            "fail",
+            (
+                f"Expected successful_runs >= {expected_min_cycles}, got "
+                f"{successful_runs!r}"
+            ),
+            artifact="runner_state.json",
+            field_name="successful_runs",
+        )
+    else:
+        add_finding(
+            "Runner successful runs",
+            "pass",
+            f"successful_runs={successful_runs} covers the expected minimum cycles",
+            artifact="runner_state.json",
+            field_name="successful_runs",
+        )
+    if failed_runs != 0:
+        add_finding(
+            "Runner failed runs",
+            "fail",
+            f"Expected failed_runs=0, got {failed_runs!r}",
+            artifact="runner_state.json",
+            field_name="failed_runs",
+        )
+    else:
+        add_finding(
+            "Runner failed runs",
+            "pass",
+            "failed_runs=0",
+            artifact="runner_state.json",
+            field_name="failed_runs",
+        )
+    last_cycle_verdict = state_payload.get("last_cycle_verdict")
+    if last_cycle_verdict != "PASS":
+        add_finding(
+            "Runner last cycle verdict",
+            "fail",
+            f"Expected last_cycle_verdict='PASS', got {last_cycle_verdict!r}",
+            artifact="runner_state.json",
+            field_name="last_cycle_verdict",
+        )
+    else:
+        add_finding(
+            "Runner last cycle verdict",
+            "pass",
+            "last_cycle_verdict is PASS",
+            artifact="runner_state.json",
+            field_name="last_cycle_verdict",
+        )
+    if latest_snapshot_ts is not None:
+        try:
+            last_cycle_ended = _parse_ts(
+                state_payload.get("last_cycle_ended_at_utc", ""),
+                "last_cycle_ended_at_utc",
+            )
+            delta_seconds = abs((last_cycle_ended - latest_snapshot_ts).total_seconds())
+            if delta_seconds > cadence_seconds:
+                add_finding(
+                    "Runner state aligns with latest snapshot",
+                    "warn",
+                    (
+                        f"last_cycle_ended_at_utc differs from the latest snapshot by "
+                        f"{delta_seconds:.0f}s"
+                    ),
+                    artifact="runner_state.json",
+                    field_name="last_cycle_ended_at_utc",
+                )
+            else:
+                add_finding(
+                    "Runner state aligns with latest snapshot",
+                    "pass",
+                    "last_cycle_ended_at_utc aligns with the latest snapshot",
+                    artifact="runner_state.json",
+                    field_name="last_cycle_ended_at_utc",
+                )
+        except OpsValidationError as exc:
+            add_finding(
+                "Runner state last_cycle_ended_at_utc",
+                "fail",
+                str(exc),
+                artifact="runner_state.json",
+                field_name="last_cycle_ended_at_utc",
+            )
+
+
+def _check_count_floor(
+    label: str,
+    count: int,
+    expected_min_cycles: int,
+    add_finding: Any,
+) -> None:
+    if count < expected_min_cycles:
+        add_finding(
+            f"{label} count floor",
+            "fail",
+            f"Expected at least {expected_min_cycles} {label.lower()} artifacts, got {count}",
+        )
+    else:
+        add_finding(
+            f"{label} count floor",
+            "pass",
+            f"Observed {count} {label.lower()} artifacts, meets minimum {expected_min_cycles}",
+        )
+
+
+def _check_cadence_series(
+    label: str,
+    timestamps: Sequence[datetime],
+    cadence_seconds: int,
+    add_finding: Any,
+) -> None:
+    if len(timestamps) < 2:
+        add_finding(
+            f"{label} cadence continuity",
+            "fail",
+            f"Need at least 2 {label.lower()} timestamps to verify cadence continuity",
+        )
+        return
+    warn_gap = cadence_seconds + DEFAULT_WARN_GRACE_SECONDS
+    fail_gap = int(cadence_seconds * DEFAULT_FAIL_MULTIPLIER)
+    sorted_ts = sorted(timestamps)
+    worst = "pass"
+    worst_message = "All gaps are within cadence target"
+    for left, right in zip(sorted_ts, sorted_ts[1:]):
+        gap = (right - left).total_seconds()
+        if gap > fail_gap:
+            worst = "fail"
+            worst_message = f"Gap of {gap:.0f}s exceeds fail threshold {fail_gap}s for {label.lower()} cadence"
+            break
+        if gap > warn_gap and worst != "fail":
+            worst = "warn"
+            worst_message = f"Gap of {gap:.0f}s exceeds warn threshold {warn_gap}s for {label.lower()} cadence"
+    add_finding(
+        f"{label} cadence continuity",
+        worst,
+        worst_message,
+    )
+
+
+def _check_window_coverage(
+    snapshot_timestamps: Sequence[datetime],
+    required_window_hours: int,
+    add_finding: Any,
+) -> tuple[datetime | None, datetime | None, float]:
+    if not snapshot_timestamps:
+        add_finding(
+            "Snapshot window coverage",
+            "fail",
+            "No valid snapshot timestamps available for window coverage",
+        )
+        return None, None, 0.0
+    ordered = sorted(snapshot_timestamps)
+    observed_start = ordered[0]
+    observed_end = ordered[-1]
+    observed_window_hours = max(
+        0.0, (observed_end - observed_start).total_seconds() / 3600.0
+    )
+    if observed_window_hours < required_window_hours:
+        add_finding(
+            "Snapshot window coverage",
+            "fail",
+            (
+                f"Observed snapshot window {observed_window_hours:.2f}h is shorter than "
+                f"required {required_window_hours}h"
+            ),
+        )
+    else:
+        add_finding(
+            "Snapshot window coverage",
+            "pass",
+            (
+                f"Observed snapshot window {observed_window_hours:.2f}h covers the "
+                f"required {required_window_hours}h"
+            ),
+        )
+    return observed_start, observed_end, observed_window_hours
+
+
+def _check_no_side_effects(
+    path: Path,
+    payload: Mapping[str, Any],
+    add_finding: Any,
+) -> None:
+    scan_payload = {key: value for key, value in payload.items() if key != "safety"}
+    text = json.dumps(scan_payload, sort_keys=True, ensure_ascii=True)
+    for pattern in FORBIDDEN_PATTERNS:
+        if pattern in text:
+            add_finding(
+                f"{path.name} forbidden side-effect content",
+                "fail",
+                f"Found forbidden pattern {pattern!r} outside the safety section",
+                artifact=path.name,
+            )
+
+
+def validate_72h_window(
+    artifact_paths: Mapping[str, Sequence[Path]],
+    *,
+    artifact_dir: Path,
+    window_start_utc: datetime | None = None,
+    window_end_utc: datetime | None = None,
+    required_window_hours: int = DEFAULT_REQUIRED_WINDOW_HOURS,
+    runner_cadence_seconds: int = DEFAULT_RUNNER_CADENCE_SECONDS,
+) -> OpsValidationReport:
+    if required_window_hours < 1:
+        raise OpsValidationError("required_window_hours must be >= 1")
+    if runner_cadence_seconds < 1:
+        raise OpsValidationError("runner_cadence_seconds must be >= 1")
+    if window_start_utc and window_end_utc and window_end_utc <= window_start_utc:
+        raise OpsValidationError("window_end_utc must be after window_start_utc")
+
+    findings: list[OpsValidationFinding] = []
+    counter = 0
+
+    def add_finding(
+        check_name: str,
+        severity: str,
+        message: str,
+        *,
+        artifact: str = "",
+        field_name: str = "",
+    ) -> None:
+        nonlocal counter
+        counter += 1
+        findings.append(
+            OpsValidationFinding(
+                check_id=f"O{counter:03d}",
+                check_name=check_name,
+                severity=severity,
+                message=message,
+                artifact=artifact,
+                field_name=field_name,
+            )
+        )
+
+    _check_required_artifacts(artifact_paths, add_finding)
+    _check_matching_counts(
+        "Snapshot",
+        artifact_paths.get("snapshots_json", []),
+        artifact_paths.get("snapshots_md", []),
+        add_finding,
+    )
+    _check_matching_counts(
+        "Alert",
+        artifact_paths.get("alerts_json", []),
+        artifact_paths.get("alerts_md", []),
+        add_finding,
+    )
+    _check_matching_counts(
+        "Watchdog",
+        artifact_paths.get("watchdog_json", []),
+        artifact_paths.get("watchdog_md", []),
+        add_finding,
+    )
+    _check_matching_counts(
+        "Write-audit",
+        artifact_paths.get("write_audit_json", []),
+        artifact_paths.get("write_audit_md", []),
+        add_finding,
+    )
+    _check_matching_counts(
+        "Boot readiness",
+        artifact_paths.get("boot_json", []),
+        artifact_paths.get("boot_md", []),
+        add_finding,
+    )
+
+    collector_payloads = _load_payloads(
+        artifact_paths.get("collector_reports", []),
+        add_finding,
+        expected_schema=COLLECTOR_REPORT_SCHEMA,
+    )
+    snapshot_payloads = _load_payloads(
+        artifact_paths.get("snapshots_json", []),
+        add_finding,
+        expected_schema=SNAPSHOT_SCHEMA_VERSION,
+        schema_field="metadata.schema_version",
+    )
+    alert_payloads = _load_payloads(
+        artifact_paths.get("alerts_json", []),
+        add_finding,
+        expected_schema=ALERT_REPORT_SCHEMA_VERSION,
+    )
+    heartbeat_payloads = _load_payloads(
+        artifact_paths.get("heartbeat", []),
+        add_finding,
+        expected_schema=HEARTBEAT_SCHEMA,
+    )
+    state_payloads = _load_payloads(
+        artifact_paths.get("state", []),
+        add_finding,
+        expected_schema=STATE_SCHEMA,
+    )
+    watchdog_payloads = _load_payloads(
+        artifact_paths.get("watchdog_json", []),
+        add_finding,
+        expected_schema=WATCHDOG_REPORT_SCHEMA,
+    )
+    write_audit_payloads = _load_payloads(
+        artifact_paths.get("write_audit_json", []),
+        add_finding,
+        expected_schema=WRITE_AUDIT_REPORT_SCHEMA,
+    )
+    boot_payloads = _load_payloads(
+        artifact_paths.get("boot_json", []),
+        add_finding,
+        expected_schema=BOOT_READINESS_SCHEMA,
+    )
+
+    for path, payload in collector_payloads:
+        _check_no_side_effects(path, payload, add_finding)
+
+    snapshot_timestamps: list[datetime] = []
+    for path, payload in snapshot_payloads:
+        _check_no_side_effects(path, payload, add_finding)
+        ts = _check_snapshot_payload(path, payload, add_finding)
+        if ts is not None:
+            snapshot_timestamps.append(ts)
+
+    alert_timestamps: list[datetime] = []
+    for path, payload in alert_payloads:
+        _check_no_side_effects(path, payload, add_finding)
+        ts = _check_alert_payload(path, payload, add_finding)
+        if ts is not None:
+            alert_timestamps.append(ts)
+
+    for path, payload in heartbeat_payloads:
+        _check_no_side_effects(path, payload, add_finding)
+        try:
+            _parse_ts(payload.get("current_run_at_utc", ""), "current_run_at_utc")
+            add_finding(
+                f"{path.name} current_run_at_utc",
+                "pass",
+                "current_run_at_utc is valid",
+                artifact=path.name,
+                field_name="current_run_at_utc",
+            )
+        except OpsValidationError as exc:
+            add_finding(
+                f"{path.name} current_run_at_utc",
+                "fail",
+                str(exc),
+                artifact=path.name,
+                field_name="current_run_at_utc",
+            )
+
+    for path, payload in state_payloads:
+        _check_no_side_effects(path, payload, add_finding)
+
+    watchdog_timestamps = _check_verdict_series(
+        "Watchdog", watchdog_payloads, add_finding
+    )
+    for path, payload in watchdog_payloads:
+        _check_no_side_effects(path, payload, add_finding)
+
+    write_audit_timestamps = _check_verdict_series(
+        "Write-audit", write_audit_payloads, add_finding
+    )
+    for path, payload in write_audit_payloads:
+        _check_no_side_effects(path, payload, add_finding)
+
+    boot_timestamps: list[datetime] = []
+    for path, payload in boot_payloads:
+        _check_no_side_effects(path, payload, add_finding)
+        ts = _check_boot_payload(path, payload, add_finding)
+        if ts is not None:
+            boot_timestamps.append(ts)
+
+    expected_cycles = _expected_min_cycles(
+        required_window_hours, runner_cadence_seconds
+    )
+    _check_count_floor(
+        "Collector report", len(collector_payloads), expected_cycles, add_finding
+    )
+    _check_count_floor("Snapshot", len(snapshot_payloads), expected_cycles, add_finding)
+    _check_count_floor("Alert", len(alert_payloads), expected_cycles, add_finding)
+    _check_count_floor("Watchdog", len(watchdog_payloads), expected_cycles, add_finding)
+    _check_count_floor(
+        "Write-audit", len(write_audit_payloads), expected_cycles, add_finding
+    )
+
+    observed_start, observed_end, observed_hours = _check_window_coverage(
+        snapshot_timestamps, required_window_hours, add_finding
+    )
+    if snapshot_timestamps:
+        _check_cadence_series(
+            "Snapshot", snapshot_timestamps, runner_cadence_seconds, add_finding
+        )
+    if alert_timestamps:
+        _check_cadence_series(
+            "Alert", alert_timestamps, runner_cadence_seconds, add_finding
+        )
+    if watchdog_timestamps:
+        _check_cadence_series(
+            "Watchdog", watchdog_timestamps, runner_cadence_seconds, add_finding
+        )
+    if write_audit_timestamps:
+        _check_cadence_series(
+            "Write-audit",
+            write_audit_timestamps,
+            runner_cadence_seconds,
+            add_finding,
+        )
+
+    heartbeat_payload = heartbeat_payloads[0][1] if heartbeat_payloads else None
+    state_payload = state_payloads[0][1] if state_payloads else None
+    latest_snapshot_ts = max(snapshot_timestamps) if snapshot_timestamps else None
+    _check_runner_state(
+        heartbeat_payload,
+        state_payload,
+        latest_snapshot_ts,
+        expected_min_cycles=expected_cycles,
+        cadence_seconds=runner_cadence_seconds,
+        add_finding=add_finding,
+    )
+
+    report_start = window_start_utc or observed_start or _now_utc()
+    report_end = window_end_utc or observed_end or report_start
+    observed_counts = {key: len(list(paths)) for key, paths in artifact_paths.items()}
+    fail_count = sum(1 for finding in findings if finding.severity == "fail")
+    warn_count = sum(1 for finding in findings if finding.severity == "warn")
+    pass_count = sum(1 for finding in findings if finding.severity == "pass")
+    if fail_count:
+        verdict = "FAIL"
+    elif warn_count:
+        verdict = "WARN"
+    else:
+        verdict = "PASS"
+
+    return OpsValidationReport(
+        schema_version=OPS_VALIDATION_SCHEMA_VERSION,
+        validated_at_utc=_format_ts(_now_utc()),
+        artifact_dir=str(artifact_dir),
+        window_start_utc=_format_ts(report_start),
+        window_end_utc=_format_ts(report_end),
+        observed_window_hours=round(observed_hours, 3),
+        required_window_hours=required_window_hours,
+        cadence_seconds=runner_cadence_seconds,
+        expected_min_cycles=expected_cycles,
+        observed_counts=observed_counts,
+        findings=tuple(
+            sorted(
+                findings,
+                key=lambda item: (
+                    {"fail": 0, "warn": 1, "pass": 2}.get(item.severity, 9),
+                    item.check_id,
+                ),
+            )
+        ),
+        summary=OpsValidationSummary(
+            verdict=verdict,
+            total_checks=len(findings),
+            pass_count=pass_count,
+            warn_count=warn_count,
+            fail_count=fail_count,
+        ),
+        runtime_handoff=_build_runtime_handoff(
+            required_window_hours=required_window_hours,
+            cadence_seconds=runner_cadence_seconds,
+        ),
+    )
+
+
+def validate_72h_window_from_dir(
+    artifact_dir: Path,
+    *,
+    window_start_utc: datetime | None = None,
+    window_end_utc: datetime | None = None,
+    required_window_hours: int = DEFAULT_REQUIRED_WINDOW_HOURS,
+    runner_cadence_seconds: int = DEFAULT_RUNNER_CADENCE_SECONDS,
+) -> OpsValidationReport:
+    if not artifact_dir.exists():
+        raise OpsValidationError(f"Artifact directory does not exist: {artifact_dir}")
+    if not artifact_dir.is_dir():
+        raise OpsValidationError(f"Path is not a directory: {artifact_dir}")
+    return validate_72h_window(
+        _collect_artifact_paths(artifact_dir),
+        artifact_dir=artifact_dir,
+        window_start_utc=window_start_utc,
+        window_end_utc=window_end_utc,
+        required_window_hours=required_window_hours,
+        runner_cadence_seconds=runner_cadence_seconds,
+    )
+
+
+def _render_finding(finding: OpsValidationFinding) -> str:
+    artifact_part = f" [{finding.artifact}]" if finding.artifact else ""
+    field_part = f" ({finding.field_name})" if finding.field_name else ""
+    return (
+        f"- [{finding.severity.upper()}] {finding.check_name}{artifact_part}"
+        f"{field_part}: {finding.message}"
+    )
+
+
+def report_to_markdown(report: OpsValidationReport) -> str:
+    payload = report.to_dict()
+    handoff = payload["runtime_handoff"]
+    lines = [
+        "# 72h Ops Validation Report",
+        "",
+        "## Metadata",
+        f"- Schema version: {payload['schema_version']}",
+        f"- Validated at (UTC): {payload['validated_at_utc']}",
+        f"- Artifact directory: `{payload['artifact_dir']}`",
+        f"- Window start (UTC): {payload['window_start_utc']}",
+        f"- Window end (UTC): {payload['window_end_utc']}",
+        f"- Observed window hours: {payload['observed_window_hours']}",
+        f"- Required window hours: {payload['required_window_hours']}",
+        f"- Cadence seconds: {payload['cadence_seconds']}",
+        f"- Expected minimum cycles: {payload['expected_min_cycles']}",
+        "",
+        "## Summary",
+        f"- Verdict: **{payload['summary']['verdict']}**",
+        f"- Total checks: {payload['summary']['total_checks']}",
+        f"- Pass: {payload['summary']['pass_count']}",
+        f"- Warn: {payload['summary']['warn_count']}",
+        f"- Fail: {payload['summary']['fail_count']}",
+        "",
+        "## Observed Counts",
+    ]
+    for key, value in sorted(payload["observed_counts"].items()):
+        lines.append(f"- {key}: {value}")
+    lines.extend(
+        [
+            "",
+            "## Findings",
+        ]
+    )
+    for item in payload["findings"]:
+        lines.append(_render_finding(OpsValidationFinding(**item)))
+    lines.extend(
+        [
+            "",
+            "## 72h Validation Contract",
+            "- PASS requires >=72h coverage, continuous runner evidence cadence, no FAIL in watchdog/write-audit/boot, and no side effects.",
+            "- WARN allows minor cadence drift or a justified boot/watchdog warning with no FAIL findings.",
+            "- FAIL means the always-on dry operation is not proven fail-closed.",
+            "",
+            "## Runtime Handoff",
+            f"- Artifact dir template: `{handoff['artifact_dir_template']}`",
+            f"- Seed fixture: `{handoff['seed_fixture']}`",
+            f"- Runner cadence seconds: {handoff['runner_cadence_seconds']}",
+            f"- Required window hours: {handoff['required_window_hours']}",
+            f"- Expected minimum cycles: {handoff['expected_min_cycles']}",
+            "- Watchdog after each runner cycle: yes",
+            "- Write-audit after each runner cycle: yes",
+            "",
+            "### Required Artifacts",
+        ]
+    )
+    for item in handoff["required_artifacts"]:
+        lines.append(f"- `{item}`")
+    lines.extend(["", "### Boot Preflight Commands"])
+    for item in handoff["boot_preflight_commands"]:
+        lines.append(f"- `{item}`")
+    lines.extend(["", "### Enable Commands"])
+    for item in handoff["enable_commands"]:
+        lines.append(f"- `{item}`")
+    lines.extend(["", "### Start Commands"])
+    for item in handoff["start_commands"]:
+        lines.append(f"- `{item}`")
+    lines.extend(["", "### Stop Commands"])
+    for item in handoff["stop_commands"]:
+        lines.append(f"- `{item}`")
+    lines.extend(["", "### Side-Effect Checklist"])
+    for item in handoff["side_effect_checklist"]:
+        lines.append(f"- {item}")
+    lines.extend(
+        [
+            "",
+            "### Gordon Checkpoint",
+            f"- {handoff['gordon_consultation_checkpoint']}",
+            "",
+            "### Safety Statement",
+            f"- {handoff['safety_statement']}",
+        ]
+    )
+    if handoff["notes"]:
+        lines.append("")
+        lines.append("### Notes")
+        for item in handoff["notes"]:
+            lines.append(f"- {item}")
+    lines.extend(
+        [
+            "",
+            "## Safety Boundaries",
+            "- No actual 72h run is started by this module.",
+            "- No Windows Task install, no Docker/runtime/DB/secrets mutation.",
+            "- No GitHub writes from module code.",
+            "- No LR-Go, no Live-Go, no Echtgeld-Go.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: list[str] | None = None) -> Any:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Validate the final >=72h evidence harvester always-on dry run."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    dir_parser = subparsers.add_parser(
+        "validate-dir",
+        help="Validate a directory containing >=72h evidence harvester artifacts.",
+    )
+    dir_parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        required=True,
+        help="Directory containing the 72h ops validation artifacts.",
+    )
+    dir_parser.add_argument(
+        "--window-start-utc",
+        help="Optional explicit window start for reporting.",
+    )
+    dir_parser.add_argument(
+        "--window-end-utc",
+        help="Optional explicit window end for reporting.",
+    )
+    dir_parser.add_argument(
+        "--required-window-hours",
+        type=int,
+        default=DEFAULT_REQUIRED_WINDOW_HOURS,
+        help="Required coverage window in hours (default: 72).",
+    )
+    dir_parser.add_argument(
+        "--runner-cadence-seconds",
+        type=int,
+        default=DEFAULT_RUNNER_CADENCE_SECONDS,
+        help="Expected runner cadence in seconds (default: 900).",
+    )
+    dir_parser.add_argument(
+        "--json-output",
+        type=Path,
+        help="Optional JSON output path for the ops validation report.",
+    )
+    dir_parser.add_argument(
+        "--markdown-output",
+        type=Path,
+        help="Optional Markdown output path for the ops validation report.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output.",
+    )
+    dir_parser.set_defaults(handler=_handle_validate_dir)
+    return parser.parse_args(argv)
+
+
+def _handle_validate_dir(args: Any) -> int:
+    window_start = (
+        _parse_ts(args.window_start_utc, "--window-start-utc")
+        if args.window_start_utc
+        else None
+    )
+    window_end = (
+        _parse_ts(args.window_end_utc, "--window-end-utc")
+        if args.window_end_utc
+        else None
+    )
+    report = validate_72h_window_from_dir(
+        args.artifact_dir,
+        window_start_utc=window_start,
+        window_end_utc=window_end,
+        required_window_hours=args.required_window_hours,
+        runner_cadence_seconds=args.runner_cadence_seconds,
+    )
+    payload = report.to_dict()
+    json_text = json.dumps(
+        payload,
+        indent=2 if args.pretty else None,
+        sort_keys=True,
+        ensure_ascii=True,
+    )
+    if args.json_output:
+        args.json_output.write_text(
+            json_text + ("" if json_text.endswith("\n") else "\n"),
+            encoding="utf-8",
+        )
+    if args.markdown_output:
+        args.markdown_output.write_text(report_to_markdown(report), encoding="utf-8")
+    if args.json_output or args.markdown_output:
+        print(report_to_markdown(report))
+    else:
+        print(json_text)
+    return 0 if report.summary.verdict != "FAIL" else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/evidence_harvester/runner.py
+++ b/tools/evidence_harvester/runner.py
@@ -459,6 +459,8 @@ def loop_fixture_command(args: argparse.Namespace) -> int:
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    if argv is None:
+        argv = sys.argv[1:]
     argv = list(argv or [])
     if not argv:
         argv = ["plan"]

--- a/tools/evidence_harvester/scheduler.py
+++ b/tools/evidence_harvester/scheduler.py
@@ -357,6 +357,8 @@ def uninstall_command(args: argparse.Namespace) -> int:
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    if argv is None:
+        argv = sys.argv[1:]
     argv = list(argv or [])
     if not argv:
         argv = ["plan"]

--- a/tools/evidence_harvester/watchdog.py
+++ b/tools/evidence_harvester/watchdog.py
@@ -1074,6 +1074,8 @@ def _write_text(path: Path, text: str) -> None:
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    if argv is None:
+        argv = sys.argv[1:]
     argv = list(argv or [])
     if not argv:
         argv = ["status"]


### PR DESCRIPTION
## Brain Evidence Block

```text
context_brain_attempted: true
context_brain_used: true
repo_fallback_used: true
repo_fallback_reason: insufficient_evidence
context_tool_status: available
context_trust_level: low
records_found: 0
```

## Ops-validation summary

- add `tools/evidence_harvester/ops_validation.py` as the final `>=72h` always-on dry-run validator
- compose runner continuity, snapshot/alert coverage, watchdog history, write-audit history, boot-readiness evidence, and side-effect checks into one PASS/WARN/FAIL verdict
- add fixture-based unit tests and a dedicated `>=72h` runbook
- wire minimal README / ops runbook / package export updates

## 72h validation contract

- artifact dir: `artifacts/evidence_harvester/72h_ops_validation/<run_id>/`
- seed fixture: `artifacts/evidence_harvester/24h_dry_run/collector_input.json`
- cadence: every `900` seconds / `15` minutes
- watchdog: after each runner cycle
- write-audit: after each runner cycle
- final validation: after `>=72h` over the whole artifact directory

## Runtime handoff

- the module emits a structured runtime handoff for the later real run
- the runbook documents boot preflight, optional scheduler enablement, bounded runner start, final validation, stop/disable steps, and the Gordon checkpoint before any Docker/infra mutation
- phase-2 note: keep latest `watchdog_report.json/.md` current for `write_audit.py` compatibility while also archiving stamped `watchdog_report_<stamp>.*`

## Tests

- `python -m pytest tests/unit/tools/evidence_harvester -q`
- `ruff check tools/evidence_harvester tests/unit/tools/evidence_harvester`
- `black --check tools/evidence_harvester tests/unit/tools/evidence_harvester`
- `git diff --check`
- targeted forbidden-pattern scan over changed files

## Safety boundaries

- no actual 72h run in this PR
- no Windows Task install in this PR
- no Docker/runtime/DB/secrets mutation
- no GitHub writes from module code
- no LR-Go
- no Live-Go
- no Echtgeld-Go
- `.opencode/plans/` and `docs/decisions/` left untouched

References #3362
