### PR TITLE
[EVIDENCE][HARVESTER] Fix watchdog freshness and coordinator recovery

### DIFF
--- a/tests/unit/tools/evidence_harvester/test_coordinator.py
+++ b/tests/unit/tools/evidence_harvester/test_coordinator.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.evidence_harvester.coordinator import (
+    RECOVERY_EVENT_SCHEMA,
+    run_fixture_window,
+)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def _write_cycle_artifacts(artifact_dir: Path, stamp: str) -> None:
+    _write_json(artifact_dir / f"collector_report_{stamp}.json", {"stamp": stamp})
+    _write_json(
+        artifact_dir / f"snapshot_{stamp}.json",
+        {
+            "metadata": {
+                "generated_at_utc": "2026-06-19T00:00:00Z",
+                "schema_version": "cdb.evidence_harvester.snapshot.v1",
+            },
+            "safety": {
+                "lr_status": "NO-GO",
+                "live_status": "NO-GO",
+                "echtgeld_status": "NO-GO",
+                "runtime_actions": "not_allowed",
+                "db_execution": "not_allowed",
+                "banner": "Paper/research evidence only; no LR-Go, no Live-Go, no Echtgeld-Go.",
+            },
+        },
+    )
+    (artifact_dir / f"snapshot_{stamp}.md").write_text("# Snapshot\n", encoding="utf-8")
+    _write_json(artifact_dir / f"alert_{stamp}.json", {"stamp": stamp})
+    (artifact_dir / f"alert_{stamp}.md").write_text("# Alert\n", encoding="utf-8")
+    _write_json(
+        artifact_dir / "runner_heartbeat.json",
+        {
+            "schema_version": "cdb.evidence_harvester.runner_heartbeat.v1",
+            "current_run_at_utc": "2026-06-19T00:00:00Z",
+        },
+    )
+    _write_json(
+        artifact_dir / "runner_state.json",
+        {
+            "schema_version": "cdb.evidence_harvester.runner_state.v1",
+            "last_cycle_verdict": "PASS",
+            "last_cycle_ended_at_utc": "2026-06-19T00:00:00Z",
+        },
+    )
+
+
+def _pass_boot_runner(repo_root: Path, artifact_dir: Path) -> tuple[int, dict]:
+    return 0, {"verdict": {"verdict": "PASS"}}
+
+
+def _noop_final_validator(repo_root: Path, artifact_dir: Path) -> tuple[int, dict]:
+    return 0, {"summary": {"verdict": "PASS"}}
+
+
+@pytest.mark.unit
+def test_recoverable_watchdog_failure_restarts_and_progresses_beyond_cycle9(
+    tmp_path: Path,
+) -> None:
+    fixture = tmp_path / "collector_input.json"
+    fixture.write_text("{}", encoding="utf-8")
+    artifact_dir = tmp_path / "run"
+
+    cycle_attempts: list[str] = []
+    sleep_calls: list[float] = []
+    recovery_injected = {"done": False}
+
+    def cycle_runner(
+        repo_root: Path, fixture_path: Path, out_dir: Path
+    ) -> tuple[int, str]:
+        stamp = f"20260619T0000{len(cycle_attempts):02d}Z"
+        cycle_attempts.append(stamp)
+        _write_cycle_artifacts(out_dir, stamp)
+        return 0, stamp
+
+    def watchdog_runner(
+        repo_root: Path,
+        out_dir: Path,
+        cycle_stamp: str,
+        cadence_seconds: int,
+    ) -> tuple[int, dict]:
+        report_name = f"watchdog_report_{cycle_stamp}.json"
+        payload = {
+            "report_name": report_name,
+            "verdict": {"verdict": "PASS"},
+            "findings": [],
+        }
+        if len(cycle_attempts) == 9 and not recovery_injected["done"]:
+            recovery_injected["done"] = True
+            payload = {
+                "report_name": report_name,
+                "verdict": {"verdict": "FAIL"},
+                "findings": [
+                    {
+                        "check_id": "W011",
+                        "severity": "fail",
+                        "field_name": "metadata.generated_at_utc",
+                        "message": "Latest snapshot is 9999s old (max_age=7200s)",
+                    }
+                ],
+            }
+        _write_json(out_dir / report_name, payload)
+        _write_json(out_dir / "watchdog_report.json", payload)
+        (out_dir / f"watchdog_report_{cycle_stamp}.md").write_text(
+            "# Watchdog\n", encoding="utf-8"
+        )
+        (out_dir / "watchdog_report.md").write_text("# Watchdog\n", encoding="utf-8")
+        return (1 if payload["verdict"]["verdict"] == "FAIL" else 0), payload
+
+    def write_audit_runner(
+        repo_root: Path,
+        out_dir: Path,
+        cycle_stamp: str,
+    ) -> tuple[int, dict]:
+        payload = {
+            "report_name": f"write_audit_report_{cycle_stamp}.json",
+            "verdict": {"verdict": "PASS"},
+            "findings": [],
+        }
+        _write_json(out_dir / payload["report_name"], payload)
+        (out_dir / f"write_audit_report_{cycle_stamp}.md").write_text(
+            "# Write Audit\n", encoding="utf-8"
+        )
+        return 0, payload
+
+    summary = run_fixture_window(
+        repo_root=tmp_path,
+        fixture_path=fixture,
+        artifact_dir=artifact_dir,
+        iterations=10,
+        cadence_seconds=1,
+        max_restart_count=3,
+        restart_backoff_seconds=7,
+        sleep_fn=sleep_calls.append,
+        boot_runner=_pass_boot_runner,
+        cycle_runner=cycle_runner,
+        watchdog_runner=watchdog_runner,
+        write_audit_runner=write_audit_runner,
+        final_validator=_noop_final_validator,
+    )
+
+    assert summary.status == "PASS"
+    assert summary.completed_cycles == 10
+    assert summary.recovery_events_written == 1
+    assert summary.restart_count == 1
+    assert 7 in sleep_calls
+    assert len(cycle_attempts) == 11
+    assert any(
+        "000010Z" in p.name for p in artifact_dir.glob("collector_report_*.json")
+    )
+
+    recovery_events = sorted(artifact_dir.glob("recovery_event_*.json"))
+    assert len(recovery_events) == 1
+    payload = json.loads(recovery_events[0].read_text(encoding="utf-8"))
+    assert payload["schema_version"] == RECOVERY_EVENT_SCHEMA
+    assert payload["classification"] == "recoverable"
+    assert payload["action"] == "restart_cycle"
+    assert payload["restart_count"] == 1
+
+
+@pytest.mark.unit
+def test_fatal_safety_failure_stops_without_restart(tmp_path: Path) -> None:
+    fixture = tmp_path / "collector_input.json"
+    fixture.write_text("{}", encoding="utf-8")
+    artifact_dir = tmp_path / "run"
+
+    cycle_attempts: list[str] = []
+
+    def cycle_runner(
+        repo_root: Path, fixture_path: Path, out_dir: Path
+    ) -> tuple[int, str]:
+        stamp = "20260619T000000Z"
+        cycle_attempts.append(stamp)
+        _write_cycle_artifacts(out_dir, stamp)
+        return 0, stamp
+
+    def watchdog_runner(
+        repo_root: Path,
+        out_dir: Path,
+        cycle_stamp: str,
+        cadence_seconds: int,
+    ) -> tuple[int, dict]:
+        payload = {
+            "report_name": f"watchdog_report_{cycle_stamp}.json",
+            "verdict": {"verdict": "FAIL"},
+            "findings": [
+                {
+                    "check_id": "W012",
+                    "severity": "fail",
+                    "field_name": "safety.live_status",
+                    "message": "Expected live_status='NO-GO', got 'GO'",
+                }
+            ],
+        }
+        return 1, payload
+
+    def write_audit_runner(
+        repo_root: Path,
+        out_dir: Path,
+        cycle_stamp: str,
+    ) -> tuple[int, dict]:
+        raise AssertionError(
+            "write_audit_runner should not run after fatal watchdog failure"
+        )
+
+    summary = run_fixture_window(
+        repo_root=tmp_path,
+        fixture_path=fixture,
+        artifact_dir=artifact_dir,
+        iterations=10,
+        cadence_seconds=1,
+        max_restart_count=3,
+        restart_backoff_seconds=7,
+        sleep_fn=lambda seconds: None,
+        boot_runner=_pass_boot_runner,
+        cycle_runner=cycle_runner,
+        watchdog_runner=watchdog_runner,
+        write_audit_runner=write_audit_runner,
+        final_validator=_noop_final_validator,
+    )
+
+    assert summary.status == "FAIL"
+    assert summary.completed_cycles == 0
+    assert summary.recovery_events_written == 1
+    assert summary.restart_count == 0
+    assert summary.stop_reason == "fatal_watchdog_failure"
+    assert len(cycle_attempts) == 1
+
+    recovery_events = sorted(artifact_dir.glob("recovery_event_*.json"))
+    assert len(recovery_events) == 1
+    payload = json.loads(recovery_events[0].read_text(encoding="utf-8"))
+    assert payload["classification"] == "fatal"
+    assert payload["action"] == "stop"

--- a/tests/unit/tools/evidence_harvester/test_ops_validation.py
+++ b/tests/unit/tools/evidence_harvester/test_ops_validation.py
@@ -16,6 +16,7 @@ from tools.evidence_harvester.ops_validation import (
     validate_72h_window_from_dir,
 )
 from tools.evidence_harvester.snapshot import SAFETY_BANNER, SNAPSHOT_SCHEMA_VERSION
+from tools.evidence_harvester.coordinator import RECOVERY_EVENT_SCHEMA
 from tools.evidence_harvester.validation import EXPECTED_ALERT_SCHEMA
 from tools.evidence_harvester.write_audit import (
     COLLECTOR_REPORT_SCHEMA,
@@ -244,6 +245,37 @@ def _boot_payload(ts: str, verdict: str = "PASS") -> dict:
     }
 
 
+def _recovery_event_payload(
+    ts: str,
+    *,
+    covered_report_name: str,
+    restart_count: int = 1,
+    max_restart_count: int = 3,
+    classification: str = "recoverable",
+    limit_exceeded: bool = False,
+    action: str = "restart_cycle",
+) -> dict:
+    return {
+        "schema_version": RECOVERY_EVENT_SCHEMA,
+        "event_at_utc": ts,
+        "artifact_dir": "test",
+        "cycle_stamp": ts.replace(":", "").replace("-", ""),
+        "failure_source": "watchdog",
+        "trigger_report_name": covered_report_name,
+        "trigger_verdict": "FAIL",
+        "classification": classification,
+        "reason_codes": ["stale_or_missing_latest_artifact"],
+        "covered_report_names": [covered_report_name],
+        "restart_attempted": classification == "recoverable" and not limit_exceeded,
+        "restart_count": restart_count,
+        "max_restart_count": max_restart_count,
+        "backoff_seconds": 30,
+        "action": action,
+        "limit_exceeded": limit_exceeded,
+        "audited": True,
+    }
+
+
 def _heartbeat_payload(started_at: str, current_ts: str, iteration: int) -> dict:
     return {
         "schema_version": HEARTBEAT_SCHEMA,
@@ -431,6 +463,78 @@ class TestValidate72hWindowFromDir:
         assert report.summary.verdict == "WARN"
         assert any(
             "Boot readiness report is WARN" in f.message for f in report.findings
+        )
+
+    @pytest.mark.unit
+    def test_warn_on_bounded_recovery_event_covering_watchdog_fail(
+        self, tmp_path: Path
+    ) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(
+            tmp_path,
+            start=start,
+            hours=2,
+            cadence_seconds=3600,
+        )
+        first_stamp = _stamp(start)
+        fail_watchdog = _watchdog_payload(_ts(start), verdict="FAIL")
+        _write_json(tmp_path / f"watchdog_report_{first_stamp}.json", fail_watchdog)
+        _write_json(
+            tmp_path / "recovery_event_20260619T003000Z.json",
+            _recovery_event_payload(
+                "2026-06-19T00:30:00Z",
+                covered_report_name=f"watchdog_report_{first_stamp}.json",
+            ),
+        )
+        _write_text(tmp_path / "recovery_event_20260619T003000Z.md")
+
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+
+        assert report.summary.verdict == "WARN"
+        assert any(
+            "covered by an audited recovery event" in f.message for f in report.findings
+        )
+        assert any("Recovery event history" == f.check_name for f in report.findings)
+
+    @pytest.mark.unit
+    def test_fail_when_recovery_restart_limit_exceeded(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(
+            tmp_path,
+            start=start,
+            hours=2,
+            cadence_seconds=3600,
+        )
+        first_stamp = _stamp(start)
+        fail_watchdog = _watchdog_payload(_ts(start), verdict="FAIL")
+        _write_json(tmp_path / f"watchdog_report_{first_stamp}.json", fail_watchdog)
+        _write_json(
+            tmp_path / "recovery_event_20260619T003000Z.json",
+            _recovery_event_payload(
+                "2026-06-19T00:30:00Z",
+                covered_report_name=f"watchdog_report_{first_stamp}.json",
+                restart_count=4,
+                max_restart_count=3,
+                limit_exceeded=True,
+                action="stop",
+            ),
+        )
+        _write_text(tmp_path / "recovery_event_20260619T003000Z.md")
+
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+
+        assert report.summary.verdict == "FAIL"
+        assert any(
+            "restart_count=4 exceeds max_restart_count=3" in f.message
+            for f in report.findings
         )
 
     @pytest.mark.unit

--- a/tests/unit/tools/evidence_harvester/test_watchdog.py
+++ b/tests/unit/tools/evidence_harvester/test_watchdog.py
@@ -64,6 +64,7 @@ def _write_state(
     successful_runs: int = 5,
     failed_runs: int = 0,
     last_verdict: str = "PASS",
+    age_minutes: int = 1,
 ) -> Path:
     payload = {
         "schema_version": "cdb.evidence_harvester.runner_state.v1",
@@ -71,7 +72,7 @@ def _write_state(
         "successful_runs": successful_runs,
         "failed_runs": failed_runs,
         "last_cycle_verdict": last_verdict,
-        "last_cycle_ended_at_utc": _ts(1),
+        "last_cycle_ended_at_utc": _ts(age_minutes),
     }
     path = artifact_dir / "runner_state.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
@@ -260,6 +261,7 @@ def _write_artifact_dir(
     snapshot_age_minutes: int = 10,
     state_failed_runs: int = 0,
     state_verdict: str = "PASS",
+    state_age_minutes: int = 1,
     include_heartbeat: bool = True,
     include_state: bool = True,
     include_snapshot: bool = True,
@@ -277,6 +279,7 @@ def _write_artifact_dir(
             d,
             failed_runs=state_failed_runs,
             last_verdict=state_verdict,
+            age_minutes=state_age_minutes,
         )
     if include_snapshot:
         _write_snapshot(d, age_minutes=snapshot_age_minutes)
@@ -435,6 +438,34 @@ def test_status_fail_on_stale_snapshot(tmp_path: Path) -> None:
     report = run_status(d, max_age_seconds=60, now=now)
 
     assert report.verdict.verdict == "FAIL"
+
+
+@pytest.mark.unit
+def test_status_ignores_historical_snapshot_freshness(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path, snapshot_age_minutes=1)
+    _write_snapshot(d, stamp="20260618T000000Z", age_minutes=200)
+    (d / "snapshot_20260618T000000Z.md").write_text("# Historical", encoding="utf-8")
+    now = datetime.now(UTC)
+
+    report = run_status(d, max_age_seconds=120, now=now)
+
+    assert report.verdict.verdict == "PASS"
+    freshness = [f for f in report.findings if f.check_id == "W011"]
+    assert len(freshness) == 1
+    assert freshness[0].severity == "pass"
+    assert "Latest snapshot" in freshness[0].message
+
+
+@pytest.mark.unit
+def test_status_fail_on_stale_runner_state(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path, state_age_minutes=200)
+    now = datetime.now(UTC)
+
+    report = run_status(d, max_age_seconds=60, now=now)
+
+    assert report.verdict.verdict == "FAIL"
+    assert report.runner_state_ok is False
+    assert any(f.check_id == "W016" and f.severity == "fail" for f in report.findings)
 
 
 @pytest.mark.unit

--- a/tests/unit/tools/evidence_harvester/test_write_audit.py
+++ b/tests/unit/tools/evidence_harvester/test_write_audit.py
@@ -193,14 +193,14 @@ def _heartbeat_payload(age_minutes: int = 1) -> dict:
     }
 
 
-def _state_payload(verdict: str = "PASS") -> dict:
+def _state_payload(verdict: str = "PASS", age_minutes: int = 1) -> dict:
     return {
         "schema_version": "cdb.evidence_harvester.runner_state.v1",
         "total_runs": 5,
         "successful_runs": 5,
         "failed_runs": 0,
         "last_cycle_verdict": verdict,
-        "last_cycle_ended_at_utc": _ts(1),
+        "last_cycle_ended_at_utc": _ts(age_minutes),
     }
 
 
@@ -505,6 +505,30 @@ def test_rwa_a006_fail_stale_snapshot(tmp_path: Path) -> None:
     assert report.verdict.verdict == "FAIL"
     a006 = [f for f in report.findings if f.check_id == "A006"]
     assert any(f.severity == "fail" for f in a006)
+
+
+def test_rwa_a006_ignore_historical_snapshot_staleness(tmp_path: Path) -> None:
+    d = _setup_complete_artifacts(tmp_path)
+    old_snap = _snapshot_payload(
+        stamp="20260618T000000Z",
+        age_minutes=9999,
+        collector_hash=_collector_hash(_collector_payload("20260618T000000Z")),
+        collector_id="report_20260618T000000Z",
+    )
+    _write_json(
+        d / "collector_report_20260618T000000Z.json",
+        _collector_payload("20260618T000000Z"),
+    )
+    _write_json(d / "snapshot_20260618T000000Z.json", old_snap)
+    (d / "snapshot_20260618T000000Z.md").write_text("# Historical", encoding="utf-8")
+
+    report = run_write_audit(d, stale_threshold=7200, now=_FIXED_TS)
+
+    assert report.verdict.verdict == "PASS"
+    a006 = [f for f in report.findings if f.check_id == "A006"]
+    assert all(
+        "latest snapshot" in f.message.lower() or f.severity == "pass" for f in a006
+    )
 
 
 # --- A007: Source modes ---

--- a/tools/evidence_harvester/coordinator.py
+++ b/tools/evidence_harvester/coordinator.py
@@ -1,0 +1,693 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+RECOVERY_EVENT_SCHEMA = "cdb.evidence_harvester.recovery_event.v1"
+
+DEFAULT_MAX_RESTART_COUNT = 3
+DEFAULT_RESTART_BACKOFF_SECONDS = 30
+DEFAULT_CADENCE_SECONDS = 900
+
+
+class CoordinatorError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryEvent:
+    schema_version: str
+    event_at_utc: str
+    artifact_dir: str
+    cycle_stamp: str
+    failure_source: str
+    trigger_report_name: str
+    trigger_verdict: str
+    classification: str
+    reason_codes: tuple[str, ...]
+    covered_report_names: tuple[str, ...]
+    restart_attempted: bool
+    restart_count: int
+    max_restart_count: int
+    backoff_seconds: int
+    action: str
+    limit_exceeded: bool
+    audited: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class CoordinatorSummary:
+    status: str
+    artifact_dir: str
+    completed_cycles: int
+    recovery_events_written: int
+    restart_count: int
+    max_restart_count: int
+    final_validation_started: bool
+    stop_reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _now_utc() -> datetime:
+    return cdb_utcnow().astimezone(UTC)
+
+
+def _format_ts(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _event_stamp(now: datetime | None = None) -> str:
+    return (now or _now_utc()).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CoordinatorError(f"Malformed JSON in {path.name}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise CoordinatorError(f"{path.name} JSON root must be an object")
+    return payload
+
+
+def _run_python_module(args: list[str], *, repo_root: Path) -> int:
+    completed = subprocess.run(
+        [sys.executable, *args],
+        cwd=str(repo_root),
+        check=False,
+    )
+    return int(completed.returncode)
+
+
+def _latest_cycle_stamp(artifact_dir: Path) -> str:
+    reports = sorted(artifact_dir.glob("collector_report_*.json"))
+    if not reports:
+        raise CoordinatorError("No collector_report_*.json found to derive cycle stamp")
+    latest = reports[-1].stem
+    return latest.removeprefix("collector_report_")
+
+
+def _extract_verdict(payload: Mapping[str, Any] | None) -> str:
+    if not payload:
+        return ""
+    verdict = payload.get("verdict")
+    if isinstance(verdict, Mapping):
+        value = verdict.get("verdict")
+        return str(value) if value is not None else ""
+    if isinstance(verdict, str):
+        return verdict
+    return ""
+
+
+def _classify_failure(
+    failure_source: str,
+    payload: Mapping[str, Any] | None,
+    *,
+    exit_code: int,
+) -> tuple[str, tuple[str, ...], tuple[str, ...]]:
+    if payload is None:
+        return (
+            "recoverable",
+            (f"{failure_source}_exit_nonzero",),
+            (),
+        )
+
+    findings = payload.get("findings", [])
+    if not isinstance(findings, list):
+        findings = []
+
+    fatal_reasons: list[str] = []
+    recoverable_reasons: list[str] = []
+
+    for item in findings:
+        if not isinstance(item, Mapping):
+            continue
+        if str(item.get("severity", "")).lower() != "fail":
+            continue
+        check_id = str(item.get("check_id", ""))
+        field_name = str(item.get("field_name", ""))
+        message = str(item.get("message", ""))
+        haystack = f"{check_id} {field_name} {message}".lower()
+
+        if field_name.startswith("safety."):
+            fatal_reasons.append("safety_flag_violation")
+            continue
+        if any(
+            token in haystack
+            for token in (
+                "lr_status",
+                "live_status",
+                "echtgeld_status",
+                "runtime_actions",
+                "db_execution",
+                "trade_executed",
+                "order_submitted",
+                "position_opened",
+                "secret",
+                "manual_escalation_only",
+            )
+        ):
+            fatal_reasons.append("safety_or_side_effect_violation")
+            continue
+        if any(
+            token in haystack
+            for token in (
+                "schema_version",
+                "malformed json",
+                "json root must be an object",
+                "runner_heartbeat.json is missing",
+                "runner_state.json is missing",
+                "current_run_at_utc",
+                "last_cycle_ended_at_utc",
+                "not valid iso-8601",
+            )
+        ):
+            fatal_reasons.append("malformed_core_state")
+            continue
+        if any(
+            token in haystack
+            for token in ("stale", "freshness", "cadence", "old", "missing")
+        ):
+            recoverable_reasons.append("stale_or_missing_latest_artifact")
+            continue
+        recoverable_reasons.append("recoverable_report_failure")
+
+    if fatal_reasons:
+        return ("fatal", tuple(sorted(set(fatal_reasons))), ())
+
+    covered_names = []
+    report_name = str(payload.get("report_name", "")).strip()
+    if report_name:
+        covered_names.append(report_name)
+    verdict = _extract_verdict(payload)
+    if verdict == "FAIL" and not recoverable_reasons:
+        recoverable_reasons.append(f"{failure_source}_report_fail")
+    if exit_code != 0 and not recoverable_reasons:
+        recoverable_reasons.append(f"{failure_source}_exit_nonzero")
+    return (
+        "recoverable",
+        tuple(sorted(set(recoverable_reasons or (f"{failure_source}_fail",)))),
+        tuple(sorted(set(covered_names))),
+    )
+
+
+def _write_recovery_event(
+    artifact_dir: Path,
+    *,
+    cycle_stamp: str,
+    failure_source: str,
+    trigger_report_name: str,
+    trigger_verdict: str,
+    classification: str,
+    reason_codes: tuple[str, ...],
+    covered_report_names: tuple[str, ...],
+    restart_attempted: bool,
+    restart_count: int,
+    max_restart_count: int,
+    backoff_seconds: int,
+    action: str,
+    limit_exceeded: bool,
+) -> RecoveryEvent:
+    event = RecoveryEvent(
+        schema_version=RECOVERY_EVENT_SCHEMA,
+        event_at_utc=_format_ts(_now_utc()),
+        artifact_dir=str(artifact_dir),
+        cycle_stamp=cycle_stamp,
+        failure_source=failure_source,
+        trigger_report_name=trigger_report_name,
+        trigger_verdict=trigger_verdict,
+        classification=classification,
+        reason_codes=reason_codes,
+        covered_report_names=covered_report_names,
+        restart_attempted=restart_attempted,
+        restart_count=restart_count,
+        max_restart_count=max_restart_count,
+        backoff_seconds=backoff_seconds,
+        action=action,
+        limit_exceeded=limit_exceeded,
+        audited=True,
+    )
+    stamp = _event_stamp()
+    json_path = artifact_dir / f"recovery_event_{stamp}.json"
+    md_path = artifact_dir / f"recovery_event_{stamp}.md"
+    json_path.write_text(
+        json.dumps(event.to_dict(), indent=2, sort_keys=True, ensure_ascii=True),
+        encoding="utf-8",
+    )
+    md_lines = [
+        "# Recovery Event",
+        "",
+        f"- Event at (UTC): `{event.event_at_utc}`",
+        f"- Cycle stamp: `{event.cycle_stamp}`",
+        f"- Failure source: `{event.failure_source}`",
+        f"- Trigger report: `{event.trigger_report_name}`",
+        f"- Trigger verdict: `{event.trigger_verdict}`",
+        f"- Classification: `{event.classification}`",
+        f"- Action: `{event.action}`",
+        f"- Restart attempted: `{event.restart_attempted}`",
+        f"- Restart count: `{event.restart_count}` / `{event.max_restart_count}`",
+        f"- Limit exceeded: `{event.limit_exceeded}`",
+        f"- Audited: `{event.audited}`",
+        "",
+        "## Reasons",
+    ]
+    for reason in event.reason_codes:
+        md_lines.append(f"- `{reason}`")
+    if event.covered_report_names:
+        md_lines.extend(["", "## Covered Reports"])
+        for name in event.covered_report_names:
+            md_lines.append(f"- `{name}`")
+    md_path.write_text("\n".join(md_lines) + "\n", encoding="utf-8")
+    return event
+
+
+def _default_boot_runner(
+    repo_root: Path, artifact_dir: Path
+) -> tuple[int, dict[str, Any] | None]:
+    json_path = artifact_dir / "boot_readiness_report.json"
+    md_path = artifact_dir / "boot_readiness_report.md"
+    exit_code = _run_python_module(
+        [
+            "-m",
+            "tools.evidence_harvester.boot",
+            "status",
+            "--json-output",
+            str(json_path),
+            "--markdown-output",
+            str(md_path),
+            "--pretty",
+        ],
+        repo_root=repo_root,
+    )
+    payload = _load_json(json_path) if json_path.exists() else None
+    return exit_code, payload
+
+
+def _default_cycle_runner(
+    repo_root: Path,
+    fixture_path: Path,
+    artifact_dir: Path,
+) -> tuple[int, str]:
+    exit_code = _run_python_module(
+        [
+            "-m",
+            "tools.evidence_harvester.runner",
+            "--pretty",
+            "run-once-fixture",
+            "--fixture",
+            str(fixture_path),
+            "--output-dir",
+            str(artifact_dir),
+        ],
+        repo_root=repo_root,
+    )
+    return exit_code, _latest_cycle_stamp(artifact_dir)
+
+
+def _default_watchdog_runner(
+    repo_root: Path,
+    artifact_dir: Path,
+    cycle_stamp: str,
+    cadence_seconds: int,
+) -> tuple[int, dict[str, Any] | None]:
+    latest_json = artifact_dir / "watchdog_report.json"
+    latest_md = artifact_dir / "watchdog_report.md"
+    exit_code = _run_python_module(
+        [
+            "-m",
+            "tools.evidence_harvester.watchdog",
+            "status",
+            "--artifact-dir",
+            str(artifact_dir),
+            "--cadence-seconds",
+            str(cadence_seconds),
+            "--json-output",
+            str(latest_json),
+            "--markdown-output",
+            str(latest_md),
+            "--pretty",
+        ],
+        repo_root=repo_root,
+    )
+    if latest_json.exists():
+        shutil.copyfile(
+            latest_json, artifact_dir / f"watchdog_report_{cycle_stamp}.json"
+        )
+    if latest_md.exists():
+        shutil.copyfile(latest_md, artifact_dir / f"watchdog_report_{cycle_stamp}.md")
+    payload = _load_json(latest_json) if latest_json.exists() else None
+    if payload is not None:
+        payload = dict(payload)
+        payload["report_name"] = f"watchdog_report_{cycle_stamp}.json"
+    return exit_code, payload
+
+
+def _default_write_audit_runner(
+    repo_root: Path,
+    artifact_dir: Path,
+    cycle_stamp: str,
+) -> tuple[int, dict[str, Any] | None]:
+    json_path = artifact_dir / f"write_audit_report_{cycle_stamp}.json"
+    md_path = artifact_dir / f"write_audit_report_{cycle_stamp}.md"
+    exit_code = _run_python_module(
+        [
+            "-m",
+            "tools.evidence_harvester.write_audit",
+            "--artifact-dir",
+            str(artifact_dir),
+            "--json-output",
+            str(json_path),
+            "--markdown-output",
+            str(md_path),
+            "--pretty",
+        ],
+        repo_root=repo_root,
+    )
+    payload = _load_json(json_path) if json_path.exists() else None
+    if payload is not None:
+        payload = dict(payload)
+        payload["report_name"] = json_path.name
+    return exit_code, payload
+
+
+def _default_final_validator(
+    repo_root: Path, artifact_dir: Path
+) -> tuple[int, dict[str, Any] | None]:
+    json_path = artifact_dir / "ops_validation_report.json"
+    md_path = artifact_dir / "ops_validation_report.md"
+    exit_code = _run_python_module(
+        [
+            "-m",
+            "tools.evidence_harvester.ops_validation",
+            "--pretty",
+            "validate-dir",
+            "--artifact-dir",
+            str(artifact_dir),
+            "--json-output",
+            str(json_path),
+            "--markdown-output",
+            str(md_path),
+        ],
+        repo_root=repo_root,
+    )
+    payload = _load_json(json_path) if json_path.exists() else None
+    return exit_code, payload
+
+
+def run_fixture_window(
+    *,
+    repo_root: Path,
+    fixture_path: Path,
+    artifact_dir: Path,
+    iterations: int,
+    cadence_seconds: int = DEFAULT_CADENCE_SECONDS,
+    max_restart_count: int = DEFAULT_MAX_RESTART_COUNT,
+    restart_backoff_seconds: int = DEFAULT_RESTART_BACKOFF_SECONDS,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    boot_runner: Callable[
+        [Path, Path], tuple[int, dict[str, Any] | None]
+    ] = _default_boot_runner,
+    cycle_runner: Callable[[Path, Path, Path], tuple[int, str]] = _default_cycle_runner,
+    watchdog_runner: Callable[
+        [Path, Path, str, int], tuple[int, dict[str, Any] | None]
+    ] = _default_watchdog_runner,
+    write_audit_runner: Callable[
+        [Path, Path, str], tuple[int, dict[str, Any] | None]
+    ] = _default_write_audit_runner,
+    final_validator: Callable[
+        [Path, Path], tuple[int, dict[str, Any] | None]
+    ] = _default_final_validator,
+) -> CoordinatorSummary:
+    if iterations < 1:
+        raise CoordinatorError("iterations must be >= 1")
+    if cadence_seconds < 1:
+        raise CoordinatorError("cadence_seconds must be >= 1")
+    if max_restart_count < 0:
+        raise CoordinatorError("max_restart_count must be >= 0")
+    if restart_backoff_seconds < 0:
+        raise CoordinatorError("restart_backoff_seconds must be >= 0")
+
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    if not fixture_path.exists():
+        raise CoordinatorError(f"fixture path does not exist: {fixture_path}")
+
+    recovery_events_written = 0
+    restart_count = 0
+    completed_cycles = 0
+    final_validation_started = False
+    stop_reason = ""
+
+    boot_exit, boot_payload = boot_runner(repo_root, artifact_dir)
+    if boot_exit != 0 or _extract_verdict(boot_payload) == "FAIL":
+        stop_reason = "boot_readiness_failed"
+        return CoordinatorSummary(
+            status="FAIL",
+            artifact_dir=str(artifact_dir),
+            completed_cycles=0,
+            recovery_events_written=0,
+            restart_count=0,
+            max_restart_count=max_restart_count,
+            final_validation_started=False,
+            stop_reason=stop_reason,
+        )
+
+    while completed_cycles < iterations:
+        runner_exit, cycle_stamp = cycle_runner(repo_root, fixture_path, artifact_dir)
+        if runner_exit != 0:
+            classification, reason_codes, covered = _classify_failure(
+                "runner", None, exit_code=runner_exit
+            )
+            limit_exceeded = restart_count >= max_restart_count
+            _write_recovery_event(
+                artifact_dir,
+                cycle_stamp=cycle_stamp if cycle_stamp else _event_stamp(),
+                failure_source="runner",
+                trigger_report_name="runner",
+                trigger_verdict="FAIL",
+                classification="fatal" if limit_exceeded else classification,
+                reason_codes=reason_codes,
+                covered_report_names=covered,
+                restart_attempted=not limit_exceeded,
+                restart_count=restart_count + 1,
+                max_restart_count=max_restart_count,
+                backoff_seconds=restart_backoff_seconds,
+                action="stop" if limit_exceeded else "restart_cycle",
+                limit_exceeded=limit_exceeded,
+            )
+            recovery_events_written += 1
+            if limit_exceeded:
+                stop_reason = "restart_limit_exceeded"
+                break
+            restart_count += 1
+            if restart_backoff_seconds:
+                sleep_fn(restart_backoff_seconds)
+            continue
+
+        watchdog_exit, watchdog_payload = watchdog_runner(
+            repo_root, artifact_dir, cycle_stamp, cadence_seconds
+        )
+        watchdog_verdict = _extract_verdict(watchdog_payload)
+        if watchdog_exit != 0 or watchdog_verdict == "FAIL":
+            classification, reason_codes, covered = _classify_failure(
+                "watchdog", watchdog_payload, exit_code=watchdog_exit
+            )
+            limit_exceeded = restart_count >= max_restart_count
+            _write_recovery_event(
+                artifact_dir,
+                cycle_stamp=cycle_stamp,
+                failure_source="watchdog",
+                trigger_report_name=str(
+                    (watchdog_payload or {}).get("report_name", "watchdog_report.json")
+                ),
+                trigger_verdict=watchdog_verdict or "FAIL",
+                classification="fatal" if limit_exceeded else classification,
+                reason_codes=reason_codes,
+                covered_report_names=covered,
+                restart_attempted=(
+                    classification == "recoverable" and not limit_exceeded
+                ),
+                restart_count=restart_count + 1,
+                max_restart_count=max_restart_count,
+                backoff_seconds=restart_backoff_seconds,
+                action=(
+                    "restart_cycle"
+                    if classification == "recoverable" and not limit_exceeded
+                    else "stop"
+                ),
+                limit_exceeded=limit_exceeded,
+            )
+            recovery_events_written += 1
+            if classification == "fatal" or limit_exceeded:
+                stop_reason = (
+                    "restart_limit_exceeded"
+                    if limit_exceeded
+                    else "fatal_watchdog_failure"
+                )
+                break
+            restart_count += 1
+            if restart_backoff_seconds:
+                sleep_fn(restart_backoff_seconds)
+            continue
+
+        write_audit_exit, write_audit_payload = write_audit_runner(
+            repo_root, artifact_dir, cycle_stamp
+        )
+        write_audit_verdict = _extract_verdict(write_audit_payload)
+        if write_audit_exit != 0 or write_audit_verdict == "FAIL":
+            classification, reason_codes, covered = _classify_failure(
+                "write_audit", write_audit_payload, exit_code=write_audit_exit
+            )
+            limit_exceeded = restart_count >= max_restart_count
+            _write_recovery_event(
+                artifact_dir,
+                cycle_stamp=cycle_stamp,
+                failure_source="write_audit",
+                trigger_report_name=str(
+                    (write_audit_payload or {}).get(
+                        "report_name", f"write_audit_report_{cycle_stamp}.json"
+                    )
+                ),
+                trigger_verdict=write_audit_verdict or "FAIL",
+                classification="fatal" if limit_exceeded else classification,
+                reason_codes=reason_codes,
+                covered_report_names=covered,
+                restart_attempted=(
+                    classification == "recoverable" and not limit_exceeded
+                ),
+                restart_count=restart_count + 1,
+                max_restart_count=max_restart_count,
+                backoff_seconds=restart_backoff_seconds,
+                action=(
+                    "restart_cycle"
+                    if classification == "recoverable" and not limit_exceeded
+                    else "stop"
+                ),
+                limit_exceeded=limit_exceeded,
+            )
+            recovery_events_written += 1
+            if classification == "fatal" or limit_exceeded:
+                stop_reason = (
+                    "restart_limit_exceeded"
+                    if limit_exceeded
+                    else "fatal_write_audit_failure"
+                )
+                break
+            restart_count += 1
+            if restart_backoff_seconds:
+                sleep_fn(restart_backoff_seconds)
+            continue
+
+        completed_cycles += 1
+        if completed_cycles < iterations:
+            sleep_fn(cadence_seconds)
+
+    final_validation_started = True
+    final_validator(repo_root, artifact_dir)
+
+    status = "PASS" if completed_cycles == iterations and not stop_reason else "FAIL"
+    if not stop_reason and completed_cycles != iterations:
+        stop_reason = "incomplete_cycle_window"
+    return CoordinatorSummary(
+        status=status,
+        artifact_dir=str(artifact_dir),
+        completed_cycles=completed_cycles,
+        recovery_events_written=recovery_events_written,
+        restart_count=restart_count,
+        max_restart_count=max_restart_count,
+        final_validation_started=final_validation_started,
+        stop_reason=stop_reason,
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evidence harvester 72h coordinator with bounded recovery."
+    )
+    parser.add_argument(
+        "--pretty", action="store_true", help="Pretty-print JSON output."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser(
+        "run-fixture-window",
+        help="Run fixture-backed harvester cycles with watchdog/write-audit recovery.",
+    )
+    run_parser.add_argument(
+        "--fixture", type=Path, required=True, help="Collector-input fixture path."
+    )
+    run_parser.add_argument(
+        "--artifact-dir", type=Path, required=True, help="Output artifact directory."
+    )
+    run_parser.add_argument(
+        "--iterations",
+        type=int,
+        required=True,
+        help="Number of successful cycles required.",
+    )
+    run_parser.add_argument(
+        "--cadence-seconds",
+        type=int,
+        default=DEFAULT_CADENCE_SECONDS,
+        help=f"Cycle cadence in seconds (default: {DEFAULT_CADENCE_SECONDS}).",
+    )
+    run_parser.add_argument(
+        "--max-restart-count",
+        type=int,
+        default=DEFAULT_MAX_RESTART_COUNT,
+        help=f"Maximum recoverable restarts (default: {DEFAULT_MAX_RESTART_COUNT}).",
+    )
+    run_parser.add_argument(
+        "--restart-backoff-seconds",
+        type=int,
+        default=DEFAULT_RESTART_BACKOFF_SECONDS,
+        help=f"Backoff between recoverable restarts (default: {DEFAULT_RESTART_BACKOFF_SECONDS}).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.command != "run-fixture-window":
+        raise CoordinatorError(f"Unsupported command: {args.command}")
+    summary = run_fixture_window(
+        repo_root=_repo_root(),
+        fixture_path=args.fixture.resolve(),
+        artifact_dir=args.artifact_dir.resolve(),
+        iterations=args.iterations,
+        cadence_seconds=args.cadence_seconds,
+        max_restart_count=args.max_restart_count,
+        restart_backoff_seconds=args.restart_backoff_seconds,
+    )
+    payload = summary.to_dict()
+    print(
+        json.dumps(
+            payload,
+            indent=2 if args.pretty else None,
+            sort_keys=True,
+            ensure_ascii=True,
+        )
+    )
+    return 0 if summary.status == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/evidence_harvester/ops_validation.py
+++ b/tools/evidence_harvester/ops_validation.py
@@ -12,6 +12,7 @@ from core.utils.clock import utcnow as cdb_utcnow
 
 from .alerts import ALERT_REPORT_SCHEMA_VERSION
 from .boot import BOOT_READINESS_SCHEMA
+from .coordinator import RECOVERY_EVENT_SCHEMA
 from .runner import HEARTBEAT_SCHEMA, STATE_SCHEMA
 from .snapshot import SAFETY_BANNER, SNAPSHOT_SCHEMA_VERSION
 from .write_audit import COLLECTOR_REPORT_SCHEMA, WRITE_AUDIT_REPORT_SCHEMA
@@ -60,6 +61,8 @@ REQUIRED_RUNTIME_ARTIFACTS: tuple[str, ...] = (
     "write_audit_report_<stamp>.md",
     "boot_readiness_report.json",
     "boot_readiness_report.md",
+    "recovery_event_<stamp>.json (optional)",
+    "recovery_event_<stamp>.md (optional)",
     "ops_validation_report.json",
     "ops_validation_report.md",
 )
@@ -197,6 +200,8 @@ def _collect_artifact_paths(artifact_dir: Path) -> dict[str, list[Path]]:
         "write_audit_md": sorted(artifact_dir.glob("write_audit_report_*.md")),
         "boot_json": sorted(artifact_dir.glob("boot_readiness_report*.json")),
         "boot_md": sorted(artifact_dir.glob("boot_readiness_report*.md")),
+        "recovery_events_json": sorted(artifact_dir.glob("recovery_event_*.json")),
+        "recovery_events_md": sorted(artifact_dir.glob("recovery_event_*.md")),
     }
 
 
@@ -237,11 +242,12 @@ def _build_runtime_handoff(
         ),
         start_commands=(
             (
-                "python -m tools.evidence_harvester.runner loop-fixture "
+                "python -m tools.evidence_harvester.coordinator --pretty run-fixture-window "
                 f"--fixture {RUNTIME_SEED_FIXTURE} "
-                f"--output-dir {run_dir} "
+                f"--artifact-dir {run_dir} "
                 f"--iterations {bounded_iterations} "
-                f"--interval-seconds {cadence_seconds} --pretty"
+                f"--cadence-seconds {cadence_seconds} "
+                "--max-restart-count 3 --restart-backoff-seconds 30"
             ),
             (
                 "After each runner cycle, write the latest watchdog report for "
@@ -280,6 +286,7 @@ def _build_runtime_handoff(
         notes=(
             "The 72h validation depends on per-cycle stamped watchdog and write-audit archives.",
             "Keep latest watchdog_report.json/.md current as a compatibility surface for write_audit.py.",
+            "Optional recovery_event_<stamp>.json/.md artifacts are accepted when they are audited and bounded.",
         ),
     )
 
@@ -561,13 +568,143 @@ def _check_boot_payload(
     return ts
 
 
+def _check_recovery_events(
+    payloads: Sequence[tuple[Path, Mapping[str, Any]]],
+    add_finding: Any,
+) -> tuple[set[str], bool]:
+    covered_fail_reports: set[str] = set()
+    restart_limit_exceeded = False
+    if not payloads:
+        return covered_fail_reports, restart_limit_exceeded
+
+    observed_restart_count = 0
+    observed_max_restart_count = 0
+    worst = "pass"
+    for path, payload in payloads:
+        classification = str(payload.get("classification", "")).strip().lower()
+        action = str(payload.get("action", "")).strip().lower()
+        limit_exceeded = bool(payload.get("limit_exceeded", False))
+        restart_count = payload.get("restart_count")
+        max_restart_count = payload.get("max_restart_count")
+        covered = payload.get("covered_report_names", [])
+        reason_codes = payload.get("reason_codes", [])
+
+        if not isinstance(restart_count, int) or restart_count < 0:
+            add_finding(
+                f"{path.name} restart_count",
+                "fail",
+                f"restart_count must be a non-negative integer, got {restart_count!r}",
+                artifact=path.name,
+                field_name="restart_count",
+            )
+            restart_limit_exceeded = True
+            continue
+        if not isinstance(max_restart_count, int) or max_restart_count < 0:
+            add_finding(
+                f"{path.name} max_restart_count",
+                "fail",
+                f"max_restart_count must be a non-negative integer, got {max_restart_count!r}",
+                artifact=path.name,
+                field_name="max_restart_count",
+            )
+            restart_limit_exceeded = True
+            continue
+
+        observed_restart_count = max(observed_restart_count, restart_count)
+        observed_max_restart_count = max(observed_max_restart_count, max_restart_count)
+
+        if classification not in {"recoverable", "fatal"}:
+            add_finding(
+                f"{path.name} recovery classification",
+                "fail",
+                f"Unexpected recovery classification {classification!r}",
+                artifact=path.name,
+                field_name="classification",
+            )
+            restart_limit_exceeded = True
+            continue
+
+        if limit_exceeded or restart_count > max_restart_count:
+            add_finding(
+                f"{path.name} restart limit",
+                "fail",
+                (
+                    f"Recovery restart_count={restart_count} exceeds max_restart_count="
+                    f"{max_restart_count}"
+                ),
+                artifact=path.name,
+                field_name="restart_count",
+            )
+            restart_limit_exceeded = True
+            continue
+
+        if classification == "fatal":
+            add_finding(
+                f"{path.name} fatal recovery event",
+                "fail",
+                f"Fatal recovery event recorded with action={action!r}",
+                artifact=path.name,
+                field_name="classification",
+            )
+            restart_limit_exceeded = True
+            continue
+
+        if not payload.get("audited", False):
+            add_finding(
+                f"{path.name} audited recovery event",
+                "fail",
+                "Recovery event must set audited=true",
+                artifact=path.name,
+                field_name="audited",
+            )
+            restart_limit_exceeded = True
+            continue
+
+        if isinstance(covered, list):
+            covered_fail_reports.update(
+                str(name) for name in covered if str(name).strip()
+            )
+
+        if worst != "fail":
+            worst = "warn"
+        add_finding(
+            f"{path.name} bounded recovery event",
+            "warn",
+            (
+                f"Recoverable event accepted with action={action!r}, restart_count="
+                f"{restart_count}/{max_restart_count}, reasons={list(reason_codes)!r}"
+            ),
+            artifact=path.name,
+        )
+
+    if restart_limit_exceeded:
+        add_finding(
+            "Recovery event history",
+            "fail",
+            "Recovery events exceed configured restart limits or include fatal events",
+        )
+    elif observed_restart_count > 0 or payloads:
+        add_finding(
+            "Recovery event history",
+            "warn",
+            (
+                f"Observed audited recovery events within configured limit "
+                f"{observed_restart_count}/{observed_max_restart_count}"
+            ),
+        )
+    return covered_fail_reports, restart_limit_exceeded
+
+
 def _check_verdict_series(
     label: str,
     payloads: Sequence[tuple[Path, Mapping[str, Any]]],
     add_finding: Any,
+    *,
+    covered_fail_reports: set[str] | None = None,
 ) -> list[datetime]:
     timestamps: list[datetime] = []
     worst: str = "PASS"
+    covered_fail_reports = covered_fail_reports or set()
     for path, payload in payloads:
         try:
             ts = _parse_ts(payload.get("evaluated_at_utc", ""), "evaluated_at_utc")
@@ -583,14 +720,25 @@ def _check_verdict_series(
         verdict = payload.get("verdict", {})
         verdict_value = verdict.get("verdict") if isinstance(verdict, dict) else None
         if verdict_value == "FAIL":
-            worst = "FAIL"
-            add_finding(
-                f"{path.name} {label} verdict",
-                "fail",
-                f"{label} report is FAIL",
-                artifact=path.name,
-                field_name="verdict.verdict",
-            )
+            if path.name in covered_fail_reports:
+                if worst != "FAIL":
+                    worst = "WARN"
+                add_finding(
+                    f"{path.name} {label} verdict",
+                    "warn",
+                    f"{label} report is FAIL but covered by an audited recovery event",
+                    artifact=path.name,
+                    field_name="verdict.verdict",
+                )
+            else:
+                worst = "FAIL"
+                add_finding(
+                    f"{path.name} {label} verdict",
+                    "fail",
+                    f"{label} report is FAIL",
+                    artifact=path.name,
+                    field_name="verdict.verdict",
+                )
         elif verdict_value == "WARN":
             if worst != "FAIL":
                 worst = "WARN"
@@ -956,6 +1104,15 @@ def validate_72h_window(
         artifact_paths.get("boot_md", []),
         add_finding,
     )
+    if artifact_paths.get("recovery_events_json") or artifact_paths.get(
+        "recovery_events_md"
+    ):
+        _check_matching_counts(
+            "Recovery event",
+            artifact_paths.get("recovery_events_json", []),
+            artifact_paths.get("recovery_events_md", []),
+            add_finding,
+        )
 
     collector_payloads = _load_payloads(
         artifact_paths.get("collector_reports", []),
@@ -998,6 +1155,11 @@ def validate_72h_window(
         add_finding,
         expected_schema=BOOT_READINESS_SCHEMA,
     )
+    recovery_event_payloads = _load_payloads(
+        artifact_paths.get("recovery_events_json", []),
+        add_finding,
+        expected_schema=RECOVERY_EVENT_SCHEMA,
+    )
 
     for path, payload in collector_payloads:
         _check_no_side_effects(path, payload, add_finding)
@@ -1039,14 +1201,25 @@ def validate_72h_window(
     for path, payload in state_payloads:
         _check_no_side_effects(path, payload, add_finding)
 
+    recovered_fail_reports, recovery_limit_exceeded = _check_recovery_events(
+        recovery_event_payloads,
+        add_finding,
+    )
+
     watchdog_timestamps = _check_verdict_series(
-        "Watchdog", watchdog_payloads, add_finding
+        "Watchdog",
+        watchdog_payloads,
+        add_finding,
+        covered_fail_reports=recovered_fail_reports,
     )
     for path, payload in watchdog_payloads:
         _check_no_side_effects(path, payload, add_finding)
 
     write_audit_timestamps = _check_verdict_series(
-        "Write-audit", write_audit_payloads, add_finding
+        "Write-audit",
+        write_audit_payloads,
+        add_finding,
+        covered_fail_reports=recovered_fail_reports,
     )
     for path, payload in write_audit_payloads:
         _check_no_side_effects(path, payload, add_finding)
@@ -1070,6 +1243,12 @@ def validate_72h_window(
     _check_count_floor(
         "Write-audit", len(write_audit_payloads), expected_cycles, add_finding
     )
+    if recovery_limit_exceeded:
+        add_finding(
+            "Recovery restart ceiling",
+            "fail",
+            "Recovery restart ceiling was exceeded during the run",
+        )
 
     observed_start, observed_end, observed_hours = _check_window_coverage(
         snapshot_timestamps, required_window_hours, add_finding

--- a/tools/evidence_harvester/watchdog.py
+++ b/tools/evidence_harvester/watchdog.py
@@ -242,6 +242,10 @@ def _check_heartbeat(
 def _check_runner_state(
     state_payload: dict[str, Any] | None,
     artifact_dir_label: str,
+    *,
+    max_age_seconds: int,
+    warn_age_seconds: int,
+    now: datetime,
 ) -> list[WatchdogFinding]:
     findings: list[WatchdogFinding] = []
     if state_payload is None:
@@ -333,6 +337,77 @@ def _check_runner_state(
             )
         )
 
+    last_cycle_raw = state_payload.get("last_cycle_ended_at_utc", "")
+    if last_cycle_raw:
+        try:
+            last_cycle_ts = _parse_ts(last_cycle_raw, "last_cycle_ended_at_utc")
+            age_seconds = (now - last_cycle_ts).total_seconds()
+            if age_seconds > max_age_seconds:
+                findings.append(
+                    WatchdogFinding(
+                        check_id="W016",
+                        check_name="Runner state freshness",
+                        severity="fail",
+                        message=(
+                            f"Runner state is {age_seconds:.0f}s old "
+                            f"(max_age={max_age_seconds}s)"
+                        ),
+                        artifact=artifact_dir_label,
+                        field_name="last_cycle_ended_at_utc",
+                    )
+                )
+            elif age_seconds > warn_age_seconds:
+                findings.append(
+                    WatchdogFinding(
+                        check_id="W016",
+                        check_name="Runner state freshness",
+                        severity="warn",
+                        message=(
+                            f"Runner state is {age_seconds:.0f}s old "
+                            f"(warn_age={warn_age_seconds}s)"
+                        ),
+                        artifact=artifact_dir_label,
+                        field_name="last_cycle_ended_at_utc",
+                    )
+                )
+            else:
+                findings.append(
+                    WatchdogFinding(
+                        check_id="W016",
+                        check_name="Runner state freshness",
+                        severity="pass",
+                        message=(
+                            f"Runner state is {age_seconds:.0f}s old (within limit)"
+                        ),
+                        artifact=artifact_dir_label,
+                        field_name="last_cycle_ended_at_utc",
+                    )
+                )
+        except WatchdogError:
+            findings.append(
+                WatchdogFinding(
+                    check_id="W016",
+                    check_name="Runner state freshness",
+                    severity="fail",
+                    message=(
+                        f"last_cycle_ended_at_utc={last_cycle_raw!r} is not valid ISO-8601"
+                    ),
+                    artifact=artifact_dir_label,
+                    field_name="last_cycle_ended_at_utc",
+                )
+            )
+    else:
+        findings.append(
+            WatchdogFinding(
+                check_id="W016",
+                check_name="Runner state freshness",
+                severity="fail",
+                message="last_cycle_ended_at_utc is missing or empty",
+                artifact=artifact_dir_label,
+                field_name="last_cycle_ended_at_utc",
+            )
+        )
+
     return findings
 
 
@@ -401,6 +476,37 @@ def _check_artifact_integrity(
     findings: list[WatchdogFinding] = []
     json_keys = {"collector_reports", "snapshots_json", "alerts_json"}
 
+    snapshot_payloads: dict[Path, dict[str, Any]] = {}
+    latest_snapshot_name: str | None = None
+    latest_snapshot_ts: datetime | None = None
+
+    for path in artifact_paths.get("snapshots_json", []):
+        artifact_label = f"{artifact_dir_label}/{path.name}"
+        try:
+            payload = _load_json(path)
+        except WatchdogError as exc:
+            findings.append(
+                WatchdogFinding(
+                    check_id="W009",
+                    check_name=f"Artifact parses as JSON: {path.name}",
+                    severity="fail",
+                    message=str(exc),
+                    artifact=artifact_label,
+                )
+            )
+            continue
+        snapshot_payloads[path] = payload
+        generated_at = payload.get("metadata", {}).get("generated_at_utc", "")
+        if not generated_at:
+            continue
+        try:
+            ts = _parse_ts(generated_at, "generated_at_utc")
+        except WatchdogError:
+            continue
+        if latest_snapshot_ts is None or ts > latest_snapshot_ts:
+            latest_snapshot_ts = ts
+            latest_snapshot_name = path.name
+
     for label, paths in artifact_paths.items():
         is_json_artifact = label in json_keys
         for path in paths:
@@ -408,19 +514,24 @@ def _check_artifact_integrity(
             if not is_json_artifact:
                 continue
 
-            try:
-                payload = _load_json(path)
-            except WatchdogError as exc:
-                findings.append(
-                    WatchdogFinding(
-                        check_id="W009",
-                        check_name=f"Artifact parses as JSON: {path.name}",
-                        severity="fail",
-                        message=str(exc),
-                        artifact=artifact_label,
+            if label == "snapshots_json":
+                payload = snapshot_payloads.get(path)
+                if payload is None:
+                    continue
+            else:
+                try:
+                    payload = _load_json(path)
+                except WatchdogError as exc:
+                    findings.append(
+                        WatchdogFinding(
+                            check_id="W009",
+                            check_name=f"Artifact parses as JSON: {path.name}",
+                            severity="fail",
+                            message=str(exc),
+                            artifact=artifact_label,
+                        )
                     )
-                )
-                continue
+                    continue
 
             if label == "snapshots_json":
                 schema_ver = payload.get("metadata", {}).get("schema_version", "")
@@ -442,49 +553,50 @@ def _check_artifact_integrity(
                 if generated_at:
                     try:
                         ts = _parse_ts(generated_at, "generated_at_utc")
-                        age_seconds = (now - ts).total_seconds()
-                        if age_seconds > max_age_seconds:
-                            findings.append(
-                                WatchdogFinding(
-                                    check_id="W011",
-                                    check_name=f"Snapshot freshness: {path.name}",
-                                    severity="fail",
-                                    message=(
-                                        f"Snapshot is {age_seconds:.0f}s old "
-                                        f"(max_age={max_age_seconds}s)"
-                                    ),
-                                    artifact=artifact_label,
-                                    field_name="metadata.generated_at_utc",
+                        if path.name == latest_snapshot_name:
+                            age_seconds = (now - ts).total_seconds()
+                            if age_seconds > max_age_seconds:
+                                findings.append(
+                                    WatchdogFinding(
+                                        check_id="W011",
+                                        check_name=f"Snapshot freshness: {path.name}",
+                                        severity="fail",
+                                        message=(
+                                            f"Latest snapshot is {age_seconds:.0f}s old "
+                                            f"(max_age={max_age_seconds}s)"
+                                        ),
+                                        artifact=artifact_label,
+                                        field_name="metadata.generated_at_utc",
+                                    )
                                 )
-                            )
-                        elif age_seconds > warn_age_seconds:
-                            findings.append(
-                                WatchdogFinding(
-                                    check_id="W011",
-                                    check_name=f"Snapshot freshness: {path.name}",
-                                    severity="warn",
-                                    message=(
-                                        f"Snapshot is {age_seconds:.0f}s old "
-                                        f"(warn_age={warn_age_seconds}s)"
-                                    ),
-                                    artifact=artifact_label,
-                                    field_name="metadata.generated_at_utc",
+                            elif age_seconds > warn_age_seconds:
+                                findings.append(
+                                    WatchdogFinding(
+                                        check_id="W011",
+                                        check_name=f"Snapshot freshness: {path.name}",
+                                        severity="warn",
+                                        message=(
+                                            f"Latest snapshot is {age_seconds:.0f}s old "
+                                            f"(warn_age={warn_age_seconds}s)"
+                                        ),
+                                        artifact=artifact_label,
+                                        field_name="metadata.generated_at_utc",
+                                    )
                                 )
-                            )
-                        else:
-                            findings.append(
-                                WatchdogFinding(
-                                    check_id="W011",
-                                    check_name=f"Snapshot freshness: {path.name}",
-                                    severity="pass",
-                                    message=(
-                                        f"Snapshot is {age_seconds:.0f}s old "
-                                        "(within limit)"
-                                    ),
-                                    artifact=artifact_label,
-                                    field_name="metadata.generated_at_utc",
+                            else:
+                                findings.append(
+                                    WatchdogFinding(
+                                        check_id="W011",
+                                        check_name=f"Snapshot freshness: {path.name}",
+                                        severity="pass",
+                                        message=(
+                                            f"Latest snapshot is {age_seconds:.0f}s old "
+                                            "(within limit)"
+                                        ),
+                                        artifact=artifact_label,
+                                        field_name="metadata.generated_at_utc",
+                                    )
                                 )
-                            )
                     except WatchdogError:
                         findings.append(
                             WatchdogFinding(
@@ -668,7 +780,13 @@ def run_status(
     )
     all_findings.extend(hb_findings)
 
-    state_findings = _check_runner_state(state_payload, artifact_dir_label)
+    state_findings = _check_runner_state(
+        state_payload,
+        artifact_dir_label,
+        max_age_seconds=max_age_seconds,
+        warn_age_seconds=warn_age_seconds,
+        now=eval_now,
+    )
     all_findings.extend(state_findings)
 
     artifact_findings = _check_required_artifacts(
@@ -708,7 +826,8 @@ def run_status(
         f.check_id == "W003" and f.severity == "fail" for f in all_findings
     )
     runner_state_ok = not any(
-        f.check_id == "W006" and f.severity == "fail" for f in all_findings
+        f.check_id in {"W004", "W005", "W006", "W016"} and f.severity == "fail"
+        for f in all_findings
     )
     required_artifacts_present = not any(
         f.check_id == "W008" and f.severity == "fail" for f in all_findings

--- a/tools/evidence_harvester/write_audit.py
+++ b/tools/evidence_harvester/write_audit.py
@@ -597,6 +597,62 @@ def _check_timestamp_coherence(
                     )
                 )
 
+    state_paths = artifact_paths.get("state", [])
+    for state_path in state_paths:
+        try:
+            state_payload = _load_json(state_path)
+        except WriteAuditError:
+            continue
+        last_cycle = state_payload.get("last_cycle_ended_at_utc", "")
+        if last_cycle:
+            try:
+                ts = _parse_ts(last_cycle, "last_cycle_ended_at_utc")
+                age = (now - ts).total_seconds()
+                if age > stale_threshold:
+                    all_coherent = False
+                    findings.append(
+                        WriteAuditFinding(
+                            check_id="A006",
+                            check_name="Timestamp coherence",
+                            severity="fail",
+                            message=(
+                                f"runner_state last_cycle_ended_at_utc is {age:.0f}s old "
+                                f"(threshold {stale_threshold}s)"
+                            ),
+                            artifact=f"{artifact_dir_label}/{state_path.name}",
+                            field_name="last_cycle_ended_at_utc",
+                        )
+                    )
+                elif age > warn_stale:
+                    findings.append(
+                        WriteAuditFinding(
+                            check_id="A006",
+                            check_name="Timestamp coherence",
+                            severity="warn",
+                            message=(
+                                f"runner_state last_cycle_ended_at_utc is {age:.0f}s old "
+                                f"(warn threshold {warn_stale}s)"
+                            ),
+                            artifact=f"{artifact_dir_label}/{state_path.name}",
+                            field_name="last_cycle_ended_at_utc",
+                        )
+                    )
+            except WriteAuditError:
+                all_coherent = False
+                findings.append(
+                    WriteAuditFinding(
+                        check_id="A006",
+                        check_name="Timestamp coherence",
+                        severity="fail",
+                        message=(
+                            "runner_state has invalid "
+                            f"last_cycle_ended_at_utc={last_cycle!r}"
+                        ),
+                        artifact=f"{artifact_dir_label}/{state_path.name}",
+                        field_name="last_cycle_ended_at_utc",
+                    )
+                )
+
     collector_reports = artifact_paths.get("collector_reports", [])
     for cr_path in collector_reports:
         try:
@@ -624,6 +680,8 @@ def _check_timestamp_coherence(
                 )
 
     snapshots = artifact_paths.get("snapshots_json", [])
+    latest_snapshot_path: Path | None = None
+    latest_snapshot_ts: datetime | None = None
     for snap_path in snapshots:
         try:
             snap = _load_json(snap_path)
@@ -633,36 +691,9 @@ def _check_timestamp_coherence(
         if gen_at:
             try:
                 ts = _parse_ts(gen_at, "generated_at_utc")
-                age = (now - ts).total_seconds()
-                if age > stale_threshold:
-                    all_coherent = False
-                    findings.append(
-                        WriteAuditFinding(
-                            check_id="A006",
-                            check_name="Timestamp coherence",
-                            severity="fail",
-                            message=(
-                                f"{snap_path.name} generated_at_utc is {age:.0f}s "
-                                f"old (threshold {stale_threshold}s)"
-                            ),
-                            artifact=f"{artifact_dir_label}/{snap_path.name}",
-                            field_name="metadata.generated_at_utc",
-                        )
-                    )
-                elif age > warn_stale:
-                    findings.append(
-                        WriteAuditFinding(
-                            check_id="A006",
-                            check_name="Timestamp coherence",
-                            severity="warn",
-                            message=(
-                                f"{snap_path.name} generated_at_utc is {age:.0f}s "
-                                f"old (warn threshold {warn_stale}s)"
-                            ),
-                            artifact=f"{artifact_dir_label}/{snap_path.name}",
-                            field_name="metadata.generated_at_utc",
-                        )
-                    )
+                if latest_snapshot_ts is None or ts > latest_snapshot_ts:
+                    latest_snapshot_ts = ts
+                    latest_snapshot_path = snap_path
             except WriteAuditError:
                 all_coherent = False
                 findings.append(
@@ -678,6 +709,38 @@ def _check_timestamp_coherence(
                         field_name="metadata.generated_at_utc",
                     )
                 )
+
+    if latest_snapshot_path is not None and latest_snapshot_ts is not None:
+        age = (now - latest_snapshot_ts).total_seconds()
+        if age > stale_threshold:
+            all_coherent = False
+            findings.append(
+                WriteAuditFinding(
+                    check_id="A006",
+                    check_name="Timestamp coherence",
+                    severity="fail",
+                    message=(
+                        f"latest snapshot {latest_snapshot_path.name} generated_at_utc is "
+                        f"{age:.0f}s old (threshold {stale_threshold}s)"
+                    ),
+                    artifact=f"{artifact_dir_label}/{latest_snapshot_path.name}",
+                    field_name="metadata.generated_at_utc",
+                )
+            )
+        elif age > warn_stale:
+            findings.append(
+                WriteAuditFinding(
+                    check_id="A006",
+                    check_name="Timestamp coherence",
+                    severity="warn",
+                    message=(
+                        f"latest snapshot {latest_snapshot_path.name} generated_at_utc is "
+                        f"{age:.0f}s old (warn threshold {warn_stale}s)"
+                    ),
+                    artifact=f"{artifact_dir_label}/{latest_snapshot_path.name}",
+                    field_name="metadata.generated_at_utc",
+                )
+            )
     if all_coherent:
         findings.append(
             WriteAuditFinding(


### PR DESCRIPTION
## Brain Evidence Block
- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_brain_used: false
- repo_fallback_used: true
- repo_fallback_reason: insufficient_evidence
- context_tool_status: available
- context_trust_level: low
- records_found: none
- repo_crosscheck:
  - AGENTS.md
  - agents/AGENTS.md
  - knowledge/governance/CDB_AGENT_POLICY.md
  - tools/evidence_harvester/watchdog.py
  - tools/evidence_harvester/write_audit.py
  - tools/evidence_harvester/ops_validation.py
  - tools/evidence_harvester/coordinator.py
  - tests/unit/tools/evidence_harvester/*

## Root Cause Analysis from Failed Run `20260619T203907Z`
- Watchdog treated historical snapshots in the long-run artifact directory as freshness failures instead of history.
- Write-audit had the same stale-history semantic risk for snapshot timestamp coherence.
- The coordinator stopped on recoverable watchdog/write-audit FAIL and never resumed progress.
- Independent hourly monitoring confirmed the stall persisted: watchdog stayed FAIL, heartbeat/state stopped advancing after cycle 9, no new artifacts were produced, and ops validation stayed FAIL.

## Failure Reproduction Summary
- The failed run `20260619T203907Z` entered a persistent unhealthy state after cycle 9.
- Repeated follow-up checks showed no new runner progress and no automatic recovery.
- This was systemic, not transient: stale-history semantics and missing recovery logic together prevented the run from resuming.

## Recovery Semantics Summary
- Watchdog freshness now applies only to the latest snapshot, latest heartbeat, and latest runner state.
- Historical snapshots remain parseable/auditable but no longer fail freshness solely because they are old.
- New repo-backed coordinator classifies failures as recoverable vs fatal.
- Recoverable failures trigger bounded restart/backoff and emit audited `recovery_event_<stamp>.json/.md` artifacts.
- Fatal failures still stop immediately for safety-flag violations, live/echtgeld/trading side effects, DB-mutation risk, secrets exposure, and malformed core state.
- Ops validation now accepts bounded audited recovery events and fails if restart limits are exceeded.

## Test Evidence
- `pytest -q tests/unit/tools/evidence_harvester/test_watchdog.py tests/unit/tools/evidence_harvester/test_write_audit.py tests/unit/tools/evidence_harvester/test_ops_validation.py tests/unit/tools/evidence_harvester/test_coordinator.py`
  - `100 passed`
- `ruff check` on touched harvester files: PASS
- `black --check` on touched harvester files: PASS
- Added coverage for:
  - historical snapshots no longer failing freshness
  - stale latest snapshot still failing
  - recoverable coordinator failures restarting and progressing beyond cycle 9
  - fatal safety failures stopping immediately
  - ops validation accepting bounded recovery events and failing on restart-limit overflow

## References
- References #3362
- Parent context: #3345