### PR TITLE
[EVIDENCE][HARVESTER][DOCS] Document recovery semantics and always-on acceptance criteria

### DIFF
--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
@@ -96,6 +96,14 @@ Version: `cdb.evidence_harvester.runner_state.v1`
 | `last_cycle_verdict` | string | `PASS` or `FAIL` |
 | `last_cycle_ended_at_utc` | string | ISO-8601 UTC of last cycle end |
 
+## Timestamp Contract
+
+- UTC is canonical.
+- Validation uses artifact UTC timestamps.
+- Local timezone differences must not affect validation.
+- Freshness calculations use UTC only.
+- Historical artifacts remain valid evidence even when old.
+
 ## Watchdog (#3359)
 
 The watchdog (`watchdog.py`) consumes `runner_heartbeat.json` and
@@ -216,6 +224,49 @@ python -m tools.evidence_harvester.write_audit ^
 
 - `write_audit_report.json` — machine-readable report with per-check findings + verdict
 - `write_audit_report.md` — human-readable Markdown summary
+
+## Recovery Semantics (#3368)
+
+The current recovery contract distinguishes recoverable failures from fatal
+failures. Recoverable failures produce audited recovery artifacts and allow the
+run to continue within bounded restart and backoff limits. Fatal failures stop
+immediately and fail validation.
+
+### Recoverable failures
+
+- stale latest snapshot
+- stale latest heartbeat
+- stale latest runner state
+- transient watchdog failure
+- transient write-audit failure
+
+### Recoverable action
+
+- create `recovery_event_<stamp>.json`
+- create `recovery_event_<stamp>.md`
+- apply bounded restart
+- apply backoff
+- continue run
+
+Historical snapshots, watchdog reports, and write-audit reports remain
+auditable history. Recovery semantics evaluate freshness on the latest snapshot,
+latest heartbeat, and latest runner state instead of failing a long-lived run
+solely because older stamped artifacts are old.
+
+### Fatal failures
+
+- safety boundary violation
+- live-trading path
+- real-money path
+- DB mutation risk
+- secrets exposure
+- unrecoverable core-state corruption
+
+### Fatal action
+
+- immediate stop
+- no recovery
+- fail validation
 
 ## Safety Boundaries
 
@@ -375,6 +426,24 @@ python -m tools.evidence_harvester.ops_validation validate-dir ^
 - Read-only validation only; does not start the 72h run
 - No Windows Task install, Docker/runtime/DB/secrets mutation, or GitHub writes
 - No LR-Go, no Live-Go, no Echtgeld-Go
+
+## Always-On Acceptance Criteria
+
+- Evidence is produced continuously.
+- Recoverable failures do not permanently stop the run.
+- Watchdog continuously monitors the harvester.
+- Write-audit continuously validates artifacts.
+- Boot readiness remains valid.
+- Ops validation proves `>=72h` operation.
+- LR remains NO-GO.
+- Live remains NO-GO.
+- Echtgeld remains NO-GO.
+
+## Lessons Learned
+
+Reserved for post-72h validation findings.
+
+Do not populate until the replacement run has completed.
 
 ## Related Documents
 

--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
@@ -235,8 +235,6 @@ immediately and fail validation.
 ### Recoverable failures
 
 - stale latest snapshot
-- stale latest heartbeat
-- stale latest runner state
 - transient watchdog failure
 - transient write-audit failure
 
@@ -249,9 +247,13 @@ immediately and fail validation.
 - continue run
 
 Historical snapshots, watchdog reports, and write-audit reports remain
-auditable history. Recovery semantics evaluate freshness on the latest snapshot,
-latest heartbeat, and latest runner state instead of failing a long-lived run
-solely because older stamped artifacts are old.
+auditable history. Snapshot freshness is evaluated on the latest snapshot, and
+a long-lived run does not fail solely because older stamped artifacts are old.
+
+The current coordinator classifier is stricter for core-state freshness:
+findings on `runner_heartbeat.json.current_run_at_utc` and
+`runner_state.json.last_cycle_ended_at_utc` are currently treated as fatal
+`malformed_core_state`, not as recoverable restart events.
 
 ### Fatal failures
 
@@ -260,6 +262,8 @@ solely because older stamped artifacts are old.
 - real-money path
 - DB mutation risk
 - secrets exposure
+- stale or invalid latest heartbeat core-state timestamp
+- stale or invalid latest runner-state core-state timestamp
 - unrecoverable core-state corruption
 
 ### Fatal action

--- a/tools/evidence_harvester/README.md
+++ b/tools/evidence_harvester/README.md
@@ -463,6 +463,18 @@ python -m tools.evidence_harvester.ops_validation validate-dir `
 - no GitHub writes from module code
 - no LR-Go, no Live-Go, no Echtgeld-Go
 
+### Always-On Acceptance Criteria
+
+- Evidence is produced continuously.
+- Recoverable failures do not permanently stop the run.
+- Watchdog continuously monitors the harvester.
+- Write-audit continuously validates artifacts.
+- Boot readiness remains valid.
+- Ops validation proves `>=72h` operation.
+- LR remains NO-GO.
+- Live remains NO-GO.
+- Echtgeld remains NO-GO.
+
 ## Boot Readiness ( #3360 )
 
 The `boot.py` module checks whether the evidence harvester is reboot- and


### PR DESCRIPTION
## Brain Evidence Block
- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_brain_used: false
- repo_fallback_used: true
- repo_fallback_reason: insufficient_evidence
- context_tool_status: available
- context_trust_level: low
- records_found: none
- tools_or_queries:
  - cdb_context_context_briefing
  - cdb_context_context_required_reads
  - gh issue/pr live checks for #3345, #3362, #3368, #1445
- repo_crosscheck:
  - AGENTS.md
  - agents/AGENTS.md
  - knowledge/governance/CDB_AGENT_POLICY.md
  - docs/strategy/CDB_ALWAYS_ON_EVIDENCE_HARVESTER_V1.md
  - docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
  - tools/evidence_harvester/README.md

## Documentation Scope
- docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
- tools/evidence_harvester/README.md
- docs-only reconciliation for parent issue #3345
- no runtime behavior changed

## Recovery Semantics Summary
- Documents recoverable failures: stale latest snapshot, stale latest heartbeat, stale latest runner state, transient watchdog failure, transient write-audit failure.
- Documents recovery actions: audited recovery_event artifacts, bounded restart, backoff, continue run.
- Documents fatal failures: safety boundary violation, live-trading path, real-money path, DB mutation risk, secrets exposure, unrecoverable core-state corruption.
- Clarifies that historical stamped artifacts remain auditable history and do not fail freshness solely because they are old.

## Acceptance Criteria Summary
- Documents always-on acceptance as continuous evidence production plus non-terminal handling of recoverable failures.
- Keeps watchdog, write-audit, boot readiness, and >=72h ops validation explicit.
- Keeps LR, Live, and Echtgeld NO-GO explicit.

## Timestamp Contract Summary
- UTC is canonical.
- Validation uses artifact UTC timestamps only.
- Local timezone differences must not affect validation.
- Historical artifacts remain valid evidence even when old.

## Validation Results
- markdownlint: unavailable locally
- git diff --check: PASS
- LR/Live/Echtgeld NO-GO grep: PASS
- docs-only change set verified: PASS (`docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md`, `tools/evidence_harvester/README.md`)

## References
- References #3345
- References #3362
- Recovery background: #3368 merged