### PR TITLE
[EVIDENCE][HARVESTER] Stabilize coordinator lifecycle and run-state telemetry

### DIFF
--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_72H_OPS_VALIDATION.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_72H_OPS_VALIDATION.md
@@ -45,6 +45,7 @@ used only after the real dry run finishes.
 - `snapshot_<stamp>.md`
 - `alert_<stamp>.json`
 - `alert_<stamp>.md`
+- `coordinator_events.jsonl`
 - `runner_heartbeat.json`
 - `runner_state.json`
 - `watchdog_report_<stamp>.json`
@@ -61,7 +62,7 @@ used only after the real dry run finishes.
 ### PASS
 
 - `>=72h` window covered
-- runner continuity evidenced by heartbeat/state counters and stamped cadence history
+- runner continuity evidenced by heartbeat/state counters, coordinator lifecycle telemetry, and stamped cadence history
 - watchdog history PASS or justified WARN
 - write-audit history PASS with no FAIL findings
 - boot-readiness PASS or justified WARN

--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
@@ -60,6 +60,7 @@ Each runner cycle writes to the configured `--output-dir`:
 | `snapshot_<stamp>.md` | Markdown snapshot summary | No (stamped) |
 | `alert_<stamp>.json` | Alert findings | No (stamped) |
 | `alert_<stamp>.md` | Markdown alert summary | No (stamped) |
+| `coordinator_events.jsonl` | Coordinator lifecycle telemetry stream | Yes (append-only for the run) |
 | `runner_heartbeat.json` | Latest cycle metadata | Yes (per cycle) |
 | `runner_state.json` | Cumulative run statistics | Yes (per cycle) |
 
@@ -95,6 +96,31 @@ Version: `cdb.evidence_harvester.runner_state.v1`
 | `failed_runs` | int | Cycles that raised an exception |
 | `last_cycle_verdict` | string | `PASS` or `FAIL` |
 | `last_cycle_ended_at_utc` | string | ISO-8601 UTC of last cycle end |
+| `run_id` | string | Coordinator run identifier |
+| `total_cycles_started` | int | Total coordinator cycle attempts |
+| `total_cycles_completed` | int | Total coordinator cycles completed |
+| `total_successful_cycles` | int | Total completed successful coordinator cycles |
+| `total_failed_cycles` | int | Total failed coordinator cycles |
+| `last_cycle_started_at_utc` | string | ISO-8601 UTC of last cycle start |
+| `next_cycle_due_at_utc` | string | ISO-8601 UTC of the next scheduled cycle while sleeping |
+| `last_successful_artifact_stamp` | string | Stamp of the last successful artifact cycle |
+| `coordinator_status` | string | Coordinator lifecycle status such as `running`, `sleeping`, `recovering`, `final_validation`, `completed`, or `failed` |
+
+## Coordinator Lifecycle Telemetry
+
+Version: `cdb.evidence_harvester.coordinator_event.v1`
+
+`coordinator_events.jsonl` is the canonical coordinator lifecycle stream for
+coordinator-managed runs. Each line is one JSON object with at minimum:
+
+- `schema_version`
+- `event_at_utc`
+- `run_id`
+- `event_type`
+
+When applicable the event also carries `cycle_index`, `artifact_stamp`,
+`verdict`, `next_cycle_due_at_utc`, `recovery_attempt`, `error_classification`,
+and `coordinator_status`.
 
 ## Timestamp Contract
 
@@ -109,6 +135,9 @@ Version: `cdb.evidence_harvester.runner_state.v1`
 The watchdog (`watchdog.py`) consumes `runner_heartbeat.json` and
 `runner_state.json` plus all stamped artifacts to detect stalls, repeated
 failures, missed heartbeats, or stale evidence.
+
+For coordinator-managed runs, Watchdog also treats `coordinator_status=sleeping`
+with a valid future `next_cycle_due_at_utc` as an explicit healthy sleep window.
 
 ### Modes
 

--- a/tests/unit/tools/evidence_harvester/test_coordinator.py
+++ b/tests/unit/tools/evidence_harvester/test_coordinator.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from tools.evidence_harvester.coordinator import (
+    COORDINATOR_EVENT_SCHEMA,
     RECOVERY_EVENT_SCHEMA,
     run_fixture_window,
 )
@@ -72,6 +73,7 @@ def test_recoverable_watchdog_failure_restarts_and_progresses_beyond_cycle9(
 
     cycle_attempts: list[str] = []
     sleep_calls: list[float] = []
+    next_due_samples: list[str] = []
     recovery_injected = {"done": False}
 
     def cycle_runner(
@@ -132,6 +134,15 @@ def test_recoverable_watchdog_failure_restarts_and_progresses_beyond_cycle9(
         )
         return 0, payload
 
+    def sleep_fn(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        state_path = artifact_dir / "runner_state.json"
+        if state_path.exists():
+            payload = json.loads(state_path.read_text(encoding="utf-8"))
+            next_due = str(payload.get("next_cycle_due_at_utc", ""))
+            if next_due:
+                next_due_samples.append(next_due)
+
     summary = run_fixture_window(
         repo_root=tmp_path,
         fixture_path=fixture,
@@ -140,7 +151,7 @@ def test_recoverable_watchdog_failure_restarts_and_progresses_beyond_cycle9(
         cadence_seconds=1,
         max_restart_count=3,
         restart_backoff_seconds=7,
-        sleep_fn=sleep_calls.append,
+        sleep_fn=sleep_fn,
         boot_runner=_pass_boot_runner,
         cycle_runner=cycle_runner,
         watchdog_runner=watchdog_runner,
@@ -154,9 +165,22 @@ def test_recoverable_watchdog_failure_restarts_and_progresses_beyond_cycle9(
     assert summary.restart_count == 1
     assert 7 in sleep_calls
     assert len(cycle_attempts) == 11
+    assert next_due_samples
     assert any(
         "000010Z" in p.name for p in artifact_dir.glob("collector_report_*.json")
     )
+
+    state_payload = json.loads(
+        (artifact_dir / "runner_state.json").read_text(encoding="utf-8")
+    )
+    assert state_payload["run_id"] == artifact_dir.name
+    assert state_payload["total_cycles_started"] == 11
+    assert state_payload["total_cycles_completed"] == 10
+    assert state_payload["total_successful_cycles"] == 10
+    assert state_payload["total_failed_cycles"] == 1
+    assert state_payload["successful_runs"] == 10
+    assert state_payload["failed_runs"] == 1
+    assert state_payload["coordinator_status"] == "completed"
 
     recovery_events = sorted(artifact_dir.glob("recovery_event_*.json"))
     assert len(recovery_events) == 1
@@ -165,6 +189,35 @@ def test_recoverable_watchdog_failure_restarts_and_progresses_beyond_cycle9(
     assert payload["classification"] == "recoverable"
     assert payload["action"] == "restart_cycle"
     assert payload["restart_count"] == 1
+
+    event_lines = (
+        (artifact_dir / "coordinator_events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    )
+    events = [json.loads(line) for line in event_lines]
+    assert events
+    assert all(event["schema_version"] == COORDINATOR_EVENT_SCHEMA for event in events)
+    assert [event["event_at_utc"] for event in events] == sorted(
+        event["event_at_utc"] for event in events
+    )
+    event_types = {event["event_type"] for event in events}
+    assert {
+        "run_started",
+        "boot_readiness_completed",
+        "cycle_started",
+        "runner_cycle_completed",
+        "watchdog_completed",
+        "write_audit_completed",
+        "cycle_completed",
+        "sleep_started",
+        "sleep_completed",
+        "next_cycle_due_at_utc",
+        "recovery_started",
+        "recovery_completed",
+        "final_validation_started",
+        "final_validation_completed",
+    }.issubset(event_types)
 
 
 @pytest.mark.unit
@@ -240,3 +293,11 @@ def test_fatal_safety_failure_stops_without_restart(tmp_path: Path) -> None:
     payload = json.loads(recovery_events[0].read_text(encoding="utf-8"))
     assert payload["classification"] == "fatal"
     assert payload["action"] == "stop"
+
+    events = [
+        json.loads(line)
+        for line in (artifact_dir / "coordinator_events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert any(event["event_type"] == "fatal_stop" for event in events)

--- a/tests/unit/tools/evidence_harvester/test_ops_validation.py
+++ b/tests/unit/tools/evidence_harvester/test_ops_validation.py
@@ -302,7 +302,141 @@ def _state_payload(current_ts: str, runs: int, verdict: str = "PASS") -> dict:
         "failed_runs": 0 if verdict == "PASS" else 1,
         "last_cycle_verdict": verdict,
         "last_cycle_ended_at_utc": current_ts,
+        "run_id": "test-run",
+        "total_cycles_started": runs,
+        "total_cycles_completed": runs if verdict == "PASS" else max(0, runs - 1),
+        "total_successful_cycles": runs if verdict == "PASS" else max(0, runs - 1),
+        "total_failed_cycles": 0 if verdict == "PASS" else 1,
+        "last_cycle_started_at_utc": current_ts,
+        "next_cycle_due_at_utc": "",
+        "last_successful_artifact_stamp": "20260619T000000Z",
+        "coordinator_status": "completed" if verdict == "PASS" else "failed",
     }
+
+
+def _write_coordinator_events(artifact_dir: Path, times: list[datetime]) -> None:
+    run_id = artifact_dir.name or "test-run"
+    events: list[dict] = []
+    events.append(
+        {
+            "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+            "event_at_utc": _ts(times[0] - timedelta(seconds=30)),
+            "run_id": run_id,
+            "event_type": "run_started",
+        }
+    )
+    events.append(
+        {
+            "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+            "event_at_utc": _ts(times[0] - timedelta(seconds=20)),
+            "run_id": run_id,
+            "event_type": "boot_readiness_completed",
+            "verdict": "PASS",
+        }
+    )
+    for index, ts in enumerate(times, start=1):
+        stamp = _stamp(ts)
+        events.extend(
+            [
+                {
+                    "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+                    "event_at_utc": _ts(ts - timedelta(seconds=10)),
+                    "run_id": run_id,
+                    "event_type": "cycle_started",
+                    "cycle_index": index,
+                },
+                {
+                    "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+                    "event_at_utc": _ts(ts - timedelta(seconds=8)),
+                    "run_id": run_id,
+                    "event_type": "runner_cycle_completed",
+                    "cycle_index": index,
+                    "artifact_stamp": stamp,
+                    "verdict": "PASS",
+                },
+                {
+                    "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+                    "event_at_utc": _ts(ts - timedelta(seconds=6)),
+                    "run_id": run_id,
+                    "event_type": "watchdog_completed",
+                    "cycle_index": index,
+                    "artifact_stamp": stamp,
+                    "verdict": "PASS",
+                },
+                {
+                    "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+                    "event_at_utc": _ts(ts - timedelta(seconds=4)),
+                    "run_id": run_id,
+                    "event_type": "write_audit_completed",
+                    "cycle_index": index,
+                    "artifact_stamp": stamp,
+                    "verdict": "PASS",
+                },
+                {
+                    "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+                    "event_at_utc": _ts(ts - timedelta(seconds=2)),
+                    "run_id": run_id,
+                    "event_type": "cycle_completed",
+                    "cycle_index": index,
+                    "artifact_stamp": stamp,
+                    "verdict": "PASS",
+                },
+            ]
+        )
+        if index < len(times):
+            due_at = ts + timedelta(seconds=3600)
+            events.extend(
+                [
+                    {
+                        "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+                        "event_at_utc": _ts(ts - timedelta(seconds=1)),
+                        "run_id": run_id,
+                        "event_type": "next_cycle_due_at_utc",
+                        "cycle_index": index,
+                        "artifact_stamp": stamp,
+                        "next_cycle_due_at_utc": _ts(due_at),
+                    },
+                    {
+                        "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+                        "event_at_utc": _ts(ts),
+                        "run_id": run_id,
+                        "event_type": "sleep_started",
+                        "cycle_index": index,
+                        "artifact_stamp": stamp,
+                        "next_cycle_due_at_utc": _ts(due_at),
+                    },
+                    {
+                        "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+                        "event_at_utc": _ts(ts + timedelta(seconds=1)),
+                        "run_id": run_id,
+                        "event_type": "sleep_completed",
+                        "cycle_index": index,
+                        "artifact_stamp": stamp,
+                        "next_cycle_due_at_utc": _ts(due_at),
+                    },
+                ]
+            )
+    events.extend(
+        [
+            {
+                "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+                "event_at_utc": _ts(times[-1] + timedelta(seconds=10)),
+                "run_id": run_id,
+                "event_type": "final_validation_started",
+            },
+            {
+                "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+                "event_at_utc": _ts(times[-1] + timedelta(seconds=11)),
+                "run_id": run_id,
+                "event_type": "final_validation_completed",
+                "verdict": "PASS",
+            },
+        ]
+    )
+    (artifact_dir / "coordinator_events.jsonl").write_text(
+        "\n".join(json.dumps(event, sort_keys=True) for event in events) + "\n",
+        encoding="utf-8",
+    )
 
 
 def _stamp(ts: datetime) -> str:
@@ -363,6 +497,7 @@ def _write_valid_run(
         artifact_dir / "runner_state.json",
         _state_payload(final_ts, len(times), "PASS"),
     )
+    _write_coordinator_events(artifact_dir, times)
     _write_json(
         artifact_dir / "boot_readiness_report.json",
         _boot_payload(final_ts, boot_verdict),
@@ -382,7 +517,21 @@ class TestValidate72hWindowFromDir:
         )
         assert report.summary.verdict == "PASS"
         assert report.required_window_hours == 2
+        assert report.observed_counts["coordinator_events"] == 1
         assert report.observed_counts["watchdog_json"] == 3
+
+    @pytest.mark.unit
+    def test_fail_on_missing_coordinator_lifecycle(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        (tmp_path / "coordinator_events.jsonl").unlink()
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert report.summary.verdict == "FAIL"
+        assert any("coordinator_events.jsonl" in f.message for f in report.findings)
 
     @pytest.mark.unit
     def test_fail_on_short_window(self, tmp_path: Path) -> None:
@@ -587,6 +736,7 @@ class TestValidate72hWindowFromDir:
         _write_json(
             tmp_path / "runner_state.json", _state_payload(final_ts, len(times))
         )
+        _write_coordinator_events(tmp_path, times)
         _write_json(tmp_path / "boot_readiness_report.json", _boot_payload(final_ts))
         _write_text(tmp_path / "boot_readiness_report.md")
         report = validate_72h_window_from_dir(
@@ -627,6 +777,7 @@ class TestValidate72hWindowFromDir:
         _write_json(
             tmp_path / "runner_state.json", _state_payload(final_ts, len(times))
         )
+        _write_coordinator_events(tmp_path, times)
         _write_json(tmp_path / "boot_readiness_report.json", _boot_payload(final_ts))
         _write_text(tmp_path / "boot_readiness_report.md")
         report = validate_72h_window_from_dir(

--- a/tests/unit/tools/evidence_harvester/test_watchdog.py
+++ b/tests/unit/tools/evidence_harvester/test_watchdog.py
@@ -65,6 +65,8 @@ def _write_state(
     failed_runs: int = 0,
     last_verdict: str = "PASS",
     age_minutes: int = 1,
+    coordinator_status: str = "",
+    next_cycle_due_at_utc: str = "",
 ) -> Path:
     payload = {
         "schema_version": "cdb.evidence_harvester.runner_state.v1",
@@ -73,6 +75,15 @@ def _write_state(
         "failed_runs": failed_runs,
         "last_cycle_verdict": last_verdict,
         "last_cycle_ended_at_utc": _ts(age_minutes),
+        "run_id": "test-run",
+        "total_cycles_started": total_runs,
+        "total_cycles_completed": successful_runs,
+        "total_successful_cycles": successful_runs,
+        "total_failed_cycles": failed_runs,
+        "last_cycle_started_at_utc": _ts(age_minutes + 1),
+        "next_cycle_due_at_utc": next_cycle_due_at_utc,
+        "last_successful_artifact_stamp": "20260619T000000Z",
+        "coordinator_status": coordinator_status,
     }
     path = artifact_dir / "runner_state.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
@@ -370,6 +381,26 @@ def test_status_warn_on_failed_runs(tmp_path: Path) -> None:
 
     assert report.verdict.verdict == "WARN"
     assert report.runner_state_ok is True
+
+
+@pytest.mark.unit
+def test_status_pass_when_coordinator_sleep_schedule_is_healthy(tmp_path: Path) -> None:
+    d = _write_artifact_dir(tmp_path)
+    due_at = (
+        (datetime.now(UTC) + timedelta(minutes=10)).isoformat().replace("+00:00", "Z")
+    )
+    _write_state(
+        d,
+        age_minutes=1,
+        coordinator_status="sleeping",
+        next_cycle_due_at_utc=due_at,
+    )
+    now = datetime.now(UTC)
+
+    report = run_status(d, now=now)
+
+    assert report.verdict.verdict == "PASS"
+    assert any(f.check_id == "W017" and f.severity == "pass" for f in report.findings)
 
 
 # ============================================================

--- a/tools/evidence_harvester/README.md
+++ b/tools/evidence_harvester/README.md
@@ -246,8 +246,9 @@ Each cycle produces:
 - `snapshot_<stamp>.md` — Markdown snapshot summary
 - `alert_<stamp>.json` — alert findings
 - `alert_<stamp>.md` — Markdown alert summary
+- `coordinator_events.jsonl` — canonical coordinator lifecycle event stream
 - `runner_heartbeat.json` — latest cycle metadata (overwritten each cycle)
-- `runner_state.json` — cumulative run statistics (overwritten each cycle)
+- `runner_state.json` — cumulative run statistics plus coordinator-managed lifecycle state (overwritten each cycle)
 
 ### Safety boundaries
 
@@ -304,8 +305,8 @@ python -m tools.evidence_harvester.watchdog render-escalation-draft `
 | Verdict | Conditions |
 |---------|-----------|
 | PASS    | Heartbeat fresh, state reports PASS, required artifacts exist, all JSON parses, safety flags correct |
-| WARN    | Artifact age near threshold, last run had failures, optional artifact missing |
-| FAIL    | Heartbeat stale, state missing, required artifact missing, malformed JSON, runner FAIL verdict, wrong safety flags |
+| WARN    | Artifact age near threshold, last run had failures, optional artifact missing, next cycle due slightly exceeded |
+| FAIL    | Heartbeat stale, state missing, required artifact missing, malformed JSON, runner FAIL verdict, wrong safety flags, or sleeping schedule exceeded beyond tolerance |
 
 ### Safety boundaries
 

--- a/tools/evidence_harvester/coordinator.py
+++ b/tools/evidence_harvester/coordinator.py
@@ -13,6 +13,9 @@ from typing import Any, Callable, Mapping
 
 from core.utils.clock import utcnow as cdb_utcnow
 
+from .runner import RunnerState
+
+COORDINATOR_EVENT_SCHEMA = "cdb.evidence_harvester.coordinator_event.v1"
 RECOVERY_EVENT_SCHEMA = "cdb.evidence_harvester.recovery_event.v1"
 
 DEFAULT_MAX_RESTART_COUNT = 3
@@ -104,6 +107,125 @@ def _latest_cycle_stamp(artifact_dir: Path) -> str:
         raise CoordinatorError("No collector_report_*.json found to derive cycle stamp")
     latest = reports[-1].stem
     return latest.removeprefix("collector_report_")
+
+
+def _coordinator_events_path(artifact_dir: Path) -> Path:
+    return artifact_dir / "coordinator_events.jsonl"
+
+
+def _derive_run_id(artifact_dir: Path) -> str:
+    name = artifact_dir.name.strip()
+    return name or _event_stamp()
+
+
+def _read_runner_state(artifact_dir: Path) -> RunnerState | None:
+    path = artifact_dir / "runner_state.json"
+    if not path.exists():
+        return None
+    payload = _load_json(path)
+    string_fields = {
+        "schema_version",
+        "last_cycle_verdict",
+        "last_cycle_ended_at_utc",
+        "run_id",
+        "last_cycle_started_at_utc",
+        "next_cycle_due_at_utc",
+        "last_successful_artifact_stamp",
+        "coordinator_status",
+    }
+    return RunnerState(
+        **{
+            field: payload.get(field, "" if field in string_fields else 0)
+            for field in RunnerState.__dataclass_fields__
+        }
+    )
+
+
+def _seed_runner_state(artifact_dir: Path, run_id: str) -> RunnerState:
+    existing = _read_runner_state(artifact_dir)
+    if existing is None:
+        return RunnerState(run_id=run_id)
+    if existing.run_id and existing.run_id != run_id:
+        return RunnerState(run_id=run_id)
+    return RunnerState(
+        schema_version=existing.schema_version,
+        total_runs=existing.total_runs,
+        successful_runs=existing.successful_runs,
+        failed_runs=existing.failed_runs,
+        last_cycle_verdict=existing.last_cycle_verdict,
+        last_cycle_ended_at_utc=existing.last_cycle_ended_at_utc,
+        run_id=existing.run_id or run_id,
+        total_cycles_started=existing.total_cycles_started,
+        total_cycles_completed=existing.total_cycles_completed,
+        total_successful_cycles=existing.total_successful_cycles,
+        total_failed_cycles=existing.total_failed_cycles,
+        last_cycle_started_at_utc=existing.last_cycle_started_at_utc,
+        next_cycle_due_at_utc=existing.next_cycle_due_at_utc,
+        last_successful_artifact_stamp=existing.last_successful_artifact_stamp,
+        coordinator_status=existing.coordinator_status,
+    )
+
+
+def _write_runner_state(artifact_dir: Path, state: RunnerState) -> None:
+    (artifact_dir / "runner_state.json").write_text(
+        json.dumps(state.to_dict(), indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _update_runner_state(
+    state: RunnerState,
+    **changes: Any,
+) -> RunnerState:
+    payload = state.to_dict()
+    payload.update(changes)
+    payload["total_runs"] = payload.get("total_cycles_started", payload["total_runs"])
+    payload["successful_runs"] = payload.get(
+        "total_successful_cycles", payload["successful_runs"]
+    )
+    payload["failed_runs"] = payload.get("total_failed_cycles", payload["failed_runs"])
+    return RunnerState(**payload)
+
+
+def _write_coordinator_event(
+    artifact_dir: Path,
+    *,
+    run_id: str,
+    event_type: str,
+    cycle_index: int | None = None,
+    artifact_stamp: str = "",
+    verdict: str = "",
+    next_cycle_due_at_utc: str = "",
+    recovery_attempt: int | None = None,
+    error_classification: str = "",
+    coordinator_status: str = "",
+    stop_reason: str = "",
+) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "schema_version": COORDINATOR_EVENT_SCHEMA,
+        "event_at_utc": _format_ts(_now_utc()),
+        "run_id": run_id,
+        "event_type": event_type,
+    }
+    if cycle_index is not None:
+        event["cycle_index"] = cycle_index
+    if artifact_stamp:
+        event["artifact_stamp"] = artifact_stamp
+    if verdict:
+        event["verdict"] = verdict
+    if next_cycle_due_at_utc:
+        event["next_cycle_due_at_utc"] = next_cycle_due_at_utc
+    if recovery_attempt is not None:
+        event["recovery_attempt"] = recovery_attempt
+    if error_classification:
+        event["error_classification"] = error_classification
+    if coordinator_status:
+        event["coordinator_status"] = coordinator_status
+    if stop_reason:
+        event["stop_reason"] = stop_reason
+    with _coordinator_events_path(artifact_dir).open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, sort_keys=True, ensure_ascii=True) + "\n")
+    return event
 
 
 def _extract_verdict(payload: Mapping[str, Any] | None) -> str:
@@ -450,15 +572,51 @@ def run_fixture_window(
     if not fixture_path.exists():
         raise CoordinatorError(f"fixture path does not exist: {fixture_path}")
 
+    run_id = _derive_run_id(artifact_dir)
     recovery_events_written = 0
     restart_count = 0
     completed_cycles = 0
     final_validation_started = False
     stop_reason = ""
+    state = _seed_runner_state(artifact_dir, run_id)
+
+    _write_coordinator_event(
+        artifact_dir,
+        run_id=run_id,
+        event_type="run_started",
+        coordinator_status="starting",
+    )
+    state = _update_runner_state(state, run_id=run_id, coordinator_status="starting")
+    _write_runner_state(artifact_dir, state)
 
     boot_exit, boot_payload = boot_runner(repo_root, artifact_dir)
+    boot_verdict = _extract_verdict(boot_payload) or (
+        "PASS" if boot_exit == 0 else "FAIL"
+    )
+    _write_coordinator_event(
+        artifact_dir,
+        run_id=run_id,
+        event_type="boot_readiness_completed",
+        verdict=boot_verdict,
+        coordinator_status="boot_checked",
+    )
     if boot_exit != 0 or _extract_verdict(boot_payload) == "FAIL":
         stop_reason = "boot_readiness_failed"
+        state = _update_runner_state(
+            state,
+            coordinator_status="fatal_stop",
+            last_cycle_verdict="FAIL",
+        )
+        _write_runner_state(artifact_dir, state)
+        _write_coordinator_event(
+            artifact_dir,
+            run_id=run_id,
+            event_type="fatal_stop",
+            verdict="FAIL",
+            error_classification="boot_readiness_failed",
+            coordinator_status="fatal_stop",
+            stop_reason=stop_reason,
+        )
         return CoordinatorSummary(
             status="FAIL",
             artifact_dir=str(artifact_dir),
@@ -471,12 +629,51 @@ def run_fixture_window(
         )
 
     while completed_cycles < iterations:
+        cycle_index = state.total_cycles_started + 1
+        cycle_started_at = _format_ts(_now_utc())
+        state = _update_runner_state(
+            state,
+            total_cycles_started=cycle_index,
+            total_runs=cycle_index,
+            last_cycle_started_at_utc=cycle_started_at,
+            next_cycle_due_at_utc="",
+            coordinator_status="running",
+        )
+        _write_runner_state(artifact_dir, state)
+        _write_coordinator_event(
+            artifact_dir,
+            run_id=run_id,
+            event_type="cycle_started",
+            cycle_index=cycle_index,
+            coordinator_status="running",
+        )
         runner_exit, cycle_stamp = cycle_runner(repo_root, fixture_path, artifact_dir)
         if runner_exit != 0:
             classification, reason_codes, covered = _classify_failure(
                 "runner", None, exit_code=runner_exit
             )
             limit_exceeded = restart_count >= max_restart_count
+            cycle_ended_at = _format_ts(_now_utc())
+            state = _update_runner_state(
+                state,
+                total_failed_cycles=state.total_failed_cycles + 1,
+                failed_runs=state.total_failed_cycles + 1,
+                last_cycle_verdict="FAIL",
+                last_cycle_ended_at_utc=cycle_ended_at,
+                coordinator_status="recovering" if not limit_exceeded else "fatal_stop",
+            )
+            _write_runner_state(artifact_dir, state)
+            _write_coordinator_event(
+                artifact_dir,
+                run_id=run_id,
+                event_type="recovery_started",
+                cycle_index=cycle_index,
+                artifact_stamp=cycle_stamp if cycle_stamp else "",
+                verdict="FAIL",
+                recovery_attempt=restart_count + 1,
+                error_classification=classification,
+                coordinator_status=state.coordinator_status,
+            )
             _write_recovery_event(
                 artifact_dir,
                 cycle_stamp=cycle_stamp if cycle_stamp else _event_stamp(),
@@ -494,23 +691,89 @@ def run_fixture_window(
                 limit_exceeded=limit_exceeded,
             )
             recovery_events_written += 1
+            _write_coordinator_event(
+                artifact_dir,
+                run_id=run_id,
+                event_type="recovery_completed",
+                cycle_index=cycle_index,
+                artifact_stamp=cycle_stamp if cycle_stamp else "",
+                verdict="FAIL",
+                recovery_attempt=restart_count + 1,
+                error_classification="fatal" if limit_exceeded else classification,
+                coordinator_status="fatal_stop" if limit_exceeded else "recovering",
+            )
             if limit_exceeded:
                 stop_reason = "restart_limit_exceeded"
+                _write_coordinator_event(
+                    artifact_dir,
+                    run_id=run_id,
+                    event_type="fatal_stop",
+                    cycle_index=cycle_index,
+                    artifact_stamp=cycle_stamp if cycle_stamp else "",
+                    verdict="FAIL",
+                    error_classification="restart_limit_exceeded",
+                    coordinator_status="fatal_stop",
+                    stop_reason=stop_reason,
+                )
                 break
             restart_count += 1
             if restart_backoff_seconds:
                 sleep_fn(restart_backoff_seconds)
             continue
 
+        _write_coordinator_event(
+            artifact_dir,
+            run_id=run_id,
+            event_type="runner_cycle_completed",
+            cycle_index=cycle_index,
+            artifact_stamp=cycle_stamp,
+            verdict="PASS",
+            coordinator_status="running",
+        )
+
         watchdog_exit, watchdog_payload = watchdog_runner(
             repo_root, artifact_dir, cycle_stamp, cadence_seconds
         )
         watchdog_verdict = _extract_verdict(watchdog_payload)
+        _write_coordinator_event(
+            artifact_dir,
+            run_id=run_id,
+            event_type="watchdog_completed",
+            cycle_index=cycle_index,
+            artifact_stamp=cycle_stamp,
+            verdict=watchdog_verdict or ("PASS" if watchdog_exit == 0 else "FAIL"),
+            coordinator_status="running",
+        )
         if watchdog_exit != 0 or watchdog_verdict == "FAIL":
             classification, reason_codes, covered = _classify_failure(
                 "watchdog", watchdog_payload, exit_code=watchdog_exit
             )
             limit_exceeded = restart_count >= max_restart_count
+            cycle_ended_at = _format_ts(_now_utc())
+            state = _update_runner_state(
+                state,
+                total_failed_cycles=state.total_failed_cycles + 1,
+                failed_runs=state.total_failed_cycles + 1,
+                last_cycle_verdict="FAIL",
+                last_cycle_ended_at_utc=cycle_ended_at,
+                coordinator_status=(
+                    "recovering"
+                    if classification == "recoverable" and not limit_exceeded
+                    else "fatal_stop"
+                ),
+            )
+            _write_runner_state(artifact_dir, state)
+            _write_coordinator_event(
+                artifact_dir,
+                run_id=run_id,
+                event_type="recovery_started",
+                cycle_index=cycle_index,
+                artifact_stamp=cycle_stamp,
+                verdict=watchdog_verdict or "FAIL",
+                recovery_attempt=restart_count + 1,
+                error_classification=classification,
+                coordinator_status=state.coordinator_status,
+            )
             _write_recovery_event(
                 artifact_dir,
                 cycle_stamp=cycle_stamp,
@@ -536,11 +799,37 @@ def run_fixture_window(
                 limit_exceeded=limit_exceeded,
             )
             recovery_events_written += 1
+            _write_coordinator_event(
+                artifact_dir,
+                run_id=run_id,
+                event_type="recovery_completed",
+                cycle_index=cycle_index,
+                artifact_stamp=cycle_stamp,
+                verdict=watchdog_verdict or "FAIL",
+                recovery_attempt=restart_count + 1,
+                error_classification="fatal" if limit_exceeded else classification,
+                coordinator_status=state.coordinator_status,
+            )
             if classification == "fatal" or limit_exceeded:
                 stop_reason = (
                     "restart_limit_exceeded"
                     if limit_exceeded
                     else "fatal_watchdog_failure"
+                )
+                _write_coordinator_event(
+                    artifact_dir,
+                    run_id=run_id,
+                    event_type="fatal_stop",
+                    cycle_index=cycle_index,
+                    artifact_stamp=cycle_stamp,
+                    verdict=watchdog_verdict or "FAIL",
+                    error_classification=(
+                        "restart_limit_exceeded"
+                        if limit_exceeded
+                        else "fatal_watchdog_failure"
+                    ),
+                    coordinator_status="fatal_stop",
+                    stop_reason=stop_reason,
                 )
                 break
             restart_count += 1
@@ -552,11 +841,47 @@ def run_fixture_window(
             repo_root, artifact_dir, cycle_stamp
         )
         write_audit_verdict = _extract_verdict(write_audit_payload)
+        _write_coordinator_event(
+            artifact_dir,
+            run_id=run_id,
+            event_type="write_audit_completed",
+            cycle_index=cycle_index,
+            artifact_stamp=cycle_stamp,
+            verdict=(
+                write_audit_verdict or ("PASS" if write_audit_exit == 0 else "FAIL")
+            ),
+            coordinator_status="running",
+        )
         if write_audit_exit != 0 or write_audit_verdict == "FAIL":
             classification, reason_codes, covered = _classify_failure(
                 "write_audit", write_audit_payload, exit_code=write_audit_exit
             )
             limit_exceeded = restart_count >= max_restart_count
+            cycle_ended_at = _format_ts(_now_utc())
+            state = _update_runner_state(
+                state,
+                total_failed_cycles=state.total_failed_cycles + 1,
+                failed_runs=state.total_failed_cycles + 1,
+                last_cycle_verdict="FAIL",
+                last_cycle_ended_at_utc=cycle_ended_at,
+                coordinator_status=(
+                    "recovering"
+                    if classification == "recoverable" and not limit_exceeded
+                    else "fatal_stop"
+                ),
+            )
+            _write_runner_state(artifact_dir, state)
+            _write_coordinator_event(
+                artifact_dir,
+                run_id=run_id,
+                event_type="recovery_started",
+                cycle_index=cycle_index,
+                artifact_stamp=cycle_stamp,
+                verdict=write_audit_verdict or "FAIL",
+                recovery_attempt=restart_count + 1,
+                error_classification=classification,
+                coordinator_status=state.coordinator_status,
+            )
             _write_recovery_event(
                 artifact_dir,
                 cycle_stamp=cycle_stamp,
@@ -584,11 +909,37 @@ def run_fixture_window(
                 limit_exceeded=limit_exceeded,
             )
             recovery_events_written += 1
+            _write_coordinator_event(
+                artifact_dir,
+                run_id=run_id,
+                event_type="recovery_completed",
+                cycle_index=cycle_index,
+                artifact_stamp=cycle_stamp,
+                verdict=write_audit_verdict or "FAIL",
+                recovery_attempt=restart_count + 1,
+                error_classification="fatal" if limit_exceeded else classification,
+                coordinator_status=state.coordinator_status,
+            )
             if classification == "fatal" or limit_exceeded:
                 stop_reason = (
                     "restart_limit_exceeded"
                     if limit_exceeded
                     else "fatal_write_audit_failure"
+                )
+                _write_coordinator_event(
+                    artifact_dir,
+                    run_id=run_id,
+                    event_type="fatal_stop",
+                    cycle_index=cycle_index,
+                    artifact_stamp=cycle_stamp,
+                    verdict=write_audit_verdict or "FAIL",
+                    error_classification=(
+                        "restart_limit_exceeded"
+                        if limit_exceeded
+                        else "fatal_write_audit_failure"
+                    ),
+                    coordinator_status="fatal_stop",
+                    stop_reason=stop_reason,
                 )
                 break
             restart_count += 1
@@ -597,15 +948,102 @@ def run_fixture_window(
             continue
 
         completed_cycles += 1
+        cycle_ended_at = _format_ts(_now_utc())
+        state = _update_runner_state(
+            state,
+            total_cycles_completed=completed_cycles,
+            total_successful_cycles=state.total_successful_cycles + 1,
+            successful_runs=state.total_successful_cycles + 1,
+            last_cycle_verdict="PASS",
+            last_cycle_ended_at_utc=cycle_ended_at,
+            last_successful_artifact_stamp=cycle_stamp,
+            coordinator_status="cycle_completed",
+        )
+        _write_runner_state(artifact_dir, state)
+        _write_coordinator_event(
+            artifact_dir,
+            run_id=run_id,
+            event_type="cycle_completed",
+            cycle_index=cycle_index,
+            artifact_stamp=cycle_stamp,
+            verdict="PASS",
+            coordinator_status="cycle_completed",
+        )
         if completed_cycles < iterations:
+            next_due_at = _format_ts(
+                datetime.fromtimestamp(_now_utc().timestamp() + cadence_seconds, tz=UTC)
+            )
+            state = _update_runner_state(
+                state,
+                next_cycle_due_at_utc=next_due_at,
+                coordinator_status="sleeping",
+            )
+            _write_runner_state(artifact_dir, state)
+            _write_coordinator_event(
+                artifact_dir,
+                run_id=run_id,
+                event_type="next_cycle_due_at_utc",
+                cycle_index=cycle_index,
+                artifact_stamp=cycle_stamp,
+                next_cycle_due_at_utc=next_due_at,
+                coordinator_status="sleeping",
+            )
+            _write_coordinator_event(
+                artifact_dir,
+                run_id=run_id,
+                event_type="sleep_started",
+                cycle_index=cycle_index,
+                artifact_stamp=cycle_stamp,
+                next_cycle_due_at_utc=next_due_at,
+                coordinator_status="sleeping",
+            )
             sleep_fn(cadence_seconds)
+            _write_coordinator_event(
+                artifact_dir,
+                run_id=run_id,
+                event_type="sleep_completed",
+                cycle_index=cycle_index,
+                artifact_stamp=cycle_stamp,
+                next_cycle_due_at_utc=next_due_at,
+                coordinator_status="sleeping",
+            )
 
     final_validation_started = True
-    final_validator(repo_root, artifact_dir)
+    state = _update_runner_state(
+        state,
+        next_cycle_due_at_utc="",
+        coordinator_status="final_validation",
+    )
+    _write_runner_state(artifact_dir, state)
+    _write_coordinator_event(
+        artifact_dir,
+        run_id=run_id,
+        event_type="final_validation_started",
+        coordinator_status="final_validation",
+    )
+    final_validation_exit, final_validation_payload = final_validator(
+        repo_root, artifact_dir
+    )
+    final_validation_verdict = _extract_verdict(final_validation_payload) or (
+        "PASS" if final_validation_exit == 0 else "FAIL"
+    )
+    _write_coordinator_event(
+        artifact_dir,
+        run_id=run_id,
+        event_type="final_validation_completed",
+        verdict=final_validation_verdict,
+        coordinator_status="final_validation",
+    )
 
     status = "PASS" if completed_cycles == iterations and not stop_reason else "FAIL"
     if not stop_reason and completed_cycles != iterations:
         stop_reason = "incomplete_cycle_window"
+    state = _update_runner_state(
+        state,
+        next_cycle_due_at_utc="",
+        coordinator_status="completed" if status == "PASS" else "failed",
+    )
+    _write_runner_state(artifact_dir, state)
     return CoordinatorSummary(
         status=status,
         artifact_dir=str(artifact_dir),

--- a/tools/evidence_harvester/ops_validation.py
+++ b/tools/evidence_harvester/ops_validation.py
@@ -37,6 +37,7 @@ REQUIRED_ARTIFACT_RULES: dict[str, str] = {
     "snapshots_md": "snapshot_*.md",
     "alerts_json": "alert_*.json",
     "alerts_md": "alert_*.md",
+    "coordinator_events": "coordinator_events.jsonl",
     "heartbeat": "runner_heartbeat.json",
     "state": "runner_state.json",
     "watchdog_json": "watchdog_report_*.json",
@@ -53,6 +54,7 @@ REQUIRED_RUNTIME_ARTIFACTS: tuple[str, ...] = (
     "snapshot_<stamp>.md",
     "alert_<stamp>.json",
     "alert_<stamp>.md",
+    "coordinator_events.jsonl",
     "runner_heartbeat.json",
     "runner_state.json",
     "watchdog_report_<stamp>.json",
@@ -184,6 +186,11 @@ def _collect_artifact_paths(artifact_dir: Path) -> dict[str, list[Path]]:
         "snapshots_md": sorted(artifact_dir.glob("snapshot_*.md")),
         "alerts_json": sorted(artifact_dir.glob("alert_*.json")),
         "alerts_md": sorted(artifact_dir.glob("alert_*.md")),
+        "coordinator_events": (
+            [artifact_dir / "coordinator_events.jsonl"]
+            if (artifact_dir / "coordinator_events.jsonl").exists()
+            else []
+        ),
         "heartbeat": (
             [artifact_dir / "runner_heartbeat.json"]
             if (artifact_dir / "runner_heartbeat.json").exists()
@@ -1033,6 +1040,151 @@ def _check_no_side_effects(
             )
 
 
+def _load_coordinator_events(
+    paths: Sequence[Path],
+    add_finding: Any,
+) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for path in paths:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            add_finding(
+                f"{path.name} readable",
+                "fail",
+                f"Failed to read {path.name}: {exc}",
+                artifact=path.name,
+            )
+            continue
+        if not lines:
+            add_finding(
+                f"{path.name} lifecycle events present",
+                "fail",
+                "Lifecycle event stream is empty",
+                artifact=path.name,
+            )
+            continue
+        for index, line in enumerate(lines, start=1):
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError as exc:
+                add_finding(
+                    f"{path.name} line {index} parses as JSON",
+                    "fail",
+                    f"Malformed JSON line: {exc}",
+                    artifact=path.name,
+                )
+                continue
+            if not isinstance(payload, dict):
+                add_finding(
+                    f"{path.name} line {index} event shape",
+                    "fail",
+                    "Lifecycle event line must be a JSON object",
+                    artifact=path.name,
+                )
+                continue
+            events.append(payload)
+            add_finding(
+                f"{path.name} line {index} parses as JSON",
+                "pass",
+                "Lifecycle event line is valid JSON",
+                artifact=path.name,
+            )
+    return events
+
+
+def _check_coordinator_events(
+    events: Sequence[Mapping[str, Any]], add_finding: Any
+) -> None:
+    if not events:
+        add_finding(
+            "Coordinator lifecycle telemetry",
+            "fail",
+            "Missing parseable coordinator lifecycle telemetry",
+            artifact="coordinator_events.jsonl",
+        )
+        return
+
+    required_event_types = {
+        "run_started",
+        "boot_readiness_completed",
+        "cycle_started",
+        "runner_cycle_completed",
+        "watchdog_completed",
+        "write_audit_completed",
+        "cycle_completed",
+        "final_validation_started",
+        "final_validation_completed",
+    }
+    seen_types: set[str] = set()
+    previous_ts: datetime | None = None
+    chronological = True
+
+    for index, event in enumerate(events, start=1):
+        for field_name in ("schema_version", "event_at_utc", "run_id", "event_type"):
+            value = event.get(field_name)
+            if not isinstance(value, str) or not value.strip():
+                add_finding(
+                    f"Coordinator event {index} required field {field_name}",
+                    "fail",
+                    f"Lifecycle event missing required field {field_name}",
+                    artifact="coordinator_events.jsonl",
+                    field_name=field_name,
+                )
+        if event.get("schema_version") != "cdb.evidence_harvester.coordinator_event.v1":
+            add_finding(
+                f"Coordinator event {index} schema version",
+                "fail",
+                f"Unexpected schema_version {event.get('schema_version')!r}",
+                artifact="coordinator_events.jsonl",
+                field_name="schema_version",
+            )
+        event_type = str(event.get("event_type", "")).strip()
+        if event_type:
+            seen_types.add(event_type)
+        try:
+            event_ts = _parse_ts(event.get("event_at_utc", ""), "event_at_utc")
+            if previous_ts is not None and event_ts < previous_ts:
+                chronological = False
+            previous_ts = event_ts
+        except OpsValidationError as exc:
+            chronological = False
+            add_finding(
+                f"Coordinator event {index} timestamp",
+                "fail",
+                str(exc),
+                artifact="coordinator_events.jsonl",
+                field_name="event_at_utc",
+            )
+
+    missing_types = sorted(required_event_types - seen_types)
+    if missing_types:
+        add_finding(
+            "Coordinator lifecycle required event coverage",
+            "fail",
+            f"Missing required lifecycle event types: {missing_types}",
+            artifact="coordinator_events.jsonl",
+        )
+    else:
+        add_finding(
+            "Coordinator lifecycle required event coverage",
+            "pass",
+            "Required lifecycle event types are present",
+            artifact="coordinator_events.jsonl",
+        )
+
+    add_finding(
+        "Coordinator lifecycle chronology",
+        "pass" if chronological else "fail",
+        (
+            "Lifecycle events are chronological"
+            if chronological
+            else "Lifecycle events are not chronological"
+        ),
+        artifact="coordinator_events.jsonl",
+    )
+
+
 def validate_72h_window(
     artifact_paths: Mapping[str, Sequence[Path]],
     *,
@@ -1135,6 +1287,10 @@ def validate_72h_window(
         add_finding,
         expected_schema=HEARTBEAT_SCHEMA,
     )
+    coordinator_events = _load_coordinator_events(
+        artifact_paths.get("coordinator_events", []),
+        add_finding,
+    )
     state_payloads = _load_payloads(
         artifact_paths.get("state", []),
         add_finding,
@@ -1200,6 +1356,8 @@ def validate_72h_window(
 
     for path, payload in state_payloads:
         _check_no_side_effects(path, payload, add_finding)
+
+    _check_coordinator_events(coordinator_events, add_finding)
 
     recovered_fail_reports, recovery_limit_exceeded = _check_recovery_events(
         recovery_event_payloads,

--- a/tools/evidence_harvester/runner.py
+++ b/tools/evidence_harvester/runner.py
@@ -97,6 +97,15 @@ class RunnerState:
     failed_runs: int = 0
     last_cycle_verdict: str = ""
     last_cycle_ended_at_utc: str = ""
+    run_id: str = ""
+    total_cycles_started: int = 0
+    total_cycles_completed: int = 0
+    total_successful_cycles: int = 0
+    total_failed_cycles: int = 0
+    last_cycle_started_at_utc: str = ""
+    next_cycle_due_at_utc: str = ""
+    last_successful_artifact_stamp: str = ""
+    coordinator_status: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -142,6 +151,7 @@ def _run_complete_cycle(
     existing_heartbeat: RunnerHeartbeat | None,
     mode: str = "run-once-fixture",
 ) -> tuple[RunnerHeartbeat, RunnerState]:
+    prior_state = _read_state(output_dir)
     raw_input = _load_json(fixture_path)
     raw_input.setdefault("stale_after_minutes", 120)
     collector_input = CollectorInput.from_mapping(raw_input)
@@ -197,11 +207,30 @@ def _run_complete_cycle(
         last_alert_markdown=str(alert_markdown_path),
     )
     state = RunnerState(
-        total_runs=1,
-        successful_runs=1,
-        failed_runs=0,
+        total_runs=(prior_state.total_runs if prior_state else 0) + 1,
+        successful_runs=(prior_state.successful_runs if prior_state else 0) + 1,
+        failed_runs=prior_state.failed_runs if prior_state else 0,
         last_cycle_verdict="PASS",
         last_cycle_ended_at_utc=_format_ts(now),
+        run_id=prior_state.run_id if prior_state else "",
+        total_cycles_started=(prior_state.total_cycles_started if prior_state else 0),
+        total_cycles_completed=(
+            prior_state.total_cycles_completed if prior_state else 0
+        ),
+        total_successful_cycles=(
+            prior_state.total_successful_cycles if prior_state else 0
+        ),
+        total_failed_cycles=prior_state.total_failed_cycles if prior_state else 0,
+        last_cycle_started_at_utc=(
+            prior_state.last_cycle_started_at_utc if prior_state else ""
+        ),
+        next_cycle_due_at_utc=(
+            prior_state.next_cycle_due_at_utc if prior_state else ""
+        ),
+        last_successful_artifact_stamp=(
+            prior_state.last_successful_artifact_stamp if prior_state else ""
+        ),
+        coordinator_status=prior_state.coordinator_status if prior_state else "",
     )
 
     _write_heartbeat(output_dir, heartbeat, pretty)

--- a/tools/evidence_harvester/watchdog.py
+++ b/tools/evidence_harvester/watchdog.py
@@ -245,6 +245,7 @@ def _check_runner_state(
     *,
     max_age_seconds: int,
     warn_age_seconds: int,
+    cadence_seconds: int,
     now: datetime,
 ) -> list[WatchdogFinding]:
     findings: list[WatchdogFinding] = []
@@ -407,6 +408,79 @@ def _check_runner_state(
                 field_name="last_cycle_ended_at_utc",
             )
         )
+
+    coordinator_status = str(state_payload.get("coordinator_status", "")).strip()
+    next_cycle_due_at_utc = str(state_payload.get("next_cycle_due_at_utc", "")).strip()
+    if coordinator_status == "sleeping":
+        if not next_cycle_due_at_utc:
+            findings.append(
+                WatchdogFinding(
+                    check_id="W017",
+                    check_name="Coordinator sleep schedule",
+                    severity="fail",
+                    message="coordinator_status is sleeping but next_cycle_due_at_utc is missing",
+                    artifact=artifact_dir_label,
+                    field_name="next_cycle_due_at_utc",
+                )
+            )
+        else:
+            try:
+                due_at = _parse_ts(next_cycle_due_at_utc, "next_cycle_due_at_utc")
+                delta_seconds = (now - due_at).total_seconds()
+                if delta_seconds <= 0:
+                    findings.append(
+                        WatchdogFinding(
+                            check_id="W017",
+                            check_name="Coordinator sleep schedule",
+                            severity="pass",
+                            message=(
+                                "Coordinator is sleeping until next_cycle_due_at_utc"
+                            ),
+                            artifact=artifact_dir_label,
+                            field_name="next_cycle_due_at_utc",
+                        )
+                    )
+                elif delta_seconds <= cadence_seconds:
+                    findings.append(
+                        WatchdogFinding(
+                            check_id="W017",
+                            check_name="Coordinator sleep schedule",
+                            severity="warn",
+                            message=(
+                                f"next_cycle_due_at_utc exceeded by {delta_seconds:.0f}s "
+                                f"within cadence tolerance {cadence_seconds}s"
+                            ),
+                            artifact=artifact_dir_label,
+                            field_name="next_cycle_due_at_utc",
+                        )
+                    )
+                else:
+                    findings.append(
+                        WatchdogFinding(
+                            check_id="W017",
+                            check_name="Coordinator sleep schedule",
+                            severity="fail",
+                            message=(
+                                f"next_cycle_due_at_utc exceeded by {delta_seconds:.0f}s "
+                                f"beyond cadence tolerance {cadence_seconds}s"
+                            ),
+                            artifact=artifact_dir_label,
+                            field_name="next_cycle_due_at_utc",
+                        )
+                    )
+            except WatchdogError:
+                findings.append(
+                    WatchdogFinding(
+                        check_id="W017",
+                        check_name="Coordinator sleep schedule",
+                        severity="fail",
+                        message=(
+                            f"next_cycle_due_at_utc={next_cycle_due_at_utc!r} is not valid ISO-8601"
+                        ),
+                        artifact=artifact_dir_label,
+                        field_name="next_cycle_due_at_utc",
+                    )
+                )
 
     return findings
 
@@ -785,6 +859,7 @@ def run_status(
         artifact_dir_label,
         max_age_seconds=max_age_seconds,
         warn_age_seconds=warn_age_seconds,
+        cadence_seconds=cadence_seconds,
         now=eval_now,
     )
     all_findings.extend(state_findings)
@@ -826,7 +901,7 @@ def run_status(
         f.check_id == "W003" and f.severity == "fail" for f in all_findings
     )
     runner_state_ok = not any(
-        f.check_id in {"W004", "W005", "W006", "W016"} and f.severity == "fail"
+        f.check_id in {"W004", "W005", "W006", "W016", "W017"} and f.severity == "fail"
         for f in all_findings
     )
     required_artifacts_present = not any(


### PR DESCRIPTION
## Brain Evidence Block

- brain_source: repo-only
- brain_status: not-used
- tools_or_queries:
  - `context.briefing` (LOW trust, no DB-backed records)
  - `git fetch origin --prune`
  - `git status -sb`
  - `git rev-parse HEAD`
  - `git rev-parse origin/main`
  - `git worktree list`
  - `gh issue view 3370`
  - `gh issue view 3362`
  - `gh issue view 3345`
  - `gh pr list --state open`
  - repo reads + scoped unit tests + lint/format checks
- records_or_results:
  - no DB-/MCP-backed evidence records available
  - no open PR already implementing #3370
  - issue scope confirmed live: #3370 OPEN, #3362 OPEN, #3345 OPEN
- repo_crosscheck:
  - `tools/evidence_harvester/coordinator.py`
  - `tools/evidence_harvester/runner.py`
  - `tools/evidence_harvester/watchdog.py`
  - `tools/evidence_harvester/ops_validation.py`
  - `tests/unit/tools/evidence_harvester/`
- impact_on_plan:
  - implemented the smallest direct contract slice in existing harvester surfaces
  - kept broader runpy warning cleanup for #3371 and broader watchdog classification for #3372
- limitations:
  - run `20260620T153015Z` remains incident input; local artifact evidence was not verified in this slice
  - no DB-backed Brain claims made
- context_brain_attempted: true
- context_brain_used: false
- repo_fallback_used: true
- repo_fallback_reason: insufficient_evidence
- context_tool_status: available
- context_trust_level: low
- records_found: 0

## Bootloader Evidence

- Resolved bootloader chain: `AGENTS.md` -> `agents/AGENTS.md` -> full canonical read order.
- Read `knowledge/governance/CDB_AGENT_POLICY.md` section 4 before write actions.
- Reconfirmed LR SSOT: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` => **NO-GO**.
- Reconfirmed board/stage SSOT: `docs/runbooks/CONTROL_REGISTER.md` => `trade-capable`, explicitly not Live-Go.
- Treated `CURRENT_STATUS.md` as ledger only, not live truth.

## Root Cause From Run 20260620T153015Z

This PR treats run `20260620T153015Z` as **incident input** rather than locally verified artifact truth.

The issue-backed root cause to address here was:

- no canonical coordinator lifecycle telemetry stream
- coordinator-managed runs not maintaining cumulative run-wide state in `runner_state.json`
- no explicit `next_cycle_due_at_utc` surface for healthy sleep scheduling
- downstream consumers had no lifecycle evidence surface to read

## Delivered

- Added canonical `coordinator_events.jsonl` lifecycle telemetry in `coordinator.py`.
- Emitted lifecycle events for run start, boot completion, cycle start/completion, runner/watchdog/write-audit completion, sleep start/completion, next-cycle scheduling, recovery start/completion, fatal stop, and final validation start/completion.
- Added cumulative coordinator-managed state fields to `runner_state.json` while preserving compatibility fields:
  - `run_id`
  - `total_cycles_started`
  - `total_cycles_completed`
  - `total_successful_cycles`
  - `total_failed_cycles`
  - `last_cycle_started_at_utc`
  - `next_cycle_due_at_utc`
  - `last_successful_artifact_stamp`
  - `coordinator_status`
- Prevented `run-once-fixture` from blindly resetting cumulative counts when state already exists in the same artifact directory.
- Added minimal watchdog support for healthy sleeping windows via `coordinator_status=sleeping` + `next_cycle_due_at_utc`.
- Added ops-validation support for parsing and validating `coordinator_events.jsonl`.
- Updated evidence-harvester docs where the artifact contract changed.

## Validation

- `python -m pytest tests/unit/tools/evidence_harvester -q`
- `ruff check tools/evidence_harvester tests/unit/tools/evidence_harvester`
- `black --check tools/evidence_harvester tests/unit/tools/evidence_harvester`
- `git diff --check`
- forbidden-pattern grep over scoped files completed; only expected guardrail/safety strings remained

## Safety Boundaries

- No Docker.
- No runtime start.
- No Windows Task install.
- No DB mutation.
- No secrets output.
- No trading execution.
- No LR-Go.
- No Live-Go.
- No Echtgeld-Go.

Closes #3370
References #3362
References #3345
