### PR TITLE
feat(ops-validation): add is_final param, lifecycle-runner_state crosscheck, watchdog liveness (#3373)

### DIFF
--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_72H_OPS_VALIDATION.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_72H_OPS_VALIDATION.md
@@ -63,7 +63,8 @@ used only after the real dry run finishes.
 
 - `>=72h` window covered
 - runner continuity evidenced by heartbeat/state counters, coordinator lifecycle telemetry, and stamped cadence history
-- watchdog history PASS or justified WARN
+- lifecycle cycle count consistent with `runner_state.total_cycles_completed` and artifact snapshot count
+- watchdog history PASS or justified WARN; `coordinator_liveness` must not be FATAL_STOP or STALE_NEXT_CYCLE
 - write-audit history PASS with no FAIL findings
 - boot-readiness PASS or justified WARN
 - no side effects
@@ -73,6 +74,7 @@ used only after the real dry run finishes.
 - minor cadence drift
 - documented non-critical boot warning
 - documented non-critical watchdog warning
+- missing lifecycle telemetry (non-final validation only, `--no-final`)
 
 ### FAIL
 
@@ -92,6 +94,11 @@ python -m tools.evidence_harvester.ops_validation validate-dir ^
     --json-output artifacts\evidence_harvester\72h_ops_validation\<run_id>\ops_validation_report.json ^
     --markdown-output artifacts\evidence_harvester\72h_ops_validation\<run_id>\ops_validation_report.md ^
     --pretty
+
+# Non-final validation (lifecycle telemetry WARN instead of FAIL):
+python -m tools.evidence_harvester.ops_validation validate-dir ^
+    --artifact-dir artifacts\evidence_harvester\72h_ops_validation\<run_id> ^
+    --no-final --pretty
 ```
 
 ## Runtime Handoff

--- a/tests/unit/tools/evidence_harvester/test_ops_validation.py
+++ b/tests/unit/tools/evidence_harvester/test_ops_validation.py
@@ -178,7 +178,11 @@ def _collector_payload(ts: str) -> dict:
     }
 
 
-def _watchdog_payload(ts: str, verdict: str = "PASS") -> dict:
+def _watchdog_payload(
+    ts: str,
+    verdict: str = "PASS",
+    coordinator_liveness: dict | None = None,
+) -> dict:
     return {
         "schema_version": WATCHDOG_REPORT_SCHEMA,
         "evaluated_at_utc": ts,
@@ -187,6 +191,17 @@ def _watchdog_payload(ts: str, verdict: str = "PASS") -> dict:
         "heartbeat_fresh": verdict != "FAIL",
         "runner_state_ok": verdict != "FAIL",
         "required_artifacts_present": True,
+        "coordinator_liveness": coordinator_liveness
+        or {
+            "classification": "RUNNING_HEALTHY",
+            "severity": "pass",
+            "reason": "Coordinator status is 'running' and heartbeat is fresh",
+            "coordinator_status_from_state": "running",
+            "has_lifecycle_telemetry": True,
+            "last_heartbeat_age_seconds": 30.0,
+            "has_fatal_stop_event": False,
+            "has_recovery_events": False,
+        },
         "verdict": {
             "verdict": verdict,
             "total_checks": 10,
@@ -532,6 +547,169 @@ class TestValidate72hWindowFromDir:
         )
         assert report.summary.verdict == "FAIL"
         assert any("coordinator_events.jsonl" in f.message for f in report.findings)
+
+    @pytest.mark.unit
+    def test_warn_on_missing_lifecycle_non_final(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        (tmp_path / "coordinator_events.jsonl").write_text("", encoding="utf-8")
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+            is_final=False,
+        )
+        assert report.summary.verdict == "WARN"
+        assert any(
+            "Missing parseable coordinator lifecycle telemetry" in f.message
+            and f.severity == "warn"
+            for f in report.findings
+        )
+
+    @pytest.mark.unit
+    def test_fail_on_lifecycle_runner_state_mismatch(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        state_path = tmp_path / "runner_state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["total_cycles_completed"] = 999
+        state["total_runs"] = 999
+        state["successful_runs"] = 999
+        state_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert report.summary.verdict == "FAIL"
+        assert any(
+            "diverges from runner_state.total_cycles_completed" in f.message
+            for f in report.findings
+        )
+
+    @pytest.mark.unit
+    def test_warn_on_lifecycle_artifact_count_mismatch(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        extra_ts = _ts(start + timedelta(hours=2, minutes=5))
+        extra_stamp = _stamp(start + timedelta(hours=2, minutes=5))
+        _write_json(
+            tmp_path / f"snapshot_{extra_stamp}.json",
+            _snapshot_payload(extra_ts),
+        )
+        _write_text(tmp_path / f"snapshot_{extra_stamp}.md")
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert any(
+            "Lifecycle-artifact count consistency" in f.check_name
+            and f.severity == "warn"
+            for f in report.findings
+        )
+
+    @pytest.mark.unit
+    def test_fail_on_watchdog_fatal_stop_liveness(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(
+            tmp_path,
+            start=start,
+            hours=2,
+            cadence_seconds=3600,
+        )
+        first_stamp = _stamp(start)
+        fatal_stop_wd = _watchdog_payload(
+            _ts(start),
+            verdict="FAIL",
+            coordinator_liveness={
+                "classification": "FATAL_STOP",
+                "severity": "fail",
+                "reason": "Coordinator has a fatal stop lifecycle event",
+                "coordinator_status_from_state": "fatal_stop",
+                "has_lifecycle_telemetry": True,
+                "last_heartbeat_age_seconds": 30.0,
+                "has_fatal_stop_event": True,
+                "has_recovery_events": False,
+            },
+        )
+        _write_json(tmp_path / f"watchdog_report_{first_stamp}.json", fatal_stop_wd)
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert any(
+            "FATAL_STOP" in f.message and f.severity == "fail" for f in report.findings
+        )
+
+    @pytest.mark.unit
+    def test_fail_on_watchdog_stale_next_cycle_liveness(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(
+            tmp_path,
+            start=start,
+            hours=2,
+            cadence_seconds=3600,
+        )
+        first_stamp = _stamp(start)
+        stale_wd = _watchdog_payload(
+            _ts(start),
+            verdict="FAIL",
+            coordinator_liveness={
+                "classification": "STALE_NEXT_CYCLE",
+                "severity": "fail",
+                "reason": "next_cycle_due_at_utc exceeded by 99999s beyond cadence tolerance",
+                "coordinator_status_from_state": "sleeping",
+                "has_lifecycle_telemetry": True,
+                "last_heartbeat_age_seconds": 30.0,
+                "next_cycle_due_at_utc": "2026-06-19T01:00:00Z",
+                "has_fatal_stop_event": False,
+                "has_recovery_events": False,
+            },
+        )
+        _write_json(tmp_path / f"watchdog_report_{first_stamp}.json", stale_wd)
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert any(
+            "STALE_NEXT_CYCLE" in f.message and f.severity == "fail"
+            for f in report.findings
+        )
+
+    @pytest.mark.unit
+    def test_pass_with_healthy_watchdog_liveness(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(
+            tmp_path,
+            start=start,
+            hours=2,
+            cadence_seconds=3600,
+        )
+        first_stamp = _stamp(start)
+        healthy_wd = _watchdog_payload(
+            _ts(start),
+            verdict="PASS",
+            coordinator_liveness={
+                "classification": "RUNNING_HEALTHY",
+                "severity": "pass",
+                "reason": "Coordinator status is 'running' and heartbeat is fresh",
+                "coordinator_status_from_state": "running",
+                "has_lifecycle_telemetry": True,
+                "last_heartbeat_age_seconds": 30.0,
+                "has_fatal_stop_event": False,
+                "has_recovery_events": False,
+            },
+        )
+        _write_json(tmp_path / f"watchdog_report_{first_stamp}.json", healthy_wd)
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert report.summary.verdict == "PASS"
 
     @pytest.mark.unit
     def test_fail_on_short_window(self, tmp_path: Path) -> None:

--- a/tools/evidence_harvester/README.md
+++ b/tools/evidence_harvester/README.md
@@ -444,6 +444,25 @@ python -m tools.evidence_harvester.ops_validation validate-dir `
     --pretty
 ```
 
+For non-final bounded validation (e.g. short fixture tests) missing lifecycle
+telemetry produces WARN instead of FAIL:
+
+```powershell
+python -m tools.evidence_harvester.ops_validation validate-dir `
+    --artifact-dir ... --no-final --pretty
+```
+
+### PASS requirements (final >=72h validation)
+
+- Coordinator lifecycle telemetry (`coordinator_events.jsonl`) must be present
+  and contain all required event types
+- Lifecycle cycle counts must be consistent with `runner_state.json` and
+  artifact counts
+- Watchdog `coordinator_liveness` must not report FATAL_STOP or
+  STALE_NEXT_CYCLE
+- Heartbeat/state counters, window coverage, cadence, and safety boundaries
+  must all pass
+
 ### Phase-2 runtime contract
 
 - seed fixture: `artifacts/evidence_harvester/24h_dry_run/collector_input.json`

--- a/tools/evidence_harvester/ops_validation.py
+++ b/tools/evidence_harvester/ops_validation.py
@@ -1057,12 +1057,6 @@ def _load_coordinator_events(
             )
             continue
         if not lines:
-            add_finding(
-                f"{path.name} lifecycle events present",
-                "fail",
-                "Lifecycle event stream is empty",
-                artifact=path.name,
-            )
             continue
         for index, line in enumerate(lines, start=1):
             try:
@@ -1094,12 +1088,16 @@ def _load_coordinator_events(
 
 
 def _check_coordinator_events(
-    events: Sequence[Mapping[str, Any]], add_finding: Any
+    events: Sequence[Mapping[str, Any]],
+    add_finding: Any,
+    *,
+    is_final: bool = True,
 ) -> None:
     if not events:
+        severity = "fail" if is_final else "warn"
         add_finding(
             "Coordinator lifecycle telemetry",
-            "fail",
+            severity,
             "Missing parseable coordinator lifecycle telemetry",
             artifact="coordinator_events.jsonl",
         )
@@ -1159,9 +1157,10 @@ def _check_coordinator_events(
 
     missing_types = sorted(required_event_types - seen_types)
     if missing_types:
+        ev_severity = "fail" if is_final else "warn"
         add_finding(
             "Coordinator lifecycle required event coverage",
-            "fail",
+            ev_severity,
             f"Missing required lifecycle event types: {missing_types}",
             artifact="coordinator_events.jsonl",
         )
@@ -1185,6 +1184,101 @@ def _check_coordinator_events(
     )
 
 
+def _check_lifecycle_runner_state_consistency(
+    coordinator_events: Sequence[Mapping[str, Any]],
+    state_payload: Mapping[str, Any] | None,
+    snapshot_count: int,
+    add_finding: Any,
+) -> None:
+    if not coordinator_events or state_payload is None:
+        return
+    lifecycle_cycle_count = sum(
+        1 for e in coordinator_events if e.get("event_type") == "cycle_completed"
+    )
+    state_cycle_count = state_payload.get("total_cycles_completed", 0)
+    if not isinstance(state_cycle_count, int):
+        add_finding(
+            "Lifecycle-runner state cycle consistency",
+            "fail",
+            f"runner_state.total_cycles_completed is not an integer: {state_cycle_count!r}",
+            artifact="runner_state.json",
+            field_name="total_cycles_completed",
+        )
+        return
+    diff = lifecycle_cycle_count - state_cycle_count
+    if abs(diff) > 1:
+        add_finding(
+            "Lifecycle-runner state cycle consistency",
+            "fail",
+            f"Lifecycle cycle_completed count ({lifecycle_cycle_count}) diverges from runner_state.total_cycles_completed ({state_cycle_count}) by {abs(diff)}",
+            artifact="coordinator_events.jsonl",
+        )
+    elif abs(diff) == 1:
+        add_finding(
+            "Lifecycle-runner state cycle consistency",
+            "warn",
+            f"Lifecycle cycle_completed count ({lifecycle_cycle_count}) differs from runner_state.total_cycles_completed ({state_cycle_count}) by 1",
+            artifact="coordinator_events.jsonl",
+        )
+    else:
+        add_finding(
+            "Lifecycle-runner state cycle consistency",
+            "pass",
+            f"Lifecycle cycle_completed count ({lifecycle_cycle_count}) matches runner_state.total_cycles_completed ({state_cycle_count})",
+            artifact="coordinator_events.jsonl",
+        )
+    if lifecycle_cycle_count != snapshot_count:
+        add_finding(
+            "Lifecycle-artifact count consistency",
+            "warn",
+            f"Lifecycle cycle_completed count ({lifecycle_cycle_count}) != snapshot artifact count ({snapshot_count})",
+            artifact="coordinator_events.jsonl",
+        )
+    else:
+        add_finding(
+            "Lifecycle-artifact count consistency",
+            "pass",
+            f"Lifecycle cycle_completed count ({lifecycle_cycle_count}) matches snapshot artifact count ({snapshot_count})",
+            artifact="coordinator_events.jsonl",
+        )
+
+
+def _check_watchdog_coordinator_liveness(
+    watchdog_payloads: Sequence[tuple[Path, Mapping[str, Any]]],
+    add_finding: Any,
+) -> None:
+    if not watchdog_payloads:
+        return
+    for path, payload in watchdog_payloads:
+        cl = payload.get("coordinator_liveness")
+        if not isinstance(cl, Mapping):
+            continue
+        classification = str(cl.get("classification", "")).strip()
+        severity = str(cl.get("severity", "")).strip()
+        reason = str(cl.get("reason", "")).strip()
+        msg = f"Watchdog coordinator liveness: {classification} — {reason}"
+        if classification == "FATAL_STOP":
+            add_finding(
+                "Watchdog coordinator liveness", "fail", msg, artifact=path.name
+            )
+        elif classification == "STALE_NEXT_CYCLE":
+            add_finding(
+                "Watchdog coordinator liveness", "fail", msg, artifact=path.name
+            )
+        elif classification == "STALE_HEARTBEAT" and severity == "fail":
+            add_finding(
+                "Watchdog coordinator liveness", "fail", msg, artifact=path.name
+            )
+        elif classification in ("RECOVERY_IN_PROGRESS", "COORDINATOR_STOPPED"):
+            add_finding(
+                "Watchdog coordinator liveness", "warn", msg, artifact=path.name
+            )
+        else:
+            add_finding(
+                "Watchdog coordinator liveness", "pass", msg, artifact=path.name
+            )
+
+
 def validate_72h_window(
     artifact_paths: Mapping[str, Sequence[Path]],
     *,
@@ -1193,6 +1287,7 @@ def validate_72h_window(
     window_end_utc: datetime | None = None,
     required_window_hours: int = DEFAULT_REQUIRED_WINDOW_HOURS,
     runner_cadence_seconds: int = DEFAULT_RUNNER_CADENCE_SECONDS,
+    is_final: bool = True,
 ) -> OpsValidationReport:
     if required_window_hours < 1:
         raise OpsValidationError("required_window_hours must be >= 1")
@@ -1296,6 +1391,8 @@ def validate_72h_window(
         add_finding,
         expected_schema=STATE_SCHEMA,
     )
+    state_payload = state_payloads[0][1] if state_payloads else None
+    heartbeat_payload = heartbeat_payloads[0][1] if heartbeat_payloads else None
     watchdog_payloads = _load_payloads(
         artifact_paths.get("watchdog_json", []),
         add_finding,
@@ -1357,7 +1454,14 @@ def validate_72h_window(
     for path, payload in state_payloads:
         _check_no_side_effects(path, payload, add_finding)
 
-    _check_coordinator_events(coordinator_events, add_finding)
+    _check_coordinator_events(coordinator_events, add_finding, is_final=is_final)
+
+    _check_lifecycle_runner_state_consistency(
+        coordinator_events,
+        state_payload,
+        len(snapshot_payloads),
+        add_finding,
+    )
 
     recovered_fail_reports, recovery_limit_exceeded = _check_recovery_events(
         recovery_event_payloads,
@@ -1370,6 +1474,7 @@ def validate_72h_window(
         add_finding,
         covered_fail_reports=recovered_fail_reports,
     )
+    _check_watchdog_coordinator_liveness(watchdog_payloads, add_finding)
     for path, payload in watchdog_payloads:
         _check_no_side_effects(path, payload, add_finding)
 
@@ -1431,8 +1536,6 @@ def validate_72h_window(
             add_finding,
         )
 
-    heartbeat_payload = heartbeat_payloads[0][1] if heartbeat_payloads else None
-    state_payload = state_payloads[0][1] if state_payloads else None
     latest_snapshot_ts = max(snapshot_timestamps) if snapshot_timestamps else None
     _check_runner_state(
         heartbeat_payload,
@@ -1497,6 +1600,7 @@ def validate_72h_window_from_dir(
     window_end_utc: datetime | None = None,
     required_window_hours: int = DEFAULT_REQUIRED_WINDOW_HOURS,
     runner_cadence_seconds: int = DEFAULT_RUNNER_CADENCE_SECONDS,
+    is_final: bool = True,
 ) -> OpsValidationReport:
     if not artifact_dir.exists():
         raise OpsValidationError(f"Artifact directory does not exist: {artifact_dir}")
@@ -1509,6 +1613,7 @@ def validate_72h_window_from_dir(
         window_end_utc=window_end_utc,
         required_window_hours=required_window_hours,
         runner_cadence_seconds=runner_cadence_seconds,
+        is_final=is_final,
     )
 
 
@@ -1561,8 +1666,8 @@ def report_to_markdown(report: OpsValidationReport) -> str:
         [
             "",
             "## 72h Validation Contract",
-            "- PASS requires >=72h coverage, continuous runner evidence cadence, no FAIL in watchdog/write-audit/boot, and no side effects.",
-            "- WARN allows minor cadence drift or a justified boot/watchdog warning with no FAIL findings.",
+            "- PASS requires >=72h coverage, continuous runner evidence cadence, lifecycle telemetry, no FAIL in watchdog/write-audit/boot, consistent cycle counts, and no side effects.",
+            "- WARN allows minor cadence drift, a justified boot/watchdog warning with no FAIL findings, or missing lifecycle telemetry in non-final validation.",
             "- FAIL means the always-on dry operation is not proven fail-closed.",
             "",
             "## Runtime Handoff",
@@ -1660,6 +1765,19 @@ def parse_args(argv: list[str] | None = None) -> Any:
         help="Expected runner cadence in seconds (default: 900).",
     )
     dir_parser.add_argument(
+        "--is-final",
+        action="store_true",
+        default=True,
+        dest="is_final",
+        help="Treat this as final >=72h validation (default: True).",
+    )
+    dir_parser.add_argument(
+        "--no-final",
+        action="store_false",
+        dest="is_final",
+        help="Treat this as non-final bounded validation.",
+    )
+    dir_parser.add_argument(
         "--json-output",
         type=Path,
         help="Optional JSON output path for the ops validation report.",
@@ -1695,6 +1813,7 @@ def _handle_validate_dir(args: Any) -> int:
         window_end_utc=window_end,
         required_window_hours=args.required_window_hours,
         runner_cadence_seconds=args.runner_cadence_seconds,
+        is_final=args.is_final,
     )
     payload = report.to_dict()
     json_text = json.dumps(


### PR DESCRIPTION
Closes #3373

## Summary

Hardens `ops_validation.py` so a `>=72h` PASS requires lifecycle telemetry, run-wide state consistency, and watchdog coordinator-liveness evidence.

### Changes

**`ops_validation.py`:**
- `is_final: bool = True` parameter on `validate_72h_window()`, `validate_72h_window_from_dir()`, `_check_coordinator_events()`
- `_check_coordinator_events()` downgrades empty/missing-event-types from FAIL to WARN when `is_final=False`
- `_check_lifecycle_runner_state_consistency()` — compares `cycle_completed` count vs `total_cycles_completed` (runner_state) vs snapshot artifact count
- `_check_watchdog_coordinator_liveness()` — maps `coordinator_liveness.classification` to FAIL/WARN/PASS findings
- Removed redundant "Lifecycle event stream is empty" FAIL from `_load_coordinator_events()` (now handled by `_check_coordinator_events` with `is_final` awareness)
- Extracted `state_payload` / `heartbeat_payload` earlier to fix forward-reference
- CLI: `--is-final` / `--no-final` on `validate-dir` subparser

**Tests (6 new in `test_ops_validation.py`):**
- `test_warn_on_missing_lifecycle_non_final` — WARN when lifecycle missing and `is_final=False`
- `test_fail_on_lifecycle_runner_state_mismatch` — FAIL when `total_cycles_completed` diverges
- `test_warn_on_lifecycle_artifact_count_mismatch` — WARN when lifecycle cycle count != snapshots
- `test_fail_on_watchdog_fatal_stop_liveness` — FAIL on `FATAL_STOP`
- `test_fail_on_watchdog_stale_next_cycle_liveness` — FAIL on `STALE_NEXT_CYCLE`
- `test_pass_with_healthy_watchdog_liveness` — PASS on `RUNNING_HEALTHY`

**Docs:**
- README updated with `--no-final` usage and PASS requirements
- 72h runbook updated with lifecycle consistency and `--no-final` contract

### Verification

- 214/214 evidence harvester tests pass
- `ruff check` clean on changed .py files
- `black` formatted
- No secrets leaked
