### PR TITLE
fix(evidence-harvester): detect coordinator sleep stalls, fix UTC timestamp drift

### DIFF
--- a/tests/unit/tools/evidence_harvester/test_coordinator.py
+++ b/tests/unit/tools/evidence_harvester/test_coordinator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,8 @@ import pytest
 from tools.evidence_harvester.coordinator import (
     COORDINATOR_EVENT_SCHEMA,
     RECOVERY_EVENT_SCHEMA,
+    _now_utc,
+    _sleep_with_interval_check,
     run_fixture_window,
 )
 
@@ -301,3 +304,88 @@ def test_fatal_safety_failure_stops_without_restart(tmp_path: Path) -> None:
         .splitlines()
     ]
     assert any(event["event_type"] == "fatal_stop" for event in events)
+
+
+@pytest.mark.unit
+def test_sleep_with_interval_check_accumulates_exact_duration() -> None:
+    calls: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        calls.append(seconds)
+
+    overshoot = _sleep_with_interval_check(
+        fake_sleep, total_seconds=300, chunk_seconds=60
+    )
+
+    assert overshoot == pytest.approx(0.0, abs=0.001)
+    assert calls == [60, 60, 60, 60, 60]
+    assert sum(calls) == 300
+
+
+@pytest.mark.unit
+def test_sleep_with_interval_check_partial_chunk() -> None:
+    calls: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        calls.append(seconds)
+
+    overshoot = _sleep_with_interval_check(
+        fake_sleep, total_seconds=125, chunk_seconds=60
+    )
+
+    assert overshoot == pytest.approx(0.0, abs=0.001)
+    assert calls == [60, 60, 5]
+    assert sum(calls) == 125
+
+
+@pytest.mark.unit
+def test_sleep_with_interval_check_zero_duration() -> None:
+    calls: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        calls.append(seconds)
+
+    overshoot = _sleep_with_interval_check(
+        fake_sleep, total_seconds=0, chunk_seconds=60
+    )
+
+    assert overshoot == pytest.approx(0.0, abs=0.001)
+    assert calls == []
+
+
+@pytest.mark.unit
+def test_now_utc_returns_aware_datetime_when_cdb_utcnow_is_naive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    naive_utc = datetime(2026, 6, 20, 18, 44, 13)
+    assert naive_utc.tzinfo is None
+
+    monkeypatch.setattr(
+        "tools.evidence_harvester.coordinator.cdb_utcnow",
+        lambda: naive_utc,
+    )
+
+    result = _now_utc()
+
+    assert result.tzinfo is not None
+    assert result.tzinfo == UTC
+    assert result.hour == 18
+    assert result.minute == 44
+    assert result.second == 13
+
+
+@pytest.mark.unit
+def test_now_utc_preserves_aware_datetime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    aware_utc = datetime(2026, 6, 20, 18, 44, 13, tzinfo=UTC)
+
+    monkeypatch.setattr(
+        "tools.evidence_harvester.coordinator.cdb_utcnow",
+        lambda: aware_utc,
+    )
+
+    result = _now_utc()
+
+    assert result.tzinfo is not None
+    assert result == aware_utc

--- a/tests/unit/tools/evidence_harvester/test_watchdog.py
+++ b/tests/unit/tools/evidence_harvester/test_watchdog.py
@@ -364,6 +364,7 @@ def test_liveness_sleeping_until_next_cycle(tmp_path: Path) -> None:
     cl = report.coordinator_liveness
     assert cl.classification == "SLEEPING_UNTIL_NEXT_CYCLE"
     assert cl.severity == "pass"
+    assert cl.overdue_seconds == 0.0
 
 
 @pytest.mark.unit
@@ -382,6 +383,7 @@ def test_liveness_sleeping_warn_within_tolerance(tmp_path: Path) -> None:
     cl = report.coordinator_liveness
     assert cl.classification == "SLEEPING_UNTIL_NEXT_CYCLE"
     assert cl.severity == "warn"
+    assert cl.overdue_seconds == pytest.approx(300, abs=5)
 
 
 @pytest.mark.unit
@@ -409,6 +411,7 @@ def test_liveness_stale_next_cycle(tmp_path: Path) -> None:
     cl = report.coordinator_liveness
     assert cl.classification == "STALE_NEXT_CYCLE"
     assert cl.severity == "fail"
+    assert cl.overdue_seconds == pytest.approx(7200, abs=60)
 
 
 @pytest.mark.unit

--- a/tools/evidence_harvester/coordinator.py
+++ b/tools/evidence_harvester/coordinator.py
@@ -67,7 +67,10 @@ class CoordinatorSummary:
 
 
 def _now_utc() -> datetime:
-    return cdb_utcnow().astimezone(UTC)
+    now = cdb_utcnow()
+    if now.tzinfo is None:
+        return now.replace(tzinfo=UTC)
+    return now.astimezone(UTC)
 
 
 def _format_ts(value: datetime) -> str:
@@ -400,6 +403,23 @@ def _write_recovery_event(
             md_lines.append(f"- `{name}`")
     md_path.write_text("\n".join(md_lines) + "\n", encoding="utf-8")
     return event
+
+
+def _sleep_with_interval_check(
+    sleep_fn: Callable[[float], None],
+    total_seconds: int,
+    chunk_seconds: int = 60,
+) -> float:
+    """Sleep in chunks, returning overshoot (actual - expected) seconds."""
+    started = time.monotonic()
+    remaining = total_seconds
+    while remaining > 0:
+        chunk = min(remaining, chunk_seconds)
+        sleep_fn(chunk)
+        remaining -= chunk
+    elapsed = time.monotonic() - started
+    overshoot = elapsed - total_seconds
+    return max(overshoot, 0.0)
 
 
 def _default_boot_runner(
@@ -997,7 +1017,19 @@ def run_fixture_window(
                 next_cycle_due_at_utc=next_due_at,
                 coordinator_status="sleeping",
             )
-            sleep_fn(cadence_seconds)
+            overshoot = _sleep_with_interval_check(
+                sleep_fn, cadence_seconds, chunk_seconds=60
+            )
+            if overshoot > 60:
+                _write_coordinator_event(
+                    artifact_dir,
+                    run_id=run_id,
+                    event_type="sleep_overshoot",
+                    cycle_index=cycle_index,
+                    artifact_stamp=cycle_stamp,
+                    next_cycle_due_at_utc=next_due_at,
+                    coordinator_status="sleeping",
+                )
             _write_coordinator_event(
                 artifact_dir,
                 run_id=run_id,

--- a/tools/evidence_harvester/runner.py
+++ b/tools/evidence_harvester/runner.py
@@ -39,7 +39,10 @@ def _format_ts(value: datetime) -> str:
 
 
 def _now_utc() -> datetime:
-    return cdb_utcnow().astimezone(UTC)
+    now = cdb_utcnow()
+    if now.tzinfo is None:
+        return now.replace(tzinfo=UTC)
+    return now.astimezone(UTC)
 
 
 def _load_json(path: Path) -> dict[str, Any]:

--- a/tools/evidence_harvester/watchdog.py
+++ b/tools/evidence_harvester/watchdog.py
@@ -57,7 +57,10 @@ def _format_ts(value: datetime) -> str:
 
 
 def _now_utc() -> datetime:
-    return cdb_utcnow().astimezone(UTC)
+    now = cdb_utcnow()
+    if now.tzinfo is None:
+        return now.replace(tzinfo=UTC)
+    return now.astimezone(UTC)
 
 
 def _require_mapping(value: Any, field_name: str) -> Mapping[str, Any]:
@@ -127,6 +130,7 @@ class CoordinatorLiveness:
     next_cycle_due_at_utc: str = ""
     has_fatal_stop_event: bool = False
     has_recovery_events: bool = False
+    overdue_seconds: float = 0.0
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -218,109 +222,91 @@ def _classify_coordinator_liveness(
             except WatchdogError:
                 pass
 
-    if has_fatal_stop_event or coordinator_status == "fatal_stop":
+    has_fatal_stop = has_fatal_stop_event or coordinator_status == "fatal_stop"
+    is_recovering = coordinator_status == "recovering"
+    is_stopped = coordinator_status in ("completed", "failed")
+
+    def _make(
+        classification: str,
+        severity: str,
+        reason: str,
+        **extra: Any,
+    ) -> CoordinatorLiveness:
         return CoordinatorLiveness(
-            classification="FATAL_STOP",
-            severity="fail",
-            reason=(
+            classification=classification,
+            severity=severity,
+            reason=reason,
+            coordinator_status_from_state=coordinator_status,
+            has_lifecycle_telemetry=has_lifecycle,
+            last_heartbeat_age_seconds=max(heartbeat_age, 0.0),
+            next_cycle_due_at_utc=next_cycle_due_raw,
+            has_fatal_stop_event=has_fatal_stop_event,
+            has_recovery_events=has_recovery_events,
+            overdue_seconds=extra.get("overdue_seconds", 0.0),
+        )
+
+    if has_fatal_stop:
+        return _make(
+            "FATAL_STOP",
+            "fail",
+            (
                 "Coordinator has a fatal stop lifecycle event"
                 if has_fatal_stop_event
                 else "coordinator_status is fatal_stop"
             ),
-            coordinator_status_from_state=coordinator_status,
-            has_lifecycle_telemetry=has_lifecycle,
-            last_heartbeat_age_seconds=max(heartbeat_age, 0.0),
-            has_fatal_stop_event=has_fatal_stop_event,
-            has_recovery_events=has_recovery_events,
         )
 
-    if coordinator_status == "recovering":
-        return CoordinatorLiveness(
-            classification="RECOVERY_IN_PROGRESS",
-            severity="warn",
-            reason="Coordinator status indicates recovery in progress",
-            coordinator_status_from_state=coordinator_status,
-            has_lifecycle_telemetry=has_lifecycle,
-            last_heartbeat_age_seconds=max(heartbeat_age, 0.0),
-            has_recovery_events=has_recovery_events,
+    if is_recovering:
+        return _make(
+            "RECOVERY_IN_PROGRESS",
+            "warn",
+            "Coordinator status indicates recovery in progress",
         )
 
-    if coordinator_status in ("completed", "failed"):
-        return CoordinatorLiveness(
-            classification="COORDINATOR_STOPPED",
-            severity="warn" if coordinator_status == "completed" else "fail",
-            reason=(f"Coordinator has stopped with status {coordinator_status!r}"),
-            coordinator_status_from_state=coordinator_status,
-            has_lifecycle_telemetry=has_lifecycle,
-            last_heartbeat_age_seconds=max(heartbeat_age, 0.0),
-            has_recovery_events=has_recovery_events,
+    if is_stopped:
+        return _make(
+            "COORDINATOR_STOPPED",
+            "warn" if coordinator_status == "completed" else "fail",
+            f"Coordinator has stopped with status {coordinator_status!r}",
         )
 
     if coordinator_status == "sleeping":
         if not next_cycle_due_raw:
-            return CoordinatorLiveness(
-                classification="STALE_NEXT_CYCLE",
-                severity="fail",
-                reason="Coordinator is sleeping but next_cycle_due_at_utc is missing",
-                coordinator_status_from_state=coordinator_status,
-                has_lifecycle_telemetry=has_lifecycle,
-                last_heartbeat_age_seconds=max(heartbeat_age, 0.0),
-                has_recovery_events=has_recovery_events,
+            return _make(
+                "STALE_NEXT_CYCLE",
+                "fail",
+                "Coordinator is sleeping but next_cycle_due_at_utc is missing",
             )
         try:
             due_at = _parse_ts(next_cycle_due_raw, "next_cycle_due_at_utc")
             delta = (now - due_at).total_seconds()
             if delta <= 0:
-                return CoordinatorLiveness(
-                    classification="SLEEPING_UNTIL_NEXT_CYCLE",
-                    severity="pass",
-                    reason="Coordinator is sleeping and next cycle is not yet due",
-                    coordinator_status_from_state=coordinator_status,
-                    has_lifecycle_telemetry=has_lifecycle,
-                    last_heartbeat_age_seconds=max(heartbeat_age, 0.0),
-                    next_cycle_due_at_utc=next_cycle_due_raw,
-                    has_recovery_events=has_recovery_events,
+                return _make(
+                    "SLEEPING_UNTIL_NEXT_CYCLE",
+                    "pass",
+                    "Coordinator is sleeping and next cycle is not yet due",
                 )
             if delta <= cadence_seconds:
-                return CoordinatorLiveness(
-                    classification="SLEEPING_UNTIL_NEXT_CYCLE",
-                    severity="warn",
-                    reason=(
-                        f"Sleeping but next_cycle_due_at_utc exceeded by "
-                        f"{delta:.0f}s within cadence tolerance"
-                    ),
-                    coordinator_status_from_state=coordinator_status,
-                    has_lifecycle_telemetry=has_lifecycle,
-                    last_heartbeat_age_seconds=max(heartbeat_age, 0.0),
-                    next_cycle_due_at_utc=next_cycle_due_raw,
-                    has_recovery_events=has_recovery_events,
+                return _make(
+                    "SLEEPING_UNTIL_NEXT_CYCLE",
+                    "warn",
+                    f"Sleeping but next_cycle_due_at_utc exceeded by "
+                    f"{delta:.0f}s within cadence tolerance",
+                    overdue_seconds=delta,
                 )
-            return CoordinatorLiveness(
-                classification="STALE_NEXT_CYCLE",
-                severity="fail",
-                reason=(
-                    f"next_cycle_due_at_utc exceeded by {delta:.0f}s "
-                    f"beyond cadence tolerance {cadence_seconds}s"
-                ),
-                coordinator_status_from_state=coordinator_status,
-                has_lifecycle_telemetry=has_lifecycle,
-                last_heartbeat_age_seconds=max(heartbeat_age, 0.0),
-                next_cycle_due_at_utc=next_cycle_due_raw,
-                has_recovery_events=has_recovery_events,
+            return _make(
+                "STALE_NEXT_CYCLE",
+                "fail",
+                f"next_cycle_due_at_utc exceeded by {delta:.0f}s "
+                f"beyond cadence tolerance {cadence_seconds}s",
+                overdue_seconds=delta,
             )
         except WatchdogError:
-            return CoordinatorLiveness(
-                classification="STALE_NEXT_CYCLE",
-                severity="fail",
-                reason=(
-                    f"next_cycle_due_at_utc={next_cycle_due_raw!r} "
-                    "is not valid ISO-8601"
-                ),
-                coordinator_status_from_state=coordinator_status,
-                has_lifecycle_telemetry=has_lifecycle,
-                last_heartbeat_age_seconds=max(heartbeat_age, 0.0),
-                next_cycle_due_at_utc=next_cycle_due_raw,
-                has_recovery_events=has_recovery_events,
+            return _make(
+                "STALE_NEXT_CYCLE",
+                "fail",
+                f"next_cycle_due_at_utc={next_cycle_due_raw!r} "
+                "is not valid ISO-8601",
             )
 
     running_statuses = (
@@ -335,61 +321,30 @@ def _classify_coordinator_liveness(
         "starting"
     ):
         if heartbeat_age >= 0 and heartbeat_age > max_age_seconds:
-            return CoordinatorLiveness(
-                classification="STALE_HEARTBEAT",
-                severity="fail",
-                reason=(
-                    f"Heartbeat is {heartbeat_age:.0f}s old "
-                    f"(max_age={max_age_seconds}s) while coordinator "
-                    f"status is {coordinator_status!r}"
-                ),
-                coordinator_status_from_state=coordinator_status,
-                has_lifecycle_telemetry=has_lifecycle,
-                last_heartbeat_age_seconds=heartbeat_age,
-                has_recovery_events=has_recovery_events,
+            return _make(
+                "STALE_HEARTBEAT",
+                "fail",
+                f"Heartbeat is {heartbeat_age:.0f}s old "
+                f"(max_age={max_age_seconds}s) while coordinator "
+                f"status is {coordinator_status!r}",
+                overdue_seconds=heartbeat_age,
             )
         if not coordinator_status and not has_lifecycle:
-            return CoordinatorLiveness(
-                classification="COORDINATOR_UNKNOWN",
-                severity="warn",
-                reason=("No coordinator status or lifecycle telemetry available"),
-                coordinator_status_from_state=coordinator_status,
-                has_lifecycle_telemetry=has_lifecycle,
-                last_heartbeat_age_seconds=max(heartbeat_age, 0.0),
-                has_recovery_events=has_recovery_events,
+            return _make(
+                "COORDINATOR_UNKNOWN",
+                "warn",
+                "No coordinator status or lifecycle telemetry available",
             )
-        return CoordinatorLiveness(
-            classification="RUNNING_HEALTHY",
-            severity="pass",
-            reason=(
-                f"Coordinator status is {coordinator_status!r} "
-                "and heartbeat is fresh"
-            ),
-            coordinator_status_from_state=coordinator_status,
-            has_lifecycle_telemetry=has_lifecycle,
-            last_heartbeat_age_seconds=max(heartbeat_age, 0.0),
-            has_recovery_events=has_recovery_events,
+        return _make(
+            "RUNNING_HEALTHY",
+            "pass",
+            f"Coordinator status is {coordinator_status!r} " "and heartbeat is fresh",
         )
 
-    if coordinator_status == "recovering":
-        return CoordinatorLiveness(
-            classification="RECOVERY_IN_PROGRESS",
-            severity="warn",
-            reason="Coordinator status indicates recovery in progress",
-            coordinator_status_from_state=coordinator_status,
-            has_lifecycle_telemetry=has_lifecycle,
-            last_heartbeat_age_seconds=max(heartbeat_age, 0.0),
-            has_recovery_events=has_recovery_events,
-        )
-
-    return CoordinatorLiveness(
-        classification="COORDINATOR_UNKNOWN",
-        severity="warn",
-        reason=(f"Unknown coordinator_status={coordinator_status!r}"),
-        coordinator_status_from_state=coordinator_status,
-        has_lifecycle_telemetry=has_lifecycle,
-        last_heartbeat_age_seconds=max(heartbeat_age, 0.0),
-        has_recovery_events=has_recovery_events,
+    return _make(
+        "COORDINATOR_UNKNOWN",
+        "warn",
+        f"Unknown coordinator_status={coordinator_status!r}",
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #3386 — Evidence Harvester coordinator sleep/wake failure and watchdog detection.

## Root Cause

**UTC timestamp drift (2h):** \_now_utc()\ called \cdb_utcnow().astimezone(UTC)\ on naive \datetime.utcnow()\. Python interprets naive datetimes as system **local** time, then converts to UTC, shifting events ~2h backward (e.g. 18:44:14 CEST → 16:44:14Z).

**Sleep hang:** coordinator used \	ime.sleep(cadence)\ which hangs indefinitely on OS suspension, process pause, or clock jump — watchdog only runs at cycle boundaries and never fires during a stuck sleep.

## Changes

### Bugfixes
- \_now_utc()\ in coordinator.py, watchdog.py, runner.py: check \	zinfo is None\ and \.replace(tzinfo=UTC)\ instead of converting naive → local → UTC
- coordinator sleep loop: replace single \	ime.sleep(900)\ with interval-based 60s chunks, detect overshoot >60s, write \sleep_overshoot\ event

### Watchdog hardening
- Add \overdue_seconds: float\ field to \CoordinatorLiveness\ dataclass for precise diagnostics
- Refactor \_classify_coordinator_liveness\ with \_make()\ helper to reduce duplication and consistently populate \overdue_seconds\
- \STALE_NEXT_CYCLE\ and \SLEEPING_UNTIL_NEXT_CYCLE\ (warn) now carry \overdue_seconds\ in report JSON

### Tests
- \	est_sleep_with_interval_check\ (exact, partial, zero-duration chunking)
- \	est_now_utc_returns_aware_datetime_when_cdb_utcnow_is_naive\ (verifies no 2h drift)
- \	est_now_utc_preserves_aware_datetime\ (backward compat)
- \overdue_seconds\ assertions on \	est_liveness_sleeping_warn_within_tolerance\ and \	est_liveness_stale_next_cycle\

## Validation
- 219/219 evidence harvester tests pass
- ruff check + black --check pass

## Remaining Issues (not closed)
- #3374 — harvester runs beyond 24h (separate scheduler concern)
- #3362 — 7-cycle watchdog FAULT recovery gap (shadow-level, separate issue)
- #3345 — live readiness (LR remains NO-GO)