### PR TITLE
fix(evidence-harvester): harden remaining UTC helpers

### DIFF
--- a/tests/unit/tools/evidence_harvester/test_utc_helpers.py
+++ b/tests/unit/tools/evidence_harvester/test_utc_helpers.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib
+from datetime import UTC, datetime
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+PATCHED_HELPERS: tuple[tuple[str, str], ...] = (
+    ("tools.evidence_harvester.boot", "_now_utc"),
+    ("tools.evidence_harvester.ops_validation", "_now_utc"),
+    ("tools.evidence_harvester.snapshot", "utc_now"),
+    ("tools.evidence_harvester.validation", "_now_utc"),
+    ("tools.evidence_harvester.write_audit", "_now_utc"),
+)
+
+
+def _load(module_name: str) -> ModuleType:
+    return importlib.import_module(module_name)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("module_name", "helper_name"), PATCHED_HELPERS)
+def test_utc_helper_returns_aware_utc_when_cdb_utcnow_is_naive(
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+    helper_name: str,
+) -> None:
+    module = _load(module_name)
+    naive_utc = datetime(2026, 6, 20, 18, 44, 13)
+
+    monkeypatch.setattr(module, "cdb_utcnow", lambda: naive_utc)
+
+    result = getattr(module, helper_name)()
+
+    assert result == naive_utc.replace(tzinfo=UTC)
+    assert result.tzinfo == UTC
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("module_name", "helper_name"), PATCHED_HELPERS)
+def test_utc_helper_preserves_aware_utc(
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+    helper_name: str,
+) -> None:
+    module = _load(module_name)
+    aware_utc = datetime(2026, 6, 20, 18, 44, 13, tzinfo=UTC)
+
+    monkeypatch.setattr(module, "cdb_utcnow", lambda: aware_utc)
+
+    result = getattr(module, helper_name)()
+
+    assert result == aware_utc
+    assert result.tzinfo == UTC
+
+
+@pytest.mark.unit
+def test_no_unsafe_cdb_utcnow_astimezone_pattern_remains() -> None:
+    repo_root = Path(__file__).resolve().parents[4]
+    harvester_dir = repo_root / "tools" / "evidence_harvester"
+    unsafe_pattern = "cdb_utcnow().astimezone(UTC)"
+
+    offenders = [
+        path.relative_to(repo_root).as_posix()
+        for path in sorted(harvester_dir.glob("*.py"))
+        if unsafe_pattern in path.read_text(encoding="utf-8")
+    ]
+
+    assert offenders == []

--- a/tools/evidence_harvester/boot.py
+++ b/tools/evidence_harvester/boot.py
@@ -57,7 +57,10 @@ def _format_ts(value: datetime) -> str:
 
 
 def _now_utc() -> datetime:
-    return cdb_utcnow().astimezone(UTC)
+    now = cdb_utcnow()
+    if now.tzinfo is None:
+        return now.replace(tzinfo=UTC)
+    return now.astimezone(UTC)
 
 
 def _format_json(payload: Mapping[str, Any], pretty: bool) -> str:

--- a/tools/evidence_harvester/ops_validation.py
+++ b/tools/evidence_harvester/ops_validation.py
@@ -143,7 +143,10 @@ class OpsValidationReport:
 
 
 def _now_utc() -> datetime:
-    return cdb_utcnow().astimezone(UTC)
+    now = cdb_utcnow()
+    if now.tzinfo is None:
+        return now.replace(tzinfo=UTC)
+    return now.astimezone(UTC)
 
 
 def _format_ts(value: datetime) -> str:

--- a/tools/evidence_harvester/snapshot.py
+++ b/tools/evidence_harvester/snapshot.py
@@ -25,7 +25,10 @@ class SnapshotValidationError(ValueError):
 
 
 def utc_now() -> datetime:
-    return cdb_utcnow().astimezone(UTC)
+    now = cdb_utcnow()
+    if now.tzinfo is None:
+        return now.replace(tzinfo=UTC)
+    return now.astimezone(UTC)
 
 
 def _hash_payload(payload: Mapping[str, Any]) -> str:

--- a/tools/evidence_harvester/validation.py
+++ b/tools/evidence_harvester/validation.py
@@ -555,7 +555,7 @@ def validate_24h_window(
     else:
         verdict = "PASS"
 
-    now = cdb_utcnow().astimezone(UTC)
+    now = _now_utc()
     return ValidationReport(
         schema_version="cdb.evidence_harvester.24h_validation.v1",
         validated_at_utc=_format_ts(now),
@@ -600,7 +600,7 @@ def validate_24h_window_from_dir(
     if not alert_paths:
         alert_paths = sorted(artifact_dir.glob("alerts_*.json"))
 
-    window_end = window_end_utc or cdb_utcnow().astimezone(UTC)
+    window_end = window_end_utc or _now_utc()
     if window_start_utc is None:
         window_start = window_end - timedelta(hours=DEFAULT_EXPECTED_WINDOW_HOURS)
     else:
@@ -660,7 +660,10 @@ def report_to_markdown(report: ValidationReport) -> str:
 
 
 def _now_utc() -> datetime:
-    return cdb_utcnow().astimezone(UTC)
+    now = cdb_utcnow()
+    if now.tzinfo is None:
+        return now.replace(tzinfo=UTC)
+    return now.astimezone(UTC)
 
 
 def parse_args(argv: list[str] | None = None) -> Any:

--- a/tools/evidence_harvester/write_audit.py
+++ b/tools/evidence_harvester/write_audit.py
@@ -56,7 +56,10 @@ def _format_ts(value: datetime) -> str:
 
 
 def _now_utc() -> datetime:
-    return cdb_utcnow().astimezone(UTC)
+    now = cdb_utcnow()
+    if now.tzinfo is None:
+        return now.replace(tzinfo=UTC)
+    return now.astimezone(UTC)
 
 
 def _require_mapping(value: Any, field_name: str) -> Mapping[str, Any]:


### PR DESCRIPTION
Closes #3388
Refs #3374
Refs #3386
Refs #3362

## Brain Evidence
brain_source: repo-only
brain_status: not-used
tools_or_queries:
- context.briefing returned LOW/mock context with no evidence_records, claim_records, decision_events, or memory_records.
- context.required_reads resolved canonical repo reads.
- GitHub live checks via gh CLI for #3374, #3362, #3386, duplicate issue search, and open PR list.
- Repo audit via rg for cdb_utcnow().astimezone(UTC), datetime.utcnow(), and def utc_now.
records_or_results:
- records_found=0 from Context Brain; no DB-backed claims used.
- Duplicate search found no existing open narrow UTC helper bug issue.
- #3388 created as deduplicated bug issue.
repo_crosscheck:
- AGENTS.md, agents/AGENTS.md, agents/OPEN_CODE_AGENTS.md.
- CONTROL_REGISTER.md, CURRENT_STATUS.md, docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md.
- tools/evidence_harvester/{boot.py,snapshot.py,write_audit.py,validation.py,ops_validation.py}.
impact_on_plan:
- Keep fix bounded to Evidence Harvester helpers.
- Do not modify core/utils/clock.py.
- Do not start a new 72h run.
limitations:
- Context Brain had no usable DB-backed records.
- Existing unrelated untracked local files were left untouched and unstaged.

## Changed files
- tools/evidence_harvester/boot.py
- tools/evidence_harvester/snapshot.py
- tools/evidence_harvester/write_audit.py
- tools/evidence_harvester/validation.py
- tools/evidence_harvester/ops_validation.py
- tests/unit/tools/evidence_harvester/test_utc_helpers.py

## Validation
- git diff --check
- python -m pytest tests/unit/tools/evidence_harvester -q
- ruff check tools/evidence_harvester tests/unit/tools/evidence_harvester
- black --check tools/evidence_harvester tests/unit/tools/evidence_harvester
- rg -n "cdb_utcnow\\(\\)\\.astimezone\\(UTC\\)" tools/evidence_harvester (no matches)

## Safety boundaries
- No Docker mutation.
- No DB mutation.
- No secrets access.
- No runtime or Windows Task mutation.
- No new 72h run started.
- No LR-Go, Live-Go, or Echtgeld-Go.
- #3374, #3362, and #3345 remain open.