### PR TITLE
docs(evidence-harvester): remove Gordon gate drift

### DIFF
--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_72H_OPS_VALIDATION.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_72H_OPS_VALIDATION.md
@@ -149,7 +149,7 @@ python -m tools.evidence_harvester.scheduler uninstall --explicit
 
 ## Side-Effect Checklist
 
-- [ ] No Docker mutation unless Gordon gives a separate documented GO
+- [ ] No Docker mutation without documented Infra-Mutation-Gate approval
 - [ ] No runtime start beyond the dry runner loop itself
 - [ ] No DB mutation
 - [ ] No secrets output
@@ -157,10 +157,10 @@ python -m tools.evidence_harvester.scheduler uninstall --explicit
 - [ ] No LR-Go / Live-Go / Echtgeld-Go
 - [ ] No trading / order / risk / execution mutation
 
-## Gordon Consultation Checkpoint
+## Operator Approval Checkpoint
 
 Before any Docker or infrastructure mutation, stop and obtain a separate,
-documented Gordon operator GO.
+documented Jannek-Ops-GO / Infra-Mutation-Gate approval.
 
 ## Status Boundary
 

--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
@@ -397,7 +397,7 @@ Boot readiness (#3360) is the precondition for #3362:
 - Boot readiness **detects** Docker availability (`Docker available: yes/no`).
 - Boot readiness does **not** start Docker, run `docker compose up`, or perform
   any Docker mutation.
-- Docker enablement requires a separate INFRA-GO from Gordon as part of #3362.
+- Docker enablement requires a separate Infra-Mutation-Gate approval as part of #3362.
 - The `install-plan` mode prints the intended Docker command but does not
   execute it.
 

--- a/tests/smoke/test_onboarding_scenario_contract.py
+++ b/tests/smoke/test_onboarding_scenario_contract.py
@@ -70,6 +70,11 @@ ACTIVE_CANON_GORDON_PATHS = [
     "docs/onboarding/ONBOARDING_SCENARIO_001_FRESH_AGENT_SAFE_WORK_DRILL.md",
     "DEVELOPER_ONBOARDING.md",
     "README.md",
+    "tools/evidence_harvester/README.md",
+    "tools/evidence_harvester/boot.py",
+    "tools/evidence_harvester/ops_validation.py",
+    "docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md",
+    "docs/runbooks/CDB_EVIDENCE_HARVESTER_72H_OPS_VALIDATION.md",
 ]
 
 GORDON_ALLOWED_CONTEXTS = [
@@ -91,17 +96,13 @@ def read_text(relative_path: str) -> str:
 def assert_terms_in_text(text: str, terms: list[str], source_label: str):
     missing = [t for t in terms if t not in text]
     if missing:
-        pytest.fail(
-            f"{source_label}: missing required term(s): {missing}"
-        )
+        pytest.fail(f"{source_label}: missing required term(s): {missing}")
 
 
 def assert_terms_absent(text: str, terms: list[str], source_label: str):
     found = [t for t in terms if t in text]
     if found:
-        pytest.fail(
-            f"{source_label}: forbidden term(s) present: {found}"
-        )
+        pytest.fail(f"{source_label}: forbidden term(s) present: {found}")
 
 
 class TestOnboardingScenarioPaths:
@@ -112,9 +113,7 @@ class TestOnboardingScenarioPaths:
 
     def test_no_archive_paths_in_required(self):
         for p in REQUIRED_PATHS:
-            assert "docs/archive" not in p, (
-                f"Archive path found in required paths: {p}"
-            )
+            assert "docs/archive" not in p, f"Archive path found in required paths: {p}"
 
 
 class TestOnboardingScenarioTerms:
@@ -140,9 +139,9 @@ class TestOnboardingScenarioTerms:
         text = read_text(self.SCENARIO_DOC)
         assert "trade-capable" in text
         for meaning in SAFETY_MEANINGS:
-            assert meaning in text, (
-                f"{self.SCENARIO_DOC}: missing safety separation term '{meaning}'"
-            )
+            assert (
+                meaning in text
+            ), f"{self.SCENARIO_DOC}: missing safety separation term '{meaning}'"
 
     def test_scenario_no_secrets_output(self):
         text = read_text(self.SCENARIO_DOC)
@@ -172,9 +171,7 @@ class TestSafetyContract:
         ]
         found = [t for t in no_go_variants if t in text]
         if not found:
-            pytest.fail(
-                f"{self.LR_DOC}: no NO-GO pattern found"
-            )
+            pytest.fail(f"{self.LR_DOC}: no NO-GO pattern found")
         assert "NO-GO" in text or "no-go" in text
 
     def test_develop_doc_safety_boundaries(self):
@@ -189,9 +186,7 @@ class TestSafetyContract:
         forbidden = ["live go", "live-go", "echtgeld-go"]
         found = [t for t in forbidden if t in text]
         if found:
-            pytest.fail(
-                f"README.md: contains forbidden term(s): {found}"
-            )
+            pytest.fail(f"README.md: contains forbidden term(s): {found}")
 
     def test_trading_mode_default_is_safe(self):
         from core.config.trading_mode import TradingMode
@@ -205,7 +200,8 @@ class TestSafetyContract:
         assert "trade-capable" in text
         go_phrases = ["LR remains NO-GO", "LR-050" in text and "NO-GO" in text]
         assert any(
-            phrase for phrase in ["LR remains NO-GO", "kein Live-Kapital", "LR-050"]
+            phrase
+            for phrase in ["LR remains NO-GO", "kein Live-Kapital", "LR-050"]
             if phrase in text
         )
 
@@ -290,9 +286,7 @@ class TestLiveReadinessFile:
         no_go_variants = ["NO-GO", "No-Go", "no-go"]
         found = [t for t in no_go_variants if t in text]
         if not found:
-            pytest.fail(
-                f"{self.LR_DOC}: no NO-GO variant found"
-            )
+            pytest.fail(f"{self.LR_DOC}: no NO-GO variant found")
 
     def test_lr_file_structure(self):
         text = read_text(self.LR_DOC)
@@ -302,9 +296,9 @@ class TestLiveReadinessFile:
             "NO-GO",
         ]
         for section in expected_sections:
-            assert section in text, (
-                f"{self.LR_DOC}: missing expected section '{section}'"
-            )
+            assert (
+                section in text
+            ), f"{self.LR_DOC}: missing expected section '{section}'"
 
 
 class TestControlRegister:

--- a/tests/unit/tools/evidence_harvester/test_boot.py
+++ b/tests/unit/tools/evidence_harvester/test_boot.py
@@ -170,7 +170,7 @@ def test_render_operator_handoff_includes_install_instructions(
     output = capsys.readouterr().out
     assert "Windows Task Scheduler" in output
     assert "Docker-based background runner" in output
-    assert "Gordon" in output
+    assert "Infra-Mutation-Gate" in output
     assert "3362" in output
     assert "No LR-Go" in output
 

--- a/tools/evidence_harvester/README.md
+++ b/tools/evidence_harvester/README.md
@@ -580,7 +580,7 @@ pwsh -NoProfile -File .\scripts\evidence_harvester_boot.ps1 -Action status -Pret
 - Default mode is `status` (read-only assessment)
 - No Docker start/stop, runtime start, DB mutation, secrets access, or network write
 - `install-plan` prints steps but does not execute them
-- Docker mutation requires separate INFRA-GO from Gordon
+- Docker mutation requires separate Infra-Mutation-Gate approval
 - Windows Task install requires separate GO (see #3362 OPS validation)
 - No LR-Go, no Live-Go, no Echtgeld-Go
 

--- a/tools/evidence_harvester/boot.py
+++ b/tools/evidence_harvester/boot.py
@@ -582,12 +582,12 @@ def _render_operator_handoff_md(report: BootReadinessReport) -> str:
         "   python -m tools.evidence_harvester.scheduler install --fixture <path> --explicit",
         "   ```",
         "",
-        "3. **Enable Docker-based background runner** (requires separate Docker GO from Gordon):",
+        "3. **Enable Docker-based background runner** (requires separate Docker/infra GO via Infra-Mutation-Gate):",
         "",
         "   - Verify `docker_available` is True in boot readiness.",
         "   - Use `boot install-plan` to see the full command surface before any Docker action.",
         "   - Do not start Docker stack from the boot module — Docker mutation requires explicit",
-        "     INFRA-GO from Gordon (see #3362 OPS validation runbook).",
+        "     Infra-Mutation-Gate approval (see #3362 OPS validation runbook).",
         "",
         "4. **Verify scheduled task runs**:",
         "",
@@ -608,7 +608,7 @@ def _render_operator_handoff_md(report: BootReadinessReport) -> str:
         "- Windows Task Scheduler starts the harvester daily at the configured time.",
         "- The boot module can be run at any time to verify readiness post-reboot.",
         "- If Docker is used instead, a Docker restart policy or Windows scheduled task",
-        "  restart is needed — both require explicit GO from Gordon.",
+        "  restart is needed — both require explicit Infra-Mutation-Gate approval.",
         "",
         "## Safety",
         "- No LR-Go, no Live-Go, no Echtgeld-Go.",
@@ -664,7 +664,7 @@ def _render_report_md(report: BootReadinessReport) -> str:
             "- No Docker, runtime, DB, secrets, or network write action.",
             "- Boot readiness is read-only; does not modify files or start services.",
             "- Default mode is status-only.",
-            "- For Docker/infra mutation, separate GO from Gordon required.",
+            "- For Docker/infra mutation, separate Infra-Mutation-Gate approval required.",
         ]
     )
     return "\n".join(lines) + "\n"
@@ -818,13 +818,13 @@ def _build_install_plan_payload(
             {
                 "step": "start-docker-stack",
                 "command": "docker compose -f infrastructure/compose/compose.blue.yml up -d",
-                "requires_go": "Gordon INFRA-GO",
+                "requires_go": "separate Infra-Mutation-Gate approval",
             },
         ],
         "safety": [
             "Plan-only. No action taken.",
             "No Docker/runtime/DB/secrets mutation.",
-            "Each step requires its own GO gate (3362, Gordon).",
+            "Each step requires its own GO gate (3362 OPS_VALIDATION, Infra-Mutation-Gate).",
             "No LR-Go / No Live-Go / No Echtgeld-Go.",
         ],
     }

--- a/tools/evidence_harvester/ops_validation.py
+++ b/tools/evidence_harvester/ops_validation.py
@@ -117,7 +117,7 @@ class RuntimeHandoff:
     start_commands: tuple[str, ...]
     stop_commands: tuple[str, ...]
     side_effect_checklist: tuple[str, ...]
-    gordon_consultation_checkpoint: str
+    operator_approval_checkpoint: str
     safety_statement: str
     notes: tuple[str, ...]
 
@@ -281,14 +281,14 @@ def _build_runtime_handoff(
             ),
         ),
         side_effect_checklist=(
-            "No Docker start/stop or compose mutation unless Gordon explicitly approves it.",
+            "No Docker start/stop or compose mutation without explicit operator approval.",
             "No runtime, DB, Redis, secrets, or GitHub write action from module code.",
             "No LR-Go, no Live-Go, no Echtgeld-Go.",
             "No trading, order, risk, or execution mutation.",
         ),
-        gordon_consultation_checkpoint=(
-            "Before any Docker or infrastructure mutation, stop and obtain a separate "
-            "documented Gordon operator GO."
+        operator_approval_checkpoint=(
+            "Before any Docker or infrastructure mutation, stop and obtain documented "
+            "explicit operator approval via Jannek-Ops-GO / Infra-Mutation-Gate."
         ),
         safety_statement=(
             "Dry/paper/research only. LR remains NO-GO. No Live-Go. No Echtgeld-Go."
@@ -1705,8 +1705,8 @@ def report_to_markdown(report: OpsValidationReport) -> str:
     lines.extend(
         [
             "",
-            "### Gordon Checkpoint",
-            f"- {handoff['gordon_consultation_checkpoint']}",
+            "### Operator Approval Checkpoint",
+            f"- {handoff['operator_approval_checkpoint']}",
             "",
             "### Safety Statement",
             f"- {handoff['safety_statement']}",


### PR DESCRIPTION
Closes #3379

Refs #3345
Refs #3362
Refs #3374

## Brain Evidence

\\\
brain_source: repo-only
brain_status: not-used
tools_or_queries:
  - rg (Gordon references in active files)
  - gh (GitHub issue/PR state)
  - git (working tree state)
records_or_results:
  - 5 active files with Gordon references found and fixed
context_brain_attempted: true
context_brain_used: false
repo_fallback_used: true
repo_fallback_reason: insufficient_evidence
context_tool_status: available
context_trust_level: low
records_found: none
\\\

## Changed files

- \	ools/evidence_harvester/ops_validation.py\ — renamed \gordon_consultation_checkpoint\ -> \operator_approval_checkpoint\, replaced Gordon language with Jannek-Ops-GO / Infra-Mutation-Gate
- \	ools/evidence_harvester/boot.py\ — replaced 6 Gordon refs with current governance terms
- \	ools/evidence_harvester/README.md\ — replaced Gordon INFRA-GO with Infra-Mutation-Gate
- \docs/runbooks/CDB_EVIDENCE_HARVESTER_72H_OPS_VALIDATION.md\ — Gordon Consultation Checkpoint -> Operator Approval Checkpoint
- \docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md\ — replaced Gordon INFRA-GO reference
- \	ests/unit/tools/evidence_harvester/test_boot.py\ — updated assertion to expect Infra-Mutation-Gate
- \	ests/smoke/test_onboarding_scenario_contract.py\ — added harvester paths to regression check list

## Validation

- \python -m pytest tests/unit/tools/evidence_harvester -q\: **230 passed**
- \uff check tools/evidence_harvester tests/unit/tools/evidence_harvester\: **all checks passed**
- \lack --check tools/evidence_harvester tests/unit/tools/evidence_harvester\: **all unchanged**
- \pytest tests/smoke/test_onboarding_scenario_contract.py::TestGordonRegression -q\: **3 passed**
- \g -n Gordon tools/evidence_harvester/ docs/runbooks/ tests/\: **no active harvester Gordon references**
- \git diff --check\: **clean**

## Safety boundaries

- No runtime behavior change
- No Docker mutation
- No DB mutation
- No secrets access
- No LR-Go / Live-Go / Echtgeld-Go
- No 72h run start/stop/checkpoint
- No Windows Task installation
- Untracked files remain unstaged