### PR TITLE
[DOCS] Add CDB Strategic Idea Lab entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Diese Root-README ist die GitHub-Haupt-Landingpage. Der aktive Pfad bleibt Shado
 
 ## Start Here
 
+- Strategic Idea Lab: [`docs/strategy/CDB_STRATEGIC_IDEA_LAB.md`](docs/strategy/CDB_STRATEGIC_IDEA_LAB.md) — public CDB strategy and architecture drafts, discussion material, and future-state explorations
 - Neue Entwickler: [`DEVELOPER_ONBOARDING.md`](DEVELOPER_ONBOARDING.md)
 - Kurzer Docs-Index: [`docs/index.md`](docs/index.md)
 - Agenten-Bootloader: [`AGENTS.md`](AGENTS.md) -> [`agents/AGENTS.md`](agents/AGENTS.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ sondern ein Pointer auf die bestehenden Docs, Runbooks und Source Trees.
 | den Echtgeld-Go/No-Go-Stand brauchst | [docs/live-readiness/README.md](live-readiness/README.md) | Single Source of Truth fuer Live-Readiness |
 | Board-, Milestone- oder Project-v2-Automation brauchst | [docs/runbooks/project_board_automation.md](runbooks/project_board_automation.md) | Operativer Leitfaden fuer Board-Automation |
 | Paper-Trading-Runner (Port 8004) | [tools/paper_trading/README.md](../tools/paper_trading/README.md) | Compose-Service `cdb_paper_runner` |
+| Strategic Idea Lab (public CDB strategy & architecture Gists) | [docs/strategy/CDB_STRATEGIC_IDEA_LAB.md](strategy/CDB_STRATEGIC_IDEA_LAB.md) | Public future-state docs, discussion space, non-canonical strategic drafts |
 
 ## Kern-Pointer
 

--- a/docs/strategy/CDB_STRATEGIC_IDEA_LAB.md
+++ b/docs/strategy/CDB_STRATEGIC_IDEA_LAB.md
@@ -1,0 +1,87 @@
+# CDB Strategic Idea Lab
+
+## Purpose
+
+The CDB Strategic Idea Lab is a public collection of strategy, architecture, and product-line documents that explore where Claire de Binare could go next. It is an open space for ideas, discussion, and collaborative thinking — not a roadmap, not a commitment, and not an implementation plan.
+
+## What This Is
+
+- A **public reference point** for CDB's future-state architecture documents, published as GitHub Gists
+- A **discussion space** where ideas, criticism, suggestions, and further elaboration are welcome
+- A **bridge** between the active working repo (canon, code, evidence, governance) and external strategic thinking
+- A **collection of curated documents** covering profitability scaling, validation platforms, context intelligence, cloud operations, client products, and future-domain exploration
+
+## What This Is Not
+
+- **Not** a roadmap — no delivery deadlines, no milestone commitments
+- **Not** a specification — no implementation-ready contracts or API definitions
+- **Not** an authority — no document in this lab overrides repo canon, issues, PRs, governance, or live-readiness status
+- **Not** a Live-Go, Echtgeld-Go, Runtime-Go, DB-Go, or any operations or capital authorisation
+- **Not** a replacement for the active repository — the working repo remains the single source of truth for everything that runs
+
+## Public Gist Index
+
+All documents in the Strategic Idea Lab are published as public GitHub Gists, centrally indexed at:
+
+> [CDB Gist Publication Index](https://gist.github.com/jannekbuengener/2096b165498da8bce6f5489229fbf4f6)
+
+The index lists every published document, its role, its source, and the governing boundary for the entire set.
+
+## Document Pack
+
+The lab currently contains nine documents across the following areas:
+
+| Area | Document |
+|------|----------|
+| Umbrella orientation | Strategic Consolidation Report |
+| Profitability engine architecture | Profitability Scaling Architecture |
+| Validation platform | ARVP Validation Platform Blueprint |
+| Context intelligence | Context Intelligence System Endbild |
+| Cloud platform operating model | Hetzner Fullstack Cloud Platform Plan |
+| Client/product vision | Desktop App Client Platform Vision |
+| Future-domain concept | Betting Pipeline Concept |
+| Future-domain specification | Betting Architecture Integration Spec |
+| Multi-strategy target architecture | Multi-Strategy Gearbox Architecture |
+
+Each document is structurally unified (following the same 12-section template), cross-linked to its siblings, and clearly marked as non-canonical future-state material.
+
+## How To Use This Space
+
+- **Read and explore.** Start at the [Gist Index](https://gist.github.com/jannekbuengener/2096b165498da8bce6f5489229fbf4f6) and follow the recommended reading order.
+- **Discuss and criticise.** Open a GitHub Discussion, comment on a Gist, or raise an Issue in the repo if a document sparks an idea or a concern.
+- **Reference and remix.** Use these documents as raw material for your own strategic thinking, system design, or architecture brainstorming.
+- **Bring it back to the repo.** If an idea matures past the lab stage, the path forward is: Issue → Evidence → PR → Governance → Implementation. The lab is the front porch, not the building.
+
+## Discussion And Contributions
+
+Ideen, Kritik, Anregungen und Weiterentwicklung sind ausdrücklich willkommen.
+
+This is a creative strategy and architecture space. The documents are intentionally drafted as outward-facing artefacts — written to be read, questioned, and improved by anyone interested in CDB's direction.
+
+If you have a thought, a better approach, a missing perspective, or a concrete suggestion:
+
+- **Open a GitHub Issue** in the repo for structured feedback
+- **Comment on the Gist** for lightweight, document-level discussion
+- **Start a conversation** if you want to explore a topic before formalising it
+
+Serious proposals that survive lab-stage discussion should follow the standard CDB path: issue → evidence → PR → governance gate → implementation. The lab accelerates early thinking; it does not shortcut delivery.
+
+## Governance Boundaries
+
+- **Live-Readiness remains NO-GO.** No document in this lab changes the LR-050 verdict or authorises live capital.
+- **No Live-Go.** No document in this lab is a go-live signal.
+- **No Echtgeld-Go.** No document in this lab authorises real-money trading, betting, or any financial operation.
+- **No Runtime-Go.** No document in this lab authorises changes to running services, containers, or infrastructure.
+- **No DB-Go.** No document in this lab authorises database writes, migrations, or schema changes.
+- **No Risk-/Execution-/Allocation-Go.** No document in this lab overrides risk limits, execution gates, or allocation policies.
+- **Repo canon wins.** The active Claire de Binare repository, its issues, PRs, required checks, governance documents, and live-readiness SSOT override every document in this lab.
+- **CDB governance applies.** All rules from the [CDB Constitution](../knowledge/governance/CDB_CONSTITUTION.md), [CDB Governance](../knowledge/governance/CDB_GOVERNANCE.md), and [CDB Agent Policy](../knowledge/governance/CDB_AGENT_POLICY.md) apply to any activity that moves from lab discussion into repo work.
+- **Board stage `trade-capable` is orthogonal.** The Board stage does not imply live-readiness, and lab documents do not change Board stage.
+
+## Status
+
+**Current state:** `ACTIVE` — public Gists published, cross-links established, structurally unified.
+
+**Maintenance:** Documents may be updated, added, or retired as strategic thinking evolves. The Gist Index is the authoritative inventory.
+
+**Next step:** Discussion, feedback, and iteration. The lab is open.


### PR DESCRIPTION
## Purpose

Create a repo-backed entrypoint for the public CDB Strategic Idea Lab — a collection of strategy, architecture, and product-line documents published as GitHub Gists.

## Changed Files

| File | Change |
|------|--------|
| docs/strategy/CDB_STRATEGIC_IDEA_LAB.md | NEW — Strategic Idea Lab entrypoint document |
| docs/index.md | ADD — link to Strategic Idea Lab in task table |
| README.md | ADD — link in Start Here section |

## Gist Index Link

The central entry point is the CDB Gist Publication Index:
https://gist.github.com/jannekbuengener/2096b165498da8bce6f5489229fbf4f6

## Safety Boundaries

* LR remains NO-GO — no live, real-money, or runtime authorisation
* No DB, Docker, Risk, Execution, or Allocation changes
* Board stage 	rade-capable is orthogonal and unchanged
* All docs are marked non-canonical; repo canon, governance, issues, and PRs remain authoritative

## Validation

* Markdown formatting verified
* All internal repo links resolve (relative paths)
* Gist Index URL is the correct public Gist ID
* No old secret Gist IDs referenced
* No code, config, or runtime files changed
