### PR TITLE
[DOCS] Polish public CDB presentation entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Claire de Binare
 
-Claire de Binare (CDB) ist ein deterministisches, governance-first Trading-System im Working Repo Canon.
+Claire de Binare (CDB) is a deterministic, governance-first trading and validation system.
+This is the public GitHub landing page. CDB operates in shadow/paper mode — live capital is not authorised.
+
+[Deutsch] Claire de Binare (CDB) ist ein deterministisches, governance-first Trading-/Validation-System.
 Diese Root-README ist die GitHub-Haupt-Landingpage. Der aktive Pfad bleibt Shadow/Paper-first; Live-Kapital ist nicht freigegeben.
 
 ## Start Here
 
-- Strategic Idea Lab: [`docs/strategy/CDB_STRATEGIC_IDEA_LAB.md`](docs/strategy/CDB_STRATEGIC_IDEA_LAB.md) — public CDB strategy and architecture drafts, discussion material, and future-state explorations
+- [CDB Strategic Idea Lab](docs/strategy/CDB_STRATEGIC_IDEA_LAB.md) — public strategy and architecture drafts, discussion space, and creative exploration around CDB's future-state concepts. Ideas, critique, and suggestions are welcome.
 - Neue Entwickler: [`DEVELOPER_ONBOARDING.md`](DEVELOPER_ONBOARDING.md)
 - Kurzer Docs-Index: [`docs/index.md`](docs/index.md)
 - Agenten-Bootloader: [`AGENTS.md`](AGENTS.md) -> [`agents/AGENTS.md`](agents/AGENTS.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ sondern ein Pointer auf die bestehenden Docs, Runbooks und Source Trees.
 | den Echtgeld-Go/No-Go-Stand brauchst | [docs/live-readiness/README.md](live-readiness/README.md) | Single Source of Truth fuer Live-Readiness |
 | Board-, Milestone- oder Project-v2-Automation brauchst | [docs/runbooks/project_board_automation.md](runbooks/project_board_automation.md) | Operativer Leitfaden fuer Board-Automation |
 | Paper-Trading-Runner (Port 8004) | [tools/paper_trading/README.md](../tools/paper_trading/README.md) | Compose-Service `cdb_paper_runner` |
-| Strategic Idea Lab (public CDB strategy & architecture Gists) | [docs/strategy/CDB_STRATEGIC_IDEA_LAB.md](strategy/CDB_STRATEGIC_IDEA_LAB.md) | Public future-state docs, discussion space, non-canonical strategic drafts |
+| Strategic Idea Lab (öffentlicher Strategie-/Architektur-Diskussionsraum) | [docs/strategy/CDB_STRATEGIC_IDEA_LAB.md](strategy/CDB_STRATEGIC_IDEA_LAB.md) | Public Gist-Pack mit Future-State-Architektur, Produktlinien und strategischen Ideen — Diskussion und Kritik willkommen |
 
 ## Kern-Pointer
 

--- a/docs/strategy/CDB_STRATEGIC_IDEA_LAB.md
+++ b/docs/strategy/CDB_STRATEGIC_IDEA_LAB.md
@@ -1,8 +1,12 @@
 # CDB Strategic Idea Lab
 
+**Strategischer Ideen-, Diskussions- und Ausarbeitungsraum — Strategic Idea Lab for Claire de Binare.**
+
+Claire de Binare (CDB) is a deterministic, governance-first trading and validation system that currently operates in shadow/paper mode (no live capital, no real-money trading). This lab is the public front porch for strategic thinking around CDB's future.
+
 ## Purpose
 
-The CDB Strategic Idea Lab is a public collection of strategy, architecture, and product-line documents that explore where Claire de Binare could go next. It is an open space for ideas, discussion, and collaborative thinking — not a roadmap, not a commitment, and not an implementation plan.
+The CDB Strategic Idea Lab is a public collection of strategy, architecture, product-line, and future-state documents — an open space for ideas, discussion, collaborative thinking, and creative exploration. It is not a roadmap, not a commitment, and not an implementation plan.
 
 ## What This Is
 
@@ -48,15 +52,18 @@ Each document is structurally unified (following the same 12-section template), 
 ## How To Use This Space
 
 - **Read and explore.** Start at the [Gist Index](https://gist.github.com/jannekbuengener/2096b165498da8bce6f5489229fbf4f6) and follow the recommended reading order.
+- **Send ideas and feedback.** Have a thought, a better approach, or a missing perspective? Open a GitHub Issue, comment on a Gist, or start a conversation. Every perspective helps.
 - **Discuss and criticise.** Open a GitHub Discussion, comment on a Gist, or raise an Issue in the repo if a document sparks an idea or a concern.
 - **Reference and remix.** Use these documents as raw material for your own strategic thinking, system design, or architecture brainstorming.
 - **Bring it back to the repo.** If an idea matures past the lab stage, the path forward is: Issue → Evidence → PR → Governance → Implementation. The lab is the front porch, not the building.
 
 ## Discussion And Contributions
 
+**Ideas, critique, and suggestions are welcome.** This is a creative strategy and architecture space — an open invitation to think together about what CDB could become.
+
 Ideen, Kritik, Anregungen und Weiterentwicklung sind ausdrücklich willkommen.
 
-This is a creative strategy and architecture space. The documents are intentionally drafted as outward-facing artefacts — written to be read, questioned, and improved by anyone interested in CDB's direction.
+The documents are intentionally drafted as outward-facing artefacts — written to be read, questioned, and improved by anyone interested in CDB's direction.
 
 If you have a thought, a better approach, a missing perspective, or a concrete suggestion:
 


### PR DESCRIPTION
## Purpose

Polish the public CDB presentation entrypoints on README, docs/index, and the Strategic Idea Lab document to make the project and its public Gist pack clearer and more welcoming for external visitors.

## Changed Files

| File | Change |
|------|--------|
| README.md | ADD English intro for external visitors; bilingual landing (EN + DE); cleaner Strategic Idea Lab link with explicit "Ideas, critique, and suggestions are welcome" message |
| docs/index.md | IMPROVE Idea Lab entry description — now mentions public Gist pack, architecture drafts, and discussion |
| docs/strategy/CDB_STRATEGIC_IDEA_LAB.md | ADD German strategic sub-headline; ADD CDB context intro sentence; STRENGTHEN welcome messaging; ADD "Send ideas and feedback" item under How To Use |

## Key Links

- Strategic Idea Lab: docs/strategy/CDB_STRATEGIC_IDEA_LAB.md
- Gist Index: https://gist.github.com/jannekbuengener/2096b165498da8bce6f5489229fbf4f6

## Safety Boundaries

* LR remains NO-GO — no live, real-money, or runtime authorisation
* No DB, Docker, Risk, Execution, or Allocation changes
* Board stage trade-capable is orthogonal and unchanged
* No Gist edits or new Gists

## Validation

* Markdown formatting clean
* All internal repo links resolve (relative paths)
* Gist Index URL is the correct public ID (2096b165...)
* No old secret Gist IDs
* No code, config, or runtime files changed

## Optional Suggestion: GitHub About / Topics

For consideration (no metadata writes without separate GO):

- Description: "Deterministic governance-first trading and validation system. Shadow/paper-mode. Strategic Idea Lab at docs/strategy/CDB_STRATEGIC_IDEA_LAB.md"
- Topics: trading, validation, deterministic-trading, governance-first, python, system-design
