### PR TITLE
[DOCS] Add Strategic Idea Lab contribution intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/strategic_idea_lab.yml
+++ b/.github/ISSUE_TEMPLATE/strategic_idea_lab.yml
@@ -95,10 +95,10 @@ body:
     id: model_name
     attributes:
       label: Model Name
-      description: If AI-generated, include the model name (e.g. Claude 4 Opus, GPT-5, Gemini 3.0)
+      description: Required. AI agents must include the model name (e.g. Claude 4 Opus, GPT-5, Gemini 3.0). Human contributors enter "N/A".
       placeholder: "N/A"
     validations:
-      required: false
+      required: true
 
   - type: checkboxes
     id: boundary

--- a/.github/ISSUE_TEMPLATE/strategic_idea_lab.yml
+++ b/.github/ISSUE_TEMPLATE/strategic_idea_lab.yml
@@ -1,0 +1,110 @@
+name: CDB Strategic Idea Lab Contribution
+description: Submit structured ideas, critique, questions, risk notes, improvement suggestions, or AI agent comments for the Strategic Idea Lab.
+title: "[Idea Lab] "
+labels: ["status:idea"]
+body:
+  - type: dropdown
+    id: contribution_type
+    attributes:
+      label: Contribution Type
+      options:
+        - Idea
+        - Critique
+        - Question
+        - Risk Note
+        - Improvement Suggestion
+        - AI Agent Comment
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected_document
+    attributes:
+      label: Affected Document / Area
+      options:
+        - Strategic Consolidation
+        - Profitability
+        - ARVP
+        - Context Intelligence
+        - Hetzner
+        - Desktop App
+        - Betting Pipeline
+        - Betting Architecture
+        - Gearbox
+        - General
+    validations:
+      required: true
+
+  - type: input
+    id: short_description
+    attributes:
+      label: Short Description
+      description: One-line summary of your contribution
+      placeholder: "Briefly describe your idea, critique, or suggestion"
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggestion / Comment
+      description: Your full proposal, thought, critique, or question
+      placeholder: "Detailed description of your contribution..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: relevance
+    attributes:
+      label: Why Is This Relevant?
+      description: How does this contribute to CDB's strategic direction?
+      placeholder: "Explain the relevance"
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence / References
+      description: Links, documents, data, or prior work that support this contribution (optional)
+      placeholder: "Any supporting evidence or links"
+    validations:
+      required: false
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks / Open Questions
+      description: Potential downsides, trade-offs, or unanswered questions (optional)
+      placeholder: "Risks or open questions to consider"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: ai_generated
+    attributes:
+      label: Is This AI-Generated?
+      description: All AI-generated contributions must be declared and include the model name
+      options:
+        - "No"
+        - "Yes"
+    validations:
+      required: true
+
+  - type: input
+    id: model_name
+    attributes:
+      label: Model Name
+      description: If AI-generated, include the model name (e.g. Claude 4 Opus, GPT-5, Gemini 3.0)
+      placeholder: "N/A"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: boundary
+    attributes:
+      label: Contribution Boundary
+      description: Every contribution to the Strategic Idea Lab is non-authoritative
+      options:
+        - label: "I understand this is a non-authoritative Strategic Idea Lab contribution and not a Canon decision, Live-Go, Echtgeld-Go, Runtime-Go, DB-Go, Docker-Go, Risk-Go, Execution-Go, or Allocation-Go."
+          required: true

--- a/docs/strategy/CDB_STRATEGIC_IDEA_LAB.md
+++ b/docs/strategy/CDB_STRATEGIC_IDEA_LAB.md
@@ -67,7 +67,7 @@ The documents are intentionally drafted as outward-facing artefacts — written 
 
 If you have a thought, a better approach, a missing perspective, or a concrete suggestion:
 
-- **Open a GitHub Issue** in the repo for structured feedback
+- **Open a [Strategic Idea Lab contribution issue](https://github.com/jannekbuengener/Claire_de_Binare/issues/new?template=strategic_idea_lab.yml)** for structured ideas, critique, AI-agent comments, or improvement suggestions
 - **Comment on the Gist** for lightweight, document-level discussion
 - **Start a conversation** if you want to explore a topic before formalising it
 


### PR DESCRIPTION
## Purpose

Create a clean GitHub Issue intake for the CDB Strategic Idea Lab, enabling external visitors, humans, and AI agents to submit structured contributions (ideas, critique, questions, risk notes, improvement suggestions, AI agent comments).

The Strategic Idea Lab is now public and linked. This PR adds a clear issue path for contributions without creating a Canon-Go, Live-Go, or implementation mandate.

## Changed Files

- **\.github/ISSUE_TEMPLATE/strategic_idea_lab.yml\** (new) — GitHub Issue Form for structured Strategic Idea Lab contributions
- **\docs/strategy/CDB_STRATEGIC_IDEA_LAB.md\** — Updated intake link in the Discussion And Contributions section

## Template Structure

The Issue Form captures:
- **Contribution Type**: Idea, Critique, Question, Risk Note, Improvement Suggestion, AI Agent Comment
- **Affected Document/Area**: Strategic Consolidation, Profitability, ARVP, Context Intelligence, Hetzner, Desktop App, Betting Pipeline, Betting Architecture, Gearbox, General
- **Short Description** (required)
- **Suggestion / Comment** (required, full-text)
- **Why Is This Relevant?** (required)
- **Evidence / References** (optional)
- **Risks / Open Questions** (optional)
- **AI-Generated flag** (required dropdown: Yes/No)
- **Model Name** (required only if AI-generated)
- **Boundary Checkbox** (required): acknowledges non-authoritative nature

## Safety Boundaries

- No code change — Issue-Template and docs only
- No runtime change
- No Docker/DB/Risk/Execution/Allocation change
- No Gist change
- No GitHub metadata change
- No label creation — uses existing \status:idea\ label
- \config.yml\ untouched (blank issues already disabled; new template appears automatically)
- LR remains NO-GO
- \	rade-capable\ is not a Live-Go

## Validation

- YAML syntax validated (\yaml.safe_load\ passes)
- Follows existing repo Issue Form style (\eature_request.yml\, \	ask.yml\)
- All required fields present
- Boundary checkbox present and required
- AI-generated flag and model name field present
- Intake link in Strategic Idea Lab doc working
- Only the two intended files changed

## Notes

- No labels, metadata, or Gists were modified.
- The \status:idea\ label already exists — no new label was created.
- AI-agent contributions require model name and remain non-authoritative.
- Path to delivery remains: Issue → Evidence → PR → Review → Jannek-GO.