### PR TITLE
fix(evidence-harvester): honor sleep deadline after late wake

### DIFF
--- a/tests/unit/tools/evidence_harvester/test_coordinator.py
+++ b/tests/unit/tools/evidence_harvester/test_coordinator.py
@@ -339,6 +339,33 @@ def test_sleep_with_interval_check_partial_chunk() -> None:
 
 
 @pytest.mark.unit
+def test_sleep_with_interval_check_stops_when_chunk_returns_after_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = {"value": 0.0}
+    calls: list[float] = []
+
+    def fake_monotonic() -> float:
+        return now["value"]
+
+    def fake_sleep(seconds: float) -> None:
+        calls.append(seconds)
+        now["value"] += 130.0
+
+    monkeypatch.setattr(
+        "tools.evidence_harvester.coordinator.time.monotonic",
+        fake_monotonic,
+    )
+
+    overshoot = _sleep_with_interval_check(
+        fake_sleep, total_seconds=125, chunk_seconds=60
+    )
+
+    assert calls == [60]
+    assert overshoot == pytest.approx(5.0, abs=0.001)
+
+
+@pytest.mark.unit
 def test_sleep_with_interval_check_zero_duration() -> None:
     calls: list[float] = []
 

--- a/tools/evidence_harvester/coordinator.py
+++ b/tools/evidence_harvester/coordinator.py
@@ -411,13 +411,25 @@ def _sleep_with_interval_check(
     chunk_seconds: int = 60,
 ) -> float:
     """Sleep in chunks, returning overshoot (actual - expected) seconds."""
+    if total_seconds <= 0:
+        return 0.0
+    if chunk_seconds < 1:
+        raise CoordinatorError("chunk_seconds must be >= 1")
+
     started = time.monotonic()
-    remaining = total_seconds
-    while remaining > 0:
-        chunk = min(remaining, chunk_seconds)
+    deadline = started + total_seconds
+    requested_sleep = 0.0
+    while requested_sleep < total_seconds:
+        elapsed_remaining = deadline - time.monotonic()
+        requested_remaining = total_seconds - requested_sleep
+        if elapsed_remaining <= 0 or requested_remaining <= 0:
+            break
+        chunk = min(requested_remaining, elapsed_remaining, chunk_seconds)
         sleep_fn(chunk)
-        remaining -= chunk
-    elapsed = time.monotonic() - started
+        requested_sleep += chunk
+        if time.monotonic() >= deadline:
+            break
+    elapsed = max(time.monotonic() - started, requested_sleep)
     overshoot = elapsed - total_seconds
     return max(overshoot, 0.0)
 


### PR DESCRIPTION
## Summary
- make coordinator sleep use an absolute monotonic deadline instead of subtracting requested chunks only
- stop sleeping immediately when a chunk returns after the deadline, preserving overshoot reporting
- add a regression test for a late-returning sleep chunk

## Validation
- git diff --check
- python -m pytest tests/unit/tools/evidence_harvester -q
- ruff check tools/evidence_harvester tests/unit/tools/evidence_harvester
- black --check tools/evidence_harvester tests/unit/tools/evidence_harvester

## Scope
Refs #3374, #3362, #3345.

No new 72h run started. No Docker, DB, secrets, scheduler/runtime mutation, LR-Go, Live-Go, or Echtgeld-Go.