### PR TITLE
feat(profitability): add evidence packet assembler

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -11,6 +11,7 @@ Repo-backed JSON/YAML schemas und Contract-Dokumente für Messages, Replay und C
 | Examples | [`examples/`](examples/) | Valid/invalid fixtures |
 | Replay | [`REPLAY_CONTRACTS_AND_DETERMINISM.md`](REPLAY_CONTRACTS_AND_DETERMINISM.md) | Determinism rules |
 | Profitability | `profitability_candidate_contract.v1.schema.json`, `profitability_evidence_packet.v1.schema.json` | Strategy candidate and evidence packet research contracts |
+| Profitability evidence inputs | `profitability_replay_report.v1.schema.json`, `profitability_harvester_ref.v1.schema.json`, `shadow_comparison.v1.schema.json`, `arvp_regime_scorecard.v1.schema.json` | Offline assembler input contracts for canonical replay, harvester provenance, compare, and regime scorecard artifacts |
 | Profitability data quality | `profitability_dataset_quality_report.v1.schema.json` | Dataset quality gate report for candidate validation |
 | Profitability ARVP batch | `profitability_arvp_batch_manifest.v1.schema.json`, `profitability_arvp_batch_summary.v1.schema.json` | Multi-candidate ARVP batch runner design contracts |
 | Profitability scenario packs | `profitability_scenario_pack_catalog.v1.schema.json`, `profitability_scenario_stress_summary.v1.schema.json` | Stress-scenario catalog and candidate stress summary contracts |

--- a/docs/contracts/arvp_regime_scorecard.v1.schema.json
+++ b/docs/contracts/arvp_regime_scorecard.v1.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/arvp_regime_scorecard.v1.schema.json",
+  "title": "ARVP Regime Scorecard v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "status",
+    "run_id",
+    "source",
+    "scorecard_fingerprint",
+    "segments",
+    "notes"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "arvp_regime_scorecard.v1"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "ok",
+        "unavailable",
+        "insufficient-data"
+      ]
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "type": "string",
+      "enum": [
+        "replay_trace",
+        "comparison"
+      ]
+    },
+    "scorecard_fingerprint": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "segments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "regime_id",
+          "observation_count",
+          "signal_count",
+          "trade_close_count"
+        ],
+        "properties": {
+          "regime_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "observation_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "signal_count": {
+            "oneOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "trade_close_count": {
+            "oneOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pnl_sum_r": {
+            "type": "string",
+            "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+          }
+        }
+      }
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/contracts/profitability_evidence_packet.v1.schema.json
+++ b/docs/contracts/profitability_evidence_packet.v1.schema.json
@@ -268,6 +268,125 @@
         "minLength": 1,
         "maxLength": 500
       }
+    },
+    "source_artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "artifact_role",
+          "path",
+          "schema_ref",
+          "sha256"
+        ],
+        "properties": {
+          "artifact_role": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "schema_ref": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 300
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^sha256:[a-f0-9]{64}$"
+          }
+        }
+      }
+    },
+    "missing_evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "artifact_role",
+          "classification",
+          "summary"
+        ],
+        "properties": {
+          "artifact_role": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          },
+          "classification": {
+            "type": "string",
+            "enum": [
+              "OPTIONAL_NOT_PROVIDED",
+              "MISSING_REFERENCE",
+              "UNAVAILABLE_FROM_INPUT",
+              "UNUSABLE_INPUT",
+              "AMBIGUOUS_ALIGNMENT"
+            ]
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1000
+          }
+        }
+      }
+    },
+    "coverage_readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coverage_report_ready",
+        "ranking_inputs_complete",
+        "data_quality_ready",
+        "economics_ready",
+        "scenario_ready",
+        "replay_ready",
+        "replay_vs_paper_ready",
+        "regime_scorecard_ready",
+        "harvester_refs_ready",
+        "summary"
+      ],
+      "properties": {
+        "coverage_report_ready": {
+          "type": "boolean"
+        },
+        "ranking_inputs_complete": {
+          "type": "boolean"
+        },
+        "data_quality_ready": {
+          "type": "boolean"
+        },
+        "economics_ready": {
+          "type": "boolean"
+        },
+        "scenario_ready": {
+          "type": "boolean"
+        },
+        "replay_ready": {
+          "type": "boolean"
+        },
+        "replay_vs_paper_ready": {
+          "type": "boolean"
+        },
+        "regime_scorecard_ready": {
+          "type": "boolean"
+        },
+        "harvester_refs_ready": {
+          "type": "boolean"
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        }
+      }
     }
   }
 }

--- a/docs/contracts/profitability_harvester_ref.v1.schema.json
+++ b/docs/contracts/profitability_harvester_ref.v1.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/profitability_harvester_ref.v1.schema.json",
+  "title": "Profitability Harvester Ref v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "source_run_refs",
+    "risk_blocks",
+    "kill_switch_events",
+    "limitations",
+    "safety_boundaries"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_harvester_ref.v1"
+    },
+    "candidate_id": {
+      "type": "string",
+      "pattern": "^cand-[a-z0-9_-]{4,80}$"
+    },
+    "source_run_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 300
+      }
+    },
+    "risk_blocks": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "kill_switch_events": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 500
+      }
+    },
+    "safety_boundaries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 500
+      }
+    }
+  }
+}

--- a/docs/contracts/profitability_replay_report.v1.schema.json
+++ b/docs/contracts/profitability_replay_report.v1.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/profitability_replay_report.v1.schema.json",
+  "title": "Profitability Replay Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "candidate_id",
+    "replay_run_id",
+    "strategy_id",
+    "symbol",
+    "timeframe",
+    "generated_at",
+    "gross_return",
+    "profit_factor",
+    "expectancy",
+    "win_rate",
+    "avg_win",
+    "avg_loss",
+    "max_drawdown",
+    "loss_streak",
+    "trade_count",
+    "data_integrity_ok",
+    "deterministic_replay_ok",
+    "notes"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "profitability_replay_report.v1"
+    },
+    "candidate_id": {
+      "type": "string",
+      "pattern": "^cand-[a-z0-9_-]{4,80}$"
+    },
+    "replay_run_id": {
+      "type": "string",
+      "pattern": "^replay-[a-f0-9]{12}-[0-9]{4}$"
+    },
+    "strategy_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "symbol": {
+      "type": "string",
+      "pattern": "^[A-Z0-9_:-]{3,40}$"
+    },
+    "timeframe": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 20
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "gross_return": {
+      "type": "number"
+    },
+    "profit_factor": {
+      "type": "number",
+      "minimum": 0.0
+    },
+    "expectancy": {
+      "type": "number"
+    },
+    "win_rate": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
+    "avg_win": {
+      "type": "number",
+      "minimum": 0.0
+    },
+    "avg_loss": {
+      "type": "number",
+      "minimum": 0.0
+    },
+    "max_drawdown": {
+      "type": "number",
+      "minimum": 0.0
+    },
+    "loss_streak": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "trade_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "data_integrity_ok": {
+      "type": "boolean"
+    },
+    "deterministic_replay_ok": {
+      "type": "boolean"
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/docs/contracts/shadow_comparison.v1.schema.json
+++ b/docs/contracts/shadow_comparison.v1.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/shadow_comparison.v1.schema.json",
+  "title": "Shadow Comparison Artifact v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "comparison_fingerprint",
+    "status",
+    "paper_provenance_id",
+    "replay_run_id",
+    "symbol",
+    "strategy_id",
+    "signal_count_delta",
+    "order_count_delta",
+    "fill_count_delta",
+    "inferred_unfilled_count_delta",
+    "signal_context_delta",
+    "signal_count_false_neutral_detected",
+    "window_start_utc_replay",
+    "window_end_utc_replay",
+    "window_start_utc_paper",
+    "window_end_utc_paper"
+  ],
+  "properties": {
+    "comparison_fingerprint": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "aligned",
+        "unusable"
+      ]
+    },
+    "alignment_issue": {
+      "type": "string",
+      "minLength": 1
+    },
+    "paper_provenance_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "replay_run_id": {
+      "type": "string",
+      "pattern": "^replay-[a-f0-9]{12}-[0-9]{4}$"
+    },
+    "symbol": {
+      "type": "string",
+      "pattern": "^[A-Z0-9_:-]{3,40}$"
+    },
+    "strategy_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "signal_count_delta": {
+      "type": "integer"
+    },
+    "order_count_delta": {
+      "type": "integer"
+    },
+    "fill_count_delta": {
+      "type": "integer"
+    },
+    "inferred_unfilled_count_delta": {
+      "type": "integer"
+    },
+    "actual_reject_count_delta": {
+      "type": "integer"
+    },
+    "fill_rate_replay": {
+      "type": "string",
+      "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+    },
+    "fill_rate_paper": {
+      "type": "string",
+      "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+    },
+    "fill_rate_delta": {
+      "type": "string",
+      "pattern": "^-?[0-9]+(\\.[0-9]+)?$"
+    },
+    "signal_context_delta": {
+      "type": "integer"
+    },
+    "signal_count_false_neutral_detected": {
+      "type": "boolean"
+    },
+    "window_start_utc_replay": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "window_end_utc_replay": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "window_start_utc_paper": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "window_end_utc_paper": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/services/validation/README.md
+++ b/services/validation/README.md
@@ -18,12 +18,27 @@ Offline-/Batch-Validierung: Replay, Backtest, Paper-Runtime-Stimulus, ARVP-Score
 | `paper_runtime_stimulus_runner.py` | Paper-Stimulus |
 | `gate_evaluator.py` | Gate-Auswertung |
 | `arvp_regime_scorecard_runner.py` | ARVP-Scorecard |
+| `profitability_evidence_packet_assembler.py` | Evidence Packet Assembler — deterministic offline CLI that builds `profitability_evidence_packet.v1` JSON + Markdown from explicit validated input artifact paths |
 
 ## Usage
 
 ```bash
 # Typisch über pytest oder dedizierte Scripts/Make-Targets
 pytest -q tests/unit/validation/
+
+# Evidence Packet Assembler (offline, deterministisch)
+python -m services.validation.profitability_evidence_packet_assembler \
+    --candidate-contract path/to/candidate.json \
+    --data-quality-report path/to/dq.json \
+    --replay-report path/to/replay.json \
+    --scenario-stress-summary path/to/scenario.json \
+    --execution-economics-assessment path/to/economics.json \
+    --harvester-ref path/to/harvester.json \
+    --replay-vs-paper-compare path/to/compare.json \
+    --regime-scorecard path/to/scorecard.json \
+    --generated-at-utc 2026-06-22T12:00:00Z \
+    --out-json out/packet.json \
+    --out-md out/packet.md
 ```
 
 ## Canonical References

--- a/services/validation/profitability_evidence_packet_assembler.py
+++ b/services/validation/profitability_evidence_packet_assembler.py
@@ -1,0 +1,1249 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+from jsonschema.validators import validator_for
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CONTRACTS_DIR = PROJECT_ROOT / "docs" / "contracts"
+
+_CANDIDATE_SCHEMA_PATH = (
+    CONTRACTS_DIR / "profitability_candidate_contract.v1.schema.json"
+)
+_DATA_QUALITY_SCHEMA_PATH = (
+    CONTRACTS_DIR / "profitability_dataset_quality_report.v1.schema.json"
+)
+_REPLAY_SCHEMA_PATH = CONTRACTS_DIR / "profitability_replay_report.v1.schema.json"
+_SCENARIO_SCHEMA_PATH = (
+    CONTRACTS_DIR / "profitability_scenario_stress_summary.v1.schema.json"
+)
+_ECONOMICS_SCHEMA_PATH = (
+    CONTRACTS_DIR / "profitability_execution_economics_assessment.v1.schema.json"
+)
+_HARVESTER_SCHEMA_PATH = CONTRACTS_DIR / "profitability_harvester_ref.v1.schema.json"
+_COMPARE_SCHEMA_PATH = CONTRACTS_DIR / "shadow_comparison.v1.schema.json"
+_SCORECARD_SCHEMA_PATH = CONTRACTS_DIR / "arvp_regime_scorecard.v1.schema.json"
+_PACKET_SCHEMA_PATH = CONTRACTS_DIR / "profitability_evidence_packet.v1.schema.json"
+
+_DEFAULT_SAFETY_BOUNDARIES = (
+    "LR remains NO-GO.",
+    "Board stage trade-capable is not Live-Go.",
+    "Evidence packets are research-only and do not authorize paper or live execution.",
+    "No automatic candidate promotion is authorized.",
+)
+
+
+class ProfitabilityEvidencePacketAssemblerError(ValueError):
+    """Raised when packet assembly cannot complete safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedJsonDocument:
+    artifact_role: str
+    path: Path
+    display_path: str
+    sha256: str
+    schema_ref: str
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class AssemblyResult:
+    packet: dict[str, Any]
+    markdown: str
+
+
+def _deterministic_json_dumps(payload: Any, *, pretty: bool = False) -> str:
+    kwargs: dict[str, Any] = {
+        "ensure_ascii": True,
+        "sort_keys": True,
+    }
+    if pretty:
+        kwargs["indent"] = 2
+    else:
+        kwargs["separators"] = (",", ":")
+    return json.dumps(payload, **kwargs)
+
+
+def _sha256_hex(raw_bytes: bytes) -> str:
+    return hashlib.sha256(raw_bytes).hexdigest()
+
+
+def _sha256_ref(raw_bytes: bytes) -> str:
+    return f"sha256:{_sha256_hex(raw_bytes)}"
+
+
+def _normalize_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
+def _normalize_schema_ref(path: Path) -> str:
+    return path.resolve().relative_to(PROJECT_ROOT).as_posix()
+
+
+def _load_schema(schema_path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(schema_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            f"Failed to read schema {schema_path}: {exc}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            f"Invalid JSON in schema {schema_path}: {exc}"
+        ) from exc
+
+
+def _read_json_payload(path: Path) -> tuple[bytes, dict[str, Any]]:
+    try:
+        raw_bytes = path.read_bytes()
+    except OSError as exc:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            f"Failed to read JSON input {path}: {exc}"
+        ) from exc
+
+    try:
+        payload = json.loads(raw_bytes.decode("utf-8"))
+    except UnicodeDecodeError as exc:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            f"Invalid UTF-8 in JSON input {path}: {exc}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            f"Invalid JSON in {path}: {exc}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise ProfitabilityEvidencePacketAssemblerError(
+            f"JSON input {path} must be an object"
+        )
+
+    return raw_bytes, payload
+
+
+def _sorted_validation_errors(errors: list[Any]) -> list[Any]:
+    return sorted(
+        errors,
+        key=lambda err: (
+            ".".join(str(part) for part in err.path),
+            ".".join(str(part) for part in err.schema_path),
+            err.message,
+        ),
+    )
+
+
+def _validate_payload_against_schema(
+    payload: dict[str, Any],
+    *,
+    schema_path: Path,
+    artifact_role: str,
+) -> None:
+    schema = _load_schema(schema_path)
+    validator_cls = validator_for(schema)
+    validator_cls.check_schema(schema)
+    validator = validator_cls(schema)
+    errors = _sorted_validation_errors(list(validator.iter_errors(payload)))
+    if errors:
+        first = errors[0]
+        path = ".".join(str(part) for part in first.path) or "<root>"
+        raise ProfitabilityEvidencePacketAssemblerError(
+            f"Schema mismatch for {artifact_role} against {_normalize_schema_ref(schema_path)} "
+            f"at {path}: {first.message}"
+        )
+
+
+def _validate_document(
+    artifact_role: str,
+    path: Path,
+    schema_path: Path,
+) -> ValidatedJsonDocument:
+    raw_bytes, payload = _read_json_payload(path)
+    _validate_payload_against_schema(
+        payload, schema_path=schema_path, artifact_role=artifact_role
+    )
+    return ValidatedJsonDocument(
+        artifact_role=artifact_role,
+        path=path.resolve(),
+        display_path=_normalize_path(path),
+        sha256=_sha256_ref(raw_bytes),
+        schema_ref=_normalize_schema_ref(schema_path),
+        payload=payload,
+    )
+
+
+def _parse_generated_at_utc(raw_value: str) -> str:
+    candidate = raw_value.strip()
+    if not candidate:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "--generated-at-utc must be a non-empty UTC timestamp"
+        )
+
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            f"--generated-at-utc must be ISO-8601 UTC: {exc}"
+        ) from exc
+
+    if parsed.tzinfo is None:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "--generated-at-utc must include an explicit UTC offset"
+        )
+
+    normalized = parsed.astimezone(UTC)
+    return normalized.isoformat().replace("+00:00", "Z")
+
+
+def _require_mapping(value: object, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ProfitabilityEvidencePacketAssemblerError(f"{name} must be a JSON object")
+    return value
+
+
+def _require_string(value: object, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ProfitabilityEvidencePacketAssemblerError(
+            f"{name} must be a non-empty string"
+        )
+    return value.strip()
+
+
+def _require_number(value: object, name: str) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ProfitabilityEvidencePacketAssemblerError(f"{name} must be a number")
+    return float(value)
+
+
+def _require_non_negative_number(value: object, name: str) -> float:
+    result = _require_number(value, name)
+    if result < 0.0:
+        raise ProfitabilityEvidencePacketAssemblerError(f"{name} must be >= 0")
+    return result
+
+
+def _require_int(value: object, name: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ProfitabilityEvidencePacketAssemblerError(f"{name} must be an integer")
+    return value
+
+
+def _require_non_negative_int(value: object, name: str) -> int:
+    result = _require_int(value, name)
+    if result < 0:
+        raise ProfitabilityEvidencePacketAssemblerError(f"{name} must be >= 0")
+    return result
+
+
+def _optional_string(value: object, name: str) -> str | None:
+    if value is None:
+        return None
+    return _require_string(value, name)
+
+
+def _optional_number(value: object, name: str) -> float | None:
+    if value is None:
+        return None
+    return _require_number(value, name)
+
+
+def _dedupe_preserve_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        normalized = value.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def _slugify_for_packet_id(raw_value: str) -> str:
+    allowed: list[str] = []
+    for char in raw_value.lower():
+        if char.isalnum():
+            allowed.append(char)
+        elif char in {"-", "_", " ", "/", "."}:
+            allowed.append("-")
+    slug = "".join(allowed).strip("-")
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    if not slug:
+        slug = "packet"
+    return slug
+
+
+def _build_packet_id(
+    candidate_id: str, generated_at: str, source_artifacts: list[dict[str, Any]]
+) -> str:
+    slug = _slugify_for_packet_id(candidate_id.removeprefix("cand-"))[:48]
+    digest = _sha256_hex(
+        _deterministic_json_dumps(
+            {
+                "candidate_id": candidate_id,
+                "generated_at": generated_at,
+                "source_artifacts": source_artifacts,
+            }
+        ).encode("utf-8")
+    )[:12]
+    return f"pep-{slug}-{digest}"
+
+
+def _build_source_artifacts(
+    documents: list[ValidatedJsonDocument],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "artifact_role": doc.artifact_role,
+            "path": doc.display_path,
+            "schema_ref": doc.schema_ref,
+            "sha256": doc.sha256,
+        }
+        for doc in documents
+    ]
+
+
+def _validate_cross_document_consistency(
+    candidate_contract: ValidatedJsonDocument,
+    data_quality_report: ValidatedJsonDocument,
+    replay_report: ValidatedJsonDocument,
+    scenario_stress_summary: ValidatedJsonDocument,
+    economics_assessment: ValidatedJsonDocument,
+    harvester_ref: ValidatedJsonDocument,
+    replay_vs_paper_compare: ValidatedJsonDocument | None,
+    regime_scorecard: ValidatedJsonDocument | None,
+) -> None:
+    candidate_payload = candidate_contract.payload
+    candidate_id = _require_string(
+        candidate_payload.get("candidate_id"), "candidate_contract.candidate_id"
+    )
+    timeframe = _require_string(
+        candidate_payload.get("timeframe"), "candidate_contract.timeframe"
+    )
+    symbol_universe = candidate_payload.get("symbol_universe")
+    if not isinstance(symbol_universe, list) or not symbol_universe:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "candidate_contract.symbol_universe must be a non-empty list"
+        )
+
+    data_quality = data_quality_report.payload
+    dq_symbol = _require_string(
+        data_quality.get("symbol"), "data_quality_report.symbol"
+    )
+    dq_timeframe = _require_string(
+        data_quality.get("timeframe"), "data_quality_report.timeframe"
+    )
+    if dq_symbol not in symbol_universe:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "data_quality_report.symbol must exist in candidate_contract.symbol_universe"
+        )
+    if dq_timeframe != timeframe:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "data_quality_report.timeframe must match candidate_contract.timeframe"
+        )
+
+    replay_payload = replay_report.payload
+    replay_candidate_id = _require_string(
+        replay_payload.get("candidate_id"), "replay_report.candidate_id"
+    )
+    replay_symbol = _require_string(
+        replay_payload.get("symbol"), "replay_report.symbol"
+    )
+    replay_timeframe = _require_string(
+        replay_payload.get("timeframe"), "replay_report.timeframe"
+    )
+    if replay_candidate_id != candidate_id:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "replay_report.candidate_id must match candidate_contract.candidate_id"
+        )
+    if replay_symbol not in symbol_universe:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "replay_report.symbol must exist in candidate_contract.symbol_universe"
+        )
+    if replay_timeframe != timeframe:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "replay_report.timeframe must match candidate_contract.timeframe"
+        )
+
+    scenario_payload = scenario_stress_summary.payload
+    if (
+        _require_string(
+            scenario_payload.get("candidate_id"), "scenario_stress_summary.candidate_id"
+        )
+        != candidate_id
+    ):
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "scenario_stress_summary.candidate_id must match candidate_contract.candidate_id"
+        )
+
+    economics_payload = economics_assessment.payload
+    if (
+        _require_string(
+            economics_payload.get("candidate_id"),
+            "execution_economics_assessment.candidate_id",
+        )
+        != candidate_id
+    ):
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "execution_economics_assessment.candidate_id must match candidate_contract.candidate_id"
+        )
+
+    harvester_payload = harvester_ref.payload
+    harvester_candidate_id = _optional_string(
+        harvester_payload.get("candidate_id"), "harvester_ref.candidate_id"
+    )
+    if harvester_candidate_id is not None and harvester_candidate_id != candidate_id:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "harvester_ref.candidate_id must match candidate_contract.candidate_id"
+        )
+
+    replay_run_id = _require_string(
+        replay_payload.get("replay_run_id"), "replay_report.replay_run_id"
+    )
+    if replay_vs_paper_compare is not None:
+        compare_payload = replay_vs_paper_compare.payload
+        compare_run_id = _require_string(
+            compare_payload.get("replay_run_id"),
+            "replay_vs_paper_compare.replay_run_id",
+        )
+        if compare_run_id != replay_run_id:
+            raise ProfitabilityEvidencePacketAssemblerError(
+                "replay_vs_paper_compare.replay_run_id must match replay_report.replay_run_id"
+            )
+
+    if regime_scorecard is not None:
+        scorecard_payload = regime_scorecard.payload
+        scorecard_run_id = _require_string(
+            scorecard_payload.get("run_id"), "regime_scorecard.run_id"
+        )
+        if scorecard_run_id != replay_run_id:
+            raise ProfitabilityEvidencePacketAssemblerError(
+                "regime_scorecard.run_id must match replay_report.replay_run_id"
+            )
+
+
+def _extract_replay_metrics(
+    replay_report: Mapping[str, Any],
+) -> dict[str, float | int | bool | str]:
+    raw_avg_win = replay_report.get("avg_win")
+    raw_avg_loss = replay_report.get("avg_loss")
+    if raw_avg_win is None:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "replay_report.avg_win must be explicit; null is not packet-compatible"
+        )
+    if raw_avg_loss is None:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "replay_report.avg_loss must be explicit; null is not packet-compatible"
+        )
+
+    avg_loss = abs(_require_number(raw_avg_loss, "replay_report.avg_loss"))
+
+    return {
+        "replay_run_id": _require_string(
+            replay_report.get("replay_run_id"), "replay_report.replay_run_id"
+        ),
+        "strategy_id": _require_string(
+            replay_report.get("strategy_id"), "replay_report.strategy_id"
+        ),
+        "symbol": _require_string(replay_report.get("symbol"), "replay_report.symbol"),
+        "timeframe": _require_string(
+            replay_report.get("timeframe"), "replay_report.timeframe"
+        ),
+        "generated_at": _require_string(
+            replay_report.get("generated_at"), "replay_report.generated_at"
+        ),
+        "gross_return": _require_number(
+            replay_report.get("gross_return"), "replay_report.gross_return"
+        ),
+        "profit_factor": _require_non_negative_number(
+            replay_report.get("profit_factor"), "replay_report.profit_factor"
+        ),
+        "expectancy": _require_number(
+            replay_report.get("expectancy"), "replay_report.expectancy"
+        ),
+        "win_rate": _require_non_negative_number(
+            replay_report.get("win_rate"), "replay_report.win_rate"
+        ),
+        "avg_win": _require_non_negative_number(raw_avg_win, "replay_report.avg_win"),
+        "avg_loss": avg_loss,
+        "max_drawdown": _require_non_negative_number(
+            replay_report.get("max_drawdown"), "replay_report.max_drawdown"
+        ),
+        "loss_streak": _require_non_negative_int(
+            replay_report.get("loss_streak"), "replay_report.loss_streak"
+        ),
+        "trade_count": _require_non_negative_int(
+            replay_report.get("trade_count"), "replay_report.trade_count"
+        ),
+        "deterministic_replay_ok": bool(replay_report.get("deterministic_replay_ok")),
+        "data_integrity_ok": bool(replay_report.get("data_integrity_ok")),
+    }
+
+
+def _build_regime_scorecard_block(
+    regime_scorecard: ValidatedJsonDocument | None,
+    missing_evidence: list[dict[str, str]],
+) -> dict[str, Any]:
+    if regime_scorecard is None:
+        missing_evidence.append(
+            {
+                "artifact_role": "regime_scorecard",
+                "classification": "OPTIONAL_NOT_PROVIDED",
+                "summary": "No regime scorecard input was provided; packet uses status=unavailable.",
+            }
+        )
+        return {
+            "status": "unavailable",
+            "artifact_ref": None,
+            "summary": "Regime scorecard input was not provided to the assembler.",
+        }
+
+    payload = regime_scorecard.payload
+    raw_status = _require_string(payload.get("status"), "regime_scorecard.status")
+    status = raw_status.replace("-", "_")
+    segments = payload.get("segments")
+    if not isinstance(segments, list):
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "regime_scorecard.segments must be a list"
+        )
+
+    if status != "ok":
+        missing_evidence.append(
+            {
+                "artifact_role": "regime_scorecard",
+                "classification": "UNAVAILABLE_FROM_INPUT",
+                "summary": f"Regime scorecard status is {raw_status}; packet propagates this as {status}.",
+            }
+        )
+
+    return {
+        "status": status,
+        "artifact_ref": regime_scorecard.display_path,
+        "summary": (
+            f"Regime scorecard status={raw_status}; source={_require_string(payload.get('source'), 'regime_scorecard.source')}; "
+            f"segments={len(segments)}."
+        ),
+    }
+
+
+def _safe_decimal_string_to_float(value: object, name: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError as exc:
+            raise ProfitabilityEvidencePacketAssemblerError(
+                f"{name} must be a decimal string when present"
+            ) from exc
+    return _require_number(value, name)
+
+
+def _classify_replay_vs_paper(
+    replay_vs_paper_compare: ValidatedJsonDocument | None,
+    missing_evidence: list[dict[str, str]],
+) -> tuple[str, str]:
+    if replay_vs_paper_compare is None:
+        missing_evidence.append(
+            {
+                "artifact_role": "replay_vs_paper_compare",
+                "classification": "OPTIONAL_NOT_PROVIDED",
+                "summary": (
+                    "No replay-vs-paper comparison input was provided; "
+                    "packet uses replay_vs_paper_status=not_run and simulator_drift=not_assessed."
+                ),
+            }
+        )
+        return "not_run", "not_assessed"
+
+    payload = replay_vs_paper_compare.payload
+    status = _require_string(payload.get("status"), "replay_vs_paper_compare.status")
+    alignment_issue = _optional_string(
+        payload.get("alignment_issue"), "replay_vs_paper_compare.alignment_issue"
+    )
+
+    if status == "unusable":
+        classification = "UNUSABLE_INPUT"
+        replay_status = "ambiguous_drift"
+        simulator_drift = "unusable"
+        if alignment_issue and alignment_issue.startswith("missing_reference"):
+            classification = "MISSING_REFERENCE"
+            replay_status = "missing_reference"
+            simulator_drift = "not_assessed"
+        missing_evidence.append(
+            {
+                "artifact_role": "replay_vs_paper_compare",
+                "classification": classification,
+                "summary": alignment_issue
+                or "Replay-vs-paper comparison was unusable.",
+            }
+        )
+        return replay_status, simulator_drift
+
+    signal_false_neutral = bool(
+        payload.get("signal_count_false_neutral_detected", False)
+    )
+    if signal_false_neutral:
+        missing_evidence.append(
+            {
+                "artifact_role": "replay_vs_paper_compare",
+                "classification": "AMBIGUOUS_ALIGNMENT",
+                "summary": "Replay-vs-paper compare flagged signal_count_false_neutral_detected=true.",
+            }
+        )
+        return "ambiguous_drift", "ambiguous"
+
+    order_delta = _require_int(
+        payload.get("order_count_delta"), "replay_vs_paper_compare.order_count_delta"
+    )
+    fill_delta = _require_int(
+        payload.get("fill_count_delta"), "replay_vs_paper_compare.fill_count_delta"
+    )
+    fill_rate_delta = _safe_decimal_string_to_float(
+        payload.get("fill_rate_delta"), "replay_vs_paper_compare.fill_rate_delta"
+    )
+
+    if (
+        order_delta == 0
+        and fill_delta == 0
+        and (fill_rate_delta is None or fill_rate_delta == 0.0)
+    ):
+        return "aligned", "none"
+    if (
+        fill_delta < 0
+        or order_delta < 0
+        or (fill_rate_delta is not None and fill_rate_delta < 0.0)
+    ):
+        return "pessimistic_drift", "pessimistic"
+    if (
+        fill_delta > 0
+        or order_delta > 0
+        or (fill_rate_delta is not None and fill_rate_delta > 0.0)
+    ):
+        return "optimistic_drift", "optimistic"
+    return "ambiguous_drift", "ambiguous"
+
+
+def _build_scenario_results(
+    scenario_stress_summary: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    raw_results = scenario_stress_summary.get("scenario_results")
+    if not isinstance(raw_results, list) or not raw_results:
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "scenario_stress_summary.scenario_results must be a non-empty list"
+        )
+
+    scenario_results: list[dict[str, Any]] = []
+    summaries: list[str] = []
+    for index, raw_result in enumerate(raw_results):
+        result = _require_mapping(
+            raw_result, f"scenario_stress_summary.scenario_results[{index}]"
+        )
+        max_drawdown_delta = result.get("max_drawdown_delta")
+        if isinstance(max_drawdown_delta, (int, float)) and not isinstance(
+            max_drawdown_delta, bool
+        ):
+            if float(max_drawdown_delta) < 0.0:
+                raise ProfitabilityEvidencePacketAssemblerError(
+                    "scenario_stress_summary.max_drawdown_delta must be >= 0 to fit profitability_evidence_packet.v1"
+                )
+
+        scenario_id = _require_string(
+            result.get("scenario_id"), f"scenario_results[{index}].scenario_id"
+        )
+        status = _require_string(
+            result.get("status"), f"scenario_results[{index}].status"
+        )
+        impact_summary = _require_string(
+            result.get("impact_summary"), f"scenario_results[{index}].impact_summary"
+        )
+        notes = (
+            f"domain={_require_string(result.get('domain'), f'scenario_results[{index}].domain')}; "
+            f"severity={_require_string(result.get('severity'), f'scenario_results[{index}].severity')}; "
+            f"impact={impact_summary}"
+        )
+
+        scenario_results.append(
+            {
+                "scenario_id": scenario_id,
+                "status": status,
+                "net_return": _optional_number(
+                    result.get("net_return_delta"),
+                    f"scenario_results[{index}].net_return_delta",
+                ),
+                "max_drawdown": _optional_number(
+                    max_drawdown_delta,
+                    f"scenario_results[{index}].max_drawdown_delta",
+                ),
+                "notes": notes,
+            }
+        )
+        summaries.append(f"{scenario_id}: {status}")
+    return scenario_results, summaries
+
+
+def _build_coverage_readiness(
+    *,
+    data_quality_report: Mapping[str, Any],
+    replay_metrics: Mapping[str, Any],
+    scenario_stress_summary: Mapping[str, Any],
+    economics_assessment: Mapping[str, Any],
+    regime_scorecard_block: Mapping[str, Any],
+    replay_vs_paper_status: str,
+    harvester_ref: Mapping[str, Any],
+) -> dict[str, Any]:
+    data_quality_verdict = _require_string(
+        data_quality_report.get("quality_verdict"),
+        "data_quality_report.quality_verdict",
+    )
+    overall_stress_outcome = _require_string(
+        scenario_stress_summary.get("overall_stress_outcome"),
+        "scenario_stress_summary.overall_stress_outcome",
+    )
+    assessment_status = _require_string(
+        economics_assessment.get("assessment_status"),
+        "execution_economics_assessment.assessment_status",
+    )
+    ranking_ready = bool(economics_assessment.get("ranking_ready"))
+    replay_ready = bool(replay_metrics["data_integrity_ok"]) and bool(
+        replay_metrics["deterministic_replay_ok"]
+    )
+    regime_ready = regime_scorecard_block["status"] == "ok"
+    replay_vs_paper_ready = replay_vs_paper_status == "aligned"
+    harvester_refs = harvester_ref.get("source_run_refs")
+    harvester_ready = isinstance(harvester_refs, list) and len(harvester_refs) > 0
+    data_quality_ready = data_quality_verdict not in {"FAIL", "BLOCKED"}
+    scenario_ready = overall_stress_outcome not in {"BLOCKED"}
+    economics_ready = assessment_status not in {"FAIL", "BLOCKED"} and ranking_ready
+
+    coverage_report_ready = all(
+        [data_quality_ready, replay_ready, scenario_ready, harvester_ready]
+    )
+    ranking_inputs_complete = all(
+        [
+            data_quality_ready,
+            replay_ready,
+            scenario_ready,
+            economics_ready,
+            replay_vs_paper_ready,
+            regime_ready,
+        ]
+    )
+
+    return {
+        "coverage_report_ready": coverage_report_ready,
+        "ranking_inputs_complete": ranking_inputs_complete,
+        "data_quality_ready": data_quality_ready,
+        "economics_ready": economics_ready,
+        "scenario_ready": scenario_ready,
+        "replay_ready": replay_ready,
+        "replay_vs_paper_ready": replay_vs_paper_ready,
+        "regime_scorecard_ready": regime_ready,
+        "harvester_refs_ready": harvester_ready,
+        "summary": (
+            "coverage_report_ready="
+            f"{coverage_report_ready}; ranking_inputs_complete={ranking_inputs_complete}; "
+            f"replay_vs_paper_ready={replay_vs_paper_ready}; regime_scorecard_ready={regime_ready}."
+        ),
+    }
+
+
+def _build_recommendation(
+    *,
+    candidate_contract: Mapping[str, Any],
+    economics_assessment: Mapping[str, Any],
+    coverage_readiness: Mapping[str, Any],
+) -> str:
+    candidate_status = _require_string(
+        candidate_contract.get("status"), "candidate_contract.status"
+    )
+    if candidate_status == "UNSAFE":
+        return "UNSAFE"
+    if candidate_status == "REJECTED":
+        return "REJECT"
+    if candidate_status in {"PARKED", "STALE", "SUPERSEDED"}:
+        return "PARK"
+    if not bool(coverage_readiness.get("ranking_inputs_complete")):
+        return "NO_RECOMMENDATION"
+    if not bool(economics_assessment.get("ranking_ready")):
+        return "PARK"
+    return "NO_RECOMMENDATION"
+
+
+def build_profitability_evidence_packet(
+    *,
+    candidate_contract: ValidatedJsonDocument,
+    data_quality_report: ValidatedJsonDocument,
+    replay_report: ValidatedJsonDocument,
+    scenario_stress_summary: ValidatedJsonDocument,
+    economics_assessment: ValidatedJsonDocument,
+    harvester_ref: ValidatedJsonDocument,
+    generated_at_utc: str,
+    replay_vs_paper_compare: ValidatedJsonDocument | None = None,
+    regime_scorecard: ValidatedJsonDocument | None = None,
+) -> AssemblyResult:
+    _validate_cross_document_consistency(
+        candidate_contract,
+        data_quality_report,
+        replay_report,
+        scenario_stress_summary,
+        economics_assessment,
+        harvester_ref,
+        replay_vs_paper_compare,
+        regime_scorecard,
+    )
+
+    replay_metrics = _extract_replay_metrics(replay_report.payload)
+    missing_evidence: list[dict[str, str]] = []
+    regime_scorecard_block = _build_regime_scorecard_block(
+        regime_scorecard, missing_evidence
+    )
+    replay_vs_paper_status, simulator_drift = _classify_replay_vs_paper(
+        replay_vs_paper_compare, missing_evidence
+    )
+    scenario_results, scenario_summaries = _build_scenario_results(
+        scenario_stress_summary.payload
+    )
+
+    source_documents = [
+        candidate_contract,
+        data_quality_report,
+        replay_report,
+        scenario_stress_summary,
+        economics_assessment,
+        harvester_ref,
+    ]
+    if replay_vs_paper_compare is not None:
+        source_documents.append(replay_vs_paper_compare)
+    if regime_scorecard is not None:
+        source_documents.append(regime_scorecard)
+
+    source_artifacts = _build_source_artifacts(source_documents)
+    harvester_payload = harvester_ref.payload
+    coverage_readiness = _build_coverage_readiness(
+        data_quality_report=data_quality_report.payload,
+        replay_metrics=replay_metrics,
+        scenario_stress_summary=scenario_stress_summary.payload,
+        economics_assessment=economics_assessment.payload,
+        regime_scorecard_block=regime_scorecard_block,
+        replay_vs_paper_status=replay_vs_paper_status,
+        harvester_ref=harvester_payload,
+    )
+
+    candidate_payload = candidate_contract.payload
+    economics_payload = economics_assessment.payload
+    data_quality_payload = data_quality_report.payload
+    packet = {
+        "schema_version": "profitability_evidence_packet.v1",
+        "evidence_packet_id": _build_packet_id(
+            _require_string(
+                candidate_payload.get("candidate_id"), "candidate_contract.candidate_id"
+            ),
+            generated_at_utc,
+            source_artifacts,
+        ),
+        "candidate_id": _require_string(
+            candidate_payload.get("candidate_id"), "candidate_contract.candidate_id"
+        ),
+        "generated_at": generated_at_utc,
+        "dataset_id": _require_string(
+            data_quality_payload.get("dataset_id"), "data_quality_report.dataset_id"
+        ),
+        "dataset_fingerprint": _require_string(
+            data_quality_payload.get("dataset_fingerprint"),
+            "data_quality_report.dataset_fingerprint",
+        ),
+        "source_run_refs": _dedupe_preserve_order(
+            [
+                *[
+                    _require_string(value, "harvester_ref.source_run_refs[]")
+                    for value in harvester_payload.get("source_run_refs", [])
+                ],
+                replay_report.display_path,
+                scenario_stress_summary.display_path,
+                economics_assessment.display_path,
+                *(
+                    [replay_vs_paper_compare.display_path]
+                    if replay_vs_paper_compare is not None
+                    else []
+                ),
+                *(
+                    [regime_scorecard.display_path]
+                    if regime_scorecard is not None
+                    else []
+                ),
+            ]
+        ),
+        "gross_return": replay_metrics["gross_return"],
+        "net_return": _require_number(
+            economics_payload.get("net_return"),
+            "execution_economics_assessment.net_return",
+        ),
+        "fees": _require_non_negative_number(
+            _require_mapping(
+                economics_payload.get("cost_breakdown"),
+                "execution_economics_assessment.cost_breakdown",
+            ).get("fees"),
+            "execution_economics_assessment.cost_breakdown.fees",
+        ),
+        "spread_cost": _require_non_negative_number(
+            _require_mapping(
+                economics_payload.get("cost_breakdown"),
+                "execution_economics_assessment.cost_breakdown",
+            ).get("spread_cost"),
+            "execution_economics_assessment.cost_breakdown.spread_cost",
+        ),
+        "slippage_cost": _require_non_negative_number(
+            _require_mapping(
+                economics_payload.get("cost_breakdown"),
+                "execution_economics_assessment.cost_breakdown",
+            ).get("slippage_cost"),
+            "execution_economics_assessment.cost_breakdown.slippage_cost",
+        ),
+        "profit_factor": replay_metrics["profit_factor"],
+        "expectancy": replay_metrics["expectancy"],
+        "win_rate": replay_metrics["win_rate"],
+        "avg_win": replay_metrics["avg_win"],
+        "avg_loss": replay_metrics["avg_loss"],
+        "max_drawdown": replay_metrics["max_drawdown"],
+        "loss_streak": replay_metrics["loss_streak"],
+        "trade_count": replay_metrics["trade_count"],
+        "regime_scorecard": regime_scorecard_block,
+        "scenario_results": scenario_results,
+        "replay_vs_paper_status": replay_vs_paper_status,
+        "simulator_drift": simulator_drift,
+        "risk_blocks": _require_non_negative_int(
+            harvester_payload.get("risk_blocks"), "harvester_ref.risk_blocks"
+        ),
+        "kill_switch_events": _require_non_negative_int(
+            harvester_payload.get("kill_switch_events"),
+            "harvester_ref.kill_switch_events",
+        ),
+        "recommendation": _build_recommendation(
+            candidate_contract=candidate_payload,
+            economics_assessment=economics_payload,
+            coverage_readiness=coverage_readiness,
+        ),
+        "limitations": _dedupe_preserve_order(
+            [
+                *[
+                    _require_string(v, "candidate_contract.limitations[]")
+                    for v in candidate_payload.get("limitations", [])
+                ],
+                *[
+                    _require_string(v, "data_quality_report.limitations[]")
+                    for v in data_quality_payload.get("limitations", [])
+                ],
+                *[
+                    _require_string(v, "execution_economics_assessment.limitations[]")
+                    for v in economics_payload.get("limitations", [])
+                ],
+                *[
+                    _require_string(v, "scenario_stress_summary.limitations[]")
+                    for v in scenario_stress_summary.payload.get("limitations", [])
+                ],
+                *[
+                    _require_string(v, "harvester_ref.limitations[]")
+                    for v in harvester_payload.get("limitations", [])
+                ],
+                *[entry["summary"] for entry in missing_evidence],
+                "Assembler is offline and deterministic; no network, runtime, Docker, DB, Redis, secrets, or scheduler access was used.",
+            ]
+        ),
+        "safety_boundaries": _dedupe_preserve_order(
+            [
+                *[
+                    _require_string(v, "candidate_contract.execution_assumptions[]")
+                    for v in candidate_payload.get("execution_assumptions", [])
+                ],
+                *[
+                    _require_string(v, "harvester_ref.safety_boundaries[]")
+                    for v in harvester_payload.get("safety_boundaries", [])
+                ],
+                *_DEFAULT_SAFETY_BOUNDARIES,
+            ]
+        ),
+        "source_artifacts": source_artifacts,
+        "missing_evidence": missing_evidence,
+        "coverage_readiness": coverage_readiness,
+    }
+
+    _validate_payload_against_schema(
+        packet,
+        schema_path=_PACKET_SCHEMA_PATH,
+        artifact_role="profitability_evidence_packet",
+    )
+
+    markdown = build_profitability_evidence_packet_markdown(
+        packet=packet,
+        candidate_contract=candidate_contract,
+        data_quality_report=data_quality_report,
+        replay_report=replay_report,
+        scenario_stress_summary=scenario_stress_summary,
+        economics_assessment=economics_assessment,
+        harvester_ref=harvester_ref,
+        replay_vs_paper_compare=replay_vs_paper_compare,
+        regime_scorecard=regime_scorecard,
+        scenario_summaries=scenario_summaries,
+    )
+    return AssemblyResult(packet=packet, markdown=markdown)
+
+
+def build_profitability_evidence_packet_markdown(
+    *,
+    packet: Mapping[str, Any],
+    candidate_contract: ValidatedJsonDocument,
+    data_quality_report: ValidatedJsonDocument,
+    replay_report: ValidatedJsonDocument,
+    scenario_stress_summary: ValidatedJsonDocument,
+    economics_assessment: ValidatedJsonDocument,
+    harvester_ref: ValidatedJsonDocument,
+    replay_vs_paper_compare: ValidatedJsonDocument | None,
+    regime_scorecard: ValidatedJsonDocument | None,
+    scenario_summaries: list[str],
+) -> str:
+    coverage = _require_mapping(
+        packet.get("coverage_readiness"), "packet.coverage_readiness"
+    )
+    missing_evidence = packet.get("missing_evidence")
+    if not isinstance(missing_evidence, list):
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "packet.missing_evidence must be a list"
+        )
+
+    source_artifacts = packet.get("source_artifacts")
+    if not isinstance(source_artifacts, list):
+        raise ProfitabilityEvidencePacketAssemblerError(
+            "packet.source_artifacts must be a list"
+        )
+
+    harvester_payload = harvester_ref.payload
+    lines = [
+        "# Profitability Evidence Packet Summary",
+        "",
+        "## Candidate",
+        "",
+        f"- Candidate ID: `{packet['candidate_id']}`",
+        f"- Evidence Packet ID: `{packet['evidence_packet_id']}`",
+        f"- Generated At: `{packet['generated_at']}`",
+        f"- Recommendation: `{packet['recommendation']}`",
+        "",
+        "## Source Artifacts",
+        "",
+    ]
+
+    for artifact in source_artifacts:
+        artifact_map = _require_mapping(artifact, "packet.source_artifacts[]")
+        lines.append(
+            "- "
+            f"`{_require_string(artifact_map.get('artifact_role'), 'packet.source_artifacts[].artifact_role')}`: "
+            f"`{_require_string(artifact_map.get('path'), 'packet.source_artifacts[].path')}` "
+            f"({ _require_string(artifact_map.get('sha256'), 'packet.source_artifacts[].sha256') }, "
+            f"schema `{_require_string(artifact_map.get('schema_ref'), 'packet.source_artifacts[].schema_ref')}`)"
+        )
+
+    lines += [
+        "",
+        "## Data Quality",
+        "",
+        f"- Dataset ID: `{packet['dataset_id']}`",
+        f"- Dataset Fingerprint: `{packet['dataset_fingerprint']}`",
+        f"- Quality Verdict: `{_require_string(data_quality_report.payload.get('quality_verdict'), 'data_quality_report.quality_verdict')}`",
+        "",
+        "## Replay Summary",
+        "",
+        f"- Replay Report: `{replay_report.display_path}`",
+        f"- Gross Return: `{packet['gross_return']}`",
+        f"- Profit Factor: `{packet['profit_factor']}`",
+        f"- Expectancy: `{packet['expectancy']}`",
+        f"- Trade Count: `{packet['trade_count']}`",
+        "",
+        "## Execution Economics",
+        "",
+        f"- Economics Assessment: `{economics_assessment.display_path}`",
+        f"- Net Return: `{packet['net_return']}`",
+        f"- Fees / Spread / Slippage: `{packet['fees']}` / `{packet['spread_cost']}` / `{packet['slippage_cost']}`",
+        f"- Ranking Ready: `{bool(economics_assessment.payload.get('ranking_ready'))}`",
+        "",
+        "## Scenario Summary",
+        "",
+        f"- Scenario Stress Summary: `{scenario_stress_summary.display_path}`",
+    ]
+    lines.extend([f"- {summary}" for summary in scenario_summaries])
+
+    lines += [
+        "",
+        "## Harvester Provenance",
+        "",
+        f"- Harvester Ref: `{harvester_ref.display_path}`",
+    ]
+    for ref in harvester_payload.get("source_run_refs", []):
+        lines.append(
+            f"- Source Run Ref: `{_require_string(ref, 'harvester_ref.source_run_refs[]')}`"
+        )
+
+    lines += [
+        "",
+        "## Optional Evidence",
+        "",
+        f"- Replay-vs-Paper Compare: `{replay_vs_paper_compare.display_path if replay_vs_paper_compare is not None else 'not provided'}`",
+        f"- Replay-vs-Paper Status: `{packet['replay_vs_paper_status']}`",
+        f"- Simulator Drift: `{packet['simulator_drift']}`",
+        f"- Regime Scorecard: `{regime_scorecard.display_path if regime_scorecard is not None else 'not provided'}`",
+        f"- Regime Scorecard Status: `{_require_mapping(packet.get('regime_scorecard'), 'packet.regime_scorecard')['status']}`",
+        "",
+        "## Missing Evidence Classification",
+        "",
+    ]
+    if missing_evidence:
+        for entry in missing_evidence:
+            entry_map = _require_mapping(entry, "packet.missing_evidence[]")
+            lines.append(
+                "- "
+                f"`{_require_string(entry_map.get('artifact_role'), 'packet.missing_evidence[].artifact_role')}` "
+                f"=> `{_require_string(entry_map.get('classification'), 'packet.missing_evidence[].classification')}`: "
+                f"{_require_string(entry_map.get('summary'), 'packet.missing_evidence[].summary')}"
+            )
+    else:
+        lines.append("- None")
+
+    lines += [
+        "",
+        "## Coverage Readiness",
+        "",
+        f"- Coverage Report Ready: `{bool(coverage.get('coverage_report_ready'))}`",
+        f"- Ranking Inputs Complete: `{bool(coverage.get('ranking_inputs_complete'))}`",
+        f"- Data Quality Ready: `{bool(coverage.get('data_quality_ready'))}`",
+        f"- Economics Ready: `{bool(coverage.get('economics_ready'))}`",
+        f"- Scenario Ready: `{bool(coverage.get('scenario_ready'))}`",
+        f"- Replay-vs-Paper Ready: `{bool(coverage.get('replay_vs_paper_ready'))}`",
+        f"- Regime Scorecard Ready: `{bool(coverage.get('regime_scorecard_ready'))}`",
+        f"- Summary: {_require_string(coverage.get('summary'), 'packet.coverage_readiness.summary')}",
+        "",
+        "## Safety",
+        "",
+        "- Non-live, non-promotion safety statement: This packet is research-only evidence. "
+        "It does not authorize paper trading, live trading, candidate promotion, runtime changes, or capital scaling.",
+    ]
+    for boundary in packet.get("safety_boundaries", []):
+        lines.append(f"- {_require_string(boundary, 'packet.safety_boundaries[]')}")
+
+    return "\n".join(lines) + "\n"
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="profitability_evidence_packet_assembler",
+        description=(
+            "Build a deterministic offline profitability_evidence_packet.v1 from "
+            "explicit validated local inputs."
+        ),
+    )
+    parser.add_argument("--candidate-contract", required=True, type=Path)
+    parser.add_argument("--data-quality-report", required=True, type=Path)
+    parser.add_argument("--replay-report", required=True, type=Path)
+    parser.add_argument("--scenario-stress-summary", required=True, type=Path)
+    parser.add_argument("--execution-economics-assessment", required=True, type=Path)
+    parser.add_argument("--harvester-ref", required=True, type=Path)
+    parser.add_argument("--replay-vs-paper-compare", type=Path)
+    parser.add_argument("--regime-scorecard", type=Path)
+    parser.add_argument("--generated-at-utc", required=True)
+    parser.add_argument("--out-json", required=True, type=Path)
+    parser.add_argument("--out-md", required=True, type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_argument_parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit:
+        return 1
+
+    try:
+        candidate_contract = _validate_document(
+            "candidate_contract", args.candidate_contract, _CANDIDATE_SCHEMA_PATH
+        )
+        data_quality_report = _validate_document(
+            "data_quality_report", args.data_quality_report, _DATA_QUALITY_SCHEMA_PATH
+        )
+        replay_report = _validate_document(
+            "replay_report", args.replay_report, _REPLAY_SCHEMA_PATH
+        )
+        scenario_stress_summary = _validate_document(
+            "scenario_stress_summary",
+            args.scenario_stress_summary,
+            _SCENARIO_SCHEMA_PATH,
+        )
+        execution_economics_assessment = _validate_document(
+            "execution_economics_assessment",
+            args.execution_economics_assessment,
+            _ECONOMICS_SCHEMA_PATH,
+        )
+        harvester_ref = _validate_document(
+            "harvester_ref", args.harvester_ref, _HARVESTER_SCHEMA_PATH
+        )
+        replay_vs_paper_compare = (
+            _validate_document(
+                "replay_vs_paper_compare",
+                args.replay_vs_paper_compare,
+                _COMPARE_SCHEMA_PATH,
+            )
+            if args.replay_vs_paper_compare is not None
+            else None
+        )
+        regime_scorecard = (
+            _validate_document(
+                "regime_scorecard", args.regime_scorecard, _SCORECARD_SCHEMA_PATH
+            )
+            if args.regime_scorecard is not None
+            else None
+        )
+
+        generated_at_utc = _parse_generated_at_utc(args.generated_at_utc)
+        result = build_profitability_evidence_packet(
+            candidate_contract=candidate_contract,
+            data_quality_report=data_quality_report,
+            replay_report=replay_report,
+            scenario_stress_summary=scenario_stress_summary,
+            economics_assessment=execution_economics_assessment,
+            harvester_ref=harvester_ref,
+            generated_at_utc=generated_at_utc,
+            replay_vs_paper_compare=replay_vs_paper_compare,
+            regime_scorecard=regime_scorecard,
+        )
+
+        args.out_json.parent.mkdir(parents=True, exist_ok=True)
+        args.out_md.parent.mkdir(parents=True, exist_ok=True)
+        args.out_json.write_text(
+            _deterministic_json_dumps(result.packet) + "\n",
+            encoding="utf-8",
+        )
+        args.out_md.write_text(result.markdown, encoding="utf-8")
+    except ProfitabilityEvidencePacketAssemblerError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    print(
+        "OK: profitability evidence packet assembled "
+        f"(packet_id={result.packet['evidence_packet_id']}, candidate_id={result.packet['candidate_id']})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/validation/test_profitability_evidence_packet_assembler.py
+++ b/tests/unit/validation/test_profitability_evidence_packet_assembler.py
@@ -1,0 +1,1056 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import jsonschema
+import pytest
+
+from services.validation.profitability_evidence_packet_assembler import (
+    ProfitabilityEvidencePacketAssemblerError,
+    _deterministic_json_dumps,
+    _read_json_payload,
+    _sha256_hex,
+    _sha256_ref,
+    _validate_document,
+    _validate_payload_against_schema,
+    build_profitability_evidence_packet,
+    build_profitability_evidence_packet_markdown,
+    main,
+    _normalize_path,
+    _build_packet_id,
+    _parse_generated_at_utc,
+    _classify_replay_vs_paper,
+    _build_regime_scorecard_block,
+    _dedupe_preserve_order,
+    _slugify_for_packet_id,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+CONTRACTS_DIR = PROJECT_ROOT / "docs" / "contracts"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_valid_candidate(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "schema_version": "profitability_candidate_contract.v1",
+        "candidate_id": "cand-test-001",
+        "strategy_family": "primary_breakout_v1",
+        "symbol_universe": ["BTCUSDT"],
+        "timeframe": "1h",
+        "direction": "long_only",
+        "regime_scope": {
+            "allowed_regimes": ["trend"],
+            "blocked_regimes": ["choppy"],
+            "freshness_required": True,
+        },
+        "parameter_set": {},
+        "hypothesis": "Test hypothesis for profitability evidence packet assembler unit tests.",
+        "risk_assumptions": ["No risk"],
+        "execution_assumptions": ["Standard execution"],
+        "status": "ARVP_VALIDATED",
+        "allowed_next_gate": "STRESS_TESTED",
+        "reject_reason": None,
+        "unsafe_zones": [],
+        "limitations": ["Test limitation"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_valid_dq(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "schema_version": "profitability_dataset_quality_report.v1",
+        "report_id": "dq-test-001",
+        "dataset_id": "ds-test-001",
+        "dataset_fingerprint": "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        "generated_at": "2026-06-22T12:00:00Z",
+        "symbol": "BTCUSDT",
+        "timeframe": "1h",
+        "requested_window": {"start_ts_ms": 1000, "end_ts_ms": 2000},
+        "observed_window": {
+            "start_ts_ms": 1000,
+            "end_ts_ms": 2000,
+            "candles_expected": 1000,
+            "candles_observed": 998,
+        },
+        "coverage_summary": {
+            "coverage_ratio": 0.998,
+            "missing_candle_count": 2,
+            "duplicate_timestamp_count": 0,
+            "out_of_order_count": 0,
+            "timeframe_mismatch_count": 0,
+        },
+        "checks": {
+            "coverage_check": {"status": "PASS", "summary": "Coverage ok"},
+            "missing_candle_check": {
+                "status": "WARNING",
+                "summary": "Missing 2 candles",
+            },
+            "duplicate_check": {"status": "PASS", "summary": "No duplicates"},
+            "ordering_check": {"status": "PASS", "summary": "In order"},
+            "timeframe_consistency_check": {"status": "PASS", "summary": "Consistent"},
+            "symbol_window_metadata_check": {
+                "status": "PASS",
+                "summary": "Metadata ok",
+            },
+            "dataset_fingerprint_check": {
+                "status": "PASS",
+                "summary": "Fingerprint matches",
+            },
+        },
+        "quality_verdict": "PASS",
+        "blocking_reasons": [],
+        "limitations": ["Some data gaps"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_valid_replay(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "schema_version": "profitability_replay_report.v1",
+        "candidate_id": "cand-test-001",
+        "replay_run_id": "replay-abcdef123456-2026",
+        "strategy_id": "pbv1-test",
+        "symbol": "BTCUSDT",
+        "timeframe": "1h",
+        "generated_at": "2026-06-22T12:00:00Z",
+        "gross_return": 0.05,
+        "profit_factor": 1.5,
+        "expectancy": 0.02,
+        "win_rate": 0.55,
+        "avg_win": 0.04,
+        "avg_loss": 0.02,
+        "max_drawdown": 0.08,
+        "loss_streak": 3,
+        "trade_count": 100,
+        "data_integrity_ok": True,
+        "deterministic_replay_ok": True,
+        "notes": ["Replay completed"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_valid_scenario(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "schema_version": "profitability_scenario_stress_summary.v1",
+        "stress_summary_id": "pss-test-001",
+        "candidate_id": "cand-test-001",
+        "catalog_id": "psc-test-001",
+        "generated_at": "2026-06-22T12:00:00Z",
+        "overall_stress_outcome": "PASS",
+        "scenario_results": [
+            {
+                "scenario_id": "slippage_high",
+                "domain": "SLIPPAGE",
+                "severity": "HIGH",
+                "status": "PASS",
+                "net_return_delta": None,
+                "max_drawdown_delta": 0.02,
+                "impact_summary": "Slippage impact within bounds",
+            }
+        ],
+        "recommendation_impact": {
+            "promote_allowed": True,
+            "park_required": False,
+            "reject_required": False,
+            "notes": "No impact",
+        },
+        "limitations": ["Scenario set limited"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_valid_economics(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "schema_version": "profitability_execution_economics_assessment.v1",
+        "assessment_id": "peea-test-001",
+        "candidate_id": "cand-test-001",
+        "model_id": "peem-test-001",
+        "generated_at": "2026-06-22T12:00:00Z",
+        "gross_return": 0.05,
+        "net_return": 0.02,
+        "cost_breakdown": {
+            "fees": 0.01,
+            "spread_cost": 0.01,
+            "slippage_cost": 0.01,
+            "other_friction_cost": 0.0,
+            "total_cost": 0.03,
+        },
+        "assessment_status": "PASS",
+        "ranking_ready": True,
+        "assumption_findings": [
+            {
+                "category": "FEE",
+                "severity": "INFO",
+                "summary": "Fees within expected range",
+            }
+        ],
+        "limitations": ["Cost model assumes standard tier"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_valid_harvester(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "schema_version": "profitability_harvester_ref.v1",
+        "candidate_id": "cand-test-001",
+        "source_run_refs": ["run-harvester-001"],
+        "risk_blocks": 0,
+        "kill_switch_events": 0,
+        "limitations": ["Harvester run had partial coverage"],
+        "safety_boundaries": ["No live execution without human gate"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_valid_compare(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "comparison_fingerprint": "ab" * 32,
+        "status": "aligned",
+        "paper_provenance_id": "paper-001",
+        "replay_run_id": "replay-abcdef123456-2026",
+        "symbol": "BTCUSDT",
+        "strategy_id": "pbv1-test",
+        "signal_count_delta": 0,
+        "order_count_delta": 0,
+        "fill_count_delta": 0,
+        "inferred_unfilled_count_delta": 0,
+        "signal_context_delta": 0,
+        "signal_count_false_neutral_detected": False,
+        "window_start_utc_replay": "2026-06-01T00:00:00Z",
+        "window_end_utc_replay": "2026-06-22T00:00:00Z",
+        "window_start_utc_paper": "2026-06-01T00:00:00Z",
+        "window_end_utc_paper": "2026-06-22T00:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_valid_scorecard(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "schema_version": "arvp_regime_scorecard.v1",
+        "status": "ok",
+        "run_id": "replay-abcdef123456-2026",
+        "source": "replay_trace",
+        "scorecard_fingerprint": "cd" * 32,
+        "segments": [
+            {
+                "regime_id": "trend",
+                "observation_count": 100,
+                "signal_count": 10,
+                "trade_close_count": 5,
+            }
+        ],
+        "notes": ["Scorecard completed"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_json(
+    tmp_path: Path, subdir: str, filename: str, payload: dict[str, Any]
+) -> Path:
+    dirpath = tmp_path / subdir
+    dirpath.mkdir(parents=True, exist_ok=True)
+    filepath = dirpath / filename
+    filepath.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+    return filepath
+
+
+def _write_required_inputs(
+    tmp_path: Path,
+    *,
+    candidate: dict[str, Any] | None = None,
+    dq: dict[str, Any] | None = None,
+    replay: dict[str, Any] | None = None,
+    scenario: dict[str, Any] | None = None,
+    economics: dict[str, Any] | None = None,
+    harvester: dict[str, Any] | None = None,
+) -> dict[str, Path]:
+    return {
+        "candidate": _write_json(
+            tmp_path, "inputs", "candidate.json", candidate or _make_valid_candidate()
+        ),
+        "dq": _write_json(tmp_path, "inputs", "dq.json", dq or _make_valid_dq()),
+        "replay": _write_json(
+            tmp_path, "inputs", "replay.json", replay or _make_valid_replay()
+        ),
+        "scenario": _write_json(
+            tmp_path, "inputs", "scenario.json", scenario or _make_valid_scenario()
+        ),
+        "economics": _write_json(
+            tmp_path, "inputs", "economics.json", economics or _make_valid_economics()
+        ),
+        "harvester": _write_json(
+            tmp_path, "inputs", "harvester.json", harvester or _make_valid_harvester()
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def _build_result(
+    tmp_path: Path, generated_at: str = "2026-06-22T12:00:00Z", **overrides: Any
+):
+    paths = _write_required_inputs(tmp_path)
+    candidate = _validate_document(
+        "candidate_contract",
+        paths["candidate"],
+        CONTRACTS_DIR / "profitability_candidate_contract.v1.schema.json",
+    )
+    dq = _validate_document(
+        "data_quality_report",
+        paths["dq"],
+        CONTRACTS_DIR / "profitability_dataset_quality_report.v1.schema.json",
+    )
+    replay = _validate_document(
+        "replay_report",
+        paths["replay"],
+        CONTRACTS_DIR / "profitability_replay_report.v1.schema.json",
+    )
+    scenario = _validate_document(
+        "scenario_stress_summary",
+        paths["scenario"],
+        CONTRACTS_DIR / "profitability_scenario_stress_summary.v1.schema.json",
+    )
+    economics = _validate_document(
+        "execution_economics_assessment",
+        paths["economics"],
+        CONTRACTS_DIR / "profitability_execution_economics_assessment.v1.schema.json",
+    )
+    harvester = _validate_document(
+        "harvester_ref",
+        paths["harvester"],
+        CONTRACTS_DIR / "profitability_harvester_ref.v1.schema.json",
+    )
+
+    optional_compare = None
+    optional_scorecard = None
+    if "compare" in overrides:
+        path = _write_json(tmp_path, "inputs", "compare.json", overrides["compare"])
+        optional_compare = _validate_document(
+            "replay_vs_paper_compare",
+            path,
+            CONTRACTS_DIR / "shadow_comparison.v1.schema.json",
+        )
+    if "scorecard" in overrides:
+        path = _write_json(tmp_path, "inputs", "scorecard.json", overrides["scorecard"])
+        optional_scorecard = _validate_document(
+            "regime_scorecard",
+            path,
+            CONTRACTS_DIR / "arvp_regime_scorecard.v1.schema.json",
+        )
+
+    result = build_profitability_evidence_packet(
+        candidate_contract=candidate,
+        data_quality_report=dq,
+        replay_report=replay,
+        scenario_stress_summary=scenario,
+        economics_assessment=economics,
+        harvester_ref=harvester,
+        generated_at_utc=generated_at,
+        replay_vs_paper_compare=optional_compare,
+        regime_scorecard=optional_scorecard,
+    )
+    return result, paths
+
+
+@pytest.mark.unit
+def test_happy_path_creates_valid_json_and_markdown(tmp_path: Path) -> None:
+    result, _ = _build_result(tmp_path)
+
+    packet = result.packet
+    assert packet["schema_version"] == "profitability_evidence_packet.v1"
+    assert packet["candidate_id"] == "cand-test-001"
+    assert packet["evidence_packet_id"].startswith("pep-test-001-")
+    assert packet["generated_at"] == "2026-06-22T12:00:00Z"
+    assert packet["gross_return"] == 0.05
+    assert packet["recommendation"] == "NO_RECOMMENDATION"
+    assert packet["replay_vs_paper_status"] == "not_run"
+    assert packet["simulator_drift"] == "not_assessed"
+
+    schema_path = CONTRACTS_DIR / "profitability_evidence_packet.v1.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator_cls.check_schema(schema)
+    validator = validator_cls(schema)
+    errors = list(validator.iter_errors(packet))
+    assert not errors, f"Schema validation errors: {errors}"
+
+    md = result.markdown
+    assert md.startswith("# Profitability Evidence Packet Summary")
+    assert "cand-test-001" in md
+    assert "NO_RECOMMENDATION" in md
+    assert packet["evidence_packet_id"] in md
+    assert "not_run" in md
+    assert "not_assessed" in md
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_determinism_identical_inputs_produce_identical_json(tmp_path: Path) -> None:
+    generated_at = "2026-06-22T12:00:00Z"
+    result1, _ = _build_result(tmp_path, generated_at=generated_at)
+    result2, _ = _build_result(tmp_path, generated_at=generated_at)
+
+    json1 = _deterministic_json_dumps(result1.packet)
+    json2 = _deterministic_json_dumps(result2.packet)
+    assert json1 == json2
+    assert (
+        hashlib.sha256(json1.encode("utf-8")).hexdigest()
+        == hashlib.sha256(json2.encode("utf-8")).hexdigest()
+    )
+
+
+@pytest.mark.unit
+def test_determinism_different_utc_produces_different_id(tmp_path: Path) -> None:
+    result1, _ = _build_result(tmp_path, generated_at="2026-06-22T12:00:00Z")
+    result2, _ = _build_result(tmp_path, generated_at="2026-06-23T12:00:00Z")
+
+    assert result1.packet["evidence_packet_id"] != result2.packet["evidence_packet_id"]
+
+
+# ---------------------------------------------------------------------------
+# Missing required inputs (fails closed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_missing_economics_fails_closed(tmp_path: Path) -> None:
+    paths = _write_required_inputs(tmp_path)
+    candidate = _validate_document(
+        "candidate_contract",
+        paths["candidate"],
+        CONTRACTS_DIR / "profitability_candidate_contract.v1.schema.json",
+    )
+    dq = _validate_document(
+        "data_quality_report",
+        paths["dq"],
+        CONTRACTS_DIR / "profitability_dataset_quality_report.v1.schema.json",
+    )
+    replay = _validate_document(
+        "replay_report",
+        paths["replay"],
+        CONTRACTS_DIR / "profitability_replay_report.v1.schema.json",
+    )
+    scenario = _validate_document(
+        "scenario_stress_summary",
+        paths["scenario"],
+        CONTRACTS_DIR / "profitability_scenario_stress_summary.v1.schema.json",
+    )
+    harvester = _validate_document(
+        "harvester_ref",
+        paths["harvester"],
+        CONTRACTS_DIR / "profitability_harvester_ref.v1.schema.json",
+    )
+
+    with pytest.raises(TypeError):
+        build_profitability_evidence_packet(
+            candidate_contract=candidate,
+            data_quality_report=dq,
+            replay_report=replay,
+            scenario_stress_summary=scenario,
+            harvester_ref=harvester,
+            generated_at_utc="2026-06-22T12:00:00Z",
+        )
+
+
+@pytest.mark.unit
+def test_missing_replay_report_path_fails_closed(tmp_path: Path) -> None:
+    nonexistent = tmp_path / "no_such_file.json"
+    with pytest.raises(
+        ProfitabilityEvidencePacketAssemblerError, match="Failed to read"
+    ):
+        _validate_document(
+            "replay_report",
+            nonexistent,
+            CONTRACTS_DIR / "profitability_replay_report.v1.schema.json",
+        )
+
+
+@pytest.mark.unit
+def test_missing_data_quality_path_fails_closed(tmp_path: Path) -> None:
+    nonexistent = tmp_path / "no_such_dq.json"
+    with pytest.raises(
+        ProfitabilityEvidencePacketAssemblerError, match="Failed to read"
+    ):
+        _validate_document(
+            "data_quality_report",
+            nonexistent,
+            CONTRACTS_DIR / "profitability_dataset_quality_report.v1.schema.json",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Invalid JSON
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_invalid_json_fails_closed(tmp_path: Path) -> None:
+    bad_file = tmp_path / "bad.json"
+    bad_file.write_text("not json", encoding="utf-8")
+    with pytest.raises(ProfitabilityEvidencePacketAssemblerError, match="Invalid JSON"):
+        _validate_document(
+            "replay_report",
+            bad_file,
+            CONTRACTS_DIR / "profitability_replay_report.v1.schema.json",
+        )
+
+
+@pytest.mark.unit
+def test_non_dict_json_fails_closed(tmp_path: Path) -> None:
+    bad_file = tmp_path / "array.json"
+    bad_file.write_text("[1,2,3]", encoding="utf-8")
+    with pytest.raises(
+        ProfitabilityEvidencePacketAssemblerError, match="must be an object"
+    ):
+        _validate_document(
+            "replay_report",
+            bad_file,
+            CONTRACTS_DIR / "profitability_replay_report.v1.schema.json",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Schema mismatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_schema_mismatch_fails_closed(tmp_path: Path) -> None:
+    invalid_payload = {"invalid": "data", "schema_version": "wrong"}
+    bad_file = _write_json(tmp_path, "inputs", "bad_replay.json", invalid_payload)
+    with pytest.raises(
+        ProfitabilityEvidencePacketAssemblerError, match="Schema mismatch"
+    ):
+        _validate_document(
+            "replay_report",
+            bad_file,
+            CONTRACTS_DIR / "profitability_replay_report.v1.schema.json",
+        )
+
+
+@pytest.mark.unit
+def test_bad_candidate_id_mismatch_fails_closed(tmp_path: Path) -> None:
+    paths = _write_required_inputs(
+        tmp_path, candidate=_make_valid_candidate(candidate_id="cand-other-001")
+    )
+    candidate = _validate_document(
+        "candidate_contract",
+        paths["candidate"],
+        CONTRACTS_DIR / "profitability_candidate_contract.v1.schema.json",
+    )
+    dq = _validate_document(
+        "data_quality_report",
+        paths["dq"],
+        CONTRACTS_DIR / "profitability_dataset_quality_report.v1.schema.json",
+    )
+    replay = _validate_document(
+        "replay_report",
+        paths["replay"],
+        CONTRACTS_DIR / "profitability_replay_report.v1.schema.json",
+    )
+    scenario = _validate_document(
+        "scenario_stress_summary",
+        paths["scenario"],
+        CONTRACTS_DIR / "profitability_scenario_stress_summary.v1.schema.json",
+    )
+    economics = _validate_document(
+        "execution_economics_assessment",
+        paths["economics"],
+        CONTRACTS_DIR / "profitability_execution_economics_assessment.v1.schema.json",
+    )
+    harvester = _validate_document(
+        "harvester_ref",
+        paths["harvester"],
+        CONTRACTS_DIR / "profitability_harvester_ref.v1.schema.json",
+    )
+
+    with pytest.raises(
+        ProfitabilityEvidencePacketAssemblerError,
+        match="replay_report.candidate_id must match",
+    ):
+        build_profitability_evidence_packet(
+            candidate_contract=candidate,
+            data_quality_report=dq,
+            replay_report=replay,
+            scenario_stress_summary=scenario,
+            economics_assessment=economics,
+            harvester_ref=harvester,
+            generated_at_utc="2026-06-22T12:00:00Z",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Optional inputs classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_optional_compare_not_provided_classified_correctly(tmp_path: Path) -> None:
+    result, _ = _build_result(tmp_path)
+    assert result.packet["replay_vs_paper_status"] == "not_run"
+    assert result.packet["simulator_drift"] == "not_assessed"
+    roles = [e["artifact_role"] for e in result.packet.get("missing_evidence", [])]
+    assert "replay_vs_paper_compare" in roles
+
+
+@pytest.mark.unit
+def test_optional_scorecard_not_provided_classified_correctly(tmp_path: Path) -> None:
+    result, _ = _build_result(tmp_path)
+    assert result.packet["regime_scorecard"]["status"] == "unavailable"
+    roles = [e["artifact_role"] for e in result.packet.get("missing_evidence", [])]
+    assert "regime_scorecard" in roles
+
+
+@pytest.mark.unit
+def test_optional_compare_provided_aligned(tmp_path: Path) -> None:
+    result, _ = _build_result(tmp_path, compare=_make_valid_compare())
+    assert result.packet["replay_vs_paper_status"] == "aligned"
+    assert result.packet["simulator_drift"] == "none"
+
+
+@pytest.mark.unit
+def test_optional_scorecard_provided(tmp_path: Path) -> None:
+    result, _ = _build_result(tmp_path, scorecard=_make_valid_scorecard())
+    assert result.packet["regime_scorecard"]["status"] == "ok"
+    assert result.packet["regime_scorecard"]["artifact_ref"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Harvester refs propagate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_harvester_refs_propagate_into_source_run_refs(tmp_path: Path) -> None:
+    harvester = _make_valid_harvester(source_run_refs=["run-alpha", "run-beta"])
+    paths = _write_required_inputs(tmp_path, harvester=harvester)
+    candidate = _validate_document(
+        "candidate_contract",
+        paths["candidate"],
+        CONTRACTS_DIR / "profitability_candidate_contract.v1.schema.json",
+    )
+    dq = _validate_document(
+        "data_quality_report",
+        paths["dq"],
+        CONTRACTS_DIR / "profitability_dataset_quality_report.v1.schema.json",
+    )
+    replay = _validate_document(
+        "replay_report",
+        paths["replay"],
+        CONTRACTS_DIR / "profitability_replay_report.v1.schema.json",
+    )
+    scenario = _validate_document(
+        "scenario_stress_summary",
+        paths["scenario"],
+        CONTRACTS_DIR / "profitability_scenario_stress_summary.v1.schema.json",
+    )
+    economics = _validate_document(
+        "execution_economics_assessment",
+        paths["economics"],
+        CONTRACTS_DIR / "profitability_execution_economics_assessment.v1.schema.json",
+    )
+    harvester_doc = _validate_document(
+        "harvester_ref",
+        paths["harvester"],
+        CONTRACTS_DIR / "profitability_harvester_ref.v1.schema.json",
+    )
+
+    result = build_profitability_evidence_packet(
+        candidate_contract=candidate,
+        data_quality_report=dq,
+        replay_report=replay,
+        scenario_stress_summary=scenario,
+        economics_assessment=economics,
+        harvester_ref=harvester_doc,
+        generated_at_utc="2026-06-22T12:00:00Z",
+    )
+
+    refs = result.packet["source_run_refs"]
+    assert "run-alpha" in refs
+    assert "run-beta" in refs
+    assert result.packet["risk_blocks"] == 0
+    assert result.packet["kill_switch_events"] == 0
+
+
+@pytest.mark.unit
+def test_harvester_safety_boundaries_propagate(tmp_path: Path) -> None:
+    harvester = _make_valid_harvester(safety_boundaries=["Custom safety boundary"])
+    paths = _write_required_inputs(tmp_path, harvester=harvester)
+    candidate = _validate_document(
+        "candidate_contract",
+        paths["candidate"],
+        CONTRACTS_DIR / "profitability_candidate_contract.v1.schema.json",
+    )
+    dq = _validate_document(
+        "data_quality_report",
+        paths["dq"],
+        CONTRACTS_DIR / "profitability_dataset_quality_report.v1.schema.json",
+    )
+    replay = _validate_document(
+        "replay_report",
+        paths["replay"],
+        CONTRACTS_DIR / "profitability_replay_report.v1.schema.json",
+    )
+    scenario = _validate_document(
+        "scenario_stress_summary",
+        paths["scenario"],
+        CONTRACTS_DIR / "profitability_scenario_stress_summary.v1.schema.json",
+    )
+    economics = _validate_document(
+        "execution_economics_assessment",
+        paths["economics"],
+        CONTRACTS_DIR / "profitability_execution_economics_assessment.v1.schema.json",
+    )
+    harvester_doc = _validate_document(
+        "harvester_ref",
+        paths["harvester"],
+        CONTRACTS_DIR / "profitability_harvester_ref.v1.schema.json",
+    )
+
+    result = build_profitability_evidence_packet(
+        candidate_contract=candidate,
+        data_quality_report=dq,
+        replay_report=replay,
+        scenario_stress_summary=scenario,
+        economics_assessment=economics,
+        harvester_ref=harvester_doc,
+        generated_at_utc="2026-06-22T12:00:00Z",
+    )
+
+    boundaries = result.packet["safety_boundaries"]
+    assert "Custom safety boundary" in boundaries
+
+
+# ---------------------------------------------------------------------------
+# Legacy / non-canonical economics payload rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_legacy_economics_payload_rejected(tmp_path: Path) -> None:
+    legacy = {"schema_version": "v0_legacy", "candidate_id": "cand-test-001"}
+    bad_file = _write_json(tmp_path, "inputs", "legacy_economics.json", legacy)
+    with pytest.raises(
+        ProfitabilityEvidencePacketAssemblerError, match="Schema mismatch"
+    ):
+        _validate_document(
+            "execution_economics_assessment",
+            bad_file,
+            CONTRACTS_DIR
+            / "profitability_execution_economics_assessment.v1.schema.json",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Serializer preserves null and sorts stably
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_deterministic_json_dumps_preserves_null() -> None:
+    payload = {"a": None, "b": 1, "c": "hello"}
+    dumped = _deterministic_json_dumps(payload)
+    assert '"a":null' in dumped
+    assert dumped == '{"a":null,"b":1,"c":"hello"}'
+
+
+@pytest.mark.unit
+def test_deterministic_json_dumps_sorted_keys() -> None:
+    payload = {"z": 1, "a": 2, "m": 3}
+    dumped = _deterministic_json_dumps(payload)
+    assert dumped == '{"a":2,"m":3,"z":1}'
+
+
+@pytest.mark.unit
+def test_deterministic_json_dumps_pretty() -> None:
+    payload = {"a": 1, "b": 2}
+    dumped = _deterministic_json_dumps(payload, pretty=True)
+    assert "  " in dumped
+    assert "\n" in dumped
+
+
+# ---------------------------------------------------------------------------
+# _build_packet_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_build_packet_id_format() -> None:
+    artifacts = [
+        {
+            "artifact_role": "candidate_contract",
+            "path": "test.json",
+            "schema_ref": "schema.json",
+            "sha256": "sha256:ab" * 32,
+        }
+    ]
+    pid = _build_packet_id("cand-test-001", "2026-06-22T12:00:00Z", artifacts)
+    assert pid.startswith("pep-test-001-")
+    assert len(pid) > 20
+
+
+# ---------------------------------------------------------------------------
+# _parse_generated_at_utc
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_generated_at_utc_valid() -> None:
+    result = _parse_generated_at_utc("2026-06-22T12:00:00Z")
+    assert result.endswith("Z")
+    assert "2026-06-22" in result
+
+
+@pytest.mark.unit
+def test_parse_generated_at_utc_no_tz_fails() -> None:
+    with pytest.raises(ProfitabilityEvidencePacketAssemblerError, match="UTC offset"):
+        _parse_generated_at_utc("2026-06-22T12:00:00")
+
+
+@pytest.mark.unit
+def test_parse_generated_at_utc_empty_fails() -> None:
+    with pytest.raises(ProfitabilityEvidencePacketAssemblerError, match="non-empty"):
+        _parse_generated_at_utc("")
+
+
+# ---------------------------------------------------------------------------
+# _classify_replay_vs_paper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_classify_replay_vs_paper_missing() -> None:
+    missing: list[dict[str, Any]] = []
+    status, drift = _classify_replay_vs_paper(None, missing)
+    assert status == "not_run"
+    assert drift == "not_assessed"
+    assert len(missing) == 1
+    assert missing[0]["classification"] == "OPTIONAL_NOT_PROVIDED"
+
+
+@pytest.mark.unit
+def test_classify_replay_vs_paper_aligned() -> None:
+    payload = _make_valid_compare(status="aligned")
+    missing: list[dict[str, Any]] = []
+    from services.validation.profitability_evidence_packet_assembler import (
+        ValidatedJsonDocument,
+    )
+
+    doc = ValidatedJsonDocument(
+        artifact_role="replay_vs_paper_compare",
+        path=Path("/fake"),
+        display_path="fake.json",
+        sha256="sha256:aa",
+        schema_ref="shadow_comparison.v1.schema.json",
+        payload=payload,
+    )
+    status, drift = _classify_replay_vs_paper(doc, missing)
+    assert status == "aligned"
+    assert drift == "none"
+    assert len(missing) == 0
+
+
+# ---------------------------------------------------------------------------
+# _build_regime_scorecard_block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_build_regime_scorecard_block_missing() -> None:
+    missing: list[dict[str, Any]] = []
+    block = _build_regime_scorecard_block(None, missing)
+    assert block["status"] == "unavailable"
+    assert block["artifact_ref"] is None
+
+
+@pytest.mark.unit
+def test_build_regime_scorecard_block_ok() -> None:
+    missing: list[dict[str, Any]] = []
+    from services.validation.profitability_evidence_packet_assembler import (
+        ValidatedJsonDocument,
+    )
+
+    doc = ValidatedJsonDocument(
+        artifact_role="regime_scorecard",
+        path=Path("/fake"),
+        display_path="scorecard.json",
+        sha256="sha256:bb",
+        schema_ref="arvp_regime_scorecard.v1.schema.json",
+        payload=_make_valid_scorecard(),
+    )
+    block = _build_regime_scorecard_block(doc, missing)
+    assert block["status"] == "ok"
+    assert block["artifact_ref"] == "scorecard.json"
+
+
+# ---------------------------------------------------------------------------
+# CLI main integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_main_happy_path(tmp_path: Path) -> None:
+    paths = _write_required_inputs(tmp_path)
+    out_json = tmp_path / "out" / "packet.json"
+    out_md = tmp_path / "out" / "packet.md"
+
+    exit_code = main(
+        [
+            "--candidate-contract",
+            str(paths["candidate"]),
+            "--data-quality-report",
+            str(paths["dq"]),
+            "--replay-report",
+            str(paths["replay"]),
+            "--scenario-stress-summary",
+            str(paths["scenario"]),
+            "--execution-economics-assessment",
+            str(paths["economics"]),
+            "--harvester-ref",
+            str(paths["harvester"]),
+            "--generated-at-utc",
+            "2026-06-22T12:00:00Z",
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+        ]
+    )
+    assert exit_code == 0
+    assert out_json.exists()
+    assert out_md.exists()
+
+    packet = json.loads(out_json.read_text(encoding="utf-8"))
+    assert packet["schema_version"] == "profitability_evidence_packet.v1"
+
+
+@pytest.mark.unit
+def test_main_missing_required_arg_fails() -> None:
+    exit_code = main(["--generated-at-utc", "2026-06-22T12:00:00Z"])
+    assert exit_code == 1
+
+
+@pytest.mark.unit
+def test_main_bad_input_path_fails(tmp_path: Path) -> None:
+    exit_code = main(
+        [
+            "--candidate-contract",
+            str(tmp_path / "nonexistent.json"),
+            "--data-quality-report",
+            str(tmp_path / "nonexistent.json"),
+            "--replay-report",
+            str(tmp_path / "nonexistent.json"),
+            "--scenario-stress-summary",
+            str(tmp_path / "nonexistent.json"),
+            "--execution-economics-assessment",
+            str(tmp_path / "nonexistent.json"),
+            "--harvester-ref",
+            str(tmp_path / "nonexistent.json"),
+            "--generated-at-utc",
+            "2026-06-22T12:00:00Z",
+            "--out-json",
+            str(tmp_path / "out.json"),
+            "--out-md",
+            str(tmp_path / "out.md"),
+        ]
+    )
+    assert exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# Dedupe preserve order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dedupe_preserve_order() -> None:
+    result = _dedupe_preserve_order(["b", "a", "b", "c", "a"])
+    assert result == ["b", "a", "c"]
+
+
+@pytest.mark.unit
+def test_dedupe_preserve_order_skips_empty() -> None:
+    result = _dedupe_preserve_order(["", "a", " ", "b"])
+    assert result == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Slugify for packet ID
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_slugify_simple() -> None:
+    assert _slugify_for_packet_id("cand-test-001") == "cand-test-001"
+
+
+@pytest.mark.unit
+def test_slugify_special_chars() -> None:
+    result = _slugify_for_packet_id("hello world/foo.bar")
+    assert "--" not in result
+    assert result == "hello-world-foo-bar"
+
+
+@pytest.mark.unit
+def test_slugify_empty_fallback() -> None:
+    assert _slugify_for_packet_id("!!!") == "packet"
+
+
+# ---------------------------------------------------------------------------
+# Schema validation helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_payload_against_schema_passes() -> None:
+    payload = _make_valid_replay()
+    _validate_payload_against_schema(
+        payload,
+        schema_path=CONTRACTS_DIR / "profitability_replay_report.v1.schema.json",
+        artifact_role="replay_report",
+    )
+
+
+@pytest.mark.unit
+def test_validate_payload_against_schema_candidate_passes() -> None:
+    payload = _make_valid_candidate()
+    _validate_payload_against_schema(
+        payload,
+        schema_path=CONTRACTS_DIR / "profitability_candidate_contract.v1.schema.json",
+        artifact_role="candidate_contract",
+    )
+
+
+@pytest.mark.unit
+def test_validate_payload_against_schema_fails() -> None:
+    with pytest.raises(
+        ProfitabilityEvidencePacketAssemblerError, match="Schema mismatch"
+    ):
+        _validate_payload_against_schema(
+            {"wrong": "data"},
+            schema_path=CONTRACTS_DIR / "profitability_replay_report.v1.schema.json",
+            artifact_role="replay_report",
+        )


### PR DESCRIPTION
Closes #3381

Refs #3380
Refs #3383
Refs #3032

## Brain Evidence

- brain_source: repo-only
- brain_status: not-used
- tools_or_queries: context.briefing (unavailable); context.search (unavailable)
- records_or_results: 0 records from MCP/DB-backed Context Brain
- repo_crosscheck: session-start verified issue #3381 OPEN, no open/merged PR for this branch; existing assembler work from prior session preserved in worktree
- impact_on_plan: no live/MCP/DB dependency; offline-only assembler; LR NO-GO remains orthogonal
- limitations: no DB-backed claims; fully repo-evidenced offline delivery

## Scope

**IN:**
- New offline CLI assembler at \services/validation/profitability_evidence_packet_assembler.py\ with \main()\ entry point
- Four new input-contract schemas under \docs/contracts/\ for replay-report, harvester-ref, shadow-comparison, regime-scorecard
- Backward-compatible \source_artifacts\, \missing_evidence\, \coverage_readiness\ optional fields on \profitability_evidence_packet.v1.schema.json\
- Comprehensive unit tests at \	ests/unit/validation/test_profitability_evidence_packet_assembler.py\ (39 tests)
- Usage note in \services/validation/README.md\

**OUT:**
- No Strategy League Table ranking
- No candidate promotion
- No paper/live execution
- No LR-Go, Live-Go, or Echtgeld-Go
- No Docker/DB/Redis/MCP/secrets/runtime changes

## Implementation

- Deterministic offline assembler; purely file-based input through explicit CLI paths
- \jsonschema.validators.validator_for\ for multi-draft schema support (Draft-07 and Draft-2020-12)
- Cross-document consistency validation (candidate_id, symbol, timeframe, replay_run_id matching across inputs)
- Optional \--replay-vs-paper-compare\ and \--regime-scorecard\ with explicit missing-evidence classification (OPTIONAL_NOT_PROVIDED, UNAVAILABLE_FROM_INPUT, UNUSABLE_INPUT, etc.)
- Deterministic JSON serialization: sorted keys, stable separators, explicit null preserved
- Required \--generated-at-utc\ guarantees byte-identical output from identical inputs
- Default safety boundaries always carried into packet

## Contract / Schema

- \profitability_evidence_packet.v1.schema.json\: extended with optional \source_artifacts\, \missing_evidence\, \coverage_readiness\ (backward-compatible)
- New input schemas (all Draft-2020-12; multi-draft supported):
  - \profitability_replay_report.v1.schema.json\
  - \profitability_harvester_ref.v1.schema.json\
  - \shadow_comparison.v1.schema.json\
  - \rvp_regime_scorecard.v1.schema.json\

## CLI / Usage

\\\ash
python -m services.validation.profitability_evidence_packet_assembler \\
    --candidate-contract candidate.json \\
    --data-quality-report dq.json \\
    --replay-report replay.json \\
    --scenario-stress-summary scenario.json \\
    --execution-economics-assessment economics.json \\
    --harvester-ref harvester.json \\
    --replay-vs-paper-compare compare.json \\
    --regime-scorecard scorecard.json \\
    --generated-at-utc 2026-06-22T12:00:00Z \\
    --out-json out/packet.json \\
    --out-md out/packet.md
\\\

## Validation

- \pytest -q tests/unit/validation/test_profitability_evidence_packet_assembler.py\: **39 passed**
- \uff check ...\: **PASS** (no warnings on new/changed files)
- \lack --check ...\: **PASS** (files left unchanged after formatting)

## Safety Boundaries

- LR remains NO-GO.
- Board stage trade-capable is not Live-Go.
- Evidence packets are research-only and do not authorize paper or live execution.
- No candidate promotion is authorized.
- No Docker, DB, Redis, MCP, secrets, scheduler, or runtime access used.
- Active #3374 artifacts not modified.