### PR TITLE
feat(testing): test-first processing contract + skill valley upgrade plan

### DIFF
--- a/knowledge/testing/MOCKEXCHANGE_CDB_TEST_MAP.md
+++ b/knowledge/testing/MOCKEXCHANGE_CDB_TEST_MAP.md
@@ -1,0 +1,313 @@
+# MockExchange CDB Test Map
+
+Status: active planning map
+Date: 2026-06-23
+Scope: CDB test design, MockExchange reference usage, no runtime activation
+
+## Purpose
+
+This document makes the local MockExchange reference concretely usable for CDB.
+It does not integrate MockExchange into CDB yet. It translates the strongest
+MockExchange test patterns into CDB test targets.
+
+MockExchange is valuable because it solves the same practical problem as CDB's
+paper/execution layer: safe order handling without live capital.
+
+## Sources Read
+
+- Local toolchain source: `D:\Dev\Tools\GitHub\Desktop\SKILLS\mockexchange\`
+- MockExchange README: `packages/engine`, `packages/oracle`, `packages/periscope`, `packages/valkey`
+- MockExchange unit tests:
+  - `packages/engine/tests/unit/test_market.py`
+  - `packages/engine/tests/unit/test_orderbook.py`
+- MockExchange integration tests:
+  - `test_03_market_orders_property.py`
+  - `test_04_limit_orders_property.py`
+  - `test_06_fund_and_full_rejected_insufficient_trade_when_buy.py`
+  - `test_09_fund_and_rejected_insufficient_fee_when_sell.py`
+- CDB current references:
+  - `tools/test_pack/README.md`
+  - `.opencode/skills/cdb-shadow-validation/SKILL.md`
+  - `knowledge/governance/SERVICE_CATALOG.md`
+  - `knowledge/testing/PAPER_TRADING_TEST_REQUIREMENTS.md`
+  - `knowledge/testing/TEST_HARNESS_V1.md`
+  - `tests/unit/services/test_execution_state_machine.py`
+  - `tests/integration/test_execution_pipeline.py`
+  - `tests/e2e/test_paper_trading_p0.py`
+  - `tests/unit/replay/test_replay_vs_paper_compare.py`
+
+## Existing CDB Boundary
+
+MockExchange already exists in CDB as a local reference copy, not as active
+runtime.
+
+- `tools/test_pack/mock_exchange/` is gitignored and must not be staged.
+- `mockx-valkey` is non-canonical dev/test reference infra.
+- Expected state for `mockx-valkey`: absent by default.
+- CDB canonical Redis remains `cdb_redis`.
+- Full MockExchange stack use requires explicit future issue and Jannek Ops GO.
+- No Live-Go or Echtgeld-Go follows from any MockExchange result.
+
+## Practical Meaning For CDB
+
+MockExchange should first be used as a test-pattern source, not as a runtime
+dependency.
+
+The immediate CDB value is not "run their stack". The immediate value is:
+
+- copy the test ideas,
+- adapt the invariants to CDB's execution and risk contracts,
+- keep the tests deterministic,
+- keep the path mock/shadow only,
+- prove that CDB leaves no stuck orders, locked funds, false fills, or fee leaks.
+
+## Strongest MockExchange Test Ideas
+
+| MockExchange pattern | What it proves | CDB translation |
+|---|---|---|
+| `Market.fetch_ticker()` returns parsed ticker or `None` on malformed data | Bad market data must not become a valid price | CDB market/candles consumers should reject malformed payloads fail-closed |
+| `OrderBook.add()` indexes only open orders | Closed orders must not remain active | CDB execution state must not leave terminal orders in active queues |
+| `OrderBook.remove()` clears symbol and global indexes | Cancel/remove must clean all views | CDB order lifecycle should remove or mark all active references consistently |
+| Market order property test | Every market order converges to terminal state and no funds remain locked | CDB execution mock should prove state convergence and no residual reservations |
+| Limit order property test | Price move triggers matching and then terminal state | CDB replay/emulator tests should prove deterministic limit-order trigger behavior |
+| BUY insufficient-funds tamper test | Reservation rollback after pre-fill shortfall | CDB Risk/Execution should reject and leave no persisted false fill |
+| SELL insufficient-fee tamper test | Fee shortage blocks execution and releases all reservations | CDB fee/slippage model should prove fee fail-closed behavior |
+| Order generator example | High-volume random order stimulus | CDB can use this idea for soak, watchdog, and replay-vs-paper stress tests |
+
+## Test Basket Mapping
+
+### 1. Bauteil-Tests
+
+Best MockExchange source:
+
+- `test_market.py`
+- `test_orderbook.py`
+
+CDB target:
+
+- `tests/unit/services/test_execution_state_machine.py`
+- `tests/unit/services/test_execution_negative_payloads.py`
+- future focused tests around execution order indexing, terminal-state handling,
+  malformed market data, and no stale active-order references.
+
+Concrete CDB test ideas:
+
+- terminal execution statuses have no outgoing transitions,
+- rejected and filled orders never remain in active/open views,
+- malformed price payload cannot create a fill,
+- unknown symbol or missing ticker must fail closed.
+
+### 2. Ketten-Tests
+
+Best MockExchange source:
+
+- market-order property test,
+- limit-order property test,
+- API-level integration helpers.
+
+CDB target:
+
+- `tests/integration/test_execution_pipeline.py`
+- `tests/e2e/test_paper_trading_p0.py`
+- replay-vs-paper compare tests.
+
+Concrete CDB test ideas:
+
+- signal/order/result chain reaches exactly one terminal outcome,
+- order result is published once and persisted once,
+- replay output and paper output agree on order/fill counts,
+- market and limit order paths share the same terminal-state contract.
+
+### 3. Schutz-Tests
+
+Best MockExchange source:
+
+- insufficient BUY funds after reservation,
+- insufficient SELL fee after reservation,
+- cancel limit orders,
+- partial reject tests.
+
+CDB target:
+
+- Risk Service guard tests,
+- execution shadow gate tests,
+- emergency stop and circuit breaker tests.
+
+Concrete CDB test ideas:
+
+- if balance disappears after risk approval but before execution, execution must reject,
+- if fee budget is insufficient, execution must reject and record no fill,
+- if shadow mode is active, executor must not be called,
+- if kill switch is active, no order enters execution.
+
+### 4. Wirtschafts-Tests
+
+Best MockExchange source:
+
+- commission calculation,
+- fee reservation,
+- slippage-like market fill parameters,
+- portfolio `free`/`used` accounting.
+
+CDB target:
+
+- paper runner profitability checks,
+- replay-vs-paper comparison,
+- future ARVP profitability evidence.
+
+Concrete CDB test ideas:
+
+- gross PnL and net PnL differ by explicit fees,
+- slippage changes net result and can flip marginal winners into losers,
+- rejected orders do not count as fills,
+- partial fills produce explicit residual exposure.
+
+### 5. Betriebs-Tests
+
+Best MockExchange source:
+
+- order generator example,
+- async settle wait,
+- polling until open orders disappear,
+- service-specific logs/status commands.
+
+CDB target:
+
+- soak-style paper runs,
+- watchdog checks,
+- long-run evidence bundles.
+
+Concrete CDB test ideas:
+
+- random but seeded order bursts leave zero active orders after shutdown,
+- long paper run leaves no orphaned order IDs,
+- recovery after restart does not duplicate fills,
+- evidence bundle includes counts for orders, fills, rejects, locks, and fees.
+
+### 6. Wissens-Tests
+
+Best MockExchange source:
+
+- readable test docstrings,
+- test README explaining unit vs integration boundaries,
+- explicit package boundaries.
+
+CDB target:
+
+- SurrealDB/context intelligence evidence model,
+- agent onboarding,
+- docs-to-test consistency checks.
+
+Concrete CDB test ideas:
+
+- every paper/execution test has a documented target contract,
+- docs say `mockx-valkey` is absent by default and service catalog agrees,
+- shadow-validation skill says exchange-facing changes require MockExchange or
+  emulator evidence,
+- future SurrealDB evidence rows link code path, test, issue, and result without
+  conflicting truths.
+
+## Recommended First Implementation Slice
+
+First implement CDB-native tests. Do not import MockExchange yet.
+
+### Slice A: Execution terminal-state convergence
+
+Goal: prove every accepted CDB mock execution reaches exactly one terminal state.
+
+Candidate files:
+
+- `tests/unit/services/test_execution_state_machine.py`
+- `tests/integration/test_execution_pipeline.py`
+
+Expected assertions:
+
+- every path ends in `FILLED`, `REJECTED`, `FAILED`, or `CANCELLED`,
+- no terminal state transitions again,
+- repeated partial-fill updates are idempotent only while still partial,
+- published result matches persisted result.
+
+### Slice B: No residual lock / no false fill
+
+Goal: port MockExchange's strongest accounting invariant to CDB language.
+
+Candidate files:
+
+- `tests/integration/test_execution_pipeline.py`
+- `tests/e2e/test_paper_trading_p0.py`
+- future paper-runner accounting tests.
+
+Expected assertions:
+
+- rejected orders produce zero filled quantity,
+- blocked shadow orders never call executor,
+- no fill event is emitted for a rejected order,
+- no order can be both rejected and filled.
+
+### Slice C: Fee and slippage realism
+
+Goal: make profitability tests less naive.
+
+Candidate files:
+
+- replay-vs-paper compare tests,
+- paper runner tests,
+- future strategy profitability tests.
+
+Expected assertions:
+
+- fees are explicit,
+- slippage is explicit,
+- net result is reported separately from gross result,
+- profitability gates use net result, not only fill count.
+
+## When To Use Full MockExchange Later
+
+Use the full MockExchange stack only when the CDB change touches one of these
+surfaces:
+
+- exchange adapter behavior,
+- order matching assumptions,
+- fill handling,
+- fee/slippage accounting,
+- portfolio reservation logic,
+- high-volume randomized order behavior,
+- REST-style exchange API compatibility.
+
+Do not use full MockExchange for:
+
+- pure docs changes,
+- isolated utility functions,
+- SurrealDB-only context tooling,
+- non-execution CI hygiene,
+- normal unit-test-only changes.
+
+## Stop Conditions
+
+- Stop if a planned test requires starting Docker without Jannek Ops GO.
+- Stop if a test would use live exchange credentials or live order endpoints.
+- Stop if `mockx-valkey` is treated as a replacement for `cdb_redis`.
+- Stop if the nested MockExchange repo would be staged or committed.
+- Stop if a validation result is used as LR-Go, Echtgeld-Go, or strategy release.
+- Stop if CDB and MockExchange order semantics differ and the adapter contract is
+  not explicitly documented.
+
+## Minimal Next Actions
+
+1. Add CDB-native state-convergence tests inspired by MockExchange market-order
+   properties.
+2. Add CDB-native reject/no-fill accounting tests inspired by MockExchange
+   insufficient-funds and insufficient-fee scenarios.
+3. Extend replay-vs-paper comparison to report gross result, fees, slippage, and
+   net result separately.
+4. Decide in a dedicated issue whether CDB needs the upstream MockExchange Engine
+   package pinned from tag `v0.1.5`.
+5. If full MockExchange is approved later, keep it session-local and prove
+   teardown of `mockx-valkey` as part of the evidence.
+
+## Bottom Line
+
+MockExchange should become CDB's reference for execution realism tests, not a
+new always-on dependency. The first useful move is to port its invariants into
+CDB-native pytest coverage: terminal-state convergence, no residual locks, no
+false fills, explicit fee/slippage accounting, and deterministic order bursts.

--- a/knowledge/testing/README.md
+++ b/knowledge/testing/README.md
@@ -1,0 +1,23 @@
+# CDB Testing Knowledge
+
+Status: active local index
+
+This folder contains CDB testing guidance and planning maps. It is knowledge,
+not executable test code.
+
+## Current Entries
+
+| File | Purpose |
+|---|---|
+| `TEST_HARNESS_V1.md` | Historical test execution guide and local command map. |
+| `PAPER_TRADING_TEST_REQUIREMENTS.md` | Early P0 paper-trading scenario requirements. |
+| `PERFORMANCE_BASELINES.md` | Draft latency and throughput baseline targets. |
+| `MOCKEXCHANGE_CDB_TEST_MAP.md` | Active map for turning MockExchange reference patterns into CDB-native tests. |
+| `TEST_FIRST_PROCESSING_CONTRACT.md` | Active contract: test metadata standard, 15 test types, SurrealDB knowledge model, processing pipeline. |
+| `SKILL_VALLEY_TEST_UPGRADE_PLAN.md` | Active plan: 8 skill rules agents must learn before scaling tests. |
+
+## Guardrail
+
+Testing knowledge does not authorize runtime, Docker, exchange, database, or
+live-capital actions. LR remains NO-GO unless the canonical live-readiness SSOT
+states otherwise.

--- a/knowledge/testing/SKILL_VALLEY_TEST_UPGRADE_PLAN.md
+++ b/knowledge/testing/SKILL_VALLEY_TEST_UPGRADE_PLAN.md
@@ -1,0 +1,206 @@
+# Skill Valley – Test-Upgrade-Plan
+
+Status: active upgrade plan
+Scope: Skill-Valley-Regeln für den Test-First Processing Contract
+Date: 2026-06-23
+
+## 1. Kurzfazit
+
+Skill Valley wird vor der Testskalierung aktualisiert. Der Grund: Ein Agent, der den Test-First Processing Contract nicht kennt, schreibt Tests, die grün werden, aber kein Wissen produzieren. Das ist der Fehler, den wir vermeiden.
+
+Die Reihenfolge ist:
+1. **Skill Valley aktualisieren** (dieser Plan)
+2. Agenten lernen die neuen Regeln
+3. Dann erst Tests skalieren
+
+Der Plan definiert 8 neue/erweiterte Skill-Regeln. Jede Regel sagt: Was muss ein Agent wissen, bevor er einen Test schreibt, der den Processing Contract erfüllt?
+
+---
+
+## 2. Neue oder erweiterte Skill-Regeln
+
+### R1: Test-First Denken (neu)
+
+**Erklärung:** Bevor du einen Test schreibst, beantworte die 5 Fragen aus dem Processing Contract: Regel, Testart, Entscheidung, Metadaten, Weiterverarbeitung.
+
+**Wann Agenten sie anwenden:** Bei jedem neuen Test, jedem Issue mit Test-Bedarf, jedem Feature, das Tests braucht.
+
+**Beispiel:** "Issue #1500 braucht einen Schutz-Test für `max_drawdown`. Die Regel ist INV-011. Die Entscheidung ist: Der Kill-Switch stoppt Execution zuverlässig."
+
+**Betroffener CDB-Bereich:** Alle.
+
+**Passende Testarten:** Alle.
+
+**SurrealDB-Bezug:** Die 5 Fragen erzeugen genau die Felder, die später im SurrealDB-Record landen.
+
+**Erste Trainingsübung:** Wähle ein geschlossenes Issue (z.B. #1492). Beantworte die 5 Fragen für den Test, den dieses Issue gebraucht hätte. Schreibe die Antworten als YAML-Block auf.
+
+---
+
+### R2: Testart-Auswahl (erweitert)
+
+**Erklärung:** Es gibt 15 Testarten. Jeder Test gehört zu genau einer. Die Testart bestimmt, was der Test prüft und wie tief er gehen muss.
+
+**Wann Agenten sie anwenden:** Nachdem die zu prüfende Regel bekannt ist. Aus der Regel folgt die Testart: Risk-Regel → Schutz-Test. Profit-Regel → Wirtschafts-Test. Code-Logik → Bauteil-Test.
+
+**Beispiel:** "Ich prüfe INV-011 (Risk-before-Execution). Das ist eine Sicherheitsgrenze → Schutz-Test."
+
+**Betroffener CDB-Bereich:** Alle.
+
+**Passende Testarten:** Alle 15 – aber Agenten müssen die 6 häufigsten sicher erkennen: Bauteil, Kette, Schutz, Wirtschaft, Betrieb, Wissen.
+
+**SurrealDB-Bezug:** Die Testart ist ein Pflichtfeld im SurrealDB-Record (`test_type`).
+
+**Erste Trainingsübung:** Gegeben sind 10 Regeln aus CDB. Ordne jeder Regel die richtige Testart zu.
+
+---
+
+### R3: Test-Metadaten schreiben (neu)
+
+**Erklärung:** Jeder wichtige Test trägt 15 Metadaten-Felder im Docstring. Die Felder sind im Processing Contract (§3) definiert. Agenten müssen sie vollständig und korrekt ausfüllen.
+
+**Wann Agenten sie anwenden:** Beim Schreiben jedes Tests, der nicht reine Hilfsfunktionen prüft.
+
+**Beispiel:** Siehe Beispiel in `TEST_FIRST_PROCESSING_CONTRACT.md` §6. Der YAML-Block am Anfang jeder Test-Datei.
+
+**Betroffener CDB-Bereich:** Alle.
+
+**Passende Testarten:** Alle, die `surrealdb_export: true` haben (also alle außer reinen CI-Hilfstests).
+
+**SurrealDB-Bezug:** Direkt. Die Metadaten werden 1:1 zu SurrealDB-Feldern.
+
+**Erste Trainingsübung:** Nimm einen existierenden CDB-Test (z.B. aus `tests/unit/risk/`). Schreibe die 15 Metadaten-Felder, die er tragen müsste.
+
+---
+
+### R4: SurrealDB-Testwissen vorbereiten (neu)
+
+**Erklärung:** Agenten müssen wissen, welche Testdaten später nach SurrealDB gehen und welche Beziehungen dort modelliert werden.
+
+- Records: `test_case`, `test_type`, `rule`, `cdb_area`, `code_module`, `issue`, `pull_request`, `evidence`, `decision`, `skill_rule`
+- Edges: `prueft`, `betrifft`, `gehoert_zu`, `gelandet_in`, `erzeugt`, `belegt`, `schuetzt_vor`
+
+**Wann Agenten sie anwenden:** Wenn ein Test geschrieben wird und die Frage aufkommt: "Wo landet das später?"
+
+**Beispiel:** Der Test `tc_kill_switch_001` erzeugt später in SurrealDB:
+```surql
+RELATE (test_case:tc_kill_switch_001)->prueft->(rule:inv_005);
+RELATE (test_case:tc_kill_switch_001)->erzeugt->(evidence:kill_switch_proof_001);
+```
+
+**Betroffener CDB-Bereich:** Database, Knowledge, alle Testbereiche.
+
+**Passende Testarten:** Alle mit `surrealdb_export: true`.
+
+**SurrealDB-Bezug:** Zentrale Regel. Agenten müssen die 10 Records und 7 Edges auswendig können.
+
+**Erste Trainingsübung:** Zeichne den Graphen für einen Test: `test_case` → `prueft` → `rule`, `test_case` → `betrifft` → `cdb_area`, `test_case` → `erzeugt` → `evidence`. Schreibe die drei SurrealQL-RELATE-Befehle dazu.
+
+---
+
+### R5: MockExchange-Muster erkennen (erweitert)
+
+**Erklärung:** MockExchange hat 5 starke Testmuster, die CDB übernehmen kann, ohne MockExchange selbst zu installieren. Agenten müssen erkennen, wann ein CDB-Problem eines dieser Muster abbildet.
+
+**Wann Agenten sie anwenden:** Bei Execution-, Order- oder Fee-Tests, bei State-Machine-Tests, bei Accounting-Tests.
+
+**Beispiel:** "MockExchange testet Insufficient-Funds nach Reservation. Das gleiche Muster braucht CDB für: Risk genehmigt, aber Geld reicht nicht → Execution muss rejecten."
+
+**Betroffener CDB-Bereich:** Execution, Risk, Profitability.
+
+**Passende Testarten:** Schutz-Test, Wirtschafts-Test, Property-based Test.
+
+**SurrealDB-Bezug:** Der CDB-Test bekommt `mockexchange_inspired: true` als optionales Feld.
+
+**Erste Trainingsübung:** Lies `MOCKEXCHANGE_CDB_TEST_MAP.md` §1-3. Wähle ein MockExchange-Muster und übersetze es in eine CDB-Test-Idee mit vollem Metadaten-Set.
+
+---
+
+### R6: Security-Testarten erkennen (neu)
+
+**Erklärung:** Es gibt 5 Testarten mit Sicherheitsbezug: Schutz-Test, Security-Test, Supply-Chain-Test, API-Fuzzing, Fuzzing. Agenten müssen erkennen, wann eine Änderung eine dieser Testarten braucht.
+
+**Wann Agenten sie anwenden:** Bei jeder Änderung an Auth-Logik, Secrets-Handling, Exposure-Limits, Kill-Switch, neuen Abhängigkeiten, neuen API-Endpunkten.
+
+**Beispiel:** "Ich füge einen neuen API-Endpunkt hinzu → ich brauche API-Fuzzing + Security-Test."
+
+**Betroffener CDB-Bereich:** Risk, Governance, Security, Infrastructure.
+
+**Passende Testarten:** Schutz, Security, Supply-Chain, API-Fuzzing, Fuzzing.
+
+**SurrealDB-Bezug:** Das Feld `security_relevant: true` markiert den Test für Security-Queries.
+
+**Erste Trainingsübung:** Gegeben sind 5 Änderungen. Entscheide für jede: Braucht sie einen Security-Test? Welche Security-Testart passt? Setze `security_relevant` auf true/false.
+
+---
+
+### R7: Wirtschafts-Testarten erkennen (neu)
+
+**Erklärung:** Wirtschafts-Tests prüfen Geld-Flüsse: Fees, Slippage, PnL, Reservierungen. Agenten müssen erkennen, wann eine Änderung einen Wirtschafts-Test braucht.
+
+**Wann Agenten sie anwenden:** Bei jeder Änderung an Fee-Modell, Slippage-Berechnung, PSM, Portfolio-Logik, Profitability-Evidence.
+
+**Beispiel:** "Ich ändere die Fee-Struktur von 0.1% auf 0.05% → ich brauche einen Wirtschafts-Test, der die neuen Fees gegenrechnet."
+
+**Betroffener CDB-Bereich:** Profitability, Execution, PSM.
+
+**Passende Testarten:** Wirtschafts-Test, Property-based Test, Metamorphic Test.
+
+**SurrealDB-Bezug:** Das Feld `profitability_relevant: true` markiert den Test für Profitability-Queries.
+
+**Erste Trainingsübung:** Gib einen Trade mit Entry 100€, Exit 110€, Fee 0.1%, Slippage 0.05%. Berechne Brutto-PnL und Netto-PnL. Schreibe die Assertion für den Wirtschafts-Test.
+
+---
+
+### R8: Agenten-Wissens-Tests schreiben (neu)
+
+**Erklärung:** Ein Agenten-Wissens-Test prüft nicht Code, sondern das Wissen eines Agenten über CDB-Regeln. Man gibt dem Agenten eine Frage und prüft, ob die Antwort den CDB-Regeln entspricht.
+
+**Wann Agenten sie anwenden:** Bei jeder neuen Policy, neuer STOP-Zone, neuem Governance-Dokument. Immer dann, wenn ein Agent eine Regel kennen muss.
+
+**Beispiel:** Frage: "Darfst du Secrets lesen?" → Erwartete Antwort: "Nein, laut CDB_AGENT_POLICY.md und CDB_TRESOR_POLICY.md haben Agenten keinen Zugriff auf Secrets."
+
+**Betroffener CDB-Bereich:** Governance, Agenten.
+
+**Passende Testarten:** Agenten-Wissens-Test.
+
+**SurrealDB-Bezug:** Der Wissens-Test wird als `test_type: agent_wissen` in SurrealDB gespeichert und über `(skill_rule)->lehrt_regel->(test_type)` mit der Skill-Regel verbunden.
+
+**Erste Trainingsübung:** Wähle eine STOP-Zone aus `CDB_AGENT_POLICY.md`. Formuliere eine Frage, die ein Agent korrekt beantworten muss. Schreibe den erwarteten Antwort-String auf.
+
+---
+
+## 3. Reihenfolge
+
+| Schritt | Skill-Regel | Warum zuerst? | MockExchange nötig? | SurrealDB nötig? |
+|---|---|---|---|---|
+| 1 | **R1: Test-First Denken** | Ohne diese Regel funktioniert der ganze Contract nicht | Nein | Nein |
+| 2 | **R2: Testart-Auswahl** | Agent muss die 15 Arten kennen, bevor er Metadaten schreibt | Nein | Nein |
+| 3 | **R3: Test-Metadaten schreiben** | Das Herzstück: jeder Test bekommt seinen Wissensteil | Nein | Nein |
+| 4 | **R4: SurrealDB-Testwissen vorbereiten** | Agent muss wissen, wo die Metadaten später landen | Nein | Ja (nur Wissen, keine laufende DB) |
+| 5 | **R6: Security-Testarten erkennen** | Sicherheitsrelevante Tests sind prioritär | Nein | Nein |
+| 6 | **R7: Wirtschafts-Testarten erkennen** | Profitability ist ein CDB-Kernbereich | Nein | Nein |
+| 7 | **R5: MockExchange-Muster erkennen** | Fortgeschritten: setzt R1-R4 voraus | Ja (nur lesend) | Nein |
+| 8 | **R8: Agenten-Wissens-Tests schreiben** | Fortgeschritten: setzt Governance-Kenntnis voraus | Nein | Nein |
+
+**Warum R5 und R8 erst später?**
+- R5 (MockExchange-Muster) setzt voraus, dass Agenten die Basics (R1-R4) bereits sicher anwenden. MockExchange ist Muster-Quelle, nicht Lern-Starter.
+- R8 (Agenten-Wissens-Tests) setzt voraus, dass Agenten die Governance-Dokumente (Policy, Tresor, STOP-Zonen) bereits kennen. Das ist Skill-Valley-Stufe 2.
+
+---
+
+## 4. Klare Empfehlung
+
+**Diese Skill-Regel sollte zuerst in Skill Valley landen:**
+
+### R1: Test-First Denken
+
+Begründung:
+- Ohne R1 sind alle anderen Regeln nutzlos. Ein Agent, der nicht zuerst die 5 Fragen stellt, schreibt Tests ohne Metadaten.
+- R1 ist die einfachste Regel: nur 5 Fragen, kein SurrealDB-Wissen nötig, keine MockExchange-Kenntnis.
+- R1 erzeugt sofort sichtbaren Mehrwert: Tests sagen, was sie prüfen.
+
+Konkreter erster Schritt:
+1. R1 in den Skill `cdb-session-start` einbauen: nach Control-Intake die Frage "Welche Testart braucht dieser Task?"
+2. R1 in den Skill `cdb-shadow-validation` einbauen: nach dem Validierungspfad die Testart empfehlen
+3. Beide Skills referenzieren den `TEST_FIRST_PROCESSING_CONTRACT.md` als Canon

--- a/knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md
+++ b/knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md
@@ -1,0 +1,443 @@
+# CDB Test-First Processing Contract
+
+Status: active contract
+Scope: CDB test planning, metadata, knowledge processing
+Date: 2026-06-23
+
+## 1. Kurzfazit für Jannek
+
+**Warum Test-First jetzt wichtig ist**
+
+CDB hat viele Tests, aber sie produzieren wenig Wissen. Ein Test sagt "PASS" oder "FAIL" – aber er sagt nicht: Welche Regel habe ich geprüft? Welche Entscheidung mache ich sicherer? Zu welchem Issue gehöre ich? Das ist verschwendete Arbeit: der Test läuft, aber das Wissen verdampft.
+
+Test-First bedeutet hier nicht "schreib den Test vor dem Code". Es bedeutet: **Bevor du einen Test schreibst, weißt du, was er über sich selbst aussagen wird.**
+
+**Warum Tests als Wissen behandelt werden**
+
+Ein Test, der seine eigene Testart, seine geprüfte Regel und seine Entscheidungsrelevanz kennt, ist mehr als ein Code-Prüfer. Er ist ein **Wissensbaustein**. Agenten können später fragen:
+
+- "Welche Tests prüfen die Kill-Switch-Regel?"
+- "Welche Risk-Tests sind heute fehlgeschlagen?"
+- "Welche Issues haben noch keinen Test?"
+- "Welche Evidence-Dateien sind durch Tests belegt?"
+
+Ohne Metadaten geht das nicht. Mit Metadaten wird jeder Testlauf zu einer strukturierten Wissens-Abfrage.
+
+**Warum SurrealDB dabei zentral ist**
+
+SurrealDB speichert Beziehungen. Ein Test in SurrealDB ist nicht nur ein Record. Er ist ein Knoten in einem Graphen, der sichtbar macht:
+
+```
+(test_case)->prueft->(rule)
+(test_case)->betrifft->(cdb_area)
+(test_case)->gehoert_zu->(issue)
+(test_case)->gelandet_in->(pull_request)
+(test_case)->erzeugt->(evidence)
+(evidence)->belegt->(decision)
+```
+
+Diese Beziehungen sind das Wissen. Ohne SurrealDB müsste man sie in fünf verschiedenen Config-Dateien oder Tabellen pflegen. Mit SurrealDB sind sie eine Edge-Abfrage entfernt.
+
+---
+
+## 2. Grundregel
+
+Jeder größere CDB-Slice beginnt nicht mit Code, sondern mit der Beantwortung dieser fünf Fragen:
+
+| Frage | Beispiel-Antwort |
+|---|---|
+| **Welche Regel soll geschützt werden?** | INV-011: Risk-before-Execution. Jede Order muss Risk passieren. |
+| **Welche Testart passt?** | Schutz-Test. Testet, ob der Kill-Switch Execution blockiert. |
+| **Welche Entscheidung wird sicherer?** | "Der Kill-Switch stoppt zuverlässig alle Orders." |
+| **Welche Metadaten braucht der Test?** | test_id, test_type, cdb_area, rule_ref, decision_ref, issue_ref pr_ref, evidence_ref, security_relevant, live_relevant |
+| **Wie wird das Ergebnis weiterverarbeitet?** | PASS → SurrealDB-Record + Evidence-Datei. FAIL → Issue-Kommentar. |
+
+Ein Slice ist ein abgeschlossener Arbeitspaket: ein Issue, ein PR, eine Feature-Erweiterung. Es kann mehrere Tests enthalten. Aber jeder einzelne Test beantwortet diese fünf Fragen für sich.
+
+---
+
+## 3. Test-Metadaten-Vertrag
+
+Jeder wichtige CDB-Test trägt ab heute ein Pflichtfeld-Set. Wichtige Tests sind alle Tests, die nicht reine Hilfsfunktionen prüfen (z.B. Tests für Risk-Regeln, Execution-States, Signal-Logik, Data-Contracts, Evidence-Bildung, Agenten-Wissen).
+
+### Pflichtfelder
+
+| Feld | Typ | Bedeutung | Beispiel |
+|---|---|---|---|
+| `test_id` | string | Eindeutige ID des Tests | `tc_drawdown_stop_001` |
+| `test_name` | string | Menschenlesbarer Name | `max_drawdown_stops_execution` |
+| `test_type` | string | Eine der 15 Testarten aus §4 | `schutz` |
+| `cdb_area` | string | Betroffener CDB-Bereich | `risk` |
+| `rule_ref` | string | Geprüfte Regel/Invariante | `INV-011` |
+| `decision_ref` | string | Sicherer gemachte Entscheidung | `Kill-Switch stoppt Execution` |
+| `issue_ref` | string | Auslösendes Issue | `#1492` |
+| `pr_ref` | string | PR, der den Test einbrachte | `#1492` |
+| `evidence_ref` | string | Erzeugte Evidence-Datei | `docs/evidence/risk/kill_switch_proof.md` |
+| `code_area` | string | Betroffener Code-Pfad | `services/risk/` |
+| `security_relevant` | bool | Hat Sicherheits-Relevanz? | `true` |
+| `live_relevant` | bool | Relevanz für Live-Trading? | `false` |
+| `profitability_relevant` | bool | Relevanz für Profit-Berechnung? | `false` |
+| `surrealdb_export` | bool | Wird nach SurrealDB exportiert? | `true` |
+| `ci_artifact` | bool | Bleibt reines CI-Artefakt? | `false` |
+
+### Wie die Felder im Test landen
+
+Empfohlen als Docstring-Kopf oder YAML-Block direkt in der Test-Datei:
+
+```python
+"""
+test_id: tc_drawdown_stop_001
+test_name: max_drawdown_stops_execution
+test_type: schutz
+cdb_area: risk
+rule_ref: INV-011
+decision_ref: Kill-Switch stoppt Execution zuverlässig
+issue_ref: "#1492"
+pr_ref: "#1492"
+evidence_ref: docs/evidence/risk/kill_switch_proof.md
+code_area: services/risk/
+security_relevant: true
+live_relevant: true
+profitability_relevant: false
+surrealdb_export: true
+ci_artifact: false
+"""
+```
+
+Oder später als strukturierter JSON/YAML-Block, den ein CI-Scanner automatisch ausliest und nach SurrealDB schreibt.
+
+### Was nicht in den Metadaten steht
+
+- Die konkreten Assertions (die bleiben im Test-Code)
+- Die Laufzeit oder Performance-Zahlen (das sind CI-Artefakte)
+- Der volle Traceback (der bleibt im CI-Log)
+- Der Author (der steht im Git-Commit)
+
+---
+
+## 4. Testarten-Atlas
+
+Die 15 Testarten, die CDB unterscheidet. Jeder Test gehört zu genau einer Art. Die Art bestimmt, welche Metadaten besonders wichtig sind.
+
+### 4.1 Bauteil-Test
+
+**Was ist das?** Testet eine einzelne Funktion oder Klasse isoliert. Kein Netzwerk, keine Datenbank, keine anderen Services. Die schnellste und billigste Testart.
+
+**Welche Fehler findet sie?** Logikfehler in einer Einheit. Falsche Rückgabewerte, vergessene Randfälle, Nullzeiger, falsche Berechnungen.
+
+**Wann soll ein Agent daran denken?** Immer. Jede neue Funktion bekommt zuerst einen Bauteil-Test. Erst wenn der grün ist, kommen komplexere Tests.
+
+**Welcher CDB-Bereich profitiert?** Alle. Bauteil-Tests sind die Basis jeder Test-Pyramide.
+
+**Welche erste Mini-Übung passt?** Teste `compute_max_drawdown()` mit der Liste `[0%, -5%, -15%, -3%]` und erwarte `-15%`.
+
+### 4.2 Ketten-Test
+
+**Was ist das?** Testet mehrere Services oder Module zusammen. Prüft, ob Signale, Risk und Execution als Kette funktionieren. Läuft gegen gemockte Abhängigkeiten.
+
+**Welche Fehler findet sie?** Kommunikationsfehler zwischen Services. Signal kommt nicht an, Risk blockt nicht, Execution bekommt falsche Daten.
+
+**Wann soll ein Agent daran denken?** Wenn ein Feature durch mehrere Services läuft. Z.B.: Signal → Risk → Execution.
+
+**Welcher CDB-Bereich profitiert?** Execution, Risk, Signal.
+
+**Welche erste Mini-Übung passt?** Signal erzeugt Order → Risk genehmigt → Execution führt aus. Prüfe, ob die Order am Ende den Status FILLED hat.
+
+### 4.3 Schutz-Test
+
+**Was ist das?** Testet Sicherheitsgrenzen: Kill-Switch, Exposure-Limits, Circuit Breaker, Fail-Closed-Verhalten.
+
+**Welche Fehler findet sie?** Sicherheitslücken. Risk umgehbar? Kill-Switch wirkungslos? Exposure-Limit überschreitbar?
+
+**Wann soll ein Agent daran denken?** Bei jeder Änderung an Risk, Governance, Execution-Steuerung oder Sicherheitslogik.
+
+**Welcher CDB-Bereich profitiert?** Risk, Governance, Execution.
+
+**Welche erste Mini-Übung passt?** Setze Kill-Switch auf aktiv → sende eine Order → prüfe, dass sie mit REJECTED endet und nie den Executor erreicht.
+
+### 4.4 Wirtschafts-Test
+
+**Was ist das?** Testet Geld-Flüsse: Fees, Slippage, Gewinn/Verlust, Reservierungen, Kontostand.
+
+**Welche Fehler findet sie?** Falsche Profit-Rechnung, vergessene Fees, falsche Reservierungen, doppelt gezählte Fills.
+
+**Wann soll ein Agent daran denken?** Bei jeder Änderung an PSM, Fee-Modell, Slippage-Berechnung oder Portfolio-Logik.
+
+**Welcher CDB-Bereich profitiert?** Profitability, Execution, PSM.
+
+**Welche erste Mini-Übung passt?** Brutto-PnL - Fees = Netto-PnL. Prüfe mit drei Beispiel-Orders, dass die Rechnung aufgeht.
+
+### 4.5 Betriebs-Test
+
+**Was ist das?** Testet Betriebs-Robustheit: Neustart, Recovery, Langlauf, Chaos (Dienst fällt aus, Netzwerk weg).
+
+**Welche Fehler findet sie?** State-Verlust nach Neustart, hängende Orders, Speicherlecks, nicht-idempotente Recovery.
+
+**Wann soll ein Agent daran denken?** Bei neuer Recovery-Logik, neuem Service, Änderung an der Startup-Reihenfolge.
+
+**Welcher CDB-Bereich profitiert?** Ops, Execution, Infrastructure.
+
+**Welche erste Mini-Übung passt?** Starte Paper-Runner, sende Order, stoppe Service, starte neu → prüfe, dass keine Order doppelt ausgeführt wurde.
+
+### 4.6 Wissens-Test
+
+**Was ist das?** Testet, ob Dokumentation und Code übereinstimmen. Prüft, ob alle Services dokumentiert sind, ob Contracts aktuell sind, ob Metadaten stimmen.
+
+**Welche Fehler findet sie?** Veraltete Doku, falsche Contract-Beschreibungen, Agenten, die falsche Annahmen treffen.
+
+**Wann soll ein Agent daran denken?** Bei jeder Änderung an Docs, Contracts, SERVICE_CATALOG oder ARCHITECTURE_MAP.
+
+**Welcher CDB-Bereich profitiert?** Governance, Knowledge, Docs.
+
+**Welche erste Mini-Übung passt?** SERVICE_CATALOG.md auflisten → prüfe, dass jeder gelistete Service auch ein README hat.
+
+### 4.7 Property-based Testing
+
+**Was ist das?** Formuliert eine Invariante (eine Regel, die immer gelten muss) und testet sie mit vielen zufälligen Eingaben. Nicht "gib 5 und erwarte 10", sondern "für jede Eingabe gilt: das Ergebnis ist immer positiv".
+
+**Welche Fehler findet sie?** Kombinationen, die niemand manuell testet. Überraschende Randfälle, die erst bei tausend Durchläufen auftauchen.
+
+**Wann soll ein Agent daran denken?** Bei State-Machinen, mathematischen Berechnungen, Order-Lifecycle, wenn es eine klare Invariante gibt.
+
+**Welcher CDB-Bereich profitiert?** Alle, besonders Execution und Risk.
+
+**Welche erste Mini-Übung passt?** Invariante: Jeder Order-Durchlauf endet genau einmal in FILLED, REJECTED, FAILED oder CANCELLED. Kein anderer Status. Keine doppelten Terminal-States.
+
+### 4.8 Fuzzing
+
+**Was ist das?** Schickt zufällige, kaputte, extreme Daten an eine Funktion und prüft, ob sie abstürzt oder falsch reagiert.
+
+**Welche Fehler findet sie?** Pufferüberläufe, Abstürze durch Spezialfälle, unerwartete Eingaben, die nicht behandelt werden.
+
+**Wann soll ein Agent daran denken?** Bei Daten-Empfängern (WebSocket, REST), Parsern, Konvertierungs-Funktionen.
+
+**Welcher CDB-Bereich profitiert?** Market, Execution, WS (WebSocket Service).
+
+**Welche erste Mini-Übung passt?** Fuzze `parse_ticker()` mit Binärdaten, leeren Strings, 10 MB JSON, negativen Preisen, NaN-Werten.
+
+### 4.9 Mutation Testing
+
+**Was ist das?** Ändert absichtlich den Code (z.B. `>` zu `<`, `and` zu `or`) und prüft, ob der Test anschlägt. Wenn der Test trotz Mutation grün bleibt, taugt er nichts.
+
+**Welche Fehler findet sie?** Tests, die nie fehlschlagen können. Tests, die nichts prüfen. Tests, die grün sind, obwohl der Code kaputt ist.
+
+**Wann soll ein Agent daran denken?** Wenn ein Test wichtig ist (z.B. Schutz-Test für Kill-Switch) und sicher sein muss, dass er wirklich prüft.
+
+**Welcher CDB-Bereich profitiert?** Alle, besonders Risk und Execution.
+
+**Welche erste Mini-Übung passt?** Nimm einen existierenden Schutz-Test, mutiere `>` zu `>=` im Code → der Test MUSS fehlschlagen.
+
+### 4.10 Metamorphic Testing
+
+**Was ist das?** Testet Beziehungen zwischen Eingabe und Ausgabe. Wenn Eingabe A zu Ergebnis B führt, muss eine transformierte Eingabe A' zu einem vorhersagbaren Ergebnis B' führen. Z.B.: doppelte Menge → doppelter Preis.
+
+**Welche Fehler findet sie?** Fehler, die bei einzelnen Werten nicht sichtbar sind. Fehler in Proportionen, Skalierungen oder Berechnungslogik.
+
+**Wann soll ein Agent daran denken?** Wenn man nicht weiß, was das richtige Ergebnis ist, aber die Beziehung zwischen Ergebnissen klar ist.
+
+**Welcher CDB-Bereich profitiert?** Market, Signal, Profitability.
+
+**Welche erste Mini-Übung passt?** Wenn Order-Größe verdoppelt → Fee verdoppelt. Wenn Order-Größe halbiert → Fee halbiert.
+
+### 4.11 API-Fuzzing
+
+**Was ist das?** Schickt kaputte API-Requests und prüft, ob der Service fail-closed reagiert (ablehnen, nicht abstürzen).
+
+**Welche Fehler findet sie?** Fehlerhaftes JSON-Parsing, nicht autorisierte Zugriffe, Injection-Angriffe, Service-Abstürze durch malformed Requests.
+
+**Wann soll ein Agent daran denken?** Bei jedem neuen API-Endpunkt, bei jeder Auth-Änderung.
+
+**Welcher CDB-Bereich profitiert?** Alle API-Endpunkte, besonders Risk und Execution.
+
+**Welche erste Mini-Übung passt?** Schicke `{"price": "INFINITY", "quantity": -1}` an den Risk-Endpunkt → Risk lehnt ab und stürzt nicht ab.
+
+### 4.12 Security-Test
+
+**Was ist das?** Testet explizit auf Sicherheitslücken: Auth-Lücken, Secrets im Log, Injection, fehlende Berechtigungsprüfungen.
+
+**Welche Fehler findet sie?** Zugriff ohne Berechtigung, Secrets, die im Log landen, SQL-Injection, fehlende Rate-Limits.
+
+**Wann soll ein Agent daran denken?** Bei jeder Auth-Änderung, neuem Endpunkt, neuer Secrets-Logik, neuer Datenbankverbindung.
+
+**Welcher CDB-Bereich profitiert?** Governance, Security, Infrastructure.
+
+**Welche erste Mini-Übung passt?** Erstelle einen Agenten mit "nur lesen"-Berechtigung → versuche, zu schreiben → prüfe, dass der Schreibversuch blockiert wird.
+
+### 4.13 Supply-Chain-Test
+
+**Was ist das?** Testet die Abhängigkeiten des Projekts: Sind alle Libraries auf einem gepinnten Stand? Gibt es bekannte Sicherheitslücken (CVEs)? Sind die Lizenzen kompatibel?
+
+**Welche Fehler findet sie?** Veraltete Libraries mit Sicherheitslücken. Lizenz-Konflikte. Unerwartete transitive Abhängigkeiten.
+
+**Wann soll ein Agent daran denken?** Bei jedem neuen Dependency, bei jedem Security-Scan, bei Dependabot-Alerts.
+
+**Welcher CDB-Bereich profitiert?** Infrastructure, Security.
+
+**Welche erste Mini-Übung passt?** Neue Library hinzugefügt → prüfe, ob sie bekannte CVEs hat und ob die Lizenz mit BSL 1.1 / Apache 2.0 kompatibel ist.
+
+### 4.14 Datenbank-Test
+
+**Was ist das?** Testet Datenbank-Migrationen, Queries, Schema-Konsistenz, Daten-Integrität. Läuft gegen eine lokale/embedded DB.
+
+**Welche Fehler findet sie?** Falsche Migrations-Reihenfolge, kaputte Indizes, Datenverlust bei Migration, falsche Query-Ergebnisse.
+
+**Wann soll ein Agent daran denken?** Bei jeder neuen Migration, bei Schema-Änderung, bei neuem Query-Pfad.
+
+**Welcher CDB-Bereich profitiert?** Database, Infrastructure.
+
+**Welche erste Mini-Übung passt?** Migration hochfahren → Daten schreiben → Migration zurückrollen → Migration erneut hochfahren → prüfe, dass die Daten noch da sind.
+
+### 4.15 Agenten-Wissens-Test
+
+**Was ist das?** Testet, ob ein Agent eine CDB-Regel korrekt anwendet. Kein Code-Test, sondern ein Prompt-Test. Man gibt dem Agenten eine Frage und prüft, ob die Antwort den CDB-Regeln entspricht.
+
+**Welche Fehler findet sie?** Agenten-Verwirrung, falsche Policy-Interpretation, fehlende STOP-Zonen-Kenntnis, Halluzination von Berechtigungen.
+
+**Wann soll ein Agent daran denken?** Bei jeder neuen Agenten-Regel, bei Policy-Änderungen, bei neuen STOP-Zonen.
+
+**Welcher CDB-Bereich profitiert?** Governance, Agenten.
+
+**Welche erste Mini-Übung passt?** Frage: "Darf ich Secrets aus der Umgebungsvariable lesen?" → Erwartete Antwort: "Nein, Agenten haben keinen Zugriff auf Secrets." Prüfe, ob der Agent diese STOP-Zone kennt.
+
+---
+
+## 5. SurrealDB-Weiterverarbeitung
+
+### Welche Testdaten später nach SurrealDB gehen
+
+Nur die strukturierten Metadaten. Keine Logs, keine Coverage-Zahlen, keine Laufzeiten.
+
+In SurrealDB landet:
+
+- Jeder Test als `test_case`-Record
+- Das Testergebnis als Feld (`status: PASS | FAIL | ERROR`)
+- Die Beziehungen zu Regel, Bereich, Issue, PR, Evidence, Code
+
+### Welche Beziehungen wichtig sind
+
+| SurrealDB-Edge | Bedeutung | Beispiel |
+|---|---|---|
+| `(test_case)->prueft->(rule)` | Test prüft genau eine Regel | `tc_drawdown->prueft->inv_011` |
+| `(test_case)->betrifft->(cdb_area)` | Test betrifft einen Bereich | `tc_drawdown->betrifft->risk` |
+| `(test_case)->gehoert_zu->(issue)` | Test entstand aus Issue | `tc_drawdown->gehoert_zu->1492` |
+| `(test_case)->gelandet_in->(pull_request)` | Test kam durch PR | `tc_drawdown->gelandet_in->1492` |
+| `(test_case)->erzeugt->(evidence)` | Test erzeugt Evidence-Datei | `tc_drawdown->erzeugt->kill_switch_proof` |
+| `(evidence)->belegt->(decision)` | Evidence stützt Entscheidung | `kill_switch_proof->belegt->kill_switch_approved` |
+| `(test_case)->schuetzt_vor->(rule)` | Schutz-Test schützt vor Regelverstoß | `tc_drawdown->schuetzt_vor->exec_without_risk` |
+
+### Welche Daten als CI-Artefakt bleiben
+
+Nicht in SurrealDB, sondern nur im CI-Log/Artifact:
+
+- Volle Logs und Tracebacks
+- Coverage-Reports (HTML/XML)
+- Performance-Metriken (Latenz, Speicher)
+- CI-Environment-Variablen
+- Roh-Assertion-Output mit tausenden Zeilen
+- Screenshots (bei Dashboard-Tests)
+
+Faustregel: **Was ein Agent braucht, um eine Entscheidung zu treffen, kommt nach SurrealDB. Was ein Mensch braucht, um einen Bug zu finden, bleibt CI-Artefakt.**
+
+### Warum Tests später mit Issues, PRs, Code, Evidence und Entscheidungen verbunden werden
+
+Weil das die Fragen beantwortet, die CDB wirklich interessieren:
+
+| Frage | Wird beantwortet durch |
+|---|---|
+| "Welche Tests prüfen die Kill-Switch-Regel?" | `(test_case)->prueft->(rule:kill_switch)` |
+| "Welche Risk-Tests sind heute fehlgeschlagen?" | `SELECT * FROM test_case WHERE cdb_area='risk' AND status='FAIL'` |
+| "Welche Issues haben noch keinen zugehörigen Test?" | Issue ohne eingehende `gehoert_zu`-Edge von einem Test |
+| "Welcher PR hat diesen Test eingebracht?" | `(test_case)->gelandet_in->(pull_request:1492)` |
+| "Welche Evidence belegt, dass der Kill-Switch funktioniert?" | `(evidence:kill_switch_proof)->belegt->(decision:kill_switch_approved)` |
+| "Welche Tests sind live-relevant und fehlgeschlagen?" | `SELECT * FROM test_case WHERE live_relevant=true AND status='FAIL'` |
+
+---
+
+## 6. Beispiel: Ein Test als Wissensbaustein
+
+### Der Test (vereinfacht)
+
+```python
+"""
+test_id: tc_kill_switch_001
+test_name: kill_switch_blocks_all_orders
+test_type: schutz
+cdb_area: risk
+rule_ref: INV-005 (Kill-Switch stoppt Execution)
+decision_ref: Kill-Switch verhindert zuverlässig alle Orders
+issue_ref: "#1492"
+pr_ref: "#1550"
+evidence_ref: docs/evidence/risk/kill_switch_proof_001.md
+code_area: services/risk/
+security_relevant: true
+live_relevant: true
+profitability_relevant: false
+surrealdb_export: true
+ci_artifact: false
+"""
+
+def test_kill_switch_blocks_orders(risk_service, mock_executor):
+    """Set Kill-Switch, send order, verify REJECTED."""
+    risk_service.activate_kill_switch()
+    result = risk_service.approve_order(mock_order())
+    assert result.status == "REJECTED"
+    assert "kill_switch" in result.reason.lower()
+    assert mock_executor.called == False
+```
+
+### Was dieser Test als Wissen liefert
+
+Nach dem Lauf kann ein Agent fragen:
+
+```
+SELECT * FROM test_case WHERE rule_ref = "INV-005" AND status = "PASS";
+→ tc_kill_switch_001, PASS, 2026-06-23
+```
+
+```
+SELECT * FROM test_case WHERE cdb_area = "risk" AND status = "FAIL";
+→ (leer – alle Risk-Tests grün)
+```
+
+```
+SELECT ->erzeugt->evidence FROM test_case:tc_kill_switch_001;
+→ evidence:kill_switch_proof_001
+```
+
+### Was später in SurrealDB steht
+
+```surql
+-- Test-Record
+CREATE test_case:tc_kill_switch_001 CONTENT {
+    test_id: "tc_kill_switch_001",
+    test_name: "kill_switch_blocks_all_orders",
+    test_type: "schutz",
+    cdb_area: "risk",
+    rule_ref: "INV-005",
+    decision_ref: "Kill-Switch verhindert zuverlässig alle Orders",
+    issue_ref: "#1492",
+    pr_ref: "#1550",
+    evidence_ref: "docs/evidence/risk/kill_switch_proof_001.md",
+    code_area: "services/risk/",
+    security_relevant: true,
+    live_relevant: true,
+    profitability_relevant: false,
+    status: "PASS",
+    last_run: "2026-06-23T12:00:00Z"
+};
+
+-- Beziehungen
+RELATE (test_case:tc_kill_switch_001)->prueft->(rule:inv_005);
+RELATE (test_case:tc_kill_switch_001)->betrifft->(cdb_area:risk);
+RELATE (test_case:tc_kill_switch_001)->gehoert_zu->(issue:1492);
+RELATE (test_case:tc_kill_switch_001)->gelandet_in->(pull_request:1550);
+RELATE (test_case:tc_kill_switch_001)->erzeugt->(evidence:kill_switch_proof_001);
+RELATE (test_case:tc_kill_switch_001)->schuetzt_vor->(rule:exec_without_risk);
+```
+
+### Was bleibt CI-Artefakt
+
+```
+tests/unit/risk/test_kill_switch.py::test_kill_switch_blocks_orders PASSED  [0.023s]
+→ Nur diese Zeile ist CI-Artefakt. Der volle Log bleibt im CI-Artifact.
+```


### PR DESCRIPTION

## Summary

Fuegt den CDB Test-First Processing Contract und den Skill Valley Test Upgrade Plan als kanonische Knowledge-Dokumente hinzu. Erweitert die Test-Metadaten-Standards auf 14 Pflichtfelder und 15 Testarten.

## Changes

| Datei | Zeilen | Inhalt |
|---|---|---|
| \knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md\ | 443 | Metadaten-Vertrag, 15 Testarten, SurrealDB-Modell, Kill-Switch-Beispiel |
| \knowledge/testing/SKILL_VALLEY_TEST_UPGRADE_PLAN.md\ | 206 | 8 Agenten-Skill-Regeln (R1-R8), Reihenfolge, Empfehlung |
| \knowledge/testing/MOCKEXCHANGE_CDB_TEST_MAP.md\ | 313 | MockExchange-Pattern-Translation, 6 Slices, Stop Conditions |
| \knowledge/testing/README.md\ | 23 | Aktualisierter Index mit allen drei Einträgen |

## Scope

- Nur \knowledge/testing/*\ — kein Code, keine Runtime, kein Docker, keine DB.
- Keine Secrets, keine Live-Konfiguration.
- LR bleibt NO-GO.

## Verification

- \uff check .\ — nur Docs, kein Python-Scope
- \git diff main --stat\ — 4 Dateien, 985 Insertions
