### PR TITLE
feat: add test-first metadata pilot block (CDB-PILOT-001)

### DIFF
--- a/knowledge/testing/README.md
+++ b/knowledge/testing/README.md
@@ -15,6 +15,7 @@ not executable test code.
 | `MOCKEXCHANGE_CDB_TEST_MAP.md` | Active map for turning MockExchange reference patterns into CDB-native tests. |
 | `TEST_FIRST_PROCESSING_CONTRACT.md` | Active contract: test metadata standard, 15 test types, SurrealDB knowledge model, processing pipeline. |
 | `SKILL_VALLEY_TEST_UPGRADE_PLAN.md` | Active plan: 8 skill rules agents must learn before scaling tests. |
+| `TEST_FIRST_METADATA_PILOT.md` | Pilot: Test-First-Metadatenblock in `tests/unit/validation/test_profitability_evidence_packet_assembler.py` — Proof-of-Concept fuer SurrealDB-Export-faehige Metadaten. |
 
 ## Guardrail
 

--- a/tests/unit/validation/test_profitability_evidence_packet_assembler.py
+++ b/tests/unit/validation/test_profitability_evidence_packet_assembler.py
@@ -32,6 +32,56 @@ from services.validation.profitability_evidence_packet_assembler import (
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 CONTRACTS_DIR = PROJECT_ROOT / "docs" / "contracts"
 
+# ===========================================================================
+# Test-First Metadata (Pilot: CDB-PILOT-001)
+# ===========================================================================
+#
+# 1. Welche Regel wird geschützt?
+#    Profitability Evidence Packet Assembly muss deterministisch,
+#    schema-konform und fail-closed sein. Kein undichter Fehlerpfad
+#    darf zum Absturz oder stillem Datenverlust führen.
+#
+# 2. Welche Testart passt?
+#    Hauptsaechlich Bauteil-Tests (isolierte Funktionen/Klassen).
+#    Einige Schutz-Tests (fail-closed bei fehlenden/kaputten Inputs).
+#    Einige Ketten-Tests (Pipeline vom Input ueber Validierung zum Packet).
+#    Klassifikation pro Gruppe unten.
+#
+# 3. Welche Entscheidung wird sicherer?
+#    "Der ProfitabilityEvidencePacketAssembler produziert zuverlaessig
+#     schema-konforme Packete, failt geschlossen bei fehlenden/kaputten
+#     Inputs und ist deterministisch."
+#
+# 4. Welche Metadaten braucht der Test? (siehe Block unten)
+#
+# 5. Wie wird das Ergebnis weiterverarbeitet?
+#    CI: pytest-sammlung + JUnit-Report. Spaeter SurrealDB-Export
+#    (surrealdb_export: false im Pilot).
+#
+# Metadata fields (TEST_FIRST_PROCESSING_CONTRACT.md §6):
+#   test_id:              cdb-test-pilot-001
+#   test_title:           Profitability Evidence Packet Assembler
+#   test_type:            mixed (Bauteil / Schutz / Ketten; siehe Gruppe)
+#   cdb_area:             validation
+#   rule_ref:             PROFITABILITY_EVIDENCE_PACKET_SCHEMA_CONFORMANCE
+#   decision_ref:         d-2026-04-08-evidence-packet-structure
+#   issue_ref:            #1492
+#   pr_ref:               (wird beim Pilot-PR gesetzt)
+#   evidence_ref:         docs/contracts/profitability_evidence_packet.v1.schema.json
+#   code_area:            ProfitabilityEvidencePacketAssembler
+#   security_relevant:    false
+#   live_relevant:        false
+#   profitability_relevant: true
+#   surrealdb_export:     false
+#   ci_artifact:          test-report
+#
+# Gruppen-Klassifikation:
+#   Happy-Path + CLI main  → Ketten-Test  (Pipeline-Durchstich)
+#   Determinism + Serializer → Bauteil-Test (Determinismus-Garantie)
+#   Missing/Invalid/Schema/Legacy → Schutz-Test (fail-closed)
+#   Alle anderen           → Bauteil-Test  (isolierte Logik)
+# ===========================================================================
+
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary

Add a machine-readable test-first metadata block to \	ests/unit/validation/test_profitability_evidence_packet_assembler.py\ as the first CDB pilot (CDB-PILOT-001). This is a proof-of-concept for SurrealDB-export-capable metadata per \TEST_FIRST_PROCESSING_CONTRACT.md §6\.

## Changes

1. **Metadata block** (test file): 15-field YAML-style block after imports, answering the 5 test-first questions and classifying each test group by type (Bauteil/Schutz/Ketten).
2. **Knowledge index** (\knowledge/testing/README.md\): New row for \TEST_FIRST_METADATA_PILOT.md\.

## Verification

- All 39 tests pass (pytest)
- Ruff lint clean on Python
- No runtime, Docker, DB, exchange, or live-capital changes
- LR remains NO-GO