### PR TITLE
test(tools): add test-first metadata scanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *test*.js
 # Allow official test suite in tests/ directory (must come AFTER wildcard)
 !tests/**/*.py
+!tools/test_metadata_scanner.py
 !tests/**/*.js
 !services/validation/strategy_backtest_runner.py
 !services/validation/rmr_backtest_runner.py

--- a/knowledge/testing/README.md
+++ b/knowledge/testing/README.md
@@ -17,6 +17,38 @@ not executable test code.
 | `SKILL_VALLEY_TEST_UPGRADE_PLAN.md` | Active plan: 8 skill rules agents must learn before scaling tests. |
 | `TEST_FIRST_METADATA_PILOT.md` | Pilot: Test-First-Metadatenblock in `tests/unit/validation/test_profitability_evidence_packet_assembler.py` — Proof-of-Concept fuer SurrealDB-Export-faehige Metadaten. |
 
+## Scanner
+
+`tools/test_metadata_scanner.py` — read-only CDB Test-First Metadata Scanner.
+
+**Zweck:** Findet 15-field Metadatenbloecke in Python-Testdateien, validiert
+Pflichtfelder und gibt ein JSON-Artefakt aus — Vorstufe zum SurrealDB-Import.
+
+**read-only Grenze:** Der Scanner schreibt nur in die explizit per `--output`
+angegebene Datei. Kein DB-Zugriff, kein Netzwerk, keine Mutation ausserhalb
+der Output-Datei.
+
+**Nutzung:**
+```bash
+# Stdout
+python -m tools.test_metadata_scanner tests/
+
+# Datei
+python -m tools.test_metadata_scanner tests/ --output artifacts/test-metadata.json
+
+# Einzelfile
+python -m tools.test_metadata_scanner tests/unit/validation/test_profitability_evidence_packet_assembler.py
+```
+
+**Exit-Codes:**
+- 0: alle Bloecke gueltig (oder keine gefunden)
+- 1: Validierungsfehler (fehlende Pflichtfelder)
+- 2: Usage-/Parse-Fehler (keine Python-Dateien)
+
+**SurrealDB-Export:** `surrealdb_export: true` wird im JSON sichtbar als
+`"surrealdb_export_ready"`-Zaehler. Dieser Scanner schreibt noch nicht nach
+SurrealDB — er bereitet nur den Export vor.
+
 ## Guardrail
 
 Testing knowledge does not authorize runtime, Docker, exchange, database, or

--- a/tests/unit/tools/test_test_metadata_scanner.py
+++ b/tests/unit/tools/test_test_metadata_scanner.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tools.test_metadata_scanner import (
+    REQUIRED_FIELDS,
+    _find_metadata_blocks,
+    _process_fields,
+    _coerce_bool,
+    scan_file,
+    build_report,
+    collect_paths,
+    run,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+VALID_BLOCK = """\
+# ===========================================================================
+# Test-First Metadata (Pilot: CDB-PILOT-001)
+# ===========================================================================
+#
+# Metadata fields (TEST_FIRST_PROCESSING_CONTRACT.md §6):
+#   test_id:              cdb-test-pilot-001
+#   test_title:           Profitability Evidence Packet Assembler
+#   test_type:            mixed
+#   cdb_area:             validation
+#   rule_ref:             PROFITABILITY_EVIDENCE_PACKET_SCHEMA_CONFORMANCE
+#   decision_ref:         d-2026-04-08-evidence-packet-structure
+#   issue_ref:            #1492
+#   pr_ref:               #3408
+#   evidence_ref:         docs/contracts/profitability_evidence_packet.v1.schema.json
+#   code_area:            ProfitabilityEvidencePacketAssembler
+#   security_relevant:    false
+#   live_relevant:        false
+#   profitability_relevant: true
+#   surrealdb_export:     false
+#   ci_artifact:          test-report
+# ===========================================================================
+"""
+
+VALID_BLOCK_SURRDB = """\
+#   test_id:              tc-export-001
+#   test_title:           Export-Ready Block
+#   test_type:            bauteil
+#   cdb_area:             risk
+#   rule_ref:             EXPORT_TEST
+#   decision_ref:         export test decision
+#   issue_ref:            #9999
+#   pr_ref:               #9999
+#   evidence_ref:         docs/test/export.md
+#   code_area:            services/risk/
+#   security_relevant:    false
+#   live_relevant:        false
+#   profitability_relevant: false
+#   surrealdb_export:     true
+#   ci_artifact:          false
+"""
+
+PARTIAL_BLOCK = """\
+#   test_id:              tc-partial-001
+#   test_title:           Partial Block
+#   test_type:            bauteil
+#   cdb_area:             risk
+#   rule_ref:             PARTIAL_TEST
+#   decision_ref:         partial test decision
+#   issue_ref:            #8888
+#   pr_ref:               #8888
+#   evidence_ref:         docs/test/partial.md
+#   code_area:            services/risk/
+#   security_relevant:    true
+#   live_relevant:        false
+   # missing: profitability_relevant, surrealdb_export, ci_artifact
+"""
+
+NO_METADATA_FILE = """\
+from __future__ import annotations
+import pytest
+
+def test_something():
+    assert True
+"""
+
+
+def _write_tmp_file(content: str, suffix: str = ".py") -> Path:
+    fd, path = tempfile.mkstemp(suffix=suffix, text=True)
+    os.write(fd, content.encode("utf-8"))
+    os.close(fd)
+    return Path(path)
+
+
+# ---------------------------------------------------------------------------
+# _find_metadata_blocks
+# ---------------------------------------------------------------------------
+
+
+class TestFindMetadataBlocks:
+    def test_valid_block_found(self):
+        blocks = _find_metadata_blocks(VALID_BLOCK)
+        assert len(blocks) == 1
+        fields = blocks[0]
+        assert fields["test_id"] == "cdb-test-pilot-001"
+        assert fields["surrealdb_export"] == "false"
+
+    def test_surrealdb_true_detected(self):
+        blocks = _find_metadata_blocks(VALID_BLOCK_SURRDB)
+        assert len(blocks) == 1
+        assert blocks[0]["surrealdb_export"] == "true"
+
+    def test_partial_block(self):
+        """A block missing some fields is still found but flagged later."""
+        blocks = _find_metadata_blocks(PARTIAL_BLOCK)
+        assert len(blocks) == 1
+        assert "profitability_relevant" not in blocks[0]
+
+    def test_no_metadata(self):
+        blocks = _find_metadata_blocks(NO_METADATA_FILE)
+        assert len(blocks) == 0
+
+    def test_empty_content(self):
+        blocks = _find_metadata_blocks("")
+        assert len(blocks) == 0
+
+    def test_multiple_blocks_separated(self):
+        content = VALID_BLOCK + "\n\nsome_code()\n\n" + VALID_BLOCK_SURRDB
+        blocks = _find_metadata_blocks(content)
+        assert len(blocks) == 2
+
+
+# ---------------------------------------------------------------------------
+# _process_fields
+# ---------------------------------------------------------------------------
+
+
+class TestProcessFields:
+    def test_valid_block(self):
+        raw = {
+            "test_id": "tc-001",
+            "test_title": "Test",
+            "test_type": "bauteil",
+            "cdb_area": "risk",
+            "rule_ref": "RULE-001",
+            "decision_ref": "decision",
+            "issue_ref": "#1",
+            "pr_ref": "#1",
+            "evidence_ref": "docs/test.md",
+            "code_area": "risk/",
+            "security_relevant": "true",
+            "live_relevant": "false",
+            "profitability_relevant": "false",
+            "surrealdb_export": "true",
+            "ci_artifact": "false",
+        }
+        processed, missing = _process_fields(raw)
+        assert len(missing) == 0
+        assert processed["test_id"] == "tc-001"
+        assert processed["security_relevant"] is True
+        assert processed["surrealdb_export"] is True
+        assert processed["ci_artifact"] is False
+
+    def test_missing_fields(self):
+        raw = {
+            "test_id": "tc-001",
+            "test_title": "Test",
+        }
+        processed, missing = _process_fields(raw)
+        assert len(missing) > 0
+        assert "test_type" in missing
+        assert "cdb_area" in missing
+
+    def test_all_fields_missing(self):
+        processed, missing = _process_fields({})
+        assert len(missing) == len(REQUIRED_FIELDS)
+
+
+# ---------------------------------------------------------------------------
+# _coerce_bool
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceBool:
+    def test_true(self):
+        assert _coerce_bool("true") is True
+        assert _coerce_bool("  true  ") is True
+        assert _coerce_bool("True") is True
+
+    def test_false(self):
+        assert _coerce_bool("false") is False
+        assert _coerce_bool("False") is False
+        assert _coerce_bool("") is False
+        assert _coerce_bool("yes") is False
+        assert _coerce_bool("1") is False
+
+
+# ---------------------------------------------------------------------------
+# scan_file
+# ---------------------------------------------------------------------------
+
+
+class TestScanFile:
+    def test_valid_block(self):
+        path = _write_tmp_file(VALID_BLOCK)
+        result = scan_file(path)
+        assert result["file"] == path.name
+        assert len(result["blocks"]) == 1
+        assert result["blocks"][0]["is_valid"] is True
+        assert result["validation_errors"] == []
+
+    def test_surrealdb_export_true(self):
+        path = _write_tmp_file(VALID_BLOCK_SURRDB)
+        result = scan_file(path)
+        assert result["blocks"][0]["surrealdb_export"] is True
+
+    def test_partial_block_flags_errors(self):
+        path = _write_tmp_file(PARTIAL_BLOCK)
+        result = scan_file(path)
+        assert len(result["validation_errors"]) == 1
+        assert (
+            "profitability_relevant" in result["validation_errors"][0]["missing_fields"]
+        )
+        assert "surrealdb_export" in result["validation_errors"][0]["missing_fields"]
+        assert "ci_artifact" in result["validation_errors"][0]["missing_fields"]
+
+    def test_no_metadata(self):
+        path = _write_tmp_file(NO_METADATA_FILE)
+        result = scan_file(path)
+        assert len(result["blocks"]) == 0
+        assert result["validation_errors"] == []
+
+    def test_nonexistent_file(self):
+        path = Path("nonexistent_file_xyz.py")
+        result = scan_file(path)
+        assert "error" in result
+        assert result["blocks"] == []
+
+    def test_repo_root_relative(self):
+        path = _write_tmp_file(VALID_BLOCK)
+        repo_root = path.parent
+        result = scan_file(path, repo_root=repo_root)
+        # Relative path must not contain the repo_root as a prefix
+        rel = result["file"]
+        assert not rel.startswith(
+            str(repo_root)
+        ), f"{rel} should be relative to {repo_root}"
+
+
+# ---------------------------------------------------------------------------
+# build_report
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReport:
+    def test_empty_results(self):
+        report = build_report([])
+        assert report["scanned_files"] == 0
+        assert report["total_blocks"] == 0
+        assert report["total_errors"] == 0
+
+    def test_valid_results(self):
+        path = _write_tmp_file(VALID_BLOCK)
+        results = [scan_file(path)]
+        report = build_report(results)
+        assert report["scanned_files"] == 1
+        assert report["total_blocks"] == 1
+        assert report["total_errors"] == 0
+
+    def test_surrealdb_ready_count(self):
+        path1 = _write_tmp_file(VALID_BLOCK_SURRDB)
+        path2 = _write_tmp_file(VALID_BLOCK)
+        results = [scan_file(path1), scan_file(path2)]
+        report = build_report(results)
+        assert report["surrealdb_export_ready"] == 1
+
+    def test_deterministic_order(self):
+        path_a = _write_tmp_file(VALID_BLOCK)
+        path_b = _write_tmp_file(VALID_BLOCK_SURRDB)
+        res1 = build_report([scan_file(path_a), scan_file(path_b)])
+        res2 = build_report([scan_file(path_b), scan_file(path_a)])
+        # Results are in input order; build_report doesn't sort
+        assert res1["results"][0]["file"] != res2["results"][0]["file"]
+
+    def test_no_absolute_paths_in_output(self):
+        path = _write_tmp_file(VALID_BLOCK)
+        result = scan_file(path)
+        json_str = json.dumps(result, indent=2)
+        # No drive letter or root slash in the 'file' field
+        file_path = result["file"]
+        assert ":" not in file_path  # no Windows drive letter
+        assert "\\" not in file_path or "\\\\" not in file_path
+
+
+# ---------------------------------------------------------------------------
+# collect_paths
+# ---------------------------------------------------------------------------
+
+
+class TestCollectPaths:
+    def test_single_file(self):
+        path = _write_tmp_file(VALID_BLOCK)
+        files = collect_paths([str(path)])
+        assert len(files) >= 1
+
+    def test_non_py_file_skipped(self):
+        path = _write_tmp_file("hello world", suffix=".txt")
+        files = collect_paths([str(path)])
+        assert len(files) == 0
+
+    def test_directory_scan(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            f1 = d / "test_a.py"
+            f2 = d / "sub" / "test_b.py"
+            f2.parent.mkdir()
+            f1.write_text("", encoding="utf-8")
+            f2.write_text("", encoding="utf-8")
+            files = collect_paths([str(d)])
+            assert len(files) == 2
+
+    def test_nonexistent_path_warns(self, capsys):
+        files = collect_paths(["nonexistent_dir_xyz"])
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# run() integration
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    def test_stdout_no_blocks(self):
+        path = _write_tmp_file(NO_METADATA_FILE)
+        code = run([str(path)])
+        assert code == 0
+
+    def test_valid_returns_zero(self):
+        path = _write_tmp_file(VALID_BLOCK)
+        code = run([str(path)])
+        assert code == 0
+
+    def test_partial_returns_one(self):
+        path = _write_tmp_file(PARTIAL_BLOCK)
+        code = run([str(path)])
+        assert code == 1
+
+    def test_output_file(self):
+        path = _write_tmp_file(VALID_BLOCK)
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            out_path = f.name
+        try:
+            code = run([str(path), "--output", out_path])
+            assert code == 0
+            with open(out_path, encoding="utf-8") as f:
+                data = json.load(f)
+            assert data["total_blocks"] == 1
+        finally:
+            os.unlink(out_path)
+
+    def test_no_files_returns_two(self):
+        code = run(["nonexistent_dir_xyz"])
+        assert code == 2

--- a/tools/test_metadata_scanner.py
+++ b/tools/test_metadata_scanner.py
@@ -1,0 +1,262 @@
+"""CDB Test-First Metadata Scanner (read-only).
+
+Scans Python test files for CDB test-first metadata blocks,
+validates required fields, and outputs JSON.
+
+Usage:
+    python -m tools.test_metadata_scanner <path>...
+    python -m tools.test_metadata_scanner --output <file> <path>...
+
+Exit codes:
+    0 - all blocks valid (or no blocks found)
+    1 - validation errors found
+    2 - usage / parse error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REQUIRED_FIELDS: list[str] = [
+    "test_id",
+    "test_title",
+    "test_type",
+    "cdb_area",
+    "rule_ref",
+    "decision_ref",
+    "issue_ref",
+    "pr_ref",
+    "evidence_ref",
+    "code_area",
+    "security_relevant",
+    "live_relevant",
+    "profitability_relevant",
+    "surrealdb_export",
+    "ci_artifact",
+]
+
+REQUIRED_FIELD_SET: frozenset[str] = frozenset(REQUIRED_FIELDS)
+
+BOOLEAN_FIELDS: frozenset[str] = frozenset(
+    {
+        "security_relevant",
+        "live_relevant",
+        "profitability_relevant",
+        "surrealdb_export",
+        "ci_artifact",
+    }
+)
+
+FIELD_LINE_RE: re.Pattern = re.compile(r"^#\s{2,}(\w+):\s+(.+)$")
+
+
+def _find_metadata_blocks(content: str) -> list[dict[str, str]]:
+    """Find metadata field blocks in Python comment content.
+
+    Looks for consecutive lines matching '#   field_name: value'
+    where field_name is a known CDB metadata field.
+    Groups consecutive field lines into blocks.
+    """
+    blocks: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for line in content.splitlines():
+        m = FIELD_LINE_RE.match(line.strip())
+        if m and m.group(1) in REQUIRED_FIELD_SET:
+            current[m.group(1)] = m.group(2).strip()
+        else:
+            if current:
+                blocks.append(current)
+                current = {}
+    if current:
+        blocks.append(current)
+    return blocks
+
+
+def _coerce_bool(raw: str) -> bool:
+    """Parse a string boolean value. Anything not 'true' is false."""
+    return raw.strip().lower() == "true"
+
+
+def _process_fields(
+    raw: dict[str, str],
+) -> dict[str, Any]:
+    """Convert raw string fields to typed dict and validate."""
+    processed: dict[str, Any] = {}
+    missing: list[str] = []
+    for field in REQUIRED_FIELDS:
+        if field not in raw:
+            missing.append(field)
+            continue
+        val: str = raw[field]
+        if field in BOOLEAN_FIELDS:
+            processed[field] = _coerce_bool(val)
+        else:
+            processed[field] = val
+    return processed, missing
+
+
+def _to_relpath(path: Path, anchor: Path | None = None) -> str:
+    """Convert path to relative, or keep as simple name."""
+    try:
+        if anchor:
+            return str(path.relative_to(anchor))
+        return str(path.relative_to(Path.cwd()))
+    except ValueError:
+        return path.name
+
+
+def scan_file(
+    path: Path,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """Scan a single file for metadata blocks."""
+    try:
+        content: str = path.read_text(encoding="utf-8")
+    except Exception as exc:
+        return {
+            "file": _to_relpath(path, repo_root),
+            "error": f"Cannot read file: {exc}",
+            "blocks": [],
+        }
+
+    raw_blocks: list[dict[str, str]] = _find_metadata_blocks(content)
+    result_blocks: list[dict[str, Any]] = []
+    validation_errors: list[dict[str, Any]] = []
+
+    for raw in raw_blocks:
+        processed, missing = _process_fields(raw)
+        is_valid: bool = len(missing) == 0
+        block: dict[str, Any] = {
+            "fields": processed,
+            "is_valid": is_valid,
+            "surrealdb_export": processed.get("surrealdb_export", False),
+        }
+        if missing:
+            block["missing_fields"] = missing
+            validation_errors.append(
+                {
+                    "file": _to_relpath(path, repo_root),
+                    "missing_fields": missing,
+                }
+            )
+        result_blocks.append(block)
+
+    return {
+        "file": _to_relpath(path, repo_root),
+        "blocks": result_blocks,
+        "validation_errors": validation_errors,
+    }
+
+
+def build_report(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build final JSON report from scan results."""
+    total_blocks: int = 0
+    total_errors: int = 0
+    surrealdb_ready: int = 0
+    scanned_files: int = 0
+
+    for res in results:
+        if "error" not in res:
+            scanned_files += 1
+        total_blocks += len(res.get("blocks", []))
+        total_errors += len(res.get("validation_errors", []))
+        for b in res.get("blocks", []):
+            if b.get("surrealdb_export"):
+                surrealdb_ready += 1
+
+    return {
+        "scanner_version": "1.0.0",
+        "scanned_files": scanned_files,
+        "total_blocks": total_blocks,
+        "total_errors": total_errors,
+        "surrealdb_export_ready": surrealdb_ready,
+        "results": results,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="CDB Test-First Metadata Scanner (read-only)",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["tests/"],
+        help="Files or directories to scan (default: tests/)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Write JSON report to file (default: stdout)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repository root for relative paths in output",
+    )
+    return parser.parse_args(argv)
+
+
+def collect_paths(patterns: list[str]) -> list[Path]:
+    """Resolve file/directory patterns to Python file paths."""
+    files: list[Path] = []
+    seen: set[Path] = set()
+    for pattern in patterns:
+        p = Path(pattern)
+        if p.is_file() and p.suffix == ".py":
+            resolved = p.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                files.append(resolved)
+        elif p.is_dir():
+            for child in sorted(p.rglob("*.py")):
+                resolved = child.resolve()
+                if resolved not in seen:
+                    seen.add(resolved)
+                    files.append(resolved)
+        else:
+            print(f"Warning: not a Python file or directory: {p}", file=sys.stderr)
+    return files
+
+
+def run(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    paths: list[Path] = collect_paths(args.paths)
+    if not paths:
+        print("No Python files found to scan.", file=sys.stderr)
+        return 2
+
+    repo_root: Path | None = Path(args.repo_root).resolve() if args.repo_root else None
+
+    results: list[dict[str, Any]] = []
+    for path in sorted(paths):
+        results.append(scan_file(path, repo_root=repo_root))
+
+    report: dict[str, Any] = build_report(results)
+
+    output: str = json.dumps(report, indent=2, ensure_ascii=False)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(output, encoding="utf-8")
+    else:
+        print(output)
+
+    if report["total_errors"] > 0:
+        return 1
+    return 0
+
+
+def main() -> None:
+    sys.exit(run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add a read-only CDB Test-First Metadata Scanner (\	ools/test_metadata_scanner.py\) that finds, parses, and validates 15-field metadata blocks per \TEST_FIRST_PROCESSING_CONTRACT.md\.

## Scope

- **New tool:** \	ools/test_metadata_scanner.py\ — read-only scanner with stdout/\--output\ JSON export
- **Tests:** \	ests/unit/tools/test_test_metadata_scanner.py\ — 31 tests covering valid/partial/missing/malformed/export flag/determinism
- **Docs:** \knowledge/testing/README.md\ — new Scanner section explaining purpose, usage, exit codes, read-only boundary
- **Config:** \.gitignore\ — exception for \	ools/test_metadata_scanner.py\ (blocked by \*test*.py\ wildcard)

## Brain Evidence

- **context_tool_status:** repo-only (kein SurrealDB, kein DB-Cache)
- **context_trust_level:** repo-read (direkte Dateizugriffe)
- **records_found:** PR #3408 merged at be0be141; PILOT-001 block in test file; TEST_FIRST_PROCESSING_CONTRACT.md defines 15-field schema

## Validation

- \pytest -q tests/unit/tools/test_test_metadata_scanner.py\ — 31 passed
- \uff check tools/test_metadata_scanner.py tests/unit/tools/test_test_metadata_scanner.py\ — All checks passed
- \python -m tools.test_metadata_scanner tests/unit/validation/test_profitability_evidence_packet_assembler.py\ — correctly detects PILOT-001 block, 0 errors
- \python -m tools.test_metadata_scanner tests/unit/validation/test_profitability_evidence_packet_assembler.py --output <tmp>.json\ — writes valid JSON artifact

## Non-goals

- No SurrealDB write
- No productive DB access
- No MCP write
- No runtime
- No Docker
- No CI workflow change
- No migration of other test files
- No change to production code
- No LR / Live / Echtgeld-Go

## Safety Boundaries

- Scanner = read-only (writes only to --output path)
- No DB connection, no network, no mutation
- Gitignore exception narrowly scoped to one tool file
- Pre-existing untracked files not committed

## Restunsicherheiten

- \ci_artifact\ is defined as bool in the contract but PILOT-001 uses string \	est-report\; scanner treats non-'true' strings as \alse\ (fail-closed).
- No SurrealDB import logic in this slice — next step when \surrealdb_export: true\ blocks exist.