### PR TITLE
test(metadata): harmonize ci_artifact contract

### DIFF
--- a/knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md
+++ b/knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md
@@ -78,7 +78,7 @@ Jeder wichtige CDB-Test trägt ab heute ein Pflichtfeld-Set. Wichtige Tests sind
 | `live_relevant` | bool | Relevanz für Live-Trading? | `false` |
 | `profitability_relevant` | bool | Relevanz für Profit-Berechnung? | `false` |
 | `surrealdb_export` | bool | Wird nach SurrealDB exportiert? | `true` |
-| `ci_artifact` | bool | Bleibt reines CI-Artefakt? | `false` |
+| `ci_artifact` | string | Bezeichnung des CI-Artefakts (z. B. `test-report`, `coverage-html`). Kein Ja/Nein-Flag — die Art des Artefakts. | `test-report` |
 
 ### Wie die Felder im Test landen
 
@@ -100,9 +100,8 @@ security_relevant: true
 live_relevant: true
 profitability_relevant: false
 surrealdb_export: true
-ci_artifact: false
+ci_artifact: test-report
 """
-```
 
 Oder später als strukturierter JSON/YAML-Block, den ein CI-Scanner automatisch ausliest und nach SurrealDB schreibt.
 
@@ -373,7 +372,7 @@ security_relevant: true
 live_relevant: true
 profitability_relevant: false
 surrealdb_export: true
-ci_artifact: false
+ci_artifact: test-report
 """
 
 def test_kill_switch_blocks_orders(risk_service, mock_executor):

--- a/tests/unit/tools/test_test_metadata_scanner.py
+++ b/tests/unit/tools/test_test_metadata_scanner.py
@@ -156,14 +156,14 @@ class TestProcessFields:
             "live_relevant": "false",
             "profitability_relevant": "false",
             "surrealdb_export": "true",
-            "ci_artifact": "false",
+            "ci_artifact": "test-report",
         }
         processed, missing = _process_fields(raw)
         assert len(missing) == 0
         assert processed["test_id"] == "tc-001"
         assert processed["security_relevant"] is True
         assert processed["surrealdb_export"] is True
-        assert processed["ci_artifact"] is False
+        assert processed["ci_artifact"] == "test-report"
 
     def test_missing_fields(self):
         raw = {

--- a/tools/test_metadata_scanner.py
+++ b/tools/test_metadata_scanner.py
@@ -48,7 +48,6 @@ BOOLEAN_FIELDS: frozenset[str] = frozenset(
         "live_relevant",
         "profitability_relevant",
         "surrealdb_export",
-        "ci_artifact",
     }
 )
 


### PR DESCRIPTION
## Delivered

Harmonize ci_artifact field type across all CDB surfaces: Contract, Scanner, Tests, and PILOT-001 now agree.

## Brain Evidence

- context_tool_status: repo-only
- context_trust_level: repo-read
- records_found: PR #3408 (PILOT-001) at be0be141, PR #3409 (Scanner) at fe815266, Contract on main

## Validation

- pytest -q tests/unit/tools/test_test_metadata_scanner.py - 31 passed
- uff check tools/ tests/ - All checks passed
- lack --check - 2 files unchanged
- Scanner output shows ci_artifact as string 	est-report instead of bool alse

## Non-goals

- No SurrealDB write
- No runtime / Docker / DB mutation
- No CI workflow change

## Safety Boundaries

- Scanner remains read-only
- Pre-existing untracked files not committed

## Restunsicherheiten

Keine. Contract und Praxis sind jetzt konsistent.
