### PR TITLE
test(metadata): mark pilot001 for surrealdb export

### DIFF
--- a/knowledge/testing/README.md
+++ b/knowledge/testing/README.md
@@ -15,11 +15,13 @@ not executable test code.
 | `MOCKEXCHANGE_CDB_TEST_MAP.md` | Active map for turning MockExchange reference patterns into CDB-native tests. |
 | `TEST_FIRST_PROCESSING_CONTRACT.md` | Active contract: test metadata standard, 15 test types, SurrealDB knowledge model, processing pipeline. |
 | `SKILL_VALLEY_TEST_UPGRADE_PLAN.md` | Active plan: 8 skill rules agents must learn before scaling tests. |
-| `TEST_FIRST_METADATA_PILOT.md` | Pilot: Test-First-Metadatenblock in `tests/unit/validation/test_profitability_evidence_packet_assembler.py` — Proof-of-Concept fuer SurrealDB-Export-faehige Metadaten. |
 
 ## Scanner
 
 `tools/test_metadata_scanner.py` — read-only CDB Test-First Metadata Scanner.
+
+Aktueller Pilot-Block: `tests/unit/validation/test_profitability_evidence_packet_assembler.py`
+(`CDB-PILOT-001`).
 
 **Zweck:** Findet 15-field Metadatenbloecke in Python-Testdateien, validiert
 Pflichtfelder und gibt ein JSON-Artefakt aus — Vorstufe zum SurrealDB-Import.
@@ -45,9 +47,11 @@ python -m tools.test_metadata_scanner tests/unit/validation/test_profitability_e
 - 1: Validierungsfehler (fehlende Pflichtfelder)
 - 2: Usage-/Parse-Fehler (keine Python-Dateien)
 
-**SurrealDB-Export:** `surrealdb_export: true` wird im JSON sichtbar als
-`"surrealdb_export_ready"`-Zaehler. Dieser Scanner schreibt noch nicht nach
-SurrealDB — er bereitet nur den Export vor.
+**SurrealDB-Export:** `surrealdb_export: true` markiert genau einen
+Metadatenblock als exportfreigegeben fuer das JSON-Artefakt des Scanners. Im
+JSON erscheint das als Block-Feld und im Report als
+`"surrealdb_export_ready"`-Zaehler. Das ist kein SurrealDB-Write und keine
+Import-Freigabe; ein spaeterer Importer bleibt ein eigener Slice.
 
 ## Guardrail
 

--- a/tests/unit/tools/test_test_metadata_scanner.py
+++ b/tests/unit/tools/test_test_metadata_scanner.py
@@ -18,6 +18,15 @@ from tools.test_metadata_scanner import (
     run,
 )
 
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+PILOT_METADATA_FILE = (
+    PROJECT_ROOT
+    / "tests"
+    / "unit"
+    / "validation"
+    / "test_profitability_evidence_packet_assembler.py"
+)
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -61,7 +70,7 @@ VALID_BLOCK_SURRDB = """\
 #   live_relevant:        false
 #   profitability_relevant: false
 #   surrealdb_export:     true
-#   ci_artifact:          false
+#   ci_artifact:          test-report
 """
 
 PARTIAL_BLOCK = """\
@@ -170,13 +179,13 @@ class TestProcessFields:
             "test_id": "tc-001",
             "test_title": "Test",
         }
-        processed, missing = _process_fields(raw)
+        _, missing = _process_fields(raw)
         assert len(missing) > 0
         assert "test_type" in missing
         assert "cdb_area" in missing
 
     def test_all_fields_missing(self):
-        processed, missing = _process_fields({})
+        _, missing = _process_fields({})
         assert len(missing) == len(REQUIRED_FIELDS)
 
 
@@ -217,6 +226,24 @@ class TestScanFile:
         path = _write_tmp_file(VALID_BLOCK_SURRDB)
         result = scan_file(path)
         assert result["blocks"][0]["surrealdb_export"] is True
+
+    def test_actual_pilot001_is_export_ready(self):
+        result = scan_file(PILOT_METADATA_FILE, repo_root=PROJECT_ROOT)
+        assert result["file"] == (
+            "tests/unit/validation/"
+            "test_profitability_evidence_packet_assembler.py"
+        )
+        assert len(result["blocks"]) == 1
+        assert result["validation_errors"] == []
+
+        block = result["blocks"][0]
+        fields = block["fields"]
+        assert block["is_valid"] is True
+        assert block["surrealdb_export"] is True
+        assert fields["test_id"] == "cdb-test-pilot-001"
+        assert fields["surrealdb_export"] is True
+        assert fields["ci_artifact"] == "test-report"
+        assert set(fields) == set(REQUIRED_FIELDS)
 
     def test_partial_block_flags_errors(self):
         path = _write_tmp_file(PARTIAL_BLOCK)
@@ -289,11 +316,29 @@ class TestBuildReport:
     def test_no_absolute_paths_in_output(self):
         path = _write_tmp_file(VALID_BLOCK)
         result = scan_file(path)
-        json_str = json.dumps(result, indent=2)
         # No drive letter or root slash in the 'file' field
         file_path = result["file"]
         assert ":" not in file_path  # no Windows drive letter
         assert "\\" not in file_path or "\\\\" not in file_path
+
+    def test_actual_pilot001_report_is_stable_and_machine_readable(self):
+        report1 = build_report([scan_file(PILOT_METADATA_FILE, repo_root=PROJECT_ROOT)])
+        report2 = build_report([scan_file(PILOT_METADATA_FILE, repo_root=PROJECT_ROOT)])
+
+        assert report1 == report2
+        assert set(report1) == {
+            "scanner_version",
+            "scanned_files",
+            "total_blocks",
+            "total_errors",
+            "surrealdb_export_ready",
+            "results",
+        }
+        assert report1["scanned_files"] == 1
+        assert report1["total_blocks"] == 1
+        assert report1["total_errors"] == 0
+        assert report1["surrealdb_export_ready"] == 1
+        assert ":" not in report1["results"][0]["file"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/validation/test_profitability_evidence_packet_assembler.py
+++ b/tests/unit/validation/test_profitability_evidence_packet_assembler.py
@@ -55,8 +55,9 @@ CONTRACTS_DIR = PROJECT_ROOT / "docs" / "contracts"
 # 4. Welche Metadaten braucht der Test? (siehe Block unten)
 #
 # 5. Wie wird das Ergebnis weiterverarbeitet?
-#    CI: pytest-sammlung + JUnit-Report. Spaeter SurrealDB-Export
-#    (surrealdb_export: false im Pilot).
+#    CI: pytest-sammlung + JUnit-Report. JSON-Export ist fuer
+#    spaetere SurrealDB-Nutzung freigegeben
+#    (surrealdb_export: true im Pilot). Kein DB-Write in diesem Slice.
 #
 # Metadata fields (TEST_FIRST_PROCESSING_CONTRACT.md §6):
 #   test_id:              cdb-test-pilot-001
@@ -72,7 +73,7 @@ CONTRACTS_DIR = PROJECT_ROOT / "docs" / "contracts"
 #   security_relevant:    false
 #   live_relevant:        false
 #   profitability_relevant: true
-#   surrealdb_export:     false
+#   surrealdb_export:     true
 #   ci_artifact:          test-report
 #
 # Gruppen-Klassifikation:

--- a/tools/test_metadata_scanner.py
+++ b/tools/test_metadata_scanner.py
@@ -103,8 +103,8 @@ def _to_relpath(path: Path, anchor: Path | None = None) -> str:
     """Convert path to relative, or keep as simple name."""
     try:
         if anchor:
-            return str(path.relative_to(anchor))
-        return str(path.relative_to(Path.cwd()))
+            return path.relative_to(anchor).as_posix()
+        return path.relative_to(Path.cwd()).as_posix()
     except ValueError:
         return path.name
 


### PR DESCRIPTION
## Delivered
- Marked the existing `CDB-PILOT-001` metadata block in `tests/unit/validation/test_profitability_evidence_packet_assembler.py` with `surrealdb_export: true`.
- Kept `ci_artifact` as the string `test-report` and documented the export-only meaning in `knowledge/testing/README.md`.
- Added scanner regression coverage for the real pilot file and normalized scanner-relative paths to POSIX form for OS-stable JSON artifacts.

## Brain Evidence
```text
brain_source: repo-only
brain_status: not-used
tools_or_queries:
  - context.briefing
  - context.search
  - context.required_reads
  - git fetch origin --prune
  - gh pr view 3411 --json number,title,state,mergedAt,mergeCommit,url
  - gh pr list --state open --limit 20
  - rg -n "CDB-PILOT-001|surrealdb_export|ci_artifact|test_metadata_scanner|metadata" tests knowledge tools CURRENT_STATUS.md
records_or_results:
  - context.briefing operator_trust_level=LOW; no evidence_records/claim_records/decision_events/memory_records
  - context.search hits=0
  - context.required_reads resolved 10/10 read-order files available
  - git/live baseline matched merged PR #3411 at 7fde2c42e97dcfc94700a7c6c363d9cc4146ceb0
repo_crosscheck:
  - AGENTS.md
  - agents/AGENTS.md
  - agents/OPEN_CODE_AGENTS.md
  - tests/unit/validation/test_profitability_evidence_packet_assembler.py
  - tools/test_metadata_scanner.py
  - tests/unit/tools/test_test_metadata_scanner.py
  - knowledge/testing/README.md
impact_on_plan:
  - Used repo fallback because context tools were available but low-trust / no DB-backed records for this slice.
  - Kept scope to one existing pilot block, scanner contract coverage, and README drift within the same slice.
limitations:
  - No DB-backed claim or SurrealDB record evidence was available.
  - No SurrealDB import/write path was implemented or exercised.
context_brain_attempted: true
context_brain_used: false
repo_fallback_used: true
repo_fallback_reason: insufficient_evidence
context_tool_status: available
context_trust_level: low
records_found: none
```

## Validation
- `git diff --check`
- `pytest -q tests/unit/tools/test_test_metadata_scanner.py`
- `python tools/test_metadata_scanner.py tests/unit/validation/test_profitability_evidence_packet_assembler.py`
- `ruff check tools/test_metadata_scanner.py tests/unit/tools/test_test_metadata_scanner.py`
- `rg -n "CDB-PILOT-001|surrealdb_export: true|ci_artifact: test-report|test_metadata_scanner" tests knowledge tools`

## Non-goals
- No SurrealDB importer
- No DB write
- No MCP write
- No runtime or Docker change
- No CI workflow change
- No broad metadata migration

## Safety Boundaries
- LR remains `NO-GO`.
- Board `trade-capable` was treated as orthogonal to LR and not as Live-Go.
- `surrealdb_export: true` is only a JSON export marker, not a write authorization.

## Restunsicherheiten
- Required checks were not green at PR creation time yet.
- There are unrelated local untracked files in the worktree that were not touched by this slice.