### PR TITLE
chore(github): configure sponsor funding button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Funding configuration for Claire de Binare.
+# GitHub uses this file to display the Sponsor button on the repository landing page.
+github: jannekbuengener

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Diese Root-README ist die GitHub-Haupt-Landingpage. Der aktive Pfad bleibt Shado
 - GitHub-Control-Plane-Unterdokument: [`.github/CONTROL_PLANE.md`](.github/CONTROL_PLANE.md)
 - CDB Glossary: [`docs/onboarding/cdb_glossary.md`](docs/onboarding/cdb_glossary.md)
 - Repo-/Engineering-Ledger: [`CURRENT_STATUS.md`](CURRENT_STATUS.md)
+- Support: GitHub Sponsors is configured via [`.github/FUNDING.yml`](.github/FUNDING.yml) for people who want to support ongoing development.
 
 ## Safety / LR Status
 


### PR DESCRIPTION
Closes #3413

## Delivered
- Added `.github/FUNDING.yml` with the verified GitHub Sponsors target `jannekbuengener`.
- Added one neutral README support pointer to the configured funding file.

## Evidence
- GitHub documentation: https://docs.github.com/de/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
- Live sponsor page checked: https://github.com/sponsors/jannekbuengener
- Repo live identity checked: `jannekbuengener/Claire_de_Binare`, default branch `main`.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Placeholder search on changed files for `Replace with`, template usernames, example payment URLs, and unused provider keys.
- Manual YAML shape check: simple `github: jannekbuengener` mapping only.

## Non-goals
- No runtime, trading, workflow, dependency, Docker, DB, MCP, LR, Live, or Echtgeld changes.
- No additional funding providers guessed or added.

## Safety Boundaries
- LR remains NO-GO.
- `trade-capable` Board stage is not Live-Go.
- No real-money or live-trading authorization is implied.

## Restunsicherheiten
- GitHub may take a short time after merge to render the Sponsor button on the repository landing page.