### PR TITLE
feat: add test-metadata-import-bundle-builder (read-only SurrealDB-ready bundle)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # Allow official test suite in tests/ directory (must come AFTER wildcard)
 !tests/**/*.py
 !tools/test_metadata_scanner.py
+!tools/test_metadata_import_bundle.py
 !tests/**/*.js
 !services/validation/strategy_backtest_runner.py
 !services/validation/rmr_backtest_runner.py

--- a/knowledge/testing/README.md
+++ b/knowledge/testing/README.md
@@ -53,6 +53,43 @@ JSON erscheint das als Block-Feld und im Report als
 `"surrealdb_export_ready"`-Zaehler. Das ist kein SurrealDB-Write und keine
 Import-Freigabe; ein spaeterer Importer bleibt ein eigener Slice.
 
+## Import-Bundle-Builder
+
+`tools/test_metadata_import_bundle.py` — read-only SurrealDB-ready Import-Bundle-Builder.
+
+**Zweck:** Transformiert das JSON des Scanners in ein deterministisches,
+SurrealDB-kompatibles Import-Bundle. Nur Blöcke mit `is_valid: true` und
+`surrealdb_export: true` werden übernommen. Kein DB-Zugriff, kein Netzwerk,
+keine Mutation.
+
+**Record-Format:**
+- `record_type: test_case` (aligniert mit `TEST_FIRST_PROCESSING_CONTRACT.md`)
+- `record_id` aus `source_file` + `test_id` (deterministisch, stabil)
+- `content_hash` per `canonical_hash()` aus `core/replay/canonical_json.py`
+- `pilot_id` wird aus `test_id` abgeleitet (Pattern: `cdb-test-pilot-NNN`)
+- `metadata` enthält alle Scanner-Felder unverändert
+
+**Nutzung:**
+```bash
+# Pipe aus Scanner
+python -m tools.test_metadata_scanner tests/ --output artifacts/scanner-report.json
+python -m tools.test_metadata_import_bundle artifacts/scanner-report.json
+
+# Datei
+python -m tools.test_metadata_import_bundle artifacts/scanner-report.json --output artifacts/import-bundle.json
+
+# Stdin
+python -m tools.test_metadata_scanner tests/ | python -m tools.test_metadata_import_bundle -
+```
+
+**Exit-Codes:**
+- 0: valides Bundle erzeugt
+- 1: keine exportierbaren Blöcke oder Validierungsfehler
+- 2: Parse-/Usage-Fehler
+
+**Path-Sicherheit:** Absolute Pfade (Windows-Laufwerkbuchstabe oder führender
+Schrägstrich) werden fail-closed abgelehnt.
+
 ## Guardrail
 
 Testing knowledge does not authorize runtime, Docker, exchange, database, or

--- a/tests/unit/tools/test_test_metadata_import_bundle.py
+++ b/tests/unit/tools/test_test_metadata_import_bundle.py
@@ -1,0 +1,595 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tools.test_metadata_import_bundle import (
+    SCHEMA_VERSION,
+    SOURCE_SCANNER,
+    RECORD_TYPE,
+    _derive_pilot_id,
+    _to_relpath_posix,
+    _build_record_id,
+    _build_content_hash,
+    _build_record,
+    load_scanner_report,
+    build_bundle,
+    validate_records,
+    write_bundle,
+    run,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+EXPORT_BLOCK = {
+    "file": "tests/unit/validation/test_profitability_evidence_packet_assembler.py",
+    "blocks": [
+        {
+            "fields": {
+                "test_id": "cdb-test-pilot-001",
+                "test_title": "Profitability Evidence Packet Assembler",
+                "test_type": "mixed",
+                "cdb_area": "validation",
+                "rule_ref": "PROFITABILITY_EVIDENCE_PACKET_SCHEMA_CONFORMANCE",
+                "decision_ref": "d-2026-04-08-evidence-packet-structure",
+                "issue_ref": "#1492",
+                "pr_ref": "#3408",
+                "evidence_ref": "docs/contracts/profitability_evidence_packet.v1.schema.json",
+                "code_area": "ProfitabilityEvidencePacketAssembler",
+                "security_relevant": False,
+                "live_relevant": False,
+                "profitability_relevant": True,
+                "surrealdb_export": True,
+                "ci_artifact": "test-report",
+            },
+            "is_valid": True,
+            "surrealdb_export": True,
+        },
+    ],
+    "validation_errors": [],
+}
+
+NO_EXPORT_BLOCK = {
+    "file": "tests/unit/validation/test_no_export.py",
+    "blocks": [
+        {
+            "fields": {
+                "test_id": "tc-no-export-001",
+                "test_title": "No Export Block",
+                "test_type": "bauteil",
+                "cdb_area": "risk",
+                "rule_ref": "NO_EXPORT",
+                "decision_ref": "no export decision",
+                "issue_ref": "#9999",
+                "pr_ref": "#9999",
+                "evidence_ref": "docs/test/noexport.md",
+                "code_area": "services/risk/",
+                "security_relevant": False,
+                "live_relevant": False,
+                "profitability_relevant": False,
+                "surrealdb_export": False,
+                "ci_artifact": "test-report",
+            },
+            "is_valid": True,
+            "surrealdb_export": False,
+        },
+    ],
+    "validation_errors": [],
+}
+
+INVALID_BLOCK = {
+    "file": "tests/unit/validation/test_invalid.py",
+    "blocks": [
+        {
+            "fields": {
+                "test_id": "tc-invalid-001",
+                "test_title": "Invalid Block",
+                "test_type": "bauteil",
+                "cdb_area": "risk",
+            },
+            "is_valid": False,
+            "surrealdb_export": False,
+            "missing_fields": [
+                "rule_ref",
+                "decision_ref",
+                "issue_ref",
+                "pr_ref",
+                "evidence_ref",
+                "code_area",
+                "security_relevant",
+                "live_relevant",
+                "profitability_relevant",
+                "surrealdb_export",
+                "ci_artifact",
+            ],
+        },
+    ],
+    "validation_errors": [],
+}
+
+ABSOLUTE_PATH_RESULT = {
+    "file": "C:/Users/test/some_file.py",
+    "blocks": [
+        {
+            "fields": {
+                "test_id": "tc-abs-001",
+                "test_title": "Absolute Path",
+                "test_type": "bauteil",
+                "cdb_area": "risk",
+                "rule_ref": "ABS_PATH",
+                "decision_ref": "abs path decision",
+                "issue_ref": "#9999",
+                "pr_ref": "#9999",
+                "evidence_ref": "docs/test/abs.md",
+                "code_area": "services/risk/",
+                "security_relevant": False,
+                "live_relevant": False,
+                "profitability_relevant": False,
+                "surrealdb_export": True,
+                "ci_artifact": "test-report",
+            },
+            "is_valid": True,
+            "surrealdb_export": True,
+        },
+    ],
+    "validation_errors": [],
+}
+
+VALID_SCANNER_REPORT = {
+    "scanner_version": "1.0.0",
+    "scanned_files": 1,
+    "total_blocks": 1,
+    "total_errors": 0,
+    "surrealdb_export_ready": 1,
+    "results": [EXPORT_BLOCK],
+}
+
+
+def _write_tmp_json(content: dict) -> Path:
+    fd, path = tempfile.mkstemp(suffix=".json", text=True)
+    os.write(fd, json.dumps(content, indent=2).encode("utf-8"))
+    os.close(fd)
+    return Path(path)
+
+
+# ---------------------------------------------------------------------------
+# _derive_pilot_id
+# ---------------------------------------------------------------------------
+
+
+class TestDerivePilotId:
+    def test_pilot_pattern_matches(self):
+        assert _derive_pilot_id("cdb-test-pilot-001") == "CDB-PILOT-001"
+
+    def test_pilot_pattern_matches_large_number(self):
+        assert _derive_pilot_id("cdb-test-pilot-042") == "CDB-PILOT-042"
+
+    def test_non_pilot_id_returns_empty(self):
+        assert _derive_pilot_id("tc-drawdown-001") == ""
+
+    def test_empty_string_returns_empty(self):
+        assert _derive_pilot_id("") == ""
+
+    def test_case_insensitive(self):
+        assert _derive_pilot_id("CDB-TEST-PILOT-007") == "CDB-PILOT-007"
+
+
+# ---------------------------------------------------------------------------
+# _to_relpath_posix
+# ---------------------------------------------------------------------------
+
+
+class TestToRelpathPosix:
+    def test_relative_posix_accepted(self):
+        assert _to_relpath_posix("tests/unit/risk/test_risk.py") == "tests/unit/risk/test_risk.py"
+
+    def test_relative_with_backslashes_normalized(self):
+        assert _to_relpath_posix("tests\\unit\\risk\\test_risk.py") == "tests/unit/risk/test_risk.py"
+
+    def test_basename_accepted(self):
+        assert _to_relpath_posix("test_risk.py") == "test_risk.py"
+
+    def test_windows_drive_letter_rejected(self):
+        with pytest.raises(ValueError, match="Absolute path rejected"):
+            _to_relpath_posix("C:\\Users\\test\\file.py")
+
+    def test_unix_absolute_rejected(self):
+        with pytest.raises(ValueError, match="Absolute path rejected"):
+            _to_relpath_posix("/home/user/file.py")
+
+    def test_windows_forward_slash_drive_rejected(self):
+        with pytest.raises(ValueError, match="Absolute path rejected"):
+            _to_relpath_posix("C:/Users/test/file.py")
+
+    def test_empty_string_returns_empty(self):
+        assert _to_relpath_posix("") == ""
+
+    def test_strip_whitespace(self):
+        assert _to_relpath_posix("  tests/unit/test.py  ") == "tests/unit/test.py"
+
+
+# ---------------------------------------------------------------------------
+# _build_record_id
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRecordId:
+    def test_deterministic_same_input(self):
+        id1 = _build_record_id("tests/unit/risk/test_risk.py", "tc-001")
+        id2 = _build_record_id("tests/unit/risk/test_risk.py", "tc-001")
+        assert id1 == id2
+
+    def test_different_input_different_id(self):
+        id1 = _build_record_id("tests/unit/risk/test_risk.py", "tc-001")
+        id2 = _build_record_id("tests/unit/risk/test_risk.py", "tc-002")
+        assert id1 != id2
+
+    def test_prefix_is_test_case(self):
+        rid = _build_record_id("tests/unit/test.py", "tc-001")
+        assert rid.startswith("test_case:")
+
+    def test_consistent_hash_length(self):
+        rid = _build_record_id("some/file.py", "tc-001")
+        suffix = rid.split(":")[1]
+        assert len(suffix) == 24
+
+
+# ---------------------------------------------------------------------------
+# _build_content_hash
+# ---------------------------------------------------------------------------
+
+
+class TestBuildContentHash:
+    def test_deterministic_same_record(self):
+        record = {
+            "record_id": "test_case:abc123",
+            "source_file": "tests/unit/test.py",
+            "test_id": "tc-001",
+            "test_type": "bauteil",
+            "ci_artifact": "test-report",
+            "surrealdb_export": True,
+        }
+        h1 = _build_content_hash(record)
+        h2 = _build_content_hash(record)
+        assert h1 == h2
+
+    def test_different_content_different_hash(self):
+        r1 = {
+            "record_id": "test_case:abc123",
+            "source_file": "tests/unit/test.py",
+            "test_id": "tc-001",
+            "test_type": "bauteil",
+            "surrealdb_export": True,
+        }
+        r2 = {
+            "record_id": "test_case:def456",
+            "source_file": "tests/unit/test.py",
+            "test_id": "tc-002",
+            "test_type": "schutz",
+            "surrealdb_export": True,
+        }
+        assert _build_content_hash(r1) != _build_content_hash(r2)
+
+    def test_record_id_excluded_from_hash(self):
+        record = {
+            "record_id": "test_case:abc123",
+            "source_file": "tests/unit/test.py",
+            "test_id": "tc-001",
+            "surrealdb_export": True,
+        }
+        h1 = _build_content_hash(record)
+        record["record_id"] = "test_case:xyz999"
+        h2 = _build_content_hash(record)
+        assert h1 == h2
+
+
+# ---------------------------------------------------------------------------
+# _build_record
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRecord:
+    def test_basic_record_structure(self):
+        block = EXPORT_BLOCK["blocks"][0]
+        record = _build_record("tests/unit/validation/test_profitability_evidence_packet_assembler.py", block)
+
+        assert record["schema_version"] == SCHEMA_VERSION
+        assert record["record_type"] == RECORD_TYPE
+        assert record["source_file"] == "tests/unit/validation/test_profitability_evidence_packet_assembler.py"
+        assert record["pilot_id"] == "CDB-PILOT-001"
+        assert record["test_id"] == "cdb-test-pilot-001"
+        assert record["test_type"] == "mixed"
+        assert record["ci_artifact"] == "test-report"
+        assert record["surrealdb_export"] is True
+        assert record["source_scanner"] == SOURCE_SCANNER
+        assert record["limitations"] == []
+
+        assert record["record_id"].startswith("test_case:")
+        assert len(record["content_hash"]) == 64
+
+    def test_metadata_contains_all_fields(self):
+        block = EXPORT_BLOCK["blocks"][0]
+        record = _build_record("tests/unit/test.py", block)
+        for key in block["fields"]:
+            assert record["metadata"][key] == block["fields"][key]
+
+    def test_deterministic_build(self):
+        block = EXPORT_BLOCK["blocks"][0]
+        r1 = _build_record("tests/unit/test.py", block)
+        r2 = _build_record("tests/unit/test.py", block)
+        assert r1 == r2
+
+    def test_record_id_is_stable(self):
+        block = EXPORT_BLOCK["blocks"][0]
+        source_file = "tests/unit/validation/test_profitability_evidence_packet_assembler.py"
+        r1 = _build_record(source_file, block)
+        r2 = _build_record(source_file, block)
+        assert r1["record_id"] == r2["record_id"]
+
+    def test_non_pilot_block_has_empty_pilot_id(self):
+        block = NO_EXPORT_BLOCK["blocks"][0]
+        record = _build_record("tests/unit/test.py", block)
+        assert record["pilot_id"] == ""
+
+
+# ---------------------------------------------------------------------------
+# load_scanner_report
+# ---------------------------------------------------------------------------
+
+
+class TestLoadScannerReport:
+    def test_valid_report(self):
+        raw = json.dumps(VALID_SCANNER_REPORT)
+        report = load_scanner_report(raw)
+        assert report["scanner_version"] == "1.0.0"
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(ValueError, match="Invalid scanner JSON"):
+            load_scanner_report("not json")
+
+    def test_non_dict_raises(self):
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            load_scanner_report("[]")
+
+    def test_missing_results_raises(self):
+        with pytest.raises(ValueError, match="missing 'results'"):
+            load_scanner_report('{"scanner_version": "1.0.0"}')
+
+
+# ---------------------------------------------------------------------------
+# build_bundle
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBundle:
+    def test_exportable_block_included(self):
+        report = {
+            "scanner_version": "1.0.0",
+            "scanned_files": 1,
+            "total_blocks": 1,
+            "total_errors": 0,
+            "surrealdb_export_ready": 1,
+            "results": [EXPORT_BLOCK],
+        }
+        records = build_bundle(report)
+        assert len(records) == 1
+        assert records[0]["test_id"] == "cdb-test-pilot-001"
+
+    def test_no_export_excluded(self):
+        report = {
+            "scanner_version": "1.0.0",
+            "scanned_files": 2,
+            "total_blocks": 2,
+            "total_errors": 0,
+            "surrealdb_export_ready": 1,
+            "results": [EXPORT_BLOCK, NO_EXPORT_BLOCK],
+        }
+        records = build_bundle(report)
+        assert len(records) == 1
+
+    def test_invalid_block_excluded(self):
+        report = {
+            "scanner_version": "1.0.0",
+            "scanned_files": 2,
+            "total_blocks": 2,
+            "total_errors": 1,
+            "surrealdb_export_ready": 0,
+            "results": [EXPORT_BLOCK, INVALID_BLOCK],
+        }
+        records = build_bundle(report)
+        assert len(records) == 1
+
+    def test_all_excluded_returns_empty(self):
+        report = {
+            "scanner_version": "1.0.0",
+            "scanned_files": 1,
+            "total_blocks": 1,
+            "total_errors": 0,
+            "surrealdb_export_ready": 0,
+            "results": [NO_EXPORT_BLOCK],
+        }
+        records = build_bundle(report)
+        assert len(records) == 0
+
+    def test_absolute_path_result_skipped(self):
+        report = {
+            "scanner_version": "1.0.0",
+            "scanned_files": 2,
+            "total_blocks": 2,
+            "total_errors": 0,
+            "surrealdb_export_ready": 1,
+            "results": [ABSOLUTE_PATH_RESULT, EXPORT_BLOCK],
+        }
+        records = build_bundle(report)
+        assert len(records) == 1
+        assert records[0]["source_file"] == EXPORT_BLOCK["file"]
+
+    def test_empty_report(self):
+        report = {
+            "scanner_version": "1.0.0",
+            "scanned_files": 0,
+            "total_blocks": 0,
+            "total_errors": 0,
+            "surrealdb_export_ready": 0,
+            "results": [],
+        }
+        records = build_bundle(report)
+        assert len(records) == 0
+
+    def test_deterministic_order(self):
+        report = {
+            "scanner_version": "1.0.0",
+            "scanned_files": 2,
+            "total_blocks": 2,
+            "total_errors": 0,
+            "surrealdb_export_ready": 2,
+            "results": [NO_EXPORT_BLOCK, EXPORT_BLOCK],
+        }
+        records = build_bundle(report)
+        assert len(records) == 1
+
+    def test_maintains_ci_artifact_as_string(self):
+        report = {
+            "scanner_version": "1.0.0",
+            "scanned_files": 1,
+            "total_blocks": 1,
+            "total_errors": 0,
+            "surrealdb_export_ready": 1,
+            "results": [EXPORT_BLOCK],
+        }
+        records = build_bundle(report)
+        assert isinstance(records[0]["ci_artifact"], str)
+        assert records[0]["ci_artifact"] == "test-report"
+
+
+# ---------------------------------------------------------------------------
+# validate_records
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRecords:
+    def test_no_errors_for_valid_records(self):
+        records = build_bundle(VALID_SCANNER_REPORT)
+        errors = validate_records(records)
+        assert errors == []
+
+    def test_duplicate_record_id_detected(self):
+        records = [
+            {"record_id": "test_case:dup", "source_file": "a.py"},
+            {"record_id": "test_case:dup", "source_file": "b.py"},
+        ]
+        errors = validate_records(records)
+        assert len(errors) == 1
+        assert "duplicate" in errors[0]
+
+    def test_empty_records_no_errors(self):
+        errors = validate_records([])
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# write_bundle
+# ---------------------------------------------------------------------------
+
+
+class TestWriteBundle:
+    def test_bundle_has_required_keys(self):
+        records = build_bundle(VALID_SCANNER_REPORT)
+        bundle = json.loads(write_bundle(records))
+        assert bundle["schema_version"] == SCHEMA_VERSION
+        assert bundle["source_scanner"] == SOURCE_SCANNER
+        assert bundle["record_count"] == 1
+        assert len(bundle["records"]) == 1
+
+    def test_empty_records(self):
+        bundle = json.loads(write_bundle([]))
+        assert bundle["record_count"] == 0
+        assert bundle["records"] == []
+
+    def test_valid_json_output(self):
+        records = build_bundle(VALID_SCANNER_REPORT)
+        raw = write_bundle(records)
+        data = json.loads(raw)
+        assert isinstance(data, dict)
+
+
+# ---------------------------------------------------------------------------
+# run() integration
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    def test_stdin_no_data(self, monkeypatch):
+        monkeypatch.setattr("sys.stdin.read", lambda: "")
+        code = run([])
+        assert code == 2
+
+    def test_valid_file_returns_zero(self):
+        path = _write_tmp_json(VALID_SCANNER_REPORT)
+        try:
+            code = run([str(path)])
+            assert code == 0
+        finally:
+            os.unlink(str(path))
+
+    def test_output_file(self):
+        path = _write_tmp_json(VALID_SCANNER_REPORT)
+        out_path_obj = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
+        out_path = out_path_obj.name
+        out_path_obj.close()
+        try:
+            code = run([str(path), "--output", out_path])
+            assert code == 0
+            with open(out_path, encoding="utf-8") as f:
+                data = json.load(f)
+            assert data["record_count"] == 1
+        finally:
+            os.unlink(str(path))
+            os.unlink(out_path)
+
+    def test_no_exportable_blocks_returns_one(self):
+        report = {
+            "scanner_version": "1.0.0",
+            "scanned_files": 1,
+            "total_blocks": 1,
+            "total_errors": 0,
+            "surrealdb_export_ready": 0,
+            "results": [NO_EXPORT_BLOCK],
+        }
+        path = _write_tmp_json(report)
+        try:
+            code = run([str(path)])
+            assert code == 1
+        finally:
+            os.unlink(str(path))
+
+    def test_nonexistent_file_returns_two(self):
+        code = run(["nonexistent_file_xyz.json"])
+        assert code == 2
+
+    def test_malformed_json_returns_two(self):
+        fd, path = tempfile.mkstemp(suffix=".json", text=True)
+        os.write(fd, b"not json at all")
+        os.close(fd)
+        try:
+            code = run([str(path)])
+            assert code == 2
+        finally:
+            os.unlink(path)
+
+    def test_standard_input_pipe(self, monkeypatch):
+        path = _write_tmp_json(VALID_SCANNER_REPORT)
+        try:
+            with open(str(path), encoding="utf-8") as f:
+                content = f.read()
+            monkeypatch.setattr("sys.stdin.read", lambda: content)
+            code = run(["-"])
+            assert code == 0
+        finally:
+            os.unlink(str(path))

--- a/tools/test_metadata_import_bundle.py
+++ b/tools/test_metadata_import_bundle.py
@@ -1,0 +1,235 @@
+"""CDB Test-First Metadata Import Bundle Builder (read-only).
+
+Transforms scanner JSON output into a deterministic, SurrealDB-ready
+import bundle. Only blocks with is_valid=true and surrealdb_export=true
+are included.
+
+This tool is read-only: it never connects to SurrealDB, never executes
+SurrealQL, and never opens a database connection.
+
+Usage:
+    python -m tools.test_metadata_import_bundle <scanner-report.json>
+    python -m tools.test_metadata_import_bundle --stdin < scanner-report.json
+    python -m tools.test_metadata_import_bundle --output <bundle.json> <scanner-report.json>
+
+Exit codes:
+    0 - valid bundle produced
+    1 - no exportable blocks or validation errors
+    2 - parse / usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from core.replay.canonical_json import canonical_hash
+
+SCHEMA_VERSION = "test-metadata-import-bundle/v1"
+SOURCE_SCANNER = "test_metadata_scanner/v1.0.0"
+RECORD_TYPE = "test_case"
+
+PILOT_ID_RE = re.compile(r"cdb-test-pilot-(\d+)", re.IGNORECASE)
+ABSOLUTE_PATH_RE = re.compile(r"^[a-zA-Z]:[/\\]|^/")
+
+
+def _derive_pilot_id(test_id: str) -> str:
+    m = PILOT_ID_RE.match(test_id)
+    if m:
+        return f"CDB-PILOT-{m.group(1)}"
+    return ""
+
+
+def _to_relpath_posix(file_value: str) -> str:
+    cleaned = file_value.strip().replace("\\", "/")
+    if ABSOLUTE_PATH_RE.match(cleaned):
+        raise ValueError(f"Absolute path rejected: {file_value}")
+    return cleaned
+
+
+def _build_record_id(source_file: str, test_id: str) -> str:
+    stable_input = f"{source_file}|{test_id}"
+    h = canonical_hash(stable_input)
+    return f"{RECORD_TYPE}:{h[:24]}"
+
+
+def _build_content_hash(record: dict[str, Any]) -> str:
+    hash_payload = {
+        k: v for k, v in record.items()
+        if k not in ("record_id", "content_hash")
+    }
+    return canonical_hash(hash_payload)
+
+
+def _build_record(source_file: str, block: dict[str, Any]) -> dict[str, Any]:
+    fields: dict[str, Any] = block.get("fields", {})
+    test_id: str = fields.get("test_id", "")
+    test_type: str = fields.get("test_type", "")
+    ci_artifact: str = fields.get("ci_artifact", "")
+    pilot_id: str = _derive_pilot_id(test_id)
+
+    record = {
+        "schema_version": SCHEMA_VERSION,
+        "record_type": RECORD_TYPE,
+        "source_file": source_file,
+        "pilot_id": pilot_id,
+        "test_id": test_id,
+        "test_type": test_type,
+        "ci_artifact": ci_artifact,
+        "surrealdb_export": True,
+        "metadata": dict(fields),
+        "source_scanner": SOURCE_SCANNER,
+        "limitations": [],
+    }
+
+    record["record_id"] = _build_record_id(source_file, test_id)
+    record["content_hash"] = _build_content_hash(record)
+
+    return record
+
+
+def load_scanner_report(input_data: str) -> dict[str, Any]:
+    try:
+        report = json.loads(input_data)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid scanner JSON: {exc}") from exc
+
+    if not isinstance(report, dict):
+        raise ValueError("Scanner report must be a JSON object")
+
+    results = report.get("results")
+    if not isinstance(results, list):
+        raise ValueError("Scanner report missing 'results' list")
+
+    return report
+
+
+def build_bundle(report: dict[str, Any]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = report.get("results", [])
+
+    for result in results:
+        source_file: str = result.get("file", "")
+        try:
+            source_file = _to_relpath_posix(source_file)
+        except ValueError:
+            continue
+
+        blocks: list[dict[str, Any]] = result.get("blocks", [])
+        for block in blocks:
+            is_valid: bool = block.get("is_valid", False)
+            surrealdb_export: bool = block.get("surrealdb_export", False)
+            if is_valid and surrealdb_export:
+                try:
+                    record = _build_record(source_file, block)
+                    records.append(record)
+                except (ValueError, KeyError):
+                    continue
+
+    records.sort(key=lambda r: (r.get("source_file", ""), r.get("test_id", ""), r.get("record_id", "")))
+
+    return records
+
+
+def validate_records(records: list[dict[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    seen_record_ids: set[str] = set()
+
+    for i, record in enumerate(records):
+        rid = record.get("record_id", "")
+        if rid in seen_record_ids:
+            errors.append(f"records[{i}]: duplicate record_id: {rid}")
+        seen_record_ids.add(rid)
+
+        source_file = record.get("source_file", "")
+        if ABSOLUTE_PATH_RE.match(source_file.replace("\\", "/")):
+            errors.append(f"records[{i}]: absolute path in source_file: {source_file}")
+
+    return errors
+
+
+def write_bundle(records: list[dict[str, Any]]) -> str:
+    bundle = {
+        "schema_version": SCHEMA_VERSION,
+        "source_scanner": SOURCE_SCANNER,
+        "record_count": len(records),
+        "records": records,
+    }
+    return json.dumps(bundle, indent=2, ensure_ascii=False, sort_keys=True)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="CDB Test-First Metadata Import Bundle Builder (read-only)",
+    )
+    parser.add_argument(
+        "input",
+        nargs="?",
+        default="-",
+        help="Scanner JSON file path, or '-' for stdin (default: '-')",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Write bundle JSON to file (default: stdout)",
+    )
+    return parser.parse_args(argv)
+
+
+def run(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.input == "-":
+        input_data = sys.stdin.read()
+    else:
+        input_path = Path(args.input)
+        if not input_path.is_file():
+            print(f"Error: file not found: {args.input}", file=sys.stderr)
+            return 2
+        try:
+            input_data = input_path.read_text(encoding="utf-8")
+        except Exception as exc:
+            print(f"Error: cannot read input: {exc}", file=sys.stderr)
+            return 2
+
+    try:
+        report = load_scanner_report(input_data)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    records = build_bundle(report)
+
+    if not records:
+        print("No exportable blocks found.", file=sys.stderr)
+        return 1
+
+    errors = validate_records(records)
+    if errors:
+        for err in errors:
+            print(f"Validation error: {err}", file=sys.stderr)
+        return 1
+
+    output = write_bundle(records)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(output, encoding="utf-8")
+    else:
+        print(output)
+
+    return 0
+
+
+def main() -> None:
+    sys.exit(run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a read-only Import-Bundle-Builder that transforms scanner JSON into a deterministic, SurrealDB-ready import bundle.

## Changes

- \	ools/test_metadata_import_bundle.py\ — new CLI tool: reads scanner report, filters \is_valid && surrealdb_export\, builds deterministic test_case records
- \	ests/unit/tools/test_test_metadata_import_bundle.py\ — 50 unit tests covering all filters, determinism, path safety, exit codes
- \knowledge/testing/README.md\ — added builder section with usage and contract
- \.gitignore\ — allow \	ools/test_metadata_import_bundle.py\ (was blocked by \*test*.py\ wildcard)

## Key Design Decisions

- \ecord_type: test_case\ aligned with TEST_FIRST_PROCESSING_CONTRACT.md
- \ecord_id\ deterministic from \source_file + test_id\ (stable across metadata updates)
- \content_hash\ via \canonical_hash()\ from core/replay/canonical_json.py
- \pilot_id\ derived from \cdb-test-pilot-NNN\ pattern
- Fail-closed on absolute paths (drive letters, /root), backslash-normalized to POSIX
- No SurrealDB write, no SurrealQL execute, no DB/MCP/Docker/runtime scope

## Validation

- \uff check .\ — clean
- \pytest tests/unit/tools/test_test_metadata_import_bundle.py\ — 50 passed
- \pytest tests/unit/tools/test_test_metadata_scanner.py\ — 33 passed (no regression)
- Scanner-to-builder end-to-end pipeline verified against actual PILOT-001 block

## Rest Unsicherheiten

- \pilot_id\ extraction relies on \cdb-test-pilot-NNN\ naming convention; blocks outside this pattern get empty \pilot_id\ (limitation documented in bundle record)
- No SurrealDB import test exists yet (out of scope — this slice is read-only bundle only)
- \	est_title\ kept unchanged inside \metadata\; no \	est_name\ migration