### PR TITLE
feat(tools): SurrealDB Import Contract v1 + dry-run plan builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # policy drift is cleaned up separately.
 # Block ad-hoc test files in root/services
 *test*.py
+!test_metadata_surrealdb_import_plan.py
 *test*.js
 # Allow official test suite in tests/ directory (must come AFTER wildcard)
 !tests/**/*.py

--- a/knowledge/testing/README.md
+++ b/knowledge/testing/README.md
@@ -90,6 +90,49 @@ python -m tools.test_metadata_scanner tests/ | python -m tools.test_metadata_imp
 **Path-Sicherheit:** Absolute Pfade (Windows-Laufwerkbuchstabe oder führender
 Schrägstrich) werden fail-closed abgelehnt.
 
+## Import Plan Builder
+
+`tools/test_metadata_surrealdb_import_plan.py` — read-only, dry-run SurrealDB Import Plan Builder.
+
+**Zweck:** Übersetzt ein Import-Bundle v1 in einen deterministischen Dry-Run-Import-Plan.
+Der Plan beschreibt `test_case:*`-Ziel-Datensätze, schreibt aber **nie nach SurrealDB**.
+Kein DB-Connector, kein SurrealQL, keine MCP-Abhängigkeit.
+
+**Plan-Format:**
+- `plan_type: upsert_dry_run`
+- `dry_run: true`, `surrealdb_write: false`
+- Jede Operation enthält `target_table`, `target_id`, `record` (Payload),
+  `content_hash`, `source_bundle_record_id`, `limitations`
+- `bundle_fingerprint` per SHA-256 zur Plan-Identifikation
+- Warnungen bei fehlendem `pilot_id` oder Vertragsverletzungen
+
+**Nutzung:**
+```bash
+# Pipe aus Bundle-Builder
+python -m tools.test_metadata_import_bundle artifacts/scanner-report.json | python -m tools.test_metadata_surrealdb_import_plan -
+
+# Datei
+python -m tools.test_metadata_surrealdb_import_plan artifacts/import-bundle.json --output artifacts/import-plan.json
+
+# Bundle direkt
+python -m tools.test_metadata_surrealdb_import_plan artifacts/import-bundle.json
+```
+
+**Exit-Codes:**
+- 0: valider Dry-Run-Plan erzeugt
+- 1: keine importierbaren Records oder Contract-Validation-Fehler
+- 2: Parse-/Usage-Fehler
+
+**Safety Gates:**
+- Absolutpfade werden fail-closed blockiert
+- `ci_artifact` muss String sein (kein Bool)
+- Fehlende Pflichtfelder werden mit Warning ausgeschlossen
+- `pilot_id` ausserhalb des `cdb-test-pilot-NNN`-Patterns erzeugt Warning
+  und Eintrag in `limitations`
+
+**Contract:** Siehe `TEST_METADATA_SURREALDB_IMPORT_CONTRACT.md` für das vollständige
+Contract-Dokument.
+
 ## Guardrail
 
 Testing knowledge does not authorize runtime, Docker, exchange, database, or

--- a/knowledge/testing/TEST_METADATA_SURREALDB_IMPORT_CONTRACT.md
+++ b/knowledge/testing/TEST_METADATA_SURREALDB_IMPORT_CONTRACT.md
@@ -1,0 +1,281 @@
+# Test-Metadata SurrealDB Import Contract v1
+
+**Status:** active contract
+**Scope:** Test-First Metadata SurrealDB dry-run import planning
+**Date:** 2026-06-23
+**Predecessors:** PR #3409 (Scanner), PR #3415 (Import Bundle), PR #3416 (Ledger)
+
+---
+
+## 1. Purpose
+
+This contract defines the deterministic translation of a Test-First Metadata
+Import Bundle (v1) into a SurrealDB-ready dry-run Import Plan (v1). The plan
+describes `test_case:*` target records but **never writes to SurrealDB**.
+
+The contract bridges two read-only tools:
+- **Scanner** (`tools/test_metadata_scanner.py`) — finds and validates metadata blocks in Python test files
+- **Bundle Builder** (`tools/test_metadata_import_bundle.py`) — transforms scanner output into deterministic import bundle records
+- **Import Plan Builder** (`tools/test_metadata_surrealdb_import_plan.py`) — translates bundle records into a SurrealDB dry-run import plan
+
+A future real Import Adapter (separate gate slice) will consume the plan and
+execute actual SurrealDB writes.
+
+---
+
+## 2. Scope
+
+### 2.1 In Scope
+
+- Translation of Import Bundle v1 records to import plan operations
+- Deterministic sorting of plan operations
+- Validation of bundle contract (required fields, path safety, hash integrity)
+- Dry-run only — no SurrealDB connection, no SurrealQL execution
+- Explicit limitation documentation for unresolvable fields (e.g. missing `pilot_id`)
+
+### 2.2 Out of Scope
+
+- SurrealDB connection or write of any kind
+- SurrealQL execution or `.surql` file generation as primary output
+- Real import adapter or apply pipeline
+- Database migrations or schema changes
+- MCP tool changes or MCP write paths
+- Runtime / Docker / Secrets / Exchange scope
+- `test_title` to `test_name` migration
+- Live or Echtgeld trading readiness
+
+---
+
+## 3. Input: Import Bundle v1
+
+The plan builder consumes output from `tools/test_metadata_import_bundle.py`.
+
+### 3.1 Bundle Envelope
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `schema_version` | string | yes | `test-metadata-import-bundle/v1` |
+| `source_scanner` | string | yes | `test_metadata_scanner/v1.0.0` |
+| `record_count` | int | yes | Number of records |
+| `records` | array | yes | Array of record objects |
+
+### 3.2 Bundle Record
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `schema_version` | string | yes | Bundle schema version |
+| `record_type` | string | yes | `test_case` |
+| `record_id` | string | yes | `test_case:<24-char-hex>` from `source_file + test_id` |
+| `source_file` | string | yes | Relative POSIX path to test file |
+| `pilot_id` | string | yes | `CDB-PILOT-NNN` or empty string |
+| `test_id` | string | yes | Unique test identifier |
+| `test_type` | string | yes | One of the 15 test types |
+| `ci_artifact` | string | yes | CI artifact type (e.g. `test-report`) |
+| `surrealdb_export` | bool | yes | `true` for all exported records |
+| `metadata` | object | yes | Full scanner output fields (unchanged) |
+| `content_hash` | string | yes | SHA-256 hex via `canonical_hash()` |
+| `source_scanner` | string | yes | Scanner version |
+| `limitations` | array | yes | Known limitation strings |
+
+---
+
+## 4. Output: Dry-run Import Plan v1
+
+### 4.1 Plan Envelope
+
+```json
+{
+  "schema_version": "test-metadata-surrealdb-import-plan/v1",
+  "source_bundle_schema": "test-metadata-import-bundle/v1",
+  "plan_type": "upsert_dry_run",
+  "operation_count": 1,
+  "dry_run": true,
+  "surrealdb_write": false,
+  "warnings": [],
+  "limitations": [],
+  "operations": [
+    {
+      "operation": "upsert_dry_run",
+      "target_table": "test_case",
+      "target_id": "test_case:f7cbdae5b69b6355575cf520",
+      "record": {
+        "source_file": "tests/unit/validation/test_profitability_evidence_packet_assembler.py",
+        "pilot_id": "CDB-PILOT-001",
+        "test_id": "cdb-test-pilot-001",
+        "test_type": "mixed",
+        "ci_artifact": "test-report",
+        "surrealdb_export": true
+      },
+      "content_hash": "9cb810756e8cb05f5ebe62352517cc23c98797294a6a8a26c374efc03676b574",
+      "source_bundle_record_id": "test_case:f7cbdae5b69b6355575cf520",
+      "limitations": []
+    }
+  ]
+}
+```
+
+### 4.2 Operation Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `operation` | string | yes | `upsert_dry_run` (the only operation type in v1) |
+| `target_table` | string | yes | `test_case` |
+| `target_id` | string | yes | `test_case:<stable_id>` — matches `record_id` from bundle |
+| `record` | object | yes | The actual record payload (fields for DB write) |
+| `content_hash` | string | yes | Stable content hash from bundle |
+| `source_bundle_record_id` | string | yes | Echo of the source bundle's `record_id` |
+| `limitations` | array | yes | Per-operation limitations |
+
+### 4.3 Record Subset in Operation
+
+The `record` object in each operation contains only the fields relevant to a
+SurrealDB `test_case:*` record:
+
+- `source_file` (string, relative POSIX path)
+- `pilot_id` (string, may be empty)
+- `test_id` (string)
+- `test_type` (string)
+- `ci_artifact` (string, never bool)
+- `surrealdb_export` (bool, always `true`)
+- All fields from `metadata`
+
+**Excluded from `record` (present in bundle but not in import target):**
+- `schema_version` — bundle metadata, not a DB field
+- `record_type` — expressed by `target_table` + `target_id`
+- `record_id` — expressed by `target_id`
+- `content_hash` — expressed at operation level
+- `source_scanner` — bundle provenance, not a DB field
+- `limitations` — expressed at operation level
+
+### 4.4 Warnings
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `code` | string | Machine-readable code (e.g. `empty_pilot_id`) |
+| `message` | string | Human-readable explanation |
+| `target_id` | string | Optional affected target ID |
+
+---
+
+## 5. Validation Rules
+
+### 5.1 Bundle Validation
+
+| Check | Fail Behaviour |
+|-------|---------------|
+| Invalid JSON | Exit 2 |
+| Missing `records` key | Exit 2 |
+| Empty `records` array | Exit 1 |
+| Record missing `record_id` | Exit 1 |
+| Record missing `content_hash` | Exit 1 |
+| Record missing `test_id` | Exit 1 |
+| Record missing `ci_artifact` | Exit 1 |
+| Record missing `surrealdb_export` | Exit 1 |
+| `ci_artifact` is not a string | Exit 1 (must be string, never bool) |
+| `source_file` contains absolute path | Exit 1 |
+| `record_id` does not start with `test_case:` | Warning (not blocking in v1) |
+
+### 5.2 Hash Determinism
+
+- `content_hash` is computed via `canonical_hash()` from `core/replay/canonical_json.py`.
+- The hash input excludes `record_id` and `content_hash` itself.
+- Records with identical content produce identical `content_hash` values.
+- `content_hash` passes through from the bundle; the plan builder does **not**
+  recompute it.
+
+### 5.3 Path Safety
+
+- `source_file` must be a relative POSIX path.
+- Windows drive letters (`C:\`, `D:/`) and Unix absolute paths (`/root/...`) are
+  rejected fail-closed.
+- Backslashes are normalized to forward slashes before validation.
+
+### 5.4 pilot_id Limitation
+
+- `pilot_id` is derived from the `cdb-test-pilot-NNN` naming convention.
+- If `pilot_id` is empty, a warning `empty_pilot_id` is emitted and
+  `"pilot_id: not derivable from test_id (expected cdb-test-pilot-NNN pattern)"`
+  is added to `limitations`.
+
+### 5.5 Forbidden Content
+
+- No secrets or credentials (no `token`, `password`, `secret` key patterns in output)
+- No absolute paths
+- No SurrealDB connection parameters
+- No database target addresses
+- No write authorization flags
+
+---
+
+## 6. Determinism Rules
+
+| Aspect | Rule |
+|--------|------|
+| Record order | Sort by `(source_file, test_id, record_id)` — same as bundle |
+| Operation order | Same order as sorted records |
+| `content_hash` | Passed through from bundle (not recomputed) |
+| `record` content | Sorted keys via `json.dumps(sort_keys=True)` |
+| Bundle fingerprint | SHA-256 of `source_bundle_schema + "," + sorted(target_ids)` |
+
+---
+
+## 7. Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Valid dry-run plan produced |
+| 1 | No importable records or contract validation error |
+| 2 | Parse / usage error (invalid JSON, missing file, bad arguments) |
+
+---
+
+## 8. Safety Boundaries
+
+- **No SurrealDB write.** The plan sets `"surrealdb_write": false` and
+  `"dry_run": true`. Any future adapter must check these flags fail-closed.
+- **No SurrealQL.** The plan builder never imports or calls SurrealQL code.
+- **No DB connector.** The plan builder never imports `surrealdb` or
+  `psycopg2` or any DB library.
+- **No MCP.** The plan builder is a pure CLI tool with no MCP dependencies.
+- **No Runtime/Docker/Secrets.** The plan builder does not start services,
+  access secrets, or open network connections.
+- **No Live/Echtgeld.** LR remains NO-GO. Board `trade-capable` is not a live
+  trading authorization.
+
+---
+
+## 9. Pipeline Summary
+
+```
+Python test file
+    │
+    ▼
+tools/test_metadata_scanner.py  (read-only)
+    │  finds metadata blocks, validates 15 fields, outputs JSON report
+    ▼
+Scanner JSON report
+    │
+    ▼
+tools/test_metadata_import_bundle.py  (read-only)
+    │  filters is_valid + surrealdb_export, builds deterministic records
+    ▼
+Import Bundle v1
+    │
+    ▼
+tools/test_metadata_surrealdb_import_plan.py  (read-only, dry-run)
+    │  translates records to planned operations, no DB write
+    ▼
+Import Plan v1  ──►  Future: SurrealDB Import Adapter (gate slice)
+```
+
+---
+
+## 10. Limitations
+
+- `pilot_id` relies on `cdb-test-pilot-NNN` naming convention. Blocks outside
+  this pattern get empty `pilot_id` with a warning.
+- The plan describes `test_case:*` records only. Relation edges
+  (`prueft`, `betrifft`, `gehoert_zu`, etc.) are not part of v1.
+- No existing-records reconciliation (diff against current DB state) — this
+  would require a real SurrealDB connection and is deferred.
+- `test_title` remains inside `metadata`; no `test_name` field migration.

--- a/tests/unit/tools/test_test_metadata_surrealdb_import_plan.py
+++ b/tests/unit/tools/test_test_metadata_surrealdb_import_plan.py
@@ -1,0 +1,510 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tools.test_metadata_surrealdb_import_plan import (
+    PLAN_SCHEMA_VERSION,
+    BUNDLE_SCHEMA_VERSION,
+    PLAN_TYPE,
+    TARGET_TABLE,
+    _check_absolute_path,
+    _build_operation,
+    load_bundle,
+    validate_bundle_record,
+    build_plan,
+    write_plan,
+    run,
+)
+
+VALID_RECORD = {
+    "schema_version": "test-metadata-import-bundle/v1",
+    "record_type": "test_case",
+    "record_id": "test_case:f7cbdae5b69b6355575cf520",
+    "source_file": "tests/unit/validation/test_profitability_evidence_packet_assembler.py",
+    "pilot_id": "CDB-PILOT-001",
+    "test_id": "cdb-test-pilot-001",
+    "test_type": "mixed",
+    "ci_artifact": "test-report",
+    "surrealdb_export": True,
+    "content_hash": "9cb810756e8cb05f5ebe62352517cc23c98797294a6a8a26c374efc03676b574",
+    "source_scanner": "test_metadata_scanner/v1.0.0",
+    "limitations": [],
+    "metadata": {
+        "test_title": "Profitability Evidence Packet Assembler",
+        "test_type": "mixed",
+        "cdb_area": "validation",
+    },
+}
+
+VALID_BUNDLE = {
+    "schema_version": "test-metadata-import-bundle/v1",
+    "source_scanner": "test_metadata_scanner/v1.0.0",
+    "record_count": 1,
+    "records": [VALID_RECORD],
+}
+
+VALID_RECORD_NO_PILOT = {
+    "schema_version": "test-metadata-import-bundle/v1",
+    "record_type": "test_case",
+    "record_id": "test_case:abc123def4567890abcdef12",
+    "source_file": "tests/unit/risk/test_drawdown.py",
+    "pilot_id": "",
+    "test_id": "tc-drawdown-001",
+    "test_type": "schutz",
+    "ci_artifact": "test-report",
+    "surrealdb_export": True,
+    "content_hash": "a" * 64,
+    "source_scanner": "test_metadata_scanner/v1.0.0",
+    "limitations": [],
+    "metadata": {
+        "test_title": "Drawdown Limit Test",
+    },
+}
+
+VALID_RECORD_WITH_LIMITATION = {
+    "schema_version": "test-metadata-import-bundle/v1",
+    "record_type": "test_case",
+    "record_id": "test_case:def4567890abcdef12345678",
+    "source_file": "tests/unit/risk/test_variance.py",
+    "pilot_id": "CDB-PILOT-002",
+    "test_id": "cdb-test-pilot-002",
+    "test_type": "bauteil",
+    "ci_artifact": "test-report",
+    "surrealdb_export": True,
+    "content_hash": "b" * 64,
+    "source_scanner": "test_metadata_scanner/v1.0.0",
+    "limitations": ["some-known-limitation"],
+    "metadata": {
+        "test_title": "Variance Test",
+    },
+}
+
+
+def _write_tmp_json(content: dict) -> Path:
+    fd, path = tempfile.mkstemp(suffix=".json", text=True)
+    os.write(fd, json.dumps(content, indent=2).encode("utf-8"))
+    os.close(fd)
+    return Path(path)
+
+
+# ---------------------------------------------------------------------------
+# _check_absolute_path
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAbsolutePath:
+    def test_relative_path_false(self):
+        assert _check_absolute_path("tests/unit/test.py") is False
+
+    def test_windows_drive_letter_true(self):
+        assert _check_absolute_path("C:\\Users\\test\\file.py") is True
+
+    def test_windows_forward_slash_drive_true(self):
+        assert _check_absolute_path("C:/Users/test/file.py") is True
+
+    def test_unix_absolute_true(self):
+        assert _check_absolute_path("/home/user/file.py") is True
+
+    def test_backslash_normalized(self):
+        assert _check_absolute_path("C:\\Projects\\test.py") is True
+
+    def test_empty_string_false(self):
+        assert _check_absolute_path("") is False
+
+    def test_basename_false(self):
+        assert _check_absolute_path("test_risk.py") is False
+
+
+# ---------------------------------------------------------------------------
+# load_bundle
+# ---------------------------------------------------------------------------
+
+
+class TestLoadBundle:
+    def test_valid_bundle(self):
+        raw = json.dumps(VALID_BUNDLE)
+        bundle = load_bundle(raw)
+        assert bundle["schema_version"] == "test-metadata-import-bundle/v1"
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(ValueError, match="Invalid bundle JSON"):
+            load_bundle("not json")
+
+    def test_non_dict_raises(self):
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            load_bundle("[]")
+
+    def test_missing_records_raises(self):
+        with pytest.raises(ValueError, match="missing 'records'"):
+            load_bundle('{"schema_version": "v1"}')
+
+
+# ---------------------------------------------------------------------------
+# validate_bundle_record
+# ---------------------------------------------------------------------------
+
+
+class TestValidateBundleRecord:
+    def test_valid_record_no_errors(self):
+        errors = validate_bundle_record(VALID_RECORD)
+        assert errors == []
+
+    def test_missing_record_id(self):
+        record = dict(VALID_RECORD)
+        del record["record_id"]
+        errors = validate_bundle_record(record)
+        assert any("record_id" in e for e in errors)
+
+    def test_missing_content_hash(self):
+        record = dict(VALID_RECORD)
+        del record["content_hash"]
+        errors = validate_bundle_record(record)
+        assert any("content_hash" in e for e in errors)
+
+    def test_missing_test_id(self):
+        record = dict(VALID_RECORD)
+        del record["test_id"]
+        errors = validate_bundle_record(record)
+        assert any("test_id" in e for e in errors)
+
+    def test_missing_ci_artifact(self):
+        record = dict(VALID_RECORD)
+        del record["ci_artifact"]
+        errors = validate_bundle_record(record)
+        assert any("ci_artifact" in e for e in errors)
+
+    def test_missing_surrealdb_export(self):
+        record = dict(VALID_RECORD)
+        del record["surrealdb_export"]
+        errors = validate_bundle_record(record)
+        assert any("surrealdb_export" in e for e in errors)
+
+    def test_ci_artifact_bool_rejected(self):
+        record = dict(VALID_RECORD)
+        record["ci_artifact"] = True
+        errors = validate_bundle_record(record)
+        assert any("must be a string" in e for e in errors)
+
+    def test_absolute_source_file_detected(self):
+        record = dict(VALID_RECORD)
+        record["source_file"] = "C:/Users/test/file.py"
+        errors = validate_bundle_record(record)
+        assert any("Absolute path" in e for e in errors)
+
+    def test_multiple_errors_returned(self):
+        record = {}
+        errors = validate_bundle_record(record)
+        assert len(errors) >= 5
+
+
+# ---------------------------------------------------------------------------
+# _build_operation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildOperation:
+    def test_operation_structure(self):
+        op = _build_operation(VALID_RECORD)
+        assert op["operation"] == PLAN_TYPE
+        assert op["target_table"] == TARGET_TABLE
+        assert op["target_id"] == "test_case:f7cbdae5b69b6355575cf520"
+        assert (
+            op["content_hash"]
+            == "9cb810756e8cb05f5ebe62352517cc23c98797294a6a8a26c374efc03676b574"
+        )
+        assert op["source_bundle_record_id"] == "test_case:f7cbdae5b69b6355575cf520"
+
+    def test_record_subset_excludes_control_fields(self):
+        op = _build_operation(VALID_RECORD)
+        record = op["record"]
+        assert "schema_version" not in record
+        assert "record_type" not in record
+        assert "record_id" not in record
+        assert "content_hash" not in record
+        assert "source_scanner" not in record
+        assert "limitations" not in record
+
+    def test_record_subset_includes_payload_fields(self):
+        op = _build_operation(VALID_RECORD)
+        record = op["record"]
+        assert (
+            record["source_file"]
+            == "tests/unit/validation/test_profitability_evidence_packet_assembler.py"
+        )
+        assert record["pilot_id"] == "CDB-PILOT-001"
+        assert record["test_id"] == "cdb-test-pilot-001"
+        assert record["test_type"] == "mixed"
+        assert record["ci_artifact"] == "test-report"
+        assert record["surrealdb_export"] is True
+
+    def test_metadata_merged_into_record(self):
+        op = _build_operation(VALID_RECORD)
+        record = op["record"]
+        assert record["test_title"] == "Profitability Evidence Packet Assembler"
+        assert record["cdb_area"] == "validation"
+
+    def test_limitations_passed_through(self):
+        op = _build_operation(VALID_RECORD_WITH_LIMITATION)
+        assert op["limitations"] == ["some-known-limitation"]
+
+    def test_no_metadata_fallback(self):
+        record = dict(VALID_RECORD)
+        record["metadata"] = {}
+        op = _build_operation(record)
+        assert op["record"] is not None
+
+
+# ---------------------------------------------------------------------------
+# build_plan
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPlan:
+    def test_happy_path(self):
+        operations, warnings, limitations, fingerprint = build_plan(VALID_BUNDLE)
+        assert len(operations) == 1
+        assert warnings == []
+        assert limitations == []
+        assert isinstance(fingerprint, str)
+        assert len(fingerprint) == 64
+
+    def test_empty_bundle(self):
+        bundle = {
+            "schema_version": "test-metadata-import-bundle/v1",
+            "source_scanner": "test_metadata_scanner/v1.0.0",
+            "record_count": 0,
+            "records": [],
+        }
+        operations, warnings, limitations, fingerprint = build_plan(bundle)
+        assert len(operations) == 0
+        assert warnings == []
+        assert isinstance(fingerprint, str)
+
+    def test_no_pilot_generates_warning(self):
+        bundle = {
+            "schema_version": "test-metadata-import-bundle/v1",
+            "source_scanner": "test_metadata_scanner/v1.0.0",
+            "record_count": 1,
+            "records": [VALID_RECORD_NO_PILOT],
+        }
+        operations, warnings, limitations, _ = build_plan(bundle)
+        assert len(operations) == 1
+        assert any("empty_pilot_id" in w for w in warnings)
+        assert "pilot_id: not derivable" in operations[0]["limitations"][0]
+
+    def test_ci_artifact_bool_record_excluded(self):
+        record = dict(VALID_RECORD)
+        record["ci_artifact"] = True
+        bundle = {
+            "schema_version": "test-metadata-import-bundle/v1",
+            "source_scanner": "test_metadata_scanner/v1.0.0",
+            "record_count": 1,
+            "records": [record],
+        }
+        operations, warnings, _, _ = build_plan(bundle)
+        assert len(operations) == 0
+        assert any("must be a string" in w for w in warnings)
+
+    def test_absolute_path_record_excluded(self):
+        record = dict(VALID_RECORD)
+        record["source_file"] = "D:/Projects/test.py"
+        bundle = {
+            "schema_version": "test-metadata-import-bundle/v1",
+            "source_scanner": "test_metadata_scanner/v1.0.0",
+            "record_count": 1,
+            "records": [record],
+        }
+        operations, warnings, _, _ = build_plan(bundle)
+        assert len(operations) == 0
+        assert any("Absolute path" in w for w in warnings)
+
+    def test_missing_field_record_excluded(self):
+        record = dict(VALID_RECORD)
+        del record["test_id"]
+        bundle = {
+            "schema_version": "test-metadata-import-bundle/v1",
+            "source_scanner": "test_metadata_scanner/v1.0.0",
+            "record_count": 1,
+            "records": [record],
+        }
+        operations, warnings, _, _ = build_plan(bundle)
+        assert len(operations) == 0
+        assert any("test_id" in w for w in warnings)
+
+    def test_deterministic_sort_order(self):
+        record_b = dict(VALID_RECORD)
+        record_b["source_file"] = "tests/unit/beta/test_b.py"
+        record_b["test_id"] = "tc-beta-001"
+        record_b["record_id"] = "test_case:bbbbbbbbbbbbbbbbbbbbbbbb"
+        record_b["content_hash"] = "c" * 64
+
+        record_a = dict(VALID_RECORD)
+        record_a["source_file"] = "tests/unit/alpha/test_a.py"
+        record_a["test_id"] = "tc-alpha-001"
+        record_a["record_id"] = "test_case:aaaaaaaaaaaaaaaaaaaaaaaa"
+        record_a["content_hash"] = "d" * 64
+
+        bundle = {
+            "schema_version": "test-metadata-import-bundle/v1",
+            "source_scanner": "test_metadata_scanner/v1.0.0",
+            "record_count": 2,
+            "records": [record_b, record_a],
+        }
+        operations, _, _, _ = build_plan(bundle)
+        assert len(operations) == 2
+        assert operations[0]["target_id"] == "test_case:aaaaaaaaaaaaaaaaaaaaaaaa"
+        assert operations[1]["target_id"] == "test_case:bbbbbbbbbbbbbbbbbbbbbbbb"
+
+    def test_deterministic_fingerprint(self):
+        ops1, _, _, fp1 = build_plan(VALID_BUNDLE)
+        ops2, _, _, fp2 = build_plan(VALID_BUNDLE)
+        assert fp1 == fp2
+        assert len(fp1) == 64
+
+    def test_mixed_valid_and_invalid_records(self):
+        bad_record = dict(VALID_RECORD)
+        bad_record["ci_artifact"] = 123
+        bad_record["record_id"] = "test_case:badbadbadbadbadbadbadbad"
+
+        bundle = {
+            "schema_version": "test-metadata-import-bundle/v1",
+            "source_scanner": "test_metadata_scanner/v1.0.0",
+            "record_count": 2,
+            "records": [VALID_RECORD, bad_record],
+        }
+        operations, warnings, _, _ = build_plan(bundle)
+        assert len(operations) == 1
+        assert any("ci_artifact" in w for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# write_plan
+# ---------------------------------------------------------------------------
+
+
+class TestWritePlan:
+    def test_plan_has_required_keys(self):
+        operations, warnings, limitations, fingerprint = build_plan(VALID_BUNDLE)
+        plan = json.loads(write_plan(operations, warnings, limitations, fingerprint))
+        assert plan["schema_version"] == PLAN_SCHEMA_VERSION
+        assert plan["source_bundle_schema"] == BUNDLE_SCHEMA_VERSION
+        assert plan["plan_type"] == PLAN_TYPE
+        assert plan["operation_count"] == 1
+        assert plan["dry_run"] is True
+        assert plan["surrealdb_write"] is False
+        assert isinstance(plan["bundle_fingerprint"], str)
+        assert isinstance(plan["warnings"], list)
+        assert isinstance(plan["limitations"], list)
+        assert len(plan["operations"]) == 1
+
+    def test_empty_operations(self):
+        raw = write_plan([], [], [], "f" * 64)
+        plan = json.loads(raw)
+        assert plan["operation_count"] == 0
+        assert plan["operations"] == []
+
+    def test_valid_json_output(self):
+        operations, warnings, limitations, fingerprint = build_plan(VALID_BUNDLE)
+        raw = write_plan(operations, warnings, limitations, fingerprint)
+        data = json.loads(raw)
+        assert isinstance(data, dict)
+
+    def test_warnings_formatted(self):
+        raw = write_plan([], ["[tc-001] some warning"], [], "f" * 64)
+        plan = json.loads(raw)
+        assert "[tc-001] some warning" in plan["warnings"]
+
+
+# ---------------------------------------------------------------------------
+# run() integration
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    def test_stdin_no_data(self, monkeypatch):
+        monkeypatch.setattr("sys.stdin.read", lambda: "")
+        code = run([])
+        assert code == 2
+
+    def test_valid_file_returns_zero(self):
+        path = _write_tmp_json(VALID_BUNDLE)
+        try:
+            code = run([str(path)])
+            assert code == 0
+        finally:
+            os.unlink(str(path))
+
+    def test_output_file(self):
+        path = _write_tmp_json(VALID_BUNDLE)
+        out_path_obj = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
+        out_path = out_path_obj.name
+        out_path_obj.close()
+        try:
+            code = run([str(path), "--output", out_path])
+            assert code == 0
+            with open(out_path, encoding="utf-8") as f:
+                data = json.load(f)
+            assert data["operation_count"] == 1
+        finally:
+            os.unlink(str(path))
+            os.unlink(out_path)
+
+    def test_empty_bundle_returns_one(self):
+        bundle = {
+            "schema_version": "test-metadata-import-bundle/v1",
+            "source_scanner": "test_metadata_scanner/v1.0.0",
+            "record_count": 0,
+            "records": [],
+        }
+        path = _write_tmp_json(bundle)
+        try:
+            code = run([str(path)])
+            assert code == 1
+        finally:
+            os.unlink(str(path))
+
+    def test_all_records_invalid_returns_one(self):
+        record = dict(VALID_RECORD)
+        record["ci_artifact"] = 1234
+        bundle = {
+            "schema_version": "test-metadata-import-bundle/v1",
+            "source_scanner": "test_metadata_scanner/v1.0.0",
+            "record_count": 1,
+            "records": [record],
+        }
+        path = _write_tmp_json(bundle)
+        try:
+            code = run([str(path)])
+            assert code == 1
+        finally:
+            os.unlink(str(path))
+
+    def test_nonexistent_file_returns_two(self):
+        code = run(["nonexistent_file_xyz.json"])
+        assert code == 2
+
+    def test_malformed_json_returns_two(self):
+        fd, path = tempfile.mkstemp(suffix=".json", text=True)
+        os.write(fd, b"not json at all")
+        os.close(fd)
+        try:
+            code = run([str(path)])
+            assert code == 2
+        finally:
+            os.unlink(path)
+
+    def test_standard_input_pipe(self, monkeypatch):
+        path = _write_tmp_json(VALID_BUNDLE)
+        try:
+            with open(str(path), encoding="utf-8") as f:
+                content = f.read()
+            monkeypatch.setattr("sys.stdin.read", lambda: content)
+            code = run(["-"])
+            assert code == 0
+        finally:
+            os.unlink(str(path))

--- a/tools/test_metadata_surrealdb_import_plan.py
+++ b/tools/test_metadata_surrealdb_import_plan.py
@@ -1,0 +1,254 @@
+"""CDB Test-First Metadata SurrealDB Import Plan Builder (dry-run, read-only).
+
+Translates an Import Bundle v1 into a deterministic dry-run SurrealDB
+import plan. No SurrealDB connection, no SurrealQL, no write of any kind.
+
+Usage:
+    python -m tools.test_metadata_surrealdb_import_plan <bundle.json>
+    python -m tools.test_metadata_surrealdb_import_plan --stdin < bundle.json
+    python -m tools.test_metadata_surrealdb_import_plan --output <plan.json> <bundle.json>
+
+Exit codes:
+    0 - valid dry-run plan produced
+    1 - no importable records / contract validation error
+    2 - parse / usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from core.replay.canonical_json import canonical_hash
+
+PLAN_SCHEMA_VERSION = "test-metadata-surrealdb-import-plan/v1"
+BUNDLE_SCHEMA_VERSION = "test-metadata-import-bundle/v1"
+PLAN_TYPE = "upsert_dry_run"
+TARGET_TABLE = "test_case"
+
+ABSOLUTE_PATH_RE = re.compile(r"^[a-zA-Z]:[/\\]|^/")
+
+
+def _check_absolute_path(value: str) -> bool:
+    cleaned = value.strip().replace("\\", "/")
+    return bool(ABSOLUTE_PATH_RE.match(cleaned))
+
+
+def _build_operation(record: dict[str, Any]) -> dict[str, Any]:
+    target_id: str = record.get("record_id", "")
+    content_hash: str = record.get("content_hash", "")
+
+    record_payload: dict[str, Any] = {
+        "source_file": record.get("source_file", ""),
+        "pilot_id": record.get("pilot_id", ""),
+        "test_id": record.get("test_id", ""),
+        "test_type": record.get("test_type", ""),
+        "ci_artifact": record.get("ci_artifact", ""),
+        "surrealdb_export": record.get("surrealdb_export", False),
+    }
+
+    metadata = record.get("metadata")
+    if isinstance(metadata, dict):
+        record_payload.update(metadata)
+
+    limitations: list[str] = list(record.get("limitations", []))
+
+    return {
+        "operation": PLAN_TYPE,
+        "target_table": TARGET_TABLE,
+        "target_id": target_id,
+        "record": record_payload,
+        "content_hash": content_hash,
+        "source_bundle_record_id": target_id,
+        "limitations": limitations,
+    }
+
+
+def load_bundle(input_data: str) -> dict[str, Any]:
+    try:
+        bundle = json.loads(input_data)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid bundle JSON: {exc}") from exc
+
+    if not isinstance(bundle, dict):
+        raise ValueError("Bundle must be a JSON object")
+
+    records = bundle.get("records")
+    if not isinstance(records, list):
+        raise ValueError("Bundle missing 'records' list")
+
+    return bundle
+
+
+def validate_bundle_record(record: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    for field in (
+        "record_id",
+        "content_hash",
+        "test_id",
+        "ci_artifact",
+        "surrealdb_export",
+    ):
+        if field not in record:
+            errors.append(f"Record missing required field: {field}")
+
+    ci_artifact = record.get("ci_artifact")
+    if ci_artifact is not None and not isinstance(ci_artifact, str):
+        errors.append(f"ci_artifact must be a string, got {type(ci_artifact).__name__}")
+
+    source_file = record.get("source_file", "")
+    if _check_absolute_path(source_file):
+        errors.append(f"Absolute path in source_file: {source_file}")
+
+    return errors
+
+
+def build_plan(
+    bundle: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[str], list[str], str]:
+    records: list[dict[str, Any]] = bundle.get("records", [])
+    operations: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    global_limitations: list[str] = []
+
+    sorted_records = sorted(
+        records,
+        key=lambda r: (
+            r.get("source_file", ""),
+            r.get("test_id", ""),
+            r.get("record_id", ""),
+        ),
+    )
+
+    for record in sorted_records:
+        validation_errors = validate_bundle_record(record)
+        if validation_errors:
+            rid = record.get("record_id", "<unknown>")
+            for err in validation_errors:
+                warnings.append(f"[{rid}] {err}")
+            continue
+
+        pilot_id = record.get("pilot_id", "")
+        if not pilot_id:
+            rid = record.get("record_id", "")
+            warnings.append(f"[{rid}] empty_pilot_id")
+            limitation = "pilot_id: not derivable from test_id (expected cdb-test-pilot-NNN pattern)"
+            record_limitations: list[str] = list(record.get("limitations", []))
+            if limitation not in record_limitations:
+                record_limitations.append(limitation)
+            record["limitations"] = record_limitations
+
+        operation = _build_operation(record)
+        operations.append(operation)
+
+    target_ids = sorted(op["target_id"] for op in operations)
+    fingerprint_input = PLAN_SCHEMA_VERSION + "," + ",".join(target_ids)
+    bundle_fingerprint = canonical_hash(fingerprint_input)
+
+    return operations, warnings, global_limitations, bundle_fingerprint
+
+
+def format_warning(w: str) -> str:
+    if w.startswith("["):
+        return w
+    return f"[plan] {w}"
+
+
+def write_plan(
+    operations: list[dict[str, Any]],
+    warnings: list[str],
+    limitations: list[str],
+    bundle_fingerprint: str,
+) -> str:
+    plan = {
+        "schema_version": PLAN_SCHEMA_VERSION,
+        "source_bundle_schema": BUNDLE_SCHEMA_VERSION,
+        "plan_type": PLAN_TYPE,
+        "operation_count": len(operations),
+        "dry_run": True,
+        "surrealdb_write": False,
+        "bundle_fingerprint": bundle_fingerprint,
+        "warnings": [format_warning(w) for w in warnings],
+        "limitations": limitations,
+        "operations": operations,
+    }
+    return json.dumps(plan, indent=2, ensure_ascii=False, sort_keys=True)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="CDB Test-First Metadata SurrealDB Import Plan Builder (dry-run, read-only)",
+    )
+    parser.add_argument(
+        "input",
+        nargs="?",
+        default="-",
+        help="Bundle JSON file path, or '-' for stdin (default: '-')",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Write plan JSON to file (default: stdout)",
+    )
+    return parser.parse_args(argv)
+
+
+def run(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.input == "-":
+        input_data = sys.stdin.read()
+    else:
+        input_path = Path(args.input)
+        if not input_path.is_file():
+            print(f"Error: file not found: {args.input}", file=sys.stderr)
+            return 2
+        try:
+            input_data = input_path.read_text(encoding="utf-8")
+        except Exception as exc:
+            print(f"Error: cannot read input: {exc}", file=sys.stderr)
+            return 2
+
+    try:
+        bundle = load_bundle(input_data)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    result = build_plan(bundle)
+    operations, warnings, limitations, bundle_fingerprint = result
+
+    if not operations:
+        for w in warnings:
+            print(f"Warning: {w}", file=sys.stderr)
+        print("No importable records found.", file=sys.stderr)
+        return 1
+
+    output = write_plan(operations, warnings, limitations, bundle_fingerprint)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(output, encoding="utf-8")
+    else:
+        print(output)
+
+    if warnings:
+        for w in warnings:
+            print(f"Warning: {w}", file=sys.stderr)
+
+    return 0
+
+
+def main() -> None:
+    sys.exit(run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR defines the SurrealDB Import Contract v1 and implements the deterministic dry-run import plan builder. It is the next slice in the test-first metadata pipeline chain (scanner -> bundle -> plan).

### Brain Evidence Block

| Field | Value |
|---|---|
| context_tool_status | available (Git/GitHub/repo reads all verified) |
| context_trust_level | LOW (DB evidence absent in this read-only slice) |
| records_found | 3 direct: TEST_FIRST_PROCESSING_CONTRACT test_case:* target model, context_importer table:id pattern + _payload_hash(), canonical_json canonical_hash() |

### What changed

- knowledge/testing/TEST_METADATA_SURREALDB_IMPORT_CONTRACT.md - contract document (purpose, scope, input/output, validation, determinism, exit codes, safety boundaries, pipeline summary)
- tools/test_metadata_surrealdb_import_plan.py - dry-run plan builder CLI (no SurrealDB write, no SurrealQL, no DB connector)
- tests/unit/tools/test_test_metadata_surrealdb_import_plan.py - 47 unit tests (load, validate, build, write, run, fail-closed edge cases)
- .gitignore - negate wildcard for new plan tool (*test*.py matched the name)
- knowledge/testing/README.md - Import Plan Builder section (DE)

### Pipeline chain

| Slice | Tool | Status |
|---|---|---|
| PR #3409 | test_metadata_scanner.py | Merged |
| PR #3415 | test_metadata_import_bundle.py | Merged (475c4783) |
| PR #3416 | CURRENT_STATUS.md ledger | Merged (659c7c79) |
| **This PR** | test_metadata_surrealdb_import_plan.py + contract | **Open** |
| Future | SurrealDB Import Adapter | Gate slice |

### Key design decisions

- record_type: test_case with test_case:<24-char-hex> record IDs aligned with TEST_FIRST_PROCESSING_CONTRACT.md and existing context-importer patterns
- Dry-run plan: operation=upsert_dry_run, target_table=test_case, dry_run=true, surrealdb_write=false
- record in each operation excludes bundle envelope fields (schema_version, record_type, record_id, content_hash, source_scanner, limitations)
- pilot_id limitation for non-cdb-test-pilot-NNN patterns (warning + limitation field entry)
- ci_artifact must be string (bool rejected with validation warning)
- Absolute paths blocked fail-closed
- canonical_hash() from core/replay/canonical_json.py for bundle fingerprint; content_hash passed through from bundle unchanged
- test_title remains in metadata (no test_name migration)

### Validation

- ruff check: clean on all .py files
- black: formatted
- 47/47 unit tests passing
- Existing 50 bundle tests: no regression
- End-to-end CLI pipeline verified: bundle stdin -> plan stdout
- Exit codes verified: 0 (valid), 1 (empty/invalid), 2 (parse error)

### Safety boundaries

This tool is explicitly fail-closed:
- **No SurrealDB write** (surrealdb_write: false, dry_run: true)
- **No SurrealQL** import or execution
- **No DB connector** import (surrealdb, psycopg2, etc.)
- **No MCP** dependency
- **No Runtime/Docker/Secrets/Exchange scope**
