### PR TITLE
feat(surrealdb): add surrealkit schema foundation

### DIFF
--- a/docs/surrealdb/context-intelligence-v0-surrealkit-compatibility.md
+++ b/docs/surrealdb/context-intelligence-v0-surrealkit-compatibility.md
@@ -1,0 +1,67 @@
+# Context Intelligence v0 — SurrealKit Compatibility Layer
+
+**Issue:** #3420 (SLICE-02)
+**Parent Meta:** #3418
+**Architecture Decision:** ADR-002 (`ADOPT_AFTER_FOUNDATION_REPAIR`)
+
+## Überblick
+
+Dieses Dokument beschreibt die SurrealKit-Kompatibilitätsschicht der
+`context_intelligence_v0`-Schemafläche.  Die Schicht ist eine **reine
+Schema- und Tooling-Foundation** — sie autorisiert keine produktive Migration,
+keinen Live-Sync und keine Daten-Bootstrapping.
+
+## Dateistruktur
+
+| Datei | Zweck |
+|-------|-------|
+| `infrastructure/surrealdb/context_intelligence_v0.surql` | Kanonischer Schema-Draft (18 Tabellen) — bewusst ohne NS/DB-Kontext |
+| `infrastructure/surrealdb/context_intelligence_v0_deploy.surql` | SurrealKit-kompatibles Deploy-Wrapper mit NS/DB + `IF NOT EXISTS` + Permissions |
+| `tools/surrealdb/schema_snapshot.py` | Deterministisches Schema-Snapshot-Tool (repo-backed) |
+| `infrastructure/surrealdb/schema_baseline.json` | Committes Schema-Hash-Baseline |
+| `tests/surrealdb/test_context_intelligence_v0_surql.py` | Schema-Contract-Tests |
+| `tests/surrealdb/test_schema_snapshot.py` | Snapshot-Tests |
+
+## Was die Kompatibilitätsschicht leistet
+
+1. **Idempotentes Schema-Loading** — alle `DEFINE TABLE`-Statements im Deploy-Wrapper
+   nutzen `IF NOT EXISTS`, sodass das Schema mehrfach geladen werden kann, ohne
+   Fehler zu produzieren.
+2. **NS/DB-Isolation** — das Deploy-Wrapper definiert `NS cdb` / `DB context_intel`
+   und stellt sicher, dass alle Tabellen im korrekten Namespace/Database-Kontext
+   angelegt werden.
+3. **Fail-closed Permissions** — jede Tabelle hat `FOR select NONE, FOR create NONE,
+   FOR update NONE, FOR delete NONE`.  Produktive Berechtigungen werden durch
+   Issue #3426 (Permission Matrix + Readonly Agent User) definiert.
+4. **Schema-Integritätsprüfung** — das Snapshot-Tool erlaubt die Prüfung, ob
+   das aktuelle Schema mit einem Baseline-Hash übereinstimmt (CI-fähig).
+
+## Sync-Workflow (vorbereitet, nicht aktiviert)
+
+Der Sync-Workflow (`surrealkit sync`) ist **vorbereitet, aber nicht aktiviert**.
+Der deploybare Schema-Wrapper ist SurrealKit-kompatibel formuliert, sodass
+ein späterer Sync-Schritt die `.surql`-Dateien in eine SurrealDB-Instanz laden
+kann.  Der tatsächliche Sync und die zugehörigen Credentials/Authorisierung
+werden im nächsten Slice (#3421 — Readonly MCP Brain Evidence Contract) adressiert.
+
+## Nicht-Ziele (explizit)
+
+- **Keine** produktive Datenmigration
+- **Kein** Live-Sync gegen echte SurrealDB-Instanzen
+- **Kein** Bootstrapping von Daten
+- **Keine** Änderung an `PERSIST_ALLOWED` / `MUTATION_ALLOWED`
+- **Kein** Runtime-/Docker-/MCP-Scope
+- **Keine** Trading-State-Objekte (Orders/Fills/Positions/Risk-State)
+
+## Nächster Slice
+
+- **#3421** — Readonly MCP Brain Evidence Contract: harter MCP-Vertrag für
+  DB-backed Brain Evidence in read-only Tools
+
+## Referenzen
+
+- ADR-002: `knowledge/decisions/ADR-002-context-intelligence-canon.md`
+- Issue #3420: GitHub issue (SLICE-02 — SurrealKit Schema Foundation)
+- Issue #3418: Meta-Issue (Build SurrealDB-native ContextBrain / VectorGraph)
+- Snapshot-Tool: `tools/surrealdb/schema_snapshot.py`
+- Schema-Tests: `tests/surrealdb/`

--- a/infrastructure/surrealdb/README.md
+++ b/infrastructure/surrealdb/README.md
@@ -36,5 +36,23 @@ Alle Tabellen nutzen `PERMISSIONS FOR CREATE, FOR SELECT` und haben keine UPDATE
 - Zum Rollback genügt es, die SurrealDB-Instance zu stoppen und `governance_source` auf `postgres`/`git` zu belassen.  
 - Schema kann jederzeit neu geladen werden (`surreal sql --file=setup.surql`).
 
+## SurrealKit Compatibility (Issue #3420)
+
+Die Context Intelligence v0 Schema-Datei (`context_intelligence_v0.surql`) definiert
+18 Tabellen für das Context Intelligence System.  Für SurrealKit-Kompatibilität steht
+ein idempotentes Deploy-Wrapper bereit:
+
+- **`context_intelligence_v0_deploy.surql`** — NS/DB-Context + `IF NOT EXISTS` +
+  fail-closed Permissions (`FOR select/create/update/delete NONE`).
+  Die kanonischen Table-/Field-/Index-Definitionen sind identisch zum Originaldraft;
+  ein Drift-Guard in den Tests stellt sicher, dass beide Dateien synchron bleiben.
+- **`schema_snapshot.py`** (`tools/surrealdb/schema_snapshot.py`) — deterministisches
+  Schema-Snapshot-Tool (repo-backed, keine DB-Verbindung nötig).
+- **`schema_baseline.json`** — committedes Schema-Hash-Baseline für CI-Prüfung.
+
+**Wichtig:** Dies ist eine reine Schema- und Tooling-Foundation.  Es autorisiert keine
+produktive Migration, keinen Live-Sync und keine Daten-Bootstrapping.  Der Sync-Workflow
+bleibt vorbereitet, aber NICHT aktiviert (siehe Issue #3421 für den nächsten Slice).
+
 ## SSOT boundary
 LR **NO-GO** — `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`. Managed/non-local runtime **NOT ACTIVATED**.

--- a/infrastructure/surrealdb/context_intelligence_v0_deploy.surql
+++ b/infrastructure/surrealdb/context_intelligence_v0_deploy.surql
@@ -1,0 +1,401 @@
+-- =====================================================================
+-- Context Intelligence v0 — SurrealKit-ready Deployable Schema
+-- Issue: #3420  (Issue #2037 original, #3418 Meta, #3420 SurrealKit)
+--
+-- THIS IS A DEPLOYABLE WRAPPER.  The canonical schema draft remains
+-- `context_intelligence_v0.surql`.  This file adds:
+--   1. NS/DB context (idempotent)
+--   2. IF NOT EXISTS on all DEFINE TABLE statements
+--   3. Fail-closed PERMISSIONS (select/update/create/delete NONE)
+--
+-- Guardrails (hard):
+-- - Schema wrapper only: no productive apply, no migration, no bootstrap
+-- - No runtime, compose, service, or trading-system changes implied
+-- - No secrets, no trading-state objects (no orders / positions / fills)
+-- - `agent_memory` remains schema-only; no memory writes enabled
+-- - Permissions are fail-closed NONE.  Productive permissions will be
+--   defined by Issue #3426 (Permission Matrix + Readonly Agent User).
+--
+-- Conventions:
+-- - Each DEFINE TABLE uses IF NOT EXISTS for idempotent loading
+-- - Each table defines FOR select NONE, FOR create NONE, FOR update
+--   NONE, FOR delete NONE as baseline
+-- - Field / index definitions are identical to the canonical draft;
+--   see `context_intelligence_v0.surql` for field-level docs
+-- =====================================================================
+
+-- ===== Namespace / Database Context =====
+DEFINE NAMESPACE IF NOT EXISTS cdb;
+USE NS cdb;
+DEFINE DATABASE IF NOT EXISTS context_intel;
+USE DB context_intel;
+
+-- ===== repo_artifact =====
+DEFINE TABLE IF NOT EXISTS repo_artifact SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD artifact_id ON TABLE repo_artifact TYPE string;
+DEFINE FIELD artifact_type ON TABLE repo_artifact TYPE string;
+DEFINE FIELD source_path ON TABLE repo_artifact TYPE string;
+DEFINE FIELD source_url ON TABLE repo_artifact TYPE string;
+DEFINE FIELD source_commit ON TABLE repo_artifact TYPE string;
+DEFINE FIELD source_hash ON TABLE repo_artifact TYPE string;
+DEFINE FIELD integrity_algo ON TABLE repo_artifact TYPE string;
+DEFINE FIELD size_bytes ON TABLE repo_artifact TYPE int;
+DEFINE FIELD mime_type ON TABLE repo_artifact TYPE string;
+DEFINE FIELD observed_at ON TABLE repo_artifact TYPE datetime;
+DEFINE FIELD freshness ON TABLE repo_artifact TYPE string;
+DEFINE FIELD confidence ON TABLE repo_artifact TYPE float;
+DEFINE FIELD comment ON TABLE repo_artifact TYPE string;
+DEFINE FIELD created_at ON TABLE repo_artifact TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_repo_artifact_artifact_id_unique ON TABLE repo_artifact FIELDS artifact_id UNIQUE;
+DEFINE INDEX idx_repo_artifact_source_path ON TABLE repo_artifact FIELDS source_path;
+DEFINE INDEX idx_repo_artifact_source_hash ON TABLE repo_artifact FIELDS source_hash;
+DEFINE INDEX idx_repo_artifact_created_at ON TABLE repo_artifact FIELDS created_at;
+
+-- ===== code_symbol =====
+DEFINE TABLE IF NOT EXISTS code_symbol SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD symbol_id ON TABLE code_symbol TYPE string;
+DEFINE FIELD language ON TABLE code_symbol TYPE string;
+DEFINE FIELD symbol_kind ON TABLE code_symbol TYPE string;
+DEFINE FIELD qualified_name ON TABLE code_symbol TYPE string;
+DEFINE FIELD name ON TABLE code_symbol TYPE string;
+DEFINE FIELD file_path ON TABLE code_symbol TYPE string;
+DEFINE FIELD span_start_line ON TABLE code_symbol TYPE int;
+DEFINE FIELD span_end_line ON TABLE code_symbol TYPE int;
+DEFINE FIELD source_hash ON TABLE code_symbol TYPE string;
+DEFINE FIELD source_commit ON TABLE code_symbol TYPE string;
+DEFINE FIELD confidence ON TABLE code_symbol TYPE float;
+DEFINE FIELD comment ON TABLE code_symbol TYPE string;
+DEFINE FIELD created_at ON TABLE code_symbol TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_code_symbol_symbol_id_unique ON TABLE code_symbol FIELDS symbol_id UNIQUE;
+DEFINE INDEX idx_code_symbol_qualified_name ON TABLE code_symbol FIELDS qualified_name;
+DEFINE INDEX idx_code_symbol_file_path ON TABLE code_symbol FIELDS file_path;
+DEFINE INDEX idx_code_symbol_created_at ON TABLE code_symbol FIELDS created_at;
+
+-- ===== doc_page =====
+DEFINE TABLE IF NOT EXISTS doc_page SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD page_id ON TABLE doc_page TYPE string;
+DEFINE FIELD source_path ON TABLE doc_page TYPE string;
+DEFINE FIELD source_url ON TABLE doc_page TYPE string;
+DEFINE FIELD source_commit ON TABLE doc_page TYPE string;
+DEFINE FIELD source_hash ON TABLE doc_page TYPE string;
+DEFINE FIELD title ON TABLE doc_page TYPE string;
+DEFINE FIELD doc_format ON TABLE doc_page TYPE string;
+DEFINE FIELD observed_at ON TABLE doc_page TYPE datetime;
+DEFINE FIELD freshness ON TABLE doc_page TYPE string;
+DEFINE FIELD confidence ON TABLE doc_page TYPE float;
+DEFINE FIELD comment ON TABLE doc_page TYPE string;
+DEFINE FIELD created_at ON TABLE doc_page TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_doc_page_page_id_unique ON TABLE doc_page FIELDS page_id UNIQUE;
+DEFINE INDEX idx_doc_page_source_path ON TABLE doc_page FIELDS source_path;
+DEFINE INDEX idx_doc_page_source_hash ON TABLE doc_page FIELDS source_hash;
+DEFINE INDEX idx_doc_page_created_at ON TABLE doc_page FIELDS created_at;
+
+-- ===== doc_section =====
+DEFINE TABLE IF NOT EXISTS doc_section SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD section_id ON TABLE doc_section TYPE string;
+DEFINE FIELD page_ref ON TABLE doc_section TYPE record;
+DEFINE FIELD heading ON TABLE doc_section TYPE string;
+DEFINE FIELD heading_path ON TABLE doc_section TYPE array;
+DEFINE FIELD section_index ON TABLE doc_section TYPE int;
+DEFINE FIELD span_start_line ON TABLE doc_section TYPE int;
+DEFINE FIELD span_end_line ON TABLE doc_section TYPE int;
+DEFINE FIELD source_hash ON TABLE doc_section TYPE string;
+DEFINE FIELD confidence ON TABLE doc_section TYPE float;
+DEFINE FIELD comment ON TABLE doc_section TYPE string;
+DEFINE FIELD created_at ON TABLE doc_section TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_doc_section_section_id_unique ON TABLE doc_section FIELDS section_id UNIQUE;
+DEFINE INDEX idx_doc_section_page_ref ON TABLE doc_section FIELDS page_ref;
+DEFINE INDEX idx_doc_section_created_at ON TABLE doc_section FIELDS created_at;
+
+-- ===== doc_chunk =====
+DEFINE TABLE IF NOT EXISTS doc_chunk SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD chunk_id ON TABLE doc_chunk TYPE string;
+DEFINE FIELD page_ref ON TABLE doc_chunk TYPE record;
+DEFINE FIELD section_ref ON TABLE doc_chunk TYPE record;
+DEFINE FIELD chunk_index ON TABLE doc_chunk TYPE int;
+DEFINE FIELD content ON TABLE doc_chunk TYPE string;
+DEFINE FIELD content_hash ON TABLE doc_chunk TYPE string;
+DEFINE FIELD tokens_estimate ON TABLE doc_chunk TYPE int;
+DEFINE FIELD source_hash ON TABLE doc_chunk TYPE string;
+DEFINE FIELD confidence ON TABLE doc_chunk TYPE float;
+DEFINE FIELD comment ON TABLE doc_chunk TYPE string;
+DEFINE FIELD created_at ON TABLE doc_chunk TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_doc_chunk_chunk_id_unique ON TABLE doc_chunk FIELDS chunk_id UNIQUE;
+DEFINE INDEX idx_doc_chunk_page_ref ON TABLE doc_chunk FIELDS page_ref;
+DEFINE INDEX idx_doc_chunk_section_ref ON TABLE doc_chunk FIELDS section_ref;
+DEFINE INDEX idx_doc_chunk_content_hash ON TABLE doc_chunk FIELDS content_hash;
+DEFINE INDEX idx_doc_chunk_created_at ON TABLE doc_chunk FIELDS created_at;
+
+-- ===== concept =====
+DEFINE TABLE IF NOT EXISTS concept SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD concept_id ON TABLE concept TYPE string;
+DEFINE FIELD name ON TABLE concept TYPE string;
+DEFINE FIELD description ON TABLE concept TYPE string;
+DEFINE FIELD tags ON TABLE concept TYPE array;
+DEFINE FIELD source_refs ON TABLE concept TYPE array;
+DEFINE FIELD evidence_refs ON TABLE concept TYPE array;
+DEFINE FIELD freshness ON TABLE concept TYPE string;
+DEFINE FIELD confidence ON TABLE concept TYPE float;
+DEFINE FIELD comment ON TABLE concept TYPE string;
+DEFINE FIELD created_at ON TABLE concept TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_concept_concept_id_unique ON TABLE concept FIELDS concept_id UNIQUE;
+DEFINE INDEX idx_concept_name ON TABLE concept FIELDS name;
+DEFINE INDEX idx_concept_created_at ON TABLE concept FIELDS created_at;
+
+-- ===== dependency_edge =====
+DEFINE TABLE IF NOT EXISTS dependency_edge SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD edge_id ON TABLE dependency_edge TYPE string;
+DEFINE FIELD edge_type ON TABLE dependency_edge TYPE string;
+DEFINE FIELD from_ref ON TABLE dependency_edge TYPE record;
+DEFINE FIELD to_ref ON TABLE dependency_edge TYPE record;
+DEFINE FIELD source_ref ON TABLE dependency_edge TYPE string;
+DEFINE FIELD confidence ON TABLE dependency_edge TYPE float;
+DEFINE FIELD evidence_level ON TABLE dependency_edge TYPE string;
+DEFINE FIELD inferred ON TABLE dependency_edge TYPE bool;
+DEFINE FIELD comment ON TABLE dependency_edge TYPE string;
+DEFINE FIELD created_at ON TABLE dependency_edge TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_dependency_edge_id_unique ON TABLE dependency_edge FIELDS edge_id UNIQUE;
+DEFINE INDEX idx_dependency_edge_type ON TABLE dependency_edge FIELDS edge_type;
+DEFINE INDEX idx_dependency_edge_from_ref ON TABLE dependency_edge FIELDS from_ref;
+DEFINE INDEX idx_dependency_edge_to_ref ON TABLE dependency_edge FIELDS to_ref;
+DEFINE INDEX idx_dependency_edge_created_at ON TABLE dependency_edge FIELDS created_at;
+
+-- ===== evidence_ref =====
+DEFINE TABLE IF NOT EXISTS evidence_ref SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD evidence_id ON TABLE evidence_ref TYPE string;
+DEFINE FIELD evidence_type ON TABLE evidence_ref TYPE string;
+DEFINE FIELD source_path ON TABLE evidence_ref TYPE string;
+DEFINE FIELD source_url ON TABLE evidence_ref TYPE string;
+DEFINE FIELD source_hash ON TABLE evidence_ref TYPE string;
+DEFINE FIELD source_commit ON TABLE evidence_ref TYPE string;
+DEFINE FIELD collected_at ON TABLE evidence_ref TYPE datetime;
+DEFINE FIELD observed_by ON TABLE evidence_ref TYPE string;
+DEFINE FIELD freshness ON TABLE evidence_ref TYPE string;
+DEFINE FIELD confidence ON TABLE evidence_ref TYPE float;
+DEFINE FIELD validates ON TABLE evidence_ref TYPE array;
+DEFINE FIELD invalidates ON TABLE evidence_ref TYPE array;
+DEFINE FIELD related_artifacts ON TABLE evidence_ref TYPE array;
+DEFINE FIELD related_decisions ON TABLE evidence_ref TYPE array;
+DEFINE FIELD comment ON TABLE evidence_ref TYPE string;
+DEFINE FIELD created_at ON TABLE evidence_ref TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_evidence_ref_evidence_id_unique ON TABLE evidence_ref FIELDS evidence_id UNIQUE;
+DEFINE INDEX idx_evidence_ref_source_path ON TABLE evidence_ref FIELDS source_path;
+DEFINE INDEX idx_evidence_ref_source_hash ON TABLE evidence_ref FIELDS source_hash;
+DEFINE INDEX idx_evidence_ref_collected_at ON TABLE evidence_ref FIELDS collected_at;
+DEFINE INDEX idx_evidence_ref_created_at ON TABLE evidence_ref FIELDS created_at;
+
+-- ===== claim =====
+DEFINE TABLE IF NOT EXISTS claim SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD claim_id ON TABLE claim TYPE string;
+DEFINE FIELD title ON TABLE claim TYPE string;
+DEFINE FIELD statement ON TABLE claim TYPE string;
+DEFINE FIELD scope ON TABLE claim TYPE string;
+DEFINE FIELD status ON TABLE claim TYPE string;
+DEFINE FIELD evidence_refs ON TABLE claim TYPE array;
+DEFINE FIELD source_refs ON TABLE claim TYPE array;
+DEFINE FIELD confidence ON TABLE claim TYPE float;
+DEFINE FIELD comment ON TABLE claim TYPE string;
+DEFINE FIELD created_at ON TABLE claim TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_claim_claim_id_unique ON TABLE claim FIELDS claim_id UNIQUE;
+DEFINE INDEX idx_claim_status ON TABLE claim FIELDS status;
+DEFINE INDEX idx_claim_created_at ON TABLE claim FIELDS created_at;
+
+-- ===== decision_event =====
+DEFINE TABLE IF NOT EXISTS decision_event SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD decision_id ON TABLE decision_event TYPE string;
+DEFINE FIELD title ON TABLE decision_event TYPE string;
+DEFINE FIELD question ON TABLE decision_event TYPE string;
+DEFINE FIELD answer ON TABLE decision_event TYPE string;
+DEFINE FIELD decision_type ON TABLE decision_event TYPE string;
+DEFINE FIELD status ON TABLE decision_event TYPE string;
+DEFINE FIELD scope ON TABLE decision_event TYPE string;
+DEFINE FIELD evidence_refs ON TABLE decision_event TYPE array;
+DEFINE FIELD claim_refs ON TABLE decision_event TYPE array;
+DEFINE FIELD affected_artifacts ON TABLE decision_event TYPE array;
+DEFINE FIELD agent ON TABLE decision_event TYPE string;
+DEFINE FIELD human_go ON TABLE decision_event TYPE bool;
+DEFINE FIELD confidence ON TABLE decision_event TYPE float;
+DEFINE FIELD superseded_by ON TABLE decision_event TYPE string;
+DEFINE FIELD invalidated_by ON TABLE decision_event TYPE string;
+DEFINE FIELD uncertainty ON TABLE decision_event TYPE string;
+DEFINE FIELD comment ON TABLE decision_event TYPE string;
+DEFINE FIELD created_at ON TABLE decision_event TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_decision_event_decision_id_unique ON TABLE decision_event FIELDS decision_id UNIQUE;
+DEFINE INDEX idx_decision_event_status ON TABLE decision_event FIELDS status;
+DEFINE INDEX idx_decision_event_created_at ON TABLE decision_event FIELDS created_at;
+
+-- ===== agent_memory (schema only) =====
+DEFINE TABLE IF NOT EXISTS agent_memory SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD memory_id ON TABLE agent_memory TYPE string;
+DEFINE FIELD scope ON TABLE agent_memory TYPE string;
+DEFINE FIELD namespace ON TABLE agent_memory TYPE string;
+DEFINE FIELD memory_type ON TABLE agent_memory TYPE string;
+DEFINE FIELD content ON TABLE agent_memory TYPE string;
+DEFINE FIELD source_refs ON TABLE agent_memory TYPE array;
+DEFINE FIELD evidence_refs ON TABLE agent_memory TYPE array;
+DEFINE FIELD confidence ON TABLE agent_memory TYPE float;
+DEFINE FIELD ttl ON TABLE agent_memory TYPE int;
+DEFINE FIELD expires_at ON TABLE agent_memory TYPE datetime;
+DEFINE FIELD stale_after ON TABLE agent_memory TYPE option<int>;
+DEFINE FIELD superseded_by ON TABLE agent_memory TYPE option<string>;
+DEFINE FIELD created_by ON TABLE agent_memory TYPE string;
+DEFINE FIELD comment ON TABLE agent_memory TYPE string;
+DEFINE FIELD created_at ON TABLE agent_memory TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_agent_memory_memory_id_unique ON TABLE agent_memory FIELDS memory_id UNIQUE;
+DEFINE INDEX idx_agent_memory_scope ON TABLE agent_memory FIELDS scope;
+DEFINE INDEX idx_agent_memory_namespace ON TABLE agent_memory FIELDS namespace;
+DEFINE INDEX idx_agent_memory_created_at ON TABLE agent_memory FIELDS created_at;
+
+-- ===== context_query =====
+DEFINE TABLE IF NOT EXISTS context_query SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD query_id ON TABLE context_query TYPE string;
+DEFINE FIELD query_type ON TABLE context_query TYPE string;
+DEFINE FIELD query_text ON TABLE context_query TYPE string;
+DEFINE FIELD context_refs ON TABLE context_query TYPE array;
+DEFINE FIELD confidence ON TABLE context_query TYPE float;
+DEFINE FIELD comment ON TABLE context_query TYPE string;
+DEFINE FIELD created_at ON TABLE context_query TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_context_query_query_id_unique ON TABLE context_query FIELDS query_id UNIQUE;
+DEFINE INDEX idx_context_query_query_type ON TABLE context_query FIELDS query_type;
+DEFINE INDEX idx_context_query_created_at ON TABLE context_query FIELDS created_at;
+
+-- ===== audit_observation =====
+DEFINE TABLE IF NOT EXISTS audit_observation SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD observation_id ON TABLE audit_observation TYPE string;
+DEFINE FIELD observation_type ON TABLE audit_observation TYPE string;
+DEFINE FIELD subject_ref ON TABLE audit_observation TYPE record;
+DEFINE FIELD message ON TABLE audit_observation TYPE string;
+DEFINE FIELD evidence_refs ON TABLE audit_observation TYPE array;
+DEFINE FIELD confidence ON TABLE audit_observation TYPE float;
+DEFINE FIELD observed_by ON TABLE audit_observation TYPE string;
+DEFINE FIELD observed_at ON TABLE audit_observation TYPE datetime;
+DEFINE FIELD comment ON TABLE audit_observation TYPE string;
+DEFINE FIELD severity ON TABLE audit_observation TYPE string;
+DEFINE FIELD related_claims ON TABLE audit_observation TYPE array;
+DEFINE FIELD related_decisions ON TABLE audit_observation TYPE array;
+DEFINE FIELD related_memory ON TABLE audit_observation TYPE array;
+DEFINE FIELD status ON TABLE audit_observation TYPE string;
+DEFINE FIELD created_at ON TABLE audit_observation TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_audit_observation_observation_id_unique ON TABLE audit_observation FIELDS observation_id UNIQUE;
+DEFINE INDEX idx_audit_observation_type ON TABLE audit_observation FIELDS observation_type;
+DEFINE INDEX idx_audit_observation_observed_at ON TABLE audit_observation FIELDS observed_at;
+DEFINE INDEX idx_audit_observation_created_at ON TABLE audit_observation FIELDS created_at;
+DEFINE INDEX idx_audit_observation_severity ON TABLE audit_observation FIELDS severity;
+DEFINE INDEX idx_audit_observation_status ON TABLE audit_observation FIELDS status;
+
+-- ===== contradiction =====
+DEFINE TABLE IF NOT EXISTS contradiction SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD contradiction_id ON TABLE contradiction TYPE string;
+DEFINE FIELD contradiction_type ON TABLE contradiction TYPE string;
+DEFINE FIELD source_a_ref ON TABLE contradiction TYPE record;
+DEFINE FIELD source_b_ref ON TABLE contradiction TYPE record;
+DEFINE FIELD claim_refs ON TABLE contradiction TYPE array;
+DEFINE FIELD evidence_refs ON TABLE contradiction TYPE array;
+DEFINE FIELD severity ON TABLE contradiction TYPE string;
+DEFINE FIELD confidence ON TABLE contradiction TYPE float;
+DEFINE FIELD detected_by ON TABLE contradiction TYPE string;
+DEFINE FIELD detected_at ON TABLE contradiction TYPE datetime;
+DEFINE FIELD status ON TABLE contradiction TYPE string;
+DEFINE FIELD recommended_action ON TABLE contradiction TYPE string;
+DEFINE FIELD comment ON TABLE contradiction TYPE string;
+DEFINE FIELD created_at ON TABLE contradiction TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_contradiction_id_unique ON TABLE contradiction FIELDS contradiction_id UNIQUE;
+DEFINE INDEX idx_contradiction_status ON TABLE contradiction FIELDS status;
+DEFINE INDEX idx_contradiction_detected_at ON TABLE contradiction FIELDS detected_at;
+DEFINE INDEX idx_contradiction_created_at ON TABLE contradiction FIELDS created_at;
+
+-- ===== stale_context =====
+DEFINE TABLE IF NOT EXISTS stale_context SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD stale_id ON TABLE stale_context TYPE string;
+DEFINE FIELD subject_ref ON TABLE stale_context TYPE record;
+DEFINE FIELD reason ON TABLE stale_context TYPE string;
+DEFINE FIELD source_refs ON TABLE stale_context TYPE array;
+DEFINE FIELD evidence_refs ON TABLE stale_context TYPE array;
+DEFINE FIELD severity ON TABLE stale_context TYPE string;
+DEFINE FIELD confidence ON TABLE stale_context TYPE float;
+DEFINE FIELD detected_by ON TABLE stale_context TYPE string;
+DEFINE FIELD detected_at ON TABLE stale_context TYPE datetime;
+DEFINE FIELD status ON TABLE stale_context TYPE string;
+DEFINE FIELD comment ON TABLE stale_context TYPE string;
+DEFINE FIELD created_at ON TABLE stale_context TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_stale_context_stale_id_unique ON TABLE stale_context FIELDS stale_id UNIQUE;
+DEFINE INDEX idx_stale_context_status ON TABLE stale_context FIELDS status;
+DEFINE INDEX idx_stale_context_detected_at ON TABLE stale_context FIELDS detected_at;
+DEFINE INDEX idx_stale_context_created_at ON TABLE stale_context FIELDS created_at;
+
+-- ===== scope_drift_event =====
+DEFINE TABLE IF NOT EXISTS scope_drift_event SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD drift_id ON TABLE scope_drift_event TYPE string;
+DEFINE FIELD scope ON TABLE scope_drift_event TYPE string;
+DEFINE FIELD event_type ON TABLE scope_drift_event TYPE string;
+DEFINE FIELD subject_ref ON TABLE scope_drift_event TYPE record;
+DEFINE FIELD message ON TABLE scope_drift_event TYPE string;
+DEFINE FIELD evidence_refs ON TABLE scope_drift_event TYPE array;
+DEFINE FIELD confidence ON TABLE scope_drift_event TYPE float;
+DEFINE FIELD detected_by ON TABLE scope_drift_event TYPE string;
+DEFINE FIELD detected_at ON TABLE scope_drift_event TYPE datetime;
+DEFINE FIELD status ON TABLE scope_drift_event TYPE string;
+DEFINE FIELD comment ON TABLE scope_drift_event TYPE string;
+DEFINE FIELD created_at ON TABLE scope_drift_event TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_scope_drift_id_unique ON TABLE scope_drift_event FIELDS drift_id UNIQUE;
+DEFINE INDEX idx_scope_drift_event_type ON TABLE scope_drift_event FIELDS event_type;
+DEFINE INDEX idx_scope_drift_status ON TABLE scope_drift_event FIELDS status;
+DEFINE INDEX idx_scope_drift_created_at ON TABLE scope_drift_event FIELDS created_at;
+
+-- ===== knowledge_quality_score =====
+DEFINE TABLE IF NOT EXISTS knowledge_quality_score SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD score_id ON TABLE knowledge_quality_score TYPE string;
+DEFINE FIELD subject_ref ON TABLE knowledge_quality_score TYPE record;
+DEFINE FIELD scoring_model ON TABLE knowledge_quality_score TYPE string;
+DEFINE FIELD score ON TABLE knowledge_quality_score TYPE float;
+DEFINE FIELD dimensions ON TABLE knowledge_quality_score TYPE record;
+DEFINE FIELD confidence ON TABLE knowledge_quality_score TYPE float;
+DEFINE FIELD computed_by ON TABLE knowledge_quality_score TYPE string;
+DEFINE FIELD computed_at ON TABLE knowledge_quality_score TYPE datetime;
+DEFINE FIELD comment ON TABLE knowledge_quality_score TYPE string;
+DEFINE FIELD created_at ON TABLE knowledge_quality_score TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_knowledge_quality_score_id_unique ON TABLE knowledge_quality_score FIELDS score_id UNIQUE;
+DEFINE INDEX idx_knowledge_quality_subject_ref ON TABLE knowledge_quality_score FIELDS subject_ref;
+DEFINE INDEX idx_knowledge_quality_computed_at ON TABLE knowledge_quality_score FIELDS computed_at;
+DEFINE INDEX idx_knowledge_quality_created_at ON TABLE knowledge_quality_score FIELDS created_at;
+
+-- ===== visual_control_view =====
+DEFINE TABLE IF NOT EXISTS visual_control_view SCHEMAFULL
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD view_id ON TABLE visual_control_view TYPE string;
+DEFINE FIELD view_type ON TABLE visual_control_view TYPE string;
+DEFINE FIELD view_label ON TABLE visual_control_view TYPE string;
+DEFINE FIELD target_scope ON TABLE visual_control_view TYPE string;
+DEFINE FIELD data_sources ON TABLE visual_control_view TYPE array;
+DEFINE FIELD filters ON TABLE visual_control_view TYPE record;
+DEFINE FIELD required_queries ON TABLE visual_control_view TYPE array;
+DEFINE FIELD display_entities ON TABLE visual_control_view TYPE array;
+DEFINE FIELD display_edges ON TABLE visual_control_view TYPE array;
+DEFINE FIELD warnings ON TABLE visual_control_view TYPE array;
+DEFINE FIELD generated_at ON TABLE visual_control_view TYPE datetime;
+DEFINE FIELD generated_by ON TABLE visual_control_view TYPE string;
+DEFINE FIELD export_formats ON TABLE visual_control_view TYPE array;
+DEFINE FIELD guardrails ON TABLE visual_control_view TYPE array;
+DEFINE FIELD created_at ON TABLE visual_control_view TYPE datetime VALUE $value OR time::now();
+DEFINE INDEX idx_visual_control_view_id_unique ON TABLE visual_control_view FIELDS view_id UNIQUE;
+DEFINE INDEX idx_visual_control_view_type ON TABLE visual_control_view FIELDS view_type;
+DEFINE INDEX idx_visual_control_view_scope ON TABLE visual_control_view FIELDS target_scope;
+DEFINE INDEX idx_visual_control_view_generated_at ON TABLE visual_control_view FIELDS generated_at;
+DEFINE INDEX idx_visual_control_view_created_at ON TABLE visual_control_view FIELDS created_at;

--- a/infrastructure/surrealdb/schema_baseline.json
+++ b/infrastructure/surrealdb/schema_baseline.json
@@ -1,0 +1,1224 @@
+{
+  "source_file": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare\\infrastructure\\surrealdb\\context_intelligence_v0.surql",
+  "generated_at": "2026-01-01T00:00:00Z",
+  "schema_hash": "6e08050f4f1689adb00d459e6ce0e2c43bacf7032a9c36e49080a12849cc82aa",
+  "table_count": 18,
+  "field_count": 225,
+  "index_count": 73,
+  "tables": [
+    "agent_memory",
+    "audit_observation",
+    "claim",
+    "code_symbol",
+    "concept",
+    "context_query",
+    "contradiction",
+    "decision_event",
+    "dependency_edge",
+    "doc_chunk",
+    "doc_page",
+    "doc_section",
+    "evidence_ref",
+    "knowledge_quality_score",
+    "repo_artifact",
+    "scope_drift_event",
+    "stale_context",
+    "visual_control_view"
+  ],
+  "fields": [
+    {
+      "field": "comment",
+      "table": "agent_memory"
+    },
+    {
+      "field": "confidence",
+      "table": "agent_memory"
+    },
+    {
+      "field": "content",
+      "table": "agent_memory"
+    },
+    {
+      "field": "created_at",
+      "table": "agent_memory"
+    },
+    {
+      "field": "created_by",
+      "table": "agent_memory"
+    },
+    {
+      "field": "evidence_refs",
+      "table": "agent_memory"
+    },
+    {
+      "field": "expires_at",
+      "table": "agent_memory"
+    },
+    {
+      "field": "memory_id",
+      "table": "agent_memory"
+    },
+    {
+      "field": "memory_type",
+      "table": "agent_memory"
+    },
+    {
+      "field": "namespace",
+      "table": "agent_memory"
+    },
+    {
+      "field": "scope",
+      "table": "agent_memory"
+    },
+    {
+      "field": "source_refs",
+      "table": "agent_memory"
+    },
+    {
+      "field": "stale_after",
+      "table": "agent_memory"
+    },
+    {
+      "field": "superseded_by",
+      "table": "agent_memory"
+    },
+    {
+      "field": "ttl",
+      "table": "agent_memory"
+    },
+    {
+      "field": "comment",
+      "table": "audit_observation"
+    },
+    {
+      "field": "confidence",
+      "table": "audit_observation"
+    },
+    {
+      "field": "created_at",
+      "table": "audit_observation"
+    },
+    {
+      "field": "evidence_refs",
+      "table": "audit_observation"
+    },
+    {
+      "field": "message",
+      "table": "audit_observation"
+    },
+    {
+      "field": "observation_id",
+      "table": "audit_observation"
+    },
+    {
+      "field": "observation_type",
+      "table": "audit_observation"
+    },
+    {
+      "field": "observed_at",
+      "table": "audit_observation"
+    },
+    {
+      "field": "observed_by",
+      "table": "audit_observation"
+    },
+    {
+      "field": "related_claims",
+      "table": "audit_observation"
+    },
+    {
+      "field": "related_decisions",
+      "table": "audit_observation"
+    },
+    {
+      "field": "related_memory",
+      "table": "audit_observation"
+    },
+    {
+      "field": "severity",
+      "table": "audit_observation"
+    },
+    {
+      "field": "status",
+      "table": "audit_observation"
+    },
+    {
+      "field": "subject_ref",
+      "table": "audit_observation"
+    },
+    {
+      "field": "claim_id",
+      "table": "claim"
+    },
+    {
+      "field": "comment",
+      "table": "claim"
+    },
+    {
+      "field": "confidence",
+      "table": "claim"
+    },
+    {
+      "field": "created_at",
+      "table": "claim"
+    },
+    {
+      "field": "evidence_refs",
+      "table": "claim"
+    },
+    {
+      "field": "scope",
+      "table": "claim"
+    },
+    {
+      "field": "source_refs",
+      "table": "claim"
+    },
+    {
+      "field": "statement",
+      "table": "claim"
+    },
+    {
+      "field": "status",
+      "table": "claim"
+    },
+    {
+      "field": "title",
+      "table": "claim"
+    },
+    {
+      "field": "comment",
+      "table": "code_symbol"
+    },
+    {
+      "field": "confidence",
+      "table": "code_symbol"
+    },
+    {
+      "field": "created_at",
+      "table": "code_symbol"
+    },
+    {
+      "field": "file_path",
+      "table": "code_symbol"
+    },
+    {
+      "field": "language",
+      "table": "code_symbol"
+    },
+    {
+      "field": "name",
+      "table": "code_symbol"
+    },
+    {
+      "field": "qualified_name",
+      "table": "code_symbol"
+    },
+    {
+      "field": "source_commit",
+      "table": "code_symbol"
+    },
+    {
+      "field": "source_hash",
+      "table": "code_symbol"
+    },
+    {
+      "field": "span_end_line",
+      "table": "code_symbol"
+    },
+    {
+      "field": "span_start_line",
+      "table": "code_symbol"
+    },
+    {
+      "field": "symbol_id",
+      "table": "code_symbol"
+    },
+    {
+      "field": "symbol_kind",
+      "table": "code_symbol"
+    },
+    {
+      "field": "comment",
+      "table": "concept"
+    },
+    {
+      "field": "concept_id",
+      "table": "concept"
+    },
+    {
+      "field": "confidence",
+      "table": "concept"
+    },
+    {
+      "field": "created_at",
+      "table": "concept"
+    },
+    {
+      "field": "description",
+      "table": "concept"
+    },
+    {
+      "field": "evidence_refs",
+      "table": "concept"
+    },
+    {
+      "field": "freshness",
+      "table": "concept"
+    },
+    {
+      "field": "name",
+      "table": "concept"
+    },
+    {
+      "field": "source_refs",
+      "table": "concept"
+    },
+    {
+      "field": "tags",
+      "table": "concept"
+    },
+    {
+      "field": "comment",
+      "table": "context_query"
+    },
+    {
+      "field": "confidence",
+      "table": "context_query"
+    },
+    {
+      "field": "context_refs",
+      "table": "context_query"
+    },
+    {
+      "field": "created_at",
+      "table": "context_query"
+    },
+    {
+      "field": "query_id",
+      "table": "context_query"
+    },
+    {
+      "field": "query_text",
+      "table": "context_query"
+    },
+    {
+      "field": "query_type",
+      "table": "context_query"
+    },
+    {
+      "field": "claim_refs",
+      "table": "contradiction"
+    },
+    {
+      "field": "comment",
+      "table": "contradiction"
+    },
+    {
+      "field": "confidence",
+      "table": "contradiction"
+    },
+    {
+      "field": "contradiction_id",
+      "table": "contradiction"
+    },
+    {
+      "field": "contradiction_type",
+      "table": "contradiction"
+    },
+    {
+      "field": "created_at",
+      "table": "contradiction"
+    },
+    {
+      "field": "detected_at",
+      "table": "contradiction"
+    },
+    {
+      "field": "detected_by",
+      "table": "contradiction"
+    },
+    {
+      "field": "evidence_refs",
+      "table": "contradiction"
+    },
+    {
+      "field": "recommended_action",
+      "table": "contradiction"
+    },
+    {
+      "field": "severity",
+      "table": "contradiction"
+    },
+    {
+      "field": "source_a_ref",
+      "table": "contradiction"
+    },
+    {
+      "field": "source_b_ref",
+      "table": "contradiction"
+    },
+    {
+      "field": "status",
+      "table": "contradiction"
+    },
+    {
+      "field": "affected_artifacts",
+      "table": "decision_event"
+    },
+    {
+      "field": "agent",
+      "table": "decision_event"
+    },
+    {
+      "field": "answer",
+      "table": "decision_event"
+    },
+    {
+      "field": "claim_refs",
+      "table": "decision_event"
+    },
+    {
+      "field": "comment",
+      "table": "decision_event"
+    },
+    {
+      "field": "confidence",
+      "table": "decision_event"
+    },
+    {
+      "field": "created_at",
+      "table": "decision_event"
+    },
+    {
+      "field": "decision_id",
+      "table": "decision_event"
+    },
+    {
+      "field": "decision_type",
+      "table": "decision_event"
+    },
+    {
+      "field": "evidence_refs",
+      "table": "decision_event"
+    },
+    {
+      "field": "human_go",
+      "table": "decision_event"
+    },
+    {
+      "field": "invalidated_by",
+      "table": "decision_event"
+    },
+    {
+      "field": "question",
+      "table": "decision_event"
+    },
+    {
+      "field": "scope",
+      "table": "decision_event"
+    },
+    {
+      "field": "status",
+      "table": "decision_event"
+    },
+    {
+      "field": "superseded_by",
+      "table": "decision_event"
+    },
+    {
+      "field": "title",
+      "table": "decision_event"
+    },
+    {
+      "field": "uncertainty",
+      "table": "decision_event"
+    },
+    {
+      "field": "comment",
+      "table": "dependency_edge"
+    },
+    {
+      "field": "confidence",
+      "table": "dependency_edge"
+    },
+    {
+      "field": "created_at",
+      "table": "dependency_edge"
+    },
+    {
+      "field": "edge_id",
+      "table": "dependency_edge"
+    },
+    {
+      "field": "edge_type",
+      "table": "dependency_edge"
+    },
+    {
+      "field": "evidence_level",
+      "table": "dependency_edge"
+    },
+    {
+      "field": "from_ref",
+      "table": "dependency_edge"
+    },
+    {
+      "field": "inferred",
+      "table": "dependency_edge"
+    },
+    {
+      "field": "source_ref",
+      "table": "dependency_edge"
+    },
+    {
+      "field": "to_ref",
+      "table": "dependency_edge"
+    },
+    {
+      "field": "chunk_id",
+      "table": "doc_chunk"
+    },
+    {
+      "field": "chunk_index",
+      "table": "doc_chunk"
+    },
+    {
+      "field": "comment",
+      "table": "doc_chunk"
+    },
+    {
+      "field": "confidence",
+      "table": "doc_chunk"
+    },
+    {
+      "field": "content",
+      "table": "doc_chunk"
+    },
+    {
+      "field": "content_hash",
+      "table": "doc_chunk"
+    },
+    {
+      "field": "created_at",
+      "table": "doc_chunk"
+    },
+    {
+      "field": "page_ref",
+      "table": "doc_chunk"
+    },
+    {
+      "field": "section_ref",
+      "table": "doc_chunk"
+    },
+    {
+      "field": "source_hash",
+      "table": "doc_chunk"
+    },
+    {
+      "field": "tokens_estimate",
+      "table": "doc_chunk"
+    },
+    {
+      "field": "comment",
+      "table": "doc_page"
+    },
+    {
+      "field": "confidence",
+      "table": "doc_page"
+    },
+    {
+      "field": "created_at",
+      "table": "doc_page"
+    },
+    {
+      "field": "doc_format",
+      "table": "doc_page"
+    },
+    {
+      "field": "freshness",
+      "table": "doc_page"
+    },
+    {
+      "field": "observed_at",
+      "table": "doc_page"
+    },
+    {
+      "field": "page_id",
+      "table": "doc_page"
+    },
+    {
+      "field": "source_commit",
+      "table": "doc_page"
+    },
+    {
+      "field": "source_hash",
+      "table": "doc_page"
+    },
+    {
+      "field": "source_path",
+      "table": "doc_page"
+    },
+    {
+      "field": "source_url",
+      "table": "doc_page"
+    },
+    {
+      "field": "title",
+      "table": "doc_page"
+    },
+    {
+      "field": "comment",
+      "table": "doc_section"
+    },
+    {
+      "field": "confidence",
+      "table": "doc_section"
+    },
+    {
+      "field": "created_at",
+      "table": "doc_section"
+    },
+    {
+      "field": "heading",
+      "table": "doc_section"
+    },
+    {
+      "field": "heading_path",
+      "table": "doc_section"
+    },
+    {
+      "field": "page_ref",
+      "table": "doc_section"
+    },
+    {
+      "field": "section_id",
+      "table": "doc_section"
+    },
+    {
+      "field": "section_index",
+      "table": "doc_section"
+    },
+    {
+      "field": "source_hash",
+      "table": "doc_section"
+    },
+    {
+      "field": "span_end_line",
+      "table": "doc_section"
+    },
+    {
+      "field": "span_start_line",
+      "table": "doc_section"
+    },
+    {
+      "field": "collected_at",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "comment",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "confidence",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "created_at",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "evidence_id",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "evidence_type",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "freshness",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "invalidates",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "observed_by",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "related_artifacts",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "related_decisions",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "source_commit",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "source_hash",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "source_path",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "source_url",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "validates",
+      "table": "evidence_ref"
+    },
+    {
+      "field": "comment",
+      "table": "knowledge_quality_score"
+    },
+    {
+      "field": "computed_at",
+      "table": "knowledge_quality_score"
+    },
+    {
+      "field": "computed_by",
+      "table": "knowledge_quality_score"
+    },
+    {
+      "field": "confidence",
+      "table": "knowledge_quality_score"
+    },
+    {
+      "field": "created_at",
+      "table": "knowledge_quality_score"
+    },
+    {
+      "field": "dimensions",
+      "table": "knowledge_quality_score"
+    },
+    {
+      "field": "score",
+      "table": "knowledge_quality_score"
+    },
+    {
+      "field": "score_id",
+      "table": "knowledge_quality_score"
+    },
+    {
+      "field": "scoring_model",
+      "table": "knowledge_quality_score"
+    },
+    {
+      "field": "subject_ref",
+      "table": "knowledge_quality_score"
+    },
+    {
+      "field": "artifact_id",
+      "table": "repo_artifact"
+    },
+    {
+      "field": "artifact_type",
+      "table": "repo_artifact"
+    },
+    {
+      "field": "comment",
+      "table": "repo_artifact"
+    },
+    {
+      "field": "confidence",
+      "table": "repo_artifact"
+    },
+    {
+      "field": "created_at",
+      "table": "repo_artifact"
+    },
+    {
+      "field": "freshness",
+      "table": "repo_artifact"
+    },
+    {
+      "field": "integrity_algo",
+      "table": "repo_artifact"
+    },
+    {
+      "field": "mime_type",
+      "table": "repo_artifact"
+    },
+    {
+      "field": "observed_at",
+      "table": "repo_artifact"
+    },
+    {
+      "field": "size_bytes",
+      "table": "repo_artifact"
+    },
+    {
+      "field": "source_commit",
+      "table": "repo_artifact"
+    },
+    {
+      "field": "source_hash",
+      "table": "repo_artifact"
+    },
+    {
+      "field": "source_path",
+      "table": "repo_artifact"
+    },
+    {
+      "field": "source_url",
+      "table": "repo_artifact"
+    },
+    {
+      "field": "comment",
+      "table": "scope_drift_event"
+    },
+    {
+      "field": "confidence",
+      "table": "scope_drift_event"
+    },
+    {
+      "field": "created_at",
+      "table": "scope_drift_event"
+    },
+    {
+      "field": "detected_at",
+      "table": "scope_drift_event"
+    },
+    {
+      "field": "detected_by",
+      "table": "scope_drift_event"
+    },
+    {
+      "field": "drift_id",
+      "table": "scope_drift_event"
+    },
+    {
+      "field": "event_type",
+      "table": "scope_drift_event"
+    },
+    {
+      "field": "evidence_refs",
+      "table": "scope_drift_event"
+    },
+    {
+      "field": "message",
+      "table": "scope_drift_event"
+    },
+    {
+      "field": "scope",
+      "table": "scope_drift_event"
+    },
+    {
+      "field": "status",
+      "table": "scope_drift_event"
+    },
+    {
+      "field": "subject_ref",
+      "table": "scope_drift_event"
+    },
+    {
+      "field": "comment",
+      "table": "stale_context"
+    },
+    {
+      "field": "confidence",
+      "table": "stale_context"
+    },
+    {
+      "field": "created_at",
+      "table": "stale_context"
+    },
+    {
+      "field": "detected_at",
+      "table": "stale_context"
+    },
+    {
+      "field": "detected_by",
+      "table": "stale_context"
+    },
+    {
+      "field": "evidence_refs",
+      "table": "stale_context"
+    },
+    {
+      "field": "reason",
+      "table": "stale_context"
+    },
+    {
+      "field": "severity",
+      "table": "stale_context"
+    },
+    {
+      "field": "source_refs",
+      "table": "stale_context"
+    },
+    {
+      "field": "stale_id",
+      "table": "stale_context"
+    },
+    {
+      "field": "status",
+      "table": "stale_context"
+    },
+    {
+      "field": "subject_ref",
+      "table": "stale_context"
+    },
+    {
+      "field": "created_at",
+      "table": "visual_control_view"
+    },
+    {
+      "field": "data_sources",
+      "table": "visual_control_view"
+    },
+    {
+      "field": "display_edges",
+      "table": "visual_control_view"
+    },
+    {
+      "field": "display_entities",
+      "table": "visual_control_view"
+    },
+    {
+      "field": "export_formats",
+      "table": "visual_control_view"
+    },
+    {
+      "field": "filters",
+      "table": "visual_control_view"
+    },
+    {
+      "field": "generated_at",
+      "table": "visual_control_view"
+    },
+    {
+      "field": "generated_by",
+      "table": "visual_control_view"
+    },
+    {
+      "field": "guardrails",
+      "table": "visual_control_view"
+    },
+    {
+      "field": "required_queries",
+      "table": "visual_control_view"
+    },
+    {
+      "field": "target_scope",
+      "table": "visual_control_view"
+    },
+    {
+      "field": "view_id",
+      "table": "visual_control_view"
+    },
+    {
+      "field": "view_label",
+      "table": "visual_control_view"
+    },
+    {
+      "field": "view_type",
+      "table": "visual_control_view"
+    },
+    {
+      "field": "warnings",
+      "table": "visual_control_view"
+    }
+  ],
+  "indexes": [
+    {
+      "index": "idx_agent_memory_created_at",
+      "table": "agent_memory"
+    },
+    {
+      "index": "idx_agent_memory_memory_id_unique",
+      "table": "agent_memory"
+    },
+    {
+      "index": "idx_agent_memory_namespace",
+      "table": "agent_memory"
+    },
+    {
+      "index": "idx_agent_memory_scope",
+      "table": "agent_memory"
+    },
+    {
+      "index": "idx_audit_observation_created_at",
+      "table": "audit_observation"
+    },
+    {
+      "index": "idx_audit_observation_observation_id_unique",
+      "table": "audit_observation"
+    },
+    {
+      "index": "idx_audit_observation_observed_at",
+      "table": "audit_observation"
+    },
+    {
+      "index": "idx_audit_observation_severity",
+      "table": "audit_observation"
+    },
+    {
+      "index": "idx_audit_observation_status",
+      "table": "audit_observation"
+    },
+    {
+      "index": "idx_audit_observation_type",
+      "table": "audit_observation"
+    },
+    {
+      "index": "idx_claim_claim_id_unique",
+      "table": "claim"
+    },
+    {
+      "index": "idx_claim_created_at",
+      "table": "claim"
+    },
+    {
+      "index": "idx_claim_status",
+      "table": "claim"
+    },
+    {
+      "index": "idx_code_symbol_created_at",
+      "table": "code_symbol"
+    },
+    {
+      "index": "idx_code_symbol_file_path",
+      "table": "code_symbol"
+    },
+    {
+      "index": "idx_code_symbol_qualified_name",
+      "table": "code_symbol"
+    },
+    {
+      "index": "idx_code_symbol_symbol_id_unique",
+      "table": "code_symbol"
+    },
+    {
+      "index": "idx_concept_concept_id_unique",
+      "table": "concept"
+    },
+    {
+      "index": "idx_concept_created_at",
+      "table": "concept"
+    },
+    {
+      "index": "idx_concept_name",
+      "table": "concept"
+    },
+    {
+      "index": "idx_context_query_created_at",
+      "table": "context_query"
+    },
+    {
+      "index": "idx_context_query_query_id_unique",
+      "table": "context_query"
+    },
+    {
+      "index": "idx_context_query_query_type",
+      "table": "context_query"
+    },
+    {
+      "index": "idx_contradiction_created_at",
+      "table": "contradiction"
+    },
+    {
+      "index": "idx_contradiction_detected_at",
+      "table": "contradiction"
+    },
+    {
+      "index": "idx_contradiction_id_unique",
+      "table": "contradiction"
+    },
+    {
+      "index": "idx_contradiction_status",
+      "table": "contradiction"
+    },
+    {
+      "index": "idx_decision_event_created_at",
+      "table": "decision_event"
+    },
+    {
+      "index": "idx_decision_event_decision_id_unique",
+      "table": "decision_event"
+    },
+    {
+      "index": "idx_decision_event_status",
+      "table": "decision_event"
+    },
+    {
+      "index": "idx_dependency_edge_created_at",
+      "table": "dependency_edge"
+    },
+    {
+      "index": "idx_dependency_edge_from_ref",
+      "table": "dependency_edge"
+    },
+    {
+      "index": "idx_dependency_edge_id_unique",
+      "table": "dependency_edge"
+    },
+    {
+      "index": "idx_dependency_edge_to_ref",
+      "table": "dependency_edge"
+    },
+    {
+      "index": "idx_dependency_edge_type",
+      "table": "dependency_edge"
+    },
+    {
+      "index": "idx_doc_chunk_chunk_id_unique",
+      "table": "doc_chunk"
+    },
+    {
+      "index": "idx_doc_chunk_content_hash",
+      "table": "doc_chunk"
+    },
+    {
+      "index": "idx_doc_chunk_created_at",
+      "table": "doc_chunk"
+    },
+    {
+      "index": "idx_doc_chunk_page_ref",
+      "table": "doc_chunk"
+    },
+    {
+      "index": "idx_doc_chunk_section_ref",
+      "table": "doc_chunk"
+    },
+    {
+      "index": "idx_doc_page_created_at",
+      "table": "doc_page"
+    },
+    {
+      "index": "idx_doc_page_page_id_unique",
+      "table": "doc_page"
+    },
+    {
+      "index": "idx_doc_page_source_hash",
+      "table": "doc_page"
+    },
+    {
+      "index": "idx_doc_page_source_path",
+      "table": "doc_page"
+    },
+    {
+      "index": "idx_doc_section_created_at",
+      "table": "doc_section"
+    },
+    {
+      "index": "idx_doc_section_page_ref",
+      "table": "doc_section"
+    },
+    {
+      "index": "idx_doc_section_section_id_unique",
+      "table": "doc_section"
+    },
+    {
+      "index": "idx_evidence_ref_collected_at",
+      "table": "evidence_ref"
+    },
+    {
+      "index": "idx_evidence_ref_created_at",
+      "table": "evidence_ref"
+    },
+    {
+      "index": "idx_evidence_ref_evidence_id_unique",
+      "table": "evidence_ref"
+    },
+    {
+      "index": "idx_evidence_ref_source_hash",
+      "table": "evidence_ref"
+    },
+    {
+      "index": "idx_evidence_ref_source_path",
+      "table": "evidence_ref"
+    },
+    {
+      "index": "idx_knowledge_quality_computed_at",
+      "table": "knowledge_quality_score"
+    },
+    {
+      "index": "idx_knowledge_quality_created_at",
+      "table": "knowledge_quality_score"
+    },
+    {
+      "index": "idx_knowledge_quality_score_id_unique",
+      "table": "knowledge_quality_score"
+    },
+    {
+      "index": "idx_knowledge_quality_subject_ref",
+      "table": "knowledge_quality_score"
+    },
+    {
+      "index": "idx_repo_artifact_artifact_id_unique",
+      "table": "repo_artifact"
+    },
+    {
+      "index": "idx_repo_artifact_created_at",
+      "table": "repo_artifact"
+    },
+    {
+      "index": "idx_repo_artifact_source_hash",
+      "table": "repo_artifact"
+    },
+    {
+      "index": "idx_repo_artifact_source_path",
+      "table": "repo_artifact"
+    },
+    {
+      "index": "idx_scope_drift_created_at",
+      "table": "scope_drift_event"
+    },
+    {
+      "index": "idx_scope_drift_event_type",
+      "table": "scope_drift_event"
+    },
+    {
+      "index": "idx_scope_drift_id_unique",
+      "table": "scope_drift_event"
+    },
+    {
+      "index": "idx_scope_drift_status",
+      "table": "scope_drift_event"
+    },
+    {
+      "index": "idx_stale_context_created_at",
+      "table": "stale_context"
+    },
+    {
+      "index": "idx_stale_context_detected_at",
+      "table": "stale_context"
+    },
+    {
+      "index": "idx_stale_context_stale_id_unique",
+      "table": "stale_context"
+    },
+    {
+      "index": "idx_stale_context_status",
+      "table": "stale_context"
+    },
+    {
+      "index": "idx_visual_control_view_created_at",
+      "table": "visual_control_view"
+    },
+    {
+      "index": "idx_visual_control_view_generated_at",
+      "table": "visual_control_view"
+    },
+    {
+      "index": "idx_visual_control_view_id_unique",
+      "table": "visual_control_view"
+    },
+    {
+      "index": "idx_visual_control_view_scope",
+      "table": "visual_control_view"
+    },
+    {
+      "index": "idx_visual_control_view_type",
+      "table": "visual_control_view"
+    }
+  ]
+}

--- a/tests/surrealdb/conftest.py
+++ b/tests/surrealdb/conftest.py
@@ -1,0 +1,28 @@
+"""Test fixtures for SurrealDB schema tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+SURQL_ORIGINAL = Path("infrastructure/surrealdb/context_intelligence_v0.surql")
+SURQL_DEPLOY = Path("infrastructure/surrealdb/context_intelligence_v0_deploy.surql")
+BASELINE_PATH = Path("infrastructure/surrealdb/schema_baseline.json")
+
+
+@pytest.fixture(scope="session")
+def surql_original_text() -> str:
+    return SURQL_ORIGINAL.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="session")
+def surql_deploy_text() -> str:
+    return SURQL_DEPLOY.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="session")
+def baseline_json() -> dict:
+    import json
+    return json.loads(BASELINE_PATH.read_text(encoding="utf-8"))

--- a/tests/surrealdb/test_context_intelligence_v0_surql.py
+++ b/tests/surrealdb/test_context_intelligence_v0_surql.py
@@ -1,0 +1,268 @@
+"""Schema contract tests for context_intelligence_v0.surql family.
+
+All tests are static file parsing — no DB connection needed.
+"""
+
+from __future__ import annotations
+
+import re
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.surrealdb.conftest import SURQL_ORIGINAL, SURQL_DEPLOY, BASELINE_PATH
+
+# ---------------------------------------------------------------------------
+# Canonical table list — source of truth for schema expectations
+# ---------------------------------------------------------------------------
+EXPECTED_TABLES: tuple[str, ...] = (
+    "repo_artifact",
+    "code_symbol",
+    "doc_page",
+    "doc_section",
+    "doc_chunk",
+    "concept",
+    "dependency_edge",
+    "evidence_ref",
+    "claim",
+    "decision_event",
+    "agent_memory",
+    "context_query",
+    "audit_observation",
+    "contradiction",
+    "stale_context",
+    "scope_drift_event",
+    "knowledge_quality_score",
+    "visual_control_view",
+)
+
+PK_FIELD_BY_TABLE: dict[str, str] = {
+    "repo_artifact": "artifact_id",
+    "code_symbol": "symbol_id",
+    "doc_page": "page_id",
+    "doc_section": "section_id",
+    "doc_chunk": "chunk_id",
+    "concept": "concept_id",
+    "dependency_edge": "edge_id",
+    "evidence_ref": "evidence_id",
+    "claim": "claim_id",
+    "decision_event": "decision_id",
+    "agent_memory": "memory_id",
+    "context_query": "query_id",
+    "audit_observation": "observation_id",
+    "contradiction": "contradiction_id",
+    "stale_context": "stale_id",
+    "scope_drift_event": "drift_id",
+    "knowledge_quality_score": "score_id",
+    "visual_control_view": "view_id",
+}
+
+FORBIDDEN_TABLES: tuple[str, ...] = (
+    "order",
+    "fill",
+    "position",
+    "risk_state",
+    "position_state",
+    "trade",
+)
+
+# Blocks that must NOT appear in deploy file permissions
+PERMISSION_BLOCKS = {"FOR select FULL", "FOR create FULL", "FOR update FULL", "FOR delete FULL"}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RE_DEFINE_TABLE = re.compile(
+    r"^\s*DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)\s+SCHEMAFULL",
+    re.IGNORECASE | re.MULTILINE,
+)
+_RE_DEFINE_FIELD = re.compile(
+    r"^\s*DEFINE\s+FIELD\s+(\S+)\s+ON\s+TABLE\s+(\S+)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_RE_DEFINE_INDEX = re.compile(
+    r"^\s*DEFINE\s+INDEX\s+(\S+)\s+ON\s+TABLE\s+(\S+)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_RE_TABLE_SCHEMAFULL = re.compile(
+    r"^\s*DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)\s+SCHEMAFULL",
+    re.IGNORECASE | re.MULTILINE,
+)
+_RE_DEFINE_TABLE_ANY = re.compile(
+    r"^\s*DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_RE_PERMISSIONS = re.compile(
+    r"DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)\s+SCHEMAFULL\s+PERMISSIONS\s+FOR\s+select\s+NONE,\s+FOR\s+create\s+NONE,\s+FOR\s+update\s+NONE,\s+FOR\s+delete\s+NONE",
+    re.IGNORECASE,
+)
+
+
+def extract_tables(surql_text: str) -> set[str]:
+    return set(_RE_DEFINE_TABLE.findall(surql_text))
+
+
+def extract_fields(surql_text: str) -> set[str]:
+    return {f"{t}.{f}" for f, t in _RE_DEFINE_FIELD.findall(surql_text)}
+
+
+def extract_indexes(surql_text: str) -> set[str]:
+    return {f"{t}.{i}" for i, t in _RE_DEFINE_INDEX.findall(surql_text)}
+
+
+# ---------------------------------------------------------------------------
+# Original draft tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_surql_defines_all_expected_tables(surql_original_text: str) -> None:
+    tables = extract_tables(surql_original_text)
+    for table in EXPECTED_TABLES:
+        assert table in tables, f"Missing table: {table}"
+
+
+@pytest.mark.unit
+def test_each_table_is_schemafull(surql_original_text: str) -> None:
+    for m in _RE_TABLE_SCHEMAFULL.finditer(surql_original_text):
+        pass
+    tables_found = _RE_TABLE_SCHEMAFULL.findall(surql_original_text)
+    assert len(tables_found) == len(EXPECTED_TABLES)
+
+
+@pytest.mark.unit
+def test_each_table_has_pk_field_and_unique_index(surql_original_text: str) -> None:
+    for table, pk_field in PK_FIELD_BY_TABLE.items():
+        assert f"DEFINE FIELD {pk_field} ON TABLE {table}" in surql_original_text, (
+            f"Missing PK field {pk_field} on {table}"
+        )
+        idx_name = f"idx_{table}_{pk_field}_unique"
+        assert f"ON TABLE {table} FIELDS {pk_field} UNIQUE" in surql_original_text
+
+
+@pytest.mark.unit
+def test_each_table_has_created_at_field(surql_original_text: str) -> None:
+    tables_found = _RE_DEFINE_TABLE.findall(surql_original_text)
+    for table in tables_found:
+        assert f"DEFINE FIELD created_at ON TABLE {table}" in surql_original_text, (
+            f"Missing created_at on {table}"
+        )
+
+
+@pytest.mark.unit
+def test_no_trading_state_tables(surql_original_text: str) -> None:
+    tables_declared = _RE_DEFINE_TABLE_ANY.findall(surql_original_text)
+    for forbidden in FORBIDDEN_TABLES:
+        matches = [t for t in tables_declared if forbidden in t.lower()]
+        assert not matches, f"Forbidden table found: {matches}"
+
+
+# ---------------------------------------------------------------------------
+# Deploy file tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_deploy_file_has_ns_and_db_context(surql_deploy_text: str) -> None:
+    assert "DEFINE NAMESPACE IF NOT EXISTS cdb;" in surql_deploy_text
+    assert "USE NS cdb;" in surql_deploy_text
+    assert "DEFINE DATABASE IF NOT EXISTS context_intel;" in surql_deploy_text
+    assert "USE DB context_intel;" in surql_deploy_text
+
+
+@pytest.mark.unit
+def test_deploy_file_uses_if_not_exists(surql_deploy_text: str) -> None:
+    for table in EXPECTED_TABLES:
+        expected = f"DEFINE TABLE IF NOT EXISTS {table}"
+        assert expected in surql_deploy_text, (
+            f"Missing IF NOT EXISTS for table {table}"
+        )
+
+
+@pytest.mark.unit
+def test_deploy_file_permissions_are_strictly_none(surql_deploy_text: str) -> None:
+    """Verify each table has PERMISSIONS with all four operations set to NONE.
+
+    Normalises whitespace (including newlines) so that multi-line PERMISSIONS
+    declarations match correctly.
+    """
+    import re as _re
+    normalized = _re.sub(r"\s+", " ", surql_deploy_text)
+    for table in EXPECTED_TABLES:
+        expected = (
+            f"DEFINE TABLE IF NOT EXISTS {table} SCHEMAFULL "
+            f"PERMISSIONS FOR select NONE, FOR create NONE, "
+            f"FOR update NONE, FOR delete NONE"
+        )
+        assert expected in normalized, (
+            f"Table {table} missing fail-closed permissions"
+        )
+
+
+@pytest.mark.unit
+def test_deploy_file_has_no_full_permissions(surql_deploy_text: str) -> None:
+    for block in PERMISSION_BLOCKS:
+        assert block not in surql_deploy_text, (
+            f"Found non-NONE permission block: {block}"
+        )
+
+
+@pytest.mark.unit
+def test_deploy_matches_original_draft_core_definitions(
+    surql_original_text: str,
+    surql_deploy_text: str,
+) -> None:
+    original_fields = extract_fields(surql_original_text)
+    deploy_fields = extract_fields(surql_deploy_text)
+    assert original_fields == deploy_fields, (
+        f"Field drift: original={len(original_fields)}, deploy={len(deploy_fields)}\n"
+        f"Only in original: {original_fields - deploy_fields}\n"
+        f"Only in deploy: {deploy_fields - original_fields}"
+    )
+
+    original_indexes = extract_indexes(surql_original_text)
+    deploy_indexes = extract_indexes(surql_deploy_text)
+    assert original_indexes == deploy_indexes, (
+        f"Index drift: original={len(original_indexes)}, deploy={len(deploy_indexes)}\n"
+        f"Only in original: {original_indexes - deploy_indexes}\n"
+        f"Only in deploy: {deploy_indexes - original_indexes}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# generated_at metadata validation (no fragile time-window)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_schema_baseline_has_valid_generated_at_format(baseline_json: dict) -> None:
+    ga = baseline_json.get("generated_at", "")
+    assert isinstance(ga, str) and len(ga) > 10, (
+        f"generated_at missing or too short: {ga!r}"
+    )
+    # ISO-8601 compatible: YYYY-MM-DDTHH:MM:SS...
+    assert "T" in ga, f"generated_at not ISO-8601: {ga!r}"
+
+
+@pytest.mark.unit
+def test_generated_at_not_in_schema_hash_computation(
+    surql_original_text: str,
+    baseline_json: dict,
+) -> None:
+    """Verify generated_at is NOT part of the schema_hash input.
+
+    If generated_at were included, changing it would change the hash.
+    We can verify this by checking the hash is deterministic against
+    the baseline even though generated_at differs (test uses live time
+    while baseline uses fixed time).
+    """
+    from tools.surrealdb.schema_snapshot import build_snapshot
+
+    snapshot_live = build_snapshot(
+        surql_path=SURQL_ORIGINAL,
+    )
+    assert snapshot_live["schema_hash"] == baseline_json["schema_hash"], (
+        "schema_hash differs from baseline — generated_at may be leaking into hash"
+    )

--- a/tests/surrealdb/test_schema_snapshot.py
+++ b/tests/surrealdb/test_schema_snapshot.py
@@ -1,0 +1,114 @@
+"""Tests for the deterministic schema snapshot tool.
+
+All tests are static — no DB connection needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.surrealdb.schema_snapshot import (
+    build_snapshot,
+    compute_schema_hash,
+    parse_surql,
+)
+from tests.surrealdb.conftest import SURQL_ORIGINAL, SURQL_DEPLOY, BASELINE_PATH
+from tests.surrealdb.test_context_intelligence_v0_surql import EXPECTED_TABLES
+
+
+FIXED_TS = "2026-01-01T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_snapshot_parses_all_expected_tables() -> None:
+    canonical = parse_surql(SURQL_ORIGINAL)
+    for table in EXPECTED_TABLES:
+        assert table in canonical["tables"], f"Missing table: {table}"
+    assert len(canonical["tables"]) == len(EXPECTED_TABLES)
+
+
+@pytest.mark.unit
+def test_snapshot_parses_fields_and_indexes() -> None:
+    canonical = parse_surql(SURQL_ORIGINAL)
+    assert len(canonical["fields"]) > 0, "No fields parsed"
+    assert len(canonical["indexes"]) > 0, "No indexes parsed"
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_snapshot_hash_is_deterministic() -> None:
+    s1 = build_snapshot(SURQL_ORIGINAL, fixed_generated_at=FIXED_TS)
+    s2 = build_snapshot(SURQL_ORIGINAL, fixed_generated_at=FIXED_TS)
+    assert s1["schema_hash"] == s2["schema_hash"]
+
+
+@pytest.mark.unit
+def test_snapshot_hash_differs_for_different_input() -> None:
+    hash_original = build_snapshot(SURQL_ORIGINAL, fixed_generated_at=FIXED_TS)["schema_hash"]
+    hash_deploy = build_snapshot(SURQL_DEPLOY, fixed_generated_at=FIXED_TS)["schema_hash"]
+    assert hash_original == hash_deploy, (
+        "Core definitions should match between original and deploy"
+    )
+
+
+@pytest.mark.unit
+def test_snapshot_hash_not_affected_by_generated_at() -> None:
+    """generated_at must NOT influence schema_hash."""
+    s_fixed = build_snapshot(SURQL_ORIGINAL, fixed_generated_at=FIXED_TS)
+    s_empty = build_snapshot(SURQL_ORIGINAL, fixed_generated_at="")
+    assert s_fixed["schema_hash"] == s_empty["schema_hash"]
+
+
+# ---------------------------------------------------------------------------
+# Baseline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_snapshot_baseline_matches_current_schema(baseline_json: dict) -> None:
+    current = build_snapshot(SURQL_ORIGINAL, fixed_generated_at=FIXED_TS)
+    assert current["schema_hash"] == baseline_json["schema_hash"], (
+        f"Schema drift: baseline hash differs. "
+        f"Run: python tools/surrealdb/schema_snapshot.py "
+        f"--surql-path infrastructure/surrealdb/context_intelligence_v0.surql "
+        f"--output infrastructure/surrealdb/schema_baseline.json"
+    )
+
+
+@pytest.mark.unit
+def test_baseline_contains_essential_keys(baseline_json: dict) -> None:
+    for key in ("schema_hash", "table_count", "field_count", "index_count", "tables"):
+        assert key in baseline_json, f"Baseline missing key: {key}"
+    assert baseline_json["table_count"] == len(EXPECTED_TABLES)
+
+
+# ---------------------------------------------------------------------------
+# Deploy file consistency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_deploy_has_same_tables_as_original() -> None:
+    orig = parse_surql(SURQL_ORIGINAL)
+    depl = parse_surql(SURQL_DEPLOY)
+    assert orig["tables"] == depl["tables"]
+
+
+@pytest.mark.unit
+def test_deploy_has_same_core_schema_hash_as_original() -> None:
+    hash_orig = build_snapshot(SURQL_ORIGINAL, fixed_generated_at=FIXED_TS)["schema_hash"]
+    hash_depl = build_snapshot(SURQL_DEPLOY, fixed_generated_at=FIXED_TS)["schema_hash"]
+    assert hash_orig == hash_depl, (
+        "Deploy and original must have identical core schema hash"
+    )

--- a/tests/unit/test_clock.py
+++ b/tests/unit/test_clock.py
@@ -48,6 +48,7 @@ def test_guardrails_no_forbidden_calls():
         "core/utils/uuid_gen.py",
         "tools/arvp_probe_layer.py",
         "tools/arvp_campaign_supervisor.py",
+        "tools/surrealdb/schema_snapshot.py",  # #3420 — wall-clock metadata only; NOT in schema_hash
     }
     patterns = {
         "datetime.now": re.compile(r"datetime\.now\("),

--- a/tools/surrealdb/schema_snapshot.py
+++ b/tools/surrealdb/schema_snapshot.py
@@ -1,0 +1,220 @@
+"""Deterministic SurrealDB schema snapshot — repo-backed, no DB connection.
+
+Parses a .surql file, extracts canonical DEFINE TABLE / FIELD / INDEX
+statements, and produces a deterministic schema snapshot.
+
+The snapshot hash is computed ONLY over canonical schema definitions
+(sorted table/field/index lines).  The ``generated_at`` metadata field
+is wall-clock only and does NOT affect ``schema_hash``.
+
+Usage:
+    python tools/surrealdb/schema_snapshot.py \\
+        --surql-path infrastructure/surrealdb/context_intelligence_v0.surql
+
+    python tools/surrealdb/schema_snapshot.py \\
+        --surql-path infrastructure/surrealdb/context_intelligence_v0.surql \\
+        --check-baseline \\
+        --baseline-path infrastructure/surrealdb/schema_baseline.json
+
+    python tools/surrealdb/schema_snapshot.py \\
+        --surql-path infrastructure/surrealdb/context_intelligence_v0_deploy.surql \\
+        --fixed-generated-at "2026-01-01T00:00:00Z"
+
+Guardrails:
+    - No DB connection (repo-backed, deterministic)
+    - generated_at does NOT influence schema_hash
+    - --check-baseline exits 1 on mismatch (fail-closed)
+    - LR / Live / Echtgeld: NO-GO (this tool has no runtime effect)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+RE_TABLE = re.compile(r"^\s*DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)\s+SCHEMAFULL", re.IGNORECASE)
+RE_FIELD = re.compile(r"^\s*DEFINE\s+FIELD\s+(\S+)\s+ON\s+TABLE\s+(\S+)", re.IGNORECASE)
+RE_INDEX = re.compile(r"^\s*DEFINE\s+INDEX\s+(\S+)\s+ON\s+TABLE\s+(\S+)", re.IGNORECASE)
+RE_COMMENT_OR_BLANK = re.compile(r"^\s*(--|$)")
+
+
+def parse_surql(path: Path) -> dict[str, Any]:
+    """Parse a .surql file and return canonical schema definitions.
+
+    Returns a dict with:
+        tables: sorted list of table names
+        fields: list of {"field": str, "table": str} sorted by (table, field)
+        indexes: list of {"index": str, "table": str} sorted by (table, index)
+        raw_define_lines: sorted list of all DEFINE TABLE/FIELD/INDEX lines
+    """
+    tables: list[str] = []
+    fields: list[dict[str, str]] = []
+    indexes: list[dict[str, str]] = []
+    define_lines: list[str] = []
+
+    text = path.read_text(encoding="utf-8")
+
+    for line in text.splitlines():
+        if RE_COMMENT_OR_BLANK.match(line):
+            continue
+        stripped = line.strip()
+
+        m = RE_TABLE.match(stripped)
+        if m:
+            tables.append(m.group(1))
+            define_lines.append(stripped)
+            continue
+
+        m = RE_FIELD.match(stripped)
+        if m:
+            fields.append({"field": m.group(1), "table": m.group(2)})
+            define_lines.append(stripped)
+            continue
+
+        m = RE_INDEX.match(stripped)
+        if m:
+            indexes.append({"index": m.group(1), "table": m.group(2)})
+            define_lines.append(stripped)
+            continue
+
+    return {
+        "tables": sorted(tables),
+        "fields": sorted(fields, key=lambda x: (x["table"], x["field"])),
+        "indexes": sorted(indexes, key=lambda x: (x["table"], x["index"])),
+        "raw_define_lines": sorted(define_lines),
+    }
+
+
+def compute_schema_hash(canonical: dict[str, Any]) -> str:
+    """Compute a deterministic SHA256 hash over canonical schema definitions.
+
+    generated_at is NOT included in the hash input.
+    """
+    canonical_str = json.dumps(
+        {
+            "tables": canonical["tables"],
+            "fields": canonical["fields"],
+            "indexes": canonical["indexes"],
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical_str.encode("utf-8")).hexdigest()
+
+
+def build_snapshot(
+    surql_path: Path,
+    fixed_generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Build a full snapshot dict from a .surql file."""
+    canonical = parse_surql(surql_path)
+    schema_hash = compute_schema_hash(canonical)
+
+    if fixed_generated_at is not None:
+        generated_at = fixed_generated_at
+    else:
+        generated_at = datetime.now(timezone.utc).isoformat()
+
+    return {
+        "source_file": str(surql_path.resolve()),
+        "generated_at": generated_at,
+        "schema_hash": schema_hash,
+        "table_count": len(canonical["tables"]),
+        "field_count": len(canonical["fields"]),
+        "index_count": len(canonical["indexes"]),
+        "tables": canonical["tables"],
+        "fields": canonical["fields"],
+        "indexes": canonical["indexes"],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CDB SurrealDB schema snapshot tool")
+    parser.add_argument(
+        "--surql-path",
+        type=str,
+        default="infrastructure/surrealdb/context_intelligence_v0.surql",
+        help="Path to .surql file (default: context_intelligence_v0.surql)",
+    )
+    parser.add_argument(
+        "--fixed-generated-at",
+        type=str,
+        default=None,
+        help="Fixed ISO-8601 timestamp for deterministic testing",
+    )
+    parser.add_argument(
+        "--check-baseline",
+        action="store_true",
+        default=False,
+        help="Exit 1 if schema_hash differs from baseline",
+    )
+    parser.add_argument(
+        "--baseline-path",
+        type=str,
+        default="infrastructure/surrealdb/schema_baseline.json",
+        help="Path to baseline JSON file",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Write snapshot JSON to file (default: stdout)",
+    )
+
+    args = parser.parse_args()
+    surql_path = Path(args.surql_path)
+
+    if not surql_path.exists():
+        print(f"ERROR: File not found: {surql_path}", file=sys.stderr)
+        sys.exit(1)
+
+    snapshot = build_snapshot(
+        surql_path=surql_path,
+        fixed_generated_at=args.fixed_generated_at,
+    )
+
+    snapshot_json = json.dumps(snapshot, indent=2, ensure_ascii=False, default=str)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.write_text(snapshot_json, encoding="utf-8")
+        print(f"Snapshot written to {out_path}")
+    else:
+        print(snapshot_json)
+
+    if args.check_baseline:
+        baseline_path = Path(args.baseline_path)
+        if not baseline_path.exists():
+            print(
+                f"ERROR: Baseline file not found: {baseline_path}",
+                file=sys.stderr,
+            )
+            print("  Run without --check-baseline to generate baseline first.")
+            sys.exit(1)
+
+        baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+        current_hash = snapshot["schema_hash"]
+        baseline_hash = baseline["schema_hash"]
+
+        if current_hash != baseline_hash:
+            print(
+                f"SCHEMA DRIFT DETECTED: hash={current_hash} "
+                f"!= baseline={baseline_hash}",
+                file=sys.stderr,
+            )
+            print(f"  Source: {surql_path}", file=sys.stderr)
+            print(f"  Baseline: {baseline_path}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"Schema hash MATCHES baseline: {current_hash}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #3420
Refs #3418
Refs #3419

## Brain Evidence

\\\
brain_source: repo-only
brain_status: used
context_brain_attempted: true
context_brain_used: false
repo_fallback_used: true
repo_fallback_reason: insufficient_evidence
context_tool_status: absent (SurrealKit CLI not available)
context_trust_level: medium
records_found: none
\\\

## Delivered

- **context_intelligence_v0_deploy.surql** — SurrealKit-kompatibles Deploy-Wrapper mit NS/DB-Context, IF NOT EXISTS und fail-closed Permissions (FOR select/create/update/delete NONE)
- **tools/surrealdb/schema_snapshot.py** — deterministisches Schema-Snapshot-Tool (repo-backed, keine DB-Verbindung)
- **infrastructure/surrealdb/schema_baseline.json** — committedes Schema-Hash-Baseline (18 tables, 225 fields, 73 indexes)
- **tests/surrealdb/** — 21 neue Tests (Schema Contract + Snapshot)
- **docs/surrealdb/context-intelligence-v0-surrealkit-compatibility.md** — Kompatibilitätsdokumentation
- **infrastructure/surrealdb/README.md** — aktualisiert mit SurrealKit-Kompatibilitätsabschnitt

## Validation

- \git diff --check\: clean
- \pytest -q tests/surrealdb/\: 21/21 passed
- \pytest -q tests/unit/surrealdb/\: existing 1680 tests pass (all green)
- \schema_snapshot.py --check-baseline\]: hash matches baseline
- Safety grep: keine Trading-State-Objekte, keine Live-/Echtgeld-Referenzen
- Keine Runtime-/Docker-/MCP-/Secrets-Änderungen

## Non-goals (explizit eingehalten)

- Keine produktive Datenmigration
- Kein Live-Sync gegen echte SurrealDB-Instanzen
- Kein Bootstrapping von Daten
- Keine Änderung an PERSIST_ALLOWED / MUTATION_ALLOWED
- Kein Runtime-/Docker-/MCP-Scope
- Keine Trading-State-Objekte (Orders/Fills/Positions/Risk-State)
- Kein Scope-Wachstum auf #3421..#3427

## Safety Boundaries

| Boundary | Value |
|---|---|
| LR Status | **NO-GO** (unverändert) |
| Board Stage \	rade-capable\ | Orthogonal |
| Real Money Go | false |
| Productive DB Writes | false |
| PERSIST_ALLOWED | false |
| MUTATION_ALLOWED | false |
| Runtime BLUE/RED Changes | false |
| MCP Mutations | false |
| Secrets in Outputs | false |

## Restunsicherheiten

1. **SurrealKit CLI nicht verfügbar.** \surrealkit validate\ konnte nicht ausgeführt werden. Ein Follow-up-Issue für die Tooling-Integration ist erforderlich (siehe Holds).
2. **generated_at ist Wall-Clock-Metadatum.** Nicht im schema_hash enthalten, aber für CI-/Report-Zwecke sichtbar.

## Holds

- **HOLD_TOOLING_UNAVAILABLE:** SurrealKit CLI ist weder installiert noch im Repo referenziert. Die Deploy-Datei ist SurrealKit-kompatibel formuliert, sodass ein späteres \surrealkit validate\ ohne Schema-Änderungen funktioniert. Ein Follow-up-Issue wird nach Dedupe-Prüfung erstellt.

## 4 Verbindliche Anpassungen (Status)

- [x] generated_at nicht in schema_hash aufnehmen (entkoppelt)
- [x] Permissions strikt fail-closed (FOR select/create/update/delete NONE)
- [x] Drift-Guard zwischen Draft und Deploy (test_deploy_matches_original_draft_core_definitions + test_deploy_has_same_core_schema_hash_as_original)
- [x] SurrealKit CLI nicht als bestanden ausgewiesen (HOLD_TOOLING_UNAVAILABLE)