### PR TITLE
feat(surrealdb): add graph relations traversal foundation (#3423)

### DIFF
--- a/docs/surrealdb/context-relationship-vocabulary-v0.md
+++ b/docs/surrealdb/context-relationship-vocabulary-v0.md
@@ -347,7 +347,42 @@ Trace-level causal linkage. The source (effect) was caused by the target
 | Confidence | 1.0 (explicit attribution) / 0.7 (heuristic linkage) |
 | Example | `claim` "Scope drift detected" caused_by `scope_drift_event` "module boundary change" |
 
-### 5.18 `used_by`
+### 5.18 `cites`
+
+The source references or cites the target as an authoritative or contextual source.
+Used for artifact-to-decision traceability in the EvidenceGraph.
+
+| Property | Value |
+|---|---|
+| Direction | source → target |
+| Source types | `repo_artifact`, `doc_page`, `doc_chunk` |
+| Target types | `decision_event` |
+| Cardinality | N:M |
+| Inferred | No (explicit citation) |
+| Confidence | 0.9 (explicit citation, may be stale) |
+| Example | `repo_artifact` "ADR-002.md" cites `decision_event` "Decision to adopt ADOPT_AFTER_FOUNDATION_REPAIR" |
+
+Corresponding SurrealDB edge table: `artifact_cites_decision` (TYPE RELATION).
+
+### 5.19 `supports_evidence`
+
+The source provides contextual or evidential support for the target decision.
+Weaker than `validates` — memory entries may support a decision without constituting
+formal evidence.
+
+| Property | Value |
+|---|---|
+| Direction | source → target |
+| Source types | `agent_memory` |
+| Target types | `decision_event` |
+| Cardinality | N:M |
+| Inferred | No (explicit support attribution) |
+| Confidence | 0.8 (explicit support, memory is ephemeral) |
+| Example | `agent_memory` "Session log: LR-040 INCONCLUSIVE" supports_evidence `decision_event` "LR-050 NO-GO confirmed" |
+
+Corresponding SurrealDB edge table: `memory_supports_decision` (TYPE RELATION).
+
+### 5.20 `used_by`
 
 Inverse of `depends_on`. The source is used (depended upon) by the target.
 This is the canonical reverse-edge type for downstream trace traversal.
@@ -429,6 +464,8 @@ Store as an `audit_observation` flagged for human review instead.
 | `mentions` | any | any | Yes | 0.5 |
 | `related_to` | any | any | Yes | 0.5 |
 | `caused_by` | claim, decision_event, audit_observation, evidence_ref | decision_event, claim, code_symbol, scope_drift_event | No | 0.7 |
+| `cites` | repo_artifact, doc_page, doc_chunk | decision_event | No | 0.9 |
+| `supports_evidence` | agent_memory | decision_event | No | 0.8 |
 | `used_by` | any | any | Yes | 0.6 |
 
 ---
@@ -447,7 +484,57 @@ Store as an `audit_observation` flagged for human review instead.
 
 ---
 
-## 9. Relationship to Dependency Edge Model (#2000)
+## 9. SurrealDB Graph Schema (#3423)
+
+### 9.1 Record Links vs Graph Relations
+
+Issue #3423 introduces the first SurrealDB-native graph edge tables using
+`TYPE RELATION`. The decision per edge type:
+
+| Mechanism | Used For | Rationale |
+|---|---|---|
+| **Record Link** (`TYPE record`) | `page_ref`, `section_ref` on `doc_section`/`doc_chunk` | Simple 1:N parent reference; no metadata on the link itself |
+| **Graph Relation** (`TYPE RELATION`) | `artifact_cites_decision`, `memory_supports_decision`, `chunk_mentions_symbol` | Edge carries metadata (confidence, source, timestamp, hash); requires arrow traversal (`->edge->`) |
+
+### 9.2 Edge Table → Vocabulary Type Mapping
+
+| Edge Table | Vocabulary Type | Direction | Source Types | Target Types | Purpose |
+|---|---|---|---|---|---|
+| `artifact_cites_decision` | `cites` | source→target | repo_artifact, doc_page, doc_chunk | decision_event | Artifact-to-decision citation for EvidenceGraph |
+| `memory_supports_decision` | `supports_evidence` | source→target | agent_memory | decision_event | Memory-backed decision support |
+| `chunk_mentions_symbol` | `mentions` | source→target | doc_chunk | code_symbol | Content-to-code reference |
+
+### 9.3 Edge Metadata Conventions
+
+All TYPE RELATION tables carry the following metadata fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `source` | string | Provenance: tool, agent, or parser that created the edge |
+| `confidence` | float | Confidence score matching vocabulary confidence rules |
+| `timestamp` | datetime | When the relation was observed or asserted |
+| `hash` | string | Deterministic content hash for deduplication |
+| `comment` | string | Free-text annotation |
+| `created_at` | datetime | Record creation timestamp |
+
+### 9.4 Non-Goals (#3423)
+
+- No embedding or vector operations
+- No hybrid retrieval
+- No MCP evidence contract
+- No productive DB writes or schema sync
+- No data migration
+- No trading state references
+
+### 9.5 Next Slices
+
+- #3424 — Full-text + Vector + Hybrid Retrieval Contract
+- #3426 — Permission Matrix + Readonly Agent User
+- #3421 — Readonly MCP Brain Evidence Contract
+
+---
+
+## 10. Relationship to Dependency Edge Model (#2000)
 
 This vocabulary defines the **semantic types** of relations. The Dependency Edge
 Model (#2000) will:
@@ -467,9 +554,14 @@ fields. The importer validation does not yet enforce them. These gaps are tracke
 as implementation slices under #2000 / #2001 and are **not** in scope of this
 vocabulary specification (#1982).
 
+**Graph Relations (#3423)** are orthogonal to the Dependency Edge Model (#2000).
+The #3423 edges are SurrealDB-native `TYPE RELATION` tables with explicit metadata,
+whereas #2000 `dependency_edge` is a SCHEMAFULL table used by the indexer/importer
+pipeline. Both can coexist; #3423 does not replace or modify #2000.
+
 ---
 
-## 10. Downstream Consumers
+## 11. Downstream Consumers
 
 | Consumer | Issue | Usage |
 |---|---|---|
@@ -482,10 +574,14 @@ vocabulary specification (#1982).
 
 ---
 
-## 11. Validation Checklist
+## 12. Validation Checklist
 
-- [ ] All 18 relation types are defined with semantics, direction, and cardinality
+- [ ] All 20 relation types defined (including cites + supports_evidence from #3423)
+- [ ] SurrealDB TYPE RELATION edge tables exist for cites, supports_evidence, mentions
+- [ ] Edge metadata (source, confidence, timestamp, hash) matches vocabulary conventions
 - [ ] Source/target types reference only existing schema tables and endpoint reference types
+- [ ] Record Links vs Graph Relations decision is documented (Section 9.1)
+- [ ] Edge Table → Vocabulary Type mapping is documented (Section 9.2)
 - [ ] Confidence rules are defined per type (minimum confidence ≥ 0.5 for graph edge persistence)
 - [ ] Source reference requirement is specified as target-state contract (Section 6.2)
 - [ ] Inference rules are specified (Section 6.3)
@@ -494,11 +590,13 @@ vocabulary specification (#1982).
 - [ ] No secrets references
 - [ ] No live/echtgeld go inference
 - [ ] No runtime/compose/service changes implied
-- [ ] Downstream consumer mapping is present (Section 10)
+- [ ] Downstream consumer mapping is present (Section 11)
+- [ ] Non-goals for #3423 documented (Section 9.4)
+- [ ] Next slices documented (Section 9.5)
 
 ---
 
-## Provenance / Sources
+## 13. Provenance / Sources
 
 - **Issue**: #1982
 - **Parent**: #1976

--- a/infrastructure/surrealdb/context_intelligence_v0.surql
+++ b/infrastructure/surrealdb/context_intelligence_v0.surql
@@ -431,3 +431,58 @@ DEFINE INDEX idx_visual_control_view_scope ON TABLE visual_control_view FIELDS t
 DEFINE INDEX idx_visual_control_view_generated_at ON TABLE visual_control_view FIELDS generated_at;
 DEFINE INDEX idx_visual_control_view_created_at ON TABLE visual_control_view FIELDS created_at;
 
+-- ---------------------------
+-- Graph Relations v0 (Issue #3423)
+-- EvidenceGraph Foundation — TYPE RELATION Edge Tables
+-- Vocabulary: cites, supports_evidence, mentions
+-- ---------------------------
+
+-- ---------------------------
+-- artifact_cites_decision
+-- EvidenceGraph: artifact → decision citation link
+-- Vocabulary type: cites (v0)
+-- FROM repo_artifact|doc_page|doc_chunk TO decision_event
+-- ---------------------------
+DEFINE TABLE artifact_cites_decision TYPE RELATION
+  FROM repo_artifact | doc_page | doc_chunk
+  TO decision_event;
+DEFINE FIELD source ON TABLE artifact_cites_decision TYPE string;
+DEFINE FIELD confidence ON TABLE artifact_cites_decision TYPE float;
+DEFINE FIELD timestamp ON TABLE artifact_cites_decision TYPE datetime;
+DEFINE FIELD hash ON TABLE artifact_cites_decision TYPE string;
+DEFINE FIELD comment ON TABLE artifact_cites_decision TYPE string;
+DEFINE FIELD created_at ON TABLE artifact_cites_decision TYPE datetime VALUE $value OR time::now();
+
+-- ---------------------------
+-- memory_supports_decision
+-- EvidenceGraph: agent_memory → decision support link
+-- Vocabulary type: supports_evidence (v0)
+-- FROM agent_memory TO decision_event
+-- ---------------------------
+DEFINE TABLE memory_supports_decision TYPE RELATION
+  FROM agent_memory
+  TO decision_event;
+DEFINE FIELD source ON TABLE memory_supports_decision TYPE string;
+DEFINE FIELD confidence ON TABLE memory_supports_decision TYPE float;
+DEFINE FIELD timestamp ON TABLE memory_supports_decision TYPE datetime;
+DEFINE FIELD hash ON TABLE memory_supports_decision TYPE string;
+DEFINE FIELD comment ON TABLE memory_supports_decision TYPE string;
+DEFINE FIELD created_at ON TABLE memory_supports_decision TYPE datetime VALUE $value OR time::now();
+
+-- ---------------------------
+-- chunk_mentions_symbol
+-- EvidenceGraph: doc_chunk → code_symbol mention link
+-- Vocabulary type: mentions (existing v0)
+-- FROM doc_chunk TO code_symbol
+-- ---------------------------
+DEFINE TABLE chunk_mentions_symbol TYPE RELATION
+  FROM doc_chunk
+  TO code_symbol;
+DEFINE FIELD source ON TABLE chunk_mentions_symbol TYPE string;
+DEFINE FIELD confidence ON TABLE chunk_mentions_symbol TYPE float;
+DEFINE FIELD timestamp ON TABLE chunk_mentions_symbol TYPE datetime;
+DEFINE FIELD hash ON TABLE chunk_mentions_symbol TYPE string;
+DEFINE FIELD mention_context ON TABLE chunk_mentions_symbol TYPE string;
+DEFINE FIELD comment ON TABLE chunk_mentions_symbol TYPE string;
+DEFINE FIELD created_at ON TABLE chunk_mentions_symbol TYPE datetime VALUE $value OR time::now();
+

--- a/infrastructure/surrealdb/context_intelligence_v0_deploy.surql
+++ b/infrastructure/surrealdb/context_intelligence_v0_deploy.surql
@@ -405,3 +405,42 @@ DEFINE INDEX idx_visual_control_view_type ON TABLE visual_control_view FIELDS vi
 DEFINE INDEX idx_visual_control_view_scope ON TABLE visual_control_view FIELDS target_scope;
 DEFINE INDEX idx_visual_control_view_generated_at ON TABLE visual_control_view FIELDS generated_at;
 DEFINE INDEX idx_visual_control_view_created_at ON TABLE visual_control_view FIELDS created_at;
+
+-- ===== Graph Relations v0 (Issue #3423) =====
+
+-- ===== artifact_cites_decision =====
+DEFINE TABLE IF NOT EXISTS artifact_cites_decision TYPE RELATION
+  FROM repo_artifact | doc_page | doc_chunk
+  TO decision_event
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD source ON TABLE artifact_cites_decision TYPE string;
+DEFINE FIELD confidence ON TABLE artifact_cites_decision TYPE float;
+DEFINE FIELD timestamp ON TABLE artifact_cites_decision TYPE datetime;
+DEFINE FIELD hash ON TABLE artifact_cites_decision TYPE string;
+DEFINE FIELD comment ON TABLE artifact_cites_decision TYPE string;
+DEFINE FIELD created_at ON TABLE artifact_cites_decision TYPE datetime VALUE $value OR time::now();
+
+-- ===== memory_supports_decision =====
+DEFINE TABLE IF NOT EXISTS memory_supports_decision TYPE RELATION
+  FROM agent_memory
+  TO decision_event
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD source ON TABLE memory_supports_decision TYPE string;
+DEFINE FIELD confidence ON TABLE memory_supports_decision TYPE float;
+DEFINE FIELD timestamp ON TABLE memory_supports_decision TYPE datetime;
+DEFINE FIELD hash ON TABLE memory_supports_decision TYPE string;
+DEFINE FIELD comment ON TABLE memory_supports_decision TYPE string;
+DEFINE FIELD created_at ON TABLE memory_supports_decision TYPE datetime VALUE $value OR time::now();
+
+-- ===== chunk_mentions_symbol =====
+DEFINE TABLE IF NOT EXISTS chunk_mentions_symbol TYPE RELATION
+  FROM doc_chunk
+  TO code_symbol
+  PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE;
+DEFINE FIELD source ON TABLE chunk_mentions_symbol TYPE string;
+DEFINE FIELD confidence ON TABLE chunk_mentions_symbol TYPE float;
+DEFINE FIELD timestamp ON TABLE chunk_mentions_symbol TYPE datetime;
+DEFINE FIELD hash ON TABLE chunk_mentions_symbol TYPE string;
+DEFINE FIELD mention_context ON TABLE chunk_mentions_symbol TYPE string;
+DEFINE FIELD comment ON TABLE chunk_mentions_symbol TYPE string;
+DEFINE FIELD created_at ON TABLE chunk_mentions_symbol TYPE datetime VALUE $value OR time::now();

--- a/infrastructure/surrealdb/schema_baseline.json
+++ b/infrastructure/surrealdb/schema_baseline.json
@@ -1,14 +1,17 @@
 {
   "source_file": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare\\infrastructure\\surrealdb\\context_intelligence_v0.surql",
-  "generated_at": "2026-06-24T16:29:54.973969+00:00",
-  "schema_hash": "a575bbd09ec02f9dad28b4b5d4303d8626ca6151bace72462f67f6860699cadd",
-  "table_count": 18,
-  "field_count": 226,
+  "generated_at": "2026-06-24T17:11:29.501136+00:00",
+  "schema_hash": "15d82aa2e0baae1d4bc455666f88ce1245d690eb69735d676651dcf646d64a5b",
+  "table_count": 21,
+  "relation_table_count": 3,
+  "field_count": 245,
   "index_count": 75,
   "analyzer_count": 1,
   "tables": [
     "agent_memory",
+    "artifact_cites_decision",
     "audit_observation",
+    "chunk_mentions_symbol",
     "claim",
     "code_symbol",
     "concept",
@@ -21,10 +24,16 @@
     "doc_section",
     "evidence_ref",
     "knowledge_quality_score",
+    "memory_supports_decision",
     "repo_artifact",
     "scope_drift_event",
     "stale_context",
     "visual_control_view"
+  ],
+  "relation_tables": [
+    "artifact_cites_decision",
+    "chunk_mentions_symbol",
+    "memory_supports_decision"
   ],
   "fields": [
     {
@@ -89,6 +98,30 @@
     },
     {
       "field": "comment",
+      "table": "artifact_cites_decision"
+    },
+    {
+      "field": "confidence",
+      "table": "artifact_cites_decision"
+    },
+    {
+      "field": "created_at",
+      "table": "artifact_cites_decision"
+    },
+    {
+      "field": "hash",
+      "table": "artifact_cites_decision"
+    },
+    {
+      "field": "source",
+      "table": "artifact_cites_decision"
+    },
+    {
+      "field": "timestamp",
+      "table": "artifact_cites_decision"
+    },
+    {
+      "field": "comment",
       "table": "audit_observation"
     },
     {
@@ -146,6 +179,34 @@
     {
       "field": "subject_ref",
       "table": "audit_observation"
+    },
+    {
+      "field": "comment",
+      "table": "chunk_mentions_symbol"
+    },
+    {
+      "field": "confidence",
+      "table": "chunk_mentions_symbol"
+    },
+    {
+      "field": "created_at",
+      "table": "chunk_mentions_symbol"
+    },
+    {
+      "field": "hash",
+      "table": "chunk_mentions_symbol"
+    },
+    {
+      "field": "mention_context",
+      "table": "chunk_mentions_symbol"
+    },
+    {
+      "field": "source",
+      "table": "chunk_mentions_symbol"
+    },
+    {
+      "field": "timestamp",
+      "table": "chunk_mentions_symbol"
     },
     {
       "field": "claim_id",
@@ -718,6 +779,30 @@
     {
       "field": "subject_ref",
       "table": "knowledge_quality_score"
+    },
+    {
+      "field": "comment",
+      "table": "memory_supports_decision"
+    },
+    {
+      "field": "confidence",
+      "table": "memory_supports_decision"
+    },
+    {
+      "field": "created_at",
+      "table": "memory_supports_decision"
+    },
+    {
+      "field": "hash",
+      "table": "memory_supports_decision"
+    },
+    {
+      "field": "source",
+      "table": "memory_supports_decision"
+    },
+    {
+      "field": "timestamp",
+      "table": "memory_supports_decision"
     },
     {
       "field": "artifact_id",

--- a/infrastructure/surrealdb/traversal_query_fixtures.surql
+++ b/infrastructure/surrealdb/traversal_query_fixtures.surql
@@ -1,0 +1,40 @@
+-- =====================================================================
+-- Traversal Query Fixtures — static contract tests for Issue #3423
+-- These are NOT executable against a live DB in CI (no runtime).
+-- They define the expected SurrealQL traversal syntax contract.
+--
+-- Guardrails:
+-- - No productive DB connection needed
+-- - No migration, no runtime changes
+-- - No embedding / hybrid retrieval scope
+-- - No MCP evidence contract scope
+-- - LR remains NO-GO
+-- =====================================================================
+
+-- Forward traversal: artifact → cited decision
+SELECT ->artifact_cites_decision->decision_event.*
+FROM ONLY $artifact_id;
+
+-- Backward traversal: decision ← supported by memory
+SELECT <-memory_supports_decision<-agent_memory.*
+FROM ONLY $decision_id;
+
+-- Multi-hop: chunk → mentioned symbol → repo_artifact
+SELECT ->chunk_mentions_symbol->code_symbol->repo_artifact.*
+FROM ONLY $chunk_id;
+
+-- Recursive traversal (known depth 3): artifact → decision chain
+SELECT @.{3}->artifact_cites_decision->decision_event.*
+FROM ONLY $artifact_id;
+
+-- Bi-directional evidence chain: chunk → symbol ← chunks that mention it
+SELECT ->chunk_mentions_symbol->code_symbol<-chunk_mentions_symbol<-doc_chunk.*
+FROM ONLY $chunk_id;
+
+-- Decision with supporting memory chain (multi-hop backward)
+SELECT <-memory_supports_decision<-agent_memory->memory_supports_decision->decision_event.*
+FROM ONLY $decision_id;
+
+-- All artifacts citing a decision (forward from decision via backward traversal)
+SELECT <-artifact_cites_decision<-repo_artifact.*
+FROM ONLY $decision_id;

--- a/tests/surrealdb/test_context_intelligence_v0_surql.py
+++ b/tests/surrealdb/test_context_intelligence_v0_surql.py
@@ -17,25 +17,43 @@ from tests.surrealdb.conftest import SURQL_ORIGINAL, SURQL_DEPLOY, BASELINE_PATH
 # Canonical table list — source of truth for schema expectations
 # ---------------------------------------------------------------------------
 EXPECTED_TABLES: tuple[str, ...] = (
-    "repo_artifact",
+    "agent_memory",
+    "artifact_cites_decision",
+    "audit_observation",
+    "chunk_mentions_symbol",
+    "claim",
     "code_symbol",
+    "concept",
+    "context_query",
+    "contradiction",
+    "decision_event",
+    "dependency_edge",
+    "doc_chunk",
     "doc_page",
     "doc_section",
-    "doc_chunk",
-    "concept",
-    "dependency_edge",
     "evidence_ref",
-    "claim",
-    "decision_event",
-    "agent_memory",
-    "context_query",
-    "audit_observation",
-    "contradiction",
-    "stale_context",
-    "scope_drift_event",
     "knowledge_quality_score",
+    "memory_supports_decision",
+    "repo_artifact",
+    "scope_drift_event",
+    "stale_context",
     "visual_control_view",
 )
+
+EXPECTED_RELATION_TABLES: tuple[str, ...] = (
+    "artifact_cites_decision",
+    "memory_supports_decision",
+    "chunk_mentions_symbol",
+)
+
+RELATION_METADATA_FIELDS: tuple[str, ...] = (
+    "source",
+    "confidence",
+    "timestamp",
+    "hash",
+)
+
+TRAVERSAL_FIXTURE_PATH = "infrastructure/surrealdb/traversal_query_fixtures.surql"
 
 PK_FIELD_BY_TABLE: dict[str, str] = {
     "repo_artifact": "artifact_id",
@@ -80,7 +98,7 @@ PERMISSION_BLOCKS = {
 # ---------------------------------------------------------------------------
 
 _RE_DEFINE_TABLE = re.compile(
-    r"^\s*DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)\s+SCHEMAFULL",
+    r"^\s*DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)\s+(?:SCHEMAFULL|TYPE\s+RELATION)",
     re.IGNORECASE | re.MULTILINE,
 )
 _RE_DEFINE_FIELD = re.compile(
@@ -95,12 +113,20 @@ _RE_TABLE_SCHEMAFULL = re.compile(
     r"^\s*DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)\s+SCHEMAFULL",
     re.IGNORECASE | re.MULTILINE,
 )
+_RE_TABLE_TYPE = re.compile(
+    r"^\s*DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)\s+(?:SCHEMAFULL|TYPE\s+RELATION)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_RE_TABLE_RELATION = re.compile(
+    r"^\s*DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)\s+TYPE\s+RELATION",
+    re.IGNORECASE | re.MULTILINE,
+)
 _RE_DEFINE_TABLE_ANY = re.compile(
     r"^\s*DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)",
     re.IGNORECASE | re.MULTILINE,
 )
 _RE_PERMISSIONS = re.compile(
-    r"DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)\s+SCHEMAFULL\s+PERMISSIONS\s+FOR\s+select\s+NONE,\s+FOR\s+create\s+NONE,\s+FOR\s+update\s+NONE,\s+FOR\s+delete\s+NONE",
+    r"DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)\s+(?:SCHEMAFULL|TYPE\s+RELATION)\s+PERMISSIONS\s+FOR\s+select\s+NONE,\s+FOR\s+create\s+NONE,\s+FOR\s+update\s+NONE,\s+FOR\s+delete\s+NONE",
     re.IGNORECASE,
 )
 
@@ -130,11 +156,13 @@ def test_surql_defines_all_expected_tables(surql_original_text: str) -> None:
 
 
 @pytest.mark.unit
-def test_each_table_is_schemafull(surql_original_text: str) -> None:
-    for m in _RE_TABLE_SCHEMAFULL.finditer(surql_original_text):
-        pass
-    tables_found = _RE_TABLE_SCHEMAFULL.findall(surql_original_text)
+def test_each_table_is_schemafull_or_type_relation(surql_original_text: str) -> None:
+    """All tables must be either SCHEMAFULL or TYPE RELATION."""
+    tables_found = _RE_TABLE_TYPE.findall(surql_original_text)
     assert len(tables_found) == len(EXPECTED_TABLES)
+    schemafull = _RE_TABLE_SCHEMAFULL.findall(surql_original_text)
+    relation = _RE_TABLE_RELATION.findall(surql_original_text)
+    assert len(schemafull) + len(relation) == len(EXPECTED_TABLES)
 
 
 @pytest.mark.unit
@@ -194,13 +222,27 @@ def test_deploy_file_permissions_are_strictly_none(surql_deploy_text: str) -> No
     import re as _re
 
     normalized = _re.sub(r"\s+", " ", surql_deploy_text)
+    relation_set = set(EXPECTED_RELATION_TABLES)
     for table in EXPECTED_TABLES:
-        expected = (
-            f"DEFINE TABLE IF NOT EXISTS {table} SCHEMAFULL "
-            f"PERMISSIONS FOR select NONE, FOR create NONE, "
-            f"FOR update NONE, FOR delete NONE"
-        )
-        assert expected in normalized, f"Table {table} missing fail-closed permissions"
+        if table in relation_set:
+            # TYPE RELATION tables: table header + PERMISSIONS block are separated by FROM/TO
+            table_header = f"DEFINE TABLE IF NOT EXISTS {table} TYPE RELATION"
+            permissions_block = "PERMISSIONS FOR select NONE, FOR create NONE, FOR update NONE, FOR delete NONE"
+            assert (
+                table_header in normalized
+            ), f"Table {table} missing TYPE RELATION header"
+            assert (
+                permissions_block in normalized
+            ), f"Table {table} missing fail-closed permissions"
+        else:
+            expected = (
+                f"DEFINE TABLE IF NOT EXISTS {table} SCHEMAFULL "
+                f"PERMISSIONS FOR select NONE, FOR create NONE, "
+                f"FOR update NONE, FOR delete NONE"
+            )
+            assert (
+                expected in normalized
+            ), f"Table {table} missing fail-closed permissions"
 
 
 @pytest.mark.unit
@@ -291,6 +333,109 @@ def test_no_embedding_runtime_data_in_schema(surql_original_text: str) -> None:
         assert (
             pattern not in surql_original_text
         ), f"Embedding runtime data leaking: {pattern}"
+
+
+# ---------------------------------------------------------------------------
+# Graph Relations tests (Issue #3423)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_all_graph_relation_tables_exist(surql_original_text: str) -> None:
+    for table in EXPECTED_RELATION_TABLES:
+        assert table in surql_original_text, f"Missing relation table: {table}"
+
+
+@pytest.mark.unit
+def test_graph_relation_tables_are_type_relation(surql_original_text: str) -> None:
+    for table in EXPECTED_RELATION_TABLES:
+        assert (
+            f"DEFINE TABLE {table} TYPE RELATION" in surql_original_text
+        ), f"{table} is not TYPE RELATION"
+
+
+@pytest.mark.unit
+def test_graph_relation_tables_have_metadata_fields(surql_original_text: str) -> None:
+    for table in EXPECTED_RELATION_TABLES:
+        for field in RELATION_METADATA_FIELDS:
+            assert (
+                f"DEFINE FIELD {field} ON TABLE {table}" in surql_original_text
+            ), f"Missing {field} on {table}"
+
+
+@pytest.mark.unit
+def test_graph_relation_tables_have_created_at(surql_original_text: str) -> None:
+    for table in EXPECTED_RELATION_TABLES:
+        assert (
+            f"DEFINE FIELD created_at ON TABLE {table}" in surql_original_text
+        ), f"Missing created_at on {table}"
+
+
+@pytest.mark.unit
+def test_chunk_mentions_symbol_has_mention_context(surql_original_text: str) -> None:
+    assert (
+        "DEFINE FIELD mention_context ON TABLE chunk_mentions_symbol"
+        in surql_original_text
+    )
+
+
+@pytest.mark.unit
+def test_no_trading_state_in_relation_tables(surql_original_text: str) -> None:
+    for table in EXPECTED_RELATION_TABLES:
+        block = f"DEFINE TABLE {table}"
+        for forbidden in FORBIDDEN_TABLES:
+            assert (
+                forbidden.lower() not in table.lower()
+            ), f"Relation table name uses forbidden trading term: {table}"
+
+
+@pytest.mark.unit
+def test_deploy_relation_tables_have_if_not_exists(surql_deploy_text: str) -> None:
+    for table in EXPECTED_RELATION_TABLES:
+        expected = f"DEFINE TABLE IF NOT EXISTS {table}"
+        assert expected in surql_deploy_text, f"Missing IF NOT EXISTS for {table}"
+
+
+@pytest.mark.unit
+def test_deploy_relation_tables_have_fail_closed_permissions(
+    surql_deploy_text: str,
+) -> None:
+    normalized = re.sub(r"\s+", " ", surql_deploy_text)
+    for table in EXPECTED_RELATION_TABLES:
+        table_header = f"DEFINE TABLE IF NOT EXISTS {table} TYPE RELATION"
+        permissions_block = (
+            "PERMISSIONS FOR select NONE, FOR create NONE, "
+            "FOR update NONE, FOR delete NONE"
+        )
+        assert table_header in normalized, f"Table {table} missing TYPE RELATION header"
+        assert (
+            permissions_block in normalized
+        ), f"Table {table} missing fail-closed permissions"
+    assert "FOR select FULL" not in surql_deploy_text
+    assert "FOR create FULL" not in surql_deploy_text
+
+
+@pytest.mark.unit
+def test_traversal_query_fixture_exists() -> None:
+    path = Path(TRAVERSAL_FIXTURE_PATH)
+    assert path.exists(), f"Traversal fixture missing: {TRAVERSAL_FIXTURE_PATH}"
+    text = path.read_text(encoding="utf-8")
+    assert "RELATE" not in text, "Fixture must not contain RELATE (no runtime)"
+    assert "->" in text, "Fixture must contain arrow traversal syntax"
+
+
+@pytest.mark.unit
+def test_traversal_fixture_has_recursive_query() -> None:
+    path = Path(TRAVERSAL_FIXTURE_PATH)
+    text = path.read_text(encoding="utf-8")
+    assert "@." in text, "Fixture must contain recursive traversal syntax"
+
+
+@pytest.mark.unit
+def test_traversal_fixture_has_backward_traversal() -> None:
+    path = Path(TRAVERSAL_FIXTURE_PATH)
+    text = path.read_text(encoding="utf-8")
+    assert "<-" in text, "Fixture must contain backward traversal syntax"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/surrealdb/test_schema_snapshot.py
+++ b/tests/surrealdb/test_schema_snapshot.py
@@ -146,3 +146,52 @@ def test_deploy_has_same_core_schema_hash_as_original() -> None:
     assert (
         hash_orig == hash_depl
     ), "Deploy and original must have identical core schema hash"
+
+
+# ---------------------------------------------------------------------------
+# TYPE RELATION parsing tests (Issue #3423)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_snapshot_parses_type_relation_tables() -> None:
+    canonical = parse_surql(SURQL_ORIGINAL)
+    for table in (
+        "artifact_cites_decision",
+        "memory_supports_decision",
+        "chunk_mentions_symbol",
+    ):
+        assert table in canonical["tables"], f"Missing TYPE RELATION table: {table}"
+    assert "artifact_cites_decision" in canonical["relation_tables"]
+    assert "memory_supports_decision" in canonical["relation_tables"]
+    assert "chunk_mentions_symbol" in canonical["relation_tables"]
+
+
+@pytest.mark.unit
+def test_snapshot_reports_relation_count() -> None:
+    canonical = parse_surql(SURQL_ORIGINAL)
+    assert len(canonical["relation_tables"]) == 3
+
+
+@pytest.mark.unit
+def test_snapshot_table_types_are_correct() -> None:
+    canonical = parse_surql(SURQL_ORIGINAL)
+    for table in canonical["table_types"]:
+        if table in canonical["relation_tables"]:
+            assert canonical["table_types"][table] == "TYPE_RELATION"
+        else:
+            assert canonical["table_types"][table] == "SCHEMAFULL"
+
+
+@pytest.mark.unit
+def test_baseline_contains_relation_tables(baseline_json: dict) -> None:
+    assert "relation_tables" in baseline_json
+    assert baseline_json["relation_table_count"] == 3
+    assert "artifact_cites_decision" in baseline_json["relation_tables"]
+
+
+@pytest.mark.unit
+def test_deploy_has_same_relation_tables_as_original() -> None:
+    orig = parse_surql(SURQL_ORIGINAL)
+    depl = parse_surql(SURQL_DEPLOY)
+    assert orig["relation_tables"] == depl["relation_tables"]

--- a/tools/surrealdb/schema_snapshot.py
+++ b/tools/surrealdb/schema_snapshot.py
@@ -38,8 +38,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-RE_TABLE = re.compile(
+RE_TABLE_SCHEMAFULL = re.compile(
     r"^\s*DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)\s+SCHEMAFULL", re.IGNORECASE
+)
+RE_TABLE_RELATION = re.compile(
+    r"^\s*DEFINE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)\s+TYPE\s+RELATION",
+    re.IGNORECASE,
 )
 RE_FIELD = re.compile(r"^\s*DEFINE\s+FIELD\s+(\S+)\s+ON\s+TABLE\s+(\S+)", re.IGNORECASE)
 RE_INDEX = re.compile(
@@ -63,6 +67,7 @@ def parse_surql(path: Path) -> dict[str, Any]:
         raw_define_lines: sorted list of all DEFINE TABLE/FIELD/INDEX lines
     """
     tables: list[str] = []
+    relation_tables: list[str] = []
     fields: list[dict[str, str]] = []
     indexes: list[dict[str, str]] = []
     analyzers: list[str] = []
@@ -75,7 +80,14 @@ def parse_surql(path: Path) -> dict[str, Any]:
             continue
         stripped = line.strip()
 
-        m = RE_TABLE.match(stripped)
+        m = RE_TABLE_RELATION.match(stripped)
+        if m:
+            tables.append(m.group(1))
+            relation_tables.append(m.group(1))
+            define_lines.append(stripped)
+            continue
+
+        m = RE_TABLE_SCHEMAFULL.match(stripped)
         if m:
             tables.append(m.group(1))
             define_lines.append(stripped)
@@ -98,8 +110,15 @@ def parse_surql(path: Path) -> dict[str, Any]:
             analyzers.append(m.group(1))
             continue
 
+    relation_set = set(relation_tables)
+    table_types: dict[str, str] = {}
+    for t in tables:
+        table_types[t] = "TYPE_RELATION" if t in relation_set else "SCHEMAFULL"
+
     return {
         "tables": sorted(tables),
+        "relation_tables": sorted(relation_tables),
+        "table_types": table_types,
         "fields": sorted(fields, key=lambda x: (x["table"], x["field"])),
         "indexes": sorted(indexes, key=lambda x: (x["table"], x["index"])),
         "analyzers": sorted(analyzers),
@@ -115,6 +134,7 @@ def compute_schema_hash(canonical: dict[str, Any]) -> str:
     canonical_str = json.dumps(
         {
             "tables": canonical["tables"],
+            "relation_tables": canonical["relation_tables"],
             "fields": canonical["fields"],
             "indexes": canonical["indexes"],
         },
@@ -142,10 +162,12 @@ def build_snapshot(
         "generated_at": generated_at,
         "schema_hash": schema_hash,
         "table_count": len(canonical["tables"]),
+        "relation_table_count": len(canonical["relation_tables"]),
         "field_count": len(canonical["fields"]),
         "index_count": len(canonical["indexes"]),
         "analyzer_count": len(canonical["analyzers"]),
         "tables": canonical["tables"],
+        "relation_tables": canonical["relation_tables"],
         "fields": canonical["fields"],
         "indexes": canonical["indexes"],
         "analyzers": canonical["analyzers"],


### PR DESCRIPTION
## Summary

Implements the graph relations phase of the Context Intelligence schema — 3 new \TYPE RELATION\ edge tables, traversal query contracts, schema snapshot extension, vocabulary documentation, and static schema tests.

## Changes

### Schema (SurrealDB)
- \infrastructure/surrealdb/context_intelligence_v0.surql\: Added 3 \TYPE RELATION\ tables — \rtifact_cites_decision\, \memory_supports_decision\, \chunk_mentions_symbol\ — with \FROM\/\TO\ constraints and metadata fields (source, confidence, timestamp, hash, comment, created_at)
- \infrastructure/surrealdb/context_intelligence_v0_deploy.surql\: Deploy wrapper with \IF NOT EXISTS\ and fail-closed \PERMISSIONS FOR select/create/update/delete NONE\
- \infrastructure/surrealdb/traversal_query_fixtures.surql\: 7 traversal query contracts (forward, backward, multi-hop, recursive \@{3}\, bi-directional)
- \infrastructure/surrealdb/schema_baseline.json\: Regenerated — 21 tables, 3 relation tables, 245 fields, 75 indexes, 1 analyzer

### Tooling
- \	ools/surrealdb/schema_snapshot.py\: Added \TYPE RELATION\ regex parsing, \elation_tables\ extraction, \elation_table_count\ in snapshot output

### Documentation
- \docs/surrealdb/context-relationship-vocabulary-v0.md\: Extended with \cites\ (5.18) and \supports_evidence\ (5.19) vocabulary types, cross-reference matrix, Section 9 SurrealDB Graph Schema (#3423) — Record Links vs Graph Relations decision, edge-to-vocabulary mapping, non-goals

### Tests
- \	ests/surrealdb/test_context_intelligence_v0_surql.py\: 10 new tests — relation table existence, TYPE RELATION syntax, metadata fields, created_at, mention_context, fail-closed permissions, deploy IF NOT EXISTS, traversal fixture existence, recursive/backward syntax (49 total, all passing)
- \	ests/surrealdb/test_schema_snapshot.py\: 5 new TYPE RELATION parsing tests — table types correctness, relation count, deploy parity

## Validation
- \pytest tests/surrealdb/\ — **49/49 passed**
- Baseline drift guard — PASS
- Trading-state scan — PASS (no trading tables)
- Deploy/original hash parity — PASS

Closes #3423