### PR TITLE
feat(surrealdb): add hybrid retrieval contract

### DIFF
--- a/docs/surrealdb/context-hybrid-retrieval-strategy-v1.md
+++ b/docs/surrealdb/context-hybrid-retrieval-strategy-v1.md
@@ -447,6 +447,156 @@ This contract was validated against:
 
 ---
 
+
+---
+
+## DB-backed Hybrid Retrieval Contract (#3424)
+
+**Issue**: #3424 (SLICE-06)
+**Status**: Contract Defined
+**Date**: 2026-06-24
+**Dependencies**: #3422 (VectorGraph Schema), #3423 (Graph Relations)
+
+### Purpose
+
+Define the SurrealQL-level query contract for BM25 full-text search, vector similarity search, and hybrid retrieval via Reciprocal Rank Fusion (RRF). This contract DOES NOT replace the existing Python hybrid ranking (`tools/surrealdb/hybrid_retrieval_ranking.py`) — both paths exist in parallel.
+
+### Non-Goals (DB-backed Contract)
+
+- No embedding generation or runtime
+- No MCP Evidence Contract (#3421)
+- No Permission Matrix (#3426)
+- No productive DB writes or data migration
+- Not a replacement for the Python ranking path
+
+### BM25 Full-text Query Contract
+
+SurrealQL query for keyword search against `doc_chunk.content`:
+
+```surql
+LET $bm25_keyword = 'policy_hash';
+LET $bm25_limit = 10;
+
+SELECT
+    id,
+    chunk_id,
+    content,
+    content_hash,
+    search::score(1) AS bm25_score
+FROM doc_chunk
+WHERE content @1@ $bm25_keyword
+ORDER BY bm25_score DESC
+LIMIT $bm25_limit;
+```
+
+- Uses `@N@` matches operator with predicate reference number `1`
+- `search::score(1)` returns the BM25 relevance score
+- `FULLTEXT ANALYZER cdb_code_analyzer BM25` index from #3422
+- Single-field limitation: one FULLTEXT index per field
+
+### Vector Similarity Query Contract
+
+SurrealQL query for semantic search against `doc_chunk.embedding`:
+
+```surql
+LET $query_vector = [0.1, ..., 0.20]; -- 1536-dim at runtime
+LET $k = 10;
+LET $ef = 40;
+
+SELECT
+    id,
+    chunk_id,
+    content,
+    content_hash,
+    1.0 - vector::distance::knn() AS vector_score
+FROM doc_chunk
+WHERE embedding <|$k, $ef|> $query_vector
+ORDER BY vector_score DESC;
+```
+
+- Uses `<|K, EF|>` KNN operator for HNSW approximate search
+- `vector::distance::knn()` returns the distance computed by the index
+- Score conversion: `1.0 - distance` for higher-better scoring
+- HNSW DIMENSION 1536 DIST COSINE index from #3422
+
+### Hybrid RRF Retrieval Contract
+
+SurrealQL query fusing BM25 + Vector results:
+
+```surql
+-- Vector sub-query: top K by vector similarity
+LET $vs = SELECT id, chunk_id, content_hash
+FROM doc_chunk
+WHERE embedding <|$hybrid_limit, $ef|> $query_vector;
+
+-- Full-text sub-query: top K by BM25 score
+LET $ft = SELECT id, chunk_id, content_hash, search::score(1) AS bm25_score
+FROM doc_chunk
+WHERE content @1@ $bm25_keyword
+ORDER BY bm25_score DESC
+LIMIT $hybrid_limit;
+
+-- Fused result via Reciprocal Rank Fusion
+SELECT * FROM search::rrf([$vs, $ft], $hybrid_limit, 60);
+```
+
+Alternative linear fusion:
+
+```surql
+SELECT * FROM search::linear([$vs, $ft], [1, 1], $hybrid_limit, 'minmax');
+```
+
+### RRF Formula
+
+```
+rrf_score = Σ 1 / (k + rank_in_list)
+```
+
+- **k = 60** (standard default per Cormack et al. 2009)
+- Rank is 1-based position within each list
+- Tie-breaker: `rrf_score DESC`, then `id ASC`
+- Results include a `fuse_score` field in the output
+
+### Result Contract
+
+| Field | Source | Description |
+|-------|--------|-------------|
+| `id` | SurrealDB | Record ID (used for dedup fusion) |
+| `rrf_score` / `fuse_score` | RRF | Fused relevance score |
+| `chunk_id` | doc_chunk | Deterministic chunk identifier |
+| `content_hash` | doc_chunk | SHA256 of chunk content |
+| `content` | doc_chunk | Chunk text content |
+| `bm25_score` | full-text list | BM25 relevance score (if from FT) |
+| `vector_distance` | vector list | Distance from query vector (if from VS) |
+| `vector_score` | vector list | 1.0 - distance (if from VS) |
+
+### Abgrenzung zum bestehenden Python-Hybrid-Ranking
+
+| Aspect | Python Ranking (existing) | DB-backed Contract (this issue) |
+|--------|--------------------------|-------------------------------|
+| Module | `hybrid_retrieval_ranking.py` | `.surql` query fixtures |
+| Entry points | `rank_retrieval_results()`, `compute_ranking_explanation()` | `search::rrf()`, `search::linear()` |
+| Factors | 7 weighted factors (source, graph, evidence, etc.) | BM25 score + vector distance only |
+| Scope | In-memory candidate enrichment | DB-level fusion |
+| Status | Parallel reference | Parallel reference |
+| Replacement | NOT replaced | NOT replacing |
+
+### Query Fixture Source
+
+`infrastructure/surrealdb/hybrid_retrieval_fixtures.surql` — static contract tests under `tests/surrealdb/`.
+
+### Sources
+
+- SurrealDB Search functions: https://surrealdb.com/docs/reference/query-language/functions/database-functions/search
+- SurrealDB Vector indexes: https://surrealdb.com/docs/learn/data-models/vector-search/vector-indexes
+- SurrealDB Hybrid search: https://surrealdb.com/docs/learn/data-models/vector-search/hybrid-search
+
+### Nächste Slices
+
+- #3421 — Readonly MCP Brain Evidence Contract
+- #3426 — Permission Matrix + Readonly Agent User
+- #3427 — ContextBrain Report / Gist Ledger Integration
+
 ## References
 
 - Epic: #1976 (CDB Context Intelligence System)

--- a/infrastructure/surrealdb/context_intelligence_v0.surql
+++ b/infrastructure/surrealdb/context_intelligence_v0.surql
@@ -35,7 +35,7 @@
 
 -- ---------------------------
 -- VectorGraph: Analyzer for code/doc full-text search
--- Dimension 1536 (OpenAI embedding standard); replaceable in #3424
+-- Dimension 1536 (OpenAI embedding standard); used by #3424 Hybrid Retrieval
 -- Issue #3422
 -- ---------------------------
 DEFINE ANALYZER cdb_code_analyzer TOKENIZERS class, camel FILTERS lowercase, ascii;

--- a/infrastructure/surrealdb/hybrid_retrieval_fixtures.surql
+++ b/infrastructure/surrealdb/hybrid_retrieval_fixtures.surql
@@ -1,0 +1,144 @@
+-- =====================================================================
+-- Hybrid Retrieval Query Fixtures — static contract tests for Issue #3424
+-- These are NOT executable against a live DB in CI (no runtime).
+-- They define the expected SurrealQL retrieval syntax contract.
+--
+-- Sources:
+--   SurrealDB Search functions (docs/reference/query-language/functions/database-functions/search)
+--   SurrealDB Vector indexes (docs/learn/data-models/vector-search/vector-indexes)
+--   SurrealDB Hybrid search (docs/learn/data-models/vector-search/hybrid-search)
+--
+-- Schema dependencies (Issue #3422):
+--   idx_doc_chunk_embedding_hnsw — HNSW DIMENSION 1536 DIST COSINE
+--   idx_doc_chunk_content_ft — FULLTEXT ANALYZER cdb_code_analyzer BM25 HIGHLIGHTS
+--
+-- Guardrails:
+--   - No productive DB connection needed
+--   - No embedding generation (embedding vectors are query parameters only)
+--   - No migration, no runtime changes
+--   - No MCP evidence contract scope
+--   - Does NOT replace the existing Python hybrid ranking
+--   - LR remains NO-GO
+-- =====================================================================
+
+-- -----------------------------------------------------------------------
+-- BM25 Full-text Search Query
+-- Searches doc_chunk.content using the FULLTEXT BM25 index.
+-- SurrealQL syntax: @N@ matches operator + search::score(N)
+-- -----------------------------------------------------------------------
+-- Reference: search::score() — returns BM25 relevance score
+--   SELECT id, search::score(1) as score FROM doc_chunk
+--   WHERE content @1@ 'keyword' ORDER BY score DESC LIMIT $limit;
+
+LET $bm25_keyword = 'policy_hash';
+LET $bm25_limit = 10;
+
+SELECT
+    id,
+    chunk_id,
+    content,
+    content_hash,
+    page_ref,
+    search::score(1) AS bm25_score
+FROM doc_chunk
+WHERE content @1@ $bm25_keyword
+ORDER BY bm25_score DESC
+LIMIT $bm25_limit;
+
+-- -----------------------------------------------------------------------
+-- Vector Similarity Search Query
+-- Searches doc_chunk.embedding using HNSW approximate KNN.
+-- SurrealQL syntax: embedding <|K, EF|> $vector
+--   WHERE embedding <|$k, $ef|> $query_vector
+--   vector::distance::knn() returns the computed distance
+-- -----------------------------------------------------------------------
+-- Reference: Vector indexes — HNSW KNN operator
+--   SELECT id, vector::distance::knn() AS dist FROM doc_chunk
+--   WHERE embedding <|10, 40|> $qvec
+
+LET $query_vector = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+    0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20];
+LET $k = 10;
+LET $ef = 40;
+
+SELECT
+    id,
+    chunk_id,
+    content,
+    content_hash,
+    vector::distance::knn() AS vector_distance
+FROM doc_chunk
+WHERE embedding <|$k, $ef|> $query_vector
+ORDER BY vector_distance ASC;
+
+SELECT
+    id,
+    chunk_id,
+    content,
+    content_hash,
+    1.0 - vector::distance::knn() AS vector_score
+FROM doc_chunk
+WHERE embedding <|$k, $ef|> $query_vector
+ORDER BY vector_score DESC;
+
+-- -----------------------------------------------------------------------
+-- Hybrid Retrieval Contract: RRF (Reciprocal Rank Fusion)
+-- Fuses BM25 full-text results with vector similarity results.
+-- SurrealQL syntax: search::rrf([$list1, $list2], $limit, $k)
+--
+-- RRF formula: rrf_score = Sum 1 / (k + rank_in_list)
+-- k = 60 (standard default per Cormack et al. 2009)
+-- Tie-breaker: rrf_score DESC, then id ASC
+--
+-- Result contract fields: id, rrf_score (fuse_score),
+--   plus source fields from the first non-null source per list order
+-- -----------------------------------------------------------------------
+-- Reference: Hybrid search — search::rrf()
+--   search::rrf([$vs, $ft], 2, 60);
+
+LET $hybrid_limit = 10;
+LET $rrf_k = 60;
+
+LET $vs = SELECT
+    id,
+    chunk_id,
+    content_hash
+FROM doc_chunk
+WHERE embedding <|$hybrid_limit, $ef|> $query_vector;
+
+LET $ft = SELECT
+    id,
+    chunk_id,
+    content_hash,
+    search::score(1) AS bm25_score
+FROM doc_chunk
+WHERE content @1@ $bm25_keyword
+ORDER BY bm25_score DESC
+LIMIT $hybrid_limit;
+
+SELECT * FROM search::rrf([$vs, $ft], $hybrid_limit, $rrf_k);
+
+-- -----------------------------------------------------------------------
+-- Hybrid Retrieval Contract: Linear Fusion (alternative)
+-- Weighted linear fusion with minmax normalization.
+-- SurrealQL syntax: search::linear([$list1, $list2], [w1, w2], limit, 'minmax')
+-- -----------------------------------------------------------------------
+SELECT * FROM search::linear([$vs, $ft], [1, 1], $hybrid_limit, 'minmax');
+
+-- -----------------------------------------------------------------------
+-- Result Contract
+--
+-- Each hybrid retrieval result contains:
+--   id:            record id (SurrealDB native)
+--   rrf_score:     fused score from RRF (fuse_score in output)
+--   chunk_id:      deterministic chunk identifier
+--   content_hash:  SHA256 of chunk content
+--   bm25_score:    BM25 relevance score (if from full-text list)
+--   vector_distance / vector_score: vector similarity (if from vector list)
+--   source fields: first non-null from list order
+--
+-- Note: Embedding vectors are query parameters only.
+-- No embedding generation, storage, or runtime is defined here.
+-- The existing Python hybrid ranking (hybrid_retrieval_ranking.py) is
+-- a parallel reference and is NOT replaced by this contract.
+-- =======================================================================

--- a/tests/surrealdb/test_context_intelligence_v0_surql.py
+++ b/tests/surrealdb/test_context_intelligence_v0_surql.py
@@ -477,8 +477,12 @@ def test_hybrid_fixture_has_vector_knn_query() -> None:
     path = Path(HYBRID_FIXTURE_PATH)
     text = path.read_text(encoding="utf-8")
     assert "<|" in text, "Fixture must contain KNN operator <|K, EF|>"
-    assert "vector::distance::knn()" in text, "Fixture must contain vector::distance::knn()"
-    assert "HNSW" not in text.splitlines()[-20:], "Fixture query section must not reference HNSW"
+    assert (
+        "vector::distance::knn()" in text
+    ), "Fixture must contain vector::distance::knn()"
+    assert (
+        "HNSW" not in text.splitlines()[-20:]
+    ), "Fixture query section must not reference HNSW"
     assert "<|" in text, "Fixture must contain KNN operator <|K, EF|>"
 
 
@@ -502,10 +506,28 @@ def test_hybrid_fixture_no_relate_or_create() -> None:
 def test_hybrid_fixture_no_trading_tables() -> None:
     path = Path(HYBRID_FIXTURE_PATH)
     text = path.read_text(encoding="utf-8")
-    for forbidden in ("fill", "fills", "position", "positions", "risk_state", "position_state", "trade"):
-        define_matches = [l for l in text.splitlines() if "DEFINE" in l.upper() and forbidden.lower() in l.lower()]
-        assert not define_matches, f"Forbidden trading table defined in fixture: {forbidden}"
-    order_defines = [l for l in text.splitlines() if "DEFINE" in l.upper() and re.search(r'\border\b', l, re.IGNORECASE)]
+    for forbidden in (
+        "fill",
+        "fills",
+        "position",
+        "positions",
+        "risk_state",
+        "position_state",
+        "trade",
+    ):
+        define_matches = [
+            line
+            for line in text.splitlines()
+            if "DEFINE" in line.upper() and forbidden.lower() in line.lower()
+        ]
+        assert (
+            not define_matches
+        ), f"Forbidden trading table defined in fixture: {forbidden}"
+    order_defines = [
+        line
+        for line in text.splitlines()
+        if "DEFINE" in line.upper() and re.search(r"\border\b", line, re.IGNORECASE)
+    ]
     assert not order_defines, f"Forbidden trading table defined in fixture: order"
 
 
@@ -530,9 +552,9 @@ def test_hybrid_fixture_has_result_contract_documented() -> None:
 def test_rrf_formula_documented() -> None:
     path = Path(HYBRID_FIXTURE_PATH)
     text = path.read_text(encoding="utf-8")
-    assert "1 / (k + rank" in text or "1/(k + rank" in text, (
-        "RRF formula must be documented: score = sum(1 / (k + rank))"
-    )
+    assert (
+        "1 / (k + rank" in text or "1/(k + rank" in text
+    ), "RRF formula must be documented: score = sum(1 / (k + rank))"
     assert "k = 60" in text, "RRF k=60 must be documented"
     assert "rrf_score DESC" in text, "RRF tie-breaker must be documented"
 
@@ -544,6 +566,7 @@ def test_python_hybrid_ranking_not_modified() -> None:
     text = ranking_path.read_text(encoding="utf-8")
     assert "SCHEMA_VERSION" in text, "Ranking must still contain SCHEMA_VERSION"
     assert "RANKING_FACTORS" in text, "Ranking must still contain RANKING_FACTORS"
+
 
 # ---------------------------------------------------------------------------
 
@@ -578,6 +601,3 @@ def test_generated_at_not_in_schema_hash_computation(
     assert (
         snapshot_live["schema_hash"] == baseline_json["schema_hash"]
     ), "schema_hash differs from baseline — generated_at may be leaking into hash"
-
-
-

--- a/tests/surrealdb/test_context_intelligence_v0_surql.py
+++ b/tests/surrealdb/test_context_intelligence_v0_surql.py
@@ -441,6 +441,111 @@ def test_traversal_fixture_has_backward_traversal() -> None:
 # ---------------------------------------------------------------------------
 # generated_at metadata validation (no fragile time-window)
 # ---------------------------------------------------------------------------
+# Hybrid Retrieval Contract tests (Issue #3424)
+# ---------------------------------------------------------------------------
+
+HYBRID_FIXTURE_PATH = "infrastructure/surrealdb/hybrid_retrieval_fixtures.surql"
+
+FORBIDDEN_EMBEDDING_PATTERNS: tuple[str, ...] = (
+    "CREATE test:",
+    "embedding_generated",
+    "embedding_model",
+    "embedding_provider",
+)
+
+
+@pytest.mark.unit
+def test_hybrid_retrieval_fixture_exists() -> None:
+    path = Path(HYBRID_FIXTURE_PATH)
+    assert path.exists(), f"Hybrid retrieval fixture missing: {HYBRID_FIXTURE_PATH}"
+    text = path.read_text(encoding="utf-8")
+    assert "search::rrf" in text, "Fixture must contain RRF fusion"
+    assert "search::linear" in text, "Fixture must contain linear fusion"
+
+
+@pytest.mark.unit
+def test_hybrid_fixture_has_bm25_fulltext_query() -> None:
+    path = Path(HYBRID_FIXTURE_PATH)
+    text = path.read_text(encoding="utf-8")
+    assert "@1@" in text, "Fixture must contain BM25 matches operator @N@"
+    assert "search::score" in text, "Fixture must contain search::score() for BM25"
+    assert "bm25_score" in text, "Fixture must contain bm25_score field"
+
+
+@pytest.mark.unit
+def test_hybrid_fixture_has_vector_knn_query() -> None:
+    path = Path(HYBRID_FIXTURE_PATH)
+    text = path.read_text(encoding="utf-8")
+    assert "<|" in text, "Fixture must contain KNN operator <|K, EF|>"
+    assert "vector::distance::knn()" in text, "Fixture must contain vector::distance::knn()"
+    assert "HNSW" not in text.splitlines()[-20:], "Fixture query section must not reference HNSW"
+    assert "<|" in text, "Fixture must contain KNN operator <|K, EF|>"
+
+
+@pytest.mark.unit
+def test_hybrid_fixture_has_rrf() -> None:
+    path = Path(HYBRID_FIXTURE_PATH)
+    text = path.read_text(encoding="utf-8")
+    assert "search::rrf(" in text, "Fixture must contain search::rrf()"
+    assert "rrf_k" in text or "60" in text, "Fixture must reference RRF k constant"
+
+
+@pytest.mark.unit
+def test_hybrid_fixture_no_relate_or_create() -> None:
+    path = Path(HYBRID_FIXTURE_PATH)
+    text = path.read_text(encoding="utf-8")
+    assert "RELATE" not in text, "Fixture must not contain RELATE"
+    assert "CREATE " not in text, "Fixture must not contain CREATE"
+
+
+@pytest.mark.unit
+def test_hybrid_fixture_no_trading_tables() -> None:
+    path = Path(HYBRID_FIXTURE_PATH)
+    text = path.read_text(encoding="utf-8")
+    for forbidden in ("fill", "fills", "position", "positions", "risk_state", "position_state", "trade"):
+        define_matches = [l for l in text.splitlines() if "DEFINE" in l.upper() and forbidden.lower() in l.lower()]
+        assert not define_matches, f"Forbidden trading table defined in fixture: {forbidden}"
+    order_defines = [l for l in text.splitlines() if "DEFINE" in l.upper() and re.search(r'\border\b', l, re.IGNORECASE)]
+    assert not order_defines, f"Forbidden trading table defined in fixture: order"
+
+
+@pytest.mark.unit
+def test_no_embedding_runtime_in_hybrid_fixtures() -> None:
+    path = Path(HYBRID_FIXTURE_PATH)
+    text = path.read_text(encoding="utf-8")
+    for pattern in FORBIDDEN_EMBEDDING_PATTERNS:
+        assert pattern not in text, f"Embedding runtime data leaking: {pattern}"
+
+
+@pytest.mark.unit
+def test_hybrid_fixture_has_result_contract_documented() -> None:
+    path = Path(HYBRID_FIXTURE_PATH)
+    text = path.read_text(encoding="utf-8")
+    contract_fields = ("rrf_score", "chunk_id", "content_hash", "fuse_score")
+    for field in contract_fields:
+        assert field in text.lower(), f"Result contract field missing in doc: {field}"
+
+
+@pytest.mark.unit
+def test_rrf_formula_documented() -> None:
+    path = Path(HYBRID_FIXTURE_PATH)
+    text = path.read_text(encoding="utf-8")
+    assert "1 / (k + rank" in text or "1/(k + rank" in text, (
+        "RRF formula must be documented: score = sum(1 / (k + rank))"
+    )
+    assert "k = 60" in text, "RRF k=60 must be documented"
+    assert "rrf_score DESC" in text, "RRF tie-breaker must be documented"
+
+
+@pytest.mark.unit
+def test_python_hybrid_ranking_not_modified() -> None:
+    ranking_path = Path("tools/surrealdb/hybrid_retrieval_ranking.py")
+    assert ranking_path.exists(), "Python hybrid ranking must still exist"
+    text = ranking_path.read_text(encoding="utf-8")
+    assert "SCHEMA_VERSION" in text, "Ranking must still contain SCHEMA_VERSION"
+    assert "RANKING_FACTORS" in text, "Ranking must still contain RANKING_FACTORS"
+
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
@@ -473,3 +578,6 @@ def test_generated_at_not_in_schema_hash_computation(
     assert (
         snapshot_live["schema_hash"] == baseline_json["schema_hash"]
     ), "schema_hash differs from baseline — generated_at may be leaking into hash"
+
+
+


### PR DESCRIPTION
## Brain Evidence Block

| Source | Status | Evidence |
|--------|--------|----------|
| AGENTS.md | READ | Root-Pointer, Read Order aufgeloest |
| agents/AGENTS.md | READ | Read Order (10 Items) |
| Live-Git-Checks | DONE | HEAD f086d194 = origin/main |
| #3424 Issue | READ | OPEN, SLICE-06 |
| #3422 | VERIFIED | DONE_MERGED_CLOSED via PR #3431 |
| #3423 | VERIFIED | DONE_MERGED_CLOSED via PR #3432 |
| Python Ranking | READ | hybrid_retrieval_ranking.py (479 Zeilen) unveraendert |
| Strategy Doc | READ | context-hybrid-retrieval-strategy-v1.md |
| Schema Draft | READ | HNSW + BM25 Index existieren seit #3422 |
| SurrealDB Docs Gate | VERIFIED | search::rrf(), search::linear(), KNN, BM25 |

### SurrealDB Documentation Gate
- BM25 Full-Text: WHERE content @1@ keyword with search::score(1)
- Vector KNN: WHERE embedding <|K, EF|> $vector with vector::distance::knn()
- Hybrid RRF: search::rrf([$vs, $ft], limit, k) with k=60
- RRF Formula: rrf_score = sum(1 / (k + rank)), k=60

## Delivered

### New file: infrastructure/surrealdb/hybrid_retrieval_fixtures.surql
- BM25 Full-text Query (doc_chunk.content, @1@ operator, search::score)
- Vector Similarity Query (doc_chunk.embedding, <|K,EF|> KNN, vector::distance::knn)
- Hybrid RRF Retrieval (search::rrf, k=60)
- Hybrid Linear Fusion (search::linear, minmax normalization)
- Result Contract: id, rrf_score/fuse_score, chunk_id, content_hash, source fields
- RRF deterministic ranking formula documented: sum(1 / (k + rank_i))
- Tie-breaker: rrf_score DESC, then id ASC
- No RELATE, no CREATE, no embedding runtime, no trading tables

### Modified: docs/surrealdb/context-hybrid-retrieval-strategy-v1.md
- New section: DB-backed Hybrid Retrieval Contract (#3424)
- BM25/Vector/RRF/Linear Query Contracts in SurrealQL syntax
- Result Contract table
- Abgrenzung zum bestehenden Python-Hybrid-Ranking

### Modified: infrastructure/surrealdb/context_intelligence_v0.surql
- Comment updated to reference #3424 Hybrid Retrieval

### Modified: tests/surrealdb/test_context_intelligence_v0_surql.py
- 10 new tests for hybrid retrieval contract fixtures

## Validation

| Check | Result |
|-------|--------|
| pytest tests/surrealdb/ | 59/59 passed (49 existing + 10 new) |
| pytest unit surrealdb ranking | 21/21 passed (no regression) |
| Schema baseline drift | MATCHES |
| Trading-state scan | PASS |
| git diff --check | PASS |
| Python hybrid ranking | NOT MODIFIED |

## Non-goals
- No embedding generation or runtime
- No productive DB writes or migrations
- No MCP Evidence Contract (#3421)
- No Permission Matrix (#3426)
- No replacement of Python hybrid_retrieval_ranking.py

## Safety Boundaries
- LR remains NO-GO
- No docker/runtime/blue-red changes
- PERSIST_ALLOWED: false, MUTATION_ALLOWED: false

## Restunsicherheiten
- SurrealDB 3.x syntax verified from official docs but not tested against live DB
- DISKANN (SurrealDB 3.1+) not in current schema

Closes #3424
Refs #3418
Refs #3422
Refs #3423
