### PR TITLE
feat(surrealdb): add readonly MCP brain evidence contract (#3421 SLICE-03)

### DIFF
--- a/docs/contracts/context_tooling/DB_RECORD_EVIDENCE_CONTRACT.md
+++ b/docs/contracts/context_tooling/DB_RECORD_EVIDENCE_CONTRACT.md
@@ -9,6 +9,8 @@
 | Validator | [`tools/surrealdb/db_record_evidence_contract.py`](../../../tools/surrealdb/db_record_evidence_contract.py) |
 | JSON Schema | [`docs/contracts/db_record_evidence_claim.v1.schema.json`](../db_record_evidence_claim.v1.schema.json) |
 | Invocation bundle (#2850) | [`TOOL_INVOCATION_JSON_EVIDENCE.md`](TOOL_INVOCATION_JSON_EVIDENCE.md) |
+| Read-only query contract (#3421) | [`READONLY_QUERY_CONTRACT.md`](READONLY_QUERY_CONTRACT.md) |
+| Response schema (#3421) | [`DB_RECORD_EVIDENCE_RESPONSE_SCHEMA.md`](DB_RECORD_EVIDENCE_RESPONSE_SCHEMA.md) |
 
 ## Purpose
 
@@ -21,6 +23,8 @@ This contract complements (does not replace):
 - [`tools/mcp/memory_output_contract.py`](../../../tools/mcp/memory_output_contract.py) (MCP response envelope)
 - [`tools/surrealdb/claim_evidence_at_rest.py`](../../../tools/surrealdb/claim_evidence_at_rest.py) (DB row integrity)
 - Live invocation harness: [`tools/surrealdb/context_live_invocation_harness.py`](../../../tools/surrealdb/context_live_invocation_harness.py)
+- [`READONLY_QUERY_CONTRACT.md`](READONLY_QUERY_CONTRACT.md) — Read-only query boundary (MCP → SurrealDB)
+- [`DB_RECORD_EVIDENCE_RESPONSE_SCHEMA.md`](DB_RECORD_EVIDENCE_RESPONSE_SCHEMA.md) — Standardized response envelope for DB-backed evidence
 
 ## Safety boundaries
 
@@ -151,6 +155,30 @@ For `cdb_context_trust_summary` / briefing trust synthesis, operator-facing
 [`CDB_CONTEXT_TRUST_THRESHOLD_CONTRACT.md`](CDB_CONTEXT_TRUST_THRESHOLD_CONTRACT.md)
 (Issue [#2856](https://github.com/jannekbuengener/Claire_de_Binare/issues/2856)).
 Trust levels do not override DB-record evidence rules above.
+
+## #3421 Contracts
+
+Issue [#3421](https://github.com/jannekbuengener/Claire_de_Binare/issues/3421) (SLICE-03)
+added two complementary contracts to the evidence surface:
+
+- **READONLY_QUERY_CONTRACT.md** — Documents the three-layer defense-in-depth
+  (MCP permission guard → SurrealQL statement classifier → SurrealDB VIEWER role)
+  that ensures all MCP evidence tools are fail-closed read-only. Formalizes the
+  existing `classify_statement()` rules, DENIED_KEYWORDS, ALLOWED_PREFIXES,
+  table whitelist/blacklist, and the adapter flow for evidence queries.
+
+- **DB_RECORD_EVIDENCE_RESPONSE_SCHEMA.md** — Defines the standardized response
+  envelope for all DB-backed evidence responses. Adds trust, confidence,
+  freshness, and record-level metadata fields. Implemented by
+  `tools/surrealdb/db_record_evidence_response.py`.
+
+- **tests/surrealdb/test_mcp_evidence_contract.py** — 59 tests for the response
+  schema validator, trust derivation, freshness computation, secret leak
+  detection, and response factory functions.
+
+These contracts formalize existing behavior at the envelope and query-boundary
+level. No existing `classify_statement()`, `permission_guard.py`, or MCP handler
+code was modified; only new documentation, validation, and tests were added.
 
 ## Related Wave-14 tables
 

--- a/docs/contracts/context_tooling/DB_RECORD_EVIDENCE_RESPONSE_SCHEMA.md
+++ b/docs/contracts/context_tooling/DB_RECORD_EVIDENCE_RESPONSE_SCHEMA.md
@@ -1,0 +1,209 @@
+# DB-Record Evidence Response Schema
+
+| Field | Value |
+| --- | --- |
+| Status | **active** |
+| Version | `db-record-evidence-response/v1` |
+| Issue | [#3421](https://github.com/jannekbuengener/Claire_de_Binare/issues/3421) |
+| Parent meta | [#3368](https://github.com/jannekbuengener/Claire_de_Binare/issues/3368) (SLICE-03) |
+| Validator | [`tools/surrealdb/db_record_evidence_response.py`](../../../tools/surrealdb/db_record_evidence_response.py) |
+| Predecessor pattern | [`tools/mcp/memory_output_contract.py`](../../../tools/mcp/memory_output_contract.py) |
+| Claim contract | [`docs/contracts/context_tooling/DB_RECORD_EVIDENCE_CONTRACT.md`](DB_RECORD_EVIDENCE_CONTRACT.md) |
+| Query contract | [`docs/contracts/context_tooling/READONLY_QUERY_CONTRACT.md`](READONLY_QUERY_CONTRACT.md) |
+
+## Purpose
+
+This schema defines the standardized response envelope for evidence retrieved
+from the SurrealDB Context Intelligence database via the MCP read-only query
+adapter. Every DB-backed response from Wave-14 tools (`cdb_context_evidence_resolve`,
+`cdb_context_claim_resolve`, `cdb_context_memory_get`) and the trust summary tool
+(`cdb_context_trust_summary`) MUST conform to this envelope.
+
+The schema wraps raw SurrealDB query results into a consistent format that
+surfaces source provenance, trust classification, confidence scores, freshness
+signals, and record-level metadata. This enables downstream tooling and
+agent briefings to make reliable trust assessments without re-interpreting
+raw database rows.
+
+## Schema Structure
+
+```yaml
+schema_version: "db-record-evidence-response/v1"
+tool: string                    # MCP tool name
+status: "ok" | "error"         # Response status
+source: "surrealdb-local" | "surrealdb-local-unavailable" | "in_memory"
+metadata:
+  source: string               # Same as source above (from derive_guarded_source_label)
+  read_only: true
+  query_time_ms: integer
+record_count: integer           # Number of records in results
+records: list<object>           # Normalised SurrealDB rows
+filters_applied: object         # Active WHERE clause filters
+trust:
+  level: "HIGH" | "MEDIUM" | "LOW" | "BLOCKED"
+  classification: string        # valid_db_backed | partial | repo_only | in_memory_fixture | accepted_limitation | invalid_fake_db
+  confidence: float            # 0.0 – 1.0
+  source_priority: string      # live_github | repo_files | surrealdb_context | ledger_snapshots | fallback
+freshness:
+  age_seconds: integer
+  stale_threshold_seconds: integer
+  is_stale: boolean
+  freshness_signal: string     # Human-readable freshness assessment
+limitations: list<string>       # Standard + tool-specific limitations
+no_echtgeld_go: true
+```
+
+## Field Specifications
+
+### `schema_version` (required)
+Always `"db-record-evidence-response/v1"`. Must be the first field validated.
+
+### `tool` (required)
+The MCP tool name that produced this response. One of:
+- `cdb_context_evidence_resolve`
+- `cdb_context_claim_resolve`
+- `cdb_context_memory_get`
+- `cdb_context_trust_summary`
+
+### `status` (required)
+- `"ok"` — Query succeeded, results returned (may be empty).
+- `"error"` — Query failed (error envelope returned).
+
+### `source` (required)
+Derived from `derive_guarded_source_label()` in `surrealdb_adapter_factory.py`:
+- `"surrealdb-local"` — Query executed against a reachable local SurrealDB.
+- `"surrealdb-local-unavailable"` — DB unreachable, soft-fail with empty results.
+- `"in_memory"` — No adapter config supplied; caller-provided records.
+
+### `metadata` (required)
+Carries the same `source` label plus `read_only: true` and `query_time_ms`.
+This mirrors the envelope structure from `memory_output_contract.py`.
+
+### `record_count` (required)
+Integer count of records in `results`. Must equal `len(results)`.
+
+### `records` (required)
+List of normalised record objects. For DB-backed responses, each record is a
+mapping with SurrealDB field names projected to contract-compatible names per
+the normalisation functions in `context_evidence_memory_tools.py`:
+- `_normalize_evidence_ref_row()` for evidence records
+- `_normalize_claim_row()` for claim records
+- `_normalize_memory_row()` for memory records
+
+### `filters_applied` (required)
+Documents which WHERE clause filters were active during the query. Keys include
+`mode`, any parameters passed to the `_build_*_where()` functions, and the
+effective `limit` value. When no safe filter can be constructed, the filter is
+omitted and `filters_applied` records `"filter_mode": "full_page_with_in_memory_filtering"`.
+
+### `trust` (required)
+Aggregate trust assessment for the response:
+
+| Field | Source |
+| --- | --- |
+| `level` | Derived from `CDB_CONTEXT_TRUST_THRESHOLD_CONTRACT.md` thresholds |
+| `classification` | `valid_db_backed`, `partial`, `repo_only`, `in_memory_fixture`, `accepted_limitation`, `invalid_fake_db` |
+| `confidence` | 0.0–1.0; aggregate over record-level confidences or adapter status |
+| `source_priority` | From the source priority hierarchy in `DB_RECORD_EVIDENCE_CONTRACT.md` |
+
+Trust derivation rules:
+- `source = "surrealdb-local"` with valid records → `classification = "valid_db_backed"`, `level >= "MEDIUM"`.
+- `source = "surrealdb-local-unavailable"` → `classification = "partial"`, `level <= "LOW"`.
+- `source = "in_memory"` → `classification = "in_memory_fixture"`, `level = "LOW"`.
+- Empty results from any source → `classification = "partial"`, `level = "LOW"`.
+
+### `freshness` (required)
+Assesses record timeliness:
+
+- `age_seconds`: Wall-clock time since the query was issued.
+- `stale_threshold_seconds`: Config-driven; default 3600 (1 hour).
+- `is_stale`: `true` when `age_seconds > stale_threshold_seconds`.
+- `freshness_signal`: Human-readable label — `"fresh"`, `"aging"`, `"stale"`, or `"unknown"`.
+
+### `limitations` (required)
+Copied from `memory_output_contract.py` default limitations plus any
+tool-specific extensions. Must always include:
+```
+"Memory is provided as context, not as authoritative truth."
+"stale/superseded memory is flagged but not auto-removed."
+"LR remains NO-GO; no live-go or Echtgeld-GO implied."
+```
+
+### `no_echtgeld_go` (required)
+Always `true`. Reaffirms that this response does not authorize live capital,
+trading actions, or strategy changes.
+
+## Error Response Schema
+
+When `status = "error"`, the envelope collapses to:
+
+```yaml
+schema_version: "db-record-evidence-response/v1"
+tool: string
+status: "error"
+error:
+  code: string
+  message: string
+metadata:
+  source: "in_memory"
+  read_only: true
+  query_time_ms: 0
+limitations: [...]               # Standard limitations still apply
+no_echtgeld_go: true
+```
+
+## Validation Rules
+
+The `DbRecordEvidenceResponseValidator` in `db_record_evidence_response.py`
+enforces:
+
+1. `schema_version` must be `"db-record-evidence-response/v1"`.
+2. `tool` must be a recognised Wave-14 tool name.
+3. `source` must be in `{"surrealdb-local", "surrealdb-local-unavailable", "in_memory"}`.
+4. `status` must be `"ok"` or `"error"`.
+5. For `status = "ok"`:
+   - `records` must be a list.
+   - `record_count` must equal `len(records)`.
+   - `trust.classification` must be a valid trust classification.
+   - `trust.confidence` must be between 0.0 and 1.0.
+   - `freshness.is_stale` must be boolean.
+   - `no_echtgeld_go` must be `true`.
+6. For `status = "error"`:
+   - `error.code` and `error.message` must be non-empty strings.
+7. Response must not contain secret-like substrings (same rules as
+   `DB_RECORD_EVIDENCE_CONTRACT.md` § Redaction).
+8. `limitations` must include the three standard limitation strings.
+
+## Integration with Existing Contracts
+
+### DB_RECORD_EVIDENCE_CONTRACT.md
+The claim evidence contract defines the *claim-level* contract for individual
+evidence assertions. This response schema defines the *envelope-level* contract
+for bulk responses from the database. The trust classification and source
+priority fields are shared between both contracts.
+
+### READONLY_QUERY_CONTRACT.md
+The query contract defines the read-only boundary between MCP tools and
+SurrealDB. Responses that pass through that boundary MUST be wrapped in this
+envelope before reaching the MCP client.
+
+### memory_output_contract.py
+This schema extends the memory output contract pattern to the DB-backed
+evidence surface. The `metadata`, `source`, `limitations`, and `no_echtgeld_go`
+fields are inherited directly from that contract.
+
+## Testing
+
+```bash
+python -m pytest tests/surrealdb/test_mcp_evidence_contract.py -q
+```
+
+Test coverage requirements (see `test_mcp_evidence_contract.py`):
+- Schema field validation (ok and error paths)
+- Source label enforcement
+- Trust classification consistency
+- Freshness computation and staleness detection
+- LIMIT and filter transparency
+- Secret leak detection
+- Empty results handling
+- `no_echtgeld_go` enforcement

--- a/docs/contracts/context_tooling/READONLY_QUERY_CONTRACT.md
+++ b/docs/contracts/context_tooling/READONLY_QUERY_CONTRACT.md
@@ -1,0 +1,197 @@
+# Read-only Query Contract (MCP Evidence → SurrealDB)
+
+| Field | Value |
+| --- | --- |
+| Status | **active** |
+| Version | `readonly-query-contract/v1` |
+| Issue | [#3421](https://github.com/jannekbuengener/Claire_de_Binare/issues/3421) |
+| Parent meta | [#3368](https://github.com/jannekbuengener/Claire_de_Binare/issues/3368) (SLICE-03) |
+| Validator | [`tools/surrealdb/context_query.py`](../../../tools/surrealdb/context_query.py) — `classify_statement()` |
+| Permission layer | [`tools/mcp/permission_guard.py`](../../../tools/mcp/permission_guard.py) |
+| DB permission contract | [`infrastructure/surrealdb/context_intelligence_readonly_agent_permissions.surql`](../../../infrastructure/surrealdb/context_intelligence_readonly_agent_permissions.surql) |
+| Response contract | [`docs/contracts/context_tooling/DB_RECORD_EVIDENCE_RESPONSE_SCHEMA.md`](DB_RECORD_EVIDENCE_RESPONSE_SCHEMA.md) |
+
+## Purpose
+
+This contract establishes the formal read-only boundary between MCP evidence tools
+and the SurrealDB Context Intelligence database. It documents the three-layer
+defense-in-depth architecture that ensures no MCP tool path can execute writes,
+mutations, or schema changes — even when an adapter config is supplied.
+
+This contract formalizes what already exists and is enforced at runtime. No new
+code behavior is introduced; the contract serves as a specification and audit
+surface for the read-only guarantees already implemented across the stack.
+
+## Three-Layer Defense Architecture
+
+### Layer 1 — MCP Permission Guard (`tools/mcp/permission_guard.py`)
+
+- All Wave-14 evidence/memory tools are listed in `INPUT_SCAN_EXEMPT_TOOLS`.
+- The registry enforces `read_only=True` on every registered `ToolDefinition`.
+- `assert_read_only_consistency()` runs post-init to catch any bypass.
+- Structural tools (readiness, briefing, stop_resolver) are exempt from input
+  scanning because their handlers validate inputs with operation_mode enums.
+
+### Layer 2 — SurrealQL Statement Classifier (`tools/surrealdb/context_query.py`)
+
+`classify_statement()` enforces a fail-closed allowlist before any query reaches
+the SurrealDB adapter:
+
+**Denied keywords** (statement-level rejection):
+
+```
+CREATE, INSERT, UPDATE, UPSERT, DELETE, RELATE, MERGE, PATCH,
+DEFINE, REMOVE, ALTER, LIVE, KILL, USE, BEGIN, COMMIT, CANCEL,
+EXPLAIN, SHOW CHANGES, INFO FOR ROOT
+```
+
+**Allowed prefixes** (statement-level pass):
+
+```
+SELECT, INFO FOR DB, INFO FOR TABLE, INFO FOR NS
+```
+
+**Additional guards in classify_statement():**
+
+- Multi-statement inputs (containing `;`) are rejected.
+- `APPLY`, `MIGRATION`, `TRANSACTION` keywords are rejected.
+- Table policy: `_enforce_table_policy_tokens()` validates that referenced
+  tables appear in `allowed_tables` and not in `forbidden_tables`.
+- `FORBIDDEN_CONTEXT_QUERY_TABLES` includes trading state tables
+  (`orders`, `fills`, `positions`, `balances`, `pnl`, `risk_state`,
+  `execution_state`) and governance mirror tables (`governance_event`,
+  `governance_decision`, `governance_state`).
+
+**USE keyword design note:** `USE` remains in `DENIED_KEYWORDS` at the query
+classifier level because `context_query.py` enforces statement-level guards
+independently. The MCP adapter layer controls namespace and database selection
+through HTTP headers (`surreal-ns`, `surreal-db`) on the `/sql` endpoint, not
+through SurrealQL `USE` statements. This is correct by design — the MCP layer's
+`SurrealDBLocalQueryAdapter` sets NS/DB on construction from config values.
+
+### Layer 3 — SurrealDB VIEWER Permissions (`infrastructure/surrealdb/context_intelligence_readonly_agent_permissions.surql`)
+
+The `cdb_context_agent` user operates under the `VIEWER` role:
+
+- `SELECT` permission on all context intelligence tables.
+- No `CREATE`, `UPDATE`, `DELETE`, `DEFINE`, or `REMOVE` permissions.
+- Scope isolation: tables in the `context_intelligence` namespace only.
+- Enforced by SurrealDB's own permission system at the database level.
+
+This layer is the last-resort defense: even if layers 1 and 2 were bypassed,
+the database itself would reject any non-SELECT operation from the
+`cdb_context_agent` user.
+
+## Adapter Flow
+
+When an MCP evidence tool receives `adapter_config_path` in its parameters:
+
+```
+MCP Tool Handler
+    |
+    v
+build_adapter_from_params()          [surrealdb_adapter_factory.py]
+    |-- load_config()                 [context_query.py]
+    |-- _load_query_credentials()     [context_query.py]
+    |-- SurrealDBLocalQueryAdapter()  [context_query.py]
+    |
+    v
+adapter.execute(query)
+    |-- adapter.classify(query)       [Layer 2: classify_statement()]
+    |-- adapter._sql_request(query)   [HTTP POST to localhost /sql]
+    |
+    v
+SurrealDB (localhost)
+    |-- User: cdb_context_agent       [Layer 3: VIEWER role]
+    |-- NS/DB from HTTP headers       [surreal-ns, surreal-db]
+    |
+    v
+Response → normalize → response envelope → MCP client
+```
+
+When no `adapter_config_path` is supplied, the flow uses `NoopQueryAdapter`
+(source = `"in_memory"`) and caller-supplied records — no DB contact.
+
+## Query Builder Functions
+
+The following read-only query builders are available in `context_query.py`.
+All produce only `SELECT` statements. Parameters are always validated via
+`_surrealql_string()` which emits JSON-safe double-quoted literals.
+
+| Builder | Table |
+| --- | --- |
+| `build_artifact_query()` | `repo_artifact` |
+| `build_doc_query()` | `doc_chunk` |
+| `build_symbol_query()` | `code_symbol` |
+| `build_import_query()` | `import_reference` |
+| `build_trace_query()` | `dependency_edge` |
+| `build_explain_source_query()` | `repo_artifact` |
+| `build_snapshot_query()` | `repo_artifact` |
+| `build_drift_query()` | `dependency_edge` |
+| `build_audit_query()` | `import_reference` |
+
+Additional table access for evidence/claim/memory/decision tables is handled
+directly by the MCP tool handlers using `SELECT * FROM <table> WHERE ... LIMIT`
+with `_build_evidence_ref_where()`, `_build_claim_where()`, and
+`_build_memory_where()` in `context_evidence_memory_tools.py`.
+
+## Safety Guarantees
+
+1. **No write path exists.** The classifier rejects every known SurrealQL
+   mutation statement. The adapter only issues HTTP POST to localhost `/sql`
+   with classified-safe queries.
+
+2. **No network egress.** `_validate_local_query_url()` rejects any URL not
+   pointing to `127.0.0.1`, `::1`, or `localhost`. HTTP redirects are
+   blocked by `_NoRedirectHandler`.
+
+3. **No credential leak.** `_load_query_credentials()` reads credentials from
+   `SECRETS_PATH` only when `auth_mode="root"` and `adapter_config_path` is
+   explicitly supplied. The Authorization header is never forwarded to a
+   redirect target.
+
+4. **Soft DB failure.** `hard_mode=False` on `SurrealDBLocalQueryAdapter` means
+   an unreachable DB returns empty results with `status = "surrealdb-local-unavailable"`
+   rather than raising exceptions to the MCP client.
+
+5. **LR remains NO-GO.** This surface is context/read-only and does not
+   authorize live capital, trading actions, or strategy changes.
+
+## Configuration Constraints
+
+The context query config (`config.context_query_local.yaml`) must enforce:
+
+- `read_only: true`
+- `mode.read_only: true`
+- `mode.surrealdb_write: "forbidden"`
+- `mode.surrealdb_apply: "forbidden"`
+- `surreal_url` must be local-only (`127.0.0.1`, `::1`, `localhost`)
+- `auth_mode` must be `"none"` or `"root"`
+- `allowed_tables` must not intersect `FORBIDDEN_CONTEXT_QUERY_TABLES`
+- `forbidden_tables` must include all `FORBIDDEN_CONTEXT_QUERY_TABLES`
+- `max_limit_default <= max_limit_hard`
+
+## Response Schema
+
+DB-backed responses MUST conform to the
+[DB_RECORD_EVIDENCE_RESPONSE_SCHEMA](DB_RECORD_EVIDENCE_RESPONSE_SCHEMA.md),
+which defines the standardized envelope including `source`, `trust`,
+`confidence`, `freshness`, `record_metadata`, and `results` fields.
+
+## Related Contracts
+
+- `DB_RECORD_EVIDENCE_CONTRACT.md` — Claim-level evidence contract
+- `DB_RECORD_EVIDENCE_RESPONSE_SCHEMA.md` — Standardized response envelope
+- `CDB_CONTEXT_TRUST_THRESHOLD_CONTRACT.md` — Trust level thresholds
+- `tools/mcp/memory_output_contract.py` — MCP response envelope (predecessor pattern)
+- `docs/surrealdb/context-intelligence-permission-matrix-v0.md` — Permission matrix documentation
+- `infrastructure/surrealdb/context_intelligence_readonly_agent_permissions.surql` — VIEWER role
+
+## Validation
+
+```bash
+python -m pytest tests/unit/surrealdb/test_context_query_classifier.py -q
+python -m pytest tests/unit/tools/mcp/test_permission_guard.py -q
+python -m pytest tests/unit/tools/mcp/test_mcp_wave14_tools.py -q
+python -m pytest tests/surrealdb/test_mcp_evidence_contract.py -q
+```

--- a/tests/surrealdb/test_mcp_evidence_contract.py
+++ b/tests/surrealdb/test_mcp_evidence_contract.py
@@ -1,0 +1,658 @@
+"""Tests for DB-Record Evidence Response Schema validator (Issue #3421).
+
+Covers:
+    - Schema field validation (ok and error paths)
+    - Source label enforcement
+    - Trust classification consistency
+    - Freshness computation and staleness detection
+    - LIMIT and filter transparency
+    - Secret leak detection
+    - Empty results handling
+    - no_echtgeld_go enforcement
+    - build_ok_response / build_error_response factory functions
+    - validate_db_record_evidence_response / enforce_response_contract
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.surrealdb.db_record_evidence_response import (
+    SCHEMA_VERSION,
+    ALLOWED_SOURCES,
+    ALLOWED_TOOLS,
+    DbRecordEvidenceResponseError,
+    build_error_response,
+    build_ok_response,
+    derive_freshness_signal,
+    derive_trust_level,
+    enforce_response_contract,
+    validate_db_record_evidence_response,
+)
+
+# ── derive_trust_level ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_derive_trust_level_valid_db_backed_high():
+    assert derive_trust_level("surrealdb-local", "valid_db_backed", 5) == "HIGH"
+
+
+@pytest.mark.unit
+def test_derive_trust_level_valid_db_backed_medium_no_records():
+    assert derive_trust_level("surrealdb-local", "valid_db_backed", 0) == "MEDIUM"
+
+
+@pytest.mark.unit
+def test_derive_trust_level_valid_db_backed_in_memory_source():
+    assert derive_trust_level("in_memory", "valid_db_backed", 10) == "MEDIUM"
+
+
+@pytest.mark.unit
+def test_derive_trust_level_surrealdb_local_with_records():
+    assert derive_trust_level("surrealdb-local", "partial", 3) == "MEDIUM"
+
+
+@pytest.mark.unit
+def test_derive_trust_level_in_memory_low():
+    assert derive_trust_level("in_memory", "in_memory_fixture", 5) == "LOW"
+
+
+@pytest.mark.unit
+def test_derive_trust_level_unavailable_low():
+    assert derive_trust_level("surrealdb-local-unavailable", "partial", 0) == "LOW"
+
+
+@pytest.mark.unit
+def test_derive_trust_level_empty_records_low():
+    assert derive_trust_level("in_memory", "in_memory_fixture", 0) == "LOW"
+
+
+@pytest.mark.unit
+def test_derive_trust_level_invalid_fake_db_blocked():
+    assert derive_trust_level("surrealdb-local", "invalid_fake_db", 0) == "BLOCKED"
+
+
+@pytest.mark.unit
+def test_derive_trust_level_unknown_classification_blocked():
+    assert derive_trust_level("in_memory", "unknown_type", 5) == "BLOCKED"
+
+
+# ── derive_freshness_signal ──────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_derive_freshness_signal_fresh():
+    assert derive_freshness_signal(30, 3600) == "fresh"
+
+
+@pytest.mark.unit
+def test_derive_freshness_signal_aging():
+    assert derive_freshness_signal(1800, 3600) == "aging"
+
+
+@pytest.mark.unit
+def test_derive_freshness_signal_stale():
+    assert derive_freshness_signal(4000, 3600) == "stale"
+
+
+@pytest.mark.unit
+def test_derive_freshness_signal_at_boundary():
+    assert derive_freshness_signal(3600, 3600) == "aging"
+
+
+@pytest.mark.unit
+def test_derive_freshness_signal_negative_age():
+    assert derive_freshness_signal(-1, 3600) == "unknown"
+
+
+@pytest.mark.unit
+def test_derive_freshness_signal_zero_threshold():
+    assert derive_freshness_signal(10, 0) == "stale"
+
+
+# ── build_ok_response ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_build_ok_response_basic():
+    records = [{"id": "rec:1", "name": "test"}]
+    result = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "surrealdb-local",
+        records,
+    )
+    assert result["schema_version"] == SCHEMA_VERSION
+    assert result["status"] == "ok"
+    assert result["tool"] == "cdb_context_evidence_resolve"
+    assert result["source"] == "surrealdb-local"
+    assert result["record_count"] == 1
+    assert result["records"] == records
+    assert result["metadata"]["read_only"] is True
+    assert result["metadata"]["source"] == "surrealdb-local"
+    assert result["trust"]["level"] == "HIGH"
+    assert result["trust"]["classification"] == "valid_db_backed"
+    assert result["trust"]["confidence"] == 0.9
+    assert result["trust"]["source_priority"] == "surrealdb_context"
+    assert isinstance(result["freshness"]["is_stale"], bool)
+    assert result["no_echtgeld_go"] is True
+
+
+@pytest.mark.unit
+def test_build_ok_response_empty_records():
+    result = build_ok_response(
+        "cdb_context_memory_get",
+        "surrealdb-local",
+        [],
+    )
+    assert result["record_count"] == 0
+    assert result["records"] == []
+    assert result["trust"]["classification"] == "partial"
+    assert result["trust"]["level"] == "LOW"
+
+
+@pytest.mark.unit
+def test_build_ok_response_in_memory_source():
+    records = [{"id": "rec:1"}]
+    result = build_ok_response(
+        "cdb_context_claim_resolve",
+        "in_memory",
+        records,
+    )
+    assert result["source"] == "in_memory"
+    assert result["trust"]["classification"] == "in_memory_fixture"
+    assert result["trust"]["level"] == "LOW"
+    assert result["trust"]["confidence"] == 0.3
+
+
+@pytest.mark.unit
+def test_build_ok_response_unavailable_source():
+    result = build_ok_response(
+        "cdb_context_trust_summary",
+        "surrealdb-local-unavailable",
+        [],
+    )
+    assert result["trust"]["classification"] == "partial"
+    assert result["trust"]["level"] == "LOW"
+
+
+@pytest.mark.unit
+def test_build_ok_response_explicit_trust():
+    records = [{"id": "rec:1"}]
+    result = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "surrealdb-local",
+        records,
+        trust_level="MEDIUM",
+        trust_classification="partial",
+        trust_confidence=0.5,
+        trust_source_priority="repo_files",
+    )
+    assert result["trust"]["level"] == "MEDIUM"
+    assert result["trust"]["classification"] == "partial"
+    assert result["trust"]["confidence"] == 0.5
+    assert result["trust"]["source_priority"] == "repo_files"
+
+
+@pytest.mark.unit
+def test_build_ok_response_with_filters():
+    records = [{"id": "rec:1"}]
+    filters = {"mode": "by_artifact", "artifact": "test.md", "limit": 50}
+    result = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "surrealdb-local",
+        records,
+        filters_applied=filters,
+    )
+    assert result["filters_applied"] == filters
+
+
+@pytest.mark.unit
+def test_build_ok_response_extra_limitations():
+    result = build_ok_response(
+        "cdb_context_memory_get",
+        "in_memory",
+        [],
+        extra_limitations=["test limit"],
+    )
+    assert "test limit" in result["limitations"]
+
+
+@pytest.mark.unit
+def test_build_ok_response_invalid_source_falls_back():
+    records = [{"id": "rec:1"}]
+    result = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "invalid-source",
+        records,
+    )
+    assert result["source"] == "in_memory"
+
+
+# ── build_error_response ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_build_error_response():
+    result = build_error_response(
+        "cdb_context_evidence_resolve",
+        code="adapter_query_error",
+        message="SurrealDB unreachable",
+    )
+    assert result["schema_version"] == SCHEMA_VERSION
+    assert result["status"] == "error"
+    assert result["tool"] == "cdb_context_evidence_resolve"
+    assert result["error"]["code"] == "adapter_query_error"
+    assert result["error"]["message"] == "SurrealDB unreachable"
+    assert result["metadata"]["read_only"] is True
+    assert result["no_echtgeld_go"] is True
+
+
+# ── validate_db_record_evidence_response (ok path) ───────────────────────────
+
+
+@pytest.mark.unit
+def test_validate_ok_response_compliant():
+    records = [{"id": "rec:1"}]
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "surrealdb-local",
+        records,
+    )
+    violations = validate_db_record_evidence_response(response)
+    assert violations == []
+
+
+@pytest.mark.unit
+def test_validate_ok_response_empty_records():
+    response = build_ok_response(
+        "cdb_context_memory_get",
+        "in_memory",
+        [],
+    )
+    violations = validate_db_record_evidence_response(response)
+    assert violations == []
+
+
+@pytest.mark.unit
+def test_validate_ok_response_missing_schema_version():
+    response = build_ok_response("cdb_context_evidence_resolve", "in_memory", [])
+    del response["schema_version"]
+    violations = validate_db_record_evidence_response(response)
+    assert any("schema_version" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_ok_response_wrong_schema_version():
+    response = build_ok_response("cdb_context_evidence_resolve", "in_memory", [])
+    response["schema_version"] = "wrong/v1"
+    violations = validate_db_record_evidence_response(response)
+    assert any("schema_version" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_ok_response_bad_source():
+    response = build_ok_response("cdb_context_evidence_resolve", "in_memory", [])
+    response["source"] = "remote-db"
+    violations = validate_db_record_evidence_response(response)
+    assert any("source" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_ok_response_record_count_mismatch():
+    records = [{"id": "rec:1"}]
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "surrealdb-local",
+        records,
+    )
+    response["record_count"] = 99
+    violations = validate_db_record_evidence_response(response)
+    assert any("record_count" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_ok_response_missing_trust():
+    response = build_ok_response("cdb_context_evidence_resolve", "in_memory", [])
+    del response["trust"]
+    violations = validate_db_record_evidence_response(response)
+    assert any("trust" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_ok_response_bad_trust_level():
+    response = build_ok_response("cdb_context_evidence_resolve", "in_memory", [])
+    response["trust"]["level"] = "INVALID"
+    violations = validate_db_record_evidence_response(response)
+    assert any("trust.level" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_ok_response_trust_level_inconsistent():
+    records = [{"id": "rec:1"}]
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "surrealdb-local",
+        records,
+    )
+    # Override to a wrong level for the source+classification
+    response["trust"]["level"] = "LOW"
+    violations = validate_db_record_evidence_response(response)
+    assert any("trust.level" in v and "inconsistent" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_ok_response_confidence_out_of_range():
+    response = build_ok_response("cdb_context_evidence_resolve", "in_memory", [])
+    response["trust"]["confidence"] = 1.5
+    violations = validate_db_record_evidence_response(response)
+    assert any("confidence" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_ok_response_confidence_negative():
+    response = build_ok_response("cdb_context_evidence_resolve", "in_memory", [])
+    response["trust"]["confidence"] = -0.1
+    violations = validate_db_record_evidence_response(response)
+    assert any("confidence" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_ok_response_missing_freshness():
+    response = build_ok_response("cdb_context_evidence_resolve", "in_memory", [])
+    del response["freshness"]
+    violations = validate_db_record_evidence_response(response)
+    assert any("freshness" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_ok_response_is_stale_not_bool():
+    response = build_ok_response("cdb_context_evidence_resolve", "in_memory", [])
+    response["freshness"]["is_stale"] = "yes"
+    violations = validate_db_record_evidence_response(response)
+    assert any("is_stale" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_ok_response_freshness_inconsistent():
+    response = build_ok_response("cdb_context_evidence_resolve", "in_memory", [])
+    response["freshness"]["is_stale"] = True
+    response["freshness"]["freshness_signal"] = "fresh"
+    violations = validate_db_record_evidence_response(response)
+    assert any("freshness" in v and "inconsistent" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_ok_response_stale_signal_false_stale():
+    response = build_ok_response("cdb_context_evidence_resolve", "in_memory", [])
+    response["freshness"]["is_stale"] = False
+    response["freshness"]["freshness_signal"] = "stale"
+    violations = validate_db_record_evidence_response(response)
+    assert any("freshness" in v and "inconsistent" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_ok_response_missing_no_echtgeld_go():
+    response = build_ok_response("cdb_context_evidence_resolve", "in_memory", [])
+    del response["no_echtgeld_go"]
+    violations = validate_db_record_evidence_response(response)
+    assert any("no_echtgeld_go" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_ok_response_no_echtgeld_go_false():
+    response = build_ok_response("cdb_context_evidence_resolve", "in_memory", [])
+    response["no_echtgeld_go"] = False
+    violations = validate_db_record_evidence_response(response)
+    assert any("no_echtgeld_go" in v for v in violations)
+
+
+# ── validate_db_record_evidence_response (error path) ────────────────────────
+
+
+@pytest.mark.unit
+def test_validate_error_response_compliant():
+    response = build_error_response(
+        "cdb_context_evidence_resolve",
+        code="adapter_query_error",
+        message="SurrealDB unreachable",
+    )
+    violations = validate_db_record_evidence_response(response)
+    assert violations == []
+
+
+@pytest.mark.unit
+def test_validate_error_response_missing_error():
+    response = build_error_response(
+        "cdb_context_trust_summary",
+        code="adapter_query_error",
+        message="test",
+    )
+    del response["error"]
+    violations = validate_db_record_evidence_response(response)
+    assert any("error" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_error_response_missing_code():
+    response = build_error_response(
+        "cdb_context_trust_summary",
+        code="adapter_query_error",
+        message="test",
+    )
+    response["error"] = {"message": "test"}
+    violations = validate_db_record_evidence_response(response)
+    assert any("error.code" in v for v in violations)
+
+
+# ── enforce_response_contract ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_enforce_response_contract_passes_on_valid():
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "in_memory",
+        [],
+    )
+    enforce_response_contract(response)
+
+
+@pytest.mark.unit
+def test_enforce_response_contract_raises_on_invalid():
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "in_memory",
+        [],
+    )
+    del response["no_echtgeld_go"]
+    with pytest.raises(DbRecordEvidenceResponseError):
+        enforce_response_contract(response)
+
+
+# ── secret leak detection ────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_validate_detects_secret_in_response():
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "in_memory",
+        [],
+    )
+    response["records"] = [{"password": "Bearer secret123"}]
+    violations = validate_db_record_evidence_response(response)
+    assert any("secret" in v.lower() for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_detects_surreal_pass():
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "in_memory",
+        [],
+    )
+    response["metadata"] = {
+        "source": "in_memory",
+        "read_only": True,
+        "query_time_ms": 0,
+        "password": "SURREAL_PASS=abc123",
+    }
+    violations = validate_db_record_evidence_response(response)
+    assert any("secret" in v.lower() for v in violations)
+
+
+# ── non-mapping input ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_validate_non_mapping_input():
+    violations = validate_db_record_evidence_response("not a mapping")  # type: ignore[arg-type]
+    assert any("mapping" in v for v in violations)
+
+
+# ── unknown status ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_validate_unknown_status():
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "in_memory",
+        [],
+    )
+    response["status"] = "unknown"
+    violations = validate_db_record_evidence_response(response)
+    assert any("status" in v for v in violations)
+
+
+# ── records not a list ───────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_validate_records_not_list():
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "in_memory",
+        [],
+    )
+    response["records"] = {"not": "a list"}
+    violations = validate_db_record_evidence_response(response)
+    assert any("records" in v for v in violations)
+
+
+# ── filters_applied not a mapping ────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_validate_filters_applied_not_mapping():
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "in_memory",
+        [],
+    )
+    response["filters_applied"] = ["not", "a", "mapping"]
+    violations = validate_db_record_evidence_response(response)
+    assert any("filters_applied" in v for v in violations)
+
+
+# ── missing record_count ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_validate_missing_record_count():
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "in_memory",
+        [],
+    )
+    del response["record_count"]
+    violations = validate_db_record_evidence_response(response)
+    assert any("record_count" in v for v in violations)
+
+
+# ── tool not in allowed set ──────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_validate_bad_tool_name():
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "in_memory",
+        [],
+    )
+    response["tool"] = "not_a_tool"
+    violations = validate_db_record_evidence_response(response)
+    assert any("tool" in v for v in violations)
+
+
+# ── limitations not a list ───────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_validate_limitations_not_list():
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "in_memory",
+        [],
+    )
+    response["limitations"] = "not a list"
+    violations = validate_db_record_evidence_response(response)
+    assert any("limitations" in v for v in violations)
+
+
+# ── freshness negative age ───────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_validate_freshness_negative_age():
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "in_memory",
+        [],
+    )
+    response["freshness"]["age_seconds"] = -5
+    violations = validate_db_record_evidence_response(response)
+    assert any("age_seconds" in v for v in violations)
+
+
+# ── freshness zero threshold ─────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_validate_freshness_zero_threshold():
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "in_memory",
+        [],
+    )
+    response["freshness"]["stale_threshold_seconds"] = 0
+    violations = validate_db_record_evidence_response(response)
+    assert any("stale_threshold_seconds" in v for v in violations)
+
+
+# ── trust cross-validation: trust classification consistency ─────────────────
+
+
+@pytest.mark.unit
+def test_validate_trust_bad_classification():
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "in_memory",
+        [],
+    )
+    response["trust"]["classification"] = "unknown_classification"
+    violations = validate_db_record_evidence_response(response)
+    assert any("classification" in v for v in violations)
+
+
+@pytest.mark.unit
+def test_validate_trust_bad_source_priority():
+    response = build_ok_response(
+        "cdb_context_evidence_resolve",
+        "in_memory",
+        [],
+    )
+    response["trust"]["source_priority"] = "unknown_source"
+    violations = validate_db_record_evidence_response(response)
+    assert any("source_priority" in v for v in violations)

--- a/tools/surrealdb/db_record_evidence_response.py
+++ b/tools/surrealdb/db_record_evidence_response.py
@@ -1,0 +1,546 @@
+"""DB-Record Evidence Response Schema validator (Issue #3421).
+
+Read-only validation for the standardized response envelope that wraps
+SurrealDB query results from MCP evidence tools. Does not access the
+database, does not perform writes, and does not authorize any action.
+
+LR remains NO-GO.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+SCHEMA_VERSION = "db-record-evidence-response/v1"
+
+ALLOWED_TOOLS = frozenset(
+    {
+        "cdb_context_evidence_resolve",
+        "cdb_context_claim_resolve",
+        "cdb_context_memory_get",
+        "cdb_context_trust_summary",
+    }
+)
+
+ALLOWED_SOURCES = frozenset(
+    {
+        "surrealdb-local",
+        "surrealdb-local-unavailable",
+        "in_memory",
+    }
+)
+
+ALLOWED_STATUSES = frozenset({"ok", "error"})
+
+ALLOWED_TRUST_CLASSIFICATIONS = frozenset(
+    {
+        "valid_db_backed",
+        "partial",
+        "repo_only",
+        "in_memory_fixture",
+        "accepted_limitation",
+        "invalid_fake_db",
+    }
+)
+
+ALLOWED_TRUST_LEVELS = frozenset({"HIGH", "MEDIUM", "LOW", "BLOCKED"})
+
+ALLOWED_SOURCE_PRIORITIES = frozenset(
+    {
+        "live_github",
+        "repo_files",
+        "surrealdb_context",
+        "ledger_snapshots",
+        "fallback",
+    }
+)
+
+ALLOWED_FRESHNESS_SIGNALS = frozenset({"fresh", "aging", "stale", "unknown"})
+
+STANDARD_LIMITATIONS = (
+    "Memory is provided as context, not as authoritative truth.",
+    "stale/superseded memory is flagged but not auto-removed.",
+    "LR remains NO-GO; no live-go or Echtgeld-GO implied.",
+)
+
+SECRET_SUBSTRINGS = frozenset(
+    {
+        "SURREAL_PASS",
+        "SURREAL_USER",
+        "Authorization:",
+        "Authorization ",
+        "Basic ",
+        "password=",
+        "api_key=",
+        "api-key=",
+        "secret=",
+        "token=",
+        "Bearer ",
+    }
+)
+
+_SECRET_RE = re.compile(
+    "|".join(re.escape(s) for s in sorted(SECRET_SUBSTRINGS, key=len, reverse=True)),
+    re.IGNORECASE,
+)
+
+REQUIRED_OK_FIELDS = frozenset(
+    {
+        "schema_version",
+        "tool",
+        "status",
+        "source",
+        "metadata",
+        "record_count",
+        "records",
+        "filters_applied",
+        "trust",
+        "freshness",
+        "limitations",
+        "no_echtgeld_go",
+    }
+)
+
+REQUIRED_ERROR_FIELDS = frozenset(
+    {
+        "schema_version",
+        "tool",
+        "status",
+        "error",
+        "metadata",
+        "limitations",
+        "no_echtgeld_go",
+    }
+)
+
+REQUIRED_METADATA_FIELDS = frozenset({"source", "read_only", "query_time_ms"})
+
+REQUIRED_TRUST_FIELDS = frozenset(
+    {"level", "classification", "confidence", "source_priority"}
+)
+
+REQUIRED_FRESHNESS_FIELDS = frozenset(
+    {"age_seconds", "stale_threshold_seconds", "is_stale", "freshness_signal"}
+)
+
+
+class DbRecordEvidenceResponseError(ValueError):
+    """Raised when a response violates the evidence response schema."""
+
+
+def _as_str(value: Any) -> str:
+    return str(value) if value is not None else ""
+
+
+def _has_secret_leak(text: str) -> bool:
+    return bool(_SECRET_RE.search(text))
+
+
+def _serialize_for_scan(obj: Any) -> str:
+    if isinstance(obj, Mapping):
+        parts = []
+        for key in sorted(obj.keys()):
+            parts.append(f"{key}={_serialize_for_scan(obj[key])}")
+        return "{" + ",".join(parts) + "}"
+    if isinstance(obj, (list, tuple)):
+        return "[" + ",".join(_serialize_for_scan(v) for v in obj) + "]"
+    return str(obj)
+
+
+def derive_trust_level(
+    source: str,
+    classification: str,
+    record_count: int,
+) -> str:
+    """Derive the trust level from source, classification, and record count.
+
+    Rules (fail-closed):
+        - BLOCKED:  invalid_fake_db or unknown classification
+        - HIGH:     valid_db_backed AND surrealdb-local AND records > 0
+        - MEDIUM:   valid_db_backed (any source) OR surrealdb-local with records
+        - LOW:      everything else (empty results, in_memory, unavailable, etc.)
+    """
+    if classification not in ALLOWED_TRUST_CLASSIFICATIONS:
+        return "BLOCKED"
+    if classification == "invalid_fake_db":
+        return "BLOCKED"
+
+    if (
+        classification == "valid_db_backed"
+        and source == "surrealdb-local"
+        and record_count > 0
+    ):
+        return "HIGH"
+    if classification == "valid_db_backed":
+        return "MEDIUM"
+    if source == "surrealdb-local" and record_count > 0:
+        return "MEDIUM"
+
+    return "LOW"
+
+
+def derive_freshness_signal(age_seconds: int, stale_threshold_seconds: int) -> str:
+    """Derive a human-readable freshness label."""
+    if age_seconds < 0:
+        return "unknown"
+    ratio = age_seconds / max(stale_threshold_seconds, 1)
+    if ratio <= 0.25:
+        return "fresh"
+    if ratio <= 1.0:
+        return "aging"
+    return "stale"
+
+
+def validate_db_record_evidence_response(
+    response: Mapping[str, Any],
+) -> list[str]:
+    """Validate that *response* conforms to the DB-Record Evidence Response Schema.
+
+    Returns a list of violation messages. An empty list means compliant.
+    """
+    violations: list[str] = []
+
+    if not isinstance(response, Mapping):
+        return ["response must be a mapping"]
+
+    serialized = _serialize_for_scan(response)
+    if _has_secret_leak(serialized):
+        violations.append("response contains forbidden secret-like substrings")
+
+    version = _as_str(response.get("schema_version") or "")
+    if version != SCHEMA_VERSION:
+        violations.append(f"schema_version must be {SCHEMA_VERSION!r}, got {version!r}")
+
+    status = _as_str(response.get("status") or "")
+    if status not in ALLOWED_STATUSES:
+        violations.append(
+            f"status must be one of {sorted(ALLOWED_STATUSES)}, got {status!r}"
+        )
+        return violations
+
+    if status == "ok":
+        violations.extend(_validate_ok_response(response))
+    elif status == "error":
+        violations.extend(_validate_error_response(response))
+
+    limitations = response.get("limitations")
+    if isinstance(limitations, list):
+        limits_text = " ".join(str(item) for item in limitations)
+        for std_lim in STANDARD_LIMITATIONS:
+            if std_lim not in limits_text:
+                violations.append(f"missing standard limitation: {std_lim}")
+    else:
+        violations.append("limitations must be a list of strings")
+
+    no_go = response.get("no_echtgeld_go")
+    if no_go is not True:
+        violations.append(
+            "no_echtgeld_go must be True; "
+            "this response does not authorize live capital or trading actions"
+        )
+
+    return violations
+
+
+def _validate_ok_response(response: Mapping[str, Any]) -> list[str]:
+    violations: list[str] = []
+
+    for field in REQUIRED_OK_FIELDS:
+        if field not in response:
+            violations.append(f"missing required field: {field}")
+
+    tool = _as_str(response.get("tool") or "")
+    if not tool:
+        violations.append("tool must be a non-empty string")
+    elif tool not in ALLOWED_TOOLS:
+        violations.append(f"tool {tool!r} not in allowed set: {sorted(ALLOWED_TOOLS)}")
+
+    source = _as_str(response.get("source") or "")
+    if source and source not in ALLOWED_SOURCES:
+        violations.append(f"source {source!r} not in {sorted(ALLOWED_SOURCES)}")
+
+    violations.extend(_validate_metadata(response))
+
+    records = response.get("records")
+    if not isinstance(records, list):
+        violations.append("records must be a list")
+    record_count = response.get("record_count")
+    if isinstance(records, list) and isinstance(record_count, int):
+        if record_count != len(records):
+            violations.append(
+                f"record_count ({record_count}) must equal len(records) ({len(records)})"
+            )
+    elif not isinstance(record_count, int):
+        violations.append("record_count must be an integer")
+
+    filters = response.get("filters_applied")
+    if not isinstance(filters, Mapping):
+        violations.append("filters_applied must be a mapping")
+
+    violations.extend(
+        _validate_trust(
+            response, source, isinstance(records, list) and len(records) or 0
+        )
+    )
+    violations.extend(_validate_freshness(response))
+
+    return violations
+
+
+def _validate_error_response(response: Mapping[str, Any]) -> list[str]:
+    violations: list[str] = []
+
+    for field in REQUIRED_ERROR_FIELDS:
+        if field not in response:
+            violations.append(f"missing required field: {field}")
+
+    error = response.get("error")
+    if isinstance(error, Mapping):
+        code = _as_str(error.get("code") or "")
+        message = _as_str(error.get("message") or "")
+        if not code:
+            violations.append("error.code must be a non-empty string")
+        if not message:
+            violations.append("error.message must be a non-empty string")
+    else:
+        violations.append("error must be a mapping with code and message")
+
+    violations.extend(_validate_metadata(response))
+    return violations
+
+
+def _validate_metadata(response: Mapping[str, Any]) -> list[str]:
+    violations: list[str] = []
+    metadata = response.get("metadata")
+    if not isinstance(metadata, Mapping):
+        violations.append("metadata must be a mapping")
+        return violations
+
+    for field in REQUIRED_METADATA_FIELDS:
+        if field not in metadata:
+            violations.append(f"metadata missing required field: {field}")
+
+    read_only = metadata.get("read_only")
+    if read_only is not True:
+        violations.append("metadata.read_only must be True")
+
+    return violations
+
+
+def _validate_trust(
+    response: Mapping[str, Any],
+    source: str,
+    record_count: int,
+) -> list[str]:
+    violations: list[str] = []
+    trust = response.get("trust")
+    if not isinstance(trust, Mapping):
+        violations.append("trust must be a mapping")
+        return violations
+
+    for field in REQUIRED_TRUST_FIELDS:
+        if field not in trust:
+            violations.append(f"trust missing required field: {field}")
+
+    level = _as_str(trust.get("level") or "")
+    if level and level not in ALLOWED_TRUST_LEVELS:
+        violations.append(
+            f"trust.level {level!r} not in {sorted(ALLOWED_TRUST_LEVELS)}"
+        )
+
+    classification = _as_str(trust.get("classification") or "")
+    if classification and classification not in ALLOWED_TRUST_CLASSIFICATIONS:
+        violations.append(
+            f"trust.classification {classification!r} not in "
+            f"{sorted(ALLOWED_TRUST_CLASSIFICATIONS)}"
+        )
+
+    confidence = trust.get("confidence")
+    if confidence is not None:
+        if not isinstance(confidence, (int, float)):
+            violations.append("trust.confidence must be a numeric value")
+        elif not (0.0 <= float(confidence) <= 1.0):
+            violations.append(
+                f"trust.confidence must be between 0.0 and 1.0, got {confidence}"
+            )
+
+    src_priority = _as_str(trust.get("source_priority") or "")
+    if src_priority and src_priority not in ALLOWED_SOURCE_PRIORITIES:
+        violations.append(
+            f"trust.source_priority {src_priority!r} not in "
+            f"{sorted(ALLOWED_SOURCE_PRIORITIES)}"
+        )
+
+    # Cross-validate: trust level should be consistent with source + classification
+    if level and classification and source:
+        expected_level = derive_trust_level(source, classification, record_count)
+        if level != expected_level:
+            violations.append(
+                f"trust.level {level!r} inconsistent: expected {expected_level!r} "
+                f"for source={source!r} classification={classification!r} record_count={record_count}"
+            )
+
+    return violations
+
+
+def _validate_freshness(response: Mapping[str, Any]) -> list[str]:
+    violations: list[str] = []
+    freshness = response.get("freshness")
+    if not isinstance(freshness, Mapping):
+        violations.append("freshness must be a mapping")
+        return violations
+
+    for field in REQUIRED_FRESHNESS_FIELDS:
+        if field not in freshness:
+            violations.append(f"freshness missing required field: {field}")
+
+    is_stale = freshness.get("is_stale")
+    if is_stale is not None and not isinstance(is_stale, bool):
+        violations.append("freshness.is_stale must be a boolean")
+
+    age = freshness.get("age_seconds")
+    if isinstance(age, (int, float)) and age < 0:
+        violations.append("freshness.age_seconds must be >= 0")
+
+    threshold = freshness.get("stale_threshold_seconds")
+    if isinstance(threshold, (int, float)) and threshold <= 0:
+        violations.append("freshness.stale_threshold_seconds must be > 0")
+
+    signal = _as_str(freshness.get("freshness_signal") or "")
+    if signal and signal not in ALLOWED_FRESHNESS_SIGNALS:
+        violations.append(
+            f"freshness.freshness_signal {signal!r} not in "
+            f"{sorted(ALLOWED_FRESHNESS_SIGNALS)}"
+        )
+
+    # Cross-validate: is_stale should match freshness_signal
+    if isinstance(is_stale, bool) and signal:
+        if is_stale and signal == "fresh":
+            violations.append(
+                "freshness.is_stale=True inconsistent with freshness_signal='fresh'"
+            )
+        if not is_stale and signal == "stale":
+            violations.append(
+                "freshness.is_stale=False inconsistent with freshness_signal='stale'"
+            )
+
+    return violations
+
+
+def build_ok_response(
+    tool: str,
+    source: str,
+    records: list[dict[str, Any]],
+    *,
+    query_time_ms: int = 0,
+    filters_applied: dict[str, Any] | None = None,
+    trust_level: str | None = None,
+    trust_classification: str | None = None,
+    trust_confidence: float | None = None,
+    trust_source_priority: str | None = None,
+    age_seconds: int = 0,
+    stale_threshold_seconds: int = 3600,
+    extra_limitations: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a schema-compliant ok response envelope.
+
+    Source and record count drive automatic trust derivation when explicit
+    trust parameters are not provided.
+    """
+    if source not in ALLOWED_SOURCES:
+        source = "in_memory"
+
+    record_count = len(records)
+    classification = trust_classification or (
+        "valid_db_backed"
+        if source == "surrealdb-local" and record_count > 0
+        else (
+            "partial"
+            if source in ("surrealdb-local", "surrealdb-local-unavailable")
+            else "in_memory_fixture"
+        )
+    )
+    level = trust_level or derive_trust_level(source, classification, record_count)
+    confidence = (
+        trust_confidence
+        if trust_confidence is not None
+        else (
+            0.9
+            if source == "surrealdb-local" and record_count > 0
+            else 0.5 if source == "surrealdb-local" else 0.3
+        )
+    )
+    src_priority = trust_source_priority or (
+        "surrealdb_context" if source == "surrealdb-local" else "repo_files"
+    )
+    freshness_signal = derive_freshness_signal(age_seconds, stale_threshold_seconds)
+
+    limitations = list(STANDARD_LIMITATIONS)
+    if extra_limitations:
+        limitations.extend(extra_limitations)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "tool": tool,
+        "status": "ok",
+        "source": source,
+        "metadata": {
+            "source": source,
+            "read_only": True,
+            "query_time_ms": query_time_ms,
+        },
+        "record_count": record_count,
+        "records": records,
+        "filters_applied": filters_applied or {},
+        "trust": {
+            "level": level,
+            "classification": classification,
+            "confidence": confidence,
+            "source_priority": src_priority,
+        },
+        "freshness": {
+            "age_seconds": age_seconds,
+            "stale_threshold_seconds": stale_threshold_seconds,
+            "is_stale": freshness_signal == "stale",
+            "freshness_signal": freshness_signal,
+        },
+        "limitations": limitations,
+        "no_echtgeld_go": True,
+    }
+
+
+def build_error_response(
+    tool: str,
+    *,
+    code: str,
+    message: str,
+    source: str = "in_memory",
+) -> dict[str, Any]:
+    """Build a schema-compliant error response envelope."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "tool": tool,
+        "status": "error",
+        "source": source,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+        "metadata": {
+            "source": "in_memory",
+            "read_only": True,
+            "query_time_ms": 0,
+        },
+        "limitations": list(STANDARD_LIMITATIONS),
+        "no_echtgeld_go": True,
+    }
+
+
+def enforce_response_contract(response: Mapping[str, Any]) -> None:
+    """Raise ``DbRecordEvidenceResponseError`` if *response* violates the schema."""
+    violations = validate_db_record_evidence_response(response)
+    if violations:
+        raise DbRecordEvidenceResponseError(
+            f"DB-Record Evidence Response Schema violations: {'; '.join(violations)}"
+        )


### PR DESCRIPTION
## Summary

Issue #3421 (SLICE-03): Implement read-only MCP Evidence Contract between CDB-Agents and SurrealDB.

## Deliverables

### 1. READONLY_QUERY_CONTRACT.md
Formalizes the three-layer defense-in-depth architecture ensuring all MCP evidence tools are fail-closed read-only:
- Layer 1: MCP permission guard (tool-level allowlist)
- Layer 2: SurrealQL statement classifier (classify_statement() with DENIED_KEYWORDS, ALLOWED_PREFIXES, table whitelist/blacklist)
- Layer 3: SurrealDB VIEWER role (database-level RBAC)

### 2. DB_RECORD_EVIDENCE_RESPONSE_SCHEMA.md
Standardized response envelope for all DB-backed evidence responses:
- Trust (level, classification, source_priority)
- Confidence (0.0–1.0 float)
- Freshness (signal, age_seconds, stale_threshold_seconds, is_stale)
- record_metadata, filters_applied, limitations, no_echtgeld_go

### 3. db_record_evidence_response.py
Validator module implementing:
- \derive_trust_level()\ — classifies trust from source + classification + record_count
- \derive_freshness_signal()\ — fresh/aging/stale with zero-threshold protection
- \uild_ok_response()\ / \uild_error_response()\ — factory functions
- \alidate_db_record_evidence_response()\ — full contract validator with cross-validation
- \nforce_response_contract()\ — raises on violation
- Secret leak detection in response payloads

### 4. test_mcp_evidence_contract.py
59 tests covering:
- Trust derivation (9 tests)
- Freshness derivation (6 tests)
- Response factories (9 tests)
- Full validation paths (24 tests)
- Edge cases, secret detection, cross-validation (11 tests)

### 5. DB_RECORD_EVIDENCE_CONTRACT.md
Updated with #3421 cross-references in header metadata, complementary contracts list, and new \#3421 Contracts\ section.

## Safety

- **No existing code modified**: classify_statement(), permission_guard.py, MCP handlers unchanged
- **No secrets**: no live credentials, no DB passwords, no Tresor access
- **No DB writes**: all validation code is static/in-memory
- **LR remains NO-GO**: no live trading capability added
- **136 surrealdb tests pass** (77 existing + 59 new)
- **Ruff clean**, **git diff --check clean**

## Test Evidence

\\\
136 passed in 0.37s  (tests/surrealdb/)
ruff check: All checks passed
\\\

Closes #3421