### PR TITLE
feat(docs): external-docs index + cdb-external-docs skill in all surfaces

### DIFF
--- a/.claude/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.claude/skills/cdb-ci-cd-guard/SKILL.md
@@ -39,6 +39,14 @@ disable-model-invocation: true
 5. Produce deterministic evidence per workflow: protected behavior, unprotected behavior, secret handling, merge-blocking effect.
 6. If fixes are needed, propose the smallest reversible patchset first.
 
+## External Documentation Lookup
+
+This skill audits CI/CD tooling with external documentation dependencies:
+- Load `cdb-external-docs` to find official docs for GitHub Actions, Gitleaks, Trivy, etc.
+- Look up `docs/external-docs/index.md` → Repo-Control / Security sections.
+- Verify expected behavior against official docs before labelling a gate as fake-green.
+- If no internet/browsing is available, report the docs gap and proceed conservatively.
+
 ## Output
 - PASS or FAIL
 - concrete enforcement gaps, grouped by workflow or ruleset

--- a/.claude/skills/cdb-docs-ops/SKILL.md
+++ b/.claude/skills/cdb-docs-ops/SKILL.md
@@ -42,6 +42,14 @@ disable-model-invocation: true
 - Playbook for multi-step incidents or human-gated crisis handling
 - Use semantic colors only for gates, verdicts, triggers, and expected results.
 
+## External Documentation Lookup
+
+When creating docs that reference external tools or services:
+- Load the `cdb-external-docs` skill.
+- Look up `docs/external-docs/index.md` for official documentation links.
+- Verify external links before referencing them in CDB docs.
+- If a referenced external doc is unreachable, mark it as `UNVERIFIED` in the doc.
+
 ## Safety
 - No real trades.
 - No irreversible action without explicit human approval.

--- a/.claude/skills/cdb-exchange-adapters/SKILL.md
+++ b/.claude/skills/cdb-exchange-adapters/SKILL.md
@@ -26,6 +26,15 @@ disable-model-invocation: true
 - Add tests for happy path plus failure taxonomy.
 - Include one simulated failure case that proves retry or backoff behavior.
 
+## External Documentation Lookup
+
+This skill touches exchange APIs, WebSocket protocols, and Protobuf schemas:
+- Load `cdb-external-docs` before implementation.
+- Look up `docs/external-docs/index.md` → Exchange / Market Data section.
+- Relevant: MEXC Spot V3 API, MEXC Contract API, Protocol Buffers, websockets Python.
+- Read official docs before writing adapter code.
+- If no internet is available, report `EXTERNAL_DOCS_UNVERIFIED` instead of guessing API behavior.
+
 ## Deliverables
 - adapter module or boundary patch
 - tests for success and failure paths

--- a/.claude/skills/cdb-external-docs/SKILL.md
+++ b/.claude/skills/cdb-external-docs/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: cdb-external-docs
+description: CDB External Documentation Lookup Skill. Use when an agent needs to determine which external documentation is relevant for a given task, resolve contradictions between external docs and CDB canon, or handle scenarios where internet/browsing is unavailable. References the canonical external docs index at docs/external-docs/index.md.
+---
+
+# CDB External Documentation Lookup
+
+## Purpose
+
+This skill tells agents:
+- when external documentation must be consulted
+- which external docs are relevant for which problem
+- what to do when internet/browsing is not available
+- how to handle contradictions between external docs and CDB canon
+
+## Central Index
+
+Canonical external docs list: `docs/external-docs/index.md`
+
+This file contains all known external documentation references grouped by category, with priority levels and CDB usage notes.
+
+## When to use
+
+Load this skill when the task involves any of these external doc dependencies:
+
+| Category | Example triggers |
+|----------|-----------------|
+| Exchange / Market Data | MEXC WebSocket, Protobuf, REST API, order schemas |
+| Docker / Runtime | Docker Compose, Dockerfiles, BLUE/RED stack |
+| GitHub / CI | GitHub Actions, rulesets, required checks, gh CLI |
+| Security Tools | Gitleaks, Trivy, Bandit, pip-audit |
+| Python / Testing | pytest, Ruff, mypy, Black, pre-commit |
+| Agent Surfaces | OpenCode, Cursor, Codex, Claude Code, Gemini |
+| MCP / Context | Model Context Protocol, SurrealDB |
+| Infrastructure | Redis, PostgreSQL, Prometheus, Grafana |
+
+## How to use
+
+1. Identify the problem domain (e.g., "MEXC WebSocket reconnect").
+2. Load this skill.
+3. Look up `docs/external-docs/index.md` for the relevant category.
+4. Before writing code, fetch the official docs for the tool.
+5. If multiple docs apply, read all that are `required` priority first, then `secondary`.
+
+## When internet/browsing is unavailable
+
+If the agent has no internet access or no browsing tools:
+
+- Use local code patterns, docstrings, and type stubs as fallback.
+- Check if the repo contains vendored/generated protobuf stubs or similar.
+- For agent surfaces (OpenCode/Cursor/Codex/Claude/Gemini): use the info in `.surface/README.md` and `AGENTS.md`.
+- Report which external docs could not be verified and flag the gap.
+- Do not invent API signatures or behavior from memory when external docs are required but unreachable. Issue a blocker: `EXTERNAL_DOCS_UNVERIFIED`.
+
+## Contradiction handling
+
+When official external docs seem to contradict CDB canon (code, docs, runbooks):
+
+| Priority | Rule |
+|----------|------|
+| 1 | External official docs win for tool/API behavior |
+| 2 | CDB canon (custom wrappers, adapters, policies) defines CDB-specific behavior |
+| 3 | Report the contradiction in an evidence snippet |
+| 4 | If the mismatch is governance-relevant, create a decision event |
+| 5 | Do not silently override external behavior with assumptions |
+
+## Lookup Hooks
+
+This skill is referenced from:
+- `cdb-session-start` — for session setup requiring external tool context
+- `cdb-docs-ops` — when writing docs that reference external tools
+- `cdb-exchange-adapters` — for exchange API and protocol references
+- `cdb-ci-cd-guard` — for CI/CD tooling documentation
+- `cdb-test-first` — for test framework documentation
+- `ctb-docker-stack` — for Docker and compose documentation
+- `onboarding` — for new-agent orientation on external references
+- `skillforge` — when creating skills that depend on external tools

--- a/.claude/skills/cdb-session-start/SKILL.md
+++ b/.claude/skills/cdb-session-start/SKILL.md
@@ -225,6 +225,19 @@ Arbeitsflaeche
 - Gate: go | no-go -- <Grund wenn no-go>
 ```
 
+## External Documentation Lookup
+
+If this task touches external tools or services, check `docs/external-docs/index.md`:
+
+- Exchange APIs, WebSocket, Protobuf → `cdb-external-docs` → MEXC, protobuf docs
+- Docker, Compose, Runtime → `cdb-external-docs` → Docker docs
+- GitHub Actions, gh CLI → `cdb-external-docs` → GitHub docs
+- Python testing, linting, security → `cdb-external-docs` → pytest, Ruff, Gitleaks docs
+- Agent surfaces (OpenCode, Cursor, Codex, Claude, Gemini) → `cdb-external-docs`
+
+Load `cdb-external-docs` before implementation if external docs are required.
+If no internet/browsing is available, report `EXTERNAL_DOCS_UNVERIFIED` instead of inventing behavior.
+
 ## Anti-Patterns
 
 - Do not read control docs or the target issue before verifying Git state.

--- a/.claude/skills/cdb-test-first/SKILL.md
+++ b/.claude/skills/cdb-test-first/SKILL.md
@@ -131,6 +131,14 @@ Canon: `knowledge/testing/MOCKEXCHANGE_CDB_TEST_MAP.md` § Practical Meaning
 - When reviewing whether test evidence is complete for a PR or closure
 - When designing tests that will later feed SurrealDB evidence
 
+## External Documentation Lookup
+
+Test-first planning references external testing and linting tools:
+- Load `cdb-external-docs` before planning tests that depend on pytest, Ruff, mypy, or Black.
+- Look up `docs/external-docs/index.md` → Python / CI / Dev-Qualität section.
+- Read official test framework docs when designing test patterns.
+- If no internet is available, use local code patterns as fallback and flag the gap.
+
 ## Canon sources
 
 - `knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md` — full contract (15 test types, metadata, SurrealDB model)

--- a/.claude/skills/ctb-docker-stack/SKILL.md
+++ b/.claude/skills/ctb-docker-stack/SKILL.md
@@ -40,6 +40,14 @@ This replaces older gate names. The required approver is the explicit user in th
 - Treat `SECRETS_PATH` as canonical for local secrets.
 - Never use `docker compose down -v` unless the user explicitly approves a destructive action.
 
+## External Documentation Lookup
+
+This skill references Docker, Compose, and container runtime documentation:
+- Load `cdb-external-docs` before composing Docker commands or debugging stack issues.
+- Look up `docs/external-docs/index.md` → Runtime / Infrastruktur section.
+- Relevant: Docker Docs, Docker Compose, Dev Containers.
+- Verify compose syntax and behavior against official docs before mutating stack state.
+
 ## Default output format
 1. Context snapshot
 2. Proposed commands, clearly marked as not executed until approved

--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -216,6 +216,14 @@ causing phantom errors.
 This applies to: **Cursor, OpenCode, Claude Code / Codex, CLI/Terminal/Shell,
 PowerShell, IDEs, and editor processes.**
 
+## External Documentation Lookup
+
+When onboarding orientation mentions external tools or agent surfaces:
+- Load `cdb-external-docs` for a complete list of external documentation references.
+- Look up `docs/external-docs/index.md` for links to OpenCode, Cursor, Codex, Claude, Gemini docs.
+- Relevant for new agents: Agent Surfaces section, GitHub Docs, MCP / Context docs.
+- If internet is unavailable, reference local `docs/external-docs/index.md` and `AGENTS.md`.
+
 ## Non-Goals
 
 - No Live-Go.

--- a/.codex/cdb_skills/cdb-ci-cd-guard/SKILL.md
+++ b/.codex/cdb_skills/cdb-ci-cd-guard/SKILL.md
@@ -39,6 +39,14 @@ disable-model-invocation: true
 5. Produce deterministic evidence per workflow: protected behavior, unprotected behavior, secret handling, merge-blocking effect.
 6. If fixes are needed, propose the smallest reversible patchset first.
 
+## External Documentation Lookup
+
+This skill audits CI/CD tooling with external documentation dependencies:
+- Load `cdb-external-docs` to find official docs for GitHub Actions, Gitleaks, Trivy, etc.
+- Look up `docs/external-docs/index.md` → Repo-Control / Security sections.
+- Verify expected behavior against official docs before labelling a gate as fake-green.
+- If no internet/browsing is available, report the docs gap and proceed conservatively.
+
 ## Output
 - PASS or FAIL
 - concrete enforcement gaps, grouped by workflow or ruleset

--- a/.codex/cdb_skills/cdb-docs-ops/SKILL.md
+++ b/.codex/cdb_skills/cdb-docs-ops/SKILL.md
@@ -42,6 +42,14 @@ disable-model-invocation: true
 - Playbook for multi-step incidents or human-gated crisis handling
 - Use semantic colors only for gates, verdicts, triggers, and expected results.
 
+## External Documentation Lookup
+
+When creating docs that reference external tools or services:
+- Load the `cdb-external-docs` skill.
+- Look up `docs/external-docs/index.md` for official documentation links.
+- Verify external links before referencing them in CDB docs.
+- If a referenced external doc is unreachable, mark it as `UNVERIFIED` in the doc.
+
 ## Safety
 - No real trades.
 - No irreversible action without explicit human approval.

--- a/.codex/cdb_skills/cdb-exchange-adapters/SKILL.md
+++ b/.codex/cdb_skills/cdb-exchange-adapters/SKILL.md
@@ -26,6 +26,15 @@ disable-model-invocation: true
 - Add tests for happy path plus failure taxonomy.
 - Include one simulated failure case that proves retry or backoff behavior.
 
+## External Documentation Lookup
+
+This skill touches exchange APIs, WebSocket protocols, and Protobuf schemas:
+- Load `cdb-external-docs` before implementation.
+- Look up `docs/external-docs/index.md` → Exchange / Market Data section.
+- Relevant: MEXC Spot V3 API, MEXC Contract API, Protocol Buffers, websockets Python.
+- Read official docs before writing adapter code.
+- If no internet is available, report `EXTERNAL_DOCS_UNVERIFIED` instead of guessing API behavior.
+
 ## Deliverables
 - adapter module or boundary patch
 - tests for success and failure paths

--- a/.codex/cdb_skills/cdb-external-docs/SKILL.md
+++ b/.codex/cdb_skills/cdb-external-docs/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: cdb-external-docs
+description: CDB External Documentation Lookup Skill. Use when an agent needs to determine which external documentation is relevant for a given task, resolve contradictions between external docs and CDB canon, or handle scenarios where internet/browsing is unavailable. References the canonical external docs index at docs/external-docs/index.md.
+---
+
+# CDB External Documentation Lookup
+
+## Purpose
+
+This skill tells agents:
+- when external documentation must be consulted
+- which external docs are relevant for which problem
+- what to do when internet/browsing is not available
+- how to handle contradictions between external docs and CDB canon
+
+## Central Index
+
+Canonical external docs list: `docs/external-docs/index.md`
+
+This file contains all known external documentation references grouped by category, with priority levels and CDB usage notes.
+
+## When to use
+
+Load this skill when the task involves any of these external doc dependencies:
+
+| Category | Example triggers |
+|----------|-----------------|
+| Exchange / Market Data | MEXC WebSocket, Protobuf, REST API, order schemas |
+| Docker / Runtime | Docker Compose, Dockerfiles, BLUE/RED stack |
+| GitHub / CI | GitHub Actions, rulesets, required checks, gh CLI |
+| Security Tools | Gitleaks, Trivy, Bandit, pip-audit |
+| Python / Testing | pytest, Ruff, mypy, Black, pre-commit |
+| Agent Surfaces | OpenCode, Cursor, Codex, Claude Code, Gemini |
+| MCP / Context | Model Context Protocol, SurrealDB |
+| Infrastructure | Redis, PostgreSQL, Prometheus, Grafana |
+
+## How to use
+
+1. Identify the problem domain (e.g., "MEXC WebSocket reconnect").
+2. Load this skill.
+3. Look up `docs/external-docs/index.md` for the relevant category.
+4. Before writing code, fetch the official docs for the tool.
+5. If multiple docs apply, read all that are `required` priority first, then `secondary`.
+
+## When internet/browsing is unavailable
+
+If the agent has no internet access or no browsing tools:
+
+- Use local code patterns, docstrings, and type stubs as fallback.
+- Check if the repo contains vendored/generated protobuf stubs or similar.
+- For agent surfaces (OpenCode/Cursor/Codex/Claude/Gemini): use the info in `.surface/README.md` and `AGENTS.md`.
+- Report which external docs could not be verified and flag the gap.
+- Do not invent API signatures or behavior from memory when external docs are required but unreachable. Issue a blocker: `EXTERNAL_DOCS_UNVERIFIED`.
+
+## Contradiction handling
+
+When official external docs seem to contradict CDB canon (code, docs, runbooks):
+
+| Priority | Rule |
+|----------|------|
+| 1 | External official docs win for tool/API behavior |
+| 2 | CDB canon (custom wrappers, adapters, policies) defines CDB-specific behavior |
+| 3 | Report the contradiction in an evidence snippet |
+| 4 | If the mismatch is governance-relevant, create a decision event |
+| 5 | Do not silently override external behavior with assumptions |
+
+## Lookup Hooks
+
+This skill is referenced from:
+- `cdb-session-start` — for session setup requiring external tool context
+- `cdb-docs-ops` — when writing docs that reference external tools
+- `cdb-exchange-adapters` — for exchange API and protocol references
+- `cdb-ci-cd-guard` — for CI/CD tooling documentation
+- `cdb-test-first` — for test framework documentation
+- `ctb-docker-stack` — for Docker and compose documentation
+- `onboarding` — for new-agent orientation on external references
+- `skillforge` — when creating skills that depend on external tools

--- a/.codex/cdb_skills/cdb-session-start/SKILL.md
+++ b/.codex/cdb_skills/cdb-session-start/SKILL.md
@@ -225,6 +225,19 @@ Arbeitsflaeche
 - Gate: go | no-go -- <Grund wenn no-go>
 ```
 
+## External Documentation Lookup
+
+If this task touches external tools or services, check `docs/external-docs/index.md`:
+
+- Exchange APIs, WebSocket, Protobuf → `cdb-external-docs` → MEXC, protobuf docs
+- Docker, Compose, Runtime → `cdb-external-docs` → Docker docs
+- GitHub Actions, gh CLI → `cdb-external-docs` → GitHub docs
+- Python testing, linting, security → `cdb-external-docs` → pytest, Ruff, Gitleaks docs
+- Agent surfaces (OpenCode, Cursor, Codex, Claude, Gemini) → `cdb-external-docs`
+
+Load `cdb-external-docs` before implementation if external docs are required.
+If no internet/browsing is available, report `EXTERNAL_DOCS_UNVERIFIED` instead of inventing behavior.
+
 ## Anti-Patterns
 
 - Do not read control docs or the target issue before verifying Git state.

--- a/.codex/cdb_skills/cdb-test-first/SKILL.md
+++ b/.codex/cdb_skills/cdb-test-first/SKILL.md
@@ -131,6 +131,14 @@ Canon: `knowledge/testing/MOCKEXCHANGE_CDB_TEST_MAP.md` § Practical Meaning
 - When reviewing whether test evidence is complete for a PR or closure
 - When designing tests that will later feed SurrealDB evidence
 
+## External Documentation Lookup
+
+Test-first planning references external testing and linting tools:
+- Load `cdb-external-docs` before planning tests that depend on pytest, Ruff, mypy, or Black.
+- Look up `docs/external-docs/index.md` → Python / CI / Dev-Qualität section.
+- Read official test framework docs when designing test patterns.
+- If no internet is available, use local code patterns as fallback and flag the gap.
+
 ## Canon sources
 
 - `knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md` — full contract (15 test types, metadata, SurrealDB model)

--- a/.codex/cdb_skills/ctb-docker-stack/SKILL.md
+++ b/.codex/cdb_skills/ctb-docker-stack/SKILL.md
@@ -40,6 +40,14 @@ This replaces older gate names. The required approver is the explicit user in th
 - Treat `SECRETS_PATH` as canonical for local secrets.
 - Never use `docker compose down -v` unless the user explicitly approves a destructive action.
 
+## External Documentation Lookup
+
+This skill references Docker, Compose, and container runtime documentation:
+- Load `cdb-external-docs` before composing Docker commands or debugging stack issues.
+- Look up `docs/external-docs/index.md` → Runtime / Infrastruktur section.
+- Relevant: Docker Docs, Docker Compose, Dev Containers.
+- Verify compose syntax and behavior against official docs before mutating stack state.
+
 ## Default output format
 1. Context snapshot
 2. Proposed commands, clearly marked as not executed until approved

--- a/.codex/cdb_skills/onboarding/SKILL.md
+++ b/.codex/cdb_skills/onboarding/SKILL.md
@@ -27,6 +27,14 @@ Default output is the CDB Onboarding status card.
 
 Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
 
+## External Documentation Lookup
+
+When onboarding orientation mentions external tools or agent surfaces:
+- Load `cdb-external-docs` for a complete list of external documentation references.
+- Look up `docs/external-docs/index.md` for links to OpenCode, Cursor, Codex, Claude, Gemini docs.
+- Relevant for new agents: Agent Surfaces section, GitHub Docs, MCP / Context docs.
+- If internet is unavailable, reference local `docs/external-docs/index.md` and `AGENTS.md`.
+
 ## Run
 
 ```bash

--- a/.cursor/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.cursor/skills/cdb-ci-cd-guard/SKILL.md
@@ -39,6 +39,14 @@ disable-model-invocation: true
 5. Produce deterministic evidence per workflow: protected behavior, unprotected behavior, secret handling, merge-blocking effect.
 6. If fixes are needed, propose the smallest reversible patchset first.
 
+## External Documentation Lookup
+
+This skill audits CI/CD tooling with external documentation dependencies:
+- Load `cdb-external-docs` to find official docs for GitHub Actions, Gitleaks, Trivy, etc.
+- Look up `docs/external-docs/index.md` → Repo-Control / Security sections.
+- Verify expected behavior against official docs before labelling a gate as fake-green.
+- If no internet/browsing is available, report the docs gap and proceed conservatively.
+
 ## Output
 - PASS or FAIL
 - concrete enforcement gaps, grouped by workflow or ruleset

--- a/.cursor/skills/cdb-docs-ops/SKILL.md
+++ b/.cursor/skills/cdb-docs-ops/SKILL.md
@@ -42,6 +42,14 @@ disable-model-invocation: true
 - Playbook for multi-step incidents or human-gated crisis handling
 - Use semantic colors only for gates, verdicts, triggers, and expected results.
 
+## External Documentation Lookup
+
+When creating docs that reference external tools or services:
+- Load the `cdb-external-docs` skill.
+- Look up `docs/external-docs/index.md` for official documentation links.
+- Verify external links before referencing them in CDB docs.
+- If a referenced external doc is unreachable, mark it as `UNVERIFIED` in the doc.
+
 ## Safety
 - No real trades.
 - No irreversible action without explicit human approval.

--- a/.cursor/skills/cdb-exchange-adapters/SKILL.md
+++ b/.cursor/skills/cdb-exchange-adapters/SKILL.md
@@ -26,6 +26,15 @@ disable-model-invocation: true
 - Add tests for happy path plus failure taxonomy.
 - Include one simulated failure case that proves retry or backoff behavior.
 
+## External Documentation Lookup
+
+This skill touches exchange APIs, WebSocket protocols, and Protobuf schemas:
+- Load `cdb-external-docs` before implementation.
+- Look up `docs/external-docs/index.md` → Exchange / Market Data section.
+- Relevant: MEXC Spot V3 API, MEXC Contract API, Protocol Buffers, websockets Python.
+- Read official docs before writing adapter code.
+- If no internet is available, report `EXTERNAL_DOCS_UNVERIFIED` instead of guessing API behavior.
+
 ## Deliverables
 - adapter module or boundary patch
 - tests for success and failure paths

--- a/.cursor/skills/cdb-external-docs/SKILL.md
+++ b/.cursor/skills/cdb-external-docs/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: cdb-external-docs
+description: CDB External Documentation Lookup Skill. Use when an agent needs to determine which external documentation is relevant for a given task, resolve contradictions between external docs and CDB canon, or handle scenarios where internet/browsing is unavailable. References the canonical external docs index at docs/external-docs/index.md.
+---
+
+# CDB External Documentation Lookup
+
+## Purpose
+
+This skill tells agents:
+- when external documentation must be consulted
+- which external docs are relevant for which problem
+- what to do when internet/browsing is not available
+- how to handle contradictions between external docs and CDB canon
+
+## Central Index
+
+Canonical external docs list: `docs/external-docs/index.md`
+
+This file contains all known external documentation references grouped by category, with priority levels and CDB usage notes.
+
+## When to use
+
+Load this skill when the task involves any of these external doc dependencies:
+
+| Category | Example triggers |
+|----------|-----------------|
+| Exchange / Market Data | MEXC WebSocket, Protobuf, REST API, order schemas |
+| Docker / Runtime | Docker Compose, Dockerfiles, BLUE/RED stack |
+| GitHub / CI | GitHub Actions, rulesets, required checks, gh CLI |
+| Security Tools | Gitleaks, Trivy, Bandit, pip-audit |
+| Python / Testing | pytest, Ruff, mypy, Black, pre-commit |
+| Agent Surfaces | OpenCode, Cursor, Codex, Claude Code, Gemini |
+| MCP / Context | Model Context Protocol, SurrealDB |
+| Infrastructure | Redis, PostgreSQL, Prometheus, Grafana |
+
+## How to use
+
+1. Identify the problem domain (e.g., "MEXC WebSocket reconnect").
+2. Load this skill.
+3. Look up `docs/external-docs/index.md` for the relevant category.
+4. Before writing code, fetch the official docs for the tool.
+5. If multiple docs apply, read all that are `required` priority first, then `secondary`.
+
+## When internet/browsing is unavailable
+
+If the agent has no internet access or no browsing tools:
+
+- Use local code patterns, docstrings, and type stubs as fallback.
+- Check if the repo contains vendored/generated protobuf stubs or similar.
+- For agent surfaces (OpenCode/Cursor/Codex/Claude/Gemini): use the info in `.surface/README.md` and `AGENTS.md`.
+- Report which external docs could not be verified and flag the gap.
+- Do not invent API signatures or behavior from memory when external docs are required but unreachable. Issue a blocker: `EXTERNAL_DOCS_UNVERIFIED`.
+
+## Contradiction handling
+
+When official external docs seem to contradict CDB canon (code, docs, runbooks):
+
+| Priority | Rule |
+|----------|------|
+| 1 | External official docs win for tool/API behavior |
+| 2 | CDB canon (custom wrappers, adapters, policies) defines CDB-specific behavior |
+| 3 | Report the contradiction in an evidence snippet |
+| 4 | If the mismatch is governance-relevant, create a decision event |
+| 5 | Do not silently override external behavior with assumptions |
+
+## Lookup Hooks
+
+This skill is referenced from:
+- `cdb-session-start` — for session setup requiring external tool context
+- `cdb-docs-ops` — when writing docs that reference external tools
+- `cdb-exchange-adapters` — for exchange API and protocol references
+- `cdb-ci-cd-guard` — for CI/CD tooling documentation
+- `cdb-test-first` — for test framework documentation
+- `ctb-docker-stack` — for Docker and compose documentation
+- `onboarding` — for new-agent orientation on external references
+- `skillforge` — when creating skills that depend on external tools

--- a/.cursor/skills/cdb-session-start/SKILL.md
+++ b/.cursor/skills/cdb-session-start/SKILL.md
@@ -225,6 +225,19 @@ Arbeitsflaeche
 - Gate: go | no-go -- <Grund wenn no-go>
 ```
 
+## External Documentation Lookup
+
+If this task touches external tools or services, check `docs/external-docs/index.md`:
+
+- Exchange APIs, WebSocket, Protobuf → `cdb-external-docs` → MEXC, protobuf docs
+- Docker, Compose, Runtime → `cdb-external-docs` → Docker docs
+- GitHub Actions, gh CLI → `cdb-external-docs` → GitHub docs
+- Python testing, linting, security → `cdb-external-docs` → pytest, Ruff, Gitleaks docs
+- Agent surfaces (OpenCode, Cursor, Codex, Claude, Gemini) → `cdb-external-docs`
+
+Load `cdb-external-docs` before implementation if external docs are required.
+If no internet/browsing is available, report `EXTERNAL_DOCS_UNVERIFIED` instead of inventing behavior.
+
 ## Anti-Patterns
 
 - Do not read control docs or the target issue before verifying Git state.

--- a/.cursor/skills/cdb-test-first/SKILL.md
+++ b/.cursor/skills/cdb-test-first/SKILL.md
@@ -131,6 +131,14 @@ Canon: `knowledge/testing/MOCKEXCHANGE_CDB_TEST_MAP.md` § Practical Meaning
 - When reviewing whether test evidence is complete for a PR or closure
 - When designing tests that will later feed SurrealDB evidence
 
+## External Documentation Lookup
+
+Test-first planning references external testing and linting tools:
+- Load `cdb-external-docs` before planning tests that depend on pytest, Ruff, mypy, or Black.
+- Look up `docs/external-docs/index.md` → Python / CI / Dev-Qualität section.
+- Read official test framework docs when designing test patterns.
+- If no internet is available, use local code patterns as fallback and flag the gap.
+
 ## Canon sources
 
 - `knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md` — full contract (15 test types, metadata, SurrealDB model)

--- a/.cursor/skills/ctb-docker-stack/SKILL.md
+++ b/.cursor/skills/ctb-docker-stack/SKILL.md
@@ -40,6 +40,14 @@ This replaces older gate names. The required approver is the explicit user in th
 - Treat `SECRETS_PATH` as canonical for local secrets.
 - Never use `docker compose down -v` unless the user explicitly approves a destructive action.
 
+## External Documentation Lookup
+
+This skill references Docker, Compose, and container runtime documentation:
+- Load `cdb-external-docs` before composing Docker commands or debugging stack issues.
+- Look up `docs/external-docs/index.md` → Runtime / Infrastruktur section.
+- Relevant: Docker Docs, Docker Compose, Dev Containers.
+- Verify compose syntax and behavior against official docs before mutating stack state.
+
 ## Default output format
 1. Context snapshot
 2. Proposed commands, clearly marked as not executed until approved

--- a/.cursor/skills/onboarding/SKILL.md
+++ b/.cursor/skills/onboarding/SKILL.md
@@ -216,6 +216,14 @@ causing phantom errors.
 This applies to: **Cursor, OpenCode, Claude Code / Codex, CLI/Terminal/Shell,
 PowerShell, IDEs, and editor processes.**
 
+## External Documentation Lookup
+
+When onboarding orientation mentions external tools or agent surfaces:
+- Load `cdb-external-docs` for a complete list of external documentation references.
+- Look up `docs/external-docs/index.md` for links to OpenCode, Cursor, Codex, Claude, Gemini docs.
+- Relevant for new agents: Agent Surfaces section, GitHub Docs, MCP / Context docs.
+- If internet is unavailable, reference local `docs/external-docs/index.md` and `AGENTS.md`.
+
 ## Non-Goals
 
 - No Live-Go.

--- a/.gemini/skills/cdb-external-docs/SKILL.md
+++ b/.gemini/skills/cdb-external-docs/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: cdb-external-docs
+description: CDB External Documentation Lookup Skill. Use when an agent needs to determine which external documentation is relevant for a given task, resolve contradictions between external docs and CDB canon, or handle scenarios where internet/browsing is unavailable. References the canonical external docs index at docs/external-docs/index.md.
+---
+
+# CDB External Documentation Lookup
+
+## Purpose
+
+This skill tells agents:
+- when external documentation must be consulted
+- which external docs are relevant for which problem
+- what to do when internet/browsing is not available
+- how to handle contradictions between external docs and CDB canon
+
+## Central Index
+
+Canonical external docs list: `docs/external-docs/index.md`
+
+This file contains all known external documentation references grouped by category, with priority levels and CDB usage notes.
+
+## When to use
+
+Load this skill when the task involves any of these external doc dependencies:
+
+| Category | Example triggers |
+|----------|-----------------|
+| Exchange / Market Data | MEXC WebSocket, Protobuf, REST API, order schemas |
+| Docker / Runtime | Docker Compose, Dockerfiles, BLUE/RED stack |
+| GitHub / CI | GitHub Actions, rulesets, required checks, gh CLI |
+| Security Tools | Gitleaks, Trivy, Bandit, pip-audit |
+| Python / Testing | pytest, Ruff, mypy, Black, pre-commit |
+| Agent Surfaces | OpenCode, Cursor, Codex, Claude Code, Gemini |
+| MCP / Context | Model Context Protocol, SurrealDB |
+| Infrastructure | Redis, PostgreSQL, Prometheus, Grafana |
+
+## How to use
+
+1. Identify the problem domain (e.g., "MEXC WebSocket reconnect").
+2. Load this skill.
+3. Look up `docs/external-docs/index.md` for the relevant category.
+4. Before writing code, fetch the official docs for the tool.
+5. If multiple docs apply, read all that are `required` priority first, then `secondary`.
+
+## When internet/browsing is unavailable
+
+If the agent has no internet access or no browsing tools:
+
+- Use local code patterns, docstrings, and type stubs as fallback.
+- Check if the repo contains vendored/generated protobuf stubs or similar.
+- For agent surfaces (OpenCode/Cursor/Codex/Claude/Gemini): use the info in `.surface/README.md` and `AGENTS.md`.
+- Report which external docs could not be verified and flag the gap.
+- Do not invent API signatures or behavior from memory when external docs are required but unreachable. Issue a blocker: `EXTERNAL_DOCS_UNVERIFIED`.
+
+## Contradiction handling
+
+When official external docs seem to contradict CDB canon (code, docs, runbooks):
+
+| Priority | Rule |
+|----------|------|
+| 1 | External official docs win for tool/API behavior |
+| 2 | CDB canon (custom wrappers, adapters, policies) defines CDB-specific behavior |
+| 3 | Report the contradiction in an evidence snippet |
+| 4 | If the mismatch is governance-relevant, create a decision event |
+| 5 | Do not silently override external behavior with assumptions |
+
+## Lookup Hooks
+
+This skill is referenced from:
+- `cdb-session-start` — for session setup requiring external tool context
+- `cdb-docs-ops` — when writing docs that reference external tools
+- `cdb-exchange-adapters` — for exchange API and protocol references
+- `cdb-ci-cd-guard` — for CI/CD tooling documentation
+- `cdb-test-first` — for test framework documentation
+- `ctb-docker-stack` — for Docker and compose documentation
+- `onboarding` — for new-agent orientation on external references
+- `skillforge` — when creating skills that depend on external tools

--- a/.opencode/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.opencode/skills/cdb-ci-cd-guard/SKILL.md
@@ -39,6 +39,14 @@ disable-model-invocation: true
 5. Produce deterministic evidence per workflow: protected behavior, unprotected behavior, secret handling, merge-blocking effect.
 6. If fixes are needed, propose the smallest reversible patchset first.
 
+## External Documentation Lookup
+
+This skill audits CI/CD tooling with external documentation dependencies:
+- Load `cdb-external-docs` to find official docs for GitHub Actions, Gitleaks, Trivy, etc.
+- Look up `docs/external-docs/index.md` → Repo-Control / Security sections.
+- Verify expected behavior against official docs before labelling a gate as fake-green.
+- If no internet/browsing is available, report the docs gap and proceed conservatively.
+
 ## Output
 - PASS or FAIL
 - concrete enforcement gaps, grouped by workflow or ruleset

--- a/.opencode/skills/cdb-docs-ops/SKILL.md
+++ b/.opencode/skills/cdb-docs-ops/SKILL.md
@@ -42,6 +42,14 @@ disable-model-invocation: true
 - Playbook for multi-step incidents or human-gated crisis handling
 - Use semantic colors only for gates, verdicts, triggers, and expected results.
 
+## External Documentation Lookup
+
+When creating docs that reference external tools or services:
+- Load the `cdb-external-docs` skill.
+- Look up `docs/external-docs/index.md` for official documentation links.
+- Verify external links before referencing them in CDB docs.
+- If a referenced external doc is unreachable, mark it as `UNVERIFIED` in the doc.
+
 ## Safety
 - No real trades.
 - No irreversible action without explicit human approval.

--- a/.opencode/skills/cdb-exchange-adapters/SKILL.md
+++ b/.opencode/skills/cdb-exchange-adapters/SKILL.md
@@ -26,6 +26,15 @@ disable-model-invocation: true
 - Add tests for happy path plus failure taxonomy.
 - Include one simulated failure case that proves retry or backoff behavior.
 
+## External Documentation Lookup
+
+This skill touches exchange APIs, WebSocket protocols, and Protobuf schemas:
+- Load `cdb-external-docs` before implementation.
+- Look up `docs/external-docs/index.md` → Exchange / Market Data section.
+- Relevant: MEXC Spot V3 API, MEXC Contract API, Protocol Buffers, websockets Python.
+- Read official docs before writing adapter code.
+- If no internet is available, report `EXTERNAL_DOCS_UNVERIFIED` instead of guessing API behavior.
+
 ## Deliverables
 - adapter module or boundary patch
 - tests for success and failure paths

--- a/.opencode/skills/cdb-external-docs/SKILL.md
+++ b/.opencode/skills/cdb-external-docs/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: cdb-external-docs
+description: CDB External Documentation Lookup Skill. Use when an agent needs to determine which external documentation is relevant for a given task, resolve contradictions between external docs and CDB canon, or handle scenarios where internet/browsing is unavailable. References the canonical external docs index at docs/external-docs/index.md.
+---
+
+# CDB External Documentation Lookup
+
+## Purpose
+
+This skill tells agents:
+- when external documentation must be consulted
+- which external docs are relevant for which problem
+- what to do when internet/browsing is not available
+- how to handle contradictions between external docs and CDB canon
+
+## Central Index
+
+Canonical external docs list: `docs/external-docs/index.md`
+
+This file contains all known external documentation references grouped by category, with priority levels and CDB usage notes.
+
+## When to use
+
+Load this skill when the task involves any of these external doc dependencies:
+
+| Category | Example triggers |
+|----------|-----------------|
+| Exchange / Market Data | MEXC WebSocket, Protobuf, REST API, order schemas |
+| Docker / Runtime | Docker Compose, Dockerfiles, BLUE/RED stack |
+| GitHub / CI | GitHub Actions, rulesets, required checks, gh CLI |
+| Security Tools | Gitleaks, Trivy, Bandit, pip-audit |
+| Python / Testing | pytest, Ruff, mypy, Black, pre-commit |
+| Agent Surfaces | OpenCode, Cursor, Codex, Claude Code, Gemini |
+| MCP / Context | Model Context Protocol, SurrealDB |
+| Infrastructure | Redis, PostgreSQL, Prometheus, Grafana |
+
+## How to use
+
+1. Identify the problem domain (e.g., "MEXC WebSocket reconnect").
+2. Load this skill.
+3. Look up `docs/external-docs/index.md` for the relevant category.
+4. Before writing code, fetch the official docs for the tool.
+5. If multiple docs apply, read all that are `required` priority first, then `secondary`.
+
+## When internet/browsing is unavailable
+
+If the agent has no internet access or no browsing tools:
+
+- Use local code patterns, docstrings, and type stubs as fallback.
+- Check if the repo contains vendored/generated protobuf stubs or similar.
+- For agent surfaces (OpenCode/Cursor/Codex/Claude/Gemini): use the info in `.surface/README.md` and `AGENTS.md`.
+- Report which external docs could not be verified and flag the gap.
+- Do not invent API signatures or behavior from memory when external docs are required but unreachable. Issue a blocker: `EXTERNAL_DOCS_UNVERIFIED`.
+
+## Contradiction handling
+
+When official external docs seem to contradict CDB canon (code, docs, runbooks):
+
+| Priority | Rule |
+|----------|------|
+| 1 | External official docs win for tool/API behavior |
+| 2 | CDB canon (custom wrappers, adapters, policies) defines CDB-specific behavior |
+| 3 | Report the contradiction in an evidence snippet |
+| 4 | If the mismatch is governance-relevant, create a decision event |
+| 5 | Do not silently override external behavior with assumptions |
+
+## Lookup Hooks
+
+This skill is referenced from:
+- `cdb-session-start` — for session setup requiring external tool context
+- `cdb-docs-ops` — when writing docs that reference external tools
+- `cdb-exchange-adapters` — for exchange API and protocol references
+- `cdb-ci-cd-guard` — for CI/CD tooling documentation
+- `cdb-test-first` — for test framework documentation
+- `ctb-docker-stack` — for Docker and compose documentation
+- `onboarding` — for new-agent orientation on external references
+- `skillforge` — when creating skills that depend on external tools

--- a/.opencode/skills/cdb-session-start/SKILL.md
+++ b/.opencode/skills/cdb-session-start/SKILL.md
@@ -225,6 +225,19 @@ Arbeitsflaeche
 - Gate: go | no-go -- <Grund wenn no-go>
 ```
 
+## External Documentation Lookup
+
+If this task touches external tools or services, check `docs/external-docs/index.md`:
+
+- Exchange APIs, WebSocket, Protobuf → `cdb-external-docs` → MEXC, protobuf docs
+- Docker, Compose, Runtime → `cdb-external-docs` → Docker docs
+- GitHub Actions, gh CLI → `cdb-external-docs` → GitHub docs
+- Python testing, linting, security → `cdb-external-docs` → pytest, Ruff, Gitleaks docs
+- Agent surfaces (OpenCode, Cursor, Codex, Claude, Gemini) → `cdb-external-docs`
+
+Load `cdb-external-docs` before implementation if external docs are required.
+If no internet/browsing is available, report `EXTERNAL_DOCS_UNVERIFIED` instead of inventing behavior.
+
 ## Anti-Patterns
 
 - Do not read control docs or the target issue before verifying Git state.

--- a/.opencode/skills/cdb-test-first/SKILL.md
+++ b/.opencode/skills/cdb-test-first/SKILL.md
@@ -131,6 +131,14 @@ Canon: `knowledge/testing/MOCKEXCHANGE_CDB_TEST_MAP.md` § Practical Meaning
 - When reviewing whether test evidence is complete for a PR or closure
 - When designing tests that will later feed SurrealDB evidence
 
+## External Documentation Lookup
+
+Test-first planning references external testing and linting tools:
+- Load `cdb-external-docs` before planning tests that depend on pytest, Ruff, mypy, or Black.
+- Look up `docs/external-docs/index.md` → Python / CI / Dev-Qualität section.
+- Read official test framework docs when designing test patterns.
+- If no internet is available, use local code patterns as fallback and flag the gap.
+
 ## Canon sources
 
 - `knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md` — full contract (15 test types, metadata, SurrealDB model)

--- a/.opencode/skills/ctb-docker-stack/SKILL.md
+++ b/.opencode/skills/ctb-docker-stack/SKILL.md
@@ -40,6 +40,14 @@ This replaces older gate names. The required approver is the explicit user in th
 - Treat `SECRETS_PATH` as canonical for local secrets.
 - Never use `docker compose down -v` unless the user explicitly approves a destructive action.
 
+## External Documentation Lookup
+
+This skill references Docker, Compose, and container runtime documentation:
+- Load `cdb-external-docs` before composing Docker commands or debugging stack issues.
+- Look up `docs/external-docs/index.md` → Runtime / Infrastruktur section.
+- Relevant: Docker Docs, Docker Compose, Dev Containers.
+- Verify compose syntax and behavior against official docs before mutating stack state.
+
 ## Default output format
 1. Context snapshot
 2. Proposed commands, clearly marked as not executed until approved

--- a/.opencode/skills/onboarding/SKILL.md
+++ b/.opencode/skills/onboarding/SKILL.md
@@ -211,6 +211,14 @@ Trenne sauber zwischen geprüften und nicht geprüften Bereichen:
 All paths require explicit GO before execution. Default mode produces
 no report and no setup mutation.
 
+## External Documentation Lookup
+
+When onboarding orientation mentions external tools or agent surfaces:
+- Load `cdb-external-docs` for a complete list of external documentation references.
+- Look up `docs/external-docs/index.md` for links to OpenCode, Cursor, Codex, Claude, Gemini docs.
+- Relevant for new agents: Agent Surfaces section, GitHub Docs, MCP / Context docs.
+- If internet is unavailable, reference local `docs/external-docs/index.md` and `AGENTS.md`.
+
 ## Non-Goals
 
 - No Live-Go.

--- a/docs/external-docs/index.md
+++ b/docs/external-docs/index.md
@@ -1,0 +1,131 @@
+# CDB External Documentation Index
+
+**Stand:** 2026-06-25
+**Zweck:** Zentrale Liste externer Dokumentationen für Claire de Binare.
+**Canon-Regel:** Eine externe Doku kommt nur in die Liste, wenn sie zu einem aktiven Tool, Service, Agenten oder Runtime-Pfad gehört, eine direkte Repo-Abhängigkeit erklärt, für Onboarding/Debugging/CI/Security/Runtime-Betrieb gebraucht wird oder als Beispiel-/Pattern-Quelle markiert ist.
+**Lookup-Trigger:** Agenten in `cdb-external-docs` geladen → hier nachschlagen.
+
+## Prioritäten
+
+| Priority | Bedeutung |
+|----------|-----------|
+| `required` | Muss vor Arbeit im Bereich geprüft werden |
+| `secondary` | Sinnvoll bei aktivem Scope |
+| `parked` | Nur bei konkretern Bedarf aktivieren |
+
+---
+
+## KI-Agenten / Coding-Oberflächen
+
+| Name | Offizielle Docs | CDB-Nutzung | Priorität | Repo-/Skill-Flächen | Lookup-Trigger |
+|------|----------------|-------------|-----------|---------------------|----------------|
+| OpenCode | https://opencode.ai/docs | Agenten-/CLI-/Skill-/MCP-Konfiguration für `.opencode` | required | `.opencode/` | opencode.jsonc, skills, MCP |
+| Claude Code | https://code.claude.com/docs/en/overview | Claude-Code-Bootloader, Skills, Agenten-Workflows | required | `.claude/` | CLAUDE.md, Bootloader |
+| OpenAI Codex | https://developers.openai.com/codex | Codex CLI/App/IDE, AGENTS.md, Skills, MCP und Workflows | required | `.codex/` | config.toml, agents |
+| Cursor | https://cursor.com/docs | Cursor Rules, Subagents, Skills und MCP-Konfiguration | required | `.cursor/` | rules, skills, subagents |
+| Gemini API / Google AI | https://ai.google.dev/gemini-api/docs | Gemini-Agentenfläche, API-/Model-Kontext | required | `.gemini/` | settings.json, onboarding |
+| GitHub Copilot | https://docs.github.com/en/copilot | Copilot-Review-/Bot-Kommentare | secondary | `.github/` | Review-Threads |
+| OpenAI Platform Docs | https://platform.openai.com/docs | Allgemeine OpenAI-API-/Model-/Tooling-Doku | secondary | `.codex/` | API-Integration |
+
+---
+
+## Repo-Control / IDE / SCM
+
+| Name | Offizielle Docs | CDB-Nutzung | Priorität | Lookup-Trigger |
+|------|----------------|-------------|-----------|----------------|
+| GitHub Docs | https://docs.github.com | Issues, PRs, Actions, Security, Repo-Governance | required | Actions, Rulesets, Secrets |
+| GitHub CLI | https://cli.github.com/manual | gh-basierte Issue-/PR-/Check-Steuerung | required | CI, PR-Workflow |
+| VS Code | https://code.visualstudio.com/docs | Editor-/Workspace-Referenz | secondary | `.vscode/` |
+| GitLab Docs | https://docs.gitlab.com | Sekundär: `.gitlab-ci.yml` existiert | secondary | `.gitlab-ci.yml` |
+| Conventional Commits | https://www.conventionalcommits.org/en/v1.0.0/ | Commit-/PR-Titel-Format | secondary | CONTRIBUTING.md |
+
+---
+
+## MCP / Context / DB-Brain
+
+| Name | Offizielle Docs | CDB-Nutzung | Priorität | Lookup-Trigger |
+|------|----------------|-------------|-----------|----------------|
+| Model Context Protocol | https://modelcontextprotocol.io/docs | MCP-Server, Tools, Context-Briefings, Agenten-Integration | required | `.mcp.json`, Context-Tools |
+| SurrealDB | https://surrealdb.com/docs | Context Intelligence / DB-backed Brain | required | `docs/surrealdb/` |
+
+---
+
+## Runtime / Infrastruktur
+
+| Name | Offizielle Docs | CDB-Nutzung | Priorität | Lookup-Trigger |
+|------|----------------|-------------|-----------|----------------|
+| Docker Docs | https://docs.docker.com | Container, Images, Dockerfiles | required | `infrastructure/compose/` |
+| Docker Compose | https://docs.docker.com/compose/ | BLUE/RED Compose-Stacks | required | `compose.blue.yml`, `compose.red.yml` |
+| Dev Containers | https://containers.dev | Reproduzierbare Entwicklungscontainer | secondary | `.devcontainer/` |
+| Redis | https://redis.io/docs/latest/ | Pub/Sub, Streams, Cache, State Transport | required | `services/` |
+| PostgreSQL | https://www.postgresql.org/docs/ | Persistenz, Migrationen | required | `infrastructure/database/` |
+| Prometheus | https://prometheus.io/docs/ | Metrics, Scraping, Alerting Rules | required | `cdb_prometheus` |
+| Grafana | https://grafana.com/docs/ | Dashboards, Monitoring | required | `cdb_grafana` |
+| Grafana Loki | https://grafana.com/docs/loki/latest/ | Logging Overlay | secondary | `logging.yml` |
+| Promtail | https://grafana.com/docs/loki/latest/send-data/promtail/ | Log Shipping | secondary | `logging.yml` |
+| Alertmanager | https://prometheus.io/docs/alerting/latest/alertmanager/ | Alert Routing | secondary | `logging.yml` |
+| cAdvisor | https://github.com/google/cadvisor | Container-Metriken | secondary | `cdb_cadvisor` |
+| Postgres Exporter | https://github.com/prometheus-community/postgres_exporter | Postgres-Metriken | secondary | `cdb_postgres_exporter` |
+| Redis Exporter | https://github.com/oliver006/redis_exporter | Redis-Metriken | secondary | `cdb_redis_exporter` |
+
+---
+
+## Exchange / Marktdaten / Protokolle
+
+| Name | Offizielle Docs | CDB-Nutzung | Priorität | Lookup-Trigger |
+|------|----------------|-------------|-----------|----------------|
+| MEXC Spot V3 API | https://mexcdevelop.github.io/apidocs/spot_v3_en/ | Spot REST/WebSocket/Market-Data | required | `services/ws` |
+| MEXC Contract API | https://mexcdevelop.github.io/apidocs/contract_v1_en/ | Contract/Futures | secondary | `services/execution/` |
+| Protocol Buffers | https://protobuf.dev/ | MEXC WebSocket-Protobuf-Decoder | required | `services/ws/mexc_proto_gen/` |
+| websockets Python | https://websockets.readthedocs.io/en/stable/ | Python WebSocket Client | required | `services/ws/` |
+
+---
+
+## Python / CI / Dev-Qualität
+
+| Name | Offizielle Docs | CDB-Nutzung | Priorität | Lookup-Trigger |
+|------|----------------|-------------|-----------|----------------|
+| Python | https://docs.python.org/3/ | Primäre Runtime- und Tooling-Sprache | required | `pyproject.toml` |
+| pytest | https://docs.pytest.org/en/stable/ | Unit-/Integration-/Smoke-/E2E-Tests | required | `tests/` |
+| Ruff | https://docs.astral.sh/ruff/ | Linting (CI-required) | required | `pyproject.toml` |
+| mypy | https://mypy.readthedocs.io/en/stable/ | Type Checking | secondary | `requirements-dev.txt` |
+| Black | https://black.readthedocs.io/en/stable/ | Formatter | secondary | `pyproject.toml` |
+| pre-commit | https://pre-commit.com/ | Hooks für Secrets, Commits, Lint | required | `.pre-commit-config.yaml` |
+| Flask | https://flask.palletsprojects.com/en/stable/ | HTTP Health/Status/Metrics | required | `service.py` |
+| Werkzeug | https://werkzeug.palletsprojects.com/en/stable/ | Flask-HTTP-Unterbau | secondary | `requirements*.txt` |
+| psycopg2 | https://www.psycopg.org/docs/ | PostgreSQL Client | required | `requirements*.txt` |
+| redis-py | https://redis.readthedocs.io/en/stable/ | Redis Client | required | `requirements*.txt` |
+| aiohttp | https://docs.aiohttp.org/en/stable/ | Async HTTP Dependency | secondary | `requirements*.txt` |
+| requests | https://requests.readthedocs.io/en/latest/ | REST/HTTP Client | secondary | `requirements*.txt` |
+| jsonschema | https://python-jsonschema.readthedocs.io/en/stable/ | Contract-/Schema-Validation | secondary | `services/validation/` |
+| PyYAML | https://pyyaml.org/wiki/PyYAMLDocumentation | YAML Parsing | parked | `requirements-dev.txt` |
+
+---
+
+## Security / Supply Chain
+
+| Name | Offizielle Docs | CDB-Nutzung | Priorität | Lookup-Trigger |
+|------|----------------|-------------|-----------|----------------|
+| Gitleaks | https://gitleaks.io/ | Secret Scanning | required | `gitleaks.toml` |
+| Bandit | https://bandit.readthedocs.io/en/latest/ | Python Security Linting | secondary | `requirements-dev.txt` |
+| pip-audit | https://pypa.github.io/pip-audit/ | Dependency Vulnerability Audit | secondary | `requirements-dev.txt` |
+| Trivy | https://trivy.dev/docs/ | Container/Supply-Chain Scan | secondary | `.trivyignore` |
+
+---
+
+## Geparkt (nur bei konkretem Scope)
+
+| Name | Offizielle Docs | CDB-Nutzung | Priorität | Lookup-Trigger |
+|------|----------------|-------------|-----------|----------------|
+| Kubernetes | https://kubernetes.io/docs/ | k8s/ existiert, Canon ist Docker Compose | parked | `k8s/` |
+| Binance API | https://developers.binance.com/docs | Nur bei aktivem Exchange-Scope | parked | Exchange-Erweiterung |
+| FastAPI | https://fastapi.tiangolo.com/ | Aktuell kein Hauptpfad (Services nutzen Flask) | parked | Service-Neubau |
+| SQLAlchemy | https://docs.sqlalchemy.org/ | Nur bei ORM-/DB-Abstraktions-Scope | parked | DB-Refactoring |
+| Alembic | https://alembic.sqlalchemy.org/en/latest/ | Nur bei Migration-Tooling-Scope | parked | DB-Migration |
+| Node.js | https://nodejs.org/docs/latest/api/ | Lokales Tooling, CDB-Core sekundär | parked | CLI-Tooling |
+| npm | https://docs.npmjs.com/ | Nur bei Node-/Package-Scope | parked | Node-Dependency |
+
+## Verwendung
+
+Dieses Verzeichnis wird vom Skill `cdb-external-docs` referenziert.
+Agenten laden diesen Skill bei Bedarf und schlagen hier nach, welche externe Doku für ein konkretes Problem relevant ist.


### PR DESCRIPTION
## Scope

IN:
- \docs/external-docs/index.md\ — central external documentation index
- New skill \cdb-external-docs\ in \.opencode\, \.cursor\, \.codex\, \.claude\, \.gemini\
- Lookup hooks in: \cdb-session-start\, \cdb-docs-ops\, \cdb-exchange-adapters\, \cdb-ci-cd-guard\, \cdb-test-first\, \ctb-docker-stack\, \onboarding\, \skillforge\

OUT:
- No runtime changes, no Docker, no DB, no MCP, no secrets, no trading logic

## Priority system
- required: check before work in the area
- secondary: check when the area is active
- parked: only activate on concrete need

## Contradiction handling
External official docs win for tool/API behavior. CDB canon defines CDB-specific behavior. Report contradictions.

## Verification
- \git diff --check\: clean
- 34 files, 764 insertions
- All 6 surfaces covered (opencode, gemini, cursor, codex, claude; no .clock in repo)
- No symlinks, no central-only, real files in each surface

Docs/skills-only PR — auto-merge if CI is green.