### PR TITLE
fix(evidence): warn on incomplete coordinator sleep lifecycle at final validation

### DIFF
--- a/tests/unit/tools/evidence_harvester/test_ops_validation.py
+++ b/tests/unit/tools/evidence_harvester/test_ops_validation.py
@@ -967,6 +967,143 @@ class TestValidate72hWindowFromDir:
         assert any("fail threshold" in f.message for f in report.findings)
 
     @pytest.mark.unit
+    def test_warn_on_missing_sleep_completed(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        events_path = tmp_path / "coordinator_events.jsonl"
+        events = [
+            json.loads(line)
+            for line in events_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        events = [
+            e
+            for e in events
+            if e.get("event_type")
+            not in ("final_validation_started", "final_validation_completed")
+        ]
+        last_ts = events[-1]["event_at_utc"] if events else _ts(start)
+        events.append(
+            {
+                "schema_version": (
+                    "cdb.evidence_harvester.coordinator_event.v1"
+                ),
+                "event_at_utc": last_ts,
+                "run_id": "test-run",
+                "event_type": "sleep_started",
+            }
+        )
+        events_path.write_text(
+            "\n".join(json.dumps(e, sort_keys=True) for e in events)
+            + "\n",
+            encoding="utf-8",
+        )
+        state_path = tmp_path / "runner_state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["coordinator_status"] = "sleeping"
+        state_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert any(
+            "Coordinator sleep lifecycle completeness" in f.check_name
+            and f.severity == "warn"
+            for f in report.findings
+        )
+
+    @pytest.mark.unit
+    def test_no_sleep_finding_when_sleep_completed(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert not any(
+            "Coordinator sleep lifecycle completeness" in f.check_name
+            for f in report.findings
+        )
+
+    @pytest.mark.unit
+    def test_no_sleep_finding_when_no_sleep_events(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        events_path = tmp_path / "coordinator_events.jsonl"
+        events = [
+            json.loads(line)
+            for line in events_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        events = [
+            e
+            for e in events
+            if e.get("event_type")
+            not in ("sleep_started", "sleep_completed", "sleep_overshoot")
+        ]
+        events_path.write_text(
+            "\n".join(json.dumps(e, sort_keys=True) for e in events)
+            + "\n",
+            encoding="utf-8",
+        )
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert not any(
+            "Coordinator sleep lifecycle completeness" in f.check_name
+            for f in report.findings
+        )
+
+    @pytest.mark.unit
+    def test_no_sleep_finding_on_non_final(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        events_path = tmp_path / "coordinator_events.jsonl"
+        events = [
+            json.loads(line)
+            for line in events_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        events = [
+            e
+            for e in events
+            if e.get("event_type")
+            not in ("final_validation_started", "final_validation_completed")
+        ]
+        last_ts = events[-1]["event_at_utc"] if events else _ts(start)
+        events.append(
+            {
+                "schema_version": (
+                    "cdb.evidence_harvester.coordinator_event.v1"
+                ),
+                "event_at_utc": last_ts,
+                "run_id": "test-run",
+                "event_type": "sleep_started",
+            }
+        )
+        events_path.write_text(
+            "\n".join(json.dumps(e, sort_keys=True) for e in events)
+            + "\n",
+            encoding="utf-8",
+        )
+
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+            is_final=False,
+        )
+        assert not any(
+            "Coordinator sleep lifecycle completeness" in f.check_name
+            for f in report.findings
+        )
+
+    @pytest.mark.unit
     def test_fail_on_nonexistent_dir(self, tmp_path: Path) -> None:
         with pytest.raises(OpsValidationError, match="does not exist"):
             validate_72h_window_from_dir(tmp_path / "missing")

--- a/tests/unit/tools/evidence_harvester/test_ops_validation.py
+++ b/tests/unit/tools/evidence_harvester/test_ops_validation.py
@@ -985,17 +985,14 @@ class TestValidate72hWindowFromDir:
         last_ts = events[-1]["event_at_utc"] if events else _ts(start)
         events.append(
             {
-                "schema_version": (
-                    "cdb.evidence_harvester.coordinator_event.v1"
-                ),
+                "schema_version": ("cdb.evidence_harvester.coordinator_event.v1"),
                 "event_at_utc": last_ts,
                 "run_id": "test-run",
                 "event_type": "sleep_started",
             }
         )
         events_path.write_text(
-            "\n".join(json.dumps(e, sort_keys=True) for e in events)
-            + "\n",
+            "\n".join(json.dumps(e, sort_keys=True) for e in events) + "\n",
             encoding="utf-8",
         )
         state_path = tmp_path / "runner_state.json"
@@ -1045,8 +1042,7 @@ class TestValidate72hWindowFromDir:
             not in ("sleep_started", "sleep_completed", "sleep_overshoot")
         ]
         events_path.write_text(
-            "\n".join(json.dumps(e, sort_keys=True) for e in events)
-            + "\n",
+            "\n".join(json.dumps(e, sort_keys=True) for e in events) + "\n",
             encoding="utf-8",
         )
         report = validate_72h_window_from_dir(
@@ -1078,17 +1074,14 @@ class TestValidate72hWindowFromDir:
         last_ts = events[-1]["event_at_utc"] if events else _ts(start)
         events.append(
             {
-                "schema_version": (
-                    "cdb.evidence_harvester.coordinator_event.v1"
-                ),
+                "schema_version": ("cdb.evidence_harvester.coordinator_event.v1"),
                 "event_at_utc": last_ts,
                 "run_id": "test-run",
                 "event_type": "sleep_started",
             }
         )
         events_path.write_text(
-            "\n".join(json.dumps(e, sort_keys=True) for e in events)
-            + "\n",
+            "\n".join(json.dumps(e, sort_keys=True) for e in events) + "\n",
             encoding="utf-8",
         )
 

--- a/tools/evidence_harvester/ops_validation.py
+++ b/tools/evidence_harvester/ops_validation.py
@@ -1203,9 +1203,7 @@ def _check_sleep_lifecycle_completeness(
         return
     coordinator_status = ""
     if state_payload is not None:
-        coordinator_status = str(
-            state_payload.get("coordinator_status", "") or ""
-        )
+        coordinator_status = str(state_payload.get("coordinator_status", "") or "")
     add_finding(
         "Coordinator sleep lifecycle completeness",
         "warn",

--- a/tools/evidence_harvester/ops_validation.py
+++ b/tools/evidence_harvester/ops_validation.py
@@ -1187,6 +1187,36 @@ def _check_coordinator_events(
     )
 
 
+def _check_sleep_lifecycle_completeness(
+    events: Sequence[Mapping[str, Any]],
+    state_payload: Mapping[str, Any] | None,
+    add_finding: Any,
+    *,
+    is_final: bool = True,
+) -> None:
+    if not is_final:
+        return
+    if not events:
+        return
+    last_event = events[-1]
+    if last_event.get("event_type") != "sleep_started":
+        return
+    coordinator_status = ""
+    if state_payload is not None:
+        coordinator_status = str(
+            state_payload.get("coordinator_status", "") or ""
+        )
+    add_finding(
+        "Coordinator sleep lifecycle completeness",
+        "warn",
+        f"The coordinator event stream ends with sleep_started "
+        f"and no matching sleep_completed or sleep_overshoot. "
+        f"Coordinator status: {coordinator_status!r}. "
+        f"The run may have been interrupted during sleep.",
+        artifact="coordinator_events.jsonl",
+    )
+
+
 def _check_lifecycle_runner_state_consistency(
     coordinator_events: Sequence[Mapping[str, Any]],
     state_payload: Mapping[str, Any] | None,
@@ -1458,6 +1488,10 @@ def validate_72h_window(
         _check_no_side_effects(path, payload, add_finding)
 
     _check_coordinator_events(coordinator_events, add_finding, is_final=is_final)
+
+    _check_sleep_lifecycle_completeness(
+        coordinator_events, state_payload, add_finding, is_final=is_final
+    )
 
     _check_lifecycle_runner_state_consistency(
         coordinator_events,


### PR DESCRIPTION
## Summary

Adds final validation WARN for `sleep_started` without matching `sleep_completed` / `sleep_overshoot` in the coordinator event stream. Covers the #3374 cycle-143 stall pattern where the process died during the sleep interval.

## Changes

### `tools/evidence_harvester/ops_validation.py`
- New `_check_sleep_lifecycle_completeness(events, state_payload, add_finding, *, is_final=True)`
- Only fires at `is_final=True` (non-final checkpoints allow partial sleep lifecycle)
- Checks: last event is `sleep_started` and no matching `sleep_completed` or `sleep_overshoot`
- Reads `coordinator_status` from `runner_state.json` for context in the WARN message
- Called from `validate_72h_window` after `_check_coordinator_events`

### `tests/unit/tools/evidence_harvester/test_ops_validation.py`
4 new tests:

| Test | Scenario | Expected |
|------|----------|----------|
| `test_warn_on_missing_sleep_completed` | Final validation, event stream ends with `sleep_started` | WARN finding |
| `test_no_sleep_finding_when_sleep_completed` | Complete run, all sleep lifecycle complete | No finding |
| `test_no_sleep_finding_when_no_sleep_events` | No sleep events at all | No finding |
| `test_no_sleep_finding_on_non_final` | Non-final validation, event stream ends with `sleep_started` | No finding (is_final=False) |

## Verification

- `pytest tests/unit/tools/evidence_harvester/` -> 235/235 PASS (including 4 new tests)
- `ruff check tools/evidence_harvester/ops_validation.py` -> All checks passed
- `ruff check tests/unit/tools/evidence_harvester/test_ops_validation.py` -> All checks passed

## Does NOT

- **Does not claim 72h PASS** -- the validator now detects interrupted sleep, but does not change the coverage requirement
- **Does not prove post-#3403 behavior** -- the #3374 run started pre-#3403 at SHA 7f357cfb
- **Does not close #3374, #3384, #3362, or #3345** -- Slice A is validator hardening only

## Refs

Refs #3374, #3362, #3384, #3345
