### PR TITLE
fix(mcp): add missing enrichment parameters to context.briefing input schema

### DIFF
--- a/tools/mcp/registry.py
+++ b/tools/mcp/registry.py
@@ -529,6 +529,34 @@ TOOLS_V0 = [
                     "items": {"type": "string"},
                     "description": "Optional session limitations supplied by the caller.",
                 },
+                "evidence_records": {
+                    "type": "array",
+                    "description": "Optional in-memory evidence records for Wave-14 enrichment (evidence_lookup, trust_summary).",
+                },
+                "claim_records": {
+                    "type": "array",
+                    "description": "Optional in-memory claim records for Wave-14 enrichment (claim_resolver).",
+                },
+                "decision_events": {
+                    "type": "array",
+                    "description": "Optional in-memory decision events for Wave-14 enrichment (decision_history).",
+                },
+                "memory_records": {
+                    "type": "array",
+                    "description": "Optional in-memory memory records for Wave-14 enrichment (memory_read).",
+                },
+                "enrichment_scope": {
+                    "type": "string",
+                    "description": "Scope for enrichment filtering (default wave14). Controls which records are processed.",
+                },
+                "adapter_config_path": {
+                    "type": "string",
+                    "description": "Optional SurrealDB adapter config path for DB-backed briefing (requires local SurrealDB).",
+                },
+                "secrets_path": {
+                    "type": "string",
+                    "description": "Optional secrets directory path for DB-backed SurrealDB adapter access.",
+                },
             },
             "required": [
                 "task_id",


### PR DESCRIPTION
## Root Cause

\context.briefing\ input_schema in \	ools/mcp/registry.py:441-540\ (deep-copied to \cdb_context_briefing\ via \egistry.py:1727\) did **not** advertise the 7 optional Wave-14 enrichment parameters. Agents calling the MCP tool could never discover these fields and always passed \None\, causing \operator_trust_level=LOW\ regardless of available context.

The handler code (\context_briefing_handler\ in \context_bridge.py\) already accepted and processed all enrichment fields — the schema simply did not expose them.

## Fix

**One file: \	ools/mcp/registry.py\** — 28 additions, 0 deletions.

Added 7 optional fields to \context.briefing\ input_schema \properties\:

| Field | Type | Purpose |
|---|---|---|
| \vidence_records\ | array | Evidence records for Wave-14 enrichment |
| \claim_records\ | array | Claim records for Wave-14 enrichment |
| \decision_events\ | array | Decision events for Wave-14 enrichment |
| \memory_records\ | array | Memory records for Wave-14 enrichment |
| \nrichment_scope\ | string | Scope filtering (default wave14) |
| \dapter_config_path\ | string | SurrealDB adapter path (optional, no DB-Go) |
| \secrets_path\ | string | Secrets dir for SurrealDB adapter (optional) |

All fields are **optional** (not added to \equired\ list) — backward compatible.

The schema change propagates automatically to \cdb_context_briefing\ via the existing \deepcopy(base.input_schema)\ at \egistry.py:1727\.

## Validation

- **104/104 tests passing** (34 enrichment + 11 trust threshold + 59 evidence contract)
- Ruff check: clean
- No handler, fixture, test, or config changes
- No SurrealDB writes, no DB-Go, no runtime changes

## Safety Boundaries

- No \PERSIST_ALLOWED=True\
- No \MUTATION_ALLOWED=True\
- No SurrealDB live query
- No runtime / BLUE / RED changes
- No Docker / compose changes
- No feature toggles changed
- LR remains NO-GO