### PR TITLE
docs(governance): set context trust floor to MEDIUM for all agent surfaces

### DIFF
--- a/.opencode/skills/cdb-session-start/SKILL.md
+++ b/.opencode/skills/cdb-session-start/SKILL.md
@@ -121,19 +121,27 @@ Establish a verified, fail-closed starting state before any repo work begins.
    `tools_or_queries`, `records_or_results`, `repo_crosscheck`, `impact_on_plan`,
    `limitations`) with honest values.
 
-   **No plan may claim Memory/Evidence/Decision consideration without
-   record/tool/query evidence.**
+    **No plan may claim Memory/Evidence/Decision consideration without
+    record/tool/query evidence.**
 
-   If the block is missing or incomplete:
-   - STOP.
-   - Report which fields are missing or which values are unsubstantiated.
-   - Do not proceed to implementation planning.
+    Post-#3449: `cdb_context_briefing` / `context.briefing` enrichment check.
+    - Context trust floor: MEDIUM. Nur HIGH/MEDIUM sind nutzbar (`context_available=true`).
+    - Prüfe ob evidence_records/claim_records/decision_events/memory_records übergeben wurden.
+    - Ohne Records → `brain_source=repo-only`, `brain_status=not-used`, `context_available=false`.
+    - Inline-Records → `brain_source=in_memory`, max `context_trust_level=MEDIUM`.
+    - HIGH nur mit `record_source=surrealdb-local` + Record-IDs + kein stale/disputed/blocking.
+    - LOW/BLOCKED sind keine operative Agentenoption; hinter `none` verborgen.
 
-   Reference: `agents/AGENTS.md` § Brain Evidence Gate;
-   default posture SSOT: `knowledge/decisions/CDB_CONTEXT_BRAIN_DEFAULT_POSTURE.md`
-   (#2775). Until verified MCP/DB evidence: `brain_source=repo-only`,
-   `brain_status=not-used`. `PERSIST_ALLOWED=False` / `MUTATION_ALLOWED=False`
-   on `main`; Context Brain output does not authorize writes or issue creation.
+    If the block is missing or incomplete:
+    - STOP.
+    - Report which fields are missing or which values are unsubstantiated.
+    - Do not proceed to implementation planning.
+
+    Reference: `agents/AGENTS.md` § Brain Evidence Gate;
+    default posture SSOT: `knowledge/decisions/CDB_CONTEXT_BRAIN_DEFAULT_POSTURE.md`
+    (#2775). Until verified MCP/DB evidence: `brain_source=repo-only`,
+    `brain_status=not-used`. `PERSIST_ALLOWED=False` / `MUTATION_ALLOWED=False`
+    on `main`; Context Brain output does not authorize writes or issue creation.
 
 7. MCP Capability Resolution Gate (conditional):
 

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -116,10 +116,11 @@ Repo-Fallback ist nur nach belegtem Fehlversuch erlaubt.
 ```text
 context_brain_attempted: true
 context_brain_used: true | false
+context_available: true | false
 repo_fallback_used: true | false
 repo_fallback_reason: none | unavailable | stale | contradictory | insufficient_evidence | missing_record | tool_blocked
 context_tool_status: available | partial | blocked | absent
-context_trust_level: high | medium | low | none
+context_trust_level: high | medium | none
 records_found: <count> | none
 ```
 
@@ -128,19 +129,19 @@ records_found: <count> | none
 Welcher `repo_fallback_reason` bei welchem tatsächlichen Tool-Zustand korrekt ist:
 
 | Tool-Status | Trust-Level | Records Found | Korrekter `repo_fallback_reason` |
-|---|---|---|---|
+|---|---|---|---|---|
 | `available` | `high` | >=1 | `none` (kein Fallback nötig) |
-| `available` | `low` | 0 | `insufficient_evidence` |
+| `available` | `none` | 0 | `insufficient_evidence` |
 | `available` | `medium` | 0 | `missing_record` |
-| `available` | `low` | >=1 (stale) | `stale` |
+| `available` | `none` | >=1 (stale) | `stale` |
 | `available` | `any` | widersprüchlich | `contradictory` |
-| `partial` | `low` | 0 | `insufficient_evidence` |
+| `partial` | `none` | 0 | `insufficient_evidence` |
 | `blocked` | `none` | 0 | `tool_blocked` |
 | `absent` | `none` | 0 | `unavailable` |
 
 **Härteregel:** `repo_fallback_reason=unavailable` ist NUR erlaubt, wenn der
 Context-Brain-Tool-Zugang wirklich fehlt (Tool nicht importierbar, nicht aufrufbar,
-nicht im aktiven MCP-Surface). Ein verfügbares Tool, das LOW Trust oder keine
+nicht im aktiven MCP-Surface). Ein verfügbares Tool, das kein Trust oder keine
 Records liefert, ist **nicht** `unavailable`.
 
 ### Regeln
@@ -162,7 +163,7 @@ Records liefert, ist **nicht** `unavailable`.
    Context Briefing, session memory oder caller-supplied metadata allein
    sind keine DB-backed Evidence.
 7. Falsche Fallback-Klassifikation (z. B. `unavailable` bei verfügbarem Tool mit
-   LOW/no Records) löst `HOLD_BOOTLOADER_EVIDENCE_MISCLASSIFIED` aus und blockiert
+   keinem Trust oder keinen Records) löst `HOLD_BOOTLOADER_EVIDENCE_MISCLASSIFIED` aus und blockiert
    den weiteren Workflow bis zur Korrektur.
 8. Lokale Context-Refresh-/Brain-Apply-Artefakte aus #3287-#3291 sind als
    repo-backed Brain-Evidence-Kandidaten zu prüfen, wenn Context Tools keine
@@ -190,10 +191,11 @@ limitations:
   - <Was nicht bewiesen ist>
 context_brain_attempted: true
 context_brain_used: true | false
+context_available: true | false
 repo_fallback_used: true | false
 repo_fallback_reason: none | unavailable | stale | contradictory | insufficient_evidence | missing_record | tool_blocked
 context_tool_status: available | partial | blocked | absent
-context_trust_level: high | medium | low | none
+context_trust_level: high | medium | none
 records_found: <count> | none
 ```
 
@@ -210,13 +212,15 @@ records_found: <count> | none
   Context Briefing, session memory oder caller-supplied metadata allein sind
   keine DB-backed Evidence.
 - `repo_fallback_used`: `true` wenn nach Preflight auf Repo-Reads zurueckgefallen wurde.
+- `context_available`: `true` nur bei `context_trust_level >= MEDIUM`. Bei `false`:
+  kein nutzbarer Context; Agent muss auf GitHub/Repo-Fallback ausweichen oder HOLD.
 - `repo_fallback_reason`: Exakter Grund fuer Repo-Fallback (Enum). Siehe
   Fallback-Klassifikationsmatrix oben: `unavailable` ist NUR bei echt fehlendem
-  Tool-Zugang erlaubt, nicht bei LOW/no Records.
+  Tool-Zugang erlaubt, nicht bei keinem Trust oder keinen Records.
 - `context_tool_status`: Tatsaechlicher Status des Context-Brain-Tools nach
   Preflight-Versuch.
-- `context_trust_level`: Vertrauensniveau der gelieferten Evidence (kann auf
-  Tool-Metadaten oder Bundle-Signalen basieren).
+- `context_trust_level`: Agenten-sichtbares Trust-Niveau. Nur `high` und `medium`
+  sind nutzbar (usable context trust floor = MEDIUM). `none` bedeutet kein nutzbarer Context.
 - `records_found`: Anzahl der gefundenen Records (0 bei `none`).
 
 ### Default posture (SSOT)
@@ -250,6 +254,16 @@ Higher wins; fail-closed when lower layers conflict:
 - `context.briefing` / `briefing.session_context` is read-only working/session
   memory (`session_only=true`); not persistent DB memory; see
   `agents/OPEN_CODE_AGENTS.md` for handoff mapping.
+- **Context trust floor:** `usable_context_trust_minimum = MEDIUM`.
+  Nur `context_trust_level=HIGH` oder `MEDIUM` sind nutzbar.
+  `none` = `context_available=false` — kein DB-backed Claim, kein "Repo-Brain used",
+  Agent muss GitHub/Repo-Fallback oder HOLD. Interne Diagnose (LOW/BLOCKED) bleibt
+  im Trust-Service-SSOT, ist aber keine operative Agentenoption.
+- Post-#3449: `cdb_context_briefing` enrichment check ist Pflicht vor Brain-Claim.
+  Ohne evidence_records/claim_records/decision_events/memory_records keine Brain-Nutzung.
+  - `brain_source=repo-only` + `brain_status=not-used` bei leerem Briefing → `context_available=false`.
+  - `brain_source=in_memory` bei Inline-Records; max `context_trust_level=MEDIUM`.
+  - `context_trust_level=HIGH` nur mit `record_source=surrealdb-local` + Record-IDs + kein stale/disputed/blocking.
 - Context Brain / MCP read results do **not** authorize automatic code changes,
   issue creation, or writes — parent agent and Jannek GO still required.
 - `PERSIST_ALLOWED=False` and `MUTATION_ALLOWED=False` remain defaults on `main`;
@@ -259,7 +273,7 @@ Higher wins; fail-closed when lower layers conflict:
 - Board-Stage `trade-capable` is not Live-Go.
 - LR remains NO-GO.
 - Falsche Fallback-Klassifikation (z. B. `unavailable` bei verfügbarem Tool mit
-  LOW/no Records) löst `HOLD_BOOTLOADER_EVIDENCE_MISCLASSIFIED` aus. Der Workflow
+  keinem Trust oder keinen Records) löst `HOLD_BOOTLOADER_EVIDENCE_MISCLASSIFIED` aus. Der Workflow
   muss bis zur Korrektur blockiert bleiben.
 
 ## Legacy Note

--- a/agents/AGENT_SETUP_GUIDE.md
+++ b/agents/AGENT_SETUP_GUIDE.md
@@ -87,6 +87,7 @@ Linux/macOS: `.venv/bin/python` statt `.venv/Scripts/python.exe`.
 - Vor jeder Planung prüfen, ob `context.briefing` im aktiven MCP-Inventar ist.
 - Falls nicht: `brain_source=unavailable` oder `repo-only` + `brain_status=not-used`.
 - Keine DB-backed Brain-Claims ohne `surrealdb-local` und nutzbaren `brain_status`.
+- **Context trust floor:** MEDIUM. Nur HIGH/MEDIUM nutzbar. Unter MEDIUM → `context_available=false`, GitHub/Repo-Fallback oder HOLD.
 - Referenz: `docs/runbooks/surrealdb_context_mcp_access.md` § 1.5.1.
 
 ### Per-Agent Templates und Setup-Script

--- a/agents/CLAUDE.md
+++ b/agents/CLAUDE.md
@@ -156,6 +156,7 @@ Wenn der Task-Scope **Context, SurrealDB, MCP tools, ContextBridge, DB-backed Me
 3. Falls nicht verfügbar: **STOP** und explizit auf `repo-only` + `brain_status=not-used` degradieren.
 4. DB-backed Brain-Claims nur bei `brain_source=surrealdb-local` und nutzbarem `brain_status` (`used`/`partial`).
 5. Nicht-DB-Fallback nie `brain_status=used` melden.
+6. **Context trust floor:** MEDIUM. Nur HIGH/MEDIUM sind nutzbar. Unter MEDIUM → `context_available=false`, GitHub/Repo-Fallback oder HOLD.
 
 ### 6.1.2 Fallback
 

--- a/agents/CODEX.md
+++ b/agents/CODEX.md
@@ -181,6 +181,7 @@ Wenn der Task-Scope **Context, SurrealDB, MCP tools, ContextBridge, DB-backed Me
 3. Falls nicht verfügbar: **STOP** und explizit auf `repo-only` degradieren.
 4. DB-backed Brain/Evidence/Memory nur beanspruchen, wenn `surrealdb-local` tatsächlich verfügbar und nutzbar ist (`brain_source=surrealdb-local` mit `brain_status=used` oder `partial`).
 5. Nicht-DB-Fallback darf **nie** `brain_status=used` melden.
+6. **Context trust floor:** MEDIUM. Nur HIGH/MEDIUM nutzbar. Unter MEDIUM → `context_available=false`, GitHub/Repo-Fallback oder HOLD.
 
 ### 9.2 Fallback-Regel
 

--- a/agents/GEMINI.md
+++ b/agents/GEMINI.md
@@ -80,6 +80,7 @@ Wenn der Task-Scope **Context, SurrealDB, MCP tools, ContextBridge, DB-backed Me
 3. Falls nicht verfügbar: **STOP** und explizit auf `repo-only` + `brain_status=not-used` degradieren.
 4. DB-backed Brain-Claims nur bei `brain_source=surrealdb-local` und nutzbarem `brain_status` (`used`/`partial`). `blocked`, `not-used`, `repo-only` und `unavailable` bleiben fail-closed.
 5. Repo-Evidence unter `records_or_results` dokumentieren.
+6. **Context trust floor:** MEDIUM. Nur HIGH/MEDIUM nutzbar. Unter MEDIUM → `context_available=false`, GitHub/Repo-Fallback oder HOLD.
 
 ### Referenz
 

--- a/agents/OPEN_CODE_AGENTS.md
+++ b/agents/OPEN_CODE_AGENTS.md
@@ -41,6 +41,15 @@ Gilt für **alle** OpenCode Agents (egal welcher Provider).
 - **`operator_trust_level`** aus `cdb_context_trust_summary` / `context.briefing` ([#2856](https://github.com/jannekbuengener/Claire_de_Binare/issues/2856)): `LOW` und `BLOCKED` sind **keine** operative Wahrheit — keine Writes, Live-Aktionen, Merge- oder LR-Entscheidungen allein aus Trust; auch `HIGH` ersetzt kein Human-GO, Live-GO, Echtgeld-GO, `PERSIST_ALLOWED` oder `MUTATION_ALLOWED`. SSOT: [`docs/contracts/context_tooling/CDB_CONTEXT_TRUST_THRESHOLD_CONTRACT.md`](../docs/contracts/context_tooling/CDB_CONTEXT_TRUST_THRESHOLD_CONTRACT.md).
 - Brain-Evidence-Mapping aus `briefing.session_context`: `brain_source <- session_context.brain_source`, `brain_status <- session_context.brain_status`, `records_or_results <- session_context.repo_state + session_context.github_state`, `impact_on_plan <- session_context.working_assumptions + session_context.limitations`, `limitations <- session_context.limitations`. `tools_or_queries` kommen aus Caller-Tooling oder konservativ aus Session-Limitations; `repo_crosscheck` kommt aus `session_context.repo_state` plus `briefing.required_reads` und gegebenenfalls Request-Scope/Target-Pfaden.
 - CDB Context MCP Capability Baseline gilt für alle Agenten-Surfaces (Codex, OpenCode, Claude/Cloud Code, Gemini, Onboarding). Die kanonische Agent-MCP-Matrix steht in `docs/runbooks/surrealdb_context_mcp_access.md` § 1.5.1 mit fünf Bewertungsebenen (Config existiert → Host kennt Config → Server startet → Tool-Inventar → Aufruf funktioniert) und den konkreten Status pro Surface.
+- **Context trust floor:** `usable_context_trust_minimum = MEDIUM`.
+  Nur `HIGH`/`MEDIUM` sind nutzbar → `context_available=true`.
+  `none` = kein nutzbarer Context → `context_available=false`, Agent muss GitHub/Repo-Fallback oder HOLD.
+  LOW/BLOCKED bleiben im Trust-Service-SSOT, sind aber keine operative Agentenoption.
+- Post-#3449: `cdb_context_briefing` enrichment check vor Brain-Claim.
+  Ohne evidence_records/claim_records/decision_events/memory_records → `brain_source=repo-only`,
+  `brain_status=not-used`, `context_available=false`. Inline-Records → `brain_source=in_memory`,
+  max `context_trust_level=MEDIUM`. `context_trust_level=HIGH` nur mit `record_source=surrealdb-local`
+  + Record-IDs + kein stale/disputed/blocking.
 - Danach nur task-spezifische Skills laden
 - Keine pauschale Skill-Massenladung
 - Third-Party-/Cybersecurity-Skills nur bei explizitem Bedarf und nur defensiv/prüfend

--- a/docs/contracts/context_tooling/CDB_CONTEXT_TRUST_THRESHOLD_CONTRACT.md
+++ b/docs/contracts/context_tooling/CDB_CONTEXT_TRUST_THRESHOLD_CONTRACT.md
@@ -112,9 +112,18 @@ When `context_signals` is **omitted**, `operator_trust_level` follows legacy bas
 
 In Brain Evidence and Context scope:
 
-- Treat `operator_trust_level` of `LOW` or `BLOCKED` as **fail-closed for operational truth**.
+- **Context trust floor:** `usable_context_trust_minimum = MEDIUM`.
+  Nur `HIGH`/`MEDIUM` sind operative Agentenoptionen (`context_available=true`).
+  `LOW`/`BLOCKED` bleiben SSOT des Trust-Service, sind aber keine nutzbare Agentenoption.
+  Unter MEDIUM → `context_available=false`, Agent muss GitHub/Repo-Fallback oder HOLD.
+  `HIGH` und `MEDIUM` ersetzen kein Human-GO, Live-GO, Echtgeld-GO.
 - Do not merge, persist, mutate runtime, or infer LR/live-go from trust output alone.
 - Prefer live GitHub + repo reads over trust summary text.
+- Post-#3449: `cdb_context_briefing` enrichment check vor Brain-Claim.
+  Ohne evidence_records/claim_records/decision_events/memory_records keine Brain-Nutzung.
+  - `brain_source=repo-only` + `brain_status=not-used` bei leerem Briefing → `context_available=false`.
+  - `brain_source=in_memory` bei Inline-Records; max `operator_trust_level=MEDIUM`.
+  - `operator_trust_level=HIGH` nur mit `record_source=surrealdb-local` + Record-IDs + kein stale/disputed/blocking.
 
 Canonical agent surfaces: [`agents/OPEN_CODE_AGENTS.md`](../../../agents/OPEN_CODE_AGENTS.md), [`docs/runbooks/CDB_AGENT_SENSES_OPERATOR.md`](../../runbooks/CDB_AGENT_SENSES_OPERATOR.md) §8.
 

--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -348,6 +348,7 @@ output does not authorize automatic code, issue, or productive DB writes.
 5. Non-DB fallback must not report DB-backed `brain_status="used"`.
 6. Missing MCP access must be reported as `brain_source=unavailable` or explicit `repo-only` / `brain_status=not-used` fallback.
 7. Repo-wide fallback for any surface that cannot verify MCP access: `brain_source=repo-only`, `brain_status=not-used`, repo evidence under `records_or_results`.
+8. **Context trust floor:** `usable_context_trust_minimum = MEDIUM`. Nur `HIGH`/`MEDIUM` sind nutzbar → `context_available=true`. `LOW`/`BLOCKED` bleiben Trust-Service-SSOT, keine Agentenoption. Unter MEDIUM → `context_available=false`, GitHub/Repo-Fallback oder HOLD.
 
 ---
 


### PR DESCRIPTION
## Problem

LOW/BLOCKED appeared on the agent-visible \context_trust_level\ surface (Brain Evidence Gate template, fallback matrix, rules) as normal options. Agents could cite LOW as a valid trust outcome rather than recognizing it as a non-usable state.

## Solution

Establish a hard **context trust floor** at MEDIUM for all agent surfaces:

- **Agent-visible trust levels:** only \high\, \medium\, \
one\ (removed \low\)
- **New field:** \context_available: true | false\ — \alse\ when trust is below MEDIUM
- **Below MEDIUM:** \context_available=false\, \rain_status=not-used\, \ecords_found=none\, \epo_fallback_used=true\ — Agent must GitHub/Repo-fallback or HOLD
- **Internal SSOT unchanged:** \	rust_summary.py\ still diagnoses LOW/BLOCKED internally; these are just not exposed as agent options

## Changed Files (9)

| File | Change |
|------|--------|
| \gents/AGENTS.md\ | Brain Evidence template: removed \low\, added \context_available\. Updated fallback matrix, field logic, rules. |
| \gents/OPEN_CODE_AGENTS.md\ | Added trust floor rule + \context_available\ semantics. |
| \.opencode/skills/cdb-session-start/SKILL.md\ | Step 6 updated with trust floor check. |
| \docs/contracts/context_tooling/CDB_CONTEXT_TRUST_THRESHOLD_CONTRACT.md\ | Agent prompt rule extended with trust floor. |
| \docs/runbooks/surrealdb_context_mcp_access.md\ | Capability rule 8: trust floor. |
| \gents/CLAUDE.md\ | One-liner: trust floor MEDIUM. |
| \gents/CODEX.md\ | One-liner: trust floor MEDIUM. |
| \gents/GEMINI.md\ | One-liner: trust floor MEDIUM. |
| \gents/AGENT_SETUP_GUIDE.md\ | One-liner: trust floor MEDIUM. |

## Validation

- \git diff --check\: no errors
- 104/104 tests pass (enrichment + trust threshold + evidence contract)
- Remaining LOW/BLOCKED references are diagnostic-only (explanations that they are SSOT-internal, not operative options)

## Safety

- LR remains NO-GO
- HIGH and MEDIUM do not replace Human-GO
- No productive DB writes
- No runtime mutation