### PR TITLE
fix(context): propagate adapter trust result through briefing adapter-only path

### DIFF
--- a/tests/unit/tools/mcp/test_mcp_briefing_enrichment.py
+++ b/tests/unit/tools/mcp/test_mcp_briefing_enrichment.py
@@ -727,3 +727,273 @@ class TestRegistryWave14Completeness:
         )
         assert result["status"] == "ok", f"Expected ok, got: {result}"
         assert result["result"]["approval_semantics"]["no_echtgeld_go"] is True
+
+
+# Monkeypatch target for adapter trust path tests.
+# _derive_briefing_brain_context uses a lazy local import, so patching the
+# module attribute is the correct approach (confirmed by test_context_bridge.py).
+_TRUST_SUMMARY_MP_TARGET = (
+    "tools.mcp.context_evidence_memory_tools.handle_cdb_context_trust_summary"
+)
+
+# Limitations stub matching build_trust_summary_v1 output for HIGH operator trust.
+_HIGH_TRUST_LIMITATIONS = [
+    "Trust summary is assessment-only; it does not grant Human-GO, Live-GO, "
+    "Echtgeld-GO, persist, mutation, or operational truth.",
+]
+
+
+def _make_trust_summary_response(
+    *,
+    operator_trust_level: str = "HIGH",
+    trust_level: str = "strong",
+    composite_score: float = 0.83,
+    blocking_trust_findings: list | None = None,
+    stale_flags: list | None = None,
+    disputed_flags: list | None = None,
+    limitations: list | None = None,
+    source: str = "surrealdb-local",
+) -> dict:
+    """Return a minimal but valid handle_cdb_context_trust_summary response."""
+    return {
+        "tool": "cdb_context_trust_summary",
+        "status": "ok",
+        "result": {
+            "operator_trust_level": operator_trust_level,
+            "trust_level": trust_level,
+            "composite_score": composite_score,
+            "blocking_trust_findings": blocking_trust_findings or [],
+            "stale_flags": stale_flags or [],
+            "disputed_flags": disputed_flags or [],
+            "limitations": limitations if limitations is not None else _HIGH_TRUST_LIMITATIONS,
+        },
+        "metadata": {
+            "query_time_ms": 0,
+            "source": source,
+            "read_only": True,
+        },
+    }
+
+
+def _make_generic_trust_response(*, source: str = "surrealdb-local") -> dict:
+    """Return a surrealdb-local response WITHOUT any trust sentinel keys.
+
+    Simulates an adapter that returned ok+surrealdb-local but no
+    build_trust_summary_v1 fields — should trigger the safe fallback path.
+    """
+    return {
+        "tool": "cdb_context_trust_summary",
+        "status": "ok",
+        "result": {"scope": "wave14"},  # no sentinel key present
+        "metadata": {
+            "query_time_ms": 0,
+            "source": source,
+            "read_only": True,
+        },
+    }
+
+
+class TestBriefingAdapterOnlyPath:
+    """Tests for the adapter-only path (#3453).
+
+    All tests in this class use adapter_config_path without inline records and
+    monkeypatch handle_cdb_context_trust_summary to return controlled responses.
+
+    Trust contract:
+    - Adapter trust propagates only when result contains sentinel fields.
+    - HIGH requires surrealdb-local source + real trust data (gates enforced by
+      build_trust_summary_v1 upstream; here we verify the plumbing).
+    - Truthy-but-invalid adapter results (no sentinel keys) → safe fallback.
+    - Inline records (in_memory path) remain capped at MEDIUM.
+    - LR NO-GO / no Echtgeld-GO / no runtime write.
+    """
+
+    def test_adapter_only_high_trust_propagates_operator_level(
+        self, monkeypatch
+    ) -> None:
+        """Adapter-only path with HIGH trust result: operator_trust_level must be HIGH."""
+        monkeypatch.setattr(
+            _TRUST_SUMMARY_MP_TARGET,
+            lambda _req: _make_trust_summary_response(operator_trust_level="HIGH"),
+        )
+        result = context_briefing_handler(
+            **_minimal_kwargs(
+                task_id="test-adapter-high-level",
+                adapter_config_path="/fake/path/config.yaml",
+            )
+        )
+        assert result["status"] == "ok"
+        briefing = result["briefing"]
+        assert briefing["operator_trust_level"] == "HIGH", (
+            f"Expected HIGH, got: {briefing['operator_trust_level']}"
+        )
+        assert briefing["approval_semantics"]["no_echtgeld_go"] is True
+
+    def test_adapter_only_no_s5_stop_condition(self, monkeypatch) -> None:
+        """Adapter-only path must not fire S5 (S5 is for missing inline records)."""
+        monkeypatch.setattr(
+            _TRUST_SUMMARY_MP_TARGET,
+            lambda _req: _make_trust_summary_response(),
+        )
+        result = context_briefing_handler(
+            **_minimal_kwargs(
+                task_id="test-adapter-no-s5",
+                adapter_config_path="/fake/path/config.yaml",
+            )
+        )
+        assert result["status"] == "ok"
+        stop = result["briefing"]["stop_conditions"]
+        assert not any("S5" in sc for sc in stop), (
+            f"S5 must not fire on adapter-only path, got: {stop}"
+        )
+
+    def test_adapter_only_trust_summary_text_includes_level_and_score(
+        self, monkeypatch
+    ) -> None:
+        """Trust summary text must reflect actual adapter operator trust and score."""
+        monkeypatch.setattr(
+            _TRUST_SUMMARY_MP_TARGET,
+            lambda _req: _make_trust_summary_response(
+                operator_trust_level="HIGH", composite_score=0.83
+            ),
+        )
+        result = context_briefing_handler(
+            **_minimal_kwargs(
+                task_id="test-adapter-text",
+                adapter_config_path="/fake/path/config.yaml",
+            )
+        )
+        assert result["status"] == "ok"
+        ts = result["briefing"]["trust_summary"]
+        assert "HIGH" in ts, f"Expected 'HIGH' in trust_summary, got: {ts}"
+        assert "0.83" in ts, f"Expected '0.83' in trust_summary, got: {ts}"
+        assert "surrealdb-local" in ts, (
+            f"Expected 'surrealdb-local' in trust_summary, got: {ts}"
+        )
+        assert "no_echtgeld_go: true" in ts, (
+            f"Expected 'no_echtgeld_go: true' in trust_summary, got: {ts}"
+        )
+
+    def test_adapter_only_blocking_findings_fires_s6(self, monkeypatch) -> None:
+        """Adapter result with blocking_trust_findings must fire S6 stop condition."""
+        monkeypatch.setattr(
+            _TRUST_SUMMARY_MP_TARGET,
+            lambda _req: _make_trust_summary_response(
+                operator_trust_level="BLOCKED",
+                trust_level="blocked",
+                composite_score=0.0,
+                blocking_trust_findings=["blocking_missing_evidence"],
+            ),
+        )
+        result = context_briefing_handler(
+            **_minimal_kwargs(
+                task_id="test-adapter-blocking-s6",
+                adapter_config_path="/fake/path/config.yaml",
+            )
+        )
+        assert result["status"] == "ok"
+        briefing = result["briefing"]
+        stop = briefing["stop_conditions"]
+        assert any("S6" in sc for sc in stop), (
+            f"S6 must fire when adapter has blocking findings, got: {stop}"
+        )
+        assert briefing["blocking_trust_findings"], (
+            "blocking_trust_findings must be populated from adapter result"
+        )
+        assert "Blocking findings:" in briefing["trust_summary"], (
+            f"trust_summary must mention blocking count: {briefing['trust_summary']}"
+        )
+
+    def test_adapter_only_stale_flags_propagated(self, monkeypatch) -> None:
+        """Stale flags from adapter result surface in stale_evidence_notice."""
+        monkeypatch.setattr(
+            _TRUST_SUMMARY_MP_TARGET,
+            lambda _req: _make_trust_summary_response(
+                stale_flags=["stale_evidence: 2 records"]
+            ),
+        )
+        result = context_briefing_handler(
+            **_minimal_kwargs(
+                task_id="test-adapter-stale",
+                adapter_config_path="/fake/path/config.yaml",
+            )
+        )
+        assert result["status"] == "ok"
+        stale = result["briefing"]["stale_evidence_notice"]
+        assert any("stale_evidence" in s for s in stale), (
+            f"Expected stale_flags propagated to stale_evidence_notice, got: {stale}"
+        )
+
+    def test_adapter_only_disputed_flags_propagated(self, monkeypatch) -> None:
+        """Disputed flags from adapter result surface in contradictory_evidence_notice."""
+        monkeypatch.setattr(
+            _TRUST_SUMMARY_MP_TARGET,
+            lambda _req: _make_trust_summary_response(
+                operator_trust_level="MEDIUM",
+                disputed_flags=["disputed_claims: 1 records"],
+            ),
+        )
+        result = context_briefing_handler(
+            **_minimal_kwargs(
+                task_id="test-adapter-disputed",
+                adapter_config_path="/fake/path/config.yaml",
+            )
+        )
+        assert result["status"] == "ok"
+        contradictory = result["briefing"]["contradictory_evidence_notice"]
+        assert any("disputed_claims" in c for c in contradictory), (
+            f"Expected disputed_flags in contradictory_evidence_notice, got: {contradictory}"
+        )
+
+    def test_adapter_only_truthy_but_invalid_result_no_fake_high(
+        self, monkeypatch
+    ) -> None:
+        """Adapter response with no trust sentinel keys must NOT produce operator_trust_level=HIGH.
+
+        A truthy dict like {"scope": "wave14"} (no operator_trust_level, trust_level,
+        composite_score, or blocking_trust_findings) must fall back to the safe
+        DB-backed-generic path — never fake a HIGH trust result.
+        """
+        monkeypatch.setattr(
+            _TRUST_SUMMARY_MP_TARGET,
+            lambda _req: _make_generic_trust_response(),
+        )
+        result = context_briefing_handler(
+            **_minimal_kwargs(
+                task_id="test-adapter-invalid-no-high",
+                adapter_config_path="/fake/path/config.yaml",
+            )
+        )
+        assert result["status"] == "ok"
+        briefing = result["briefing"]
+        # Must NOT be HIGH — no trust fields were present to justify it
+        assert briefing["operator_trust_level"] != "HIGH", (
+            f"operator_trust_level must not be HIGH when adapter result has no sentinel keys, "
+            f"got: {briefing['operator_trust_level']}"
+        )
+        # Must fall back to safe DB-backed message
+        ts = briefing["trust_summary"]
+        assert "DB-backed session context" in ts, (
+            f"Expected fallback DB-backed message in trust_summary, got: {ts}"
+        )
+
+    def test_inline_records_remain_medium_not_high(self) -> None:
+        """Inline records (in_memory brain path) must not produce operator_trust_level=HIGH.
+
+        Regression guard for PR #3452: context_signals caps in_memory records at MEDIUM.
+        No monkeypatch needed — in_memory path never calls the adapter.
+        """
+        fx = _load_fixture()
+        result = context_briefing_handler(
+            **_minimal_kwargs(
+                task_id="test-inline-max-medium",
+                evidence_records=fx["evidence_records"],
+                claim_records=fx["claim_records"],
+                enrichment_scope="wave14",
+            )
+        )
+        assert result["status"] == "ok"
+        level = result["briefing"]["operator_trust_level"]
+        assert level != "HIGH", (
+            f"Inline records (in_memory) must not reach HIGH operator trust, got: {level}"
+        )

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -1606,6 +1606,14 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
     }
 
 
+# Sentinel keys from build_trust_summary_v1 output contract (#3453).
+# At least one must be present for adapter_trust_result to be treated as a
+# real trust summary rather than a generic metadata dict.
+_ADAPTER_TRUST_SENTINEL_KEYS: frozenset[str] = frozenset(
+    {"operator_trust_level", "trust_level", "composite_score", "blocking_trust_findings"}
+)
+
+
 def _briefing_error_from_inner_result(
     result: dict[str, Any],
     *,
@@ -1648,7 +1656,7 @@ def _derive_briefing_brain_context(
     memory_records: Any,
     caller_brain_source: Any,
     caller_brain_status: Any,
-) -> tuple[str, str, list[str]] | dict[str, Any]:
+) -> tuple[str, str, list[str], dict[str, Any] | None] | dict[str, Any]:
     """Derive briefing brain context from real reads or conservative fallbacks."""
     limitations: list[str] = []
 
@@ -1703,7 +1711,7 @@ def _derive_briefing_brain_context(
         limitations.append(
             "brain context derived from Wave-14 trust summary adapter metadata"
         )
-        return "surrealdb-local", "used", limitations
+        return "surrealdb-local", "used", limitations, trust_summary_result.get("result") or {}
 
     if any(
         (
@@ -1716,12 +1724,12 @@ def _derive_briefing_brain_context(
         limitations.append(
             "brain context derived from inline enrichment records (in-memory)"
         )
-        return "in_memory", "used", limitations
+        return "in_memory", "used", limitations, None
 
     limitations.append(
         "brain_source derived as repo-only; no DB-backed memory or evidence claims"
     )
-    return "repo-only", "not-used", limitations
+    return "repo-only", "not-used", limitations, None
 
 
 def context_briefing_handler(**kwargs) -> dict[str, Any]:
@@ -1870,7 +1878,7 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
     )
     if isinstance(brain_context, dict):
         return brain_context
-    brain_source, brain_status, derived_brain_limitations = brain_context
+    brain_source, brain_status, derived_brain_limitations, adapter_trust_result = brain_context
     session_context_limitations.extend(derived_brain_limitations)
 
     repo_state = {
@@ -2278,14 +2286,61 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
 
     if not _has_records:
         if brain_source == "surrealdb-local":
-            trust_summary = (
-                "DB-backed session context established via Wave-14 trust summary. "
-                "Artifact enrichment skipped because no inline enrichment records "
-                "were provided to context.briefing."
-            )
-            recommended_next_reads_enrichment.append(
-                "Provide inline enrichment records if artifact-level enrichment is required in the briefing payload"
-            )
+            # Validate that adapter_trust_result is a real build_trust_summary_v1
+            # output, not a generic metadata dict (e.g. {"scope": "..."}).
+            # Fail-closed: only propagate if at least one sentinel field is present.
+            _atr = adapter_trust_result if isinstance(adapter_trust_result, dict) else {}
+            _has_real_trust = bool(_ADAPTER_TRUST_SENTINEL_KEYS.intersection(_atr))
+            if _has_real_trust:
+                # Propagate DB-backed trust fields from the adapter result.
+                # Per contract: operator_trust_level HIGH requires
+                # record_source=surrealdb-local + freshness_ok + repo_crosscheck.
+                # These gates are already enforced by build_trust_summary_v1 /
+                # _derive_operator_trust_level — we trust the result as-is.
+                operator_trust_level = str(_atr.get("operator_trust_level") or "MEDIUM")
+                trust_limitations = list(_atr.get("limitations") or [])
+                _adapter_composite: float = float(_atr.get("composite_score") or 0.0)
+                _adapter_trust_lvl = str(_atr.get("trust_level") or "unknown")
+                _adapter_blocking = [
+                    str(f) for f in (_atr.get("blocking_trust_findings") or [])
+                ]
+                if _adapter_blocking:
+                    blocking_trust_findings.extend(_adapter_blocking)
+                _adapter_stale = [str(f) for f in (_atr.get("stale_flags") or [])]
+                if _adapter_stale:
+                    stale_evidence_notice.extend(_adapter_stale)
+                _adapter_disputed = [
+                    str(f) for f in (_atr.get("disputed_flags") or [])
+                ]
+                if _adapter_disputed:
+                    contradictory_evidence_notice.extend(_adapter_disputed)
+                trust_summary = (
+                    f"Operator trust: {operator_trust_level}. "
+                    f"Trust level (legacy): {_adapter_trust_lvl}. "
+                    f"Composite score: {_adapter_composite:.2f}. "
+                    "Source: surrealdb-local (adapter-only). no_echtgeld_go: true."
+                )
+                if blocking_trust_findings:
+                    trust_summary += (
+                        f" Blocking findings: {len(blocking_trust_findings)}. "
+                        "Review before proceeding."
+                    )
+                    if not any("S6" in sc for sc in stop_conditions):
+                        stop_conditions.append(
+                            "S6: blocking trust findings present — "
+                            "review evidence before proceeding"
+                        )
+            else:
+                # Adapter returned surrealdb-local but no recognisable trust
+                # summary fields — fall back to safe DB-backed-generic message.
+                trust_summary = (
+                    "DB-backed session context established via Wave-14 trust summary. "
+                    "Artifact enrichment skipped because no inline enrichment records "
+                    "were provided to context.briefing."
+                )
+                recommended_next_reads_enrichment.append(
+                    "Provide inline enrichment records if artifact-level enrichment is required in the briefing payload"
+                )
         else:
             # Fail-closed: no records provided — controlled-empty enrichment
             missing_evidence_notice = [


### PR DESCRIPTION
## Root Cause

`_derive_briefing_brain_context()` called `handle_cdb_context_trust_summary` for the adapter path, validated `source == surrealdb-local`, but **discarded** the full trust result — returning only a 3-tuple `(brain_source, brain_status, limitations)`.

Back in `context_briefing_handler`, the `if not _has_records: if brain_source == surrealdb-local:` branch set only a generic message while `operator_trust_level` stayed at default `MEDIUM` (L2267). The adapter's actual trust data (composite_score, operator_trust_level, blocking_findings, stale_flags) was silently discarded.

## Delivered

### `tools/mcp/context_bridge.py`

- **`_ADAPTER_TRUST_SENTINEL_KEYS`** (module-level): frozenset of `{operator_trust_level, trust_level, composite_score, blocking_trust_findings}`. An adapter result must contain at least one of these to be treated as a real trust summary (not a generic metadata dict).
- **`_derive_briefing_brain_context`**: 3-tuple → 4-tuple. Adapter path returns `trust_summary_result.get("result") or {}` as 4th element; in_memory / repo-only return `None`.
- **`context_briefing_handler`**: unpack 4-tuple. In the `surrealdb-local / no-records` branch, validate sentinel keys and, when present, propagate `operator_trust_level`, `trust_limitations`, `blocking_trust_findings`, `stale_evidence_notice`, `contradictory_evidence_notice`, and `trust_summary` text (with composite score + legacy level + source label). Fire S6 if blocking findings present. When no sentinel keys → safe fallback to existing DB-backed-generic message.

### `tests/unit/tools/mcp/test_mcp_briefing_enrichment.py`

New class **`TestBriefingAdapterOnlyPath`** (8 tests, all monkeypatching `handle_cdb_context_trust_summary`):

| Test | Contract |
|---|---|
| `test_adapter_only_high_trust_propagates_operator_level` | HIGH propagates to `briefing["operator_trust_level"]` |
| `test_adapter_only_no_s5_stop_condition` | S5 must not fire for adapter-only path |
| `test_adapter_only_trust_summary_text_includes_level_and_score` | trust_summary text includes level + score + source |
| `test_adapter_only_blocking_findings_fires_s6` | blocking findings → S6 + blocking_trust_findings + trust_summary count |
| `test_adapter_only_stale_flags_propagated` | stale_flags → stale_evidence_notice |
| `test_adapter_only_disputed_flags_propagated` | disputed_flags → contradictory_evidence_notice |
| `test_adapter_only_truthy_but_invalid_result_no_fake_high` | `{"scope": "..."}` (no sentinel keys) → safe fallback, never HIGH |
| `test_inline_records_remain_medium_not_high` | inline records (in_memory) capped at MEDIUM (PR #3452 regression guard) |

## Brain Evidence

```
brain_source: repo-only
context_available: false
context_trust_level: none
context_brain_attempted: true
context_brain_used: false
repo_fallback_used: true
repo_fallback_reason: unavailable
```

## Validation

- `git diff --check`: OK
- `ruff check`: All checks passed
- `pytest tests/unit/tools/mcp/test_mcp_briefing_enrichment.py`: **42/42 passed**
- `pytest tests/unit/surrealdb/test_trust_threshold_contract.py`: **12/12 passed**
- `pytest tests/unit/tools/mcp/`: **946/946 passed** (full MCP unit suite)

## Safety Boundaries

- LR **NO-GO** unchanged
- Board `trade-capable` ≠ Live-GO; no Echtgeld-GO
- No productive SurrealDB writes
- `PERSIST_ALLOWED` not set; `MUTATION_ALLOWED` not set
- No runtime / Docker / BLUE / RED change
- No secrets exposed

## Non-Goals

- No changes to `trust_summary.py` or `context_evidence_memory_tools.py`
- No doc updates (contract semantics unchanged)
- No new issue tracker beyond #3453

## Rest-Unsicherheiten

- The existing test `test_db_requested_briefing_uses_surrealdb_local_metadata` in `test_context_bridge.py` monkeypatches with `result={"scope": ...}` (no sentinel keys). After this fix it correctly falls back to the generic DB-backed message and stays MEDIUM — behavior unchanged relative to what agents observed before. The test continues to verify `brain_source=surrealdb-local` and `db_claims_allowed=True`, which are unaffected.
- The adapter-only HIGH path requires a real SurrealDB local adapter returning a full `build_trust_summary_v1` response. In-process unit tests cannot exercise this end-to-end without a DB fixture; the new tests cover the plumbing via monkeypatching. Full DB-backed evidence remains a local/E2E concern.

Closes #3453