### PR TITLE
fix(trust): scope-filter evidence in adapter trust summary when no artifact specified

### DIFF
--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -531,6 +531,113 @@ def test_trust_summary_db_mode_scope_fallback_for_schema_claims(monkeypatch) -> 
     assert result["result"]["memory_trust_summary"]["total"] == 1
 
 
+@pytest.mark.unit
+def test_trust_summary_db_mode_no_artifact_scope_filters_evidence(
+    monkeypatch,
+) -> None:
+    """DB trust_summary without artifact must scope-filter evidence and use by_freshness.
+
+    When adapter_config_path is provided but no artifact is specified,
+    handle_cdb_context_trust_summary must pre-filter evidence records to the
+    requested scope before calling lookup_evidence_v1 (by_freshness mode).
+    This prevents cross-scope contamination and allows scope-wide HIGH trust
+    when scoped evidence is strong.
+
+    Root cause of gap: previously used by_artifact with artifact=None, which
+    matched nothing ('' in any artifact_refs set is always False), so evidence
+    always scored 0.0, capping composite at 0.70 and making HIGH unreachable.
+    (Revealed by E2E proof against ephemeral SurrealDB, 2026-06-28.)
+    """
+    # Two evidence records: one in the target scope (wave14), one in another scope.
+    # The scope pre-filter must exclude the out-of-scope record.
+    ev_in_scope: dict[str, Any] = {
+        "evidence_id": "ev-scope-001",
+        "evidence_type": "test_run",
+        "confidence": 0.92,
+        "stale": False,
+        "blocking_missing": False,
+        "scope": "wave14",
+        "created_at": "2026-06-01T00:00:00Z",
+    }
+    ev_out_of_scope: dict[str, Any] = {
+        "evidence_id": "ev-other-scope",
+        "evidence_type": "test_run",
+        "confidence": 0.9,
+        "stale": False,
+        "blocking_missing": True,  # would cause BLOCKED if included
+        "scope": "other-scope",
+        "created_at": "2026-06-01T00:00:00Z",
+    }
+    mem_source_backed: dict[str, Any] = {
+        "memory_id": "mem-scope-001",
+        "memory_type": "decision",
+        "scope": "wave14",
+        "source_refs": ["docs/AGENTS.md"],
+        "created_at": "2026-06-01T00:00:00Z",
+    }
+    claim_supported: dict[str, Any] = {
+        "claim_id": "cl-scope-001",
+        "title": "Supported claim",
+        "status": "substantiated",
+        "scope": "wave14",
+        "created_at": "2026-06-01T00:00:00Z",
+    }
+    decision_current: dict[str, Any] = {
+        "decision_id": "dec-scope-001",
+        "title": "Current decision",
+        "status": "current",
+        "scope": "wave14",
+        "created_at": "2026-06-01T00:00:00Z",
+    }
+
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    mock_adapter.execute.side_effect = [
+        [ev_in_scope, ev_out_of_scope],  # evidence_ref — both scopes
+        [claim_supported],  # claim
+        [mem_source_backed],  # agent_memory
+        [decision_current],  # decision_event
+    ]
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "scope": "wave14",
+                # No 'artifact' — scope-wide assessment
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    assert result["metadata"]["source"] == "surrealdb-local"
+    res = result["result"]
+    # Evidence from wave14 scope is included: strength="strong" (conf 0.92 ≥ 0.85)
+    assert res["evidence_strength"] == "strong", (
+        f"Expected strong evidence, got {res['evidence_strength']!r}; "
+        f"composite={res['composite_score']}"
+    )
+    # Out-of-scope blocking_missing record must NOT have contaminated the result
+    assert "blocking_missing_evidence" not in res.get(
+        "blocking_trust_findings", []
+    ), "Out-of-scope blocking_missing evidence must not appear in blocking_trust_findings"
+    # Composite should be ≥ 0.80 with strong evidence + substantiated claim
+    assert res["composite_score"] >= 0.80, (
+        f"Expected composite ≥ 0.80 with strong evidence + claim; "
+        f"got {res['composite_score']}"
+    )
+    assert res["operator_trust_level"] in (
+        "HIGH",
+        "MEDIUM",
+    ), f"Expected HIGH or MEDIUM, got {res['operator_trust_level']!r}"
+
+
 # ---------------------------------------------------------------------------
 # Decision History — DB mode
 # ---------------------------------------------------------------------------

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -704,12 +704,29 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
         memory_result_raw: dict[str, Any] | None = None
         decision_result_raw: dict[str, Any] | None = None
         try:
-            evidence_result_raw = lookup_evidence_v1(
-                [_normalize_evidence_ref_row(r) for r in _ev_raw],
-                EvidenceLookupRequest(
+            # When artifact is specified, filter evidence to that artifact (by_artifact).
+            # When no artifact is specified (scope-wide trust assessment), pre-filter
+            # records to the requested scope and use by_freshness — consistent with
+            # the inline-records path in context_briefing_handler (freshness_days=36500).
+            # Pre-filtering prevents cross-scope contamination when the DB contains
+            # evidence from multiple scopes.  by_artifact with an empty artifact
+            # string matches nothing, so this branch only applies when a real
+            # artifact identifier is present.
+            if _artifact:
+                _ev_input = [_normalize_evidence_ref_row(r) for r in _ev_raw]
+                _ev_req = EvidenceLookupRequest(
                     mode="by_artifact", artifact=_artifact, limit=_limit
-                ),
-            )
+                )
+            else:
+                _ev_input = [
+                    _normalize_evidence_ref_row(r)
+                    for r in _ev_raw
+                    if isinstance(r, dict) and r.get("scope") == scope
+                ]
+                _ev_req = EvidenceLookupRequest(
+                    mode="by_freshness", freshness_days=36500, limit=_limit
+                )
+            evidence_result_raw = lookup_evidence_v1(_ev_input, _ev_req)
         except EvidenceLookupError as _exc:
             logging.getLogger(__name__).debug(
                 "trust_summary: evidence lookup skipped (%s)", _exc


### PR DESCRIPTION
## Root Cause (revealed by E2E proof, 2026-06-28)

`handle_cdb_context_trust_summary` adapter path used `EvidenceLookupRequest(mode='by_artifact', artifact=None)`. With no `artifact` specified, the filter reduces to `"" in artifact_refs_set` — False for every record. Evidence was always 0.0, making the composite score cap at 0.70 (claims + decisions + memory max). Since legacy `strong` requires composite ≥ 0.80, **HIGH was mathematically unreachable via the adapter-only path** despite correct DB records.

This gap was not caught by existing unit tests because they monkeypatch the entire `handle_cdb_context_trust_summary` response (PR #3454 unit tests) or use `by_artifact` with explicit artifacts. The E2E proof against a real ephemeral SurrealDB exposed it.

## Delivered

### `tools/mcp/context_evidence_memory_tools.py`

In `handle_cdb_context_trust_summary` adapter path:
- **When `artifact` is specified**: keep `by_artifact` mode (unchanged, no regression).
- **When `artifact` is None** (scope-wide trust assessment):
  - Pre-filter evidence records to `scope` before lookup → prevents cross-scope contamination.
  - Use `EvidenceLookupRequest(mode='by_freshness', freshness_days=36500)` — consistent with the inline-records path in `context_briefing_handler`.

### `tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py`

New test: **`test_trust_summary_db_mode_no_artifact_scope_filters_evidence`**
- Two evidence records: one with `scope='wave14'` (strong), one with `scope='other-scope'` and `blocking_missing=True`.
- Verifies scope filter excludes the out-of-scope blocking record.
- Asserts `evidence_strength='strong'`, `composite ≥ 0.80`, no contamination from foreign blocking.

## E2E Proof (ephemeral Docker SurrealDB, in-memory, port 8015, throwaway)

| Case | Scope | operator_trust_level | composite | Notes |
|---|---|---|---|---|
| HIGH-trust | wave14-proof | **HIGH** | 0.97 | strong evidence + substantiated claim + current decision + source_backed memory |
| STALE records | wave14-stale | LOW | 0.46 | stale evidence + stale memory → LOW, stale_evidence_notice populated |
| BLOCKING/DISPUTED | wave14-blocked | BLOCKED | 0.25 | blocking_missing evidence + disputed claim → BLOCKED + S6 fires |
| Empty scope | wave14-empty | LOW | 0.35 | no records → neutral scores → LOW |

All 26 proof checks PASSED.

## Validation

- `git diff --check`: OK
- `ruff check`: All checks passed
- `pytest tests/unit/tools/mcp/`: **947/947 passed**
- `pytest tests/unit/surrealdb/test_trust_threshold_contract.py`: **12/12 passed**

## Safety

- LR **NO-GO** unchanged
- No productive SurrealDB writes
- `PERSIST_ALLOWED` not set; `MUTATION_ALLOWED` not set
- No runtime / Docker / BLUE / RED change
- E2E proof used ephemeral Docker container only (throwaway, in-memory, local port 8015)

## Relation to PR #3454

PR #3454 (fcd77b5e) fixed the trust result propagation path (3-tuple → 4-tuple). This PR fixes the upstream gap: the trust summary itself couldn't produce HIGH without evidence being matched. Together, both PRs deliver the complete adapter-only HIGH path.

## Rest-Unsicherheiten

- Memory seed: `_normalize_memory` computes `source_backed` from `source_refs` list, not the raw `trust_level` string field. Real DB seeds must include `source_refs` or `evidence_refs` as non-empty lists for non-weak memory trust. This is documented behavior (no code fix needed).
- The `by_freshness` mode silently excludes undated evidence records (no `created_at`). The pre-filter narrows the input but doesn't recover undated records. For production use, evidence records should always have `created_at`.

Closes #3453 (together with #3454)