### PR TITLE
fix(trust): derive context_signals from adapter query results, not caller-supplied metadata

### DIFF
--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -1234,3 +1234,199 @@ def test_wave14_invalid_adapter_config_with_forged_db_claim_fields_fails_closed(
     assert result["error"]["code"] == "adapter_config_error"
     assert result["metadata"]["source"] == "in_memory"
     _assert_no_secret_leak(result)
+
+
+# ---------------------------------------------------------------------------
+# context_signals hardening (#3456): adapter path derives signals from results
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_trust_summary_db_mode_adapter_signals_always_supplied(monkeypatch) -> None:
+    """Adapter path always provides context_signals (context_signals_supplied=True).
+
+    After #3456, handle_cdb_context_trust_summary derives context_signals from
+    the actual query results when adapter_config_path is used. This ensures
+    operator_trust_mapping.context_signals_supplied is True and
+    record_source is 'surrealdb-local' — never sourced from caller input.
+    """
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    mock_adapter.execute.side_effect = [
+        [_EVIDENCE_RECORD],
+        [_CLAIM_RECORD],
+        [_MEMORY_RECORD],
+        [_DECISION_RECORD],
+    ]
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "scope": "wave14",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    mapping = result["result"].get("operator_trust_mapping", {})
+    assert (
+        mapping.get("context_signals_supplied") is True
+    ), f"Expected context_signals_supplied=True for adapter path, got: {mapping}"
+    signals = mapping.get("context_signals", {})
+    assert signals.get("record_source") == "surrealdb-local", (
+        f"Expected record_source=surrealdb-local (derived, not caller-supplied), "
+        f"got: {signals}"
+    )
+    assert signals.get("repo_crosscheck_present") is True
+    assert signals.get("caller_supplied_source_only") is False
+
+
+@pytest.mark.unit
+def test_trust_summary_db_mode_stale_evidence_caps_via_freshness_signal(
+    monkeypatch,
+) -> None:
+    """Stale evidence in adapter results sets freshness_ok=False, capping at LOW.
+
+    When evidence_result has stale_evidence_ids, the derived context_signals
+    must have freshness_ok=False. The freshness_not_ok gate in
+    _derive_operator_trust_level caps operator_trust_level at LOW regardless
+    of composite score — even if claims/decisions/memory are all strong.
+    """
+    stale_ev: dict[str, Any] = {
+        "evidence_id": "ev-stale-high-conf",
+        "evidence_type": "test_run",
+        "confidence": 0.92,  # high confidence but stale
+        "stale": True,
+        "blocking_missing": False,
+        "scope": "wave14",
+        "created_at": "2025-01-01T00:00:00Z",
+    }
+    strong_claim: dict[str, Any] = {
+        "claim_id": "cl-strong-001",
+        "status": "substantiated",
+        "scope": "wave14",
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    current_decision: dict[str, Any] = {
+        "decision_id": "dec-current-001",
+        "status": "current",
+        "scope": "wave14",
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    source_backed_mem: dict[str, Any] = {
+        "memory_id": "mem-source-001",
+        "memory_type": "decision",
+        "scope": "wave14",
+        "source_refs": ["docs/AGENTS.md"],
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    mock_adapter.execute.side_effect = [
+        [stale_ev],
+        [strong_claim],
+        [source_backed_mem],
+        [current_decision],
+    ]
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "scope": "wave14",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    res = result["result"]
+    # Stale evidence must prevent HIGH (freshness_not_ok gate caps at LOW)
+    assert (
+        res["operator_trust_level"] != "HIGH"
+    ), f"Stale evidence must not reach HIGH, got: {res['operator_trust_level']}"
+    mapping = res.get("operator_trust_mapping", {})
+    signals = mapping.get("context_signals", {})
+    # Derived freshness_ok must be False because of stale evidence
+    assert (
+        signals.get("freshness_ok") is False
+    ), f"Expected freshness_ok=False for stale evidence, got signals: {signals}"
+    assert "freshness_not_ok" in mapping.get(
+        "gates_applied", []
+    ), f"Expected freshness_not_ok in gates_applied, got: {mapping.get('gates_applied')}"
+
+
+@pytest.mark.unit
+def test_trust_summary_db_mode_caller_cannot_override_freshness_signal(
+    monkeypatch,
+) -> None:
+    """Caller-supplied context_signals cannot override derived adapter signals.
+
+    A caller that passes context_signals with freshness_ok=True alongside
+    adapter_config_path and stale records must NOT be able to bypass the
+    freshness gate. The adapter path derives freshness_ok from actual query
+    results and ignores caller-supplied context_signals entirely.
+    """
+    stale_ev: dict[str, Any] = {
+        "evidence_id": "ev-stale-override-attempt",
+        "confidence": 0.92,
+        "stale": True,
+        "blocking_missing": False,
+        "scope": "wave14",
+        "created_at": "2025-01-01T00:00:00Z",
+    }
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    mock_adapter.execute.side_effect = [
+        [stale_ev],  # stale evidence
+        [],  # no claims
+        [],  # no memory
+        [],  # no decisions
+    ]
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    # Caller attempts to fake freshness_ok=True to bypass the stale cap
+    result = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "scope": "wave14",
+                "context_signals": {
+                    "freshness_ok": True,  # forged — must be ignored
+                    "record_source": "surrealdb-local",
+                    "repo_crosscheck_present": True,
+                    "caller_supplied_source_only": False,
+                },
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    res = result["result"]
+    signals = res.get("operator_trust_mapping", {}).get("context_signals", {})
+    # Adapter-derived signals must override caller: freshness_ok must be False
+    # because stale evidence was returned by the adapter
+    assert signals.get("freshness_ok") is False, (
+        f"Caller freshness_ok=True must not override derived freshness_ok=False "
+        f"(stale evidence present); got signals: {signals}"
+    )
+    assert (
+        res["operator_trust_level"] != "HIGH"
+    ), "Stale evidence must not reach HIGH even when caller supplies freshness_ok=True"

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -674,6 +674,9 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
         )
 
     # Adapter opt-in (Issue #2461): fetch all sub-data from local SurrealDB.
+    # _derived_adapter_signals is set inside the adapter block from real query
+    # results and overrides any caller-supplied context_signals (#3456).
+    _derived_adapter_signals: TrustContextSignals | None = None
     if params.get("adapter_config_path") is not None:
         _adapter_result = build_adapter_from_params(
             params, TOOL_CDB_CONTEXT_TRUST_SUMMARY
@@ -758,6 +761,22 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
             logging.getLogger(__name__).debug(
                 "trust_summary: decision lookup skipped (%s)", _exc
             )  # soft: available sub-results used
+        # Derive context_signals from actual adapter query results (#3456).
+        # Signals are always derived here — never taken from caller-supplied
+        # context_signals — to prevent fake DB-backed trust claims.
+        # freshness_ok is False when any stale records are present in any dimension;
+        # this enforces the governance rule that HIGH requires fresh data.
+        _has_stale = bool(
+            (evidence_result_raw and evidence_result_raw.get("stale_evidence_ids"))
+            or (memory_result_raw and memory_result_raw.get("stale_memory_ids"))
+            or (claim_result_raw and claim_result_raw.get("stale_claim_ids"))
+        )
+        _derived_adapter_signals = TrustContextSignals(
+            record_source="surrealdb-local",
+            freshness_ok=not _has_stale,
+            repo_crosscheck_present=True,
+            caller_supplied_source_only=False,
+        )
     else:
         _source = derive_guarded_source_label(params)
         evidence_result_raw = _as_mapping(params.get("evidence_result"))
@@ -778,17 +797,22 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
             message=str(exc),
         )
 
-    context_signals: TrustContextSignals | None = None
-    try:
-        context_signals = TrustContextSignals.from_mapping(
-            _as_mapping(params.get("context_signals"))
-        )
-    except TrustSummaryError as exc:
-        return _error_response(
-            TOOL_CDB_CONTEXT_TRUST_SUMMARY,
-            code="invalid_parameters",
-            message=str(exc),
-        )
+    # context_signals: adapter path always uses derived signals (never caller-supplied);
+    # non-adapter path reads from request params (existing behaviour).
+    if _derived_adapter_signals is not None:
+        context_signals: TrustContextSignals | None = _derived_adapter_signals
+    else:
+        context_signals = None
+        try:
+            context_signals = TrustContextSignals.from_mapping(
+                _as_mapping(params.get("context_signals"))
+            )
+        except TrustSummaryError as exc:
+            return _error_response(
+                TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+                code="invalid_parameters",
+                message=str(exc),
+            )
 
     try:
         result = build_trust_summary_v1(


### PR DESCRIPTION
## Root Cause

`handle_cdb_context_trust_summary` adapter path called `build_trust_summary_v1` with `context_signals=None`. With `context_signals=None`, `_derive_operator_trust_level` returns the base level from legacy mapping with no gate enforcement:
- `record_source=surrealdb-local` not enforced via signals
- `freshness_ok` not checked — stale records could reach HIGH if composite stayed high
- `repo_crosscheck_present` not gated
- Caller-supplied `context_signals` in request params were accepted alongside `adapter_config_path`, enabling potential trust inflation via forgeable signals

## Delivered

### `tools/mcp/context_evidence_memory_tools.py`

After all four DB sub-result queries (evidence, claim, memory, decision), derive `context_signals` from the actual query results:

```python
_has_stale = bool(
    (evidence_result_raw and evidence_result_raw.get("stale_evidence_ids"))
    or (memory_result_raw and memory_result_raw.get("stale_memory_ids"))
    or (claim_result_raw and claim_result_raw.get("stale_claim_ids"))
)
_derived_adapter_signals = TrustContextSignals(
    record_source="surrealdb-local",
    freshness_ok=not _has_stale,
    repo_crosscheck_present=True,
    caller_supplied_source_only=False,
)
```

Context_signals block is now conditional:
- Adapter path: always uses `_derived_adapter_signals` (caller-supplied params ignored)
- Non-adapter path: existing behaviour — reads from `params.get("context_signals")`

**Trust gates now enforced for adapter path:**
| Gate | Condition | Effect |
|---|---|---|
| `record_source=surrealdb-local` | always | no in_memory/repo-only caps |
| `freshness_not_ok` | any stale record present | cap at LOW |
| `stale_or_disputed_context` | stale_flags from sub-results | cap at MEDIUM |
| `legacy_not_strong` | composite < 0.80 | demote from HIGH |
| `blocking_trust_findings` | blocking evidence/claims | BLOCKED (unchanged) |

### `tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py`

3 new tests:

| Test | Contract |
|---|---|
| `test_trust_summary_db_mode_adapter_signals_always_supplied` | adapter path: `context_signals_supplied=True`, `record_source=surrealdb-local`, `caller_supplied_source_only=False` |
| `test_trust_summary_db_mode_stale_evidence_caps_via_freshness_signal` | stale evidence → `freshness_ok=False` → `freshness_not_ok` gate → not HIGH |
| `test_trust_summary_db_mode_caller_cannot_override_freshness_signal` | caller-supplied `freshness_ok=True` with stale evidence → still `freshness_ok=False` (override ignored) |

## Brain Evidence

```
brain_source: repo-only
context_available: false
context_trust_level: none
context_brain_attempted: true
context_brain_used: false
repo_fallback_used: true
repo_fallback_reason: unavailable
```

## Validation

- `git diff --check`: OK
- `ruff check`: All checks passed
- `black --check`: OK (after reformat)
- `pytest tests/unit/tools/mcp/`: **962/962 passed**
- `pytest tests/unit/surrealdb/test_trust_threshold_contract.py`: **12/12 passed**

## Safety Boundaries

- LR **NO-GO** unchanged
- Board `trade-capable` ≠ Live-GO; no Echtgeld-GO
- HIGH/MEDIUM are not Human-/Live-/Echtgeld-Freigabe
- No productive SurrealDB writes; no `PERSIST_ALLOWED`/`MUTATION_ALLOWED`
- No runtime/Docker/BLUE/RED change

## Non-Goals

- No change to `trust_summary.py` (logic unchanged)
- No change to `context_bridge.py`
- No new DB tables, schema, or adapter changes
- No broad refactor

## Rest-Unsicherheiten

- `repo_crosscheck_present=True` is set statically for the adapter path. A stricter implementation would verify the DB content was recently imported from the current repo HEAD. This is a separate concern and out of scope for this slice.
- `github_live_mismatch` and `ledger_stale_vs_live` remain False (no live GitHub/ledger checks in this path). These are separate signal sources not available here.

Closes #3456