### PR TITLE
fix(surrealdb): derive repo_crosscheck_present from adapter evidence

### DIFF
--- a/tests/unit/surrealdb/test_trust_threshold_contract.py
+++ b/tests/unit/surrealdb/test_trust_threshold_contract.py
@@ -389,3 +389,35 @@ def test_has_repo_evidence_mixed_source_refs_entries() -> None:
     assert has_repo_evidence_from_records(
         [{"decision_id": "d1", "source_refs": ["", " docs/AGENTS.md "]}]
     )
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_source_ref_tool_id_does_not_count() -> None:
+    """Tool identifiers are not repo provenance for trust crosscheck."""
+    assert not has_repo_evidence_from_records(
+        [{"memory_id": "m1", "source_ref": "tool:context.readiness"}]
+    )
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_source_refs_issue_url_does_not_count() -> None:
+    """Issue/PR URLs are not repo file provenance for trust crosscheck."""
+    assert not has_repo_evidence_from_records(
+        [{"claim_id": "c1", "source_refs": ["https://github.com/foo/bar/issues/1"]}]
+    )
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_source_refs_path_prefix_counts() -> None:
+    """path: repo-relative refs still count as repo provenance."""
+    assert has_repo_evidence_from_records(
+        [{"claim_id": "c1", "source_refs": ["path:docs/runbooks/CONTROL_REGISTER.md"]}]
+    )
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_source_refs_hashed_path_counts() -> None:
+    """Hashed repo-relative refs still count as repo provenance."""
+    assert has_repo_evidence_from_records(
+        [{"memory_id": "m1", "source_refs": ["docs/AGENTS.md@abc123"]}]
+    )

--- a/tests/unit/surrealdb/test_trust_threshold_contract.py
+++ b/tests/unit/surrealdb/test_trust_threshold_contract.py
@@ -373,3 +373,19 @@ def test_has_repo_evidence_empty_source_refs() -> None:
     assert not has_repo_evidence_from_records(
         [{"decision_id": "d1", "source_refs": []}]
     )
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_blank_source_refs_entries() -> None:
+    """Blank or None source_refs entries do NOT count as repo evidence."""
+    assert not has_repo_evidence_from_records(
+        [{"decision_id": "d1", "source_refs": ["", "   ", None]}]
+    )
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_mixed_source_refs_entries() -> None:
+    """A source_refs list counts only when at least one entry is non-empty."""
+    assert has_repo_evidence_from_records(
+        [{"decision_id": "d1", "source_refs": ["", " docs/AGENTS.md "]}]
+    )

--- a/tests/unit/surrealdb/test_trust_threshold_contract.py
+++ b/tests/unit/surrealdb/test_trust_threshold_contract.py
@@ -339,3 +339,37 @@ def test_has_repo_evidence_from_records_mixed() -> None:
         [{"claim_id": "c1", "source_hash": "abc123"}],
         [],
     )
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_empty_source_path() -> None:
+    """Empty string source_path does NOT count as repo evidence."""
+    assert not has_repo_evidence_from_records(
+        [{"evidence_id": "e1", "source_path": ""}]
+    )
+    assert not has_repo_evidence_from_records(
+        [{"evidence_id": "e2", "source_path": "   "}]
+    )
+    assert not has_repo_evidence_from_records(
+        [{"evidence_id": "e3", "source_path": None}]
+    )
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_empty_source_hash() -> None:
+    """Empty string source_hash does NOT count as repo evidence."""
+    assert not has_repo_evidence_from_records([{"claim_id": "c1", "source_hash": ""}])
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_empty_source_ref() -> None:
+    """Empty string source_ref does NOT count as repo evidence."""
+    assert not has_repo_evidence_from_records([{"memory_id": "m1", "source_ref": ""}])
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_empty_source_refs() -> None:
+    """Empty list source_refs does NOT count as repo evidence."""
+    assert not has_repo_evidence_from_records(
+        [{"decision_id": "d1", "source_refs": []}]
+    )

--- a/tests/unit/surrealdb/test_trust_threshold_contract.py
+++ b/tests/unit/surrealdb/test_trust_threshold_contract.py
@@ -16,6 +16,7 @@ from tools.surrealdb.trust_summary import (
     TrustContextSignals,
     TrustSummaryRequest,
     build_trust_summary_v1,
+    has_repo_evidence_from_records,
 )
 
 _FIXTURE_DIR = Path(__file__).resolve().parents[2] / "fixtures" / "trust_threshold"
@@ -239,4 +240,102 @@ def test_fixture_scenarios_match_contract() -> None:
             memory_result=payload.get("memory_result"),
             context_signals=signals,
         )
-        assert result["operator_trust_level"] == payload["expected_operator_trust_level"]
+        assert (
+            result["operator_trust_level"] == payload["expected_operator_trust_level"]
+        )
+
+
+@pytest.mark.unit
+def test_no_repo_crosscheck_prevents_high() -> None:
+    """Missing repo crosscheck caps at MEDIUM even with strong evidence."""
+    result = build_trust_summary_v1(
+        TrustSummaryRequest(scope="wave14-no-crosscheck"),
+        context_signals=TrustContextSignals(
+            repo_crosscheck_present=False,
+            record_source="surrealdb-local",
+            freshness_ok=True,
+        ),
+        **_strong_inputs(),
+    )
+    assert result["operator_trust_level"] == "MEDIUM", (
+        f"Expected MEDIUM when repo_crosscheck_present=False, "
+        f"got {result['operator_trust_level']}"
+    )
+
+
+@pytest.mark.unit
+def test_default_crosscheck_is_false() -> None:
+    """Default TrustContextSignals must have repo_crosscheck_present=False."""
+    signals = TrustContextSignals()
+    assert signals.repo_crosscheck_present is False
+
+
+@pytest.mark.unit
+def test_default_crosscheck_from_mapping_is_false() -> None:
+    """from_mapping must default repo_crosscheck_present to False."""
+    signals = TrustContextSignals.from_mapping({})
+    assert signals is not None
+    assert signals.repo_crosscheck_present is False
+
+
+@pytest.mark.unit
+def test_from_mapping_explicit_true() -> None:
+    """from_mapping honors explicit repo_crosscheck_present=True."""
+    signals = TrustContextSignals.from_mapping({"repo_crosscheck_present": True})
+    assert signals is not None
+    assert signals.repo_crosscheck_present is True
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_from_records_source_path() -> None:
+    """source_path in a record counts as repo evidence."""
+    assert has_repo_evidence_from_records(
+        [{"evidence_id": "e1", "source_path": "docs/test.md"}]
+    )
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_from_records_source_hash() -> None:
+    """source_hash in a record counts as repo evidence."""
+    assert has_repo_evidence_from_records([{"claim_id": "c1", "source_hash": "abc123"}])
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_from_records_source_ref() -> None:
+    """source_ref in a record counts as repo evidence."""
+    assert has_repo_evidence_from_records(
+        [{"memory_id": "m1", "source_ref": "docs/AGENTS.md"}]
+    )
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_from_records_source_refs() -> None:
+    """source_refs in a record counts as repo evidence."""
+    assert has_repo_evidence_from_records(
+        [{"decision_id": "d1", "source_refs": ["docs/AGENTS.md"]}]
+    )
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_from_records_missing() -> None:
+    """Records without repo evidence fields return False."""
+    assert not has_repo_evidence_from_records(
+        [{"evidence_id": "e1", "scope": "wave14", "confidence": 0.9}]
+    )
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_from_records_empty() -> None:
+    """Empty or None record lists return False."""
+    assert not has_repo_evidence_from_records([])
+    assert not has_repo_evidence_from_records(None)
+
+
+@pytest.mark.unit
+def test_has_repo_evidence_from_records_mixed() -> None:
+    """At least one record with repo evidence among multiple lists returns True."""
+    assert has_repo_evidence_from_records(
+        [{"evidence_id": "e1", "scope": "wave14"}],
+        [{"claim_id": "c1", "source_hash": "abc123"}],
+        [],
+    )

--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -1284,8 +1284,86 @@ def test_trust_summary_db_mode_adapter_signals_always_supplied(monkeypatch) -> N
         f"Expected record_source=surrealdb-local (derived, not caller-supplied), "
         f"got: {signals}"
     )
-    assert signals.get("repo_crosscheck_present") is True
     assert signals.get("caller_supplied_source_only") is False
+
+
+@pytest.mark.unit
+def test_trust_summary_db_mode_repo_crosscheck_from_records(monkeypatch) -> None:
+    """repo_crosscheck_present is True when adapter records have source_path."""
+    ev_with_source: dict[str, Any] = {
+        "evidence_id": "ev-source-001",
+        "source_path": "tools/surrealdb/evidence_lookup.py",
+        "scope": "wave14",
+    }
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    mock_adapter.execute.side_effect = [
+        [ev_with_source],
+        [],
+        [],
+        [],
+    ]
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "scope": "wave14",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    signals = (
+        result["result"].get("operator_trust_mapping", {}).get("context_signals", {})
+    )
+    assert signals.get("repo_crosscheck_present") is True, (
+        f"Expected repo_crosscheck_present=True when records have source_path, "
+        f"got: {signals}"
+    )
+
+
+@pytest.mark.unit
+def test_trust_summary_db_mode_repo_crosscheck_missing(monkeypatch) -> None:
+    """repo_crosscheck_present is False when adapter records have no repo fields."""
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    mock_adapter.execute.side_effect = [
+        [_EVIDENCE_RECORD],
+        [_CLAIM_RECORD],
+        [_MEMORY_RECORD],
+        [_DECISION_RECORD],
+    ]
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "scope": "wave14",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    signals = (
+        result["result"].get("operator_trust_mapping", {}).get("context_signals", {})
+    )
+    assert signals.get("repo_crosscheck_present") is False, (
+        f"Expected repo_crosscheck_present=False when records lack repo fields, "
+        f"got: {signals}"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -1367,6 +1367,57 @@ def test_trust_summary_db_mode_repo_crosscheck_missing(monkeypatch) -> None:
 
 
 @pytest.mark.unit
+def test_trust_summary_db_mode_repo_crosscheck_scope_isolated(monkeypatch) -> None:
+    """Out-of-scope records with source_path must not set repo_crosscheck_present.
+
+    Only records matching the trust summary scope should contribute to the
+    repo crosscheck signal. An unrelated scope with repo provenance must
+    not falsely enable HIGH for a different scope.
+    """
+    out_of_scope: dict[str, Any] = {
+        "evidence_id": "ev-other-scope",
+        "source_path": "docs/other.md",
+        "scope": "wave17",
+    }
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    mock_adapter.execute.side_effect = [
+        [out_of_scope],
+        [],
+        [],
+        [],
+    ]
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "scope": "wave14",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    signals = (
+        result["result"].get("operator_trust_mapping", {}).get("context_signals", {})
+    )
+    assert signals.get("repo_crosscheck_present") is False, (
+        f"Expected repo_crosscheck_present=False when only out-of-scope records "
+        f"have source_path, got: {signals}"
+    )
+    # Without repo crosscheck the level must be capped at MEDIUM
+    assert (
+        result["result"].get("operator_trust_level") != "HIGH"
+    ), "Must not reach HIGH without in-scope repo evidence"
+
+
+@pytest.mark.unit
 def test_trust_summary_db_mode_stale_evidence_caps_via_freshness_signal(
     monkeypatch,
 ) -> None:

--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -1294,6 +1294,7 @@ def test_trust_summary_db_mode_repo_crosscheck_from_records(monkeypatch) -> None
         "evidence_id": "ev-source-001",
         "source_path": "tools/surrealdb/evidence_lookup.py",
         "scope": "wave14",
+        "created_at": "2026-01-01T00:00:00Z",
     }
     mock_adapter = MagicMock(spec=QueryAdapter)
     mock_adapter.status = "surrealdb-local"
@@ -1465,6 +1466,58 @@ def test_trust_summary_db_mode_repo_crosscheck_scope_isolated_with_artifact(
     assert (
         result["result"].get("operator_trust_level") != "HIGH"
     ), "Must not reach HIGH without in-scope repo evidence"
+
+
+@pytest.mark.unit
+def test_trust_summary_db_mode_repo_crosscheck_artifact_isolated(monkeypatch) -> None:
+    """Only matched artifact evidence may contribute to repo_crosscheck_present."""
+    matching_artifact_no_source: dict[str, Any] = {
+        "evidence_id": "ev-artifact-match-no-source",
+        "scope": "wave14",
+        "artifact_refs": ["tools/surrealdb/evidence_lookup.py"],
+    }
+    other_artifact_with_source: dict[str, Any] = {
+        "evidence_id": "ev-artifact-other-source",
+        "scope": "wave14",
+        "artifact_refs": ["docs/other.md"],
+        "source_path": "docs/other.md",
+    }
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    mock_adapter.execute.side_effect = [
+        [matching_artifact_no_source, other_artifact_with_source],
+        [],
+        [],
+        [],
+    ]
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "scope": "wave14",
+                "artifact": "tools/surrealdb/evidence_lookup.py",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    signals = (
+        result["result"].get("operator_trust_mapping", {}).get("context_signals", {})
+    )
+    assert signals.get("repo_crosscheck_present") is False, (
+        "Expected repo_crosscheck_present=False when only a different artifact "
+        f"has repo provenance, got: {signals}"
+    )
+    assert (
+        result["result"].get("operator_trust_level") != "HIGH"
+    ), "Must not reach HIGH without matched artifact repo evidence"
 
 
 @pytest.mark.unit

--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -1331,6 +1331,51 @@ def test_trust_summary_db_mode_repo_crosscheck_from_records(monkeypatch) -> None
 
 
 @pytest.mark.unit
+def test_trust_summary_db_mode_repo_crosscheck_from_source_hash(
+    monkeypatch,
+) -> None:
+    """source_hash-only provenance must count for matched evidence rows."""
+    ev_with_source_hash: dict[str, Any] = {
+        "evidence_id": "ev-source-hash-001",
+        "source_hash": "sha256:abc123",
+        "scope": "wave14",
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    mock_adapter.execute.side_effect = [
+        [ev_with_source_hash],
+        [],
+        [],
+        [],
+    ]
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "scope": "wave14",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    signals = (
+        result["result"].get("operator_trust_mapping", {}).get("context_signals", {})
+    )
+    assert signals.get("repo_crosscheck_present") is True, (
+        f"Expected repo_crosscheck_present=True when records have source_hash, "
+        f"got: {signals}"
+    )
+
+
+@pytest.mark.unit
 def test_trust_summary_db_mode_repo_crosscheck_missing(monkeypatch) -> None:
     """repo_crosscheck_present is False when adapter records have no repo fields."""
     mock_adapter = MagicMock(spec=QueryAdapter)

--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -1418,6 +1418,56 @@ def test_trust_summary_db_mode_repo_crosscheck_scope_isolated(monkeypatch) -> No
 
 
 @pytest.mark.unit
+def test_trust_summary_db_mode_repo_crosscheck_scope_isolated_with_artifact(
+    monkeypatch,
+) -> None:
+    """Out-of-scope evidence with source_path must not set repo_crosscheck_present
+    even when artifact is specified (artifact path builds _ev_input from all rows)."""
+    out_of_scope_ev: dict[str, Any] = {
+        "evidence_id": "ev-artifact-other-scope",
+        "source_path": "tools/surrealdb/evidence_lookup.py",
+        "scope": "wave17",
+        "artifact_refs": ["tools/surrealdb/evidence_lookup.py"],
+    }
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    mock_adapter.execute.side_effect = [
+        [out_of_scope_ev],
+        [],
+        [],
+        [],
+    ]
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "scope": "wave14",
+                "artifact": "tools/surrealdb/evidence_lookup.py",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    signals = (
+        result["result"].get("operator_trust_mapping", {}).get("context_signals", {})
+    )
+    assert signals.get("repo_crosscheck_present") is False, (
+        f"Expected repo_crosscheck_present=False when only out-of-scope records "
+        f"have source_path (artifact path), got: {signals}"
+    )
+    assert (
+        result["result"].get("operator_trust_level") != "HIGH"
+    ), "Must not reach HIGH without in-scope repo evidence"
+
+
+@pytest.mark.unit
 def test_trust_summary_db_mode_stale_evidence_caps_via_freshness_signal(
     monkeypatch,
 ) -> None:

--- a/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
+++ b/tests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py
@@ -1566,6 +1566,57 @@ def test_trust_summary_db_mode_repo_crosscheck_artifact_isolated(monkeypatch) ->
 
 
 @pytest.mark.unit
+def test_trust_summary_db_mode_repo_crosscheck_artifact_ignores_memory_provenance(
+    monkeypatch,
+) -> None:
+    """Artifact trust summaries must ignore unrelated same-scope memory provenance."""
+    matching_artifact_no_source: dict[str, Any] = {
+        "evidence_id": "ev-artifact-match-no-source-2",
+        "scope": "wave14",
+        "artifact_refs": ["tools/surrealdb/evidence_lookup.py"],
+    }
+    same_scope_memory_with_repo_ref: dict[str, Any] = {
+        "memory_id": "mem-other-provenance",
+        "scope": "wave14",
+        "artifact_refs": ["docs/other.md"],
+        "source_refs": ["docs/other.md@abc123"],
+    }
+    mock_adapter = MagicMock(spec=QueryAdapter)
+    mock_adapter.status = "surrealdb-local"
+    mock_adapter.execute.side_effect = [
+        [matching_artifact_no_source],
+        [],
+        [same_scope_memory_with_repo_ref],
+        [],
+    ]
+    _patch_adapter_factory(
+        monkeypatch,
+        "tools.mcp.context_evidence_memory_tools.build_adapter_from_params",
+        mock_adapter,
+    )
+
+    result = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                "adapter_config_path": _FAKE_CONFIG_PATH,
+                "scope": "wave14",
+                "artifact": "tools/surrealdb/evidence_lookup.py",
+            },
+        }
+    )
+
+    assert result["status"] == "ok", result
+    signals = (
+        result["result"].get("operator_trust_mapping", {}).get("context_signals", {})
+    )
+    assert signals.get("repo_crosscheck_present") is False, (
+        "Expected repo_crosscheck_present=False when only unrelated same-scope "
+        f"memory has repo provenance, got: {signals}"
+    )
+
+
+@pytest.mark.unit
 def test_trust_summary_db_mode_stale_evidence_caps_via_freshness_signal(
     monkeypatch,
 ) -> None:

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -1610,7 +1610,12 @@ def context_readiness_handler(**kwargs) -> dict[str, Any]:
 # At least one must be present for adapter_trust_result to be treated as a
 # real trust summary rather than a generic metadata dict.
 _ADAPTER_TRUST_SENTINEL_KEYS: frozenset[str] = frozenset(
-    {"operator_trust_level", "trust_level", "composite_score", "blocking_trust_findings"}
+    {
+        "operator_trust_level",
+        "trust_level",
+        "composite_score",
+        "blocking_trust_findings",
+    }
 )
 
 
@@ -1711,7 +1716,12 @@ def _derive_briefing_brain_context(
         limitations.append(
             "brain context derived from Wave-14 trust summary adapter metadata"
         )
-        return "surrealdb-local", "used", limitations, trust_summary_result.get("result") or {}
+        return (
+            "surrealdb-local",
+            "used",
+            limitations,
+            trust_summary_result.get("result") or {},
+        )
 
     if any(
         (
@@ -1878,7 +1888,9 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
     )
     if isinstance(brain_context, dict):
         return brain_context
-    brain_source, brain_status, derived_brain_limitations, adapter_trust_result = brain_context
+    brain_source, brain_status, derived_brain_limitations, adapter_trust_result = (
+        brain_context
+    )
     session_context_limitations.extend(derived_brain_limitations)
 
     repo_state = {
@@ -2289,7 +2301,9 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
             # Validate that adapter_trust_result is a real build_trust_summary_v1
             # output, not a generic metadata dict (e.g. {"scope": "..."}).
             # Fail-closed: only propagate if at least one sentinel field is present.
-            _atr = adapter_trust_result if isinstance(adapter_trust_result, dict) else {}
+            _atr = (
+                adapter_trust_result if isinstance(adapter_trust_result, dict) else {}
+            )
             _has_real_trust = bool(_ADAPTER_TRUST_SENTINEL_KEYS.intersection(_atr))
             if _has_real_trust:
                 # Propagate DB-backed trust fields from the adapter result.
@@ -2309,9 +2323,7 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
                 _adapter_stale = [str(f) for f in (_atr.get("stale_flags") or [])]
                 if _adapter_stale:
                     stale_evidence_notice.extend(_adapter_stale)
-                _adapter_disputed = [
-                    str(f) for f in (_atr.get("disputed_flags") or [])
-                ]
+                _adapter_disputed = [str(f) for f in (_atr.get("disputed_flags") or [])]
                 if _adapter_disputed:
                     contradictory_evidence_notice.extend(_adapter_disputed)
                 trust_summary = (
@@ -2384,6 +2396,7 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
             TrustSummaryError,
             TrustSummaryRequest,
             build_trust_summary_v1,
+            has_repo_evidence_from_records,
         )
         from tools.surrealdb.decision_history_query import (
             DecisionHistoryQueryError,
@@ -2574,10 +2587,19 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
         # Derive context_signals from brain_source so trust caps are enforced
         # per AGENTS.md: inline records (in_memory) capped at MEDIUM;
         # surrealdb-local can reach HIGH with crosscheck + freshness.
+        # repo_crosscheck_present is derived from enrichment records (#3458):
+        # only set True when at least one record has repo/import provenance fields
+        # (source_path, source_hash, source_ref, source_refs).
         _context_signals: TrustContextSignals | None = None
         if brain_source == "surrealdb-local":
+            _has_repo = has_repo_evidence_from_records(
+                _evidence_records_raw,
+                _claim_records_raw,
+                _decision_events_raw,
+                _memory_records_raw,
+            )
             _context_signals = TrustContextSignals(
-                repo_crosscheck_present=True,
+                repo_crosscheck_present=_has_repo,
                 record_source="surrealdb-local",
                 freshness_ok=True,
             )

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -2592,11 +2592,28 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
         # (source_path, source_hash, source_ref, source_refs).
         _context_signals: TrustContextSignals | None = None
         if brain_source == "surrealdb-local":
+            _ev_for_repo = [
+                r
+                for r in (_evidence_records_raw or [])
+                if isinstance(r, dict) and r.get("scope") == _enrichment_scope
+            ]
+            _cl_for_repo = [
+                r
+                for r in (_claim_records_raw or [])
+                if isinstance(r, dict) and r.get("scope") == _enrichment_scope
+            ]
+            _dec_for_repo = [
+                r
+                for r in (_decision_events_raw or [])
+                if isinstance(r, dict) and r.get("scope") == _enrichment_scope
+            ]
+            _mem_for_repo = [
+                r
+                for r in (_memory_records_raw or [])
+                if isinstance(r, dict) and r.get("scope") == _enrichment_scope
+            ]
             _has_repo = has_repo_evidence_from_records(
-                _evidence_records_raw,
-                _claim_records_raw,
-                _decision_events_raw,
-                _memory_records_raw,
+                _ev_for_repo, _cl_for_repo, _dec_for_repo, _mem_for_repo
             )
             _context_signals = TrustContextSignals(
                 repo_crosscheck_present=_has_repo,

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -777,7 +777,9 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
             or (claim_result_raw and claim_result_raw.get("stale_claim_ids"))
         )
         _ev_for_repo = [
-            r for r in _ev_input if isinstance(r, dict) and r.get("scope") == scope
+            r
+            for r in (evidence_result_raw or {}).get("matched_evidence", [])
+            if isinstance(r, dict) and r.get("scope") == scope
         ]
         _cl_for_repo = [
             r for r in _cl_raw if isinstance(r, dict) and r.get("scope") == scope

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -776,10 +776,17 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
             or (memory_result_raw and memory_result_raw.get("stale_memory_ids"))
             or (claim_result_raw and claim_result_raw.get("stale_claim_ids"))
         )
+        _matched_ev_ids = {
+            r.get("evidence_id")
+            for r in (evidence_result_raw or {}).get("matched_evidence", [])
+            if isinstance(r, dict) and r.get("evidence_id")
+        }
         _ev_for_repo = [
             r
-            for r in (evidence_result_raw or {}).get("matched_evidence", [])
-            if isinstance(r, dict) and r.get("scope") == scope
+            for r in _ev_input
+            if isinstance(r, dict)
+            and r.get("scope") == scope
+            and r.get("evidence_id") in _matched_ev_ids
         ]
         _cl_for_repo = [
             r for r in _cl_raw if isinstance(r, dict) and r.get("scope") == scope

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -38,6 +38,7 @@ from tools.surrealdb.trust_summary import (
     TrustSummaryError,
     TrustSummaryRequest,
     build_trust_summary_v1,
+    has_repo_evidence_from_records,
 )
 from tools.surrealdb.decision_history_query import (
     DecisionHistoryQueryError,
@@ -766,15 +767,19 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
         # context_signals — to prevent fake DB-backed trust claims.
         # freshness_ok is False when any stale records are present in any dimension;
         # this enforces the governance rule that HIGH requires fresh data.
+        # repo_crosscheck_present is derived from adapter raw records (#3458):
+        # only set True when at least one record has repo/import provenance fields
+        # (source_path, source_hash, source_ref, source_refs).
         _has_stale = bool(
             (evidence_result_raw and evidence_result_raw.get("stale_evidence_ids"))
             or (memory_result_raw and memory_result_raw.get("stale_memory_ids"))
             or (claim_result_raw and claim_result_raw.get("stale_claim_ids"))
         )
+        _has_repo = has_repo_evidence_from_records(_ev_raw, _cl_raw, _mem_raw, _dec_raw)
         _derived_adapter_signals = TrustContextSignals(
             record_source="surrealdb-local",
             freshness_ok=not _has_stale,
-            repo_crosscheck_present=True,
+            repo_crosscheck_present=_has_repo,
             caller_supplied_source_only=False,
         )
     else:

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -767,15 +767,28 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
         # context_signals — to prevent fake DB-backed trust claims.
         # freshness_ok is False when any stale records are present in any dimension;
         # this enforces the governance rule that HIGH requires fresh data.
-        # repo_crosscheck_present is derived from adapter raw records (#3458):
-        # only set True when at least one record has repo/import provenance fields
-        # (source_path, source_hash, source_ref, source_refs).
+        # repo_crosscheck_present is derived from scoped adapter records (#3458):
+        # only set True when at least one in-scope record has repo/import
+        # provenance with non-empty values. Records from other scopes are
+        # excluded to prevent cross-scope contamination.
         _has_stale = bool(
             (evidence_result_raw and evidence_result_raw.get("stale_evidence_ids"))
             or (memory_result_raw and memory_result_raw.get("stale_memory_ids"))
             or (claim_result_raw and claim_result_raw.get("stale_claim_ids"))
         )
-        _has_repo = has_repo_evidence_from_records(_ev_raw, _cl_raw, _mem_raw, _dec_raw)
+        _ev_for_repo = _ev_input
+        _cl_for_repo = [
+            r for r in _cl_raw if isinstance(r, dict) and r.get("scope") == scope
+        ]
+        _mem_for_repo = [
+            r for r in _mem_raw if isinstance(r, dict) and r.get("scope") == scope
+        ]
+        _dec_for_repo = [
+            r for r in _dec_raw if isinstance(r, dict) and r.get("scope") == scope
+        ]
+        _has_repo = has_repo_evidence_from_records(
+            _ev_for_repo, _cl_for_repo, _mem_for_repo, _dec_for_repo
+        )
         _derived_adapter_signals = TrustContextSignals(
             record_source="surrealdb-local",
             freshness_ok=not _has_stale,

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -776,7 +776,9 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
             or (memory_result_raw and memory_result_raw.get("stale_memory_ids"))
             or (claim_result_raw and claim_result_raw.get("stale_claim_ids"))
         )
-        _ev_for_repo = _ev_input
+        _ev_for_repo = [
+            r for r in _ev_input if isinstance(r, dict) and r.get("scope") == scope
+        ]
         _cl_for_repo = [
             r for r in _cl_raw if isinstance(r, dict) and r.get("scope") == scope
         ]

--- a/tools/mcp/context_evidence_memory_tools.py
+++ b/tools/mcp/context_evidence_memory_tools.py
@@ -797,9 +797,12 @@ def handle_cdb_context_trust_summary(request: Mapping[str, Any]) -> dict[str, An
         _dec_for_repo = [
             r for r in _dec_raw if isinstance(r, dict) and r.get("scope") == scope
         ]
-        _has_repo = has_repo_evidence_from_records(
-            _ev_for_repo, _cl_for_repo, _mem_for_repo, _dec_for_repo
-        )
+        if _artifact:
+            _has_repo = has_repo_evidence_from_records(_ev_for_repo)
+        else:
+            _has_repo = has_repo_evidence_from_records(
+                _ev_for_repo, _cl_for_repo, _mem_for_repo, _dec_for_repo
+            )
         _derived_adapter_signals = TrustContextSignals(
             record_source="surrealdb-local",
             freshness_ok=not _has_stale,

--- a/tools/surrealdb/trust_summary.py
+++ b/tools/surrealdb/trust_summary.py
@@ -104,16 +104,19 @@ _REPO_EVIDENCE_FIELDS = frozenset(
 )
 
 
-def _has_non_empty_repo_value(record: dict, field: str) -> bool:
-    """Check if a repo evidence field in a record has a non-empty value."""
-    value = record.get(field)
+def _has_non_empty_provenance_value(value: Any) -> bool:
     if value is None:
         return False
     if isinstance(value, str):
         return bool(value.strip())
     if isinstance(value, (list, tuple)):
-        return len(value) > 0
+        return any(_has_non_empty_provenance_value(item) for item in value)
     return bool(value)
+
+
+def _has_non_empty_repo_value(record: dict, field: str) -> bool:
+    """Check if a repo evidence field in a record has a non-empty value."""
+    return _has_non_empty_provenance_value(record.get(field))
 
 
 def has_repo_evidence_from_records(*record_lists: Any) -> bool:

--- a/tools/surrealdb/trust_summary.py
+++ b/tools/surrealdb/trust_summary.py
@@ -103,6 +103,50 @@ _REPO_EVIDENCE_FIELDS = frozenset(
     {"source_path", "source_hash", "source_ref", "source_refs"}
 )
 
+_DIRECT_REPO_PROVENANCE_FIELDS = frozenset({"source_path", "source_hash"})
+_REPO_REF_ALLOWED_EXTENSIONS = frozenset(
+    {
+        "bat",
+        "csv",
+        "html",
+        "ini",
+        "json",
+        "jsonl",
+        "md",
+        "ps1",
+        "py",
+        "sh",
+        "sql",
+        "surql",
+        "toml",
+        "txt",
+        "yaml",
+        "yml",
+    }
+)
+_REPO_REF_ALLOWED_ROOT_NAMES = frozenset(
+    {
+        "AGENTS.md",
+        "CURRENT_STATUS.md",
+        "Dockerfile",
+        "Makefile",
+        "PROJECT_STATUS.md",
+        "README.md",
+    }
+)
+_NON_REPO_REF_PREFIXES = (
+    "tool:",
+    "http://",
+    "https://",
+    "issue:",
+    "pr:",
+    "claim:",
+    "memory:",
+    "decision:",
+    "evidence:",
+    "issuecomment-",
+)
+
 
 def _has_non_empty_provenance_value(value: Any) -> bool:
     if value is None:
@@ -114,9 +158,51 @@ def _has_non_empty_provenance_value(value: Any) -> bool:
     return bool(value)
 
 
+def _looks_like_repo_provenance_ref(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    text = value.strip()
+    if not text:
+        return False
+    lowered = text.lower()
+    if lowered.startswith(_NON_REPO_REF_PREFIXES) or text.startswith("#"):
+        return False
+    if lowered.startswith("path:"):
+        text = text[5:].strip()
+        if not text:
+            return False
+    candidate = text.rsplit("@", 1)[0].strip()
+    if not candidate or " " in candidate:
+        return False
+    normalized = candidate.replace("\\", "/")
+    if (
+        normalized.startswith(("/", "./", "../", "//"))
+        or "/../" in normalized
+        or normalized.endswith("/..")
+    ):
+        return False
+    if len(normalized) >= 2 and normalized[1] == ":" and normalized[0].isalpha():
+        return False
+    name = normalized.rsplit("/", 1)[-1]
+    if name in _REPO_REF_ALLOWED_ROOT_NAMES:
+        return True
+    if "." not in name:
+        return False
+    extension = name.rsplit(".", 1)[-1].lower()
+    return extension in _REPO_REF_ALLOWED_EXTENSIONS
+
+
 def _has_non_empty_repo_value(record: dict, field: str) -> bool:
     """Check if a repo evidence field in a record has a non-empty value."""
-    return _has_non_empty_provenance_value(record.get(field))
+    value = record.get(field)
+    if field in _DIRECT_REPO_PROVENANCE_FIELDS:
+        return _has_non_empty_provenance_value(value)
+    if field == "source_ref":
+        return _looks_like_repo_provenance_ref(value)
+    if field == "source_refs":
+        values = value if isinstance(value, (list, tuple)) else [value]
+        return any(_looks_like_repo_provenance_ref(item) for item in values)
+    return _has_non_empty_provenance_value(value)
 
 
 def has_repo_evidence_from_records(*record_lists: Any) -> bool:

--- a/tools/surrealdb/trust_summary.py
+++ b/tools/surrealdb/trust_summary.py
@@ -75,7 +75,7 @@ class TrustContextSignals:
 
     github_live_mismatch: bool = False
     ledger_stale_vs_live: bool = False
-    repo_crosscheck_present: bool = True
+    repo_crosscheck_present: bool = False
     record_source: str | None = None
     caller_supplied_source_only: bool = False
     freshness_ok: bool = True
@@ -91,12 +91,35 @@ class TrustContextSignals:
         return cls(
             github_live_mismatch=bool(raw.get("github_live_mismatch")),
             ledger_stale_vs_live=bool(raw.get("ledger_stale_vs_live")),
-            repo_crosscheck_present=bool(raw.get("repo_crosscheck_present", True)),
+            repo_crosscheck_present=bool(raw.get("repo_crosscheck_present", False)),
             record_source=record_source,
             caller_supplied_source_only=bool(raw.get("caller_supplied_source_only")),
             freshness_ok=bool(raw.get("freshness_ok", True)),
             required_db_records_missing=bool(raw.get("required_db_records_missing")),
         )
+
+
+_REPO_EVIDENCE_FIELDS = frozenset(
+    {"source_path", "source_hash", "source_ref", "source_refs"}
+)
+
+
+def has_repo_evidence_from_records(*record_lists: Any) -> bool:
+    """Check if any record across all provided lists has repo/import provenance fields.
+
+    Returns True only if at least one record dict contains a field that proves
+    the data was imported from the CDB repo (source_path, source_hash,
+    source_ref, or source_refs).  Pure function, side-effect-free.
+    """
+    for records in record_lists:
+        if not isinstance(records, (list, tuple)):
+            continue
+        for record in records:
+            if isinstance(record, dict) and any(
+                field in record for field in _REPO_EVIDENCE_FIELDS
+            ):
+                return True
+    return False
 
 
 def _as_str(value: Any) -> str | None:
@@ -183,7 +206,9 @@ def _memory_trust_score(result: Mapping[str, Any]) -> float:
     total = sum(trust_counts.values())
     if total == 0:
         return 0.5  # neutral when no memory
-    score = sum(weights.get(level, 0.0) * count for level, count in trust_counts.items())
+    score = sum(
+        weights.get(level, 0.0) * count for level, count in trust_counts.items()
+    )
     return min(score / total, 1.0)
 
 
@@ -222,7 +247,9 @@ def _collect_blocking_findings(
     if decision_result:
         unresolved = _as_list(decision_result.get("unresolved_evidence_refs"))
         if unresolved:
-            findings.append(f"unresolved_evidence_refs_in_decisions ({len(unresolved)})")
+            findings.append(
+                f"unresolved_evidence_refs_in_decisions ({len(unresolved)})"
+            )
     return findings
 
 
@@ -391,7 +418,9 @@ def build_trust_summary_v1(
 
     warnings: list[str] = []
 
-    ev_summary = dict(evidence_result.get("evidence_summary") or {}) if evidence_result else {}
+    ev_summary = (
+        dict(evidence_result.get("evidence_summary") or {}) if evidence_result else {}
+    )
     ev_strength = _as_str(ev_summary.get("overall_strength")) or "none"
     evidence_strength_score = _evidence_strength_score(ev_strength)
 
@@ -445,13 +474,15 @@ def build_trust_summary_v1(
 
     trust_level = _derive_trust_level(composite_score, blocking_findings)
 
-    operator_trust_level, operator_trust_mapping, gate_notes = _derive_operator_trust_level(
-        trust_level,
-        composite_score=composite_score,
-        blocking_findings=blocking_findings,
-        stale_flags=stale_flags,
-        disputed_flags=disputed_flags,
-        context_signals=context_signals,
+    operator_trust_level, operator_trust_mapping, gate_notes = (
+        _derive_operator_trust_level(
+            trust_level,
+            composite_score=composite_score,
+            blocking_findings=blocking_findings,
+            stale_flags=stale_flags,
+            disputed_flags=disputed_flags,
+            context_signals=context_signals,
+        )
     )
     if gate_notes:
         warnings.extend(gate_notes)

--- a/tools/surrealdb/trust_summary.py
+++ b/tools/surrealdb/trust_summary.py
@@ -104,19 +104,33 @@ _REPO_EVIDENCE_FIELDS = frozenset(
 )
 
 
+def _has_non_empty_repo_value(record: dict, field: str) -> bool:
+    """Check if a repo evidence field in a record has a non-empty value."""
+    value = record.get(field)
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple)):
+        return len(value) > 0
+    return bool(value)
+
+
 def has_repo_evidence_from_records(*record_lists: Any) -> bool:
     """Check if any record across all provided lists has repo/import provenance fields.
 
     Returns True only if at least one record dict contains a field that proves
     the data was imported from the CDB repo (source_path, source_hash,
-    source_ref, or source_refs).  Pure function, side-effect-free.
+    source_ref, or source_refs) AND the field value is non-empty.
+    Pure function, side-effect-free.
     """
     for records in record_lists:
         if not isinstance(records, (list, tuple)):
             continue
         for record in records:
             if isinstance(record, dict) and any(
-                field in record for field in _REPO_EVIDENCE_FIELDS
+                _has_non_empty_repo_value(record, field)
+                for field in _REPO_EVIDENCE_FIELDS
             ):
                 return True
     return False


### PR DESCRIPTION
## Summary

Changes \epo_crosscheck_present\ default from \True\ to \False\ in \TrustContextSignals\ and replaces the static \True\ in both adapter and enrichment paths with a dynamic check via \has_repo_evidence_from_records()\.

## Changes

- \	ools/surrealdb/trust_summary.py\: Default \False\ in dataclass and \rom_mapping\; new \has_repo_evidence_from_records()\ helper
- \	ools/mcp/context_evidence_memory_tools.py\: Adapter path derives signal from raw DB records
- \	ools/mcp/context_bridge.py\: Enrichment path derives signal from enrichment records
- \	ests/unit/surrealdb/test_trust_threshold_contract.py\: Unit tests for defaults, \rom_mapping\, \has_repo_evidence\ variants, no-crosscheck caps
- \	ests/unit/tools/mcp/test_mcp_wave14_surrealdb_mode.py\: Adapter-path integration tests for derived signals

## Verification

- \uff check\ passes (no new violations)
- \lack\ formatting applied
- All 71 tests pass (22 trust_threshold + 49 wave14 surrealdb mode)

Closes #3458