### PR TITLE
fix(evidence): mark stale sleeping coordinator runs inconclusive

### DIFF
--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_72H_OPS_VALIDATION.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_72H_OPS_VALIDATION.md
@@ -69,6 +69,15 @@ used only after the real dry run finishes.
 - boot-readiness PASS or justified WARN
 - no side effects
 
+### INCONCLUSIVE (FAIL with classification)
+
+A run that ended before the required window but with all-PASS cycles and
+no final validation marker receives a dedicated `INCONCLUSIVE` finding.
+Example: Slice-B (68.5h, 259/259 PASS cycles, 0 failures, crashed during
+sleep). Partial evidence is preserved but does not satisfy the `>=72h`
+requirement. The run is marked FAIL with an `INCONCLUSIVE` explanation so
+it is never confused with a clean PASS or a cycle-failure FAIL.
+
 ### WARN
 
 - minor cadence drift
@@ -78,7 +87,7 @@ used only after the real dry run finishes.
 
 ### FAIL
 
-- window shorter than required
+- window shorter than required (includes INCONCLUSIVE classification)
 - missing or malformed required artifacts
 - write-audit FAIL
 - watchdog FAIL

--- a/tests/unit/tools/evidence_harvester/test_ops_validation.py
+++ b/tests/unit/tools/evidence_harvester/test_ops_validation.py
@@ -967,6 +967,133 @@ class TestValidate72hWindowFromDir:
         assert any("fail threshold" in f.message for f in report.findings)
 
     @pytest.mark.unit
+    def test_fail_inconclusive_when_sleeping_overdue_no_final(
+        self, tmp_path: Path
+    ) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        events_path = tmp_path / "coordinator_events.jsonl"
+        events = [
+            json.loads(line)
+            for line in events_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        events = [
+            e
+            for e in events
+            if e.get("event_type")
+            not in ("final_validation_started", "final_validation_completed")
+        ]
+        last_ts = events[-1]["event_at_utc"] if events else _ts(start)
+        events.append(
+            {
+                "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+                "event_at_utc": last_ts,
+                "run_id": "test-run",
+                "event_type": "sleep_started",
+            }
+        )
+        events_path.write_text(
+            "\n".join(json.dumps(e, sort_keys=True) for e in events) + "\n",
+            encoding="utf-8",
+        )
+        state_path = tmp_path / "runner_state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["coordinator_status"] = "sleeping"
+        state["next_cycle_due_at_utc"] = _ts(start - timedelta(seconds=60))
+        state["total_failed_cycles"] = 0
+        state_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=72,
+            runner_cadence_seconds=3600,
+        )
+        assert any(
+            "Run outcome: INCONCLUSIVE" in f.check_name and f.severity == "fail"
+            for f in report.findings
+        )
+
+    @pytest.mark.unit
+    def test_inconclusive_not_raised_when_valid_run(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=2,
+            runner_cadence_seconds=3600,
+        )
+        assert not any(
+            "Run outcome: INCONCLUSIVE" in f.check_name for f in report.findings
+        )
+
+    @pytest.mark.unit
+    def test_inconclusive_not_raised_when_non_final(self, tmp_path: Path) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        events_path = tmp_path / "coordinator_events.jsonl"
+        events = [
+            json.loads(line)
+            for line in events_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        events = [
+            e
+            for e in events
+            if e.get("event_type")
+            not in ("final_validation_started", "final_validation_completed")
+        ]
+        last_ts = events[-1]["event_at_utc"] if events else _ts(start)
+        events.append(
+            {
+                "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+                "event_at_utc": last_ts,
+                "run_id": "test-run",
+                "event_type": "sleep_started",
+            }
+        )
+        events_path.write_text(
+            "\n".join(json.dumps(e, sort_keys=True) for e in events) + "\n",
+            encoding="utf-8",
+        )
+        state_path = tmp_path / "runner_state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["coordinator_status"] = "sleeping"
+        state["next_cycle_due_at_utc"] = _ts(start - timedelta(seconds=60))
+        state_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=72,
+            runner_cadence_seconds=3600,
+            is_final=False,
+        )
+        assert not any(
+            "Run outcome: INCONCLUSIVE" in f.check_name for f in report.findings
+        )
+
+    @pytest.mark.unit
+    def test_inconclusive_not_raised_with_final_validation(
+        self, tmp_path: Path
+    ) -> None:
+        start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
+        _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)
+        state_path = tmp_path / "runner_state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["coordinator_status"] = "sleeping"
+        state["next_cycle_due_at_utc"] = _ts(start - timedelta(seconds=60))
+        state_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+
+        report = validate_72h_window_from_dir(
+            tmp_path,
+            required_window_hours=72,
+            runner_cadence_seconds=3600,
+        )
+        assert not any(
+            "Run outcome: INCONCLUSIVE" in f.check_name for f in report.findings
+        )
+
+    @pytest.mark.unit
     def test_warn_on_missing_sleep_completed(self, tmp_path: Path) -> None:
         start = datetime(2026, 6, 19, 0, 0, tzinfo=UTC)
         _write_valid_run(tmp_path, start=start, hours=2, cadence_seconds=3600)

--- a/tools/evidence_harvester/ops_validation.py
+++ b/tools/evidence_harvester/ops_validation.py
@@ -1187,6 +1187,80 @@ def _check_coordinator_events(
     )
 
 
+def _check_inconclusive_run(
+    state_payload: Mapping[str, Any] | None,
+    coordinator_events: Sequence[Mapping[str, Any]],
+    observed_window_hours: float,
+    required_window_hours: int,
+    add_finding: Any,
+) -> None:
+    if state_payload is None:
+        return
+    coordinator_status = str(state_payload.get("coordinator_status", "") or "")
+    next_due = str(state_payload.get("next_cycle_due_at_utc", "") or "")
+    has_final_validation = any(
+        e.get("event_type") == "final_validation_started" for e in coordinator_events
+    )
+    observed_cycles = state_payload.get("total_cycles_completed", 0) or 0
+    failed_cycles = state_payload.get("total_failed_cycles", 0) or 0
+    reached_72h = observed_window_hours >= required_window_hours
+    all_pass = isinstance(failed_cycles, int) and failed_cycles == 0
+
+    overdue = False
+    if coordinator_status == "sleeping" and next_due:
+        try:
+            due_at = _parse_ts(next_due, "next_cycle_due_at_utc")
+            if _now_utc() > due_at:
+                overdue = True
+        except OpsValidationError:
+            overdue = True
+
+    if (
+        not reached_72h
+        and not has_final_validation
+        and all_pass
+        and observed_cycles >= 1
+    ):
+        add_finding(
+            "Run outcome: INCONCLUSIVE",
+            "fail",
+            (
+                f"Run ended inconclusively after {observed_window_hours:.2f}h "
+                f"({observed_cycles}/{required_window_hours}h minimum) with "
+                f"{observed_cycles} all-PASS cycles and 0 failed cycles, "
+                f"but no final validation marker exists. "
+                f"Coordinator status was {coordinator_status!r}. "
+                f"Partial evidence is preserved but does not satisfy the "
+                f"{required_window_hours}h requirement."
+            ),
+            artifact="runner_state.json",
+            field_name="coordinator_status",
+        )
+        return
+
+    if (
+        coordinator_status == "sleeping"
+        and overdue
+        and not has_final_validation
+        and not reached_72h
+    ):
+        add_finding(
+            "Run outcome: INCONCLUSIVE (interrupted during sleep)",
+            "fail",
+            (
+                f"Run ended inconclusively: coordinator was sleeping "
+                f"(cycle {observed_cycles}) with overdue next_cycle_due_at_utc "
+                f"({next_due}) but no final validation was ever started. "
+                f"This matches the pattern of a host/process crash during sleep. "
+                f"Partial evidence ({observed_window_hours:.2f}h, {observed_cycles} "
+                f"all-PASS cycles, 0 failures) is preserved but does not satisfy "
+                f"the {required_window_hours}h requirement."
+            ),
+            artifact="runner_state.json",
+            field_name="coordinator_status",
+        )
+
+
 def _check_sleep_lifecycle_completeness(
     events: Sequence[Mapping[str, Any]],
     state_payload: Mapping[str, Any] | None,
@@ -1551,6 +1625,14 @@ def validate_72h_window(
     observed_start, observed_end, observed_hours = _check_window_coverage(
         snapshot_timestamps, required_window_hours, add_finding
     )
+    if is_final:
+        _check_inconclusive_run(
+            state_payload,
+            coordinator_events,
+            observed_hours,
+            required_window_hours,
+            add_finding,
+        )
     if snapshot_timestamps:
         _check_cadence_series(
             "Snapshot", snapshot_timestamps, runner_cadence_seconds, add_finding


### PR DESCRIPTION
Closes #3461

## Root Cause
The coordinator can die during \sleep\ (Windows/Docker/host crash). After death, the \unner_state.json\ shows \coordinator_status: sleeping\ and \
ext_cycle_due_at_utc\ is overdue, but no \inal_validation_started\ event exists and no final marker is written. Previous runs (e.g. Slice-B) remained \SLICE_B_INCONCLUSIVE_CRASHED\ without explicit detection.

## Delivered
- Added \_check_inconclusive_run()\ to \ops_validation.py\: detects the pattern of sleeping + overdue next_cycle_due + missing final validation + all-PASS cycles and produces a FAIL finding with a clear INCONCLUSIVE explanation.
- A second INCONCLUSIVE branch covers any <72h all-PASS run without final marker.
- Both checks only fire in \--is-final\ mode (not during mid-run non-final validation).
- 4 new unit tests covering:
  - Sleeping + overdue + missing final → INCONCLUSIVE fail
  - Valid full run → no INCONCLUSIVE finding
  - Non-final validation → no INCONCLUSIVE finding
  - Sleeping + overdue but final validation exists → no INCONCLUSIVE finding
- Updated the 72h ops validation runbook with INCONCLUSIVE contract documentation.

## Tests / Validation
- \python -m pytest tests/unit/tools/evidence_harvester/\: 239 passed
- \uff check tools/evidence_harvester/ tests/unit/tools/evidence_harvester/\: clean
- \lack --check\: clean
- \git diff --check\: clean

## Safety Boundaries
- No coordinator, runner, watchdog, or write_audit code was modified.
- INCONCLUSIVE detection is read-only (ops_validation post-hoc analysis only).
- No automatic recovery, no restart, no supervisor logic.
- No Docker/runtime/DB/secrets mutation.
- LR remains NO-GO.
- No Live/Echtgeld-Go.

## Non-Goals
- No supervisor or Task Scheduler implementation.
- No automatic recovery from crash.
- No new 72h run.
- No coordinator restart.
- No change to #3362, #3384, or #3345 status.

## Restunsicherheiten
- \_check_inconclusive_run()\ uses \_now_utc()\ for the overdue check, so realtime clock must be accurate at validation time.
- The INCONCLUSIVE detection only works post-hoc via \ops_validation validate-dir --is-final\, not during the run itself (watchdog already covers live STALE_NEXT_CYCLE).