### PR TITLE
test(context): reuse wave14 local briefing proof

### DIFF
--- a/docs/runbooks/surrealdb_context_import.md
+++ b/docs/runbooks/surrealdb_context_import.md
@@ -16,7 +16,7 @@ This runbook describes how to drive the Wave-10 Context Importer (`tools/surreal
 - Validate them as read-only input.
 - Build a deterministic import plan.
 - Reconcile the plan against an explicit local "existing records" snapshot in dry-run mode.
-- Optionally execute a **gated, in-memory local-dev apply** with tombstone-only deletions.
+- Optionally execute a **gated local-dev apply** with tombstone-only deletions.
 - Inspect the audit report.
 
 Out of scope for this runbook:
@@ -24,7 +24,7 @@ Out of scope for this runbook:
 - Production SurrealDB activation.
 - Default writes to any SurrealDB instance.
 - Live-trading, risk, execution, governance, or runtime state.
-- A real SurrealDB adapter (`real_surrealdb_adapter_available = false` in this slice).
+- Automatic or implicit DB activation.
 - MCP bridge, Agent-Briefing engine, vector search, or query CLI (Wave 11+).
 
 ---
@@ -39,7 +39,7 @@ This runbook explicitly does **not** establish or imply any of the following:
 - No trading-state, risk, execution, or governance tables are touched (forbidden-tables list is fail-closed).
 - No Live-Readiness change. LR verdict remains **NO-GO** for live trading independent of this runbook.
 - No Echtgeld-Go. Wave-10 completion does not authorize real capital.
-- No real SurrealDB adapter is installed, registered, or selectable through CLI.
+- No implicit real SurrealDB adapter is used by default.
 - No secrets, real tokens, or production URLs are used in any example.
 
 If any of the steps below appear to require production credentials, a real SurrealDB endpoint, or a real network call, **stop**. The Wave-10 importer is intentionally local/dev only.
@@ -57,8 +57,9 @@ Required:
 
 Not required:
 
-- Docker is **not** required for the dry-run / local-dev apply paths. The default adapter is in-memory and offline.
-- A running SurrealDB instance is **not** required. The importer never opens a real network connection in this slice.
+- Docker is **not** required for validation, planning, or dry-run reconcile.
+- A running SurrealDB instance is **not** required when you stay on the default in-memory adapter.
+- A running local SurrealDB instance **is** required only for the explicit local proof/apply path that passes `--adapter surrealdb-local`.
 - No production secrets, no live API keys.
 
 If you choose to run a local SurrealDB container later for Wave-11+ query work, that is **out of scope** here.
@@ -67,7 +68,12 @@ If you choose to run a local SurrealDB container later for Wave-11+ query work, 
 
 ## 4. SurrealDB Local/Dev Posture
 
-Even though no real SurrealDB is contacted, the importer parses URL/namespace/database arguments and validates them against config. Use only local/dev placeholders:
+The importer supports two local/dev postures:
+
+- **Default CLI posture**: in-memory adapter, no DB network access.
+- **Explicit local proof posture**: `--adapter surrealdb-local` with a localhost-only URL, local secrets, and the local-dev apply gate.
+
+In both cases, use only local/dev values:
 
 - `--surreal-url` and `surreal_url` in YAML must be a local/dev placeholder, e.g. `ws://127.0.0.1:8000/rpc`. Do not paste a production URL.
 - Namespace must be the Context Intelligence namespace (the example config uses `cdb_ctx`).
@@ -175,12 +181,12 @@ The reconcile output classifies each candidate as `create`, `update`, `skip` (un
 
 ## 9. Step 5 - Gated Local-Dev Apply (Optional)
 
-Apply is **off by default** and requires four explicit flags simultaneously: `--apply`, `--apply-mode local-dev`, `--config`, plus `--input-dir` and `--run-id`. The default adapter is the **in-memory mock adapter**; no real SurrealDB instance is contacted, no real network is opened. Any missing gate yields Exit `5` (`WRITE_DENIED`).
+Apply is **off by default** and requires four explicit flags simultaneously: `--apply`, `--apply-mode local-dev`, `--config`, plus `--input-dir` and `--run-id`. If `--adapter` is omitted, the default adapter stays **in-memory** and no DB connection is opened. The repo's local proof path opts in explicitly with `--adapter surrealdb-local`. Any missing gate yields Exit `5` (`WRITE_DENIED`).
 
 Example:
 
 ```bash
-# example, not production - in-memory adapter, no network
+# example, not production - explicit local-only SurrealDB apply path
 python tools/surrealdb/context_importer.py apply \
   --apply \
   --apply-mode local-dev \
@@ -188,6 +194,8 @@ python tools/surrealdb/context_importer.py apply \
   --input-dir temp/context-index/run \
   --existing-records temp/context-index/existing.json \
   --run-id wave10-local-dev-1 \
+  --adapter surrealdb-local \
+  --secrets-path "$SECRETS_PATH" \
   --report-output artifacts/apply/report.json \
   --audit-output artifacts/audit/apply.json
 ```
@@ -195,9 +203,16 @@ python tools/surrealdb/context_importer.py apply \
 Important:
 
 - `--apply-mode` accepts only `local-dev`. argparse rejects any other value.
-- The importer reports `real_surrealdb_adapter_available: false` and `surrealdb_writes: in-memory-only` in the apply report.
+- The importer defaults to the in-memory adapter unless `--adapter surrealdb-local` is passed.
+- The `surrealdb-local` adapter remains fail-closed and localhost-only; remote URLs are rejected.
 - If the loaded config has `allow_apply_default: true`, the loader fails closed.
 - Forbidden-table writes are blocked at config load time, not at apply time.
+
+For the repo-backed local proof path, reuse the existing operator surfaces instead of building a second seed engine:
+
+- `make context-query-config-init` creates the gitignored local query config at `infrastructure/config/surrealdb/context_query.local.yaml`.
+- `tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.py` seeds a small run-scoped Wave-14 bundle via `context_importer.py` and proves the DB-backed read path.
+- `adapter_config_path` remains an explicit operator opt-in for MCP/briefing calls; there is no implicit MCP default or auto-discovery.
 
 ---
 

--- a/docs/runbooks/surrealdb_context_mcp_access.md
+++ b/docs/runbooks/surrealdb_context_mcp_access.md
@@ -211,6 +211,41 @@ python -m tools.surrealdb.context_onboarding_doctor --format json
 - Issue #2642 prüft optional `127.0.0.1:8811` (HTTP MCP host).
 - Separater remote `cdb`-Server in OpenCode nutzt laut Runbook-Hinweis `127.0.0.1:8812/mcp` — nicht mit #2642 verwechseln.
 
+### 1.5.2. Local DB-backed briefing proof (reuse-first)
+
+For a real local `context.briefing` / `cdb_context_briefing` proof, reuse the existing local SurrealDB surfaces instead of inventing a new seed or config layer:
+
+1. Create the gitignored local query config once:
+
+```bash
+make context-query-config-init
+```
+
+This creates `infrastructure/config/surrealdb/context_query.local.yaml` from the tracked example. The MCP/briefing path stays **explicit opt-in**: pass `adapter_config_path` to that local file. There is **no** implicit MCP default and **no** auto-discovery in the briefing handler.
+
+2. Ensure the local secrets path contains `SURREALDB_ENV` for the local-only context DB.
+
+3. Run the existing reuse-first local proof:
+
+```bash
+pytest -v tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.py -m local_only
+```
+
+What this proves:
+- run-scoped rows are seeded into local `cdb_context_local` / `cdb_context_intel`
+- Wave-14 MCP tools read them back with `metadata.source = surrealdb-local`
+- `context.briefing` derives `brain_source = surrealdb-local` and `brain_status = used`
+- trust remains adapter-derived and fail-closed; the proof does not promise HIGH and may still resolve to LOW or MEDIUM depending on the current trust signals
+
+What this does **not** prove:
+- no Live-Go, no Echtgeld-Go, no LR change
+- no productive or remote DB writes
+- no registry-only result may be confused with DB-backed evidence
+
+Evidence distinction:
+- **Registry-only / bridge-only**: tool is registered, handler resolves, no DB rows required.
+- **DB-backed evidence**: explicit `adapter_config_path` + local config + local secrets + actual local rows returned from SurrealDB.
+
 **Cross-repo root inventory** (#2853) — deterministische Tabelle für Working-Repo und
 konfigurierte Sibling-/Extern-Roots (lokal vs. GitHub getrennt; kein Clone):
 

--- a/tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.py
+++ b/tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.py
@@ -33,6 +33,7 @@ from tests.local.tools.mcp.wave14_smoke_helpers import (
     resolve_smoke_run_id,
     smoke_tmp_root,
 )
+from tools.mcp.context_bridge import create_bridge
 from tools.mcp.context_decision_tools import (
     TOOL_CDB_CONTEXT_DECISION_HISTORY,
     TOOL_CDB_CONTEXT_DECISION_REPLAY,
@@ -302,6 +303,43 @@ def _run_handler_smoke_checks(seeded_bundle: dict[str, Any]) -> None:
     _assert_no_secret_leak(trust, secrets_path=secrets_path)
     assert trust["result"]["evidence_strength"] != "none", trust
 
+    briefing_trust = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                **common,
+                "scope": "wave14",
+            },
+        }
+    )
+    _assert_ok_source(briefing_trust, TOOL_CDB_CONTEXT_TRUST_SUMMARY)
+    _assert_no_secret_leak(briefing_trust, secrets_path=secrets_path)
+    expected_operator_trust_level = briefing_trust["result"]["operator_trust_level"]
+
+    bridge = create_bridge()
+    briefing = bridge.execute_tool(
+        "context.briefing",
+        {
+            "task_id": "wave14-real-surrealdb-briefing-proof",
+            "task_scope": "Verify local DB-backed context briefing proof path.",
+            "target_issue": "#3468",
+            "requested_depth": "quick",
+            "operation_mode": "read_only",
+            "adapter_config_path": str(_QUERY_CONFIG_PATH),
+            "secrets_path": str(secrets_path),
+        },
+    )
+    assert briefing["status"] == "ok", briefing
+    _assert_no_secret_leak(briefing, secrets_path=secrets_path)
+    session_context = briefing["briefing"]["session_context"]
+    assert session_context["brain_source"] == "surrealdb-local", briefing
+    assert session_context["brain_status"] == "used", briefing
+    assert session_context["agent_operating_mode"]["db_claims_allowed"] is True
+    assert (
+        briefing["briefing"]["operator_trust_level"] == expected_operator_trust_level
+    ), briefing
+    assert "surrealdb-local" in briefing["briefing"]["trust_summary"], briefing
+
 
 @pytest.fixture(scope="module")
 def seeded_bundle() -> dict[str, Any]:
@@ -431,6 +469,48 @@ def test_wave14_real_surrealdb_local_trust_summary_ok(
     assert result["result"]["claim_status_summary"].get("supported", 0) >= 1, result
     assert result["result"]["memory_trust_summary"]["total"] >= 1, result
     assert result["result"]["decision_currentness"]["total"] >= 1, result
+
+
+def test_wave14_real_surrealdb_local_context_briefing_ok(
+    seeded_bundle: dict[str, Any],
+) -> None:
+    expected_trust = handle_cdb_context_trust_summary(
+        {
+            "tool": TOOL_CDB_CONTEXT_TRUST_SUMMARY,
+            "parameters": {
+                **_common_parameters(Path(seeded_bundle["secrets_path"])),
+                "scope": "wave14",
+            },
+        }
+    )
+    _assert_ok_source(expected_trust, TOOL_CDB_CONTEXT_TRUST_SUMMARY)
+
+    bridge = create_bridge()
+    result = bridge.execute_tool(
+        "context.briefing",
+        {
+            "task_id": "wave14-real-surrealdb-briefing-proof",
+            "task_scope": "Verify local DB-backed context briefing proof path.",
+            "target_issue": "#3468",
+            "requested_depth": "quick",
+            "operation_mode": "read_only",
+            "adapter_config_path": str(_QUERY_CONFIG_PATH),
+            "secrets_path": seeded_bundle["secrets_path"],
+        },
+    )
+
+    assert result["status"] == "ok", result
+    _assert_no_secret_leak(result, secrets_path=Path(seeded_bundle["secrets_path"]))
+    briefing = result["briefing"]
+    session_context = briefing["session_context"]
+    assert session_context["brain_source"] == "surrealdb-local", result
+    assert session_context["brain_status"] == "used", result
+    assert session_context["agent_operating_mode"]["db_claims_allowed"] is True
+    assert (
+        briefing["operator_trust_level"]
+        == expected_trust["result"]["operator_trust_level"]
+    ), result
+    assert "surrealdb-local" in briefing["trust_summary"], result
 
 
 def test_wave14_real_smoke_cleanup_proof(seeded_bundle: dict[str, Any]) -> None:

--- a/tests/local/tools/mcp/wave14_smoke_helpers.py
+++ b/tests/local/tools/mcp/wave14_smoke_helpers.py
@@ -7,7 +7,9 @@ assertions, and targeted cleanup via the local SurrealDB /sql endpoint.
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
+from datetime import datetime, timedelta, timezone
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -18,6 +20,7 @@ import urllib.parse
 import urllib.request
 from typing import Any
 
+from core.utils.clock import utcnow as cdb_utcnow
 from tools.surrealdb.context_importer import TABLE_BY_ARTIFACT
 from tools.surrealdb.gen_run_id import _timestamp_run_id
 
@@ -43,6 +46,15 @@ _BASE_EVIDENCE_ID = "ev-wave14-real-001"
 _BASE_CLAIM_ID = "claim-wave14-real-001"
 _BASE_MEMORY_ID = "mem-wave14-real-001"
 _BASE_DECISION_IDS = ("dec-wave14-real-001", "dec-wave14-real-002")
+
+_FRESH_MEMORY_TTL_SECONDS = int(timedelta(days=30).total_seconds())
+_FRESH_MEMORY_STALE_AFTER_SECONDS = int(timedelta(days=7).total_seconds())
+_CREATED_AT_BASE_OFFSETS_SECONDS = {
+    "evidence_refs.jsonl": 240,
+    "claims.jsonl": 180,
+    "decision_events.jsonl": 120,
+    "agent_memories.jsonl": 30,
+}
 
 _ID_REFERENCE_FIELDS = frozenset(
     {
@@ -143,21 +155,98 @@ def _replace_record_fields(
     return updated
 
 
+def _normalize_materialized_at(materialized_at: datetime | None) -> datetime:
+    now = materialized_at if materialized_at is not None else cdb_utcnow()
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = now.astimezone(timezone.utc)
+    return now.replace(microsecond=0)
+
+
+def _isoformat_z(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def _repo_file_sha256(relative_path: str) -> str:
+    normalized = relative_path.strip().replace("\\", "/")
+    if not normalized or normalized.startswith("/") or ".." in normalized.split("/"):
+        raise ValueError(f"invalid repo-relative source_path for Wave-14 smoke: {relative_path!r}")
+
+    target = (_REPO_ROOT / normalized).resolve()
+    repo_root = _REPO_ROOT.resolve()
+    try:
+        target.relative_to(repo_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"source_path escapes repo root for Wave-14 smoke: {relative_path!r}"
+        ) from exc
+
+    if not target.is_file():
+        raise FileNotFoundError(
+            f"source_path does not resolve to a repo file for Wave-14 smoke: {relative_path!r}"
+        )
+
+    return hashlib.sha256(target.read_bytes()).hexdigest()
+
+
+def _apply_dynamic_seed_fields(
+    filename: str,
+    record: dict[str, Any],
+    *,
+    item_index: int,
+    materialized_at: datetime,
+) -> dict[str, Any]:
+    updated = dict(record)
+
+    created_at = materialized_at - timedelta(
+        seconds=max(_CREATED_AT_BASE_OFFSETS_SECONDS.get(filename, 0) - item_index * 30, 0)
+    )
+    updated["created_at"] = _isoformat_z(created_at)
+
+    source_path = updated.get("source_path")
+    if isinstance(source_path, str) and source_path.strip() and "source_hash" in updated:
+        updated["source_hash"] = _repo_file_sha256(source_path)
+
+    if filename == "evidence_refs.jsonl":
+        updated["collected_at"] = _isoformat_z(created_at)
+        updated["freshness"] = "fresh"
+    elif filename == "agent_memories.jsonl":
+        updated["ttl"] = _FRESH_MEMORY_TTL_SECONDS
+        if "stale_after" in updated:
+            updated["stale_after"] = _FRESH_MEMORY_STALE_AFTER_SECONDS
+        updated["expires_at"] = _isoformat_z(
+            materialized_at + timedelta(seconds=_FRESH_MEMORY_TTL_SECONDS)
+        )
+
+    return updated
+
+
 def materialize_fixture_records(
     filename: str,
     *,
     run_id: str,
     plan: Wave14SmokeRecordPlan,
+    materialized_at: datetime | None = None,
 ) -> str:
     path = _FIXTURE_DIR / filename
     id_map = _id_remap(plan)
+    effective_now = _normalize_materialized_at(materialized_at)
     records: list[str] = []
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
+    for item_index, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines()):
         if not raw_line.strip():
             continue
         record = json.loads(raw_line)
         record["run_id"] = run_id
         record = _replace_record_fields(record, id_map)
+        record = _apply_dynamic_seed_fields(
+            filename,
+            record,
+            item_index=item_index,
+            materialized_at=effective_now,
+        )
         records.append(json.dumps(record, ensure_ascii=True, sort_keys=True))
     return "\n".join(records) + ("\n" if records else "")
 

--- a/tests/unit/tools/mcp/test_wave14_smoke_helpers.py
+++ b/tests/unit/tools/mcp/test_wave14_smoke_helpers.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from tests.local.tools.mcp.wave14_smoke_helpers import (
+    _FRESH_MEMORY_STALE_AFTER_SECONDS,
+    _FRESH_MEMORY_TTL_SECONDS,
+    build_record_plan,
+    materialize_fixture_records,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _load_single_record(text: str) -> dict[str, object]:
+    records = [json.loads(line) for line in text.splitlines() if line.strip()]
+    assert len(records) == 1
+    return records[0]
+
+
+def test_materialize_fixture_records_refreshes_evidence_hash_and_timestamps() -> None:
+    fixed_now = datetime(2026, 6, 29, 12, 0, 0, tzinfo=timezone.utc)
+    plan = build_record_plan("wave14-real-smoke-unit")
+
+    record = _load_single_record(
+        materialize_fixture_records(
+            "evidence_refs.jsonl",
+            run_id=plan.run_id,
+            plan=plan,
+            materialized_at=fixed_now,
+        )
+    )
+
+    source_path = Path(str(record["source_path"]))
+    expected_hash = hashlib.sha256(source_path.read_bytes()).hexdigest()
+
+    assert record["run_id"] == plan.run_id
+    assert record["evidence_id"] == plan.evidence_ids[0]
+    assert record["source_hash"] == expected_hash
+    assert record["created_at"] == "2026-06-29T11:56:00Z"
+    assert record["collected_at"] == "2026-06-29T11:56:00Z"
+    assert record["freshness"] == "fresh"
+
+
+def test_materialize_fixture_records_keeps_memory_fresh_for_local_proof() -> None:
+    fixed_now = datetime(2026, 6, 29, 12, 0, 0, tzinfo=timezone.utc)
+    plan = build_record_plan("wave14-real-smoke-unit")
+
+    record = _load_single_record(
+        materialize_fixture_records(
+            "agent_memories.jsonl",
+            run_id=plan.run_id,
+            plan=plan,
+            materialized_at=fixed_now,
+        )
+    )
+
+    assert record["run_id"] == plan.run_id
+    assert record["memory_id"] == plan.memory_ids[0]
+    assert record["created_at"] == "2026-06-29T11:59:30Z"
+    assert record["ttl"] == _FRESH_MEMORY_TTL_SECONDS
+    assert record["stale_after"] == _FRESH_MEMORY_STALE_AFTER_SECONDS
+    assert record["expires_at"] == (
+        fixed_now + timedelta(seconds=_FRESH_MEMORY_TTL_SECONDS)
+    ).isoformat().replace("+00:00", "Z")

--- a/tools/surrealdb/context_importer.py
+++ b/tools/surrealdb/context_importer.py
@@ -22,8 +22,9 @@ Design rules enforced here:
   ``--apply``, or ``--apply`` on a non-apply subcommand) is hard-blocked
   with exit code 5 (``WRITE_DENIED``).
 * The default apply adapter is the in-memory, no-network
-  ``InMemoryContextApplyAdapter``. A real SurrealDB adapter is
-  explicitly OUT-OF-SCOPE in this slice and is not wired into the CLI.
+  ``InMemoryContextApplyAdapter``.
+* A real local SurrealDB adapter is available only behind the explicit
+  opt-in gate ``--adapter surrealdb-local`` and remains local-dev only.
 * The local-dev apply gate additionally requires the loaded config's
   ``surreal_url`` host to be in ``LOCAL_DEV_ALLOWED_HOSTS``.
 * Tombstone handling is field-only (``tombstoned``, ``tombstoned_at``,


### PR DESCRIPTION
Closes #3468
Refs #3466

## Summary
- refresh Wave-14 local smoke seed materialization with fresh timestamps and repo-backed source hashes
- add local DB-backed context.briefing proof coverage without introducing any implicit adapter default
- reconcile the SurrealDB import/MCP runbooks with the existing explicit local surrealdb-local proof path

## Validation
- pytest -v tests/unit/tools/mcp/test_wave14_smoke_helpers.py
- pytest -v tests/unit/surrealdb/test_local_query_config_init.py
- pytest -v tests/unit/surrealdb/test_wave14_context_record_schemas.py
- pytest -v tests/unit/tools/mcp/test_mcp_briefing_enrichment.py
- pytest -v tests/unit/tools/mcp/test_context_bridge.py
- pytest -v tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.py -m local_only with CDB_RUN_REAL_SURREALDB_SMOKE=1
- ruff check tests/local/tools/mcp/wave14_smoke_helpers.py tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.py tools/surrealdb/context_importer.py tests/unit/tools/mcp/test_wave14_smoke_helpers.py
- git diff --check
- rg -n 'PERSIST_ALLOWED|MUTATION_ALLOWED|surrealdb-local|evidence_ref|decision_event|agent_memory|claim|adapter_config_path|operator_trust_level' tools tests docs scripts