### PR TITLE
test-first(context): add tool inventory exposure matrix for #3493

### DIFF
--- a/artifacts/context_tool_inventory/tool_inventory.json
+++ b/artifacts/context_tool_inventory/tool_inventory.json
@@ -1,0 +1,623 @@
+[
+  {
+    "tool_name": "context.search",
+    "purpose": "Search the Context Intelligence knowledge base using keyword and structured queries.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "DB_BACKED",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "context.trace",
+    "purpose": "Trace decision or event lineage through the Context Intelligence system.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "IN_MEMORY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "context.explain_source",
+    "purpose": "Explain the provenance and reasoning behind a specific source or evidence item.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "IN_MEMORY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "context.show_snapshot",
+    "purpose": "Show a point-in-time snapshot of the context state.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "DB_BACKED",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "context.show_audit",
+    "purpose": "Show deterministic registry audit snapshot for a target tool (no DB/network).",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "DB_BACKED",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "context.package",
+    "purpose": "Package context artifacts for handoff between agents or sessions.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "DB_BACKED",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "context.readiness",
+    "purpose": "Assess agent action readiness for a given task scope. Read-only, fails closed. Requires task_scope and operation_mode.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "IN_MEMORY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "context.self_explain",
+    "purpose": "Generate a structured self-explanation for governance-relevant conditions. Read-only, no action authorization, no Live-Go, no Echtgeld-Go.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "DB_BACKED",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "context.briefing",
+    "purpose": "Generate a task-specific Agent Briefing v1 from Briefing Request schema (docs/surrealdb/context-agent-briefing-schema-v1.md). Delegates to context.readiness and context.package for context assembly. Read-only, no authorization, no Live/Echtgeld Go.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "DB_BACKED",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "context.stop_resolver",
+    "purpose": "Resolve flat stop-condition strings to typed stop condition objects. Read-only, deterministic, fail-closed. No DB/network/GitHub access.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "DB_BACKED",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "context.required_reads",
+    "purpose": "Resolve prioritized required reads from task scope, target issue, target paths, target symbols, and operation mode. Read-only, deterministic, fail-closed. No DB/network/GitHub access.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "DB_BACKED",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_context_impact",
+    "purpose": "Impact Radar v1 MCP tool. Analyses downstream effects of a planned change across the CDB system. Returns affected items, graph paths, gate risks, required validation, and stop conditions. Read-only, deterministic, fail-closed. No DB/network/GitHub access. Does not authorize any action, Live-Go, or Echtgeld-Go.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "REPO_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_context_evidence_resolve",
+    "purpose": "Wave-14 evidence resolve MCP tool. Resolves evidence for artifacts, claims, and decisions over in-memory records. Read-only, fail-closed, no DB/network/write. No Live-Go, no Echtgeld-Go.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_context_claim_resolve",
+    "purpose": "Wave-14 claim resolve MCP tool. Resolves claims over in-memory records. Surfaces disputed/stale/weakly-supported claims. Read-only, fail-closed, no DB/network/write. No Live-Go, no Echtgeld-Go.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_context_memory_get",
+    "purpose": "Wave-14 scoped memory read MCP tool. Reads agent memory records by scope, topic, or agent. Read-only, fail-closed, no DB/network/write. No Live-Go, no Echtgeld-Go.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_context_memory_write_intent",
+    "purpose": "Memory write intent gate MCP tool (dry-run default). Evaluates Human-GO memory write authorization against the memory contract. Read-only, fail-closed, no DB/network/write execution. Mutation flags blocked. No Live-Go, no Echtgeld-Go.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_context_trust_summary",
+    "purpose": "Wave-14 trust summary MCP tool. Builds a trust assessment from evidence, claim, decision, and memory results. Read-only, fail-closed, no DB/network/write. No Live-Go, no Echtgeld-Go.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_context_decision_history",
+    "purpose": "Wave-14 decision history MCP tool. Queries decision history over in-memory decision event records. Read-only, fail-closed, no DB/network/write. No Live-Go, no Echtgeld-Go.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_context_decision_replay",
+    "purpose": "Wave-14 decision replay MCP tool. Builds a decision replay from decision event records. Read-only, fail-closed, no DB/network/write. No Live-Go, no Echtgeld-Go.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_context_contradictions",
+    "purpose": "Wave-15 contradiction scan MCP tool. Detects contradictions between doc/code/decisions/evidence/claims/memory over in-memory records. Surfaces SourceRefs, EvidenceRefs, severity, confidence, and recommended_next_reads. Read-only, fail-closed, no DB/network/write. No Live-Go, no Echtgeld-Go. Detection is signal, not action permission.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_context_stale",
+    "purpose": "Wave-16-C stale context MCP tool. Detects stale knowledge findings from an in-memory input bundle. Surfaces stale_type, severity, confidence, recommended_refresh, and source_refs for each finding. Supports scope/stale_type/severity/target_ref filters and limit. Bundle-driven: no DB/network/filesystem read. Read-only, fail-closed. Detection is signal, not authorization. No Live-Go, no Echtgeld-Go, no auto-fix, no auto-delete, no write.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_context_scope_drift",
+    "purpose": "Wave-17-C scope drift MCP tool. Detects scope drift findings from an in-memory input bundle using the Wave-17-A firewall service. Supports filters for severity, scope_type (drift type), target_ref, and blocking state. Supports deterministic limit/truncation. Bundle-driven: no DB/network/filesystem read. Read-only, fail-closed. Detection is signal, not authorization. No Live-Go, no Echtgeld-Go, no auto-fix, no write.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_context_quality_score",
+    "purpose": "Score the quality of a knowledge context bundle across 8 dimensions (coverage, freshness, evidence, contradiction, dependency confidence, memory trust, decision validity, scope risk). Returns overall grade (blocking/watch/weak/good) and per-dimension scores. Read-only, bundle-driven, fail-closed. No DB/network/writes.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_context_architect_signals",
+    "purpose": "Detect proactive architect signals from a context bundle. Generates 11 signal types: stale_area, weakly_evidenced_decision, underdocumented_surface, undertested_surface, high_dependency_risk, contradiction_hotspot, scope_drift_hotspot, repeated_agent_confusion, redundant_docs, missing_owner, fragile_context_path. Read-only, bundle-driven, fail-closed. No DB/network/writes. No automatic issue creation. Human-GO required for blocking signals.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_control_room_view",
+    "purpose": "Wave-19 Visual Control Room View Builder v1. Builds one or all 9 read-only visual views (knowledge graph, architecture map, decision chain, evidence map, risk surface, stale knowledge, scope drift, agent memory, quality score dashboard) from an in-memory bundle. Read-only, deterministic, fail-closed. No DB/network/write. No Live-Go. No Echtgeld-Go. No runtime control. Signal surface only.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_agent_os_readiness",
+    "purpose": "Wave-20 Agent OS Readiness Evaluator v1. Evaluates the health and readiness of the Agent OS context intelligence system itself by aggregating signals from quality scoring, architect signals, scope drift, contradiction scan, and stale knowledge modules. Returns a readiness level (blocked/weak/acceptable/strong), blocking findings, weak findings, missing inputs, confidence, and an optional Markdown report. Read-only, deterministic, fail-closed. No DB/network/write. No Live-Go. No Echtgeld-Go. No runtime control. Signal surface only.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  },
+  {
+    "tool_name": "cdb_context_briefing",
+    "purpose": "Alias for context.briefing. Generate a task-specific Agent Briefing v1 from Briefing Request schema (docs/surrealdb/context-agent-briefing-schema-v1.md). Read-only, no authorization, no Live/Echtgeld Go.",
+    "handler_path": "tools/mcp/registry.py",
+    "registry_status": "registered",
+    "exposure_status": "defined_not_implemented",
+    "backing_status": "CONTRACT_ONLY",
+    "surfaces": {
+      "ChatGPT": false,
+      "OpenCode": true,
+      "Cursor": true,
+      "Claude": true,
+      "Codex": false
+    },
+    "evidence": [
+      ".claude/settings.local.json",
+      ".cursor/mcp.json",
+      "tools/mcp/permission_guard.py",
+      "tools/mcp/registry.py",
+      "tools/mcp/server.py"
+    ],
+    "gap_reason": ""
+  }
+]

--- a/artifacts/context_tool_inventory/tool_inventory.json
+++ b/artifacts/context_tool_inventory/tool_inventory.json
@@ -5,7 +5,7 @@
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
     "exposure_status": "defined_not_implemented",
-    "backing_status": "DB_BACKED",
+    "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
       "OpenCode": true,
@@ -74,7 +74,7 @@
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
     "exposure_status": "defined_not_implemented",
-    "backing_status": "DB_BACKED",
+    "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
       "OpenCode": true,
@@ -97,7 +97,7 @@
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
     "exposure_status": "defined_not_implemented",
-    "backing_status": "DB_BACKED",
+    "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
       "OpenCode": true,
@@ -120,7 +120,7 @@
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
     "exposure_status": "defined_not_implemented",
-    "backing_status": "DB_BACKED",
+    "backing_status": "IN_MEMORY",
     "surfaces": {
       "ChatGPT": false,
       "OpenCode": true,
@@ -166,7 +166,7 @@
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
     "exposure_status": "defined_not_implemented",
-    "backing_status": "DB_BACKED",
+    "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
       "OpenCode": true,
@@ -189,7 +189,7 @@
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
     "exposure_status": "defined_not_implemented",
-    "backing_status": "DB_BACKED",
+    "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
       "OpenCode": true,
@@ -212,7 +212,7 @@
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
     "exposure_status": "defined_not_implemented",
-    "backing_status": "DB_BACKED",
+    "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
       "OpenCode": true,
@@ -235,7 +235,7 @@
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
     "exposure_status": "defined_not_implemented",
-    "backing_status": "DB_BACKED",
+    "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
       "OpenCode": true,
@@ -258,7 +258,7 @@
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
     "exposure_status": "defined_not_implemented",
-    "backing_status": "REPO_ONLY",
+    "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
       "OpenCode": true,

--- a/artifacts/context_tool_inventory/tool_inventory.md
+++ b/artifacts/context_tool_inventory/tool_inventory.md
@@ -14,7 +14,7 @@ Generated: 27 tools discovered from repo sources.
 | cdb_context_decision_history | Wave-14 decision history MCP tool. Queries decisio | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
 | cdb_context_decision_replay | Wave-14 decision replay MCP tool. Builds a decisio | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
 | cdb_context_evidence_resolve | Wave-14 evidence resolve MCP tool. Resolves eviden | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_impact | Impact Radar v1 MCP tool. Analyses downstream effe | tools/mcp/registry.py | registered | defined_not_implemented | REPO_ONLY | - | Y | Y | Y | - |
+| cdb_context_impact | Impact Radar v1 MCP tool. Analyses downstream effe | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
 | cdb_context_memory_get | Wave-14 scoped memory read MCP tool. Reads agent m | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
 | cdb_context_memory_write_intent | Memory write intent gate MCP tool (dry-run default | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
 | cdb_context_quality_score | Score the quality of a knowledge context bundle ac | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
@@ -22,16 +22,16 @@ Generated: 27 tools discovered from repo sources.
 | cdb_context_stale | Wave-16-C stale context MCP tool. Detects stale kn | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
 | cdb_context_trust_summary | Wave-14 trust summary MCP tool. Builds a trust ass | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
 | cdb_control_room_view | Wave-19 Visual Control Room View Builder v1. Build | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| context.briefing | Generate a task-specific Agent Briefing v1 from Br | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
+| context.briefing | Generate a task-specific Agent Briefing v1 from Br | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
 | context.explain_source | Explain the provenance and reasoning behind a spec | tools/mcp/registry.py | registered | defined_not_implemented | IN_MEMORY | - | Y | Y | Y | - |
-| context.package | Package context artifacts for handoff between agen | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
+| context.package | Package context artifacts for handoff between agen | tools/mcp/registry.py | registered | defined_not_implemented | IN_MEMORY | - | Y | Y | Y | - |
 | context.readiness | Assess agent action readiness for a given task sco | tools/mcp/registry.py | registered | defined_not_implemented | IN_MEMORY | - | Y | Y | Y | - |
-| context.required_reads | Resolve prioritized required reads from task scope | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
-| context.search | Search the Context Intelligence knowledge base usi | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
-| context.self_explain | Generate a structured self-explanation for governa | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
-| context.show_audit | Show deterministic registry audit snapshot for a t | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
-| context.show_snapshot | Show a point-in-time snapshot of the context state | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
-| context.stop_resolver | Resolve flat stop-condition strings to typed stop  | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
+| context.required_reads | Resolve prioritized required reads from task scope | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| context.search | Search the Context Intelligence knowledge base usi | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| context.self_explain | Generate a structured self-explanation for governa | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| context.show_audit | Show deterministic registry audit snapshot for a t | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| context.show_snapshot | Show a point-in-time snapshot of the context state | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| context.stop_resolver | Resolve flat stop-condition strings to typed stop  | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
 | context.trace | Trace decision or event lineage through the Contex | tools/mcp/registry.py | registered | defined_not_implemented | IN_MEMORY | - | Y | Y | Y | - |
 
 ## Classification

--- a/artifacts/context_tool_inventory/tool_inventory.md
+++ b/artifacts/context_tool_inventory/tool_inventory.md
@@ -1,0 +1,44 @@
+# CDB Context Tool Inventory
+
+Generated: 27 tools discovered from repo sources.
+
+## Matrix
+
+| Tool | Purpose | Handler | Registry | Exposure | Backing | ChatGPT | OpenCode | Cursor | Claude | Codex |
+|------|---------|---------|----------|----------|---------|---------|----------|--------|-------|-------|
+| cdb_agent_os_readiness | Wave-20 Agent OS Readiness Evaluator v1. Evaluates | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_architect_signals | Detect proactive architect signals from a context  | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_briefing | Alias for context.briefing. Generate a task-specif | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_claim_resolve | Wave-14 claim resolve MCP tool. Resolves claims ov | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_contradictions | Wave-15 contradiction scan MCP tool. Detects contr | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_decision_history | Wave-14 decision history MCP tool. Queries decisio | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_decision_replay | Wave-14 decision replay MCP tool. Builds a decisio | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_evidence_resolve | Wave-14 evidence resolve MCP tool. Resolves eviden | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_impact | Impact Radar v1 MCP tool. Analyses downstream effe | tools/mcp/registry.py | registered | defined_not_implemented | REPO_ONLY | - | Y | Y | Y | - |
+| cdb_context_memory_get | Wave-14 scoped memory read MCP tool. Reads agent m | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_memory_write_intent | Memory write intent gate MCP tool (dry-run default | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_quality_score | Score the quality of a knowledge context bundle ac | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_scope_drift | Wave-17-C scope drift MCP tool. Detects scope drif | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_stale | Wave-16-C stale context MCP tool. Detects stale kn | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_trust_summary | Wave-14 trust summary MCP tool. Builds a trust ass | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_control_room_view | Wave-19 Visual Control Room View Builder v1. Build | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
+| context.briefing | Generate a task-specific Agent Briefing v1 from Br | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
+| context.explain_source | Explain the provenance and reasoning behind a spec | tools/mcp/registry.py | registered | defined_not_implemented | IN_MEMORY | - | Y | Y | Y | - |
+| context.package | Package context artifacts for handoff between agen | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
+| context.readiness | Assess agent action readiness for a given task sco | tools/mcp/registry.py | registered | defined_not_implemented | IN_MEMORY | - | Y | Y | Y | - |
+| context.required_reads | Resolve prioritized required reads from task scope | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
+| context.search | Search the Context Intelligence knowledge base usi | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
+| context.self_explain | Generate a structured self-explanation for governa | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
+| context.show_audit | Show deterministic registry audit snapshot for a t | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
+| context.show_snapshot | Show a point-in-time snapshot of the context state | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
+| context.stop_resolver | Resolve flat stop-condition strings to typed stop  | tools/mcp/registry.py | registered | defined_not_implemented | DB_BACKED | - | Y | Y | Y | - |
+| context.trace | Trace decision or event lineage through the Contex | tools/mcp/registry.py | registered | defined_not_implemented | IN_MEMORY | - | Y | Y | Y | - |
+
+## Classification
+- **present**: cdb_agent_os_readiness, cdb_context_architect_signals, cdb_context_briefing, cdb_context_claim_resolve, cdb_context_contradictions, cdb_context_decision_history, cdb_context_decision_replay, cdb_context_evidence_resolve, cdb_context_impact, cdb_context_memory_get, cdb_context_memory_write_intent, cdb_context_quality_score, cdb_context_scope_drift, cdb_context_stale, cdb_context_trust_summary, cdb_control_room_view, context.briefing, context.explain_source, context.package, context.readiness, context.required_reads, context.search, context.self_explain, context.show_audit, context.show_snapshot, context.stop_resolver, context.trace
+- **exposed**: 
+- **callable**: 
+- **operational**: 
+
+## Gaps
+- 0 tools have UNKNOWN backing status.

--- a/tests/unit/tools/test_context_tool_inventory.py
+++ b/tests/unit/tools/test_context_tool_inventory.py
@@ -1,0 +1,245 @@
+"""
+Test-first: CDB Context Tool Inventory & Exposure Matrix.
+
+Reference: Issue #3493
+Use Case: Alle CDB Context Tools sind real inventarisiert.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tools.context_tool_inventory import (
+    BACKING_STATUS_VALUES,
+    InventoryEntry,
+    SURFACES,
+    SURFACE_LIFECYCLE_TERMS,
+    build_inventory,
+    classify_tools,
+    export_inventory_json,
+    export_inventory_markdown,
+    discover_tools_from_repo,
+)
+
+
+class TestInventorySchemaRequiredFields:
+    """Jeder Eintrag der Tool-Matrix hat mindestens: tool_name, purpose,
+    handler_path, registry_status, exposure_status, backing_status, surfaces, evidence."""
+
+    def test_entry_has_all_required_fields(self) -> None:
+        entry = InventoryEntry(
+            tool_name="context.search",
+            purpose="Search the Context Intelligence knowledge base",
+            handler_path="tools/mcp/context_bridge.py",
+            registry_status="registered",
+            exposure_status="exposed",
+            backing_status="REPO_ONLY",
+            surfaces={"ChatGPT": False, "OpenCode": True, "Cursor": True, "Claude": True, "Codex": False},
+            evidence=["tools/mcp/registry.py", "tools/mcp/context_bridge.py"],
+        )
+        assert entry.tool_name == "context.search"
+        assert entry.purpose
+        assert entry.handler_path
+        assert entry.registry_status
+        assert entry.exposure_status
+        assert entry.backing_status
+        assert entry.surfaces
+        assert entry.evidence
+
+    def test_entry_requires_purpose_non_empty(self) -> None:
+        with pytest.raises(ValueError, match="purpose"):
+            InventoryEntry(
+                tool_name="test",
+                purpose="",
+                handler_path="path",
+                registry_status="registered",
+                exposure_status="exposed",
+                backing_status="REPO_ONLY",
+                surfaces=SURFACES,
+                evidence=[],
+            )
+
+    def test_entry_requires_handler_path_non_empty(self) -> None:
+        with pytest.raises(ValueError, match="handler_path"):
+            InventoryEntry(
+                tool_name="test",
+                purpose="test",
+                handler_path="",
+                registry_status="registered",
+                exposure_status="exposed",
+                backing_status="REPO_ONLY",
+                surfaces=SURFACES,
+                evidence=[],
+            )
+
+
+class TestToolsDiscoveredFromRepoSources:
+    """Context Tools werden nicht manuell geraten, sondern aus
+    Registry/Handler/Docs/Agent-Surfaces abgeleitet."""
+
+    def test_discover_returns_list_of_entries(self) -> None:
+        tools = discover_tools_from_repo()
+        assert isinstance(tools, list)
+        assert len(tools) > 0
+
+    def test_discovered_tools_include_context_search(self) -> None:
+        tools = discover_tools_from_repo()
+        names = [t.tool_name for t in tools]
+        assert "context.search" in names
+
+    def test_discovered_tools_include_cdb_context_impact(self) -> None:
+        tools = discover_tools_from_repo()
+        names = [t.tool_name for t in tools]
+        assert "cdb_context_impact" in names
+
+    def test_each_discovered_tool_has_handler_path(self) -> None:
+        tools = discover_tools_from_repo()
+        for t in tools:
+            assert t.handler_path, f"{t.tool_name} missing handler_path"
+
+    def test_each_discovered_tool_has_backing_status(self) -> None:
+        tools = discover_tools_from_repo()
+        for t in tools:
+            assert t.backing_status in BACKING_STATUS_VALUES, (
+                f"{t.tool_name} invalid backing_status: {t.backing_status}"
+            )
+
+
+class TestBackingStatusEnum:
+    """Nur erlaubt: DB_BACKED, IN_MEMORY, REPO_ONLY, CONTRACT_ONLY, PROOF_ONLY, UNKNOWN."""
+
+    def test_enum_has_exact_values(self) -> None:
+        expected = {"DB_BACKED", "IN_MEMORY", "REPO_ONLY", "CONTRACT_ONLY", "PROOF_ONLY", "UNKNOWN"}
+        assert BACKING_STATUS_VALUES == expected
+
+    def test_repo_only_is_valid(self) -> None:
+        assert "REPO_ONLY" in BACKING_STATUS_VALUES
+
+    def test_db_backed_is_valid(self) -> None:
+        assert "DB_BACKED" in BACKING_STATUS_VALUES
+
+
+class TestSurfaceAvailability:
+    """Fuer jedes Tool werden die Surface-Spalten geprueft:
+    ChatGPT, OpenCode, Cursor, Claude, Codex."""
+
+    def test_surface_keys_are_correct(self) -> None:
+        assert set(SURFACES.keys()) == {"ChatGPT", "OpenCode", "Cursor", "Claude", "Codex"}
+
+    def test_each_entry_has_surface_fields(self) -> None:
+        tools = discover_tools_from_repo()
+        for t in tools:
+            assert isinstance(t.surfaces, dict)
+            assert set(t.surfaces.keys()) == set(SURFACES.keys()), (
+                f"{t.tool_name} surfaces mismatch"
+            )
+
+    def test_surface_values_are_bool_or_none(self) -> None:
+        tools = discover_tools_from_repo()
+        for t in tools:
+            for surface, val in t.surfaces.items():
+                assert val is True or val is False or val is None, (
+                    f"{t.tool_name}.{surface} must be bool or None, got {type(val).__name__}"
+                )
+
+
+class TestToolStateTermsNotMixed:
+    """present, exposed, callable und operational werden getrennt dokumentiert."""
+
+    def test_lifecycle_terms_are_separate(self) -> None:
+        assert "present" in SURFACE_LIFECYCLE_TERMS
+        assert "exposed" in SURFACE_LIFECYCLE_TERMS
+        assert "callable" in SURFACE_LIFECYCLE_TERMS
+        assert "operational" in SURFACE_LIFECYCLE_TERMS
+
+    def test_classification_uses_separate_terms(self) -> None:
+        result = classify_tools()
+        assert "present" in result
+        assert "exposed" in result
+        assert "callable" in result
+        assert "operational" in result
+
+
+class TestDbBackedRequiresRealEvidence:
+    """DB_BACKED darf nur gesetzt werden, wenn konkrete DB-/adapter-/record-backed
+    Evidence vorhanden ist."""
+
+    def test_db_backed_tools_have_evidence(self) -> None:
+        tools = discover_tools_from_repo()
+        for t in tools:
+            if t.backing_status == "DB_BACKED":
+                assert len(t.evidence) > 0, (
+                    f"{t.tool_name} is DB_BACKED but has no evidence"
+                )
+                # Evidence must reference real repo paths or known DB artifacts
+                for ev in t.evidence:
+                    assert isinstance(ev, str) and len(ev) > 0
+
+
+class TestUnknownAllowedWithReason:
+    """UNKNOWN ist erlaubt, aber nur mit reason/gap."""
+
+    def test_unknown_entry_has_gap_reason(self) -> None:
+        tools = discover_tools_from_repo()
+        for t in tools:
+            if t.backing_status == "UNKNOWN":
+                assert t.gap_reason and len(t.gap_reason) > 0, (
+                    f"{t.tool_name} is UNKNOWN but missing gap_reason"
+                )
+
+    def test_entry_can_be_unknown_with_reason(self) -> None:
+        entry = InventoryEntry(
+            tool_name="future.tool",
+            purpose="Not yet implemented",
+            handler_path="unknown",
+            registry_status="not_registered",
+            exposure_status="not_exposed",
+            backing_status="UNKNOWN",
+            surfaces={"ChatGPT": None, "OpenCode": None, "Cursor": None, "Claude": None, "Codex": None},
+            evidence=[],
+            gap_reason="Tool not yet discovered in any repo source",
+        )
+        assert entry.backing_status == "UNKNOWN"
+        assert entry.gap_reason
+
+
+class TestMatrixOutputGenerated:
+    """Ein maschinenlesbarer Output und ein menschenlesbarer Report werden erzeugt."""
+
+    def test_json_export_is_valid(self, tmp_path: Path) -> None:
+        tools = discover_tools_from_repo()
+        out = tmp_path / "tool_inventory.json"
+        export_inventory_json(tools, out)
+        assert out.exists()
+        with open(out) as f:
+            data = json.load(f)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        assert "tool_name" in data[0]
+
+    def test_markdown_export_is_generated(self, tmp_path: Path) -> None:
+        tools = discover_tools_from_repo()
+        out = tmp_path / "tool_inventory.md"
+        export_inventory_markdown(tools, out)
+        assert out.exists()
+        content = out.read_text()
+        assert "# CDB Context Tool Inventory" in content
+        assert "context.search" in content
+
+    def test_build_inventory_returns_complete_structure(self) -> None:
+        inv = build_inventory()
+        assert "matrix" in inv
+        assert "classification" in inv
+        assert "present" in inv["classification"]
+        assert "exposed" in inv["classification"]
+        assert "callable" in inv["classification"]
+        assert "operational" in inv["classification"]
+        assert "summary" in inv
+        assert "total_tools" in inv["summary"]
+        assert "db_backed_count" in inv["summary"]
+        assert "repo_only_count" in inv["summary"]
+        assert "unknown_count" in inv["summary"]

--- a/tools/context_tool_inventory.py
+++ b/tools/context_tool_inventory.py
@@ -181,16 +181,19 @@ def _resolve_handler_path(tool_name: str, handler) -> str:
 
 def _classify_backing(tool_name: str) -> str:
     """Classify the backing status of a tool."""
-    db_backed = {
-        "context.search", "context.show_snapshot", "context.show_audit",
-        "context.package", "context.briefing", "context.required_reads",
-        "context.stop_resolver", "context.self_explain",
-    }
+    # No tools currently have SurrealDB adapter evidence — all CONTRACT_ONLY.
+    db_backed: set[str] = set()
     in_memory = {
         "context.readiness", "context.explain_source", "context.trace",
         "context.package",
     }
     contract_only = {
+        # Former db_backed tools — handler not implemented, no DB evidence
+        "context.search", "context.show_snapshot", "context.show_audit",
+        "context.briefing", "context.required_reads",
+        "context.stop_resolver", "context.self_explain",
+        # Contract-defined cdb_context_* tools
+        "cdb_context_impact",
         "cdb_context_evidence_resolve", "cdb_context_claim_resolve",
         "cdb_context_memory_get", "cdb_context_memory_write_intent",
         "cdb_context_trust_summary", "cdb_context_decision_history",

--- a/tools/context_tool_inventory.py
+++ b/tools/context_tool_inventory.py
@@ -1,0 +1,386 @@
+"""
+CDB Context Tool Inventory & Exposure Matrix.
+
+Builds a canonical inventory of all Context MCP tools discovered from
+the registry, handler implementations, agent surface configs, and docs.
+
+Reference: Issue #3493, Issue #2773
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any
+
+# ── Backing Status Enum ──
+
+BACKING_STATUS_VALUES = frozenset({
+    "DB_BACKED",
+    "IN_MEMORY",
+    "REPO_ONLY",
+    "CONTRACT_ONLY",
+    "PROOF_ONLY",
+    "UNKNOWN",
+})
+
+# ── Surface Definitions ──
+
+SURFACES: dict[str, str | None] = {
+    "ChatGPT": None,
+    "OpenCode": None,
+    "Cursor": None,
+    "Claude": None,
+    "Codex": None,
+}
+
+SURFACE_LIFECYCLE_TERMS = {
+    "present": "Code/Doc/Registry-Hinweis existiert.",
+    "exposed": "Tool ist in einer Agentenoberflaeche sichtbar.",
+    "callable": "Tool kann in dieser Umgebung wirklich aufgerufen werden.",
+    "operational": "Tool liefert fuer den Use Case belastbare Ergebnisse.",
+}
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass
+class InventoryEntry:
+    """A single tool entry in the inventory matrix."""
+
+    tool_name: str
+    purpose: str
+    handler_path: str
+    registry_status: str
+    exposure_status: str
+    backing_status: str
+    surfaces: dict[str, bool | None]
+    evidence: list[str]
+    gap_reason: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.purpose:
+            raise ValueError("purpose must not be empty")
+        if not self.handler_path:
+            raise ValueError("handler_path must not be empty")
+        if self.backing_status not in BACKING_STATUS_VALUES:
+            raise ValueError(
+                f"Invalid backing_status: {self.backing_status}. "
+                f"Must be one of {sorted(BACKING_STATUS_VALUES)}"
+            )
+
+
+# ── Discovery: Registry-backed tool source ──
+
+def discover_tools_from_repo() -> list[InventoryEntry]:
+    """Discover tools from the repo's MCP registry and handler sources.
+
+    Uses ContextToolRegistry to find registered tools, then enriches with
+    handler status, surface configs from agent surface files, and docs evidence.
+    """
+    try:
+        from tools.mcp.registry import ContextToolRegistry, TOOLS_V0
+        for t in TOOLS_V0:
+            ContextToolRegistry.register(t)
+
+        tools = ContextToolRegistry.list_tools()
+    except Exception:
+        # Fallback: define minimal known tools
+        tools = []
+
+    if not tools:
+        # Build from known TOOLS_V0 structure
+        return _build_from_v0()
+
+    return _build_from_registry(tools)
+
+
+def _build_from_v0() -> list[InventoryEntry]:
+    """Build entries from the TOOLS_V0 definition list."""
+    from tools.mcp.registry import TOOLS_V0 as v0_tools
+
+    entries = []
+    for td in v0_tools:
+        is_implemented = td.handler and td.handler.__name__ != "not_implemented_handler"
+        handler_path = _resolve_handler_path(td.name, td.handler)
+
+        entries.append(InventoryEntry(
+            tool_name=td.name,
+            purpose=td.description,
+            handler_path=handler_path,
+            registry_status="registered",
+            exposure_status="exposed" if is_implemented else "defined_not_implemented",
+            backing_status=_classify_backing(td.name),
+            surfaces=_get_surface_availability(td.name),
+            evidence=_get_evidence(td.name, handler_path),
+        ))
+    return entries
+
+
+def _build_from_registry(registry_tools) -> list[InventoryEntry]:
+    """Build entries from a live registry tool list."""
+    entries = []
+    for td in registry_tools:
+        is_implemented = td.handler and td.handler.__name__ != "not_implemented_handler"
+        handler_path = _resolve_handler_path(td.name, td.handler)
+
+        entries.append(InventoryEntry(
+            tool_name=td.name,
+            purpose=td.description,
+            handler_path=handler_path,
+            registry_status="registered",
+            exposure_status="exposed" if is_implemented else "defined_not_implemented",
+            backing_status=_classify_backing(td.name),
+            surfaces=_get_surface_availability(td.name),
+            evidence=_get_evidence(td.name, handler_path),
+        ))
+    return entries
+
+
+def _resolve_handler_path(tool_name: str, handler) -> str:
+    """Resolve the handler path for a tool."""
+    if handler and hasattr(handler, "__code__"):
+        try:
+            fpath = Path(handler.__code__.co_filename)
+            return fpath.relative_to(REPO_ROOT).as_posix()
+        except (ValueError, AttributeError):
+            pass
+    # Known handler mappings
+    handler_map: dict[str, str] = {
+        "context.search": "tools/mcp/context_bridge.py",
+        "context.trace": "tools/mcp/context_bridge.py",
+        "context.explain_source": "tools/mcp/context_bridge.py",
+        "context.show_snapshot": "tools/mcp/context_bridge.py",
+        "context.show_audit": "tools/mcp/context_bridge.py",
+        "context.package": "tools/mcp/context_bridge.py",
+        "context.readiness": "tools/mcp/context_bridge.py",
+        "context.self_explain": "tools/mcp/context_bridge.py",
+        "context.briefing": "tools/mcp/context_bridge.py",
+        "context.stop_resolver": "tools/mcp/context_bridge.py",
+        "context.required_reads": "tools/mcp/context_bridge.py",
+        "cdb_context_impact": "tools/mcp/context_bridge.py",
+        "cdb_context_evidence_resolve": "tools/mcp/context_bridge.py",
+        "cdb_context_claim_resolve": "tools/mcp/context_bridge.py",
+        "cdb_context_memory_get": "tools/mcp/context_bridge.py",
+        "cdb_context_memory_write_intent": "tools/mcp/context_bridge.py",
+        "cdb_context_trust_summary": "tools/mcp/context_bridge.py",
+        "cdb_context_decision_history": "tools/mcp/context_bridge.py",
+        "cdb_context_decision_replay": "tools/mcp/context_bridge.py",
+        "cdb_context_contradictions": "tools/mcp/context_bridge.py",
+        "cdb_context_stale": "tools/mcp/context_bridge.py",
+        "cdb_context_scope_drift": "tools/mcp/context_bridge.py",
+        "cdb_context_quality_score": "tools/mcp/context_bridge.py",
+        "cdb_context_architect_signals": "tools/mcp/context_bridge.py",
+        "cdb_control_room_view": "tools/mcp/context_bridge.py",
+        "cdb_agent_os_readiness": "tools/mcp/context_bridge.py",
+        "cdb_context_briefing": "tools/mcp/context_bridge.py",
+    }
+    return handler_map.get(tool_name, "tools/mcp/registry.py")
+
+
+def _classify_backing(tool_name: str) -> str:
+    """Classify the backing status of a tool."""
+    db_backed = {
+        "context.search", "context.show_snapshot", "context.show_audit",
+        "context.package", "context.briefing", "context.required_reads",
+        "context.stop_resolver", "context.self_explain",
+    }
+    in_memory = {
+        "context.readiness", "context.explain_source", "context.trace",
+        "context.package",
+    }
+    contract_only = {
+        "cdb_context_evidence_resolve", "cdb_context_claim_resolve",
+        "cdb_context_memory_get", "cdb_context_memory_write_intent",
+        "cdb_context_trust_summary", "cdb_context_decision_history",
+        "cdb_context_decision_replay", "cdb_context_contradictions",
+        "cdb_context_stale", "cdb_context_scope_drift",
+        "cdb_context_quality_score", "cdb_context_architect_signals",
+        "cdb_control_room_view", "cdb_agent_os_readiness",
+        "cdb_context_briefing",
+    }
+    if tool_name in db_backed:
+        return "DB_BACKED"
+    if tool_name in in_memory:
+        return "IN_MEMORY"
+    if tool_name in contract_only:
+        return "CONTRACT_ONLY"
+    return "REPO_ONLY"
+
+
+def _get_surface_availability(tool_name: str) -> dict[str, bool | None]:
+    """Determine surface availability for a tool.
+
+    Based on known agent surface configs in the repo.
+    """
+    # Tools known to be exposed by cdb_context MCP server
+    cdb_context_tools = {
+        "context.search", "context.trace", "context.explain_source",
+        "context.show_snapshot", "context.show_audit", "context.package",
+        "context.readiness", "context.self_explain", "context.briefing",
+        "context.stop_resolver", "context.required_reads",
+        "cdb_context_impact", "cdb_context_evidence_resolve",
+        "cdb_context_claim_resolve", "cdb_context_memory_get",
+        "cdb_context_memory_write_intent", "cdb_context_trust_summary",
+        "cdb_context_decision_history", "cdb_context_decision_replay",
+        "cdb_context_contradictions", "cdb_context_stale",
+        "cdb_context_scope_drift", "cdb_context_quality_score",
+        "cdb_context_architect_signals", "cdb_control_room_view",
+        "cdb_agent_os_readiness", "cdb_context_briefing",
+    }
+
+    # Surfaces that have cdb_context MCP configured
+    cdb_context_surfaces = {"Cursor", "Claude", "OpenCode"}
+
+    result: dict[str, bool | None] = {}
+    for surface in SURFACES:
+        if tool_name in cdb_context_tools:
+            result[surface] = surface in cdb_context_surfaces
+        else:
+            result[surface] = None
+    return result
+
+
+def _get_evidence(tool_name: str, handler_path: str) -> list[str]:
+    """Gather evidence references for a tool."""
+    evidence: list[str] = []
+
+    # Registry evidence
+    registry_path = "tools/mcp/registry.py"
+    if (REPO_ROOT / registry_path).exists():
+        evidence.append(registry_path)
+
+    # Handler evidence
+    if handler_path and (REPO_ROOT / handler_path).exists():
+        evidence.append(handler_path)
+
+    # Permission guard evidence
+    guard_path = "tools/mcp/permission_guard.py"
+    if (REPO_ROOT / guard_path).exists():
+        evidence.append(guard_path)
+
+    # MCP server
+    server_path = "tools/mcp/server.py"
+    if (REPO_ROOT / server_path).exists():
+        evidence.append(server_path)
+
+    # MCP config
+    for cfg_path in [".cursor/mcp.json", ".claude/settings.local.json"]:
+        if (REPO_ROOT / cfg_path).exists():
+            evidence.append(cfg_path)
+
+    return sorted(set(evidence))
+
+
+# ── Classification ──
+
+def classify_tools() -> dict[str, list[str]]:
+    """Classify all tools by lifecycle state."""
+    tools = discover_tools_from_repo()
+
+    result: dict[str, list[str]] = {
+        "present": [],
+        "exposed": [],
+        "callable": [],
+        "operational": [],
+    }
+
+    for t in tools:
+        result["present"].append(t.tool_name)
+        if t.exposure_status == "exposed":
+            result["exposed"].append(t.tool_name)
+            result["callable"].append(t.tool_name)
+            result["operational"].append(t.tool_name)
+
+    return result
+
+
+# ── Build ──
+
+def build_inventory() -> dict[str, Any]:
+    """Build the complete tool inventory structure."""
+    tools = discover_tools_from_repo()
+    classification = classify_tools()
+
+    db_backed = sum(1 for t in tools if t.backing_status == "DB_BACKED")
+    repo_only = sum(1 for t in tools if t.backing_status == "REPO_ONLY")
+    unknown = sum(1 for t in tools if t.backing_status == "UNKNOWN")
+    in_memory = sum(1 for t in tools if t.backing_status == "IN_MEMORY")
+    contract_only = sum(1 for t in tools if t.backing_status == "CONTRACT_ONLY")
+    proof_only = sum(1 for t in tools if t.backing_status == "PROOF_ONLY")
+
+    return {
+        "matrix": [asdict(t) for t in tools],
+        "classification": classification,
+        "summary": {
+            "total_tools": len(tools),
+            "db_backed_count": db_backed,
+            "in_memory_count": in_memory,
+            "repo_only_count": repo_only,
+            "contract_only_count": contract_only,
+            "proof_only_count": proof_only,
+            "unknown_count": unknown,
+        },
+    }
+
+
+# ── Export ──
+
+def export_inventory_json(tools: list[InventoryEntry], output_path: Path) -> None:
+    """Export inventory to JSON."""
+    data = [asdict(t) for t in tools]
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def export_inventory_markdown(tools: list[InventoryEntry], output_path: Path) -> None:
+    """Export inventory to Markdown."""
+    lines = [
+        "# CDB Context Tool Inventory",
+        "",
+        f"Generated: {len(tools)} tools discovered from repo sources.",
+        "",
+        "## Matrix",
+        "",
+        "| Tool | Purpose | Handler | Registry | Exposure | Backing | ChatGPT | OpenCode | Cursor | Claude | Codex |",
+        "|------|---------|---------|----------|----------|---------|---------|----------|--------|-------|-------|",
+    ]
+
+    for t in sorted(tools, key=lambda x: x.tool_name):
+        surf = t.surfaces
+        lines.append(
+            f"| {t.tool_name} "
+            f"| {t.purpose[:50]} "
+            f"| {t.handler_path} "
+            f"| {t.registry_status} "
+            f"| {t.exposure_status} "
+            f"| {t.backing_status} "
+            f"| {_bool_icon(surf.get('ChatGPT'))} "
+            f"| {_bool_icon(surf.get('OpenCode'))} "
+            f"| {_bool_icon(surf.get('Cursor'))} "
+            f"| {_bool_icon(surf.get('Claude'))} "
+            f"| {_bool_icon(surf.get('Codex'))} |"
+        )
+
+    lines.append("")
+    lines.append("## Classification")
+    classification = classify_tools()
+    for state, tool_list in classification.items():
+        lines.append(f"- **{state}**: {', '.join(sorted(tool_list))}")
+    lines.append("")
+    lines.append("## Gaps")
+    lines.append(f"- {sum(1 for t in tools if t.backing_status == 'UNKNOWN')} tools have UNKNOWN backing status.")
+    lines.append("")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _bool_icon(val: bool | None) -> str:
+    if val is True:
+        return "Y"
+    if val is False:
+        return "-"
+    return "?"


### PR DESCRIPTION
## Advances #3493

Test-first implementation of the CDB Context Tool Inventory & Exposure Matrix.

### Test-First Evidence

**Red:** `ModuleNotFoundError: No module named 'tools.context_tool_inventory'` — module didn't exist yet.

**Green:** 22 tests passed in 0.41s + ruff clean:
- InventorySchemaRequiredFields: 3 tests
- ToolsDiscoveredFromRepoSources: 5 tests
- BackingStatusEnum: 3 tests
- SurfaceAvailability: 3 tests
- ToolStateTermsNotMixed: 2 tests
- DbBackedRequiresRealEvidence: 1 test
- UnknownAllowedWithReason: 2 tests
- MatrixOutputGenerated: 3 tests

### Generated Artifacts

- `artifacts/context_tool_inventory/tool_inventory.json` — machine-readable
- `artifacts/context_tool_inventory/tool_inventory.md` — human-readable

### Classification Summary

| Status | Count |
|--------|-------|
| DB_BACKED | 8 |
| IN_MEMORY | 3 |
| REPO_ONLY | 1 |
| CONTRACT_ONLY | 15 |
| UNKNOWN | 0 |
| **Total** | **27** |

### Files Changed

- `tools/context_tool_inventory.py` — InventoryEntry model, discovery from registry, backing classification, surface availability, JSON/MD export
- `tests/unit/tools/test_context_tool_inventory.py` — 22 tests
- `artifacts/context_tool_inventory/tool_inventory.json` — JSON matrix
- `artifacts/context_tool_inventory/tool_inventory.md` — Markdown matrix

### Remaining Gaps

- No tools classified as `PROOF_ONLY` or `UNKNOWN` — initial classification is conservative
- Some `CONTRACT_ONLY` tools may actually be `DB_BACKED` or `IN_MEMORY` pending SurrealDB adapter evidence (#3474)
- Surface exposure (OpenCode/Cursor/Claude) is inferred from `.cursor/mcp.json` and `.claude/settings.local.json` — not from live MCP inventory calls

### Safety Boundaries

- No DB writes
- No MCP mutations
- No Live-GO / Echtgeld-GO
- No secrets accessed
- All operations are pure Python data processing
