### PR TITLE
test-first(skills): activate official SurrealDB skills and rules for #3482

### DIFF
--- a/.claude/skills/surrealdb-python/SKILL.md
+++ b/.claude/skills/surrealdb-python/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: surrealdb-python
+description: "CDB-curated, script-free activation of the official SurrealDB Python skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealDB Python SDK
+
+## Zweck
+
+Nutze diesen Skill fuer den SurrealDB-Python-SDK-Kontext: `Surreal`,
+`AsyncSurreal`, Client/Server-Modus und Embedded-Varianten wie `mem://` oder
+`file://`.
+
+## Wann zuenden
+
+- bei Python-Code mit dem Paket `surrealdb`
+- bei Review von `Surreal(...)` oder `AsyncSurreal(...)`
+- bei Embedded-Nutzung mit `mem://` oder `file://`
+- bei SDK-Fragen zu CRUD, Query-Calls oder Session-Nutzung
+
+## CDB-Kernpunkte
+
+- Beispiele aus Upstream muessen auf CDB-Read-only- und Governance-Grenzen angepasst werden.
+- Keine Zugangsdaten, Root-Defaults oder Startbefehle aus Upstream-Beispielen uebernehmen.
+- Embedded- oder lokale Laufmodi sind kein Signal fuer produktive Freigabe.
+- Dieser Skill bleibt script-frei und autorisiert keine Ausfuehrung.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealdb-python`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Nutze Upstream nur als API- und Pattern-Referenz.
+- Fuer produktive oder DB-backed Behauptungen zaehlt CDB-Evidence vor Beispielcode.
+- Wenn Embedded- oder WebSocket-Verhalten relevant ist, gleiche es mit dem Repo-Canon ab.

--- a/.claude/skills/surrealdb-vector/SKILL.md
+++ b/.claude/skills/surrealdb-vector/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: surrealdb-vector
+description: "CDB-curated, script-free activation of the official SurrealDB vector skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealDB Vector Search
+
+## Zweck
+
+Nutze diesen Skill fuer HNSW-Indexe, KNN-Abfragen, Similarity-Scoring und
+vektorbasierte Retrieval-Muster in SurrealDB.
+
+## Wann zuenden
+
+- bei `DEFINE INDEX ... HNSW`
+- bei KNN-Queries mit `<|K, EF|>`
+- bei Score-/Threshold-Logik fuer RAG oder semantische Suche
+- bei Review von Vector-Schema- oder Embedding-Feldern
+
+## CDB-Kernpunkte
+
+- Dimension, Distanzfunktion und Typ muessen zum Embedding-Vertrag passen.
+- Scoring-Logik gehoert nachvollziehbar dokumentiert und testbar gemacht.
+- Dieser Skill bleibt script-frei und gibt keine Laufzeit- oder Installationsbefehle vor.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealdb-vector`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Halte Vector-Suche strikt getrennt von Runtime- oder Live-Freigaben.
+- Nutze diesen Skill fuer Query- und Schema-Verstaendnis, nicht als Schreibfreigabe.
+- Wenn HNSW-Details von CDB-Vertraegen abweichen, gilt der engere CDB-Vertrag.

--- a/.claude/skills/surrealql/SKILL.md
+++ b/.claude/skills/surrealql/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: surrealql
+description: "CDB-curated, script-free activation of the official SurrealQL agent skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealQL
+
+## Zweck
+
+Nutze diesen Skill fuer SurrealQL-Queries, Schema-Definitionen,
+Graph-Traversals und Syntax-Reviews rund um SurrealDB.
+
+## Wann zuenden
+
+- beim Schreiben oder Pruefen von `.surql`
+- bei `DEFINE TABLE` / `DEFINE FIELD` / `DEFINE INDEX`
+- bei Graph-Relationships und Record-IDs
+- wenn SQL-Denkmuster auf SurrealQL uebersetzt werden muessen
+
+## CDB-Kernpunkte
+
+- SurrealQL ist nicht ANSI-SQL.
+- Fuer aktuelle Syntax gilt die offizielle SurrealDB-Doku als SSOT.
+- Repo-Kanon und CDB-Vertraege haben Vorrang, wenn CDB den Upstream enger fasst.
+- Dieser Skill ist absichtlich script-frei und enthaelt keine Installations- oder
+  Auto-Run-Anweisungen.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealql`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Nutze diesen Skill zusammen mit der offiziellen Doku, wenn Syntax oder
+  Versionsverhalten unklar ist.
+- Wenn CDB-Canon und Upstream-Beispiel kollidieren, stoppe und dokumentiere den
+  Widerspruch statt still zu raten.
+- Fuer Vector- oder Python-SDK-Themen lade den passenden Schwester-Skill.

--- a/.codex/cdb_skills/README.md
+++ b/.codex/cdb_skills/README.md
@@ -35,6 +35,9 @@ Spiegelt die Cursor-Skill-Oberfläche unter [`.cursor/skills/README.md`](../../.
 | [`cdb-docs-ops`](cdb-docs-ops/SKILL.md) | Docs maintenance |
 | [`ctb-docker-stack`](ctb-docker-stack/SKILL.md) | Docker BLUE+RED |
 | [`cdb-ci-cd-guard`](cdb-ci-cd-guard/SKILL.md) | CI/CD guardrails |
+| [`surrealql`](surrealql/SKILL.md) | CDB-curated official SurrealQL skill |
+| [`surrealdb-vector`](surrealdb-vector/SKILL.md) | CDB-curated official vector skill |
+| [`surrealdb-python`](surrealdb-python/SKILL.md) | CDB-curated official Python SDK skill |
 
 ## GitHub helpers
 

--- a/.codex/cdb_skills/surrealdb-python/SKILL.md
+++ b/.codex/cdb_skills/surrealdb-python/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: surrealdb-python
+description: "CDB-curated, script-free activation of the official SurrealDB Python skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealDB Python SDK
+
+## Zweck
+
+Nutze diesen Skill fuer den SurrealDB-Python-SDK-Kontext: `Surreal`,
+`AsyncSurreal`, Client/Server-Modus und Embedded-Varianten wie `mem://` oder
+`file://`.
+
+## Wann zuenden
+
+- bei Python-Code mit dem Paket `surrealdb`
+- bei Review von `Surreal(...)` oder `AsyncSurreal(...)`
+- bei Embedded-Nutzung mit `mem://` oder `file://`
+- bei SDK-Fragen zu CRUD, Query-Calls oder Session-Nutzung
+
+## CDB-Kernpunkte
+
+- Beispiele aus Upstream muessen auf CDB-Read-only- und Governance-Grenzen angepasst werden.
+- Keine Zugangsdaten, Root-Defaults oder Startbefehle aus Upstream-Beispielen uebernehmen.
+- Embedded- oder lokale Laufmodi sind kein Signal fuer produktive Freigabe.
+- Dieser Skill bleibt script-frei und autorisiert keine Ausfuehrung.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealdb-python`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Nutze Upstream nur als API- und Pattern-Referenz.
+- Fuer produktive oder DB-backed Behauptungen zaehlt CDB-Evidence vor Beispielcode.
+- Wenn Embedded- oder WebSocket-Verhalten relevant ist, gleiche es mit dem Repo-Canon ab.

--- a/.codex/cdb_skills/surrealdb-vector/SKILL.md
+++ b/.codex/cdb_skills/surrealdb-vector/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: surrealdb-vector
+description: "CDB-curated, script-free activation of the official SurrealDB vector skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealDB Vector Search
+
+## Zweck
+
+Nutze diesen Skill fuer HNSW-Indexe, KNN-Abfragen, Similarity-Scoring und
+vektorbasierte Retrieval-Muster in SurrealDB.
+
+## Wann zuenden
+
+- bei `DEFINE INDEX ... HNSW`
+- bei KNN-Queries mit `<|K, EF|>`
+- bei Score-/Threshold-Logik fuer RAG oder semantische Suche
+- bei Review von Vector-Schema- oder Embedding-Feldern
+
+## CDB-Kernpunkte
+
+- Dimension, Distanzfunktion und Typ muessen zum Embedding-Vertrag passen.
+- Scoring-Logik gehoert nachvollziehbar dokumentiert und testbar gemacht.
+- Dieser Skill bleibt script-frei und gibt keine Laufzeit- oder Installationsbefehle vor.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealdb-vector`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Halte Vector-Suche strikt getrennt von Runtime- oder Live-Freigaben.
+- Nutze diesen Skill fuer Query- und Schema-Verstaendnis, nicht als Schreibfreigabe.
+- Wenn HNSW-Details von CDB-Vertraegen abweichen, gilt der engere CDB-Vertrag.

--- a/.codex/cdb_skills/surrealql/SKILL.md
+++ b/.codex/cdb_skills/surrealql/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: surrealql
+description: "CDB-curated, script-free activation of the official SurrealQL agent skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealQL
+
+## Zweck
+
+Nutze diesen Skill fuer SurrealQL-Queries, Schema-Definitionen,
+Graph-Traversals und Syntax-Reviews rund um SurrealDB.
+
+## Wann zuenden
+
+- beim Schreiben oder Pruefen von `.surql`
+- bei `DEFINE TABLE` / `DEFINE FIELD` / `DEFINE INDEX`
+- bei Graph-Relationships und Record-IDs
+- wenn SQL-Denkmuster auf SurrealQL uebersetzt werden muessen
+
+## CDB-Kernpunkte
+
+- SurrealQL ist nicht ANSI-SQL.
+- Fuer aktuelle Syntax gilt die offizielle SurrealDB-Doku als SSOT.
+- Repo-Kanon und CDB-Vertraege haben Vorrang, wenn CDB den Upstream enger fasst.
+- Dieser Skill ist absichtlich script-frei und enthaelt keine Installations- oder
+  Auto-Run-Anweisungen.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealql`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Nutze diesen Skill zusammen mit der offiziellen Doku, wenn Syntax oder
+  Versionsverhalten unklar ist.
+- Wenn CDB-Canon und Upstream-Beispiel kollidieren, stoppe und dokumentiere den
+  Widerspruch statt still zu raten.
+- Fuer Vector- oder Python-SDK-Themen lade den passenden Schwester-Skill.

--- a/.cursor/rules/surrealdb-python-embedded.mdc
+++ b/.cursor/rules/surrealdb-python-embedded.mdc
@@ -1,0 +1,17 @@
+---
+description: CDB-curated embedded Python rule derived from the official SurrealDB embedded rule.
+alwaysApply: false
+---
+
+CDB Governance gewinnt vor externer Doku.
+No Live-GO / Echtgeld-GO.
+
+Offizielle Quelle: `https://surrealdb.com/docs/build/ai-agents/agent-rules`
+Inspectierter Rule-Stand: `surrealdb-python-embedded.mdc` aus Commit `a69077df`.
+
+Nutze diese Rule als read-only Orientierung:
+
+- Embedded-Kontexte drehen sich um `mem://` und `file://` im Python-SDK.
+- Behandle Embedded-Beispiele als lokale Referenz, nicht als Produktionspfad.
+- Wenn CDB-Canon einen engeren Betriebsrahmen vorgibt, gilt CDB-Canon.
+- Diese Rule autorisiert keine DB-Writes, keine MCP-Mutationen und keine Laufzeitaktivierung.

--- a/.cursor/rules/surrealdb-python.mdc
+++ b/.cursor/rules/surrealdb-python.mdc
@@ -1,0 +1,17 @@
+---
+description: CDB-curated Python SDK rule derived from the official SurrealDB Python rule.
+alwaysApply: false
+---
+
+CDB Governance gewinnt vor externer Doku.
+No Live-GO / Echtgeld-GO.
+
+Offizielle Quelle: `https://surrealdb.com/docs/build/ai-agents/agent-rules`
+Inspectierter Rule-Stand: `surrealdb-python.mdc` aus Commit `a69077df`.
+
+Nutze diese Rule als read-only Orientierung:
+
+- Richte Python-SDK-Code an `Surreal` und `AsyncSurreal` aus.
+- Uebernehme keine Root-Defaults oder Beispiel-Credentials.
+- Embedded- oder lokale Beispiele muessen auf CDB-Grenzen heruntergebrochen werden.
+- Diese Rule autorisiert keine DB-Writes, keine MCP-Mutationen und keine Runtime-Freigabe.

--- a/.cursor/rules/surrealdb-vector.mdc
+++ b/.cursor/rules/surrealdb-vector.mdc
@@ -1,0 +1,17 @@
+---
+description: CDB-curated vector rule derived from the official SurrealDB vector rule.
+alwaysApply: false
+---
+
+CDB Governance gewinnt vor externer Doku.
+No Live-GO / Echtgeld-GO.
+
+Offizielle Quelle: `https://surrealdb.com/docs/build/ai-agents/agent-rules`
+Inspectierter Rule-Stand: `surrealdb-vector.mdc` aus Commit `a69077df`.
+
+Nutze diese Rule als read-only Orientierung:
+
+- HNSW-Indexe brauchen passende `DIMENSION`, `DIST` und `TYPE`.
+- Trenne Query-Logik, Score-Berechnung und Thresholds klar voneinander.
+- Behandle Vector-Muster als Schema-/Query-Hilfe, nicht als Freigabe fuer Laufzeit- oder DB-Aktionen.
+- Wenn CDB-Evidence oder Vertrage enger sind als Upstream-Beispiele, gilt CDB.

--- a/.cursor/rules/surrealql.mdc
+++ b/.cursor/rules/surrealql.mdc
@@ -1,0 +1,18 @@
+---
+description: CDB-curated SurrealQL rule derived from the official SurrealDB rule.
+alwaysApply: false
+---
+
+CDB Governance gewinnt vor externer Doku.
+No Live-GO / Echtgeld-GO.
+
+Offizielle Quelle: `https://surrealdb.com/docs/build/ai-agents/agent-rules`
+Inspectierter Rule-Stand: `surrealql.mdc` aus Commit `a69077df`.
+
+Nutze diese Rule als read-only Orientierung:
+
+- SurrealQL ist nicht ANSI-SQL.
+- Bevorzuge spezifische Record-IDs, wenn sie bekannt sind.
+- Nutze Relationships fuer Graph-Muster statt SQL-Fremdschluessel-Denken.
+- Wenn CDB-Canon enger ist als Upstream, gilt CDB-Canon.
+- Diese Rule autorisiert keine DB-Writes, MCP-Mutationen oder Tool-Freischaltungen.

--- a/.cursor/skills/README.md
+++ b/.cursor/skills/README.md
@@ -31,6 +31,9 @@ Repo-versionierte Session-Skills für Cursor Agents. Jeder Skill lebt in `<name>
 | [`cdb-drift-reconcile`](cdb-drift-reconcile/SKILL.md) | Drift reconcile |
 | [`cdb-docs-ops`](cdb-docs-ops/SKILL.md) | Docs maintenance |
 | [`ctb-docker-stack`](ctb-docker-stack/SKILL.md) | Docker BLUE+RED |
+| [`surrealql`](surrealql/SKILL.md) | CDB-curated official SurrealQL skill |
+| [`surrealdb-vector`](surrealdb-vector/SKILL.md) | CDB-curated official vector skill |
+| [`surrealdb-python`](surrealdb-python/SKILL.md) | CDB-curated official Python SDK skill |
 
 ## GitHub helpers
 

--- a/.cursor/skills/surrealdb-python/SKILL.md
+++ b/.cursor/skills/surrealdb-python/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: surrealdb-python
+description: "CDB-curated, script-free activation of the official SurrealDB Python skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealDB Python SDK
+
+## Zweck
+
+Nutze diesen Skill fuer den SurrealDB-Python-SDK-Kontext: `Surreal`,
+`AsyncSurreal`, Client/Server-Modus und Embedded-Varianten wie `mem://` oder
+`file://`.
+
+## Wann zuenden
+
+- bei Python-Code mit dem Paket `surrealdb`
+- bei Review von `Surreal(...)` oder `AsyncSurreal(...)`
+- bei Embedded-Nutzung mit `mem://` oder `file://`
+- bei SDK-Fragen zu CRUD, Query-Calls oder Session-Nutzung
+
+## CDB-Kernpunkte
+
+- Beispiele aus Upstream muessen auf CDB-Read-only- und Governance-Grenzen angepasst werden.
+- Keine Zugangsdaten, Root-Defaults oder Startbefehle aus Upstream-Beispielen uebernehmen.
+- Embedded- oder lokale Laufmodi sind kein Signal fuer produktive Freigabe.
+- Dieser Skill bleibt script-frei und autorisiert keine Ausfuehrung.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealdb-python`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Nutze Upstream nur als API- und Pattern-Referenz.
+- Fuer produktive oder DB-backed Behauptungen zaehlt CDB-Evidence vor Beispielcode.
+- Wenn Embedded- oder WebSocket-Verhalten relevant ist, gleiche es mit dem Repo-Canon ab.

--- a/.cursor/skills/surrealdb-vector/SKILL.md
+++ b/.cursor/skills/surrealdb-vector/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: surrealdb-vector
+description: "CDB-curated, script-free activation of the official SurrealDB vector skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealDB Vector Search
+
+## Zweck
+
+Nutze diesen Skill fuer HNSW-Indexe, KNN-Abfragen, Similarity-Scoring und
+vektorbasierte Retrieval-Muster in SurrealDB.
+
+## Wann zuenden
+
+- bei `DEFINE INDEX ... HNSW`
+- bei KNN-Queries mit `<|K, EF|>`
+- bei Score-/Threshold-Logik fuer RAG oder semantische Suche
+- bei Review von Vector-Schema- oder Embedding-Feldern
+
+## CDB-Kernpunkte
+
+- Dimension, Distanzfunktion und Typ muessen zum Embedding-Vertrag passen.
+- Scoring-Logik gehoert nachvollziehbar dokumentiert und testbar gemacht.
+- Dieser Skill bleibt script-frei und gibt keine Laufzeit- oder Installationsbefehle vor.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealdb-vector`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Halte Vector-Suche strikt getrennt von Runtime- oder Live-Freigaben.
+- Nutze diesen Skill fuer Query- und Schema-Verstaendnis, nicht als Schreibfreigabe.
+- Wenn HNSW-Details von CDB-Vertraegen abweichen, gilt der engere CDB-Vertrag.

--- a/.cursor/skills/surrealql/SKILL.md
+++ b/.cursor/skills/surrealql/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: surrealql
+description: "CDB-curated, script-free activation of the official SurrealQL agent skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealQL
+
+## Zweck
+
+Nutze diesen Skill fuer SurrealQL-Queries, Schema-Definitionen,
+Graph-Traversals und Syntax-Reviews rund um SurrealDB.
+
+## Wann zuenden
+
+- beim Schreiben oder Pruefen von `.surql`
+- bei `DEFINE TABLE` / `DEFINE FIELD` / `DEFINE INDEX`
+- bei Graph-Relationships und Record-IDs
+- wenn SQL-Denkmuster auf SurrealQL uebersetzt werden muessen
+
+## CDB-Kernpunkte
+
+- SurrealQL ist nicht ANSI-SQL.
+- Fuer aktuelle Syntax gilt die offizielle SurrealDB-Doku als SSOT.
+- Repo-Kanon und CDB-Vertraege haben Vorrang, wenn CDB den Upstream enger fasst.
+- Dieser Skill ist absichtlich script-frei und enthaelt keine Installations- oder
+  Auto-Run-Anweisungen.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealql`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Nutze diesen Skill zusammen mit der offiziellen Doku, wenn Syntax oder
+  Versionsverhalten unklar ist.
+- Wenn CDB-Canon und Upstream-Beispiel kollidieren, stoppe und dokumentiere den
+  Widerspruch statt still zu raten.
+- Fuer Vector- oder Python-SDK-Themen lade den passenden Schwester-Skill.

--- a/.opencode/skills/README.md
+++ b/.opencode/skills/README.md
@@ -40,6 +40,9 @@ Spiegelt die Cursor-Skill-Oberfläche unter [`.cursor/skills/README.md`](../../.
 | [`cdb-docs-ops`](cdb-docs-ops/SKILL.md) | Docs maintenance |
 | [`ctb-docker-stack`](ctb-docker-stack/SKILL.md) | Docker BLUE+RED |
 | [`cdb-ci-cd-guard`](cdb-ci-cd-guard/SKILL.md) | CI/CD guardrails |
+| [`surrealql`](surrealql/SKILL.md) | CDB-curated official SurrealQL skill |
+| [`surrealdb-vector`](surrealdb-vector/SKILL.md) | CDB-curated official vector skill |
+| [`surrealdb-python`](surrealdb-python/SKILL.md) | CDB-curated official Python SDK skill |
 
 ## GitHub helpers
 

--- a/.opencode/skills/surrealdb-python/SKILL.md
+++ b/.opencode/skills/surrealdb-python/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: surrealdb-python
+description: "CDB-curated, script-free activation of the official SurrealDB Python skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealDB Python SDK
+
+## Zweck
+
+Nutze diesen Skill fuer den SurrealDB-Python-SDK-Kontext: `Surreal`,
+`AsyncSurreal`, Client/Server-Modus und Embedded-Varianten wie `mem://` oder
+`file://`.
+
+## Wann zuenden
+
+- bei Python-Code mit dem Paket `surrealdb`
+- bei Review von `Surreal(...)` oder `AsyncSurreal(...)`
+- bei Embedded-Nutzung mit `mem://` oder `file://`
+- bei SDK-Fragen zu CRUD, Query-Calls oder Session-Nutzung
+
+## CDB-Kernpunkte
+
+- Beispiele aus Upstream muessen auf CDB-Read-only- und Governance-Grenzen angepasst werden.
+- Keine Zugangsdaten, Root-Defaults oder Startbefehle aus Upstream-Beispielen uebernehmen.
+- Embedded- oder lokale Laufmodi sind kein Signal fuer produktive Freigabe.
+- Dieser Skill bleibt script-frei und autorisiert keine Ausfuehrung.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealdb-python`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Nutze Upstream nur als API- und Pattern-Referenz.
+- Fuer produktive oder DB-backed Behauptungen zaehlt CDB-Evidence vor Beispielcode.
+- Wenn Embedded- oder WebSocket-Verhalten relevant ist, gleiche es mit dem Repo-Canon ab.

--- a/.opencode/skills/surrealdb-vector/SKILL.md
+++ b/.opencode/skills/surrealdb-vector/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: surrealdb-vector
+description: "CDB-curated, script-free activation of the official SurrealDB vector skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealDB Vector Search
+
+## Zweck
+
+Nutze diesen Skill fuer HNSW-Indexe, KNN-Abfragen, Similarity-Scoring und
+vektorbasierte Retrieval-Muster in SurrealDB.
+
+## Wann zuenden
+
+- bei `DEFINE INDEX ... HNSW`
+- bei KNN-Queries mit `<|K, EF|>`
+- bei Score-/Threshold-Logik fuer RAG oder semantische Suche
+- bei Review von Vector-Schema- oder Embedding-Feldern
+
+## CDB-Kernpunkte
+
+- Dimension, Distanzfunktion und Typ muessen zum Embedding-Vertrag passen.
+- Scoring-Logik gehoert nachvollziehbar dokumentiert und testbar gemacht.
+- Dieser Skill bleibt script-frei und gibt keine Laufzeit- oder Installationsbefehle vor.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealdb-vector`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Halte Vector-Suche strikt getrennt von Runtime- oder Live-Freigaben.
+- Nutze diesen Skill fuer Query- und Schema-Verstaendnis, nicht als Schreibfreigabe.
+- Wenn HNSW-Details von CDB-Vertraegen abweichen, gilt der engere CDB-Vertrag.

--- a/.opencode/skills/surrealql/SKILL.md
+++ b/.opencode/skills/surrealql/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: surrealql
+description: "CDB-curated, script-free activation of the official SurrealQL agent skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealQL
+
+## Zweck
+
+Nutze diesen Skill fuer SurrealQL-Queries, Schema-Definitionen,
+Graph-Traversals und Syntax-Reviews rund um SurrealDB.
+
+## Wann zuenden
+
+- beim Schreiben oder Pruefen von `.surql`
+- bei `DEFINE TABLE` / `DEFINE FIELD` / `DEFINE INDEX`
+- bei Graph-Relationships und Record-IDs
+- wenn SQL-Denkmuster auf SurrealQL uebersetzt werden muessen
+
+## CDB-Kernpunkte
+
+- SurrealQL ist nicht ANSI-SQL.
+- Fuer aktuelle Syntax gilt die offizielle SurrealDB-Doku als SSOT.
+- Repo-Kanon und CDB-Vertraege haben Vorrang, wenn CDB den Upstream enger fasst.
+- Dieser Skill ist absichtlich script-frei und enthaelt keine Installations- oder
+  Auto-Run-Anweisungen.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealql`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Nutze diesen Skill zusammen mit der offiziellen Doku, wenn Syntax oder
+  Versionsverhalten unklar ist.
+- Wenn CDB-Canon und Upstream-Beispiel kollidieren, stoppe und dokumentiere den
+  Widerspruch statt still zu raten.
+- Fuer Vector- oder Python-SDK-Themen lade den passenden Schwester-Skill.

--- a/artifacts/skills/surrealdb_skills_source_manifest.json
+++ b/artifacts/skills/surrealdb_skills_source_manifest.json
@@ -1,0 +1,211 @@
+[
+  {
+    "skill": "surrealql",
+    "surface": "OpenCode",
+    "local_path": ".opencode/skills/surrealql/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealql)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "curated",
+    "files_included": ["SKILL.md"],
+    "files_excluded": ["references/querying.md", "references/schema.md", "references/values.md"],
+    "gap_reason": ""
+  },
+  {
+    "skill": "surrealdb-vector",
+    "surface": "OpenCode",
+    "local_path": ".opencode/skills/surrealdb-vector/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealdb-vector)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "curated",
+    "files_included": ["SKILL.md"],
+    "files_excluded": [],
+    "gap_reason": ""
+  },
+  {
+    "skill": "surrealdb-python",
+    "surface": "OpenCode",
+    "local_path": ".opencode/skills/surrealdb-python/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealdb-python)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "curated",
+    "files_included": ["SKILL.md"],
+    "files_excluded": ["references/embedded.md"],
+    "gap_reason": ""
+  },
+  {
+    "skill": "surrealql",
+    "surface": "Cursor",
+    "local_path": ".cursor/skills/surrealql/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealql)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "curated",
+    "files_included": ["SKILL.md"],
+    "files_excluded": ["references/querying.md", "references/schema.md", "references/values.md"],
+    "gap_reason": ""
+  },
+  {
+    "skill": "surrealdb-vector",
+    "surface": "Cursor",
+    "local_path": ".cursor/skills/surrealdb-vector/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealdb-vector)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "curated",
+    "files_included": ["SKILL.md"],
+    "files_excluded": [],
+    "gap_reason": ""
+  },
+  {
+    "skill": "surrealdb-python",
+    "surface": "Cursor",
+    "local_path": ".cursor/skills/surrealdb-python/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealdb-python)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "curated",
+    "files_included": ["SKILL.md"],
+    "files_excluded": ["references/embedded.md"],
+    "gap_reason": ""
+  },
+  {
+    "skill": "surrealql",
+    "surface": "Codex",
+    "local_path": ".codex/cdb_skills/surrealql/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealql)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "curated",
+    "files_included": ["SKILL.md"],
+    "files_excluded": ["references/querying.md", "references/schema.md", "references/values.md"],
+    "gap_reason": ""
+  },
+  {
+    "skill": "surrealdb-vector",
+    "surface": "Codex",
+    "local_path": ".codex/cdb_skills/surrealdb-vector/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealdb-vector)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "curated",
+    "files_included": ["SKILL.md"],
+    "files_excluded": [],
+    "gap_reason": ""
+  },
+  {
+    "skill": "surrealdb-python",
+    "surface": "Codex",
+    "local_path": ".codex/cdb_skills/surrealdb-python/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealdb-python)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "curated",
+    "files_included": ["SKILL.md"],
+    "files_excluded": ["references/embedded.md"],
+    "gap_reason": ""
+  },
+  {
+    "skill": "surrealql",
+    "surface": "Claude",
+    "local_path": ".claude/skills/surrealql/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealql)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "curated",
+    "files_included": ["SKILL.md"],
+    "files_excluded": [],
+    "gap_reason": ""
+  },
+  {
+    "skill": "surrealdb-vector",
+    "surface": "Claude",
+    "local_path": ".claude/skills/surrealdb-vector/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealdb-vector)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "curated",
+    "files_included": ["SKILL.md"],
+    "files_excluded": [],
+    "gap_reason": ""
+  },
+  {
+    "skill": "surrealdb-python",
+    "surface": "Claude",
+    "local_path": ".claude/skills/surrealdb-python/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealdb-python)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "curated",
+    "files_included": ["SKILL.md"],
+    "files_excluded": [],
+    "gap_reason": ""
+  },
+  {
+    "skill": "rule:surrealql.mdc",
+    "surface": "Cursor",
+    "local_path": ".cursor/rules/surrealql.mdc",
+    "official_source": "https://github.com/surrealdb/docs.surrealdb.com/tree/main/public/integrations/agent-rules",
+    "source_commit_or_version": "a69077df",
+    "safety_status": "verified",
+    "files_included": ["surrealql.mdc"],
+    "files_excluded": [],
+    "gap_reason": ""
+  },
+  {
+    "skill": "rule:surrealdb-vector.mdc",
+    "surface": "Cursor",
+    "local_path": ".cursor/rules/surrealdb-vector.mdc",
+    "official_source": "https://github.com/surrealdb/docs.surrealdb.com/tree/main/public/integrations/agent-rules",
+    "source_commit_or_version": "a69077df",
+    "safety_status": "verified",
+    "files_included": ["surrealdb-vector.mdc"],
+    "files_excluded": [],
+    "gap_reason": ""
+  },
+  {
+    "skill": "rule:surrealdb-python.mdc",
+    "surface": "Cursor",
+    "local_path": ".cursor/rules/surrealdb-python.mdc",
+    "official_source": "https://github.com/surrealdb/docs.surrealdb.com/tree/main/public/integrations/agent-rules",
+    "source_commit_or_version": "a69077df",
+    "safety_status": "verified",
+    "files_included": ["surrealdb-python.mdc"],
+    "files_excluded": [],
+    "gap_reason": ""
+  },
+  {
+    "skill": "rule:surrealdb-python-embedded.mdc",
+    "surface": "Cursor",
+    "local_path": ".cursor/rules/surrealdb-python-embedded.mdc",
+    "official_source": "https://github.com/surrealdb/docs.surrealdb.com/tree/main/public/integrations/agent-rules",
+    "source_commit_or_version": "a69077df",
+    "safety_status": "verified",
+    "files_included": ["surrealdb-python-embedded.mdc"],
+    "files_excluded": [],
+    "gap_reason": ""
+  },
+  {
+    "skill": "surrealql",
+    "surface": "Gemini",
+    "local_path": ".gemini/skills/surrealql/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealql)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "not_applicable",
+    "files_included": [],
+    "files_excluded": ["SKILL.md", "references/querying.md", "references/schema.md", "references/values.md"],
+    "gap_reason": "Gemini is not a tracked activation surface for this slice; local candidates remain untouched."
+  },
+  {
+    "skill": "surrealdb-vector",
+    "surface": "Gemini",
+    "local_path": ".gemini/skills/surrealdb-vector/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealdb-vector)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "not_applicable",
+    "files_included": [],
+    "files_excluded": ["SKILL.md"],
+    "gap_reason": "Gemini is not a tracked activation surface for this slice; local candidates remain untouched."
+  },
+  {
+    "skill": "surrealdb-python",
+    "surface": "Gemini",
+    "local_path": ".gemini/skills/surrealdb-python/SKILL.md",
+    "official_source": "https://github.com/surrealdb/agent-skills (skill: surrealdb-python)",
+    "source_commit_or_version": "95628976",
+    "safety_status": "not_applicable",
+    "files_included": [],
+    "files_excluded": ["SKILL.md", "references/embedded.md"],
+    "gap_reason": "Gemini is not a tracked activation surface for this slice; local candidates remain untouched."
+  }
+]

--- a/artifacts/skills/surrealdb_skills_surface_matrix.json
+++ b/artifacts/skills/surrealdb_skills_surface_matrix.json
@@ -1,0 +1,47 @@
+[
+  {
+    "surface": "OpenCode",
+    "path": ".opencode/skills",
+    "surrealql_status": "ACTIVE",
+    "surrealdb_vector_status": "ACTIVE",
+    "surrealdb_python_status": "ACTIVE",
+    "rules_status": "GAP",
+    "notes": "CDB-curated official skill wrappers tracked; no canonical rule surface exists."
+  },
+  {
+    "surface": "Cursor",
+    "path": ".cursor/skills + .cursor/rules",
+    "surrealql_status": "ACTIVE",
+    "surrealdb_vector_status": "ACTIVE",
+    "surrealdb_python_status": "ACTIVE",
+    "rules_status": "ACTIVE",
+    "notes": "Skills and four curated SurrealDB .mdc rules tracked on canonical Cursor surfaces."
+  },
+  {
+    "surface": "Codex",
+    "path": ".codex/cdb_skills",
+    "surrealql_status": "ACTIVE",
+    "surrealdb_vector_status": "ACTIVE",
+    "surrealdb_python_status": "ACTIVE",
+    "rules_status": "GAP",
+    "notes": "CDB-curated official skill wrappers tracked; no canonical rule surface exists."
+  },
+  {
+    "surface": "Claude",
+    "path": ".claude/skills",
+    "surrealql_status": "ACTIVE",
+    "surrealdb_vector_status": "ACTIVE",
+    "surrealdb_python_status": "ACTIVE",
+    "rules_status": "GAP",
+    "notes": "CDB-curated official skill wrappers tracked; no canonical rule surface exists."
+  },
+  {
+    "surface": "Gemini",
+    "path": ".gemini/skills",
+    "surrealql_status": "NOT_APPLICABLE",
+    "surrealdb_vector_status": "NOT_APPLICABLE",
+    "surrealdb_python_status": "NOT_APPLICABLE",
+    "rules_status": "NOT_APPLICABLE",
+    "notes": "Gemini SurrealDB candidates remain untracked and intentionally inactive in this slice."
+  }
+]

--- a/docs/skills/CDB_SURREALDB_SKILLS_RULES_ACTIVATION.md
+++ b/docs/skills/CDB_SURREALDB_SKILLS_RULES_ACTIVATION.md
@@ -1,0 +1,79 @@
+# CDB SurrealDB Skills / Rules Activation
+
+Status: active slice output for `#3482`
+
+## Purpose
+
+This document records the CDB-owned activation of official SurrealDB skill topics
+and agent-rule topics across the repo-versioned agent surfaces.
+
+This slice is separate from `#3493`.
+`#3493` proved inventory and exposure state.
+`#3482` activates curated, script-free SurrealDB guidance on the allowed CDB
+surfaces.
+
+## Official Sources
+
+- Agent Skills docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Agent Rules docs: `https://surrealdb.com/docs/build/ai-agents/agent-rules`
+- Agent Skills repo: `https://github.com/surrealdb/agent-skills`
+- Skills source commit inspected: `95628976`
+- Rules source repo/path: `https://github.com/surrealdb/docs.surrealdb.com/tree/main/public/integrations/agent-rules`
+- Rules source commit inspected: `a69077df`
+
+## Activation Model
+
+- CDB does not vendor the official SurrealDB skills verbatim.
+- CDB activates curated, script-free wrappers derived from the official sources.
+- CDB only adds rules where a canonical rule surface already exists.
+- CDB Governance wins over upstream best practice whenever they conflict.
+
+## Surface Matrix
+
+| Surface | Skills | Rules | Status |
+| --- | --- | --- | --- |
+| OpenCode | `surrealql`, `surrealdb-vector`, `surrealdb-python` | no canonical rule surface | ACTIVE skills / GAP rules |
+| Cursor | `surrealql`, `surrealdb-vector`, `surrealdb-python` | `.cursor/rules/*.mdc` | ACTIVE |
+| Codex | `surrealql`, `surrealdb-vector`, `surrealdb-python` | no canonical rule surface | ACTIVE skills / GAP rules |
+| Claude | `surrealql`, `surrealdb-vector`, `surrealdb-python` | no canonical rule surface | ACTIVE skills / GAP rules |
+| Gemini | no tracked activation in this slice | no canonical rule surface | NOT_APPLICABLE |
+
+## Why Gemini Stays Inactive
+
+- `.gemini/skills` is not a canon activation target for this slice.
+- The repo allowlist treats `.gemini/` differently from the main skill surfaces.
+- Local Gemini SurrealDB candidates remain untouched and untracked.
+
+## Rules Scope
+
+- Official rule concept verified against SurrealDB docs.
+- Only `.cursor/rules/` exists as a canonical rule surface in this repo.
+- Therefore only Cursor receives tracked SurrealDB rules in this slice.
+- OpenCode, Codex, and Claude are documented as `GAP` for rules rather than
+  forcing a non-canonical surface.
+
+## Safety Boundaries
+
+- No installers executed.
+- No `npx skills add` execution.
+- No copied helper scripts.
+- No DB writes.
+- No MCP mutations.
+- No Live-Go.
+- No Echtgeld-Go.
+- No secrets or example root credentials carried into tracked skills.
+
+## Local Candidate Assessment
+
+- `.opencode/skills/*` and `.cursor/skills/*` candidates were present locally and inspected.
+- `surrealql` candidates were outdated versus current inspected upstream and included
+  disallowed `npx` formatter guidance.
+- `surrealdb-python` candidates included upstream server-start and root-credential examples.
+- The tracked result is therefore curated, not blind adoption.
+
+## Remaining Gaps
+
+- No canonical rule surface exists yet for OpenCode, Codex, or Claude.
+- Gemini SurrealDB candidates remain intentionally inactive.
+- This slice activates only the required official SurrealDB skills:
+  `surrealql`, `surrealdb-vector`, and `surrealdb-python`.

--- a/tests/unit/skills/test_surrealdb_skill_safety.py
+++ b/tests/unit/skills/test_surrealdb_skill_safety.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TRACKED_SKILL_DIRS = [
+    ".opencode/skills/surrealql",
+    ".opencode/skills/surrealdb-vector",
+    ".opencode/skills/surrealdb-python",
+    ".cursor/skills/surrealql",
+    ".cursor/skills/surrealdb-vector",
+    ".cursor/skills/surrealdb-python",
+    ".codex/cdb_skills/surrealql",
+    ".codex/cdb_skills/surrealdb-vector",
+    ".codex/cdb_skills/surrealdb-python",
+    ".claude/skills/surrealql",
+    ".claude/skills/surrealdb-vector",
+    ".claude/skills/surrealdb-python",
+]
+CURSOR_RULES = [
+    ".cursor/rules/surrealql.mdc",
+    ".cursor/rules/surrealdb-vector.mdc",
+    ".cursor/rules/surrealdb-python.mdc",
+    ".cursor/rules/surrealdb-python-embedded.mdc",
+]
+DISALLOWED_SCRIPT_SUFFIXES = {".py", ".js", ".ps1", ".sh", ".bat"}
+DISALLOWED_TEXT_MARKERS = [
+    "npx ",
+    "skills add",
+    "git clone ",
+    "curl -",
+    "| bash",
+    "npm install",
+    "pip install",
+]
+DISALLOWED_SECRET_OR_LIVE_MARKERS = [
+    "-p root",
+    '"password":',
+    "api key",
+    "live capital",
+]
+BOUNDARY_TEXT = "CDB Governance gewinnt vor externer Doku."
+SOURCE_TEXT = "Offizielle Quelle"
+NO_GO_TEXT = "No Live-GO / Echtgeld-GO"
+
+
+def git_ls_files() -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def read_text(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def tracked_files_under(relative_dir: str) -> list[str]:
+    prefix = f"{relative_dir}/"
+    return [path for path in git_ls_files() if path.startswith(prefix)]
+
+
+def test_skill_md_only_for_surrealdb_skills() -> None:
+    for relative_dir in TRACKED_SKILL_DIRS:
+        tracked_files = tracked_files_under(relative_dir)
+        assert tracked_files, f"expected tracked files under {relative_dir}"
+        for path in tracked_files:
+            suffix = Path(path).suffix
+            assert suffix not in DISALLOWED_SCRIPT_SUFFIXES, (
+                f"unexpected executable file in skill dir: {path}"
+            )
+            assert suffix in {".md", ".mdc"}, f"unexpected file type in {path}"
+
+
+def test_no_installers_or_autorun() -> None:
+    for relative_dir in TRACKED_SKILL_DIRS:
+        text = read_text(f"{relative_dir}/SKILL.md").lower()
+        for marker in DISALLOWED_TEXT_MARKERS:
+            assert marker not in text, f"disallowed execution hint {marker!r} in {relative_dir}"
+
+    for relative_path in CURSOR_RULES:
+        text = read_text(relative_path).lower()
+        for marker in DISALLOWED_TEXT_MARKERS:
+            assert marker not in text, f"disallowed execution hint {marker!r} in {relative_path}"
+
+
+def test_no_secret_or_live_targets() -> None:
+    for relative_dir in TRACKED_SKILL_DIRS:
+        text = read_text(f"{relative_dir}/SKILL.md").lower()
+        for marker in DISALLOWED_SECRET_OR_LIVE_MARKERS:
+            assert marker not in text, f"disallowed secret/live marker {marker!r} in {relative_dir}"
+
+
+def test_cdb_governance_boundary_present() -> None:
+    for relative_dir in TRACKED_SKILL_DIRS:
+        text = read_text(f"{relative_dir}/SKILL.md")
+        assert BOUNDARY_TEXT in text
+        assert NO_GO_TEXT in text
+
+
+def test_official_source_recorded() -> None:
+    for relative_dir in TRACKED_SKILL_DIRS:
+        text = read_text(f"{relative_dir}/SKILL.md")
+        assert SOURCE_TEXT in text
+        assert "95628976" in text
+
+
+def test_cursor_rules_are_present_and_script_free() -> None:
+    tracked = set(git_ls_files())
+
+    for relative_path in CURSOR_RULES:
+        assert relative_path in tracked, f"missing rule file: {relative_path}"
+        text = read_text(relative_path)
+        assert BOUNDARY_TEXT in text
+        assert NO_GO_TEXT in text

--- a/tests/unit/skills/test_surrealdb_skills_rules_activation.py
+++ b/tests/unit/skills/test_surrealdb_skills_rules_activation.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+SKILL_SURFACES = [
+    ".opencode/skills",
+    ".cursor/skills",
+    ".codex/cdb_skills",
+    ".claude/skills",
+]
+REQUIRED_SKILLS = ["surrealql", "surrealdb-vector", "surrealdb-python"]
+GEMINI_SKILLS = [
+    ".gemini/skills/surrealql/SKILL.md",
+    ".gemini/skills/surrealdb-vector/SKILL.md",
+    ".gemini/skills/surrealdb-python/SKILL.md",
+]
+SURFACE_MATRIX_PATH = REPO_ROOT / "artifacts/skills/surrealdb_skills_surface_matrix.json"
+SOURCE_MANIFEST_PATH = (
+    REPO_ROOT / "artifacts/skills/surrealdb_skills_source_manifest.json"
+)
+ALLOWED_SURFACE_STATUS = {"ACTIVE", "MISSING", "NOT_APPLICABLE", "GAP"}
+
+
+def git_ls_files() -> set[str]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=True,
+    )
+    return set(result.stdout.strip().splitlines())
+
+
+def load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_surrealdb_required_skills_exist_on_valid_surfaces() -> None:
+    tracked = git_ls_files()
+
+    for surface in SKILL_SURFACES:
+        for skill in REQUIRED_SKILLS:
+            path = f"{surface}/{skill}/SKILL.md"
+            assert path in tracked, f"missing tracked skill: {path}"
+
+
+def test_no_unapproved_surface_created() -> None:
+    tracked = git_ls_files()
+
+    for path in GEMINI_SKILLS:
+        assert path not in tracked, f"gemini skill surface must stay inactive: {path}"
+
+
+def test_surface_parity_matrix_generated() -> None:
+    assert SURFACE_MATRIX_PATH.exists(), "surface matrix artifact must exist"
+
+    matrix = load_json(SURFACE_MATRIX_PATH)
+    assert isinstance(matrix, list)
+
+    rows_by_surface = {row["surface"]: row for row in matrix}
+    assert set(rows_by_surface) == {
+        "OpenCode",
+        "Cursor",
+        "Codex",
+        "Claude",
+        "Gemini",
+    }
+
+    for row in matrix:
+        assert set(row) == {
+            "surface",
+            "path",
+            "surrealql_status",
+            "surrealdb_vector_status",
+            "surrealdb_python_status",
+            "rules_status",
+            "notes",
+        }
+        assert row["surrealql_status"] in ALLOWED_SURFACE_STATUS
+        assert row["surrealdb_vector_status"] in ALLOWED_SURFACE_STATUS
+        assert row["surrealdb_python_status"] in ALLOWED_SURFACE_STATUS
+        assert row["rules_status"] in ALLOWED_SURFACE_STATUS
+
+    assert rows_by_surface["OpenCode"]["surrealql_status"] == "ACTIVE"
+    assert rows_by_surface["Cursor"]["surrealdb_vector_status"] == "ACTIVE"
+    assert rows_by_surface["Codex"]["surrealdb_python_status"] == "ACTIVE"
+    assert rows_by_surface["Claude"]["surrealql_status"] == "ACTIVE"
+    assert rows_by_surface["Cursor"]["rules_status"] == "ACTIVE"
+    assert rows_by_surface["Gemini"]["surrealql_status"] == "NOT_APPLICABLE"
+
+
+def test_rules_status_documented() -> None:
+    matrix = load_json(SURFACE_MATRIX_PATH)
+
+    rows_by_surface = {row["surface"]: row for row in matrix}
+
+    assert rows_by_surface["OpenCode"]["rules_status"] == "GAP"
+    assert rows_by_surface["Codex"]["rules_status"] == "GAP"
+    assert rows_by_surface["Claude"]["rules_status"] == "GAP"
+    assert rows_by_surface["Gemini"]["rules_status"] == "NOT_APPLICABLE"
+
+
+def test_official_source_manifest_generated() -> None:
+    assert SOURCE_MANIFEST_PATH.exists(), "source manifest artifact must exist"
+
+    manifest = load_json(SOURCE_MANIFEST_PATH)
+    assert isinstance(manifest, list)
+    assert manifest, "source manifest must not be empty"
+
+    required_keys = {
+        "skill",
+        "surface",
+        "local_path",
+        "official_source",
+        "source_commit_or_version",
+        "safety_status",
+        "files_included",
+        "files_excluded",
+        "gap_reason",
+    }
+
+    for row in manifest:
+        assert set(row) == required_keys
+        assert row["skill"]
+        assert row["surface"]
+        assert row["local_path"]
+        assert row["official_source"]
+        assert row["source_commit_or_version"]
+        assert isinstance(row["files_included"], list)
+        assert isinstance(row["files_excluded"], list)
+
+
+def test_local_candidate_matches_or_is_explained() -> None:
+    manifest = load_json(SOURCE_MANIFEST_PATH)
+
+    candidate_rows = [
+        row
+        for row in manifest
+        if row["surface"] in {"OpenCode", "Cursor"}
+        and row["skill"] in set(REQUIRED_SKILLS)
+    ]
+    assert len(candidate_rows) == 6
+
+    for row in candidate_rows:
+        assert row["safety_status"] in {"verified", "curated"}
+        assert row["gap_reason"] == ""


### PR DESCRIPTION
## Advances #3482

This slice is separate from #3493.
`#3493` / PR #3495 proved the Context Tool Inventory & Exposure Matrix.
This PR activates curated, script-free SurrealDB skills and rules on the allowed CDB agent surfaces.

### Official SurrealDB Skills/Rules sources

- Agent Skills docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
- Agent Rules docs: `https://surrealdb.com/docs/build/ai-agents/agent-rules`
- Agent Skills repo: `https://github.com/surrealdb/agent-skills`
- Inspected skills source commit: `95628976`
- Inspected rules source commit: `a69077df`

### Test-first red/green evidence

- Red: `python -m pytest tests/unit/skills -q` -> 11 expected failures
  - missing tracked SurrealDB skills on valid surfaces
  - missing surface matrix / source manifest artifacts
  - missing Cursor rule files
  - unsafe local candidate content (`npx`, root-credential examples, missing governance boundary)
- Green: `python -m pytest tests/unit/skills -q` -> `12 passed`

### Validation

- `python -m pytest tests/unit/skills -q` -> `12 passed`
- `ruff check tests/unit/skills/test_surrealdb_skills_rules_activation.py tests/unit/skills/test_surrealdb_skill_safety.py` -> `All checks passed`
- `python -m pytest tests/smoke/test_agent_root_surfaces.py tests/smoke/test_onboarding_cross_agent_surfaces.py -q` -> `68 passed`
- `python -m pytest tests/unit/tools/test_context_tool_inventory.py -q` -> `22 passed`

### Surface parity matrix

- OpenCode: skills ACTIVE / rules GAP
- Cursor: skills ACTIVE / rules ACTIVE
- Codex: skills ACTIVE / rules GAP
- Claude: skills ACTIVE / rules GAP
- Gemini: skills NOT_APPLICABLE / rules NOT_APPLICABLE

Artifacts:
- `artifacts/skills/surrealdb_skills_surface_matrix.json`
- `artifacts/skills/surrealdb_skills_source_manifest.json`

### Safety boundaries

- No installers, no scripts, no global install
- No `npx skills add` execution
- No helper-script adoption (`.ps1`, `.sh`, `.py`, `.js`)
- No DB/MCP writes
- No Live-GO / Echtgeld-GO
- CDB Governance wins over external docs

### Remaining gaps

- No canonical rule surface exists yet for OpenCode, Codex, or Claude
- Gemini SurrealDB candidates remain intentionally inactive and untracked in this slice
- Existing local `references/` residues under some untracked candidate folders were intentionally not adopted