### PR TITLE
test-only(surrealdb): add red tests for fulltext bm25 contract

### DIFF
--- a/artifacts/surrealdb/context_fulltext_bm25_contract.json
+++ b/artifacts/surrealdb/context_fulltext_bm25_contract.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "cdb://schemas/context-fulltext-bm25-contract/v1",
+  "version": 1,
+  "meta": {
+    "title": "CDB Context Fulltext BM25 Contract",
+    "description": "Defines which context categories are indexable via SurrealDB FULLTEXT BM25, the canonical analyzer, score configuration, freshness policies, and explicit blocklist for forbidden categories. CONTRACT_ONLY — no live DB operationality claimed.",
+    "canonical_source": [
+      "infrastructure/surrealdb/context_intelligence_v0.surql",
+      "infrastructure/surrealdb/context_intelligence_v0_deploy.surql",
+      "infrastructure/surrealdb/proof_graph_vector_setup.surql",
+      "infrastructure/surrealdb/hybrid_retrieval_fixtures.surql",
+      "artifacts/surrealdb/context_data_model_ownership_matrix.json",
+      "docs/surrealdb/CDB_CONTEXT_DATA_MODEL_OWNERSHIP.md",
+      "docs/surrealdb/context-core-schema-v1.md",
+      "docs/surrealdb/context-hybrid-retrieval-strategy-v1.md",
+      "tools/context_tool_inventory.py",
+      "tools/mcp_access_boundary.py"
+    ],
+    "issues": ["#3485", "#3483", "#3479"],
+    "created_by": "test-only/3485-fulltext-bm25-contract",
+    "status": "CONTRACT_ONLY",
+    "live_db_operational": false
+  },
+  "indexable_categories": {
+    "repo_file": {
+      "analyzer": "cdb_code_analyzer",
+      "indexed_fields": ["content", "file_path"],
+      "score_function": "BM25",
+      "highlight_allowed": true,
+      "evidence_required": "source_hash",
+      "source_of_truth": "repo",
+      "freshness_policy": "no_expiry_hash_verified",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_index_exists": false,
+      "notes": "Versioned repo files. BM25 indexed on doc_chunk.content via idx_doc_chunk_content_ft. Source-hash per artifact required. Stale when hash differs from working repo HEAD."
+    },
+    "github_issue": {
+      "analyzer": "cdb_code_analyzer",
+      "indexed_fields": ["title", "body"],
+      "score_function": "BM25",
+      "highlight_allowed": true,
+      "evidence_required": "issue_url_or_number",
+      "source_of_truth": "github_live",
+      "freshness_policy": "stale_after_24h_or_state_change",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_index_exists": false,
+      "notes": "GitHub issues mirrored as cache. SurrealDB mirror is not primary. TTL-driven refresh. BM25 on mirrored content."
+    },
+    "github_pr": {
+      "analyzer": "cdb_code_analyzer",
+      "indexed_fields": ["title", "body", "diff"],
+      "score_function": "BM25",
+      "highlight_allowed": true,
+      "evidence_required": "pr_url_or_number",
+      "source_of_truth": "github_live",
+      "freshness_policy": "stale_after_24h_or_state_change",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_index_exists": false,
+      "notes": "GitHub PRs mirrored as cache. Stale when PR state changes on GitHub. BM25 on mirrored content."
+    },
+    "evidence": {
+      "analyzer": "cdb_code_analyzer",
+      "indexed_fields": ["content", "description"],
+      "score_function": "BM25",
+      "highlight_allowed": true,
+      "evidence_required": "source_hash_and_provenance",
+      "source_of_truth": "repo_and_surrealdb",
+      "freshness_policy": "no_expiry_hash_verified",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_index_exists": false,
+      "notes": "Evidence refs are primary in SurrealDB but must reference Git source hashes. BM25 on evidence content. Append-only."
+    },
+    "claim": {
+      "analyzer": "cdb_code_analyzer",
+      "indexed_fields": ["statement", "rationale"],
+      "score_function": "BM25",
+      "highlight_allowed": true,
+      "evidence_required": "evidence_ref_and_source_hash",
+      "source_of_truth": "repo_and_surrealdb",
+      "freshness_policy": "no_expiry_hash_verified",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_index_exists": false,
+      "notes": "Claims are assertions backed by evidence refs. BM25 on claim content. Append-only."
+    },
+    "decision": {
+      "analyzer": "cdb_code_analyzer",
+      "indexed_fields": ["description", "rationale"],
+      "score_function": "BM25",
+      "highlight_allowed": true,
+      "evidence_required": "ledger_source_and_event_id",
+      "source_of_truth": "git_ledger",
+      "freshness_policy": "no_expiry",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_index_exists": false,
+      "notes": "Decision events recorded in Git ledger. BM25 on decision content. Ingest only, no edits."
+    },
+    "external_doc": {
+      "analyzer": "cdb_code_analyzer",
+      "indexed_fields": ["content", "title"],
+      "score_function": "BM25",
+      "highlight_allowed": true,
+      "evidence_required": "source_url_or_ref",
+      "source_of_truth": "external_upstream",
+      "freshness_policy": "stale_after_7d_or_upstream_change",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_index_exists": false,
+      "notes": "External documentation (SurrealDB official docs, exchange APIs, etc.). Mirrored as cache. BM25 on mirrored content. No live DB operationality."
+    }
+  },
+  "forbidden_categories": {
+    "secrets": {
+      "reason": "CDB_AGENT_POLICY section 4 — secrets never stored in any CDB system.",
+      "source_of_truth": "never_stored",
+      "notes": "API keys, passwords, private keys, credentials, tokens. Enforced by gitleaks and CDB_AGENT_POLICY.md."
+    },
+    "broker_credentials": {
+      "reason": "Broker credentials must never be indexed or stored in context systems.",
+      "source_of_truth": "never_stored",
+      "notes": "Broker API credentials, exchange keys, wallet secrets. LR remains NO-GO."
+    },
+    "live_positions": {
+      "reason": "Position data is Postgres-only runtime data, never mirrored into context.",
+      "source_of_truth": "postgres_trading",
+      "notes": "Open, closed, or pending positions. Never stored in SurrealDB or Context Brain."
+    },
+    "live_orders": {
+      "reason": "Order data is Postgres-only runtime data, never stored in Context Brain.",
+      "source_of_truth": "postgres_trading",
+      "notes": "Orders in any state. Never stored in SurrealDB or Context Brain."
+    },
+    "live_fills": {
+      "reason": "Fill data is Postgres-only runtime data, never mirrored into SurrealDB.",
+      "source_of_truth": "postgres_trading",
+      "notes": "Partial or complete fills. Never mirrored into SurrealDB."
+    },
+    "live_risk_state": {
+      "reason": "Live risk state (exposure, drawdown, limits) is Postgres-only, never in Context Brain.",
+      "source_of_truth": "postgres_trading",
+      "notes": "Live exposure, drawdown, limits, margin. Never stored or queried via Context Brain."
+    },
+    "trading_runtime_control": {
+      "reason": "Trading runtime control (kill-switch, execution flags) is Postgres-only.",
+      "source_of_truth": "postgres_trading",
+      "notes": "Kill-switch state, execution control flags, trading mode. Never stored in SurrealDB."
+    },
+    "agent_memory_raw": {
+      "reason": "Raw agent memory must be excluded from fulltext indexing per data ownership model — agent_memory is a sub-category blocked from fulltext.",
+      "source_of_truth": "surrealdb_scoped",
+      "notes": "Per-agent raw memory never indexed via BM25. Agent memory has explicit scope and TTL but is excluded from fulltext search as raw agent state is not context-indexable."
+    }
+  },
+  "governance_rules": {
+    "no_live_db_operationality_without_adapter_evidence": true,
+    "cdb_code_analyzer_is_canonical_for_fulltext": true,
+    "repo_rg_is_fallback_mode_only": true,
+    "context_tool_and_mcp_boundary_remain_repo_only": true,
+    "agent_memory_raw_explicitly_blocked": true
+  },
+  "references": [
+    "artifacts/surrealdb/context_data_model_ownership_matrix.json",
+    "docs/surrealdb/CDB_CONTEXT_DATA_MODEL_OWNERSHIP.md",
+    "infrastructure/surrealdb/context_intelligence_v0.surql",
+    "infrastructure/surrealdb/context_intelligence_v0_deploy.surql",
+    "infrastructure/surrealdb/proof_graph_vector_setup.surql",
+    "docs/surrealdb/context-core-schema-v1.md",
+    "docs/surrealdb/context-hybrid-retrieval-strategy-v1.md"
+  ]
+}

--- a/docs/surrealdb/CDB_CONTEXT_FULLTEXT_BM25_CONTRACT.md
+++ b/docs/surrealdb/CDB_CONTEXT_FULLTEXT_BM25_CONTRACT.md
@@ -1,0 +1,105 @@
+# CDB Context Fulltext BM25 Contract
+
+**Status:** CONTRACT_ONLY — no live DB operationality claimed.
+
+**Issues:** [#3485], [#3483], [#3479]
+
+## 1. Purpose
+
+This contract defines which context categories are indexable via SurrealDB
+FULLTEXT BM25, the canonical analyzer and index configuration, score semantics,
+freshness policies, and the explicit forbidden-category blocklist. It formalises
+the gap proven by Issue #3485: the SurrealDB analyzer and BM25 index exist in
+`.surql` definitions but had zero CDB-level contract document or machine-readable
+artifact.
+
+The contract is **CONTRACT_ONLY** until adapter evidence proves
+`DB_BACKED_READONLY_PROVEN` for at least one category.
+
+## 2. Canonical Analyzer
+
+All indexable categories use the same canonical analyzer:
+
+| Property | Value |
+|----------|-------|
+| Analyzer name | `cdb_code_analyzer` |
+| TOKENIZERS | `class`, `camel` |
+| FILTERS | `lowercase`, `ascii` |
+| Defined in | `context_intelligence_v0.surql`, `context_intelligence_v0_deploy.surql`, `proof_graph_vector_setup.surql` |
+
+## 3. Canonical BM25 Index
+
+| Property | Value |
+|----------|-------|
+| Index name | `idx_doc_chunk_content_ft` |
+| ON TABLE | `doc_chunk` |
+| FIELDS | `content` |
+| Type | FULLTEXT |
+| Analyzer | `cdb_code_analyzer` |
+| Scoring | BM25 |
+| Highlights | Enabled (`BM25 HIGHLIGHTS`) |
+
+## 4. Indexable Categories
+
+| Category | Analyzer | Indexed Fields | Score | Highlights | Evidence Required | Source of Truth | Freshness Policy |
+|----------|----------|----------------|------|------------|-------------------|-----------------|-----------------|
+| `repo_file` | cdb_code_analyzer | content, file_path | BM25 | yes | source_hash | repo | no_expiry_hash_verified |
+| `github_issue` | cdb_code_analyzer | title, body | BM25 | yes | issue_url_or_number | github_live | stale_after_24h_or_state_change |
+| `github_pr` | cdb_code_analyzer | title, body, diff | BM25 | yes | pr_url_or_number | github_live | stale_after_24h_or_state_change |
+| `evidence` | cdb_code_analyzer | content, description | BM25 | yes | source_hash_and_provenance | repo_and_surrealdb | no_expiry_hash_verified |
+| `claim` | cdb_code_analyzer | statement, rationale | BM25 | yes | evidence_ref_and_source_hash | repo_and_surrealdb | no_expiry_hash_verified |
+| `decision` | cdb_code_analyzer | description, rationale | BM25 | yes | ledger_source_and_event_id | git_ledger | no_expiry |
+| `external_doc` | cdb_code_analyzer | content, title | BM25 | yes | source_url_or_ref | external_upstream | stale_after_7d_or_upstream_change |
+
+All seven categories share:
+
+- **operational:** `false`
+- **backing_status:** `CONTRACT_ONLY`
+- **live_index_exists:** `false`
+
+These three fields must remain `false`/`CONTRACT_ONLY` until a real SurrealDB
+adapter is operational and evidence of `DB_BACKED_READONLY_PROVEN` exists
+per category.
+
+## 5. Forbidden Categories
+
+These categories are **explicitly blocked** from fulltext BM25 indexing:
+
+| Category | Reason |
+|----------|--------|
+| `secrets` | CDB_AGENT_POLICY section 4 — never stored in any CDB system |
+| `broker_credentials` | Broker/exchange credentials — never stored or indexed |
+| `live_positions` | Postgres-only runtime data |
+| `live_orders` | Postgres-only runtime data |
+| `live_fills` | Postgres-only runtime data |
+| `live_risk_state` | Postgres-only runtime data |
+| `trading_runtime_control` | Postgres-only runtime data |
+| `agent_memory_raw` | Raw agent memory excluded from fulltext per data ownership model |
+
+Categories not in either list (`context_tool`, `mcp_boundary`, `agent_memory`)
+are **repo-only or scoped** surfaces. `context_tool` and `mcp_boundary` remain
+repo-only — not fulltext-indexable — as confirmed by the ownership matrix.
+`agent_memory` is scoped to SurrealDB but `agent_memory_raw` is explicitly
+blocked from fulltext indexing.
+
+## 6. Governance Rules
+
+- **No live DB operationality** may be claimed without adapter evidence.
+- `cdb_code_analyzer` is the **canonical** fulltext analyzer for all CDB context
+  categories.
+- `repo-rg (ripgrep)` is the documented **fallback** for repo-local fulltext
+  search where SurrealDB BM25 is not available.
+- `context_tool` and `mcp_boundary` remain **repo-only** — no DB-backed fulltext.
+- `agent_memory_raw` is **explicitly blocked** from fulltext indexing (sub-category
+  of `agent_memory` per ownership matrix).
+
+## 7. References
+
+- [Context Data Model Ownership Matrix](../../artifacts/surrealdb/context_data_model_ownership_matrix.json)
+- [Context Data Model Ownership Doc](./CDB_CONTEXT_DATA_MODEL_OWNERSHIP.md)
+- [Context Core Schema](./context-core-schema-v1.md)
+- [Hybrid Retrieval Strategy](./context-hybrid-retrieval-strategy-v1.md)
+- `infrastructure/surrealdb/context_intelligence_v0.surql`
+- `infrastructure/surrealdb/context_intelligence_v0_deploy.surql`
+- `infrastructure/surrealdb/proof_graph_vector_setup.surql`
+- `infrastructure/surrealdb/hybrid_retrieval_fixtures.surql`

--- a/tests/unit/surrealdb/test_context_fulltext_bm25_contract.py
+++ b/tests/unit/surrealdb/test_context_fulltext_bm25_contract.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CONTRACT_DOC_PATH = (
+    REPO_ROOT / "docs" / "surrealdb" / "CDB_CONTEXT_FULLTEXT_BM25_CONTRACT.md"
+)
+CONTRACT_ARTIFACT_PATH = (
+    REPO_ROOT / "artifacts" / "surrealdb" / "context_fulltext_bm25_contract.json"
+)
+OWNERSHIP_MATRIX_PATH = (
+    REPO_ROOT / "artifacts" / "surrealdb" / "context_data_model_ownership_matrix.json"
+)
+OWNERSHIP_DOC_PATH = (
+    REPO_ROOT / "docs" / "surrealdb" / "CDB_CONTEXT_DATA_MODEL_OWNERSHIP.md"
+)
+
+INDEXABLE_CATEGORIES = frozenset(
+    {
+        "repo_file",
+        "github_issue",
+        "github_pr",
+        "evidence",
+        "claim",
+        "decision",
+        "external_doc",
+    }
+)
+
+BLOCKED_CATEGORIES = frozenset(
+    {
+        "secrets",
+        "broker_credentials",
+        "live_positions",
+        "live_orders",
+        "live_fills",
+        "live_risk_state",
+        "trading_runtime_control",
+        "agent_memory_raw",
+    }
+)
+
+REQUIRED_INDEX_FIELDS = frozenset(
+    {
+        "analyzer",
+        "indexed_fields",
+        "score_function",
+        "highlight_allowed",
+        "evidence_required",
+        "source_of_truth",
+        "freshness_policy",
+    }
+)
+
+
+def _load_contract() -> dict:
+    if not CONTRACT_ARTIFACT_PATH.exists():
+        pytest.fail(
+            f"Fulltext BM25 contract artifact not found at {CONTRACT_ARTIFACT_PATH}. "
+            f"Expected a JSON file with indexable categories, analyzers, and score configuration."
+        )
+    with open(CONTRACT_ARTIFACT_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+class TestFulltextBM25Contract:
+    def test_fulltext_bm25_contract_doc_exists(self):
+        assert CONTRACT_DOC_PATH.exists(), (
+            f"RED: Fulltext BM25 contract documentation does not exist at "
+            f"{CONTRACT_DOC_PATH}. "
+            f"Expected: docs/surrealdb/CDB_CONTEXT_FULLTEXT_BM25_CONTRACT.md"
+        )
+
+    def test_fulltext_bm25_contract_artifact_exists(self):
+        assert CONTRACT_ARTIFACT_PATH.exists(), (
+            f"RED: Fulltext BM25 contract artifact does not exist at "
+            f"{CONTRACT_ARTIFACT_PATH}. "
+            f"Expected: artifacts/surrealdb/context_fulltext_bm25_contract.json"
+        )
+
+    def test_contract_defines_indexable_context_categories(self):
+        contract = _load_contract()
+        indexable = set(contract.get("indexable_categories", {}).keys())
+        missing = INDEXABLE_CATEGORIES - indexable
+        assert not missing, (
+            f"RED: Required indexable categories missing from contract: "
+            f"{sorted(missing)}. "
+            f"Expected indexable: {sorted(INDEXABLE_CATEGORIES)}"
+        )
+
+    def test_contract_blocks_forbidden_categories_from_fulltext(self):
+        contract = _load_contract()
+        blocked = set(contract.get("forbidden_categories", {}).keys())
+        missing_blocked = BLOCKED_CATEGORIES - blocked
+        assert not missing_blocked, (
+            f"RED: Forbidden categories missing from fulltext blocklist: "
+            f"{sorted(missing_blocked)}. "
+            f"All secrets, live trading state, credentials, and raw agent memory "
+            f"must be explicitly blocked from fulltext indexing."
+        )
+
+    def test_contract_requires_analyzer_and_score_fields(self):
+        contract = _load_contract()
+        for cat_name, cat_data in contract.get("indexable_categories", {}).items():
+            missing_fields = REQUIRED_INDEX_FIELDS - set(cat_data.keys())
+            assert not missing_fields, (
+                f"RED: Indexable category '{cat_name}' missing required fields: "
+                f"{sorted(missing_fields)}. "
+                f"Expected fields: {sorted(REQUIRED_INDEX_FIELDS)}"
+            )
+
+    def test_no_fulltext_contract_claims_live_db_operationality(self):
+        contract = _load_contract()
+        for cat_name, cat_data in contract.get("indexable_categories", {}).items():
+            assert cat_data.get("operational") is not True, (
+                f"RED: Category '{cat_name}' claims operational=true. "
+                f"No fulltext contract may claim live DB operationality "
+                f"without adapter evidence."
+            )
+            assert cat_data.get("backing_status") != "DB_BACKED_READONLY_PROVEN", (
+                f"RED: Category '{cat_name}' claims DB_BACKED_READONLY_PROVEN. "
+                f"Fulltext contract must remain CONTRACT_ONLY until "
+                f"adapter evidence is provided."
+            )
+            assert cat_data.get("live_index_exists") is not True, (
+                f"RED: Category '{cat_name}' claims live_index_exists=true. "
+                f"No live index may be claimed without real SurrealDB adapter."
+            )
+
+    def test_fulltext_contract_links_to_data_model_ownership_matrix(self):
+        contract = _load_contract()
+        refs = contract.get("references", [])
+        assert str(OWNERSHIP_MATRIX_PATH) in refs or "context_data_model_ownership_matrix.json" in str(
+            refs
+        ), (
+            f"RED: Fulltext contract does not reference the data model ownership "
+            f"matrix at {OWNERSHIP_MATRIX_PATH}."
+        )
+        assert str(OWNERSHIP_DOC_PATH) in refs or "CDB_CONTEXT_DATA_MODEL_OWNERSHIP.md" in str(
+            refs
+        ), (
+            f"RED: Fulltext contract does not reference the data model ownership "
+            f"doc at {OWNERSHIP_DOC_PATH}."
+        )


### PR DESCRIPTION
## IMPLEMENTED — 7/7 GREEN

This PR was originally RED_ONLY (PR #3509 commit 529c44c4). Now implements the Fulltext BM25 Contract, turning all 7 RED tests GREEN.

### Delivered

| Artifact | Path |
|----------|------|
| Contract document | \docs/surrealdb/CDB_CONTEXT_FULLTEXT_BM25_CONTRACT.md\ |
| Contract artifact | \rtifacts/surrealdb/context_fulltext_bm25_contract.json\ |

### Indexable Categories (7)

All use canonical \cdb_code_analyzer\ (TOKENIZERS: class,camel FILTERS: lowercase,ascii), BM25 scoring, HIGHLIGHTS enabled:

| Category | Indexed Fields | Evidence Required | Source of Truth | Freshness |
|----------|---------------|-------------------|-----------------|-----------|
| repo_file | content, file_path | source_hash | repo | no_expiry_hash_verified |
| github_issue | title, body | issue_url_or_number | github_live | stale_after_24h_or_state_change |
| github_pr | title, body, diff | pr_url_or_number | github_live | stale_after_24h_or_state_change |
| evidence | content, description | source_hash_and_provenance | repo_and_surrealdb | no_expiry_hash_verified |
| claim | statement, rationale | evidence_ref_and_source_hash | repo_and_surrealdb | no_expiry_hash_verified |
| decision | description, rationale | ledger_source_and_event_id | git_ledger | no_expiry |
| external_doc | content, title | source_url_or_ref | external_upstream | stale_after_7d_or_upstream_change |

All marked \operational=false\, \acking_status=CONTRACT_ONLY\, \live_index_exists=false\.

### Explicitly Blocked (8)

secrets, broker_credentials, live_positions, live_orders, live_fills, live_risk_state, trading_runtime_control, agent_memory_raw

### GREEN Test Evidence

\\\
python -m pytest tests/unit/surrealdb/test_context_fulltext_bm25_contract.py -v
-> 7 passed in 0.39s
All 7 tests GREEN — contract doc exists, artifact exists, indexable categories defined,
forbidden categories blocked, all required fields present, no live DB claims, ownership matrix linked
\\\

### Validation

\\\
ruff check . -> 3 pre-existing errors in untouched .opencode/plans dirs (not related)
pytest tests/contract/ tests/unit/surrealdb/test_context_fulltext_bm25_contract.py tests/unit/surrealdb/test_context_smoke_db_contracts.py tests/unit/surrealdb/test_context_query_classifier.py -v
-> 103 passed (no regression)
\\\

### Ownership Matrix Linkage

Contract references:
- \rtifacts/surrealdb/context_data_model_ownership_matrix.json\
- \docs/surrealdb/CDB_CONTEXT_DATA_MODEL_OWNERSHIP.md\

### References

- Closes #3485 (once merged)
- Refs #3479, #3483
- Based on RED_ONLY commit 529c44c4