### PR TITLE
test-only(surrealdb): add red tests for agent memory contract

### DIFF
--- a/artifacts/surrealdb/agent_memory_contract.json
+++ b/artifacts/surrealdb/agent_memory_contract.json
@@ -1,0 +1,187 @@
+{
+  "$schema": "cdb://schemas/agent-memory-contract/v1",
+  "version": 1,
+  "meta": {
+    "title": "CDB Agent Memory Contract",
+    "description": "Defines the agent-facing memory classes, forbidden inputs, and gating rules for CDB Agent Memory. CONTRACT_ONLY — no productive DB write claims.",
+    "canonical_source": [
+      "docs/surrealdb/scoped-agent-memory-model-v1.md",
+      "docs/surrealdb/CDB_CONTEXT_DATA_MODEL_OWNERSHIP.md",
+      "artifacts/surrealdb/context_data_model_ownership_matrix.json",
+      "docs/surrealdb/CDB_CONTEXT_FULLTEXT_BM25_CONTRACT.md",
+      "artifacts/surrealdb/context_fulltext_bm25_contract.json",
+      "artifacts/mcp/mcp_access_boundary_matrix.json",
+      "artifacts/context_tool_inventory/tool_inventory.json",
+      "tools/mcp_access_boundary.py",
+      "tools/mcp/memory_write_intent_tools.py"
+    ],
+    "issues": ["#3490", "#3483", "#3485", "#3479"],
+    "created_by": "test-only/3490-agent-memory-contract",
+    "status": "CONTRACT_ONLY",
+    "live_db_operational": false,
+    "runtime_mapping_status": "NO_RUNTIME_MAPPING_IMPLEMENTED"
+  },
+  "allowed_memory_types": {
+    "operator_note": {
+      "scope": "issue_or_task_or_agent_scope_required",
+      "ttl_policy": "stale_after_7d_or_issue_state_change",
+      "source_of_truth": "repo_or_github_evidence",
+      "evidence_required": "source_hash_or_issue_ref_plus_evidence_ref",
+      "write_gate": "cdb_context_memory_write_intent_dry_run_only_human_go_required",
+      "read_gate": "cdb_context_memory_get_read_only_scoped_non_authoritative",
+      "redaction_required": true,
+      "operational": false,
+      "persist_allowed": false,
+      "mutation_allowed": false,
+      "backing_status": "CONTRACT_ONLY",
+      "future_storage_family_hint": "preference_memory",
+      "notes": "Operator observations must be summarized, scoped, and redacted. Never raw transcript capture."
+    },
+    "issue_memory": {
+      "scope": "issue_scope_required",
+      "ttl_policy": "stale_after_24h_or_issue_state_change",
+      "source_of_truth": "github_live_plus_repo_crosscheck",
+      "evidence_required": "issue_url_or_number_plus_evidence_ref",
+      "write_gate": "cdb_context_memory_write_intent_dry_run_only_human_go_required",
+      "read_gate": "cdb_context_memory_get_read_only_scoped_non_authoritative",
+      "redaction_required": true,
+      "operational": false,
+      "persist_allowed": false,
+      "mutation_allowed": false,
+      "backing_status": "CONTRACT_ONLY",
+      "future_storage_family_hint": "episodic_memory",
+      "notes": "Issue-local summaries follow live GitHub truth and must refresh when issue state changes."
+    },
+    "decision_memory": {
+      "scope": "decision_or_issue_scope_required",
+      "ttl_policy": "no_expiry_ledger_verified",
+      "source_of_truth": "git_ledger",
+      "evidence_required": "ledger_source_and_event_id",
+      "write_gate": "cdb_context_memory_write_intent_dry_run_only_human_go_required",
+      "read_gate": "cdb_context_memory_get_read_only_scoped_non_authoritative",
+      "redaction_required": true,
+      "operational": false,
+      "persist_allowed": false,
+      "mutation_allowed": false,
+      "backing_status": "CONTRACT_ONLY",
+      "future_storage_family_hint": "episodic_memory",
+      "notes": "Decision memory points to prior decisions but never replaces the ledger as source of truth."
+    },
+    "evidence_summary": {
+      "scope": "artifact_or_issue_scope_required",
+      "ttl_policy": "no_expiry_hash_verified",
+      "source_of_truth": "repo_and_evidence_refs",
+      "evidence_required": "source_hash_and_provenance",
+      "write_gate": "cdb_context_memory_write_intent_dry_run_only_human_go_required",
+      "read_gate": "cdb_context_memory_get_read_only_scoped_non_authoritative",
+      "redaction_required": true,
+      "operational": false,
+      "persist_allowed": false,
+      "mutation_allowed": false,
+      "backing_status": "CONTRACT_ONLY",
+      "future_storage_family_hint": "semantic_memory",
+      "notes": "Evidence summaries are compact pointers to already-audited evidence, not freeform assertions."
+    },
+    "session_lesson": {
+      "scope": "session_or_agent_scope_required",
+      "ttl_policy": "stale_after_24h_or_session_close",
+      "source_of_truth": "repo_and_session_evidence",
+      "evidence_required": "source_hash_or_evidence_ref",
+      "write_gate": "cdb_context_memory_write_intent_dry_run_only_human_go_required",
+      "read_gate": "cdb_context_memory_get_read_only_scoped_non_authoritative",
+      "redaction_required": true,
+      "operational": false,
+      "persist_allowed": false,
+      "mutation_allowed": false,
+      "backing_status": "CONTRACT_ONLY",
+      "future_storage_family_hint": "procedural_memory",
+      "notes": "Session lessons must be summarized, short-lived, and never treated as persistent truth by default."
+    },
+    "repo_fact_cache": {
+      "scope": "repo_path_or_component_scope_required",
+      "ttl_policy": "repo_refresh_on_main_merge_or_hash_change",
+      "source_of_truth": "repo",
+      "evidence_required": "source_hash",
+      "write_gate": "cdb_context_memory_write_intent_dry_run_only_human_go_required",
+      "read_gate": "cdb_context_memory_get_read_only_scoped_non_authoritative",
+      "redaction_required": true,
+      "operational": false,
+      "persist_allowed": false,
+      "mutation_allowed": false,
+      "backing_status": "CONTRACT_ONLY",
+      "future_storage_family_hint": "semantic_memory",
+      "notes": "Repo fact cache entries must be revalidated whenever the underlying repo hash changes."
+    }
+  },
+  "forbidden_memory_inputs": {
+    "secrets": {
+      "reason": "Secrets are never stored in any CDB system.",
+      "source_of_truth": "never_stored",
+      "notes": "API keys, passwords, tokens, and private keys are excluded before any memory classification."
+    },
+    "broker_credentials": {
+      "reason": "Broker and exchange credentials are never stored in memory.",
+      "source_of_truth": "never_stored",
+      "notes": "This includes API credentials, wallet secrets, and similar operator secrets."
+    },
+    "live_positions": {
+      "reason": "Live trading state remains Postgres-only runtime data.",
+      "source_of_truth": "postgres_trading",
+      "notes": "Positions are runtime data, not memory context."
+    },
+    "live_orders": {
+      "reason": "Live trading state remains Postgres-only runtime data.",
+      "source_of_truth": "postgres_trading",
+      "notes": "Orders in any state remain outside the agent memory contract."
+    },
+    "live_fills": {
+      "reason": "Live trading state remains Postgres-only runtime data.",
+      "source_of_truth": "postgres_trading",
+      "notes": "Fills are runtime execution data, not memory context."
+    },
+    "live_risk_state": {
+      "reason": "Live risk state remains Postgres-only runtime data.",
+      "source_of_truth": "postgres_trading",
+      "notes": "Exposure, drawdown, margin, and limits are forbidden memory inputs."
+    },
+    "trading_runtime_control": {
+      "reason": "Trading runtime control must never enter agent memory.",
+      "source_of_truth": "postgres_trading",
+      "notes": "Kill-switch state, execution flags, and live/shadow/paper mode are runtime-only."
+    },
+    "raw_chat_dump": {
+      "reason": "Raw transcripts are unredacted, weakly evidenced, and not stable memory input.",
+      "source_of_truth": "session_only",
+      "notes": "Only summarized and redacted lessons or notes may ever become future memory candidates."
+    },
+    "unscoped_agent_memory": {
+      "reason": "Unscoped memory violates the scoped memory model and cross-agent boundary.",
+      "source_of_truth": "never_stored",
+      "notes": "Global or cross-agent memory without explicit scope is forbidden."
+    }
+  },
+  "governance_rules": {
+    "persist_allowed_default": false,
+    "mutation_allowed_default": false,
+    "operational_requires_adapter_evidence": true,
+    "db_backed_readonly_proven_claim_forbidden": true,
+    "memory_write_intent_allowed_mode": "dry_run_only",
+    "memory_get_allowed_mode": "read_only",
+    "agent_memory_raw_excluded_from_fulltext": true,
+    "raw_chat_dump_forbidden": true,
+    "unscoped_agent_memory_forbidden": true,
+    "scope_ttl_evidence_redaction_required": true,
+    "governance_wins_over_surrealdb_capabilities": true
+  },
+  "references": [
+    "artifacts/surrealdb/context_data_model_ownership_matrix.json",
+    "docs/surrealdb/CDB_CONTEXT_DATA_MODEL_OWNERSHIP.md",
+    "artifacts/surrealdb/context_fulltext_bm25_contract.json",
+    "docs/surrealdb/CDB_CONTEXT_FULLTEXT_BM25_CONTRACT.md",
+    "docs/surrealdb/scoped-agent-memory-model-v1.md",
+    "artifacts/mcp/mcp_access_boundary_matrix.json",
+    "artifacts/context_tool_inventory/tool_inventory.json",
+    "tools/mcp_access_boundary.py",
+    "tools/mcp/memory_write_intent_tools.py"
+  ]
+}

--- a/docs/surrealdb/CDB_AGENT_MEMORY_CONTRACT.md
+++ b/docs/surrealdb/CDB_AGENT_MEMORY_CONTRACT.md
@@ -1,0 +1,195 @@
+# CDB Agent Memory Contract
+
+**Status:** CONTRACT_ONLY - no productive DB write claims.
+
+**Issues:** [#3490], [#3483], [#3485], [#3479]
+
+## 1. Purpose
+
+Agent Memory in CDB is a controlled subconscious context layer. It may help an
+agent remember scoped observations, issue-local findings, decision pointers,
+evidence summaries, and repo facts, but it is never truth and never
+authorisation.
+
+This contract defines the agent-facing memory classes that a future CDB memory
+implementation may accept, which inputs are forbidden, and which scope, TTL,
+evidence, read, write, and redaction gates must hold before any later runtime
+implementation is allowed to persist or expose memory.
+
+This slice is intentionally limited to contract documentation plus a
+machine-readable artifact. It does not operationalise memory writes, SurrealDB
+adapters, MCP mutation, or any live database behavior.
+
+## 2. Relationship To Existing Memory Surfaces
+
+This contract sits above the existing lower-level memory model in
+`docs/surrealdb/scoped-agent-memory-model-v1.md`.
+
+- `scoped-agent-memory-model-v1.md` defines the current low-level storage-side
+  memory families such as `working_memory`, `semantic_memory`, and
+  `episodic_memory`.
+- This contract defines the higher-level agent-facing memory classes that CDB
+  wants to allow at the policy boundary.
+- No runtime mapping from these contract classes to the lower-level storage
+  families is implemented in this slice.
+
+Because that mapping is not yet implemented and no adapter evidence exists, this
+contract remains `CONTRACT_ONLY`.
+
+## 3. Allowed Memory Types
+
+The following memory classes are allowed at the contract level.
+
+| Type | Practical role | Scope rule | TTL rule | Evidence rule | Read rule | Write rule |
+|------|----------------|------------|----------|---------------|-----------|------------|
+| `operator_note` | Human or operator observation summarized for a bounded task | issue/task/agent scoped | short-to-medium TTL | source hash or issue ref plus evidence | read-only, scoped, non-authoritative | dry-run gate only |
+| `issue_memory` | condensed issue-local status or findings | issue scoped | issue-state or 24h-bound refresh | issue ref plus evidence | read-only, scoped, non-authoritative | dry-run gate only |
+| `decision_memory` | bounded summary of a prior decision | decision/issue scoped | no-expiry only as contract pointer | ledger or decision evidence | read-only, scoped, non-authoritative | dry-run gate only |
+| `evidence_summary` | compact summary of evidence already collected | artifact/issue scoped | hash/freshness bound | evidence ref plus provenance | read-only, scoped, non-authoritative | dry-run gate only |
+| `session_lesson` | summarized lesson from a finished session | session/agent scoped | short-to-medium TTL | repo or issue evidence | read-only, scoped, non-authoritative | dry-run gate only |
+| `repo_fact_cache` | cached repo fact for repeated use | repo path/component scoped | refresh on main merge or hash change | source hash required | read-only, scoped, non-authoritative | dry-run gate only |
+
+All allowed types share the same hard boundaries:
+
+- scope is mandatory
+- TTL or freshness policy is mandatory
+- evidence linkage is mandatory
+- redaction is mandatory
+- reads are read-only-first
+- writes remain dry-run-only at the contract surface
+- `operational=false`
+- `persist_allowed=false`
+- `mutation_allowed=false`
+- `backing_status=CONTRACT_ONLY`
+
+## 4. Forbidden Inputs
+
+The following inputs are explicitly forbidden at the contract boundary:
+
+| Input | Why forbidden |
+|-------|---------------|
+| `secrets` | secrets are never stored in any CDB system |
+| `broker_credentials` | exchange or broker credentials are never stored |
+| `live_positions` | trading runtime data is Postgres-only |
+| `live_orders` | trading runtime data is Postgres-only |
+| `live_fills` | trading runtime data is Postgres-only |
+| `live_risk_state` | trading runtime data is Postgres-only |
+| `trading_runtime_control` | kill-switch and execution flags are runtime-only |
+| `raw_chat_dump` | raw chat transcripts are unredacted, unscoped, and not evidence-stable |
+| `unscoped_agent_memory` | global or cross-agent unscoped memory violates the scoped memory model |
+
+Additional exclusion inherited from the fulltext contract:
+
+- `agent_memory_raw` remains excluded from BM25/fulltext indexing.
+
+## 5. Scope, TTL, Evidence, Read, And Write Gates
+
+### Scope gate
+
+- No memory entry is valid without an explicit scope.
+- Issue, task, session, artifact, or agent scope must be named.
+- Cross-agent bypass remains forbidden.
+- `unscoped_agent_memory` is invalid by contract.
+
+### TTL gate
+
+- Memory is TTL-bound or freshness-bound.
+- Short-lived session knowledge must expire quickly.
+- Repo and issue facts must refresh when the underlying repo hash or GitHub
+  state changes.
+- No agent may treat stale memory as current truth.
+
+### Evidence gate
+
+- Every allowed memory type needs provenance.
+- A source hash, issue/PR reference, decision pointer, or evidence reference is
+  mandatory depending on type.
+- Memory without evidence remains invalid by contract.
+
+### Read gate
+
+- `cdb_context_memory_get` remains read-only.
+- Returned memory is advisory context, not truth.
+- Stale or superseded memory may be visible, but must not be treated as current
+  authority.
+
+### Write gate
+
+- `cdb_context_memory_write_intent` remains `dry_run_only`.
+- This contract does not authorise productive writes.
+- `PERSIST_ALLOWED` stays false at the contract surface.
+- `MUTATION_ALLOWED` stays false at the contract surface.
+
+### Redaction gate
+
+- Raw chat dumps are forbidden.
+- Sensitive values must be summarized or redacted before any future memory write
+  flow is considered.
+- Secrets, credentials, and live trading state remain blocked before any
+  SurrealDB capability is considered.
+
+## 6. Why The Contract Is Not Operational Yet
+
+This contract is not operational because the current repo evidence shows:
+
+- `cdb_context_memory_get` is exposed as read-only, but remains
+  `DB_BACKED_READONLY_UNPROVEN` in the MCP boundary matrix.
+- `cdb_context_memory_write_intent` is exposed as a dry-run gate only and stays
+  `CONTRACT_ONLY` in tool inventory.
+- no adapter evidence proves `DB_BACKED_READONLY_PROVEN`
+- no productive write path is authorised by this slice
+
+Therefore this contract must not claim:
+
+- `operational=true`
+- `PERSIST_ALLOWED=true`
+- `MUTATION_ALLOWED=true`
+- `DB_BACKED_READONLY_PROVEN`
+
+## 7. Relationship To #3483 Ownership And #3485 Fulltext
+
+### Ownership matrix (#3483)
+
+`artifacts/surrealdb/context_data_model_ownership_matrix.json` defines the
+underlying `agent_memory` category as scoped, TTL-bound, and evidence-linked.
+It also marks the category as conceptually persist-capable inside the ownership
+model.
+
+This contract does not elevate that ownership capability into current runtime
+write permission. At the agent-facing boundary, persistence remains blocked
+until a dedicated implementation slice proves the adapter, gate, and audit path.
+
+### Fulltext contract (#3485)
+
+`artifacts/surrealdb/context_fulltext_bm25_contract.json` explicitly excludes
+`agent_memory_raw` from BM25 indexing.
+
+This contract inherits that boundary:
+
+- no raw chat dump storage
+- no raw agent memory indexing
+- no assumption that agent memory is searchable as normal repo/evidence content
+
+## 8. What A Later GO Would Still Need
+
+The following is outside this slice and requires a separate GO:
+
+- runtime mapping from these contract types to low-level memory families
+- adapter-backed evidence for any DB-backed claim
+- explicit approval model for any productive memory persistence
+- cross-agent handoff semantics beyond read-only consumption
+- validated redaction pipeline for memory creation
+
+Until then, the only allowed outcome is a documented contract surface plus a
+machine-readable artifact.
+
+## 9. References
+
+- `docs/surrealdb/scoped-agent-memory-model-v1.md`
+- `docs/surrealdb/CDB_CONTEXT_DATA_MODEL_OWNERSHIP.md`
+- `artifacts/surrealdb/context_data_model_ownership_matrix.json`
+- `docs/surrealdb/CDB_CONTEXT_FULLTEXT_BM25_CONTRACT.md`
+- `artifacts/surrealdb/context_fulltext_bm25_contract.json`
+- `artifacts/mcp/mcp_access_boundary_matrix.json`
+- `artifacts/context_tool_inventory/tool_inventory.json`
+- `tools/mcp_access_boundary.py`

--- a/tests/unit/surrealdb/test_agent_memory_contract.py
+++ b/tests/unit/surrealdb/test_agent_memory_contract.py
@@ -1,0 +1,160 @@
+"""
+test_id: tc_agent_memory_contract_001
+test_type: wissens
+cdb_area: surrealdb/agent_memory
+rule_ref: INV-CONTEXT-010
+decision_ref: Agent Memory Contract schreibt Memory-Typen, Gates, TTL, Evidence-Link und Blocklist vor
+issue_ref: "#3490"
+pr_ref: TBD
+evidence_ref: RED_ONLY — Contract existiert noch nicht
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CONTRACT_DOC_PATH = (
+    REPO_ROOT / "docs" / "surrealdb" / "CDB_AGENT_MEMORY_CONTRACT.md"
+)
+CONTRACT_ARTIFACT_PATH = (
+    REPO_ROOT / "artifacts" / "surrealdb" / "agent_memory_contract.json"
+)
+OWNERSHIP_MATRIX_PATH = (
+    REPO_ROOT / "artifacts" / "surrealdb" / "context_data_model_ownership_matrix.json"
+)
+FULLTEXT_CONTRACT_PATH = (
+    REPO_ROOT / "artifacts" / "surrealdb" / "context_fulltext_bm25_contract.json"
+)
+
+ALLOWED_MEMORY_TYPES = frozenset(
+    {
+        "operator_note",
+        "issue_memory",
+        "decision_memory",
+        "evidence_summary",
+        "session_lesson",
+        "repo_fact_cache",
+    }
+)
+
+FORBIDDEN_MEMORY_INPUTS = frozenset(
+    {
+        "secrets",
+        "broker_credentials",
+        "live_positions",
+        "live_orders",
+        "live_fills",
+        "live_risk_state",
+        "trading_runtime_control",
+        "raw_chat_dump",
+        "unscoped_agent_memory",
+    }
+)
+
+REQUIRED_TYPE_FIELDS = frozenset(
+    {
+        "scope",
+        "ttl_policy",
+        "source_of_truth",
+        "evidence_required",
+        "write_gate",
+        "read_gate",
+        "redaction_required",
+    }
+)
+
+
+def _load_contract() -> dict:
+    if not CONTRACT_ARTIFACT_PATH.exists():
+        pytest.fail(
+            f"Agent Memory contract artifact not found at {CONTRACT_ARTIFACT_PATH}. "
+            f"Expected a JSON file with allowed memory types, forbidden inputs, "
+            f"and gate configuration."
+        )
+    with open(CONTRACT_ARTIFACT_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+class TestAgentMemoryContract:
+    def test_agent_memory_contract_doc_exists(self):
+        assert CONTRACT_DOC_PATH.exists(), (
+            f"RED: Agent Memory contract documentation does not exist at "
+            f"{CONTRACT_DOC_PATH}. "
+            f"Expected: docs/surrealdb/CDB_AGENT_MEMORY_CONTRACT.md"
+        )
+
+    def test_agent_memory_contract_artifact_exists(self):
+        assert CONTRACT_ARTIFACT_PATH.exists(), (
+            f"RED: Agent Memory contract artifact does not exist at "
+            f"{CONTRACT_ARTIFACT_PATH}. "
+            f"Expected: artifacts/surrealdb/agent_memory_contract.json"
+        )
+
+    def test_contract_defines_allowed_memory_types(self):
+        contract = _load_contract()
+        allowed = set(contract.get("allowed_memory_types", {}).keys())
+        missing = ALLOWED_MEMORY_TYPES - allowed
+        assert not missing, (
+            f"RED: Required allowed memory types missing from contract: "
+            f"{sorted(missing)}. "
+            f"Expected allowed: {sorted(ALLOWED_MEMORY_TYPES)}"
+        )
+
+    def test_contract_blocks_forbidden_memory_inputs(self):
+        contract = _load_contract()
+        forbidden = set(contract.get("forbidden_memory_inputs", {}).keys())
+        missing_blocked = FORBIDDEN_MEMORY_INPUTS - forbidden
+        assert not missing_blocked, (
+            f"RED: Forbidden memory inputs missing from contract blocklist: "
+            f"{sorted(missing_blocked)}. "
+            f"All secrets, live trading state, credentials, raw chat dumps, "
+            f"and unscoped agent memory must be explicitly blocked."
+        )
+
+    def test_each_memory_type_requires_scope_ttl_and_evidence(self):
+        contract = _load_contract()
+        for type_name, type_data in contract.get("allowed_memory_types", {}).items():
+            missing_fields = REQUIRED_TYPE_FIELDS - set(type_data.keys())
+            assert not missing_fields, (
+                f"RED: Allowed memory type '{type_name}' missing required fields: "
+                f"{sorted(missing_fields)}. "
+                f"Expected fields: {sorted(REQUIRED_TYPE_FIELDS)}"
+            )
+
+    def test_no_memory_contract_claims_productive_db_write(self):
+        contract = _load_contract()
+        for type_name, type_data in contract.get("allowed_memory_types", {}).items():
+            assert type_data.get("operational") is not True, (
+                f"RED: Memory type '{type_name}' claims operational=true. "
+                f"No memory contract may claim productive DB operationality "
+                f"without adapter evidence."
+            )
+            assert type_data.get("persist_allowed") is not True, (
+                f"RED: Memory type '{type_name}' claims PERSIST_ALLOWED=true. "
+                f"Agent memory contract must remain CONTRACT_ONLY until "
+                f"adapter evidence is provided."
+            )
+            assert type_data.get("mutation_allowed") is not True, (
+                f"RED: Memory type '{type_name}' claims MUTATION_ALLOWED=true. "
+                f"Memory mutation must remain blocked without adapter evidence."
+            )
+
+    def test_agent_memory_links_to_ownership_and_fulltext_contracts(self):
+        contract = _load_contract()
+        refs = contract.get("references", [])
+        assert str(OWNERSHIP_MATRIX_PATH) in refs or "context_data_model_ownership_matrix.json" in str(
+            refs
+        ), (
+            f"RED: Agent Memory contract does not reference the data model ownership "
+            f"matrix at {OWNERSHIP_MATRIX_PATH}."
+        )
+        assert str(FULLTEXT_CONTRACT_PATH) in refs or "context_fulltext_bm25_contract.json" in str(
+            refs
+        ), (
+            f"RED: Agent Memory contract does not reference the fulltext BM25 "
+            f"contract at {FULLTEXT_CONTRACT_PATH}."
+        )


### PR DESCRIPTION
## IMPLEMENTED - Agent Memory Contract

This PR started as a RED_ONLY test slice. It now implements the minimal #3490 contract surface required to turn the 7 RED tests GREEN, without adding productive memory writes, DB operationality claims, or MCP mutation.

### Delivered

| Artifact | Path |
|---|---|
| Contract doc | `docs/surrealdb/CDB_AGENT_MEMORY_CONTRACT.md` |
| Contract artifact | `artifacts/surrealdb/agent_memory_contract.json` |

### Allowed Memory Types (6)

- `operator_note`
- `issue_memory`
- `decision_memory`
- `evidence_summary`
- `session_lesson`
- `repo_fact_cache`

Each allowed type defines: `scope`, `ttl_policy`, `source_of_truth`, `evidence_required`, `write_gate`, `read_gate`, and `redaction_required`.

All allowed types remain:

- `operational=false`
- `persist_allowed=false`
- `mutation_allowed=false`
- `backing_status=CONTRACT_ONLY`

### Forbidden Memory Inputs (9)

- `secrets`
- `broker_credentials`
- `live_positions`
- `live_orders`
- `live_fills`
- `live_risk_state`
- `trading_runtime_control`
- `raw_chat_dump`
- `unscoped_agent_memory`

### Key Safety Boundaries

- `cdb_context_memory_write_intent` remains `dry_run_only`
- `cdb_context_memory_get` remains read-only
- no `DB_BACKED_READONLY_PROVEN` claim
- no productive memory-write authorization
- `agent_memory_raw` remains excluded from fulltext/BM25 indexing
- governance wins over SurrealDB capabilities

### GREEN Evidence

```text
python -m pytest tests/unit/surrealdb/test_agent_memory_contract.py -q
-> 7 passed

ruff check tests/unit/surrealdb/test_agent_memory_contract.py
-> All checks passed

python -m pytest tests/unit/surrealdb/test_context_data_model_ownership_matrix.py -q
-> 6 passed

python -m pytest tests/unit/surrealdb/test_context_fulltext_bm25_contract.py -q
-> 7 passed

python -m pytest tests/unit/mcp -q
-> 9 passed

git diff --check
-> clean
```

### Reconciled With Existing Canon

- `scoped-agent-memory-model-v1.md` remains the lower-level storage-side memory model
- this PR adds the higher-level agent-facing contract layer only
- no runtime mapping from contract classes to storage families is implemented in this slice

### References

- Closes #3490
- Refs #3479
- Refs #3483
- Refs #3485