### PR TITLE
test-only(surrealdb): add red tests for drift stale contradiction contract

### DIFF
--- a/artifacts/surrealdb/context_drift_stale_contradiction_contract.json
+++ b/artifacts/surrealdb/context_drift_stale_contradiction_contract.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "cdb://schemas/context-drift-stale-contradiction-contract/v1",
+  "version": 1,
+  "meta": {
+    "title": "CDB Context Drift / Stale / Contradiction Contract",
+    "description": "Top-level warning-layer contract for drift, stale knowledge, and contradiction findings across repo, GitHub, claim, decision, and memory surfaces. CONTRACT_ONLY — no operational detection or mutation claims.",
+    "canonical_source": [
+      "docs/surrealdb/CDB_CONTEXT_DRIFT_STALE_CONTRADICTION_CONTRACT.md",
+      "docs/surrealdb/context-contradiction-detection-runbook.md",
+      "docs/surrealdb/stale-knowledge-runbook.md",
+      "docs/surrealdb/scope-drift-runbook.md",
+      "artifacts/surrealdb/context_data_model_ownership_matrix.json",
+      "artifacts/surrealdb/context_fulltext_bm25_contract.json",
+      "artifacts/surrealdb/agent_memory_contract.json",
+      "artifacts/mcp/mcp_access_boundary_matrix.json",
+      "artifacts/context_tool_inventory/tool_inventory.json"
+    ],
+    "issues": [
+      "#3491",
+      "#3483",
+      "#3485",
+      "#3490",
+      "#3479"
+    ],
+    "created_by": "test-only/3491-drift-stale-contradiction-contract",
+    "status": "CONTRACT_ONLY",
+    "live_db_operational": false
+  },
+  "detectable_signal_types": {
+    "stale_doc": {
+      "source_category": "repo_file",
+      "evidence_required": "source_hash",
+      "freshness_policy": "no_expiry_hash_verified_or_repo_refresh_on_main_merge",
+      "detection_basis": "repo doc hash or contract snapshot differs from current repo-backed source",
+      "severity": "warning",
+      "resolution_state": "open",
+      "owner": "context_indexer",
+      "allowed_action": "recommend_refresh_only",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_detection_enabled": false,
+      "mutation_allowed": false
+    },
+    "stale_issue_status": {
+      "source_category": "github_issue",
+      "evidence_required": "issue_url_or_number",
+      "freshness_policy": "stale_after_24h_or_state_change",
+      "detection_basis": "repo or cached issue statement diverges from GitHub live issue state",
+      "severity": "warning",
+      "resolution_state": "open",
+      "owner": "jannek",
+      "allowed_action": "recommend_live_recheck_only",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_detection_enabled": false,
+      "mutation_allowed": false
+    },
+    "stale_pr_status": {
+      "source_category": "github_pr",
+      "evidence_required": "pr_url_or_number",
+      "freshness_policy": "stale_after_24h_or_state_change",
+      "detection_basis": "repo or cached PR statement diverges from GitHub live PR state",
+      "severity": "warning",
+      "resolution_state": "open",
+      "owner": "jannek",
+      "allowed_action": "recommend_live_recheck_only",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_detection_enabled": false,
+      "mutation_allowed": false
+    },
+    "stale_claim": {
+      "source_category": "claim",
+      "evidence_required": "evidence_ref_and_source_hash",
+      "freshness_policy": "no_expiry_hash_verified_but_invalid_when_evidence_or_source_is_stale",
+      "detection_basis": "claim status, evidence freshness, or source hash no longer supports the claim",
+      "severity": "warning",
+      "resolution_state": "open",
+      "owner": "context_indexer",
+      "allowed_action": "recommend_evidence_recheck_only",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_detection_enabled": false,
+      "mutation_allowed": false
+    },
+    "stale_memory": {
+      "source_category": "agent_memory",
+      "evidence_required": "source_hash_or_evidence_ref",
+      "freshness_policy": "ttl_bound_agent_id_and_namespace_or_issue_state_change",
+      "detection_basis": "memory TTL elapsed or scoped source context changed",
+      "severity": "warning",
+      "resolution_state": "open",
+      "owner": "agents",
+      "allowed_action": "recommend_memory_refresh_only",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_detection_enabled": false,
+      "mutation_allowed": false
+    },
+    "contradicted_claim": {
+      "source_category": "claim",
+      "evidence_required": "evidence_ref_and_source_hash",
+      "freshness_policy": "no_truth_without_current_evidence",
+      "detection_basis": "claim is disputed by evidence, repo truth, or source-of-truth record",
+      "severity": "blocking",
+      "resolution_state": "open",
+      "owner": "context_indexer",
+      "allowed_action": "request_human_review_only",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_detection_enabled": false,
+      "mutation_allowed": false
+    },
+    "contradicted_decision": {
+      "source_category": "decision",
+      "evidence_required": "ledger_source_and_event_id",
+      "freshness_policy": "no_expiry_ledger_verified_but_recheck_when_new_evidence_conflicts",
+      "detection_basis": "decision conflicts with newer evidence, newer canon, or explicit superseding decision",
+      "severity": "blocking",
+      "resolution_state": "open",
+      "owner": "agents_via_ledger",
+      "allowed_action": "request_human_review_only",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_detection_enabled": false,
+      "mutation_allowed": false
+    },
+    "repo_doc_drift": {
+      "source_category": "repo_file",
+      "evidence_required": "source_hash_and_repo_crosscheck",
+      "freshness_policy": "repo_refresh_on_main_merge",
+      "detection_basis": "repo docs, contracts, or artifacts diverge inside the working repo canon",
+      "severity": "warning",
+      "resolution_state": "open",
+      "owner": "context_indexer",
+      "allowed_action": "recommend_repo_reconcile_only",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_detection_enabled": false,
+      "mutation_allowed": false
+    },
+    "github_repo_drift": {
+      "source_category": "github_issue_or_pr",
+      "evidence_required": "live_issue_or_pr_ref_plus_repo_crosscheck",
+      "freshness_policy": "stale_after_24h_or_state_change",
+      "detection_basis": "GitHub live state and repo ledger/doc claim diverge and need conservative reconciliation",
+      "severity": "warning",
+      "resolution_state": "open",
+      "owner": "jannek",
+      "allowed_action": "recommend_live_reconcile_only",
+      "operational": false,
+      "backing_status": "CONTRACT_ONLY",
+      "live_detection_enabled": false,
+      "mutation_allowed": false
+    }
+  },
+  "resolution_states": [
+    "open",
+    "confirmed",
+    "dismissed",
+    "superseded",
+    "fixed",
+    "parked"
+  ],
+  "forbidden_auto_resolution": {
+    "auto_close_issue": {
+      "reason": "Issue state changes require live evidence review and explicit human-directed action."
+    },
+    "auto_change_live_gate": {
+      "reason": "Board stage and LR gate changes are separate governance systems and cannot be auto-mutated."
+    },
+    "auto_override_lr_status": {
+      "reason": "LR remains SSOT-governed and cannot be upgraded or downgraded by warning-layer findings."
+    },
+    "auto_delete_memory": {
+      "reason": "Memory findings are advisory only; deletion requires a separate scoped and approved path."
+    },
+    "auto_mutate_db": {
+      "reason": "This slice authorises no DB mutation and no MCP mutation."
+    },
+    "auto_mark_claim_true_without_evidence": {
+      "reason": "Claims never become true by warning-layer inference alone; evidence is mandatory."
+    }
+  },
+  "hard_rules": {
+    "operational": false,
+    "db_backed_readonly_proven_claim_allowed": false,
+    "live_detection_enabled": false,
+    "mutation_allowed": false,
+    "auto_close_issue_allowed": false,
+    "auto_change_live_gate_allowed": false,
+    "auto_override_lr_status_allowed": false,
+    "auto_delete_memory_allowed": false,
+    "auto_mutate_db_allowed": false,
+    "auto_mark_claim_true_without_evidence_allowed": false,
+    "warning_layer_mark_and_recommend_only": true,
+    "governance_wins_over_surrealdb_capabilities": true
+  },
+  "references": [
+    "docs/surrealdb/CDB_CONTEXT_DRIFT_STALE_CONTRADICTION_CONTRACT.md",
+    "docs/surrealdb/context-contradiction-detection-runbook.md",
+    "docs/surrealdb/stale-knowledge-runbook.md",
+    "docs/surrealdb/scope-drift-runbook.md",
+    "artifacts/surrealdb/context_data_model_ownership_matrix.json",
+    "artifacts/surrealdb/context_fulltext_bm25_contract.json",
+    "artifacts/surrealdb/agent_memory_contract.json",
+    "artifacts/mcp/mcp_access_boundary_matrix.json",
+    "artifacts/context_tool_inventory/tool_inventory.json"
+  ]
+}

--- a/docs/surrealdb/CDB_CONTEXT_DRIFT_STALE_CONTRADICTION_CONTRACT.md
+++ b/docs/surrealdb/CDB_CONTEXT_DRIFT_STALE_CONTRADICTION_CONTRACT.md
@@ -1,0 +1,187 @@
+# CDB Context Drift / Stale / Contradiction Contract
+
+**Status:** CONTRACT_ONLY — warning-layer contract only, no operational detection.
+
+**Issues:** [#3491], [#3483], [#3485], [#3490], [#3479]
+
+## 1. Purpose
+
+This contract defines the top-level CDB warning layer for drift, stale knowledge,
+and contradiction findings around Context / SurrealDB surfaces.
+
+Practical meaning in CDB:
+
+- **stale** means a repo, GitHub, claim, decision, or memory statement is no
+  longer fresh enough to be trusted without re-checking the source of truth
+- **contradiction** means two authoritative or quasi-authoritative sources
+  disagree and need human review
+- **drift** means repo docs, live GitHub reality, or declared scope have
+  diverged enough that an agent must stop, warn, or narrow its claim
+
+This slice is intentionally limited to:
+
+- one concise contract document
+- one machine-readable contract artifact
+- warning-layer semantics only
+
+This slice does **not** build:
+
+- a drift engine
+- a stale scanner
+- a contradiction resolver
+- auto-resolution
+- DB-backed detection
+- productive Evidence / Claim / Decision / Memory writes
+
+## 2. Contract Posture
+
+Hard rules for this slice:
+
+- `operational=false`
+- `DB_BACKED_READONLY_PROVEN` must not be claimed
+- `live_detection_enabled=false`
+- `mutation_allowed=false`
+- no automatic issue closure
+- no automatic LR or live-gate change
+- no automatic DB mutation
+- no claim truth promotion without evidence
+- the warning layer may mark and recommend, but never authorise
+- CDB governance wins over SurrealDB capabilities
+
+Repo-backed context for the current warning surfaces:
+
+- the Wave-15/16/17/20 tools exist as read-only signal surfaces
+- `artifacts/context_tool_inventory/tool_inventory.json` keeps the warning tools
+  at `CONTRACT_ONLY`
+- `artifacts/mcp/mcp_access_boundary_matrix.json` keeps them
+  `ALLOWED_READONLY` but `DB_BACKED_READONLY_UNPROVEN`
+
+Therefore the contract must stay **signal-only** and **non-operational**.
+
+## 3. Detectable Signal Types
+
+Each signal type carries:
+
+- `source_category`
+- `evidence_required`
+- `freshness_policy`
+- `detection_basis`
+- `severity`
+- `resolution_state`
+- `owner`
+- `allowed_action`
+
+### Signal matrix
+
+| Signal | Meaning | Typical source | Severity | Allowed action |
+|---|---|---|---|---|
+| `stale_doc` | repo doc is older than its verified repo truth | repo file | `warning` | recommend refresh only |
+| `stale_issue_status` | issue narrative is stale against GitHub live | GitHub issue | `warning` | recommend live recheck only |
+| `stale_pr_status` | PR narrative is stale against GitHub live | GitHub PR | `warning` | recommend live recheck only |
+| `stale_claim` | claim freshness or linked evidence is stale | claim + evidence | `warning` | recommend evidence recheck only |
+| `stale_memory` | scoped memory expired or lost freshness | agent memory | `warning` | recommend memory refresh only |
+| `contradicted_claim` | a claim is disputed by evidence or source truth | claim + evidence | `blocking` | request human review only |
+| `contradicted_decision` | a decision conflicts with newer evidence or canon | decision + evidence | `blocking` | request human review only |
+| `repo_doc_drift` | repo docs and current repo-backed contract surfaces diverge | repo docs + artifacts | `warning` | recommend repo reconcile only |
+| `github_repo_drift` | GitHub live state and repo/ledger claim diverge | GitHub + repo | `warning` | recommend live reconcile only |
+
+## 4. Evidence And Freshness Rules
+
+The warning layer inherits evidence and freshness boundaries from the foundation
+contracts:
+
+- repo-backed surfaces require source hashes where applicable
+- GitHub-backed surfaces require live issue/PR references and refresh on state
+  change or TTL expiry
+- claim and evidence surfaces require provenance plus source-linked evidence
+- decision surfaces point back to the Git ledger
+- memory surfaces remain scoped, TTL-bound, and non-authoritative
+
+Practical freshness policy by family:
+
+| Family | Freshness rule |
+|---|---|
+| repo docs / repo artifacts | hash-verified or refresh on main merge |
+| GitHub issue / PR mirrors | stale after 24h or state change |
+| claims / evidence | hash-verified, no truth without evidence |
+| decisions | no-expiry ledger pointer, but contradiction possible against new evidence |
+| agent memory | TTL-bound or refresh on issue/session/state change |
+
+## 5. Resolution States
+
+The contract recognises six resolution states:
+
+| State | Meaning |
+|---|---|
+| `open` | finding exists and is not yet triaged |
+| `confirmed` | finding is real and acknowledged |
+| `dismissed` | finding was reviewed and rejected |
+| `superseded` | a newer finding or decision replaces it |
+| `fixed` | the underlying source divergence was reconciled |
+| `parked` | deferred intentionally without pretending the gap disappeared |
+
+These states classify a finding. They do not authorise write actions by
+themselves.
+
+## 6. Explicitly Forbidden Auto-Resolutions
+
+The following actions must remain blocked:
+
+- `auto_close_issue`
+- `auto_change_live_gate`
+- `auto_override_lr_status`
+- `auto_delete_memory`
+- `auto_mutate_db`
+- `auto_mark_claim_true_without_evidence`
+
+If a warning surface suggests any of the above, the correct interpretation is:
+
+- stop
+- gather evidence
+- require human review or a separate implementation/governance slice
+
+## 7. Foundation Contract Linkage
+
+This contract sits above three foundation contracts:
+
+1. **#3483 Ownership**
+   - `docs/surrealdb/CDB_CONTEXT_DATA_MODEL_OWNERSHIP.md`
+   - `artifacts/surrealdb/context_data_model_ownership_matrix.json`
+   - supplies source-of-truth, owner, mirror, persistence, and forbidden-domain boundaries
+2. **#3485 Fulltext / BM25**
+   - `docs/surrealdb/CDB_CONTEXT_FULLTEXT_BM25_CONTRACT.md`
+   - `artifacts/surrealdb/context_fulltext_bm25_contract.json`
+   - supplies repo/GitHub/evidence/claim/decision freshness cues and the fulltext exclusion posture
+3. **#3490 Agent Memory**
+   - `docs/surrealdb/CDB_AGENT_MEMORY_CONTRACT.md`
+   - `artifacts/surrealdb/agent_memory_contract.json`
+   - supplies scoped memory TTL, evidence, and non-authoritative read/write boundaries
+
+## 8. Safety Boundaries
+
+This contract does not authorise:
+
+- runtime or BLUE/RED changes
+- productive SurrealDB writes
+- MCP mutation
+- live detection
+- live trading or Echtgeld actions
+- LR uplift
+- GitHub issue state changes without separate human-directed evidence
+
+The only truthful outcome of this slice is:
+
+- a documented contract surface
+- a machine-readable artifact
+- repo-backed tests turning green for the contract-only warning layer
+
+## 9. References
+
+- `artifacts/surrealdb/context_data_model_ownership_matrix.json`
+- `artifacts/surrealdb/context_fulltext_bm25_contract.json`
+- `artifacts/surrealdb/agent_memory_contract.json`
+- `artifacts/mcp/mcp_access_boundary_matrix.json`
+- `artifacts/context_tool_inventory/tool_inventory.json`
+- `docs/surrealdb/context-contradiction-detection-runbook.md`
+- `docs/surrealdb/stale-knowledge-runbook.md`
+- `docs/surrealdb/scope-drift-runbook.md`

--- a/tests/unit/surrealdb/test_context_drift_stale_contradiction_contract.py
+++ b/tests/unit/surrealdb/test_context_drift_stale_contradiction_contract.py
@@ -1,0 +1,197 @@
+"""
+test_id: tc_context_drift_stale_contradiction_contract_001
+test_type: wissens
+cdb_area: surrealdb/context_warning_layer
+rule_ref: INV-CONTEXT-011
+decision_ref: Drift-, Stale- und Contradiction-Erkennung braucht einen expliziten CDB-Contract
+issue_ref: "#3491"
+pr_ref: TBD
+evidence_ref: RED_ONLY - Contract existiert noch nicht
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CONTRACT_DOC_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "surrealdb"
+    / "CDB_CONTEXT_DRIFT_STALE_CONTRADICTION_CONTRACT.md"
+)
+CONTRACT_ARTIFACT_PATH = (
+    REPO_ROOT
+    / "artifacts"
+    / "surrealdb"
+    / "context_drift_stale_contradiction_contract.json"
+)
+OWNERSHIP_MATRIX_PATH = (
+    REPO_ROOT / "artifacts" / "surrealdb" / "context_data_model_ownership_matrix.json"
+)
+FULLTEXT_CONTRACT_PATH = (
+    REPO_ROOT / "artifacts" / "surrealdb" / "context_fulltext_bm25_contract.json"
+)
+AGENT_MEMORY_CONTRACT_PATH = (
+    REPO_ROOT / "artifacts" / "surrealdb" / "agent_memory_contract.json"
+)
+
+DETECTABLE_SIGNAL_TYPES = frozenset(
+    {
+        "stale_doc",
+        "stale_issue_status",
+        "stale_pr_status",
+        "stale_claim",
+        "stale_memory",
+        "contradicted_claim",
+        "contradicted_decision",
+        "repo_doc_drift",
+        "github_repo_drift",
+    }
+)
+
+REQUIRED_SIGNAL_FIELDS = frozenset(
+    {
+        "source_category",
+        "evidence_required",
+        "freshness_policy",
+        "detection_basis",
+        "severity",
+        "resolution_state",
+        "owner",
+        "allowed_action",
+    }
+)
+
+RESOLUTION_STATES = frozenset(
+    {
+        "open",
+        "confirmed",
+        "dismissed",
+        "superseded",
+        "fixed",
+        "parked",
+    }
+)
+
+UNSAFE_AUTO_RESOLUTIONS = frozenset(
+    {
+        "auto_close_issue",
+        "auto_change_live_gate",
+        "auto_override_lr_status",
+        "auto_delete_memory",
+        "auto_mutate_db",
+        "auto_mark_claim_true_without_evidence",
+    }
+)
+
+
+def _load_contract() -> dict:
+    if not CONTRACT_ARTIFACT_PATH.exists():
+        pytest.fail(
+            f"Drift/Stale/Contradiction contract artifact not found at "
+            f"{CONTRACT_ARTIFACT_PATH}. Expected a JSON file with detectable "
+            f"signal types, resolution states, and unsafe auto-resolution blocklist."
+        )
+    with open(CONTRACT_ARTIFACT_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+class TestContextDriftStaleContradictionContract:
+    def test_drift_stale_contradiction_contract_doc_exists(self):
+        assert CONTRACT_DOC_PATH.exists(), (
+            f"RED: Drift/Stale/Contradiction contract documentation does not exist at "
+            f"{CONTRACT_DOC_PATH}. Expected: "
+            f"docs/surrealdb/CDB_CONTEXT_DRIFT_STALE_CONTRADICTION_CONTRACT.md"
+        )
+
+    def test_drift_stale_contradiction_contract_artifact_exists(self):
+        assert CONTRACT_ARTIFACT_PATH.exists(), (
+            f"RED: Drift/Stale/Contradiction contract artifact does not exist at "
+            f"{CONTRACT_ARTIFACT_PATH}. Expected: "
+            f"artifacts/surrealdb/context_drift_stale_contradiction_contract.json"
+        )
+
+    def test_contract_defines_detectable_signal_types(self):
+        contract = _load_contract()
+        signal_types = set(contract.get("detectable_signal_types", {}).keys())
+        missing = DETECTABLE_SIGNAL_TYPES - signal_types
+        assert not missing, (
+            f"RED: Required detectable signal types missing from contract: "
+            f"{sorted(missing)}. Expected signal types: "
+            f"{sorted(DETECTABLE_SIGNAL_TYPES)}"
+        )
+
+    def test_each_signal_type_requires_evidence_and_resolution_state(self):
+        contract = _load_contract()
+        for signal_name, signal_data in contract.get("detectable_signal_types", {}).items():
+            missing_fields = REQUIRED_SIGNAL_FIELDS - set(signal_data.keys())
+            assert not missing_fields, (
+                f"RED: Signal type '{signal_name}' missing required fields: "
+                f"{sorted(missing_fields)}. Expected fields: "
+                f"{sorted(REQUIRED_SIGNAL_FIELDS)}"
+            )
+
+    def test_contract_defines_resolution_states(self):
+        contract = _load_contract()
+        states = set(contract.get("resolution_states", []))
+        missing_states = RESOLUTION_STATES - states
+        assert not missing_states, (
+            f"RED: Required resolution states missing from contract: "
+            f"{sorted(missing_states)}. Expected states: {sorted(RESOLUTION_STATES)}"
+        )
+
+    def test_contract_blocks_unsafe_auto_resolution(self):
+        contract = _load_contract()
+        blocked = set(contract.get("forbidden_auto_resolution", {}).keys())
+        missing_blocked = UNSAFE_AUTO_RESOLUTIONS - blocked
+        assert not missing_blocked, (
+            f"RED: Unsafe auto-resolution actions missing from blocklist: "
+            f"{sorted(missing_blocked)}. These actions must remain explicitly blocked."
+        )
+
+    def test_contract_links_to_foundation_contracts(self):
+        contract = _load_contract()
+        refs = contract.get("references", [])
+        assert str(OWNERSHIP_MATRIX_PATH) in refs or "context_data_model_ownership_matrix.json" in str(
+            refs
+        ), (
+            f"RED: Contract does not reference the ownership matrix at "
+            f"{OWNERSHIP_MATRIX_PATH}."
+        )
+        assert str(FULLTEXT_CONTRACT_PATH) in refs or "context_fulltext_bm25_contract.json" in str(
+            refs
+        ), (
+            f"RED: Contract does not reference the fulltext contract at "
+            f"{FULLTEXT_CONTRACT_PATH}."
+        )
+        assert str(AGENT_MEMORY_CONTRACT_PATH) in refs or "agent_memory_contract.json" in str(
+            refs
+        ), (
+            f"RED: Contract does not reference the agent memory contract at "
+            f"{AGENT_MEMORY_CONTRACT_PATH}."
+        )
+
+    def test_no_contract_claims_operational_surrealdb_detection(self):
+        contract = _load_contract()
+        for signal_name, signal_data in contract.get("detectable_signal_types", {}).items():
+            assert signal_data.get("operational") is not True, (
+                f"RED: Signal type '{signal_name}' claims operational=true. "
+                f"No contract may claim live SurrealDB detection without adapter evidence."
+            )
+            assert signal_data.get("backing_status") != "DB_BACKED_READONLY_PROVEN", (
+                f"RED: Signal type '{signal_name}' claims DB_BACKED_READONLY_PROVEN. "
+                f"Contract must remain CONTRACT_ONLY until adapter evidence exists."
+            )
+            assert signal_data.get("live_detection_enabled") is not True, (
+                f"RED: Signal type '{signal_name}' claims live_detection_enabled=true. "
+                f"No live detection may be claimed without real DB evidence."
+            )
+            assert signal_data.get("mutation_allowed") is not True, (
+                f"RED: Signal type '{signal_name}' claims mutation_allowed=true. "
+                f"Detection findings must remain read-only in this contract slice."
+            )


### PR DESCRIPTION
## Implementation-GO Executed

This PR now delivers the minimal #3491 implementation slice that turns the RED_ONLY contract gap green.

### Delivered

- `docs/surrealdb/CDB_CONTEXT_DRIFT_STALE_CONTRADICTION_CONTRACT.md`
- `artifacts/surrealdb/context_drift_stale_contradiction_contract.json`

### Scope Kept Intentionally Narrow

- contract doc only
- machine-readable contract artifact only
- no drift engine
- no stale scanner implementation
- no contradiction resolver
- no DB-backed detection
- no DB or MCP writes
- no auto-resolution
- CONTRACT_ONLY posture retained

### Detectable Signal Types

- `stale_doc`
- `stale_issue_status`
- `stale_pr_status`
- `stale_claim`
- `stale_memory`
- `contradicted_claim`
- `contradicted_decision`
- `repo_doc_drift`
- `github_repo_drift`

### Resolution States

- `open`
- `confirmed`
- `dismissed`
- `superseded`
- `fixed`
- `parked`

### Unsafe Auto-Resolution Stays Blocked

- `auto_close_issue`
- `auto_change_live_gate`
- `auto_override_lr_status`
- `auto_delete_memory`
- `auto_mutate_db`
- `auto_mark_claim_true_without_evidence`

### Green Evidence

```text
python -m pytest tests/unit/surrealdb/test_context_drift_stale_contradiction_contract.py -q
ruff check tests/unit/surrealdb/test_context_drift_stale_contradiction_contract.py
python -m pytest tests/unit/surrealdb/test_context_data_model_ownership_matrix.py -q
python -m pytest tests/unit/surrealdb/test_context_fulltext_bm25_contract.py -q
python -m pytest tests/unit/surrealdb/test_agent_memory_contract.py -q
python -m pytest tests/unit/mcp -q
git diff --check
```

Result: local validation green for the contract slice.

### Foundation Linkage

- Refs #3483 ownership matrix
- Refs #3485 fulltext BM25 contract
- Refs #3490 agent memory contract

### References

- Closes #3491
- Refs #3479
- Refs #3483
- Refs #3485
- Refs #3490
