### PR TITLE
fix(ci): correct dependabot docker update paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,10 +47,10 @@ updates:
       prefix: "deps(actions)"
 
   # ----------------------------
-  # Docker (Root + Infra)
+  # Docker (exact Dockerfile directories only)
   # ----------------------------
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/infrastructure/actions-runner"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -63,7 +63,7 @@ updates:
       prefix: "deps(docker)"
 
   - package-ecosystem: "docker"
-    directory: "/infrastructure"
+    directory: "/infrastructure/compose"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -74,3 +74,173 @@ updates:
       - "docker"
     commit-message:
       prefix: "deps(docker)"
+
+  - package-ecosystem: "docker"
+    directory: "/services/allocation"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:30"
+      timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker)"
+
+  - package-ecosystem: "docker"
+    directory: "/services/candles"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:30"
+      timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker)"
+
+  - package-ecosystem: "docker"
+    directory: "/services/db_writer"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:30"
+      timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker)"
+
+  - package-ecosystem: "docker"
+    directory: "/services/execution"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:30"
+      timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker)"
+
+  - package-ecosystem: "docker"
+    directory: "/services/market"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:30"
+      timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker)"
+
+  - package-ecosystem: "docker"
+    directory: "/services/regime"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:30"
+      timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker)"
+
+  - package-ecosystem: "docker"
+    directory: "/services/reports"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:30"
+      timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker)"
+
+  - package-ecosystem: "docker"
+    directory: "/services/risk"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:30"
+      timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker)"
+
+  - package-ecosystem: "docker"
+    directory: "/services/signal"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:30"
+      timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker)"
+
+  - package-ecosystem: "docker"
+    directory: "/services/ws"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:30"
+      timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker)"
+
+  - package-ecosystem: "docker"
+    directory: "/tools/paper_trading"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:30"
+      timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker)"
+
+  # Official docs use the separate docker-compose ecosystem for compose files.
+  - package-ecosystem: "docker-compose"
+    directory: "/infrastructure/actions-runner"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:35"
+      timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker-compose)"
+
+  - package-ecosystem: "docker-compose"
+    directory: "/infrastructure/compose"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:35"
+      timezone: "Europe/Berlin"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker-compose)"


### PR DESCRIPTION
Closes #3510

## Problem

Dependabot erzeugt derzeit Docker-Update-Jobs auf Verzeichnissen ohne passendes
`Dockerfile` und meldet deshalb "konnte keine Dockerfile finden". Gleichzeitig
werden echte Dockerfile- und Compose-Abhängigkeitsflächen im Repo nicht
vollständig oder nicht mit dem passenden Ökosystem abgedeckt.

## Before / After Dependabot-Targets

Before:
- `docker` auf `/`
- `docker` auf `/infrastructure`

After:
- `docker` nur noch auf echte Dockerfile-Verzeichnisse:
  `/infrastructure/actions-runner`, `/infrastructure/compose`,
  `/services/allocation`, `/services/candles`, `/services/db_writer`,
  `/services/execution`, `/services/market`, `/services/regime`,
  `/services/reports`, `/services/risk`, `/services/signal`, `/services/ws`,
  `/tools/paper_trading`
- `docker-compose` separat auf Verzeichnisse mit echten Compose-Dateien:
  `/infrastructure/actions-runner`, `/infrastructure/compose`

## Validierung

- `git diff --check`
- `git diff origin/main...HEAD -- .github/dependabot.yml`
- `rg -n "package-ecosystem|directory:|directories:|docker|docker-compose" .github/dependabot.yml`
- GitHub-live geprüft:
  - `gh issue view 3510 --json number,title,state,url`
  - `gh pr list --state open --json number,title,headRefName,baseRefName,url`

## Non-Goals

- Keine Dockerfile-Inhalte ändern
- Keine Base-Image-Upgrades
- Keine Compose-Runtime-Änderungen
- Keine BLUE/RED-Stack-Änderung
- Keine Secrets
- Kein Live-/Echtgeld-Go

## Restunsicherheiten

- Der Commit-Subject auf dem Branch ist aktuell `fix(ci):correct-dependabot-docker-update-paths`; ich habe ihn nicht umgeschrieben, weil bisher kein belegt strenges Commit-Message-Gate sichtbar ist.
- Unrelated untracked lokale Residuen bleiben bewusst unberührt.
