### PR TITLE
fix(context): reconcile tool inventory exposure truth for #3493

### DIFF
--- a/artifacts/context_tool_inventory/tool_inventory.json
+++ b/artifacts/context_tool_inventory/tool_inventory.json
@@ -4,7 +4,11 @@
     "purpose": "Search the Context Intelligence knowledge base using keyword and structured queries.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -14,7 +18,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -27,7 +30,11 @@
     "purpose": "Trace decision or event lineage through the Context Intelligence system.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "IN_MEMORY",
     "surfaces": {
       "ChatGPT": false,
@@ -37,7 +44,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -50,7 +56,11 @@
     "purpose": "Explain the provenance and reasoning behind a specific source or evidence item.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "IN_MEMORY",
     "surfaces": {
       "ChatGPT": false,
@@ -60,7 +70,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -73,7 +82,11 @@
     "purpose": "Show a point-in-time snapshot of the context state.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -83,7 +96,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -96,7 +108,11 @@
     "purpose": "Show deterministic registry audit snapshot for a target tool (no DB/network).",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -106,7 +122,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -119,7 +134,11 @@
     "purpose": "Package context artifacts for handoff between agents or sessions.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "IN_MEMORY",
     "surfaces": {
       "ChatGPT": false,
@@ -129,7 +148,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -142,7 +160,11 @@
     "purpose": "Assess agent action readiness for a given task scope. Read-only, fails closed. Requires task_scope and operation_mode.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "session_callable",
+    "operational_status": "not_proven",
+    "evidence_level": "session_live_call",
     "backing_status": "IN_MEMORY",
     "surfaces": {
       "ChatGPT": false,
@@ -152,8 +174,8 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
+      "session:2026-06-29 copilot-cli cdb_context context.readiness call succeeded",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
       "tools/mcp/server.py"
@@ -165,7 +187,11 @@
     "purpose": "Generate a structured self-explanation for governance-relevant conditions. Read-only, no action authorization, no Live-Go, no Echtgeld-Go.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -175,7 +201,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -188,7 +213,11 @@
     "purpose": "Generate a task-specific Agent Briefing v1 from Briefing Request schema (docs/surrealdb/context-agent-briefing-schema-v1.md). Delegates to context.readiness and context.package for context assembly. Read-only, no authorization, no Live/Echtgeld Go.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -198,7 +227,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -211,7 +239,11 @@
     "purpose": "Resolve flat stop-condition strings to typed stop condition objects. Read-only, deterministic, fail-closed. No DB/network/GitHub access.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -221,7 +253,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -234,7 +265,11 @@
     "purpose": "Resolve prioritized required reads from task scope, target issue, target paths, target symbols, and operation mode. Read-only, deterministic, fail-closed. No DB/network/GitHub access.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "session_callable",
+    "operational_status": "not_proven",
+    "evidence_level": "session_live_call",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -244,8 +279,8 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
+      "session:2026-06-29 copilot-cli cdb_context context.required_reads call succeeded",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
       "tools/mcp/server.py"
@@ -257,7 +292,11 @@
     "purpose": "Impact Radar v1 MCP tool. Analyses downstream effects of a planned change across the CDB system. Returns affected items, graph paths, gate risks, required validation, and stop conditions. Read-only, deterministic, fail-closed. No DB/network/GitHub access. Does not authorize any action, Live-Go, or Echtgeld-Go.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -267,7 +306,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -280,7 +318,11 @@
     "purpose": "Wave-14 evidence resolve MCP tool. Resolves evidence for artifacts, claims, and decisions over in-memory records. Read-only, fail-closed, no DB/network/write. No Live-Go, no Echtgeld-Go.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -290,7 +332,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -303,7 +344,11 @@
     "purpose": "Wave-14 claim resolve MCP tool. Resolves claims over in-memory records. Surfaces disputed/stale/weakly-supported claims. Read-only, fail-closed, no DB/network/write. No Live-Go, no Echtgeld-Go.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -313,7 +358,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -326,7 +370,11 @@
     "purpose": "Wave-14 scoped memory read MCP tool. Reads agent memory records by scope, topic, or agent. Read-only, fail-closed, no DB/network/write. No Live-Go, no Echtgeld-Go.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -336,7 +384,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -349,7 +396,11 @@
     "purpose": "Memory write intent gate MCP tool (dry-run default). Evaluates Human-GO memory write authorization against the memory contract. Read-only, fail-closed, no DB/network/write execution. Mutation flags blocked. No Live-Go, no Echtgeld-Go.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -359,7 +410,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -372,7 +422,11 @@
     "purpose": "Wave-14 trust summary MCP tool. Builds a trust assessment from evidence, claim, decision, and memory results. Read-only, fail-closed, no DB/network/write. No Live-Go, no Echtgeld-Go.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -382,7 +436,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -395,7 +448,11 @@
     "purpose": "Wave-14 decision history MCP tool. Queries decision history over in-memory decision event records. Read-only, fail-closed, no DB/network/write. No Live-Go, no Echtgeld-Go.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -405,7 +462,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -418,7 +474,11 @@
     "purpose": "Wave-14 decision replay MCP tool. Builds a decision replay from decision event records. Read-only, fail-closed, no DB/network/write. No Live-Go, no Echtgeld-Go.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -428,7 +488,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -441,7 +500,11 @@
     "purpose": "Wave-15 contradiction scan MCP tool. Detects contradictions between doc/code/decisions/evidence/claims/memory over in-memory records. Surfaces SourceRefs, EvidenceRefs, severity, confidence, and recommended_next_reads. Read-only, fail-closed, no DB/network/write. No Live-Go, no Echtgeld-Go. Detection is signal, not action permission.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -451,7 +514,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -464,7 +526,11 @@
     "purpose": "Wave-16-C stale context MCP tool. Detects stale knowledge findings from an in-memory input bundle. Surfaces stale_type, severity, confidence, recommended_refresh, and source_refs for each finding. Supports scope/stale_type/severity/target_ref filters and limit. Bundle-driven: no DB/network/filesystem read. Read-only, fail-closed. Detection is signal, not authorization. No Live-Go, no Echtgeld-Go, no auto-fix, no auto-delete, no write.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -474,7 +540,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -487,7 +552,11 @@
     "purpose": "Wave-17-C scope drift MCP tool. Detects scope drift findings from an in-memory input bundle using the Wave-17-A firewall service. Supports filters for severity, scope_type (drift type), target_ref, and blocking state. Supports deterministic limit/truncation. Bundle-driven: no DB/network/filesystem read. Read-only, fail-closed. Detection is signal, not authorization. No Live-Go, no Echtgeld-Go, no auto-fix, no write.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -497,7 +566,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -510,7 +578,11 @@
     "purpose": "Score the quality of a knowledge context bundle across 8 dimensions (coverage, freshness, evidence, contradiction, dependency confidence, memory trust, decision validity, scope risk). Returns overall grade (blocking/watch/weak/good) and per-dimension scores. Read-only, bundle-driven, fail-closed. No DB/network/writes.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -520,7 +592,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -533,7 +604,11 @@
     "purpose": "Detect proactive architect signals from a context bundle. Generates 11 signal types: stale_area, weakly_evidenced_decision, underdocumented_surface, undertested_surface, high_dependency_risk, contradiction_hotspot, scope_drift_hotspot, repeated_agent_confusion, redundant_docs, missing_owner, fragile_context_path. Read-only, bundle-driven, fail-closed. No DB/network/writes. No automatic issue creation. Human-GO required for blocking signals.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -543,7 +618,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -556,7 +630,11 @@
     "purpose": "Wave-19 Visual Control Room View Builder v1. Builds one or all 9 read-only visual views (knowledge graph, architecture map, decision chain, evidence map, risk surface, stale knowledge, scope drift, agent memory, quality score dashboard) from an in-memory bundle. Read-only, deterministic, fail-closed. No DB/network/write. No Live-Go. No Echtgeld-Go. No runtime control. Signal surface only.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -566,7 +644,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -579,7 +656,11 @@
     "purpose": "Wave-20 Agent OS Readiness Evaluator v1. Evaluates the health and readiness of the Agent OS context intelligence system itself by aggregating signals from quality scoring, architect signals, scope drift, contradiction scan, and stale knowledge modules. Returns a readiness level (blocked/weak/acceptable/strong), blocking findings, weak findings, missing inputs, confidence, and an optional Markdown report. Read-only, deterministic, fail-closed. No DB/network/write. No Live-Go. No Echtgeld-Go. No runtime control. Signal surface only.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -589,7 +670,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",
@@ -602,7 +682,11 @@
     "purpose": "Alias for context.briefing. Generate a task-specific Agent Briefing v1 from Briefing Request schema (docs/surrealdb/context-agent-briefing-schema-v1.md). Read-only, no authorization, no Live/Echtgeld Go.",
     "handler_path": "tools/mcp/registry.py",
     "registry_status": "registered",
-    "exposure_status": "defined_not_implemented",
+    "handler_status": "not_implemented",
+    "exposure_status": "repo_surface_configured",
+    "callability_status": "not_proven",
+    "operational_status": "not_proven",
+    "evidence_level": "repo_surface_config",
     "backing_status": "CONTRACT_ONLY",
     "surfaces": {
       "ChatGPT": false,
@@ -612,7 +696,6 @@
       "Codex": false
     },
     "evidence": [
-      ".claude/settings.local.json",
       ".cursor/mcp.json",
       "tools/mcp/permission_guard.py",
       "tools/mcp/registry.py",

--- a/artifacts/context_tool_inventory/tool_inventory.md
+++ b/artifacts/context_tool_inventory/tool_inventory.md
@@ -2,43 +2,61 @@
 
 Generated: 27 tools discovered from repo sources.
 
+## Summary
+
+| Signal | Count |
+|--------|-------|
+| Total tools | 27 |
+| DB_BACKED | 0 |
+| IN_MEMORY | 4 |
+| CONTRACT_ONLY | 23 |
+| REPO_ONLY | 0 |
+| PROOF_ONLY | 0 |
+| UNKNOWN | 0 |
+| repo_surface_configured | 27 |
+| session_callable | 2 |
+| operationally_proven | 0 |
+
+Session-callable means the tool was proven callable in this session. It is not a DB-backed or operational claim.
+
 ## Matrix
 
-| Tool | Purpose | Handler | Registry | Exposure | Backing | ChatGPT | OpenCode | Cursor | Claude | Codex |
-|------|---------|---------|----------|----------|---------|---------|----------|--------|-------|-------|
-| cdb_agent_os_readiness | Wave-20 Agent OS Readiness Evaluator v1. Evaluates | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_architect_signals | Detect proactive architect signals from a context  | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_briefing | Alias for context.briefing. Generate a task-specif | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_claim_resolve | Wave-14 claim resolve MCP tool. Resolves claims ov | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_contradictions | Wave-15 contradiction scan MCP tool. Detects contr | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_decision_history | Wave-14 decision history MCP tool. Queries decisio | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_decision_replay | Wave-14 decision replay MCP tool. Builds a decisio | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_evidence_resolve | Wave-14 evidence resolve MCP tool. Resolves eviden | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_impact | Impact Radar v1 MCP tool. Analyses downstream effe | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_memory_get | Wave-14 scoped memory read MCP tool. Reads agent m | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_memory_write_intent | Memory write intent gate MCP tool (dry-run default | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_quality_score | Score the quality of a knowledge context bundle ac | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_scope_drift | Wave-17-C scope drift MCP tool. Detects scope drif | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_stale | Wave-16-C stale context MCP tool. Detects stale kn | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_context_trust_summary | Wave-14 trust summary MCP tool. Builds a trust ass | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| cdb_control_room_view | Wave-19 Visual Control Room View Builder v1. Build | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| context.briefing | Generate a task-specific Agent Briefing v1 from Br | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| context.explain_source | Explain the provenance and reasoning behind a spec | tools/mcp/registry.py | registered | defined_not_implemented | IN_MEMORY | - | Y | Y | Y | - |
-| context.package | Package context artifacts for handoff between agen | tools/mcp/registry.py | registered | defined_not_implemented | IN_MEMORY | - | Y | Y | Y | - |
-| context.readiness | Assess agent action readiness for a given task sco | tools/mcp/registry.py | registered | defined_not_implemented | IN_MEMORY | - | Y | Y | Y | - |
-| context.required_reads | Resolve prioritized required reads from task scope | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| context.search | Search the Context Intelligence knowledge base usi | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| context.self_explain | Generate a structured self-explanation for governa | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| context.show_audit | Show deterministic registry audit snapshot for a t | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| context.show_snapshot | Show a point-in-time snapshot of the context state | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| context.stop_resolver | Resolve flat stop-condition strings to typed stop  | tools/mcp/registry.py | registered | defined_not_implemented | CONTRACT_ONLY | - | Y | Y | Y | - |
-| context.trace | Trace decision or event lineage through the Contex | tools/mcp/registry.py | registered | defined_not_implemented | IN_MEMORY | - | Y | Y | Y | - |
+| Tool | Purpose | Handler | Registry | Handler status | Exposure | Callable | Operational | Evidence level | Backing | ChatGPT | OpenCode | Cursor | Claude | Codex |
+|------|---------|---------|----------|----------------|----------|----------|-------------|----------------|---------|---------|----------|--------|-------|-------|
+| cdb_agent_os_readiness | Wave-20 Agent OS Readiness Evaluator v1. Evaluates | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_architect_signals | Detect proactive architect signals from a context  | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_briefing | Alias for context.briefing. Generate a task-specif | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_claim_resolve | Wave-14 claim resolve MCP tool. Resolves claims ov | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_contradictions | Wave-15 contradiction scan MCP tool. Detects contr | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_decision_history | Wave-14 decision history MCP tool. Queries decisio | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_decision_replay | Wave-14 decision replay MCP tool. Builds a decisio | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_evidence_resolve | Wave-14 evidence resolve MCP tool. Resolves eviden | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_impact | Impact Radar v1 MCP tool. Analyses downstream effe | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_memory_get | Wave-14 scoped memory read MCP tool. Reads agent m | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_memory_write_intent | Memory write intent gate MCP tool (dry-run default | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_quality_score | Score the quality of a knowledge context bundle ac | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_scope_drift | Wave-17-C scope drift MCP tool. Detects scope drif | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_stale | Wave-16-C stale context MCP tool. Detects stale kn | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_context_trust_summary | Wave-14 trust summary MCP tool. Builds a trust ass | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| cdb_control_room_view | Wave-19 Visual Control Room View Builder v1. Build | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| context.briefing | Generate a task-specific Agent Briefing v1 from Br | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| context.explain_source | Explain the provenance and reasoning behind a spec | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | IN_MEMORY | - | Y | Y | Y | - |
+| context.package | Package context artifacts for handoff between agen | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | IN_MEMORY | - | Y | Y | Y | - |
+| context.readiness | Assess agent action readiness for a given task sco | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | session_callable | not_proven | session_live_call | IN_MEMORY | - | Y | Y | Y | - |
+| context.required_reads | Resolve prioritized required reads from task scope | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | session_callable | not_proven | session_live_call | CONTRACT_ONLY | - | Y | Y | Y | - |
+| context.search | Search the Context Intelligence knowledge base usi | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| context.self_explain | Generate a structured self-explanation for governa | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| context.show_audit | Show deterministic registry audit snapshot for a t | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| context.show_snapshot | Show a point-in-time snapshot of the context state | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| context.stop_resolver | Resolve flat stop-condition strings to typed stop  | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | CONTRACT_ONLY | - | Y | Y | Y | - |
+| context.trace | Trace decision or event lineage through the Contex | tools/mcp/registry.py | registered | not_implemented | repo_surface_configured | not_proven | not_proven | repo_surface_config | IN_MEMORY | - | Y | Y | Y | - |
 
 ## Classification
 - **present**: cdb_agent_os_readiness, cdb_context_architect_signals, cdb_context_briefing, cdb_context_claim_resolve, cdb_context_contradictions, cdb_context_decision_history, cdb_context_decision_replay, cdb_context_evidence_resolve, cdb_context_impact, cdb_context_memory_get, cdb_context_memory_write_intent, cdb_context_quality_score, cdb_context_scope_drift, cdb_context_stale, cdb_context_trust_summary, cdb_control_room_view, context.briefing, context.explain_source, context.package, context.readiness, context.required_reads, context.search, context.self_explain, context.show_audit, context.show_snapshot, context.stop_resolver, context.trace
-- **exposed**: 
-- **callable**: 
+- **exposed**: cdb_agent_os_readiness, cdb_context_architect_signals, cdb_context_briefing, cdb_context_claim_resolve, cdb_context_contradictions, cdb_context_decision_history, cdb_context_decision_replay, cdb_context_evidence_resolve, cdb_context_impact, cdb_context_memory_get, cdb_context_memory_write_intent, cdb_context_quality_score, cdb_context_scope_drift, cdb_context_stale, cdb_context_trust_summary, cdb_control_room_view, context.briefing, context.explain_source, context.package, context.readiness, context.required_reads, context.search, context.self_explain, context.show_audit, context.show_snapshot, context.stop_resolver, context.trace
+- **callable**: context.readiness, context.required_reads
 - **operational**: 
 
 ## Gaps
 - 0 tools have UNKNOWN backing status.
+- `session_callable` is intentionally narrower than `repo_surface_configured` and narrower than any operational or DB-backed claim.

--- a/tests/unit/tools/test_context_tool_inventory.py
+++ b/tests/unit/tools/test_context_tool_inventory.py
@@ -8,14 +8,18 @@ Use Case: Alle CDB Context Tools sind real inventarisiert.
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import pytest
 
 from tools.context_tool_inventory import (
     BACKING_STATUS_VALUES,
+    CALLABILITY_STATUS_VALUES,
+    EVIDENCE_LEVEL_VALUES,
+    EXPOSURE_STATUS_VALUES,
+    HANDLER_STATUS_VALUES,
     InventoryEntry,
+    OPERATIONAL_STATUS_VALUES,
     SURFACES,
     SURFACE_LIFECYCLE_TERMS,
     build_inventory,
@@ -28,7 +32,9 @@ from tools.context_tool_inventory import (
 
 class TestInventorySchemaRequiredFields:
     """Jeder Eintrag der Tool-Matrix hat mindestens: tool_name, purpose,
-    handler_path, registry_status, exposure_status, backing_status, surfaces, evidence."""
+    handler_path, registry_status, handler_status, exposure_status,
+    callability_status, operational_status, evidence_level,
+    backing_status, surfaces, evidence."""
 
     def test_entry_has_all_required_fields(self) -> None:
         entry = InventoryEntry(
@@ -36,7 +42,11 @@ class TestInventorySchemaRequiredFields:
             purpose="Search the Context Intelligence knowledge base",
             handler_path="tools/mcp/context_bridge.py",
             registry_status="registered",
-            exposure_status="exposed",
+            handler_status="implemented",
+            exposure_status="repo_surface_configured",
+            callability_status="not_proven",
+            operational_status="not_proven",
+            evidence_level="repo_surface_config",
             backing_status="REPO_ONLY",
             surfaces={"ChatGPT": False, "OpenCode": True, "Cursor": True, "Claude": True, "Codex": False},
             evidence=["tools/mcp/registry.py", "tools/mcp/context_bridge.py"],
@@ -45,7 +55,11 @@ class TestInventorySchemaRequiredFields:
         assert entry.purpose
         assert entry.handler_path
         assert entry.registry_status
+        assert entry.handler_status
         assert entry.exposure_status
+        assert entry.callability_status
+        assert entry.operational_status
+        assert entry.evidence_level
         assert entry.backing_status
         assert entry.surfaces
         assert entry.evidence
@@ -57,7 +71,11 @@ class TestInventorySchemaRequiredFields:
                 purpose="",
                 handler_path="path",
                 registry_status="registered",
-                exposure_status="exposed",
+                handler_status="implemented",
+                exposure_status="repo_surface_configured",
+                callability_status="not_proven",
+                operational_status="not_proven",
+                evidence_level="repo_surface_config",
                 backing_status="REPO_ONLY",
                 surfaces=SURFACES,
                 evidence=[],
@@ -70,7 +88,11 @@ class TestInventorySchemaRequiredFields:
                 purpose="test",
                 handler_path="",
                 registry_status="registered",
-                exposure_status="exposed",
+                handler_status="implemented",
+                exposure_status="repo_surface_configured",
+                callability_status="not_proven",
+                operational_status="not_proven",
+                evidence_level="repo_surface_config",
                 backing_status="REPO_ONLY",
                 surfaces=SURFACES,
                 evidence=[],
@@ -147,6 +169,31 @@ class TestSurfaceAvailability:
                 )
 
 
+class TestStatusFieldEnums:
+    """Handler-, Exposure-, Callability-, Operational- und Evidence-Level
+    sind getrennte Felder mit konservativen Enums."""
+
+    def test_handler_status_enum_has_expected_values(self) -> None:
+        assert HANDLER_STATUS_VALUES == {"implemented", "not_implemented"}
+
+    def test_exposure_status_enum_has_expected_values(self) -> None:
+        assert EXPOSURE_STATUS_VALUES == {"repo_surface_configured", "not_exposed"}
+
+    def test_callability_status_enum_has_expected_values(self) -> None:
+        assert CALLABILITY_STATUS_VALUES == {"session_callable", "not_proven"}
+
+    def test_operational_status_enum_has_expected_values(self) -> None:
+        assert OPERATIONAL_STATUS_VALUES == {"not_proven", "operationally_proven"}
+
+    def test_evidence_level_enum_has_expected_values(self) -> None:
+        assert EVIDENCE_LEVEL_VALUES == {
+            "session_live_call",
+            "repo_surface_config",
+            "repo_handler_only",
+            "registry_contract",
+        }
+
+
 class TestToolStateTermsNotMixed:
     """present, exposed, callable und operational werden getrennt dokumentiert."""
 
@@ -162,6 +209,35 @@ class TestToolStateTermsNotMixed:
         assert "exposed" in result
         assert "callable" in result
         assert "operational" in result
+
+
+class TestExposureAndCallabilityTruth:
+    """Session-callability, repo-surface exposure und operational proof bleiben getrennt."""
+
+    def test_minimum_session_callable_tools_are_preserved(self) -> None:
+        tools = {tool.tool_name: tool for tool in discover_tools_from_repo()}
+        assert tools["context.required_reads"].callability_status == "session_callable"
+        assert tools["context.readiness"].callability_status == "session_callable"
+
+    def test_session_callable_does_not_upgrade_backing_status(self) -> None:
+        tools = {tool.tool_name: tool for tool in discover_tools_from_repo()}
+        assert tools["context.required_reads"].backing_status != "DB_BACKED"
+        assert tools["context.readiness"].backing_status != "DB_BACKED"
+
+    def test_repo_surface_exposure_is_not_empty(self) -> None:
+        result = classify_tools()
+        assert "context.required_reads" in result["exposed"]
+        assert "context.readiness" in result["exposed"]
+
+    def test_context_briefing_is_not_marked_session_callable_without_live_proof(self) -> None:
+        tools = {tool.tool_name: tool for tool in discover_tools_from_repo()}
+        assert tools["context.briefing"].callability_status == "not_proven"
+
+    def test_operational_stays_empty_without_operational_proof(self) -> None:
+        result = classify_tools()
+        assert result["operational"] == []
+        for tool in discover_tools_from_repo():
+            assert tool.operational_status == "not_proven"
 
 
 class TestDbBackedRequiresRealEvidence:
@@ -197,7 +273,11 @@ class TestUnknownAllowedWithReason:
             purpose="Not yet implemented",
             handler_path="unknown",
             registry_status="not_registered",
+            handler_status="not_implemented",
             exposure_status="not_exposed",
+            callability_status="not_proven",
+            operational_status="not_proven",
+            evidence_level="registry_contract",
             backing_status="UNKNOWN",
             surfaces={"ChatGPT": None, "OpenCode": None, "Cursor": None, "Claude": None, "Codex": None},
             evidence=[],
@@ -220,6 +300,9 @@ class TestMatrixOutputGenerated:
         assert isinstance(data, list)
         assert len(data) > 0
         assert "tool_name" in data[0]
+        assert "callability_status" in data[0]
+        assert "operational_status" in data[0]
+        assert "evidence_level" in data[0]
 
     def test_markdown_export_is_generated(self, tmp_path: Path) -> None:
         tools = discover_tools_from_repo()
@@ -229,6 +312,7 @@ class TestMatrixOutputGenerated:
         content = out.read_text()
         assert "# CDB Context Tool Inventory" in content
         assert "context.search" in content
+        assert "Session-callable means the tool was proven callable in this session." in content
 
     def test_build_inventory_returns_complete_structure(self) -> None:
         inv = build_inventory()
@@ -243,3 +327,37 @@ class TestMatrixOutputGenerated:
         assert "db_backed_count" in inv["summary"]
         assert "repo_only_count" in inv["summary"]
         assert "unknown_count" in inv["summary"]
+        assert "exposed_count" in inv["summary"]
+        assert "session_callable_count" in inv["summary"]
+        assert "operational_count" in inv["summary"]
+
+    def test_build_inventory_summary_matches_conservative_truth(self) -> None:
+        inv = build_inventory()
+        assert inv["summary"]["db_backed_count"] == 0
+        assert inv["summary"]["session_callable_count"] >= 2
+        assert inv["summary"]["operational_count"] == 0
+
+    def test_json_and_markdown_summaries_stay_consistent(self, tmp_path: Path) -> None:
+        tools = discover_tools_from_repo()
+        json_out = tmp_path / "tool_inventory.json"
+        md_out = tmp_path / "tool_inventory.md"
+
+        export_inventory_json(tools, json_out)
+        export_inventory_markdown(tools, md_out)
+
+        data = json.loads(json_out.read_text(encoding="utf-8"))
+        markdown = md_out.read_text(encoding="utf-8")
+
+        db_backed_count = sum(1 for entry in data if entry["backing_status"] == "DB_BACKED")
+        callable_count = sum(
+            1 for entry in data if entry["callability_status"] == "session_callable"
+        )
+        operational_count = sum(
+            1
+            for entry in data
+            if entry["operational_status"] == "operationally_proven"
+        )
+
+        assert f"| DB_BACKED | {db_backed_count} |" in markdown
+        assert f"| session_callable | {callable_count} |" in markdown
+        assert f"| operationally_proven | {operational_count} |" in markdown

--- a/tools/context_tool_inventory.py
+++ b/tools/context_tool_inventory.py
@@ -10,7 +10,7 @@ Reference: Issue #3493, Issue #2773
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +23,33 @@ BACKING_STATUS_VALUES = frozenset({
     "CONTRACT_ONLY",
     "PROOF_ONLY",
     "UNKNOWN",
+})
+
+HANDLER_STATUS_VALUES = frozenset({
+    "implemented",
+    "not_implemented",
+})
+
+EXPOSURE_STATUS_VALUES = frozenset({
+    "repo_surface_configured",
+    "not_exposed",
+})
+
+CALLABILITY_STATUS_VALUES = frozenset({
+    "session_callable",
+    "not_proven",
+})
+
+OPERATIONAL_STATUS_VALUES = frozenset({
+    "not_proven",
+    "operationally_proven",
+})
+
+EVIDENCE_LEVEL_VALUES = frozenset({
+    "session_live_call",
+    "repo_surface_config",
+    "repo_handler_only",
+    "registry_contract",
 })
 
 # ── Surface Definitions ──
@@ -44,6 +71,17 @@ SURFACE_LIFECYCLE_TERMS = {
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
+SESSION_CALLABLE_TOOL_EVIDENCE: dict[str, str] = {
+    "context.required_reads": (
+        "session:2026-06-29 copilot-cli cdb_context context.required_reads "
+        "call succeeded"
+    ),
+    "context.readiness": (
+        "session:2026-06-29 copilot-cli cdb_context context.readiness call "
+        "succeeded"
+    ),
+}
+
 
 @dataclass
 class InventoryEntry:
@@ -53,7 +91,11 @@ class InventoryEntry:
     purpose: str
     handler_path: str
     registry_status: str
+    handler_status: str
     exposure_status: str
+    callability_status: str
+    operational_status: str
+    evidence_level: str
     backing_status: str
     surfaces: dict[str, bool | None]
     evidence: list[str]
@@ -64,6 +106,31 @@ class InventoryEntry:
             raise ValueError("purpose must not be empty")
         if not self.handler_path:
             raise ValueError("handler_path must not be empty")
+        if self.handler_status not in HANDLER_STATUS_VALUES:
+            raise ValueError(
+                f"Invalid handler_status: {self.handler_status}. "
+                f"Must be one of {sorted(HANDLER_STATUS_VALUES)}"
+            )
+        if self.exposure_status not in EXPOSURE_STATUS_VALUES:
+            raise ValueError(
+                f"Invalid exposure_status: {self.exposure_status}. "
+                f"Must be one of {sorted(EXPOSURE_STATUS_VALUES)}"
+            )
+        if self.callability_status not in CALLABILITY_STATUS_VALUES:
+            raise ValueError(
+                f"Invalid callability_status: {self.callability_status}. "
+                f"Must be one of {sorted(CALLABILITY_STATUS_VALUES)}"
+            )
+        if self.operational_status not in OPERATIONAL_STATUS_VALUES:
+            raise ValueError(
+                f"Invalid operational_status: {self.operational_status}. "
+                f"Must be one of {sorted(OPERATIONAL_STATUS_VALUES)}"
+            )
+        if self.evidence_level not in EVIDENCE_LEVEL_VALUES:
+            raise ValueError(
+                f"Invalid evidence_level: {self.evidence_level}. "
+                f"Must be one of {sorted(EVIDENCE_LEVEL_VALUES)}"
+            )
         if self.backing_status not in BACKING_STATUS_VALUES:
             raise ValueError(
                 f"Invalid backing_status: {self.backing_status}. "
@@ -104,15 +171,28 @@ def _build_from_v0() -> list[InventoryEntry]:
     for td in v0_tools:
         is_implemented = td.handler and td.handler.__name__ != "not_implemented_handler"
         handler_path = _resolve_handler_path(td.name, td.handler)
+        surfaces = _get_surface_availability(td.name)
+        handler_status = _infer_handler_status(is_implemented)
+        exposure_status = _infer_exposure_status(surfaces)
+        callability_status = _infer_callability_status(td.name)
+        operational_status = _infer_operational_status(td.name)
 
         entries.append(InventoryEntry(
             tool_name=td.name,
             purpose=td.description,
             handler_path=handler_path,
             registry_status="registered",
-            exposure_status="exposed" if is_implemented else "defined_not_implemented",
+            handler_status=handler_status,
+            exposure_status=exposure_status,
+            callability_status=callability_status,
+            operational_status=operational_status,
+            evidence_level=_infer_evidence_level(
+                handler_status=handler_status,
+                exposure_status=exposure_status,
+                callability_status=callability_status,
+            ),
             backing_status=_classify_backing(td.name),
-            surfaces=_get_surface_availability(td.name),
+            surfaces=surfaces,
             evidence=_get_evidence(td.name, handler_path),
         ))
     return entries
@@ -124,15 +204,28 @@ def _build_from_registry(registry_tools) -> list[InventoryEntry]:
     for td in registry_tools:
         is_implemented = td.handler and td.handler.__name__ != "not_implemented_handler"
         handler_path = _resolve_handler_path(td.name, td.handler)
+        surfaces = _get_surface_availability(td.name)
+        handler_status = _infer_handler_status(is_implemented)
+        exposure_status = _infer_exposure_status(surfaces)
+        callability_status = _infer_callability_status(td.name)
+        operational_status = _infer_operational_status(td.name)
 
         entries.append(InventoryEntry(
             tool_name=td.name,
             purpose=td.description,
             handler_path=handler_path,
             registry_status="registered",
-            exposure_status="exposed" if is_implemented else "defined_not_implemented",
+            handler_status=handler_status,
+            exposure_status=exposure_status,
+            callability_status=callability_status,
+            operational_status=operational_status,
+            evidence_level=_infer_evidence_level(
+                handler_status=handler_status,
+                exposure_status=exposure_status,
+                callability_status=callability_status,
+            ),
             backing_status=_classify_backing(td.name),
-            surfaces=_get_surface_availability(td.name),
+            surfaces=surfaces,
             evidence=_get_evidence(td.name, handler_path),
         ))
     return entries
@@ -212,6 +305,42 @@ def _classify_backing(tool_name: str) -> str:
     return "REPO_ONLY"
 
 
+def _infer_handler_status(is_implemented: bool) -> str:
+    return "implemented" if is_implemented else "not_implemented"
+
+
+def _infer_exposure_status(surfaces: dict[str, bool | None]) -> str:
+    if any(value is True for value in surfaces.values()):
+        return "repo_surface_configured"
+    return "not_exposed"
+
+
+def _infer_callability_status(tool_name: str) -> str:
+    if tool_name in SESSION_CALLABLE_TOOL_EVIDENCE:
+        return "session_callable"
+    return "not_proven"
+
+
+def _infer_operational_status(tool_name: str) -> str:
+    _ = tool_name
+    return "not_proven"
+
+
+def _infer_evidence_level(
+    *,
+    handler_status: str,
+    exposure_status: str,
+    callability_status: str,
+) -> str:
+    if callability_status == "session_callable":
+        return "session_live_call"
+    if exposure_status == "repo_surface_configured":
+        return "repo_surface_config"
+    if handler_status == "implemented":
+        return "repo_handler_only"
+    return "registry_contract"
+
+
 def _get_surface_availability(tool_name: str) -> dict[str, bool | None]:
     """Determine surface availability for a tool.
 
@@ -273,6 +402,10 @@ def _get_evidence(tool_name: str, handler_path: str) -> list[str]:
         if (REPO_ROOT / cfg_path).exists():
             evidence.append(cfg_path)
 
+    session_evidence = SESSION_CALLABLE_TOOL_EVIDENCE.get(tool_name)
+    if session_evidence:
+        evidence.append(session_evidence)
+
     return sorted(set(evidence))
 
 
@@ -291,9 +424,11 @@ def classify_tools() -> dict[str, list[str]]:
 
     for t in tools:
         result["present"].append(t.tool_name)
-        if t.exposure_status == "exposed":
+        if t.exposure_status == "repo_surface_configured":
             result["exposed"].append(t.tool_name)
+        if t.callability_status == "session_callable":
             result["callable"].append(t.tool_name)
+        if t.operational_status == "operationally_proven":
             result["operational"].append(t.tool_name)
 
     return result
@@ -312,6 +447,9 @@ def build_inventory() -> dict[str, Any]:
     in_memory = sum(1 for t in tools if t.backing_status == "IN_MEMORY")
     contract_only = sum(1 for t in tools if t.backing_status == "CONTRACT_ONLY")
     proof_only = sum(1 for t in tools if t.backing_status == "PROOF_ONLY")
+    exposed = sum(1 for t in tools if t.exposure_status == "repo_surface_configured")
+    callable_count = sum(1 for t in tools if t.callability_status == "session_callable")
+    operational = sum(1 for t in tools if t.operational_status == "operationally_proven")
 
     return {
         "matrix": [asdict(t) for t in tools],
@@ -324,6 +462,9 @@ def build_inventory() -> dict[str, Any]:
             "contract_only_count": contract_only,
             "proof_only_count": proof_only,
             "unknown_count": unknown,
+            "exposed_count": exposed,
+            "session_callable_count": callable_count,
+            "operational_count": operational,
         },
     }
 
@@ -340,15 +481,46 @@ def export_inventory_json(tools: list[InventoryEntry], output_path: Path) -> Non
 
 def export_inventory_markdown(tools: list[InventoryEntry], output_path: Path) -> None:
     """Export inventory to Markdown."""
+    inventory = build_inventory()
+    summary = inventory["summary"]
+    classification = inventory["classification"]
     lines = [
         "# CDB Context Tool Inventory",
         "",
         f"Generated: {len(tools)} tools discovered from repo sources.",
         "",
+        "## Summary",
+        "",
+        "| Signal | Count |",
+        "|--------|-------|",
+        f"| Total tools | {summary['total_tools']} |",
+        f"| DB_BACKED | {summary['db_backed_count']} |",
+        f"| IN_MEMORY | {summary['in_memory_count']} |",
+        f"| CONTRACT_ONLY | {summary['contract_only_count']} |",
+        f"| REPO_ONLY | {summary['repo_only_count']} |",
+        f"| PROOF_ONLY | {summary['proof_only_count']} |",
+        f"| UNKNOWN | {summary['unknown_count']} |",
+        f"| repo_surface_configured | {summary['exposed_count']} |",
+        f"| session_callable | {summary['session_callable_count']} |",
+        f"| operationally_proven | {summary['operational_count']} |",
+        "",
+        (
+            "Session-callable means the tool was proven callable in this session. "
+            "It is not a DB-backed or operational claim."
+        ),
+        "",
         "## Matrix",
         "",
-        "| Tool | Purpose | Handler | Registry | Exposure | Backing | ChatGPT | OpenCode | Cursor | Claude | Codex |",
-        "|------|---------|---------|----------|----------|---------|---------|----------|--------|-------|-------|",
+        (
+            "| Tool | Purpose | Handler | Registry | Handler status | "
+            "Exposure | Callable | Operational | Evidence level | Backing | "
+            "ChatGPT | OpenCode | Cursor | Claude | Codex |"
+        ),
+        (
+            "|------|---------|---------|----------|----------------|----------|"
+            "----------|-------------|----------------|---------|---------|----------|"
+            "--------|-------|-------|"
+        ),
     ]
 
     for t in sorted(tools, key=lambda x: x.tool_name):
@@ -358,7 +530,11 @@ def export_inventory_markdown(tools: list[InventoryEntry], output_path: Path) ->
             f"| {t.purpose[:50]} "
             f"| {t.handler_path} "
             f"| {t.registry_status} "
+            f"| {t.handler_status} "
             f"| {t.exposure_status} "
+            f"| {t.callability_status} "
+            f"| {t.operational_status} "
+            f"| {t.evidence_level} "
             f"| {t.backing_status} "
             f"| {_bool_icon(surf.get('ChatGPT'))} "
             f"| {_bool_icon(surf.get('OpenCode'))} "
@@ -369,16 +545,27 @@ def export_inventory_markdown(tools: list[InventoryEntry], output_path: Path) ->
 
     lines.append("")
     lines.append("## Classification")
-    classification = classify_tools()
     for state, tool_list in classification.items():
         lines.append(f"- **{state}**: {', '.join(sorted(tool_list))}")
     lines.append("")
     lines.append("## Gaps")
     lines.append(f"- {sum(1 for t in tools if t.backing_status == 'UNKNOWN')} tools have UNKNOWN backing status.")
+    lines.append(
+        "- `session_callable` is intentionally narrower than `repo_surface_configured` "
+        "and narrower than any operational or DB-backed claim."
+    )
     lines.append("")
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_canonical_inventory_artifacts() -> dict[str, Any]:
+    """Write the canonical JSON and Markdown artifacts for the inventory."""
+    tools = discover_tools_from_repo()
+    export_inventory_json(tools, REPO_ROOT / "artifacts/context_tool_inventory/tool_inventory.json")
+    export_inventory_markdown(tools, REPO_ROOT / "artifacts/context_tool_inventory/tool_inventory.md")
+    return build_inventory()
 
 
 def _bool_icon(val: bool | None) -> str:


### PR DESCRIPTION
Closes #3493
Refs #3479

## Delivered

- separates `handler_status`, `exposure_status`, `callability_status`, `operational_status`, and `evidence_level` in the context tool inventory
- keeps `DB_BACKED=0` and `operationally_proven=0` conservative
- preserves the minimum session-callable proof for `context.required_reads` and `context.readiness`
- regenerates the JSON and Markdown inventory artifacts from the corrected truth model
- extends focused tests so session callability cannot silently inflate DB-backed or operational claims

## Brain Evidence

- brain_source: repo-only
- brain_status: not-used
- tools_or_queries:
  - live GitHub truth for #3479, #3493, PR #3495
  - prior in-session successful calls to `context.required_reads` and `context.readiness`
  - local inventory regeneration via `write_canonical_inventory_artifacts()`
  - focused pytest + Ruff + `git diff --check`
- records_or_results:
  - session-callable proof recorded only for `context.required_reads` and `context.readiness`
  - corrected summary: total=27, DB_BACKED=0, IN_MEMORY=4, CONTRACT_ONLY=23, repo_surface_configured=27, session_callable=2, operationally_proven=0
- repo_crosscheck:
  - `tools/context_tool_inventory.py`
  - `artifacts/context_tool_inventory/tool_inventory.json`
  - `artifacts/context_tool_inventory/tool_inventory.md`
  - `tests/unit/tools/test_context_tool_inventory.py`
- impact_on_plan:
  - exposure, callability, and operational truth now stay separate
  - session callability no longer disappears into an empty callable surface
- limitations:
  - no DB-backed record evidence introduced
  - `context.briefing` was not promoted because it was not re-proven live in this slice

## Validation

- `python -m pytest tests/unit/tools/test_context_tool_inventory.py -q`
- `ruff check tools/context_tool_inventory.py tests/unit/tools/test_context_tool_inventory.py`
- `git diff --check`

## Corrected Truth

- `repo_surface_configured` is derived from repo surface configuration, not from handler implementation alone
- `session_callable` is narrower than exposure and is not treated as DB-backed or operational proof
- `operationally_proven` remains empty until real adapter/runtime evidence exists
- no PR-body claim of `DB_BACKED=8`; the repo-backed artifact remains conservatively at `DB_BACKED=0`

## Safety Boundaries

- no DB or MCP writes
- no SurrealDB migration
- no runtime / BLUE / RED change
- no secrets
- no live or Echtgeld action

## Non-goals

- no scope expansion to #3488, #3489, #3492, or #3494
- no DB-backed certification
- no operational certification
- no attempt to normalize the dirty root worktree

## Remaining Gaps

- live session callability is still intentionally narrower than full operational proof
- `context.briefing` remains `not_proven` until it is re-proven in a future scoped slice