### PR TITLE
fix(context): reconcile #3481 mcp boundary surface parity

### DIFF
--- a/docs/surrealdb/CDB_MCP_ACCESS_BOUNDARY.md
+++ b/docs/surrealdb/CDB_MCP_ACCESS_BOUNDARY.md
@@ -76,6 +76,42 @@ Machine-readable access boundary for CDB Context/MCP/SurrealDB tooling.
 - `select`
 - `use`
 
+## #3481 Acceptance / Evidence Reconcile
+
+This document is the canonical #3481 boundary surface. It now also carries the
+explicit reconcile mapping between the safety boundary delivered in PR #3497 and
+the later surface-parity evidence delivered for #3493 in PR #3534.
+
+| #3481 acceptance surface | Repo-backed truth | Delivery source | Reconcile status |
+|---|---|---|---|
+| MCP access boundary | Boundary matrix exists as a canonical doc and machine artifact. | PR #3497; `tools/mcp_access_boundary.py`; `artifacts/mcp/mcp_access_boundary_matrix.{json,md}` | delivered |
+| Raw upstream MCP blocking | `query`, `select`, `list`, `use`, `info` stay blocked raw MCP tools. | PR #3497 boundary matrix | delivered |
+| Forbidden mutation list | `create`, `insert`, `upsert`, `update`, `delete`, `relate`, `run` stay forbidden. | PR #3497 boundary matrix | delivered |
+| Curated read-only surface | 27 exposed CDB context tools are classified `ALLOWED_READONLY`. | PR #3497 boundary matrix | delivered |
+| Unknown-gap control | `UNKNOWN=0` in the boundary matrix. | PR #3497 boundary matrix + tests | delivered |
+| Surface parity / every-surface check | Repo-backed inventory truth shows `repo_surface_configured=27` across the configured agent surfaces. | PR #3534; `artifacts/context_tool_inventory/tool_inventory.{json,md}` | reconciled |
+| Session callability | Only `context.required_reads` and `context.readiness` are proven `session_callable=2`. | PR #3534 inventory truth | reconciled with explicit limits |
+| Operational proof boundary | `operationally_proven=0`; no tool is promoted to operational proof by this reconcile. | PR #3534 inventory truth | unchanged by design |
+| DB-backed proof boundary | `DB_BACKED=0`; no `DB_BACKED_READONLY_PROVEN` claim is added here. | PR #3534 inventory truth + boundary guardrails | unchanged by design |
+
+### Boundary Truth vs. Surface Truth
+
+- **PR #3497** delivered the #3481 safety core: allowed read-only tools,
+  forbidden mutation tools, blocked raw MCP tools, FUTURE aliases, and
+  `UNKNOWN=0`.
+- **PR #3534** delivered the later repo-backed surface-truth needed to reconcile
+  #3481's parity question without inflating runtime truth:
+  `repo_surface_configured=27`, `session_callable=2`,
+  `operationally_proven=0`, `DB_BACKED=0`.
+- Surface parity here means the configured repo surface is now mapped back to
+  #3481. It does **not** mean that every exposed tool is live-proven callable,
+  operationally proven, or DB-backed.
+- `session_callable` is intentionally narrower than repo surface exposure and is
+  not a DB-backed claim.
+- `operationally_proven=0` remains the canonical status for this surface.
+- `DB_BACKED_READONLY_PROVEN` remains out of scope for #3481 and requires
+  separate adapter/record evidence.
+
 ## Matrix
 
 | Tool | Family | Repo | Exposed | Callable | Operational | Decision | Allowed Mode | Mutation Risk | Handler |

--- a/tests/unit/mcp/test_mcp_access_boundary_matrix.py
+++ b/tests/unit/mcp/test_mcp_access_boundary_matrix.py
@@ -21,6 +21,9 @@ from tools.mcp_access_boundary import (
 
 pytestmark = pytest.mark.unit
 
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BOUNDARY_DOC = REPO_ROOT / "docs" / "surrealdb" / "CDB_MCP_ACCESS_BOUNDARY.md"
+
 
 REQUIRED_MATRIX_FIELDS = {
     "tool_name",
@@ -99,3 +102,27 @@ def test_repo_present_not_exposed_tools_are_separated() -> None:
         entry = matrix_entries[tool_name]
         assert entry["repo_present"] is True
         assert entry["exposed"] is False
+
+
+def test_unknown_count_stays_zero() -> None:
+    result = build_mcp_access_boundary()
+
+    unknown_entries = [
+        entry for entry in result["matrix"] if entry["decision"] == "UNKNOWN"
+    ]
+    assert unknown_entries == []
+
+
+def test_boundary_doc_reconciles_surface_parity_without_claim_inflation() -> None:
+    doc = BOUNDARY_DOC.read_text(encoding="utf-8")
+
+    assert "## #3481 Acceptance / Evidence Reconcile" in doc
+    assert "PR #3497" in doc
+    assert "PR #3534" in doc
+    assert "#3493" in doc
+    assert "`repo_surface_configured=27`" in doc
+    assert "`session_callable=2`" in doc
+    assert "`operationally_proven=0`" in doc
+    assert "`DB_BACKED=0`" in doc
+    assert "not a DB-backed claim" in doc
+    assert "`DB_BACKED_READONLY_PROVEN` remains out of scope for #3481" in doc

--- a/tests/unit/mcp/test_mcp_access_boundary_safety.py
+++ b/tests/unit/mcp/test_mcp_access_boundary_safety.py
@@ -29,6 +29,17 @@ def test_standard_mutating_surrealdb_tools_are_forbidden() -> None:
         assert entry["mutation_risk"] != "none"
 
 
+def test_raw_upstream_tools_stay_blocked() -> None:
+    result = build_mcp_access_boundary()
+    entries = _entries_by_name(result["matrix"])
+
+    for tool_name in {"query", "select", "list", "use", "info"}:
+        entry = entries[tool_name]
+        assert entry["decision"] == "BLOCKED"
+        assert entry["callable_status"] == "NOT_EXPOSED"
+        assert entry["operational_status"] == "BLOCKED_RAW_MCP"
+
+
 def test_readonly_tools_have_evidence() -> None:
     result = build_mcp_access_boundary()
 


### PR DESCRIPTION
Closes #3481
Refs #3479
Refs #3493
Refs #3534

## Delivered
- #3481 Acceptance-/Evidence-Reconcile in `docs/surrealdb/CDB_MCP_ACCESS_BOUNDARY.md`
- Surface-Parity-Mapping gegen #3493/#3534
- Tests fuer UNKNOWN=0, raw upstream blocking und no-inflation wording

## Boundary Truth
- PR #3497 liefert Boundary-Kern
- PR #3534 liefert Surface-/Inventory-Truth

## Safety Boundaries
- DB_BACKED bleibt 0
- operationally_proven bleibt 0
- session_callable ist nicht DB-backed
- kein DB_BACKED_READONLY_PROVEN

## Validation
- pytest MCP boundary tests
- pytest tool inventory tests
- ruff
- git diff --check

## Remaining Gaps
- keine repo-backed #3481 Acceptance Gap mehr, sofern Checks gruen bleiben