### PR TITLE
test(context): add red decision replay gates for #3489

### DIFF
--- a/docs/surrealdb/decision_replay_query_contract.md
+++ b/docs/surrealdb/decision_replay_query_contract.md
@@ -225,7 +225,23 @@ v2 **behält alle v1-Felder** und ergänzt read-only Evidence-Enrichment:
 - **Nie implizit verifizieren**: `known_evidence_ids` allein reicht **nicht** für `resolved_evidence`; fehlende Records/Summaries bleiben in `unresolved_evidence_refs`.
 - **`decision_chain_hash`**: Hash über `decision_chain`, `supersession_chain`, sortierte evidence/claim refs, **v2-angereicherte** `unresolved_evidence_refs`, `resolved_evidence_ids`, `evidence_resolution_status` — **ohne** `current_status.as_of`.
 - **Redaction**: token/secret/password/api_key-artige Felder in resolved payloads → `[REDACTED]`.
-- **LR / Live**: `approval_semantics` und `replay_explainability.history_only` bleiben non-authorizing; kein Live-Go, kein Echtgeld-Go.
+- **LR / Live**: `approval_semantics` und `replay_explainability.history_only` bleiben non-authorizing; kein LR-Go, kein Live-Go, kein Echtgeld-Go.
+
+### v2 MCP status-proof enrichment (#3489, additive)
+
+`cdb_context_decision_replay` darf Replay-Ergebnisse für Agenten nur mit expliziten, maschinenlesbaren Status-Proof-Gates ausgeben:
+
+- `brain_evidence_block` übernimmt die #3488 Brain-Evidence-Felder auch im Replay.
+- `decision_replay_gate` deklariert fehlende Record-Surfaces (`evidence_records`, `claim_records`, `decision_events`, `memory_records`) als degraded statt sie still zu implizieren.
+- `status_proof_block` trennt GitHub live, Repo live, Ledger und Brain strikt.
+- `closure_drift_markers` markieren Widersprüche wie `closure_drift` oder `partial_delivery`.
+- `approval_semantics.no_lr_go` ist verpflichtend zusätzlich zu `no_live_go` und `no_echtgeld_go`.
+
+Nicht erlaubte Herleitungen:
+
+- Issue-State nur aus Ledger oder PR-Body
+- Issue-Closure automatisch aus Merge-State ohne Closing-Reference
+- DB-backed Roadmap-Claims aus `local_staged_files` oder `pr_narrative`
 
 ### v2 Validation (CI)
 

--- a/tests/unit/tools/mcp/test_decision_replay_status_proof_red_3489.py
+++ b/tests/unit/tools/mcp/test_decision_replay_status_proof_red_3489.py
@@ -1,0 +1,154 @@
+"""RED_ONLY contract tests for #3489 decision replay and status-proof gates."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.mcp.context_decision_tools import (
+    TOOL_CDB_CONTEXT_DECISION_REPLAY,
+    handle_cdb_context_decision_replay,
+)
+
+pytestmark = pytest.mark.unit
+
+FIXTURE_PATH = Path("tests/fixtures/surrealdb/decision_mcp/decision_mcp_v1.json")
+
+
+def _load_fixture() -> dict:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _replay(**overrides) -> dict:
+    fixture = _load_fixture()
+    parameters = {
+        **fixture["cases"]["replay_by_decision_id"]["parameters"],
+        "decision_events": fixture["decision_events"],
+        "known_evidence_ids": fixture["known_evidence_ids"],
+        "known_claim_ids": fixture["known_claim_ids"],
+        "evidence_summaries": fixture["evidence_summaries"],
+        "claim_summaries": fixture["claim_summaries"],
+        "stop_conditions": fixture["stop_conditions"],
+        **overrides,
+    }
+    result = handle_cdb_context_decision_replay(
+        {"tool": TOOL_CDB_CONTEXT_DECISION_REPLAY, "parameters": parameters}
+    )
+    assert result["status"] == "ok"
+    return result["result"]
+
+
+def test_replay_requires_machine_readable_status_proof_block() -> None:
+    """#3489: replay must separate GitHub, repo, ledger, and brain proof surfaces."""
+    replay = _replay()
+    status_proof = replay["status_proof_block"]
+    assert set(status_proof) >= {"github_live", "repo_live", "ledger", "brain"}
+
+
+def test_replay_degrades_without_evidence_claim_and_memory_resolution_inputs() -> None:
+    """#3489: missing resolution inputs must be surfaced as a replay gate, not refs_only only."""
+    replay = _replay(
+        known_evidence_ids=[],
+        known_claim_ids=[],
+        evidence_summaries={},
+        claim_summaries={},
+    )
+    gate = replay["decision_replay_gate"]
+    assert gate["status"] in {"degraded", "fail_closed"}
+    assert set(gate["missing_inputs"]) >= {
+        "evidence_records",
+        "claim_records",
+        "decision_events",
+    }
+
+
+def test_replay_inherits_brain_evidence_gate_contract_from_3488() -> None:
+    """#3489: decision replay must not bypass the machine-readable #3488 brain-evidence gates."""
+    replay = _replay()
+    block = replay["brain_evidence_block"]
+    assert set(block) >= {
+        "brain_source",
+        "brain_status",
+        "context_brain_attempted",
+        "context_brain_used",
+        "repo_fallback_used",
+        "repo_fallback_reason",
+        "context_tool_status",
+        "context_trust_level",
+        "records_found",
+    }
+
+
+def test_issue_state_cannot_be_inferred_from_ledger_or_pr_body_claims() -> None:
+    """#3489: ledger- and PR-body-only issue state claims must stay non-proving."""
+    replay = _replay(
+        status_claims=[
+            {
+                "surface": "issue_state",
+                "sources": ["ledger", "pr_body"],
+                "state": "closed",
+            }
+        ]
+    )
+    issue_state = replay["status_proof_block"]["github_live"]["issue_state"]
+    assert issue_state["proof_status"] == "missing_live_truth"
+    assert "ledger_only_issue_state" in issue_state["blocking_findings"]
+    assert "pr_body_issue_state" in issue_state["blocking_findings"]
+
+
+def test_merge_state_does_not_imply_issue_closure_without_closing_reference() -> None:
+    """#3489: merge proof and issue-closure proof must remain separate surfaces."""
+    replay = _replay(
+        status_claims=[
+            {
+                "surface": "merge_state",
+                "state": "merged",
+                "closing_reference_present": False,
+            }
+        ]
+    )
+    merge_state = replay["status_proof_block"]["github_live"]["merge_state"]
+    assert merge_state["issue_closure_inferred"] is False
+    assert "missing_closing_reference" in merge_state["blocking_findings"]
+
+
+def test_replay_can_mark_closure_drift_or_partial_delivery() -> None:
+    """#3489: open issue plus repo-delivered surface must be markable as drift/partial delivery."""
+    replay = _replay(
+        status_claims=[
+            {
+                "surface": "delivery_reconcile",
+                "github_issue_state": "open",
+                "repo_delivery_state": "delivered",
+            }
+        ]
+    )
+    assert set(replay["closure_drift_markers"]) >= {"closure_drift", "partial_delivery"}
+
+
+def test_roadmap_status_rejects_local_staged_and_pr_narrative_as_db_backed_claims() -> None:
+    """#3489: roadmap state must not become DB-backed from local/staged or PR narrative inputs."""
+    replay = _replay(
+        status_claims=[
+            {
+                "surface": "roadmap_state",
+                "sources": ["local_staged_files", "pr_narrative"],
+                "state": "done",
+            }
+        ]
+    )
+    roadmap_state = replay["status_proof_block"]["ledger"]["roadmap_state"]
+    assert roadmap_state["db_backed_claim"] is False
+    assert "staged_files_non_db_backed" in roadmap_state["blocking_findings"]
+    assert "pr_narrative_non_db_backed" in roadmap_state["blocking_findings"]
+
+
+def test_replay_carries_explicit_no_lr_go_in_addition_to_live_and_echtgeld_guards() -> None:
+    """#3489: replay must explicitly forbid LR decisions, not only live/echtgeld ones."""
+    replay = _replay()
+    semantics = replay["approval_semantics"]
+    assert semantics["no_lr_go"] is True
+    assert semantics["no_live_go"] is True
+    assert semantics["no_echtgeld_go"] is True

--- a/tools/mcp/context_decision_tools.py
+++ b/tools/mcp/context_decision_tools.py
@@ -171,6 +171,239 @@ def _extract_decision_events(
     return events
 
 
+def _count_records(records: list[Mapping[str, Any]] | None) -> int:
+    return len(records or [])
+
+
+def _build_replay_brain_evidence_fields(
+    *,
+    source: str,
+    decision_events: list[Mapping[str, Any]],
+    evidence_records: list[Mapping[str, Any]] | None,
+    claim_records: list[Mapping[str, Any]] | None,
+    memory_records: list[Mapping[str, Any]] | None,
+) -> dict[str, Any]:
+    record_count = (
+        len(decision_events)
+        + _count_records(evidence_records)
+        + _count_records(claim_records)
+        + _count_records(memory_records)
+    )
+    if source == "surrealdb-local":
+        return {
+            "brain_source": "surrealdb-local",
+            "brain_status": "used",
+            "context_brain_attempted": True,
+            "context_brain_used": True,
+            "context_available": True,
+            "repo_fallback_used": False,
+            "repo_fallback_reason": "none",
+            "context_tool_status": "available",
+            "context_trust_level": "medium",
+            "records_found": record_count,
+        }
+
+    if record_count > 0:
+        return {
+            "brain_source": "in_memory",
+            "brain_status": "used",
+            "context_brain_attempted": True,
+            "context_brain_used": True,
+            "context_available": True,
+            "repo_fallback_used": False,
+            "repo_fallback_reason": "none",
+            "context_tool_status": "available",
+            "context_trust_level": "medium",
+            "records_found": record_count,
+        }
+
+    return {
+        "brain_source": "repo-only",
+        "brain_status": "not-used",
+        "context_brain_attempted": True,
+        "context_brain_used": False,
+        "context_available": False,
+        "repo_fallback_used": True,
+        "repo_fallback_reason": "insufficient_evidence",
+        "context_tool_status": "available",
+        "context_trust_level": "none",
+        "records_found": "none",
+    }
+
+
+def _build_replay_brain_evidence_block(
+    fields: Mapping[str, Any],
+    *,
+    source: str,
+) -> dict[str, Any]:
+    limitations = [
+        "Replay is read-only and non-authorizing.",
+        "Repo text, PR narrative, and staged files do not become DB-backed evidence.",
+    ]
+    if source != "surrealdb-local":
+        limitations.append(
+            "Decision replay uses repo or in-memory surfaces only; no DB-backed claim "
+            "may be inferred from this output."
+        )
+    return {
+        "brain_source": fields["brain_source"],
+        "brain_status": fields["brain_status"],
+        "context_brain_attempted": fields["context_brain_attempted"],
+        "context_brain_used": fields["context_brain_used"],
+        "repo_fallback_used": fields["repo_fallback_used"],
+        "repo_fallback_reason": fields["repo_fallback_reason"],
+        "context_tool_status": fields["context_tool_status"],
+        "context_trust_level": fields["context_trust_level"],
+        "records_found": fields["records_found"],
+        "tools_or_queries": [
+            "cdb_context_decision_replay",
+            "build_decision_replay_v2",
+        ],
+        "records_or_results": [
+            f"replay_source={source}",
+            f"records_found={fields['records_found']}",
+        ],
+        "repo_crosscheck": [
+            "decision_chain",
+            "evidence_chain",
+            "claim_chain",
+        ],
+        "impact_on_plan": [
+            "Keep replay status proof read-only, evidence-bound, and fail-closed.",
+        ],
+        "limitations": limitations,
+    }
+
+
+def _normalize_status_claims(raw_claims: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw_claims, list):
+        return []
+    return [dict(item) for item in raw_claims if isinstance(item, Mapping)]
+
+
+def _build_status_proof_block(
+    *,
+    status_claims: list[dict[str, Any]],
+    brain_fields: Mapping[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    status_proof_block: dict[str, Any] = {
+        "github_live": {
+            "issue_state": {
+                "proof_status": "missing_live_truth",
+                "blocking_findings": [],
+                "sources_considered": [],
+                "state": "unknown",
+            },
+            "merge_state": {
+                "proof_status": "missing_live_truth",
+                "blocking_findings": [],
+                "issue_closure_inferred": False,
+                "state": "unknown",
+            },
+        },
+        "repo_live": {
+            "delivery_state": {
+                "proof_status": "repo_only_observation",
+                "blocking_findings": [],
+                "state": "unknown",
+            }
+        },
+        "ledger": {
+            "roadmap_state": {
+                "proof_status": "non_db_backed",
+                "blocking_findings": [],
+                "db_backed_claim": False,
+                "state": "unknown",
+            }
+        },
+        "brain": {
+            "brain_source": brain_fields["brain_source"],
+            "brain_status": brain_fields["brain_status"],
+            "context_trust_level": brain_fields["context_trust_level"],
+            "records_found": brain_fields["records_found"],
+        },
+    }
+    closure_drift_markers: set[str] = set()
+
+    issue_state = status_proof_block["github_live"]["issue_state"]
+    merge_state = status_proof_block["github_live"]["merge_state"]
+    delivery_state = status_proof_block["repo_live"]["delivery_state"]
+    roadmap_state = status_proof_block["ledger"]["roadmap_state"]
+
+    for claim in status_claims:
+        surface = str(claim.get("surface") or "").strip()
+        sources = [
+            str(source).strip()
+            for source in claim.get("sources", [])
+            if isinstance(source, str) and source.strip()
+        ]
+
+        if surface == "issue_state":
+            issue_state["state"] = str(claim.get("state") or "unknown")
+            issue_state["sources_considered"] = sources
+            if "ledger" in sources:
+                issue_state["blocking_findings"].append("ledger_only_issue_state")
+            if "pr_body" in sources:
+                issue_state["blocking_findings"].append("pr_body_issue_state")
+        elif surface == "merge_state":
+            merge_state["state"] = str(claim.get("state") or "unknown")
+            if merge_state["state"] == "merged" and not bool(
+                claim.get("closing_reference_present")
+            ):
+                merge_state["blocking_findings"].append("missing_closing_reference")
+                merge_state["issue_closure_inferred"] = False
+        elif surface == "delivery_reconcile":
+            delivery_state["state"] = str(claim.get("repo_delivery_state") or "unknown")
+            if (
+                str(claim.get("github_issue_state") or "").strip().lower() == "open"
+                and delivery_state["state"] == "delivered"
+            ):
+                closure_drift_markers.update({"closure_drift", "partial_delivery"})
+        elif surface == "roadmap_state":
+            roadmap_state["state"] = str(claim.get("state") or "unknown")
+            if "local_staged_files" in sources:
+                roadmap_state["blocking_findings"].append(
+                    "staged_files_non_db_backed"
+                )
+            if "pr_narrative" in sources:
+                roadmap_state["blocking_findings"].append(
+                    "pr_narrative_non_db_backed"
+                )
+
+    issue_state["blocking_findings"] = sorted(set(issue_state["blocking_findings"]))
+    merge_state["blocking_findings"] = sorted(set(merge_state["blocking_findings"]))
+    roadmap_state["blocking_findings"] = sorted(set(roadmap_state["blocking_findings"]))
+    return status_proof_block, sorted(closure_drift_markers)
+
+
+def _build_decision_replay_gate(
+    *,
+    source: str,
+    evidence_records: list[Mapping[str, Any]] | None,
+    claim_records: list[Mapping[str, Any]] | None,
+    memory_records: list[Mapping[str, Any]] | None,
+) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    if not evidence_records:
+        missing_inputs.append("evidence_records")
+    if not claim_records:
+        missing_inputs.append("claim_records")
+    if source != "surrealdb-local":
+        missing_inputs.append("decision_events")
+    if not memory_records:
+        missing_inputs.append("memory_records")
+    return {
+        "status": "ready" if not missing_inputs else "degraded",
+        "missing_inputs": missing_inputs,
+        "non_authorizing": True,
+        "db_backed_only_when_recorded": source == "surrealdb-local",
+        "notes": [
+            "Replay cannot promote repo text, PR body, ledger text, or staged files to DB-backed proof.",
+            "Missing record surfaces degrade trust before any status claim can be treated as proven.",
+        ],
+    }
+
+
 def handle_cdb_context_decision_history(request: Mapping[str, Any]) -> dict[str, Any]:
     parsed = _parse_tool_request(
         request, expected_tool=TOOL_CDB_CONTEXT_DECISION_HISTORY
@@ -392,6 +625,8 @@ def handle_cdb_context_decision_replay(request: Mapping[str, Any]) -> dict[str, 
     claim_summaries = _as_mapping(params.get("claim_summaries"))
     evidence_records = _as_list_of_mappings(params.get("evidence_records"))
     claim_records = _as_list_of_mappings(params.get("claim_records"))
+    memory_records = _as_list_of_mappings(params.get("memory_records"))
+    status_claims = _normalize_status_claims(params.get("status_claims"))
 
     stop_conditions_raw = params.get("stop_conditions")
     stop_conditions: list[dict[str, Any]] | None = None
@@ -420,4 +655,27 @@ def handle_cdb_context_decision_replay(request: Mapping[str, Any]) -> dict[str, 
             details={"mode": replay_request.mode},
         )
 
+    brain_evidence_fields = _build_replay_brain_evidence_fields(
+        source=_source,
+        decision_events=list(decision_events),
+        evidence_records=evidence_records,
+        claim_records=claim_records,
+        memory_records=memory_records,
+    )
+    status_proof_block, closure_drift_markers = _build_status_proof_block(
+        status_claims=status_claims,
+        brain_fields=brain_evidence_fields,
+    )
+    result["brain_evidence_block"] = _build_replay_brain_evidence_block(
+        brain_evidence_fields,
+        source=_source,
+    )
+    result["status_proof_block"] = status_proof_block
+    result["decision_replay_gate"] = _build_decision_replay_gate(
+        source=_source,
+        evidence_records=evidence_records,
+        claim_records=claim_records,
+        memory_records=memory_records,
+    )
+    result["closure_drift_markers"] = closure_drift_markers
     return _ok_response(TOOL_CDB_CONTEXT_DECISION_REPLAY, result=result, source=_source)

--- a/tools/surrealdb/decision_replay_builder.py
+++ b/tools/surrealdb/decision_replay_builder.py
@@ -497,6 +497,7 @@ def build_decision_replay_v1(
     approval_semantics = {
         "history_only": True,
         "no_approval": True,
+        "no_lr_go": True,
         "no_live_go": True,
         "no_echtgeld_go": True,
         "note": (


### PR DESCRIPTION
Closes #3489
Refs #3479
Refs #3488

## RED -> GREEN Summary
- Implements the 8 RED_ONLY replay/status-proof tests from `tests/unit/tools/mcp/test_decision_replay_status_proof_red_3489.py`.
- Keeps replay read-only and non-authorizing while adding machine-readable status-proof output.
- Does not invent DB-backed claims, issue closure, LR-Go, or live/Echtgeld approval.

## Brain Evidence
- brain_source: repo-only for planning; in-memory for local replay payloads
- brain_status: not-used for planning; used only when replay input records are explicitly present
- tools_or_queries:
  - `context.required_reads`
  - `context.readiness`
  - `git fetch origin --prune`
  - `gh pr view 3537 --json ...`
  - `gh issue view 3479 --json ...`
  - `gh issue view 3488 --json ...`
  - `gh issue view 3489 --json ...`
- records_or_results:
  - live GitHub truth for #3479 / #3488 / #3489 and PR #3537 was rechecked before implementation
  - replay implementation stayed in MCP + builder surfaces only
  - validation matrix passed without DB writes or runtime changes
- repo_crosscheck:
  - `tools/mcp/context_decision_tools.py`
  - `tools/surrealdb/decision_replay_builder.py`
  - `tools/mcp/context_bridge.py`
  - `tests/unit/tools/mcp/test_decision_replay_status_proof_red_3489.py`
  - `tests/unit/tools/mcp/test_mcp_briefing_evidence_claim_trust_red_3488.py`
  - `docs/surrealdb/decision_replay_query_contract.md`
- impact_on_plan:
  - implemented only the missing #3489 replay/status-proof contract
  - preserved #3488 brain-evidence semantics and degraded trust instead of promoting unsupported claims
- limitations:
  - no SurrealDB-backed record evidence was added or faked
  - replay still does not authorize LR/live/Echtgeld actions

## Implemented Status-Proof Gates
- `approval_semantics.no_lr_go` added alongside `no_live_go` and `no_echtgeld_go`
- `brain_evidence_block` added to MCP replay output with #3488-compatible gate fields
- `decision_replay_gate` added to expose degraded replay state when record surfaces are missing
- `status_proof_block` added to separate `github_live`, `repo_live`, `ledger`, and `brain`
- `closure_drift_markers` added for `closure_drift` / `partial_delivery`
- issue-state proof rejects ledger-only and PR-body-only closure claims
- merge-state proof keeps merge separate from issue closure unless a closing reference exists
- roadmap-state proof rejects `local_staged_files` and `pr_narrative` as DB-backed claims

## Decision Replay Safety Boundaries
- replay remains read-only and non-authorizing
- DB-backed only when real recorded evidence surfaces exist
- repo text, PR body, ledger text, and staged files are not DB-backed proof
- merge does not imply issue closure
- no LR-Go, live-Go, or Echtgeld-Go can be produced by replay

## Validation
- `pytest -q tests/unit/tools/mcp/test_decision_replay_status_proof_red_3489.py`
- `pytest -q tests/unit/surrealdb/test_decision_replay_builder_v2.py`
- `pytest -q tests/unit/tools/mcp/test_mcp_briefing_evidence_claim_trust_red_3488.py`
- `pytest -q tests/unit/tools/mcp/test_mcp_briefing_tool.py tests/unit/tools/mcp/test_mcp_briefing_enrichment.py`
- `pytest -q tests/unit/surrealdb/test_decision_mcp_tools_v1.py`
- `ruff check tools/mcp/context_decision_tools.py tools/surrealdb/decision_replay_builder.py tests/unit/tools/mcp/test_decision_replay_status_proof_red_3489.py`
- `git diff --check`

## Remaining Gaps
- none within #3489 scope
