### PR TITLE
feat(context): implement default sensory loop gates for #3492

### DIFF
--- a/tests/unit/tools/mcp/test_context_bridge.py
+++ b/tests/unit/tools/mcp/test_context_bridge.py
@@ -1497,6 +1497,8 @@ class TestContextBriefingHandler:
             "branch": "unknown",
             "commit": "unknown",
             "working_tree": "unknown",
+            "main_sync": "unknown",
+            "delivery_state": "unknown",
         }
         assert session_context["github_state"]["target_issue"] is None
         assert session_context["github_state"]["related_prs"] == []
@@ -1712,6 +1714,8 @@ class TestContextBriefingHandler:
             "branch": "feature/session-context",
             "commit": "abc123def456",
             "working_tree": "dirty",
+            "main_sync": "unknown",
+            "delivery_state": "unknown",
         }
 
     def test_github_state_values_are_preserved_when_provided(self) -> None:

--- a/tests/unit/tools/mcp/test_default_sensory_loop_red_3492.py
+++ b/tests/unit/tools/mcp/test_default_sensory_loop_red_3492.py
@@ -1,0 +1,150 @@
+"""RED_ONLY contract tests for #3492 default sensory loop gates."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.mcp.context_bridge import context_briefing_handler
+
+pytestmark = pytest.mark.unit
+
+ALLOWED_NEXT_MOVES = {
+    "Plan",
+    "RED_ONLY",
+    "Implementation",
+    "Reconcile",
+    "Closeout",
+    "Blocked",
+}
+
+
+def _briefing(**extra: object) -> dict:
+    result = context_briefing_handler(
+        task_id="red-3492",
+        task_scope="RED_ONLY issue #3492 default sensory loop gates",
+        target_issue="#3492",
+        requested_depth="quick",
+        operation_mode="write (code/docs)",
+        **extra,
+    )
+    assert result["status"] == "ok"
+    return result["briefing"]
+
+
+def _loop(briefing: dict) -> dict:
+    loop = briefing.get("default_sensory_loop")
+    assert isinstance(
+        loop, dict
+    ), "default_sensory_loop contract missing from context.briefing output"
+    return loop
+
+
+def test_loop_models_required_reads_readiness_and_briefing_as_preflight_steps() -> None:
+    """#3492: the default sensory loop must model required_reads, readiness, and briefing explicitly."""
+    loop = _loop(_briefing())
+    preflight_steps = loop.get("preflight_steps")
+    assert isinstance(preflight_steps, list), "preflight_steps missing from default_sensory_loop"
+    step_names = [step.get("tool") for step in preflight_steps if isinstance(step, dict)]
+    assert step_names[:3] == [
+        "context.required_reads",
+        "context.readiness",
+        "context.briefing",
+    ]
+
+
+def test_loop_forwards_machine_readable_brain_evidence_block() -> None:
+    """#3492: the loop must carry the normalized #3488 brain-evidence block, not only a sibling field."""
+    briefing = _briefing()
+    loop = _loop(briefing)
+    assert loop.get("brain_evidence_block") == briefing["brain_evidence_block"]
+
+
+def test_loop_forwards_status_proof_block_and_decision_replay_gate() -> None:
+    """#3492: the loop must forward #3489 status-proof and replay-gate surfaces."""
+    loop = _loop(_briefing())
+    assert "status_proof_block" in loop
+    assert "decision_replay_gate" in loop
+
+
+def test_repo_only_or_low_trust_loop_fails_closed_instead_of_staying_neutral() -> None:
+    """#3492: repo-only / LOW trust must visibly degrade the loop outcome."""
+    loop = _loop(_briefing())
+    assert loop.get("status") in {"degraded", "fail_closed"}
+    degraded_reasons = loop.get("degraded_reasons")
+    assert isinstance(degraded_reasons, list), "degraded_reasons missing"
+    assert any(reason in {"repo_only", "LOW", "insufficient_evidence"} for reason in degraded_reasons)
+
+
+def test_loop_blocks_db_backed_roadmap_closure_and_status_claims_without_db_evidence() -> None:
+    """#3492: repo-only evidence must not authorize DB-backed roadmap, closure, or status claims."""
+    loop = _loop(
+        _briefing(
+            repo_state={
+                "working_tree": "dirty",
+                "main_state": "stale",
+                "delivery_state": "local_only",
+            },
+            github_state={
+                "target_issue": "#3492",
+                "roadmap_issue": "#3479",
+            },
+            working_assumptions=[
+                "Roadmap truth is implied by local files.",
+                "Closure truth is implied by a branch-local summary.",
+                "Status proof is implied without DB-backed evidence.",
+            ],
+        )
+    )
+    claim_boundaries = loop.get("claim_boundaries")
+    assert isinstance(claim_boundaries, dict), "claim_boundaries missing"
+    assert claim_boundaries["allow_db_backed_roadmap_claims"] is False
+    assert claim_boundaries["allow_db_backed_closure_claims"] is False
+    assert claim_boundaries["allow_db_backed_status_claims"] is False
+
+
+def test_dirty_or_stale_worktree_becomes_a_risky_condition_without_forcing_write() -> None:
+    """#3492: dirty/stale worktree state must be explicit and must not produce a write recommendation."""
+    loop = _loop(
+        _briefing(
+            repo_state={
+                "worktree": "dirty",
+                "main_sync": "stale",
+            }
+        )
+    )
+    risky_conditions = loop.get("risky_conditions")
+    assert isinstance(risky_conditions, list), "risky_conditions missing"
+    risky_ids = {item.get("id") for item in risky_conditions if isinstance(item, dict)}
+    assert {"dirty_worktree", "stale_main"}.issubset(risky_ids)
+    next_move = loop.get("next_move")
+    assert isinstance(next_move, dict), "next_move missing"
+    assert next_move.get("kind") == "Blocked"
+
+
+def test_loop_separates_trade_capable_stage_from_lr_no_go() -> None:
+    """#3492: stage and LR must remain separate proof surfaces."""
+    loop = _loop(_briefing())
+    status_surfaces = loop.get("status_surfaces")
+    assert isinstance(status_surfaces, dict), "status_surfaces missing"
+    assert status_surfaces["board_stage"]["value"] == "trade-capable"
+    assert status_surfaces["lr_verdict"]["value"] == "NO-GO"
+    assert status_surfaces["board_stage"]["implies_live_go"] is False
+
+
+def test_loop_returns_exactly_one_machine_readable_next_move() -> None:
+    """#3492: the loop must decide one bounded next move, not an open-ended list of options."""
+    loop = _loop(_briefing())
+    next_move = loop.get("next_move")
+    assert isinstance(next_move, dict), "next_move missing"
+    assert next_move.get("kind") in ALLOWED_NEXT_MOVES
+    assert isinstance(next_move.get("reason"), str) and next_move["reason"].strip()
+    assert "candidate_next_moves" not in loop
+
+
+def test_loop_explicitly_marks_3494_end_to_end_proof_as_out_of_scope() -> None:
+    """#3492: the default sensory loop slice must not pre-empt the #3494 end-to-end proof slice."""
+    loop = _loop(_briefing())
+    proof_boundary = loop.get("proof_boundary")
+    assert isinstance(proof_boundary, dict), "proof_boundary missing"
+    assert proof_boundary["e2e_proof_issue"] == "#3494"
+    assert proof_boundary["e2e_proof_scope"] == "excluded"

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -1890,6 +1890,318 @@ def _detect_non_db_backed_claim_findings(
     return findings
 
 
+def _build_default_sensory_status_claims(
+    *,
+    repo_state: Mapping[str, Any],
+    github_state: Mapping[str, Any],
+    working_assumptions: list[str],
+    non_db_backed_claim_findings: list[str],
+) -> list[dict[str, Any]]:
+    status_claims: list[dict[str, Any]] = []
+
+    delivery_state = str(repo_state.get("delivery_state") or "").strip()
+    if delivery_state and delivery_state != "unknown":
+        status_claims.append(
+            {
+                "surface": "delivery_reconcile",
+                "github_issue_state": "open" if github_state.get("target_issue") else "unknown",
+                "repo_delivery_state": delivery_state,
+            }
+        )
+
+    roadmap_sources: list[str] = []
+    if "non_db_backed_staged_file_claim" in non_db_backed_claim_findings:
+        roadmap_sources.append("local_staged_files")
+    if "non_db_backed_pr_body_claim" in non_db_backed_claim_findings:
+        roadmap_sources.append("pr_narrative")
+    if roadmap_sources:
+        status_claims.append(
+            {
+                "surface": "roadmap_state",
+                "sources": roadmap_sources,
+                "state": "unproven",
+            }
+        )
+
+    assumptions_text = " ".join(
+        item.strip().lower() for item in working_assumptions if isinstance(item, str)
+    )
+    issue_sources: list[str] = []
+    if "closure" in assumptions_text:
+        issue_sources.append("pr_body")
+    if "status proof" in assumptions_text or "status truth" in assumptions_text:
+        issue_sources.append("ledger")
+    if issue_sources:
+        status_claims.append(
+            {
+                "surface": "issue_state",
+                "sources": issue_sources,
+                "state": "closed",
+            }
+        )
+
+    return status_claims
+
+
+def _build_default_sensory_risky_conditions(
+    *,
+    repo_state: Mapping[str, Any],
+    brain_source: str,
+    brain_status: str,
+    brain_evidence_fields: Mapping[str, Any],
+    operator_trust_level: str,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    risky_conditions: list[dict[str, Any]] = []
+    degraded_reasons: list[str] = []
+
+    def _append(condition_id: str, severity: str, summary: str, reason: str) -> None:
+        risky_conditions.append(
+            {
+                "id": condition_id,
+                "severity": severity,
+                "summary": summary,
+                "reason": reason,
+            }
+        )
+        degraded_reasons.append(reason)
+
+    if repo_state.get("working_tree") == "dirty":
+        _append(
+            "dirty_worktree",
+            "blocking",
+            "Dirty worktree must remain visible before any write recommendation.",
+            "dirty_worktree",
+        )
+
+    if repo_state.get("main_sync") == "stale":
+        _append(
+            "stale_main",
+            "blocking",
+            "Stale base branch must block automatic write progression.",
+            "stale_main",
+        )
+
+    if brain_source == "repo-only":
+        _append(
+            "repo_only_fallback",
+            "warning",
+            "Repo-only fallback cannot justify DB-backed claims.",
+            "repo_only",
+        )
+
+    fallback_reason = str(brain_evidence_fields.get("repo_fallback_reason") or "")
+    if fallback_reason == "insufficient_evidence":
+        _append(
+            "insufficient_evidence",
+            "warning",
+            "Context tools yielded no usable record-backed evidence.",
+            "insufficient_evidence",
+        )
+
+    if operator_trust_level == "LOW":
+        _append(
+            "low_trust",
+            "warning",
+            "LOW operator trust must degrade the sensory loop.",
+            "LOW",
+        )
+
+    if operator_trust_level == "BLOCKED" or brain_status == "blocked":
+        _append(
+            "blocked_context",
+            "blocking",
+            "Blocked context must fail closed.",
+            "blocked_context",
+        )
+
+    deduped_conditions: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for item in risky_conditions:
+        condition_id = str(item.get("id") or "")
+        if condition_id and condition_id not in seen_ids:
+            deduped_conditions.append(item)
+            seen_ids.add(condition_id)
+
+    deduped_reasons = list(dict.fromkeys(degraded_reasons))
+    return deduped_conditions, deduped_reasons
+
+
+def _derive_default_sensory_next_move(
+    *,
+    task_scope: str,
+    operation_mode: str,
+    risky_conditions: list[dict[str, Any]],
+) -> dict[str, str]:
+    blocking_ids = {
+        str(item.get("id") or "")
+        for item in risky_conditions
+        if str(item.get("severity") or "").strip().lower() == "blocking"
+    }
+    if blocking_ids:
+        return {
+            "kind": "Blocked",
+            "reason": "Blocking risky conditions present: " + ", ".join(sorted(blocking_ids)),
+        }
+
+    scope_lower = task_scope.lower()
+    if "red_only" in scope_lower or "red-only" in scope_lower:
+        return {
+            "kind": "RED_ONLY",
+            "reason": "Task scope explicitly targets a RED_ONLY test-first slice.",
+        }
+    if operation_mode == "read_only":
+        return {
+            "kind": "Plan",
+            "reason": "Read-only scope should stop at planning and evidence shaping.",
+        }
+    if "reconcile" in scope_lower:
+        return {
+            "kind": "Reconcile",
+            "reason": "Task scope explicitly requests reconciliation work.",
+        }
+    if "close" in scope_lower or "closeout" in scope_lower:
+        return {
+            "kind": "Closeout",
+            "reason": "Task scope explicitly requests closeout work.",
+        }
+    return {
+        "kind": "Implementation",
+        "reason": "No blocking condition remains and scope allows implementation.",
+    }
+
+
+def _build_default_sensory_loop(
+    *,
+    task_scope: str,
+    operation_mode: str,
+    briefing_id: str,
+    required_reads: list[str],
+    readiness_status: str,
+    human_go_required: bool,
+    brain_evidence_block: Mapping[str, Any],
+    brain_source: str,
+    brain_status: str,
+    brain_evidence_fields: Mapping[str, Any],
+    operator_trust_level: str,
+    repo_state: Mapping[str, Any],
+    github_state: Mapping[str, Any],
+    working_assumptions: list[str],
+    evidence_records: Any,
+    claim_records: Any,
+    decision_events: Any,
+    memory_records: Any,
+) -> dict[str, Any]:
+    from tools.mcp.context_decision_tools import (
+        _build_decision_replay_gate,
+        _build_status_proof_block,
+    )
+
+    non_db_backed_claim_findings = _detect_non_db_backed_claim_findings(
+        db_claims_allowed=bool(
+            brain_source == "surrealdb-local"
+            and brain_status in {"used", "partial"}
+            and brain_evidence_fields.get("context_available") is True
+        ),
+        repo_state=repo_state,
+        working_assumptions=working_assumptions,
+    )
+
+    status_claims = _build_default_sensory_status_claims(
+        repo_state=repo_state,
+        github_state=github_state,
+        working_assumptions=working_assumptions,
+        non_db_backed_claim_findings=non_db_backed_claim_findings,
+    )
+    status_proof_block, closure_drift_markers = _build_status_proof_block(
+        status_claims=status_claims,
+        brain_fields=dict(brain_evidence_block),
+    )
+    decision_replay_gate = _build_decision_replay_gate(
+        source=brain_source,
+        evidence_records=evidence_records if isinstance(evidence_records, list) else None,
+        claim_records=claim_records if isinstance(claim_records, list) else None,
+        memory_records=memory_records if isinstance(memory_records, list) else None,
+    )
+
+    risky_conditions, degraded_reasons = _build_default_sensory_risky_conditions(
+        repo_state=repo_state,
+        brain_source=brain_source,
+        brain_status=brain_status,
+        brain_evidence_fields=brain_evidence_fields,
+        operator_trust_level=operator_trust_level,
+    )
+
+    loop_status = "ready"
+    if any(
+        str(item.get("severity") or "").strip().lower() == "blocking"
+        for item in risky_conditions
+    ):
+        loop_status = "fail_closed"
+    elif risky_conditions or decision_replay_gate.get("status") == "degraded":
+        loop_status = "degraded"
+
+    next_move = _derive_default_sensory_next_move(
+        task_scope=task_scope,
+        operation_mode=operation_mode,
+        risky_conditions=risky_conditions,
+    )
+    if next_move["kind"] == "Blocked" and "blocked_context" not in degraded_reasons and loop_status == "ready":
+        loop_status = "fail_closed"
+
+    return {
+        "preflight_steps": [
+            {
+                "tool": "context.required_reads",
+                "status": "ready",
+                "required_reads": list(required_reads),
+            },
+            {
+                "tool": "context.readiness",
+                "status": readiness_status,
+                "human_go_required": human_go_required,
+            },
+            {
+                "tool": "context.briefing",
+                "status": "ready",
+                "briefing_id": briefing_id,
+            },
+        ],
+        "status": loop_status,
+        "degraded_reasons": degraded_reasons,
+        "brain_evidence_block": dict(brain_evidence_block),
+        "status_proof_block": status_proof_block,
+        "decision_replay_gate": decision_replay_gate,
+        "closure_drift_markers": closure_drift_markers,
+        "risky_conditions": risky_conditions,
+        "claim_boundaries": {
+            "allow_db_backed_roadmap_claims": False,
+            "allow_db_backed_closure_claims": False,
+            "allow_db_backed_status_claims": False,
+            "blocking_findings": non_db_backed_claim_findings,
+        },
+        "status_surfaces": {
+            "board_stage": {
+                "value": "trade-capable",
+                "implies_live_go": False,
+            },
+            "lr_verdict": {
+                "value": "NO-GO",
+                "implies_live_go": False,
+            },
+            "live_authorization": {
+                "value": False,
+                "implies_echtgeld_go": False,
+            },
+        },
+        "next_move": next_move,
+        "proof_boundary": {
+            "e2e_proof_issue": "#3494",
+            "e2e_proof_scope": "excluded",
+            "reason": "End-to-end sensory proof belongs to the later #3494 slice.",
+        },
+    }
+
+
 def context_briefing_handler(**kwargs) -> dict[str, Any]:
     """
     Read-only handler for context.briefing tool.
@@ -2022,6 +2334,7 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
         risk_level = "medium"
 
     valid_working_tree_states = frozenset({"clean", "dirty", "unknown"})
+    valid_main_sync_states = frozenset({"current", "stale", "unknown"})
     session_context_limitations: list[str] = []
     brain_context = _derive_briefing_brain_context(
         adapter_config_path=_adapter_config_path,
@@ -2045,11 +2358,19 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
         "branch": "unknown",
         "commit": "unknown",
         "working_tree": "unknown",
+        "main_sync": "unknown",
+        "delivery_state": "unknown",
     }
     if isinstance(_repo_state_raw, dict):
         repo_branch = _repo_state_raw.get("branch")
         repo_commit = _repo_state_raw.get("commit")
         repo_working_tree = _repo_state_raw.get("working_tree")
+        if repo_working_tree is None:
+            repo_working_tree = _repo_state_raw.get("worktree")
+        repo_main_sync = _repo_state_raw.get("main_sync")
+        if repo_main_sync is None:
+            repo_main_sync = _repo_state_raw.get("main_state")
+        repo_delivery_state = _repo_state_raw.get("delivery_state")
 
         if isinstance(repo_branch, str) and repo_branch.strip():
             repo_state["branch"] = repo_branch.strip()
@@ -2071,6 +2392,16 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
             session_context_limitations.append(
                 "repo_state.working_tree missing or malformed; using unknown"
             )
+
+        if repo_main_sync in valid_main_sync_states:
+            repo_state["main_sync"] = repo_main_sync
+        elif repo_main_sync is not None:
+            session_context_limitations.append(
+                "repo_state.main_sync missing or malformed; using unknown"
+            )
+
+        if isinstance(repo_delivery_state, str) and repo_delivery_state.strip():
+            repo_state["delivery_state"] = repo_delivery_state.strip()
     else:
         session_context_limitations.append(
             "repo_state not provided; using unknown repo state"
@@ -2889,6 +3220,27 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
     )
 
     # --- Assemble briefing result ---
+    default_sensory_loop = _build_default_sensory_loop(
+        task_scope=task_scope,
+        operation_mode=operation_mode,
+        briefing_id=briefing_id,
+        required_reads=required_reads,
+        readiness_status=readiness_status,
+        human_go_required=human_go_required,
+        brain_evidence_block=brain_evidence_block,
+        brain_source=brain_source,
+        brain_status=brain_status,
+        brain_evidence_fields=brain_evidence_fields,
+        operator_trust_level=operator_trust_level,
+        repo_state=repo_state,
+        github_state=github_state,
+        working_assumptions=working_assumptions,
+        evidence_records=_evidence_records_raw,
+        claim_records=_claim_records_raw,
+        decision_events=_decision_events_raw,
+        memory_records=_memory_records_raw,
+    )
+
     briefing: dict[str, Any] = {
         "briefing_id": briefing_id,
         "enrichment_id": f"cdb-enrich-{enrichment_id}",
@@ -2913,8 +3265,13 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
         "missing_evidence_notice": missing_evidence_notice,
         "blocking_trust_findings": blocking_trust_findings,
         "recommended_next_reads": recommended_next_reads_enrichment,
-        "approval_semantics": {"no_echtgeld_go": True},
+        "approval_semantics": {
+            "no_lr_go": True,
+            "no_live_go": True,
+            "no_echtgeld_go": True,
+        },
         "brain_evidence_block": brain_evidence_block,
+        "default_sensory_loop": default_sensory_loop,
         "session_context": session_context,
         "dependency_paths": dependency_paths,
         "known_risks": known_risks,


### PR DESCRIPTION
Closes #3492
Refs #3479
Refs #3488
Refs #3489

## RED -> GREEN Summary
- implements a machine-readable `default_sensory_loop` in `context.briefing`
- reuses the existing #3488 brain-evidence contract and #3489 status-proof / decision-replay gates
- keeps #3494 end-to-end sensory proof explicitly out of scope

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- tools_or_queries:
  - `context.readiness`
  - `git fetch origin --prune`
  - `git status -sb`
  - `git branch --show-current`
  - `git rev-parse HEAD`
  - `git rev-parse origin/main`
  - `git worktree list`
  - `gh pr view 3538 --json number,title,state,headRefName,baseRefName,isDraft,mergeable,url,files,commits`
  - `gh issue view 3492 --json number,title,state,body,comments,updatedAt,url`
  - `gh issue view 3479 --json number,title,state,updatedAt,url`
  - `gh issue view 3488 --json number,title,state,updatedAt,url`
  - `gh issue view 3489 --json number,title,state,updatedAt,url`
  - `gh issue view 3494 --json number,title,state,body,updatedAt,url`
- records_or_results:
  - existing `context.briefing` already exposed #3488 brain evidence
  - existing replay/status-proof surfaces already exposed #3489 machine-readable gates
  - missing contract was the composition layer in `context.briefing`
  - focused green validation passed for #3492 plus nearby #3488/#3489/briefing/replay tests
- repo_crosscheck:
  - `tools/mcp/context_bridge.py`
  - `tools/mcp/context_decision_tools.py`
  - `tools/surrealdb/decision_replay_builder.py`
  - `tests/unit/tools/mcp/test_default_sensory_loop_red_3492.py`
  - `tests/unit/tools/mcp/test_mcp_briefing_evidence_claim_trust_red_3488.py`
  - `tests/unit/tools/mcp/test_decision_replay_status_proof_red_3489.py`
- impact_on_plan:
  - composed existing evidence and replay gates instead of weakening or duplicating them
  - default loop now degrades or fails closed on repo-only, insufficient-evidence, LOW-trust, dirty, and stale conditions
- limitations:
  - no DB-backed evidence was invented
  - loop remains advisory only and does not authorize LR-Go, Live-Go, or Echtgeld-Go
  - #3494 end-to-end proof remains a later slice

## Implemented Default Sensory Loop
- models explicit preflight order for `context.required_reads`, `context.readiness`, and `context.briefing`
- forwards `brain_evidence_block`, `status_proof_block`, `decision_replay_gate`, and `closure_drift_markers`
- surfaces risky conditions for dirty worktree, stale main, repo-only fallback, insufficient evidence, LOW trust, and blocked context
- emits exactly one machine-readable `next_move`
- separates board stage `trade-capable` from LR verdict `NO-GO` and any live/echtgeld authorization
- marks `#3494` as the later end-to-end proof boundary

## Safety Boundaries
- no DB or MCP writes
- no runtime, BLUE, or RED system changes
- no LR, Live, or Echtgeld authorization
- no scope expansion into #3494
- root dirty worktree remained untouched; implementation stayed in the auxiliary worktree branch

## Validation
- `pytest -q tests/unit/tools/mcp/test_default_sensory_loop_red_3492.py`
- `pytest -q tests/unit/tools/mcp/test_mcp_briefing_evidence_claim_trust_red_3488.py`
- `pytest -q tests/unit/tools/mcp/test_decision_replay_status_proof_red_3489.py`
- `pytest -q tests/unit/tools/mcp/test_mcp_briefing_tool.py tests/unit/tools/mcp/test_mcp_briefing_enrichment.py`
- `pytest -q tests/unit/surrealdb/test_decision_replay_builder_v2.py`
- `ruff check tools/mcp/context_bridge.py tests/unit/tools/mcp/test_default_sensory_loop_red_3492.py`
- `git diff --check`

## Remaining Gaps
- none in #3492 scope; #3494 remains the separate end-to-end proof slice
