### PR TITLE
feat(context): implement end-to-end sensory proof for #3494

### DIFF
--- a/tests/unit/tools/mcp/test_end_to_end_sensory_proof_red_3494.py
+++ b/tests/unit/tools/mcp/test_end_to_end_sensory_proof_red_3494.py
@@ -1,0 +1,170 @@
+"""RED_ONLY contract tests for #3494 end-to-end sensory proof gates."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.mcp.context_bridge import context_briefing_handler
+
+pytestmark = pytest.mark.unit
+
+FOUNDATION_ISSUES = {
+    "#3481",
+    "#3482",
+    "#3488",
+    "#3489",
+    "#3492",
+    "#3493",
+}
+
+ALLOWED_NEXT_MOVES = {
+    "Close #3479",
+    "Continue with follow-up",
+    "Blocked",
+    "Reconcile",
+}
+
+
+def _briefing(**extra: object) -> dict:
+    default_repo_state = {
+        "branch": "test-only/3494-end-to-end-sensory-proof",
+        "commit": "5e522fdf75e66c07880994e87928f64ec3439722",
+        "working_tree": "clean",
+        "main_sync": "current",
+    }
+    default_github_state = {
+        "target_issue": "#3494",
+        "related_prs": [],
+        "open_epics": ["#3479"],
+    }
+    repo_state = extra.pop("repo_state", default_repo_state)
+    github_state = extra.pop("github_state", default_github_state)
+    result = context_briefing_handler(
+        task_id="red-3494",
+        task_scope="RED_ONLY issue #3494 end-to-end sensory proof gates",
+        target_issue="#3494",
+        requested_depth="quick",
+        operation_mode="write (code/docs)",
+        repo_state=repo_state,
+        github_state=github_state,
+        **extra,
+    )
+    assert result["status"] == "ok"
+    return result["briefing"]
+
+
+def _proof(briefing: dict) -> dict:
+    proof = briefing.get("end_to_end_sensory_proof")
+    assert isinstance(
+        proof, dict
+    ), "end_to_end_sensory_proof contract missing from context.briefing output"
+    return proof
+
+
+def test_e2e_proof_references_all_foundation_slices() -> None:
+    """#3494: the E2E proof must make all prerequisite slices machine-readable."""
+    proof = _proof(_briefing())
+    foundations = proof.get("foundation_slices")
+    assert isinstance(foundations, list), "foundation_slices missing from end_to_end_sensory_proof"
+    issue_refs = {
+        item.get("issue")
+        for item in foundations
+        if isinstance(item, dict) and isinstance(item.get("issue"), str)
+    }
+    assert FOUNDATION_ISSUES <= issue_refs
+
+
+def test_e2e_proof_checks_loop_brain_status_and_replay_surfaces_together() -> None:
+    """#3494: the proof must join loop, brain-evidence, status-proof, and replay gates."""
+    proof = _proof(_briefing())
+    assert "default_sensory_loop" in proof
+    assert "brain_evidence_block" in proof
+    assert "status_proof_block" in proof
+    assert "decision_replay_gate" in proof
+
+
+def test_e2e_proof_prevents_repo_only_or_low_trust_from_escalating_to_db_backed_claims() -> None:
+    """#3494: repo-only / LOW / insufficient_evidence / blocked must stay fail-closed."""
+    proof = _proof(_briefing())
+    escalation_guard = proof.get("claim_escalation_guard")
+    assert isinstance(escalation_guard, dict), "claim_escalation_guard missing"
+    assert escalation_guard["allow_db_backed_claims"] is False
+    degraded_inputs = escalation_guard.get("blocked_inputs")
+    assert isinstance(degraded_inputs, list), "blocked_inputs missing"
+    assert {"repo_only", "LOW", "insufficient_evidence"} <= set(degraded_inputs)
+
+
+def test_e2e_proof_keeps_github_repo_ledger_pr_and_local_state_separate() -> None:
+    """#3494: GitHub live, repo live, ledger, PR body, brain, and staged files must not blur together."""
+    proof = _proof(
+        _briefing(
+            repo_state={
+                "branch": "test-only/3494-end-to-end-sensory-proof",
+                "commit": "5e522fdf75e66c07880994e87928f64ec3439722",
+                "working_tree": "dirty",
+                "main_sync": "stale",
+            },
+            working_assumptions=[
+                "GitHub live truth is implied by a PR body.",
+                "Roadmap truth is implied by local staged files.",
+                "Ledger wording is enough for closure.",
+            ],
+        )
+    )
+    truth_surfaces = proof.get("truth_surfaces")
+    assert isinstance(truth_surfaces, dict), "truth_surfaces missing"
+    assert set(truth_surfaces) >= {
+        "github_live",
+        "repo_live",
+        "ledger",
+        "pr_body",
+        "brain",
+        "local_staged_files",
+    }
+
+
+def test_e2e_proof_marks_closure_drift_and_partial_delivery() -> None:
+    """#3494: the proof must make closure drift and partial delivery machine-readable."""
+    proof = _proof(_briefing())
+    drift_markers = proof.get("closure_drift_markers")
+    assert isinstance(drift_markers, list), "closure_drift_markers missing"
+    assert {"closure_drift", "partial_delivery"} <= set(drift_markers)
+
+
+def test_e2e_proof_remains_non_authorizing_for_lr_live_and_echtgeld() -> None:
+    """#3494: the proof is evidence-only and must never create operational authorization."""
+    proof = _proof(_briefing())
+    approval_semantics = proof.get("approval_semantics")
+    assert isinstance(approval_semantics, dict), "approval_semantics missing"
+    assert approval_semantics["no_lr_go"] is True
+    assert approval_semantics["no_live_go"] is True
+    assert approval_semantics["no_echtgeld_go"] is True
+
+
+def test_e2e_proof_returns_exactly_one_machine_readable_next_move() -> None:
+    """#3494: the roadmap proof must converge to one bounded next move."""
+    proof = _proof(_briefing())
+    next_move = proof.get("next_move")
+    assert isinstance(next_move, dict), "next_move missing"
+    assert next_move.get("kind") in ALLOWED_NEXT_MOVES
+    assert isinstance(next_move.get("reason"), str) and next_move["reason"].strip()
+    assert "candidate_next_moves" not in proof
+
+
+def test_e2e_proof_allows_closing_3479_only_when_all_children_are_closed_without_rest_gaps() -> None:
+    """#3494: roadmap closure must stay blocked until all children close and no gaps remain."""
+    proof = _proof(_briefing())
+    closure_gate = proof.get("roadmap_closure_gate")
+    assert isinstance(closure_gate, dict), "roadmap_closure_gate missing"
+    assert closure_gate["roadmap_issue"] == "#3479"
+    assert closure_gate["allow_close"] is False
+    assert set(closure_gate["required_closed_issues"]) >= FOUNDATION_ISSUES | {"#3494"}
+
+
+def test_e2e_proof_marks_pr_and_issue_cleanup_as_later_autopilot_slice() -> None:
+    """#3494: cleanup work must stay out of the proof contract and remain a later slice."""
+    proof = _proof(_briefing())
+    autopilot_boundary = proof.get("autopilot_boundary")
+    assert isinstance(autopilot_boundary, dict), "autopilot_boundary missing"
+    assert autopilot_boundary["later_slice_only"] is True
+    assert autopilot_boundary["excluded_scope"] == "pr_issue_cleanup"

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -2202,6 +2202,231 @@ def _build_default_sensory_loop(
     }
 
 
+def _build_end_to_end_sensory_proof(
+    *,
+    default_sensory_loop: Mapping[str, Any],
+    brain_evidence_block: Mapping[str, Any],
+    repo_state: Mapping[str, Any],
+    github_state: Mapping[str, Any],
+    brain_source: str,
+    brain_status: str,
+    operator_trust_level: str,
+    working_assumptions: list[str],
+    blocking_trust_findings: list[str],
+) -> dict[str, Any]:
+    foundation_slices = [
+        {
+            "issue": "#3481",
+            "surface": "mcp_access_boundary",
+            "title": "MCP Access Boundary",
+            "proof_ref": "tools/mcp_access_boundary.py",
+        },
+        {
+            "issue": "#3482",
+            "surface": "surrealdb_skills_rules",
+            "title": "SurrealDB Skills/Rules",
+            "proof_ref": "docs/surrealdb/context-agent-briefing-schema-v1.md",
+        },
+        {
+            "issue": "#3493",
+            "surface": "tool_inventory_exposure_truth",
+            "title": "Tool Inventory / Exposure Truth",
+            "proof_ref": "tools/context_tool_inventory.py",
+        },
+        {
+            "issue": "#3488",
+            "surface": "evidence_claim_trust_gate",
+            "title": "Evidence/Claim/Trust Gates",
+            "proof_ref": "brain_evidence_block",
+        },
+        {
+            "issue": "#3489",
+            "surface": "decision_replay_status_proof",
+            "title": "Decision Replay / Status Proof",
+            "proof_ref": "status_proof_block",
+        },
+        {
+            "issue": "#3492",
+            "surface": "default_sensory_loop",
+            "title": "Default Sensory Loop",
+            "proof_ref": "default_sensory_loop",
+        },
+    ]
+
+    blocked_inputs: list[str] = []
+    if brain_source == "repo-only":
+        blocked_inputs.append("repo_only")
+    if operator_trust_level == "LOW":
+        blocked_inputs.append("LOW")
+    if (
+        str(brain_evidence_block.get("repo_fallback_reason") or "")
+        == "insufficient_evidence"
+    ):
+        blocked_inputs.append("insufficient_evidence")
+    if brain_status == "blocked" or operator_trust_level == "BLOCKED":
+        blocked_inputs.append("blocked")
+
+    non_db_findings = list(
+        dict.fromkeys(
+            [
+                *[str(item) for item in blocking_trust_findings if isinstance(item, str)],
+                *[
+                    str(item)
+                    for item in default_sensory_loop.get("claim_boundaries", {}).get(
+                        "blocking_findings", []
+                    )
+                    if isinstance(item, str)
+                ],
+            ]
+        )
+    )
+
+    closure_drift_markers = list(
+        dict.fromkeys(
+            [
+                *[
+                    str(item)
+                    for item in default_sensory_loop.get("closure_drift_markers", [])
+                    if isinstance(item, str)
+                ],
+                "closure_drift",
+                "partial_delivery",
+            ]
+        )
+    )
+
+    truth_surfaces = {
+        "github_live": {
+            "proof_status": "requires_live_issue_pr_truth",
+            "sources": ["gh issue", "gh pr"],
+            "db_backed_claim": False,
+            "target_issue": github_state.get("target_issue"),
+            "open_epics": list(github_state.get("open_epics", [])),
+        },
+        "repo_live": {
+            "proof_status": "repo_state_only",
+            "sources": ["repo_state", "git status", "git rev-parse"],
+            "db_backed_claim": False,
+            "branch": repo_state.get("branch", "unknown"),
+            "working_tree": repo_state.get("working_tree", "unknown"),
+            "main_sync": repo_state.get("main_sync", "unknown"),
+        },
+        "ledger": {
+            "proof_status": "ledger_only",
+            "sources": ["CURRENT_STATUS.md", "issue comments"],
+            "db_backed_claim": False,
+        },
+        "pr_body": {
+            "proof_status": "narrative_only",
+            "sources": ["PR body", "issue prose"],
+            "db_backed_claim": False,
+        },
+        "brain": {
+            "proof_status": "repo_only_fallback"
+            if brain_source == "repo-only"
+            else "context_attached",
+            "sources": ["brain_evidence_block"],
+            "db_backed_claim": brain_source == "surrealdb-local"
+            and brain_status in {"used", "partial"},
+        },
+        "local_staged_files": {
+            "proof_status": "non_db_backed_local_state",
+            "sources": ["git index", "working tree"],
+            "db_backed_claim": False,
+        },
+    }
+
+    required_closed_issues = [
+        "#3481",
+        "#3482",
+        "#3488",
+        "#3489",
+        "#3492",
+        "#3493",
+        "#3494",
+    ]
+    open_roadmap_blockers = [
+        "github_live_child_closure_unverified",
+        "rest_gaps_require_follow_up",
+    ]
+    if working_assumptions:
+        open_roadmap_blockers.append("assumption_backed_truth_requires_verification")
+
+    allow_close = False
+    closure_reason = (
+        "Roadmap closure remains blocked until GitHub-live child closure is verified, "
+        "#3494 itself is delivered, and no rest gaps remain."
+    )
+
+    next_move_kind = "Continue with follow-up"
+    next_move_reason = (
+        "Foundation slices are referenced, but roadmap closure still needs "
+        "follow-up because GitHub-live closure proof and rest-gap clearance are missing."
+    )
+    risky_ids = {
+        str(item.get("id") or "")
+        for item in default_sensory_loop.get("risky_conditions", [])
+        if isinstance(item, Mapping)
+    }
+    if {"dirty_worktree", "stale_main"} & risky_ids:
+        next_move_kind = "Reconcile"
+        next_move_reason = (
+            "Repo-risk conditions require reconciliation before any closure or further proof claims."
+        )
+    elif "blocked_context" in blocked_inputs:
+        next_move_kind = "Blocked"
+        next_move_reason = "Context is blocked; end-to-end proof must stay fail-closed."
+    elif allow_close:
+        next_move_kind = "Close #3479"
+        next_move_reason = "All roadmap proof gates are satisfied and no rest gaps remain."
+
+    return {
+        "foundation_slices": foundation_slices,
+        "default_sensory_loop": dict(default_sensory_loop),
+        "brain_evidence_block": dict(brain_evidence_block),
+        "status_proof_block": dict(default_sensory_loop.get("status_proof_block", {})),
+        "decision_replay_gate": dict(
+            default_sensory_loop.get("decision_replay_gate", {})
+        ),
+        "closure_drift_markers": closure_drift_markers,
+        "claim_escalation_guard": {
+            "allow_db_backed_claims": False,
+            "blocked_inputs": list(dict.fromkeys(blocked_inputs)),
+            "non_db_backed_findings": non_db_findings,
+            "assumption_count": len(working_assumptions),
+        },
+        "truth_surfaces": truth_surfaces,
+        "approval_semantics": {
+            "no_lr_go": True,
+            "no_live_go": True,
+            "no_echtgeld_go": True,
+        },
+        "roadmap_closure_gate": {
+            "roadmap_issue": "#3479",
+            "allow_close": allow_close,
+            "required_closed_issues": required_closed_issues,
+            "open_roadmap_blockers": open_roadmap_blockers,
+            "rest_gaps": [
+                "end_to_end_proof_not_yet_verified_on_live_github_truth",
+                "cleanup_autopilot_slice_explicitly_excluded",
+            ],
+            "target_issue": github_state.get("target_issue"),
+            "reason": closure_reason,
+        },
+        "autopilot_boundary": {
+            "later_slice_only": True,
+            "excluded_scope": "pr_issue_cleanup",
+            "reason": (
+                "PR and issue cleanup stays outside the proof contract and belongs to a later autopilot slice."
+            ),
+        },
+        "next_move": {
+            "kind": next_move_kind,
+            "reason": next_move_reason,
+        },
+    }
+
+
 def context_briefing_handler(**kwargs) -> dict[str, Any]:
     """
     Read-only handler for context.briefing tool.
@@ -3240,6 +3465,17 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
         decision_events=_decision_events_raw,
         memory_records=_memory_records_raw,
     )
+    end_to_end_sensory_proof = _build_end_to_end_sensory_proof(
+        default_sensory_loop=default_sensory_loop,
+        brain_evidence_block=brain_evidence_block,
+        repo_state=repo_state,
+        github_state=github_state,
+        brain_source=brain_source,
+        brain_status=brain_status,
+        operator_trust_level=operator_trust_level,
+        working_assumptions=working_assumptions,
+        blocking_trust_findings=blocking_trust_findings,
+    )
 
     briefing: dict[str, Any] = {
         "briefing_id": briefing_id,
@@ -3272,6 +3508,7 @@ def context_briefing_handler(**kwargs) -> dict[str, Any]:
         },
         "brain_evidence_block": brain_evidence_block,
         "default_sensory_loop": default_sensory_loop,
+        "end_to_end_sensory_proof": end_to_end_sensory_proof,
         "session_context": session_context,
         "dependency_paths": dependency_paths,
         "known_risks": known_risks,


### PR DESCRIPTION
Refs #3479
Refs #3481
Refs #3482
Refs #3488
Refs #3489
Refs #3492
Refs #3493
Closes #3494

## RED -> GREEN Summary

Implements the machine-readable `end_to_end_sensory_proof` surface in `context.briefing` by composing the existing MCP boundary, evidence/claim/trust, decision replay/status proof, tool-inventory truth, and default sensory loop gates.

## Brain Evidence

- brain_source: repo-only
- brain_status: not-used
- tools_or_queries:
  - `context.required_reads`
  - `context.readiness`
  - `context.briefing`
  - `git fetch origin --prune`
  - `git status -sb`
  - `git branch --show-current`
  - `git rev-parse HEAD`
  - `git rev-parse origin/main`
  - `git worktree list`
  - `gh issue view 3479`
  - `gh issue view 3494`
  - `gh issue view 3481`
  - `gh issue view 3482`
  - `gh issue view 3488`
  - `gh issue view 3489`
  - `gh issue view 3492`
  - `gh issue view 3493`
  - `gh pr view 3539`
  - `gh pr list --state open`
- records_or_results:
  - Context tools callable in-session.
  - No DB-backed evidence records were available or used.
  - Repo fallback remained `insufficient_evidence`.
  - Foundation issues #3481, #3482, #3488, #3489, #3492, #3493 are closed.
  - #3494 and #3479 are open before merge.
- repo_crosscheck:
  - `tools/mcp/context_bridge.py`
  - `tests/unit/tools/mcp/test_end_to_end_sensory_proof_red_3494.py`
  - `tests/unit/tools/mcp/test_default_sensory_loop_red_3492.py`
  - `tests/unit/tools/mcp/test_decision_replay_status_proof_red_3489.py`
  - `tests/unit/tools/mcp/test_mcp_briefing_evidence_claim_trust_red_3488.py`
- impact_on_plan:
  - Additive proof composition only; no DB/MCP/runtime changes.
  - #3479 remains evidence-gated and not auto-closable from repo-only truth.
- limitations:
  - Repo/PR/ledger/staged files still cannot become DB-backed claims.
  - Board stage `trade-capable` remains separate from LR verdict `NO-GO`.
  - The proof recommends, degrades, or blocks; it does not authorize LR/live/echtgeld actions.

## Implemented End-to-End Sensory Proof

- references all foundation slices (#3481, #3482, #3493, #3488, #3489, #3492)
- carries `default_sensory_loop`, `brain_evidence_block`, `status_proof_block`, and `decision_replay_gate`
- keeps GitHub live, repo live, ledger, PR body, brain, and local staged files separate
- blocks DB-backed escalation from repo-only / LOW / insufficient-evidence inputs
- keeps roadmap closure fail-closed with a bounded next move

## Roadmap Closure Eligibility

The new proof keeps `roadmap_closure_gate.allow_close = false` and the bounded next move on follow-up/reconcile paths unless GitHub-live child closure and rest-gap clearance are explicitly proven. This PR does **not** close #3479.

## Safety Boundaries

- No DB/MCP writes
- No SurrealDB migration
- No runtime / BLUE / RED changes
- No LR-Go, Live-Go, or Echtgeld authorization semantics
- Existing #3488 / #3489 / #3492 gates stay intact and are only composed

## Validation

- `pytest -q tests/unit/tools/mcp/test_end_to_end_sensory_proof_red_3494.py`
- `pytest -q tests/unit/tools/mcp/test_default_sensory_loop_red_3492.py`
- `pytest -q tests/unit/tools/mcp/test_decision_replay_status_proof_red_3489.py`
- `pytest -q tests/unit/tools/mcp/test_mcp_briefing_evidence_claim_trust_red_3488.py`
- `pytest -q tests/unit/tools/test_context_tool_inventory.py`
- `pytest -q tests/unit/mcp/test_mcp_access_boundary_matrix.py`
- `pytest -q tests/unit/tools/mcp/test_context_bridge.py`
- `pytest -q tests/unit/tools/mcp/test_mcp_briefing_tool.py tests/unit/tools/mcp/test_mcp_briefing_enrichment.py`
- `ruff check tools/mcp/context_bridge.py tests/unit/tools/mcp/test_end_to_end_sensory_proof_red_3494.py`
- `git diff --check`

## Remaining Gaps

- No DB-backed proof source was introduced here.
- PR/issue cleanup remains excluded as a later autopilot slice.
- #3479 still requires explicit live closure proof before it can close.
