### PR TITLE
docs(context): define #3480 sensory layer canon

### DIFF
--- a/docs/onboarding/repo_brain_context_intelligence.md
+++ b/docs/onboarding/repo_brain_context_intelligence.md
@@ -244,6 +244,7 @@ pwsh -File agents/templates/onboarding_mcp_setup.ps1
 
 | Doc | Purpose |
 |-----|---------|
+| `knowledge/decisions/CDB_CONTEXT_BRAIN_SENSORY_LAYER.md` | Canonical sensory-layer principle and boundary contract |
 | `docs/surrealdb/README.md` | Context-/MCP-Docs-Index |
 | `docs/runbooks/surrealdb_context_mcp_access.md` | MCP capability resolution |
 | `docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md` | Local context runtime |

--- a/knowledge/decisions/CDB_CONTEXT_BRAIN_SENSORY_LAYER.md
+++ b/knowledge/decisions/CDB_CONTEXT_BRAIN_SENSORY_LAYER.md
@@ -1,0 +1,108 @@
+# Context Brain Sensory Layer
+
+| Field | Value |
+| --- | --- |
+| Status | **accepted** / **active** |
+| Date | 2026-06-29 |
+| Issue | GitHub issue #3480 |
+| Parent | GitHub issue #3479 |
+| Principle | `empfindsamer, nicht schlauer` |
+
+## Scope
+
+This canon defines the CDB Context Brain as a **Sensorik-Schicht** for agent and
+developer orientation. It sharpens the already active read-only posture without
+changing runtime, DB, MCP, LR, or trading behavior.
+
+Out of scope:
+
+- #3484 graph operationalization
+- #3486 vector / embedding pipeline
+- #3487 hybrid retrieval / sensory fusion
+- runtime logic, Graph/Vector/Hybrid implementation, or policy expansion
+
+## Core principle
+
+Context Brain makes agents **empfindsamer, nicht schlauer**.
+
+It improves perception and orientation before action. It does **not** grant
+autonomy, authority, or execution rights.
+
+## Layer model
+
+Canonical tool/order separation:
+
+`Sensory -> Evidence -> Action`
+
+- **Sensory** gathers orientation signals and surfaces proximity, relevance,
+  drift, decision context, evidence pointers, and memory hints.
+- **Evidence** validates or rejects claims with concrete repo/live/tool/query/record proof.
+- **Action** remains separately gated and never follows from Context Brain output alone.
+
+## Truth order
+
+Canonical priority:
+
+`GitHub > Repo > Context > Memory`
+
+Interpretation:
+
+1. GitHub live — issues, PRs, checks, branches, comments
+2. Repo live — canon docs, code, contracts, runbooks
+3. Context — read-only context tooling only when separately evidenced
+4. Memory — session or stored memory hints, never authority
+
+`CURRENT_STATUS.md` stays a **ledger, not live truth**.
+
+## Separation boundaries
+
+These surfaces must stay explicitly separate:
+
+- GitHub live
+- Repo live
+- Ledger / `CURRENT_STATUS.md`
+- PR body
+- local staged files
+
+None of these lower-authority surfaces may be upgraded into DB truth, live truth,
+or closure truth by narrative alone.
+
+## Perception contract
+
+The Context Brain sensory layer is expected to surface:
+
+`Naehe, Relevanz, Drift, Decisions, Evidence, Memory`
+
+This is perception support only. It is not autonomous reasoning authority.
+
+## Evidence contract
+
+No DB-backed claim is allowed without Tool/Query/Record evidence.
+
+Repo text, ledger text, PR body text, or local staged files are not enough to
+claim DB-backed proof by themselves.
+
+## Forbidden zone
+
+The sensory layer must not cross these boundaries:
+
+- keine Autonomie
+- keine Live-Entscheidung
+- kein Echtgeld
+- keine Trading-Freigabe
+- keine produktiven DB-Writes
+- keine MCP-Mutation
+
+LR remains NO-GO. Board stage stays orthogonal to Live-Go.
+
+## Roadmap placement
+
+- #3479 remains the parent epic for the sensory roadmap.
+- #3480 defines the canonical sensory-layer baseline in documentation.
+- #3484, #3486, and #3487 remain explicit follow-on work and are not delivered by this file.
+
+## References
+
+- [CDB_CONTEXT_BRAIN_DEFAULT_POSTURE.md](CDB_CONTEXT_BRAIN_DEFAULT_POSTURE.md)
+- [ADR-002-context-intelligence-canon.md](ADR-002-context-intelligence-canon.md)
+- [docs/onboarding/repo_brain_context_intelligence.md](../../docs/onboarding/repo_brain_context_intelligence.md)

--- a/knowledge/decisions/README.md
+++ b/knowledge/decisions/README.md
@@ -7,6 +7,7 @@ Recorded decisions (ADR-style) for governance, context/MCP posture, and infrastr
 | File | Topic |
 |---|---|
 | [`CDB_CONTEXT_BRAIN_DEFAULT_POSTURE.md`](CDB_CONTEXT_BRAIN_DEFAULT_POSTURE.md) | Brain evidence default (#2775) |
+| [`CDB_CONTEXT_BRAIN_SENSORY_LAYER.md`](CDB_CONTEXT_BRAIN_SENSORY_LAYER.md) | Context Brain as sensory layer canon (#3480) |
 | [`CDB_CONTEXT_MANAGED_NONLOCAL_RUNTIME_DECISION.md`](CDB_CONTEXT_MANAGED_NONLOCAL_RUNTIME_DECISION.md) | Managed runtime (not activated) |
 | [`CDB_CONTROLLED_WRITE_STRATEGY_V2_DESIGN.md`](CDB_CONTROLLED_WRITE_STRATEGY_V2_DESIGN.md) | Write strategy design only |
 | [`K8S_BUDGET_DECISION.md`](K8S_BUDGET_DECISION.md) | Kubernetes GO/NO-GO |

--- a/tests/unit/agents/test_context_brain_sensory_layer_contract.py
+++ b/tests/unit/agents/test_context_brain_sensory_layer_contract.py
@@ -1,0 +1,52 @@
+"""RED contract anchors for #3480 Context Brain sensory layer canon."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SENSORY_LAYER_DOC = "knowledge/decisions/CDB_CONTEXT_BRAIN_SENSORY_LAYER.md"
+
+CANONICAL_FILES: dict[str, tuple[str, ...]] = {
+    SENSORY_LAYER_DOC: (
+        "# Context Brain Sensory Layer",
+        "Sensorik-Schicht",
+        "empfindsamer, nicht schlauer",
+        "Sensory -> Evidence -> Action",
+        "GitHub > Repo > Context > Memory",
+        "CURRENT_STATUS.md",
+        "ledger, not live truth",
+        "PR body",
+        "local staged files",
+        "No DB-backed claim",
+        "Naehe, Relevanz, Drift, Decisions, Evidence, Memory",
+        "keine Autonomie",
+        "keine Live-Entscheidung",
+        "kein Echtgeld",
+        "#3479",
+        "#3484",
+        "#3486",
+        "#3487",
+    ),
+    "knowledge/decisions/README.md": (
+        "CDB_CONTEXT_BRAIN_SENSORY_LAYER.md",
+    ),
+    "docs/onboarding/repo_brain_context_intelligence.md": (
+        "CDB_CONTEXT_BRAIN_SENSORY_LAYER.md",
+    ),
+}
+
+
+@pytest.mark.parametrize("relative_path,needles", list(CANONICAL_FILES.items()))
+def test_context_brain_sensory_layer_contract_anchors(
+    relative_path: str, needles: tuple[str, ...]
+) -> None:
+    path = REPO_ROOT / relative_path
+    assert path.is_file(), f"missing canonical file: {relative_path}"
+    text = path.read_text(encoding="utf-8")
+    for needle in needles:
+        assert needle in text, f"{relative_path} missing contract anchor: {needle!r}"


### PR DESCRIPTION
Refs #3480
Refs #3479

## RED -> GREEN Summary

PR #3540 now carries the minimal canon/docs follow-up needed to turn the RED contract slice green.
The original RED test remains unchanged; the repo-backed canon surface now exists and is referenced from the decision index and onboarding entrypoint.

## Implemented Canon Surface

- `knowledge/decisions/CDB_CONTEXT_BRAIN_SENSORY_LAYER.md`
  - defines Context Brain as Sensorik-Schicht
  - anchors the principle `empfindsamer, nicht schlauer`
  - defines the layer model `Sensory -> Evidence -> Action`
  - documents truth order `GitHub > Repo > Context > Memory`
  - separates GitHub live, Repo live, `CURRENT_STATUS.md`, PR body, and local staged files
  - forbids DB-backed claims without Tool/Query/Record evidence
  - defines perception modes and the forbidden zone
  - keeps `#3484`, `#3486`, and `#3487` explicitly downstream and out of scope
- `knowledge/decisions/README.md`
  - references `CDB_CONTEXT_BRAIN_SENSORY_LAYER.md`
- `docs/onboarding/repo_brain_context_intelligence.md`
  - references `CDB_CONTEXT_BRAIN_SENSORY_LAYER.md`

## Validation

- `pytest -q tests/unit/agents/test_context_brain_sensory_layer_contract.py` -> PASS (`3 passed`)
- `ruff check tests/unit/agents/test_context_brain_sensory_layer_contract.py` -> PASS
- `git diff --check` -> PASS

## Safety Boundaries

- No runtime, BLUE, or RED changes
- No DB or MCP writes
- No Graph/Vector/Hybrid implementation
- No LR-Go, Live-Go, Echtgeld-Go, or trading authorization claim
- No test weakening
- Root dirty worktree untouched

## Remaining Scope

- `#3484` open
- `#3486` open
- `#3487` open
- `#3480` open lassen
- `#3479` open lassen
