### PR TITLE
feat(surrealdb): implement #3487 hybrid retrieval contract

### DIFF
--- a/docs/onboarding/repo_brain_context_intelligence.md
+++ b/docs/onboarding/repo_brain_context_intelligence.md
@@ -190,6 +190,26 @@ These anchors document the vector pipeline contract, fixtures, and proof boundar
 They stay repo-only, non-authorizing, and do not create DB-backed truth, runtime
 rebuild authority, or any Live-/Echtgeld-Go. #3487 remains a later follow-up.
 
+## Hybrid retrieval discoverability
+
+For the #3487 hybrid retrieval follow-up, start from the same sensory canon and keep
+the foundations separate:
+
+- #3484 provides the graph anchor
+- #3486 provides the vector / embedding anchor
+- #3487 connects BM25 + Vector + Graph only as contract / fixture / ranking semantics
+
+Use these repo-only discoverability anchors:
+
+- `docs/surrealdb/context-hybrid-retrieval-strategy-v1.md`
+- `infrastructure/surrealdb/hybrid_retrieval_fixtures.surql`
+- `tools/surrealdb/hybrid_retrieval_ranking.py`
+- `context.search`
+
+The hybrid follow-up remains non-authorizing. It does not create productive DB
+execution, does not create DB-backed evidence without Tool/Query/Record proof, and
+does not imply any Live-/Echtgeld-Go.
+
 ## Local Readiness Check
 
 Start with the **developer onboarding doctor** for a general setup check:

--- a/docs/surrealdb/context-hybrid-retrieval-strategy-v1.md
+++ b/docs/surrealdb/context-hybrid-retrieval-strategy-v1.md
@@ -22,6 +22,28 @@ The hybrid retrieval strategy enables agents to query the Context Intelligence k
 - No trading/risk/execution/strategy change
 - Vector search is optional (not required for baseline)
 
+## #3487 hybrid follow-up status
+
+Issue #3487 builds on #3484 and #3486 as a repo-only follow-up:
+
+- #3484 provides the graph anchor and traversal semantics
+- #3486 provides the vector / embedding anchor and proof boundary
+- #3487 connects BM25, Vector, and Graph as contract / fixture / ranking semantics
+
+The current repo-only status of `context.search` must stay explicit:
+
+- `operational` — the MCP tool surface exists and dispatches read-only search behavior
+- `contract-only` — hybrid retrieval semantics are documented but not promoted to DB-backed runtime truth
+- `gap` — any missing fusion, explanation, or path-hint surface must stay visible
+
+For #3487, any required hybrid vector input that is unavailable must be treated
+`fail-closed`, not silently downgraded into a success-shaped hybrid result.
+
+Relevant repo-only implementation surfaces:
+
+- `tools/mcp/context_bridge.py`
+- `tools/surrealdb/hybrid_retrieval_ranking.py`
+
 ---
 
 ## Retrieval Modes

--- a/infrastructure/surrealdb/hybrid_retrieval_fixtures.surql
+++ b/infrastructure/surrealdb/hybrid_retrieval_fixtures.surql
@@ -83,8 +83,8 @@ ORDER BY vector_score DESC;
 
 -- -----------------------------------------------------------------------
 -- Hybrid Retrieval Contract: RRF (Reciprocal Rank Fusion)
--- Fuses BM25 full-text results with vector similarity results.
--- SurrealQL syntax: search::rrf([$list1, $list2], $limit, $k)
+-- Fuses BM25 full-text, vector similarity, and graph proximity results.
+-- SurrealQL syntax: search::rrf([$list1, $list2, $list3], $limit, $k)
 --
 -- RRF formula: rrf_score = Sum 1 / (k + rank_in_list)
 -- k = 60 (standard default per Cormack et al. 2009)
@@ -98,6 +98,7 @@ ORDER BY vector_score DESC;
 
 LET $hybrid_limit = 10;
 LET $rrf_k = 60;
+LET $graph_seed_chunk = doc_chunk:⟨seed-hybrid-chunk⟩;
 
 LET $vs = SELECT
     id,
@@ -116,7 +117,15 @@ WHERE content @1@ $bm25_keyword
 ORDER BY bm25_score DESC
 LIMIT $hybrid_limit;
 
-SELECT * FROM search::rrf([$vs, $ft], $hybrid_limit, $rrf_k);
+-- Graph proximity sub-query: start from a seed chunk, walk
+-- ->chunk_mentions_symbol->code_symbol and back to related chunks.
+LET $graph = SELECT
+    ->chunk_mentions_symbol->code_symbol<-chunk_mentions_symbol<-doc_chunk.id AS id,
+    ->chunk_mentions_symbol->code_symbol<-chunk_mentions_symbol<-doc_chunk.chunk_id AS chunk_id,
+    ->chunk_mentions_symbol->code_symbol<-chunk_mentions_symbol<-doc_chunk.content_hash AS content_hash
+FROM ONLY $graph_seed_chunk;
+
+SELECT * FROM search::rrf([$vs, $ft, $graph], $hybrid_limit, $rrf_k);
 
 -- -----------------------------------------------------------------------
 -- Hybrid Retrieval Contract: Linear Fusion (alternative)
@@ -135,10 +144,14 @@ SELECT * FROM search::linear([$vs, $ft], [1, 1], $hybrid_limit, 'minmax');
 --   content_hash:  SHA256 of chunk content
 --   bm25_score:    BM25 relevance score (if from full-text list)
 --   vector_distance / vector_score: vector similarity (if from vector list)
+--   graph path seed: graph-nearby chunk set from the traversal list
 --   source fields: first non-null from list order
 --
 -- Note: Embedding vectors are query parameters only.
 -- No embedding generation, storage, or runtime is defined here.
 -- The existing Python hybrid ranking (hybrid_retrieval_ranking.py) is
 -- a parallel reference and is NOT replaced by this contract.
+-- If vector input is required but unavailable, the hybrid contract remains
+-- fail-closed and must not pretend that BM25 + Graph alone satisfied the
+-- required hybrid vector path.
 -- =======================================================================

--- a/knowledge/decisions/CDB_CONTEXT_BRAIN_SENSORY_LAYER.md
+++ b/knowledge/decisions/CDB_CONTEXT_BRAIN_SENSORY_LAYER.md
@@ -130,6 +130,21 @@ These anchors stay repo-only and non-authorizing. They do not prove DB-backed ve
 state, do not authorize productive embeddings, and do not collapse #3484, #3486, and
 #3487 into one slice.
 
+## Hybrid retrieval follow-up discoverability (#3487)
+
+The #3487 hybrid retrieval follow-up starts from the graph anchor in #3484 and the
+vector / embedding anchor in #3486, then adds repo-only sensory-fusion semantics for
+BM25 + Vector + Graph.
+
+- Hybrid retrieval canon: `docs/surrealdb/context-hybrid-retrieval-strategy-v1.md`
+- Hybrid query fixtures: `infrastructure/surrealdb/hybrid_retrieval_fixtures.surql`
+- Python ranking semantics: `tools/surrealdb/hybrid_retrieval_ranking.py`
+- MCP status surface: `context.search`
+
+These anchors are contract / fixture / ranking semantics only. They do not authorize
+productive DB execution, do not create DB-backed evidence without Tool/Query/Record
+proof, and do not upgrade repo text into runtime truth.
+
 ## References
 
 - [CDB_CONTEXT_BRAIN_DEFAULT_POSTURE.md](CDB_CONTEXT_BRAIN_DEFAULT_POSTURE.md)
@@ -137,6 +152,8 @@ state, do not authorize productive embeddings, and do not collapse #3484, #3486,
 - [docs/onboarding/repo_brain_context_intelligence.md](../../docs/onboarding/repo_brain_context_intelligence.md)
 - [docs/surrealdb/context-relationship-vocabulary-v0.md](../../docs/surrealdb/context-relationship-vocabulary-v0.md)
 - [docs/surrealdb/context-embedding-pipeline-v0.md](../../docs/surrealdb/context-embedding-pipeline-v0.md)
+- [docs/surrealdb/context-hybrid-retrieval-strategy-v1.md](../../docs/surrealdb/context-hybrid-retrieval-strategy-v1.md)
 - [infrastructure/surrealdb/traversal_query_fixtures.surql](../../infrastructure/surrealdb/traversal_query_fixtures.surql)
 - [infrastructure/surrealdb/hybrid_retrieval_fixtures.surql](../../infrastructure/surrealdb/hybrid_retrieval_fixtures.surql)
+- [tools/surrealdb/hybrid_retrieval_ranking.py](../../tools/surrealdb/hybrid_retrieval_ranking.py)
 - [tools/surrealdb/graph_vector_proof_cli.py](../../tools/surrealdb/graph_vector_proof_cli.py)

--- a/tests/unit/agents/test_context_brain_hybrid_followup_contract.py
+++ b/tests/unit/agents/test_context_brain_hybrid_followup_contract.py
@@ -1,0 +1,59 @@
+"""RED discovery anchors for #3487 hybrid retrieval follow-up."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HYBRID_STRATEGY_DOC = "docs/surrealdb/context-hybrid-retrieval-strategy-v1.md"
+
+HYBRID_DISCOVERY_ANCHORS: dict[str, tuple[str, ...]] = {
+    "knowledge/decisions/CDB_CONTEXT_BRAIN_SENSORY_LAYER.md": (
+        "#3484",
+        "#3486",
+        "#3487",
+        HYBRID_STRATEGY_DOC,
+        "infrastructure/surrealdb/hybrid_retrieval_fixtures.surql",
+        "tools/surrealdb/hybrid_retrieval_ranking.py",
+        "context.search",
+    ),
+    "docs/onboarding/repo_brain_context_intelligence.md": (
+        "CDB_CONTEXT_BRAIN_SENSORY_LAYER.md",
+        HYBRID_STRATEGY_DOC,
+        "infrastructure/surrealdb/hybrid_retrieval_fixtures.surql",
+        "tools/surrealdb/hybrid_retrieval_ranking.py",
+        "context.search",
+    ),
+    HYBRID_STRATEGY_DOC: (
+        "#3484",
+        "#3486",
+        "#3487",
+        "context.search",
+        "operational",
+        "contract-only",
+        "gap",
+        "fail-closed",
+        "tools/mcp/context_bridge.py",
+        "tools/surrealdb/hybrid_retrieval_ranking.py",
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "relative_path,needles", list(HYBRID_DISCOVERY_ANCHORS.items())
+)
+def test_3487_hybrid_followup_is_canonically_discoverable(
+    relative_path: str, needles: tuple[str, ...]
+) -> None:
+    """#3487 should expose hybrid retrieval anchors before implementation exists."""
+
+    path = REPO_ROOT / relative_path
+    assert path.is_file(), f"missing canonical file: {relative_path}"
+    text = path.read_text(encoding="utf-8")
+
+    for needle in needles:
+        assert needle in text, f"{relative_path} missing #3487 hybrid anchor: {needle!r}"

--- a/tests/unit/surrealdb/test_hybrid_retrieval_followup_red_3487.py
+++ b/tests/unit/surrealdb/test_hybrid_retrieval_followup_red_3487.py
@@ -1,0 +1,53 @@
+"""RED machine-readable follow-up checks for #3487 hybrid retrieval."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.surrealdb.hybrid_retrieval_ranking import compute_ranking_explanation
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_PATH = REPO_ROOT / "infrastructure/surrealdb/hybrid_retrieval_fixtures.surql"
+
+
+def test_3487_hybrid_fixture_fuses_graph_vector_and_fulltext() -> None:
+    """#3487 requires graph input in addition to BM25 and vector fixtures."""
+
+    text = FIXTURE_PATH.read_text(encoding="utf-8")
+
+    assert "LET $graph =" in text
+    assert "->chunk_mentions_symbol->code_symbol" in text
+    assert "search::rrf([$vs, $ft, $graph], $hybrid_limit, $rrf_k);" in text
+
+
+def test_3487_hybrid_ranking_fails_closed_when_vector_is_required_but_missing() -> None:
+    """#3487 requires an explicit fail-closed contract when vector evidence is absent."""
+
+    explanation = compute_ranking_explanation(
+        {
+            "result_id": "bm25-only",
+            "source_ref": "doc_chunk:bm25-only",
+            "confidence": 0.92,
+            "freshness": 0.91,
+            "source_match": 0.88,
+            "graph_distance": 1,
+            "evidence_strength": "strong",
+            "scope_match": 0.77,
+            "memory_trust": 0.70,
+            "retrieval_mode": "full_text",
+        },
+        query_context={
+            "issue_ref": "#3487",
+            "hybrid_mode": "surrealql_rrf",
+            "vector_required": True,
+            "vector_available": False,
+            "context_search_status": "contract-only",
+        },
+    )
+
+    assert "hybrid_gap:vector_required_but_missing" in explanation["warnings"]
+    assert "context.search_status:contract-only" in explanation["caveats"]

--- a/tests/unit/tools/mcp/test_context_briefing_hybrid_followup_red_3487.py
+++ b/tests/unit/tools/mcp/test_context_briefing_hybrid_followup_red_3487.py
@@ -1,0 +1,94 @@
+"""RED briefing contract checks for #3487 hybrid retrieval follow-up."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.mcp.context_bridge import context_briefing_handler
+
+pytestmark = pytest.mark.unit
+
+
+def test_3487_briefing_exposes_hybrid_followup_paths_without_authorizing_db_truth() -> None:
+    """#3487 should surface hybrid path hints while staying repo-only and non-authorizing."""
+
+    result = context_briefing_handler(
+        task_id="cdb-briefing-3487-hybrid-retrieval",
+        task_scope="Build RED_ONLY tests for #3487 hybrid retrieval sensory fusion.",
+        target_issue="#3487",
+        target_paths=[
+            "docs/surrealdb/context-hybrid-retrieval-strategy-v1.md",
+            "docs/surrealdb/context-relationship-vocabulary-v0.md",
+            "docs/surrealdb/context-embedding-pipeline-v0.md",
+            "infrastructure/surrealdb/hybrid_retrieval_fixtures.surql",
+        ],
+        requested_depth="standard",
+        operation_mode="read_only",
+        working_assumptions=[
+            "#3484 graph semantics and #3486 vector pipeline are existing foundations.",
+            "This slice remains repo-only and must not claim DB-backed hybrid truth.",
+        ],
+        limitations=[
+            "No DB-backed claim without Tool/Query/Record evidence.",
+            "No productive vector search, graph traversal, or hybrid ranking against a DB.",
+            "No LR, live, or Echtgeld implication.",
+        ],
+    )
+
+    assert result["status"] == "ok"
+    briefing = result["briefing"]
+
+    assert briefing["approval_semantics"]["no_echtgeld_go"] is True
+    assert briefing["session_context"]["brain_source"] == "repo-only"
+    assert briefing["session_context"]["brain_status"] == "not-used"
+
+    graph_paths = briefing["graph_paths"]
+    assert any(
+        path["path_id"] == "issue-3487-hybrid-strategy"
+        and path["nodes"]
+        == [
+            "knowledge/decisions/CDB_CONTEXT_BRAIN_SENSORY_LAYER.md",
+            "docs/surrealdb/context-hybrid-retrieval-strategy-v1.md",
+        ]
+        and path["relationships"] == ["canonically_discovers"]
+        and path["source"] == "repo_only"
+        and path["authorizes"] is False
+        for path in graph_paths
+    )
+    assert any(
+        path["path_id"] == "issue-3487-foundation-chain"
+        and path["nodes"]
+        == [
+            "docs/surrealdb/context-relationship-vocabulary-v0.md",
+            "docs/surrealdb/context-embedding-pipeline-v0.md",
+            "infrastructure/surrealdb/hybrid_retrieval_fixtures.surql",
+        ]
+        and path["relationships"]
+        == ["builds_on_graph_anchor", "builds_on_vector_anchor"]
+        and path["source"] == "repo_only"
+        and path["authorizes"] is False
+        for path in graph_paths
+    )
+    assert any(
+        path["path_id"] == "issue-3487-ranking-split"
+        and path["nodes"]
+        == [
+            "docs/surrealdb/context-hybrid-retrieval-strategy-v1.md",
+            "tools/surrealdb/hybrid_retrieval_ranking.py",
+            "infrastructure/surrealdb/hybrid_retrieval_fixtures.surql",
+        ]
+        and path["relationships"]
+        == ["python_ranking_parallel_to_surrealql_rrf", "verifies_query_contract"]
+        and path["source"] == "repo_only"
+        and path["authorizes"] is False
+        for path in graph_paths
+    )
+    assert any(
+        path["path_id"] == "issue-3487-context-search-status"
+        and path["nodes"] == ["context.search", "tools/mcp/context_bridge.py", "#3487"]
+        and path["relationships"]
+        == ["status_must_be_classified", "fail_closed_if_vector_missing"]
+        and path["source"] == "repo_only"
+        and path["authorizes"] is False
+        for path in graph_paths
+    )

--- a/tools/mcp/context_bridge.py
+++ b/tools/mcp/context_bridge.py
@@ -2544,6 +2544,76 @@ def _derive_briefing_graph_paths(
             ]
         )
 
+    if target_issue == "#3487":
+        graph_paths.extend(
+            [
+                {
+                    "path_id": "issue-3487-hybrid-strategy",
+                    "nodes": [
+                        "knowledge/decisions/CDB_CONTEXT_BRAIN_SENSORY_LAYER.md",
+                        "docs/surrealdb/context-hybrid-retrieval-strategy-v1.md",
+                    ],
+                    "relationships": ["canonically_discovers"],
+                    "source": "repo_only",
+                    "authorizes": False,
+                    "non_authorizing": True,
+                    "no_db_write": True,
+                    "no_runtime_rebuild": True,
+                    "no_lr_go": True,
+                },
+                {
+                    "path_id": "issue-3487-foundation-chain",
+                    "nodes": [
+                        "docs/surrealdb/context-relationship-vocabulary-v0.md",
+                        "docs/surrealdb/context-embedding-pipeline-v0.md",
+                        "infrastructure/surrealdb/hybrid_retrieval_fixtures.surql",
+                    ],
+                    "relationships": [
+                        "builds_on_graph_anchor",
+                        "builds_on_vector_anchor",
+                    ],
+                    "source": "repo_only",
+                    "authorizes": False,
+                    "non_authorizing": True,
+                    "no_db_write": True,
+                    "no_runtime_rebuild": True,
+                    "no_lr_go": True,
+                },
+                {
+                    "path_id": "issue-3487-ranking-split",
+                    "nodes": [
+                        "docs/surrealdb/context-hybrid-retrieval-strategy-v1.md",
+                        "tools/surrealdb/hybrid_retrieval_ranking.py",
+                        "infrastructure/surrealdb/hybrid_retrieval_fixtures.surql",
+                    ],
+                    "relationships": [
+                        "python_ranking_parallel_to_surrealql_rrf",
+                        "verifies_query_contract",
+                    ],
+                    "source": "repo_only",
+                    "authorizes": False,
+                    "non_authorizing": True,
+                    "no_db_write": True,
+                    "no_runtime_rebuild": True,
+                    "no_lr_go": True,
+                },
+                {
+                    "path_id": "issue-3487-context-search-status",
+                    "nodes": ["context.search", "tools/mcp/context_bridge.py", "#3487"],
+                    "relationships": [
+                        "status_must_be_classified",
+                        "fail_closed_if_vector_missing",
+                    ],
+                    "source": "repo_only",
+                    "authorizes": False,
+                    "non_authorizing": True,
+                    "no_db_write": True,
+                    "no_runtime_rebuild": True,
+                    "no_lr_go": True,
+                },
+            ]
+        )
+
     return graph_paths
 
 

--- a/tools/surrealdb/hybrid_retrieval_ranking.py
+++ b/tools/surrealdb/hybrid_retrieval_ranking.py
@@ -234,6 +234,7 @@ def _resolve_factor_scores(
     candidate: Mapping[str, Any],
     *,
     reference: datetime | None = None,
+    query_context: Mapping[str, Any] | None = None,
 ) -> tuple[dict[str, float], list[str], list[str]]:
     """Extract normalized factor scores, warnings, and caveats for one candidate."""
     warnings: list[str] = list(candidate.get("warnings") or [])
@@ -350,6 +351,18 @@ def _resolve_factor_scores(
             "vector_score present but optional_vector_search is deferred in ranking v1"
         )
 
+    vector_required = _as_bool((query_context or {}).get("vector_required"))
+    vector_available = _as_bool((query_context or {}).get("vector_available"))
+    if vector_required and not vector_available:
+        warnings.append("hybrid_gap:vector_required_but_missing")
+        caveats.append(
+            "Hybrid retrieval remains fail-closed when required vector input is unavailable."
+        )
+
+    context_search_status = _as_str((query_context or {}).get("context_search_status"))
+    if context_search_status is not None:
+        caveats.append(f"context.search_status:{context_search_status}")
+
     return scores, sorted(set(warnings)), caveats
 
 
@@ -399,7 +412,7 @@ def compute_ranking_explanation(
     resolved_weights = _coalesce_weights(weights)
     reference = _resolve_reference_time(candidate, query_context)
     factor_scores, warnings, caveats = _resolve_factor_scores(
-        candidate, reference=reference
+        candidate, reference=reference, query_context=query_context
     )
 
     contributions: dict[str, float] = {


### PR DESCRIPTION
Refs #3479
Refs #3480
Refs #3484
Refs #3486
Closes #3487

## RED -> GREEN Summary
- Converts the #3544 RED_ONLY gates into the repo-only #3487 hybrid retrieval contract.
- Keeps #3484 graph and #3486 vector foundations separate, then wires their hybrid follow-up semantics on top.
- Stays inside SurrealDB / Context Brain scope with no productive DB, MCP, runtime, BLUE, or RED mutation.

## Implemented Hybrid Retrieval Contract
- Added #3487 repo-only hybrid anchors to `knowledge/decisions/CDB_CONTEXT_BRAIN_SENSORY_LAYER.md`.
- Added matching onboarding discoverability anchors to `docs/onboarding/repo_brain_context_intelligence.md`.
- Extended `docs/surrealdb/context-hybrid-retrieval-strategy-v1.md` with explicit #3484 / #3486 / #3487 follow-up framing, `context.search` status classification (`operational`, `contract-only`, `gap`), and fail-closed wording.
- Expanded `infrastructure/surrealdb/hybrid_retrieval_fixtures.surql` to cover BM25 + Vector + Graph with a 3-way RRF contract.

## Context Briefing Hybrid Paths
- `tools/mcp/context_bridge.py` now exposes repo-only `graph_paths` for #3487:
  - `issue-3487-hybrid-strategy`
  - `issue-3487-foundation-chain`
  - `issue-3487-ranking-split`
  - `issue-3487-context-search-status`
- Paths remain non-authorizing and explicitly avoid DB-backed claims.

## Ranking Fail-Closed Boundary
- `tools/surrealdb/hybrid_retrieval_ranking.py` now marks `hybrid_gap:vector_required_but_missing` when hybrid ranking requires vector input but none is available.
- Ranking explanations also surface `context.search_status:<status>` caveats so repo-only contract state stays visible.

## Brain Evidence
```text
brain_source: repo-only
brain_status: not-used
tools_or_queries:
  - context.required_reads(task_scope=#3487 implementation)
  - context.readiness(task_scope=#3487 implementation)
  - context.search(query="3487 hybrid retrieval sensory fusion surrealdb context brain")
  - git fetch origin --prune
  - git status -sb
  - git branch --show-current
  - git rev-parse HEAD
  - git rev-parse origin/main
  - git worktree list
  - gh pr view 3544
  - gh issue view 3479/3480/3484/3486/3487
records_or_results:
  - context.required_reads resolved canon/control/surrealdb surfaces
  - context.readiness => ready_for_human_go with repo-backed fallback guardrails
  - context.search => 0 hits
  - GitHub live: #3479 OPEN, #3480 OPEN, #3484 CLOSED, #3486 CLOSED, #3487 OPEN, PR #3544 OPEN/DRAFT/MERGEABLE before green push
repo_crosscheck:
  - knowledge/decisions/CDB_CONTEXT_BRAIN_SENSORY_LAYER.md
  - docs/onboarding/repo_brain_context_intelligence.md
  - docs/surrealdb/context-hybrid-retrieval-strategy-v1.md
  - infrastructure/surrealdb/hybrid_retrieval_fixtures.surql
  - tools/mcp/context_bridge.py
  - tools/surrealdb/hybrid_retrieval_ranking.py
impact_on_plan:
  - Implemented only the repo-only #3487 contract surfaces required by the RED tests.
  - Preserved the #3484 graph and #3486 vector gates while adding hybrid follow-up semantics on top.
limitations:
  - No DB-backed context records were available from context.search.
  - No productive SurrealDB query, vector search, graph traversal, or MCP write was executed.
context_brain_attempted: true
context_brain_used: false
context_available: false
repo_fallback_used: true
repo_fallback_reason: insufficient_evidence
context_tool_status: available
context_trust_level: none
records_found: none
```

## Safety Boundaries
- Repo files document discoverability and contract only; they do not assert runtime truth.
- SurrealQL fixtures remain fixtures and are not executed productively.
- No SurrealDB write, no MCP write, no LR-Go, no Live-Go, no Echtgeld-Go.

## Validation
- `pytest -q tests/unit/agents/test_context_brain_hybrid_followup_contract.py tests/unit/tools/mcp/test_context_briefing_hybrid_followup_red_3487.py tests/unit/surrealdb/test_hybrid_retrieval_followup_red_3487.py`
- `pytest -q tests/unit/tools/mcp/test_context_briefing_graph_followup.py`
- `pytest -q tests/unit/agents/test_context_brain_vector_followup_contract.py tests/unit/tools/mcp/test_context_briefing_vector_followup_red_3486.py tests/unit/surrealdb/test_graph_vector_proof_red_3486.py`
- `pytest -q tests/unit/tools/mcp/test_context_bridge.py`
- `ruff check tests/unit/agents/test_context_brain_hybrid_followup_contract.py tests/unit/tools/mcp/test_context_briefing_hybrid_followup_red_3487.py tests/unit/surrealdb/test_hybrid_retrieval_followup_red_3487.py tools/mcp/context_bridge.py tools/surrealdb/hybrid_retrieval_ranking.py`
- `git diff --check`

## Remaining Scope
- #3480 remains open as the parent sensory-layer anchor.
- #3479 remains open as the broader epic / roadmap anchor.