### PR TITLE
docs(skills): define canonical skill surface registry

### DIFF
--- a/.claude/skills/cdb-github-api-ops.skill
+++ b/.claude/skills/cdb-github-api-ops.skill
@@ -1,0 +1,9 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-github-api-ops/SKILL.md
+Surface: claude (index)
+Sync Status: mirrored
+Last Verified: 2026-06-30
+-->
+[cdb-github-api-ops]
+name = cdb-github-api-ops
+path = cdb-github-api-ops/SKILL.md

--- a/.claude/skills/cdb-github-api-ops/SKILL.md
+++ b/.claude/skills/cdb-github-api-ops/SKILL.md
@@ -1,0 +1,275 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-github-api-ops/SKILL.md
+Surface: claude
+Sync Status: mirrored
+Last Verified: 2026-06-30
+Drift Policy: Surface darf nur abweichen, wenn Begruendung in docs/skills/cdb-github-api-ops/SKILL.md dokumentiert ist.
+-->
+
+---
+name: cdb-github-api-ops
+description: >
+  GitHub API-aware agent routing for CDB. Teaches agents when to use GitHub
+  API calls, which data to pull, which permissions matter, and when to stop.
+  Covers Status Snapshot, API Opportunity Scan, CI/Checks Readout, PR Queue
+  Radar, Issue Dedupe, ProjectV2 Reconciliation, Rate-Limit Awareness, and
+  Permission Safety. Read-only by default; writes require separate approved
+  scope. Does not replace gh-fix-ci or gh-address-comments but complements
+  them with upstream API awareness.
+disable-model-invocation: true
+---
+
+# CDB GitHub API Ops
+
+Route GitHub API usage intelligently. Read broadly, write narrowly.
+
+## Use this skill when
+
+- the agent touches PRs, issues, CI checks, or ProjectV2 and needs live
+  GitHub data beyond what `git` alone provides
+- the agent should check whether a GitHub API call is the right approach
+  before firing `gh api` blindly
+- the agent needs a Status Snapshot of the repo, PR queue, or CI state
+- the agent encounters repetitive manual GitHub actions that could be API calls
+- the agent sees red checks and wants to understand the API-level picture
+  before delegating to `gh-fix-ci`
+- the agent considers creating an issue and should deduplicate first
+- the agent works on Modusmono/CDB portfolio and needs multi-repo visibility
+- ProjectV2 fields are relevant and `read:project` may be missing
+- a write operation seems necessary and the agent must verify scope first
+
+## Do NOT use this skill when
+
+- CI is already failing and the task is purely fixing code (use `gh-fix-ci`)
+- PR review comments need triage or replies (use `gh-address-comments`)
+- the task is local git work with no GitHub interaction needed
+- the task is repo settings, branch protection, or admin changes (separate
+  scope, never automatic)
+
+## Inputs
+
+- Authenticated `gh` CLI
+- Target repo (default: current repo)
+- Optional: issue/PR numbers, branch names, ProjectV2 board IDs
+
+## Workflow
+
+### 1. Auth profile check
+
+Before any API call, verify what the current auth profile can do:
+
+```bash
+gh auth status
+```
+
+Determine:
+
+| Signal | Meaning |
+|--------|---------|
+| `repo` scope present | Issues, PRs, contents, actions readable |
+| `read:org` scope present | Org membership readable |
+| `workflow` scope present | Workflow runs readable |
+| `read:project` scope missing | ProjectV2 NOT visible — known gap |
+| fine-grained PAT in use | Checks API may be blocked; see limits below |
+
+Record the auth profile in any output:
+
+```text
+auth_profile: gh-session | fine-grained-pat | classic-pat | github-app
+evidence_sources: [list what was actually readable]
+partial_visibility: [list what was blocked or incomplete]
+```
+
+### 2. Route to the right sub-operation
+
+| Situation | Sub-operation | Primary API | Notes |
+|-----------|---------------|-------------|-------|
+| Need full repo status picture | Status Snapshot | GraphQL (issues, PRs, reviews, statusCheckRollup) + REST (Actions runs/jobs, commit statuses) | See `docs/github/UNIFIED_GITHUB_STATUS_SNAPSHOT.md` |
+| Red checks on a PR | CI/Checks Readout | REST Actions runs/jobs + Checks | Delegate fix to `gh-fix-ci` after readout |
+| Open PRs need triage view | PR Queue Radar | GraphQL (PRs + reviews + mergeState) | Complement `gh pr list` with deeper fields |
+| About to create an issue | Issue Dedupe | REST search: `GET /search/issues?q=repo:...+<keywords>` | Always search before opening |
+| Repetitive manual GitHub clicks | API Opportunity Scan | N/A (diagnostic) | Propose API automation, do not implement |
+| Multi-repo portfolio view | Multi-Repo Snapshot | GraphQL per repo or `gh api` loop | Same snapshot logic, multiple repos |
+| ProjectV2 fields needed | ProjectV2 Reconciliation | GraphQL ProjectV2 items | Requires `read:project`; mark as gap if missing |
+| Rate limit approaching | Rate-Limit Awareness | REST `/rate_limit` | Check before batch operations |
+| Write seems necessary | Permission Safety | N/A (gate check) | STOP — see write rules below |
+
+### 3. Execute the read
+
+Use `gh api` as the CLI-MVP carrier:
+
+**GraphQL example (Status Snapshot):**
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "jannekbuengener", name: "Claire_de_Binare") {
+    pullRequests(states: [OPEN], first: 10, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes {
+        number title reviewDecision mergeStateStatus
+        statusCheckRollup { nodes { state description } }
+      }
+    }
+  }
+}
+'
+```
+
+**REST example (Actions runs):**
+
+```bash
+gh api repos/jannekbuengener/Claire_de_Binare/actions/runs --jq '.workflow_runs[] | {id, name, status, conclusion, created_at}'
+```
+
+**Search example (Issue Dedupe):**
+
+```bash
+gh api "search/issues?q=repo:jannekbuengener/Claire_de_Binare+<keywords>" --jq '.items[] | {number, title, state}'
+```
+
+**Rate limit check:**
+
+```bash
+gh api rate_limit --jq '.resources | to_entries[] | {name: .key, remaining: .value.remaining, limit: .value.limit, reset: .value.reset}'
+```
+
+### 4. Handle partial visibility honestly
+
+If an API call fails due to missing scope or permissions:
+
+- Record exactly what failed and why
+- Do NOT silently skip the missing data
+- Do NOT treat the partial result as complete
+- Output must include `partial_visibility` and `collection_errors`
+
+### 5. Write gate
+
+| Intent | Rule |
+|--------|------|
+| Read any GitHub data | Automatically OK when scope touches GitHub live state |
+| Comment on issue/PR | Only if Plan-GO explicitly allows it |
+| Create issue/PR | Only if Plan-GO explicitly allows it |
+| Label/milestone changes | Only if Plan-GO explicitly allows it |
+| Merge/rebase/push | Separate scope, never automatic |
+| Repo settings/admin | Separate scope, never automatic |
+| Branch protection changes | Separate scope, never automatic |
+
+When a write seems necessary but no approved scope exists:
+
+1. STOP.
+2. Report what needs writing and why.
+3. Propose the write as a follow-up with explicit Human-GO.
+4. Do NOT execute the write.
+
+## Hard rules
+
+### Read-first posture
+
+- GitHub live data is truth. Prefer API reads over assumptions or cached
+  memory.
+- Always record auth profile, evidence sources, and partial visibility in
+  output.
+- Never treat a partial result as complete.
+
+### Permission safety
+
+- Broad read, narrow write. Snapshot MVP is strictly read-only.
+- Fine-grained PAT has known gaps: cannot call Checks API, cannot access
+  user-owned Projects per GitHub docs.
+- Classic PAT has `repo` scope but no `read:project` — ProjectV2 remains
+  invisible without it.
+- GitHub App is the target architecture for stable broad read access but
+  is not yet implemented.
+- Never present fine-grained PAT as a universal solution for the full
+  snapshot surface.
+
+### ProjectV2 visibility
+
+- `read:project` scope is required to read ProjectV2 items via GraphQL.
+- If `read:project` is missing, mark ProjectV2 as a known visibility gap.
+- Do NOT infer ProjectV2 field values from other data sources.
+
+### Rate limit discipline
+
+- Primary: 5,000 requests/hour (authenticated REST).
+- GraphQL: 5,000 points/hour (single-node query = 1 point).
+- Check `/rate_limit` before batch operations.
+- Prefer GraphQL for connected data (issues, PRs, reviews, checks) to
+  reduce request count.
+- Use REST for Actions runs/jobs/logs, labels, commit statuses, contents.
+
+### Fail-closed on auth ambiguity
+
+- If auth scope is unclear, test with a minimal read before assuming access.
+- If a read returns 403/404, record it as a visibility gap, not as "nothing
+  there."
+- Do NOT retry with elevated privileges or different tokens automatically.
+
+## API surface reference
+
+| Sub-operation | Preferred API | Key permission | Known gap |
+|---------------|---------------|---------------|-----------|
+| Status Snapshot | GraphQL + REST | `repo`, `read:project` | ProjectV2 without `read:project` |
+| CI/Checks Readout | REST (Actions, Checks) | `repo` | Fine-grained PAT: no Checks |
+| PR Queue Radar | GraphQL | `repo` | — |
+| Issue Dedupe | REST Search | `repo` | — |
+| API Opportunity Scan | N/A (diagnostic) | — | — |
+| Multi-Repo Snapshot | GraphQL + REST per repo | `repo` per repo | Same per-repo auth gaps |
+| ProjectV2 Reconciliation | GraphQL ProjectV2 | `read:project` | Missing scope = invisible |
+| Rate-Limit Awareness | REST `/rate_limit` | none | — |
+| Permission Safety | N/A (gate) | — | — |
+
+## Official GitHub docs evidence
+
+- REST overview: https://docs.github.com/en/rest/about-the-rest-api/about-the-rest-api
+- GraphQL overview: https://docs.github.com/en/graphql
+- `gh api` manual: https://cli.github.com/manual/gh_api
+- REST rate limits: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+- `GITHUB_TOKEN` permissions: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
+- PAT creation/limits: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+- GitHub App permissions: https://docs.github.com/en/apps/creating-github-apps/setting-up-a-github-app/choosing-permissions-for-a-github-app
+- Fine-grained PAT permissions matrix: https://docs.github.com/en/rest/overview/permissions-required-for-fine-grained-personal-access-tokens
+- Issues REST: https://docs.github.com/en/rest/issues/issues
+- Pull Requests REST: https://docs.github.com/en/rest/pulls/pulls
+- PR Reviews REST: https://docs.github.com/en/rest/pulls/reviews
+- Labels REST: https://docs.github.com/en/rest/issues/labels
+- Commit Statuses REST: https://docs.github.com/en/rest/commits/statuses
+- Contents REST: https://docs.github.com/en/rest/repos/contents
+- Actions workflow runs REST: https://docs.github.com/en/rest/actions/workflow-runs
+- Checks REST: https://docs.github.com/en/rest/checks
+
+## Relationship to existing skills
+
+- `gh-fix-ci`: handles CI fix implementation after this skill identifies
+  the failure picture
+- `gh-address-comments`: handles PR review comment triage after this skill
+  identifies the PR landscape
+- `cdb-ci-cd-guard`: governs CI/CD ruleset compliance; this skill provides
+  the live API data that `cdb-ci-cd-guard` may need
+- `cdb-control-intake`: reads control context; this skill reads live GitHub
+  data as a complementary source
+- `cdb-session-start`: may invoke this skill when session scope touches
+  GitHub live data
+- `docs/github/UNIFIED_GITHUB_STATUS_SNAPSHOT.md`: the detailed reference
+  document for the Status Snapshot sub-operation
+
+## Follow-up issues (proposed, not created)
+
+- `[GITHUB-API][MVP] Build read-only Unified GitHub Status Snapshot CLI`
+- `[GITHUB-API][GRAPHQL] Add reusable ProjectV2/statusCheckRollup query bundle`
+- `[GITHUB-API][AGENTS] Add API Opportunity Scan to CDB/Modusmono agent prompts`
+- `[GITHUB-API][APP] Evaluate GitHub App target architecture`
+
+## Anti-patterns
+
+- Do NOT fire `gh api` calls without checking auth scope first
+- Do NOT treat partial GitHub data as complete truth
+- Do NOT write to GitHub without explicit Plan-GO
+- Do NOT present fine-grained PAT as a universal auth solution
+- Do NOT infer ProjectV2 data when `read:project` is missing
+- Do NOT batch API calls without checking rate limits first
+- Do NOT retry 403 with different credentials automatically
+- Do NOT replace `gh-fix-ci` or `gh-address-comments` with this skill
+- Do NOT read or expose tokens, secrets, or private keys in any output
+- Do NOT create issues, PRs, or comments without Human-GO
+- Do NOT treat Board stage or `trade-capable` as Live-Go; LR remains NO-GO

--- a/.codex/cdb_skills/README.md
+++ b/.codex/cdb_skills/README.md
@@ -45,6 +45,13 @@ Spiegelt die Cursor-Skill-Oberfläche unter [`.cursor/skills/README.md`](../../.
 |---|---|
 | [`gh-fix-ci`](gh-fix-ci/SKILL.md) | CI failures |
 | [`gh-address-comments`](gh-address-comments/SKILL.md) | PR review comments |
+| [`cdb-github-api-ops`](cdb-github-api-ops/SKILL.md) | GitHub API-aware agent routing |
+
+## Canonical skill source
+
+- `docs/skills/` ist die kanonische Skill-Flaeche.
+- Jede Surface-Kopie muss den Pflicht-Header aus Registry Abschnitt 7 tragen.
+- Registry: [`docs/skills/SKILL_SURFACE_REGISTRY.md`](../../docs/skills/SKILL_SURFACE_REGISTRY.md).
 
 ## Related surfaces
 

--- a/.codex/cdb_skills/cdb-github-api-ops/SKILL.md
+++ b/.codex/cdb_skills/cdb-github-api-ops/SKILL.md
@@ -1,0 +1,275 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-github-api-ops/SKILL.md
+Surface: codex
+Sync Status: mirrored
+Last Verified: 2026-06-30
+Drift Policy: Surface darf nur abweichen, wenn Begruendung in docs/skills/cdb-github-api-ops/SKILL.md dokumentiert ist.
+-->
+
+---
+name: cdb-github-api-ops
+description: >
+  GitHub API-aware agent routing for CDB. Teaches agents when to use GitHub
+  API calls, which data to pull, which permissions matter, and when to stop.
+  Covers Status Snapshot, API Opportunity Scan, CI/Checks Readout, PR Queue
+  Radar, Issue Dedupe, ProjectV2 Reconciliation, Rate-Limit Awareness, and
+  Permission Safety. Read-only by default; writes require separate approved
+  scope. Does not replace gh-fix-ci or gh-address-comments but complements
+  them with upstream API awareness.
+disable-model-invocation: true
+---
+
+# CDB GitHub API Ops
+
+Route GitHub API usage intelligently. Read broadly, write narrowly.
+
+## Use this skill when
+
+- the agent touches PRs, issues, CI checks, or ProjectV2 and needs live
+  GitHub data beyond what `git` alone provides
+- the agent should check whether a GitHub API call is the right approach
+  before firing `gh api` blindly
+- the agent needs a Status Snapshot of the repo, PR queue, or CI state
+- the agent encounters repetitive manual GitHub actions that could be API calls
+- the agent sees red checks and wants to understand the API-level picture
+  before delegating to `gh-fix-ci`
+- the agent considers creating an issue and should deduplicate first
+- the agent works on Modusmono/CDB portfolio and needs multi-repo visibility
+- ProjectV2 fields are relevant and `read:project` may be missing
+- a write operation seems necessary and the agent must verify scope first
+
+## Do NOT use this skill when
+
+- CI is already failing and the task is purely fixing code (use `gh-fix-ci`)
+- PR review comments need triage or replies (use `gh-address-comments`)
+- the task is local git work with no GitHub interaction needed
+- the task is repo settings, branch protection, or admin changes (separate
+  scope, never automatic)
+
+## Inputs
+
+- Authenticated `gh` CLI
+- Target repo (default: current repo)
+- Optional: issue/PR numbers, branch names, ProjectV2 board IDs
+
+## Workflow
+
+### 1. Auth profile check
+
+Before any API call, verify what the current auth profile can do:
+
+```bash
+gh auth status
+```
+
+Determine:
+
+| Signal | Meaning |
+|--------|---------|
+| `repo` scope present | Issues, PRs, contents, actions readable |
+| `read:org` scope present | Org membership readable |
+| `workflow` scope present | Workflow runs readable |
+| `read:project` scope missing | ProjectV2 NOT visible — known gap |
+| fine-grained PAT in use | Checks API may be blocked; see limits below |
+
+Record the auth profile in any output:
+
+```text
+auth_profile: gh-session | fine-grained-pat | classic-pat | github-app
+evidence_sources: [list what was actually readable]
+partial_visibility: [list what was blocked or incomplete]
+```
+
+### 2. Route to the right sub-operation
+
+| Situation | Sub-operation | Primary API | Notes |
+|-----------|---------------|-------------|-------|
+| Need full repo status picture | Status Snapshot | GraphQL (issues, PRs, reviews, statusCheckRollup) + REST (Actions runs/jobs, commit statuses) | See `docs/github/UNIFIED_GITHUB_STATUS_SNAPSHOT.md` |
+| Red checks on a PR | CI/Checks Readout | REST Actions runs/jobs + Checks | Delegate fix to `gh-fix-ci` after readout |
+| Open PRs need triage view | PR Queue Radar | GraphQL (PRs + reviews + mergeState) | Complement `gh pr list` with deeper fields |
+| About to create an issue | Issue Dedupe | REST search: `GET /search/issues?q=repo:...+<keywords>` | Always search before opening |
+| Repetitive manual GitHub clicks | API Opportunity Scan | N/A (diagnostic) | Propose API automation, do not implement |
+| Multi-repo portfolio view | Multi-Repo Snapshot | GraphQL per repo or `gh api` loop | Same snapshot logic, multiple repos |
+| ProjectV2 fields needed | ProjectV2 Reconciliation | GraphQL ProjectV2 items | Requires `read:project`; mark as gap if missing |
+| Rate limit approaching | Rate-Limit Awareness | REST `/rate_limit` | Check before batch operations |
+| Write seems necessary | Permission Safety | N/A (gate check) | STOP — see write rules below |
+
+### 3. Execute the read
+
+Use `gh api` as the CLI-MVP carrier:
+
+**GraphQL example (Status Snapshot):**
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "jannekbuengener", name: "Claire_de_Binare") {
+    pullRequests(states: [OPEN], first: 10, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes {
+        number title reviewDecision mergeStateStatus
+        statusCheckRollup { nodes { state description } }
+      }
+    }
+  }
+}
+'
+```
+
+**REST example (Actions runs):**
+
+```bash
+gh api repos/jannekbuengener/Claire_de_Binare/actions/runs --jq '.workflow_runs[] | {id, name, status, conclusion, created_at}'
+```
+
+**Search example (Issue Dedupe):**
+
+```bash
+gh api "search/issues?q=repo:jannekbuengener/Claire_de_Binare+<keywords>" --jq '.items[] | {number, title, state}'
+```
+
+**Rate limit check:**
+
+```bash
+gh api rate_limit --jq '.resources | to_entries[] | {name: .key, remaining: .value.remaining, limit: .value.limit, reset: .value.reset}'
+```
+
+### 4. Handle partial visibility honestly
+
+If an API call fails due to missing scope or permissions:
+
+- Record exactly what failed and why
+- Do NOT silently skip the missing data
+- Do NOT treat the partial result as complete
+- Output must include `partial_visibility` and `collection_errors`
+
+### 5. Write gate
+
+| Intent | Rule |
+|--------|------|
+| Read any GitHub data | Automatically OK when scope touches GitHub live state |
+| Comment on issue/PR | Only if Plan-GO explicitly allows it |
+| Create issue/PR | Only if Plan-GO explicitly allows it |
+| Label/milestone changes | Only if Plan-GO explicitly allows it |
+| Merge/rebase/push | Separate scope, never automatic |
+| Repo settings/admin | Separate scope, never automatic |
+| Branch protection changes | Separate scope, never automatic |
+
+When a write seems necessary but no approved scope exists:
+
+1. STOP.
+2. Report what needs writing and why.
+3. Propose the write as a follow-up with explicit Human-GO.
+4. Do NOT execute the write.
+
+## Hard rules
+
+### Read-first posture
+
+- GitHub live data is truth. Prefer API reads over assumptions or cached
+  memory.
+- Always record auth profile, evidence sources, and partial visibility in
+  output.
+- Never treat a partial result as complete.
+
+### Permission safety
+
+- Broad read, narrow write. Snapshot MVP is strictly read-only.
+- Fine-grained PAT has known gaps: cannot call Checks API, cannot access
+  user-owned Projects per GitHub docs.
+- Classic PAT has `repo` scope but no `read:project` — ProjectV2 remains
+  invisible without it.
+- GitHub App is the target architecture for stable broad read access but
+  is not yet implemented.
+- Never present fine-grained PAT as a universal solution for the full
+  snapshot surface.
+
+### ProjectV2 visibility
+
+- `read:project` scope is required to read ProjectV2 items via GraphQL.
+- If `read:project` is missing, mark ProjectV2 as a known visibility gap.
+- Do NOT infer ProjectV2 field values from other data sources.
+
+### Rate limit discipline
+
+- Primary: 5,000 requests/hour (authenticated REST).
+- GraphQL: 5,000 points/hour (single-node query = 1 point).
+- Check `/rate_limit` before batch operations.
+- Prefer GraphQL for connected data (issues, PRs, reviews, checks) to
+  reduce request count.
+- Use REST for Actions runs/jobs/logs, labels, commit statuses, contents.
+
+### Fail-closed on auth ambiguity
+
+- If auth scope is unclear, test with a minimal read before assuming access.
+- If a read returns 403/404, record it as a visibility gap, not as "nothing
+  there."
+- Do NOT retry with elevated privileges or different tokens automatically.
+
+## API surface reference
+
+| Sub-operation | Preferred API | Key permission | Known gap |
+|---------------|---------------|---------------|-----------|
+| Status Snapshot | GraphQL + REST | `repo`, `read:project` | ProjectV2 without `read:project` |
+| CI/Checks Readout | REST (Actions, Checks) | `repo` | Fine-grained PAT: no Checks |
+| PR Queue Radar | GraphQL | `repo` | — |
+| Issue Dedupe | REST Search | `repo` | — |
+| API Opportunity Scan | N/A (diagnostic) | — | — |
+| Multi-Repo Snapshot | GraphQL + REST per repo | `repo` per repo | Same per-repo auth gaps |
+| ProjectV2 Reconciliation | GraphQL ProjectV2 | `read:project` | Missing scope = invisible |
+| Rate-Limit Awareness | REST `/rate_limit` | none | — |
+| Permission Safety | N/A (gate) | — | — |
+
+## Official GitHub docs evidence
+
+- REST overview: https://docs.github.com/en/rest/about-the-rest-api/about-the-rest-api
+- GraphQL overview: https://docs.github.com/en/graphql
+- `gh api` manual: https://cli.github.com/manual/gh_api
+- REST rate limits: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+- `GITHUB_TOKEN` permissions: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
+- PAT creation/limits: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+- GitHub App permissions: https://docs.github.com/en/apps/creating-github-apps/setting-up-a-github-app/choosing-permissions-for-a-github-app
+- Fine-grained PAT permissions matrix: https://docs.github.com/en/rest/overview/permissions-required-for-fine-grained-personal-access-tokens
+- Issues REST: https://docs.github.com/en/rest/issues/issues
+- Pull Requests REST: https://docs.github.com/en/rest/pulls/pulls
+- PR Reviews REST: https://docs.github.com/en/rest/pulls/reviews
+- Labels REST: https://docs.github.com/en/rest/issues/labels
+- Commit Statuses REST: https://docs.github.com/en/rest/commits/statuses
+- Contents REST: https://docs.github.com/en/rest/repos/contents
+- Actions workflow runs REST: https://docs.github.com/en/rest/actions/workflow-runs
+- Checks REST: https://docs.github.com/en/rest/checks
+
+## Relationship to existing skills
+
+- `gh-fix-ci`: handles CI fix implementation after this skill identifies
+  the failure picture
+- `gh-address-comments`: handles PR review comment triage after this skill
+  identifies the PR landscape
+- `cdb-ci-cd-guard`: governs CI/CD ruleset compliance; this skill provides
+  the live API data that `cdb-ci-cd-guard` may need
+- `cdb-control-intake`: reads control context; this skill reads live GitHub
+  data as a complementary source
+- `cdb-session-start`: may invoke this skill when session scope touches
+  GitHub live data
+- `docs/github/UNIFIED_GITHUB_STATUS_SNAPSHOT.md`: the detailed reference
+  document for the Status Snapshot sub-operation
+
+## Follow-up issues (proposed, not created)
+
+- `[GITHUB-API][MVP] Build read-only Unified GitHub Status Snapshot CLI`
+- `[GITHUB-API][GRAPHQL] Add reusable ProjectV2/statusCheckRollup query bundle`
+- `[GITHUB-API][AGENTS] Add API Opportunity Scan to CDB/Modusmono agent prompts`
+- `[GITHUB-API][APP] Evaluate GitHub App target architecture`
+
+## Anti-patterns
+
+- Do NOT fire `gh api` calls without checking auth scope first
+- Do NOT treat partial GitHub data as complete truth
+- Do NOT write to GitHub without explicit Plan-GO
+- Do NOT present fine-grained PAT as a universal auth solution
+- Do NOT infer ProjectV2 data when `read:project` is missing
+- Do NOT batch API calls without checking rate limits first
+- Do NOT retry 403 with different credentials automatically
+- Do NOT replace `gh-fix-ci` or `gh-address-comments` with this skill
+- Do NOT read or expose tokens, secrets, or private keys in any output
+- Do NOT create issues, PRs, or comments without Human-GO
+- Do NOT treat Board stage or `trade-capable` as Live-Go; LR remains NO-GO

--- a/.cursor/skills/README.md
+++ b/.cursor/skills/README.md
@@ -41,6 +41,13 @@ Repo-versionierte Session-Skills für Cursor Agents. Jeder Skill lebt in `<name>
 |---|---|
 | [`gh-fix-ci`](gh-fix-ci/SKILL.md) | CI failures |
 | [`gh-address-comments`](gh-address-comments/SKILL.md) | PR review comments |
+| [`cdb-github-api-ops`](cdb-github-api-ops/SKILL.md) | GitHub API-aware agent routing |
+
+## Canonical skill source
+
+- `docs/skills/` ist die kanonische Skill-Flaeche.
+- Jede Surface-Kopie muss den Pflicht-Header aus Registry Abschnitt 7 tragen.
+- Registry: [`docs/skills/SKILL_SURFACE_REGISTRY.md`](../../docs/skills/SKILL_SURFACE_REGISTRY.md).
 
 ## Related surfaces
 

--- a/.cursor/skills/cdb-github-api-ops/SKILL.md
+++ b/.cursor/skills/cdb-github-api-ops/SKILL.md
@@ -1,0 +1,275 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-github-api-ops/SKILL.md
+Surface: cursor
+Sync Status: mirrored
+Last Verified: 2026-06-30
+Drift Policy: Surface darf nur abweichen, wenn Begruendung in docs/skills/cdb-github-api-ops/SKILL.md dokumentiert ist.
+-->
+
+---
+name: cdb-github-api-ops
+description: >
+  GitHub API-aware agent routing for CDB. Teaches agents when to use GitHub
+  API calls, which data to pull, which permissions matter, and when to stop.
+  Covers Status Snapshot, API Opportunity Scan, CI/Checks Readout, PR Queue
+  Radar, Issue Dedupe, ProjectV2 Reconciliation, Rate-Limit Awareness, and
+  Permission Safety. Read-only by default; writes require separate approved
+  scope. Does not replace gh-fix-ci or gh-address-comments but complements
+  them with upstream API awareness.
+disable-model-invocation: true
+---
+
+# CDB GitHub API Ops
+
+Route GitHub API usage intelligently. Read broadly, write narrowly.
+
+## Use this skill when
+
+- the agent touches PRs, issues, CI checks, or ProjectV2 and needs live
+  GitHub data beyond what `git` alone provides
+- the agent should check whether a GitHub API call is the right approach
+  before firing `gh api` blindly
+- the agent needs a Status Snapshot of the repo, PR queue, or CI state
+- the agent encounters repetitive manual GitHub actions that could be API calls
+- the agent sees red checks and wants to understand the API-level picture
+  before delegating to `gh-fix-ci`
+- the agent considers creating an issue and should deduplicate first
+- the agent works on Modusmono/CDB portfolio and needs multi-repo visibility
+- ProjectV2 fields are relevant and `read:project` may be missing
+- a write operation seems necessary and the agent must verify scope first
+
+## Do NOT use this skill when
+
+- CI is already failing and the task is purely fixing code (use `gh-fix-ci`)
+- PR review comments need triage or replies (use `gh-address-comments`)
+- the task is local git work with no GitHub interaction needed
+- the task is repo settings, branch protection, or admin changes (separate
+  scope, never automatic)
+
+## Inputs
+
+- Authenticated `gh` CLI
+- Target repo (default: current repo)
+- Optional: issue/PR numbers, branch names, ProjectV2 board IDs
+
+## Workflow
+
+### 1. Auth profile check
+
+Before any API call, verify what the current auth profile can do:
+
+```bash
+gh auth status
+```
+
+Determine:
+
+| Signal | Meaning |
+|--------|---------|
+| `repo` scope present | Issues, PRs, contents, actions readable |
+| `read:org` scope present | Org membership readable |
+| `workflow` scope present | Workflow runs readable |
+| `read:project` scope missing | ProjectV2 NOT visible — known gap |
+| fine-grained PAT in use | Checks API may be blocked; see limits below |
+
+Record the auth profile in any output:
+
+```text
+auth_profile: gh-session | fine-grained-pat | classic-pat | github-app
+evidence_sources: [list what was actually readable]
+partial_visibility: [list what was blocked or incomplete]
+```
+
+### 2. Route to the right sub-operation
+
+| Situation | Sub-operation | Primary API | Notes |
+|-----------|---------------|-------------|-------|
+| Need full repo status picture | Status Snapshot | GraphQL (issues, PRs, reviews, statusCheckRollup) + REST (Actions runs/jobs, commit statuses) | See `docs/github/UNIFIED_GITHUB_STATUS_SNAPSHOT.md` |
+| Red checks on a PR | CI/Checks Readout | REST Actions runs/jobs + Checks | Delegate fix to `gh-fix-ci` after readout |
+| Open PRs need triage view | PR Queue Radar | GraphQL (PRs + reviews + mergeState) | Complement `gh pr list` with deeper fields |
+| About to create an issue | Issue Dedupe | REST search: `GET /search/issues?q=repo:...+<keywords>` | Always search before opening |
+| Repetitive manual GitHub clicks | API Opportunity Scan | N/A (diagnostic) | Propose API automation, do not implement |
+| Multi-repo portfolio view | Multi-Repo Snapshot | GraphQL per repo or `gh api` loop | Same snapshot logic, multiple repos |
+| ProjectV2 fields needed | ProjectV2 Reconciliation | GraphQL ProjectV2 items | Requires `read:project`; mark as gap if missing |
+| Rate limit approaching | Rate-Limit Awareness | REST `/rate_limit` | Check before batch operations |
+| Write seems necessary | Permission Safety | N/A (gate check) | STOP — see write rules below |
+
+### 3. Execute the read
+
+Use `gh api` as the CLI-MVP carrier:
+
+**GraphQL example (Status Snapshot):**
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "jannekbuengener", name: "Claire_de_Binare") {
+    pullRequests(states: [OPEN], first: 10, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes {
+        number title reviewDecision mergeStateStatus
+        statusCheckRollup { nodes { state description } }
+      }
+    }
+  }
+}
+'
+```
+
+**REST example (Actions runs):**
+
+```bash
+gh api repos/jannekbuengener/Claire_de_Binare/actions/runs --jq '.workflow_runs[] | {id, name, status, conclusion, created_at}'
+```
+
+**Search example (Issue Dedupe):**
+
+```bash
+gh api "search/issues?q=repo:jannekbuengener/Claire_de_Binare+<keywords>" --jq '.items[] | {number, title, state}'
+```
+
+**Rate limit check:**
+
+```bash
+gh api rate_limit --jq '.resources | to_entries[] | {name: .key, remaining: .value.remaining, limit: .value.limit, reset: .value.reset}'
+```
+
+### 4. Handle partial visibility honestly
+
+If an API call fails due to missing scope or permissions:
+
+- Record exactly what failed and why
+- Do NOT silently skip the missing data
+- Do NOT treat the partial result as complete
+- Output must include `partial_visibility` and `collection_errors`
+
+### 5. Write gate
+
+| Intent | Rule |
+|--------|------|
+| Read any GitHub data | Automatically OK when scope touches GitHub live state |
+| Comment on issue/PR | Only if Plan-GO explicitly allows it |
+| Create issue/PR | Only if Plan-GO explicitly allows it |
+| Label/milestone changes | Only if Plan-GO explicitly allows it |
+| Merge/rebase/push | Separate scope, never automatic |
+| Repo settings/admin | Separate scope, never automatic |
+| Branch protection changes | Separate scope, never automatic |
+
+When a write seems necessary but no approved scope exists:
+
+1. STOP.
+2. Report what needs writing and why.
+3. Propose the write as a follow-up with explicit Human-GO.
+4. Do NOT execute the write.
+
+## Hard rules
+
+### Read-first posture
+
+- GitHub live data is truth. Prefer API reads over assumptions or cached
+  memory.
+- Always record auth profile, evidence sources, and partial visibility in
+  output.
+- Never treat a partial result as complete.
+
+### Permission safety
+
+- Broad read, narrow write. Snapshot MVP is strictly read-only.
+- Fine-grained PAT has known gaps: cannot call Checks API, cannot access
+  user-owned Projects per GitHub docs.
+- Classic PAT has `repo` scope but no `read:project` — ProjectV2 remains
+  invisible without it.
+- GitHub App is the target architecture for stable broad read access but
+  is not yet implemented.
+- Never present fine-grained PAT as a universal solution for the full
+  snapshot surface.
+
+### ProjectV2 visibility
+
+- `read:project` scope is required to read ProjectV2 items via GraphQL.
+- If `read:project` is missing, mark ProjectV2 as a known visibility gap.
+- Do NOT infer ProjectV2 field values from other data sources.
+
+### Rate limit discipline
+
+- Primary: 5,000 requests/hour (authenticated REST).
+- GraphQL: 5,000 points/hour (single-node query = 1 point).
+- Check `/rate_limit` before batch operations.
+- Prefer GraphQL for connected data (issues, PRs, reviews, checks) to
+  reduce request count.
+- Use REST for Actions runs/jobs/logs, labels, commit statuses, contents.
+
+### Fail-closed on auth ambiguity
+
+- If auth scope is unclear, test with a minimal read before assuming access.
+- If a read returns 403/404, record it as a visibility gap, not as "nothing
+  there."
+- Do NOT retry with elevated privileges or different tokens automatically.
+
+## API surface reference
+
+| Sub-operation | Preferred API | Key permission | Known gap |
+|---------------|---------------|---------------|-----------|
+| Status Snapshot | GraphQL + REST | `repo`, `read:project` | ProjectV2 without `read:project` |
+| CI/Checks Readout | REST (Actions, Checks) | `repo` | Fine-grained PAT: no Checks |
+| PR Queue Radar | GraphQL | `repo` | — |
+| Issue Dedupe | REST Search | `repo` | — |
+| API Opportunity Scan | N/A (diagnostic) | — | — |
+| Multi-Repo Snapshot | GraphQL + REST per repo | `repo` per repo | Same per-repo auth gaps |
+| ProjectV2 Reconciliation | GraphQL ProjectV2 | `read:project` | Missing scope = invisible |
+| Rate-Limit Awareness | REST `/rate_limit` | none | — |
+| Permission Safety | N/A (gate) | — | — |
+
+## Official GitHub docs evidence
+
+- REST overview: https://docs.github.com/en/rest/about-the-rest-api/about-the-rest-api
+- GraphQL overview: https://docs.github.com/en/graphql
+- `gh api` manual: https://cli.github.com/manual/gh_api
+- REST rate limits: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+- `GITHUB_TOKEN` permissions: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
+- PAT creation/limits: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+- GitHub App permissions: https://docs.github.com/en/apps/creating-github-apps/setting-up-a-github-app/choosing-permissions-for-a-github-app
+- Fine-grained PAT permissions matrix: https://docs.github.com/en/rest/overview/permissions-required-for-fine-grained-personal-access-tokens
+- Issues REST: https://docs.github.com/en/rest/issues/issues
+- Pull Requests REST: https://docs.github.com/en/rest/pulls/pulls
+- PR Reviews REST: https://docs.github.com/en/rest/pulls/reviews
+- Labels REST: https://docs.github.com/en/rest/issues/labels
+- Commit Statuses REST: https://docs.github.com/en/rest/commits/statuses
+- Contents REST: https://docs.github.com/en/rest/repos/contents
+- Actions workflow runs REST: https://docs.github.com/en/rest/actions/workflow-runs
+- Checks REST: https://docs.github.com/en/rest/checks
+
+## Relationship to existing skills
+
+- `gh-fix-ci`: handles CI fix implementation after this skill identifies
+  the failure picture
+- `gh-address-comments`: handles PR review comment triage after this skill
+  identifies the PR landscape
+- `cdb-ci-cd-guard`: governs CI/CD ruleset compliance; this skill provides
+  the live API data that `cdb-ci-cd-guard` may need
+- `cdb-control-intake`: reads control context; this skill reads live GitHub
+  data as a complementary source
+- `cdb-session-start`: may invoke this skill when session scope touches
+  GitHub live data
+- `docs/github/UNIFIED_GITHUB_STATUS_SNAPSHOT.md`: the detailed reference
+  document for the Status Snapshot sub-operation
+
+## Follow-up issues (proposed, not created)
+
+- `[GITHUB-API][MVP] Build read-only Unified GitHub Status Snapshot CLI`
+- `[GITHUB-API][GRAPHQL] Add reusable ProjectV2/statusCheckRollup query bundle`
+- `[GITHUB-API][AGENTS] Add API Opportunity Scan to CDB/Modusmono agent prompts`
+- `[GITHUB-API][APP] Evaluate GitHub App target architecture`
+
+## Anti-patterns
+
+- Do NOT fire `gh api` calls without checking auth scope first
+- Do NOT treat partial GitHub data as complete truth
+- Do NOT write to GitHub without explicit Plan-GO
+- Do NOT present fine-grained PAT as a universal auth solution
+- Do NOT infer ProjectV2 data when `read:project` is missing
+- Do NOT batch API calls without checking rate limits first
+- Do NOT retry 403 with different credentials automatically
+- Do NOT replace `gh-fix-ci` or `gh-address-comments` with this skill
+- Do NOT read or expose tokens, secrets, or private keys in any output
+- Do NOT create issues, PRs, or comments without Human-GO
+- Do NOT treat Board stage or `trade-capable` as Live-Go; LR remains NO-GO

--- a/.opencode/skills/README.md
+++ b/.opencode/skills/README.md
@@ -50,6 +50,13 @@ Spiegelt die Cursor-Skill-Oberfläche unter [`.cursor/skills/README.md`](../../.
 |---|---|
 | [`gh-fix-ci`](gh-fix-ci/SKILL.md) | CI failures |
 | [`gh-address-comments`](gh-address-comments/SKILL.md) | PR review comments |
+| [`cdb-github-api-ops`](cdb-github-api-ops/SKILL.md) | GitHub API-aware agent routing |
+
+## Canonical skill source
+
+- `docs/skills/` ist die kanonische Skill-Flaeche.
+- Jede Surface-Kopie muss den Pflicht-Header aus Registry Abschnitt 7 tragen.
+- Registry: [`docs/skills/SKILL_SURFACE_REGISTRY.md`](../../docs/skills/SKILL_SURFACE_REGISTRY.md).
 
 ## Related surfaces
 

--- a/.opencode/skills/cdb-github-api-ops/SKILL.md
+++ b/.opencode/skills/cdb-github-api-ops/SKILL.md
@@ -1,0 +1,275 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-github-api-ops/SKILL.md
+Surface: opencode
+Sync Status: mirrored
+Last Verified: 2026-06-30
+Drift Policy: Surface darf nur abweichen, wenn Begruendung in docs/skills/cdb-github-api-ops/SKILL.md dokumentiert ist.
+-->
+
+---
+name: cdb-github-api-ops
+description: >
+  GitHub API-aware agent routing for CDB. Teaches agents when to use GitHub
+  API calls, which data to pull, which permissions matter, and when to stop.
+  Covers Status Snapshot, API Opportunity Scan, CI/Checks Readout, PR Queue
+  Radar, Issue Dedupe, ProjectV2 Reconciliation, Rate-Limit Awareness, and
+  Permission Safety. Read-only by default; writes require separate approved
+  scope. Does not replace gh-fix-ci or gh-address-comments but complements
+  them with upstream API awareness.
+disable-model-invocation: true
+---
+
+# CDB GitHub API Ops
+
+Route GitHub API usage intelligently. Read broadly, write narrowly.
+
+## Use this skill when
+
+- the agent touches PRs, issues, CI checks, or ProjectV2 and needs live
+  GitHub data beyond what `git` alone provides
+- the agent should check whether a GitHub API call is the right approach
+  before firing `gh api` blindly
+- the agent needs a Status Snapshot of the repo, PR queue, or CI state
+- the agent encounters repetitive manual GitHub actions that could be API calls
+- the agent sees red checks and wants to understand the API-level picture
+  before delegating to `gh-fix-ci`
+- the agent considers creating an issue and should deduplicate first
+- the agent works on Modusmono/CDB portfolio and needs multi-repo visibility
+- ProjectV2 fields are relevant and `read:project` may be missing
+- a write operation seems necessary and the agent must verify scope first
+
+## Do NOT use this skill when
+
+- CI is already failing and the task is purely fixing code (use `gh-fix-ci`)
+- PR review comments need triage or replies (use `gh-address-comments`)
+- the task is local git work with no GitHub interaction needed
+- the task is repo settings, branch protection, or admin changes (separate
+  scope, never automatic)
+
+## Inputs
+
+- Authenticated `gh` CLI
+- Target repo (default: current repo)
+- Optional: issue/PR numbers, branch names, ProjectV2 board IDs
+
+## Workflow
+
+### 1. Auth profile check
+
+Before any API call, verify what the current auth profile can do:
+
+```bash
+gh auth status
+```
+
+Determine:
+
+| Signal | Meaning |
+|--------|---------|
+| `repo` scope present | Issues, PRs, contents, actions readable |
+| `read:org` scope present | Org membership readable |
+| `workflow` scope present | Workflow runs readable |
+| `read:project` scope missing | ProjectV2 NOT visible — known gap |
+| fine-grained PAT in use | Checks API may be blocked; see limits below |
+
+Record the auth profile in any output:
+
+```text
+auth_profile: gh-session | fine-grained-pat | classic-pat | github-app
+evidence_sources: [list what was actually readable]
+partial_visibility: [list what was blocked or incomplete]
+```
+
+### 2. Route to the right sub-operation
+
+| Situation | Sub-operation | Primary API | Notes |
+|-----------|---------------|-------------|-------|
+| Need full repo status picture | Status Snapshot | GraphQL (issues, PRs, reviews, statusCheckRollup) + REST (Actions runs/jobs, commit statuses) | See `docs/github/UNIFIED_GITHUB_STATUS_SNAPSHOT.md` |
+| Red checks on a PR | CI/Checks Readout | REST Actions runs/jobs + Checks | Delegate fix to `gh-fix-ci` after readout |
+| Open PRs need triage view | PR Queue Radar | GraphQL (PRs + reviews + mergeState) | Complement `gh pr list` with deeper fields |
+| About to create an issue | Issue Dedupe | REST search: `GET /search/issues?q=repo:...+<keywords>` | Always search before opening |
+| Repetitive manual GitHub clicks | API Opportunity Scan | N/A (diagnostic) | Propose API automation, do not implement |
+| Multi-repo portfolio view | Multi-Repo Snapshot | GraphQL per repo or `gh api` loop | Same snapshot logic, multiple repos |
+| ProjectV2 fields needed | ProjectV2 Reconciliation | GraphQL ProjectV2 items | Requires `read:project`; mark as gap if missing |
+| Rate limit approaching | Rate-Limit Awareness | REST `/rate_limit` | Check before batch operations |
+| Write seems necessary | Permission Safety | N/A (gate check) | STOP — see write rules below |
+
+### 3. Execute the read
+
+Use `gh api` as the CLI-MVP carrier:
+
+**GraphQL example (Status Snapshot):**
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "jannekbuengener", name: "Claire_de_Binare") {
+    pullRequests(states: [OPEN], first: 10, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes {
+        number title reviewDecision mergeStateStatus
+        statusCheckRollup { nodes { state description } }
+      }
+    }
+  }
+}
+'
+```
+
+**REST example (Actions runs):**
+
+```bash
+gh api repos/jannekbuengener/Claire_de_Binare/actions/runs --jq '.workflow_runs[] | {id, name, status, conclusion, created_at}'
+```
+
+**Search example (Issue Dedupe):**
+
+```bash
+gh api "search/issues?q=repo:jannekbuengener/Claire_de_Binare+<keywords>" --jq '.items[] | {number, title, state}'
+```
+
+**Rate limit check:**
+
+```bash
+gh api rate_limit --jq '.resources | to_entries[] | {name: .key, remaining: .value.remaining, limit: .value.limit, reset: .value.reset}'
+```
+
+### 4. Handle partial visibility honestly
+
+If an API call fails due to missing scope or permissions:
+
+- Record exactly what failed and why
+- Do NOT silently skip the missing data
+- Do NOT treat the partial result as complete
+- Output must include `partial_visibility` and `collection_errors`
+
+### 5. Write gate
+
+| Intent | Rule |
+|--------|------|
+| Read any GitHub data | Automatically OK when scope touches GitHub live state |
+| Comment on issue/PR | Only if Plan-GO explicitly allows it |
+| Create issue/PR | Only if Plan-GO explicitly allows it |
+| Label/milestone changes | Only if Plan-GO explicitly allows it |
+| Merge/rebase/push | Separate scope, never automatic |
+| Repo settings/admin | Separate scope, never automatic |
+| Branch protection changes | Separate scope, never automatic |
+
+When a write seems necessary but no approved scope exists:
+
+1. STOP.
+2. Report what needs writing and why.
+3. Propose the write as a follow-up with explicit Human-GO.
+4. Do NOT execute the write.
+
+## Hard rules
+
+### Read-first posture
+
+- GitHub live data is truth. Prefer API reads over assumptions or cached
+  memory.
+- Always record auth profile, evidence sources, and partial visibility in
+  output.
+- Never treat a partial result as complete.
+
+### Permission safety
+
+- Broad read, narrow write. Snapshot MVP is strictly read-only.
+- Fine-grained PAT has known gaps: cannot call Checks API, cannot access
+  user-owned Projects per GitHub docs.
+- Classic PAT has `repo` scope but no `read:project` — ProjectV2 remains
+  invisible without it.
+- GitHub App is the target architecture for stable broad read access but
+  is not yet implemented.
+- Never present fine-grained PAT as a universal solution for the full
+  snapshot surface.
+
+### ProjectV2 visibility
+
+- `read:project` scope is required to read ProjectV2 items via GraphQL.
+- If `read:project` is missing, mark ProjectV2 as a known visibility gap.
+- Do NOT infer ProjectV2 field values from other data sources.
+
+### Rate limit discipline
+
+- Primary: 5,000 requests/hour (authenticated REST).
+- GraphQL: 5,000 points/hour (single-node query = 1 point).
+- Check `/rate_limit` before batch operations.
+- Prefer GraphQL for connected data (issues, PRs, reviews, checks) to
+  reduce request count.
+- Use REST for Actions runs/jobs/logs, labels, commit statuses, contents.
+
+### Fail-closed on auth ambiguity
+
+- If auth scope is unclear, test with a minimal read before assuming access.
+- If a read returns 403/404, record it as a visibility gap, not as "nothing
+  there."
+- Do NOT retry with elevated privileges or different tokens automatically.
+
+## API surface reference
+
+| Sub-operation | Preferred API | Key permission | Known gap |
+|---------------|---------------|---------------|-----------|
+| Status Snapshot | GraphQL + REST | `repo`, `read:project` | ProjectV2 without `read:project` |
+| CI/Checks Readout | REST (Actions, Checks) | `repo` | Fine-grained PAT: no Checks |
+| PR Queue Radar | GraphQL | `repo` | — |
+| Issue Dedupe | REST Search | `repo` | — |
+| API Opportunity Scan | N/A (diagnostic) | — | — |
+| Multi-Repo Snapshot | GraphQL + REST per repo | `repo` per repo | Same per-repo auth gaps |
+| ProjectV2 Reconciliation | GraphQL ProjectV2 | `read:project` | Missing scope = invisible |
+| Rate-Limit Awareness | REST `/rate_limit` | none | — |
+| Permission Safety | N/A (gate) | — | — |
+
+## Official GitHub docs evidence
+
+- REST overview: https://docs.github.com/en/rest/about-the-rest-api/about-the-rest-api
+- GraphQL overview: https://docs.github.com/en/graphql
+- `gh api` manual: https://cli.github.com/manual/gh_api
+- REST rate limits: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+- `GITHUB_TOKEN` permissions: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
+- PAT creation/limits: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+- GitHub App permissions: https://docs.github.com/en/apps/creating-github-apps/setting-up-a-github-app/choosing-permissions-for-a-github-app
+- Fine-grained PAT permissions matrix: https://docs.github.com/en/rest/overview/permissions-required-for-fine-grained-personal-access-tokens
+- Issues REST: https://docs.github.com/en/rest/issues/issues
+- Pull Requests REST: https://docs.github.com/en/rest/pulls/pulls
+- PR Reviews REST: https://docs.github.com/en/rest/pulls/reviews
+- Labels REST: https://docs.github.com/en/rest/issues/labels
+- Commit Statuses REST: https://docs.github.com/en/rest/commits/statuses
+- Contents REST: https://docs.github.com/en/rest/repos/contents
+- Actions workflow runs REST: https://docs.github.com/en/rest/actions/workflow-runs
+- Checks REST: https://docs.github.com/en/rest/checks
+
+## Relationship to existing skills
+
+- `gh-fix-ci`: handles CI fix implementation after this skill identifies
+  the failure picture
+- `gh-address-comments`: handles PR review comment triage after this skill
+  identifies the PR landscape
+- `cdb-ci-cd-guard`: governs CI/CD ruleset compliance; this skill provides
+  the live API data that `cdb-ci-cd-guard` may need
+- `cdb-control-intake`: reads control context; this skill reads live GitHub
+  data as a complementary source
+- `cdb-session-start`: may invoke this skill when session scope touches
+  GitHub live data
+- `docs/github/UNIFIED_GITHUB_STATUS_SNAPSHOT.md`: the detailed reference
+  document for the Status Snapshot sub-operation
+
+## Follow-up issues (proposed, not created)
+
+- `[GITHUB-API][MVP] Build read-only Unified GitHub Status Snapshot CLI`
+- `[GITHUB-API][GRAPHQL] Add reusable ProjectV2/statusCheckRollup query bundle`
+- `[GITHUB-API][AGENTS] Add API Opportunity Scan to CDB/Modusmono agent prompts`
+- `[GITHUB-API][APP] Evaluate GitHub App target architecture`
+
+## Anti-patterns
+
+- Do NOT fire `gh api` calls without checking auth scope first
+- Do NOT treat partial GitHub data as complete truth
+- Do NOT write to GitHub without explicit Plan-GO
+- Do NOT present fine-grained PAT as a universal auth solution
+- Do NOT infer ProjectV2 data when `read:project` is missing
+- Do NOT batch API calls without checking rate limits first
+- Do NOT retry 403 with different credentials automatically
+- Do NOT replace `gh-fix-ci` or `gh-address-comments` with this skill
+- Do NOT read or expose tokens, secrets, or private keys in any output
+- Do NOT create issues, PRs, or comments without Human-GO
+- Do NOT treat Board stage or `trade-capable` as Live-Go; LR remains NO-GO

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,8 @@ Cursor subagent surface: `.cursor/agents/` (helper roles; shared contract
 
 OpenCode skill surface zusaetzlich: `.opencode/skills/` (gezielt laden, nicht pauschal).
 
+**Kanonische Skill-Flaeche:** `docs/skills/` ist Source of Truth. Siehe `docs/skills/SKILL_SURFACE_REGISTRY.md`.
+
 | Skill | Purpose | Cursor path |
 |-------|---------|-------------|
 | `cdb-session-start` | Fail-closed session start (verifies Git truth first) | `.cursor/skills/cdb-session-start/SKILL.md` |
@@ -287,6 +289,7 @@ OpenCode skill surface zusaetzlich: `.opencode/skills/` (gezielt laden, nicht pa
 | `ctb-docker-stack` | Docker stack operations | `.cursor/skills/ctb-docker-stack/SKILL.md` |
 | `gh-address-comments` | GitHub comment handling | `.cursor/skills/gh-address-comments/SKILL.md` |
 | `gh-fix-ci` | CI fix operations | `.cursor/skills/gh-fix-ci/SKILL.md` |
+| `cdb-github-api-ops` | GitHub API-aware agent routing | `.cursor/skills/cdb-github-api-ops/SKILL.md` |
 
 ---
 

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -1,0 +1,40 @@
+# CDB Skills (`/docs/skills/`)
+
+Status: kanonische Skill-Flaeche (siehe `SKILL_SURFACE_REGISTRY.md`).
+
+`docs/skills/` ist die **Single Source of Truth** fuer CDB-Skills.
+Alle anderen Surface-Pfade (`.opencode/`, `.cursor/`, `.codex/`,
+`.claude/`) sind Mirror-Adapter und muessen gegen diese Dateien
+synchron gehalten werden.
+
+## Kanonische Skill-Dateien
+
+| Skill | Pfad | Eingefuehrt |
+|---|---|---|
+| `gh-fix-ci` | [`gh-fix-ci/SKILL.md`](gh-fix-ci/SKILL.md) | bestehend |
+| `cdb-github-api-ops` | [`cdb-github-api-ops/SKILL.md`](cdb-github-api-ops/SKILL.md) | PR #3569 |
+
+## Registry
+
+- [`SKILL_SURFACE_REGISTRY.md`](SKILL_SURFACE_REGISTRY.md): verbindliche
+  Definition der kanonischen Flaeche, der Surface-Adapter-Typen und
+  der Drift-Regeln.
+
+## Neue Skills
+
+Bitte zuerst in `docs/skills/<skill-name>/SKILL.md` anlegen, dann auf
+die Surfaces spiegeln. Workflow-Details siehe Registry, Abschnitt 9.
+
+## Anti-Pattern
+
+- Do NOT Skills direkt in `.opencode/`, `.cursor/`, `.codex/`,
+  `.claude/` ohne kanonische Datei in `docs/skills/` anlegen.
+- Do NOT Mirror-Kopien ohne Pflicht-Header aus Registry, Abschnitt 7.
+
+## Related Surfaces
+
+OpenCode: [`.opencode/skills/README.md`](../../.opencode/skills/README.md)
+Cursor: [`.cursor/skills/README.md`](../../.cursor/skills/README.md)
+Codex: [`.codex/cdb_skills/README.md`](../../.codex/cdb_skills/README.md)
+Claude: [`.claude/skills/`](../../.claude/skills/)
+Registry: [`SKILL_SURFACE_REGISTRY.md`](SKILL_SURFACE_REGISTRY.md)

--- a/docs/skills/SKILL_SURFACE_REGISTRY.md
+++ b/docs/skills/SKILL_SURFACE_REGISTRY.md
@@ -1,0 +1,208 @@
+# CDB Skill Surface Registry
+
+Status: kanonische Skill-Verwaltung (CDB only, kein Modusmono-Scope).
+Single-Writer-Prinzip: jede Skill-Datei hat genau eine kanonische Quelle.
+
+## 1. Executive Summary
+
+CDB-Skills leben auf mehreren Agenten-Surfaces
+(`.opencode/`, `.cursor/`, `.codex/`, `.claude/`, `docs/skills/`).
+Ohne eine klare Registrierung entsteht Drift: identische Skills koennen
+inhaltlich abweichen, die Source-of-Truth ist unklar, Agents wissen nicht,
+wohin neue Skills gehoeren.
+
+Dieses Dokument definiert:
+
+- eine einzige kanonische Skill-Flaeche,
+- alle aktiven und eingeschraenkten Surface-Adapter,
+- die Pflicht-Header fuer jede Surface-Kopie,
+- Drift-Regeln und Workflows (neu / update / deprecated).
+
+Skopus ist **strikt CDB**. Modusmono-Repostrukturierung ist explizit
+ausgeschlossen.
+
+## 2. Warum eine Skill-Registry noetig ist
+
+| Problem | Wirkung |
+|---|---|
+| Mehrere Surface-Pfade fuer dieselbe Datei | Drift zwischen den Kopien |
+| Keine ausgewiesene Source of Truth | Agenten raten, wo sie schreiben sollen |
+| Kein Sync-Status | Aenderungen werden nicht verifiziert |
+| Kein Deprecation-Pfad | Veraltete Skills bleiben aktiv |
+| Surface-READMEs koennen abweichen | Inkonsistente Skill-Listen |
+
+PR #3569 (`cdb-github-api-ops`) hat diese Risiken sichtbar gemacht
+und ist das erste Beispiel, fuer das diese Registry jetzt greift.
+
+## 3. Kanonische Skill-Flaeche (Monopol)
+
+`docs/skills/<skill-name>/SKILL.md` ist die kanonische Quelle.
+
+Begruendung:
+
+- `docs/` liegt versioniert im Repo und folgt der Docs-Hub-Governance.
+- `docs/skills/` enthaelt bereits erweiterte Skill-Dokumente
+  (`gh-fix-ci/` mit `META.yaml`, `evals.json`, `DISCOVERY_REPORT.md`).
+- `docs/` ist docs-only und nicht an einen Agent-Runtime-Loader gebunden,
+  wodurch Schreibregeln klar bleiben.
+- Diese Flaeche ist **Monopol im Sinne einer einzigen Source of Truth**:
+  identische Skill-Dateien auf anderen Surfaces sind Adapter, nicht
+  eigenstaendige Quellen.
+
+Folgerung:
+
+- Aenderungen am Skill-Inhalt passieren in `docs/skills/<name>/SKILL.md`.
+- Surface-Adapter erhalten die Datei ueber den in Abschnitt 7 definierten
+  Mirror-Workflow.
+
+## 4. Aktive Skill-Surfaces
+
+| Surface | Pfad | Rolle |
+|---|---|---|
+| Kanonisch | `docs/skills/<name>/SKILL.md` | Source of Truth (SSOT) |
+| OpenCode | `.opencode/skills/<name>/SKILL.md` | Surface Adapter (mirrored) |
+| Cursor | `.cursor/skills/<name>/SKILL.md` | Surface Adapter (mirrored) |
+| Codex | `.codex/cdb_skills/<name>/SKILL.md` | Surface Adapter (mirrored) |
+| Claude | `.claude/skills/<name>/SKILL.md` + `cdb-<name>.skill` Index | Surface Adapter (mirrored) |
+| Docs (verweist) | `docs/skills/` Surface-README | Index/Quelle |
+
+Alle aktiven Surfaces muessen dieselbe Skill-Datei spiegeln oder als
+expliziter Adapter dokumentiert sein.
+
+## 5. Eingeschraenkte / nicht-standardmaessige Surfaces
+
+| Surface | Pfad | Status | Begruendung |
+|---|---|---|---|
+| Gemini | `.gemini/skills/` | Eingeschraenkt | Bewusst eingeschraenkter Surface-Set, Onboarding-only; nur 4 Skills deploybar (`cdb-external-docs`, `surrealdb-python`, `surrealdb-vector`, `surrealql`). Domain-Skills wie CDB-Workflow-Skills sind **nicht** auf Gemini-Surface vorgesehen. |
+| Skillforge assets | `.opencode/skills/skillforge/` | Tooling, nicht Skill | Skillforge ist Meta-Tool fuer Skill-Erstellung, kein Domain-Skill |
+| Codex system | `.codex/cdb_skills/.system/` | Codex-spezifisch | Nur fuer Codex-Clients sichtbar |
+| Archiv / Legacy | `docs/archive/...` | Read-only | Historische Referenz, kein aktiver Skill |
+
+Regel: keine Skills auf `.gemini/` ohne explizite Surface-Entscheidung.
+
+## 6. Surface-Adapter-Modell
+
+Jede Surface-Kopie einer Skill-Datei ist ein **Adapter**.
+
+Adapter-Typen:
+
+| Typ | Bedeutung | Konsequenz |
+|---|---|---|
+| `mirrored` | Byte-faerbige Kopie der kanonischen Datei | Pflicht-Sync, kein abweichender Inhalt |
+| `adapted` | Inhaltliche Variante mit Begruendung (z. B. Frontmatter-only) | Abweichung dokumentieren |
+| `alias` | Verweist nur auf kanonische Datei | Minimaler Wrapper |
+| `deprecated` | Veraltete Version, soll entfernt werden | EOL-Datum, Migrationshinweis |
+
+Default-Typ fuer alle aktiven Skills: **`mirrored`**.
+
+## 7. Referenzpflicht in jeder Surface-Kopie
+
+Jede Surface-Kopie **muss** am Dateianfang folgenden Header-Traeger
+enthalten (Markdown-Frontmatter oder erster Markdown-Block):
+
+```text
+<!--
+Canonical Skill Source: docs/skills/<skill-name>/SKILL.md
+Surface: <opencode | cursor | codex | claude>
+Sync Status: <mirrored | adapted | alias | deprecated>
+Last Verified: <YYYY-MM-DD | <commit-sha>>
+Drift Policy: Surface darf nur abweichen, wenn Begruendung in <kanonischer Quelldatei> dokumentiert ist.
+-->
+```
+
+Wird der Header weggelassen, gilt die Datei als **nicht-registriert**
+und darf in der Surface-README nicht ohne Eintrag in dieser Registry
+gelistet werden.
+
+## 8. Drift Policy
+
+- Surface-Adapter ohne Header = Drift-Verdacht, STOP-Review.
+- Inhaltliche Abweichung nur wenn:
+  - Adapter-Typ ist `adapted` oder `deprecated`
+  - Begruendung in der kanonischen Datei dokumentiert
+  - Cross-Reference in der Registry vorhanden
+- `mirrored`-Adapter, die vom kanonischen Inhalt abweichen, sind kein
+  gültiger Zustand und muessen sofort synchronisiert oder auf `adapted`
+  umgestellt werden.
+- Drift-Erkennung gehoert zum `cdb-drift-reconcile`-Workflow und wird in
+  Folge-Issues verfeinert.
+
+## 9. Skill-Neuanlage-Workflow
+
+1. Skill-Inhalt in `docs/skills/<skill-name>/SKILL.md` anlegen.
+2. Optional `META.yaml` und `evals.json` (nur fuer CDB, falls Pruefung noetig).
+3. Surface-Adapter-Header (Abschnitt 7) in der kanonischen Datei setzen.
+4. Mirror auf alle aktiven Surfaces (Abschnitt 4).
+5. `.claude/skills/cdb-<name>.skill` Index anlegen, falls Claude relevant.
+6. Eintrag in `AGENTS.md` Skill-Tabelle (root pointer).
+7. Eintrag in Surface-READMEs der aktiven Surfaces.
+8. Drift-Check und `git diff --check`.
+
+## 10. Skill-Update-Workflow
+
+1. Aenderung in `docs/skills/<skill-name>/SKILL.md` (kanonisch).
+2. `Last Verified` in allen Adaptern aktualisieren.
+3. Falls Typ-Wechsel: Header in allen betroffenen Adaptern anpassen.
+4. Adapter spiegeln (Copy + CRLF-Normalisierung auf Windows).
+5. Surface-README-Eintraege nur anpassen, wenn Skill-Name oder Scope sich aendert.
+
+## 11. Skill-Deprecation-Workflow
+
+1. `Sync Status: deprecated` im Header aller Kopien setzen.
+2. Eintrag in `docs/skills/<skill-name>/DEPRECATION.md` mit:
+   - Deprecated date
+   - Replacement (falls existent)
+   - EOL date
+3. Surface-Adapter bleiben bis EOL erhalten, danach entfernt.
+4. Eintrag aus `AGENTS.md` Skill-Tabelle und Surface-READMEs takten.
+
+## 12. Beispiel: `cdb-github-api-ops`
+
+Eintrag in dieser Registry:
+
+| Feld | Wert |
+|---|---|
+| Kanonische Datei | `docs/skills/cdb-github-api-ops/SKILL.md` |
+| Eingefuehrt | PR #3569 |
+| Surface-Adapter | opencode, cursor, codex, claude (alle `mirrored`) |
+| `.gemini/`-Adapter | nicht aktiv |
+| Drift-Status | nach erstem Mirror-Lauf konsistent |
+| Cross-Refs | `docs/github/UNIFIED_GITHUB_STATUS_SNAPSHOT.md`, `gh-fix-ci`, `gh-address-comments`, `cdb-ci-cd-guard` |
+
+Der Skill ist der erste offizielle Anwendungsfall dieser Registry. Er
+dokumentiert das Routing-Muster fuer kuenftige Multi-Surface-Skills.
+
+## 13. Zusammenhang zu PR #3569
+
+PR #3569 hat `cdb-github-api-ops` als Multi-Surface-Skill eingefuehrt.
+Dabei wurden die Surface-Kopien ohne explizite Source-Of-Truth-Doku
+parallel angelegt. Diese Registry schliesst die Lucke:
+
+- SSOT wird auf `docs/skills/` festgelegt
+- Pflicht-Header auf den Spiegeldateien wird mit dieser Definition
+  verbindlich
+- Folge-Skills koennen sich an `cdb-github-api-ops` als Referenz
+  orientieren
+
+Folge-Issues koennen PR #3569 als Praezedenzfall referenzieren.
+
+## 14. Folge-Issues / naechste Slices
+
+Vorgeschlagen, **nicht in diesem Slice zu erstellen**:
+
+- `[SKILLS] Apply Surface-Adapter-Header to all existing mirrored skills`
+- `[SKILLS] Add drift-reconcile hook for skill surface adapters`
+- `[SKILLS] Add skill-meta schema (META.yaml + evals.json) for new CDB domain skills`
+- `[SKILLS] Document `.gemini/` activation policy if domain skills are ever needed`
+
+Diese Issues werden dedupliziert und mit klarem Scope spaeter angelegt,
+sobald die Registry auf `main` ist.
+
+## Anti-Patterns
+
+- Do NOT neue Skills direkt auf einer Surface ohne Eintrag in `docs/skills/`
+- Do NOT Mirror-Kopien ohne Pflicht-Header aus Abschnitt 7
+- Do NOT `adapted`-Typ verwenden, ohne Begruendung in der kanonischen Datei
+- Do NOT `.gemini/` fuer CDB Domain-Skills ohne separate Surface-Entscheidung
+- Do NOT Surface-READMEs divergieren lassen (immer synchron mit Registry)
+- Do NOT Modusmono-Scope hier einziehen — dieses Dokument bleibt CDB-only

--- a/docs/skills/cdb-github-api-ops/SKILL.md
+++ b/docs/skills/cdb-github-api-ops/SKILL.md
@@ -1,0 +1,275 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-github-api-ops/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-06-30
+Drift Policy: Surface darf nur abweichen, wenn Begruendung in docs/skills/cdb-github-api-ops/SKILL.md dokumentiert ist.
+-->
+
+---
+name: cdb-github-api-ops
+description: >
+  GitHub API-aware agent routing for CDB. Teaches agents when to use GitHub
+  API calls, which data to pull, which permissions matter, and when to stop.
+  Covers Status Snapshot, API Opportunity Scan, CI/Checks Readout, PR Queue
+  Radar, Issue Dedupe, ProjectV2 Reconciliation, Rate-Limit Awareness, and
+  Permission Safety. Read-only by default; writes require separate approved
+  scope. Does not replace gh-fix-ci or gh-address-comments but complements
+  them with upstream API awareness.
+disable-model-invocation: true
+---
+
+# CDB GitHub API Ops
+
+Route GitHub API usage intelligently. Read broadly, write narrowly.
+
+## Use this skill when
+
+- the agent touches PRs, issues, CI checks, or ProjectV2 and needs live
+  GitHub data beyond what `git` alone provides
+- the agent should check whether a GitHub API call is the right approach
+  before firing `gh api` blindly
+- the agent needs a Status Snapshot of the repo, PR queue, or CI state
+- the agent encounters repetitive manual GitHub actions that could be API calls
+- the agent sees red checks and wants to understand the API-level picture
+  before delegating to `gh-fix-ci`
+- the agent considers creating an issue and should deduplicate first
+- the agent works on Modusmono/CDB portfolio and needs multi-repo visibility
+- ProjectV2 fields are relevant and `read:project` may be missing
+- a write operation seems necessary and the agent must verify scope first
+
+## Do NOT use this skill when
+
+- CI is already failing and the task is purely fixing code (use `gh-fix-ci`)
+- PR review comments need triage or replies (use `gh-address-comments`)
+- the task is local git work with no GitHub interaction needed
+- the task is repo settings, branch protection, or admin changes (separate
+  scope, never automatic)
+
+## Inputs
+
+- Authenticated `gh` CLI
+- Target repo (default: current repo)
+- Optional: issue/PR numbers, branch names, ProjectV2 board IDs
+
+## Workflow
+
+### 1. Auth profile check
+
+Before any API call, verify what the current auth profile can do:
+
+```bash
+gh auth status
+```
+
+Determine:
+
+| Signal | Meaning |
+|--------|---------|
+| `repo` scope present | Issues, PRs, contents, actions readable |
+| `read:org` scope present | Org membership readable |
+| `workflow` scope present | Workflow runs readable |
+| `read:project` scope missing | ProjectV2 NOT visible — known gap |
+| fine-grained PAT in use | Checks API may be blocked; see limits below |
+
+Record the auth profile in any output:
+
+```text
+auth_profile: gh-session | fine-grained-pat | classic-pat | github-app
+evidence_sources: [list what was actually readable]
+partial_visibility: [list what was blocked or incomplete]
+```
+
+### 2. Route to the right sub-operation
+
+| Situation | Sub-operation | Primary API | Notes |
+|-----------|---------------|-------------|-------|
+| Need full repo status picture | Status Snapshot | GraphQL (issues, PRs, reviews, statusCheckRollup) + REST (Actions runs/jobs, commit statuses) | See `docs/github/UNIFIED_GITHUB_STATUS_SNAPSHOT.md` |
+| Red checks on a PR | CI/Checks Readout | REST Actions runs/jobs + Checks | Delegate fix to `gh-fix-ci` after readout |
+| Open PRs need triage view | PR Queue Radar | GraphQL (PRs + reviews + mergeState) | Complement `gh pr list` with deeper fields |
+| About to create an issue | Issue Dedupe | REST search: `GET /search/issues?q=repo:...+<keywords>` | Always search before opening |
+| Repetitive manual GitHub clicks | API Opportunity Scan | N/A (diagnostic) | Propose API automation, do not implement |
+| Multi-repo portfolio view | Multi-Repo Snapshot | GraphQL per repo or `gh api` loop | Same snapshot logic, multiple repos |
+| ProjectV2 fields needed | ProjectV2 Reconciliation | GraphQL ProjectV2 items | Requires `read:project`; mark as gap if missing |
+| Rate limit approaching | Rate-Limit Awareness | REST `/rate_limit` | Check before batch operations |
+| Write seems necessary | Permission Safety | N/A (gate check) | STOP — see write rules below |
+
+### 3. Execute the read
+
+Use `gh api` as the CLI-MVP carrier:
+
+**GraphQL example (Status Snapshot):**
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "jannekbuengener", name: "Claire_de_Binare") {
+    pullRequests(states: [OPEN], first: 10, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes {
+        number title reviewDecision mergeStateStatus
+        statusCheckRollup { nodes { state description } }
+      }
+    }
+  }
+}
+'
+```
+
+**REST example (Actions runs):**
+
+```bash
+gh api repos/jannekbuengener/Claire_de_Binare/actions/runs --jq '.workflow_runs[] | {id, name, status, conclusion, created_at}'
+```
+
+**Search example (Issue Dedupe):**
+
+```bash
+gh api "search/issues?q=repo:jannekbuengener/Claire_de_Binare+<keywords>" --jq '.items[] | {number, title, state}'
+```
+
+**Rate limit check:**
+
+```bash
+gh api rate_limit --jq '.resources | to_entries[] | {name: .key, remaining: .value.remaining, limit: .value.limit, reset: .value.reset}'
+```
+
+### 4. Handle partial visibility honestly
+
+If an API call fails due to missing scope or permissions:
+
+- Record exactly what failed and why
+- Do NOT silently skip the missing data
+- Do NOT treat the partial result as complete
+- Output must include `partial_visibility` and `collection_errors`
+
+### 5. Write gate
+
+| Intent | Rule |
+|--------|------|
+| Read any GitHub data | Automatically OK when scope touches GitHub live state |
+| Comment on issue/PR | Only if Plan-GO explicitly allows it |
+| Create issue/PR | Only if Plan-GO explicitly allows it |
+| Label/milestone changes | Only if Plan-GO explicitly allows it |
+| Merge/rebase/push | Separate scope, never automatic |
+| Repo settings/admin | Separate scope, never automatic |
+| Branch protection changes | Separate scope, never automatic |
+
+When a write seems necessary but no approved scope exists:
+
+1. STOP.
+2. Report what needs writing and why.
+3. Propose the write as a follow-up with explicit Human-GO.
+4. Do NOT execute the write.
+
+## Hard rules
+
+### Read-first posture
+
+- GitHub live data is truth. Prefer API reads over assumptions or cached
+  memory.
+- Always record auth profile, evidence sources, and partial visibility in
+  output.
+- Never treat a partial result as complete.
+
+### Permission safety
+
+- Broad read, narrow write. Snapshot MVP is strictly read-only.
+- Fine-grained PAT has known gaps: cannot call Checks API, cannot access
+  user-owned Projects per GitHub docs.
+- Classic PAT has `repo` scope but no `read:project` — ProjectV2 remains
+  invisible without it.
+- GitHub App is the target architecture for stable broad read access but
+  is not yet implemented.
+- Never present fine-grained PAT as a universal solution for the full
+  snapshot surface.
+
+### ProjectV2 visibility
+
+- `read:project` scope is required to read ProjectV2 items via GraphQL.
+- If `read:project` is missing, mark ProjectV2 as a known visibility gap.
+- Do NOT infer ProjectV2 field values from other data sources.
+
+### Rate limit discipline
+
+- Primary: 5,000 requests/hour (authenticated REST).
+- GraphQL: 5,000 points/hour (single-node query = 1 point).
+- Check `/rate_limit` before batch operations.
+- Prefer GraphQL for connected data (issues, PRs, reviews, checks) to
+  reduce request count.
+- Use REST for Actions runs/jobs/logs, labels, commit statuses, contents.
+
+### Fail-closed on auth ambiguity
+
+- If auth scope is unclear, test with a minimal read before assuming access.
+- If a read returns 403/404, record it as a visibility gap, not as "nothing
+  there."
+- Do NOT retry with elevated privileges or different tokens automatically.
+
+## API surface reference
+
+| Sub-operation | Preferred API | Key permission | Known gap |
+|---------------|---------------|---------------|-----------|
+| Status Snapshot | GraphQL + REST | `repo`, `read:project` | ProjectV2 without `read:project` |
+| CI/Checks Readout | REST (Actions, Checks) | `repo` | Fine-grained PAT: no Checks |
+| PR Queue Radar | GraphQL | `repo` | — |
+| Issue Dedupe | REST Search | `repo` | — |
+| API Opportunity Scan | N/A (diagnostic) | — | — |
+| Multi-Repo Snapshot | GraphQL + REST per repo | `repo` per repo | Same per-repo auth gaps |
+| ProjectV2 Reconciliation | GraphQL ProjectV2 | `read:project` | Missing scope = invisible |
+| Rate-Limit Awareness | REST `/rate_limit` | none | — |
+| Permission Safety | N/A (gate) | — | — |
+
+## Official GitHub docs evidence
+
+- REST overview: https://docs.github.com/en/rest/about-the-rest-api/about-the-rest-api
+- GraphQL overview: https://docs.github.com/en/graphql
+- `gh api` manual: https://cli.github.com/manual/gh_api
+- REST rate limits: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+- `GITHUB_TOKEN` permissions: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
+- PAT creation/limits: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+- GitHub App permissions: https://docs.github.com/en/apps/creating-github-apps/setting-up-a-github-app/choosing-permissions-for-a-github-app
+- Fine-grained PAT permissions matrix: https://docs.github.com/en/rest/overview/permissions-required-for-fine-grained-personal-access-tokens
+- Issues REST: https://docs.github.com/en/rest/issues/issues
+- Pull Requests REST: https://docs.github.com/en/rest/pulls/pulls
+- PR Reviews REST: https://docs.github.com/en/rest/pulls/reviews
+- Labels REST: https://docs.github.com/en/rest/issues/labels
+- Commit Statuses REST: https://docs.github.com/en/rest/commits/statuses
+- Contents REST: https://docs.github.com/en/rest/repos/contents
+- Actions workflow runs REST: https://docs.github.com/en/rest/actions/workflow-runs
+- Checks REST: https://docs.github.com/en/rest/checks
+
+## Relationship to existing skills
+
+- `gh-fix-ci`: handles CI fix implementation after this skill identifies
+  the failure picture
+- `gh-address-comments`: handles PR review comment triage after this skill
+  identifies the PR landscape
+- `cdb-ci-cd-guard`: governs CI/CD ruleset compliance; this skill provides
+  the live API data that `cdb-ci-cd-guard` may need
+- `cdb-control-intake`: reads control context; this skill reads live GitHub
+  data as a complementary source
+- `cdb-session-start`: may invoke this skill when session scope touches
+  GitHub live data
+- `docs/github/UNIFIED_GITHUB_STATUS_SNAPSHOT.md`: the detailed reference
+  document for the Status Snapshot sub-operation
+
+## Follow-up issues (proposed, not created)
+
+- `[GITHUB-API][MVP] Build read-only Unified GitHub Status Snapshot CLI`
+- `[GITHUB-API][GRAPHQL] Add reusable ProjectV2/statusCheckRollup query bundle`
+- `[GITHUB-API][AGENTS] Add API Opportunity Scan to CDB/Modusmono agent prompts`
+- `[GITHUB-API][APP] Evaluate GitHub App target architecture`
+
+## Anti-patterns
+
+- Do NOT fire `gh api` calls without checking auth scope first
+- Do NOT treat partial GitHub data as complete truth
+- Do NOT write to GitHub without explicit Plan-GO
+- Do NOT present fine-grained PAT as a universal auth solution
+- Do NOT infer ProjectV2 data when `read:project` is missing
+- Do NOT batch API calls without checking rate limits first
+- Do NOT retry 403 with different credentials automatically
+- Do NOT replace `gh-fix-ci` or `gh-address-comments` with this skill
+- Do NOT read or expose tokens, secrets, or private keys in any output
+- Do NOT create issues, PRs, or comments without Human-GO
+- Do NOT treat Board stage or `trade-capable` as Live-Go; LR remains NO-GO


### PR DESCRIPTION
## Delivered

- Added `docs/skills/SKILL_SURFACE_REGISTRY.md` with 14 mandatory sections:
  1. Executive Summary
  2. Why a registry is needed
  3. Canonical skill surface (`docs/skills/` as monopoly SSOT)
  4. Active skill surfaces
  5. Restricted / non-standard surfaces (`.gemini/`, tooling, archive)
  6. Surface adapter model (`mirrored`, `adapted`, `alias`, `deprecated`)
  7. Required header block in every surface copy
  8. Drift policy
  9. New skill workflow
  10. Skill update workflow
  11. Skill deprecation workflow
  12. Example: `cdb-github-api-ops`
  13. Reference to PR #3569
  14. Follow-up slices

- Added `docs/skills/README.md` as canonical skill index.
- Added canonical `docs/skills/cdb-github-api-ops/SKILL.md` with Surface-Adapter-Header.
- Mirrored `cdb-github-api-ops` to 4 surface adapters:
  - `.opencode/skills/cdb-github-api-ops/SKILL.md` (Surface: opencode)
  - `.cursor/skills/cdb-github-api-ops/SKILL.md` (Surface: cursor)
  - `.codex/cdb_skills/cdb-github-api-ops/SKILL.md` (Surface: codex)
  - `.claude/skills/cdb-github-api-ops/SKILL.md` (Surface: claude)
- Added `.claude/skills/cdb-github-api-ops.skill` index file.
- Registered all skills in surface READMEs and AGENTS.md.
- Added canonical skill source reference line to AGENTS.md and all surface READMEs.

## Permission model

- Broad read, narrow write. Docs-only registry.
- No write or admin permissions included.
- `.gemini` is explicitly restricted and not touched.
- No tokens, no secrets, no GitHub App.

## Official GitHub docs researched

- Not applicable (this is a CDB-governance docs issue, no API endpoint research needed).
- Only CDB-internal skill surfaces were documented.

## Validation

- `git diff --check`: no errors (only CRLF warnings).
- All 5 SKILL.md files exist with correct Surface: header value.
- Canonical source reference `docs/skills/cdb-github-api-ops/SKILL.md` present in all 4 mirrors.
- `cdb-github-api-ops` is listed in AGENTS.md skill table and all surface READMEs.
- Token/secret leak scan: no hits.
- `.gemini/` not touched.

## Non-goals

- No runtime changes
- No token/secret creation
- No GitHub App creation
- No MCP mutations
- No `.gemini/` expansion
- No blanket rewrite of all existing skills
- No issue creation (follow-ups proposed in doc, not created)
- No Modusmono scope

## Follow-ups

Proposed in registry doc (not created):
- `[SKILLS] Apply Surface-Adapter-Header to all existing mirrored skills`
- `[SKILLS] Add drift-reconcile hook for skill surface adapters`
- `[SKILLS] Add skill-meta schema (META.yaml + evals.json) for new CDB domain skills`
- `[SKILLS] Document .gemini/ activation policy if domain skills are ever needed`

## Safety boundaries

- No tokens were read.
- No secrets were output.
- No live admin changes were made.
- No write permissions were added.
- LR remains NO-GO. No live or Echtgeld scope.
- `.gemini/` is explicitly excluded from all skill mirrors.
