### PR TITLE
fix(runner): harden actions runner secret hygiene

### DIFF
--- a/docs/env/index.md
+++ b/docs/env/index.md
@@ -43,6 +43,9 @@ Canon-Pointer:
   - [`infrastructure/scripts/check_env.ps1`](../../infrastructure/scripts/check_env.ps1)
 - Self-hosted Runner Env:
   - [`infrastructure/actions-runner/.env.runner.example`](../../infrastructure/actions-runner/.env.runner.example)
+  - `RUNNER_TOKEN` is bootstrap-only / registration-only; keep `.env.runner*`
+    local-only and out of commits, logs, screenshots, and Docker build context
+  - Do not inherit a foreign/global `COMPOSE_PROJECT_NAME` when launching runner compose files
 
 ## Read-only DB discovery secrets
 

--- a/docs/runbooks/local_ops_artifacts.md
+++ b/docs/runbooks/local_ops_artifacts.md
@@ -17,10 +17,19 @@ with explicit intent.
 
 ## Local-Only Runtime And Secrets
 
-- Keep `.env`, `*.env.runtime`, `.secrets/`, `.mcp.json`, and
-  `infrastructure/actions-runner/.env.runner` local-only.
+- Keep `.env`, `*.env.runtime`, `.secrets/`, `.mcp.json`,
+  `infrastructure/actions-runner/.env.runner`, and
+  `infrastructure/actions-runner/.env.runner2` local-only.
 - Do not relax secret-related ignore rules unless the tracking impact is fully
   understood.
+- Runner bootstrap tokens belong only in local operator files for the shortest
+  possible registration window and must never be promoted into repo artifacts,
+  screenshots, or issue comments.
+- Runner secret files must stay out of Docker build context; see
+  `infrastructure/actions-runner/.dockerignore`.
+- Docker-project isolation for sibling/self-hosted runners remains a separate
+  live ops concern under `#3571`; this policy only covers repo-local artifact
+  and secret hygiene.
 
 ## Local Cache And Tooling State
 

--- a/infrastructure/actions-runner/.dockerignore
+++ b/infrastructure/actions-runner/.dockerignore
@@ -1,0 +1,11 @@
+.env.runner
+.env.runner2
+.env.runner*
+*.log
+tmp/
+temp/
+__pycache__/
+.pytest_cache/
+.ruff_cache/
+README.md
+*.md

--- a/infrastructure/actions-runner/README.md
+++ b/infrastructure/actions-runner/README.md
@@ -8,11 +8,11 @@ Containerized GitHub Actions runner for CDB required checks.
 2. **Configure**:
    ```bash
    cp .env.runner.example .env.runner
-   # paste RUNNER_TOKEN into .env.runner
+   # paste a bootstrap-only RUNNER_TOKEN into .env.runner
    ```
 3. **Start**:
    ```bash
-   docker compose -f infrastructure/actions-runner/docker-compose.runner.yml up -d --build
+   COMPOSE_PROJECT_NAME=cdb_gh_runner docker compose -f infrastructure/actions-runner/docker-compose.runner.yml up -d --build
    ```
 4. **Verify**:
    ```bash
@@ -43,6 +43,10 @@ authenticates with its own credentials stored in `.runner`/`.credentials`.
 A new token is required only when the container is rebuilt from scratch
 or after a manual "Remove runner" in the GitHub UI.
 
+Treat `RUNNER_TOKEN` as a **bootstrap-only / registration-only** credential.
+Do not keep it in plaintext local env files longer than needed for initial
+registration or a deliberate re-registration window.
+
 ## State Persistence
 
 Runner credentials (`.runner`, `.credentials`, `.credentials_rsaparams`,
@@ -60,6 +64,10 @@ rebuilds without re-registration.
 **First-time setup** still requires `RUNNER_TOKEN`. After that, rebuilds
 (`docker compose down && docker compose up -d --build`) do not need a
 new token.
+
+After successful registration, remove or blank the token in `.env.runner`
+unless you are intentionally keeping a short-lived local file for a planned
+re-registration or deregistration step.
 
 ### Complete vs Partial State
 
@@ -127,6 +135,18 @@ runner with Docker socket access.
   and `usermod` — exactly what the entrypoint needs. If Docker-in-Docker is not
   needed for a job, remove the socket mount.
 
+**Secret hygiene:**
+- Never print real `RUNNER_TOKEN` values into logs, issues, commits, PRs, or screenshots.
+- `.env.runner` and `.env.runner2` are local-only ops files, not repo artifacts.
+- Runner secret files are excluded from the local Docker build context via
+  `infrastructure/actions-runner/.dockerignore`.
+
+**Compose-project hygiene:**
+- Do not inherit a foreign/global `COMPOSE_PROJECT_NAME` when starting runner compose files.
+- Set the runner project name deliberately for each launch command so the runner does not
+  collapse into the CDB runtime project in Docker Desktop.
+- Docker-project isolation cleanup remains tracked separately in `#3571`.
+
 ## Runner 2 — Dedicated Merge-Gate Runner
 
 Runner 2 is a second self-hosted runner. It was originally dedicated to
@@ -141,11 +161,11 @@ runner name, volume, and labels — completely independent from Runner 1.
 2. **Configure**:
    ```bash
    cp .env.runner2.example .env.runner2
-   # paste RUNNER_TOKEN into .env.runner2
+   # paste a bootstrap-only RUNNER_TOKEN into .env.runner2
    ```
 3. **Start**:
    ```bash
-   docker compose -f infrastructure/actions-runner/docker-compose.runner2.yml up -d --build
+   COMPOSE_PROJECT_NAME=cdb_gh_runner_2 docker compose -f infrastructure/actions-runner/docker-compose.runner2.yml up -d --build
    ```
 4. **Verify**:
    ```bash
@@ -203,6 +223,9 @@ docker compose -f infrastructure/actions-runner/docker-compose.runner2.yml up -d
 
 If the state volume is deleted or corrupted, a new `RUNNER_TOKEN` is required
 for re-registration.
+
+As with Runner 1, remove or blank the token in `.env.runner2` after successful
+registration unless you are in an intentional re-registration or deregistration window.
 
 ## Rollback
 


### PR DESCRIPTION
Closes #3572

Refs #3571

## Delivered
- add `infrastructure/actions-runner/.dockerignore` to keep runner env files, logs, and local temp/cache artefacts out of the runner build context
- harden `infrastructure/actions-runner/README.md` so `RUNNER_TOKEN` is bootstrap-only / registration-only and must not stay in plaintext local files longer than needed
- document deliberate `COMPOSE_PROJECT_NAME` usage for runner compose launches to avoid accidental project inheritance
- clarify in env/ops docs that `.env.runner*` are local-only ops artefacts and not repo artefacts

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- tools_or_queries: context.search (0 hits), git fetch/status/rev-parse, gh issue view 3572/3571, gh pr list, repo reads under infrastructure/actions-runner docs, read-only docker metadata
- records_or_results: context records=0; live issues #3572/#3571 open; local `.env.runner` and `.env.runner2` exist as ignored local files; no git history for tracked secret files; read-only docker metadata showed inherited compose project grouping
- repo_crosscheck: `AGENTS.md`, `agents/AGENTS.md`, `docs/runbooks/CONTROL_REGISTER.md`, `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`, `infrastructure/actions-runner/*`, `docs/env/index.md`, `docs/runbooks/local_ops_artifacts.md`, `.github/workflows/mcp_runtime.yml`, `.github/workflows/surrealdb-memory-proof.yml`
- impact_on_plan: keep the slice docs/config-only; no token validation, no runner relaunch, no Docker mutation; isolate Docker-project cleanup to #3571
- limitations: no DB-backed context records; no token values read/printed; no live token validity proof

## Validation
- `git diff --check`
- `git status -sb`
- `rg -n "RUNNER_TOKEN|COMPOSE_PROJECT_NAME|env.runner|dockerignore|build context" infrastructure/actions-runner docs`
- `git check-ignore -v infrastructure/actions-runner/.env.runner`
- `git check-ignore -v infrastructure/actions-runner/.env.runner2`

## Safety Boundaries
- no `.env.runner` or `.env.runner2` contents read, printed, or changed
- no token validation or rotation
- no runner registration or deregistration
- no Docker container start/stop/rebuild
- no Windows/global env mutation
- no sample-brain mutation
- no BLUE/RED runtime, DB, MCP, LR, or live-trading change

## Non-goals
- not solving live Docker project cleanup for existing runner containers
- not rotating or expiring existing runner tokens
- not changing self-hosted workflow routing beyond documentation

## Restunsicherheiten
- token validity remains unknown by design in this slice
- existing live runner grouping under inherited `COMPOSE_PROJECT_NAME` remains an ops cleanup item in #3571
- sibling repo `sample-brain` may need its own follow-up hardening outside this repo scope