### PR TITLE
fix(runner): isolate runner Compose project via explicit name: key

### DIFF
--- a/infrastructure/actions-runner/.env.runner.example
+++ b/infrastructure/actions-runner/.env.runner.example
@@ -22,3 +22,8 @@ RUNNER_DEREGISTER_ON_EXIT=false
 # Optional: match host docker-socket GID for non-root access
 # Run `stat -c '%g' /var/run/docker.sock` on the host to find the GID.
 # DOCKER_GID=999
+#
+# COMPOSE_PROJECT_NAME should NOT be set here — the compose file declares its own
+# project name via the `name:` key. A global COMPOSE_PROJECT_NAME override would
+# collapse this runner into the CDB runtime project in Docker Desktop.
+# COMPOSE_PROJECT_NAME=cdb_gh_runner

--- a/infrastructure/actions-runner/.env.runner2.example
+++ b/infrastructure/actions-runner/.env.runner2.example
@@ -25,3 +25,8 @@ RUNNER_DEREGISTER_ON_EXIT=false
 # Optional: match host docker-socket GID for non-root access
 # Run `stat -c '%g' /var/run/docker.sock` on the host to find the GID.
 # DOCKER_GID=999
+#
+# COMPOSE_PROJECT_NAME should NOT be set here — the compose file declares its own
+# project name via the `name:` key. A global COMPOSE_PROJECT_NAME override would
+# collapse this runner into the CDB runtime project in Docker Desktop.
+# COMPOSE_PROJECT_NAME=cdb_gh_runner_2

--- a/infrastructure/actions-runner/README.md
+++ b/infrastructure/actions-runner/README.md
@@ -12,7 +12,7 @@ Containerized GitHub Actions runner for CDB required checks.
    ```
 3. **Start**:
    ```bash
-   COMPOSE_PROJECT_NAME=cdb_gh_runner docker compose -f infrastructure/actions-runner/docker-compose.runner.yml up -d --build
+   docker compose -f infrastructure/actions-runner/docker-compose.runner.yml up -d --build
    ```
 4. **Verify**:
    ```bash
@@ -142,10 +142,13 @@ runner with Docker socket access.
   `infrastructure/actions-runner/.dockerignore`.
 
 **Compose-project hygiene:**
-- Do not inherit a foreign/global `COMPOSE_PROJECT_NAME` when starting runner compose files.
-- Set the runner project name deliberately for each launch command so the runner does not
-  collapse into the CDB runtime project in Docker Desktop.
-- Docker-project isolation cleanup remains tracked separately in `#3571`.
+- Both runner compose files now declare an explicit `name:` (`cdb_gh_runner` / `cdb_gh_runner_2`)
+  so the runner stack always gets its own Compose project regardless of working directory
+  or any inherited `COMPOSE_PROJECT_NAME`.
+- A global or inherited `COMPOSE_PROJECT_NAME` can still override this — do not set
+  `COMPOSE_PROJECT_NAME` globally when running runner compose files.
+- Docker-project isolation cleanup (live migration of existing containers) remains tracked
+  separately in `#3571`.
 
 ## Runner 2 — Dedicated Merge-Gate Runner
 
@@ -165,7 +168,7 @@ runner name, volume, and labels — completely independent from Runner 1.
    ```
 3. **Start**:
    ```bash
-   COMPOSE_PROJECT_NAME=cdb_gh_runner_2 docker compose -f infrastructure/actions-runner/docker-compose.runner2.yml up -d --build
+   docker compose -f infrastructure/actions-runner/docker-compose.runner2.yml up -d --build
    ```
 4. **Verify**:
    ```bash

--- a/infrastructure/actions-runner/docker-compose.runner.yml
+++ b/infrastructure/actions-runner/docker-compose.runner.yml
@@ -1,6 +1,8 @@
 # GitHub Actions Self-Hosted Runner – standalone compose stack
 # Usage: docker compose -f infrastructure/actions-runner/docker-compose.runner.yml up -d --build
 
+name: cdb_gh_runner
+
 services:
   gh_runner:
     build:

--- a/infrastructure/actions-runner/docker-compose.runner2.yml
+++ b/infrastructure/actions-runner/docker-compose.runner2.yml
@@ -1,6 +1,8 @@
 # GitHub Actions Self-Hosted Runner 2 – dedicated merge-gate runner
 # Usage: docker compose -f infrastructure/actions-runner/docker-compose.runner2.yml up -d --build
 
+name: cdb_gh_runner_2
+
 services:
   gh_runner_2:
     build:


### PR DESCRIPTION
## Summary

Add \
ame: cdb_gh_runner\ / \
ame: cdb_gh_runner_2\ to both runner docker-compose files so the runner stack always gets its own Compose project regardless of working directory or any inherited \COMPOSE_PROJECT_NAME\.

Closes \#3571\ Part A (docs/config-only). Issue stays open for Part B (live container migration).

## Changes

| File | Change |
|---|---|
| \docker-compose.runner.yml\ | Added \
ame: cdb_gh_runner\ |
| \docker-compose.runner2.yml\ | Added \
ame: cdb_gh_runner_2\ |
| \README.md\ | Removed \COMPOSE_PROJECT_NAME=...\ prefix from Quick Start commands; updated Compose-project hygiene section |
| \.env.runner.example\ | Documented that \COMPOSE_PROJECT_NAME\ should not be set here |
| \.env.runner2.example\ | Same |

## What this fixes

Before: both runner compose files had no \
ame:\ key. When invoked from the repo root, Docker Compose derived the project name from the working directory (\claire_de_binare\), collapsing runner containers into the default CDB project. This made them appear grouped with CDB runtime containers in Docker Desktop.

After: each runner compose file declares its own project name (\cdb_gh_runner\ / \cdb_gh_runner_2\). The runner stack now appears as a separate project in Docker Desktop, regardless of working directory or inherited \COMPOSE_PROJECT_NAME\.

## What this does NOT do

- No Docker mutation — existing containers continue using their old project labels.
- No runner registration/deregistration.
- No secrets read or token access.
- No CDB runtime changes.
- No LR/Live/Echtgeld-GO.

## What remains

Part B (live container migration) tracked separately in \#3571\: stop existing runner containers, restart with the fixed compose files, verify \com.docker.compose.project\ label.

Refs #3571