### PR TITLE
chore(runner): decommission self-hosted workflow dependencies

### DIFF
--- a/.github/workflows/mcp_runtime.yml
+++ b/.github/workflows/mcp_runtime.yml
@@ -2,8 +2,10 @@ name: mcp-runtime
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "30 3,11,19 * * *"
+
+# Self-hosted runner surface decommissioned in #3575.
+# Keep this workflow as manual-only optional smoke until a future issue decides
+# whether it should stay on GitHub-hosted infrastructure or be removed.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,8 +16,8 @@ permissions:
 
 jobs:
   mcp-runtime:
-    name: MCP Runtime Smoke
-    runs-on: [self-hosted, cdb]
+    name: MCP Runtime Smoke (optional, manual-only)
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/surrealdb-memory-proof.yml
+++ b/.github/workflows/surrealdb-memory-proof.yml
@@ -2,6 +2,8 @@ name: Optional SurrealDB Memory Proof
 
 # Non-required, opt-in proof workflow for #2603/#2606 memory paths.
 # Does NOT gate merges. LR remains NO-GO. No productive memory write.
+# Self-hosted runner dependency removed in #3575; this remains manual-only and
+# optional on GitHub-hosted infrastructure.
 
 on:
   workflow_dispatch:
@@ -34,7 +36,7 @@ permissions:
 jobs:
   surrealdb-memory-proof:
     name: Optional SurrealDB Memory Proof
-    runs-on: [self-hosted, cdb, docker]
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     continue-on-error: true
     env:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Auf `origin/main` sind die juengsten Kern-Cluster gelandet, u. a.:
 - **LR-050 Final Reconcile (#2535):** Child-SSOTs #2526–#2534 plus finales Reconcile-Dokument; Verdikt bleibt **NO-GO** / not ready for live capital.
 - **SurrealDB / Context Phase-2 closeout (#1976):** Grandparent arc geschlossen; Real-Task-Proofs, Wave-Matrix-Recert und Phase-2-Review auf `main`.
 - **Context / MCP tooling hardening (#2847):** Benchmark #2 ratifiziert; Harness PASS / PASS_WITH_LIMITS ohne produktive Writes.
-- **CI / Agent surface (#2994):** Canonical PR-Gate wieder `.github/workflows/ci.yml` auf self-hosted Runner; repo-lokale Skills unter `.codex/cdb_skills/` und `.cursor/skills/`.
+- **CI / Agent surface (#2994/#3405/#3575):** Canonical PR-Gate `.github/workflows/ci.yml` und `policy-gate.yml` laufen GitHub-hosted; self-hosted runner are decommissioned from active workflow dependencies.
 
 Operatives Cockpit: GitHub Issue `#1445`. Aktiver Engineering-Fokus (nicht exhaustiv): `#2440` (LR-030 Shadow/Soak), `#2513` (Trivy upstream tracking, orthogonal).
 

--- a/docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md
+++ b/docs/runbooks/SURREALDB_LOCAL_CONTEXT_RUNTIME.md
@@ -390,18 +390,19 @@ make context-memory-rediscovery-proof
 
 ### Optional GitHub Actions proof (#2721)
 
-Non-required, opt-in workflow for self-hosted runners with the `docker` label.
+Non-required, opt-in workflow on GitHub-hosted infrastructure.
 Does **not** gate merges; failures are informational. LR remains **NO-GO**.
 
 | Item | Value |
 |------|-------|
 | Workflow | `.github/workflows/surrealdb-memory-proof.yml` |
 | Trigger | `workflow_dispatch` only |
-| Runner | `[self-hosted, cdb, docker]` |
+| Runner | `ubuntu-latest` |
 | Permissions | `contents: read` |
 | Inputs | `proof_suite` (`all` / `db-read-only` / `preflight-only`); `attempt_runtime_proof` |
 
-**Runner prerequisites:** Docker, `SECRETS_PATH` with `SURREALDB_ENV`, local query config
+**Runner prerequisites:** GitHub-hosted Docker availability plus any required secrets,
+`SECRETS_PATH` with `SURREALDB_ENV`, local query config
 (`make context-query-config-init`). The workflow runs preflight first; when preflight passes
 and `attempt_runtime_proof=true`, it may invoke the same `make` targets as the operator path
 above and uploads redacted artifacts (`proof_plan.json`, `summary.md`, logs).

--- a/docs/surrealdb/db-runtime-ci-proof-path-v1.md
+++ b/docs/surrealdb/db-runtime-ci-proof-path-v1.md
@@ -46,7 +46,7 @@ compose changes; closing #2606; SurrealDB in required CI (~26 min `context-smoke
 | `make context-claim-evidence-proof` | Claim evidence at rest on run-scoped fixtures (#2719) | No (operator; minutes) |
 | `make context-memory-rediscovery-proof` | Cross-session memory_id+scope rediscovery (#2720) | No (operator; minutes) |
 | `pytest -m local_only` memory proof tests | Same as CLI cycle with env gate | No |
-| `.github/workflows/surrealdb-memory-proof.yml` | Preflight + optional operator proofs on self-hosted Docker runner | No (opt-in `workflow_dispatch` only) |
+| `.github/workflows/surrealdb-memory-proof.yml` | Preflight + optional operator proofs on GitHub-hosted manual workflow | No (opt-in `workflow_dispatch` only) |
 
 **CI policy:** Do not add live SurrealDB to required `.github/workflows/ci.yml`.
 Optional proof workflow: `surrealdb-memory-proof.yml` (#2721) — `continue-on-error: true`,

--- a/infrastructure/actions-runner/README.md
+++ b/infrastructure/actions-runner/README.md
@@ -1,6 +1,11 @@
 # Self-Hosted GitHub Actions Runner
 
-Containerized GitHub Actions runner for CDB required checks.
+Containerized GitHub Actions runner for optional CDB operator workflows.
+
+> Status: self-hosted runner surface decommissioned from active CDB workflow
+> dependencies via #3575. GitHub-hosted required checks remain standard.
+> Re-activation requires a new issue, fresh registration tokens, and explicit
+> Ops-GO.
 
 ## Quick Start
 
@@ -33,7 +38,8 @@ stat -c '%g' /var/run/docker.sock   # find GID on host
 
 Custom labels: `cdb, docker`. The default label `self-hosted` is added
 automatically by GitHub.
-Workflows target: `runs-on: [self-hosted, cdb]`.
+Historical target surface: `runs-on: [self-hosted, cdb]`.
+There is no active default CDB workflow dependency on this label set after #3575.
 
 ## Token Refresh
 
@@ -125,8 +131,10 @@ runner with Docker socket access.
 
 **Rules:**
 - No `pull_request`-triggered workflow may target the self-hosted runner.
-- Self-hosted runners (`cdb-docker-runner-1`, `cdb-docker-runner-2`) are
-  reserved exclusively for `workflow_dispatch` and `schedule` triggers.
+- Self-hosted runners (`cdb-docker-runner-1`, `cdb-docker-runner-2`) are no
+  longer part of the active default workflow surface.
+- Any future re-activation must be explicit, issue-scoped, and use fresh
+  registration tokens plus bounded Ops-GO.
 - Before adding a new `pull_request` workflow on a self-hosted runner, verify
   that it cannot be reached by untrusted fork PRs.
 - Docker socket (`/var/run/docker.sock`) remains mounted in the compose files
@@ -154,8 +162,8 @@ runner with Docker socket access.
 
 Runner 2 is a second self-hosted runner. It was originally dedicated to
 merge-blocking required checks (`ci`, `policy-gate`) — those checks now run on
-GitHub-hosted runners. Runner 2 remains available for `workflow_dispatch` jobs
-that need self-hosted capabilities. It uses its own env file, container name,
+GitHub-hosted runners. Runner 2 is currently decommissioned from the active CDB
+workflow surface. It uses its own env file, container name,
 runner name, volume, and labels — completely independent from Runner 1.
 
 ### Quick Start
@@ -191,8 +199,8 @@ runner name, volume, and labels — completely independent from Runner 1.
 
 Runner 2 custom labels: `cdb`, `docker`, `merge-gate`. The default label
 `self-hosted` is added automatically by GitHub.
-Workflows target: `runs-on: [self-hosted, cdb, docker, merge-gate]` for
-`workflow_dispatch` jobs only.
+Historical target surface: `runs-on: [self-hosted, cdb, docker, merge-gate]`.
+There is no active default CDB workflow dependency on this label set after #3575.
 
 **Important**: `runs-on` with multiple labels is hard label matching. GitHub
 routes the job only to a runner that has **all** specified labels. There is no

--- a/tests/unit/scripts/test_surrealdb_memory_proof_workflow.py
+++ b/tests/unit/scripts/test_surrealdb_memory_proof_workflow.py
@@ -47,9 +47,9 @@ def test_surrealdb_memory_proof_workflow_minimal_permissions() -> None:
 
 
 @pytest.mark.unit
-def test_surrealdb_memory_proof_workflow_uses_self_hosted_docker() -> None:
+def test_surrealdb_memory_proof_workflow_uses_github_hosted_runner() -> None:
     content = WORKFLOW_PATH.read_text(encoding="utf-8")
-    assert "runs-on: [self-hosted, cdb, docker]" in content
+    assert "runs-on: ubuntu-latest" in content
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Closes #3575.
Refs #3571.
Refs #3572.

This PR decommissions the remaining active self-hosted workflow dependencies so
offline self-hosted runners are no longer part of the active CDB workflow
surface.

## Delivered

- `mcp_runtime.yml`
  - removed scheduled execution
  - kept manual-only
  - moved from self-hosted to `ubuntu-latest`
- `surrealdb-memory-proof.yml`
  - remains optional/manual-only
  - moved from self-hosted to `ubuntu-latest`
- documentation updated to mark self-hosted runner surface as decommissioned
  from active workflow dependencies

## Brain Evidence

- `brain_source=repo-only`
- `brain_status=not-used`
- context search for decommission dependency evidence returned no records
- live GitHub runner API showed both self-hosted runners offline
- live open PR checks showed no merge-blocking dependency on self-hosted runners
- repo workflow search found only two remaining self-hosted workflow references:
  - `.github/workflows/mcp_runtime.yml`
  - `.github/workflows/surrealdb-memory-proof.yml`

## Validation

- `rg -n "self-hosted|cdb_gh_runner|cdb_gh_runner_2|merge-gate" .github/workflows docs infrastructure`
- `gh pr list --state open --limit 30`
- `gh pr checks 3532 3530 3529 3528 3524 3523 3515`
- `gh api repos/jannekbuengener/Claire_de_Binare/actions/runners`
- `git diff --check`

Expected outcome after merge:

- no active workflow file under `.github/workflows/` depends on self-hosted runner labels
- required PR checks remain GitHub-hosted
- stale offline GitHub runner records can be removed safely

## Non-goals

- no runner recovery
- no new runner registration
- no token rotation
- no `.env.runner*` reads
- no BLUE/RED runtime mutation
- no sample-brain mutation
- no Dependabot PR changes

## Safety Boundaries

- merge-relevant checks remain `ci (Unit/Integration + Lint gesammelt)` and `policy-gate`
- no open PR currently waits on self-hosted runners
- self-hosted decommission only proceeds after workflow dependency removal

## Remaining notes

- historical docs and ledgers may still reference earlier self-hosted phases; this PR only updates the active workflow/decommission path required for #3575
