### PR TITLE
fix(paper-trading): reconcile Python 3.14 requirements

### DIFF
--- a/tools/paper_trading/Dockerfile
+++ b/tools/paper_trading/Dockerfile
@@ -1,5 +1,5 @@
 # Paper Trading Runner - Containerized Service
-FROM python:3.12-slim-bookworm@sha256:593bd06efe90efa80dc4eee3948be7c0fde4134606dd40d8dd8dbcade98e669c
+FROM python:3.14-slim-bookworm@sha256:4ff4b92a68355dbdb52584ab3391dff8d371a61d4e063468bfd0130e3189c6d9
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \

--- a/tools/paper_trading/requirements.txt
+++ b/tools/paper_trading/requirements.txt
@@ -6,14 +6,10 @@ Flask==3.1.3
 Werkzeug>=3.1.4  # Security: Fix CVEs in Dependabot alerts #339
 
 # Database
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.12
 
 # Message queue
 redis==5.0.1
-
-# Data processing
-pandas==2.1.4
-numpy==1.26.2
 
 # Utilities
 python-dotenv==1.2.2


### PR DESCRIPTION
## Closes #3566, Refs #3524

### Problem
PR #3524 bumps only the Docker base image to Python 3.14, but `tools/paper_trading/requirements.txt` has incompatible pins:
- `psycopg2-binary==2.9.9` -- no cp314 wheel, source build fails (`pg_config not found`)
- `pandas==2.1.4` -- no cp314 wheel, and **dead dependency** (no import found in code)
- `numpy==1.26.2` -- no cp314 wheel, and **dead dependency** (no import found in code)

### Changes
1. `psycopg2-binary==2.9.9` -> `==2.9.12` (cp314 wheel available; already proven in risk/market/reports services)
2. Remove `pandas==2.1.4` and `numpy==1.26.2` (zero imports in `tools/paper_trading/`)
3. Dockerfile: `python:3.12-slim-bookworm` -> `python:3.14-slim-bookworm` (adopts #3524 bump)

### Brain Evidence
- brain_source: repo-only
- brain_status: used
- Active import: `psycopg2` (service.py:35-36)
- Dead imports: pandas, numpy (rg confirms zero hits in `tools/paper_trading/`)
- Cross-service precedent: risk/market/reports already on psycopg2-binary==2.9.12

### Validation
- [x] No pandas/numpy imports in tools/paper_trading/
- [ ] Docker build succeeds
- [ ] Import check passes
- [ ] Python version 3.14 confirmed in image

### Non-goals
- No runtime BLUE/RED changes
- No DB migration
- No other Dependabot PRs touched (#3532, #3523, #3515)
- No pandas/numpy replacement (truly unused)

### Safety Boundaries
- LR remains NO-GO
- No secrets accessed
- No .env contents exposed
- No live/testnet trading

### Open Items
- PyYAML 6.0.1 cp314 wheel availability: pure-Python fallback should work; verify on Docker build
- If build fails due to PyYAML, follow-up pin to >=6.0.2

### Supersedes
This PR supersedes #3524 (Dependabot Dockerfile-only bump) by combining the base-image bump with the required requirements reconcile.
