### PR TITLE
fix(ci): remove invalid worktrees backup pip target

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,19 +18,6 @@ updates:
     commit-message:
       prefix: "deps(pip)"
   # ----------------------------
-  # Worktrees backup (explicitly ignored)
-  # ----------------------------
-  - package-ecosystem: "pip"
-    directory: "/.worktrees_backup"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:05"
-      timezone: "Europe/Berlin"
-    ignore:
-      - dependency-name: "*"
-
-  # ----------------------------
   # GitHub Actions
   # ----------------------------
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
\'
- records_or_results: '.worktrees_backup was erroneously targeted by Dependabot, although it's ignored in .gitignore.'
- repo_crosscheck: 'Confirmed config entry removal.'
- impact_on_plan: 'None.'
- limitations: 'None.'

### Validation
- git diff --check (Passed)
- Verified YAML structure in .github/dependabot.yml

### Safety Boundaries
- No Docker mutation.
- No runtime rebuild.
- No secrets.
- Narrow scope: only dependabot.yml.