### PR TITLE
fix(security): bump grafana image for CVE-2026-33815

### DIFF
--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -114,7 +114,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:13.0.1-security-01-ubuntu@sha256:1d1280584274f875db9db69dace8397396560f95baf4351991c720298b41fff8
+    image: grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084
     container_name: cdb_grafana
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Closes #3499
Refs #3529
Delivered

## Brain Evidence
- context_tool_status: available
- context_trust_level: none
- records_found: none
- brain_source: repo-only
- brain_status: not-used
- repo_fallback_reason: insufficient_evidence

## Candidate Scan Evidence
Scanned official `grafana/grafana` candidates after #3529 left `CVE-2026-33815` present in `13.0.1-security-01-ubuntu`.

Chosen clean candidate:
- `grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084`
- Trivy result: `CVE-2026-33815` -> `NO_MATCH`
- Total HIGH/CRITICAL findings in candidate scan: `0`

Previously checked candidates before choosing this one:
- `grafana/grafana:13.0.3`
- `grafana/grafana:13.1.0-ubuntu`

## Validation
- `git diff --check`
- diff scope verified: only `infrastructure/compose/compose.red.yml`
- line scope verified: only `cdb_grafana` image reference changed
- candidate image Trivy scan shows `CVE-2026-33815: NO_MATCH`

## Non-goals
- No dashboard changes
- No datasource changes
- No RED-wide recreate
- No BLUE changes
- No workflow changes

## Safety Boundaries
- Official `grafana/grafana` image only
- Digest pinned
- Runtime recreate limited to `cdb_grafana` after merge only
- No code-scanning dismissals
- No LR/live-trading scope

## Restunsicherheiten
- Final closure still depends on merged-main recreate of `cdb_grafana` and fresh Trivy scan against the running image.