### PR TITLE
docs(governance): reconcile grafana service catalog image

### DIFF
--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -121,7 +121,7 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 | Service | Container | Image | Port | Status | Funktion |
 |---------|-----------|-------|------|--------|----------|
 | **Prometheus** | cdb_prometheus | prom/prometheus:v3.11.3 | 19090→9090 | **AKTIV** | Metrics Collection |
-| **Grafana** | cdb_grafana | grafana/grafana:12.4.3-security-02-ubuntu@sha256:089f9dbb | 3000 | **AKTIV** | Dashboards |
+| **Grafana** | cdb_grafana | grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084 | 3000 | **AKTIV** | Dashboards |
 | **Postgres Exporter** | cdb_postgres_exporter | prometheuscommunity/postgres-exporter | 9187 | **AKTIV** | PG Metrics; DSN-Wiring ueber `postgres_password` Secret + `PGPASSWORD`, `DATA_SOURCE_NAME` wird zur Laufzeit aus `POSTGRES_USER`/`POSTGRES_DB` und Host/Port zusammengesetzt |
 | **Redis Exporter** | cdb_redis_exporter | bitnami/redis-exporter | 9121 | **AKTIV** | Redis Metrics |
 | **cAdvisor** | cdb_cadvisor | gcr.io/cadvisor/cadvisor:v0.49.2 | — | **AKTIV** | Container Metrics |


### PR DESCRIPTION
Closes #3586
Closes #3583
Refs #3529
Refs #3585

## Delivered
- update `knowledge/governance/SERVICE_CATALOG.md` so the `cdb_grafana` image pin matches the current `infrastructure/compose/compose.red.yml` truth
- keep the change scoped to the single Grafana service-catalog entry

## Validation
- `git diff --check`
- repo crosscheck: `infrastructure/compose/compose.red.yml` vs `knowledge/governance/SERVICE_CATALOG.md`
- diff scope check: only `knowledge/governance/SERVICE_CATALOG.md` changed

## Non-goals
- no compose changes
- no Docker/runtime changes
- no Dockerfile or requirements changes
- no architecture map rewrite beyond this catalog drift

## Safety Boundaries
- docs-only fix
- no Docker commands
- no runtime recreate/rebuild
- no secrets read
- no DB/MCP/LR/live-trading mutation

## Restunsicherheiten
- runtime state itself was not inspected; this PR only reconciles repo canon
- other Grafana follow-ups, if any, remain out of scope unless separately evidenced