### PR TITLE
docs(architecture): sync architecture map after control reconciliation

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -3,12 +3,14 @@
 **Status Class**: Working Repo / Engineering Status
 **Authority**: Current repo/main/test/dependency snapshot; not the canonical live-readiness or Echtgeld Go/No-Go source.
 **Operational Canon**: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-**Last Updated**: 2026-06-30
+**Last Updated**: 2026-07-01
 **GitHub Boundary**: The live commit and PR state is tracked in GitHub (UI/API or `gh`); this file is a curated repo/engineering ledger, not a live mirror.
 
 ---
 
-## Repo / Engineering Status (2026-06-30)
+## Repo / Engineering Status (2026-07-01)
+
+- **Architecture docs sync after Dependabot #3528/#3530 / PR pending / merge SHA TBD**: IN PROGRESS on branch `docs/3593-architecture-sync`. `SERVICE_CATALOG.md` Redis `8.8.0-alpine` + `ARCHITECTURE_MAP.md` changelog/image-SSOT cross-ref + `ARCHITECTURE_COCKPIT.md` canonical doc links. Closes #3593. Refs #3595, #3601, #3602, #3603. Runtime rebuilds (#3592, #3594, #3600) remain open. LR NO-GO.
 
 - **Control docs reconcile after Dependabot #3528/#3530 / PR #3602 / `40910d7e`**: MERGED. `CONTROL_REGISTER.md` workflow-control notes for Redis `8.8.0-alpine` (#3528) and Postgres `18.4-alpine` (#3530) semver-major bumps in `security-scan.yml`. Closes #3595, #3601. Runtime rebuilds (#3592, #3594, #3600) and architecture sync (#3593) out of scope. LR NO-GO.
 

--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -10,7 +10,7 @@
 
 ## Repo / Engineering Status (2026-07-01)
 
-- **Architecture docs sync after Dependabot #3528/#3530 / PR pending / merge SHA TBD**: IN PROGRESS on branch `docs/3593-architecture-sync`. `SERVICE_CATALOG.md` Redis `8.8.0-alpine` + `ARCHITECTURE_MAP.md` changelog/image-SSOT cross-ref + `ARCHITECTURE_COCKPIT.md` canonical doc links. Closes #3593. Refs #3595, #3601, #3602, #3603. Runtime rebuilds (#3592, #3594, #3600) remain open. LR NO-GO.
+- **Architecture docs sync after Dependabot #3528/#3530 / PR #3604 / merge SHA pending**: DOCS PR. `SERVICE_CATALOG.md` Redis `8.8.0-alpine` + `ARCHITECTURE_MAP.md` changelog/image-SSOT cross-ref + `ARCHITECTURE_COCKPIT.md` canonical doc links. Closes #3593. Refs #3595, #3601, #3602, #3603. Runtime rebuilds (#3592, #3594, #3600) remain open. LR NO-GO.
 
 - **Control docs reconcile after Dependabot #3528/#3530 / PR #3602 / `40910d7e`**: MERGED. `CONTROL_REGISTER.md` workflow-control notes for Redis `8.8.0-alpine` (#3528) and Postgres `18.4-alpine` (#3530) semver-major bumps in `security-scan.yml`. Closes #3595, #3601. Runtime rebuilds (#3592, #3594, #3600) and architecture sync (#3593) out of scope. LR NO-GO.
 

--- a/knowledge/ARCHITECTURE_COCKPIT.md
+++ b/knowledge/ARCHITECTURE_COCKPIT.md
@@ -7,6 +7,11 @@
 - **Working Repo Code**: GitHub-Link mit Branch-Placeholder:  
   `https://github.com/jannekbuengener/Claire_de_Binare/blob/{{BRANCH}}/<path>`
 
+## Kanonische Architektur-Docs
+
+- [ARCHITECTURE_MAP.md](./ARCHITECTURE_MAP.md) — BLUE/RED-Topologie, Service Map, Redis-Channels
+- [SERVICE_CATALOG.md](./governance/SERVICE_CATALOG.md) — Service-Inventar inkl. pinned Base-Images (`cdb_postgres`, `cdb_redis`)
+
 ---
 
 ## 🗺️ Systemkarte (20-Sekunden-Überblick)

--- a/knowledge/ARCHITECTURE_MAP.md
+++ b/knowledge/ARCHITECTURE_MAP.md
@@ -247,6 +247,8 @@ logging.yml        -> Logging Overlay (Loki + Promtail + Alertmanager) [separate
 
 Legacy-Layer (base.yml, dev.yml, tls.yml, etc.) existieren noch, sind nicht mehr kanonisch.
 
+Kanonische Image-Pins fuer BLUE-Datenlayer (`cdb_postgres`, `cdb_redis`): `governance/SERVICE_CATALOG.md` § Infrastruktur-Services (Spiegel von `compose.blue.yml`).
+
 ---
 
 ## Changelog
@@ -271,6 +273,7 @@ Legacy-Layer (base.yml, dev.yml, tls.yml, etc.) existieren noch, sind nicht mehr
 | 2026-06-05 | PRs #2989/#2992/#3006 Nachzug: `paper_runtime_stimulus_runner.py` als runtime-adjacent ARVP operator CLI dokumentiert; `stimulus_fixture`-Events mit `stimulus_run_id` erzeugen deterministische `signal_id`s fuer exportierbare paper chains. Kein Live-Go; keine DB-Schreibfläche (Issues #2990/#2993/#3008) | Codex |
 | 2026-06-06 | PRs #3016/#3019/#3022 Nachzug: `paper_runtime_stimulus_runner.py` Determinismus-Härtung (`stimulus_run_id` -> `signal_id`) und Wall-Clock-Override für Stimulus-Freshness (RC_004 Safety) in `cdb_market` und `cdb_candles` dokumentiert (Issues #3017/#3020/#3023) | Codex |
 | 2026-06-08 | PR #3081 Nachzug: `historical_bridge.py` + `evaluate_price_policies.py` als Replay-Infrastruktur-Komponenten dokumentiert; `price_policy`-Support vermerkt (Issue #3082) | Codex |
+| 2026-07-01 | PRs #3528/#3530 Nachzug (#3593): BLUE base images Redis `8.8.0-alpine` / Postgres `18.4-alpine`; Image-SSOT-Hinweis in §7 Compose Layer Referenz; Runtime-Recreate bleibt #3594/#3600 | Cursor |
 ### PostgreSQL Schema Artefacts (PR #2793)
 
 | Artifact | Migration | Status | Bedeutung |

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -114,7 +114,7 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 | Service | Container | Image | Port | Status | Funktion |
 |---------|-----------|-------|------|--------|----------|
 | **PostgreSQL** | cdb_postgres | postgres:18.4-alpine | 5432 | **AKTIV** | Persistenz |
-| **Redis** | cdb_redis | redis:7.4.8-alpine | 6379 | **AKTIV** | Cache, Pub/Sub, Streams |
+| **Redis** | cdb_redis | redis:8.8.0-alpine | 6379 | **AKTIV** | Cache, Pub/Sub, Streams |
 
 ### RED Stack (compose.red.yml) — Monitoring
 
@@ -275,6 +275,7 @@ Referenz: `infrastructure/compose/SERVICE_MAPPING.md`, PR #2670.
 | 2026-06-18 | Audit #3302: Entfernte-Services-Sektion ergänzt; cdb_node_exporter als LEGACY mit Decommission-Datum, Grund, Alternative, erwartetem Runtime-Zustand und Runbook-Prüfpfad dokumentiert; Prüf-Checkliste um Legacy-Check ergänzt | Codex |
 | 2026-06-18 | Audit #3304: `lr030_soak_monitor` + `lr040_soak_monitor` als LEGACY dokumentiert; Container decommissioned, Windows-Tasks `CDB_LR040_SoakMonitor` + `CDB_Soak_Sidecar` deaktiviert; Runbooks um Windows-Scheduler-Cleanup ergänzt | OpenCode |
 | 2026-06-18 | Audit #3305: MockX Valkey als non-canonical dev/test reference infra dokumentiert; Expected-State `absent by default`; Boundary `mockx-valkey` ist nicht CDB-canonical Redis und darf `cdb_redis` nie ersetzen; Refs #1648 | OpenCode |
+| 2026-07-01 | PRs #3528/#3530 Nachzug (#3593): BLUE base images — Redis `8.8.0-alpine`, Postgres `18.4-alpine` — mit `compose.blue.yml` synchron; Runtime-Recreate bleibt #3594/#3600 | Cursor |
 ## PostgreSQL Schema Artefacts
 
 | Artefakt | Migration | Status | Bedeutung |

--- a/knowledge/logs/sessions/2026-07-01-issue-3593-architecture-sync.md
+++ b/knowledge/logs/sessions/2026-07-01-issue-3593-architecture-sync.md
@@ -1,0 +1,52 @@
+# Session Log: 2026-07-01 — Issue #3593 Architecture Docs Sync
+
+## Auftrag
+
+Docs-only Reconciliation: `ARCHITECTURE_MAP`, `ARCHITECTURE_COCKPIT` und `SERVICE_CATALOG` nach Dependabot-Merges #3528 (Redis 8.8) und #3530 (Postgres 18) sowie Control-Reconcile #3602/#3603 synchronisieren. Closes #3593.
+
+## Ausgangslage
+
+- PR #3528 (`9a4ea814`): Redis `7.4.9-alpine` → `8.8.0-alpine` in Compose + `security-scan.yml`; `SERVICE_CATALOG` nicht nachgezogen
+- PR #3530 (`7973a66f`): Postgres `15.17-alpine` → `18.4-alpine` in Compose; `SERVICE_CATALOG` Postgres-Zeile aktualisiert, Redis blieb `7.4.8-alpine`
+- PR #3602/#3603: `CONTROL_REGISTER` + Ledger für Control-Reconcile — `ARCHITECTURE_MAP` explizit out of scope (#3593)
+- `origin/main`: `f5cb5932`
+
+## Befund (real drift)
+
+| Datei | Drift | Fix |
+|---|---|---|
+| `knowledge/governance/SERVICE_CATALOG.md` | Redis `7.4.8-alpine` vs Compose `8.8.0-alpine` | → `redis:8.8.0-alpine` |
+| `knowledge/ARCHITECTURE_MAP.md` | Kein Changelog/Image-SSOT-Hinweis für #3528/#3530 | Changelog + §7 Hinweis |
+| `knowledge/ARCHITECTURE_COCKPIT.md` | Keine Links zu kanonischen Arch-Docs | Cross-Ref-Block ergänzt |
+
+Out of scope: `redis_aof_corruption_recovery.md` (noch `7.4.9`), Runtime-Rebuilds #3592/#3594/#3600.
+
+## Implementierung
+
+| Datei | Änderung |
+|---|---|
+| `knowledge/governance/SERVICE_CATALOG.md` | Redis image + Changelog #3593 |
+| `knowledge/ARCHITECTURE_MAP.md` | §7 Image-SSOT-Hinweis + Changelog |
+| `knowledge/ARCHITECTURE_COCKPIT.md` | Kanonische Architektur-Docs Block |
+| `CURRENT_STATUS.md` | Ledger-Eintrag #3593 |
+| `knowledge/logs/sessions/2026-07-01-issue-3593-architecture-sync.md` | Dieses Log |
+
+Branch: `docs/3593-architecture-sync` von `origin/main` (`f5cb5932`).
+
+## Validation
+
+- `git diff --check`: pending
+- Stale image tags in primary architecture docs: pending
+- Diff docs-only: pending
+
+## Safety Boundaries
+
+- LR NO-GO unverändert
+- Keine Compose/Docker/Runtime/Secret/DB-Mutation
+- Redis = Runtime/Messaging; SurrealDB = Brain (unberührt)
+
+## Merge / Close
+
+- PR: pending
+- Merge SHA: pending
+- Issue #3593: pending close after merge


### PR DESCRIPTION
## Summary

- Sync `SERVICE_CATALOG.md` Redis base image `7.4.8-alpine` → `8.8.0-alpine` (matches `compose.blue.yml` after #3528)
- Add `ARCHITECTURE_MAP.md` changelog + §7 image-SSOT cross-ref to SERVICE_CATALOG
- Add canonical architecture doc links in `ARCHITECTURE_COCKPIT.md`
- Update `CURRENT_STATUS.md` ledger + session log

Closes #3593
Refs #3595
Refs #3601
Refs #3602
Refs #3603

## Delivered

- `knowledge/governance/SERVICE_CATALOG.md` — Redis `8.8.0-alpine`, changelog row
- `knowledge/ARCHITECTURE_MAP.md` — §7 image-SSOT hint, changelog
- `knowledge/ARCHITECTURE_COCKPIT.md` — links to MAP + CATALOG
- `CURRENT_STATUS.md` — #3593 ledger entry
- `knowledge/logs/sessions/2026-07-01-issue-3593-architecture-sync.md`

## Brain Evidence

```text
brain_source: repo-only
brain_status: not-used
tools_or_queries: git show origin/main, rg image tags, gh issue/pr view
records_or_results: SERVICE_CATALOG Redis drift confirmed vs compose.blue.yml
repo_crosscheck: compose.blue.yml redis:8.8.0-alpine, postgres:18.4-alpine
impact_on_plan: docs-only Redis sync + changelog/cross-refs
limitations: no DB-backed brain; runtime rebuilds remain open
context_brain_attempted: true
context_brain_used: false
context_available: false
repo_fallback_used: true
repo_fallback_reason: insufficient_evidence
context_tool_status: available
context_trust_level: none
records_found: none
```

## Validation

- `git diff --check` — pass
- Diff is docs-only (5 markdown files)
- `rg` stale tags: none in primary architecture docs (SERVICE_CATALOG shows `8.8.0` / `18.4`)

## Non-goals

- Runtime rebuilds #3592, #3594, #3600
- `redis_aof_corruption_recovery.md` (still references Redis 7.4.9)
- Compose/Docker/Secrets/Runtime changes

## Safety Boundaries

- LR NO-GO unchanged
- Redis = Runtime/Cache/Messaging; SurrealDB = Brain — boundary preserved
- No productive DB writes, no MCP mutations, no BLUE/RED runtime changes

## Restunsicherheiten

- Local runtime may still run old Redis/Postgres images until operator executes #3594/#3600
- Historical security evidence docs retain point-in-time image references

## Test plan

- [x] Docs-only diff verified
- [x] Image tag cross-check vs `compose.blue.yml`
- [ ] CI + policy-gate green
