### PR TITLE
fix(monitoring): restore redis exporter health after Redis upgrade

### DIFF
--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -153,7 +153,11 @@ services:
     depends_on:
       - cdb_redis
     healthcheck:
-      test: ["CMD-SHELL", "nc -z localhost 9121 || exit 1"]
+      test:
+        [
+          "CMD-SHELL",
+          "bash -c 'exec 3<>/dev/tcp/127.0.0.1/9121' || exit 1",
+        ]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -183,7 +183,11 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command: ["exec redis_exporter --redis.addr=redis://cdb_redis:6379 --redis.password=$$(cat /run/secrets/redis_password | tr -d '\\n')"]
     healthcheck:
-      test: ["CMD-SHELL", "nc -z localhost 9121 || exit 1"]
+      test:
+        [
+          "CMD-SHELL",
+          "bash -c 'exec 3<>/dev/tcp/127.0.0.1/9121' || exit 1",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

- Replace `nc -z localhost 9121` redis_exporter healthcheck with a bash `/dev/tcp` probe in `base.yml` and `compose.red.yml`.
- Root cause: `bitnami/redis-exporter:latest` has no `nc`/`wget`/`curl`; exporter metrics were healthy but Docker health failed for 1768+ streaks.

Closes #3606

## Delivered

- Compose healthcheck fix for `cdb_redis_exporter` only (monitoring scope).

## Root Cause

`redis_healthy_but_exporter_probe_wrong` — stale `nc`-based probe incompatible with bitnami image; logs showed `nc: command not found` while `:9121/metrics` returned HTTP 200.

## Brain Evidence

- `brain_source`: repo-only
- `brain_status`: not-used
- Runtime diagnosis: docker logs/inspect + curl metrics endpoint

## Runtime Evidence

- Before: `cdb_redis_exporter` unhealthy, health log `nc: command not found`
- After recreate with fix: `Up (healthy)`, health ExitCode 0
- `cdb_redis` remains `redis:8.8.0-alpine` healthy; `cdb_postgres` `18.4-alpine` healthy
- `stack verify`: 10/10 core services OK

## Validation

- [x] `docker compose config` valid (local)
- [x] `cdb_redis_exporter` healthy after `--force-recreate --no-deps`
- [x] Metrics endpoint HTTP 200
- [x] No Redis/Postgres mutation

## Non-goals

- No Redis/Postgres recreate or volume changes
- No Prometheus/Grafana refactor
- No secret value changes

## Safety Boundaries

- LR NO-GO unchanged; monitoring-only fix

## Restunsicherheiten

- `base.yml` CI-lab path shares the same probe; postgres_exporter still uses `nc` (available in that image)
