### PR TITLE
docs(status): ledger runtime rebuild batch and redis exporter fix #3606

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -10,9 +10,13 @@
 
 ## Repo / Engineering Status (2026-07-01)
 
-- **Architecture docs sync after Dependabot #3528/#3530 / PR #3604 / `f20ef70b`**: MERGED. `SERVICE_CATALOG.md` Redis `8.8.0-alpine` + `ARCHITECTURE_MAP.md` changelog/image-SSOT cross-ref + `ARCHITECTURE_COCKPIT.md` canonical doc links. Closes #3593. Refs #3595, #3601, #3602, #3603. Runtime rebuilds (#3592, #3594, #3600) remain open. LR NO-GO.
+- **Redis exporter health #3606 / PR #3607 / `498c8b5a`**: MERGED. `cdb_redis_exporter` healthcheck von `nc -z` auf bash `/dev/tcp` umgestellt (`base.yml`, `compose.red.yml`); Ursache: `bitnami/redis-exporter` ohne `nc`. Runtime recreate exporter only → **healthy**. Closes #3606. LR NO-GO.
 
-- **Control docs reconcile after Dependabot #3528/#3530 / PR #3602 / `40910d7e`**: MERGED. `CONTROL_REGISTER.md` workflow-control notes for Redis `8.8.0-alpine` (#3528) and Postgres `18.4-alpine` (#3530) semver-major bumps in `security-scan.yml`. Closes #3595, #3601. Runtime rebuilds (#3592, #3594, #3600) and architecture sync (#3593) out of scope. LR NO-GO.
+- **Runtime rebuild batch (operator sessions)**: #3592 CI-Lab Python 3.14 CLOSED; #3594 Redis `8.8.0-alpine` CLOSED; #3600 Postgres `18.4-alpine` dump/restore CLOSED. Stack verify 10/10. LR NO-GO.
+
+- **Architecture docs sync after Dependabot #3528/#3530 / PR #3604 / `f20ef70b`**: MERGED. Closes #3593. LR NO-GO.
+
+- **Control docs reconcile after Dependabot #3528/#3530 / PR #3602 / `40910d7e`**: MERGED. Closes #3595, #3601. LR NO-GO.
 
 - **#3441 ContextBrain Report / Gist Ledger Integration / PR #3441 / `76ac249a`**: MERGED. Report template, Gist-Ledger-Zielreferenz, Decision-Event-Ledger-Format, Foundation-Status-Matrix. `docs/surrealdb/context-brain-report-gist-ledger-v0.md`. Gist-URL dokumentiert (kein Live-Posting). Closes #3427. Closes meta #3418 (all 9 children previously CLOSED). LR NO-GO.
 

--- a/knowledge/logs/sessions/2026-07-01-issue-3594-redis-rebuild.md
+++ b/knowledge/logs/sessions/2026-07-01-issue-3594-redis-rebuild.md
@@ -1,0 +1,111 @@
+# Session Log: 2026-07-01 — Issue #3594 Redis Runtime Rebuild
+
+## Auftrag
+
+Operator-GO Phase 2: `cdb_redis` Image-Recreate von `redis:7.4.9-alpine` auf `redis:8.8.0-alpine` (PR #3528 Nachzug), Volume `claire_de_binare_redis_data` beibehalten, Backup-Basis `F:\Claire_Backups\cdb_backup_20260701_022424.zip`. Closes #3594 bei PASS.
+
+## Scope / Boundaries
+
+- Autorisiert: Redis stop/recreate, Volume-Tarball, Validierung, Stack verify, Issue close
+- Nicht autorisiert: Postgres (#3600), Volume delete, `compose down -v`, SurrealDB-Mutationen
+- LR: NO-GO (unverändert)
+
+## Preflight
+
+| Check | Ergebnis |
+|---|---|
+| Backup | `F:\Claire_Backups\cdb_backup_20260701_022424.zip` — 129 775 436 B; manifest Redis+Postgres PASS |
+| Compose-Projekt | `claire_de_binare` (nicht `cdb-blue` aus Compose `name:`) — Recreate mit `-p claire_de_binare` |
+| Volume | `claire_de_binare_redis_data` → `/data` |
+| SECRETS_PATH | vorhanden (nicht geloggt) |
+| Postgres (unchanged) | `postgres:15.18-alpine@sha256:df7bca0066e6…` |
+
+## Before Baseline
+
+| Item | Wert |
+|---|---|
+| Image | `redis:7.4.9-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99` |
+| PING | PONG |
+| DBSIZE | 12 |
+| redis_version | 7.4.9 |
+| market_state:BTCUSDT | string |
+
+### Stream XLEN (Before)
+
+| Stream | XLEN |
+|---|---|
+| stream.candles_1m | 100030 |
+| stream.regime_signals | 10042 |
+| stream.signals | 10009 |
+| stream.orders | 10013 |
+| stream.allocation_decisions | 252 |
+| stream.order_results | 10013 |
+| stream.fills | 10013 |
+| stream.orders_blocked | 10010 |
+
+## Phase 1 — Volume Tarball
+
+| Feld | Wert |
+|---|---|
+| Pfad | `artifacts/redis_rebuild_3594_20260701_023436/redis_data_full.tar.gz` |
+| Größe | 16 141 604 B |
+| SHA256 | `DAF7A6C4415379D354DF377BB6F6427CBB5DD69E8CDE9D5AA68F862E19F4B4DF` |
+
+## Phase 2 — Recreate
+
+```powershell
+docker stop cdb_redis
+docker compose -p claire_de_binare -f infrastructure/compose/compose.blue.yml up -d --force-recreate --no-deps cdb_redis
+```
+
+After Image: `redis:8.8.0-alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005`
+
+AOF-Log: keine Parse-/Format-Fehler; `Ready to accept connections`
+
+## Phase 3 — After Validation
+
+| Gate | Ergebnis |
+|---|---|
+| PING | PONG |
+| DBSIZE | 12 |
+| redis_version | 8.8.0 |
+| AOF | clean |
+| market_state:BTCUSDT | string |
+
+### Stream XLEN (After)
+
+| Stream | Before | After |
+|---|---|---|
+| stream.candles_1m | 100030 | 100031 |
+| stream.regime_signals | 10042 | 10043 |
+| stream.signals | 10009 | 10009 |
+| stream.orders | 10013 | 10013 |
+| stream.allocation_decisions | 252 | 254 |
+| stream.order_results | 10013 | 10013 |
+| stream.fills | 10013 | 10013 |
+| stream.orders_blocked | 10010 | 10010 |
+
+Stream-Probe: `XREVRANGE stream.candles_1m + - COUNT 1` liefert Eintrag (read-only).
+
+## Phase 4 — Dependents
+
+Alle geprüften Services healthy — kein sequentieller Restart erforderlich:
+
+`cdb_db_writer`, `cdb_candles`, `cdb_regime`, `cdb_allocation`, `cdb_signal`, `cdb_risk`, `cdb_execution`, `cdb_paper_runner`, `cdb_market`, `cdb_ws`
+
+Postgres unverändert: `postgres:15.18-alpine`, healthy.
+
+## Phase 5 — Stack Verify
+
+```
+.\tools\cdb.ps1 stack verify -Verbose
+Services healthy: 10/10
+Stack is healthy
+Exit code: 0
+```
+
+Logging overlay (cdb_loki/cdb_promtail) excluded per default — bekannt, non-blocking.
+
+## Ergebnis
+
+**PASS** — Redis runtime rebuild #3594 abgeschlossen. #3600 (Postgres rebuild) bleibt offen.

--- a/knowledge/logs/sessions/2026-07-01-issue-3600-postgres-migration.md
+++ b/knowledge/logs/sessions/2026-07-01-issue-3600-postgres-migration.md
@@ -1,0 +1,61 @@
+# Session Log: 2026-07-01 — Issue #3600 Postgres Runtime Migration
+
+## Auftrag
+
+Operator-GO Phase 3: `cdb_postgres` Migration von `postgres:15.18-alpine` auf `postgres:18.4-alpine` (PR #3530 Nachzug) via dump/restore. Volume `claire_de_binare_postgres_data`; Backup-Basis `F:\Claire_Backups\cdb_backup_20260701_024024.zip`. Closes #3600 bei PASS.
+
+## Scope / Boundaries
+
+- Autorisiert: Postgres stop/recreate, Volume-Tarball, pg_dump restore, Validierung, Stack verify, Issue close
+- Nicht autorisiert: Volume delete (`-v`), Redis restore from backup (Redis bereits #3594 auf 8.8.0), LR/Live-Go
+- LR: NO-GO (unverändert)
+
+## Preflight
+
+| Check | Ergebnis |
+|---|---|
+| Backup (pre-migration) | `F:\Claire_Backups\cdb_backup_20260701_024024.zip` — Postgres+Redis PASS, 123.76 MB |
+| Volume tarball | `artifacts/postgres_rebuild_3600_20260701_024237/postgres_data_full.tar.gz` — 194 452 677 B, SHA256 `41335A0D3E2DB3BC9BCFFF7C1B0EBC0A3A55DD3D6D1FE57E9AD69C349CD81D6B` |
+| Compose-Projekt | `claire_de_binare` |
+| Redis (unchanged) | `redis:8.8.0-alpine` healthy (#3594) |
+
+## Before Baseline (PG15)
+
+| Item | Wert |
+|---|---|
+| Image | `postgres:15.18-alpine` |
+| Mount | `claire_de_binare_postgres_data` → `/var/lib/postgresql/data` |
+| orders | 10511 |
+| trades | 9963 |
+| signals | 221161 |
+
+## Migration Steps
+
+1. `make backup` → `cdb_backup_20260701_024024.zip`
+2. Stopped: `cdb_db_writer`, `cdb_execution`, `cdb_risk`, `cdb_paper_runner`, `cdb_signal`, `cdb_reports`, `cdb_postgres_exporter`, `cdb_postgres`
+3. First recreate → **PG18 crash loop** (PG15 data at volume root incompatible with PG18 mount layout)
+4. Archived PG15 cluster files to volume `.pg15_archived/` (tarball + pg_dump retained)
+5. Second recreate → PG18 fresh init on `/var/lib/postgresql` — healthy
+6. Restore: `docker cp` dump + `psql -f /tmp/postgres_dump.sql` (exit 0, ~4 min)
+
+## After Validation (PG18)
+
+| Gate | Ergebnis |
+|---|---|
+| Image | `postgres:18.4-alpine@sha256:1b1689b20d16a014a3d195653381cf2caa75a41a92d93b255a9d6ea29fd353aa` |
+| Version | PostgreSQL 18.4 |
+| Mount | `claire_de_binare_postgres_data` → `/var/lib/postgresql` |
+| orders | 10511 (match) |
+| trades | 9963 (match) |
+| signals | 221161 (match) |
+| stack verify | 10/10 healthy, exit 0 |
+
+## Ergebnis
+
+**PASS** — Postgres runtime migration #3600 abgeschlossen. Runtime matches repo compose pins for both data layer services (Redis 8.8.0 + Postgres 18.4).
+
+## Restgaps (non-blocking)
+
+- `cdb_redis_exporter` weiterhin unhealthy (pre-existing)
+- Volume enthält `.pg15_archived/` — optional cleanup in separatem Ops-GO
+- `stack verify` Volumes/Networks count 0/6 — verify-script quirk, services 10/10 OK

--- a/knowledge/logs/sessions/2026-07-01-issue-3606-redis-exporter-health.md
+++ b/knowledge/logs/sessions/2026-07-01-issue-3606-redis-exporter-health.md
@@ -1,0 +1,44 @@
+# Session Log: 2026-07-01 — Issue #3606 Redis Exporter Health
+
+## Auftrag
+
+Diagnose und Fix für `cdb_redis_exporter` unhealthy nach Redis 8.8 Rebuild (#3594). Autonomer Slice: Fix, PR, Merge, Issue close.
+
+## Root Cause
+
+`redis_healthy_but_exporter_probe_wrong`
+
+- Exporter liefert Metriken (`:9121/metrics` HTTP 200, Logs ohne Auth-Fehler)
+- Docker-Healthcheck: `nc -z localhost 9121`
+- `bitnami/redis-exporter:latest` hat **kein** `nc`, `wget`, oder `curl`
+- Health-Log: `/bin/sh: line 1: nc: command not found` (FailingStreak 1768+)
+
+## Fix
+
+`infrastructure/compose/base.yml` + `compose.red.yml`:
+
+```yaml
+test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/9121' || exit 1"]
+```
+
+Bash `/dev/tcp` ist im Image verfügbar und prüft Port 9121 ohne externe Tools.
+
+## Runtime Validation
+
+| Check | Ergebnis |
+|---|---|
+| Recreate | `docker compose -p claire_de_binare -f compose.red.yml up -d --force-recreate --no-deps cdb_redis_exporter` |
+| Exporter | **healthy** (ExitCode 0) |
+| `cdb_redis` | `redis:8.8.0-alpine` healthy (unverändert) |
+| `cdb_postgres` | `postgres:18.4-alpine` healthy (unverändert) |
+| stack verify | 10/10 core services |
+
+## GitHub
+
+- Issue: #3606 CLOSED
+- PR: #3607 MERGED (`498c8b5a`)
+
+## Boundaries
+
+- LR NO-GO unchanged
+- Nur `cdb_redis_exporter` recreated; keine Redis/Postgres-Mutation


### PR DESCRIPTION
## Summary
- Update CURRENT_STATUS for runtime rebuild batch (#3592/#3594/#3600) and redis exporter fix (#3606/#3607).
- Add session logs for operator evidence.

## Validation
- Docs-only

## Boundaries
- LR NO-GO unchanged

Made with [Cursor](https://cursor.com)