### PR TITLE
docs(runbooks): sync redis AOF recovery runbook to Redis 8.8 SSOT

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -10,6 +10,8 @@
 
 ## Repo / Engineering Status (2026-07-01)
 
+- **Redis AOF runbook SSOT sync (docs-only)**: `redis_aof_corruption_recovery.md` — Recovery-One-off und Current-Runtime-Zeile auf `redis:8.8.0-alpine` (#3594); Incident-Evidence 7.4.9 historisch belassen. LR NO-GO.
+
 - **Redis exporter health #3606 / PR #3607 / `498c8b5a`**: MERGED. `cdb_redis_exporter` healthcheck von `nc -z` auf bash `/dev/tcp` umgestellt (`base.yml`, `compose.red.yml`); Ursache: `bitnami/redis-exporter` ohne `nc`. Runtime recreate exporter only → **healthy**. Closes #3606. LR NO-GO.
 
 - **Runtime rebuild batch (operator sessions)**: #3592 CI-Lab Python 3.14 CLOSED; #3594 Redis `8.8.0-alpine` CLOSED; #3600 Postgres `18.4-alpine` dump/restore CLOSED. Stack verify 10/10. LR NO-GO.

--- a/docs/runbooks/redis_aof_corruption_recovery.md
+++ b/docs/runbooks/redis_aof_corruption_recovery.md
@@ -17,7 +17,9 @@ Primary session log: [`knowledge/logs/sessions/2026-05-29-redis-aof-recovery.md`
 | Corruption | 3422-byte tail truncation in `appendonly.aof.179.incr.aof` (`ok_up_to=38757026` of `38760448`) |
 | Repair tool | `redis-check-aof --fix` on `/data/appendonlydir/appendonly.aof.manifest` |
 | Post-repair | `PONG`, `Ready to accept connections`, no AOF parse errors |
-| Runtime config | `redis:7.4.9-alpine`, `--appendonly yes` in [`compose.blue.yml`](../../infrastructure/compose/compose.blue.yml) |
+| Incident runtime (2026-05-29) | `redis:7.4.9-alpine` |
+| Current runtime SSOT | `redis:8.8.0-alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005` in [`compose.blue.yml`](../../infrastructure/compose/compose.blue.yml) (runtime rebuild #3594, 2026-07-01) |
+| AOF config | `--appendonly yes` (unchanged across rebuild) |
 | Volume | `claire_de_binare_redis_data` → `/data` |
 | Backup (2026-05-29) | `artifacts/redis_aof_recovery_20260529_004112/redis_data_full.tar.gz` (16 106 009 bytes) |
 | Backup SHA256 | `5021085D8D39159633149656756D9F89DDEFF54DAA089E1B025F45B5D81697E6` |
@@ -57,10 +59,10 @@ Do **not** re-run unless a new incident occurs. Steps from the 2026-05-29 recove
 
 1. **Backup** the Redis volume to `artifacts/` (tar.gz + SHA256).
 2. `docker stop cdb_redis`
-3. Start a one-off container with the Redis data volume mounted:
+3. Start a one-off container with the Redis data volume mounted. Use the **current compose SSOT image** (not the historical 7.4.9 incident image):
 
    ```bash
-   docker run --rm -v claire_de_binare_redis_data:/data redis:7.4.9-alpine \
+   docker run --rm -v claire_de_binare_redis_data:/data redis:8.8.0-alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005 \
      sh -c "yes y | redis-check-aof --fix /data/appendonlydir/appendonly.aof.manifest"
    ```
 
@@ -79,3 +81,4 @@ Do **not** re-run unless a new incident occurs. Steps from the 2026-05-29 recove
 
 - **#2668 / #2669:** Stack verify logging default + Windows `docker-health` — fixed in PR #2670.
 - **#2667:** This runbook closes the RCA documentation gap.
+- **#3594:** Runtime rebuild to `redis:8.8.0-alpine` (2026-07-01); AOF volume preserved; post-rebuild validation PASS.

--- a/knowledge/logs/sessions/2026-07-01-redis-aof-runbook-8.8-sync.md
+++ b/knowledge/logs/sessions/2026-07-01-redis-aof-runbook-8.8-sync.md
@@ -1,0 +1,34 @@
+# Session Log: 2026-07-01 — Redis AOF Runbook 8.8 SSOT Sync
+
+## Auftrag
+
+Docs-only: `redis_aof_corruption_recovery.md` Image-Pin von `7.4.9` auf aktuelle Compose-SSOT `8.8.0` nachziehen. Nebenan: `.pg15_archived/` read-only analysieren (kein Delete).
+
+## Delivered
+
+| Datei | Änderung |
+|---|---|
+| `docs/runbooks/redis_aof_corruption_recovery.md` | Incident-Historie 7.4.9 beibehalten; Current SSOT + Recovery-One-off auf `redis:8.8.0-alpine@sha256:9d317178…`; Ref #3594 |
+
+## `.pg15_archived/` Analyse (read-only, kein Delete)
+
+| Feld | Wert |
+|---|---|
+| Volume | `claire_de_binare_postgres_data` |
+| Pfad | `/data/.pg15_archived/` |
+| Größe | ~951 MB |
+| Inhalt | PG15-Cluster-Dateien (archiviert bei #3600 Migration) |
+| Aktive PG18-Daten | `/data/18/` (neues Layout) |
+| Backup-Referenz | `F:\Claire_Backups\cdb_backup_20260701_024024.zip` + Volume-Tarball `artifacts/postgres_rebuild_3600_20260701_024237/` |
+
+**Empfehlung:** `.pg15_archived/` vorerst belassen. Cleanup nur in separatem Ops-GO nach verifizierter PG18-Stabilität und Backup-Frische.
+
+## Validation
+
+- Docs-only diff
+- Keine Runtime-Mutation
+
+## Boundaries
+
+- LR NO-GO unchanged
+- Kein Volume-Delete, kein Postgres-Touch


### PR DESCRIPTION
## Summary
- Update \edis_aof_corruption_recovery.md\ recovery one-off image and current runtime SSOT to \edis:8.8.0-alpine\ (compose pin after #3594).
- Preserve 2026-05-29 incident evidence on \7.4.9-alpine\ as historical fact.

## Validation
- Docs-only

## Non-goals
- No runtime/volume changes
- \.pg15_archived/\ analyzed read-only in session log; not deleted

Made with [Cursor](https://cursor.com)