### PR TITLE
docs(onboarding): add agent compatibility readiness

### DIFF
--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -224,6 +224,16 @@ When onboarding orientation mentions external tools or agent surfaces:
 - Relevant for new agents: Agent Surfaces section, GitHub Docs, MCP / Context docs.
 - If internet is unavailable, reference local `docs/external-docs/index.md` and `AGENTS.md`.
 
+## Agent Onboarding Readiness
+
+Optional, informational readiness orientation for new agents and fresh clones.
+Canonical description: [`../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md`](../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md).
+
+- Four read-only checks: CLI compatibility scan, startup review, validation review, docs reliability review.
+- Score is informational only: no CI gate, no merge gate, no automatic blocker. The primary output is a prioritized Top-fixes list.
+- The external scanner `npx -y agent-compatibility@latest .` is optional and not bundled; missing Node/npm/network is `ENV_UNAVAILABLE` and must not be scored as a repo defect.
+- Boundaries unchanged: LR remains NO-GO, `trade-capable` is not Live-Go, no Echtgeld-Go.
+
 ## Non-Goals
 
 - No Live-Go.

--- a/.codex/cdb_skills/cdb-onboarding/SKILL.md
+++ b/.codex/cdb_skills/cdb-onboarding/SKILL.md
@@ -8,3 +8,5 @@ description: Thin alias to the canonical Codex onboarding skill.
 Use `../onboarding/SKILL.md` as the canonical instruction surface.
 
 Primary route: `python -m tools.onboarding_orchestrator`
+
+Agent Onboarding Readiness (optional, informational): [`../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md`](../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md).

--- a/.codex/cdb_skills/onboarding/SKILL.md
+++ b/.codex/cdb_skills/onboarding/SKILL.md
@@ -82,3 +82,13 @@ python -m tools.onboarding_orchestrator --mode check-only
 - `--mode check-only` is dry-run only and must not imply setup execution.
 - The `1. Ja / 2. Abbruch` prompt is only valid when the orchestrator reports `State: SETUP_CONFIRMATION_PENDING`.
 - Board-Stage nie als Schalter oder Freigabe darstellen.
+
+## Agent Onboarding Readiness
+
+Optional, informational readiness orientation for new agents and fresh clones.
+Canonical description: [`../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md`](../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md).
+
+- Four read-only checks: CLI compatibility scan, startup review, validation review, docs reliability review.
+- Score is informational only: no CI gate, no merge gate, no automatic blocker. The primary output is a prioritized Top-fixes list.
+- The external scanner `npx -y agent-compatibility@latest .` is optional and not bundled; missing Node/npm/network is `ENV_UNAVAILABLE` and must not be scored as a repo defect.
+- Boundaries unchanged: LR remains NO-GO, `trade-capable` is not Live-Go, no Echtgeld-Go.

--- a/.cursor/skills/onboarding/SKILL.md
+++ b/.cursor/skills/onboarding/SKILL.md
@@ -224,6 +224,16 @@ When onboarding orientation mentions external tools or agent surfaces:
 - Relevant for new agents: Agent Surfaces section, GitHub Docs, MCP / Context docs.
 - If internet is unavailable, reference local `docs/external-docs/index.md` and `AGENTS.md`.
 
+## Agent Onboarding Readiness
+
+Optional, informational readiness orientation for new agents and fresh clones.
+Canonical description: [`../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md`](../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md).
+
+- Four read-only checks: CLI compatibility scan, startup review, validation review, docs reliability review.
+- Score is informational only: no CI gate, no merge gate, no automatic blocker. The primary output is a prioritized Top-fixes list.
+- The external scanner `npx -y agent-compatibility@latest .` is optional and not bundled; missing Node/npm/network is `ENV_UNAVAILABLE` and must not be scored as a repo defect.
+- Boundaries unchanged: LR remains NO-GO, `trade-capable` is not Live-Go, no Echtgeld-Go.
+
 ## Non-Goals
 
 - No Live-Go.

--- a/.gemini/onboarding.md
+++ b/.gemini/onboarding.md
@@ -44,3 +44,9 @@ Wenn der Intent auf eine geführte Generalprobe zielt (`onboarding rehearsal`, `
 - Keine Echtgeld-Transaktionen
 - Keine Runtime-Änderungen
 - Keine Secrets in Outputs
+
+## Agent Onboarding Readiness
+
+Optionaler, rein informativer Readiness-Hinweis (kein CI-Gate, kein Blocker).
+Kanonische Beschreibung: [`../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md`](../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md).
+Externer Scanner `npx -y agent-compatibility@latest .` ist optional; fehlendes Node/npm/Netz (`ENV_UNAVAILABLE`) ist kein Repo-Defekt. LR bleibt NO-GO.

--- a/.opencode/skills/onboarding/SKILL.md
+++ b/.opencode/skills/onboarding/SKILL.md
@@ -219,6 +219,16 @@ When onboarding orientation mentions external tools or agent surfaces:
 - Relevant for new agents: Agent Surfaces section, GitHub Docs, MCP / Context docs.
 - If internet is unavailable, reference local `docs/external-docs/index.md` and `AGENTS.md`.
 
+## Agent Onboarding Readiness
+
+Optional, informational readiness orientation for new agents and fresh clones.
+Canonical description: [`../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md`](../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md).
+
+- Four read-only checks: CLI compatibility scan, startup review, validation review, docs reliability review.
+- Score is informational only: no CI gate, no merge gate, no automatic blocker. The primary output is a prioritized Top-fixes list.
+- The external scanner `npx -y agent-compatibility@latest .` is optional and not bundled; missing Node/npm/network is `ENV_UNAVAILABLE` and must not be scored as a repo defect.
+- Boundaries unchanged: LR remains NO-GO, `trade-capable` is not Live-Go, no Echtgeld-Go.
+
 ## Non-Goals
 
 - No Live-Go.

--- a/docs/onboarding/AGENT_COMPATIBILITY_READINESS.md
+++ b/docs/onboarding/AGENT_COMPATIBILITY_READINESS.md
@@ -1,0 +1,136 @@
+# Agent Onboarding Readiness
+
+Status: Onboarding surface (informational)
+Scope: Onboarding orientation for new agents and new developers only
+
+## Purpose
+
+Agent Onboarding Readiness is an optional, read-only orientation check that tells
+a new agent or a fresh clone whether this repo can be **cold-started**,
+**understood**, and **validated for a small change** without guesswork.
+
+It exists so that a first-time actor gets an honest picture of onboarding
+friction. It is **informational only**: it is not a CI gate, not a merge gate,
+and not an automatic blocker. The primary output is a short list of concrete
+**Top fixes**, not a pass/fail verdict.
+
+This surface complements the canonical onboarding entrypoint
+([`../../tools/onboarding_orchestrator.py`](../../tools/onboarding_orchestrator.py))
+and the visual start map
+([`DEVELOPER_VISUAL_START_HERE.md`](DEVELOPER_VISUAL_START_HERE.md)). It does not
+replace the bootloader ([`../../AGENTS.md`](../../AGENTS.md) ->
+[`../../agents/AGENTS.md`](../../agents/AGENTS.md)) or any governance canon.
+
+## What it checks
+
+Four independent read-only reviews, each producing its own informational score
+and its own problem list:
+
+| Check | Question it answers |
+|---|---|
+| CLI compatibility scan | What is the deterministic, heuristic repo signal from the external scanner? |
+| Startup review | Can a cold agent bootstrap and start the repo within a fixed time budget? |
+| Validation review | Can an agent verify a small change without an unnecessarily heavy loop? |
+| Docs reliability review | Do the documented setup and run paths reliably match reality? |
+
+The reviews are read-only. They inspect repo surfaces (README, scripts,
+toolchain files, test/lint paths, onboarding docs) and, where safe, try the most
+likely path. Standard local prerequisites (for example Docker or a local
+database) count as friction, not failure.
+
+## Score model (informational)
+
+The readiness score is a blended orientation number, never a gate:
+
+- `Agent Compatibility Score`: final blended orientation score.
+- `Deterministic Compatibility Score`: raw score from the external CLI scanner.
+- `Startup Compatibility Score`, `Validation Loop Score`, `Docs Reliability Score`:
+  the three behavioral checks.
+
+Blend used for orientation only:
+
+```text
+workflow = round(mean(startup, validation, docs))
+Agent Compatibility Score = round((deterministic * 0.7) + (workflow * 0.3))
+```
+
+Rules for reading the score:
+
+- The score never blocks a commit, PR, merge, or onboarding step.
+- The **Top fixes** list is the real deliverable; treat the number as context.
+- Environment problems must not be scored as repo defects (see below).
+
+## Optional external scanner
+
+The deterministic layer uses the published `agent-compatibility` npm package. It
+is **not** bundled or vendored into this repo, and this slice does **not** add
+any npm dependency, `package.json`, or lockfile entry.
+
+Run it on demand (optional):
+
+```bash
+npx -y agent-compatibility@latest .
+npx -y agent-compatibility@latest --json .
+```
+
+Known limitations:
+
+- `@latest` is convenient but **not version-stable**: results can drift between
+  runs as the published package changes. Pin a specific version if you need a
+  reproducible number (tracked as a follow-up, not part of this slice).
+- The scanner is **heuristic**. It surfaces likely friction; it is not a full
+  quality verdict on the codebase.
+- If Node, npm, or network access is missing, the scan is `ENV_UNAVAILABLE`.
+  This is a tool-environment gap and **must not** be reported as a repo defect
+  or used to penalize the repository. Fall back to the three behavioral reviews
+  and say plainly that the deterministic scan was unavailable.
+
+## The four-review pack (described, docs-only)
+
+This slice documents the review pack; it does **not** create new
+`.cursor/agents/*` subagent files. If these reviews are run, they run read-only.
+
+| Review | Role | Mode |
+|---|---|---|
+| `compatibility-scan-review` | Runs the external scanner and reports the raw deterministic score plus its main problems. | read-only |
+| `startup-review` | Attempts a cold bootstrap and reports where the startup path breaks down. | read-only |
+| `validation-review` | Judges whether a scoped validation loop exists for a small change. | read-only |
+| `docs-reliability-review` | Follows the documented setup path and reports where docs drift from reality. | read-only |
+
+Each review returns a plain-text report: one score line, a short summary, and a
+`Problems` list. Deterministic and behavioral findings are folded into a single
+prioritized `Top fixes` list. None of the reviews runs in the background and
+none performs writes.
+
+## Routing and boundary
+
+Short routing for a new agent or a fresh clone:
+
+```text
+new agent / fresh clone  ->  onboarding entrypoint  ->  Agent Onboarding Readiness (optional)
+```
+
+Boundary versus the audit surface:
+
+- **Onboarding (this surface)** is the *entry* experience: can I start, understand,
+  and validate a small change? It is orientation for first-time actors.
+- **[`cdb-repository-auditor`](../../.cursor/agents/cdb-repository-auditor.md)** is an
+  *audit* role: a deeper, read-only repository audit for maintainers. It is not
+  the onboarding entrypoint, and Agent Onboarding Readiness does not replace it.
+
+## Safety boundaries
+
+- Read-only by default: no file writes, no GitHub writes, no branch or PR
+  creation, no runtime, Docker, DB, or MCP mutation, no secrets.
+- Informational only: no CI gate is activated and no score blocks any step.
+- LR remains NO-GO. SSOT: [`../live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../live-readiness/LR-AUDIT-STATUS-2026-03-05.md).
+- Board stage `trade-capable` is Board/Stage context, not a Live-Go. See
+  [`../runbooks/CONTROL_REGISTER.md`](../runbooks/CONTROL_REGISTER.md).
+- No Echtgeld-Go.
+
+## Non-goals
+
+- No replacement of the onboarding orchestrator, the bootloader, or governance canon.
+- No new active truth outside existing onboarding surfaces.
+- No npm install, `package.json`, or lockfile change, and no scanner vendoring.
+- No automatic scoring, blocking, or gating of any workflow.

--- a/docs/onboarding/DEVELOPER_VISUAL_START_HERE.md
+++ b/docs/onboarding/DEVELOPER_VISUAL_START_HERE.md
@@ -115,6 +115,7 @@ flowchart TD
 - First-issue sandbox (guided rehearsal): [`first_issue_sandbox.md`](first_issue_sandbox.md)
 - First issue-to-PR flow (companion example): [`examples/first_issue_to_pr_flow.md`](examples/first_issue_to_pr_flow.md)
 - Repo Brain / Context Intelligence onboarding: [`repo_brain_context_intelligence.md`](repo_brain_context_intelligence.md)
+- Agent Onboarding Readiness (optional, informational): [`AGENT_COMPATIBILITY_READINESS.md`](AGENT_COMPATIBILITY_READINESS.md)
 - First Repo Brain / Context use: [`examples/repo_brain_first_use.md`](examples/repo_brain_first_use.md)
 - Agent prompt template: [`templates/agent_prompt_template.md`](templates/agent_prompt_template.md)
 - Evidence doc template: [`templates/evidence_doc_template.md`](templates/evidence_doc_template.md)

--- a/tools/validate_onboarding_docs.py
+++ b/tools/validate_onboarding_docs.py
@@ -39,6 +39,7 @@ ACTIVE_ONBOARDING_SURFACES: list[str] = [
     "tools/README.md",
     "docs/surrealdb/README.md",
     "docs/onboarding/DEVELOPER_VISUAL_START_HERE.md",
+    "docs/onboarding/AGENT_COMPATIBILITY_READINESS.md",
     "docs/onboarding/fresh_clone_rehearsal.md",
     "docs/onboarding/repo_brain_context_intelligence.md",
     "docs/onboarding/examples/README.md",


### PR DESCRIPTION
## Summary

Adds an optional, informational "Agent Onboarding Readiness" module to CDB onboarding so new agents and new developers can tell whether the repo can be cold-started, understood, and validated for a small change. Score is informational only: no CI gate, no merge gate, no automatic blocker. Top fixes are the primary output.

## Delivered

- New canonical doc `docs/onboarding/AGENT_COMPATIBILITY_READINESS.md` describing the four read-only checks (CLI compatibility scan, startup review, validation review, docs reliability review), the informational score model, the optional external scanner, routing, and the onboarding-vs-audit boundary.
- Registered the new doc as an active onboarding surface in `tools/validate_onboarding_docs.py` (link-integrity guarded by CI).
- Discoverability link from `docs/onboarding/DEVELOPER_VISUAL_START_HERE.md`.
- Short "Agent Onboarding Readiness" pointer sections added to the active onboarding surfaces: `.cursor`, `.opencode`, `.claude`, `.codex/cdb_skills/onboarding`, `.codex/cdb_skills/cdb-onboarding` (thin), and a single pointer in `.gemini/onboarding.md` (restricted surface, no domain-skill mirror).
- Docs-only for the four-review pack: no new `.cursor/agents/*` subagent files.

## Validation

- `git diff --check`: clean.
- `python -m tools.validate_onboarding_docs`: OK (all active onboarding surfaces pass; includes the new doc).
- `pytest tests/smoke/test_onboarding_cross_agent_surfaces.py tests/smoke/test_agent_root_surfaces.py`: 68 passed.
- `ruff check tools/validate_onboarding_docs.py`: passed. `black --config pyproject.toml --check tools/validate_onboarding_docs.py`: unchanged.
- Optional external scanner `npx -y agent-compatibility@latest --json .`: ENV_UNAVAILABLE (local `EPERM` on `.tmp/pytest-cdb` temp dir). Tool-environment gap, not scored as a repo defect.

## Brain Evidence

brain_source: repo-only
brain_status: not-used
tools_or_queries:
  - git status/rev-parse/fetch, gh pr list, gh issue list (live GitHub: 0 open PRs, 0 matching issues)
  - python -m tools.validate_onboarding_docs; pytest smoke onboarding surfaces
repo_crosscheck:
  - AGENTS.md -> agents/AGENTS.md Read Order resolved; all 10 Read-Order files present
  - tests/smoke/test_onboarding_cross_agent_surfaces.py; tools/validate_onboarding_docs.py; .github/workflows/ci.yml
impact_on_plan:
  - Onboarding is surface-only (no docs/skills/onboarding SKILL); readiness placed in docs/onboarding/ + surface pointers, additive only
limitations:
  - Deterministic npx scan not run (ENV_UNAVAILABLE); no SurrealDB/Context/MCP records used
context_brain_attempted: true
context_brain_used: false
context_available: false
repo_fallback_used: true
repo_fallback_reason: unavailable
context_tool_status: absent
context_trust_level: none
records_found: none

## Non-goals

- No new `.cursor/agents/*` subagent files.
- No npm install, `package.json`, or lockfile change; no scanner vendoring/bundling.
- No CI required-gate activation; no automatic scoring/blocking.
- No runtime, Docker, DB, MCP, secrets, or LR changes.
- No broad onboarding rewrite; no new active truth outside existing onboarding surfaces.

## Safety Boundaries

- LR remains NO-GO (SSOT: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`).
- Board stage `trade-capable` is not Live-Go. No Echtgeld-Go.
- Read-only orientation; informational score only.

## Known limitations

- `npx agent-compatibility@latest` is convenient but not version-stable; results can drift between runs.
- The scanner is heuristic and not a full quality verdict.
- Deterministic scan currently ENV_UNAVAILABLE in this environment.

## Follow-ups (deduplicated, not in this slice)

- Optional: pin a specific `agent-compatibility` scanner version for reproducibility.
- Optional: add a non-blocking CI report for readiness.
- Optional: integrate the readiness score into Context Brain / Trust Summary.
