### PR TITLE
fix(backup): align redis manifest flag with backup artifact

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -10,7 +10,7 @@
 
 ## Repo / Engineering Status (2026-07-01)
 
-- **Backup manifest Redis drift #3614 / PR #TBD**: `Components.Redis` aligned with `redis_dump.rdb` artifact via `Sync-BackupComponentManifest`; restore tolerates legacy drift ZIPs. Closes #3614. LR NO-GO.
+- **Backup manifest Redis drift #3614 / PR #3615**: `Components.Redis` aligned with `redis_dump.rdb` artifact via `Sync-BackupComponentManifest`; restore tolerates legacy drift ZIPs. Closes #3614. LR NO-GO.
 
 - **`.pg15_archived` cleanup follow-up #3612`**: OPEN — optional volume cleanup after PG18 retention window (earliest 2026-07-15); no delete authorized yet. LR NO-GO.
 

--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -10,6 +10,10 @@
 
 ## Repo / Engineering Status (2026-07-01)
 
+- **Backup manifest Redis drift #3614 / PR #TBD**: `Components.Redis` aligned with `redis_dump.rdb` artifact via `Sync-BackupComponentManifest`; restore tolerates legacy drift ZIPs. Closes #3614. LR NO-GO.
+
+- **`.pg15_archived` cleanup follow-up #3612`**: OPEN — optional volume cleanup after PG18 retention window (earliest 2026-07-15); no delete authorized yet. LR NO-GO.
+
 - **Redis AOF runbook SSOT sync (docs-only)**: `redis_aof_corruption_recovery.md` — Recovery-One-off und Current-Runtime-Zeile auf `redis:8.8.0-alpine` (#3594); Incident-Evidence 7.4.9 historisch belassen. LR NO-GO.
 
 - **Redis exporter health #3606 / PR #3607 / `498c8b5a`**: MERGED. `cdb_redis_exporter` healthcheck von `nc -z` auf bash `/dev/tcp` umgestellt (`base.yml`, `compose.red.yml`); Ursache: `bitnami/redis-exporter` ohne `nc`. Runtime recreate exporter only → **healthy**. Closes #3606. LR NO-GO.

--- a/docs/runbooks/BACKUP_AUTOMATION.md
+++ b/docs/runbooks/BACKUP_AUTOMATION.md
@@ -6,6 +6,7 @@
 ## Übersicht
 
 - `infrastructure/scripts/backup_all.ps1` erstellt Postgres- und Redis-Backups als ZIP unter `F:\Claire_Backups`.
+- `manifest.json` markiert in `Components.*` nur tatsächlich erfasste Artefakte; `ComponentSelection.*` beschreibt den geplanten Scope.
 - Optional kann `backup_all.ps1 -IncludeSurrealDB` den lokalen SurrealDB-File-Backend-Volume-Stand physisch mit in dasselbe Archiv aufnehmen.
 - `infrastructure/scripts/setup_backup_task.ps1` registriert den Windows Task `Claire_Hourly_Backup`.
 - `infrastructure/scripts/backup_health_check.ps1` prüft auf ein aktuelles Archiv (`exit 0 = PASS`, `exit 1 = FAIL`).

--- a/infrastructure/scripts/backup_all.ps1
+++ b/infrastructure/scripts/backup_all.ps1
@@ -32,6 +32,8 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+. (Join-Path $PSScriptRoot "backup_manifest_helpers.ps1")
+
 $TIMESTAMP = Get-Date -Format "yyyyMMdd_HHmmss"
 $BACKUP_NAME = "cdb_backup_$TIMESTAMP"
 $WORK_DIR = Join-Path $BackupDir $BACKUP_NAME
@@ -333,22 +335,30 @@ if ($redisRunning -notmatch "cdb_redis") {
             docker exec cdb_redis redis-cli SAVE 2>&1 | Out-Null
         }
 
-        if ($LASTEXITCODE -ne 0) {
-            Write-Fail "redis-cli SAVE failed"
-        } else {
-            # Copy RDB from container
-            docker cp cdb_redis:/data/dump.rdb $redisFile 2>&1
+        $saveExitCode = $LASTEXITCODE
+        if ($saveExitCode -ne 0) {
+            Write-Fail "redis-cli SAVE failed (exit $saveExitCode)"
+        }
 
-            if ($LASTEXITCODE -ne 0 -or -not (Test-Path $redisFile)) {
-                Write-Fail "Redis RDB copy failed"
+        docker cp cdb_redis:/data/dump.rdb $redisFile 2>&1 | Out-Null
+        $copyExitCode = $LASTEXITCODE
+
+        if (Test-BackupArtifactPresent -Path $redisFile) {
+            if ($copyExitCode -ne 0) {
+                Write-Host "WARN  Redis RDB present but docker cp exit code was $copyExitCode" -ForegroundColor Yellow
+            }
+            $redisSizeKB = [math]::Round((Get-Item $redisFile).Length / 1KB, 2)
+            $componentStatus.Redis = $true
+            $componentEvidence.Redis = @{
+                Artifact = "redis_dump.rdb"
+                SizeBytes = [int64](Get-Item $redisFile).Length
+            }
+            Write-Pass "Redis backup: $redisSizeKB KB"
+        } else {
+            if ($copyExitCode -ne 0) {
+                Write-Fail "Redis RDB copy failed (exit $copyExitCode)"
             } else {
-                $redisSizeKB = [math]::Round((Get-Item $redisFile).Length / 1KB, 2)
-                $componentStatus.Redis = $true
-                $componentEvidence.Redis = @{
-                    Artifact = "redis_dump.rdb"
-                    SizeBytes = [int64](Get-Item $redisFile).Length
-                }
-                Write-Pass "Redis backup: $redisSizeKB KB"
+                Write-Fail "Redis RDB copy produced no artifact"
             }
         }
     } catch {
@@ -417,6 +427,11 @@ if ($IncludeSurrealDB) {
 # ── 5. Manifest ──────────────────────────────────────────────────────────
 
 Write-Step "Writing manifest..."
+
+Sync-BackupComponentManifest `
+    -WorkDir $WORK_DIR `
+    -ComponentStatus $componentStatus `
+    -ComponentEvidence $componentEvidence
 
 $gitCommit = "unknown"
 try {

--- a/infrastructure/scripts/backup_manifest_helpers.ps1
+++ b/infrastructure/scripts/backup_manifest_helpers.ps1
@@ -1,0 +1,117 @@
+# backup_manifest_helpers.ps1 - Shared manifest reconciliation for backup_all.ps1
+
+function Test-BackupArtifactPresent {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return $false
+    }
+
+    return ((Get-Item $Path).Length -gt 0)
+}
+
+function Set-BackupComponentEvidence {
+    param(
+        [hashtable]$ComponentEvidence,
+        [string]$ComponentName,
+        [string]$Artifact,
+        [int64]$SizeBytes
+    )
+
+    $ComponentEvidence[$ComponentName] = @{
+        Artifact = $Artifact
+        SizeBytes = $SizeBytes
+    }
+}
+
+function Sync-BackupComponentManifest {
+    param(
+        [string]$WorkDir,
+        [hashtable]$ComponentStatus,
+        [hashtable]$ComponentEvidence
+    )
+
+    $postgresFile = Join-Path $WorkDir "postgres_dump.sql"
+    if (Test-BackupArtifactPresent -Path $postgresFile) {
+        $ComponentStatus.Postgres = $true
+        Set-BackupComponentEvidence `
+            -ComponentEvidence $ComponentEvidence `
+            -ComponentName "Postgres" `
+            -Artifact "postgres_dump.sql" `
+            -SizeBytes ([int64](Get-Item $postgresFile).Length)
+    } else {
+        $ComponentStatus.Postgres = $false
+        $ComponentEvidence.Postgres = @{}
+    }
+
+    $redisFile = Join-Path $WorkDir "redis_dump.rdb"
+    if (Test-BackupArtifactPresent -Path $redisFile) {
+        $ComponentStatus.Redis = $true
+        Set-BackupComponentEvidence `
+            -ComponentEvidence $ComponentEvidence `
+            -ComponentName "Redis" `
+            -Artifact "redis_dump.rdb" `
+            -SizeBytes ([int64](Get-Item $redisFile).Length)
+    } else {
+        $ComponentStatus.Redis = $false
+        $ComponentEvidence.Redis = @{}
+    }
+
+    $surrealBackupPath = Join-Path $WorkDir "surrealdb_data"
+    if (Test-Path $surrealBackupPath) {
+        $files = @(Get-ChildItem -Path $surrealBackupPath -File -Recurse -Force -ErrorAction SilentlyContinue)
+        $totalBytes = 0
+        if ($files.Count -gt 0) {
+            $totalBytes = [int64](($files | Measure-Object -Property Length -Sum).Sum)
+        }
+
+        if ($files.Count -gt 0 -and $totalBytes -gt 0) {
+            $ComponentStatus.SurrealDB = $true
+            if (-not $ComponentEvidence.ContainsKey("SurrealDB")) {
+                $ComponentEvidence.SurrealDB = @{}
+            }
+            $ComponentEvidence.SurrealDB.FileCount = [int64]$files.Count
+            $ComponentEvidence.SurrealDB.TotalBytes = $totalBytes
+            if (-not $ComponentEvidence.SurrealDB.ContainsKey("Artifact")) {
+                $ComponentEvidence.SurrealDB.Artifact = "surrealdb_data"
+            }
+        }
+    }
+}
+
+function Resolve-BackupComponentInclusion {
+    param(
+        [string]$BackupRoot,
+        [bool]$ManifestFlag,
+        [string]$ComponentName,
+        [string]$ArtifactPattern,
+        [string]$ArtifactLabel
+    )
+
+    $artifact = Get-ChildItem -Path $BackupRoot -Filter $ArtifactPattern -Recurse -ErrorAction SilentlyContinue |
+        Where-Object { $_.Length -gt 0 } |
+        Select-Object -First 1
+
+    if ($ManifestFlag) {
+        return @{
+            Included = $true
+            Artifact = $artifact
+            DriftCorrected = $false
+        }
+    }
+
+    if ($artifact) {
+        Write-Warning "Manifest drift: $ComponentName=false but $ArtifactLabel present - treating as included"
+        return @{
+            Included = $true
+            Artifact = $artifact
+            DriftCorrected = $true
+        }
+    }
+
+    return @{
+        Included = $false
+        Artifact = $null
+        DriftCorrected = $false
+    }
+}

--- a/infrastructure/scripts/restore_all.ps1
+++ b/infrastructure/scripts/restore_all.ps1
@@ -23,6 +23,8 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+. (Join-Path $PSScriptRoot "backup_manifest_helpers.ps1")
+
 function Write-Pass { param([string]$Msg) Write-Host "PASS  $Msg" -ForegroundColor Green }
 function Write-Fail { param([string]$Msg) Write-Host "FAIL  $Msg" -ForegroundColor Red }
 function Write-Step { param([string]$Msg) Write-Host "---   $Msg" -ForegroundColor Cyan }
@@ -270,6 +272,22 @@ if (-not $manifestFile) {
 $manifest = Get-Content $manifestFile.FullName | ConvertFrom-Json
 $backupRoot = $manifestFile.DirectoryName
 
+$postgresResolution = Resolve-BackupComponentInclusion `
+    -BackupRoot $backupRoot `
+    -ManifestFlag ([bool]$manifest.Components.Postgres) `
+    -ComponentName "Postgres" `
+    -ArtifactPattern "postgres_dump.sql" `
+    -ArtifactLabel "postgres_dump.sql"
+$postgresIncluded = $postgresResolution.Included
+
+$redisResolution = Resolve-BackupComponentInclusion `
+    -BackupRoot $backupRoot `
+    -ManifestFlag ([bool]$manifest.Components.Redis) `
+    -ComponentName "Redis" `
+    -ArtifactPattern "redis_dump.rdb" `
+    -ArtifactLabel "redis_dump.rdb"
+$redisIncluded = $redisResolution.Included
+
 $surrealDbEvidence = $null
 if (Test-ObjectProperty -Object $manifest -Name "Evidence" -and (Test-ObjectProperty -Object $manifest.Evidence -Name "SurrealDB")) {
     $surrealDbEvidence = $manifest.Evidence.SurrealDB
@@ -332,16 +350,16 @@ if ($surrealDbIncluded) {
 Write-Pass "Manifest loaded"
 Write-Host "      Backup from:  $($manifest.Timestamp)"
 Write-Host "      Git commit:   $($manifest.GitCommit)"
-Write-Host "      Postgres:     $(if ($manifest.Components.Postgres) { 'included' } else { 'not included' })"
-Write-Host "      Redis:        $(if ($manifest.Components.Redis) { 'included' } else { 'not included' })"
+Write-Host "      Postgres:     $(if ($postgresIncluded) { 'included' } else { 'not included' })"
+Write-Host "      Redis:        $(if ($redisIncluded) { 'included' } else { 'not included' })"
 Write-Host "      SurrealDB:    $surrealDbDisplay"
 Write-Host ""
 
 # ── Safety confirmation ──────────────────────────────────────────────────
 
 $restoreTargets = @()
-if ($manifest.Components.Postgres) { $restoreTargets += "Postgres" }
-if ($manifest.Components.Redis) { $restoreTargets += "Redis" }
+if ($postgresIncluded) { $restoreTargets += "Postgres" }
+if ($redisIncluded) { $restoreTargets += "Redis" }
 if ($surrealDbIncluded) { $restoreTargets += "SurrealDB" }
 
 if ($restoreTargets.Count -eq 0) {
@@ -371,7 +389,7 @@ $restoreResults = @{
 
 # ── Restore Postgres ─────────────────────────────────────────────────────
 
-if ($manifest.Components.Postgres) {
+if ($postgresIncluded) {
     Write-Step "Restoring Postgres..."
 
     $pgDump = Get-ChildItem -Path $backupRoot -Filter "postgres_dump.sql" -Recurse | Select-Object -First 1
@@ -416,7 +434,7 @@ if ($manifest.Components.Postgres) {
 
 # ── Restore Redis ────────────────────────────────────────────────────────
 
-if ($manifest.Components.Redis) {
+if ($redisIncluded) {
     Write-Step "Restoring Redis..."
 
     $redisDump = Get-ChildItem -Path $backupRoot -Filter "redis_dump.rdb" -Recurse | Select-Object -First 1
@@ -607,12 +625,12 @@ if ($surrealDbIncluded) {
 Write-Host ""
 
 # Exit code: fail if any included component failed
-if ($manifest.Components.Postgres -and -not $restoreResults.Postgres) {
+if ($postgresIncluded -and -not $restoreResults.Postgres) {
     Write-Fail "Restore incomplete - Postgres failed"
     exit 1
 }
 
-if ($manifest.Components.Redis -and -not $restoreResults.Redis) {
+if ($redisIncluded -and -not $restoreResults.Redis) {
     Write-Fail "Restore incomplete - Redis failed"
     exit 1
 }

--- a/knowledge/logs/sessions/2026-07-01-backup-manifest-redis-drift.md
+++ b/knowledge/logs/sessions/2026-07-01-backup-manifest-redis-drift.md
@@ -1,0 +1,26 @@
+# Session Log: 2026-07-01 — Backup Manifest Redis Drift (#3614)
+
+## Auftrag
+
+Fix `Components.Redis=false` while `redis_dump.rdb` present in backup ZIP (`cdb_backup_20260701_030012.zip`). Closes #3614.
+
+## Root Cause
+
+`docker cp` can write `redis_dump.rdb` successfully while `$LASTEXITCODE` is non-zero on Windows. Manifest was written from `$componentStatus` without artifact reconciliation.
+
+## Delivered
+
+- `infrastructure/scripts/backup_manifest_helpers.ps1` — `Test-BackupArtifactPresent`, `Sync-BackupComponentManifest`, `Resolve-BackupComponentInclusion`
+- `backup_all.ps1` — artifact-based Redis success + sync before manifest
+- `restore_all.ps1` — legacy drift tolerance when artifact present but flag false
+- `tests/unit/scripts/test_backup_manifest_sync.py` — 5 unit tests
+- `docs/runbooks/BACKUP_AUTOMATION.md` — Components vs ComponentSelection note
+
+## Validation
+
+- `pytest -m unit tests/unit/scripts/test_backup_manifest_sync.py` — 5/5 PASS
+- No runtime mutation, no restore drill
+
+## Boundaries
+
+- LR NO-GO; no Docker/backup/restore execution in session

--- a/tests/unit/scripts/test_backup_manifest_contract.py
+++ b/tests/unit/scripts/test_backup_manifest_contract.py
@@ -1,0 +1,34 @@
+"""Cross-platform contract tests for backup manifest drift behavior."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.mark.unit
+def test_manifest_drift_fixture_documents_redis_false_with_artifact() -> None:
+    """Regression fixture for #3614 observed ZIP/manifest mismatch."""
+    manifest = {
+        "Components": {"Postgres": True, "Redis": False, "SurrealDB": False},
+        "ComponentSelection": {"Postgres": True, "Redis": True, "SurrealDB": False},
+        "Evidence": {
+            "Postgres": {"Artifact": "postgres_dump.sql", "SizeBytes": 1039873045},
+            "Redis": {},
+        },
+    }
+    artifacts = {
+        "postgres_dump.sql": 1039873045,
+        "redis_dump.rdb": 10957629,
+    }
+
+    assert manifest["Components"]["Redis"] is False
+    assert artifacts["redis_dump.rdb"] > 0
+    assert manifest["ComponentSelection"]["Redis"] is True
+
+    reconciled_redis = artifacts.get("redis_dump.rdb", 0) > 0
+    assert reconciled_redis is True
+
+    payload = json.dumps(manifest)
+    assert '"Redis":  false' in payload or '"Redis": false' in payload

--- a/tests/unit/scripts/test_backup_manifest_sync.py
+++ b/tests/unit/scripts/test_backup_manifest_sync.py
@@ -1,0 +1,134 @@
+"""Unit tests for backup manifest helper reconciliation (no Docker)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HELPERS = REPO_ROOT / "infrastructure" / "scripts" / "backup_manifest_helpers.ps1"
+
+
+def _ps_path(path: Path) -> str:
+    return str(path).replace("'", "''")
+
+
+def _run_helpers(script_body: str) -> dict:
+    command = f". '{_ps_path(HELPERS)}'; {script_body}"
+    result = subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            command,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    text = result.stdout.strip()
+    json_line = text.splitlines()[-1]
+    return json.loads(json_line)
+
+
+@pytest.mark.unit
+def test_sync_sets_redis_true_when_rdb_present(tmp_path: Path) -> None:
+    work_dir = tmp_path / "backup"
+    work_dir.mkdir()
+    (work_dir / "redis_dump.rdb").write_bytes(b"redis-data")
+
+    payload = _run_helpers(
+        f"""
+$status = @{{ Postgres = $false; Redis = $false; SurrealDB = $false }}
+$evidence = @{{ Postgres = @{{}}; Redis = @{{}}; SurrealDB = @{{}} }}
+Sync-BackupComponentManifest -WorkDir '{_ps_path(work_dir)}' -ComponentStatus $status -ComponentEvidence $evidence
+@{{ Redis = $status.Redis; SizeBytes = $evidence.Redis.SizeBytes }} | ConvertTo-Json -Compress
+"""
+    )
+
+    assert payload["Redis"] is True
+    assert payload["SizeBytes"] == len(b"redis-data")
+
+
+@pytest.mark.unit
+def test_sync_keeps_redis_false_when_rdb_missing(tmp_path: Path) -> None:
+    work_dir = tmp_path / "backup"
+    work_dir.mkdir()
+
+    payload = _run_helpers(
+        f"""
+$status = @{{ Postgres = $false; Redis = $false; SurrealDB = $false }}
+$evidence = @{{ Postgres = @{{}}; Redis = @{{}}; SurrealDB = @{{}} }}
+Sync-BackupComponentManifest -WorkDir '{_ps_path(work_dir)}' -ComponentStatus $status -ComponentEvidence $evidence
+@{{ Redis = $status.Redis }} | ConvertTo-Json -Compress
+"""
+    )
+
+    assert payload["Redis"] is False
+
+
+@pytest.mark.unit
+def test_sync_keeps_redis_false_when_rdb_empty(tmp_path: Path) -> None:
+    work_dir = tmp_path / "backup"
+    work_dir.mkdir()
+    (work_dir / "redis_dump.rdb").write_bytes(b"")
+
+    payload = _run_helpers(
+        f"""
+$status = @{{ Postgres = $false; Redis = $true; SurrealDB = $false }}
+$evidence = @{{ Postgres = @{{}}; Redis = @{{}}; SurrealDB = @{{}} }}
+Sync-BackupComponentManifest -WorkDir '{_ps_path(work_dir)}' -ComponentStatus $status -ComponentEvidence $evidence
+@{{ Redis = $status.Redis }} | ConvertTo-Json -Compress
+"""
+    )
+
+    assert payload["Redis"] is False
+
+
+@pytest.mark.unit
+def test_sync_sets_postgres_true_when_dump_present(tmp_path: Path) -> None:
+    work_dir = tmp_path / "backup"
+    work_dir.mkdir()
+    (work_dir / "postgres_dump.sql").write_text(
+        "PostgreSQL database dump\n", encoding="utf-8"
+    )
+
+    payload = _run_helpers(
+        f"""
+$status = @{{ Postgres = $false; Redis = $false; SurrealDB = $false }}
+$evidence = @{{ Postgres = @{{}}; Redis = @{{}}; SurrealDB = @{{}} }}
+Sync-BackupComponentManifest -WorkDir '{_ps_path(work_dir)}' -ComponentStatus $status -ComponentEvidence $evidence
+@{{ Postgres = $status.Postgres; Artifact = $evidence.Postgres.Artifact }} | ConvertTo-Json -Compress
+"""
+    )
+
+    assert payload["Postgres"] is True
+    assert payload["Artifact"] == "postgres_dump.sql"
+
+
+@pytest.mark.unit
+def test_resolve_inclusion_treats_redis_artifact_as_included(tmp_path: Path) -> None:
+    backup_root = tmp_path / "archive"
+    backup_root.mkdir()
+    (backup_root / "redis_dump.rdb").write_bytes(b"redis-data")
+
+    payload = _run_helpers(
+        f"""
+$result = Resolve-BackupComponentInclusion `
+    -BackupRoot '{_ps_path(backup_root)}' `
+    -ManifestFlag $false `
+    -ComponentName 'Redis' `
+    -ArtifactPattern 'redis_dump.rdb' `
+    -ArtifactLabel 'redis_dump.rdb'
+@{{ Included = $result.Included; DriftCorrected = $result.DriftCorrected }} | ConvertTo-Json -Compress
+"""
+    )
+
+    assert payload["Included"] is True
+    assert payload["DriftCorrected"] is True

--- a/tests/unit/scripts/test_backup_manifest_sync.py
+++ b/tests/unit/scripts/test_backup_manifest_sync.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import platform
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -10,6 +12,12 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 HELPERS = REPO_ROOT / "infrastructure" / "scripts" / "backup_manifest_helpers.ps1"
+
+POWERSHELL = shutil.which("powershell.exe") or shutil.which("powershell")
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Windows" or POWERSHELL is None,
+    reason="backup manifest helper tests require Windows PowerShell",
+)
 
 
 def _ps_path(path: Path) -> str:
@@ -20,7 +28,7 @@ def _run_helpers(script_body: str) -> dict:
     command = f". '{_ps_path(HELPERS)}'; {script_body}"
     result = subprocess.run(
         [
-            "powershell.exe",
+            POWERSHELL,
             "-NoProfile",
             "-ExecutionPolicy",
             "Bypass",


### PR DESCRIPTION
## Summary

Closes #3614

Fixes backup manifest drift where `redis_dump.rdb` was present in the ZIP but `manifest.json` had `Components.Redis=false` (observed in `cdb_backup_20260701_030012.zip` during PG18 read-only verification).

## Root Cause

`docker cp` can write the Redis RDB successfully while `$LASTEXITCODE` is non-zero on Windows. Manifest flags were set only from exit-code success branches, without reconciling against artifacts in `WORK_DIR`.

## Delivered

- `backup_manifest_helpers.ps1`: artifact checks, `Sync-BackupComponentManifest`, `Resolve-BackupComponentInclusion`
- `backup_all.ps1`: artifact-based Redis success + sync before manifest write
- `restore_all.ps1`: legacy drift tolerance when artifact exists but manifest flag is false
- `tests/unit/scripts/test_backup_manifest_sync.py`: 5 unit tests (no Docker)
- Docs note in `BACKUP_AUTOMATION.md`

## Validation

- `pytest -m unit tests/unit/scripts/test_backup_manifest_sync.py` — 5/5 PASS
- `ruff check tests/unit/scripts/test_backup_manifest_sync.py` — PASS

## Safety Boundaries

- No runtime mutation
- No backup restore drill
- No backup deletion
- LR NO-GO unchanged

## Non-goals

- No backup system redesign
- No retention policy changes
