### PR TITLE
docs(onboarding): pin agent-compatibility@0.1.7 (#3616)

### DIFF
--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -231,7 +231,7 @@ Canonical description: [`../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.
 
 - Four read-only checks: CLI compatibility scan, startup review, validation review, docs reliability review.
 - Score is informational only: no CI gate, no merge gate, no automatic blocker. The primary output is a prioritized Top-fixes list.
-- The external scanner `npx -y agent-compatibility@latest .` is optional and not bundled; missing Node/npm/network is `ENV_UNAVAILABLE` and must not be scored as a repo defect.
+- The external scanner `npx -y agent-compatibility@0.1.7 .` is optional and not bundled; missing Node/npm/network is `ENV_UNAVAILABLE` and must not be scored as a repo defect.
 - Boundaries unchanged: LR remains NO-GO, `trade-capable` is not Live-Go, no Echtgeld-Go.
 
 ## Non-Goals

--- a/.codex/cdb_skills/onboarding/SKILL.md
+++ b/.codex/cdb_skills/onboarding/SKILL.md
@@ -90,5 +90,5 @@ Canonical description: [`../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.
 
 - Four read-only checks: CLI compatibility scan, startup review, validation review, docs reliability review.
 - Score is informational only: no CI gate, no merge gate, no automatic blocker. The primary output is a prioritized Top-fixes list.
-- The external scanner `npx -y agent-compatibility@latest .` is optional and not bundled; missing Node/npm/network is `ENV_UNAVAILABLE` and must not be scored as a repo defect.
+- The external scanner `npx -y agent-compatibility@0.1.7 .` is optional and not bundled; missing Node/npm/network is `ENV_UNAVAILABLE` and must not be scored as a repo defect.
 - Boundaries unchanged: LR remains NO-GO, `trade-capable` is not Live-Go, no Echtgeld-Go.

--- a/.cursor/skills/onboarding/SKILL.md
+++ b/.cursor/skills/onboarding/SKILL.md
@@ -231,7 +231,7 @@ Canonical description: [`../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.
 
 - Four read-only checks: CLI compatibility scan, startup review, validation review, docs reliability review.
 - Score is informational only: no CI gate, no merge gate, no automatic blocker. The primary output is a prioritized Top-fixes list.
-- The external scanner `npx -y agent-compatibility@latest .` is optional and not bundled; missing Node/npm/network is `ENV_UNAVAILABLE` and must not be scored as a repo defect.
+- The external scanner `npx -y agent-compatibility@0.1.7 .` is optional and not bundled; missing Node/npm/network is `ENV_UNAVAILABLE` and must not be scored as a repo defect.
 - Boundaries unchanged: LR remains NO-GO, `trade-capable` is not Live-Go, no Echtgeld-Go.
 
 ## Non-Goals

--- a/.gemini/onboarding.md
+++ b/.gemini/onboarding.md
@@ -49,4 +49,4 @@ Wenn der Intent auf eine geführte Generalprobe zielt (`onboarding rehearsal`, `
 
 Optionaler, rein informativer Readiness-Hinweis (kein CI-Gate, kein Blocker).
 Kanonische Beschreibung: [`../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md`](../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md).
-Externer Scanner `npx -y agent-compatibility@latest .` ist optional; fehlendes Node/npm/Netz (`ENV_UNAVAILABLE`) ist kein Repo-Defekt. LR bleibt NO-GO.
+Externer Scanner `npx -y agent-compatibility@0.1.7 .` ist optional; fehlendes Node/npm/Netz (`ENV_UNAVAILABLE`) ist kein Repo-Defekt. LR bleibt NO-GO.

--- a/.opencode/skills/onboarding/SKILL.md
+++ b/.opencode/skills/onboarding/SKILL.md
@@ -226,7 +226,7 @@ Canonical description: [`../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.
 
 - Four read-only checks: CLI compatibility scan, startup review, validation review, docs reliability review.
 - Score is informational only: no CI gate, no merge gate, no automatic blocker. The primary output is a prioritized Top-fixes list.
-- The external scanner `npx -y agent-compatibility@latest .` is optional and not bundled; missing Node/npm/network is `ENV_UNAVAILABLE` and must not be scored as a repo defect.
+- The external scanner `npx -y agent-compatibility@0.1.7 .` is optional and not bundled; missing Node/npm/network is `ENV_UNAVAILABLE` and must not be scored as a repo defect.
 - Boundaries unchanged: LR remains NO-GO, `trade-capable` is not Live-Go, no Echtgeld-Go.
 
 ## Non-Goals

--- a/docs/onboarding/AGENT_COMPATIBILITY_READINESS.md
+++ b/docs/onboarding/AGENT_COMPATIBILITY_READINESS.md
@@ -69,15 +69,33 @@ any npm dependency, `package.json`, or lockfile entry.
 Run it on demand (optional):
 
 ```bash
-npx -y agent-compatibility@latest .
-npx -y agent-compatibility@latest --json .
+npx -y agent-compatibility@0.1.7 .
+npx -y agent-compatibility@0.1.7 --json .
 ```
+
+The canonical pin is **`0.1.7`** (verified via `npm view agent-compatibility version`
+at documentation time). Use this exact version for reproducible
+`Deterministic Compatibility Score` results on the same repo commit.
+
+### Version pinning
+
+Pinning keeps onboarding readiness comparable and auditable:
+
+- Same repo commit + same pinned scanner version → stable, comparable scores.
+- Score changes are easier to attribute to repo changes vs. upstream tool drift.
+- The scanner remains **optional**; pinning does not make it a CI gate or
+  required check.
+
+**Deliberate upgrade** (maintainer or docs slice, not automatic):
+
+1. Run `npm view agent-compatibility version` (read-only; needs npm/network).
+2. Update this file and the onboarding surface pointers that echo the command.
+3. Open a focused docs PR; note the old and new pin in the PR body.
+4. If npm/network is unavailable (`ENV_UNAVAILABLE`), do not guess a version —
+   hold the pin update until a version can be verified.
 
 Known limitations:
 
-- `@latest` is convenient but **not version-stable**: results can drift between
-  runs as the published package changes. Pin a specific version if you need a
-  reproducible number (tracked as a follow-up, not part of this slice).
 - The scanner is **heuristic**. It surfaces likely friction; it is not a full
   quality verdict on the codebase.
 - If Node, npm, or network access is missing, the scan is `ENV_UNAVAILABLE`.


### PR DESCRIPTION
## Summary

- Pin the optional `agent-compatibility` scanner to **`0.1.7`** (verified via `npm view agent-compatibility version`).
- Replace `@latest` in the canonical onboarding doc and all onboarding surface pointers.
- Document why version pinning matters, how to deliberately upgrade, and that the scanner stays optional (no CI gate).

## Test plan

- [x] `python -m tools.validate_onboarding_docs` — PASS
- [x] `rg` — no `agent-compatibility@latest` in docs/agents/surface paths
- [x] `git diff --check` — clean

## Non-goals

- No `npm install`, no `package.json`/lockfile change, no vendor bundling
- No runtime/Docker/DB/MCP/secrets/LR changes
- Scanner remains optional; not a required check

Closes #3616
