### PR TITLE
docs(security): CVE-2026-11824 UPSTREAM_BLOCKED evidence (#3619–#3625)

### DIFF
--- a/docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3619-3625-CVE-11824_2026-07-01.md
+++ b/docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3619-3625-CVE-11824_2026-07-01.md
@@ -1,0 +1,96 @@
+# Security Batch Matrix — Issues #3619–#3625 / CVE-2026-11824
+
+**Stand:** 2026-07-01 (UTC)  
+**Parent epic:** [#2289](https://github.com/jannekbuengener/Claire_de_Binare/issues/2289)  
+**Related trackers:** [#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513), [#2932](https://github.com/jannekbuengener/Claire_de_Binare/issues/2932)  
+**Branch:** `fix/3619-cve-2026-11824-blue-services`  
+**Scope guard:** Triage/evidence only. Kein LR-Go, keine Alert-Dismissals, keine Runtime-/Stack-Mutation.
+
+---
+
+## Executive summary
+
+| Gruppe | Issues | CVE | Package | Installed | Fixed (Trivy/Debian) | Verdict |
+|--------|--------|-----|---------|-----------|---------------------|---------|
+| BLUE custom services (Trixie) | #3619–#3625 | CVE-2026-11824 | `libsqlite3-0` | `3.46.1-7+deb13u1` | **empty** / requires SQLite >= 3.53.2 | **UPSTREAM_BLOCKED** |
+
+**Remediation in this slice:** Kein Dockerfile-/Digest-Diff — Fixability-Probes zeigen, dass weder ein neuer `python:3.14-slim-trixie`-Digest noch `apt-get upgrade -y` eine fixed Version liefert. Beobachtung bis Debian Trixie ein Security-Update für `sqlite3` veröffentlicht.
+
+---
+
+## Batch matrix
+
+| Issue | Service | GH alert | Fingerprint | Package | Installed | Fixed | Verdict |
+|-------|---------|----------|-------------|---------|-----------|-------|---------|
+| [#3619](https://github.com/jannekbuengener/Claire_de_Binare/issues/3619) | `cdb_db_writer` | [#4725](https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/4725) | `3ae371c8ffacf866` | `libsqlite3-0` | `3.46.1-7+deb13u1` | — | UPSTREAM_BLOCKED |
+| [#3620](https://github.com/jannekbuengener/Claire_de_Binare/issues/3620) | `cdb_execution` | [#5332](https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/5332) | `8004943d4a5a5dd4` | `libsqlite3-0` | `3.46.1-7+deb13u1` | — | UPSTREAM_BLOCKED |
+| [#3621](https://github.com/jannekbuengener/Claire_de_Binare/issues/3621) | `cdb_market` | [#4877](https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/4877) | `0adce0e1b3f4fa5c` | `libsqlite3-0` | `3.46.1-7+deb13u1` | — | UPSTREAM_BLOCKED |
+| [#3622](https://github.com/jannekbuengener/Claire_de_Binare/issues/3622) | `cdb_regime` | [#4954](https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/4954) | `866509d9dc0c2368` | `libsqlite3-0` | `3.46.1-7+deb13u1` | — | UPSTREAM_BLOCKED |
+| [#3623](https://github.com/jannekbuengener/Claire_de_Binare/issues/3623) | `cdb_risk` | [#5256](https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/5256) | `c65c30af5caab68b` | `libsqlite3-0` | `3.46.1-7+deb13u1` | — | UPSTREAM_BLOCKED |
+| [#3624](https://github.com/jannekbuengener/Claire_de_Binare/issues/3624) | `cdb_signal` | [#5102](https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/5102) | `93331e9e21f0dc02` | `libsqlite3-0` | `3.46.1-7+deb13u1` | — | UPSTREAM_BLOCKED |
+| [#3625](https://github.com/jannekbuengener/Claire_de_Binare/issues/3625) | `cdb_ws` | [#4800](https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/4800) | `4c769769e8a07509` | `libsqlite3-0` | `3.46.1-7+deb13u1` | — | UPSTREAM_BLOCKED |
+
+Pinned base (all seven scope Dockerfiles @ `origin/main` `1e825269`):
+
+- `python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1`
+
+Sources: `services/{db_writer,execution,market,regime,risk,signal,ws}/Dockerfile`, `.github/workflows/security-scan.yml` (`trivy-scan-custom` matrix).
+
+---
+
+## Root-cause / fixability evidence
+
+### CVE-2026-11824 (SQLite FTS5 heap overflow)
+
+| Probe | Result |
+|-------|--------|
+| `docker pull python:3.14-slim-trixie` (2026-07-01) | Digest **unchanged**: `sha256:b877e50…` |
+| `apt-get update && apt-get upgrade -y` in base image | `libsqlite3-0` **Candidate: 3.46.1-7+deb13u1** (no upgrade available) |
+| `docker build -f services/risk/Dockerfile -t cdb_risk:cve11824-probe .` | Build **success** |
+| `trivy image cdb_risk:cve11824-probe` (0.71.2) | CVE-2026-11824 **still present**: `libsqlite3-0@3.46.1-7+deb13u1`, FixedVersion **empty** |
+| Debian Security Tracker | Trixie **vulnerable** @ `3.46.1-7+deb13u1`; note `[trixie] - sqlite3 <no-dsa> (Minor issue)` |
+| sid fixed version | `3.53.3-1` — **not** available on Trixie stable without base-image migration (out of slice scope) |
+| Prior slice #2289 Slice 4 | `apt-get upgrade -y` already present in all scope Dockerfiles — **did not close** this CVE |
+
+**Required fix:** SQLite **>= 3.53.2** (upstream advisory). Debian Trixie has not published a security backport.
+
+**Conclusion:** `FIXABLE_NOW_DIGEST_REFRESH` and `FIXABLE_NOW_APT_UPGRADE` **rejected**. Verdict: **UPSTREAM_BLOCKED**.
+
+### Exploitability note (CDB context)
+
+CDB BLUE services use Postgres/Redis for trading state; `libsqlite3-0` is an OS-layer dependency in the Python slim base. FTS5 exploitation requires crafted SQLite databases with FTS5 enabled — **no known CDB runtime path** supplies attacker-controlled SQLite files. Trivy/GitHub severity remains HIGH; operational risk is **indirect OS-layer exposure**, not a proven trading-core exploit path.
+
+---
+
+## Re-triage triggers
+
+Reopen remediation slice when **all** are true:
+
+1. Debian Trixie publishes `libsqlite3-0` with SQLite **>= 3.53.2** (security update or backport), **and**
+2. `docker build` + `trivy image` on representative scope service shows CVE-2026-11824 **absent**, **and**
+3. GitHub Code Scanning alerts #4725, #4800, #4877, #4954, #5102, #5256, #5332 transition to **closed/fixed**.
+
+Until then: track under #2513 / #2932 residual clusters; **no alert dismissals** without separate Human-GO.
+
+---
+
+## Safety boundaries
+
+- No alert dismissals.
+- No runtime, Docker Compose, or deploy changes.
+- No LR / live-readiness / live-trading / Echtgeld implication.
+- Code Scanning alerts remain **open**; this slice documents issue tracking and fixability only.
+- `allocation` has the same CVE alert (#5179) but is **out of slice scope** (#3619–#3625 only).
+
+---
+
+## Validation commands (this slice)
+
+```bash
+docker pull python:3.14-slim-trixie
+docker run --rm python:3.14-slim-trixie bash -c "apt-get update -qq && apt-get upgrade -y -qq && apt-cache policy libsqlite3-0"
+docker build -f services/risk/Dockerfile -t cdb_risk:cve11824-probe .
+trivy image --scanners vuln --format json cdb_risk:cve11824-probe
+git diff --check
+pytest -q tests/smoke/test_mcp_runtime.py --collect-only
+```


### PR DESCRIPTION
## Summary

- Triage and fixability evidence for **CVE-2026-11824** (`libsqlite3-0`) across BLUE custom service images tied to #3619–#3625.
- Fixability probes (base digest refresh, `apt-get upgrade`, probe build + Trivy on `cdb_risk:cve11824-probe`) show **no fixed package** on Debian Trixie.
- Verdict: **UPSTREAM_BLOCKED** — evidence matrix added; no Dockerfile changes; no alert dismissals.

## Delivered

- `docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3619-3625-CVE-11824_2026-07-01.md`
- Batch matrix for issues #3619–#3625 with GH alert IDs, fingerprints, probe results, re-triage triggers

## Security Evidence

| Probe | Result |
|---|---|
| `python:3.14-slim-trixie` digest pull | Unchanged `sha256:b877e50…` |
| `apt-get upgrade` on base | `libsqlite3-0` stays `3.46.1-7+deb13u1` |
| `docker build services/risk` + Trivy | CVE-2026-11824 still open, FixedVersion empty |
| Debian tracker | Trixie vulnerable; `<no-dsa>` (Minor issue) |

## Validation

- `git diff --check` — pass
- `pytest -q tests/smoke/test_mcp_runtime.py --collect-only` — 1 collected
- Local Trivy 0.71.2 on probe image documented in evidence file

## Non-goals

- No alert dismissals (Human-GO required per #2513)
- No Dockerfile/base-image changes (not fixable now)
- No allocation/candles/reports scope
- No BLUE/RED runtime recreate

## Safety Boundaries

- LR remains NO-GO; no live/echtgeld implication
- Code Scanning alerts stay open until Debian publishes fix + rescan verified
- Issues #3619–#3625 remain **open** with `status:blocked`

## Remaining uncertainty

- Code Scanning UI will not auto-close from docs-only merge; closure requires future image rebuild after Debian security update
- FTS5 exploit path not proven reachable in CDB runtime (OS-layer residual)
- `allocation` (#5179 alert) same CVE but out of slice scope

Refs #3619 #3620 #3621 #3622 #3623 #3624 #3625