### PR TITLE
fix(security): CVE-2026-25680 monitoring image pins (#3626–#3628)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -37,9 +37,9 @@ jobs:
             scan_name: redis
           - image: postgres:18.4-alpine@sha256:1b1689b20d16a014a3d195653381cf2caa75a41a92d93b255a9d6ea29fd353aa
             scan_name: postgres
-          - image: prom/prometheus:v3.11.3@sha256:e4254400b85610324913f0dc4acf92603d9984e7519414c5a12811aa6146acc3
+          - image: prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
             scan_name: prometheus
-          - image: grafana/grafana:12.4.3-security-02-ubuntu@sha256:089f9dbbfa3c21e6989aab20f14f1a78cef54c04819af5e9deb2bd9c37966bc5
+          - image: grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084
             scan_name: grafana
       fail-fast: false
 

--- a/docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3626-3628-CVE-25680_2026-07-01.md
+++ b/docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3626-3628-CVE-25680_2026-07-01.md
@@ -1,0 +1,87 @@
+# Security Batch Matrix — Issues #3626–#3628 / CVE-2026-25680
+
+**Stand:** 2026-07-01 (UTC)  
+**Parent epic:** [#2289](https://github.com/jannekbuengener/Claire_de_Binare/issues/2289)  
+**Related:** [#2933](https://github.com/jannekbuengener/Claire_de_Binare/issues/2933) (upstream-blocked monitoring cluster)  
+**Branch:** `fix/3626-cve-2026-25680-monitoring-images`  
+**Scope guard:** Image-pin alignment only. Kein LR-Go, keine Alert-Dismissals, keine Dashboard/Rule/Runtime-Konfig-Änderung.
+
+---
+
+## Executive summary
+
+| Gruppe | Issues | CVE | Package | Installed (vulnerable pins) | Fixed Version | Verdict |
+|--------|--------|-----|---------|----------------------------|---------------|---------|
+| Prometheus / promtool | #3626, #3627 | CVE-2026-25680 | `golang.org/x/net` | v0.52.0 (v3.11.3 image) | 0.55.0 | **FIXABLE** |
+| Grafana | #3628 | CVE-2026-25680 | `golang.org/x/net` | v0.49.0 (12.4.3-security image) | 0.55.0 | **FIXABLE** |
+
+**Remediation:** Align stale pins in `base.yml` and `security-scan.yml` to match **already scan-verified** RED runtime pins in `compose.red.yml` (`prom/prometheus:v3.12.0`, `grafana/grafana:13.0.3-ubuntu`).
+
+---
+
+## Batch matrix
+
+| Issue | Component | GH alert | Fingerprint | Vulnerable pin | Target pin | Verdict |
+|-------|-----------|----------|-------------|----------------|------------|---------|
+| [#3626](https://github.com/jannekbuengener/Claire_de_Binare/issues/3626) | `bin/prometheus` | [#4640](https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/4640) | `2ff127605a49b6ff` | `prom/prometheus:v3.11.3` | `v3.12.0@sha256:69f524…` | FIXED_BY_PIN |
+| [#3627](https://github.com/jannekbuengener/Claire_de_Binare/issues/3627) | `bin/promtool` | [#4661](https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/4661) | `5a3b77d08b13a6b8` | `prom/prometheus:v3.11.3` | `v3.12.0@sha256:69f524…` | FIXED_BY_PIN |
+| [#3628](https://github.com/jannekbuengener/Claire_de_Binare/issues/3628) | `usr/share/grafana/bin/grafana` | [#5035](https://github.com/jannekbuengener/Claire_de_Binare/security/code-scanning/5035) | `a5ffde1377c6e13d` | `grafana/grafana:12.4.3-security-02-ubuntu` | `13.0.3-ubuntu@sha256:7c1acd…` | FIXED_BY_PIN |
+
+---
+
+## Root-cause / fixability evidence
+
+### CVE-2026-25680 (golang.org/x/net HTML parser DoS)
+
+| Probe | Image | CVE-2026-25680 hits | golang.org/x/net |
+|-------|-------|---------------------|------------------|
+| Before (vulnerable) | `prom/prometheus:v3.11.3@sha256:e4254400…` | **2** (prometheus + promtool) | v0.52.0 |
+| After (target) | `prom/prometheus:v3.12.0@sha256:69f524…` | **0** | (>= 0.55.0) |
+| Before (vulnerable) | `grafana/grafana:12.4.3-security-02-ubuntu@sha256:089f9dbb…` | **1** | v0.49.0 |
+| After (target) | `grafana/grafana:13.0.3-ubuntu@sha256:7c1acd…` | **0** | (>= 0.55.0) |
+
+Trivy 0.71.2 local rescan (2026-07-01). Fixed Version per advisory: **0.55.0**.
+
+### Drift note
+
+`infrastructure/compose/compose.red.yml` **already** pinned the CVE-cleared images before this slice. Alerts persisted because `base.yml` and `.github/workflows/security-scan.yml` still scanned/shipped older vulnerable digests.
+
+**Conclusion:** `UPSTREAM_BLOCKED` **rejected** — upstream fixed releases exist and are already validated in RED runtime compose. Slice = **pin reconciliation**, not breaking major upgrade discovery.
+
+---
+
+## Changed files (this slice)
+
+| File | Change |
+|------|--------|
+| `infrastructure/compose/base.yml` | Prometheus + Grafana image pins → v3.12.0 / 13.0.3-ubuntu |
+| `.github/workflows/security-scan.yml` | `trivy-scan-base` matrix aligned |
+| `knowledge/governance/SERVICE_CATALOG.md` | Prometheus catalog line aligned |
+| `infrastructure/compose/compose.prometheus-v3.yml` | Comment only (default runtime version) |
+
+**Not changed:** `compose.red.yml` (already correct), Grafana dashboards/rules, Alertmanager, runtime recreate.
+
+---
+
+## Post-merge verification
+
+Code Scanning alerts #4640, #4661, #5035 close after next successful `security-scan.yml` SARIF upload on `main` with updated matrix pins. No manual dismissals.
+
+---
+
+## Safety boundaries
+
+- No alert dismissals without Human-GO.
+- No LR / live-readiness / Echtgeld implication.
+- No BLUE/RED stack recreate in this slice (operator scope separate).
+
+---
+
+## Validation commands
+
+```bash
+trivy image prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
+trivy image grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084
+git diff --check
+pytest -q tests/smoke/test_mcp_runtime.py --collect-only
+```

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -56,7 +56,7 @@ services:
       - cdb_network
 
   cdb_prometheus:
-    image: prom/prometheus:v3.11.3@sha256:e4254400b85610324913f0dc4acf92603d9984e7519414c5a12811aa6146acc3
+    image: prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
     container_name: cdb_prometheus
     restart: unless-stopped
     volumes:
@@ -75,7 +75,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:12.4.3-security-02-ubuntu@sha256:089f9dbbfa3c21e6989aab20f14f1a78cef54c04819af5e9deb2bd9c37966bc5
+    image: grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084
     container_name: cdb_grafana
     restart: unless-stopped
     environment:

--- a/infrastructure/compose/compose.prometheus-v3.yml
+++ b/infrastructure/compose/compose.prometheus-v3.yml
@@ -4,7 +4,7 @@
 #
 # Scope:
 # - Adds an optional parallel Prometheus v3 canary service
-# - Does not change default runtime service cdb_prometheus (v3.11.3)
+# - Does not change default runtime service cdb_prometheus (v3.12.0)
 
 services:
   cdb_prometheus_v3:

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -120,7 +120,7 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 
 | Service | Container | Image | Port | Status | Funktion |
 |---------|-----------|-------|------|--------|----------|
-| **Prometheus** | cdb_prometheus | prom/prometheus:v3.11.3 | 19090→9090 | **AKTIV** | Metrics Collection |
+| **Prometheus** | cdb_prometheus | prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac | 19090→9090 | **AKTIV** | Metrics Collection |
 | **Grafana** | cdb_grafana | grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084 | 3000 | **AKTIV** | Dashboards |
 | **Postgres Exporter** | cdb_postgres_exporter | prometheuscommunity/postgres-exporter | 9187 | **AKTIV** | PG Metrics; DSN-Wiring ueber `postgres_password` Secret + `PGPASSWORD`, `DATA_SOURCE_NAME` wird zur Laufzeit aus `POSTGRES_USER`/`POSTGRES_DB` und Host/Port zusammengesetzt |
 | **Redis Exporter** | cdb_redis_exporter | bitnami/redis-exporter | 9121 | **AKTIV** | Redis Metrics |


### PR DESCRIPTION
## Summary

- Align stale Prometheus/Grafana image pins in `base.yml` and `security-scan.yml` with CVE-cleared RED runtime pins already in `compose.red.yml`.
- Closes Code Scanning alerts for CVE-2026-25680 (`golang.org/x/net` < 0.55.0) in `bin/prometheus`, `bin/promtool`, and Grafana binary.
- Adds security evidence matrix with before/after Trivy probes.

Closes #3626
Closes #3627
Closes #3628

## Delivered

| File | Change |
|------|--------|
| `infrastructure/compose/base.yml` | `prom/prometheus` v3.11.3 → v3.12.0; `grafana/grafana` 12.4.3-security → 13.0.3-ubuntu (digest-pinned) |
| `.github/workflows/security-scan.yml` | Trivy matrix aligned to same pins |
| `knowledge/governance/SERVICE_CATALOG.md` | Prometheus catalog line updated |
| `infrastructure/compose/compose.prometheus-v3.yml` | Comment only |
| `docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3626-3628-CVE-25680_2026-07-01.md` | Evidence matrix |

## Security Evidence

- **CVE:** CVE-2026-25680 — `golang.org/x/net` HTML parser DoS; fixed in **0.55.0**
- **Before:** `prom/prometheus:v3.11.3` → 2 hits; `grafana/grafana:12.4.3-security-02-ubuntu` → 1 hit (Trivy 0.71.2)
- **After:** `prom/prometheus:v3.12.0@sha256:69f524…` → 0 hits; `grafana/grafana:13.0.3-ubuntu@sha256:7c1acd…` → 0 hits
- **Verdict:** FIXABLE (pin reconciliation; RED runtime already used target pins)

## Validation

- [x] `git diff --check`
- [x] `pytest -q tests/smoke/test_mcp_runtime.py --collect-only` — 1 collected
- [x] Local Trivy rescan on target image digests (0 CVE-2026-25680 hits)

## Non-goals

- No Grafana dashboard or Prometheus rule changes
- No Alertmanager / runtime reconfiguration
- No BLUE/RED stack recreate
- No alert dismissals (alerts close via next SARIF upload)

## Safety Boundaries

- LR remains NO-GO; no live/echtgeld scope
- No secrets in diff
- Monitoring image pins only

## Remaining uncertainty

- Code Scanning alerts #4640, #4661, #5035 close after next successful `security-scan` workflow on `main`; not instant on merge.
