### PR TITLE
docs(session): close CVE-2026-11824 S1 blocked cluster ledger

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -10,6 +10,8 @@
 
 ## Repo / Engineering Status (2026-07-01)
 
+- **CVE-2026-11824 BLUE services #3619–#3625 / PR #3629 / `23401b21`**: MERGED (evidence-only). Verdict **UPSTREAM_BLOCKED** — `libsqlite3-0` in `python:3.14-slim-trixie`; Debian Trixie `<no-dsa>`. Issues #3619–#3625 bleiben **OPEN** (`status:blocked`). Evidence: `docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3619-3625-CVE-11824_2026-07-01.md`. Re-Triage via Tracker #2513. LR NO-GO.
+
 - **Backup manifest Redis drift #3614 / PR #3615**: `Components.Redis` aligned with `redis_dump.rdb` artifact via `Sync-BackupComponentManifest`; restore tolerates legacy drift ZIPs. Closes #3614. LR NO-GO.
 
 - **`.pg15_archived` cleanup follow-up #3612`**: OPEN — optional volume cleanup after PG18 retention window (earliest 2026-07-15); no delete authorized yet. LR NO-GO.

--- a/knowledge/logs/sessions/2026-07-01-cve-11824-blue-services-3619-3625.md
+++ b/knowledge/logs/sessions/2026-07-01-cve-11824-blue-services-3619-3625.md
@@ -1,0 +1,53 @@
+# Session Log — CVE-2026-11824 BLUE Services (#3619–#3625)
+
+**Date:** 2026-07-01  
+**Branch:** `fix/3619-cve-2026-11824-blue-services`  
+**PR:** [#3629](https://github.com/jannekbuengener/Claire_de_Binare/pull/3629)  
+**Merge-SHA:** `23401b217ae83677ad2536338f43ced1c5d4a3ea`
+
+## Scope
+
+Security Slice S1 — triage and bounded remediation for CVE-2026-11824 across seven BLUE custom services (`python:3.14-slim-trixie` base).
+
+## Verdict
+
+**UPSTREAM_BLOCKED** — no Dockerfile/digest diff in this slice. Debian Trixie has not published a security backport for `libsqlite3-0`; Trivy FixedVersion empty.
+
+## Root Cause
+
+`libsqlite3-0@3.46.1-7+deb13u1` in `python:3.14-slim-trixie`; fix requires SQLite **>= 3.53.2**. Debian tracker: Trixie vulnerable, `<no-dsa>` (Minor issue). sid fixed at `3.53.3-1` — not available on Trixie without base migration (out of slice scope).
+
+## Delivered
+
+- `docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3619-3625-CVE-11824_2026-07-01.md` — batch matrix, fixability probes, re-triage triggers
+
+**Not changed:** Dockerfiles, Compose, runtime, alert dismissals.
+
+## Fixability Probes (summary)
+
+| Probe | Result |
+|-------|--------|
+| `python:3.14-slim-trixie` digest pull | Unchanged `sha256:b877e50…` |
+| `apt-get upgrade` in base | `libsqlite3-0` stays `3.46.1-7+deb13u1` |
+| `docker build` + Trivy on `cdb_risk:cve11824-probe` | CVE-2026-11824 still present |
+
+## Issue Status
+
+#3619, #3620, #3621, #3622, #3623, #3624, #3625 — **OPEN** (`status:blocked`). Evidence comments posted; issues intentionally not closed.
+
+## Re-Triage
+
+Reopen remediation when all conditions in evidence matrix §Re-triage triggers are met. Watch tracked under [#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513).
+
+## Boundaries
+
+- No alert dismissals without Human-GO
+- No runtime / Docker Compose / deploy changes
+- LR NO-GO unchanged
+- `allocation` alert #5179 same CVE — out of S1 slice scope
+
+## Validation
+
+- `git diff --check` — clean (evidence-only PR)
+- `pytest -q tests/smoke/test_mcp_runtime.py --collect-only` — 1 collected
+- CI + policy-gate green on PR #3629


### PR DESCRIPTION
## Summary

- Session log for Security Slice S1 (CVE-2026-11824, #3619–#3625): verdict **UPSTREAM_BLOCKED**, PR #3629 evidence merged.
- CURRENT_STATUS ledger entry: issues remain OPEN (`status:blocked`); re-triage via #2513.

## Delivered

| File | Change |
|------|--------|
| `knowledge/logs/sessions/2026-07-01-cve-11824-blue-services-3619-3625.md` | Session close log |
| `CURRENT_STATUS.md` | S1 blocked-cluster bullet |

## Validation

- [x] `git diff --check`
- [x] `pytest -q tests/smoke/test_mcp_runtime.py --collect-only` — 1 collected

## Non-goals

- No Dockerfile/Compose/runtime changes
- No issue close (#3619–#3625 stay OPEN until upstream fix)
- No alert dismissals

## Safety Boundaries

- LR NO-GO; docs-only
- No secrets

## Remaining uncertainty

Re-triage watch procedure anchored on #2513 (separate comment in this session).
