### PR TITLE
docs(skills): canonicalize CDB skill source tree

### DIFF
--- a/docs/skills/CDB.VERFUEGBARE.SKILLS_LISTE_2026-07-01.md
+++ b/docs/skills/CDB.VERFUEGBARE.SKILLS_LISTE_2026-07-01.md
@@ -1,0 +1,102 @@
+# CDB Verfügbare Skills — Übersicht
+
+| Field | Value |
+| --- | --- |
+| Status | **canonical** (available-skills index) |
+| Date | 2026-07-01 |
+| Supersedes | [`CDB.VERFUEGBARE.SKILLS_LISTE_2026-06-30.md`](CDB.VERFUEGBARE.SKILLS_LISTE_2026-06-30.md) |
+| Related | PR skills-canon-sync, Issue #3598 (Vorgänger-Index) |
+
+## Zweck
+
+Diese Liste fasst **verfügbare Agent-Skills** für CDB-Arbeit zusammen und verweist
+auf die jeweiligen SSOT-Dokumente. Sie ersetzt keine Skill-Implementierungen und
+erfindet keine neuen Slash-Befehle.
+
+**Registry / Mirror-Modell:** [`SKILL_SURFACE_REGISTRY.md`](SKILL_SURFACE_REGISTRY.md)
+
+**Canon-Update 2026-07-01:** Alle 25 aktiven CDB-Repo-Skills haben jetzt
+`docs/skills/<name>/SKILL.md` als Single Source of Truth. Surface-Adapter
+(`.opencode/`, `.cursor/`, `.codex/`, `.claude/`) sind Mirror — Änderungen
+starten in `docs/skills/`.
+
+## Grenze: Brain vs Runtime
+
+| Rolle | Technologie | SSOT |
+| --- | --- | --- |
+| **Brain / Context Intelligence** | SurrealDB Context Brain | [`CDB_SURREALDB_SKILLS_RULES_ACTIVATION.md`](CDB_SURREALDB_SKILLS_RULES_ACTIVATION.md), `knowledge/decisions/CDB_CONTEXT_BRAIN_DEFAULT_POSTURE.md` |
+| **Runtime / Cache / Messaging** | Redis (`cdb_redis`) | [`CDB_REDIS_SKILL_ROUTING.md`](CDB_REDIS_SKILL_ROUTING.md) |
+
+## Session-Boundary (Pflicht, CDB repo skills)
+
+| Skill | Canon | Surface-Adapter |
+| --- | --- | --- |
+| `cdb-session-start` | [`cdb-session-start/SKILL.md`](cdb-session-start/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-session-close` | [`cdb-session-close/SKILL.md`](cdb-session-close/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-control-intake` | [`cdb-control-intake/SKILL.md`](cdb-control-intake/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-issue-to-session-plan` | [`cdb-issue-to-session-plan/SKILL.md`](cdb-issue-to-session-plan/SKILL.md) | opencode, cursor, codex, claude |
+| `onboarding` | [`onboarding/SKILL.md`](onboarding/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-onboarding` | [`cdb-onboarding/SKILL.md`](cdb-onboarding/SKILL.md) | codex alias → onboarding |
+
+Bootloader vor Skills: `AGENTS.md` → `agents/AGENTS.md` → `agents/OPEN_CODE_AGENTS.md`.
+
+## CDB Repo-Domain-Skills (kanonisch unter docs/skills/)
+
+| Skill | Canon | Zweck |
+| --- | --- | --- |
+| `cdb-operator` | [`cdb-operator/SKILL.md`](cdb-operator/SKILL.md) | Bootloader, GO gates |
+| `cdb-trading-core` | [`cdb-trading-core/SKILL.md`](cdb-trading-core/SKILL.md) | Trading core |
+| `cdb-risk-governance` | [`cdb-risk-governance/SKILL.md`](cdb-risk-governance/SKILL.md) | Risk governance |
+| `cdb-exchange-adapters` | [`cdb-exchange-adapters/SKILL.md`](cdb-exchange-adapters/SKILL.md) | Exchange adapters |
+| `cdb-backtest-engine` | [`cdb-backtest-engine/SKILL.md`](cdb-backtest-engine/SKILL.md) | Backtest |
+| `cdb-shadow-validation` | [`cdb-shadow-validation/SKILL.md`](cdb-shadow-validation/SKILL.md) | Shadow validation |
+| `cdb-contract-evidence-gatekeeper` | [`cdb-contract-evidence-gatekeeper/SKILL.md`](cdb-contract-evidence-gatekeeper/SKILL.md) | Contract evidence |
+| `cdb-drift-reconcile` | [`cdb-drift-reconcile/SKILL.md`](cdb-drift-reconcile/SKILL.md) | Drift reconcile |
+| `cdb-ci-cd-guard` | [`cdb-ci-cd-guard/SKILL.md`](cdb-ci-cd-guard/SKILL.md) | CI/CD guardrails |
+| `cdb-docs-ops` | [`cdb-docs-ops/SKILL.md`](cdb-docs-ops/SKILL.md) | Docs maintenance |
+| `cdb-external-docs` | [`cdb-external-docs/SKILL.md`](cdb-external-docs/SKILL.md) | External docs index |
+| `ctb-docker-stack` | [`ctb-docker-stack/SKILL.md`](ctb-docker-stack/SKILL.md) | Docker BLUE+RED |
+| `cdb-github-api-ops` | [`cdb-github-api-ops/SKILL.md`](cdb-github-api-ops/SKILL.md) | GitHub API routing |
+| `gh-fix-ci` | [`gh-fix-ci/SKILL.md`](gh-fix-ci/SKILL.md) | CI failures |
+| `gh-address-comments` | [`gh-address-comments/SKILL.md`](gh-address-comments/SKILL.md) | PR review comments |
+| `cdb-test-first` | [`cdb-test-first/SKILL.md`](cdb-test-first/SKILL.md) | Test-first planning |
+
+Vollständige Tabelle: [`README.md`](README.md). Cursor-Pointer: [`AGENTS.md`](../../AGENTS.md).
+
+## SurrealDB Skills (official, curated — Brain-Scope)
+
+| Skill | Canon | Rolle |
+| --- | --- | --- |
+| `surrealql` | [`surrealql/SKILL.md`](surrealql/SKILL.md) | SurrealQL / Context queries |
+| `surrealdb-vector` | [`surrealdb-vector/SKILL.md`](surrealdb-vector/SKILL.md) | Vector in SurrealDB context |
+| `surrealdb-python` | [`surrealdb-python/SKILL.md`](surrealdb-python/SKILL.md) | Python SDK |
+
+SSOT Activation: [`CDB_SURREALDB_SKILLS_RULES_ACTIVATION.md`](CDB_SURREALDB_SKILLS_RULES_ACTIVATION.md)
+
+## Redis Skills — Routing SSOT (extern, nicht mirrored)
+
+**SSOT:** [`CDB_REDIS_SKILL_ROUTING.md`](CDB_REDIS_SKILL_ROUTING.md)
+
+## Nicht als aktive Skills
+
+- `skillforge/` — Meta-Tool, gitignored
+- `mockexchange/` — kein SKILL.md
+- `codex-primary-runtime` — kein verifizierter SKILL.md
+- Redis Plugin Skills — routing-only
+- `.gemini/skills/` — eingeschränkt (4 Skills), kein Domain-Mirror
+
+## Verwandte Dokumente
+
+| Dokument | Rolle |
+| --- | --- |
+| [`README.md`](README.md) | `docs/skills/` Index (25 Skills) |
+| [`SKILL_SURFACE_REGISTRY.md`](SKILL_SURFACE_REGISTRY.md) | Mirror-SSOT, Drift-Matrix §16 |
+| [`CDB_REDIS_SKILL_ROUTING.md`](CDB_REDIS_SKILL_ROUTING.md) | Redis-Routing-SSOT |
+| [`agents/OPEN_CODE_AGENTS.md`](../../agents/OPEN_CODE_AGENTS.md) | OpenCode Skill Routing |
+| [`AGENTS.md`](../../AGENTS.md) | Root pointer |
+
+## Non-goals
+
+- Keine Runtime-/Config-/Compose-Änderungen
+- Keine fachliche Erweiterung von `cdb-session-close` in diesem Index
+- LR bleibt **NO-GO**

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -7,36 +7,68 @@ Alle anderen Surface-Pfade (`.opencode/`, `.cursor/`, `.codex/`,
 `.claude/`) sind Mirror-Adapter und muessen gegen diese Dateien
 synchron gehalten werden.
 
-## Kanonische Skill-Dateien
+**Aenderungen an Skills starten hier.** Surface-Adapter werden daraus gespiegelt.
 
-| Skill / Dokument | Pfad | Eingefuehrt |
+## Kanonische Skill-Dateien (25 aktive CDB-Repo-Skills)
+
+| Skill | Pfad | Surfaces |
 |---|---|---|
-| `gh-fix-ci` | [`gh-fix-ci/SKILL.md`](gh-fix-ci/SKILL.md) | bestehend |
-| `cdb-github-api-ops` | [`cdb-github-api-ops/SKILL.md`](cdb-github-api-ops/SKILL.md) | PR #3569 |
+| `onboarding` | [`onboarding/SKILL.md`](onboarding/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-onboarding` | [`cdb-onboarding/SKILL.md`](cdb-onboarding/SKILL.md) | codex (alias → onboarding) |
+| `cdb-session-start` | [`cdb-session-start/SKILL.md`](cdb-session-start/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-session-close` | [`cdb-session-close/SKILL.md`](cdb-session-close/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-control-intake` | [`cdb-control-intake/SKILL.md`](cdb-control-intake/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-issue-to-session-plan` | [`cdb-issue-to-session-plan/SKILL.md`](cdb-issue-to-session-plan/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-operator` | [`cdb-operator/SKILL.md`](cdb-operator/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-test-first` | [`cdb-test-first/SKILL.md`](cdb-test-first/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-trading-core` | [`cdb-trading-core/SKILL.md`](cdb-trading-core/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-risk-governance` | [`cdb-risk-governance/SKILL.md`](cdb-risk-governance/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-exchange-adapters` | [`cdb-exchange-adapters/SKILL.md`](cdb-exchange-adapters/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-backtest-engine` | [`cdb-backtest-engine/SKILL.md`](cdb-backtest-engine/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-shadow-validation` | [`cdb-shadow-validation/SKILL.md`](cdb-shadow-validation/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-contract-evidence-gatekeeper` | [`cdb-contract-evidence-gatekeeper/SKILL.md`](cdb-contract-evidence-gatekeeper/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-drift-reconcile` | [`cdb-drift-reconcile/SKILL.md`](cdb-drift-reconcile/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-docs-ops` | [`cdb-docs-ops/SKILL.md`](cdb-docs-ops/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-external-docs` | [`cdb-external-docs/SKILL.md`](cdb-external-docs/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-ci-cd-guard` | [`cdb-ci-cd-guard/SKILL.md`](cdb-ci-cd-guard/SKILL.md) | opencode, cursor, codex, claude |
+| `ctb-docker-stack` | [`ctb-docker-stack/SKILL.md`](ctb-docker-stack/SKILL.md) | opencode, cursor, codex, claude |
+| `gh-fix-ci` | [`gh-fix-ci/SKILL.md`](gh-fix-ci/SKILL.md) | opencode, cursor, codex, claude |
+| `gh-address-comments` | [`gh-address-comments/SKILL.md`](gh-address-comments/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-github-api-ops` | [`cdb-github-api-ops/SKILL.md`](cdb-github-api-ops/SKILL.md) | opencode, cursor, codex, claude |
+| `surrealql` | [`surrealql/SKILL.md`](surrealql/SKILL.md) | opencode, cursor, codex, claude |
+| `surrealdb-vector` | [`surrealdb-vector/SKILL.md`](surrealdb-vector/SKILL.md) | opencode, cursor, codex, claude |
+| `surrealdb-python` | [`surrealdb-python/SKILL.md`](surrealdb-python/SKILL.md) | opencode, cursor, codex, claude |
+
+## Routing / Index (kein SKILL.md-Mirror)
+
+| Dokument | Pfad | Rolle |
+|---|---|---|
 | Redis Skill Routing (SSOT) | [`CDB_REDIS_SKILL_ROUTING.md`](CDB_REDIS_SKILL_ROUTING.md) | PR #3597 |
-| Verfuegbare Skills (Index) | [`CDB.VERFUEGBARE.SKILLS_LISTE_2026-06-30.md`](CDB.VERFUEGBARE.SKILLS_LISTE_2026-06-30.md) | PR #3598 |
+| Verfuegbare Skills (Index) | [`CDB.VERFUEGBARE.SKILLS_LISTE_2026-07-01.md`](CDB.VERFUEGBARE.SKILLS_LISTE_2026-07-01.md) | aktueller Index |
+| Verfuegbare Skills (Vorgaenger) | [`CDB.VERFUEGBARE.SKILLS_LISTE_2026-06-30.md`](CDB.VERFUEGBARE.SKILLS_LISTE_2026-06-30.md) | PR #3598 |
 | SurrealDB Skills Activation | [`CDB_SURREALDB_SKILLS_RULES_ACTIVATION.md`](CDB_SURREALDB_SKILLS_RULES_ACTIVATION.md) | #3482 |
+
+## Nicht als aktive Skills
+
+| Fläche | Grund |
+|---|---|
+| `skillforge/` | Meta-Tool, gitignored, Registry §5 |
+| `mockexchange/` | Kein `SKILL.md` |
+| `codex-primary-runtime` | Kein verifizierter Skill-Inhalt |
+| `.cursor/rules/`, `.cursor/agents/` | Rules/Subagents |
+| Redis Plugin Skills | Routing-only (extern) |
+| `.claude/skills/*.skill` | Alias/Paketfläche, nicht primäre Quelle |
+| `.gemini/skills/` | Eingeschraenkt (4 Skills), nicht Domain-Mirror |
 
 ## Redis Skills (extern — Routing only)
 
 Redis-Plugin-Skills sind **nicht** repo-mirrored. Routing-SSOT:
 [`CDB_REDIS_SKILL_ROUTING.md`](CDB_REDIS_SKILL_ROUTING.md).
 
-- **Core:** `redis-development`, `redis-core`, `redis-connections`,
-  `redis-security`, `redis-observability`
-- **Event/Runtime-Zusatz:** `messaging-redis-streams`, `ctb-docker-stack`,
-  `cdb-shadow-validation`
-- **Parking-Lot:** `redis-search`, `redis-semantic-cache`, RedisVL, LangCache,
-  RQE/Vector — nicht Default
-
-SurrealDB bleibt Brain; Redis bleibt Runtime/Cache/Messaging. Siehe auch
-[`CDB.VERFUEGBARE.SKILLS_LISTE_2026-06-30.md`](CDB.VERFUEGBARE.SKILLS_LISTE_2026-06-30.md).
-
 ## Registry
 
 - [`SKILL_SURFACE_REGISTRY.md`](SKILL_SURFACE_REGISTRY.md): verbindliche
-  Definition der kanonischen Flaeche, der Surface-Adapter-Typen und
-  der Drift-Regeln.
+  Definition der kanonischen Flaeche, Inventar, Drift-Matrix und Adapter-Regeln.
 
 ## Neue Skills
 

--- a/docs/skills/SKILL_SURFACE_REGISTRY.md
+++ b/docs/skills/SKILL_SURFACE_REGISTRY.md
@@ -211,15 +211,59 @@ Regeln:
 
 ## 15. Folge-Issues / naechste Slices
 
-Vorgeschlagen, **nicht in diesem Slice zu erstellen**:
+Nach Canon-Tree-Merge (2026-07-01):
 
+- `[SKILLS] Mirror surface adapters from docs/skills canon` — Header + byte-sync
+  fuer Skills mit bekannter Drift (`cdb-session-start`, `onboarding`, `gh-fix-ci`,
+  `cdb-github-api-ops`)
+- `[SKILLS] Extend cdb-session-close with post-close follow-up issue intake`
 - `[SKILLS] Apply Surface-Adapter-Header to all existing mirrored skills`
 - `[SKILLS] Add drift-reconcile hook for skill surface adapters`
 - `[SKILLS] Add skill-meta schema (META.yaml + evals.json) for new CDB domain skills`
 - `[SKILLS] Document `.gemini/` activation policy if domain skills are ever needed`
 
-Diese Issues werden dedupliziert und mit klarem Scope spaeter angelegt,
-sobald die Registry auf `main` ist.
+Diese Issues werden dedupliziert und mit klarem Scope angelegt.
+
+## 16. Aktives Skill-Inventar (2026-07-01)
+
+Status nach Canon-Tree-Slice: **25/25** aktive CDB-Repo-Skills haben
+`docs/skills/<name>/SKILL.md`. Surface-Adapter bleiben vorerst unveraendert;
+Drift ist dokumentiert.
+
+| Skill | Canon | opencode | cursor | codex | claude | Body-Drift |
+|---|---|---|---|---|---|---|
+| cdb-session-start | Y | Y | Y | Y | Y | cursor, codex, claude |
+| cdb-session-close | Y | Y | Y | Y | Y | — |
+| cdb-control-intake | Y | Y | Y | Y | Y | — |
+| cdb-issue-to-session-plan | Y | Y | Y | Y | Y | — |
+| cdb-operator | Y | Y | Y | Y | Y | — |
+| onboarding | Y | Y | Y | Y | Y | cursor, codex, claude |
+| cdb-onboarding | Y | — | — | Y | — | — (alias) |
+| cdb-test-first | Y | Y | Y | Y | Y | — |
+| cdb-trading-core | Y | Y | Y | Y | Y | — |
+| cdb-risk-governance | Y | Y | Y | Y | Y | — |
+| cdb-exchange-adapters | Y | Y | Y | Y | Y | — |
+| cdb-backtest-engine | Y | Y | Y | Y | Y | — |
+| cdb-shadow-validation | Y | Y | Y | Y | Y | — |
+| cdb-contract-evidence-gatekeeper | Y | Y | Y | Y | Y | — |
+| cdb-drift-reconcile | Y | Y | Y | Y | Y | — |
+| cdb-docs-ops | Y | Y | Y | Y | Y | — |
+| cdb-external-docs | Y | Y | Y | Y | Y | — |
+| cdb-ci-cd-guard | Y | Y | Y | Y | Y | — |
+| ctb-docker-stack | Y | Y | Y | Y | Y | — |
+| gh-fix-ci | Y | Y | Y | Y | Y | alle Adapter (Canon hat scripts/META) |
+| gh-address-comments | Y | Y | Y | Y | Y | — |
+| cdb-github-api-ops | Y | Y | Y | Y | Y | alle Adapter (Header-only auf Canon) |
+| surrealql | Y | Y | Y | Y | Y | — |
+| surrealdb-vector | Y | Y | Y | Y | Y | — |
+| surrealdb-python | Y | Y | Y | Y | Y | — |
+
+**Nicht gezaehlt:** `skillforge` (Meta-Tool, gitignored), `mockexchange`
+(kein SKILL.md), `codex-primary-runtime` (kein SKILL.md), Cursor Rules/Subagents,
+Redis Plugin (routing-only), `.claude/skills/*.skill` (Alias).
+
+**Drift-Policy dieses Slices:** Canon-Inhalt aus OpenCode-Prioritaet; Adapter-Sync
+ist Follow-up-Issue `[SKILLS] Mirror surface adapters from docs/skills canon`.
 
 ## Anti-Patterns
 

--- a/docs/skills/cdb-backtest-engine/SKILL.md
+++ b/docs/skills/cdb-backtest-engine/SKILL.md
@@ -1,0 +1,38 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-backtest-engine/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-backtest-engine
+description: Deterministic CDB backtesting and strategy evaluation in the working repo. Use when Codex needs to run or update offline backtests, parameter sweeps, walk-forward tests, baseline comparisons, or PR-ready evidence packs. Treat the local working repo as canon, not the retired external docs repo; never infer live readiness from Board stage; no live keys, no live or testnet execution.
+disable-model-invocation: true
+---
+
+# Backtest Engine
+
+## Canon first
+- Use local working-repo paths only.
+- Read `CURRENT_STATUS.md` for repo and engineering context.
+- Read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for Echtgeld guardrails and current `NO-GO`.
+- Read `docs/runbooks/CONTROL_REGISTER.md` for Board stage, but never treat `trade-capable` as live authorization.
+
+## Use this when you see
+- backtest, walk-forward, parameter sweep
+- baseline comparison or regression check
+- equity curve, drawdown, Sharpe, profit factor
+- evidence pack, report, or gate-supporting metrics
+
+## Hard rules
+- Evidence over assumptions: if the dataset, baseline, or configuration is ambiguous, stop and surface the missing artifact.
+- Determinism required: freeze dataset window, seed, parameters, and code reference.
+- Offline replay only. Do not call live or testnet endpoints.
+- Always print output artifact paths in the final response.
+
+## Default deliverables
+1. `results.json` for raw run output when available
+2. `metrics.json` for computed summary
+3. `report.md` for human-readable evidence
+4. `compare.md` only when a baseline is provided

--- a/docs/skills/cdb-ci-cd-guard/SKILL.md
+++ b/docs/skills/cdb-ci-cd-guard/SKILL.md
@@ -1,0 +1,61 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-ci-cd-guard/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-ci-cd-guard
+description: CDB CI/CD governance audit and hardening for the working repo. Use when GitHub Actions, rulesets, required checks, secret guards, or fake-green behavior need to be verified or fixed. Derive protected refs, required checks, and enforcement behavior from current repo evidence and GitHub state instead of assuming old branch patterns or legacy docs-hub paths.
+disable-model-invocation: true
+---
+
+# CI/CD Guard
+
+## Canon first
+- Use the working repo as the only default source.
+- Start control-first:
+  1. GitHub control issue `#1445`
+  2. newest weekly comment on `#1445`
+  3. stage-ratification issue `#1492` as Board context only
+  4. `docs/runbooks/CONTROL_REGISTER.md`
+  5. `CURRENT_STATUS.md`
+  6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+  7. only then inspect rulesets, issues, PRs, and workflows
+- Read `docs/index.md` and `docs/runbooks/merge_policy_ci_gate.md` for local CI canon after the control-first chain.
+- Treat GitHub rulesets and required checks as evidence-bearing runtime state. If they are not observable, report the gap instead of inventing a result.
+- Treat `#1492` only as current Board context, not as any CI or LR override.
+
+## Use this when
+- a run is green but hidden stub, mock, skip, or fallback behavior is suspected
+- required checks, branch protection, secret guards, or delivery gates look inconsistent
+- workflow behavior changes by branch or secret availability
+
+## Hard rules
+- Do not assume protected branch patterns. Derive them from current rulesets, workflows, or explicit user input.
+- No silent stub or mock path on protected refs.
+- Missing critical secrets on protected refs must fail closed.
+- Without explicit approval, default to audit plus fix plan rather than mutation.
+
+## Workflow
+1. Inventory active workflows and identify gate-bearing jobs.
+2. Derive protected refs, required checks, and enforcement scope from repo evidence plus GitHub state.
+3. Search for fake-green vectors: stub, mock, fallback, skipped gates, soft-fail secret handling.
+4. Verify that guard decisions are visible in logs and outputs.
+5. Produce deterministic evidence per workflow: protected behavior, unprotected behavior, secret handling, merge-blocking effect.
+6. If fixes are needed, propose the smallest reversible patchset first.
+
+## External Documentation Lookup
+
+This skill audits CI/CD tooling with external documentation dependencies:
+- Load `cdb-external-docs` to find official docs for GitHub Actions, Gitleaks, Trivy, etc.
+- Look up `docs/external-docs/index.md` → Repo-Control / Security sections.
+- Verify expected behavior against official docs before labelling a gate as fake-green.
+- If no internet/browsing is available, report the docs gap and proceed conservatively.
+
+## Output
+- PASS or FAIL
+- concrete enforcement gaps, grouped by workflow or ruleset
+- mapping table: workflow -> trigger/ref scope -> secret behavior -> merge effect
+- minimal fix plan, or patchset if explicit approval exists

--- a/docs/skills/cdb-contract-evidence-gatekeeper/SKILL.md
+++ b/docs/skills/cdb-contract-evidence-gatekeeper/SKILL.md
@@ -1,0 +1,226 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-contract-evidence-gatekeeper/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-contract-evidence-gatekeeper
+description: 'Hard gatekeeper for Claire_de_Binare acceptance and evidence decisions. Use when the task is deciding `freigabefaehig`, `closure-ready`, `wirklich erledigt`, `go/no-go`, `accept/reject`, `PASS/BLOCKED`, blocker vs non-blocking gap, report artifact vs real defect, canon drift vs evidence gap, Stage-System vs LR-System vs Repo/Engineering-Status, or cross-service contract ambiguity around producer, owner, unit, metadata, persistence, or proof. Do not use for broad implementation work.'
+disable-model-invocation: true
+---
+
+# CDB Contract Evidence Gatekeeper
+
+## Purpose
+Use this skill for hard gate decisions, not for implementation.
+
+This skill exists to decide whether a claim, issue, PR, report, status change, or proposed conclusion is actually justified under the current Claire_de_Binare canon.
+
+Use it to stop:
+- fake closure
+- status inflation
+- stage/LR confusion
+- narrative replacing evidence
+- contract claims passing without producer, owner, unit, or persistence clarity
+
+## Use this skill when
+- the user asks `freigabefaehig?`
+- the user asks `closure-ready?`
+- the user asks `wirklich erledigt?`
+- the user asks for go/no-go, accept/reject, PASS/BLOCKED
+- the user asks whether something is a blocker or only a non-blocking gap
+- the user asks to separate Stage-System, LR-System, and Repo/Engineering-Status
+- the user asks whether a claim is repo-backed or only narrative
+- the user asks whether a problem is canon drift, contract drift, evidence gap, policy ambiguity, or only a reporting artifact
+- the user asks whether cross-service metadata, payload, producer, owner, unit, or persistence claims are actually proven
+
+## Do NOT use this skill when
+- the task is mainly feature implementation
+- the task is broad coding work without a gate decision
+- the task is routine documentation editing without an acceptance question
+- the task is a straightforward CI repair with no canon, evidence, or gate ambiguity
+- the task is future architecture brainstorming without a current closure or acceptance decision
+
+If the hard decision is complete and the remaining work becomes implementation, hand off to the relevant execution skill.
+
+## Mandatory canon sources
+Before making a gate decision, use this control-first order:
+
+1. `#1445`
+2. newest weekly comment in `#1445`
+3. `#1492` only when Stage-/`trade-capable`-context is involved
+4. `docs/runbooks/CONTROL_REGISTER.md`
+5. `CURRENT_STATUS.md`
+6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+7. only then directly relevant issues, PRs, files, tests, and committed evidence artifacts
+
+If the task does not touch GitHub, stage, LR, or status claims, scale this down conservatively. If it does touch those surfaces, skipping the canon is forbidden.
+
+## Hard rules
+### 1. Status-class first
+Classify every decision surface before judging it:
+- Stage-System
+- LR-System
+- Repo/Engineering-Status
+- Runtime/Operator-Reality
+- CI/Workflow-Reality
+- Data-contract/persistence-reality
+- Documentation/reporting quality
+
+If more than one class is involved, split them. Never let one system silently overwrite another.
+
+### 2. SSOT boundaries are mandatory
+- `CURRENT_STATUS.md` = repo and engineering status
+- `docs/runbooks/CONTROL_REGISTER.md` = control-board focus, stage context, cockpit memory
+- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` = LR verdict and LR phase status
+- `#1445` = operational control umbrella
+- `#1492` = ratified stage context only when `trade-capable` is relevant
+
+Never derive LR go/no-go from Board stage.
+Never read `trade-capable` as implicit live-readiness.
+Never treat issue closure by itself as proof.
+
+### 3. Evidence over narrative
+Split every claim into these buckets:
+- direct repo-backed evidence
+- indirect evidence
+- policy decision
+- assumption or interpretation
+- missing evidence
+
+Do not blend them into one soft conclusion.
+
+### 4. Fail closed on unresolved ambiguity
+Do not produce a fake PASS if any required gate depends on unresolved ambiguity such as:
+- unclear producer
+- unclear owner of truth
+- unclear units or semantics
+- unclear source of truth
+- unclear Stage-vs-LR scope
+- ambiguous evidence wording
+- memory-backed criteria with no repo anchor
+
+Use `BLOCKED` or `NON-BLOCKING GAP` instead.
+
+### 5. Separate policy from proof
+A maintainer policy decision can be valid, but it is not the same as repo-backed proof.
+If the conclusion depends on policy, say so explicitly.
+
+### 6. No fake closure
+Do not recommend full closure when the truthful result is one of these:
+- closure-ready with explicit limits
+- stage-ratified but LR-still-partial
+- fixed in code but not evidenced enough
+- report corrected, underlying system unchanged
+- non-blocking residual still needs to stay explicit
+
+### 7. Cross-service claims require contract checking
+If the task touches payload propagation, metadata, persistence, replayability, or cross-service meaning, inspect explicitly:
+- producer
+- consumer
+- owner of truth
+- units and semantics
+- propagation path
+- persisted surface
+- test coverage
+- fail-closed behavior
+
+Do not accept a cross-service claim just because one layer mentions the field.
+
+## Decision workflow
+1. Classify the decision surface.
+2. State the exact claim under review.
+3. Pull the canon and only the artifacts that can change the verdict.
+4. Build the evidence map.
+5. Classify each gap exactly once.
+6. Issue one verdict from the allowed verdict classes.
+7. Recommend exactly one next move.
+
+## Allowed verdict classes
+- `PASS`
+- `PASS WITH EXPLICIT LIMITS`
+- `NON-BLOCKING GAP`
+- `BLOCKED`
+- `OUT OF SCOPE`
+
+Use the narrowest truthful verdict.
+
+## Required output format
+1. `Decision surface`
+2. `Claim under review`
+3. `Canon anchors`
+4. `Evidence map`
+5. `Verdict`
+6. `Why`
+7. `Recommended next move`
+
+Optional:
+8. `Issue comment draft`
+
+## Special decision patterns
+### Report vs real system defect
+If the problem is only wording or reporting, say so directly.
+Use the smallest truthful label:
+- reporting artifact
+- canon drift
+- runtime defect
+- contract defect
+- evidence gap
+- policy ambiguity
+
+### Stage vs LR
+If Stage and LR diverge:
+- state both statuses explicitly
+- state which one is under review
+- forbid implicit promotion from one system into the other
+
+Typical pattern:
+- Stage: ratified or acceptable
+- LR: still partial or still NO-GO
+- conclusion: stage decision may pass with limits while LR cannot be upgraded
+
+### Code fixed, proof incomplete
+If implementation exists but proof for the claimed status is incomplete:
+- do not call it fully done
+- prefer `PASS WITH EXPLICIT LIMITS` or `NON-BLOCKING GAP`
+
+### Contract ambiguity
+If a field exists somewhere but producer, owner, unit, or meaning is unclear:
+- treat it as contract ambiguity
+- do not pass the claim as canonically clean
+
+## Repo-specific guardrails
+- `trade-capable` is a stage label, not live-capital authorization
+- `LR-050` remaining `NO-GO` is orthogonal to stage ratification
+- Grafana is not automatically a gate surface
+- Solo-maintainer reality applies; do not invent teams, reviewers, or escalation chains
+- evidence beats storytelling
+- non-blocking residuals must remain explicit instead of disappearing into comments
+- the working repo is canon
+- historical docs are not active proof unless explicitly relevant
+
+## Tooling posture
+- read-only first
+- inspect before action
+- prefer file reads, grep, issue reads, PR reads, tests, and committed artifacts
+- only propose writes, updates, or closure after the verdict is stable
+
+This skill should feel like a gate review, not like opportunistic implementation.
+
+## Anti-patterns
+Do not:
+- claim `PASS` because wording sounds convincing
+- treat issue closure as proof by itself
+- use remembered thresholds with no repo match
+- merge Stage, LR, and Repo status into one blended judgement
+- call something a blocker without naming the blocking system
+- call something done when it is really a non-blocking residual
+- accept field propagation without producer, owner, unit, and semantics clarity
+- rewrite scope just to avoid a hard verdict
+
+## References
+- Read [references/CDB_DECISION_SURFACE_MATRIX.md](references/CDB_DECISION_SURFACE_MATRIX.md) when the task spans multiple status classes.
+- Read [references/CDB_VERDICT_CLASSES.md](references/CDB_VERDICT_CLASSES.md) when the verdict boundary is tight.
+- Read [references/CDB_ISSUE_COMMENT_PATTERNS.md](references/CDB_ISSUE_COMMENT_PATTERNS.md) when the result should be posted back to GitHub.

--- a/docs/skills/cdb-control-intake/SKILL.md
+++ b/docs/skills/cdb-control-intake/SKILL.md
@@ -1,0 +1,52 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-control-intake/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-control-intake
+description: >
+  Establishes the CDB control context for a session by reading canonical control
+  surfaces and producing a fail-closed operational snapshot. Use when beginning
+  CDB repo work after session-start, or when rebuilding control context before
+  planning or implementation in Claire_de_Binare.
+disable-model-invocation: true
+---
+
+# CDB control intake
+
+Build the minimum reliable control snapshot before planning or implementation.
+
+## Pflichtquellen
+
+- `docs/runbooks/CONTROL_REGISTER.md`
+- GitHub Issue `#1445` live, falls GitHub verfuegbar
+- `CURRENT_STATUS.md` nur als Ledger (nicht als Live-SSOT)
+- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- offene PRs/Issues live, falls fuer den aktuellen Scope relevant
+
+## Prozess (minimal)
+
+1. Read control sources in this order:
+   - `docs/runbooks/CONTROL_REGISTER.md`
+   - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+   - `CURRENT_STATUS.md`
+   - GitHub `#1445` and relevant open PRs/issues live, if available
+2. Separate ledger statements from live GitHub truth.
+3. Produce a conservative control snapshot for the current session scope.
+
+## Output
+
+- Board stage
+- LR verdict
+- aktueller operativer Fokus
+- rote Checks / Unsicherheiten
+- kleinster sinnvoller naechster Slice
+
+## Stop-Regeln
+
+- Keine LR-/Live-/Echtgeld-Ableitung aus Board stage oder Ledger.
+- Wenn Live-GitHub-Pruefung nicht verfuegbar ist: Unsicherheit explizit markieren.
+- Bei widerspruechlicher Ledger-/Live-Lage: stoppen oder klar trennen und fail-closed bewerten.

--- a/docs/skills/cdb-docs-ops/SKILL.md
+++ b/docs/skills/cdb-docs-ops/SKILL.md
@@ -1,0 +1,63 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-docs-ops/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-docs-ops
+description: 'Create or update CDB operational documentation from the working-repo canon. Use when Codex needs to capture system state, derive a health/status digest, write a tactical runbook, or build a crisis playbook. Keep the current SSOT split explicit: `CURRENT_STATUS.md` for repo state, `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for Echtgeld Go/No-Go, and `docs/runbooks/CONTROL_REGISTER.md` for Board stage and operating focus.'
+disable-model-invocation: true
+---
+
+# CDB Ops Docs
+
+## Canon first
+- Working repo only. Do not default to retired external docs repos.
+- Start control-first:
+  1. GitHub control issue `#1445`
+  2. newest weekly comment on `#1445`
+  3. stage-ratification issue `#1492` as Board context only
+  4. `docs/runbooks/CONTROL_REGISTER.md`
+  5. `CURRENT_STATUS.md`
+  6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+  7. only then supporting issues, PRs, or repo artifacts
+- Keep status classes separate:
+  - `CURRENT_STATUS.md` = repo and engineering state
+  - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` = live-readiness verdict
+  - `docs/runbooks/CONTROL_REGISTER.md` = Board stage and operating focus
+- Never restate `trade-capable` as live authorization. LR is still `NO-GO`.
+- Treat `#1492` strictly as ratified stage context, never as LR clearance.
+
+## Modes
+1. Create a source doc from raw operational knowledge.
+2. Derive exactly one artifact from source docs or canon docs:
+   - status digest
+   - runbook
+   - playbook
+
+## Source doc rules
+- Use deterministic wording only.
+- Capture facts, constraints, dependencies, downstream impact, and invalidation triggers.
+- If the request mixes repo state, LR verdict, and Board stage, split them explicitly instead of collapsing them into one status claim.
+- If evidence is missing, stop and ask targeted questions rather than filling gaps with assumptions.
+
+## Artifact rules
+- Status digest for health or "where do we stand?"
+- Runbook for tactical recovery steps
+- Playbook for multi-step incidents or human-gated crisis handling
+- Use semantic colors only for gates, verdicts, triggers, and expected results.
+
+## External Documentation Lookup
+
+When creating docs that reference external tools or services:
+- Load the `cdb-external-docs` skill.
+- Look up `docs/external-docs/index.md` for official documentation links.
+- Verify external links before referencing them in CDB docs.
+- If a referenced external doc is unreachable, mark it as `UNVERIFIED` in the doc.
+
+## Safety
+- No real trades.
+- No irreversible action without explicit human approval.
+- For any live-trading topic, treat `knowledge/operating_rules/LIVE_TRADING_RUNBOOK.md` as procedure shape only and `LR-AUDIT-STATUS` as the verdict authority.

--- a/docs/skills/cdb-drift-reconcile/SKILL.md
+++ b/docs/skills/cdb-drift-reconcile/SKILL.md
@@ -1,0 +1,114 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-drift-reconcile/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-drift-reconcile
+description: >
+  Reconcile known Claire_de_Binare drift vectors against the current canon and
+  produce a conservative findings report. Use when Codex must inspect
+  documentation, runbooks, discovery surfaces, architecture maps, stack and
+  secrets references, or service catalogs for canon drift, classify each area
+  as belegt, unklar, or kein Befund, and separate documentation drift from
+  operational drift without expanding scope. Use this for bounded canon-drift
+  reconciliation, not for generic docs cleanup.
+disable-model-invocation: true
+---
+
+# CDB drift reconcile
+
+Check known drift vectors against the current canon and return a bounded reconciliation finding, not a broad cleanup campaign.
+
+## Inputs
+
+- A drift-check request, drift suspicion, or maintenance pass over canon surfaces.
+- Working repo at `D:\Dev\Workspaces\Repos\Claire_de_Binare`.
+- Access to `docs/runbooks/CONTROL_REGISTER.md` and the repo surfaces it points to.
+
+## Required Drift Areas
+
+Always check these areas unless the request explicitly narrows scope further:
+
+- Solo-Maintainer-Drift in SOPs
+- Terminologie-Drift: use `Risk Service` / `cdb_risk` consistently; avoid stale service terminology
+- Stack-Canon-Drift: `BLUE/RED` instead of legacy single-compose language
+- Secrets-Canon-Drift
+- SSOT-Grenzen between `CURRENT_STATUS.md` and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- Discovery-Surfaces / EntryPoints / Cheatsheets
+- `ARCHITECTURE_MAP` / `SERVICE_CATALOG` when service changes are implicated
+
+## Workflow
+
+1. Read `docs/runbooks/CONTROL_REGISTER.md` first.
+2. Build the search and review matrix from the drift vectors defined there:
+   - Do not invent new drift categories unless the control source itself requires them.
+   - Use the required drift areas above as the minimum matrix.
+3. Inspect only the repo surfaces needed to evaluate the active matrix:
+   - Runbooks, SOPs, status files, architecture maps, service catalogs, discovery docs, cheatsheets, and stack or secrets references.
+   - Pull service maps only when the suspected drift touches service naming, boundaries, or runtime topology.
+   - Keep historical snapshots and archive paths out of scope unless needed to confirm that something is merely historical.
+4. Classify every checked area with exactly one finding state:
+   - `belegt`
+   - `unklar`
+   - `kein Befund`
+5. For every `belegt` or `unklar` finding, separate the impact type:
+   - Documentation drift only
+   - Operational drift
+   - Blocker-relevant operational drift
+6. Reconcile conservatively:
+   - Treat historical anchors as historical unless current canon still points to them as active.
+   - Treat canon-boundary uncertainty as unresolved, not as clean.
+   - Do not convert every drift finding into a follow-up issue or workflow change.
+   - Keep Board stage separate from LR status at all times.
+
+## Classification Rules
+
+- `belegt` means the repo surface directly contradicts or lags the current canon.
+- `unklar` means the evidence is incomplete, ambiguous, or canon boundaries are not stable enough to call clean.
+- `kein Befund` means the checked surface matches the current canon closely enough for the reviewed vector.
+- Documentation drift only means wording, pointers, naming, or navigation are stale but the live operational path or enforced runtime behavior is not changed by the drift.
+- Operational drift means the stale canon can misroute execution, verification, secrets handling, stack invocation, or service understanding in current work.
+- Blocker-relevant operational drift means the drift can directly compromise safe operation, safe validation, or correct control interpretation and should be treated as a blocker until reconciled.
+
+## Fail-Closed Rules
+
+- If `CONTROL_REGISTER.md` cannot be read, stop and report reconciliation blocked.
+- If canon boundaries between active docs and historical snapshots cannot be determined confidently, classify the area as `unklar`.
+- If a surface looks stale but the active canon source is not identifiable, do not normalize it away; keep the finding conservative.
+- If service topology, secrets canon, or status-source boundaries may be affected and the relevant maps cannot be confirmed, do not downgrade below `unklar`.
+- If a finding appears historical only, but current entrypoints still route users there, classify it as active drift rather than archive noise.
+
+## Output
+
+Return the result in this structure:
+
+```md
+Drift-Befund
+- Area: belegt | unklar | kein Befund
+
+Betroffene Dateien / Artefakte
+- ...
+
+Schweregrad
+- low | medium | high
+
+Drift-Typ
+- Dokumentationsdrift | operative Drift | blocker-relevante operative Drift
+
+Empfohlene naechste Schritte
+- ...
+
+Nicht im Scope
+- ...
+```
+
+## Anti-Patterns
+
+- Do not turn every stale reference into a new issue.
+- Do not create meta-management work that is not justified by current canon.
+- Do not treat historical anchors as active tasks by default.
+- Do not expand from one drift vector into a full repo rewrite.
+- Do not read Board stage as LR-GO or use LR files to redefine Board stage.

--- a/docs/skills/cdb-exchange-adapters/SKILL.md
+++ b/docs/skills/cdb-exchange-adapters/SKILL.md
@@ -1,0 +1,48 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-exchange-adapters/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-exchange-adapters
+description: CDB exchange-adapter work in the current working repo. Use when Codex needs to implement or harden REST or websocket adapters, order or market-data normalization, rate-limit handling, reconnect logic, or idempotent exchange boundaries. Prefer current repo realities and active integrations; treat MEXC as the default exchange only when the repo context proves it, and keep all work in paper or testnet-safe scope.
+disable-model-invocation: true
+---
+
+# Exchange Adapters
+
+## Canon first
+- Use the working repo as canon. Do not reference the retired external docs repo.
+- Read `CURRENT_STATUS.md` and local adapter code before assuming the active exchange scope.
+- Stage `trade-capable` is not a license for live endpoints or live keys.
+
+## Trigger phrases
+- exchange adapter, REST client, websocket client
+- MEXC, Binance, Crypto.com, market data, order schema
+- rate limit, retry, backoff, reconnect, heartbeat
+- idempotency, auth failure, timeout taxonomy
+
+## Non-negotiables
+- No real keys in code.
+- Default-safe scope is paper/mock only.
+- Testnet is allowed only with explicit user GO and an explicit reason.
+- Live endpoints / real keys are never the default; do not derive any live-trading authorization from this skill text.
+- Normalize to the repo's current internal schema instead of inventing a new one.
+- Add tests for happy path plus failure taxonomy.
+- Include one simulated failure case that proves retry or backoff behavior.
+
+## External Documentation Lookup
+
+This skill touches exchange APIs, WebSocket protocols, and Protobuf schemas:
+- Load `cdb-external-docs` before implementation.
+- Look up `docs/external-docs/index.md` → Exchange / Market Data section.
+- Relevant: MEXC Spot V3 API, MEXC Contract API, Protocol Buffers, websockets Python.
+- Read official docs before writing adapter code.
+- If no internet is available, report `EXTERNAL_DOCS_UNVERIFIED` instead of guessing API behavior.
+
+## Deliverables
+- adapter module or boundary patch
+- tests for success and failure paths
+- short evidence snippet for the user or PR

--- a/docs/skills/cdb-external-docs/SKILL.md
+++ b/docs/skills/cdb-external-docs/SKILL.md
@@ -1,0 +1,85 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-external-docs/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-external-docs
+description: CDB External Documentation Lookup Skill. Use when an agent needs to determine which external documentation is relevant for a given task, resolve contradictions between external docs and CDB canon, or handle scenarios where internet/browsing is unavailable. References the canonical external docs index at docs/external-docs/index.md.
+---
+
+# CDB External Documentation Lookup
+
+## Purpose
+
+This skill tells agents:
+- when external documentation must be consulted
+- which external docs are relevant for which problem
+- what to do when internet/browsing is not available
+- how to handle contradictions between external docs and CDB canon
+
+## Central Index
+
+Canonical external docs list: `docs/external-docs/index.md`
+
+This file contains all known external documentation references grouped by category, with priority levels and CDB usage notes.
+
+## When to use
+
+Load this skill when the task involves any of these external doc dependencies:
+
+| Category | Example triggers |
+|----------|-----------------|
+| Exchange / Market Data | MEXC WebSocket, Protobuf, REST API, order schemas |
+| Docker / Runtime | Docker Compose, Dockerfiles, BLUE/RED stack |
+| GitHub / CI | GitHub Actions, rulesets, required checks, gh CLI |
+| Security Tools | Gitleaks, Trivy, Bandit, pip-audit |
+| Python / Testing | pytest, Ruff, mypy, Black, pre-commit |
+| Agent Surfaces | OpenCode, Cursor, Codex, Claude Code, Gemini |
+| MCP / Context | Model Context Protocol, SurrealDB |
+| SurrealDB Agent Skills / Rules | Offizielle SurrealDB Skills, Rules, Memory SDKs |
+| Infrastructure | Redis, PostgreSQL, Prometheus, Grafana |
+
+## How to use
+
+1. Identify the problem domain (e.g., "MEXC WebSocket reconnect").
+2. Load this skill.
+3. Look up `docs/external-docs/index.md` for the relevant category.
+4. Before writing code, fetch the official docs for the tool.
+5. If multiple docs apply, read all that are `required` priority first, then `secondary`.
+
+## When internet/browsing is unavailable
+
+If the agent has no internet access or no browsing tools:
+
+- Use local code patterns, docstrings, and type stubs as fallback.
+- Check if the repo contains vendored/generated protobuf stubs or similar.
+- For agent surfaces (OpenCode/Cursor/Codex/Claude/Gemini): use the info in `.surface/README.md` and `AGENTS.md`.
+- Report which external docs could not be verified and flag the gap.
+- Do not invent API signatures or behavior from memory when external docs are required but unreachable. Issue a blocker: `EXTERNAL_DOCS_UNVERIFIED`.
+
+## Contradiction handling
+
+When official external docs seem to contradict CDB canon (code, docs, runbooks):
+
+| Priority | Rule |
+|----------|------|
+| 1 | External official docs win for tool/API behavior |
+| 2 | CDB canon (custom wrappers, adapters, policies) defines CDB-specific behavior |
+| 3 | Report the contradiction in an evidence snippet |
+| 4 | If the mismatch is governance-relevant, create a decision event |
+| 5 | Do not silently override external behavior with assumptions |
+
+## Lookup Hooks
+
+This skill is referenced from:
+- `cdb-session-start` — for session setup requiring external tool context
+- `cdb-docs-ops` — when writing docs that reference external tools
+- `cdb-exchange-adapters` — for exchange API and protocol references
+- `cdb-ci-cd-guard` — for CI/CD tooling documentation
+- `cdb-test-first` — for test framework documentation
+- `ctb-docker-stack` — for Docker and compose documentation
+- `onboarding` — for new-agent orientation on external references
+- `skillforge` — when creating skills that depend on external tools

--- a/docs/skills/cdb-issue-to-session-plan/SKILL.md
+++ b/docs/skills/cdb-issue-to-session-plan/SKILL.md
@@ -1,0 +1,109 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-issue-to-session-plan/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-issue-to-session-plan
+description: >
+  Turn a concrete Claire_de_Binare GitHub issue into a fail-closed session plan.
+  Use when given an issue number or URL and control context must be rebuilt first
+  via CONTROL_REGISTER and Issue #1445 before deriving a conservative mini-plan.
+disable-model-invocation: true
+---
+
+# CDB issue to session plan
+
+Use this after `cdb-control-intake` when the next concrete unit of work is one specific GitHub issue. Convert that issue into an executable session plan without treating the issue itself as authorization.
+
+## Inputs
+
+- A concrete GitHub issue number, URL, or issue thread.
+- Working repo at `D:\Dev\Workspaces\Repos\Claire_de_Binare`.
+- Access to GitHub Issue `#1445`, its comments, and current open issues/PRs.
+
+## Workflow
+
+1. Rebuild the control context first. Do not read the target issue before this sequence is complete:
+   - Read `docs/runbooks/CONTROL_REGISTER.md`.
+   - Read GitHub Issue `#1445`.
+   - Read the current newest substantive human weekly comment in `#1445`, not a later bot-generated digest or report-only follow-up.
+   - Read `CURRENT_STATUS.md`.
+   - Read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`.
+2. Read the target issue only after the control stack above is in hand.
+3. Pull only the extra workflow context needed to ground the issue:
+   - Check relevant open PRs if the issue references them or they materially affect execution order.
+   - Check closely related follow-up or blocker issues only when the target issue explicitly depends on them.
+   - Check newer repo-backed automation comments in `#1445` only when they materially change the issue's readiness, blocker state, or sequencing.
+   - Do not broaden the search surface without evidence from the issue or the control sources.
+4. Mirror the issue against the current operating reality:
+   - Determine current Board stage and operating focus from `CONTROL_REGISTER.md`.
+   - Determine weekly priorities and sequencing from the newest weekly comment in `#1445`.
+   - Determine repo and engineering posture from `CURRENT_STATUS.md`.
+   - Determine Go/No-Go and live-trading boundaries from `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`.
+   - Determine whether the issue is aligned, premature, blocked, superseded, or too risky in the current workflow state.
+5. Derive a session plan from the issue without overcommitting:
+   - State the short diagnosis first.
+   - Rank the issue inside the current stage and weekly context.
+   - Name guardrails, blockers, and explicit non-goals.
+   - Break the work into a short, ordered session plan with concrete next steps.
+   - Mark all unresolved assumptions as unconfirmed.
+
+## Interpretation Rules
+
+- Never implement or recommend work only because an issue is open.
+- Treat an open issue as a work package candidate, not as authorization.
+- Never treat Board stage as live-trading approval.
+- Never use `CURRENT_STATUS.md` as the LR verdict source.
+- Use `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` as SSOT for Go/No-Go.
+- If LR is `NO-GO`, keep the session plan in shadow/mock-only scope even if the issue language sounds execution-ready.
+- Respect solo-maintainer reality unless a source explicitly proves otherwise.
+- Keep scope pinned to the target issue and proven prerequisites.
+- Keep parked or future-anchor issues out of the committed plan unless the control context proves they are active again.
+- If status sources conflict, stay conservative and surface the conflict instead of reconciling it optimistically.
+
+## Fail-Closed Rules
+
+- If the control stack cannot be rebuilt in the required order, stop and report planning blocked.
+- If Issue `#1445` or its newest weekly comment cannot be read confidently, stop and report planning blocked.
+- If the target issue is missing, ambiguous, or underspecified, stop and report what remains unconfirmed.
+- If the issue conflicts with current stage, LR guardrails, or weekly sequencing, do not silently rewrite priorities; surface the conflict and narrow the plan.
+- If related PRs or follow-up issues appear relevant but cannot be confirmed as dependencies, mark them as possible context and keep them out of the committed plan.
+- If the target issue is parked, future-facing, or otherwise lacks an active delivery signal in the current control context, do not force a work plan; return a narrow no-action or watch-state plan instead.
+- If live-readiness is unclear, assume `NO-GO`.
+
+## Output
+
+Return the result in this structure:
+
+```md
+Kurzbefund
+- ...
+
+Prioritaet im aktuellen Stage-Kontext
+- ...
+
+Risiken / Guardrails
+- ...
+
+Empfohlene Session-Schritte
+1. Action - why now - evidence
+2. Action - why now - evidence
+3. Action - why now - evidence
+
+Nicht anfassen
+- ...
+
+Restunsicherheiten
+- ...
+```
+
+## Anti-Patterns
+
+- Do not read the target issue first and add control context afterward.
+- Do not convert issue text directly into implementation tasks without checking current control posture.
+- Do not expand into adjacent issues, epics, or refactors unless the dependency is explicit and current.
+- Do not imply live approval, Echtgeld readiness, or strategy release from issue wording.
+- Do not hide uncertainty; mark open points as unconfirmed.

--- a/docs/skills/cdb-onboarding/SKILL.md
+++ b/docs/skills/cdb-onboarding/SKILL.md
@@ -1,0 +1,19 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-onboarding/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-onboarding
+description: Thin alias to the canonical CDB onboarding skill.
+---
+
+# CDB onboarding alias
+
+Use [`docs/skills/onboarding/SKILL.md`](../onboarding/SKILL.md) as the canonical instruction surface.
+
+Primary route: `python -m tools.onboarding_orchestrator`
+
+Agent Onboarding Readiness (optional, informational): [`../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md`](../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md).

--- a/docs/skills/cdb-operator/SKILL.md
+++ b/docs/skills/cdb-operator/SKILL.md
@@ -1,0 +1,38 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-operator/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-operator
+description: Enforces Claire de Binare operator workflow: bootloader first, live GitHub truth, dry-run planning, strict GO gates, no merge without human approval.
+compatibility: opencode
+metadata:
+  project: claire-de-binare
+  workflow: operator
+disable-model-invocation: true
+---
+
+# CDB Operator Skill
+
+## Purpose
+
+Use this skill when working on Claire_de_Binare with OpenCode.
+
+## Required workflow
+
+1. Read `AGENTS.md` in the repo root.
+2. Follow the pointer to `agents/AGENTS.md`.
+3. Read `agents/OPEN_CODE_AGENTS.md` if present.
+4. Read the complete repo read order before planning.
+5. Pull GitHub issue and PR state live.
+6. Treat `CURRENT_STATUS.md` as ledger, not live truth.
+7. Produce only Lage, Befund, Plan, Dry-Run, Validierung, Restunsicherheiten.
+8. Do not write, commit, push, comment, label, close, or merge without explicit human GO.
+
+## Stop conditions
+
+Stop immediately on missing bootloader, unclear scope, unexpected diff, red checks, pending checks before merge, scope growth, or any live-readiness/echtgeld implication.
+

--- a/docs/skills/cdb-risk-governance/SKILL.md
+++ b/docs/skills/cdb-risk-governance/SKILL.md
@@ -1,0 +1,37 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-risk-governance/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-risk-governance
+description: CDB risk-governance changes for the current Risk Service (`cdb_risk`). Use when Codex needs to implement or harden enforceable limits, kill-switches, drawdown or exposure caps, fail-closed gating, or human-approval semantics. Respect the current repo canon, the `Risk Service` naming, and the fact that Board stage does not clear live trading.
+disable-model-invocation: true
+---
+
+# Risk Governance
+
+## Canon first
+- Use the working repo and current `Risk Service` / `cdb_risk` terminology.
+- Read `CURRENT_STATUS.md` for recent risk and runtime changes.
+- Read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` before making any claim about live readiness.
+- Never interpret `trade-capable` as permission to resume or enable live trading.
+
+## Trigger phrases
+- risk limits, daily loss, drawdown
+- kill switch, circuit breaker, stop trading
+- exposure cap, position cap, leverage guard
+- no-trade mode, human approval, fail-closed gate
+
+## Non-negotiables
+- Critical breaches must produce a machine-checkable stop state.
+- Resume paths require explicit human approval where policy demands it.
+- Add tests for breach and non-breach paths.
+- If thresholds or policy intent are unclear, stop and surface the ambiguity instead of guessing.
+
+## Deliverables
+- guard logic and config changes
+- tests for breach and non-breach scenarios
+- concise evidence table mapping scenario to expected gate state

--- a/docs/skills/cdb-session-close/SKILL.md
+++ b/docs/skills/cdb-session-close/SKILL.md
@@ -1,0 +1,190 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-session-close/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-session-close
+description: >
+  Enforce a disciplined Claire_de_Binare session close. Use when Codex must
+  turn completed or partially completed local work into a clean closing state:
+  determine whether the session was issue-driven, capture actual changes and
+  verification, stage only intended files, prepare a scoped commit, account for
+  push and issue-status follow-through, and generate an issue-ready closing
+  comment without overstating completion. Use after implementation,
+  reconciliation, or validation work when the session needs an honest close.
+  When a PR was merged during the session, also verifies delivery on main,
+  normalizes local main, and classifies temporary git surfaces before marking
+  the session complete.
+---
+
+# CDB session close
+
+Close a working session so the repo, git state, and issue thread reflect reality instead of intention.
+
+## Inputs
+
+- Current working tree and session context.
+- Optional issue number, PR, branch context, or prior session goal.
+- Optional prior outputs from `cdb-control-intake` or `cdb-issue-to-session-plan`.
+- Access to git status, diffs, staged state, and issue or PR context when relevant.
+
+## Workflow
+
+0. Human-GO gate (hard):
+   - Default mode is read-only analysis.
+   - Require explicit user GO before any action that mutates repository, working tree, index, branch, remote, GitHub, or worktree state, including:
+     - staging changes (any `git add` / patch staging)
+     - branch switching or checkout/switch operations
+     - pull, merge, rebase, or fast-forward update operations
+     - stash/apply operations
+     - creating a commit
+     - pushing to any remote
+     - removing worktrees
+     - deleting local or remote branches
+     - cleanup/delete operations
+     - writing to GitHub (issue/PR comment, review reply/resolve, status update, label/state change)
+   - If GO is not granted: stop after producing the close-out summary draft.
+
+1. Determine session scope before touching git:
+   - Decide whether the session was issue-bezogen.
+   - Identify the intended deliverable, the files actually changed, and any unrelated local residue.
+   - If the issue link is unclear, keep the close-out generic and mark the missing linkage.
+2. Reconstruct what was really done:
+   - Capture changed files and artifacts.
+   - Capture verification actually performed, not verification that was planned.
+   - Capture anything intentionally left undone, blocked, or uncertain.
+3. Gate the working tree:
+   - Inspect `git status`, unstaged diff, and staged diff.
+   - Separate intended session changes from unrelated or half-finished residue.
+   - Never use `git add .`.
+   - Stage only the files or hunks that belong to the session close, using targeted file staging or patch staging.
+4. Prepare the commit conservatively:
+   - Prefer one small, testable, reversible commit per coherent topic.
+   - If the work is not commit-worthy yet, say so explicitly and stop short of artificial closure.
+   - Write a commit message that describes what changed and why.
+5. Consider push and issue follow-through as part of the close:
+   - If a clean commit exists and push is appropriate, include push in the close path.
+   - If push is not done, say so explicitly in the rest status.
+   - If the issue state should change, describe the correct next state rather than claiming it changed when it did not.
+   - If the work is still local-only, make that explicit in the issue-facing close-out instead of implying landed or review-ready state.
+   - If a PR was merged during this session, proceed to step 6. If no PR exists or the PR is still open, skip steps 6–7 and record `pending main-verification` or `n.a.` in the rest status.
+6. Verify delivery on `main` — only when a PR was merged in this session:
+
+   ```bash
+   gh pr view <PR> --json state,mergedAt,mergeCommit
+   git fetch origin main
+   git log origin/main --oneline -5
+   git checkout main
+   git merge --ff-only origin/main
+   ```
+
+   Determine:
+   - PR merged + merge commit visible on `origin/main` + `--ff-only` succeeded → proceed to step 7.
+   - PR merged but merge commit absent from `origin/main` → STOP, session = incomplete.
+   - `--ff-only` fails → report as pending, do not force.
+   - No PR in this session → mark as `n.a.`, skip this step.
+7. Classify temporary git surfaces — only when applicable:
+
+   ```bash
+   git worktree list                       # any session worktrees?
+   git branch -v --merged origin/main      # any merged feature branch?
+   ```
+
+   - If a session worktree is present and unambiguously from this session: `git worktree remove <path>`.
+   - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
+   - Otherwise: record as `n.a.` or `pending` — no blind deletes.
+   - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
+8. Produce the close-out summary:
+   - State the factual result.
+   - Name changed files and artifacts.
+   - Name the root cause or central insight if one exists.
+   - Name checks that actually ran and their outcomes.
+   - Name real remaining work and uncertainties.
+   - Set the final status conservatively.
+
+## Decision Rules
+
+- Do not mark a session as complete if verification, staging, commit scope, or issue linkage is still unclear.
+- Do not stage unrelated local changes just to get to a clean tree.
+- Do not create a commit that mixes logic, docs, refactors, and residue unless they are one coherent change.
+- Prefer leaving honest local residue uncommitted over forcing a misleading close.
+- Use `bereit fuer Claude Code` only when there is a concrete handoff reason that another agent should continue from.
+- Use `erledigt` only when the issue-facing work is actually verified and the claimed git or GitHub state is real.
+- Do not imply LR uplift, live approval, or a Board-stage interpretation from a successful session close.
+- Respect solo-maintainer reality; do not invent reviewer, approver, or handoff ceremonies.
+
+## Fail-Closed Rules
+
+- If any write step would exceed the agreed scope (unexpected files/hunks, scope growth): STOP and ask for clarification + explicit GO.
+- If checks are red/failed/unknown for the claimed result: STOP; do not stage/commit/push; report the failing check(s).
+- If the PR/review/writer/lock situation is unclear or conflicting: STOP; do not stage/commit/push or write to GitHub; ask for explicit handoff/GO.
+- If there is an active PR or lock collision touching the same files/scope: STOP; no further actions until clarified.
+- If intended session changes cannot be separated from unrelated local changes, stop and report the close as incomplete.
+- If verification is missing or ambiguous, report exactly that instead of implying confidence.
+- If the session was issue-driven but the issue mapping is uncertain, do not fabricate an issue-ready completion claim.
+- If no clean commit boundary exists, do not force a commit.
+- If push or issue-status updates were not performed, keep them as pending actions in the close-out.
+- If the issue comment would overstate what landed, what was pushed, or what is actually done, downgrade the final status and state the pending step explicitly.
+- If a PR was merged but the merge commit cannot be verified on `origin/main`: the session is incomplete; do not set status to `erledigt`.
+- If `git merge --ff-only origin/main` fails: report as pending; do not force a merge or ignore the divergence.
+
+## Output
+
+Return the result in this structure:
+
+```md
+Session-Befund
+- ...
+
+Betroffene Dateien / Artefakte
+- ...
+
+Verifikation / Checks
+- ...
+
+Reststatus
+- ...
+
+Main-Verifikation (nur wenn PR gemergt, sonst n.a.)
+- PR-State: gemergt / offen / n.a.
+- Merge-Commit auf origin/main: ja / nein / n.a.
+- Lokales main normalisiert: ja / nein / pending / n.a.
+
+Surface-Cleanup (nur wenn applicable, sonst n.a.)
+- Worktrees: entfernt: <liste> / n.a. / pending
+- Feature-Branch: gelöscht: <name> / n.a. / pending
+- Leftover-Files: <klassifikation> / keine / n.a.
+
+Issue-Kommentar
+Befund
+- ...
+
+betroffene Dateien / Artefakte
+- ...
+
+Root Cause oder zentrale Erkenntnis
+- ...
+
+empfohlene naechste Schritte
+- ...
+
+Validierung / Checks
+- ...
+
+Restunsicherheiten
+- ...
+
+Status
+- erledigt | weitere Zuarbeit noetig | bereit fuer Claude Code
+```
+
+## Anti-Patterns
+
+- Do not use `git add .`.
+- Do not beautify an incomplete session into a finished one.
+- Do not claim checks ran when they did not.
+- Do not hide uncommitted residue.
+- Do not label work as `bereit fuer Claude Code` without a real continuation need.

--- a/docs/skills/cdb-session-start/SKILL.md
+++ b/docs/skills/cdb-session-start/SKILL.md
@@ -1,0 +1,267 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-session-start/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-session-start
+description: >
+  Enforce a fail-closed session start for Claire_de_Binare repo work. Use when
+  any agent must begin implementation, planning, or triage work in the working
+  repo. Verifies Git truth before any other action, detects risky starting
+  conditions such as stale local main, dirty worktree, gone-upstream branches,
+  or branch-local state mistaken for merged truth, verifies issue state against
+  GitHub, then delegates control-context reading to cdb-control-intake. Produces
+  a verified execution surface and a conservative go/no-go gate before any repo
+  change is made.
+---
+
+# CDB session start
+
+Establish a verified, fail-closed starting state before any repo work begins.
+
+## Inputs
+
+- Session goal, issue number, or user request.
+- Working repo at `D:\Dev\Workspaces\Repos\Claire_de_Binare`.
+- Access to git CLI and GitHub CLI (`gh`).
+
+## Workflow
+
+0. Route onboarding intent before session-start takes over:
+
+   - If the user says `/onboarding`, `onboarding`, `onboarding durchführen`,
+     `mach onboarding`, `fresh agent onboarding`, or equivalent, run:
+     `python -m tools.onboarding_orchestrator`
+   - Do not start `cdb-session-start` or `onboarding_doctor` as the primary path
+     for onboarding intent.
+   - Default output is the CDB Onboarding status card.
+   - Do not create `.env`, initialize secrets, initialize context, write
+     reports, create issues, or run Docker unless the user explicitly selects a
+     next option after the status card.
+
+1. Verify Git truth before reading anything else:
+
+   ```bash
+   git fetch origin main
+   git rev-parse --abbrev-ref HEAD          # which branch am I on?
+   git status                               # clean or dirty?
+   git log --oneline origin/main..HEAD      # commits above main?
+   ```
+
+   Interpret the output:
+   - If HEAD is on a named branch that is not `main`: confirm whether this branch
+     has a known purpose or is leftover. If unclear, treat as stale and do not
+     use it as the work surface.
+   - If the worktree is dirty (unstaged or staged changes): stop and identify what
+     the changes are and whether they belong to the current task.
+   - If local `main` is behind `origin/main`: do not start branching from stale
+     local main; use `origin/main` as the base explicitly.
+   - If the branch has commits above `origin/main` with no corresponding open PR:
+     surface this as an unreported delivery candidate before continuing.
+
+2. Detect risky starting conditions and apply the gates below before any planning:
+
+   | Condition | Gate |
+   |---|---|
+   | Dirty worktree with unknown changes | STOP — identify origin, stash or resolve |
+   | Local main behind origin/main | Do not start from stale local main; refresh or use origin/main explicitly |
+   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it |
+   | Old local worktree from a prior session | Do not read as implicit active progress |
+   | Branch-local commits presented as merged truth | Verify via `gh pr list --state merged` |
+   | Auto-merge enabled on repo during closure-sensitive work | State `Closes #N` vs `Refs #N` explicitly |
+
+3. Verify issue state — not just issue prose:
+
+   ```bash
+   gh issue view <N>                                         # open or closed? labels?
+   gh pr list --search "Closes #<N>" --state merged         # already landed?
+   ```
+
+   Determine:
+   - Is the target issue still open, or was it closed (possibly prematurely)?
+   - Does a merged PR already deliver what the issue asks for?
+   - Is the issue superseded by a related issue that is now the active delivery
+     vehicle?
+   - Was a prior closure valid, or should the issue be reopened?
+
+   If the issue is already closed and no reopening is justified, stop and report
+   the session as pre-empted rather than inventing new work.
+
+4. Run `cdb-control-intake` to rebuild the control context:
+
+   Do not continue past this point without the output of `cdb-control-intake`.
+   The Git truth checks in steps 1-3 do not replace the control-context read; they
+   precede it.
+
+5. Test-First Check (conditional):
+
+   If the session involves testing, test planning, validation, evidence
+   generation, or any significant implementation that needs test coverage:
+
+   - Load the `cdb-test-first` skill.
+   - Answer the five test-first questions from
+     `knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md` §2:
+     * Welche Regel wird geschützt?
+     * Welche Testart passt?
+     * Welche Entscheidung wird sicherer?
+     * Welche Metadaten braucht der Test?
+     * Wie wird das Ergebnis weiterverarbeitet?
+   - If this is a change that could affect execution, orders, risk, or
+     profitability, load `knowledge/testing/MOCKEXCHANGE_CDB_TEST_MAP.md` as
+     pattern reference.
+   - Proceed with test planning alongside implementation planning.
+
+   Reference: `.opencode/skills/cdb-test-first/SKILL.md` (all surfaces);
+   `knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md`.
+
+6. Brain Evidence Gate (scope-abhängig):
+
+   If the session scope includes **Strategy, Runtime, Module, Service, Contract,
+   Context, SurrealDB, MCP tools, DB-backed Memory, or Evidence**, output the
+   Brain Evidence block from `agents/AGENTS.md` § Brain Evidence Gate **before
+   any plan**.
+
+   The block MUST contain all fields (`brain_source`, `brain_status`,
+   `tools_or_queries`, `records_or_results`, `repo_crosscheck`, `impact_on_plan`,
+   `limitations`) with honest values.
+
+    **No plan may claim Memory/Evidence/Decision consideration without
+    record/tool/query evidence.**
+
+    Post-#3449: `cdb_context_briefing` / `context.briefing` enrichment check.
+    - Context trust floor: MEDIUM. Nur HIGH/MEDIUM sind nutzbar (`context_available=true`).
+    - Prüfe ob evidence_records/claim_records/decision_events/memory_records übergeben wurden.
+    - Ohne Records → `brain_source=repo-only`, `brain_status=not-used`, `context_available=false`.
+    - Inline-Records → `brain_source=in_memory`, max `context_trust_level=MEDIUM`.
+    - HIGH nur mit `record_source=surrealdb-local` + Record-IDs + kein stale/disputed/blocking.
+    - LOW/BLOCKED sind keine operative Agentenoption; hinter `none` verborgen.
+
+    If the block is missing or incomplete:
+    - STOP.
+    - Report which fields are missing or which values are unsubstantiated.
+    - Do not proceed to implementation planning.
+
+    Reference: `agents/AGENTS.md` § Brain Evidence Gate;
+    default posture SSOT: `knowledge/decisions/CDB_CONTEXT_BRAIN_DEFAULT_POSTURE.md`
+    (#2775). Until verified MCP/DB evidence: `brain_source=repo-only`,
+    `brain_status=not-used`. `PERSIST_ALLOWED=False` / `MUTATION_ALLOWED=False`
+    on `main`; Context Brain output does not authorize writes or issue creation.
+
+7. MCP Capability Resolution Gate (conditional):
+
+   When the session scope includes Context, SurrealDB, MCP tools, ContextBridge,
+   or DB-backed agent memory, verify capability before any implementation or
+   tool-dependent planning.
+
+   **Capability beats assumption.** Repo presence is not MCP availability. A tool
+   counts as available only if the active MCP surface exposes it and invocation
+   dispatches a real handler.
+
+   | # | Check | Pass criterion |
+   |---|---|---|
+   | 1 | Active inventory | Tool appears in the active MCP tool list |
+   | 2 | No `unknown_tool` | Tool call does not return `unknown_tool` |
+   | 3 | No `not_implemented` | Tool call does not return `not_implemented` |
+   | 4 | Real dispatch | Handler returns real behavior |
+   | 5 | Read-only contract | `metadata.read_only == true` where applicable |
+   | 6 | Explicit DB opt-in | DB-backed mode requires explicit `adapter_config_path` |
+   | 7 | Fail-closed boundaries | Remote DB URLs and write/admin statements are rejected |
+
+   If any check fails:
+   - STOP.
+   - Report the exact missing layer.
+   - Do not adopt raw/external SurrealDB MCP as a shortcut.
+   - Propose only the smallest CDB-native read-only slice after Human-GO.
+   - LR remains NO-GO. No Echtgeld-Go.
+
+   Reference: `docs/runbooks/surrealdb_context_mcp_access.md` § 1.5.
+
+8. Create a clean execution surface:
+
+   Once steps 1-7 are complete and no gate has fired, create the working surface:
+   - Branch from current `origin/main` (never from stale local main).
+   - Clean worktree confirmed.
+   - Explicit target issue identified and open.
+   - Scope stated: what is IN, what is OUT.
+   - Closure semantics confirmed: `Closes #N` (full delivery) vs. `Refs #N`
+     (partial or scoped delivery).
+
+## Fail-Closed Rules
+
+- If `git fetch origin main` fails, stop and report the session as blocked.
+- If the worktree is dirty and the changes cannot be attributed, stop.
+- If local main is stale and the correct base cannot be confirmed, stop.
+- If the target issue cannot be read via `gh issue view`, stop.
+- If `cdb-control-intake` cannot be completed, stop.
+- If any of the risky conditions in step 2 cannot be resolved, stop and report
+  what remains unresolved before any file is touched.
+- If the Brain Evidence Gate block is missing or incomplete for a relevant
+  scope, stop and report which fields are missing or unsubstantiated.
+- If MCP capability cannot be verified for a Context/SurrealDB tool in scope,
+  stop and report the missing layer instead of implementing or calling around it.
+
+## Output
+
+Return the result in this structure:
+
+```md
+Git-Wahrheit
+- Branch:
+- Worktree:
+- Commits ueber origin/main:
+- Risky conditions gefunden: ja / nein -- <Detail>
+
+Issue-Wahrheit
+- Issue #N: offen / geschlossen
+- Merged PR gefunden: ja / nein -- <PR-Nummer oder keiner>
+- Bewertung: gueltige Startbasis / pre-empted / Klaerungsbedarf
+
+Control-Snapshot (via cdb-control-intake)
+- Board stage:
+- LR verdict:
+- Weekly focus:
+
+Brain Evidence (nur bei relevantem Scope)
+- brain_source:
+- brain_status:
+- tools_or_queries:
+- records_or_results:
+- repo_crosscheck:
+- impact_on_plan:
+- limitations:
+
+Arbeitsflaeche
+- Branch:
+- Scope:
+- Closure-Semantik:
+- Gate: go | no-go -- <Grund wenn no-go>
+```
+
+## External Documentation Lookup
+
+If this task touches external tools or services, check `docs/external-docs/index.md`:
+
+- Exchange APIs, WebSocket, Protobuf → `cdb-external-docs` → MEXC, protobuf docs
+- Docker, Compose, Runtime → `cdb-external-docs` → Docker docs
+- GitHub Actions, gh CLI → `cdb-external-docs` → GitHub docs
+- Python testing, linting, security → `cdb-external-docs` → pytest, Ruff, Gitleaks docs
+- Agent surfaces (OpenCode, Cursor, Codex, Claude, Gemini) → `cdb-external-docs`
+
+Load `cdb-external-docs` before implementation if external docs are required.
+If no internet/browsing is available, report `EXTERNAL_DOCS_UNVERIFIED` instead of inventing behavior.
+
+## Anti-Patterns
+
+- Do not read control docs or the target issue before verifying Git state.
+- Do not assume local main is current without an explicit fetch.
+- Do not treat branch-local commits as merged truth.
+- Do not start work on a dirty worktree without identifying the changes.
+- Do not use `git add .` at any point during session start.
+- Do not mark the gate as `go` when any of the fail-closed conditions is unresolved.
+- Do not invent reviewer, approver, or merge-authority roles; this is a
+  solo-maintainer repo.
+- Do not treat repo presence of MCP files, registry entries, or `tools/mcp/server.py`
+  as proof that a tool is callable through the active MCP surface.

--- a/docs/skills/cdb-shadow-validation/SKILL.md
+++ b/docs/skills/cdb-shadow-validation/SKILL.md
@@ -1,0 +1,138 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-shadow-validation/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-shadow-validation
+description: >
+  Decide the conservative validation path for Claire_de_Binare strategy,
+  signal, execution, dataflow, contract, persistence, observability, or
+  shadow-relevant changes. Use when Codex must classify a change, assess blast
+  radius and risk against current control status, and choose exactly one
+  outcome: unit tests only, replay needed, mock exchange or emulator needed,
+  shadow evidence needed, or stop and do not release. Use after planning or
+  before session close when a concrete change needs a validation decision.
+disable-model-invocation: true
+---
+
+# CDB shadow validation
+
+Use this after planning narrows to a concrete change or before `cdb-session-close` when validation depth is still undecided. Choose the minimum safe validation path for a concrete change and fail closed when the evidence is incomplete.
+
+## Inputs
+
+- A concrete change, diff, PR, issue, commit, or scoped work description.
+- Working repo at `D:\Dev\Workspaces\Repos\Claire_de_Binare`.
+- Access to `docs/runbooks/CONTROL_REGISTER.md`, `CURRENT_STATUS.md`, and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`.
+
+## Required Outcomes
+
+Choose exactly one:
+
+- `nur Unit Tests`
+- `Replay noetig`
+- `MockExchange / Emulator noetig`
+- `Shadow-Evidence noetig`
+- `stoppen / nicht freigeben`
+
+## Workflow
+
+1. Read control status first, before looking at the change details in depth:
+   - Read `docs/runbooks/CONTROL_REGISTER.md`.
+   - Read `CURRENT_STATUS.md`.
+   - Read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`.
+   - Extract the current control boundary: Board stage may be `trade-capable`, but LR remains `NO-GO` and work stays shadow/mock only unless an explicit source proves otherwise.
+2. Determine the change class from evidence, not from intent:
+   - Strategy or signal logic.
+   - Execution, order, trade, routing, or exchange path.
+   - Interface, API, schema, or contract boundary.
+   - Data model, persistence, storage, or migration path.
+   - Observability, alerting, monitoring, or operator signal path.
+   - Purely local and isolated internal logic.
+3. Identify affected systems and contracts:
+   - Name the touched services, modules, adapters, reports, or persistence layers.
+   - Name any producer-consumer or request-response contracts affected.
+   - Name whether the change can influence orders, fills, positions, balances, signals, or operator decisions.
+4. Assess risk and blast radius conservatively:
+   - Low: isolated internal logic with no contract, execution, persistence, or control-signal effect.
+   - Medium: cross-module or contract-adjacent change without direct execution exposure.
+   - High: strategy, signal, execution, order, trade, persistence, or operator control path.
+   - Critical: ambiguous or multi-surface change, or any change where the blast radius cannot be bounded confidently.
+5. Select the validation path:
+   - `nur Unit Tests` only for low-risk isolated logic with no shadow, LR, contract, persistence, execution, or observability relevance.
+   - `Replay noetig` for strategy, signal, deterministic decision logic, contract-adjacent, or dataflow changes that can be validated offline without exchange behavior.
+   - `MockExchange / Emulator noetig` for execution, order lifecycle, adapter, fill-handling, or exchange-facing changes.
+   - `Shadow-Evidence noetig` for changes that can alter operational behavior, confidence, or release posture beyond replay or emulation alone, especially when strategy, signal, execution, observability, or cross-service interactions remain behaviorally relevant.
+   - `stoppen / nicht freigeben` if the change is ambiguous, unbounded, under-specified, conflicts with control status, or needs validation evidence that is unavailable.
+6. Escalate upward when uncertain:
+   - If two outcomes seem plausible, choose the stricter one.
+   - If the required validation environment or evidence cannot be confirmed, choose `stoppen / nicht freigeben`.
+   - If LR or shadow relevance is uncertain, treat the change as shadow-relevant.
+
+## Decision Rules
+
+- Never infer LR-GO from Board stage, repo status, or successful local tests.
+- Never allow live-capital reasoning or live-release implications.
+- Never mix unrelated scope into the validation decision.
+- Derive test depth from blast radius and risk, not from developer convenience.
+- Treat strategy and signal changes as behavior changes even when the diff looks small.
+- Treat contract, persistence, and observability changes as potentially cross-service until proven otherwise.
+- Treat missing evidence as increased risk, not as neutral.
+- Treat current `trade-capable` Board stage as orthogonal to validation strictness; it does not justify a lighter path.
+- If the selected path is anything other than `nur Unit Tests` for a truly isolated internal change, default the operational posture to shadow/mock only.
+
+## Fail-Closed Rules
+
+- If any required control file cannot be read, stop and return `stoppen / nicht freigeben`.
+- If the change scope cannot be bounded confidently, stop and return `stoppen / nicht freigeben`.
+- If execution, order, or trade paths may be touched but the boundary is unclear, require at least `MockExchange / Emulator noetig`; if even that scope is unclear, stop.
+- If cross-service contracts or persistence may be affected and offline evidence is insufficient, require at least `Replay noetig`; escalate to `Shadow-Evidence noetig` when behavior remains operationally relevant.
+- If observability or alerting changes could alter operator understanding, do not downgrade below the highest validation level justified by the affected operational path.
+- If the change has possible LR or shadow relevance and that relevance cannot be excluded, keep it shadow/mock only.
+
+## Output
+
+Return the result in this structure:
+
+```md
+Befund
+- ...
+
+Aenderungsklasse
+- ...
+
+Empfohlener Validierungspfad
+- one of: nur Unit Tests | Replay noetig | MockExchange / Emulator noetig | Shadow-Evidence noetig | stoppen / nicht freigeben
+
+Notwendige Checks
+- ...
+
+Stop-Kriterien
+- ...
+
+Restunsicherheiten
+- ...
+
+Shadow/mock only
+- yes/no + why
+
+Test-First Empfehlung
+- Wenn der Validierungspfad "nur Unit Tests" ist:
+  - Lade `cdb-test-first` Skill
+  - Beantworte die 5 Test-First-Fragen (Regel, Testart, Entscheidung, Metadaten, Weiterverarbeitung)
+  - Dokumentiere die Testart und die 15 Metadaten-Felder aus `knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md` §3
+  - Prüfe, ob der Test später SurrealDB-Wissen erzeugt (`surrealdb_export: true`)
+- Wenn der Pfad "Replay" oder "MockExchange/Emulator" ist:
+  - Zusätzlich zu den Test-First-Fragen: Prüfe MockExchange-Muster aus `knowledge/testing/MOCKEXCHANGE_CDB_TEST_MAP.md`
+```
+
+## Anti-Patterns
+
+- Do not guess the lightest validation path.
+- Do not reduce validation depth because the diff is small.
+- Do not treat passing unit tests as sufficient for strategy, signal, execution, contract, persistence, or observability changes.
+- Do not imply deployment or release approval from a validation-path decision.
+- Do not blur replay, emulation, and shadow evidence into one bucket.

--- a/docs/skills/cdb-test-first/SKILL.md
+++ b/docs/skills/cdb-test-first/SKILL.md
@@ -1,0 +1,154 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-test-first/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-test-first
+description: >
+  CDB test-first planning rules. Load when the task involves testing, test
+  planning, validation, evidence generation, or any significant implementation
+  that needs test coverage. Teaches test-first thinking, test type selection,
+  metadata contract, SurrealDB test knowledge model, and MockExchange pattern
+  recognition.
+---
+
+# CDB Test-First Skill
+
+## Purpose
+
+Every CDB test is a **knowledge building block**, not just a code checker.
+Before writing any test, clarify what it protects, what type fits, which
+decision it strengthens, how it is structured, and how its result becomes
+machine-usable knowledge later.
+
+---
+
+## 1. Test-First Thinking (R1)
+
+Before writing a test, answer these five questions:
+
+| Frage | Beispiel |
+|---|---|
+| **Welche Regel wird geschützt?** | INV-011: Risk-before-Execution |
+| **Welche Testart passt?** | Schutz-Test |
+| **Welche Entscheidung wird sicherer?** | Kill-Switch stoppt Execution zuverlässig |
+| **Welche Metadaten braucht der Test?** | test_id, test_type, cdb_area, rule_ref, decision_ref, issue_ref, pr_ref, evidence_ref, security_relevant, live_relevant, profitability_relevant |
+| **Wie wird das Ergebnis weiterverarbeitet?** | PASS -> SurrealDB-Record + Evidence, FAIL -> Issue |
+
+Canon: `knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md` §2
+
+---
+
+## 2. Testart-Auswahl (R2)
+
+Jeder Test gehört zu genau einer der 15 Testarten. Die Testart folgt aus der
+geprüften Regel:
+
+| # | Testart | Prüft | Wann wählen |
+|---|---------|-------|-------------|
+| 1 | **Bauteil-Test** | Einzelne Funktion/Klasse isoliert | Immer. Jeder neue Code zuerst. |
+| 2 | **Ketten-Test** | Service-übergreifende Kommunikation | Feature durchläuft mehrere Services |
+| 3 | **Schutz-Test** | Sicherheitsgrenzen (Kill-Switch, Exposure, Fail-Closed) | Risk-, Governance-, Execution-Änderung |
+| 4 | **Wirtschafts-Test** | Geldflüsse (Fees, Slippage, PnL, Reservierungen) | Fee-Modell, PSM, Portfolio-Änderung |
+| 5 | **Betriebs-Test** | Neustart, Recovery, Langlauf, Chaos | Recovery-Logik, neuer Service, Startup-Reihenfolge |
+| 6 | **Wissens-Test** | Doku-Code-Konsistenz | Docs, Contracts, SERVICE_CATALOG-Änderung |
+| 7 | **Property-based** | Invariante mit Zufallseingaben | State-Machine, Order-Lifecycle, math. Berechnung |
+| 8 | **Fuzzing** | Kaputte/extreme Daten an Parser/Schnittstelle | Datenempfänger (WS, REST), Parser |
+| 9 | **Mutation Testing** | Testqualität (Code mutieren, Test muss failen) | Wichtige Schutz-Tests absichern |
+| 10 | **Metamorphic Testing** | Beziehung zwischen Eingabe/Ausgabe | Skalierung, Proportionen, Fee-Verdopplung |
+| 11 | **API-Fuzzing** | Kaputte API-Requests -> fail-closed | Neuer API-Endpunkt |
+| 12 | **Security-Test** | Auth-Lücken, Secrets im Log, Injection | Auth-Änderung, neuer Endpunkt, Secrets-Logik |
+| 13 | **Supply-Chain-Test** | Dependency-Sicherheit, CVEs, Lizenzen | Neue Library, Security-Scan |
+| 14 | **Datenbank-Test** | Migrationen, Queries, Schema | Neue Migration, Schema-Änderung |
+| 15 | **Agenten-Wissens-Test** | Agenten-Kenntnis von CDB-Regeln | Neue Policy, STOP-Zone, Governance-Dokument |
+
+Canon: `knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md` §4
+
+---
+
+## 3. Test-Metadaten (R3)
+
+Jeder wichtige CDB-Test trägt diese 15 Felder als Docstring-Kopf oder
+YAML-Block:
+
+| Feld | Typ | Beispiel |
+|---|---|---|
+| `test_id` | string | `tc_kill_switch_001` |
+| `test_name` | string | `kill_switch_blocks_all_orders` |
+| `test_type` | string | `schutz` |
+| `cdb_area` | string | `risk` |
+| `rule_ref` | string | `INV-011` |
+| `decision_ref` | string | `Kill-Switch stoppt Execution zuverlässig` |
+| `issue_ref` | string | `#1492` |
+| `pr_ref` | string | `#1550` |
+| `evidence_ref` | string | `docs/evidence/risk/kill_switch_proof_001.md` |
+| `code_area` | string | `services/risk/` |
+| `security_relevant` | bool | `true` |
+| `live_relevant` | bool | `true` |
+| `profitability_relevant` | bool | `false` |
+| `surrealdb_export` | bool | `true` |
+| `ci_artifact` | bool | `false` |
+
+Canon: `knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md` §3
+
+---
+
+## 4. SurrealDB-Testwissen (R4)
+
+Tests sind Wissensbausteine. Agenten planen Tests mit diesen Beziehungen:
+
+```
+(test_case) --prueft--> (rule)
+(test_case) --betrifft--> (cdb_area)
+(test_case) --gehoert_zu--> (issue)
+(test_case) --gelandet_in--> (pull_request)
+(test_case) --erzeugt--> (evidence)
+(evidence) --belegt--> (decision)
+(skill_rule) --lehrt_regel--> (test_type)
+```
+
+Das Feld `surrealdb_export: true` markiert Tests für den späteren Export.
+
+Canon: `knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md` §5
+
+---
+
+## 5. MockExchange-Muster (R5)
+
+MockExchange liefert Testmuster ohne Integration. Erkennbare Muster:
+
+| Muster | CDB-Übersetzung |
+|---|---|
+| **State-Convergence** | Jede Order endet genau einmal in FILLED/REJECTED/FAILED/CANCELLED |
+| **No false fill** | Rejected orders erzeugen Null-Fill, kein Executor-Aufruf |
+| **Fee/Slippage realism** | Netto-PnL = Brutto-PnL - Fees - Slippage, getrennt ausweisbar |
+
+Canon: `knowledge/testing/MOCKEXCHANGE_CDB_TEST_MAP.md` § Practical Meaning
+
+---
+
+## 6. When to load this skill
+
+- Before writing any test for a new feature, issue, or slice
+- Before planning validation scope (`cdb-shadow-validation` path)
+- During session start (`cdb-session-start`) when the task has test scope
+- When reviewing whether test evidence is complete for a PR or closure
+- When designing tests that will later feed SurrealDB evidence
+
+## External Documentation Lookup
+
+Test-first planning references external testing and linting tools:
+- Load `cdb-external-docs` before planning tests that depend on pytest, Ruff, mypy, or Black.
+- Look up `docs/external-docs/index.md` → Python / CI / Dev-Qualität section.
+- Read official test framework docs when designing test patterns.
+- If no internet is available, use local code patterns as fallback and flag the gap.
+
+## Canon sources
+
+- `knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md` — full contract (15 test types, metadata, SurrealDB model)
+- `knowledge/testing/MOCKEXCHANGE_CDB_TEST_MAP.md` — MockExchange pattern translations
+- `knowledge/testing/SKILL_VALLEY_TEST_UPGRADE_PLAN.md` — upgrade plan (R1-R8)
+- `knowledge/testing/README.md` — testing knowledge index

--- a/docs/skills/cdb-trading-core/SKILL.md
+++ b/docs/skills/cdb-trading-core/SKILL.md
@@ -1,0 +1,46 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-trading-core/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: cdb-trading-core
+description: 'Trading-system development for Claire de Binare in the current working repo. Use when Codex needs cross-cutting work over strategy logic, backtesting, market-data flow, Risk Service integration, shadow or paper evidence, or performance reporting. Respect the current canon: the working repo is authoritative, `trade-capable` does not imply LR-GO, and no action may place live orders or use live credentials.'
+disable-model-invocation: true
+---
+
+# Claire de Binare Trading
+
+## Canon first
+- Use the working repo as canon; do not use the retired external docs repo.
+- Separate status classes:
+  - `CURRENT_STATUS.md` for repo and engineering state
+  - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` for live-readiness verdict
+  - `docs/runbooks/CONTROL_REGISTER.md` for Board stage
+- Current reality: Board stage can be `trade-capable` while LR remains `NO-GO`.
+
+## Scope
+- strategy logic and evaluation
+- market-data and decision-flow plumbing
+- shadow or paper execution evidence
+- performance reporting
+- coordination across backtesting, exchange boundaries, and risk gates
+
+## Routing rule
+- If the task is mainly backtesting, prefer `cdb-backtest-engine`.
+- If the task is mainly exchange-boundary work, prefer `cdb-exchange-adapters`.
+- If the task is mainly gating or limits, prefer `cdb-risk-governance`.
+- Use this skill when the request spans multiple of those areas.
+
+## Working rules
+- Evidence over assumptions. If a strategy, exchange, or runtime mode is unclear, derive it from the repo or ask.
+- Prefer paper, replay, or shadow evidence.
+- Do not introduce live-order behavior.
+- Keep credentials in secret storage only and never print them.
+
+## Safety
+- No live orders.
+- No live-credential changes.
+- If the request implies enabling live trading, stop and point to `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` plus `knowledge/operating_rules/LIVE_TRADING_RUNBOOK.md` as procedure shape only.

--- a/docs/skills/ctb-docker-stack/SKILL.md
+++ b/docs/skills/ctb-docker-stack/SKILL.md
@@ -1,0 +1,62 @@
+<!--
+Canonical Skill Source: docs/skills/ctb-docker-stack/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: ctb-ops-stack-skillpack
+description: Ops skillpack for the current CDB stack. Use when Codex needs command-first PowerShell guidance for Docker, compose, DR, rollback, incident response, or stack inspection in the working repo. Use canonical BLUE+RED runtime paths, respect `SECRETS_PATH`, and require explicit user approval before any mutating Docker or compose action.
+disable-model-invocation: true
+---
+
+# CDB Ops Stack Skillpack
+
+## Discovery mapping
+- Folder: ctb-docker-stack
+- Skill name: ctb-ops-stack-skillpack
+- Treat these as the same OpenCode skill surface; do not rename the folder or the skill in this patch.
+
+## Canon first
+- Working repo only.
+- Start control-first:
+  1. GitHub control issue `#1445`
+  2. newest weekly comment on `#1445`
+  3. ratified stage issue `#1492` as Board context only
+  4. `docs/runbooks/CONTROL_REGISTER.md`
+  5. `CURRENT_STATUS.md`
+  6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+  7. only then repo-level commands, issues, or PR actions
+- Use `knowledge/CDB_DOCKER_STACK_INVENTORY.md` only after the control-first chain above.
+- Treat Board stage and LR verdict separately. `trade-capable` does not authorize live operations.
+- `#1492` is ratified stage context, not LR-GO.
+
+## Approval gate
+For any command that mutates Docker Desktop, compose state, containers, networks, volumes, images, or configuration:
+
+> STOP -> present the exact command -> wait for explicit user approval -> then act
+
+This replaces older gate names. The required approver is the explicit user in the current thread.
+
+## Hard rules
+- No guessing. Missing runtime facts or target paths require a short clarifying question.
+- No secrets: never print secret values or secret file contents.
+- Use canonical compose files explicitly: `infrastructure/compose/compose.blue.yml` and `infrastructure/compose/compose.red.yml`.
+- Do not give single-compose shortcuts as default guidance; prefer `make docker-up` and explicitly reference `infrastructure/compose/compose.blue.yml` + `infrastructure/compose/compose.red.yml`.
+- Treat `SECRETS_PATH` as canonical for local secrets.
+- Never use `docker compose down -v` unless the user explicitly approves a destructive action.
+
+## External Documentation Lookup
+
+This skill references Docker, Compose, and container runtime documentation:
+- Load `cdb-external-docs` before composing Docker commands or debugging stack issues.
+- Look up `docs/external-docs/index.md` → Runtime / Infrastruktur section.
+- Relevant: Docker Docs, Docker Compose, Dev Containers.
+- Verify compose syntax and behavior against official docs before mutating stack state.
+
+## Default output format
+1. Context snapshot
+2. Proposed commands, clearly marked as not executed until approved
+3. Mini-runbook
+4. Approval status: pending or approved

--- a/docs/skills/gh-address-comments/SKILL.md
+++ b/docs/skills/gh-address-comments/SKILL.md
@@ -1,0 +1,50 @@
+<!--
+Canonical Skill Source: docs/skills/gh-address-comments/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: gh-address-comments
+description: Address GitHub PR review comments in the current repo with `gh`. Use when the user wants comment triage, replies, or code changes for review feedback on the current-branch PR or a specified PR. Verify `gh` authentication first, rebuild context control-first, and do not assume an open PR exists. This skill does not handle generic issue-comment threads unless a separate workflow is added.
+disable-model-invocation: true
+---
+
+# GitHub Comment Handler
+
+Run `gh` commands with escalated network access when needed.
+
+## Workflow
+1. Rebuild context control-first:
+   - inspect GitHub control issue `#1445`
+   - inspect the newest weekly comment on `#1445`
+   - treat issue `#1492` only as current stage context
+   - read `docs/runbooks/CONTROL_REGISTER.md`
+   - read `CURRENT_STATUS.md`
+   - read `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+2. Verify `gh` authentication with `gh auth status`.
+3. Resolve the target PR:
+   - prefer the current branch PR when one exists
+   - otherwise use the explicit PR number or URL the user provided
+   - if no PR is discoverable, stop and ask for it
+4. Fetch comments and review threads with `gh` directly:
+   - `gh pr view <PR> --json reviewThreads,comments,reviews`
+   - `gh api /repos/{owner}/{repo}/pulls/<PR>/comments`
+   - optional: use a repo-provided helper script only if it exists locally
+5. Summarize actionable comments in numbered form.
+6. Stop and ask for explicit user GO, separately for:
+   - code changes (repo writes)
+   - GitHub writes (reply, review, resolve threads)
+7. Only after explicit GO: implement the selected code changes and/or draft the selected replies/resolves.
+
+## Rules
+- Do not assume there is an open PR for the current branch.
+- Do not imply support for generic issue-comment threads; this pack is PR-focused.
+- If auth or rate limits fail, ask the user to re-authenticate and retry.
+- Keep code changes scoped to the selected comments.
+- Do not read `#1492` as LR clearance.
+- Default is read-only: first read, then plan, then wait for explicit GO.
+- No code changes without explicit user GO.
+- No GitHub writes without explicit user GO (reply/review/resolve).
+- Never resolve review threads blindly; show the planned replies/resolves first and why.

--- a/docs/skills/onboarding/SKILL.md
+++ b/docs/skills/onboarding/SKILL.md
@@ -1,0 +1,245 @@
+<!--
+Canonical Skill Source: docs/skills/onboarding/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: onboarding
+description: >
+  Canonical CDB onboarding slash command for agents, developers, and docs
+  maintainers. Single smart read-only entrypoint: runs bootloader checks,
+  scenario integrity, LR status, doctor/validator reachability. Produces a
+  status card with two clear next paths. Read-only by default. No
+  Live-Go, no Echtgeld-Go, no runtime/Docker/DB/MCP mutation. Safe for
+  fresh clones and first-time agent sessions.
+---
+
+# /onboarding — Canonical CDB Onboarding Slash Skill
+
+## Purpose
+
+`/onboarding` is the **single smart developer entrypoint** for CDB onboarding.
+It delegates to `tools/onboarding_orchestrator.py` which produces a read-only
+status card with bootloader check, scenario integrity, LR status, doctor/validator
+reachability, and two clear next paths.
+
+If the user says `/onboarding`, `onboarding`, `onboarding durchführen`, `mach onboarding`,
+`fresh agent onboarding`, or equivalent, run: `python -m tools.onboarding_orchestrator`
+
+If the user says `onboarding rehearsal`, `guided rehearsal`, `rehearsal mode`,
+`generalprobe`, `tu so als waere ich neuer entwickler`, `reisefuehrer`,
+`nicht staendig fragen`, `realitaetsnah simulieren`, `onboarding als test-szenario`,
+or equivalent, run: `python -m tools.onboarding_simulation --mode guided-rehearsal --role developer`
+Guided rehearsal ist kein Setup-GO und kein Live-Go. Mutierende Schritte werden nur simuliert.
+
+**Nach guided-rehearsal-Lauf:** KEINE Anschlussfrage, keine Einladung, kein "Wenn du willst...".
+Keine nummerierten Nachfolgemenues (1/2/3).
+Der letzte Ausgabe-Absatz MUSS ein Abschluss sein: Status, ein naechster empfohlener Schritt, STOP.
+
+Do not start `cdb-session-start` or `onboarding_doctor` as the primary path for onboarding intent.
+
+**This is a session-skill / command-skill, not a subagent.**
+
+## Default Invocation
+
+```text
+/onboarding
+```
+
+Equivalent default config:
+
+```yaml
+mode: default
+writes: disabled
+github_writes: disabled
+lr: NO-GO
+```
+
+Expected initial output - a status card with explicit state and allowed next actions:
+
+```text
+=== CDB Onboarding ===
+Status: PASS | SETUP_WARN | BLOCKED
+State: STATUS_ONLY | SETUP_CONFIRMATION_PENDING | SETUP_REQUIRED | DRY_RUN_COMPLETE | BLOCKED
+check_scope: onboarding_status_default | onboarding_status_check_only
+allowed_next_actions: <machine-readable list>
+...
+No changes made.
+LR remains NO-GO.
+trade-capable is not Live-Go.
+
+Only when `State: SETUP_CONFIRMATION_PENDING`:
+
+Moechtest du das Onboarding-Setup jetzt ausfuehren?
+
+1. Ja
+2. Abbruch
+```
+
+## Optional Forms
+
+Optional aliases exist, but `/onboarding` remains canonical:
+
+```text
+/onboarding developer    # Developer onboarding path (alias)
+/onboarding check        # Check-only mode
+```
+
+## Orchestrated Flow
+
+1. **Bootloader check:** `AGENTS.md` + `agents/AGENTS.md` exist and are readable.
+2. **Scenario integrity:** `ONBOARDING_SCENARIO_001_FRESH_AGENT_SAFE_WORK_DRILL.md`
+   exists and contains required governance terms.
+3. **LR status:** `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` confirms NO-GO.
+4. **Doctor / Validator reachability:** `tools/onboarding_doctor.py` and
+   `tools.surrealdb.context_onboarding_doctor` respond.
+5. **Env check:** `.env` presence is a setup-warn only (non-blocking).
+6. **Live Checks (evidence-pflichtig):** `git fetch`, `gh issue view`, `gh pr list`
+   — Ergebnisse dokumentieren. Ohne diese Kommandos: "GitHub-/Check-Live nicht geprüft."
+7. **Final Verdict:** `PASS` | `SETUP_WARN` | `BLOCKED`.
+
+The orchestrator is **read-only by default**: no file writes, no report,
+no setup mutation, no Docker, no secrets. Check-only is a dry-run only and
+must not show or imply setup execution.
+
+Do not create `.env`, initialize secrets, initialize context, write reports, create issues, or run Docker unless the user explicitly selects a next option after the status card.
+
+## Referenced V2 Surfaces
+
+| Surface | Purpose |
+|---------|---------|
+| `AGENTS.md` | Root pointer -> canonical agent registry |
+| `agents/AGENTS.md` | Read Order, Brain Evidence Gate, Context Brain Preflight Gate |
+| `tools/onboarding_orchestrator.py` | **Single smart entrypoint** (status card + verdict) |
+| `tools/onboarding_tour.py` | Role-specific read-only tour |
+| `tools/onboarding_doctor.py` | Local developer setup preflight |
+| `tools/validate_onboarding_docs.py` | Active onboarding docs integrity validator |
+| `tools/onboarding_simulation.py` | Deterministic simulation runner |
+| `docs/onboarding/first_issue_sandbox.md` | Guided first-issue rehearsal |
+| `docs/onboarding/fresh_clone_rehearsal.md` | Read-only fresh-clone path |
+| `docs/onboarding/DEVELOPER_VISUAL_START_HERE.md` | Visual onboarding map |
+| `docs/onboarding/cdb_glossary.md` | CDB terminology reference |
+| `DEVELOPER_ONBOARDING.md` | Developer setup and first PR workflow |
+
+## Run the Orchestrator
+
+```bash
+# Default: status card
+python -m tools.onboarding_orchestrator
+
+# JSON output
+python -m tools.onboarding_orchestrator --format json
+
+# Check-only mode
+python -m tools.onboarding_orchestrator --mode check-only
+
+# PowerShell front door
+.\tools\cdb.ps1 onboarding
+```
+
+## Safety Boundaries
+
+- **LR remains NO-GO** — SSOT: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- **Board stage `trade-capable` is not Live-Go**
+- **No Echtgeld-Go**
+- **Read-only by default** — no file writes, no GitHub writes, no branch creation,
+  no PR creation, no runtime/Docker/DB/MCP mutation, no secrets.
+- **No subagent replacement** — `/onboarding` is a slash-skill, not a subagent.
+  CDB subagents (`/cdb-governance-gatekeeper`, etc.) remain unchanged.
+
+## BLOCKER Conditions
+
+The flow produces `BLOCKED` if:
+
+- Bootloader files (`AGENTS.md`, `agents/AGENTS.md`) are missing or unreadable
+- Scenario document `ONBOARDING_SCENARIO_001_FRESH_AGENT_SAFE_WORK_DRILL.md`
+  is missing or unreadable
+
+Non-blocking warnings (`SETUP_WARN`):
+
+- `.env` fehlt (setup warn, kein blocker)
+- Context Doctor nicht initialisiert (setup warn, kein blocker)
+- `onboarding_doctor` nicht erreichbar
+
+## Allowed Next Paths
+
+Default output may expose these machine-readable next actions only:
+
+- `status_only`
+- `approve_setup`
+- `request_setup_go`
+- `abort`
+
+The two-option prompt appears only when `State: SETUP_CONFIRMATION_PENDING`.
+`1. Ja` maps only to setup approval / an allowed next action boundary in this
+slice. It does not create `.env` or perform any local setup mutation.
+
+## Agent Response Guardrails
+
+### Response Contract (required fields)
+
+- Report the orchestrator `Status`, `State`, warnings, and `allowed_next_actions`.
+- Include `check_scope` and `skipped_checks` as part of the report.
+- Include **Evidence-Abgrenzung**: was wurde geprüft, was nicht (siehe Wording Contract).
+- Include **Safety-Grenzen**: LR NO-GO, kein Live-Go, kein Echtgeld-Go.
+
+### Wording Contract (Evidence-Abgrenzung)
+
+Trenne sauber zwischen geprüften und nicht geprüften Bereichen:
+
+- **Ohne ausgeführte git/gh/check-Kommandos**:
+  erlaubt → "Repo-/Canon-Prüfung durchgeführt; GitHub-/Check-Live nicht geprüft."
+- **Mit Live-Kommandos**:
+  erlaubt → "GitHub-/Repo-Live geprüft: <konkrete Kommandos und Ergebnis>."
+- **`CURRENT_STATUS.md`** → "Engineering-Ledger, nicht Live-Wahrheit."
+- **LR-SSOT** → "`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`"
+- **trade-capable** → "Board-/Stage-Kontext, kein Live-Go."
+- **Invarianten** → "Zentrale Sicherheitsgrenzen erkannt."
+
+### Verbotene Phrasen
+
+- "Live-Wahrheit geprüft: Ja" (nur mit konkreten git/gh/check-Kommandos erlaubt)
+- "trade-capable ist deaktiviert" / "trade-capable ist aktiviert"
+- "alle systemischen Invarianten erfasst" / "vollständige Live-Wahrheit geprüft"
+- "CURRENT_STATUS.md ist Live-Wahrheit"
+- "trade-capable erlaubt Live" / "trade-capable ist Live-Go"
+- Freie Management-Zusammenfassung ohne Evidence-Abgrenzung
+
+### Weitere Regeln
+
+- Do not invent, renumber, or expand options beyond the orchestrator contract.
+- Do not offer direct setup execution after `--mode check-only` / dry-run.
+- If doctor output is partial, say so explicitly instead of presenting it as a full check.
+- Board-Stage nie als Schalter oder Freigabe darstellen.
+- Vollständigkeitsclaims nach Teilreads vermeiden.
+
+All paths require explicit GO before execution. Default mode produces
+no report and no setup mutation.
+
+## External Documentation Lookup
+
+When onboarding orientation mentions external tools or agent surfaces:
+- Load `cdb-external-docs` for a complete list of external documentation references.
+- Look up `docs/external-docs/index.md` for links to OpenCode, Cursor, Codex, Claude, Gemini docs.
+- Relevant for new agents: Agent Surfaces section, GitHub Docs, MCP / Context docs.
+- If internet is unavailable, reference local `docs/external-docs/index.md` and `AGENTS.md`.
+
+## Agent Onboarding Readiness
+
+Optional, informational readiness orientation for new agents and fresh clones.
+Canonical description: [`../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md`](../../../docs/onboarding/AGENT_COMPATIBILITY_READINESS.md).
+
+- Four read-only checks: CLI compatibility scan, startup review, validation review, docs reliability review.
+- Score is informational only: no CI gate, no merge gate, no automatic blocker. The primary output is a prioritized Top-fixes list.
+- The external scanner `npx -y agent-compatibility@0.1.7 .` is optional and not bundled; missing Node/npm/network is `ENV_UNAVAILABLE` and must not be scored as a repo defect.
+- Boundaries unchanged: LR remains NO-GO, `trade-capable` is not Live-Go, no Echtgeld-Go.
+
+## Non-Goals
+
+- No Live-Go.
+- No Echtgeld-Go.
+- No runtime, Docker, trading, strategy, LR, productive DB, SurrealDB, or MCP mutation.
+- No automatic setup, report, or runtime action.
+- No replacement of existing CDB subagents.

--- a/docs/skills/surrealdb-python/SKILL.md
+++ b/docs/skills/surrealdb-python/SKILL.md
@@ -1,0 +1,57 @@
+<!--
+Canonical Skill Source: docs/skills/surrealdb-python/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: surrealdb-python
+description: "CDB-curated, script-free activation of the official SurrealDB Python skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealDB Python SDK
+
+## Zweck
+
+Nutze diesen Skill fuer den SurrealDB-Python-SDK-Kontext: `Surreal`,
+`AsyncSurreal`, Client/Server-Modus und Embedded-Varianten wie `mem://` oder
+`file://`.
+
+## Wann zuenden
+
+- bei Python-Code mit dem Paket `surrealdb`
+- bei Review von `Surreal(...)` oder `AsyncSurreal(...)`
+- bei Embedded-Nutzung mit `mem://` oder `file://`
+- bei SDK-Fragen zu CRUD, Query-Calls oder Session-Nutzung
+
+## CDB-Kernpunkte
+
+- Beispiele aus Upstream muessen auf CDB-Read-only- und Governance-Grenzen angepasst werden.
+- Keine Zugangsdaten, Root-Defaults oder Startbefehle aus Upstream-Beispielen uebernehmen.
+- Embedded- oder lokale Laufmodi sind kein Signal fuer produktive Freigabe.
+- Dieser Skill bleibt script-frei und autorisiert keine Ausfuehrung.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealdb-python`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Nutze Upstream nur als API- und Pattern-Referenz.
+- Fuer produktive oder DB-backed Behauptungen zaehlt CDB-Evidence vor Beispielcode.
+- Wenn Embedded- oder WebSocket-Verhalten relevant ist, gleiche es mit dem Repo-Canon ab.

--- a/docs/skills/surrealdb-vector/SKILL.md
+++ b/docs/skills/surrealdb-vector/SKILL.md
@@ -1,0 +1,55 @@
+<!--
+Canonical Skill Source: docs/skills/surrealdb-vector/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: surrealdb-vector
+description: "CDB-curated, script-free activation of the official SurrealDB vector skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealDB Vector Search
+
+## Zweck
+
+Nutze diesen Skill fuer HNSW-Indexe, KNN-Abfragen, Similarity-Scoring und
+vektorbasierte Retrieval-Muster in SurrealDB.
+
+## Wann zuenden
+
+- bei `DEFINE INDEX ... HNSW`
+- bei KNN-Queries mit `<|K, EF|>`
+- bei Score-/Threshold-Logik fuer RAG oder semantische Suche
+- bei Review von Vector-Schema- oder Embedding-Feldern
+
+## CDB-Kernpunkte
+
+- Dimension, Distanzfunktion und Typ muessen zum Embedding-Vertrag passen.
+- Scoring-Logik gehoert nachvollziehbar dokumentiert und testbar gemacht.
+- Dieser Skill bleibt script-frei und gibt keine Laufzeit- oder Installationsbefehle vor.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealdb-vector`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Halte Vector-Suche strikt getrennt von Runtime- oder Live-Freigaben.
+- Nutze diesen Skill fuer Query- und Schema-Verstaendnis, nicht als Schreibfreigabe.
+- Wenn HNSW-Details von CDB-Vertraegen abweichen, gilt der engere CDB-Vertrag.

--- a/docs/skills/surrealql/SKILL.md
+++ b/docs/skills/surrealql/SKILL.md
@@ -1,0 +1,59 @@
+<!--
+Canonical Skill Source: docs/skills/surrealql/SKILL.md
+Surface: docs (canonical)
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
+-->
+---
+name: surrealql
+description: "CDB-curated, script-free activation of the official SurrealQL agent skill."
+metadata:
+  author: surrealdb
+  source_commit: "95628976"
+  cdb_curated: true
+---
+
+# SurrealQL
+
+## Zweck
+
+Nutze diesen Skill fuer SurrealQL-Queries, Schema-Definitionen,
+Graph-Traversals und Syntax-Reviews rund um SurrealDB.
+
+## Wann zuenden
+
+- beim Schreiben oder Pruefen von `.surql`
+- bei `DEFINE TABLE` / `DEFINE FIELD` / `DEFINE INDEX`
+- bei Graph-Relationships und Record-IDs
+- wenn SQL-Denkmuster auf SurrealQL uebersetzt werden muessen
+
+## CDB-Kernpunkte
+
+- SurrealQL ist nicht ANSI-SQL.
+- Fuer aktuelle Syntax gilt die offizielle SurrealDB-Doku als SSOT.
+- Repo-Kanon und CDB-Vertraege haben Vorrang, wenn CDB den Upstream enger fasst.
+- Dieser Skill ist absichtlich script-frei und enthaelt keine Installations- oder
+  Auto-Run-Anweisungen.
+
+## Governance Boundary
+
+- CDB Governance gewinnt vor externer Doku.
+- This skill is read-only guidance only; it does not authorize command execution.
+- No DB-/MCP-writes are authorized by this skill.
+- No Live-GO / Echtgeld-GO.
+
+## Offizielle Quelle
+
+- Docs: `https://surrealdb.com/docs/build/ai-agents/agent-skills`
+- Repo: `https://github.com/surrealdb/agent-skills`
+- Skill: `surrealql`
+- Inspected source commit: `95628976`
+
+## Sichere Nutzung in CDB
+
+- Nutze diesen Skill zusammen mit der offiziellen Doku, wenn Syntax oder
+  Versionsverhalten unklar ist.
+- Wenn CDB-Canon und Upstream-Beispiel kollidieren, stoppe und dokumentiere den
+  Widerspruch statt still zu raten.
+- Fuer Vector- oder Python-SDK-Themen lade den passenden Schwester-Skill.


### PR DESCRIPTION
## Summary

Establish `docs/skills/<name>/SKILL.md` as Single Source of Truth for all 25 active CDB repo skills. Surface adapters (`.opencode/`, `.cursor/`, `.codex/`, `.claude/`) remain unchanged in this slice; drift is documented for follow-up.

## Delivered

- 23 new canonical `docs/skills/<name>/SKILL.md` files (plus 2 pre-existing: `gh-fix-ci`, `cdb-github-api-ops`)
- Updated [`docs/skills/README.md`](docs/skills/README.md) with full 25-skill inventory
- Updated [`docs/skills/SKILL_SURFACE_REGISTRY.md`](docs/skills/SKILL_SURFACE_REGISTRY.md) with §16 inventory + drift matrix
- New [`docs/skills/CDB.VERFUEGBARE.SKILLS_LISTE_2026-07-01.md`](docs/skills/CDB.VERFUEGBARE.SKILLS_LISTE_2026-07-01.md)

## Skill-Inventar

25/25 active CDB repo skills now have canonical files under `docs/skills/`.

Excluded (not counted as skills): `skillforge` (meta-tool, gitignored), `mockexchange` (no SKILL.md), `codex-primary-runtime` (no SKILL.md), Cursor rules/subagents, Redis plugin (routing-only), `.claude/skills/*.skill` (alias).

## Neu angelegte kanonische Skill-Dateien (23)

`cdb-backtest-engine`, `cdb-ci-cd-guard`, `cdb-contract-evidence-gatekeeper`, `cdb-control-intake`, `cdb-docs-ops`, `cdb-drift-reconcile`, `cdb-exchange-adapters`, `cdb-external-docs`, `cdb-issue-to-session-plan`, `cdb-onboarding`, `cdb-operator`, `cdb-risk-governance`, `cdb-session-close`, `cdb-session-start`, `cdb-shadow-validation`, `cdb-test-first`, `cdb-trading-core`, `ctb-docker-stack`, `gh-address-comments`, `onboarding`, `surrealdb-python`, `surrealdb-vector`, `surrealql`

Source priority used: `.opencode/skills/` (except `cdb-onboarding` from codex alias).

## Surface-Abgleich

| Skill | Body drift vs canon |
|---|---|
| 21 skills | Identical across opencode/cursor/codex/claude |
| `cdb-session-start` | cursor, codex, claude differ |
| `onboarding` | cursor, codex, claude differ |
| `gh-fix-ci` | adapters differ (canon has META/scripts) |
| `cdb-github-api-ops` | adapters differ (canon has registry header) |
| `cdb-onboarding` | codex-only alias |

Follow-up: `[SKILLS] Mirror surface adapters from docs/skills canon`

## Nicht-Ziele

- No content changes to `cdb-session-close` (post-close follow-up intake = next slice)
- No runtime/Docker/DB/MCP changes
- No Gemini domain-skill mirror
- No surface adapter rewrites in this PR
- No touch of unrelated ARVP dirty state in main worktree

## Validation

- `python -m tools.validate_onboarding_docs` — PASS
- 25/25 canon files present under `docs/skills/`
- `git diff --check` — PASS
- Docs/skill-only diff

## Follow-up

- `[SKILLS] Extend cdb-session-close with post-close follow-up issue intake` (to be created after merge)
- `[SKILLS] Mirror surface adapters from docs/skills canon`

## Restunsicherheiten

- Surface adapter headers (Registry §7) not yet applied repo-wide
- `gh-fix-ci` canon vs adapter structural difference (scripts/META in canon only) is intentional for now

## Test plan

- [x] Canon completeness check (25/25)
- [x] `validate_onboarding_docs`
- [x] `git diff --check`
- [x] CI + policy-gate green
