### PR TITLE
docs(skills): add cdb-session-close follow-up intake

### DIFF
--- a/.claude/skills/cdb-session-close/SKILL.md
+++ b/.claude/skills/cdb-session-close/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-session-close/SKILL.md
+Surface: claude
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface darf nur abweichen, wenn Begruendung in docs/skills/cdb-session-close/SKILL.md dokumentiert ist.
+-->
 ---
 name: cdb-session-close
 description: >
@@ -9,7 +16,8 @@ description: >
   comment without overstating completion. Use after implementation,
   reconciliation, or validation work when the session needs an honest close.
   When a PR was merged during the session, also verifies delivery on main,
-  normalizes local main, and classifies temporary git surfaces before marking
+  normalizes local main, classifies temporary git surfaces, and performs
+  mandatory post-close Control-Plane follow-up issue intake before marking
   the session complete.
 ---
 
@@ -20,9 +28,15 @@ Close a working session so the repo, git state, and issue thread reflect reality
 ## Inputs
 
 - Current working tree and session context.
+- Session start timestamp or last known issue/PR checkpoint.
 - Optional issue number, PR, branch context, or prior session goal.
+- Merged PR number and merge timestamp when a PR was merged in this session.
 - Optional prior outputs from `cdb-control-intake` or `cdb-issue-to-session-plan`.
 - Access to git status, diffs, staged state, and issue or PR context when relevant.
+- Access to GitHub issues, PRs, workflow runs, and relevant Control-Plane runbooks.
+- Optional outputs or artifacts from:
+  - `cdb-post-merge-followup-scanner`
+  - `cdb-control-followup-classifier`
 
 ## Workflow
 
@@ -90,7 +104,66 @@ Close a working session so the repo, git state, and issue thread reflect reality
    - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
    - Otherwise: record as `n.a.` or `pending` — no blind deletes.
    - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
-8. Produce the close-out summary:
+8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:
+
+   Always after a merged PR or issue-driven session close, sweep for new
+   Control-/Drift-/Post-Merge follow-up issues:
+
+   ```bash
+   gh issue list --state open --limit 30 --json number,title,createdAt,labels,body,url
+   ```
+
+   Identify issues created since session start or PR merge. Search titles,
+   labels, and bodies for markers including:
+
+   - `cdb-post-merge-followup-scanner`
+   - `CDB Post-Merge Follow-up Scanner`
+   - `cdb-control-followup-classifier`
+   - `control follow-up`
+   - `post-merge follow-up`
+   - `drift`
+   - `docs after PR`
+   - `runbook_evidence_followup_drift`
+   - `architecture_service_catalog_drift`
+   - `discovery_surface_drift`
+   - `canon_terminology_drift`
+   - `docker_runtime_rebuild_followup_required`
+
+   Also inspect workflow-run artifacts or comments referencing the above
+   scanners when available.
+
+   For each candidate issue, determine whether it was directly triggered by
+   this session's PR, merge commit, branch, or changed files. If yes,
+   classify as `post-close follow-up candidate`.
+
+   **Candidate rules:**
+
+   - If exactly one candidate exists and it is small and safe:
+     - Pull the issue into the next work hop.
+     - Apply `cdb-control-intake`, then `cdb-issue-to-session-plan` on that issue.
+     - When Plan-GO or routine docs/control/reconcile follow-up autonomy already
+       applies: start directly.
+     - When no valid GO context exists: emit a concrete next-issue handoff
+       instruction instead of auto-starting.
+   - If multiple candidates exist, prioritize by direct causality:
+     1. explicit mention of this PR/branch/merge
+     2. identical changed files
+     3. workflow marker with PR number
+     4. newest issue
+     - Start at most one issue automatically; list the rest under Reststatus.
+   - If the candidate is unclear, large, safety-critical, CI-red,
+     LR-/Live-/Trading-relevant, or scope-expanding: fail-closed; do not
+     auto-start; formulate a clear handoff.
+
+   **Bounded autonomy:**
+
+   - At most one automatic follow-up hop per session close.
+   - No recursive endless agent loop.
+   - After completing the follow-up issue, run normal `cdb-session-close` again.
+   - If the second close finds new issues again: report only; do not auto-start
+     unless Jannek grants explicit new GO.
+
+9. Produce the close-out summary:
    - State the factual result.
    - Name changed files and artifacts.
    - Name the root cause or central insight if one exists.
@@ -108,6 +181,8 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - Use `erledigt` only when the issue-facing work is actually verified and the claimed git or GitHub state is real.
 - Do not imply LR uplift, live approval, or a Board-stage interpretation from a successful session close.
 - Respect solo-maintainer reality; do not invent reviewer, approver, or handoff ceremonies.
+- Do not auto-start more than one follow-up issue per session close.
+- Do not recurse into endless follow-up chains without explicit new GO.
 
 ## Fail-Closed Rules
 
@@ -123,6 +198,12 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - If the issue comment would overstate what landed, what was pushed, or what is actually done, downgrade the final status and state the pending step explicitly.
 - If a PR was merged but the merge commit cannot be verified on `origin/main`: the session is incomplete; do not set status to `erledigt`.
 - If `git merge --ff-only origin/main` fails: report as pending; do not force a merge or ignore the divergence.
+- If new follow-up issues are found but their link to this session is unclear: do not auto-start.
+- If more than one equally ranked candidate exists: do not pick blindly; emit a prioritized list.
+- If the candidate issue has Runtime-, Docker-rebuild-, Secrets-, Security-, LR-, Live-,
+  or Echtgeld impact: no auto-start without explicit GO.
+- If GitHub issues or workflow runs cannot be read: Reststatus = `follow-up intake unknown`, not `erledigt`.
+- If new Control-Plane issues exist and were not checked: do not mark the session fully complete.
 
 ## Output
 
@@ -151,6 +232,14 @@ Surface-Cleanup (nur wenn applicable, sonst n.a.)
 - Feature-Branch: gelöscht: <name> / n.a. / pending
 - Leftover-Files: <klassifikation> / keine / n.a.
 
+Post-Close Follow-up Intake
+- GitHub-Issue-Sweep: geprüft / nicht geprüft / pending
+- Workflow-Follow-up-Artefakte: geprüft / nicht gefunden / pending
+- Neue Follow-up-Issues seit Session-Start/PR-Merge: <liste> / keine / unknown
+- Direkt zugehöriger Candidate: #<nr> / keiner / unklar
+- Auto-Start nächstes Issue: ja / nein / blocked
+- Begründung: ...
+
 Issue-Kommentar
 Befund
 - ...
@@ -169,6 +258,12 @@ Validierung / Checks
 
 Restunsicherheiten
 - ...
+
+Post-Close Follow-up
+- GitHub-Issue-Sweep: ...
+- Candidate: ...
+- Auto-Start: ...
+- Begründung: ...
 
 Status
 - erledigt | weitere Zuarbeit noetig | bereit fuer Claude Code

--- a/.codex/cdb_skills/cdb-session-close/SKILL.md
+++ b/.codex/cdb_skills/cdb-session-close/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-session-close/SKILL.md
+Surface: codex
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface darf nur abweichen, wenn Begruendung in docs/skills/cdb-session-close/SKILL.md dokumentiert ist.
+-->
 ---
 name: cdb-session-close
 description: >
@@ -9,7 +16,8 @@ description: >
   comment without overstating completion. Use after implementation,
   reconciliation, or validation work when the session needs an honest close.
   When a PR was merged during the session, also verifies delivery on main,
-  normalizes local main, and classifies temporary git surfaces before marking
+  normalizes local main, classifies temporary git surfaces, and performs
+  mandatory post-close Control-Plane follow-up issue intake before marking
   the session complete.
 ---
 
@@ -20,9 +28,15 @@ Close a working session so the repo, git state, and issue thread reflect reality
 ## Inputs
 
 - Current working tree and session context.
+- Session start timestamp or last known issue/PR checkpoint.
 - Optional issue number, PR, branch context, or prior session goal.
+- Merged PR number and merge timestamp when a PR was merged in this session.
 - Optional prior outputs from `cdb-control-intake` or `cdb-issue-to-session-plan`.
 - Access to git status, diffs, staged state, and issue or PR context when relevant.
+- Access to GitHub issues, PRs, workflow runs, and relevant Control-Plane runbooks.
+- Optional outputs or artifacts from:
+  - `cdb-post-merge-followup-scanner`
+  - `cdb-control-followup-classifier`
 
 ## Workflow
 
@@ -90,7 +104,66 @@ Close a working session so the repo, git state, and issue thread reflect reality
    - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
    - Otherwise: record as `n.a.` or `pending` — no blind deletes.
    - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
-8. Produce the close-out summary:
+8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:
+
+   Always after a merged PR or issue-driven session close, sweep for new
+   Control-/Drift-/Post-Merge follow-up issues:
+
+   ```bash
+   gh issue list --state open --limit 30 --json number,title,createdAt,labels,body,url
+   ```
+
+   Identify issues created since session start or PR merge. Search titles,
+   labels, and bodies for markers including:
+
+   - `cdb-post-merge-followup-scanner`
+   - `CDB Post-Merge Follow-up Scanner`
+   - `cdb-control-followup-classifier`
+   - `control follow-up`
+   - `post-merge follow-up`
+   - `drift`
+   - `docs after PR`
+   - `runbook_evidence_followup_drift`
+   - `architecture_service_catalog_drift`
+   - `discovery_surface_drift`
+   - `canon_terminology_drift`
+   - `docker_runtime_rebuild_followup_required`
+
+   Also inspect workflow-run artifacts or comments referencing the above
+   scanners when available.
+
+   For each candidate issue, determine whether it was directly triggered by
+   this session's PR, merge commit, branch, or changed files. If yes,
+   classify as `post-close follow-up candidate`.
+
+   **Candidate rules:**
+
+   - If exactly one candidate exists and it is small and safe:
+     - Pull the issue into the next work hop.
+     - Apply `cdb-control-intake`, then `cdb-issue-to-session-plan` on that issue.
+     - When Plan-GO or routine docs/control/reconcile follow-up autonomy already
+       applies: start directly.
+     - When no valid GO context exists: emit a concrete next-issue handoff
+       instruction instead of auto-starting.
+   - If multiple candidates exist, prioritize by direct causality:
+     1. explicit mention of this PR/branch/merge
+     2. identical changed files
+     3. workflow marker with PR number
+     4. newest issue
+     - Start at most one issue automatically; list the rest under Reststatus.
+   - If the candidate is unclear, large, safety-critical, CI-red,
+     LR-/Live-/Trading-relevant, or scope-expanding: fail-closed; do not
+     auto-start; formulate a clear handoff.
+
+   **Bounded autonomy:**
+
+   - At most one automatic follow-up hop per session close.
+   - No recursive endless agent loop.
+   - After completing the follow-up issue, run normal `cdb-session-close` again.
+   - If the second close finds new issues again: report only; do not auto-start
+     unless Jannek grants explicit new GO.
+
+9. Produce the close-out summary:
    - State the factual result.
    - Name changed files and artifacts.
    - Name the root cause or central insight if one exists.
@@ -108,6 +181,8 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - Use `erledigt` only when the issue-facing work is actually verified and the claimed git or GitHub state is real.
 - Do not imply LR uplift, live approval, or a Board-stage interpretation from a successful session close.
 - Respect solo-maintainer reality; do not invent reviewer, approver, or handoff ceremonies.
+- Do not auto-start more than one follow-up issue per session close.
+- Do not recurse into endless follow-up chains without explicit new GO.
 
 ## Fail-Closed Rules
 
@@ -123,6 +198,12 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - If the issue comment would overstate what landed, what was pushed, or what is actually done, downgrade the final status and state the pending step explicitly.
 - If a PR was merged but the merge commit cannot be verified on `origin/main`: the session is incomplete; do not set status to `erledigt`.
 - If `git merge --ff-only origin/main` fails: report as pending; do not force a merge or ignore the divergence.
+- If new follow-up issues are found but their link to this session is unclear: do not auto-start.
+- If more than one equally ranked candidate exists: do not pick blindly; emit a prioritized list.
+- If the candidate issue has Runtime-, Docker-rebuild-, Secrets-, Security-, LR-, Live-,
+  or Echtgeld impact: no auto-start without explicit GO.
+- If GitHub issues or workflow runs cannot be read: Reststatus = `follow-up intake unknown`, not `erledigt`.
+- If new Control-Plane issues exist and were not checked: do not mark the session fully complete.
 
 ## Output
 
@@ -151,6 +232,14 @@ Surface-Cleanup (nur wenn applicable, sonst n.a.)
 - Feature-Branch: gelöscht: <name> / n.a. / pending
 - Leftover-Files: <klassifikation> / keine / n.a.
 
+Post-Close Follow-up Intake
+- GitHub-Issue-Sweep: geprüft / nicht geprüft / pending
+- Workflow-Follow-up-Artefakte: geprüft / nicht gefunden / pending
+- Neue Follow-up-Issues seit Session-Start/PR-Merge: <liste> / keine / unknown
+- Direkt zugehöriger Candidate: #<nr> / keiner / unklar
+- Auto-Start nächstes Issue: ja / nein / blocked
+- Begründung: ...
+
 Issue-Kommentar
 Befund
 - ...
@@ -169,6 +258,12 @@ Validierung / Checks
 
 Restunsicherheiten
 - ...
+
+Post-Close Follow-up
+- GitHub-Issue-Sweep: ...
+- Candidate: ...
+- Auto-Start: ...
+- Begründung: ...
 
 Status
 - erledigt | weitere Zuarbeit noetig | bereit fuer Claude Code

--- a/.cursor/skills/cdb-session-close/SKILL.md
+++ b/.cursor/skills/cdb-session-close/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-session-close/SKILL.md
+Surface: cursor
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface darf nur abweichen, wenn Begruendung in docs/skills/cdb-session-close/SKILL.md dokumentiert ist.
+-->
 ---
 name: cdb-session-close
 description: >
@@ -9,7 +16,8 @@ description: >
   comment without overstating completion. Use after implementation,
   reconciliation, or validation work when the session needs an honest close.
   When a PR was merged during the session, also verifies delivery on main,
-  normalizes local main, and classifies temporary git surfaces before marking
+  normalizes local main, classifies temporary git surfaces, and performs
+  mandatory post-close Control-Plane follow-up issue intake before marking
   the session complete.
 ---
 
@@ -20,9 +28,15 @@ Close a working session so the repo, git state, and issue thread reflect reality
 ## Inputs
 
 - Current working tree and session context.
+- Session start timestamp or last known issue/PR checkpoint.
 - Optional issue number, PR, branch context, or prior session goal.
+- Merged PR number and merge timestamp when a PR was merged in this session.
 - Optional prior outputs from `cdb-control-intake` or `cdb-issue-to-session-plan`.
 - Access to git status, diffs, staged state, and issue or PR context when relevant.
+- Access to GitHub issues, PRs, workflow runs, and relevant Control-Plane runbooks.
+- Optional outputs or artifacts from:
+  - `cdb-post-merge-followup-scanner`
+  - `cdb-control-followup-classifier`
 
 ## Workflow
 
@@ -90,7 +104,66 @@ Close a working session so the repo, git state, and issue thread reflect reality
    - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
    - Otherwise: record as `n.a.` or `pending` — no blind deletes.
    - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
-8. Produce the close-out summary:
+8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:
+
+   Always after a merged PR or issue-driven session close, sweep for new
+   Control-/Drift-/Post-Merge follow-up issues:
+
+   ```bash
+   gh issue list --state open --limit 30 --json number,title,createdAt,labels,body,url
+   ```
+
+   Identify issues created since session start or PR merge. Search titles,
+   labels, and bodies for markers including:
+
+   - `cdb-post-merge-followup-scanner`
+   - `CDB Post-Merge Follow-up Scanner`
+   - `cdb-control-followup-classifier`
+   - `control follow-up`
+   - `post-merge follow-up`
+   - `drift`
+   - `docs after PR`
+   - `runbook_evidence_followup_drift`
+   - `architecture_service_catalog_drift`
+   - `discovery_surface_drift`
+   - `canon_terminology_drift`
+   - `docker_runtime_rebuild_followup_required`
+
+   Also inspect workflow-run artifacts or comments referencing the above
+   scanners when available.
+
+   For each candidate issue, determine whether it was directly triggered by
+   this session's PR, merge commit, branch, or changed files. If yes,
+   classify as `post-close follow-up candidate`.
+
+   **Candidate rules:**
+
+   - If exactly one candidate exists and it is small and safe:
+     - Pull the issue into the next work hop.
+     - Apply `cdb-control-intake`, then `cdb-issue-to-session-plan` on that issue.
+     - When Plan-GO or routine docs/control/reconcile follow-up autonomy already
+       applies: start directly.
+     - When no valid GO context exists: emit a concrete next-issue handoff
+       instruction instead of auto-starting.
+   - If multiple candidates exist, prioritize by direct causality:
+     1. explicit mention of this PR/branch/merge
+     2. identical changed files
+     3. workflow marker with PR number
+     4. newest issue
+     - Start at most one issue automatically; list the rest under Reststatus.
+   - If the candidate is unclear, large, safety-critical, CI-red,
+     LR-/Live-/Trading-relevant, or scope-expanding: fail-closed; do not
+     auto-start; formulate a clear handoff.
+
+   **Bounded autonomy:**
+
+   - At most one automatic follow-up hop per session close.
+   - No recursive endless agent loop.
+   - After completing the follow-up issue, run normal `cdb-session-close` again.
+   - If the second close finds new issues again: report only; do not auto-start
+     unless Jannek grants explicit new GO.
+
+9. Produce the close-out summary:
    - State the factual result.
    - Name changed files and artifacts.
    - Name the root cause or central insight if one exists.
@@ -108,6 +181,8 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - Use `erledigt` only when the issue-facing work is actually verified and the claimed git or GitHub state is real.
 - Do not imply LR uplift, live approval, or a Board-stage interpretation from a successful session close.
 - Respect solo-maintainer reality; do not invent reviewer, approver, or handoff ceremonies.
+- Do not auto-start more than one follow-up issue per session close.
+- Do not recurse into endless follow-up chains without explicit new GO.
 
 ## Fail-Closed Rules
 
@@ -123,6 +198,12 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - If the issue comment would overstate what landed, what was pushed, or what is actually done, downgrade the final status and state the pending step explicitly.
 - If a PR was merged but the merge commit cannot be verified on `origin/main`: the session is incomplete; do not set status to `erledigt`.
 - If `git merge --ff-only origin/main` fails: report as pending; do not force a merge or ignore the divergence.
+- If new follow-up issues are found but their link to this session is unclear: do not auto-start.
+- If more than one equally ranked candidate exists: do not pick blindly; emit a prioritized list.
+- If the candidate issue has Runtime-, Docker-rebuild-, Secrets-, Security-, LR-, Live-,
+  or Echtgeld impact: no auto-start without explicit GO.
+- If GitHub issues or workflow runs cannot be read: Reststatus = `follow-up intake unknown`, not `erledigt`.
+- If new Control-Plane issues exist and were not checked: do not mark the session fully complete.
 
 ## Output
 
@@ -151,6 +232,14 @@ Surface-Cleanup (nur wenn applicable, sonst n.a.)
 - Feature-Branch: gelöscht: <name> / n.a. / pending
 - Leftover-Files: <klassifikation> / keine / n.a.
 
+Post-Close Follow-up Intake
+- GitHub-Issue-Sweep: geprüft / nicht geprüft / pending
+- Workflow-Follow-up-Artefakte: geprüft / nicht gefunden / pending
+- Neue Follow-up-Issues seit Session-Start/PR-Merge: <liste> / keine / unknown
+- Direkt zugehöriger Candidate: #<nr> / keiner / unklar
+- Auto-Start nächstes Issue: ja / nein / blocked
+- Begründung: ...
+
 Issue-Kommentar
 Befund
 - ...
@@ -169,6 +258,12 @@ Validierung / Checks
 
 Restunsicherheiten
 - ...
+
+Post-Close Follow-up
+- GitHub-Issue-Sweep: ...
+- Candidate: ...
+- Auto-Start: ...
+- Begründung: ...
 
 Status
 - erledigt | weitere Zuarbeit noetig | bereit fuer Claude Code

--- a/.opencode/skills/cdb-session-close/SKILL.md
+++ b/.opencode/skills/cdb-session-close/SKILL.md
@@ -1,3 +1,10 @@
+<!--
+Canonical Skill Source: docs/skills/cdb-session-close/SKILL.md
+Surface: opencode
+Sync Status: mirrored
+Last Verified: 2026-07-01
+Drift Policy: Surface darf nur abweichen, wenn Begruendung in docs/skills/cdb-session-close/SKILL.md dokumentiert ist.
+-->
 ---
 name: cdb-session-close
 description: >
@@ -9,7 +16,8 @@ description: >
   comment without overstating completion. Use after implementation,
   reconciliation, or validation work when the session needs an honest close.
   When a PR was merged during the session, also verifies delivery on main,
-  normalizes local main, and classifies temporary git surfaces before marking
+  normalizes local main, classifies temporary git surfaces, and performs
+  mandatory post-close Control-Plane follow-up issue intake before marking
   the session complete.
 ---
 
@@ -20,9 +28,15 @@ Close a working session so the repo, git state, and issue thread reflect reality
 ## Inputs
 
 - Current working tree and session context.
+- Session start timestamp or last known issue/PR checkpoint.
 - Optional issue number, PR, branch context, or prior session goal.
+- Merged PR number and merge timestamp when a PR was merged in this session.
 - Optional prior outputs from `cdb-control-intake` or `cdb-issue-to-session-plan`.
 - Access to git status, diffs, staged state, and issue or PR context when relevant.
+- Access to GitHub issues, PRs, workflow runs, and relevant Control-Plane runbooks.
+- Optional outputs or artifacts from:
+  - `cdb-post-merge-followup-scanner`
+  - `cdb-control-followup-classifier`
 
 ## Workflow
 
@@ -90,7 +104,66 @@ Close a working session so the repo, git state, and issue thread reflect reality
    - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
    - Otherwise: record as `n.a.` or `pending` — no blind deletes.
    - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
-8. Produce the close-out summary:
+8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:
+
+   Always after a merged PR or issue-driven session close, sweep for new
+   Control-/Drift-/Post-Merge follow-up issues:
+
+   ```bash
+   gh issue list --state open --limit 30 --json number,title,createdAt,labels,body,url
+   ```
+
+   Identify issues created since session start or PR merge. Search titles,
+   labels, and bodies for markers including:
+
+   - `cdb-post-merge-followup-scanner`
+   - `CDB Post-Merge Follow-up Scanner`
+   - `cdb-control-followup-classifier`
+   - `control follow-up`
+   - `post-merge follow-up`
+   - `drift`
+   - `docs after PR`
+   - `runbook_evidence_followup_drift`
+   - `architecture_service_catalog_drift`
+   - `discovery_surface_drift`
+   - `canon_terminology_drift`
+   - `docker_runtime_rebuild_followup_required`
+
+   Also inspect workflow-run artifacts or comments referencing the above
+   scanners when available.
+
+   For each candidate issue, determine whether it was directly triggered by
+   this session's PR, merge commit, branch, or changed files. If yes,
+   classify as `post-close follow-up candidate`.
+
+   **Candidate rules:**
+
+   - If exactly one candidate exists and it is small and safe:
+     - Pull the issue into the next work hop.
+     - Apply `cdb-control-intake`, then `cdb-issue-to-session-plan` on that issue.
+     - When Plan-GO or routine docs/control/reconcile follow-up autonomy already
+       applies: start directly.
+     - When no valid GO context exists: emit a concrete next-issue handoff
+       instruction instead of auto-starting.
+   - If multiple candidates exist, prioritize by direct causality:
+     1. explicit mention of this PR/branch/merge
+     2. identical changed files
+     3. workflow marker with PR number
+     4. newest issue
+     - Start at most one issue automatically; list the rest under Reststatus.
+   - If the candidate is unclear, large, safety-critical, CI-red,
+     LR-/Live-/Trading-relevant, or scope-expanding: fail-closed; do not
+     auto-start; formulate a clear handoff.
+
+   **Bounded autonomy:**
+
+   - At most one automatic follow-up hop per session close.
+   - No recursive endless agent loop.
+   - After completing the follow-up issue, run normal `cdb-session-close` again.
+   - If the second close finds new issues again: report only; do not auto-start
+     unless Jannek grants explicit new GO.
+
+9. Produce the close-out summary:
    - State the factual result.
    - Name changed files and artifacts.
    - Name the root cause or central insight if one exists.
@@ -108,6 +181,8 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - Use `erledigt` only when the issue-facing work is actually verified and the claimed git or GitHub state is real.
 - Do not imply LR uplift, live approval, or a Board-stage interpretation from a successful session close.
 - Respect solo-maintainer reality; do not invent reviewer, approver, or handoff ceremonies.
+- Do not auto-start more than one follow-up issue per session close.
+- Do not recurse into endless follow-up chains without explicit new GO.
 
 ## Fail-Closed Rules
 
@@ -123,6 +198,12 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - If the issue comment would overstate what landed, what was pushed, or what is actually done, downgrade the final status and state the pending step explicitly.
 - If a PR was merged but the merge commit cannot be verified on `origin/main`: the session is incomplete; do not set status to `erledigt`.
 - If `git merge --ff-only origin/main` fails: report as pending; do not force a merge or ignore the divergence.
+- If new follow-up issues are found but their link to this session is unclear: do not auto-start.
+- If more than one equally ranked candidate exists: do not pick blindly; emit a prioritized list.
+- If the candidate issue has Runtime-, Docker-rebuild-, Secrets-, Security-, LR-, Live-,
+  or Echtgeld impact: no auto-start without explicit GO.
+- If GitHub issues or workflow runs cannot be read: Reststatus = `follow-up intake unknown`, not `erledigt`.
+- If new Control-Plane issues exist and were not checked: do not mark the session fully complete.
 
 ## Output
 
@@ -151,6 +232,14 @@ Surface-Cleanup (nur wenn applicable, sonst n.a.)
 - Feature-Branch: gelöscht: <name> / n.a. / pending
 - Leftover-Files: <klassifikation> / keine / n.a.
 
+Post-Close Follow-up Intake
+- GitHub-Issue-Sweep: geprüft / nicht geprüft / pending
+- Workflow-Follow-up-Artefakte: geprüft / nicht gefunden / pending
+- Neue Follow-up-Issues seit Session-Start/PR-Merge: <liste> / keine / unknown
+- Direkt zugehöriger Candidate: #<nr> / keiner / unklar
+- Auto-Start nächstes Issue: ja / nein / blocked
+- Begründung: ...
+
 Issue-Kommentar
 Befund
 - ...
@@ -169,6 +258,12 @@ Validierung / Checks
 
 Restunsicherheiten
 - ...
+
+Post-Close Follow-up
+- GitHub-Issue-Sweep: ...
+- Candidate: ...
+- Auto-Start: ...
+- Begründung: ...
 
 Status
 - erledigt | weitere Zuarbeit noetig | bereit fuer Claude Code

--- a/docs/skills/CDB.VERFUEGBARE.SKILLS_LISTE_2026-07-01.md
+++ b/docs/skills/CDB.VERFUEGBARE.SKILLS_LISTE_2026-07-01.md
@@ -32,7 +32,7 @@ starten in `docs/skills/`.
 | Skill | Canon | Surface-Adapter |
 | --- | --- | --- |
 | `cdb-session-start` | [`cdb-session-start/SKILL.md`](cdb-session-start/SKILL.md) | opencode, cursor, codex, claude |
-| `cdb-session-close` | [`cdb-session-close/SKILL.md`](cdb-session-close/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-session-close` | [`cdb-session-close/SKILL.md`](cdb-session-close/SKILL.md) | opencode, cursor, codex, claude — includes Post-Close Follow-up Intake (Issue #3638) |
 | `cdb-control-intake` | [`cdb-control-intake/SKILL.md`](cdb-control-intake/SKILL.md) | opencode, cursor, codex, claude |
 | `cdb-issue-to-session-plan` | [`cdb-issue-to-session-plan/SKILL.md`](cdb-issue-to-session-plan/SKILL.md) | opencode, cursor, codex, claude |
 | `onboarding` | [`onboarding/SKILL.md`](onboarding/SKILL.md) | opencode, cursor, codex, claude |
@@ -98,5 +98,6 @@ SSOT Activation: [`CDB_SURREALDB_SKILLS_RULES_ACTIVATION.md`](CDB_SURREALDB_SKIL
 ## Non-goals
 
 - Keine Runtime-/Config-/Compose-Änderungen
-- Keine fachliche Erweiterung von `cdb-session-close` in diesem Index
+- Keine fachliche Erweiterung weiterer Skills in diesem Index
+- `cdb-session-close` Post-Close Follow-up Intake: Canon + Adapter gespiegelt (Issue #3638); breiter Surface-Mirror bleibt #3639
 - LR bleibt **NO-GO**

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -16,7 +16,7 @@ synchron gehalten werden.
 | `onboarding` | [`onboarding/SKILL.md`](onboarding/SKILL.md) | opencode, cursor, codex, claude |
 | `cdb-onboarding` | [`cdb-onboarding/SKILL.md`](cdb-onboarding/SKILL.md) | codex (alias → onboarding) |
 | `cdb-session-start` | [`cdb-session-start/SKILL.md`](cdb-session-start/SKILL.md) | opencode, cursor, codex, claude |
-| `cdb-session-close` | [`cdb-session-close/SKILL.md`](cdb-session-close/SKILL.md) | opencode, cursor, codex, claude |
+| `cdb-session-close` | [`cdb-session-close/SKILL.md`](cdb-session-close/SKILL.md) | opencode, cursor, codex, claude — Post-Close Follow-up Intake (#3638) |
 | `cdb-control-intake` | [`cdb-control-intake/SKILL.md`](cdb-control-intake/SKILL.md) | opencode, cursor, codex, claude |
 | `cdb-issue-to-session-plan` | [`cdb-issue-to-session-plan/SKILL.md`](cdb-issue-to-session-plan/SKILL.md) | opencode, cursor, codex, claude |
 | `cdb-operator` | [`cdb-operator/SKILL.md`](cdb-operator/SKILL.md) | opencode, cursor, codex, claude |

--- a/docs/skills/SKILL_SURFACE_REGISTRY.md
+++ b/docs/skills/SKILL_SURFACE_REGISTRY.md
@@ -216,7 +216,7 @@ Nach Canon-Tree-Merge (2026-07-01):
 - `[SKILLS] Mirror surface adapters from docs/skills canon` — Header + byte-sync
   fuer Skills mit bekannter Drift (`cdb-session-start`, `onboarding`, `gh-fix-ci`,
   `cdb-github-api-ops`)
-- `[SKILLS] Extend cdb-session-close with post-close follow-up issue intake`
+- `[SKILLS] Extend cdb-session-close with post-close follow-up issue intake` — **done** (Issue #3638; Canon + `cdb-session-close` adapters only)
 - `[SKILLS] Apply Surface-Adapter-Header to all existing mirrored skills`
 - `[SKILLS] Add drift-reconcile hook for skill surface adapters`
 - `[SKILLS] Add skill-meta schema (META.yaml + evals.json) for new CDB domain skills`
@@ -233,7 +233,7 @@ Drift ist dokumentiert.
 | Skill | Canon | opencode | cursor | codex | claude | Body-Drift |
 |---|---|---|---|---|---|---|
 | cdb-session-start | Y | Y | Y | Y | Y | cursor, codex, claude |
-| cdb-session-close | Y | Y | Y | Y | Y | — |
+| cdb-session-close | Y | Y | Y | Y | Y | — (Post-Close Follow-up Intake #3638; adapters synced) |
 | cdb-control-intake | Y | Y | Y | Y | Y | — |
 | cdb-issue-to-session-plan | Y | Y | Y | Y | Y | — |
 | cdb-operator | Y | Y | Y | Y | Y | — |

--- a/docs/skills/cdb-session-close/SKILL.md
+++ b/docs/skills/cdb-session-close/SKILL.md
@@ -16,7 +16,8 @@ description: >
   comment without overstating completion. Use after implementation,
   reconciliation, or validation work when the session needs an honest close.
   When a PR was merged during the session, also verifies delivery on main,
-  normalizes local main, and classifies temporary git surfaces before marking
+  normalizes local main, classifies temporary git surfaces, and performs
+  mandatory post-close Control-Plane follow-up issue intake before marking
   the session complete.
 ---
 
@@ -27,9 +28,15 @@ Close a working session so the repo, git state, and issue thread reflect reality
 ## Inputs
 
 - Current working tree and session context.
+- Session start timestamp or last known issue/PR checkpoint.
 - Optional issue number, PR, branch context, or prior session goal.
+- Merged PR number and merge timestamp when a PR was merged in this session.
 - Optional prior outputs from `cdb-control-intake` or `cdb-issue-to-session-plan`.
 - Access to git status, diffs, staged state, and issue or PR context when relevant.
+- Access to GitHub issues, PRs, workflow runs, and relevant Control-Plane runbooks.
+- Optional outputs or artifacts from:
+  - `cdb-post-merge-followup-scanner`
+  - `cdb-control-followup-classifier`
 
 ## Workflow
 
@@ -97,7 +104,66 @@ Close a working session so the repo, git state, and issue thread reflect reality
    - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
    - Otherwise: record as `n.a.` or `pending` — no blind deletes.
    - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
-8. Produce the close-out summary:
+8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:
+
+   Always after a merged PR or issue-driven session close, sweep for new
+   Control-/Drift-/Post-Merge follow-up issues:
+
+   ```bash
+   gh issue list --state open --limit 30 --json number,title,createdAt,labels,body,url
+   ```
+
+   Identify issues created since session start or PR merge. Search titles,
+   labels, and bodies for markers including:
+
+   - `cdb-post-merge-followup-scanner`
+   - `CDB Post-Merge Follow-up Scanner`
+   - `cdb-control-followup-classifier`
+   - `control follow-up`
+   - `post-merge follow-up`
+   - `drift`
+   - `docs after PR`
+   - `runbook_evidence_followup_drift`
+   - `architecture_service_catalog_drift`
+   - `discovery_surface_drift`
+   - `canon_terminology_drift`
+   - `docker_runtime_rebuild_followup_required`
+
+   Also inspect workflow-run artifacts or comments referencing the above
+   scanners when available.
+
+   For each candidate issue, determine whether it was directly triggered by
+   this session's PR, merge commit, branch, or changed files. If yes,
+   classify as `post-close follow-up candidate`.
+
+   **Candidate rules:**
+
+   - If exactly one candidate exists and it is small and safe:
+     - Pull the issue into the next work hop.
+     - Apply `cdb-control-intake`, then `cdb-issue-to-session-plan` on that issue.
+     - When Plan-GO or routine docs/control/reconcile follow-up autonomy already
+       applies: start directly.
+     - When no valid GO context exists: emit a concrete next-issue handoff
+       instruction instead of auto-starting.
+   - If multiple candidates exist, prioritize by direct causality:
+     1. explicit mention of this PR/branch/merge
+     2. identical changed files
+     3. workflow marker with PR number
+     4. newest issue
+     - Start at most one issue automatically; list the rest under Reststatus.
+   - If the candidate is unclear, large, safety-critical, CI-red,
+     LR-/Live-/Trading-relevant, or scope-expanding: fail-closed; do not
+     auto-start; formulate a clear handoff.
+
+   **Bounded autonomy:**
+
+   - At most one automatic follow-up hop per session close.
+   - No recursive endless agent loop.
+   - After completing the follow-up issue, run normal `cdb-session-close` again.
+   - If the second close finds new issues again: report only; do not auto-start
+     unless Jannek grants explicit new GO.
+
+9. Produce the close-out summary:
    - State the factual result.
    - Name changed files and artifacts.
    - Name the root cause or central insight if one exists.
@@ -115,6 +181,8 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - Use `erledigt` only when the issue-facing work is actually verified and the claimed git or GitHub state is real.
 - Do not imply LR uplift, live approval, or a Board-stage interpretation from a successful session close.
 - Respect solo-maintainer reality; do not invent reviewer, approver, or handoff ceremonies.
+- Do not auto-start more than one follow-up issue per session close.
+- Do not recurse into endless follow-up chains without explicit new GO.
 
 ## Fail-Closed Rules
 
@@ -130,6 +198,12 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - If the issue comment would overstate what landed, what was pushed, or what is actually done, downgrade the final status and state the pending step explicitly.
 - If a PR was merged but the merge commit cannot be verified on `origin/main`: the session is incomplete; do not set status to `erledigt`.
 - If `git merge --ff-only origin/main` fails: report as pending; do not force a merge or ignore the divergence.
+- If new follow-up issues are found but their link to this session is unclear: do not auto-start.
+- If more than one equally ranked candidate exists: do not pick blindly; emit a prioritized list.
+- If the candidate issue has Runtime-, Docker-rebuild-, Secrets-, Security-, LR-, Live-,
+  or Echtgeld impact: no auto-start without explicit GO.
+- If GitHub issues or workflow runs cannot be read: Reststatus = `follow-up intake unknown`, not `erledigt`.
+- If new Control-Plane issues exist and were not checked: do not mark the session fully complete.
 
 ## Output
 
@@ -158,6 +232,14 @@ Surface-Cleanup (nur wenn applicable, sonst n.a.)
 - Feature-Branch: gelöscht: <name> / n.a. / pending
 - Leftover-Files: <klassifikation> / keine / n.a.
 
+Post-Close Follow-up Intake
+- GitHub-Issue-Sweep: geprüft / nicht geprüft / pending
+- Workflow-Follow-up-Artefakte: geprüft / nicht gefunden / pending
+- Neue Follow-up-Issues seit Session-Start/PR-Merge: <liste> / keine / unknown
+- Direkt zugehöriger Candidate: #<nr> / keiner / unklar
+- Auto-Start nächstes Issue: ja / nein / blocked
+- Begründung: ...
+
 Issue-Kommentar
 Befund
 - ...
@@ -176,6 +258,12 @@ Validierung / Checks
 
 Restunsicherheiten
 - ...
+
+Post-Close Follow-up
+- GitHub-Issue-Sweep: ...
+- Candidate: ...
+- Auto-Start: ...
+- Begründung: ...
 
 Status
 - erledigt | weitere Zuarbeit noetig | bereit fuer Claude Code


### PR DESCRIPTION
## Summary

Closes #3638
Refs #3637
Refs #3639

Extend `cdb-session-close` with mandatory **Post-close Control-Plane Follow-up Intake**: GitHub issue sweep after merged PR or issue-driven close, candidate classification, bounded one-hop autonomy, fail-closed rules, and output templates.

## Delivered

- Canon `docs/skills/cdb-session-close/SKILL.md`: new workflow step 8, extended inputs, candidate rules, bounded autonomy, fail-closed rules, output/issue-comment templates
- Adapter sync (this skill only): `.opencode/`, `.cursor/`, `.codex/`, `.claude/`
- Minimal registry/index updates: `SKILL_SURFACE_REGISTRY.md`, `README.md`, `CDB.VERFUEGBARE.SKILLS_LISTE_2026-07-01.md`

## Brain Evidence

```text
brain_source: repo-only
brain_status: not-used
tools_or_queries:
  - gh issue view 3638, 3639
  - git fetch/status on origin/main (1d12b774)
records_or_results:
  - Issue #3638 OPEN, scope confirmed
  - PR #3637 merged at 1d12b774
repo_crosscheck:
  - docs/skills/cdb-session-close/SKILL.md post-#3637 canon tree
impact_on_plan:
  - Dedicated worktree from origin/main; main worktree ARVP dirty state untouched
limitations:
  - No SurrealDB/MCP brain records used; follow-up intake logic is docs-only
```

## Changed Files

- `docs/skills/cdb-session-close/SKILL.md`
- `.opencode/skills/cdb-session-close/SKILL.md`
- `.cursor/skills/cdb-session-close/SKILL.md`
- `.codex/cdb_skills/cdb-session-close/SKILL.md`
- `.claude/skills/cdb-session-close/SKILL.md`
- `docs/skills/SKILL_SURFACE_REGISTRY.md`
- `docs/skills/README.md`
- `docs/skills/CDB.VERFUEGBARE.SKILLS_LISTE_2026-07-01.md`

## Validation

- `rg` keyword sweep across canon + 4 adapters (Post-close intake markers present)
- `python -m tools.validate_onboarding_docs` → OK
- `git diff --check` → clean
- Only allowed files in commit

## Non-goals

- No broad surface-mirror sync of all skills (#3639 remains separate)
- No changes to other skills
- No runtime/Docker/DB/MCP changes
- No LR/live/trading approval
- No auto-start of risky follow-up issues
- No endless agent loop

## Safety Boundaries

- Skill/docs-only; Shadow/Paper-first unchanged
- LR remains NO-GO; no live/echtgeld implication
- No productive DB or MCP mutations
- Fail-closed for unclear, multi-candidate, or safety-critical follow-ups

## Restunsicherheiten

- Runtime behavior of post-merge scanners not exercised in this slice (docs contract only)
- Codex adapter requires `git add -f` due to `.codex` gitignore parent (file remains tracked)

## Test plan

- [x] Canon + adapter keyword parity (`rg` sweep)
- [x] `python -m tools.validate_onboarding_docs`
- [x] Scope-limited diff (8 files only)
