### PR TITLE
fix(evidence-harvester): resume-safe coordinator + sleep-stall supervisor (#3634)

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -10,6 +10,8 @@
 
 ## Repo / Engineering Status (2026-07-01)
 
+- **Coordinator sleep-window stall fix (#3634)**: Resume-safe coordinator + testable sleep-stall supervisor. `resume-fixture-window` seeds `completed_cycles` from durable `runner_state`, emits `sleep_resumed` + audited recovery on a stalled sleep, and is fail-closed (missing state / `run_id` mismatch / terminal status). New `tools/evidence_harvester/supervisor.py` (`decide_supervision` + bounded `supervise_loop`, no process spawn / scheduler / Docker). A resumed run reaching `final_validation_completed` clears O264/O303. Tests: 29 unit (coordinator+supervisor), full harvester suite 260 PASS, ruff clean. No new 72h run; Slice-E documented only. LR NO-GO.
+
 - **Evidence-Harvester Reconcile (#3384)**: `RECONCILED_NEXT_BLOCKER_IDENTIFIED` — Slice-B/C/D all formal INCONCLUSIVE; #3384/#3589 CLOSED; #3362/#3345 OPEN. Next blocker: **#3634** (coordinator sleep-window stall). LR NO-GO.
 
 - **PR #3635 / #3384 reconcile closeout**: MERGED `325369fb` (2026-07-01, squash). Reconcile docs + Slice-B/C artifact reports on `main`. #3634 triage started (sleep-window stall). LR NO-GO.

--- a/docs/evidence/evidence_harvester_slice_c_inconclusive_2026-06-30.md
+++ b/docs/evidence/evidence_harvester_slice_c_inconclusive_2026-06-30.md
@@ -111,6 +111,53 @@ process supervision against sleep-crash recurrence.
 - Side-effect checklist clean
 - Result posted to #3362 and referenced from #3384 reconcile
 
+## #3634 Sleep-Stall Root Cause & Fix (2026-07-01)
+
+### Root cause (code-backed)
+
+`tools/evidence_harvester/coordinator.py::run_fixture_window` re-initialised
+`completed_cycles = 0` on every launch and looped `while completed_cycles <
+iterations`. The durable events `sleep_started` and `sleep_completed` bracket a
+single in-process blocking `_sleep_with_interval_check`. When the host/process
+died inside that sleep, `sleep_completed` was never written, no
+`final_validation_*` followed, and nothing resumed — the exact Slice-B/C/D
+signature (O264 sleep-lifecycle warn + O303 INCONCLUSIVE). There was no safe
+resume: a restart re-ran the window or double-counted.
+
+### Fix delivered (#3634)
+
+- **Resume-safe coordinator:** new `resume-fixture-window` subcommand
+  (`resume=True`) seeds `completed_cycles` from
+  `runner_state.total_cycles_completed`, detects the stalled sleep, writes a
+  `sleep_resumed` lifecycle event + audited `recovery_event`
+  (`failure_source="sleep_stall"`, `action="resume_cycle_window"`), and
+  continues to the next cycle or directly to final validation. Fail-closed on
+  missing state, `run_id` mismatch, or terminal status.
+- **Testable supervisor:** `tools/evidence_harvester/supervisor.py` adds a pure
+  `decide_supervision` decision (`WAIT | RELAUNCH_RESUME | DONE | STOP_FATAL |
+  STOP_LIMIT`) and an injectable, bounded `supervise_loop`. No process spawn, no
+  scheduler install, no Docker/DB/Redis/secrets.
+- **Regression proof:** a resumed run reaching `final_validation_completed`
+  clears both `_check_sleep_lifecycle_completeness` (O264) and
+  `_check_inconclusive_run` (O303); covered by unit tests in
+  `tests/unit/tools/evidence_harvester/test_coordinator.py` and
+  `tests/unit/tools/evidence_harvester/test_supervisor.py`.
+
+### Slice-E plan (documented; needs Runtime-GO — not executed here)
+
+1. Start a fresh `run_id` with `run-fixture-window` (cadence 900s, iterations
+   ≥288) on a post-#3634 `main` SHA.
+2. Attach the supervisor (`supervisor supervise --explicit` or an external
+   wrapper) so a sleep-window process death triggers `RELAUNCH_RESUME` instead
+   of ending INCONCLUSIVE.
+3. On any stall, resume writes `sleep_resumed` + recovery evidence and continues
+   to `>=72h`, then `ops_validation --is-final`.
+4. Success = `observed_window_hours >= 72` with final verdict PASS or accepted
+   WARN; post result to #3362.
+
+No new 72h run was executed in the #3634 slice. LR remains NO-GO; no Live-Go, no
+Echtgeld-Go.
+
 ## Validation Commands Used
 
 ```powershell

--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
@@ -104,7 +104,7 @@ Version: `cdb.evidence_harvester.runner_state.v1`
 | `last_cycle_started_at_utc` | string | ISO-8601 UTC of last cycle start |
 | `next_cycle_due_at_utc` | string | ISO-8601 UTC of the next scheduled cycle while sleeping |
 | `last_successful_artifact_stamp` | string | Stamp of the last successful artifact cycle |
-| `coordinator_status` | string | Coordinator lifecycle status such as `running`, `sleeping`, `recovering`, `final_validation`, `completed`, or `failed` |
+| `coordinator_status` | string | Coordinator lifecycle status such as `running`, `sleeping`, `resuming`, `recovering`, `final_validation`, `completed`, or `failed` |
 
 ## Coordinator Lifecycle Telemetry
 
@@ -301,10 +301,87 @@ findings on `runner_heartbeat.json.current_run_at_utc` and
 - no recovery
 - fail validation
 
+## Coordinator Resume & Sleep-Stall Supervisor (#3634)
+
+### Root cause
+
+Slice-B/C/D all ended `INCONCLUSIVE` with the same signature: the coordinator
+process died inside the in-process blocking sleep between the durable
+`sleep_started` and `sleep_completed` events. `run_fixture_window` re-initialised
+`completed_cycles = 0` on every launch, so there was no safe resume — a restart
+either re-ran the whole window or double-counted. `ops_validation` detects the
+post-hoc symptom (O264 sleep-lifecycle warn, O303 INCONCLUSIVE) but cannot
+recover it.
+
+### Resume-safe coordinator
+
+`resume-fixture-window` (same arguments as `run-fixture-window`) continues an
+interrupted run from durable state instead of restarting it:
+
+```powershell
+python -m tools.evidence_harvester.coordinator resume-fixture-window ^
+    --fixture artifacts\evidence_harvester\24h_dry_run\collector_input.json ^
+    --artifact-dir artifacts\evidence_harvester\72h_ops_validation\<run_id> ^
+    --iterations 288 ^
+    --cadence-seconds 900
+```
+
+- Seeds `completed_cycles` from `runner_state.total_cycles_completed` (no
+  re-run, no double count).
+- Stall predicate: last durable event is `sleep_started` and
+  `coordinator_status == "sleeping"`. On match it writes a `sleep_resumed`
+  lifecycle event plus an audited `recovery_event_<stamp>.json`
+  (`failure_source="sleep_stall"`, `action="resume_cycle_window"`), then
+  continues to the next cycle — or straight to final validation if all cycles
+  are already complete.
+- Idempotent: resuming a fully-cycled window goes directly to
+  `final_validation_started`/`final_validation_completed` without repeating
+  cycles.
+- Fail-closed guards (raise `CoordinatorError`): missing `runner_state.json`,
+  `run_id` mismatch vs the artifact directory, or terminal status
+  (`completed` / `failed` / `fatal_stop`).
+
+A resumed run that reaches `final_validation_completed` clears both O264 and
+O303: the event stream no longer ends on `sleep_started`, and a final validation
+marker exists.
+
+### Sleep-stall supervisor
+
+`supervisor.py` is a testable decision + bounded-relaunch layer. It does not
+spawn processes, install an OS scheduler, or touch Docker/DB/Redis/secrets.
+
+`decide_supervision(state, events, now, process_alive, relaunch_count,
+max_relaunch_count)` returns exactly one action:
+
+| Action | Condition |
+|---|---|
+| `DONE` | `coordinator_status == "completed"` or a `final_validation_completed` event is present |
+| `STOP_FATAL` | terminal status `failed` / `fatal_stop` |
+| `RELAUNCH_RESUME` | stalled sleep (`sleep_started` last, status `sleeping`) past `next_cycle_due_at_utc` with a dead process, within relaunch budget |
+| `STOP_LIMIT` | relaunch condition met but `relaunch_count >= max_relaunch_count` |
+| `WAIT` | process alive, or no relaunch condition met |
+
+Read-only decision preview:
+
+```powershell
+python -m tools.evidence_harvester.supervisor status ^
+    --artifact-dir artifacts\evidence_harvester\72h_ops_validation\<run_id> ^
+    --pretty
+```
+
+`supervise` runs the poll/relaunch loop in-process and is fail-closed behind
+`--explicit` (without it, only the plan is printed). The loop is fully injectable
+(`launcher`, `process_alive_fn`, `now_fn`, `sleep_fn`) and bounded by
+`--max-relaunch-count` and optional `--max-polls`. Real external supervision
+(subprocess spawn / scheduled wake probe) remains a Slice-E operational wrapper
+that requires its own Runtime-GO.
+
 ## Safety Boundaries
 
 - No Docker start/stop, runtime start, DB execution/mutation, secrets access
 - No LR-Go, no Live-Go, no Echtgeld-Go
+- `resume-fixture-window` reads durable state only; it never rewinds completed cycles
+- `supervisor supervise` requires `--explicit`; `supervisor status` is read-only
 - `loop-fixture` is always bounded (`--iterations N` required)
 - Failure in one loop iteration raises immediately (fail-closed)
 - Signal handling: SIGTERM/SIGINT cleanly stop the loop at the next iteration boundary
@@ -482,6 +559,8 @@ Do not populate until the replacement run has completed.
 
 - `tools/evidence_harvester/README.md` — module-level documentation
 - `tools/evidence_harvester/runner.py` — source
+- `tools/evidence_harvester/coordinator.py` — coordinator + resume source (#3634)
+- `tools/evidence_harvester/supervisor.py` — sleep-stall supervisor source (#3634)
 - `tools/evidence_harvester/boot.py` — boot readiness source
 - `docs/runbooks/CDB_EVIDENCE_HARVESTER_24H_DRY_VALIDATION.md` — 24h dry validation runbook
 - `docs/runbooks/CDB_EVIDENCE_HARVESTER_72H_OPS_VALIDATION.md` — final >=72h validation runbook

--- a/knowledge/logs/sessions/2026-07-01-issue-3634-sleep-stall-fix.md
+++ b/knowledge/logs/sessions/2026-07-01-issue-3634-sleep-stall-fix.md
@@ -1,0 +1,83 @@
+# Session Log: 2026-07-01 — Issue #3634 Coordinator Sleep-Stall Fix
+
+## Scope
+
+Root-cause and harden the 72h Evidence Harvester so a run no longer ends after
+`sleep_started` without `sleep_completed` (Slice-B/C/D INCONCLUSIVE pattern).
+Deliver a resume-safe coordinator + testable supervisor, unit/regression tests,
+docs. No new 72h run; no runtime mutation beyond local/test.
+
+## Brain Evidence
+
+```text
+brain_source: repo-only
+brain_status: not-used
+tools_or_queries:
+  - Read tools/evidence_harvester/coordinator.py (run_fixture_window, _sleep_with_interval_check)
+  - Read tools/evidence_harvester/ops_validation.py (_check_inconclusive_run, _check_sleep_lifecycle_completeness)
+  - pytest tests/unit/tools/evidence_harvester/
+records_or_results:
+  - root cause: completed_cycles=0 re-init per launch; blocking sleep between durable sleep_started/sleep_completed
+  - tests: 29 targeted PASS; 260 harvester-suite PASS; ruff clean
+repo_crosscheck:
+  - tools/evidence_harvester/coordinator.py (resume path, _prepare_resume, _last_event_is_stalled_sleep)
+  - tools/evidence_harvester/supervisor.py (decide_supervision, supervise_loop)
+impact_on_plan:
+  - resume clears O264/O303 without a real 288-cycle run
+limitations:
+  - no >=72h PASS produced; #3362 remains OPEN; external subprocess supervision deferred to Slice-E (Runtime-GO)
+```
+
+## Root cause (code-backed)
+
+`run_fixture_window` re-initialised `completed_cycles = 0` on every launch and
+looped `while completed_cycles < iterations`. The durable events `sleep_started`
+and `sleep_completed` bracket a single in-process blocking
+`_sleep_with_interval_check`. A process death inside that sleep left no
+`sleep_completed`, no `final_validation_*`, and no resume path → O264 warn +
+O303 INCONCLUSIVE.
+
+## Delivered
+
+- **Coordinator resume** (`tools/evidence_harvester/coordinator.py`): new
+  `resume-fixture-window` subcommand + `resume=True`; `_prepare_resume`
+  (fail-closed on missing state / `run_id` mismatch / terminal status);
+  `_last_event_is_stalled_sleep`; `sleep_resumed` lifecycle event + audited
+  `recovery_event` (`failure_source="sleep_stall"`, `action="resume_cycle_window"`);
+  `completed_cycles` seeded from `runner_state.total_cycles_completed`.
+- **Supervisor** (`tools/evidence_harvester/supervisor.py`, new): pure
+  `decide_supervision` (`WAIT|RELAUNCH_RESUME|DONE|STOP_FATAL|STOP_LIMIT`) +
+  injectable bounded `supervise_loop`; read-only `status` CLI; `supervise` CLI
+  fail-closed behind `--explicit`. No process spawn, scheduler, or Docker.
+- **Tests**: `test_coordinator.py` (resume seeding/no double-count, interrupted
+  sleep → `final_validation_completed`, resume-of-completed → final only,
+  fail-closed x3, interrupt propagation, O264/O303 validator consistency);
+  `test_supervisor.py` (decision matrix, relaunch→DONE, STOP_LIMIT,
+  WAIT_TIMEOUT, arg parsing).
+- **Docs**: runbook `CDB_EVIDENCE_HARVESTER_OPS.md` (resume + supervisor
+  section, schema `resuming`, related docs); evidence doc `#3634` section +
+  Slice-E plan; `CURRENT_STATUS.md` entry.
+
+## Validation
+
+```powershell
+python -m pytest tests/unit/tools/evidence_harvester/test_coordinator.py tests/unit/tools/evidence_harvester/test_supervisor.py -q
+# 29 passed
+
+python -m pytest tests/unit/tools/evidence_harvester/ -q
+# 260 passed
+
+ruff check tools/evidence_harvester/coordinator.py tools/evidence_harvester/supervisor.py `
+  tests/unit/tools/evidence_harvester/test_coordinator.py tests/unit/tools/evidence_harvester/test_supervisor.py
+# All checks passed!
+```
+
+## Boundaries
+
+LR NO-GO. No Live/Echtgeld-Go. No Docker/DB/Redis/secrets. No new 72h run; no
+72h-PASS claim. #3362 and #3345 remain OPEN.
+
+## Status
+
+`DONE` (engineering) — resume + supervisor + tests + docs delivered; PR/merge and
+#3634 close tracked in the delivery step.

--- a/tests/unit/tools/evidence_harvester/test_coordinator.py
+++ b/tests/unit/tools/evidence_harvester/test_coordinator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -11,6 +11,8 @@ from tools.evidence_harvester.coordinator import (
     RECOVERY_EVENT_SCHEMA,
     CoordinatorError,
     _now_utc,
+    _remaining_sleep_seconds,
+    _seed_restart_count,
     _sleep_with_interval_check,
     run_fixture_window,
 )
@@ -807,3 +809,222 @@ def test_resumed_run_clears_sleep_and_inconclusive_validators(
     _check_inconclusive_run(state_payload, events, 1.0, 72, _add_finding)
 
     assert findings == []
+
+
+def _iso_z(delta_seconds: int) -> str:
+    stamp = _now_utc() + timedelta(seconds=delta_seconds)
+    return stamp.isoformat().replace("+00:00", "Z")
+
+
+def _craft_stalled_run(
+    artifact_dir: Path,
+    *,
+    run_id: str,
+    completed: int,
+    next_due: str,
+    restart_events: int = 0,
+) -> None:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(
+        artifact_dir / "runner_state.json",
+        {
+            "schema_version": "cdb.evidence_harvester.runner_state.v1",
+            "run_id": run_id,
+            "total_runs": completed,
+            "successful_runs": completed,
+            "failed_runs": 0,
+            "last_cycle_verdict": "PASS",
+            "last_cycle_ended_at_utc": "2026-06-19T00:00:00Z",
+            "total_cycles_started": completed,
+            "total_cycles_completed": completed,
+            "total_successful_cycles": completed,
+            "total_failed_cycles": 0,
+            "last_cycle_started_at_utc": "2026-06-19T00:00:00Z",
+            "next_cycle_due_at_utc": next_due,
+            "last_successful_artifact_stamp": "20260619T000000Z",
+            "coordinator_status": "sleeping",
+        },
+    )
+    events = [
+        {
+            "schema_version": COORDINATOR_EVENT_SCHEMA,
+            "event_at_utc": "2026-06-19T00:00:00Z",
+            "run_id": run_id,
+            "event_type": "cycle_completed",
+        },
+        {
+            "schema_version": COORDINATOR_EVENT_SCHEMA,
+            "event_at_utc": "2026-06-19T00:00:01Z",
+            "run_id": run_id,
+            "event_type": "sleep_started",
+        },
+    ]
+    (artifact_dir / "coordinator_events.jsonl").write_text(
+        "\n".join(json.dumps(event) for event in events) + "\n", encoding="utf-8"
+    )
+    for index in range(restart_events):
+        _write_json(
+            artifact_dir / f"recovery_event_2026061900000{index}Z.json",
+            {
+                "schema_version": RECOVERY_EVENT_SCHEMA,
+                "action": "restart_cycle",
+                "restart_count": index + 1,
+            },
+        )
+
+
+@pytest.mark.unit
+def test_seed_restart_count_counts_only_restart_cycle(tmp_path: Path) -> None:
+    _write_json(tmp_path / "recovery_event_1.json", {"action": "restart_cycle"})
+    _write_json(tmp_path / "recovery_event_2.json", {"action": "restart_cycle"})
+    _write_json(
+        tmp_path / "recovery_event_3.json", {"action": "resume_cycle_window"}
+    )
+    _write_json(tmp_path / "recovery_event_4.json", {"action": "stop"})
+    assert _seed_restart_count(tmp_path) == 2
+
+
+@pytest.mark.unit
+def test_remaining_sleep_seconds_bounds() -> None:
+    assert _remaining_sleep_seconds("") == 0
+    assert _remaining_sleep_seconds(_iso_z(-100)) == 0
+    assert 90 <= _remaining_sleep_seconds(_iso_z(100)) <= 100
+
+
+@pytest.mark.unit
+def test_resume_preserves_restart_budget(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run-budget"
+    _craft_stalled_run(
+        artifact_dir,
+        run_id="run-budget",
+        completed=2,
+        next_due=_iso_z(-10),
+        restart_events=2,
+    )
+    fixture = tmp_path / "collector_input.json"
+    fixture.write_text("{}", encoding="utf-8")
+
+    def guard_cycle_runner(
+        repo_root: Path, fixture_path: Path, out_dir: Path
+    ) -> tuple[int, str]:
+        raise AssertionError("no new cycles expected on a completed resume")
+
+    run_fixture_window(
+        repo_root=tmp_path,
+        fixture_path=fixture,
+        artifact_dir=artifact_dir,
+        iterations=2,
+        cadence_seconds=1,
+        max_restart_count=3,
+        restart_backoff_seconds=0,
+        resume=True,
+        sleep_fn=lambda seconds: None,
+        boot_runner=_pass_boot_runner,
+        cycle_runner=guard_cycle_runner,
+        watchdog_runner=_pass_watchdog_runner,
+        write_audit_runner=_pass_write_audit_runner,
+        final_validator=_noop_final_validator,
+    )
+
+    sleep_stall = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in artifact_dir.glob("recovery_event_*.json")
+    ]
+    sleep_stall = [e for e in sleep_stall if e.get("failure_source") == "sleep_stall"]
+    assert sleep_stall
+    assert sleep_stall[0]["restart_count"] == 2
+
+
+@pytest.mark.unit
+def test_resume_honors_remaining_sleep_window(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run-future"
+    _craft_stalled_run(
+        artifact_dir,
+        run_id="run-future",
+        completed=2,
+        next_due=_iso_z(600),
+    )
+    fixture = tmp_path / "collector_input.json"
+    fixture.write_text("{}", encoding="utf-8")
+    sleeps: list[float] = []
+
+    def guard_cycle_runner(
+        repo_root: Path, fixture_path: Path, out_dir: Path
+    ) -> tuple[int, str]:
+        raise AssertionError("no new cycles expected on a completed resume")
+
+    run_fixture_window(
+        repo_root=tmp_path,
+        fixture_path=fixture,
+        artifact_dir=artifact_dir,
+        iterations=2,
+        cadence_seconds=1,
+        max_restart_count=3,
+        restart_backoff_seconds=0,
+        resume=True,
+        sleep_fn=lambda seconds: sleeps.append(seconds),
+        boot_runner=_pass_boot_runner,
+        cycle_runner=guard_cycle_runner,
+        watchdog_runner=_pass_watchdog_runner,
+        write_audit_runner=_pass_write_audit_runner,
+        final_validator=_noop_final_validator,
+    )
+
+    # The remaining ~600s sleep window is honored, not skipped.
+    assert sum(sleeps) >= 300
+
+    events = [
+        json.loads(line)
+        for line in (artifact_dir / "coordinator_events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    types = [event["event_type"] for event in events]
+    assert "sleep_resumed" in types
+    assert "sleep_completed" in types
+    assert types[-1] == "final_validation_completed"
+
+
+@pytest.mark.unit
+def test_resume_overdue_sleep_does_not_wait(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run-overdue"
+    _craft_stalled_run(
+        artifact_dir,
+        run_id="run-overdue",
+        completed=2,
+        next_due=_iso_z(-600),
+    )
+    fixture = tmp_path / "collector_input.json"
+    fixture.write_text("{}", encoding="utf-8")
+    sleeps: list[float] = []
+
+    def guard_cycle_runner(
+        repo_root: Path, fixture_path: Path, out_dir: Path
+    ) -> tuple[int, str]:
+        raise AssertionError("no new cycles expected on a completed resume")
+
+    run_fixture_window(
+        repo_root=tmp_path,
+        fixture_path=fixture,
+        artifact_dir=artifact_dir,
+        iterations=2,
+        cadence_seconds=1,
+        max_restart_count=3,
+        restart_backoff_seconds=0,
+        resume=True,
+        sleep_fn=lambda seconds: sleeps.append(seconds),
+        boot_runner=_pass_boot_runner,
+        cycle_runner=guard_cycle_runner,
+        watchdog_runner=_pass_watchdog_runner,
+        write_audit_runner=_pass_write_audit_runner,
+        final_validator=_noop_final_validator,
+    )
+
+    assert sum(sleeps) == 0
+    events = [
+        json.loads(line)
+        for line in (artifact_dir / "coordinator_events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert "sleep_completed" in [event["event_type"] for event in events]

--- a/tests/unit/tools/evidence_harvester/test_coordinator.py
+++ b/tests/unit/tools/evidence_harvester/test_coordinator.py
@@ -9,9 +9,14 @@ import pytest
 from tools.evidence_harvester.coordinator import (
     COORDINATOR_EVENT_SCHEMA,
     RECOVERY_EVENT_SCHEMA,
+    CoordinatorError,
     _now_utc,
     _sleep_with_interval_check,
     run_fixture_window,
+)
+from tools.evidence_harvester.ops_validation import (
+    _check_inconclusive_run,
+    _check_sleep_lifecycle_completeness,
 )
 
 
@@ -64,6 +69,43 @@ def _pass_boot_runner(repo_root: Path, artifact_dir: Path) -> tuple[int, dict]:
 
 def _noop_final_validator(repo_root: Path, artifact_dir: Path) -> tuple[int, dict]:
     return 0, {"summary": {"verdict": "PASS"}}
+
+
+def _pass_watchdog_runner(
+    repo_root: Path,
+    out_dir: Path,
+    cycle_stamp: str,
+    cadence_seconds: int,
+) -> tuple[int, dict]:
+    payload = {
+        "report_name": f"watchdog_report_{cycle_stamp}.json",
+        "verdict": {"verdict": "PASS"},
+        "findings": [],
+    }
+    _write_json(out_dir / payload["report_name"], payload)
+    _write_json(out_dir / "watchdog_report.json", payload)
+    (out_dir / f"watchdog_report_{cycle_stamp}.md").write_text(
+        "# Watchdog\n", encoding="utf-8"
+    )
+    (out_dir / "watchdog_report.md").write_text("# Watchdog\n", encoding="utf-8")
+    return 0, payload
+
+
+def _pass_write_audit_runner(
+    repo_root: Path,
+    out_dir: Path,
+    cycle_stamp: str,
+) -> tuple[int, dict]:
+    payload = {
+        "report_name": f"write_audit_report_{cycle_stamp}.json",
+        "verdict": {"verdict": "PASS"},
+        "findings": [],
+    }
+    _write_json(out_dir / payload["report_name"], payload)
+    (out_dir / f"write_audit_report_{cycle_stamp}.md").write_text(
+        "# Write Audit\n", encoding="utf-8"
+    )
+    return 0, payload
 
 
 @pytest.mark.unit
@@ -416,3 +458,352 @@ def test_now_utc_preserves_aware_datetime(
 
     assert result.tzinfo is not None
     assert result == aware_utc
+
+
+def _counting_cycle_runner(counter: dict) -> object:
+    def _runner(repo_root: Path, fixture_path: Path, out_dir: Path) -> tuple[int, str]:
+        stamp = f"20260619T0000{counter['n']:02d}Z"
+        counter["n"] += 1
+        _write_cycle_artifacts(out_dir, stamp)
+        return 0, stamp
+
+    return _runner
+
+
+class _SimulatedCrash(RuntimeError):
+    pass
+
+
+@pytest.mark.unit
+def test_resume_after_interrupted_sleep_reaches_final_validation(
+    tmp_path: Path,
+) -> None:
+    fixture = tmp_path / "collector_input.json"
+    fixture.write_text("{}", encoding="utf-8")
+    artifact_dir = tmp_path / "slice-e-resume"
+    counter = {"n": 0}
+    cycle_runner = _counting_cycle_runner(counter)
+
+    def crashing_sleep(seconds: float) -> None:
+        raise _SimulatedCrash("process died during sleep window")
+
+    with pytest.raises(_SimulatedCrash):
+        run_fixture_window(
+            repo_root=tmp_path,
+            fixture_path=fixture,
+            artifact_dir=artifact_dir,
+            iterations=3,
+            cadence_seconds=1,
+            max_restart_count=3,
+            restart_backoff_seconds=0,
+            sleep_fn=crashing_sleep,
+            boot_runner=_pass_boot_runner,
+            cycle_runner=cycle_runner,
+            watchdog_runner=_pass_watchdog_runner,
+            write_audit_runner=_pass_write_audit_runner,
+            final_validator=_noop_final_validator,
+        )
+
+    stalled = json.loads(
+        (artifact_dir / "runner_state.json").read_text(encoding="utf-8")
+    )
+    assert stalled["coordinator_status"] == "sleeping"
+    assert stalled["total_cycles_completed"] == 1
+    events_before = [
+        json.loads(line)
+        for line in (artifact_dir / "coordinator_events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert events_before[-1]["event_type"] == "sleep_started"
+
+    summary = run_fixture_window(
+        repo_root=tmp_path,
+        fixture_path=fixture,
+        artifact_dir=artifact_dir,
+        iterations=3,
+        cadence_seconds=1,
+        max_restart_count=3,
+        restart_backoff_seconds=0,
+        resume=True,
+        sleep_fn=lambda seconds: None,
+        boot_runner=_pass_boot_runner,
+        cycle_runner=cycle_runner,
+        watchdog_runner=_pass_watchdog_runner,
+        write_audit_runner=_pass_write_audit_runner,
+        final_validator=_noop_final_validator,
+    )
+
+    assert summary.status == "PASS"
+    assert summary.completed_cycles == 3
+
+    final_state = json.loads(
+        (artifact_dir / "runner_state.json").read_text(encoding="utf-8")
+    )
+    assert final_state["total_cycles_completed"] == 3
+    assert final_state["coordinator_status"] == "completed"
+
+    events = [
+        json.loads(line)
+        for line in (artifact_dir / "coordinator_events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    types = [event["event_type"] for event in events]
+    assert "run_resumed" in types
+    assert "sleep_resumed" in types
+    assert types[-1] == "final_validation_completed"
+    # No double counting: exactly three cycle_completed events for a 3-cycle run.
+    assert types.count("cycle_completed") == 3
+
+    recoveries = sorted(artifact_dir.glob("recovery_event_*.json"))
+    sleep_stall = [
+        json.loads(path.read_text(encoding="utf-8")) for path in recoveries
+    ]
+    assert any(
+        event["failure_source"] == "sleep_stall"
+        and event["action"] == "resume_cycle_window"
+        for event in sleep_stall
+    )
+
+
+@pytest.mark.unit
+def test_resume_of_completed_cycles_reruns_only_final_validation(
+    tmp_path: Path,
+) -> None:
+    fixture = tmp_path / "collector_input.json"
+    fixture.write_text("{}", encoding="utf-8")
+    artifact_dir = tmp_path / "resume-final"
+    counter = {"n": 0}
+
+    def crashing_final(repo_root: Path, out_dir: Path) -> tuple[int, dict]:
+        raise _SimulatedCrash("process died during final validation")
+
+    with pytest.raises(_SimulatedCrash):
+        run_fixture_window(
+            repo_root=tmp_path,
+            fixture_path=fixture,
+            artifact_dir=artifact_dir,
+            iterations=2,
+            cadence_seconds=1,
+            max_restart_count=3,
+            restart_backoff_seconds=0,
+            sleep_fn=lambda seconds: None,
+            boot_runner=_pass_boot_runner,
+            cycle_runner=_counting_cycle_runner(counter),
+            watchdog_runner=_pass_watchdog_runner,
+            write_audit_runner=_pass_write_audit_runner,
+            final_validator=crashing_final,
+        )
+
+    stalled = json.loads(
+        (artifact_dir / "runner_state.json").read_text(encoding="utf-8")
+    )
+    assert stalled["total_cycles_completed"] == 2
+    assert stalled["coordinator_status"] == "final_validation"
+
+    resume_cycles = {"n": 0}
+
+    def guard_cycle_runner(
+        repo_root: Path, fixture_path: Path, out_dir: Path
+    ) -> tuple[int, str]:
+        resume_cycles["n"] += 1
+        return 0, "unexpected"
+
+    summary = run_fixture_window(
+        repo_root=tmp_path,
+        fixture_path=fixture,
+        artifact_dir=artifact_dir,
+        iterations=2,
+        cadence_seconds=1,
+        max_restart_count=3,
+        restart_backoff_seconds=0,
+        resume=True,
+        sleep_fn=lambda seconds: None,
+        boot_runner=_pass_boot_runner,
+        cycle_runner=guard_cycle_runner,
+        watchdog_runner=_pass_watchdog_runner,
+        write_audit_runner=_pass_write_audit_runner,
+        final_validator=_noop_final_validator,
+    )
+
+    assert resume_cycles["n"] == 0
+    assert summary.status == "PASS"
+    assert summary.completed_cycles == 2
+
+    events = [
+        json.loads(line)
+        for line in (artifact_dir / "coordinator_events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert events[-1]["event_type"] == "final_validation_completed"
+
+
+@pytest.mark.unit
+def test_resume_fails_without_prior_state(tmp_path: Path) -> None:
+    fixture = tmp_path / "collector_input.json"
+    fixture.write_text("{}", encoding="utf-8")
+    with pytest.raises(CoordinatorError, match="runner_state"):
+        run_fixture_window(
+            repo_root=tmp_path,
+            fixture_path=fixture,
+            artifact_dir=tmp_path / "empty-run",
+            iterations=2,
+            resume=True,
+            boot_runner=_pass_boot_runner,
+        )
+
+
+@pytest.mark.unit
+def test_resume_fails_on_run_id_mismatch(tmp_path: Path) -> None:
+    fixture = tmp_path / "collector_input.json"
+    fixture.write_text("{}", encoding="utf-8")
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    _write_json(
+        artifact_dir / "runner_state.json",
+        {
+            "schema_version": "cdb.evidence_harvester.runner_state.v1",
+            "run_id": "some-other-run",
+            "coordinator_status": "sleeping",
+            "total_cycles_completed": 1,
+        },
+    )
+    with pytest.raises(CoordinatorError, match="run_id mismatch"):
+        run_fixture_window(
+            repo_root=tmp_path,
+            fixture_path=fixture,
+            artifact_dir=artifact_dir,
+            iterations=2,
+            resume=True,
+            boot_runner=_pass_boot_runner,
+        )
+
+
+@pytest.mark.unit
+def test_resume_refused_for_terminal_status(tmp_path: Path) -> None:
+    fixture = tmp_path / "collector_input.json"
+    fixture.write_text("{}", encoding="utf-8")
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    _write_json(
+        artifact_dir / "runner_state.json",
+        {
+            "schema_version": "cdb.evidence_harvester.runner_state.v1",
+            "run_id": "run",
+            "coordinator_status": "completed",
+            "total_cycles_completed": 2,
+        },
+    )
+    with pytest.raises(CoordinatorError, match="terminal"):
+        run_fixture_window(
+            repo_root=tmp_path,
+            fixture_path=fixture,
+            artifact_dir=artifact_dir,
+            iterations=2,
+            resume=True,
+            boot_runner=_pass_boot_runner,
+        )
+
+
+@pytest.mark.unit
+def test_sleep_with_interval_check_propagates_interrupt() -> None:
+    def interrupted_sleep(seconds: float) -> None:
+        raise KeyboardInterrupt()
+
+    with pytest.raises(KeyboardInterrupt):
+        _sleep_with_interval_check(
+            interrupted_sleep, total_seconds=120, chunk_seconds=60
+        )
+
+
+@pytest.mark.unit
+def test_resumed_run_clears_sleep_and_inconclusive_validators(
+    tmp_path: Path,
+) -> None:
+    fixture = tmp_path / "collector_input.json"
+    fixture.write_text("{}", encoding="utf-8")
+    artifact_dir = tmp_path / "validator-consistency"
+    counter = {"n": 0}
+    cycle_runner = _counting_cycle_runner(counter)
+
+    def crashing_sleep(seconds: float) -> None:
+        raise _SimulatedCrash("process died during sleep window")
+
+    with pytest.raises(_SimulatedCrash):
+        run_fixture_window(
+            repo_root=tmp_path,
+            fixture_path=fixture,
+            artifact_dir=artifact_dir,
+            iterations=2,
+            cadence_seconds=1,
+            max_restart_count=3,
+            restart_backoff_seconds=0,
+            sleep_fn=crashing_sleep,
+            boot_runner=_pass_boot_runner,
+            cycle_runner=cycle_runner,
+            watchdog_runner=_pass_watchdog_runner,
+            write_audit_runner=_pass_write_audit_runner,
+            final_validator=_noop_final_validator,
+        )
+
+    # Before resume: the stalled stream would trip both validators.
+    stalled_events = [
+        json.loads(line)
+        for line in (artifact_dir / "coordinator_events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    stalled_state = json.loads(
+        (artifact_dir / "runner_state.json").read_text(encoding="utf-8")
+    )
+    pre_findings: list[tuple[str, str]] = []
+
+    def _pre_add(name: str, severity: str, message: str, **kwargs: object) -> None:
+        pre_findings.append((name, severity))
+
+    _check_sleep_lifecycle_completeness(
+        stalled_events, stalled_state, _pre_add, is_final=True
+    )
+    _check_inconclusive_run(stalled_state, stalled_events, 1.0, 72, _pre_add)
+    assert pre_findings, "stalled run must trip O264/O303 before resume"
+
+    run_fixture_window(
+        repo_root=tmp_path,
+        fixture_path=fixture,
+        artifact_dir=artifact_dir,
+        iterations=2,
+        cadence_seconds=1,
+        max_restart_count=3,
+        restart_backoff_seconds=0,
+        resume=True,
+        sleep_fn=lambda seconds: None,
+        boot_runner=_pass_boot_runner,
+        cycle_runner=cycle_runner,
+        watchdog_runner=_pass_watchdog_runner,
+        write_audit_runner=_pass_write_audit_runner,
+        final_validator=_noop_final_validator,
+    )
+
+    events = [
+        json.loads(line)
+        for line in (artifact_dir / "coordinator_events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    state_payload = json.loads(
+        (artifact_dir / "runner_state.json").read_text(encoding="utf-8")
+    )
+
+    findings: list[tuple[str, str]] = []
+
+    def _add_finding(name: str, severity: str, message: str, **kwargs: object) -> None:
+        findings.append((name, severity))
+
+    _check_sleep_lifecycle_completeness(
+        events, state_payload, _add_finding, is_final=True
+    )
+    _check_inconclusive_run(state_payload, events, 1.0, 72, _add_finding)
+
+    assert findings == []

--- a/tests/unit/tools/evidence_harvester/test_supervisor.py
+++ b/tests/unit/tools/evidence_harvester/test_supervisor.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from tools.evidence_harvester.coordinator import CoordinatorSummary
+from tools.evidence_harvester.runner import RunnerState
+from tools.evidence_harvester.supervisor import (
+    ACTION_DONE,
+    ACTION_RELAUNCH_RESUME,
+    ACTION_STOP_FATAL,
+    ACTION_STOP_LIMIT,
+    ACTION_WAIT,
+    SupervisorError,
+    decide_supervision,
+    parse_args,
+    supervise_loop,
+)
+
+NOW = datetime(2026, 6, 30, 12, 0, 0, tzinfo=UTC)
+PAST = "2026-06-30T11:00:00Z"
+FUTURE = "2026-06-30T13:00:00Z"
+
+
+def _state(**changes: object) -> RunnerState:
+    return RunnerState(run_id="run", **changes)
+
+
+def _events(*types: str) -> list[dict[str, str]]:
+    return [
+        {
+            "schema_version": "cdb.evidence_harvester.coordinator_event.v1",
+            "event_at_utc": f"2026-06-30T10:00:0{index}Z",
+            "run_id": "run",
+            "event_type": event_type,
+        }
+        for index, event_type in enumerate(types)
+    ]
+
+
+def _dummy_summary(artifact_dir: Path) -> CoordinatorSummary:
+    return CoordinatorSummary(
+        status="FAIL",
+        artifact_dir=str(artifact_dir),
+        completed_cycles=1,
+        recovery_events_written=1,
+        restart_count=0,
+        max_restart_count=3,
+        final_validation_started=False,
+        stop_reason="",
+    )
+
+
+def _write_state(artifact_dir: Path, **changes: object) -> None:
+    payload = {
+        "schema_version": "cdb.evidence_harvester.runner_state.v1",
+        "run_id": "run",
+        "total_cycles_completed": 1,
+    }
+    payload.update(changes)
+    (artifact_dir / "runner_state.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def _write_events(artifact_dir: Path, *types: str) -> None:
+    lines = [json.dumps(event) for event in _events(*types)]
+    (artifact_dir / "coordinator_events.jsonl").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
+
+
+# --- decide_supervision matrix -------------------------------------------------
+
+
+@pytest.mark.unit
+def test_decision_done_via_status() -> None:
+    decision = decide_supervision(
+        _state(coordinator_status="completed"), [], NOW, False, 0, 5
+    )
+    assert decision.action == ACTION_DONE
+
+
+@pytest.mark.unit
+def test_decision_done_via_final_validation_event() -> None:
+    decision = decide_supervision(
+        _state(coordinator_status="final_validation"),
+        _events("cycle_completed", "final_validation_completed"),
+        NOW,
+        False,
+        0,
+        5,
+    )
+    assert decision.action == ACTION_DONE
+
+
+@pytest.mark.unit
+def test_decision_stop_fatal_on_terminal_status() -> None:
+    decision = decide_supervision(
+        _state(coordinator_status="fatal_stop"), [], NOW, False, 0, 5
+    )
+    assert decision.action == ACTION_STOP_FATAL
+
+
+@pytest.mark.unit
+def test_decision_relaunch_resume_on_stalled_sleep() -> None:
+    decision = decide_supervision(
+        _state(coordinator_status="sleeping", next_cycle_due_at_utc=PAST),
+        _events("cycle_completed", "sleep_started"),
+        NOW,
+        False,
+        0,
+        5,
+    )
+    assert decision.action == ACTION_RELAUNCH_RESUME
+    assert decision.overdue is True
+
+
+@pytest.mark.unit
+def test_decision_stop_limit_when_budget_exhausted() -> None:
+    decision = decide_supervision(
+        _state(coordinator_status="sleeping", next_cycle_due_at_utc=PAST),
+        _events("cycle_completed", "sleep_started"),
+        NOW,
+        False,
+        5,
+        5,
+    )
+    assert decision.action == ACTION_STOP_LIMIT
+
+
+@pytest.mark.unit
+def test_decision_wait_when_process_alive() -> None:
+    decision = decide_supervision(
+        _state(coordinator_status="sleeping", next_cycle_due_at_utc=PAST),
+        _events("cycle_completed", "sleep_started"),
+        NOW,
+        True,
+        0,
+        5,
+    )
+    assert decision.action == ACTION_WAIT
+    assert decision.reason == "coordinator process alive"
+
+
+@pytest.mark.unit
+def test_decision_wait_when_future_due_and_alive() -> None:
+    decision = decide_supervision(
+        _state(coordinator_status="sleeping", next_cycle_due_at_utc=FUTURE),
+        _events("cycle_completed", "sleep_started"),
+        NOW,
+        True,
+        0,
+        5,
+    )
+    assert decision.action == ACTION_WAIT
+    assert decision.overdue is False
+
+
+@pytest.mark.unit
+def test_decision_wait_when_dead_but_not_stalled_sleep() -> None:
+    decision = decide_supervision(
+        _state(coordinator_status="running"),
+        _events("cycle_started"),
+        NOW,
+        False,
+        0,
+        5,
+    )
+    assert decision.action == ACTION_WAIT
+    assert decision.reason == "no relaunch condition met"
+
+
+# --- supervise_loop ------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_supervise_loop_relaunches_then_done(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    _write_state(
+        artifact_dir, coordinator_status="sleeping", next_cycle_due_at_utc=PAST
+    )
+    _write_events(artifact_dir, "cycle_completed", "sleep_started")
+
+    launches: list[int] = []
+
+    def launcher() -> CoordinatorSummary:
+        launches.append(1)
+        _write_state(artifact_dir, coordinator_status="completed")
+        _write_events(
+            artifact_dir,
+            "cycle_completed",
+            "sleep_resumed",
+            "final_validation_completed",
+        )
+        return _dummy_summary(artifact_dir)
+
+    result = supervise_loop(
+        artifact_dir=artifact_dir,
+        launcher=launcher,
+        process_alive_fn=lambda: False,
+        now_fn=lambda: NOW,
+        sleep_fn=lambda seconds: None,
+        poll_seconds=0,
+        max_relaunch_count=5,
+        max_polls=10,
+    )
+
+    assert result.status == "DONE"
+    assert result.relaunch_count == 1
+    assert len(launches) == 1
+
+
+@pytest.mark.unit
+def test_supervise_loop_stops_at_relaunch_limit(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    _write_state(
+        artifact_dir, coordinator_status="sleeping", next_cycle_due_at_utc=PAST
+    )
+    _write_events(artifact_dir, "cycle_completed", "sleep_started")
+
+    launches: list[int] = []
+
+    def launcher() -> CoordinatorSummary:
+        launches.append(1)
+        # Launcher fails to clear the stall -> loop keeps seeing a stalled sleep.
+        return _dummy_summary(artifact_dir)
+
+    result = supervise_loop(
+        artifact_dir=artifact_dir,
+        launcher=launcher,
+        process_alive_fn=lambda: False,
+        now_fn=lambda: NOW,
+        sleep_fn=lambda seconds: None,
+        poll_seconds=0,
+        max_relaunch_count=2,
+        max_polls=50,
+    )
+
+    assert result.status == "STOP_LIMIT"
+    assert result.relaunch_count == 2
+    assert len(launches) == 2
+
+
+@pytest.mark.unit
+def test_supervise_loop_wait_timeout(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    _write_state(
+        artifact_dir, coordinator_status="sleeping", next_cycle_due_at_utc=FUTURE
+    )
+    _write_events(artifact_dir, "cycle_completed", "sleep_started")
+
+    sleeps: list[float] = []
+
+    def launcher() -> CoordinatorSummary:  # pragma: no cover - must not run
+        raise AssertionError("launcher must not run while waiting")
+
+    result = supervise_loop(
+        artifact_dir=artifact_dir,
+        launcher=launcher,
+        process_alive_fn=lambda: True,
+        now_fn=lambda: NOW,
+        sleep_fn=lambda seconds: sleeps.append(seconds),
+        poll_seconds=30,
+        max_relaunch_count=5,
+        max_polls=3,
+    )
+
+    assert result.status == "WAIT_TIMEOUT"
+    assert result.polls == 3
+    assert result.relaunch_count == 0
+    assert sleeps == [30, 30]
+
+
+@pytest.mark.unit
+def test_supervise_loop_rejects_negative_relaunch(tmp_path: Path) -> None:
+    with pytest.raises(SupervisorError):
+        supervise_loop(
+            artifact_dir=tmp_path,
+            launcher=lambda: _dummy_summary(tmp_path),
+            process_alive_fn=lambda: False,
+            max_relaunch_count=-1,
+        )
+
+
+# --- CLI arg parsing -----------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_args_status_defaults() -> None:
+    args = parse_args(["status", "--artifact-dir", "runs/x"])
+    assert args.command == "status"
+    assert args.assume_process_alive is False
+
+
+@pytest.mark.unit
+def test_parse_args_supervise_requires_explicit_flag() -> None:
+    args = parse_args(
+        [
+            "supervise",
+            "--artifact-dir",
+            "runs/x",
+            "--fixture",
+            "f.json",
+            "--iterations",
+            "288",
+        ]
+    )
+    assert args.command == "supervise"
+    assert args.explicit is False
+    assert args.iterations == 288

--- a/tools/evidence_harvester/coordinator.py
+++ b/tools/evidence_harvester/coordinator.py
@@ -6,7 +6,7 @@ import time
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, Sequence
 
 from core.utils.clock import utcnow as cdb_utcnow
 
@@ -18,6 +18,9 @@ RECOVERY_EVENT_SCHEMA = "cdb.evidence_harvester.recovery_event.v1"
 DEFAULT_MAX_RESTART_COUNT = 3
 DEFAULT_RESTART_BACKOFF_SECONDS = 30
 DEFAULT_CADENCE_SECONDS = 900
+
+# Terminal coordinator states that a resume must not silently reopen.
+_RESUME_REFUSED_STATUSES = frozenset({"completed", "failed", "fatal_stop"})
 
 
 class CoordinatorError(ValueError):
@@ -104,6 +107,25 @@ def _coordinator_events_path(artifact_dir: Path) -> Path:
     return artifact_dir / "coordinator_events.jsonl"
 
 
+def _read_coordinator_events(artifact_dir: Path) -> list[dict[str, Any]]:
+    """Read durable coordinator lifecycle events, skipping malformed lines."""
+    path = _coordinator_events_path(artifact_dir)
+    if not path.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            events.append(payload)
+    return events
+
+
 def _derive_run_id(artifact_dir: Path) -> str:
     name = artifact_dir.name.strip()
     return name or _event_stamp()
@@ -176,6 +198,40 @@ def _update_runner_state(
     )
     payload["failed_runs"] = payload.get("total_failed_cycles", payload["failed_runs"])
     return RunnerState(**payload)
+
+
+def _last_event_is_stalled_sleep(
+    events: Sequence[Mapping[str, Any]],
+    coordinator_status: str,
+) -> bool:
+    """Detect the Slice-B/C/D stall: last durable event is sleep_started."""
+    if not events:
+        return False
+    last_type = str(events[-1].get("event_type", "")).strip()
+    if last_type != "sleep_started":
+        return False
+    return coordinator_status == "sleeping"
+
+
+def _prepare_resume(artifact_dir: Path, run_id: str) -> tuple[RunnerState, int]:
+    """Fail-closed resume preflight: require matching, non-terminal prior state."""
+    state = _read_runner_state(artifact_dir)
+    if state is None:
+        raise CoordinatorError(
+            "resume requires an existing runner_state.json in the artifact dir"
+        )
+    if state.run_id and state.run_id != run_id:
+        raise CoordinatorError(
+            f"resume run_id mismatch: runner_state.run_id={state.run_id!r} "
+            f"but artifact dir implies run_id={run_id!r}"
+        )
+    if state.coordinator_status in _RESUME_REFUSED_STATUSES:
+        raise CoordinatorError(
+            "resume refused: coordinator_status is terminal "
+            f"({state.coordinator_status!r})"
+        )
+    completed_cycles = int(state.total_cycles_completed or 0)
+    return state, completed_cycles
 
 
 def _write_coordinator_event(
@@ -556,6 +612,7 @@ def run_fixture_window(
     cadence_seconds: int = DEFAULT_CADENCE_SECONDS,
     max_restart_count: int = DEFAULT_MAX_RESTART_COUNT,
     restart_backoff_seconds: int = DEFAULT_RESTART_BACKOFF_SECONDS,
+    resume: bool = False,
     sleep_fn: Callable[[float], None] = time.sleep,
     boot_runner: Callable[
         [Path, Path], tuple[int, dict[str, Any] | None]
@@ -590,16 +647,64 @@ def run_fixture_window(
     completed_cycles = 0
     final_validation_started = False
     stop_reason = ""
-    state = _seed_runner_state(artifact_dir, run_id)
 
-    _write_coordinator_event(
-        artifact_dir,
-        run_id=run_id,
-        event_type="run_started",
-        coordinator_status="starting",
-    )
-    state = _update_runner_state(state, run_id=run_id, coordinator_status="starting")
-    _write_runner_state(artifact_dir, state)
+    if resume:
+        state, completed_cycles = _prepare_resume(artifact_dir, run_id)
+        prior_events = _read_coordinator_events(artifact_dir)
+        _write_coordinator_event(
+            artifact_dir,
+            run_id=run_id,
+            event_type="run_resumed",
+            coordinator_status="resuming",
+        )
+        if _last_event_is_stalled_sleep(prior_events, state.coordinator_status):
+            resume_cycle_index = int(state.total_cycles_started or 0)
+            resume_stamp = state.last_successful_artifact_stamp or _event_stamp()
+            _write_coordinator_event(
+                artifact_dir,
+                run_id=run_id,
+                event_type="sleep_resumed",
+                cycle_index=resume_cycle_index or None,
+                artifact_stamp=state.last_successful_artifact_stamp,
+                next_cycle_due_at_utc=state.next_cycle_due_at_utc,
+                coordinator_status="resuming",
+            )
+            _write_recovery_event(
+                artifact_dir,
+                cycle_stamp=resume_stamp,
+                failure_source="sleep_stall",
+                trigger_report_name="coordinator_events.jsonl",
+                trigger_verdict="INCONCLUSIVE",
+                classification="recoverable",
+                reason_codes=("sleep_started_without_sleep_completed",),
+                covered_report_names=(),
+                restart_attempted=True,
+                restart_count=0,
+                max_restart_count=max_restart_count,
+                backoff_seconds=0,
+                action="resume_cycle_window",
+                limit_exceeded=False,
+            )
+            recovery_events_written += 1
+        state = _update_runner_state(
+            state,
+            run_id=run_id,
+            coordinator_status="running",
+            next_cycle_due_at_utc="",
+        )
+        _write_runner_state(artifact_dir, state)
+    else:
+        state = _seed_runner_state(artifact_dir, run_id)
+        _write_coordinator_event(
+            artifact_dir,
+            run_id=run_id,
+            event_type="run_started",
+            coordinator_status="starting",
+        )
+        state = _update_runner_state(
+            state, run_id=run_id, coordinator_status="starting"
+        )
+        _write_runner_state(artifact_dir, state)
 
     boot_exit, boot_payload = boot_runner(repo_root, artifact_dir)
     boot_verdict = _extract_verdict(boot_payload) or (
@@ -1080,6 +1185,39 @@ def run_fixture_window(
     )
 
 
+def _add_window_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--fixture", type=Path, required=True, help="Collector-input fixture path."
+    )
+    parser.add_argument(
+        "--artifact-dir", type=Path, required=True, help="Output artifact directory."
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        required=True,
+        help="Number of successful cycles required.",
+    )
+    parser.add_argument(
+        "--cadence-seconds",
+        type=int,
+        default=DEFAULT_CADENCE_SECONDS,
+        help=f"Cycle cadence in seconds (default: {DEFAULT_CADENCE_SECONDS}).",
+    )
+    parser.add_argument(
+        "--max-restart-count",
+        type=int,
+        default=DEFAULT_MAX_RESTART_COUNT,
+        help=f"Maximum recoverable restarts (default: {DEFAULT_MAX_RESTART_COUNT}).",
+    )
+    parser.add_argument(
+        "--restart-backoff-seconds",
+        type=int,
+        default=DEFAULT_RESTART_BACKOFF_SECONDS,
+        help=f"Backoff between recoverable restarts (default: {DEFAULT_RESTART_BACKOFF_SECONDS}).",
+    )
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Evidence harvester 72h coordinator with bounded recovery."
@@ -1093,42 +1231,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "run-fixture-window",
         help="Run fixture-backed harvester cycles with watchdog/write-audit recovery.",
     )
-    run_parser.add_argument(
-        "--fixture", type=Path, required=True, help="Collector-input fixture path."
+    _add_window_args(run_parser)
+
+    resume_parser = subparsers.add_parser(
+        "resume-fixture-window",
+        help=(
+            "Resume an interrupted fixture-backed run from durable state, "
+            "recovering a stalled sleep window (sleep_started without "
+            "sleep_completed)."
+        ),
     )
-    run_parser.add_argument(
-        "--artifact-dir", type=Path, required=True, help="Output artifact directory."
-    )
-    run_parser.add_argument(
-        "--iterations",
-        type=int,
-        required=True,
-        help="Number of successful cycles required.",
-    )
-    run_parser.add_argument(
-        "--cadence-seconds",
-        type=int,
-        default=DEFAULT_CADENCE_SECONDS,
-        help=f"Cycle cadence in seconds (default: {DEFAULT_CADENCE_SECONDS}).",
-    )
-    run_parser.add_argument(
-        "--max-restart-count",
-        type=int,
-        default=DEFAULT_MAX_RESTART_COUNT,
-        help=f"Maximum recoverable restarts (default: {DEFAULT_MAX_RESTART_COUNT}).",
-    )
-    run_parser.add_argument(
-        "--restart-backoff-seconds",
-        type=int,
-        default=DEFAULT_RESTART_BACKOFF_SECONDS,
-        help=f"Backoff between recoverable restarts (default: {DEFAULT_RESTART_BACKOFF_SECONDS}).",
-    )
+    _add_window_args(resume_parser)
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    if args.command != "run-fixture-window":
+    if args.command not in ("run-fixture-window", "resume-fixture-window"):
         raise CoordinatorError(f"Unsupported command: {args.command}")
     summary = run_fixture_window(
         repo_root=_repo_root(),
@@ -1138,6 +1257,7 @@ def main(argv: list[str] | None = None) -> int:
         cadence_seconds=args.cadence_seconds,
         max_restart_count=args.max_restart_count,
         restart_backoff_seconds=args.restart_backoff_seconds,
+        resume=(args.command == "resume-fixture-window"),
     )
     payload = summary.to_dict()
     print(

--- a/tools/evidence_harvester/coordinator.py
+++ b/tools/evidence_harvester/coordinator.py
@@ -234,6 +234,50 @@ def _prepare_resume(artifact_dir: Path, run_id: str) -> tuple[RunnerState, int]:
     return state, completed_cycles
 
 
+def _seed_restart_count(artifact_dir: Path) -> int:
+    """Reconstruct the consumed cycle-restart budget from durable recovery events.
+
+    Only ``action == "restart_cycle"`` events count against ``max_restart_count``;
+    the ``resume_cycle_window`` sleep-stall recovery is a resume marker, not a
+    cycle restart, so it is excluded.
+    """
+    count = 0
+    for path in sorted(artifact_dir.glob("recovery_event_*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict) and payload.get("action") == "restart_cycle":
+            count += 1
+    return count
+
+
+def _parse_utc_ts(value: str) -> datetime | None:
+    text = (value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _remaining_sleep_seconds(next_cycle_due_at_utc: str) -> int:
+    """Seconds still owed on an interrupted sleep window (0 if overdue/unknown)."""
+    due = _parse_utc_ts(next_cycle_due_at_utc)
+    if due is None:
+        return 0
+    remaining = (due - _now_utc()).total_seconds()
+    if remaining <= 0:
+        return 0
+    return int(remaining)
+
+
 def _write_coordinator_event(
     artifact_dir: Path,
     *,
@@ -650,6 +694,9 @@ def run_fixture_window(
 
     if resume:
         state, completed_cycles = _prepare_resume(artifact_dir, run_id)
+        # Preserve the bounded recovery budget across resumes (do not grant a
+        # fresh max_restart_count on every relaunch).
+        restart_count = _seed_restart_count(artifact_dir)
         prior_events = _read_coordinator_events(artifact_dir)
         _write_coordinator_event(
             artifact_dir,
@@ -679,13 +726,28 @@ def run_fixture_window(
                 reason_codes=("sleep_started_without_sleep_completed",),
                 covered_report_names=(),
                 restart_attempted=True,
-                restart_count=0,
+                restart_count=restart_count,
                 max_restart_count=max_restart_count,
                 backoff_seconds=0,
                 action="resume_cycle_window",
                 limit_exceeded=False,
             )
             recovery_events_written += 1
+            # Honor the remainder of the interrupted sleep window so an early
+            # resume does not compress the cadence / observation window.
+            remaining_sleep = _remaining_sleep_seconds(state.next_cycle_due_at_utc)
+            if remaining_sleep > 0:
+                _sleep_with_interval_check(
+                    sleep_fn, remaining_sleep, chunk_seconds=60
+                )
+            _write_coordinator_event(
+                artifact_dir,
+                run_id=run_id,
+                event_type="sleep_completed",
+                cycle_index=resume_cycle_index or None,
+                next_cycle_due_at_utc=state.next_cycle_due_at_utc,
+                coordinator_status="resuming",
+            )
         state = _update_runner_state(
             state,
             run_id=run_id,

--- a/tools/evidence_harvester/supervisor.py
+++ b/tools/evidence_harvester/supervisor.py
@@ -1,0 +1,437 @@
+"""Evidence harvester sleep-stall supervisor.
+
+Decision-and-relaunch layer that detects the Slice-B/C/D stall pattern
+(``sleep_started`` without ``sleep_completed`` past ``next_cycle_due_at_utc``
+with a dead coordinator process) and relaunches the coordinator in resume mode
+with a bounded relaunch budget.
+
+The decision function and supervise loop are pure and fully injectable
+(launcher, process-liveness probe, clock, sleep) so they are unit-testable
+without spawning any process, installing an OS scheduler, or touching Docker /
+DB / Redis / secrets. The CLI ``supervise`` path is fail-closed behind
+``--explicit``; the read-only ``status`` path never mutates anything.
+
+Boundaries: dry/fixture research only. LR NO-GO. No Live-Go, no Echtgeld-Go.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from .coordinator import (
+    DEFAULT_CADENCE_SECONDS,
+    DEFAULT_MAX_RESTART_COUNT,
+    DEFAULT_RESTART_BACKOFF_SECONDS,
+    CoordinatorSummary,
+    _now_utc,
+    _read_coordinator_events,
+    _read_runner_state,
+    _repo_root,
+    run_fixture_window,
+)
+from .runner import RunnerState
+
+SUPERVISION_SCHEMA = "cdb.evidence_harvester.supervision.v1"
+
+DEFAULT_MAX_RELAUNCH_COUNT = 5
+DEFAULT_POLL_SECONDS = 60
+
+ACTION_WAIT = "WAIT"
+ACTION_RELAUNCH_RESUME = "RELAUNCH_RESUME"
+ACTION_DONE = "DONE"
+ACTION_STOP_FATAL = "STOP_FATAL"
+ACTION_STOP_LIMIT = "STOP_LIMIT"
+
+_TERMINAL_STATUSES = frozenset({"failed", "fatal_stop"})
+
+
+class SupervisorError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class SupervisionDecision:
+    action: str
+    reason: str
+    coordinator_status: str
+    next_cycle_due_at_utc: str
+    overdue: bool
+    process_alive: bool
+    relaunch_count: int
+    max_relaunch_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class SupervisionResult:
+    schema_version: str
+    status: str
+    artifact_dir: str
+    relaunch_count: int
+    max_relaunch_count: int
+    polls: int
+    final_coordinator_status: str
+    decisions: tuple[dict[str, Any], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _parse_ts(value: str) -> datetime | None:
+    text = (value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def decide_supervision(
+    state: RunnerState | None,
+    events: Sequence[Mapping[str, Any]],
+    now: datetime,
+    process_alive: bool,
+    relaunch_count: int,
+    max_relaunch_count: int,
+) -> SupervisionDecision:
+    """Pure decision: what should the supervisor do given durable evidence."""
+    coordinator_status = str(state.coordinator_status) if state else ""
+    next_due = str(state.next_cycle_due_at_utc) if state else ""
+
+    has_final_completed = any(
+        str(event.get("event_type", "")) == "final_validation_completed"
+        for event in events
+    )
+
+    due_at = _parse_ts(next_due)
+    if due_at is not None:
+        overdue = now > due_at
+    else:
+        overdue = coordinator_status == "sleeping"
+
+    def build(action: str, reason: str) -> SupervisionDecision:
+        return SupervisionDecision(
+            action=action,
+            reason=reason,
+            coordinator_status=coordinator_status,
+            next_cycle_due_at_utc=next_due,
+            overdue=overdue,
+            process_alive=process_alive,
+            relaunch_count=relaunch_count,
+            max_relaunch_count=max_relaunch_count,
+        )
+
+    if coordinator_status == "completed" or has_final_completed:
+        return build(ACTION_DONE, "run reached completion")
+    if coordinator_status in _TERMINAL_STATUSES:
+        return build(
+            ACTION_STOP_FATAL,
+            f"terminal coordinator_status={coordinator_status!r}",
+        )
+
+    last_type = str(events[-1].get("event_type", "")).strip() if events else ""
+    stalled_sleep = coordinator_status == "sleeping" and last_type == "sleep_started"
+
+    if stalled_sleep and overdue and not process_alive:
+        if relaunch_count >= max_relaunch_count:
+            return build(ACTION_STOP_LIMIT, "relaunch budget exhausted")
+        return build(
+            ACTION_RELAUNCH_RESUME,
+            "stalled sleep past next_cycle_due_at_utc with dead process",
+        )
+
+    if process_alive:
+        return build(ACTION_WAIT, "coordinator process alive")
+    return build(ACTION_WAIT, "no relaunch condition met")
+
+
+def _build_result(
+    status: str,
+    artifact_dir: Path,
+    relaunch_count: int,
+    max_relaunch_count: int,
+    polls: int,
+    decisions: list[dict[str, Any]],
+    state: RunnerState | None,
+) -> SupervisionResult:
+    return SupervisionResult(
+        schema_version=SUPERVISION_SCHEMA,
+        status=status,
+        artifact_dir=str(artifact_dir),
+        relaunch_count=relaunch_count,
+        max_relaunch_count=max_relaunch_count,
+        polls=polls,
+        final_coordinator_status=(str(state.coordinator_status) if state else ""),
+        decisions=tuple(decisions),
+    )
+
+
+def supervise_loop(
+    *,
+    artifact_dir: Path,
+    launcher: Callable[[], CoordinatorSummary],
+    process_alive_fn: Callable[[], bool],
+    now_fn: Callable[[], datetime] = _now_utc,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    poll_seconds: int = DEFAULT_POLL_SECONDS,
+    max_relaunch_count: int = DEFAULT_MAX_RELAUNCH_COUNT,
+    max_polls: int | None = None,
+) -> SupervisionResult:
+    """Poll durable state and relaunch the coordinator in resume mode on stall.
+
+    Fully injectable for deterministic tests: ``launcher`` performs the resume
+    (default binds ``run_fixture_window(resume=True)``), ``process_alive_fn``
+    reports coordinator liveness, and ``sleep_fn``/``now_fn`` control timing.
+    """
+    if poll_seconds < 0:
+        raise SupervisorError("poll_seconds must be >= 0")
+    if max_relaunch_count < 0:
+        raise SupervisorError("max_relaunch_count must be >= 0")
+
+    relaunch_count = 0
+    polls = 0
+    decisions: list[dict[str, Any]] = []
+
+    while True:
+        state = _read_runner_state(artifact_dir)
+        events = _read_coordinator_events(artifact_dir)
+        decision = decide_supervision(
+            state,
+            events,
+            now_fn(),
+            process_alive_fn(),
+            relaunch_count,
+            max_relaunch_count,
+        )
+        decisions.append(decision.to_dict())
+
+        if decision.action == ACTION_DONE:
+            return _build_result(
+                "DONE", artifact_dir, relaunch_count,
+                max_relaunch_count, polls, decisions, state,
+            )
+        if decision.action == ACTION_STOP_FATAL:
+            return _build_result(
+                "STOP_FATAL", artifact_dir, relaunch_count,
+                max_relaunch_count, polls, decisions, state,
+            )
+        if decision.action == ACTION_STOP_LIMIT:
+            return _build_result(
+                "STOP_LIMIT", artifact_dir, relaunch_count,
+                max_relaunch_count, polls, decisions, state,
+            )
+        if decision.action == ACTION_RELAUNCH_RESUME:
+            relaunch_count += 1
+            launcher()
+            continue
+
+        polls += 1
+        if max_polls is not None and polls >= max_polls:
+            return _build_result(
+                "WAIT_TIMEOUT", artifact_dir, relaunch_count,
+                max_relaunch_count, polls, decisions, state,
+            )
+        if poll_seconds:
+            sleep_fn(poll_seconds)
+
+
+def _resume_launcher(
+    *,
+    repo_root: Path,
+    fixture_path: Path,
+    artifact_dir: Path,
+    iterations: int,
+    cadence_seconds: int,
+    max_restart_count: int,
+    restart_backoff_seconds: int,
+) -> Callable[[], CoordinatorSummary]:
+    def _launch() -> CoordinatorSummary:
+        return run_fixture_window(
+            repo_root=repo_root,
+            fixture_path=fixture_path,
+            artifact_dir=artifact_dir,
+            iterations=iterations,
+            cadence_seconds=cadence_seconds,
+            max_restart_count=max_restart_count,
+            restart_backoff_seconds=restart_backoff_seconds,
+            resume=True,
+        )
+
+    return _launch
+
+
+def _format_json(payload: Mapping[str, Any], pretty: bool) -> str:
+    return json.dumps(
+        payload,
+        indent=2 if pretty else None,
+        sort_keys=True,
+        ensure_ascii=True,
+    )
+
+
+def _emit(payload: Mapping[str, Any], pretty: bool) -> None:
+    print(_format_json(payload, pretty))
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    artifact_dir = args.artifact_dir.resolve()
+    state = _read_runner_state(artifact_dir)
+    events = _read_coordinator_events(artifact_dir)
+    process_alive = bool(args.assume_process_alive)
+    decision = decide_supervision(
+        state,
+        events,
+        _now_utc(),
+        process_alive,
+        relaunch_count=0,
+        max_relaunch_count=args.max_relaunch_count,
+    )
+    payload = {
+        "schema_version": SUPERVISION_SCHEMA,
+        "mode": "status",
+        "artifact_dir": str(artifact_dir),
+        "assumed_process_alive": process_alive,
+        "decision": decision.to_dict(),
+    }
+    _emit(payload, args.pretty)
+    return 0
+
+
+def _cmd_supervise(args: argparse.Namespace) -> int:
+    artifact_dir = args.artifact_dir.resolve()
+    fixture_path = args.fixture.resolve()
+    plan = {
+        "schema_version": SUPERVISION_SCHEMA,
+        "mode": "supervise",
+        "artifact_dir": str(artifact_dir),
+        "fixture": str(fixture_path),
+        "iterations": args.iterations,
+        "cadence_seconds": args.cadence_seconds,
+        "max_relaunch_count": args.max_relaunch_count,
+        "poll_seconds": args.poll_seconds,
+        "explicit": bool(args.explicit),
+        "safety": "dry/fixture only; LR NO-GO; no Live-Go; no Echtgeld-Go",
+    }
+    if not args.explicit:
+        plan["status"] = "planned"
+        plan["note"] = "Re-run with --explicit to execute in-process resume supervision."
+        _emit(plan, args.pretty)
+        return 0
+
+    if not fixture_path.exists():
+        raise SupervisorError(f"fixture path does not exist: {fixture_path}")
+    if _read_runner_state(artifact_dir) is None:
+        raise SupervisorError(
+            "supervise --explicit requires an existing run to resume; start it "
+            "first with 'coordinator run-fixture-window'"
+        )
+
+    launcher = _resume_launcher(
+        repo_root=_repo_root(),
+        fixture_path=fixture_path,
+        artifact_dir=artifact_dir,
+        iterations=args.iterations,
+        cadence_seconds=args.cadence_seconds,
+        max_restart_count=args.max_restart_count,
+        restart_backoff_seconds=args.restart_backoff_seconds,
+    )
+    result = supervise_loop(
+        artifact_dir=artifact_dir,
+        launcher=launcher,
+        process_alive_fn=lambda: False,
+        poll_seconds=args.poll_seconds,
+        max_relaunch_count=args.max_relaunch_count,
+        max_polls=args.max_polls,
+    )
+    _emit(result.to_dict(), args.pretty)
+    return 0 if result.status in ("DONE", "WAIT_TIMEOUT") else 1
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Evidence harvester sleep-stall supervisor (resume-mode relaunch)."
+        )
+    )
+    parser.add_argument(
+        "--pretty", action="store_true", help="Pretty-print JSON output."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    status_parser = subparsers.add_parser(
+        "status",
+        help="Read-only supervision decision for an artifact dir.",
+    )
+    status_parser.add_argument("--artifact-dir", type=Path, required=True)
+    status_parser.add_argument(
+        "--assume-process-alive",
+        action="store_true",
+        help="Assume the coordinator process is alive (default: assume dead).",
+    )
+    status_parser.add_argument(
+        "--max-relaunch-count",
+        type=int,
+        default=DEFAULT_MAX_RELAUNCH_COUNT,
+    )
+
+    supervise_parser = subparsers.add_parser(
+        "supervise",
+        help=(
+            "Resume-supervise an existing run in-process (fail-closed behind "
+            "--explicit)."
+        ),
+    )
+    supervise_parser.add_argument("--artifact-dir", type=Path, required=True)
+    supervise_parser.add_argument("--fixture", type=Path, required=True)
+    supervise_parser.add_argument("--iterations", type=int, required=True)
+    supervise_parser.add_argument(
+        "--cadence-seconds", type=int, default=DEFAULT_CADENCE_SECONDS
+    )
+    supervise_parser.add_argument(
+        "--max-restart-count", type=int, default=DEFAULT_MAX_RESTART_COUNT
+    )
+    supervise_parser.add_argument(
+        "--restart-backoff-seconds",
+        type=int,
+        default=DEFAULT_RESTART_BACKOFF_SECONDS,
+    )
+    supervise_parser.add_argument(
+        "--max-relaunch-count", type=int, default=DEFAULT_MAX_RELAUNCH_COUNT
+    )
+    supervise_parser.add_argument(
+        "--poll-seconds", type=int, default=DEFAULT_POLL_SECONDS
+    )
+    supervise_parser.add_argument("--max-polls", type=int, default=None)
+    supervise_parser.add_argument(
+        "--explicit",
+        action="store_true",
+        help="Required to actually run supervision; otherwise prints the plan.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.command == "status":
+        return _cmd_status(args)
+    if args.command == "supervise":
+        return _cmd_supervise(args)
+    raise SupervisorError(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fixes the coordinator sleep-window stall (#3634) that ended Slice-B/C/D runs
INCONCLUSIVE (O264 warn + O303). Adds a resume-safe coordinator and a testable
sleep-stall supervisor so an interrupted run resumes instead of dying after
`sleep_started` without `sleep_completed`.

## Root cause

`run_fixture_window` re-initialised `completed_cycles = 0` on every launch and
looped `while completed_cycles < iterations`. The durable events `sleep_started`
and `sleep_completed` bracket a single in-process blocking
`_sleep_with_interval_check`. A process death inside that sleep left no
`sleep_completed`, no `final_validation_*`, and no resume path.

## Delivered

- **Resume-safe coordinator** (`tools/evidence_harvester/coordinator.py`):
  `resume-fixture-window` subcommand (`resume=True`); seeds `completed_cycles`
  from `runner_state.total_cycles_completed`; emits `sleep_resumed` + audited
  `recovery_event` (`failure_source="sleep_stall"`) on a stalled sleep;
  idempotent (completed window -> final validation only); fail-closed on missing
  state / `run_id` mismatch / terminal status.
- **Sleep-stall supervisor** (`tools/evidence_harvester/supervisor.py`, new):
  pure `decide_supervision` (`WAIT | RELAUNCH_RESUME | DONE | STOP_FATAL |
  STOP_LIMIT`) + injectable bounded `supervise_loop`; read-only `status` CLI;
  `supervise` fail-closed behind `--explicit`. No process spawn, scheduler
  install, or Docker/DB/Redis/secrets.
- **Tests**: resume seeding/no double-count, interrupted sleep ->
  `final_validation_completed`, resume-of-completed -> final only, fail-closed
  x3, `_sleep_with_interval_check` interrupt, supervisor decision matrix + loop +
  relaunch limit, O264/O303 validator consistency.
- **Docs**: runbook resume/supervisor section, evidence doc (root cause +
  Slice-E plan), `CURRENT_STATUS.md`, session log.

## Validation

- `pytest tests/unit/tools/evidence_harvester/test_coordinator.py test_supervisor.py -q` -> 29 passed
- `pytest tests/unit/tools/evidence_harvester/ -q` -> 260 passed
- `ruff check` on changed files -> All checks passed

## Non-goals

- No new 72h run in this slice (Slice-E documented, needs Runtime-GO).
- No external subprocess supervision / OS scheduler install.
- No 72h-PASS claim; #3362 and #3345 remain OPEN.

## Boundaries

LR NO-GO. No Live-Go, no Echtgeld-Go. No Docker/DB/Redis/secrets. No runtime
mutation beyond local/test.

## Remaining uncertainty

Resume covers the sleep-window stall (the observed Slice-B/C/D failure). A
mid-cycle process death resumes cycle counts correctly but is not separately
supervised; production crash-recovery still needs the Slice-E external wrapper
(Runtime-GO).

Closes #3634
Refs #3362 #3384
