### PR TITLE
docs(skills): add skill surface drift guard

### DIFF
--- a/.claude/skills/cdb-drift-reconcile/SKILL.md
+++ b/.claude/skills/cdb-drift-reconcile/SKILL.md
@@ -5,6 +5,7 @@ Sync Status: mirrored-from-canon
 Last Verified: 2026-07-01
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
+
 ---
 name: cdb-drift-reconcile
 description: >
@@ -39,6 +40,7 @@ Always check these areas unless the request explicitly narrows scope further:
 - SSOT-Grenzen between `CURRENT_STATUS.md` and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
 - Discovery-Surfaces / EntryPoints / Cheatsheets
 - `ARCHITECTURE_MAP` / `SERVICE_CATALOG` when service changes are implicated
+- Skill Surface Mirror Drift: canon `docs/skills/<name>/SKILL.md` vs adapter surfaces `.opencode`, `.cursor`, `.codex`, `.claude`
 
 ## Workflow
 
@@ -63,6 +65,39 @@ Always check these areas unless the request explicitly narrows scope further:
    - Treat canon-boundary uncertainty as unresolved, not as clean.
    - Do not convert every drift finding into a follow-up issue or workflow change.
    - Keep Board stage separate from LR status at all times.
+
+## Skill Surface Mirror Drift
+
+Since PR #3637 the canonical skill source is `docs/skills/<name>/SKILL.md`.
+Surface adapters mirror those bodies (PR #3641). Canon edits can silently drift
+the adapters, so this drift vector has a dedicated, scriptable check.
+
+- Canon: `docs/skills/<name>/SKILL.md`
+- Adapters: `.opencode/skills/<name>/SKILL.md`, `.cursor/skills/<name>/SKILL.md`,
+  `.codex/cdb_skills/<name>/SKILL.md`, `.claude/skills/<name>/SKILL.md`
+- Check command (read-only, no writes, no network):
+
+  ```bash
+  python tools/validate_skill_surface_mirror.py          # human report
+  python tools/validate_skill_surface_mirror.py --json   # machine-readable
+  python tools/validate_skill_surface_mirror.py --skill <name>
+  ```
+
+- Result semantics and exit codes:
+  - `PASS` (exit 0): every expected adapter body matches canon (header ignored).
+  - `DRIFT_FOUND` (exit 1): an adapter body differs, or an expected adapter is missing.
+  - `BLOCKED` (exit 2): missing canon tree, unknown skill, or parse/usage error.
+- Documented exclusions (not drift): `cdb-onboarding` is codex-only alias;
+  `gh-fix-ci` keeps `META.yaml`/`evals.json`/`scripts/` canon-only (only `SKILL.md`
+  bodies are compared); `.claude/skills/*.skill` and `.gemini/skills/` are out of scope.
+
+**Fail-Closed rule:** If `docs/skills/<name>/SKILL.md` was changed in the session
+and the drift checker was not run, do not mark the session as fully complete —
+report `skill surface drift unknown`.
+
+**Follow-up rule:** On `DRIFT_FOUND`, either re-mirror the affected adapters from
+canon within the current scope, or create a deduplicated re-mirror follow-up issue
+and hand off. Never auto-merge without green required checks.
 
 ## Classification Rules
 

--- a/.claude/skills/cdb-drift-reconcile/SKILL.md
+++ b/.claude/skills/cdb-drift-reconcile/SKILL.md
@@ -84,8 +84,10 @@ the adapters, so this drift vector has a dedicated, scriptable check.
   ```
 
 - Result semantics and exit codes:
-  - `PASS` (exit 0): every expected adapter body matches canon (header ignored).
-  - `DRIFT_FOUND` (exit 1): an adapter body differs, or an expected adapter is missing.
+  - `PASS` (exit 0): every expected adapter matches canon in body (header ignored)
+    and carries a valid `mirrored-from-canon` surface header.
+  - `DRIFT_FOUND` (exit 1): an adapter body differs, an adapter header is missing or
+    not `mirrored-from-canon`, or an expected adapter is missing.
   - `BLOCKED` (exit 2): missing canon tree, unknown skill, or parse/usage error.
 - Documented exclusions (not drift): `cdb-onboarding` is codex-only alias;
   `gh-fix-ci` keeps `META.yaml`/`evals.json`/`scripts/` canon-only (only `SKILL.md`

--- a/.codex/cdb_skills/cdb-drift-reconcile/SKILL.md
+++ b/.codex/cdb_skills/cdb-drift-reconcile/SKILL.md
@@ -5,6 +5,7 @@ Sync Status: mirrored-from-canon
 Last Verified: 2026-07-01
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
+
 ---
 name: cdb-drift-reconcile
 description: >
@@ -39,6 +40,7 @@ Always check these areas unless the request explicitly narrows scope further:
 - SSOT-Grenzen between `CURRENT_STATUS.md` and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
 - Discovery-Surfaces / EntryPoints / Cheatsheets
 - `ARCHITECTURE_MAP` / `SERVICE_CATALOG` when service changes are implicated
+- Skill Surface Mirror Drift: canon `docs/skills/<name>/SKILL.md` vs adapter surfaces `.opencode`, `.cursor`, `.codex`, `.claude`
 
 ## Workflow
 
@@ -63,6 +65,39 @@ Always check these areas unless the request explicitly narrows scope further:
    - Treat canon-boundary uncertainty as unresolved, not as clean.
    - Do not convert every drift finding into a follow-up issue or workflow change.
    - Keep Board stage separate from LR status at all times.
+
+## Skill Surface Mirror Drift
+
+Since PR #3637 the canonical skill source is `docs/skills/<name>/SKILL.md`.
+Surface adapters mirror those bodies (PR #3641). Canon edits can silently drift
+the adapters, so this drift vector has a dedicated, scriptable check.
+
+- Canon: `docs/skills/<name>/SKILL.md`
+- Adapters: `.opencode/skills/<name>/SKILL.md`, `.cursor/skills/<name>/SKILL.md`,
+  `.codex/cdb_skills/<name>/SKILL.md`, `.claude/skills/<name>/SKILL.md`
+- Check command (read-only, no writes, no network):
+
+  ```bash
+  python tools/validate_skill_surface_mirror.py          # human report
+  python tools/validate_skill_surface_mirror.py --json   # machine-readable
+  python tools/validate_skill_surface_mirror.py --skill <name>
+  ```
+
+- Result semantics and exit codes:
+  - `PASS` (exit 0): every expected adapter body matches canon (header ignored).
+  - `DRIFT_FOUND` (exit 1): an adapter body differs, or an expected adapter is missing.
+  - `BLOCKED` (exit 2): missing canon tree, unknown skill, or parse/usage error.
+- Documented exclusions (not drift): `cdb-onboarding` is codex-only alias;
+  `gh-fix-ci` keeps `META.yaml`/`evals.json`/`scripts/` canon-only (only `SKILL.md`
+  bodies are compared); `.claude/skills/*.skill` and `.gemini/skills/` are out of scope.
+
+**Fail-Closed rule:** If `docs/skills/<name>/SKILL.md` was changed in the session
+and the drift checker was not run, do not mark the session as fully complete —
+report `skill surface drift unknown`.
+
+**Follow-up rule:** On `DRIFT_FOUND`, either re-mirror the affected adapters from
+canon within the current scope, or create a deduplicated re-mirror follow-up issue
+and hand off. Never auto-merge without green required checks.
 
 ## Classification Rules
 

--- a/.codex/cdb_skills/cdb-drift-reconcile/SKILL.md
+++ b/.codex/cdb_skills/cdb-drift-reconcile/SKILL.md
@@ -84,8 +84,10 @@ the adapters, so this drift vector has a dedicated, scriptable check.
   ```
 
 - Result semantics and exit codes:
-  - `PASS` (exit 0): every expected adapter body matches canon (header ignored).
-  - `DRIFT_FOUND` (exit 1): an adapter body differs, or an expected adapter is missing.
+  - `PASS` (exit 0): every expected adapter matches canon in body (header ignored)
+    and carries a valid `mirrored-from-canon` surface header.
+  - `DRIFT_FOUND` (exit 1): an adapter body differs, an adapter header is missing or
+    not `mirrored-from-canon`, or an expected adapter is missing.
   - `BLOCKED` (exit 2): missing canon tree, unknown skill, or parse/usage error.
 - Documented exclusions (not drift): `cdb-onboarding` is codex-only alias;
   `gh-fix-ci` keeps `META.yaml`/`evals.json`/`scripts/` canon-only (only `SKILL.md`

--- a/.cursor/skills/cdb-drift-reconcile/SKILL.md
+++ b/.cursor/skills/cdb-drift-reconcile/SKILL.md
@@ -5,6 +5,7 @@ Sync Status: mirrored-from-canon
 Last Verified: 2026-07-01
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
+
 ---
 name: cdb-drift-reconcile
 description: >
@@ -39,6 +40,7 @@ Always check these areas unless the request explicitly narrows scope further:
 - SSOT-Grenzen between `CURRENT_STATUS.md` and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
 - Discovery-Surfaces / EntryPoints / Cheatsheets
 - `ARCHITECTURE_MAP` / `SERVICE_CATALOG` when service changes are implicated
+- Skill Surface Mirror Drift: canon `docs/skills/<name>/SKILL.md` vs adapter surfaces `.opencode`, `.cursor`, `.codex`, `.claude`
 
 ## Workflow
 
@@ -63,6 +65,39 @@ Always check these areas unless the request explicitly narrows scope further:
    - Treat canon-boundary uncertainty as unresolved, not as clean.
    - Do not convert every drift finding into a follow-up issue or workflow change.
    - Keep Board stage separate from LR status at all times.
+
+## Skill Surface Mirror Drift
+
+Since PR #3637 the canonical skill source is `docs/skills/<name>/SKILL.md`.
+Surface adapters mirror those bodies (PR #3641). Canon edits can silently drift
+the adapters, so this drift vector has a dedicated, scriptable check.
+
+- Canon: `docs/skills/<name>/SKILL.md`
+- Adapters: `.opencode/skills/<name>/SKILL.md`, `.cursor/skills/<name>/SKILL.md`,
+  `.codex/cdb_skills/<name>/SKILL.md`, `.claude/skills/<name>/SKILL.md`
+- Check command (read-only, no writes, no network):
+
+  ```bash
+  python tools/validate_skill_surface_mirror.py          # human report
+  python tools/validate_skill_surface_mirror.py --json   # machine-readable
+  python tools/validate_skill_surface_mirror.py --skill <name>
+  ```
+
+- Result semantics and exit codes:
+  - `PASS` (exit 0): every expected adapter body matches canon (header ignored).
+  - `DRIFT_FOUND` (exit 1): an adapter body differs, or an expected adapter is missing.
+  - `BLOCKED` (exit 2): missing canon tree, unknown skill, or parse/usage error.
+- Documented exclusions (not drift): `cdb-onboarding` is codex-only alias;
+  `gh-fix-ci` keeps `META.yaml`/`evals.json`/`scripts/` canon-only (only `SKILL.md`
+  bodies are compared); `.claude/skills/*.skill` and `.gemini/skills/` are out of scope.
+
+**Fail-Closed rule:** If `docs/skills/<name>/SKILL.md` was changed in the session
+and the drift checker was not run, do not mark the session as fully complete —
+report `skill surface drift unknown`.
+
+**Follow-up rule:** On `DRIFT_FOUND`, either re-mirror the affected adapters from
+canon within the current scope, or create a deduplicated re-mirror follow-up issue
+and hand off. Never auto-merge without green required checks.
 
 ## Classification Rules
 

--- a/.cursor/skills/cdb-drift-reconcile/SKILL.md
+++ b/.cursor/skills/cdb-drift-reconcile/SKILL.md
@@ -84,8 +84,10 @@ the adapters, so this drift vector has a dedicated, scriptable check.
   ```
 
 - Result semantics and exit codes:
-  - `PASS` (exit 0): every expected adapter body matches canon (header ignored).
-  - `DRIFT_FOUND` (exit 1): an adapter body differs, or an expected adapter is missing.
+  - `PASS` (exit 0): every expected adapter matches canon in body (header ignored)
+    and carries a valid `mirrored-from-canon` surface header.
+  - `DRIFT_FOUND` (exit 1): an adapter body differs, an adapter header is missing or
+    not `mirrored-from-canon`, or an expected adapter is missing.
   - `BLOCKED` (exit 2): missing canon tree, unknown skill, or parse/usage error.
 - Documented exclusions (not drift): `cdb-onboarding` is codex-only alias;
   `gh-fix-ci` keeps `META.yaml`/`evals.json`/`scripts/` canon-only (only `SKILL.md`

--- a/.opencode/skills/cdb-drift-reconcile/SKILL.md
+++ b/.opencode/skills/cdb-drift-reconcile/SKILL.md
@@ -5,6 +5,7 @@ Sync Status: mirrored-from-canon
 Last Verified: 2026-07-01
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
+
 ---
 name: cdb-drift-reconcile
 description: >
@@ -39,6 +40,7 @@ Always check these areas unless the request explicitly narrows scope further:
 - SSOT-Grenzen between `CURRENT_STATUS.md` and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
 - Discovery-Surfaces / EntryPoints / Cheatsheets
 - `ARCHITECTURE_MAP` / `SERVICE_CATALOG` when service changes are implicated
+- Skill Surface Mirror Drift: canon `docs/skills/<name>/SKILL.md` vs adapter surfaces `.opencode`, `.cursor`, `.codex`, `.claude`
 
 ## Workflow
 
@@ -63,6 +65,39 @@ Always check these areas unless the request explicitly narrows scope further:
    - Treat canon-boundary uncertainty as unresolved, not as clean.
    - Do not convert every drift finding into a follow-up issue or workflow change.
    - Keep Board stage separate from LR status at all times.
+
+## Skill Surface Mirror Drift
+
+Since PR #3637 the canonical skill source is `docs/skills/<name>/SKILL.md`.
+Surface adapters mirror those bodies (PR #3641). Canon edits can silently drift
+the adapters, so this drift vector has a dedicated, scriptable check.
+
+- Canon: `docs/skills/<name>/SKILL.md`
+- Adapters: `.opencode/skills/<name>/SKILL.md`, `.cursor/skills/<name>/SKILL.md`,
+  `.codex/cdb_skills/<name>/SKILL.md`, `.claude/skills/<name>/SKILL.md`
+- Check command (read-only, no writes, no network):
+
+  ```bash
+  python tools/validate_skill_surface_mirror.py          # human report
+  python tools/validate_skill_surface_mirror.py --json   # machine-readable
+  python tools/validate_skill_surface_mirror.py --skill <name>
+  ```
+
+- Result semantics and exit codes:
+  - `PASS` (exit 0): every expected adapter body matches canon (header ignored).
+  - `DRIFT_FOUND` (exit 1): an adapter body differs, or an expected adapter is missing.
+  - `BLOCKED` (exit 2): missing canon tree, unknown skill, or parse/usage error.
+- Documented exclusions (not drift): `cdb-onboarding` is codex-only alias;
+  `gh-fix-ci` keeps `META.yaml`/`evals.json`/`scripts/` canon-only (only `SKILL.md`
+  bodies are compared); `.claude/skills/*.skill` and `.gemini/skills/` are out of scope.
+
+**Fail-Closed rule:** If `docs/skills/<name>/SKILL.md` was changed in the session
+and the drift checker was not run, do not mark the session as fully complete —
+report `skill surface drift unknown`.
+
+**Follow-up rule:** On `DRIFT_FOUND`, either re-mirror the affected adapters from
+canon within the current scope, or create a deduplicated re-mirror follow-up issue
+and hand off. Never auto-merge without green required checks.
 
 ## Classification Rules
 

--- a/.opencode/skills/cdb-drift-reconcile/SKILL.md
+++ b/.opencode/skills/cdb-drift-reconcile/SKILL.md
@@ -84,8 +84,10 @@ the adapters, so this drift vector has a dedicated, scriptable check.
   ```
 
 - Result semantics and exit codes:
-  - `PASS` (exit 0): every expected adapter body matches canon (header ignored).
-  - `DRIFT_FOUND` (exit 1): an adapter body differs, or an expected adapter is missing.
+  - `PASS` (exit 0): every expected adapter matches canon in body (header ignored)
+    and carries a valid `mirrored-from-canon` surface header.
+  - `DRIFT_FOUND` (exit 1): an adapter body differs, an adapter header is missing or
+    not `mirrored-from-canon`, or an expected adapter is missing.
   - `BLOCKED` (exit 2): missing canon tree, unknown skill, or parse/usage error.
 - Documented exclusions (not drift): `cdb-onboarding` is codex-only alias;
   `gh-fix-ci` keeps `META.yaml`/`evals.json`/`scripts/` canon-only (only `SKILL.md`

--- a/docs/skills/CDB.VERFUEGBARE.SKILLS_LISTE_2026-07-01.md
+++ b/docs/skills/CDB.VERFUEGBARE.SKILLS_LISTE_2026-07-01.md
@@ -20,6 +20,10 @@ erfindet keine neuen Slash-Befehle.
 (`.opencode/`, `.cursor/`, `.codex/`, `.claude/`) sind auf Canon gespiegelt
 (Issue #3639; Header `mirrored-from-canon`, Body-Parity verifiziert).
 
+**Drift-Guard (Issue #3643):** `python tools/validate_skill_surface_mirror.py`
+prueft Canon vs Adapter (read-only; `PASS`/`DRIFT_FOUND`/`BLOCKED`). Nach jeder
+Skill-Canon-Aenderung ausfuehren; Details in `SKILL_SURFACE_REGISTRY.md` §8.1.
+
 ## Grenze: Brain vs Runtime
 
 | Rolle | Technologie | SSOT |

--- a/docs/skills/SKILL_SURFACE_REGISTRY.md
+++ b/docs/skills/SKILL_SURFACE_REGISTRY.md
@@ -143,6 +143,9 @@ python tools/validate_skill_surface_mirror.py --skill <name>
 ```
 
 - Exit codes: `0` = PASS, `1` = DRIFT_FOUND, `2` = BLOCKED.
+- Prueft Body-Parity **und** den Pflicht-Header (`mirrored-from-canon` +
+  korrekte Canon-Quelle je Adapter, siehe §7); ein Body-Match mit fehlendem
+  Header ist Drift.
 - **Pflicht:** Nach jeder Aenderung an `docs/skills/<name>/SKILL.md` den
   Drift-Guard laufen lassen und Adapter nachziehen, bevor die Session als
   vollstaendig abgeschlossen gilt. Bei `DRIFT_FOUND` re-mirror im Scope oder

--- a/docs/skills/SKILL_SURFACE_REGISTRY.md
+++ b/docs/skills/SKILL_SURFACE_REGISTRY.md
@@ -128,8 +128,29 @@ gelistet werden.
 - `mirrored`-Adapter, die vom kanonischen Inhalt abweichen, sind kein
   gültiger Zustand und muessen sofort synchronisiert oder auf `adapted`
   umgestellt werden.
-- Drift-Erkennung gehoert zum `cdb-drift-reconcile`-Workflow und wird in
-  Folge-Issues verfeinert.
+- Drift-Erkennung gehoert zum `cdb-drift-reconcile`-Workflow.
+
+### 8.1 Skill Surface Mirror Drift Guard (Issue #3643)
+
+Der Drift-Guard `tools/validate_skill_surface_mirror.py` prueft Canon-Body
+gegen alle erwarteten Adapter (Header ignoriert). Er ist read-only, macht
+keine Datei-, Netzwerk-, GitHub-, DB- oder MCP-Aktionen.
+
+```bash
+python tools/validate_skill_surface_mirror.py          # human report
+python tools/validate_skill_surface_mirror.py --json   # machine-readable
+python tools/validate_skill_surface_mirror.py --skill <name>
+```
+
+- Exit codes: `0` = PASS, `1` = DRIFT_FOUND, `2` = BLOCKED.
+- **Pflicht:** Nach jeder Aenderung an `docs/skills/<name>/SKILL.md` den
+  Drift-Guard laufen lassen und Adapter nachziehen, bevor die Session als
+  vollstaendig abgeschlossen gilt. Bei `DRIFT_FOUND` re-mirror im Scope oder
+  dedupliziertes Re-Mirror-Follow-up-Issue anlegen (kein Auto-Merge ohne gruene
+  Required Checks).
+- Dokumentierte Ausnahmen (kein Drift): `cdb-onboarding` (codex-only Alias),
+  `gh-fix-ci` Canon-Extras (`META.yaml`/`evals.json`/`scripts/`; nur `SKILL.md`
+  wird verglichen), `.claude/skills/*.skill`, `.gemini/skills/`.
 
 ## 9. Skill-Neuanlage-Workflow
 
@@ -220,7 +241,7 @@ Nach Canon-Tree-Merge (2026-07-01):
 - `[SKILLS] Mirror surface adapters from docs/skills canon` — **done** (Issue #3639; 25/25 canon, 99 adapter SKILL.md synced)
 - `[SKILLS] Extend cdb-session-close with post-close follow-up issue intake` — **done** (Issue #3638)
 - `[SKILLS] Apply Surface-Adapter-Header to all existing mirrored skills` — **done** (merged into #3639)
-- `[SKILLS] Add drift-reconcile hook for skill surface adapters`
+- `[SKILLS] Add drift-reconcile hook for skill surface adapters` — **done** (Issue #3643; `tools/validate_skill_surface_mirror.py` + tests, `cdb-drift-reconcile` §Skill Surface Mirror Drift)
 - `[SKILLS] Add skill-meta schema (META.yaml + evals.json) for new CDB domain skills`
 - `[SKILLS] Document `.gemini/` activation policy if domain skills are ever needed`
 
@@ -228,9 +249,11 @@ Diese Issues werden dedupliziert und mit klarem Scope angelegt.
 
 ## 16. Aktives Skill-Inventar (2026-07-01)
 
-Status nach Surface-Mirror-Slice (#3639): **25/25** Canon-Dateien;
-**99/99** erwartete Adapter-`SKILL.md` mit `mirrored-from-canon` Header und
-byte-parity zum Canon-Body (minus Header). `docs/skills/` bleibt SSOT.
+Status nach Surface-Mirror-Slice (#3639) und Drift-Guard (#3643): **25/25**
+Canon-Dateien; **97/97** erwartete Adapter-`SKILL.md` mit `mirrored-from-canon`
+Header und body-parity zum Canon-Body (minus Header). Verifiziert durch
+`tools/validate_skill_surface_mirror.py` (`PASS`, 97 Adapter, 3 dokumentierte
+`cdb-onboarding`-Ausnahmen). `docs/skills/` bleibt SSOT.
 
 | Skill | Canon | opencode | cursor | codex | claude | Body-Drift |
 |---|---|---|---|---|---|---|
@@ -274,7 +297,9 @@ byte-parity zum Canon-Body (minus Header). `docs/skills/` bleibt SSOT.
 Redis Plugin (routing-only), `.claude/skills/*.skill` (Alias).
 
 **Mirror-Workflow:** Aenderungen starten in `docs/skills/<name>/SKILL.md`,
-danach Adapter spiegeln (Header `mirrored-from-canon` + identischer Body).
+danach Adapter spiegeln (Header `mirrored-from-canon` + identischer Body) und
+`python tools/validate_skill_surface_mirror.py` bis `PASS` laufen lassen
+(siehe §8.1).
 
 ## Anti-Patterns
 

--- a/docs/skills/cdb-drift-reconcile/SKILL.md
+++ b/docs/skills/cdb-drift-reconcile/SKILL.md
@@ -39,6 +39,7 @@ Always check these areas unless the request explicitly narrows scope further:
 - SSOT-Grenzen between `CURRENT_STATUS.md` and `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
 - Discovery-Surfaces / EntryPoints / Cheatsheets
 - `ARCHITECTURE_MAP` / `SERVICE_CATALOG` when service changes are implicated
+- Skill Surface Mirror Drift: canon `docs/skills/<name>/SKILL.md` vs adapter surfaces `.opencode`, `.cursor`, `.codex`, `.claude`
 
 ## Workflow
 
@@ -63,6 +64,39 @@ Always check these areas unless the request explicitly narrows scope further:
    - Treat canon-boundary uncertainty as unresolved, not as clean.
    - Do not convert every drift finding into a follow-up issue or workflow change.
    - Keep Board stage separate from LR status at all times.
+
+## Skill Surface Mirror Drift
+
+Since PR #3637 the canonical skill source is `docs/skills/<name>/SKILL.md`.
+Surface adapters mirror those bodies (PR #3641). Canon edits can silently drift
+the adapters, so this drift vector has a dedicated, scriptable check.
+
+- Canon: `docs/skills/<name>/SKILL.md`
+- Adapters: `.opencode/skills/<name>/SKILL.md`, `.cursor/skills/<name>/SKILL.md`,
+  `.codex/cdb_skills/<name>/SKILL.md`, `.claude/skills/<name>/SKILL.md`
+- Check command (read-only, no writes, no network):
+
+  ```bash
+  python tools/validate_skill_surface_mirror.py          # human report
+  python tools/validate_skill_surface_mirror.py --json   # machine-readable
+  python tools/validate_skill_surface_mirror.py --skill <name>
+  ```
+
+- Result semantics and exit codes:
+  - `PASS` (exit 0): every expected adapter body matches canon (header ignored).
+  - `DRIFT_FOUND` (exit 1): an adapter body differs, or an expected adapter is missing.
+  - `BLOCKED` (exit 2): missing canon tree, unknown skill, or parse/usage error.
+- Documented exclusions (not drift): `cdb-onboarding` is codex-only alias;
+  `gh-fix-ci` keeps `META.yaml`/`evals.json`/`scripts/` canon-only (only `SKILL.md`
+  bodies are compared); `.claude/skills/*.skill` and `.gemini/skills/` are out of scope.
+
+**Fail-Closed rule:** If `docs/skills/<name>/SKILL.md` was changed in the session
+and the drift checker was not run, do not mark the session as fully complete —
+report `skill surface drift unknown`.
+
+**Follow-up rule:** On `DRIFT_FOUND`, either re-mirror the affected adapters from
+canon within the current scope, or create a deduplicated re-mirror follow-up issue
+and hand off. Never auto-merge without green required checks.
 
 ## Classification Rules
 

--- a/docs/skills/cdb-drift-reconcile/SKILL.md
+++ b/docs/skills/cdb-drift-reconcile/SKILL.md
@@ -83,8 +83,10 @@ the adapters, so this drift vector has a dedicated, scriptable check.
   ```
 
 - Result semantics and exit codes:
-  - `PASS` (exit 0): every expected adapter body matches canon (header ignored).
-  - `DRIFT_FOUND` (exit 1): an adapter body differs, or an expected adapter is missing.
+  - `PASS` (exit 0): every expected adapter matches canon in body (header ignored)
+    and carries a valid `mirrored-from-canon` surface header.
+  - `DRIFT_FOUND` (exit 1): an adapter body differs, an adapter header is missing or
+    not `mirrored-from-canon`, or an expected adapter is missing.
   - `BLOCKED` (exit 2): missing canon tree, unknown skill, or parse/usage error.
 - Documented exclusions (not drift): `cdb-onboarding` is codex-only alias;
   `gh-fix-ci` keeps `META.yaml`/`evals.json`/`scripts/` canon-only (only `SKILL.md`

--- a/tests/unit/tools/test_validate_skill_surface_mirror.py
+++ b/tests/unit/tools/test_validate_skill_surface_mirror.py
@@ -1,0 +1,242 @@
+"""Unit tests for the skill surface mirror drift guard (#3643)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools import validate_skill_surface_mirror as guard
+
+pytestmark = pytest.mark.unit
+
+
+CANON_HEADER = (
+    "<!--\n"
+    "Canonical Skill Source: docs/skills/{name}/SKILL.md\n"
+    "Surface: docs (canonical)\n"
+    "Sync Status: canonical\n"
+    "Last Verified: 2026-07-01\n"
+    "Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.\n"
+    "-->\n"
+)
+
+ADAPTER_HEADER = (
+    "<!--\n"
+    "Canonical Skill Source: docs/skills/{name}/SKILL.md\n"
+    "Surface: {surface}\n"
+    "Sync Status: mirrored-from-canon\n"
+    "Last Verified: 2026-07-01\n"
+    "Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.\n"
+    "-->\n"
+)
+
+BODY = "---\nname: {name}\n---\n\n# {name}\n\nSome skill body content.\n"
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _adapter_path(root: Path, surface: str, name: str) -> Path:
+    return root / guard.SURFACES[surface].format(name=name)
+
+
+def _make_skill(
+    root: Path,
+    name: str,
+    *,
+    surfaces: tuple[str, ...] = ("opencode", "cursor", "codex", "claude"),
+    body: str | None = None,
+    adapter_bodies: dict[str, str] | None = None,
+) -> None:
+    """Create a canon skill and its adapter mirrors in a fake repo."""
+    resolved_body = (body or BODY).format(name=name)
+    _write(
+        root / "docs" / "skills" / name / "SKILL.md",
+        CANON_HEADER.format(name=name) + resolved_body,
+    )
+    adapter_bodies = adapter_bodies or {}
+    for surface in surfaces:
+        surface_body = adapter_bodies.get(surface, resolved_body)
+        _write(
+            _adapter_path(root, surface, name),
+            ADAPTER_HEADER.format(name=name, surface=surface) + surface_body,
+        )
+
+
+# --- header / body normalization ---
+
+
+def test_strip_header_removes_leading_comment() -> None:
+    text = CANON_HEADER.format(name="x") + "body"
+    assert guard.strip_header(text) == "body"
+
+
+def test_strip_header_no_header_is_noop() -> None:
+    assert guard.strip_header("no header here") == "no header here"
+
+
+def test_normalize_body_ignores_header_and_line_endings() -> None:
+    canon = CANON_HEADER.format(name="x") + "line one\nline two\n"
+    adapter = ADAPTER_HEADER.format(name="x", surface="cursor") + "line one\r\nline two\r\n"
+    assert guard.normalize_body(canon) == guard.normalize_body(adapter)
+
+
+# --- PASS ---
+
+
+def test_pass_identical_body_different_headers(tmp_path: Path) -> None:
+    _make_skill(tmp_path, "cdb-alpha")
+    report = guard.run(tmp_path)
+    assert report["status"] == "PASS"
+    assert report["canon_count"] == 1
+    assert report["adapter_count"] == 4
+    assert report["mismatches"] == []
+    assert report["missing"] == []
+
+
+# --- DRIFT: modified adapter body ---
+
+
+def test_drift_found_on_modified_adapter_body(tmp_path: Path) -> None:
+    _make_skill(
+        tmp_path,
+        "cdb-beta",
+        adapter_bodies={"cursor": "---\nname: cdb-beta\n---\n\n# tampered\n"},
+    )
+    report = guard.run(tmp_path)
+    assert report["status"] == "DRIFT_FOUND"
+    assert len(report["mismatches"]) == 1
+    assert report["mismatches"][0]["surface"] == "cursor"
+    assert report["mismatches"][0]["skill"] == "cdb-beta"
+
+
+# --- DRIFT: missing expected adapter ---
+
+
+def test_drift_found_on_missing_expected_adapter(tmp_path: Path) -> None:
+    _make_skill(tmp_path, "cdb-gamma")
+    _adapter_path(tmp_path, "claude", "cdb-gamma").unlink()
+    report = guard.run(tmp_path)
+    assert report["status"] == "DRIFT_FOUND"
+    assert len(report["missing"]) == 1
+    assert report["missing"][0]["surface"] == "claude"
+
+
+# --- BLOCKED: missing canon tree ---
+
+
+def test_blocked_when_canon_dir_missing(tmp_path: Path) -> None:
+    with pytest.raises(guard.DriftCheckError):
+        guard.run(tmp_path)
+
+
+def test_blocked_when_no_canon_skills(tmp_path: Path) -> None:
+    (tmp_path / "docs" / "skills").mkdir(parents=True)
+    with pytest.raises(guard.DriftCheckError):
+        guard.run(tmp_path)
+
+
+def test_blocked_on_unknown_skill_filter(tmp_path: Path) -> None:
+    _make_skill(tmp_path, "cdb-alpha")
+    with pytest.raises(guard.DriftCheckError):
+        guard.run(tmp_path, skill_filter="does-not-exist")
+
+
+# --- documented exception: cdb-onboarding codex-only ---
+
+
+def test_cdb_onboarding_codex_only_is_not_drift(tmp_path: Path) -> None:
+    # Only the codex adapter exists; opencode/cursor/claude are excluded.
+    _make_skill(tmp_path, "cdb-onboarding", surfaces=("codex",))
+    report = guard.run(tmp_path, skill_filter="cdb-onboarding")
+    assert report["status"] == "PASS"
+    assert report["adapter_count"] == 1
+    excluded_surfaces = {e["surface"] for e in report["excluded"]}
+    assert excluded_surfaces == {"opencode", "cursor", "claude"}
+
+
+# --- gh-fix-ci extras must not affect comparison ---
+
+
+def test_gh_fix_ci_canon_extras_do_not_cause_drift(tmp_path: Path) -> None:
+    _make_skill(tmp_path, "gh-fix-ci")
+    # Canon-only extra artifacts alongside SKILL.md.
+    _write(tmp_path / "docs" / "skills" / "gh-fix-ci" / "META.yaml", "meta: true\n")
+    _write(tmp_path / "docs" / "skills" / "gh-fix-ci" / "evals.json", "{}\n")
+    _write(
+        tmp_path / "docs" / "skills" / "gh-fix-ci" / "scripts" / "run.sh",
+        "echo hi\n",
+    )
+    report = guard.run(tmp_path, skill_filter="gh-fix-ci")
+    assert report["status"] == "PASS"
+    assert report["mismatches"] == []
+
+
+# --- JSON / CLI contract ---
+
+
+def test_report_has_required_json_fields(tmp_path: Path) -> None:
+    _make_skill(tmp_path, "cdb-alpha")
+    report = guard.run(tmp_path)
+    for field in (
+        "status",
+        "canon_count",
+        "adapter_count",
+        "mismatches",
+        "missing",
+        "excluded",
+        "limitations",
+    ):
+        assert field in report
+
+
+def test_main_exit_code_pass(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _make_skill(tmp_path, "cdb-alpha")
+    code = guard.main(["--repo-root", str(tmp_path), "--json"])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert '"status": "PASS"' in out
+
+
+def test_main_exit_code_drift(tmp_path: Path) -> None:
+    _make_skill(
+        tmp_path,
+        "cdb-beta",
+        adapter_bodies={"codex": "---\nname: cdb-beta\n---\n\n# tampered\n"},
+    )
+    code = guard.main(["--repo-root", str(tmp_path)])
+    assert code == 1
+
+
+def test_main_exit_code_blocked(tmp_path: Path) -> None:
+    code = guard.main(["--repo-root", str(tmp_path)])
+    assert code == 2
+
+
+def test_main_blocked_json_emits_status(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code = guard.main(["--repo-root", str(tmp_path), "--json"])
+    assert code == 2
+    out = capsys.readouterr().out
+    assert '"status": "BLOCKED"' in out
+
+
+# --- real repo drift gate (runs in CI, no workflow change needed) ---
+
+
+def test_real_repo_skill_surfaces_are_in_sync() -> None:
+    """CI gate: real canon skills must match their adapters (Issue #3643).
+
+    Fails if a canon `docs/skills/<name>/SKILL.md` was changed without
+    re-mirroring the `.opencode`/`.cursor`/`.codex`/`.claude` adapters.
+    """
+    report = guard.run(guard.REPO_ROOT_DEFAULT)
+    assert report["status"] == "PASS", (
+        f"skill surface drift detected: "
+        f"mismatches={report['mismatches']} missing={report['missing']}"
+    )
+    assert report["canon_count"] >= 1

--- a/tests/unit/tools/test_validate_skill_surface_mirror.py
+++ b/tests/unit/tools/test_validate_skill_surface_mirror.py
@@ -84,6 +84,15 @@ def test_normalize_body_ignores_header_and_line_endings() -> None:
     assert guard.normalize_body(canon) == guard.normalize_body(adapter)
 
 
+def test_header_issue_detects_missing_and_valid_headers() -> None:
+    valid = ADAPTER_HEADER.format(name="cdb-alpha", surface="cursor") + "body"
+    assert guard.header_issue("cdb-alpha", valid) is None
+    assert guard.header_issue("cdb-alpha", "no header body") is not None
+    canon_hdr = CANON_HEADER.format(name="cdb-alpha") + "body"
+    # canon header lacks the mirrored-from-canon marker
+    assert guard.header_issue("cdb-alpha", canon_hdr) is not None
+
+
 # --- PASS ---
 
 
@@ -114,6 +123,30 @@ def test_drift_found_on_modified_adapter_body(tmp_path: Path) -> None:
 
 
 # --- DRIFT: missing expected adapter ---
+
+
+def test_drift_found_on_missing_adapter_header(tmp_path: Path) -> None:
+    _make_skill(tmp_path, "cdb-delta")
+    # Overwrite one adapter with the correct body but NO surface header.
+    adapter = _adapter_path(tmp_path, "opencode", "cdb-delta")
+    adapter.write_text(BODY.format(name="cdb-delta"), encoding="utf-8")
+    report = guard.run(tmp_path)
+    assert report["status"] == "DRIFT_FOUND"
+    header_mismatches = [m for m in report["mismatches"] if m.get("kind") == "header"]
+    assert len(header_mismatches) == 1
+    assert header_mismatches[0]["surface"] == "opencode"
+
+
+def test_drift_found_on_wrong_sync_status_header(tmp_path: Path) -> None:
+    _make_skill(tmp_path, "cdb-epsilon")
+    adapter = _adapter_path(tmp_path, "cursor", "cdb-epsilon")
+    wrong_header = ADAPTER_HEADER.format(name="cdb-epsilon", surface="cursor").replace(
+        "mirrored-from-canon", "canonical"
+    )
+    adapter.write_text(wrong_header + BODY.format(name="cdb-epsilon"), encoding="utf-8")
+    report = guard.run(tmp_path)
+    assert report["status"] == "DRIFT_FOUND"
+    assert any(m.get("kind") == "header" for m in report["mismatches"])
 
 
 def test_drift_found_on_missing_expected_adapter(tmp_path: Path) -> None:

--- a/tools/validate_skill_surface_mirror.py
+++ b/tools/validate_skill_surface_mirror.py
@@ -68,6 +68,10 @@ OUT_OF_SCOPE_NOTES: list[str] = [
 ]
 
 _HEADER_RE = re.compile(r"^\ufeff?\s*<!--.*?-->\s*", flags=re.DOTALL)
+_HEADER_BLOCK_RE = re.compile(r"^\ufeff?\s*<!--(.*?)-->", flags=re.DOTALL)
+
+# Adapters must declare they are mirrored from canon (Registry §7).
+MIRRORED_MARKER = "mirrored-from-canon"
 
 
 class DriftCheckError(Exception):
@@ -77,6 +81,31 @@ class DriftCheckError(Exception):
 def strip_header(text: str) -> str:
     """Remove a leading HTML-comment surface header block, if present."""
     return _HEADER_RE.sub("", text, count=1)
+
+
+def extract_header(text: str) -> str | None:
+    """Return the leading HTML-comment header block content, or None if absent."""
+    match = _HEADER_BLOCK_RE.match(text)
+    return match.group(1) if match else None
+
+
+def header_issue(skill: str, text: str) -> str | None:
+    """Return a reason string if the adapter header is missing/invalid, else None.
+
+    Enforces the Registry §7 rule that mirrored adapters must carry a
+    ``mirrored-from-canon`` surface header referencing the canonical source.
+    A body-only match is not sufficient: a lost or wrong header means the file
+    is effectively unregistered / wrongly classified.
+    """
+    header = extract_header(text)
+    if header is None:
+        return "adapter has no surface header block (expected mirrored-from-canon)"
+    if MIRRORED_MARKER not in header:
+        return f"adapter header missing '{MIRRORED_MARKER}' marker"
+    expected_source = f"docs/skills/{skill}/SKILL.md"
+    if expected_source not in header:
+        return f"adapter header does not reference canon source '{expected_source}'"
+    return None
 
 
 def normalize_body(text: str) -> str:
@@ -142,13 +171,26 @@ def check_skill(repo_root: Path, skill: str) -> dict:
             continue
 
         adapter_count += 1
-        if normalize_body(_read_text(adapter_path)) != canon_body:
+        adapter_text = _read_text(adapter_path)
+        if normalize_body(adapter_text) != canon_body:
             mismatches.append(
                 {
                     "skill": skill,
                     "surface": surface,
                     "path": rel,
+                    "kind": "body",
                     "reason": "adapter body differs from canon (header ignored)",
+                }
+            )
+        head_reason = header_issue(skill, adapter_text)
+        if head_reason is not None:
+            mismatches.append(
+                {
+                    "skill": skill,
+                    "surface": surface,
+                    "path": rel,
+                    "kind": "header",
+                    "reason": head_reason,
                 }
             )
 
@@ -220,7 +262,9 @@ def format_human(report: dict) -> str:
     lines.append(f"Mismatches ({len(mismatches)}):")
     if mismatches:
         for m in mismatches:
-            lines.append(f"  - DRIFT {m['skill']} [{m['surface']}] {m['path']}: {m['reason']}")
+            kind = m.get("kind", "")
+            tag = f"DRIFT/{kind}" if kind else "DRIFT"
+            lines.append(f"  - {tag} {m['skill']} [{m['surface']}] {m['path']}: {m['reason']}")
     else:
         lines.append("  - none")
 

--- a/tools/validate_skill_surface_mirror.py
+++ b/tools/validate_skill_surface_mirror.py
@@ -1,0 +1,312 @@
+"""Read-only drift guard for CDB skill surface mirrors.
+
+Canonical skill bodies live in ``docs/skills/<name>/SKILL.md`` (SSOT since
+PR #3637). Surface adapters mirror those bodies to:
+
+- ``.opencode/skills/<name>/SKILL.md``
+- ``.cursor/skills/<name>/SKILL.md``
+- ``.codex/cdb_skills/<name>/SKILL.md``
+- ``.claude/skills/<name>/SKILL.md``
+
+This validator compares each canon skill body against its expected adapters
+(ignoring the surface header block) and reports drift. It never modifies files
+and performs no network / GitHub / DB / MCP actions.
+
+Usage:
+    python tools/validate_skill_surface_mirror.py
+    python tools/validate_skill_surface_mirror.py --json
+    python tools/validate_skill_surface_mirror.py --skill cdb-session-close
+    python tools/validate_skill_surface_mirror.py --repo-root .
+
+Exit codes:
+    0 - PASS (no drift)
+    1 - DRIFT_FOUND (body mismatch or missing expected adapter)
+    2 - BLOCKED (missing canon tree, unknown skill, parse/usage error)
+
+Issue: #3643
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT_DEFAULT = Path(__file__).resolve().parent.parent
+
+CANON_GLOB = "docs/skills/*/SKILL.md"
+
+# Adapter surfaces and their path templates relative to the repo root.
+SURFACES: dict[str, str] = {
+    "opencode": ".opencode/skills/{name}/SKILL.md",
+    "cursor": ".cursor/skills/{name}/SKILL.md",
+    "codex": ".codex/cdb_skills/{name}/SKILL.md",
+    "claude": ".claude/skills/{name}/SKILL.md",
+}
+
+# Documented, intentional adapter exclusions (Registry §16).
+# skill -> {surface: reason}. Excluded (skill, surface) pairs are NOT drift.
+EXCLUDED_ADAPTERS: dict[str, dict[str, str]] = {
+    "cdb-onboarding": {
+        "opencode": "codex-only alias; other surfaces use `onboarding` directly",
+        "cursor": "codex-only alias; other surfaces use `onboarding` directly",
+        "claude": "codex-only alias; other surfaces use `onboarding` directly",
+    },
+}
+
+# Surfaces/paths intentionally out of scope for this mirror check.
+# Documented for transparency; not compared, not treated as drift.
+OUT_OF_SCOPE_NOTES: list[str] = [
+    "`gh-fix-ci` canon extras (META.yaml, evals.json, scripts/) are canon-only; "
+    "only SKILL.md bodies are compared.",
+    "`.claude/skills/*.skill` package/alias files are out of scope.",
+    "`.gemini/skills/` is a restricted surface; no CDB domain mirror expected.",
+    "`.codex/cdb_skills/.system/` is out of scope.",
+]
+
+_HEADER_RE = re.compile(r"^\ufeff?\s*<!--.*?-->\s*", flags=re.DOTALL)
+
+
+class DriftCheckError(Exception):
+    """Raised for BLOCKED conditions (missing canon, unknown skill, parse error)."""
+
+
+def strip_header(text: str) -> str:
+    """Remove a leading HTML-comment surface header block, if present."""
+    return _HEADER_RE.sub("", text, count=1)
+
+
+def normalize_body(text: str) -> str:
+    """Normalize a skill body for comparison.
+
+    Ignores surface-header differences and cosmetic line-ending / trailing
+    whitespace differences that are not meaningful content drift.
+    """
+    body = strip_header(text)
+    body = body.replace("\r\n", "\n").replace("\r", "\n")
+    lines = [line.rstrip() for line in body.split("\n")]
+    return "\n".join(lines).strip()
+
+
+def find_canon_skills(repo_root: Path) -> list[str]:
+    """Return sorted canon skill names discovered under docs/skills/*/SKILL.md."""
+    canon_dir = repo_root / "docs" / "skills"
+    if not canon_dir.is_dir():
+        raise DriftCheckError(f"canon directory not found: {canon_dir}")
+    names = sorted(
+        p.parent.name for p in canon_dir.glob("*/SKILL.md") if p.is_file()
+    )
+    if not names:
+        raise DriftCheckError(f"no canon skills found under {canon_dir}/*/SKILL.md")
+    return names
+
+
+def exclusion_reason(skill: str, surface: str) -> str | None:
+    """Return the documented exclusion reason for (skill, surface), or None."""
+    return EXCLUDED_ADAPTERS.get(skill, {}).get(surface)
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:  # pragma: no cover - defensive
+        raise DriftCheckError(f"cannot read {path}: {exc}") from exc
+
+
+def check_skill(repo_root: Path, skill: str) -> dict:
+    """Compare one canon skill body against its expected adapter bodies."""
+    canon_path = repo_root / "docs" / "skills" / skill / "SKILL.md"
+    if not canon_path.is_file():
+        raise DriftCheckError(f"canon file missing for skill '{skill}': {canon_path}")
+
+    canon_body = normalize_body(_read_text(canon_path))
+
+    mismatches: list[dict] = []
+    missing: list[dict] = []
+    excluded: list[dict] = []
+    adapter_count = 0
+
+    for surface, template in SURFACES.items():
+        rel = template.format(name=skill)
+        reason = exclusion_reason(skill, surface)
+        if reason is not None:
+            excluded.append({"skill": skill, "surface": surface, "reason": reason})
+            continue
+
+        adapter_path = repo_root / rel
+        if not adapter_path.is_file():
+            missing.append({"skill": skill, "surface": surface, "path": rel})
+            continue
+
+        adapter_count += 1
+        if normalize_body(_read_text(adapter_path)) != canon_body:
+            mismatches.append(
+                {
+                    "skill": skill,
+                    "surface": surface,
+                    "path": rel,
+                    "reason": "adapter body differs from canon (header ignored)",
+                }
+            )
+
+    return {
+        "skill": skill,
+        "adapter_count": adapter_count,
+        "mismatches": mismatches,
+        "missing": missing,
+        "excluded": excluded,
+    }
+
+
+def run(repo_root: Path, skill_filter: str | None = None) -> dict:
+    """Run the drift check across all canon skills (or one filtered skill)."""
+    canon_skills = find_canon_skills(repo_root)
+
+    if skill_filter is not None:
+        if skill_filter not in canon_skills:
+            raise DriftCheckError(
+                f"skill '{skill_filter}' not found in canon "
+                f"({len(canon_skills)} skills discovered)"
+            )
+        canon_skills = [skill_filter]
+
+    mismatches: list[dict] = []
+    missing: list[dict] = []
+    excluded: list[dict] = []
+    adapter_count = 0
+
+    for skill in canon_skills:
+        result = check_skill(repo_root, skill)
+        adapter_count += result["adapter_count"]
+        mismatches.extend(result["mismatches"])
+        missing.extend(result["missing"])
+        excluded.extend(result["excluded"])
+
+    limitations: list[str] = list(OUT_OF_SCOPE_NOTES)
+
+    if mismatches or missing:
+        status = "DRIFT_FOUND"
+    else:
+        status = "PASS"
+
+    return {
+        "status": status,
+        "canon_count": len(canon_skills),
+        "adapter_count": adapter_count,
+        "mismatches": mismatches,
+        "missing": missing,
+        "excluded": excluded,
+        "limitations": limitations,
+    }
+
+
+def _status_exit_code(status: str) -> int:
+    return {"PASS": 0, "DRIFT_FOUND": 1, "BLOCKED": 2}.get(status, 2)
+
+
+def format_human(report: dict) -> str:
+    """Render a human-readable report from a run() result."""
+    lines: list[str] = []
+    lines.append("CDB Skill Surface Mirror Drift Check")
+    lines.append(f"Status: {report['status']}")
+    lines.append(f"Canon skills: {report['canon_count']}")
+    lines.append(f"Adapters compared: {report['adapter_count']}")
+
+    mismatches = report.get("mismatches", [])
+    lines.append("")
+    lines.append(f"Mismatches ({len(mismatches)}):")
+    if mismatches:
+        for m in mismatches:
+            lines.append(f"  - DRIFT {m['skill']} [{m['surface']}] {m['path']}: {m['reason']}")
+    else:
+        lines.append("  - none")
+
+    missing = report.get("missing", [])
+    lines.append("")
+    lines.append(f"Missing expected adapters ({len(missing)}):")
+    if missing:
+        for m in missing:
+            lines.append(f"  - MISSING {m['skill']} [{m['surface']}] {m['path']}")
+    else:
+        lines.append("  - none")
+
+    excluded = report.get("excluded", [])
+    lines.append("")
+    lines.append(f"Documented exclusions ({len(excluded)}):")
+    if excluded:
+        for e in excluded:
+            lines.append(f"  - EXCLUDED {e['skill']} [{e['surface']}]: {e['reason']}")
+    else:
+        lines.append("  - none")
+
+    limitations = report.get("limitations", [])
+    if limitations:
+        lines.append("")
+        lines.append("Limitations / out of scope:")
+        for note in limitations:
+            lines.append(f"  - {note}")
+
+    return "\n".join(lines)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only drift guard for CDB skill surface mirrors (Issue #3643).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(REPO_ROOT_DEFAULT),
+        help="Repository root (default: repo containing this tool).",
+    )
+    parser.add_argument(
+        "--skill",
+        default=None,
+        help="Limit the check to a single canon skill name.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Emit machine-readable JSON instead of a human report.",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    repo_root = Path(args.repo_root).resolve()
+
+    try:
+        report = run(repo_root, skill_filter=args.skill)
+    except DriftCheckError as exc:
+        blocked = {
+            "status": "BLOCKED",
+            "canon_count": 0,
+            "adapter_count": 0,
+            "mismatches": [],
+            "missing": [],
+            "excluded": [],
+            "limitations": [f"blocked: {exc}"],
+        }
+        if args.as_json:
+            print(json.dumps(blocked, indent=2, ensure_ascii=False))
+        else:
+            print(format_human(blocked))
+            print(f"\nBLOCKED: {exc}", file=sys.stderr)
+        return _status_exit_code("BLOCKED")
+
+    if args.as_json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(format_human(report))
+
+    return _status_exit_code(report["status"])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #3643
Refs #3637
Refs #3640
Refs #3641

## Delivered

A testable, read-only drift guard for CDB skill surfaces so future edits to
`docs/skills/<name>/SKILL.md` cannot silently diverge from the `.opencode`,
`.cursor`, `.codex`, and `.claude` adapters.

- New tool `tools/validate_skill_surface_mirror.py` (canon-vs-adapter body parity, header-agnostic).
- New unit tests `tests/unit/tools/test_validate_skill_surface_mirror.py` (17 tests) incl. a real-repo drift gate that runs in the existing CI `pytest` step.
- Extended `docs/skills/cdb-drift-reconcile/SKILL.md` with a dedicated **Skill Surface Mirror Drift** area (command, semantics, fail-closed + follow-up rules) and re-mirrored its 4 adapters.
- Documented the hook in `docs/skills/SKILL_SURFACE_REGISTRY.md` (§8.1 + §15 done) and the skills index, and corrected the adapter count to the tool-verified `97/97`.

## Brain Evidence

- brain_source: repo-only
- brain_status: not-used
- tools_or_queries:
  - `git fetch/status/log/rev-parse/worktree`, `gh issue view 3643`, `gh pr list`
  - `python tools/validate_skill_surface_mirror.py` (+`--json`, `--skill`)
  - `python -m pytest tests/unit/tools/test_validate_skill_surface_mirror.py`
  - `python -m tools.validate_onboarding_docs`, `git diff --check`, `rg` sweeps
- records_or_results:
  - origin/main `0ef4449a`; branch `docs/3643-skills-surface-drift-hook` commit `1ae0f489`
  - drift check: PASS, canon=25, adapters=97, 3 documented `cdb-onboarding` exclusions
- repo_crosscheck:
  - `docs/skills/SKILL_SURFACE_REGISTRY.md` §16, `docs/skills/cdb-drift-reconcile/SKILL.md`
- impact_on_plan:
  - registry `99/99` was an overcount; tool proves `97/97` (24×3 + codex incl. `cdb-onboarding` alias)
- limitations:
  - no SurrealDB/MCP evidence used; repo files are authoritative for this docs/tooling scope

## Changed Files

- `tools/validate_skill_surface_mirror.py` (new)
- `tests/unit/tools/test_validate_skill_surface_mirror.py` (new)
- `docs/skills/cdb-drift-reconcile/SKILL.md` (canon body: new drift area)
- `.opencode|.cursor|.codex|.claude/.../cdb-drift-reconcile/SKILL.md` (re-mirror)
- `docs/skills/SKILL_SURFACE_REGISTRY.md`, `docs/skills/CDB.VERFUEGBARE.SKILLS_LISTE_2026-07-01.md`

## Drift-Checker Contract

- Canon: `docs/skills/<name>/SKILL.md`; adapters: `.opencode`, `.cursor`, `.codex`, `.claude`.
- Compares bodies with the surface header block stripped and line-endings normalized.
- Exit codes: `0` = PASS, `1` = DRIFT_FOUND (body mismatch or missing expected adapter), `2` = BLOCKED (missing canon tree, unknown skill, parse/usage error).
- Human report + `--json` (`status`, `canon_count`, `adapter_count`, `mismatches`, `missing`, `excluded`, `limitations`).
- Documented exclusions (not drift): `cdb-onboarding` codex-only alias; `gh-fix-ci` canon extras (`META.yaml`/`evals.json`/`scripts/`); `.claude/skills/*.skill`; `.gemini/skills/`.
- Read-only: no file writes, no network/GitHub/DB/MCP.

## Tests / Validation

- `python tools/validate_skill_surface_mirror.py` -> PASS (25 canon, 97 adapters), exit 0
- `python tools/validate_skill_surface_mirror.py --json` -> required fields present
- `pytest -q tests/unit/tools/test_validate_skill_surface_mirror.py` -> 17 passed
- `python -m tools.validate_onboarding_docs` -> OK
- `git diff --check` -> clean (only benign LF->CRLF notices)

## CI-Integration

Minimal by design: the real-repo drift gate `test_real_repo_skill_surfaces_are_in_sync`
runs inside the existing CI `pytest` step, so any canon change without adapter
re-mirror fails required checks. No new/heavy workflow was added.

## Non-goals

- No skill content changes beyond adding the drift area to `cdb-drift-reconcile`.
- No new skill; no Gemini mirror; no changes to Claude `.skill` packages.
- No runtime/Docker/DB/MCP changes; no LR/live/trading enablement.
- No Cursor rules/subagent changes.

## Safety Boundaries

- LR stays NO-GO; board stage is not a live-go. No echtgeld/live derivation.
- No productive DB writes, no MCP mutation, no BLUE/RED runtime change.
- No secrets touched. Read-only tool.

## Restunsicherheiten

- Excluded (skill, surface) pairs are skipped, so drift inside a documented
  exclusion (e.g. a hypothetical `.opencode` `cdb-onboarding`) is not compared by design.
- `.claude/skills/cdb-drift-reconcile/SKILL.md` (the mirrored `SKILL.md`) is in scope;
  the `.skill` package/alias files remain untouched.
