### PR TITLE
docs(skills): mark session-close residual intake done

### DIFF
--- a/docs/skills/SKILL_SURFACE_REGISTRY.md
+++ b/docs/skills/SKILL_SURFACE_REGISTRY.md
@@ -243,7 +243,7 @@ Nach Canon-Tree-Merge (2026-07-01):
 
 - `[SKILLS] Mirror surface adapters from docs/skills canon` — **done** (Issue #3639; 25/25 canon, 99 adapter SKILL.md synced)
 - `[SKILLS] Extend cdb-session-close with post-close follow-up issue intake` — **done** (Issue #3638)
-- `[SKILLS] Extend cdb-session-close with Residual Work / Restunsicherheits-Intake` — **in flight** (mandatory step 9; dedupe + follow-up issue path; canon + 4 mirrors)
+- `[SKILLS] Extend cdb-session-close with Residual Work / Restunsicherheits-Intake` — **done** (PR #3645; merge afd98aa3)
 - `[SKILLS] Apply Surface-Adapter-Header to all existing mirrored skills` — **done** (merged into #3639)
 - `[SKILLS] Add drift-reconcile hook for skill surface adapters` — **done** (Issue #3643; `tools/validate_skill_surface_mirror.py` + tests, `cdb-drift-reconcile` §Skill Surface Mirror Drift)
 - `[SKILLS] Add skill-meta schema (META.yaml + evals.json) for new CDB domain skills`


### PR DESCRIPTION
Refs #3645

## Delivered
- Update `docs/skills/SKILL_SURFACE_REGISTRY.md` section 15: Residual Work / Restunsicherheits-Intake slice status from **in flight** to **done**
- References PR #3645 and merge commit `afd98aa3`

## Validation
- `rg` confirms PR #3645 and `afd98aa3` on slice line; no remaining `in flight` for this slice
- `git diff -- docs/skills/SKILL_SURFACE_REGISTRY.md` — single line change, one file only
- `git diff --check` — clean

## Non-goals
- No skill content changes
- No surface mirror updates
- No broader registry refactor

## Safety Boundaries
- Docs-only change
- No runtime, Docker, DB, secrets, LR, live, or echtgeld impact

Made with [Cursor](https://cursor.com)