### PR TITLE
docs(skills): add skill-meta schema

### DIFF
--- a/docs/skills/SKILL_META_SCHEMA.md
+++ b/docs/skills/SKILL_META_SCHEMA.md
@@ -1,0 +1,149 @@
+# CDB Skill-Meta Schema v1
+
+Status: kanonischer Vertrag fuer optionale Skill-Metadaten
+Scope: neue und erweiterte CDB Domain-Skills unter `docs/skills/<name>/`
+Referenz-Implementierung: `docs/skills/gh-fix-ci/` (`META.yaml`, `evals.json`)
+
+## 1. Zweck
+
+`SKILL.md` ist der ausfuehrbare Skill-Inhalt und bleibt die kanonische
+Quelle fuer Agenten-Anweisungen. `META.yaml` und `evals.json` sind
+**optionale Metadaten** im selben Canon-Verzeichnis:
+
+| Artefakt | Rolle |
+|---|---|
+| `SKILL.md` | Ausfuehrbare Anweisungen, Workflows, Guardrails |
+| `META.yaml` | Maschinenlesbare Metadaten (Name, Version, Dateien, Invocation) |
+| `evals.json` | Manuelle oder halbautomatische Eval-Hinweise (kein CI-Runner in v1) |
+
+Surface-Adapter (`.opencode/`, `.cursor/`, `.codex/`, `.claude/`) spiegeln
+**nur `SKILL.md`**. Meta-Artefakte bleiben canon-only, ausser ein spaeterer
+expliziter Slice verlangt etwas anderes. Siehe
+[`SKILL_SURFACE_REGISTRY.md`](SKILL_SURFACE_REGISTRY.md) §8.1 und §16.
+
+## 2. Wann Meta-Artefakte nutzen
+
+Pflicht: **nein** — die meisten CDB-Skills brauchen nur `SKILL.md`.
+
+Empfohlen, wenn mindestens eines zutrifft:
+
+- Der Skill hat ein ausfuehrbares Script oder CLI-Einstieg.
+- Evals oder Smoke-Checks sollen dokumentiert werden.
+- Abhaengigkeiten (`gh`, `python`, Container) muessen maschinenlesbar sein.
+- Mehrere Maintainer oder Versionen brauchen klare Metadaten.
+
+Nicht noetig fuer reine Prompt-/Workflow-Skills ohne ausfuehrbare Artefakte.
+
+## 3. Verzeichnislayout
+
+```text
+docs/skills/<skill-name>/
+  SKILL.md          # Pflicht (kanonisch, wird gespiegelt)
+  META.yaml         # Optional (canon-only)
+  evals.json        # Optional (canon-only)
+  scripts/          # Optional (canon-only, falls Skill Scripts hat)
+```
+
+Starter-Templates: [`_templates/META.yaml`](_templates/META.yaml),
+[`_templates/evals.json`](_templates/evals.json).
+
+## 4. `META.yaml` — Pflicht- und optionale Felder
+
+### 4.1 Pflicht (v1)
+
+| Feld | Typ | Beschreibung |
+|---|---|---|
+| `skill_name` | string | Kurzname, gleich Ordnername unter `docs/skills/` |
+| `version` | string | Semver (`MAJOR.MINOR.PATCH`) |
+| `status` | string | `active`, `deprecated`, oder `draft` |
+| `description` | string (block) | Ein-Satz-Zusammenfassung des Skills |
+| `canonical_location` | string | Pfad zum Canon-Verzeichnis, z. B. `docs/skills/<name>/` |
+
+### 4.2 Empfohlen
+
+| Feld | Typ | Beschreibung |
+|---|---|---|
+| `created` | date (`YYYY-MM-DD`) | Erstanlage |
+| `last_updated` | date | Letzte inhaltliche Aenderung |
+| `maintainer` | string | Verantwortlicher Owner |
+| `files` | list[string] | Dateien im Skill-Verzeichnis (inkl. `SKILL.md`) |
+| `invocation.default` | string | Primaerer Aufruf (Befehl oder Slash) |
+| `invocation.examples` | list | Named examples mit `command` + `description` |
+| `dependencies.required` | map | Tool-Versionen (`gh`, `python`, …) |
+| `dependencies.optional` | map | Optionale Tools |
+| `safety_rules` | list[string] | Kurze Guardrails (kein Auto-Merge, kein Live-Go, …) |
+| `tags` | list[string] | Discovery-Tags |
+
+### 4.3 Optional / skill-spezifisch
+
+Weitere Abschnitte sind erlaubt (z. B. `exit_codes`, `features`, `references`,
+`changelog`), solange sie skill-spezifisch bleiben und `SKILL.md` nicht
+ersetzen. `gh-fix-ci` zeigt ein erweitertes Beispiel.
+
+### 4.4 Nicht in META.yaml
+
+- Keine Secrets, Tokens oder Pfade zu Credential-Dateien.
+- Keine LR-/Live-/Echtgeld-Freigaben.
+- Keine Duplikation des vollen Skill-Workflows aus `SKILL.md`.
+
+## 5. `evals.json` — Mindeststruktur
+
+Evals sind **Dokumentation und manuelle Pruefhinweise**, kein CI-Contract in v1.
+
+### 5.1 Top-Level
+
+| Feld | Pflicht | Beschreibung |
+|---|---|---|
+| `skill_name` | ja | Gleich `META.yaml` / Ordnername |
+| `version` | ja | Gleich `META.yaml` |
+| `evals` | ja | Liste von Eval-Eintraegen (kann leer `[]` sein fuer reine Docs-Skills) |
+
+### 5.2 Eval-Eintrag (minimal)
+
+| Feld | Pflicht | Beschreibung |
+|---|---|---|
+| `name` | ja | Kurz-ID (`snake_case`) |
+| `description` | ja | Was geprueft wird |
+
+Mindestens eines von:
+
+| Feld | Beschreibung |
+|---|---|
+| `command` | Shell-Befehl fuer manuellen Lauf |
+| `note` | Rein dokumentarischer Hinweis ohne ausfuehrbaren Befehl |
+
+Optional: `expected_exit_code`, `expected_output_contains`,
+`expected_output_json_fields`, `skip_reason`, `mock_*` Felder fuer
+dokumentierte Unit-Test-Muster (siehe `gh-fix-ci`).
+
+### 5.3 Non-goals (evals v1)
+
+- Kein automatischer Eval-Runner in CI (separater Slice noetig).
+- Keine Live-Trading- oder Produktiv-DB-Tests.
+- Keine Secrets in Commands oder erwarteten Outputs.
+
+## 6. Neuanlage-Workflow (Kurz)
+
+1. `docs/skills/<skill-name>/SKILL.md` anlegen (kanonisch).
+2. Optional: `_templates/META.yaml` und `_templates/evals.json` kopieren und
+   anpassen.
+3. Surface-Adapter-Header setzen und `SKILL.md` spiegeln (Registry §7–§8).
+4. `python tools/validate_skill_surface_mirror.py` bis `PASS`.
+5. Registry-Eintrag und `AGENTS.md`-Pointer bei Bedarf.
+
+Vollstaendiger Workflow: [`SKILL_SURFACE_REGISTRY.md`](SKILL_SURFACE_REGISTRY.md) §9.
+
+## 7. Update- und Deprecation-Regeln
+
+- `SKILL.md`-Aenderungen: Adapter re-mirroren (Drift-Guard).
+- `META.yaml` / `evals.json`: nur Canon aktualisieren; `last_updated` und
+  `version` in `META.yaml` anheben bei inhaltlicher Aenderung.
+- Bei Deprecation: `status: deprecated` in `META.yaml`, `DEPRECATION.md`
+  gemaess Registry §11.
+
+## 8. Referenzen
+
+- [`SKILL_SURFACE_REGISTRY.md`](SKILL_SURFACE_REGISTRY.md) — SSOT fuer Surfaces
+- [`gh-fix-ci/META.yaml`](gh-fix-ci/META.yaml) — erweiterte Referenz
+- [`gh-fix-ci/evals.json`](gh-fix-ci/evals.json) — erweiterte Eval-Referenz
+- [`cdb-drift-reconcile/SKILL.md`](cdb-drift-reconcile/SKILL.md) — Mirror-Drift

--- a/docs/skills/SKILL_SURFACE_REGISTRY.md
+++ b/docs/skills/SKILL_SURFACE_REGISTRY.md
@@ -158,7 +158,11 @@ python tools/validate_skill_surface_mirror.py --skill <name>
 ## 9. Skill-Neuanlage-Workflow
 
 1. Skill-Inhalt in `docs/skills/<skill-name>/SKILL.md` anlegen.
-2. Optional `META.yaml` und `evals.json` (nur fuer CDB, falls Pruefung noetig).
+2. Optional `META.yaml` und `evals.json` (nur fuer CDB, falls Pruefung noetig):
+   Vertrag: [`SKILL_META_SCHEMA.md`](SKILL_META_SCHEMA.md);
+   Starter: [`_templates/META.yaml`](_templates/META.yaml),
+   [`_templates/evals.json`](_templates/evals.json).
+   Meta-Artefakte bleiben canon-only (Adapter spiegeln nur `SKILL.md`).
 3. Surface-Adapter-Header (Abschnitt 7) in der kanonischen Datei setzen.
 4. Mirror auf alle aktiven Surfaces (Abschnitt 4).
 5. `.claude/skills/cdb-<name>.skill` Index anlegen, falls Claude relevant.
@@ -246,7 +250,7 @@ Nach Canon-Tree-Merge (2026-07-01):
 - `[SKILLS] Extend cdb-session-close with Residual Work / Restunsicherheits-Intake` — **done** (PR #3645; merge afd98aa3)
 - `[SKILLS] Apply Surface-Adapter-Header to all existing mirrored skills` — **done** (merged into #3639)
 - `[SKILLS] Add drift-reconcile hook for skill surface adapters` — **done** (Issue #3643; `tools/validate_skill_surface_mirror.py` + tests, `cdb-drift-reconcile` §Skill Surface Mirror Drift)
-- `[SKILLS] Add skill-meta schema (META.yaml + evals.json) for new CDB domain skills`
+- `[SKILLS] Add skill-meta schema (META.yaml + evals.json) for new CDB domain skills` — **in flight** (pending merge finalization)
 - `[SKILLS] Document `.gemini/` activation policy if domain skills are ever needed`
 
 Diese Issues werden dedupliziert und mit klarem Scope angelegt.

--- a/docs/skills/_templates/META.yaml
+++ b/docs/skills/_templates/META.yaml
@@ -1,0 +1,42 @@
+---
+# CDB Skill-Meta template v1 — copy to docs/skills/<skill-name>/META.yaml
+# Contract: docs/skills/SKILL_META_SCHEMA.md
+
+skill_name: <skill-name>
+version: 0.1.0
+created: YYYY-MM-DD
+last_updated: YYYY-MM-DD
+status: draft  # active | deprecated | draft
+
+description: |
+  One-sentence summary of what this CDB domain skill does.
+
+maintainer: jannekbuengener
+
+canonical_location: docs/skills/<skill-name>/
+
+dependencies:
+  required:
+    python: ">=3.12"
+  optional: {}
+
+files:
+  - SKILL.md
+  # - META.yaml
+  # - evals.json
+  # - scripts/example.py
+
+invocation:
+  default: "<primary command or slash invocation>"
+  examples:
+    - command: "<example command>"
+      description: "<what this example demonstrates>"
+
+safety_rules:
+  - "No live trading or echtgeld actions without explicit human gate."
+  - "LR remains NO-GO unless canon explicitly changes."
+  - "No secrets in skill files, issues, or PRs."
+
+tags:
+  - cdb
+  - <domain-tag>

--- a/docs/skills/_templates/evals.json
+++ b/docs/skills/_templates/evals.json
@@ -1,0 +1,28 @@
+{
+  "skill_name": "<skill-name>",
+  "version": "0.1.0",
+  "evals": [
+    {
+      "name": "smoke_read_skill",
+      "description": "Canon SKILL.md exists and is readable",
+      "note": "Manual: open docs/skills/<skill-name>/SKILL.md and verify required sections."
+    },
+    {
+      "name": "optional_command_smoke",
+      "description": "Primary invocation runs without tool/auth errors",
+      "command": "<replace with skill default command>",
+      "expected_exit_code": 0,
+      "note": "Replace or remove before marking skill active."
+    }
+  ],
+  "test_instructions": {
+    "setup": [
+      "Read docs/skills/SKILL_META_SCHEMA.md for eval contract limits.",
+      "Ensure required tools from META.yaml are available."
+    ],
+    "run_evals": [
+      "Run each eval command manually or document skip_reason if not applicable.",
+      "Do not add CI integration in the skill-meta v1 slice."
+    ]
+  }
+}


### PR DESCRIPTION
Closes #3647

## Delivered

- `docs/skills/SKILL_META_SCHEMA.md` — v1 contract for optional `META.yaml` + `evals.json`
- `docs/skills/_templates/META.yaml` — minimal copy-ready template
- `docs/skills/_templates/evals.json` — minimal eval template
- `docs/skills/SKILL_SURFACE_REGISTRY.md` — §9 schema/template references; §15 marked **in flight** (pending merge finalization)

## Brain Evidence

- brain_source: repo-only
- brain_status: not-used
- tools_or_queries:
  - `git fetch/status`, branch `docs/skill-meta-schema-v1` from `origin/main`
  - `gh issue create` → #3647 (dedupe: no prior open skill-meta issue)
  - `python tools/validate_skill_surface_mirror.py`
  - `python -m tools.validate_onboarding_docs`
  - `pytest -q tests/unit/tools/test_validate_skill_surface_mirror.py`
- records_or_results:
  - PR #3645 MERGED @ afd98aa3; PR #3646 MERGED @ 7111635d
  - drift guard PASS (25 canon, 97 adapters)
- repo_crosscheck:
  - `docs/skills/gh-fix-ci/META.yaml`, `evals.json` as reference
  - `docs/skills/SKILL_SURFACE_REGISTRY.md` §9/§15
- impact_on_plan:
  - `cdb-docs-ops` cross-link omitted to avoid mirror drift without adapter sync
- limitations:
  - no SurrealDB/MCP evidence; Registry §15 `done` + merge SHA deferred to follow-up

## Validation

- `python tools/validate_skill_surface_mirror.py` → PASS
- `python -m tools.validate_onboarding_docs` → OK
- `pytest -q tests/unit/tools/test_validate_skill_surface_mirror.py` → 20 passed
- `git diff --check` → clean on staged docs slice

## Non-goals

- No existing skill body rewrites
- No mirror-surface adapter changes
- No Gemini policy slice
- No runtime/CI eval executor
- No `CURRENT_STATUS.md` or session log in this PR

## Safety Boundaries

- Docs/templates only
- LR NO-GO; board `trade-capable` is not live-go
- No Docker/runtime/DB/MCP/secrets changes

## Remaining uncertainty

- Registry §15 still **in flight** until mini follow-up sets **done** with merge SHA
- Evals remain manual/documentation-only in v1 (no CI hook)

## Follow-up

- After merge: deduplicated mini-slice to flip Registry §15 `in flight` → `done` with merge SHA
- Separate: #3631 control reconcile; CURRENT_STATUS skill-wave ledger; Gemini activation policy
