### PR TITLE
C3 (#3661): finalize self-hosted runner status in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ Coverage target: 80% on `core/` and `services/` (enforced by `make test-coverage
 - `policy-gate` categorizes PRs; core/service PRs need label `allow-core-change` or `manual-approval`
 - `strict: true` — branch must be up-to-date with main before merge
 - Bot review threads (Sourcery, Copilot) must be resolved before merge
-- Runner: self-hosted `[self-hosted, cdb]` for `ci.yml`; labels defined in `infrastructure/actions-runner/`
+- Runner: `ci.yml` runs on `ubuntu-latest` (GitHub-hosted); self-hosted runners decommissioned from active CI per #3575; historical labels defined in `infrastructure/actions-runner/`
 
 ### Key Governance Files
 

--- a/docs/env/index.md
+++ b/docs/env/index.md
@@ -41,8 +41,9 @@ Canon-Pointer:
   - [`infrastructure/scripts/manage_secrets.ps1`](../../infrastructure/scripts/manage_secrets.ps1)
   - [`infrastructure/scripts/init-secrets.ps1`](../../infrastructure/scripts/init-secrets.ps1)
   - [`infrastructure/scripts/check_env.ps1`](../../infrastructure/scripts/check_env.ps1)
-- Self-hosted Runner Env:
-  - [`infrastructure/actions-runner/.env.runner.example`](../../infrastructure/actions-runner/.env.runner.example)
+- Self-hosted Runner Env (decommissioned from active CI per #3575, historical):
+  - [`infrastructure/actions-runner/README.md`](../../infrastructure/actions-runner/README.md) — decommissioned status
+  - [`infrastructure/actions-runner/.env.runner.example`](../../infrastructure/actions-runner/.env.runner.example) — local-only reference
   - `RUNNER_TOKEN` is bootstrap-only / registration-only; keep `.env.runner*`
     local-only and out of commits, logs, screenshots, and Docker build context
   - Do not inherit a foreign/global `COMPOSE_PROJECT_NAME` when launching runner compose files


### PR DESCRIPTION
Closes #3661 (C3)

## Changes
- `docs/env/index.md`: mark Self-hosted Runner Env section as decommissioned (per #3575), add pointer to `infrastructure/actions-runner/README.md`
- `CLAUDE.md`: correct runner claim from `[self-hosted, cdb]` to `ubuntu-latest` (GitHub-hosted), note decommissioned status

## Scope
Docs-only. No workflow, runner config, or infrastructure changes.

## Pre-existing (documented, not resolved)
- CodeQL Python SARIF conflict, Docs Hub Guard audit.log tracking

## Related
- #3654 (parent issue, C3 completed)
- #3660 (C2 merged)
- #3659 (C1 merged)
- #3575 (original decommission)
