### PR TITLE
fix(contracts): allow nullable metrics + document evidence fields in profitability_evidence_packet.v1

### DIFF
--- a/docs/contracts/profitability_evidence_packet.v1.schema.json
+++ b/docs/contracts/profitability_evidence_packet.v1.schema.json
@@ -89,8 +89,16 @@
       "minimum": 0.0
     },
     "profit_factor": {
-      "type": "number",
-      "minimum": 0.0
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number",
+          "minimum": 0.0
+        }
+      ],
+      "description": "null means the metric could not be reliably computed from the evidence (evidence gap); null is not 0.0 and not a positive result."
     },
     "expectancy": {
       "type": "number"
@@ -101,16 +109,40 @@
       "maximum": 1.0
     },
     "avg_win": {
-      "type": "number",
-      "minimum": 0.0
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number",
+          "minimum": 0.0
+        }
+      ],
+      "description": "null means the metric could not be reliably computed from the evidence (evidence gap); null is not 0.0 and not a positive result."
     },
     "avg_loss": {
-      "type": "number",
-      "minimum": 0.0
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number",
+          "minimum": 0.0
+        }
+      ],
+      "description": "null means the metric could not be reliably computed from the evidence (evidence gap); null is not 0.0 and not a positive result."
     },
     "max_drawdown": {
-      "type": "number",
-      "minimum": 0.0
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number",
+          "minimum": 0.0
+        }
+      ],
+      "description": "null means the metric could not be reliably computed from the evidence (evidence gap); null is not 0.0 and not a positive result."
     },
     "loss_streak": {
       "type": "integer",
@@ -387,6 +419,54 @@
           "maxLength": 1000
         }
       }
+    },
+    "evidence_class": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120,
+      "description": "Advisory evidence classification (e.g. controlled_lab_evidence). Descriptive metadata; authorizes nothing."
+    },
+    "lr_status": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 40,
+      "description": "Live-Readiness verdict recorded with the packet (e.g. NO-GO). Descriptive only; never a Live/Echtgeld authorization."
+    },
+    "board_stage": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 60,
+      "description": "Control-board stage recorded with the packet (e.g. trade-capable). Orthogonal to LR; authorizes no live capital."
+    },
+    "board_stage_note": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000,
+      "description": "Free-text clarification of board_stage semantics."
+    },
+    "sample_size_verdict": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 60,
+      "description": "Advisory sample-size assessment for the packet's aggregate evidence."
+    },
+    "sample_size_note": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000,
+      "description": "Free-text clarification of the sample_size_verdict."
+    },
+    "parent_issue": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 40,
+      "description": "Traceability reference to the parent GitHub issue (e.g. #3032)."
+    },
+    "child_issue": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 40,
+      "description": "Traceability reference to a follow-up GitHub issue (e.g. #3152)."
     }
   }
 }

--- a/docs/evidence/profitability_evidence_packet_primary_breakout_v1_mexc_multi_window_3032.json
+++ b/docs/evidence/profitability_evidence_packet_primary_breakout_v1_mexc_multi_window_3032.json
@@ -283,6 +283,12 @@
     "No Live-Go, no Echtgeld-Go, LR remains NO-GO.",
     "public.candles_1m has no source/venue column; MEXC attribution for this BTCUSDT series is inherited from prior same-venue evidence and runtime canon, not from per-row DB labels."
   ],
+  "safety_boundaries": [
+    "LR remains NO-GO; no Live-Go and no Echtgeld-Go.",
+    "Controlled-lab evidence only; no runtime, config, or strategy change.",
+    "PARK is a research hold; not a promotion, not paper-ready, not live-ready.",
+    "This packet authorizes no candidate promotion and no capital allocation."
+  ],
   "evidence_class": "controlled_lab_evidence",
   "lr_status": "NO-GO",
   "board_stage": "trade-capable",

--- a/scripts/profitability/build_mexc_multi_window_evidence_3032.py
+++ b/scripts/profitability/build_mexc_multi_window_evidence_3032.py
@@ -1051,6 +1051,12 @@ def build_evidence_packet_json(
             "No Live-Go, no Echtgeld-Go, LR remains NO-GO.",
             "public.candles_1m has no source/venue column; MEXC attribution for this BTCUSDT series is inherited from prior same-venue evidence and runtime canon, not from per-row DB labels.",
         ],
+        "safety_boundaries": [
+            "LR remains NO-GO; no Live-Go and no Echtgeld-Go.",
+            "Controlled-lab evidence only; no runtime, config, or strategy change.",
+            "PARK is a research hold; not a promotion, not paper-ready, not live-ready.",
+            "This packet authorizes no candidate promotion and no capital allocation.",
+        ],
         "evidence_class": EVIDENCE_CLASS,
         "lr_status": LR_STATUS,
         "board_stage": BOARD_STAGE,

--- a/tests/unit/validation/test_profitability_league_scorer.py
+++ b/tests/unit/validation/test_profitability_league_scorer.py
@@ -12,7 +12,10 @@ from services.validation.profitability_league_scorer import (
     FORMULA_REF,
     ProfitabilityLeagueScorerError,
     _DIMENSION_ORDER,
+    _PACKET_SCHEMA_PATH,
     _WEIGHTS,
+    _read_pep_file,
+    _validate_against_schema,
     _validate_report,
     build_league_table_report,
     hard_gate_failures,
@@ -20,6 +23,14 @@ from services.validation.profitability_league_scorer import (
     score_candidate,
     score_net_economics,
     score_safety_status,
+)
+
+# Canonical, repo-backed worked example named in Formula v1 (#3682) and #3686.
+CANONICAL_PEP_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "docs"
+    / "evidence"
+    / "profitability_evidence_packet_primary_breakout_v1_mexc_multi_window_3032.json"
 )
 
 # ===========================================================================
@@ -310,6 +321,81 @@ def test_non_finite_numeric_inputs_fail_closed() -> None:
     inf_result = score_candidate(inf_pep)
     assert inf_result.sentinel_mode is True
     assert inf_result.ranking_ready is False
+
+
+# --------------------------------------------------------------------------- #
+# Contract alignment (#3686): nullable metrics + canonical worked example
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_canonical_pep_with_null_metrics_is_schema_valid_and_sentinel() -> None:
+    # #3686: the canonical worked example sets profit_factor/avg_win/avg_loss/
+    # max_drawdown to null. It MUST validate against the PEP schema (i.e. run
+    # through the scorer WITHOUT --no-validate-input) and, because
+    # replay_vs_paper_status=not_run, resolve fail-closed to the sentinel case.
+    pep = _read_pep_file(CANONICAL_PEP_PATH, validate=True)  # must not raise
+
+    assert pep["profit_factor"] is None
+    assert pep["avg_win"] is None
+    assert pep["avg_loss"] is None
+    assert pep["max_drawdown"] is None
+
+    result = score_candidate(pep)
+    assert result.sentinel_mode is True
+    assert result.ranking_ready is False
+    assert result.total_score == 0.0
+    assert all(dim.score == 0.0 for dim in result.dimension_scores)
+
+
+@pytest.mark.unit
+def test_pep_schema_allows_null_metrics_but_rejects_non_number() -> None:
+    # null is an evidence gap (metric not reliably computable) — allowed.
+    # A non-null, non-number value stays fail-closed (rejected).
+    base = _ranking_ready_pep()
+
+    for field in ("profit_factor", "avg_win", "avg_loss", "max_drawdown"):
+        ok = copy.deepcopy(base)
+        ok[field] = None
+        _validate_against_schema(  # must not raise
+            ok, schema_path=_PACKET_SCHEMA_PATH, artifact_role=f"pep-null-{field}"
+        )
+
+        bad = copy.deepcopy(base)
+        bad[field] = "not-a-number"
+        with pytest.raises(ProfitabilityLeagueScorerError):
+            _validate_against_schema(
+                bad, schema_path=_PACKET_SCHEMA_PATH, artifact_role=f"pep-bad-{field}"
+            )
+
+
+@pytest.mark.unit
+def test_pep_schema_documents_canonical_evidence_fields() -> None:
+    # The canonical packet carries advisory evidence/governance/traceability
+    # fields; the schema must accept them under additionalProperties=false.
+    base = _ranking_ready_pep()
+    base.update(
+        {
+            "evidence_class": "controlled_lab_evidence",
+            "lr_status": "NO-GO",
+            "board_stage": "trade-capable",
+            "board_stage_note": "Board stage is orthogonal to LR.",
+            "sample_size_verdict": "pass",
+            "sample_size_note": "Multi-window sample threshold reached.",
+            "parent_issue": "#3032",
+            "child_issue": "#3152",
+        }
+    )
+    _validate_against_schema(  # must not raise
+        base, schema_path=_PACKET_SCHEMA_PATH, artifact_role="pep-evidence-fields"
+    )
+
+    unknown = copy.deepcopy(base)
+    unknown["totally_unexpected_field"] = "x"
+    with pytest.raises(ProfitabilityLeagueScorerError):
+        _validate_against_schema(
+            unknown, schema_path=_PACKET_SCHEMA_PATH, artifact_role="pep-unknown"
+        )
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Aligns `profitability_evidence_packet.v1` with the canonical, repo-backed worked
example, Formula v1, and the offline Strategy League scorer, so the scorer can
validate the documented worked example **without** `--no-validate-input`.

Ground-truth before the fix: the canonical packet had **6** schema errors in 3
classes (4 null metrics, missing required `safety_boundaries`, 8 undocumented
fields) — not just the null metrics named in #3686.

## Changes

- **Nullable metrics**: `profit_factor`, `avg_win`, `avg_loss`, `max_drawdown`
  become `oneOf [null, number]`. `null` = metric not reliably computable
  (evidence gap); it is **not** 0.0 and **not** a positive result.
- **Documented evidence fields**: added `evidence_class`, `lr_status`,
  `board_stage`, `board_stage_note`, `sample_size_verdict`, `sample_size_note`,
  `parent_issue`, `child_issue` as optional properties. `additionalProperties`
  stays `false` (unknown fields still rejected).
- **safety_boundaries**: added the required field to the canonical packet and to
  its generator (`scripts/profitability/build_mexc_multi_window_evidence_3032.py`)
  so a rebuild reproduces a schema-valid artifact.
- **Tests**: canonical PEP now validates and resolves fail-closed to the sentinel
  case (`replay_vs_paper_status=not_run`); null metrics accepted while non-number
  values stay rejected; documented evidence fields accepted, unknown fields
  rejected.

## Validation

- jsonschema: canonical packet **0 errors**; existing
  `profitability_evidence_packet_valid.json` stays valid (superset change).
- `pytest tests/unit/validation/test_profitability_league_scorer.py
  tests/unit/validation/test_profitability_evidence_packet_assembler.py
  tests/unit/contracts/test_contracts.py` -> all pass.
- `ruff check` + `black --check` clean; `git diff --check` clean.

## Non-goals / Safety

- Contract + evidence-completeness change only. No runtime, no DB/secrets
  mutation, no promotion, no capital allocation.
- LR remains **NO-GO**. Nullable metrics are evidence gaps, not positive scores.

## Remaining uncertainty

- The 8 documented fields are typed as bounded strings (not enums) to avoid
  over-constraining; tightening to enums (e.g. `lr_status`, `board_stage`) can be
  a later contract slice if desired.

Closes #3686
