### PR TITLE
[SECURITY] Bump Prometheus to v3.13.0 for CVE batch #3692-3701

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -39,7 +39,7 @@ jobs:
             scan_name: redis
           - image: postgres:18.4-alpine@sha256:1b1689b20d16a014a3d195653381cf2caa75a41a92d93b255a9d6ea29fd353aa
             scan_name: postgres
-          - image: prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
+          - image: prom/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
             scan_name: prometheus
           - image: grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084
             scan_name: grafana

--- a/docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3692-3701_2026-07-03.md
+++ b/docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3692-3701_2026-07-03.md
@@ -1,0 +1,101 @@
+# Security Batch Matrix — Issues #3692–#3701 / CVE-2026-27145 + CVE-2026-39827/28/29
+
+**Stand:** 2026-07-03 (UTC)  
+**Parent epic:** [#2289](https://github.com/jannekbuengener/Claire_de_Binare/issues/2289)  
+**Related trackers:** [#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513), [#2933](https://github.com/jannekbuengener/Claire_de_Binare/issues/2933)  
+**Branch:** `fix/3692-prometheus-v3.13.0`  
+**Scope guard:** Image-pin bump only. Kein LR-Go, keine Alert-Dismissals, keine Grafana/Postgres/Redis-Änderung.
+
+---
+
+## Executive summary
+
+| Gruppe | Issues | CVEs | Package / Layer | Vulnerable pin | Target pin | Verdict |
+|--------|--------|------|-----------------|----------------|------------|---------|
+| Prometheus / promtool | #3692–#3701 (8) | CVE-2026-27145, CVE-2026-39827, CVE-2026-39828, CVE-2026-39829 | Go stdlib + `golang.org/x/crypto` in `bin/prometheus`, `bin/promtool` | `prom/prometheus:v3.12.0@sha256:69f524…` | `v3.13.0@sha256:c6b27ea…` | **FIXABLE_NOW** |
+
+**Out of scope (separate upstream-blocked tracking under #2933):** #3694 (gosu/postgres), #3695 (Grafana bundled elasticsearch plugin).
+
+---
+
+## Batch matrix
+
+| Issue | Component | Fingerprint | CVE | Verdict |
+|-------|-----------|-------------|-----|---------|
+| [#3692](https://github.com/jannekbuengener/Claire_de_Binare/issues/3692) | `bin/prometheus` | `015cd9342c37aed6` | CVE-2026-27145 | FIXED_BY_PIN |
+| [#3693](https://github.com/jannekbuengener/Claire_de_Binare/issues/3693) | `bin/promtool` | `d5a63d2033384ecd` | CVE-2026-27145 | FIXED_BY_PIN |
+| [#3696](https://github.com/jannekbuengener/Claire_de_Binare/issues/3696) | `bin/prometheus` | `666cca4c30cf10ac` | CVE-2026-39827 | FIXED_BY_PIN |
+| [#3697](https://github.com/jannekbuengener/Claire_de_Binare/issues/3697) | `bin/promtool` | `1019d04986b6c3f8` | CVE-2026-39827 | FIXED_BY_PIN |
+| [#3698](https://github.com/jannekbuengener/Claire_de_Binare/issues/3698) | `bin/prometheus` | `a3048f2b8c69923e` | CVE-2026-39828 | FIXED_BY_PIN |
+| [#3699](https://github.com/jannekbuengener/Claire_de_Binare/issues/3699) | `bin/promtool` | `8061de20942c9469` | CVE-2026-39828 | FIXED_BY_PIN |
+| [#3700](https://github.com/jannekbuengener/Claire_de_Binare/issues/3700) | `bin/prometheus` | `94426d7b1c253c5e` | CVE-2026-39829 | FIXED_BY_PIN |
+| [#3701](https://github.com/jannekbuengener/Claire_de_Binare/issues/3701) | `bin/promtool` | `52ea2da1064f885a` | CVE-2026-39829 | FIXED_BY_PIN |
+
+Readout source: Security Alert Readout `2026-07-03T07:24:19Z`.
+
+---
+
+## Root-cause / fixability evidence
+
+### CVE-2026-27145 (Go stdlib `crypto/x509` DoS)
+
+| Probe | Result |
+|-------|--------|
+| Vulnerable pin `v3.12.0@69f524…` | stdlib **v1.26.3** in prometheus + promtool; FixedVersion **1.25.11, 1.26.4** |
+| Target pin `v3.13.0@c6b27ea…` | **0 hits** for CVE-2026-27145 |
+
+### CVE-2026-39827 / CVE-2026-39828 / CVE-2026-39829 (`golang.org/x/crypto`)
+
+| Probe | Result |
+|-------|--------|
+| Vulnerable pin `v3.12.0@69f524…` | `golang.org/x/crypto` **v0.51.0**; FixedVersion **0.52.0** in prometheus + promtool |
+| Target pin `v3.13.0@c6b27ea…` | **0 hits** for all three CVEs |
+
+### Trivy local rescan (0.72.0, 2026-07-03)
+
+```text
+trivy image prom/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+→ HIGH/CRITICAL total: 0
+→ Target CVEs (27145, 39827, 39828, 39829): absent
+```
+
+**Conclusion:** `UPSTREAM_BLOCKED` **rejected** — scan-verified upstream release clears all eight alert fingerprints via single digest pin.
+
+---
+
+## Changed files (this slice)
+
+| File | Change |
+|------|--------|
+| `infrastructure/compose/compose.red.yml` | Prometheus image → v3.13.0 |
+| `infrastructure/compose/base.yml` | Prometheus image → v3.13.0 |
+| `.github/workflows/security-scan.yml` | `trivy-scan-base` prometheus matrix → v3.13.0 |
+| `infrastructure/compose/compose.prometheus-v3.yml` | Canary comment + image aligned |
+| `knowledge/governance/SERVICE_CATALOG.md` | Prometheus catalog line aligned |
+
+**Not changed:** Grafana, Redis, Postgres pins; no runtime recreate; no alert dismissals.
+
+---
+
+## Post-merge verification
+
+Code Scanning alerts for fingerprints `015cd9342c37aed6` … `52ea2da1064f885a` close after next successful `security-scan.yml` SARIF upload on `main` with updated matrix pin. No manual dismissals.
+
+---
+
+## Safety boundaries
+
+- No alert dismissals without separate Human-GO.
+- No LR / live-readiness / Echtgeld implication.
+- #3694 / #3695 remain **UPSTREAM_BLOCKED** under [#2933](https://github.com/jannekbuengener/Claire_de_Binare/issues/2933).
+
+---
+
+## Validation commands
+
+```bash
+git diff --check
+rg 69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
+rg c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+trivy image prom/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+```

--- a/docs/runbooks/CONTROL_REGISTER.md
+++ b/docs/runbooks/CONTROL_REGISTER.md
@@ -1,6 +1,6 @@
 # Control Register
 
-**Letzte Aktualisierung:** 2026-07-01
+**Letzte Aktualisierung:** 2026-07-03
 **SSOT Live-Readiness:** `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
 **Verdict:** NO-GO
 **Control-Board Stage:** `trade-capable` (ratifiziert 2026-04-08 via Issue `#1492`)
@@ -173,6 +173,7 @@ Kontext-Issue-Nummern sind historische Anker (alle CLOSED) — nicht als offene 
 - Self-hosted runner docs (PR #3666, gemergt 2026-07-01T23:00:28Z, Commit `030fc8eb`, Issue #3661): Runner-Doku auf decommissioned-Status finalisiert; Merge-Gate laeuft auf `ubuntu-latest` (#3405). Kein LR-/Live-/Echtgeld-Signal.
 - `docs-hub-guard.yml` / artifact hygiene (PR #3668, gemergt 2026-07-01T23:07:48Z, Commit `0eae84ac`, Issue #3667): Vier tracked generierte `artifacts/**/audit.log` entfernt; `.gitignore` gehaertet; Guard auf `main` gruen. Kein LR-/Live-/Echtgeld-Signal.
 - `codeql-python.yml` (PR #3673, gemergt 2026-07-01T23:22:26Z, Commit `c961c30e`, Issue #3670): **Aktuelle Posture** — GitHub CodeQL Default Setup ist autoritativ fuer Code-Scanning-Alerts; Advanced-Workflow behaelt `security-and-quality`-Queries und `config-file`, setzt aber `upload: false` im analyze-Step (kein SARIF-Upload solange Default Setup aktiv). Non-required Check `Analyze Python` gruen auf `main`. Option B (Trigger-Reduktion auf `workflow_dispatch`-only) bewusst **Later**. Register-Detail in `GITHUB_WORKFLOW_REGISTER.md` (#3672). Kein LR-/Live-/Echtgeld-Signal.
+- `security-scan.yml` (PR TBD, Slice 2026-07-03): CVE-2026-27145 + CVE-2026-39827/28/29 — Prometheus/Promtool Image-Bump `prom/prometheus:v3.12.0@sha256:69f524…` → `v3.13.0@sha256:c6b27ea…` in `trivy-scan-base`-Matrix, `base.yml`, `compose.red.yml`, `compose.prometheus-v3.yml` und `SERVICE_CATALOG.md`. Closes #3692, #3693, #3696–#3701. Trivy local: 0 HIGH/CRITICAL auf Ziel-Digest. Evidence: `docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3692-3701_2026-07-03.md`. #3694/#3695 bleiben upstream-blocked unter #2933. Kein LR-/Live-/Echtgeld-Signal.
 
 ---
 

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -56,7 +56,7 @@ services:
       - cdb_network
 
   cdb_prometheus:
-    image: prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
+    image: prom/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
     container_name: cdb_prometheus
     restart: unless-stopped
     volumes:

--- a/infrastructure/compose/compose.prometheus-v3.yml
+++ b/infrastructure/compose/compose.prometheus-v3.yml
@@ -4,11 +4,11 @@
 #
 # Scope:
 # - Adds an optional parallel Prometheus v3 canary service
-# - Does not change default runtime service cdb_prometheus (v3.12.0)
+# - Does not change default runtime service cdb_prometheus (v3.13.0)
 
 services:
   cdb_prometheus_v3:
-    image: prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
+    image: prom/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
     container_name: cdb_prometheus_v3
     restart: unless-stopped
     profiles:

--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -93,7 +93,7 @@ services:
   # ==================== MONITORING ====================
 
   cdb_prometheus:
-    image: prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
+    image: prom/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
     container_name: cdb_prometheus
     restart: unless-stopped
     volumes:

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -122,7 +122,7 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 
 | Service | Container | Image | Port | Status | Funktion |
 |---------|-----------|-------|------|--------|----------|
-| **Prometheus** | cdb_prometheus | prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac | 19090→9090 | **AKTIV** | Metrics Collection |
+| **Prometheus** | cdb_prometheus | prom/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7 | 19090→9090 | **AKTIV** | Metrics Collection |
 | **Grafana** | cdb_grafana | grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084 | 3000 | **AKTIV** | Dashboards |
 | **Postgres Exporter** | cdb_postgres_exporter | prometheuscommunity/postgres-exporter | 9187 | **AKTIV** | PG Metrics; DSN-Wiring ueber `postgres_password` Secret + `PGPASSWORD`, `DATA_SOURCE_NAME` wird zur Laufzeit aus `POSTGRES_USER`/`POSTGRES_DB` und Host/Port zusammengesetzt |
 | **Redis Exporter** | cdb_redis_exporter | bitnami/redis-exporter | 9121 | **AKTIV** | Redis Metrics |


### PR DESCRIPTION
## Summary

Bump `prom/prometheus` from `v3.12.0@sha256:69f524…` to scan-verified `v3.13.0@sha256:c6b27ea…` to clear eight HIGH Code Scanning alerts (Prometheus + Promtool) for CVE-2026-27145 and CVE-2026-39827/28/29.

## Delivered

- `infrastructure/compose/compose.red.yml` — runtime Prometheus pin
- `infrastructure/compose/base.yml` — base compose pin
- `.github/workflows/security-scan.yml` — `trivy-scan-base` matrix pin
- `infrastructure/compose/compose.prometheus-v3.yml` — canary comment + image aligned
- `knowledge/governance/SERVICE_CATALOG.md` — catalog line aligned
- `docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3692-3701_2026-07-03.md` — evidence matrix
- `docs/runbooks/CONTROL_REGISTER.md` — control ledger entry

## Validation

- `git diff --check` — clean
- Old digest `69f524…` remains only in historical evidence docs (`CDB_SECURITY_BATCH_MATRIX_3626-3628…`)
- New digest present in all operational pin surfaces
- Trivy 0.72.0 local on target image: **0 HIGH/CRITICAL**, target CVEs **absent**

## Non-goals

- No Grafana bump (#3695 upstream-blocked)
- No Postgres/Redis/gosu changes (#3694 upstream-blocked)
- No alert dismissals, no runtime recreate, no LR/live/echtgeld implication

## Remaining uncertainty

- Code Scanning alert auto-close depends on post-merge `security-scan.yml` SARIF upload on `main`

Closes #3692
Closes #3693
Closes #3696
Closes #3697
Closes #3698
Closes #3699
Closes #3700
Closes #3701

Refs #2289
Refs #2513
Refs #2933
