### PR TITLE
[LR-050] Define canonical receiver proof path for #2981

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -12,6 +12,8 @@
 
 - **#2977 LR-050 Blocker Refresh Matrix**: **COMPLETED** — PR [#3707](https://github.com/jannekbuengener/Claire_de_Binare/pull/3707) squash-merged (`9d2a38d0`); deliverable [`docs/live-readiness/LR-050-BLOCKER-REFRESH-MATRIX-2026-07-03.md`](docs/live-readiness/LR-050-BLOCKER-REFRESH-MATRIX-2026-07-03.md). All seven `blocker_before_live` rows remain **OPEN** / **TBD** / **Policy**; child gates #2976, #2978, #2979, #2981, #2983, #2984 stay **OPEN**; #3362 Harvester `>=72h` proof **PENDING**. GitHub-live: #2977 **CLOSED**. LR **NO-GO** unchanged; no runtime/secrets/trading. Session log: `knowledge/logs/sessions/2026-07-03-lr-050-blocker-refresh-2977.md`.
 
+- **#2981 LR-050 Receiver Proof Canon**: **IN FLIGHT** — canonical path `grafana-smtp-operator` via Grafana SMTP Test Notification; preflight PR [#3709](https://github.com/jannekbuengener/Claire_de_Binare/pull/3709) (`a2d6451d`). #2981 **OPEN**; next slice = Operator-GO proof run. LR **NO-GO**; no alerts/secrets/runtime in canon slice.
+
 ## Repo / Engineering Status (2026-07-01)
 
 - **Skill-Governance-Welle (#3637–#3656)**: **COMPLETED** — docs/skills/governance only; kein Runtime/Docker/DB/MCP/Secrets/LR/Live-Go. `docs/skills/` bleibt SSOT; 25/25 Canon-Skills, 97 Mirror-Adapter (`tools/validate_skill_surface_mirror.py` PASS). Registry §15: alle Slices **done** (Mirror #3639, Drift-Guard #3643, Session-Close-Intake #3638, Residual-Intake PR #3645, Skill-Meta #3647, Gemini-Policy #3652).

--- a/docs/live-readiness/LR-050-OBSERVABILITY-GATES.md
+++ b/docs/live-readiness/LR-050-OBSERVABILITY-GATES.md
@@ -144,9 +144,15 @@ Historical shadow digest material under `reports/shadow_mode/` is **not** LR-050
 |---------|-------------|-------------|
 | Prometheus → Alertmanager | `alerts.yml` + `alertmanager.yml` | Primary **documented** path for `ServiceDown`, `DatabaseConnectionLost`, `CircuitBreakerTriggered` |
 | Grafana Unified Alerting | `infrastructure/monitoring/grafana/provisioning/alerting/*.yml` | e.g. high rejection rate, orders rejected, circuit breaker — **parallel** path |
-| Operator notification | Grafana notification policies (see shadow reports) vs Alertmanager receivers | **blocker_before_live** until #2532 names canonical operator channel |
+| Operator notification | Grafana notification policies (see shadow reports) vs Alertmanager receivers | **blocker_before_live** until operator receipt proof on `main` |
 
-Canary Plan ([#2532](https://github.com/jannekbuengener/Claire_de_Binare/issues/2532)) MUST declare which channel is authoritative for operator paging during live-capital canary.
+**LR-050 #2981 canonical operator paging proof:** Grafana SMTP Test Notification,
+receiver class `grafana-smtp-operator` — SSOT:
+[`LR-050-RECEIVER-PROOF-CANON-2026-07-03.md`](./LR-050-RECEIVER-PROOF-CANON-2026-07-03.md).
+Alertmanager webhook ingest remains **not** operator receipt (§3). Prometheus →
+Alertmanager rules stay the infra alert path; they do not substitute for #2981 proof.
+
+Canary Plan ([#2532](https://github.com/jannekbuengener/Claire_de_Binare/issues/2532)) MUST align live-capital paging with this canon or document an explicit superseding operator decision.
 
 ---
 

--- a/docs/live-readiness/LR-050-RECEIVER-PROOF-CANON-2026-07-03.md
+++ b/docs/live-readiness/LR-050-RECEIVER-PROOF-CANON-2026-07-03.md
@@ -1,0 +1,212 @@
+# LR-050 Receiver Proof Canon — Operator Receipt Path (#2981)
+
+## Purpose
+
+Define the **canonical** LR-050 operator-receipt proof path for
+[#2981](https://github.com/jannekbuengener/Claire_de_Binare/issues/2981), so a
+**separate Operator-GO** test slice can execute without re-deciding routing on each
+run.
+
+This document is **documentation only**. It does not trigger alerts, read secrets,
+start Docker, or close #2981.
+
+Supersedes the channel-declaration gap identified in
+[`LR-050-RECEIVER-PROOF-PREFLIGHT-2026-07-03.md`](./LR-050-RECEIVER-PROOF-PREFLIGHT-2026-07-03.md)
+(Preflight PR [#3709](https://github.com/jannekbuengener/Claire_de_Binare/pull/3709)).
+
+## Scope
+
+In scope:
+
+- Canonical receiver class, test method, operator inputs, evidence format, redaction,
+  and acceptance criteria for #2981.
+- Explicit exclusions (Alertmanager internal webhooks, LR-030 synthetic AM proof).
+
+Out of scope:
+
+- No alert firing, SMTP send, Grafana UI mutation, or runtime restart.
+- No secret reads by agents; no Live-Go / Echtgeld-Go / LR status change.
+- No closure of #2981 (requires committed evidence artifact).
+
+## Control State
+
+| Surface | State |
+|---|---|
+| LR-050 verdict | **NO-GO** ([`LR-AUDIT-STATUS-2026-03-05.md`](./LR-AUDIT-STATUS-2026-03-05.md)) |
+| Blocker | Operator Receiver Proof missing — [`LR-050-FINAL-RECONCILE.md`](./LR-050-FINAL-RECONCILE.md) §3 |
+| Refresh matrix | [`LR-050-BLOCKER-REFRESH-MATRIX-2026-07-03.md`](./LR-050-BLOCKER-REFRESH-MATRIX-2026-07-03.md) row 2 |
+| Gate SSOT | [`LR-050-OBSERVABILITY-GATES.md`](./LR-050-OBSERVABILITY-GATES.md) §3–§4 |
+| Secrets cross-ref | [#2983](https://github.com/jannekbuengener/Claire_de_Binare/issues/2983) — SMTP secret **names** only; verification is operator-local |
+| Downstream | [#2984](https://github.com/jannekbuengener/Claire_de_Binare/issues/2984) — kill-switch drill depends on receiver proof |
+| Canon date | 2026-07-03 |
+
+---
+
+## Canonical Decisions (binding for #2981)
+
+| # | Decision |
+|---|---|
+| 1 | **LR-050 operator-receipt proof runs through Grafana SMTP Test Notification** to the operator human inbox. |
+| 2 | **Alertmanager internal webhook routing** (`default-receiver`, `critical-receiver`, `high-priority-receiver`, `trading-halt-receiver` → `cdb_signal:8005/alerts/*`) **does not** count as operator receipt. |
+| 3 | **LR-030 synthetic Alertmanager API proof** (`reports/lr030/.../synthetic_alert_proof_summary.json`) **does not** count as LR-050 operator receipt. |
+| 4 | **Real secret values** are verified **only locally by the operator** under `SECRETS_PATH`; agents must not read, echo, or commit SMTP credentials or `ALERT_EMAIL_TO`. |
+| 5 | **Prometheus → Alertmanager** remains the documented path for infrastructure alert **rules**; it is **not** the canonical LR-050 **operator paging** proof channel for #2981. |
+
+---
+
+## Receiver Class
+
+| Field | Value |
+|---|---|
+| **Canonical receiver class** | `grafana-smtp-operator` |
+| **Human channel** | Operator email inbox (destination configured via local `ALERT_EMAIL_TO` secret — never committed) |
+| **Stack anchor** | Grafana in [`compose.red.yml`](../../infrastructure/compose/compose.red.yml) with `GF_SMTP_*` + Docker secrets `smtp_user`, `smtp_password`, `smtp_from`, `alert_email_to` |
+| **Not in scope for proof** | Alertmanager webhook ingest, internal service logs as sole proof |
+
+---
+
+## Operator Inputs (before Operator-GO test)
+
+Operator verifies locally (**agent does not read values**):
+
+| Input | Secret / config name | Required? |
+|---|---|---|
+| SMTP user | `SMTP_USER` in `SECRETS_PATH` | **Yes** |
+| SMTP password | `SMTP_PASSWORD` in `SECRETS_PATH` | **Yes** |
+| SMTP from address | `SMTP_FROM` in `SECRETS_PATH` | **Yes** |
+| Operator inbox destination | `ALERT_EMAIL_TO` in `SECRETS_PATH` | **Yes** |
+| Grafana admin access | `GRAFANA_PASSWORD` in `SECRETS_PATH` | **Yes** (local UI only) |
+| Grafana email contact point | UI contact point bound to SMTP; routes to operator inbox | **Yes** — operator confirms configured or configures under GO |
+
+Cross-ref [#2983](https://github.com/jannekbuengener/Claire_de_Binare/issues/2983): SMTP/alert credential readiness is a **separate** gate; #2981 proof may proceed when operator attests these four SMTP-related files exist and Grafana contact point works — without publishing values.
+
+---
+
+## Test Method (Operator-GO slice only — not executed by this document)
+
+| Step | Action |
+|---|---|
+| 1 | Operator-GO: non-destructive RED stack up (`MOCK_TRADING` / `DRY_RUN` unchanged on trading path). |
+| 2 | Operator opens Grafana (`http://localhost:3000`, local bind). |
+| 3 | Operator uses **Test notification** on the email contact point used for LR-050 proof (preferred — minimal blast radius). |
+| 4 | Operator confirms notification received on human inbox. |
+| 5 | Operator (or scoped agent under GO) commits **redacted** evidence per format below. |
+
+**Forbidden as sole proof:** Alertmanager API v2 direct POST; webhook delivery to `cdb_signal`; Prometheus alert firing without human-channel receipt.
+
+**Suggested proof labels in evidence:** `alertname`: `CDB-LR050-ReceiverProofTest`; `test_method`: `grafana_test_notification`.
+
+---
+
+## Evidence Format
+
+**Directory:** `reports/lr050/receiver_proof/YYYY-MM-DD/`
+
+| File | Required? | Content |
+|---|---|---|
+| `manifest.json` | **Yes** | Structured metadata (schema below) |
+| `operator_attestation.md` | **Yes** | Redacted operator statement: receipt confirmed, UTC times, channel class |
+| `summary.md` | Recommended | Human-readable summary; explicit NO-GO / not Live-Go |
+| `redacted_screenshot.sha256` | Optional | Hash only if screenshot stored outside repo |
+
+### `manifest.json` minimum schema
+
+```json
+{
+  "proof_type": "lr050_operator_receiver_proof",
+  "issue": "2981",
+  "canon_ref": "docs/live-readiness/LR-050-RECEIVER-PROOF-CANON-2026-07-03.md",
+  "receiver_class": "grafana-smtp-operator",
+  "test_method": "grafana_test_notification",
+  "alertname": "CDB-LR050-ReceiverProofTest",
+  "severity": "critical",
+  "proof_ts_utc": "2026-07-03T12:00:00Z",
+  "receipt_ts_utc": "2026-07-03T12:00:05Z",
+  "lr_verdict_at_proof": "NO-GO",
+  "live_go": false,
+  "echtgeld_go": false,
+  "operator_attestation_ref": "operator_attestation.md",
+  "redaction_policy": "LR-050-RECEIVER-PROOF-CANON-2026-07-03.md",
+  "notes": "LR-050 canary readiness only. Does not clear LR-050 or authorize live capital."
+}
+```
+
+Aligns with [`LR-050-OBSERVABILITY-GATES.md`](./LR-050-OBSERVABILITY-GATES.md) §4.4 fields 1–5.
+
+---
+
+## Redaction Rules (mandatory)
+
+| Allowed in repo | Forbidden in repo |
+|---|---|
+| UTC timestamps (test + receipt) | Email addresses (`ALERT_EMAIL_TO`, from, to, SMTP user) |
+| Receiver class `grafana-smtp-operator` | SMTP passwords, API tokens, webhook URLs with secrets |
+| `alertname`, `severity`, `test_method` | Full email body with PII or host-specific secrets |
+| Operator attestation text (no PII) | Grafana admin password |
+| SHA-256 of redacted screenshot (optional) | Raw notification headers with addresses |
+
+Replace forbidden fields with `[REDACTED_OPERATOR_CHANNEL]` or `[REDACTED_SECRET]`.
+
+---
+
+## Acceptance Criteria (Operator-GO test — closes #2981 only when all met)
+
+| # | Criterion |
+|---|---|
+| 1 | **Timestamp** — `proof_ts_utc` and `receipt_ts_utc` in evidence |
+| 2 | **Receiver class name** — `grafana-smtp-operator` in manifest |
+| 3 | **Redacted operator attestation** — human receipt confirmed, no PII |
+| 4 | **Test method** — `grafana_test_notification` documented |
+| 5 | **No Live-Go** — manifest and attestation state LR **NO-GO**; no live-capital authorization |
+| 6 | **Evidence on `main`** — under `reports/lr050/receiver_proof/YYYY-MM-DD/` |
+
+Until all six are satisfied, #2981 remains **OPEN**.
+
+---
+
+## Readiness After This Canon
+
+| Question | Answer |
+|---|---|
+| Is canonical path defined? | **Yes** — this document |
+| Is Operator-GO test possible next? | **Yes** — **`READY_FOR_OPERATOR_RECEIVER_TEST`** once operator confirms local SMTP secrets + Grafana contact point (no agent secret read) |
+| Does this close #2981? | **No** |
+| Does this clear LR-050? | **No** — **NO-GO** unchanged |
+| #2984 unblocked? | **Partially** — receiver proof evidence still required before kill-switch drill evidence |
+
+---
+
+## Excluded Paths (explicit)
+
+### Alertmanager internal webhooks
+
+[`alertmanager.yml`](../../infrastructure/monitoring/alertmanager.yml) routes to
+`http://cdb_signal:8005/alerts/*`. Per OBSERVABILITY-GATES §3, internal ingest is
+**not** operator receipt. Signal service exposes `/health`, `/status`, `/metrics` only.
+
+### LR-030 synthetic Alertmanager proof
+
+`reports/lr030/2026-05-17/synthetic_alert_proof_summary.json` — AM API direct post to
+`default-receiver` — shadow/soak scope only; **not** LR-050 canary operator proof.
+
+---
+
+## Cross-References
+
+| Document | Relationship |
+|---|---|
+| [`LR-050-RECEIVER-PROOF-PREFLIGHT-2026-07-03.md`](./LR-050-RECEIVER-PROOF-PREFLIGHT-2026-07-03.md) | Preflight inventory; channel gap closed by this canon |
+| [`LR-050-OBSERVABILITY-GATES.md`](./LR-050-OBSERVABILITY-GATES.md) | Proof hierarchy §3; operator receipt definition §4.4 |
+| [`LR-050-SECRETS-READINESS.md`](./LR-050-SECRETS-READINESS.md) | Alert credential gate matrix (#2530 / #2983) |
+| [`ALERTING_DIGEST_FIX.md`](../operations/ALERTING_DIGEST_FIX.md) | Grafana notification policy ops notes |
+
+---
+
+## Document Metadata
+
+| Field | Value |
+|---|---|
+| Issue | [#2981](https://github.com/jannekbuengener/Claire_de_Binare/issues/2981) |
+| Refs | [#2983](https://github.com/jannekbuengener/Claire_de_Binare/issues/2983), [#2984](https://github.com/jannekbuengener/Claire_de_Binare/issues/2984), PR [#3709](https://github.com/jannekbuengener/Claire_de_Binare/pull/3709) |
+| Status target | `DONE_LR050_RECEIVER_PROOF_CANON` |
+| LR verdict | **NO-GO** (unchanged) |

--- a/docs/live-readiness/LR-050-RECEIVER-PROOF-PREFLIGHT-2026-07-03.md
+++ b/docs/live-readiness/LR-050-RECEIVER-PROOF-PREFLIGHT-2026-07-03.md
@@ -6,6 +6,8 @@ Read-only preflight for [#2981](https://github.com/jannekbuengener/Claire_de_Bin
 identify how Alertmanager / monitoring receiver proof can be executed **safely** and
 **redacted**, without Live-Go, trading, or secret exposure in repo artifacts.
 
+**Canonical path (post-preflight):** [`LR-050-RECEIVER-PROOF-CANON-2026-07-03.md`](./LR-050-RECEIVER-PROOF-CANON-2026-07-03.md) — Grafana SMTP Test Notification, receiver class `grafana-smtp-operator`.
+
 This document does **not** trigger alerts, start Docker, or close #2981.
 
 ## Scope
@@ -40,8 +42,9 @@ Out of scope:
 
 | Field | Value |
 |---|---|
-| **Decision** | **`BLOCKED_NEEDS_CONFIG`** |
-| Secondary gate | **`BLOCKED_NEEDS_SECRET_CONTEXT`** (for execution only — operator verifies SMTP secrets locally) |
+| **Decision (preflight)** | **`BLOCKED_NEEDS_CONFIG`** — channel undeclared at preflight time |
+| **Decision (post-canon)** | **`READY_FOR_OPERATOR_RECEIVER_TEST`** — see [`LR-050-RECEIVER-PROOF-CANON-2026-07-03.md`](./LR-050-RECEIVER-PROOF-CANON-2026-07-03.md) |
+| Secondary gate | **`BLOCKED_NEEDS_SECRET_CONTEXT`** at execution — operator verifies SMTP secrets locally |
 | Operator-GO required for test? | **Yes** — stack interaction + human receipt attestation |
 | #2981 status after preflight | **Stays OPEN** — no evidence artifact on `main` |
 


### PR DESCRIPTION
## Summary

- Add `docs/live-readiness/LR-050-RECEIVER-PROOF-CANON-2026-07-03.md` — canonical LR-050 operator-receipt path for #2981.
- Receiver class: `grafana-smtp-operator`; test method: Grafana SMTP Test Notification.
- Cross-links: preflight doc, OBSERVABILITY-GATES §6, CURRENT_STATUS ledger line.

## Canon decisions

- Grafana SMTP Test Notification = canonical operator receipt proof
- Alertmanager internal webhooks ≠ operator receipt
- LR-030 synthetic AM proof ≠ LR-050 proof
- Secrets verified locally by operator only

## Test plan

- [x] Read-only docs; no alerts, secrets, Docker, or runtime
- [x] `git diff --check`
- [x] rg safety review

## Boundaries

- Refs #2981 #2983 #2984 #3709
- Documentation-only
- LR remains **NO-GO**
- No alerts sent / no secrets read / no runtime action
- #2981 stays **OPEN**
