### PR TITLE
[LR-050] Add secrets and account readiness evidence for #2983

### DIFF
--- a/reports/lr050/secrets_readiness/2026-07-03/manifest.json
+++ b/reports/lr050/secrets_readiness/2026-07-03/manifest.json
@@ -1,0 +1,62 @@
+{
+  "proof_type": "lr050_secrets_account_readiness",
+  "issue": "2983",
+  "result": "INCONCLUSIVE",
+  "aggregate_gate": "INCONCLUSIVE",
+  "lr_verdict_at_proof": "NO-GO",
+  "live_go": false,
+  "echtgeld_go": false,
+  "proof_ts_utc": "2026-07-03T20:32:05Z",
+  "proof_window_utc_start": "2026-07-03T20:25:00Z",
+  "proof_window_utc_end": "2026-07-03T20:32:05Z",
+  "repo_head_at_proof": "88b0bf1ddb037b81b7e304d092b69330b10a00aa",
+  "ssot_path_status": "PRESENT",
+  "secrets_path_env": "SET",
+  "ssot_files": {
+    "REDIS_PASSWORD": "PRESENT",
+    "POSTGRES_PASSWORD": "PRESENT",
+    "MEXC_API_KEY.txt": "PRESENT",
+    "MEXC_API_SECRET.txt": "PRESENT",
+    "POSTGRES_PASSWORD_DSN": "PRESENT",
+    "GRAFANA_PASSWORD": "PRESENT",
+    "SMTP_USER": "PRESENT",
+    "SMTP_PASSWORD": "PRESENT",
+    "SMTP_FROM": "PRESENT",
+    "ALERT_EMAIL_TO": "PRESENT"
+  },
+  "gate_results": {
+    "S1": "PASS",
+    "S2": "PASS",
+    "S3": "PASS",
+    "S4": "PASS",
+    "S5": "PASS",
+    "S6": "PASS",
+    "S7": "INCONCLUSIVE",
+    "S8": "PASS",
+    "S9": "PASS",
+    "S10": "PASS",
+    "S11": "INCONCLUSIVE",
+    "S12": "PASS"
+  },
+  "permission_scope_class": "trade_limited",
+  "forbidden_permissions": {
+    "withdrawal": "disabled",
+    "transfer": "disabled",
+    "admin": "disabled"
+  },
+  "ip_allowlist_status": "unknown",
+  "ip_allowlist_entry_count": null,
+  "account_binding_status": "verified",
+  "testnet_mainnet_separation": "verified",
+  "designated_key_class": "undecided",
+  "agent_read_credentials": false,
+  "exchange_api_called": false,
+  "redaction_pass": true,
+  "blockers": [
+    "S7 ip_allowlist_status unknown — operator could not attest status/count without policy detail exposure",
+    "S11 designated_key_class undecided pending #2976 (non-blocking for aggregate per scope; documented)"
+  ],
+  "redaction_policy": "LR-050-SECRETS-READINESS.md §9 + LR-050-SECRETS-ACCOUNT-READINESS-PREFLIGHT-2026-07-03.md",
+  "operator_attestation_ref": "operator_attestation.md",
+  "notes": "LR-050 readiness attestation only. Does not clear LR-050 or authorize live capital."
+}

--- a/reports/lr050/secrets_readiness/2026-07-03/operator_attestation.md
+++ b/reports/lr050/secrets_readiness/2026-07-03/operator_attestation.md
@@ -1,0 +1,105 @@
+# LR-050 Operator Secrets & Account Readiness Attestation (#2983)
+
+## Scope
+
+Operator-GO slice for [#2983](https://github.com/jannekbuengener/Claire_de_Binare/issues/2983):
+redacted attestation of local SSOT presence, permission scope, IP allowlist posture,
+and account binding — without secret values, IPs, account IDs, or venue API calls.
+
+## Proof window
+
+| Field | Value (UTC) |
+|-------|-------------|
+| `proof_window_utc_start` | `2026-07-03T20:25:00Z` |
+| `proof_window_utc_end` | `2026-07-03T20:32:05Z` |
+
+## S1–S3 — Local SSOT and env
+
+| Field | Attestation |
+|-------|-------------|
+| `ssot_path_status` | `PRESENT` |
+| `ssot_path_ref` | `[REDACTED_LOCAL_SSOT]` |
+| `secrets_path_env` | `SET` |
+
+## S2 — Required secret files (names only)
+
+Operator verified file presence via local `Test-Path` on **names** only.
+Agent did **not** read secret file contents.
+
+| Secret name | Status |
+|-------------|--------|
+| `REDIS_PASSWORD` | `PRESENT` |
+| `POSTGRES_PASSWORD` | `PRESENT` |
+| `MEXC_API_KEY.txt` | `PRESENT` |
+| `MEXC_API_SECRET.txt` | `PRESENT` |
+| `POSTGRES_PASSWORD_DSN` | `PRESENT` |
+| `GRAFANA_PASSWORD` | `PRESENT` |
+| `SMTP_USER` | `PRESENT` |
+| `SMTP_PASSWORD` | `PRESENT` |
+| `SMTP_FROM` | `PRESENT` |
+| `ALERT_EMAIL_TO` | `PRESENT` |
+
+## S5 — Forbidden permissions (venue dashboard, enum only)
+
+| Permission | Status |
+|------------|--------|
+| `withdrawal` | `disabled` |
+| `transfer` | `disabled` |
+| `admin` | `disabled` |
+
+## S6 — Trading permission scope
+
+| Field | Value |
+|-------|-------|
+| `permission_scope_class` | `trade_limited` |
+
+## S7 — IP allowlist / egress binding
+
+| Field | Value |
+|-------|-------|
+| `ip_allowlist_status` | `unknown` |
+| `ip_allowlist_entry_count` | `unknown` |
+
+**Note:** Operator initially indicated `configured` but corrected to `unknown` when
+entry count could not be attested without disclosing policy detail. Gate S7 remains
+**not reviewed** for aggregate purposes.
+
+## S8 — Account / channel binding
+
+| Field | Value |
+|-------|-------|
+| `account_binding_status` | `verified` |
+| `account_channel_ref` | `[REDACTED_VENUE_ACCOUNT_CHANNEL]` |
+| `testnet_mainnet_separation` | `verified` |
+
+## S11 — Designated key class
+
+| Field | Value |
+|-------|-------|
+| `designated_key_class` | `undecided` |
+
+Gap acknowledged pending [#2976](https://github.com/jannekbuengener/Claire_de_Binare/issues/2976);
+does not substitute S7 review.
+
+## Agent / proof boundaries
+
+| Field | Value |
+|-------|-------|
+| `agent_read_credentials` | `false` |
+| `exchange_api_called` | `false` |
+| `lr_verdict` | `NO-GO` |
+| `live_go` | `false` |
+| `echtgeld_go` | `false` |
+
+## Verification method (operator-local, redacted)
+
+- File presence: local name-only checks under `[REDACTED_LOCAL_SSOT]`
+- Permission scope and forbidden flags: venue dashboard review (no API calls, no proof orders)
+- Account binding and testnet/mainnet separation: venue dashboard review (enum only)
+- IP allowlist: **not conclusively reviewed** in this window (S7 `unknown`)
+
+## Boundaries (unchanged)
+
+- LR verdict remains **NO-GO**
+- No Live-Go, no Echtgeld-Go, no trading authorization
+- No secret values, IP addresses, account IDs, emails, API keys, tokens, or PII in this artifact

--- a/reports/lr050/secrets_readiness/2026-07-03/redaction_review.md
+++ b/reports/lr050/secrets_readiness/2026-07-03/redaction_review.md
@@ -1,0 +1,54 @@
+# Redaction Review — LR-050 Secrets Readiness (#2983)
+
+## Tier boundary
+
+| Tier | Actor | This slice |
+|------|-------|------------|
+| A — Agent/repo | Agent | Compose/manifest name inventory; evidence authoring; pattern scan |
+| B — Operator local | Human | S1–S8 attestation (enum only); no values pasted to agent |
+| C — Evidence commit | Agent + operator attestation | Files under `reports/lr050/secrets_readiness/2026-07-03/` |
+
+## Agent actions (S4 / S9 / S10)
+
+What the agent did **not** do:
+
+- no reads under `SECRETS_PATH` or local SSOT directory
+- no `cat` / `Get-Content` of credential files
+- no venue/exchange REST or WebSocket calls
+- no proof orders or auth validation calls
+- no Docker recreate or runtime restart
+
+What the agent did:
+
+- read repo docs and compose secret **name** references only
+- read [`tools/secrets/secrets.manifest.json`](../../../tools/secrets/secrets.manifest.json) for S12 gap note (infra names only; path not copied into evidence)
+- authored redacted attestation from operator enum input
+
+## Scan method
+
+```text
+rg -i "password|token|api_key|secret|dsn|smtp|mexc|binance|private|credential|@.*\\.|account|AKIA|ghp_|xoxb-|BEGIN .*PRIVATE KEY|[0-9]{1,3}(\\.[0-9]{1,3}){3}" reports/lr050/secrets_readiness/2026-07-03/
+git diff --check
+```
+
+## Expected false positives
+
+Literal identifiers allowed in this pack:
+
+- secret **names** (`MEXC_API_KEY.txt`, `SMTP_PASSWORD`, …)
+- enum tokens (`PRESENT`, `disabled`, `trade_limited`, `unknown`)
+- issue references and doc paths
+
+## Findings
+
+- no secret values or partial key material
+- no IP address literals (v4/v6)
+- no account IDs, emails, or DSN password values
+- no PEM blocks or token prefixes (`ghp_`, `AKIA`, `xoxb-`)
+- redaction placeholders used: `[REDACTED_LOCAL_SSOT]`, `[REDACTED_VENUE_ACCOUNT_CHANNEL]`
+
+## Verdict
+
+`redaction_pass: true`
+
+Residual scan hits on allowed secret **names** only. No value-like leaks in committed artifacts.

--- a/reports/lr050/secrets_readiness/2026-07-03/summary.md
+++ b/reports/lr050/secrets_readiness/2026-07-03/summary.md
@@ -1,0 +1,52 @@
+# LR-050 Secrets & Account Readiness — Summary (#2983)
+
+| Field | Value |
+|-------|-------|
+| Issue | [#2983](https://github.com/jannekbuengener/Claire_de_Binare/issues/2983) |
+| Proof date | 2026-07-03 |
+| `aggregate_gate` | **INCONCLUSIVE** |
+| `result` | **INCONCLUSIVE** |
+| `lr_verdict_at_proof` | **NO-GO** |
+| `live_go` | `false` |
+| `echtgeld_go` | `false` |
+| `agent_read_credentials` | `false` |
+| `exchange_api_called` | `false` |
+| `redaction_pass` | `true` |
+
+## Gate summary
+
+| Gate | Result | Notes |
+|------|--------|-------|
+| S1 | PASS | SSOT directory `PRESENT` |
+| S2 | PASS | All required secret files `PRESENT` (names only) |
+| S3 | PASS | `SECRETS_PATH` env `SET` |
+| S4 | PASS | No secret values in evidence artifacts |
+| S5 | PASS | Forbidden permissions all `disabled` |
+| S6 | PASS | `permission_scope_class=trade_limited` (not excessive) |
+| S7 | **INCONCLUSIVE** | `ip_allowlist_status=unknown`; entry count not attested |
+| S8 | PASS | Account binding and testnet/mainnet separation `verified` |
+| S9 | PASS | Agent did not read credentials |
+| S10 | PASS | No exchange API used for proof |
+| S11 | INCONCLUSIVE | `designated_key_class=undecided` (#2976) — documented, non-blocking alone |
+| S12 | PASS | Manifest rotation gap for MEXC keys acknowledged |
+
+## Blockers (issue remains OPEN)
+
+1. **S7:** IP allowlist / egress binding not conclusively reviewed (`unknown`). Operator must
+   attest `configured` / `not_configured` / `not_required` plus integer `entry_count` only —
+   without IP literals — before aggregate PASS.
+2. **S11 (informational):** Canary key class still `undecided` per #2976; does not alone block
+   #2983 once S7 is resolved.
+
+## Next step
+
+Re-run operator attestation for S7 only (enum + integer count), refresh evidence pack,
+merge PR with aggregate **PASS**, then close #2983.
+
+## Explicit boundaries
+
+This evidence pack does **not**:
+
+- change LR verdict (remains **NO-GO**)
+- authorize Live-Go or Echtgeld-Go
+- substitute #2976, #2979, or #2985 closure


### PR DESCRIPTION
## Summary

- Add redacted operator attestation evidence under `reports/lr050/secrets_readiness/2026-07-03/`.
- Aggregate gate: **INCONCLUSIVE** — S7 IP allowlist `unknown`; S1–S6, S8–S10 PASS; redaction PASS.
- Refs #2983 — **does not close** #2983 (aggregate not PASS).

## Refs

Refs #2983 #3716 #2976 #2979 #2985

## Delivered

- `manifest.json`, `operator_attestation.md`, `redaction_review.md`, `summary.md`
- `agent_read_credentials: false`, `exchange_api_called: false`

## Blockers (issue stays OPEN)

- S7: `ip_allowlist_status=unknown` — operator must re-attest status + integer entry count (no IP literals) for aggregate PASS.

## Boundaries

- LR remains **NO-GO**
- no secrets included
- no exchange API calls
- no Live-Go / Echtgeld-Go

## Test plan

- [x] Redaction scan on evidence pack (names only, no values/IPs)
- [x] `git diff --check`
- [ ] CI required checks
