### PR TITLE
[LR-050][VENUE] Fix stale MEXC testnet URL defaults

### DIFF
--- a/core/clients/mexc.py
+++ b/core/clients/mexc.py
@@ -52,13 +52,36 @@ class MexcClient:
                 "MEXC API credentials required. Set MEXC_API_KEY and MEXC_API_SECRET"
             )
 
-        # API Endpoints
+        # API Endpoints (spot REST).
+        #
+        # MEXC offers NO Spot API testnet/sandbox: the spot API connects directly to
+        # the live trading environment. The former host "https://contract.mexc.com"
+        # was the MEXC *Futures* access domain (discontinued 2026-01-19) and never
+        # served the spot /api/v3/* paths this client uses. Routing "testnet" there
+        # was a stale, mislabeled default and an API-family mismatch.
+        #
+        # Fail closed on testnet=True instead of silently talking to a deprecated
+        # futures host, and never silently fall back to mainnet. `testnet` is also
+        # NOT a no-send proof: no-send for CDB depends on DRY_RUN=true +
+        # MOCK_TRADING=true (mock_builtin), not on this flag.
+        # See docs/live-readiness/LR-050-VENUE-ENDPOINT-SEMANTICS-2026-07-03.md
+        # §3.3 (no spot testnet), §4 (reconciliation), §5 (no-send boundary).
         if testnet:
-            self.base_url = "https://contract.mexc.com"  # Testnet URL
-            logger.info("🧪 MEXC Client initialized in TESTNET mode")
-        else:
-            self.base_url = "https://api.mexc.com"
-            logger.warning("🔴 MEXC Client initialized in LIVE mode - real money!")
+            raise ValueError(
+                "MEXC has no Spot API testnet/sandbox; testnet=True is unsupported. "
+                "The former host https://contract.mexc.com was a deprecated MEXC "
+                "Futures domain (discontinued 2026-01-19), not a spot testnet. Use "
+                "the mainnet spot base https://api.mexc.com and rely on DRY_RUN=true "
+                "+ MOCK_TRADING=true for no-send safety (testnet is not a no-send "
+                "proof)."
+            )
+
+        self.base_url = "https://api.mexc.com"
+        logger.warning(
+            "🔴 MEXC Client initialized against mainnet spot base %s - real money "
+            "when DRY_RUN/MOCK_TRADING are off!",
+            self.base_url,
+        )
 
         self.session = requests.Session()
         self.session.headers.update(
@@ -109,7 +132,9 @@ class MexcClient:
             response.raise_for_status()
             data = response.json()
 
-            logger.info(f"✅ Fetched account balance: {len(data.get('balances', []))} assets")
+            logger.info(
+                f"✅ Fetched account balance: {len(data.get('balances', []))} assets"
+            )
             return data
 
         except requests.exceptions.RequestException as e:

--- a/core/config/trading_mode.py
+++ b/core/config/trading_mode.py
@@ -5,7 +5,9 @@ Provides centralized trading mode management with safe defaults.
 CRITICAL SAFETY:
 - Default mode is PAPER (no real money)
 - LIVE mode requires explicit confirmation
-- STAGED mode uses testnet
+- STAGED sets the nominal MEXC_TESTNET flag; note MEXC has no spot testnet and
+  MEXC_TESTNET is not a no-send proof (no-send = DRY_RUN + MOCK_TRADING).
+  See docs/live-readiness/LR-050-VENUE-ENDPOINT-SEMANTICS-2026-07-03.md §5.
 """
 
 import os
@@ -94,9 +96,7 @@ def get_trading_mode(
     if mode == TradingMode.LIVE and require_confirmation:
         confirmation = os.getenv("LIVE_TRADING_CONFIRMED", "").lower().strip()
         if confirmation != "yes":
-            logger.critical(
-                "🚨 LIVE TRADING MODE BLOCKED 🚨"
-            )
+            logger.critical("🚨 LIVE TRADING MODE BLOCKED 🚨")
             logger.critical(
                 "LIVE mode requires LIVE_TRADING_CONFIRMED=yes environment variable"
             )
@@ -104,7 +104,8 @@ def get_trading_mode(
                 "This is a safety measure to prevent accidental real-money trading"
             )
             logger.critical(
-                "Current LIVE_TRADING_CONFIRMED value: '%s'", confirmation or "(not set)"
+                "Current LIVE_TRADING_CONFIRMED value: '%s'",
+                confirmation or "(not set)",
             )
             sys.exit(1)
 
@@ -204,7 +205,9 @@ def get_legacy_config(mode: TradingMode) -> dict:
         return {
             "MOCK_TRADING": False,  # Use real executor
             "DRY_RUN": False,  # Execute orders
-            "MEXC_TESTNET": True,  # Use testnet
+            # Nominal flag only: no MEXC spot testnet exists and this is not a
+            # no-send proof; STAGED is exchange-capable (LR-050 venue semantics §4/§5).
+            "MEXC_TESTNET": True,
         }
     elif mode == TradingMode.LIVE:
         return {

--- a/services/execution/config.py
+++ b/services/execution/config.py
@@ -18,7 +18,14 @@ SERVICE_PORT = 8003
 # MEXC API Configuration (Docker secrets with .env fallback)
 MEXC_API_KEY = read_secret("mexc_api_key", "MEXC_API_KEY")
 MEXC_API_SECRET = read_secret("mexc_api_secret", "MEXC_API_SECRET")
-MEXC_BASE_URL = os.getenv("MEXC_BASE_URL", "https://contract.mexc.com")
+# Spot REST base. Default is the mainnet spot host https://api.mexc.com.
+# MEXC has no spot testnet; the former https://contract.mexc.com futures host was
+# discontinued 2026-01-19 and must not be a spot default.
+# See docs/live-readiness/LR-050-VENUE-ENDPOINT-SEMANTICS-2026-07-03.md §4.
+MEXC_BASE_URL = os.getenv("MEXC_BASE_URL", "https://api.mexc.com")
+# Nominal flag only: MEXC_TESTNET is NOT a no-send proof and selects no real sandbox
+# (no MEXC spot testnet exists). No-send depends on DRY_RUN + MOCK_TRADING
+# (mock_builtin). See LR-050-VENUE-ENDPOINT-SEMANTICS-2026-07-03.md §5.
 MEXC_TESTNET = os.getenv("MEXC_TESTNET", "true").lower() == "true"
 
 # Trading Mode

--- a/services/risk/balance_fetcher.py
+++ b/services/risk/balance_fetcher.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 class BalanceFetchError(Exception):
     """Raised when balance cannot be fetched - FAIL FAST"""
+
     pass
 
 
@@ -29,7 +30,10 @@ class RealBalanceFetcher:
         # Use unified secret loader: Docker secrets first, then env fallback
         self.api_key = read_secret("mexc_api_key", "MEXC_API_KEY")
         self.api_secret = read_secret("mexc_api_secret", "MEXC_API_SECRET")
-        self.base_url = os.getenv("MEXC_BASE_URL", "https://contract.mexc.com")
+        # Spot REST base; mainnet spot host by default. MEXC has no spot testnet and
+        # the former contract.mexc.com futures host was discontinued 2026-01-19, so it
+        # must not be a spot default (LR-050-VENUE-ENDPOINT-SEMANTICS-2026-07-03.md §4).
+        self.base_url = os.getenv("MEXC_BASE_URL", "https://api.mexc.com")
 
         if not self.api_key or not self.api_secret:
             raise ValueError("MEXC API credentials required for real balance")
@@ -149,7 +153,9 @@ class RealBalanceFetcher:
         except requests.RequestException as e:
             # FAIL FAST: Try cache, then raise exception
             if self._balance_cache and (time.time() - self._cache_timestamp) < 300:
-                logger.warning(f"API failed, using cached balance (age: {time.time() - self._cache_timestamp:.0f}s): {e}")
+                logger.warning(
+                    f"API failed, using cached balance (age: {time.time() - self._cache_timestamp:.0f}s): {e}"
+                )
                 return self._balance_cache
 
             raise BalanceFetchError(

--- a/tests/integration/test_mexc_testnet.py
+++ b/tests/integration/test_mexc_testnet.py
@@ -1,5 +1,13 @@
 """
-MEXC Testnet Integration Tests (offline by default)
+MEXC Spot Client Integration Tests (offline by default)
+
+NOTE (Issue #3719 / LR-050 venue endpoint semantics): MEXC offers no Spot API
+testnet/sandbox. The former host contract.mexc.com was a deprecated MEXC Futures
+domain (discontinued 2026-01-19), not a spot testnet, so `MexcClient(testnet=True)`
+now fails closed. These tests therefore exercise the mainnet spot base
+https://api.mexc.com (offline requests are stubbed; no live venue calls in CI).
+The dedicated fail-closed regression lives in
+tests/unit/core/test_mexc_base_url_3719.py.
 
 Offline tests use requests-mock to stub network calls.
 External tests are opt-in: set CDB_EXTERNAL_TESTS=1 and MEXC_API_KEY/MEXC_API_SECRET.
@@ -18,11 +26,17 @@ completely different UUIDs. This requires disciplined event design:
 import os
 import sys
 import pytest
-requests_mock = pytest.importorskip("requests_mock", reason="test requires requests-mock")
+
+requests_mock = pytest.importorskip(
+    "requests_mock", reason="test requires requests-mock"
+)
 import logging
 from urllib.parse import urlparse, parse_qsl
+
 # Add services to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "services", "execution"))
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "..", "..", "services", "execution")
+)
 
 import mexc_client
 
@@ -36,22 +50,28 @@ def _external_enabled() -> bool:
 
 @pytest.fixture
 def offline_client(monkeypatch):
-    """Create an offline client with stubbed session and fixed time."""
+    """Create an offline mainnet spot client with stubbed session and fixed time."""
     monkeypatch.setattr(mexc_client.time, "time", lambda: 1700000000.0)
-    client = mexc_client.MexcClient(api_key="test_key", api_secret="test_secret", testnet=True)
+    client = mexc_client.MexcClient(api_key="test_key", api_secret="test_secret")
     return client
 
 
 @pytest.fixture
 def external_client():
-    """Create a real testnet client (opt-in via CDB_EXTERNAL_TESTS=1)."""
+    """Create a real mainnet spot client (opt-in via CDB_EXTERNAL_TESTS=1).
+
+    No MEXC spot testnet exists (#3719); external smoke tests target the mainnet
+    spot base. Deeply opt-in and excluded from CI.
+    """
     if not _external_enabled():
         pytest.skip("External tests disabled (set CDB_EXTERNAL_TESTS=1 to enable)")
     api_key = os.getenv("MEXC_API_KEY")
     api_secret = os.getenv("MEXC_API_SECRET")
     if not api_key or not api_secret:
-        pytest.skip("MEXC API credentials not configured (set MEXC_API_KEY and MEXC_API_SECRET)")
-    return mexc_client.MexcClient(api_key=api_key, api_secret=api_secret, testnet=True)
+        pytest.skip(
+            "MEXC API credentials not configured (set MEXC_API_KEY and MEXC_API_SECRET)"
+        )
+    return mexc_client.MexcClient(api_key=api_key, api_secret=api_secret)
 
 
 def _validate_request_signature(request, client):
@@ -66,7 +86,9 @@ def _validate_request_signature(request, client):
     signature = params["signature"]
     unsigned = {k: v for k, v in params.items() if k != "signature"}
     expected_signature = client._sign_request(unsigned)
-    assert signature == expected_signature, f"Invalid signature: {signature} != {expected_signature}"
+    assert (
+        signature == expected_signature
+    ), f"Invalid signature: {signature} != {expected_signature}"
 
 
 @pytest.mark.integration
@@ -75,6 +97,7 @@ class TestMexcTestnetOffline:
 
     def test_get_account_balance(self, offline_client, requests_mock):
         """Test account balance retrieval with mocked API response."""
+
         # Mock the account endpoint
         def custom_matcher(request):
             _validate_request_signature(request, offline_client)
@@ -83,7 +106,7 @@ class TestMexcTestnetOffline:
         requests_mock.get(
             f"{offline_client.base_url}/api/v3/account",
             additional_matcher=custom_matcher,
-            json={"balances": [{"asset": "USDT", "free": "12.5"}]}
+            json={"balances": [{"asset": "USDT", "free": "12.5"}]},
         )
 
         balance_data = offline_client.get_account_balance()
@@ -94,6 +117,7 @@ class TestMexcTestnetOffline:
 
     def test_get_usdt_balance(self, offline_client, requests_mock):
         """Test USDT balance parsing with mocked API response."""
+
         def custom_matcher(request):
             _validate_request_signature(request, offline_client)
             return True
@@ -101,7 +125,7 @@ class TestMexcTestnetOffline:
         requests_mock.get(
             f"{offline_client.base_url}/api/v3/account",
             additional_matcher=custom_matcher,
-            json={"balances": [{"asset": "USDT", "free": "12.5"}]}
+            json={"balances": [{"asset": "USDT", "free": "12.5"}]},
         )
 
         usdt_balance = offline_client.get_balance("USDT")
@@ -111,8 +135,7 @@ class TestMexcTestnetOffline:
     def test_get_ticker_price(self, offline_client, requests_mock):
         """Test ticker price retrieval (unsigned endpoint)."""
         requests_mock.get(
-            f"{offline_client.base_url}/api/v3/ticker/price",
-            json={"price": "50000.0"}
+            f"{offline_client.base_url}/api/v3/ticker/price", json={"price": "50000.0"}
         )
 
         btc_price = offline_client.get_ticker_price("BTCUSDT")
@@ -126,6 +149,7 @@ class TestMexcTestnetOffline:
 
     def test_get_order_status(self, offline_client, requests_mock):
         """Test order status retrieval with signed request."""
+
         def custom_matcher(request):
             _validate_request_signature(request, offline_client)
             # Verify orderId is in params
@@ -137,7 +161,7 @@ class TestMexcTestnetOffline:
         requests_mock.get(
             f"{offline_client.base_url}/api/v3/order",
             additional_matcher=custom_matcher,
-            json={"orderId": "ORDER123", "status": "FILLED"}
+            json={"orderId": "ORDER123", "status": "FILLED"},
         )
 
         result = offline_client.get_order_status("BTCUSDT", "ORDER123")
@@ -147,6 +171,7 @@ class TestMexcTestnetOffline:
 
     def test_place_order(self, offline_client, requests_mock):
         """Test order placement with signed POST request."""
+
         def custom_matcher(request):
             _validate_request_signature(request, offline_client)
             # Verify order params are present
@@ -158,7 +183,7 @@ class TestMexcTestnetOffline:
         requests_mock.post(
             f"{offline_client.base_url}/api/v3/order",
             additional_matcher=custom_matcher,
-            json={"orderId": "123456", "status": "FILLED"}
+            json={"orderId": "123456", "status": "FILLED"},
         )
 
         # This would call client.place_order() - assuming such a method exists
@@ -167,20 +192,26 @@ class TestMexcTestnetOffline:
 
 
 @pytest.mark.external
-class TestMexcTestnetExternal:
-    """External smoke tests (opt-in) - these make real network calls to MEXC testnet."""
+class TestMexcMainnetSpotExternal:
+    """External smoke tests (opt-in) - real network calls to the MEXC mainnet spot API.
 
-    def test_testnet_client_initialization(self, external_client):
-        """Verify testnet client is properly initialized."""
+    There is no MEXC spot testnet (#3719); these smoke tests target the mainnet
+    spot base. They are opt-in (CDB_EXTERNAL_TESTS=1 + credentials) and excluded
+    from CI.
+    """
+
+    def test_mainnet_spot_client_initialization(self, external_client):
+        """Verify the client initializes against the mainnet spot base."""
         assert external_client is not None
         parsed_url = urlparse(external_client.base_url)
         hostname = (parsed_url.hostname or "").lower()
         assert parsed_url.scheme == "https"
-        assert hostname == "contract.mexc.com"
-        logger.info("Testnet client initialized")
+        assert hostname == "api.mexc.com"
+        assert hostname != "contract.mexc.com"
+        logger.info("Mainnet spot client initialized")
 
     def test_get_account_balance(self, external_client):
-        """Test real account balance retrieval from testnet."""
+        """Test real account balance retrieval from the mainnet spot API."""
         balance_data = external_client.get_account_balance()
         assert balance_data is not None
         assert "balances" in balance_data
@@ -188,7 +219,7 @@ class TestMexcTestnetExternal:
         logger.info("Fetched balance: %s assets", len(balance_data["balances"]))
 
     def test_get_ticker_price(self, external_client):
-        """Test real ticker price from testnet."""
+        """Test real ticker price from the mainnet spot API."""
         btc_price = external_client.get_ticker_price("BTCUSDT")
         assert isinstance(btc_price, float)
         assert btc_price > 0

--- a/tests/unit/core/test_mexc_base_url_3719.py
+++ b/tests/unit/core/test_mexc_base_url_3719.py
@@ -1,0 +1,123 @@
+"""
+Regression tests for MEXC spot base-URL / "testnet" semantics (Issue #3719).
+
+Guards the LR-050 venue-endpoint-semantics finding that ``contract.mexc.com`` is a
+deprecated MEXC *Futures* host (discontinued 2026-01-19) and NOT a MEXC spot
+testnet/sandbox. These tests fail-close the stale "testnet" routing and lock the
+mainnet spot defaults.
+
+Zielaussagen (task #3719):
+1. ``contract.mexc.com`` is not a default for a spot "testnet".
+2. ``MEXC_TESTNET=true`` / ``testnet=True`` does not create a no-send claim.
+3. Mainnet spot REST/WS defaults remain correct.
+4. Unsupported spot-testnet is handled fail-closed.
+
+Test-First metadata (knowledge/testing/TEST_FIRST_PROCESSING_CONTRACT.md §3):
+    test_id: tc_mexc_base_url_3719
+    test_name: mexc_spot_base_url_and_testnet_semantics
+    test_type: schutz
+    cdb_area: execution
+    rule_ref: LR-050-VENUE-ENDPOINT-SEMANTICS-2026-07-03 §3.3/§4/§5
+    decision_ref: contract.mexc.com is not a valid MEXC spot testnet or no-send path
+    issue_ref: "#3719"
+    pr_ref: "[LR-050][VENUE] Fix stale MEXC testnet URL defaults"
+    evidence_ref: docs/live-readiness/LR-050-VENUE-ENDPOINT-SEMANTICS-2026-07-03.md
+    code_area: core/clients/mexc.py, services/execution/config.py, services/risk/balance_fetcher.py, services/ws/mexc_v3_client.py
+    security_relevant: true
+    live_relevant: true
+    profitability_relevant: false
+    surrealdb_export: true
+    ci_artifact: false
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from core.clients.mexc import MexcClient
+
+DEPRECATED_FUTURES_HOST = "contract.mexc.com"
+MAINNET_SPOT_REST = "https://api.mexc.com"
+MAINNET_SPOT_WS = "wss://wbs-api.mexc.com/ws"
+
+
+@pytest.mark.unit
+def test_mainnet_spot_rest_base_is_default():
+    """testnet defaults to False and yields the mainnet spot REST base (#3719 #3)."""
+    client = MexcClient(api_key="k", api_secret="s")
+    assert client.base_url == MAINNET_SPOT_REST
+    assert DEPRECATED_FUTURES_HOST not in client.base_url
+
+
+@pytest.mark.unit
+def test_spot_testnet_is_fail_closed():
+    """testnet=True is unsupported and must raise; no spot testnet exists (#3719 #4)."""
+    with pytest.raises(ValueError) as excinfo:
+        MexcClient(api_key="k", api_secret="s", testnet=True)
+
+    message = str(excinfo.value).lower()
+    assert "testnet" in message
+    assert "unsupported" in message or "no spot api testnet" in message
+    # If the deprecated host is named at all, it must be flagged as deprecated,
+    # never offered as a usable testnet base URL.
+    if DEPRECATED_FUTURES_HOST in message:
+        assert "deprecated" in message
+
+
+@pytest.mark.unit
+def test_testnet_true_is_not_a_no_send_claim():
+    """testnet=True fails closed instead of producing a usable "safe" client that
+    could be mistaken for a no-send path (#3719 #2).
+
+    No-send for CDB depends on DRY_RUN=true + MOCK_TRADING=true, not on this flag.
+    """
+    with pytest.raises(ValueError):
+        MexcClient(api_key="k", api_secret="s", testnet=True)
+
+
+@pytest.mark.unit
+def test_execution_config_base_url_default_is_mainnet(monkeypatch):
+    """services/execution/config.py defaults MEXC_BASE_URL to the mainnet spot host,
+    not the deprecated futures host (#3719 #1)."""
+    monkeypatch.delenv("MEXC_BASE_URL", raising=False)
+    import services.execution.config as exec_config
+
+    exec_config = importlib.reload(exec_config)
+    try:
+        assert exec_config.MEXC_BASE_URL == MAINNET_SPOT_REST
+        assert DEPRECATED_FUTURES_HOST not in exec_config.MEXC_BASE_URL
+    finally:
+        importlib.reload(exec_config)
+
+
+@pytest.mark.unit
+def test_balance_fetcher_base_url_default_is_mainnet(monkeypatch):
+    """services/risk/balance_fetcher.py defaults its spot base to the mainnet host,
+    not the deprecated futures host (#3719 #1)."""
+    monkeypatch.delenv("MEXC_BASE_URL", raising=False)
+    monkeypatch.setenv("MEXC_API_KEY", "unit-test-key")
+    monkeypatch.setenv("MEXC_API_SECRET", "unit-test-secret")
+
+    from services.risk.balance_fetcher import RealBalanceFetcher
+
+    fetcher = RealBalanceFetcher()
+    assert fetcher.base_url == MAINNET_SPOT_REST
+    assert DEPRECATED_FUTURES_HOST not in fetcher.base_url
+
+
+@pytest.mark.unit
+def test_mainnet_spot_ws_url_unchanged():
+    """The spot WebSocket base stays the correct mainnet host (#3719 #3).
+
+    Guarded import: skip when optional WS runtime deps are unavailable in this env.
+    """
+    pytest.importorskip("websockets")
+    try:
+        from services.ws.mexc_v3_client import WS_URL
+    except Exception as exc:  # pragma: no cover - env-dependent
+        pytest.skip(f"services.ws.mexc_v3_client not importable here: {exc}")
+
+    assert WS_URL == MAINNET_SPOT_WS
+    assert DEPRECATED_FUTURES_HOST not in WS_URL


### PR DESCRIPTION
## Summary

Fix the stale/deprecated `contract.mexc.com` MEXC spot "testnet" semantics found during #2979 venue verification and documented in PR #3718 (`docs/live-readiness/LR-050-VENUE-ENDPOINT-SEMANTICS-2026-07-03.md` §4/§5).

MEXC offers **no** spot API testnet/sandbox; `contract.mexc.com` was the deprecated MEXC **Futures** host (discontinued 2026-01-19), never a spot testnet, and was mislabeled while still using spot `/api/v3/*` paths.

## Delivered

- `core/clients/mexc.py`: `testnet=True` now **fails closed** (`ValueError`) instead of silently routing spot paths to the deprecated futures host. No silent mainnet fallback, no new fake testnet URL. Default (`testnet=False`) stays `https://api.mexc.com`.
- `services/execution/config.py` + `services/risk/balance_fetcher.py`: `MEXC_BASE_URL` default corrected from `https://contract.mexc.com` to the mainnet spot host `https://api.mexc.com`.
- Comments clarify `MEXC_TESTNET` is **not** a no-send proof (no-send = `DRY_RUN=true` + `MOCK_TRADING=true` / `mock_builtin`).
- `core/config/trading_mode.py`: comment-only clarification that STAGED's `MEXC_TESTNET` is nominal; mapping values unchanged (backward-compat preserved).
- Spot WS base `wss://wbs-api.mexc.com/ws` unchanged (already correct).
- Tests: new `tests/unit/core/test_mexc_base_url_3719.py` (4 target assertions) + aligned `tests/integration/test_mexc_testnet.py`.

## Validation

- `ruff check` clean; `black --config pyproject.toml --check` clean on all changed files.
- `git diff --check` clean.
- `pytest tests/unit/core/test_mexc_base_url_3719.py tests/integration/test_mexc_testnet.py tests/unit/config/test_trading_mode.py` -> 43 passed, 4 skipped.
- Affected suites `tests/unit/{execution,risk,core}` -> 174 passed, 4 skipped.
- Redaction scan: no secret values, no IP literals, no account IDs, no tokens in the diff.

## Non-goals

- No credentials read; no exchange/venue API calls; no orders (not even test orders).
- No runtime/Docker/stack change; no strategy change.
- No FINAL-RECONCILE / blocker-matrix edits; no #2976/#2983/#2985 changes. #2983 stays parked/open.

## Remaining uncertainty

- Official-doc facts are sourced from the merged #3718 doc, not from a live venue call (venue API calls are out of scope).
- The WS regression assertion skips when optional WS runtime deps are unavailable in the runner.

**LR remains NO-GO. Kein Live-Go. Kein Echtgeld-Go.**

Closes #3719
Refs #2979 #2976 #2983 #2985 #3718
