### PR TITLE
ci(docs): reduce docs hub guard false positive

### DIFF
--- a/knowledge/deep-issues-lab/cdb_execution.md
+++ b/knowledge/deep-issues-lab/cdb_execution.md
@@ -84,7 +84,7 @@ import hmac
 import hashlib
 import time
 
-def generate_signature(params: dict, api_secret: str) -> str:
+def generate_signature(params: dict, signing_key: str) -> str:
     # 1. Sortiere Parameter alphabetisch
     sorted_params = sorted(params.items())
     
@@ -93,7 +93,7 @@ def generate_signature(params: dict, api_secret: str) -> str:
     
     # 3. HMAC-SHA256 Hash
     signature = hmac.new(
-        api_secret.encode("utf-8"),
+        signing_key.encode("utf-8"),
         query_string.encode("utf-8"),
         hashlib.sha256
     ).hexdigest()
@@ -326,7 +326,7 @@ if config.execution_mode == "LIVE":
     
     response = await self.http_client.post(
         f"{config.mexc_base_url}/api/v3/order",
-        headers={"X-MEXC-APIKEY": config.mexc_api_key},
+        headers={"X-MEXC-APIKEY": config.mexc_key},
         params={**order_params, "signature": signature}
     )
     
@@ -343,7 +343,7 @@ async def validate_live_mode_requirements(self):
     checks = []
     
     # 1. API Key vorhanden?
-    checks.append(bool(config.mexc_api_key))
+    checks.append(bool(config.mexc_key))
     
     # 2. Server Time Sync?
     server_time = await self._get_server_time()
@@ -479,7 +479,7 @@ params = {
     "timestamp": "1698745123456",
     "recvWindow": "5000"
 }
-signature = generate_signature(params, api_secret)
+signature = generate_signature(params, signing_key)
 
 # 2. POST zu MEXC
 response = requests.post(
@@ -643,7 +643,7 @@ query_string = "&".join([f"{k}={v}" for k, v in sorted(params.items())])
 print(f"Query String: {query_string}")
 
 # 2. Print Signature
-signature = generate_signature(params, api_secret)
+signature = generate_signature(params, signing_key)
 print(f"Signature: {signature}")
 
 # 3. Test mit MEXC Signature Tool


### PR DESCRIPTION
## Summary

Docs-only fix for Docs Hub Guard false positives on historical HMAC/API example prose in `knowledge/deep-issues-lab/cdb_execution.md`.

Closes #3730
Refs #3729

## Delivered

- Renamed lab-doc example identifiers: `api_secret` → `signing_key`, `config.mexc_api_key` → `config.mexc_key` (6 lines).
- No workflow or secret-pattern changes; real secret detection unchanged.

## Brain Evidence

- **brain_source:** repo-only
- **brain_status:** not-used
- **context_brain_attempted:** true
- **context_brain_used:** false
- **context_available:** false
- **repo_fallback_used:** true
- **repo_fallback_reason:** insufficient_evidence
- **context_tool_status:** absent
- **context_trust_level:** none
- **records_found:** none
- **tools_or_queries:** `gh issue view 3730`, `gh pr view 3729`, `gh run view 28714748368 --log-failed`, repo reads of `docs-hub-guard.yml` and `cdb_execution.md`, local `git grep` guard simulation
- **records_or_results:** PR #3729 guard job failed on 6 lines in `cdb_execution.md`; post-fix local `git grep` returns zero hits
- **repo_crosscheck:** `.github/workflows/docs-hub-guard.yml` L64 scans full changed files under agents/knowledge/governance/docs
- **impact_on_plan:** Chose docs-only rename over workflow allowlist (preferred order in #3730)
- **limitations:** No SurrealDB/MCP records; other lab docs may still trigger if edited and they contain pattern matches

## Root Cause

Docs Hub Guard scans **entire changed files** (not diff hunks only) with `(api[_-]?key|secret|...)`. PR #3729 touched `cdb_execution.md`; pre-existing example code using `api_secret` and `mexc_api_key` matched the pattern (6 hits). Required checks were green; guard was non-blocking on #3729.

## Validation

- `git diff --check` clean
- `git grep` with guard regex on `cdb_execution.md`: zero hits (pre-push)
- Docs-only diff (1 file); no workflow/runtime/secret-pattern changes

## Non-goals

- No diff-line-only guard redesign
- No global deep-issues-lab exclude
- No secret pattern removal or guard disable
- No code, Docker, DB, MCP, or LR changes

## Safety Boundaries

- LR remains **NO-GO**
- No secret values introduced or logged
- Guard patterns and fail-closed posture unchanged

## Restunsicherheiten

- Future lab-doc edits that reintroduce `api_key`/`secret` identifiers in changed files could re-trigger the guard until a diff-line-only scan is scoped separately

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single markdown file with illustrative identifier renames; no application code, CI logic, or credentials.
> 
> **Overview**
> **Docs-only** update in `knowledge/deep-issues-lab/cdb_execution.md` so the **Docs Hub Guard** no longer flags historical HMAC/API example prose when that file is touched. The guard scans **whole changed files** with patterns like `api_key` and `secret`; unrelated edits had been tripping on pre-existing sample code.
> 
> Example identifiers are renamed only: `api_secret` → `signing_key` in `generate_signature` and call sites, and `config.mexc_api_key` → `config.mexc_key` in live-mode snippets. **No** workflow, runtime, or guard-regex changes—real secret detection stays the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96368c3b830df103f798b4318c1546ec1a34ddfc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->